### PR TITLE
SDXL change open-clip-torch==2.26.1

### DIFF
--- a/tt_metal/python_env/requirements-dev.txt
+++ b/tt_metal/python_env/requirements-dev.txt
@@ -78,7 +78,7 @@ pydantic==2.9.2 # Required for Superset benchmarking
 fiftyone==0.25.2 # Required for Yolo benchmarking
 jiwer==3.0.5 # Required for speech recognition evaluation
 toolz==0.12.0 # Required for Save environment data step
-open_clip_torch==2.32.0 # Required for SDXL accuracy evaluation
+open_clip_torch==2.26.1 # Required for SDXL accuracy evaluation
 
 # Suff that used to be in pyproject.toml
 # Needed for various tests


### PR DESCRIPTION
### Problem description
Version of open-clip-torch library influences resulting clip score in accuracy test a lot. Ml commons inference uses different version for open-clip-torch library: [mlcommons requirements.txt link](https://github.com/mlcommons/inference/blob/master/text_to_image/requirements.txt) 

### What's changed
- open clip torch version changed resulting clip score in valid MLcommons range:
 **CLIP scores within [31.68631873, 31.81331801]**
 
- [accuracy test 5000 images on branch link](https://github.com/tenstorrent/tt-shield/actions/runs/22555586598)
       -      "average_clip": **31.772899176478386**
       -      "fid_score": 23.466179745408567

### Checklist

- [x] [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/22568824421) passed ✅
- [x] [SDXL (Single-card) Demo tests (no perf)](https://github.com/tenstorrent/tt-metal/actions/runs/22665319692)
- [x] [SDXL (Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/22665645742)
- [ ] [SDXL (Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/22665349398/job/65696539828) failed but same flaky error on main [link](https://github.com/tenstorrent/tt-metal/actions/runs/22612652138/job/65518795272)
- [x] [SD35 (T3K) T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/22665198228)
- [ ] [SD35 (T3K) T3000 perf tests](https://github.com/tenstorrent/tt-metal/actions/runs/22665283455) with same error on main [link](https://github.com/tenstorrent/tt-metal/actions/runs/22668963781/job/65708603109)



