### PR TITLE
add "fast path" for neighbour exchange. 

### DIFF
--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -1278,6 +1278,23 @@ FabricEriscDatamoverBuilder::CompileTimeArgs FabricEriscDatamoverBuilder::get_co
         named_args["DISABLE_RX_CH1_FORWARDING"] = 0;
     }
 
+    // Credit amortization named compile-time args
+    // Only enabled when there is a single sender channel (common 1D case)
+    uint32_t sender_amort_freq = 0;
+    uint32_t receiver_amort_freq = 0;
+    if (num_sender_channels == 1) {
+        auto* static_alloc =
+            dynamic_cast<tt::tt_fabric::FabricStaticSizedChannelsAllocator*>(config.channel_allocator.get());
+        if (static_alloc != nullptr) {
+            uint32_t receiver_slots = static_cast<uint32_t>(static_alloc->get_receiver_channel_number_of_slots(0));
+            uint32_t sender_slots = static_cast<uint32_t>(static_alloc->get_sender_channel_number_of_slots(0));
+            receiver_amort_freq = std::max<uint32_t>(std::min<uint32_t>(4u, receiver_slots / 2), 1);
+            sender_amort_freq = std::max<uint32_t>(std::min<uint32_t>(2u, sender_slots / 2), 1);
+        }
+    }
+    named_args["SENDER_CREDIT_AMORTIZATION_FREQUENCY"] = sender_amort_freq;
+    named_args["RECEIVER_CREDIT_AMORTIZATION_FREQUENCY"] = receiver_amort_freq;
+
     return {std::move(ct_args), std::move(named_args)};
 }
 

--- a/tt_metal/fabric/fabric_edm_packet_header.hpp
+++ b/tt_metal/fabric/fabric_edm_packet_header.hpp
@@ -393,6 +393,23 @@ public:
     // otherwise.
     uint8_t src_ch_id;
 
+    // Packed representation of the 4 bytes at offset 40: payload_size_bytes(2B) + noc_send_type(1B) + src_ch_id(1B).
+    // A single 4B aligned load avoids two separate uncached L1 reads.
+    struct PackedPayloadAndSendType {
+        uint16_t payload_size_bytes;
+        NocSendType noc_send_type;
+
+        static PackedPayloadAndSendType load(const volatile Derived* hdr) {
+            // offset 40 from header start is 4B-aligned (sizeof(NocCommandFields)==40)
+            auto raw = *reinterpret_cast<const volatile uint32_t*>(
+                reinterpret_cast<uintptr_t>(hdr) + offsetof(PacketHeaderBase, payload_size_bytes));
+            PackedPayloadAndSendType result;
+            result.payload_size_bytes = static_cast<uint16_t>(raw & 0xFFFF);
+            result.noc_send_type = static_cast<NocSendType>((raw >> 16) & 0xFF);
+            return result;
+        }
+    };
+
     // Returns size of payload in bytes - TODO: convert to words (4B)
     size_t get_payload_size_excluding_header() volatile const { return this->payload_size_bytes; }
 

--- a/tt_metal/fabric/fabric_edm_packet_header.hpp
+++ b/tt_metal/fabric/fabric_edm_packet_header.hpp
@@ -400,6 +400,9 @@ public:
         NocSendType noc_send_type;
 
         static PackedPayloadAndSendType load(const volatile Derived* hdr) {
+            static_assert(
+                offsetof(PacketHeaderBase, payload_size_bytes) % 4 == 0,
+                "payload_size_bytes must be 4B-aligned for packed load to function properly");
             // offset 40 from header start is 4B-aligned (sizeof(NocCommandFields)==40)
             auto raw = *reinterpret_cast<const volatile uint32_t*>(
                 reinterpret_cast<uintptr_t>(hdr) + offsetof(PacketHeaderBase, payload_size_bytes));

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_edm_packet_transmission.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_edm_packet_transmission.hpp
@@ -121,16 +121,18 @@ FORCE_INLINE void flush_write_to_noc_pipeline(uint8_t rx_channel_id) {
 // Shifts the chunk encoding in a scatter write packet to the next chunk
 FORCE_INLINE void shift_to_next_chunk(uint8_t& chunk_encodings) { chunk_encodings >>= 2; }
 
-// Since we unicast to local, we must omit the packet header
-// This function only does reads, and within scope there are no modifications to the packet header
+// Core implementation of unicast-to-local-chip dispatch.
+// Accepts pre-resolved payload_size_bytes and noc_send_type to avoid redundant uncached L1 reads
+// when the caller has already loaded these (e.g. via a packed 4B load).
 __attribute__((optimize("jump-tables")))
 #ifndef FABRIC_2D
 FORCE_INLINE
 #endif
     void
-    execute_chip_unicast_to_local_chip(
+    execute_chip_unicast_to_local_chip_impl(
         tt_l1_ptr PACKET_HEADER_TYPE* const packet_start,
         uint16_t payload_size_bytes,
+        tt::tt_fabric::NocSendType noc_send_type,
         uint32_t transaction_id,
         uint8_t rx_channel_id) {
     const auto& header = *packet_start;
@@ -138,7 +140,6 @@ FORCE_INLINE
 
     constexpr bool update_counter = false;
 
-    tt::tt_fabric::NocSendType noc_send_type = header.noc_send_type;
     channel_trimming_usage_recorder.set_noc_send_type_used(rx_channel_id, noc_send_type);
     if (noc_send_type > tt::tt_fabric::NocSendType::NOC_SEND_TYPE_LAST) {
         __builtin_unreachable();
@@ -296,6 +297,25 @@ FORCE_INLINE
             ASSERT(false);
         } break;
     };
+}
+
+// Wrapper that resolves noc_send_type from the packet header via a packed 4B load
+// (payload_size_bytes + noc_send_type in one read), then delegates to the core implementation.
+// The caller-provided payload_size_bytes is still used (not the packed copy) to preserve
+// existing call-site semantics.
+__attribute__((optimize("jump-tables")))
+#ifndef FABRIC_2D
+FORCE_INLINE
+#endif
+    void
+    execute_chip_unicast_to_local_chip(
+        tt_l1_ptr PACKET_HEADER_TYPE* const packet_start,
+        uint16_t payload_size_bytes,
+        uint32_t transaction_id,
+        uint8_t rx_channel_id) {
+    auto packed = PACKET_HEADER_TYPE::PackedPayloadAndSendType::load(packet_start);
+    execute_chip_unicast_to_local_chip_impl(
+        packet_start, payload_size_bytes, packed.noc_send_type, transaction_id, rx_channel_id);
 }
 
 // Forward packet to local relay in UDM mode

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
@@ -714,3 +714,11 @@ using ChannelTrimmingUsagePtr = tt::tt_fabric::FabricDatapathUsageL1Ptr<
     MAX_NUM_RECEIVER_CHANNELS,
     MAX_NUM_SENDER_CHANNELS>;
 constexpr ChannelTrimmingUsagePtr channel_trimming_usage_recorder{};
+
+//-------------------------------- Credit Amortization --------------------------------//
+constexpr uint32_t SENDER_CREDIT_AMORTIZATION_FREQUENCY =
+    get_named_compile_time_arg_val("SENDER_CREDIT_AMORTIZATION_FREQUENCY");
+constexpr uint32_t RECEIVER_CREDIT_AMORTIZATION_FREQUENCY =
+    get_named_compile_time_arg_val("RECEIVER_CREDIT_AMORTIZATION_FREQUENCY");
+constexpr bool super_speedy_mode =
+    SENDER_CREDIT_AMORTIZATION_FREQUENCY > 0 && RECEIVER_CREDIT_AMORTIZATION_FREQUENCY > 0;

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_speedy_path.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_speedy_path.hpp
@@ -1,0 +1,226 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// This header provides amortized credit-passing "speedy" step functions for the
+// fabric erisc router.  They are only used when super_speedy_mode == true
+// (single sender channel with non-zero amortization frequencies).
+//
+// Must be included AFTER fabric_erisc_router_ct_args.hpp and all other router
+// headers that define helpers such as send_next_data, send_credits_to_upstream_workers,
+// receiver_send_completion_ack, receiver_send_received_ack, etc.
+
+static_assert(
+    !super_speedy_mode || !enable_deadlock_avoidance,
+    "super_speedy_mode is incompatible with deadlock avoidance (bubble flow control)");
+static_assert(!super_speedy_mode || NUM_SENDER_CHANNELS == 1, "super_speedy_mode requires exactly 1 sender channel");
+
+static size_t completion_count = 0;
+
+/*
+ * A fast neighbour exchange only sender channel step impl
+ */
+template <
+    uint8_t sender_channel_index,
+    uint8_t to_receiver_pkts_sent_id,
+    bool enable_first_level_ack,
+    typename SenderChannelT,
+    typename WorkerInterfaceT,
+    typename ReceiverPointersT,
+    typename ReceiverChannelT,
+    typename LocalTelemetryT>
+FORCE_INLINE bool run_sender_channel_step_speedy(
+    SenderChannelT& local_sender_channel,
+    WorkerInterfaceT& local_sender_channel_worker_interface,
+    ReceiverPointersT& outbound_to_receiver_channel_pointers,
+    ReceiverChannelT& remote_receiver_channel,
+    bool& channel_connection_established,
+    uint32_t sender_channel_free_slots_stream_id,
+    SenderChannelFromReceiverCredits& sender_channel_from_receiver_credits,
+    PerfTelemetryRecorder& perf_telemetry_recorder,
+    LocalTelemetryT& local_fabric_telemetry,
+    uint32_t& sender_amort_counter) {
+    bool progress = false;
+
+    bool receiver_has_space_for_packet = outbound_to_receiver_channel_pointers.has_space_for_packet();
+    uint32_t free_slots = get_ptr_val(sender_channel_free_slots_stream_id);
+    bool has_unsent_packet = free_slots != WorkerInterfaceT::num_buffers;
+    bool can_send = receiver_has_space_for_packet && has_unsent_packet;
+
+    if constexpr (!ETH_TXQ_SPIN_WAIT_SEND_NEXT_DATA) {
+        can_send = can_send && !internal_::eth_txq_is_busy(sender_txq_id);
+    }
+
+    if (can_send) {
+        progress = true;
+
+        auto* pkt_header = reinterpret_cast<volatile tt_l1_ptr PACKET_HEADER_TYPE*>(
+            local_sender_channel.get_cached_next_buffer_slot_addr());
+        // explicit inline of send next data shaves about 9 cycles off the send time due to more efficient code-gen
+        {
+            auto& remote_receiver_num_free_slots = outbound_to_receiver_channel_pointers.num_free_slots;
+            uint32_t src_addr = local_sender_channel.get_cached_next_buffer_slot_addr();
+
+            const size_t payload_size_bytes = pkt_header->get_payload_size_including_header();
+
+            bool busy = internal_::eth_txq_is_busy(sender_txq_id);
+
+            const auto dest_addr = outbound_to_receiver_channel_pointers.remote_receiver_channel_address_ptr;
+
+            if constexpr (ETH_TXQ_SPIN_WAIT_SEND_NEXT_DATA) {
+                while (busy) {
+                    busy = internal_::eth_txq_is_busy(sender_txq_id);
+                }
+            }
+            internal_::eth_send_packet_bytes_unsafe(sender_txq_id, src_addr, dest_addr, payload_size_bytes);
+
+            // Note: We can only advance to the next buffer index if we have fully completed the send (both the payload
+            // and sync messages)
+            local_sender_channel_worker_interface.template update_write_counter_for_send<false /*SKIP_LIVENESS*/>();
+
+            // Advance receiver buffer pointers
+            busy = internal_::eth_txq_is_busy(sender_txq_id);
+            outbound_to_receiver_channel_pointers.advance_remote_receiver_buffer_pointer();
+            local_sender_channel.advance_to_next_cached_buffer_slot_addr();
+            remote_receiver_num_free_slots--;
+
+            record_packet_send(perf_telemetry_recorder, sender_channel_index, payload_size_bytes);
+
+            while (busy) {
+                busy = internal_::eth_txq_is_busy(sender_txq_id);
+            };
+            remote_update_ptr_val<to_receiver_pkts_sent_id, sender_txq_id>(1U);
+        }
+        sender_amort_counter++;
+        if constexpr (FABRIC_TELEMETRY_BANDWIDTH) {
+            update_bw_counters(pkt_header, local_fabric_telemetry);
+        }
+        increment_local_update_ptr_val(sender_channel_free_slots_stream_id, 1);
+    }
+
+    // We only want to actually bother checking for completions after a certain number of sent packets are outstanding
+    // since the instructions to actually process each inbound completion from receiver is somewhat costly
+    bool check_completions = sender_amort_counter > SENDER_CREDIT_AMORTIZATION_FREQUENCY;
+    if (check_completions) {
+        int32_t completions = sender_channel_from_receiver_credits
+                                  .template get_num_unprocessed_completions_from_receiver<ENABLE_RISC_CPU_DATA_CACHE>();
+        if (completions) {
+            outbound_to_receiver_channel_pointers.num_free_slots += completions;
+            sender_channel_from_receiver_credits.increment_num_processed_completions(completions);
+
+            completion_count += completions;
+        }
+    }
+
+    // Similarly only send back the credit to the worker very infrequently since it's a very
+    // expensive operation.
+    bool send_credits = completion_count >= SENDER_CREDIT_AMORTIZATION_FREQUENCY;
+    if (send_credits) {
+        send_credits_to_upstream_workers<false /*deadlock_avoidance*/, false /*SKIP_LIVENESS*/>(
+            local_sender_channel_worker_interface, completion_count, channel_connection_established);
+        sender_amort_counter -= completion_count;
+        completion_count = 0;
+    }
+    return progress;
+}
+
+/*
+ * A fast neighbour exchange only receiver channel step impl
+ */
+static uint32_t unacked_sends = 0;
+static constexpr uint8_t pingpong_trid_a = RX_CH_TRID_STARTS[0];
+static constexpr uint8_t pingpong_trid_b = RX_CH_TRID_STARTS[0] + 1;
+static_assert(
+    !super_speedy_mode || NUM_TRANSACTION_IDS >= 2,
+    "Ping-pong TRID requires at least 2 transaction IDs per receiver channel");
+static_assert(!super_speedy_mode || pingpong_trid_a == 0, "Ping-pong TRID flip uses '1 - trid', requires trid_a == 0");
+static uint8_t current_write_trid = pingpong_trid_a;
+static uint8_t pending_flush_trid = pingpong_trid_b;
+static uint32_t pending_flush_batch_count = 0;
+static bool has_pending_flush = false;
+
+template <
+    uint8_t receiver_channel,
+    uint8_t to_receiver_pkts_sent_id,
+    bool enable_first_level_ack,
+    size_t DOWNSTREAM_EDM_SIZE,
+    typename WriteTridTracker,
+    typename ReceiverChannelBufferT,
+    typename ReceiverChannelPointersT,
+    typename DownstreamSenderT,
+    typename LocalRelayInterfaceT,
+    typename LocalTelemetryT>
+FORCE_INLINE bool run_receiver_channel_step_speedy(
+    ReceiverChannelBufferT& local_receiver_channel,
+    std::array<DownstreamSenderT, DOWNSTREAM_EDM_SIZE>& downstream_edm_interfaces,
+    LocalRelayInterfaceT& local_relay_interface,
+    ReceiverChannelPointersT& receiver_channel_pointers,
+    WriteTridTracker& receiver_channel_trid_tracker,
+    std::array<uint8_t, num_eth_ports>& port_direction_table,
+    ReceiverChannelResponseCreditSender& receiver_channel_response_credit_sender,
+    const tt::tt_fabric::routing_l1_info_t& routing_table,
+    LocalTelemetryT& local_fabric_telemetry) {
+    bool progress = false;
+    auto& wr_sent_counter = receiver_channel_pointers.wr_sent_counter;
+    auto pkts_received = get_ptr_val<to_receiver_pkts_sent_id>();
+    bool unwritten_packets = pkts_received != 0;
+
+    if (unwritten_packets) {
+        static_assert(!ENABLE_RISC_CPU_DATA_CACHE, "ENABLE_RISC_CPU_DATA_CACHE must be disabled for speedy path");
+        // TODO: hoist me between get_ptr_val and the mask for its value.
+        auto receiver_buffer_index = wr_sent_counter.get_buffer_index();
+        tt_l1_ptr PACKET_HEADER_TYPE* packet_header = const_cast<PACKET_HEADER_TYPE*>(
+            local_receiver_channel.template get_packet_header<PACKET_HEADER_TYPE>(receiver_buffer_index));
+
+        // Single 4B aligned load at offset 40 to get payload_size_bytes + noc_send_type
+        // instead of two separate uncached L1 reads.
+        auto packed = PACKET_HEADER_TYPE::PackedPayloadAndSendType::load(packet_header);
+
+        execute_chip_unicast_to_local_chip_impl(
+            packet_header, packed.payload_size_bytes, packed.noc_send_type, current_write_trid, receiver_channel);
+
+        did_something = true;
+        progress = true;
+        if constexpr (FABRIC_TELEMETRY_BANDWIDTH) {
+            update_bw_counters(packet_header, local_fabric_telemetry);
+        }
+        channel_trimming_usage_recorder.set_receiver_channel_data_forwarded(receiver_channel);
+
+        wr_sent_counter.increment();
+        increment_local_update_ptr_val<to_receiver_pkts_sent_id>(-1);
+        unacked_sends++;
+    }
+
+    // --- Ping-pong TRID flush ---
+    // All packets in a batch share a single TRID (current_write_trid). When the batch
+    // threshold is hit, we flip to the other TRID and check the previous batch's single
+    // TRID for completion — replacing the per-slot loop with a single register read.
+    //
+    // The pending TRID is checked eagerly (every call) to minimize credit return latency.
+    // Only the batch flip requires reaching the threshold.
+    // when we pass the threshold of unacked messages,
+    if ((unacked_sends >= RECEIVER_CREDIT_AMORTIZATION_FREQUENCY) && !has_pending_flush) {
+        pending_flush_trid = current_write_trid;
+        pending_flush_batch_count = unacked_sends;
+        current_write_trid = 1 - current_write_trid;
+        has_pending_flush = true;
+    }
+    if (has_pending_flush) {
+        bool flushed = ncrisc_noc_nonposted_write_with_transaction_id_sent(
+            tt::tt_fabric::edm_to_local_chip_noc, pending_flush_trid);
+
+        if (flushed) {
+            auto& completion_counter = receiver_channel_pointers.completion_counter;
+            completion_counter.increment_n(pending_flush_batch_count);
+            receiver_send_completion_ack<false /*CHECK_BUSY*/>(
+                receiver_channel_response_credit_sender, 0, pending_flush_batch_count);
+
+            unacked_sends -= pending_flush_batch_count;
+            has_pending_flush = false;
+        }
+    }
+
+    return progress;
+}

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_router_flow_control.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_router_flow_control.hpp
@@ -24,8 +24,8 @@ struct ReceiverChannelCounterBasedResponseCreditSender {
         }
     }
 
-    FORCE_INLINE void send_completion_credit(uint8_t src_id) {
-        completion_counters[src_id]++;
+    FORCE_INLINE void send_completion_credit(uint8_t src_id, uint32_t num_completions) {
+        completion_counters[src_id] += num_completions;
         completion_counters_base_ptr[src_id] = completion_counters[src_id];
         update_sender_side_credits();
     }
@@ -61,8 +61,8 @@ struct ReceiverChannelStreamRegisterFreeSlotsBasedCreditSender {
         }
     }
 
-    FORCE_INLINE void send_completion_credit(uint8_t src_id) {
-        remote_update_ptr_val<receiver_txq_id>(sender_channel_packets_completed_stream_ids[src_id], 1);
+    FORCE_INLINE void send_completion_credit(uint8_t src_id, uint32_t num_completions) {
+        remote_update_ptr_val<receiver_txq_id>(sender_channel_packets_completed_stream_ids[src_id], num_completions);
     }
 
     // Assumes !eth_txq_is_busy() -- PLEASE CHECK BEFORE CALLING
@@ -237,12 +237,14 @@ constexpr FORCE_INLINE auto init_sender_channel_from_receiver_credits_flow_contr
 // MUST CHECK !is_eth_txq_busy() before calling
 template <bool CHECK_BUSY>
 FORCE_INLINE void receiver_send_completion_ack(
-    ReceiverChannelResponseCreditSender& receiver_channel_response_credit_sender, uint8_t src_id) {
+    ReceiverChannelResponseCreditSender& receiver_channel_response_credit_sender,
+    uint8_t src_id,
+    uint32_t num_completions = 1) {
     if constexpr (CHECK_BUSY) {
         while (internal_::eth_txq_is_busy(receiver_txq_id)) {
         };
     }
-    receiver_channel_response_credit_sender.send_completion_credit(src_id);
+    receiver_channel_response_credit_sender.send_completion_credit(src_id, num_completions);
 }
 
 template <bool CHECK_BUSY>

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -2215,8 +2215,9 @@ FORCE_INLINE void run_fabric_edm_main_loop(
     // This value defines the number of loop iterations we perform of the main control sequence before exiting
     // to check for termination and context switch. Removing the these checks from the inner loop can drastically
     // improve performance. The value of 32 was chosen somewhat empirically and then raised up slightly.
-    auto execute_main_loop = [&]() {
-        uint32_t sender_amort_counter = 0;
+    size_t persistent_sender_amort_counter = 0;
+    auto execute_main_loop = [&](size_t& persistent_sender_amort_counter) {
+        uint32_t sender_amort_counter = persistent_sender_amort_counter;
         // while (!got_immediate_termination_signal<ENABLE_RISC_CPU_DATA_CACHE>(termination_signal_ptr) && !state_manager_l1->is_non_run_command_pending/*<ENABLE_RISC_CPU_DATA_CACHE>*/()) {
         while (continue_running_main_run_loop<ENABLE_RISC_CPU_DATA_CACHE>(termination_signal_ptr, state_manager_l1)) {
             did_something = false;
@@ -2516,6 +2517,8 @@ FORCE_INLINE void run_fabric_edm_main_loop(
                 }
             }
         }
+
+        persistent_sender_amort_counter = sender_amort_counter;
     };
 
     uint64_t loop_start_cycles;
@@ -2525,7 +2528,7 @@ FORCE_INLINE void run_fabric_edm_main_loop(
             switch (reinterpret_cast<volatile tt_l1_ptr RouterStateManager*>(state_manager_l1)->command) {
                 case RouterCommand::RUN:
                     state_manager_l1->state = RouterState::RUNNING;
-                    execute_main_loop();
+                    execute_main_loop(persistent_sender_amort_counter);
                     break;
                 case RouterCommand::PAUSE:
                     // Signal erisc1 to pause before entering pause command handling
@@ -2549,7 +2552,7 @@ FORCE_INLINE void run_fabric_edm_main_loop(
         // immediately jump into the main loop. Any time the the master erisc is not in the run state (e.g. it
         // is paused, draining, retraining, etc.), we will enter a busy wait loop in the main run loop
         while (!got_immediate_termination_signal<ENABLE_RISC_CPU_DATA_CACHE>(termination_signal_ptr)) {
-            execute_main_loop();
+            execute_main_loop(persistent_sender_amort_counter);
         }
     }
 }

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -2118,6 +2118,9 @@ FORCE_INLINE bool continue_running_main_run_loop(volatile tt::tt_fabric::Termina
     }
 }
 
+// Include the speedy path functions (must come after all helper function definitions above)
+#include "tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_speedy_path.hpp"
+
 /*
  * Main control loop for fabric EDM. Run indefinitely until a termination signal is received
  *
@@ -2213,6 +2216,7 @@ FORCE_INLINE void run_fabric_edm_main_loop(
     // to check for termination and context switch. Removing the these checks from the inner loop can drastically
     // improve performance. The value of 32 was chosen somewhat empirically and then raised up slightly.
     auto execute_main_loop = [&]() {
+        uint32_t sender_amort_counter = 0;
         // while (!got_immediate_termination_signal<ENABLE_RISC_CPU_DATA_CACHE>(termination_signal_ptr) && !state_manager_l1->is_non_run_command_pending/*<ENABLE_RISC_CPU_DATA_CACHE>*/()) {
         while (continue_running_main_run_loop<ENABLE_RISC_CPU_DATA_CACHE>(termination_signal_ptr, state_manager_l1)) {
             did_something = false;
@@ -2228,70 +2232,81 @@ FORCE_INLINE void run_fabric_edm_main_loop(
             if constexpr (FABRIC_TELEMETRY_BANDWIDTH) {
                 loop_start_cycles = get_timestamp();
             }
-
+            if constexpr (super_speedy_mode && is_sender_channel_serviced[0]) {
+                auto check_connection_status =
+                    !channel_connection_established[0] ||
+                    local_sender_channel_worker_interfaces.template get<0>().has_worker_teardown_request();
+                if (check_connection_status) {
+                    check_worker_connections<MY_ETH_CHANNEL, ENABLE_RISC_CPU_DATA_CACHE>(
+                        local_sender_channel_worker_interfaces.template get<0>(),
+                        channel_connection_established[0],
+                        local_sender_channel_free_slots_stream_ids[0]);
+                }
+            }
             for (size_t i = 0; i < iterations_between_ctx_switch_and_teardown_checks; i++) {
-                router_invalidate_l1_cache<ENABLE_RISC_CPU_DATA_CACHE>();
-                // Capture these to see if we made progress
+                if constexpr (super_speedy_mode) {
+                    router_invalidate_l1_cache<ENABLE_RISC_CPU_DATA_CACHE>();
 
-                // There are some cases, mainly for performance, where we don't want to switch between sender channels
-                // so we interoduce this to provide finer grain control over when we disable the automatic switching
-                tx_progress |= run_sender_channel_step<VC0_RECEIVER_CHANNEL, 0, ENABLE_FIRST_LEVEL_ACK_VC0>(
-                    local_sender_channels,
-                    local_sender_channel_worker_interfaces,
-                    outbound_to_receiver_channel_pointer_ch0,
-                    remote_receiver_channels,
-                    channel_connection_established,
-                    local_sender_channel_free_slots_stream_ids,
-                    sender_channel_from_receiver_credits,
-                    inner_loop_perf_telemetry_collector,
-                    local_fabric_telemetry);
+                    if constexpr (is_sender_channel_serviced[0]) {
+                        tx_progress |= run_sender_channel_step_speedy<
+                            0,
+                            to_receiver_packets_sent_streams[VC0_RECEIVER_CHANNEL],
+                            ENABLE_FIRST_LEVEL_ACK_VC0>(
+                            local_sender_channels.template get<0>(),
+                            local_sender_channel_worker_interfaces.template get<0>(),
+                            outbound_to_receiver_channel_pointer_ch0,
+                            remote_receiver_channels.template get<VC0_RECEIVER_CHANNEL>(),
+                            channel_connection_established[0],
+                            local_sender_channel_free_slots_stream_ids[0],
+                            sender_channel_from_receiver_credits[0],
+                            inner_loop_perf_telemetry_collector,
+                            local_fabric_telemetry,
+                            sender_amort_counter);
+                    }
+
+                    if constexpr (is_receiver_channel_serviced[0]) {
 #if defined(FABRIC_2D_VC0_CROSSOVER_TO_VC1)
-                // Inter-mesh routers receive neighbor mesh's locally generated traffic on VC0.
-                // This VC0 traffic needs to be forwarded over VC1 in the receiving mesh.
-                rx_progress |= run_receiver_channel_step<
-                    0,
-                    ENABLE_FIRST_LEVEL_ACK_VC0,
-                    VC1_DOWNSTREAM_EDM_SIZE,  // Explicit size for VC1 downstream interfaces
-                    DownstreamSenderVC1T,
-                    decltype(local_relay_interface)>(
-                    local_receiver_channels,
-                    downstream_edm_noc_interfaces_vc1,
-                    local_relay_interface,
-                    receiver_channel_pointers_ch0,
-                    receiver_channel_0_trid_tracker,
-                    port_direction_table,
-                    receiver_channel_response_credit_senders,
-                    routing_table,
-                    local_fabric_telemetry);
+                        rx_progress |= run_receiver_channel_step_speedy<
+                            0,
+                            to_receiver_packets_sent_streams[0],
+                            ENABLE_FIRST_LEVEL_ACK_VC0,
+                            VC1_DOWNSTREAM_EDM_SIZE,
+                            decltype(receiver_channel_0_trid_tracker)>(
+                            local_receiver_channels.template get<0>(),
+                            downstream_edm_noc_interfaces_vc1,
+                            local_relay_interface,
+                            receiver_channel_pointers_ch0,
+                            receiver_channel_0_trid_tracker,
+                            port_direction_table,
+                            receiver_channel_response_credit_senders[0],
+                            routing_table,
+                            local_fabric_telemetry);
 #else
-                rx_progress |= run_receiver_channel_step<
-                    0,
-                    ENABLE_FIRST_LEVEL_ACK_VC0,
-                    VC0_DOWNSTREAM_EDM_SIZE,  // Explicit size for VC0 downstream interfaces
-                    DownstreamSenderVC0T,
-                    decltype(local_relay_interface)>(
-                    local_receiver_channels,
-                    downstream_edm_noc_interfaces_vc0,
-                    local_relay_interface,
-                    receiver_channel_pointers_ch0,
-                    receiver_channel_0_trid_tracker,
-                    port_direction_table,
-                    receiver_channel_response_credit_senders,
-                    routing_table,
-                    local_fabric_telemetry);
+                        rx_progress |= run_receiver_channel_step_speedy<
+                            0,
+                            to_receiver_packets_sent_streams[0],
+                            ENABLE_FIRST_LEVEL_ACK_VC0,
+                            VC0_DOWNSTREAM_EDM_SIZE,
+                            decltype(receiver_channel_0_trid_tracker)>(
+                            local_receiver_channels.template get<0>(),
+                            downstream_edm_noc_interfaces_vc0,
+                            local_relay_interface,
+                            receiver_channel_pointers_ch0,
+                            receiver_channel_0_trid_tracker,
+                            port_direction_table,
+                            receiver_channel_response_credit_senders[0],
+                            routing_table,
+                            local_fabric_telemetry);
 #endif
-                tx_progress |= run_sender_channel_step<VC0_RECEIVER_CHANNEL, 1, ENABLE_FIRST_LEVEL_ACK_VC0>(
-                    local_sender_channels,
-                    local_sender_channel_worker_interfaces,
-                    outbound_to_receiver_channel_pointer_ch0,
-                    remote_receiver_channels,
-                    channel_connection_established,
-                    local_sender_channel_free_slots_stream_ids,
-                    sender_channel_from_receiver_credits,
-                    inner_loop_perf_telemetry_collector,
-                    local_fabric_telemetry);
-                if constexpr (is_2d_fabric) {
-                    tx_progress |= run_sender_channel_step<VC0_RECEIVER_CHANNEL, 2, ENABLE_FIRST_LEVEL_ACK_VC0>(
+                    }
+                } else {
+                    router_invalidate_l1_cache<ENABLE_RISC_CPU_DATA_CACHE>();
+                    // Capture these to see if we made progress
+
+                    // There are some cases, mainly for performance, where we don't want to switch between sender
+                    // channels so we interoduce this to provide finer grain control over when we disable the automatic
+                    // switching
+                    tx_progress |= run_sender_channel_step<VC0_RECEIVER_CHANNEL, 0, ENABLE_FIRST_LEVEL_ACK_VC0>(
                         local_sender_channels,
                         local_sender_channel_worker_interfaces,
                         outbound_to_receiver_channel_pointer_ch0,
@@ -2301,7 +2316,42 @@ FORCE_INLINE void run_fabric_edm_main_loop(
                         sender_channel_from_receiver_credits,
                         inner_loop_perf_telemetry_collector,
                         local_fabric_telemetry);
-                    tx_progress |= run_sender_channel_step<VC0_RECEIVER_CHANNEL, 3, ENABLE_FIRST_LEVEL_ACK_VC0>(
+#if defined(FABRIC_2D_VC0_CROSSOVER_TO_VC1)
+                    // Inter-mesh routers receive neighbor mesh's locally generated traffic on VC0.
+                    // This VC0 traffic needs to be forwarded over VC1 in the receiving mesh.
+                    rx_progress |= run_receiver_channel_step<
+                        0,
+                        ENABLE_FIRST_LEVEL_ACK_VC0,
+                        VC1_DOWNSTREAM_EDM_SIZE,  // Explicit size for VC1 downstream interfaces
+                        DownstreamSenderVC1T,
+                        decltype(local_relay_interface)>(
+                        local_receiver_channels,
+                        downstream_edm_noc_interfaces_vc1,
+                        local_relay_interface,
+                        receiver_channel_pointers_ch0,
+                        receiver_channel_0_trid_tracker,
+                        port_direction_table,
+                        receiver_channel_response_credit_senders,
+                        routing_table,
+                        local_fabric_telemetry);
+#else
+                    rx_progress |= run_receiver_channel_step<
+                        0,
+                        ENABLE_FIRST_LEVEL_ACK_VC0,
+                        VC0_DOWNSTREAM_EDM_SIZE,  // Explicit size for VC0 downstream interfaces
+                        DownstreamSenderVC0T,
+                        decltype(local_relay_interface)>(
+                        local_receiver_channels,
+                        downstream_edm_noc_interfaces_vc0,
+                        local_relay_interface,
+                        receiver_channel_pointers_ch0,
+                        receiver_channel_0_trid_tracker,
+                        port_direction_table,
+                        receiver_channel_response_credit_senders,
+                        routing_table,
+                        local_fabric_telemetry);
+#endif
+                    tx_progress |= run_sender_channel_step<VC0_RECEIVER_CHANNEL, 1, ENABLE_FIRST_LEVEL_ACK_VC0>(
                         local_sender_channels,
                         local_sender_channel_worker_interfaces,
                         outbound_to_receiver_channel_pointer_ch0,
@@ -2311,8 +2361,8 @@ FORCE_INLINE void run_fabric_edm_main_loop(
                         sender_channel_from_receiver_credits,
                         inner_loop_perf_telemetry_collector,
                         local_fabric_telemetry);
-                    if constexpr (ACTUAL_VC0_SENDER_CHANNELS > 4) {
-                        tx_progress |= run_sender_channel_step<VC0_RECEIVER_CHANNEL, 4, ENABLE_FIRST_LEVEL_ACK_VC0>(
+                    if constexpr (is_2d_fabric) {
+                        tx_progress |= run_sender_channel_step<VC0_RECEIVER_CHANNEL, 2, ENABLE_FIRST_LEVEL_ACK_VC0>(
                             local_sender_channels,
                             local_sender_channel_worker_interfaces,
                             outbound_to_receiver_channel_pointer_ch0,
@@ -2322,51 +2372,32 @@ FORCE_INLINE void run_fabric_edm_main_loop(
                             sender_channel_from_receiver_credits,
                             inner_loop_perf_telemetry_collector,
                             local_fabric_telemetry);
-                    }
+                        tx_progress |= run_sender_channel_step<VC0_RECEIVER_CHANNEL, 3, ENABLE_FIRST_LEVEL_ACK_VC0>(
+                            local_sender_channels,
+                            local_sender_channel_worker_interfaces,
+                            outbound_to_receiver_channel_pointer_ch0,
+                            remote_receiver_channels,
+                            channel_connection_established,
+                            local_sender_channel_free_slots_stream_ids,
+                            sender_channel_from_receiver_credits,
+                            inner_loop_perf_telemetry_collector,
+                            local_fabric_telemetry);
+                        if constexpr (ACTUAL_VC0_SENDER_CHANNELS > 4) {
+                            tx_progress |= run_sender_channel_step<VC0_RECEIVER_CHANNEL, 4, ENABLE_FIRST_LEVEL_ACK_VC0>(
+                                local_sender_channels,
+                                local_sender_channel_worker_interfaces,
+                                outbound_to_receiver_channel_pointer_ch0,
+                                remote_receiver_channels,
+                                channel_connection_established,
+                                local_sender_channel_free_slots_stream_ids,
+                                sender_channel_from_receiver_credits,
+                                inner_loop_perf_telemetry_collector,
+                                local_fabric_telemetry);
+                        }
 #if defined(FABRIC_2D_VC1_SERVICED)
-                    tx_progress |= run_sender_channel_step<
-                        VC1_RECEIVER_CHANNEL,
-                        ACTUAL_VC0_SENDER_CHANNELS,
-                        ENABLE_FIRST_LEVEL_ACK_VC1>(
-                        local_sender_channels,
-                        local_sender_channel_worker_interfaces,
-                        outbound_to_receiver_channel_pointer_ch1,
-                        remote_receiver_channels,
-                        channel_connection_established,
-                        local_sender_channel_free_slots_stream_ids,
-                        sender_channel_from_receiver_credits,
-                        inner_loop_perf_telemetry_collector,
-                        local_fabric_telemetry);
-                    tx_progress |= run_sender_channel_step<
-                        VC1_RECEIVER_CHANNEL,
-                        ACTUAL_VC0_SENDER_CHANNELS + 1,
-                        ENABLE_FIRST_LEVEL_ACK_VC1>(
-                        local_sender_channels,
-                        local_sender_channel_worker_interfaces,
-                        outbound_to_receiver_channel_pointer_ch1,
-                        remote_receiver_channels,
-                        channel_connection_established,
-                        local_sender_channel_free_slots_stream_ids,
-                        sender_channel_from_receiver_credits,
-                        inner_loop_perf_telemetry_collector,
-                        local_fabric_telemetry);
-                    tx_progress |= run_sender_channel_step<
-                        VC1_RECEIVER_CHANNEL,
-                        ACTUAL_VC0_SENDER_CHANNELS + 2,
-                        ENABLE_FIRST_LEVEL_ACK_VC1>(
-                        local_sender_channels,
-                        local_sender_channel_worker_interfaces,
-                        outbound_to_receiver_channel_pointer_ch1,
-                        remote_receiver_channels,
-                        channel_connection_established,
-                        local_sender_channel_free_slots_stream_ids,
-                        sender_channel_from_receiver_credits,
-                        inner_loop_perf_telemetry_collector,
-                        local_fabric_telemetry);
-                    if constexpr (ACTUAL_VC1_SENDER_CHANNELS > 3) {
                         tx_progress |= run_sender_channel_step<
                             VC1_RECEIVER_CHANNEL,
-                            ACTUAL_VC0_SENDER_CHANNELS + 3,
+                            ACTUAL_VC0_SENDER_CHANNELS,
                             ENABLE_FIRST_LEVEL_ACK_VC1>(
                             local_sender_channels,
                             local_sender_channel_worker_interfaces,
@@ -2377,24 +2408,65 @@ FORCE_INLINE void run_fabric_edm_main_loop(
                             sender_channel_from_receiver_credits,
                             inner_loop_perf_telemetry_collector,
                             local_fabric_telemetry);
-                    }
-                    rx_progress |= run_receiver_channel_step<
-                        1,
-                        ENABLE_FIRST_LEVEL_ACK_VC1,
-                        VC1_DOWNSTREAM_EDM_SIZE,  // Explicit size for VC1 downstream interfaces
-                        DownstreamSenderVC1T,
-                        decltype(local_relay_interface)>(
-                        local_receiver_channels,
-                        downstream_edm_noc_interfaces_vc1,
-                        local_relay_interface,
-                        receiver_channel_pointers_ch1,
-                        receiver_channel_1_trid_tracker,
-                        port_direction_table,
-                        receiver_channel_response_credit_senders,
-                        routing_table,
-                        local_fabric_telemetry);
+                        tx_progress |= run_sender_channel_step<
+                            VC1_RECEIVER_CHANNEL,
+                            ACTUAL_VC0_SENDER_CHANNELS + 1,
+                            ENABLE_FIRST_LEVEL_ACK_VC1>(
+                            local_sender_channels,
+                            local_sender_channel_worker_interfaces,
+                            outbound_to_receiver_channel_pointer_ch1,
+                            remote_receiver_channels,
+                            channel_connection_established,
+                            local_sender_channel_free_slots_stream_ids,
+                            sender_channel_from_receiver_credits,
+                            inner_loop_perf_telemetry_collector,
+                            local_fabric_telemetry);
+                        tx_progress |= run_sender_channel_step<
+                            VC1_RECEIVER_CHANNEL,
+                            ACTUAL_VC0_SENDER_CHANNELS + 2,
+                            ENABLE_FIRST_LEVEL_ACK_VC1>(
+                            local_sender_channels,
+                            local_sender_channel_worker_interfaces,
+                            outbound_to_receiver_channel_pointer_ch1,
+                            remote_receiver_channels,
+                            channel_connection_established,
+                            local_sender_channel_free_slots_stream_ids,
+                            sender_channel_from_receiver_credits,
+                            inner_loop_perf_telemetry_collector,
+                            local_fabric_telemetry);
+                        if constexpr (ACTUAL_VC1_SENDER_CHANNELS > 3) {
+                            tx_progress |= run_sender_channel_step<
+                                VC1_RECEIVER_CHANNEL,
+                                ACTUAL_VC0_SENDER_CHANNELS + 3,
+                                ENABLE_FIRST_LEVEL_ACK_VC1>(
+                                local_sender_channels,
+                                local_sender_channel_worker_interfaces,
+                                outbound_to_receiver_channel_pointer_ch1,
+                                remote_receiver_channels,
+                                channel_connection_established,
+                                local_sender_channel_free_slots_stream_ids,
+                                sender_channel_from_receiver_credits,
+                                inner_loop_perf_telemetry_collector,
+                                local_fabric_telemetry);
+                        }
+                        rx_progress |= run_receiver_channel_step<
+                            1,
+                            ENABLE_FIRST_LEVEL_ACK_VC1,
+                            VC1_DOWNSTREAM_EDM_SIZE,  // Explicit size for VC1 downstream interfaces
+                            DownstreamSenderVC1T,
+                            decltype(local_relay_interface)>(
+                            local_receiver_channels,
+                            downstream_edm_noc_interfaces_vc1,
+                            local_relay_interface,
+                            receiver_channel_pointers_ch1,
+                            receiver_channel_1_trid_tracker,
+                            port_direction_table,
+                            receiver_channel_response_credit_senders,
+                            routing_table,
+                            local_fabric_telemetry);
 #endif  // FABRIC_2D_VC1_SERVICED
-                }
+                    }
+                }  // end else (non-speedy path)
             }
 
             if constexpr (FABRIC_TELEMETRY_BANDWIDTH) {


### PR DESCRIPTION
On Blackhole: achieves 30-40% speedup for neighbour exchange topologies (only). Reaches ~39-40 GB/s 4k packet size and ~19-20 GB/s 2k packet size on Blackhole. 

Further optimizations can bring us to >95% util for 4k packet size and the ability to stream 2k @200G, but that is future work.

Those measured performance numbers depend on fabric test infra optimizations to the sender worker kernels (the sender worker was too slow). Those are not included here to make changes more incremental. One of those optimizations is addressed by https://github.com/tenstorrent/tt-metal/pull/38862.

The general optimization strategies from this change will be ported up to the other topologies

The primary optimization here is a change to the transaction ID scheme and ack credit strategy from receiver to sender. Credit processing is amortized on both the sender and receiver side. The receiver will not bother constructing or sending completion credits until some number of packets have been received and forwarded. Likewise, the sender side will not even bother checking for credits until the number of outstanding writes exceeds some threshold. Additionally, a second layer of amortization exist for the sender side to send credits to its upstream. Those credits are via noc writes, which are expensive, so the actual upstream credit send is amortized as well. The fabric router builder will define what that amortization size is.


### Ticket
Closes https://github.com/tenstorrent/tt-metal/issues/38402

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=snijjar/neighbour-exchange-amortized-acks)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:snijjar/neighbour-exchange-amortized-acks)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snijjar/neighbour-exchange-amortized-acks)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snijjar/neighbour-exchange-amortized-acks)
- [x] [![Fabric Tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tm-fabric-tests.yaml/badge.svg?branch=snijjar/neighbour-exchange-amortized-acks)](https://github.com/tenstorrent/tt-metal/actions/workflows/tm-fabric-tests.yaml?query=branch:snijjar/neighbour-exchange-amortized-acks) - same failures as [on main](https://github.com/tenstorrent/tt-metal/actions/runs/22548882480)

