### PR TITLE
[tt-train] Fix GCC and libc++ build failures in ttml CMakeLists.txt

### DIFF
--- a/tt-train/sources/ttml/CMakeLists.txt
+++ b/tt-train/sources/ttml/CMakeLists.txt
@@ -399,13 +399,14 @@ target_precompile_headers(
 
 if(ENABLE_LIBCXX)
     target_link_libraries(
+        ttml
         PUBLIC
             ${LIBC++}
             ${LIBC++ABI}
     )
 endif()
 
-add_definitions(-DTOKENIZERS_DATA_PATH="${CMAKE_SOURCE_DIR}/data")
+target_compile_definitions(ttml PUBLIC TOKENIZERS_DATA_PATH="${CMAKE_SOURCE_DIR}/data")
 
 set(GPT2_TOKENIZER_URL "https://huggingface.co/openai-community/gpt2/resolve/main/tokenizer.json")
 set(GPT2_TOKENIZER_FILE "${CMAKE_SOURCE_DIR}/data/gpt2-tokenizer.json")


### PR DESCRIPTION
### Ticket
Fixes #38847

### Problem description
Two CMake bugs in `tt-train/sources/ttml/CMakeLists.txt` prevent building tt-train with GCC or with clang+libc++:

**Bug 1 (blocks all GCC builds):** `add_definitions(-DTOKENIZERS_DATA_PATH=...)` at line 408 is placed after `target_precompile_headers(ttml PRIVATE ...)` at line 372. The PCH is compiled without `TOKENIZERS_DATA_PATH` defined, then GCC rejects the mismatch with `-Werror=invalid-pch`. Clang silently succeeds, masking this in CI. Regressed in #37694.

**Bug 2 (blocks clang+libc++):** `target_link_libraries(PUBLIC ...)` at line 401 is missing the target name `ttml`. CMake interprets `PUBLIC` as the target name and fails. Pre-existing (never tested).

### What's changed
Two-line fix:

1. Added missing target name `ttml` to `target_link_libraries()` call in the `ENABLE_LIBCXX` block
2. Replaced global `add_definitions(-DTOKENIZERS_DATA_PATH=...)` with target-scoped `target_compile_definitions(ttml PUBLIC TOKENIZERS_DATA_PATH=...)` — this ensures the definition is included when the PCH is compiled and propagates to consumers via the `PUBLIC` keyword

**Container build verification:**

| Build | Result | Notes |
|-------|--------|-------|
| Ubuntu 22.04 default (clang-20, libstdc++) | PASS | Regression test — no behavior change |
| Ubuntu 24.04 gcc-14 | PASS | Verifies Fix 1 (GCC PCH) — was failing with `-Werror=invalid-pch` |
| Ubuntu 22.04 clang-20-libcpp | PASS | Verifies Fix 2 (libc++) — CMake configure + build succeed |

All builds verified: tt-metal (`unit_tests_api`, 1119 tests) and tt-train (`ttml_tests`, 448 tests) binaries built and functional in both integrated and standalone modes. Python `ttnn` import confirmed.

<details>
<summary>Note on standalone tt-train with libc++</summary>

The standalone tt-train build (separate CMake invocation in `tt-train/`) passes CMake configure and compilation with clang-20+libc++, confirming Fix 2 works. Linking fails due to a pre-existing ABI mismatch (`std::optional` symbol differences between libc++ and libstdc++) that is unrelated to the changes in this PR.

</details>

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ivoitovych/issue-38847-fix-tt-train-cmake-gcc-libcpp)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ivoitovych/issue-38847-fix-tt-train-cmake-gcc-libcpp)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ivoitovych/issue-38847-fix-tt-train-cmake-gcc-libcpp)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ivoitovych/issue-38847-fix-tt-train-cmake-gcc-libcpp)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ivoitovych/issue-38847-fix-tt-train-cmake-gcc-libcpp)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ivoitovych/issue-38847-fix-tt-train-cmake-gcc-libcpp)
- [x] New/Existing tests provide coverage for changes