### PR TITLE
#37665: Update pre-SDPA (includes FlashMLA) to do proper SP=4

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
@@ -38,6 +38,7 @@
 #include "../../../unified_kernels/broadcast.hpp"
 #include "../../../unified_kernels/kv_cache_update.hpp"
 #include "../../../unified_kernels/flash_mla.hpp"
+#include "../../../micro_ops/flash_mla/kernels/rt_args_common.hpp"
 
 // Compile-time role flags for dead code elimination via if constexpr
 // Defined at namespace scope (local classes cannot have static data members)
@@ -62,6 +63,11 @@ struct Core {
 
     // MLA
     static constexpr bool is_mla_core = get_named_compile_time_arg_val("is_mla_core") == 1;
+
+    // Sequence Parallel configs
+    static constexpr uint32_t kv_cache_device_chunk_size = get_named_compile_time_arg_val("kv_cache_device_chunk_size");
+    static constexpr uint32_t kv_cache_sp_device_idx = get_named_compile_time_arg_val("kv_cache_sp_device_idx");
+    static constexpr uint32_t kv_cache_num_sp_devices = get_named_compile_time_arg_val("kv_cache_num_sp_devices");
 };
 
 void kernel_main() {
@@ -268,7 +274,7 @@ uint32_t per_core_rta_arg_idx = 0;
     if constexpr (Core::is_mla_core) {
         flash_mla_args = {
             .k_addr = get_common_arg_val<uint32_t>(13),
-            .pos_addr = get_common_arg_val<uint32_t>(14),
+            .local_cur_pos = 0,  // set via flash_mla.set_local_cur_pos() below
             .cur_batch = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
             .core_num_in_reduce = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
             .is_mcast_sender = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
@@ -435,7 +441,7 @@ uint32_t per_core_rta_arg_idx = 0;
 
     deepseek_b1_ops::KVCacheUpdate::WriterArgs kv_cache_update_args{
         .kv_cache_buffer_base_addr = get_common_arg_val<uint32_t>(0),
-        .pos_addr = get_common_arg_val<uint32_t>(1),
+        .local_cur_pos = 0,  // set via kv_cache_update.set_local_cur_pos() below
         .kv_cache_input_cb = get_named_compile_time_arg_val("kv_cache_input_cb"),
         .kv_cache_intermed_cb = get_named_compile_time_arg_val("kv_cache_intermed_cb"),
         .kv_cache_output_cb = get_named_compile_time_arg_val("kv_cache_output_cb"),
@@ -468,7 +474,7 @@ uint32_t per_core_rta_arg_idx = 0;
         per_core_rta_arg_idx += num_tree_reduction_steps * 4;
 
         flash_mla_args = {
-            .pos_addr = get_common_arg_val<uint32_t>(1),
+            .local_cur_pos = 0,  // set via flash_mla.set_local_cur_pos() below
             .cur_batch = cur_batch,
             .core_num_in_reduce = core_num_in_reduce,
             .is_output_core = is_output_core,
@@ -708,7 +714,7 @@ uint32_t per_core_rta_arg_idx = 0;
         per_core_rta_arg_idx += num_tree_reduction_steps * 2;
 
         flash_mla_args = {
-            .pos_addr = get_common_arg_val<uint32_t>(7),
+            .local_cur_pos = 0,  // set via flash_mla.set_local_cur_pos() below
             .do_reduce = do_reduce,
             .do_output = do_output,
             .cur_batch = cur_batch,
@@ -803,6 +809,14 @@ uint32_t per_core_rta_arg_idx = 0;
     }
 #endif
 
+#if defined(COMPILE_FOR_BRISC)
+    uint32_t cur_pos_addr = get_common_arg_val<uint32_t>(1);
+#elif defined(COMPILE_FOR_NCRISC)
+    uint32_t cur_pos_addr = get_common_arg_val<uint32_t>(14);
+#elif defined(COMPILE_FOR_TRISC)
+    uint32_t cur_pos_addr = get_common_arg_val<uint32_t>(7);
+#endif
+
     // ========================================================================
     // CCL Broadcast (optional, skip if single-device mode)
     // ========================================================================
@@ -825,17 +839,9 @@ uint32_t per_core_rta_arg_idx = 0;
     }
 #endif
 
-    // ========================================================================
-    // Input core: RMSNorm + Mcast send
-    // ========================================================================
-    {
-        DeviceZoneScopedN("RMSNORM");
-        // pop_input = true (input is consumed after RMSNorm)
-        deepseek_b1_ops::RMSNorm::Op<RMSNormCTArgs, Core::is_input_core, true> rmsnorm;
-        rmsnorm(rmsnorm_args);
-    }
-
-    // pop_src = true (rmsnorm output is consumed after mcast)
+    // ====================================================================
+    // Mcast: Initialize persistent mcast
+    // ====================================================================
     deepseek_b1_ops::Mcast::Op<
         McastCTArgs,
         Core::is_input_core,
@@ -843,182 +849,200 @@ uint32_t per_core_rta_arg_idx = 0;
         Core::is_matmul_core || Core::is_dkv_matmul_core,
         true>
         mcast;
-    mcast.init(mcast_args);
     {
-        DeviceZoneScopedN("MCAST");
-        // Mcast: NCRISC sends from input core, BRISC receives on matmul cores, TRISC no-op
-        // pop_src = true (input is consumed after mcast)
-        mcast(mcast_args);
+        DeviceZoneScopedN("MCAST_INIT");
+        mcast.init(mcast_args);
     }
 
     // ========================================================================
-    // Matmul operation
+    // SP position handling.
+    // Read the global position from L1 and decide whether this device has
+    // work / owns the current KV-cache slot. The normalized (device-local)
+    // local_cur_pos is used for kv cache update and flash mla.
     // ========================================================================
-    {
-        DeviceZoneScopedN("MATMUL");
-        // pop_act = false (shared activation buffer), pop_weights = false (weights are persistent)
-        deepseek_b1_ops::KNSlicedMatmul::Op<MatmulCTArgs, Core::is_matmul_core, false, false> matmul;
-        matmul(matmul_args);
-    }
+    volatile tt_l1_ptr uint32_t* pos_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cur_pos_addr);
+    uint32_t cur_pos = pos_ptr[0];
 
-    // ========================================================================
-    // GatherReduce: matmul cores (senders) -> input core (receiver/reducer)
-    // NCRISC sends from matmul cores, BRISC receives on input core, TRISC reduces CB7 += CB8
-    // ========================================================================
-    {
-        DeviceZoneScopedN("GATHER");
-        // pop_src = true (matmul output is consumed after gather)
-        deepseek_b1_ops::GatherReduce::Op<Core::is_matmul_core, Core::is_input_core, Core::is_input_core, true>
-            gather_reduce;
-        gather_reduce(gather_reduce_args);
-    }
+    const auto [skip_attention, skip_kv_cache_update, local_cur_pos] = get_device_mla_work_assignment(
+        cur_pos, Core::kv_cache_sp_device_idx, Core::kv_cache_device_chunk_size, Core::kv_cache_num_sp_devices);
 
-    // ========================================================================
-    // RMSNorm2: Apply RMSNorm to the gathered data (1536 elements = 3 tiles of 16x32)
-    // Gather writes directly to rmsnorm2_input_cb (3 tiles of 16x32)
-    // Uses SEPARATE CBs with exact sizes:
-    //   - Input: rmsnorm2_input_cb (3 tiles from gather)
-    //   - Output: rmsnorm2_output_cb (3 tiles)
-    //   - Gamma: rmsnorm2_gamma_cb (3 tiles)
-    // ========================================================================
-    // pop_input = true (gathered data is consumed after RMSNorm2)
-    {
-        DeviceZoneScopedN("RMSNORM2");
-        deepseek_b1_ops::RMSNorm::Op<RMSNorm2CTArgs, Core::is_input_core, true> rmsnorm2;
-        rmsnorm2(rmsnorm2_args);
-    }
-
-    // ========================================================================
-    // Mcast2: Broadcast rmsnorm2 output from input core to all matmul2 cores
-    // Reads from rmsnorm2_output_cb, writes to matmul2_in0 with loopback
-    // Uses same grid and semaphores as first mcast
-    // ========================================================================
-    // pop_src = true (rmsnorm2 output is consumed after mcast)
-    {
-        DeviceZoneScopedN("MCAST2");
-        // Mcast2: NCRISC sends from input core, BRISC receives on matmul2 cores, TRISC no-op
-        deepseek_b1_ops::Mcast::Op<McastCTArgs, Core::is_input_core, Core::is_matmul2_core, Core::is_matmul2_core, true>
-            mcast2;
-        mcast2(mcast2_args);
-    }
-    mcast.teardown();
-
-    // ========================================================================
-    // Matmul2: matmul2_input[1, 1536] @ matmul2_weights[1536, N]
-    // N = 12288 for P150 (96 cores * 4 tiles * 32) or 11264 for non-P150
-    // Each core computes 1x4 output tiles (4 1x32 tiles)
-    // ========================================================================
-    {
-        DeviceZoneScopedN("MATMUL2");
-        // pop_in0 = true (consumed), pop_in1 = false (weights are persistent)
-        // On Qnope cores: output stays in matmul2_output_cb for matmul3 input
-        // On Qrope cores: output goes to matmul2_output_cb for RoPE input
-        deepseek_b1_ops::Matmul::Op<Matmul2CTArgs, Core::is_matmul2_core, true, false> matmul2;
-        matmul2(matmul2_args);
-    }
-
-    {
-        DeviceZoneScopedN("Q_HEADS") static_assert(
-            !(Core::is_qnope_core && Core::is_qrope_core), "Core cannot be both QNOPE and QROPE");
-
-        // ========================================================================
-        // Matmul3 (QNoPE): matmul3_input[64, 1, 128] @ matmul3_weights[64, 128, 512] -> matmul3_output[64, 1, 512]
-        // 64 cores (8x8 grid) each compute 1x16 output tiles (16 1x32 tiles)
-        // ========================================================================
+    if (!skip_attention) {
+        // ====================================================================
+        // Input core: RMSNorm + Mcast send
+        // ====================================================================
         {
-            DeviceZoneScopedN("QNOPE/MATMUL3");
-            // pop_in0 = true (consumed), pop_in1 = false (weights are persistent)
-            deepseek_b1_ops::Matmul::Op<Matmul3CTArgs, Core::is_qnope_core, true, false> matmul3;
-            matmul3(matmul3_args);
+            DeviceZoneScopedN("RMSNORM");
+            deepseek_b1_ops::RMSNorm::Op<RMSNormCTArgs, Core::is_input_core, true> rmsnorm;
+            rmsnorm(rmsnorm_args);
         }
 
-        // ========================================================================
-        // RoPE (Qrope): Applies rotary position embedding to Qrope heads
-        // Reads from matmul2_output_cb, writes to qrope_output_cb
-        // ========================================================================
         {
-            DeviceZoneScopedN("QROPE");
-            deepseek_b1_ops::Rope::Op<QRopeCTArgs, Core::is_qrope_core> rope;
-            rope(qrope_args);
+            DeviceZoneScopedN("MCAST");
+            mcast(mcast_args);
         }
 
-        // ========================================================================
-        // CreateQHeads: 3-phase QNOPE/QROPE -> SDPA transfer with tilization
-        // Phase 1: QNOPE first 256 elements → [8, 256] row-major → 8 tiles
-        // Phase 2: QNOPE second 256 elements → [8, 256] row-major → 8 tiles
-        // Phase 3: QROPE 64 elements per head → [8, 64] row-major → 2 tiles
-        // Senders write to intermediate CB, TRISC tilizes to output CB
-        // NCRISC sends from qnope/qrope cores, BRISC receives on sdpa input cores, TRISC no-op
-        // ========================================================================
+        // ====================================================================
+        // Matmul operation
+        // ====================================================================
         {
-            DeviceZoneScopedN("CREATE_Q_HEADS");
-            // CreateQHeads Op configuration:
-            // - IsSenderCore: is_qnope_core || is_qrope_core
-            // - IsReceiverCore: is_sdpa_input_core
-            // - pop_src: true (pop source CB after sending)
-            constexpr bool is_create_q_heads_sender = Core::is_qnope_core || Core::is_qrope_core;
-            deepseek_b1_ops::CreateQHeads::
-                Op<CreateQHeadsCTArgs, is_create_q_heads_sender, Core::is_sdpa_input_core, false, true>
-                    create_q_heads;
-            create_q_heads(create_q_heads_args);
-        }
-    }
-    {
-        // ========================================================================
-        // KV Cache Branch - Matmul
-        // DKV Matmul: 9x2 grid, each core handles 1 head of 32 dim
-        // ========================================================================
-        {
-            DeviceZoneScopedN("DKV_MATMUL");
-            // pop_in0 = true (consumed), pop_in1 = false (weights are persistent)o
-            deepseek_b1_ops::Matmul::Op<DKV_MatmulCTArgs, Core::is_dkv_matmul_core, false, false> dkv_matmul;
-            dkv_matmul(dkv_matmul_args);
+            DeviceZoneScopedN("MATMUL");
+            deepseek_b1_ops::KNSlicedMatmul::Op<MatmulCTArgs, Core::is_matmul_core, false, false> matmul;
+            matmul(matmul_args);
         }
 
-        // ========================================================================
-        // KV Cache Branch: Gather: dkv matmul cores (senders) -> rmsnorm core (receiver)
-        // NCRISC sends from knope grid of dkv matmul cores, BRISC receives on rmsnorm grid, TRISC no-op
-        // ========================================================================
+        // ====================================================================
+        // GatherReduce: matmul cores (senders) -> input core (receiver/reducer)
+        // ====================================================================
         {
-            DeviceZoneScopedN("DKV_GATHER");
-            deepseek_b1_ops::Gather::Op<Core::is_knope_core, Core::is_kv_rmsnorm_core, true> dkv_gather;
-            dkv_gather(dkv_gather_args);
+            DeviceZoneScopedN("GATHER");
+            deepseek_b1_ops::GatherReduce::Op<Core::is_matmul_core, Core::is_input_core, Core::is_input_core, true>
+                gather_reduce;
+            gather_reduce(gather_reduce_args);
         }
 
-        // ========================================================================
-        // RMSNorm: Apply RMSNorm to the gathered data
+        // ====================================================================
+        // RMSNorm2
+        // ====================================================================
         {
-            DeviceZoneScopedN("KV_RMSNORM");
-            deepseek_b1_ops::RMSNorm::Op<KV_RMSNormCTArgs, Core::is_kv_rmsnorm_core, true> kv_rmsnorm;
-            kv_rmsnorm(kv_rmsnorm_args);
-        }
-        // ========================================================================
-        // KV Cache Branch: RoPE
-        // ========================================================================
-        {
-            DeviceZoneScopedN("K_ROPE");
-            deepseek_b1_ops::Rope::Op<K_RopeCTArgs, Core::is_krope_core> krope;
-            krope(krope_args);
-        }
-        // ========================================================================
-        // KV Cache Update: Write results to DRAM interleaved tensor
-        // BRISC handles writing from output CBs to DRAM
-        // ========================================================================
-        {
-            DeviceZoneScopedN("KV_CACHE_UPDATE");
-            deepseek_b1_ops::KVCacheUpdate::Op<Core::is_kv_rmsnorm_core, Core::is_krope_core> kv_cache_update;
-            kv_cache_update(kv_cache_update_args);
+            DeviceZoneScopedN("RMSNORM2");
+            deepseek_b1_ops::RMSNorm::Op<RMSNorm2CTArgs, Core::is_input_core, true> rmsnorm2;
+            rmsnorm2(rmsnorm2_args);
         }
 
-        // ========================================================================
+        // ====================================================================
+        // Mcast2: Broadcast rmsnorm2 output to matmul2 cores
+        // ====================================================================
+        {
+            DeviceZoneScopedN("MCAST2");
+            deepseek_b1_ops::Mcast::
+                Op<McastCTArgs, Core::is_input_core, Core::is_matmul2_core, Core::is_matmul2_core, true>
+                    mcast2;
+            mcast2(mcast2_args);
+        }
+
+        // ====================================================================
+        // Matmul2
+        // ====================================================================
+        {
+            DeviceZoneScopedN("MATMUL2");
+            deepseek_b1_ops::Matmul::Op<Matmul2CTArgs, Core::is_matmul2_core, true, false> matmul2;
+            matmul2(matmul2_args);
+        }
+
+        {
+            DeviceZoneScopedN("Q_HEADS") static_assert(
+                !(Core::is_qnope_core && Core::is_qrope_core), "Core cannot be both QNOPE and QROPE");
+
+            // ================================================================
+            // Matmul3 (QNoPE)
+            // ================================================================
+            {
+                DeviceZoneScopedN("QNOPE/MATMUL3");
+                deepseek_b1_ops::Matmul::Op<Matmul3CTArgs, Core::is_qnope_core, true, false> matmul3;
+                matmul3(matmul3_args);
+            }
+
+            // ================================================================
+            // RoPE (Qrope)
+            // ================================================================
+            {
+                DeviceZoneScopedN("QROPE");
+                deepseek_b1_ops::Rope::Op<QRopeCTArgs, Core::is_qrope_core> rope;
+                rope(qrope_args);
+            }
+
+            // ================================================================
+            // CreateQHeads
+            // ================================================================
+            {
+                DeviceZoneScopedN("CREATE_Q_HEADS");
+                constexpr bool is_create_q_heads_sender = Core::is_qnope_core || Core::is_qrope_core;
+                deepseek_b1_ops::CreateQHeads::
+                    Op<CreateQHeadsCTArgs, is_create_q_heads_sender, Core::is_sdpa_input_core, false, true>
+                        create_q_heads;
+                create_q_heads(create_q_heads_args);
+            }
+        }
+
+        // ====================================================================
+        // KV Cache Branch
+        // Non-owning SP devices skip the entire branch and just signal the
+        // KV-cache-ready semaphore so FlashMLA can proceed.
+        // ====================================================================
+        deepseek_b1_ops::KVCacheUpdate::Op<Core::is_kv_rmsnorm_core, Core::is_krope_core> kv_cache_update;
+        kv_cache_update.set_local_cur_pos(kv_cache_update_args, local_cur_pos);
+        if (!skip_kv_cache_update) {
+            DeviceZoneScopedN("KV CACHE");
+            // ================================================================
+            // DKV Matmul: 9x2 grid, each core handles 1 head of 32 dim
+            // ================================================================
+            {
+                DeviceZoneScopedN("DKV_MATMUL");
+                // pop_in0 = true (consumed), pop_in1 = false (weights are persistent)
+                deepseek_b1_ops::Matmul::Op<DKV_MatmulCTArgs, Core::is_dkv_matmul_core, false, false> dkv_matmul;
+                dkv_matmul(dkv_matmul_args);
+            }
+
+            // ================================================================
+            // Gather: dkv matmul cores (senders) -> rmsnorm core (receiver)
+            // NCRISC sends from knope grid, BRISC receives on rmsnorm grid
+            // ================================================================
+            {
+                DeviceZoneScopedN("DKV_GATHER");
+                deepseek_b1_ops::Gather::Op<Core::is_knope_core, Core::is_kv_rmsnorm_core, true> dkv_gather;
+                dkv_gather(dkv_gather_args);
+            }
+
+            // ================================================================
+            // RMSNorm: Apply RMSNorm to the gathered data
+            // ================================================================
+            {
+                DeviceZoneScopedN("KV_RMSNORM");
+                deepseek_b1_ops::RMSNorm::Op<KV_RMSNormCTArgs, Core::is_kv_rmsnorm_core, true> kv_rmsnorm;
+                kv_rmsnorm(kv_rmsnorm_args);
+            }
+
+            // ================================================================
+            // RoPE
+            // ================================================================
+            {
+                DeviceZoneScopedN("K_ROPE");
+                deepseek_b1_ops::Rope::Op<K_RopeCTArgs, Core::is_krope_core> krope;
+                krope(krope_args);
+            }
+
+            // ================================================================
+            // KV Cache Update: Write results to DRAM interleaved tensor
+            // BRISC handles writing from output CBs to DRAM
+            // ================================================================
+            {
+                DeviceZoneScopedN("KV_CACHE_UPDATE");
+                kv_cache_update(kv_cache_update_args);
+            }
+        }
+        {
+            DeviceZoneScopedN("KV_CACHE_SIGNAL_READY");
+            kv_cache_update.signal_cache_ready(kv_cache_update_args);
+        }
+
+        // ====================================================================
         // Flash MLA: Compute
-        // ========================================================================
+        // ====================================================================
         {
             DeviceZoneScopedN("FLASH_MLA");
             deepseek_b1_ops::FlashMLADecode::
                 Op<FlashMLACTArgs, Core::is_mla_core, Core::is_kv_rmsnorm_core || Core::is_krope_core>
                     flash_mla;
+            flash_mla.set_local_cur_pos(flash_mla_args, local_cur_pos);
             flash_mla(flash_mla_args);
         }
+    }
+
+    // ====================================================================
+    // Mcast: Teardown persistent mcast
+    // ====================================================================
+    {
+        DeviceZoneScopedN("MCAST_TEARDOWN");
+        mcast.teardown();
     }
 }

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
@@ -47,7 +47,8 @@ class PreSDPA:
         matmul3_weights_tensor,
         sin_tensor,
         cos_tensor,
-        position_ids,
+        local_position_ids,
+        global_position_ids,
         dkv_matmul_weights_tensor,
         dkv_rmsnorm_gamma_tensor,
         kv_cache_tensor,
@@ -60,9 +61,17 @@ class PreSDPA:
         heads_per_row=8,
         nope_dim=512,
         rope_dim=64,
+        kv_cache_update=True,
     ):
         """
-        PyTorch reference implementation for validation.
+        PyTorch reference implementation of the fused PreSDPA pipeline:
+          RMSNorm → Matmul → GatherReduce → RMSNorm2 → Matmul2 → Matmul3(Qnope) + RoPE(Qrope)
+          → [optional] DKV Matmul → KV RMSNorm → K RoPE → KV cache update
+          → FlashMLA decode
+
+        The KV cache branch is controlled by kv_cache_update.  When False the
+        cache is used as-is (no new entry is written), which models non-owning
+        SP devices that only run MLA over their existing local cache.
 
         Args:
             input_tensor: Input tensor (torch.Tensor) [1, K]
@@ -74,19 +83,34 @@ class PreSDPA:
                                     e.g., [64, 128, 512] for batched matmul on Qnope heads
             sin_tensor: Sin tensor (torch.Tensor) [max_seq_len, qrope_head_dim]
             cos_tensor: Cos tensor (torch.Tensor) [max_seq_len, qrope_head_dim]
-            position_ids: Position indices (torch.Tensor) [batch] for decode mode
-            epsilon: Small value to avoid division by zero
+            local_position_ids: Device-local position indices (torch.Tensor) [batch].
+                          Used for KV cache write position and MLA sequence length.
+                          In SP mode this is the normalized position within the device's
+                          local KV cache slice.
+            global_position_ids: Global position indices (torch.Tensor) [batch].
+                          Used for Q/K RoPE cos/sin table lookup, since the rotation
+                          tables are full-length and replicated across all SP devices.
+            dkv_matmul_weights_tensor: DKV matmul weights (torch.Tensor) [K, nope_dim + rope_dim]
+            dkv_rmsnorm_gamma_tensor: DKV RMSNorm gamma (torch.Tensor) [1, nope_dim]
+            kv_cache_tensor: KV cache (torch.Tensor) [1, 1, seq_len, nope_dim + rope_dim]
+            scale: Scale factor for FlashMLA
+            epsilon: Small value to avoid division by zero (default 1e-6)
             num_qnope_heads: Number of Qnope heads (default 64)
             num_qrope_heads: Number of Qrope heads (default 64)
             qnope_head_dim: Dimension per Qnope head (default 128)
             qrope_head_dim: Dimension per Qrope head (default 64)
             heads_per_row: Number of heads per grid row (default 8)
+            nope_dim: NOPE dimension / KV nope dim (default 512)
+            rope_dim: RoPE dimension / KV rope dim (default 64)
+            kv_cache_update: When True (default), compute new KV entry and write it into
+                             the cache at local_position_ids[0].  When False, skip the
+                             KV cache update and use the cache as-is for MLA.
 
         Returns:
-            Tuple of (qnope_output, qrope_output, sdpa_interleaved):
-            - qnope_output: [num_qnope_heads, 1, qnope_out_dim] after matmul3
-            - qrope_output: [num_qrope_heads, 1, qrope_head_dim] after RoPE
-            - sdpa_interleaved: [8, 8, 576] interleaved QNOPE/QROPE output for SDPA
+            Tuple of (full_q, new_kv, mla_output):
+            - full_q: [1, 1, num_qnope_heads, nope_dim + rope_dim] combined Q heads
+            - new_kv: [1, 1, 1, nope_dim + rope_dim] new KV entry (None when kv_cache_update is False)
+            - mla_output: [num_heads * heads_per_row, nope_dim] MLA attention output
         """
         from models.demos.deepseek_v3_b1.micro_ops.rope.op import RopeSingleCore
 
@@ -95,7 +119,6 @@ class PreSDPA:
             normalized = x * torch.rsqrt(variance + epsilon)
             return normalized * gamma
 
-        position_id = position_ids[0]
         # RMSNorm -> Matmul: [1, K] @ [K, N] -> [1, N]
         input_layernorm = rmsnorm(input_tensor, gamma_tensor)
         matmul_result = input_layernorm @ matmul_weights_tensor
@@ -107,39 +130,31 @@ class PreSDPA:
         qrope_heads = matmul2_result[:, num_qnope_heads * qnope_head_dim :].reshape(num_qrope_heads, 1, qrope_head_dim)
 
         # Matmul3: Batched matmul on Qnope heads
-        # [64, 1, 128] @ [64, 128, 512] -> [64, 1, 512]
         qnope_output = torch.bmm(qnope_heads, matmul3_weights_tensor)
 
-        # Apply RoPE to Qrope heads
-        # qrope_heads: [num_qrope_heads, 1, qrope_head_dim] = [64, 1, 64]
-        # Reshape for RopeSingleCore.golden: [batch, n_heads, seq_len, head_dim] = [1, 64, 1, 64]
-        qrope_reshaped_for_rope = qrope_heads.permute(1, 0, 2).unsqueeze(0)  # [1, 64, 1, 64]
-        # position_ids_expanded: [batch, seq_len] = [1, 1]
-        position_ids_expanded = position_ids.unsqueeze(1)  # [batch, 1]
-        # Apply RoPE
+        # Apply RoPE to Qrope heads (cos/sin indexed by global position)
+        qrope_reshaped_for_rope = qrope_heads.permute(1, 0, 2).unsqueeze(0)
+        global_position_ids_expanded = global_position_ids.unsqueeze(1)
         qrope_output_reshaped = RopeSingleCore.golden(
-            qrope_reshaped_for_rope, cos_tensor, sin_tensor, position_ids_expanded
+            qrope_reshaped_for_rope, cos_tensor, sin_tensor, global_position_ids_expanded
         )
-        # Reshape back: [1, 64, 1, 64] -> [64, 1, 64]
-        qrope_output = qrope_output_reshaped.squeeze(0).permute(1, 0, 2)  # [64, 1, 64]
+        qrope_output = qrope_output_reshaped.squeeze(0).permute(1, 0, 2)
 
-        # Combine QNOPE and QROPE outputs
-        combined_head_dim = nope_dim + rope_dim  # 512 + 64 = 576
-
+        combined_head_dim = nope_dim + rope_dim
         full_q = torch.concat([qnope_output, qrope_output], dim=-1).reshape(1, 1, num_qnope_heads, combined_head_dim)
 
-        # KV Cache Branch
-        dkv = input_layernorm @ dkv_matmul_weights_tensor
-        kv, k_rope = torch.split(dkv, [nope_dim, rope_dim], dim=-1)
-        kv = rmsnorm(kv, dkv_rmsnorm_gamma_tensor)
-        k_rope = RopeSingleCore.golden(k_rope, cos_tensor, sin_tensor, position_ids).squeeze(0)
-
-        # from 0 to position id, the kv cache is valid
         full_kv = kv_cache_tensor.to(full_q.dtype)
-        new_kv = torch.cat([kv, k_rope], dim=-1).reshape(1, 1, 1, combined_head_dim).to(full_q.dtype)
-        full_kv[:, :, position_id, :] = new_kv
+        new_kv = None
 
-        output = FlashMLADecode.golden(full_q, full_kv, position_ids, nope_dim, scale).squeeze()
+        if kv_cache_update:
+            dkv = input_layernorm @ dkv_matmul_weights_tensor
+            kv, k_rope = torch.split(dkv, [nope_dim, rope_dim], dim=-1)
+            kv = rmsnorm(kv, dkv_rmsnorm_gamma_tensor)
+            k_rope = RopeSingleCore.golden(k_rope, cos_tensor, sin_tensor, global_position_ids).squeeze(0)
+            new_kv = torch.cat([kv, k_rope], dim=-1).reshape(1, 1, 1, combined_head_dim).to(full_q.dtype)
+            full_kv = torch.cat([full_kv, new_kv], dim=2)
+
+        output = FlashMLADecode.golden(full_q, full_kv, local_position_ids, nope_dim, scale).squeeze()
         return full_q, new_kv, output
 
     @staticmethod
@@ -1073,6 +1088,8 @@ class PreSDPA:
         ]
 
         # KVCacheUpdate CB indices and krope_Wt passed as runtime args (ReaderArgs/WriterArgs/ComputeArgs)
+        flash_mla_program_config = FlashMLADecode.ProgramConfig()
+        device_chunk_size = flash_mla_program_config.device_chunk_size
         kv_cache_brisc_named_compile_time_args = [
             ("krope_output_cb", krope_output_cb),
             ("kv_cache_output_cb", kv_cache_output_cb),
@@ -1095,7 +1112,6 @@ class PreSDPA:
 
         # Flash MLA named compile-time args
         # a lot of the setup is reused from the FlashMLADecode op
-        flash_mla_program_config = FlashMLADecode.ProgramConfig()
         k_chunk_size = flash_mla_program_config.k_chunk_size
         num_q_heads_per_core = 8
         k_shape = kv_cache_tensor.padded_shape
@@ -2178,16 +2194,22 @@ class PreSDPA:
                 krope_sin_tensor_address = krope_sin_tensor_device.buffer_address()
                 position_ids_tensor_addr = position_ids_tensor_device.buffer_address()
 
+                kv_cache_sp_named_compile_time_args = [
+                    ("kv_cache_device_chunk_size", device_chunk_size),
+                    ("kv_cache_sp_device_idx", row),
+                    ("kv_cache_num_sp_devices", mesh_rows),
+                ]
+
                 # TRISC common runtime args (shared scalar values)
                 trisc_common_runtime_args = [
                     epsilon_packed,  # idx 0
                     scalar_packed,  # idx 1
                     scalar2_packed,  # idx 2
                     kv_scalar_packed,  # idx 3
-                    kv_cache_input_cb,
-                    kv_cache_output_cb,
-                    kv_cache_intermed_cb,
-                    position_ids_tensor_addr,
+                    kv_cache_input_cb,  # idx 4
+                    kv_cache_output_cb,  # idx 5
+                    kv_cache_intermed_cb,  # idx 6
+                    position_ids_tensor_addr,  # idx 7
                 ]
 
                 qrope_ncrisc_addr_args = [
@@ -2227,6 +2249,7 @@ class PreSDPA:
                     + dkv_gather_sender_named_compile_time_args
                     + krope_ncrisc_named_compile_time_args
                     + krope_ncrisc_addr_args
+                    + kv_cache_sp_named_compile_time_args
                     + mla_ncrisc_named_compile_time_args
                 )
                 ncrisc_common_runtime_args = ncrisc_bcast_common_args + [
@@ -2247,6 +2270,7 @@ class PreSDPA:
                     + dkv_gather_receiver_named_compile_time_args
                     + kv_rmsnorm_brisc_named_compile_time_args
                     + kv_cache_brisc_named_compile_time_args
+                    + kv_cache_sp_named_compile_time_args
                     + mla_brisc_named_compile_time_args
                 )
                 brisc_common_runtime_args = [k_addr, position_ids_tensor_addr]
@@ -2265,6 +2289,7 @@ class PreSDPA:
                     + kv_rmsnorm_trisc_named_compile_time_args
                     + krope_trisc_named_compile_time_args
                     + kv_cache_trisc_named_compile_time_args
+                    + kv_cache_sp_named_compile_time_args
                     + mla_trisc_named_compile_time_args
                 )
 

--- a/models/demos/deepseek_v3_b1/micro_ops/flash_mla/kernels/flash_mla_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/flash_mla/kernels/flash_mla_kernel.cpp
@@ -15,7 +15,7 @@ void kernel_main() {
     uint32_t arg_idx = 0;
     deepseek_b1_ops::FlashMLADecode::ReaderArgs args{
         .k_addr = get_common_arg_val<uint32_t>(0),
-        .pos_addr = get_common_arg_val<uint32_t>(1),
+        .local_cur_pos = 0,
         .cur_batch = get_arg_val<uint32_t>(arg_idx++),
         .core_num_in_reduce = get_arg_val<uint32_t>(arg_idx++),
         .is_mcast_sender = get_arg_val<uint32_t>(arg_idx++),
@@ -58,7 +58,7 @@ void kernel_main() {
     arg_idx += num_tree_reduction_steps * 4;
 
     deepseek_b1_ops::FlashMLADecode::WriterArgs args{
-        .pos_addr = get_common_arg_val<uint32_t>(0),
+        .local_cur_pos = 0,
         .cur_batch = cur_batch,
         .core_num_in_reduce = core_num_in_reduce,
         .is_output_core = is_output_core,
@@ -114,7 +114,7 @@ void kernel_main() {
     arg_idx += num_tree_reduction_steps * 2;
 
     deepseek_b1_ops::FlashMLADecode::ComputeArgs args{
-        .pos_addr = get_common_arg_val<uint32_t>(0),
+        .local_cur_pos = 0,
         .do_reduce = do_reduce,
         .do_output = do_output,
         .cur_batch = cur_batch,
@@ -147,6 +147,14 @@ void kernel_main() {
     }
 #endif
 
+#if defined(COMPILE_FOR_NCRISC)
+    uint32_t pos_addr = get_common_arg_val<uint32_t>(1);
+#elif defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_TRISC)
+    uint32_t pos_addr = get_common_arg_val<uint32_t>(0);
+#endif
+
     deepseek_b1_ops::FlashMLADecode::Op<FlashMLACTArgs, true, false> op;
+    volatile tt_l1_ptr uint32_t* pos_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(pos_addr);
+    op.set_local_cur_pos(args, pos_ptr[0]);
     op(args);
 }

--- a/models/demos/deepseek_v3_b1/micro_ops/flash_mla/kernels/rt_args_common.hpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/flash_mla/kernels/rt_args_common.hpp
@@ -9,6 +9,40 @@
 
 inline uint32_t nearest_n(uint32_t x, uint32_t n) { return ((x + n - 1) / n) * n; }
 
+// Given a global current position and this device's SP parameters, determine:
+//   - skip_attention: device has no data yet (global pos < this device's first slot)
+//   - skip_kv_cache_update: device has data but doesn't own the new write slot
+//   - local_cur_pos: the device-local position for KV cache / MLA
+//
+// Tokens are assigned in device_chunk_size groups round-robin across SP devices:
+//   [0, dcs) -> dev 0, [dcs, 2*dcs) -> dev 1, ...
+// The owning device is (cur_pos / dcs) % num_sp_devices.
+// local_cur_pos = local_seq_len for the owning device (write slot),
+//              = local_seq_len - 1 for non-owning devices (last valid entry).
+inline std::tuple<bool, bool, uint32_t> get_device_mla_work_assignment(
+    uint32_t cur_pos, uint32_t sp_device_idx, uint32_t device_chunk_size, uint32_t num_sp_devices) {
+    if (cur_pos < sp_device_idx * device_chunk_size) {
+        return {true, true, 0};
+    }
+
+    uint32_t sp_block = device_chunk_size * num_sp_devices;
+    uint32_t num_full_blocks = cur_pos / sp_block;
+    uint32_t remainder = cur_pos % sp_block;
+
+    uint32_t dev_start = sp_device_idx * device_chunk_size;
+    uint32_t dev_contrib = (remainder > dev_start) ? remainder - dev_start : 0;
+    if (dev_contrib > device_chunk_size) {
+        dev_contrib = device_chunk_size;
+    }
+    uint32_t local_seq_len = num_full_blocks * device_chunk_size + dev_contrib;
+
+    uint32_t owning_device = (cur_pos / device_chunk_size) % num_sp_devices;
+    bool skip_kv_cache_update = (sp_device_idx != owning_device);
+    uint32_t local_cur_pos = skip_kv_cache_update ? local_seq_len - 1 : local_seq_len;
+
+    return {false, skip_kv_cache_update, local_cur_pos};
+}
+
 inline std::tuple<uint32_t, uint32_t, uint32_t> get_runtime_args(
     int cur_pos, int cur_batch, int core_num, int num_cores_per_batch, uint32_t k_chunk_size) {
     // No sliding window: process from beginning up to cur_pos
@@ -31,21 +65,15 @@ inline std::tuple<uint32_t, uint32_t, uint32_t> get_runtime_args(
         k_chunk_end = k_chunk_start + chunks_per_core;
     } else {
         // More chunks than cores: strided distribution
-        // Core N processes chunks: N, N+num_cores, N+2*num_cores, ...
-        // We encode this as: k_chunk_start = first chunk for this core
-        //                    k_chunk_end = k_chunk_start + num_chunks_for_core * num_cores (stride encoded)
-        // But kernel expects contiguous range, so we return stride info differently:
         // k_chunk_start = core_num (first chunk index)
-        // k_chunk_end encodes the count: we'll iterate with stride in the kernel
+        // k_chunk_end = first chunk + (num_chunks - 1) * stride + 1
+        // Kernel iterates: for (k = start; k < end; k += stride)
+        // where stride = num_cores_per_batch
         int chunks_per_core = num_chunks_value / num_cores_per_batch;
         int residuals = num_chunks_value % num_cores_per_batch;
         int num_chunks_for_core = chunks_per_core + (core_num < residuals ? 1 : 0);
 
-        // First chunk for this core
         k_chunk_start = core_num;
-        // k_chunk_end = first chunk + (num_chunks - 1) * stride + 1
-        // This way the kernel can iterate: for (k = start; k < end; k += stride)
-        // where stride = num_cores_per_batch
         k_chunk_end =
             k_chunk_start + (num_chunks_for_core > 0 ? (num_chunks_for_core - 1) * num_cores_per_batch + 1 : 0);
     }

--- a/models/demos/deepseek_v3_b1/micro_ops/flash_mla/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/flash_mla/op.py
@@ -245,8 +245,20 @@ class FlashMLAProgramConfig:
     """Program config for FlashMLADecode operation."""
 
     k_chunk_size: int = 128
+    device_chunk_size: int = None
     exp_approx_mode: bool = True
     grid: type = FlashMLAOptimalGridNOC0  # Grid layout class (NOC0 optimized by default)
+
+    def __post_init__(self):
+        expected = self.grid.CORES_PER_BLOCK * self.k_chunk_size
+        if self.device_chunk_size is None:
+            self.device_chunk_size = expected
+        else:
+            assert self.device_chunk_size == expected, (
+                f"device_chunk_size must equal grid.CORES_PER_BLOCK * k_chunk_size "
+                f"({self.grid.CORES_PER_BLOCK} * {self.k_chunk_size} = {expected}), "
+                f"got {self.device_chunk_size}"
+            )
 
 
 class FlashMLADecode:

--- a/models/demos/deepseek_v3_b1/micro_ops/kv_cache_update/kernels/kv_cache_update_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/kv_cache_update/kernels/kv_cache_update_kernel.cpp
@@ -31,7 +31,7 @@ void kernel_main() {
 #elif defined(COMPILE_FOR_BRISC)
     deepseek_b1_ops::KVCacheUpdate::WriterArgs args{
         .kv_cache_buffer_base_addr = get_common_arg_val<uint32_t>(0),
-        .pos_addr = get_common_arg_val<uint32_t>(1),
+        .local_cur_pos = 0,
         .kv_cache_input_cb = get_named_compile_time_arg_val("kv_cache_input_cb"),
         .kv_cache_intermed_cb = get_named_compile_time_arg_val("kv_cache_intermed_cb"),
         .kv_cache_output_cb = get_named_compile_time_arg_val("kv_cache_output_cb"),
@@ -57,5 +57,12 @@ void kernel_main() {
 #endif
 
     deepseek_b1_ops::KVCacheUpdate::Op<Core::is_nope_core, Core::is_rope_core> op;
+#if defined(COMPILE_FOR_BRISC)
+    {
+        uint32_t pos_addr = get_common_arg_val<uint32_t>(1);
+        volatile tt_l1_ptr uint32_t* pos_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(pos_addr);
+        op.set_local_cur_pos(args, pos_ptr[0]);
+    }
+#endif
     op(args);
 }

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py
@@ -28,6 +28,96 @@ def create_fabric_router_config(max_payload_size):
     return config
 
 
+def test_get_device_mla_work_assignment():
+    """Unit tests for get_device_mla_work_assignment, covering the key SP scenarios.
+
+    Python mirror of get_device_mla_work_assignment in rt_args_common.hpp.
+    Returns (skip_attention, skip_kv_cache_update, local_cur_pos).
+    """
+
+    def get_device_mla_work_assignment(cur_pos, sp_device_idx, device_chunk_size, num_sp_devices):
+        if cur_pos < sp_device_idx * device_chunk_size:
+            return True, True, 0
+
+        sp_block = device_chunk_size * num_sp_devices
+        num_full_blocks = cur_pos // sp_block
+        remainder = cur_pos % sp_block
+
+        dev_start = sp_device_idx * device_chunk_size
+        dev_contrib = max(0, remainder - dev_start)
+        if dev_contrib > device_chunk_size:
+            dev_contrib = device_chunk_size
+        local_seq_len = num_full_blocks * device_chunk_size + dev_contrib
+
+        owning_device = (cur_pos // device_chunk_size) % num_sp_devices
+        skip_kv_cache_update = sp_device_idx != owning_device
+        local_cur_pos = local_seq_len - 1 if skip_kv_cache_update else local_seq_len
+
+        return False, skip_kv_cache_update, local_cur_pos
+
+    dcs = 1024  # device_chunk_size
+    nsp = 4  # num_sp_devices
+
+    # ---- pos=0: only dev0 has work (owns it) ----
+    assert get_device_mla_work_assignment(0, 0, dcs, nsp) == (False, False, 0)  # dev0 owns, write slot 0
+    assert get_device_mla_work_assignment(0, 1, dcs, nsp) == (True, True, 0)  # dev1 no data yet
+    assert get_device_mla_work_assignment(0, 2, dcs, nsp) == (True, True, 0)  # dev2 no data yet
+    assert get_device_mla_work_assignment(0, 3, dcs, nsp) == (True, True, 0)  # dev3 no data yet
+
+    # ---- pos=1023: last slot in dev0's first chunk, dev0 owns it ----
+    assert get_device_mla_work_assignment(1023, 0, dcs, nsp) == (False, False, 1023)  # dev0 owns, write slot 1023
+    assert get_device_mla_work_assignment(1023, 1, dcs, nsp) == (True, True, 0)  # dev1 no data yet
+    assert get_device_mla_work_assignment(1023, 2, dcs, nsp) == (True, True, 0)  # dev2 no data yet
+    assert get_device_mla_work_assignment(1023, 3, dcs, nsp) == (True, True, 0)  # dev3 no data yet
+
+    # ---- pos=1024: first slot in dev1's first chunk, dev1 owns it ----
+    assert get_device_mla_work_assignment(1024, 0, dcs, nsp) == (False, True, 1023)  # dev0 full first block, non-owner
+    assert get_device_mla_work_assignment(1024, 1, dcs, nsp) == (False, False, 0)  # dev1 owns, write slot 0
+    assert get_device_mla_work_assignment(1024, 2, dcs, nsp) == (True, True, 0)  # dev2 no data yet
+    assert get_device_mla_work_assignment(1024, 3, dcs, nsp) == (True, True, 0)  # dev3 no data yet
+
+    # ---- pos=2047: last slot in dev1's first chunk ----
+    assert get_device_mla_work_assignment(2047, 0, dcs, nsp) == (False, True, 1023)  # dev0 full first block, non-owner
+    assert get_device_mla_work_assignment(2047, 1, dcs, nsp) == (False, False, 1023)  # dev1 owns, write slot 1023
+    assert get_device_mla_work_assignment(2047, 2, dcs, nsp) == (True, True, 0)  # dev2 no data yet
+    assert get_device_mla_work_assignment(2047, 3, dcs, nsp) == (True, True, 0)  # dev3 no data yet
+
+    # ---- pos=4095: last slot in dev3's first chunk ----
+    assert get_device_mla_work_assignment(4095, 0, dcs, nsp) == (False, True, 1023)  # dev0 full first block, non-owner
+    assert get_device_mla_work_assignment(4095, 1, dcs, nsp) == (False, True, 1023)  # dev1 full first block, non-owner
+    assert get_device_mla_work_assignment(4095, 2, dcs, nsp) == (False, True, 1023)  # dev2 full first block, non-owner
+    assert get_device_mla_work_assignment(4095, 3, dcs, nsp) == (False, False, 1023)  # dev3 owns, write slot 1023
+
+    # ---- pos=4096: first slot of second round-robin block, dev0 owns again ----
+    assert get_device_mla_work_assignment(4096, 0, dcs, nsp) == (False, False, 1024)  # dev0 owns, write slot 1024
+    assert get_device_mla_work_assignment(4096, 1, dcs, nsp) == (False, True, 1023)  # dev1 full first block, non-owner
+    assert get_device_mla_work_assignment(4096, 2, dcs, nsp) == (False, True, 1023)  # dev2 full first block, non-owner
+    assert get_device_mla_work_assignment(4096, 3, dcs, nsp) == (False, True, 1023)  # dev3 full first block, non-owner
+
+    # ---- local counts (2,2,1 + partial,1): 1 full block + partial reaching into dev2
+    # pos = sp_block + 2*dcs + 500 = 6644, owner=dev2, dev2 local=1524 (write slot)
+    assert get_device_mla_work_assignment(6644, 0, dcs, nsp) == (False, True, 2047)  # dev0 2 full chunks, non-owner
+    assert get_device_mla_work_assignment(6644, 1, dcs, nsp) == (False, True, 2047)  # dev1 2 full chunks, non-owner
+    assert get_device_mla_work_assignment(6644, 2, dcs, nsp) == (False, False, 1524)  # dev2 owns, write slot 1524
+    assert get_device_mla_work_assignment(6644, 3, dcs, nsp) == (False, True, 1023)  # dev3 1 full chunk, non-owner
+
+    # ---- local counts (3,2 + partial,2,2): 2 full blocks + partial into dev1
+    # pos = 2*sp_block + dcs + 700 = 9916, owner=dev1, dev1 local=2748 (write slot)
+    assert get_device_mla_work_assignment(9916, 0, dcs, nsp) == (False, True, 3071)  # dev0 3 full chunks, non-owner
+    assert get_device_mla_work_assignment(9916, 1, dcs, nsp) == (False, False, 2748)  # dev1 owns, write slot 2748
+    assert get_device_mla_work_assignment(9916, 2, dcs, nsp) == (False, True, 2047)  # dev2 2 full chunks, non-owner
+    assert get_device_mla_work_assignment(9916, 3, dcs, nsp) == (False, True, 2047)  # dev3 2 full chunks, non-owner
+
+    # ---- local counts (3,3,3,2 + partial): 2 full blocks + partial into dev3
+    # pos = 2*sp_block + 3*dcs + 400 = 11664, owner=dev3, dev3 local=2448 (write slot)
+    assert get_device_mla_work_assignment(11664, 0, dcs, nsp) == (False, True, 3071)  # dev0 3 full chunks, non-owner
+    assert get_device_mla_work_assignment(11664, 1, dcs, nsp) == (False, True, 3071)  # dev1 3 full chunks, non-owner
+    assert get_device_mla_work_assignment(11664, 2, dcs, nsp) == (False, True, 3071)  # dev2 3 full chunks, non-owner
+    assert get_device_mla_work_assignment(11664, 3, dcs, nsp) == (False, False, 2448)  # dev3 owns, write slot 2448
+
+    logger.info("test_get_device_mla_work_assignment passed")
+
+
 @pytest.mark.parametrize(
     "sender_row, sender_col",
     [
@@ -40,7 +130,24 @@ def create_fabric_router_config(max_payload_size):
 @pytest.mark.parametrize("secondary_cluster_axis", [1])
 @pytest.mark.parametrize("mesh_rows, mesh_cols", [(4, 2), (1, 1)])
 @pytest.mark.parametrize("num_iters", [(1)])
-@pytest.mark.parametrize("position_id", [0, 1, 127, 242, 255, 564, 1023])
+@pytest.mark.parametrize("max_seq_len", [32 * 1024])
+@pytest.mark.parametrize(
+    "position_id",
+    [
+        0,
+        1,
+        127,
+        242,
+        255,
+        564,
+        1023,
+        2047,
+        4096,  # (1 + partial,1,1,1): partial into dev0 (if SP = 4)
+        pytest.param(6644, marks=pytest.mark.skip_post_commit),  # (2,2,1 + partial,1): partial into dev2 (if SP = 4)
+        pytest.param(9916, marks=pytest.mark.skip_post_commit),  # (3,2 + partial,2,2): partial into dev1 (if SP = 4)
+        pytest.param(11664, marks=pytest.mark.skip_post_commit),  # (3,3,3,2 + partial): partial into dev3 (if SP = 4)
+    ],
+)
 @pytest.mark.parametrize(
     "device_params",
     [
@@ -65,6 +172,7 @@ def test_pre_sdpa(
     cluster_axis,
     secondary_cluster_axis,
     num_iters,
+    max_seq_len,
     position_id,
     noc_mode,
 ):
@@ -93,7 +201,7 @@ def test_pre_sdpa(
     shape = (1, 7168)
     matmul_weights_shape = (7168, 1536)
 
-    max_seq_len = 32 * 1024
+    per_device_max_seq_len = max_seq_len // mesh_rows
     assert position_id < max_seq_len, f"Position ID {position_id} must be less than max sequence length {max_seq_len}"
 
     # Head configuration
@@ -539,13 +647,32 @@ def test_pre_sdpa(
         k_chunk_size=128,
         exp_approx_mode=False,  # Use exact exp for higher precision
     )
-    logger.info(f"Creating KV cache with seq_len={max_seq_len}...")
+    logger.info(f"Creating KV cache with per-device seq_len={per_device_max_seq_len}, total_seq_len={max_seq_len}...")
     kvpe_dim = KNOPE_DIM + KROPE_DIM
     cache_shape = (1, 1, max_seq_len, kvpe_dim)
-    # from 0 to position id, the kv cache is valid, position_id data is filled by test
+
+    def deinterleave_kv_cache(kv: torch.Tensor, device_chunk_size: int, num_devices: int) -> torch.Tensor:
+        """Reorder a round-robin interleaved KV cache for ShardTensor2dMesh.
+
+        The global KV cache is written in round-robin device_chunk_size blocks:
+          [dev0_chunk0 | dev1_chunk0 | ... | devN_chunk0 | dev0_chunk1 | ...]
+        ShardTensor2dMesh splits dim-2 contiguously, so each device would
+        receive the wrong data.  This function reorders to:
+          [dev0_chunk0 | dev0_chunk1 | ... | dev1_chunk0 | dev1_chunk1 | ...]
+        so that after the contiguous split each device gets its own chunks.
+        """
+        b, h, seq, d = kv.shape
+        num_chunks = seq // device_chunk_size
+        chunks_per_device = num_chunks // num_devices
+        return (
+            kv.reshape(b, h, chunks_per_device, num_devices, device_chunk_size, d).transpose(2, 3).reshape(b, h, seq, d)
+        )
+
+    dcs = program_config.device_chunk_size
+    num_sp = mesh_rows
     torch_kv_cache = torch.zeros(cache_shape, dtype=torch.bfloat16)
-    for i in range(position_id):
-        torch_kv_cache[:, :, i, :] = torch.randn(1, 1, 1, kvpe_dim, dtype=torch.bfloat16)
+    torch_kv_cache[:, :, :position_id, :] = torch.randn(1, 1, position_id, kvpe_dim, dtype=torch.bfloat16)
+    torch_kv_cache_shuffled = deinterleave_kv_cache(torch_kv_cache, dcs, num_sp)
 
     # ND sharding with ROUND_ROBIN_1D distribution across DRAM banks
     # Each shard = one k_chunk (k_chunk_size x kvpe_dim), distributed round-robin
@@ -568,19 +695,19 @@ def test_pre_sdpa(
     )
 
     ttnn_kv_cache = ttnn.from_torch(
-        torch_kv_cache,
+        torch_kv_cache_shuffled,
         dtype=ttnn.bfloat8_b,
         layout=ttnn.TILE_LAYOUT,
         device=submesh,
         memory_config=kv_mem_config,
-        mesh_mapper=ttnn.ReplicateTensorToMesh(submesh),
+        mesh_mapper=ttnn.ShardTensor2dMesh(submesh, mesh_shape=(mesh_rows, mesh_cols), dims=(2, None)),
     )
     kv_cache_bfp8_before_op = ttnn.to_torch(ttnn_kv_cache, mesh_composer=ttnn.ConcatMeshToTensor(submesh, dim=0))
 
     # ========================================================================
     # Run pre-SDPA operation
     # ========================================================================
-    logger.info("Running pre-SDPA operation...")
+    logger.info(f"Running pre-SDPA operation with position_id={position_id}...")
 
     for i in range(num_iters):
         ttnn_output_result = PreSDPA.op(
@@ -620,28 +747,62 @@ def test_pre_sdpa(
 
     # Convert back to torch for verification
     output_torch = ttnn.to_torch(ttnn_output_result, mesh_composer=ttnn.ConcatMeshToTensor(submesh, dim=0))
+    assert output_torch.shape[-1] == KNOPE_DIM, f"Output width {output_torch.shape[-1]} != {KNOPE_DIM}"
 
     # ========================================================================
-    # Compute golden reference
+    # Compute golden reference per SP device
+    #
+    # KV cache positions are distributed across SP devices in interleaved
+    # device_chunk_size blocks:
+    #   global [0, dcs) → SP0, [dcs, 2*dcs) → SP1, ..., wrapping round-robin.
+    # For each SP device that has data we run PreSDPA.golden with the
+    # device's local KV cache slice and the normalized local position_id.
+    # Only the owning device (the one whose chunk contains position_id)
+    # performs the KV cache update; all others run MLA over existing data.
     # ========================================================================
     logger.info("Computing golden reference...")
 
-    # Golden uses unshuffled weights (sequential output: all QNOPE, then all QROPE).
-    # Full tensor with num_tp * 64 heads; output is split per-TP for comparison.
-    torch_q_expected, torch_kv_cache_expected, torch_output_expected = PreSDPA.golden(
-        torch_input,
-        torch_gamma,
-        torch_matmul_weights,
-        torch_rmsnorm2_gamma,
-        torch_matmul2_weights_full_unshuffled,
-        torch_matmul3_weights,
-        torch_sin,
-        torch_cos,
-        position_ids,
-        torch_dkv_matmul_weights,
-        torch_dkv_rmsnorm_gamma,
-        torch_kv_cache,
-        scale,
+    device_chunk_size = program_config.device_chunk_size
+    num_sp = mesh_rows
+    owning_sp_device = (position_id // device_chunk_size) % num_sp
+    kvpe_dim = KNOPE_DIM + KROPE_DIM
+
+    def build_local_kv_cache(sp_idx):
+        """Extract sp_idx's local KV cache from torch_kv_cache_shuffled.
+
+        After the deinterleave shuffle, device sp_idx's data sits at
+        torch_kv_cache_shuffled[:, :, sp_idx*per_dev_seq : ..., :].
+        We compute local_len the same way get_normalized_position does.
+        """
+        sp_block = device_chunk_size * num_sp
+        num_full_blocks = position_id // sp_block
+        remainder = position_id % sp_block
+
+        # How many positions in the partial block belong to this device:
+        # clamp the remainder to this device's [dev_start, dev_start + dcs) window.
+        dev_start = sp_idx * device_chunk_size
+        dev_end = dev_start + device_chunk_size
+        dev_contrib = max(0, min(remainder, dev_end) - dev_start)
+        local_len = num_full_blocks * device_chunk_size + dev_contrib
+
+        if local_len == 0:
+            return None, 0
+        shard_offset = sp_idx * per_device_max_seq_len
+        local_kv = torch_kv_cache_shuffled[:, :, shard_offset : shard_offset + local_len, :]
+        return local_kv, local_len
+
+    golden_args = dict(
+        input_tensor=torch_input,
+        gamma_tensor=torch_gamma,
+        matmul_weights_tensor=torch_matmul_weights,
+        rmsnorm2_gamma_tensor=torch_rmsnorm2_gamma,
+        matmul2_weights_tensor=torch_matmul2_weights_full_unshuffled,
+        matmul3_weights_tensor=torch_matmul3_weights,
+        sin_tensor=torch_sin,
+        cos_tensor=torch_cos,
+        dkv_matmul_weights_tensor=torch_dkv_matmul_weights,
+        dkv_rmsnorm_gamma_tensor=torch_dkv_rmsnorm_gamma,
+        scale=scale,
         epsilon=epsilon,
         num_qnope_heads=total_qnope_heads,
         num_qrope_heads=total_qrope_heads,
@@ -652,97 +813,91 @@ def test_pre_sdpa(
         rope_dim=KROPE_DIM,
     )
 
+    golden_per_sp = {}
+    for sp_idx in range(num_sp):
+        local_kv, local_seq_len = build_local_kv_cache(sp_idx)
+        is_owner = sp_idx == owning_sp_device
+        if local_kv is None:
+            if is_owner:
+                # Owning device at pos 0: no prior cache exists yet, but it
+                # still writes the first entry and runs MLA on it.
+                local_kv = torch.zeros(1, 1, 0, kvpe_dim, dtype=torch.bfloat16)
+            else:
+                continue
+        local_pos = torch.tensor([local_seq_len if is_owner else local_seq_len - 1])
+        _, golden_new_kv, mla_output = PreSDPA.golden(
+            **golden_args,
+            local_position_ids=local_pos,
+            global_position_ids=torch.tensor([position_id]),
+            kv_cache_tensor=local_kv,
+            kv_cache_update=is_owner,
+        )
+        golden_per_sp[sp_idx] = (golden_new_kv, mla_output, local_seq_len)
+
+    logger.info(
+        f"Golden computed for {len(golden_per_sp)} SP devices "
+        f"(owning_sp_device={owning_sp_device}, device_chunk_size={device_chunk_size})"
+    )
+
+    # ========================================================================
+    # Validate outputs
+    # ========================================================================
     slice_size = sdpa_input_output_shape[0]
-    expected_width = KNOPE_DIM  # 512
-
-    # KV Cache is same across devices in 4x2 submesh
-    expected_nope = torch_kv_cache_expected[..., :KNOPE_DIM]
-    expected_rope = torch_kv_cache_expected[..., KNOPE_DIM:]
-
-    sdpa_pcc_by_tp = {}
-    kv_nope_pcc_first = None
-    kv_rope_pcc_first = None
 
     for device_idx in range(mesh_rows * mesh_cols):
-        tp_group = device_idx % mesh_cols  # TP group determined by mesh column
+        tp_group = device_idx % mesh_cols
+        sp_group = device_idx // mesh_cols
 
-        # ---- KV Cache (fully replicated, no TP) ----
-        compare_kv_cache = kv_cache_output_torch[device_idx, ..., position_id, :]
+        if sp_group not in golden_per_sp:
+            logger.info(f"Device {device_idx} (SP={sp_group}) no work, skipped")
+            continue
 
-        # check that kv cache for 0 to pos_id -  1 is identical to kv cache before op
-        for i in range(position_id):
-            assert torch.allclose(
-                kv_cache_bfp8_before_op[device_idx, ..., i, :], kv_cache_output_torch[device_idx, ..., i, :], atol=1e-6
-            ), "KV Cache before and after op mismatch"
-        logger.info(f"Device {device_idx} old cache validation passed")
+        golden_new_kv, golden_mla_output, local_seq_len = golden_per_sp[sp_group]
 
-        # Check that the new kv cache for pos_id is correct compared to golden
-        compare_nope = compare_kv_cache[..., :KNOPE_DIM]
-        compare_rope = compare_kv_cache[..., KNOPE_DIM:]
+        # ---- KV Cache: old positions must be unchanged ----
+        assert torch.equal(
+            kv_cache_bfp8_before_op[device_idx, ..., :local_seq_len, :],
+            kv_cache_output_torch[device_idx, ..., :local_seq_len, :],
+        ), f"Device {device_idx} (SP={sp_group}) KV Cache before and after op mismatch"
+        logger.info(f"Device {device_idx} (SP={sp_group}) old cache validation passed")
 
-        nope_max_diff = torch.max(torch.abs(expected_nope - compare_nope)).item()
-        nope_mean_diff = torch.mean(torch.abs(expected_nope - compare_nope)).item()
-        logger.info(f"Device {device_idx} KV Cache NOPE: Max diff={nope_max_diff}, Mean diff={nope_mean_diff}")
-        nope_passing, nope_pcc = comp_pcc(compare_nope, expected_nope, 0.98)
-        logger.info(f"Device {device_idx} KV Cache NOPE PCC: {nope_pcc}")
-        assert nope_passing, f"Device {device_idx} KV Cache NOPE PCC check failed: {nope_pcc}"
+        # ---- KV Cache new-position check (owning device only) ----
+        if golden_new_kv is not None:
+            compare_kv_cache = kv_cache_output_torch[device_idx, ..., local_seq_len, :]
+            expected_nope = golden_new_kv[..., :KNOPE_DIM]
+            expected_rope = golden_new_kv[..., KNOPE_DIM:]
+            compare_nope = compare_kv_cache[..., :KNOPE_DIM]
+            compare_rope = compare_kv_cache[..., KNOPE_DIM:]
 
-        if kv_nope_pcc_first is not None:
-            assert nope_pcc == kv_nope_pcc_first, (
-                f"Device {device_idx} KV Cache NOPE PCC mismatch across replicated dim: "
-                f"got {nope_pcc}, expected {kv_nope_pcc_first}"
-            )
-        else:
-            kv_nope_pcc_first = nope_pcc
-        rope_max_diff = torch.max(torch.abs(expected_rope - compare_rope)).item()
-        rope_mean_diff = torch.mean(torch.abs(expected_rope - compare_rope)).item()
-        logger.info(f"Device {device_idx} KV Cache ROPE: Max diff={rope_max_diff}, Mean diff={rope_mean_diff}")
-        rope_passing, rope_pcc = comp_pcc(compare_rope, expected_rope, 0.98)
-        logger.info(f"Device {device_idx} KV Cache ROPE PCC: {rope_pcc}")
-        assert rope_passing, f"Device {device_idx} KV Cache ROPE PCC check failed: {rope_pcc}"
+            nope_passing, nope_pcc = comp_pcc(compare_nope, expected_nope, 0.98)
+            logger.info(f"Device {device_idx} (SP={sp_group}) KV Cache NOPE PCC: {nope_pcc}")
+            assert nope_passing, f"Device {device_idx} (SP={sp_group}) KV Cache NOPE PCC check failed: {nope_pcc}"
 
-        if kv_rope_pcc_first is not None:
-            assert rope_pcc == kv_rope_pcc_first, (
-                f"Device {device_idx} KV Cache ROPE PCC mismatch across replicated dim: "
-                f"got {rope_pcc}, expected {kv_rope_pcc_first}"
-            )
-        else:
-            kv_rope_pcc_first = rope_pcc
+            rope_passing, rope_pcc = comp_pcc(compare_rope, expected_rope, 0.98)
+            logger.info(f"Device {device_idx} (SP={sp_group}) KV Cache ROPE PCC: {rope_pcc}")
+            assert rope_passing, f"Device {device_idx} (SP={sp_group}) KV Cache ROPE PCC check failed: {rope_pcc}"
 
-        # ---- PreSDPA Output (TP-sharded: replicated across rows, different across columns) ----
+        # ---- PreSDPA / MLA Output ----
         start = device_idx * slice_size
         end = start + slice_size
-        received = output_torch[start:end, :expected_width]
+        received = output_torch[start:end, :]
 
-        # Golden SDPA output is [num_tp * 64, 576]; slice per TP group.
-        # Each row is one head: [qnope[512], qrope[64]], 8 cores x 8 heads = 64 rows per TP.
         tp_start = tp_group * slice_size
         tp_end = tp_start + slice_size
-        torch_output_expected_flat = torch_output_expected[tp_start:tp_end, :]
+        torch_output_expected_flat = golden_mla_output[tp_start:tp_end, :]
 
         if received.shape != torch_output_expected_flat.shape:
             logger.error(
-                f"PreSDPA Output shape mismatch at device {device_idx} (TP={tp_group}): "
+                f"Device {device_idx} (TP={tp_group}, SP={sp_group}) output shape mismatch: "
                 f"got {received.shape}, expected {torch_output_expected_flat.shape}"
             )
             continue
 
-        max_diff = torch.max(torch.abs(received - torch_output_expected_flat)).item()
-        mean_diff = torch.mean(torch.abs(received - torch_output_expected_flat)).item()
-        logger.info(f"Device {device_idx} (TP={tp_group}) PreSDPA Output: Max diff={max_diff}, Mean diff={mean_diff}")
-
-        # Lower PCC threshold due to random weights
-        passing, sdpa_pcc = comp_pcc(torch_output_expected_flat, received, 0.90)
-        logger.info(f"Device {device_idx} (TP={tp_group}) PreSDPA Output PCC: {sdpa_pcc}")
-        assert passing, f"Device {device_idx} (TP={tp_group}) PreSDPA Output PCC check failed: {sdpa_pcc}"
-
-        if tp_group in sdpa_pcc_by_tp:
-            assert sdpa_pcc == sdpa_pcc_by_tp[tp_group], (
-                f"Device {device_idx} (TP={tp_group}) PreSDPA Output PCC mismatch across replicated dim: "
-                f"got {sdpa_pcc}, expected {sdpa_pcc_by_tp[tp_group]}"
-            )
-        else:
-            sdpa_pcc_by_tp[tp_group] = sdpa_pcc
+        passing, sdpa_pcc = comp_pcc(torch_output_expected_flat, received, 0.84)
+        logger.info(f"Device {device_idx} (TP={tp_group}, SP={sp_group}) PreSDPA Output PCC: {sdpa_pcc}")
+        assert (
+            passing
+        ), f"Device {device_idx} (TP={tp_group}, SP={sp_group}) PreSDPA Output PCC check failed: {sdpa_pcc}"
 
     logger.info("✓ PreSDPA mesh test passed!")
 

--- a/models/demos/deepseek_v3_b1/unified_kernels/flash_mla.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/flash_mla.hpp
@@ -102,7 +102,7 @@ struct FlashMLADecode {
 
     struct ReaderArgs {
         uint32_t k_addr;
-        uint32_t pos_addr;
+        uint32_t local_cur_pos;
         uint32_t cur_batch;
         uint32_t core_num_in_reduce;
         uint32_t is_mcast_sender;
@@ -125,7 +125,7 @@ struct FlashMLADecode {
     };
 
     struct WriterArgs {
-        uint32_t pos_addr;
+        uint32_t local_cur_pos;
         uint32_t cur_batch;
         uint32_t core_num_in_reduce;
         uint32_t is_output_core;
@@ -164,7 +164,7 @@ struct FlashMLADecode {
     };
 
     struct ComputeArgs {
-        uint32_t pos_addr;
+        uint32_t local_cur_pos;
         uint32_t do_reduce;
         uint32_t do_output;
         uint32_t cur_batch;
@@ -190,6 +190,8 @@ struct FlashMLADecode {
             }
         }
 
+        void set_local_cur_pos(RTArgs& args, uint32_t local_cur_pos) { args.local_cur_pos = local_cur_pos; }
+
     private:
         void impl([[maybe_unused]] const RTArgs& args) {
 // ====================================================================
@@ -202,8 +204,7 @@ struct FlashMLADecode {
 
             const bool is_mcast_sender = args.is_mcast_sender == 1;
 
-            volatile tt_l1_ptr uint32_t* pos_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.pos_addr);
-            uint32_t cur_pos = pos_ptr[0];
+            uint32_t cur_pos = args.local_cur_pos;
 
             auto [k_num_chunks, k_chunk_start, k_chunk_end] = get_runtime_args(
                 cur_pos, args.cur_batch, args.core_num_in_reduce, args.num_cores_per_head, args.k_chunk_size);
@@ -391,8 +392,7 @@ struct FlashMLADecode {
                 noc_semaphore_set(q_input_mcast_semaphore_ptr, 0);
             }
 
-            volatile tt_l1_ptr uint32_t* pos_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.pos_addr);
-            uint32_t cur_pos = pos_ptr[0];
+            uint32_t cur_pos = args.local_cur_pos;
 
             auto [k_num_chunks, k_chunk_start, k_chunk_end] = get_runtime_args(
                 cur_pos, args.cur_batch, args.core_num_in_reduce, args.num_cores_per_head, args.k_chunk_size);
@@ -593,8 +593,7 @@ struct FlashMLADecode {
             PACK(SFPU_TEMPLATE_INIT_KERNEL(exponential, sfpu::exp_init, true, true, scale_fp32, true));
             sdpa_custom_mm_block_init_short<transpose_k>(cb_q_in, cb_k_in, cb_out_o, Sk_chunk_t);
 
-            volatile tt_l1_ptr uint32_t* pos_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.pos_addr);
-            uint32_t cur_pos = pos_ptr[0];
+            uint32_t cur_pos = args.local_cur_pos;
             auto [k_num_chunks, k_chunk_start, k_chunk_end] = get_runtime_args(
                 cur_pos, args.cur_batch, args.core_num_in_reduce, args.num_cores_per_head, args.k_chunk_size);
             if (k_chunk_start == k_chunk_end) {

--- a/models/demos/deepseek_v3_b1/unified_kernels/kv_cache_update.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/kv_cache_update.hpp
@@ -20,7 +20,7 @@
 namespace deepseek_b1_ops {
 
 // ============================================================================
-// RMSNorm micro-op
+// KVCacheUpdate micro-op
 //
 // Computes: Update existing KV Cache with 1x576 new cache
 // assumes one core with 1x512 NOPE cache and 2 cores each with 1x32 ROPE cache
@@ -48,7 +48,7 @@ struct KVCacheUpdate {
     struct ReaderArgs {};
     struct WriterArgs {
         uint32_t kv_cache_buffer_base_addr;
-        uint32_t pos_addr;
+        uint32_t local_cur_pos;
         uint32_t kv_cache_input_cb;
         uint32_t kv_cache_intermed_cb;
         uint32_t kv_cache_output_cb;
@@ -71,12 +71,34 @@ struct KVCacheUpdate {
     using RTArgs = unified_kernels::SelectByRISCV<ReaderArgs, WriterArgs, ComputeArgs>;
 
     // ========================================================================
-    // Op - the actual operation, IsActiveCore
+    // Op - full KV cache update (owning device)
     // ========================================================================
     template <bool IsNopeCore, bool IsRopeCore>
     class Op {
     public:
         void operator()([[maybe_unused]] const RTArgs& args) { impl(args); }
+
+        void set_local_cur_pos([[maybe_unused]] RTArgs& args, [[maybe_unused]] uint32_t local_cur_pos) {
+#if defined(COMPILE_FOR_BRISC)
+            args.local_cur_pos = local_cur_pos;
+#endif
+        }
+
+        void signal_cache_ready([[maybe_unused]] const RTArgs& args) {
+#if defined(COMPILE_FOR_BRISC)
+            if constexpr (IsRopeCore || IsNopeCore) {
+                constexpr uint8_t MCAST_NOC = 0;
+                uint64_t sem_noc_addr = get_noc_multicast_addr<MCAST_NOC>(
+                    args.full_grid_mcast_start_x,
+                    args.full_grid_mcast_start_y,
+                    args.full_grid_mcast_end_x,
+                    args.full_grid_mcast_end_y,
+                    args.kv_cache_cur_pos_ready_semaphore_addr);
+                noc_semaphore_inc_multicast(sem_noc_addr, 1, args.full_grid_mcast_num_dests, MCAST_NOC);
+                noc_async_atomic_barrier(MCAST_NOC);
+            }
+#endif
+        }
 
     private:
         void impl([[maybe_unused]] const RTArgs& args) {
@@ -93,8 +115,7 @@ struct KVCacheUpdate {
                 constexpr uint32_t nope_num_pages = 16;  // Offset in 1x576 for rope component
                 constexpr uint32_t kv_cache_num_tiles = IsRopeCore ? 1 : 16;
 
-                volatile tt_l1_ptr uint32_t* pos_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.pos_addr);
-                uint32_t cur_pos = pos_ptr[0];
+                uint32_t cur_pos = args.local_cur_pos;
 
                 constexpr auto k_args = TensorAccessorArgs<0>();
                 auto kv_tensor_accessor = TensorAccessor(k_args, args.kv_cache_buffer_base_addr, PAGE_SIZE);
@@ -149,19 +170,8 @@ struct KVCacheUpdate {
                     noc_async_write_page(kv_cache_page_id_start + i, kv_tensor_accessor, cb_addr);
                     cb_addr += kv_tensor_accessor.page_size;
                 }
-                constexpr uint8_t MCAST_NOC = 0;
-                uint64_t kv_cache_cur_pos_ready_sem_noc_addr = get_noc_multicast_addr<MCAST_NOC>(
-                    args.full_grid_mcast_start_x,
-                    args.full_grid_mcast_start_y,
-                    args.full_grid_mcast_end_x,
-                    args.full_grid_mcast_end_y,
-                    args.kv_cache_cur_pos_ready_semaphore_addr);
                 noc_async_write_barrier();
-                // KV CACHE update is done, signal to all core to start compute
-                noc_semaphore_inc_multicast(
-                    kv_cache_cur_pos_ready_sem_noc_addr, 1, args.full_grid_mcast_num_dests, MCAST_NOC);
                 cb_pop_front(kv_cache_output_cb, kv_cache_num_tiles);
-                noc_async_atomic_barrier(MCAST_NOC);
             }
 #elif defined(COMPILE_FOR_TRISC)
             if constexpr (IsNopeCore || IsRopeCore) {


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/37665)

### Problem description
We are doing Sequence Parallel (SP) 4 on our 4x2 stages. Our current MLA just fully replicates KV cache and essentially runs single-device SP=1. Updating kernel, op, and tests to properly do SP=4 with interleaved KV cache.

### What's changed
- Add per_device_chunk_size field in FlashMLAConfig
  * Determines how context is interleaved across devices
- Update kernel to process context for SP=4
  * Three possibilities:
    ** Device runs FlashMLA + updates kv cache
    ** Device runs FlashMLA + use kv cache as is
    ** Device skips entire FlashMLA until post-SDPA
  * Add helper function to get SP params
  * Update kv cache update + FlashMLA to take in local cur pos
    ** Local cur pos is how much each device should process
    ** Also determines where kv cache update should happen if global position belongs to that device's cache
  * Refactor kv cache update to expose signal_cache_ready
    ** Main kv_cache_op() no longer signals FlashMLA to start
    ** Always call signal_cache_ready if device is doing FlashMLA
- Update test_pre_sdpa to properly run golden for each device
  * KV cache is shuffled to account for interleaving
  * Run golden for each of the unique SPs
    ** Needed because full SDPA requires reduction across devices which happens in post-SDPA
    ** Uniquely calculate outputs by only running SDPA on each device's kv cache
    ** Golden for ROPE uses full global current position because we fully replicate cos/sin weights

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:{{branch_name}}): https://github.com/tenstorrent/tt-metal/actions/runs/22641184220
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}}): https://github.com/tenstorrent/tt-metal/actions/runs/22642975735
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
