### PR TITLE
Add API support for fp32_dest_acc control

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_common_api.h
@@ -29,6 +29,8 @@ inline void llk_math_hw_configure(const std::uint32_t srca_operand, const std::u
         unpack_dst_format[srca_operand_id], unpack_dst_format[srcb_operand_id]);
 }
 
+inline void llk_math_set_fp32_dest_acc(bool enable) { _llk_math_set_fp32_dest_acc_(enable); }
+
 inline void llk_math_reconfig_remap(const bool remap_enable) { _llk_math_reconfig_remap_(remap_enable); }
 
 inline void llk_math_wait_for_dest_available() {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_common_api.h
@@ -29,6 +29,8 @@ inline void llk_math_hw_configure(const std::uint32_t srca_operand, const std::u
         unpack_dst_format[srca_operand_id], unpack_dst_format[srcb_operand_id]);
 }
 
+inline void llk_math_set_fp32_dest_acc(bool enable) { _llk_math_set_fp32_dest_acc_(enable); }
+
 inline void llk_math_wait_for_dest_available() {
     WAYPOINT("MWDW");
     _llk_math_wait_for_dest_available_<DST_SYNC_MODE>();

--- a/tt_metal/hw/inc/api/compute/compute_kernel_hw_startup.h
+++ b/tt_metal/hw/inc/api/compute/compute_kernel_hw_startup.h
@@ -71,4 +71,48 @@ ALWI void compute_kernel_hw_startup(uint32_t icb0, uint32_t ocb) {
 #endif  // TODO: AM; add Quasar implementation
 }
 
+// clang-format off
+/**
+ * Enables FP32 accumulation in the destination register (ALU and SFPU).
+ *
+ * This is a lightweight, standalone reconfiguration that only toggles the
+ * ALU_ACC_CTRL Fp32_enabled and SFPU_Fp32_enabled bits. It does not touch
+ * any unpacker or packer configuration, making it safe to call mid-kernel
+ * without re-running compute_kernel_hw_startup.
+ *
+ * Must be paired with math_disable_fp32_dest_acc() when switching back to
+ * BF16 accumulation mode within the same kernel.
+ *
+ * Only available on Wormhole and Blackhole (no-op on Quasar).
+ *
+ * Return value: None
+ */
+// clang-format on
+ALWI void math_enable_fp32_dest_acc() {
+#ifndef ARCH_QUASAR
+    MATH((llk_math_set_fp32_dest_acc(true)));
+#endif
+}
+
+// clang-format off
+/**
+ * Disables FP32 accumulation in the destination register (ALU and SFPU),
+ * reverting to BF16 accumulation mode.
+ *
+ * This is a lightweight, standalone reconfiguration that only toggles the
+ * ALU_ACC_CTRL Fp32_enabled and SFPU_Fp32_enabled bits. It does not touch
+ * any unpacker or packer configuration, making it safe to call mid-kernel
+ * without re-running compute_kernel_hw_startup.
+ *
+ * Only available on Wormhole and Blackhole (no-op on Quasar).
+ *
+ * Return value: None
+ */
+// clang-format on
+ALWI void math_disable_fp32_dest_acc() {
+#ifndef ARCH_QUASAR
+    MATH((llk_math_set_fp32_dest_acc(false)));
+#endif
+}
+
 }  // namespace ckernel


### PR DESCRIPTION
### Ticket
#38923 

### Problem description
To support the Deepseek effort, we need to implement API that allows the users to enable/disable float32 individually and add proper LLK support.

### What's changed
This PR introduces new APIs that allow the users to manually enable and disable `float32_dest_acc`.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=pmilenkovic/add-fp32-enable-disable)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:pmilenkovic/add-fp32-enable-disable) (Same as main)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pmilenkovic/add-fp32-enable-disable)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pmilenkovic/add-fp32-enable-disable)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pmilenkovic/add-fp32-enable-disable)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pmilenkovic/add-fp32-enable-disable)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pmilenkovic/add-fp32-enable-disable)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pmilenkovic/add-fp32-enable-disable)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pmilenkovic/add-fp32-enable-disable)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pmilenkovic/add-fp32-enable-disable)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pmilenkovic/add-fp32-enable-disable)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pmilenkovic/add-fp32-enable-disable)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
