### PR TITLE
Fix uint16/int16 dtype mismatch in prepare_expert_tensors test

### DIFF
--- a/models/demos/gpt_oss/tests/fused_op_unit_tests/test_gpt_oss_prepare_expert_tensors.py
+++ b/models/demos/gpt_oss/tests/fused_op_unit_tests/test_gpt_oss_prepare_expert_tensors.py
@@ -394,7 +394,10 @@ def _run_prepare_expert_tensors_test(
     )
 
     # Compare outputs - indices (use exact match for integers)
-    indices_match = torch.all(tt_indices_rm_torch == ref_indices_rm)
+    # Cast both to int32 before comparing: tt_indices_rm_torch is uint16 (from TTNN DataType::UINT16)
+    # and ref_indices_rm is int16 (torch.Short). PyTorch does not support type promotion between
+    # unsigned and signed integer types, so we widen both to int32 for the comparison.
+    indices_match = torch.all(tt_indices_rm_torch.to(torch.int32) == ref_indices_rm.to(torch.int32))
     logger.info(f"Indices exact match: {indices_match}")
     assert indices_match, "Expert indices don't match exactly"
 


### PR DESCRIPTION
## Summary

- The `test_gpt_oss_prepare_expert_tensors` test was failing with `RuntimeError: Promotion for uint16, uint32, uint64 types is not supported, attempted to promote UInt16 and Short`
- The TTNN `tt_topk_indices` tensor uses `DataType::UINT16`, which converts to `torch.uint16` after `ttnn.to_torch()`
- The reference tensor `ref_indices_rm` is built as `torch.int16` (`torch.Short`)
- PyTorch does not support type promotion between unsigned and signed integer types, so the `==` comparison raised a `RuntimeError`
- Fix: cast both tensors to `int32` before comparing, which safely widens both signed and unsigned 16-bit values without any loss

## Test plan

- [ ] [![(Galaxy) perf tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml/badge.svg?branch=handrews/fix-prepare-expert-tensors-uint16-comparison)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml?query=branch:handrews/fix-prepare-expert-tensors-uint16-comparison)