### PR TITLE
Allow Quasar `CreateKernel` APIs to create kernels on multiple clusters

### DIFF
--- a/tests/tt_metal/tt_metal/test_multi_dm_add_two_ints.cpp
+++ b/tests/tt_metal/tt_metal/test_multi_dm_add_two_ints.cpp
@@ -10,6 +10,7 @@
 #include <tt-metalium/experimental/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include "hw/inc/internal/tt-2xx/quasar/dev_mem_map.h"
+#include "llrt/rtoptions.hpp"
 
 #ifndef OVERRIDE_KERNEL_PREFIX
 #define OVERRIDE_KERNEL_PREFIX ""
@@ -21,16 +22,15 @@ using namespace tt::tt_metal;
 // This test requires simulator environment
 TEST_F(MeshDeviceSingleCardFixture, MultiDmAddTwoInts) {
     // Skip if simulator is not available
-    char* env_var = std::getenv("TT_METAL_SIMULATOR");
-    if (env_var == nullptr) {
+    if (!MetalContext::instance().rtoptions().get_simulator_enabled()) {
         GTEST_SKIP() << "This test can only be run using a simulator. Set TT_METAL_SIMULATOR environment variable.";
     }
-    env_var = std::getenv("TT_METAL_DPRINT_CORES");
-    if (env_var == nullptr) {
-        std::cerr << "WARNING: Please set the environment variable TT_METAL_DPRINT_CORES to 0,0 to see the output of "
-                     "the Data Movement kernels."
-                  << std::endl;
-        std::cerr << "WARNING: For example, export TT_METAL_DPRINT_CORES=0,0" << std::endl;
+    if (!MetalContext::instance().rtoptions().get_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint)) {
+        std::cerr
+            << "WARNING: Please set the environment variable TT_METAL_DPRINT_CORES to (0,0),(1,0) to see the output of "
+               "the Data Movement kernels."
+            << std::endl;
+        std::cerr << "WARNING: For example, export TT_METAL_DPRINT_CORES=(0,0),(1,0)" << std::endl;
     }
 
     IDevice* dev = devices_[0]->get_devices()[0];
@@ -40,31 +40,42 @@ TEST_F(MeshDeviceSingleCardFixture, MultiDmAddTwoInts) {
     distributed::MeshWorkload workload;
     distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
     Program program = CreateProgram();
-    constexpr CoreCoord core = {0, 0};
+    const CoreRange core_range = {{0, 0}, {1, 0}};
 
     KernelHandle kernel_0 = experimental::quasar::CreateKernel(
         program,
         "tests/tt_metal/tt_metal/test_kernels/misc/add_two_ints.cpp",
-        core,
+        core_range,
         experimental::quasar::QuasarDataMovementConfig{
-            .num_threads_per_cluster = 5, .compile_args = {MEM_L1_UNCACHED_BASE}});
+            .num_threads_per_cluster = 4, .compile_args = {MEM_L1_UNCACHED_BASE}});
 
     KernelHandle kernel_1 = experimental::quasar::CreateKernel(
         program,
         "tests/tt_metal/tt_metal/test_kernels/misc/add_two_ints.cpp",
-        core,
+        CoreCoord(0, 0),
         experimental::quasar::QuasarDataMovementConfig{
             .num_threads_per_cluster = 3, .compile_args = {MEM_L1_UNCACHED_BASE + sizeof(int)}});
 
-    SetRuntimeArgs(program, kernel_0, core, {100, 200});
-    SetRuntimeArgs(program, kernel_1, core, {300, 400});
+    KernelHandle kernel_2 = experimental::quasar::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/misc/add_two_ints.cpp",
+        CoreCoord(1, 0),
+        experimental::quasar::QuasarDataMovementConfig{
+            .num_threads_per_cluster = 4, .compile_args = {MEM_L1_UNCACHED_BASE + sizeof(int)}});
+
+    SetRuntimeArgs(program, kernel_0, core_range, {1, 2});
+    SetRuntimeArgs(program, kernel_1, CoreCoord(0, 0), {3, 4});
+    SetRuntimeArgs(program, kernel_2, CoreCoord(1, 0), {5, 6});
 
     workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, true);
 
-    std::vector<uint32_t> result{0, 0};
-    tt_metal::detail::ReadFromDeviceL1(dev, core, 0, sizeof(int) * 2, result);
+    std::vector<uint32_t> result_core_0(2, 0);
+    tt_metal::detail::ReadFromDeviceL1(dev, CoreCoord(0, 0), 0, sizeof(uint32_t) * 2, result_core_0);
 
-    ASSERT_EQ(result[0], 300) << "Got the value " << result[0] << " instead of " << 300;
-    ASSERT_EQ(result[1], 700) << "Got the value " << result[1] << " instead of " << 700;
+    std::vector<uint32_t> result_core_1(2, 0);
+    tt_metal::detail::ReadFromDeviceL1(dev, CoreCoord(1, 0), 0, sizeof(uint32_t) * 2, result_core_1);
+
+    ASSERT_EQ(result_core_0, (std::vector<uint32_t>{3, 7}));
+    ASSERT_EQ(result_core_1, (std::vector<uint32_t>{3, 11}));
 }

--- a/tests/tt_metal/tt_metal/test_multi_dm_add_two_ints.cpp
+++ b/tests/tt_metal/tt_metal/test_multi_dm_add_two_ints.cpp
@@ -48,35 +48,43 @@ TEST_F(MeshDeviceSingleCardFixture, MultiDmAddTwoInts) {
         "tests/tt_metal/tt_metal/test_kernels/misc/add_two_ints.cpp",
         core_range,
         experimental::quasar::QuasarDataMovementConfig{
-            .num_threads_per_cluster = 4, .compile_args = {MEM_L1_UNCACHED_BASE}});
+            .num_threads_per_cluster = 3, .compile_args = {MEM_L1_UNCACHED_BASE}});
 
     KernelHandle kernel_1 = experimental::quasar::CreateKernel(
         program,
         "tests/tt_metal/tt_metal/test_kernels/misc/add_two_ints.cpp",
-        CoreCoord(0, 0),
+        core_range,
         experimental::quasar::QuasarDataMovementConfig{
-            .num_threads_per_cluster = 3, .compile_args = {MEM_L1_UNCACHED_BASE + sizeof(int)}});
+            .num_threads_per_cluster = 2, .compile_args = {MEM_L1_UNCACHED_BASE + sizeof(int)}});
 
     KernelHandle kernel_2 = experimental::quasar::CreateKernel(
         program,
         "tests/tt_metal/tt_metal/test_kernels/misc/add_two_ints.cpp",
+        CoreCoord(0, 0),
+        experimental::quasar::QuasarDataMovementConfig{
+            .num_threads_per_cluster = 3, .compile_args = {MEM_L1_UNCACHED_BASE + 2 * sizeof(int)}});
+
+    KernelHandle kernel_3 = experimental::quasar::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/misc/add_two_ints.cpp",
         CoreCoord(1, 0),
         experimental::quasar::QuasarDataMovementConfig{
-            .num_threads_per_cluster = 4, .compile_args = {MEM_L1_UNCACHED_BASE + sizeof(int)}});
+            .num_threads_per_cluster = 2, .compile_args = {MEM_L1_UNCACHED_BASE + 2 * sizeof(int)}});
 
     SetRuntimeArgs(program, kernel_0, core_range, {1, 2});
-    SetRuntimeArgs(program, kernel_1, CoreCoord(0, 0), {3, 4});
-    SetRuntimeArgs(program, kernel_2, CoreCoord(1, 0), {5, 6});
+    SetRuntimeArgs(program, kernel_1, core_range, {3, 4});
+    SetRuntimeArgs(program, kernel_2, CoreCoord(0, 0), {5, 6});
+    SetRuntimeArgs(program, kernel_3, CoreCoord(1, 0), {7, 8});
 
     workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, true);
 
-    std::vector<uint32_t> result_core_0(2, 0);
-    tt_metal::detail::ReadFromDeviceL1(dev, CoreCoord(0, 0), 0, sizeof(uint32_t) * 2, result_core_0);
+    std::vector<uint32_t> result_core_0(3, 0);
+    tt_metal::detail::ReadFromDeviceL1(dev, CoreCoord(0, 0), 0, sizeof(uint32_t) * 3, result_core_0);
 
-    std::vector<uint32_t> result_core_1(2, 0);
-    tt_metal::detail::ReadFromDeviceL1(dev, CoreCoord(1, 0), 0, sizeof(uint32_t) * 2, result_core_1);
+    std::vector<uint32_t> result_core_1(3, 0);
+    tt_metal::detail::ReadFromDeviceL1(dev, CoreCoord(1, 0), 0, sizeof(uint32_t) * 3, result_core_1);
 
-    ASSERT_EQ(result_core_0, (std::vector<uint32_t>{3, 7}));
-    ASSERT_EQ(result_core_1, (std::vector<uint32_t>{3, 11}));
+    ASSERT_EQ(result_core_0, (std::vector<uint32_t>{3, 7, 11}));
+    ASSERT_EQ(result_core_1, (std::vector<uint32_t>{3, 7, 15}));
 }

--- a/tests/tt_metal/tt_metal/test_multi_dm_add_two_ints.cpp
+++ b/tests/tt_metal/tt_metal/test_multi_dm_add_two_ints.cpp
@@ -4,6 +4,7 @@
 
 #include "common/device_fixture.hpp"
 
+#include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/host_api.hpp>
@@ -26,11 +27,11 @@ TEST_F(MeshDeviceSingleCardFixture, MultiDmAddTwoInts) {
         GTEST_SKIP() << "This test can only be run using a simulator. Set TT_METAL_SIMULATOR environment variable.";
     }
     if (!MetalContext::instance().rtoptions().get_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint)) {
-        std::cerr
-            << "WARNING: Please set the environment variable TT_METAL_DPRINT_CORES to (0,0),(1,0) to see the output of "
-               "the Data Movement kernels."
-            << std::endl;
-        std::cerr << "WARNING: For example, export TT_METAL_DPRINT_CORES=(0,0),(1,0)" << std::endl;
+        log_error(
+            tt::LogTest,
+            "Please set the environment variable TT_METAL_DPRINT_CORES to (0,0),(1,0) to see the output of the Data "
+            "Movement kernels.");
+        log_error(tt::LogTest, "For example, export TT_METAL_DPRINT_CORES=(0,0),(1,0)");
     }
 
     IDevice* dev = devices_[0]->get_devices()[0];

--- a/tests/tt_metal/tt_metal/test_multi_dm_add_two_ints.cpp
+++ b/tests/tt_metal/tt_metal/test_multi_dm_add_two_ints.cpp
@@ -62,14 +62,14 @@ TEST_F(MeshDeviceSingleCardFixture, MultiDmAddTwoInts) {
         "tests/tt_metal/tt_metal/test_kernels/misc/add_two_ints.cpp",
         CoreCoord(0, 0),
         experimental::quasar::QuasarDataMovementConfig{
-            .num_threads_per_cluster = 3, .compile_args = {MEM_L1_UNCACHED_BASE + 2 * sizeof(int)}});
+            .num_threads_per_cluster = 3, .compile_args = {MEM_L1_UNCACHED_BASE + (2 * sizeof(int))}});
 
     KernelHandle kernel_3 = experimental::quasar::CreateKernel(
         program,
         "tests/tt_metal/tt_metal/test_kernels/misc/add_two_ints.cpp",
         CoreCoord(1, 0),
         experimental::quasar::QuasarDataMovementConfig{
-            .num_threads_per_cluster = 2, .compile_args = {MEM_L1_UNCACHED_BASE + 2 * sizeof(int)}});
+            .num_threads_per_cluster = 2, .compile_args = {MEM_L1_UNCACHED_BASE + (2 * sizeof(int))}});
 
     SetRuntimeArgs(program, kernel_0, core_range, {1, 2});
     SetRuntimeArgs(program, kernel_1, core_range, {3, 4});

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -1606,44 +1606,74 @@ void UpdateDynamicCircularBufferAddress(
 
 namespace quasar {
 
+std::set<DataMovementProcessor> GetDataMovementProcessorsInUseOnClusterQuasar(
+    Program& program, const CoreCoord& cluster) {
+    const KernelGroup* kernel_group = program.impl().kernels_on_core(
+        cluster, MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::TENSIX));
+    if (kernel_group == nullptr) {
+        return {};
+    }
+    std::set<DataMovementProcessor> processors_in_use;
+    for (const KernelHandle kernel_id : kernel_group->kernel_ids) {
+        const std::shared_ptr<Kernel> kernel = program.impl().get_kernel(kernel_id);
+        if (kernel->get_kernel_processor_class() == HalProcessorClassType::DM) {
+            const std::shared_ptr<QuasarDataMovementKernel> dm_kernel =
+                std::dynamic_pointer_cast<QuasarDataMovementKernel>(kernel);
+            const std::vector<DataMovementProcessor> dm_processors = dm_kernel->get_dm_processors();
+            processors_in_use.insert(dm_processors.begin(), dm_processors.end());
+        }
+    }
+    return processors_in_use;
+}
+
+bool DoesClusterHaveComputeKernelQuasar(Program& program, const CoreCoord& cluster) {
+    const KernelGroup* kernel_group = program.impl().kernels_on_core(
+        cluster, MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::TENSIX));
+    if (kernel_group == nullptr) {
+        return false;
+    }
+    for (const KernelHandle kernel_id : kernel_group->kernel_ids) {
+        const std::shared_ptr<Kernel> kernel = program.impl().get_kernel(kernel_id);
+        if (kernel->get_kernel_processor_class() == HalProcessorClassType::COMPUTE) {
+            return true;
+        }
+    }
+    return false;
+}
+
 template <typename ProcessorClassType>
 std::set<ProcessorClassType> GetProcessorsPerClusterQuasar(
     Program& program, const CoreRangeSet& core_ranges, uint32_t num_processors_per_cluster) {
-    TT_FATAL(core_ranges.num_cores() == 1, "Currently, kernels can only be created on a single cluster in Quasar.");
-
     std::set<ProcessorClassType> processors(
         enchantum::values<ProcessorClassType>.begin(), enchantum::values<ProcessorClassType>.end());
-    const auto& hal = MetalContext::instance().hal();
-    for (const auto& core_range : core_ranges.ranges()) {
+    std::vector<std::set<DataMovementProcessor>> dm_processors_in_use_per_cluster;
+
+    for (const CoreRange& core_range : core_ranges.ranges()) {
         for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
             for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
-                const KernelGroup* kernel_group = program.impl().kernels_on_core(
-                    CoreCoord(x, y), hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX));
-                if (kernel_group != nullptr) {
-                    for (const KernelHandle kernel_id : kernel_group->kernel_ids) {
-                        const auto kernel = program.impl().get_kernel(kernel_id);
-                        if constexpr (std::is_same_v<ProcessorClassType, DataMovementProcessor>) {
-                            if (kernel->get_kernel_processor_class() == HalProcessorClassType::DM) {
-                                const QuasarDataMovementConfig config =
-                                    std::get<QuasarDataMovementConfig>(kernel->config());
-                                const uint32_t num_processors_in_use = config.num_threads_per_cluster;
-                                const uint32_t start_processor_type = kernel->get_kernel_processor_type(0);
-                                for (uint32_t i = start_processor_type;
-                                     i < start_processor_type + num_processors_in_use;
-                                     i++) {
-                                    TT_ASSERT(processors.contains(static_cast<ProcessorClassType>(i)));
-                                    processors.erase(static_cast<ProcessorClassType>(i));
-                                }
-                            }
-                        } else if constexpr (std::is_same_v<ProcessorClassType, QuasarComputeProcessor>) {
-                            if (kernel->get_kernel_processor_class() == HalProcessorClassType::COMPUTE) {
-                                TT_THROW("In Quasar, each cluster can only have a single compute kernel.");
-                            }
-                        }
+                if constexpr (std::is_same_v<ProcessorClassType, DataMovementProcessor>) {
+                    const std::set<DataMovementProcessor> dm_processors_in_use_on_cluster =
+                        GetDataMovementProcessorsInUseOnClusterQuasar(program, CoreCoord(x, y));
+                    dm_processors_in_use_per_cluster.push_back(dm_processors_in_use_on_cluster);
+                    for (const DataMovementProcessor dm_processor : dm_processors_in_use_on_cluster) {
+                        processors.erase(dm_processor);
+                    }
+                } else if constexpr (std::is_same_v<ProcessorClassType, QuasarComputeProcessor>) {
+                    if (DoesClusterHaveComputeKernelQuasar(program, CoreCoord(x, y))) {
+                        TT_THROW("In Quasar, each cluster can only have a single compute kernel.");
                     }
                 }
             }
         }
+    }
+
+    for (uint32_t i = 1; i < dm_processors_in_use_per_cluster.size(); i++) {
+        TT_FATAL(
+            dm_processors_in_use_per_cluster[i] == dm_processors_in_use_per_cluster[i - 1],
+            "All clusters in {} must have the same data movement processors already in use to reserve {} new data "
+            "movement processors per cluster.",
+            core_ranges,
+            num_processors_per_cluster);
     }
 
     while (processors.size() > num_processors_per_cluster) {

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -1619,6 +1619,7 @@ std::set<DataMovementProcessor> GetDataMovementProcessorsInUseOnClusterQuasar(
         if (kernel->get_kernel_processor_class() == HalProcessorClassType::DM) {
             const std::shared_ptr<QuasarDataMovementKernel> dm_kernel =
                 std::dynamic_pointer_cast<QuasarDataMovementKernel>(kernel);
+            TT_ASSERT(dm_kernel != nullptr);
             const std::vector<DataMovementProcessor> dm_processors = dm_kernel->get_dm_processors();
             processors_in_use.insert(dm_processors.begin(), dm_processors.end());
         }
@@ -1659,9 +1660,9 @@ std::set<ProcessorClassType> GetProcessorsPerClusterQuasar(
                         processors.erase(dm_processor);
                     }
                 } else if constexpr (std::is_same_v<ProcessorClassType, QuasarComputeProcessor>) {
-                    if (DoesClusterHaveComputeKernelQuasar(program, CoreCoord(x, y))) {
-                        TT_THROW("In Quasar, each cluster can only have a single compute kernel.");
-                    }
+                    TT_FATAL(
+                        !DoesClusterHaveComputeKernelQuasar(program, CoreCoord(x, y)),
+                        "In Quasar, each cluster can only have a single compute kernel.");
                 }
             }
         }

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -1657,6 +1657,7 @@ std::set<ProcessorClassType> GetProcessorsPerClusterQuasar(
         }
     }
 
+    // NOLINTNEXTLINE(bugprone-nondeterministic-pointer-iteration-order)
     for (const KernelGroup* kernel_group : kernel_groups) {
         if constexpr (std::is_same_v<ProcessorClassType, DataMovementProcessor>) {
             const std::set<DataMovementProcessor> dm_processors_in_use_on_kernel_group =

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -1606,10 +1606,8 @@ void UpdateDynamicCircularBufferAddress(
 
 namespace quasar {
 
-std::set<DataMovementProcessor> GetDataMovementProcessorsInUseOnClusterQuasar(
-    Program& program, const CoreCoord& cluster) {
-    const KernelGroup* kernel_group = program.impl().kernels_on_core(
-        cluster, MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::TENSIX));
+std::set<DataMovementProcessor> GetDataMovementProcessorsInUseOnKernelGroup(
+    Program& program, const KernelGroup* kernel_group) {
     if (kernel_group == nullptr) {
         return {};
     }
@@ -1627,9 +1625,7 @@ std::set<DataMovementProcessor> GetDataMovementProcessorsInUseOnClusterQuasar(
     return processors_in_use;
 }
 
-bool DoesClusterHaveComputeKernelQuasar(Program& program, const CoreCoord& cluster) {
-    const KernelGroup* kernel_group = program.impl().kernels_on_core(
-        cluster, MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::TENSIX));
+bool DoesKernelGroupHaveComputeKernel(Program& program, const KernelGroup* kernel_group) {
     if (kernel_group == nullptr) {
         return false;
     }
@@ -1647,30 +1643,38 @@ std::set<ProcessorClassType> GetProcessorsPerClusterQuasar(
     Program& program, const CoreRangeSet& core_ranges, uint32_t num_processors_per_cluster) {
     std::set<ProcessorClassType> processors(
         enchantum::values<ProcessorClassType>.begin(), enchantum::values<ProcessorClassType>.end());
-    std::vector<std::set<DataMovementProcessor>> dm_processors_in_use_per_cluster;
+    std::vector<std::set<DataMovementProcessor>> dm_processors_in_use_per_kernel_group;
 
+    std::unordered_set<const KernelGroup*> kernel_groups;
     for (const CoreRange& core_range : core_ranges.ranges()) {
         for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
             for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
-                if constexpr (std::is_same_v<ProcessorClassType, DataMovementProcessor>) {
-                    const std::set<DataMovementProcessor> dm_processors_in_use_on_cluster =
-                        GetDataMovementProcessorsInUseOnClusterQuasar(program, CoreCoord(x, y));
-                    dm_processors_in_use_per_cluster.push_back(dm_processors_in_use_on_cluster);
-                    for (const DataMovementProcessor dm_processor : dm_processors_in_use_on_cluster) {
-                        processors.erase(dm_processor);
-                    }
-                } else if constexpr (std::is_same_v<ProcessorClassType, QuasarComputeProcessor>) {
-                    TT_FATAL(
-                        !DoesClusterHaveComputeKernelQuasar(program, CoreCoord(x, y)),
-                        "In Quasar, each cluster can only have a single compute kernel.");
-                }
+                const KernelGroup* kernel_group = program.impl().kernels_on_core(
+                    CoreCoord(x, y),
+                    MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::TENSIX));
+                kernel_groups.insert(kernel_group);
             }
         }
     }
 
-    for (uint32_t i = 1; i < dm_processors_in_use_per_cluster.size(); i++) {
+    for (const KernelGroup* kernel_group : kernel_groups) {
+        if constexpr (std::is_same_v<ProcessorClassType, DataMovementProcessor>) {
+            const std::set<DataMovementProcessor> dm_processors_in_use_on_kernel_group =
+                GetDataMovementProcessorsInUseOnKernelGroup(program, kernel_group);
+            dm_processors_in_use_per_kernel_group.push_back(dm_processors_in_use_on_kernel_group);
+            for (const DataMovementProcessor dm_processor : dm_processors_in_use_on_kernel_group) {
+                processors.erase(dm_processor);
+            }
+        } else if constexpr (std::is_same_v<ProcessorClassType, QuasarComputeProcessor>) {
+            TT_FATAL(
+                !DoesKernelGroupHaveComputeKernel(program, kernel_group),
+                "In Quasar, each cluster can only have a single compute kernel.");
+        }
+    }
+
+    for (uint32_t i = 1; i < dm_processors_in_use_per_kernel_group.size(); i++) {
         TT_FATAL(
-            dm_processors_in_use_per_cluster[i] == dm_processors_in_use_per_cluster[i - 1],
+            dm_processors_in_use_per_kernel_group[i] == dm_processors_in_use_per_kernel_group[i - 1],
             "All clusters in {} must have the same data movement processors already in use to reserve {} new data "
             "movement processors per cluster.",
             core_ranges,


### PR DESCRIPTION
### Problem description
The `CreateKernel` APIs for Quasar only allows kernels to be created on a single cluster.

### What's changed
The `CreateKernel` APIs for Quasar have been modified to allow for kernels to be created on multiple clusters with the restriction that each cluster specified must already have the exact same DM processors in use if a DM kernel is being created, or that each cluster specified must not have a compute kernel already assigned to it if a compute kernel is being created. In Quasar, each cluster is limited to run a maximum of one compute kernel regardless of how many Tensix engines that kernel uses.

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=sagarwal/qsr_kernel_multiple_clusters)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:sagarwal/qsr_kernel_multiple_clusters)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sagarwal/qsr_kernel_multiple_clusters)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sagarwal/qsr_kernel_multiple_clusters)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sagarwal/qsr_kernel_multiple_clusters)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sagarwal/qsr_kernel_multiple_clusters)
- [x] New/Existing tests provide coverage for changes