### PR TITLE
#37169: Update rand hashing

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/rand/test_rand.py
+++ b/tests/ttnn/nightly/unit_tests/operations/rand/test_rand.py
@@ -140,6 +140,36 @@ def test_rand_with_memory_config(device, mem_config):
     assert tuple(tensor.shape) == tuple(DEFAULT_SHAPE)
 
 
+def test_rand_different_from_to_values(device):
+    device.enable_program_cache()
+    device.clear_program_cache()
+
+    shape = (256, 256)
+    dtype = ttnn.float32
+
+    low_1, high_1 = 0.0, 1.0
+    tensor_1 = ttnn.rand(shape, device=device, dtype=dtype, low=low_1, high=high_1)
+    data_1 = ttnn.to_torch(tensor_1).float()
+    assert (
+        device.num_program_cache_entries() == 1
+    ), f"Expected 1 cache entry after first rand, got {device.num_program_cache_entries()}"
+
+    low_2, high_2 = 5.0, 10.0
+    tensor_2 = ttnn.rand(shape, device=device, dtype=dtype, low=low_2, high=high_2)
+    data_2 = ttnn.to_torch(tensor_2).float()
+    assert (
+        device.num_program_cache_entries() == 1
+    ), f"Expected 1 cache entry after second rand (cache hit; from/to runtime-only), got {device.num_program_cache_entries()}"
+
+    for torch_tensor, value_range in ((data_1, (low_1, high_1)), (data_2, (low_2, high_2))):
+        assert not torch.isnan(torch_tensor).any(), "Tensor contains NaN values!"
+        assert check_uniform_distribution(
+            torch_tensor, value_range=value_range, is_discrete=False
+        ), "The distribution of random values is not uniform!"
+
+    device.disable_and_clear_program_cache()
+
+
 def test_rand_invalid_args(device):
     """
     Passing invalid args should raise TypeError.

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.cpp
@@ -42,10 +42,12 @@ RandDeviceOperation::tensor_return_value_t RandDeviceOperation::create_output_te
 }
 
 tt::stl::hash::hash_t RandDeviceOperation::compute_program_hash(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    auto cached_operation_attributes = operation_attributes;
-    cached_operation_attributes.seed = 0;
-    return tt::stl::hash::hash_objects_with_default_seed(cached_operation_attributes, tensor_args);
+    const operation_attributes_t& operation_attributes, const tensor_args_t& /*tensor_args*/) {
+    return tt::tt_metal::operation::hash_operation<RandDeviceOperation>(
+        operation_attributes.shape,
+        operation_attributes.dtype,
+        operation_attributes.layout,
+        operation_attributes.memory_config);
 }
 
 }  // namespace ttnn::operations::rand

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_program_factory.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
+#include <bit>
 #include <cstring>
 
 #include <tt-metalium/constants.hpp>
@@ -98,18 +99,14 @@ RandDeviceOperation::ProgramFactory::cached_program_t RandDeviceOperation::Progr
             TT_THROW("Core not in specified core ranges");
         }
 
-        const float eps = 1e-6;
-        union {
-            float f;
-            uint32_t u;
-        } f2u_from{}, f2u_to{};
-        f2u_from.f = operation_attributes.from;
-        f2u_to.f = operation_attributes.to - eps;  // -eps make sure that generated number is < operation_attributes.to
+        const float eps = 1e-6f;
+        const uint32_t from_bits = std::bit_cast<uint32_t>(operation_attributes.from);
+        const uint32_t to_bits = std::bit_cast<uint32_t>(operation_attributes.to - eps);
 
         // Each core has its own seed to increase the number of generated random numbers
         uint32_t seed = operation_attributes.seed != 0 ? operation_attributes.seed + i : get_random_seed();
 
-        std::vector<uint32_t> compute_runtime_args = {seed, f2u_from.u, f2u_to.u, tile_offset, units_per_core};
+        std::vector<uint32_t> compute_runtime_args = {seed, from_bits, to_bits, tile_offset, units_per_core};
         SetRuntimeArgs(program, compute_kernel_id, core, compute_runtime_args);
 
         std::vector<uint32_t> writer_runtime_args = {output.buffer()->address(), tile_offset, units_per_core};
@@ -135,10 +132,16 @@ void RandDeviceOperation::ProgramFactory::override_runtime_arguments(
 
     const uint32_t output_addr = output.buffer()->address();
 
+    const float eps = 1e-6f;
+    const uint32_t from_bits = std::bit_cast<uint32_t>(operation_attributes.from);
+    const uint32_t to_bits = std::bit_cast<uint32_t>(operation_attributes.to - eps);
+
     for (int i = 0; i < cores.size(); ++i) {
         {
             auto& runtime_args = GetRuntimeArgs(program, compute_kernel_id, cores[i]);
             runtime_args[0] = operation_attributes.seed != 0 ? operation_attributes.seed + i : get_random_seed();
+            runtime_args[1] = from_bits;
+            runtime_args[2] = to_bits;
         }
         {
             auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, cores[i]);


### PR DESCRIPTION
### Ticket
Link to Github Issue #37169

### What's changed
**Updated Hash (rand_device_operation.cpp):**

- Dropped from and to from the hash; they are runtime-only and updated in override.
- Hash now: shape, dtype, layout, memory_config only.

**Override (rand_program_factory.cpp):**

- In override_runtime_arguments, update from and to (compute kernel runtime args [1] and [2]) on cache hit, using the same to - eps logic as in create.

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=mouliraj/rand_cache_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:mouliraj/rand_cache_issue)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mouliraj/rand_cache_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mouliraj/rand_cache_issue)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mouliraj/rand_cache_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mouliraj/rand_cache_issue)


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [x] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mouliraj/rand_cache_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mouliraj/rand_cache_issue)
  - [x] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [x] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mouliraj/rand_cache_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mouliraj/rand_cache_issue)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mouliraj/rand_cache_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mouliraj/rand_cache_issue)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
