### PR TITLE
fused kernel profiling tool prototype

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
@@ -920,8 +920,8 @@ uint32_t per_core_rta_arg_idx = 0;
     }
 
     {
-        DeviceZoneScopedN("Q_HEADS") static_assert(
-            !(Core::is_qnope_core && Core::is_qrope_core), "Core cannot be both QNOPE and QROPE");
+        DeviceZoneScopedN("Q_HEADS");
+        static_assert(!(Core::is_qnope_core && Core::is_qrope_core), "Core cannot be both QNOPE and QROPE");
 
         // ========================================================================
         // Matmul3 (QNoPE): matmul3_input[64, 1, 128] @ matmul3_weights[64, 128, 512] -> matmul3_output[64, 1, 512]

--- a/models/demos/deepseek_v3_b1/profiling/fused_kernel_profiler.py
+++ b/models/demos/deepseek_v3_b1/profiling/fused_kernel_profiler.py
@@ -1,0 +1,1149 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Generalized Fused-Kernel Micro-Op Profiler
+
+Produces accurate per-micro-op execution time breakdowns for fused kernels,
+using type-aware timing formulas and a YAML config that describes the kernel's
+micro-ops, RISC roles, core roles, and inter-op dependencies.
+
+The tool parses profile_log_device.csv (from the TT device profiler) and applies
+formulas tailored to each micro-op type:
+  - compute: max across cores of TRISC pipeline wall clock
+  - mcast:   sender_duration + max(receiver_durations)
+  - gather:  max(sender_durations) + receiver_duration
+  - gather_reduce: max(senders) + receiver + reducer_compute
+  - broadcast: sender + max(receivers)
+  - dram_write: max(writer_durations)
+  - span: max(end) - min(start) across all participants
+
+Usage:
+    python fused_kernel_profiler.py --kernel pre_sdpa --log profile_log_device.csv
+    python fused_kernel_profiler.py --config my_kernel.yaml --log profile_log_device.csv --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import enum
+import itertools
+import json
+import re
+import sys
+from collections import defaultdict, deque
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError:
+    yaml = None  # type: ignore[assignment]
+
+
+# ============================================================================
+# Config Schema
+# ============================================================================
+
+
+class OpType(enum.Enum):
+    COMPUTE = "compute"
+    MCAST = "mcast"
+    GATHER = "gather"
+    GATHER_REDUCE = "gather_reduce"
+    BROADCAST = "broadcast"
+    DRAM_WRITE = "dram_write"
+    DRAM_READ = "dram_read"
+    SPAN = "span"
+
+
+@dataclass
+class Participant:
+    role: str
+    risc: str
+    function: str
+
+
+@dataclass
+class CoreRoleConfig:
+    infer_from_zone: str
+
+
+@dataclass
+class MicroOpConfig:
+    zone: str
+    type: OpType
+    participants: list[Participant]
+
+
+@dataclass
+class KernelConfig:
+    kernel_name: str
+    core_roles: dict[str, CoreRoleConfig]
+    micro_ops: list[MicroOpConfig]
+    dependencies: list[tuple[str, str]]
+    display_order: list[str]
+
+    @property
+    def allowed_zones(self) -> set[str]:
+        return {op.zone for op in self.micro_ops}
+
+    def get_micro_op(self, zone: str) -> MicroOpConfig | None:
+        for op in self.micro_ops:
+            if op.zone == zone:
+                return op
+        return None
+
+
+# ============================================================================
+# Config Loader
+# ============================================================================
+
+_CONFIG_DIR = Path(__file__).parent / "kernel_configs"
+
+
+def load_kernel_config(path_or_name: str | Path) -> KernelConfig:
+    """Load kernel config from a YAML file or a built-in kernel name."""
+    if yaml is None:
+        raise ImportError("PyYAML is required: pip install pyyaml")
+
+    path = Path(path_or_name)
+    if not path.exists():
+        path = _CONFIG_DIR / f"{path_or_name}.yaml"
+    if not path.exists():
+        raise FileNotFoundError(f"Config not found: {path_or_name}")
+
+    with path.open() as f:
+        raw = yaml.safe_load(f)
+
+    core_roles = {
+        name: CoreRoleConfig(infer_from_zone=cfg["infer_from_zone"]) for name, cfg in raw.get("core_roles", {}).items()
+    }
+
+    micro_ops = []
+    for op_raw in raw.get("micro_ops", []):
+        participants = [
+            Participant(role=p["role"], risc=p["risc"], function=p["function"]) for p in op_raw.get("participants", [])
+        ]
+        micro_ops.append(
+            MicroOpConfig(
+                zone=op_raw["zone"],
+                type=OpType(op_raw["type"]),
+                participants=participants,
+            )
+        )
+
+    dependencies = [(d[0], d[1]) for d in raw.get("dependencies", [])]
+    display_order = raw.get("display_order", [op.zone for op in micro_ops])
+
+    config = KernelConfig(
+        kernel_name=raw["kernel_name"],
+        core_roles=core_roles,
+        micro_ops=micro_ops,
+        dependencies=dependencies,
+        display_order=display_order,
+    )
+    _validate_config(config)
+    return config
+
+
+def _validate_config(config: KernelConfig) -> None:
+    zone_set = config.allowed_zones
+    for child, parent in config.dependencies:
+        if child not in zone_set:
+            raise ValueError(f"Dependency child '{child}' not in micro_ops")
+        if parent not in zone_set:
+            raise ValueError(f"Dependency parent '{parent}' not in micro_ops")
+    for op in config.micro_ops:
+        for p in op.participants:
+            if p.role not in config.core_roles:
+                raise ValueError(f"Participant role '{p.role}' in op '{op.zone}' not in core_roles")
+
+
+# ============================================================================
+# Zone Interval
+# ============================================================================
+
+
+@dataclass
+class ZoneInterval:
+    """A single zone execution: start and end cycles for one (core, risc) pair."""
+
+    chip_id: int
+    core: tuple[int, int]
+    risc: str
+    zone_name: str
+    start_cycle: int
+    end_cycle: int
+    timer_id: int
+
+    @property
+    def duration_cycles(self) -> int:
+        return self.end_cycle - self.start_cycle
+
+
+# ============================================================================
+# Log Parser (generalized)
+# ============================================================================
+
+
+def extract_chip_freq_mhz(log_path: Path) -> float:
+    """Extract chip frequency from first line of device log."""
+    with log_path.open() as f:
+        first = f.readline()
+    m = re.search(r"CHIP_FREQ\[MHz\]:\s*(\d+\.?\d*)", first or "")
+    return float(m.group(1)) if m else 1000.0
+
+
+def cycles_to_ns(cycles: int, freq_mhz: float) -> float:
+    """Convert device cycles to nanoseconds."""
+    return (cycles * 1000.0) / freq_mhz
+
+
+def parse_device_log(
+    log_path: Path,
+    allowed_zones: set[str] | None = None,
+    verbose: bool = False,
+) -> tuple[list[ZoneInterval], float]:
+    """
+    Parse profile_log_device.csv and extract zone intervals.
+
+    If allowed_zones is provided, only matching zone names are kept.
+    """
+    freq_mhz = extract_chip_freq_mhz(log_path)
+    starts: dict[tuple, tuple[int, str]] = {}
+    intervals: list[ZoneInterval] = []
+
+    def _zone_ok(name: str) -> bool:
+        if allowed_zones is None:
+            return True
+        return name in allowed_zones
+
+    with log_path.open(newline="") as f:
+        _ = f.readline()  # ARCH / CHIP_FREQ line
+        reader = csv.reader(f)
+        header = next(reader, None)
+        if not header:
+            return intervals, freq_mhz
+
+        field_map: dict[str, str] = {}
+        for col in header:
+            n = (col or "").strip()
+            if n:
+                key = n.lower().replace(" ", "_").replace("[", "").replace("]", "")
+                field_map[key] = n
+
+        use_dict = "zone" in " ".join(header).lower() or "zone_name" in field_map
+
+        if use_dict:
+            f.seek(0)
+            _ = f.readline()
+            dict_reader = csv.DictReader(f, skipinitialspace=True)
+            for row in dict_reader:
+                _parse_row_dict(row, field_map, starts, intervals, _zone_ok)
+        else:
+            for row in itertools.chain([header], reader):
+                if len(row) >= 13:
+                    _parse_row_positional(tuple(row), starts, intervals, _zone_ok)
+
+    if verbose:
+        print(f"Parsed {len(intervals)} zone intervals, freq={freq_mhz} MHz", file=sys.stderr)
+
+    return intervals, freq_mhz
+
+
+def _parse_row_dict(
+    row: dict,
+    field_map: dict,
+    starts: dict,
+    intervals: list,
+    zone_ok: Any,
+) -> None:
+    def get(*candidates: str) -> str | None:
+        for c in candidates:
+            key = c.lower().replace(" ", "_").replace("[", "").replace("]", "")
+            if key in field_map:
+                val = row.get(field_map[key], "")
+                return str(val).strip() if val is not None else ""
+        return None
+
+    chip_s = get("PCIe slot", "chip_id", "chip")
+    cx_s = get("core_x", "corex")
+    cy_s = get("core_y", "corey")
+    risc_s = get("RISC processor type", "risc")
+    timer_s = get("timer_id")
+    cycles_s = get("time[cycles since reset]", "time", "cycles")
+    zone_s = get("zone name", "zone_name")
+    phase_s = get("zone phase", "type", "phase")
+
+    if not all([chip_s, cx_s, cy_s, risc_s, timer_s, cycles_s, zone_s, phase_s]):
+        return
+    try:
+        chip_id = int(chip_s)
+        core_x = int(cx_s)
+        core_y = int(cy_s)
+        cycles = int(float(cycles_s))
+        timer_id = int(timer_s)
+    except (ValueError, TypeError):
+        return
+
+    zone_name = (zone_s or "").strip()
+    phase = (phase_s or "").strip().upper()
+    is_start = phase in ("BEGIN", "ZONE_START", "START")
+    is_end = phase in ("END", "ZONE_END", "END ")
+    if not is_start and not is_end:
+        return
+
+    key = (chip_id, (core_x, core_y), risc_s.strip(), timer_id)
+    if is_start:
+        starts[key] = (cycles, zone_name)
+    elif is_end and key in starts:
+        start_cycle, start_zone = starts.pop(key)
+        name = start_zone or zone_name
+        if zone_ok(name):
+            intervals.append(
+                ZoneInterval(
+                    chip_id=chip_id,
+                    core=(core_x, core_y),
+                    risc=risc_s.strip(),
+                    zone_name=name,
+                    start_cycle=start_cycle,
+                    end_cycle=cycles,
+                    timer_id=timer_id,
+                )
+            )
+
+
+def _parse_row_positional(
+    row: tuple,
+    starts: dict,
+    intervals: list,
+    zone_ok: Any,
+) -> None:
+    if len(row) < 13:
+        return
+    try:
+        chip_id = int(row[1])
+        core_x = int(row[2])
+        core_y = int(row[3])
+        timer_id = int(float(row[5])) if str(row[5]).strip() else 0
+        cycles = int(float(row[6]))
+    except (ValueError, TypeError):
+        return
+    risc_s = str(row[4]).strip()
+    zone_name = str(row[11]).strip()
+    phase = str(row[12]).strip().upper()
+    is_start = phase in ("BEGIN", "ZONE_START", "START")
+    is_end = phase in ("END", "ZONE_END", "END ")
+    if not is_start and not is_end:
+        return
+
+    key = (chip_id, (core_x, core_y), risc_s, timer_id)
+    if is_start:
+        starts[key] = (cycles, zone_name)
+    elif is_end and key in starts:
+        start_cycle, start_zone = starts.pop(key)
+        name = start_zone or zone_name
+        if zone_ok(name):
+            intervals.append(
+                ZoneInterval(
+                    chip_id=chip_id,
+                    core=(core_x, core_y),
+                    risc=risc_s,
+                    zone_name=name,
+                    start_cycle=start_cycle,
+                    end_cycle=cycles,
+                    timer_id=timer_id,
+                )
+            )
+
+
+# ============================================================================
+# Interval Classifier
+# ============================================================================
+
+
+@dataclass
+class ClassifiedInterval:
+    interval: ZoneInterval
+    micro_op_zone: str
+    function: str
+    core_role: str
+
+
+def risc_matches(config_risc: str, csv_risc: str) -> bool:
+    """Check if a config RISC spec matches a CSV RISC value."""
+    if config_risc == csv_risc:
+        return True
+    if config_risc == "TRISC" and csv_risc.startswith("TRISC"):
+        return True
+    return False
+
+
+NOOP_THRESHOLD_RATIO = 0.01
+
+
+def infer_core_roles(
+    intervals: list[ZoneInterval],
+    config: KernelConfig,
+) -> dict[str, set[tuple[int, int]]]:
+    """
+    Infer which cores belong to which role using config's infer_from_zone.
+
+    Unified kernels fire DeviceZoneScopedN on ALL cores (including no-op cores),
+    so we filter out cores whose max duration for the inference zone is below
+    1% of the global max for that zone.
+    """
+    by_zone_core: dict[str, dict[tuple[int, int], int]] = defaultdict(lambda: defaultdict(int))
+    for iv in intervals:
+        dur = iv.duration_cycles
+        prev = by_zone_core[iv.zone_name][iv.core]
+        if dur > prev:
+            by_zone_core[iv.zone_name][iv.core] = dur
+
+    roles: dict[str, set[tuple[int, int]]] = {}
+    for role_name, role_cfg in config.core_roles.items():
+        zone = role_cfg.infer_from_zone
+        core_max = by_zone_core.get(zone, {})
+        if not core_max:
+            roles[role_name] = set()
+            continue
+        global_max = max(core_max.values())
+        threshold = global_max * NOOP_THRESHOLD_RATIO
+        roles[role_name] = {core for core, dur in core_max.items() if dur > threshold}
+    return roles
+
+
+def classify_intervals(
+    intervals: list[ZoneInterval],
+    config: KernelConfig,
+    core_roles: dict[str, set[tuple[int, int]]],
+) -> dict[str, list[ClassifiedInterval]]:
+    """Classify each interval into (micro_op, participant_function)."""
+    core_to_roles: dict[tuple[int, int], set[str]] = defaultdict(set)
+    for role_name, cores in core_roles.items():
+        for core in cores:
+            core_to_roles[core].add(role_name)
+
+    classified: dict[str, list[ClassifiedInterval]] = defaultdict(list)
+    for iv in intervals:
+        micro_op = config.get_micro_op(iv.zone_name)
+        if micro_op is None:
+            continue
+
+        matched = False
+        for participant in micro_op.participants:
+            if participant.role in core_to_roles.get(iv.core, set()) and risc_matches(participant.risc, iv.risc):
+                classified[iv.zone_name].append(
+                    ClassifiedInterval(
+                        interval=iv,
+                        micro_op_zone=iv.zone_name,
+                        function=participant.function,
+                        core_role=participant.role,
+                    )
+                )
+                matched = True
+                break
+
+        if not matched:
+            classified[iv.zone_name].append(
+                ClassifiedInterval(
+                    interval=iv,
+                    micro_op_zone=iv.zone_name,
+                    function="unknown",
+                    core_role="unknown",
+                )
+            )
+
+    return classified
+
+
+# ============================================================================
+# Predecessor Gate Computation
+# ============================================================================
+
+
+def compute_predecessor_gates(
+    zone: str,
+    config: KernelConfig,
+    all_classified: dict[str, list[ClassifiedInterval]],
+) -> dict[tuple[int, int], int]:
+    """
+    For a given op zone, compute per-core gate times from its dependency parents.
+
+    The gate time on a core is the latest end_cycle from any predecessor's
+    participant that shares the same core role (and thus the same physical core).
+    This represents when predecessor output becomes available on that core,
+    allowing subtraction of blocking wait time from the current op's duration.
+
+    For predecessors on a different core type (no shared role), use the op-level
+    predecessor end as the gate for all child cores.
+    """
+    micro_op = config.get_micro_op(zone)
+    if micro_op is None:
+        return {}
+
+    parent_zones = [parent for child, parent in config.dependencies if child == zone]
+    if not parent_zones:
+        return {}
+
+    child_roles = {p.role for p in micro_op.participants}
+    gates: dict[tuple[int, int], int] = {}
+
+    for parent_zone in parent_zones:
+        parent_op = config.get_micro_op(parent_zone)
+        if parent_op is None:
+            continue
+
+        parent_roles = {p.role for p in parent_op.participants}
+        shared_roles = child_roles & parent_roles
+
+        parent_classified = all_classified.get(parent_zone, [])
+        if not parent_classified:
+            continue
+
+        if shared_roles:
+            for ci in parent_classified:
+                if ci.core_role in shared_roles:
+                    core = ci.interval.core
+                    gates[core] = max(gates.get(core, 0), ci.interval.end_cycle)
+        else:
+            parent_end = max(ci.interval.end_cycle for ci in parent_classified)
+            child_classified = all_classified.get(zone, [])
+            for ci in child_classified:
+                core = ci.interval.core
+                gates[core] = max(gates.get(core, 0), parent_end)
+
+    return gates
+
+
+# ============================================================================
+# Timing Engine
+# ============================================================================
+
+
+@dataclass
+class OpTimingResult:
+    zone: str
+    duration_cycles: int
+    duration_ns: float
+    duration_us: float
+    core_count: int
+    interval_count: int
+    breakdown: dict[str, int]
+    raw_duration_cycles: int = 0
+    raw_duration_us: float = 0.0
+    blocking_cycles: int = 0
+    blocking_us: float = 0.0
+    slowest_core: tuple[int, int] | None = None
+    slowest_risc: str | None = None
+
+
+def _trisc_pipeline_wall_clock(
+    intervals: list[ClassifiedInterval],
+    gates: dict[tuple[int, int], int] | None = None,
+) -> tuple[int, tuple[int, int] | None]:
+    """
+    Per-core: max(T_end) - min(T_start) across TRISC sub-processors.
+    Then max across cores.  Returns (duration_cycles, slowest_core).
+
+    If gates is provided, each core's start is clamped to at least the gate
+    time, subtracting blocking wait on a predecessor.
+    """
+    if not intervals:
+        return 0, None
+    by_core: dict[tuple[int, int], list[ClassifiedInterval]] = defaultdict(list)
+    for ci in intervals:
+        by_core[ci.interval.core].append(ci)
+
+    per_core: dict[tuple[int, int], int] = {}
+    for core, cis in by_core.items():
+        max_end = max(ci.interval.end_cycle for ci in cis)
+        min_start = min(ci.interval.start_cycle for ci in cis)
+        gate = gates.get(core, 0) if gates else 0
+        per_core[core] = max(0, max_end - max(min_start, gate))
+
+    slowest_core = max(per_core, key=lambda c: per_core[c])
+    return per_core[slowest_core], slowest_core
+
+
+def _max_duration(intervals: list[ClassifiedInterval]) -> int:
+    if not intervals:
+        return 0
+    return max(ci.interval.duration_cycles for ci in intervals)
+
+
+def _adjusted_max_duration(
+    intervals: list[ClassifiedInterval],
+    gates: dict[tuple[int, int], int] | None = None,
+) -> int:
+    """Max duration across intervals, with per-core gate adjustment."""
+    if not intervals:
+        return 0
+    if not gates:
+        return max(ci.interval.duration_cycles for ci in intervals)
+    best = 0
+    for ci in intervals:
+        gate = gates.get(ci.interval.core, 0)
+        adj = max(0, ci.interval.end_cycle - max(ci.interval.start_cycle, gate))
+        best = max(best, adj)
+    return best
+
+
+def _span_cycles(intervals: list[ClassifiedInterval]) -> int:
+    if not intervals:
+        return 0
+    return max(ci.interval.end_cycle for ci in intervals) - min(ci.interval.start_cycle for ci in intervals)
+
+
+def _adjusted_span_cycles(
+    intervals: list[ClassifiedInterval],
+    gates: dict[tuple[int, int], int] | None = None,
+) -> int:
+    """Span from earliest start to latest end, with gate adjustment."""
+    if not intervals:
+        return 0
+    max_end = max(ci.interval.end_cycle for ci in intervals)
+    min_start = min(ci.interval.start_cycle for ci in intervals)
+    if gates:
+        cores = {ci.interval.core for ci in intervals}
+        max_gate = max((gates.get(c, 0) for c in cores), default=0)
+        return max(0, max_end - max(min_start, max_gate))
+    return max_end - min_start
+
+
+def _slowest_interval(
+    intervals: list[ClassifiedInterval],
+) -> tuple[tuple[int, int] | None, str | None]:
+    if not intervals:
+        return None, None
+    s = max(intervals, key=lambda c: c.interval.duration_cycles)
+    return s.interval.core, s.interval.risc
+
+
+def _uniform_gate(
+    intervals: list[ClassifiedInterval],
+    gate_cycle: int,
+) -> dict[tuple[int, int], int]:
+    """Build a gate dict that applies the same gate_cycle to every core."""
+    return {ci.interval.core: gate_cycle for ci in intervals}
+
+
+def compute_op_duration(
+    micro_op: MicroOpConfig,
+    classified: list[ClassifiedInterval],
+    freq_mhz: float,
+    predecessor_gates: dict[tuple[int, int], int] | None = None,
+) -> OpTimingResult:
+    """
+    Compute duration for a single micro-op using its type-specific formula.
+
+    If predecessor_gates is provided, blocking time on predecessors is subtracted
+    from the entry-point participants.  Within-op blocking (e.g. receiver on
+    sender) is also subtracted internally.
+    """
+    if not classified:
+        return OpTimingResult(
+            zone=micro_op.zone,
+            duration_cycles=0,
+            duration_ns=0,
+            duration_us=0,
+            core_count=0,
+            interval_count=0,
+            breakdown={},
+        )
+
+    by_func: dict[str, list[ClassifiedInterval]] = defaultdict(list)
+    for ci in classified:
+        by_func[ci.function].append(ci)
+
+    cores = {ci.interval.core for ci in classified}
+    breakdown: dict[str, int] = {}
+    slowest_core: tuple[int, int] | None = None
+    slowest_risc: str | None = None
+    raw_cycles = 0
+    adj_cycles = 0
+
+    if micro_op.type == OpType.COMPUTE:
+        compute_ivs = by_func.get("compute", [])
+        if compute_ivs:
+            raw_cycles, _ = _trisc_pipeline_wall_clock(compute_ivs)
+            adj_cycles, slowest_core = _trisc_pipeline_wall_clock(
+                compute_ivs,
+                predecessor_gates,
+            )
+            slowest_risc = "TRISC"
+        else:
+            raw_cycles = _span_cycles(classified)
+            adj_cycles = _adjusted_span_cycles(classified, predecessor_gates)
+            slowest_core, slowest_risc = _slowest_interval(classified)
+        breakdown["compute"] = adj_cycles
+
+    elif micro_op.type in (OpType.MCAST, OpType.BROADCAST):
+        senders = by_func.get("sender", [])
+        receivers = by_func.get("receiver", [])
+
+        raw_s = _max_duration(senders)
+        raw_r = _max_duration(receivers)
+        raw_cycles = raw_s + raw_r
+
+        adj_s = _adjusted_max_duration(senders, predecessor_gates)
+        sender_end = max((ci.interval.end_cycle for ci in senders), default=0)
+        recv_gate = _uniform_gate(receivers, sender_end) if receivers else None
+        adj_r = _adjusted_max_duration(receivers, recv_gate)
+        adj_cycles = adj_s + adj_r
+
+        breakdown["sender"] = adj_s
+        breakdown["receiver"] = adj_r
+        all_ivs = senders + receivers
+        slowest_core, slowest_risc = _slowest_interval(all_ivs)
+
+    elif micro_op.type == OpType.GATHER:
+        senders = by_func.get("sender", [])
+        receivers = by_func.get("receiver", [])
+
+        raw_s = _max_duration(senders)
+        raw_r = _max_duration(receivers)
+        raw_cycles = raw_s + raw_r
+
+        adj_s = _adjusted_max_duration(senders, predecessor_gates)
+        max_sender_end = max(
+            (ci.interval.end_cycle for ci in senders),
+            default=0,
+        )
+        recv_gate = _uniform_gate(receivers, max_sender_end) if receivers else None
+        adj_r = _adjusted_max_duration(receivers, recv_gate)
+        adj_cycles = adj_s + adj_r
+
+        breakdown["sender"] = adj_s
+        breakdown["receiver"] = adj_r
+        all_ivs = senders + receivers
+        slowest_core, slowest_risc = _slowest_interval(all_ivs)
+
+    elif micro_op.type == OpType.GATHER_REDUCE:
+        senders = by_func.get("sender", [])
+        receivers = by_func.get("receiver", [])
+        reducers = by_func.get("reducer", [])
+
+        raw_s = _max_duration(senders)
+        raw_r = _max_duration(receivers)
+        raw_red, _ = _trisc_pipeline_wall_clock(reducers)
+        raw_cycles = raw_s + raw_r + raw_red
+
+        adj_s = _adjusted_max_duration(senders, predecessor_gates)
+        max_sender_end = max(
+            (ci.interval.end_cycle for ci in senders),
+            default=0,
+        )
+        recv_gate = _uniform_gate(receivers, max_sender_end) if receivers else None
+        adj_r = _adjusted_max_duration(receivers, recv_gate)
+        max_recv_end = max(
+            (ci.interval.end_cycle for ci in receivers),
+            default=0,
+        )
+        red_gate = _uniform_gate(reducers, max_recv_end) if reducers else None
+        adj_red, red_core = _trisc_pipeline_wall_clock(reducers, red_gate)
+        adj_cycles = adj_s + adj_r + adj_red
+
+        breakdown["sender"] = adj_s
+        breakdown["receiver"] = adj_r
+        breakdown["reducer"] = adj_red
+        longest = max(
+            ("sender", adj_s),
+            ("receiver", adj_r),
+            ("reducer", adj_red),
+            key=lambda x: x[1],
+        )
+        if longest[0] == "reducer" and red_core:
+            slowest_core, slowest_risc = red_core, "TRISC"
+        else:
+            pool = by_func.get(longest[0], [])
+            slowest_core, slowest_risc = _slowest_interval(pool)
+
+    elif micro_op.type == OpType.DRAM_WRITE:
+        writers = by_func.get("writer", [])
+        raw_cycles = _max_duration(writers)
+        adj_cycles = _adjusted_max_duration(writers, predecessor_gates)
+        breakdown["writer"] = adj_cycles
+        slowest_core, slowest_risc = _slowest_interval(writers)
+
+    elif micro_op.type == OpType.DRAM_READ:
+        readers = by_func.get("reader", [])
+        raw_cycles = _max_duration(readers)
+        adj_cycles = _adjusted_max_duration(readers, predecessor_gates)
+        breakdown["reader"] = adj_cycles
+        slowest_core, slowest_risc = _slowest_interval(readers)
+
+    elif micro_op.type == OpType.SPAN:
+        raw_cycles = _span_cycles(classified)
+        adj_cycles = _adjusted_span_cycles(classified, predecessor_gates)
+        breakdown["span"] = adj_cycles
+        slowest_core, slowest_risc = _slowest_interval(classified)
+
+    else:
+        raw_cycles = _span_cycles(classified)
+        adj_cycles = _adjusted_span_cycles(classified, predecessor_gates)
+        breakdown["span"] = adj_cycles
+
+    blocking = max(0, raw_cycles - adj_cycles)
+    dur_ns = cycles_to_ns(adj_cycles, freq_mhz)
+    raw_ns = cycles_to_ns(raw_cycles, freq_mhz)
+    return OpTimingResult(
+        zone=micro_op.zone,
+        duration_cycles=adj_cycles,
+        duration_ns=dur_ns,
+        duration_us=dur_ns / 1000.0,
+        core_count=len(cores),
+        interval_count=len(classified),
+        breakdown=breakdown,
+        raw_duration_cycles=raw_cycles,
+        raw_duration_us=raw_ns / 1000.0,
+        blocking_cycles=blocking,
+        blocking_us=cycles_to_ns(blocking, freq_mhz) / 1000.0,
+        slowest_core=slowest_core,
+        slowest_risc=slowest_risc,
+    )
+
+
+# ============================================================================
+# Critical-Path Solver
+# ============================================================================
+
+
+def _topological_sort(
+    ops: set[str],
+    dependencies: list[tuple[str, str]],
+) -> list[str]:
+    """Kahn's algorithm topological sort over *ops* respecting *dependencies*."""
+    adj: dict[str, list[str]] = defaultdict(list)
+    in_degree: dict[str, int] = {op: 0 for op in ops}
+    for child, parent in dependencies:
+        if child in ops and parent in ops:
+            adj[parent].append(child)
+            in_degree[child] = in_degree.get(child, 0) + 1
+    queue = deque(op for op in ops if in_degree[op] == 0)
+    order: list[str] = []
+    while queue:
+        op = queue.popleft()
+        order.append(op)
+        for child in adj.get(op, []):
+            in_degree[child] -= 1
+            if in_degree[child] == 0:
+                queue.append(child)
+    return order
+
+
+def compute_critical_path(
+    op_durations: dict[str, int],
+    dependencies: list[tuple[str, str]],
+) -> tuple[dict[str, int], list[str], int]:
+    """
+    Compute critical path through the dependency DAG.
+
+    Returns (earliest_finish, critical_path_ops, total_duration).
+    """
+    all_ops = set(op_durations.keys())
+    parents: dict[str, set[str]] = defaultdict(set)
+    for child, parent in dependencies:
+        if child in all_ops and parent in all_ops:
+            parents[child].add(parent)
+
+    topo_order = _topological_sort(all_ops, dependencies)
+
+    earliest_finish: dict[str, int] = {}
+    predecessor: dict[str, str | None] = {}
+    for op in topo_order:
+        parent_deps = parents.get(op, set())
+        best_parent: str | None = None
+        earliest_start = 0
+        for p in parent_deps:
+            if p in all_ops:
+                ef = earliest_finish.get(p, 0)
+                if ef > earliest_start:
+                    earliest_start = ef
+                    best_parent = p
+        earliest_finish[op] = earliest_start + op_durations.get(op, 0)
+        predecessor[op] = best_parent
+
+    if not earliest_finish:
+        return {}, [], 0
+
+    total = max(earliest_finish.values())
+    end_op = max(earliest_finish, key=lambda o: earliest_finish[o])
+    path: list[str] = []
+    current: str | None = end_op
+    while current is not None:
+        path.append(current)
+        current = predecessor.get(current)
+    path.reverse()
+
+    return earliest_finish, path, total
+
+
+# ============================================================================
+# Report Generator
+# ============================================================================
+
+
+def format_text_report(
+    config: KernelConfig,
+    op_results: dict[str, OpTimingResult],
+    earliest_finish: dict[str, int],
+    critical_path: list[str],
+    total_critical_cycles: int,
+    core_roles: dict[str, set[tuple[int, int]]],
+    intervals: list[ZoneInterval],
+    freq_mhz: float,
+) -> str:
+    lines: list[str] = []
+    lines.append("=" * 90)
+    lines.append(f"Fused-Kernel Micro-Op Timing: {config.kernel_name}")
+    lines.append("=" * 90)
+    lines.append(f"Chip frequency: {freq_mhz:.0f} MHz")
+    lines.append(f"Total zone intervals: {len(intervals)}")
+    lines.append("")
+
+    if intervals:
+        all_starts = [iv.start_cycle for iv in intervals]
+        all_ends = [iv.end_cycle for iv in intervals]
+        total_span_ns = cycles_to_ns(max(all_ends) - min(all_starts), freq_mhz)
+        lines.append(f"Overall kernel span: {total_span_ns / 1000:.3f} us")
+
+    total_cp_ns = cycles_to_ns(total_critical_cycles, freq_mhz)
+    lines.append(f"Critical-path duration: {total_cp_ns / 1000:.3f} us")
+    if critical_path:
+        lines.append(f"Critical-path ops: {' -> '.join(critical_path)}")
+    lines.append("")
+
+    lines.append("--- Inferred Core Roles ---")
+    for role, cores in sorted(core_roles.items()):
+        if cores:
+            cores_sorted = sorted(cores)
+            shown = str(cores_sorted[:5])
+            extra = f"...+{len(cores) - 5}" if len(cores) > 5 else ""
+            lines.append(f"  {role}: {len(cores)} core(s) {shown}{extra}")
+    lines.append("")
+
+    hdr = f"{'Micro-Op':<22} {'Adjusted(us)':>12} {'Raw(us)':>10} " f"{'Blocked(us)':>11} {'Cores':>6} {'Breakdown'}"
+    lines.append("--- Per Micro-Op Timing ---")
+    lines.append(hdr)
+    lines.append("-" * 100)
+
+    for zone in config.display_order:
+        result = op_results.get(zone)
+        if result is None or result.duration_cycles == 0:
+            continue
+        parts = ", ".join(f"{k}={cycles_to_ns(v, freq_mhz)/1000:.1f}us" for k, v in result.breakdown.items() if v)
+        on_cp = " *" if zone in critical_path else ""
+        lines.append(
+            f"{zone:<22} {result.duration_us:>12.3f} "
+            f"{result.raw_duration_us:>10.3f} {result.blocking_us:>11.3f} "
+            f"{result.core_count:>6} {parts}{on_cp}"
+        )
+
+    lines.append("")
+    lines.append("  (* = on critical path)")
+    lines.append("")
+
+    lines.append("--- Dependency Chain ---")
+    for child, parent in config.dependencies:
+        p_res = op_results.get(parent)
+        c_res = op_results.get(child)
+        if p_res and c_res and p_res.duration_cycles > 0 and c_res.duration_cycles > 0:
+            lines.append(f"  {parent} ({p_res.duration_us:.2f} us) -> " f"{child} ({c_res.duration_us:.2f} us)")
+
+    if critical_path and op_results:
+        bottleneck = max(
+            (op_results[z] for z in critical_path if z in op_results),
+            key=lambda r: r.duration_cycles,
+            default=None,
+        )
+        if bottleneck and total_critical_cycles > 0:
+            pct = 100.0 * bottleneck.duration_cycles / total_critical_cycles
+            lines.append("")
+            lines.append(
+                f"Bottleneck: {bottleneck.zone} = {bottleneck.duration_us:.3f} us " f"({pct:.1f}% of critical path)"
+            )
+
+    lines.append("")
+    lines.append("=" * 90)
+    return "\n".join(lines)
+
+
+def format_json_report(
+    config: KernelConfig,
+    op_results: dict[str, OpTimingResult],
+    earliest_finish: dict[str, int],
+    critical_path: list[str],
+    total_critical_cycles: int,
+    core_roles: dict[str, set[tuple[int, int]]],
+    freq_mhz: float,
+) -> dict:
+    ops = {}
+    for zone, result in op_results.items():
+        if result.duration_cycles == 0:
+            continue
+        ops[zone] = {
+            "duration_us": result.duration_us,
+            "duration_ns": result.duration_ns,
+            "duration_cycles": result.duration_cycles,
+            "raw_duration_us": result.raw_duration_us,
+            "raw_duration_cycles": result.raw_duration_cycles,
+            "blocking_us": result.blocking_us,
+            "blocking_cycles": result.blocking_cycles,
+            "core_count": result.core_count,
+            "interval_count": result.interval_count,
+            "slowest_core": result.slowest_core,
+            "slowest_risc": result.slowest_risc,
+            "breakdown": {
+                k: {"cycles": v, "us": cycles_to_ns(v, freq_mhz) / 1000.0} for k, v in result.breakdown.items() if v
+            },
+            "on_critical_path": zone in critical_path,
+        }
+    total_cp_ns = cycles_to_ns(total_critical_cycles, freq_mhz)
+    return {
+        "kernel_name": config.kernel_name,
+        "freq_mhz": freq_mhz,
+        "critical_path": {
+            "ops": critical_path,
+            "total_duration_us": total_cp_ns / 1000.0,
+            "total_duration_ns": total_cp_ns,
+            "total_duration_cycles": total_critical_cycles,
+        },
+        "micro_ops": ops,
+        "core_roles": {k: sorted(list(v)) for k, v in core_roles.items() if v},
+    }
+
+
+# ============================================================================
+# Top-level analysis pipeline
+# ============================================================================
+
+
+def analyze(
+    log_path: Path,
+    config: KernelConfig,
+    verbose: bool = False,
+) -> tuple[
+    dict[str, OpTimingResult],
+    dict[str, int],
+    list[str],
+    int,
+    dict[str, set[tuple[int, int]]],
+    list[ZoneInterval],
+    float,
+]:
+    """Run the full analysis pipeline."""
+    intervals, freq_mhz = parse_device_log(log_path, config.allowed_zones, verbose)
+    core_roles = infer_core_roles(intervals, config)
+    classified = classify_intervals(intervals, config, core_roles)
+
+    all_zones = {op.zone for op in config.micro_ops}
+    topo_order = _topological_sort(all_zones, config.dependencies)
+
+    op_results: dict[str, OpTimingResult] = {}
+    op_dur_cycles: dict[str, int] = {}
+    for zone in topo_order:
+        micro_op = config.get_micro_op(zone)
+        if micro_op is None:
+            continue
+        gates = compute_predecessor_gates(zone, config, classified)
+        result = compute_op_duration(
+            micro_op,
+            classified.get(zone, []),
+            freq_mhz,
+            gates or None,
+        )
+        op_results[zone] = result
+        op_dur_cycles[zone] = result.duration_cycles
+
+    earliest_finish, critical_path, total_cp = compute_critical_path(
+        op_dur_cycles,
+        config.dependencies,
+    )
+
+    return (op_results, earliest_finish, critical_path, total_cp, core_roles, intervals, freq_mhz)
+
+
+# ============================================================================
+# CLI
+# ============================================================================
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Generalized fused-kernel micro-op timing analysis",
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--kernel", type=str, help="Built-in kernel name (e.g. pre_sdpa)")
+    group.add_argument("--config", type=Path, help="Path to custom YAML config")
+    parser.add_argument(
+        "--log",
+        type=Path,
+        default=Path("generated/profiler/.logs/profile_log_device.csv"),
+        help="Path to profile_log_device.csv",
+    )
+    parser.add_argument("--output", type=Path, default=None, help="Write report to file")
+    parser.add_argument("--json", action="store_true", help="Output JSON instead of text")
+    parser.add_argument("--verbose", action="store_true", help="Print debug info")
+    args = parser.parse_args()
+
+    config_source = args.config if args.config else args.kernel
+    try:
+        config = load_kernel_config(config_source)
+    except Exception as e:
+        print(f"Error loading config: {e}", file=sys.stderr)
+        return 1
+
+    log_path = args.log
+    if not log_path.is_absolute():
+        tt_home = Path(__file__).resolve().parents[4]
+        log_path = tt_home / log_path
+    if not log_path.exists():
+        print(f"Error: device log not found: {log_path}", file=sys.stderr)
+        return 1
+
+    (op_results, earliest_finish, critical_path, total_cp, core_roles, intervals, freq_mhz) = analyze(
+        log_path, config, args.verbose
+    )
+
+    if not intervals:
+        print(f"No {config.kernel_name} zone intervals found in log.", file=sys.stderr)
+        return 1
+
+    if args.json:
+        data = format_json_report(
+            config,
+            op_results,
+            earliest_finish,
+            critical_path,
+            total_cp,
+            core_roles,
+            freq_mhz,
+        )
+        report = json.dumps(data, indent=2)
+    else:
+        report = format_text_report(
+            config,
+            op_results,
+            earliest_finish,
+            critical_path,
+            total_cp,
+            core_roles,
+            intervals,
+            freq_mhz,
+        )
+
+    if args.output:
+        args.output.write_text(report)
+        print(f"Report written to {args.output}")
+    else:
+        print(report)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/models/demos/deepseek_v3_b1/profiling/kernel_configs/kv_cache_branch.yaml
+++ b/models/demos/deepseek_v3_b1/profiling/kernel_configs/kv_cache_branch.yaml
@@ -1,0 +1,60 @@
+kernel_name: kv_cache_branch
+
+core_roles:
+  dkv_matmul_core:
+    infer_from_zone: DKV_MATMUL
+  kv_rmsnorm_core:
+    infer_from_zone: KV_RMSNORM
+
+micro_ops:
+  - zone: DKV_MATMUL
+    type: compute
+    participants:
+      - role: dkv_matmul_core
+        risc: TRISC
+        function: compute
+
+  - zone: DKV_GATHER
+    type: gather
+    participants:
+      - role: dkv_matmul_core
+        risc: NCRISC
+        function: sender
+      - role: kv_rmsnorm_core
+        risc: BRISC
+        function: receiver
+
+  - zone: KV_RMSNORM
+    type: compute
+    participants:
+      - role: kv_rmsnorm_core
+        risc: TRISC
+        function: compute
+
+  - zone: K_ROPE
+    type: compute
+    participants:
+      - role: kv_rmsnorm_core
+        risc: TRISC
+        function: compute
+
+  - zone: KV_CACHE_UPDATE
+    type: dram_write
+    participants:
+      - role: kv_rmsnorm_core
+        risc: BRISC
+        function: writer
+
+dependencies:
+  - [DKV_GATHER, DKV_MATMUL]
+  - [KV_RMSNORM, DKV_GATHER]
+  - [K_ROPE, KV_RMSNORM]
+  - [KV_CACHE_UPDATE, KV_RMSNORM]
+  - [KV_CACHE_UPDATE, K_ROPE]
+
+display_order:
+  - DKV_MATMUL
+  - DKV_GATHER
+  - KV_RMSNORM
+  - K_ROPE
+  - KV_CACHE_UPDATE

--- a/models/demos/deepseek_v3_b1/profiling/kernel_configs/lm_head_sampling.yaml
+++ b/models/demos/deepseek_v3_b1/profiling/kernel_configs/lm_head_sampling.yaml
@@ -1,0 +1,62 @@
+kernel_name: lm_head_sampling
+
+core_roles:
+  input_core:
+    infer_from_zone: RMSNORM
+  matmul_core:
+    infer_from_zone: MATMUL
+
+micro_ops:
+  - zone: CCL_BROADCAST
+    type: broadcast
+    participants:
+      - role: input_core
+        risc: NCRISC
+        function: sender
+      - role: input_core
+        risc: BRISC
+        function: receiver
+
+  - zone: RMSNORM
+    type: compute
+    participants:
+      - role: input_core
+        risc: TRISC
+        function: compute
+
+  - zone: MCAST
+    type: mcast
+    participants:
+      - role: input_core
+        risc: BRISC
+        function: sender
+      - role: matmul_core
+        risc: NCRISC
+        function: receiver
+
+  - zone: MATMUL
+    type: compute
+    participants:
+      - role: matmul_core
+        risc: TRISC
+        function: compute
+
+  - zone: ARGMAX
+    type: span
+    participants:
+      - role: matmul_core
+        risc: NCRISC
+        function: reader
+
+dependencies:
+  - [RMSNORM, CCL_BROADCAST]
+  - [MCAST, RMSNORM]
+  - [MATMUL, MCAST]
+  - [ARGMAX, MATMUL]
+
+display_order:
+  - CCL_BROADCAST
+  - RMSNORM
+  - MCAST
+  - MATMUL
+  - ARGMAX

--- a/models/demos/deepseek_v3_b1/profiling/kernel_configs/moe.yaml
+++ b/models/demos/deepseek_v3_b1/profiling/kernel_configs/moe.yaml
@@ -1,0 +1,176 @@
+kernel_name: moe
+
+core_roles:
+  input_core:
+    infer_from_zone: RMSNORM
+  routing_core:
+    infer_from_zone: MATMUL
+  expert_core:
+    infer_from_zone: GATE_PROJ
+  down_proj_core:
+    infer_from_zone: DOWN_PROJ
+
+micro_ops:
+  - zone: RESIDUAL_MCAST
+    type: mcast
+    participants:
+      - role: input_core
+        risc: BRISC
+        function: sender
+      - role: expert_core
+        risc: NCRISC
+        function: receiver
+
+  - zone: RMSNORM
+    type: compute
+    participants:
+      - role: input_core
+        risc: TRISC
+        function: compute
+
+  - zone: MCAST
+    type: mcast
+    participants:
+      - role: input_core
+        risc: BRISC
+        function: sender
+      - role: routing_core
+        risc: NCRISC
+        function: receiver
+
+  - zone: MATMUL
+    type: compute
+    participants:
+      - role: routing_core
+        risc: TRISC
+        function: compute
+
+  - zone: GATHER
+    type: gather_reduce
+    participants:
+      - role: routing_core
+        risc: NCRISC
+        function: sender
+      - role: input_core
+        risc: BRISC
+        function: receiver
+      - role: input_core
+        risc: TRISC
+        function: reducer
+
+  - zone: GATE
+    type: compute
+    participants:
+      - role: input_core
+        risc: TRISC
+        function: compute
+
+  - zone: MCAST_INDEX
+    type: mcast
+    participants:
+      - role: input_core
+        risc: BRISC
+        function: sender
+      - role: expert_core
+        risc: NCRISC
+        function: receiver
+
+  - zone: MCAST_EXPERT_SCALE
+    type: mcast
+    participants:
+      - role: input_core
+        risc: BRISC
+        function: sender
+      - role: expert_core
+        risc: NCRISC
+        function: receiver
+
+  - zone: GATE_PROJ
+    type: compute
+    participants:
+      - role: expert_core
+        risc: TRISC
+        function: compute
+
+  - zone: UP_PROJ
+    type: compute
+    participants:
+      - role: expert_core
+        risc: TRISC
+        function: compute
+
+  - zone: MUL
+    type: compute
+    participants:
+      - role: expert_core
+        risc: TRISC
+        function: compute
+
+  - zone: DOWN_PROJ_GATHER
+    type: gather
+    participants:
+      - role: expert_core
+        risc: NCRISC
+        function: sender
+      - role: down_proj_core
+        risc: BRISC
+        function: receiver
+
+  - zone: DOWN_PROJ_MCAST
+    type: mcast
+    participants:
+      - role: down_proj_core
+        risc: BRISC
+        function: sender
+      - role: down_proj_core
+        risc: NCRISC
+        function: receiver
+
+  - zone: DOWN_PROJ
+    type: compute
+    participants:
+      - role: down_proj_core
+        risc: TRISC
+        function: compute
+
+  - zone: ELTWISE_ADD
+    type: compute
+    participants:
+      - role: down_proj_core
+        risc: TRISC
+        function: compute
+
+dependencies:
+  - [RMSNORM, RESIDUAL_MCAST]
+  - [MCAST, RMSNORM]
+  - [MATMUL, MCAST]
+  - [GATHER, MATMUL]
+  - [GATE, GATHER]
+  - [MCAST_INDEX, GATE]
+  - [MCAST_EXPERT_SCALE, GATE]
+  - [GATE_PROJ, MCAST_INDEX]
+  - [GATE_PROJ, MCAST_EXPERT_SCALE]
+  - [UP_PROJ, MCAST_INDEX]
+  - [MUL, GATE_PROJ]
+  - [MUL, UP_PROJ]
+  - [DOWN_PROJ_GATHER, MUL]
+  - [DOWN_PROJ_MCAST, DOWN_PROJ_GATHER]
+  - [DOWN_PROJ, DOWN_PROJ_MCAST]
+  - [ELTWISE_ADD, DOWN_PROJ]
+
+display_order:
+  - RESIDUAL_MCAST
+  - RMSNORM
+  - MCAST
+  - MATMUL
+  - GATHER
+  - GATE
+  - MCAST_INDEX
+  - MCAST_EXPERT_SCALE
+  - GATE_PROJ
+  - UP_PROJ
+  - MUL
+  - DOWN_PROJ_GATHER
+  - DOWN_PROJ_MCAST
+  - DOWN_PROJ
+  - ELTWISE_ADD

--- a/models/demos/deepseek_v3_b1/profiling/kernel_configs/post_sdpa.yaml
+++ b/models/demos/deepseek_v3_b1/profiling/kernel_configs/post_sdpa.yaml
@@ -1,0 +1,118 @@
+kernel_name: post_sdpa
+
+core_roles:
+  sdpa_core:
+    infer_from_zone: SDPA_REDUCE_TO_ALL
+  matmul1_core:
+    infer_from_zone: MATMUL1
+  matmul2_core:
+    infer_from_zone: MATMUL2
+
+micro_ops:
+  - zone: SDPA_REDUCE_TO_ALL
+    type: span
+    participants:
+      - role: sdpa_core
+        risc: TRISC
+        function: compute
+
+  - zone: MATMUL1
+    type: compute
+    participants:
+      - role: matmul1_core
+        risc: TRISC
+        function: compute
+
+  - zone: GATHER1
+    type: gather_reduce
+    participants:
+      - role: matmul1_core
+        risc: NCRISC
+        function: sender
+      - role: sdpa_core
+        risc: BRISC
+        function: receiver
+      - role: sdpa_core
+        risc: TRISC
+        function: reducer
+
+  - zone: MCAST
+    type: mcast
+    participants:
+      - role: sdpa_core
+        risc: BRISC
+        function: sender
+      - role: matmul2_core
+        risc: NCRISC
+        function: receiver
+
+  - zone: MATMUL2
+    type: compute
+    participants:
+      - role: matmul2_core
+        risc: TRISC
+        function: compute
+
+  - zone: GATHER2
+    type: gather_reduce
+    participants:
+      - role: matmul2_core
+        risc: NCRISC
+        function: sender
+      - role: sdpa_core
+        risc: BRISC
+        function: receiver
+      - role: sdpa_core
+        risc: TRISC
+        function: reducer
+
+  - zone: CCL_SENDER_READ
+    type: span
+    participants:
+      - role: sdpa_core
+        risc: NCRISC
+        function: reader
+
+  - zone: CCL_SENDER_SEND
+    type: span
+    participants:
+      - role: sdpa_core
+        risc: BRISC
+        function: sender
+
+  - zone: CCL_RECEIVER_WAIT
+    type: span
+    participants:
+      - role: sdpa_core
+        risc: NCRISC
+        function: reader
+
+  - zone: CCL_RECEIVER_COMPUTE
+    type: compute
+    participants:
+      - role: sdpa_core
+        risc: TRISC
+        function: compute
+
+dependencies:
+  - [MATMUL1, SDPA_REDUCE_TO_ALL]
+  - [GATHER1, MATMUL1]
+  - [MCAST, GATHER1]
+  - [MATMUL2, MCAST]
+  - [GATHER2, MATMUL2]
+  - [CCL_SENDER_READ, GATHER2]
+  - [CCL_SENDER_SEND, CCL_SENDER_READ]
+  - [CCL_RECEIVER_WAIT, GATHER2]
+  - [CCL_RECEIVER_COMPUTE, CCL_RECEIVER_WAIT]
+
+display_order:
+  - SDPA_REDUCE_TO_ALL
+  - MATMUL1
+  - GATHER1
+  - MCAST
+  - MATMUL2
+  - GATHER2
+  - CCL_SENDER_READ
+  - CCL_SENDER_SEND
+  - CCL_RECEIVER_WAIT
+  - CCL_RECEIVER_COMPUTE

--- a/models/demos/deepseek_v3_b1/profiling/kernel_configs/pre_sdpa.yaml
+++ b/models/demos/deepseek_v3_b1/profiling/kernel_configs/pre_sdpa.yaml
@@ -1,0 +1,197 @@
+kernel_name: pre_sdpa
+
+core_roles:
+  input_core:
+    infer_from_zone: RMSNORM
+  matmul_core:
+    infer_from_zone: MATMUL
+  matmul2_core:
+    infer_from_zone: MATMUL2
+  qnope_core:
+    infer_from_zone: "QNOPE/MATMUL3"
+  qrope_core:
+    infer_from_zone: QROPE
+  dkv_matmul_core:
+    infer_from_zone: DKV_MATMUL
+  kv_rmsnorm_core:
+    infer_from_zone: KV_RMSNORM
+
+micro_ops:
+  - zone: CCL_BROADCAST
+    type: broadcast
+    participants:
+      - role: input_core
+        risc: NCRISC
+        function: sender
+      - role: input_core
+        risc: BRISC
+        function: receiver
+
+  - zone: RMSNORM
+    type: compute
+    participants:
+      - role: input_core
+        risc: TRISC
+        function: compute
+
+  - zone: MCAST
+    type: mcast
+    participants:
+      - role: input_core
+        risc: BRISC
+        function: sender
+      - role: matmul_core
+        risc: NCRISC
+        function: receiver
+
+  - zone: MATMUL
+    type: compute
+    participants:
+      - role: matmul_core
+        risc: TRISC
+        function: compute
+
+  - zone: GATHER
+    type: gather_reduce
+    participants:
+      - role: matmul_core
+        risc: NCRISC
+        function: sender
+      - role: input_core
+        risc: BRISC
+        function: receiver
+      - role: input_core
+        risc: TRISC
+        function: reducer
+
+  - zone: RMSNORM2
+    type: compute
+    participants:
+      - role: input_core
+        risc: TRISC
+        function: compute
+
+  - zone: MCAST2
+    type: mcast
+    participants:
+      - role: input_core
+        risc: BRISC
+        function: sender
+      - role: matmul2_core
+        risc: NCRISC
+        function: receiver
+
+  - zone: MATMUL2
+    type: compute
+    participants:
+      - role: matmul2_core
+        risc: TRISC
+        function: compute
+
+  - zone: "QNOPE/MATMUL3"
+    type: compute
+    participants:
+      - role: qnope_core
+        risc: TRISC
+        function: compute
+
+  - zone: QROPE
+    type: compute
+    participants:
+      - role: qrope_core
+        risc: TRISC
+        function: compute
+
+  - zone: CREATE_Q_HEADS
+    type: span
+    participants:
+      - role: qnope_core
+        risc: NCRISC
+        function: sender
+      - role: qrope_core
+        risc: NCRISC
+        function: sender
+
+  - zone: DKV_MATMUL
+    type: compute
+    participants:
+      - role: dkv_matmul_core
+        risc: TRISC
+        function: compute
+
+  - zone: DKV_GATHER
+    type: gather
+    participants:
+      - role: dkv_matmul_core
+        risc: NCRISC
+        function: sender
+      - role: kv_rmsnorm_core
+        risc: BRISC
+        function: receiver
+
+  - zone: KV_RMSNORM
+    type: compute
+    participants:
+      - role: kv_rmsnorm_core
+        risc: TRISC
+        function: compute
+
+  - zone: K_ROPE
+    type: compute
+    participants:
+      - role: kv_rmsnorm_core
+        risc: TRISC
+        function: compute
+
+  - zone: KV_CACHE_UPDATE
+    type: dram_write
+    participants:
+      - role: kv_rmsnorm_core
+        risc: BRISC
+        function: writer
+
+  - zone: FLASH_MLA
+    type: span
+    participants:
+      - role: kv_rmsnorm_core
+        risc: TRISC
+        function: compute
+
+dependencies:
+  - [RMSNORM, CCL_BROADCAST]
+  - [MCAST, RMSNORM]
+  - [MATMUL, MCAST]
+  - [DKV_MATMUL, MCAST]
+  - [GATHER, MATMUL]
+  - [DKV_GATHER, DKV_MATMUL]
+  - [RMSNORM2, GATHER]
+  - [KV_RMSNORM, DKV_GATHER]
+  - [MCAST2, RMSNORM2]
+  - [MATMUL2, MCAST2]
+  - ["QNOPE/MATMUL3", MATMUL2]
+  - [QROPE, MATMUL2]
+  - [CREATE_Q_HEADS, "QNOPE/MATMUL3"]
+  - [CREATE_Q_HEADS, QROPE]
+  - [K_ROPE, KV_RMSNORM]
+  - [KV_CACHE_UPDATE, KV_RMSNORM]
+  - [KV_CACHE_UPDATE, K_ROPE]
+  - [FLASH_MLA, KV_CACHE_UPDATE]
+
+display_order:
+  - CCL_BROADCAST
+  - RMSNORM
+  - MCAST
+  - MATMUL
+  - DKV_MATMUL
+  - GATHER
+  - DKV_GATHER
+  - RMSNORM2
+  - KV_RMSNORM
+  - MCAST2
+  - MATMUL2
+  - "QNOPE/MATMUL3"
+  - QROPE
+  - CREATE_Q_HEADS
+  - K_ROPE
+  - KV_CACHE_UPDATE
+  - FLASH_MLA

--- a/models/demos/deepseek_v3_b1/profiling/kernel_configs/shared_expert.yaml
+++ b/models/demos/deepseek_v3_b1/profiling/kernel_configs/shared_expert.yaml
@@ -1,0 +1,123 @@
+kernel_name: shared_expert
+
+core_roles:
+  input_core:
+    infer_from_zone: GATED_REDUCE
+  matmul_core:
+    infer_from_zone: GATE_UP_MATMUL
+  down_matmul_core:
+    infer_from_zone: DOWN_MATMUL
+
+micro_ops:
+  - zone: ACT_MCAST
+    type: mcast
+    participants:
+      - role: input_core
+        risc: BRISC
+        function: sender
+      - role: matmul_core
+        risc: NCRISC
+        function: receiver
+
+  - zone: GATE_UP_MATMUL
+    type: compute
+    participants:
+      - role: matmul_core
+        risc: TRISC
+        function: compute
+
+  - zone: GATE_GATHER
+    type: gather
+    participants:
+      - role: matmul_core
+        risc: NCRISC
+        function: sender
+      - role: input_core
+        risc: BRISC
+        function: receiver
+
+  - zone: UP_GATHER
+    type: gather
+    participants:
+      - role: matmul_core
+        risc: NCRISC
+        function: sender
+      - role: input_core
+        risc: BRISC
+        function: receiver
+
+  - zone: GATED_REDUCE
+    type: compute
+    participants:
+      - role: input_core
+        risc: TRISC
+        function: compute
+
+  - zone: MCAST1
+    type: mcast
+    participants:
+      - role: input_core
+        risc: BRISC
+        function: sender
+      - role: down_matmul_core
+        risc: NCRISC
+        function: receiver
+
+  - zone: MCAST2
+    type: mcast
+    participants:
+      - role: input_core
+        risc: BRISC
+        function: sender
+      - role: down_matmul_core
+        risc: NCRISC
+        function: receiver
+
+  - zone: DOWN_MATMUL
+    type: compute
+    participants:
+      - role: down_matmul_core
+        risc: TRISC
+        function: compute
+
+  - zone: ADD
+    type: compute
+    participants:
+      - role: down_matmul_core
+        risc: TRISC
+        function: compute
+
+  - zone: OUTPUT_GATHER
+    type: gather
+    participants:
+      - role: down_matmul_core
+        risc: NCRISC
+        function: sender
+      - role: input_core
+        risc: BRISC
+        function: receiver
+
+dependencies:
+  - [GATE_UP_MATMUL, ACT_MCAST]
+  - [GATE_GATHER, GATE_UP_MATMUL]
+  - [UP_GATHER, GATE_UP_MATMUL]
+  - [GATED_REDUCE, GATE_GATHER]
+  - [GATED_REDUCE, UP_GATHER]
+  - [MCAST1, GATED_REDUCE]
+  - [MCAST2, GATED_REDUCE]
+  - [DOWN_MATMUL, MCAST1]
+  - [DOWN_MATMUL, MCAST2]
+  - [ADD, DOWN_MATMUL]
+  - [OUTPUT_GATHER, ADD]
+
+display_order:
+  - ACT_MCAST
+  - GATE_UP_MATMUL
+  - GATE_GATHER
+  - UP_GATHER
+  - GATED_REDUCE
+  - MCAST1
+  - MCAST2
+  - DOWN_MATMUL
+  - ADD
+  - OUTPUT_GATHER

--- a/models/demos/deepseek_v3_b1/profiling/tests/test_fused_kernel_profiler.py
+++ b/models/demos/deepseek_v3_b1/profiling/tests/test_fused_kernel_profiler.py
@@ -1,0 +1,933 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the generalized fused-kernel micro-op profiler."""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+PROFILING_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROFILING_DIR))
+
+from fused_kernel_profiler import (
+    ClassifiedInterval,
+    CoreRoleConfig,
+    KernelConfig,
+    MicroOpConfig,
+    OpType,
+    Participant,
+    ZoneInterval,
+    _adjusted_max_duration,
+    _adjusted_span_cycles,
+    _trisc_pipeline_wall_clock,
+    _uniform_gate,
+    classify_intervals,
+    compute_critical_path,
+    compute_op_duration,
+    compute_predecessor_gates,
+    cycles_to_ns,
+    extract_chip_freq_mhz,
+    format_json_report,
+    format_text_report,
+    infer_core_roles,
+    load_kernel_config,
+    parse_device_log,
+    risc_matches,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _iv(core, risc, zone, start, end, chip=0, tid=1):
+    """Shorthand to create a ZoneInterval."""
+    return ZoneInterval(
+        chip_id=chip,
+        core=core,
+        risc=risc,
+        zone_name=zone,
+        start_cycle=start,
+        end_cycle=end,
+        timer_id=tid,
+    )
+
+
+def _ci(iv, func="unknown", role="unknown"):
+    """Shorthand to create a ClassifiedInterval."""
+    return ClassifiedInterval(
+        interval=iv,
+        micro_op_zone=iv.zone_name,
+        function=func,
+        core_role=role,
+    )
+
+
+def _simple_config():
+    """Minimal config with RMSNORM (compute), MCAST, MATMUL, GATHER."""
+    return KernelConfig(
+        kernel_name="test",
+        core_roles={
+            "input_core": CoreRoleConfig(infer_from_zone="RMSNORM"),
+            "matmul_core": CoreRoleConfig(infer_from_zone="MATMUL"),
+        },
+        micro_ops=[
+            MicroOpConfig(
+                zone="RMSNORM",
+                type=OpType.COMPUTE,
+                participants=[Participant("input_core", "TRISC", "compute")],
+            ),
+            MicroOpConfig(
+                zone="MCAST",
+                type=OpType.MCAST,
+                participants=[
+                    Participant("input_core", "BRISC", "sender"),
+                    Participant("matmul_core", "NCRISC", "receiver"),
+                ],
+            ),
+            MicroOpConfig(
+                zone="MATMUL",
+                type=OpType.COMPUTE,
+                participants=[Participant("matmul_core", "TRISC", "compute")],
+            ),
+            MicroOpConfig(
+                zone="GATHER",
+                type=OpType.GATHER_REDUCE,
+                participants=[
+                    Participant("matmul_core", "NCRISC", "sender"),
+                    Participant("input_core", "BRISC", "receiver"),
+                    Participant("input_core", "TRISC", "reducer"),
+                ],
+            ),
+        ],
+        dependencies=[
+            ("MCAST", "RMSNORM"),
+            ("MATMUL", "MCAST"),
+            ("GATHER", "MATMUL"),
+        ],
+        display_order=["RMSNORM", "MCAST", "MATMUL", "GATHER"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Config loading
+# ---------------------------------------------------------------------------
+
+
+class TestConfigLoading:
+    def test_load_pre_sdpa_config(self):
+        config = load_kernel_config("pre_sdpa")
+        assert config.kernel_name == "pre_sdpa"
+        assert len(config.micro_ops) == 17
+        assert "input_core" in config.core_roles
+        assert "matmul_core" in config.core_roles
+        assert config.get_micro_op("MATMUL") is not None
+        assert config.get_micro_op("NONEXISTENT") is None
+
+    def test_load_all_built_in_configs(self):
+        for name in ["pre_sdpa", "post_sdpa", "shared_expert", "kv_cache_branch", "lm_head_sampling", "moe"]:
+            config = load_kernel_config(name)
+            assert config.kernel_name == name
+            assert len(config.micro_ops) > 0
+            assert len(config.display_order) > 0
+
+    def test_config_validation_bad_dependency(self, tmp_path):
+        bad_yaml = tmp_path / "bad.yaml"
+        bad_yaml.write_text(
+            "kernel_name: bad\n"
+            "core_roles:\n"
+            "  c1:\n"
+            "    infer_from_zone: Z1\n"
+            "micro_ops:\n"
+            "  - zone: Z1\n"
+            "    type: compute\n"
+            "    participants:\n"
+            "      - role: c1\n"
+            "        risc: TRISC\n"
+            "        function: compute\n"
+            "dependencies:\n"
+            "  - [Z1, NONEXISTENT]\n"
+        )
+        with pytest.raises(ValueError, match="NONEXISTENT"):
+            load_kernel_config(bad_yaml)
+
+    def test_config_not_found(self):
+        with pytest.raises(FileNotFoundError):
+            load_kernel_config("definitely_not_a_real_kernel_name_xyz")
+
+
+# ---------------------------------------------------------------------------
+# RISC matching
+# ---------------------------------------------------------------------------
+
+
+class TestRiscMatching:
+    def test_exact_match(self):
+        assert risc_matches("BRISC", "BRISC")
+        assert risc_matches("NCRISC", "NCRISC")
+
+    def test_trisc_wildcard(self):
+        assert risc_matches("TRISC", "TRISC_0")
+        assert risc_matches("TRISC", "TRISC_1")
+        assert risc_matches("TRISC", "TRISC_2")
+
+    def test_no_match(self):
+        assert not risc_matches("BRISC", "NCRISC")
+        assert not risc_matches("BRISC", "TRISC_0")
+        assert not risc_matches("NCRISC", "TRISC_1")
+
+
+# ---------------------------------------------------------------------------
+# Log parsing
+# ---------------------------------------------------------------------------
+
+SAMPLE_LOG = """ARCH: wormhole, CHIP_FREQ[MHz]: 1200
+PCIe slot, core_x, core_y, RISC processor type, timer_id, time[cycles since reset], stat value, Run ID, zone name, zone phase, source line, source file
+0,0,0,TRISC_0,1001,10000000000,0,1,RMSNORM,begin,100,k.cpp
+0,0,0,TRISC_0,1001,10000120000,0,1,RMSNORM,end,100,k.cpp
+0,0,0,TRISC_1,1002,10000010000,0,1,RMSNORM,begin,100,k.cpp
+0,0,0,TRISC_1,1002,10000100000,0,1,RMSNORM,end,100,k.cpp
+0,0,0,TRISC_2,1003,10000020000,0,1,RMSNORM,begin,100,k.cpp
+0,0,0,TRISC_2,1003,10000130000,0,1,RMSNORM,end,100,k.cpp
+0,0,0,BRISC,1004,10000130000,0,1,MCAST,begin,200,k.cpp
+0,0,0,BRISC,1004,10000180000,0,1,MCAST,end,200,k.cpp
+0,1,0,NCRISC,1005,10000180000,0,1,MCAST,begin,210,k.cpp
+0,1,0,NCRISC,1005,10000200000,0,1,MCAST,end,210,k.cpp
+0,2,0,NCRISC,1006,10000180000,0,1,MCAST,begin,210,k.cpp
+0,2,0,NCRISC,1006,10000210000,0,1,MCAST,end,210,k.cpp
+0,1,0,TRISC_0,1007,10000210000,0,1,MATMUL,begin,300,k.cpp
+0,1,0,TRISC_0,1007,10001010000,0,1,MATMUL,end,300,k.cpp
+0,1,0,TRISC_1,1008,10000220000,0,1,MATMUL,begin,300,k.cpp
+0,1,0,TRISC_1,1008,10001020000,0,1,MATMUL,end,300,k.cpp
+0,1,0,TRISC_2,1009,10000230000,0,1,MATMUL,begin,300,k.cpp
+0,1,0,TRISC_2,1009,10001050000,0,1,MATMUL,end,300,k.cpp
+0,2,0,TRISC_0,1010,10000210000,0,1,MATMUL,begin,300,k.cpp
+0,2,0,TRISC_0,1010,10001000000,0,1,MATMUL,end,300,k.cpp
+0,2,0,TRISC_1,1011,10000220000,0,1,MATMUL,begin,300,k.cpp
+0,2,0,TRISC_1,1011,10001010000,0,1,MATMUL,end,300,k.cpp
+0,2,0,TRISC_2,1012,10000230000,0,1,MATMUL,begin,300,k.cpp
+0,2,0,TRISC_2,1012,10001040000,0,1,MATMUL,end,300,k.cpp
+"""
+
+
+class TestLogParsing:
+    @pytest.fixture
+    def log_path(self, tmp_path):
+        p = tmp_path / "device_log.csv"
+        p.write_text(SAMPLE_LOG)
+        return p
+
+    def test_extract_freq(self, log_path):
+        assert extract_chip_freq_mhz(log_path) == 1200.0
+
+    def test_parse_all_zones(self, log_path):
+        intervals, freq = parse_device_log(log_path)
+        assert freq == 1200.0
+        zones = {iv.zone_name for iv in intervals}
+        assert zones == {"RMSNORM", "MCAST", "MATMUL"}
+
+    def test_parse_with_zone_filter(self, log_path):
+        intervals, _ = parse_device_log(log_path, allowed_zones={"RMSNORM"})
+        assert all(iv.zone_name == "RMSNORM" for iv in intervals)
+        assert len(intervals) == 3  # TRISC_0, TRISC_1, TRISC_2
+
+    def test_interval_duration(self, log_path):
+        intervals, _ = parse_device_log(log_path, allowed_zones={"RMSNORM"})
+        t0 = next(iv for iv in intervals if iv.risc == "TRISC_0")
+        assert t0.duration_cycles == 120000
+
+    def test_cycles_to_ns(self):
+        assert cycles_to_ns(1200000, 1200.0) == 1000000.0  # 1ms
+
+
+# ---------------------------------------------------------------------------
+# Core role inference
+# ---------------------------------------------------------------------------
+
+
+class TestCoreRoleInference:
+    def test_infer_roles(self, tmp_path):
+        intervals = [
+            _iv((0, 0), "TRISC_0", "RMSNORM", 0, 100000),
+            _iv((0, 0), "TRISC_1", "RMSNORM", 0, 90000),
+            _iv((1, 0), "TRISC_0", "RMSNORM", 0, 50),  # no-op
+            _iv((1, 0), "TRISC_0", "MATMUL", 0, 800000),
+            _iv((2, 0), "TRISC_0", "MATMUL", 0, 750000),
+        ]
+        config = _simple_config()
+        roles = infer_core_roles(intervals, config)
+        assert roles["input_core"] == {(0, 0)}
+        assert (1, 0) in roles["matmul_core"]
+        assert (2, 0) in roles["matmul_core"]
+        # (1,0) has RMSNORM with 50 cycles = 0.05% of 100000 -> filtered out
+        assert (1, 0) not in roles["input_core"]
+
+
+# ---------------------------------------------------------------------------
+# Interval classification
+# ---------------------------------------------------------------------------
+
+
+class TestIntervalClassification:
+    def test_classify_mcast(self):
+        intervals = [
+            _iv((0, 0), "BRISC", "MCAST", 0, 50000),
+            _iv((1, 0), "NCRISC", "MCAST", 50000, 70000),
+            _iv((2, 0), "NCRISC", "MCAST", 50000, 80000),
+        ]
+        config = _simple_config()
+        core_roles = {
+            "input_core": {(0, 0)},
+            "matmul_core": {(1, 0), (2, 0)},
+        }
+        classified = classify_intervals(intervals, config, core_roles)
+        mcast_cls = classified["MCAST"]
+        senders = [c for c in mcast_cls if c.function == "sender"]
+        receivers = [c for c in mcast_cls if c.function == "receiver"]
+        assert len(senders) == 1
+        assert senders[0].interval.core == (0, 0)
+        assert len(receivers) == 2
+
+    def test_classify_trisc_compute(self):
+        intervals = [
+            _iv((0, 0), "TRISC_0", "RMSNORM", 0, 100000),
+            _iv((0, 0), "TRISC_1", "RMSNORM", 10000, 95000),
+            _iv((0, 0), "TRISC_2", "RMSNORM", 20000, 110000),
+        ]
+        config = _simple_config()
+        core_roles = {"input_core": {(0, 0)}, "matmul_core": set()}
+        classified = classify_intervals(intervals, config, core_roles)
+        rms_cls = classified["RMSNORM"]
+        assert all(c.function == "compute" for c in rms_cls)
+        assert len(rms_cls) == 3  # all 3 TRISCs classified
+
+
+# ---------------------------------------------------------------------------
+# Timing engine
+# ---------------------------------------------------------------------------
+
+
+class TestTimingEngine:
+    def test_compute_trisc_pipeline(self):
+        """Per-core wall clock = max(end) - min(start) across TRISC sub-procs."""
+        intervals = [
+            _ci(_iv((0, 0), "TRISC_0", "X", 1000, 1100), "compute"),
+            _ci(_iv((0, 0), "TRISC_1", "X", 1020, 1110), "compute"),
+            _ci(_iv((0, 0), "TRISC_2", "X", 1040, 1120), "compute"),
+        ]
+        dur, core = _trisc_pipeline_wall_clock(intervals)
+        # wall clock = 1120 - 1000 = 120 (NOT max of durations 100, 90, 80)
+        assert dur == 120
+        assert core == (0, 0)
+
+    def test_compute_multi_core(self):
+        """Max across cores of per-core pipeline wall clock."""
+        intervals = [
+            _ci(_iv((0, 0), "TRISC_0", "X", 1000, 1100), "compute"),
+            _ci(_iv((0, 0), "TRISC_1", "X", 1020, 1110), "compute"),
+            _ci(_iv((0, 0), "TRISC_2", "X", 1040, 1120), "compute"),
+            _ci(_iv((1, 0), "TRISC_0", "X", 2000, 2200), "compute"),
+            _ci(_iv((1, 0), "TRISC_1", "X", 2030, 2210), "compute"),
+            _ci(_iv((1, 0), "TRISC_2", "X", 2050, 2250), "compute"),
+        ]
+        dur, core = _trisc_pipeline_wall_clock(intervals)
+        # core (0,0): 1120-1000=120, core (1,0): 2250-2000=250 -> max=250
+        assert dur == 250
+        assert core == (1, 0)
+
+    def test_mcast_sender_plus_max_receiver(self):
+        """Mcast duration = sender + max(receivers)."""
+        micro_op = MicroOpConfig(
+            zone="MCAST",
+            type=OpType.MCAST,
+            participants=[
+                Participant("input_core", "BRISC", "sender"),
+                Participant("matmul_core", "NCRISC", "receiver"),
+            ],
+        )
+        classified = [
+            _ci(_iv((0, 0), "BRISC", "MCAST", 0, 50000), "sender", "input_core"),
+            _ci(_iv((1, 0), "NCRISC", "MCAST", 50000, 70000), "receiver", "matmul_core"),
+            _ci(_iv((2, 0), "NCRISC", "MCAST", 50000, 80000), "receiver", "matmul_core"),
+        ]
+        result = compute_op_duration(micro_op, classified, 1000.0)
+        # sender=50000, max(receiver)=30000, total=80000
+        assert result.duration_cycles == 80000
+        assert result.breakdown["sender"] == 50000
+        assert result.breakdown["receiver"] == 30000
+
+    def test_gather_reduce(self):
+        """gather_reduce = max(senders) + receiver + reducer TRISC pipeline."""
+        micro_op = MicroOpConfig(
+            zone="GATHER",
+            type=OpType.GATHER_REDUCE,
+            participants=[
+                Participant("matmul_core", "NCRISC", "sender"),
+                Participant("input_core", "BRISC", "receiver"),
+                Participant("input_core", "TRISC", "reducer"),
+            ],
+        )
+        classified = [
+            _ci(_iv((1, 0), "NCRISC", "GATHER", 0, 10000), "sender"),
+            _ci(_iv((2, 0), "NCRISC", "GATHER", 0, 12000), "sender"),
+            _ci(_iv((0, 0), "BRISC", "GATHER", 12000, 17000), "receiver"),
+            _ci(_iv((0, 0), "TRISC_0", "GATHER", 17000, 22000), "reducer"),
+            _ci(_iv((0, 0), "TRISC_1", "GATHER", 17500, 22500), "reducer"),
+            _ci(_iv((0, 0), "TRISC_2", "GATHER", 18000, 23000), "reducer"),
+        ]
+        result = compute_op_duration(micro_op, classified, 1000.0)
+        # max(sender)=12000, receiver=5000, reducer=23000-17000=6000
+        assert result.duration_cycles == 12000 + 5000 + 6000
+
+    def test_dram_write(self):
+        micro_op = MicroOpConfig(
+            zone="KV_CACHE_UPDATE",
+            type=OpType.DRAM_WRITE,
+            participants=[Participant("kv_core", "BRISC", "writer")],
+        )
+        classified = [
+            _ci(_iv((3, 0), "BRISC", "KV_CACHE_UPDATE", 0, 5000), "writer"),
+            _ci(_iv((4, 0), "BRISC", "KV_CACHE_UPDATE", 0, 7000), "writer"),
+        ]
+        result = compute_op_duration(micro_op, classified, 1000.0)
+        assert result.duration_cycles == 7000
+
+    def test_span_type(self):
+        micro_op = MicroOpConfig(
+            zone="FLASH_MLA",
+            type=OpType.SPAN,
+            participants=[Participant("kv_core", "TRISC", "compute")],
+        )
+        classified = [
+            _ci(_iv((3, 0), "TRISC_0", "FLASH_MLA", 100, 500), "compute"),
+            _ci(_iv((3, 0), "TRISC_1", "FLASH_MLA", 200, 600), "compute"),
+            _ci(_iv((4, 0), "TRISC_0", "FLASH_MLA", 50, 700), "compute"),
+        ]
+        result = compute_op_duration(micro_op, classified, 1000.0)
+        # span = 700 - 50 = 650
+        assert result.duration_cycles == 650
+
+    def test_empty_classified(self):
+        micro_op = MicroOpConfig(
+            zone="X",
+            type=OpType.COMPUTE,
+            participants=[],
+        )
+        result = compute_op_duration(micro_op, [], 1000.0)
+        assert result.duration_cycles == 0
+
+
+# ---------------------------------------------------------------------------
+# Critical-path solver
+# ---------------------------------------------------------------------------
+
+
+class TestCriticalPath:
+    def test_linear_chain(self):
+        durations = {"A": 100, "B": 200, "C": 50}
+        deps = [("B", "A"), ("C", "B")]
+        ef, path, total = compute_critical_path(durations, deps)
+        assert total == 350
+        assert path == ["A", "B", "C"]
+
+    def test_parallel_branches_take_max(self):
+        durations = {"ROOT": 10, "FAST": 20, "SLOW": 100, "JOIN": 5}
+        deps = [("FAST", "ROOT"), ("SLOW", "ROOT"), ("JOIN", "FAST"), ("JOIN", "SLOW")]
+        ef, path, total = compute_critical_path(durations, deps)
+        # critical path: ROOT(10) -> SLOW(100) -> JOIN(5) = 115
+        assert total == 115
+        assert "SLOW" in path
+        assert "FAST" not in path
+
+    def test_independent_ops(self):
+        durations = {"A": 100, "B": 200}
+        deps = []
+        ef, path, total = compute_critical_path(durations, deps)
+        assert total == 200
+        assert path == ["B"]
+
+    def test_empty(self):
+        ef, path, total = compute_critical_path({}, [])
+        assert total == 0
+        assert path == []
+
+
+# ---------------------------------------------------------------------------
+# Report generation
+# ---------------------------------------------------------------------------
+
+
+class TestReportGeneration:
+    def _run_pipeline(self, log_path):
+        from fused_kernel_profiler import analyze
+
+        config = _simple_config()
+        return analyze(log_path, config)
+
+    @pytest.fixture
+    def log_path(self, tmp_path):
+        p = tmp_path / "device_log.csv"
+        p.write_text(SAMPLE_LOG)
+        return p
+
+    def test_text_report_contains_key_info(self, log_path):
+        (op_results, ef, cp, total_cp, roles, ivs, freq) = self._run_pipeline(log_path)
+        config = _simple_config()
+        report = format_text_report(config, op_results, ef, cp, total_cp, roles, ivs, freq)
+        assert "test" in report
+        assert "MATMUL" in report
+        assert "Critical-path" in report
+
+    def test_json_report_structure(self, log_path):
+        (op_results, ef, cp, total_cp, roles, ivs, freq) = self._run_pipeline(log_path)
+        config = _simple_config()
+        data = format_json_report(config, op_results, ef, cp, total_cp, roles, freq)
+        assert data["kernel_name"] == "test"
+        assert "critical_path" in data
+        assert "micro_ops" in data
+        assert "MATMUL" in data["micro_ops"]
+
+
+# ---------------------------------------------------------------------------
+# End-to-end with pre_sdpa config
+# ---------------------------------------------------------------------------
+
+
+class TestEndToEnd:
+    @pytest.fixture
+    def log_path(self, tmp_path):
+        p = tmp_path / "device_log.csv"
+        p.write_text(SAMPLE_LOG)
+        return p
+
+    def test_pre_sdpa_config_loads_and_runs(self, log_path):
+        """Load the real pre_sdpa config and run against sample data."""
+        from fused_kernel_profiler import analyze
+
+        config = load_kernel_config("pre_sdpa")
+        (op_results, ef, cp, total_cp, roles, ivs, freq) = analyze(log_path, config)
+        assert freq == 1200.0
+        # MATMUL should be found
+        assert "MATMUL" in op_results
+        matmul_result = op_results["MATMUL"]
+        assert matmul_result.duration_cycles > 0
+
+    def test_main_cli_json(self, log_path, tmp_path):
+        """Test CLI --json output."""
+        import sys
+
+        from fused_kernel_profiler import main
+
+        out_path = tmp_path / "out.json"
+        orig = sys.argv
+        try:
+            sys.argv = [
+                "fused_kernel_profiler",
+                "--kernel",
+                "pre_sdpa",
+                "--log",
+                str(log_path),
+                "--json",
+                "--output",
+                str(out_path),
+            ]
+            code = main()
+            assert code == 0
+            data = json.loads(out_path.read_text())
+            assert data["kernel_name"] == "pre_sdpa"
+        finally:
+            sys.argv = orig
+
+    def test_main_cli_missing_log(self, tmp_path):
+        import sys
+
+        from fused_kernel_profiler import main
+
+        orig = sys.argv
+        try:
+            sys.argv = [
+                "fused_kernel_profiler",
+                "--kernel",
+                "pre_sdpa",
+                "--log",
+                str(tmp_path / "nonexistent.csv"),
+            ]
+            code = main()
+            assert code == 1
+        finally:
+            sys.argv = orig
+
+
+# ---------------------------------------------------------------------------
+# Predecessor gate computation
+# ---------------------------------------------------------------------------
+
+
+class TestPredecessorGates:
+    def test_no_predecessors_returns_empty(self):
+        config = _simple_config()
+        classified = {}
+        gates = compute_predecessor_gates("RMSNORM", config, classified)
+        assert gates == {}
+
+    def test_same_core_gate(self):
+        """MATMUL depends on MCAST; both have matmul_core participants."""
+        config = _simple_config()
+        classified = {
+            "MCAST": [
+                _ci(_iv((0, 0), "BRISC", "MCAST", 100, 200), "sender", "input_core"),
+                _ci(_iv((1, 0), "NCRISC", "MCAST", 100, 300), "receiver", "matmul_core"),
+                _ci(_iv((2, 0), "NCRISC", "MCAST", 100, 350), "receiver", "matmul_core"),
+            ],
+            "MATMUL": [
+                _ci(_iv((1, 0), "TRISC_0", "MATMUL", 250, 900), "compute", "matmul_core"),
+                _ci(_iv((2, 0), "TRISC_0", "MATMUL", 250, 920), "compute", "matmul_core"),
+            ],
+        }
+        gates = compute_predecessor_gates("MATMUL", config, classified)
+        assert gates[(1, 0)] == 300
+        assert gates[(2, 0)] == 350
+        assert (0, 0) not in gates
+
+    def test_cross_core_gate(self):
+        """MCAST depends on RMSNORM; MCAST sender (input_core) shares role,
+        MCAST receivers (matmul_core) do NOT share a role with RMSNORM."""
+        config = _simple_config()
+        classified = {
+            "RMSNORM": [
+                _ci(_iv((0, 0), "TRISC_0", "RMSNORM", 0, 150), "compute", "input_core"),
+            ],
+            "MCAST": [
+                _ci(_iv((0, 0), "BRISC", "MCAST", 100, 260), "sender", "input_core"),
+                _ci(_iv((1, 0), "NCRISC", "MCAST", 100, 300), "receiver", "matmul_core"),
+            ],
+        }
+        gates = compute_predecessor_gates("MCAST", config, classified)
+        assert gates[(0, 0)] == 150
+
+    def test_multiple_predecessors_take_max(self):
+        """CREATE_Q_HEADS depends on both QNOPE and QROPE in pre_sdpa."""
+        config = KernelConfig(
+            kernel_name="test_multi_pred",
+            core_roles={
+                "core_a": CoreRoleConfig(infer_from_zone="OP_A"),
+                "core_b": CoreRoleConfig(infer_from_zone="OP_B"),
+            },
+            micro_ops=[
+                MicroOpConfig("OP_A", OpType.COMPUTE, [Participant("core_a", "TRISC", "compute")]),
+                MicroOpConfig("OP_B", OpType.COMPUTE, [Participant("core_b", "TRISC", "compute")]),
+                MicroOpConfig(
+                    "JOIN",
+                    OpType.SPAN,
+                    [Participant("core_a", "NCRISC", "sender"), Participant("core_b", "NCRISC", "sender")],
+                ),
+            ],
+            dependencies=[("JOIN", "OP_A"), ("JOIN", "OP_B")],
+            display_order=["OP_A", "OP_B", "JOIN"],
+        )
+        classified = {
+            "OP_A": [_ci(_iv((1, 0), "TRISC_0", "OP_A", 0, 500), "compute", "core_a")],
+            "OP_B": [_ci(_iv((2, 0), "TRISC_0", "OP_B", 0, 800), "compute", "core_b")],
+            "JOIN": [
+                _ci(_iv((1, 0), "NCRISC", "JOIN", 100, 900), "sender", "core_a"),
+                _ci(_iv((2, 0), "NCRISC", "JOIN", 100, 950), "sender", "core_b"),
+            ],
+        }
+        gates = compute_predecessor_gates("JOIN", config, classified)
+        assert gates[(1, 0)] == 500
+        assert gates[(2, 0)] == 800
+
+
+# ---------------------------------------------------------------------------
+# Gate-adjusted timing helpers
+# ---------------------------------------------------------------------------
+
+
+class TestGateAdjustedHelpers:
+    def test_trisc_pipeline_with_gate_subtracts_blocking(self):
+        """TRISC on core (1,0): starts at 200, ends at 900.
+        Gate (MCAST NCRISC end) on that core = 500.
+        Blocking = 500-200 = 300.  Adjusted = 900-500 = 400."""
+        intervals = [
+            _ci(_iv((1, 0), "TRISC_0", "X", 200, 850), "compute"),
+            _ci(_iv((1, 0), "TRISC_1", "X", 220, 870), "compute"),
+            _ci(_iv((1, 0), "TRISC_2", "X", 240, 900), "compute"),
+        ]
+        gates = {(1, 0): 500}
+        adj, core = _trisc_pipeline_wall_clock(intervals, gates)
+        assert adj == 900 - 500
+        assert core == (1, 0)
+
+    def test_trisc_pipeline_no_blocking_when_gate_before_start(self):
+        """Gate is before the zone starts -> no adjustment."""
+        intervals = [
+            _ci(_iv((1, 0), "TRISC_0", "X", 600, 900), "compute"),
+            _ci(_iv((1, 0), "TRISC_1", "X", 610, 910), "compute"),
+        ]
+        gates = {(1, 0): 500}
+        adj, core = _trisc_pipeline_wall_clock(intervals, gates)
+        assert adj == 910 - 600
+        assert core == (1, 0)
+
+    def test_trisc_pipeline_multi_core_with_different_gates(self):
+        """Two cores, each with different gate times."""
+        intervals = [
+            _ci(_iv((1, 0), "TRISC_0", "X", 100, 800), "compute"),
+            _ci(_iv((2, 0), "TRISC_0", "X", 100, 900), "compute"),
+        ]
+        gates = {(1, 0): 300, (2, 0): 600}
+        adj, core = _trisc_pipeline_wall_clock(intervals, gates)
+        # core (1,0): 800 - max(100,300) = 500
+        # core (2,0): 900 - max(100,600) = 300
+        assert adj == 500
+        assert core == (1, 0)
+
+    def test_adjusted_max_duration_with_gate(self):
+        intervals = [
+            _ci(_iv((0, 0), "BRISC", "X", 100, 500), "sender"),
+            _ci(_iv((1, 0), "BRISC", "X", 100, 600), "sender"),
+        ]
+        gates = {(0, 0): 400, (1, 0): 400}
+        result = _adjusted_max_duration(intervals, gates)
+        # (0,0): 500 - max(100,400) = 100
+        # (1,0): 600 - max(100,400) = 200
+        assert result == 200
+
+    def test_adjusted_max_duration_no_gate(self):
+        intervals = [
+            _ci(_iv((0, 0), "BRISC", "X", 100, 500), "sender"),
+            _ci(_iv((1, 0), "BRISC", "X", 100, 300), "sender"),
+        ]
+        result = _adjusted_max_duration(intervals, None)
+        assert result == 400
+
+    def test_adjusted_span_cycles_with_gate(self):
+        intervals = [
+            _ci(_iv((0, 0), "TRISC_0", "X", 100, 700), "compute"),
+            _ci(_iv((1, 0), "TRISC_0", "X", 200, 800), "compute"),
+        ]
+        gates = {(0, 0): 500, (1, 0): 500}
+        result = _adjusted_span_cycles(intervals, gates)
+        # min_start=100, max_end=800, max_gate=500
+        # 800 - max(100, 500) = 300
+        assert result == 300
+
+    def test_adjusted_span_no_gate_unchanged(self):
+        intervals = [
+            _ci(_iv((0, 0), "TRISC_0", "X", 100, 700), "compute"),
+        ]
+        result = _adjusted_span_cycles(intervals)
+        assert result == 600
+
+    def test_uniform_gate(self):
+        intervals = [
+            _ci(_iv((1, 0), "NCRISC", "X", 0, 100), "receiver"),
+            _ci(_iv((2, 0), "NCRISC", "X", 0, 200), "receiver"),
+        ]
+        gate = _uniform_gate(intervals, 50)
+        assert gate == {(1, 0): 50, (2, 0): 50}
+
+
+# ---------------------------------------------------------------------------
+# Gate-adjusted op timing (integrated)
+# ---------------------------------------------------------------------------
+
+
+class TestGateAdjustedOpTiming:
+    def test_compute_with_gate_subtracts_blocking(self):
+        """MATMUL TRISC starts at t=200, predecessor MCAST ends at t=500."""
+        micro_op = MicroOpConfig(
+            zone="MATMUL",
+            type=OpType.COMPUTE,
+            participants=[Participant("matmul_core", "TRISC", "compute")],
+        )
+        classified = [
+            _ci(_iv((1, 0), "TRISC_0", "MATMUL", 200, 850), "compute", "matmul_core"),
+            _ci(_iv((1, 0), "TRISC_1", "MATMUL", 220, 870), "compute", "matmul_core"),
+            _ci(_iv((1, 0), "TRISC_2", "MATMUL", 240, 900), "compute", "matmul_core"),
+        ]
+        gates = {(1, 0): 500}
+        result = compute_op_duration(micro_op, classified, 1000.0, gates)
+        assert result.duration_cycles == 900 - 500  # 400 adjusted
+        assert result.raw_duration_cycles == 900 - 200  # 700 raw
+        assert result.blocking_cycles == 300
+        assert result.duration_us == pytest.approx(0.4)
+        assert result.raw_duration_us == pytest.approx(0.7)
+        assert result.blocking_us == pytest.approx(0.3)
+
+    def test_compute_no_gate_raw_equals_adjusted(self):
+        micro_op = MicroOpConfig(
+            zone="MATMUL",
+            type=OpType.COMPUTE,
+            participants=[Participant("matmul_core", "TRISC", "compute")],
+        )
+        classified = [
+            _ci(_iv((1, 0), "TRISC_0", "MATMUL", 200, 900), "compute", "matmul_core"),
+        ]
+        result = compute_op_duration(micro_op, classified, 1000.0)
+        assert result.duration_cycles == result.raw_duration_cycles
+        assert result.blocking_cycles == 0
+
+    def test_mcast_cross_op_and_within_op_gate(self):
+        """
+        MCAST sender on input_core blocks on RMSNORM (cross-op gate).
+        MCAST receiver on matmul_core blocks on sender (within-op gate).
+        """
+        micro_op = MicroOpConfig(
+            zone="MCAST",
+            type=OpType.MCAST,
+            participants=[
+                Participant("input_core", "BRISC", "sender"),
+                Participant("matmul_core", "NCRISC", "receiver"),
+            ],
+        )
+        # Sender enters zone at 100, RMSNORM ends at 200, sender finishes at 260
+        # Receiver enters zone at 95, blocks on sender until ~260, finishes at 280
+        classified = [
+            _ci(_iv((0, 0), "BRISC", "MCAST", 100, 260), "sender", "input_core"),
+            _ci(_iv((1, 0), "NCRISC", "MCAST", 95, 280), "receiver", "matmul_core"),
+        ]
+        cross_op_gate = {(0, 0): 200}  # RMSNORM TRISC end on input_core
+        result = compute_op_duration(micro_op, classified, 1000.0, cross_op_gate)
+
+        # adjusted sender = 260 - max(100, 200) = 60
+        # within-op gate for receiver = sender_end = 260
+        # adjusted receiver = 280 - max(95, 260) = 20
+        # adjusted total = 60 + 20 = 80
+        assert result.duration_cycles == 80
+        assert result.breakdown["sender"] == 60
+        assert result.breakdown["receiver"] == 20
+
+        # raw sender = 160, raw receiver = 185, raw total = 345
+        assert result.raw_duration_cycles == 160 + 185
+
+    def test_gather_reduce_full_adjustment(self):
+        """
+        GATHER: senders (matmul_core) block on MATMUL (cross-op gate).
+        Receiver (input_core) blocks on senders (within-op gate).
+        Reducer (input_core) blocks on receiver (within-op gate).
+        """
+        micro_op = MicroOpConfig(
+            zone="GATHER",
+            type=OpType.GATHER_REDUCE,
+            participants=[
+                Participant("matmul_core", "NCRISC", "sender"),
+                Participant("input_core", "BRISC", "receiver"),
+                Participant("input_core", "TRISC", "reducer"),
+            ],
+        )
+        classified = [
+            _ci(_iv((1, 0), "NCRISC", "GATHER", 800, 1050), "sender", "matmul_core"),
+            _ci(_iv((2, 0), "NCRISC", "GATHER", 800, 1100), "sender", "matmul_core"),
+            _ci(_iv((0, 0), "BRISC", "GATHER", 900, 1200), "receiver", "input_core"),
+            _ci(_iv((0, 0), "TRISC_0", "GATHER", 1000, 1400), "reducer", "input_core"),
+            _ci(_iv((0, 0), "TRISC_1", "GATHER", 1020, 1420), "reducer", "input_core"),
+            _ci(_iv((0, 0), "TRISC_2", "GATHER", 1040, 1450), "reducer", "input_core"),
+        ]
+        # MATMUL TRISC ends at 950 on core (1,0) and 980 on core (2,0)
+        cross_op_gate = {(1, 0): 950, (2, 0): 980}
+        result = compute_op_duration(micro_op, classified, 1000.0, cross_op_gate)
+
+        # adj sender (1,0): 1050 - max(800, 950) = 100
+        # adj sender (2,0): 1100 - max(800, 980) = 120
+        # max adj sender = 120
+        adj_s = 120
+
+        # within-op gate for receiver = max(sender_ends) = 1100
+        # adj receiver: 1200 - max(900, 1100) = 100
+        adj_r = 100
+
+        # within-op gate for reducer = receiver_end = 1200
+        # reducer TRISC: starts 1000,1020,1040 ends 1400,1420,1450
+        # adj on core (0,0): max(1450) - max(min(1000), 1200) = 1450 - 1200 = 250
+        adj_red = 250
+
+        assert result.duration_cycles == adj_s + adj_r + adj_red
+        assert result.breakdown["sender"] == adj_s
+        assert result.breakdown["receiver"] == adj_r
+        assert result.breakdown["reducer"] == adj_red
+
+    def test_dram_write_with_gate(self):
+        micro_op = MicroOpConfig(
+            zone="KV_CACHE",
+            type=OpType.DRAM_WRITE,
+            participants=[Participant("kv_core", "BRISC", "writer")],
+        )
+        classified = [
+            _ci(_iv((3, 0), "BRISC", "KV_CACHE", 100, 500), "writer", "kv_core"),
+        ]
+        gates = {(3, 0): 400}
+        result = compute_op_duration(micro_op, classified, 1000.0, gates)
+        assert result.duration_cycles == 100  # 500 - max(100, 400)
+        assert result.raw_duration_cycles == 400
+        assert result.blocking_cycles == 300
+
+    def test_span_with_gate(self):
+        micro_op = MicroOpConfig(
+            zone="FLASH",
+            type=OpType.SPAN,
+            participants=[Participant("kv_core", "TRISC", "compute")],
+        )
+        classified = [
+            _ci(_iv((3, 0), "TRISC_0", "FLASH", 100, 800), "compute", "kv_core"),
+            _ci(_iv((4, 0), "TRISC_0", "FLASH", 200, 900), "compute", "kv_core"),
+        ]
+        gates = {(3, 0): 500, (4, 0): 500}
+        result = compute_op_duration(micro_op, classified, 1000.0, gates)
+        # raw span = 900-100 = 800
+        # adjusted: max_end=900, min_start=100, max_gate=500
+        # 900 - max(100, 500) = 400
+        assert result.duration_cycles == 400
+        assert result.raw_duration_cycles == 800
+
+    def test_json_report_includes_blocking_fields(self):
+        """JSON report should contain raw_duration_us and blocking_us."""
+        config = _simple_config()
+        micro_op = config.micro_ops[0]  # RMSNORM
+        result = compute_op_duration(
+            micro_op,
+            [
+                _ci(_iv((0, 0), "TRISC_0", "RMSNORM", 0, 1000), "compute", "input_core"),
+            ],
+            1000.0,
+        )
+        op_results = {"RMSNORM": result}
+        data = format_json_report(
+            config,
+            op_results,
+            {"RMSNORM": 1000},
+            ["RMSNORM"],
+            1000,
+            {"input_core": {(0, 0)}, "matmul_core": set()},
+            1000.0,
+        )
+        rmsnorm_data = data["micro_ops"]["RMSNORM"]
+        assert "raw_duration_us" in rmsnorm_data
+        assert "blocking_us" in rmsnorm_data
+        assert "blocking_cycles" in rmsnorm_data
+
+    def test_text_report_shows_adjusted_column(self):
+        """Text report header should include Adjusted and Blocked columns."""
+        config = _simple_config()
+        result = compute_op_duration(
+            config.micro_ops[0],
+            [
+                _ci(_iv((0, 0), "TRISC_0", "RMSNORM", 0, 1000), "compute", "input_core"),
+            ],
+            1000.0,
+        )
+        report = format_text_report(
+            config,
+            {"RMSNORM": result},
+            {"RMSNORM": 1000},
+            ["RMSNORM"],
+            1000,
+            {"input_core": {(0, 0)}, "matmul_core": set()},
+            [_iv((0, 0), "TRISC_0", "RMSNORM", 0, 1000)],
+            1000.0,
+        )
+        assert "Adjusted(us)" in report
+        assert "Blocked(us)" in report


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ssundaram/profile_deepseek_ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ssundaram/profile_deepseek_ops)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ssundaram/profile_deepseek_ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ssundaram/profile_deepseek_ops)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ssundaram/profile_deepseek_ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ssundaram/profile_deepseek_ops)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ssundaram/profile_deepseek_ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ssundaram/profile_deepseek_ops)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ssundaram/profile_deepseek_ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ssundaram/profile_deepseek_ops)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ssundaram/profile_deepseek_ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ssundaram/profile_deepseek_ops)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
