### PR TITLE
#0: update owner ids for eltwise and transformer tests

### DIFF
--- a/tests/pipeline_reorg/ttnn-tests.yaml
+++ b/tests/pipeline_reorg/ttnn-tests.yaml
@@ -33,7 +33,7 @@
     bh_p150b_civ2:
       timeout: 40
   team: ttnn
-  owner_id: U08411R54Q2 # Chris Maryan
+  owner_id: U09BX3N0N95 # Mateusz Nowak
   merge_gate: false
   ttsim: true
 
@@ -47,7 +47,7 @@
     bh_p150b_civ2:
       timeout: 40
   team: ttnn
-  owner_id: U08411R54Q2 # Chris Maryan
+  owner_id: U09BX3N0N95 # Mateusz Nowak
   merge_gate: false
   ttsim: true
 
@@ -61,7 +61,7 @@
     bh_p150b_civ2:
       timeout: 40
   team: ttnn
-  owner_id: U08411R54Q2 # Chris Maryan
+  owner_id: U09BX3N0N95 # Mateusz Nowak
   merge_gate: false
   ttsim: true
 
@@ -75,7 +75,7 @@
     bh_p150b_civ2:
       timeout: 40
   team: ttnn
-  owner_id: U08411R54Q2 # Chris Maryan
+  owner_id: U09BX3N0N95 # Mateusz Nowak
   merge_gate: false
   ttsim: true
 
@@ -89,7 +89,7 @@
     bh_p150b_civ2:
       timeout: 40
   team: ttnn
-  owner_id: U08411R54Q2 # Chris Maryan
+  owner_id: U09BX3N0N95 # Mateusz Nowak
   merge_gate: false
   ttsim: true
 
@@ -159,7 +159,7 @@
     bh_p150b_civ2:
       timeout: 40
   team: ttnn
-  owner_id: U06UEFWB4P9 # Colman Glagovich
+  owner_id: U08JFM3CFA4 # Gongyu Wang
   merge_gate: false
   ttsim: true
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Mateusz owns eltwise now and for some reason transformers was going to @cmaryanTT as well, instead of @cglagovich :
```
All post-commit tests — [workflow](https://github.com/tenstorrent/tt-metal/actions/workflows/.github/workflows/all-post-commit-workflows.yaml?query=branch%3Amain) — [run](https://github.com/tenstorrent/tt-metal/actions/runs/22323092307) — [c269648](https://github.com/tenstorrent/tt-metal/commit/c26964868e3c275843522e89f5b2b43276832e59)
    • ttnn-unit-tests (wormhole_b0, N300) / ttnn transformers group wormhole_b0 N300 [@Chris Maryan](https://tenstorrent.enterprise.slack.com/team/U08411R54Q2)
    • ttnn-unit-tests (wormhole_b0, N300) / ttnn sdpa group wormhole_b0 N300 [@Evan Smal](https://tenstorrent.enterprise.slack.com/team/U088DBNUKGR)
```

### What's changed
Update the owner ids to @mateusznowakTT and @gwangTT per Chris's request.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=bbradel-0_owner_id_ttnn)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:bbradel-0_owner_id_ttnn)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-0_owner_id_ttnn)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-0_owner_id_ttnn)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-0_owner_id_ttnn)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-0_owner_id_ttnn)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-0_owner_id_ttnn)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-0_owner_id_ttnn)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-0_owner_id_ttnn)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-0_owner_id_ttnn)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-0_owner_id_ttnn)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-0_owner_id_ttnn)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
