### PR TITLE
#38898: use device 2.0 constructs in accumulation kernels

### DIFF
--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/compute/accumulation_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/compute/accumulation_compute.cpp
@@ -11,6 +11,7 @@
 #define APPROX false
 #include "api/compute/common.h"
 #include "api/compute/eltwise_binary_sfpu.h"
+#include "experimental/circular_buffer.h"
 #include "../accumulation_common.hpp"
 
 void kernel_main() {
@@ -18,7 +19,12 @@ void kernel_main() {
     const uint32_t tiles_per_row = get_arg_val<uint32_t>(1);
     const AccumulationOp accumulation_op = static_cast<AccumulationOp>(get_arg_val<uint32_t>(2));
 
-    cb_wait_front(cb_start, ONE_TILE);
+    experimental::CircularBuffer cb_start_obj(cb_start);
+    experimental::CircularBuffer cb_in_obj(cb_in);
+    experimental::CircularBuffer cb_out_obj(cb_out);
+    experimental::CircularBuffer cb_acc_obj(cb_acc);
+
+    cb_start_obj.wait_front(ONE_TILE);
 
     for (uint32_t i = 0; i < num_rows; i++) {
         bool enable_reload = false;
@@ -26,7 +32,7 @@ void kernel_main() {
         for (uint32_t j = 0; j < tiles_per_row; j++) {
             tile_regs_acquire();
             const uint32_t cb_op = enable_reload ? cb_acc : cb_start;
-            cb_wait_front(cb_in, ONE_TILE);
+            cb_in_obj.wait_front(ONE_TILE);
 
             binary_op_init_common(cb_in, cb_op, cb_out);
 
@@ -53,40 +59,33 @@ void kernel_main() {
 #endif  // CUMSUM_USE_INT32
             }
 
-            cb_pop_front(cb_in, ONE_TILE);
+            cb_in_obj.pop_front(ONE_TILE);
             if (enable_reload) {
-                cb_pop_front(cb_acc, ONE_TILE);
+                cb_acc_obj.pop_front(ONE_TILE);
             }
 
             tile_regs_commit();
             tile_regs_wait();
 
-            cb_reserve_back(cb_acc, ONE_TILE);
-            // pack_reconfig_data_format(cb_acc);
+            cb_acc_obj.reserve_back(ONE_TILE);
             pack_tile(WORKING_REG, cb_acc);
-            cb_push_back(cb_acc, ONE_TILE);
+            cb_acc_obj.push_back(ONE_TILE);
 
-            // release_dst();
-
-            // acquire_dst();
-
-            cb_wait_front(cb_acc, ONE_TILE);
+            cb_acc_obj.wait_front(ONE_TILE);
             copy_tile_to_dst_init_short(cb_acc);
             copy_tile(cb_acc, FIRST_TILE, WORKING_REG);
 
-            cb_reserve_back(cb_out, ONE_TILE);
-            // pack_reconfig_data_format(cb_out);
+            cb_out_obj.reserve_back(ONE_TILE);
             pack_tile(WORKING_REG, cb_out);
-            cb_push_back(cb_out, ONE_TILE);
+            cb_out_obj.push_back(ONE_TILE);
 
             tile_regs_release();
 
             enable_reload = true;
         }
 
-        // cb_wait_front(cb_acc);
-        cb_pop_front(cb_acc, ONE_TILE);
+        cb_acc_obj.pop_front(ONE_TILE);
     }
 
-    cb_pop_front(cb_start, ONE_TILE);
+    cb_start_obj.pop_front(ONE_TILE);
 }

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/dataflow/accumulation_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/dataflow/accumulation_reader.cpp
@@ -76,7 +76,7 @@ void kernel_main() {
     }
 
     // TODO(jbbieniekTT): issue #21108
-    experimental::CoreLocalMem<int32_t> data_start(data_start_addr);
+    volatile experimental::CoreLocalMem<int32_t> data_start(data_start_addr);
     for (uint32_t i = 0; i < ublock_size_bytes / sizeof(int32_t); i++) {
         data_start[i] = scaler;
     }

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/dataflow/accumulation_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/dataflow/accumulation_reader.cpp
@@ -3,6 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/core_local_mem.h"
+#include "experimental/tensor.h"
 
 #include "../accumulation_common.hpp"
 
@@ -32,8 +36,12 @@ void kernel_main() {
     // type of accumulation
     const AccumulationOp accumulation_op = static_cast<AccumulationOp>(get_arg_val<uint32_t>(8));
 
-    cb_reserve_back(cb_start, ONE_TILE);
-    uint32_t data_start_addr = get_write_ptr(cb_start);
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_start_obj(cb_start);
+    experimental::CircularBuffer cb_in_obj(cb_in);
+
+    cb_start_obj.reserve_back(ONE_TILE);
+    uint32_t data_start_addr = cb_start_obj.get_write_ptr();
 
     const int32_t ACC_START_VALUE_F32{caster.u};
     constexpr int32_t ACC_START_VALUE_F16{0x3F80};
@@ -68,25 +76,24 @@ void kernel_main() {
     }
 
     // TODO(jbbieniekTT): issue #21108
-    volatile tt_l1_ptr int32_t* data_start = reinterpret_cast<volatile tt_l1_ptr int32_t*>(data_start_addr);
-    for (uint32_t i = 0; i < ublock_size_bytes / sizeof(data_start); i++) {
+    experimental::CoreLocalMem<int32_t> data_start(data_start_addr);
+    for (uint32_t i = 0; i < ublock_size_bytes / sizeof(int32_t); i++) {
         data_start[i] = scaler;
     }
 
     const auto input_addrg = TensorAccessor(input_addrg_args, input_base_addr, input_tile_bytes);
 
-    cb_push_back(cb_start, ONE_TILE);
+    cb_start_obj.push_back(ONE_TILE);
 
     for (uint32_t i = start_id; i < start_id + num_rows_per_core; ++i) {
         for (uint32_t j = 0; j < tiles_per_row; ++j) {
             const uint32_t tile_j = flip ? (tiles_per_row - j - 1) : j;
             const uint32_t read_tile_id{
                 get_tile_id(low_rank_offset, high_rank_offset, tile_j, tiles_per_row, input_tile_offset)};
-            cb_reserve_back(cb_in, ONE_TILE);
-            uint32_t l1_write_addr{get_write_ptr(cb_in)};
-            noc_async_read_tile(read_tile_id, input_addrg, l1_write_addr);
-            noc_async_read_barrier();
-            cb_push_back(cb_in, ONE_TILE);
+            cb_in_obj.reserve_back(ONE_TILE);
+            noc.async_read(input_addrg, cb_in_obj, input_tile_bytes, {.page_id = read_tile_id}, {.offset_bytes = 0});
+            noc.async_read_barrier();
+            cb_in_obj.push_back(ONE_TILE);
         }
         ++high_rank_offset;
         if (high_rank_offset >= input_tile_offset) {

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/dataflow/accumulation_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/dataflow/accumulation_reader.cpp
@@ -76,7 +76,7 @@ void kernel_main() {
     }
 
     // TODO(jbbieniekTT): issue #21108
-    volatile experimental::CoreLocalMem<int32_t> data_start(data_start_addr);
+    experimental::CoreLocalMem<volatile int32_t> data_start(data_start_addr);
     for (uint32_t i = 0; i < ublock_size_bytes / sizeof(int32_t); i++) {
         data_start[i] = scaler;
     }

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/dataflow/accumulation_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/dataflow/accumulation_writer.cpp
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 
 #include "../accumulation_common.hpp"
 
@@ -27,16 +30,19 @@ void kernel_main() {
 
     const auto output_addrg = TensorAccessor(output_addrg_args, output_base_addr, output_tile_bytes);
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_out_obj(cb_out);
+
     for (uint32_t i = start_id; i < start_id + num_rows_per_core; ++i) {
         for (uint32_t j = 0; j < tiles_per_row; ++j) {
             const uint32_t tile_j = flip ? (tiles_per_row - j - 1) : j;
             const uint32_t write_tile_id =
                 get_tile_id(low_rank_offset, high_rank_offset, tile_j, tiles_per_row, input_tile_offset);
-            cb_wait_front(cb_out, ONE_TILE);
-            uint32_t l1_read_addr = get_read_ptr(cb_out);
-            noc_async_write_tile(write_tile_id, output_addrg, l1_read_addr);
-            noc_async_write_barrier();
-            cb_pop_front(cb_out, ONE_TILE);
+            cb_out_obj.wait_front(ONE_TILE);
+            noc.async_write(
+                cb_out_obj, output_addrg, output_tile_bytes, {.offset_bytes = 0}, {.page_id = write_tile_id});
+            noc.async_write_barrier();
+            cb_out_obj.pop_front(ONE_TILE);
         }
         ++high_rank_offset;
         if (high_rank_offset >= input_tile_offset) {

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/compute/ema_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/compute/ema_compute.cpp
@@ -6,6 +6,7 @@
 #include "api/compute/transpose_wh.h"
 #include "api/compute/ema.h"
 #include "experimental/circular_buffer.h"
+#include "../../../device/kernels/accumulation_common.hpp"
 
 /*
  * -------------------------------------------------------------------------------------------------
@@ -74,13 +75,13 @@ void kernel_main() {
 
     // CB indices
     // ----------
-    constexpr auto src_cb = tt::CBIndex::c_0;
-    constexpr auto dst_cb = tt::CBIndex::c_1;
-    constexpr auto trp_cb = tt::CBIndex::c_2;
+    constexpr auto src_cb_idx = tt::CBIndex::c_0;
+    constexpr auto dst_cb_idx = tt::CBIndex::c_1;
+    constexpr auto trp_cb_idx = tt::CBIndex::c_2;
 
-    experimental::CircularBuffer cb_src(src_cb);
-    experimental::CircularBuffer cb_dst(dst_cb);
-    experimental::CircularBuffer cb_trp(trp_cb);
+    experimental::CircularBuffer cb_src(src_cb_idx);
+    experimental::CircularBuffer cb_dst(dst_cb_idx);
+    experimental::CircularBuffer cb_trp(trp_cb_idx);
 
     // DST indices
     // -----------
@@ -90,38 +91,38 @@ void kernel_main() {
     //-------------------------------------------------------------------------
     // Main loop - compute ema for each batch
     ema_init(alpha_bits, beta_bits);
-    transpose_wh_init(src_cb, dst_cb);
+    transpose_wh_init(src_cb_idx, dst_cb_idx);
 
     for (uint32_t batch_id = 0; batch_id < total_batches_per_core; ++batch_id) {
         // For each batch, clear the previous output
         ema_clear_previous_output();
         for (uint32_t tile_id = 0; tile_id < tiles_per_channel; ++tile_id) {
             // Read input, transpose and compute ema
-            cb_src.wait_front(1);
+            cb_src.wait_front(ONE_TILE);
             tile_regs_acquire();
-            transpose_wh_tile(src_cb, 0, inp_dst_index);
+            transpose_wh_tile(src_cb_idx, 0, inp_dst_index);
             ema_tile(inp_dst_index);
             tile_regs_commit();
-            cb_src.pop_front(1);
+            cb_src.pop_front(ONE_TILE);
 
-            cb_trp.reserve_back(1);
+            cb_trp.reserve_back(ONE_TILE);
             tile_regs_wait();
-            pack_tile(output_dst_index, trp_cb);
+            pack_tile(output_dst_index, trp_cb_idx);
             tile_regs_release();
-            cb_trp.push_back(1);
+            cb_trp.push_back(ONE_TILE);
 
             // Transpose back and write to output
-            cb_trp.wait_front(1);
+            cb_trp.wait_front(ONE_TILE);
             tile_regs_acquire();
-            transpose_wh_tile(trp_cb, 0, output_dst_index);
+            transpose_wh_tile(trp_cb_idx, 0, output_dst_index);
             tile_regs_commit();
-            cb_trp.pop_front(1);
+            cb_trp.pop_front(ONE_TILE);
 
-            cb_dst.reserve_back(1);
+            cb_dst.reserve_back(ONE_TILE);
             tile_regs_wait();
-            pack_tile(output_dst_index, dst_cb);
+            pack_tile(output_dst_index, dst_cb_idx);
             tile_regs_release();
-            cb_dst.push_back(1);
+            cb_dst.push_back(ONE_TILE);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/compute/ema_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/compute/ema_compute.cpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include "api/compute/transpose_wh.h"
 #include "api/compute/ema.h"
+#include "experimental/circular_buffer.h"
 
 /*
  * -------------------------------------------------------------------------------------------------
@@ -77,6 +78,10 @@ void kernel_main() {
     constexpr auto dst_cb = tt::CBIndex::c_1;
     constexpr auto trp_cb = tt::CBIndex::c_2;
 
+    experimental::CircularBuffer cb_src(src_cb);
+    experimental::CircularBuffer cb_dst(dst_cb);
+    experimental::CircularBuffer cb_trp(trp_cb);
+
     // DST indices
     // -----------
     constexpr auto inp_dst_index = 0;
@@ -92,31 +97,31 @@ void kernel_main() {
         ema_clear_previous_output();
         for (uint32_t tile_id = 0; tile_id < tiles_per_channel; ++tile_id) {
             // Read input, transpose and compute ema
-            cb_wait_front(src_cb, 1);
+            cb_src.wait_front(1);
             tile_regs_acquire();
             transpose_wh_tile(src_cb, 0, inp_dst_index);
             ema_tile(inp_dst_index);
             tile_regs_commit();
-            cb_pop_front(src_cb, 1);
+            cb_src.pop_front(1);
 
-            cb_reserve_back(trp_cb, 1);
+            cb_trp.reserve_back(1);
             tile_regs_wait();
             pack_tile(output_dst_index, trp_cb);
             tile_regs_release();
-            cb_push_back(trp_cb, 1);
+            cb_trp.push_back(1);
 
             // Transpose back and write to output
-            cb_wait_front(trp_cb, 1);
+            cb_trp.wait_front(1);
             tile_regs_acquire();
             transpose_wh_tile(trp_cb, 0, output_dst_index);
             tile_regs_commit();
-            cb_pop_front(trp_cb, 1);
+            cb_trp.pop_front(1);
 
-            cb_reserve_back(dst_cb, 1);
+            cb_dst.reserve_back(1);
             tile_regs_wait();
             pack_tile(output_dst_index, dst_cb);
             tile_regs_release();
-            cb_push_back(dst_cb, 1);
+            cb_dst.push_back(1);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/dataflow/ema_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/dataflow/ema_reader.cpp
@@ -5,6 +5,9 @@
 #include <cstdint>
 
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 
 void kernel_main() {
     // Compile time args
@@ -29,14 +32,15 @@ void kernel_main() {
     // ---------------
     const auto src_accessor = TensorAccessor(src_args, src_base_addr, src_tile_size);
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_src(src_cb);
+
     //-------------------------------------------------------------------------
     // Main loop - pull pages from src and push to src_cb
     for (uint32_t tile_id = src_start_tile; tile_id < (src_start_tile + total_tiles_per_core); ++tile_id) {
-        cb_reserve_back(src_cb, 1);
-        const uint32_t l1_write_addr = get_write_ptr(src_cb);
-        const uint64_t src_noc_addr = src_accessor.get_noc_addr(tile_id);
-        noc_async_read(src_noc_addr, l1_write_addr, src_tile_size);
-        noc_async_read_barrier();
-        cb_push_back(src_cb, 1);
+        cb_src.reserve_back(1);
+        noc.async_read(src_accessor, cb_src, src_tile_size, {.page_id = tile_id}, {.offset_bytes = 0});
+        noc.async_read_barrier();
+        cb_src.push_back(1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/dataflow/ema_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/dataflow/ema_reader.cpp
@@ -8,6 +8,7 @@
 #include "experimental/noc.h"
 #include "experimental/circular_buffer.h"
 #include "experimental/tensor.h"
+#include "../../../device/kernels/accumulation_common.hpp"
 
 void kernel_main() {
     // Compile time args
@@ -22,25 +23,25 @@ void kernel_main() {
 
     // CB indices
     // ----------
-    constexpr auto src_cb = tt::CBIndex::c_0;
+    constexpr auto src_cb_idx = tt::CBIndex::c_0;
 
     // Tile sizes
     // ----------
-    constexpr uint32_t src_tile_size = get_tile_size(src_cb);
+    constexpr uint32_t src_tile_size = get_tile_size(src_cb_idx);
 
     // Tensor accessor
     // ---------------
     const auto src_accessor = TensorAccessor(src_args, src_base_addr, src_tile_size);
 
     experimental::Noc noc;
-    experimental::CircularBuffer cb_src(src_cb);
+    experimental::CircularBuffer cb_src(src_cb_idx);
 
     //-------------------------------------------------------------------------
     // Main loop - pull pages from src and push to src_cb
     for (uint32_t tile_id = src_start_tile; tile_id < (src_start_tile + total_tiles_per_core); ++tile_id) {
-        cb_src.reserve_back(1);
+        cb_src.reserve_back(ONE_TILE);
         noc.async_read(src_accessor, cb_src, src_tile_size, {.page_id = tile_id}, {.offset_bytes = 0});
         noc.async_read_barrier();
-        cb_src.push_back(1);
+        cb_src.push_back(ONE_TILE);
     }
 }

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/dataflow/ema_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/dataflow/ema_writer.cpp
@@ -8,6 +8,7 @@
 #include "experimental/noc.h"
 #include "experimental/circular_buffer.h"
 #include "experimental/tensor.h"
+#include "../../../device/kernels/accumulation_common.hpp"
 
 void kernel_main() {
     // Compile time args
@@ -22,25 +23,25 @@ void kernel_main() {
 
     // CB indices
     // ----------
-    constexpr auto dst_cb = tt::CBIndex::c_1;
+    constexpr auto dst_cb_idx = tt::CBIndex::c_1;
 
     // Tile sizes
     // ----------
-    constexpr uint32_t dst_tile_size = get_tile_size(dst_cb);
+    constexpr uint32_t dst_tile_size = get_tile_size(dst_cb_idx);
 
     // Tensor accessor
     // ---------------
     const auto dst_accessor = TensorAccessor(dst_args, dst_base_addr, dst_tile_size);
 
     experimental::Noc noc;
-    experimental::CircularBuffer cb_dst(dst_cb);
+    experimental::CircularBuffer cb_dst(dst_cb_idx);
 
     //-------------------------------------------------------------------------
     // Main loop - pull pages from dst_cb and push to dst
     for (uint32_t tile_id = dst_start_tile; tile_id < (dst_start_tile + total_tiles_per_core); ++tile_id) {
-        cb_dst.wait_front(1);
+        cb_dst.wait_front(ONE_TILE);
         noc.async_write(cb_dst, dst_accessor, dst_tile_size, {.offset_bytes = 0}, {.page_id = tile_id});
         noc.async_write_barrier();
-        cb_dst.pop_front(1);
+        cb_dst.pop_front(ONE_TILE);
     }
 }

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/dataflow/ema_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/dataflow/ema_writer.cpp
@@ -5,6 +5,9 @@
 #include <cstdint>
 
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 
 void kernel_main() {
     // Compile time args
@@ -29,14 +32,15 @@ void kernel_main() {
     // ---------------
     const auto dst_accessor = TensorAccessor(dst_args, dst_base_addr, dst_tile_size);
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_dst(dst_cb);
+
     //-------------------------------------------------------------------------
     // Main loop - pull pages from dst_cb and push to dst
     for (uint32_t tile_id = dst_start_tile; tile_id < (dst_start_tile + total_tiles_per_core); ++tile_id) {
-        cb_wait_front(dst_cb, 1);
-        const uint32_t l1_read_addr = get_read_ptr(dst_cb);
-        const uint64_t dst_noc_addr = dst_accessor.get_noc_addr(tile_id);
-        noc_async_write(l1_read_addr, dst_noc_addr, dst_tile_size);
-        noc_async_write_barrier();
-        cb_pop_front(dst_cb, 1);
+        cb_dst.wait_front(1);
+        noc.async_write(cb_dst, dst_accessor, dst_tile_size, {.offset_bytes = 0}, {.page_id = tile_id});
+        noc.async_write_barrier();
+        cb_dst.pop_front(1);
     }
 }


### PR DESCRIPTION
### Ticket
Link to Github Issue #38898

### Problem description
There's a new API

### What's changed
Move to the new API

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=bbradel-38898_acc_m20)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:bbradel-38898_acc_m20) https://github.com/tenstorrent/tt-metal/actions/runs/22579780629
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-38898_acc_m20)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-38898_acc_m20)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-38898_acc_m20)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-38898_acc_m20)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-38898_acc_m20)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-38898_acc_m20)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-38898_acc_m20)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-38898_acc_m20)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-38898_acc_m20)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-38898_acc_m20)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
