### PR TITLE
#38899: use device 2.0 api for moe reduction op

### DIFF
--- a/ttnn/cpp/ttnn/operations/reduction/moe/device/kernels/dataflow/reader_create_index_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/moe/device/kernels/dataflow/reader_create_index_tensor.cpp
@@ -4,6 +4,10 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/core_local_mem.h"
+#include "experimental/tensor.h"
 
 /**
  * add a cb full of indices for the tile
@@ -13,9 +17,9 @@
  */
 FORCE_INLINE void generate_index_tile(const uint32_t cb_id, const uint32_t wt) {
     // TODO: investigate moving to compile time (binary size is at risk)
-    cb_reserve_back(cb_id, 1);
-    uint32_t write_addr = get_write_ptr(cb_id);
-    volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(write_addr);
+    experimental::CircularBuffer cb(cb_id);
+    cb.reserve_back(1);
+    experimental::CoreLocalMem<volatile uint32_t> ptr(cb.get_write_ptr());
     uint16_t wt_offset = wt << 5;
 
     uint32_t count = 0;
@@ -30,7 +34,7 @@ FORCE_INLINE void generate_index_tile(const uint32_t cb_id, const uint32_t wt) {
             }
         }
     }
-    cb_push_back(cb_id, 1);
+    cb.push_back(1);
 }
 
 void kernel_main() {
@@ -52,7 +56,6 @@ void kernel_main() {
     constexpr auto s1_args = TensorAccessorArgs<s0_args.next_compile_time_args_offset()>();
     constexpr auto s2_args = TensorAccessorArgs<s1_args.next_compile_time_args_offset()>();
 
-    // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
     constexpr uint32_t tile_bytes_input = get_tile_size(cb_id_in0);
 
@@ -66,6 +69,11 @@ void kernel_main() {
 
     const auto s2 = TensorAccessor(s2_args, expert_addr, tile_bytes_expert);
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_in0(cb_id_in0);
+    experimental::CircularBuffer cb_topk(cb_topk_mask);
+    experimental::CircularBuffer cb_expert(cb_expert_mask);
+
     // Stream in input tensor, buffer has four tiles as we double-buffer to continue streaming while waiting for compute
     // and we need two tiles for the bitonic sort llk We could load in an entire row of tiles at a time but that would
     // require substantially more memory (we would be double buffering four Wt sized CBs)
@@ -75,37 +83,33 @@ void kernel_main() {
     uint32_t tile_id_expert = 0;
     for (uint32_t i = 0; i < Ht; ++i) {
         // input
-        cb_reserve_back(cb_id_in0, Wt);
-        uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
+        cb_in0.reserve_back(Wt);
         for (uint32_t j = 0; j < Wt; ++j) {
-            noc_async_read_tile(tile_id, s0, l1_write_addr);
-            l1_write_addr += tile_bytes_input;
+            noc.async_read(s0, cb_in0, tile_bytes_input, {.page_id = tile_id}, {.offset_bytes = j * tile_bytes_input});
             tile_id++;
             generate_index_tile(cb_intermed_index, j);
         }
-        noc_async_read_barrier();
-        cb_push_back(cb_id_in0, Wt);
+        noc.async_read_barrier();
+        cb_in0.push_back(Wt);
 
         // topk mask
-        cb_reserve_back(cb_topk_mask, Kt);
-        uint32_t l1_write_addr_topk = get_write_ptr(cb_topk_mask);
+        cb_topk.reserve_back(Kt);
         for (uint32_t j = 0; j < Kt; ++j) {
-            noc_async_read_tile(tile_id_topk, s1, l1_write_addr_topk);
-            l1_write_addr_topk += tile_bytes_topk;
+            noc.async_read(
+                s1, cb_topk, tile_bytes_topk, {.page_id = tile_id_topk}, {.offset_bytes = j * tile_bytes_topk});
             tile_id_topk++;
         }
-        noc_async_read_barrier();
-        cb_push_back(cb_topk_mask, Kt);
+        noc.async_read_barrier();
+        cb_topk.push_back(Kt);
 
         // expert mask
-        cb_reserve_back(cb_expert_mask, Wt);
-        uint32_t l1_write_addr_expert = get_write_ptr(cb_expert_mask);
+        cb_expert.reserve_back(Wt);
         for (uint32_t j = 0; j < Wt; ++j) {
-            noc_async_read_tile(tile_id_expert, s2, l1_write_addr_expert);
-            l1_write_addr_expert += tile_bytes_expert;
+            noc.async_read(
+                s2, cb_expert, tile_bytes_expert, {.page_id = tile_id_expert}, {.offset_bytes = j * tile_bytes_expert});
             tile_id_expert++;
         }
-        noc_async_read_barrier();
-        cb_push_back(cb_expert_mask, Wt);
+        noc.async_read_barrier();
+        cb_expert.push_back(Wt);
     }
 }

--- a/ttnn/cpp/ttnn/operations/reduction/moe/device/kernels/dataflow/writer_unary_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/moe/device/kernels/dataflow/writer_unary_interleaved.cpp
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 #include "ttnn/kernel/dataflow/generate_reduce_scaler.hpp"
 
 void kernel_main() {
@@ -27,16 +30,22 @@ void kernel_main() {
 
     const auto interleaved_accessor0 = TensorAccessor(out_args, dst_addr0, tile_bytes);
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_out(out_cb_index);
+
     uint32_t tile_id = 0;
-    cb_wait_front(out_cb_index, Ht * Kt);
-    uint32_t l1_read_addr = get_read_ptr(out_cb_index);
+    cb_out.wait_front(Ht * Kt);
     for (uint32_t j = 0; j < Ht; ++j) {
         for (uint32_t i = 0; i < Kt; ++i) {
-            noc_async_write_tile(tile_id, interleaved_accessor0, l1_read_addr);
-            l1_read_addr += tile_bytes;
+            noc.async_write(
+                cb_out,
+                interleaved_accessor0,
+                tile_bytes,
+                {.offset_bytes = tile_id * tile_bytes},
+                {.page_id = tile_id});
             tile_id++;
         }
     }
-    noc_async_write_barrier();
-    cb_pop_front(out_cb_index, Ht * Kt);
+    noc.async_write_barrier();
+    cb_out.pop_front(Ht * Kt);
 }


### PR DESCRIPTION
### Ticket
Link to Github Issue #38899

### Problem description
There's a new api.

### What's changed
Move to the new api.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=bbradel-38899_moe_m20)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:bbradel-38899_moe_m20)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-38899_moe_m20)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-38899_moe_m20)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-38899_moe_m20)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-38899_moe_m20)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-38899_moe_m20)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-38899_moe_m20)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-38899_moe_m20)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-38899_moe_m20)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-38899_moe_m20)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-38899_moe_m20)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
