### PR TITLE
Fix TensixSingleCoreDirectDramReaderDatacopyWriter by removing accidental deletion of CBs

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_direct.cpp
+++ b/tests/tt_metal/tt_metal/api/test_direct.cpp
@@ -369,6 +369,16 @@ bool reader_datacopy_writer(
         const uint32_t input0_cb_index = 0;
         const uint32_t output_cb_index = 16;
 
+        tt_metal::CircularBufferConfig l1_input_cb_config =
+            tt_metal::CircularBufferConfig(byte_size, {{input0_cb_index, test_config.l1_input_data_format}})
+                .set_page_size(input0_cb_index, test_config.tile_byte_size);
+        tt_metal::CreateCircularBuffer(program_, test_config.core, l1_input_cb_config);
+
+        tt_metal::CircularBufferConfig l1_output_cb_config =
+            tt_metal::CircularBufferConfig(byte_size, {{output_cb_index, test_config.l1_output_data_format}})
+                .set_page_size(output_cb_index, test_config.tile_byte_size);
+        tt_metal::CreateCircularBuffer(program_, test_config.core, l1_output_cb_config);
+
         reader_kernel = tt_metal::CreateKernel(
             program_,
             "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary.cpp",
@@ -431,6 +441,9 @@ bool reader_datacopy_writer(
 
     auto blocking = device->arch() == ARCH::QUASAR;
     distributed::EnqueueMeshWorkload(cq, workload, blocking);
+    if (not blocking) {
+        distributed::Finish(cq);
+    }
 
     std::vector<uint32_t> dest_buffer_data;
     tt_metal::detail::ReadFromBuffer(output_dram_buffer, dest_buffer_data);


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Accidentally deleted CB creation in 1576efcf7d241ad0d38410a37cafb97c8dfc2546.

### Checklist

- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=abhullar/direct-dc)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:abhullar/direct-dc)
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early

