### PR TITLE
Fix num_workers calculation in fd_mesh_command_queue

### DIFF
--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -284,7 +284,12 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
     uint32_t num_virtual_eth_cores = 0;
 
     if (mcast_go_signals) {
-        num_workers += mesh_device_->num_worker_cores(HalProgrammableCoreType::TENSIX, sub_device_id);
+        for (auto& [device_range, program] : mesh_workload.get_programs()) {
+            uint32_t active_cores = 0;
+            for (auto& v : program.impl().logical_cores())
+                active_cores += v.size();
+            num_workers += active_cores << 6;
+        }
     }
     if (unicast_go_signals) {
         // Issue #19729: Running MeshWorkloads on Active Eth cores is supported through multiple workarounds


### PR DESCRIPTION
num_worker_cores(TENSIX) returns the total number of Tensix cores on the device (~140), but each worker signals completion with at_data = 0x40 (1 << 6). The expected total should be num_active_cores << 6, not the raw core count.

This mismatch causes the host to wait for a completion count that will never be reached when a program uses fewer cores than the total available, resulting in a timeout.

Fix by iterating over the actual programs in the workload, summing their logical_cores() counts, and shifting by 6 to match the per-core signal value.

### Ticket
N/A (discovered during Blackhole emulator development)

### Problem description
`num_worker_cores(TENSIX)` returns the total number of Tensix cores on the device (~140), but each worker signals completion with `at_data = 0x40` (1 << 6). The expected total should be `num_active_cores << 6`, not the raw core count.

### What's changed
Replace `num_worker_cores()` with the actual active core count from the workload's programs by iterating over `mesh_workload.get_programs()`, summing their `logical_cores()` counts, and shifting by 6 to match the per-core signal value.

### Checklist

- [ ] New/Existing tests provide coverage for changes

