### PR TITLE
fix(ttnn): rename experimental::distributed namespace to avoid unity build collision

### DIFF
--- a/tt_metal/api/tt-metalium/experimental/blitz_decode_pipeline.hpp
+++ b/tt_metal/api/tt-metalium/experimental/blitz_decode_pipeline.hpp
@@ -10,7 +10,7 @@
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/mesh_device.hpp>
 
-namespace tt::tt_metal::experimental::distributed {
+namespace tt::tt_metal::experimental::blitz {
 
 struct BlitzDecodePipelineStage {
     std::size_t stage_index;
@@ -21,4 +21,4 @@ struct BlitzDecodePipelineStage {
 std::vector<BlitzDecodePipelineStage> generate_blitz_decode_pipeline(
     const ::tt::tt_metal::distributed::MeshDevice& mesh_device);
 
-}  // namespace tt::tt_metal::experimental::distributed
+}  // namespace tt::tt_metal::experimental::blitz

--- a/tt_metal/distributed/experimental/blitz_decode_pipeline.cpp
+++ b/tt_metal/distributed/experimental/blitz_decode_pipeline.cpp
@@ -21,8 +21,6 @@
 namespace tt::tt_metal::experimental::blitz {
 
 using ::tt::tt_metal::distributed::MeshCoordinate;
-using ::tt::tt_metal::distributed::MeshDevice;
-namespace multihost = ::tt::tt_metal::distributed::multihost;
 
 namespace {
 

--- a/tt_metal/distributed/experimental/blitz_decode_pipeline.cpp
+++ b/tt_metal/distributed/experimental/blitz_decode_pipeline.cpp
@@ -18,7 +18,7 @@
 #include "tt_metal/fabric/physical_system_descriptor.hpp"
 #include "tt_metal/llrt/tt_cluster.hpp"
 
-namespace tt::tt_metal::experimental::distributed {
+namespace tt::tt_metal::experimental::blitz {
 
 using ::tt::tt_metal::distributed::MeshCoordinate;
 using ::tt::tt_metal::distributed::MeshCoordinateRange;
@@ -509,4 +509,4 @@ std::vector<BlitzDecodePipelineStage> generate_blitz_decode_pipeline(const distr
     return build_pipeline(physical_system_descriptor, asic_id_to_mesh_coord);
 }
 
-}  // namespace tt::tt_metal::experimental::distributed
+}  // namespace tt::tt_metal::experimental::blitz

--- a/tt_metal/distributed/experimental/blitz_decode_pipeline.cpp
+++ b/tt_metal/distributed/experimental/blitz_decode_pipeline.cpp
@@ -21,7 +21,6 @@
 namespace tt::tt_metal::experimental::blitz {
 
 using ::tt::tt_metal::distributed::MeshCoordinate;
-using ::tt::tt_metal::distributed::MeshCoordinateRange;
 using ::tt::tt_metal::distributed::MeshDevice;
 namespace multihost = ::tt::tt_metal::distributed::multihost;
 

--- a/ttnn/cpp/ttnn-nanobind/pipeline_module_nanobind.cpp
+++ b/ttnn/cpp/ttnn-nanobind/pipeline_module_nanobind.cpp
@@ -14,7 +14,7 @@
 namespace ttnn::pipeline_module {
 
 void bind_blitz_decode_pipeline(nb::module_& mod) {
-    using tt::tt_metal::experimental::distributed::BlitzDecodePipelineStage;
+    using tt::tt_metal::experimental::blitz::BlitzDecodePipelineStage;
 
     nb::class_<BlitzDecodePipelineStage>(mod, "BlitzDecodePipelineStage")
         .def_ro("stage_index", &BlitzDecodePipelineStage::stage_index)
@@ -31,7 +31,7 @@ void bind_blitz_decode_pipeline(nb::module_& mod) {
     mod.def(
         "generate_blitz_decode_pipeline",
         [](tt::tt_metal::distributed::MeshDevice& mesh_device) {
-            return tt::tt_metal::experimental::distributed::generate_blitz_decode_pipeline(mesh_device);
+            return tt::tt_metal::experimental::blitz::generate_blitz_decode_pipeline(mesh_device);
         },
         nb::arg("mesh_device"),
         R"doc(


### PR DESCRIPTION
Rename experimental::distributed namespace to avoid unity build collision

The namespace `tt::tt_metal::experimental::distributed` shadows `tt::tt_metal::distributed`, causing compilation failures in unity builds when files are grouped such that `blitz_decode_pipeline.hpp` is processed before code that uses `distributed::AnyBuffer` from within `namespace tt::tt_metal::experimental`.

Concrete example when `pipeline_module_nanobind.cpp` ended up in the same compilation unit as code that includes `global_circular_buffer.hpp`, and when `blitz_decode_pipeline.hpp` was processed first, it introduced `tt::tt_metal::experimental::distributed` and when `global_circular_buffer.hpp` tried to resolve `distributed::AnyBuffer` from inside `namespace tt::tt_metal::experimental` and the followig error occurs

```
error: no type named 'AnyBuffer' in namespace 'tt::tt_metal::experimental::distributed';
did you mean '::tt::tt_metal::distributed::AnyBuffer'?
```

Renamed to `tt::tt_metal::experimental::blitz` to eliminate the shadowing.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=mbezulj/2603-unity_build_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:mbezulj/2603-unity_build_fix)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mbezulj/2603-unity_build_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mbezulj/2603-unity_build_fix)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mbezulj/2603-unity_build_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mbezulj/2603-unity_build_fix)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early

