### PR TITLE
#36020: Update moe gate and rmsnorm to use overlapped weights

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
@@ -38,7 +38,12 @@ from models.demos.deepseek_v3_b1.unified_kernel_descriptor import (
     UnifiedCompileTimeCoreDescriptor,
     UnifiedKernelDescriptor,
 )
-from models.demos.deepseek_v3_b1.utils import build_cb_reconfig_tensor, float_to_uint32, record_cb_metadata
+from models.demos.deepseek_v3_b1.utils import (
+    build_cb_reconfig_tensor,
+    cb_descriptor_from_overlapped_tensor,
+    float_to_uint32,
+    record_cb_metadata,
+)
 
 
 class MoeCB:
@@ -983,7 +988,10 @@ class MoeRoutedExpertOp:
         rmsnorm_output_cb_descriptor.format_descriptors[0].tile = rmsnorm_tile_descriptor
         rmsnorm_output_cb_descriptor.format_descriptors[0].page_size = rmsnorm_cb_page_size
 
-        rmsnorm_gamma_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(rmsnorm_gamma_cb, rmsnorm_gamma_tensor)
+        rmsnorm_gamma_fused_device0 = ttnn.get_device_tensors(rmsnorm_gamma_tensor.fused_tensor)[0]
+        rmsnorm_gamma_cb_descriptor = cb_descriptor_from_overlapped_tensor(
+            rmsnorm_gamma_cb, rmsnorm_gamma_tensor, rmsnorm_gamma_fused_device0
+        )
         rmsnorm_gamma_cb_descriptor.format_descriptors[0].tile = rmsnorm_tile_descriptor
         rmsnorm_gamma_cb_descriptor.format_descriptors[0].page_size = rmsnorm_cb_page_size
 
@@ -1035,7 +1043,7 @@ class MoeRoutedExpertOp:
                 in0_cb=gate_mm_input_cb,
                 in1_cb=gate_mm_weights_cb,
                 out_cb=gate_mm_output_cb,
-                weights_tensor=gate_mm_weights_tensor,
+                weights_overlapped=gate_mm_weights_tensor,
                 k_num_tiles=num_tiles_k,
                 fused_activation=MoeRoutedExpertOp.ACTIVATION_SIGMOID,
             )
@@ -2387,7 +2395,7 @@ class MoeSharedExpertOp:
             in0_cb=shared_down_mcast_dst_cb,
             in1_cb=shared_down_matmul_in1_cb,
             out_cb=shared_down_matmul_out_cb,
-            weights_tensor=shared_down_weights_tensor,
+            weights_overlapped=shared_down_weights_tensor,
             k_num_tiles=n_parallel,
         )
 
@@ -2933,7 +2941,7 @@ class MoeOp:
         in0_cb,
         in1_cb,
         out_cb,
-        weights_tensor,
+        weights_overlapped,
         output_tensor=None,
         k_num_tiles=0,
         fused_activation=0,
@@ -2948,7 +2956,7 @@ class MoeOp:
             in0_cb: Input CB index (receives mcasted input)
             in1_cb: Weights CB index
             out_cb: Output CB index
-            weights_tensor: Weight tensor (WIDTH_SHARDED in L1)
+            weights_overlapped: OverlappedTensor or plain ttnn.Tensor (WIDTH_SHARDED in L1)
             output_tensor: Output tensor (WIDTH_SHARDED in L1), or None if CB descriptor
                            will be created by the overlap function.
             k_num_tiles: K dimension in tiles
@@ -2957,14 +2965,21 @@ class MoeOp:
         Returns:
             Dictionary with matmul parameters and CB descriptors
         """
-        weights_tile = weights_tensor.get_tile()
-        weights_shard_shape = weights_tensor.memory_config().shard_spec.shape
-        weights_shard_width = weights_shard_shape[1]
-        out_w = weights_shard_width // weights_tile.tile_shape[1]
+        if hasattr(weights_overlapped, "fused_tensor"):
+            fused_tensor_device0 = ttnn.get_device_tensors(weights_overlapped.fused_tensor)[0]
+            out_w = weights_overlapped.shard_shape[1] // weights_overlapped.tile_shape[1]
+            core_grid = weights_overlapped.core_range_set
+            weights_cb_descriptor = cb_descriptor_from_overlapped_tensor(
+                in1_cb, weights_overlapped, fused_tensor_device0
+            )
+        else:
+            weights_device0 = ttnn.get_device_tensors(weights_overlapped)[0]
+            tile = weights_device0.get_tile()
+            shard_shape = weights_overlapped.memory_config().shard_spec.shape
+            out_w = shard_shape[1] // tile.tile_shape[1]
+            core_grid = weights_overlapped.memory_config().shard_spec.grid
+            weights_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(in1_cb, weights_device0)
 
-        core_grid = weights_tensor.memory_config().shard_spec.grid
-
-        weights_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(in1_cb, weights_tensor)
         output_cb_descriptor = None
         if output_tensor is not None:
             output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(out_cb, output_tensor)
@@ -4197,8 +4212,9 @@ class MoeOp:
         ctx = self.ctx
         io_tensors = []
         if ctx.enable_routing:
+            gate_mm_backing = getattr(ctx.gate_mm_weights_tensor, "fused_tensor", ctx.gate_mm_weights_tensor)
             io_tensors += [
-                ctx.gate_mm_weights_tensor,
+                gate_mm_backing,
                 ctx.gate_bias_tensor,
                 ctx.gate_indices_tensor,
                 ctx.gate_output_scores_tensor,
@@ -4208,7 +4224,7 @@ class MoeOp:
         if ctx.final_output_tensor is not None:
             io_tensors += [ctx.final_output_tensor]
         io_tensors += [
-            ctx.rmsnorm_gamma_tensor,
+            ctx.rmsnorm_gamma_tensor.fused_tensor,
             ctx.shared_residual_mcast_src_tensor,
             ctx.shared_gate_weights_fused_tensor,
             ctx.shared_down_weights_tensor,

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_mlp.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_mlp.py
@@ -156,9 +156,7 @@ def create_routed_expert_tensors(
     )  # Gate bias (batch=1, 8, 32) - matches golden expectation
     # Expert indices 0-255, transposed as expected by gate
     torch_indices = torch.arange(N, dtype=torch.int32).reshape(16, 16).T.contiguous().to(torch.uint16)
-
-    # Define core grid for compute (first column, 8 cores)
-    compute_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, num_cores - 1))])
+    torch_rmsnorm_gamma = torch.randn(1, K, dtype=torch.bfloat16).float()
 
     # Input tensor: sharded on sender core OUTSIDE the compute grid
     device_grid_size = device.compute_with_storage_grid_size()
@@ -181,56 +179,44 @@ def create_routed_expert_tensors(
         **from_torch_kwargs,
     )
 
-    # ── RMSNorm gamma weights [1, K] on sender core ──
-    torch_rmsnorm_gamma = torch.randn(1, K, dtype=torch.bfloat16).float()
-    rmsnorm_gamma_shard = ttnn.ShardSpec(input_core_grid, (M, K), ttnn.ShardOrientation.ROW_MAJOR)
-    rmsnorm_gamma_mem = ttnn.MemoryConfig(
-        ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, rmsnorm_gamma_shard
-    )
-    ttnn_rmsnorm_gamma = ttnn.from_torch(
-        torch_rmsnorm_gamma,
-        dtype=ttnn.bfloat16,
-        layout=ttnn.TILE_LAYOUT,
-        device=device,
-        memory_config=rmsnorm_gamma_mem,
-        tile=tile_1x32,
-        **from_torch_kwargs,
-    )
-
     # Get optimal DRAM bank cores for DRAM streaming matmul + SiLU
     gate_proj_noc = ttnn.NOC.NOC_0
     gate_proj_worker_cores = device.get_optimal_dram_bank_to_logical_worker_assignment(gate_proj_noc)
     gate_proj_core_ranges = ttnn.CoreRangeSet([ttnn.CoreRange(core, core) for core in gate_proj_worker_cores])
     num_gate_proj_cores = len(gate_proj_worker_cores)
 
+    # ── Gate MM weights + RMSNorm gamma via overlapped tensor (matches production layout) ──
+    bdw_weights = BlitzDecodeWeights(device)
+    torch_o_proj_dummy = torch.zeros((8192 * bdw_weights.mla_tp, K), dtype=torch.bfloat16)
+    torch_attn_norm_dummy = torch.zeros((1, K), dtype=torch.bfloat16)
+    torch_q_norm_dummy = torch.zeros((1, 1536), dtype=torch.bfloat16)
+    torch_kv_norm_dummy = torch.zeros((1, 512), dtype=torch.bfloat16)
+    (
+        _,  # o_proj
+        ttnn_gate_mm_weights,  # gate_mm overlapped tensor on (12,0)-(12,7)
+        _,  # attn_norm
+        _,  # q_norm
+        _,  # kv_norm
+        ttnn_rmsnorm_gamma,  # ffn_norm overlapped tensor on gamma core
+    ) = bdw_weights.get_tt_o_proj_and_gate_mm_weights(
+        torch_o_proj_dummy,
+        torch_gate_mm_weights,
+        torch_attn_norm_dummy,
+        torch_q_norm_dummy,
+        torch_kv_norm_dummy,
+        torch_rmsnorm_gamma.bfloat16(),
+    )
+    compute_core_grid = ttnn_gate_mm_weights.core_range_set
+
     # Routing tensors (only when enable_routing=True)
-    ttnn_gate_mm_weights = None
+    if not enable_routing:
+        ttnn_gate_mm_weights = None
     ttnn_gate_bias = None
     ttnn_gate_indices = None
     gate_output_scores_tensor = None
     gate_output_indices_tensor = None
 
     if enable_routing:
-        # Gate matmul weights: width-sharded across 8 cores
-        gate_mm_weights_shard_spec = ttnn.ShardSpec(
-            compute_core_grid,
-            (K, N_per_core),
-            ttnn.ShardOrientation.ROW_MAJOR,
-        )
-        gate_mm_weights_mem_config = ttnn.MemoryConfig(
-            ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, gate_mm_weights_shard_spec
-        )
-
-        ttnn_gate_mm_weights = ttnn.from_torch(
-            torch_gate_mm_weights,
-            dtype=ttnn.bfloat16,
-            layout=ttnn.TILE_LAYOUT,
-            device=device,
-            memory_config=gate_mm_weights_mem_config,
-            tile=tile_32x32,
-            **from_torch_kwargs,
-        )
-
         # Gate bias and indices tensors: [16, 16] on sender core
         gate_input_shard_spec = ttnn.ShardSpec(
             input_core_grid,

--- a/models/demos/deepseek_v3_b1/utils.py
+++ b/models/demos/deepseek_v3_b1/utils.py
@@ -5,12 +5,8 @@
 from __future__ import annotations
 
 import struct
-from typing import TYPE_CHECKING
 
 import ttnn
-
-if TYPE_CHECKING:
-    from models.demos.deepseek_v3_b1.blitz_decode_weights import OverlappedTensor
 
 
 def float_to_bfloat16_packed(value):


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/36020)

### Problem description
Need to swap remaining moe gate mm and rmsnorm gamma to use overlapped tensor. There is an issue (#38839) that is causing ND PCC with some test_moe_mlp tests. Reverting `4473b097` in `tt_llk` is needed to get deterministic testing. 

### What's changed
- Flip moe gate mm and rmsnorm gamma to use overlapped tensor

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=bliu/deepseek)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:bliu/deepseek): https://github.com/tenstorrent/tt-metal/actions/runs/22546839857
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bliu/deepseek)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bliu/deepseek): https://github.com/tenstorrent/tt-metal/actions/runs/22546844652
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bliu/deepseek)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bliu/deepseek)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bliu/deepseek)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bliu/deepseek)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bliu/deepseek)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bliu/deepseek)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bliu/deepseek)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bliu/deepseek)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
