### PR TITLE
Locked memory regions and CBs on the device

### DIFF
--- a/tests/tt_metal/tt_metal/noc_debugging/noc_debugging_fixture.hpp
+++ b/tests/tt_metal/tt_metal/noc_debugging/noc_debugging_fixture.hpp
@@ -68,6 +68,22 @@ public:
                issue.has_base_issue(NOCDebugIssueBaseType::WRITE_TO_LOCKED_CB);
     }
 
+    std::vector<NOCDebugIssueType> get_write_to_locked_issues(
+        ChipId chip_id, CoreCoord virtual_core, int processor_id) const {
+        auto& noc_debug_state = tt::tt_metal::MetalContext::instance().noc_debug_state();
+        std::vector<NOCDebugIssueType> result;
+        if (!noc_debug_state) {
+            return result;
+        }
+        tt_cxy_pair core{chip_id, {virtual_core.x, virtual_core.y}};
+        const NOCDebugIssue& issue = noc_debug_state->get_issues(core, processor_id);
+        auto mem_issues = issue.get_issues_by_base(NOCDebugIssueBaseType::WRITE_TO_LOCKED_CORE_LOCAL_MEM);
+        auto cb_issues = issue.get_issues_by_base(NOCDebugIssueBaseType::WRITE_TO_LOCKED_CB);
+        result.insert(result.end(), mem_issues.begin(), mem_issues.end());
+        result.insert(result.end(), cb_issues.begin(), cb_issues.end());
+        return result;
+    }
+
     template <typename T>
     void RunTestOnDevice(
         const std::function<void(T*, std::shared_ptr<distributed::MeshDevice>)>& run_function,

--- a/tests/tt_metal/tt_metal/noc_debugging/noc_debugging_fixture.hpp
+++ b/tests/tt_metal/tt_metal/noc_debugging/noc_debugging_fixture.hpp
@@ -57,6 +57,17 @@ public:
                 NOCDebugIssueType(NOCDebugIssueBaseType::UNFLUSHED_WRITE_AT_END, /*mcast=*/true, /*semaphore=*/false));
     }
 
+    bool has_write_to_locked_issue(ChipId chip_id, CoreCoord virtual_core, int processor_id) const {
+        auto& noc_debug_state = tt::tt_metal::MetalContext::instance().noc_debug_state();
+        if (!noc_debug_state) {
+            return false;
+        }
+        tt_cxy_pair core{chip_id, {virtual_core.x, virtual_core.y}};
+        const NOCDebugIssue& issue = noc_debug_state->get_issues(core, processor_id);
+        return issue.has_base_issue(NOCDebugIssueBaseType::WRITE_TO_LOCKED_CORE_LOCAL_MEM) ||
+               issue.has_base_issue(NOCDebugIssueBaseType::WRITE_TO_LOCKED_CB);
+    }
+
     template <typename T>
     void RunTestOnDevice(
         const std::function<void(T*, std::shared_ptr<distributed::MeshDevice>)>& run_function,

--- a/tests/tt_metal/tt_metal/noc_debugging/sources.cmake
+++ b/tests/tt_metal/tt_metal/noc_debugging/sources.cmake
@@ -1,4 +1,7 @@
 # Source files for tt_metal noc_debugging tests
 # Module owners should update this file when adding/removing/renaming source files
 
-set(UNIT_TESTS_NOC_DEBUGGING_SRC test_reads_writes.cpp)
+set(UNIT_TESTS_NOC_DEBUGGING_SRC
+    test_reads_writes.cpp
+    test_scoped_lock.cpp
+)

--- a/tests/tt_metal/tt_metal/noc_debugging/test_scoped_lock.cpp
+++ b/tests/tt_metal/tt_metal/noc_debugging/test_scoped_lock.cpp
@@ -99,16 +99,24 @@ TEST_F(NOCDebuggingFixture, ScopedLockConcurrentAccessIssue) {
         ReadMeshDeviceProfilerResults(*mesh_device);
 
         // Writer core (source of the NOC writes) should have been flagged for writing to a locked buffer
-        bool found_write_to_locked = false;
+        std::vector<NOCDebugIssueType> locked_issues;
         for (IDevice* device : mesh_device->get_devices()) {
-            ChipId chip_id = device->id();
-            if (this->has_write_to_locked_issue(chip_id, writer_virtual_core, 0)) {
-                found_write_to_locked = true;
-                break;
-            }
+            auto issues = this->get_write_to_locked_issues(device->id(), writer_virtual_core, 0);
+            locked_issues.insert(locked_issues.end(), issues.begin(), issues.end());
         }
-        EXPECT_TRUE(found_write_to_locked)
+        ASSERT_FALSE(locked_issues.empty())
             << "Expected write-to-locked-buffer issue on writer core (1,0); NOC debug did not report the violation.";
+
+        uint32_t expected_write_size = num_elements * sizeof(uint32_t);
+        for (const auto& issue : locked_issues) {
+            EXPECT_EQ(issue.base_type, NOCDebugIssueBaseType::WRITE_TO_LOCKED_CORE_LOCAL_MEM);
+            EXPECT_EQ(issue.issue_address, locker_buffer_addr);
+            EXPECT_EQ(issue.issue_size, expected_write_size);
+            EXPECT_EQ(issue.src_x, writer_virtual_core.x);
+            EXPECT_EQ(issue.src_y, writer_virtual_core.y);
+            EXPECT_EQ(issue.dst_x, locker_virtual_core.x);
+            EXPECT_EQ(issue.dst_y, locker_virtual_core.y);
+        }
     }
 }
 
@@ -276,15 +284,23 @@ TEST_F(NOCDebuggingFixture, ScopedLockConcurrentAccessCBIssue) {
         distributed::Finish(mesh_device->mesh_command_queue());
         ReadMeshDeviceProfilerResults(*mesh_device);
 
-        bool found_write_to_locked_cb = false;
+        std::vector<NOCDebugIssueType> locked_issues;
         for (IDevice* device : mesh_device->get_devices()) {
-            if (this->has_write_to_locked_issue(device->id(), writer_virtual_core, 0)) {
-                found_write_to_locked_cb = true;
-                break;
-            }
+            auto issues = this->get_write_to_locked_issues(device->id(), writer_virtual_core, 0);
+            locked_issues.insert(locked_issues.end(), issues.begin(), issues.end());
         }
-        EXPECT_TRUE(found_write_to_locked_cb)
+        ASSERT_FALSE(locked_issues.empty())
             << "Expected write-to-locked-CB issue on writer core; NOC debug did not report the violation.";
+
+        for (const auto& issue : locked_issues) {
+            EXPECT_EQ(issue.base_type, NOCDebugIssueBaseType::WRITE_TO_LOCKED_CB);
+            EXPECT_GE(issue.issue_size, write_size);
+            EXPECT_GT(issue.issue_address, 0u);
+            EXPECT_EQ(issue.src_x, writer_virtual_core.x);
+            EXPECT_EQ(issue.src_y, writer_virtual_core.y);
+            EXPECT_EQ(issue.dst_x, locker_virtual_core.x);
+            EXPECT_EQ(issue.dst_y, locker_virtual_core.y);
+        }
     }
 }
 

--- a/tests/tt_metal/tt_metal/noc_debugging/test_scoped_lock.cpp
+++ b/tests/tt_metal/tt_metal/noc_debugging/test_scoped_lock.cpp
@@ -506,4 +506,159 @@ TEST_F(NOCDebuggingFixture, ScopedLockConcurrentAccessCBNoIssue) {
     }
 }
 
+TEST_F(NOCDebuggingFixture, ScopedLockSelfWriteToLockedIssue) {
+    for (auto& mesh_device : devices_) {
+        log_info(tt::LogMetal, "Running on mesh device {}", mesh_device->id());
+
+        const CoreCoord core = {0, 0};
+        Program program = CreateProgram();
+        distributed::MeshWorkload workload;
+
+        auto zero_coord = distributed::MeshCoordinate(0, 0);
+        auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+
+        auto& mc = MetalContext::instance();
+        uint32_t unreserved_addr =
+            mc.hal().get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
+        uint32_t alignment = mc.hal().get_alignment(HalMemType::L1);
+
+        uint32_t lock_addr = unreserved_addr;
+        uint32_t num_elements = 8;
+        uint32_t src_buffer_addr = unreserved_addr + (alignment * 32);
+        uint32_t write_target_addr = lock_addr;
+        uint32_t write_size = num_elements * sizeof(uint32_t);
+
+        auto virtual_core = mesh_device->worker_core_from_logical_core(core);
+
+        KernelHandle kernel = CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/scoped_lock_self_write_kernel.cpp",
+            core,
+            DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_0});
+
+        SetRuntimeArgs(
+            program,
+            kernel,
+            core,
+            {lock_addr, num_elements, src_buffer_addr, write_target_addr, write_size, virtual_core.x, virtual_core.y});
+
+        workload.add_program(device_range, std::move(program));
+
+        distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, false);
+        distributed::Finish(mesh_device->mesh_command_queue());
+
+        ReadMeshDeviceProfilerResults(*mesh_device);
+
+        std::vector<NOCDebugIssueType> locked_issues;
+        for (IDevice* device : mesh_device->get_devices()) {
+            auto issues = this->get_write_to_locked_issues(device->id(), virtual_core, 0);
+            locked_issues.insert(locked_issues.end(), issues.begin(), issues.end());
+        }
+        ASSERT_FALSE(locked_issues.empty())
+            << "Expected write-to-locked issue when kernel writes to its own locked region";
+
+        for (const auto& issue : locked_issues) {
+            EXPECT_EQ(issue.base_type, NOCDebugIssueBaseType::WRITE_TO_LOCKED_CORE_LOCAL_MEM);
+            EXPECT_EQ(issue.issue_address, write_target_addr);
+            EXPECT_EQ(issue.issue_size, write_size);
+            EXPECT_EQ(issue.src_x, virtual_core.x);
+            EXPECT_EQ(issue.src_y, virtual_core.y);
+            EXPECT_EQ(issue.dst_x, virtual_core.x);
+            EXPECT_EQ(issue.dst_y, virtual_core.y);
+        }
+    }
+}
+
+TEST_F(NOCDebuggingFixture, ScopedLockSelfWriteToUnlockedNoIssue) {
+    for (auto& mesh_device : devices_) {
+        log_info(tt::LogMetal, "Running on mesh device {}", mesh_device->id());
+
+        const CoreCoord core = {0, 0};
+        Program program = CreateProgram();
+        distributed::MeshWorkload workload;
+
+        auto zero_coord = distributed::MeshCoordinate(0, 0);
+        auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+
+        auto& mc = MetalContext::instance();
+        uint32_t unreserved_addr =
+            mc.hal().get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
+        uint32_t alignment = mc.hal().get_alignment(HalMemType::L1);
+
+        uint32_t lock_addr = unreserved_addr;
+        uint32_t num_elements = 8;
+        uint32_t src_buffer_addr = unreserved_addr + (alignment * 32);
+        uint32_t write_target_addr = unreserved_addr + (alignment * 16);
+        uint32_t write_size = num_elements * sizeof(uint32_t);
+
+        auto virtual_core = mesh_device->worker_core_from_logical_core(core);
+
+        KernelHandle kernel = CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/scoped_lock_self_write_kernel.cpp",
+            core,
+            DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_0});
+
+        SetRuntimeArgs(
+            program,
+            kernel,
+            core,
+            {lock_addr, num_elements, src_buffer_addr, write_target_addr, write_size, virtual_core.x, virtual_core.y});
+
+        workload.add_program(device_range, std::move(program));
+
+        distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, false);
+        distributed::Finish(mesh_device->mesh_command_queue());
+
+        ReadMeshDeviceProfilerResults(*mesh_device);
+
+        for (IDevice* device : mesh_device->get_devices()) {
+            EXPECT_FALSE(this->has_write_to_locked_issue(device->id(), virtual_core, 0))
+                << "Unexpected write-to-locked issue; NOC write targeted an unlocked region.";
+        }
+    }
+}
+
+TEST_F(NOCDebuggingFixture, ScopedLockNoWritesNoIssue) {
+    for (auto& mesh_device : devices_) {
+        log_info(tt::LogMetal, "Running on mesh device {}", mesh_device->id());
+
+        const CoreCoord core = {0, 0};
+        Program program = CreateProgram();
+        distributed::MeshWorkload workload;
+
+        auto zero_coord = distributed::MeshCoordinate(0, 0);
+        auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+
+        auto& mc = MetalContext::instance();
+        uint32_t unreserved_addr =
+            mc.hal().get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
+
+        uint32_t lock_addr = unreserved_addr;
+        uint32_t num_elements = 8;
+
+        auto virtual_core = mesh_device->worker_core_from_logical_core(core);
+
+        KernelHandle kernel = CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/scoped_lock_only_kernel.cpp",
+            core,
+            DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_0});
+
+        SetRuntimeArgs(program, kernel, core, {lock_addr, num_elements});
+
+        workload.add_program(device_range, std::move(program));
+
+        distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, false);
+        distributed::Finish(mesh_device->mesh_command_queue());
+
+        ReadMeshDeviceProfilerResults(*mesh_device);
+
+        for (IDevice* device : mesh_device->get_devices()) {
+            EXPECT_FALSE(this->has_write_to_locked_issue(device->id(), virtual_core, 0))
+                << "Unexpected write-to-locked issue; kernel only locked and unlocked with no NOC writes.";
+        }
+    }
+}
+
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/noc_debugging/test_scoped_lock.cpp
+++ b/tests/tt_metal/tt_metal/noc_debugging/test_scoped_lock.cpp
@@ -8,7 +8,6 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/device.hpp>
-#include <tt-metalium/allocator.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/program.hpp>
@@ -20,8 +19,6 @@
 #include <vector>
 
 #include "noc_debugging_fixture.hpp"
-#include "impl/program/program_impl.hpp"
-#include "impl/buffers/circular_buffer.hpp"
 
 namespace tt::tt_metal {
 
@@ -223,18 +220,21 @@ TEST_F(NOCDebuggingFixture, ScopedLockConcurrentAccessCBIssue) {
         uint32_t writer_buffer_addr = unreserved_addr + alignment * 32;
 
         constexpr uint8_t cb_buffer_index = 0;
-        uint32_t num_elements = 8;
-        uint32_t cb_page_size = num_elements * sizeof(uint32_t);
+        uint32_t cb_page_size = 32;
         uint32_t cb_total_size = cb_page_size * 2;
         CircularBufferConfig cb_config =
             CircularBufferConfig(cb_total_size, {{cb_buffer_index, tt::DataFormat::Float16_b}})
                 .set_page_size(cb_buffer_index, cb_page_size);
-        CBHandle cb_handle = CreateCircularBuffer(program, locker_core, cb_config);
+        CreateCircularBuffer(program, locker_core, cb_config);
 
         auto locker_virtual_core = mesh_device->worker_core_from_logical_core(locker_core);
         auto writer_virtual_core = mesh_device->worker_core_from_logical_core(writer_core);
         uint32_t locker_sem_id = CreateSemaphore(program, locker_core, 0);
         uint32_t writer_sem_id = CreateSemaphore(program, writer_core, 0);
+
+        uint32_t write_size = alignment;
+        uint32_t l1_size = mesh_device->l1_size_per_core();
+        uint32_t stride = alignment * 64;
 
         KernelHandle locker_kernel = CreateKernel(
             program,
@@ -243,12 +243,9 @@ TEST_F(NOCDebuggingFixture, ScopedLockConcurrentAccessCBIssue) {
             DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_0});
         KernelHandle writer_kernel = CreateKernel(
             program,
-            "tests/tt_metal/tt_metal/test_kernels/dataflow/scoped_lock_writer_kernel.cpp",
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/scoped_lock_cb_writer_kernel.cpp",
             writer_core,
             DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_0});
-
-        uint32_t cb_addr = program.impl().get_circular_buffer(cb_handle)->address();
-        log_info(tt::LogMetal, "CB address: {}", cb_addr);
 
         SetRuntimeArgs(
             program,
@@ -264,10 +261,12 @@ TEST_F(NOCDebuggingFixture, ScopedLockConcurrentAccessCBIssue) {
             writer_kernel,
             writer_core,
             {writer_buffer_addr,
-             num_elements,
+             write_size,
              locker_virtual_core.x,
              locker_virtual_core.y,
-             cb_addr,
+             unreserved_addr,
+             l1_size,
+             stride,
              writer_sem_id,
              locker_sem_id,
              locker_virtual_core.x,
@@ -312,18 +311,21 @@ TEST_F(NOCDebuggingFixture, ScopedLockConcurrentAccessCBNoIssue) {
         uint32_t writer_buffer_addr = unreserved_addr + alignment * 32;
 
         constexpr uint8_t cb_buffer_index = 0;
-        uint32_t num_elements = 8;
-        uint32_t cb_page_size = num_elements * sizeof(uint32_t);
+        uint32_t cb_page_size = 32;
         uint32_t cb_total_size = cb_page_size * 2;
         CircularBufferConfig cb_config =
             CircularBufferConfig(cb_total_size, {{cb_buffer_index, tt::DataFormat::Float16_b}})
                 .set_page_size(cb_buffer_index, cb_page_size);
-        CBHandle cb_handle = CreateCircularBuffer(program, locker_core, cb_config);
+        CreateCircularBuffer(program, locker_core, cb_config);
 
         auto locker_virtual_core = mesh_device->worker_core_from_logical_core(locker_core);
         auto writer_virtual_core = mesh_device->worker_core_from_logical_core(writer_core);
         uint32_t locker_sem_id = CreateSemaphore(program, locker_core, 0);
         uint32_t writer_sem_id = CreateSemaphore(program, writer_core, 0);
+
+        uint32_t write_size = alignment;
+        uint32_t l1_size = mesh_device->l1_size_per_core();
+        uint32_t stride = alignment * 64;
 
         KernelHandle locker_kernel = CreateKernel(
             program,
@@ -332,7 +334,7 @@ TEST_F(NOCDebuggingFixture, ScopedLockConcurrentAccessCBNoIssue) {
             DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_0});
         KernelHandle writer_kernel = CreateKernel(
             program,
-            "tests/tt_metal/tt_metal/test_kernels/dataflow/scoped_lock_writer_kernel_no_issue.cpp",
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/scoped_lock_cb_writer_kernel_no_issue.cpp",
             writer_core,
             DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_0});
 
@@ -345,17 +347,17 @@ TEST_F(NOCDebuggingFixture, ScopedLockConcurrentAccessCBNoIssue) {
              writer_sem_id,
              writer_virtual_core.x,
              writer_virtual_core.y});
-
-        uint32_t cb_addr = program.impl().get_circular_buffer(cb_handle)->address();
         SetRuntimeArgs(
             program,
             writer_kernel,
             writer_core,
             {writer_buffer_addr,
-             num_elements,
+             write_size,
              locker_virtual_core.x,
              locker_virtual_core.y,
-             cb_addr,
+             unreserved_addr,
+             l1_size,
+             stride,
              writer_sem_id,
              locker_sem_id,
              locker_virtual_core.x,

--- a/tests/tt_metal/tt_metal/noc_debugging/test_scoped_lock.cpp
+++ b/tests/tt_metal/tt_metal/noc_debugging/test_scoped_lock.cpp
@@ -47,7 +47,7 @@ TEST_F(NOCDebuggingFixture, ScopedLockConcurrentAccessIssue) {
         uint32_t alignment = mc.hal().get_alignment(HalMemType::L1);
 
         uint32_t locker_buffer_addr = unreserved_addr;
-        uint32_t writer_buffer_addr = unreserved_addr + alignment * 32;
+        uint32_t writer_buffer_addr = unreserved_addr + (alignment * 32);
         uint32_t num_elements = 8;
 
         auto locker_virtual_core = mesh_device->worker_core_from_logical_core(locker_core);
@@ -135,7 +135,7 @@ TEST_F(NOCDebuggingFixture, ScopedLockConcurrentAccessNoIssue) {
         uint32_t alignment = mc.hal().get_alignment(HalMemType::L1);
 
         uint32_t locker_buffer_addr = unreserved_addr;
-        uint32_t writer_buffer_addr = unreserved_addr + alignment * 32;
+        uint32_t writer_buffer_addr = unreserved_addr + (alignment * 32);
         uint32_t num_elements = 8;
 
         auto locker_virtual_core = mesh_device->worker_core_from_logical_core(locker_core);
@@ -217,7 +217,7 @@ TEST_F(NOCDebuggingFixture, ScopedLockConcurrentAccessCBIssue) {
         uint32_t unreserved_addr =
             mc.hal().get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
         uint32_t alignment = mc.hal().get_alignment(HalMemType::L1);
-        uint32_t writer_buffer_addr = unreserved_addr + alignment * 32;
+        uint32_t writer_buffer_addr = unreserved_addr + (alignment * 32);
 
         constexpr uint8_t cb_buffer_index = 0;
         uint32_t cb_page_size = 32;
@@ -308,7 +308,7 @@ TEST_F(NOCDebuggingFixture, ScopedLockConcurrentAccessCBNoIssue) {
         uint32_t unreserved_addr =
             mc.hal().get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
         uint32_t alignment = mc.hal().get_alignment(HalMemType::L1);
-        uint32_t writer_buffer_addr = unreserved_addr + alignment * 32;
+        uint32_t writer_buffer_addr = unreserved_addr + (alignment * 32);
 
         constexpr uint8_t cb_buffer_index = 0;
         uint32_t cb_page_size = 32;

--- a/tests/tt_metal/tt_metal/noc_debugging/test_scoped_lock.cpp
+++ b/tests/tt_metal/tt_metal/noc_debugging/test_scoped_lock.cpp
@@ -1,0 +1,378 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/allocator.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-metalium/program.hpp>
+#include <tt-metalium/hal.hpp>
+#include <tt-metalium/hal_types.hpp>
+#include <tt-logger/tt-logger.hpp>
+#include "impl/context/metal_context.hpp"
+
+#include <vector>
+
+#include "noc_debugging_fixture.hpp"
+#include "impl/program/program_impl.hpp"
+#include "impl/buffers/circular_buffer.hpp"
+
+namespace tt::tt_metal {
+
+// Test two cores: one locks and writes, another writes to the same region
+// Both kernels synchronize using semaphores at start and end to ensure
+// locks are held concurrently for the profiler to capture overlapping accesses
+TEST_F(NOCDebuggingFixture, ScopedLockConcurrentAccessIssue) {
+    for (auto& mesh_device : devices_) {
+        log_info(tt::LogMetal, "Running on mesh device {}", mesh_device->id());
+        auto grid_size = mesh_device->compute_with_storage_grid_size();
+        if (grid_size.x < 2) {
+            GTEST_SKIP() << "Test requires at least 2 cores in x dimension";
+        }
+
+        const CoreCoord locker_core = {0, 0};
+        const CoreCoord writer_core = {1, 0};
+        Program program = CreateProgram();
+        distributed::MeshWorkload workload;
+
+        auto zero_coord = distributed::MeshCoordinate(0, 0);
+        auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+
+        auto& mc = MetalContext::instance();
+        uint32_t unreserved_addr =
+            mc.hal().get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
+        uint32_t alignment = mc.hal().get_alignment(HalMemType::L1);
+
+        uint32_t locker_buffer_addr = unreserved_addr;
+        uint32_t writer_buffer_addr = unreserved_addr + alignment * 32;
+        uint32_t num_elements = 8;
+
+        auto locker_virtual_core = mesh_device->worker_core_from_logical_core(locker_core);
+        auto writer_virtual_core = mesh_device->worker_core_from_logical_core(writer_core);
+
+        uint32_t locker_sem_id = CreateSemaphore(program, locker_core, 0);
+        uint32_t writer_sem_id = CreateSemaphore(program, writer_core, 0);
+
+        std::vector<uint32_t> locker_args = {
+            locker_buffer_addr,
+            num_elements,
+            locker_sem_id,
+            writer_sem_id,
+            writer_virtual_core.x,
+            writer_virtual_core.y};
+
+        KernelHandle locker_kernel = CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/scoped_lock_test_kernel.cpp",
+            locker_core,
+            DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_0});
+
+        SetRuntimeArgs(program, locker_kernel, locker_core, locker_args);
+
+        std::vector<uint32_t> writer_args = {
+            writer_buffer_addr,
+            num_elements,
+            locker_virtual_core.x,
+            locker_virtual_core.y,
+            locker_buffer_addr,
+            writer_sem_id,
+            locker_sem_id,
+            locker_virtual_core.x,
+            locker_virtual_core.y};
+
+        KernelHandle writer_kernel = CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/scoped_lock_writer_kernel.cpp",
+            writer_core,
+            DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_0});
+
+        SetRuntimeArgs(program, writer_kernel, writer_core, writer_args);
+
+        workload.add_program(device_range, std::move(program));
+
+        distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, false);
+        distributed::Finish(mesh_device->mesh_command_queue());
+
+        ReadMeshDeviceProfilerResults(*mesh_device);
+
+        // Writer core (source of the NOC writes) should have been flagged for writing to a locked buffer
+        bool found_write_to_locked = false;
+        for (IDevice* device : mesh_device->get_devices()) {
+            ChipId chip_id = device->id();
+            if (this->has_write_to_locked_issue(chip_id, writer_virtual_core, 0)) {
+                found_write_to_locked = true;
+                break;
+            }
+        }
+        EXPECT_TRUE(found_write_to_locked)
+            << "Expected write-to-locked-buffer issue on writer core (1,0); NOC debug did not report the violation.";
+    }
+}
+
+TEST_F(NOCDebuggingFixture, ScopedLockConcurrentAccessNoIssue) {
+    // inverted version of the test above
+    for (auto& mesh_device : devices_) {
+        log_info(tt::LogMetal, "Running on mesh device {}", mesh_device->id());
+        auto grid_size = mesh_device->compute_with_storage_grid_size();
+        if (grid_size.x < 2) {
+            GTEST_SKIP() << "Test requires at least 2 cores in x dimension";
+        }
+
+        const CoreCoord locker_core = {0, 0};
+        const CoreCoord writer_core = {1, 0};
+        Program program = CreateProgram();
+        distributed::MeshWorkload workload;
+
+        auto zero_coord = distributed::MeshCoordinate(0, 0);
+        auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+
+        auto& mc = MetalContext::instance();
+        uint32_t unreserved_addr =
+            mc.hal().get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
+        uint32_t alignment = mc.hal().get_alignment(HalMemType::L1);
+
+        uint32_t locker_buffer_addr = unreserved_addr;
+        uint32_t writer_buffer_addr = unreserved_addr + alignment * 32;
+        uint32_t num_elements = 8;
+
+        auto locker_virtual_core = mesh_device->worker_core_from_logical_core(locker_core);
+        auto writer_virtual_core = mesh_device->worker_core_from_logical_core(writer_core);
+
+        uint32_t locker_sem_id = CreateSemaphore(program, locker_core, 0);
+        uint32_t writer_sem_id = CreateSemaphore(program, writer_core, 0);
+
+        std::vector<uint32_t> locker_args = {
+            locker_buffer_addr,
+            num_elements,
+            locker_sem_id,
+            writer_sem_id,
+            writer_virtual_core.x,
+            writer_virtual_core.y};
+
+        KernelHandle locker_kernel = CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/scoped_lock_test_kernel_no_issue.cpp",
+            locker_core,
+            DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_0});
+
+        SetRuntimeArgs(program, locker_kernel, locker_core, locker_args);
+
+        std::vector<uint32_t> writer_args = {
+            writer_buffer_addr,
+            num_elements,
+            locker_virtual_core.x,
+            locker_virtual_core.y,
+            locker_buffer_addr,
+            writer_sem_id,
+            locker_sem_id,
+            locker_virtual_core.x,
+            locker_virtual_core.y};
+
+        KernelHandle writer_kernel = CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/scoped_lock_writer_kernel_no_issue.cpp",
+            writer_core,
+            DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_0});
+
+        SetRuntimeArgs(program, writer_kernel, writer_core, writer_args);
+
+        workload.add_program(device_range, std::move(program));
+
+        distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, false);
+        distributed::Finish(mesh_device->mesh_command_queue());
+
+        ReadMeshDeviceProfilerResults(*mesh_device);
+
+        // No write-to-locked issues should be reported (writes happen only when buffer is not locked)
+        for (IDevice* device : mesh_device->get_devices()) {
+            ChipId chip_id = device->id();
+            EXPECT_FALSE(this->has_write_to_locked_issue(chip_id, writer_virtual_core, 0))
+                << "Unexpected write-to-locked-buffer issue on writer core; writes were outside lock scope.";
+            EXPECT_FALSE(this->has_write_to_locked_issue(chip_id, locker_virtual_core, 0))
+                << "Unexpected write-to-locked-buffer issue on locker core.";
+        }
+    }
+}
+
+TEST_F(NOCDebuggingFixture, ScopedLockConcurrentAccessCBIssue) {
+    for (auto& mesh_device : devices_) {
+        log_info(tt::LogMetal, "Running on mesh device {}", mesh_device->id());
+        auto grid_size = mesh_device->compute_with_storage_grid_size();
+        if (grid_size.x < 2) {
+            GTEST_SKIP() << "Test requires at least 2 cores in x dimension";
+        }
+
+        const CoreCoord locker_core = {0, 0};
+        const CoreCoord writer_core = {1, 0};
+        distributed::MeshWorkload workload;
+        auto zero_coord = distributed::MeshCoordinate(0, 0);
+        auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+        workload.add_program(device_range, CreateProgram());
+
+        Program& program = workload.get_programs().at(device_range);
+        auto& mc = MetalContext::instance();
+        uint32_t unreserved_addr =
+            mc.hal().get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
+        uint32_t alignment = mc.hal().get_alignment(HalMemType::L1);
+        uint32_t writer_buffer_addr = unreserved_addr + alignment * 32;
+
+        constexpr uint8_t cb_buffer_index = 0;
+        uint32_t num_elements = 8;
+        uint32_t cb_page_size = num_elements * sizeof(uint32_t);
+        uint32_t cb_total_size = cb_page_size * 2;
+        CircularBufferConfig cb_config =
+            CircularBufferConfig(cb_total_size, {{cb_buffer_index, tt::DataFormat::Float16_b}})
+                .set_page_size(cb_buffer_index, cb_page_size);
+        CBHandle cb_handle = CreateCircularBuffer(program, locker_core, cb_config);
+
+        auto locker_virtual_core = mesh_device->worker_core_from_logical_core(locker_core);
+        auto writer_virtual_core = mesh_device->worker_core_from_logical_core(writer_core);
+        uint32_t locker_sem_id = CreateSemaphore(program, locker_core, 0);
+        uint32_t writer_sem_id = CreateSemaphore(program, writer_core, 0);
+
+        KernelHandle locker_kernel = CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/scoped_lock_test_kernel_cb.cpp",
+            locker_core,
+            DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_0});
+        KernelHandle writer_kernel = CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/scoped_lock_writer_kernel.cpp",
+            writer_core,
+            DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_0});
+
+        uint32_t cb_addr = program.impl().get_circular_buffer(cb_handle)->address();
+        log_info(tt::LogMetal, "CB address: {}", cb_addr);
+
+        SetRuntimeArgs(
+            program,
+            locker_kernel,
+            locker_core,
+            {static_cast<uint32_t>(cb_buffer_index),
+             locker_sem_id,
+             writer_sem_id,
+             writer_virtual_core.x,
+             writer_virtual_core.y});
+        SetRuntimeArgs(
+            program,
+            writer_kernel,
+            writer_core,
+            {writer_buffer_addr,
+             num_elements,
+             locker_virtual_core.x,
+             locker_virtual_core.y,
+             cb_addr,
+             writer_sem_id,
+             locker_sem_id,
+             locker_virtual_core.x,
+             locker_virtual_core.y});
+
+        distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, false);
+        distributed::Finish(mesh_device->mesh_command_queue());
+        ReadMeshDeviceProfilerResults(*mesh_device);
+
+        bool found_write_to_locked_cb = false;
+        for (IDevice* device : mesh_device->get_devices()) {
+            if (this->has_write_to_locked_issue(device->id(), writer_virtual_core, 0)) {
+                found_write_to_locked_cb = true;
+                break;
+            }
+        }
+        EXPECT_TRUE(found_write_to_locked_cb)
+            << "Expected write-to-locked-CB issue on writer core; NOC debug did not report the violation.";
+    }
+}
+
+TEST_F(NOCDebuggingFixture, ScopedLockConcurrentAccessCBNoIssue) {
+    for (auto& mesh_device : devices_) {
+        log_info(tt::LogMetal, "Running on mesh device {}", mesh_device->id());
+        auto grid_size = mesh_device->compute_with_storage_grid_size();
+        if (grid_size.x < 2) {
+            GTEST_SKIP() << "Test requires at least 2 cores in x dimension";
+        }
+
+        const CoreCoord locker_core = {0, 0};
+        const CoreCoord writer_core = {1, 0};
+        distributed::MeshWorkload workload;
+        auto zero_coord = distributed::MeshCoordinate(0, 0);
+        auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+        workload.add_program(device_range, CreateProgram());
+
+        Program& program = workload.get_programs().at(device_range);
+        auto& mc = MetalContext::instance();
+        uint32_t unreserved_addr =
+            mc.hal().get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
+        uint32_t alignment = mc.hal().get_alignment(HalMemType::L1);
+        uint32_t writer_buffer_addr = unreserved_addr + alignment * 32;
+
+        constexpr uint8_t cb_buffer_index = 0;
+        uint32_t num_elements = 8;
+        uint32_t cb_page_size = num_elements * sizeof(uint32_t);
+        uint32_t cb_total_size = cb_page_size * 2;
+        CircularBufferConfig cb_config =
+            CircularBufferConfig(cb_total_size, {{cb_buffer_index, tt::DataFormat::Float16_b}})
+                .set_page_size(cb_buffer_index, cb_page_size);
+        CBHandle cb_handle = CreateCircularBuffer(program, locker_core, cb_config);
+
+        auto locker_virtual_core = mesh_device->worker_core_from_logical_core(locker_core);
+        auto writer_virtual_core = mesh_device->worker_core_from_logical_core(writer_core);
+        uint32_t locker_sem_id = CreateSemaphore(program, locker_core, 0);
+        uint32_t writer_sem_id = CreateSemaphore(program, writer_core, 0);
+
+        KernelHandle locker_kernel = CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/scoped_lock_test_kernel_cb_no_issue.cpp",
+            locker_core,
+            DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_0});
+        KernelHandle writer_kernel = CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/scoped_lock_writer_kernel_no_issue.cpp",
+            writer_core,
+            DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_0});
+
+        SetRuntimeArgs(
+            program,
+            locker_kernel,
+            locker_core,
+            {static_cast<uint32_t>(cb_buffer_index),
+             locker_sem_id,
+             writer_sem_id,
+             writer_virtual_core.x,
+             writer_virtual_core.y});
+
+        uint32_t cb_addr = program.impl().get_circular_buffer(cb_handle)->address();
+        SetRuntimeArgs(
+            program,
+            writer_kernel,
+            writer_core,
+            {writer_buffer_addr,
+             num_elements,
+             locker_virtual_core.x,
+             locker_virtual_core.y,
+             cb_addr,
+             writer_sem_id,
+             locker_sem_id,
+             locker_virtual_core.x,
+             locker_virtual_core.y});
+
+        distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, false);
+        distributed::Finish(mesh_device->mesh_command_queue());
+        ReadMeshDeviceProfilerResults(*mesh_device);
+
+        for (IDevice* device : mesh_device->get_devices()) {
+            ChipId chip_id = device->id();
+            EXPECT_FALSE(this->has_write_to_locked_issue(chip_id, writer_virtual_core, 0))
+                << "Unexpected write-to-locked-CB issue on writer core; writes were outside lock scope.";
+            EXPECT_FALSE(this->has_write_to_locked_issue(chip_id, locker_virtual_core, 0))
+                << "Unexpected write-to-locked-CB issue on locker core.";
+        }
+    }
+}
+
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/noc_debugging/test_scoped_lock.cpp
+++ b/tests/tt_metal/tt_metal/noc_debugging/test_scoped_lock.cpp
@@ -120,6 +120,119 @@ TEST_F(NOCDebuggingFixture, ScopedLockConcurrentAccessIssue) {
     }
 }
 
+TEST_F(NOCDebuggingFixture, ScopedLockMultipleL1Issues) {
+    for (auto& mesh_device : devices_) {
+        log_info(tt::LogMetal, "Running on mesh device {}", mesh_device->id());
+        auto grid_size = mesh_device->compute_with_storage_grid_size();
+        if (grid_size.x < 2) {
+            GTEST_SKIP() << "Test requires at least 2 cores in x dimension";
+        }
+
+        const CoreCoord locker_core = {0, 0};
+        const CoreCoord writer_core = {1, 0};
+        Program program = CreateProgram();
+        distributed::MeshWorkload workload;
+
+        auto zero_coord = distributed::MeshCoordinate(0, 0);
+        auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+
+        auto& mc = MetalContext::instance();
+        uint32_t unreserved_addr =
+            mc.hal().get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
+        uint32_t alignment = mc.hal().get_alignment(HalMemType::L1);
+
+        uint32_t buffer_addr_a = unreserved_addr;
+        uint32_t num_elements_a = 8;
+        uint32_t buffer_addr_b = unreserved_addr + (alignment * 16);
+        uint32_t num_elements_b = 16;
+        uint32_t writer_buffer_addr = unreserved_addr + (alignment * 48);
+
+        auto locker_virtual_core = mesh_device->worker_core_from_logical_core(locker_core);
+        auto writer_virtual_core = mesh_device->worker_core_from_logical_core(writer_core);
+
+        uint32_t locker_sem_id = CreateSemaphore(program, locker_core, 0);
+        uint32_t writer_sem_id = CreateSemaphore(program, writer_core, 0);
+
+        KernelHandle locker_kernel = CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/scoped_lock_test_kernel_multi.cpp",
+            locker_core,
+            DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_0});
+        KernelHandle writer_kernel = CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/scoped_lock_writer_kernel_multi.cpp",
+            writer_core,
+            DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_0});
+
+        SetRuntimeArgs(
+            program,
+            locker_kernel,
+            locker_core,
+            {buffer_addr_a,
+             num_elements_a,
+             buffer_addr_b,
+             num_elements_b,
+             locker_sem_id,
+             writer_sem_id,
+             writer_virtual_core.x,
+             writer_virtual_core.y});
+
+        uint32_t write_size_a = num_elements_a * sizeof(uint32_t);
+        uint32_t write_size_b = num_elements_b * sizeof(uint32_t);
+        SetRuntimeArgs(
+            program,
+            writer_kernel,
+            writer_core,
+            {writer_buffer_addr,
+             write_size_a,
+             write_size_b,
+             locker_virtual_core.x,
+             locker_virtual_core.y,
+             buffer_addr_a,
+             buffer_addr_b,
+             writer_sem_id,
+             locker_sem_id,
+             locker_virtual_core.x,
+             locker_virtual_core.y});
+
+        workload.add_program(device_range, std::move(program));
+
+        distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, false);
+        distributed::Finish(mesh_device->mesh_command_queue());
+
+        ReadMeshDeviceProfilerResults(*mesh_device);
+
+        std::vector<NOCDebugIssueType> locked_issues;
+        for (IDevice* device : mesh_device->get_devices()) {
+            auto issues = this->get_write_to_locked_issues(device->id(), writer_virtual_core, 0);
+            locked_issues.insert(locked_issues.end(), issues.begin(), issues.end());
+        }
+        ASSERT_GE(locked_issues.size(), 2u)
+            << "Expected at least 2 write-to-locked-buffer issues (one per locked region)";
+
+        bool found_issue_a = false;
+        bool found_issue_b = false;
+        for (const auto& issue : locked_issues) {
+            EXPECT_EQ(issue.base_type, NOCDebugIssueBaseType::WRITE_TO_LOCKED_CORE_LOCAL_MEM);
+            EXPECT_EQ(issue.src_x, writer_virtual_core.x);
+            EXPECT_EQ(issue.src_y, writer_virtual_core.y);
+            EXPECT_EQ(issue.dst_x, locker_virtual_core.x);
+            EXPECT_EQ(issue.dst_y, locker_virtual_core.y);
+
+            if (issue.issue_address == buffer_addr_a && issue.issue_size == write_size_a) {
+                found_issue_a = true;
+            }
+            if (issue.issue_address == buffer_addr_b && issue.issue_size == write_size_b) {
+                found_issue_b = true;
+            }
+        }
+        EXPECT_TRUE(found_issue_a) << "Missing write-to-locked issue for buffer A at addr 0x" << std::hex
+                                   << buffer_addr_a;
+        EXPECT_TRUE(found_issue_b) << "Missing write-to-locked issue for buffer B at addr 0x" << std::hex
+                                   << buffer_addr_b;
+    }
+}
+
 TEST_F(NOCDebuggingFixture, ScopedLockConcurrentAccessNoIssue) {
     // inverted version of the test above
     for (auto& mesh_device : devices_) {

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/scoped_lock_cb_writer_kernel.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/scoped_lock_cb_writer_kernel.cpp
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "api/dataflow/dataflow_api.h"
+#include "experimental/core_local_mem.h"
+#include "experimental/endpoints.h"
+#include "experimental/noc_semaphore.h"
+
+void kernel_main() {
+    uint32_t local_buffer_addr = get_arg_val<uint32_t>(0);
+    uint32_t write_size = get_arg_val<uint32_t>(1);
+    uint32_t target_noc_x = get_arg_val<uint32_t>(2);
+    uint32_t target_noc_y = get_arg_val<uint32_t>(3);
+    uint32_t target_start_addr = get_arg_val<uint32_t>(4);
+    uint32_t target_end_addr = get_arg_val<uint32_t>(5);
+    uint32_t stride = get_arg_val<uint32_t>(6);
+    uint32_t my_sem_id = get_arg_val<uint32_t>(7);
+    uint32_t other_sem_id = get_arg_val<uint32_t>(8);
+    uint32_t other_noc_x = get_arg_val<uint32_t>(9);
+    uint32_t other_noc_y = get_arg_val<uint32_t>(10);
+
+    experimental::Semaphore my_sem(my_sem_id);
+    experimental::Semaphore other_sem(other_sem_id);
+    experimental::Noc noc;
+    experimental::UnicastEndpoint unicast_endpoint;
+
+    experimental::CoreLocalMem<uint32_t> local_buffer(local_buffer_addr);
+
+    my_sem.down(1);
+
+    for (uint32_t addr = target_start_addr; addr + write_size <= target_end_addr; addr += stride) {
+        noc.async_write(
+            local_buffer,
+            unicast_endpoint,
+            write_size,
+            {},
+            {.noc_x = target_noc_x, .noc_y = target_noc_y, .addr = addr});
+        noc.async_write_barrier();
+    }
+
+    other_sem.up(noc, other_noc_x, other_noc_y, 1);
+
+    my_sem.down(1);
+
+    for (uint32_t addr = target_start_addr; addr + write_size <= target_end_addr; addr += stride) {
+        noc.async_write(
+            local_buffer,
+            unicast_endpoint,
+            write_size,
+            {},
+            {.noc_x = target_noc_x, .noc_y = target_noc_y, .addr = addr});
+        noc.async_write_barrier();
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/scoped_lock_cb_writer_kernel_no_issue.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/scoped_lock_cb_writer_kernel_no_issue.cpp
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "api/dataflow/dataflow_api.h"
+#include "experimental/core_local_mem.h"
+#include "experimental/endpoints.h"
+#include "experimental/noc_semaphore.h"
+
+void kernel_main() {
+    uint32_t local_buffer_addr = get_arg_val<uint32_t>(0);
+    uint32_t write_size = get_arg_val<uint32_t>(1);
+    uint32_t target_noc_x = get_arg_val<uint32_t>(2);
+    uint32_t target_noc_y = get_arg_val<uint32_t>(3);
+    uint32_t target_start_addr = get_arg_val<uint32_t>(4);
+    uint32_t target_end_addr = get_arg_val<uint32_t>(5);
+    uint32_t stride = get_arg_val<uint32_t>(6);
+    uint32_t my_sem_id = get_arg_val<uint32_t>(7);
+    uint32_t other_sem_id = get_arg_val<uint32_t>(8);
+    uint32_t other_noc_x = get_arg_val<uint32_t>(9);
+    uint32_t other_noc_y = get_arg_val<uint32_t>(10);
+
+    experimental::Semaphore my_sem(my_sem_id);
+    experimental::Semaphore other_sem(other_sem_id);
+    experimental::Noc noc;
+    experimental::UnicastEndpoint unicast_endpoint;
+
+    experimental::CoreLocalMem<uint32_t> local_buffer(local_buffer_addr);
+
+    for (uint32_t addr = target_start_addr; addr + write_size <= target_end_addr; addr += stride) {
+        noc.async_write(
+            local_buffer,
+            unicast_endpoint,
+            write_size,
+            {},
+            {.noc_x = target_noc_x, .noc_y = target_noc_y, .addr = addr});
+        noc.async_write_barrier();
+    }
+
+    other_sem.up(noc, other_noc_x, other_noc_y, 1);
+
+    my_sem.down(1);
+
+    my_sem.down(1);
+
+    for (uint32_t addr = target_start_addr; addr + write_size <= target_end_addr; addr += stride) {
+        noc.async_write(
+            local_buffer,
+            unicast_endpoint,
+            write_size,
+            {},
+            {.noc_x = target_noc_x, .noc_y = target_noc_y, .addr = addr});
+        noc.async_write_barrier();
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/scoped_lock_only_kernel.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/scoped_lock_only_kernel.cpp
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "api/dataflow/dataflow_api.h"
+#include "experimental/core_local_mem.h"
+
+void kernel_main() {
+    uint32_t lock_addr = get_arg_val<uint32_t>(0);
+    uint32_t lock_num_elements = get_arg_val<uint32_t>(1);
+
+    experimental::CoreLocalMem<uint32_t> buffer(lock_addr);
+
+    {
+        [[maybe_unused]] auto lock = buffer.scoped_lock(lock_num_elements);
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/scoped_lock_self_write_kernel.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/scoped_lock_self_write_kernel.cpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "api/dataflow/dataflow_api.h"
+#include "experimental/core_local_mem.h"
+#include "experimental/endpoints.h"
+
+void kernel_main() {
+    uint32_t lock_addr = get_arg_val<uint32_t>(0);
+    uint32_t lock_num_elements = get_arg_val<uint32_t>(1);
+    uint32_t src_buffer_addr = get_arg_val<uint32_t>(2);
+    uint32_t write_target_addr = get_arg_val<uint32_t>(3);
+    uint32_t write_size = get_arg_val<uint32_t>(4);
+    uint32_t self_noc_x = get_arg_val<uint32_t>(5);
+    uint32_t self_noc_y = get_arg_val<uint32_t>(6);
+
+    experimental::Noc noc;
+    experimental::UnicastEndpoint unicast_endpoint;
+    experimental::CoreLocalMem<uint32_t> src_buffer(src_buffer_addr);
+    experimental::CoreLocalMem<uint32_t> lock_buffer(lock_addr);
+
+    {
+        auto lock = lock_buffer.scoped_lock(lock_num_elements);
+        noc.async_write(
+            src_buffer,
+            unicast_endpoint,
+            write_size,
+            {},
+            {.noc_x = self_noc_x, .noc_y = self_noc_y, .addr = write_target_addr});
+        noc.async_write_barrier();
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/scoped_lock_test_kernel.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/scoped_lock_test_kernel.cpp
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "api/dataflow/dataflow_api.h"
+#include "experimental/noc_semaphore.h"
+#include "experimental/core_local_mem.h"
+
+void kernel_main() {
+    uint32_t l1_buffer_addr = get_arg_val<uint32_t>(0);
+    uint32_t num_elements = get_arg_val<uint32_t>(1);
+    uint32_t my_sem_id = get_arg_val<uint32_t>(2);
+    uint32_t other_sem_id = get_arg_val<uint32_t>(3);
+    uint32_t other_noc_x = get_arg_val<uint32_t>(4);
+    uint32_t other_noc_y = get_arg_val<uint32_t>(5);
+
+    experimental::Semaphore my_sem(my_sem_id);
+    experimental::Semaphore other_sem(other_sem_id);
+    experimental::Noc noc;
+    experimental::CoreLocalMem<uint32_t> buffer(l1_buffer_addr);
+
+    {
+        // Lock this buffer for num_elements
+        auto lock = buffer.scoped_lock(num_elements);
+        other_sem.up(noc, other_noc_x, other_noc_y, 1);
+
+        my_sem.down(1);
+    }
+
+    // Unlocked
+    other_sem.up(noc, other_noc_x, other_noc_y, 1);
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/scoped_lock_test_kernel_cb.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/scoped_lock_test_kernel_cb.cpp
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "api/dataflow/dataflow_api.h"
+#include "experimental/noc_semaphore.h"
+#include "experimental/circular_buffer.h"
+
+void kernel_main() {
+    uint32_t cb_id = get_arg_val<uint32_t>(0);
+    uint32_t my_sem_id = get_arg_val<uint32_t>(1);
+    uint32_t other_sem_id = get_arg_val<uint32_t>(2);
+    uint32_t other_noc_x = get_arg_val<uint32_t>(3);
+    uint32_t other_noc_y = get_arg_val<uint32_t>(4);
+
+    experimental::Semaphore my_sem(my_sem_id);
+    experimental::Semaphore other_sem(other_sem_id);
+    experimental::Noc noc;
+    experimental::CircularBuffer cb(cb_id);
+
+    {
+        auto lock = cb.scoped_lock();
+        other_sem.up(noc, other_noc_x, other_noc_y, 1);
+        my_sem.down(1);
+    }
+
+    other_sem.up(noc, other_noc_x, other_noc_y, 2);
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/scoped_lock_test_kernel_cb_no_issue.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/scoped_lock_test_kernel_cb_no_issue.cpp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "api/dataflow/dataflow_api.h"
+#include "experimental/noc_semaphore.h"
+#include "experimental/circular_buffer.h"
+
+void kernel_main() {
+    uint32_t cb_id = get_arg_val<uint32_t>(0);
+    uint32_t my_sem_id = get_arg_val<uint32_t>(1);
+    uint32_t other_sem_id = get_arg_val<uint32_t>(2);
+    uint32_t other_noc_x = get_arg_val<uint32_t>(3);
+    uint32_t other_noc_y = get_arg_val<uint32_t>(4);
+
+    experimental::Semaphore my_sem(my_sem_id);
+    experimental::Semaphore other_sem(other_sem_id);
+    experimental::Noc noc;
+    experimental::CircularBuffer cb(cb_id);
+
+    my_sem.down(1);
+
+    {
+        auto lock = cb.scoped_lock();
+        other_sem.up(noc, other_noc_x, other_noc_y, 1);
+    }
+
+    other_sem.up(noc, other_noc_x, other_noc_y, 2);
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/scoped_lock_test_kernel_multi.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/scoped_lock_test_kernel_multi.cpp
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "api/dataflow/dataflow_api.h"
+#include "experimental/noc_semaphore.h"
+#include "experimental/core_local_mem.h"
+
+void kernel_main() {
+    uint32_t buffer_addr_a = get_arg_val<uint32_t>(0);
+    uint32_t num_elements_a = get_arg_val<uint32_t>(1);
+    uint32_t buffer_addr_b = get_arg_val<uint32_t>(2);
+    uint32_t num_elements_b = get_arg_val<uint32_t>(3);
+    uint32_t my_sem_id = get_arg_val<uint32_t>(4);
+    uint32_t other_sem_id = get_arg_val<uint32_t>(5);
+    uint32_t other_noc_x = get_arg_val<uint32_t>(6);
+    uint32_t other_noc_y = get_arg_val<uint32_t>(7);
+
+    experimental::Semaphore my_sem(my_sem_id);
+    experimental::Semaphore other_sem(other_sem_id);
+    experimental::Noc noc;
+    experimental::CoreLocalMem<uint32_t> buf_a(buffer_addr_a);
+    experimental::CoreLocalMem<uint32_t> buf_b(buffer_addr_b);
+
+    {
+        auto lock_a = buf_a.scoped_lock(num_elements_a);
+        auto lock_b = buf_b.scoped_lock(num_elements_b);
+        other_sem.up(noc, other_noc_x, other_noc_y, 1);
+
+        my_sem.down(1);
+    }
+
+    other_sem.up(noc, other_noc_x, other_noc_y, 1);
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/scoped_lock_test_kernel_no_issue.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/scoped_lock_test_kernel_no_issue.cpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "api/dataflow/dataflow_api.h"
+#include "experimental/noc_semaphore.h"
+#include "experimental/core_local_mem.h"
+
+// No-issue flow: wait for writer to finish first batch (no lock) -> lock -> signal locked -> unlock -> signal unlocked
+void kernel_main() {
+    uint32_t l1_buffer_addr = get_arg_val<uint32_t>(0);
+    uint32_t num_elements = get_arg_val<uint32_t>(1);
+    uint32_t my_sem_id = get_arg_val<uint32_t>(2);     // locker_sem: wait for "writer first batch done"
+    uint32_t other_sem_id = get_arg_val<uint32_t>(3);  // writer_sem: signal "locked" then "unlocked"
+    uint32_t other_noc_x = get_arg_val<uint32_t>(4);
+    uint32_t other_noc_y = get_arg_val<uint32_t>(5);
+
+    experimental::Semaphore my_sem(my_sem_id);
+    experimental::Semaphore other_sem(other_sem_id);
+    experimental::Noc noc;
+    experimental::CoreLocalMem<uint32_t> buffer(l1_buffer_addr);
+
+    // Wait for writer to complete first batch of writes (while buffer was not locked)
+    my_sem.down(1);
+
+    {
+        // Lock this buffer for num_elements
+        auto lock = buffer.scoped_lock(num_elements);
+        other_sem.up(noc, other_noc_x, other_noc_y, 1);  // signal "locked"
+    }
+
+    other_sem.up(noc, other_noc_x, other_noc_y, 1);
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/scoped_lock_writer_kernel.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/scoped_lock_writer_kernel.cpp
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "api/dataflow/dataflow_api.h"
+#include "experimental/core_local_mem.h"
+#include "experimental/endpoints.h"
+#include "experimental/noc_semaphore.h"
+
+void kernel_main() {
+    uint32_t local_buffer_addr = get_arg_val<uint32_t>(0);
+    uint32_t num_elements = get_arg_val<uint32_t>(1);
+    uint32_t target_noc_x = get_arg_val<uint32_t>(2);
+    uint32_t target_noc_y = get_arg_val<uint32_t>(3);
+    uint32_t target_addr = get_arg_val<uint32_t>(4);
+    uint32_t my_sem_id = get_arg_val<uint32_t>(5);
+    uint32_t other_sem_id = get_arg_val<uint32_t>(6);
+    uint32_t other_noc_x = get_arg_val<uint32_t>(7);
+    uint32_t other_noc_y = get_arg_val<uint32_t>(8);
+
+    experimental::Semaphore my_sem(my_sem_id);
+    experimental::Semaphore other_sem(other_sem_id);
+    experimental::Noc noc;
+    experimental::UnicastEndpoint unicast_endpoint;
+
+    experimental::CoreLocalMem<uint32_t> local_buffer(local_buffer_addr);
+    uint32_t write_size = num_elements * sizeof(uint32_t);
+
+    // Wait for the locked core to signal it is locked
+    my_sem.down(1);
+
+    // Do writes to the locked core
+    for (uint32_t i = 0; i < 5; ++i) {
+        noc.async_write(
+            local_buffer,
+            unicast_endpoint,
+            write_size,
+            {},
+            {.noc_x = target_noc_x, .noc_y = target_noc_y, .addr = target_addr});
+        noc.async_write_barrier();
+    }
+
+    // Signal the locked core to unlock
+    other_sem.up(noc, other_noc_x, other_noc_y, 1);
+
+    // Now unlocked
+    my_sem.down(1);
+
+    // Write to the other core's memory which is not locked
+    for (uint32_t i = 0; i < 5; ++i) {
+        noc.async_write(
+            local_buffer,
+            unicast_endpoint,
+            write_size,
+            {},
+            {.noc_x = target_noc_x, .noc_y = target_noc_y, .addr = target_addr});
+        noc.async_write_barrier();
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/scoped_lock_writer_kernel_multi.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/scoped_lock_writer_kernel_multi.cpp
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "api/dataflow/dataflow_api.h"
+#include "experimental/core_local_mem.h"
+#include "experimental/endpoints.h"
+#include "experimental/noc_semaphore.h"
+
+void kernel_main() {
+    uint32_t local_buffer_addr = get_arg_val<uint32_t>(0);
+    uint32_t write_size_a = get_arg_val<uint32_t>(1);
+    uint32_t write_size_b = get_arg_val<uint32_t>(2);
+    uint32_t target_noc_x = get_arg_val<uint32_t>(3);
+    uint32_t target_noc_y = get_arg_val<uint32_t>(4);
+    uint32_t target_addr_a = get_arg_val<uint32_t>(5);
+    uint32_t target_addr_b = get_arg_val<uint32_t>(6);
+    uint32_t my_sem_id = get_arg_val<uint32_t>(7);
+    uint32_t other_sem_id = get_arg_val<uint32_t>(8);
+    uint32_t other_noc_x = get_arg_val<uint32_t>(9);
+    uint32_t other_noc_y = get_arg_val<uint32_t>(10);
+
+    experimental::Semaphore my_sem(my_sem_id);
+    experimental::Semaphore other_sem(other_sem_id);
+    experimental::Noc noc;
+    experimental::UnicastEndpoint unicast_endpoint;
+
+    experimental::CoreLocalMem<uint32_t> local_buffer(local_buffer_addr);
+
+    my_sem.down(1);
+
+    noc.async_write(
+        local_buffer,
+        unicast_endpoint,
+        write_size_a,
+        {},
+        {.noc_x = target_noc_x, .noc_y = target_noc_y, .addr = target_addr_a});
+    noc.async_write_barrier();
+
+    noc.async_write(
+        local_buffer,
+        unicast_endpoint,
+        write_size_b,
+        {},
+        {.noc_x = target_noc_x, .noc_y = target_noc_y, .addr = target_addr_b});
+    noc.async_write_barrier();
+
+    other_sem.up(noc, other_noc_x, other_noc_y, 1);
+
+    my_sem.down(1);
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/scoped_lock_writer_kernel_no_issue.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/scoped_lock_writer_kernel_no_issue.cpp
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "api/dataflow/dataflow_api.h"
+#include "experimental/core_local_mem.h"
+#include "experimental/endpoints.h"
+#include "experimental/noc_semaphore.h"
+
+// No-issue flow: write -> signal "first batch done" -> wait locked -> wait unlocked -> write (no writes while locked)
+void kernel_main() {
+    uint32_t local_buffer_addr = get_arg_val<uint32_t>(0);
+    uint32_t num_elements = get_arg_val<uint32_t>(1);
+    uint32_t target_noc_x = get_arg_val<uint32_t>(2);
+    uint32_t target_noc_y = get_arg_val<uint32_t>(3);
+    uint32_t target_addr = get_arg_val<uint32_t>(4);
+    uint32_t my_sem_id = get_arg_val<uint32_t>(5);     // writer_sem: signal "first batch done"
+    uint32_t other_sem_id = get_arg_val<uint32_t>(6);  // locker_sem: wait "locked" then "unlocked"
+    uint32_t other_noc_x = get_arg_val<uint32_t>(7);
+    uint32_t other_noc_y = get_arg_val<uint32_t>(8);
+
+    experimental::Semaphore my_sem(my_sem_id);
+    experimental::Semaphore other_sem(other_sem_id);
+    experimental::Noc noc;
+    experimental::UnicastEndpoint unicast_endpoint;
+
+    experimental::CoreLocalMem<uint32_t> local_buffer(local_buffer_addr);
+    uint32_t write_size = num_elements * sizeof(uint32_t);
+
+    // First batch: write while locker has not locked (no issue)
+    for (uint32_t i = 0; i < 5; ++i) {
+        noc.async_write(
+            local_buffer,
+            unicast_endpoint,
+            write_size,
+            {},
+            {.noc_x = target_noc_x, .noc_y = target_noc_y, .addr = target_addr});
+        noc.async_write_barrier();
+    }
+
+    other_sem.up(noc, other_noc_x, other_noc_y, 1);
+
+    // locked
+    my_sem.down(1);
+
+    // unlocked
+    my_sem.down(1);
+
+    // Second batch: write after locker has unlocked (no issue)
+    for (uint32_t i = 0; i < 5; ++i) {
+        noc.async_write(
+            local_buffer,
+            unicast_endpoint,
+            write_size,
+            {},
+            {.noc_x = target_noc_x, .noc_y = target_noc_y, .addr = target_addr});
+        noc.async_write_barrier();
+    }
+}

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -224,6 +224,7 @@ target_sources(
             tools/profiler/fabric_event_profiler.hpp
             tools/profiler/noc_event_profiler.hpp
             tools/profiler/noc_debugging_profiler.hpp
+            tools/profiler/noc_debugging_event_metadata.hpp
             tools/profiler/cpp_device_analyses.json
             # Kernel sources
             impl/dispatch/kernels/cq_dispatch.cpp

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -224,7 +224,7 @@ target_sources(
             tools/profiler/fabric_event_profiler.hpp
             tools/profiler/noc_event_profiler.hpp
             tools/profiler/noc_debugging_profiler.hpp
-            tools/profiler/noc_debugging_event_metadata.hpp
+            tools/profiler/noc_debugging_metadata.hpp
             tools/profiler/cpp_device_analyses.json
             # Kernel sources
             impl/dispatch/kernels/cq_dispatch.cpp

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -223,6 +223,7 @@ target_sources(
             tools/profiler/kernel_profiler.hpp
             tools/profiler/fabric_event_profiler.hpp
             tools/profiler/noc_event_profiler.hpp
+            tools/profiler/noc_debugging_profiler.hpp
             tools/profiler/cpp_device_analyses.json
             # Kernel sources
             impl/dispatch/kernels/cq_dispatch.cpp

--- a/tt_metal/hostdevcommon/api/hostdevcommon/profiler_common.h
+++ b/tt_metal/hostdevcommon/api/hostdevcommon/profiler_common.h
@@ -15,6 +15,11 @@ namespace kernel_profiler {
 static constexpr int SUM_COUNT = 2;
 static constexpr uint32_t DRAM_PROFILER_ADDRESS_STALLED = 0xFFFFFFFF;
 
+// Static IDs need to be unique for these features
+// also must fit in 16 bits (timer_id & 0xFFFF)
+static constexpr uint32_t NOC_TRACING_STATIC_ID = 12345;
+static constexpr uint32_t NOC_DEBUGGING_STATIC_ID = 23456;
+
 enum BufferIndex {
     ID_HH,
     ID_HL,

--- a/tt_metal/hw/inc/experimental/circular_buffer.h
+++ b/tt_metal/hw/inc/experimental/circular_buffer.h
@@ -14,8 +14,8 @@
 #endif
 #else  // !COMPILE_FOR_TRISC
 #include "experimental/noc.h"
-#include "noc_debugging_metadata.hpp"
-#include "noc_debugging_profiler.hpp"
+#include "tools/profiler/noc_debugging_metadata.hpp"
+#include "tools/profiler/noc_debugging_profiler.hpp"
 #endif
 
 #include "experimental/lock.h"

--- a/tt_metal/hw/inc/experimental/circular_buffer.h
+++ b/tt_metal/hw/inc/experimental/circular_buffer.h
@@ -143,18 +143,13 @@ public:
         RECORD_SCOPED_LOCK_EVENT(NocDebuggingEventMetadata::NocDebugEventType::CB_LOCK, addr, num_bytes);
         return Lock([this, addr, num_bytes]() {
             RECORD_SCOPED_LOCK_EVENT(NocDebuggingEventMetadata::NocDebugEventType::CB_UNLOCK, addr, num_bytes);
-            release_scoped_lock();
         });
 #else
-        return Lock([this]() { release_scoped_lock(); });
+        return Lock([this]() {});
 #endif
     }
 
 private:
-    void release_scoped_lock() {
-        // TODO: Unregister with the debugger
-    }
-
     uint32_t cb_id_;
 };
 

--- a/tt_metal/hw/inc/experimental/circular_buffer.h
+++ b/tt_metal/hw/inc/experimental/circular_buffer.h
@@ -14,8 +14,8 @@
 #endif
 #else  // !COMPILE_FOR_TRISC
 #include "experimental/noc.h"
-#include "tools/profiler/noc_debugging_metadata.hpp"
-#include "tools/profiler/noc_debugging_profiler.hpp"
+#include "noc_debugging_metadata.hpp"
+#include "noc_debugging_profiler.hpp"
 #endif
 
 #include "experimental/lock.h"

--- a/tt_metal/hw/inc/experimental/circular_buffer.h
+++ b/tt_metal/hw/inc/experimental/circular_buffer.h
@@ -14,6 +14,8 @@
 #endif
 #else  // !COMPILE_FOR_TRISC
 #include "experimental/noc.h"
+#include "tools/profiler/noc_debugging_metadata.hpp"
+#include "tools/profiler/noc_debugging_profiler.hpp"
 #endif
 
 #include "experimental/lock.h"
@@ -133,8 +135,19 @@ public:
     }
 
     [[nodiscard]] auto scoped_lock() {
-        // TODO: Register with the debugger to track the lock
+#ifndef COMPILE_FOR_TRISC
+        auto& iface = get_local_cb_interface(cb_id_);
+        uint32_t base_16b = iface.fifo_limit - iface.fifo_size;
+        uint32_t addr = base_16b << 4;
+        uint32_t num_bytes = iface.fifo_size << 4;
+        RECORD_SCOPED_LOCK_EVENT(NocDebuggingEventMetadata::NocDebugEventType::CB_LOCK, addr, num_bytes);
+        return Lock([this, addr, num_bytes]() {
+            RECORD_SCOPED_LOCK_EVENT(NocDebuggingEventMetadata::NocDebugEventType::CB_UNLOCK, addr, num_bytes);
+            release_scoped_lock();
+        });
+#else
         return Lock([this]() { release_scoped_lock(); });
+#endif
     }
 
 private:

--- a/tt_metal/hw/inc/experimental/core_local_mem.h
+++ b/tt_metal/hw/inc/experimental/core_local_mem.h
@@ -143,10 +143,6 @@ public:
         return byte_diff / sizeof(T);
     }
 
-    [[nodiscard]] auto scoped_lock() {
-        return Lock([this]() { release_scoped_lock(); });
-    }
-
     /** @brief Lock a region of num_elements for the duration of the returned guard (same as scoped_lock(); size for
      * future debug/profiler use). */
     [[nodiscard]] auto scoped_lock(size_t num_elements) {

--- a/tt_metal/hw/inc/experimental/core_local_mem.h
+++ b/tt_metal/hw/inc/experimental/core_local_mem.h
@@ -155,7 +155,6 @@ public:
         RECORD_SCOPED_LOCK_EVENT(NocDebuggingEventMetadata::NocDebugEventType::MEM_LOCK, addr, num_bytes);
         return Lock([this, addr, num_bytes]() {
             RECORD_SCOPED_LOCK_EVENT(NocDebuggingEventMetadata::NocDebugEventType::MEM_UNLOCK, addr, num_bytes);
-            release_scoped_lock();
         });
     }
 
@@ -168,10 +167,6 @@ public:
     explicit operator bool() const { return address_ != 0; }
 
 private:
-    void release_scoped_lock() {
-        // TODO: Unregister with the debugger
-    }
-
     AddressType address_;
 };
 

--- a/tt_metal/hw/inc/experimental/core_local_mem.h
+++ b/tt_metal/hw/inc/experimental/core_local_mem.h
@@ -6,8 +6,8 @@
 
 #include "experimental/noc.h"
 #include "experimental/lock.h"
-#include "noc_debugging_metadata.hpp"
-#include "noc_debugging_profiler.hpp"
+#include "tools/profiler/noc_debugging_metadata.hpp"
+#include "tools/profiler/noc_debugging_profiler.hpp"
 
 namespace experimental {
 

--- a/tt_metal/hw/inc/experimental/core_local_mem.h
+++ b/tt_metal/hw/inc/experimental/core_local_mem.h
@@ -6,6 +6,8 @@
 
 #include "experimental/noc.h"
 #include "experimental/lock.h"
+#include "tools/profiler/noc_debugging_metadata.hpp"
+#include "tools/profiler/noc_debugging_profiler.hpp"
 
 namespace experimental {
 
@@ -143,6 +145,18 @@ public:
 
     [[nodiscard]] auto scoped_lock() {
         return Lock([this]() { release_scoped_lock(); });
+    }
+
+    /** @brief Lock a region of num_elements for the duration of the returned guard (same as scoped_lock(); size for
+     * future debug/profiler use). */
+    [[nodiscard]] auto scoped_lock(size_t num_elements) {
+        uint32_t addr = static_cast<uint32_t>(get_address());
+        uint32_t num_bytes = static_cast<uint32_t>(num_elements * sizeof(T));
+        RECORD_SCOPED_LOCK_EVENT(NocDebuggingEventMetadata::NocDebugEventType::MEM_LOCK, addr, num_bytes);
+        return Lock([this, addr, num_bytes]() {
+            RECORD_SCOPED_LOCK_EVENT(NocDebuggingEventMetadata::NocDebugEventType::MEM_UNLOCK, addr, num_bytes);
+            release_scoped_lock();
+        });
     }
 
     bool operator==(const CoreLocalMem& other) const { return address_ == other.address_; }

--- a/tt_metal/hw/inc/experimental/core_local_mem.h
+++ b/tt_metal/hw/inc/experimental/core_local_mem.h
@@ -6,8 +6,8 @@
 
 #include "experimental/noc.h"
 #include "experimental/lock.h"
-#include "tools/profiler/noc_debugging_metadata.hpp"
-#include "tools/profiler/noc_debugging_profiler.hpp"
+#include "noc_debugging_metadata.hpp"
+#include "noc_debugging_profiler.hpp"
 
 namespace experimental {
 

--- a/tt_metal/impl/debug/noc_debugging.cpp
+++ b/tt_metal/impl/debug/noc_debugging.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <map>
 #include <type_traits>
+#include <enchantum/enchantum.hpp>
 
 #include <fmt/base.h>
 #include <fmt/ranges.h>
@@ -66,9 +67,8 @@ void NOCDebugState::handle_write_event(tt_cxy_pair core, int processor_id, uint6
 
     // Multiple writes from the same source address without a barrier in between
     // Source data potentially overwritten before being flushed
-    if (posted && state.posted_writes_pending[noc_id].contains(src_addr)) {
-        issue_found = true;
-    } else if (!posted && state.nonposted_writes_pending[noc_id].contains(src_addr)) {
+    if ((posted && state.posted_writes_pending[noc_id].contains(src_addr)) ||
+        (!posted && state.nonposted_writes_pending[noc_id].contains(src_addr))) {
         issue_found = true;
     }
 
@@ -313,9 +313,9 @@ void NOCDebugState::print_aggregated_errors() const {
                     core_issues.has_read_barrier = true;
                 } else if (issue_type.base_type == NOCDebugIssueBaseType::UNFLUSHED_WRITE_AT_END) {
                     core_issues.unflushed_write_issues.push_back(get_issue_description(issue_type));
-                } else if (issue_type.base_type == NOCDebugIssueBaseType::WRITE_TO_LOCKED_CORE_LOCAL_MEM) {
-                    core_issues.locked_buffer_issues.push_back(get_issue_description(issue_type));
-                } else if (issue_type.base_type == NOCDebugIssueBaseType::WRITE_TO_LOCKED_CB) {
+                } else if (
+                    issue_type.base_type == NOCDebugIssueBaseType::WRITE_TO_LOCKED_CORE_LOCAL_MEM ||
+                    issue_type.base_type == NOCDebugIssueBaseType::WRITE_TO_LOCKED_CB) {
                     core_issues.locked_buffer_issues.push_back(get_issue_description(issue_type));
                 }
             }
@@ -397,6 +397,8 @@ void NOCDebugState::push_event(size_t chip_id, uint64_t timestamp, int processor
 }
 
 void NOCDebugState::process_accumulated_events_all_chips() {
+    std::lock_guard<std::mutex> cores_lock{cores_mutex};
+
     // Store them immediately because the main thread will still insert events while we are
     // processing the current batch
     std::vector<PendingEvent> to_process;

--- a/tt_metal/impl/debug/noc_debugging.cpp
+++ b/tt_metal/impl/debug/noc_debugging.cpp
@@ -4,6 +4,7 @@
 
 #include "noc_debugging.hpp"
 
+#include <algorithm>
 #include <map>
 #include <type_traits>
 
@@ -13,6 +14,7 @@
 #include <umd/device/types/cluster_descriptor_types.hpp>
 #include <umd/device/types/xy_pair.hpp>
 #include "tt_metal/third_party/umd/device/api/umd/device/types/xy_pair.hpp"
+#include "tt_stl/assert.hpp"
 
 namespace tt::tt_metal {
 
@@ -31,11 +33,27 @@ inline bool wrap_ge(uint32_t a, uint32_t b) {
     return (diff << shift) >= 0;
 }
 
+NOCDebugState::LockedBufferInfo::LockType get_lock_type(NocDebuggingEventMetadata::NocDebugEventType event_type) {
+    if (event_type == NocDebuggingEventMetadata::NocDebugEventType::CB_LOCK ||
+        event_type == NocDebuggingEventMetadata::NocDebugEventType::CB_UNLOCK) {
+        return NOCDebugState::LockedBufferInfo::LockType::CB;
+    }
+
+    if (event_type == NocDebuggingEventMetadata::NocDebugEventType::MEM_LOCK ||
+        event_type == NocDebuggingEventMetadata::NocDebugEventType::MEM_UNLOCK) {
+        return NOCDebugState::LockedBufferInfo::LockType::MEM;
+    }
+
+    TT_THROW("Invalid lock type: {}", enchantum::to_string(event_type));
+}
+
 }  // namespace detail
 
 NOCDebugState::CoreDebugState& NOCDebugState::get_state(tt_cxy_pair core) { return cores[core]; }
 
 const NOCDebugState::CoreDebugState& NOCDebugState::get_state(tt_cxy_pair core) const { return cores[core]; }
+
+bool NOCDebugState::has_state(tt_cxy_pair core) const { return cores.contains(core); }
 
 void NOCDebugState::handle_write_event(tt_cxy_pair core, int processor_id, uint64_t timestamp, NocWriteEvent event) {
     CoreDebugState& state = get_state(core);
@@ -44,14 +62,14 @@ void NOCDebugState::handle_write_event(tt_cxy_pair core, int processor_id, uint6
     bool posted = event.posted;
     bool is_semaphore = event.is_semaphore;
     bool is_mcast = event.is_mcast;
-    std::string problem_type;
+    bool issue_found = false;
 
     // Multiple writes from the same source address without a barrier in between
     // Source data potentially overwritten before being flushed
     if (posted && state.posted_writes_pending[noc_id].contains(src_addr)) {
-        problem_type = "multiple posted writes from the same source address without a barrier in between";
+        issue_found = true;
     } else if (!posted && state.nonposted_writes_pending[noc_id].contains(src_addr)) {
-        problem_type = "multiple non-posted writes from the same source address without a barrier in between";
+        issue_found = true;
     }
 
     // Check if transaction counter has not increased (should always increase)
@@ -59,23 +77,40 @@ void NOCDebugState::handle_write_event(tt_cxy_pair core, int processor_id, uint6
     if (posted) {
         if (state.any_posted_writes[noc_id] &&
             !detail::wrap_ge(event.counter_snapshot, state.posted_write_counter_snapshot[noc_id])) {
-            problem_type =
-                "multiple posted writes from the same source address without a barrier/flush (transaction counters are "
-                "the same)";
+            issue_found = true;
         }
     } else {
         if (state.any_nonposted_writes[noc_id] &&
             !detail::wrap_ge(event.counter_snapshot, state.nonposted_write_counter_snapshot[noc_id])) {
-            problem_type =
-                "multiple non-posted writes from the same source address without a barrier/flush (transaction counters "
-                "are the same)";
+            issue_found = true;
         }
     }
 
-    if (!problem_type.empty()) {
+    if (issue_found) {
         // Classify write type for more detailed error reporting
         NOCDebugIssueType issue_type(NOCDebugIssueBaseType::WRITE_FLUSH_BARRIER, is_mcast, is_semaphore);
         state.issue[processor_id].set_issue(issue_type);
+    }
+
+    // Check if the write hit a locked buffer in the destination core
+    tt_cxy_pair dst_core{core.chip, static_cast<size_t>(event.dst_x), static_cast<size_t>(event.dst_y)};
+    if (has_state(dst_core)) {
+        CoreDebugState& dst_state = get_state(dst_core);
+        if (const auto* locked_buf = dst_state.get_noc_write_to_lock_buffer(event); locked_buf != nullptr) {
+            NOCDebugIssueType issue_type;
+            if (locked_buf->lock_type == NOCDebugState::LockedBufferInfo::LockType::MEM) {
+                issue_type.base_type = NOCDebugIssueBaseType::WRITE_TO_LOCKED_CORE_LOCAL_MEM;
+            } else {
+                issue_type.base_type = NOCDebugIssueBaseType::WRITE_TO_LOCKED_CB;
+            }
+            issue_type.issue_address = locked_buf->address;
+            issue_type.issue_size = locked_buf->size;
+            issue_type.src_x = event.src_x;
+            issue_type.src_y = event.src_y;
+            issue_type.dst_x = event.dst_x;
+            issue_type.dst_y = event.dst_y;
+            state.issue[processor_id].set_issue(issue_type);
+        }
     }
 
     if (event.posted) {
@@ -94,27 +129,23 @@ void NOCDebugState::handle_read_event(tt_cxy_pair core, int processor_id, uint64
     CoreDebugState& state = get_state(core);
     uint8_t noc_id = event.noc;
     uint32_t dst_addr = event.dst_addr;
-    std::string problem_type;
+    bool issue_found = false;
 
     // Multiple reads to the same destination address without a barrier in between
     // Destination data potentially being read before a read barrier has ensured that data has fully arrived
     if (state.reads_not_flushed[noc_id].contains(dst_addr)) {
-        problem_type = "multiple reads to the same address without read barrier";
+        issue_found = true;
     }
 
     // Check if transaction counter has not increased (should always increase)
     // This detects cases where counters wrap incorrectly or don't advance
     if (state.any_reads[noc_id]) {
         if (!detail::wrap_ge(event.counter_snapshot, state.read_counter_snapshot[noc_id])) {
-            if (!problem_type.empty()) {
-                problem_type += "; ";
-            }
-            problem_type +=
-                "multiple reads to the same address without read barrier (transaction counters are the same)";
+            issue_found = true;
         }
     }
 
-    if (!problem_type.empty()) {
+    if (issue_found) {
         state.issue[processor_id].set_issue(NOCDebugIssueType(NOCDebugIssueBaseType::READ_BARRIER));
     }
 
@@ -160,6 +191,25 @@ void NOCDebugState::handle_write_flush_event(
     }
 }
 
+void NOCDebugState::handle_scoped_lock_event(
+    tt_cxy_pair core, int processor_id, uint64_t timestamp, ScopedLockEvent event) {
+    CoreDebugState& state = get_state(core);
+
+    // Merge intervals is not required.
+    // for unlocking, the start and end address of the request will be the same as from the lock request.
+    // if multiple locks and unlocks are requested for the same buffer, then only one will be removed as eventually
+    // the Lock destructor will release the lock
+    auto& bufs = state.locked_buffers[processor_id];
+    auto lock_type = detail::get_lock_type(event.event_type);
+    if (event.is_lock()) {
+        bufs.insert({event.locked_address_base, event.num_bytes, lock_type});
+    } else {
+        bufs.erase({event.locked_address_base, event.num_bytes, lock_type});
+    }
+
+    update_latest_risc_timestamp(core, processor_id, timestamp);
+}
+
 void NOCDebugState::update_latest_risc_timestamp(tt_cxy_pair core, int processor_id, uint64_t timestamp) {
     cores[core].latest_risc_timestamp[processor_id] = timestamp;
 }
@@ -191,29 +241,45 @@ NOCDebugIssue NOCDebugState::get_issues(tt_cxy_pair core, int processor_id) cons
 }
 
 void NOCDebugState::reset_state() {
+    {
+        std::lock_guard<std::mutex> lock{pending_events_mutex_};
+        pending_events_.clear();
+    }
     std::unique_lock<std::mutex> lock{cores_mutex};
     cores.clear();
 }
 
 std::string NOCDebugState::get_issue_description(const NOCDebugIssueType& issue_type) {
-    std::string desc;
     if (issue_type.base_type == NOCDebugIssueBaseType::READ_BARRIER) {
         return "read";
     }
 
-    // For writes, build description based on flags
+    if (issue_type.base_type == NOCDebugIssueBaseType::WRITE_TO_LOCKED_CORE_LOCAL_MEM ||
+        issue_type.base_type == NOCDebugIssueBaseType::WRITE_TO_LOCKED_CB) {
+        const char* locked_type =
+            (issue_type.base_type == NOCDebugIssueBaseType::WRITE_TO_LOCKED_CB) ? "CB" : "core local mem";
+        return fmt::format(
+            "from ({},{}) to ({},{}) addr 0x{:08X} size {} locked {}",
+            static_cast<int>(issue_type.src_x),
+            static_cast<int>(issue_type.src_y),
+            static_cast<int>(issue_type.dst_x),
+            static_cast<int>(issue_type.dst_y),
+            issue_type.issue_address,
+            issue_type.issue_size,
+            locked_type);
+    }
+
+    std::string desc;
     if (issue_type.is_semaphore) {
         desc = "semaphore";
     } else {
         desc = "write";
     }
-
     if (issue_type.is_mcast) {
         desc += " mcast";
     } else {
         desc += " unicast";
     }
-
     return desc;
 }
 
@@ -224,6 +290,7 @@ void NOCDebugState::print_aggregated_errors() const {
     struct CoreIssues {
         std::vector<std::string> write_barrier_issues;
         std::vector<std::string> unflushed_write_issues;  // at end of kernel
+        std::vector<std::string> locked_buffer_issues;
         bool has_read_barrier = false;
     };
     std::map<std::string, CoreIssues> issues_by_core;
@@ -246,6 +313,10 @@ void NOCDebugState::print_aggregated_errors() const {
                     core_issues.has_read_barrier = true;
                 } else if (issue_type.base_type == NOCDebugIssueBaseType::UNFLUSHED_WRITE_AT_END) {
                     core_issues.unflushed_write_issues.push_back(get_issue_description(issue_type));
+                } else if (issue_type.base_type == NOCDebugIssueBaseType::WRITE_TO_LOCKED_CORE_LOCAL_MEM) {
+                    core_issues.locked_buffer_issues.push_back(get_issue_description(issue_type));
+                } else if (issue_type.base_type == NOCDebugIssueBaseType::WRITE_TO_LOCKED_CB) {
+                    core_issues.locked_buffer_issues.push_back(get_issue_description(issue_type));
                 }
             }
         }
@@ -304,33 +375,85 @@ void NOCDebugState::print_aggregated_errors() const {
         }
     }
 
+    for (const auto& [core_key, core_issues] : issues_by_core) {
+        if (!core_issues.locked_buffer_issues.empty()) {
+            log_error(tt::LogMetal, "Write to locked buffer:");
+            break;
+        }
+    }
+    for (const auto& [core_key, core_issues] : issues_by_core) {
+        if (!core_issues.locked_buffer_issues.empty()) {
+            log_error(tt::LogMetal, "  {} [{}]", core_key, fmt::join(core_issues.locked_buffer_issues, ", "));
+        }
+    }
+
     log_error(tt::LogMetal, "========================================");
     log_error(tt::LogMetal, "");
 }
 
 void NOCDebugState::push_event(size_t chip_id, uint64_t timestamp, int processor_id, const NOCDebugEvent& event) {
-    std::unique_lock<std::mutex> lock{cores_mutex};
-    std::visit(
-        [&](auto&& e) {
-            using T = std::decay_t<decltype(e)>;
-            if constexpr (std::is_same_v<T, NocWriteEvent>) {
-                tt_cxy_pair key{chip_id, {static_cast<size_t>(e.src_x), static_cast<size_t>(e.src_y)}};
-                handle_write_event(key, processor_id, timestamp, e);
-            } else if constexpr (std::is_same_v<T, NocReadEvent>) {
-                tt_cxy_pair key{chip_id, {static_cast<size_t>(e.dst_x), static_cast<size_t>(e.dst_y)}};
-                handle_read_event(key, processor_id, timestamp, e);
-            } else if constexpr (std::is_same_v<T, NocReadBarrierEvent>) {
-                tt_cxy_pair key{chip_id, {static_cast<size_t>(e.src_x), static_cast<size_t>(e.src_y)}};
-                handle_read_barrier_event(key, processor_id, timestamp, e);
-            } else if constexpr (std::is_same_v<T, NocWriteBarrierEvent>) {
-                tt_cxy_pair key{chip_id, {static_cast<size_t>(e.src_x), static_cast<size_t>(e.src_y)}};
-                handle_write_barrier_event(key, processor_id, timestamp, e);
-            } else if constexpr (std::is_same_v<T, NocWriteFlushEvent>) {
-                tt_cxy_pair key{chip_id, {static_cast<size_t>(e.src_x), static_cast<size_t>(e.src_y)}};
-                handle_write_flush_event(key, processor_id, timestamp, e);
+    std::lock_guard<std::mutex> lock{pending_events_mutex_};
+    pending_events_.push_back({chip_id, timestamp, processor_id, event});
+}
+
+void NOCDebugState::process_accumulated_events_all_chips() {
+    // Store them immediately because the main thread will still insert events while we are
+    // processing the current batch
+    std::vector<PendingEvent> to_process;
+    {
+        std::lock_guard<std::mutex> lock{pending_events_mutex_};
+        to_process = std::move(pending_events_);
+        pending_events_.clear();
+    }
+    // process in global sorted order
+    std::sort(to_process.begin(), to_process.end(), [](const PendingEvent& a, const PendingEvent& b) {
+        return a.timestamp < b.timestamp;
+    });
+    for (const PendingEvent& entry : to_process) {
+        std::visit(
+            [this, &entry](auto&& e) {
+                using T = std::decay_t<decltype(e)>;
+                const size_t chip_id = entry.chip_id;
+                const uint64_t timestamp = entry.timestamp;
+                const int processor_id = entry.processor_id;
+                if constexpr (std::is_same_v<T, NocWriteEvent>) {
+                    tt_cxy_pair key{chip_id, {static_cast<size_t>(e.src_x), static_cast<size_t>(e.src_y)}};
+                    handle_write_event(key, processor_id, timestamp, e);
+                } else if constexpr (std::is_same_v<T, NocReadEvent>) {
+                    tt_cxy_pair key{chip_id, {static_cast<size_t>(e.dst_x), static_cast<size_t>(e.dst_y)}};
+                    handle_read_event(key, processor_id, timestamp, e);
+                } else if constexpr (std::is_same_v<T, NocReadBarrierEvent>) {
+                    tt_cxy_pair key{chip_id, {static_cast<size_t>(e.src_x), static_cast<size_t>(e.src_y)}};
+                    handle_read_barrier_event(key, processor_id, timestamp, e);
+                } else if constexpr (std::is_same_v<T, NocWriteBarrierEvent>) {
+                    tt_cxy_pair key{chip_id, {static_cast<size_t>(e.src_x), static_cast<size_t>(e.src_y)}};
+                    handle_write_barrier_event(key, processor_id, timestamp, e);
+                } else if constexpr (std::is_same_v<T, NocWriteFlushEvent>) {
+                    tt_cxy_pair key{chip_id, {static_cast<size_t>(e.src_x), static_cast<size_t>(e.src_y)}};
+                    handle_write_flush_event(key, processor_id, timestamp, e);
+                } else if constexpr (std::is_same_v<T, ScopedLockEvent>) {
+                    tt_cxy_pair key{chip_id, {static_cast<size_t>(e.src_x), static_cast<size_t>(e.src_y)}};
+                    handle_scoped_lock_event(key, processor_id, timestamp, e);
+                }
+            },
+            entry.event);
+    }
+}
+
+const NOCDebugState::LockedBufferInfo* NOCDebugState::CoreDebugState::get_noc_write_to_lock_buffer(
+    const NocWriteEvent& event) const {
+    const uint32_t write_start = event.dst_addr;
+    const uint32_t write_end = event.dst_addr + event.num_bytes;
+    const auto& bufs = this->locked_buffers;
+    for (auto proc_id = 0; proc_id < CoreDebugState::MAX_PROCESSORS; ++proc_id) {
+        for (const auto& buf : bufs[proc_id]) {
+            const uint32_t buf_end = buf.address + buf.size;
+            if (write_end > buf.address && buf_end > write_start) {
+                return &buf;
             }
-        },
-        event);
+        }
+    }
+    return nullptr;
 }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/debug/noc_debugging.cpp
+++ b/tt_metal/impl/debug/noc_debugging.cpp
@@ -103,8 +103,8 @@ void NOCDebugState::handle_write_event(tt_cxy_pair core, int processor_id, uint6
             } else {
                 issue_type.base_type = NOCDebugIssueBaseType::WRITE_TO_LOCKED_CB;
             }
-            issue_type.issue_address = locked_buf->address;
-            issue_type.issue_size = locked_buf->size;
+            issue_type.issue_address = event.dst_addr;
+            issue_type.issue_size = event.num_bytes;
             issue_type.src_x = event.src_x;
             issue_type.src_y = event.src_y;
             issue_type.dst_x = event.dst_x;

--- a/tt_metal/impl/debug/noc_debugging.cpp
+++ b/tt_metal/impl/debug/noc_debugging.cpp
@@ -257,7 +257,7 @@ std::string NOCDebugState::get_issue_description(const NOCDebugIssueType& issue_
     if (issue_type.base_type == NOCDebugIssueBaseType::WRITE_TO_LOCKED_CORE_LOCAL_MEM ||
         issue_type.base_type == NOCDebugIssueBaseType::WRITE_TO_LOCKED_CB) {
         const char* locked_type =
-            (issue_type.base_type == NOCDebugIssueBaseType::WRITE_TO_LOCKED_CB) ? "CB" : "core local mem";
+            (issue_type.base_type == NOCDebugIssueBaseType::WRITE_TO_LOCKED_CB) ? "circular buffer" : "core local mem";
         return fmt::format(
             "from ({},{}) to ({},{}) addr 0x{:08X} size {} locked {}",
             static_cast<int>(issue_type.src_x),

--- a/tt_metal/impl/debug/noc_debugging.hpp
+++ b/tt_metal/impl/debug/noc_debugging.hpp
@@ -105,8 +105,8 @@ enum class NOCDebugIssueBaseType : uint8_t {
 // TODO: Move metadata out into a variant so we can have different metadata for each issue types
 struct NOCDebugIssueType {
     NOCDebugIssueBaseType base_type;
-    uint32_t issue_address;  // The address of the issue
-    uint32_t issue_size;     // The size of the issue in bytes
+    uint32_t issue_address;  // The destination address of the violating NOC transaction
+    uint32_t issue_size;     // The size of the violating NOC transaction in bytes
     uint8_t src_x;
     uint8_t src_y;
     uint8_t dst_x;

--- a/tt_metal/impl/debug/noc_debugging.hpp
+++ b/tt_metal/impl/debug/noc_debugging.hpp
@@ -118,6 +118,10 @@ struct NOCDebugIssueType {
         base_type(NOCDebugIssueBaseType::WRITE_FLUSH_BARRIER),
         issue_address(0),
         issue_size(0),
+        src_x(0),
+        src_y(0),
+        dst_x(0),
+        dst_y(0),
         is_mcast(false),
         is_semaphore(false) {}
 

--- a/tt_metal/impl/debug/noc_debugging.hpp
+++ b/tt_metal/impl/debug/noc_debugging.hpp
@@ -104,29 +104,20 @@ enum class NOCDebugIssueBaseType : uint8_t {
 
 // TODO: Move metadata out into a variant so we can have different metadata for each issue types
 struct NOCDebugIssueType {
-    NOCDebugIssueBaseType base_type;
-    uint32_t issue_address;  // The destination address of the violating NOC transaction
-    uint32_t issue_size;     // The size of the violating NOC transaction in bytes
-    uint8_t src_x;
-    uint8_t src_y;
-    uint8_t dst_x;
-    uint8_t dst_y;
-    bool is_mcast : 1;      // True if the issue involved a multicast
-    bool is_semaphore : 1;  // True if the issue involved a semaphore operation
+    NOCDebugIssueBaseType base_type = NOCDebugIssueBaseType::WRITE_FLUSH_BARRIER;
+    uint32_t issue_address = 0;  // The destination address of the violating NOC transaction
+    uint32_t issue_size = 0;     // The size of the violating NOC transaction in bytes
+    uint8_t src_x = 0;
+    uint8_t src_y = 0;
+    uint8_t dst_x = 0;
+    uint8_t dst_y = 0;
+    bool is_mcast : 1 = false;      // True if the issue involved a multicast
+    bool is_semaphore : 1 = false;  // True if the issue involved a semaphore operation
 
-    NOCDebugIssueType() :
-        base_type(NOCDebugIssueBaseType::WRITE_FLUSH_BARRIER),
-        issue_address(0),
-        issue_size(0),
-        src_x(0),
-        src_y(0),
-        dst_x(0),
-        dst_y(0),
-        is_mcast(false),
-        is_semaphore(false) {}
+    NOCDebugIssueType() = default;
 
     NOCDebugIssueType(NOCDebugIssueBaseType type, bool mcast = false, bool semaphore = false) :
-        base_type(type), issue_address(0), issue_size(0), is_mcast(mcast), is_semaphore(semaphore) {}
+        base_type(type), is_mcast(mcast), is_semaphore(semaphore) {}
 
     auto operator<=>(const NOCDebugIssueType& other) const = default;
 };

--- a/tt_metal/impl/debug/noc_debugging.hpp
+++ b/tt_metal/impl/debug/noc_debugging.hpp
@@ -5,12 +5,14 @@
 #pragma once
 
 #include <bitset>
+#include <compare>
 #include <cstdint>
 #include <mutex>
 #include <umd/device/types/xy_pair.hpp>
 #include <unordered_map>
 #include <array>
 #include <tools/profiler/event_metadata.hpp>
+#include <tools/profiler/noc_debugging_metadata.hpp>
 #include <unordered_set>
 #include <set>
 #include <string>
@@ -69,30 +71,58 @@ struct NocWriteFlushEvent {
 
 struct UnknownNocEvent {};
 
+struct ScopedLockEvent {
+    int8_t src_x;
+    int8_t src_y;
+    NocDebuggingEventMetadata::NocDebugEventType event_type;
+    uint32_t locked_address_base;  // 16b aligned
+    uint32_t num_bytes;
+
+    bool is_lock() const {
+        return event_type == NocDebuggingEventMetadata::NocDebugEventType::CB_LOCK ||
+               event_type == NocDebuggingEventMetadata::NocDebugEventType::MEM_LOCK;
+    }
+};
+
 using NOCDebugEvent = std::variant<
     NocWriteEvent,
     NocReadEvent,
     NocReadBarrierEvent,
     NocWriteBarrierEvent,
     NocWriteFlushEvent,
+    ScopedLockEvent,
     UnknownNocEvent>;
 
 enum class NOCDebugIssueBaseType : uint8_t {
     WRITE_FLUSH_BARRIER,
     READ_BARRIER,
     UNFLUSHED_WRITE_AT_END,
+    WRITE_TO_LOCKED_CORE_LOCAL_MEM,
+    WRITE_TO_LOCKED_CB,
     COUNT,
 };
 
+// TODO: Move metadata out into a variant so we can have different metadata for each issue types
 struct NOCDebugIssueType {
     NOCDebugIssueBaseType base_type;
+    uint32_t issue_address;  // The address of the issue
+    uint32_t issue_size;     // The size of the issue in bytes
+    uint8_t src_x;
+    uint8_t src_y;
+    uint8_t dst_x;
+    uint8_t dst_y;
     bool is_mcast : 1;      // True if the issue involved a multicast
     bool is_semaphore : 1;  // True if the issue involved a semaphore operation
 
-    NOCDebugIssueType() : base_type(NOCDebugIssueBaseType::WRITE_FLUSH_BARRIER), is_mcast(false), is_semaphore(false) {}
+    NOCDebugIssueType() :
+        base_type(NOCDebugIssueBaseType::WRITE_FLUSH_BARRIER),
+        issue_address(0),
+        issue_size(0),
+        is_mcast(false),
+        is_semaphore(false) {}
 
     NOCDebugIssueType(NOCDebugIssueBaseType type, bool mcast = false, bool semaphore = false) :
-        base_type(type), is_mcast(mcast), is_semaphore(semaphore) {}
+        base_type(type), issue_address(0), issue_size(0), is_mcast(mcast), is_semaphore(semaphore) {}
 
     auto operator<=>(const NOCDebugIssueType& other) const = default;
 };
@@ -130,8 +160,11 @@ struct NOCDebugIssue {
 
 class NOCDebugState {
 public:
-    // Add an event
+    // Accumulate an event (processed in timestamp order when process_accumulated_events is called)
     void push_event(size_t chip_id, uint64_t timestamp, int processor_id, const NOCDebugEvent& event);
+
+    // Sort accumulated events by timestamp, process them, then clear the queue. Call after a poll is complete.
+    void process_accumulated_events_all_chips();
 
     // Get the issue reported for a given core and processor during the lifetime of the debug state
     NOCDebugIssue get_issues(tt_cxy_pair core, int processor_id) const;
@@ -151,6 +184,19 @@ public:
         int processor_id = 0;
         bool is_semaphore = false;
         bool is_mcast = false;
+    };
+
+    struct LockedBufferInfo {
+        enum class LockType {
+            CB,
+            MEM,
+        };
+
+        uint32_t address;
+        uint32_t size;
+        LockType lock_type;
+
+        auto operator<=>(const LockedBufferInfo& other) const = default;
     };
 
 private:
@@ -175,11 +221,17 @@ private:
         std::array<bool, MAX_NOCS> any_posted_writes{};
         std::array<bool, MAX_NOCS> any_nonposted_writes{};
 
+        // Captures which buffers are marked as locked for each RISC
+        std::array<std::set<LockedBufferInfo>, MAX_PROCESSORS> locked_buffers{};
+
         // Latest RISC timestamp for each processor
         std::array<uint64_t, MAX_PROCESSORS> latest_risc_timestamp{};
 
         // Keep track of reported issues for each processor
         std::array<NOCDebugIssue, MAX_PROCESSORS> issue{};
+
+        // Check if a NOC write hit a locked buffer in this core
+        const LockedBufferInfo* get_noc_write_to_lock_buffer(const NocWriteEvent& event) const;
     };
 
     void handle_write_event(tt_cxy_pair core, int processor_id, uint64_t timestamp, NocWriteEvent event);
@@ -187,6 +239,7 @@ private:
     void handle_read_barrier_event(tt_cxy_pair core, int processor_id, uint64_t timestamp, NocReadBarrierEvent event);
     void handle_write_barrier_event(tt_cxy_pair core, int processor_id, uint64_t timestamp, NocWriteBarrierEvent event);
     void handle_write_flush_event(tt_cxy_pair core, int processor_id, uint64_t timestamp, NocWriteFlushEvent event);
+    void handle_scoped_lock_event(tt_cxy_pair core, int processor_id, uint64_t timestamp, ScopedLockEvent event);
 
     void update_latest_risc_timestamp(tt_cxy_pair core, int processor_id, uint64_t timestamp);
 
@@ -194,7 +247,18 @@ private:
 
     const CoreDebugState& get_state(tt_cxy_pair core) const;
 
+    bool has_state(tt_cxy_pair core) const;
+
     static std::string get_issue_description(const NOCDebugIssueType& issue_type);
+
+    struct PendingEvent {
+        size_t chip_id;
+        uint64_t timestamp;
+        int processor_id;
+        NOCDebugEvent event;
+    };
+    mutable std::vector<PendingEvent> pending_events_;
+    mutable std::mutex pending_events_mutex_;
 
     mutable std::unordered_map<tt_cxy_pair, CoreDebugState> cores;
     mutable std::mutex cores_mutex;

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -50,6 +50,7 @@
 #include "tt_cluster.hpp"
 #include "tools/profiler/perf_counters.hpp"
 #include "debug/noc_debugging.hpp"
+#include "tools/profiler/noc_debugging_metadata.hpp"
 
 #if !defined(TRACY_ENABLE) && defined(__clang__)
 #pragma clang diagnostic push
@@ -564,6 +565,13 @@ auto coalesceFabricEvents(
         std::unordered_map<CoreCoord, std::queue<tracy::TTDeviceMarker>> fabric_mux_markers;
 
         for (size_t i = 0; i < markers.size(); /* manual increment */) {
+            // Scoped lock events (CB_LOCK, CB_UNLOCK, MEM_LOCK, MEM_UNLOCK) use different metadata; pass through as-is.
+            // marker_id is full timer_id; static ID is the low 16 bits.
+            if ((markers[i].marker_id & 0xFFFF) == kernel_profiler::NOC_DEBUGGING_STATIC_ID) {
+                coalesced_events_by_op[program_execution_uid].push_back(markers[i]);
+                i += 1;
+                continue;
+            }
             // If it is a zone, simply copy existing event as-is
             auto current_event = EMD(markers[i].data).getContents();
             TT_FATAL(
@@ -767,6 +775,23 @@ std::unordered_map<experimental::ProgramExecutionUID, nlohmann::json::array_t> c
                         {"zone_phase", enchantum::to_string(zone_phase)},
                         {"sx", device_marker.core_x},
                         {"sy", device_marker.core_y},
+                        {"timestamp", device_marker.timestamp},
+                    });
+                } else if ((device_marker.marker_id & 0xFFFF) == kernel_profiler::NOC_DEBUGGING_STATIC_ID) {
+                    NocDebuggingEventMetadata ev_md(device_marker.data);
+                    json_events_by_op[program_execution_uid].push_back(nlohmann::ordered_json{
+                        {"run_host_id", device_marker.runtime_host_id},
+                        {"op_name", device_marker.op_name},
+                        {"proc", enchantum::to_string(device_marker.risc)},
+                        {"src_device_id", device_marker.chip_id},
+                        {"sx", device_marker.core_x},
+                        {"sy", device_marker.core_y},
+                        {"type", "scoped_lock"},
+                        {"event_type",
+                         enchantum::to_string(
+                             static_cast<NocDebuggingEventMetadata::NocDebugEventType>(ev_md.event_type))},
+                        {"locked_addr", ev_md.getLockedAddressBase()},
+                        {"num_bytes", ev_md.getNumBytes()},
                         {"timestamp", device_marker.timestamp},
                     });
                 } else if (std::holds_alternative<EMD::LocalNocEvent>(EMD(device_marker.data).getContents())) {
@@ -1771,6 +1796,27 @@ void DeviceProfiler::readDeviceMarkerData(
     device_tracy_contexts.try_emplace({device_id, physical_core}, nullptr);
 
     updateFirstTimestamp(timestamp);
+
+    if ((timer_id & 0xFFFF) == kernel_profiler::NOC_DEBUGGING_STATIC_ID) {
+        NOCDebugState* noc_debug_state = MetalContext::instance().noc_debug_state().get();
+        if (noc_debug_state) {
+            const metal_SocDescriptor& soc_desc = MetalContext::instance().get_cluster().get_soc_desc(device_id);
+            // disable linting here; slicing is __intended__
+            // NOLINTBEGIN
+            const CoreCoord virtual_core =
+                soc_desc.translate_coord_to(physical_core, CoordSystem::NOC0, CoordSystem::TRANSLATED);
+            // NOLINTEND
+
+            NocDebuggingEventMetadata ev_md(data);
+            ScopedLockEvent scoped_ev{
+                static_cast<int8_t>(virtual_core.x),
+                static_cast<int8_t>(virtual_core.y),
+                static_cast<NocDebuggingEventMetadata::NocDebugEventType>(ev_md.event_type),
+                ev_md.getLockedAddressBase(),
+                ev_md.getNumBytes()};
+            noc_debug_state->push_event(device_id, timestamp, get_processor_id(risc_type), NOCDebugEvent{scoped_ev});
+        }
+    }
 }
 
 void DeviceProfiler::readTsData16BMarkerData(

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -1797,6 +1797,7 @@ void DeviceProfiler::readDeviceMarkerData(
 
     updateFirstTimestamp(timestamp);
 
+#if defined(TRACY_ENABLE)
     if ((timer_id & 0xFFFF) == kernel_profiler::NOC_DEBUGGING_STATIC_ID) {
         NOCDebugState* noc_debug_state = MetalContext::instance().noc_debug_state().get();
         if (noc_debug_state) {
@@ -1817,6 +1818,7 @@ void DeviceProfiler::readDeviceMarkerData(
             noc_debug_state->push_event(device_id, timestamp, get_processor_id(risc_type), NOCDebugEvent{scoped_ev});
         }
     }
+#endif
 }
 
 void DeviceProfiler::readTsData16BMarkerData(

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -1150,8 +1150,12 @@ void ReadMeshDeviceProfilerResults(
             profiler_state_manager->signal_debug_dump_read();
         }
         if (auto& noc_debug_state = MetalContext::instance().noc_debug_state()) {
+            noc_debug_state->process_accumulated_events_all_chips();
             noc_debug_state->finish_cores();
-            noc_debug_state->print_aggregated_errors();
+            // Only print when called by the user (state == normal) to avoid duplicate printing
+            if (state != ProfilerReadState::LAST_FD_READ) {
+                noc_debug_state->print_aggregated_errors();
+            }
         }
         return;
     }

--- a/tt_metal/tools/profiler/fabric_event_profiler.hpp
+++ b/tt_metal/tools/profiler/fabric_event_profiler.hpp
@@ -9,6 +9,7 @@
 
 #include "tools/profiler/noc_event_profiler.hpp"
 #include "fabric/fabric_edm_packet_header.hpp"
+#include "hostdevcommon/profiler_common.h"
 
 // Type alias for cleaner access to 2D mesh routing constants
 using MeshRoutingFields = tt::tt_fabric::RoutingFieldsConstants::Mesh;
@@ -16,7 +17,7 @@ using MeshRoutingFields = tt::tt_fabric::RoutingFieldsConstants::Mesh;
 namespace kernel_profiler {
 
 // For Unicasts
-template <typename NocAddrU64, uint32_t STATIC_ID = 12345>
+template <typename NocAddrU64, uint32_t STATIC_ID = NOC_TRACING_STATIC_ID>
 FORCE_INLINE void recordFabricNocEvent(
     KernelProfilerNocEventMetadata::NocEventType noc_event_type,
     KernelProfilerNocEventMetadata::FabricPacketType packet_type,
@@ -42,7 +43,7 @@ FORCE_INLINE void recordFabricNocEvent(
     kernel_profiler::timeStampedData<STATIC_ID, kernel_profiler::DoingDispatch::DISPATCH>(ev_md.asU64());
 }
 
-template <uint32_t STATIC_ID = 12345>
+template <uint32_t STATIC_ID = NOC_TRACING_STATIC_ID>
 FORCE_INLINE void recordFabricNocEventMulticast(
     KernelProfilerNocEventMetadata::NocEventType noc_event_type,
     KernelProfilerNocEventMetadata::FabricPacketType packet_type,
@@ -68,7 +69,7 @@ FORCE_INLINE void recordFabricNocEventMulticast(
     kernel_profiler::timeStampedData<STATIC_ID, kernel_profiler::DoingDispatch::DISPATCH>(ev_md.asU64());
 }
 
-template <uint32_t STATIC_ID = 12345>
+template <uint32_t STATIC_ID = NOC_TRACING_STATIC_ID>
 FORCE_INLINE void recordFabricScatterEvent(
     KernelProfilerNocEventMetadata::NocEventType noc_event_type,
     KernelProfilerNocEventMetadata::FabricPacketType packet_type,
@@ -102,7 +103,7 @@ FORCE_INLINE void recordFabricScatterEvent(
     }
 }
 
-template <uint32_t STATIC_ID = 12345>
+template <uint32_t STATIC_ID = NOC_TRACING_STATIC_ID>
 FORCE_INLINE void recordRoutingFields1D(uint32_t routing_fields) {
     KernelProfilerNocEventMetadata event_routing_fields;
     event_routing_fields.data.fabric_routing_fields_1d.noc_xfer_type =
@@ -114,7 +115,7 @@ FORCE_INLINE void recordRoutingFields1D(uint32_t routing_fields) {
 }
 
 // how slow is this? alternative is sotring entire route buffer which isn't ideal either...
-template <uint32_t STATIC_ID = 12345>
+template <uint32_t STATIC_ID = NOC_TRACING_STATIC_ID>
 FORCE_INLINE void recordRoutingFields2D(
     const volatile tt::tt_fabric::LowLatencyMeshRoutingFields routing_fields, const volatile uint8_t* route_buffer) {
     KernelProfilerNocEventMetadata ev_md;

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -767,6 +767,9 @@ __attribute__((noinline)) void trace_only_init() {
 #define RECORD_NOC_EVENT(type, posted, noc)
 #define NOC_TRACE_QUICK_PUSH_IF_LINKED(cmd_buf, linked)
 
+// null macros when noc debugging is disabled
+#define RECORD_SCOPED_LOCK_EVENT(event_type, locked_address_base, num_bytes)
+
 // null macros when perf counters are disabled
 #define StartPerfCounters()
 #define StopPerfCounters()

--- a/tt_metal/tools/profiler/noc_debugging_metadata.hpp
+++ b/tt_metal/tools/profiler/noc_debugging_metadata.hpp
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+// Metadata for NOC debugging / scoped lock events (device records via RECORD_SCOPED_LOCK_EVENT).
+// Static ID for host/device to identify these markers (same pattern as PERF_COUNTER_PROFILER_ID in perf_counters.hpp).
+struct alignas(uint64_t) NocDebuggingEventMetadata {
+    enum class NocDebugEventType : unsigned char {
+        CB_LOCK = 0,
+        CB_UNLOCK = 1,
+        MEM_LOCK = 2,
+        MEM_UNLOCK = 3,
+    };
+
+    union {
+        uint64_t raw;
+        struct {
+            uint64_t event_type : 8;
+            uint64_t locked_addr_16b : 16;
+            uint64_t size_16b : 16;
+            uint64_t reserved : 24;
+        };
+    };
+
+    NocDebuggingEventMetadata() : raw(0) {}
+
+    explicit NocDebuggingEventMetadata(const uint64_t raw_data) : raw(raw_data) {}
+
+    void setEventType(NocDebugEventType type) { event_type = static_cast<uint64_t>(type); }
+
+    void setLockedRegion(uint32_t locked_address_base, uint32_t num_bytes) {
+        locked_addr_16b = locked_address_base >> 4;
+        size_16b = num_bytes >> 4;
+    }
+
+    uint32_t getLockedAddressBase() const { return static_cast<uint32_t>(locked_addr_16b) << 4; }
+    uint32_t getNumBytes() const { return static_cast<uint32_t>(size_16b) << 4; }
+
+    uint64_t asU64() const { return raw; }
+};
+static_assert(sizeof(NocDebuggingEventMetadata) == sizeof(uint64_t));

--- a/tt_metal/tools/profiler/noc_debugging_metadata.hpp
+++ b/tt_metal/tools/profiler/noc_debugging_metadata.hpp
@@ -6,8 +6,6 @@
 
 #include <cstdint>
 
-// Metadata for NOC debugging / scoped lock events (device records via RECORD_SCOPED_LOCK_EVENT).
-// Static ID for host/device to identify these markers (same pattern as PERF_COUNTER_PROFILER_ID in perf_counters.hpp).
 struct alignas(uint64_t) NocDebuggingEventMetadata {
     enum class NocDebugEventType : unsigned char {
         CB_LOCK = 0,

--- a/tt_metal/tools/profiler/noc_debugging_profiler.hpp
+++ b/tt_metal/tools/profiler/noc_debugging_profiler.hpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#if defined(DEVICE_DEBUG_DUMP) && (defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC))
+
+#include "noc_debugging_metadata.hpp"
+#include "internal/risc_attribs.h"
+#include "kernel_profiler.hpp"
+#include "hostdevcommon/profiler_common.h"
+
+namespace noc_debugging_profiler {
+
+template <NocDebuggingEventMetadata::NocDebugEventType event_type>
+FORCE_INLINE void recordScopedLockEvent(uint32_t locked_address_base, uint32_t num_bytes) {
+    NocDebuggingEventMetadata ev_md;
+    ev_md.setEventType(event_type);
+    ev_md.setLockedRegion(locked_address_base, num_bytes);
+
+    kernel_profiler::flush_to_dram_if_full<kernel_profiler::DoingDispatch::DISPATCH>();
+    kernel_profiler::
+        timeStampedData<kernel_profiler::NOC_DEBUGGING_STATIC_ID, kernel_profiler::DoingDispatch::DISPATCH>(
+            ev_md.asU64());
+}
+
+}  // namespace noc_debugging_profiler
+
+#define RECORD_SCOPED_LOCK_EVENT(event_type, locked_address_base, num_bytes) \
+    noc_debugging_profiler::recordScopedLockEvent<event_type>((locked_address_base), (num_bytes))
+
+#else
+
+#define RECORD_SCOPED_LOCK_EVENT(event_type, locked_address_base, num_bytes)
+
+#endif

--- a/tt_metal/tools/profiler/noc_event_profiler.hpp
+++ b/tt_metal/tools/profiler/noc_event_profiler.hpp
@@ -12,6 +12,7 @@
 #include "event_metadata.hpp"
 #include "internal/risc_attribs.h"
 #include "kernel_profiler.hpp"
+#include "hostdevcommon/profiler_common.h"
 
 namespace noc_event_profiler {
 
@@ -70,7 +71,10 @@ FORCE_INLINE KernelProfilerNocEventMetadata createNocEventDstTrailer(uint32_t sr
     return ev_md;
 }
 
-template <KernelProfilerNocEventMetadata::NocEventType noc_event_type, bool posted, uint32_t STATIC_ID = 12345>
+template <
+    KernelProfilerNocEventMetadata::NocEventType noc_event_type,
+    bool posted,
+    uint32_t STATIC_ID = kernel_profiler::NOC_TRACING_STATIC_ID>
 FORCE_INLINE void recordNocEvent(
     int32_t dst_x = -1,
     int32_t dst_y = -1,
@@ -107,7 +111,9 @@ FORCE_INLINE void recordNocEvent(
     }
 }
 
-template <KernelProfilerNocEventMetadata::NocEventType noc_event_type, uint32_t STATIC_ID = 12345>
+template <
+    KernelProfilerNocEventMetadata::NocEventType noc_event_type,
+    uint32_t STATIC_ID = kernel_profiler::NOC_TRACING_STATIC_ID>
 FORCE_INLINE void recordMulticastNocEvent(
     int32_t mcast_dst_start_x,
     int32_t mcast_dst_start_y,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/35425

### Problem description
- We can mark regions of user memory on the device "locked". When a user memory is locked and NOC device 2.0 debugging is enabled, the host can detect if NOC transactions from remote cores are writing into the memory and print a message about the unintended access.

### What's changed
- Replaced the `scoped_lock()` placeholder with the impl in `CircularBuffer` and `CoreLocalMem`. It will release the lock when the returned `Lock` goes out of scope.
- Add a Lock/Unlock event for CBs and L1 memory on the device side. This is placed into a separate struct from the NOC Event Tracing because these events aren't related to the NOC
- Updated the Profiler code to accept the new Lock/Unlock events. They are made distinct from the existing NOC Events by using a different profiler event ID.
- Update NOC Debugging to accept the new events, capture them for each core, and whenever a core executes a NOC Write, it will verify if the write is going to hit a locked buffer on the destination core.
  - This class needed to be updated to first accumulated the events, and then process them as a batch because we need to sort events by global timestamp as the relative order of lock/unlock to the NOC events matter
- Add unit tests & kernels to verify writing to locked L1, unlocked L1, locked CB, unlocked CB, and multiple issues.

Sample Output printed after the debug packets are polled from the device

Noc Write hitting a locked L1
<img width="1139" height="118" alt="image" src="https://github.com/user-attachments/assets/5ff8709b-a45b-4349-bed9-a2f8f7c7ae05" />


Noc Write hitting a locked CB
<img width="1139" height="118" alt="image" src="https://github.com/user-attachments/assets/e161abed-0dee-436c-a105-0aa0fd1a1d03" />

These error messages are not the best. A followup PR will be made to print out logical coordinates as well as the processor name rather than ID.


### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=nhuang/debug-lock)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:nhuang/debug-lock)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nhuang/debug-lock)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nhuang/debug-lock)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nhuang/debug-lock)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nhuang/debug-lock)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early

Profiler CI
https://github.com/tenstorrent/tt-metal/actions/runs/22603248337

Merge Gate
https://github.com/tenstorrent/tt-metal/actions/runs/22603260707

#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nhuang/debug-lock)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nhuang/debug-lock)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nhuang/debug-lock)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nhuang/debug-lock)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nhuang/debug-lock)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nhuang/debug-lock)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
