### PR TITLE
#38711: Update pack_scalar_runtime_arg

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_ternary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_ternary.py
@@ -239,7 +239,7 @@ def test_addcmul_with_bcast_bf8b(device, torch_dtype, ttnn_dtype, a_shape, b_sha
         (torch.float32, ttnn.float32),
     ],
 )
-@pytest.mark.parametrize("value", [1.0, 0.5])
+@pytest.mark.parametrize("value", [0.5, 3])
 @pytest.mark.parametrize(
     "in_data1_shape, in_data2_shape, in_data3_shape",
     [

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -1077,7 +1077,7 @@ def test_unary_atanh_ttnn(input_shapes, torch_dtype, ttnn_dtype, low, high, devi
 )
 @pytest.mark.parametrize(
     "param",
-    (0.65, 7.7, 36.49, 58.6, 97.2),
+    (0.65, 7.7, 36, 58.6, 74, 97.2),
 )
 @pytest.mark.parametrize(
     "ttnn_function",

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_op_utils.cpp
@@ -338,7 +338,10 @@ uint32_t pack_scalar_runtime_arg(const ScalarVariant scalar, const DataType dtyp
                 return pack_scalar_runtime_arg_float(v, dtype);
             } else {
                 static_assert(std::is_same_v<T, int32_t> || std::is_same_v<T, uint32_t>);
-                return std::bit_cast<uint32_t>(v);
+                if (dtype == DataType::INT32 || dtype == DataType::UINT32) {
+                    return std::bit_cast<uint32_t>(v);
+                }
+                return std::bit_cast<uint32_t>(static_cast<float>(v));
             }
         },
         scalar);

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary.cpp
@@ -253,6 +253,14 @@ Tensor AddcmulOperation::invoke(
     const std::optional<Tensor>& output) {
     log_debug(tt::LogOp, "Addcmul LLK - TTT");
 
+    bool is_supported_dtype =
+        (input_a.dtype() == DataType::BFLOAT16 || input_a.dtype() == DataType::FLOAT32 ||
+         input_a.dtype() == DataType::INT32 || input_a.dtype() == DataType::BFLOAT8_B);  // TODO(#38972): UINT32 support
+    TT_FATAL(
+        is_supported_dtype,
+        "Addcmul supports only BFLOAT16, BFLOAT8_B, FLOAT32, and INT32 dtypes. Got {}",
+        input_a.dtype());
+
     // Only TTT variant is supported for addcmul
     auto broadcast_type = ttnn::operations::ternary::get_broadcast_type(
         input_a.logical_shape(), input_b.logical_shape(), input_c.logical_shape());

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -1014,10 +1014,18 @@ std::uint32_t pack_scalar_runtime_arg_impl(float param, DataType dtype) {
     return std::bit_cast<std::uint32_t>(param);
 }
 
-std::uint32_t pack_scalar_runtime_arg_impl(std::uint32_t param, DataType /*dtype*/) { return param; }
+std::uint32_t pack_scalar_runtime_arg_impl(std::uint32_t param, DataType dtype) {
+    if (dtype == DataType::INT32 || dtype == DataType::UINT32) {
+        return param;
+    }
+    return std::bit_cast<std::uint32_t>(static_cast<float>(param));
+}
 
-std::uint32_t pack_scalar_runtime_arg_impl(std::int32_t param, DataType /*dtype*/) {
-    return std::bit_cast<std::uint32_t>(param);
+std::uint32_t pack_scalar_runtime_arg_impl(std::int32_t param, DataType dtype) {
+    if (dtype == DataType::INT32 || dtype == DataType::UINT32) {
+        return std::bit_cast<std::uint32_t>(param);
+    }
+    return std::bit_cast<std::uint32_t>(static_cast<float>(param));
 }
 
 uint32_t pack_scalar_runtime_arg(const EltwiseUnaryWithParam& op, size_t index, DataType dtype) {


### PR DESCRIPTION
### Ticket
Link to Github Issue #38711 


### What's changed
Fix addcmul scalar bit-cast bug by converting integer scalars to float when packing for float/bfloat16 tensors (ternary and unary), and add addcmul dtype checks so only BFLOAT16, FLOAT32, INT32, and BFLOAT8_B are allowed.
### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=mouliraj/bit-cast_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:mouliraj/bit-cast_bug)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mouliraj/bit-cast_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mouliraj/bit-cast_bug)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mouliraj/bit-cast_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mouliraj/bit-cast_bug)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mouliraj/bit-cast_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mouliraj/bit-cast_bug)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mouliraj/bit-cast_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mouliraj/bit-cast_bug)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mouliraj/bit-cast_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mouliraj/bit-cast_bug)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
