### PR TITLE
#38908: use device 2.0 api for generic reduce

### DIFF
--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_h.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_h.cpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 
 #include "api/compute/reduce.h"
+#include "experimental/circular_buffer.h"
 
 void kernel_main() {
     uint32_t Ht = get_compile_time_arg_val(0);
@@ -12,10 +13,14 @@ void kernel_main() {
     uint32_t NC = get_compile_time_arg_val(2);
     uint32_t row_chunk = get_compile_time_arg_val(3);
 
+    experimental::CircularBuffer cb0(tt::CBIndex::c_0);
+    experimental::CircularBuffer cb2(tt::CBIndex::c_2);
+    experimental::CircularBuffer cb3(tt::CBIndex::c_3);
+
     compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_3);
     reduce_init(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_3);
 
-    cb_wait_front(tt::CBIndex::c_2, 1);  // scaler tile from the reader
+    cb2.wait_front(1);  // scaler tile from the reader
 
     constexpr int onetile = 1;
 
@@ -39,16 +44,16 @@ void kernel_main() {
             for (uint32_t ht = 0; ht < Ht; ++ht) {
                 reduce_dst_idx = 0;
                 for (uint32_t i = wt; i < chunk_end; ++i) {
-                    cb_wait_front(tt::CB::c_in0, onetile);
+                    cb0.wait_front(onetile);
                     reduce_tile(tt::CB::c_in0, tt::CB::c_in2, 0, 0, reduce_dst_idx);
-                    cb_pop_front(tt::CB::c_in0, onetile);
+                    cb0.pop_front(onetile);
                     ++reduce_dst_idx;
                 }
             }
             for (uint32_t i = wt; i < chunk_end; ++i) {
-                cb_reserve_back(tt::CBIndex::c_3, onetile);
+                cb3.reserve_back(onetile);
                 pack_tile((i - wt), tt::CBIndex::c_3);
-                cb_push_back(tt::CBIndex::c_3, onetile);
+                cb3.push_back(onetile);
             }
             release_dst();
         }

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_h_neg.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_h_neg.cpp
@@ -9,6 +9,7 @@
 #include "api/compute/eltwise_unary/eltwise_unary.h"
 #include "api/compute/eltwise_unary/negative.h"
 #include "api/compute/tile_move_copy.h"
+#include "experimental/circular_buffer.h"
 
 void kernel_main() {
     uint32_t Ht = get_compile_time_arg_val(0);
@@ -23,8 +24,14 @@ void kernel_main() {
     constexpr uint32_t cb_acc = tt::CBIndex::c_4;
     constexpr uint32_t cb_ineg = tt::CBIndex::c_5;
 
+    experimental::CircularBuffer cb_input_obj(cb_input);
+    experimental::CircularBuffer cb_scaler_obj(cb_scaler);
+    experimental::CircularBuffer cb_output_obj(cb_output);
+    experimental::CircularBuffer cb_acc_obj(cb_acc);
+    experimental::CircularBuffer cb_ineg_obj(cb_ineg);
+
     compute_kernel_hw_startup(cb_input, cb_scaler, cb_output);
-    cb_wait_front(cb_scaler, 1);  // scaler tile from the reader
+    cb_scaler_obj.wait_front(1);  // scaler tile from the reader
 
     constexpr int onetile = 1;
 
@@ -48,7 +55,7 @@ void kernel_main() {
             for (uint32_t ht = 0; ht < Ht; ++ht) {
                 reduce_dst_idx = 0;
                 tile_regs_acquire();
-                cb_wait_front(cb_input, ntiles);
+                cb_input_obj.wait_front(ntiles);
 
                 reconfig_data_format_srca(cb_input);
                 copy_tile_init(cb_input);
@@ -59,23 +66,23 @@ void kernel_main() {
                 }
 
                 tile_regs_commit();
-                cb_pop_front(cb_input, chunk_end - wt);
-                cb_reserve_back(cb_ineg, ntiles);
+                cb_input_obj.pop_front(chunk_end - wt);
+                cb_ineg_obj.reserve_back(ntiles);
                 tile_regs_wait();
                 pack_reconfig_data_format(cb_ineg);
                 for (uint32_t i = 0; i < ntiles; ++i) {
                     pack_tile(i, cb_ineg);
                 }
                 tile_regs_release();
-                cb_push_back(cb_ineg, ntiles);
+                cb_ineg_obj.push_back(ntiles);
 
                 tile_regs_acquire();
 
                 if (ht > 0) {
-                    cb_wait_front(cb_acc, ntiles);
+                    cb_acc_obj.wait_front(ntiles);
                 }
 
-                cb_wait_front(cb_ineg, ntiles);
+                cb_ineg_obj.wait_front(ntiles);
 
                 if (ht > 0) {
                     reconfig_data_format_srca(cb_acc);
@@ -91,23 +98,23 @@ void kernel_main() {
                 }
                 reduce_uninit(cb_ineg);
                 tile_regs_commit();
-                cb_pop_front(cb_ineg, ntiles);
+                cb_ineg_obj.pop_front(ntiles);
 
                 if (ht > 0) {
-                    cb_pop_front(cb_acc, ntiles);
+                    cb_acc_obj.pop_front(ntiles);
                 }
-                cb_reserve_back(cb_acc, ntiles);
+                cb_acc_obj.reserve_back(ntiles);
                 tile_regs_wait();
                 for (uint32_t i = 0; i < ntiles; ++i) {
                     pack_tile(i, cb_acc);
                 }
                 tile_regs_release();
-                cb_push_back(cb_acc, ntiles);
+                cb_acc_obj.push_back(ntiles);
             }
 
             tile_regs_acquire();
 
-            cb_wait_front(cb_acc, ntiles);
+            cb_acc_obj.wait_front(ntiles);
 
             reconfig_data_format_srca(cb_acc);
             copy_tile_init(cb_acc);
@@ -120,15 +127,15 @@ void kernel_main() {
             }
 
             tile_regs_commit();
-            cb_pop_front(cb_acc, ntiles);
-            cb_reserve_back(cb_output, ntiles);
+            cb_acc_obj.pop_front(ntiles);
+            cb_output_obj.reserve_back(ntiles);
             tile_regs_wait();
             pack_reconfig_data_format(cb_output);
             for (uint32_t i = 0; i < ntiles; ++i) {
                 pack_tile(i, cb_output);
             }
             tile_regs_release();
-            cb_push_back(cb_output, ntiles);
+            cb_output_obj.push_back(ntiles);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_hw.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_hw.cpp
@@ -5,16 +5,21 @@
 #include <cstdint>
 
 #include "api/compute/reduce.h"
+#include "experimental/circular_buffer.h"
 
 void kernel_main() {
     uint32_t Ht = get_compile_time_arg_val(0);
     uint32_t Wt = get_compile_time_arg_val(1);
     uint32_t NC = get_compile_time_arg_val(2);
 
+    experimental::CircularBuffer cb0(tt::CBIndex::c_0);
+    experimental::CircularBuffer cb2(tt::CBIndex::c_2);
+    experimental::CircularBuffer cb3(tt::CBIndex::c_3);
+
     compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_3);
     reduce_init(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_3);
 
-    cb_wait_front(tt::CBIndex::c_2, 1);  // scaler tile from the reader
+    cb2.wait_front(1);  // scaler tile from the reader
     for (uint32_t nc = 0; nc < NC; nc++) {
         constexpr int onetile = 1;
         int reduce_dst_idx = 0;
@@ -24,15 +29,15 @@ void kernel_main() {
             // reducing in W means out[h][0] = sum(w=0..W-1, in[h][w])
             // in this case we just sequentially add to accumulator all the W-tiles in a row
             for (uint32_t wt = 0; wt < Wt; ++wt) {
-                cb_wait_front(tt::CBIndex::c_0, onetile);
+                cb0.wait_front(onetile);
                 // REDUCE_OP/DIM is expected to come from add_define
                 reduce_tile(tt::CBIndex::c_0, tt::CBIndex::c_2, 0, 0, reduce_dst_idx);
-                cb_pop_front(tt::CBIndex::c_0, onetile);
+                cb0.pop_front(onetile);
             }
         }
-        cb_reserve_back(tt::CBIndex::c_3, onetile);
+        cb3.reserve_back(onetile);
         pack_tile(reduce_dst_idx, tt::CBIndex::c_3);
-        cb_push_back(tt::CBIndex::c_3, onetile);
+        cb3.push_back(onetile);
         release_dst();
     }
 }

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_hw_neg.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_hw_neg.cpp
@@ -9,6 +9,7 @@
 #include "api/compute/eltwise_unary/eltwise_unary.h"
 #include "api/compute/eltwise_unary/negative.h"
 #include "api/compute/tile_move_copy.h"
+#include "experimental/circular_buffer.h"
 
 void kernel_main() {
     uint32_t Ht = get_compile_time_arg_val(0);
@@ -21,8 +22,14 @@ void kernel_main() {
     constexpr uint32_t cb_acc = tt::CBIndex::c_4;
     constexpr uint32_t cb_ineg = tt::CBIndex::c_5;
 
+    experimental::CircularBuffer cb_input_obj(cb_input);
+    experimental::CircularBuffer cb_scaler_obj(cb_scaler);
+    experimental::CircularBuffer cb_output_obj(cb_output);
+    experimental::CircularBuffer cb_acc_obj(cb_acc);
+    experimental::CircularBuffer cb_ineg_obj(cb_ineg);
+
     compute_kernel_hw_startup(cb_input, cb_scaler, cb_output);
-    cb_wait_front(cb_scaler, 1);  // scaler tile from the reader
+    cb_scaler_obj.wait_front(1);  // scaler tile from the reader
     for (uint32_t nc = 0; nc < NC; nc++) {
         constexpr int onetile = 1;
         int reduce_dst_idx = 0;
@@ -32,49 +39,49 @@ void kernel_main() {
             // in this case we just sequentially add to accumulator all the W-tiles in a row
             for (uint32_t wt = 0; wt < Wt; ++wt) {
                 acquire_dst();
-                cb_wait_front(cb_input, onetile);
+                cb_input_obj.wait_front(onetile);
                 copy_tile_init(cb_input);
                 copy_tile(cb_input, 0, reduce_dst_idx);
                 negative_tile_init();
                 negative_tile(reduce_dst_idx);
-                cb_pop_front(cb_input, onetile);
-                cb_reserve_back(cb_ineg, onetile);
+                cb_input_obj.pop_front(onetile);
+                cb_ineg_obj.reserve_back(onetile);
                 pack_tile(reduce_dst_idx, cb_ineg);
-                cb_push_back(cb_ineg, onetile);
+                cb_ineg_obj.push_back(onetile);
                 release_dst();
 
                 acquire_dst();
                 if (wt > 0 || ht > 0) {
-                    cb_wait_front(cb_acc, onetile);
+                    cb_acc_obj.wait_front(onetile);
                     copy_tile_init(cb_acc);
                     copy_tile(cb_acc, 0, reduce_dst_idx);
                 }
 
-                cb_wait_front(cb_ineg, onetile);
+                cb_ineg_obj.wait_front(onetile);
                 reduce_init(cb_ineg, cb_scaler, cb_acc);
                 reduce_tile(cb_ineg, cb_scaler, 0, 0, reduce_dst_idx);
                 reduce_uninit();
-                cb_pop_front(cb_ineg, onetile);
+                cb_ineg_obj.pop_front(onetile);
                 if (wt > 0 || ht > 0) {
-                    cb_pop_front(cb_acc, onetile);
+                    cb_acc_obj.pop_front(onetile);
                 }
-                cb_reserve_back(cb_acc, onetile);
+                cb_acc_obj.reserve_back(onetile);
                 pack_tile(reduce_dst_idx, cb_acc);
-                cb_push_back(cb_acc, onetile);
+                cb_acc_obj.push_back(onetile);
                 release_dst();
             }  // wt
         }  // ht
 
         acquire_dst();
-        cb_wait_front(cb_acc, onetile);
+        cb_acc_obj.wait_front(onetile);
         copy_tile_init(cb_acc);
         copy_tile(cb_acc, 0, reduce_dst_idx);
         negative_tile_init();
         negative_tile(reduce_dst_idx);
-        cb_pop_front(cb_acc, onetile);
-        cb_reserve_back(cb_output, onetile);
+        cb_acc_obj.pop_front(onetile);
+        cb_output_obj.reserve_back(onetile);
         pack_tile(reduce_dst_idx, cb_output);
-        cb_push_back(cb_output, onetile);
+        cb_output_obj.push_back(onetile);
         release_dst();
     }  // nc
 }

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_w.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_w.cpp
@@ -9,11 +9,16 @@
 #else
 #include "api/compute/matmul.h"
 #endif
+#include "experimental/circular_buffer.h"
 
 void kernel_main() {
     uint32_t Ht = get_compile_time_arg_val(0);
     uint32_t Wt = get_compile_time_arg_val(1);
     uint32_t NC = get_compile_time_arg_val(2);
+
+    experimental::CircularBuffer cb0(tt::CBIndex::c_0);
+    experimental::CircularBuffer cb2(tt::CBIndex::c_2);
+    experimental::CircularBuffer cb3(tt::CBIndex::c_3);
 
 #ifndef REDUCE_ROW_SUM_VIA_MM
     compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_3);
@@ -22,7 +27,7 @@ void kernel_main() {
     mm_init(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_3);
 #endif
 
-    cb_wait_front(tt::CBIndex::c_2, 1);  // scaler tile from the reader
+    cb2.wait_front(1);  // scaler tile from the reader
     for (uint32_t nc = 0; nc < NC; nc++) {
         constexpr int onetile = 1;
         int reduce_dst_idx = 0;
@@ -32,19 +37,19 @@ void kernel_main() {
             // in this case we just sequentially add to accumulator all the W-tiles in a row
             acquire_dst();
             for (uint32_t wt = 0; wt < Wt; ++wt) {
-                cb_wait_front(tt::CBIndex::c_0, onetile);
+                cb0.wait_front(onetile);
                 // REDUCE_OP is expected to come from add_define
 #ifndef REDUCE_ROW_SUM_VIA_MM
                 reduce_tile(tt::CBIndex::c_0, tt::CBIndex::c_2, 0, 0, reduce_dst_idx);
 #else
                 matmul_tiles(tt::CBIndex::c_0, tt::CBIndex::c_2, 0, 0, 0);
 #endif
-                cb_pop_front(tt::CBIndex::c_0, onetile);
+                cb0.pop_front(onetile);
             }
 
-            cb_reserve_back(tt::CBIndex::c_3, onetile);
+            cb3.reserve_back(onetile);
             pack_tile(reduce_dst_idx, tt::CBIndex::c_3);
-            cb_push_back(tt::CBIndex::c_3, onetile);
+            cb3.push_back(onetile);
             release_dst();
         }
     }

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_w_neg.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_w_neg.cpp
@@ -10,6 +10,7 @@
 #include "api/compute/eltwise_unary/fill.h"
 #include "api/compute/eltwise_unary/negative.h"
 #include "api/compute/tile_move_copy.h"
+#include "experimental/circular_buffer.h"
 
 #include "llk_math_eltwise_binary.h"
 
@@ -25,9 +26,15 @@ void kernel_main() {
     constexpr uint32_t cb_acc = tt::CBIndex::c_4;
     constexpr uint32_t cb_ineg = tt::CBIndex::c_5;
 
+    experimental::CircularBuffer cb_input_obj(cb_input);
+    experimental::CircularBuffer cb_scaler_obj(cb_scaler);
+    experimental::CircularBuffer cb_output_obj(cb_output);
+    experimental::CircularBuffer cb_acc_obj(cb_acc);
+    experimental::CircularBuffer cb_ineg_obj(cb_ineg);
+
     compute_kernel_hw_startup(cb_input, cb_scaler, cb_output);
 
-    cb_wait_front(cb_scaler, 1);  // scaler tile from the reader
+    cb_scaler_obj.wait_front(1);  // scaler tile from the reader
     for (uint32_t nc = 0; nc < NC; nc++) {
         constexpr int onetile = 1;
         int dst_idx = 0;
@@ -36,56 +43,56 @@ void kernel_main() {
             // reducing in W means out[h][0] = sum(w=0..W-1, in[h][w])
             // in this case we just sequentially add to accumulator all the W-tiles in a row
             for (uint32_t wt = 0; wt < Wt; ++wt) {
-                cb_wait_front(cb_input, onetile);
+                cb_input_obj.wait_front(onetile);
                 tile_regs_acquire();
                 copy_tile_init(cb_input);
                 copy_tile(cb_input, 0, dst_idx);
                 negative_tile_init();
                 negative_tile(dst_idx);
                 tile_regs_wait();
-                cb_pop_front(cb_input, onetile);
-                cb_reserve_back(cb_ineg, onetile);
+                cb_input_obj.pop_front(onetile);
+                cb_ineg_obj.reserve_back(onetile);
                 tile_regs_commit();
                 pack_tile(dst_idx, cb_ineg);
                 tile_regs_release();
-                cb_push_back(cb_ineg, onetile);
+                cb_ineg_obj.push_back(onetile);
 
                 tile_regs_acquire();
                 if (wt > 0) {
-                    cb_wait_front(cb_acc, onetile);
+                    cb_acc_obj.wait_front(onetile);
                     copy_tile_init(cb_acc);
                     copy_tile(cb_acc, 0, dst_idx);
                 }
 
-                cb_wait_front(cb_ineg, onetile);
+                cb_ineg_obj.wait_front(onetile);
                 reduce_init(cb_ineg, cb_scaler, cb_acc);
                 reduce_tile(cb_ineg, cb_scaler, 0, 0, dst_idx);
                 reduce_uninit();
                 tile_regs_wait();
-                cb_pop_front(cb_ineg, onetile);
+                cb_ineg_obj.pop_front(onetile);
                 if (wt > 0) {
-                    cb_pop_front(cb_acc, onetile);
+                    cb_acc_obj.pop_front(onetile);
                 }
-                cb_reserve_back(cb_acc, onetile);
+                cb_acc_obj.reserve_back(onetile);
                 tile_regs_commit();
                 pack_tile(dst_idx, cb_acc);
                 tile_regs_release();
-                cb_push_back(cb_acc, onetile);
+                cb_acc_obj.push_back(onetile);
             }  // wt
 
-            cb_wait_front(cb_acc, onetile);
+            cb_acc_obj.wait_front(onetile);
             tile_regs_acquire();
             copy_tile_init(cb_acc);
             copy_tile(cb_acc, 0, dst_idx);
             negative_tile_init();
             negative_tile(dst_idx);
             tile_regs_wait();
-            cb_pop_front(cb_acc, onetile);
-            cb_reserve_back(cb_output, onetile);
+            cb_acc_obj.pop_front(onetile);
+            cb_output_obj.reserve_back(onetile);
             tile_regs_commit();
             pack_tile(dst_idx, cb_output);
             tile_regs_release();
-            cb_push_back(cb_output, onetile);
+            cb_output_obj.push_back(onetile);
         }  // ht
     }  // nc
 }

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_reduce_universal_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_reduce_universal_start_id.cpp
@@ -4,6 +4,9 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 #ifndef REDUCE_ROW_SUM_VIA_MM
 #include "ttnn/kernel/dataflow/generate_reduce_scaler.hpp"
 #else
@@ -26,18 +29,19 @@ void kernel_main() {
 
     constexpr uint32_t cb_id_in0 = 0;
 
-    // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
     uint32_t tile_bytes = get_tile_size(cb_id_in0);
 
     auto tensor_accessor = TensorAccessor(tensor_args, src_addr, tile_bytes);
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_in0(cb_id_in0);
+
     // read a ublock of tiles from src to CB, and then push the ublock to unpacker
     for (uint32_t i = start_id; i < start_id + num_tiles; i++) {
-        cb_reserve_back(cb_id_in0, onetile);
-        uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
-        noc_async_read_page(i, tensor_accessor, l1_write_addr);
-        noc_async_read_barrier();
-        cb_push_back(cb_id_in0, onetile);
+        cb_in0.reserve_back(onetile);
+        noc.async_read(tensor_accessor, cb_in0, tile_bytes, {.page_id = i}, {.offset_bytes = 0});
+        noc.async_read_barrier();
+        cb_in0.push_back(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_input_cols_partitioned_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_input_cols_partitioned_sharded.cpp
@@ -6,6 +6,7 @@
 #include "api/dataflow/dataflow_api.h"
 #include "experimental/noc.h"
 #include "experimental/circular_buffer.h"
+#include "experimental/endpoints.h"
 #include "ttnn/kernel/dataflow/generate_reduce_scaler.hpp"
 
 void kernel_main() {
@@ -33,21 +34,30 @@ void kernel_main() {
     experimental::CircularBuffer cb_in1(cb_id_in1);
 
     cb_in1.reserve_back(num_tiles);
-    uint64_t base_noc_addr = get_noc_addr(cb_in1.get_write_ptr());
+    uint32_t base_l1_addr = cb_in1.get_write_ptr();
+
+    experimental::UnicastEndpoint src;
+    uint32_t src_noc_x = my_x[noc_index];
+    uint32_t src_noc_y = my_y[noc_index];
 
     for (uint32_t b = 0; b < batch; ++b) {
-        uint64_t col_noc_addr = base_noc_addr;
+        uint32_t col_l1_addr = base_l1_addr;
         for (uint32_t i = 0; i < Wt; ++i) {
-            uint64_t curr_noc_addr = col_noc_addr;
+            uint32_t curr_l1_addr = col_l1_addr;
             for (uint32_t j = 0; j < Ht; ++j) {
                 cb_in0.reserve_back(onetile);
-                noc_async_read(curr_noc_addr, cb_in0.get_write_ptr(), tile_bytes);
-                curr_noc_addr += row_size_bytes;
+                noc.async_read(
+                    src,
+                    cb_in0,
+                    tile_bytes,
+                    {.noc_x = src_noc_x, .noc_y = src_noc_y, .addr = curr_l1_addr},
+                    {.offset_bytes = 0});
+                curr_l1_addr += row_size_bytes;
                 noc.async_read_barrier();
                 cb_in0.push_back(onetile);
             }
-            col_noc_addr += tile_bytes;
+            col_l1_addr += tile_bytes;
         }
-        base_noc_addr += batch_size_bytes;
+        base_l1_addr += batch_size_bytes;
     }
 }

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_input_cols_partitioned_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_input_cols_partitioned_sharded.cpp
@@ -4,6 +4,8 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
 #include "ttnn/kernel/dataflow/generate_reduce_scaler.hpp"
 
 void kernel_main() {
@@ -26,20 +28,23 @@ void kernel_main() {
     constexpr uint32_t onetile = 1;
     uint32_t tile_bytes = get_tile_size(cb_id_in0);
 
-    cb_reserve_back(cb_id_in1, num_tiles);
-    uint64_t base_noc_addr = get_noc_addr(get_write_ptr(cb_id_in1));
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_in0(cb_id_in0);
+    experimental::CircularBuffer cb_in1(cb_id_in1);
+
+    cb_in1.reserve_back(num_tiles);
+    uint64_t base_noc_addr = get_noc_addr(cb_in1.get_write_ptr());
 
     for (uint32_t b = 0; b < batch; ++b) {
         uint64_t col_noc_addr = base_noc_addr;
         for (uint32_t i = 0; i < Wt; ++i) {
             uint64_t curr_noc_addr = col_noc_addr;
             for (uint32_t j = 0; j < Ht; ++j) {
-                cb_reserve_back(cb_id_in0, onetile);
-                uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
-                noc_async_read(curr_noc_addr, l1_write_addr, tile_bytes);
+                cb_in0.reserve_back(onetile);
+                noc_async_read(curr_noc_addr, cb_in0.get_write_ptr(), tile_bytes);
                 curr_noc_addr += row_size_bytes;
-                noc_async_read_barrier();
-                cb_push_back(cb_id_in0, onetile);
+                noc.async_read_barrier();
+                cb_in0.push_back(onetile);
             }
             col_noc_addr += tile_bytes;
         }

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_universal_input_cols_partitioned.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_universal_input_cols_partitioned.cpp
@@ -4,6 +4,9 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 #include "ttnn/kernel/dataflow/generate_reduce_scaler.hpp"
 
 void kernel_main() {
@@ -20,7 +23,6 @@ void kernel_main() {
 
     constexpr uint32_t cb_id_in0 = tt::CBIndex::c_0;
 
-    // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
     const uint32_t tile_bytes = get_tile_size(cb_id_in0);
 
@@ -30,6 +32,9 @@ void kernel_main() {
 
     constexpr auto tensor_args = TensorAccessorArgs<5>();
     auto tensor_accessor = TensorAccessor(tensor_args, src_addr, tile_bytes);
+
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_in0(cb_id_in0);
 
     uint32_t w = curr_col_in_batch;
 
@@ -55,16 +60,14 @@ void kernel_main() {
         uint32_t reset_w = w;
         uint32_t reset_col_start = col_start_tile_id;
 
-        // row wise read for one chunk
         for (uint32_t j = 0; j < Ht; ++j) {
             w = reset_w;
             col_start_tile_id = reset_col_start;
             for (uint32_t k = i; k < chunk_end; ++k) {
-                cb_reserve_back(cb_id_in0, onetile);
-                uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
-                noc_async_read_page(curr_id, tensor_accessor, l1_write_addr);
-                noc_async_read_barrier();
-                cb_push_back(cb_id_in0, onetile);
+                cb_in0.reserve_back(onetile);
+                noc.async_read(tensor_accessor, cb_in0, tile_bytes, {.page_id = curr_id}, {.offset_bytes = 0});
+                noc.async_read_barrier();
+                cb_in0.push_back(onetile);
 
                 ++w;
 


### PR DESCRIPTION
### Ticket
Link to Github Issue #38908

### Problem description
There is now a device 2.0 api

### What's changed
Moving generic reduce kernels to device 2.0 api

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=bbradel-38908_red_m20)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:bbradel-38908_red_m20)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-38908_red_m20)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-38908_red_m20)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-38908_red_m20)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-38908_red_m20)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-38908_red_m20)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-38908_red_m20)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-38908_red_m20)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-38908_red_m20)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-38908_red_m20)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-38908_red_m20)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
