### PR TITLE
[qsr]: removing unpack namespace and defines from trisc3

### DIFF
--- a/tt_metal/llrt/hal/tt-2xx/hal_2xx_common.cpp
+++ b/tt_metal/llrt/hal/tt-2xx/hal_2xx_common.cpp
@@ -53,8 +53,6 @@ std::vector<std::string> HalJitBuildQueryBase::defines(const HalJitBuildQueryInt
                         case experimental::quasar::QuasarComputeProcessor::NEO_1_COMPUTE_3:
                         case experimental::quasar::QuasarComputeProcessor::NEO_2_COMPUTE_3:
                         case experimental::quasar::QuasarComputeProcessor::NEO_3_COMPUTE_3:
-                            defines.push_back("UCK_CHLKC_UNPACK");
-                            defines.push_back("NAMESPACE=chlkc_unpack");
                             break;
                         default: TT_THROW("Invalid processor id {}", params.processor_id);
                     }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/38044

### Problem description
DFB integration was suspected to cause multi-tile datacopy test to mismatch but issue was that trisc3 was running same code as unpacker 

### Checklist

- [ ] New/Existing tests provide coverage for changes (tests running locally for Quasar) 
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early
