### PR TITLE
enable channel trim override config support

### DIFF
--- a/tests/tt_metal/tt_fabric/fabric_router/test_channel_trimming_capture.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_channel_trimming_capture.cpp
@@ -50,6 +50,8 @@
 #include "tt_metal/fabric/channel_trimming_import.hpp"
 
 #include "fabric_fixture.hpp"
+#include "t3k_mesh_descriptor_chip_mappings.hpp"
+#include "utils.hpp"
 
 namespace tt::tt_fabric::fabric_router_tests {
 
@@ -1743,6 +1745,313 @@ TEST(ChannelTrimmingGlobalOverride, ApplyEmptyOverrideNoEffect) {
     // Nothing should change
     EXPECT_EQ(entry.sender_channel_used_bitfield_by_vc, 0x0023u);
     EXPECT_EQ(entry.receiver_channel_data_forwarded_bitfield_by_vc, 0x0001u);
+}
+
+// Test: Apply global override with VC0={s0,s1,r0} and VC1=all enabled
+// Uses 2D-mesh-like channel counts: VC0 has 4 sender + 1 receiver, VC1 has 4 sender + 1 receiver
+TEST(ChannelTrimmingGlobalOverride, ApplyVC0S0S1AndVC1All) {
+    std::array<std::size_t, builder_config::MAX_NUM_VCS> sender_counts = {4, 4};
+    std::array<std::size_t, builder_config::MAX_NUM_VCS> receiver_counts = {1, 1};
+
+    // Capture: all channels used
+    ChannelTrimmingOverrides entry{};
+    entry.sender_channel_min_packet_size_seen_bytes_by_vc.fill(std::numeric_limits<uint16_t>::max());
+    entry.sender_channel_used_bitfield_by_vc = 0x00FF;              // all 8 sender bits
+    entry.receiver_channel_data_forwarded_bitfield_by_vc = 0x0003;  // both receivers
+
+    // Override: VC0={s0,s1,r0}, VC1=all
+    ChannelTrimmingGlobalOverrides overrides;
+    overrides.per_vc[0].force_enable_sender_channels = std::vector<size_t>{0, 1};
+    overrides.per_vc[0].force_enable_receiver_channels = std::vector<size_t>{0};
+    overrides.per_vc[1].force_enable_all_sender_channels = true;
+    overrides.per_vc[1].force_enable_all_receiver_channels = true;
+
+    apply_global_overrides_to_entry(entry, overrides, sender_counts, receiver_counts);
+
+    // VC0 senders (bits 0-3): only bits 0,1 set (replacement clears bits 2,3)
+    EXPECT_EQ(entry.sender_channel_used_bitfield_by_vc & 0x000F, 0x0003u);
+    // VC1 senders (bits 4-7): all bits set
+    EXPECT_EQ(entry.sender_channel_used_bitfield_by_vc & 0x00F0, 0x00F0u);
+    // VC0 receiver (bit 0): set
+    EXPECT_EQ(entry.receiver_channel_data_forwarded_bitfield_by_vc & 0x0001, 0x0001u);
+    // VC1 receiver (bit 1): set
+    EXPECT_EQ(entry.receiver_channel_data_forwarded_bitfield_by_vc & 0x0002, 0x0002u);
+}
+
+// Test: Apply VC0={s0,s1} override to a baseline with NO channels used
+// Verifies that override sets bits even when the capture had nothing enabled.
+TEST(ChannelTrimmingGlobalOverride, ApplyVC0S0S1AndVC1AllToEmptyBaseline) {
+    std::array<std::size_t, builder_config::MAX_NUM_VCS> sender_counts = {4, 4};
+    std::array<std::size_t, builder_config::MAX_NUM_VCS> receiver_counts = {1, 1};
+
+    // Capture: no channels used at all
+    ChannelTrimmingOverrides entry{};
+    entry.sender_channel_min_packet_size_seen_bytes_by_vc.fill(std::numeric_limits<uint16_t>::max());
+    entry.sender_channel_used_bitfield_by_vc = 0x0000;
+    entry.receiver_channel_data_forwarded_bitfield_by_vc = 0x0000;
+
+    // Override: VC0={s0,s1,r0}, VC1=all
+    ChannelTrimmingGlobalOverrides overrides;
+    overrides.per_vc[0].force_enable_sender_channels = std::vector<size_t>{0, 1};
+    overrides.per_vc[0].force_enable_receiver_channels = std::vector<size_t>{0};
+    overrides.per_vc[1].force_enable_all_sender_channels = true;
+    overrides.per_vc[1].force_enable_all_receiver_channels = true;
+
+    apply_global_overrides_to_entry(entry, overrides, sender_counts, receiver_counts);
+
+    // VC0 senders: bits 0,1 set (override replaces empty baseline)
+    EXPECT_EQ(entry.sender_channel_used_bitfield_by_vc & 0x000F, 0x0003u);
+    // VC1 senders: all bits 4-7 set
+    EXPECT_EQ(entry.sender_channel_used_bitfield_by_vc & 0x00F0, 0x00F0u);
+    // VC0 receiver: bit 0 set
+    EXPECT_EQ(entry.receiver_channel_data_forwarded_bitfield_by_vc & 0x0001, 0x0001u);
+    // VC1 receiver: bit 1 set
+    EXPECT_EQ(entry.receiver_channel_data_forwarded_bitfield_by_vc & 0x0002, 0x0002u);
+}
+
+// ============================================================================
+// Fixture: Fabric2D with override: VC0={s0,s1,r0}, VC1=all enabled.
+// Override-only mode (no capture profile) — the builder context constructs a
+// fully-enabled baseline and applies the override with replacement semantics.
+// ============================================================================
+class Fabric2DChannelTrimmingOverrideVC0S0S1VC1AllFixture : public BaseFabricFixture {
+protected:
+    static void SetUpTestSuite() {
+        if (tt::get_arch_from_string(tt::test_utils::get_umd_arch_name()) != tt::ARCH::BLACKHOLE) {
+            should_skip_ = true;
+            return;
+        }
+        if (tt::tt_metal::GetNumAvailableDevices() < 4) {
+            should_skip_ = true;
+            return;
+        }
+
+        // Write override YAML to a temp file
+        override_dir_ = std::filesystem::temp_directory_path() / "channel_trimming_override_2d_vc0s0s1_vc1all_test";
+        std::filesystem::create_directories(override_dir_);
+        override_yaml_path_ = override_dir_ / "override.yaml";
+        {
+            std::ofstream f(override_yaml_path_);
+            f << "channel_trimming_overrides:\n"
+              << "  vc0:\n"
+              << "    force_enable_sender_channels: [0, 1]\n"
+              << "    force_enable_receiver_channels: [0]\n"
+              << "  vc1:\n"
+              << "    force_enable_all_sender_channels: true\n"
+              << "    force_enable_all_receiver_channels: true\n";
+        }
+
+        auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
+        rtoptions.set_fabric_trimming_override_path(override_yaml_path_.string());
+        // Override-only mode: no capture, no profile
+        BaseFabricFixture::DoSetUpTestSuite(tt::tt_fabric::FabricConfig::FABRIC_2D);
+    }
+
+    static void TearDownTestSuite() {
+        if (!should_skip_) {
+            BaseFabricFixture::DoTearDownTestSuite();
+            auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
+            rtoptions.set_fabric_trimming_override_path("");
+        }
+        if (std::filesystem::exists(override_dir_)) {
+            std::filesystem::remove_all(override_dir_);
+        }
+    }
+
+    void SetUp() override {
+        if (should_skip_) {
+            GTEST_SKIP() << "2D channel trimming override tests require Blackhole architecture with at least 4 devices";
+        }
+        BaseFabricFixture::SetUp();
+    }
+
+    inline static bool should_skip_ = false;
+    inline static std::filesystem::path override_dir_;
+    inline static std::filesystem::path override_yaml_path_;
+};
+
+// ============================================================================
+// Tests: Fabric2DChannelTrimmingOverrideVC0S0S1VC1AllFixture
+// ============================================================================
+
+// Test: Global overrides are loaded and match the YAML specification
+TEST_F(Fabric2DChannelTrimmingOverrideVC0S0S1VC1AllFixture, OverrideLoadedCorrectly) {
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& builder_ctx = control_plane.get_fabric_context().get_builder_context();
+    const auto& global_overrides = builder_ctx.get_channel_trimming_global_overrides();
+
+    EXPECT_TRUE(global_overrides.has_any_override());
+
+    // VC0: sender[0,1] + receiver[0]
+    EXPECT_TRUE(global_overrides.per_vc[0].has_sender_override());
+    EXPECT_TRUE(global_overrides.per_vc[0].has_receiver_override());
+    ASSERT_TRUE(global_overrides.per_vc[0].force_enable_sender_channels.has_value());
+    ASSERT_EQ(global_overrides.per_vc[0].force_enable_sender_channels->size(), 2u);
+    EXPECT_EQ((*global_overrides.per_vc[0].force_enable_sender_channels)[0], 0u);
+    EXPECT_EQ((*global_overrides.per_vc[0].force_enable_sender_channels)[1], 1u);
+    ASSERT_TRUE(global_overrides.per_vc[0].force_enable_receiver_channels.has_value());
+    ASSERT_EQ(global_overrides.per_vc[0].force_enable_receiver_channels->size(), 1u);
+    EXPECT_EQ((*global_overrides.per_vc[0].force_enable_receiver_channels)[0], 0u);
+
+    // VC1: all senders + all receivers
+    EXPECT_TRUE(global_overrides.per_vc[1].has_sender_override());
+    EXPECT_TRUE(global_overrides.per_vc[1].has_receiver_override());
+    EXPECT_TRUE(global_overrides.per_vc[1].force_enable_all_sender_channels.value_or(false));
+    EXPECT_TRUE(global_overrides.per_vc[1].force_enable_all_receiver_channels.value_or(false));
+}
+
+// Test: Max channel counts from builder context are consistent with 2D mesh topology
+// Note: VC1 channel counts depend on whether inter-mesh routing is active; on a
+// single-mesh 2D fabric they may be 0.  We only assert VC0 minimums here.
+TEST_F(Fabric2DChannelTrimmingOverrideVC0S0S1VC1AllFixture, ChannelCountsConsistentWith2DMesh) {
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& builder_ctx = control_plane.get_fabric_context().get_builder_context();
+
+    const auto& max_sender = builder_ctx.get_max_sender_channels_per_vc();
+    const auto& max_receiver = builder_ctx.get_max_receiver_channels_per_vc();
+
+    // 2D mesh: VC0 should have >= 4 sender channels (Worker + N/E/S/W directions)
+    EXPECT_GE(max_sender[0], 4u);
+    // VC0 should have at least 1 receiver
+    EXPECT_GE(max_receiver[0], 1u);
+}
+
+// Test: Override-only mode (no capture profile) creates a fully-enabled baseline.
+// Verify that no per-router capture profile is loaded (override-only mode).
+TEST_F(Fabric2DChannelTrimmingOverrideVC0S0S1VC1AllFixture, StandaloneOverrideCreatesFullyEnabledBaseline) {
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& builder_ctx = control_plane.get_fabric_context().get_builder_context();
+
+    // In override-only mode (no profile path), the per-router override map should be empty
+    const auto& trimming_overrides = builder_ctx.get_channel_trimming_overrides();
+    EXPECT_FALSE(trimming_overrides.has_value()) << "Override-only mode should not have a per-router capture profile";
+
+    // But global overrides should be active
+    const auto& global_overrides = builder_ctx.get_channel_trimming_global_overrides();
+    EXPECT_TRUE(global_overrides.has_any_override());
+}
+
+// ============================================================================
+// Fixture: T3k 2D multi-mesh (intermesh) with override: VC0={s0,s1,r0}, VC1=all.
+// Uses a T3k 2x2 mesh descriptor (two 2x2 meshes with inter-mesh connectivity),
+// which enables VC1. Per-test SetUp/TearDown because custom mesh graph requires it.
+// ============================================================================
+class T3kIntermeshChannelTrimmingOverrideVC0S0S1VC1AllFixture : public BaseFabricFixture {
+protected:
+    static void SetUpTestSuite() {}
+    static void TearDownTestSuite() {}
+
+    void SetUp() override {
+        const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+        if (cluster.get_cluster_type() != tt::tt_metal::ClusterType::T3K) {
+            GTEST_SKIP() << "Intermesh channel trimming override tests require a T3K cluster";
+        }
+        if (tt::tt_metal::GetNumAvailableDevices() < 8) {
+            GTEST_SKIP() << "Intermesh channel trimming override tests require at least 8 devices";
+        }
+
+        // Write override YAML to a temp file
+        override_dir_ = std::filesystem::temp_directory_path() / "channel_trimming_override_t3k_intermesh_test";
+        std::filesystem::create_directories(override_dir_);
+        override_yaml_path_ = override_dir_ / "override.yaml";
+        {
+            std::ofstream f(override_yaml_path_);
+            f << "channel_trimming_overrides:\n"
+              << "  vc0:\n"
+              << "    force_enable_sender_channels: [0, 1]\n"
+              << "    force_enable_receiver_channels: [0]\n"
+              << "  vc1:\n"
+              << "    force_enable_all_sender_channels: true\n"
+              << "    force_enable_all_receiver_channels: true\n";
+        }
+
+        auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
+        rtoptions.set_fabric_trimming_override_path(override_yaml_path_.string());
+
+        // Use t3k_2x2 mesh descriptor (2 meshes, inter-mesh connectivity → VC1 enabled)
+        const auto& [mesh_graph_desc_path, mesh_graph_eth_coords] = t3k_mesh_descriptor_chip_mappings[2];
+        tt::tt_metal::MetalContext::instance().set_custom_fabric_topology(
+            mesh_graph_desc_path, get_physical_chip_mapping_from_eth_coords_mapping(mesh_graph_eth_coords));
+        BaseFabricFixture::DoSetUpTestSuite(tt::tt_fabric::FabricConfig::FABRIC_2D);
+    }
+
+    void TearDown() override {
+        if (IsSkipped()) {
+            return;
+        }
+        BaseFabricFixture::DoTearDownTestSuite();
+        tt::tt_metal::MetalContext::instance().set_default_fabric_topology();
+        auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
+        rtoptions.set_fabric_trimming_override_path("");
+        if (std::filesystem::exists(override_dir_)) {
+            std::filesystem::remove_all(override_dir_);
+        }
+    }
+
+    std::filesystem::path override_dir_;
+    std::filesystem::path override_yaml_path_;
+};
+
+// ============================================================================
+// Tests: T3kIntermeshChannelTrimmingOverrideVC0S0S1VC1AllFixture
+// ============================================================================
+
+// Test: Global overrides are loaded and match the YAML specification (with intermesh VC1)
+TEST_F(T3kIntermeshChannelTrimmingOverrideVC0S0S1VC1AllFixture, OverrideLoadedCorrectly) {
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& builder_ctx = control_plane.get_fabric_context().get_builder_context();
+    const auto& global_overrides = builder_ctx.get_channel_trimming_global_overrides();
+
+    EXPECT_TRUE(global_overrides.has_any_override());
+
+    // VC0: sender[0,1] + receiver[0]
+    EXPECT_TRUE(global_overrides.per_vc[0].has_sender_override());
+    EXPECT_TRUE(global_overrides.per_vc[0].has_receiver_override());
+    ASSERT_TRUE(global_overrides.per_vc[0].force_enable_sender_channels.has_value());
+    ASSERT_EQ(global_overrides.per_vc[0].force_enable_sender_channels->size(), 2u);
+    EXPECT_EQ((*global_overrides.per_vc[0].force_enable_sender_channels)[0], 0u);
+    EXPECT_EQ((*global_overrides.per_vc[0].force_enable_sender_channels)[1], 1u);
+    ASSERT_TRUE(global_overrides.per_vc[0].force_enable_receiver_channels.has_value());
+    ASSERT_EQ(global_overrides.per_vc[0].force_enable_receiver_channels->size(), 1u);
+    EXPECT_EQ((*global_overrides.per_vc[0].force_enable_receiver_channels)[0], 0u);
+
+    // VC1: all senders + all receivers
+    EXPECT_TRUE(global_overrides.per_vc[1].has_sender_override());
+    EXPECT_TRUE(global_overrides.per_vc[1].has_receiver_override());
+    EXPECT_TRUE(global_overrides.per_vc[1].force_enable_all_sender_channels.value_or(false));
+    EXPECT_TRUE(global_overrides.per_vc[1].force_enable_all_receiver_channels.value_or(false));
+}
+
+// Test: VC1 channel counts are non-zero in an intermesh topology
+TEST_F(T3kIntermeshChannelTrimmingOverrideVC0S0S1VC1AllFixture, IntermeshVC1ChannelCountsNonZero) {
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& builder_ctx = control_plane.get_fabric_context().get_builder_context();
+
+    const auto& max_sender = builder_ctx.get_max_sender_channels_per_vc();
+    const auto& max_receiver = builder_ctx.get_max_receiver_channels_per_vc();
+
+    // VC0: should have >= 4 sender channels (Worker + mesh directions)
+    EXPECT_GE(max_sender[0], 4u);
+    EXPECT_GE(max_receiver[0], 1u);
+
+    // VC1: intermesh topology should have non-zero VC1 channels
+    EXPECT_GT(max_sender[1], 0u) << "Intermesh topology should have VC1 sender channels";
+    EXPECT_GE(max_sender[1], 3u) << "Intermesh VC1 should have >= 3 sender channels (one per mesh direction)";
+    EXPECT_GE(max_receiver[1], 1u) << "Intermesh VC1 should have >= 1 receiver channel";
+}
+
+// Test: Override-only mode has no per-router profile, but global overrides are active
+TEST_F(T3kIntermeshChannelTrimmingOverrideVC0S0S1VC1AllFixture, StandaloneOverrideNoProfile) {
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& builder_ctx = control_plane.get_fabric_context().get_builder_context();
+
+    // No per-router capture profile
+    const auto& trimming_overrides = builder_ctx.get_channel_trimming_overrides();
+    EXPECT_FALSE(trimming_overrides.has_value()) << "Override-only mode should not have a per-router capture profile";
+
+    // Global overrides should be active
+    const auto& global_overrides = builder_ctx.get_channel_trimming_global_overrides();
+    EXPECT_TRUE(global_overrides.has_any_override());
 }
 
 }  // namespace tt::tt_fabric::fabric_router_tests

--- a/tests/tt_metal/tt_fabric/fabric_router/test_channel_trimming_capture.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_channel_trimming_capture.cpp
@@ -23,6 +23,8 @@
 #include <cstdint>
 #include <cstring>
 #include <filesystem>
+#include <fstream>
+#include <limits>
 #include <vector>
 
 #include <tt-metalium/host_api.hpp>
@@ -1201,6 +1203,546 @@ TEST_F(Fabric2DChannelTrimmingFixture, DirectionalChannelForwardedTo) {
     auto all_captures = src_captures;
     all_captures.insert(all_captures.end(), dst_captures.begin(), dst_captures.end());
     verify_capture_roundtrip(all_captures);
+}
+
+// ============================================================================
+// Fixture: Fabric1D with channel trimming override (force-enable all VC1)
+// applied standalone (no capture profile). Verifies that override-only mode
+// correctly loads overrides and that traffic still flows through the fabric.
+// ============================================================================
+class Fabric1DChannelTrimmingOverrideFixture : public BaseFabricFixture {
+protected:
+    static void SetUpTestSuite() {
+        if (tt::get_arch_from_string(tt::test_utils::get_umd_arch_name()) != tt::ARCH::BLACKHOLE) {
+            should_skip_ = true;
+            return;
+        }
+        if (tt::tt_metal::GetNumAvailableDevices() < 4) {
+            should_skip_ = true;
+            return;
+        }
+
+        // Write override YAML to a temp file
+        override_dir_ = std::filesystem::temp_directory_path() / "channel_trimming_override_test";
+        std::filesystem::create_directories(override_dir_);
+        override_yaml_path_ = override_dir_ / "override.yaml";
+        {
+            std::ofstream f(override_yaml_path_);
+            f << "channel_trimming_overrides:\n"
+              << "  vc1:\n"
+              << "    force_enable_all_sender_channels: true\n"
+              << "    force_enable_all_receiver_channels: true\n";
+        }
+
+        auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
+        rtoptions.set_fabric_trimming_override_path(override_yaml_path_.string());
+        // Override-only mode: no capture mode (mutually exclusive), no profile
+        BaseFabricFixture::DoSetUpTestSuite(tt::tt_fabric::FabricConfig::FABRIC_1D);
+    }
+
+    static void TearDownTestSuite() {
+        if (!should_skip_) {
+            BaseFabricFixture::DoTearDownTestSuite();
+            auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
+            rtoptions.set_fabric_trimming_override_path("");
+        }
+        if (std::filesystem::exists(override_dir_)) {
+            std::filesystem::remove_all(override_dir_);
+        }
+    }
+
+    void SetUp() override {
+        if (should_skip_) {
+            GTEST_SKIP() << "Channel trimming override tests require Blackhole architecture with at least 4 devices";
+        }
+        BaseFabricFixture::SetUp();
+    }
+
+    inline static bool should_skip_ = false;
+    inline static std::filesystem::path override_dir_;
+    inline static std::filesystem::path override_yaml_path_;
+};
+
+// ============================================================================
+// Fixture: Fabric1D with a synthetic capture profile + override.
+//
+// Phase 1: Initialize fabric with capture mode enabled, run 1-hop unicast
+//          traffic to populate capture data, export the capture to YAML.
+// Phase 2: Tear down and re-initialize with the captured profile + an
+//          override that force-enables all VC1 channels.
+//
+// This tests the full end-to-end flow: capture → export → reimport + override.
+// ============================================================================
+class Fabric1DChannelTrimmingCaptureAndOverrideFixture : public BaseFabricFixture {
+protected:
+    static void SetUpTestSuite() {
+        if (tt::get_arch_from_string(tt::test_utils::get_umd_arch_name()) != tt::ARCH::BLACKHOLE) {
+            should_skip_ = true;
+            return;
+        }
+        if (tt::tt_metal::GetNumAvailableDevices() < 4) {
+            should_skip_ = true;
+            return;
+        }
+
+        auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
+
+        // === Phase 1: Capture traffic ===
+        rtoptions.set_enable_channel_trimming_capture(true);
+        rtoptions.set_fabric_trimming_profile_path("");
+        rtoptions.set_fabric_trimming_override_path("");
+        BaseFabricFixture::DoSetUpTestSuite(tt::tt_fabric::FabricConfig::FABRIC_1D);
+
+        // Export capture data (even if zero — that's a valid baseline)
+        export_channel_trimming_capture();
+        capture_yaml_path_ =
+            std::filesystem::path(rtoptions.get_logs_dir()) / "generated" / "reports" / "channel_trimming_capture.yaml";
+
+        if (!std::filesystem::exists(capture_yaml_path_)) {
+            should_skip_ = true;
+            BaseFabricFixture::DoTearDownTestSuite();
+            rtoptions.set_enable_channel_trimming_capture(false);
+            return;
+        }
+
+        // Tear down Phase 1
+        BaseFabricFixture::DoTearDownTestSuite();
+        rtoptions.set_enable_channel_trimming_capture(false);
+
+        // === Phase 2: Re-initialize with profile + override ===
+        override_dir_ = std::filesystem::temp_directory_path() / "channel_trimming_capture_and_override_test";
+        std::filesystem::create_directories(override_dir_);
+        override_yaml_path_ = override_dir_ / "override.yaml";
+        {
+            std::ofstream f(override_yaml_path_);
+            // Override: force-enable VC0 sender[0]+receiver[0] (keeps worker channel alive)
+            // and force-enable all VC1 channels (simulating KV cache migration support)
+            f << "channel_trimming_overrides:\n"
+              << "  vc0:\n"
+              << "    force_enable_sender_channels: [0]\n"
+              << "    force_enable_receiver_channels: [0]\n"
+              << "  vc1:\n"
+              << "    force_enable_all_sender_channels: true\n"
+              << "    force_enable_all_receiver_channels: true\n";
+        }
+
+        rtoptions.set_fabric_trimming_profile_path(capture_yaml_path_.string());
+        rtoptions.set_fabric_trimming_override_path(override_yaml_path_.string());
+        BaseFabricFixture::DoSetUpTestSuite(tt::tt_fabric::FabricConfig::FABRIC_1D);
+    }
+
+    static void TearDownTestSuite() {
+        if (!should_skip_) {
+            BaseFabricFixture::DoTearDownTestSuite();
+            auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
+            rtoptions.set_fabric_trimming_profile_path("");
+            rtoptions.set_fabric_trimming_override_path("");
+        }
+        if (std::filesystem::exists(override_dir_)) {
+            std::filesystem::remove_all(override_dir_);
+        }
+    }
+
+    void SetUp() override {
+        if (should_skip_) {
+            GTEST_SKIP() << "Channel trimming capture+override tests require Blackhole with at least 4 devices "
+                            "and a successful capture export";
+        }
+        BaseFabricFixture::SetUp();
+    }
+
+    inline static bool should_skip_ = false;
+    inline static std::filesystem::path capture_yaml_path_;
+    inline static std::filesystem::path override_dir_;
+    inline static std::filesystem::path override_yaml_path_;
+};
+
+// ============================================================================
+// Tests: Fabric1DChannelTrimmingOverrideFixture (override-only, no capture profile)
+// ============================================================================
+
+// Test: Global overrides are loaded into the builder context
+TEST_F(Fabric1DChannelTrimmingOverrideFixture, GlobalOverridesLoaded) {
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& builder_ctx = control_plane.get_fabric_context().get_builder_context();
+    const auto& global_overrides = builder_ctx.get_channel_trimming_global_overrides();
+
+    EXPECT_TRUE(global_overrides.has_any_override());
+    // VC0 should have no override
+    EXPECT_FALSE(global_overrides.per_vc[0].has_override());
+    // VC1 should have force_enable_all
+    EXPECT_TRUE(global_overrides.per_vc[1].has_override());
+    EXPECT_TRUE(global_overrides.per_vc[1].force_enable_all_sender_channels.value_or(false));
+    EXPECT_TRUE(global_overrides.per_vc[1].force_enable_all_receiver_channels.value_or(false));
+}
+
+// Test: Runtime option getter/setter for override path
+TEST_F(Fabric1DChannelTrimmingOverrideFixture, RuntimeOptionOverridePath) {
+    auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
+    EXPECT_TRUE(rtoptions.has_fabric_trimming_override());
+    EXPECT_FALSE(rtoptions.get_fabric_trimming_override_path().empty());
+}
+
+// Test: 1-hop unicast traffic works with override-only mode (no capture profile)
+// The override applies to a fully-enabled baseline, so all channels remain available.
+// This verifies that override-only mode doesn't break normal traffic flow.
+TEST_F(Fabric1DChannelTrimmingOverrideFixture, UnicastTrafficWithOverride) {
+    auto path_result = find_1d_path_with_hops(1);
+    if (!path_result.found) {
+        GTEST_SKIP() << "No 1-hop neighbor pair found on the mesh";
+    }
+
+    // Traffic should flow — override-only mode constructs a fully-enabled baseline
+    // and applies the override (which only affects VC1 here). VC0 remains fully enabled.
+    auto result = run_unicast_traffic_bw_nodes(this, path_result.src_node, path_result.dst_node, 1);
+    EXPECT_FALSE(result.skipped) << "Override-only mode should not prevent traffic flow";
+}
+
+// ============================================================================
+// Fixture: Fabric1D with a restrictive override that only enables VC0
+// sender channel 0 and receiver channel 0 (all other channels disabled).
+// No capture profile — override-only mode with replacement semantics.
+// Verifies that unicast traffic (which uses channel 0) still works when
+// all other channels are trimmed via override.
+// ============================================================================
+class Fabric1DChannelTrimmingOverrideChannel0OnlyFixture : public BaseFabricFixture {
+protected:
+    static void SetUpTestSuite() {
+        if (tt::get_arch_from_string(tt::test_utils::get_umd_arch_name()) != tt::ARCH::BLACKHOLE) {
+            should_skip_ = true;
+            return;
+        }
+        if (tt::tt_metal::GetNumAvailableDevices() < 4) {
+            should_skip_ = true;
+            return;
+        }
+
+        // Write override YAML: only VC0 sender[0] + receiver[0] enabled
+        override_dir_ = std::filesystem::temp_directory_path() / "channel_trimming_override_ch0_only_test";
+        std::filesystem::create_directories(override_dir_);
+        override_yaml_path_ = override_dir_ / "override.yaml";
+        {
+            std::ofstream f(override_yaml_path_);
+            f << "channel_trimming_overrides:\n"
+              << "  vc0:\n"
+              << "    force_enable_sender_channels: [0]\n"
+              << "    force_enable_receiver_channels: [0]\n"
+              << "  vc1:\n"
+              << "    force_enable_sender_channels: []\n"
+              << "    force_enable_receiver_channels: []\n";
+        }
+
+        auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
+        rtoptions.set_fabric_trimming_override_path(override_yaml_path_.string());
+        BaseFabricFixture::DoSetUpTestSuite(tt::tt_fabric::FabricConfig::FABRIC_1D);
+    }
+
+    static void TearDownTestSuite() {
+        if (!should_skip_) {
+            BaseFabricFixture::DoTearDownTestSuite();
+            auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
+            rtoptions.set_fabric_trimming_override_path("");
+        }
+        if (std::filesystem::exists(override_dir_)) {
+            std::filesystem::remove_all(override_dir_);
+        }
+    }
+
+    void SetUp() override {
+        if (should_skip_) {
+            GTEST_SKIP() << "Channel trimming override tests require Blackhole architecture with at least 4 devices";
+        }
+        BaseFabricFixture::SetUp();
+    }
+
+    inline static bool should_skip_ = false;
+    inline static std::filesystem::path override_dir_;
+    inline static std::filesystem::path override_yaml_path_;
+};
+
+// Test: Override loads correctly — only VC0 has sender/receiver overrides
+TEST_F(Fabric1DChannelTrimmingOverrideChannel0OnlyFixture, OverrideLoaded) {
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& builder_ctx = control_plane.get_fabric_context().get_builder_context();
+
+    const auto& global_overrides = builder_ctx.get_channel_trimming_global_overrides();
+    EXPECT_TRUE(global_overrides.has_any_override());
+
+    // VC0: only sender[0] and receiver[0]
+    EXPECT_TRUE(global_overrides.per_vc[0].has_sender_override());
+    EXPECT_TRUE(global_overrides.per_vc[0].has_receiver_override());
+    ASSERT_TRUE(global_overrides.per_vc[0].force_enable_sender_channels.has_value());
+    ASSERT_EQ(global_overrides.per_vc[0].force_enable_sender_channels->size(), 1u);
+    EXPECT_EQ((*global_overrides.per_vc[0].force_enable_sender_channels)[0], 0u);
+
+    // VC1: explicitly disabled — empty channel lists
+    EXPECT_TRUE(global_overrides.per_vc[1].has_sender_override());
+    EXPECT_TRUE(global_overrides.per_vc[1].has_receiver_override());
+    ASSERT_TRUE(global_overrides.per_vc[1].force_enable_sender_channels.has_value());
+    EXPECT_TRUE(global_overrides.per_vc[1].force_enable_sender_channels->empty());
+    ASSERT_TRUE(global_overrides.per_vc[1].force_enable_receiver_channels.has_value());
+    EXPECT_TRUE(global_overrides.per_vc[1].force_enable_receiver_channels->empty());
+}
+
+// Test: 1-hop unicast traffic works with only channel 0 enabled
+// Unicast uses sender channel 0, so this restrictive override should not block traffic.
+TEST_F(Fabric1DChannelTrimmingOverrideChannel0OnlyFixture, UnicastTrafficWithChannel0Only) {
+    auto path_result = find_1d_path_with_hops(1);
+    if (!path_result.found) {
+        GTEST_SKIP() << "No 1-hop neighbor pair found on the mesh";
+    }
+
+    auto result = run_unicast_traffic_bw_nodes(this, path_result.src_node, path_result.dst_node, 1);
+    EXPECT_FALSE(result.skipped) << "Override with only channel 0 enabled should still allow unicast traffic";
+}
+
+// ============================================================================
+// Tests: Fabric1DChannelTrimmingCaptureAndOverrideFixture (capture + override)
+// ============================================================================
+
+// Test: Both capture overrides and global overrides are loaded
+TEST_F(Fabric1DChannelTrimmingCaptureAndOverrideFixture, BothOverridesLoaded) {
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& builder_ctx = control_plane.get_fabric_context().get_builder_context();
+
+    // Capture profile should be loaded
+    const auto& trimming_overrides = builder_ctx.get_channel_trimming_overrides();
+    EXPECT_TRUE(trimming_overrides.has_value());
+    EXPECT_GT(trimming_overrides->size(), 0u) << "Capture profile should have at least one router entry";
+
+    // Global overrides should also be loaded
+    const auto& global_overrides = builder_ctx.get_channel_trimming_global_overrides();
+    EXPECT_TRUE(global_overrides.has_any_override());
+
+    // Verify VC0 override
+    EXPECT_TRUE(global_overrides.per_vc[0].has_override());
+    ASSERT_TRUE(global_overrides.per_vc[0].force_enable_sender_channels.has_value());
+    ASSERT_EQ(global_overrides.per_vc[0].force_enable_sender_channels->size(), 1u);
+    EXPECT_EQ((*global_overrides.per_vc[0].force_enable_sender_channels)[0], 0u);
+
+    // Verify VC1 override
+    EXPECT_TRUE(global_overrides.per_vc[1].has_override());
+    EXPECT_TRUE(global_overrides.per_vc[1].force_enable_all_sender_channels.value_or(false));
+    EXPECT_TRUE(global_overrides.per_vc[1].force_enable_all_receiver_channels.value_or(false));
+}
+
+// Test: 1-hop unicast traffic works with capture + override
+TEST_F(Fabric1DChannelTrimmingCaptureAndOverrideFixture, UnicastTrafficWithCaptureAndOverride) {
+    auto path_result = find_1d_path_with_hops(1);
+    if (!path_result.found) {
+        GTEST_SKIP() << "No 1-hop neighbor pair found on the mesh";
+    }
+
+    auto result = run_unicast_traffic_bw_nodes(this, path_result.src_node, path_result.dst_node, 1);
+    if (result.skipped) {
+        GTEST_SKIP() << "No forwarding links between selected nodes";
+    }
+
+    // Traffic should flow correctly — the override replaces VC decisions but
+    // VC0 sender channel 0 (worker channel) is explicitly enabled in the override,
+    // so normal unicast traffic should work fine.
+    // Verify sender/receiver status was PASS (checked inside run_unicast_traffic_bw_nodes)
+    EXPECT_FALSE(result.skipped);
+}
+
+// ============================================================================
+// Host-Side Unit Tests: Global Override Parsing and Apply Logic
+// These tests don't require a device — they exercise YAML parsing and the
+// bitfield merge logic using synthetic data.
+// ============================================================================
+
+// Test: Parse a global override YAML with force_enable_all for VC1
+TEST(ChannelTrimmingGlobalOverride, ParseForceEnableAllVC1) {
+    // Write a temporary YAML file
+    auto tmp_dir = std::filesystem::temp_directory_path() / "channel_trimming_test";
+    std::filesystem::create_directories(tmp_dir);
+    auto yaml_path = tmp_dir / "override_vc1_all.yaml";
+
+    {
+        std::ofstream f(yaml_path);
+        f << "channel_trimming_overrides:\n"
+          << "  vc1:\n"
+          << "    force_enable_all_sender_channels: true\n"
+          << "    force_enable_all_receiver_channels: true\n";
+    }
+
+    auto overrides = load_channel_trimming_global_overrides(yaml_path.string());
+
+    // VC0 should have no override
+    EXPECT_FALSE(overrides.per_vc[0].has_override());
+
+    // VC1 should have force_enable_all
+    EXPECT_TRUE(overrides.per_vc[1].has_override());
+    EXPECT_TRUE(overrides.per_vc[1].force_enable_all_sender_channels.value_or(false));
+    EXPECT_TRUE(overrides.per_vc[1].force_enable_all_receiver_channels.value_or(false));
+    EXPECT_FALSE(overrides.per_vc[1].force_enable_sender_channels.has_value());
+    EXPECT_FALSE(overrides.per_vc[1].force_enable_receiver_channels.has_value());
+
+    EXPECT_TRUE(overrides.has_any_override());
+
+    std::filesystem::remove_all(tmp_dir);
+}
+
+// Test: Parse a global override YAML with specific channel indices for VC0 and force_all for VC1
+TEST(ChannelTrimmingGlobalOverride, ParseMixedVC0AndVC1) {
+    auto tmp_dir = std::filesystem::temp_directory_path() / "channel_trimming_test";
+    std::filesystem::create_directories(tmp_dir);
+    auto yaml_path = tmp_dir / "override_mixed.yaml";
+
+    {
+        std::ofstream f(yaml_path);
+        f << "channel_trimming_overrides:\n"
+          << "  vc0:\n"
+          << "    force_enable_sender_channels: [0, 2]\n"
+          << "    force_enable_receiver_channels: [0]\n"
+          << "  vc1:\n"
+          << "    force_enable_all_sender_channels: true\n"
+          << "    force_enable_all_receiver_channels: true\n";
+    }
+
+    auto overrides = load_channel_trimming_global_overrides(yaml_path.string());
+
+    // VC0: specific indices
+    EXPECT_TRUE(overrides.per_vc[0].has_override());
+    EXPECT_FALSE(overrides.per_vc[0].force_enable_all_sender_channels.has_value());
+    ASSERT_TRUE(overrides.per_vc[0].force_enable_sender_channels.has_value());
+    ASSERT_EQ(overrides.per_vc[0].force_enable_sender_channels->size(), 2u);
+    EXPECT_EQ((*overrides.per_vc[0].force_enable_sender_channels)[0], 0u);
+    EXPECT_EQ((*overrides.per_vc[0].force_enable_sender_channels)[1], 2u);
+    ASSERT_TRUE(overrides.per_vc[0].force_enable_receiver_channels.has_value());
+    ASSERT_EQ(overrides.per_vc[0].force_enable_receiver_channels->size(), 1u);
+    EXPECT_EQ((*overrides.per_vc[0].force_enable_receiver_channels)[0], 0u);
+
+    // VC1: force_enable_all
+    EXPECT_TRUE(overrides.per_vc[1].has_override());
+    EXPECT_TRUE(overrides.per_vc[1].force_enable_all_sender_channels.value_or(false));
+    EXPECT_TRUE(overrides.per_vc[1].force_enable_all_receiver_channels.value_or(false));
+
+    std::filesystem::remove_all(tmp_dir);
+}
+
+// Test: Apply global override replaces VC bits — force_enable_all on VC1
+TEST(ChannelTrimmingGlobalOverride, ApplyForceEnableAllVC1) {
+    // Simulate a topology with:
+    //   VC0: 5 sender channels, 1 receiver channel
+    //   VC1: 3 sender channels, 1 receiver channel
+    std::array<std::size_t, builder_config::MAX_NUM_VCS> sender_counts = {5, 3};
+    std::array<std::size_t, builder_config::MAX_NUM_VCS> receiver_counts = {1, 1};
+
+    // Start with a capture that has VC0 sender channels 0,1 used (bits 0,1),
+    // and no VC1 channels used.
+    ChannelTrimmingOverrides entry{};
+    entry.sender_channel_min_packet_size_seen_bytes_by_vc.fill(std::numeric_limits<uint16_t>::max());
+    entry.sender_channel_used_bitfield_by_vc = 0x0003;              // bits 0,1 = VC0 channels 0,1
+    entry.receiver_channel_data_forwarded_bitfield_by_vc = 0x0001;  // bit 0 = VC0 receiver 0
+
+    // Override: force-enable ALL VC1 sender+receiver channels (no receiver override for VC1 senders test)
+    ChannelTrimmingGlobalOverrides overrides;
+    overrides.per_vc[1].force_enable_all_sender_channels = true;    // std::optional<bool> = true
+    overrides.per_vc[1].force_enable_all_receiver_channels = true;  // std::optional<bool> = true
+
+    apply_global_overrides_to_entry(entry, overrides, sender_counts, receiver_counts);
+
+    // VC0 bits (0..4) should be UNCHANGED: bits 0,1 still set
+    EXPECT_EQ(entry.sender_channel_used_bitfield_by_vc & 0x001F, 0x0003u);
+
+    // VC1 bits (5..7) should all be set: channels 5,6,7
+    uint16_t vc1_sender_mask = 0x07 << 5;  // bits 5,6,7
+    EXPECT_EQ(entry.sender_channel_used_bitfield_by_vc & vc1_sender_mask, vc1_sender_mask);
+
+    // VC0 receiver bit (0) should be UNCHANGED
+    EXPECT_EQ(entry.receiver_channel_data_forwarded_bitfield_by_vc & 0x0001, 0x0001u);
+
+    // VC1 receiver bit (1) should be set
+    EXPECT_EQ(entry.receiver_channel_data_forwarded_bitfield_by_vc & 0x0002, 0x0002u);
+}
+
+// Test: Apply global override replaces VC bits — specific channels on VC0
+TEST(ChannelTrimmingGlobalOverride, ApplySpecificChannelsReplacesCapture) {
+    // Topology: VC0 has 5 sender channels, VC1 has 3
+    std::array<std::size_t, builder_config::MAX_NUM_VCS> sender_counts = {5, 3};
+    std::array<std::size_t, builder_config::MAX_NUM_VCS> receiver_counts = {1, 1};
+
+    // Capture shows ALL VC0 senders used (bits 0..4 set) and all VC1 senders used (bits 5..7)
+    ChannelTrimmingOverrides entry{};
+    entry.sender_channel_min_packet_size_seen_bytes_by_vc.fill(std::numeric_limits<uint16_t>::max());
+    entry.sender_channel_used_bitfield_by_vc = 0x00FF;              // all bits set
+    entry.receiver_channel_data_forwarded_bitfield_by_vc = 0x0003;  // both receivers
+
+    // Override: for VC0, only enable sender channel 0 and receiver channel 0 (REPLACES, not ORs)
+    ChannelTrimmingGlobalOverrides overrides;
+    overrides.per_vc[0].force_enable_sender_channels = std::vector<size_t>{0};
+    overrides.per_vc[0].force_enable_receiver_channels = std::vector<size_t>{0};
+
+    apply_global_overrides_to_entry(entry, overrides, sender_counts, receiver_counts);
+
+    // VC0 should only have bit 0 set (replacement semantics — capture bits cleared first)
+    EXPECT_EQ(entry.sender_channel_used_bitfield_by_vc & 0x001F, 0x0001u);
+
+    // VC1 bits should be UNCHANGED (no override for VC1)
+    uint16_t vc1_sender_mask = 0x07 << 5;
+    EXPECT_EQ(entry.sender_channel_used_bitfield_by_vc & vc1_sender_mask, vc1_sender_mask);
+
+    // VC0 receiver: only bit 0
+    EXPECT_EQ(entry.receiver_channel_data_forwarded_bitfield_by_vc & 0x0001, 0x0001u);
+    // VC1 receiver: unchanged (bit 1)
+    EXPECT_EQ(entry.receiver_channel_data_forwarded_bitfield_by_vc & 0x0002, 0x0002u);
+}
+
+// Test: Sender-only override does not affect receiver bits
+TEST(ChannelTrimmingGlobalOverride, SenderOnlyOverridePreservesReceiverBits) {
+    // Topology: VC0 has 5 sender channels, 1 receiver channel
+    //           VC1 has 3 sender channels, 1 receiver channel
+    std::array<std::size_t, builder_config::MAX_NUM_VCS> sender_counts = {5, 3};
+    std::array<std::size_t, builder_config::MAX_NUM_VCS> receiver_counts = {1, 1};
+
+    // Start with capture: VC0 senders 0,1 used, VC1 senders 5,6 used, both receivers used
+    ChannelTrimmingOverrides entry{};
+    entry.sender_channel_min_packet_size_seen_bytes_by_vc.fill(std::numeric_limits<uint16_t>::max());
+    entry.sender_channel_used_bitfield_by_vc = 0x0063;              // bits 0,1 (VC0) + bits 5,6 (VC1)
+    entry.receiver_channel_data_forwarded_bitfield_by_vc = 0x0003;  // both receivers
+
+    // Override: force-enable ALL VC1 senders, but NO receiver override
+    ChannelTrimmingGlobalOverrides overrides;
+    overrides.per_vc[1].force_enable_all_sender_channels = true;
+    // Deliberately leave receiver override as nullopt
+
+    apply_global_overrides_to_entry(entry, overrides, sender_counts, receiver_counts);
+
+    // VC0 sender bits (0..4) should be UNCHANGED: bits 0,1 still set
+    EXPECT_EQ(entry.sender_channel_used_bitfield_by_vc & 0x001F, 0x0003u);
+
+    // VC1 sender bits (5..7) should all be set (force_enable_all)
+    uint16_t vc1_sender_mask = 0x07 << 5;
+    EXPECT_EQ(entry.sender_channel_used_bitfield_by_vc & vc1_sender_mask, vc1_sender_mask);
+
+    // BOTH receiver bits should be UNCHANGED — sender-only override must not touch receivers
+    EXPECT_EQ(entry.receiver_channel_data_forwarded_bitfield_by_vc, 0x0003u);
+}
+
+// Test: has_any_override returns false when no overrides specified
+TEST(ChannelTrimmingGlobalOverride, HasAnyOverrideEmpty) {
+    ChannelTrimmingGlobalOverrides overrides;
+    EXPECT_FALSE(overrides.has_any_override());
+}
+
+// Test: Apply with empty override has no effect
+TEST(ChannelTrimmingGlobalOverride, ApplyEmptyOverrideNoEffect) {
+    std::array<std::size_t, builder_config::MAX_NUM_VCS> sender_counts = {5, 3};
+    std::array<std::size_t, builder_config::MAX_NUM_VCS> receiver_counts = {1, 1};
+
+    ChannelTrimmingOverrides entry{};
+    entry.sender_channel_min_packet_size_seen_bytes_by_vc.fill(std::numeric_limits<uint16_t>::max());
+    entry.sender_channel_used_bitfield_by_vc = 0x0023;
+    entry.receiver_channel_data_forwarded_bitfield_by_vc = 0x0001;
+
+    ChannelTrimmingGlobalOverrides overrides;  // empty
+
+    apply_global_overrides_to_entry(entry, overrides, sender_counts, receiver_counts);
+
+    // Nothing should change
+    EXPECT_EQ(entry.sender_channel_used_bitfield_by_vc, 0x0023u);
+    EXPECT_EQ(entry.receiver_channel_data_forwarded_bitfield_by_vc, 0x0001u);
 }
 
 }  // namespace tt::tt_fabric::fabric_router_tests

--- a/tt_metal/fabric/channel_trimming_import.cpp
+++ b/tt_metal/fabric/channel_trimming_import.cpp
@@ -5,7 +5,6 @@
 #include "channel_trimming_import.hpp"
 
 #include <limits>
-#include <stdexcept>
 #include <string>
 
 #include <tt-logger/tt-logger.hpp>
@@ -170,6 +169,71 @@ ChannelTrimmingOverrideMap load_channel_trimming_overrides(const std::string& ya
     }
 
     log_info(tt::LogFabric, "Loaded {} channel trimming overrides from profile", overrides.size());
+    return overrides;
+}
+
+ChannelTrimmingGlobalOverrides load_channel_trimming_global_overrides(const std::string& yaml_path) {
+    log_info(tt::LogFabric, "Loading channel trimming global overrides from: {}", yaml_path);
+
+    YAML::Node root = YAML::LoadFile(yaml_path);
+    TT_FATAL(
+        root["channel_trimming_overrides"],
+        "Override YAML missing 'channel_trimming_overrides' root key: {}",
+        yaml_path);
+
+    ChannelTrimmingGlobalOverrides overrides;
+    const auto& overrides_node = root["channel_trimming_overrides"];
+
+    auto vc_keys = collect_map_keys(overrides_node);
+    for (const auto& vc_key : vc_keys) {
+        // Parse "vcN" → N
+        TT_FATAL(
+            vc_key.size() >= 3 && vc_key.substr(0, 2) == "vc",
+            "Invalid VC key '{}' in override YAML (expected 'vc0', 'vc1', ...)",
+            vc_key);
+        size_t vc = std::stoul(vc_key.substr(2));
+        TT_FATAL(
+            vc < builder_config::MAX_NUM_VCS,
+            "VC index {} exceeds MAX_NUM_VCS ({}) in override YAML",
+            vc,
+            builder_config::MAX_NUM_VCS);
+
+        const auto& vc_node = overrides_node[vc_key];
+        auto& vc_override = overrides.per_vc[vc];
+
+        if (vc_node["force_enable_all_sender_channels"]) {
+            vc_override.force_enable_all_sender_channels = vc_node["force_enable_all_sender_channels"].as<bool>();
+        }
+        if (vc_node["force_enable_all_receiver_channels"]) {
+            vc_override.force_enable_all_receiver_channels = vc_node["force_enable_all_receiver_channels"].as<bool>();
+        }
+        if (vc_node["force_enable_sender_channels"]) {
+            std::vector<size_t> indices;
+            for (const auto& idx_node : vc_node["force_enable_sender_channels"]) {
+                indices.push_back(idx_node.as<size_t>());
+            }
+            vc_override.force_enable_sender_channels = std::move(indices);
+        }
+        if (vc_node["force_enable_receiver_channels"]) {
+            std::vector<size_t> indices;
+            for (const auto& idx_node : vc_node["force_enable_receiver_channels"]) {
+                indices.push_back(idx_node.as<size_t>());
+            }
+            vc_override.force_enable_receiver_channels = std::move(indices);
+        }
+
+        log_debug(
+            tt::LogFabric,
+            "  VC{}: force_all_sender={} force_all_receiver={} sender_indices={} receiver_indices={}",
+            vc,
+            vc_override.force_enable_all_sender_channels.value_or(false),
+            vc_override.force_enable_all_receiver_channels.value_or(false),
+            vc_override.force_enable_sender_channels.has_value() ? vc_override.force_enable_sender_channels->size() : 0,
+            vc_override.force_enable_receiver_channels.has_value() ? vc_override.force_enable_receiver_channels->size()
+                                                                   : 0);
+    }
+
+    log_info(tt::LogFabric, "Loaded channel trimming global overrides from: {}", yaml_path);
     return overrides;
 }
 

--- a/tt_metal/fabric/channel_trimming_import.hpp
+++ b/tt_metal/fabric/channel_trimming_import.hpp
@@ -4,9 +4,12 @@
 
 #pragma once
 
+#include <array>
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 #include <umd/device/types/cluster_descriptor_types.hpp>  // ChipId
 #include <hostdevcommon/fabric_common.h>                   // chan_id_t
@@ -27,7 +30,52 @@ inline uint64_t make_override_key(ChipId chip_id, chan_id_t eth_chan) {
     return (static_cast<uint64_t>(static_cast<uint32_t>(chip_id)) << 32) | eth_chan;
 }
 
+// Per-VC override specification for channel trimming.
+// Sender and receiver overrides are independent — specifying only sender overrides
+// for a VC will not affect receiver bits, and vice versa.
+// When a field has a value, it REPLACES the capture's decision for that VC+direction.
+struct ChannelTrimmingVcOverride {
+    std::optional<bool> force_enable_all_sender_channels;               // true = enable all senders on this VC
+    std::optional<std::vector<size_t>> force_enable_sender_channels;    // VC-relative indices
+    std::optional<bool> force_enable_all_receiver_channels;             // true = enable all receivers on this VC
+    std::optional<std::vector<size_t>> force_enable_receiver_channels;  // VC-relative indices
+
+    bool has_sender_override() const {
+        return force_enable_all_sender_channels.has_value() || force_enable_sender_channels.has_value();
+    }
+    bool has_receiver_override() const {
+        return force_enable_all_receiver_channels.has_value() || force_enable_receiver_channels.has_value();
+    }
+    bool has_override() const { return has_sender_override() || has_receiver_override(); }
+};
+
+// Global overrides that apply across all routers, keyed by VC.
+struct ChannelTrimmingGlobalOverrides {
+    std::array<ChannelTrimmingVcOverride, builder_config::MAX_NUM_VCS> per_vc = {};
+
+    bool has_any_override() const {
+        for (const auto& vc_override : per_vc) {
+            if (vc_override.has_override()) {
+                return true;
+            }
+        }
+        return false;
+    }
+};
+
 // Parse a previously exported channel trimming capture YAML and return per-router overrides.
 ChannelTrimmingOverrideMap load_channel_trimming_overrides(const std::string& yaml_path);
+
+// Parse a channel trimming global override YAML and return global overrides.
+ChannelTrimmingGlobalOverrides load_channel_trimming_global_overrides(const std::string& yaml_path);
+
+// Apply global overrides to a per-router trimming entry using replacement semantics.
+// Sender and receiver overrides are applied independently per VC.
+// sender_channels_per_vc and receiver_channels_per_vc provide the topology-known channel counts.
+void apply_global_overrides_to_entry(
+    ChannelTrimmingOverrides& entry,
+    const ChannelTrimmingGlobalOverrides& global_overrides,
+    const std::array<std::size_t, builder_config::MAX_NUM_VCS>& sender_channels_per_vc,
+    const std::array<std::size_t, builder_config::MAX_NUM_VCS>& receiver_channels_per_vc);
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/fabric/compute_mesh_router_builder.cpp
+++ b/tt_metal/fabric/compute_mesh_router_builder.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "compute_mesh_router_builder.hpp"
+#include <limits>
 #include "tt_metal/fabric/erisc_datamover_builder.hpp"
 #include "tt_metal/fabric/fabric_tensix_builder.hpp"
 #include "tt_metal/fabric/fabric_context.hpp"
@@ -19,6 +20,142 @@
 #include <tt_stl/assert.hpp>
 
 namespace tt::tt_fabric {
+
+namespace {
+
+// Set bits [0, channels_per_vc[0]) | [offset1, offset1+channels_per_vc[1]) | ... in a bitfield.
+void set_all_channel_bits(
+    uint16_t& bitfield, const std::array<std::size_t, builder_config::MAX_NUM_VCS>& channels_per_vc) {
+    size_t offset = 0;
+    for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
+        bitfield |= static_cast<uint16_t>(((1u << channels_per_vc[vc]) - 1) << offset);
+        offset += channels_per_vc[vc];
+    }
+}
+
+// Replace a VC's channel bits in a bitfield using override settings.
+// Clears all bits in [offset, offset+count), then sets only override-specified bits.
+void apply_vc_override_to_bitfield(
+    uint16_t& bitfield,
+    size_t offset,
+    size_t count,
+    size_t vc,
+    const std::optional<bool>& force_enable_all,
+    const std::optional<std::vector<size_t>>& force_enable_indices,
+    const char* direction_name) {
+    uint16_t vc_mask = static_cast<uint16_t>(((1u << count) - 1) << offset);
+
+    // CLEAR all bits for this VC range
+    bitfield &= ~vc_mask;
+
+    // SET only what the override says
+    if (force_enable_all.value_or(false)) {
+        bitfield |= vc_mask;
+    } else if (force_enable_indices.has_value()) {
+        for (size_t idx : *force_enable_indices) {
+            TT_FATAL(
+                idx < count,
+                "Override {} channel index {} exceeds VC{} {} count {}",
+                direction_name,
+                idx,
+                vc,
+                direction_name,
+                count);
+            bitfield |= (1u << (offset + idx));
+        }
+    }
+}
+
+}  // namespace
+
+void apply_global_overrides_to_entry(
+    ChannelTrimmingOverrides& entry,
+    const ChannelTrimmingGlobalOverrides& global_overrides,
+    const std::array<std::size_t, builder_config::MAX_NUM_VCS>& sender_channels_per_vc,
+    const std::array<std::size_t, builder_config::MAX_NUM_VCS>& receiver_channels_per_vc) {
+    size_t sender_offset = 0;
+    size_t receiver_offset = 0;
+    for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
+        const auto& vc_override = global_overrides.per_vc[vc];
+
+        if (vc_override.has_sender_override()) {
+            apply_vc_override_to_bitfield(
+                entry.sender_channel_used_bitfield_by_vc,
+                sender_offset,
+                sender_channels_per_vc[vc],
+                vc,
+                vc_override.force_enable_all_sender_channels,
+                vc_override.force_enable_sender_channels,
+                "sender");
+        }
+        sender_offset += sender_channels_per_vc[vc];
+
+        if (vc_override.has_receiver_override()) {
+            apply_vc_override_to_bitfield(
+                entry.receiver_channel_data_forwarded_bitfield_by_vc,
+                receiver_offset,
+                receiver_channels_per_vc[vc],
+                vc,
+                vc_override.force_enable_all_receiver_channels,
+                vc_override.force_enable_receiver_channels,
+                "receiver");
+        }
+        receiver_offset += receiver_channels_per_vc[vc];
+    }
+}
+
+namespace {
+
+// Resolve the effective channel trimming overrides for a single router.
+//
+// Looks up the router in the capture map (if present), then conditionally applies
+// global overrides. Returns nullopt if neither capture nor global override applies
+// (meaning the builder should use its default: all channels enabled).
+//
+// Priority:
+//   - No capture, no global override → nullopt (builder default)
+//   - Capture only → capture entry (existing behavior)
+//   - Global override only → fully-enabled baseline with override applied
+//   - Capture + global override → capture entry with override applied
+std::optional<ChannelTrimmingOverrides> resolve_channel_trimming_for_router(
+    const std::optional<ChannelTrimmingOverrideMap>& capture_overrides,
+    const ChannelTrimmingGlobalOverrides& global_overrides,
+    ChipId chip_id,
+    chan_id_t eth_chan,
+    const std::array<std::size_t, builder_config::MAX_NUM_VCS>& sender_channels_per_vc,
+    const std::array<std::size_t, builder_config::MAX_NUM_VCS>& receiver_channels_per_vc) {
+    // Look up capture entry for this router
+    std::optional<ChannelTrimmingOverrides> result;
+    if (capture_overrides.has_value()) {
+        auto key = make_override_key(chip_id, eth_chan);
+        auto it = capture_overrides->find(key);
+        if (it != capture_overrides->end()) {
+            result = it->second;
+        }
+    }
+
+    bool has_global_override = global_overrides.has_any_override();
+    if (!result.has_value() && !has_global_override) {
+        return std::nullopt;  // No trimming — builder default
+    }
+
+    if (!result.has_value()) {
+        // No capture entry — construct a fully-enabled baseline for the override to modify
+        ChannelTrimmingOverrides baseline;
+        baseline.sender_channel_min_packet_size_seen_bytes_by_vc.fill(std::numeric_limits<uint16_t>::max());
+        set_all_channel_bits(baseline.sender_channel_used_bitfield_by_vc, sender_channels_per_vc);
+        set_all_channel_bits(baseline.receiver_channel_data_forwarded_bitfield_by_vc, receiver_channels_per_vc);
+        result = baseline;
+    }
+
+    if (has_global_override) {
+        apply_global_overrides_to_entry(*result, global_overrides, sender_channels_per_vc, receiver_channels_per_vc);
+    }
+
+    return result;
+}
+
+}  // namespace
 
 ComputeMeshRouterBuilder::ComputeMeshRouterBuilder(
     FabricNodeId local_node,
@@ -142,16 +279,14 @@ std::unique_ptr<ComputeMeshRouterBuilder> ComputeMeshRouterBuilder::build(
         actual_receiver_channels_per_vc[vc] = 1;  // Always 1 receiver per VC (when VC exists)
     }
 
-    // Look up channel trimming overrides for this router (if a profile is loaded)
-    std::optional<ChannelTrimmingOverrides> channel_trimming_overrides_for_router;
-    const auto& trimming_overrides = builder_context.get_channel_trimming_overrides();
-    if (trimming_overrides.has_value()) {
-        auto key = make_override_key(device->id(), location.eth_chan);
-        auto it = trimming_overrides->find(key);
-        if (it != trimming_overrides->end()) {
-            channel_trimming_overrides_for_router = it->second;
-        }
-    }
+    // Resolve channel trimming for this router: capture lookup + global override application
+    auto channel_trimming_overrides_for_router = resolve_channel_trimming_for_router(
+        builder_context.get_channel_trimming_overrides(),
+        builder_context.get_channel_trimming_global_overrides(),
+        device->id(),
+        location.eth_chan,
+        actual_sender_channels_per_vc,
+        actual_receiver_channels_per_vc);
 
     // NOW create erisc builder with computed injection flags and actual channel counts
     auto edm_builder = std::make_unique<FabricEriscDatamoverBuilder>(FabricEriscDatamoverBuilder::build(

--- a/tt_metal/fabric/config/channel_trimming_overrides/enable_vc0_s0r0_vc1_all.yaml
+++ b/tt_metal/fabric/config/channel_trimming_overrides/enable_vc0_s0r0_vc1_all.yaml
@@ -1,0 +1,7 @@
+channel_trimming_overrides:
+  vc0:
+    force_enable_sender_channels: [0]
+    force_enable_receiver_channels: [0]
+  vc1:
+    force_enable_all_sender_channels: true
+    force_enable_all_receiver_channels: true

--- a/tt_metal/fabric/config/channel_trimming_overrides/enable_vc1_all_channels.yaml
+++ b/tt_metal/fabric/config/channel_trimming_overrides/enable_vc1_all_channels.yaml
@@ -1,0 +1,4 @@
+channel_trimming_overrides:
+  vc1:
+    force_enable_all_sender_channels: true
+    force_enable_all_receiver_channels: true

--- a/tt_metal/fabric/fabric_builder_context.cpp
+++ b/tt_metal/fabric/fabric_builder_context.cpp
@@ -65,10 +65,22 @@ FabricBuilderContext::FabricBuilderContext(const FabricContext& fabric_context) 
         "TT_METAL_FABRIC_TRIMMING_PROFILE and TT_METAL_ENABLE_CHANNEL_TRIMMING_CAPTURE are mutually exclusive. "
         "Capture mode instruments routers to record usage; import mode applies a previously captured profile to "
         "optimize router construction. Enable only one at a time.");
+    TT_FATAL(
+        !(rtoptions.has_fabric_trimming_override() && rtoptions.get_enable_channel_trimming_capture()),
+        "TT_METAL_FABRIC_TRIMMING_OVERRIDE and TT_METAL_ENABLE_CHANNEL_TRIMMING_CAPTURE are mutually exclusive. "
+        "Capture mode instruments routers to record usage; override mode applies forced channel settings. "
+        "Enable only one at a time.");
     if (rtoptions.has_fabric_trimming_profile()) {
         const auto& path = rtoptions.get_fabric_trimming_profile_path();
         log_info(tt::LogFabric, "Loading channel trimming profile: {}", path);
         channel_trimming_overrides_ = load_channel_trimming_overrides(path);
+    }
+
+    // Load global overrides from override file if specified
+    if (rtoptions.has_fabric_trimming_override()) {
+        const auto& override_path = rtoptions.get_fabric_trimming_override_path();
+        log_info(tt::LogFabric, "Loading channel trimming global overrides: {}", override_path);
+        channel_trimming_global_overrides_ = load_channel_trimming_global_overrides(override_path);
     }
 
     this->intermesh_vc_config_ = this->compute_intermesh_vc_config();

--- a/tt_metal/fabric/fabric_builder_context.hpp
+++ b/tt_metal/fabric/fabric_builder_context.hpp
@@ -167,6 +167,9 @@ public:
     const std::optional<ChannelTrimmingOverrideMap>& get_channel_trimming_overrides() const {
         return channel_trimming_overrides_;
     }
+    const ChannelTrimmingGlobalOverrides& get_channel_trimming_global_overrides() const {
+        return channel_trimming_global_overrides_;
+    }
 
     // ============ Intermesh VC Configuration ============
     const IntermeshVCConfig& get_intermesh_vc_config() const { return intermesh_vc_config_; }
@@ -184,6 +187,9 @@ private:
 
     // Channel trimming overrides loaded from profile YAML (if specified)
     std::optional<ChannelTrimmingOverrideMap> channel_trimming_overrides_;
+
+    // Global channel trimming overrides loaded from override YAML (if specified)
+    ChannelTrimmingGlobalOverrides channel_trimming_global_overrides_;
 
     IntermeshVCConfig intermesh_vc_config_;
 

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -88,6 +88,7 @@ enum class EnvVarID {
     TT_FABRIC_PROFILE_RX_CH_FWD,               // Enable fabric RX channel forwarding profiling
     TT_METAL_ENABLE_CHANNEL_TRIMMING_CAPTURE,  // Enable channel trimming resource usage capture
     TT_METAL_FABRIC_TRIMMING_PROFILE,          // Path to channel trimming profile YAML for import
+    TT_METAL_FABRIC_TRIMMING_OVERRIDE,         // Path to channel trimming global override YAML
     TT_METAL_FORCE_REINIT,                     // Force context reinitialization
     TT_METAL_DISABLE_FABRIC_TWO_ERISC,         // Disable fabric 2-ERISC mode
     TT_METAL_LOG_KERNELS_COMPILE_COMMANDS,     // Log kernel compilation commands
@@ -558,6 +559,16 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
         // Default: empty (no profile import)
         // Usage: export TT_METAL_FABRIC_TRIMMING_PROFILE=/path/to/channel_trimming_capture.yaml
         case EnvVarID::TT_METAL_FABRIC_TRIMMING_PROFILE: this->fabric_trimming_profile_path = std::string(value); break;
+
+        // TT_METAL_FABRIC_TRIMMING_OVERRIDE
+        // Path to a global override YAML file for channel trimming. When set, override entries
+        // replace capture-driven decisions for specified VCs (force-enable/disable channels).
+        // Can be used with or without TT_METAL_FABRIC_TRIMMING_PROFILE.
+        // Default: empty (no override)
+        // Usage: export TT_METAL_FABRIC_TRIMMING_OVERRIDE=/path/to/override.yaml
+        case EnvVarID::TT_METAL_FABRIC_TRIMMING_OVERRIDE:
+            this->fabric_trimming_override_path = std::string(value);
+            break;
 
         // RELIABILITY_MODE
         // Sets the fabric reliability mode (STRICT, RELAXED, or DYNAMIC).

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -273,6 +273,9 @@ class RunTimeOptions {
     // Path to channel trimming profile YAML for import-driven router construction
     std::string fabric_trimming_profile_path;
 
+    // Path to channel trimming global override YAML
+    std::string fabric_trimming_override_path;
+
     // Enable fabric telemetry
     bool enable_fabric_telemetry = false;
     FabricTelemetrySettings fabric_telemetry_settings;
@@ -662,6 +665,11 @@ public:
     bool has_fabric_trimming_profile() const { return !fabric_trimming_profile_path.empty(); }
     const std::string& get_fabric_trimming_profile_path() const { return fabric_trimming_profile_path; }
     void set_fabric_trimming_profile_path(const std::string& path) { fabric_trimming_profile_path = path; }
+
+    // Channel trimming global override path
+    bool has_fabric_trimming_override() const { return !fabric_trimming_override_path.empty(); }
+    const std::string& get_fabric_trimming_override_path() const { return fabric_trimming_override_path; }
+    void set_fabric_trimming_override_path(const std::string& path) { fabric_trimming_override_path = path; }
 
     // Reliability mode override accessor
     std::optional<tt::tt_fabric::FabricReliabilityMode> get_reliability_mode() const { return reliability_mode; }


### PR DESCRIPTION
This change adds complementary functionality to the earlier channel trimming capture/replay work: https://github.com/tenstorrent/tt-metal/pull/38327. Specifically, it add a channel trim override option. This feature is helpful for "keeping" fabric resources enabled. This is necessary for workloads where any non-deterministic traffic may exist in the general case, but that may not have been present during workload capture phase. One example that fits this profile is kv-cache migration. 

In a case like kv-cache migration, we can constrain its traffic to just the intermesh VC and so we would, for example, provide an override to force-enable VC1 in that workload.

# Channel Enablement Priority
The priority hierarchy for channel enablement is:
1. Default topology channel enablement < 2. channel trim capture/replay channel enablement < 3. override yaml channel enablement

# Usage
##  Environment Variable

`export TT_METAL_FABRIC_TRIMMING_OVERRIDE=/path/to/override.yaml`

- Mutually exclusive with `TT_METAL_ENABLE_CHANNEL_TRIMMING_CAPTURE` (capture mode)
- Can be combined with `TT_METAL_FABRIC_TRIMMING_PROFILE` (profile + override)
- When used alone (no profile), a fully-enabled baseline is constructed and the override replaces the relevant VC bits

##  YAML Schema
```
  channel_trimming_overrides:
    vc0:                                        # Per-VC block (vc0, vc1, ...)
      force_enable_sender_channels: [0, 1]      # VC-relative sender channel indices to enable
      force_enable_receiver_channels: [0]        # VC-relative receiver channel indices to enable
    vc1:
      force_enable_all_sender_channels: true     # Enable ALL sender channels on this VC
      force_enable_all_receiver_channels: true   # Enable ALL receiver channels on this VC
```

| Field | Type | Description |
|-|-|-|
| force_enable_sender_channels       | list[int] | VC-relative sender channel indices to enable. Replaces capture bits — unlisted channels are disabled. Use [] to disable all. |
| force_enable_receiver_channels     | list[int] | VC-relative receiver channel indices to enable. Same replacement semantics. |
| force_enable_all_sender_channels   | bool      | When true, enables all sender channels on this VC.|
| force_enable_all_receiver_channels | bool      | When true, enables all receiver channels on this VC. |


###  Semantics

  - Replacement, not OR: Override entries replace the capture/baseline bits for the specified VC+direction. Channels not listed are cleared.
  - Independent per direction: Specifying only sender overrides for a VC does not affect receiver bits, and vice versa.
  - Omitted VCs are untouched: Only VCs present in the YAML are overridden; others retain their capture/baseline state.

###  Pre-Configured Overrides

Some reference yamls are provided for general use
  
|                              File                              |                           Description                           |
|-|-|
| config/channel_trimming_overrides/enable_vc1_all_channels.yaml | Force-enable all VC1 channels (inter-mesh), leave VC0 untouched |
| config/channel_trimming_overrides/enable_vc0_s0r0_vc1_all.yaml | VC0: only worker channel (s0+r0), VC1: all channels |



### Ticket
Closes https://github.com/tenstorrent/tt-metal/issues/38386


### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=snijjar/enable-fabric-channel-trim-override-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:snijjar/enable-fabric-channel-trim-override-support)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snijjar/enable-fabric-channel-trim-override-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snijjar/enable-fabric-channel-trim-override-support)
- [x] New/Existing tests provide coverage for changes
- `./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric*ChannelTrimming*Override`
  - ApplyVC0S0S1AndVC1All — override on fully-used baseline                                                                                                                                             
  - ApplyVC0S0S1AndVC1AllToEmptyBaseline — override on empty baseline
  - OverrideLoadedCorrectly — global overrides match YAML
  - ChannelCountsConsistentWith2DMesh — VC0 channel counts valid
  - StandaloneOverrideCreatesFullyEnabledBaseline — no profile, overrides active
  - OverrideLoadedCorrectly — global overrides match YAML on intermesh
  - IntermeshVC1ChannelCountsNonZero — VC1 sender >= 3, receiver >= 1
  - StandaloneOverrideNoProfile — no profile, overrides active

