### PR TITLE
feat(deepseek_b1): Support single-shot L tensor transfer in SDPA reduce-to-all

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/kernels/post_sdpa_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/kernels/post_sdpa_kernel.cpp
@@ -324,7 +324,12 @@ void kernel_main() {
                 get_named_compile_time_arg_val("sdpa_num_l_chunks"),
                 get_named_compile_time_arg_val("sdpa_tiles_per_l_chunk"),
                 get_named_compile_time_arg_val("sdpa_position_enabled"),
-                get_named_compile_time_arg_val("sdpa_per_device_chunk_size")>;
+                get_named_compile_time_arg_val("sdpa_per_device_chunk_size"),
+                get_named_compile_time_arg_val("sdpa_single_shot_l")>;
+
+            // Dummy WriterCT and ComputeCT - not used by NCRISC but needed for Op template
+            using WriterCTArgs = Worker::WriterCTArgs<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>;
+            using ComputeCTArgs = Worker::ComputeCTArgs<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>;
 
             uint32_t per_core_rta_arg_idx = 0;
             Worker::ReaderArgs reader_args{
@@ -333,10 +338,13 @@ void kernel_main() {
                 .r1_recv_buffer_addr = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
                 .r2_recv_buffer_addr = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
             };
-            Worker::Op<ReaderCTArgs> sdpa_worker;
+            Worker::Op<ReaderCTArgs, WriterCTArgs, ComputeCTArgs> sdpa_worker;
             sdpa_worker(reader_args);
 
 #elif defined(COMPILE_FOR_BRISC)
+            // Dummy ReaderCT and ComputeCT - not used by BRISC but needed for Op template
+            using ReaderCTArgs = Worker::ReaderCTArgs<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>;
+
             using WriterCTArgs = Worker::WriterCTArgs<
                 get_named_compile_time_arg_val("sdpa_cb_local_l"),
                 get_named_compile_time_arg_val("sdpa_cb_local_ms"),
@@ -350,6 +358,7 @@ void kernel_main() {
                 get_named_compile_time_arg_val("sdpa_l_chunk_size_bytes"),
                 get_named_compile_time_arg_val("sdpa_num_l_chunks"),
                 get_named_compile_time_arg_val("sdpa_tiles_per_l_chunk"),
+                get_named_compile_time_arg_val("sdpa_single_shot_l"),
                 get_named_compile_time_arg_val("sdpa_cb_l_out"),
                 get_named_compile_time_arg_val("sdpa_scatter_num_tiles"),
                 get_named_compile_time_arg_val("sdpa_scatter_src_tile_size"),
@@ -358,6 +367,8 @@ void kernel_main() {
                 get_named_compile_time_arg_val("sdpa_scatter_row_face_size"),
                 get_named_compile_time_arg_val("sdpa_scatter_num_rows"),
                 1>;  // scatter_arrival_enabled=1 (signal matmul4 cores after each scatter row)
+
+            using ComputeCTArgs = Worker::ComputeCTArgs<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>;
 
             uint32_t per_core_rta_arg_idx = 0;
             Worker::WriterArgs writer_args{
@@ -385,10 +396,14 @@ void kernel_main() {
                 .scatter_arrival_sem_addr =
                     get_semaphore(get_named_compile_time_arg_val("scatter_arrival_semaphore_id")),
             };
-            Worker::Op<WriterCTArgs> sdpa_worker;
+            Worker::Op<ReaderCTArgs, WriterCTArgs, ComputeCTArgs> sdpa_worker;
             sdpa_worker(writer_args);
 
 #elif defined(COMPILE_FOR_TRISC)
+            // Dummy ReaderCT and WriterCT - not used by TRISC but needed for Op template
+            using ReaderCTArgs = Worker::ReaderCTArgs<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>;
+            using WriterCTArgs = Worker::WriterCTArgs<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>;
+
             using ComputeCTArgs = Worker::ComputeCTArgs<
                 get_named_compile_time_arg_val("sdpa_cb_local_l"),
                 get_named_compile_time_arg_val("sdpa_cb_local_ms"),
@@ -409,7 +424,7 @@ void kernel_main() {
 
             // Note: compute_kernel_hw_startup already called at top of TRISC block
             Worker::ComputeArgs compute_args{};
-            Worker::Op<ComputeCTArgs> sdpa_worker;
+            Worker::Op<ReaderCTArgs, WriterCTArgs, ComputeCTArgs> sdpa_worker;
             sdpa_worker(compute_args);
 #endif
         }

--- a/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/op.py
@@ -297,6 +297,11 @@ class PostSDPA:
 
             sdpa_tiles_per_l_chunk = sdpa_out_tiles // sdpa_num_l_chunks
             sdpa_l_chunk_size_bytes = sdpa_tiles_per_l_chunk * sdpa_input_page_size_bytes
+            sdpa_total_l_bytes = sdpa_out_tiles * sdpa_input_page_size_bytes
+
+            # Determine transfer mode: single-shot if full L fits in one fabric packet
+            max_fabric_payload_size = ttnn.get_tt_fabric_max_payload_size_bytes()
+            sdpa_single_shot_l = sdpa_total_l_bytes <= max_fabric_payload_size
 
             # Alias for backward compatibility with CB descriptor code
             sdpa_l_tiles_per_worker = sdpa_out_tiles
@@ -335,11 +340,16 @@ class PostSDPA:
             sdpa_num_forwarders = 2
             sdpa_workers_per_forwarder = sdpa_num_workers // sdpa_num_forwarders  # 4
             sdpa_workers_per_type = sdpa_workers_per_forwarder // 2  # 2 (Type A and Type B alternate)
-            sdpa_slots_per_worker = 1 + sdpa_num_l_chunks  # MS + L chunks = 5 slots
-            sdpa_fwd_slots_per_round = sdpa_workers_per_type * sdpa_slots_per_worker  # 2 * 5 = 10 slots per direction
-            sdpa_fwd_slot_size = (
-                ttnn.get_tt_fabric_packet_header_size_bytes() + sdpa_l_chunk_size_bytes
-            )  # Header + max payload
+            if sdpa_single_shot_l:
+                sdpa_slots_per_worker = 2  # MS + full L = 2 slots
+                sdpa_max_payload_per_slot = sdpa_total_l_bytes
+            else:
+                sdpa_slots_per_worker = 1 + sdpa_num_l_chunks  # MS + L chunks = 5 slots
+                sdpa_max_payload_per_slot = sdpa_l_chunk_size_bytes
+            sdpa_fwd_slots_per_round = sdpa_workers_per_type * sdpa_slots_per_worker
+            sdpa_fwd_slot_size = _round_up(
+                ttnn.get_tt_fabric_packet_header_size_bytes() + sdpa_max_payload_per_slot, sdpa_l1_alignment
+            )
             sdpa_fwd_r2_buffer_offset = sdpa_fwd_slots_per_round * sdpa_fwd_slot_size
 
             # SDPA semaphore ID for scatter arrival (new semaphore)
@@ -586,6 +596,8 @@ class PostSDPA:
                             # SDPA position
                             ("sdpa_position_enabled", 1 if sdpa_position_enabled else 0),
                             ("sdpa_per_device_chunk_size", sdpa_per_device_chunk_size),
+                            # SDPA transfer mode
+                            ("sdpa_single_shot_l", 1 if sdpa_single_shot_l else 0),
                             # SDPA forwarder params
                             ("sdpa_fwd_slots_per_round", sdpa_fwd_slots_per_round),
                             ("sdpa_fwd_slot_size", sdpa_fwd_slot_size),
@@ -664,6 +676,8 @@ class PostSDPA:
                             ("sdpa_l_chunk_size_bytes", sdpa_l_chunk_size_bytes),
                             ("sdpa_num_l_chunks", sdpa_num_l_chunks),
                             ("sdpa_tiles_per_l_chunk", sdpa_tiles_per_l_chunk),
+                            # SDPA transfer mode
+                            ("sdpa_single_shot_l", 1 if sdpa_single_shot_l else 0),
                             ("sdpa_l1_alignment", l1_alignment),
                             ("sdpa_page_size_bytes", sdpa_l_tile_size),
                             ("sdpa_slot_size", sdpa_fwd_slot_size),

--- a/models/demos/deepseek_v3_b1/micro_ops/sdpa_reduce_to_all/kernels/sdpa_reduce_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/sdpa_reduce_to_all/kernels/sdpa_reduce_kernel.cpp
@@ -44,10 +44,11 @@ void kernel_main() {
             get_named_compile_time_arg_val("num_l_chunks"),
             get_named_compile_time_arg_val("tiles_per_l_chunk"),
             get_named_compile_time_arg_val("position_enabled"),
-            get_named_compile_time_arg_val("per_device_chunk_size")>;
+            get_named_compile_time_arg_val("per_device_chunk_size"),
+            get_named_compile_time_arg_val("single_shot_l")>;
 
         // Dummy WriterCT and ComputeCT - not used by NCRISC but needed for Op template
-        using WriterCTArgs = Worker::WriterCTArgs<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>;
+        using WriterCTArgs = Worker::WriterCTArgs<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>;
         using ComputeCTArgs = Worker::ComputeCTArgs<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>;
 
         uint32_t per_core_rta_arg_idx = 0;
@@ -86,7 +87,7 @@ void kernel_main() {
         using Worker = deepseek_b1_ops::SdpaReduceWorker;
 
         // Dummy ReaderCT and ComputeCT - not used by BRISC but needed for Op template
-        using ReaderCTArgs = Worker::ReaderCTArgs<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>;
+        using ReaderCTArgs = Worker::ReaderCTArgs<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>;
 
         using WriterCTArgs = Worker::WriterCTArgs<
             get_named_compile_time_arg_val("cb_local_l"),
@@ -101,6 +102,7 @@ void kernel_main() {
             get_named_compile_time_arg_val("l_chunk_size_bytes"),
             get_named_compile_time_arg_val("num_l_chunks"),
             get_named_compile_time_arg_val("tiles_per_l_chunk"),
+            get_named_compile_time_arg_val("single_shot_l"),
             get_named_compile_time_arg_val("cb_l_out"),
             get_named_compile_time_arg_val("scatter_num_tiles"),
             get_named_compile_time_arg_val("scatter_src_tile_size"),
@@ -165,8 +167,8 @@ void kernel_main() {
         using Worker = deepseek_b1_ops::SdpaReduceWorker;
 
         // Dummy ReaderCT and WriterCT - not used by TRISC but needed for Op template
-        using ReaderCTArgs = Worker::ReaderCTArgs<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>;
-        using WriterCTArgs = Worker::WriterCTArgs<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>;
+        using ReaderCTArgs = Worker::ReaderCTArgs<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>;
+        using WriterCTArgs = Worker::WriterCTArgs<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>;
 
         using ComputeCTArgs = Worker::ComputeCTArgs<
             get_named_compile_time_arg_val("cb_local_l"),

--- a/models/demos/deepseek_v3_b1/micro_ops/sdpa_reduce_to_all/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/sdpa_reduce_to_all/op.py
@@ -277,18 +277,27 @@ class SdpaReduceToAll:
                 tiles_per_l_chunk = out_tiles // num_l_chunks
                 l_chunk_size_bytes = tiles_per_l_chunk * input_page_size_bytes
                 ms_tile_size_bytes = aligned_page_size
+                total_l_bytes = out_tiles * input_page_size_bytes
 
-                if l_chunk_size_bytes > max_fabric_payload_size:
-                    raise ValueError("L chunk payload exceeds fabric max payload size")
+                # Determine transfer mode: single-shot if full L fits in one packet
+                single_shot_l = total_l_bytes <= max_fabric_payload_size
 
-                # Slots are sized for the largest payload (L chunk); MS uses slot 0.
+                if single_shot_l:
+                    max_payload_per_slot = total_l_bytes
+                else:
+                    max_payload_per_slot = l_chunk_size_bytes
+                    if l_chunk_size_bytes > max_fabric_payload_size:
+                        raise ValueError("L chunk payload exceeds fabric max payload size")
+
+                # Slots are sized for the largest payload; MS uses slot 0.
                 header_cb_size = _round_up(packet_header_size_bytes, l1_alignment)
-                slot_size = _round_up(packet_header_size_bytes + l_chunk_size_bytes, l1_alignment)
+                slot_size = _round_up(packet_header_size_bytes + max_payload_per_slot, l1_alignment)
 
                 num_links = 2
                 num_workers_per_link = num_shard_cores // num_links
                 workers_per_type = num_workers_per_link // 2
-                slots_per_worker = 1 + num_l_chunks
+                # Single-shot: 2 slots (MS + full_L). Chunked: 1 + num_l_chunks slots.
+                slots_per_worker = 2 if single_shot_l else (1 + num_l_chunks)
                 # Bit-packed forwarder semaphores support up to 32 slots per round.
                 slots_per_round = workers_per_type * slots_per_worker
 
@@ -351,6 +360,7 @@ class SdpaReduceToAll:
                     ("tiles_per_l_chunk", tiles_per_l_chunk),
                     ("position_enabled", 1 if position_enabled else 0),
                     ("per_device_chunk_size", per_device_chunk_size),
+                    ("single_shot_l", 1 if single_shot_l else 0),
                 ]
 
                 writer_named_ct_args = [
@@ -366,6 +376,7 @@ class SdpaReduceToAll:
                     ("l_chunk_size_bytes", l_chunk_size_bytes),
                     ("num_l_chunks", num_l_chunks),
                     ("tiles_per_l_chunk", tiles_per_l_chunk),
+                    ("single_shot_l", 1 if single_shot_l else 0),
                     ("cb_l_out", cb_l_out),
                     ("scatter_num_tiles", scatter_ct_num_tiles),
                     ("scatter_src_tile_size", scatter_ct_src_tile_size),

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_post_sdpa.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_post_sdpa.py
@@ -69,11 +69,14 @@ def compute_forwarder_scratch_size(
     tile_width: int = 32,
     bytes_per_element: int = 2,
     num_links: int = 2,
+    max_payload_size: int = 0,
 ):
     """
     Compute the total forwarder scratch buffer size in bytes for SDPA reduce-to-all.
 
     This matches the calculation in sdpa_reduce_to_all/op.py for proper L1 allocation.
+    Supports both single-shot L transfer (when total_l_bytes fits in max_payload_size)
+    and chunked streaming.
     """
     input_page_size_bytes = tile_height * tile_width * bytes_per_element
     input_l_num_pages = (batch_size // tile_height) * (l_width // tile_width)
@@ -92,14 +95,29 @@ def compute_forwarder_scratch_size(
 
     tiles_per_l_chunk = out_tiles // num_l_chunks
     l_chunk_size_bytes = tiles_per_l_chunk * input_page_size_bytes
+    total_l_bytes = out_tiles * input_page_size_bytes
+
+    # Determine transfer mode: single-shot if full L fits in one fabric packet
+    if max_payload_size > 0:
+        max_fabric_payload = max_payload_size - ttnn.get_tt_fabric_packet_header_size_bytes()
+    else:
+        max_fabric_payload = ttnn.get_tt_fabric_max_payload_size_bytes()
+    single_shot_l = total_l_bytes <= max_fabric_payload
 
     header_size = ttnn.get_tt_fabric_packet_header_size_bytes()
     l1_alignment = 16
-    slot_size = _round_up(header_size + l_chunk_size_bytes, l1_alignment)
+
+    if single_shot_l:
+        slots_per_worker = 2  # MS + full L
+        max_payload_per_slot = total_l_bytes
+    else:
+        slots_per_worker = 1 + num_l_chunks  # MS + L chunks
+        max_payload_per_slot = l_chunk_size_bytes
+
+    slot_size = _round_up(header_size + max_payload_per_slot, l1_alignment)
 
     num_workers_per_link = num_cores // num_links
     workers_per_type = num_workers_per_link // 2
-    slots_per_worker = 1 + num_l_chunks
     slots_per_round = workers_per_type * slots_per_worker
 
     return 2 * slots_per_round * slot_size * 2
@@ -1050,6 +1068,7 @@ def test_post_sdpa_with_sdpa_phase(
         batch_size=SDPA_L_HEIGHT,
         l_width=sdpa_l_per_worker,
         num_cores=NUM_SDPA_WORKERS,
+        max_payload_size=15232,
     )
     # Total elements (bfloat16 = 2 bytes per element)
     sdpa_fwd_total_elements = sdpa_fwd_buffer_bytes // 2

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_sdpa_reduce_to_all.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_sdpa_reduce_to_all.py
@@ -16,10 +16,18 @@ def _round_up(value: int, alignment: int) -> int:
     return ((value + alignment - 1) // alignment) * alignment
 
 
+def create_fabric_router_config(max_payload_size):
+    """Helper to create FabricRouterConfig with custom max payload size."""
+    config = ttnn._ttnn.fabric.FabricRouterConfig()
+    config.max_packet_payload_size_bytes = max_payload_size
+    return config
+
+
 def compute_forwarder_scratch_size(
     batch_size: int,
     l_width: int,
     num_cores: int,
+    max_payload_size: int = 0,
     tile_height: int = 8,
     tile_width: int = 32,
     bytes_per_element: int = 2,
@@ -42,14 +50,27 @@ def compute_forwarder_scratch_size(
 
     tiles_per_l_chunk = out_tiles // num_l_chunks
     l_chunk_size_bytes = tiles_per_l_chunk * input_page_size_bytes
+    total_l_bytes = out_tiles * input_page_size_bytes
+
+    # Use runtime max_fabric_payload_size if max_payload_size not specified
+    if max_payload_size <= 0:
+        max_payload_size = ttnn.get_tt_fabric_max_payload_size_bytes()
+
+    single_shot_l = total_l_bytes <= max_payload_size
+
+    if single_shot_l:
+        max_payload_per_slot = total_l_bytes
+        slots_per_worker = 2
+    else:
+        max_payload_per_slot = l_chunk_size_bytes
+        slots_per_worker = 1 + num_l_chunks
 
     header_size = ttnn.get_tt_fabric_packet_header_size_bytes()
     l1_alignment = 16
-    slot_size = _round_up(header_size + l_chunk_size_bytes, l1_alignment)
+    slot_size = _round_up(header_size + max_payload_per_slot, l1_alignment)
 
     num_workers_per_link = num_cores // num_links
     workers_per_type = num_workers_per_link // 2
-    slots_per_worker = 1 + num_l_chunks
     slots_per_round = workers_per_type * slots_per_worker
 
     return 2 * slots_per_round * slot_size * 2
@@ -57,13 +78,27 @@ def compute_forwarder_scratch_size(
 
 @skip_for_wormhole_b0("This test is for blackhole")
 @pytest.mark.parametrize(
-    "device_params",
-    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D_TORUS_X}],
+    "device_params, max_payload_size",
+    [
+        pytest.param(
+            {"fabric_config": ttnn.FabricConfig.FABRIC_2D_TORUS_X},
+            0,
+            id="default_chunked",
+        ),
+        pytest.param(
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_2D_TORUS_X,
+                "fabric_router_config": create_fabric_router_config(15232),
+            },
+            15232,
+            id="single_shot_15232",
+        ),
+    ],
     indirect=["device_params"],
 )
 @pytest.mark.parametrize("scatter_enabled", [False, True], ids=["reduce_only", "reduce_and_scatter"])
 @pytest.mark.parametrize("position_id", [500, 1500, 2500, 3500], ids=["pos500", "pos1500", "pos2500", "pos3500"])
-def test_sdpa_reduce_to_all(bh_2d_mesh_device, scatter_enabled, position_id):
+def test_sdpa_reduce_to_all(bh_2d_mesh_device, scatter_enabled, position_id, max_payload_size):
     num_devices = 4
     num_cores = 8
     l_width = 512
@@ -205,7 +240,13 @@ def test_sdpa_reduce_to_all(bh_2d_mesh_device, scatter_enabled, position_id):
     # Per-core scratch size (covers BRISC + NCRISC regions).
     # The shard is split across forwarder cores; each core gets the full per-core size.
     forwarder_buffer_size_bytes = compute_forwarder_scratch_size(
-        batch_size=batch_size, l_width=l_width, num_cores=num_cores, tile_height=8, tile_width=32, bytes_per_element=2
+        batch_size=batch_size,
+        l_width=l_width,
+        num_cores=num_cores,
+        max_payload_size=max_payload_size,
+        tile_height=8,
+        tile_width=32,
+        bytes_per_element=2,
     )
 
     num_forwarder_cores = 2

--- a/models/demos/deepseek_v3_b1/unified_kernels/sdpa_reduce_worker.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/sdpa_reduce_worker.hpp
@@ -86,6 +86,10 @@ struct SdpaRoundConfig {
 /**
  * Packet sender with cached core coordinates and round configuration.
  * Template parameters encode size constants for zero-overhead abstraction.
+ *
+ * When single_shot_l is true, the entire L tensor is sent as a single packet
+ * (slot layout: MS=0, L=1). Otherwise, L is sent in num_l_chunks chunks
+ * (slot layout: MS=0, L_chunk_0=1, L_chunk_1=2, ...).
  */
 template <
     uint32_t cb_packet_slot,
@@ -94,7 +98,8 @@ template <
     uint32_t ms_tile_size_bytes,
     uint32_t l_chunk_size_bytes,
     uint32_t num_l_chunks,
-    uint32_t tiles_per_l_chunk>
+    uint32_t tiles_per_l_chunk,
+    bool single_shot_l>
 struct SdpaChunkSender {
     // Core coordinates (constant across rounds)
     uint32_t current_core_x;
@@ -114,6 +119,7 @@ struct SdpaChunkSender {
 
     // Derived constants
     static constexpr uint32_t total_l_bytes = num_l_chunks * l_chunk_size_bytes;
+    static constexpr uint32_t out_tiles = num_l_chunks * tiles_per_l_chunk;
     static constexpr size_t packet_header_size_bytes = sizeof(PACKET_HEADER_TYPE);
 
     // Slot indices: MS = slot 0, L_chunk_i = slot (1 + i)
@@ -182,6 +188,14 @@ struct SdpaChunkSender {
         send_packet(fabric_dest, fwd_dest, get_read_ptr(cfg.cb_ms), ms_tile_size_bytes);
     }
 
+    FORCE_INLINE void send_full_l() const {
+        uint32_t dst_addr = cfg.dst_base_addr;
+        uint32_t src_addr = get_read_ptr(cfg.cb_l);
+        auto fabric_dest = get_fabric_dest(dst_addr);
+        auto fwd_dest = get_forwarder_dest<false>(0);
+        send_packet(fabric_dest, fwd_dest, src_addr, total_l_bytes);
+    }
+
     FORCE_INLINE void send_l_chunk(uint32_t l_chunk_idx) const {
         uint32_t dst_addr = cfg.dst_base_addr + l_chunk_idx * l_chunk_size_bytes;
         uint32_t src_addr = get_read_ptr(cfg.cb_l) + l_chunk_idx * l_chunk_size_bytes;
@@ -192,8 +206,12 @@ struct SdpaChunkSender {
 
     FORCE_INLINE void send_all() const {
         send_ms();
-        for (uint32_t i = 0; i < num_l_chunks; i++) {
-            send_l_chunk(i);
+        if constexpr (single_shot_l) {
+            send_full_l();
+        } else {
+            for (uint32_t i = 0; i < num_l_chunks; i++) {
+                send_l_chunk(i);
+            }
         }
     }
 
@@ -201,9 +219,14 @@ struct SdpaChunkSender {
         cb_wait_front(cfg.cb_ms, 1);
         send_ms();
 
-        for (uint32_t i = 0; i < num_l_chunks; i++) {
-            cb_wait_front(cfg.cb_l, (i + 1) * tiles_per_l_chunk);
-            send_l_chunk(i);
+        if constexpr (single_shot_l) {
+            cb_wait_front(cfg.cb_l, out_tiles);
+            send_full_l();
+        } else {
+            for (uint32_t i = 0; i < num_l_chunks; i++) {
+                cb_wait_front(cfg.cb_l, (i + 1) * tiles_per_l_chunk);
+                send_l_chunk(i);
+            }
         }
     }
 };
@@ -407,7 +430,8 @@ struct SdpaReduceWorker {
         uint32_t numLChunks,
         uint32_t tilesPerLChunk,
         uint32_t positionEnabled,
-        uint32_t perDeviceChunkSize>
+        uint32_t perDeviceChunkSize,
+        uint32_t singleShotL>
     struct ReaderCTArgs {
         static constexpr uint32_t cb_local_l = cbLocalL;
         static constexpr uint32_t cb_local_ms = cbLocalMs;
@@ -421,10 +445,14 @@ struct SdpaReduceWorker {
         static constexpr uint32_t tiles_per_l_chunk = tilesPerLChunk;
         static constexpr uint32_t position_enabled = positionEnabled;
         static constexpr uint32_t per_device_chunk_size = perDeviceChunkSize;
+        static constexpr bool single_shot_l = singleShotL != 0;
         // Derived constants
         static constexpr uint32_t out_tiles = numLChunks * tilesPerLChunk;
         static constexpr uint32_t total_l_bytes = numLChunks * lChunkSizeBytes;
         static constexpr uint32_t MS_SEM_THRESHOLD = 1;
+        // Single-shot: one signal at threshold 2 for full L.
+        // Chunked: incremental signals starting at base threshold 2 (2, 3, 4, ...).
+        static constexpr uint32_t L_SEM_THRESHOLD = 2;
         static constexpr uint32_t L_SEM_BASE_THRESHOLD = 2;
     };
 
@@ -442,6 +470,7 @@ struct SdpaReduceWorker {
         uint32_t lChunkSizeBytes,
         uint32_t numLChunks,
         uint32_t tilesPerLChunk,
+        uint32_t singleShotL,
         uint32_t cbLOut,
         uint32_t scatterNumTiles,
         uint32_t scatterSrcTileSize,
@@ -463,6 +492,7 @@ struct SdpaReduceWorker {
         static constexpr uint32_t l_chunk_size_bytes = lChunkSizeBytes;
         static constexpr uint32_t num_l_chunks = numLChunks;
         static constexpr uint32_t tiles_per_l_chunk = tilesPerLChunk;
+        static constexpr bool single_shot_l = singleShotL != 0;
         static constexpr uint32_t cb_l_out = cbLOut;
         static constexpr uint32_t scatter_num_tiles = scatterNumTiles;
         static constexpr uint32_t scatter_src_tile_size = scatterSrcTileSize;
@@ -559,8 +589,10 @@ struct SdpaReduceWorker {
     // ========================================================================
     // Op - unified worker operation
     // ========================================================================
-    template <typename CTArgs>
+    template <typename ReaderCTArgsT, typename WriterCTArgsT, typename ComputeCTArgsT>
     class Op {
+        using CTArgs = unified_kernels::SelectByRISCV<ReaderCTArgsT, WriterCTArgsT, ComputeCTArgsT>;
+
     public:
         void operator()([[maybe_unused]] const RTArgs& args) {
 #if defined(COMPILE_FOR_NCRISC)
@@ -597,8 +629,16 @@ struct SdpaReduceWorker {
             uint32_t cb_l, uint32_t cb_ms, uint32_t sem_addr, uint32_t recv_buffer_addr) {
             volatile tt_l1_ptr uint32_t* sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sem_addr);
             prepare_ms_for_compute(cb_ms, sem_ptr, recv_buffer_addr);
-            for (uint32_t i = 0; i < CTArgs::num_l_chunks; i++) {
-                prepare_l_chunk_for_compute(cb_l, sem_ptr, i);
+            if constexpr (CTArgs::single_shot_l) {
+                // Single-shot: wait for one L signal, push all tiles at once
+                cb_reserve_back(cb_l, CTArgs::out_tiles);
+                noc_semaphore_wait_min(sem_ptr, CTArgs::L_SEM_THRESHOLD);
+                cb_push_back(cb_l, CTArgs::out_tiles);
+            } else {
+                // Chunked: wait for each L chunk incrementally
+                for (uint32_t i = 0; i < CTArgs::num_l_chunks; i++) {
+                    prepare_l_chunk_for_compute(cb_l, sem_ptr, i);
+                }
             }
             noc_semaphore_set(sem_ptr, 0);
         }
@@ -671,7 +711,8 @@ struct SdpaReduceWorker {
                 CTArgs::ms_tile_size_bytes,
                 CTArgs::l_chunk_size_bytes,
                 CTArgs::num_l_chunks,
-                CTArgs::tiles_per_l_chunk>;
+                CTArgs::tiles_per_l_chunk,
+                CTArgs::single_shot_l>;
 
             // Initialize sender with core coordinates
             Sender sender{args.current_core_x, args.current_core_y, args.fwd_core_x, args.fwd_core_y};


### PR DESCRIPTION
## Summary

Add dynamic mode selection for L tensor transfer in the SDPA reduce-to-all operation. When the total L tensor size fits within a single fabric packet (`max_payload_size`), the entire L tensor is sent as one packet instead of being chunked into multiple smaller packets. This reduces fabric overhead for configurations with large max packet sizes (e.g., 15232 bytes).

## Changes

### Core Implementation
- **`sdpa_reduce_worker.hpp`**: Add `single_shot_l` template parameter to `ReaderCTArgs`, `WriterCTArgs`, and `SdpaChunkSender`. Add `send_full_l()` method for single-packet L transfer. Update `Op` template to accept all three CTArgs types with `SelectByRISCV` dispatch.

### Micro Op (standalone SDPA reduce-to-all)
- **`micro_ops/sdpa_reduce_to_all/op.py`**: Dynamic mode selection based on `total_l_bytes` vs `max_fabric_payload_size`. Adjusts slot count (2 for single-shot, 1+num_chunks for chunked) and slot sizing.
- **`micro_ops/sdpa_reduce_to_all/kernels/sdpa_reduce_kernel.cpp`**: Pass `single_shot_l` CT arg and use 3-arg Op template instantiation.

### Fused Op (PostSDPA)
- **`fused_ops/post_sdpa/op.py`**: Same dynamic mode selection for the fused PostSDPA op, passing `sdpa_single_shot_l` CT arg to NCRISC and BRISC.
- **`fused_ops/post_sdpa/kernels/post_sdpa_kernel.cpp`**: Pass `sdpa_single_shot_l` CT arg, add dummy CTArgs for non-active RISC cores, use 3-arg Op template.

### Tests
- **`test_sdpa_reduce_to_all.py`**: Parameterize `max_payload_size` to test both chunked streaming and single-shot modes.
- **`test_post_sdpa.py`**: Update `compute_forwarder_scratch_size()` to support single-shot sizing; use 15232 byte max payload size.

## Mode Selection Logic

```
total_l_bytes = out_tiles * input_page_size_bytes
single_shot_l = total_l_bytes <= max_fabric_payload_size

if single_shot_l:
    slots_per_worker = 2          # MS + full L
    payload_per_slot = total_l_bytes
else:
    slots_per_worker = 1 + num_l_chunks  # MS + L chunks
    payload_per_slot = l_chunk_size_bytes
```
