### PR TITLE
Rename moe compile time arguments to avoid conflicts with upcoming attention block

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/moe/moe_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe/moe_kernel.cpp
@@ -107,9 +107,9 @@ void kernel_main() {
             // Mcast (receiver)
             using McastCTArgs = deepseek_b1_ops::Mcast::ReceiverCTArgs;
             deepseek_b1_ops::Mcast::ReceiverArgs mcast_args{
-                get_named_compile_time_arg_val("mcast_data_receiver_semaphore_addr"),
-                get_named_compile_time_arg_val("mcast_dst_cb"),
-                get_named_compile_time_arg_val("mcast_dst_num_pages"),
+                get_named_compile_time_arg_val("moe_mcast_data_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("moe_mcast_dst_cb"),
+                get_named_compile_time_arg_val("moe_mcast_dst_num_pages"),
             };
 
 #ifdef ENABLE_ROUTING
@@ -326,8 +326,8 @@ void kernel_main() {
     auto setup_all_sharded_buffers = [&]() {
         if constexpr (Core::is_sender_core) {
             unified_kernels::setup_sharded_buffer(
-                get_named_compile_time_arg_val("rmsnorm_gamma_cb"),
-                get_named_compile_time_arg_val("rmsnorm_gamma_num_pages"));
+                get_named_compile_time_arg_val("moe_rmsnorm_gamma_cb"),
+                get_named_compile_time_arg_val("moe_rmsnorm_gamma_num_pages"));
 #ifdef ENABLE_ROUTING
             unified_kernels::setup_sharded_buffer(get_named_compile_time_arg_val("gate_bias_cb"), 1);
             unified_kernels::setup_sharded_buffer(get_named_compile_time_arg_val("gate_input_indices_cb"), 1);
@@ -372,21 +372,21 @@ void kernel_main() {
         struct Routed {
             // Mcast (sender)
             using McastCTArgs = deepseek_b1_ops::Mcast::SenderCTArgs<
-                get_named_compile_time_arg_val("mcast_num_cores"),
-                get_named_compile_time_arg_val("mcast_is_part_of_receiver_grid"),
+                get_named_compile_time_arg_val("moe_mcast_num_cores"),
+                get_named_compile_time_arg_val("moe_mcast_is_part_of_receiver_grid"),
                 Core::is_sender_core && Core::is_mcast_grid_core>;
             deepseek_b1_ops::Mcast::SenderArgs mcast_args{
-                get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
-                get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
-                get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
-                get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
-                get_named_compile_time_arg_val("mcast_data_sender_semaphore_addr"),
-                get_named_compile_time_arg_val("mcast_data_receiver_semaphore_addr"),
-                get_named_compile_time_arg_val("mcast_data_size_bytes"),
-                get_named_compile_time_arg_val("mcast_src_cb"),
-                get_named_compile_time_arg_val("mcast_src_num_pages"),
-                get_read_ptr(get_named_compile_time_arg_val("mcast_src_cb")),
-                get_write_ptr(get_named_compile_time_arg_val("mcast_dst_cb")),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_x"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_y"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_x"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_y"),
+                get_named_compile_time_arg_val("moe_mcast_data_sender_semaphore_addr"),
+                get_named_compile_time_arg_val("moe_mcast_data_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("moe_mcast_data_size_bytes"),
+                get_named_compile_time_arg_val("moe_mcast_src_cb"),
+                get_named_compile_time_arg_val("moe_mcast_src_num_pages"),
+                get_read_ptr(get_named_compile_time_arg_val("moe_mcast_src_cb")),
+                get_write_ptr(get_named_compile_time_arg_val("moe_mcast_dst_cb")),
             };
 
 #ifdef ENABLE_ROUTING
@@ -418,10 +418,10 @@ void kernel_main() {
 
             // Index Mcast (sender)
             deepseek_b1_ops::Mcast::SenderArgs index_mcast_args{
-                get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
-                get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
-                get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
-                get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_x"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_y"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_x"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_y"),
                 get_named_compile_time_arg_val("index_mcast_sender_semaphore_addr"),
                 get_named_compile_time_arg_val("index_mcast_receiver_semaphore_addr"),
                 get_named_compile_time_arg_val("index_mcast_data_size_bytes"),
@@ -433,10 +433,10 @@ void kernel_main() {
 
             // Expert Scale Mcast (sender)
             deepseek_b1_ops::Mcast::SenderArgs expert_scale_mcast_args{
-                get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
-                get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
-                get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
-                get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_x"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_y"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_x"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_y"),
                 get_named_compile_time_arg_val("expert_scale_mcast_sender_semaphore_addr"),
                 get_named_compile_time_arg_val("expert_scale_mcast_receiver_semaphore_addr"),
                 get_named_compile_time_arg_val("expert_scale_mcast_data_size_bytes"),
@@ -480,10 +480,10 @@ void kernel_main() {
 
             // down_proj Mcast (sender)
             deepseek_b1_ops::Mcast::SenderArgs down_proj_mcast_args{
-                get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
-                get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
-                get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
-                get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_x"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_y"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_x"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_y"),
                 get_named_compile_time_arg_val("down_proj_mcast_sender_semaphore_addr"),
                 get_named_compile_time_arg_val("down_proj_mcast_receiver_semaphore_addr"),
                 get_named_compile_time_arg_val("down_proj_mcast_data_size_bytes"),
@@ -502,10 +502,10 @@ void kernel_main() {
             // Residual Mcast — sender (input from sender → residual CB, pop_src=false)
             using ResidualMcastCTArgs = McastCTArgs;
             deepseek_b1_ops::Mcast::SenderArgs residual_mcast_args{
-                get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
-                get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
-                get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
-                get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_x"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_y"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_x"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_y"),
                 get_named_compile_time_arg_val("shared_residual_mcast_data_sender_semaphore_addr"),
                 get_named_compile_time_arg_val("shared_residual_mcast_data_receiver_semaphore_addr"),
                 get_named_compile_time_arg_val("shared_residual_mcast_data_size_bytes"),
@@ -590,10 +590,10 @@ void kernel_main() {
             // Down Mcast — sender (reuse Routed::McastCTArgs: same grid, same persistent sender)
             using DownMcastCTArgs = Routed::McastCTArgs;
             deepseek_b1_ops::Mcast::SenderArgs down_mcast_args{
-                get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
-                get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
-                get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
-                get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_x"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_y"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_x"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_y"),
                 get_named_compile_time_arg_val("shared_down_mcast_data_sender_semaphore_addr"),
                 get_named_compile_time_arg_val("shared_down_mcast_data_receiver_semaphore_addr"),
                 get_named_compile_time_arg_val("shared_down_mcast_data_size_bytes"),
@@ -631,10 +631,10 @@ void kernel_main() {
             // Output Mcast — sender (sender core → 130 cores)
             using OutputMcastCTArgs = Routed::McastCTArgs;
             deepseek_b1_ops::Mcast::SenderArgs output_mcast_args{
-                get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
-                get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
-                get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
-                get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_x"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_y"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_x"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_y"),
                 get_named_compile_time_arg_val("shared_output_mcast_data_sender_semaphore_addr"),
                 get_named_compile_time_arg_val("shared_output_mcast_data_receiver_semaphore_addr"),
                 get_named_compile_time_arg_val("shared_output_mcast_data_size_bytes"),
@@ -783,15 +783,16 @@ void kernel_main() {
             // RMSNorm (compute — sender core only)
             // Input: residual_mcast_src_cb (raw activation), Output: rmsnorm_output_cb
             using RMSNormCTArgs = deepseek_b1_ops::RMSNorm::ComputeCTArgs<
-                get_named_compile_time_arg_val("rmsnorm_fp32_acc") == 1,
-                get_named_compile_time_arg_val("rmsnorm_num_tiles"),
-                get_named_compile_time_arg_val("rmsnorm_rsqrt_fast_approx") == 1,
-                get_named_compile_time_arg_val("rmsnorm_input_cb"),  // residual_mcast_src_cb
-                get_named_compile_time_arg_val("rmsnorm_gamma_cb"),
-                get_named_compile_time_arg_val("rmsnorm_output_cb")>;  // rmsnorm_output_cb
+                get_named_compile_time_arg_val("moe_rmsnorm_fp32_acc") == 1,
+                get_named_compile_time_arg_val("moe_rmsnorm_num_tiles"),
+                get_named_compile_time_arg_val("moe_rmsnorm_rsqrt_fast_approx") == 1,
+                get_named_compile_time_arg_val("moe_rmsnorm_input_cb"),  // residual_mcast_src_cb
+                get_named_compile_time_arg_val("moe_rmsnorm_gamma_cb"),
+                get_named_compile_time_arg_val("moe_rmsnorm_output_cb")>;  // rmsnorm_output_cb
             deepseek_b1_ops::RMSNorm::ComputeArgs rmsnorm_args{
-                get_common_arg_val<uint32_t>(get_named_compile_time_arg_val("rmsnorm_trisc_common_rt_arg_base") + 0),
-                get_common_arg_val<float>(get_named_compile_time_arg_val("rmsnorm_trisc_common_rt_arg_base") + 1),
+                get_common_arg_val<uint32_t>(
+                    get_named_compile_time_arg_val("moe_rmsnorm_trisc_common_rt_arg_base") + 0),
+                get_common_arg_val<float>(get_named_compile_time_arg_val("moe_rmsnorm_trisc_common_rt_arg_base") + 1),
             };
 
 #ifdef ENABLE_REDUCE_TO_ONE

--- a/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
@@ -1474,11 +1474,11 @@ class MoeRoutedExpertOp:
 
         ncrisc_named_compile_time_args = [
             # Input mcast (sender sharded buffer + receiver)
-            ("mcast_src_cb", ctx.rmsnorm_mcast_params["src_cb"]),
-            ("mcast_src_num_pages", ctx.rmsnorm_mcast_params["src_num_pages"]),
-            ("mcast_data_receiver_semaphore_addr", ctx.rmsnorm_mcast_params["receiver_semaphore_addr"]),
-            ("mcast_dst_cb", ctx.rmsnorm_mcast_params["dst_cb"]),
-            ("mcast_dst_num_pages", ctx.rmsnorm_mcast_params["dst_num_pages"]),
+            ("moe_mcast_src_cb", ctx.rmsnorm_mcast_params["src_cb"]),
+            ("moe_mcast_src_num_pages", ctx.rmsnorm_mcast_params["src_num_pages"]),
+            ("moe_mcast_data_receiver_semaphore_addr", ctx.rmsnorm_mcast_params["receiver_semaphore_addr"]),
+            ("moe_mcast_dst_cb", ctx.rmsnorm_mcast_params["dst_cb"]),
+            ("moe_mcast_dst_num_pages", ctx.rmsnorm_mcast_params["dst_num_pages"]),
             # Residual mcast source (setup_sharded_buffer on sender core)
             ("shared_residual_mcast_src_cb", ctx.residual_mcast_params["src_cb"]),
             ("shared_residual_mcast_src_num_pages", ctx.residual_mcast_params["src_num_pages"]),
@@ -1487,8 +1487,8 @@ class MoeRoutedExpertOp:
             ("shared_residual_cb", ctx.residual_mcast_dst_cb),
             ("shared_residual_num_pages", ctx.residual_mcast_params["dst_num_pages"]),
             # RMSNorm (setup_sharded_buffer for gamma on sender core)
-            ("rmsnorm_gamma_cb", ctx.rmsnorm_gamma_cb),
-            ("rmsnorm_gamma_num_pages", ctx.rmsnorm_gamma_num_pages),
+            ("moe_rmsnorm_gamma_cb", ctx.rmsnorm_gamma_cb),
+            ("moe_rmsnorm_gamma_num_pages", ctx.rmsnorm_gamma_num_pages),
             # Gate matmul reader (routing only — 0 when disabled)
             ("gate_mm_in0", ctx.gate_mm_params["in0_cb"] if ctx.enable_routing else 0),
             ("gate_mm_in1", ctx.gate_mm_params["in1_cb"] if ctx.enable_routing else 0),
@@ -1598,18 +1598,18 @@ class MoeRoutedExpertOp:
 
         brisc_named_compile_time_args = [
             # Input mcast sender
-            ("mcast_dest_noc_start_x", ctx.rmsnorm_mcast_params["dest_noc_start_x"]),
-            ("mcast_dest_noc_start_y", ctx.rmsnorm_mcast_params["dest_noc_start_y"]),
-            ("mcast_dest_noc_end_x", ctx.rmsnorm_mcast_params["dest_noc_end_x"]),
-            ("mcast_dest_noc_end_y", ctx.rmsnorm_mcast_params["dest_noc_end_y"]),
-            ("mcast_num_cores", ctx.rmsnorm_mcast_params["num_cores"]),
-            ("mcast_data_sender_semaphore_addr", ctx.rmsnorm_mcast_params["sender_semaphore_addr"]),
-            ("mcast_data_receiver_semaphore_addr", ctx.rmsnorm_mcast_params["receiver_semaphore_addr"]),
-            ("mcast_data_size_bytes", ctx.rmsnorm_mcast_params["data_size_bytes"]),
-            ("mcast_src_cb", ctx.rmsnorm_mcast_params["src_cb"]),
-            ("mcast_dst_cb", ctx.rmsnorm_mcast_params["dst_cb"]),
-            ("mcast_src_num_pages", ctx.rmsnorm_mcast_params["src_num_pages"]),
-            ("mcast_is_part_of_receiver_grid", ctx.rmsnorm_mcast_params["is_sender_part_of_receiver_grid"]),
+            ("moe_mcast_dest_noc_start_x", ctx.rmsnorm_mcast_params["dest_noc_start_x"]),
+            ("moe_mcast_dest_noc_start_y", ctx.rmsnorm_mcast_params["dest_noc_start_y"]),
+            ("moe_mcast_dest_noc_end_x", ctx.rmsnorm_mcast_params["dest_noc_end_x"]),
+            ("moe_mcast_dest_noc_end_y", ctx.rmsnorm_mcast_params["dest_noc_end_y"]),
+            ("moe_mcast_num_cores", ctx.rmsnorm_mcast_params["num_cores"]),
+            ("moe_mcast_data_sender_semaphore_addr", ctx.rmsnorm_mcast_params["sender_semaphore_addr"]),
+            ("moe_mcast_data_receiver_semaphore_addr", ctx.rmsnorm_mcast_params["receiver_semaphore_addr"]),
+            ("moe_mcast_data_size_bytes", ctx.rmsnorm_mcast_params["data_size_bytes"]),
+            ("moe_mcast_src_cb", ctx.rmsnorm_mcast_params["src_cb"]),
+            ("moe_mcast_dst_cb", ctx.rmsnorm_mcast_params["dst_cb"]),
+            ("moe_mcast_src_num_pages", ctx.rmsnorm_mcast_params["src_num_pages"]),
+            ("moe_mcast_is_part_of_receiver_grid", ctx.rmsnorm_mcast_params["is_sender_part_of_receiver_grid"]),
             # Residual mcast sender (input from sender → residual CB on mcast grid)
             ("shared_residual_mcast_data_sender_semaphore_addr", ctx.mcast_data_sender_semaphore_addr),
             ("shared_residual_mcast_data_receiver_semaphore_addr", ctx.residual_mcast_receiver_semaphore_addr),
@@ -1695,13 +1695,13 @@ class MoeRoutedExpertOp:
 
         trisc_named_compile_time_args = [
             # RMSNorm compute (sender core only)
-            ("rmsnorm_input_cb", ctx.residual_mcast_src_cb),
-            ("rmsnorm_gamma_cb", ctx.rmsnorm_gamma_cb),
-            ("rmsnorm_output_cb", ctx.rmsnorm_output_cb),
-            ("rmsnorm_fp32_acc", 0),
-            ("rmsnorm_num_tiles", ctx.rmsnorm_num_tiles),
-            ("rmsnorm_rsqrt_fast_approx", 0),
-            ("rmsnorm_trisc_common_rt_arg_base", 0),
+            ("moe_rmsnorm_input_cb", ctx.residual_mcast_src_cb),
+            ("moe_rmsnorm_gamma_cb", ctx.rmsnorm_gamma_cb),
+            ("moe_rmsnorm_output_cb", ctx.rmsnorm_output_cb),
+            ("moe_rmsnorm_fp32_acc", 0),
+            ("moe_rmsnorm_num_tiles", ctx.rmsnorm_num_tiles),
+            ("moe_rmsnorm_rsqrt_fast_approx", 0),
+            ("moe_rmsnorm_trisc_common_rt_arg_base", 0),
             # Gate matmul compute (routing only — 0 when disabled)
             ("gate_mm_in0", ctx.gate_mm_params["in0_cb"] if ctx.enable_routing else 0),
             ("gate_mm_in1", ctx.gate_mm_params["in1_cb"] if ctx.enable_routing else 0),


### PR DESCRIPTION
- Right now a lot of the names are shared. This will cause issues while merging two into the decoder block.