### PR TITLE
[QSR]: Generalize Watcher Header

### DIFF
--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -4,7 +4,10 @@
 
 #pragma once
 
+#include <algorithm>
 #include <set>
+#include <fmt/core.h>
+#include <fmt/ranges.h>
 
 #include <fmt/format.h>
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
@@ -15,6 +18,7 @@
 #include "llrt.hpp"
 #include <impl/dispatch/dispatch_core_manager.hpp>
 #include <llrt/tt_cluster.hpp>
+#include "llrt/hal.hpp"
 
 namespace tt::tt_metal {
 
@@ -117,4 +121,89 @@ inline std::string get_debug_assert_message(dev_msgs::debug_assert_type_t type, 
     }
 }
 
+// Metadata for identifying and logging processor info in the watcher (Tensix and Ethernet)
+struct EnableSymbolsInfo {
+    std::string main_processor;
+    std::vector<std::string> processor_names;  // All RISC processors
+    std::vector<std::string> symbols;  // Labels per log line. Quasar: (DM:, NEO:) or (E:), BH/WH: (B, N, T) or (E)
+    std::string enable_legend;         // Legend in the watcher log header for enable/disable flags
+};
+
+// This function gets enable/disable flags for watcher header/legend in the log file
+inline EnableSymbolsInfo get_enable_symbols_info(HalProgrammableCoreType core_type) {
+    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+    const bool is_quasar = hal.get_arch() == tt::ARCH::QUASAR;
+    EnableSymbolsInfo info;
+    info.main_processor = hal.get_processor_class_name(HalProgrammableCoreType::TENSIX, 0, false);
+
+    std::vector<std::string> legend_parts;
+
+    // Create the enable flags for BH/WH (e.g. B/b=BRISC)
+    auto add_legacy_entry = [&](const std::string& sym, const std::string& name) {
+        std::string lo = sym;
+        std::transform(lo.begin(), lo.end(), lo.begin(), [](unsigned char c) { return std::tolower(c); });
+        info.symbols.push_back(sym);
+        legend_parts.push_back(fmt::format("{}/{}={}", sym, lo, name));
+    };
+
+    if (core_type == HalProgrammableCoreType::TENSIX) {
+        for (uint32_t cls = 0; cls < hal.get_processor_classes_count(core_type); cls++) {
+            auto type = static_cast<HalProcessorClassType>(cls);
+            uint32_t base = hal.get_processor_index(core_type, type, 0);
+            uint32_t count = hal.get_processor_types_count(core_type, cls);
+
+            // Log all processor names
+            for (uint32_t i = 0; i < count; ++i) {
+                auto name = hal.get_processor_class_name(core_type, base + i, false);
+                info.processor_names.push_back(name);
+                // On WH/BH: For BRISC and NCRISC, create enable flags
+                if (!is_quasar && type != HalProcessorClassType::COMPUTE) {
+                    add_legacy_entry(std::string{name[0]}, name);
+                }
+            }
+
+            // On Quasar, enable flags are displayed using a bitmask in hex
+            if (is_quasar) {
+                // DM: one symbol per processor
+                if (type == HalProcessorClassType::DM) {
+                    info.symbols.push_back("DM:");
+                    legend_parts.push_back(fmt::format("DM:[hex]=DataMovement(0-{})", count - 1));
+                } else {
+                    uint32_t ct_idx = hal.get_programmable_core_type_index(core_type);
+                    // Neo0, Neo1, Neo2, Neo3
+                    uint32_t num_clusters = count / hal.get_processor_class_num_fw_binaries(ct_idx, cls);
+                    info.symbols.push_back("NEO:");
+                    legend_parts.push_back(fmt::format("NEO:[hex]=ComputeClusters(NeoCluster0-{})", num_clusters - 1));
+                }
+            }  // On WH/BH Compute: collapse all TRISCs to one symbol, strip trailing digit (TRISC0 -> TRISC)
+            else if (type == HalProcessorClassType::COMPUTE) {
+                auto name = hal.get_processor_class_name(core_type, base, false);
+                if (!name.empty() && std::isdigit(static_cast<unsigned char>(name.back()))) {
+                    name.pop_back();
+                }
+                add_legacy_entry(std::string{name[0]}, name);
+            }
+        }
+    } else {
+        // ACTIVE_ETH/IDLE_ETH: collect names (arch-independent), then symbols (arch-specific)
+        uint32_t num = hal.get_num_risc_processors(core_type);
+        for (uint32_t i = 0; i < num; ++i) {
+            info.processor_names.push_back(hal.get_processor_class_name(core_type, i, false));
+        }
+        if (is_quasar) {
+            info.symbols.push_back("E:");
+            legend_parts.push_back(fmt::format("E:[hex]=Ethernet(0-{})", num - 1));
+        } else {
+            for (uint32_t i = 0; i < num; ++i) {
+                std::string abbrev = hal.get_processor_class_name(core_type, i, true);
+                add_legacy_entry(std::string{abbrev[0]}, info.processor_names[i]);
+            }
+        }
+    }
+    info.enable_legend = fmt::format("{}", fmt::join(legend_parts, " "));
+    if (!is_quasar) {
+        info.enable_legend = "UPPER=enabled, lower=disabled: " + info.enable_legend;
+    }
+    return info;
+}
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -6,6 +6,8 @@
 
 #include <algorithm>
 #include <set>
+#include <vector>
+#include <cctype>
 #include <fmt/core.h>
 #include <fmt/ranges.h>
 

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -34,7 +34,6 @@
 #include "api/debug/ring_buffer.h"
 #include "impl/context/metal_context.hpp"
 #include "watcher_device_reader.hpp"
-#include "debug_helpers.hpp"
 #include <impl/debug/watcher_server.hpp>
 #include <llrt/tt_cluster.hpp>
 
@@ -64,6 +63,13 @@ const char* get_riscv_name(HalProgrammableCoreType core_type, uint32_t processor
     switch (core_type) {
         case HalProgrammableCoreType::TENSIX: {
             const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+            auto num_processors = hal.get_num_risc_processors(core_type);
+            TT_FATAL(
+                processor_index < num_processors,
+                "Watcher data corrupted, unexpected processor index {} on core {} (max {})",
+                processor_index,
+                core_type,
+                num_processors);
             return hal.get_processor_class_name(core_type, processor_index, false).c_str();
         }
         case HalProgrammableCoreType::ACTIVE_ETH: {
@@ -314,6 +320,13 @@ WatcherDeviceReader::WatcherDeviceReader(FILE* f, ChipId device_id, const std::v
                 sizeof(uint32_t));
             logical_core_to_eth_link_retraining_count[eth_core] = read_data[0];
         }
+    }
+
+    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+    uint32_t core_count = hal.get_programmable_core_type_count();
+    for (uint32_t i = 0; i < core_count; i++) {
+        auto core_type = hal.get_programmable_core_type(i);
+        symbols_info_cache_.emplace(core_type, get_enable_symbols_info(core_type));
     }
 }
 
@@ -941,40 +954,55 @@ void WatcherDeviceReader::Core::DumpLaunchMessage() const {
             enables);
     }
 
-    // TODO(#17275): Generalize and pull risc data out of HAL
-    std::string_view symbols;
-    if (programmable_core_type_ == HalProgrammableCoreType::TENSIX) {
-        symbols = "BNT";
-    } else {
-        if (tt::tt_metal::MetalContext::instance().get_cluster().arch() == ARCH::BLACKHOLE) {
-            symbols = "EE";
+    // Get enable flags symbols for watcher log
+    const auto& symbols = reader_.get_cached_enable_symbols(programmable_core_type_);
+    TT_ASSERT(!symbols.empty(), "No enable symbols found for core type {}", static_cast<int>(programmable_core_type_));
+
+    if (hal.get_arch() == tt::ARCH::QUASAR) {
+        // On Quasar, we use a new format to represent enable/disable: hex bitmask for all processor types
+        if (programmable_core_type_ == HalProgrammableCoreType::TENSIX) {
+            // Enables bits: [0, 1, .. dm_count): one per DM processor
+            uint32_t dm_count = hal.get_processor_types_count(
+                programmable_core_type_, static_cast<uint32_t>(HalProcessorClassType::DM));
+            uint32_t num_fw_binaries = hal.get_processor_class_num_fw_binaries(
+                hal.get_programmable_core_type_index(programmable_core_type_),
+                static_cast<uint32_t>(HalProcessorClassType::COMPUTE));
+            uint32_t num_triscs = hal.get_processor_types_count(
+                programmable_core_type_, static_cast<uint32_t>(HalProcessorClassType::COMPUTE));
+            uint32_t num_clusters = num_triscs / num_fw_binaries;  // Neo0, Neo1, Neo2, Neo3
+
+            fprintf(reader_.f, "%s%X ", symbols[0].c_str(), enables & ((1u << dm_count) - 1));
+            uint32_t cluster_val = 0;
+
+            // On Quasar, compute clusters are all enabled as one unit
+            // So just poll enable bit of first TRISC of each compute cluster
+            // Enables bits: [dm_count + c*num_fw_binaries]
+            for (uint32_t c = 0; c < num_clusters; c++) {
+                if (enables & (1u << (dm_count + c * num_fw_binaries))) {
+                    cluster_val |= (1u << c);
+                }
+            }
+            fprintf(reader_.f, "%s%X ", symbols[1].c_str(), cluster_val);
         } else {
-            symbols = "E";
+            // ETH on Quasar: single E: hex symbol, all processor bits
+            fprintf(reader_.f, "%s%X ", symbols[0].c_str(), enables);
         }
-    }
-    for (size_t i = 0; i < symbols.size(); i++) {
-        char c = symbols[i];
-        if ((enables & (1u << i)) == 0) {
-            c = tolower(c);
+    } else {
+        // WH/BH: case-toggle format
+        for (size_t i = 0; i < symbols.size(); i++) {
+            for (char c : symbols[i]) {
+                fputc((enables & (1u << i)) ? c : (char)tolower(static_cast<unsigned char>(c)), reader_.f);
+            }
         }
-        fputc(c, reader_.f);
     }
 
     fprintf(reader_.f, " h_id:%3d ", launch_msg_.kernel_config().host_assigned_id());
-
-    if (programmable_core_type_ == HalProgrammableCoreType::TENSIX) {
+    uint32_t num_subordinates = hal.get_num_risc_processors(programmable_core_type_) - 1;
+    if (num_subordinates > 0) {
         fprintf(reader_.f, "smsg:");
-        // TODO once we have triscs running on Quasar, just loop over all RISC cores
-        DumpRunState(subordinate_sync.map()[0]);
-        if (tt::tt_metal::MetalContext::instance().get_cluster().arch() != ARCH::QUASAR) {
-            DumpRunState(subordinate_sync.map()[1]);
-            DumpRunState(subordinate_sync.map()[2]);
-            DumpRunState(subordinate_sync.map()[3]);
+        for (uint32_t i = 0; i < num_subordinates; ++i) {
+            DumpRunState(subordinate_sync.map()[i]);
         }
-        fprintf(reader_.f, " ");
-    } else if (tt::tt_metal::MetalContext::instance().get_cluster().arch() == ARCH::BLACKHOLE) {
-        fprintf(reader_.f, "smsg:");
-        DumpRunState(subordinate_sync.map()[0]);
         fprintf(reader_.f, " ");
     }
 }

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -273,6 +273,7 @@ private:
     void LogRunningKernels() const;
     const std::string& GetKernelName(uint32_t processor_index) const;
     void ValidateKernelIDs() const;
+    void SetEnableFlags(uint32_t enables) const;
 
     Core(
         CoreCoord virtual_coord,
@@ -904,6 +905,51 @@ void WatcherDeviceReader::Core::DumpRunState(uint32_t state) const {
     }
 }
 
+void WatcherDeviceReader::Core::SetEnableFlags(uint32_t enables) const {
+    const auto& hal = MetalContext::instance().hal();
+    // Get enable flags symbols for watcher log
+    const auto& symbols = reader_.get_cached_enable_symbols(programmable_core_type_);
+    TT_ASSERT(!symbols.empty(), "No enable symbols found for core type {}", static_cast<int>(programmable_core_type_));
+
+    if (hal.get_arch() == tt::ARCH::QUASAR) {
+        // On Quasar, we use a new format to represent enable/disable: hex bitmask for all processor types
+        if (programmable_core_type_ == HalProgrammableCoreType::TENSIX) {
+            // Enables bits: [0, 1, .. dm_count): one per DM processor
+            uint32_t dm_count = hal.get_processor_types_count(
+                programmable_core_type_, static_cast<uint32_t>(HalProcessorClassType::DM));
+            uint32_t num_fw_binaries = hal.get_processor_class_num_fw_binaries(
+                hal.get_programmable_core_type_index(programmable_core_type_),
+                static_cast<uint32_t>(HalProcessorClassType::COMPUTE));
+            uint32_t num_triscs = hal.get_processor_types_count(
+                programmable_core_type_, static_cast<uint32_t>(HalProcessorClassType::COMPUTE));
+            uint32_t num_clusters = num_triscs / num_fw_binaries;  // Neo0, Neo1, Neo2, Neo3
+
+            fprintf(reader_.f, "%s%X ", symbols[0].c_str(), enables & ((1u << dm_count) - 1));
+            uint32_t cluster_val = 0;
+
+            // On Quasar, compute clusters are all enabled as one unit
+            // So just poll enable bit of first TRISC of each compute cluster
+            // Enables bits: [dm_count + c*num_fw_binaries]
+            for (uint32_t c = 0; c < num_clusters; c++) {
+                if (enables & (1u << (dm_count + c * num_fw_binaries))) {
+                    cluster_val |= (1u << c);
+                }
+            }
+            fprintf(reader_.f, "%s%X ", symbols[1].c_str(), cluster_val);
+        } else {
+            // ETH on Quasar: single E: hex symbol, all processor bits
+            fprintf(reader_.f, "%s%X ", symbols[0].c_str(), enables);
+        }
+    } else {
+        // WH/BH: case-toggle format
+        for (size_t i = 0; i < symbols.size(); i++) {
+            for (char c : symbols[i]) {
+                fputc((enables & (1u << i)) ? c : (char)tolower(static_cast<unsigned char>(c)), reader_.f);
+            }
+        }
+    }
+}
+
 void WatcherDeviceReader::Core::DumpLaunchMessage() const {
     auto subordinate_sync = mbox_data_.subordinate_sync();
     const auto& hal = MetalContext::instance().hal();
@@ -954,47 +1000,8 @@ void WatcherDeviceReader::Core::DumpLaunchMessage() const {
             enables);
     }
 
-    // Get enable flags symbols for watcher log
-    const auto& symbols = reader_.get_cached_enable_symbols(programmable_core_type_);
-    TT_ASSERT(!symbols.empty(), "No enable symbols found for core type {}", static_cast<int>(programmable_core_type_));
-
-    if (hal.get_arch() == tt::ARCH::QUASAR) {
-        // On Quasar, we use a new format to represent enable/disable: hex bitmask for all processor types
-        if (programmable_core_type_ == HalProgrammableCoreType::TENSIX) {
-            // Enables bits: [0, 1, .. dm_count): one per DM processor
-            uint32_t dm_count = hal.get_processor_types_count(
-                programmable_core_type_, static_cast<uint32_t>(HalProcessorClassType::DM));
-            uint32_t num_fw_binaries = hal.get_processor_class_num_fw_binaries(
-                hal.get_programmable_core_type_index(programmable_core_type_),
-                static_cast<uint32_t>(HalProcessorClassType::COMPUTE));
-            uint32_t num_triscs = hal.get_processor_types_count(
-                programmable_core_type_, static_cast<uint32_t>(HalProcessorClassType::COMPUTE));
-            uint32_t num_clusters = num_triscs / num_fw_binaries;  // Neo0, Neo1, Neo2, Neo3
-
-            fprintf(reader_.f, "%s%X ", symbols[0].c_str(), enables & ((1u << dm_count) - 1));
-            uint32_t cluster_val = 0;
-
-            // On Quasar, compute clusters are all enabled as one unit
-            // So just poll enable bit of first TRISC of each compute cluster
-            // Enables bits: [dm_count + c*num_fw_binaries]
-            for (uint32_t c = 0; c < num_clusters; c++) {
-                if (enables & (1u << (dm_count + c * num_fw_binaries))) {
-                    cluster_val |= (1u << c);
-                }
-            }
-            fprintf(reader_.f, "%s%X ", symbols[1].c_str(), cluster_val);
-        } else {
-            // ETH on Quasar: single E: hex symbol, all processor bits
-            fprintf(reader_.f, "%s%X ", symbols[0].c_str(), enables);
-        }
-    } else {
-        // WH/BH: case-toggle format
-        for (size_t i = 0; i < symbols.size(); i++) {
-            for (char c : symbols[i]) {
-                fputc((enables & (1u << i)) ? c : (char)tolower(static_cast<unsigned char>(c)), reader_.f);
-            }
-        }
-    }
+    // Set the processor enable flags per log line entry
+    SetEnableFlags(enables);
 
     fprintf(reader_.f, " h_id:%3d ", launch_msg_.kernel_config().host_assigned_id());
     uint32_t num_subordinates = hal.get_num_risc_processors(programmable_core_type_) - 1;
@@ -1002,17 +1009,17 @@ void WatcherDeviceReader::Core::DumpLaunchMessage() const {
         hal.get_processor_types_count(programmable_core_type_, static_cast<uint32_t>(HalProcessorClassType::DM)) - 1;
     if (num_subordinates > 0) {
         fprintf(reader_.f, "smsg:");
-        for (uint32_t i = 0; i < num_subordinates; ++i) {
-            uint32_t map_idx = i;
-            if (hal.get_arch() == tt::ARCH::QUASAR && programmable_core_type_ == HalProgrammableCoreType::TENSIX) {
-                // On Quasar TENSIX, subordinate_sync.map() layout is:
-                // dm1 .. dm7, padding, neo0_trisc0, neo0_trisc1 .. neo3_trisc3
-                // so we must skip the padding byte between DM and NEO entries.
-                if (i >= dm_subordinates) {
-                    map_idx = i + 1;
-                }
+        // On Quasar TENSIX, subordinate_sync.map() layout is:
+        // dm1 .. dm7, padding, neo0_trisc0, neo0_trisc1 .. neo3_trisc3
+        // so we must skip the padding byte between DM and NEO entries.
+        const bool skip_padding =
+            (hal.get_arch() == tt::ARCH::QUASAR) && (programmable_core_type_ == HalProgrammableCoreType::TENSIX);
+        for (uint32_t i = 0, dumped = 0; dumped < num_subordinates; ++i) {
+            if (skip_padding && (i == dm_subordinates)) {
+                continue;
             }
-            DumpRunState(subordinate_sync.map()[map_idx]);
+            DumpRunState(subordinate_sync.map()[i]);
+            dumped++;
         }
         fprintf(reader_.f, " ");
     }

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -69,7 +69,7 @@ const char* get_riscv_name(HalProgrammableCoreType core_type, uint32_t processor
                 "Watcher data corrupted, unexpected processor index {} on core {} (max {})",
                 processor_index,
                 core_type,
-                num_processors);
+                num_processors - 1);
             return hal.get_processor_class_name(core_type, processor_index, false).c_str();
         }
         case HalProgrammableCoreType::ACTIVE_ETH: {
@@ -998,10 +998,21 @@ void WatcherDeviceReader::Core::DumpLaunchMessage() const {
 
     fprintf(reader_.f, " h_id:%3d ", launch_msg_.kernel_config().host_assigned_id());
     uint32_t num_subordinates = hal.get_num_risc_processors(programmable_core_type_) - 1;
+    uint32_t dm_subordinates =
+        hal.get_processor_types_count(programmable_core_type_, static_cast<uint32_t>(HalProcessorClassType::DM)) - 1;
     if (num_subordinates > 0) {
         fprintf(reader_.f, "smsg:");
         for (uint32_t i = 0; i < num_subordinates; ++i) {
-            DumpRunState(subordinate_sync.map()[i]);
+            uint32_t map_idx = i;
+            if (hal.get_arch() == tt::ARCH::QUASAR && programmable_core_type_ == HalProgrammableCoreType::TENSIX) {
+                // On Quasar TENSIX, subordinate_sync.map() layout is:
+                // dm1 .. dm7, padding, neo0_trisc0, neo0_trisc1 .. neo3_trisc3
+                // so we must skip the padding byte between DM and NEO entries.
+                if (i >= dm_subordinates) {
+                    map_idx = i + 1;
+                }
+            }
+            DumpRunState(subordinate_sync.map()[map_idx]);
         }
         fprintf(reader_.f, " ");
     }

--- a/tt_metal/impl/debug/watcher_device_reader.hpp
+++ b/tt_metal/impl/debug/watcher_device_reader.hpp
@@ -13,6 +13,7 @@
 
 #include <umd/device/soc_descriptor.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>
+#include "debug_helpers.hpp"
 
 namespace tt::tt_metal {
 
@@ -26,6 +27,13 @@ public:
     WatcherDeviceReader(FILE* f, ChipId device_id, const std::vector<std::string>& kernel_names);
     ~WatcherDeviceReader();
     void Dump(FILE* file = nullptr);
+    const std::vector<std::string>& get_cached_enable_symbols(HalProgrammableCoreType core_type) const {
+        TT_FATAL(
+            core_type < HalProgrammableCoreType::COUNT,
+            "Invalid HalProgrammableCoreType {}",
+            static_cast<int>(core_type));
+        return symbols_info_cache_.at(core_type).symbols;
+    }
 
 private:
     class Core;
@@ -34,6 +42,7 @@ private:
     ChipId device_id;
     const std::vector<std::string>& kernel_names;
     std::map<CoreCoord, uint32_t> logical_core_to_eth_link_retraining_count;
+    std::map<HalProgrammableCoreType, EnableSymbolsInfo> symbols_info_cache_;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -19,6 +19,7 @@
 #include <stdexcept>
 #include <thread>
 #include <vector>
+#include <fmt/core.h>
 
 #include <tt_stl/assert.hpp>
 #include <tt_stl/reflection.hpp>
@@ -119,7 +120,8 @@ void WatcherServer::Impl::attach_devices() {
         for (ChipId device_id : all_devices) {
             device_id_to_reader_.try_emplace(device_id, logfile_, device_id, kernel_names_);
             log_info(LogLLRuntime, "Watcher attached device {}", device_id);
-            fprintf(logfile_, "At %.3lfs attach device %d\n", get_elapsed_secs(), device_id);
+            fprintf(logfile_, "At %.3lfs attach device %d\n\n", get_elapsed_secs(), device_id);
+            fflush(logfile_);  // Ensure attach message is committed before watcher server thread writes
         }
 
         // Since dma library is not thread-safe, disable it when watcher runs.
@@ -275,7 +277,15 @@ void WatcherServer::Impl::create_log_file() {
 
     fprintf(f, "At %.3lfs starting\n", get_elapsed_secs());
     fprintf(f, "Legend:\n");
-    fprintf(f, "\tComma separated list specifices waypoint for BRISC,NCRISC,TRISC0,TRISC1,TRISC2\n");
+
+    // Get processor info from shared helper
+    auto tensix_info = get_enable_symbols_info(HalProgrammableCoreType::TENSIX);
+
+    fprintf(
+        f,
+        "\tComma separated list specifies waypoint for %s\n",
+        fmt::format("{}", fmt::join(tensix_info.processor_names, ", ")).c_str());
+    fprintf(f, "\t%s is main processor, others are subordinates\n", tensix_info.main_processor.c_str());
     fprintf(f, "\tI=initialization sequence\n");
     fprintf(f, "\tW=wait (top of spin loop)\n");
     fprintf(f, "\tR=run (entering kernel)\n");
@@ -287,10 +297,12 @@ void WatcherServer::Impl::create_log_file() {
     fprintf(f, "\t\tNWD is \"noc write done\"\n");
     fprintf(
         f,
-        "\trmsg(brisc host run message): D/H device/host dispatch; brisc NOC ID; I/G/D init/go/done; | separator; "
-        "B/b enable/disable brisc; N/n enable/disable ncrisc; T/t enable/disable TRISC\n");
-    fprintf(f, "\tsmsg(subordinate run message): I/G/D for NCRISC, TRISC0, TRISC1, TRISC2\n");
-    fprintf(f, "\tk_ids:<brisc id>|<ncrisc id>|<trisc id> (ID map to file at end of section)\n");
+        "\trmsg(%s host run message): D/H device/host dispatch; NOC ID; I/G/D init/go/done; | separator; "
+        "enable flags %s\n",
+        tensix_info.main_processor.c_str(),
+        tensix_info.enable_legend.c_str());
+    fprintf(f, "\tsmsg(subordinate run message): I/G/D for subordinate processors\n");
+    fprintf(f, "\tk_ids: kernel IDs per processor (ID map to file at end of section)\n");
     fprintf(f, "\n");
     fflush(f);
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/38105

### Problem description
The watcher legend and log header currently contains hardcoded processor strings tied to BH/WH architecture (e.g. "BRISC,NCRISC,TRISC0,TRISC1,TRISC2", "BNT"). This needed to change for Quasar, which has a fundamentally different processor layout: 8 DM cores and 4 compute clusters (NEO0–NEO3). The single-character uppercase/lowercase enable flag format (e.g. B/b, N/n, T/t) also doesn't scale very well to Quasar's larger processor counts.

### What's changed
- Added `EnableSymbolsInfo` struct and `get_enable_symbols_info()` helper in `debug_helpers.hpp` that queries the HAL to derive processor names, enable symbols, and legend text per architecture and core type, replacing all hardcoded strings.
- The watcher legend header now dynamically lists the correct processor names for the waypoint field and `rmsg` enable flags description for any arch.
- For Quasar, enable flags use a compact hex bitmask format: DM:XX for DMs and NEO:X for compute clusters, E: for ERISCs since the single-character toggle format doesn't scale to 8+ processors. On BH/WH, the legacy format is preserved.
- `smsg` dumping is now driven by `hal.get_num_risc_processors()`.
- `WatcherDeviceReader` caches `EnableSymbolsInfo` per core type at construction time.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=snadkarni/generalize_watcher_log)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:snadkarni/generalize_watcher_log)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snadkarni/generalize_watcher_log)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snadkarni/generalize_watcher_log)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadkarni/generalize_watcher_log)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadkarni/generalize_watcher_log)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early

Quasar emulator test runs: https://gist.github.com/sidnadTT/9c54ddfcfccdaf263db5603e819edb8d

#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snadkarni/generalize_watcher_log)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snadkarni/generalize_watcher_log)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snadkarni/generalize_watcher_log)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snadkarni/generalize_watcher_log)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snadkarni/generalize_watcher_log)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snadkarni/generalize_watcher_log)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
