### PR TITLE
fix: broken install_dependencies.sh on Debian 12

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -24,7 +24,7 @@ detect_os() {
         . /etc/os-release
         OS_ID="$ID"
         OS_VERSION="$VERSION_ID"
-        OS_CODENAME="${UBUNTU_CODENAME:VERSION_CODENAME}"
+        OS_CODENAME="${UBUNTU_CODENAME:-$VERSION_CODENAME}"
         OS_ID_LIKE="$ID_LIKE"
     else
         echo "Error: /etc/os-release not found. Unsupported system."
@@ -273,25 +273,29 @@ prep_ubuntu_system() {
     apt-get update
     apt-get install -y --no-install-recommends ca-certificates gpg lsb-release wget software-properties-common gnupg jq
 
-    # Add LLVM repository for Clang 17
-    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-    echo "deb http://apt.llvm.org/$OS_CODENAME/ llvm-toolchain-$OS_CODENAME-17 main" | tee /etc/apt/sources.list.d/llvm-17.list
+    # Add LLVM repository using modern keyring approach (apt-key is deprecated)
+    wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /usr/share/keyrings/llvm-archive-keyring.gpg
+    echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/$OS_CODENAME/ llvm-toolchain-$OS_CODENAME-17 main" | tee /etc/apt/sources.list.d/llvm-17.list
     # Also v20
-    echo "deb http://apt.llvm.org/$OS_CODENAME/ llvm-toolchain-$OS_CODENAME-20 main" | tee /etc/apt/sources.list.d/llvm-20.list
+    echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/$OS_CODENAME/ llvm-toolchain-$OS_CODENAME-20 main" | tee /etc/apt/sources.list.d/llvm-20.list
 
-    # Add Kitware repository for latest CMake
-    # If the kitware-archive-keyring package has not been installed previously, manually obtain a copy of our signing key
-    test -f /usr/share/doc/kitware-archive-keyring/copyright || wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+    # Add Kitware repository for latest CMake (Ubuntu only - Kitware doesn't support Debian)
+    if [[ "$OS_ID" == "ubuntu" ]]; then
+        # If the kitware-archive-keyring package has not been installed previously, manually obtain a copy of our signing key
+        test -f /usr/share/doc/kitware-archive-keyring/copyright || wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
 
-    # Add the repository to sources list and update
-    echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ $OS_CODENAME main" | tee /etc/apt/sources.list.d/kitware.list >/dev/null
-    apt-get update
+        # Add the repository to sources list and update
+        echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ $OS_CODENAME main" | tee /etc/apt/sources.list.d/kitware.list >/dev/null
+        apt-get update
 
-    # If the kitware-archive-keyring package was not installed previously, remove the manually obtained key to make room for the package
-    test -f /usr/share/doc/kitware-archive-keyring/copyright || rm /usr/share/keyrings/kitware-archive-keyring.gpg
+        # If the kitware-archive-keyring package was not installed previously, remove the manually obtained key to make room for the package
+        test -f /usr/share/doc/kitware-archive-keyring/copyright || rm /usr/share/keyrings/kitware-archive-keyring.gpg
 
-    # Install the kitware-archive-keyring package to ensure that your keyring stays up to date as keys are rotated
-    apt-get install -y --no-install-recommends kitware-archive-keyring
+        # Install the kitware-archive-keyring package to ensure that your keyring stays up to date as keys are rotated
+        apt-get install -y --no-install-recommends kitware-archive-keyring
+    else
+        echo "[INFO] Skipping Kitware repository for $OS_ID (will use distro CMake package)"
+    fi
 
     # Add GCC toolchain repository for specific g++ versions if needed
     if [[ "$OS_ID" == "ubuntu" ]]; then


### PR DESCRIPTION
## Ticket

Fixes #38832

## Problem

The `install_dependencies.sh` script fails on Debian 12 with malformed apt source entries:

```
deb http://apt.llvm.org// llvm-toolchain--17 main
deb http://apt.llvm.org// llvm-toolchain--20 main
E: Malformed entry 1 in list file /etc/apt/sources.list.d/kitware.list (Component)
E: The list of sources could not be read.
```

## What was broken

### 1. Bash syntax error in OS_CODENAME fallback (line 27)

The script had:
```bash
OS_CODENAME="${UBUNTU_CODENAME:VERSION_CODENAME}"
```

This is **incorrect bash syntax**. Using `:` without `-` performs substring extraction, not default value substitution. On Debian, `UBUNTU_CODENAME` is not set, so this results in an empty string instead of falling back to `VERSION_CODENAME`.

The empty `OS_CODENAME` causes malformed apt source entries like:
- `deb http://apt.llvm.org// llvm-toolchain--17 main` (double slashes, empty codename)

### 2. Deprecated apt-key usage

The script used `apt-key add -` which has been deprecated since Debian 11/Ubuntu 22.04 and generates warnings.

### 3. Kitware repository doesn"t support Debian

The script unconditionally adds the Kitware CMake repository (`apt.kitware.com/ubuntu/`), but Kitware only provides packages for Ubuntu codenames. When run on Debian with its own codename (e.g., "bookworm"), this creates an invalid repository entry that breaks apt.

## What was fixed

1. **Fixed bash syntax** for OS_CODENAME fallback:
   ```bash
   OS_CODENAME="${UBUNTU_CODENAME:-$VERSION_CODENAME}"
   ```

2. **Replaced deprecated apt-key** with modern keyring approach:
   - Download GPG key and convert to keyring file in `/usr/share/keyrings/`
   - Use `signed-by=` parameter in sources.list entries

3. **Skip Kitware repository on Debian**:
   - Added conditional to only add Kitware repo when `OS_ID == "ubuntu"`
   - Debian 12 ships with CMake 3.25.1 which is sufficient for building
   - Added informational log message when skipping

## Testing

- Script syntax validated with bash -n
- Changes are minimal and targeted to the specific issues reported

## Checklist

- [x] PR title follows conventional commits format
- [x] Changes address all issues described in #38832
- [x] No unrelated changes included