### PR TITLE
Fix frequent CI mistral and vadv2

### DIFF
--- a/models/experimental/vadv2/tests/pcc/test_tt_vad.py
+++ b/models/experimental/vadv2/tests/pcc/test_tt_vad.py
@@ -17,6 +17,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.experimental.vadv2.common import load_torch_model
 
 
+@pytest.mark.timeout(600)
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 20 * 1024}], indirect=True)
 def test_vadv2(
     device,

--- a/models/experimental/vadv2/tt/tt_head.py
+++ b/models/experimental/vadv2/tt/tt_head.py
@@ -664,7 +664,7 @@ class TtVADHead:
         min_map_pos_idx = ttnn.reshape(min_map_pos_idx, [-1])
         min_map_pos = ttnn.reshape(map_pos, [map_pos.shape[0] * map_pos.shape[1], map_pos.shape[2], map_pos.shape[3]])
         min_map_pos = ttnn.to_torch(min_map_pos)
-        min_map_pos_idx = ttnn.to_torch(min_map_pos_idx)
+        min_map_pos_idx = ttnn.to_torch(min_map_pos_idx).long()
         min_map_pos = min_map_pos[range(min_map_pos.shape[0]), min_map_pos_idx]  # [B*P, 2]
 
         min_map_pos = ttnn.from_torch(min_map_pos, dtype=ttnn.bfloat16, device=self.device)
@@ -827,7 +827,7 @@ class TtVADHead:
         min_map_pos_idx = ttnn.reshape(min_map_pos_idx, [-1])
         min_map_pos = ttnn.reshape(map_pos, [map_pos.shape[0] * map_pos.shape[1], map_pos.shape[2], map_pos.shape[3]])
         min_map_pos = ttnn.to_torch(min_map_pos)
-        min_map_pos_idx = ttnn.to_torch(min_map_pos_idx)
+        min_map_pos_idx = ttnn.to_torch(min_map_pos_idx).long()
 
         min_map_pos = min_map_pos[range(min_map_pos.shape[0]), min_map_pos_idx]  # [B*P, 2]
 

--- a/models/experimental/vadv2/tt/tt_spatial_cross_attention.py
+++ b/models/experimental/vadv2/tt/tt_spatial_cross_attention.py
@@ -91,7 +91,7 @@ class TtSpatialCrossAttention:
         for j in range(bs):
             for i, reference_points_per_img in enumerate(reference_points_cam):
                 index_query_per_img = indexes[i]
-                index_query_per_img = ttnn.to_torch(index_query_per_img)
+                index_query_per_img = ttnn.to_torch(index_query_per_img).long()
                 queries_rebatch[j, i, : len(index_query_per_img)] = query[j, index_query_per_img]
                 reference_points_rebatch[j, i, : len(index_query_per_img)] = reference_points_per_img[
                     j, index_query_per_img
@@ -123,7 +123,7 @@ class TtSpatialCrossAttention:
         queries = ttnn.to_torch(queries)
         for j in range(bs):
             for i, index_query_per_img in enumerate(indexes):
-                index_query_per_img = ttnn.to_torch(index_query_per_img)
+                index_query_per_img = ttnn.to_torch(index_query_per_img).long()
 
                 slots[j, index_query_per_img] += queries[j, i, : len(index_query_per_img)]
         for j in range(bs):

--- a/models/tt_transformers/tests/test_ci_dispatch.py
+++ b/models/tt_transformers/tests/test_ci_dispatch.py
@@ -45,6 +45,7 @@ def test_ci_dispatch(model_weights):
             "models/tt_transformers/tests/test_decoder_prefill.py",
         ]
         + ["-x"]  # Fail if one of the tests fails
+        + (["--timeout", "600"] if "mistral" in model_weights.lower() else [])
     )
     if exit_code == pytest.ExitCode.TESTS_FAILED:
         pytest.fail(


### PR DESCRIPTION
Latest run on main [fails](https://github.com/tenstorrent/tt-metal/actions/runs/22562704893) with these two models.

## Summary
- Add `@pytest.mark.timeout(600)` to vadv2 test that was exceeding the default 300s limit
- Add `--timeout 600` for mistral in `test_ci_dispatch.py` to prevent timeout failures
- Fix `ttnn.to_torch()` index tensors to use `.long()` for proper PyTorch advanced indexing in vadv2 head and spatial cross attention modules

## Test plan
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/22581293983)
