### PR TITLE
Fix for dfb consumer being trisc0 or (eventually) trisc3

### DIFF
--- a/tt_metal/hw/inc/experimental/dataflow_buffer.h
+++ b/tt_metal/hw/inc/experimental/dataflow_buffer.h
@@ -93,6 +93,9 @@ public:
         PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].packed_tile_counter;
         uint8_t tc_id = get_counter_id(packed_tc);
 #if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_UNPACK)
+        if ((local_dfb_interface_.tensix_trisc_mask & (1u << ckernel::csr_read<ckernel::CSR::TRISC_ID>())) == 0) {
+            return;
+        }
         llk_wait_tiles(logical_dfb_id_, num_entries);
         // DPRINT << "wait_front: tc_id: " << static_cast<uint32_t>(tc_id)
         //        << " capacity: " << static_cast<uint32_t>(tile_counters[tc_id].f.buf_capacity)
@@ -119,8 +122,10 @@ public:
         PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].packed_tile_counter;
         uint8_t tc_id = get_counter_id(packed_tc);
 #if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_UNPACK)
+        if ((local_dfb_interface_.tensix_trisc_mask & (1u << ckernel::csr_read<ckernel::CSR::TRISC_ID>())) == 0) {
+            return;
+        }
         llk_pop_tiles(logical_dfb_id_, num_entries);
-        // DPRINT << "pop_front: tc_id: " << static_cast<uint32_t>(tc_id) << " acked: " << static_cast<uint32_t>(tile_counters[tc_id].f.acked) << ENDL();
         // UNPACK({
         //     tile_counters[tc_id].f.acked = num_entries;
         //     local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr += (num_entries * local_dfb_interface_.stride_size);
@@ -159,9 +164,13 @@ public:
                 PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[i].packed_tile_counter;
                 uint8_t tc_id = get_counter_id(packed_tc);
 #if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_UNPACK)
+                if ((local_dfb_interface_.tensix_trisc_mask & (1u << ckernel::csr_read<ckernel::CSR::TRISC_ID>())) == 0) {
+                    continue;
+                }
                 all_acked = all_acked && (ckernel::trisc::tile_counters[tc_id].f.posted == 0);
 #elif !defined(COMPILE_FOR_TRISC)
                 uint8_t tensix_id = get_tensix_id(packed_tc);
+                // DPRINT << "read acked: " << static_cast<uint32_t>(fast_llk_intf_read_acked(tensix_id, tc_id)) << " read posted: " << static_cast<uint32_t>(fast_llk_intf_read_posted(tensix_id, tc_id)) << ENDL();
                 all_acked &=
                     (fast_llk_intf_read_acked(tensix_id, tc_id) == fast_llk_intf_read_posted(tensix_id, tc_id));
 #endif

--- a/tt_metal/hw/inc/internal/dataflow_buffer_init.h
+++ b/tt_metal/hw/inc/internal/dataflow_buffer_init.h
@@ -95,6 +95,7 @@ FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base
             dfb_interface.num_entries_per_txn_id_per_tc = init_ptr->num_entries_per_txn_id_per_tc;
 
             dfb_interface.tc_idx = 0;
+            dfb_interface.tensix_trisc_mask = init_ptr->risc_mask_bits.tensix_trisc_mask;
 
             // DPRINT << "remapper_pair_index: " << static_cast<uint32_t>(per_risc_ptr->flags.remapper_pair_index) << ENDL();
 
@@ -172,7 +173,7 @@ FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base
                     uint8_t tc_id = get_counter_id(ptc);
 
 
-#if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_UNPACK)
+#if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_PACK)
                     // DPRINT << "dfb " << static_cast<uint32_t>(logical_dfb_id) << " initializing tc : " << static_cast<uint32_t>(tc_id) << ENDL();
                     ckernel::trisc::tile_counters[tc_id].f.reset = 1;
                     ckernel::trisc::tile_counters[tc_id].f.buf_capacity = init_ptr->capacity;

--- a/tt_metal/hw/inc/internal/dataflow_buffer_interface.h
+++ b/tt_metal/hw/inc/internal/dataflow_buffer_interface.h
@@ -71,7 +71,7 @@ struct dfb_initializer_t {  // 24 bytes
     struct {
         uint16_t dm_mask : 8;         // bits 0-7: DM RISC mask
         uint16_t tensix_mask : 4;     // bits 8-11: Neo RISC mask
-        uint16_t reserved : 4;        // bits 12-15: reserved
+        uint16_t tensix_trisc_mask : 4;        // bits 12-15: indicates which triscs use the DFB (tensix producer uses trisc2 and tensix consumer can use trisc0 or trisc3)
     } risc_mask_bits;
     uint8_t num_producers;
     uint8_t num_txn_ids;
@@ -142,7 +142,7 @@ struct LocalDFBInterface {
     uint8_t num_tcs_to_rr;
     uint8_t num_txn_ids;  // shared across riscs so can be factored out and put into sep initialization struct
     uint8_t tc_idx;
-
+    uint8_t tensix_trisc_mask;  // which TRISC(s) use this DFB (bit N = trisc N); for runtime gate on TRISC
 
 } __attribute__((packed));
 
@@ -150,6 +150,6 @@ static_assert(sizeof(DFBTCSlot) == 17, "DFBTCSlot size is incorrect");
 static_assert(sizeof(dfb_initializer_t) == 24, "dfb_initializer_t size is incorrect");
 static_assert(sizeof(dfb_initializer_per_risc_t) == 44, "dfb_initializer_per_risc_t size is incorrect");
 static_assert(sizeof(dfb_initializer_intra_tensix_t) == 24, "dfb_initializer_intra_tensix_t size is incorrect");
-static_assert(sizeof(LocalDFBInterface) == 97, "LocalDFBInterface size is incorrect");
+static_assert(sizeof(LocalDFBInterface) == 98, "LocalDFBInterface size is incorrect");
 
 }  // namespace experimental

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
@@ -45,6 +45,7 @@ void BindDataflowBufferToProducerConsumerKernels(Program& program, uint32_t dfb_
     if (auto compute_producer = std::dynamic_pointer_cast<experimental::quasar::QuasarComputeKernel>(producer_kernel)) {
         TT_FATAL(dfb->config.num_producers == 1, "Only one Tensix is supported for now");
         dfb->config.producer_risc_mask = ::experimental::TENSIX_RISC_OFFSET;
+        dfb->tensix_trisc_mask |= (1u << 2);  // Tensix producer uses trisc2
     } else if (auto dm_producer = std::dynamic_pointer_cast<experimental::quasar::QuasarDataMovementKernel>(producer_kernel)) {
         const auto& producer_dm_riscvs = dm_producer->get_dm_processors();
         for (DataMovementProcessor dm : producer_dm_riscvs) {
@@ -57,6 +58,7 @@ void BindDataflowBufferToProducerConsumerKernels(Program& program, uint32_t dfb_
     if (auto compute_consumer = std::dynamic_pointer_cast<experimental::quasar::QuasarComputeKernel>(consumer_kernel)) {
         TT_FATAL(dfb->config.num_consumers == 1, "Only one Tensix is supported for now");
         dfb->config.consumer_risc_mask = ::experimental::TENSIX_RISC_OFFSET;
+        dfb->tensix_trisc_mask |= (1u << 0);  // Default: Tensix consumer uses trisc0; use (1u << 3) for trisc3
     } else if (auto dm_consumer = std::dynamic_pointer_cast<experimental::quasar::QuasarDataMovementKernel>(consumer_kernel)) {
         const auto& consumer_dm_riscvs = dm_consumer->get_dm_processors();
         for (DataMovementProcessor dm : consumer_dm_riscvs) {
@@ -206,7 +208,7 @@ std::vector<uint8_t> DataflowBufferImpl::serialize() const {
     init.capacity = this->capacity;
     init.risc_mask_bits.dm_mask = this->risc_mask & 0xFF;
     init.risc_mask_bits.tensix_mask = (this->risc_mask >> 8) & 0x0F;
-    init.risc_mask_bits.reserved = 0;
+    init.risc_mask_bits.tensix_trisc_mask = this->tensix_trisc_mask & 0x0F;
     init.num_producers = this->config.num_producers;
     init.num_txn_ids = this->num_txn_ids;
     for (int i = 0; i < 4; i++) {

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp
@@ -46,6 +46,7 @@ struct DataflowBufferImpl {
     DataflowBufferConfig config;
 
     uint16_t risc_mask = 0;  // bits 0-7 = DM riscs, bits 8-15 = Tensix riscs
+    uint8_t tensix_trisc_mask = 0;  // bits 0-3: which TRISC(s) use DFB (producer=bit2, consumer=bit0 or bit3)
     uint16_t capacity = 0;
     std::vector<DFBRiscConfig> risc_configs;
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Support for all  dfb integration and support for all 4 triscs weren't tested together. Adding a field to indicate which trisc on each tensix is involved in pushing/popping from the DFB

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=abhullar/multi-tensix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:abhullar/multi-tensix)
- [ ] New/Existing tests provide coverage for changes
- [x] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early