### PR TITLE
Deepseekv3 : Added option to recreate ttnn weight caches for TG

### DIFF
--- a/.github/workflows/galaxy-deepseek-tests-impl.yaml
+++ b/.github/workflows/galaxy-deepseek-tests-impl.yaml
@@ -89,7 +89,8 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - ${{ inputs.recreate_weights_cache == 'Yes' && '/mnt/MLPerf:/mnt/MLPerf' || '/mnt/MLPerf:/mnt/MLPerf:ro' }}
+        - /mnt/MLPerf:/mnt/MLPerf:ro
+        - ${{ inputs.recreate_weights_cache == 'Yes' && '/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache:/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache' || '/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache:/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache:ro' }}
       options: "--device /dev/tenstorrent"
     defaults:
       run:
@@ -109,13 +110,15 @@ jobs:
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
       - name: Prepare custom weights cache directory
         if: ${{ inputs.recreate_weights_cache == 'Yes' }}
+        env:
+          INPUT_CACHE_DIR: ${{ inputs.new_cache_dir }}
         run: |
           CACHE_BASE="/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache"
-          if [[ -z "${{ inputs.new_cache_dir }}" ]]; then
+          if [[ -z "${INPUT_CACHE_DIR}" ]]; then
             echo "::error::recreate_weights_cache is Yes but new_cache_dir is empty. Please provide a cache directory name."
             exit 1
           fi
-          DIR_NAME="${{ inputs.new_cache_dir }}"
+          DIR_NAME="${INPUT_CACHE_DIR}"
           if [[ "${DIR_NAME}" =~ [/[:space:][:cntrl:]] || "${DIR_NAME}" == "." || "${DIR_NAME}" == ".." ]]; then
             echo "::error::new_cache_dir contains invalid characters (slashes, spaces, control chars) or is '.'/'..'"
             exit 1

--- a/.github/workflows/galaxy-deepseek-tests-impl.yaml
+++ b/.github/workflows/galaxy-deepseek-tests-impl.yaml
@@ -24,6 +24,14 @@ on:
         required: false
         type: string
         default: "all"
+      recreate_weights_cache:
+        required: false
+        type: string
+        default: "No"
+      new_cache_dir:
+        required: false
+        type: string
+        default: ""
 
 jobs:
   generate-matrix:
@@ -81,7 +89,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - /mnt/MLPerf:/mnt/MLPerf:ro
+        - ${{ inputs.recreate_weights_cache == 'Yes' && '/mnt/MLPerf:/mnt/MLPerf' || '/mnt/MLPerf:/mnt/MLPerf:ro' }}
       options: "--device /dev/tenstorrent"
     defaults:
       run:
@@ -99,6 +107,36 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+      - name: Prepare custom weights cache directory
+        if: ${{ inputs.recreate_weights_cache == 'Yes' }}
+        run: |
+          CACHE_BASE="/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache"
+          if [[ -z "${{ inputs.new_cache_dir }}" ]]; then
+            echo "::error::recreate_weights_cache is Yes but new_cache_dir is empty. Please provide a cache directory name."
+            exit 1
+          fi
+          DIR_NAME="${{ inputs.new_cache_dir }}"
+          if [[ "${DIR_NAME}" =~ [/[:space:][:cntrl:]] || "${DIR_NAME}" == "." || "${DIR_NAME}" == ".." ]]; then
+            echo "::error::new_cache_dir contains invalid characters (slashes, spaces, control chars) or is '.'/'..'"
+            exit 1
+          fi
+          if [[ "${DIR_NAME}" == "CI" ]]; then
+            echo "::error::new_cache_dir cannot be 'CI' — this would overwrite the production cache."
+            exit 1
+          fi
+          NEW_DIR="${CACHE_BASE}/${DIR_NAME}"
+          RESOLVED=$(realpath -m "${NEW_DIR}")
+          if [[ "${RESOLVED}" != "${CACHE_BASE}/"* || "${RESOLVED}" == "${CACHE_BASE}/CI" ]]; then
+            echo "::error::new_cache_dir resolves outside the allowed cache base or to the CI directory."
+            exit 1
+          fi
+          echo "Creating new cache directory: ${NEW_DIR}"
+          mkdir -p "${NEW_DIR}"
+          echo "Copying test_io_cache from CI directory..."
+          rm -rf "${NEW_DIR}/test_io_cache"
+          cp -r "${CACHE_BASE}/CI/test_io_cache" "${NEW_DIR}/test_io_cache"
+          chmod -R a+rwX "${NEW_DIR}"
+          echo "DEEPSEEK_V3_CACHE=${NEW_DIR}" >> $GITHUB_ENV
       - name: Run DeepSeek unit tests
         if: ${{ matrix.test-group.test-type == 'unit' }}
         timeout-minutes: ${{ matrix.test-group.timeout }}

--- a/.github/workflows/galaxy-deepseek-tests.yaml
+++ b/.github/workflows/galaxy-deepseek-tests.yaml
@@ -37,6 +37,19 @@ on:
         type: boolean
         default: false
         description: "Enable Link Time Optimization (LTO)"
+      recreate_weights_cache:
+        description: 'Recalculate weights cache in a new directory'
+        required: false
+        type: choice
+        default: "No"
+        options:
+          - "No"
+          - "Yes"
+      new_cache_dir:
+        description: 'New cache subdirectory name (under DeepSeek-R1-0528-Cache/). Required when recreate_weights_cache is Yes.'
+        required: false
+        type: string
+        default: ''
   schedule:
     - cron: "0 3 * * *" # Run at 3:00 AM UTC (11:00 PM EST) every day
 
@@ -61,3 +74,5 @@ jobs:
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       topology: topology-6u
       test-type: ${{ inputs.test-type || 'all' }}
+      recreate_weights_cache: ${{ inputs.recreate_weights_cache || 'No' }}
+      new_cache_dir: ${{ inputs.new_cache_dir || '' }}

--- a/.github/workflows/galaxy-deepseek-tests.yaml
+++ b/.github/workflows/galaxy-deepseek-tests.yaml
@@ -38,7 +38,7 @@ on:
         default: false
         description: "Enable Link Time Optimization (LTO)"
       recreate_weights_cache:
-        description: 'Recalculate weights cache in a new directory'
+        description: 'Recreate weights cache in a new directory'
         required: false
         type: choice
         default: "No"
@@ -46,7 +46,7 @@ on:
           - "No"
           - "Yes"
       new_cache_dir:
-        description: 'New cache subdirectory name (under DeepSeek-R1-0528-Cache/). Required when recreate_weights_cache is Yes.'
+        description: 'New cache subdirectory name (under DeepSeek-R1-0528-Cache/). Required when recreating weights cache.'
         required: false
         type: string
         default: ''


### PR DESCRIPTION
This PR adds a CI/workflow option for Galaxy DeepSeek tests to recreate the TTNN weights cache in a new cache subdirectory (instead of always using the shared ...-Cache/CI directory), primarily for TG runs.

Changes:

Added recreate_weights_cache and new_cache_dir inputs to the Galaxy DeepSeek workflow and forwarded them into the reusable impl workflow.
Conditionally mounts /mnt/MLPerf read-write when cache recreation is enabled and prepares a new cache directory seeded from CI/test_io_cache.
Overrides DEEPSEEK_V3_CACHE via $GITHUB_ENV for subsequent test steps when recreation is enabled.
