### PR TITLE
#38562: Add support for causal mask in blitz sdpa

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
@@ -500,6 +500,7 @@ uint32_t per_core_rta_arg_idx = 0;
             .receiver_ready_semaphore_addr = get_named_compile_time_arg_val("mla_receiver_ready_semaphore_addr"),
             .cb_k_in = get_named_compile_time_arg_val("mla_k_in_cb"),
             .cb_q_in = get_named_compile_time_arg_val("mla_q_in_cb"),
+            .cb_mask = get_named_compile_time_arg_val("mla_mask_cb"),
             .cb_out_in = get_named_compile_time_arg_val("mla_out_in_cb"),
             .cb_ms_in = get_named_compile_time_arg_val("mla_ms_in_cb"),
             .cb_out_ms = get_named_compile_time_arg_val("mla_out_ms_cb"),
@@ -723,6 +724,7 @@ uint32_t per_core_rta_arg_idx = 0;
     using FlashMLACTArgs = deepseek_b1_ops::FlashMLADecode::ComputeCTArgs<
         get_named_compile_time_arg_val("mla_q_in_cb"),
         get_named_compile_time_arg_val("mla_k_in_cb"),
+        get_named_compile_time_arg_val("mla_mask_cb"),
         get_named_compile_time_arg_val("mla_interm_out_cb"),
         get_named_compile_time_arg_val("mla_interm_ms_cb"),
         get_named_compile_time_arg_val("mla_out_in_cb"),

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_sdpa_custom_mm_api.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_sdpa_custom_mm_api.h
@@ -20,9 +20,10 @@ inline void llk_math_sdpa_custom_mm(
     const std::uint32_t operandB,
     const std::uint32_t dst_index,
     const std::uint32_t kt_dim,
-    const std::uint32_t ct_dim = 1) {
+    const std::uint32_t ct_dim = 1,
+    const bool mask_chunk = false) {
     const std::uint32_t operandB_id = get_operand_id(operandA);
     const std::uint32_t operandB_face_r_dim = get_operand_face_r_dim(operandB_id);
 
-    _llk_math_sdpa_custom_mm_(operandB_face_r_dim, dst_index, kt_dim, ct_dim);
+    _llk_math_sdpa_custom_mm_(operandB_face_r_dim, dst_index, kt_dim, ct_dim, mask_chunk);
 }

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_custom_mm_api.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_custom_mm_api.h
@@ -38,9 +38,7 @@ inline void llk_unpack_AB_custom_mm(
     const std::uint32_t tile_index_0,
     const std::uint32_t tile_index_1,
     const std::uint32_t kt_dim,
-    const std::uint32_t ct_dim = 1,
-    const bool mask_chunk = false,
-    const std::uint32_t operand_mask = 0) {
+    const std::uint32_t ct_dim = 1) {
     // Swap operands, for matmul operand0 goes to SrcB and operand1 goes to SrcA
     const std::uint32_t operandA_id = get_operand_id(operand1);
     const std::uint32_t operandB_id = get_operand_id(operand0);
@@ -50,17 +48,7 @@ inline void llk_unpack_AB_custom_mm(
     const std::uint32_t tile_index_B = tile_index_0;
     const std::uint32_t tile_size_A = get_local_cb_interface(operandA_id).fifo_page_size;
     const std::uint32_t tile_size_B = get_local_cb_interface(operandB_id).fifo_page_size;
-    const std::uint32_t mask_address = mask_chunk ? get_local_cb_interface(operand_mask).fifo_rd_ptr - 1 : 0;
 
     _llk_unpack_AB_custom_mm_<read_transposed>(
-        base_address_A,
-        base_address_B,
-        tile_index_A,
-        tile_index_B,
-        tile_size_A,
-        tile_size_B,
-        kt_dim,
-        ct_dim,
-        mask_chunk,
-        mask_address);
+        base_address_A, base_address_B, tile_index_A, tile_index_B, tile_size_A, tile_size_B, kt_dim, ct_dim);
 }

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_custom_mm_api.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_custom_mm_api.h
@@ -38,7 +38,9 @@ inline void llk_unpack_AB_custom_mm(
     const std::uint32_t tile_index_0,
     const std::uint32_t tile_index_1,
     const std::uint32_t kt_dim,
-    const std::uint32_t ct_dim = 1) {
+    const std::uint32_t ct_dim = 1,
+    const bool mask_chunk = false,
+    const std::uint32_t operand_mask = 0) {
     // Swap operands, for matmul operand0 goes to SrcB and operand1 goes to SrcA
     const std::uint32_t operandA_id = get_operand_id(operand1);
     const std::uint32_t operandB_id = get_operand_id(operand0);
@@ -48,7 +50,17 @@ inline void llk_unpack_AB_custom_mm(
     const std::uint32_t tile_index_B = tile_index_0;
     const std::uint32_t tile_size_A = get_local_cb_interface(operandA_id).fifo_page_size;
     const std::uint32_t tile_size_B = get_local_cb_interface(operandB_id).fifo_page_size;
+    const std::uint32_t mask_address = mask_chunk ? get_local_cb_interface(operand_mask).fifo_rd_ptr - 1 : 0;
 
     _llk_unpack_AB_custom_mm_<read_transposed>(
-        base_address_A, base_address_B, tile_index_A, tile_index_B, tile_size_A, tile_size_B, kt_dim, ct_dim);
+        base_address_A,
+        base_address_B,
+        tile_index_A,
+        tile_index_B,
+        tile_size_A,
+        tile_size_B,
+        kt_dim,
+        ct_dim,
+        mask_chunk,
+        mask_address);
 }

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_sdpa_custom_mm_api.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_sdpa_custom_mm_api.h
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include "../../../../../third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_sdpa_custom_mm.h"
+#include "llk_unpack_common_api.h"
+
+template <bool read_transposed = false>
+inline void llk_unpack_AB_sdpa_custom_mm(
+    const std::uint32_t operand0,
+    const std::uint32_t operand1,
+    const std::uint32_t operand_mask,
+    const std::uint32_t tile_index_0,
+    const std::uint32_t tile_index_1,
+    const std::uint32_t kt_dim,
+    const std::uint32_t ct_dim = 1,
+    const bool mask_chunk = false) {
+    // Swap operands, for matmul operand0 goes to SrcB and operand1 goes to SrcA
+    const std::uint32_t operandA_id = get_operand_id(operand1);
+    const std::uint32_t operandB_id = get_operand_id(operand0);
+    const std::uint32_t base_address_A = get_local_cb_interface(operandA_id).fifo_rd_ptr - 1;
+    const std::uint32_t base_address_B = get_local_cb_interface(operandB_id).fifo_rd_ptr - 1;
+    const std::uint32_t tile_index_A = tile_index_1;
+    const std::uint32_t tile_index_B = tile_index_0;
+    const std::uint32_t tile_size_A = get_local_cb_interface(operandA_id).fifo_page_size;
+    const std::uint32_t tile_size_B = get_local_cb_interface(operandB_id).fifo_page_size;
+    const std::uint32_t base_address_mask =
+        mask_chunk ? get_local_cb_interface(get_operand_id(operand_mask)).fifo_rd_ptr - 1 : 0;
+    _llk_unpack_AB_sdpa_custom_mm_<read_transposed>(
+        base_address_A,
+        base_address_B,
+        base_address_mask,
+        tile_index_A,
+        tile_index_B,
+        tile_size_A,
+        tile_size_B,
+        kt_dim,
+        ct_dim,
+        mask_chunk);
+}

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/sdpa_custom_mm.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/sdpa_custom_mm.h
@@ -10,7 +10,7 @@
 #endif
 #ifdef TRISC_UNPACK
 #include "../../hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_custom_mm_api.h"
-#include "../../hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_sdpa_api.h"
+#include "../../hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_sdpa_custom_mm_api.h"
 #endif
 namespace ckernel {
 
@@ -59,8 +59,8 @@ ALWI void sdpa_custom_mm_block(
     const std::uint32_t kt_dim,
     const std::uint32_t ct_dim = 1,
     const bool mask_chunk = false) {
-    UNPACK((llk_unpack_AB_custom_mm<read_transposed>(
-        in0_cb_id, in1_cb_id, in0_tile_index, in1_tile_index, kt_dim, ct_dim, mask_chunk, mask_cb_id)));
+    UNPACK((llk_unpack_AB_sdpa_custom_mm<read_transposed>(
+        in0_cb_id, in1_cb_id, mask_cb_id, in0_tile_index, in1_tile_index, kt_dim, ct_dim, mask_chunk)));
     MATH((llk_math_sdpa_custom_mm(in0_cb_id, in1_cb_id, dst_index, kt_dim, ct_dim, mask_chunk)));
 }
 

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/sdpa_custom_mm.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/sdpa_custom_mm.h
@@ -10,6 +10,7 @@
 #endif
 #ifdef TRISC_UNPACK
 #include "../../hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_custom_mm_api.h"
+#include "../../hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_sdpa_api.h"
 #endif
 namespace ckernel {
 
@@ -51,14 +52,16 @@ template <bool read_transposed = false>
 ALWI void sdpa_custom_mm_block(
     const std::uint32_t in0_cb_id,
     const std::uint32_t in1_cb_id,
+    const std::uint32_t mask_cb_id,
     const std::uint32_t in0_tile_index,
     const std::uint32_t in1_tile_index,
     const std::uint32_t dst_index,
     const std::uint32_t kt_dim,
-    const std::uint32_t ct_dim = 1) {
+    const std::uint32_t ct_dim = 1,
+    const bool mask_chunk = false) {
     UNPACK((llk_unpack_AB_custom_mm<read_transposed>(
-        in0_cb_id, in1_cb_id, in0_tile_index, in1_tile_index, kt_dim, ct_dim)));
-    MATH((llk_math_sdpa_custom_mm(in0_cb_id, in1_cb_id, dst_index, kt_dim, ct_dim)));
+        in0_cb_id, in1_cb_id, in0_tile_index, in1_tile_index, kt_dim, ct_dim, mask_chunk, mask_cb_id)));
+    MATH((llk_math_sdpa_custom_mm(in0_cb_id, in1_cb_id, dst_index, kt_dim, ct_dim, mask_chunk)));
 }
 
 ALWI void sdpa_custom_mm_block_uninit() {

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_custom_mm.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_custom_mm.h
@@ -210,7 +210,9 @@ inline void _llk_unpack_AB_custom_mm_(
     const std::uint32_t tile_size_a,
     const std::uint32_t tile_size_b,
     const std::uint32_t kt_dim,
-    const std::uint32_t ct_dim = 1) {
+    const std::uint32_t ct_dim = 1,
+    const bool mask_chunk = false,
+    const std::uint32_t mask_address = 0) {
     volatile uint* cfg = get_cfg_pointer();
 
     const std::uint32_t block_increment = read_transposed ? kt_dim * tile_size_a : tile_size_a;
@@ -222,6 +224,11 @@ inline void _llk_unpack_AB_custom_mm_(
     // Wait for all contexts to be free
     wait_for_next_context(1);
     reset_config_context();
+
+    if (mask_chunk) {
+        cfg[THCON_SEC1_REG3_Base_cntx1_address_ADDR32] = mask_address;
+        TTI_UNPACR_COMMON_EXPLICIT_CONTEXT(SrcB, 0b00000000, 1, 1);
+    }
 
     // Program SrcB address once, its updated using counters for up to 256 kt_dim
     cfg[THCON_SEC1_REG3_Base_address_ADDR32] = address_b;

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_custom_mm.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_custom_mm.h
@@ -201,7 +201,6 @@ inline void _llk_unpack_AB_custom_mm_init_(const std::uint32_t unpB_face_r_dim, 
     TTI_SETADCXY(0b011, 0, 0, 0, 0, 0b1010);
 }
 
-template <bool read_transposed = false>
 inline void _llk_unpack_AB_custom_mm_run_(
     volatile uint* cfg,
     std::uint32_t address_a,
@@ -314,6 +313,5 @@ inline void _llk_unpack_AB_custom_mm_(
     wait_for_next_context(1);
     reset_config_context();
 
-    _llk_unpack_AB_custom_mm_run_<read_transposed>(
-        cfg, address_a, address_b, block_increment, inner_increment, kt_dim, ct_dim);
+    _llk_unpack_AB_custom_mm_run_(cfg, address_a, address_b, block_increment, inner_increment, kt_dim, ct_dim);
 }

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_custom_mm.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_custom_mm.h
@@ -202,34 +202,14 @@ inline void _llk_unpack_AB_custom_mm_init_(const std::uint32_t unpB_face_r_dim, 
 }
 
 template <bool read_transposed = false>
-inline void _llk_unpack_AB_custom_mm_(
-    const std::uint32_t base_address_a,
-    const std::uint32_t base_address_b,
-    const std::uint32_t tile_index_a,
-    const std::uint32_t tile_index_b,
-    const std::uint32_t tile_size_a,
-    const std::uint32_t tile_size_b,
+inline void _llk_unpack_AB_custom_mm_run_(
+    volatile uint* cfg,
+    std::uint32_t address_a,
+    const std::uint32_t address_b,
+    const std::uint32_t block_increment,
+    const std::uint32_t inner_increment,
     const std::uint32_t kt_dim,
-    const std::uint32_t ct_dim = 1,
-    const bool mask_chunk = false,
-    const std::uint32_t mask_address = 0) {
-    volatile uint* cfg = get_cfg_pointer();
-
-    const std::uint32_t block_increment = read_transposed ? kt_dim * tile_size_a : tile_size_a;
-    const std::uint32_t inner_increment = read_transposed ? tile_size_a : ct_dim * tile_size_a;
-
-    std::uint32_t address_a = base_address_a + tile_size_a * tile_index_a;
-    std::uint32_t address_b = base_address_b + tile_size_b * tile_index_b;
-
-    // Wait for all contexts to be free
-    wait_for_next_context(1);
-    reset_config_context();
-
-    if (mask_chunk) {
-        cfg[THCON_SEC1_REG3_Base_cntx1_address_ADDR32] = mask_address;
-        TTI_UNPACR_COMMON_EXPLICIT_CONTEXT(SrcB, 0b00000000, 1, 1);
-    }
-
+    const std::uint32_t ct_dim) {
     // Program SrcB address once, its updated using counters for up to 256 kt_dim
     cfg[THCON_SEC1_REG3_Base_address_ADDR32] = address_b;
 
@@ -311,4 +291,29 @@ inline void _llk_unpack_AB_custom_mm_(
     // Reset counters at the end
     TTI_SETADCZW(0b011, 0, 0, 0, 0, 0b1111);
     TTI_SETADCXY(0b011, 0, 0, 0, 0, 0b1010);
+}
+
+template <bool read_transposed = false>
+inline void _llk_unpack_AB_custom_mm_(
+    const std::uint32_t base_address_a,
+    const std::uint32_t base_address_b,
+    const std::uint32_t tile_index_a,
+    const std::uint32_t tile_index_b,
+    const std::uint32_t tile_size_a,
+    const std::uint32_t tile_size_b,
+    const std::uint32_t kt_dim,
+    const std::uint32_t ct_dim = 1) {
+    volatile uint* cfg = get_cfg_pointer();
+    const std::uint32_t block_increment = read_transposed ? kt_dim * tile_size_a : tile_size_a;
+    const std::uint32_t inner_increment = read_transposed ? tile_size_a : ct_dim * tile_size_a;
+
+    const std::uint32_t address_a = base_address_a + tile_size_a * tile_index_a;
+    const std::uint32_t address_b = base_address_b + tile_size_b * tile_index_b;
+
+    // Wait for all contexts to be free
+    wait_for_next_context(1);
+    reset_config_context();
+
+    _llk_unpack_AB_custom_mm_run_<read_transposed>(
+        cfg, address_a, address_b, block_increment, inner_increment, kt_dim, ct_dim);
 }

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_sdpa_custom_mm.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_sdpa_custom_mm.h
@@ -45,6 +45,5 @@ inline void _llk_unpack_AB_sdpa_custom_mm_(
         TTI_UNPACR_COMMON_EXPLICIT_CONTEXT(SrcB, 0b00000000, 1, 1);
     }
 
-    _llk_unpack_AB_custom_mm_run_<read_transposed>(
-        cfg, address_a, address_b, block_increment, inner_increment, kt_dim, ct_dim);
+    _llk_unpack_AB_custom_mm_run_(cfg, address_a, address_b, block_increment, inner_increment, kt_dim, ct_dim);
 }

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_sdpa_custom_mm.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_sdpa_custom_mm.h
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "ckernel_globals.h"
+#include "ckernel_ops.h"
+#include "ckernel_template.h"
+#include "cunpack_common.h"
+#include "llk_unpack_AB_custom_mm.h"
+
+using namespace ckernel;
+using namespace ckernel::unpacker;
+
+template <bool read_transposed = false>
+inline void _llk_unpack_AB_sdpa_custom_mm_(
+    const std::uint32_t base_address_a,
+    const std::uint32_t base_address_b,
+    const std::uint32_t base_address_mask,
+    const std::uint32_t tile_index_a,
+    const std::uint32_t tile_index_b,
+    const std::uint32_t tile_size_a,
+    const std::uint32_t tile_size_b,
+    const std::uint32_t kt_dim,
+    const std::uint32_t ct_dim = 1,
+    const bool mask_chunk = false) {
+    volatile uint* cfg = get_cfg_pointer();
+    const std::uint32_t block_increment = read_transposed ? kt_dim * tile_size_a : tile_size_a;
+    const std::uint32_t inner_increment = read_transposed ? tile_size_a : ct_dim * tile_size_a;
+
+    const std::uint32_t address_a = base_address_a + tile_size_a * tile_index_a;
+    const std::uint32_t address_b = base_address_b + tile_size_b * tile_index_b;
+
+    // Wait for all contexts to be free
+    wait_for_next_context(1);
+    reset_config_context();
+
+    if (mask_chunk) {
+        cfg[THCON_SEC1_REG3_Base_cntx1_address_ADDR32] = base_address_mask;
+        TTI_UNPACR_COMMON_EXPLICIT_CONTEXT(SrcB, 0b00000000, 1, 1);
+    }
+
+    _llk_unpack_AB_custom_mm_run_<read_transposed>(
+        cfg, address_a, address_b, block_increment, inner_increment, kt_dim, ct_dim);
+}

--- a/models/demos/deepseek_v3_b1/micro_ops/flash_mla/kernels/flash_mla_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/flash_mla/kernels/flash_mla_kernel.cpp
@@ -91,6 +91,7 @@ void kernel_main() {
         .receiver_ready_semaphore_addr = get_semaphore(get_named_compile_time_arg_val("receiver_ready_semaphore_id")),
         .cb_k_in = get_named_compile_time_arg_val("cb_k_in"),
         .cb_q_in = get_named_compile_time_arg_val("cb_q_in"),
+        .cb_mask = get_named_compile_time_arg_val("cb_mask"),
         .cb_out_in = get_named_compile_time_arg_val("cb_out_in"),
         .cb_ms_in = get_named_compile_time_arg_val("cb_ms_in"),
         .cb_out_ms = get_named_compile_time_arg_val("cb_out_ms"),
@@ -128,6 +129,7 @@ void kernel_main() {
     using FlashMLACTArgs = deepseek_b1_ops::FlashMLADecode::ComputeCTArgs<
         get_named_compile_time_arg_val("cb_q_in"),
         get_named_compile_time_arg_val("cb_k_in"),
+        get_named_compile_time_arg_val("cb_mask"),
         get_named_compile_time_arg_val("cb_interm_out"),
         get_named_compile_time_arg_val("cb_interm_ms"),
         get_named_compile_time_arg_val("cb_out_in"),

--- a/models/demos/deepseek_v3_b1/micro_ops/sdpa/kernels/sdpa_compute.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/sdpa/kernels/sdpa_compute.cpp
@@ -66,6 +66,7 @@ void kernel_main() {
             exp_approx_mode>(
             cb_q,
             cb_k,
+            0,  // cb_mask
             cb_out,
             mm1_dst_offset,
             mm2_dst_offset,
@@ -73,7 +74,8 @@ void kernel_main() {
             sum_dst_offset,
             corr_exp_dst_offset,
             chunk == 0,
-            chunk == num_chunks - 1);
+            chunk == num_chunks - 1,
+            false /* mask_last_chunk */);
     }
 
     // Sem is incremented once per 2 tiles since sem can only go up to 15

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_flash_mla.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_flash_mla.py
@@ -235,9 +235,7 @@ def test_flash_mla_decode(device, batch_size, decode_position, k_chunk_size, max
         # Basic sanity check - output should not be all zeros or NaN
         assert not torch.isnan(output_torch).any(), f"Iteration {i}: Output contains NaN values"
         assert not torch.all(output_torch == 0), f"Iteration {i}: Output is all zeros"
-        torch.set_printoptions(sci_mode=False)
-        print(output_torch)
-        print(reference_output)
+
         if i == 0:
             # First iteration: compare with golden reference and store result
             out_max_diff = torch.max(torch.abs(output_torch - reference_output)).item()

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_flash_mla.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_flash_mla.py
@@ -17,18 +17,50 @@ from models.demos.deepseek_v3_b1.micro_ops.flash_mla.op import FlashMLADecode
 
 
 @pytest.mark.parametrize("batch_size", [1])
-@pytest.mark.parametrize("num_chunks", [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 16, 17, 256])
+@pytest.mark.parametrize(
+    "decode_position",
+    [
+        # Aligned Chunks
+        127,
+        255,
+        383,
+        511,
+        639,
+        767,
+        895,
+        1023,
+        1151,
+        1279,
+        1919,
+        2047,
+        2175,
+        32767,
+        # Unaligned Chunks
+        0,
+        1,
+        2,
+        3,
+        6,
+        7,
+        8,
+        15,
+        16,
+        128,
+        564,
+        1203,
+        2046,
+        32750,
+    ],
+)
 @pytest.mark.parametrize(
     "k_chunk_size", [128]
 )  # Chunk size 256 support can be added by consolidating tensix sem incs since cap is 15 but we have 16 tiles
 @pytest.mark.parametrize("max_seq_len", [32 * 1024])  # 32k max sequence length per chip
-def test_flash_mla_decode(device, batch_size, num_chunks, k_chunk_size, max_seq_len):
+def test_flash_mla_decode(device, batch_size, decode_position, k_chunk_size, max_seq_len):
     """Test FlashMLADecode op."""
     if is_blackhole() and is_watcher_enabled():
         pytest.skip("Skipping test on Blackhole with watcher enabled, see issue #37631")
 
-    # Calculate decode_position from num_chunks and k_chunk_size
-    decode_position = num_chunks * k_chunk_size - 1
     torch.manual_seed(0)
 
     # Debug: Print optimal worker core for each DRAM bank from device API
@@ -48,7 +80,7 @@ def test_flash_mla_decode(device, batch_size, num_chunks, k_chunk_size, max_seq_
     scale = qk_head_dim**-0.5
 
     logger.info(
-        f"Testing FlashMLADecode with batch_size={batch_size}, k_chunk_size={k_chunk_size}, num_chunks={num_chunks}, "
+        f"Testing FlashMLADecode with batch_size={batch_size}, k_chunk_size={k_chunk_size}, "
         f"decode_position={decode_position}, max_seq_len={max_seq_len}"
     )
 
@@ -203,7 +235,9 @@ def test_flash_mla_decode(device, batch_size, num_chunks, k_chunk_size, max_seq_
         # Basic sanity check - output should not be all zeros or NaN
         assert not torch.isnan(output_torch).any(), f"Iteration {i}: Output contains NaN values"
         assert not torch.all(output_torch == 0), f"Iteration {i}: Output is all zeros"
-
+        torch.set_printoptions(sci_mode=False)
+        print(output_torch)
+        print(reference_output)
         if i == 0:
             # First iteration: compare with golden reference and store result
             out_max_diff = torch.max(torch.abs(output_torch - reference_output)).item()

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py
@@ -41,7 +41,7 @@ def create_fabric_router_config(max_payload_size):
 @pytest.mark.parametrize("mesh_rows, mesh_cols", [(4, 2), (1, 1)])
 @pytest.mark.parametrize("num_iters", [(1)])
 @pytest.mark.parametrize(
-    "position_id", [127, 255, 1023]
+    "position_id", [0, 1, 127, 242, 255, 564, 1023]
 )  # Must test 128 chunk aligned decode postions, add other tests when causal masks are in for SDPA
 @pytest.mark.parametrize(
     "device_params",
@@ -545,7 +545,7 @@ def test_pre_sdpa(
     kvpe_dim = KNOPE_DIM + KROPE_DIM
     cache_shape = (1, 1, max_seq_len, kvpe_dim)
     # from 0 to position id, the kv cache is valid, position_id data is filled by test
-    torch_kv_cache = torch.full(cache_shape, float("-inf"), dtype=torch.bfloat16)
+    torch_kv_cache = torch.zeros(cache_shape, dtype=torch.bfloat16)
     for i in range(position_id):
         torch_kv_cache[:, :, i, :] = torch.randn(1, 1, 1, kvpe_dim, dtype=torch.bfloat16)
 

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py
@@ -40,9 +40,7 @@ def create_fabric_router_config(max_payload_size):
 @pytest.mark.parametrize("secondary_cluster_axis", [1])
 @pytest.mark.parametrize("mesh_rows, mesh_cols", [(4, 2), (1, 1)])
 @pytest.mark.parametrize("num_iters", [(1)])
-@pytest.mark.parametrize(
-    "position_id", [0, 1, 127, 242, 255, 564, 1023]
-)  # Must test 128 chunk aligned decode postions, add other tests when causal masks are in for SDPA
+@pytest.mark.parametrize("position_id", [0, 1, 127, 242, 255, 564, 1023])
 @pytest.mark.parametrize(
     "device_params",
     [

--- a/models/demos/deepseek_v3_b1/unified_kernels/flash_mla.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/flash_mla.hpp
@@ -402,7 +402,7 @@ struct FlashMLADecode {
             }
             // Mask logic could be overlapped with the noc txns above, but currently DRAM reading fully overlaps with
             // the mask logic
-            bool mask_last_chunk = k_chunk_end == k_num_chunks;
+            bool mask_last_chunk = k_chunk_end == k_num_chunks && (cur_pos + 1) % args.k_chunk_size != 0;
             if (mask_last_chunk) {
                 DeviceZoneScopedN("mask-last-chunk");
                 cb_reserve_back(args.cb_mask, 1);
@@ -639,7 +639,7 @@ struct FlashMLADecode {
                 sdpa_ms_cb = cb_out_ms;
             }
             uint32_t num_chunks = (k_chunk_end - k_chunk_start + args.num_cores_per_head - 1) / args.num_cores_per_head;
-            bool mask_last_chunk = k_chunk_end == k_num_chunks;
+            bool mask_last_chunk = k_chunk_end == k_num_chunks && (cur_pos + 1) % args.k_chunk_size != 0;
             if (mask_last_chunk) {
                 cb_wait_front(cb_mask, 1);
             }

--- a/models/demos/deepseek_v3_b1/unified_kernels/flash_mla.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/flash_mla.hpp
@@ -79,6 +79,7 @@ struct FlashMLADecode {
     template <
         uint32_t cb_q_in_,
         uint32_t cb_k_in_,
+        uint32_t cb_mask_,
         uint32_t cb_interm_out_,
         uint32_t cb_interm_ms_,
         uint32_t cb_out_in_,
@@ -89,6 +90,7 @@ struct FlashMLADecode {
     struct ComputeCTArgs {
         static constexpr uint32_t cb_q_in = cb_q_in_;
         static constexpr uint32_t cb_k_in = cb_k_in_;
+        static constexpr uint32_t cb_mask = cb_mask_;
         static constexpr uint32_t cb_interm_out = cb_interm_out_;
         static constexpr uint32_t cb_interm_ms = cb_interm_ms_;
         static constexpr uint32_t cb_out_in = cb_out_in_;
@@ -155,6 +157,7 @@ struct FlashMLADecode {
         uint32_t receiver_ready_semaphore_addr;
         uint32_t cb_k_in;
         uint32_t cb_q_in;
+        uint32_t cb_mask;
         uint32_t cb_out_in;
         uint32_t cb_ms_in;
         uint32_t cb_out_ms;
@@ -397,6 +400,27 @@ struct FlashMLADecode {
             if (k_chunk_start == k_chunk_end) {
                 return;
             }
+            // Mask logic could be overlapped with the noc txns above, but currently DRAM reading
+            bool mask_last_chunk = k_chunk_end == k_num_chunks;
+            if (mask_last_chunk) {
+                DeviceZoneScopedN("mask-last-chunk");
+                cb_reserve_back(args.cb_mask, 1);
+                volatile tt_l1_ptr uint32_t* mask_write_ptr =
+                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(args.cb_mask));
+                uint32_t num_unmasked = cur_pos % args.k_chunk_size + 1;
+                uint32_t i = 0;
+                for (; i < num_unmasked / 2; i++) {
+                    *mask_write_ptr++ = 0x00000000;
+                }
+                if (num_unmasked % 2 == 1) {
+                    *mask_write_ptr++ = 0xFF800000;
+                    i++;
+                }
+                for (; i < args.k_chunk_size / 2; i++) {
+                    *mask_write_ptr++ = 0xFF80FF80;
+                }
+                cb_push_back(args.cb_mask, 1);
+            }
 
             // =================================================================
             // KV Cache Multicast (page-level pipelining)
@@ -537,6 +561,7 @@ struct FlashMLADecode {
             constexpr uint32_t dst_size = get_named_compile_time_arg_val("dst_size");
             constexpr uint32_t cb_q_in = CTArgs::cb_q_in;
             constexpr uint32_t cb_k_in = CTArgs::cb_k_in;
+            constexpr uint32_t cb_mask = CTArgs::cb_mask;
             constexpr uint32_t cb_interm_out = CTArgs::cb_interm_out;
             constexpr uint32_t cb_interm_ms = CTArgs::cb_interm_ms;
             constexpr uint32_t cb_out_in = CTArgs::cb_out_in;
@@ -613,11 +638,16 @@ struct FlashMLADecode {
                 sdpa_ms_cb = cb_out_ms;
             }
             uint32_t num_chunks = (k_chunk_end - k_chunk_start + args.num_cores_per_head - 1) / args.num_cores_per_head;
+            bool mask_last_chunk = k_chunk_end == k_num_chunks;
+            if (mask_last_chunk) {
+                cb_wait_front(cb_mask, 1);
+            }
             cb_wait_front(cb_q_in, q_chunk_tiles);
             cb_reserve_back(sdpa_output_cb, vDHt);
             cb_reserve_back(sdpa_ms_cb, Sq_chunk_t);
             tile_regs_acquire();
             for (uint32_t chunk = 0; chunk < num_chunks; chunk++) {
+                bool last_chunk = chunk == (num_chunks - 1);
                 compute_sdpa_chunk<
                     Sk_chunk_t,
                     q_chunk_tiles,
@@ -630,6 +660,7 @@ struct FlashMLADecode {
                     exp_approx_mode>(
                     cb_q_in,
                     cb_k_in,
+                    cb_mask,
                     sdpa_output_cb,
                     mm1_dst_offset,
                     mm2_dst_offset,
@@ -637,7 +668,8 @@ struct FlashMLADecode {
                     sum_dst_offset,
                     corr_exp_dst_offset,
                     chunk == 0,
-                    !sdpa_output_is_final && (chunk == (num_chunks - 1)));
+                    !sdpa_output_is_final && last_chunk,
+                    mask_last_chunk && last_chunk);
             }
             if (!sdpa_output_is_final) {
                 PACK(TTI_STALLWAIT(p_stall::STALL_PACK, p_stall::WAIT_SFPU));
@@ -682,6 +714,9 @@ struct FlashMLADecode {
             }
 
             cb_pop_front(cb_q_in, q_chunk_tiles);
+            if (mask_last_chunk) {
+                cb_pop_front(cb_mask, 1);
+            }
 #endif
         }
     };

--- a/models/demos/deepseek_v3_b1/unified_kernels/flash_mla.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/flash_mla.hpp
@@ -400,7 +400,8 @@ struct FlashMLADecode {
             if (k_chunk_start == k_chunk_end) {
                 return;
             }
-            // Mask logic could be overlapped with the noc txns above, but currently DRAM reading
+            // Mask logic could be overlapped with the noc txns above, but currently DRAM reading fully overlaps with
+            // the mask logic
             bool mask_last_chunk = k_chunk_end == k_num_chunks;
             if (mask_last_chunk) {
                 DeviceZoneScopedN("mask-last-chunk");


### PR DESCRIPTION
### Ticket
#38562

### Problem description
Need to add support for causal mask to support non-chunk-aligned position ids.

### What's changed
Add support for causal mask. We generate a stick the width of the chunk filled with 0s/-infs on risc doing mcasts so that it is fully overlapped with the read of the first kv cache chunk.
Unpack this single tile when the core processes the last chunk, and instead of clearing to zeros before running the first MM, unpack broadcast this into dest so it is automatically added during MVMUL dest accumulation.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=aho/causal-mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:aho/causal-mask)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aho/causal-mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/causal-mask)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aho/causal-mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/causal-mask)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aho/causal-mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/causal-mask)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aho/causal-mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/causal-mask)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aho/causal-mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/causal-mask)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
