### PR TITLE
Add cooperative device-aware test runner (tt-test.sh)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -392,6 +392,7 @@ tools/triage/ @tenstorrent/metalium-developers-triage @tenstorrent/codeowner-byp
 tools/tests/triage/ @tenstorrent/metalium-developers-triage @tenstorrent/codeowner-bypass
 scripts/install_debugger.sh @tenstorrent/metalium-developers-triage @tenstorrent/codeowner-bypass
 scripts/ttexalens_ref.txt @tenstorrent/metalium-developers-triage @tenstorrent/codeowner-bypass
+scripts/tt-test.sh @tenstorrent/metalium-developers-convolutions @tenstorrent/codeowner-bypass
 
 # docs
 docs/Makefile @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass

--- a/scripts/tt-test.sh
+++ b/scripts/tt-test.sh
@@ -1,0 +1,202 @@
+#!/bin/bash
+# tt-test.sh - Cooperative device-aware test runner
+#
+# Uses flock to serialize device access across multiple agents/terminals.
+# Uses TT_METAL_OPERATION_TIMEOUT_SECONDS for precise hang detection at the
+# dispatch layer (does not penalize setup/compilation time).
+# Automatically resets the device after hangs, ensuring the next runner
+# always gets a clean device.
+#
+# Usage: scripts/tt-test.sh [--dev] <test_path> [extra_pytest_args...]
+#
+# Options:
+#   --dev       Enables polling watcher (NoC sanitizer, waypoints, CB
+#               sanitization), lightweight ebreak asserts, and auto-triage
+#               on hang with full triage + watcher log dump.
+#
+# Modes:
+#   default  - Dispatch timeout only. Lean, no debug overhead.
+#   --dev    - Debug mode with watcher, asserts, and triage (see above).
+#
+# Exit codes:
+#   0 - All tests passed
+#   1 - Test failure (normal pytest failure, no hang)
+#   2 - Hang detected (dispatch timeout fired)
+#   3 - Setup error (missing args, etc.)
+
+set -o pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DISPATCH_TIMEOUT=5
+TRIAGE_SCRIPT="${REPO_DIR}/tools/tt-triage.py"
+WATCHER_LOG="${REPO_DIR}/generated/watcher/watcher.log"
+LOCK_FILE="/tmp/tt-device.lock"
+DIRTY_FLAG="/tmp/tt-device.dirty"
+TRIAGE_LOG="/tmp/tt-test-triage-$$.log"
+
+# --- Parse flags ---
+DEV_MODE=false
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dev)
+            DEV_MODE=true
+            shift
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+# --- Argument validation ---
+if [[ $# -eq 0 ]]; then
+    echo "TT_TEST_ERROR: No test path provided" >&2
+    echo "Usage: scripts/tt-test.sh [--dev] <test_path> [extra_pytest_args...]" >&2
+    exit 3
+fi
+
+TEST_PATH="$1"
+shift
+
+# --- Acquire flock ---
+exec 9>"$LOCK_FILE"
+
+echo "TT_TEST: Waiting for device lock..." >&2
+flock 9
+echo "TT_TEST: Device lock acquired" >&2
+
+# --- Check if device needs reset from previous hang ---
+if [[ -f "$DIRTY_FLAG" ]]; then
+    echo "TT_TEST: Device marked dirty from previous hang, resetting..." >&2
+    if ! tt-smi -r; then
+        echo "TT_TEST_ERROR: Device reset (tt-smi -r) failed" >&2
+        exit 3
+    fi
+    rm -f "$DIRTY_FLAG"
+    echo "TT_TEST: Device reset complete" >&2
+fi
+
+# --- Setup environment ---
+cd "$REPO_DIR"
+if [[ -f python_env/bin/activate ]]; then
+    if ! source python_env/bin/activate; then
+        echo "TT_TEST: WARNING: Failed to activate python_env virtual environment" >&2
+    fi
+else
+    echo "TT_TEST: WARNING: python_env not found; using system Python" >&2
+fi
+
+export TT_METAL_OPERATION_TIMEOUT_SECONDS="$DISPATCH_TIMEOUT"
+
+# Auto-triage: dispatch layer runs tt-triage when timeout fires (both modes).
+# This only executes on actual hang, not on every test — zero overhead for passing tests.
+# Requires tt-exalens: scripts/install_debugger.sh
+if ! python3 -c "import ttexalens" 2>/dev/null; then
+    echo "TT_TEST: WARNING: tt-exalens not installed — triage on hang will be unavailable." >&2
+    echo "TT_TEST: Install with: scripts/install_debugger.sh" >&2
+fi
+rm -f "$TRIAGE_LOG"
+export TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE="python3 ${TRIAGE_SCRIPT} --disable-progress > ${TRIAGE_LOG} 2>&1"
+
+if [[ "$DEV_MODE" == true ]]; then
+    # Lightweight asserts: compiles ASSERT() as ebreak, halting the core at the
+    # exact instruction. The dispatch timeout then fires and runs triage, which
+    # captures callstacks from ALL cores — showing both the assert site and any
+    # cores blocked waiting on the halted one.
+    export TT_METAL_LIGHTWEIGHT_KERNEL_ASSERTS=1
+
+    # LLK asserts: enables LLK_ASSERT() in the compute API / LLK layer.
+    # Catches invalid hardware configurations, wrong unpack/pack parameters,
+    # and API misuse deep in the compute pipeline. Also compiles as ebreak.
+    export TT_METAL_LLK_ASSERTS=1
+
+    # Polling watcher: enables all device-side instrumentation (NoC sanitizer,
+    # waypoints, CB sanitization) with the host polling thread. Recent watcher
+    # server improvements (t=0 sampling, 100ms quanta) minimize overhead for
+    # short tests. Watcher log is dumped on hang for full diagnostic context.
+    #
+    # WATCHER_DISABLE_ASSERT disables the watcher's own assert mechanism (which
+    # would conflict with the lightweight ebreak asserts above). We want ebreak
+    # asserts to halt the core so triage can capture callstacks from all cores,
+    # rather than having watcher handle asserts independently.
+    export TT_METAL_WATCHER=1
+    export TT_METAL_WATCHER_NOINLINE=1
+    export TT_METAL_WATCHER_DISABLE_ASSERT=1
+    export TT_METAL_WATCHER_DISABLE_DISPATCH=1
+
+    echo "TT_TEST: [dev] asserts=ebreak llk_asserts=ON watcher=polling triage=ON timeout=${DISPATCH_TIMEOUT}s" >&2
+else
+    echo "TT_TEST: dispatch_timeout=${DISPATCH_TIMEOUT}s" >&2
+fi
+echo "TT_TEST: pytest ${TEST_PATH} $*" >&2
+echo "========================================" >&2
+
+# --- Mark device dirty before running tests ---
+# Pessimistic: assume the device will get corrupted. If the script is killed at any
+# point (SIGKILL, OOM, etc.), the flag persists and the next runner will reset.
+# Cleared on clean exit or after a successful inline reset.
+touch "$DIRTY_FLAG"
+
+# --- Run pytest ---
+# -x: stop on first failure (avoids running tests after a hang bricks the device)
+pytest "${TEST_PATH}" -x "$@"
+EXIT_CODE=$?
+
+echo "========================================" >&2
+
+# --- Handle result ---
+if [[ $EXIT_CODE -eq 0 ]]; then
+    rm -f "$DIRTY_FLAG"
+    rm -f "$TRIAGE_LOG"
+    echo "TT_TEST_RESULT: PASS" >&2
+    exit 0
+fi
+
+# Determine if this was a hang:
+#   Triage log non-empty = dispatch timeout handler ran tt-triage (definitive hang signal)
+IS_HANG=false
+if [[ -s "$TRIAGE_LOG" ]]; then
+    IS_HANG=true
+fi
+
+# Kill any remaining child processes (pytest may have left orphans)
+pkill -9 -P $$ 2>/dev/null || true
+
+# Only reset device when the failure might have left it dirty.
+# Hangs and crashes corrupt device state. Normal test failures (PCC mismatch,
+# assertion errors) and collection errors don't touch the device.
+if [[ "$IS_HANG" == true ]]; then
+    echo "TT_TEST: Resetting device..." >&2
+    if tt-smi -r; then
+        sleep 2
+        rm -f "$DIRTY_FLAG"
+        echo "TT_TEST: Device reset complete" >&2
+    else
+        echo "TT_TEST: Device reset FAILED; leaving device marked dirty" >&2
+    fi
+
+    echo "TT_TEST_RESULT: HANG (exit code: $EXIT_CODE)" >&2
+    echo "" >&2
+
+    # Dump full triage log
+    echo "=== TRIAGE LOG ===" >&2
+    cat "$TRIAGE_LOG" >&2
+    echo "=== END TRIAGE LOG ===" >&2
+    echo "" >&2
+
+    # In dev mode, also dump watcher log
+    if [[ "$DEV_MODE" == true && -f "$WATCHER_LOG" ]]; then
+        echo "=== WATCHER LOG (last 50 lines) ===" >&2
+        tail -50 "$WATCHER_LOG" >&2
+        echo "=== END WATCHER LOG ===" >&2
+        echo "" >&2
+    fi
+
+    rm -f "$TRIAGE_LOG"
+    exit 2
+fi
+
+rm -f "$DIRTY_FLAG"
+rm -f "$TRIAGE_LOG"
+echo "TT_TEST_RESULT: FAIL (exit code: $EXIT_CODE)" >&2
+exit 1


### PR DESCRIPTION
Adds a script for automatic device serialization. Motivation behind this change is running multiple agents in parallel. In order for them to not clash for the device ownership, this script is added.

Metal context already has a mechanism that prevents multiple processes from accessing the device at the same time. However, it does not have a mechanism for recovering in cases where the device is left in a bad state (for example after a hang). This adds auto device recovery, which makes coding agents waste less time.

As this change is primarily targed for agent use, you should upgrade your CLAUDE.md / AGENTS.md, reminding it to use this instead of raw pytest 

## Summary
- Adds `scripts/tt-test.sh`, a cooperative test runner that serializes device access via `flock` so multiple users/agents can run tests without clashing
- Detects hangs via `TT_METAL_OPERATION_TIMEOUT_SECONDS` dispatch timeout (5s)
- Automatically resets devices after hangs using `tt-smi -r`, with a pessimistic dirty flag that survives SIGKILL/OOM
- `--dev` mode enables polling watcher (NoC sanitizer, waypoints, CB sanitization), lightweight kernel asserts, LLK asserts, and dumps triage + watcher logs on hang
- Warns at startup if `tt-exalens` is not installed (required for triage output)

## Usage
```bash
# Basic mode — dispatch timeout only, no debug overhead
scripts/tt-test.sh <test_path> [extra_pytest_args...]

# Dev mode — watcher + asserts + triage
scripts/tt-test.sh --dev <test_path> [extra_pytest_args...]
```

## Exit codes
- `0` — All tests passed
- `1` — Test failure (normal pytest failure, no hang)
- `2` — Hang detected (dispatch timeout fired)
- `3` — Setup error

🤖 Generated with [Claude Code](https://claude.com/claude-code)