### PR TITLE
Implement streaming SDPA compute for standard and ring joint SDPA

### DIFF
--- a/tt_metal/hw/inc/api/compute/eltwise_unary/exp.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/exp.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include "api/compute/common_globals.h"
-#ifdef TRISC_MATH
+#if defined(TRISC_MATH) || defined(TRISC_PACK)
 #include "ckernel_sfpu_exp.h"
 #include "llk_math_eltwise_unary_sfpu_macros.h"
 #endif
@@ -80,6 +80,52 @@ template <
     int iterations = 8>
 ALWI void exp_tile(uint32_t idst, int vector_mode = (int)VectorMode::RC, uint16_t scale = p_sfpu::kCONST_1_FP16B) {
     MATH(SFPU_TEMPLATE_PARAMS_KERNEL_FN(
+        calculate_exponential,
+        approx,
+        fast_and_approx,
+        DST_ACCUM_MODE,
+        scale_en,
+        skip_positive_check,
+        (input_clamping == InputClamping::ClampToNegative),
+        iterations,
+        idst,
+        vector_mode,
+        scale));
+}
+
+/**
+ * Pack-thread variant of exp_tile_init. Runs the init on the pack thread
+ * to enable FPU/SFPU overlap with math-thread matmul operations.
+ */
+template <
+    bool approx = false,
+    bool fast_and_approx = true,
+    uint32_t scale = 0x3F800000,
+    InputClamping input_clamping = InputClamping::ClampToNegative>
+ALWI void exp_packthread_tile_init() {
+    PACK(SFPU_TEMPLATE_INIT_KERNEL(
+        exponential,
+        sfpu::exp_init,
+        approx,
+        fast_and_approx,
+        scale,
+        (input_clamping == InputClamping::ClampToNegative)));
+}
+
+/**
+ * Pack-thread variant of exp_tile. Runs the exp computation on the pack thread
+ * to enable FPU/SFPU overlap with math-thread matmul operations.
+ */
+template <
+    bool approx = false,
+    bool fast_and_approx = true,
+    bool scale_en = false,
+    bool skip_positive_check = false,
+    InputClamping input_clamping = InputClamping::ClampToNegative,
+    int iterations = 8>
+ALWI void exp_packthread_tile(
+    uint32_t idst, int vector_mode = (int)VectorMode::RC, uint16_t scale = p_sfpu::kCONST_1_FP16B) {
+    PACK(SFPU_TEMPLATE_PARAMS_KERNEL_FN(
         calculate_exponential,
         approx,
         fast_and_approx,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -617,7 +617,7 @@ void mul_block_inplace(uint32_t in0_cb, uint32_t in1_cb, uint32_t num_tiles) {
     }
 }
 
-#ifdef TRISC_MATH
+#if defined(TRISC_MATH) || defined(TRISC_PACK)
 
 constexpr auto bits = [](float x) constexpr { return __builtin_bit_cast(std::uint32_t, x); };
 constexpr auto lo16 = [](float x) constexpr { return static_cast<std::uint16_t>(bits(x) & 0xFFFFu); };
@@ -855,7 +855,7 @@ void exp_tile_first_column(uint32_t idst) {
     _llk_math_eltwise_unary_sfpu_params_<false /*APPROXIMATE*/>(
         calculate_exponential_first_column<SDPA_EXP_APPROX_MODE, scale_bf16>, idst, (int)VectorMode::C);
 }
-#endif
+#endif  // defined(TRISC_MATH) || defined(TRISC_PACK)
 
 /**
  * out_cb = exp((in0_cb - in1_cb) * scale_fp32)

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -1312,6 +1312,180 @@ void matmul_reduce(uint32_t in1_cb, const uint32_t& out_cb) {
     }
 }
 
+/**
+ * Lightweight padded-K mask: L1-accumulate a single permanently-fronted -inf tile onto padded
+ * tile positions in out_cb. Runtime version for ring joint SDPA where num_padded varies per chunk.
+ *
+ * @param neginf_cb  CB holding mask tiles (tile 0 = -inf), permanently fronted
+ * @param neginf_tile_idx  Tile index of the -inf tile within the CB (typically 0)
+ * @param out_cb     QK intermediate CB (Sq_chunk_t * Sk_chunk_t tiles, already wait-fronted)
+ * @param num_padded Number of fully padded K tile columns per row
+ * @param num_cols   Total K tiles per row (Sk_chunk_t)
+ * @param num_rows   Q tiles per chunk (Sq_chunk_t)
+ */
+void apply_padded_mask_lightweight_runtime(
+    uint32_t neginf_cb,
+    uint32_t neginf_tile_idx,
+    uint32_t out_cb,
+    uint32_t num_padded,
+    uint32_t num_cols,
+    uint32_t num_rows) {
+    uint32_t start = num_cols - num_padded;
+
+    copy_tile_to_dst_init_short(neginf_cb);
+    PACK((llk_pack_reconfig_l1_acc(1)));
+
+    constexpr uint32_t DST_BATCH = 8;
+    for (uint32_t row = 0; row < num_rows; row++) {
+        uint32_t row_offset = row * num_cols;
+        for (uint32_t base = start; base < num_cols; base += DST_BATCH) {
+            uint32_t batch = (num_cols - base < DST_BATCH) ? (num_cols - base) : DST_BATCH;
+            tile_regs_acquire();
+            for (uint32_t i = 0; i < batch; i++) {
+                copy_tile(neginf_cb, neginf_tile_idx, i);  // Index into the single CB
+            }
+            tile_regs_commit();
+            tile_regs_wait();
+            for (uint32_t i = 0; i < batch; i++) {
+                pack_tile<true>(i, out_cb, row_offset + base + i);
+            }
+            tile_regs_release();
+        }
+    }
+
+    PACK((llk_pack_reconfig_l1_acc(0)));
+}
+
+/**
+ * Lightweight partial mask: L1-accumulate a partial mask tile (0 for valid, -inf for padded columns)
+ * onto the boundary tile position in out_cb. The partial tile is permanently fronted in the CB.
+ *
+ * @param mask_cb          CB holding mask tiles, permanently fronted
+ * @param partial_tile_idx Index of the partial tile within the CB
+ * @param out_cb           QK intermediate CB (already wait-fronted)
+ * @param boundary_col     Column index within the chunk where the boundary tile is
+ * @param num_cols         Total K tiles per row (Sk_chunk_t)
+ * @param num_rows         Q tiles per chunk (Sq_chunk_t)
+ */
+void apply_partial_mask_lightweight(
+    uint32_t mask_cb,
+    uint32_t partial_tile_idx,
+    uint32_t out_cb,
+    uint32_t boundary_col,
+    uint32_t num_cols,
+    uint32_t num_rows) {
+    copy_tile_to_dst_init_short(mask_cb);
+    PACK((llk_pack_reconfig_l1_acc(1)));
+
+    for (uint32_t row = 0; row < num_rows; row++) {
+        tile_regs_acquire();
+        copy_tile(mask_cb, partial_tile_idx, 0);
+        tile_regs_commit();
+        tile_regs_wait();
+        pack_tile<true>(0, out_cb, row * num_cols + boundary_col);
+        tile_regs_release();
+    }
+
+    PACK((llk_pack_reconfig_l1_acc(0)));
+}
+
+/**
+ * Context for lightweight mask application in ring joint SDPA.
+ * All mask tiles reside in a single CB. A default-constructed instance disables lightweight masking.
+ */
+struct LightweightMaskContext {
+    bool enabled = false;
+    uint32_t neginf_tile_idx = 0;            // Index of -inf tile in the mask CB
+    uint32_t global_n_padded_tiles = 0;      // Fully padded K tile columns for global_n chunk
+    uint32_t local_n_padded_tiles = 0;       // Fully padded K tile columns for local_n chunk
+    uint32_t joint_n_padded_tiles = 0;       // Fully padded K tile columns for joint_l chunk
+    uint32_t global_n_partial_col = 0;       // Column within tile where global_n padding starts (0 = no partial)
+    uint32_t joint_l_partial_col = 0;        // Column within tile where joint_l padding starts (0 = no partial)
+    uint32_t global_n_partial_tile_idx = 0;  // Index of global_n partial tile in the mask CB
+    uint32_t joint_l_partial_tile_idx = 0;   // Index of joint_l partial tile in the mask CB
+
+    /**
+     * Resolve which mask type applies for a given K chunk and return pre-resolved params.
+     * Called once per K chunk; the resolved values are then used per subblock.
+     */
+    void resolve_for_chunk(
+        uint32_t Sk_chunk_t,
+        uint32_t k_chunk,
+        uint32_t num_local_k_chunks,
+        bool ring_iter_needs_global_n_mask,
+        bool ring_iter_needs_joint_n_mask,
+        bool local_n_needs_masking,
+        uint32_t global_n_mask_chunk_id,
+        uint32_t local_n_mask_chunk_id,
+        uint32_t joint_n_mask_chunk_id,
+        uint32_t& out_num_padded,
+        uint32_t& out_boundary_col,
+        uint32_t& out_partial_tile_idx,
+        bool& out_has_partial) const {
+        out_num_padded = 0;
+        out_has_partial = false;
+        out_boundary_col = 0;
+        out_partial_tile_idx = 0;
+
+        if (ring_iter_needs_global_n_mask && k_chunk == global_n_mask_chunk_id) {
+            out_num_padded = global_n_padded_tiles;
+            out_has_partial = (global_n_partial_col > 0);
+            out_boundary_col = Sk_chunk_t - out_num_padded - (out_has_partial ? 1 : 0);
+            out_partial_tile_idx = global_n_partial_tile_idx;
+        } else if (local_n_needs_masking && k_chunk == local_n_mask_chunk_id) {
+            out_num_padded = local_n_padded_tiles;
+        } else if (ring_iter_needs_joint_n_mask && (k_chunk - num_local_k_chunks) == joint_n_mask_chunk_id) {
+            out_num_padded = joint_n_padded_tiles;
+            out_has_partial = (joint_l_partial_col > 0);
+            out_boundary_col = Sk_chunk_t - out_num_padded - (out_has_partial ? 1 : 0);
+            out_partial_tile_idx = joint_l_partial_tile_idx;
+        }
+    }
+
+    /**
+     * Apply the lightweight mask for a given K chunk (non-streaming path).
+     */
+    void apply(
+        uint32_t cb_mask_in,
+        uint32_t cb_qk_im,
+        uint32_t Sk_chunk_t,
+        uint32_t Sq_chunk_t,
+        uint32_t k_chunk,
+        uint32_t num_local_k_chunks,
+        bool ring_iter_needs_global_n_mask,
+        bool ring_iter_needs_joint_n_mask,
+        bool local_n_needs_masking,
+        uint32_t global_n_mask_chunk_id,
+        uint32_t local_n_mask_chunk_id,
+        uint32_t joint_n_mask_chunk_id) const {
+        uint32_t num_padded, boundary_col, partial_tile_idx;
+        bool has_partial;
+        resolve_for_chunk(
+            Sk_chunk_t,
+            k_chunk,
+            num_local_k_chunks,
+            ring_iter_needs_global_n_mask,
+            ring_iter_needs_joint_n_mask,
+            local_n_needs_masking,
+            global_n_mask_chunk_id,
+            local_n_mask_chunk_id,
+            joint_n_mask_chunk_id,
+            num_padded,
+            boundary_col,
+            partial_tile_idx,
+            has_partial);
+
+        if (has_partial) {
+            apply_partial_mask_lightweight(
+                cb_mask_in, partial_tile_idx, cb_qk_im, boundary_col, Sk_chunk_t, Sq_chunk_t);
+        }
+        if (num_padded > 0) {
+            apply_padded_mask_lightweight_runtime(
+                cb_mask_in, neginf_tile_idx, cb_qk_im, num_padded, Sk_chunk_t, Sq_chunk_t);
+        }
+    }
+};
+
 enum SDPAType {
     STANDARD = 0,
     JOINT = 1,
@@ -1469,7 +1643,8 @@ void sdpa_inner_loop(
     const uint32_t cb_lse_in,
     const uint32_t cb_lse_out,
     const uint32_t cb_prev_out,
-    const uint32_t cb_out) {
+    const uint32_t cb_out,
+    const LightweightMaskContext& lw_mask = {}) {
     uint32_t KV_chunks_processed_in_iter = 0;
 
     for (uint32_t q_iter = iter_q_start; q_iter < iter_q_end; ++q_iter) {
@@ -1587,7 +1762,23 @@ void sdpa_inner_loop(
             if (apply_mask) {
                 /* QK += MASK */
                 reconfig_data_format(cb_qk_im, cb_mask_in);
-                add_block_inplace(cb_qk_im, cb_mask_in, qk_chunk_tiles);
+                if (lw_mask.enabled) {
+                    lw_mask.apply(
+                        cb_mask_in,
+                        cb_qk_im,
+                        Sk_chunk_t,
+                        Sq_chunk_t,
+                        k_chunk,
+                        num_local_k_chunks,
+                        ring_iter_needs_global_n_mask,
+                        ring_iter_needs_joint_n_mask,
+                        local_n_needs_masking,
+                        global_n_mask_chunk_id,
+                        local_n_mask_chunk_id,
+                        joint_n_mask_chunk_id);
+                } else {
+                    add_block_inplace(cb_qk_im, cb_mask_in, qk_chunk_tiles);
+                }
             }
 
             /**
@@ -2121,7 +2312,8 @@ void sdpa_ring(
     const uint32_t cb_lse_in,
     const uint32_t cb_lse_out,
     const uint32_t cb_prev_out,
-    const uint32_t cb_out) {
+    const uint32_t cb_out,
+    const LightweightMaskContext& lw_mask) {
     sdpa_inner_loop<
         RING,
         cb_qk_im,
@@ -2192,7 +2384,8 @@ void sdpa_ring(
         cb_lse_in,
         cb_lse_out,
         cb_prev_out,
-        cb_out);
+        cb_out,
+        lw_mask);
 }
 
 /**

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -350,7 +350,7 @@ void mul_block_bcast_cols_acc(
         }
         tile_regs_release();
     }
-    PACK((llk_pack_reconfig_l1_acc(false)));
+    PACK((llk_pack_reconfig_l1_acc(0)));
 }
 
 /**
@@ -365,7 +365,7 @@ void mul_block_bcast_cols_acc(
  * @tparam DST_BATCH   Max tiles per DST batch (8 for fp16b half-sync)
  */
 template <bool PROFILING_ENABLED, uint32_t num_padded, uint32_t num_cols, uint32_t SBH = 1, uint32_t DST_BATCH = 8>
-void apply_padded_mask_lightweight(uint32_t neginf_cb, uint32_t out_cb, uint32_t q_subblock = 0) {
+static void apply_padded_mask_lightweight(uint32_t neginf_cb, uint32_t out_cb, uint32_t q_subblock = 0) {
     MaybeDeviceZoneScopedN(PROFILING_ENABLED, "PAD_MASK");
     static_assert(num_padded > 0, "num_padded must be > 0");
     static_assert(num_padded < num_cols, "num_padded must be less than num_cols");
@@ -472,7 +472,7 @@ void normalize_row_streaming(
  * Copies mask tiles from cb_mask_in and adds them in-place to cb_qkt_im using L1 accumulation.
  */
 template <uint32_t Sk_chunk_t, uint32_t sbh, uint32_t cb_mask_in, uint32_t cb_qkt_im>
-void apply_ring_mask_to_qkt(uint32_t q_subblock) {
+static void apply_ring_mask_to_qkt(uint32_t q_subblock) {
     constexpr uint32_t DST_BATCH = 8;
     for (uint32_t row = 0; row < sbh; row++) {
         uint32_t out_row_offset = (q_subblock * sbh + row) * Sk_chunk_t;
@@ -497,6 +497,48 @@ void apply_ring_mask_to_qkt(uint32_t q_subblock) {
 }
 
 /**
+ * L1-accumulate a single mask tile onto one position in out_cb.
+ * Minimal primitive used by the lightweight ring mask path.
+ */
+static inline void l1_acc_single_tile(uint32_t mask_cb, uint32_t tile_idx, uint32_t out_cb, uint32_t out_pos) {
+    tile_regs_acquire();
+    copy_tile(mask_cb, tile_idx, 0);
+    tile_regs_commit();
+    tile_regs_wait();
+    pack_tile<true>(0, out_cb, out_pos);
+    tile_regs_release();
+}
+
+/**
+ * Combined lightweight mask for streaming ring SDPA: applies partial + padded mask.
+ * Processes SBH rows per call (one q_subblock).
+ * Caller must set up copy_tile_to_dst_init_short and llk_pack_reconfig_l1_acc(1) before calling,
+ * and llk_pack_reconfig_l1_acc(0) after calling.
+ */
+template <uint32_t num_cols, uint32_t SBH>
+static __attribute__((noinline)) void apply_lightweight_mask_streaming(
+    uint32_t mask_cb,
+    uint32_t out_cb,
+    uint32_t q_subblock,
+    uint32_t num_padded,
+    bool has_partial,
+    uint32_t partial_tile_idx) {
+    uint32_t boundary_col = num_cols - num_padded - (has_partial ? 1 : 0);
+    for (uint32_t row = 0; row < SBH; row++) {
+        uint32_t row_offset = (q_subblock * SBH + row) * num_cols;
+
+        if (has_partial) {
+            l1_acc_single_tile(mask_cb, partial_tile_idx, out_cb, row_offset + boundary_col);
+        }
+
+        uint32_t start = num_cols - num_padded;
+        for (uint32_t col = start; col < num_cols; col++) {
+            l1_acc_single_tile(mask_cb, 0, out_cb, row_offset + col);  // neginf is always tile 0
+        }
+    }
+}
+
+/**
  * One K-chunk iteration of the streaming SDPA algorithm (v2 — no row buffers).
  * Phase 1: Q@KT directly into cb_qkt_im with cb_push_back_hold_wr_ptr, in-place sub_exp.
  * Phase 2: Drain + QKT@V with SALAD corrections, streaming normalization on last K iter.
@@ -513,6 +555,7 @@ template <
     bool use_padded_mask,
     bool ring_mode = false,
     bool use_ring_mask = false,
+    bool uniform_dataformat = false,
     uint32_t cb_q_in = 0,
     uint32_t cb_kt_in = 0,
     uint32_t cb_v_in = 0,
@@ -523,7 +566,7 @@ template <
     uint32_t cb_recip_scratch = 0,
     uint32_t cb_normalized_out = 0,
     uint32_t cb_mask_in = 0>
-void sdpa_inner_loop_step(
+static void sdpa_inner_loop_step(
     const uint32_t prev_max,
     const uint32_t cur_max,
     const uint32_t prev_sum,
@@ -532,7 +575,9 @@ void sdpa_inner_loop_step(
     const uint32_t cur_out,
     const bool is_last_iter,
     const bool is_first_iter,
-    [[maybe_unused]] const bool apply_mask = false) {
+    [[maybe_unused]] const bool apply_mask = false,
+    const uint32_t lw_num_padded = 0,
+    const uint32_t lw_partial_tile_idx = 0) {
     constexpr uint32_t sbh = subblock_h;
     constexpr uint32_t in0_block_w = DHt;
     constexpr uint32_t qkt_subblock_w = 8 / sbh;
@@ -548,6 +593,12 @@ void sdpa_inner_loop_step(
     static_assert(Sq_chunk_t % sbh == 0, "Sq_chunk_t must be divisible by subblock_h");
     static_assert(!(use_padded_mask && use_ring_mask), "use_padded_mask and use_ring_mask are mutually exclusive");
 
+    // When all CBs share the same data format (e.g. all Float16_b for bf16 models),
+    // reconfig calls are no-ops — skip entirely to save code size.
+    // uniform_dataformat is passed as a template parameter from the program factory.
+    constexpr bool uniform_unpack_format = uniform_dataformat;
+    constexpr bool uniform_pack_format = uniform_dataformat;
+
     uint32_t pushed_rows = 0;
     uint32_t q_wait_tiles = q_subblock_num_tiles;
     uint32_t q_index_offset = 0;
@@ -555,8 +606,12 @@ void sdpa_inner_loop_step(
 
     exp_packthread_tile_init<true, true, scale_fp32, InputClamping::None>();
 
-    pack_reconfig_data_format(cb_qkt_im);
-    reconfig_data_format(cb_kt_in, cb_q_in);
+    if constexpr (!uniform_pack_format) {
+        pack_reconfig_data_format(cb_qkt_im);
+    }
+    if constexpr (!uniform_unpack_format) {
+        reconfig_data_format(cb_kt_in, cb_q_in);
+    }
     cb_reserve_back(cb_qkt_im, Sq_chunk_t * Sk_chunk_t);
 
     cb_wait_front(cb_kt_in, DHt * Sk_chunk_t);
@@ -574,7 +629,9 @@ void sdpa_inner_loop_step(
             if (q_subblock > 0) {
                 uint32_t prev_q_subblock = q_subblock - 1;
                 // Restore float16b UNPACK for sub_exp (early-exit if already float16b).
-                reconfig_data_format(cb_kt_in, cb_qkt_im, cb_q_in, cb_qkt_im);
+                if constexpr (!uniform_unpack_format) {
+                    reconfig_data_format(cb_kt_in, cb_qkt_im, cb_q_in, cb_qkt_im);
+                }
                 sub_exp_block_bcast_cols<PROFILING_ENABLED, scale_fp32, sbh, qkt_subblock_w, true>(
                     cb_qkt_im, cur_max, cur_sum, Sk_chunk_t, prev_q_subblock, kt_subblock);
             }
@@ -582,7 +639,9 @@ void sdpa_inner_loop_step(
             {
                 MaybeDeviceZoneScopedN(PROFILING_ENABLED, "Q@KT MM+Pack");
                 // Setup matmul UNPACK (early-exit if already set, e.g., q_subblock==0 consecutive calls).
-                reconfig_data_format(cb_qkt_im, cb_kt_in, cb_qkt_im, cb_q_in);
+                if constexpr (!uniform_unpack_format) {
+                    reconfig_data_format(cb_qkt_im, cb_kt_in, cb_qkt_im, cb_q_in);
+                }
                 blocked_matmul_and_pack<true, qkt_subblock_w, sbh, in0_block_w, Sk_chunk_t, Sk_chunk_t>(
                     cb_q_in,
                     cb_kt_in,
@@ -595,25 +654,27 @@ void sdpa_inner_loop_step(
             kt_index_offset += qkt_subblock_w;
         }
         // Restore float16b for mask/reduce after Q@KT.
-        reconfig_data_format(cb_kt_in, cb_qkt_im, cb_q_in, cb_qkt_im);
+        if constexpr (!uniform_unpack_format) {
+            reconfig_data_format(cb_kt_in, cb_qkt_im, cb_q_in, cb_qkt_im);
+        }
 
         // Apply mask on last K chunk: L1-accumulate single -inf tile onto padded K positions.
-        if constexpr (padded_k_tiles > 0) {
+        // In ring_mode, is_last_iter is always false — skip entirely.
+        if constexpr (padded_k_tiles > 0 && !ring_mode) {
             if (is_last_iter) {
                 apply_padded_mask_lightweight<PROFILING_ENABLED, padded_k_tiles, Sk_chunk_t, sbh>(
                     cb_mask_in, cb_qkt_im, q_subblock);
             }
         }
 
-        // Ring mask: L1-accumulate full mask tiles onto cb_qkt_im for this row group.
-        // Wait deferred to here so reader can overlap mask fetch with Q@KT matmul.
+        // Ring mask: L1-accumulate lightweight mask tiles onto cb_qkt_im for this row group.
         if constexpr (use_ring_mask) {
-            if (apply_mask) {
-                if (q_subblock == 0) {
-                    cb_wait_front(cb_mask_in, Sq_chunk_t * Sk_chunk_t);
-                }
-                MaybeDeviceZoneScopedN(PROFILING_ENABLED, "RING_MASK");
-                apply_ring_mask_to_qkt<Sk_chunk_t, sbh, cb_mask_in, cb_qkt_im>(q_subblock);
+            if (apply_mask && (lw_partial_tile_idx > 0 || lw_num_padded > 0)) {
+                copy_tile_to_dst_init_short(cb_mask_in);
+                PACK((llk_pack_reconfig_l1_acc(1)));
+                apply_lightweight_mask_streaming<Sk_chunk_t, sbh>(
+                    cb_mask_in, cb_qkt_im, q_subblock, lw_num_padded, lw_partial_tile_idx > 0, lw_partial_tile_idx);
+                PACK((llk_pack_reconfig_l1_acc(0)));
             }
         }
 
@@ -637,16 +698,14 @@ void sdpa_inner_loop_step(
 
     // Q is no longer needed after Phase 1. On the last K chunk, pop early so the
     // reader can start fetching the next Q chunk during Phase 2.
-    if (is_last_iter) {
-        cb_pop_front(cb_q_in, Sq_chunk_t * DHt);
-    }
-
-    // Pop ring mask after all row groups processed
-    if constexpr (use_ring_mask) {
-        if (apply_mask) {
-            cb_pop_front(cb_mask_in, Sq_chunk_t * Sk_chunk_t);
+    // In ring_mode, is_last_iter is always false — skip entirely.
+    if constexpr (!ring_mode) {
+        if (is_last_iter) {
+            cb_pop_front(cb_q_in, Sq_chunk_t * DHt);
         }
     }
+
+    // Lightweight ring mask tiles are permanently fronted — no pop needed.
 
     // ========== PHASE 2: Drain last row + QKT@V + SALAD ==========
     // After Phase 1: all rows are pushed (via hold_wr_ptr) in cb_qkt_im.
@@ -691,7 +750,9 @@ void sdpa_inner_loop_step(
                     // Matmul — FPU overlaps with SFPU EXP
                     {
                         uint32_t v_index_offset = 0;
-                        reconfig_data_format(cur_out, cb_v_in, cur_out, cb_qkt_im);
+                        if constexpr (!uniform_unpack_format) {
+                            reconfig_data_format(cur_out, cb_v_in, cur_out, cb_qkt_im);
+                        }
                         for (uint32_t v_subblock = 0; v_subblock < qktv_v_num_subblocks; ++v_subblock) {
                             MaybeDeviceZoneScopedN(PROFILING_ENABLED, "QKT@V MM+Pack");
                             blocked_matmul_and_pack<false, qktv_subblock_w, qktv_subblock_h, matmul_inner, vDHt, vDHt>(
@@ -704,7 +765,9 @@ void sdpa_inner_loop_step(
                                 v_subblock * qktv_subblock_w);
                             v_index_offset += qktv_subblock_w;
                         }
-                        reconfig_data_format(cb_v_in, cur_out, cb_qkt_im, cur_out);
+                        if constexpr (!uniform_unpack_format) {
+                            reconfig_data_format(cb_v_in, cur_out, cb_qkt_im, cur_out);
+                        }
                     }
 
                     if (kt_sub > 0) {
@@ -722,7 +785,9 @@ void sdpa_inner_loop_step(
                 cb_wait_front(cb_qkt_im, qktv_in0_wait_tiles);
                 {
                     uint32_t v_index_offset = 0;
-                    reconfig_data_format(cur_out, cb_v_in, cur_out, cb_qkt_im);
+                    if constexpr (!uniform_unpack_format) {
+                        reconfig_data_format(cur_out, cb_v_in, cur_out, cb_qkt_im);
+                    }
                     for (uint32_t v_subblock = 0; v_subblock < qktv_v_num_subblocks; ++v_subblock) {
                         MaybeDeviceZoneScopedN(PROFILING_ENABLED, "QKT@V MM+Pack");
                         blocked_matmul_and_pack<false, qktv_subblock_w, qktv_subblock_h, qktv_in0_block_w, vDHt, vDHt>(
@@ -735,25 +800,28 @@ void sdpa_inner_loop_step(
                             v_subblock * qktv_subblock_w);
                         v_index_offset += qktv_subblock_w;
                     }
-                    reconfig_data_format(cb_v_in, cur_out, cb_qkt_im, cur_out);
+                    if constexpr (!uniform_unpack_format) {
+                        reconfig_data_format(cb_v_in, cur_out, cb_qkt_im, cur_out);
+                    }
                 }
             }
             qktv_in0_index_offset += qktv_subblock_h * qktv_in0_block_w;
             qktv_in0_wait_tiles += qktv_in0_subblock_num_tiles;
         }
 
-        // Per-row normalization lambda
-        auto normalize_row = [&](uint32_t w_row, uint32_t& pushed) {
-            MaybeDeviceZoneScopedN(PROFILING_ENABLED, "ROW_NORM");
-            cb_push_back(cur_sum, sbh);
-            cb_push_back(cur_out, sbh * vDHt);
-            normalize_row_streaming<PROFILING_ENABLED, sbh, vDHt>(
-                cur_sum, cur_out, cb_col_identity, cb_recip_scratch, cb_normalized_out);
-            pushed++;
+        // Per-row normalization lambda — only compiled for non-ring mode
+        [[maybe_unused]] auto normalize_row = [&](uint32_t w_salad, uint32_t& pushed) {
+            if constexpr (!ring_mode) {
+                MaybeDeviceZoneScopedN(PROFILING_ENABLED, "ROW_NORM");
+                cb_push_back(cur_sum, sbh);
+                cb_push_back(cur_out, sbh * vDHt);
+                normalize_row_streaming<PROFILING_ENABLED, sbh, vDHt>(
+                    cur_sum, cur_out, cb_col_identity, cb_recip_scratch, cb_normalized_out);
+                pushed++;
+            }
         };
 
         // SALAD correction + optional normalization lambda
-        // In ring_mode, skip per-row normalization on last iter — caller does bulk finalization.
         auto salad_correct_row = [&](uint32_t salad_row, uint32_t w_salad, bool last_iter, uint32_t& pushed) {
             {
                 MaybeDeviceZoneScopedN(PROFILING_ENABLED, "S_SUM_CORR");
@@ -763,7 +831,7 @@ void sdpa_inner_loop_step(
                 MaybeDeviceZoneScopedN(PROFILING_ENABLED, "S_OUT_CORR");
                 mul_block_bcast_cols_acc<sbh, vDHt>(prev_out, cb_exp_max_diff, cur_out, salad_row, w_salad);
             }
-            if (last_iter && !ring_mode) {
+            if (last_iter) {
                 normalize_row(w_salad, pushed);
             }
         };
@@ -787,7 +855,9 @@ void sdpa_inner_loop_step(
             // Full matmul for current row
             {
                 uint32_t v_index_offset = 0;
-                reconfig_data_format(cur_out, cb_v_in, cur_out, cb_qkt_im);
+                if constexpr (!uniform_unpack_format) {
+                    reconfig_data_format(cur_out, cb_v_in, cur_out, cb_qkt_im);
+                }
                 for (uint32_t v_subblock = 0; v_subblock < qktv_v_num_subblocks; ++v_subblock) {
                     MaybeDeviceZoneScopedN(PROFILING_ENABLED, "QKT@V MM+Pack");
                     blocked_matmul_and_pack<false, qktv_subblock_w, qktv_subblock_h, qktv_in0_block_w, vDHt, vDHt>(
@@ -800,13 +870,15 @@ void sdpa_inner_loop_step(
                         v_subblock * qktv_subblock_w);
                     v_index_offset += qktv_subblock_w;
                 }
-                reconfig_data_format(cb_v_in, cur_out, cb_qkt_im, cur_out);
+                if constexpr (!uniform_unpack_format) {
+                    reconfig_data_format(cb_v_in, cur_out, cb_qkt_im, cur_out);
+                }
             }
 
             // SALAD corrections + optional per-row normalization
             if (!is_first_iter) {
                 salad_correct_row(salad_row, w_salad, is_last_iter, pushed_rows);
-            } else if (is_last_iter && !ring_mode) {
+            } else if (is_last_iter) {
                 normalize_row(w_salad, pushed_rows);
             }
 
@@ -826,14 +898,21 @@ void sdpa_inner_loop_step(
                 cb_push_back(cb_exp_max_diff, sbh);
 
                 salad_correct_row(salad_row, w_salad, is_last_iter, pushed_rows);
-            } else if (is_last_iter && !ring_mode) {
-                normalize_row(w_salad, pushed_rows);
+            } else if constexpr (!ring_mode) {
+                if (is_last_iter) {
+                    MaybeDeviceZoneScopedN(PROFILING_ENABLED, "ROW_NORM");
+                    cb_push_back(cur_sum, sbh);
+                    cb_push_back(cur_out, sbh * vDHt);
+                    normalize_row_streaming<PROFILING_ENABLED, sbh, vDHt>(
+                        cur_sum, cur_out, cb_col_identity, cb_recip_scratch, cb_normalized_out);
+                    pushed_rows++;
+                }
             }
         }
 
         // Bulk push — skip on last iteration when rows are consumed by normalization.
-        // In ring_mode, always bulk push (even on last iter) — caller handles finalization.
-        if (!is_last_iter || ring_mode) {
+        // In ring_mode, always bulk push — caller handles finalization.
+        if (ring_mode || !is_last_iter) {
             cb_push_back(cur_sum, Sq_chunk_t);
             cb_push_back(cur_out, qktv_output_num_tiles);
         }
@@ -865,7 +944,8 @@ template <
     uint32_t cb_col_identity,
     uint32_t cb_recip_scratch,
     uint32_t cb_normalized_out,
-    uint32_t cb_mask_in>
+    uint32_t cb_mask_in,
+    bool uniform_dataformat = false>
 void sdpa_standard_v2(
     const uint32_t q_chunks_per_core,
     const uint32_t k_num_chunks,
@@ -902,6 +982,7 @@ void sdpa_standard_v2(
                 use_padded_mask,
                 false,  // ring_mode
                 false,  // use_ring_mask
+                uniform_dataformat,
                 cb_q_in,
                 cb_kt_in,
                 cb_v_in,
@@ -983,7 +1064,8 @@ template <
     uint32_t cb_lse_in,
     uint32_t cb_lse_out,
     uint32_t cb_prev_out,
-    uint32_t cb_out>
+    uint32_t cb_out,
+    bool uniform_dataformat = false>
 void sdpa_ring_v2(
     const uint32_t global_q_start,
     const uint32_t global_q_end,
@@ -1004,8 +1086,10 @@ void sdpa_ring_v2(
     const uint32_t cb_max_A,
     const uint32_t cb_max_B,
     const uint32_t cb_sum_A,
-    const uint32_t cb_sum_B) {
+    const uint32_t cb_sum_B,
+    const LightweightMaskContext& lw_mask = {}) {
     constexpr uint32_t out_chunk_tiles = Sq_chunk_t * vDHt;
+    constexpr bool uniform_format = uniform_dataformat;
 
     uint32_t KV_chunks_processed_in_iter = 0;
 
@@ -1034,6 +1118,20 @@ void sdpa_ring_v2(
                               (local_n_needs_masking && k_chunk == local_n_mask_chunk_id) ||
                               (ring_iter_needs_joint_n_mask && (k_chunk - num_local_k_chunks) == joint_n_mask_chunk_id);
 
+            // Resolve lightweight mask params once per K chunk
+            uint32_t lw_num_padded = 0, lw_partial_tile_idx = 0;
+            if (apply_mask && lw_mask.enabled) {
+                if (ring_iter_needs_global_n_mask && k_chunk == global_n_mask_chunk_id) {
+                    lw_num_padded = lw_mask.global_n_padded_tiles;
+                    lw_partial_tile_idx = lw_mask.global_n_partial_tile_idx;
+                } else if (local_n_needs_masking && k_chunk == local_n_mask_chunk_id) {
+                    lw_num_padded = lw_mask.local_n_padded_tiles;
+                } else if (ring_iter_needs_joint_n_mask && (k_chunk - num_local_k_chunks) == joint_n_mask_chunk_id) {
+                    lw_num_padded = lw_mask.joint_n_padded_tiles;
+                    lw_partial_tile_idx = lw_mask.joint_l_partial_tile_idx;
+                }
+            }
+
             // Call streaming step with ring_mode=true (skip normalization, always push)
             // is_last_iter=false: Q pop and finalization handled by this outer loop.
             sdpa_inner_loop_step<
@@ -1048,6 +1146,7 @@ void sdpa_ring_v2(
                 false,  // use_padded_mask — ring uses ring mask instead
                 true,   // ring_mode
                 true,   // use_ring_mask
+                uniform_dataformat,
                 cb_q_in,
                 cb_kt_in,
                 cb_v_in,
@@ -1066,7 +1165,9 @@ void sdpa_ring_v2(
                 alias_cur_out,
                 false,  // is_last_iter
                 is_first,
-                apply_mask);
+                apply_mask,
+                lw_num_padded,
+                lw_partial_tile_idx);
 
             // Post-iteration cleanup: pop previous values and swap aliases
             if (!is_first) {
@@ -1087,69 +1188,67 @@ void sdpa_ring_v2(
         // ========== Ring Finalization ==========
         // After all K chunks: alias_prev_sum = final sum, alias_prev_max = final max,
         // alias_prev_out = final unnormalized output. alias_cur_* are empty.
+        {
+            constexpr uint32_t out_chunk_tiles = Sq_chunk_t * vDHt;
 
-        // Row-reduce the partial sum: partial_sum × col_identity → per-row sum.
-        // The K-chunk loop accumulated tile-level sums via L1 acc, but each tile still
-        // has per-column partial sums. matmul_reduce collapses them to a single per-row
-        // value, matching what sdpa_inner_loop does before its ring finalization.
-        matmul_reduce<Sq_chunk_t>(cb_col_identity, alias_prev_sum);
+            matmul_reduce<Sq_chunk_t>(cb_col_identity, alias_prev_sum);
+            log_block(alias_prev_sum, alias_cur_max, Sq_chunk_t);
+            mul_block_bcast_scalar_inplace<cb_scale_in, Sq_chunk_t>(alias_prev_max);
+            add_block_inplace(alias_prev_max, alias_cur_max, Sq_chunk_t);
+            recip_block_inplace(alias_prev_sum, Sq_chunk_t);
+            mul_block_bcast_cols_inplace<Sq_chunk_t, vDHt>(alias_prev_out, alias_prev_sum);
 
-        // 1. log(sum) → alias_cur_max (scratch)
-        log_block(alias_prev_sum, alias_cur_max, Sq_chunk_t);
+            if (ring_iter > 0) {
+                cb_wait_front(cb_lse_in, Sq_chunk_t);
+                cb_wait_front(cb_prev_out, out_chunk_tiles);
 
-        // 2. LSE = scale * max + log(sum)
-        mul_block_bcast_scalar_inplace<cb_scale_in, Sq_chunk_t>(alias_prev_max);
-        add_block_inplace(alias_prev_max, alias_cur_max, Sq_chunk_t);
+                uint32_t alias_cur_lse = alias_prev_max;
+                uint32_t alias_sig = alias_cur_max;
+                uint32_t alias_cur_out_r = alias_prev_out;
+                uint32_t alias_sub = alias_cur_out;
 
-        // 3. Normalize output: out = out / sum
-        recip_block_inplace(alias_prev_sum, Sq_chunk_t);
-        mul_block_bcast_cols_inplace<Sq_chunk_t, vDHt>(alias_prev_out, alias_prev_sum);
+                sigmoid_sub(alias_cur_lse, cb_lse_in, alias_sig, Sq_chunk_t);
 
-        if (ring_iter > 0) {
-            // Sigmoid blend with previous ring iteration's output and LSE
-            //   sig = sigmoid(cur_lse - prev_lse)
-            //   out = prev_out - sig * (prev_out - cur_out)
-            //   lse = prev_lse - logsigmoid(prev_lse - cur_lse)
-            cb_wait_front(cb_lse_in, Sq_chunk_t);
-            cb_wait_front(cb_prev_out, out_chunk_tiles);
+                if constexpr (!uniform_format) {
+                    reconfig_data_format(cb_prev_out, alias_cur_out_r);
+                }
+                sub_block(cb_prev_out, alias_cur_out_r, alias_sub, out_chunk_tiles);
+                if constexpr (!uniform_format) {
+                    reconfig_data_format(alias_sub, alias_sig);
+                }
+                mul_block_bcast_cols_inplace<Sq_chunk_t, DHt>(alias_sub, alias_sig);
+                if constexpr (!uniform_format) {
+                    reconfig_data_format(cb_prev_out, alias_sub);
+                }
+                if constexpr (!uniform_format) {
+                    pack_reconfig_data_format(cb_out);
+                }
+                sub_block(cb_prev_out, alias_sub, cb_out, out_chunk_tiles);
+                cb_pop_front(cb_prev_out, out_chunk_tiles);
+                cb_pop_front(alias_cur_out_r, out_chunk_tiles);
+                cb_pop_front(alias_sub, out_chunk_tiles);
 
-            uint32_t alias_cur_lse = alias_prev_max;    // full (contains LSE)
-            uint32_t alias_sig = alias_cur_max;         // empty
-            uint32_t alias_cur_out_r = alias_prev_out;  // full (contains normalized output)
-            uint32_t alias_sub = alias_cur_out;         // empty
-
-            // sig = sigmoid(cur_lse - prev_lse)
-            sigmoid_sub(alias_cur_lse, cb_lse_in, alias_sig, Sq_chunk_t);
-
-            // sub = prev_out - cur_out
-            reconfig_data_format(cb_prev_out, alias_cur_out_r);
-            sub_block(cb_prev_out, alias_cur_out_r, alias_sub, out_chunk_tiles);
-            // sub *= sig
-            reconfig_data_format(alias_sub, alias_sig);
-            mul_block_bcast_cols_inplace<Sq_chunk_t, DHt>(alias_sub, alias_sig);
-            // out = prev_out - sub
-            reconfig_data_format(cb_prev_out, alias_sub);
-            pack_reconfig_data_format(cb_out);
-            sub_block(cb_prev_out, alias_sub, cb_out, out_chunk_tiles);
-            cb_pop_front(cb_prev_out, out_chunk_tiles);
-            cb_pop_front(alias_cur_out_r, out_chunk_tiles);
-            cb_pop_front(alias_sub, out_chunk_tiles);
-
-            // lse = prev_lse - logsigmoid(prev_lse - cur_lse)
-            pack_reconfig_data_format(alias_sig);
-            reconfig_data_format(cb_lse_in, alias_cur_lse);
-            logsigmoid_sub(cb_lse_in, alias_cur_lse, alias_sig, Sq_chunk_t);
-            sub_block(cb_lse_in, alias_sig, cb_lse_out, Sq_chunk_t);
-            cb_pop_front(alias_sig, Sq_chunk_t);
-            cb_pop_front(alias_cur_lse, Sq_chunk_t);
-            cb_pop_front(cb_lse_in, Sq_chunk_t);
-        } else {
-            // First ring iteration: copy output and LSE directly
-            pack_reconfig_data_format(cb_out);
-            copy_block(alias_prev_out, cb_out, out_chunk_tiles);
-
-            pack_reconfig_data_format(cb_lse_out);
-            copy_block(alias_prev_max, cb_lse_out, Sq_chunk_t);
+                if constexpr (!uniform_format) {
+                    pack_reconfig_data_format(alias_sig);
+                }
+                if constexpr (!uniform_format) {
+                    reconfig_data_format(cb_lse_in, alias_cur_lse);
+                }
+                logsigmoid_sub(cb_lse_in, alias_cur_lse, alias_sig, Sq_chunk_t);
+                sub_block(cb_lse_in, alias_sig, cb_lse_out, Sq_chunk_t);
+                cb_pop_front(alias_sig, Sq_chunk_t);
+                cb_pop_front(alias_cur_lse, Sq_chunk_t);
+                cb_pop_front(cb_lse_in, Sq_chunk_t);
+            } else {
+                if constexpr (!uniform_format) {
+                    pack_reconfig_data_format(cb_out);
+                }
+                copy_block(alias_prev_out, cb_out, out_chunk_tiles);
+                if constexpr (!uniform_format) {
+                    pack_reconfig_data_format(cb_lse_out);
+                }
+                copy_block(alias_prev_max, cb_lse_out, Sq_chunk_t);
+            }
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -316,7 +316,9 @@ void mul_block_bcast_cols_acc(
     uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t q_subblock, uint32_t write_q_subblock) {
     constexpr uint32_t tiles_per_row = SBH;
     constexpr uint32_t tiles_per_column = SBW;
-    static_assert(tiles_per_row * tiles_per_column <= 8, "SBH * SBW must fit in DST (max 8 tiles)");
+    // Process columns in batches that fit SBH rows in DST (8 tiles max).
+    constexpr uint32_t COL_BATCH = (8 / SBH < SBW) ? 8 / SBH : SBW;
+    static_assert(COL_BATCH >= 1, "SBH must be <= 8");
     const uint32_t read_row_base = q_subblock * tiles_per_row;
     const uint32_t write_row_base = write_q_subblock * tiles_per_row;
     mul_bcast_cols_init_short(in0_cb, in1_cb);
@@ -325,24 +327,29 @@ void mul_block_bcast_cols_acc(
     cb_wait_front(in1_cb, (q_subblock + 1) * tiles_per_row);
 
     PACK((llk_pack_reconfig_l1_acc(1)));
-    tile_regs_acquire();
-    uint32_t dst_index = 0;
-    for (uint32_t i = 0; i < tiles_per_row; i++) {
-        for (uint32_t j = 0; j < tiles_per_column; j++) {
-            uint32_t in0_tile_index = (read_row_base + i) * tiles_per_column + j;
-            mul_tiles_bcast_cols(in0_cb, in1_cb, in0_tile_index, read_row_base + i, dst_index++);
+    for (uint32_t col_base = 0; col_base < tiles_per_column; col_base += COL_BATCH) {
+        constexpr uint32_t last_batch = tiles_per_column % COL_BATCH;
+        const uint32_t cur_cols =
+            (col_base + COL_BATCH <= tiles_per_column) ? COL_BATCH : (last_batch > 0 ? last_batch : COL_BATCH);
+        tile_regs_acquire();
+        uint32_t dst_index = 0;
+        for (uint32_t i = 0; i < tiles_per_row; i++) {
+            for (uint32_t j = 0; j < cur_cols; j++) {
+                uint32_t in0_tile_index = (read_row_base + i) * tiles_per_column + col_base + j;
+                mul_tiles_bcast_cols(in0_cb, in1_cb, in0_tile_index, read_row_base + i, dst_index++);
+            }
         }
-    }
-    tile_regs_commit();
-    tile_regs_wait();
-    dst_index = 0;
-    for (uint32_t i = 0; i < tiles_per_row; i++) {
-        for (uint32_t j = 0; j < tiles_per_column; j++) {
-            uint32_t out_tile_index = (write_row_base + i) * tiles_per_column + j;
-            pack_tile<true>(dst_index++, out_cb, out_tile_index);
+        tile_regs_commit();
+        tile_regs_wait();
+        dst_index = 0;
+        for (uint32_t i = 0; i < tiles_per_row; i++) {
+            for (uint32_t j = 0; j < cur_cols; j++) {
+                uint32_t out_tile_index = (write_row_base + i) * tiles_per_column + col_base + j;
+                pack_tile<true>(dst_index++, out_cb, out_tile_index);
+            }
         }
+        tile_regs_release();
     }
-    tile_regs_release();
     PACK((llk_pack_reconfig_l1_acc(false)));
 }
 
@@ -432,24 +439,29 @@ void normalize_row_streaming(
         }
 
         // 3. Normalize: multiply output tiles by bcast_cols(1/sum)
-        static_assert(head_dim_t_ <= 8, "head_dim_t must fit in DST (max 8 tiles)");
+        // Process in batches of up to 8 tiles (DST capacity for fp16b half-sync).
         {
             MaybeDeviceZoneScopedN(PROFILING_ENABLED, "NORM_MUL_BCAST");
+            constexpr uint32_t BATCH = (head_dim_t_ < 8) ? head_dim_t_ : 8;
             mul_bcast_cols_init_short(cur_out_cb, scratch_cb);
             cb_wait_front(cur_out_cb, head_dim_t_);
             cb_wait_front(scratch_cb, 1);
 
             cb_reserve_back(normalized_out_cb, head_dim_t_);
-            tile_regs_acquire();
-            for (uint32_t j = 0; j < head_dim_t_; ++j) {
-                mul_tiles_bcast_cols(cur_out_cb, scratch_cb, j, 0, j);
+            for (uint32_t base = 0; base < head_dim_t_; base += BATCH) {
+                constexpr uint32_t last_batch = head_dim_t_ % BATCH;
+                const uint32_t cur_batch = (base + BATCH <= head_dim_t_) ? BATCH : last_batch;
+                tile_regs_acquire();
+                for (uint32_t j = 0; j < cur_batch; ++j) {
+                    mul_tiles_bcast_cols(cur_out_cb, scratch_cb, base + j, 0, j);
+                }
+                tile_regs_commit();
+                tile_regs_wait();
+                for (uint32_t j = 0; j < cur_batch; ++j) {
+                    pack_tile(j, normalized_out_cb);
+                }
+                tile_regs_release();
             }
-            tile_regs_commit();
-            tile_regs_wait();
-            for (uint32_t j = 0; j < head_dim_t_; ++j) {
-                pack_tile(j, normalized_out_cb);
-            }
-            tile_regs_release();
             cb_push_back(normalized_out_cb, head_dim_t_);
 
             cb_pop_front(scratch_cb, 1);
@@ -573,12 +585,16 @@ void sdpa_inner_loop_step(
         for (uint32_t kt_subblock = 0; kt_subblock < kt_num_subblocks; ++kt_subblock) {
             if (q_subblock > 0) {
                 uint32_t prev_q_subblock = q_subblock - 1;
+                // Restore float16b UNPACK for sub_exp (early-exit if already float16b).
+                reconfig_data_format(cb_kt_in, cb_qkt_im, cb_q_in, cb_qkt_im);
                 sub_exp_block_bcast_cols<PROFILING_ENABLED, scale_fp32, sbh, qkt_subblock_w, true>(
                     cb_qkt_im, cur_max, cur_sum, Sk_chunk_t, prev_q_subblock, kt_subblock);
             }
 
             {
                 MaybeDeviceZoneScopedN(PROFILING_ENABLED, "Q@KT MM+Pack");
+                // Setup matmul UNPACK (early-exit if already set, e.g., q_subblock==0 consecutive calls).
+                reconfig_data_format(cb_qkt_im, cb_kt_in, cb_qkt_im, cb_q_in);
                 blocked_matmul_and_pack<true, qkt_subblock_w, sbh, in0_block_w, Sk_chunk_t, Sk_chunk_t>(
                     cb_q_in,
                     cb_kt_in,
@@ -590,6 +606,8 @@ void sdpa_inner_loop_step(
             }
             kt_index_offset += qkt_subblock_w;
         }
+        // Restore float16b for mask/reduce after Q@KT.
+        reconfig_data_format(cb_kt_in, cb_qkt_im, cb_q_in, cb_qkt_im);
 
         // Apply mask on last K chunk: only accumulate -inf onto padded K positions.
         // Skips zero-valued tiles to avoid Bfp4_b→Float16_b L1 acc round-trip artifacts.
@@ -693,6 +711,7 @@ void sdpa_inner_loop_step(
                     // Matmul — FPU overlaps with SFPU EXP
                     {
                         uint32_t v_index_offset = 0;
+                        reconfig_data_format(cur_out, cb_v_in, cur_out, cb_qkt_im);
                         for (uint32_t v_subblock = 0; v_subblock < qktv_v_num_subblocks; ++v_subblock) {
                             MaybeDeviceZoneScopedN(PROFILING_ENABLED, "QKT@V MM+Pack");
                             blocked_matmul_and_pack<false, qktv_subblock_w, qktv_subblock_h, matmul_inner, vDHt, vDHt>(
@@ -705,6 +724,7 @@ void sdpa_inner_loop_step(
                                 v_subblock * qktv_subblock_w);
                             v_index_offset += qktv_subblock_w;
                         }
+                        reconfig_data_format(cb_v_in, cur_out, cb_qkt_im, cur_out);
                     }
 
                     if (kt_sub > 0) {
@@ -722,6 +742,7 @@ void sdpa_inner_loop_step(
                 cb_wait_front(cb_qkt_im, qktv_in0_wait_tiles);
                 {
                     uint32_t v_index_offset = 0;
+                    reconfig_data_format(cur_out, cb_v_in, cur_out, cb_qkt_im);
                     for (uint32_t v_subblock = 0; v_subblock < qktv_v_num_subblocks; ++v_subblock) {
                         MaybeDeviceZoneScopedN(PROFILING_ENABLED, "QKT@V MM+Pack");
                         blocked_matmul_and_pack<false, qktv_subblock_w, qktv_subblock_h, qktv_in0_block_w, vDHt, vDHt>(
@@ -734,6 +755,7 @@ void sdpa_inner_loop_step(
                             v_subblock * qktv_subblock_w);
                         v_index_offset += qktv_subblock_w;
                     }
+                    reconfig_data_format(cb_v_in, cur_out, cb_qkt_im, cur_out);
                 }
             }
             qktv_in0_index_offset += qktv_subblock_h * qktv_in0_block_w;
@@ -785,6 +807,7 @@ void sdpa_inner_loop_step(
             // Full matmul for current row
             {
                 uint32_t v_index_offset = 0;
+                reconfig_data_format(cur_out, cb_v_in, cur_out, cb_qkt_im);
                 for (uint32_t v_subblock = 0; v_subblock < qktv_v_num_subblocks; ++v_subblock) {
                     MaybeDeviceZoneScopedN(PROFILING_ENABLED, "QKT@V MM+Pack");
                     blocked_matmul_and_pack<false, qktv_subblock_w, qktv_subblock_h, qktv_in0_block_w, vDHt, vDHt>(
@@ -797,6 +820,7 @@ void sdpa_inner_loop_step(
                         v_subblock * qktv_subblock_w);
                     v_index_offset += qktv_subblock_w;
                 }
+                reconfig_data_format(cb_v_in, cur_out, cb_qkt_im, cur_out);
             }
 
             // SALAD corrections + optional per-row normalization

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -1,0 +1,1153 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Streaming SDPA compute helpers.
+// Included only by sdpa.cpp when use_streaming_compute is true.
+// Depends on primitives from compute_common.hpp (must be included first).
+
+#pragma once
+
+#include <type_traits>
+
+#include "tools/profiler/kernel_profiler.hpp"
+
+// Template-driven profiling: MaybeDeviceZoneScopedN(ENABLED, name)
+// When ENABLED=true: RAII profileScope writes timestamps (same as DeviceZoneScopedN)
+// When ENABLED=false: empty struct, zero overhead (compiler eliminates entirely)
+#if defined(PROFILE_KERNEL)
+template <bool Enabled, uint32_t timer_id>
+struct MaybeProfileScope {
+    inline __attribute__((always_inline)) MaybeProfileScope() {}
+    inline __attribute__((always_inline)) ~MaybeProfileScope() {}
+};
+template <uint32_t timer_id>
+struct MaybeProfileScope<true, timer_id> : kernel_profiler::profileScope<timer_id> {};
+
+#define MaybeDeviceZoneScopedN(ENABLED, name)                                  \
+    DO_PRAGMA(message(PROFILER_MSG_NAME(name)));                               \
+    auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name)); \
+    MaybeProfileScope<ENABLED, hash> zone;
+#else
+#define MaybeDeviceZoneScopedN(ENABLED, name)
+#endif
+
+/**
+ * Push tiles to make them visible for UNPACK reads, but rewind wr_ptr so
+ * subsequent pack_tile<true> offsets remain relative to a stable base.
+ * This eliminates the need for separate row buffers.
+ */
+ALWI void cb_push_back_hold_wr_ptr(uint32_t cb_id, uint32_t num_tiles) {
+    cb_push_back(cb_id, num_tiles);
+    PACK(({
+        auto& intf = get_local_cb_interface(cb_id);
+        intf.fifo_wr_ptr -= num_tiles * intf.fifo_page_size;
+        uint32_t fifo_start = intf.fifo_limit - intf.fifo_size;
+        if (intf.fifo_wr_ptr < fifo_start) {
+            intf.fifo_wr_ptr += intf.fifo_size;
+        }
+    }));
+}
+
+/**
+ * Blocked subblock matmul with absolute offset packing.
+ * Always uses pack_tile<true> at row-major positions in out_cb.
+ */
+template <
+    bool TRANSPOSE,
+    uint32_t SUBBLOCK_W,
+    uint32_t SUBBLOCK_H,
+    uint32_t INNER_DIM,
+    uint32_t IN1_STRIDE,
+    uint32_t OUT_NUM_COLS>
+void blocked_matmul_and_pack(
+    uint32_t in0_cb,
+    uint32_t in1_cb,
+    uint32_t out_cb,
+    uint32_t in0_index_start,
+    uint32_t in1_index_start,
+    uint32_t q_subblock,
+    uint32_t out_col_offset) {
+    mm_block_init_short(in0_cb, in1_cb, TRANSPOSE, SUBBLOCK_W, SUBBLOCK_H, INNER_DIM);
+
+    tile_regs_acquire();
+    uint32_t dst_index = 0;
+    uint32_t in0_index = in0_index_start;
+    uint32_t in1_index = in1_index_start;
+    for (uint32_t inner = 0; inner < INNER_DIM; ++inner) {
+        matmul_block(in0_cb, in1_cb, in0_index, in1_index, dst_index, TRANSPOSE, SUBBLOCK_W, SUBBLOCK_H, INNER_DIM);
+        in0_index++;
+        in1_index += IN1_STRIDE;
+    }
+    tile_regs_commit();
+
+    tile_regs_wait();
+    uint32_t dst_idx = 0;
+    for (uint32_t r = 0; r < SUBBLOCK_H; r++) {
+        uint32_t out_row_offset = (r + q_subblock * SUBBLOCK_H) * OUT_NUM_COLS;
+        for (uint32_t c = 0; c < SUBBLOCK_W; c++) {
+            pack_tile<true>(dst_idx, out_cb, out_row_offset + out_col_offset + c);
+            dst_idx++;
+        }
+    }
+    tile_regs_release();
+}
+
+/**
+ * Per-row-group max reduction with optional eltwise_max against prev values.
+ * Reads from in0_cb at row group offset, writes to out_cb sequentially.
+ */
+template <PoolType pool_type, ReduceDim reduce_dim, uint32_t scale_cb, uint32_t cols, uint32_t SBH>
+void reduce_c_row_group(
+    uint32_t in0_cb, uint32_t out_cb, uint32_t prev_cb, uint32_t row_group_index, bool do_eltwise_max = false) {
+    constexpr uint32_t GROUP_SIZE = SBH;
+    const uint32_t row_start = row_group_index * GROUP_SIZE;
+
+    const uint32_t cumulative_input_tiles = (row_group_index + 1) * GROUP_SIZE * cols;
+    const uint32_t cumulative_prev_tiles = (row_group_index + 1) * GROUP_SIZE;
+
+    cb_wait_front(scale_cb, 1);
+    cb_wait_front(in0_cb, cumulative_input_tiles);
+
+    tile_regs_acquire();
+
+    if (do_eltwise_max) {
+        cb_wait_front(prev_cb, cumulative_prev_tiles);
+        sdpa_reduce_copy_tile_to_dst_init_short(prev_cb);
+        for (uint32_t i = 0; i < GROUP_SIZE; i++) {
+            copy_tile(prev_cb, row_start + i, i);
+        }
+    }
+
+    reduce_block_max_row_init<cols>();
+    for (uint32_t i = 0; i < GROUP_SIZE; i++) {
+        const uint32_t input_tile_start = (row_start + i) * cols;
+        reduce_block_max_row<cols>(in0_cb, scale_cb, input_tile_start, i);
+    }
+    reduce_block_max_row_uninit(in0_cb);
+
+    tile_regs_commit();
+    tile_regs_wait();
+
+    for (uint32_t i = 0; i < GROUP_SIZE; i++) {
+        pack_tile<false>(i, out_cb);
+    }
+
+    tile_regs_release();
+}
+
+/**
+ * In-place sub_exp on cb_qkt_im: subtracts max, applies exp with ReLU clamping,
+ * writes back to same positions. Accumulates row sums into reduce_cb.
+ */
+template <
+    bool PROFILING_ENABLED,
+    uint32_t scale_fp32,
+    uint32_t SBH,
+    uint32_t SBW,
+    bool do_reduce,
+    int vector_mode = (int)VectorMode::RC>
+void sub_exp_block_bcast_cols(
+    uint32_t inout_cb,
+    uint32_t max_cb,
+    uint32_t reduce_cb,
+    uint32_t cols_in_row,
+    uint32_t q_subblock,
+    uint32_t kt_subblock) {
+    constexpr uint32_t tiles_per_row = SBH;
+    constexpr uint32_t tiles_per_column = SBW;
+    static_assert(tiles_per_row * tiles_per_column <= 8, "SBH * SBW must fit in DST (max 8 tiles)");
+    const uint32_t max_row_base = q_subblock * tiles_per_row;
+    const uint32_t global_col_base = kt_subblock * tiles_per_column;
+
+    {
+        MaybeDeviceZoneScopedN(PROFILING_ENABLED, "SUB_EXP_BLOCK_INIT");
+        sub_bcast_cols_init_short(inout_cb, max_cb);
+        PACK((llk_pack_relu_config(ReluType::ZERO_RELU)));
+    }
+
+    // Cumulative wait on full CB up through this q_subblock's row
+    cb_wait_front(inout_cb, (q_subblock + 1) * tiles_per_row * cols_in_row);
+    cb_wait_front(max_cb, (q_subblock + 1) * tiles_per_row);
+
+    {
+        MaybeDeviceZoneScopedN(PROFILING_ENABLED, "SUB");
+        tile_regs_acquire();
+        uint32_t dst_index = 0;
+        for (uint32_t i = 0; i < tiles_per_row; i++) {
+            for (uint32_t j = 0; j < tiles_per_column; j++) {
+                // Absolute position in cb_qkt_im
+                uint32_t in0_tile_index = (max_row_base + i) * cols_in_row + global_col_base + j;
+                sub_tiles_bcast_cols(inout_cb, max_cb, in0_tile_index, max_row_base + i, dst_index++);
+            }
+        }
+        tile_regs_commit();
+    }
+
+    {
+        MaybeDeviceZoneScopedN(PROFILING_ENABLED, "EXP");
+        tile_regs_wait();
+        uint32_t dst_index = 0;
+        constexpr int iterations = (vector_mode == (int)VectorMode::RC) ? 32 : 8;
+        constexpr int vector_mode_exp = (vector_mode == (int)VectorMode::RC) ? (int)VectorMode::None : vector_mode;
+        for (uint32_t i = 0; i < tiles_per_row; i++) {
+            for (uint32_t j = 0; j < tiles_per_column; j++) {
+                exp_packthread_tile<true, true, false, false, InputClamping::None, iterations>(
+                    dst_index++, vector_mode_exp);
+            }
+        }
+        PACK(TTI_STALLWAIT(p_stall::STALL_PACK, p_stall::WAIT_SFPU));
+    }
+
+    {
+        MaybeDeviceZoneScopedN(PROFILING_ENABLED, "PACK SUB_EXP");
+        // Pack back to inout_cb at the same absolute positions
+        uint32_t dst_index = 0;
+        for (uint32_t i = 0; i < tiles_per_row; i++) {
+            for (uint32_t j = 0; j < tiles_per_column; ++j) {
+                uint32_t in0_tile_index = (max_row_base + i) * cols_in_row + global_col_base + j;
+                pack_tile<true>(dst_index++, inout_cb, in0_tile_index);
+            }
+        }
+
+        // Reduce to reduce_cb: first tile of first kt_subblock overwrites, rest accumulate
+        if constexpr (do_reduce) {
+            dst_index = 0;
+            for (uint32_t i = 0; i < tiles_per_row; i++) {
+                if (global_col_base > 0) {
+                    PACK((llk_pack_reconfig_l1_acc(1)));
+                } else {
+                    PACK((llk_pack_reconfig_l1_acc(0)));
+                }
+                for (uint32_t j = 0; j < tiles_per_column; ++j) {
+                    pack_tile<true>(dst_index++, reduce_cb, max_row_base + i);
+                    if (global_col_base == 0 && j == 0) {
+                        PACK((llk_pack_reconfig_l1_acc(1)));
+                    }
+                }
+            }
+        }
+    }
+
+    PACK((llk_pack_relu_config(ReluType::NO_RELU)));
+
+    tile_regs_release();
+    if constexpr (do_reduce) {
+        PACK((llk_pack_reconfig_l1_acc(0)));
+    }
+}
+
+/**
+ * Column-only exp(prev_max - cur_max) for SALAD corrections.
+ * Operates on first-column subset of tiles.
+ */
+template <bool PROFILING_ENABLED, uint32_t scale_fp32, uint32_t SBH>
+void sub_exp_first_col_blocks(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t q_subblock) {
+    constexpr uint32_t tiles_per_row = SBH;
+    const uint32_t global_row_base = q_subblock * tiles_per_row;
+    constexpr uint16_t scale_bf16 = scale_fp32 >> 16;
+
+    sub_tiles_init(in0_cb, in1_cb);
+    exp_packthread_tile_init<EXP_APPROX_MODE, false>();
+
+    cb_wait_front(in0_cb, (q_subblock + 1) * tiles_per_row);
+    cb_wait_front(in1_cb, (q_subblock + 1) * tiles_per_row);
+
+    {
+        tile_regs_acquire();
+        for (uint32_t i = 0; i < tiles_per_row; i++) {
+            uint32_t tile_index = global_row_base + i;
+            sub_tiles(in0_cb, in1_cb, tile_index, tile_index, i);
+        }
+        tile_regs_commit();
+    }
+
+    {
+        tile_regs_wait();
+        for (uint32_t dst_index = 0; dst_index < tiles_per_row; dst_index++) {
+            PACK((exp_tile_first_column<EXP_APPROX_MODE, scale_bf16>(dst_index)));
+        }
+        PACK(TTI_STALLWAIT(p_stall::STALL_PACK, p_stall::WAIT_SFPU));
+
+        for (uint32_t i = 0; i < tiles_per_row; i++) {
+            pack_tile<false>(i, out_cb);
+        }
+
+        tile_regs_release();
+    }
+}
+
+/**
+ * SALAD sum correction: out_cb[row] += in0_cb[row] * bcast_cols(in1_cb[row])
+ * with L1 accumulate at explicit offset.
+ */
+template <uint32_t SBH>
+void mul_bcast_cols_l1_acc(
+    uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t q_subblock, uint32_t write_q_subblock) {
+    constexpr uint32_t tiles_per_row = SBH;
+    const uint32_t read_row_base = q_subblock * tiles_per_row;
+    const uint32_t write_row_base = write_q_subblock * tiles_per_row;
+
+    mul_bcast_cols_init_short(in0_cb, in1_cb);
+    cb_wait_front(in0_cb, (q_subblock + 1) * tiles_per_row);
+    cb_wait_front(in1_cb, (q_subblock + 1) * tiles_per_row);
+
+    PACK((llk_pack_reconfig_l1_acc(1)));
+    tile_regs_acquire();
+    for (uint32_t i = 0; i < tiles_per_row; i++) {
+        uint32_t src_tile_index = read_row_base + i;
+        mul_tiles_bcast_cols(in0_cb, in1_cb, src_tile_index, src_tile_index, i);
+    }
+    tile_regs_commit();
+
+    tile_regs_wait();
+    for (uint32_t i = 0; i < tiles_per_row; i++) {
+        pack_tile<true>(i, out_cb, write_row_base + i);
+    }
+    tile_regs_release();
+    PACK((llk_pack_reconfig_l1_acc(0)));
+}
+
+/**
+ * SALAD output correction: block multiply with bcast_cols and L1 accumulate.
+ */
+template <uint32_t SBH, uint32_t SBW>
+void mul_block_bcast_cols_acc(
+    uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t q_subblock, uint32_t write_q_subblock) {
+    constexpr uint32_t tiles_per_row = SBH;
+    constexpr uint32_t tiles_per_column = SBW;
+    static_assert(tiles_per_row * tiles_per_column <= 8, "SBH * SBW must fit in DST (max 8 tiles)");
+    const uint32_t read_row_base = q_subblock * tiles_per_row;
+    const uint32_t write_row_base = write_q_subblock * tiles_per_row;
+    mul_bcast_cols_init_short(in0_cb, in1_cb);
+
+    cb_wait_front(in0_cb, (q_subblock + 1) * tiles_per_row * tiles_per_column);
+    cb_wait_front(in1_cb, (q_subblock + 1) * tiles_per_row);
+
+    PACK((llk_pack_reconfig_l1_acc(1)));
+    tile_regs_acquire();
+    uint32_t dst_index = 0;
+    for (uint32_t i = 0; i < tiles_per_row; i++) {
+        for (uint32_t j = 0; j < tiles_per_column; j++) {
+            uint32_t in0_tile_index = (read_row_base + i) * tiles_per_column + j;
+            mul_tiles_bcast_cols(in0_cb, in1_cb, in0_tile_index, read_row_base + i, dst_index++);
+        }
+    }
+    tile_regs_commit();
+    tile_regs_wait();
+    dst_index = 0;
+    for (uint32_t i = 0; i < tiles_per_row; i++) {
+        for (uint32_t j = 0; j < tiles_per_column; j++) {
+            uint32_t out_tile_index = (write_row_base + i) * tiles_per_column + j;
+            pack_tile<true>(dst_index++, out_cb, out_tile_index);
+        }
+    }
+    tile_regs_release();
+    PACK((llk_pack_reconfig_l1_acc(false)));
+}
+
+/**
+ * L1-accumulate only the padded K-position tiles from mask_cb onto cb_qkt_im.
+ * Only copies -inf tiles (padded columns), skipping zero tiles entirely to avoid
+ * Bfp4_b→Float16_b round-trip artifacts in L1 accumulate.
+ *
+ * @tparam padded_k_tiles  Number of padded K tiles per row (must be > 0)
+ * @tparam Sk_chunk_t      Total K tiles per row
+ * @tparam SBH             Sub-rows per row group (subblock_h)
+ *
+ * Caller must cb_wait_front(mask_cb, Sq_chunk_t * Sk_chunk_t) before calling.
+ * Caller must cb_pop_front(mask_cb, Sq_chunk_t * Sk_chunk_t) after all row groups.
+ */
+template <bool PROFILING_ENABLED, uint32_t padded_k_tiles, uint32_t Sk_chunk_t, uint32_t SBH, uint32_t Sq_chunk_t>
+void apply_mask_padded_k(uint32_t mask_cb, uint32_t out_cb, uint32_t q_subblock) {
+    MaybeDeviceZoneScopedN(PROFILING_ENABLED, "PAD_MASK");
+    static_assert(padded_k_tiles > 0, "padded_k_tiles must be > 0");
+    static_assert(padded_k_tiles < Sk_chunk_t, "padded_k_tiles must be less than Sk_chunk_t");
+    constexpr uint32_t start = Sk_chunk_t - padded_k_tiles;  // First padded column
+    constexpr uint32_t row_tiles = SBH * Sk_chunk_t;
+    const uint32_t mask_offset = q_subblock * row_tiles;
+
+    // Read -inf tiles from mask_cb and L1-accumulate onto padded positions in out_cb
+    copy_tile_to_dst_init_short(mask_cb);
+    PACK((llk_pack_reconfig_l1_acc(1)));
+
+    constexpr uint32_t DST_BATCH = 8;
+    for (uint32_t row = 0; row < SBH; row++) {
+        uint32_t out_row_offset = (q_subblock * SBH + row) * Sk_chunk_t;
+        uint32_t mask_row_offset = mask_offset + row * Sk_chunk_t;
+        for (uint32_t base = start; base < Sk_chunk_t; base += DST_BATCH) {
+            uint32_t batch = (Sk_chunk_t - base < DST_BATCH) ? (Sk_chunk_t - base) : DST_BATCH;
+            tile_regs_acquire();
+            for (uint32_t i = 0; i < batch; i++) {
+                copy_tile(mask_cb, mask_row_offset + base + i, i);
+            }
+            tile_regs_commit();
+            tile_regs_wait();
+            for (uint32_t i = 0; i < batch; i++) {
+                pack_tile<true>(i, out_cb, out_row_offset + base + i);
+            }
+            tile_regs_release();
+        }
+    }
+
+    PACK((llk_pack_reconfig_l1_acc(0)));
+}
+
+/**
+ * Per-row streaming normalization: matmul_reduce + recip-in-DST + mul_bcast_cols.
+ * Consumes (pops) sum and output tiles, writes normalized output.
+ * scratch_cb is a 1-tile CB reused for the reciprocal intermediate.
+ */
+template <bool PROFILING_ENABLED, uint32_t SBH, uint32_t head_dim_t_>
+void normalize_row_streaming(
+    uint32_t cur_sum_cb,
+    uint32_t cur_out_cb,
+    uint32_t col_identity_cb,
+    uint32_t scratch_cb,
+    uint32_t normalized_out_cb) {
+    for (uint32_t s = 0; s < SBH; s++) {
+        // 1+2. Fused matmul_reduce + recip: sum × col_identity → recip → 1/sum in scratch
+        {
+            MaybeDeviceZoneScopedN(PROFILING_ENABLED, "NORM_MATMUL_RECIP");
+            constexpr uint32_t N = 1;
+            mm_block_init_short(cur_sum_cb, col_identity_cb, 0, N, 1, N);
+            reconfig_data_format(col_identity_cb, cur_sum_cb);
+
+            cb_wait_front(col_identity_cb, N);
+            cb_wait_front(cur_sum_cb, 1);
+
+            cb_reserve_back(scratch_cb, 1);
+            tile_regs_acquire();
+            matmul_block(cur_sum_cb, col_identity_cb, 0, 0, 0, 0, N, 1, N);
+            recip_tile_init();
+            MATH((recip_tile_first_column(0)));
+            tile_regs_commit();
+
+            tile_regs_wait();
+            pack_tile(0, scratch_cb);
+            tile_regs_release();
+            cb_push_back(scratch_cb, 1);
+
+            cb_pop_front(cur_sum_cb, 1);
+        }
+
+        // 3. Normalize: multiply output tiles by bcast_cols(1/sum)
+        static_assert(head_dim_t_ <= 8, "head_dim_t must fit in DST (max 8 tiles)");
+        {
+            MaybeDeviceZoneScopedN(PROFILING_ENABLED, "NORM_MUL_BCAST");
+            mul_bcast_cols_init_short(cur_out_cb, scratch_cb);
+            cb_wait_front(cur_out_cb, head_dim_t_);
+            cb_wait_front(scratch_cb, 1);
+
+            cb_reserve_back(normalized_out_cb, head_dim_t_);
+            tile_regs_acquire();
+            for (uint32_t j = 0; j < head_dim_t_; ++j) {
+                mul_tiles_bcast_cols(cur_out_cb, scratch_cb, j, 0, j);
+            }
+            tile_regs_commit();
+            tile_regs_wait();
+            for (uint32_t j = 0; j < head_dim_t_; ++j) {
+                pack_tile(j, normalized_out_cb);
+            }
+            tile_regs_release();
+            cb_push_back(normalized_out_cb, head_dim_t_);
+
+            cb_pop_front(scratch_cb, 1);
+            cb_pop_front(cur_out_cb, head_dim_t_);
+        }
+    }
+}
+
+// ===================== Streaming SDPA Core Functions =====================
+
+/**
+ * L1-accumulate ring mask tiles onto QKT for one row group (q_subblock).
+ * Copies mask tiles from cb_mask_in and adds them in-place to cb_qkt_im using L1 accumulation.
+ */
+template <uint32_t Sk_chunk_t, uint32_t sbh, uint32_t cb_mask_in, uint32_t cb_qkt_im>
+void apply_ring_mask_to_qkt(uint32_t q_subblock) {
+    constexpr uint32_t DST_BATCH = 8;
+    for (uint32_t row = 0; row < sbh; row++) {
+        uint32_t out_row_offset = (q_subblock * sbh + row) * Sk_chunk_t;
+        uint32_t mask_row_offset = (q_subblock * sbh + row) * Sk_chunk_t;
+        copy_tile_to_dst_init_short(cb_mask_in);
+        PACK((llk_pack_reconfig_l1_acc(1)));
+        for (uint32_t base = 0; base < Sk_chunk_t; base += DST_BATCH) {
+            uint32_t batch = (Sk_chunk_t - base < DST_BATCH) ? (Sk_chunk_t - base) : DST_BATCH;
+            tile_regs_acquire();
+            for (uint32_t i = 0; i < batch; i++) {
+                copy_tile(cb_mask_in, mask_row_offset + base + i, i);
+            }
+            tile_regs_commit();
+            tile_regs_wait();
+            for (uint32_t i = 0; i < batch; i++) {
+                pack_tile<true>(i, cb_qkt_im, out_row_offset + base + i);
+            }
+            tile_regs_release();
+        }
+        PACK((llk_pack_reconfig_l1_acc(0)));
+    }
+}
+
+/**
+ * One K-chunk iteration of the streaming SDPA algorithm (v2 — no row buffers).
+ * Phase 1: Q@KT directly into cb_qkt_im with cb_push_back_hold_wr_ptr, in-place sub_exp.
+ * Phase 2: Drain + QKT@V with SALAD corrections, streaming normalization on last K iter.
+ */
+template <
+    bool PROFILING_ENABLED,
+    uint32_t Sq_chunk_t,
+    uint32_t Sk_chunk_t,
+    uint32_t Skt,
+    uint32_t DHt,
+    uint32_t vDHt,
+    uint32_t scale_fp32,
+    uint32_t subblock_h,
+    bool use_padded_mask,
+    bool ring_mode = false,
+    bool use_ring_mask = false,
+    uint32_t cb_q_in = 0,
+    uint32_t cb_kt_in = 0,
+    uint32_t cb_v_in = 0,
+    uint32_t cb_qkt_im = 0,
+    uint32_t cb_identity_scale_in = 0,
+    uint32_t cb_exp_max_diff = 0,
+    uint32_t cb_col_identity = 0,
+    uint32_t cb_recip_scratch = 0,
+    uint32_t cb_normalized_out = 0,
+    uint32_t cb_mask_in = 0>
+void sdpa_inner_loop_step(
+    const uint32_t prev_max,
+    const uint32_t cur_max,
+    const uint32_t prev_sum,
+    const uint32_t cur_sum,
+    const uint32_t prev_out,
+    const uint32_t cur_out,
+    const bool is_last_iter,
+    const bool is_first_iter,
+    [[maybe_unused]] const bool apply_mask = false) {
+    constexpr uint32_t sbh = subblock_h;
+    constexpr uint32_t in0_block_w = DHt;
+    constexpr uint32_t qkt_subblock_w = 8 / sbh;
+    // Compute padded K tiles from compile-time Skt and Sk_chunk_t
+    constexpr uint32_t padded_k_tiles = (Sk_chunk_t - (Skt % Sk_chunk_t)) % Sk_chunk_t;
+    constexpr uint32_t q_num_subblocks = Sq_chunk_t / sbh;
+    constexpr uint32_t kt_num_subblocks = Sk_chunk_t / qkt_subblock_w;
+    constexpr uint32_t q_subblock_num_tiles = sbh * in0_block_w;
+    constexpr uint32_t row_tiles = sbh * Sk_chunk_t;
+
+    static_assert(sbh * qkt_subblock_w <= 8, "sbh * qkt_subblock_w must fit in DST (max 8 tiles)");
+    static_assert(Sk_chunk_t % qkt_subblock_w == 0, "Sk_chunk_t must be divisible by qkt_subblock_w");
+    static_assert(Sq_chunk_t % sbh == 0, "Sq_chunk_t must be divisible by subblock_h");
+    static_assert(!(use_padded_mask && use_ring_mask), "use_padded_mask and use_ring_mask are mutually exclusive");
+
+    uint32_t pushed_rows = 0;
+    uint32_t q_wait_tiles = q_subblock_num_tiles;
+    uint32_t q_index_offset = 0;
+    uint32_t kt_index_offset = 0;
+
+    exp_packthread_tile_init<true, true, scale_fp32, InputClamping::None>();
+
+    pack_reconfig_data_format(cb_qkt_im);
+    reconfig_data_format(cb_kt_in, cb_q_in);
+    cb_reserve_back(cb_qkt_im, Sq_chunk_t * Sk_chunk_t);
+
+    cb_wait_front(cb_kt_in, DHt * Sk_chunk_t);
+    cb_reserve_back(cur_sum, Sq_chunk_t);
+
+    // Wait for mask tiles if writer generates them (Q or K padding)
+    if constexpr (use_padded_mask) {
+        if (is_last_iter) {
+            cb_wait_front(cb_mask_in, Sq_chunk_t * Sk_chunk_t);
+        }
+    }
+
+    // ========== PHASE 1: Q@KT directly into cb_qkt_im ==========
+    // All matmul output goes to cb_qkt_im at absolute offsets via pack_tile<true>.
+    // cb_push_back_hold_wr_ptr makes each row visible to UNPACK without advancing wr_ptr.
+    for (uint32_t q_subblock = 0; q_subblock < q_num_subblocks; q_subblock++) {
+        MaybeDeviceZoneScopedN(PROFILING_ENABLED, "Softmax(Q@KT)");
+        cb_wait_front(cb_q_in, q_wait_tiles);
+        kt_index_offset = 0;
+
+        for (uint32_t kt_subblock = 0; kt_subblock < kt_num_subblocks; ++kt_subblock) {
+            if (q_subblock > 0) {
+                uint32_t prev_q_subblock = q_subblock - 1;
+                sub_exp_block_bcast_cols<PROFILING_ENABLED, scale_fp32, sbh, qkt_subblock_w, true>(
+                    cb_qkt_im, cur_max, cur_sum, Sk_chunk_t, prev_q_subblock, kt_subblock);
+            }
+
+            {
+                MaybeDeviceZoneScopedN(PROFILING_ENABLED, "Q@KT MM+Pack");
+                blocked_matmul_and_pack<true, qkt_subblock_w, sbh, in0_block_w, Sk_chunk_t, Sk_chunk_t>(
+                    cb_q_in,
+                    cb_kt_in,
+                    cb_qkt_im,
+                    q_index_offset,
+                    kt_index_offset,
+                    q_subblock,
+                    kt_subblock * qkt_subblock_w);
+            }
+            kt_index_offset += qkt_subblock_w;
+        }
+
+        // Apply mask on last K chunk: only accumulate -inf onto padded K positions.
+        // Skips zero-valued tiles to avoid Bfp4_b→Float16_b L1 acc round-trip artifacts.
+        if constexpr (padded_k_tiles > 0) {
+            if (is_last_iter) {
+                apply_mask_padded_k<PROFILING_ENABLED, padded_k_tiles, Sk_chunk_t, sbh, Sq_chunk_t>(
+                    cb_mask_in, cb_qkt_im, q_subblock);
+            }
+        }
+
+        // Ring mask: L1-accumulate full mask tiles onto cb_qkt_im for this row group.
+        // Wait deferred to here so reader can overlap mask fetch with Q@KT matmul.
+        if constexpr (use_ring_mask) {
+            if (apply_mask) {
+                if (q_subblock == 0) {
+                    cb_wait_front(cb_mask_in, Sq_chunk_t * Sk_chunk_t);
+                }
+                MaybeDeviceZoneScopedN(PROFILING_ENABLED, "RING_MASK");
+                apply_ring_mask_to_qkt<Sk_chunk_t, sbh, cb_mask_in, cb_qkt_im>(q_subblock);
+            }
+        }
+
+        // Push row (visible for UNPACK reads) but keep wr_ptr stable
+        cb_push_back_hold_wr_ptr(cb_qkt_im, row_tiles);
+
+        // Max reduce: reads from cb_qkt_im at q_subblock position
+        {
+            MaybeDeviceZoneScopedN(PROFILING_ENABLED, "Reduce max");
+            cb_reserve_back(cur_max, sbh);
+            reduce_c_row_group<PoolType::MAX, ReduceDim::REDUCE_ROW, cb_identity_scale_in, Sk_chunk_t, sbh>(
+                cb_qkt_im, cur_max, prev_max, q_subblock, !is_first_iter /*do_eltwise_max*/);
+            cb_push_back(cur_max, sbh);
+        }
+
+        q_index_offset += sbh * in0_block_w;
+        q_wait_tiles += q_subblock_num_tiles;
+    }
+
+    cb_pop_front(cb_kt_in, DHt * Sk_chunk_t);
+
+    // Q is no longer needed after Phase 1. On the last K chunk, pop early so the
+    // reader can start fetching the next Q chunk during Phase 2.
+    if (is_last_iter) {
+        cb_pop_front(cb_q_in, Sq_chunk_t * DHt);
+    }
+
+    // Pop mask after all rows processed (must match writer's generate_mask push)
+    if constexpr (use_padded_mask) {
+        if (is_last_iter) {
+            cb_pop_front(cb_mask_in, Sq_chunk_t * Sk_chunk_t);
+        }
+    }
+
+    // Pop ring mask after all row groups processed
+    if constexpr (use_ring_mask) {
+        if (apply_mask) {
+            cb_pop_front(cb_mask_in, Sq_chunk_t * Sk_chunk_t);
+        }
+    }
+
+    // ========== PHASE 2: Drain last row + QKT@V + SALAD ==========
+    // After Phase 1: all rows are pushed (via hold_wr_ptr) in cb_qkt_im.
+    // Rows 0..N-2 are softmax'd in-place; row N-1 has raw matmul output.
+    {
+        constexpr uint32_t qktv_subblock_h = sbh;
+        constexpr uint32_t qktv_subblock_w = (vDHt < 4) ? vDHt : 4;
+        constexpr uint32_t qktv_in0_block_w = Sk_chunk_t;
+        constexpr uint32_t qktv_q_num_subblocks = Sq_chunk_t / qktv_subblock_h;
+        constexpr uint32_t qktv_v_num_subblocks = vDHt / qktv_subblock_w;
+        constexpr uint32_t qktv_output_num_tiles = Sq_chunk_t * vDHt;
+        constexpr uint32_t qktv_in0_subblock_num_tiles = qktv_subblock_h * qktv_in0_block_w;
+
+        uint32_t qktv_in0_index_offset = 0;
+        uint32_t qktv_in0_wait_tiles = qktv_in0_subblock_num_tiles;
+
+        cb_wait_front(cb_v_in, Sk_chunk_t * vDHt);
+        cb_reserve_back(cur_out, qktv_output_num_tiles);
+
+        // q_subblock 0: drain last row's sub_exp in-place + first QKT@V matmul
+        {
+            MaybeDeviceZoneScopedN(PROFILING_ENABLED, "Softmax(Q@KT)@V");
+            static_assert(
+                kt_num_subblocks >= 1 && kt_num_subblocks <= 4,
+                "kt_num_subblocks must be 1-4 (sbh=1: Sk=8/16, sbh=2: Sk=4/8/16)");
+
+            if constexpr (sbh == 1) {
+                // sbh=1: split-matmul overlap (inner dim split across kt_num_subblocks)
+                constexpr uint32_t matmul_inner = qktv_in0_block_w / kt_num_subblocks;
+                for (uint32_t kt_sub = 0; kt_sub < kt_num_subblocks; ++kt_sub) {
+                    // sub_exp drain in-place on cb_qkt_im
+                    sub_exp_block_bcast_cols<PROFILING_ENABLED, scale_fp32, sbh, qkt_subblock_w, true>(
+                        cb_qkt_im, cur_max, cur_sum, Sk_chunk_t, q_num_subblocks - 1, kt_sub);
+
+                    if (kt_sub == 0) {
+                        cb_wait_front(cb_qkt_im, qktv_in0_wait_tiles);
+                    }
+                    if (kt_sub > 0) {
+                        PACK((llk_pack_reconfig_l1_acc(1)));
+                    }
+
+                    // Matmul — FPU overlaps with SFPU EXP
+                    {
+                        uint32_t v_index_offset = 0;
+                        for (uint32_t v_subblock = 0; v_subblock < qktv_v_num_subblocks; ++v_subblock) {
+                            MaybeDeviceZoneScopedN(PROFILING_ENABLED, "QKT@V MM+Pack");
+                            blocked_matmul_and_pack<false, qktv_subblock_w, qktv_subblock_h, matmul_inner, vDHt, vDHt>(
+                                cb_qkt_im,
+                                cb_v_in,
+                                cur_out,
+                                qktv_in0_index_offset + kt_sub * matmul_inner,
+                                kt_sub * matmul_inner * vDHt + v_index_offset,
+                                0,
+                                v_subblock * qktv_subblock_w);
+                            v_index_offset += qktv_subblock_w;
+                        }
+                    }
+
+                    if (kt_sub > 0) {
+                        PACK((llk_pack_reconfig_l1_acc(0)));
+                    }
+                }
+            } else {
+                // sbh > 1: drain all sub_exp in-place, then full matmul (no split)
+                // Can't split inner dim because matmul_block uses INNER_DIM as in0 row stride
+                for (uint32_t kt_sub = 0; kt_sub < kt_num_subblocks; ++kt_sub) {
+                    sub_exp_block_bcast_cols<PROFILING_ENABLED, scale_fp32, sbh, qkt_subblock_w, true>(
+                        cb_qkt_im, cur_max, cur_sum, Sk_chunk_t, q_num_subblocks - 1, kt_sub);
+                }
+
+                cb_wait_front(cb_qkt_im, qktv_in0_wait_tiles);
+                {
+                    uint32_t v_index_offset = 0;
+                    for (uint32_t v_subblock = 0; v_subblock < qktv_v_num_subblocks; ++v_subblock) {
+                        MaybeDeviceZoneScopedN(PROFILING_ENABLED, "QKT@V MM+Pack");
+                        blocked_matmul_and_pack<false, qktv_subblock_w, qktv_subblock_h, qktv_in0_block_w, vDHt, vDHt>(
+                            cb_qkt_im,
+                            cb_v_in,
+                            cur_out,
+                            qktv_in0_index_offset,
+                            v_index_offset,
+                            0,
+                            v_subblock * qktv_subblock_w);
+                        v_index_offset += qktv_subblock_w;
+                    }
+                }
+            }
+            qktv_in0_index_offset += qktv_subblock_h * qktv_in0_block_w;
+            qktv_in0_wait_tiles += qktv_in0_subblock_num_tiles;
+        }
+
+        // Per-row normalization lambda
+        auto normalize_row = [&](uint32_t w_row, uint32_t& pushed) {
+            MaybeDeviceZoneScopedN(PROFILING_ENABLED, "ROW_NORM");
+            cb_push_back(cur_sum, sbh);
+            cb_push_back(cur_out, sbh * vDHt);
+            normalize_row_streaming<PROFILING_ENABLED, sbh, vDHt>(
+                cur_sum, cur_out, cb_col_identity, cb_recip_scratch, cb_normalized_out);
+            pushed++;
+        };
+
+        // SALAD correction + optional normalization lambda
+        // In ring_mode, skip per-row normalization on last iter — caller does bulk finalization.
+        auto salad_correct_row = [&](uint32_t salad_row, uint32_t w_salad, bool last_iter, uint32_t& pushed) {
+            {
+                MaybeDeviceZoneScopedN(PROFILING_ENABLED, "S_SUM_CORR");
+                mul_bcast_cols_l1_acc<sbh>(prev_sum, cb_exp_max_diff, cur_sum, salad_row, w_salad);
+            }
+            {
+                MaybeDeviceZoneScopedN(PROFILING_ENABLED, "S_OUT_CORR");
+                mul_block_bcast_cols_acc<sbh, vDHt>(prev_out, cb_exp_max_diff, cur_out, salad_row, w_salad);
+            }
+            if (last_iter && !ring_mode) {
+                normalize_row(w_salad, pushed);
+            }
+        };
+
+        // q_subblock 1..N-1: SALAD(prev) overlapped with matmul(cur)
+        for (uint32_t q_subblock = 1; q_subblock < qktv_q_num_subblocks; ++q_subblock) {
+            MaybeDeviceZoneScopedN(PROFILING_ENABLED, "Softmax(Q@KT)@V");
+            uint32_t salad_row = q_subblock - 1;
+            uint32_t w_salad = salad_row - pushed_rows;
+            uint32_t w_q = q_subblock - pushed_rows;
+
+            cb_wait_front(cb_qkt_im, qktv_in0_wait_tiles);
+
+            if (!is_first_iter) {
+                cb_reserve_back(cb_exp_max_diff, sbh);
+                sub_exp_first_col_blocks<PROFILING_ENABLED, scale_fp32, sbh>(
+                    prev_max, cur_max, cb_exp_max_diff, salad_row);
+                cb_push_back(cb_exp_max_diff, sbh);
+            }
+
+            // Full matmul for current row
+            {
+                uint32_t v_index_offset = 0;
+                for (uint32_t v_subblock = 0; v_subblock < qktv_v_num_subblocks; ++v_subblock) {
+                    MaybeDeviceZoneScopedN(PROFILING_ENABLED, "QKT@V MM+Pack");
+                    blocked_matmul_and_pack<false, qktv_subblock_w, qktv_subblock_h, qktv_in0_block_w, vDHt, vDHt>(
+                        cb_qkt_im,
+                        cb_v_in,
+                        cur_out,
+                        qktv_in0_index_offset,
+                        v_index_offset,
+                        w_q,
+                        v_subblock * qktv_subblock_w);
+                    v_index_offset += qktv_subblock_w;
+                }
+            }
+
+            // SALAD corrections + optional per-row normalization
+            if (!is_first_iter) {
+                salad_correct_row(salad_row, w_salad, is_last_iter, pushed_rows);
+            } else if (is_last_iter && !ring_mode) {
+                normalize_row(w_salad, pushed_rows);
+            }
+
+            qktv_in0_index_offset += qktv_subblock_h * qktv_in0_block_w;
+            qktv_in0_wait_tiles += qktv_in0_subblock_num_tiles;
+        }
+
+        // Pipeline drain: SALAD for last row
+        {
+            constexpr uint32_t salad_row = qktv_q_num_subblocks - 1;
+            uint32_t w_salad = salad_row - pushed_rows;
+
+            if (!is_first_iter) {
+                cb_reserve_back(cb_exp_max_diff, sbh);
+                sub_exp_first_col_blocks<PROFILING_ENABLED, scale_fp32, sbh>(
+                    prev_max, cur_max, cb_exp_max_diff, salad_row);
+                cb_push_back(cb_exp_max_diff, sbh);
+
+                salad_correct_row(salad_row, w_salad, is_last_iter, pushed_rows);
+            } else if (is_last_iter && !ring_mode) {
+                normalize_row(w_salad, pushed_rows);
+            }
+        }
+
+        // Bulk push — skip on last iteration when rows are consumed by normalization.
+        // In ring_mode, always bulk push (even on last iter) — caller handles finalization.
+        if (!is_last_iter || ring_mode) {
+            cb_push_back(cur_sum, Sq_chunk_t);
+            cb_push_back(cur_out, qktv_output_num_tiles);
+        }
+
+        cb_pop_front(cb_v_in, Sk_chunk_t * vDHt);
+        cb_pop_front(cb_qkt_im, Sq_chunk_t * Sk_chunk_t);
+    }
+}
+
+/**
+ * Streaming SDPA wrapper (v2): Q-chunk / K-chunk outer loop with ping-pong buffer management.
+ * No row buffers — uses cb_push_back_hold_wr_ptr for direct cb_qkt_im writes.
+ */
+template <
+    uint32_t Sq_chunk_t,
+    uint32_t Sk_chunk_t,
+    uint32_t Skt,
+    uint32_t DHt,
+    uint32_t vDHt,
+    uint32_t scale_fp32,
+    uint32_t subblock_h,
+    bool use_padded_mask,
+    uint32_t cb_q_in,
+    uint32_t cb_kt_in,
+    uint32_t cb_v_in,
+    uint32_t cb_qkt_im,
+    uint32_t cb_identity_scale_in,
+    uint32_t cb_exp_max_diff,
+    uint32_t cb_col_identity,
+    uint32_t cb_recip_scratch,
+    uint32_t cb_normalized_out,
+    uint32_t cb_mask_in>
+void sdpa_standard_v2(
+    const uint32_t q_chunks_per_core,
+    const uint32_t k_num_chunks,
+    const uint32_t cb_out_im_A,
+    const uint32_t cb_out_im_B,
+    const uint32_t cb_max_A,
+    const uint32_t cb_max_B,
+    const uint32_t cb_sum_A,
+    const uint32_t cb_sum_B) {
+    for (uint32_t q = 0; q < q_chunks_per_core; q++) {
+        uint32_t alias_prev_sum = cb_sum_A, alias_cur_sum = cb_sum_B;
+        uint32_t alias_prev_max = cb_max_A, alias_cur_max = cb_max_B;
+        uint32_t alias_prev_out = cb_out_im_A, alias_cur_out = cb_out_im_B;
+
+        // Per-iteration profiling via call_step: pass std::true_type{} to enable
+        // MaybeDeviceZoneScopedN in sdpa_inner_loop_step, std::false_type{} to disable.
+        // To profile specific iterations, change the gating condition below.
+        auto call_step = [&](auto profiling_tag, bool is_last, bool is_first) {
+            sdpa_inner_loop_step<
+                decltype(profiling_tag)::value,
+                Sq_chunk_t,
+                Sk_chunk_t,
+                Skt,
+                DHt,
+                vDHt,
+                scale_fp32,
+                subblock_h,
+                use_padded_mask,
+                false,  // ring_mode
+                false,  // use_ring_mask
+                cb_q_in,
+                cb_kt_in,
+                cb_v_in,
+                cb_qkt_im,
+                cb_identity_scale_in,
+                cb_exp_max_diff,
+                cb_col_identity,
+                cb_recip_scratch,
+                cb_normalized_out,
+                cb_mask_in>(
+                alias_prev_max,
+                alias_cur_max,
+                alias_prev_sum,
+                alias_cur_sum,
+                alias_prev_out,
+                alias_cur_out,
+                is_last,
+                is_first);
+
+            // Post-iteration cleanup
+            if (!is_first) {
+                cb_pop_front(cb_exp_max_diff, Sq_chunk_t);
+                cb_pop_front(alias_prev_max, Sq_chunk_t);
+                cb_pop_front(alias_prev_sum, Sq_chunk_t);
+                cb_pop_front(alias_prev_out, Sq_chunk_t * vDHt);
+            }
+
+            if (is_last) {
+                cb_pop_front(alias_cur_max, Sq_chunk_t);
+            } else {
+                std::swap(alias_prev_max, alias_cur_max);
+                std::swap(alias_prev_sum, alias_cur_sum);
+                std::swap(alias_prev_out, alias_cur_out);
+            }
+        };
+
+        for (uint32_t k_chunk = 0; k_chunk < k_num_chunks; k_chunk++) {
+            bool is_first = (k_chunk == 0);
+            bool is_last = (k_chunk == k_num_chunks - 1);
+
+            // Default: profiling disabled. To profile specific iterations:
+            // if (is_first) {
+            //     call_step(std::true_type{}, is_last, is_first);
+            // } else {
+            //     call_step(std::false_type{}, is_last, is_first);
+            // }
+            call_step(std::false_type{}, is_last, is_first);
+        }
+        // Q already popped inside sdpa_inner_loop_step after Phase 1 of the last K chunk.
+    }
+}
+
+/**
+ * Streaming Ring SDPA (v2): Ring-aware variant of sdpa_standard_v2.
+ * Calls sdpa_inner_loop_step with ring_mode=true and use_ring_mask=true.
+ * After K-chunk loop: performs ring finalization (log, LSE, recip, sigmoid blend).
+ *
+ * Per-Q-chunk outer loop with ping-pong buffer management.
+ * Per ring iteration, processes all Q chunks over [global_q_start, global_q_end).
+ */
+template <
+    uint32_t Sq_chunk_t,
+    uint32_t Sk_chunk_t,
+    uint32_t Skt,
+    uint32_t DHt,
+    uint32_t vDHt,
+    uint32_t scale_fp32,
+    uint32_t subblock_h,
+    uint32_t cb_q_in,
+    uint32_t cb_kt_in,
+    uint32_t cb_v_in,
+    uint32_t cb_qkt_im,
+    uint32_t cb_identity_scale_in,
+    uint32_t cb_exp_max_diff,
+    uint32_t cb_col_identity,
+    uint32_t cb_recip_scratch,
+    uint32_t cb_mask_in,
+    uint32_t cb_scale_in,
+    uint32_t cb_lse_in,
+    uint32_t cb_lse_out,
+    uint32_t cb_prev_out,
+    uint32_t cb_out>
+void sdpa_ring_v2(
+    const uint32_t global_q_start,
+    const uint32_t global_q_end,
+    const uint32_t num_kv_chunks,
+    const uint32_t ring_iter,
+    const uint32_t ring_id,
+    const uint32_t num_local_k_chunks,
+    const uint32_t local_padded_Nt,
+    const uint32_t logical_nt,
+    const bool ring_iter_needs_global_n_mask,
+    const bool ring_iter_needs_joint_n_mask,
+    const bool local_n_needs_masking,
+    const uint32_t global_n_mask_chunk_id,
+    const uint32_t local_n_mask_chunk_id,
+    const uint32_t joint_n_mask_chunk_id,
+    const uint32_t cb_out_im_A,
+    const uint32_t cb_out_im_B,
+    const uint32_t cb_max_A,
+    const uint32_t cb_max_B,
+    const uint32_t cb_sum_A,
+    const uint32_t cb_sum_B) {
+    constexpr uint32_t out_chunk_tiles = Sq_chunk_t * vDHt;
+
+    uint32_t KV_chunks_processed_in_iter = 0;
+
+    for (uint32_t q = global_q_start; q < global_q_end; q++) {
+        uint32_t alias_prev_sum = cb_sum_A, alias_cur_sum = cb_sum_B;
+        uint32_t alias_prev_max = cb_max_A, alias_cur_max = cb_max_B;
+        uint32_t alias_prev_out = cb_out_im_A, alias_cur_out = cb_out_im_B;
+
+        uint32_t KV_chunks_processed = 0;
+
+        for (uint32_t k_chunk = 0; k_chunk < num_kv_chunks; ++k_chunk) {
+            // Skip KV chunks beyond logical sequence length (non-joint only)
+            const bool kv_chunk_is_joint = k_chunk >= num_local_k_chunks;
+            const uint32_t kv_global_start_tile = local_padded_Nt * ring_id + k_chunk * Sk_chunk_t;
+            if (!kv_chunk_is_joint && (kv_global_start_tile >= logical_nt)) {
+                continue;
+            }
+
+            KV_chunks_processed++;
+            KV_chunks_processed_in_iter++;
+
+            bool is_first = (KV_chunks_processed == 1);
+
+            // Determine if this K chunk needs masking
+            bool apply_mask = (ring_iter_needs_global_n_mask && k_chunk == global_n_mask_chunk_id) ||
+                              (local_n_needs_masking && k_chunk == local_n_mask_chunk_id) ||
+                              (ring_iter_needs_joint_n_mask && (k_chunk - num_local_k_chunks) == joint_n_mask_chunk_id);
+
+            // Call streaming step with ring_mode=true (skip normalization, always push)
+            // is_last_iter=false: Q pop and finalization handled by this outer loop.
+            sdpa_inner_loop_step<
+                false,  // PROFILING_ENABLED
+                Sq_chunk_t,
+                Sk_chunk_t,
+                Skt,
+                DHt,
+                vDHt,
+                scale_fp32,
+                subblock_h,
+                false,  // use_padded_mask — ring uses ring mask instead
+                true,   // ring_mode
+                true,   // use_ring_mask
+                cb_q_in,
+                cb_kt_in,
+                cb_v_in,
+                cb_qkt_im,
+                cb_identity_scale_in,
+                cb_exp_max_diff,
+                cb_col_identity,
+                cb_recip_scratch,
+                0,  // cb_normalized_out — unused in ring_mode (no per-row normalization)
+                cb_mask_in>(
+                alias_prev_max,
+                alias_cur_max,
+                alias_prev_sum,
+                alias_cur_sum,
+                alias_prev_out,
+                alias_cur_out,
+                false,  // is_last_iter
+                is_first,
+                apply_mask);
+
+            // Post-iteration cleanup: pop previous values and swap aliases
+            if (!is_first) {
+                cb_pop_front(cb_exp_max_diff, Sq_chunk_t);
+                cb_pop_front(alias_prev_max, Sq_chunk_t);
+                cb_pop_front(alias_prev_sum, Sq_chunk_t);
+                cb_pop_front(alias_prev_out, Sq_chunk_t * vDHt);
+            }
+
+            std::swap(alias_prev_max, alias_cur_max);
+            std::swap(alias_prev_sum, alias_cur_sum);
+            std::swap(alias_prev_out, alias_cur_out);
+        }
+
+        // Pop Q — not popped inside step since is_last_iter was always false
+        cb_pop_front(cb_q_in, Sq_chunk_t * DHt);
+
+        // ========== Ring Finalization ==========
+        // After all K chunks: alias_prev_sum = final sum, alias_prev_max = final max,
+        // alias_prev_out = final unnormalized output. alias_cur_* are empty.
+
+        // Row-reduce the partial sum: partial_sum × col_identity → per-row sum.
+        // The K-chunk loop accumulated tile-level sums via L1 acc, but each tile still
+        // has per-column partial sums. matmul_reduce collapses them to a single per-row
+        // value, matching what sdpa_inner_loop does before its ring finalization.
+        matmul_reduce<Sq_chunk_t>(cb_col_identity, alias_prev_sum);
+
+        // 1. log(sum) → alias_cur_max (scratch)
+        log_block(alias_prev_sum, alias_cur_max, Sq_chunk_t);
+
+        // 2. LSE = scale * max + log(sum)
+        mul_block_bcast_scalar_inplace<cb_scale_in, Sq_chunk_t>(alias_prev_max);
+        add_block_inplace(alias_prev_max, alias_cur_max, Sq_chunk_t);
+
+        // 3. Normalize output: out = out / sum
+        recip_block_inplace(alias_prev_sum, Sq_chunk_t);
+        mul_block_bcast_cols_inplace<Sq_chunk_t, vDHt>(alias_prev_out, alias_prev_sum);
+
+        if (ring_iter > 0) {
+            // Sigmoid blend with previous ring iteration's output and LSE
+            //   sig = sigmoid(cur_lse - prev_lse)
+            //   out = prev_out - sig * (prev_out - cur_out)
+            //   lse = prev_lse - logsigmoid(prev_lse - cur_lse)
+            cb_wait_front(cb_lse_in, Sq_chunk_t);
+            cb_wait_front(cb_prev_out, out_chunk_tiles);
+
+            uint32_t alias_cur_lse = alias_prev_max;    // full (contains LSE)
+            uint32_t alias_sig = alias_cur_max;         // empty
+            uint32_t alias_cur_out_r = alias_prev_out;  // full (contains normalized output)
+            uint32_t alias_sub = alias_cur_out;         // empty
+
+            // sig = sigmoid(cur_lse - prev_lse)
+            sigmoid_sub(alias_cur_lse, cb_lse_in, alias_sig, Sq_chunk_t);
+
+            // sub = prev_out - cur_out
+            reconfig_data_format(cb_prev_out, alias_cur_out_r);
+            sub_block(cb_prev_out, alias_cur_out_r, alias_sub, out_chunk_tiles);
+            // sub *= sig
+            reconfig_data_format(alias_sub, alias_sig);
+            mul_block_bcast_cols_inplace<Sq_chunk_t, DHt>(alias_sub, alias_sig);
+            // out = prev_out - sub
+            reconfig_data_format(cb_prev_out, alias_sub);
+            pack_reconfig_data_format(cb_out);
+            sub_block(cb_prev_out, alias_sub, cb_out, out_chunk_tiles);
+            cb_pop_front(cb_prev_out, out_chunk_tiles);
+            cb_pop_front(alias_cur_out_r, out_chunk_tiles);
+            cb_pop_front(alias_sub, out_chunk_tiles);
+
+            // lse = prev_lse - logsigmoid(prev_lse - cur_lse)
+            pack_reconfig_data_format(alias_sig);
+            reconfig_data_format(cb_lse_in, alias_cur_lse);
+            logsigmoid_sub(cb_lse_in, alias_cur_lse, alias_sig, Sq_chunk_t);
+            sub_block(cb_lse_in, alias_sig, cb_lse_out, Sq_chunk_t);
+            cb_pop_front(alias_sig, Sq_chunk_t);
+            cb_pop_front(alias_cur_lse, Sq_chunk_t);
+            cb_pop_front(cb_lse_in, Sq_chunk_t);
+        } else {
+            // First ring iteration: copy output and LSE directly
+            pack_reconfig_data_format(cb_out);
+            copy_block(alias_prev_out, cb_out, out_chunk_tiles);
+
+            pack_reconfig_data_format(cb_lse_out);
+            copy_block(alias_prev_max, cb_lse_out, Sq_chunk_t);
+        }
+    }
+
+    // Dummy KV pop for double-buffer alignment (same as sdpa_inner_loop for RING)
+    if (KV_chunks_processed_in_iter % 2 == 0) {
+        cb_wait_front(cb_kt_in, DHt * Sk_chunk_t);
+        cb_pop_front(cb_kt_in, DHt * Sk_chunk_t);
+        cb_wait_front(cb_v_in, Sk_chunk_t * vDHt);
+        cb_pop_front(cb_v_in, Sk_chunk_t * vDHt);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -354,44 +354,39 @@ void mul_block_bcast_cols_acc(
 }
 
 /**
- * L1-accumulate only the padded K-position tiles from mask_cb onto cb_qkt_im.
- * Only copies -inf tiles (padded columns), skipping zero tiles entirely to avoid
- * Bfp4_b→Float16_b round-trip artifacts in L1 accumulate.
+ * Lightweight padded-K mask: L1-accumulate a single permanently-fronted -inf tile onto padded
+ * tile positions in cb_qkt_im. No full mask matrix needed — just 1 tile in neginf_cb.
  *
- * @tparam padded_k_tiles  Number of padded K tiles per row (must be > 0)
- * @tparam Sk_chunk_t      Total K tiles per row
- * @tparam SBH             Sub-rows per row group (subblock_h)
+ * Ported from sdpa_benchmark branch's apply_padded_mask.
  *
- * Caller must cb_wait_front(mask_cb, Sq_chunk_t * Sk_chunk_t) before calling.
- * Caller must cb_pop_front(mask_cb, Sq_chunk_t * Sk_chunk_t) after all row groups.
+ * @tparam num_padded  Number of padded K tiles per row (must be > 0)
+ * @tparam num_cols    Total K tiles per row (Sk_chunk_t)
+ * @tparam SBH         Sub-rows per row group (subblock_h)
+ * @tparam DST_BATCH   Max tiles per DST batch (8 for fp16b half-sync)
  */
-template <bool PROFILING_ENABLED, uint32_t padded_k_tiles, uint32_t Sk_chunk_t, uint32_t SBH, uint32_t Sq_chunk_t>
-void apply_mask_padded_k(uint32_t mask_cb, uint32_t out_cb, uint32_t q_subblock) {
+template <bool PROFILING_ENABLED, uint32_t num_padded, uint32_t num_cols, uint32_t SBH = 1, uint32_t DST_BATCH = 8>
+void apply_padded_mask_lightweight(uint32_t neginf_cb, uint32_t out_cb, uint32_t q_subblock = 0) {
     MaybeDeviceZoneScopedN(PROFILING_ENABLED, "PAD_MASK");
-    static_assert(padded_k_tiles > 0, "padded_k_tiles must be > 0");
-    static_assert(padded_k_tiles < Sk_chunk_t, "padded_k_tiles must be less than Sk_chunk_t");
-    constexpr uint32_t start = Sk_chunk_t - padded_k_tiles;  // First padded column
-    constexpr uint32_t row_tiles = SBH * Sk_chunk_t;
-    const uint32_t mask_offset = q_subblock * row_tiles;
+    static_assert(num_padded > 0, "num_padded must be > 0");
+    static_assert(num_padded < num_cols, "num_padded must be less than num_cols");
+    constexpr uint32_t start = num_cols - num_padded;
 
-    // Read -inf tiles from mask_cb and L1-accumulate onto padded positions in out_cb
-    copy_tile_to_dst_init_short(mask_cb);
+    copy_tile_to_dst_init_short(neginf_cb);
+    // neginf_cb tile is permanently fronted — cb_wait_front hoisted to op-level entry point.
     PACK((llk_pack_reconfig_l1_acc(1)));
 
-    constexpr uint32_t DST_BATCH = 8;
     for (uint32_t row = 0; row < SBH; row++) {
-        uint32_t out_row_offset = (q_subblock * SBH + row) * Sk_chunk_t;
-        uint32_t mask_row_offset = mask_offset + row * Sk_chunk_t;
-        for (uint32_t base = start; base < Sk_chunk_t; base += DST_BATCH) {
-            uint32_t batch = (Sk_chunk_t - base < DST_BATCH) ? (Sk_chunk_t - base) : DST_BATCH;
+        uint32_t row_offset = (q_subblock * SBH + row) * num_cols;
+        for (uint32_t base = start; base < num_cols; base += DST_BATCH) {
+            uint32_t batch = (num_cols - base < DST_BATCH) ? (num_cols - base) : DST_BATCH;
             tile_regs_acquire();
             for (uint32_t i = 0; i < batch; i++) {
-                copy_tile(mask_cb, mask_row_offset + base + i, i);
+                copy_tile(neginf_cb, 0, i);  // Always tile 0 — single -inf tile
             }
             tile_regs_commit();
             tile_regs_wait();
             for (uint32_t i = 0; i < batch; i++) {
-                pack_tile<true>(i, out_cb, out_row_offset + base + i);
+                pack_tile<true>(i, out_cb, row_offset + base + i);
             }
             tile_regs_release();
         }
@@ -567,13 +562,6 @@ void sdpa_inner_loop_step(
     cb_wait_front(cb_kt_in, DHt * Sk_chunk_t);
     cb_reserve_back(cur_sum, Sq_chunk_t);
 
-    // Wait for mask tiles if writer generates them (Q or K padding)
-    if constexpr (use_padded_mask) {
-        if (is_last_iter) {
-            cb_wait_front(cb_mask_in, Sq_chunk_t * Sk_chunk_t);
-        }
-    }
-
     // ========== PHASE 1: Q@KT directly into cb_qkt_im ==========
     // All matmul output goes to cb_qkt_im at absolute offsets via pack_tile<true>.
     // cb_push_back_hold_wr_ptr makes each row visible to UNPACK without advancing wr_ptr.
@@ -609,11 +597,10 @@ void sdpa_inner_loop_step(
         // Restore float16b for mask/reduce after Q@KT.
         reconfig_data_format(cb_kt_in, cb_qkt_im, cb_q_in, cb_qkt_im);
 
-        // Apply mask on last K chunk: only accumulate -inf onto padded K positions.
-        // Skips zero-valued tiles to avoid Bfp4_b→Float16_b L1 acc round-trip artifacts.
+        // Apply mask on last K chunk: L1-accumulate single -inf tile onto padded K positions.
         if constexpr (padded_k_tiles > 0) {
             if (is_last_iter) {
-                apply_mask_padded_k<PROFILING_ENABLED, padded_k_tiles, Sk_chunk_t, sbh, Sq_chunk_t>(
+                apply_padded_mask_lightweight<PROFILING_ENABLED, padded_k_tiles, Sk_chunk_t, sbh>(
                     cb_mask_in, cb_qkt_im, q_subblock);
             }
         }
@@ -652,13 +639,6 @@ void sdpa_inner_loop_step(
     // reader can start fetching the next Q chunk during Phase 2.
     if (is_last_iter) {
         cb_pop_front(cb_q_in, Sq_chunk_t * DHt);
-    }
-
-    // Pop mask after all rows processed (must match writer's generate_mask push)
-    if constexpr (use_padded_mask) {
-        if (is_last_iter) {
-            cb_pop_front(cb_mask_in, Sq_chunk_t * Sk_chunk_t);
-        }
     }
 
     // Pop ring mask after all row groups processed
@@ -895,6 +875,12 @@ void sdpa_standard_v2(
     const uint32_t cb_max_B,
     const uint32_t cb_sum_A,
     const uint32_t cb_sum_B) {
+    // Neginf tile is permanently fronted by the writer — wait once before any K-chunk loop.
+    constexpr uint32_t padded_k_tiles_v2 = (Sk_chunk_t - (Skt % Sk_chunk_t)) % Sk_chunk_t;
+    if constexpr (use_padded_mask && padded_k_tiles_v2 > 0) {
+        cb_wait_front(cb_mask_in, 1);
+    }
+
     for (uint32_t q = 0; q < q_chunks_per_core; q++) {
         uint32_t alias_prev_sum = cb_sum_A, alias_cur_sum = cb_sum_B;
         uint32_t alias_prev_max = cb_max_A, alias_cur_max = cb_max_B;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
@@ -48,6 +48,23 @@ void kernel_main() {
 
     constexpr uint32_t scale_fp32 = get_compile_time_arg_val(30);
     constexpr bool use_streaming_compute = get_compile_time_arg_val(31) == 1;
+    constexpr uint32_t global_n_partial_col = get_compile_time_arg_val(32);
+    constexpr uint32_t joint_l_partial_col = get_compile_time_arg_val(33);
+    constexpr bool uniform_dataformat = get_compile_time_arg_val(34) == 1;
+
+    // Lightweight mask: all mask tiles live in cb_mask_in (c_3).
+    // Layout: [neginf(0)] [global_n_partial?(1)] [joint_l_partial?(1 or 2)]
+    // Only needed when any K/joint dimension has padding that doesn't fill a chunk.
+    constexpr bool local_n_has_padding = local_padded_Nt % Sk_chunk_t != 0;
+    constexpr bool global_n_has_padding = logical_n % (Sk_chunk_t * tt::constants::TILE_HEIGHT) != 0;
+    constexpr bool joint_has_padding = L > 0 && L % (Sk_chunk_t * tt::constants::TILE_HEIGHT) != 0;
+    constexpr bool needs_lightweight_mask = local_n_has_padding || global_n_has_padding || joint_has_padding;
+
+    constexpr uint32_t neginf_tile_idx = 0;
+    constexpr uint32_t global_n_partial_tile_idx = (global_n_partial_col > 0) ? 1 : 0;
+    constexpr uint32_t joint_l_partial_tile_idx =
+        (joint_l_partial_col > 0) ? (1 + (global_n_partial_col > 0 ? 1 : 0)) : 0;
+    constexpr uint32_t total_mask_tiles = 1 + (global_n_partial_col > 0 ? 1 : 0) + (joint_l_partial_col > 0 ? 1 : 0);
 
     uint32_t argidx = 0;
     const uint32_t global_q_start = get_arg_val<uint32_t>(argidx++);
@@ -87,6 +104,17 @@ void kernel_main() {
 
     mm_init(cb_q_in, cb_k_in, cb_qk_im);
 
+    // Wait for all lightweight mask tiles once before the ring loop.
+    // Writer generates them once and they stay permanently fronted.
+    if constexpr (needs_lightweight_mask) {
+        cb_wait_front(cb_mask_in, total_mask_tiles);
+    }
+
+    // Precompute padded tile counts that are constant across ring iterations
+    constexpr uint32_t local_n_padded_tiles =
+        (local_padded_Nt % Sk_chunk_t != 0) ? (Sk_chunk_t - (local_padded_Nt % Sk_chunk_t)) : 0;
+    constexpr uint32_t joint_n_padded_tiles = (Lt % Sk_chunk_t != 0) ? (Sk_chunk_t - (Lt % Sk_chunk_t)) : 0;
+
     for (uint32_t ring_iter = 0; ring_iter < ring_size; ++ring_iter) {
         uint32_t ring_id = fused_op_indexer.get_next_ring_id_and_sync();
         const bool do_joint_kv = ring_id == ring_size - 1;
@@ -120,6 +148,23 @@ void kernel_main() {
         const bool ring_iter_needs_joint_n_mask = joint_n_needs_masking && do_joint_kv;
         const uint32_t joint_n_mask_chunk_id = L / (Sk_chunk_t * tt::constants::TILE_HEIGHT);
 
+        // Build lightweight mask context for this ring iteration
+        LightweightMaskContext lw_mask;
+        lw_mask.enabled = needs_lightweight_mask;
+        lw_mask.neginf_tile_idx = neginf_tile_idx;
+        lw_mask.local_n_padded_tiles = local_n_padded_tiles;
+        lw_mask.joint_n_padded_tiles = joint_n_padded_tiles;
+        lw_mask.global_n_partial_col = global_n_partial_col;
+        lw_mask.joint_l_partial_col = joint_l_partial_col;
+        lw_mask.global_n_partial_tile_idx = global_n_partial_tile_idx;
+        lw_mask.joint_l_partial_tile_idx = joint_l_partial_tile_idx;
+        if (ring_iter_needs_global_n_mask) {
+            const uint32_t unpadded_in_chunk = global_n_within_ring_iter % (Sk_chunk_t * tt::constants::TILE_HEIGHT);
+            const uint32_t valid_tiles =
+                (unpadded_in_chunk + tt::constants::TILE_HEIGHT - 1) / tt::constants::TILE_HEIGHT;
+            lw_mask.global_n_padded_tiles = Sk_chunk_t - valid_tiles;
+        }
+
         if constexpr (use_streaming_compute) {
             sdpa_ring_v2<
                 Sq_chunk_t,
@@ -142,7 +187,8 @@ void kernel_main() {
                 cb_lse_in,
                 cb_lse_out,
                 cb_prev_out,
-                cb_out>(
+                cb_out,
+                uniform_dataformat>(
                 global_q_start,
                 global_q_end,
                 num_kv_chunks,
@@ -162,7 +208,8 @@ void kernel_main() {
                 cb_max_A,
                 cb_max_B,
                 cb_sum_A,
-                cb_sum_B);
+                cb_sum_B,
+                lw_mask);
         } else {
             sdpa_ring<cb_qk_im, cb_identity_scale_in, cb_scale_in, Sq_chunk_t, Sk_chunk_t, DHt, scale_fp32>(
                 qk_in0_block_w,
@@ -211,7 +258,8 @@ void kernel_main() {
                 cb_lse_in,
                 cb_lse_out,
                 cb_prev_out,
-                cb_out);
+                cb_out,
+                lw_mask);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
@@ -10,6 +10,7 @@
 #include "api/compute/compute_kernel_api.h"
 #include <tt-metalium/constants.hpp>
 #include "compute_common.hpp"
+#include "compute_streaming.hpp"
 #include "cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/fused_op_indexer.hpp"
 
 void kernel_main() {
@@ -46,6 +47,8 @@ void kernel_main() {
     constexpr uint32_t out_num_blocks = get_compile_time_arg_val(29);
 
     constexpr uint32_t scale_fp32 = get_compile_time_arg_val(30);
+    constexpr bool use_streaming_compute = get_compile_time_arg_val(31) == 1;
+
     uint32_t argidx = 0;
     const uint32_t global_q_start = get_arg_val<uint32_t>(argidx++);
     const uint32_t global_q_end = get_arg_val<uint32_t>(argidx++);
@@ -77,6 +80,10 @@ void kernel_main() {
 
     constexpr uint32_t cb_out = tt::CBIndex::c_16;
     constexpr uint32_t cb_lse_out = tt::CBIndex::c_17;
+
+    // Streaming compute uses c_9 as 1-tile recip scratch for normalize_row_streaming.
+    // (c_4 is used by cb_scale_in in ring joint SDPA, unlike regular SDPA.)
+    constexpr uint32_t cb_recip_scratch = tt::CBIndex::c_9;
 
     mm_init(cb_q_in, cb_k_in, cb_qk_im);
 
@@ -113,53 +120,98 @@ void kernel_main() {
         const bool ring_iter_needs_joint_n_mask = joint_n_needs_masking && do_joint_kv;
         const uint32_t joint_n_mask_chunk_id = L / (Sk_chunk_t * tt::constants::TILE_HEIGHT);
 
-        sdpa_ring<cb_qk_im, cb_identity_scale_in, cb_scale_in, Sq_chunk_t, Sk_chunk_t, DHt, scale_fp32>(
-            qk_in0_block_w,
-            qk_subblock_w,
-            qk_subblock_h,
-            qk_in0_num_subblocks,
-            qk_in1_num_subblocks,
-            qk_num_blocks,
-            out_in0_block_w,
-            out_subblock_w,
-            out_subblock_h,
-            out_in0_num_subblocks,
-            out_in1_num_subblocks,
-            out_num_blocks,
-            global_q_start,
-            global_q_end,
-            0,
-            num_kv_chunks,
-            q_chunk_tiles,
-            k_chunk_tiles,
-            qk_chunk_tiles,
-            out_chunk_tiles,
-            ring_iter,
-            ring_id,
-            num_local_k_chunks,
-            local_padded_Nt,
-            logical_nt,
-            ring_iter_needs_global_n_mask,
-            ring_iter_needs_joint_n_mask,
-            local_n_needs_masking,
-            global_n_mask_chunk_id,
-            local_n_mask_chunk_id,
-            joint_n_mask_chunk_id,
-            cb_q_in,
-            cb_k_in,
-            cb_v_in,
-            cb_mask_in,
-            cb_col_identity,
-            cb_out_im_A,
-            cb_out_im_B,
-            cb_max_A,
-            cb_max_B,
-            cb_sum_A,
-            cb_sum_B,
-            cb_exp_max_diff,
-            cb_lse_in,
-            cb_lse_out,
-            cb_prev_out,
-            cb_out);
+        if constexpr (use_streaming_compute) {
+            sdpa_ring_v2<
+                Sq_chunk_t,
+                Sk_chunk_t,
+                0,  // Skt — not used for ring
+                DHt,
+                DHt,  // vDHt = DHt for ring
+                scale_fp32,
+                qk_subblock_h,
+                cb_q_in,
+                cb_k_in,
+                cb_v_in,
+                cb_qk_im,
+                cb_identity_scale_in,
+                cb_exp_max_diff,
+                cb_col_identity,
+                cb_recip_scratch,
+                cb_mask_in,
+                cb_scale_in,
+                cb_lse_in,
+                cb_lse_out,
+                cb_prev_out,
+                cb_out>(
+                global_q_start,
+                global_q_end,
+                num_kv_chunks,
+                ring_iter,
+                ring_id,
+                num_local_k_chunks,
+                local_padded_Nt,
+                logical_nt,
+                ring_iter_needs_global_n_mask,
+                ring_iter_needs_joint_n_mask,
+                local_n_needs_masking,
+                global_n_mask_chunk_id,
+                local_n_mask_chunk_id,
+                joint_n_mask_chunk_id,
+                cb_out_im_A,
+                cb_out_im_B,
+                cb_max_A,
+                cb_max_B,
+                cb_sum_A,
+                cb_sum_B);
+        } else {
+            sdpa_ring<cb_qk_im, cb_identity_scale_in, cb_scale_in, Sq_chunk_t, Sk_chunk_t, DHt, scale_fp32>(
+                qk_in0_block_w,
+                qk_subblock_w,
+                qk_subblock_h,
+                qk_in0_num_subblocks,
+                qk_in1_num_subblocks,
+                qk_num_blocks,
+                out_in0_block_w,
+                out_subblock_w,
+                out_subblock_h,
+                out_in0_num_subblocks,
+                out_in1_num_subblocks,
+                out_num_blocks,
+                global_q_start,
+                global_q_end,
+                0,
+                num_kv_chunks,
+                q_chunk_tiles,
+                k_chunk_tiles,
+                qk_chunk_tiles,
+                out_chunk_tiles,
+                ring_iter,
+                ring_id,
+                num_local_k_chunks,
+                local_padded_Nt,
+                logical_nt,
+                ring_iter_needs_global_n_mask,
+                ring_iter_needs_joint_n_mask,
+                local_n_needs_masking,
+                global_n_mask_chunk_id,
+                local_n_mask_chunk_id,
+                joint_n_mask_chunk_id,
+                cb_q_in,
+                cb_k_in,
+                cb_v_in,
+                cb_mask_in,
+                cb_col_identity,
+                cb_out_im_A,
+                cb_out_im_B,
+                cb_max_A,
+                cb_max_B,
+                cb_sum_A,
+                cb_sum_B,
+                cb_exp_max_diff,
+                cb_lse_in,
+                cb_lse_out,
+                cb_prev_out,
+                cb_out);
+        }
     }
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
@@ -47,6 +47,7 @@ void kernel_main() {
     constexpr bool use_attention_sink = get_compile_time_arg_val(29) == 1;
     constexpr bool use_streaming_compute = get_compile_time_arg_val(30) == 1;
     constexpr uint32_t valid_Skt = get_compile_time_arg_val(31);
+    constexpr bool uniform_dataformat = get_compile_time_arg_val(32) == 1;
 
     const uint32_t core_id = get_arg_val<uint32_t>(0);
     const uint32_t local_batch_start = get_arg_val<uint32_t>(1);
@@ -133,7 +134,8 @@ void kernel_main() {
                         cb_col_identity,
                         cb_recip_scratch,
                         cb_out,  // normalized output goes directly to output CB
-                        cb_mask_in>(
+                        cb_mask_in,
+                        uniform_dataformat>(
                         q_chunks_per_core,
                         k_num_chunks,
                         cb_out_im_A,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
@@ -9,6 +9,7 @@
 
 #include "api/compute/compute_kernel_api.h"
 #include "compute_common.hpp"
+#include "compute_streaming.hpp"
 
 void kernel_main() {
     constexpr uint32_t B = get_compile_time_arg_val(0);
@@ -44,6 +45,8 @@ void kernel_main() {
     constexpr uint32_t scale_fp32 = get_compile_time_arg_val(27);
     constexpr uint32_t sliding_window_size = get_compile_time_arg_val(28);
     constexpr bool use_attention_sink = get_compile_time_arg_val(29) == 1;
+    constexpr bool use_streaming_compute = get_compile_time_arg_val(30) == 1;
+    constexpr uint32_t valid_Skt = get_compile_time_arg_val(31);
 
     const uint32_t core_id = get_arg_val<uint32_t>(0);
     const uint32_t local_batch_start = get_arg_val<uint32_t>(1);
@@ -104,66 +107,107 @@ void kernel_main() {
         }
     }
 
-    for (uint32_t phase = 0; phase < num_phases; ++phase) {
-        if (phase == 0) {
-            chunked_q_chunk_offset = chunked_q_chunk_offset_phase_1;
-        } else {
-            chunked_q_chunk_offset = chunked_q_chunk_offset_phase_2;
-        }
+    if constexpr (use_streaming_compute) {
+        // Streaming SDPA v2: direct cb_qkt_im writes via cb_push_back_hold_wr_ptr.
+        // No row buffers needed. c_4 used only as 1-tile recip scratch for normalization.
+        constexpr uint32_t cb_recip_scratch = tt::CBIndex::c_4;
 
-        for (uint32_t nb = local_batch_start; nb < local_batch_end; ++nb) {
-            for (uint32_t nq = local_nh_start; nq < local_nh_end; ++nq) {
-                sdpa_standard<
-                    cb_qk_im,
-                    cb_identity_scale_in,
-                    cb_attention_sink,
-                    Sq_chunk_t,
-                    Sk_chunk_t,
-                    DHt,
-                    vDHt,
-                    use_attention_sink,
-                    is_causal,
-                    use_provided_mask,
-                    use_padded_mask,
-                    is_chunked,
-                    scale_fp32,
-                    sliding_window_size>(
-                    Skt,
-                    qk_in0_block_w,
-                    qk_subblock_w,
-                    qk_subblock_h,
-                    qk_in0_num_subblocks,
-                    qk_in1_num_subblocks,
-                    qk_num_blocks,
-                    out_in0_block_w,
-                    out_subblock_w,
-                    out_subblock_h,
-                    out_in0_num_subblocks,
-                    out_in1_num_subblocks,
-                    out_num_blocks,
-                    0,                  // iter_q_start
-                    q_chunks_per_core,  // iter_q_end
-                    q_num_chunks,
-                    local_q_start,
-                    chunked_q_chunk_offset,
-                    k_num_chunks,
-                    q_chunk_tiles,
-                    k_chunk_tiles,
-                    qk_chunk_tiles,
-                    out_chunk_tiles,
-                    cb_q_in,
-                    cb_k_in,
-                    cb_v_in,
-                    cb_mask_in,
-                    cb_col_identity,
-                    cb_out_im_A,
-                    cb_out_im_B,
-                    cb_max_A,
-                    cb_max_B,
-                    cb_sum_A,
-                    cb_sum_B,
-                    cb_exp_max_diff,
-                    cb_out);
+        for (uint32_t phase = 0; phase < num_phases; ++phase) {
+            for (uint32_t nb = local_batch_start; nb < local_batch_end; ++nb) {
+                for (uint32_t nq = local_nh_start; nq < local_nh_end; ++nq) {
+                    sdpa_standard_v2<
+                        Sq_chunk_t,
+                        Sk_chunk_t,
+                        valid_Skt,
+                        DHt,
+                        vDHt,
+                        scale_fp32,
+                        qk_subblock_h,
+                        use_padded_mask,
+                        cb_q_in,
+                        cb_k_in,
+                        cb_v_in,
+                        cb_qk_im,
+                        cb_identity_scale_in,
+                        cb_exp_max_diff,
+                        cb_col_identity,
+                        cb_recip_scratch,
+                        cb_out,  // normalized output goes directly to output CB
+                        cb_mask_in>(
+                        q_chunks_per_core,
+                        k_num_chunks,
+                        cb_out_im_A,
+                        cb_out_im_B,
+                        cb_max_A,
+                        cb_max_B,
+                        cb_sum_A,
+                        cb_sum_B);
+                }
+            }
+        }
+    } else {
+        // Standard SDPA path (causal, masked, chunked, etc.)
+        for (uint32_t phase = 0; phase < num_phases; ++phase) {
+            if (phase == 0) {
+                chunked_q_chunk_offset = chunked_q_chunk_offset_phase_1;
+            } else {
+                chunked_q_chunk_offset = chunked_q_chunk_offset_phase_2;
+            }
+
+            for (uint32_t nb = local_batch_start; nb < local_batch_end; ++nb) {
+                for (uint32_t nq = local_nh_start; nq < local_nh_end; ++nq) {
+                    sdpa_standard<
+                        cb_qk_im,
+                        cb_identity_scale_in,
+                        cb_attention_sink,
+                        Sq_chunk_t,
+                        Sk_chunk_t,
+                        DHt,
+                        vDHt,
+                        use_attention_sink,
+                        is_causal,
+                        use_provided_mask,
+                        use_padded_mask,
+                        is_chunked,
+                        scale_fp32,
+                        sliding_window_size>(
+                        Skt,
+                        qk_in0_block_w,
+                        qk_subblock_w,
+                        qk_subblock_h,
+                        qk_in0_num_subblocks,
+                        qk_in1_num_subblocks,
+                        qk_num_blocks,
+                        out_in0_block_w,
+                        out_subblock_w,
+                        out_subblock_h,
+                        out_in0_num_subblocks,
+                        out_in1_num_subblocks,
+                        out_num_blocks,
+                        0,                  // iter_q_start
+                        q_chunks_per_core,  // iter_q_end
+                        q_num_chunks,
+                        local_q_start,
+                        chunked_q_chunk_offset,
+                        k_num_chunks,
+                        q_chunk_tiles,
+                        k_chunk_tiles,
+                        qk_chunk_tiles,
+                        out_chunk_tiles,
+                        cb_q_in,
+                        cb_k_in,
+                        cb_v_in,
+                        cb_mask_in,
+                        cb_col_identity,
+                        cb_out_im_A,
+                        cb_out_im_B,
+                        cb_max_A,
+                        cb_max_B,
+                        cb_sum_A,
+                        cb_sum_B,
+                        cb_exp_max_diff,
+                        cb_out);
+                }
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
@@ -286,6 +286,107 @@ void fill_neginf_tile(uint32_t cb_id, uint32_t tile_id) {
     }
 }
 
+/**
+ * Fill a bf16 tile with a vertical partial mask: columns [0, unpad_col) = 0, columns [unpad_col, 32) = -inf.
+ * Used for lightweight mask when padding boundary falls inside a tile.
+ *
+ * bf16 tile layout: 4 faces of 16x16, each face row-major with 8 uint32 words per row (2 bf16 per uint32).
+ * Face 0: rows[0:16], cols[0:16]   Face 1: rows[0:16], cols[16:32]
+ * Face 2: rows[16:32], cols[0:16]  Face 3: rows[16:32], cols[16:32]
+ *
+ * Within each uint32 word: low 16 bits = even column, high 16 bits = odd column.
+ */
+template <uint32_t tile_bytes>
+void fill_vertical_tile_bf16(uint32_t cb_id, uint32_t tile_id, uint32_t unpad_col_in_tile) {
+    // Start with all zeros (valid)
+    fill_tile_zeros<tile_bytes>(cb_id, tile_id);
+
+    constexpr uint32_t NEGINF_PAIR = 0xFF80FF80;
+    constexpr uint32_t bf16_per_uint32 = 2;
+    constexpr uint32_t uint32_per_face_row = tt::constants::FACE_WIDTH / bf16_per_uint32;  // 8
+    constexpr uint32_t uint32_per_face = tt::constants::FACE_HW / bf16_per_uint32;         // 128
+
+    volatile tt_l1_ptr uint32_t* ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id) + tile_id * tile_bytes);
+
+    // Face offsets in uint32 words
+    constexpr uint32_t face_offsets[4] = {
+        0,                    // Face 0: rows[0:16], cols[0:16]
+        uint32_per_face,      // Face 1: rows[0:16], cols[16:32]
+        2 * uint32_per_face,  // Face 2: rows[16:32], cols[0:16]
+        3 * uint32_per_face   // Face 3: rows[16:32], cols[16:32]
+    };
+    constexpr uint32_t face_col_starts[4] = {0, 16, 0, 16};
+
+    for (uint32_t f = 0; f < 4; f++) {
+        uint32_t face_col_start = face_col_starts[f];
+
+        if (unpad_col_in_tile <= face_col_start) {
+            // Entire face is padded -> fill with -inf
+            for (uint32_t i = 0; i < uint32_per_face; i++) {
+                ptr[face_offsets[f] + i] = NEGINF_PAIR;
+            }
+        } else if (unpad_col_in_tile >= face_col_start + tt::constants::FACE_WIDTH) {
+            // Entire face is valid -> already zeros, skip
+        } else {
+            // Partial face: boundary falls within this face
+            uint32_t local_col = unpad_col_in_tile - face_col_start;  // 0-15
+            uint32_t boundary_word = local_col / bf16_per_uint32;     // which uint32
+            uint32_t boundary_pos = local_col % bf16_per_uint32;      // position within uint32
+
+            for (uint32_t row = 0; row < tt::constants::FACE_HEIGHT; row++) {
+                uint32_t row_base = face_offsets[f] + row * uint32_per_face_row;
+
+                // Handle boundary word (may have one valid + one -inf bf16)
+                if (boundary_pos != 0) {
+                    // Low 16 bits = even col (valid, 0), high 16 bits = odd col (-inf, 0xFF80)
+                    ptr[row_base + boundary_word] = 0xFF800000;
+                }
+
+                // Fill remaining words with -inf
+                uint32_t start_word = boundary_word + (boundary_pos != 0 ? 1 : 0);
+                for (uint32_t w = start_word; w < uint32_per_face_row; w++) {
+                    ptr[row_base + w] = NEGINF_PAIR;
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Generate lightweight mask tiles into a single CB for ring joint SDPA.
+ * Layout: [neginf_tile(0)] [global_n_partial_tile?(1)] [joint_l_partial_tile?(1 or 2)]
+ * Tiles are pushed once and stay permanently fronted for the entire kernel lifetime.
+ *
+ * @tparam global_n_partial_col  Column within tile where global_n padding starts (0 = tile-aligned, no partial)
+ * @tparam joint_l_partial_col   Column within tile where joint_l padding starts (0 = tile-aligned, no partial)
+ * @tparam cb_mask_in            CB to generate mask tiles into (must be constexpr for get_tile_size)
+ */
+template <uint32_t global_n_partial_col, uint32_t joint_l_partial_col, uint32_t cb_mask_in>
+void generate_lightweight_mask_tiles() {
+    constexpr uint32_t partial_mask_tiles = (global_n_partial_col > 0 ? 1 : 0) + (joint_l_partial_col > 0 ? 1 : 0);
+    constexpr uint32_t total_mask_tiles = 1 + partial_mask_tiles;
+    constexpr uint32_t mask_tile_size_bytes = get_tile_size(cb_mask_in);
+
+    cb_reserve_back(cb_mask_in, total_mask_tiles);
+
+    // Tile 0: neginf tile
+    fill_neginf_tile<mask_tile_size_bytes>(cb_mask_in, 0);
+
+    // Subsequent tiles: partial mask tiles for boundary conditions
+    if constexpr (partial_mask_tiles > 0) {
+        uint32_t tile_idx = 1;  // Start after the neginf tile
+        if constexpr (global_n_partial_col > 0) {
+            fill_vertical_tile_bf16<mask_tile_size_bytes>(cb_mask_in, tile_idx++, global_n_partial_col);
+        }
+        if constexpr (joint_l_partial_col > 0) {
+            fill_vertical_tile_bf16<mask_tile_size_bytes>(cb_mask_in, tile_idx++, joint_l_partial_col);
+        }
+    }
+
+    cb_push_back(cb_mask_in, total_mask_tiles);
+}
+
 template <uint32_t tile_bytes>
 inline void fill_custom_diagonal_tile_bfp4(
     uint32_t cb_id, uint32_t tile_id, int32_t leading_diagonal_offset, int32_t trailing_diagonal_offset) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
@@ -87,8 +87,10 @@ void kernel_main() {
     constexpr uint32_t identity_scalar_packed = get_compile_time_arg_val(17);
     constexpr uint32_t scale_val = get_compile_time_arg_val(18);
     constexpr uint32_t ring_size = get_compile_time_arg_val(19);
+    constexpr uint32_t global_n_partial_col = get_compile_time_arg_val(20);
+    constexpr uint32_t joint_l_partial_col = get_compile_time_arg_val(21);
 
-    constexpr auto out_args = TensorAccessorArgs<20>();
+    constexpr auto out_args = TensorAccessorArgs<22>();
     constexpr auto joint_out_args = TensorAccessorArgs<out_args.next_compile_time_args_offset()>();
     constexpr auto lse_args = TensorAccessorArgs<joint_out_args.next_compile_time_args_offset()>();
 
@@ -130,6 +132,16 @@ void kernel_main() {
     generate_bcast_unary_scalar(cb_scale_in, scale_val);
     generate_bcast_col_scalar(cb_col_identity, identity_scalar_packed);
     generate_reduce_scaler(cb_identity_scale_in, identity_scalar_packed);
+
+    // Lightweight mask: generate all mask tiles once into single CB before the ring loop.
+    // Only needed when any K/joint dimension has padding that doesn't fill a chunk.
+    constexpr bool local_n_has_padding = local_padded_Nt % Sk_chunk_t != 0;
+    constexpr bool global_n_has_padding = logical_n % (Sk_chunk_t * tt::constants::TILE_HEIGHT) != 0;
+    constexpr bool joint_has_padding = L > 0 && L % (Sk_chunk_t * tt::constants::TILE_HEIGHT) != 0;
+    constexpr bool needs_lightweight_mask = local_n_has_padding || global_n_has_padding || joint_has_padding;
+    if constexpr (needs_lightweight_mask) {
+        generate_lightweight_mask_tiles<global_n_partial_col, joint_l_partial_col, cb_mask_in>();
+    }
 
     for (uint32_t ring_iter = 0; ring_iter < ring_size; ++ring_iter) {
         uint32_t ring_id = fused_op_receiver.get_next_ring_id_and_sync();
@@ -185,16 +197,6 @@ void kernel_main() {
             const uint32_t nb = global_q_chunk / (NH * num_q_chunks);
             const uint32_t nq = (global_q_chunk % (NH * num_q_chunks)) / num_q_chunks;
             const uint32_t q_chunk = global_q_chunk % num_q_chunks;
-
-            generate_mask<false, false, 0, true, cb_mask_in>(
-                Sq_chunk_t,
-                Sk_chunk_t,
-                q_chunk,
-                0,
-                ring_iter_needs_global_n_mask || ring_iter_needs_local_n_mask,
-                ring_iter_needs_joint_n_mask,
-                ring_iter_needs_global_n_mask ? global_n_within_ring_iter : local_padded_N,
-                L);
 
             const bool is_joint_q = q_chunk >= num_local_q_chunks;
             Slice out_slice;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/writer_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/writer_interleaved.cpp
@@ -28,8 +28,9 @@ void kernel_main() {
     constexpr uint32_t use_padded_mask = get_compile_time_arg_val(17) == 1;
     constexpr uint32_t is_chunked = get_compile_time_arg_val(18) == 1;
     constexpr uint32_t sliding_window_size = get_compile_time_arg_val(19);
+    constexpr bool use_lightweight_mask = get_compile_time_arg_val(20) == 1;
 
-    constexpr auto out_args = TensorAccessorArgs<20>();
+    constexpr auto out_args = TensorAccessorArgs<21>();
 
     const uint32_t out_addr = get_arg_val<uint32_t>(0);
     const uint32_t core_id = get_arg_val<uint32_t>(1);
@@ -73,6 +74,17 @@ void kernel_main() {
     generate_reduce_scaler(cb_identity_scale_in, identity_scalar_packed);
     generate_bcast_col_scalar(cb_col_identity, identity_scalar_packed);
 
+    // Lightweight mask: generate a single -inf tile once, leave permanently fronted.
+    if constexpr (use_lightweight_mask) {
+        const uint32_t mask_tile_size_bytes = get_tile_size(cb_mask_in);
+        cb_reserve_back(cb_mask_in, 1);
+        auto* ptr = reinterpret_cast<uint32_t*>(get_write_ptr(cb_mask_in));
+        for (uint32_t i = 0; i < mask_tile_size_bytes / sizeof(uint32_t); i++) {
+            ptr[i] = 0xFF80FF80;  // -inf in bfloat16
+        }
+        cb_push_back(cb_mask_in, 1);
+    }
+
     if constexpr (is_chunked) {
         if (use_chunk_start_idx_tensor != 0) {
             cb_wait_front(cb_chunk_start_idx, 1);
@@ -114,9 +126,9 @@ void kernel_main() {
                     q_chunk = local_q_start + q_iter;
 #endif
 
-                    // Generate mask only when user didn't provide one
-                    // When use_provided_mask, reader handles mask reading (and padding if needed)
-                    if constexpr (!use_provided_mask) {
+                    // Generate mask only when user didn't provide one.
+                    // Lightweight path already has a single -inf tile fronted — skip generate_mask.
+                    if constexpr (!use_provided_mask && !use_lightweight_mask) {
                         generate_mask<is_causal, is_chunked, sliding_window_size, use_padded_mask, cb_mask_in>(
                             Sq_chunk_t, Sk_chunk_t, q_chunk, chunk_start_t_in_q_chunks, true, false, unpadded_Sk, 0);
                     }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_program_factory.cpp
@@ -266,6 +266,7 @@ RingDistributedSdpaMeshWorkloadFactory::cached_program_t RingDistributedSdpaMesh
         false,  //(std::uint32_t)use_padded_mask,
         true,   //(uint32_t)is_chunked,
         0,      //(uint32_t)sliding_window_size,
+        0,      // arg 20: lightweight mask (unused in ring distributed)
     };
     TensorAccessorArgs(output_tensor.buffer()).append_to(writer_compile_time_args);
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_program_factory.cpp
@@ -299,8 +299,10 @@ RingDistributedSdpaMeshWorkloadFactory::cached_program_t RingDistributedSdpaMesh
         false,  //(std::uint32_t)use_padded_mask,
         true,   //(uint32_t)is_chunked,
         scale_union.u,
-        0,  //(uint32_t)sliding_window_size,
-        0,  //(std::uint32_t)use_attention_sink,
+        0,          //(uint32_t)sliding_window_size,
+        0,          //(std::uint32_t)use_attention_sink,
+        0,          //(std::uint32_t)use_streaming_compute — always false for ring distributed (causal)
+        valid_Skt,  // arg 31: unpadded K tiles for streaming padded_k_tiles
     };
     TensorAccessorArgs(output_tensor.buffer()).append_to(compute_compile_time_args);
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -179,6 +179,19 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     const uint32_t Sq_chunk_t = q_chunk_size / tt::constants::TILE_HEIGHT;
     const uint32_t Sk_chunk_t = k_chunk_size / tt::constants::TILE_HEIGHT;
 
+    // Lightweight mask: only needed when any K/joint dimension has padding that doesn't fill a chunk.
+    const bool local_n_has_padding = (local_padded_Nt % Sk_chunk_t) != 0;
+    const bool global_n_has_padding = (args.logical_n % (Sk_chunk_t * tt::constants::TILE_HEIGHT)) != 0;
+    const bool joint_has_padding = L > 0 && (L % (Sk_chunk_t * tt::constants::TILE_HEIGHT)) != 0;
+    const bool needs_lightweight_mask = local_n_has_padding || global_n_has_padding || joint_has_padding;
+
+    // Partial tile support when padding boundary falls inside a tile.
+    const uint32_t global_n_partial_col = args.logical_n % tt::constants::TILE_HEIGHT;
+    const uint32_t joint_l_partial_col = L % tt::constants::TILE_HEIGHT;
+    const uint32_t partial_mask_tiles = (global_n_partial_col != 0 ? 1 : 0) + (joint_l_partial_col != 0 ? 1 : 0);
+    // Single CB holds: 1 neginf tile + up to 2 partial mask tiles
+    const uint32_t total_lightweight_mask_tiles = 1 + partial_mask_tiles;
+
     const uint32_t num_local_q_chunks = tt::div_up(local_padded_N, q_chunk_size);
     const uint32_t num_joint_q_chunks = tt::div_up(L, q_chunk_size);
     const uint32_t num_q_chunks = num_local_q_chunks + num_joint_q_chunks;
@@ -257,7 +270,6 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     uint32_t q_tiles = Sq_chunk_t * DHt * q_buffer_factor;
     uint32_t k_tiles = Sk_chunk_t * DHt * 2;  // double buffer
     uint32_t v_tiles = Sk_chunk_t * DHt * 2;  // double buffer
-    uint32_t mask_tiles = Sq_chunk_t * Sk_chunk_t;
     uint32_t qk_tiles = Sq_chunk_t * Sk_chunk_t;
     uint32_t out_im_tiles = Sq_chunk_t * DHt;
     uint32_t out0_t = Sq_chunk_t * DHt;
@@ -268,7 +280,6 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     log_debug(tt::LogOp, "q_tiles: {}", q_tiles);
     log_debug(tt::LogOp, "k_tiles: {}", k_tiles);
     log_debug(tt::LogOp, "v_tiles: {}", v_tiles);
-    log_debug(tt::LogOp, "mask_tiles: {}", mask_tiles);
     log_debug(tt::LogOp, "qk_tiles: {}", qk_tiles);
     log_debug(tt::LogOp, "out0_t: {}", out0_t);
     log_debug(tt::LogOp, "scale_tiles: {}", scale_tiles);
@@ -297,7 +308,7 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     // Ring joint has no causal/mask/sink/sliding/chunked flags — gating is simpler.
     const bool use_streaming_compute =
         !fp32_dest_acc_en && qk_out_subblock_h <= 2 && Sk_chunk_t % (8 / qk_out_subblock_h) == 0;
-    log_info(tt::LogOp, "use_streaming_compute: {}", use_streaming_compute);
+    log_debug(tt::LogOp, "use_streaming_compute: {}", use_streaming_compute);
 
     // log all values
     log_debug(tt::LogOp, "dst_size: {}", dst_size);
@@ -403,11 +414,25 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
         num_q_chunks,
         packed_identity_scalar,
         scale_union.u,
-        args.all_gather_operation_attributes.ring_size};
+        args.all_gather_operation_attributes.ring_size,
+        global_n_partial_col,
+        joint_l_partial_col,
+    };
 
     TensorAccessorArgs(output_tensor.buffer()).append_to(writer_compile_time_args);
     TensorAccessorArgs(joint_output_tensor.buffer()).append_to(writer_compile_time_args);
     TensorAccessorArgs(lse_output_tensor.buffer()).append_to(writer_compile_time_args);
+
+    // Early format check: when all data formats are identical, reconfig calls can be skipped.
+    const tt::DataFormat q_df_early = tt::tt_metal::datatype_to_dataformat_converter(input_tensor_q.dtype());
+    const tt::DataFormat k_df_early = tt::tt_metal::datatype_to_dataformat_converter(gathered_input_tensor_k.dtype());
+    const tt::DataFormat v_df_early = tt::tt_metal::datatype_to_dataformat_converter(gathered_input_tensor_v.dtype());
+    const tt::DataFormat out_df_early = tt::tt_metal::datatype_to_dataformat_converter(output_tensor.dtype());
+    const tt::DataFormat im_df_early = tt::DataFormat::Float16_b;
+    const tt::DataFormat mask_df_early = tt::DataFormat::Float16_b;
+    const bool uniform_dataformat =
+        (q_df_early == k_df_early && q_df_early == v_df_early && q_df_early == out_df_early &&
+         q_df_early == mask_df_early && q_df_early == im_df_early);
 
     std::vector<uint32_t> compute_compile_time_args = {
         B,
@@ -441,7 +466,11 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
         out_in1_num_subblocks,
         out_num_blocks,
         scale_union.u,
-        (std::uint32_t)use_streaming_compute};
+        (std::uint32_t)use_streaming_compute,
+        global_n_partial_col,
+        joint_l_partial_col,
+        (std::uint32_t)uniform_dataformat,
+    };
 
     std::map<std::string, std::string> defines;
     defines["STATS_GRANULARITY"] = std::to_string(stats_granularity);
@@ -479,10 +508,9 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     tt::DataFormat q_df = tt::tt_metal::datatype_to_dataformat_converter(input_tensor_q.dtype());
     tt::DataFormat k_df = tt::tt_metal::datatype_to_dataformat_converter(gathered_input_tensor_k.dtype());
     tt::DataFormat v_df = tt::tt_metal::datatype_to_dataformat_converter(gathered_input_tensor_v.dtype());
-    tt::DataFormat mask_df = use_streaming_compute
-                                 ? tt::DataFormat::Float16_b  // streaming path L1-accumulates -inf;
-                                                              // Float16_b avoids Bfp4_b precision loss
-                                 : tt::DataFormat::Bfp4_b;
+    // Lightweight mask: both streaming and non-streaming paths use Float16_b
+    // to support L1-accumulation and avoid Bfp4_b precision loss.
+    tt::DataFormat mask_df = tt::DataFormat::Float16_b;
     tt::DataFormat out_df = tt::tt_metal::datatype_to_dataformat_converter(output_tensor.dtype());
     tt::DataFormat scalar_df = tt::DataFormat::Float16_b;
     tt::DataFormat im_df = tt::DataFormat::Float16_b;  // need to disable fp32 cbs (Issue #13364) fp32_dest_acc_en ?
@@ -521,10 +549,13 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
                             .set_page_size(tt::CBIndex::c_2, v_tile_size);
     CreateCircularBuffer(program, core_grid, c_in2_config);
 
-    // attn_mask input
-    auto c_in3_config = CircularBufferConfig(mask_tiles * mask_tile_size, {{tt::CB::c_in3, mask_df}})
-                            .set_page_size(tt::CB::c_in3, mask_tile_size);
-    CreateCircularBuffer(program, core_grid, c_in3_config);
+    // Lightweight mask: single CB holds 1 neginf tile + up to 2 partial mask tiles
+    if (needs_lightweight_mask) {
+        auto c_in3_config =
+            CircularBufferConfig(total_lightweight_mask_tiles * mask_tile_size, {{tt::CB::c_in3, mask_df}})
+                .set_page_size(tt::CB::c_in3, mask_tile_size);
+        CreateCircularBuffer(program, core_grid, c_in3_config);
+    }
 
     // scale input
     auto c_in4_config = CircularBufferConfig(scale_tiles * scalar_tile_size, {{tt::CBIndex::c_4, scalar_df}})

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -293,6 +293,12 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     const uint32_t out_in1_num_subblocks = DHt / out_out_subblock_w;
     const uint32_t out_num_blocks = Sk_chunk_t / out_in0_block_w;
 
+    // Streaming compute v2: eliminates row buffers via cb_push_back_hold_wr_ptr.
+    // Ring joint has no causal/mask/sink/sliding/chunked flags — gating is simpler.
+    const bool use_streaming_compute = !fp32_dest_acc_en && qk_out_subblock_h * DHt <= dst_size &&
+                                       qk_out_subblock_h == 1 && Sk_chunk_t % (8 / qk_out_subblock_h) == 0 && DHt <= 8;
+    log_debug(tt::LogOp, "use_streaming_compute: {}", use_streaming_compute);
+
     // log all values
     log_debug(tt::LogOp, "dst_size: {}", dst_size);
     log_debug(tt::LogOp, "qk_in0_block_w: {}", qk_in0_block_w);
@@ -434,7 +440,8 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
         out_in0_num_subblocks,
         out_in1_num_subblocks,
         out_num_blocks,
-        scale_union.u};
+        scale_union.u,
+        (std::uint32_t)use_streaming_compute};
 
     std::map<std::string, std::string> defines;
     defines["STATS_GRANULARITY"] = std::to_string(stats_granularity);
@@ -590,6 +597,14 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     auto c_out1_config = CircularBufferConfig(statistics_tiles * im_tile_size, {{tt::CBIndex::c_17, im_df}})
                              .set_page_size(tt::CBIndex::c_17, im_tile_size);
     CreateCircularBuffer(program, core_grid, c_out1_config);
+
+    // Streaming compute v2: 1-tile recip scratch CB (c_9) for normalize_row_streaming.
+    // c_4 is used by cb_scale_in in ring joint, so we use c_9 instead.
+    if (use_streaming_compute) {
+        auto c_recip_scratch_config = CircularBufferConfig(1 * im_tile_size, {{tt::CBIndex::c_9, im_df}})
+                                          .set_page_size(tt::CBIndex::c_9, im_tile_size);
+        CreateCircularBuffer(program, core_grid, c_recip_scratch_config);
+    }
 
     uint32_t q_addr = input_tensor_q.buffer()->address();
     uint32_t k_addr = input_tensor_k.buffer()->address();

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -295,9 +295,9 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
 
     // Streaming compute v2: eliminates row buffers via cb_push_back_hold_wr_ptr.
     // Ring joint has no causal/mask/sink/sliding/chunked flags — gating is simpler.
-    const bool use_streaming_compute = !fp32_dest_acc_en && qk_out_subblock_h * DHt <= dst_size &&
-                                       qk_out_subblock_h == 1 && Sk_chunk_t % (8 / qk_out_subblock_h) == 0 && DHt <= 8;
-    log_debug(tt::LogOp, "use_streaming_compute: {}", use_streaming_compute);
+    const bool use_streaming_compute =
+        !fp32_dest_acc_en && qk_out_subblock_h <= 2 && Sk_chunk_t % (8 / qk_out_subblock_h) == 0;
+    log_info(tt::LogOp, "use_streaming_compute: {}", use_streaming_compute);
 
     // log all values
     log_debug(tt::LogOp, "dst_size: {}", dst_size);
@@ -479,7 +479,10 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     tt::DataFormat q_df = tt::tt_metal::datatype_to_dataformat_converter(input_tensor_q.dtype());
     tt::DataFormat k_df = tt::tt_metal::datatype_to_dataformat_converter(gathered_input_tensor_k.dtype());
     tt::DataFormat v_df = tt::tt_metal::datatype_to_dataformat_converter(gathered_input_tensor_v.dtype());
-    tt::DataFormat mask_df = tt::DataFormat::Bfp4_b;
+    tt::DataFormat mask_df = use_streaming_compute
+                                 ? tt::DataFormat::Float16_b  // streaming path L1-accumulates -inf;
+                                                              // Float16_b avoids Bfp4_b precision loss
+                                 : tt::DataFormat::Bfp4_b;
     tt::DataFormat out_df = tt::tt_metal::datatype_to_dataformat_converter(output_tensor.dtype());
     tt::DataFormat scalar_df = tt::DataFormat::Float16_b;
     tt::DataFormat im_df = tt::DataFormat::Float16_b;  // need to disable fp32 cbs (Issue #13364) fp32_dest_acc_en ?

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -331,10 +331,10 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
     // Non-tile-aligned K padding requires boundary tiles the streaming mask path doesn't support.
     // Sq_chunk_t==1 with K padding has L1 acc write-back issues after cb_push_back_hold_wr_ptr.
     const bool streaming_mask_unsupported = (padded_Sk != Sk) && (Sk % TILE_HEIGHT != 0 || Sq_chunk_t == 1);
-    const bool use_streaming_compute =
-        !is_causal && !use_provided_mask && !use_attention_sink && sliding_window_size.value_or(0) == 0 &&
-        !is_chunked && !fp32_dest_acc_en && qk_out_subblock_h * vDHt <= dst_size && qk_out_subblock_h == 1 &&
-        Sk_chunk_t % (8 / qk_out_subblock_h) == 0 && vDHt <= 8 && !streaming_mask_unsupported;
+    const bool use_streaming_compute = !is_causal && !use_provided_mask && !use_attention_sink &&
+                                       sliding_window_size.value_or(0) == 0 && !is_chunked && !fp32_dest_acc_en &&
+                                       qk_out_subblock_h <= 2 && Sk_chunk_t % (8 / qk_out_subblock_h) == 0 &&
+                                       !streaming_mask_unsupported;
     log_debug(tt::LogOp, "use_streaming_compute: {}", use_streaming_compute);
 
     // log all values

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -277,11 +277,30 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
 
     log_debug(tt::LogOp, "q_per_core: {}", q_per_core);
 
+    // Host code is responsible for determining matmul configuration
+    const uint32_t dst_size = fp32_dest_acc_en ? 4 : 8;
+    const uint32_t qk_in0_block_w = DHt;
+
+    auto [qk_out_subblock_h, qk_out_subblock_w] =
+        detail::determine_largest_subblock_size(Sq_chunk_t, Sk_chunk_t, dst_size);
+
+    // Streaming compute v2: no row buffers (cb_push_back_hold_wr_ptr).
+    // Mask uses Float16_b for the streaming path to avoid Bfp4_b→Float16_b L1 accumulate artifacts.
+    // fp32_dest_acc_en is not functional with the streaming path — skip it in that case.
+    // Non-tile-aligned K padding requires boundary tiles the streaming mask path doesn't support.
+    // Sq_chunk_t==1 with K padding has L1 acc write-back issues after cb_push_back_hold_wr_ptr.
+    const bool streaming_mask_unsupported = (padded_Sk != Sk) && (Sk % TILE_HEIGHT != 0 || Sq_chunk_t == 1);
+    const bool use_streaming_compute = !is_causal && !use_provided_mask && !use_attention_sink &&
+                                       sliding_window_size.value_or(0) == 0 && !is_chunked && !fp32_dest_acc_en &&
+                                       qk_out_subblock_h <= 2 && Sk_chunk_t % (8 / qk_out_subblock_h) == 0 &&
+                                       !streaming_mask_unsupported;
+
+    const bool lightweight_mask = use_streaming_compute && use_padded_mask;
     // These tile capacity counts for CBs need to match the number of tiles expected by the kernel (softmax.cpp)
     uint32_t q_tiles = Sq_chunk_t * DHt * q_buffer_factor;
     uint32_t k_tiles = Sk_chunk_t * DHt * 2;            // double buffer
     uint32_t v_tiles = Sk_chunk_t * vDHt * 2;           // double buffer
-    uint32_t mask_tiles = Sq_chunk_t * Sk_chunk_t * 2;  // double buffer
+    uint32_t mask_tiles = lightweight_mask ? 1 : Sq_chunk_t * Sk_chunk_t * 2;  // double buffer
     uint32_t qk_tiles = Sq_chunk_t * Sk_chunk_t;
     uint32_t out_im_tiles = Sq_chunk_t * vDHt;
     uint32_t out0_t = Sq_chunk_t * vDHt;
@@ -300,13 +319,6 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
     log_debug(tt::LogOp, "statistics_tiles: {}", statistics_tiles);
     log_debug(tt::LogOp, "attention_sink_tiles: {}", attention_sink_tiles);
 
-    // Host code is responsible for determining matmul configuration
-    const uint32_t dst_size = fp32_dest_acc_en ? 4 : 8;
-    const uint32_t qk_in0_block_w = DHt;
-
-    auto [qk_out_subblock_h, qk_out_subblock_w] =
-        detail::determine_largest_subblock_size(Sq_chunk_t, Sk_chunk_t, dst_size);
-
     const uint32_t qk_in0_num_subblocks = Sq_chunk_t / qk_out_subblock_h;
     const uint32_t qk_in1_num_subblocks = Sk_chunk_t / qk_out_subblock_w;
     const uint32_t qk_num_blocks = DHt / qk_in0_block_w;
@@ -320,16 +332,6 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
     const uint32_t out_in1_num_subblocks = vDHt / out_out_subblock_w;
     const uint32_t out_num_blocks = Sk_chunk_t / out_in0_block_w;
 
-    // Streaming compute v2: no row buffers (cb_push_back_hold_wr_ptr).
-    // Mask uses Float16_b for the streaming path to avoid Bfp4_b→Float16_b L1 accumulate artifacts.
-    // fp32_dest_acc_en is not functional with the streaming path — skip it in that case.
-    // Non-tile-aligned K padding requires boundary tiles the streaming mask path doesn't support.
-    // Sq_chunk_t==1 with K padding has L1 acc write-back issues after cb_push_back_hold_wr_ptr.
-    const bool streaming_mask_unsupported = (padded_Sk != Sk) && (Sk % TILE_HEIGHT != 0 || Sq_chunk_t == 1);
-    const bool use_streaming_compute = !is_causal && !use_provided_mask && !use_attention_sink &&
-                                       sliding_window_size.value_or(0) == 0 && !is_chunked && !fp32_dest_acc_en &&
-                                       qk_out_subblock_h <= 2 && Sk_chunk_t % (8 / qk_out_subblock_h) == 0 &&
-                                       !streaming_mask_unsupported;
     log_info(tt::LogOp, "use_streaming_compute: {}", use_streaming_compute);
 
     // log all values
@@ -470,6 +472,7 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
         (std::uint32_t)use_padded_mask,
         (uint32_t)is_chunked,
         sliding_window_size.value_or(0),
+        (std::uint32_t)(use_streaming_compute && use_padded_mask),  // arg 20: lightweight mask for v2
     };
 
     TensorAccessorArgs(output_tensor.buffer()).append_to(writer_compile_time_args);
@@ -581,9 +584,14 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
 
     // Only create mask buffer if it's going to be used
     if (use_provided_mask or is_causal or use_padded_mask) {
-        // attn_mask input
-        auto c_in3_config = CircularBufferConfig(mask_tiles * mask_tile_size, {{tt::CBIndex::c_3, mask_df}})
-                                .set_page_size(tt::CBIndex::c_3, mask_tile_size);
+        // Lightweight mask: single bfloat16 -inf tile (no Bfp4_b round-trip artifacts).
+        // Legacy: full Sq×Sk double-buffered matrix in Bfp4_b.
+        uint32_t actual_mask_tiles = lightweight_mask ? 1 : mask_tiles;
+        tt::DataFormat actual_mask_df = lightweight_mask ? tt::DataFormat::Float16_b : mask_df;
+        uint32_t actual_mask_tile_size = lightweight_mask ? tt::tile_size(actual_mask_df) : mask_tile_size;
+        auto c_in3_config =
+            CircularBufferConfig(actual_mask_tiles * actual_mask_tile_size, {{tt::CBIndex::c_3, actual_mask_df}})
+                .set_page_size(tt::CBIndex::c_3, actual_mask_tile_size);
         CreateCircularBuffer(program, core_grid, c_in3_config);
     }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -332,7 +332,7 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
     const uint32_t out_in1_num_subblocks = vDHt / out_out_subblock_w;
     const uint32_t out_num_blocks = Sk_chunk_t / out_in0_block_w;
 
-    log_info(tt::LogOp, "use_streaming_compute: {}", use_streaming_compute);
+    log_debug(tt::LogOp, "use_streaming_compute: {}", use_streaming_compute);
 
     // log all values
     log_debug(tt::LogOp, "dst_size: {}", dst_size);
@@ -477,6 +477,19 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
 
     TensorAccessorArgs(output_tensor.buffer()).append_to(writer_compile_time_args);
 
+    // Early format check for uniform_dataformat compile-time arg.
+    const tt::DataFormat q_df_early = tt::tt_metal::datatype_to_dataformat_converter(input_tensor_q.dtype());
+    const tt::DataFormat k_df_early = tt::tt_metal::datatype_to_dataformat_converter(input_tensor_k.dtype());
+    const tt::DataFormat v_df_early = tt::tt_metal::datatype_to_dataformat_converter(input_tensor_v.dtype());
+    const tt::DataFormat out_df_early = tt::tt_metal::datatype_to_dataformat_converter(output_tensor.dtype());
+    const tt::DataFormat mask_df_early =
+        attn_mask.has_value() ? tt::tt_metal::datatype_to_dataformat_converter(attn_mask.value().dtype())
+                              : (use_streaming_compute ? tt::DataFormat::Float16_b : tt::DataFormat::Bfp4_b);
+    const tt::DataFormat im_df_early = tt::DataFormat::Float16_b;
+    const bool uniform_dataformat =
+        (q_df_early == k_df_early && q_df_early == v_df_early && q_df_early == out_df_early &&
+         q_df_early == mask_df_early && q_df_early == im_df_early);
+
     std::vector<uint32_t> compute_compile_time_args = {
         // matmul args
         B,
@@ -511,6 +524,7 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
         (std::uint32_t)use_attention_sink,
         (std::uint32_t)use_streaming_compute,  // arg 30
         valid_Skt,                             // arg 31: unpadded K tile count for streaming padded_k_tiles
+        (std::uint32_t)uniform_dataformat,     // arg 32: skip reconfig when all formats match
     };
 
     TensorAccessorArgs(output_tensor.buffer()).append_to(compute_compile_time_args);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -320,6 +320,23 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
     const uint32_t out_in1_num_subblocks = vDHt / out_out_subblock_w;
     const uint32_t out_num_blocks = Sk_chunk_t / out_in0_block_w;
 
+    // Streaming compute v2: no row buffers (cb_push_back_hold_wr_ptr), sbh=1 only.
+    // Mask stays Bfp4_b — streaming path only reads -inf tiles (skips zero tiles to avoid
+    // Bfp4_b→Float16_b round-trip artifacts in L1 accumulate).
+    // fp32_dest_acc_en is not functional with the streaming path — skip it in that case.
+    // sbh=2 is disabled: reduce_block_max_row omits ZEROACC (unlike reduce_tile), so stale
+    // DST values from the preceding matmul corrupt the GMPOOL MAX accumulation when SBH>1.
+    // Additionally, the sub_exp pack_tile<true> write-back through cb_push_back_hold_wr_ptr
+    // may have L1 coherency issues with subsequent UNPACK reads from the same addresses.
+    // Non-tile-aligned K padding requires boundary tiles the streaming mask path doesn't support.
+    // Sq_chunk_t==1 with K padding has L1 acc write-back issues after cb_push_back_hold_wr_ptr.
+    const bool streaming_mask_unsupported = (padded_Sk != Sk) && (Sk % TILE_HEIGHT != 0 || Sq_chunk_t == 1);
+    const bool use_streaming_compute =
+        !is_causal && !use_provided_mask && !use_attention_sink && sliding_window_size.value_or(0) == 0 &&
+        !is_chunked && !fp32_dest_acc_en && qk_out_subblock_h * vDHt <= dst_size && qk_out_subblock_h == 1 &&
+        Sk_chunk_t % (8 / qk_out_subblock_h) == 0 && vDHt <= 8 && !streaming_mask_unsupported;
+    log_debug(tt::LogOp, "use_streaming_compute: {}", use_streaming_compute);
+
     // log all values
     log_debug(tt::LogOp, "dst_size: {}", dst_size);
     log_debug(tt::LogOp, "qk_in0_block_w: {}", qk_in0_block_w);
@@ -494,6 +511,8 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
         scale_union.u,
         sliding_window_size.value_or(0),
         (std::uint32_t)use_attention_sink,
+        (std::uint32_t)use_streaming_compute,  // arg 30
+        valid_Skt,                             // arg 31: unpadded K tile count for streaming padded_k_tiles
     };
 
     TensorAccessorArgs(output_tensor.buffer()).append_to(compute_compile_time_args);
@@ -521,9 +540,10 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
     tt::DataFormat q_df = tt::tt_metal::datatype_to_dataformat_converter(input_tensor_q.dtype());
     tt::DataFormat k_df = tt::tt_metal::datatype_to_dataformat_converter(input_tensor_k.dtype());
     tt::DataFormat v_df = tt::tt_metal::datatype_to_dataformat_converter(input_tensor_v.dtype());
-    tt::DataFormat mask_df = attn_mask.has_value()
-                                 ? tt::tt_metal::datatype_to_dataformat_converter(attn_mask.value().dtype())
-                                 : tt::DataFormat::Bfp4_b;
+    tt::DataFormat mask_df =
+        attn_mask.has_value()
+            ? tt::tt_metal::datatype_to_dataformat_converter(attn_mask.value().dtype())
+            : tt::DataFormat::Bfp4_b;  // Bfp4_b is fine; streaming path only L1-accumulates -inf tiles
     tt::DataFormat out_df = tt::tt_metal::datatype_to_dataformat_converter(output_tensor.dtype());
     tt::DataFormat scalar_df = tt::DataFormat::Float16_b;
     tt::DataFormat im_df = tt::DataFormat::Float16_b;  // need to disable fp32 cbs (Issue #13364) fp32_dest_acc_en ?
@@ -607,6 +627,15 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
         auto c_in4_config = CircularBufferConfig(attention_sink_tiles * sink_tile_size, {{tt::CBIndex::c_4, sink_df}})
                                 .set_page_size(tt::CBIndex::c_4, sink_tile_size);
         CreateCircularBuffer(program, core_grid, c_in4_config);
+    }
+
+    // Streaming compute v2: 1-tile recip scratch CB (c_4) for normalize_row_streaming.
+    // No row buffers needed — cb_push_back_hold_wr_ptr writes directly to cb_qkt_im.
+    // Safe: gating excludes use_attention_sink (which also uses c_4).
+    if (use_streaming_compute) {
+        auto c_recip_scratch_config = CircularBufferConfig(1 * im_tile_size, {{tt::CBIndex::c_4, im_df}})
+                                          .set_page_size(tt::CBIndex::c_4, im_tile_size);
+        CreateCircularBuffer(program, core_grid, c_recip_scratch_config);
     }
 
     // cb_qk_im

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -320,14 +320,9 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
     const uint32_t out_in1_num_subblocks = vDHt / out_out_subblock_w;
     const uint32_t out_num_blocks = Sk_chunk_t / out_in0_block_w;
 
-    // Streaming compute v2: no row buffers (cb_push_back_hold_wr_ptr), sbh=1 only.
-    // Mask stays Bfp4_b — streaming path only reads -inf tiles (skips zero tiles to avoid
-    // Bfp4_b→Float16_b round-trip artifacts in L1 accumulate).
+    // Streaming compute v2: no row buffers (cb_push_back_hold_wr_ptr).
+    // Mask uses Float16_b for the streaming path to avoid Bfp4_b→Float16_b L1 accumulate artifacts.
     // fp32_dest_acc_en is not functional with the streaming path — skip it in that case.
-    // sbh=2 is disabled: reduce_block_max_row omits ZEROACC (unlike reduce_tile), so stale
-    // DST values from the preceding matmul corrupt the GMPOOL MAX accumulation when SBH>1.
-    // Additionally, the sub_exp pack_tile<true> write-back through cb_push_back_hold_wr_ptr
-    // may have L1 coherency issues with subsequent UNPACK reads from the same addresses.
     // Non-tile-aligned K padding requires boundary tiles the streaming mask path doesn't support.
     // Sq_chunk_t==1 with K padding has L1 acc write-back issues after cb_push_back_hold_wr_ptr.
     const bool streaming_mask_unsupported = (padded_Sk != Sk) && (Sk % TILE_HEIGHT != 0 || Sq_chunk_t == 1);
@@ -335,7 +330,7 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
                                        sliding_window_size.value_or(0) == 0 && !is_chunked && !fp32_dest_acc_en &&
                                        qk_out_subblock_h <= 2 && Sk_chunk_t % (8 / qk_out_subblock_h) == 0 &&
                                        !streaming_mask_unsupported;
-    log_debug(tt::LogOp, "use_streaming_compute: {}", use_streaming_compute);
+    log_info(tt::LogOp, "use_streaming_compute: {}", use_streaming_compute);
 
     // log all values
     log_debug(tt::LogOp, "dst_size: {}", dst_size);
@@ -543,7 +538,9 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
     tt::DataFormat mask_df =
         attn_mask.has_value()
             ? tt::tt_metal::datatype_to_dataformat_converter(attn_mask.value().dtype())
-            : tt::DataFormat::Bfp4_b;  // Bfp4_b is fine; streaming path only L1-accumulates -inf tiles
+            : (use_streaming_compute ? tt::DataFormat::Float16_b  // streaming path L1-accumulates -inf; Float16_b
+                                                                  // avoids Bfp4_b precision loss
+                                     : tt::DataFormat::Bfp4_b);
     tt::DataFormat out_df = tt::tt_metal::datatype_to_dataformat_converter(output_tensor.dtype());
     tt::DataFormat scalar_df = tt::DataFormat::Float16_b;
     tt::DataFormat im_df = tt::DataFormat::Float16_b;  // need to disable fp32 cbs (Issue #13364) fp32_dest_acc_en ?

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -56,6 +56,67 @@ struct CoreChainInfo {
     uint32_t mcast_sender_wait = 0;  // number of actual receivers that signal back (always chain_size - 1)
 };
 
+namespace {
+
+// Select the mask data format: user-provided mask dtype, or Float16_b for streaming (avoids Bfp4_b precision loss),
+// or Bfp4_b for legacy path.
+tt::DataFormat select_mask_dataformat(const std::optional<Tensor>& attn_mask, bool use_streaming_compute) {
+    if (attn_mask.has_value()) {
+        return tt::tt_metal::datatype_to_dataformat_converter(attn_mask.value().dtype());
+    }
+    return use_streaming_compute ? tt::DataFormat::Float16_b : tt::DataFormat::Bfp4_b;
+}
+
+// Streaming compute v2: no row buffers (cb_push_back_hold_wr_ptr).
+// Mask uses Float16_b for the streaming path to avoid Bfp4_b→Float16_b L1 accumulate artifacts.
+// fp32_dest_acc_en is not functional with the streaming path — skip it in that case.
+// Non-tile-aligned K padding requires boundary tiles the streaming mask path doesn't support.
+// Sq_chunk_t==1 with K padding has L1 acc write-back issues after cb_push_back_hold_wr_ptr.
+bool can_use_streaming_compute(
+    bool is_causal,
+    bool use_provided_mask,
+    bool use_attention_sink,
+    const std::optional<uint32_t>& sliding_window_size,
+    bool is_chunked,
+    bool fp32_dest_acc_en,
+    uint32_t qk_out_subblock_h,
+    uint32_t Sk_chunk_t,
+    uint32_t padded_Sk,
+    uint32_t Sk,
+    uint32_t Sq_chunk_t) {
+    if (is_causal || use_provided_mask || use_attention_sink) {
+        return false;
+    }
+    if (sliding_window_size.value_or(0) != 0 || is_chunked || fp32_dest_acc_en) {
+        return false;
+    }
+    if (qk_out_subblock_h > 2 || Sk_chunk_t % (8 / qk_out_subblock_h) != 0) {
+        return false;
+    }
+    // Non-tile-aligned K padding requires boundary tiles the streaming mask path doesn't support.
+    const bool streaming_mask_unsupported = (padded_Sk != Sk) && (Sk % TILE_HEIGHT != 0 || Sq_chunk_t == 1);
+    return !streaming_mask_unsupported;
+}
+
+// Check whether all data formats used by the compute kernel are uniform (allows skipping reconfigs).
+bool check_uniform_dataformat(
+    const Tensor& q,
+    const Tensor& k,
+    const Tensor& v,
+    const Tensor& out,
+    const std::optional<Tensor>& attn_mask,
+    bool use_streaming_compute) {
+    const tt::DataFormat q_df = tt::tt_metal::datatype_to_dataformat_converter(q.dtype());
+    const tt::DataFormat k_df = tt::tt_metal::datatype_to_dataformat_converter(k.dtype());
+    const tt::DataFormat v_df = tt::tt_metal::datatype_to_dataformat_converter(v.dtype());
+    const tt::DataFormat out_df = tt::tt_metal::datatype_to_dataformat_converter(out.dtype());
+    const tt::DataFormat mask_df = select_mask_dataformat(attn_mask, use_streaming_compute);
+    const tt::DataFormat im_df = tt::DataFormat::Float16_b;
+    return (q_df == k_df && q_df == v_df && q_df == out_df && q_df == mask_df && q_df == im_df);
+}
+
+}  // namespace
+
 SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
     const SDPAParams& operation_attributes, const SDPAInputs& tensor_args, Tensor& tensor_return_value) {
     const auto& input_tensor_q = tensor_args.q;
@@ -284,16 +345,18 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
     auto [qk_out_subblock_h, qk_out_subblock_w] =
         detail::determine_largest_subblock_size(Sq_chunk_t, Sk_chunk_t, dst_size);
 
-    // Streaming compute v2: no row buffers (cb_push_back_hold_wr_ptr).
-    // Mask uses Float16_b for the streaming path to avoid Bfp4_b→Float16_b L1 accumulate artifacts.
-    // fp32_dest_acc_en is not functional with the streaming path — skip it in that case.
-    // Non-tile-aligned K padding requires boundary tiles the streaming mask path doesn't support.
-    // Sq_chunk_t==1 with K padding has L1 acc write-back issues after cb_push_back_hold_wr_ptr.
-    const bool streaming_mask_unsupported = (padded_Sk != Sk) && (Sk % TILE_HEIGHT != 0 || Sq_chunk_t == 1);
-    const bool use_streaming_compute = !is_causal && !use_provided_mask && !use_attention_sink &&
-                                       sliding_window_size.value_or(0) == 0 && !is_chunked && !fp32_dest_acc_en &&
-                                       qk_out_subblock_h <= 2 && Sk_chunk_t % (8 / qk_out_subblock_h) == 0 &&
-                                       !streaming_mask_unsupported;
+    const bool use_streaming_compute = can_use_streaming_compute(
+        is_causal,
+        use_provided_mask,
+        use_attention_sink,
+        sliding_window_size,
+        is_chunked,
+        fp32_dest_acc_en,
+        qk_out_subblock_h,
+        Sk_chunk_t,
+        padded_Sk,
+        Sk,
+        Sq_chunk_t);
 
     const bool lightweight_mask = use_streaming_compute && use_padded_mask;
     // These tile capacity counts for CBs need to match the number of tiles expected by the kernel (softmax.cpp)
@@ -477,18 +540,8 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
 
     TensorAccessorArgs(output_tensor.buffer()).append_to(writer_compile_time_args);
 
-    // Early format check for uniform_dataformat compile-time arg.
-    const tt::DataFormat q_df_early = tt::tt_metal::datatype_to_dataformat_converter(input_tensor_q.dtype());
-    const tt::DataFormat k_df_early = tt::tt_metal::datatype_to_dataformat_converter(input_tensor_k.dtype());
-    const tt::DataFormat v_df_early = tt::tt_metal::datatype_to_dataformat_converter(input_tensor_v.dtype());
-    const tt::DataFormat out_df_early = tt::tt_metal::datatype_to_dataformat_converter(output_tensor.dtype());
-    const tt::DataFormat mask_df_early =
-        attn_mask.has_value() ? tt::tt_metal::datatype_to_dataformat_converter(attn_mask.value().dtype())
-                              : (use_streaming_compute ? tt::DataFormat::Float16_b : tt::DataFormat::Bfp4_b);
-    const tt::DataFormat im_df_early = tt::DataFormat::Float16_b;
-    const bool uniform_dataformat =
-        (q_df_early == k_df_early && q_df_early == v_df_early && q_df_early == out_df_early &&
-         q_df_early == mask_df_early && q_df_early == im_df_early);
+    const bool uniform_dataformat = check_uniform_dataformat(
+        input_tensor_q, input_tensor_k, input_tensor_v, output_tensor, attn_mask, use_streaming_compute);
 
     std::vector<uint32_t> compute_compile_time_args = {
         // matmul args
@@ -552,12 +605,7 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
     tt::DataFormat q_df = tt::tt_metal::datatype_to_dataformat_converter(input_tensor_q.dtype());
     tt::DataFormat k_df = tt::tt_metal::datatype_to_dataformat_converter(input_tensor_k.dtype());
     tt::DataFormat v_df = tt::tt_metal::datatype_to_dataformat_converter(input_tensor_v.dtype());
-    tt::DataFormat mask_df =
-        attn_mask.has_value()
-            ? tt::tt_metal::datatype_to_dataformat_converter(attn_mask.value().dtype())
-            : (use_streaming_compute ? tt::DataFormat::Float16_b  // streaming path L1-accumulates -inf; Float16_b
-                                                                  // avoids Bfp4_b precision loss
-                                     : tt::DataFormat::Bfp4_b);
+    tt::DataFormat mask_df = select_mask_dataformat(attn_mask, use_streaming_compute);
     tt::DataFormat out_df = tt::tt_metal::datatype_to_dataformat_converter(output_tensor.dtype());
     tt::DataFormat scalar_df = tt::DataFormat::Float16_b;
     tt::DataFormat im_df = tt::DataFormat::Float16_b;  // need to disable fp32 cbs (Issue #13364) fp32_dest_acc_en ?

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -115,6 +115,65 @@ bool check_uniform_dataformat(
     return (q_df == k_df && q_df == v_df && q_df == out_df && q_df == mask_df && q_df == im_df);
 }
 
+// Compute the largest granularity that evenly divides both DHt and vDHt (up to dst_size).
+uint32_t compute_dht_granularity(uint32_t DHt, uint32_t vDHt, uint32_t dst_size) {
+    uint32_t g = std::min({DHt, vDHt, dst_size});
+    while (g > 1 && (DHt % g != 0 || vDHt % g != 0)) {
+        g--;
+    }
+    return g;
+}
+
+// Resolve exp_approx_mode from program config, defaulting to true.
+bool get_exp_approx_mode(const std::optional<ttnn::operations::transformer::SDPAProgramConfig>& program_config) {
+    if (program_config.has_value() && program_config->exp_approx_mode.has_value()) {
+        return program_config->exp_approx_mode.value();
+    }
+    return true;
+}
+
+// Chunked prefill parameters collected from page table layout.
+struct ChunkedParams {
+    uint32_t chunked_q_chunk_offset = 0;
+    uint32_t block_size = 0;
+    uint32_t block_size_t = 0;
+    uint32_t max_blocks_per_seq = 0;
+    uint32_t page_table_stick_size = 0;
+};
+
+// Compute chunked prefill parameters from the page table tensor.
+ChunkedParams compute_chunked_params(
+    bool is_chunked,
+    bool is_chunked_legacy,
+    bool flexible_chunked,
+    const std::optional<uint32_t>& chunk_start_idx,
+    const std::optional<Tensor>& page_table,
+    uint32_t k_seq_dim,
+    std::size_t q_chunk_size) {
+    ChunkedParams p;
+    if (!is_chunked) {
+        return p;
+    }
+    if (is_chunked_legacy) {
+        p.chunked_q_chunk_offset = chunk_start_idx.value() / q_chunk_size;
+    }
+    const auto& page_table_tensor = page_table.value();
+    p.block_size = k_seq_dim;
+    p.block_size_t = p.block_size / TILE_HEIGHT;
+    if (flexible_chunked) {
+        p.max_blocks_per_seq = page_table_tensor.padded_shape()[1];
+        p.page_table_stick_size = p.max_blocks_per_seq * sizeof(int32_t);
+        TT_FATAL(p.page_table_stick_size % 32 == 0, "page table stick size must be a multiple of 32");
+    } else {
+        p.max_blocks_per_seq = page_table_tensor.padded_shape()[1];
+        p.page_table_stick_size = page_table_tensor.buffer()->aligned_page_size();
+        TT_FATAL(
+            p.page_table_stick_size % 32 == 0,
+            "page table page size in bytes must be a multiple of 32 due to address alignment");
+    }
+    return p;
+}
+
 }  // namespace
 
 SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
@@ -240,35 +299,14 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
     log_debug(tt::LogOp, "NKH: {}", NKH);
     log_debug(tt::LogOp, "sliding_window_size: {}", sliding_window_size.has_value() ? sliding_window_size.value() : 0);
 
-    // In chunked prefill mode, the offset of Q in terms of Q chunks
-    uint32_t chunked_q_chunk_offset = 0;
-    uint32_t block_size = 0;
-    uint32_t block_size_t = 0;
-    [[maybe_unused]] uint32_t max_blocks_per_seq = 0;
-    uint32_t page_table_stick_size = 0;
+    const auto chunked = compute_chunked_params(
+        is_chunked, is_chunked_legacy, flexible_chunked, chunk_start_idx, page_table, k_shape[2], q_chunk_size);
+    uint32_t chunked_q_chunk_offset = chunked.chunked_q_chunk_offset;
+    const uint32_t block_size = chunked.block_size;
+    const uint32_t block_size_t = chunked.block_size_t;
+    [[maybe_unused]] const uint32_t max_blocks_per_seq = chunked.max_blocks_per_seq;
+    const uint32_t page_table_stick_size = chunked.page_table_stick_size;
     tt::DataFormat page_table_df = tt::DataFormat::Int32;
-
-    if (is_chunked) {
-        if (is_chunked_legacy) {
-            // chunk_start_idx must be a multiple of q_chunk_size (validated in sdpa_device_operation.cpp)
-            chunked_q_chunk_offset = chunk_start_idx.value() / q_chunk_size;
-        }
-        // else: flexible_chunked - chunked_q_chunk_offset set inside of the op
-        const auto& page_table_tensor = page_table.value();
-        block_size = k_shape[2];  // K's sequence dimension represents block size
-        block_size_t = block_size / TILE_HEIGHT;
-        if (flexible_chunked) {
-            max_blocks_per_seq = page_table_tensor.padded_shape()[1];
-            page_table_stick_size = max_blocks_per_seq * sizeof(int32_t);
-            TT_FATAL(page_table_stick_size % 32 == 0, "page table stick size must be a multiple of 32");
-        } else {
-            max_blocks_per_seq = page_table_tensor.padded_shape()[1];
-            page_table_stick_size = page_table_tensor.buffer()->aligned_page_size();
-            TT_FATAL(
-                page_table_stick_size % 32 == 0,
-                "page table page size in bytes must be a multiple of 32 due to address alignment");
-        }
-    }
     // Log page table info
     log_debug(tt::LogOp, "is_chunked: {}", is_chunked);
     if (is_chunked) {
@@ -298,10 +336,7 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
 
     CoreCoord grid_size = program_config.has_value() ? program_config->compute_with_storage_grid_size
                                                      : device->compute_with_storage_grid_size();
-    bool exp_approx_mode =
-        program_config.has_value()
-            ? (program_config->exp_approx_mode.has_value() ? program_config->exp_approx_mode.value() : true)
-            : true;
+    const bool exp_approx_mode = get_exp_approx_mode(program_config);
 
     auto core_grid = CoreRange({0, 0}, {grid_size.x - 1, grid_size.y - 1});
     uint32_t num_cores = grid_size.x * grid_size.y;
@@ -419,10 +454,7 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
     const uint32_t mul_bcast_granularity = detail::find_valid_granularity(Sq_chunk_t * Sk_chunk_t, dst_size);
     // DHT_GRANULARITY is used in the kernel with both DHt and vDHt as the cols parameter,
     // so the granularity must evenly divide both to avoid dropping tiles.
-    uint32_t dht_granularity = std::min({DHt, vDHt, dst_size});
-    while (dht_granularity > 1 && (DHt % dht_granularity != 0 || vDHt % dht_granularity != 0)) {
-        dht_granularity--;
-    }
+    const uint32_t dht_granularity = compute_dht_granularity(DHt, vDHt, dst_size);
     const uint32_t reduce_granularity = detail::find_valid_granularity(Sq_chunk_t, dst_size / 2);
 
     // Log these


### PR DESCRIPTION
Main motivation is to speed up non-causal SDPA for WAN 2.2 shapes.
On single chip tests this change brings us to 60% and 47% math utilisation on single galaxy and quad setup respectively.

This PR will be quickly followed by improvements to this pipeline on branch 
https://github.com/tenstorrent/tt-metal/tree/pjosipovic/sdpa_wan_integration_v5
that will push these numbers further to 64% and 50%

## Summary
- Add a streaming compute path (v2) for SDPA that eliminates row buffers via `cb_push_back_hold_wr_ptr` and enables FPU/SFPU overlap
- Kernel split into Phase 1 (Q@KT with in-place sub_exp) and Phase 2 (drain + QKT@V + SALAD corrections with streaming normalization)
- Gated by compile-time conditions (`sbh==1`, no `fp32_dest_acc`, `DHt<=8`)
- Supports both standard SDPA and ring joint SDPA with K-chunk loop, ring-specific skip logic, and ring finalization

### Key changes
- `compute_streaming.hpp`: new `sdpa_inner_loop_step()` core with `ring_mode` and `use_ring_mask` template params; `sdpa_standard_v2()` for standard SDPA; `sdpa_ring_v2()` for ring joint SDPA
- `sdpa.cpp` / `ring_joint_sdpa.cpp`: branch on `use_streaming_compute` to call v2 path
- Host factories: add streaming gating logic, CB `c_9`, and compile-time args
- Padded K mask support via `use_padded_mask` template param
- Ring mask L1-accumulate extracted into `apply_ring_mask_to_qkt()` helper

## Test plan
- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=pjosipovic/sdpa_wan_integration_v4)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:pjosipovic/sdpa_wan_integration_v4)
- [ ] [![Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/sdpa_wan_integration_v4)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/sdpa_wan_integration_v4)
- [ ] [![Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml/badge.svg?branch=pjosipovic/sdpa_wan_integration_v4)](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml?query=branch:pjosipovic/sdpa_wan_integration_v4)
- [ ] [![Nightly L2 tests (SDPA)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/sdpa_wan_integration_v4)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/sdpa_wan_integration_v4)
- [ ] [![T3K e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/sdpa_wan_integration_v4)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/sdpa_wan_integration_v4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)