### PR TITLE
[gpt-oss] truncate decode logits to vocab_size

### DIFF
--- a/models/demos/gpt_oss/tt/model.py
+++ b/models/demos/gpt_oss/tt/model.py
@@ -756,8 +756,13 @@ class Model:
                 torch_out = torch.cat([ttnn.to_torch(t) for t in row_tensors], dim=-1)
         else:
             torch_out = self.concat_device_output(tt_out)
-        torch_out = torch_out[:, 0, :, :]  # [1, 1, B, vocab_size]
-        return torch_out.view(B, S, -1)
+        torch_out = torch_out[:, 0, :, :]  # [1, 1, B, padded_vocab_size]
+        torch_out = torch_out.view(B, S, -1)
+        # Truncate to vocab_size — lm_head is padded to padded_vocab_size for
+        # on-device sampling (pow2 topk), but callers expect vocab_size width.
+        if torch_out.shape[-1] > self.vocab_size:
+            torch_out = torch_out[:, :, : self.vocab_size]
+        return torch_out
 
     def concat_device_output(self, tt_out):
         """Convert multi-device tensor to torch tensor"""


### PR DESCRIPTION
## Summary
- GPT-OSS pads lm_head to `padded_vocab_size` (pow2-aligned per device) for on-device sampling topk
- The decode path returned the full padded logits (e.g. 262144) to vllm, but vllm expects `vocab_size` (201088)
- This caused structured output grammar bitmask masking to crash with: `The size of tensor a (262144) must match the size of tensor b (201088)`
- Fix: truncate logits to `self.vocab_size` in the decode output path, matching what `process_output_prefill` already does

## Test plan
- [x] Reproduced crash with GPT-OSS-120B high-throughput vllm nightly config (`--data_parallel_size 4 --max_num_seqs 32`)
- [x] Verified structured output benchmark passes (32/32, 100% correct rate) after fix
- [x] Verified regular benchmark passes (32/32) after fix