### PR TITLE
fix: install_dependencies.sh broken on Debian 12

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -24,7 +24,7 @@ detect_os() {
         . /etc/os-release
         OS_ID="$ID"
         OS_VERSION="$VERSION_ID"
-        OS_CODENAME="${UBUNTU_CODENAME:VERSION_CODENAME}"
+        OS_CODENAME="${UBUNTU_CODENAME:-$VERSION_CODENAME}"
         OS_ID_LIKE="$ID_LIKE"
     else
         echo "Error: /etc/os-release not found. Unsupported system."
@@ -280,18 +280,25 @@ prep_ubuntu_system() {
     echo "deb http://apt.llvm.org/$OS_CODENAME/ llvm-toolchain-$OS_CODENAME-20 main" | tee /etc/apt/sources.list.d/llvm-20.list
 
     # Add Kitware repository for latest CMake
-    # If the kitware-archive-keyring package has not been installed previously, manually obtain a copy of our signing key
-    test -f /usr/share/doc/kitware-archive-keyring/copyright || wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+    # Note: Kitware only supports Ubuntu, not Debian
+    if [[ "$OS_ID" == "ubuntu" ]]; then
+        # If the kitware-archive-keyring package has not been installed previously, manually obtain a copy of our signing key
+        test -f /usr/share/doc/kitware-archive-keyring/copyright || wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
 
-    # Add the repository to sources list and update
-    echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ $OS_CODENAME main" | tee /etc/apt/sources.list.d/kitware.list >/dev/null
-    apt-get update
+        # Add the repository to sources list and update
+        echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ $OS_CODENAME main" | tee /etc/apt/sources.list.d/kitware.list >/dev/null
+        apt-get update
 
-    # If the kitware-archive-keyring package was not installed previously, remove the manually obtained key to make room for the package
-    test -f /usr/share/doc/kitware-archive-keyring/copyright || rm /usr/share/keyrings/kitware-archive-keyring.gpg
+        # If the kitware-archive-keyring package was not installed previously, remove the manually obtained key to make room for the package
+        test -f /usr/share/doc/kitware-archive-keyring/copyright || rm /usr/share/keyrings/kitware-archive-keyring.gpg
 
-    # Install the kitware-archive-keyring package to ensure that your keyring stays up to date as keys are rotated
-    apt-get install -y --no-install-recommends kitware-archive-keyring
+        # Install the kitware-archive-keyring package to ensure that your keyring stays up to date as keys are rotated
+        apt-get install -y --no-install-recommends kitware-archive-keyring
+    else
+        echo "[INFO] Skipping Kitware repository for $OS_ID (only supported on Ubuntu)"
+        echo "[INFO] Using distribution's default CMake package"
+        apt-get update
+    fi
 
     # Add GCC toolchain repository for specific g++ versions if needed
     if [[ "$OS_ID" == "ubuntu" ]]; then


### PR DESCRIPTION
## Problem

The `install_dependencies.sh` script fails on Debian 12 with the following error:
```
E: Malformed entry 1 in list file /etc/apt/sources.list.d/kitware.list (Component)
E: The list of sources could not be read.
```

## Root Causes

1. **OS_CODENAME syntax error (line 27)**: 
   - Current: `${UBUNTU_CODENAME:VERSION_CODENAME}` - This is substring syntax, not default value
   - On Debian, `UBUNTU_CODENAME` is empty, so it produces invalid codename

2. **Kitware repository not supported on Debian**:
   - Kitware only supports Ubuntu (https://apt.kitware.com/ubuntu/)
   - Attempting to add `deb ... kitware.com/ubuntu/ bookworm main` fails on Debian

## Changes

1. Fix OS_CODENAME syntax: `${UBUNTU_CODENAME:-$VERSION_CODENAME}` (proper default value)
2. Add `if [[ "$OS_ID" == "ubuntu" ]]` check around Kitware repository setup
3. Debian systems will use distribution's default CMake package instead

## Testing

Tested on Debian 12 (bookworm):
- `OS_CODENAME` now correctly resolves to "bookworm"
- Kitware repository is skipped with informative message
- Script proceeds with apt package installation

Fixes #38832

Bounty: $1000