### PR TITLE
fix fp32 switch to disabled in MOE

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
@@ -422,7 +422,7 @@ class MoeRoutedExpertOp:
         core_ranges=None,
         cb_in1_index=None,
         cb_out_index=None,
-        fp32_dest_acc_en=True,
+        fp32_dest_acc_en=False,
         num_subblocks_k=4,
     ):
         """
@@ -1105,7 +1105,7 @@ class MoeRoutedExpertOp:
             core_ranges=gate_proj_core_ranges,
             cb_in1_index=gate_proj_cb_in1,
             cb_out_index=gate_proj_cb_out,
-            fp32_dest_acc_en=True,
+            fp32_dest_acc_en=False,
             num_subblocks_k=4,
         )
 
@@ -1118,7 +1118,7 @@ class MoeRoutedExpertOp:
             core_ranges=gate_proj_core_ranges,
             cb_in1_index=up_proj_cb_in1,
             cb_out_index=up_proj_cb_mm_out,
-            fp32_dest_acc_en=True,
+            fp32_dest_acc_en=False,
             num_subblocks_k=4,
         )
 
@@ -1186,7 +1186,7 @@ class MoeRoutedExpertOp:
             core_ranges=gate_proj_core_ranges,
             cb_in1_index=down_proj_cb_in1,
             cb_out_index=down_proj_cb_out,
-            fp32_dest_acc_en=True,
+            fp32_dest_acc_en=False,
             num_subblocks_k=2,
         )
 
@@ -1728,7 +1728,7 @@ class MoeRoutedExpertOp:
             ("gate_proj_num_subblocks_k", ctx.gate_proj_params["num_subblocks_k"]),
             ("gate_proj_tile_r_dim", ctx.gate_proj_params["tile_r_dim"]),
             ("gate_proj_fuse_silu", 1),
-            ("gate_proj_fp32_dest_acc_en", 1),
+            ("gate_proj_fp32_dest_acc_en", 0),
             # up_proj compute
             ("up_proj_cb_in0", ctx.gate_mm_params["in0_cb"] if ctx.enable_routing else ctx.gate_mm_input_cb),
             ("up_proj_cb_in1", ctx.up_proj_cb_in1),
@@ -1738,7 +1738,7 @@ class MoeRoutedExpertOp:
             ("up_proj_num_subblocks_k", ctx.up_proj_params["num_subblocks_k"]),
             ("up_proj_tile_r_dim", ctx.up_proj_params["tile_r_dim"]),
             ("up_proj_fuse_silu", 0),
-            ("up_proj_fp32_dest_acc_en", 1),
+            ("up_proj_fp32_dest_acc_en", 0),
             ("up_proj_cb_mm_out", ctx.up_proj_cb_mm_out),
             # Mul compute
             ("mul_cb_in0", ctx.mul_cb_in0),
@@ -1746,7 +1746,7 @@ class MoeRoutedExpertOp:
             ("mul_cb_out", ctx.mul_cb_out),
             ("mul_num_tiles", ctx.mul_num_tiles),
             ("mul_cb_scalar", ctx.mul_cb_scalar),
-            ("mul_fp32_dest_acc_en", 1),
+            ("mul_fp32_dest_acc_en", 0),
             ("up_proj_per_core_n", ctx.up_proj_params["per_core_n"]),
             # down_proj compute
             ("down_proj_cb_in0", ctx.down_proj_mcast_dst_cb),
@@ -1758,7 +1758,7 @@ class MoeRoutedExpertOp:
             ("down_proj_num_subblocks_k", ctx.down_proj_params["num_subblocks_k"]),
             ("down_proj_tile_r_dim", ctx.down_proj_params["tile_r_dim"]),
             ("down_proj_fuse_silu", 0),
-            ("down_proj_fp32_dest_acc_en", 1),
+            ("down_proj_fp32_dest_acc_en", 0),
             # Testing flag (routing only)
             ("use_hardcoded_expert_index", 1 if ctx.use_hardcoded_expert_index else 0),
             # Routing flag

--- a/models/demos/deepseek_v3_b1/fused_ops/moe_routed_expert/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe_routed_expert/op.py
@@ -924,10 +924,10 @@ class MoeRoutedExpert:
         mcast_data_sender_semaphore_id = 0
         mcast_data_receiver_semaphore_id = 1
 
-        gate_proj_fp32_dest_acc_en = 1
-        up_proj_fp32_dest_acc_en = 1
-        mul_fp32_dest_acc_en = 1
-        down_proj_fp32_dest_acc_en = 1
+        gate_proj_fp32_dest_acc_en = 0
+        up_proj_fp32_dest_acc_en = 0
+        mul_fp32_dest_acc_en = 0
+        down_proj_fp32_dest_acc_en = 0
         dst_full_sync_en = False
 
         # CB indices

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/eltwise_mul_scalar.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/eltwise_mul_scalar.h
@@ -35,7 +35,7 @@ ALWI void deepseek_mul_tiles_bcast_scalar_init_short(
 /**
  * Scalar broadcast multiply with configurable fp32 accumulation
  */
-template <bool fp32_dest_acc_en = false>
+template <bool fp32_dest_acc_en = DST_ACCUM_MODE>
 ALWI void deepseek_mul_tiles_bcast_scalar(
     uint32_t icb0, uint32_t icb1, uint32_t itile0, uint32_t itile1, uint32_t idst) {
     MATH((llk_math_eltwise_binary<
@@ -54,12 +54,10 @@ ALWI void deepseek_mul_tiles_bcast_scalar(
 /**
  * Init for binary dest reuse multiply
  */
-template <
-    bool fp32_dest_acc_en = false,
-    EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::DEST_TO_SRCA>
+template <EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::DEST_TO_SRCA>
 ALWI void deepseek_binary_dest_reuse_tiles_init(uint32_t icb0, uint32_t call_line = __builtin_LINE()) {
     state_configure(icb0, call_line);
-    UNPACK((llk_unpack_A_init<BroadcastType::NONE, fp32_dest_acc_en, binary_reuse_dest>(false, false, icb0)));
+    UNPACK((llk_unpack_A_init<BroadcastType::NONE, true, binary_reuse_dest>(false, false, icb0)));
     MATH((llk_math_eltwise_binary_init<ELWMUL, BroadcastType::NONE, MATH_FIDELITY, binary_reuse_dest>(false)));
 }
 
@@ -68,10 +66,10 @@ ALWI void deepseek_binary_dest_reuse_tiles_init(uint32_t icb0, uint32_t call_lin
  * dest[idst] = dest[idst] * cb[in_tile_index]
  */
 template <
-    bool fp32_dest_acc_en = false,
+    bool fp32_dest_acc_en = DST_ACCUM_MODE,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::DEST_TO_SRCA>
 ALWI void deepseek_binary_dest_reuse_tiles(uint32_t icb, uint32_t in_tile_index, uint32_t idst) {
-    UNPACK((llk_unpack_A<BroadcastType::NONE, fp32_dest_acc_en, binary_reuse_dest>(icb, in_tile_index)));
+    UNPACK((llk_unpack_A<BroadcastType::NONE, true, binary_reuse_dest>(icb, in_tile_index)));
     MATH((llk_math_eltwise_binary<ELWMUL, BroadcastType::NONE, fp32_dest_acc_en, MATH_FIDELITY, binary_reuse_dest>(
         icb, icb, idst, true)));
 }

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_mlp.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_mlp.py
@@ -601,6 +601,7 @@ def test_moe_fused_with_reduce(bh_2d_mesh_device, use_hardcoded_expert_index, re
         ),
     )
 
+    device_grid_size = submesh.compute_with_storage_grid_size()
     sdpa_out_interm_shard_height = 40
     sdpa_out_interm_shard_width = 544
     full_device_grid = ttnn.CoreRangeSet(
@@ -976,6 +977,7 @@ def test_mlp_with_reduce(bh_2d_mesh_device, reconfig_moe_cbs, noc_mode):
         ),
     )
 
+    device_grid_size = submesh.compute_with_storage_grid_size()
     sdpa_out_interm_shard_height = 40
     sdpa_out_interm_shard_width = 544
     full_device_grid = ttnn.CoreRangeSet(

--- a/models/demos/deepseek_v3_b1/unified_kernels/dram_streaming_matmul.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/dram_streaming_matmul.hpp
@@ -266,7 +266,7 @@ struct DRAMStreamingMatmul {
             } else {
                 reconfig_data_format<false, true>(CTArgs::cb_in1, CTArgs::cb_in0);
                 pack_reconfig_data_format<true>(CTArgs::cb_out);
-                custom_mm_block_init_short<transpose, split_acc, dense_packing, CTArgs::fp32_dest_acc_en>(
+                custom_mm_block_init_short<transpose, split_acc, dense_packing>(
                     CTArgs::cb_in0, CTArgs::cb_in1, CTArgs::cb_out);
             }
 

--- a/models/demos/deepseek_v3_b1/unified_kernels/eltwise_mul.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/eltwise_mul.hpp
@@ -179,7 +179,7 @@ struct EltwiseMul {
                         CTArgs::cb_in0, CTArgs::cb_scalar, i, 0, i);
                 }
                 // Step 2: dest * cb_in1 -> dest (using binary dest reuse)
-                deepseek_binary_dest_reuse_tiles_init<CTArgs::fp32_dest_acc_en>(CTArgs::cb_in1);
+                deepseek_binary_dest_reuse_tiles_init(CTArgs::cb_in1);
                 for (uint32_t i = 0; i < num_tiles; i++) {
                     deepseek_binary_dest_reuse_tiles<CTArgs::fp32_dest_acc_en>(CTArgs::cb_in1, i, i);
                 }


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
FP32 enabled will cause LLK race condition since we don't have a stall logic currently, thus got ND PCC issue.

### What's changed
Disable the FP32 in DRAM mm and mul op, got determined PCC now. slightly PCC drop on MOE: 0.001

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=yugao/moe21)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:yugao/moe21)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=yugao/moe21)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:yugao/moe21)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=yugao/moe21)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:yugao/moe21)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early
