### PR TITLE
Add lightweight fmt.hpp header to reduce reflection.hpp dependency fanout

### DIFF
--- a/tt_metal/api/tt-metalium/experimental/tensor/spec/layout/alignment.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/spec/layout/alignment.hpp
@@ -4,6 +4,10 @@
 
 #pragma once
 
+#include <string>
+
+#include <fmt/core.h>
+
 #include <tt_stl/small_vector.hpp>
 #include <tt-metalium/shape_base.hpp>
 
@@ -38,3 +42,16 @@ public:
 std::ostream& operator<<(std::ostream& os, const tt::tt_metal::Alignment& alignment);
 
 }  // namespace tt::tt_metal
+
+// Out-of-line string conversion (defined in alignment.cpp).
+namespace ttsl::fmt_detail {
+std::string to_string(const tt::tt_metal::Alignment& alignment);
+}  // namespace ttsl::fmt_detail
+
+// Lightweight fmt::formatter – delegates to out-of-line to_string().
+template <>
+struct fmt::formatter<tt::tt_metal::Alignment> : fmt::formatter<std::string_view> {
+    auto format(const tt::tt_metal::Alignment& val, fmt::format_context& ctx) const {
+        return fmt::formatter<std::string_view>::format(ttsl::fmt_detail::to_string(val), ctx);
+    }
+};

--- a/tt_metal/api/tt-metalium/mesh_coord.hpp
+++ b/tt_metal/api/tt-metalium/mesh_coord.hpp
@@ -561,6 +561,7 @@ typename MeshContainer<T>::ConstIterator MeshContainer<T>::end() const {
 namespace ttsl::fmt_detail {
 std::string to_string(const tt::tt_metal::distributed::MeshShape& shape);
 std::string to_string(const tt::tt_metal::distributed::MeshCoordinate& coord);
+std::string to_string(const tt::tt_metal::distributed::MeshCoordinateRange& range);
 }  // namespace ttsl::fmt_detail
 
 // Lightweight fmt::formatters – delegate to out-of-line to_string().
@@ -574,6 +575,13 @@ struct fmt::formatter<tt::tt_metal::distributed::MeshShape> : fmt::formatter<std
 template <>
 struct fmt::formatter<tt::tt_metal::distributed::MeshCoordinate> : fmt::formatter<std::string_view> {
     auto format(const tt::tt_metal::distributed::MeshCoordinate& val, fmt::format_context& ctx) const {
+        return fmt::formatter<std::string_view>::format(ttsl::fmt_detail::to_string(val), ctx);
+    }
+};
+
+template <>
+struct fmt::formatter<tt::tt_metal::distributed::MeshCoordinateRange> : fmt::formatter<std::string_view> {
+    auto format(const tt::tt_metal::distributed::MeshCoordinateRange& val, fmt::format_context& ctx) const {
         return fmt::formatter<std::string_view>::format(ttsl::fmt_detail::to_string(val), ctx);
     }
 };

--- a/tt_metal/api/tt-metalium/mesh_coord.hpp
+++ b/tt_metal/api/tt-metalium/mesh_coord.hpp
@@ -6,8 +6,11 @@
 
 #include <cstddef>
 #include <optional>
+#include <string>
 #include <type_traits>
 #include <vector>
+
+#include <fmt/core.h>
 
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/shape_base.hpp>
@@ -553,6 +556,27 @@ typename MeshContainer<T>::ConstIterator MeshContainer<T>::end() const {
 }
 
 }  // namespace tt::tt_metal::distributed
+
+// Out-of-line string conversions (defined in mesh_coord.cpp).
+namespace ttsl::fmt_detail {
+std::string to_string(const tt::tt_metal::distributed::MeshShape& shape);
+std::string to_string(const tt::tt_metal::distributed::MeshCoordinate& coord);
+}  // namespace ttsl::fmt_detail
+
+// Lightweight fmt::formatters – delegate to out-of-line to_string().
+template <>
+struct fmt::formatter<tt::tt_metal::distributed::MeshShape> : fmt::formatter<std::string_view> {
+    auto format(const tt::tt_metal::distributed::MeshShape& val, fmt::format_context& ctx) const {
+        return fmt::formatter<std::string_view>::format(ttsl::fmt_detail::to_string(val), ctx);
+    }
+};
+
+template <>
+struct fmt::formatter<tt::tt_metal::distributed::MeshCoordinate> : fmt::formatter<std::string_view> {
+    auto format(const tt::tt_metal::distributed::MeshCoordinate& val, fmt::format_context& ctx) const {
+        return fmt::formatter<std::string_view>::format(ttsl::fmt_detail::to_string(val), ctx);
+    }
+};
 
 namespace std {
 

--- a/tt_metal/api/tt-metalium/shape.hpp
+++ b/tt_metal/api/tt-metalium/shape.hpp
@@ -8,7 +8,10 @@
 #include <cstddef>
 #include <cstdint>
 #include <ostream>
+#include <string>
 #include <tuple>
+
+#include <fmt/core.h>
 
 #include <tt-metalium/shape_base.hpp>
 #include <tt_stl/small_vector.hpp>
@@ -74,6 +77,20 @@ tt::stl::SmallVector<size_t> compute_strides(const tt::tt_metal::Shape& shape);
 std::size_t compute_flat_indices(tt::stl::Span<const uint32_t> indices, tt::stl::Span<const size_t> strides);
 
 }  // namespace tt::tt_metal
+
+// Out-of-line string conversion (defined in shape.cpp).
+// Placed outside tt::tt_metal to avoid hiding std::to_string via ADL.
+namespace ttsl::fmt_detail {
+std::string to_string(const tt::tt_metal::Shape& shape);
+}  // namespace ttsl::fmt_detail
+
+// Lightweight fmt::formatter – delegates to out-of-line to_string().
+template <>
+struct fmt::formatter<tt::tt_metal::Shape> : fmt::formatter<std::string_view> {
+    auto format(const tt::tt_metal::Shape& val, fmt::format_context& ctx) const {
+        return fmt::formatter<std::string_view>::format(ttsl::fmt_detail::to_string(val), ctx);
+    }
+};
 
 // Forward declarations of json trait templates (avoids pulling in reflection.hpp)
 namespace ttsl::json {

--- a/tt_metal/api/tt-metalium/shape2d.hpp
+++ b/tt_metal/api/tt-metalium/shape2d.hpp
@@ -8,8 +8,11 @@
 #include <cstddef>
 #include <cstdint>
 #include <utility>
+#include <string>
 #include <tuple>
 #include <ostream>
+
+#include <fmt/core.h>
 
 namespace tt::tt_metal {
 
@@ -55,6 +58,19 @@ private:
 std::ostream& operator<<(std::ostream& os, const tt::tt_metal::Shape2D& size);
 
 }  // namespace tt::tt_metal
+
+// Out-of-line string conversion (defined in shape2d.cpp).
+namespace ttsl::fmt_detail {
+std::string to_string(const tt::tt_metal::Shape2D& size);
+}  // namespace ttsl::fmt_detail
+
+// Lightweight fmt::formatter – delegates to out-of-line to_string().
+template <>
+struct fmt::formatter<tt::tt_metal::Shape2D> : fmt::formatter<std::string_view> {
+    auto format(const tt::tt_metal::Shape2D& val, fmt::format_context& ctx) const {
+        return fmt::formatter<std::string_view>::format(ttsl::fmt_detail::to_string(val), ctx);
+    }
+};
 
 namespace std {
 template <>

--- a/tt_metal/common/mesh_coord.cpp
+++ b/tt_metal/common/mesh_coord.cpp
@@ -6,6 +6,7 @@
 #include <tt_stl/reflection.hpp>
 
 #include <boost/move/utility_core.hpp>
+#include <fmt/format.h>
 #include <mesh_coord.hpp>
 #include <tt_stl/span.hpp>
 #include <algorithm>
@@ -684,6 +685,13 @@ std::string ttsl::fmt_detail::to_string(const tt::tt_metal::distributed::MeshCoo
     }
     result += "])";
     return result;
+}
+
+std::string ttsl::fmt_detail::to_string(const tt::tt_metal::distributed::MeshCoordinateRange& range) {
+    return fmt::format(
+        "MeshCoordinateRange(start={}, end={})",
+        ttsl::fmt_detail::to_string(range.start_coord()),
+        ttsl::fmt_detail::to_string(range.end_coord()));
 }
 
 size_t std::hash<tt::tt_metal::distributed::MeshCoordinate>::operator()(

--- a/tt_metal/common/mesh_coord.cpp
+++ b/tt_metal/common/mesh_coord.cpp
@@ -662,6 +662,30 @@ std::ostream& operator<<(std::ostream& os, const MeshCoordinateRangeSet& range_s
 
 }  // namespace tt::tt_metal::distributed
 
+std::string ttsl::fmt_detail::to_string(const tt::tt_metal::distributed::MeshShape& shape) {
+    std::string result = "MeshShape([";
+    for (size_t i = 0; i < shape.dims(); ++i) {
+        if (i > 0) {
+            result += ", ";
+        }
+        result += std::to_string(shape[i]);
+    }
+    result += "])";
+    return result;
+}
+
+std::string ttsl::fmt_detail::to_string(const tt::tt_metal::distributed::MeshCoordinate& coord) {
+    std::string result = "MeshCoordinate([";
+    for (size_t i = 0; i < coord.dims(); ++i) {
+        if (i > 0) {
+            result += ", ";
+        }
+        result += std::to_string(coord[i]);
+    }
+    result += "])";
+    return result;
+}
+
 size_t std::hash<tt::tt_metal::distributed::MeshCoordinate>::operator()(
     const tt::tt_metal::distributed::MeshCoordinate& coord) const noexcept {
     return tt::stl::hash::hash_objects_with_default_seed(coord.attribute_values());

--- a/tt_metal/common/shape.cpp
+++ b/tt_metal/common/shape.cpp
@@ -94,6 +94,18 @@ std::size_t compute_flat_indices(tt::stl::Span<const uint32_t> indices, tt::stl:
 
 }  // namespace tt::tt_metal
 
+std::string ttsl::fmt_detail::to_string(const tt::tt_metal::Shape& shape) {
+    std::string result = "Shape([";
+    for (size_t i = 0; i < shape.rank(); ++i) {
+        if (i > 0) {
+            result += ", ";
+        }
+        result += std::to_string(shape[i]);
+    }
+    result += "])";
+    return result;
+}
+
 nlohmann::json ttsl::json::to_json_t<tt::tt_metal::Shape>::operator()(const tt::tt_metal::Shape& shape) const {
     return ttsl::json::to_json(shape.view());
 }

--- a/tt_metal/common/shape2d.cpp
+++ b/tt_metal/common/shape2d.cpp
@@ -42,3 +42,7 @@ std::ostream& operator<<(std::ostream& os, const tt::tt_metal::Shape2D& size) {
 }
 
 }  // namespace tt::tt_metal
+
+std::string ttsl::fmt_detail::to_string(const tt::tt_metal::Shape2D& size) {
+    return "(" + std::to_string(size.height()) + ", " + std::to_string(size.width()) + ")";
+}

--- a/tt_metal/distributed/dispatch_context.cpp
+++ b/tt_metal/distributed/dispatch_context.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include <tt-metalium/experimental/dispatch_context.hpp>
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/distributed_context.hpp>

--- a/tt_metal/distributed/distributed.cpp
+++ b/tt_metal/distributed/distributed.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include <tt-metalium/distributed.hpp>
 #include <utility>
 

--- a/tt_metal/distributed/distributed_coordinate_translator.cpp
+++ b/tt_metal/distributed/distributed_coordinate_translator.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include "tt_metal/distributed/distributed_coordinate_translator.hpp"
 
 #include <tt_stl/assert.hpp>

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include "fd_mesh_command_queue.hpp"
 
 #include <tracy/Tracy.hpp>

--- a/tt_metal/distributed/mesh_command_queue_base.cpp
+++ b/tt_metal/distributed/mesh_command_queue_base.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include "mesh_command_queue_base.hpp"
 
 #include <mesh_device.hpp>

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include <initializer_list>
 #include <tt-logger/tt-logger.hpp>
 #include <mesh_command_queue.hpp>

--- a/tt_metal/distributed/mesh_device_view.cpp
+++ b/tt_metal/distributed/mesh_device_view.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include <mesh_device.hpp>
 #include <mesh_device_view.hpp>
 #include "mesh_device_view_impl.hpp"

--- a/tt_metal/distributed/mesh_socket_utils.cpp
+++ b/tt_metal/distributed/mesh_socket_utils.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include "tt_metal/distributed/mesh_socket_utils.hpp"
 #include "tt_metal/distributed/mesh_socket_serialization.hpp"
 #include <tt-metalium/experimental/fabric/control_plane.hpp>

--- a/tt_metal/distributed/mesh_workload.cpp
+++ b/tt_metal/distributed/mesh_workload.cpp
@@ -2,8 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/fmt.hpp>
 #include <mesh_buffer.hpp>
+#include <tt_stl/fmt.hpp>
 #include <mesh_command_queue.hpp>
 #include <mesh_workload.hpp>
 #include <cstdint>

--- a/tt_metal/distributed/mesh_workload.cpp
+++ b/tt_metal/distributed/mesh_workload.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include <mesh_buffer.hpp>
 #include <mesh_command_queue.hpp>
 #include <mesh_workload.hpp>

--- a/tt_metal/distributed/mesh_workload_utils.cpp
+++ b/tt_metal/distributed/mesh_workload_utils.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include "device.hpp"
 #include "impl/context/metal_context.hpp"
 #include "dispatch/kernels/cq_commands.hpp"

--- a/tt_metal/distributed/sd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include "sd_mesh_command_queue.hpp"
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/common/thread_pool.hpp"

--- a/tt_metal/distributed/system_mesh.cpp
+++ b/tt_metal/distributed/system_mesh.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include <cstdint>
 #include <system_mesh.hpp>
 #include <tt-metalium/mesh_device_view.hpp>

--- a/tt_metal/distributed/system_mesh_translation_map.cpp
+++ b/tt_metal/distributed/system_mesh_translation_map.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include "tt_metal/distributed/system_mesh_translation_map.hpp"
 
 #include <unordered_set>

--- a/tt_metal/distributed/system_mesh_translation_map.cpp
+++ b/tt_metal/distributed/system_mesh_translation_map.cpp
@@ -4,6 +4,7 @@
 
 #include <tt_stl/fmt.hpp>
 #include "tt_metal/distributed/system_mesh_translation_map.hpp"
+#include <fmt/format.h>
 
 #include <unordered_set>
 #include <vector>
@@ -58,3 +59,7 @@ MeshContainer<PhysicalMeshCoordinate> get_system_mesh_coordinate_translation_map
 }
 
 }  // namespace tt::tt_metal::distributed
+
+std::string ttsl::fmt_detail::to_string(const tt::tt_metal::distributed::PhysicalMeshCoordinate& coord) {
+    return fmt::format("PhysicalMeshCoordinate(mesh_id={}, chip_id={})", *coord.mesh_id(), coord.chip_id());
+}

--- a/tt_metal/distributed/system_mesh_translation_map.hpp
+++ b/tt_metal/distributed/system_mesh_translation_map.hpp
@@ -8,7 +8,7 @@
 #include <tt-metalium/experimental/fabric/fabric_types.hpp>
 #include <stdint.h>
 #include <tuple>
-#include <fmt/format.h>
+#include <fmt/core.h>
 #include <string>
 
 namespace tt::tt_fabric {

--- a/tt_metal/distributed/system_mesh_translation_map.hpp
+++ b/tt_metal/distributed/system_mesh_translation_map.hpp
@@ -8,6 +8,8 @@
 #include <tt-metalium/experimental/fabric/fabric_types.hpp>
 #include <stdint.h>
 #include <tuple>
+#include <fmt/format.h>
+#include <string>
 
 namespace tt::tt_fabric {
 class ControlPlane;
@@ -45,3 +47,15 @@ MeshContainer<PhysicalMeshCoordinate> get_system_mesh_coordinate_translation_map
     const tt::tt_fabric::ControlPlane& control_plane);
 
 }  // namespace tt::tt_metal::distributed
+
+// fmt::formatter for PhysicalMeshCoordinate
+namespace ttsl::fmt_detail {
+std::string to_string(const tt::tt_metal::distributed::PhysicalMeshCoordinate& coord);
+}  // namespace ttsl::fmt_detail
+
+template <>
+struct fmt::formatter<tt::tt_metal::distributed::PhysicalMeshCoordinate> : fmt::formatter<std::string_view> {
+    auto format(const tt::tt_metal::distributed::PhysicalMeshCoordinate& val, fmt::format_context& ctx) const {
+        return fmt::formatter<std::string_view>::format(ttsl::fmt_detail::to_string(val), ctx);
+    }
+};

--- a/tt_metal/fabric/builder/fabric_builder_config.cpp
+++ b/tt_metal/fabric/builder/fabric_builder_config.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include "fabric_builder_config.hpp"
 #include "fabric_tensix_builder_impl.hpp"
 #include "tt_metal/fabric/fabric_context.hpp"

--- a/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
+++ b/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
@@ -11,7 +11,7 @@
 #include <enchantum/enchantum.hpp>
 #include <tt_stl/indestructible.hpp>
 #include <tt_stl/assert.hpp>
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include <algorithm>
 #include <numeric>
 

--- a/tt_metal/fabric/channel_trimming_report.cpp
+++ b/tt_metal/fabric/channel_trimming_report.cpp
@@ -11,7 +11,7 @@
 
 #include <tt-logger/tt-logger.hpp>
 #include <tt_stl/assert.hpp>
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include <yaml-cpp/yaml.h>
 
 #include "tt_metal/fabric/builder/fabric_builder_config.hpp"

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -6,7 +6,7 @@
 
 #include <cstdint>
 #include <tt_stl/assert.hpp>
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
 #include <tt-metalium/device.hpp>
 #include "erisc_datamover_builder.hpp"

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include <cstdint>
 #include <tt-metalium/core_coord.hpp>
 #include "erisc_datamover_builder.hpp"

--- a/tt_metal/fabric/fabric_builder_context.cpp
+++ b/tt_metal/fabric/fabric_builder_context.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include "tt_metal/fabric/fabric_builder_context.hpp"
 #include "tt_metal/fabric/fabric_context.hpp"
 #include "tt_metal/fabric/fabric_router_channel_mapping.hpp"

--- a/tt_metal/fabric/fabric_context.cpp
+++ b/tt_metal/fabric/fabric_context.cpp
@@ -11,7 +11,7 @@
 #include <tt-metalium/experimental/fabric/fabric_types.hpp>
 #include <tt_stl/assert.hpp>
 #include <enchantum/enchantum.hpp>
-#include <tt_stl/fmt.hpp>
+#include <tt_stl/reflection.hpp>
 #include "erisc_datamover_builder.hpp"
 #include <umd/device/types/cluster_descriptor_types.hpp>  // ChipId
 #include "tt_metal/fabric/fabric_context.hpp"

--- a/tt_metal/fabric/fabric_context.cpp
+++ b/tt_metal/fabric/fabric_context.cpp
@@ -11,7 +11,7 @@
 #include <tt-metalium/experimental/fabric/fabric_types.hpp>
 #include <tt_stl/assert.hpp>
 #include <enchantum/enchantum.hpp>
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include "erisc_datamover_builder.hpp"
 #include <umd/device/types/cluster_descriptor_types.hpp>  // ChipId
 #include "tt_metal/fabric/fabric_context.hpp"

--- a/tt_metal/fabric/fabric_types.cpp
+++ b/tt_metal/fabric/fabric_types.cpp
@@ -64,7 +64,7 @@ std::ostream& operator<<(std::ostream& os, const FabricNodeId& fabric_node_id) {
 
 namespace std {
 size_t hash<tt::tt_fabric::FabricNodeId>::operator()(const tt::tt_fabric::FabricNodeId& fabric_node_id) const noexcept {
-    return tt::stl::hash::hash_objects_with_default_seed(fabric_node_id.mesh_id, fabric_node_id.chip_id);
+    return ttsl::hash::hash_objects_with_default_seed(fabric_node_id.mesh_id, fabric_node_id.chip_id);
 }
 }  // namespace std
 

--- a/tt_metal/fabric/mesh_graph_descriptor.cpp
+++ b/tt_metal/fabric/mesh_graph_descriptor.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include <stdexcept>
 #include <fstream>
 #include <sstream>

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include <cstdint>
 #include <filesystem>
 #include <algorithm>

--- a/tt_metal/impl/data_format/tile.cpp
+++ b/tt_metal/impl/data_format/tile.cpp
@@ -12,7 +12,7 @@
 #include "impl/context/metal_context.hpp"
 #include "math.hpp"
 #include "tt_backend_api_types.hpp"
-#include <tt_stl/fmt.hpp>
+#include <tt_stl/reflection.hpp>
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/data_format/tile.cpp
+++ b/tt_metal/impl/data_format/tile.cpp
@@ -12,7 +12,7 @@
 #include "impl/context/metal_context.hpp"
 #include "math.hpp"
 #include "tt_backend_api_types.hpp"
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include <tt-metalium/experimental/dataflow_buffer/dataflow_buffer.hpp>
 
 #include <algorithm>

--- a/tt_metal/impl/debug/dprint_parser.cpp
+++ b/tt_metal/impl/debug/dprint_parser.cpp
@@ -169,7 +169,7 @@ void DPrintParser::PrintTileSlice(const uint8_t* ptr) {
         // know that the slice has been truncated.
         if (count_exceeded) {
             intermediate_stream_ << "<TileSlice data truncated due to exceeding max count ("
-                                 << to_string(static_cast<unsigned>(ts->data_count)) << ")>\n";
+                                 << to_string(ts->data_count) << ")>\n";
             break;
         }
 

--- a/tt_metal/impl/debug/dprint_parser.cpp
+++ b/tt_metal/impl/debug/dprint_parser.cpp
@@ -169,7 +169,7 @@ void DPrintParser::PrintTileSlice(const uint8_t* ptr) {
         // know that the slice has been truncated.
         if (count_exceeded) {
             intermediate_stream_ << "<TileSlice data truncated due to exceeding max count ("
-                                 << to_string(ts->data_count) << ")>\n";
+                                 << to_string(static_cast<unsigned>(ts->data_count)) << ")>\n";
             break;
         }
 

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -28,7 +28,6 @@
 #include <tt-logger/tt-logger.hpp>
 #include "impl/data_format/blockfloat_common.hpp"
 #include <tt_stl/assert.hpp>
-#include <tt_stl/fmt.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/soc_descriptor.hpp>
 #include <umd/device/types/xy_pair.hpp>

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -28,6 +28,7 @@
 #include <tt-logger/tt-logger.hpp>
 #include "impl/data_format/blockfloat_common.hpp"
 #include <tt_stl/assert.hpp>
+#include <tt_stl/fmt.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/soc_descriptor.hpp>
 #include <umd/device/types/xy_pair.hpp>

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -28,7 +28,7 @@
 #include <tt-logger/tt-logger.hpp>
 #include "impl/data_format/blockfloat_common.hpp"
 #include <tt_stl/assert.hpp>
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/soc_descriptor.hpp>
 #include <umd/device/types/xy_pair.hpp>

--- a/tt_metal/impl/debug/inspector/data.cpp
+++ b/tt_metal/impl/debug/inspector/data.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include "data.hpp"
 #include <stdexcept>
 #include "rpc_server_controller.hpp"

--- a/tt_metal/impl/debug/inspector/inspector.cpp
+++ b/tt_metal/impl/debug/inspector/inspector.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include "inspector.hpp"
 #include "impl/context/metal_context.hpp"
 #include "impl/debug/inspector/data.hpp"

--- a/tt_metal/impl/debug/inspector/logger.cpp
+++ b/tt_metal/impl/debug/inspector/logger.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include "impl/debug/inspector/logger.hpp"
 #include "impl/debug/inspector/types.hpp"
 #include "impl/context/metal_context.hpp"

--- a/tt_metal/impl/debug/noc_logging.cpp
+++ b/tt_metal/impl/debug/noc_logging.cpp
@@ -11,7 +11,7 @@
 #include <string>
 
 #include <tt_stl/assert.hpp>
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include "core_coord.hpp"
 #include "debug_helpers.hpp"
 #include "hostdevcommon/dprint_common.h"

--- a/tt_metal/impl/debug/noc_logging.cpp
+++ b/tt_metal/impl/debug/noc_logging.cpp
@@ -11,6 +11,7 @@
 #include <string>
 
 #include <tt_stl/assert.hpp>
+#include <tt_stl/fmt.hpp>
 #include "core_coord.hpp"
 #include "debug_helpers.hpp"
 #include "hostdevcommon/dprint_common.h"

--- a/tt_metal/impl/debug/noc_logging.cpp
+++ b/tt_metal/impl/debug/noc_logging.cpp
@@ -11,7 +11,6 @@
 #include <string>
 
 #include <tt_stl/assert.hpp>
-#include <tt_stl/fmt.hpp>
 #include "core_coord.hpp"
 #include "debug_helpers.hpp"
 #include "hostdevcommon/dprint_common.h"

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/fmt.hpp>
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
@@ -14,6 +13,7 @@
 #include <vector>
 
 #include <tt_stl/assert.hpp>
+#include <tt_stl/fmt.hpp>
 #include <circular_buffer_constants.h>  // For NUM_CIRCULAR_BUFFERS
 #include <core_coord.hpp>
 #include <fmt/base.h>

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -22,7 +22,6 @@
 #include <fmt/core.h>
 
 #include <tt_stl/assert.hpp>
-#include <tt_stl/fmt.hpp>
 #include "core_coord.hpp"
 #include "api/debug/ring_buffer.h"
 #include "debug_helpers.hpp"

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -22,7 +22,7 @@
 #include <fmt/core.h>
 
 #include <tt_stl/assert.hpp>
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include "core_coord.hpp"
 #include "api/debug/ring_buffer.h"
 #include "debug_helpers.hpp"

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -22,6 +22,7 @@
 #include <fmt/core.h>
 
 #include <tt_stl/assert.hpp>
+#include <tt_stl/fmt.hpp>
 #include "core_coord.hpp"
 #include "api/debug/ring_buffer.h"
 #include "debug_helpers.hpp"

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include "device_impl.hpp"
 
 #include <core_descriptor.hpp>

--- a/tt_metal/impl/device/firmware/fabric_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/fabric_firmware_initializer.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include "fabric_firmware_initializer.hpp"
 
 #include <chrono>

--- a/tt_metal/impl/dispatch/data_collection.cpp
+++ b/tt_metal/impl/dispatch/data_collection.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include "data_collection.hpp"
 
 #include <cstdint>

--- a/tt_metal/impl/dispatch/data_collector.cpp
+++ b/tt_metal/impl/dispatch/data_collector.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include "data_collector.hpp"
 #include <enchantum/enchantum.hpp>
 #include <enchantum/generators.hpp>

--- a/tt_metal/impl/dispatch/debug_tools.cpp
+++ b/tt_metal/impl/dispatch/debug_tools.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include "debug_tools.hpp"
 
 #include <cstdint>

--- a/tt_metal/impl/dispatch/dispatch_core_common.cpp
+++ b/tt_metal/impl/dispatch/dispatch_core_common.cpp
@@ -37,5 +37,5 @@ DispatchCoreConfig get_dispatch_core_config() {
 
 std::size_t std::hash<tt::tt_metal::DispatchCoreConfig>::operator()(
     const tt::tt_metal::DispatchCoreConfig& dispatch_core_config) const {
-    return tt::stl::hash::hash_objects_with_default_seed(dispatch_core_config.attribute_values());
+    return ttsl::hash::hash_objects_with_default_seed(dispatch_core_config.attribute_values());
 }

--- a/tt_metal/impl/dispatch/hardware_command_queue.cpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include "hardware_command_queue.hpp"
 
 #include <device.hpp>

--- a/tt_metal/impl/dispatch/host_runtime_commands.cpp
+++ b/tt_metal/impl/dispatch/host_runtime_commands.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include <tt_stl/assert.hpp>
 #include <buffer.hpp>
 #include <event.hpp>

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include "impl/context/metal_context.hpp"
 #include "system_memory_manager.hpp"
 #include <tt-metalium/tt_align.hpp>

--- a/tt_metal/impl/experimental/udm/mesh_builder.cpp
+++ b/tt_metal/impl/experimental/udm/mesh_builder.cpp
@@ -5,7 +5,7 @@
 #include <tt-metalium/experimental/udm/mesh_builder.hpp>
 #include <tt-metalium/experimental/udm/mesh_utils.hpp>
 #include <tt_stl/assert.hpp>
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/experimental/fabric/routing_table_generator.hpp>
 #include <unordered_map>

--- a/tt_metal/impl/experimental/udm/mesh_kernel.cpp
+++ b/tt_metal/impl/experimental/udm/mesh_kernel.cpp
@@ -7,7 +7,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/hal.hpp>
 #include <tt_stl/assert.hpp>
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include <umd/device/types/arch.hpp>
 
 namespace tt::tt_metal::experimental::udm {

--- a/tt_metal/impl/experimental/udm/mesh_program.cpp
+++ b/tt_metal/impl/experimental/udm/mesh_program.cpp
@@ -6,7 +6,7 @@
 #include <tt-metalium/experimental/udm/mesh_builder.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt_stl/assert.hpp>
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 
 namespace tt::tt_metal::experimental::udm {
 

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -8,7 +8,6 @@
 #include <fmt/ranges.h>
 #include <kernel_types.hpp>
 #include <enchantum/enchantum.hpp>
-#include <tt_stl/tt_stl/reflection.hpp>
 #include <algorithm>
 #include <cstring>
 #include <filesystem>

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -25,7 +25,7 @@
 #include "llrt.hpp"
 #include <tt-logger/tt-logger.hpp>
 #include <tt_stl/span.hpp>
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include "impl/context/metal_context.hpp"
 #include "tt_memory.h"
 #include "tt_metal/jit_build/build_env_manager.hpp"

--- a/tt_metal/impl/lightmetal/lightmetal_capture.cpp
+++ b/tt_metal/impl/lightmetal/lightmetal_capture.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include <tt_stl/assert.hpp>
 #include "lightmetal/lightmetal_capture.hpp"

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include "core_coord.hpp"
 #include <common/TracyTTDeviceData.hpp>
 #include <device.hpp>

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include "tt_metal/impl/program/dispatch.hpp"
 
 #include <mesh_workload.hpp>

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -75,7 +75,7 @@
 #include <umd/device/types/xy_pair.hpp>
 #include "host_api.hpp"
 #include "kernels/kernel.hpp"
-#include "tt_stl/reflection.hpp"
+#include <tt_stl/reflection.hpp>
 #include <impl/dispatch/dispatch_query_manager.hpp>
 #include <llrt/tt_cluster.hpp>
 #include "impl/allocator/allocator.hpp"

--- a/tt_metal/impl/sub_device/sub_device.cpp
+++ b/tt_metal/impl/sub_device/sub_device.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include <tt_stl/assert.hpp>
 #include <core_coord.hpp>
 #include <sub_device.hpp>

--- a/tt_metal/impl/sub_device/sub_device_manager.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager.cpp
@@ -18,7 +18,7 @@
 #include "llrt/hal.hpp"
 #include "dispatch/dispatch_settings.hpp"
 #include <tt_stl/strong_type.hpp>
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include "sub_device_manager.hpp"
 #include "impl/context/metal_context.hpp"
 #include "impl/allocator/allocator_types.hpp"

--- a/tt_metal/impl/sub_device/sub_device_manager_tracker.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager_tracker.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include <allocator.hpp>
 #include <buffer_types.hpp>
 #include <device.hpp>

--- a/tt_metal/impl/tensor/spec/layout/alignment.cpp
+++ b/tt_metal/impl/tensor/spec/layout/alignment.cpp
@@ -25,3 +25,15 @@ std::ostream& operator<<(std::ostream& os, const tt::tt_metal::Alignment& alignm
 }
 
 }  // namespace tt::tt_metal
+
+std::string ttsl::fmt_detail::to_string(const tt::tt_metal::Alignment& alignment) {
+    std::string result = "Alignment([";
+    for (size_t i = 0; i < alignment.size(); ++i) {
+        if (i > 0) {
+            result += ", ";
+        }
+        result += std::to_string(alignment[i]);
+    }
+    result += "])";
+    return result;
+}

--- a/tt_metal/impl/tensor/spec/layout/page_config.cpp
+++ b/tt_metal/impl/tensor/spec/layout/page_config.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include <tt-metalium/experimental/tensor/spec/layout/page_config.hpp>
 
 #include <tt-metalium/shape2d.hpp>

--- a/tt_metal/impl/tensor/spec/layout/tensor_layout.cpp
+++ b/tt_metal/impl/tensor/spec/layout/tensor_layout.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include <tt-metalium/experimental/tensor/spec/layout/tensor_layout.hpp>
 
 #include <tt-metalium/allocator.hpp>

--- a/tt_metal/impl/tensor/topology/tensor_topology.cpp
+++ b/tt_metal/impl/tensor/topology/tensor_topology.cpp
@@ -4,7 +4,7 @@
 
 #include <tt-metalium/experimental/tensor/topology/tensor_topology.hpp>
 
-#include <tt_stl/fmt.hpp>
+#include <tt_stl/reflection.hpp>
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/tensor/topology/tensor_topology.cpp
+++ b/tt_metal/impl/tensor/topology/tensor_topology.cpp
@@ -4,7 +4,7 @@
 
 #include <tt-metalium/experimental/tensor/topology/tensor_topology.hpp>
 
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 
 namespace tt::tt_metal {
 

--- a/tt_metal/jit_build/hlk_desc.hpp
+++ b/tt_metal/jit_build/hlk_desc.hpp
@@ -12,7 +12,7 @@
 #include <tt-metalium/base_types.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 
 #include "common/stable_hash.hpp"
 

--- a/tt_metal/llrt/hal/tt-1xx/hal_1xx_common.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/hal_1xx_common.cpp
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/fmt.hpp>
-
 #include "hal_1xx_common.hpp"
 #include "hal_types.hpp"
 #include "rtoptions.hpp"

--- a/tt_metal/llrt/hal/tt-1xx/hal_1xx_common.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/hal_1xx_common.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 
 #include "hal_1xx_common.hpp"
 #include "hal_types.hpp"

--- a/tt_metal/llrt/hal/tt-2xx/hal_2xx_common.cpp
+++ b/tt_metal/llrt/hal/tt-2xx/hal_2xx_common.cpp
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/fmt.hpp>
-
 #include "hal_2xx_common.hpp"
 #include "rtoptions.hpp"
 #include <enchantum/enchantum.hpp>

--- a/tt_metal/llrt/hal/tt-2xx/hal_2xx_common.cpp
+++ b/tt_metal/llrt/hal/tt-2xx/hal_2xx_common.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 
 #include "hal_2xx_common.hpp"
 #include "rtoptions.hpp"

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 #include "tt_cluster.hpp"
 #include "llrt/rtoptions.hpp"
 

--- a/tt_metal/programming_examples/vecadd_sharding/vecadd_sharding.cpp
+++ b/tt_metal/programming_examples/vecadd_sharding/vecadd_sharding.cpp
@@ -16,7 +16,7 @@
 #include "tt-metalium/buffer_types.hpp"
 #include "tt-metalium/constants.hpp"
 #include <tt-metalium/distributed.hpp>
-#include <tt_stl/reflection.hpp>
+#include <tt_stl/fmt.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/tt_stl/CMakeLists.txt
+++ b/tt_stl/CMakeLists.txt
@@ -17,6 +17,7 @@ target_sources(
             tt_stl/aligned_allocator.hpp
             tt_stl/cleanup.hpp
             tt_stl/concepts.hpp
+            tt_stl/fmt.hpp
             tt_stl/indestructible.hpp
             tt_stl/optional_reference.hpp
             tt_stl/overloaded.hpp

--- a/tt_stl/tests/CMakeLists.txt
+++ b/tt_stl/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(
     unit_tests_stl_smoke
     PRIVATE
         test_cleanup.cpp
+        test_fmt.cpp
         test_indestructible.cpp
         test_optional_reference.cpp
         test_reflection.cpp

--- a/tt_stl/tests/test_fmt.cpp
+++ b/tt_stl/tests/test_fmt.cpp
@@ -1,0 +1,187 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Unit tests for tt_stl/fmt.hpp - lightweight formatters
+//
+// This test verifies that fmt.hpp provides working formatters for common types
+// without requiring the heavy dependencies (reflect, nlohmann/json) that
+// reflection.hpp pulls in.
+
+#include <gmock/gmock.h>
+#include <tt_stl/fmt.hpp>
+
+#include <array>
+#include <map>
+#include <optional>
+#include <set>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <variant>
+#include <vector>
+
+// Test enum (should work via enchantum)
+enum class TestEnum { Value1, Value2, Value3 };
+
+// Mock pointer type for testing non-void pointer formatting
+struct MockDevice {
+    int id;
+};
+
+namespace {
+
+using ::testing::HasSubstr;
+
+// Test std::vector<int> formatting
+TEST(FmtTest, VectorInt) {
+    std::vector<int> vec = {1, 2, 3, 4, 5};
+    std::string result = fmt::format("{}", vec);
+    EXPECT_THAT(result, HasSubstr("1"));
+    EXPECT_THAT(result, HasSubstr("2"));
+    EXPECT_THAT(result, HasSubstr("3"));
+}
+
+// Test std::optional<T> formatting
+TEST(FmtTest, Optional) {
+    std::optional<int> opt_val = 42;
+    std::string result1 = fmt::format("{}", opt_val);
+    EXPECT_THAT(result1, HasSubstr("42"));
+
+    std::optional<int> opt_empty = std::nullopt;
+    std::string result2 = fmt::format("{}", opt_empty);
+    // Should format as nullopt or None or similar
+    EXPECT_TRUE(
+        result2.find("nullopt") != std::string::npos || result2.find("None") != std::string::npos ||
+        result2.find("null") != std::string::npos);
+}
+
+// Test std::optional<const T> (edge case mentioned in fmt.hpp comments)
+TEST(FmtTest, OptionalConst) {
+    std::optional<const bool> opt_const = true;
+    std::string result = fmt::format("{}", opt_const);
+    EXPECT_TRUE(result.find("true") != std::string::npos || result.find("1") != std::string::npos);
+}
+
+// Test container of non-void pointers (critical edge case)
+TEST(FmtTest, VectorOfPointers) {
+    MockDevice d1{1}, d2{2}, d3{3};
+    std::vector<MockDevice*> ptrs = {&d1, &d2, &d3};
+    std::string result = fmt::format("{}", ptrs);
+    // Should format as pointers (void* representation)
+    EXPECT_FALSE(result.empty());
+    // Should contain some indication of pointer values
+    EXPECT_TRUE(result.find("0x") != std::string::npos || result.find("ptr") != std::string::npos);
+}
+
+// Test std::array
+TEST(FmtTest, Array) {
+    std::array<int, 3> arr = {10, 20, 30};
+    std::string result = fmt::format("{}", arr);
+    EXPECT_THAT(result, HasSubstr("10"));
+    EXPECT_THAT(result, HasSubstr("20"));
+    EXPECT_THAT(result, HasSubstr("30"));
+}
+
+// Test std::map
+TEST(FmtTest, Map) {
+    std::map<std::string, int> m = {{"a", 1}, {"b", 2}, {"c", 3}};
+    std::string result = fmt::format("{}", m);
+    EXPECT_TRUE(result.find("a") != std::string::npos || result.find("\"a\"") != std::string::npos);
+    EXPECT_THAT(result, HasSubstr("1"));
+}
+
+// Test std::set
+TEST(FmtTest, Set) {
+    std::set<int> s = {3, 1, 4, 1, 5};
+    std::string result = fmt::format("{}", s);
+    EXPECT_THAT(result, HasSubstr("1"));
+    EXPECT_THAT(result, HasSubstr("3"));
+    EXPECT_THAT(result, HasSubstr("4"));
+    EXPECT_THAT(result, HasSubstr("5"));
+}
+
+// Test std::unordered_map
+TEST(FmtTest, UnorderedMap) {
+    std::unordered_map<std::string, int> um = {{"x", 10}, {"y", 20}};
+    std::string result = fmt::format("{}", um);
+    EXPECT_TRUE(result.find("x") != std::string::npos || result.find("\"x\"") != std::string::npos);
+    EXPECT_THAT(result, HasSubstr("10"));
+}
+
+// Test std::tuple
+TEST(FmtTest, Tuple) {
+    std::tuple<int, std::string, bool> t = {42, "test", true};
+    std::string result = fmt::format("{}", t);
+    EXPECT_THAT(result, HasSubstr("42"));
+    EXPECT_THAT(result, HasSubstr("test"));
+    EXPECT_TRUE(result.find("true") != std::string::npos || result.find("1") != std::string::npos);
+}
+
+// Test std::variant
+TEST(FmtTest, Variant) {
+    std::variant<int, std::string> v1 = 100;
+    std::string result1 = fmt::format("{}", v1);
+    EXPECT_THAT(result1, HasSubstr("100"));
+
+    std::variant<int, std::string> v2 = std::string("hello");
+    std::string result2 = fmt::format("{}", v2);
+    EXPECT_THAT(result2, HasSubstr("hello"));
+}
+
+// Test enum formatting (via enchantum)
+TEST(FmtTest, Enum) {
+    TestEnum e = TestEnum::Value2;
+    std::string result = fmt::format("{}", e);
+    EXPECT_FALSE(result.empty());
+    // Should format as enum name, not just number
+    EXPECT_TRUE(
+        result.find("Value2") != std::string::npos || result.find("value2") != std::string::npos ||
+        result.find("Value") != std::string::npos);
+}
+
+// Test std::filesystem::path
+TEST(FmtTest, FilesystemPath) {
+    std::filesystem::path p = "/some/path/to/file.txt";
+    std::string result = fmt::format("{}", p);
+    EXPECT_TRUE(result.find("file.txt") != std::string::npos || result.find("path") != std::string::npos);
+}
+
+// Test ttsl::SmallVector
+TEST(FmtTest, SmallVector) {
+    ttsl::SmallVector<int, 4> sv = {1, 2, 3};
+    std::string result = fmt::format("{}", sv);
+    EXPECT_THAT(result, HasSubstr("1"));
+    EXPECT_THAT(result, HasSubstr("2"));
+    EXPECT_THAT(result, HasSubstr("3"));
+}
+
+// Test ttsl::StrongType
+TEST(FmtTest, StrongType) {
+    using UserId = ttsl::StrongType<int, struct UserIdTag>;
+    UserId id{12345};
+    std::string result = fmt::format("{}", id);
+    EXPECT_THAT(result, HasSubstr("12345"));
+}
+
+// Test nested containers
+TEST(FmtTest, NestedContainers) {
+    std::vector<std::vector<int>> nested = {{1, 2}, {3, 4}, {5}};
+    std::string result = fmt::format("{}", nested);
+    EXPECT_THAT(result, HasSubstr("1"));
+    EXPECT_THAT(result, HasSubstr("2"));
+    EXPECT_THAT(result, HasSubstr("3"));
+}
+
+// Test empty containers
+TEST(FmtTest, EmptyContainers) {
+    std::vector<int> empty_vec;
+    std::string result = fmt::format("{}", empty_vec);
+    EXPECT_FALSE(result.empty());  // Should format something, even if empty
+
+    std::optional<int> empty_opt = std::nullopt;
+    std::string result2 = fmt::format("{}", empty_opt);
+    EXPECT_FALSE(result2.empty());
+}
+
+}  // namespace

--- a/tt_stl/tests/test_fmt.cpp
+++ b/tt_stl/tests/test_fmt.cpp
@@ -60,7 +60,7 @@ TEST(FmtTest, Optional) {
 TEST(FmtTest, OptionalConst) {
     std::optional<const bool> opt_const = true;
     std::string result = fmt::format("{}", opt_const);
-    EXPECT_TRUE(result.find("true") != std::string::npos || result.find("1") != std::string::npos);
+    EXPECT_TRUE(result.find("true") != std::string::npos || result.find('1') != std::string::npos);
 }
 
 // Test container of non-void pointers (critical edge case)
@@ -87,7 +87,7 @@ TEST(FmtTest, Array) {
 TEST(FmtTest, Map) {
     std::map<std::string, int> m = {{"a", 1}, {"b", 2}, {"c", 3}};
     std::string result = fmt::format("{}", m);
-    EXPECT_TRUE(result.find("a") != std::string::npos || result.find("\"a\"") != std::string::npos);
+    EXPECT_TRUE(result.find('a') != std::string::npos || result.find("\"a\"") != std::string::npos);
     EXPECT_THAT(result, HasSubstr("1"));
 }
 
@@ -105,7 +105,7 @@ TEST(FmtTest, Set) {
 TEST(FmtTest, UnorderedMap) {
     std::unordered_map<std::string, int> um = {{"x", 10}, {"y", 20}};
     std::string result = fmt::format("{}", um);
-    EXPECT_TRUE(result.find("x") != std::string::npos || result.find("\"x\"") != std::string::npos);
+    EXPECT_TRUE(result.find('x') != std::string::npos || result.find("\"x\"") != std::string::npos);
     EXPECT_THAT(result, HasSubstr("10"));
 }
 
@@ -115,7 +115,7 @@ TEST(FmtTest, Tuple) {
     std::string result = fmt::format("{}", t);
     EXPECT_THAT(result, HasSubstr("42"));
     EXPECT_THAT(result, HasSubstr("test"));
-    EXPECT_TRUE(result.find("true") != std::string::npos || result.find("1") != std::string::npos);
+    EXPECT_TRUE(result.find("true") != std::string::npos || result.find('1') != std::string::npos);
 }
 
 // Test std::variant

--- a/tt_stl/tt_stl/fmt.hpp
+++ b/tt_stl/tt_stl/fmt.hpp
@@ -1,0 +1,284 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Lightweight fmt formatters for standard containers, enums, and project types.
+//
+// Include this header instead of <tt_stl/reflection.hpp> when all you need is
+// to format standard-library types (vector, array, optional, variant, map, …)
+// or enums in log / fmt::format calls.  This header deliberately avoids the
+// heavy <reflect> and <nlohmann/json.hpp> includes that reflection.hpp pulls in.
+//
+// Why not use fmt/std.h and fmt/ranges.h directly?
+//
+//   1. fmt/ranges.h detects any type with begin()/end() as "range-like".
+//      Many project types (Shape, MeshShape, etc.) are both range-like AND use
+//      the compile-time attribute protocol (attribute_names + attribute_values),
+//      which has its own formatter in reflection.hpp.  Including fmt/ranges.h
+//      creates ambiguous specializations.
+//
+//   2. fmt/std.h's std::optional<T> formatter requires is_formattable<T>.
+//      The Attribute class type-erases over types like optional<const bool>,
+//      and fmt does not consider `const bool` formattable.
+//
+//   3. fmt 11 disallows non-void pointer formatting via a static_assert in
+//      make_arg, before any custom formatter is consulted.  Containers like
+//      vector<IDevice*> require special handling at the container level.
+
+#pragma once
+
+#include <fmt/format.h>
+
+#include <array>
+#include <filesystem>
+#include <functional>
+#include <map>
+#include <optional>
+#include <set>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <unordered_map>
+#include <variant>
+#include <vector>
+
+#include <enchantum/scoped.hpp>
+#include <tt_stl/small_vector.hpp>
+
+// ============================================================================
+// Implementation detail – format a single value, with pointer handling.
+//
+// fmt 11 rejects non-void pointers with a static_assert inside make_arg,
+// which fires before the formatter is ever consulted.  We work around this
+// by detecting pointer types at the call site and converting to void*.
+// ============================================================================
+
+namespace ttsl::fmt_detail {
+
+template <typename T>
+auto format_value(fmt::format_context::iterator out, const T& val) -> fmt::format_context::iterator {
+    if constexpr (
+        std::is_pointer_v<T> && !std::is_same_v<std::remove_const_t<std::remove_pointer_t<T>>, char> &&
+        !std::is_same_v<std::remove_const_t<std::remove_pointer_t<T>>, void>) {
+        if (val) {
+            return fmt::format_to(out, "{}", fmt::ptr(val));
+        }
+        return fmt::format_to(out, "nullptr");
+    } else {
+        return fmt::format_to(out, "{}", val);
+    }
+}
+
+// Helper to format a sequence of values with a given open/close bracket.
+template <typename Iter>
+auto format_sequence(
+    Iter begin, Iter end, fmt::format_context::iterator out, std::string_view open, std::string_view close)
+    -> fmt::format_context::iterator {
+    out = fmt::format_to(out, "{}", open);
+    bool first = true;
+    for (auto it = begin; it != end; ++it) {
+        if (!first) {
+            out = fmt::format_to(out, ", ");
+        }
+        out = format_value(out, *it);
+        first = false;
+    }
+    return fmt::format_to(out, "{}", close);
+}
+
+}  // namespace ttsl::fmt_detail
+
+// ============================================================================
+// fmt::formatter – enums (via enchantum, avoids <reflect>)
+// ============================================================================
+
+template <typename T>
+    requires std::is_enum_v<T>
+struct fmt::formatter<T> {
+    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
+
+    auto format(const T& value, format_context& ctx) const -> format_context::iterator {
+        return fmt::format_to(ctx.out(), "{}", enchantum::scoped::to_string(value));
+    }
+};
+
+// ============================================================================
+// fmt::formatter – std::filesystem::path
+// ============================================================================
+
+template <>
+struct fmt::formatter<std::filesystem::path> {
+    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
+
+    auto format(const std::filesystem::path& p, format_context& ctx) const -> format_context::iterator {
+        return fmt::format_to(ctx.out(), "{}", p.string());
+    }
+};
+
+// ============================================================================
+// fmt::formatter – std::optional
+// ============================================================================
+
+template <typename T>
+struct fmt::formatter<std::optional<T>> {
+    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
+
+    auto format(const std::optional<T>& opt, format_context& ctx) const -> format_context::iterator {
+        if (opt.has_value()) {
+            return ttsl::fmt_detail::format_value(ctx.out(), opt.value());
+        }
+        return fmt::format_to(ctx.out(), "std::nullopt");
+    }
+};
+
+// ============================================================================
+// fmt::formatter – std::variant
+// ============================================================================
+
+template <typename... Ts>
+struct fmt::formatter<std::variant<Ts...>> {
+    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
+
+    auto format(const std::variant<Ts...>& var, format_context& ctx) const -> format_context::iterator {
+        return std::visit([&ctx](const auto& val) { return ttsl::fmt_detail::format_value(ctx.out(), val); }, var);
+    }
+};
+
+// ============================================================================
+// fmt::formatter – std::reference_wrapper
+// ============================================================================
+
+template <typename T>
+struct fmt::formatter<std::reference_wrapper<T>> {
+    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
+
+    auto format(const std::reference_wrapper<T>& ref, format_context& ctx) const -> format_context::iterator {
+        return ttsl::fmt_detail::format_value(ctx.out(), ref.get());
+    }
+};
+
+// ============================================================================
+// fmt::formatter – standard containers
+// ============================================================================
+
+// std::vector
+template <typename T, typename Alloc>
+struct fmt::formatter<std::vector<T, Alloc>> {
+    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
+
+    auto format(const std::vector<T, Alloc>& vec, format_context& ctx) const -> format_context::iterator {
+        return ttsl::fmt_detail::format_sequence(vec.begin(), vec.end(), ctx.out(), "{", "}");
+    }
+};
+
+// std::array
+template <typename T, std::size_t N>
+struct fmt::formatter<std::array<T, N>> {
+    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
+
+    auto format(const std::array<T, N>& arr, format_context& ctx) const -> format_context::iterator {
+        return ttsl::fmt_detail::format_sequence(arr.begin(), arr.end(), ctx.out(), "{", "}");
+    }
+};
+
+// std::set
+template <typename Key, typename Compare, typename Alloc>
+struct fmt::formatter<std::set<Key, Compare, Alloc>> {
+    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
+
+    auto format(const std::set<Key, Compare, Alloc>& s, format_context& ctx) const -> format_context::iterator {
+        return ttsl::fmt_detail::format_sequence(s.begin(), s.end(), ctx.out(), "{", "}");
+    }
+};
+
+// std::map
+template <typename Key, typename Value, typename Compare, typename Alloc>
+struct fmt::formatter<std::map<Key, Value, Compare, Alloc>> {
+    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
+
+    auto format(const std::map<Key, Value, Compare, Alloc>& m, format_context& ctx) const -> format_context::iterator {
+        auto out = fmt::format_to(ctx.out(), "{{");
+        bool first = true;
+        for (const auto& [k, v] : m) {
+            if (!first) {
+                out = fmt::format_to(out, ", ");
+            }
+            out = ttsl::fmt_detail::format_value(out, k);
+            out = fmt::format_to(out, ": ");
+            out = ttsl::fmt_detail::format_value(out, v);
+            first = false;
+        }
+        return fmt::format_to(out, "}}");
+    }
+};
+
+// std::unordered_map
+template <typename Key, typename Value, typename Hash, typename Equal, typename Alloc>
+struct fmt::formatter<std::unordered_map<Key, Value, Hash, Equal, Alloc>> {
+    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
+
+    auto format(const std::unordered_map<Key, Value, Hash, Equal, Alloc>& m, format_context& ctx) const
+        -> format_context::iterator {
+        auto out = fmt::format_to(ctx.out(), "{{");
+        bool first = true;
+        for (const auto& [k, v] : m) {
+            if (!first) {
+                out = fmt::format_to(out, ", ");
+            }
+            out = ttsl::fmt_detail::format_value(out, k);
+            out = fmt::format_to(out, ": ");
+            out = ttsl::fmt_detail::format_value(out, v);
+            first = false;
+        }
+        return fmt::format_to(out, "}}");
+    }
+};
+
+// std::pair
+template <typename T1, typename T2>
+struct fmt::formatter<std::pair<T1, T2>> {
+    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
+
+    auto format(const std::pair<T1, T2>& p, format_context& ctx) const -> format_context::iterator {
+        auto out = fmt::format_to(ctx.out(), "(");
+        out = ttsl::fmt_detail::format_value(out, p.first);
+        out = fmt::format_to(out, ", ");
+        out = ttsl::fmt_detail::format_value(out, p.second);
+        return fmt::format_to(out, ")");
+    }
+};
+
+// std::tuple
+template <typename... Ts>
+struct fmt::formatter<std::tuple<Ts...>> {
+    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
+
+    auto format(const std::tuple<Ts...>& t, format_context& ctx) const -> format_context::iterator {
+        auto out = fmt::format_to(ctx.out(), "(");
+        std::apply(
+            [&out, first = true](const auto&... args) mutable {
+                ((out =
+                      (first ? out : fmt::format_to(out, ", "),
+                       ttsl::fmt_detail::format_value(out, args),
+                       first = false,
+                       out)),
+                 ...);
+            },
+            t);
+        return fmt::format_to(out, ")");
+    }
+};
+
+// ============================================================================
+// fmt::formatter – ttsl::SmallVector
+// ============================================================================
+
+template <typename T, std::size_t PREALLOCATED_SIZE>
+struct fmt::formatter<ttsl::SmallVector<T, PREALLOCATED_SIZE>> {
+    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
+
+    auto format(const ttsl::SmallVector<T, PREALLOCATED_SIZE>& vec, format_context& ctx) const
+        -> format_context::iterator {
+        return ttsl::fmt_detail::format_sequence(vec.begin(), vec.end(), ctx.out(), "{", "}");
+    }
+};

--- a/tt_stl/tt_stl/fmt.hpp
+++ b/tt_stl/tt_stl/fmt.hpp
@@ -44,6 +44,46 @@
 
 #include <enchantum/scoped.hpp>
 #include <tt_stl/small_vector.hpp>
+#include <tt_stl/strong_type.hpp>
+
+// ============================================================================
+// "Leaf" formatters – these must appear BEFORE the generic format_value helper
+// so that format_value can find them when instantiated with these types.
+// ============================================================================
+
+// ---- enums (via enchantum, avoids <reflect>) ----
+
+template <typename T>
+    requires std::is_enum_v<T>
+struct fmt::formatter<T> {
+    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
+
+    auto format(const T& value, format_context& ctx) const -> format_context::iterator {
+        return fmt::format_to(ctx.out(), "{}", enchantum::scoped::to_string(value));
+    }
+};
+
+// ---- std::filesystem::path ----
+
+template <>
+struct fmt::formatter<std::filesystem::path> {
+    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
+
+    auto format(const std::filesystem::path& p, format_context& ctx) const -> format_context::iterator {
+        return fmt::format_to(ctx.out(), "{}", p.string());
+    }
+};
+
+// ---- ttsl::StrongType  (fully inline – dereferences to inner T) ----
+
+template <typename T, typename Tag>
+struct fmt::formatter<ttsl::StrongType<T, Tag>> {
+    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
+
+    auto format(const ttsl::StrongType<T, Tag>& val, format_context& ctx) const -> format_context::iterator {
+        return fmt::format_to(ctx.out(), "{}", *val);
+    }
+};
 
 // ============================================================================
 // Implementation detail – format a single value, with pointer handling.
@@ -89,35 +129,10 @@ auto format_sequence(
 }  // namespace ttsl::fmt_detail
 
 // ============================================================================
-// fmt::formatter – enums (via enchantum, avoids <reflect>)
+// fmt::formatter – wrapper / sum types
 // ============================================================================
 
-template <typename T>
-    requires std::is_enum_v<T>
-struct fmt::formatter<T> {
-    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
-
-    auto format(const T& value, format_context& ctx) const -> format_context::iterator {
-        return fmt::format_to(ctx.out(), "{}", enchantum::scoped::to_string(value));
-    }
-};
-
-// ============================================================================
-// fmt::formatter – std::filesystem::path
-// ============================================================================
-
-template <>
-struct fmt::formatter<std::filesystem::path> {
-    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
-
-    auto format(const std::filesystem::path& p, format_context& ctx) const -> format_context::iterator {
-        return fmt::format_to(ctx.out(), "{}", p.string());
-    }
-};
-
-// ============================================================================
-// fmt::formatter – std::optional
-// ============================================================================
+// ---- std::optional ----
 
 template <typename T>
 struct fmt::formatter<std::optional<T>> {
@@ -131,9 +146,7 @@ struct fmt::formatter<std::optional<T>> {
     }
 };
 
-// ============================================================================
-// fmt::formatter – std::variant
-// ============================================================================
+// ---- std::variant ----
 
 template <typename... Ts>
 struct fmt::formatter<std::variant<Ts...>> {
@@ -144,9 +157,7 @@ struct fmt::formatter<std::variant<Ts...>> {
     }
 };
 
-// ============================================================================
-// fmt::formatter – std::reference_wrapper
-// ============================================================================
+// ---- std::reference_wrapper ----
 
 template <typename T>
 struct fmt::formatter<std::reference_wrapper<T>> {

--- a/tt_stl/tt_stl/reflection.hpp
+++ b/tt_stl/tt_stl/reflection.hpp
@@ -27,6 +27,7 @@
 #include <nlohmann/json.hpp>
 #include <enchantum/scoped.hpp>
 #include <tt_stl/type_name.hpp>
+#include <tt_stl/fmt.hpp>
 #include <tt-logger/tt-logger.hpp>
 
 // NOLINTBEGIN(bugprone-multi-level-implicit-pointer-conversion)
@@ -348,7 +349,7 @@ std::ostream& operator<<(std::ostream& os, const std::pair<T1, T2>& pair) {
     return os;
 }
 
-static std::ostream& operator<<(std::ostream& os, const std::filesystem::path& path) {
+inline std::ostream& operator<<(std::ostream& os, const std::filesystem::path& path) {
     os << path.c_str();
     return os;
 }
@@ -953,6 +954,13 @@ std::ostream& operator<<(std::ostream& os, const SmallVector<T, PREALLOCATED_SIZ
 
 }  // namespace ttsl
 
+// fmt::formatter specializations for standard containers, enums, filesystem::path,
+// and SmallVector are provided by the lightweight <tt_stl/fmt.hpp> header (included above)
+// so that translation units that only need formatting can avoid the heavy <reflect> and
+// <nlohmann/json.hpp> includes.
+//
+// The formatters below are for types that require the full reflection machinery.
+
 template <typename T>
 struct fmt::formatter<T, char, std::enable_if_t<ttsl::reflection::detail::supports_conversion_to_string_v<T>>> {
     constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
@@ -961,138 +969,6 @@ struct fmt::formatter<T, char, std::enable_if_t<ttsl::reflection::detail::suppor
         using ttsl::reflection::operator<<;
         std::stringstream ss;
         ss << object;
-        return fmt::format_to(ctx.out(), "{}", ss.str());
-    }
-};
-
-template <typename T>
-struct fmt::formatter<T, char, std::enable_if_t<std::is_enum_v<T>>> {
-    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
-
-    auto format(const T& value, format_context& ctx) const -> format_context::iterator {
-        using ttsl::reflection::operator<<;
-        std::stringstream ss;
-        ss << value;
-        return fmt::format_to(ctx.out(), "{}", ss.str());
-    }
-};
-
-template <>
-struct fmt::formatter<std::filesystem::path> {
-    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
-
-    auto format(const std::filesystem::path& path, format_context& ctx) const -> format_context::iterator {
-        using ttsl::reflection::operator<<;
-        std::stringstream ss;
-        ss << path;
-        return fmt::format_to(ctx.out(), "{}", ss.str());
-    }
-};
-
-template <typename T>
-struct fmt::formatter<std::optional<T>> {
-    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
-
-    auto format(const std::optional<T>& optional, format_context& ctx) const -> format_context::iterator {
-        using ttsl::reflection::operator<<;
-        std::stringstream ss;
-        ss << optional;
-        return fmt::format_to(ctx.out(), "{}", ss.str());
-    }
-};
-
-template <typename... Ts>
-struct fmt::formatter<std::variant<Ts...>> {
-    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
-
-    auto format(const std::variant<Ts...>& variant, format_context& ctx) const -> format_context::iterator {
-        using ttsl::reflection::operator<<;
-        std::stringstream ss;
-        ss << variant;
-        return fmt::format_to(ctx.out(), "{}", ss.str());
-    }
-};
-
-template <typename T>
-struct fmt::formatter<std::reference_wrapper<T>> {
-    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
-
-    auto format(const std::reference_wrapper<T> reference, format_context& ctx) const -> format_context::iterator {
-        using ttsl::reflection::operator<<;
-        std::stringstream ss;
-        ss << reference;
-        return fmt::format_to(ctx.out(), "{}", ss.str());
-    }
-};
-
-template <typename... Ts>
-struct fmt::formatter<std::tuple<Ts...>> {
-    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
-
-    auto format(const std::tuple<Ts...>& tuple, format_context& ctx) const -> format_context::iterator {
-        using ttsl::reflection::operator<<;
-        std::stringstream ss;
-        ss << tuple;
-        return fmt::format_to(ctx.out(), "{}", ss.str());
-    }
-};
-
-template <typename T, std::size_t N>
-struct fmt::formatter<std::array<T, N>> {
-    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
-
-    auto format(const std::array<T, N>& array, format_context& ctx) const -> format_context::iterator {
-        using ttsl::reflection::operator<<;
-        std::stringstream ss;
-        ss << array;
-        return fmt::format_to(ctx.out(), "{}", ss.str());
-    }
-};
-
-template <typename T>
-struct fmt::formatter<std::vector<T>> {
-    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
-
-    auto format(const std::vector<T>& vector, format_context& ctx) const -> format_context::iterator {
-        using ttsl::reflection::operator<<;
-        std::stringstream ss;
-        ss << vector;
-        return fmt::format_to(ctx.out(), "{}", ss.str());
-    }
-};
-
-template <typename T>
-struct fmt::formatter<std::set<T>> {
-    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
-
-    auto format(const std::set<T>& set, format_context& ctx) const -> format_context::iterator {
-        using ttsl::reflection::operator<<;
-        std::stringstream ss;
-        ss << set;
-        return fmt::format_to(ctx.out(), "{}", ss.str());
-    }
-};
-
-template <typename K, typename V>
-struct fmt::formatter<std::map<K, V>> {
-    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
-
-    auto format(const std::map<K, V>& map, format_context& ctx) const -> format_context::iterator {
-        using ttsl::reflection::operator<<;
-        std::stringstream ss;
-        ss << map;
-        return fmt::format_to(ctx.out(), "{}", ss.str());
-    }
-};
-
-template <typename K, typename V>
-struct fmt::formatter<std::unordered_map<K, V>> {
-    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
-
-    auto format(const std::unordered_map<K, V>& map, format_context& ctx) const -> format_context::iterator {
-        using ttsl::reflection::operator<<;
-        std::stringstream ss;
-        ss << map;
         return fmt::format_to(ctx.out(), "{}", ss.str());
     }
 };
@@ -1108,19 +984,6 @@ struct fmt::formatter<T> {
         using ttsl::reflection::operator<<;
         std::stringstream ss;
         ss << object;
-        return fmt::format_to(ctx.out(), "{}", ss.str());
-    }
-};
-
-template <typename T, size_t PREALLOCATED_SIZE>
-struct fmt::formatter<ttsl::SmallVector<T, PREALLOCATED_SIZE>> {
-    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
-
-    auto format(const ttsl::SmallVector<T, PREALLOCATED_SIZE>& vector, format_context& ctx) const
-        -> format_context::iterator {
-        using ttsl::reflection::operator<<;
-        std::stringstream ss;
-        ss << vector;
         return fmt::format_to(ctx.out(), "{}", ss.str());
     }
 };

--- a/tt_stl/tt_stl/reflection.hpp
+++ b/tt_stl/tt_stl/reflection.hpp
@@ -966,9 +966,9 @@ struct fmt::formatter<
     T,
     char,
     std::enable_if_t<ttsl::reflection::detail::supports_conversion_to_string_v<T> && !ttsl::is_strong_type_v<T>>> {
-    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
+    constexpr auto parse(fmt::format_parse_context& ctx) -> fmt::format_parse_context::iterator { return ctx.end(); }
 
-    auto format(const T& object, format_context& ctx) const -> format_context::iterator {
+    auto format(const T& object, fmt::format_context& ctx) const -> fmt::format_context::iterator {
         using ttsl::reflection::operator<<;
         std::stringstream ss;
         ss << object;
@@ -981,9 +981,9 @@ template <typename T>
         ttsl::concepts::Reflectable<T> and
         not(std::integral<T> or std::is_array_v<T> or ttsl::reflection::detail::supports_conversion_to_string_v<T>))
 struct fmt::formatter<T> {
-    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
+    constexpr auto parse(fmt::format_parse_context& ctx) -> fmt::format_parse_context::iterator { return ctx.end(); }
 
-    auto format(const T& object, format_context& ctx) const -> format_context::iterator {
+    auto format(const T& object, fmt::format_context& ctx) const -> fmt::format_context::iterator {
         using ttsl::reflection::operator<<;
         std::stringstream ss;
         ss << object;

--- a/tt_stl/tt_stl/reflection.hpp
+++ b/tt_stl/tt_stl/reflection.hpp
@@ -962,7 +962,10 @@ std::ostream& operator<<(std::ostream& os, const SmallVector<T, PREALLOCATED_SIZ
 // The formatters below are for types that require the full reflection machinery.
 
 template <typename T>
-struct fmt::formatter<T, char, std::enable_if_t<ttsl::reflection::detail::supports_conversion_to_string_v<T>>> {
+struct fmt::formatter<
+    T,
+    char,
+    std::enable_if_t<ttsl::reflection::detail::supports_conversion_to_string_v<T> && !ttsl::is_strong_type_v<T>>> {
     constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
 
     auto format(const T& object, format_context& ctx) const -> format_context::iterator {

--- a/tt_stl/tt_stl/strong_type.hpp
+++ b/tt_stl/tt_stl/strong_type.hpp
@@ -102,6 +102,14 @@ private:
     T value_;
 };
 
+// Type trait to detect StrongType instantiations.
+template <typename T>
+struct is_strong_type : std::false_type {};
+template <typename T, typename Tag>
+struct is_strong_type<StrongType<T, Tag>> : std::true_type {};
+template <typename T>
+inline constexpr bool is_strong_type_v = is_strong_type<T>::value;
+
 }  // namespace ttsl
 
 template <typename T, typename Tag>


### PR DESCRIPTION
### Ticket
N/A - Compile/structure optimization

### Problem description
The `reflection.hpp` header is heavy, pulling in dependencies like `<reflect>`, `<nlohmann/json.hpp>`, and `<enchantum>`. Many files include it only for `fmt::format` logging, which doesn't require these heavy dependencies. This causes:
- Slow compilation times, especially in no-PCH builds
- Unnecessary template instantiations

### What's changed
Created a lightweight `tt_stl/fmt.hpp` header that provides `fmt::formatter` specializations for common types without pulling in heavy dependencies. Converted ~53+ `tt_metal` files from `reflection.hpp` to `fmt.hpp` where they only needed formatting capabilities. Additional commits added formatters for project types and fixed compilation issues.

**Key changes:**
1. **New header**: `tt_stl/tt_stl/fmt.hpp` (295 lines)
   - Provides formatters for enums, standard containers, `SmallVector`, `StrongType`, etc.
   - Uses `fmt/std.h` for standard library types where possible
   - Handles edge cases like `optional<const T>` and raw pointers
   - No heavy dependencies (no `<reflect>`, no `<nlohmann/json.hpp>`)

2. **Updated `reflection.hpp`**:
   - Removed duplicate formatters now provided by `fmt.hpp`
   - Includes `fmt.hpp` to maintain backward compatibility
   - Excludes `StrongType` from generic formatter to avoid ambiguity

3. **Added out-of-line formatters** for project types:
   - `Shape`, `Shape2D`, `Alignment` - added `ttsl::fmt_detail::to_string()` and `fmt::formatter` specializations
   - `MeshShape`, `MeshCoordinate`, `MeshCoordinateRange` - added formatters
   - `PhysicalMeshCoordinate` - added formatter

4. **Converted files** (~53+ tt_metal files):
   - Initial conversion: 53 files changed from `reflection.hpp` to `fmt.hpp`
   - Additional files updated in follow-up commits to add formatters and fix issues
   - Key examples:
     - `tt_metal/impl/experimental/udm/mesh_builder.cpp`
     - `tt_metal/impl/experimental/udm/mesh_kernel.cpp`
     - `tt_metal/impl/experimental/udm/mesh_program.cpp`
     - `tt_metal/impl/kernels/kernel.cpp` (removed duplicate include)
     - `tt_metal/impl/profiler/profiler.cpp`
     - `tt_metal/distributed/mesh_workload.cpp`
     - And many more across distributed/, fabric/, impl/, etc.

5. **Fixed namespace issues**:
   - Updated `tt::stl::hash` → `ttsl::hash` in 2 files (deprecated namespace)

**Files kept with `reflection.hpp`** (need advanced features):
- Files using JSON serialization/deserialization
- Files using hashing utilities
- Files using `reflect::` directly
- Files using `ttsl::reflection::operator<<` for complex types

**Scope:**
- **Total files changed**: 73 files
- **tt_metal files**: ~68 files (include conversions + formatter additions)
- **tt_stl files**: 4 files (new fmt.hpp, updated reflection.hpp, strong_type.hpp, CMakeLists.txt)
- **Other changes**: Model demo files (unrelated to this optimization)

**Impact:**
- **No-PCH builds**: 430.42s saved (20.2% reduction in reflection.hpp time, 9.2% reduction in nlohmann/json.hpp time)
- **PCH builds**: 30.82s saved (10.2% reduction in reflection.hpp time, 6.9% reduction in nlohmann/json.hpp time)
- Build passes successfully with `--disable-pch --disable-unity-builds`
- No functional changes - all APIs remain the same

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=lightweight-fmt-formatters)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:lightweight-fmt-formatters)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=lightweight-fmt-formatters)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:lightweight-fmt-formatters)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=lightweight-fmt-formatters)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:lightweight-fmt-formatters)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early

#### Model tests

Not applicable - this is a build system optimization with no functional changes.
