### PR TITLE
Fix GPT-OSS structured output benchmark in vllm nightly CI

### DIFF
--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -85,6 +85,7 @@ jobs:
               "tt-llama-text-ver": "tt_transformers",
               "additional-server-args": "--max_num_seqs 1",
               "structured-output": true,
+              "additional-structured-output-args": "--backend openai-chat --endpoint /v1/chat/completions --dataset json",
               "co-owner-1-id": "U08TJ70UFRT",
               "co-owner-2-id": "U06F3ER8X9A"
             },
@@ -101,6 +102,7 @@ jobs:
               "override-tt-config": "{\"fabric_config\": \"FABRIC_1D_RING\"}",
               "additional-server-args": "--data_parallel_size 4 --max_num_seqs 32",
               "structured-output": true,
+              "additional-structured-output-args": "--backend openai-chat --endpoint /v1/chat/completions --dataset json",
               "co-owner-1-id": "U08TJ70UFRT",
               "co-owner-2-id": "U06F3ER8X9A"
             },
@@ -475,6 +477,12 @@ jobs:
             ADDITIONAL_BENCHMARK_ARGS=()
           fi
 
+          if [ -n "${{ matrix.test-group.additional-structured-output-args }}" ]; then
+            ADDITIONAL_STRUCTURED_OUTPUT_ARGS=(${{ matrix.test-group.additional-structured-output-args }})
+          else
+            ADDITIONAL_STRUCTURED_OUTPUT_ARGS=()
+          fi
+
           python3 vllm/benchmarks/benchmark_serving_structured_output.py \
             --backend vllm \
             --model ${{ matrix.test-group.model }} \
@@ -485,6 +493,7 @@ jobs:
             --save-result \
             --result-filename output/vllm_result_structured.json \
             "${ADDITIONAL_BENCHMARK_ARGS[@]}" \
+            "${ADDITIONAL_STRUCTURED_OUTPUT_ARGS[@]}" \
             2>&1 | tee ${FILE_BENCHMARK_STRUCTURED_OUTPUT_LOG}
 
           # The benchmark returns zero even if responses are not correct.


### PR DESCRIPTION
## Summary
- GPT-OSS structured output benchmark was failing with 9.375% correct rate (3/32) in nightly CI
- Root cause: GPT-OSS auto-configures `reasoning_parser='openai_gptoss'` with `enable_in_reasoning=False`. The benchmark default (`/v1/completions`) never produces reasoning markers, so grammar constraints are never applied — model outputs free text instead of JSON
- Fix: add `additional-structured-output-args` field for GPT-OSS entries that switches to chat completions and uses a fixed JSON schema

## Changes
- Added `additional-structured-output-args` to both GPT-OSS matrix entries: `--backend openai-chat --endpoint /v1/chat/completions --dataset json`
- Added parsing of the new field in the structured output benchmark step (same pattern as `additional-benchmark-args`)
- Args appended last so they override defaults (argparse last-value-wins for `--backend`, `--dataset`)

## Test plan
- [x] Reproduced CI failure locally: 0% correct rate with default args
- [x] Verified fix locally: 3/3 runs at 100% correct rate (32/32 prompts)
- [x] Other models unaffected (field is only set for GPT-OSS entries)