### PR TITLE
Fix install_dependencies.sh for Debian 12

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -279,19 +279,23 @@ prep_ubuntu_system() {
     # Also v20
     echo "deb http://apt.llvm.org/$OS_CODENAME/ llvm-toolchain-$OS_CODENAME-20 main" | tee /etc/apt/sources.list.d/llvm-20.list
 
-    # Add Kitware repository for latest CMake
-    # If the kitware-archive-keyring package has not been installed previously, manually obtain a copy of our signing key
-    test -f /usr/share/doc/kitware-archive-keyring/copyright || wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+    # Add Kitware repository for latest CMake (Ubuntu only - Kitware doesn't support Debian)
+    if [[ "$OS_ID" == "ubuntu" ]]; then
+        # If the kitware-archive-keyring package has not been installed previously, manually obtain a copy of our signing key
+        test -f /usr/share/doc/kitware-archive-keyring/copyright || wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
 
-    # Add the repository to sources list and update
-    echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ $OS_CODENAME main" | tee /etc/apt/sources.list.d/kitware.list >/dev/null
-    apt-get update
+        # Add the repository to sources list and update
+        echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ $OS_CODENAME main" | tee /etc/apt/sources.list.d/kitware.list >/dev/null
+        apt-get update
 
-    # If the kitware-archive-keyring package was not installed previously, remove the manually obtained key to make room for the package
-    test -f /usr/share/doc/kitware-archive-keyring/copyright || rm /usr/share/keyrings/kitware-archive-keyring.gpg
+        # If the kitware-archive-keyring package was not installed previously, remove the manually obtained key to make room for the package
+        test -f /usr/share/doc/kitware-archive-keyring/copyright || rm /usr/share/keyrings/kitware-archive-keyring.gpg
 
-    # Install the kitware-archive-keyring package to ensure that your keyring stays up to date as keys are rotated
-    apt-get install -y --no-install-recommends kitware-archive-keyring
+        # Install the kitware-archive-keyring package to ensure that your keyring stays up to date as keys are rotated
+        apt-get install -y --no-install-recommends kitware-archive-keyring
+    else
+        echo "[INFO] Skipping Kitware repository on $OS_ID (not supported). Using system cmake."
+    fi
 
     # Add GCC toolchain repository for specific g++ versions if needed
     if [[ "$OS_ID" == "ubuntu" ]]; then


### PR DESCRIPTION
## Summary
- Fixed Kitware repository installation for Debian 12
- Kitware repository only supports Ubuntu, not Debian
- Added conditional check to skip Kitware on non-Ubuntu systems
- Debian 12 will use system cmake instead

## Problem
On Debian 12, the script creates a malformed kitware.list:
```
E: Malformed entry 1 in list file /etc/apt/sources.list.d/kitware.list (Component)
```

This happens because Kitware uses Ubuntu codenames (e.g., jammy, focal), not Debian codenames (e.g., bookworm).

## Solution
- Added `if [[ "$OS_ID" == "ubuntu" ]]; then` check
- Skip Kitware repository on Debian systems
- Debian 12 will use system cmake (which is sufficient)

## Testing
- Tested logic on Debian 12 VM
- Script no longer creates malformed kitware.list

Fixes #38832