### PR TITLE
[VIT] Skipping the model testing for BH due to its failure

### DIFF
--- a/models/demos/vision/classification/vit/blackhole/tests/test_vit_device_perf.py
+++ b/models/demos/vision/classification/vit/blackhole/tests/test_vit_device_perf.py
@@ -17,7 +17,7 @@ except ModuleNotFoundError:
     use_signpost = False
 
 
-@pytest.mark.skip(reason="Sharding issue: 120 shards exceeds 110 L1 banks on BH compute cores")
+@pytest.mark.skip(reason="Sharding issue: 120 shards exceeds 110 L1 banks on BH compute cores github issue #38877")
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 @pytest.mark.parametrize("batch_size", [10])
 def test_vit_device_ops(
@@ -43,7 +43,7 @@ def test_vit_device_ops(
     ttnn.synchronize_device(device)
 
 
-@pytest.mark.skip(reason="Sharding issue: 120 shards exceeds 110 L1 banks on BH compute cores")
+@pytest.mark.skip(reason="Sharding issue: 120 shards exceeds 110 L1 banks on BH compute cores github issue #38877")
 @pytest.mark.parametrize("batch_size", [10])
 @pytest.mark.parametrize(
     "expected_kernel_samples_per_sec",

--- a/models/demos/vision/classification/vit/blackhole/tests/test_vit_device_perf.py
+++ b/models/demos/vision/classification/vit/blackhole/tests/test_vit_device_perf.py
@@ -17,6 +17,7 @@ except ModuleNotFoundError:
     use_signpost = False
 
 
+@pytest.mark.skip(reason="Sharding issue: 120 shards exceeds 110 L1 banks on BH compute cores")
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 @pytest.mark.parametrize("batch_size", [10])
 def test_vit_device_ops(
@@ -42,6 +43,7 @@ def test_vit_device_ops(
     ttnn.synchronize_device(device)
 
 
+@pytest.mark.skip(reason="Sharding issue: 120 shards exceeds 110 L1 banks on BH compute cores")
 @pytest.mark.parametrize("batch_size", [10])
 @pytest.mark.parametrize(
     "expected_kernel_samples_per_sec",


### PR DESCRIPTION
### Problem description
The pipeline Single Device Perf is failing for a couple of days since updating the fw of the CI machines. Since fixing the issue with VIT model expecting 120 cores for sharding strategy takes some time. This test is skipped, linked to the gh issue in order to reduce the noise on the Single Device Perf pipeline. This model will be included in testing once issue is resolved.

### What's changed
Vit model skipped until failure is resolved. 

### Checklist

- [x] [![(Single) Device Perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml/badge.svg?branch=dstoiljkovic/single_device_perf_green)](https://github.com/tenstorrent/tt-metal/actions/runs/22568426035?query=branch:dstoiljkovic/single_device_perf_green)
 