### PR TITLE
D2D exchange optimizations + 15K Packet size setup

### DIFF
--- a/models/demos/deepseek_v3_b1/micro_ops/host_io/kernels/fused_h2d_receiver_embedding.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/host_io/kernels/fused_h2d_receiver_embedding.cpp
@@ -16,15 +16,14 @@ constexpr bool loopback_mode = get_compile_time_arg_val(4);
 constexpr uint32_t downstream_interface_index = get_compile_time_arg_val(5);
 constexpr uint32_t fabric_packet_header_cb_id = get_compile_time_arg_val(6);
 constexpr uint32_t whole_packet_size = get_compile_time_arg_val(7);
-constexpr uint32_t num_whole_fabric_packets_link_0 = get_compile_time_arg_val(8);
-constexpr uint32_t num_whole_fabric_packets_link_1 = get_compile_time_arg_val(9);
-constexpr uint32_t partial_packet_size = get_compile_time_arg_val(10);
-constexpr bool use_fabric = get_compile_time_arg_val(11);
-constexpr uint32_t embedding_cb_index = get_compile_time_arg_val(12);
-constexpr uint32_t embedding_page_size = get_compile_time_arg_val(13);
-constexpr uint32_t embedding_addr = get_compile_time_arg_val(14);
-// TensorAccessorArgs for embedding tensor at CT arg index 15
-constexpr auto embedding_args = TensorAccessorArgs<15>();
+constexpr uint32_t num_whole_fabric_packets_per_link = get_compile_time_arg_val(8);
+constexpr uint32_t partial_packet_size = get_compile_time_arg_val(9);
+constexpr bool use_fabric = get_compile_time_arg_val(10);
+constexpr uint32_t embedding_cb_index = get_compile_time_arg_val(11);
+constexpr uint32_t embedding_page_size = get_compile_time_arg_val(12);
+constexpr uint32_t embedding_addr = get_compile_time_arg_val(13);
+// TensorAccessorArgs for embedding tensor at CT arg index 14
+constexpr auto embedding_args = TensorAccessorArgs<14>();
 
 FORCE_INLINE bool socket_wait_for_pages_with_termination(
     const SocketReceiverInterface& socket, uint32_t num_pages, volatile tt_l1_ptr uint32_t* termination_semaphore) {
@@ -47,6 +46,7 @@ FORCE_INLINE void write_data_to_local_core_with_ack(
     noc_async_writes_flushed();
 }
 
+template <bool flush = true>
 FORCE_INLINE void write_data_to_remote_core_with_ack(
     tt::tt_fabric::WorkerToFabricEdmSender& fabric_connection,
     volatile tt_l1_ptr PACKET_HEADER_TYPE* packet_header_addr,
@@ -55,11 +55,17 @@ FORCE_INLINE void write_data_to_remote_core_with_ack(
     uint64_t downstream_bytes_sent_noc_addr,
     uint32_t packet_size) {
     packet_header_addr->to_noc_fused_unicast_write_atomic_inc(
-        NocUnicastAtomicIncFusedCommandHeader{dst_addr, downstream_bytes_sent_noc_addr, packet_size}, packet_size);
+        NocUnicastAtomicIncFusedCommandHeader{dst_addr, downstream_bytes_sent_noc_addr, packet_size, false},
+        packet_size);
     fabric_connection.wait_for_empty_write_slot();
     fabric_connection.send_payload_without_header_non_blocking_from_address(l1_read_addr, packet_size);
-    fabric_connection.send_payload_flush_blocking_from_address(
-        (uint32_t)packet_header_addr, sizeof(PACKET_HEADER_TYPE));
+    if constexpr (flush) {
+        fabric_connection.send_payload_flush_blocking_from_address(
+            (uint32_t)packet_header_addr, sizeof(PACKET_HEADER_TYPE));
+    } else {
+        fabric_connection.send_payload_flush_non_blocking_from_address(
+            (uint32_t)packet_header_addr, sizeof(PACKET_HEADER_TYPE));
+    }
 }
 
 FORCE_INLINE void send_pages_over_socket(
@@ -72,36 +78,46 @@ FORCE_INLINE void send_pages_over_socket(
     uint32_t l1_read_addr,
     uint64_t dst_addr) {
     if constexpr (use_fabric) {
-        for (uint32_t i = 0; i < num_whole_fabric_packets_link_0; ++i) {
-            write_data_to_remote_core_with_ack(
+        constexpr uint32_t num_fabric_connections = 2;
+        constexpr uint32_t page_size_per_link = embedding_page_size / num_fabric_connections;
+        uint32_t l1_read_addr_0 = l1_read_addr;
+        uint32_t l1_read_addr_1 = l1_read_addr + page_size_per_link;
+        uint64_t dst_addr_0 = dst_addr;
+        uint64_t dst_addr_1 = dst_addr + page_size_per_link;
+
+        for (uint32_t i = 0; i < num_whole_fabric_packets_per_link; ++i) {
+            write_data_to_remote_core_with_ack<false>(
                 downstream_fabric_connection,
                 downstream_data_packet_header_addr,
-                l1_read_addr,
-                dst_addr,
+                l1_read_addr_0,
+                dst_addr_0,
                 downstream_bytes_sent_noc_addr,
                 whole_packet_size);
-            l1_read_addr += whole_packet_size;
-            dst_addr += whole_packet_size;
-        }
-
-        for (uint32_t i = 0; i < num_whole_fabric_packets_link_1; ++i) {
             write_data_to_remote_core_with_ack(
                 downstream_fabric_connection_2,
                 downstream_data_packet_header_addr_2,
-                l1_read_addr,
-                dst_addr,
+                l1_read_addr_1,
+                dst_addr_1,
                 downstream_bytes_sent_noc_addr,
                 whole_packet_size);
-            l1_read_addr += whole_packet_size;
-            dst_addr += whole_packet_size;
+            l1_read_addr_0 += whole_packet_size;
+            l1_read_addr_1 += whole_packet_size;
+            dst_addr_0 += whole_packet_size;
+            dst_addr_1 += whole_packet_size;
         }
-
         if constexpr (partial_packet_size > 0) {
+            write_data_to_remote_core_with_ack<false>(
+                downstream_fabric_connection,
+                downstream_data_packet_header_addr,
+                l1_read_addr_0,
+                dst_addr_0,
+                downstream_bytes_sent_noc_addr,
+                partial_packet_size);
             write_data_to_remote_core_with_ack(
                 downstream_fabric_connection_2,
                 downstream_data_packet_header_addr_2,
-                l1_read_addr,
-                dst_addr,
+                l1_read_addr_1,
+                dst_addr_1,
                 downstream_bytes_sent_noc_addr,
                 partial_packet_size);
         }

--- a/models/demos/deepseek_v3_b1/micro_ops/host_io/kernels/h2d_receiver.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/host_io/kernels/h2d_receiver.cpp
@@ -16,10 +16,9 @@ constexpr bool loopback_mode = get_compile_time_arg_val(4);
 constexpr uint32_t downstream_interface_index = get_compile_time_arg_val(5);
 constexpr uint32_t fabric_packet_header_cb_id = get_compile_time_arg_val(6);
 constexpr uint32_t whole_packet_size = get_compile_time_arg_val(7);
-constexpr uint32_t num_whole_fabric_packets_link_0 = get_compile_time_arg_val(8);
-constexpr uint32_t num_whole_fabric_packets_link_1 = get_compile_time_arg_val(9);
-constexpr uint32_t partial_packet_size = get_compile_time_arg_val(10);
-constexpr bool use_fabric = get_compile_time_arg_val(11);
+constexpr uint32_t num_whole_fabric_packets_per_link = get_compile_time_arg_val(8);
+constexpr uint32_t partial_packet_size = get_compile_time_arg_val(9);
+constexpr bool use_fabric = get_compile_time_arg_val(10);
 
 FORCE_INLINE bool socket_wait_for_pages_with_termination(
     const SocketReceiverInterface& socket, uint32_t num_pages, volatile tt_l1_ptr uint32_t* termination_semaphore) {
@@ -42,6 +41,7 @@ FORCE_INLINE void write_data_to_local_core_with_ack(
     noc_async_writes_flushed();
 }
 
+template <bool flush = true>
 FORCE_INLINE void write_data_to_remote_core_with_ack(
     tt::tt_fabric::WorkerToFabricEdmSender& fabric_connection,
     volatile tt_l1_ptr PACKET_HEADER_TYPE* packet_header_addr,
@@ -50,11 +50,17 @@ FORCE_INLINE void write_data_to_remote_core_with_ack(
     uint64_t downstream_bytes_sent_noc_addr,
     uint32_t packet_size) {
     packet_header_addr->to_noc_fused_unicast_write_atomic_inc(
-        NocUnicastAtomicIncFusedCommandHeader{dst_addr, downstream_bytes_sent_noc_addr, packet_size}, packet_size);
+        NocUnicastAtomicIncFusedCommandHeader{dst_addr, downstream_bytes_sent_noc_addr, packet_size, false},
+        packet_size);
     fabric_connection.wait_for_empty_write_slot();
     fabric_connection.send_payload_without_header_non_blocking_from_address(l1_read_addr, packet_size);
-    fabric_connection.send_payload_flush_blocking_from_address(
-        (uint32_t)packet_header_addr, sizeof(PACKET_HEADER_TYPE));
+    if constexpr (flush) {
+        fabric_connection.send_payload_flush_blocking_from_address(
+            (uint32_t)packet_header_addr, sizeof(PACKET_HEADER_TYPE));
+    } else {
+        fabric_connection.send_payload_flush_non_blocking_from_address(
+            (uint32_t)packet_header_addr, sizeof(PACKET_HEADER_TYPE));
+    }
 }
 
 FORCE_INLINE void send_pages_over_socket(
@@ -67,36 +73,46 @@ FORCE_INLINE void send_pages_over_socket(
     uint32_t l1_read_addr,
     uint64_t dst_addr) {
     if constexpr (use_fabric) {
-        for (uint32_t i = 0; i < num_whole_fabric_packets_link_0; ++i) {
-            write_data_to_remote_core_with_ack(
+        constexpr uint32_t num_fabric_connections = 2;
+        constexpr uint32_t page_size_per_link = page_size / num_fabric_connections;
+        uint32_t l1_read_addr_0 = l1_read_addr;
+        uint32_t l1_read_addr_1 = l1_read_addr + page_size_per_link;
+        uint64_t dst_addr_0 = dst_addr;
+        uint64_t dst_addr_1 = dst_addr + page_size_per_link;
+
+        for (uint32_t i = 0; i < num_whole_fabric_packets_per_link; ++i) {
+            write_data_to_remote_core_with_ack<false>(
                 downstream_fabric_connection,
                 downstream_data_packet_header_addr,
-                l1_read_addr,
-                dst_addr,
+                l1_read_addr_0,
+                dst_addr_0,
                 downstream_bytes_sent_noc_addr,
                 whole_packet_size);
-            l1_read_addr += whole_packet_size;
-            dst_addr += whole_packet_size;
-        }
-
-        for (uint32_t i = 0; i < num_whole_fabric_packets_link_1; ++i) {
             write_data_to_remote_core_with_ack(
                 downstream_fabric_connection_2,
                 downstream_data_packet_header_addr_2,
-                l1_read_addr,
-                dst_addr,
+                l1_read_addr_1,
+                dst_addr_1,
                 downstream_bytes_sent_noc_addr,
                 whole_packet_size);
-            l1_read_addr += whole_packet_size;
-            dst_addr += whole_packet_size;
+            l1_read_addr_0 += whole_packet_size;
+            l1_read_addr_1 += whole_packet_size;
+            dst_addr_0 += whole_packet_size;
+            dst_addr_1 += whole_packet_size;
         }
-
         if constexpr (partial_packet_size > 0) {
+            write_data_to_remote_core_with_ack<false>(
+                downstream_fabric_connection,
+                downstream_data_packet_header_addr,
+                l1_read_addr_0,
+                dst_addr_0,
+                downstream_bytes_sent_noc_addr,
+                partial_packet_size);
             write_data_to_remote_core_with_ack(
                 downstream_fabric_connection_2,
                 downstream_data_packet_header_addr_2,
-                l1_read_addr,
-                dst_addr,
+                l1_read_addr_1,
+                dst_addr_1,
                 downstream_bytes_sent_noc_addr,
                 partial_packet_size);
         }

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_multi_host_pipeline.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_multi_host_pipeline.py
@@ -56,7 +56,7 @@ def create_fabric_router_config(max_payload_size):
     [
         {
             "fabric_config": ttnn.FabricConfig.FABRIC_2D_TORUS_Y,
-            "fabric_router_config": create_fabric_router_config(7168),
+            "fabric_router_config": create_fabric_router_config(15232),
         }
     ],
     indirect=True,
@@ -241,7 +241,7 @@ def test_multi_host_loopback_pipeline(mesh_device, tensor_size_bytes, fifo_size,
     [
         {
             "fabric_config": ttnn.FabricConfig.FABRIC_2D_TORUS_Y,
-            "fabric_router_config": create_fabric_router_config(7168),
+            "fabric_router_config": create_fabric_router_config(15232),
         }
     ],
     indirect=True,
@@ -450,7 +450,7 @@ def test_multi_host_loopback_pipeline_with_embedding(
     [
         {
             "fabric_config": ttnn.FabricConfig.FABRIC_2D_TORUS_Y,
-            "fabric_router_config": create_fabric_router_config(7168),
+            "fabric_router_config": create_fabric_router_config(15232),
         }
     ],
     indirect=True,


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/38593)

### Problem description
- Pipelining Kernels currently use 7K Max Fabric Packet size
- This is inconsistent with the requirement of using 15K max packet sizes for Blitz

### What's changed
- Add testing for Pipelining with 15K max packet size
- Optimizations to D2D and H2D Fabric usage:
   - Use Fused Unicast Atomic Inc with no-flush since credit and data are sent to the same location
   - Minimize NOC flushes between worker sender and fabric cores
   - Interleave traffic across links instead of batching

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=asaigal/socket_15k_pkt)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:asaigal/socket_15k_pkt)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=asaigal/socket_15k_pkt)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:asaigal/socket_15k_pkt)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=asaigal/socket_15k_pkt)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:asaigal/socket_15k_pkt)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=asaigal/socket_15k_pkt)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:asaigal/socket_15k_pkt)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=asaigal/socket_15k_pkt)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:asaigal/socket_15k_pkt)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=asaigal/socket_15k_pkt)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:asaigal/socket_15k_pkt)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
