### PR TITLE
move fabric allocator state into router builders instead of global allocator state in builder config

### DIFF
--- a/tt_metal/api/tt-metalium/device.hpp
+++ b/tt_metal/api/tt-metalium/device.hpp
@@ -153,8 +153,10 @@ public:
     virtual void init_command_queue_device() = 0;
 
     // return false if compile fails (mainly come from Nebula on TG)
+    // When all_devices is non-empty, uses a two-phase build with an internal barrier
+    // to coordinate allocator state exchange across all devices before compilation.
     [[deprecated("This is an internal function. It will be removed.")]]
-    virtual bool compile_fabric() = 0;
+    virtual bool compile_fabric(const std::vector<IDevice*>& all_devices = {}) = 0;
     [[deprecated("This is an internal function. It will be removed.")]]
     virtual void configure_fabric() = 0;
     // Puts device into reset

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -165,7 +165,7 @@ public:
     [[deprecated("This is an internal function. It will be removed.")]]
     void init_command_queue_device() override;
     [[deprecated("This is an internal function. It will be removed.")]]
-    bool compile_fabric() override;
+    bool compile_fabric(const std::vector<IDevice*>& all_devices = {}) override;
     [[deprecated("This is an internal function. It will be removed.")]]
     void configure_fabric() override;
     bool close() override;

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -1217,9 +1217,9 @@ void MeshDeviceImpl::init_command_queue_device() {
     TT_THROW("init_command_queue_device() is not supported on MeshDevice - use individual devices instead");
     reference_device()->init_command_queue_device();
 }
-bool MeshDeviceImpl::compile_fabric() {
+bool MeshDeviceImpl::compile_fabric(const std::vector<IDevice*>& all_devices) {
     TT_THROW("compile_fabric() is not supported on MeshDevice - use individual devices instead");
-    return reference_device()->compile_fabric();
+    return reference_device()->compile_fabric(all_devices);
 }
 void MeshDeviceImpl::configure_fabric() {
     TT_THROW("configure_fabric() is not supported on MeshDevice - use individual devices instead");
@@ -1472,7 +1472,9 @@ bool MeshDevice::initialize(
 }
 void MeshDevice::init_command_queue_host() { pimpl_->init_command_queue_host(); }
 void MeshDevice::init_command_queue_device() { pimpl_->init_command_queue_device(); }
-bool MeshDevice::compile_fabric() { return pimpl_->compile_fabric(); }
+bool MeshDevice::compile_fabric(const std::vector<IDevice*>& all_devices) {
+    return pimpl_->compile_fabric(all_devices);
+}
 void MeshDevice::configure_fabric() { pimpl_->configure_fabric(); }
 bool MeshDevice::close() { return pimpl_->close_impl(this); }
 void MeshDevice::enable_program_cache() { pimpl_->enable_program_cache(); }

--- a/tt_metal/distributed/mesh_device_impl.hpp
+++ b/tt_metal/distributed/mesh_device_impl.hpp
@@ -255,7 +255,7 @@ public:
         bool minimal = false);
     void init_command_queue_host() override;
     void init_command_queue_device() override;
-    bool compile_fabric() override;
+    bool compile_fabric(const std::vector<IDevice*>& all_devices = {}) override;
     void configure_fabric() override;
     bool close() override;
     bool close_impl(MeshDevice* pimpl_wrapper);

--- a/tt_metal/fabric/builder/fabric_remote_channels_allocator.cpp
+++ b/tt_metal/fabric/builder/fabric_remote_channels_allocator.cpp
@@ -6,21 +6,20 @@
 
 #include "tt_metal/fabric/builder/fabric_builder_config.hpp"
 #include "tt_metal/fabric/builder/fabric_router_recipe.hpp"  // for FabricChannelPoolType
+#include "tt_metal/fabric/fabric_builder_context.hpp"  // for PublishedAllocatorState
 #include <tt_stl/assert.hpp>
 
 namespace tt::tt_fabric {
 
-FabricRemoteChannelsAllocator::FabricRemoteChannelsAllocator(
-    const FabricStaticSizedChannelsAllocator& static_allocator) :
-    FabricChannelAllocator(static_allocator.topology_, static_allocator.options_, static_allocator.memory_regions_) {
-    // Extract remote receiver channel information from the static allocator for all VCs
+FabricRemoteChannelsAllocator::FabricRemoteChannelsAllocator(const PublishedAllocatorState& peer_state) :
+    FabricChannelAllocator(peer_state.topology, peer_state.options, peer_state.memory_regions) {
+    // Populate from the peer's published receiver channel data.
+    // A sender on this device needs to know the receiver layout on the peer device.
     for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
-        this->num_used_receiver_channels_per_vc_[vc] = static_allocator.num_used_receiver_channels_per_vc[vc];
-        for (size_t i = 0; i < static_allocator.num_used_receiver_channels_per_vc[vc]; i++) {
-            this->remote_receiver_channels_base_address_[vc][i] =
-                static_allocator.remote_receiver_channels_base_address[vc][i];
-            this->remote_receiver_channels_num_buffers_[vc][i] =
-                static_allocator.remote_receiver_channels_num_buffers[vc][i];
+        this->num_used_receiver_channels_per_vc_[vc] = peer_state.num_used_receiver_channels_per_vc[vc];
+        for (size_t i = 0; i < peer_state.num_used_receiver_channels_per_vc[vc]; i++) {
+            this->remote_receiver_channels_base_address_[vc][i] = peer_state.receiver_channels_base_address[vc][i];
+            this->remote_receiver_channels_num_buffers_[vc][i] = peer_state.receiver_channels_num_buffers[vc][i];
         }
     }
 }

--- a/tt_metal/fabric/builder/fabric_remote_channels_allocator.hpp
+++ b/tt_metal/fabric/builder/fabric_remote_channels_allocator.hpp
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "fabric_channel_allocator.hpp"
-#include "fabric_static_sized_channels_allocator.hpp"
 #include "tt_metal/fabric/builder/fabric_builder_config.hpp"
 
 #include <array>
@@ -13,6 +12,8 @@
 #include <vector>
 
 namespace tt::tt_fabric {
+
+struct PublishedAllocatorState;
 
 /**
  * Remote channels allocator for tracking channel information about the remote ethernet core.
@@ -30,14 +31,12 @@ namespace tt::tt_fabric {
 class FabricRemoteChannelsAllocator : public FabricChannelAllocator {
 public:
     /**
-     * Construct a remote channels allocator from a static channels allocator.
-     * Extracts remote receiver channel base addresses and buffer counts from the static allocator
-     * for all VCs.
+     * Construct a remote channels allocator from published peer state.
+     * Uses the peer's receiver channel layout to populate remote receiver info.
      *
-     * @param static_allocator The static allocator containing remote channel information
+     * @param peer_state Published allocator state from the remote peer
      */
-    explicit FabricRemoteChannelsAllocator(
-        const FabricStaticSizedChannelsAllocator& static_allocator);
+    explicit FabricRemoteChannelsAllocator(const PublishedAllocatorState& peer_state);
 
     /**
      * Emit compile-time arguments for remote receiver channels.

--- a/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
+++ b/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
@@ -5,6 +5,7 @@
 #include "tt_metal/fabric/builder/fabric_static_sized_channels_allocator.hpp"
 #include "tt_metal/fabric/builder/fabric_builder_helpers.hpp"
 #include "tt_metal/fabric/fabric_context.hpp"
+#include "tt_metal/fabric/fabric_builder_context.hpp"
 #include "impl/context/metal_context.hpp"
 #include <tt-metalium/hal.hpp>
 #include <tt-logger/tt-logger.hpp>
@@ -68,7 +69,9 @@ FabricStaticSizedChannelsAllocator::FabricStaticSizedChannelsAllocator(
     const std::array<size_t, builder_config::MAX_NUM_VCS>& num_used_receiver_channels_per_vc,
     size_t channel_buffer_size_bytes,
     size_t available_channel_buffering_space,
-    const std::vector<MemoryRegion>& memory_regions) :
+    const std::vector<MemoryRegion>& memory_regions,
+    const std::array<bool, builder_config::num_max_sender_channels>& sender_channel_serviced,
+    const std::array<bool, builder_config::num_max_receiver_channels>& receiver_channel_serviced) :
     FabricChannelAllocator(topology, options, memory_regions),
     num_used_sender_channels_per_vc(num_used_sender_channels_per_vc),
     num_used_receiver_channels_per_vc(num_used_receiver_channels_per_vc),
@@ -104,28 +107,33 @@ FabricStaticSizedChannelsAllocator::FabricStaticSizedChannelsAllocator(
         num_receiver_buffer_slots_per_vc,
         num_remote_receiver_buffer_slots_per_vc);
 
-    // Calculate total slots across all VCs
+    // Count serviced channels and total slots (only for serviced channels)
     size_t total_slot_count = 0;
+    // Build flat sender offset -> (vc, channel_idx) mapping for servicing check
     for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
-        size_t vc_sender_slots = std::accumulate(
-            num_sender_buffer_slots_per_vc[vc].begin(),
-            num_sender_buffer_slots_per_vc[vc].begin() + num_used_sender_channels_per_vc[vc],
-            size_t{0});
-        size_t vc_receiver_slots = std::accumulate(
-            num_receiver_buffer_slots_per_vc[vc].begin(),
-            num_receiver_buffer_slots_per_vc[vc].begin() + num_used_receiver_channels_per_vc[vc],
-            size_t{0});
-        total_slot_count += vc_sender_slots + vc_receiver_slots;
+        size_t vc_sender_slots = 0;
+        size_t sender_flat_offset = 0;
+        for (size_t prev_vc = 0; prev_vc < vc; ++prev_vc) {
+            sender_flat_offset += num_used_sender_channels_per_vc[prev_vc];
+        }
+        for (size_t i = 0; i < num_used_sender_channels_per_vc[vc]; i++) {
+            if (sender_channel_serviced[sender_flat_offset + i]) {
+                vc_sender_slots += num_sender_buffer_slots_per_vc[vc][i];
+            }
+        }
 
-        log_trace(tt::LogFabric, "VC{} num_sender_buffer_slots: {}", vc, num_sender_buffer_slots_per_vc[vc]);
-        log_trace(
-            tt::LogFabric, "VC{} num_remote_sender_buffer_slots: {}", vc, num_remote_sender_buffer_slots_per_vc[vc]);
-        log_trace(tt::LogFabric, "VC{} num_receiver_buffer_slots: {}", vc, num_receiver_buffer_slots_per_vc[vc]);
-        log_trace(
-            tt::LogFabric,
-            "VC{} num_remote_receiver_buffer_slots: {}",
-            vc,
-            num_remote_receiver_buffer_slots_per_vc[vc]);
+        size_t vc_receiver_slots = 0;
+        size_t receiver_flat_offset = 0;
+        for (size_t prev_vc = 0; prev_vc < vc; ++prev_vc) {
+            receiver_flat_offset += num_used_receiver_channels_per_vc[prev_vc];
+        }
+        for (size_t i = 0; i < num_used_receiver_channels_per_vc[vc]; i++) {
+            if (receiver_channel_serviced[receiver_flat_offset + i]) {
+                vc_receiver_slots += num_receiver_buffer_slots_per_vc[vc][i];
+            }
+        }
+
+        total_slot_count += vc_sender_slots + vc_receiver_slots;
     }
     TT_FATAL(
         total_slot_count * channel_buffer_size_bytes <= available_channel_buffering_space,
@@ -133,43 +141,65 @@ FabricStaticSizedChannelsAllocator::FabricStaticSizedChannelsAllocator(
         total_slot_count * channel_buffer_size_bytes,
         available_channel_buffering_space);
 
-    log_trace(tt::LogFabric, "Available channel buffering space: {}", this->available_channel_buffering_space);
+    size_t l1_bytes_saved = 0;
 
-    // Set channel sizes and num buffers per VC
+    // Set channel sizes and num buffers per VC, zeroing unserviced channels
     for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
-        // set the sender channel sizes and num buffers
-        for (uint32_t i = 0; i < num_used_sender_channels_per_vc[vc]; i++) {
-            this->sender_channels_size_bytes[vc][i] = channel_buffer_size_bytes * num_sender_buffer_slots_per_vc[vc][i];
-            this->sender_channels_num_buffers[vc][i] = num_sender_buffer_slots_per_vc[vc][i];
+        size_t sender_flat_offset = 0;
+        for (size_t prev_vc = 0; prev_vc < vc; ++prev_vc) {
+            sender_flat_offset += num_used_sender_channels_per_vc[prev_vc];
         }
-        // set the remote sender channel sizes and num buffers
+
         for (uint32_t i = 0; i < num_used_sender_channels_per_vc[vc]; i++) {
+            if (sender_channel_serviced[sender_flat_offset + i]) {
+                this->sender_channels_size_bytes[vc][i] =
+                    channel_buffer_size_bytes * num_sender_buffer_slots_per_vc[vc][i];
+                this->sender_channels_num_buffers[vc][i] = num_sender_buffer_slots_per_vc[vc][i];
+            } else {
+                l1_bytes_saved += channel_buffer_size_bytes * num_sender_buffer_slots_per_vc[vc][i];
+                this->sender_channels_size_bytes[vc][i] = 0;
+                this->sender_channels_num_buffers[vc][i] = 0;
+            }
+            // Remote sender always gets the slot config (symmetric for now)
             this->remote_sender_channels_size_bytes[vc][i] =
                 channel_buffer_size_bytes * num_remote_sender_buffer_slots_per_vc[vc][i];
             this->remote_sender_channels_num_buffers[vc][i] = num_remote_sender_buffer_slots_per_vc[vc][i];
         }
-        // set the local receiver channel sizes and num buffers
-        for (uint32_t i = 0; i < num_used_receiver_channels_per_vc[vc]; i++) {
-            this->receiver_channels_size_bytes[vc][i] =
-                channel_buffer_size_bytes * num_receiver_buffer_slots_per_vc[vc][i];
-            this->receiver_channels_num_buffers[vc][i] = num_receiver_buffer_slots_per_vc[vc][i];
+
+        size_t receiver_flat_offset = 0;
+        for (size_t prev_vc = 0; prev_vc < vc; ++prev_vc) {
+            receiver_flat_offset += num_used_receiver_channels_per_vc[prev_vc];
         }
-        // set the remote receiver channel sizes and num buffers
+
         for (uint32_t i = 0; i < num_used_receiver_channels_per_vc[vc]; i++) {
+            if (receiver_channel_serviced[receiver_flat_offset + i]) {
+                this->receiver_channels_size_bytes[vc][i] =
+                    channel_buffer_size_bytes * num_receiver_buffer_slots_per_vc[vc][i];
+                this->receiver_channels_num_buffers[vc][i] = num_receiver_buffer_slots_per_vc[vc][i];
+            } else {
+                l1_bytes_saved += channel_buffer_size_bytes * num_receiver_buffer_slots_per_vc[vc][i];
+                this->receiver_channels_size_bytes[vc][i] = 0;
+                this->receiver_channels_num_buffers[vc][i] = 0;
+            }
             this->remote_receiver_channels_size_bytes[vc][i] =
                 channel_buffer_size_bytes * num_remote_receiver_buffer_slots_per_vc[vc][i];
             this->remote_receiver_channels_num_buffers[vc][i] = num_remote_receiver_buffer_slots_per_vc[vc][i];
         }
     }
 
-    // set the base addresses for the local channels (allocate sequentially: VC0 channels, then VC1 channels)
+    if (l1_bytes_saved > 0) {
+        log_debug(
+            tt::LogFabric,
+            "Servicing-aware allocator saved {} bytes of L1 by skipping unserviced channels",
+            l1_bytes_saved);
+    }
+
+    // Set base addresses for local channels (skipping unserviced channels)
     uint32_t sender_buffer_addr = buffer_region_start;
     for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
         for (uint32_t i = 0; i < num_used_sender_channels_per_vc[vc]; i++) {
             this->sender_channels_base_address[vc][i] = sender_buffer_addr;
             sender_buffer_addr += this->sender_channels_size_bytes[vc][i];
-            log_trace(
-                tt::LogFabric, "VC{} Sender {} channel_start: {}", vc, i, this->sender_channels_base_address[vc][i]);
         }
     }
 
@@ -178,28 +208,16 @@ FabricStaticSizedChannelsAllocator::FabricStaticSizedChannelsAllocator(
         for (uint32_t i = 0; i < num_used_receiver_channels_per_vc[vc]; i++) {
             this->receiver_channels_base_address[vc][i] = receiver_buffer_addr;
             receiver_buffer_addr += this->receiver_channels_size_bytes[vc][i];
-            log_trace(
-                tt::LogFabric,
-                "VC{} Receiver {} channel_start: {}",
-                vc,
-                i,
-                this->receiver_channels_base_address[vc][i]);
         }
     }
     uint32_t buffer_addr_end = receiver_buffer_addr;
 
-    // set the base addresses for the remote channels
+    // Set base addresses for remote channels
     uint32_t remote_sender_buffer_addr = buffer_region_start;
     for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
         for (uint32_t i = 0; i < num_used_sender_channels_per_vc[vc]; i++) {
             this->remote_sender_channels_base_address[vc][i] = remote_sender_buffer_addr;
             remote_sender_buffer_addr += this->remote_sender_channels_size_bytes[vc][i];
-            log_trace(
-                tt::LogFabric,
-                "VC{} Remote Sender {} channel_start: {}",
-                vc,
-                i,
-                this->remote_sender_channels_base_address[vc][i]);
         }
     }
 
@@ -208,27 +226,19 @@ FabricStaticSizedChannelsAllocator::FabricStaticSizedChannelsAllocator(
         for (uint32_t i = 0; i < num_used_receiver_channels_per_vc[vc]; i++) {
             this->remote_receiver_channels_base_address[vc][i] = remote_receiver_buffer_addr;
             remote_receiver_buffer_addr += this->remote_receiver_channels_size_bytes[vc][i];
-            log_trace(
-                tt::LogFabric,
-                "VC{} Remote Receiver {} channel_start: {}",
-                vc,
-                i,
-                this->remote_receiver_channels_base_address[vc][i]);
         }
     }
 
-    log_trace(tt::LogFabric, "Available channel buffering space: {}", this->available_channel_buffering_space);
-
     auto skip_current_sender_channel = [&](uint32_t vc_id, uint32_t idx) -> bool {
-        // for fabric with tensix extension, only check the worker channel (VC0 channel 0), other channels are skipped
         uint32_t target_channel = get_worker_connected_sender_channel();
         return !((vc_id == 0 && idx == target_channel) || !has_tensix_extension);
     };
 
-    // Validate sender channels per VC
+    // Validate sender channels per VC (only serviced channels need validation)
+    size_t flat_sender_idx = 0;
     for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
         for (uint32_t i = 0; i < num_used_sender_channels_per_vc[vc]; i++) {
-            if (!skip_current_sender_channel(vc, i)) {
+            if (sender_channel_serviced[flat_sender_idx] && !skip_current_sender_channel(vc, i)) {
                 TT_FATAL(
                     this->sender_channels_size_bytes[vc][i] > 0,
                     "Internal error when computing `sender_channels_size_bytes[VC{}][{}]` which was computed to be "
@@ -236,22 +246,27 @@ FabricStaticSizedChannelsAllocator::FabricStaticSizedChannelsAllocator(
                     vc,
                     i);
             }
+            flat_sender_idx++;
         }
     }
 
-    // Validate receiver channels per VC
+    // Validate receiver channels per VC (only serviced channels need validation)
+    size_t flat_receiver_idx = 0;
     for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
         for (uint32_t i = 0; i < num_used_receiver_channels_per_vc[vc]; i++) {
-            TT_FATAL(
-                this->receiver_channels_size_bytes[vc][i] > 0,
-                "Internal error when computing `receiver_channels_size_bytes[VC{}][{}]` which was computed to be size "
-                "0",
-                vc,
-                i);
+            if (receiver_channel_serviced[flat_receiver_idx]) {
+                TT_FATAL(
+                    this->receiver_channels_size_bytes[vc][i] > 0,
+                    "Internal error when computing `receiver_channels_size_bytes[VC{}][{}]` which was computed to be "
+                    "size 0",
+                    vc,
+                    i);
+            }
+            flat_receiver_idx++;
         }
     }
 
-    // Validate total size across all VCs
+    // Validate total size
     size_t total_size = 0;
     for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
         total_size += std::accumulate(
@@ -537,6 +552,31 @@ void FabricStaticSizedChannelsAllocator::configure_buffer_slots_helper(
     num_remote_sender_buffer_slots_per_vc[1].fill(vc1_sender_buffer_slots);
     num_receiver_buffer_slots_per_vc[1].fill(vc1_receiver_buffer_slots);
     num_remote_receiver_buffer_slots_per_vc[1].fill(vc1_receiver_buffer_slots);
+}
+
+
+PublishedAllocatorState FabricStaticSizedChannelsAllocator::to_published_state() const {
+    PublishedAllocatorState state;
+
+    for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
+        state.num_used_receiver_channels_per_vc[vc] = num_used_receiver_channels_per_vc[vc];
+        for (size_t i = 0; i < num_used_receiver_channels_per_vc[vc]; ++i) {
+            state.receiver_channels_base_address[vc][i] = receiver_channels_base_address[vc][i];
+            state.receiver_channels_num_buffers[vc][i] = receiver_channels_num_buffers[vc][i];
+        }
+
+        state.num_used_sender_channels_per_vc[vc] = num_used_sender_channels_per_vc[vc];
+        for (size_t i = 0; i < num_used_sender_channels_per_vc[vc]; ++i) {
+            state.sender_channels_base_address[vc][i] = sender_channels_base_address[vc][i];
+            state.sender_channels_num_buffers[vc][i] = sender_channels_num_buffers[vc][i];
+        }
+    }
+
+    state.topology = topology_;
+    state.options = options_;
+    state.memory_regions = memory_regions_;
+
+    return state;
 }
 
 void FabricStaticSizedChannelsAllocator::emit_ct_args(std::vector<uint32_t>& ct_args) const {

--- a/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.hpp
+++ b/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.hpp
@@ -15,6 +15,8 @@
 
 namespace tt::tt_fabric {
 
+struct PublishedAllocatorState;
+
 /**
  * Static-sized channels allocator implementation.
  * The `FabricStaticSizedChannelsAllocator` allocates memory for statically sized sender(outbound)
@@ -28,6 +30,16 @@ namespace tt::tt_fabric {
  */
 class FabricStaticSizedChannelsAllocator : public FabricChannelAllocator {
 public:
+    /**
+     * Construct allocator with per-channel servicing flags.
+     * Skips L1 allocation for channels marked as not serviced.
+     * A channel is "serviced" if ANY RISC services it (collapsed from per-RISC flags).
+     * Unserviced channels get size_bytes=0, num_buffers=0, and don't advance the buffer pointer.
+     * By default all channels are serviced.
+     *
+     * @param sender_channel_serviced Per-channel flat flags (across all VCs) for sender channels
+     * @param receiver_channel_serviced Per-channel flat flags (across all VCs) for receiver channels
+     */
     FabricStaticSizedChannelsAllocator(
         tt::tt_fabric::Topology topology,
         const FabricEriscDatamoverOptions& options,
@@ -35,7 +47,9 @@ public:
         const std::array<size_t, builder_config::MAX_NUM_VCS>& num_used_receiver_channels_per_vc,
         size_t channel_buffer_size_bytes,
         size_t available_channel_buffering_space,
-        const std::vector<MemoryRegion>& memory_regions);
+        const std::vector<MemoryRegion>& memory_regions,
+        const std::array<bool, builder_config::num_max_sender_channels>& sender_channel_serviced = all_channels_serviced_sender_,
+        const std::array<bool, builder_config::num_max_receiver_channels>& receiver_channel_serviced = all_channels_serviced_receiver_);
 
     void emit_ct_args(std::vector<uint32_t>& ct_args) const override;
 
@@ -103,11 +117,16 @@ public:
         return num_used_receiver_channels_per_vc[0] + num_used_receiver_channels_per_vc[1];
     }
 
+    /**
+     * Extract a PublishedAllocatorState representing this allocator's layout.
+     * Used to construct a FabricRemoteChannelsAllocator from peer state.
+     */
+    PublishedAllocatorState to_published_state() const;
+
     // Override virtual print method from base class
     void print(std::ostream& os) const override;
 
 private:
-    friend class FabricRemoteChannelsAllocator;
     /*
      * Helper function that decides the number of buffer slots for each channel per VC.
      */
@@ -138,6 +157,18 @@ private:
     // Tensix configuration channel counts
     static constexpr size_t num_sender_channels_with_tensix_config =
         builder_config::num_sender_channels_with_tensix_config;
+
+    // Default servicing flags (all channels serviced)
+    static inline const std::array<bool, builder_config::num_max_sender_channels> all_channels_serviced_sender_ = [] {
+        std::array<bool, builder_config::num_max_sender_channels> a;
+        a.fill(true);
+        return a;
+    }();
+    static inline const std::array<bool, builder_config::num_max_receiver_channels> all_channels_serviced_receiver_ = [] {
+        std::array<bool, builder_config::num_max_receiver_channels> a;
+        a.fill(true);
+        return a;
+    }();
 
     // Channel size and buffer information per VC (VC × channel)
     std::array<std::array<std::size_t, builder_config::num_max_sender_channels>, builder_config::MAX_NUM_VCS>

--- a/tt_metal/fabric/compute_mesh_router_builder.cpp
+++ b/tt_metal/fabric/compute_mesh_router_builder.cpp
@@ -10,6 +10,10 @@
 #include "tt_metal/fabric/channel_trimming_import.hpp"
 #include "tt_metal/fabric/builder/fabric_builder_helpers.hpp"
 #include "tt_metal/fabric/builder/fabric_core_placement.hpp"
+#include "tt_metal/fabric/builder/fabric_remote_channels_allocator.hpp"
+#include "tt_metal/fabric/builder/fabric_router_recipe.hpp"
+#include "tt_metal/fabric/builder/channel_to_pool_mapping.hpp"
+#include "tt_metal/fabric/builder/multi_pool_channel_allocator.hpp"
 #include "impl/context/metal_context.hpp"
 #include "impl/kernels/kernel.hpp"
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
@@ -714,6 +718,28 @@ FabricDatamoverBuilderBase* ComputeMeshRouterBuilder::get_builder_for_vc_channel
         return const_cast<FabricTensixDatamoverBuilder*>(&tensix_builder_.value());
     }
     return erisc_builder_.get();
+}
+
+PublishedAllocatorState ComputeMeshRouterBuilder::get_published_allocator_state() const {
+    return erisc_builder_->get_published_allocator_state();
+}
+
+void ComputeMeshRouterBuilder::update_remote_allocator(const PublishedAllocatorState& peer_state) {
+    // Create new remote channels allocator from peer's published state
+    auto new_remote_allocator = std::make_shared<FabricRemoteChannelsAllocator>(peer_state);
+    erisc_builder_->remote_channels_allocator_ = new_remote_allocator;
+
+    // Rebuild the remote multi-pool allocator and channel-to-pool mapping
+    auto remote_channels_recipe = FabricRouterRecipe::create_default_single_static_pool_recipe(
+        0, erisc_builder_->config.num_used_receiver_channels);
+
+    std::vector<std::shared_ptr<FabricChannelAllocator>> remote_pool_allocators{new_remote_allocator};
+    std::vector<FabricChannelPoolType> remote_pool_types{FabricChannelPoolType::STATIC};
+    // Note: remote multi-pool allocator is not stored separately in config,
+    // it's reconstructed when needed. Only remote_channels_allocator and
+    // remote_channel_to_pool_mapping need updating.
+    erisc_builder_->remote_channel_to_pool_mapping_ =
+        std::make_shared<ChannelToPoolMapping>(remote_channels_recipe);
 }
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/fabric/compute_mesh_router_builder.hpp
+++ b/tt_metal/fabric/compute_mesh_router_builder.hpp
@@ -61,6 +61,9 @@ public:
 
     void configure_for_dispatch() override;
 
+    PublishedAllocatorState get_published_allocator_state() const override;
+    void update_remote_allocator(const PublishedAllocatorState& peer_state) override;
+
     void compile_ancillary_kernels(tt::tt_metal::Program& program) override;
 
     void create_kernel(tt::tt_metal::Program& program, const KernelCreationContext& ctx) override;

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -2307,22 +2307,22 @@ ControlPlane::get_global_logical_bindings() const {
     return global_logical_bindings_;
 }
 
-// Helper function to fill connection info with common fields for fabric router configs
+// Helper function to fill connection info with common fields for fabric router configs.
+// When published_state is provided, uses per-router allocator layout for base address and
+// buffer counts (servicing-aware). Otherwise falls back to the shared config's allocator.
 void fill_connection_info_fields(
     tt::tt_fabric::fabric_connection_info_t& connection_info,
     const CoreCoord& virtual_core,
     const FabricEriscDatamoverConfig& config,
     uint32_t sender_channel,
-    uint16_t worker_free_slots_stream_id) {
-    auto* channel_allocator = config.channel_allocator.get();
-    auto* const static_channel_allocator =
-        dynamic_cast<tt::tt_fabric::FabricStaticSizedChannelsAllocator*>(channel_allocator);
-    TT_FATAL(static_channel_allocator != nullptr, "Channel allocator must be a FabricStaticSizedChannelsAllocator.");
+    uint16_t worker_free_slots_stream_id,
+    const tt::tt_fabric::PublishedAllocatorState& published_state) {
     connection_info.edm_noc_x = static_cast<uint8_t>(virtual_core.x);
     connection_info.edm_noc_y = static_cast<uint8_t>(virtual_core.y);
-    connection_info.edm_buffer_base_addr = static_channel_allocator->get_sender_channel_base_address(sender_channel);
-    connection_info.num_buffers_per_channel =
-        static_channel_allocator->get_sender_channel_number_of_slots(sender_channel);
+
+    connection_info.edm_buffer_base_addr = published_state.sender_channels_base_address[0][sender_channel];
+    connection_info.num_buffers_per_channel = published_state.sender_channels_num_buffers[0][sender_channel];
+
     connection_info.edm_connection_handshake_addr = config.sender_channels_connection_semaphore_address[sender_channel];
     connection_info.edm_worker_location_info_addr =
         config.sender_channels_worker_conn_info_base_address[sender_channel];
@@ -2372,8 +2372,19 @@ void ControlPlane::populate_fabric_connection_info(
         fabric_tensix_config, static_cast<eth_chan_directions>(sender_channel));
     CoreCoord fabric_router_virtual_core = cluster.get_virtual_eth_core_from_channel(physical_chip_id, eth_channel_id);
 
+    // Use per-router published state if available (after fabric build phase 1),
+    // otherwise fall back to the default allocator state (during early init).
+    const auto& pub_state = builder_context.has_published_allocator_state(physical_chip_id, eth_channel_id)
+                                ? builder_context.get_published_allocator_state(physical_chip_id, eth_channel_id)
+                                : builder_context.get_default_allocator_state();
+
     fill_connection_info_fields(
-        worker_connection_info, fabric_router_virtual_core, edm_config, sender_channel, WORKER_FREE_SLOTS_STREAM_ID);
+        worker_connection_info,
+        fabric_router_virtual_core,
+        edm_config,
+        sender_channel,
+        WORKER_FREE_SLOTS_STREAM_ID,
+        pub_state);
 
     // Check if fabric tensix config is enabled, if so populate different configs for dispatcher and tensix
     if (fabric_tensix_config != tt::tt_fabric::FabricTensixConfig::DISABLED) {
@@ -2384,7 +2395,8 @@ void ControlPlane::populate_fabric_connection_info(
             fabric_router_virtual_core,
             default_edm_config,
             sender_channel,
-            WORKER_FREE_SLOTS_STREAM_ID);
+            WORKER_FREE_SLOTS_STREAM_ID,
+            pub_state);
 
         const auto& tensix_config = builder_context.get_tensix_config();
         CoreCoord mux_core_logical = tensix_config.get_core_for_channel(physical_chip_id, eth_channel_id);

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -33,6 +33,7 @@
 #include "tt_metal/fabric/builder/channel_to_pool_mapping.hpp"
 #include "tt_metal/fabric/builder/multi_pool_channel_allocator.hpp"
 #include "tt_metal/fabric/builder/connection_writer_adapter.hpp"
+#include "tt_metal/fabric/fabric_builder_context.hpp"
 
 #include "impl/context/metal_context.hpp"
 #include "core_coord.hpp"
@@ -386,7 +387,7 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(Topology topology) : topo
 FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(
     std::size_t channel_buffer_size_bytes,
     Topology topology,
-    FabricEriscDatamoverOptions options,
+    FabricEriscDatamoverOptions /* options */,
     const std::array<std::size_t, builder_config::MAX_NUM_VCS>& sender_channels_per_vc,
     const std::array<std::size_t, builder_config::MAX_NUM_VCS>& receiver_channels_per_vc) :
     FabricEriscDatamoverConfig(topology) {
@@ -454,51 +455,6 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(
         "size of {}",
         min_buffer_size);
     this->channel_buffer_size_bytes = channel_buffer_size_bytes;
-
-    // Compute available channel buffering space from memory regions
-    size_t available_channel_buffering_space = std::accumulate(
-        this->available_buffer_memory_regions.begin(),
-        this->available_buffer_memory_regions.end(),
-        size_t{0},
-        [](size_t sum, const MemoryRegion& region) { return sum + region.get_size(); });
-
-    // Create a default recipe with a single static pool for backward compatibility
-    // All channels map to pool 0 (the single static pool)
-    auto recipe = tt::tt_fabric::FabricRouterRecipe::create_default_single_static_pool_recipe(
-        this->num_used_sender_channels, this->num_used_receiver_channels);
-    auto remote_channels_recipe = tt::tt_fabric::FabricRouterRecipe::create_default_single_static_pool_recipe(
-        0, this->num_used_receiver_channels);
-
-    // Create the single static pool allocator with per-VC channel distribution
-    auto static_allocator = std::make_shared<tt::tt_fabric::FabricStaticSizedChannelsAllocator>(
-        topology,
-        options,
-        this->num_used_sender_channels_per_vc,
-        this->num_used_receiver_channels_per_vc,
-        this->channel_buffer_size_bytes,
-        available_channel_buffering_space,
-        this->available_buffer_memory_regions);
-
-    // Assign static allocator directly to channel_allocator (composition, not wrapped)
-    this->channel_allocator = static_allocator;
-
-    // Create remote channels allocator from the static allocator
-    this->remote_channels_allocator = std::make_shared<tt::tt_fabric::FabricRemoteChannelsAllocator>(*static_allocator);
-
-    // Create multi-pool coordinator that manages the pool allocators
-    std::vector<std::shared_ptr<tt::tt_fabric::FabricChannelAllocator>> pool_allocators;
-    pool_allocators.push_back(static_allocator);
-
-    std::vector<tt::tt_fabric::FabricChannelPoolType> pool_types;
-    pool_types.push_back(tt::tt_fabric::FabricChannelPoolType::STATIC);
-
-    this->multi_pool_allocator =
-        std::make_shared<tt::tt_fabric::MultiPoolChannelAllocator>(std::move(pool_allocators), std::move(pool_types));
-
-    // Create the channel-to-pool mapping
-    this->channel_to_pool_mapping = std::make_shared<tt::tt_fabric::ChannelToPoolMapping>(recipe);
-    this->remote_channel_to_pool_mapping =
-        std::make_shared<tt::tt_fabric::ChannelToPoolMapping>(remote_channels_recipe);
 
     // set default noc and cmd bufs (current setup in TG 4U)
     for (uint32_t i = 0; i < builder_config::num_max_receiver_channels; i++) {
@@ -729,7 +685,7 @@ FabricEriscDatamoverBuilder::FabricEriscDatamoverBuilder(
     // 1. Stored as members for later use in compile-time args
     // 2. Used for connection validation
     // We intentionally DON'T override config values because:
-    // 1. config.multi_pool_allocator was created with MAX channel counts
+    // 1. multi_pool_allocator_ was created with MAX channel counts
     // 2. Changing config counts would cause emit_ct_args to emit wrong number of args
     // The config stays at MAX, but we pass actual counts to device via compile-time args
     // Validate injection flags vector size matches the number of sender channels
@@ -800,16 +756,65 @@ FabricEriscDatamoverBuilder::FabricEriscDatamoverBuilder(
         apply_channel_trimming_overrides(channel_trimming_overrides.value());
     }
 
+    // Create the initial allocators on the builder (moved from FabricEriscDatamoverConfig ctor)
+    {
+        // Compute available channel buffering space from memory regions
+        size_t available_channel_buffering_space = std::accumulate(
+            this->config.available_buffer_memory_regions.begin(),
+            this->config.available_buffer_memory_regions.end(),
+            size_t{0},
+            [](size_t sum, const MemoryRegion& region) { return sum + region.get_size(); });
+
+        auto recipe = FabricRouterRecipe::create_default_single_static_pool_recipe(
+            this->config.num_used_sender_channels, this->config.num_used_receiver_channels);
+        auto remote_channels_recipe = FabricRouterRecipe::create_default_single_static_pool_recipe(
+            0, this->config.num_used_receiver_channels);
+
+        auto static_allocator = std::make_shared<FabricStaticSizedChannelsAllocator>(
+            this->config.topology,
+            FabricEriscDatamoverOptions{
+                .fabric_tensix_config = this->has_tensix_extension
+                                            ? tt::tt_metal::MetalContext::instance().get_fabric_tensix_config()
+                                            : FabricTensixConfig::DISABLED,
+                .direction = this->direction_,
+            },
+            this->config.num_used_sender_channels_per_vc,
+            this->config.num_used_receiver_channels_per_vc,
+            this->config.channel_buffer_size_bytes,
+            available_channel_buffering_space,
+            this->config.available_buffer_memory_regions);
+
+        this->channel_allocator_ = static_allocator;
+
+        this->remote_channels_allocator_ =
+            std::make_shared<FabricRemoteChannelsAllocator>(static_allocator->to_published_state());
+
+        std::vector<std::shared_ptr<FabricChannelAllocator>> pool_allocators;
+        pool_allocators.push_back(static_allocator);
+        std::vector<FabricChannelPoolType> pool_types;
+        pool_types.push_back(FabricChannelPoolType::STATIC);
+        this->multi_pool_allocator_ =
+            std::make_shared<MultiPoolChannelAllocator>(std::move(pool_allocators), std::move(pool_types));
+
+        this->channel_to_pool_mapping_ = std::make_shared<ChannelToPoolMapping>(recipe);
+        this->remote_channel_to_pool_mapping_ = std::make_shared<ChannelToPoolMapping>(remote_channels_recipe);
+    }
+
+    // Create servicing-aware allocator that skips L1 allocation for unserviced channels.
+    // This replaces the builder's allocator, multi_pool_allocator, remote_channels_allocator,
+    // and channel-to-pool mappings if any channels are unserviced.
+    create_servicing_aware_allocator();
+
     std::fill(
         sender_channel_connection_liveness_check_disable_array.begin(),
         sender_channel_connection_liveness_check_disable_array.end(),
         false);
 
     TT_FATAL(
-        config.channel_allocator.get() != nullptr,
+        this->channel_allocator_.get() != nullptr,
         "Channel allocator is not set. Failed to build TT-Fabric router. Internal error.");
     auto* static_allocator =
-        dynamic_cast<tt::tt_fabric::FabricStaticSizedChannelsAllocator*>(config.channel_allocator.get());
+        dynamic_cast<tt::tt_fabric::FabricStaticSizedChannelsAllocator*>(this->channel_allocator_.get());
     TT_FATAL(
         static_allocator != nullptr,
         "Channel allocator must be a FabricStaticSizedChannelsAllocator. Failed to build TT-Fabric router. Internal "
@@ -836,6 +841,105 @@ FabricEriscDatamoverBuilder::FabricEriscDatamoverBuilder(
         static_cast<int>(direction));
 
     configure_telemetry_settings();
+}
+
+void FabricEriscDatamoverBuilder::create_servicing_aware_allocator() {
+    // Collapse per-RISC servicing flags into per-channel flags.
+    // A channel is "serviced" if ANY RISC services it.
+    std::array<bool, builder_config::num_max_sender_channels> sender_serviced{};
+    std::array<bool, builder_config::num_max_receiver_channels> receiver_serviced{};
+
+    size_t num_riscv_cores = this->config.risc_configs.size();
+    for (size_t risc_id = 0; risc_id < num_riscv_cores; ++risc_id) {
+        for (size_t ch = 0; ch < builder_config::num_max_sender_channels; ++ch) {
+            if (this->is_sender_channel_serviced_[risc_id][ch]) {
+                sender_serviced[ch] = true;
+            }
+        }
+        for (size_t ch = 0; ch < builder_config::num_max_receiver_channels; ++ch) {
+            if (this->is_receiver_channel_serviced_[risc_id][ch]) {
+                receiver_serviced[ch] = true;
+            }
+        }
+    }
+
+    // Check if any channels are actually unserviced — if all are serviced, skip replacement
+    bool has_unserviced = false;
+    size_t flat_sender_idx = 0;
+    for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
+        for (size_t i = 0; i < this->config.num_used_sender_channels_per_vc[vc]; ++i) {
+            if (!sender_serviced[flat_sender_idx++]) {
+                has_unserviced = true;
+            }
+        }
+    }
+    size_t flat_receiver_idx = 0;
+    for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
+        for (size_t i = 0; i < this->config.num_used_receiver_channels_per_vc[vc]; ++i) {
+            if (!receiver_serviced[flat_receiver_idx++]) {
+                has_unserviced = true;
+            }
+        }
+    }
+
+    if (!has_unserviced) {
+        return;  // All channels serviced, no need to replace allocator
+    }
+
+    // Compute available channel buffering space
+    size_t available_channel_buffering_space = std::accumulate(
+        this->config.available_buffer_memory_regions.begin(),
+        this->config.available_buffer_memory_regions.end(),
+        size_t{0},
+        [](size_t sum, const MemoryRegion& region) { return sum + region.get_size(); });
+
+    // Create servicing-aware allocator
+    auto static_allocator = std::make_shared<FabricStaticSizedChannelsAllocator>(
+        this->config.topology,
+        FabricEriscDatamoverOptions{
+            .fabric_tensix_config = this->has_tensix_extension
+                                        ? tt::tt_metal::MetalContext::instance().get_fabric_tensix_config()
+                                        : FabricTensixConfig::DISABLED,
+            .direction = this->direction_,
+        },
+        this->config.num_used_sender_channels_per_vc,
+        this->config.num_used_receiver_channels_per_vc,
+        this->config.channel_buffer_size_bytes,
+        available_channel_buffering_space,
+        this->config.available_buffer_memory_regions,
+        sender_serviced,
+        receiver_serviced);
+
+    // Replace builder's allocator and related shared_ptrs
+    this->channel_allocator_ = static_allocator;
+
+    // Recreate remote channels allocator from the new static allocator's published state
+    this->remote_channels_allocator_ =
+        std::make_shared<FabricRemoteChannelsAllocator>(static_allocator->to_published_state());
+
+    // Recreate multi-pool coordinator
+    auto recipe = FabricRouterRecipe::create_default_single_static_pool_recipe(
+        this->config.num_used_sender_channels, this->config.num_used_receiver_channels);
+    auto remote_channels_recipe = FabricRouterRecipe::create_default_single_static_pool_recipe(
+        0, this->config.num_used_receiver_channels);
+
+    std::vector<std::shared_ptr<FabricChannelAllocator>> pool_allocators;
+    pool_allocators.push_back(static_allocator);
+    std::vector<FabricChannelPoolType> pool_types;
+    pool_types.push_back(FabricChannelPoolType::STATIC);
+    this->multi_pool_allocator_ =
+        std::make_shared<MultiPoolChannelAllocator>(std::move(pool_allocators), std::move(pool_types));
+
+    // Recreate channel-to-pool mappings
+    this->channel_to_pool_mapping_ = std::make_shared<ChannelToPoolMapping>(recipe);
+    this->remote_channel_to_pool_mapping_ = std::make_shared<ChannelToPoolMapping>(remote_channels_recipe);
+}
+
+PublishedAllocatorState FabricEriscDatamoverBuilder::get_published_allocator_state() const {
+    auto* static_allocator =
+        dynamic_cast<const FabricStaticSizedChannelsAllocator*>(this->channel_allocator_.get());
+    TT_FATAL(static_allocator != nullptr, "Channel allocator must be FabricStaticSizedChannelsAllocator");
+    return static_allocator->to_published_state();
 }
 
 void FabricEriscDatamoverBuilder::configure_telemetry_settings() {
@@ -985,9 +1089,9 @@ FabricEriscDatamoverBuilder::CompileTimeArgs FabricEriscDatamoverBuilder::get_co
     }
 
     // TODO: this validation should be done in the allocator with the channel IDs passed in
-    auto* channel_allocator = config.channel_allocator.get();
+    auto* ct_channel_allocator = this->channel_allocator_.get();
     auto* const static_channel_allocator =
-        dynamic_cast<tt::tt_fabric::FabricStaticSizedChannelsAllocator*>(channel_allocator);
+        dynamic_cast<tt::tt_fabric::FabricStaticSizedChannelsAllocator*>(ct_channel_allocator);
     TT_FATAL(static_channel_allocator != nullptr, "Channel allocator must be a FabricStaticSizedChannelsAllocator.");
     size_t receiver_channel_num_buffers = static_channel_allocator->get_receiver_channel_number_of_slots(0);
     TT_FATAL(
@@ -1170,26 +1274,26 @@ FabricEriscDatamoverBuilder::CompileTimeArgs FabricEriscDatamoverBuilder::get_co
 
     // Emit pool data via multi-pool coordinator (steps 1-4 of schema: special tag, num_pools, pool_types, individual
     // pool CT args)
-    config.multi_pool_allocator->emit_ct_args(
+    this->multi_pool_allocator_->emit_ct_args(
         ct_args, actual_sender_channels_vc0, actual_sender_channels_vc1, num_receiver_channels);
 
     // Emit channel-to-pool mappings (steps 5-8 of schema)
     ct_args.push_back(0xabaddad8);
-    config.channel_to_pool_mapping->emit_ct_args(ct_args);
+    this->channel_to_pool_mapping_->emit_ct_args(ct_args);
 
     // Emit remote channel pool data (for remote_receiver_channels initialization)
     // Create a multi-pool for remote channels, following the same pattern as local channels
     ct_args.push_back(0xabaddad6);
 
     // Create remote multi-pool allocator with the remote channels allocator
-    TT_FATAL(config.remote_channels_allocator != nullptr, "Remote channels allocator must be non-null");
+    TT_FATAL(this->remote_channels_allocator_ != nullptr, "Remote channels allocator must be non-null");
     MultiPoolChannelAllocator remote_multi_pool_allocator(
-        {config.remote_channels_allocator}, {FabricChannelPoolType::STATIC});
+        {this->remote_channels_allocator_}, {FabricChannelPoolType::STATIC});
 
     // Emit remote channel pool data via multi-pool coordinator
     remote_multi_pool_allocator.emit_ct_args(ct_args, 0, 0, num_receiver_channels);
 
-    config.remote_channel_to_pool_mapping->emit_ct_args(ct_args);
+    this->remote_channel_to_pool_mapping_->emit_ct_args(ct_args);
 
     ct_args.push_back(0xabaddad7);
     receiver_channel_to_downstream_adapter->emit_ct_args(ct_args, config.num_fwd_paths);
@@ -1418,28 +1522,17 @@ FabricEriscDatamoverBuilder FabricEriscDatamoverBuilder::build(
     std::array<std::optional<size_t>, builder_config::max_downstream_edms>
         receiver_channels_downstream_teardown_semaphore_id;
 
-    auto remote_pool_allocators =
-        std::vector<std::shared_ptr<tt::tt_fabric::FabricChannelAllocator>>{config.remote_channels_allocator};
-    auto remote_pool_types =
-        std::vector<tt::tt_fabric::FabricChannelPoolType>{tt::tt_fabric::FabricChannelPoolType::STATIC};
-    auto remote_multi_pool_allocator = std::make_shared<tt::tt_fabric::MultiPoolChannelAllocator>(
-        std::move(remote_pool_allocators), std::move(remote_pool_types));
-
     log_debug(
         tt::LogFabric,
         "FABRIC NODE ID: M={},D={} eth=(x={},y={})\n"
-        "\tnum_sender_channels={}, num_receiver_channels={}\n"
-        "\tchannel_allocator={}\n"
-        "\tremote_channel_allocator={}\n",
+        "\tnum_sender_channels={}, num_receiver_channels={}\n",
 
         local_fabric_node_id.mesh_id,
         local_fabric_node_id.chip_id,
         ethernet_core.x,
         ethernet_core.y,
         config.num_used_sender_channels,
-        config.num_used_receiver_channels,
-        *config.channel_allocator,
-        *remote_multi_pool_allocator->get_pool(0));
+        config.num_used_receiver_channels);
 
     if (build_in_worker_connection_mode) {
         for (uint32_t i = 0; i < builder_config::num_max_receiver_channels; i++) {
@@ -1515,9 +1608,9 @@ SenderWorkerAdapterSpec FabricEriscDatamoverBuilder::build_connection_to_fabric_
     // - vc_relative_channel_id: used for VC-aware allocator calls
     // Both are already validated by ComputeMeshRouterBuilder::establish_connections_to_router
 
-    auto* channel_allocator = config.channel_allocator.get();
+    auto* bcf_channel_allocator = this->channel_allocator_.get();
     auto* const static_channel_allocator =
-        dynamic_cast<tt::tt_fabric::FabricStaticSizedChannelsAllocator*>(channel_allocator);
+        dynamic_cast<tt::tt_fabric::FabricStaticSizedChannelsAllocator*>(bcf_channel_allocator);
     TT_FATAL(static_channel_allocator != nullptr, "Channel allocator must be a FabricStaticSizedChannelsAllocator.");
 
     // Use VC-aware allocator getters with VC-relative channel ID
@@ -1604,10 +1697,6 @@ void FabricEriscDatamoverBuilder::setup_downstream_vc_connection(
         downstream_tensix_builder->append_upstream_routers_noc_xy(this->noc_x_, this->noc_y_);
     }
 
-    auto* channel_allocator = config.channel_allocator.get();
-    auto* const static_channel_allocator =
-        dynamic_cast<tt::tt_fabric::FabricStaticSizedChannelsAllocator*>(channel_allocator);
-    TT_FATAL(static_channel_allocator != nullptr, "Channel allocator must be a FabricStaticSizedChannelsAllocator.");
     auto* adapter_ptr = this->receiver_channel_to_downstream_adapter.get();
     TT_FATAL(adapter_ptr != nullptr, "Adapter is not set. Failed to build TT-Fabric router. Internal error.");
     adapter_ptr->add_downstream_connection(

--- a/tt_metal/fabric/erisc_datamover_builder.hpp
+++ b/tt_metal/fabric/erisc_datamover_builder.hpp
@@ -32,6 +32,7 @@
 namespace tt::tt_fabric {
 
 struct FabricRiscConfig;
+struct PublishedAllocatorState;
 class FabricRouterBuilder;
 class ComputeMeshRouterBuilder;
 class MultiPoolChannelAllocator;
@@ -345,22 +346,6 @@ struct FabricEriscDatamoverConfig {
     // emd vcs
     std::size_t edm_noc_vc = 0;
 
-    // Fabric channel allocator for L1 memory management
-    // Points to the primary allocator (typically static allocator for single-pool configs)
-    std::shared_ptr<FabricChannelAllocator> channel_allocator;
-
-    // Multi-pool allocator coordinator - manages all pool allocators
-    // Emits pool metadata and delegates to individual pools for CT args
-    std::shared_ptr<MultiPoolChannelAllocator> multi_pool_allocator;
-
-    // Channel-to-pool mapping for multi-pool support
-    std::shared_ptr<ChannelToPoolMapping> channel_to_pool_mapping;
-    // Channel-to-pool mapping for remote (over eth) channels multi-pool support
-    std::shared_ptr<ChannelToPoolMapping> remote_channel_to_pool_mapping;
-
-    // Remote channels allocator - tracks remote receiver channel info for the remote ethernet core
-    std::shared_ptr<FabricRemoteChannelsAllocator> remote_channels_allocator;
-
 private:
     FabricEriscDatamoverConfig(Topology topology = Topology::Linear);
 };
@@ -564,6 +549,12 @@ public:
 
     bool is_first_level_ack_enabled() const { return this->enable_first_level_ack; }
 
+    /**
+     * Extract the published allocator state from this builder's config.
+     * Used by FabricBuilder to collect per-router state for peer exchange.
+     */
+    PublishedAllocatorState get_published_allocator_state() const;
+
     //    protected:
     CoreCoord my_eth_core_logical;
     chan_id_t my_eth_channel;
@@ -575,6 +566,22 @@ public:
     bool is_inter_mesh = false;  // True if this data mover connects to a different mesh (inter-mesh router)
     size_t handshake_address = 0;
     size_t channel_buffer_size = 0;
+
+    // Fabric channel allocator for L1 memory management
+    // Points to the primary allocator (typically static allocator for single-pool configs)
+    std::shared_ptr<FabricChannelAllocator> channel_allocator_;
+
+    // Multi-pool allocator coordinator - manages all pool allocators
+    // Emits pool metadata and delegates to individual pools for CT args
+    std::shared_ptr<MultiPoolChannelAllocator> multi_pool_allocator_;
+
+    // Channel-to-pool mapping for multi-pool support
+    std::shared_ptr<ChannelToPoolMapping> channel_to_pool_mapping_;
+    // Channel-to-pool mapping for remote (over eth) channels multi-pool support
+    std::shared_ptr<ChannelToPoolMapping> remote_channel_to_pool_mapping_;
+
+    // Remote channels allocator - tracks remote receiver channel info for the remote ethernet core
+    std::shared_ptr<FabricRemoteChannelsAllocator> remote_channels_allocator_;
 
     std::shared_ptr<tt::tt_fabric::ChannelConnectionWriterAdapter> receiver_channel_to_downstream_adapter;
     std::array<std::shared_ptr<tt::tt_fabric::FabricChannelAllocator>, builder_config::max_downstream_edms>
@@ -663,6 +670,10 @@ private:
 
     // Configure telemetry settings for all RISC cores
     void configure_telemetry_settings();
+
+    // Create a servicing-aware allocator and replace config's allocators.
+    // Called after servicing flags and trimming overrides are computed.
+    void create_servicing_aware_allocator();
 };
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -217,19 +217,21 @@ void append_fabric_connection_rt_args(
             tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_eth_core_from_channel(
                 src_chip_id, fabric_router_channel);
 
-        const auto& edm_config = fabric_context.get_builder_context().get_fabric_router_config();
-        auto* channel_allocator = edm_config.channel_allocator.get();
-        auto* const static_channel_allocator =
-            dynamic_cast<tt::tt_fabric::FabricStaticSizedChannelsAllocator*>(channel_allocator);
-        TT_FATAL(
-            static_channel_allocator != nullptr, "Channel allocator must be a FabricStaticSizedChannelsAllocator.");
+        const auto& builder_context = fabric_context.get_builder_context();
+        const auto& edm_config = builder_context.get_fabric_router_config();
         // Sender channel 0 is always for local worker in the new design
         const auto sender_channel = 0;
+
+        const auto& pub_state =
+            builder_context.get_published_allocator_state(src_chip_id, fabric_router_channel);
+        size_t sender_base_address = pub_state.sender_channels_base_address[0][sender_channel];
+        size_t sender_num_buffers = pub_state.sender_channels_num_buffers[0][sender_channel];
+
         tt::tt_fabric::SenderWorkerAdapterSpec edm_connection = {
             .edm_noc_x = fabric_router_virtual_core.x,
             .edm_noc_y = fabric_router_virtual_core.y,
-            .edm_buffer_base_addr = static_channel_allocator->get_sender_channel_base_address(sender_channel),
-            .num_buffers_per_channel = static_channel_allocator->get_sender_channel_number_of_slots(sender_channel),
+            .edm_buffer_base_addr = sender_base_address,
+            .num_buffers_per_channel = sender_num_buffers,
             .edm_l1_sem_addr = edm_config.sender_channels_local_flow_control_semaphore_address[sender_channel],
             .edm_connection_handshake_addr = edm_config.sender_channels_connection_semaphore_address[sender_channel],
             .edm_worker_location_info_addr = edm_config.sender_channels_worker_conn_info_base_address[sender_channel],

--- a/tt_metal/fabric/fabric_builder.cpp
+++ b/tt_metal/fabric/fabric_builder.cpp
@@ -261,6 +261,46 @@ void FabricBuilder::compile_kernels_for_missing_directions() {
     }
 }
 
+std::vector<std::pair<AllocatorStateKey, PublishedAllocatorState>>
+FabricBuilder::collect_published_allocator_state() const {
+    std::vector<std::pair<AllocatorStateKey, PublishedAllocatorState>> result;
+    result.reserve(routers_.size());
+
+    for (const auto& [eth_chan, router_builder] : routers_) {
+        AllocatorStateKey key{device_->id(), eth_chan};
+        result.emplace_back(key, router_builder->get_published_allocator_state());
+    }
+
+    return result;
+}
+
+void FabricBuilder::update_remote_allocators() {
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+    const auto local_chip_id = control_plane.get_physical_chip_id_from_fabric_node_id(local_node_);
+    const auto& eth_connections = cluster.get_ethernet_connections();
+
+    auto chip_connections_it = eth_connections.find(local_chip_id);
+    if (chip_connections_it == eth_connections.end()) {
+        return;
+    }
+
+    for (auto& [eth_chan, router_builder] : routers_) {
+        // Look up the peer's chip and channel via cluster ethernet connections
+        auto chan_it = chip_connections_it->second.find(eth_chan);
+        if (chan_it == chip_connections_it->second.end()) {
+            continue;
+        }
+        auto [peer_chip_id, peer_eth_chan] = chan_it->second;
+
+        if (builder_context_.has_published_allocator_state(peer_chip_id, peer_eth_chan)) {
+            const auto& peer_state = builder_context_.get_published_allocator_state(peer_chip_id, peer_eth_chan);
+            router_builder->update_remote_allocator(peer_state);
+        }
+        // If no published state exists (e.g., peer didn't create routers), keep the default
+    }
+}
+
 void FabricBuilder::create_kernels() {
     uint32_t router_channels_mask = 0;
     for (const auto& [router_chan, _] : routers_) {

--- a/tt_metal/fabric/fabric_builder.hpp
+++ b/tt_metal/fabric/fabric_builder.hpp
@@ -10,6 +10,7 @@
 #include <unordered_set>
 #include <vector>
 #include "tt_metal/fabric/fabric_router_builder.hpp"
+#include "tt_metal/fabric/fabric_builder_context.hpp"
 #include "hostdevcommon/fabric_common.h"
 #include <tt-metalium/experimental/fabric/mesh_graph.hpp>
 
@@ -64,6 +65,19 @@ public:
      * Create the main ERISC router kernels.
      */
     void create_kernels();
+
+    /**
+     * Update remote allocators from peer state published in FabricBuilderContext.
+     * Called in phase 2 after the barrier and MPI exchange.
+     */
+    void update_remote_allocators();
+
+    /**
+     * Collect published allocator state from all router builders on this device.
+     * Returns a map of (chip_id, eth_chan) -> PublishedAllocatorState.
+     * Called on the main thread after phase 1 completes.
+     */
+    std::vector<std::pair<AllocatorStateKey, PublishedAllocatorState>> collect_published_allocator_state() const;
 
     /**
      * Check if any routers were created.

--- a/tt_metal/fabric/fabric_builder_context.cpp
+++ b/tt_metal/fabric/fabric_builder_context.cpp
@@ -4,10 +4,13 @@
 
 #include <tt_stl/reflection.hpp>
 #include "tt_metal/fabric/fabric_builder_context.hpp"
+#include "tt_metal/fabric/fabric_builder.hpp"
+#include <cstring>
 #include "tt_metal/fabric/fabric_context.hpp"
 #include "tt_metal/fabric/fabric_router_channel_mapping.hpp"
 #include "tt_metal/fabric/channel_trimming_import.hpp"
 #include "tt_metal/fabric/channel_trimming_report.hpp"
+#include "tt_metal/fabric/builder/fabric_static_sized_channels_allocator.hpp"
 #include "impl/context/metal_context.hpp"
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
 #include <tt-metalium/host_api.hpp>
@@ -91,6 +94,28 @@ FabricBuilderContext::FabricBuilderContext(const FabricContext& fabric_context) 
 
     tensix_config_ = nullptr;
 
+    // Compute default allocator state from the template config.
+    // This is available immediately (before any builders are created) for use during
+    // early initialization (e.g., populate_fabric_connection_info in write_routing_tables).
+    {
+        const auto& config = *router_config_;
+        size_t available_channel_buffering_space = std::accumulate(
+            config.available_buffer_memory_regions.begin(),
+            config.available_buffer_memory_regions.end(),
+            size_t{0},
+            [](size_t sum, const MemoryRegion& region) { return sum + region.get_size(); });
+
+        auto default_allocator = FabricStaticSizedChannelsAllocator(
+            config.topology,
+            FabricEriscDatamoverOptions{},
+            config.num_used_sender_channels_per_vc,
+            config.num_used_receiver_channels_per_vc,
+            config.channel_buffer_size_bytes,
+            available_channel_buffering_space,
+            config.available_buffer_memory_regions);
+        default_allocator_state_ = default_allocator.to_published_state();
+    }
+
     // Initialize per-device build state
     num_devices_ = tt::tt_metal::GetNumAvailableDevices();
     auto num_pcie_devices = tt::tt_metal::GetNumPCIeDevices();
@@ -100,6 +125,8 @@ FabricBuilderContext::FabricBuilderContext(const FabricContext& fabric_context) 
     master_router_chans_.resize(num_devices_, UNINITIALIZED_MASTER_ROUTER_CHAN);
     num_initialized_routers_.resize(num_devices_, UNINITIALIZED_ROUTERS);
 }
+
+FabricBuilderContext::~FabricBuilderContext() = default;
 
 std::unique_ptr<FabricEriscDatamoverConfig> FabricBuilderContext::create_edm_config(
     FabricTensixConfig fabric_tensix_config, eth_chan_directions direction) const {
@@ -271,5 +298,159 @@ IntermeshVCConfig FabricBuilderContext::compute_intermesh_vc_config() const {
     return config;
 }
 
+
+// ============ Published Allocator State Registry ============
+
+void FabricBuilderContext::publish_allocator_state(ChipId chip_id, chan_id_t eth_chan, PublishedAllocatorState state) {
+    AllocatorStateKey key{chip_id, eth_chan};
+    TT_FATAL(
+        !published_allocator_state_.contains(key),
+        "Allocator state already published for chip {} eth_chan {}",
+        chip_id,
+        eth_chan);
+    published_allocator_state_.emplace(key, std::move(state));
+}
+
+const PublishedAllocatorState& FabricBuilderContext::get_published_allocator_state(
+    ChipId chip_id, chan_id_t eth_chan) const {
+    AllocatorStateKey key{chip_id, eth_chan};
+    auto it = published_allocator_state_.find(key);
+    TT_FATAL(
+        it != published_allocator_state_.end(),
+        "No published allocator state for chip {} eth_chan {}",
+        chip_id,
+        eth_chan);
+    return it->second;
+}
+
+bool FabricBuilderContext::has_published_allocator_state(ChipId chip_id, chan_id_t eth_chan) const {
+    return published_allocator_state_.contains(AllocatorStateKey{chip_id, eth_chan});
+}
+
+const PublishedAllocatorState& FabricBuilderContext::get_any_published_allocator_state() const {
+    if (!published_allocator_state_.empty()) {
+        return published_allocator_state_.begin()->second;
+    }
+    // Fall back to the default state computed from the template config.
+    // This path is taken during early init before builders have published state.
+    return default_allocator_state_;
+}
+
+// ============ Build Barrier ============
+
+FabricBuildBarrier& FabricBuilderContext::get_or_create_build_barrier(
+    const std::vector<tt::tt_metal::IDevice*>& all_devices) {
+    std::lock_guard<std::mutex> lock(build_barrier_mutex_);
+    if (!build_barrier_) {
+        build_barrier_ = std::make_unique<FabricBuildBarrier>(all_devices);
+    }
+    return *build_barrier_;
+}
+
+void FabricBuilderContext::clear_build_barrier() {
+    std::lock_guard<std::mutex> lock(build_barrier_mutex_);
+    build_barrier_.reset();
+}
+
+// ============ PublishedAllocatorState Serialization ============
+
+std::vector<uint8_t> PublishedAllocatorState::serialize() const {
+    std::vector<uint8_t> buffer;
+
+    auto write_val = [&buffer](const auto& val) {
+        const auto* bytes = reinterpret_cast<const uint8_t*>(&val);
+        buffer.insert(buffer.end(), bytes, bytes + sizeof(val));
+    };
+
+    auto write_array_2d = [&](const auto& arr) {
+        for (const auto& inner : arr) {
+            for (const auto& val : inner) {
+                write_val(val);
+            }
+        }
+    };
+
+    auto write_array_1d = [&](const auto& arr) {
+        for (const auto& val : arr) {
+            write_val(val);
+        }
+    };
+
+    // Receiver data
+    write_array_2d(receiver_channels_base_address);
+    write_array_2d(receiver_channels_num_buffers);
+    write_array_1d(num_used_receiver_channels_per_vc);
+
+    // Sender data
+    write_array_2d(sender_channels_base_address);
+    write_array_2d(sender_channels_num_buffers);
+    write_array_1d(num_used_sender_channels_per_vc);
+
+    // Base class construction data
+    write_val(topology);
+    write_val(options);
+
+    // Memory regions (variable length)
+    size_t num_regions = memory_regions.size();
+    write_val(num_regions);
+    for (const auto& region : memory_regions) {
+        write_val(region.start_address);
+        write_val(region.size);
+    }
+
+    return buffer;
+}
+
+PublishedAllocatorState PublishedAllocatorState::deserialize(const std::vector<uint8_t>& data) {
+    PublishedAllocatorState state;
+    size_t offset = 0;
+
+    auto read_val = [&data, &offset](auto& val) {
+        TT_FATAL(offset + sizeof(val) <= data.size(), "Deserialization buffer underflow");
+        std::memcpy(&val, data.data() + offset, sizeof(val));
+        offset += sizeof(val);
+    };
+
+    auto read_array_2d = [&](auto& arr) {
+        for (auto& inner : arr) {
+            for (auto& val : inner) {
+                read_val(val);
+            }
+        }
+    };
+
+    auto read_array_1d = [&](auto& arr) {
+        for (auto& val : arr) {
+            read_val(val);
+        }
+    };
+
+    // Receiver data
+    read_array_2d(state.receiver_channels_base_address);
+    read_array_2d(state.receiver_channels_num_buffers);
+    read_array_1d(state.num_used_receiver_channels_per_vc);
+
+    // Sender data
+    read_array_2d(state.sender_channels_base_address);
+    read_array_2d(state.sender_channels_num_buffers);
+    read_array_1d(state.num_used_sender_channels_per_vc);
+
+    // Base class construction data
+    read_val(state.topology);
+    read_val(state.options);
+
+    // Memory regions
+    size_t num_regions = 0;
+    read_val(num_regions);
+    state.memory_regions.reserve(num_regions);
+    for (size_t i = 0; i < num_regions; ++i) {
+        size_t start_address = 0, region_size = 0;
+        read_val(start_address);
+        read_val(region_size);
+        state.memory_regions.emplace_back(start_address, region_size);
+    }
+
+    return state;
+}
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/fabric/fabric_builder_context.hpp
+++ b/tt_metal/fabric/fabric_builder_context.hpp
@@ -10,15 +10,70 @@
 #include "erisc_datamover_builder.hpp"
 #include "tt_metal/fabric/fabric_tensix_builder.hpp"
 #include "tt_metal/fabric/channel_trimming_import.hpp"
+#include "tt_metal/fabric/builder/fabric_builder_config.hpp"
+#include "tt_metal/fabric/fabric_init.hpp"
 #include <vector>
 #include <memory>
 #include <array>
+#include <atomic>
+#include <condition_variable>
 #include <limits>
+#include <mutex>
 #include <optional>
+#include <unordered_map>
+#include <utility>
 
 namespace tt::tt_fabric {
 
 class FabricContext;
+
+/**
+ * PublishedAllocatorState
+ *
+ * Per-router allocator state published after phase 1 of fabric build.
+ * Contains the channel layout (base addresses and buffer counts) for both
+ * sender and receiver channels across all VCs. This data allows a peer
+ * device to construct a FabricRemoteChannelsAllocator that accurately
+ * reflects the actual (possibly asymmetric) allocation on the remote side.
+ */
+struct PublishedAllocatorState {
+    // Per-VC receiver channels (what a peer's sender needs to know)
+    std::array<std::array<size_t, builder_config::num_max_receiver_channels>, builder_config::MAX_NUM_VCS>
+        receiver_channels_base_address{};
+    std::array<std::array<size_t, builder_config::num_max_receiver_channels>, builder_config::MAX_NUM_VCS>
+        receiver_channels_num_buffers{};
+    std::array<size_t, builder_config::MAX_NUM_VCS> num_used_receiver_channels_per_vc{};
+
+    // Per-VC sender channels (what a peer's receiver needs to know)
+    std::array<std::array<size_t, builder_config::num_max_sender_channels>, builder_config::MAX_NUM_VCS>
+        sender_channels_base_address{};
+    std::array<std::array<size_t, builder_config::num_max_sender_channels>, builder_config::MAX_NUM_VCS>
+        sender_channels_num_buffers{};
+    std::array<size_t, builder_config::MAX_NUM_VCS> num_used_sender_channels_per_vc{};
+
+    // Base class construction data (needed to construct FabricRemoteChannelsAllocator)
+    Topology topology = Topology::Linear;
+    FabricEriscDatamoverOptions options{};
+    std::vector<MemoryRegion> memory_regions;
+
+    // Serialization support for MPI exchange
+    std::vector<uint8_t> serialize() const;
+    static PublishedAllocatorState deserialize(const std::vector<uint8_t>& data);
+};
+
+/**
+ * Key type for the published allocator state registry.
+ * Identifies a specific router by (chip_id, eth_channel).
+ */
+using AllocatorStateKey = std::pair<ChipId, chan_id_t>;
+
+struct AllocatorStateKeyHash {
+    size_t operator()(const AllocatorStateKey& key) const {
+        auto h1 = std::hash<ChipId>{}(key.first);
+        auto h2 = std::hash<chan_id_t>{}(key.second);
+        return h1 ^ (h2 << 32) ^ (h2 >> 32);
+    }
+};
 
 
 /**
@@ -97,6 +152,23 @@ struct IntermeshVCConfig {
 };
 
 /**
+ * Shared state for the internal barrier in compile_fabric's two-phase build.
+ * Constructor and destructor are out-of-line (in fabric_init.cpp) because
+ * FabricBuildPhase1Result contains unique_ptr<FabricBuilder> (incomplete here).
+ */
+struct FabricBuildBarrier {
+    const std::vector<tt::tt_metal::IDevice*>& all_devices;
+    std::vector<FabricBuildPhase1Result> phase1_results;
+    std::atomic<size_t> phase1_count{0};
+    std::mutex barrier_mutex;
+    std::condition_variable barrier_cv;
+    bool phase1_published = false;
+
+    explicit FabricBuildBarrier(const std::vector<tt::tt_metal::IDevice*>& devices);
+    ~FabricBuildBarrier();
+};
+
+/**
  * FabricBuilderContext
  *
  * Build-time state and config selection for fabric initialization.
@@ -112,7 +184,7 @@ struct IntermeshVCConfig {
 class FabricBuilderContext {
 public:
     explicit FabricBuilderContext(const FabricContext& fabric_context);
-    ~FabricBuilderContext() = default;
+    ~FabricBuilderContext();
 
     // Non-copyable, non-movable (owned by FabricContext)
     FabricBuilderContext(const FabricBuilderContext&) = delete;
@@ -174,6 +246,28 @@ public:
     bool requires_intermesh_vc_full_mesh() const { return intermesh_vc_config_.requires_vc1_full_mesh; }
     bool requires_intermesh_vc_mesh_pass_through() const { return intermesh_vc_config_.requires_vc1_mesh_pass_through; }
 
+    // ============ Published Allocator State Registry ============
+    // Used for peer state exchange between build phases.
+    // Publishing happens on the main thread after phase 1 completes — no mutex needed.
+    void publish_allocator_state(ChipId chip_id, chan_id_t eth_chan, PublishedAllocatorState state);
+    const PublishedAllocatorState& get_published_allocator_state(ChipId chip_id, chan_id_t eth_chan) const;
+    bool has_published_allocator_state(ChipId chip_id, chan_id_t eth_chan) const;
+    // Return any published allocator state (for cases where any router's state suffices).
+    // Falls back to the default allocator state if no per-router states have been published yet
+    // (e.g., during early initialization before builders are created).
+    const PublishedAllocatorState& get_any_published_allocator_state() const;
+
+    // Return the default allocator state computed from the template config.
+    // Available immediately after FabricBuilderContext construction (before builders exist).
+    const PublishedAllocatorState& get_default_allocator_state() const { return default_allocator_state_; }
+
+    // ============ Build Barrier ============
+    // Thread-safe barrier for coordinating the two-phase fabric build.
+    // Created lazily on first call; shared across all threads in one build invocation.
+    struct FabricBuildBarrier& get_or_create_build_barrier(
+        const std::vector<tt::tt_metal::IDevice*>& all_devices);
+    void clear_build_barrier();
+
 private:
 
     IntermeshVCConfig compute_intermesh_vc_config() const;
@@ -213,6 +307,18 @@ private:
 
     // Helper to compute max channel counts for this fabric instance
     void compute_max_channel_counts();
+
+    // Default allocator state computed from template config at construction time.
+    // Available before builders exist (used by populate_fabric_connection_info during init).
+    PublishedAllocatorState default_allocator_state_;
+
+    // Published allocator state registry — keyed by (chip_id, eth_channel).
+    // Published on main thread after phase 1; read on worker threads in phase 2.
+    std::unordered_map<AllocatorStateKey, PublishedAllocatorState, AllocatorStateKeyHash> published_allocator_state_;
+
+    // Build barrier for two-phase fabric build coordination.
+    std::unique_ptr<FabricBuildBarrier> build_barrier_;
+    std::mutex build_barrier_mutex_;
 };
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/fabric/fabric_init.cpp
+++ b/tt_metal/fabric/fabric_init.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt-metalium/experimental/fabric/fabric.hpp>
+#include "tt_metal/fabric/fabric_init.hpp"
 
 #include "tt_metal.hpp"
 #include "tt_metal/fabric/fabric_context.hpp"
@@ -20,16 +21,65 @@ bool isFabricUnitTest() { return false; }
 
 namespace tt::tt_fabric {
 
-std::unique_ptr<tt::tt_metal::Program> create_and_compile_tt_fabric_program(tt::tt_metal::IDevice* device) {
+// FabricBuildBarrier — shared state for the internal barrier in compile_fabric.
+// Defined here because FabricBuildPhase1Result contains unique_ptr<FabricBuilder>
+// which requires the complete type (available in this TU via fabric_builder.hpp).
+FabricBuildBarrier::FabricBuildBarrier(const std::vector<tt::tt_metal::IDevice*>& devices) :
+    all_devices(devices), phase1_results(devices.size()) {}
+FabricBuildBarrier::~FabricBuildBarrier() = default;
+
+namespace {
+
+FabricBuildPhase1Result fabric_build_phase1(tt::tt_metal::IDevice* device) {
     auto fabric_program_ptr = std::make_unique<tt::tt_metal::Program>();
 
     const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     auto& fabric_context = control_plane.get_fabric_context();
 
-    // Use FabricBuilder to coordinate the build phases
+    auto builder = std::make_unique<FabricBuilder>(device, *fabric_program_ptr, fabric_context);
+
+    builder->discover_channels();
+    builder->create_routers();
+
+    if (!builder->has_routers()) {
+        return FabricBuildPhase1Result{nullptr, nullptr, false};
+    }
+
+    return FabricBuildPhase1Result{std::move(builder), std::move(fabric_program_ptr), true};
+}
+
+std::unique_ptr<tt::tt_metal::Program> fabric_build_phase2(
+    tt::tt_metal::IDevice* device, FabricBuildPhase1Result phase1_result) {
+    if (!phase1_result.has_routers || !phase1_result.builder) {
+        return nullptr;
+    }
+
+    auto& builder = *phase1_result.builder;
+    auto& program = *phase1_result.program;
+
+    // Update remote allocators from peer state (published during the barrier between phases)
+    builder.update_remote_allocators();
+
+    builder.connect_routers();
+    builder.compile_ancillary_kernels();
+    builder.create_kernels();
+
+    tt::tt_metal::detail::CompileProgram(
+        device, program, tt::tt_metal::MetalContext::instance().rtoptions().get_fast_dispatch());
+
+    return std::move(phase1_result.program);
+}
+
+// Single-phase path: full build (used by TERMINATE_FABRIC and when all_devices is empty)
+std::unique_ptr<tt::tt_metal::Program> create_and_compile_tt_fabric_program_single_phase(
+    tt::tt_metal::IDevice* device) {
+    auto fabric_program_ptr = std::make_unique<tt::tt_metal::Program>();
+
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    auto& fabric_context = control_plane.get_fabric_context();
+
     FabricBuilder builder(device, *fabric_program_ptr, fabric_context);
 
-    // Execute build phases
     builder.discover_channels();
     builder.create_routers();
     if (!builder.has_routers()) {
@@ -40,19 +90,82 @@ std::unique_ptr<tt::tt_metal::Program> create_and_compile_tt_fabric_program(tt::
     builder.compile_ancillary_kernels();
     builder.create_kernels();
 
-    // Compile the program
     tt::tt_metal::detail::CompileProgram(
         device, *fabric_program_ptr, tt::tt_metal::MetalContext::instance().rtoptions().get_fast_dispatch());
 
     return fabric_program_ptr;
 }
 
-std::unique_ptr<tt::tt_metal::Program> create_and_compile_fabric_program(tt::tt_metal::IDevice* device) {
-    auto fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
-    if (tt_fabric::is_tt_fabric_config(fabric_config)) {
-        return create_and_compile_tt_fabric_program(device);
+// Two-phase path: uses barrier to coordinate with other devices.
+// Each thread calls this for its own device. The barrier ensures all devices
+// complete phase 1 before any proceeds to phase 2.
+std::unique_ptr<tt::tt_metal::Program> create_and_compile_tt_fabric_program_two_phase(
+    tt::tt_metal::IDevice* device, const std::vector<tt::tt_metal::IDevice*>& all_devices) {
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    auto& fabric_context = control_plane.get_fabric_context();
+    auto& builder_context = fabric_context.get_builder_context();
+
+    // Find this device's index
+    size_t device_index = 0;
+    for (size_t i = 0; i < all_devices.size(); ++i) {
+        if (all_devices[i]->id() == device->id()) {
+            device_index = i;
+            break;
+        }
     }
-    return nullptr;
+
+    auto& barrier = builder_context.get_or_create_build_barrier(all_devices);
+
+    // Phase 1: discover channels, create routers with servicing-aware allocators
+    barrier.phase1_results[device_index] = fabric_build_phase1(device);
+
+    // Signal phase 1 completion and wait for all devices
+    size_t completed = barrier.phase1_count.fetch_add(1) + 1;
+    if (completed == all_devices.size()) {
+        // Last thread: collect and publish allocator state from all builders
+        for (auto& result : barrier.phase1_results) {
+            if (result.builder) {
+                auto states = result.builder->collect_published_allocator_state();
+                for (auto& [key, state] : states) {
+                    builder_context.publish_allocator_state(key.first, key.second, std::move(state));
+                }
+            }
+        }
+
+        // TODO: MPI exchange for multi-host (Galaxy) — exchange published allocator state
+        // with other hosts using DistributedContext::broadcast() following the pattern
+        // in control_plane.cpp::collect_and_merge_router_port_directions_from_all_hosts().
+        // For now, single-host mode works because all devices are local.
+
+        // Release all waiting threads
+        {
+            std::lock_guard<std::mutex> lock(barrier.barrier_mutex);
+            barrier.phase1_published = true;
+        }
+        barrier.barrier_cv.notify_all();
+    } else {
+        // Wait for the last thread to finish publishing
+        std::unique_lock<std::mutex> lock(barrier.barrier_mutex);
+        barrier.barrier_cv.wait(lock, [&] { return barrier.phase1_published; });
+    }
+
+    // Phase 2: update remote allocators from peer state, connect, compile
+    return fabric_build_phase2(device, std::move(barrier.phase1_results[device_index]));
+}
+
+}  // anonymous namespace
+
+std::unique_ptr<tt::tt_metal::Program> create_and_compile_fabric_program(
+    tt::tt_metal::IDevice* device, const std::vector<tt::tt_metal::IDevice*>& all_devices) {
+    auto fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
+    if (!tt_fabric::is_tt_fabric_config(fabric_config)) {
+        return nullptr;
+    }
+
+    if (all_devices.empty()) {
+        return create_and_compile_tt_fabric_program_single_phase(device);
+    }
+    return create_and_compile_tt_fabric_program_two_phase(device, all_devices);
 }
 
 void configure_fabric_cores(tt::tt_metal::IDevice* device) {

--- a/tt_metal/fabric/fabric_init.hpp
+++ b/tt_metal/fabric/fabric_init.hpp
@@ -6,11 +6,30 @@
 
 #include "device.hpp"
 #include "tt_metal.hpp"
+#include <memory>
+#include <vector>
 
 namespace tt::tt_fabric {
 
-// Compile fabric kernels needed to support scaleout systems.
-std::unique_ptr<tt::tt_metal::Program> create_and_compile_fabric_program(tt::tt_metal::IDevice* device);
+class FabricBuilder;
+
+/**
+ * Result of fabric build phase 1.
+ * Contains the builder (with servicing-aware allocators) and the program
+ * for use in phase 2 after peer state exchange.
+ */
+struct FabricBuildPhase1Result {
+    std::unique_ptr<FabricBuilder> builder;
+    std::unique_ptr<tt::tt_metal::Program> program;
+    bool has_routers = false;
+};
+
+// Build and compile the fabric program for a device.
+// When all_devices is non-empty, uses a two-phase build with an internal barrier
+// to coordinate allocator state exchange across all devices before compilation.
+// When all_devices is empty, uses the single-phase full build.
+std::unique_ptr<tt::tt_metal::Program> create_and_compile_fabric_program(
+    tt::tt_metal::IDevice* device, const std::vector<tt::tt_metal::IDevice*>& all_devices = {});
 
 // Perform additional configuration (writing to specific L1 addresses, etc.) for fabric kernels on this device.
 void configure_fabric_cores(tt::tt_metal::IDevice* device);

--- a/tt_metal/fabric/fabric_mux_config.cpp
+++ b/tt_metal/fabric/fabric_mux_config.cpp
@@ -12,7 +12,6 @@
 #include "tt_metal/fabric/fabric_builder_context.hpp"
 #include <umd/device/types/core_coordinates.hpp>
 #include <enchantum/enchantum.hpp>
-#include "tt_metal/fabric/builder/fabric_static_sized_channels_allocator.hpp"
 namespace tt::tt_fabric {
 
 // Implementation of nested MemoryRegion methods
@@ -219,12 +218,8 @@ std::vector<uint32_t> FabricMuxConfig::get_fabric_mux_compile_time_args() const 
         const auto& fabric_tensix_config = builder_context.get_tensix_config();
         fabric_endpoint_channel_num_buffers_ = fabric_tensix_config.get_num_buffers_per_channel();
     } else {
-        auto* channel_allocator = fabric_router_config.channel_allocator.get();
-        auto* const static_channel_allocator =
-            dynamic_cast<tt::tt_fabric::FabricStaticSizedChannelsAllocator*>(channel_allocator);
-        TT_FATAL(
-            static_channel_allocator != nullptr, "Channel allocator must be a FabricStaticSizedChannelsAllocator.");
-        fabric_endpoint_channel_num_buffers_ = static_channel_allocator->get_sender_channel_number_of_slots(0);
+        const auto& pub_state = builder_context.get_any_published_allocator_state();
+        fabric_endpoint_channel_num_buffers_ = pub_state.sender_channels_num_buffers[0][0];
     }
     fabric_endpoint_status_address_ = fabric_router_config.edm_status_address;
 
@@ -234,18 +229,15 @@ std::vector<uint32_t> FabricMuxConfig::get_fabric_mux_compile_time_args() const 
 }
 
 std::vector<uint32_t> FabricMuxConfig::get_fabric_mux_compile_time_args_for_relay_mux() const {
-    const auto& fabric_router_config = tt::tt_metal::MetalContext::instance()
-                                           .get_control_plane()
-                                           .get_fabric_context()
-                                           .get_builder_context()
-                                           .get_fabric_router_config();
-    auto* channel_allocator = fabric_router_config.channel_allocator.get();
-    auto* const static_channel_allocator =
-        dynamic_cast<tt::tt_fabric::FabricStaticSizedChannelsAllocator*>(channel_allocator);
-    TT_FATAL(static_channel_allocator != nullptr, "Channel allocator must be a FabricStaticSizedChannelsAllocator.");
+    const auto& builder_context = tt::tt_metal::MetalContext::instance()
+                                      .get_control_plane()
+                                      .get_fabric_context()
+                                      .get_builder_context();
+    const auto& fabric_router_config = builder_context.get_fabric_router_config();
 
-    // For relay mux, always use fabric router config
-    fabric_endpoint_channel_num_buffers_ = static_channel_allocator->get_sender_channel_number_of_slots(0);
+    // Use published allocator state for per-router sender channel num buffers
+    const auto& pub_state = builder_context.get_any_published_allocator_state();
+    fabric_endpoint_channel_num_buffers_ = pub_state.sender_channels_num_buffers[0][0];
     wait_for_fabric_endpoint_ready_ = true;
     fabric_endpoint_status_address_ = fabric_router_config.edm_status_address;
 

--- a/tt_metal/fabric/fabric_router_builder.hpp
+++ b/tt_metal/fabric/fabric_router_builder.hpp
@@ -17,6 +17,8 @@ class Program;
 
 namespace tt::tt_fabric {
 
+struct PublishedAllocatorState;
+
 // ============ Router Location ============
 
 /**
@@ -124,6 +126,22 @@ public:
     RoutingDirection get_routing_direction() const { return location_.direction; }
     bool is_dispatch_link() const { return location_.is_dispatch_link; }
     const RouterLocation& get_location() const { return location_; }
+
+    // ============ Allocator State ============
+
+    /**
+     * Get the published allocator state for this router.
+     * Used for collecting per-router state after phase 1 for peer exchange.
+     */
+    virtual PublishedAllocatorState get_published_allocator_state() const = 0;
+
+    /**
+     * Update the remote allocator from a peer's published state.
+     * Called in phase 2 after peer state has been published to FabricBuilderContext.
+     *
+     * @param peer_state The peer's published allocator state
+     */
+    virtual void update_remote_allocator(const PublishedAllocatorState& peer_state) = 0;
 
     // ============ Build Methods ============
 

--- a/tt_metal/fabric/fabric_tensix_builder_impl.cpp
+++ b/tt_metal/fabric/fabric_tensix_builder_impl.cpp
@@ -16,7 +16,6 @@
 #include "tt_metal/fabric/fabric_host_utils.hpp"
 #include "tt_metal/fabric/fabric_router_builder.hpp"
 #include "dispatch/kernel_config/relay_mux.hpp"
-#include "tt_metal/fabric/builder/fabric_static_sized_channels_allocator.hpp"
 #include "tt_metal/fabric/builder/fabric_builder_helpers.hpp"
 #include "tt_align.hpp"
 #include <bit>
@@ -463,12 +462,23 @@ std::vector<uint32_t> FabricTensixDatamoverMuxConfig::get_compile_time_args(
     const auto& fabric_router_config =
         fabric_context.get_builder_context().get_fabric_router_config(fabric_tensix_config);
 
-    auto* channel_allocator = fabric_router_config.channel_allocator.get();
-    auto* const static_channel_allocator =
-        dynamic_cast<tt::tt_fabric::FabricStaticSizedChannelsAllocator*>(channel_allocator);
-    TT_FATAL(static_channel_allocator != nullptr, "Channel allocator must be a FabricStaticSizedChannelsAllocator.");
-
-    fabric_endpoint_channel_num_buffers_ = static_channel_allocator->get_sender_channel_number_of_slots(0);
+    // Resolve (fabric_node_id, routing_plane_id) → (chip_id, eth_channel) to look up
+    // per-router PublishedAllocatorState for the sender channel num buffers.
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    ChipId chip_id = control_plane.get_physical_chip_id_from_fabric_node_id(fabric_node_id);
+    auto routing_direction = control_plane.eth_direction_to_routing_direction(direction);
+    auto eth_channels = control_plane.get_active_fabric_eth_channels_in_direction(fabric_node_id, routing_direction);
+    TT_FATAL(
+        routing_plane_id < eth_channels.size(),
+        "routing_plane_id {} exceeds available eth channels {} for fabric_node_id M={},D={} direction {}",
+        routing_plane_id,
+        eth_channels.size(),
+        fabric_node_id.mesh_id,
+        fabric_node_id.chip_id,
+        static_cast<int>(direction));
+    chan_id_t eth_channel = eth_channels[routing_plane_id];
+    const auto& pub_state = fabric_context.get_builder_context().get_published_allocator_state(chip_id, eth_channel);
+    fabric_endpoint_channel_num_buffers_ = pub_state.sender_channels_num_buffers[0][0];
     fabric_endpoint_status_address_ = fabric_router_config.edm_status_address;
     wait_for_fabric_endpoint_ready_ = true;
 

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -355,8 +355,8 @@ void Device::init_command_queue_device_with_topology(DispatchTopology* topo) {
 
 void Device::init_command_queue_device() { TT_FATAL(false, "Call init_command_queue_device_with_topology instead"); }
 
-bool Device::compile_fabric() {
-    fabric_program_ = tt::tt_fabric::create_and_compile_fabric_program(this);
+bool Device::compile_fabric(const std::vector<IDevice*>& all_devices) {
+    fabric_program_ = tt::tt_fabric::create_and_compile_fabric_program(this, all_devices);
     return fabric_program_ != nullptr;
 }
 

--- a/tt_metal/impl/device/device_impl.hpp
+++ b/tt_metal/impl/device/device_impl.hpp
@@ -136,7 +136,7 @@ public:
 
     void init_command_queue_device_with_topology(DispatchTopology* topology);
 
-    bool compile_fabric() override;
+    bool compile_fabric(const std::vector<IDevice*>& all_devices = {}) override;
     void configure_fabric() override;
     // Puts device into reset
     bool close() override;

--- a/tt_metal/impl/device/firmware/fabric_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/fabric_firmware_initializer.cpp
@@ -140,11 +140,13 @@ void FabricFirmwareInitializer::post_teardown() {
 bool FabricFirmwareInitializer::is_initialized() const { return initialized_; }
 
 void FabricFirmwareInitializer::compile_and_configure_fabric() {
+    std::vector<tt::tt_metal::IDevice*> idevices(devices_.begin(), devices_.end());
+
     std::vector<std::shared_future<Device*>> events;
     events.reserve(devices_.size());
     for (auto* dev : devices_) {
-        events.emplace_back(detail::async([dev]() {
-            if (dev->compile_fabric()) {
+        events.emplace_back(detail::async([dev, &idevices]() {
+            if (dev->compile_fabric(idevices)) {
                 return dev;
             }
             // Compile failure mostly comes from Nebula (TG)


### PR DESCRIPTION
Necessary for dynamic trimming. Simplifies allocator logic for when we have different router types with different channel counts and we want efficient L1 usage.

This results in some relatively deep changes to the fabric router build flow, particularly around how we synchronize across threads/ranks. In particular, there is a new sync point required after all builders are done with their channel allocator phases so that they can share channel allocations. This is necessary when routers have non uniform allocation so that they can see their peer allocator state (channel base addresses, sizes, and so on).

```
   MAIN THREAD
   ───────────
        │
        ▼
   ┌─ Stage 1: write_routing_tables_to_all_chips() ──── SINGLE THREAD ──┐
   │                                                                     │
   │  populate_fabric_connection_info()                                  │
   │    └─ default_allocator_state_   ◄── computed from template config  │
   │       └─ pub_state.sender_channels_base_address[0][0]               │
   └──────────────────────────┬──────────────────────────────────────────┘
                              │
                              ▼
   ┌─ Stage 2: compile_and_configure_fabric() ──────────────────────────┐
   │                                                                     │
   │  Thread 0              Thread 1              Thread N-1             │
   │  ┌───────────────┐     ┌───────────────┐     ┌───────────────┐     │
   │  │ PHASE 1       │     │ PHASE 1       │     │ PHASE 1       │     │
   │  │discover_chans │     │discover_chans │     │discover_chans │     │
   │  │create_routers │     │create_routers │     │create_routers │     │
   │  │ alloc on      │     │ alloc on      │     │ alloc on      │     │
   │  │ BUILDER (own) │     │ BUILDER (own) │     │ BUILDER (own) │     │
   │  └───────┬───────┘     └───────┬───────┘     └───────┬───────┘     │
   │          ▼                     ▼                     ▼             │
   │  ════════╪═════════════════════╪═════════════════════╪═══════════  │
   │  BARRIER │ last thread: collect + publish all state  │             │
   │  ════════╪═════════════════════╪═════════════════════╪═══════════  │
   │          ▼                     ▼                     ▼             │
   │  ┌───────────────┐     ┌───────────────┐     ┌───────────────┐     │
   │  │ PHASE 2       │     │ PHASE 2       │     │ PHASE 2       │     │
   │  │update_remote  │     │update_remote  │     │update_remote  │     │
   │  │ (peer state)  │     │ (peer state)  │     │ (peer state)  │     │
   │  │connect_routers│     │connect_routers│     │connect_routers│     │
   │  │compile+create │     │compile+create │     │compile+create │     │
   │  └───────────────┘     └───────────────┘     └───────────────┘     │
   └──────────────────────────┬──────────────────────────────────────────┘
                              ▼
        for each device: dev->configure_fabric()  [SEQUENTIAL]
```

### Prior Approach
```
   MAIN THREAD                                                                                                                                                           
   ───────────    
        │                                                                                                                                                                
        ▼                                                                                                                                                                
   ┌─ Stage 1: write_routing_tables_to_all_chips() ──── SINGLE THREAD ──┐
   │                                                                     │
   │  populate_fabric_connection_info()                                  │
   │    └─ config.channel_allocator   ◄── shared template allocator      │
   │       └─ dynamic_cast → get_sender_channel_base_address(0)          │
   └──────────────────────────┬──────────────────────────────────────────┘
                              │
                              ▼
   ┌─ Stage 2: compile_and_configure_fabric() ──────────────────────────┐
   │                                                                     │
   │  Thread 0              Thread 1              Thread N-1             │
   │  ┌───────────────┐     ┌───────────────┐     ┌───────────────┐     │
   │  │discover_chans │     │discover_chans │     │discover_chans │     │
   │  │create_routers │     │create_routers │     │create_routers │     │
   │  │ ⚠ replaces    │     │ ⚠ replaces    │     │ ⚠ replaces    │     │
   │  │ config.alloc  │     │ config.alloc  │     │ config.alloc  │     │
   │  │ (SHARED!)     │     │ (SHARED!)     │     │ (SHARED!)     │     │
   │  │connect_routers│     │connect_routers│     │connect_routers│     │
   │  │ ⚠ reads peer  │     │ ⚠ reads peer  │     │ ⚠ reads peer  │     │
   │  │ (RACE!)       │     │ (RACE!)       │     │ (RACE!)       │     │
   │  │compile+create │     │compile+create │     │compile+create │     │
   │  └───────────────┘     └───────────────┘     └───────────────┘     │
   │         NO BARRIER — threads fully independent                      │
   └──────────────────────────┬──────────────────────────────────────────┘
                              ▼
        for each device: dev->configure_fabric()  [SEQUENTIAL]
```

### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=snijjar/optimize-fabric-channel-allocator-when-unserviced-channels-present-issue-36861)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:snijjar/optimize-fabric-channel-allocator-when-unserviced-channels-present-issue-36861)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snijjar/optimize-fabric-channel-allocator-when-unserviced-channels-present-issue-36861)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snijjar/optimize-fabric-channel-allocator-when-unserviced-channels-present-issue-36861)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snijjar/optimize-fabric-channel-allocator-when-unserviced-channels-present-issue-36861)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snijjar/optimize-fabric-channel-allocator-when-unserviced-channels-present-issue-36861)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snijjar/optimize-fabric-channel-allocator-when-unserviced-channels-present-issue-36861)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snijjar/optimize-fabric-channel-allocator-when-unserviced-channels-present-issue-36861)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snijjar/optimize-fabric-channel-allocator-when-unserviced-channels-present-issue-36861)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snijjar/optimize-fabric-channel-allocator-when-unserviced-channels-present-issue-36861)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snijjar/optimize-fabric-channel-allocator-when-unserviced-channels-present-issue-36861)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snijjar/optimize-fabric-channel-allocator-when-unserviced-channels-present-issue-36861)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
