### PR TITLE
Narrow resnet CODEOWNERS to exact directory path

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -336,7 +336,7 @@ models/demos/t3000/llama3_70b @cglagovichTT @uaydonat @johanna-rock-tt @djordje-
 models/demos/t3000/sentence_bert @tenstorrent/cse-developer-ttnn @tenstorrent/codeowner-bypass
 models/demos/tg/falcon7b @skhorasganiTT @djordje-tt @uaydonat @tenstorrent/codeowner-bypass
 models/demos/audio/whisper @skhorasganiTT @djordje-tt @uaydonat @tenstorrent/codeowner-bypass
-models/demos/**/*resnet* @tenstorrent/metalium-developers-convolutions @tenstorrent/codeowner-bypass
+models/demos/vision/classification/resnet50/ @tenstorrent/metalium-developers-convolutions @tenstorrent/codeowner-bypass
 models/experimental/ @dgomezTT @jmalone-tt @ayerofieiev-tt @uaydonat @tenstorrent/codeowner-bypass
 models/experimental/functional_unet @esmalTT @uaydonat @tenstorrent/codeowner-bypass
 models/experimental/transfuser/ @tenstorrent/cse-developer-ttnn @dvartaniansTT @sdawle-TT @tenstorrent/codeowner-bypass


### PR DESCRIPTION
## Summary

The previous CODEOWNERS rule `models/demos/**/*resnet*` was too broad — it made the convolutions team reviewers for any file containing "resnet" in its name anywhere under `models/demos/`, including files belonging to other teams' models (e.g. `ttnn_resnet_34.py` in ufld_v2 segmentation). Examples:

- https://github.com/tenstorrent/tt-metal/pull/38810
- https://github.com/tenstorrent/tt-metal/pull/38290

This PR replaces that glob with the explicit path `models/demos/vision/classification/resnet50/`, which is the only tracked resnet model directory. This ensures the convolutions team is only requested for review on actual resnet model changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)