### PR TITLE
Add APIs to support manual Socket and Pipeline Block Allocation

### DIFF
--- a/models/demos/deepseek_v3_b1/micro_ops/d2d_exchange/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/d2d_exchange/op.py
@@ -54,6 +54,9 @@ class SocketInterface:
         receiver_mesh=None,
         sender_packet_header_cb_index=None,
         receiver_packet_header_cb_index=None,
+        sender_config_buffer_address=None,
+        receiver_config_buffer_address=None,
+        data_buffer_address=None,
     ):
         assert (
             sender_mesh.get_mesh_device() or receiver_mesh.get_mesh_device()
@@ -84,7 +87,14 @@ class SocketInterface:
             else:
                 # Upstream socket not provided, create a new socket, on the sender mesh
                 socket_connection = ttnn.SocketConnection(upstream_core_coord, send_core_coord)
-                socket_memory_config = ttnn.SocketMemoryConfig(ttnn.BufferType.L1, socket_fifo_size)
+                # In this case, the sender is the upstream, the receiver is the pipeline core
+                socket_memory_config = ttnn.SocketMemoryConfig(
+                    ttnn.BufferType.L1,
+                    socket_fifo_size,
+                    data_buffer_address=data_buffer_address,
+                    sender_config_buffer_address=sender_config_buffer_address,
+                    receiver_config_buffer_address=receiver_config_buffer_address,
+                )
                 socket_config = ttnn.SocketConfig([socket_connection], socket_memory_config)
                 self.upstream_socket_pair = ttnn.create_socket_pair(self.mesh_device, self.mesh_device, socket_config)
                 # Initialize upstream as receiver socket
@@ -98,7 +108,14 @@ class SocketInterface:
                 assert downstream_core_coord is None
             else:
                 socket_connection = ttnn.SocketConnection(recv_core_coord, downstream_core_coord)
-                socket_memory_config = ttnn.SocketMemoryConfig(ttnn.BufferType.L1, socket_fifo_size)
+                # In this case, the sender is the pipeline core, the receiver is the downstream
+                socket_memory_config = ttnn.SocketMemoryConfig(
+                    ttnn.BufferType.L1,
+                    socket_fifo_size,
+                    data_buffer_address=data_buffer_address,
+                    sender_config_buffer_address=sender_config_buffer_address,
+                    receiver_config_buffer_address=receiver_config_buffer_address,
+                )
                 socket_config = ttnn.SocketConfig([socket_connection], socket_memory_config)
                 self.downstream_socket_pair = ttnn.create_socket_pair(self.mesh_device, self.mesh_device, socket_config)
                 # Initialize downstream as sender socket
@@ -110,7 +127,14 @@ class SocketInterface:
 
         # Create a socket between the sender and receiver cores
         socket_connection = ttnn.SocketConnection(send_core_coord, recv_core_coord)
-        socket_memory_config = ttnn.SocketMemoryConfig(ttnn.BufferType.L1, socket_fifo_size)
+        # In this case the sender is the pipeline core at stage n - 1 and the receiver is the pipeline core at stage n
+        socket_memory_config = ttnn.SocketMemoryConfig(
+            ttnn.BufferType.L1,
+            socket_fifo_size,
+            data_buffer_address=data_buffer_address,
+            sender_config_buffer_address=sender_config_buffer_address,
+            receiver_config_buffer_address=receiver_config_buffer_address,
+        )
 
         if self.local_socket:
             # If running on a host/process where the sender and receiver meshes are the local mesh, create a local socket pair

--- a/models/demos/deepseek_v3_b1/micro_ops/host_io/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/host_io/op.py
@@ -50,6 +50,9 @@ class HostInterface:
         loopback_mode=False,
         embedding_cb_index=None,
         fabric_packet_header_cb_index=None,
+        sender_config_buffer_address=None,
+        receiver_config_buffer_address=None,
+        data_buffer_address=None,
     ):
         self.h2d_socket = h2d_socket
         self.d2h_socket = d2h_socket
@@ -108,16 +111,30 @@ class HostInterface:
                 self.d2h_upstream_core,
                 self.d2h_mesh_core_coord,
             )
-            socket_memory_config = ttnn.SocketMemoryConfig(ttnn.BufferType.L1, core_to_core_socket_buffer_size)
+            downstream_socket_memory_config = ttnn.SocketMemoryConfig(
+                ttnn.BufferType.L1,
+                core_to_core_socket_buffer_size,
+                data_buffer_address=data_buffer_address,
+                sender_config_buffer_address=sender_config_buffer_address,
+                receiver_config_buffer_address=receiver_config_buffer_address,
+            )
+
+            upstream_socket_memory_config = ttnn.SocketMemoryConfig(
+                ttnn.BufferType.L1,
+                core_to_core_socket_buffer_size,
+                data_buffer_address=data_buffer_address,
+                sender_config_buffer_address=sender_config_buffer_address,
+                receiver_config_buffer_address=receiver_config_buffer_address,
+            )
 
             downstream_socket_config = ttnn.SocketConfig(
                 [downstream_socket_connection],
-                socket_memory_config,
+                downstream_socket_memory_config,
             )
 
             upstream_socket_config = ttnn.SocketConfig(
                 [upstream_socket_connection],
-                socket_memory_config,
+                upstream_socket_memory_config,
             )
 
             self.downstream_socket_pair = ttnn.create_socket_pair(

--- a/models/demos/deepseek_v3_b1/micro_ops/pipeline_block/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/pipeline_block/op.py
@@ -42,6 +42,9 @@ class PipelineBlock:
         entry_node_downstream=None,
         exit_node_upstream=None,
         embedding_tensor=None,
+        sender_config_buffer_address=None,
+        receiver_config_buffer_address=None,
+        data_buffer_address=None,
     ):
         assert (
             upstream_d2d_socket_fifo_size >= upstream_d2d_socket_page_size
@@ -91,11 +94,15 @@ class PipelineBlock:
                 ttnn.BufferType.L1,
                 h2d_socket_fifo_size,
                 ttnn.H2DMode.HOST_PUSH,  # Host Push is faster than Device Pull for small page sizes
+                config_buffer_address=receiver_config_buffer_address,
+                data_buffer_address=data_buffer_address,
             )
             self.d2h_socket = ttnn.D2HSocket(
-                mesh_device, ttnn.MeshCoreCoord(d2h_device_coord, pipeline_core_coord), d2h_socket_fifo_size
+                mesh_device,
+                ttnn.MeshCoreCoord(d2h_device_coord, pipeline_core_coord),
+                d2h_socket_fifo_size,
+                config_buffer_address=sender_config_buffer_address,
             )
-
             self.host_io = HostInterface(
                 self.h2d_socket,
                 self.d2h_socket,
@@ -107,8 +114,10 @@ class PipelineBlock:
                 ),
                 d2h_upstream_core=ttnn.MeshCoreCoord(pipeline_config[num_procs].entry_node_coord, pipeline_core_coord),
                 embedding_tensor=embedding_tensor,
+                sender_config_buffer_address=sender_config_buffer_address,
+                receiver_config_buffer_address=receiver_config_buffer_address,
+                data_buffer_address=data_buffer_address,
             )
-
             self.exit_socket_interface = SocketInterface(
                 downstream_d2d_socket_page_size,
                 downstream_d2d_socket_fifo_size,
@@ -118,6 +127,9 @@ class PipelineBlock:
                 upstream_socket=self.host_io.get_downstream_socket(),
                 sender_mesh=MeshWrapper(mesh_device),
                 receiver_mesh=MeshWrapper(mesh_id=self.my_mesh_id + 1),
+                sender_config_buffer_address=sender_config_buffer_address,
+                receiver_config_buffer_address=receiver_config_buffer_address,
+                data_buffer_address=data_buffer_address,
             )
 
             self.entry_socket_interface = SocketInterface(
@@ -129,6 +141,9 @@ class PipelineBlock:
                 downstream_socket=self.host_io.get_upstream_socket(),
                 sender_mesh=MeshWrapper(mesh_id=num_procs - 1),
                 receiver_mesh=MeshWrapper(mesh_device),
+                sender_config_buffer_address=sender_config_buffer_address,
+                receiver_config_buffer_address=receiver_config_buffer_address,
+                data_buffer_address=data_buffer_address,
             )
 
         else:
@@ -143,6 +158,9 @@ class PipelineBlock:
                 else ttnn.MeshCoreCoord(pipeline_config[self.my_mesh_id].exit_node_coord, pipeline_core_coord),
                 sender_mesh=MeshWrapper(mesh_id=self.my_mesh_id - 1),
                 receiver_mesh=MeshWrapper(mesh_device),
+                sender_config_buffer_address=sender_config_buffer_address,
+                receiver_config_buffer_address=receiver_config_buffer_address,
+                data_buffer_address=data_buffer_address,
             )
             self.exit_socket_interface = SocketInterface(
                 downstream_d2d_socket_page_size,
@@ -154,6 +172,9 @@ class PipelineBlock:
                 upstream_socket=self.entry_socket_interface.get_downstream_socket() if not exit_node_upstream else None,
                 sender_mesh=MeshWrapper(mesh_device),
                 receiver_mesh=MeshWrapper(mesh_id=self.my_mesh_id + 1 if self.my_mesh_id < num_procs - 1 else 0),
+                sender_config_buffer_address=sender_config_buffer_address,
+                receiver_config_buffer_address=receiver_config_buffer_address,
+                data_buffer_address=data_buffer_address,
             )
 
     def run(self):

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_multi_host_pipeline.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_multi_host_pipeline.py
@@ -441,6 +441,10 @@ def test_multi_host_loopback_pipeline_with_embedding(
     ],
 )
 @pytest.mark.parametrize(
+    "manual_allocation",
+    [True, False],
+)
+@pytest.mark.parametrize(
     "mesh_device",
     [(4, 2)],
     indirect=True,
@@ -455,7 +459,9 @@ def test_multi_host_loopback_pipeline_with_embedding(
     ],
     indirect=True,
 )
-def test_pipeline_block(mesh_device, vocab_size, embedding_dim, token_fifo_size, embedding_fifo_factor):
+def test_pipeline_block(
+    mesh_device, vocab_size, embedding_dim, token_fifo_size, embedding_fifo_factor, manual_allocation
+):
     if not is_slow_dispatch():
         pytest.skip("Skipping test in fast dispatch mode")
 
@@ -467,6 +473,15 @@ def test_pipeline_block(mesh_device, vocab_size, embedding_dim, token_fifo_size,
     embedding_shape = (1, 1, vocab_size, embedding_dim)
     embedding_size_bytes = embedding_dim * dtype_size(embedding_dtype)
     embedding_fifo_size = embedding_size_bytes * embedding_fifo_factor
+
+    if manual_allocation:
+        sender_config_buffer_address = 1024 * 1024  # Allocate sender config buf at 1MB
+        receiver_config_buffer_address = 1024 * 1024 + 128  # Allocate receiver config 128 bytes after sender config
+        data_buffer_address = 1024 * 1024 + 256  # Allocate data buffer 256 bytes after sender config buffer
+    else:
+        sender_config_buffer_address = None
+        receiver_config_buffer_address = None
+        data_buffer_address = None
 
     if mesh_device.get_system_mesh_id() == 0:
         torch_embedding = torch.randn(embedding_shape, dtype=embedding_dtype)
@@ -485,6 +500,9 @@ def test_pipeline_block(mesh_device, vocab_size, embedding_dim, token_fifo_size,
             d2h_socket_fifo_size=embedding_fifo_size,  # d2h socket fifo size
             d2h_socket_page_size=embedding_size_bytes,  # d2h socket page size
             embedding_tensor=embedding_tensor,
+            sender_config_buffer_address=sender_config_buffer_address,
+            receiver_config_buffer_address=receiver_config_buffer_address,
+            data_buffer_address=data_buffer_address,
         )
     else:
         pipeline_block = PipelineBlock(
@@ -494,6 +512,9 @@ def test_pipeline_block(mesh_device, vocab_size, embedding_dim, token_fifo_size,
             embedding_fifo_size,  # downstream d2d socket fifo size
             embedding_size_bytes,  # upstream d2d socket page size
             embedding_size_bytes,  # downstream d2d socket page size
+            sender_config_buffer_address=sender_config_buffer_address,
+            receiver_config_buffer_address=receiver_config_buffer_address,
+            data_buffer_address=data_buffer_address,
         )
 
     pipeline_block.run()

--- a/tests/tt_metal/distributed/test_mesh_socket.cpp
+++ b/tests/tt_metal/distributed/test_mesh_socket.cpp
@@ -2155,6 +2155,48 @@ TEST_F(MeshSocketTest, MultiConnectionSingleDeviceSocketWithWorkersLoopAck) {
     test_single_device_socket_with_workers(md0, 4096, 1088, 9792, socket_core_mappings, false);
 }
 
+// Create Socket Config and Data Buffers and arbitary addresses dor 10 iterations
+// and ensure that the sockets are created correctly with the correct addresses
+// Multiple iterations allow us to ensure that the allocator is not mimicing the
+// correct behaviour by chance.
+TEST_F(MeshSocketTest, ManualAllocations) {
+    auto md0 = mesh_device_->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 0));
+    auto md1 = mesh_device_->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 0));
+
+    constexpr uint32_t socket_fifo_size = 1024;
+    auto sender_logical_coord = CoreCoord(0, 0);
+    auto recv_logical_coord = CoreCoord(0, 0);
+
+    SocketConnection socket_connection(
+        MeshCoreCoord(MeshCoordinate(0, 0), sender_logical_coord),
+        MeshCoreCoord(MeshCoordinate(0, 0), recv_logical_coord));
+
+    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+    uint32_t l1_unreserved_base = hal.get_dev_addr(
+        tt::tt_metal::HalProgrammableCoreType::TENSIX, tt::tt_metal::HalL1MemAddrType::DEFAULT_UNRESERVED);
+
+    for (int i = 0; i < 10; i++) {
+        uint32_t config_buffer_addr = l1_unreserved_base + i * hal.get_alignment(HalMemType::L1);
+        uint32_t data_buffer_addr = config_buffer_addr + socket_fifo_size;
+
+        SocketMemoryConfig socket_mem_config(
+            BufferType::L1,
+            socket_fifo_size,
+            std::nullopt,  // sender sub device
+            std::nullopt,  // receiver sub device
+            data_buffer_addr,
+            config_buffer_addr,
+            config_buffer_addr);
+
+        SocketConfig socket_config({socket_connection}, socket_mem_config);
+        auto [send_socket, recv_socket] = MeshSocket::create_socket_pair(md0, md1, socket_config);
+
+        EXPECT_EQ(send_socket.get_config_buffer()->address(), config_buffer_addr);
+        EXPECT_EQ(recv_socket.get_config_buffer()->address(), config_buffer_addr);
+        EXPECT_EQ(recv_socket.get_data_buffer()->address(), data_buffer_addr);
+    }
+}
+
 // ========= Multi Device Data Movement Tests (1D Fabric) =========
 
 TEST_F(MeshSocketTest1DFabric, SingleConnectionMultiDeviceSocketWithWorkers) {

--- a/tt_metal/api/tt-metalium/experimental/sockets/d2h_socket.hpp
+++ b/tt_metal/api/tt-metalium/experimental/sockets/d2h_socket.hpp
@@ -69,7 +69,11 @@ public:
      *
      * @throws TT_FATAL if pinned memory allocation fails or addresses are invalid.
      */
-    D2HSocket(const std::shared_ptr<MeshDevice>& mesh_device, const MeshCoreCoord& sender_core, uint32_t fifo_size);
+    D2HSocket(
+        const std::shared_ptr<MeshDevice>& mesh_device,
+        const MeshCoreCoord& sender_core,
+        uint32_t fifo_size,
+        std::optional<DeviceAddr> config_buffer_address = std::nullopt);
 
     /**
      * @brief Destroys the D2HSocket.
@@ -159,7 +163,8 @@ private:
         const std::shared_ptr<MeshDevice>& mesh_device,
         const MeshCoordinateRangeSet& device_range,
         uint32_t pcie_alignment);
-    void init_config_buffer(const std::shared_ptr<MeshDevice>& mesh_device);
+    void init_config_buffer(
+        const std::shared_ptr<MeshDevice>& mesh_device, std::optional<DeviceAddr> config_buffer_address);
     void write_socket_metadata(
         const std::shared_ptr<MeshDevice>& mesh_device,
         const PinnedBufferInfo& data_info,

--- a/tt_metal/api/tt-metalium/experimental/sockets/h2d_socket.hpp
+++ b/tt_metal/api/tt-metalium/experimental/sockets/h2d_socket.hpp
@@ -57,13 +57,17 @@ public:
      * @param buffer_type Memory type for the device-side FIFO buffer (L1 or DRAM).
      * @param fifo_size Size of the circular FIFO buffer in bytes. Must be PCIe-aligned.
      * @param h2d_mode Transfer mode: HOST_PUSH or DEVICE_PULL.
+     * @param config_buffer_address Optional L1 address of the socket configuration buffer on the device.
+     * @param data_buffer_address Optional L1 address of the socket data buffer on the device.
      */
     H2DSocket(
         const std::shared_ptr<MeshDevice>& mesh_device,
         const MeshCoreCoord& recv_core,
         BufferType buffer_type,
         uint32_t fifo_size,
-        H2DMode h2d_mode);
+        H2DMode h2d_mode,
+        std::optional<DeviceAddr> config_buffer_address = std::nullopt,
+        std::optional<DeviceAddr> data_buffer_address = std::nullopt);
 
     /**
      * @brief Destroys the H2DSocket.
@@ -144,8 +148,12 @@ private:
         const MeshCoordinateRangeSet& device_range,
         uint32_t pcie_alignment);
 
-    void init_config_buffer(const std::shared_ptr<MeshDevice>& mesh_device);
-    void init_data_buffer(const std::shared_ptr<MeshDevice>& mesh_device, uint32_t pcie_alignment);
+    void init_config_buffer(
+        const std::shared_ptr<MeshDevice>& mesh_device, std::optional<DeviceAddr> config_buffer_address);
+    void init_data_buffer(
+        const std::shared_ptr<MeshDevice>& mesh_device,
+        uint32_t pcie_alignment,
+        std::optional<DeviceAddr> data_buffer_address);
     void write_socket_metadata(
         const std::shared_ptr<MeshDevice>& mesh_device,
         const PinnedBufferInfo& bytes_acked_info,

--- a/tt_metal/api/tt-metalium/experimental/sockets/mesh_socket.hpp
+++ b/tt_metal/api/tt-metalium/experimental/sockets/mesh_socket.hpp
@@ -61,17 +61,30 @@ struct SocketMemoryConfig {
     std::optional<SubDeviceId> sender_sub_device = std::nullopt;
     std::optional<SubDeviceId> receiver_sub_device = std::nullopt;
 
+    // Optional Parameters for manual memory management.
+    // A user can specify these if they want to bypass the
+    // allocator and manage memory with their own
+    std::optional<DeviceAddr> data_buffer_address = std::nullopt;
+    std::optional<DeviceAddr> sender_config_buffer_address = std::nullopt;
+    std::optional<DeviceAddr> receiver_config_buffer_address = std::nullopt;
+
     // User-provided constructor to make this non-aggregate (prevents ambiguity with Reflectable concept)
     SocketMemoryConfig() = default;
     SocketMemoryConfig(
         BufferType socket_storage_type,
         uint32_t fifo_size,
         std::optional<SubDeviceId> sender_sub_device = std::nullopt,
-        std::optional<SubDeviceId> receiver_sub_device = std::nullopt) :
+        std::optional<SubDeviceId> receiver_sub_device = std::nullopt,
+        std::optional<DeviceAddr> data_buffer_address = std::nullopt,
+        std::optional<DeviceAddr> sender_config_buffer_address = std::nullopt,
+        std::optional<DeviceAddr> receiver_config_buffer_address = std::nullopt) :
         socket_storage_type(socket_storage_type),
         fifo_size(fifo_size),
         sender_sub_device(sender_sub_device),
-        receiver_sub_device(receiver_sub_device) {}
+        receiver_sub_device(receiver_sub_device),
+        data_buffer_address(data_buffer_address),
+        sender_config_buffer_address(sender_config_buffer_address),
+        receiver_config_buffer_address(receiver_config_buffer_address) {}
 
     static constexpr auto attribute_names =
         std::forward_as_tuple("socket_storage_type", "fifo_size", "sender_sub_device", "receiver_sub_device");

--- a/tt_metal/distributed/d2h_socket.cpp
+++ b/tt_metal/distributed/d2h_socket.cpp
@@ -56,7 +56,8 @@ D2HSocket::PinnedBufferInfo D2HSocket::init_host_buffer(
         .addr_hi = static_cast<uint32_t>(noc_addr.value().addr >> 32)};
 }
 
-void D2HSocket::init_config_buffer(const std::shared_ptr<MeshDevice>& mesh_device) {
+void D2HSocket::init_config_buffer(
+    const std::shared_ptr<MeshDevice>& mesh_device, std::optional<DeviceAddr> config_buffer_address) {
     const SocketSenderSize sender_size;
     uint32_t config_buffer_size = sender_size.md_size_bytes + sender_size.ack_size_bytes + sender_size.enc_size_bytes;
 
@@ -75,7 +76,16 @@ void D2HSocket::init_config_buffer(const std::shared_ptr<MeshDevice>& mesh_devic
         .size = config_buffer_size,
     };
 
-    config_buffer_ = MeshBuffer::create(config_mesh_buffer_specs, config_buffer_specs, mesh_device.get());
+    if (config_buffer_address.has_value()) {
+        auto l1_size = mesh_device->allocator()->get_bank_size(BufferType::L1);
+        TT_FATAL(
+            config_buffer_address.value() + config_buffer_size <= l1_size,
+            "Config buffer address {} is out of bounds for L1 size {}",
+            config_buffer_address.value(),
+            l1_size);
+    }
+    config_buffer_ =
+        MeshBuffer::create(config_mesh_buffer_specs, config_buffer_specs, mesh_device.get(), config_buffer_address);
 }
 
 void D2HSocket::write_socket_metadata(
@@ -132,7 +142,10 @@ void D2HSocket::init_sender_tlb(const std::shared_ptr<MeshDevice>& mesh_device) 
 }
 
 D2HSocket::D2HSocket(
-    const std::shared_ptr<MeshDevice>& mesh_device, const MeshCoreCoord& sender_core, uint32_t fifo_size) :
+    const std::shared_ptr<MeshDevice>& mesh_device,
+    const MeshCoreCoord& sender_core,
+    uint32_t fifo_size,
+    std::optional<DeviceAddr> config_buffer_address) :
     sender_core_(sender_core), fifo_size_(fifo_size) {
     MeshCoordinateRangeSet sender_device_range_set;
     sender_device_range_set.merge(MeshCoordinateRange(sender_core_.device_coord));
@@ -148,7 +161,7 @@ D2HSocket::D2HSocket(
     bytes_sent_info.addr_lo = static_cast<uint32_t>(bytes_sent_addr & 0xFFFFFFFFull);
     bytes_sent_info.addr_hi = static_cast<uint32_t>(bytes_sent_addr >> 32);
 
-    init_config_buffer(mesh_device);
+    init_config_buffer(mesh_device, config_buffer_address);
     write_socket_metadata(mesh_device, data_info, bytes_sent_info);
     init_sender_tlb(mesh_device);
 }

--- a/tt_metal/distributed/h2d_socket.cpp
+++ b/tt_metal/distributed/h2d_socket.cpp
@@ -84,7 +84,8 @@ H2DSocket::PinnedBufferInfo H2DSocket::init_host_data_buffer(
         .addr_hi = static_cast<uint32_t>(noc_addr.value().addr >> 32)};
 }
 
-void H2DSocket::init_config_buffer(const std::shared_ptr<MeshDevice>& mesh_device) {
+void H2DSocket::init_config_buffer(
+    const std::shared_ptr<MeshDevice>& mesh_device, std::optional<DeviceAddr> config_buffer_address) {
     uint32_t config_buffer_size = sizeof(receiver_socket_md);
     auto num_cores = 1;
     auto shard_params = ShardSpecBuffer(
@@ -105,10 +106,22 @@ void H2DSocket::init_config_buffer(const std::shared_ptr<MeshDevice>& mesh_devic
     MeshBufferConfig config_mesh_buffer_specs = ReplicatedBufferConfig{
         .size = config_buffer_size,
     };
-    config_buffer_ = MeshBuffer::create(config_mesh_buffer_specs, config_buffer_specs, mesh_device.get());
+    if (config_buffer_address.has_value()) {
+        auto l1_size = mesh_device->allocator()->get_bank_size(BufferType::L1);
+        TT_FATAL(
+            config_buffer_address.value() + config_buffer_size <= l1_size,
+            "Config buffer address {} is out of bounds for L1 size {}",
+            config_buffer_address.value(),
+            l1_size);
+    }
+    config_buffer_ =
+        MeshBuffer::create(config_mesh_buffer_specs, config_buffer_specs, mesh_device.get(), config_buffer_address);
 }
 
-void H2DSocket::init_data_buffer(const std::shared_ptr<MeshDevice>& mesh_device, uint32_t pcie_alignment) {
+void H2DSocket::init_data_buffer(
+    const std::shared_ptr<MeshDevice>& mesh_device,
+    uint32_t pcie_alignment,
+    std::optional<DeviceAddr> data_buffer_address) {
     auto num_data_cores = mesh_device->num_worker_cores(HalProgrammableCoreType::TENSIX, SubDeviceId{0});
     auto shard_grid = mesh_device->worker_cores(HalProgrammableCoreType::TENSIX, SubDeviceId{0});
 
@@ -127,7 +140,16 @@ void H2DSocket::init_data_buffer(const std::shared_ptr<MeshDevice>& mesh_device,
     MeshBufferConfig data_mesh_buffer_specs = ReplicatedBufferConfig{
         .size = total_data_buffer_size,
     };
-    data_buffer_ = MeshBuffer::create(data_mesh_buffer_specs, data_buffer_specs, mesh_device.get());
+    if (data_buffer_address.has_value()) {
+        auto l1_size = mesh_device->allocator()->get_bank_size(BufferType::L1);
+        TT_FATAL(
+            data_buffer_address.value() + fifo_size_ + pcie_alignment <= l1_size,
+            "Data buffer address {} is out of bounds for L1 size {}",
+            data_buffer_address.value(),
+            l1_size);
+    }
+    data_buffer_ =
+        MeshBuffer::create(data_mesh_buffer_specs, data_buffer_specs, mesh_device.get(), data_buffer_address);
     aligned_data_buf_start_ = tt::align(data_buffer_->address(), pcie_alignment);
     write_ptr_ = 0;
 }
@@ -136,7 +158,7 @@ void H2DSocket::write_socket_metadata(
     const std::shared_ptr<MeshDevice>& mesh_device,
     const PinnedBufferInfo& bytes_acked_info,
     const PinnedBufferInfo& data_info) {
-    const auto& core_to_core_id = config_buffer_->get_backing_buffer()->get_buffer_page_mapping()->core_to_core_id;
+    auto core_to_core_id = get_device_local_buffer_view(config_buffer_)->get_buffer_page_mapping()->core_to_core_id;
 
     std::vector<receiver_socket_md> config_data(
         config_buffer_->size() / sizeof(receiver_socket_md), receiver_socket_md());
@@ -190,7 +212,9 @@ H2DSocket::H2DSocket(
     const MeshCoreCoord& recv_core,
     BufferType buffer_type,
     uint32_t fifo_size,
-    H2DMode h2d_mode) :
+    H2DMode h2d_mode,
+    std::optional<DeviceAddr> config_buffer_address,
+    std::optional<DeviceAddr> data_buffer_address) :
     recv_core_(recv_core),
     buffer_type_(buffer_type),
     fifo_size_(fifo_size),
@@ -223,8 +247,8 @@ H2DSocket::H2DSocket(
         bytes_acked_ptr_ = host_buffer_.get();
     }
 
-    init_config_buffer(mesh_device);
-    init_data_buffer(mesh_device, pcie_alignment);
+    init_config_buffer(mesh_device, config_buffer_address);
+    init_data_buffer(mesh_device, pcie_alignment, data_buffer_address);
     write_socket_metadata(mesh_device, bytes_acked_info, data_info);
     init_receiver_tlb(mesh_device);
 }

--- a/tt_metal/distributed/mesh_socket_utils.cpp
+++ b/tt_metal/distributed/mesh_socket_utils.cpp
@@ -186,6 +186,24 @@ Tag generate_descriptor_exchange_tag(tt_fabric::MeshId peer_mesh_id, std::option
 }
 }  // namespace
 
+std::shared_ptr<Buffer> get_device_local_buffer_view(const std::shared_ptr<MeshBuffer>& buffer) {
+    if (Buffer* backing = buffer->get_backing_buffer()) {
+        // Non-owning shared_ptr: MeshBuffer keeps the backing buffer alive.
+        return std::shared_ptr<Buffer>(buffer, backing);
+    }
+
+    const auto& device_local_config = buffer->device_local_config();
+    return Buffer::create(
+        buffer->device(),
+        buffer->address(),
+        buffer->size(),
+        device_local_config.page_size,
+        device_local_config.buffer_type,
+        device_local_config.sharding_args,
+        device_local_config.bottom_up,
+        device_local_config.sub_device_id);
+}
+
 std::shared_ptr<MeshBuffer> create_socket_config_buffer(
     const std::shared_ptr<MeshDevice>& device, const SocketConfig& config, SocketEndpoint socket_endpoint) {
     const auto& socket_connections = config.socket_connection_config;
@@ -238,7 +256,26 @@ std::shared_ptr<MeshBuffer> create_socket_config_buffer(
         .size = total_config_buffer_size,
     };
 
-    return MeshBuffer::create(mesh_buffer_specs, buffer_specs, device.get());
+    if (is_sender && socket_mem_config.sender_config_buffer_address.has_value()) {
+        auto l1_size = device->allocator()->get_bank_size(BufferType::L1);
+        TT_FATAL(
+            socket_mem_config.sender_config_buffer_address.value() + config_buffer_size <= l1_size,
+            "Sender config buffer address {} is out of bounds for L1 size {}",
+            socket_mem_config.sender_config_buffer_address.value(),
+            l1_size);
+    } else if ((!is_sender) && socket_mem_config.receiver_config_buffer_address.has_value()) {
+        auto l1_size = device->allocator()->get_bank_size(BufferType::L1);
+        TT_FATAL(
+            socket_mem_config.receiver_config_buffer_address.value() + config_buffer_size <= l1_size,
+            "Receiver config buffer address {} is out of bounds for L1 size {}",
+            socket_mem_config.receiver_config_buffer_address.value(),
+            l1_size);
+    }
+    return MeshBuffer::create(
+        mesh_buffer_specs,
+        buffer_specs,
+        device.get(),
+        is_sender ? socket_mem_config.sender_config_buffer_address : socket_mem_config.receiver_config_buffer_address);
 }
 
 std::shared_ptr<MeshBuffer> create_socket_data_buffer(
@@ -275,7 +312,17 @@ std::shared_ptr<MeshBuffer> create_socket_data_buffer(
         .size = total_data_buffer_size,
     };
 
-    return MeshBuffer::create(socket_data_mesh_buffer_specs, socket_data_buffer_specs, receiver.get());
+    if (socket_mem_config.data_buffer_address.has_value()) {
+        auto bank_size = receiver->allocator()->get_bank_size(socket_mem_config.socket_storage_type);
+        TT_FATAL(
+            socket_mem_config.data_buffer_address.value() + socket_mem_config.fifo_size <= bank_size,
+            "Data buffer address {} is out of bounds for bank size {}",
+            socket_mem_config.data_buffer_address.value(),
+            bank_size);
+    }
+
+    return MeshBuffer::create(
+        socket_data_mesh_buffer_specs, socket_data_buffer_specs, receiver.get(), socket_mem_config.data_buffer_address);
 }
 
 void write_socket_configs(
@@ -285,7 +332,7 @@ void write_socket_configs(
     SocketEndpoint socket_endpoint,
     const std::shared_ptr<MeshDevice>& peer_device) {
     auto* mesh_device = config_buffer->device();
-    const auto& core_to_core_id = config_buffer->get_backing_buffer()->get_buffer_page_mapping()->core_to_core_id;
+    auto core_to_core_id = get_device_local_buffer_view(config_buffer)->get_buffer_page_mapping()->core_to_core_id;
     bool is_sender = socket_endpoint == SocketEndpoint::SENDER;
     const auto& config = peer_descriptor.config;
     auto grouped_connections = group_socket_connections(config, socket_endpoint);

--- a/tt_metal/distributed/mesh_socket_utils.hpp
+++ b/tt_metal/distributed/mesh_socket_utils.hpp
@@ -76,6 +76,8 @@ std::array<std::unordered_map<MeshCoordinate, tt::tt_fabric::FabricNodeId>, 2> g
 std::vector<multihost::Rank> get_ranks_for_mesh_id(
     tt_fabric::MeshId mesh_id, const std::unordered_map<multihost::Rank, multihost::Rank>& rank_translation_table);
 
+std::shared_ptr<Buffer> get_device_local_buffer_view(const std::shared_ptr<MeshBuffer>& buffer);
+
 template <typename OperationType, typename... Args>
 void execute_with_timeout(OperationType&& operation, Args&&... args) {
     const auto timeout = std::chrono::duration<float>(10.0f);

--- a/ttnn/cpp/ttnn-nanobind/hd_socket.cpp
+++ b/ttnn/cpp/ttnn-nanobind/hd_socket.cpp
@@ -38,12 +38,16 @@ void py_module_types(nb::module_& mod) {
                 const tt::tt_metal::distributed::MeshCoreCoord&,
                 tt::tt_metal::BufferType,
                 uint32_t,
-                tt::tt_metal::distributed::H2DMode>(),
+                tt::tt_metal::distributed::H2DMode,
+                std::optional<tt::tt_metal::DeviceAddr>,
+                std::optional<tt::tt_metal::DeviceAddr>>(),
             nb::arg("mesh_device"),
             nb::arg("recv_core"),
             nb::arg("buffer_type"),
             nb::arg("fifo_size"),
             nb::arg("h2d_mode"),
+            nb::arg("config_buffer_address") = nb::none(),
+            nb::arg("data_buffer_address") = nb::none(),
             R"doc(
                 Construct an H2DSocket for streaming data from host to a device core.
 
@@ -167,10 +171,12 @@ void py_module_types(nb::module_& mod) {
             nb::init<
                 const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>&,
                 const tt::tt_metal::distributed::MeshCoreCoord&,
-                uint32_t>(),
+                uint32_t,
+                std::optional<tt::tt_metal::DeviceAddr>>(),
             nb::arg("mesh_device"),
             nb::arg("sender_core"),
             nb::arg("fifo_size"),
+            nb::arg("config_buffer_address") = nb::none(),
             R"doc(
                 Construct a D2HSocket for streaming data from a device core to host.
 

--- a/ttnn/cpp/ttnn-nanobind/mesh_socket.cpp
+++ b/ttnn/cpp/ttnn-nanobind/mesh_socket.cpp
@@ -74,11 +74,17 @@ void py_module_types(nb::module_& mod) {
                 tt::tt_metal::BufferType,
                 uint32_t,
                 std::optional<tt::tt_metal::SubDeviceId>,
-                std::optional<tt::tt_metal::SubDeviceId>>(),
+                std::optional<tt::tt_metal::SubDeviceId>,
+                std::optional<tt::tt_metal::DeviceAddr>,
+                std::optional<tt::tt_metal::DeviceAddr>,
+                std::optional<tt::tt_metal::DeviceAddr>>(),
             nb::arg("socket_storage_type"),
             nb::arg("fifo_size"),
             nb::arg("sender_sub_device") = nb::none(),
             nb::arg("receiver_sub_device") = nb::none(),
+            nb::arg("data_buffer_address") = nb::none(),
+            nb::arg("sender_config_buffer_address") = nb::none(),
+            nb::arg("receiver_config_buffer_address") = nb::none(),
             R"doc(
                 Initialize a SocketMemoryConfig with socket storage type, fifo size, sender sub device and receiver sub device.
 
@@ -87,6 +93,9 @@ void py_module_types(nb::module_& mod) {
                     fifo_size (int): The size of the fifo
                     sender_sub_device (SubDeviceId, optional): The sub device of the sender
                     receiver_sub_device (SubDeviceId, optional): The sub device of the receiver
+                    data_buffer_address (DeviceAddr, optional): The address of the data buffer on the receiver cores
+                    sender_config_buffer_address (DeviceAddr, optional): The address of the sender config buffer on the sender cores
+                    receiver_config_buffer_address (DeviceAddr, optional): The address of the receiver config buffer on the receiver cores
             )doc");
     nb::class_<tt::tt_metal::distributed::SocketConfig>(mod, "SocketConfig")
         .def(


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/38867)

### Problem description
- SRAM heavy workloads that use sockets (such as Deepseek Blitz) need to be conservative when allocating memory for sockets
- When a socket is created through our runtime, memory is allocated across all physical devices and cores (due to the lock-step assumption). This is also true if the socket exists only on a single core
- This can cause OOM issues, since non-socket cores may be maxing out SRAM
- The solution is to support manual memory management: A user can create a socket using addresses they know are unused. Through this, they bypass the allocator which imposes the lock-step assumption
- This is an advanced use case, only for specific workloads

### What's changed
- Add `data_buffer_address` and `config_buffer_address` parameters to `MeshSocket`, `H2DSocket` and `D2HSocket` constructors
- Propagate these parameters up to `HostInterface`, `SocketInterface` and `PipelineBlock` classes used for Deepseek Blitz
- Add tests for this use case

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=asaigal/manual_socket_allocation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:asaigal/manual_socket_allocation)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=asaigal/manual_socket_allocation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:asaigal/manual_socket_allocation)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=asaigal/manual_socket_allocation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:asaigal/manual_socket_allocation)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=asaigal/manual_socket_allocation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:asaigal/manual_socket_allocation)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=asaigal/manual_socket_allocation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:asaigal/manual_socket_allocation)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=asaigal/manual_socket_allocation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:asaigal/manual_socket_allocation)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
