### PR TITLE
SDXL Unet Perf target

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -104,7 +104,7 @@ def test_refiner_unet(
     [
         (
             'pytest models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py::test_unet -k "1024x1024"',
-            191_651_771 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
+            190_201_442 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
             "sdxl_unet_1024x1024",
             "sdxl_unet_1024x1024",
             1,
@@ -114,7 +114,7 @@ def test_refiner_unet(
         ),
         (
             'pytest models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py::test_unet -k "512x512"',
-            91_463_635 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
+            90_553_421 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
             "sdxl_unet_512x512",
             "sdxl_unet_512x512",
             1,


### PR DESCRIPTION
### Problem description
(Single-card) Device perf regressions - Device perf Flaky fail for `test_sdxl_unet_512x512`

[Metal CI job run link](https://github.com/tenstorrent/tt-metal/actions/runs/22612652138/job/65518795272)
```
ERROR    | models.perf.device_perf_utils:check_device_perf:257 - AVG DEVICE KERNEL DURATION [ns] 90061141.0 is outside of expected range (90091680.475, 92835589.52499999)
```
Perf is consistently better in last 5 days then what is expected value for test_sdxl_unet_512x512 and test_sdxl_unet_1024x1024: [spreadsheet link](https://docs.google.com/spreadsheets/d/1Xy7aCLghVHOTJ9RFUdmmPIjOL7GE_DuBsZCHhUkOw7E/edit?usp=sharing)


### What's changed
Perf target lowered for:
test_sdxl_unet_512x512 and test_sdxl_unet_1024x1024

### Checklist
- [x] (Single-card) Device perf regressions [run link](https://github.com/tenstorrent/tt-metal/actions/runs/22621907306)