### PR TITLE
#37617: Fix conv2d split reader reading stale L1 on output-only cores

### DIFF
--- a/.github/workflows/perf-models-impl.yaml
+++ b/.github/workflows/perf-models-impl.yaml
@@ -94,8 +94,7 @@ jobs:
         uses: tenstorrent/tt-metal/.github/actions/single-card-perf-test@main
         with:
           commands: pytest models/demos/vision/generative/stable_diffusion/${{ matrix.test-info.arch == 'blackhole' && 'blackhole' || 'wormhole' }}/tests -m models_performance_bare_metal
-        # Disabled on blackhole until the test is fixed; issue #37617
-        if: ${{ !cancelled() && matrix.test-info.model-group == 'cnn_javelin' && matrix.test-info.arch != 'blackhole' && (inputs.model == 'all' || inputs.model == 'stable_diffusion') }}
+        if: ${{ !cancelled() && matrix.test-info.model-group == 'cnn_javelin' && (inputs.model == 'all' || inputs.model == 'stable_diffusion') }}
       # Disabled until the test is fixed; issue #35263
       # - name: Run sentence_bert model_perf test
       #   timeout-minutes: ${{ matrix.test-info.timeout }}

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_op_unit_test_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_op_unit_test_perf.py
@@ -277,7 +277,7 @@ def test_conv2d_block_sharded_sdxl_performance():
     # Extract the device kernel duration result
     device_kernel_duration = results["DEVICE KERNEL"]["AVG"]
 
-    expected_duration_ns = 1115831  # Measured: 1.12ms for Conv2D SDXL block sharded
+    expected_duration_ns = 1088021  # Measured: 1.09ms for Conv2D SDXL block sharded
 
     # Log the performance result
     print(

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp
@@ -330,7 +330,10 @@ void kernel_main() {
         start_reader_idx = reader_idx;
         if constexpr (split_reader_enabled) {
             // Increment reader index for the next number of segments (number of segments for other reader)
-            start_reader_idx += (static_cast<uint32_t>(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1);
+            // Only read reader indices on cores that have sharded input (is_sender_core).
+            if (is_sender_core) {
+                start_reader_idx += (static_cast<uint32_t>(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1);
+            }
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_2d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_2d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -94,11 +94,14 @@ void kernel_main() {
     }
 
     volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
-        split_reader_enabled ? reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_reader_indices))
-                             : nullptr;
+        (split_reader_enabled && is_sender_core)
+            ? reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_reader_indices))
+            : nullptr;
 
     // Initial setup for second reader (starting from second reader's data)
-    uint32_t start_reader_idx = split_reader_enabled ? (uint32_t)(packed_reader_indices_ptr[0] & 0xffff) + 1 : 0;
+    // Only read reader indices on cores that have sharded input (is_sender_core).
+    uint32_t start_reader_idx =
+        (split_reader_enabled && is_sender_core) ? (uint32_t)(packed_reader_indices_ptr[0] & 0xffff) + 1 : 0;
     uint32_t reader_idx = start_reader_idx;
 
     constexpr uint32_t stride_w_bytes = dilation_w * conv_act_c_read_bytes;
@@ -186,8 +189,11 @@ void kernel_main() {
             }
             if constexpr (split_reader_enabled) {
                 // Update reader index for next iteration (split reader increment)
-                start_reader_idx =
-                    reader_idx + static_cast<uint32_t>(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1;
+                // Only read reader indices on cores that have sharded input (is_sender_core).
+                if (is_sender_core) {
+                    start_reader_idx =
+                        reader_idx + static_cast<uint32_t>(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1;
+                }
             }
             if constexpr (fuse_bias) {
                 if (load_bias) {

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_2d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_2d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -115,10 +115,13 @@ void kernel_main() {
     }
 
     volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
-        split_reader_enabled ? reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_reader_indices))
-                             : nullptr;
+        (split_reader_enabled && is_sender_core)
+            ? reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_reader_indices))
+            : nullptr;
     // Initial setup for second reader (starting from second reader's data)
-    uint32_t start_reader_idx = split_reader_enabled ? (uint32_t)(packed_reader_indices_ptr[0] & 0xffff) + 1 : 0;
+    // Only read reader indices on cores that have sharded input (is_sender_core).
+    uint32_t start_reader_idx =
+        (split_reader_enabled && is_sender_core) ? (uint32_t)(packed_reader_indices_ptr[0] & 0xffff) + 1 : 0;
     uint32_t reader_idx = start_reader_idx;
 
     constexpr uint32_t stride_w_bytes = dilation_w * conv_act_c_read_bytes;
@@ -279,8 +282,11 @@ void kernel_main() {
             }
             if constexpr (split_reader_enabled) {
                 // Update reader index for next iteration (split reader increment)
-                start_reader_idx =
-                    reader_idx + static_cast<uint32_t>(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1;
+                // Only read reader indices on cores that have sharded input (is_sender_core).
+                if (is_sender_core) {
+                    start_reader_idx =
+                        reader_idx + static_cast<uint32_t>(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1;
+                }
                 if (skip_work) {
                     continue;
                 }


### PR DESCRIPTION
## Summary

Fixes #37617 — SD 1.4 timeout/hang on BH Model perf pipeline when running after UNet.

- When block-sharded conv2d has different input and output grids (e.g., input 5x8=40 cores, output 10x8=80 cores), the `READER_INDICES` config tensor is only sharded across input cores. Output-only cores have no valid reader indices at the CB address.
- With `split_reader` enabled, the writer and reader kernels unconditionally dereference `packed_reader_indices_ptr` on **all** cores, including output-only cores that have no valid data. On a clean device this reads zeros (harmless), but if L1 contains stale data from a previous process with different `l1_small_size`, the corrupted reader indices cause a mcast coordination deadlock.
- Gate all `packed_reader_indices_ptr` dereferences on `is_sender_core` so output-only cores never read from the uninitialized config tensor.
- Re-enables the SD 1.4 BH model perf test in CI.

## Test plan

- [x] UNet perf (2 CQs) → SD perf (1 CQ) no longer hangs on local BH
- [x] SD perf passes in isolation
- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=pjosipovic/fix_37617)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:pjosipovic/fix_37617)
- [x] [![Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/fix_37617)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/fix_37617)
- [x] [![Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml/badge.svg?branch=pjosipovic/fix_37617)](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml?query=branch:pjosipovic/fix_37617)
- [x] [![Model perf tests](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml/badge.svg?branch=pjosipovic/fix_37617)](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml?query=branch:pjosipovic/fix_37617)
- [x] [![Nightly L2 tests (conv)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/fix_37617)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/fix_37617)

🤖 Generated with [Claude Code](https://claude.com/claude-code)