### PR TITLE
[skip ci] Simplify ClangSA bug path context for Copilot autofix

### DIFF
--- a/.github/workflows/copilot-autofix-clangsa.yaml
+++ b/.github/workflows/copilot-autofix-clangsa.yaml
@@ -112,6 +112,71 @@ jobs:
           path: attempted_hashes.txt
           key: copilot-autofix-clangsa-attempted-${{ github.run_id }}
 
+      - name: Build Copilot prompt with bug path context
+        if: steps.select-issue.outputs.has-issue == 'true'
+        env:
+          ISSUE_HASH: ${{ steps.select-issue.outputs.hash }}
+          ISSUE_CHECKER: ${{ steps.select-issue.outputs.checker }}
+          ISSUE_FILE: ${{ steps.select-issue.outputs.file }}
+          ISSUE_LINE: ${{ steps.select-issue.outputs.line }}
+          ISSUE_MESSAGE: ${{ steps.select-issue.outputs.message }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PYEOF'
+          import json, os
+
+          repo   = os.environ.get("GITHUB_WORKSPACE", ".")
+          rhash  = os.environ["ISSUE_HASH"]
+          checker = os.environ["ISSUE_CHECKER"]
+          filepath = os.environ["ISSUE_FILE"]
+          line   = os.environ["ISSUE_LINE"]
+          msg    = os.environ["ISSUE_MESSAGE"]
+
+          # Look up the full report to get bug_path_events
+          bug_path_text = ""
+          try:
+              with open("clangsa-results/codechecker_issues.json") as f:
+                  reports = json.load(f).get("reports", [])
+              report = next((r for r in reports if r["report_hash"] == rhash), None)
+              events = report.get("bug_path_events", []) if report else []
+
+              if len(events) > 1:
+                  lines = ["", "Bug path (sequence of events leading to the finding):"]
+                  seen = set()
+                  for i, ev in enumerate(events, 1):
+                      ep = ev["file"]["path"].replace("/work/", "", 1)
+                      el, ec = ev.get("line", 0), ev.get("column", 0)
+                      em = ev.get("message", "")
+                      key = (ep, el)
+                      if key in seen:
+                          continue
+                      seen.add(key)
+                      lines.append(f"\n  Step {len(seen)}: {ep}:{el}:{ec} -- {em}")
+                      # Show source snippet (2 lines of context)
+                      try:
+                          src = open(os.path.join(repo, ep)).read().splitlines()
+                          lo, hi = max(0, el - 3), min(len(src), el + 2)
+                          for n in range(lo, hi):
+                              marker = " >> " if n + 1 == el else "    "
+                              lines.append(f"  {marker}{n+1:4d} | {src[n]}")
+                      except OSError:
+                          pass
+                  bug_path_text = "\n".join(lines)
+          except Exception as e:
+              print(f"Warning: could not extract bug path: {e}")
+
+          with open("/tmp/prompt.txt", "w") as f:
+              f.write(f"Fix this Clang Static Analyzer issue. "
+                      f"Verify it is a real issue, apply a minimal fix, and follow coding standards.\n\n"
+                      f"Checker: {checker}\n"
+                      f"File: {filepath}:{line}\n"
+                      f"Message: {msg}\n"
+                      f"{bug_path_text}\n")
+          PYEOF
+          echo "--- Copilot prompt ---"
+          cat /tmp/prompt.txt
+          echo "--- end prompt ---"
+
       - name: Run Copilot fix
         if: steps.select-issue.outputs.has-issue == 'true'
         id: copilot-fix
@@ -128,22 +193,6 @@ jobs:
             exit 1
           fi
           echo "$COPILOT_OAUTH_TOKEN" | gh auth login --with-token
-
-          # Build prompt
-          CHECKER="${{ steps.select-issue.outputs.checker }}"
-          FILE="${{ steps.select-issue.outputs.file }}"
-          LINE="${{ steps.select-issue.outputs.line }}"
-          MSG="${{ steps.select-issue.outputs.message }}"
-
-          {
-            echo "Fix this Clang Static Analyzer issue:"
-            echo ""
-            echo "- $CHECKER in $FILE:$LINE — $MSG"
-            echo ""
-            echo "Verify it's a real issue, apply minimal fix, follow coding standards."
-          } > /tmp/prompt.txt
-
-          cat /tmp/prompt.txt
 
           # Run Copilot
           BASE_BRANCH="${{ github.event_name == 'schedule' && 'main' || github.ref_name }}"

--- a/.github/workflows/copilot-autofix-clangsa.yaml
+++ b/.github/workflows/copilot-autofix-clangsa.yaml
@@ -210,10 +210,14 @@ jobs:
           # Run Copilot
           BASE_BRANCH="${{ github.event_name == 'schedule' && 'main' || github.ref_name }}"
 
+          # Note: --follow streams session logs but may exit non-zero due to
+          # a gh CLI v2.87.x regression (cli/cli#12729). The agent task itself
+          # still completes successfully, so we tolerate follow failures.
           gh agent-task create -F /tmp/prompt.txt \
             --base "$BASE_BRANCH" \
             --repo "${{ github.repository }}" \
-            --follow
+            --follow \
+          || echo "::warning::--follow exited with $? (known gh CLI issue); checking task result..."
 
           # Get the PR that was created
           PR_NUMBER=$(gh agent-task list --limit 1 | grep -oE '#[0-9]+' | tr -d '#' || true)

--- a/.github/workflows/copilot-autofix-clangsa.yaml
+++ b/.github/workflows/copilot-autofix-clangsa.yaml
@@ -125,12 +125,24 @@ jobs:
           python3 - <<'PYEOF'
           import json, os
 
-          repo   = os.environ.get("GITHUB_WORKSPACE", ".")
+          repo   = os.path.realpath(os.environ.get("GITHUB_WORKSPACE", "."))
           rhash  = os.environ["ISSUE_HASH"]
           checker = os.environ["ISSUE_CHECKER"]
           filepath = os.environ["ISSUE_FILE"]
           line   = os.environ["ISSUE_LINE"]
           msg    = os.environ["ISSUE_MESSAGE"]
+
+          def strip_prefix(p, prefix="/work/"):
+              return p[len(prefix):] if p.startswith(prefix) else p
+
+          def read_lines(path, cache={}):
+              if path not in cache:
+                  try:
+                      with open(path, encoding="utf-8", errors="replace") as f:
+                          cache[path] = f.read().splitlines()
+                  except OSError:
+                      cache[path] = None
+              return cache[path]
 
           # Look up the full report to get bug_path_events
           bug_path_text = ""
@@ -144,7 +156,7 @@ jobs:
                   lines = ["", "Bug path (sequence of events leading to the finding):"]
                   seen = set()
                   for i, ev in enumerate(events, 1):
-                      ep = ev["file"]["path"].replace("/work/", "", 1)
+                      ep = strip_prefix(ev["file"]["path"])
                       el, ec = ev.get("line", 0), ev.get("column", 0)
                       em = ev.get("message", "")
                       key = (ep, el)
@@ -153,14 +165,15 @@ jobs:
                       seen.add(key)
                       lines.append(f"\n  Step {len(seen)}: {ep}:{el}:{ec} -- {em}")
                       # Show source snippet (2 lines of context)
-                      try:
-                          src = open(os.path.join(repo, ep)).read().splitlines()
+                      full = os.path.realpath(os.path.join(repo, ep))
+                      if not full.startswith(repo):
+                          continue
+                      src = read_lines(full)
+                      if src and 0 < el <= len(src):
                           lo, hi = max(0, el - 3), min(len(src), el + 2)
                           for n in range(lo, hi):
                               marker = " >> " if n + 1 == el else "    "
                               lines.append(f"  {marker}{n+1:4d} | {src[n]}")
-                      except OSError:
-                          pass
                   bug_path_text = "\n".join(lines)
           except Exception as e:
               print(f"Warning: could not extract bug path: {e}")


### PR DESCRIPTION
## Ticket
Closes https://github.com/tenstorrent/tt-metal/issues/37368

## Summary

Simpler alternative to #38329 that achieves the same goal: giving Copilot rich bug-path context when generating fixes for Clang Static Analyzer findings.

## What changed

**One workflow file, one new step, zero new files.**

A single `Build Copilot prompt with bug path context` step uses ~35 lines of inline Python to:

1. Look up the selected report by `report_hash` in `codechecker_issues.json`
2. Walk `bug_path_events`, deduplicating by `(file, line)`
3. Show 2 lines of source context around each step from the checked-out repo
4. Fall back gracefully when the bug path has ≤1 event (e.g. padding warnings)

### Before (existing main)
```
Fix this Clang Static Analyzer issue:

- core.NullDereference in foo.cpp:208 — Dereference of undefined pointer value

Verify it's a real issue, apply minimal fix, follow coding standards.
```

### After (this PR)
```
Fix this Clang Static Analyzer issue. Verify it is a real issue, apply a minimal fix, and follow coding standards.

Checker: core.NullDereference
File: foo.cpp:208
Message: Dereference of undefined pointer value

Bug path (sequence of events leading to the finding):

  Step 1: foo.cpp:64:9 -- Assuming the condition is false
       62 |   ...
   >>  64 |   if (some_condition) {
       66 |   ...

  Step 2: foo.cpp:97:9 -- Assuming 'is_input_sharded' is false
       95 |   ...
   >>  97 |   if (is_input_sharded) {
       99 |   ...

  ...

  Step 11: foo.cpp:208:13 -- Dereference of undefined pointer value
      206 |   ...
   >> 208 |   ptr->doThing();
      210 |   ...
```

## Comparison with #38329

| | PR #38329 | This PR |
|---|---|---|
| New files | 2 (action.yml + 241-line Python script) | 0 |
| New workflow steps | 3 | 1 |
| Lines added | 353 | 65 |
| Composite action | Yes | No |
| awk post-processing | Yes (extract single finding from all-findings report) | No (queries the specific report directly) |
| Source snippets | Yes | Yes |
| Bug path dedup | No | Yes (by file+line) |
| Fallback for simple findings | Yes | Yes (implicit — skips bug path if ≤1 event) |

Both approaches produce equivalent Copilot prompts. This PR eliminates the indirection of a separate action and script by processing only the single selected finding inline, rather than generating a report for all findings and then extracting one.