### PR TITLE
Alexey zaytsev epam/issue/36707/concat nd sharding 003 adjusting003

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_concat.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_concat.py
@@ -430,22 +430,22 @@ def test_nd_sharded_concat(device, num_tensors, tensor_shape, shard_shape, conca
     # Compute output shard shape (adjust for concat dimension): same grid and layout as inputs,
     # output shard shape = sum of input shard shapes along concat_dim (mirrors device op logic).
     # TODO:Z ? should we calculate output_shard_shape in the python - or should force it in C++ code?
-    input_mem_config = ttnn_tensors[0].memory_config()
-    input_nd_spec = input_mem_config.nd_shard_spec
-    output_shard_shape = list(input_nd_spec.shard_shape)
-    output_shard_shape[concat_dim] = 0
-    for tt_t in ttnn_tensors:
-        output_shard_shape[concat_dim] += tt_t.memory_config().nd_shard_spec.shard_shape[concat_dim]
-    output_nd_shard_spec = ttnn.NdShardSpec(
-        output_shard_shape,
-        input_nd_spec.grid,
-        orientation=input_nd_spec.orientation,
-        shard_distribution_strategy=input_nd_spec.shard_distribution_strategy,
-    )
-    output_memory_config = ttnn.MemoryConfig(input_mem_config.buffer_type, output_nd_shard_spec)
+    # input_mem_config = ttnn_tensors[0].memory_config()
+    # input_nd_spec = input_mem_config.nd_shard_spec
+    # output_shard_shape = list(input_nd_spec.shard_shape)
+    # output_shard_shape[concat_dim] = 0
+    # for tt_t in ttnn_tensors:
+    #     output_shard_shape[concat_dim] += tt_t.memory_config().nd_shard_spec.shard_shape[concat_dim]
+    # output_nd_shard_spec = ttnn.NdShardSpec(
+    #     output_shard_shape,
+    #     input_nd_spec.grid,
+    #     orientation=input_nd_spec.orientation,
+    #     shard_distribution_strategy=input_nd_spec.shard_distribution_strategy,
+    # )
+    # output_memory_config = ttnn.MemoryConfig(input_mem_config.buffer_type, output_nd_shard_spec)
 
     print("\nright before concat\n")
-    ttnn_output = ttnn.concat(ttnn_tensors, dim=concat_dim, memory_config=output_memory_config)
+    ttnn_output = ttnn.concat(ttnn_tensors, dim=concat_dim)  # , memory_config=output_memory_config)
 
     # Convert back to torch and compare
     actual_output = ttnn.to_torch(ttnn_output)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_concat.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_concat.py
@@ -388,19 +388,16 @@ def test_nd_sharded_concat(device, num_tensors, tensor_shape, shard_shape, conca
     for 2, 3, and 4 input tensors across different concat dimensions.
     """
     torch.manual_seed(0)
-    print("\n\nodin\n\n")
 
     # Skip incompatible configurations
     if dtype == ttnn.bfloat8_b and layout == ttnn.ROW_MAJOR_LAYOUT:
         pytest.skip("bfloat8_b is only valid for TILE_LAYOUT")
-    print("\n\ndwa\n\n")
 
     # Setup grid
     grid_size = device.compute_with_storage_grid_size()
     core_range = ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid_size.x - 1, grid_size.y - 1))
     grid = ttnn.CoreRangeSet([core_range])  # TODOZ: to discuss/test partial core range set
 
-    print("\n\ntri\n\n")
     # Create ND shard spec for input tensors
     input_nd_shard_spec = ttnn.NdShardSpec(shard_shape, grid)
     input_memory_config = ttnn.MemoryConfig(ttnn.BufferType.L1, input_nd_shard_spec)
@@ -438,8 +435,8 @@ def test_nd_sharded_concat(device, num_tensors, tensor_shape, shard_shape, conca
     # For concat dim, the output shard shape might need adjustment based on memory layout
     # For simplicity, keep same shard shape and let output be interleaved
 
-    # Perform concat - output to DRAM (interleaved) since ND sharded output may not be supported yet
-    output_memory_config = ttnn.DRAM_MEMORY_CONFIG
+    # usage of ND sharded tensors supposes only L1_BLOCK_SHARDED_MEMORY_CONFIG memory config
+    output_memory_config = ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG
 
     ttnn_output = ttnn.concat(ttnn_tensors, dim=concat_dim, memory_config=output_memory_config)
 

--- a/tests/ttnn/unit_tests/operations/data_movement/test_concat.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_concat.py
@@ -368,12 +368,12 @@ def test_concat_1d(device, layout, dim, input_shapes):
         #        (2, [3, 4, 5], [1, 1, 5], 0, ttnn.ROW_MAJOR_LAYOUT),   # RM concat on batch
         #        (2, [3, 4, 5], [3, 1, 5], 1, ttnn.ROW_MAJOR_LAYOUT),   # RM concat on height
         # 3 tensors - ND sharding concat
-        (3, [2, 64, 64], [1, 32, 32], 0, ttnn.TILE_LAYOUT),  # concat 3 tensors on batch
+        #        (3, [2, 64, 64], [1, 32, 32], 0, ttnn.TILE_LAYOUT),  # concat 3 tensors on batch
         #        (3, [2, 64, 64], [2, 32, 32], 1, ttnn.TILE_LAYOUT),    # concat 3 tensors on height
         #        (3, [2, 64, 64], [2, 64, 32], 2, ttnn.TILE_LAYOUT),    # concat 3 tensors on width
         #        (3, [2, 4, 8], [1, 4, 8], 0, ttnn.ROW_MAJOR_LAYOUT),   # RM concat 3 tensors
         # 4 tensors - ND sharding concat
-        (4, [1, 64, 64], [1, 32, 32], 1, ttnn.TILE_LAYOUT),  # concat 4 tensors on height
+        #        (4, [1, 64, 64], [1, 32, 32], 1, ttnn.TILE_LAYOUT),  # concat 4 tensors on height
         #        (4, [1, 64, 64], [1, 64, 32], 2, ttnn.TILE_LAYOUT),    # concat 4 tensors on width
         #        (4, [2, 32, 32], [1, 32, 32], 0, ttnn.TILE_LAYOUT),    # concat 4 tensors on batch
         #        (4, [2, 4, 8], [2, 4, 8], 0, ttnn.ROW_MAJOR_LAYOUT),   # RM concat 4 tensors on batch
@@ -402,11 +402,9 @@ def test_nd_sharded_concat(device, num_tensors, tensor_shape, shard_shape, conca
     input_nd_shard_spec = ttnn.NdShardSpec(shard_shape, grid)
     input_memory_config = ttnn.MemoryConfig(ttnn.BufferType.L1, input_nd_shard_spec)
 
-    print("\n\n4etire\n\n")
     # Generate input tensors
     torch_tensors = [torch.rand(tensor_shape, dtype=torch.bfloat16) for _ in range(num_tensors)]
 
-    print("\n\npat\n\n")
     # Expected output from PyTorch
     torch_output = torch.concat(torch_tensors, dim=concat_dim)
 
@@ -438,6 +436,7 @@ def test_nd_sharded_concat(device, num_tensors, tensor_shape, shard_shape, conca
     # usage of ND sharded tensors supposes only L1_BLOCK_SHARDED_MEMORY_CONFIG memory config
     output_memory_config = ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG
 
+    print("\n\nright before concat\n\n")
     ttnn_output = ttnn.concat(ttnn_tensors, dim=concat_dim, memory_config=output_memory_config)
 
     # Convert back to torch and compare

--- a/tests/ttnn/unit_tests/operations/data_movement/test_concat.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_concat.py
@@ -352,3 +352,131 @@ def test_concat_1d(device, layout, dim, input_shapes):
     output = ttnn.to_torch(output)
 
     assert_equal(torch_output_tensor, output)
+
+
+# DN sharded
+@pytest.mark.parametrize(
+    "num_tensors, tensor_shape, shard_shape, concat_dim, layout",
+    [
+        # 2 tensors - basic ND sharding concat
+        (2, [3, 128, 160], [1, 32, 32], 0, ttnn.TILE_LAYOUT),  # concat on batch dim
+        #        (2, [3, 128, 160], [3, 32, 32], 1, ttnn.TILE_LAYOUT),  # concat on height dim
+        #        (2, [3, 128, 160], [3, 128, 32], 2, ttnn.TILE_LAYOUT),  # concat on width dim
+        #        (2, [3, 4, 5], [1, 1, 5], 0, ttnn.ROW_MAJOR_LAYOUT),   # RM concat on batch
+        #        (2, [3, 4, 5], [3, 1, 5], 1, ttnn.ROW_MAJOR_LAYOUT),   # RM concat on height
+        # 3 tensors - ND sharding concat
+        (3, [2, 64, 64], [1, 32, 32], 0, ttnn.TILE_LAYOUT),  # concat 3 tensors on batch
+        #        (3, [2, 64, 64], [2, 32, 32], 1, ttnn.TILE_LAYOUT),    # concat 3 tensors on height
+        #        (3, [2, 64, 64], [2, 64, 32], 2, ttnn.TILE_LAYOUT),    # concat 3 tensors on width
+        #        (3, [2, 4, 8], [1, 4, 8], 0, ttnn.ROW_MAJOR_LAYOUT),   # RM concat 3 tensors
+        # 4 tensors - ND sharding concat
+        (4, [1, 64, 64], [1, 32, 32], 1, ttnn.TILE_LAYOUT),  # concat 4 tensors on height
+        #        (4, [1, 64, 64], [1, 64, 32], 2, ttnn.TILE_LAYOUT),    # concat 4 tensors on width
+        #        (4, [2, 32, 32], [1, 32, 32], 0, ttnn.TILE_LAYOUT),    # concat 4 tensors on batch
+        #        (4, [2, 4, 8], [2, 4, 8], 0, ttnn.ROW_MAJOR_LAYOUT),   # RM concat 4 tensors on batch
+    ],
+)
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+def test_nd_sharded_concat(device, num_tensors, tensor_shape, shard_shape, concat_dim, layout, dtype):
+    """
+    Test concat operation with ND sharded tensors.
+
+    This test verifies that concat works correctly with N-dimensional sharding
+    for 2, 3, and 4 input tensors across different concat dimensions.
+    """
+    torch.manual_seed(0)
+    print("\n\nodin\n\n")
+
+    # Skip incompatible configurations
+    if dtype == ttnn.bfloat8_b and layout == ttnn.ROW_MAJOR_LAYOUT:
+        pytest.skip("bfloat8_b is only valid for TILE_LAYOUT")
+    print("\n\ndwa\n\n")
+
+    # Setup grid
+    grid_size = device.compute_with_storage_grid_size()
+    core_range = ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid_size.x - 1, grid_size.y - 1))
+    grid = ttnn.CoreRangeSet([core_range])  # TODOZ: to discuss/test partial core range set
+
+    print("\n\ntri\n\n")
+    # Create ND shard spec for input tensors
+    input_nd_shard_spec = ttnn.NdShardSpec(shard_shape, grid)
+    input_memory_config = ttnn.MemoryConfig(ttnn.BufferType.L1, input_nd_shard_spec)
+
+    print("\n\n4etire\n\n")
+    # Generate input tensors
+    torch_tensors = [torch.rand(tensor_shape, dtype=torch.bfloat16) for _ in range(num_tensors)]
+
+    print("\n\npat\n\n")
+    # Expected output from PyTorch
+    torch_output = torch.concat(torch_tensors, dim=concat_dim)
+
+    # Create TTNN tensors with ND sharding
+    ttnn_tensors = [
+        ttnn.from_torch(t, dtype=dtype, device=device, layout=layout, memory_config=input_memory_config)
+        for t in torch_tensors
+    ]
+    print("\n\ntensors have been created\n\n")
+
+    # Verify tensors have ND sharding
+    for tt_tensor in ttnn_tensors:
+        assert tt_tensor.memory_config().is_sharded(), "Input tensor should be sharded"
+
+    # Compute output shard shape (adjust for concat dimension)
+    output_shape = list(tensor_shape)
+    output_shape[concat_dim] *= num_tensors
+    output_shard_shape = list(shard_shape)
+    # For concat dim, the output shard shape might need adjustment based on memory layout
+    # For simplicity, keep same shard shape and let output be interleaved
+
+    # Perform concat - output to DRAM (interleaved) since ND sharded output may not be supported yet
+    output_memory_config = ttnn.DRAM_MEMORY_CONFIG
+
+    ttnn_output = ttnn.concat(ttnn_tensors, dim=concat_dim, memory_config=output_memory_config)
+
+    # Convert back to torch and compare
+    actual_output = ttnn.to_torch(ttnn_output)
+
+    assert_with_pcc(torch_output, actual_output, 0.999)
+
+
+# @pytest.mark.parametrize(
+#     "tensor_shapes, shard_shapes, concat_dim",
+#     [
+#         # Different sized tensors (same shard shape where applicable)
+#         ([(2, 64, 64), (3, 64, 64)], [(1, 32, 32), (1, 32, 32)], 0),  # Different batch sizes
+#         ([(2, 64, 64), (2, 96, 64)], [(2, 32, 32), (2, 32, 32)], 1),  # Different heights
+#         ([(2, 64, 64), (2, 64, 96)], [(2, 64, 32), (2, 64, 32)], 2),  # Different widths
+#     ],
+# )
+# @pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+# def test_nd_sharded_concat_different_sizes(device, tensor_shapes, shard_shapes, concat_dim, dtype):
+#     """
+#     Test concat with ND sharded tensors of different sizes along concat dimension.
+#     """
+#     torch.manual_seed(0)
+
+#     # Setup grid
+#     grid_size = device.compute_with_storage_grid_size()
+#     core_range = ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid_size.x - 1, grid_size.y - 1))
+#     grid = ttnn.CoreRangeSet([core_range])
+
+#     # Generate input tensors with different shapes
+#     torch_tensors = [torch.rand(shape, dtype=torch.bfloat16) for shape in tensor_shapes]
+#     torch_output = torch.concat(torch_tensors, dim=concat_dim)
+
+#     # Create TTNN tensors with ND sharding
+#     ttnn_tensors = []
+#     for torch_tensor, shard_shape in zip(torch_tensors, shard_shapes):
+#         nd_shard_spec = ttnn.NdShardSpec(shard_shape, grid)
+#         memory_config = ttnn.MemoryConfig(ttnn.BufferType.L1, nd_shard_spec)
+#         tt_tensor = ttnn.from_torch(
+#             torch_tensor, dtype=dtype, device=device,
+#             layout=ttnn.TILE_LAYOUT, memory_config=memory_config
+#         )
+#         ttnn_tensors.append(tt_tensor)
+
+#     # Concat with interleaved output
+#     ttnn_output = ttnn.concat(ttnn_tensors, dim=concat_dim, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+#     actual_output = ttnn.to_torch(ttnn_output)
+
+#     assert_with_pcc(torch_output, actual_output, 0.999)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_concat.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_concat.py
@@ -362,8 +362,8 @@ def test_concat_1d(device, layout, dim, input_shapes):
     "num_tensors, tensor_shape, shard_shape, concat_dim, layout",
     [
         # 2 tensors - basic ND sharding concat
-        (2, [3, 128, 160], [1, 32, 32], 0, ttnn.TILE_LAYOUT),  # concat on batch dim         # +
-        #        (2, [3, 128, 160], [3, 32, 32], 1, ttnn.TILE_LAYOUT),  # concat on height dim
+        #        (2, [3, 128, 160], [1, 32, 32], 0, ttnn.TILE_LAYOUT),  # concat on batch dim         # +
+        (2, [3, 128, 160], [1, 32, 32], 1, ttnn.TILE_LAYOUT),  # concat on height dim
         #        (2, [3, 128, 160], [3, 128, 32], 2, ttnn.TILE_LAYOUT),  # concat on width dim
         #        (2, [3, 4, 5], [1, 1, 5], 0, ttnn.ROW_MAJOR_LAYOUT),   # RM concat on batch
         #        (2, [3, 4, 5], [3, 1, 5], 1, ttnn.ROW_MAJOR_LAYOUT),   # RM concat on height
@@ -423,9 +423,11 @@ def test_nd_sharded_concat(device, num_tensors, tensor_shape, shard_shape, conca
         assert mem_config.nd_shard_spec is not None, "Input tensor should use ND sharding"
         assert mem_config.shard_spec is None, "Input tensor should NOT use legacy sharding"
         # verify the shard shape matches initial setup
-        assert mem_config.nd_shard_spec.shard_shape == ttnn.Shape(
-            shard_shape
-        ), f"Shard shape mismatch: expected {shard_shape}, got {mem_config.nd_shard_spec.shard_shape}"
+        expected_shape = ttnn.Shape(shard_shape)
+        actual_shape = mem_config.nd_shard_spec.shard_shape
+        assert (
+            actual_shape == expected_shape
+        ), f"Shard shape mismatch: expected {list(expected_shape)}, got {list(actual_shape)}"
 
     # Compute output shard shape (adjust for concat dimension): same grid and layout as inputs,
     # output shard shape = sum of input shard shapes along concat_dim (mirrors device op logic).

--- a/tests/ttnn/unit_tests/operations/data_movement/test_concat.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_concat.py
@@ -362,8 +362,10 @@ def test_concat_1d(device, layout, dim, input_shapes):
     "num_tensors, tensor_shape, shard_shape, concat_dim, layout",
     [
         # 2 tensors - basic ND sharding concat
+        # (3, [5, 192, 224], [1, 32, 32], 0, ttnn.TILE_LAYOUT),  # concat on batch dim         # +
+        (2, [5, 192, 224], [1, 32, 32], 1, ttnn.TILE_LAYOUT),  # concat on batch dim         # -
         #        (2, [3, 128, 160], [1, 32, 32], 0, ttnn.TILE_LAYOUT),  # concat on batch dim         # +
-        (2, [3, 128, 160], [1, 32, 32], 1, ttnn.TILE_LAYOUT),  # concat on height dim
+        # (2, [3, 128, 160], [1, 32, 32], 1, ttnn.TILE_LAYOUT),  # concat on height dim
         #        (2, [3, 128, 160], [3, 128, 32], 2, ttnn.TILE_LAYOUT),  # concat on width dim
         #        (2, [3, 4, 5], [1, 1, 5], 0, ttnn.ROW_MAJOR_LAYOUT),   # RM concat on batch
         #        (2, [3, 4, 5], [3, 1, 5], 1, ttnn.ROW_MAJOR_LAYOUT),   # RM concat on height

--- a/tests/ttnn/unit_tests/operations/data_movement/test_concat.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_concat.py
@@ -361,21 +361,42 @@ def test_concat_1d(device, layout, dim, input_shapes):
 @pytest.mark.parametrize(
     "num_tensors, tensor_shape, shard_shape, concat_dim, layout",
     [
+        # simplest
+        (2, [1, 64, 96], [1, 32, 32], 0, ttnn.TILE_LAYOUT),  # concat on batch dim         # +
+        (2, [1, 64, 96], [1, 32, 32], 0, ttnn.ROW_MAJOR_LAYOUT),  # concat on batch dim         # +
+        (3, [5, 64, 224], [1, 32, 32], 0, ttnn.ROW_MAJOR_LAYOUT),  # concat on batch dim         # +
+        (2, [1, 64, 96], [1, 32, 32], 0, ttnn.ROW_MAJOR_LAYOUT),  # concat on batch dim         # +
+        (2, [2, 64, 96], [1, 32, 32], 1, ttnn.ROW_MAJOR_LAYOUT),  # concat on batch dim         # +
+        (3, [2, 128, 96], [1, 32, 32], 1, ttnn.ROW_MAJOR_LAYOUT),  # concat on batch dim         # +
+        (3, [3, 128, 96], [1, 32, 32], 1, ttnn.ROW_MAJOR_LAYOUT),  # concat on batch dim         # +
+        (2, [2, 64, 96], [1, 32, 32], 2, ttnn.ROW_MAJOR_LAYOUT),  # concat on batch dim         #
+        (7, [2, 256, 96], [1, 32, 32], 2, ttnn.ROW_MAJOR_LAYOUT),  # concat on batch dim         #
         # 2 tensors - basic ND sharding concat
         (2, [5, 192, 224], [1, 32, 32], 0, ttnn.TILE_LAYOUT),  # concat on batch dim         # +
-        (2, [5, 192, 224], [1, 32, 32], 1, ttnn.TILE_LAYOUT),  # concat on batch dim         # +
-        (2, [5, 192, 224], [1, 32, 32], 2, ttnn.TILE_LAYOUT),  # concat on batch dim         # +
-        #        (2, [5, 192, 224], [1, 32, 32], 0, ttnn.ROW_MAJOR_LAYOUT),  # concat on batch dim         # +
+        (2, [5, 192, 224], [1, 32, 32], 1, ttnn.TILE_LAYOUT),  # concat on 1 dim         # +
+        (2, [5, 192, 224], [1, 32, 32], 2, ttnn.TILE_LAYOUT),  # concat on 2 dim         # +
+        (2, [5, 192, 224], [1, 32, 32], 0, ttnn.ROW_MAJOR_LAYOUT),  # concat on batch dim         # +
+        (2, [5, 192, 224], [1, 32, 32], 1, ttnn.ROW_MAJOR_LAYOUT),  # concat on batch dim         # +
+        (2, [5, 192, 224], [1, 32, 32], 2, ttnn.ROW_MAJOR_LAYOUT),  # concat on batch dim         # +
         # 3 tensors - ND sharding concat
         (3, [5, 192, 224], [1, 32, 32], 0, ttnn.TILE_LAYOUT),  # concat on batch dim         # +
         (3, [5, 192, 224], [1, 32, 32], 1, ttnn.TILE_LAYOUT),  # concat on batch dim         # +
         (3, [5, 192, 224], [1, 32, 32], 2, ttnn.TILE_LAYOUT),  # concat on batch dim         # +
-        #        (3, [5, 192, 224], [1, 32, 32], 0, ttnn.ROW_MAJOR_LAYOUT),  # concat on batch dim         # +
+        (3, [5, 192, 224], [1, 32, 32], 0, ttnn.ROW_MAJOR_LAYOUT),  # concat on batch dim         # +
+        (3, [5, 192, 224], [1, 32, 32], 1, ttnn.ROW_MAJOR_LAYOUT),  # concat on batch dim         # +
+        (3, [5, 192, 224], [1, 32, 32], 2, ttnn.ROW_MAJOR_LAYOUT),  # concat on batch dim         # +
         # 4 tensors - ND sharding concat
         (4, [2, 64, 64], [1, 32, 32], 0, ttnn.TILE_LAYOUT),  # concat 4 tensors on batch  # -
         (4, [1, 64, 64], [1, 32, 32], 1, ttnn.TILE_LAYOUT),  # concat 4 tensors on height
         (4, [1, 64, 64], [1, 32, 32], 2, ttnn.TILE_LAYOUT),  # concat 4 tensors on width
-        #                (4, [1, 64, 64], [1, 32, 32], 0, ttnn.ROW_MAJOR_LAYOUT),    # RM concat 4 tensors on batch
+        (4, [1, 64, 64], [1, 32, 32], 0, ttnn.ROW_MAJOR_LAYOUT),  # RM concat 4 tensors on batch
+        (4, [1, 64, 64], [1, 32, 32], 1, ttnn.ROW_MAJOR_LAYOUT),  # RM concat 4 tensors on batch
+        (4, [1, 64, 64], [1, 32, 32], 2, ttnn.ROW_MAJOR_LAYOUT),  # RM concat 4 tensors on batch
+        # 5 tensors - ND sharding concat
+        (5, [2, 64, 64, 64], [1, 32, 32], 0, ttnn.TILE_LAYOUT),  # concat 5 tensors on batch  # -
+        (5, [1, 64, 64, 64], [1, 32, 32], 1, ttnn.TILE_LAYOUT),  # concat 5 tensors on height
+        (5, [1, 64, 64, 64], [1, 32, 32], 2, ttnn.TILE_LAYOUT),  # concat 5 tensors on width
+        (5, [1, 64, 64, 64], [1, 32, 32], 3, ttnn.TILE_LAYOUT),  # concat 5 tensors on ...
     ],
 )
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
@@ -450,6 +471,20 @@ def test_nd_sharded_concat(device, num_tensors, tensor_shape, shard_shape, conca
 
     # Convert back to torch and compare
     actual_output = ttnn.to_torch(ttnn_output)
+    # Set print options to show all tensor data
+    # torch.set_printoptions(profile="full")
+    # ttnn.set_printoptions(profile="full")
+
+    # # Now printing the tensor will show all elements
+    # print("Normal")
+    # print(torch_output)
+    # print("First")
+    # print(ttnn_tensors[0])
+    # print("My")
+    # print(actual_output)
+    # print("-----")
+    # ttnn.set_printoptions(profile="default")
+    # torch.set_printoptions(profile="default")
 
     assert_with_pcc(torch_output, actual_output, 0.999)
 

--- a/tests/ttnn/unit_tests/operations/data_movement/test_concat.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_concat.py
@@ -362,23 +362,20 @@ def test_concat_1d(device, layout, dim, input_shapes):
     "num_tensors, tensor_shape, shard_shape, concat_dim, layout",
     [
         # 2 tensors - basic ND sharding concat
-        # (3, [5, 192, 224], [1, 32, 32], 0, ttnn.TILE_LAYOUT),  # concat on batch dim         # +
-        (2, [5, 192, 224], [1, 32, 32], 1, ttnn.TILE_LAYOUT),  # concat on batch dim         # -
-        #        (2, [3, 128, 160], [1, 32, 32], 0, ttnn.TILE_LAYOUT),  # concat on batch dim         # +
-        # (2, [3, 128, 160], [1, 32, 32], 1, ttnn.TILE_LAYOUT),  # concat on height dim
-        #        (2, [3, 128, 160], [3, 128, 32], 2, ttnn.TILE_LAYOUT),  # concat on width dim
-        #        (2, [3, 4, 5], [1, 1, 5], 0, ttnn.ROW_MAJOR_LAYOUT),   # RM concat on batch
-        #        (2, [3, 4, 5], [3, 1, 5], 1, ttnn.ROW_MAJOR_LAYOUT),   # RM concat on height
+        (2, [5, 192, 224], [1, 32, 32], 0, ttnn.TILE_LAYOUT),  # concat on batch dim         # +
+        (2, [5, 192, 224], [1, 32, 32], 1, ttnn.TILE_LAYOUT),  # concat on batch dim         # +
+        (2, [5, 192, 224], [1, 32, 32], 2, ttnn.TILE_LAYOUT),  # concat on batch dim         # +
+        #        (2, [5, 192, 224], [1, 32, 32], 0, ttnn.ROW_MAJOR_LAYOUT),  # concat on batch dim         # +
         # 3 tensors - ND sharding concat
-        #        (3, [2, 64, 64], [1, 32, 32], 0, ttnn.TILE_LAYOUT),  # concat 3 tensors on batch     # +
-        #        (3, [2, 64, 64], [2, 32, 32], 1, ttnn.TILE_LAYOUT),    # concat 3 tensors on height
-        #        (3, [2, 64, 64], [2, 64, 32], 2, ttnn.TILE_LAYOUT),    # concat 3 tensors on width
-        #        (3, [2, 4, 8], [1, 4, 8], 0, ttnn.ROW_MAJOR_LAYOUT),   # RM concat 3 tensors
+        (3, [5, 192, 224], [1, 32, 32], 0, ttnn.TILE_LAYOUT),  # concat on batch dim         # +
+        (3, [5, 192, 224], [1, 32, 32], 1, ttnn.TILE_LAYOUT),  # concat on batch dim         # +
+        (3, [5, 192, 224], [1, 32, 32], 2, ttnn.TILE_LAYOUT),  # concat on batch dim         # +
+        #        (3, [5, 192, 224], [1, 32, 32], 0, ttnn.ROW_MAJOR_LAYOUT),  # concat on batch dim         # +
         # 4 tensors - ND sharding concat
-        #         (4, [2, 32, 32], [1, 32, 32], 0, ttnn.TILE_LAYOUT),    # concat 4 tensors on batch  # -
-        #        (4, [1, 64, 64], [1, 32, 32], 1, ttnn.TILE_LAYOUT),    # concat 4 tensors on height
-        #        (4, [1, 64, 64], [1, 64, 32], 2, ttnn.TILE_LAYOUT),    # concat 4 tensors on width
-        #        (4, [2, 4, 8], [2, 4, 8], 0, ttnn.ROW_MAJOR_LAYOUT),   # RM concat 4 tensors on batch
+        (4, [2, 64, 64], [1, 32, 32], 0, ttnn.TILE_LAYOUT),  # concat 4 tensors on batch  # -
+        (4, [1, 64, 64], [1, 32, 32], 1, ttnn.TILE_LAYOUT),  # concat 4 tensors on height
+        (4, [1, 64, 64], [1, 32, 32], 2, ttnn.TILE_LAYOUT),  # concat 4 tensors on width
+        #                (4, [1, 64, 64], [1, 32, 32], 0, ttnn.ROW_MAJOR_LAYOUT),    # RM concat 4 tensors on batch
     ],
 )
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])

--- a/tests/ttnn/unit_tests/operations/data_movement/test_concat.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_concat.py
@@ -355,27 +355,27 @@ def test_concat_1d(device, layout, dim, input_shapes):
 
 
 ##################
-# DN sharded
+# ND sharded
 
 
 @pytest.mark.parametrize(
     "num_tensors, tensor_shape, shard_shape, concat_dim, layout",
     [
         # 2 tensors - basic ND sharding concat
-        (2, [3, 128, 160], [1, 32, 32], 0, ttnn.TILE_LAYOUT),  # concat on batch dim
+        (2, [3, 128, 160], [1, 32, 32], 0, ttnn.TILE_LAYOUT),  # concat on batch dim         # +
         #        (2, [3, 128, 160], [3, 32, 32], 1, ttnn.TILE_LAYOUT),  # concat on height dim
         #        (2, [3, 128, 160], [3, 128, 32], 2, ttnn.TILE_LAYOUT),  # concat on width dim
         #        (2, [3, 4, 5], [1, 1, 5], 0, ttnn.ROW_MAJOR_LAYOUT),   # RM concat on batch
         #        (2, [3, 4, 5], [3, 1, 5], 1, ttnn.ROW_MAJOR_LAYOUT),   # RM concat on height
         # 3 tensors - ND sharding concat
-        #        (3, [2, 64, 64], [1, 32, 32], 0, ttnn.TILE_LAYOUT),  # concat 3 tensors on batch
+        #        (3, [2, 64, 64], [1, 32, 32], 0, ttnn.TILE_LAYOUT),  # concat 3 tensors on batch     # +
         #        (3, [2, 64, 64], [2, 32, 32], 1, ttnn.TILE_LAYOUT),    # concat 3 tensors on height
         #        (3, [2, 64, 64], [2, 64, 32], 2, ttnn.TILE_LAYOUT),    # concat 3 tensors on width
         #        (3, [2, 4, 8], [1, 4, 8], 0, ttnn.ROW_MAJOR_LAYOUT),   # RM concat 3 tensors
         # 4 tensors - ND sharding concat
-        #        (4, [1, 64, 64], [1, 32, 32], 1, ttnn.TILE_LAYOUT),  # concat 4 tensors on height
+        #         (4, [2, 32, 32], [1, 32, 32], 0, ttnn.TILE_LAYOUT),    # concat 4 tensors on batch  # -
+        #        (4, [1, 64, 64], [1, 32, 32], 1, ttnn.TILE_LAYOUT),    # concat 4 tensors on height
         #        (4, [1, 64, 64], [1, 64, 32], 2, ttnn.TILE_LAYOUT),    # concat 4 tensors on width
-        #        (4, [2, 32, 32], [1, 32, 32], 0, ttnn.TILE_LAYOUT),    # concat 4 tensors on batch
         #        (4, [2, 4, 8], [2, 4, 8], 0, ttnn.ROW_MAJOR_LAYOUT),   # RM concat 4 tensors on batch
     ],
 )

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -283,9 +283,12 @@ void create_and_cache_mesh_workload(
     ttnn::MeshDevice* mesh_device,
     tt::tt_metal::program_cache::detail::ProgramCache& program_cache,
     tt::stl::hash::hash_t program_hash) {
+    std::cout << "create_and_cache_mesh_workload 01\n";
     mesh_device_operation_t::validate_on_program_cache_miss(operation_attributes, tensor_args);
+    std::cout << "create_and_cache_mesh_workload 02\n";
 
     auto program_factory = mesh_device_operation_t::select_program_factory(operation_attributes, tensor_args);
+    std::cout << "create_and_cache_mesh_workload 03\n";
     auto program_factory_index = program_factory.index();
     auto log_msg_func = [] {
         log_warning(
@@ -364,9 +367,11 @@ void launch_operation_with_adapter(
     tt::stl::reflection::visit_object_of_type<Tensor>(CheckDeviceBufferIsAllocated{}, tensor_args);
 
     if (program_cache_hit) {
+        std::cout << "launch_operation_with_adapter 05\n";
         handle_mesh_adapter_cache_hit<mesh_device_operation_t>(
             operation_attributes, tensor_args, tensor_return_value, mesh_device, program_cache, program_hash);
     } else {
+        std::cout << "launch_operation_with_adapter 06\n";
         create_and_cache_mesh_workload<mesh_device_operation_t>(
             operation_attributes, tensor_args, tensor_return_value, mesh_device, program_cache, program_hash);
     }
@@ -527,7 +532,6 @@ typename device_operation_t::tensor_return_value_t launch(
     std::vector<std::reference_wrapper<const Tensor>> input_tensors;
     tt::stl::reflection::visit_object_of_type<Tensor>(
         [&input_tensors](const Tensor& t) { input_tensors.push_back(std::cref(t)); }, tensor_args);
-
     tt::tt_metal::GraphTracker::instance().track_function_start(
         detail::get_operation_name<device_operation_t>(operation_attributes), operation_attributes, input_tensors);
 
@@ -586,10 +590,12 @@ typename device_operation_t::tensor_return_value_t launch(
         }
     }
 
+    std::cout << "lavanch 08\n";
     detail::launch_operation_with_adapter<MeshDeviceOperationAdapter<device_operation_t>>(
         operation_attributes, tensor_args, tensor_return_value, mesh_device);
 
     tt::tt_metal::GraphTracker::instance().track_function_end(tensor_return_value);
+    std::cout << "lavanch 09\n";
     return tensor_return_value;
 }
 

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -590,12 +590,10 @@ typename device_operation_t::tensor_return_value_t launch(
         }
     }
 
-    std::cout << "lavanch 08\n";
     detail::launch_operation_with_adapter<MeshDeviceOperationAdapter<device_operation_t>>(
         operation_attributes, tensor_args, tensor_return_value, mesh_device);
 
     tt::tt_metal::GraphTracker::instance().track_function_end(tensor_return_value);
-    std::cout << "lavanch 09\n";
     return tensor_return_value;
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/data_movement/CMakeLists.txt
@@ -118,6 +118,7 @@ target_sources(
         concat/device/concat_s2s_rm_program_factory.cpp
         concat/device/concat_s2s_multi_program_factory.cpp
         concat/device/concat_s2i_program_factory.cpp
+        concat/device/concat_nd_sharded_program_factory.cpp
         copy/copy.cpp
         copy/device/copy_device_operation.cpp
         copy/device/copy_program_factory.cpp

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
@@ -333,9 +333,8 @@ ttnn::Tensor ConcatOperation::invoke(
         untilize_rm_retilize_concat.sequence(unsqueeze_squeeze_1D_concat.sequence(non_aligned_last_dim_concat));
 
     const std::vector<ttnn::Tensor>& itensors(input_tensors);
-    std::cout << "ConcatOperation::invoke: I have got here 6\n";
     auto res = massaged_concat(itensors, dim, groups);
-    std::cout << "ConcatOperation::invoke: I have got here 7\n";
+    std::cout << "ConcatOperation::invoke: leaving - Yau\n";
     return res;
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
@@ -99,7 +99,6 @@ MassagedConcat build_untilize_rm_retilize_concat(
                         tensor.logical_shape().rank() == 1);
             });
             concat_db_print(res, "untilize_rm_retilize required");
-            std::cout << "build_untilize_rm_retilize_concat.predicate " << (int)res << ": I have got here\n";
             return res;
         },
         .pre_transform = [output_memory_config](const std::vector<ttnn::Tensor>& tensors, int dim, unsigned int groups)
@@ -135,10 +134,8 @@ MassagedConcat build_untilize_rm_retilize_concat(
         },
         .operation = [&output_memory_config](
                          const std::vector<ttnn::Tensor>& tensors, int dim, unsigned int groups) -> ttnn::Tensor {
-            std::cout << "build_untilize_rm_retilize_concat.operation IN" << ": I have got here\n";
             const std::vector<ttnn::Tensor>& itensors(tensors);
             auto res = concat_impl(itensors, dim, groups, output_memory_config);
-            std::cout << "build_untilize_rm_retilize_concat.operation OUT" << ": I have got here\n";
             return res;
         }});
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
@@ -235,6 +235,15 @@ TensorSpec ConcatDeviceOperation::compute_output_specs(
             first_spec.orientation,
             first_spec.shard_distribution_strategy);
         const MemoryConfig output_mem_config(ref_in_tensor.memory_config().buffer_type(), std::move(output_nd_spec));
+
+        // ensure correct memory config
+        // TODO: - to clarify: by overwriting const object (to sort out - where args.output_mem_config could be
+        // established correctly?)
+        if (args.output_mem_config == ttnn::DRAM_MEMORY_CONFIG ||   // default if it came empty
+            !args.output_mem_config.nd_shard_spec().has_value()) {  // output for nd sharding should be the same
+            std::cout << "ensure correct memory config\n";
+            const_cast<MemoryConfig&>(args.output_mem_config) = output_mem_config;
+        }
         return TensorSpec(
             shape_out, TensorLayout(ref_in_tensor.dtype(), PageConfig(ref_in_tensor.layout()), output_mem_config));
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
@@ -5,6 +5,7 @@
 #include "concat_device_operation.hpp"
 #include "ttnn/device_operation.hpp"
 #include "concat_program_factory.hpp"
+#include "concat_nd_sharded_program_factory.hpp"
 
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/data_movement/clone/clone.hpp"
@@ -37,9 +38,8 @@ ConcatDeviceOperation::program_factory_t ConcatDeviceOperation::select_program_f
 
     if (output_is_sharded) {
         if (const auto& first_nd_shard_spec = input_tensors[0].nd_shard_spec(); first_nd_shard_spec.has_value()) {
-            std::cout << "~~~~~~~~~~~~~~~~~~~~~~~~~~\n";
-            TT_FATAL(!first_nd_shard_spec.has_value(), "expected string");
-            return ConcatS2IProgramFactory{};
+            std::cout << "ConcatNDShardedProgramFactory\n~~~~~~~~~~~~~~~~~~~~~~~~~~\n";
+            return ConcatNDShardedProgramFactory{};
         } else
             // Sharded-to-sharded (s2s) cases
             if (input_tensors.size() == 2) {

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
@@ -239,10 +239,11 @@ TensorSpec ConcatDeviceOperation::compute_output_specs(
         // ensure correct memory config
         // TODO: - to clarify: by overwriting const object (to sort out - where args.output_mem_config could be
         // established correctly?)
+        // TODO: as a guess some constness need to be reworked
         if (args.output_mem_config == ttnn::DRAM_MEMORY_CONFIG ||   // default if it came empty
             !args.output_mem_config.nd_shard_spec().has_value()) {  // output for nd sharding should be the same
             std::cout << "ensure correct memory config\n";
-            const_cast<MemoryConfig&>(args.output_mem_config) = output_mem_config;
+            const_cast<decltype(args.output_mem_config)&>(args.output_mem_config) = output_mem_config;
         }
         return TensorSpec(
             shape_out, TensorLayout(ref_in_tensor.dtype(), PageConfig(ref_in_tensor.layout()), output_mem_config));

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
@@ -100,6 +100,9 @@ void ConcatDeviceOperation::validate_on_program_cache_miss(
                 TT_FATAL(
                     in_ref.nd_shard_spec().value().grid == first_nd_shard_spec.value().grid,
                     "ND Sharded tensors must have the same grid.");
+                TT_FATAL(
+                    in_ref.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED,
+                    "Block sharded inputs necessary for ND sharded tensors");
 
                 // Verify that shard shapes differ only in the concat dimension
                 const auto& first_shard_shape = first_nd_shard_spec.value().shard_shape;
@@ -134,7 +137,11 @@ void ConcatDeviceOperation::validate_on_program_cache_miss(
                 TT_FATAL(
                     in_ref.shard_spec().value().grid == first_input.shard_spec().value().grid,
                     "Sharded tensors must have the same grid.");
+                TT_FATAL(
+                    in_ref.memory_config().memory_layout() != TensorMemoryLayout::BLOCK_SHARDED,
+                    "Block sharded inputs are not supported");
             }
+
             TT_FATAL(
                 in_ref.memory_config().memory_layout() == first_input.memory_config().memory_layout(),
                 "Sharded tensors must have the same memory layout.");
@@ -142,10 +149,6 @@ void ConcatDeviceOperation::validate_on_program_cache_miss(
             TT_FATAL(
                 input_tensors.size() > 2 || in_ref.memory_config().memory_layout() != TensorMemoryLayout::WIDTH_SHARDED,
                 "Width sharded inputs are not supported for two tensors concat yet");
-            // TODO:Z Next TT_FATAL - to bypass
-            TT_FATAL(
-                in_ref.memory_config().memory_layout() != TensorMemoryLayout::BLOCK_SHARDED,
-                "Block sharded inputs are not supported");
         }
     }
     if (warn_about_alignment) {

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
@@ -93,10 +93,20 @@ void ConcatDeviceOperation::validate_on_program_cache_miss(
         TT_FATAL(curr_shape == shape_first, "concat tensors differ in shape across non-concat dimensions.");
         TT_FATAL(in_ref.is_sharded() == shard_first, "All tensors must be sharded or all must be interleaved");
         if (shard_first) {
-            TT_FATAL(in_ref.shard_spec().has_value(), "Sharded tensors must have a shard spec.");
-            TT_FATAL(
-                in_ref.shard_spec().value().grid == first_input.shard_spec().value().grid,
-                "Sharded tensors must have the same grid.");
+            if (first_input.nd_shard_spec().has_value()) {
+                TT_FATAL(in_ref.nd_shard_spec().has_value(), "ND Sharded tensors must have a shard spec.");
+
+                // TODO:Z add nd sharding verification possibility here
+                //  need to be different at the same dimention
+                TT_FATAL(
+                    in_ref.nd_shard_spec().value().grid == first_input.nd_shard_spec().value().grid,
+                    "ND Sharded tensors must have the same grid.");
+            } else {
+                TT_FATAL(in_ref.shard_spec().has_value(), "Sharded tensors must have a shard spec.");
+                TT_FATAL(
+                    in_ref.shard_spec().value().grid == first_input.shard_spec().value().grid,
+                    "Sharded tensors must have the same grid.");
+            }
             TT_FATAL(
                 in_ref.memory_config().memory_layout() == first_input.memory_config().memory_layout(),
                 "Sharded tensors must have the same memory layout.");

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
@@ -219,15 +219,10 @@ TensorSpec ConcatDeviceOperation::compute_output_specs(
     std::cout << "compute_output_specs: shape_out=" << shape_out << "\n";
 
     // When ref input has ND sharding, build output TensorSpec with derived NdShardSpec:
-    // same grid/orientation/strategy, shard_shape with concat dim = sum of input shard shapes along that dim.
+    // same grid/orientation/strategy. Use first input's shard_shape for the output.
     if (const auto& ref_nd_spec = ref_in_tensor.nd_shard_spec(); ref_nd_spec.has_value()) {
         const auto& first_spec = ref_nd_spec.value();
         ttnn::Shape output_shard_shape = first_spec.shard_shape;
-        output_shard_shape[args.dim] = 0;
-        for (const Tensor& in_ref : tensor_args.input_tensors) {
-            const auto& in_nd = in_ref.nd_shard_spec().value();
-            output_shard_shape[args.dim] += in_nd.shard_shape[args.dim];
-        }
         std::cout << "compute_output_specs: output_shard_shape=" << output_shard_shape << "\n";
         NdShardSpec output_nd_spec(
             std::move(output_shard_shape),

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
@@ -121,6 +121,16 @@ void ConcatDeviceOperation::validate_on_program_cache_miss(
                     first_shard_shape.rank(),
                     curr_shard_shape.rank());
 
+                const tt::tt_metal::Shape& first_logical_shape = in_ref.logical_shape();
+                const tt::tt_metal::Shape& first_padded_shape = in_ref.padded_shape();
+                // TODO: should be rewritten later - but now it is for cool, rounded calculations
+                TT_FATAL(
+                    first_logical_shape == first_padded_shape,
+                    "ND Sharded tensors must have shard logical and padded shapes the same. "
+                    "First tensor shard rank: {}, Current tensor shard rank: {}",
+                    first_logical_shape,
+                    first_padded_shape);
+
                 // verify dimensions
                 for (uint32_t dim_idx = 0; dim_idx < first_shard_shape.rank(); ++dim_idx) {
                     if (dim_idx == args.dim) {

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.hpp
@@ -12,6 +12,7 @@
 #include "concat_s2s_rm_program_factory.hpp"
 #include "concat_s2s_multi_program_factory.hpp"
 #include "concat_s2i_program_factory.hpp"
+#include "concat_nd_sharded_program_factory.hpp"
 
 #include "ttnn/decorators.hpp"
 
@@ -29,7 +30,8 @@ struct ConcatDeviceOperation {
         ConcatS2STiledProgramFactory,
         ConcatS2SRMProgramFactory,
         ConcatS2SMultiProgramFactory,
-        ConcatS2IProgramFactory>;
+        ConcatS2IProgramFactory,
+        ConcatNDShardedProgramFactory>;
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
 

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.cpp
@@ -1,0 +1,178 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "concat_nd_sharded_program_factory.hpp"
+
+#include <algorithm>
+#include <numeric>
+
+#include "ttnn/tensor/tensor.hpp"
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/buffer_distribution_spec.hpp>
+
+namespace ttnn::prim {
+
+namespace {
+
+// Returns the index of `core` in `cores` vector, or cores.size() if not found.
+size_t find_core_index(const CoreCoord& core, const std::vector<CoreCoord>& cores) {
+    auto it = std::find(cores.begin(), cores.end(), core);
+    return static_cast<size_t>(it - cores.begin());
+}
+
+}  // namespace
+
+// Creates the device program for ND sharded concat: one program with reader and writer kernels
+// that copy each core's input shards (in concat order) into the output shard. Reader and writer
+// split the input range so both RISC-V processors can run in parallel.
+ConcatNDShardedProgramFactory::cached_program_t ConcatNDShardedProgramFactory::create(
+    const ConcatParams& /*operation_attributes*/, const ConcatInputs& tensor_args, Tensor& tensor_return_value) {
+    using namespace tt::constants;
+    using namespace tt::tt_metal;
+
+    const auto& input_tensors = tensor_args.input_tensors;
+    Tensor& output = tensor_return_value;
+    const uint32_t num_input_tensors = static_cast<uint32_t>(input_tensors.size());
+
+    TT_FATAL(!input_tensors.empty(), "ND sharded concat requires at least one input");
+    TT_FATAL(input_tensors[0].nd_shard_spec().has_value(), "First input must be ND sharded");
+    TT_FATAL(output.nd_shard_spec().has_value(), "Output must be ND sharded");
+
+    const auto& first_nd_spec = input_tensors[0].nd_shard_spec().value();
+    const CoreRangeSet all_cores = first_nd_spec.grid;
+    const ShardOrientation orientation = first_nd_spec.orientation;
+    const bool is_row_major = (orientation == ShardOrientation::ROW_MAJOR);
+
+    // Core list order must match the order used by each buffer's distribution spec for correct core_idx.
+    std::vector<CoreCoord> cores = corerange_to_cores(all_cores, std::nullopt, is_row_major);
+
+    Program program = CreateProgram();
+
+    // All inputs and output share the same grid; use first input's buffer for alignment/page size.
+    const uint32_t page_size = input_tensors[0].buffer()->aligned_page_size();
+    const tt::DataFormat cb_data_format = datatype_to_dataformat_converter(output.dtype());
+    const uint32_t cb_dst_id = 16;
+    TT_FATAL(num_input_tensors <= cb_dst_id, "ND sharded concat supports at most {} inputs", cb_dst_id);
+
+    // Distribution specs from buffers (already set when tensors are allocated with ND sharding).
+    std::vector<const BufferDistributionSpec*> input_dist_specs(num_input_tensors);
+    for (uint32_t i = 0; i < num_input_tensors; ++i) {
+        TT_FATAL(
+            input_tensors[i].buffer()->buffer_distribution_spec().has_value(),
+            "ND sharded input {} must have buffer distribution spec",
+            i);
+        input_dist_specs[i] = &input_tensors[i].buffer()->buffer_distribution_spec().value();
+    }
+    TT_FATAL(
+        output.buffer()->buffer_distribution_spec().has_value(),
+        "ND sharded output must have buffer distribution spec");
+    const BufferDistributionSpec& output_dist_spec = output.buffer()->buffer_distribution_spec().value();
+
+    // Input CBs: each backed by the corresponding input buffer so each core sees only its shard.
+    std::vector<CBHandle> cb_inputs(num_input_tensors);
+    for (uint32_t input_id = 0; input_id < num_input_tensors; ++input_id) {
+        const BufferDistributionSpec& spec = *input_dist_specs[input_id];
+        uint32_t max_pages = static_cast<uint32_t>(spec.max_num_dev_pages_per_core());
+        const CircularBufferConfig input_cb_config =
+            CircularBufferConfig(page_size * max_pages, {{input_id, cb_data_format}})
+                .set_page_size(input_id, page_size)
+                .set_globally_allocated_address(*input_tensors[input_id].buffer());
+        cb_inputs[input_id] = CreateCircularBuffer(program, all_cores, input_cb_config);
+    }
+
+    // Output CB: backed by output buffer; each core writes its output shard.
+    uint32_t output_max_pages = static_cast<uint32_t>(output_dist_spec.max_num_dev_pages_per_core());
+    const CircularBufferConfig output_cb_config =
+        CircularBufferConfig(page_size * output_max_pages, {{cb_dst_id, cb_data_format}})
+            .set_page_size(cb_dst_id, page_size)
+            .set_globally_allocated_address(*output.buffer());
+    CBHandle cb_output = CreateCircularBuffer(program, all_cores, output_cb_config);
+
+    // Compile-time args for reader/writer: output CB id, page size, number of inputs.
+    std::vector<uint32_t> compile_time_args = {cb_dst_id, page_size, num_input_tensors};
+
+    // Reader: reads from input CBs (in concat order) and writes into output CB.
+    // Writer: same kernel, different runtime args to split work (first half of inputs vs second half).
+    KernelHandle reader_kernel_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_nd_sharded.cpp",
+        all_cores,
+        ReaderDataMovementConfig(compile_time_args));
+
+    KernelHandle writer_kernel_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/writer_concat_nd_sharded.cpp",
+        all_cores,
+        WriterDataMovementConfig(compile_time_args));
+
+    // Per-core runtime args: [start_input_id, end_input_id, (num_pages, write_offset_in_pages) for each input in
+    // [start,end)). Reader handles inputs [0, mid), writer handles [mid, num_input_tensors).
+    const uint32_t mid = (num_input_tensors + 1) / 2;
+
+    for (const CoreCoord& core : cores) {
+        const size_t core_idx = find_core_index(core, output_dist_spec.cores());
+        if (core_idx >= output_dist_spec.num_cores()) {
+            continue;
+        }
+
+        uint32_t output_write_offset_pages = 0;
+        std::vector<uint32_t> input_num_pages(num_input_tensors);
+        std::vector<uint32_t> input_write_offsets_pages(num_input_tensors);
+
+        for (uint32_t input_id = 0; input_id < num_input_tensors; ++input_id) {
+            const BufferDistributionSpec& in_spec = *input_dist_specs[input_id];
+            const size_t in_core_idx = find_core_index(core, in_spec.cores());
+            const uint32_t num_pages = (in_core_idx < in_spec.num_cores())
+                                           ? static_cast<uint32_t>(in_spec.num_dev_pages_per_core(in_core_idx))
+                                           : 0;
+            input_num_pages[input_id] = num_pages;
+            input_write_offsets_pages[input_id] = output_write_offset_pages;
+            output_write_offset_pages += num_pages;
+        }
+
+        std::vector<uint32_t> reader_runtime_args = {0u, mid};
+        for (uint32_t input_id = 0; input_id < mid; ++input_id) {
+            reader_runtime_args.push_back(input_num_pages[input_id]);
+            reader_runtime_args.push_back(input_write_offsets_pages[input_id]);
+        }
+        std::vector<uint32_t> writer_runtime_args = {mid, num_input_tensors};
+        for (uint32_t input_id = mid; input_id < num_input_tensors; ++input_id) {
+            writer_runtime_args.push_back(input_num_pages[input_id]);
+            writer_runtime_args.push_back(input_write_offsets_pages[input_id]);
+        }
+
+        SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
+        SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
+    }
+
+    return {
+        std::move(program),
+        {.num_input_tensors = num_input_tensors,
+         .cb_inputs = cb_inputs,
+         .cb_output = cb_output,
+         .reader_kernel_id = reader_kernel_id,
+         .writer_kernel_id = writer_kernel_id,
+         .all_cores = all_cores,
+         .cores = cores}};
+}
+
+// Updates buffer addresses in the cached program when the same program is reused with
+// different tensor pointers (e.g. program cache hit with new tensor allocations).
+void ConcatNDShardedProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const ConcatParams& /*operation_attributes*/,
+    const ConcatInputs& tensor_args,
+    Tensor& tensor_return_value) {
+    auto& program = cached_program.program;
+    const auto& shared_vars = cached_program.shared_variables;
+
+    for (uint32_t input_id = 0; input_id < shared_vars.num_input_tensors; ++input_id) {
+        UpdateDynamicCircularBufferAddress(
+            program, shared_vars.cb_inputs[input_id], *tensor_args.input_tensors[input_id].buffer());
+    }
+    UpdateDynamicCircularBufferAddress(program, shared_vars.cb_output, *tensor_return_value.buffer());
+}
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.cpp
@@ -127,11 +127,15 @@ ConcatNDShardedProgramFactory::cached_program_t ConcatNDShardedProgramFactory::c
     // [start,end)). Reader handles inputs [0, mid), writer handles [mid, num_input_tensors).
     const uint32_t mid = (num_input_tensors + 1) / 2;
 
+    std::cout << "cores amount " << cores.size() << " output cores amount " << output_dist_spec.cores().size() << "\n";
+
+    uint32_t cn = 0;
     for (const CoreCoord& core : cores) {
         const size_t core_idx = find_core_index(core, output_dist_spec.cores());
         if (core_idx >= output_dist_spec.num_cores()) {
             continue;
         }
+        std::cout << "core x :" << ++cn << "\n";
 
         uint32_t output_write_offset_pages = 0;
         std::vector<uint32_t> input_num_pages(num_input_tensors);
@@ -161,7 +165,7 @@ ConcatNDShardedProgramFactory::cached_program_t ConcatNDShardedProgramFactory::c
 
         SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
         SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
-    }
+    }  // for cores
 
     return {
         std::move(program),

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.cpp
@@ -24,39 +24,6 @@ using namespace tt::tt_metal;
 
 constexpr uint32_t CONCAT_ND_SHARDED_MAX_NUM_INPUTS = ttnn::kernel::CONCAT_ND_SHARDED_MAX_NUM_INPUTS;
 
-// Returns the device address of the buffer on the given core (start of this core's shard).
-// For sharded buffers, uses the buffer's page mapping to get device_start_page for the core.
-uint32_t get_buffer_address_for_core(Buffer* buffer, const CoreCoord& core) {
-    TT_FATAL(buffer->buffer_distribution_spec().has_value(), "ND sharded concat expects sharded buffers");
-    const auto& page_mapping = buffer->get_buffer_page_mapping();
-    auto it = page_mapping->core_to_core_id.find(core);
-    TT_FATAL(it != page_mapping->core_to_core_id.end(), "Core not found in buffer page mapping");
-    uint32_t core_id = it->second;
-    TT_FATAL(
-        core_id < page_mapping->core_page_mappings.size() && !page_mapping->core_page_mappings[core_id].empty(),
-        "No page mapping for core");
-    const auto& core_mapping = page_mapping->core_page_mappings[core_id][0];
-    uint32_t address = buffer->address() + core_mapping.device_start_page * buffer->aligned_page_size();
-    if (buffer->is_dram()) {
-        address += buffer->device()->allocator()->get_bank_offset(
-            BufferType::DRAM, buffer->device()->dram_channel_from_logical_core(core));
-    }
-    return address;
-}
-
-// Unroll grid into a vector of CoreCoord in row-major order.
-std::vector<CoreCoord> grid_to_coresA(const CoreRangeSet& grid) {
-    std::vector<CoreCoord> cores;
-    for (const CoreRange& range : grid.ranges()) {
-        for (uint32_t y = range.start_coord.y; y <= range.end_coord.y; ++y) {
-            for (uint32_t x = range.start_coord.x; x <= range.end_coord.x; ++x) {
-                cores.push_back(CoreCoord{x, y});
-            }
-        }
-    }
-    return cores;
-}
-
 }  // namespace
 
 // Creates the device program for ND sharded concat: a single reader kernel on each core that
@@ -79,33 +46,45 @@ ConcatNDShardedProgramFactory::cached_program_t ConcatNDShardedProgramFactory::c
 
     const auto& nd_shard_spec = input_tensors[0].nd_shard_spec().value();
     const CoreRangeSet all_cores = nd_shard_spec.grid;
-    const std::vector<CoreCoord> cores = grid_to_coresA(all_cores);
+    const std::vector<CoreCoord> cores =
+        corerange_to_cores(all_cores, std::nullopt, nd_shard_spec.orientation == ShardOrientation::ROW_MAJOR);
 
     Program program = CreateProgram();
 
-    // Single scratch CB for the reader: one page for copy (read page -> write to output).
-    const uint32_t page_size = output.buffer()->aligned_page_size();
-    const uint32_t cb_id_scratch = 0;
-    CircularBufferConfig cb_config =
-        CircularBufferConfig(page_size, {{cb_id_scratch, datatype_to_dataformat_converter(output.dtype())}})
-            .set_page_size(cb_id_scratch, page_size);
-    CreateCircularBuffer(program, all_cores, cb_config);
-
-    // Compile-time args: num_input_tensors, then 17x page_size (for make_tensor_accessor_tuple), then
-    // TensorAccessorArgs.
-    std::vector<uint32_t> reader_compile_time_args;
-    reader_compile_time_args.push_back(num_input_tensors);
-    for (uint32_t i = 0; i < 1u + CONCAT_ND_SHARDED_MAX_NUM_INPUTS; ++i) {
-        reader_compile_time_args.push_back(static_cast<uint32_t>(page_size));
+    // Page sizes: output and each of 16 input slots (fill absent from first input)
+    const uint32_t output_page_size = output.buffer()->aligned_page_size();
+    std::array<uint32_t, CONCAT_ND_SHARDED_MAX_NUM_INPUTS> input_page_sizes;
+    for (uint32_t i = 0; i < CONCAT_ND_SHARDED_MAX_NUM_INPUTS; ++i) {
+        const Buffer* buf = (i < num_input_tensors) ? input_tensors[i].buffer() : input_tensors[0].buffer();
+        input_page_sizes[i] = buf->aligned_page_size();
     }
 
-    TensorAccessorArgs(output.buffer()).append_to(reader_compile_time_args);
+    // Compile-time args: num_input_tensors, output_page_size, input_page_sizes[0..15],
+    // then output TensorAccessorArgs, then 16 input TensorAccessorArgs (absent filled from first input).
+    std::vector<uint32_t> reader_compile_time_args = {
+        num_input_tensors,
+        output_page_size,
+    };
+    for (uint32_t i = 0; i < CONCAT_ND_SHARDED_MAX_NUM_INPUTS; ++i) {
+        reader_compile_time_args.push_back(input_page_sizes[i]);
+    }
+
+    TensorAccessorArgs(*output.buffer()).append_to(reader_compile_time_args);
+    for (uint32_t i = 0; i < CONCAT_ND_SHARDED_MAX_NUM_INPUTS; ++i) {
+        const Buffer* buf = (i < num_input_tensors) ? input_tensors[i].buffer() : input_tensors[0].buffer();
+        TensorAccessorArgs(*buf).append_to(reader_compile_time_args);
+    }
+
+    // CB for reader: one page (max of output and any input page size)
+    uint32_t cb_page_size = output_page_size;
     for (uint32_t i = 0; i < num_input_tensors; ++i) {
-        TensorAccessorArgs(input_tensors[i].buffer()).append_to(reader_compile_time_args);
+        cb_page_size = std::max(cb_page_size, static_cast<uint32_t>(input_tensors[i].buffer()->aligned_page_size()));
     }
-    for (uint32_t i = num_input_tensors; i < CONCAT_ND_SHARDED_MAX_NUM_INPUTS; ++i) {
-        TensorAccessorArgs(input_tensors[0].buffer()).append_to(reader_compile_time_args);
-    }
+    const tt::DataFormat data_format = datatype_to_dataformat_converter(output.dtype());
+    constexpr uint32_t cb_index = 0;
+    CircularBufferConfig cb_config =
+        CircularBufferConfig(cb_page_size * 1, {{cb_index, data_format}}).set_page_size(cb_index, cb_page_size);
+    CreateCircularBuffer(program, all_cores, cb_config);
 
     KernelHandle reader_kernel_id = CreateKernel(
         program,
@@ -113,32 +92,27 @@ ConcatNDShardedProgramFactory::cached_program_t ConcatNDShardedProgramFactory::c
         all_cores,
         ReaderDataMovementConfig(reader_compile_time_args));
 
-    // Per-core runtime args: [output_addr, input0_addr, ..., input15_addr, shard_id] (fixed 18 args)
+    // Runtime args per core: 17 buffer addresses (output, in0..in15), then shard_id
     for (size_t c = 0; c < cores.size(); ++c) {
-        const CoreCoord& core = cores[c];
         std::vector<uint32_t> runtime_args;
-        runtime_args.reserve(18u);
-        runtime_args.push_back(get_buffer_address_for_core(output.buffer(), core));
-        for (uint32_t i = 0; i < num_input_tensors; ++i) {
-            runtime_args.push_back(get_buffer_address_for_core(input_tensors[i].buffer(), core));
+        runtime_args.push_back(output.buffer()->address());
+        for (uint32_t i = 0; i < CONCAT_ND_SHARDED_MAX_NUM_INPUTS; ++i) {
+            const Buffer* buf = (i < num_input_tensors) ? input_tensors[i].buffer() : input_tensors[0].buffer();
+            runtime_args.push_back(buf->address());
         }
-        for (uint32_t i = num_input_tensors; i < CONCAT_ND_SHARDED_MAX_NUM_INPUTS; ++i) {
-            runtime_args.push_back(0u);  // unused; kernel only uses first 1 + num_input_tensors
-        }
-        runtime_args.push_back(static_cast<uint32_t>(c));  // shard_id
-        SetRuntimeArgs(program, reader_kernel_id, core, runtime_args);
+        runtime_args.push_back(static_cast<uint32_t>(c));
+        SetRuntimeArgs(program, reader_kernel_id, cores[c], runtime_args);
     }
 
-    ConcatNDShardedSharedVariables shared_vars;
-    shared_vars.num_input_tensors = num_input_tensors;
-    shared_vars.reader_kernel_id = reader_kernel_id;
-    shared_vars.all_cores = all_cores;
-    shared_vars.cores = cores;
-    shared_vars.cb_inputs.clear();
-    shared_vars.cb_output = 0;
-    shared_vars.writer_kernel_id = 0;
-
-    return cached_program_t{std::move(program), std::move(shared_vars)};
+    return cached_program_t{
+        std::move(program),
+        {.num_input_tensors = num_input_tensors,
+         .cb_inputs = {},
+         .cb_output = tt::CBIndex::c_0,
+         .reader_kernel_id = reader_kernel_id,
+         .writer_kernel_id = 0,
+         .all_cores = all_cores,
+         .cores = cores}};
 }
 
 // Updates buffer addresses in the cached program when the same program is reused with
@@ -152,20 +126,18 @@ void ConcatNDShardedProgramFactory::override_runtime_arguments(
     const auto& shared_vars = cached_program.shared_variables;
     const uint32_t num_input_tensors = shared_vars.num_input_tensors;
     const std::vector<CoreCoord>& cores = shared_vars.cores;
+    const std::vector<Tensor>& input_tensors = tensor_args.input_tensors;
+    Tensor& output = tensor_return_value;
 
     for (size_t c = 0; c < cores.size(); ++c) {
-        const CoreCoord& core = cores[c];
         std::vector<uint32_t> runtime_args;
-        runtime_args.reserve(18u);
-        runtime_args.push_back(get_buffer_address_for_core(tensor_return_value.buffer(), core));
-        for (uint32_t i = 0; i < num_input_tensors; ++i) {
-            runtime_args.push_back(get_buffer_address_for_core(tensor_args.input_tensors[i].buffer(), core));
+        runtime_args.push_back(output.buffer()->address());
+        for (uint32_t i = 0; i < CONCAT_ND_SHARDED_MAX_NUM_INPUTS; ++i) {
+            const Buffer* buf = (i < num_input_tensors) ? input_tensors[i].buffer() : input_tensors[0].buffer();
+            runtime_args.push_back(buf->address());
         }
-        for (uint32_t i = num_input_tensors; i < CONCAT_ND_SHARDED_MAX_NUM_INPUTS; ++i) {
-            runtime_args.push_back(0u);
-        }
-        runtime_args.push_back(static_cast<uint32_t>(c));  // shard_id
-        SetRuntimeArgs(program, shared_vars.reader_kernel_id, core, runtime_args);
+        runtime_args.push_back(static_cast<uint32_t>(c));
+        SetRuntimeArgs(program, shared_vars.reader_kernel_id, cores[c], runtime_args);
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.cpp
@@ -132,8 +132,8 @@ ConcatNDShardedProgramFactory::cached_program_t ConcatNDShardedProgramFactory::c
         single_core_set,
         ReaderDataMovementConfig(reader_compile_time_args));
 
-    // Runtime args for the single core: scratch_l1_addr, output addr, then per-input (addr, first_shard_pos,
-    // shards_to_write, shards_to_skip), then shard_id
+    // Runtime args for the single core: scratch_l1_addr, output addr, then per-input (addr, absolute_offset_to_start,
+    // amount_to_write, amount_to_skip), then shard_id
     {
         std::vector<uint32_t> runtime_args;
         runtime_args.push_back(scratch_l1_addr);
@@ -141,13 +141,13 @@ ConcatNDShardedProgramFactory::cached_program_t ConcatNDShardedProgramFactory::c
         for (uint32_t i = 0; i < CONCAT_ND_SHARDED_MAX_NUM_INPUTS; ++i) {
             const Buffer* buf = (i < num_input_tensors) ? input_tensors[i].buffer() : input_tensors[0].buffer();
             runtime_args.push_back(buf->address());
-            uint32_t first_shard_pos{0};  //  - to rework - it could be absolute pos inside the tensor to write
-            uint32_t shards_to_write{0};  //  - to fill later  - it could be amount of data to copy
-            uint32_t shards_to_skip{
+            uint32_t absolute_offset_to_start{0};  //  - to rework - it could be absolute pos inside the tensor to write
+            uint32_t amount_to_write{0};           //  - to fill later  - it could be amount of data to copy
+            uint32_t amount_to_skip{
                 0};  //  - to fill later   - it could be how much data to skip to copy next amount of data
-            runtime_args.push_back(first_shard_pos);
-            runtime_args.push_back(shards_to_write);
-            runtime_args.push_back(shards_to_skip);
+            runtime_args.push_back(absolute_offset_to_start);
+            runtime_args.push_back(amount_to_write);
+            runtime_args.push_back(amount_to_skip);
         }
         runtime_args.push_back(static_cast<uint32_t>(max_core_index));
         SetRuntimeArgs(program, reader_kernel_id, max_core, runtime_args);
@@ -197,12 +197,12 @@ void ConcatNDShardedProgramFactory::override_runtime_arguments(
     for (uint32_t i = 0; i < CONCAT_ND_SHARDED_MAX_NUM_INPUTS; ++i) {
         const Buffer* buf = (i < num_input_tensors) ? input_tensors[i].buffer() : input_tensors[0].buffer();
         runtime_args.push_back(buf->address());
-        uint32_t first_shard_pos{0};  //  - to fill later
-        uint32_t shards_to_write{0};  //  - to fill later
-        uint32_t shards_to_skip{0};   //  - to fill later
-        runtime_args.push_back(first_shard_pos);
-        runtime_args.push_back(shards_to_write);
-        runtime_args.push_back(shards_to_skip);
+        uint32_t absolute_offset_to_start{0};  //  - to fill later
+        uint32_t amount_to_write{0};           //  - to fill later
+        uint32_t amount_to_skip{0};            //  - to fill later
+        runtime_args.push_back(absolute_offset_to_start);
+        runtime_args.push_back(amount_to_write);
+        runtime_args.push_back(amount_to_skip);
     }
     runtime_args.push_back(shard_id);
     SetRuntimeArgs(program, shared_vars.reader_kernel_id, single_core, runtime_args);

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.cpp
@@ -58,6 +58,7 @@ ConcatNDShardedProgramFactory::cached_program_t ConcatNDShardedProgramFactory::c
     const CoreCoord max_core = *max_core_it;
     const size_t max_core_index = static_cast<size_t>(std::distance(cores.begin(), max_core_it));
     const CoreRangeSet single_core_set = CoreRangeSet(CoreRange(max_core));
+    std::cout << "max_core_it " << max_core.x << " " << max_core.y << "\n";
 
     Program program = CreateProgram();
 

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.cpp
@@ -7,34 +7,61 @@
 
 #include <algorithm>
 #include <numeric>
+#include <vector>
 
 #include "ttnn/tensor/tensor.hpp"
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/buffer_distribution_spec.hpp>
+#include <tt-metalium/buffer_page_mapping.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 
 namespace ttnn::prim {
 
 namespace {
 
-// Returns the index of `core` in `cores` vector, or cores.size() if not found.
-size_t find_core_index(const CoreCoord& core, const std::vector<CoreCoord>& cores) {
-    auto it = std::find(cores.begin(), cores.end(), core);
-    return static_cast<size_t>(it - cores.begin());
+using namespace tt::tt_metal;
+
+constexpr uint32_t CONCAT_ND_SHARDED_MAX_NUM_INPUTS = ttnn::kernel::CONCAT_ND_SHARDED_MAX_NUM_INPUTS;
+
+// Returns the device address of the buffer on the given core (start of this core's shard).
+// For sharded buffers, uses the buffer's page mapping to get device_start_page for the core.
+uint32_t get_buffer_address_for_core(Buffer* buffer, const CoreCoord& core) {
+    TT_FATAL(buffer->buffer_distribution_spec().has_value(), "ND sharded concat expects sharded buffers");
+    const auto& page_mapping = buffer->get_buffer_page_mapping();
+    auto it = page_mapping->core_to_core_id.find(core);
+    TT_FATAL(it != page_mapping->core_to_core_id.end(), "Core not found in buffer page mapping");
+    uint32_t core_id = it->second;
+    TT_FATAL(
+        core_id < page_mapping->core_page_mappings.size() && !page_mapping->core_page_mappings[core_id].empty(),
+        "No page mapping for core");
+    const auto& core_mapping = page_mapping->core_page_mappings[core_id][0];
+    uint32_t address = buffer->address() + core_mapping.device_start_page * buffer->aligned_page_size();
+    if (buffer->is_dram()) {
+        address += buffer->device()->allocator()->get_bank_offset(
+            BufferType::DRAM, buffer->device()->dram_channel_from_logical_core(core));
+    }
+    return address;
 }
 
-// struct ReaderParameters
-// {
-//     tt::tt_metal::CoreCoord coresrc; // source core for the data portion
-//     uint32_t dataSize; // how much data on this core
-//     uint32_t bufferAddress; // buffer of the tensor
-// };
+// Unroll grid into a vector of CoreCoord in row-major order.
+std::vector<CoreCoord> grid_to_coresA(const CoreRangeSet& grid) {
+    std::vector<CoreCoord> cores;
+    for (const CoreRange& range : grid.ranges()) {
+        for (uint32_t y = range.start_coord.y; y <= range.end_coord.y; ++y) {
+            for (uint32_t x = range.start_coord.x; x <= range.end_coord.x; ++x) {
+                cores.push_back(CoreCoord{x, y});
+            }
+        }
+    }
+    return cores;
+}
 
 }  // namespace
 
-// Creates the device program for ND sharded concat: one program with reader and writer kernels
-// that copy each core's input shards (in concat order) into the output shard. Reader and writer
-// split the input range so both RISC-V processors can run in parallel.
+// Creates the device program for ND sharded concat: a single reader kernel on each core that
+// copies this core's input shards (in concat order) into this core's output shard using
+// TensorAccessors. No writer kernel; the reader does read-from-inputs and write-to-output.
 ConcatNDShardedProgramFactory::cached_program_t ConcatNDShardedProgramFactory::create(
     const ConcatParams& /*operation_attributes*/, const ConcatInputs& tensor_args, Tensor& tensor_return_value) {
     using namespace tt::constants;
@@ -44,188 +71,74 @@ ConcatNDShardedProgramFactory::cached_program_t ConcatNDShardedProgramFactory::c
     Tensor& output = tensor_return_value;
     const uint32_t num_input_tensors = static_cast<uint32_t>(input_tensors.size());
 
-    TT_FATAL(!input_tensors.empty(), "ND sharded concat requires at least one input");
-    TT_FATAL(input_tensors[0].nd_shard_spec().has_value(), "First input must be ND sharded");
-    TT_FATAL(output.nd_shard_spec().has_value(), "Output must be ND sharded");
+    TT_FATAL(
+        num_input_tensors <= CONCAT_ND_SHARDED_MAX_NUM_INPUTS,
+        "ND sharded concat supports at most {} inputs, got {}",
+        CONCAT_ND_SHARDED_MAX_NUM_INPUTS,
+        num_input_tensors);
 
-    const NdShardSpec& first_nd_spec = input_tensors[0].nd_shard_spec().value();
-    const CoreRangeSet all_cores = first_nd_spec.grid;
-    const ShardOrientation orientation = first_nd_spec.orientation;
-    const bool is_row_major = (orientation == ShardOrientation::ROW_MAJOR);
-
-    // Core list order must match the order used by each buffer's distribution spec for correct core_idx.
-    std::vector<CoreCoord> cores = corerange_to_cores(all_cores, std::nullopt, is_row_major);
+    const auto& nd_shard_spec = input_tensors[0].nd_shard_spec().value();
+    const CoreRangeSet all_cores = nd_shard_spec.grid;
+    const std::vector<CoreCoord> cores = grid_to_coresA(all_cores);
 
     Program program = CreateProgram();
 
-    const uint32_t page_size = input_tensors[0].buffer()->aligned_page_size();
-    for (uint32_t i = 1; i < num_input_tensors; ++i) {
-        TT_FATAL(
-            input_tensors[i].buffer()->aligned_page_size() == page_size,
-            "ND sharded concat requires all inputs to have the same aligned page size (input 0: {}, input {}: {})",
-            page_size,
-            i,
-            input_tensors[i].buffer()->aligned_page_size());
+    // Single scratch CB for the reader: one page for copy (read page -> write to output).
+    const uint32_t page_size = output.buffer()->aligned_page_size();
+    const uint32_t cb_id_scratch = 0;
+    CircularBufferConfig cb_config =
+        CircularBufferConfig(page_size, {{cb_id_scratch, datatype_to_dataformat_converter(output.dtype())}})
+            .set_page_size(cb_id_scratch, page_size);
+    CreateCircularBuffer(program, all_cores, cb_config);
+
+    // Compile-time args: num_input_tensors, then 17x page_size (for make_tensor_accessor_tuple), then
+    // TensorAccessorArgs.
+    std::vector<uint32_t> reader_compile_time_args;
+    reader_compile_time_args.push_back(num_input_tensors);
+    for (uint32_t i = 0; i < 1u + CONCAT_ND_SHARDED_MAX_NUM_INPUTS; ++i) {
+        reader_compile_time_args.push_back(static_cast<uint32_t>(page_size));
     }
-    TT_FATAL(
-        output.buffer()->aligned_page_size() == page_size,
-        "ND sharded concat requires output to have the same aligned page size as inputs (inputs: {}, output: {})",
-        page_size,
-        output.buffer()->aligned_page_size());
 
-    const tt::DataFormat cb_data_format = datatype_to_dataformat_converter(output.dtype());
-    const uint32_t cb_dst_id =
-        16;  // TODO:Z decide if it must be 31(wormhole) or 61(blackhole) or constant from somewhere
-    TT_FATAL(num_input_tensors <= cb_dst_id, "ND sharded concat supports at most {} inputs", cb_dst_id);
-
-    // Distribution specs from buffers (already set when tensors are allocated with ND sharding).
-    std::vector<const BufferDistributionSpec*> input_dist_specs(num_input_tensors);
+    TensorAccessorArgs(output.buffer()).append_to(reader_compile_time_args);
     for (uint32_t i = 0; i < num_input_tensors; ++i) {
-        TT_FATAL(
-            input_tensors[i].buffer()->buffer_distribution_spec().has_value(),
-            "ND sharded input {} must have buffer distribution spec",
-            i);
-        input_dist_specs[i] = &input_tensors[i].buffer()->buffer_distribution_spec().value();
-        std::cout << "tensor " << i << " output shards amount " << input_dist_specs[i]->num_shards() << "\n";
+        TensorAccessorArgs(input_tensors[i].buffer()).append_to(reader_compile_time_args);
     }
-    TT_FATAL(
-        output.buffer()->buffer_distribution_spec().has_value(),
-        "ND sharded output must have buffer distribution spec");
-    const BufferDistributionSpec& output_dist_spec = output.buffer()->buffer_distribution_spec().value();
-
-    const uint32_t input_amount_shards = input_dist_specs[0]->num_shards();
-    const uint32_t shard_size = static_cast<uint32_t>(first_nd_spec.shard_shape.volume());
-    const uint32_t total_output_shards = output_dist_spec.num_shards();
-    const uint32_t output_shard_size = static_cast<uint32_t>(output.nd_shard_spec().value().shard_shape.volume());
-
-    // Input CBs: each backed by the corresponding input buffer so each core sees only its shard.
-    std::vector<CBHandle> cb_inputs(num_input_tensors);
-    for (uint32_t input_id = 0; input_id < num_input_tensors; ++input_id) {
-        const BufferDistributionSpec& spec = *input_dist_specs[input_id];
-        uint32_t max_pages = static_cast<uint32_t>(spec.max_num_dev_pages_per_core());
-        const CircularBufferConfig input_cb_config =
-            CircularBufferConfig(page_size * max_pages, {{input_id, cb_data_format}})
-                .set_page_size(input_id, page_size)
-                .set_globally_allocated_address(*input_tensors[input_id].buffer());
-        cb_inputs[input_id] = CreateCircularBuffer(program, all_cores, input_cb_config);
+    for (uint32_t i = num_input_tensors; i < CONCAT_ND_SHARDED_MAX_NUM_INPUTS; ++i) {
+        TensorAccessorArgs(input_tensors[0].buffer()).append_to(reader_compile_time_args);
     }
 
-    // Output CB: backed by output buffer; each core writes its output shard.
-    uint32_t output_max_pages = static_cast<uint32_t>(output_dist_spec.max_num_dev_pages_per_core());
-    const CircularBufferConfig output_cb_config =
-        CircularBufferConfig(page_size * output_max_pages, {{cb_dst_id, cb_data_format}})
-            .set_page_size(cb_dst_id, page_size)
-            .set_globally_allocated_address(*output.buffer());
-    CBHandle cb_output = CreateCircularBuffer(program, all_cores, output_cb_config);
-
-    // Compile-time args for reader/writer: output CB id, page size, number of inputs.
-    std::vector<uint32_t> compile_time_args = {cb_dst_id, page_size, num_input_tensors};
-
-    // Reader: reads from input CBs (in concat order) and writes into output CB.
-    // Writer: same kernel, different runtime args to split work (first half of inputs vs second half).
     KernelHandle reader_kernel_id = CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_nd_sharded.cpp",
         all_cores,
-        ReaderDataMovementConfig(compile_time_args));
+        ReaderDataMovementConfig(reader_compile_time_args));
 
-    KernelHandle writer_kernel_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/writer_concat_nd_sharded.cpp",
-        all_cores,
-        WriterDataMovementConfig(compile_time_args));
-
-    // Per-core runtime args: [start_input_id, end_input_id, (num_pages, write_offset_in_pages) for each input in
-    // [start,end)). Reader handles inputs [0, mid), writer handles [mid, num_input_tensors).
-    //    const uint32_t mid = (num_input_tensors + 1) / 2;
-
-    std::cout << "cores amount " << cores.size() << " output cores amount " << output_dist_spec.cores().size() << "\n";
-
-    uint32_t destination_shard_pos = 0;
-
-    std::vector<std::pair<uint32_t, uint32_t>> source_shards;
-    source_shards.resize(num_input_tensors * input_amount_shards);
-    for (uint32_t input_id = 0; input_id < num_input_tensors; ++input_id) {
-        for (uint32_t pos_shard = 0; pos_shard < input_amount_shards; ++pos_shard) {
-            std::pair<uint32_t, uint32_t>& pair_tensor_shard =
-                source_shards[input_id * input_amount_shards + pos_shard];
-            pair_tensor_shard.first = input_id;
-            pair_tensor_shard.second = pos_shard;
+    // Per-core runtime args: [output_addr, input0_addr, ..., input15_addr, shard_id] (fixed 18 args)
+    for (size_t c = 0; c < cores.size(); ++c) {
+        const CoreCoord& core = cores[c];
+        std::vector<uint32_t> runtime_args;
+        runtime_args.reserve(18u);
+        runtime_args.push_back(get_buffer_address_for_core(output.buffer(), core));
+        for (uint32_t i = 0; i < num_input_tensors; ++i) {
+            runtime_args.push_back(get_buffer_address_for_core(input_tensors[i].buffer(), core));
         }
-    }
-    //    TT_FATAL(total_output_shards == source_shards.size(), "sizes in shards {} must be the same for concat {} {}
-    //    {}",
-    //         total_output_shards, source_shards.size(), num_input_tensors, input_amount_shards);
-
-    for (const CoreCoord& core : cores) {
-        const size_t core_idx = find_core_index(core, output_dist_spec.cores());
-        if (core_idx >= output_dist_spec.num_cores()) {
-            continue;
+        for (uint32_t i = num_input_tensors; i < CONCAT_ND_SHARDED_MAX_NUM_INPUTS; ++i) {
+            runtime_args.push_back(0u);  // unused; kernel only uses first 1 + num_input_tensors
         }
-        std::vector<uint32_t> reader_runtime_args;
-        for (uint32_t core_shard = destination_shard_pos; core_shard < total_output_shards;
-             core_shard += static_cast<uint32_t>(cores.size())) {
-            reader_runtime_args.push_back(core_shard);  // destination shard
-            reader_runtime_args.push_back(core_idx);    // core id
-
-            std::pair<uint32_t, uint32_t>& pair_tensor_shard = source_shards[core_shard];
-            reader_runtime_args.push_back(pair_tensor_shard.first);   // input tensor id
-            reader_runtime_args.push_back(pair_tensor_shard.second);  // source shard
-
-            reader_runtime_args.push_back(shard_size);
-            reader_runtime_args.push_back(output_shard_size);
-        }
-
-        ++destination_shard_pos;
-        SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
-        SetRuntimeArgs(program, writer_kernel_id, core, reader_runtime_args);  // TODO: add work too
+        runtime_args.push_back(static_cast<uint32_t>(c));  // shard_id
+        SetRuntimeArgs(program, reader_kernel_id, core, runtime_args);
     }
 
-    // for (const CoreCoord& core : cores) {
-    //     const size_t core_idx = find_core_index(core, output_dist_spec.cores());
-    //     if (core_idx >= output_dist_spec.num_cores()) {
-    //         continue;
-    //     }
+    ConcatNDShardedSharedVariables shared_vars;
+    shared_vars.num_input_tensors = num_input_tensors;
+    shared_vars.reader_kernel_id = reader_kernel_id;
+    shared_vars.all_cores = all_cores;
+    shared_vars.cores = cores;
+    shared_vars.cb_inputs.clear();
+    shared_vars.cb_output = 0;
+    shared_vars.writer_kernel_id = 0;
 
-    //     uint32_t output_write_offset_pages = 0;
-    //     std::vector<uint32_t> input_num_pages(num_input_tensors);
-    //     std::vector<uint32_t> input_write_offsets_pages(num_input_tensors);
-
-    //     for (uint32_t input_id = 0; input_id < num_input_tensors; ++input_id) {
-    //         const BufferDistributionSpec& in_spec = *input_dist_specs[input_id];
-    //         const size_t in_core_idx = find_core_index(core, in_spec.cores());
-    //         const uint32_t num_pages = (in_core_idx < in_spec.num_cores())
-    //                                        ? static_cast<uint32_t>(in_spec.num_dev_pages_per_core(in_core_idx))
-    //                                        : 0;
-    //         input_num_pages[input_id] = num_pages;
-    //         input_write_offsets_pages[input_id] = output_write_offset_pages;
-    //         output_write_offset_pages += num_pages;
-    //     }
-
-    //     std::vector<uint32_t> reader_runtime_args = {0u, mid};
-    //     for (uint32_t input_id = 0; input_id < mid; ++input_id) {
-    //         reader_runtime_args.push_back(input_num_pages[input_id]);
-    //         reader_runtime_args.push_back(input_write_offsets_pages[input_id]);
-    //     }
-    //     std::vector<uint32_t> writer_runtime_args = {mid, num_input_tensors};
-    //     for (uint32_t input_id = mid; input_id < num_input_tensors; ++input_id) {
-    //         writer_runtime_args.push_back(input_num_pages[input_id]);
-    //         writer_runtime_args.push_back(input_write_offsets_pages[input_id]);
-    //     }
-
-    //     SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
-    //     SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
-    // }  // for cores
-
-    return {
-        std::move(program),
-        {.num_input_tensors = num_input_tensors,
-         .cb_inputs = cb_inputs,
-         .cb_output = cb_output,
-         .reader_kernel_id = reader_kernel_id,
-         .writer_kernel_id = writer_kernel_id,
-         .all_cores = all_cores,
-         .cores = cores}};
+    return cached_program_t{std::move(program), std::move(shared_vars)};
 }
 
 // Updates buffer addresses in the cached program when the same program is reused with
@@ -237,12 +150,23 @@ void ConcatNDShardedProgramFactory::override_runtime_arguments(
     Tensor& tensor_return_value) {
     auto& program = cached_program.program;
     const auto& shared_vars = cached_program.shared_variables;
+    const uint32_t num_input_tensors = shared_vars.num_input_tensors;
+    const std::vector<CoreCoord>& cores = shared_vars.cores;
 
-    for (uint32_t input_id = 0; input_id < shared_vars.num_input_tensors; ++input_id) {
-        UpdateDynamicCircularBufferAddress(
-            program, shared_vars.cb_inputs[input_id], *tensor_args.input_tensors[input_id].buffer());
+    for (size_t c = 0; c < cores.size(); ++c) {
+        const CoreCoord& core = cores[c];
+        std::vector<uint32_t> runtime_args;
+        runtime_args.reserve(18u);
+        runtime_args.push_back(get_buffer_address_for_core(tensor_return_value.buffer(), core));
+        for (uint32_t i = 0; i < num_input_tensors; ++i) {
+            runtime_args.push_back(get_buffer_address_for_core(tensor_args.input_tensors[i].buffer(), core));
+        }
+        for (uint32_t i = num_input_tensors; i < CONCAT_ND_SHARDED_MAX_NUM_INPUTS; ++i) {
+            runtime_args.push_back(0u);
+        }
+        runtime_args.push_back(static_cast<uint32_t>(c));  // shard_id
+        SetRuntimeArgs(program, shared_vars.reader_kernel_id, core, runtime_args);
     }
-    UpdateDynamicCircularBufferAddress(program, shared_vars.cb_output, *tensor_return_value.buffer());
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.cpp
@@ -159,6 +159,10 @@ ConcatNDShardedProgramFactory::cached_program_t ConcatNDShardedProgramFactory::c
 
         uint32_t dim_pages{0};  // how many pages I need to write from every Tensor, sequentially
         uint32_t num_output_pages_per_block_total = 0;
+        uint32_t per_tensor_to_write =
+            num_output_pages_per_block_total * input_page_sizes[0];  // bytes to write from tensor
+        uint32_t per_tensor_to_skip = per_tensor_to_write * (num_input_tensors - 1);
+
         std::vector<uint32_t> runtime_args;
         uint32_t scale_factor = 1;
 
@@ -190,31 +194,40 @@ ConcatNDShardedProgramFactory::cached_program_t ConcatNDShardedProgramFactory::c
             dim_pages = input_t0.padded_shape()[dim] / scale_factor;
 
             num_output_pages_per_block_total += num_accum_pages * dim_pages;
+
+            per_tensor_to_write = num_output_pages_per_block_total * input_page_sizes[0];
+            per_tensor_to_skip = per_tensor_to_write * (num_input_tensors - 1);
         };
 
         auto fill_for_raw_major_layout = [&]() {
-            std::cout << " --> Raw Major layout ";
+            std::cout << " --> Raw Major layout\n";
 
-            uint32_t num_accum_pages = 1;
-            for (uint32_t i = dim + 1; i < num_dims; ++i) {
-                num_accum_pages *= output.padded_shape()[i];
-                std::cout << "num_acum_pages at " << i << ": " << num_accum_pages;
+            std::cout << "dim " << dim << "\n";
+            // In RAW_MAJOR layout one page = one row (last dimension).
+            // num_output_pages_per_block_total = number of output pages for one input's block
+            // (i.e. the slice of the concatenated output that comes from a single input tensor).
+            for (uint32_t i = 0; i < num_dims; ++i) {
+                std::cout << " In pages at dimention " << i << ": " << input_t0.padded_shape()[i] << "\n";
+                std::cout << " Out pages at  dimention " << i << ": " << output.padded_shape()[i] << "\n";
             }
             std::cout << "\n";
 
-            if (num_dims > 1 && dim < num_dims - 1) {
-                num_accum_pages /= output.padded_shape()[-1];
-            }
-            std::cout << "result acum_pages: " << num_accum_pages << "\n";
+            num_output_pages_per_block_total = 1;
+            per_tensor_to_write = input_t0.element_size() * input_t0.padded_shape().volume();
+            per_tensor_to_skip = per_tensor_to_write * (num_input_tensors - 1);
+            // just write everything sequentially
 
-            dim_pages = input_t0.padded_shape()[dim];
-            std::cout << "pages for dimention " << dim << "(input T 0): " << dim_pages << "\n";
-
-            if (dim == num_dims - 1) {
-                num_output_pages_per_block_total = 1;
-            } else {
-                num_output_pages_per_block_total += num_accum_pages * dim_pages;
+            // for 0 == dim - just write everything sequentially
+            // for other dimentions - by portions
+            for (uint32_t sub_dim = 0; sub_dim < dim; ++sub_dim) {
+                per_tensor_to_write /= input_t0.padded_shape()[sub_dim];
             }
+            per_tensor_to_skip = per_tensor_to_write * (num_input_tensors - 1);
+            std::cout << " to write on dim " << dim << ":  " << per_tensor_to_write << "\n";
+            // num_output_pages_per_block_total = 64 * 4;
+            // per_tensor_to_write = num_output_pages_per_block_total * input_page_sizes[0]; // bytes to write from
+            // tensor per_tensor_to_skip = per_tensor_to_write * (num_input_tensors - 1);
+            return;
         };
 
         if (rm_layout) {
@@ -228,8 +241,6 @@ ConcatNDShardedProgramFactory::cached_program_t ConcatNDShardedProgramFactory::c
         runtime_args.push_back(scratch_l1_addr);
         runtime_args.push_back(output.buffer()->address());
 
-        const uint32_t per_tensor_to_write = num_output_pages_per_block_total * input_page_sizes[0];
-        const uint32_t per_tensor_to_skip = per_tensor_to_write * (num_input_tensors - 1);
         std::cout << "per tensor write " << per_tensor_to_write << "  per tensor to skip " << per_tensor_to_skip
                   << "\n";
 

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.cpp
@@ -108,7 +108,7 @@ ConcatNDShardedProgramFactory::cached_program_t ConcatNDShardedProgramFactory::c
     AssignGlobalBufferToProgram(scratch_l1_buffer, program);
     const uint32_t scratch_l1_addr = static_cast<uint32_t>(scratch_l1_buffer->page_address(0, 0));
 
-    // Compile-time args: num_input_tensors, output_page_size, input_page_sizes[0..15],
+    // Compile-time args: num_input_tensors, concat dim, output_page_size, input_page_sizes[0..15],
     // then output TensorAccessorArgs, then 16 input TensorAccessorArgs (absent filled from first input).
     std::vector<uint32_t> reader_compile_time_args = {
         num_input_tensors,

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.cpp
@@ -49,6 +49,15 @@ ConcatNDShardedProgramFactory::cached_program_t ConcatNDShardedProgramFactory::c
     const std::vector<CoreCoord> cores =
         corerange_to_cores(all_cores, std::nullopt, nd_shard_spec.orientation == ShardOrientation::ROW_MAJOR);
 
+    // Pick the core with biggest coordinates (lexicographic: x then y) and run only on that core
+    const auto max_core_it = std::max_element(cores.begin(), cores.end(), [](const CoreCoord& a, const CoreCoord& b) {
+        return a.x < b.x || (a.x == b.x && a.y < b.y);
+    });
+    TT_FATAL(max_core_it != cores.end(), "cores must be non-empty");
+    const CoreCoord max_core = *max_core_it;
+    const size_t max_core_index = static_cast<size_t>(std::distance(cores.begin(), max_core_it));
+    const CoreRangeSet single_core_set = CoreRangeSet(CoreRange(max_core));
+
     Program program = CreateProgram();
 
     // Page sizes: output and each of 16 input slots (fill absent from first input)
@@ -65,7 +74,7 @@ ConcatNDShardedProgramFactory::cached_program_t ConcatNDShardedProgramFactory::c
     constexpr uint8_t cb_scratch_id = 0;
     auto scratch_cb_config = CircularBufferConfig(scratch_page_size, {{cb_scratch_id, tt::DataFormat::RawUInt32}})
                                  .set_page_size(cb_scratch_id, scratch_page_size);
-    CreateCircularBuffer(program, all_cores, scratch_cb_config);
+    CreateCircularBuffer(program, single_core_set, scratch_cb_config);
 
     // Compile-time args: num_input_tensors, output_page_size, input_page_sizes[0..15],
     // then output TensorAccessorArgs, then 16 input TensorAccessorArgs (absent filled from first input).
@@ -87,19 +96,19 @@ ConcatNDShardedProgramFactory::cached_program_t ConcatNDShardedProgramFactory::c
     KernelHandle reader_kernel_id = CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_nd_sharded.cpp",
-        all_cores,
+        single_core_set,
         ReaderDataMovementConfig(reader_compile_time_args));
 
-    // Runtime args per core: 17 buffer addresses (output, in0..in15), then shard_id
-    for (size_t c = 0; c < cores.size(); ++c) {
+    // Runtime args for the single core: 17 buffer addresses (output, in0..in15), then shard_id
+    {
         std::vector<uint32_t> runtime_args;
         runtime_args.push_back(output.buffer()->address());
         for (uint32_t i = 0; i < CONCAT_ND_SHARDED_MAX_NUM_INPUTS; ++i) {
             const Buffer* buf = (i < num_input_tensors) ? input_tensors[i].buffer() : input_tensors[0].buffer();
             runtime_args.push_back(buf->address());
         }
-        runtime_args.push_back(static_cast<uint32_t>(c));
-        SetRuntimeArgs(program, reader_kernel_id, cores[c], runtime_args);
+        runtime_args.push_back(static_cast<uint32_t>(max_core_index));
+        SetRuntimeArgs(program, reader_kernel_id, max_core, runtime_args);
     }
 
     return cached_program_t{
@@ -109,8 +118,8 @@ ConcatNDShardedProgramFactory::cached_program_t ConcatNDShardedProgramFactory::c
          .cb_output = 0,
          .reader_kernel_id = reader_kernel_id,
          .writer_kernel_id = 0,
-         .all_cores = all_cores,
-         .cores = cores}};
+         .all_cores = single_core_set,
+         .cores = {max_core}}};
 }
 
 // Updates buffer addresses in the cached program when the same program is reused with
@@ -127,16 +136,23 @@ void ConcatNDShardedProgramFactory::override_runtime_arguments(
     const std::vector<Tensor>& input_tensors = tensor_args.input_tensors;
     Tensor& output = tensor_return_value;
 
-    for (size_t c = 0; c < cores.size(); ++c) {
-        std::vector<uint32_t> runtime_args;
-        runtime_args.push_back(output.buffer()->address());
-        for (uint32_t i = 0; i < CONCAT_ND_SHARDED_MAX_NUM_INPUTS; ++i) {
-            const Buffer* buf = (i < num_input_tensors) ? input_tensors[i].buffer() : input_tensors[0].buffer();
-            runtime_args.push_back(buf->address());
-        }
-        runtime_args.push_back(static_cast<uint32_t>(c));
-        SetRuntimeArgs(program, shared_vars.reader_kernel_id, cores[c], runtime_args);
+    // Recompute full core list to get shard index for our single core
+    const auto& nd_shard_spec = input_tensors[0].nd_shard_spec().value();
+    const std::vector<CoreCoord> all_cores_list =
+        corerange_to_cores(nd_shard_spec.grid, std::nullopt, nd_shard_spec.orientation == ShardOrientation::ROW_MAJOR);
+    const CoreCoord& single_core = cores[0];
+    const auto shard_id_it = std::find(all_cores_list.begin(), all_cores_list.end(), single_core);
+    TT_FATAL(shard_id_it != all_cores_list.end(), "Single core must be in grid");
+    const uint32_t shard_id = static_cast<uint32_t>(std::distance(all_cores_list.begin(), shard_id_it));
+
+    std::vector<uint32_t> runtime_args;
+    runtime_args.push_back(output.buffer()->address());
+    for (uint32_t i = 0; i < CONCAT_ND_SHARDED_MAX_NUM_INPUTS; ++i) {
+        const Buffer* buf = (i < num_input_tensors) ? input_tensors[i].buffer() : input_tensors[0].buffer();
+        runtime_args.push_back(buf->address());
     }
+    runtime_args.push_back(shard_id);
+    SetRuntimeArgs(program, shared_vars.reader_kernel_id, single_core, runtime_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.cpp
@@ -70,6 +70,28 @@ ConcatNDShardedProgramFactory::cached_program_t ConcatNDShardedProgramFactory::c
         input_page_sizes[i] = buf->aligned_page_size();
     }
 
+    // some debug information about output tensor
+    {
+        const Buffer* out_buf = output.buffer();
+        const tt::tt_metal::Shape& output_logical_shape = output.logical_shape();
+        std::cout << "[concat_nd_sharded] Output tensor: total pages = " << out_buf->num_pages();
+        std::cout << ", logical_shape = " << output_logical_shape << ", padded_shape = " << output.padded_shape();
+        std::cout << ", rank = " << output_logical_shape.rank() << "\n";
+        // tt::stl::SmallVector<size_t> strides = in0.compute_strides(in0shape);
+        //  for (size_t sz : strides) {
+        //      " stride: " << sz;
+        //  }
+        //  std::cout << "\n";
+
+        const NdShardSpec& nd_spec = *output.nd_shard_spec();
+        std::cout << ", nd_shard_spec: shard_shape = " << nd_spec.shard_shape
+                  << ", grid num_cores = " << nd_spec.grid.num_cores();
+        std::cout << "\n";
+    }
+    // TODO: calculate strides for first input tensor - it will help for padded tensors
+    {
+    }
+
     // Host-allocated L1 scratch buffer (one page, max page size across all tensors) for copy_tensor_data.
     const uint32_t scratch_page_size =
         std::max(output_page_size, *std::max_element(input_page_sizes.begin(), input_page_sizes.end()));

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.cpp
@@ -80,11 +80,17 @@ ConcatNDShardedProgramFactory::cached_program_t ConcatNDShardedProgramFactory::c
             "ND sharded input {} must have buffer distribution spec",
             i);
         input_dist_specs[i] = &input_tensors[i].buffer()->buffer_distribution_spec().value();
+        std::cout << "tensor " << i << " output shards amount " << input_dist_specs[i]->num_shards() << "\n";
     }
     TT_FATAL(
         output.buffer()->buffer_distribution_spec().has_value(),
         "ND sharded output must have buffer distribution spec");
     const BufferDistributionSpec& output_dist_spec = output.buffer()->buffer_distribution_spec().value();
+
+    const uint32_t input_amount_shards = input_dist_specs[0]->num_shards();
+    const uint32_t shard_size = static_cast<uint32_t>(first_nd_spec.shard_shape.volume());
+    const uint32_t total_output_shards = output_dist_spec.num_shards();
+    const uint32_t output_shard_size = static_cast<uint32_t>(output.nd_shard_spec().value().shard_shape.volume());
 
     // Input CBs: each backed by the corresponding input buffer so each core sees only its shard.
     std::vector<CBHandle> cb_inputs(num_input_tensors);
@@ -125,47 +131,84 @@ ConcatNDShardedProgramFactory::cached_program_t ConcatNDShardedProgramFactory::c
 
     // Per-core runtime args: [start_input_id, end_input_id, (num_pages, write_offset_in_pages) for each input in
     // [start,end)). Reader handles inputs [0, mid), writer handles [mid, num_input_tensors).
-    const uint32_t mid = (num_input_tensors + 1) / 2;
+    //    const uint32_t mid = (num_input_tensors + 1) / 2;
 
     std::cout << "cores amount " << cores.size() << " output cores amount " << output_dist_spec.cores().size() << "\n";
 
-    uint32_t cn = 0;
+    uint32_t destination_shard_pos = 0;
+
+    std::vector<std::pair<uint32_t, uint32_t>> source_shards;
+    source_shards.resize(num_input_tensors * input_amount_shards);
+    for (uint32_t input_id = 0; input_id < num_input_tensors; ++input_id) {
+        for (uint32_t pos_shard = 0; pos_shard < input_amount_shards; ++pos_shard) {
+            std::pair<uint32_t, uint32_t>& pair_tensor_shard =
+                source_shards[input_id * input_amount_shards + pos_shard];
+            pair_tensor_shard.first = input_id;
+            pair_tensor_shard.second = pos_shard;
+        }
+    }
+    // TT_FATAL(total_output_shards == source_shards.size(), "sizes in shards {} must be the same for concat {} {} {}",
+    //     total_output_shards, source_shards.size(), num_input_tensors, input_amount_shards);
+
     for (const CoreCoord& core : cores) {
         const size_t core_idx = find_core_index(core, output_dist_spec.cores());
         if (core_idx >= output_dist_spec.num_cores()) {
             continue;
         }
-        std::cout << "core x :" << ++cn << "\n";
+        std::vector<uint32_t> reader_runtime_args;
+        for (uint32_t core_shard = destination_shard_pos; core_shard < total_output_shards;
+             core_shard += static_cast<uint32_t>(cores.size())) {
+            reader_runtime_args.push_back(core_shard);  // destination shard
+            reader_runtime_args.push_back(core_idx);    // core id
 
-        uint32_t output_write_offset_pages = 0;
-        std::vector<uint32_t> input_num_pages(num_input_tensors);
-        std::vector<uint32_t> input_write_offsets_pages(num_input_tensors);
+            std::pair<uint32_t, uint32_t>& pair_tensor_shard = source_shards[core_shard];
+            reader_runtime_args.push_back(pair_tensor_shard.first);   // input tensor id
+            reader_runtime_args.push_back(pair_tensor_shard.second);  // source shard
 
-        for (uint32_t input_id = 0; input_id < num_input_tensors; ++input_id) {
-            const BufferDistributionSpec& in_spec = *input_dist_specs[input_id];
-            const size_t in_core_idx = find_core_index(core, in_spec.cores());
-            const uint32_t num_pages = (in_core_idx < in_spec.num_cores())
-                                           ? static_cast<uint32_t>(in_spec.num_dev_pages_per_core(in_core_idx))
-                                           : 0;
-            input_num_pages[input_id] = num_pages;
-            input_write_offsets_pages[input_id] = output_write_offset_pages;
-            output_write_offset_pages += num_pages;
+            reader_runtime_args.push_back(shard_size);
+            reader_runtime_args.push_back(output_shard_size);
         }
 
-        std::vector<uint32_t> reader_runtime_args = {0u, mid};
-        for (uint32_t input_id = 0; input_id < mid; ++input_id) {
-            reader_runtime_args.push_back(input_num_pages[input_id]);
-            reader_runtime_args.push_back(input_write_offsets_pages[input_id]);
-        }
-        std::vector<uint32_t> writer_runtime_args = {mid, num_input_tensors};
-        for (uint32_t input_id = mid; input_id < num_input_tensors; ++input_id) {
-            writer_runtime_args.push_back(input_num_pages[input_id]);
-            writer_runtime_args.push_back(input_write_offsets_pages[input_id]);
-        }
-
+        ++destination_shard_pos;
         SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
-        SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
-    }  // for cores
+        SetRuntimeArgs(program, writer_kernel_id, core, reader_runtime_args);  // TODO: add work too
+    }
+
+    // for (const CoreCoord& core : cores) {
+    //     const size_t core_idx = find_core_index(core, output_dist_spec.cores());
+    //     if (core_idx >= output_dist_spec.num_cores()) {
+    //         continue;
+    //     }
+
+    //     uint32_t output_write_offset_pages = 0;
+    //     std::vector<uint32_t> input_num_pages(num_input_tensors);
+    //     std::vector<uint32_t> input_write_offsets_pages(num_input_tensors);
+
+    //     for (uint32_t input_id = 0; input_id < num_input_tensors; ++input_id) {
+    //         const BufferDistributionSpec& in_spec = *input_dist_specs[input_id];
+    //         const size_t in_core_idx = find_core_index(core, in_spec.cores());
+    //         const uint32_t num_pages = (in_core_idx < in_spec.num_cores())
+    //                                        ? static_cast<uint32_t>(in_spec.num_dev_pages_per_core(in_core_idx))
+    //                                        : 0;
+    //         input_num_pages[input_id] = num_pages;
+    //         input_write_offsets_pages[input_id] = output_write_offset_pages;
+    //         output_write_offset_pages += num_pages;
+    //     }
+
+    //     std::vector<uint32_t> reader_runtime_args = {0u, mid};
+    //     for (uint32_t input_id = 0; input_id < mid; ++input_id) {
+    //         reader_runtime_args.push_back(input_num_pages[input_id]);
+    //         reader_runtime_args.push_back(input_write_offsets_pages[input_id]);
+    //     }
+    //     std::vector<uint32_t> writer_runtime_args = {mid, num_input_tensors};
+    //     for (uint32_t input_id = mid; input_id < num_input_tensors; ++input_id) {
+    //         writer_runtime_args.push_back(input_num_pages[input_id]);
+    //         writer_runtime_args.push_back(input_write_offsets_pages[input_id]);
+    //     }
+
+    //     SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
+    //     SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
+    // }  // for cores
 
     return {
         std::move(program),

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "concat_nd_sharded_program_factory.hpp"
+#include "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/concat_nd_sharded_args.hpp"
 
 #include <algorithm>
 #include <numeric>
@@ -21,6 +22,13 @@ size_t find_core_index(const CoreCoord& core, const std::vector<CoreCoord>& core
     auto it = std::find(cores.begin(), cores.end(), core);
     return static_cast<size_t>(it - cores.begin());
 }
+
+// struct ReaderParameters
+// {
+//     tt::tt_metal::CoreCoord coresrc; // source core for the data portion
+//     uint32_t dataSize; // how much data on this core
+//     uint32_t bufferAddress; // buffer of the tensor
+// };
 
 }  // namespace
 
@@ -50,8 +58,6 @@ ConcatNDShardedProgramFactory::cached_program_t ConcatNDShardedProgramFactory::c
 
     Program program = CreateProgram();
 
-    // All inputs and output must share the same aligned page size; the kernels use a single page_size.
-    // (Tensor buffers can have different page sizes when shard shapes or layouts differ.)
     const uint32_t page_size = input_tensors[0].buffer()->aligned_page_size();
     for (uint32_t i = 1; i < num_input_tensors; ++i) {
         TT_FATAL(
@@ -147,8 +153,9 @@ ConcatNDShardedProgramFactory::cached_program_t ConcatNDShardedProgramFactory::c
             pair_tensor_shard.second = pos_shard;
         }
     }
-    // TT_FATAL(total_output_shards == source_shards.size(), "sizes in shards {} must be the same for concat {} {} {}",
-    //     total_output_shards, source_shards.size(), num_input_tensors, input_amount_shards);
+    //    TT_FATAL(total_output_shards == source_shards.size(), "sizes in shards {} must be the same for concat {} {}
+    //    {}",
+    //         total_output_shards, source_shards.size(), num_input_tensors, input_amount_shards);
 
     for (const CoreCoord& core : cores) {
         const size_t core_idx = find_core_index(core, output_dist_spec.cores());

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.cpp
@@ -77,19 +77,30 @@ ConcatNDShardedProgramFactory::cached_program_t ConcatNDShardedProgramFactory::c
         std::cout << "[concat_nd_sharded] Output tensor: total pages = " << out_buf->num_pages();
         std::cout << ", logical_shape = " << output_logical_shape << ", padded_shape = " << output.padded_shape();
         std::cout << ", rank = " << output_logical_shape.rank() << "\n";
-        // tt::stl::SmallVector<size_t> strides = in0.compute_strides(in0shape);
-        //  for (size_t sz : strides) {
-        //      " stride: " << sz;
-        //  }
-        //  std::cout << "\n";
+
+        const size_t sz_to_fill = output.logical_volume() * output.element_size();
+        std::cout << " size to fill in output " << sz_to_fill;
 
         const NdShardSpec& nd_spec = *output.nd_shard_spec();
         std::cout << ", nd_shard_spec: shard_shape = " << nd_spec.shard_shape
                   << ", grid num_cores = " << nd_spec.grid.num_cores();
         std::cout << "\n";
     }
-    // TODO: calculate strides for first input tensor - it will help for padded tensors
+    std::array<uint32_t, CONCAT_ND_SHARDED_MAX_NUM_INPUTS> initial_offsets_bytes{0};
+    std::array<uint32_t, CONCAT_ND_SHARDED_MAX_NUM_INPUTS> to_write_bytes{0};
+    std::array<uint32_t, CONCAT_ND_SHARDED_MAX_NUM_INPUTS> to_skip_bytes{0};
     {
+        for (uint32_t i = 0; i < num_input_tensors; ++i) {
+            const uint32_t sz_to_fill =
+                static_cast<uint32_t>(input_tensors[i].logical_volume() * input_tensors[i].element_size());
+            to_write_bytes[i] = sz_to_fill;
+            std::cout << " tensor " << i << " size to fill in output " << sz_to_fill;
+
+            if (i + 1 < num_input_tensors) {
+                initial_offsets_bytes[i + 1] = initial_offsets_bytes[i] + sz_to_fill;
+            }
+        }
+        std::cout << "\n";
     }
 
     // Host-allocated L1 scratch buffer (one page, max page size across all tensors) for copy_tensor_data.
@@ -141,13 +152,10 @@ ConcatNDShardedProgramFactory::cached_program_t ConcatNDShardedProgramFactory::c
         for (uint32_t i = 0; i < CONCAT_ND_SHARDED_MAX_NUM_INPUTS; ++i) {
             const Buffer* buf = (i < num_input_tensors) ? input_tensors[i].buffer() : input_tensors[0].buffer();
             runtime_args.push_back(buf->address());
-            uint32_t absolute_offset_to_start{0};  //  - to rework - it could be absolute pos inside the tensor to write
-            uint32_t amount_to_write{0};           //  - to fill later  - it could be amount of data to copy
-            uint32_t amount_to_skip{
-                0};  //  - to fill later   - it could be how much data to skip to copy next amount of data
-            runtime_args.push_back(absolute_offset_to_start);
-            runtime_args.push_back(amount_to_write);
-            runtime_args.push_back(amount_to_skip);
+
+            runtime_args.push_back(initial_offsets_bytes[i]);
+            runtime_args.push_back(to_write_bytes[i]);
+            runtime_args.push_back(to_skip_bytes[i]);
         }
         runtime_args.push_back(static_cast<uint32_t>(max_core_index));
         SetRuntimeArgs(program, reader_kernel_id, max_core, runtime_args);

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.cpp
@@ -132,7 +132,8 @@ ConcatNDShardedProgramFactory::cached_program_t ConcatNDShardedProgramFactory::c
         single_core_set,
         ReaderDataMovementConfig(reader_compile_time_args));
 
-    // Runtime args for the single core: scratch_l1_addr, then 17 buffer addresses (output, in0..in15), then shard_id
+    // Runtime args for the single core: scratch_l1_addr, output addr, then per-input (addr, first_shard_pos,
+    // shards_to_write, shards_to_skip), then shard_id
     {
         std::vector<uint32_t> runtime_args;
         runtime_args.push_back(scratch_l1_addr);
@@ -140,6 +141,13 @@ ConcatNDShardedProgramFactory::cached_program_t ConcatNDShardedProgramFactory::c
         for (uint32_t i = 0; i < CONCAT_ND_SHARDED_MAX_NUM_INPUTS; ++i) {
             const Buffer* buf = (i < num_input_tensors) ? input_tensors[i].buffer() : input_tensors[0].buffer();
             runtime_args.push_back(buf->address());
+            uint32_t first_shard_pos{0};  //  - to rework - it could be absolute pos inside the tensor to write
+            uint32_t shards_to_write{0};  //  - to fill later  - it could be amount of data to copy
+            uint32_t shards_to_skip{
+                0};  //  - to fill later   - it could be how much data to skip to copy next amount of data
+            runtime_args.push_back(first_shard_pos);
+            runtime_args.push_back(shards_to_write);
+            runtime_args.push_back(shards_to_skip);
         }
         runtime_args.push_back(static_cast<uint32_t>(max_core_index));
         SetRuntimeArgs(program, reader_kernel_id, max_core, runtime_args);
@@ -189,6 +197,12 @@ void ConcatNDShardedProgramFactory::override_runtime_arguments(
     for (uint32_t i = 0; i < CONCAT_ND_SHARDED_MAX_NUM_INPUTS; ++i) {
         const Buffer* buf = (i < num_input_tensors) ? input_tensors[i].buffer() : input_tensors[0].buffer();
         runtime_args.push_back(buf->address());
+        uint32_t first_shard_pos{0};  //  - to fill later
+        uint32_t shards_to_write{0};  //  - to fill later
+        uint32_t shards_to_skip{0};   //  - to fill later
+        runtime_args.push_back(first_shard_pos);
+        runtime_args.push_back(shards_to_write);
+        runtime_args.push_back(shards_to_skip);
     }
     runtime_args.push_back(shard_id);
     SetRuntimeArgs(program, shared_vars.reader_kernel_id, single_core, runtime_args);

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.cpp
@@ -59,6 +59,14 @@ ConcatNDShardedProgramFactory::cached_program_t ConcatNDShardedProgramFactory::c
         input_page_sizes[i] = buf->aligned_page_size();
     }
 
+    // Scratch CB (index 0) for copy_tensor_data: one page, size = max of all page sizes.
+    const uint32_t scratch_page_size =
+        std::max(output_page_size, *std::max_element(input_page_sizes.begin(), input_page_sizes.end()));
+    constexpr uint8_t cb_scratch_id = 0;
+    auto scratch_cb_config = CircularBufferConfig(scratch_page_size, {{cb_scratch_id, tt::DataFormat::RawUInt32}})
+                                 .set_page_size(cb_scratch_id, scratch_page_size);
+    CreateCircularBuffer(program, all_cores, scratch_cb_config);
+
     // Compile-time args: num_input_tensors, output_page_size, input_page_sizes[0..15],
     // then output TensorAccessorArgs, then 16 input TensorAccessorArgs (absent filled from first input).
     std::vector<uint32_t> reader_compile_time_args = {

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.cpp
@@ -31,7 +31,7 @@ constexpr uint32_t CONCAT_ND_SHARDED_MAX_NUM_INPUTS = ttnn::kernel::CONCAT_ND_SH
 // copies this core's input shards (in concat order) into this core's output shard using
 // TensorAccessors. No writer kernel; the reader does read-from-inputs and write-to-output.
 ConcatNDShardedProgramFactory::cached_program_t ConcatNDShardedProgramFactory::create(
-    const ConcatParams& /*operation_attributes*/, const ConcatInputs& tensor_args, Tensor& tensor_return_value) {
+    const ConcatParams& operation_attributes, const ConcatInputs& tensor_args, Tensor& tensor_return_value) {
     using namespace tt::constants;
     using namespace tt::tt_metal;
 
@@ -90,6 +90,7 @@ ConcatNDShardedProgramFactory::cached_program_t ConcatNDShardedProgramFactory::c
     // then output TensorAccessorArgs, then 16 input TensorAccessorArgs (absent filled from first input).
     std::vector<uint32_t> reader_compile_time_args = {
         num_input_tensors,
+        static_cast<uint32_t>(operation_attributes.dim),
         output_page_size,
     };
     for (uint32_t i = 0; i < CONCAT_ND_SHARDED_MAX_NUM_INPUTS; ++i) {

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.cpp
@@ -11,6 +11,7 @@
 
 #include "ttnn/tensor/tensor.hpp"
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/buffer_distribution_spec.hpp>
 #include <tt-metalium/buffer_page_mapping.hpp>
@@ -68,13 +69,21 @@ ConcatNDShardedProgramFactory::cached_program_t ConcatNDShardedProgramFactory::c
         input_page_sizes[i] = buf->aligned_page_size();
     }
 
-    // Scratch CB (index 0) for copy_tensor_data: one page, size = max of all page sizes.
+    // Host-allocated L1 scratch buffer (one page, max page size across all tensors) for copy_tensor_data.
     const uint32_t scratch_page_size =
         std::max(output_page_size, *std::max_element(input_page_sizes.begin(), input_page_sizes.end()));
-    constexpr uint8_t cb_scratch_id = 0;
-    auto scratch_cb_config = CircularBufferConfig(scratch_page_size, {{cb_scratch_id, tt::DataFormat::RawUInt32}})
-                                 .set_page_size(cb_scratch_id, scratch_page_size);
-    CreateCircularBuffer(program, single_core_set, scratch_cb_config);
+    ShardSpecBuffer scratch_shard_spec(single_core_set, {1, 1}, ShardOrientation::ROW_MAJOR, {1, 1}, {1, 1});
+    ShardedBufferConfig scratch_l1_config{
+        .device = output.device(),
+        .size = scratch_page_size,
+        .page_size = scratch_page_size,
+        .buffer_type = BufferType::L1,
+        .buffer_layout = TensorMemoryLayout::HEIGHT_SHARDED,
+        .shard_parameters = std::move(scratch_shard_spec),
+    };
+    std::shared_ptr<Buffer> scratch_l1_buffer = CreateBuffer(scratch_l1_config);
+    AssignGlobalBufferToProgram(scratch_l1_buffer, program);
+    const uint32_t scratch_l1_addr = static_cast<uint32_t>(scratch_l1_buffer->page_address(0, 0));
 
     // Compile-time args: num_input_tensors, output_page_size, input_page_sizes[0..15],
     // then output TensorAccessorArgs, then 16 input TensorAccessorArgs (absent filled from first input).
@@ -99,9 +108,10 @@ ConcatNDShardedProgramFactory::cached_program_t ConcatNDShardedProgramFactory::c
         single_core_set,
         ReaderDataMovementConfig(reader_compile_time_args));
 
-    // Runtime args for the single core: 17 buffer addresses (output, in0..in15), then shard_id
+    // Runtime args for the single core: scratch_l1_addr, then 17 buffer addresses (output, in0..in15), then shard_id
     {
         std::vector<uint32_t> runtime_args;
+        runtime_args.push_back(scratch_l1_addr);
         runtime_args.push_back(output.buffer()->address());
         for (uint32_t i = 0; i < CONCAT_ND_SHARDED_MAX_NUM_INPUTS; ++i) {
             const Buffer* buf = (i < num_input_tensors) ? input_tensors[i].buffer() : input_tensors[0].buffer();
@@ -119,7 +129,8 @@ ConcatNDShardedProgramFactory::cached_program_t ConcatNDShardedProgramFactory::c
          .reader_kernel_id = reader_kernel_id,
          .writer_kernel_id = 0,
          .all_cores = single_core_set,
-         .cores = {max_core}}};
+         .cores = {max_core},
+         .scratch_l1_buffer = std::move(scratch_l1_buffer)}};
 }
 
 // Updates buffer addresses in the cached program when the same program is reused with
@@ -145,7 +156,11 @@ void ConcatNDShardedProgramFactory::override_runtime_arguments(
     TT_FATAL(shard_id_it != all_cores_list.end(), "Single core must be in grid");
     const uint32_t shard_id = static_cast<uint32_t>(std::distance(all_cores_list.begin(), shard_id_it));
 
+    TT_FATAL(shared_vars.scratch_l1_buffer, "Scratch L1 buffer must be set");
+    const uint32_t scratch_l1_addr = static_cast<uint32_t>(shared_vars.scratch_l1_buffer->page_address(0, 0));
+
     std::vector<uint32_t> runtime_args;
+    runtime_args.push_back(scratch_l1_addr);
     runtime_args.push_back(output.buffer()->address());
     for (uint32_t i = 0; i < CONCAT_ND_SHARDED_MAX_NUM_INPUTS; ++i) {
         const Buffer* buf = (i < num_input_tensors) ? input_tensors[i].buffer() : input_tensors[0].buffer();

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.cpp
@@ -77,6 +77,7 @@ ConcatNDShardedProgramFactory::cached_program_t ConcatNDShardedProgramFactory::c
             input_page_sizes[i],
             input_page_sizes[0]);
     }
+    std::cout << " input page size " << input_page_sizes[0] << "  Element size:" << input_t0.element_size() << "\n";
 
     // some debug information about output tensor
     {
@@ -112,8 +113,7 @@ ConcatNDShardedProgramFactory::cached_program_t ConcatNDShardedProgramFactory::c
     }
 
     // Host-allocated L1 scratch buffer (one page, max page size across all tensors) for copy_tensor_data.
-    const uint32_t scratch_page_size =
-        std::max(output_page_size, *std::max_element(input_page_sizes.begin(), input_page_sizes.end()));
+    const uint32_t scratch_page_size = std::max(output_page_size, input_page_sizes[0]);
     ShardSpecBuffer scratch_shard_spec(single_core_set, {1, 1}, ShardOrientation::ROW_MAJOR, {1, 1}, {1, 1});
     ShardedBufferConfig scratch_l1_config{
         .device = output.device(),
@@ -208,15 +208,12 @@ ConcatNDShardedProgramFactory::cached_program_t ConcatNDShardedProgramFactory::c
             std::cout << "result acum_pages: " << num_accum_pages << "\n";
 
             dim_pages = input_t0.padded_shape()[dim];
-
-            if (dim == num_dims - 1) {
-                num_output_pages_per_block_total += num_accum_pages;
-            } else {
-                num_output_pages_per_block_total += num_accum_pages * dim_pages;
-            }
+            std::cout << "pages for dimention " << dim << "(input T 0): " << dim_pages << "\n";
 
             if (dim == num_dims - 1) {
                 num_output_pages_per_block_total = 1;
+            } else {
+                num_output_pages_per_block_total += num_accum_pages * dim_pages;
             }
         };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.cpp
@@ -45,7 +45,8 @@ ConcatNDShardedProgramFactory::cached_program_t ConcatNDShardedProgramFactory::c
         CONCAT_ND_SHARDED_MAX_NUM_INPUTS,
         num_input_tensors);
 
-    const auto& nd_shard_spec = input_tensors[0].nd_shard_spec().value();
+    const Tensor& input_t0 = input_tensors[0];
+    const auto& nd_shard_spec = input_t0.nd_shard_spec().value();
     const CoreRangeSet all_cores = nd_shard_spec.grid;
     const std::vector<CoreCoord> cores =
         corerange_to_cores(all_cores, std::nullopt, nd_shard_spec.orientation == ShardOrientation::ROW_MAJOR);
@@ -66,8 +67,15 @@ ConcatNDShardedProgramFactory::cached_program_t ConcatNDShardedProgramFactory::c
     const uint32_t output_page_size = output.buffer()->aligned_page_size();
     std::array<uint32_t, CONCAT_ND_SHARDED_MAX_NUM_INPUTS> input_page_sizes;
     for (uint32_t i = 0; i < CONCAT_ND_SHARDED_MAX_NUM_INPUTS; ++i) {
-        const Buffer* buf = (i < num_input_tensors) ? input_tensors[i].buffer() : input_tensors[0].buffer();
+        const Buffer* buf = (i < num_input_tensors) ? input_tensors[i].buffer() : input_t0.buffer();
         input_page_sizes[i] = buf->aligned_page_size();
+        // TODO - move to the verification part
+        TT_ASSERT(
+            input_page_sizes[i] == input_page_sizes[0],
+            "input page sizes should match {}:{} != 0:{}",
+            i,
+            input_page_sizes[i],
+            input_page_sizes[0]);
     }
 
     // some debug information about output tensor
@@ -88,7 +96,7 @@ ConcatNDShardedProgramFactory::cached_program_t ConcatNDShardedProgramFactory::c
     }
     std::array<uint32_t, CONCAT_ND_SHARDED_MAX_NUM_INPUTS> initial_offsets_bytes{0};
     std::array<uint32_t, CONCAT_ND_SHARDED_MAX_NUM_INPUTS> to_write_bytes{0};
-    std::array<uint32_t, CONCAT_ND_SHARDED_MAX_NUM_INPUTS> to_skip_bytes{0};
+    //    std::array<uint32_t, CONCAT_ND_SHARDED_MAX_NUM_INPUTS> to_skip_bytes{0};
     {
         for (uint32_t i = 0; i < num_input_tensors; ++i) {
             const uint32_t sz_to_fill =
@@ -133,7 +141,7 @@ ConcatNDShardedProgramFactory::cached_program_t ConcatNDShardedProgramFactory::c
     // TensorAccessor parameters come from tensor buffers only; no Circular Buffer required.
     TensorAccessorArgs(*output.buffer()).append_to(reader_compile_time_args);
     for (uint32_t i = 0; i < CONCAT_ND_SHARDED_MAX_NUM_INPUTS; ++i) {
-        const Buffer* buf = (i < num_input_tensors) ? input_tensors[i].buffer() : input_tensors[0].buffer();
+        const Buffer* buf = (i < num_input_tensors) ? input_tensors[i].buffer() : input_t0.buffer();
         TensorAccessorArgs(*buf).append_to(reader_compile_time_args);
     }
 
@@ -146,16 +154,74 @@ ConcatNDShardedProgramFactory::cached_program_t ConcatNDShardedProgramFactory::c
     // Runtime args for the single core: scratch_l1_addr, output addr, then per-input (addr, absolute_offset_to_start,
     // amount_to_write, amount_to_skip), then shard_id
     {
+        uint32_t dim_pages{0};  // how many pages I need to write from every Tensor, sequentially
+        const uint32_t num_dims = output.padded_shape().rank();
+        const uint32_t dim = operation_attributes.dim;
+        const bool rm_layout = (output.layout() == Layout::ROW_MAJOR);
+        uint32_t scale_factor = 1;
+        if (!rm_layout) {
+            if (dim == num_dims - 2) {
+                scale_factor = TILE_HEIGHT;
+            } else if (dim == num_dims - 1) {
+                scale_factor = TILE_WIDTH;
+            }
+        }
+        uint32_t num_accum_pages = 1;
+        for (uint32_t i = dim + 1; i < num_dims; ++i) {
+            num_accum_pages *= output.padded_shape()[i];
+            std::cout << "num_acum_pages at " << i << ": " << num_accum_pages;
+        }
+        std::cout << "\n";
+
+        if (rm_layout) {
+            if (num_dims > 1 && dim < num_dims - 1) {
+                num_accum_pages /= output.padded_shape()[-1];
+            }
+        } else {
+            if (dim < num_dims - 2) {
+                num_accum_pages /= TILE_HW;
+            } else if (dim == num_dims - 2) {
+                num_accum_pages /= TILE_WIDTH;
+            }
+        }
+        std::cout << "result acum_pages: " << num_accum_pages << "\n";
+        uint32_t num_output_pages_per_block_total = 0;
+
+        if (rm_layout) {
+            dim_pages = input_t0.padded_shape()[dim];
+        } else {
+            dim_pages = input_t0.padded_shape()[dim] / scale_factor;
+        }
+        if (rm_layout && dim == num_dims - 1) {
+            num_output_pages_per_block_total += num_accum_pages;
+        } else {
+            num_output_pages_per_block_total += num_accum_pages * dim_pages;
+        }
+        if (rm_layout && dim == num_dims - 1) {
+            num_output_pages_per_block_total = 1;
+        }
+
+        std::cout << "dim pages: " << dim_pages << ". pages per block: " << num_output_pages_per_block_total << "\n";
+
         std::vector<uint32_t> runtime_args;
         runtime_args.push_back(scratch_l1_addr);
         runtime_args.push_back(output.buffer()->address());
+        const uint32_t per_tensor_to_write = num_output_pages_per_block_total * input_page_sizes[0];
+        const uint32_t per_tensor_to_skip = per_tensor_to_write * (num_input_tensors - 1);
+        std::cout << "per tensor write " << per_tensor_to_write << "  per tensor to skip " << per_tensor_to_skip
+                  << "\n";
         for (uint32_t i = 0; i < CONCAT_ND_SHARDED_MAX_NUM_INPUTS; ++i) {
-            const Buffer* buf = (i < num_input_tensors) ? input_tensors[i].buffer() : input_tensors[0].buffer();
+            const Buffer* buf = (i < num_input_tensors) ? input_tensors[i].buffer() : input_t0.buffer();
             runtime_args.push_back(buf->address());
 
-            runtime_args.push_back(initial_offsets_bytes[i]);
-            runtime_args.push_back(to_write_bytes[i]);
-            runtime_args.push_back(to_skip_bytes[i]);
+            runtime_args.push_back(i * per_tensor_to_write);
+            runtime_args.push_back(per_tensor_to_write);
+            runtime_args.push_back(per_tensor_to_skip);
+            std::cout << i << ". ao " << i * per_tensor_to_write << "\n";
+
+            // runtime_args.push_back(initial_offsets_bytes[i]);
+            // runtime_args.push_back(to_write_bytes[i]);
+            // runtime_args.push_back(to_skip_bytes[i]);
         }
         runtime_args.push_back(static_cast<uint32_t>(max_core_index));
         SetRuntimeArgs(program, reader_kernel_id, max_core, runtime_args);

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.cpp
@@ -154,62 +154,88 @@ ConcatNDShardedProgramFactory::cached_program_t ConcatNDShardedProgramFactory::c
     // Runtime args for the single core: scratch_l1_addr, output addr, then per-input (addr, absolute_offset_to_start,
     // amount_to_write, amount_to_skip), then shard_id
     {
-        uint32_t dim_pages{0};  // how many pages I need to write from every Tensor, sequentially
         const uint32_t num_dims = output.padded_shape().rank();
         const uint32_t dim = operation_attributes.dim;
-        const bool rm_layout = (output.layout() == Layout::ROW_MAJOR);
+
+        uint32_t dim_pages{0};  // how many pages I need to write from every Tensor, sequentially
+        uint32_t num_output_pages_per_block_total = 0;
+        std::vector<uint32_t> runtime_args;
         uint32_t scale_factor = 1;
-        if (!rm_layout) {
+
+        const bool rm_layout = (output.layout() == Layout::ROW_MAJOR);
+
+        auto fill_for_tile_layout = [&]() {
+            std::cout << " --> TILE layout ";
             if (dim == num_dims - 2) {
                 scale_factor = TILE_HEIGHT;
             } else if (dim == num_dims - 1) {
                 scale_factor = TILE_WIDTH;
             }
-        }
-        uint32_t num_accum_pages = 1;
-        for (uint32_t i = dim + 1; i < num_dims; ++i) {
-            num_accum_pages *= output.padded_shape()[i];
-            std::cout << "num_acum_pages at " << i << ": " << num_accum_pages;
-        }
-        std::cout << "\n";
 
-        if (rm_layout) {
-            if (num_dims > 1 && dim < num_dims - 1) {
-                num_accum_pages /= output.padded_shape()[-1];
+            uint32_t num_accum_pages = 1;
+            for (uint32_t i = dim + 1; i < num_dims; ++i) {
+                num_accum_pages *= output.padded_shape()[i];
+                std::cout << "num_acum_pages at " << i << ": " << num_accum_pages;
             }
-        } else {
+            std::cout << "\n";
+
             if (dim < num_dims - 2) {
                 num_accum_pages /= TILE_HW;
             } else if (dim == num_dims - 2) {
                 num_accum_pages /= TILE_WIDTH;
             }
-        }
-        std::cout << "result acum_pages: " << num_accum_pages << "\n";
-        uint32_t num_output_pages_per_block_total = 0;
+
+            std::cout << "result acum_pages: " << num_accum_pages << "\n";
+
+            dim_pages = input_t0.padded_shape()[dim] / scale_factor;
+
+            num_output_pages_per_block_total += num_accum_pages * dim_pages;
+        };
+
+        auto fill_for_raw_major_layout = [&]() {
+            std::cout << " --> Raw Major layout ";
+
+            uint32_t num_accum_pages = 1;
+            for (uint32_t i = dim + 1; i < num_dims; ++i) {
+                num_accum_pages *= output.padded_shape()[i];
+                std::cout << "num_acum_pages at " << i << ": " << num_accum_pages;
+            }
+            std::cout << "\n";
+
+            if (num_dims > 1 && dim < num_dims - 1) {
+                num_accum_pages /= output.padded_shape()[-1];
+            }
+            std::cout << "result acum_pages: " << num_accum_pages << "\n";
+
+            dim_pages = input_t0.padded_shape()[dim];
+
+            if (dim == num_dims - 1) {
+                num_output_pages_per_block_total += num_accum_pages;
+            } else {
+                num_output_pages_per_block_total += num_accum_pages * dim_pages;
+            }
+
+            if (dim == num_dims - 1) {
+                num_output_pages_per_block_total = 1;
+            }
+        };
 
         if (rm_layout) {
-            dim_pages = input_t0.padded_shape()[dim];
+            fill_for_raw_major_layout();
         } else {
-            dim_pages = input_t0.padded_shape()[dim] / scale_factor;
-        }
-        if (rm_layout && dim == num_dims - 1) {
-            num_output_pages_per_block_total += num_accum_pages;
-        } else {
-            num_output_pages_per_block_total += num_accum_pages * dim_pages;
-        }
-        if (rm_layout && dim == num_dims - 1) {
-            num_output_pages_per_block_total = 1;
+            fill_for_tile_layout();
         }
 
         std::cout << "dim pages: " << dim_pages << ". pages per block: " << num_output_pages_per_block_total << "\n";
 
-        std::vector<uint32_t> runtime_args;
         runtime_args.push_back(scratch_l1_addr);
         runtime_args.push_back(output.buffer()->address());
+
         const uint32_t per_tensor_to_write = num_output_pages_per_block_total * input_page_sizes[0];
         const uint32_t per_tensor_to_skip = per_tensor_to_write * (num_input_tensors - 1);
         std::cout << "per tensor write " << per_tensor_to_write << "  per tensor to skip " << per_tensor_to_skip
                   << "\n";
+
         for (uint32_t i = 0; i < CONCAT_ND_SHARDED_MAX_NUM_INPUTS; ++i) {
             const Buffer* buf = (i < num_input_tensors) ? input_tensors[i].buffer() : input_t0.buffer();
             runtime_args.push_back(buf->address());

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.cpp
@@ -69,22 +69,12 @@ ConcatNDShardedProgramFactory::cached_program_t ConcatNDShardedProgramFactory::c
         reader_compile_time_args.push_back(input_page_sizes[i]);
     }
 
+    // TensorAccessor parameters come from tensor buffers only; no Circular Buffer required.
     TensorAccessorArgs(*output.buffer()).append_to(reader_compile_time_args);
     for (uint32_t i = 0; i < CONCAT_ND_SHARDED_MAX_NUM_INPUTS; ++i) {
         const Buffer* buf = (i < num_input_tensors) ? input_tensors[i].buffer() : input_tensors[0].buffer();
         TensorAccessorArgs(*buf).append_to(reader_compile_time_args);
     }
-
-    // CB for reader: one page (max of output and any input page size)
-    uint32_t cb_page_size = output_page_size;
-    for (uint32_t i = 0; i < num_input_tensors; ++i) {
-        cb_page_size = std::max(cb_page_size, static_cast<uint32_t>(input_tensors[i].buffer()->aligned_page_size()));
-    }
-    const tt::DataFormat data_format = datatype_to_dataformat_converter(output.dtype());
-    constexpr uint32_t cb_index = 0;
-    CircularBufferConfig cb_config =
-        CircularBufferConfig(cb_page_size * 1, {{cb_index, data_format}}).set_page_size(cb_index, cb_page_size);
-    CreateCircularBuffer(program, all_cores, cb_config);
 
     KernelHandle reader_kernel_id = CreateKernel(
         program,
@@ -108,7 +98,7 @@ ConcatNDShardedProgramFactory::cached_program_t ConcatNDShardedProgramFactory::c
         std::move(program),
         {.num_input_tensors = num_input_tensors,
          .cb_inputs = {},
-         .cb_output = tt::CBIndex::c_0,
+         .cb_output = 0,
          .reader_kernel_id = reader_kernel_id,
          .writer_kernel_id = 0,
          .all_cores = all_cores,

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.hpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "concat_device_operation_types.hpp"
+#include "ttnn/device_operation.hpp"
+
+namespace ttnn::prim {
+
+// Shared variables for ND sharded concat (inputs and output are block-sharded with NdShardSpec).
+// Used to update buffer addresses when the same program is reused with different tensor pointers.
+struct ConcatNDShardedSharedVariables {
+    uint32_t num_input_tensors = 0;
+    std::vector<tt::tt_metal::CBHandle> cb_inputs;
+    tt::tt_metal::CBHandle cb_output = 0;
+    tt::tt_metal::KernelHandle reader_kernel_id = 0;
+    tt::tt_metal::KernelHandle writer_kernel_id = 0;
+    CoreRangeSet all_cores;
+    std::vector<CoreCoord> cores;
+};
+
+// Program factory for concat when all input tensors and the output tensor are ND sharded
+// (same grid, block-sharded; shard shapes may differ only along the concat dimension).
+// Each core holds its shard of each input and writes its shard of the output by
+// reading input shards in concat order into a circular buffer, then writing to output.
+struct ConcatNDShardedProgramFactory {
+    using shared_variables_t = ConcatNDShardedSharedVariables;
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create(
+        const ConcatParams& operation_attributes, const ConcatInputs& tensor_args, Tensor& tensor_return_value);
+    static void override_runtime_arguments(
+        cached_program_t& cached_program,
+        const ConcatParams& operation_attributes,
+        const ConcatInputs& tensor_args,
+        Tensor& tensor_return_value);
+};
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.hpp
@@ -7,6 +7,12 @@
 #include "concat_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
 
+#include <memory>
+
+namespace tt::tt_metal {
+class Buffer;
+}
+
 namespace ttnn::prim {
 
 // Shared variables for ND sharded concat (inputs and output are block-sharded with NdShardSpec).
@@ -19,6 +25,7 @@ struct ConcatNDShardedSharedVariables {
     tt::tt_metal::KernelHandle writer_kernel_id = 0;
     CoreRangeSet all_cores;
     std::vector<CoreCoord> cores;
+    std::shared_ptr<tt::tt_metal::Buffer> scratch_l1_buffer;
 };
 
 // Program factory for concat when all input tensors and the output tensor are ND sharded

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/concat_nd_sharded_args.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/concat_nd_sharded_args.hpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "ttnn/kernel/kernel_common_utils.hpp"
+
+namespace ttnn::kernel {
+
+// Maximum number of input tensors supported by the ND sharded concat kernel.
+// The kernel is compiled with this many TensorAccessorArgs (output + MAX_NUM_INPUTS).
+constexpr std::uint32_t CONCAT_ND_SHARDED_MAX_NUM_INPUTS = 16u;
+
+// Runtime args layout (per core, via SetRuntimeArgs):
+//   [0 .. num_input_tensors]: buffer addresses (output at 0, then input0, input1, ...)
+//   [num_input_tensors + 1]: shard_id (this core's index in the grid)
+
+}  // namespace ttnn::kernel

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/concat_nd_sharded_args.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/concat_nd_sharded_args.hpp
@@ -15,8 +15,9 @@ namespace ttnn::kernel {
 constexpr std::uint32_t CONCAT_ND_SHARDED_MAX_NUM_INPUTS = 16u;
 
 // Runtime args layout (per core, via SetRuntimeArgs):
-//   [0]: output buffer address
-//   [1 .. 16]: input buffer addresses (input0..input15; absent filled from first input)
-//   [17]: shard_id (this core's index in the grid)
+//   [0]: scratch L1 buffer address (host-allocated, one page, max page size)
+//   [1]: output buffer address
+//   [2 .. 17]: input buffer addresses (input0..input15; absent filled from first input)
+//   [18]: shard_id (this core's index in the grid)
 
 }  // namespace ttnn::kernel

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/concat_nd_sharded_args.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/concat_nd_sharded_args.hpp
@@ -15,7 +15,8 @@ namespace ttnn::kernel {
 constexpr std::uint32_t CONCAT_ND_SHARDED_MAX_NUM_INPUTS = 16u;
 
 // Runtime args layout (per core, via SetRuntimeArgs):
-//   [0 .. num_input_tensors]: buffer addresses (output at 0, then input0, input1, ...)
-//   [num_input_tensors + 1]: shard_id (this core's index in the grid)
+//   [0]: output buffer address
+//   [1 .. 16]: input buffer addresses (input0..input15; absent filled from first input)
+//   [17]: shard_id (this core's index in the grid)
 
 }  // namespace ttnn::kernel

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_nd_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_nd_sharded.cpp
@@ -32,7 +32,7 @@ void kernel_main() {
     const uint32_t base_l1_write_addr = get_write_ptr(output_cb);
     uint32_t arg_idx = 2;
 
-    for (uint32_t input_id = start_input_id; input_id < end_input_id; input_id++) {
+    for (uint32_t input_id = start_input_id; input_id < end_input_id; ++input_id) {
         const uint32_t num_pages = get_arg_val<uint32_t>(arg_idx++);
         const uint32_t write_offset_pages = get_arg_val<uint32_t>(arg_idx++);
 
@@ -49,7 +49,7 @@ void kernel_main() {
 
         // Copy this input's shard (num_pages pages) into the output region.
         noc_async_read_one_packet_set_state(noc_addr_src, page_size);
-        for (uint32_t page = 0; page < num_pages; page++) {
+        for (uint32_t page = 0; page < num_pages; ++page) {
             noc_async_read_one_packet_with_state<true>(l1_read_addr, l1_write_addr + page * page_size);
             l1_read_addr += page_size;
         }

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_nd_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_nd_sharded.cpp
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Reader kernel for ND sharded concat.
+ *
+ * Each core holds a shard of every input and a shard of the output (same grid for all).
+ * This kernel reads from a subset of input CBs in concat order and writes into the output CB.
+ * The host splits work between reader and writer: reader handles inputs [start_input_id, end_input_id)
+ * so that two RISC-V processors can run in parallel (reader on one, writer on the other).
+ *
+ * Compile-time args: [output_cb_id, page_size, num_input_tensors]
+ * Runtime args: [start_input_id, end_input_id, (num_pages, write_offset_pages) for each input in [start, end)]
+ *
+ * Input CBs 0..num_input_tensors-1 are backed by the input buffers (each core sees its shard).
+ * Output data is written to output_cb at byte offset (write_offset_pages * page_size).
+ */
+
+#include <stdint.h>
+
+void kernel_main() {
+    // --- Compile-time: output CB, page size, total number of input tensors ---
+    constexpr uint32_t output_cb = get_compile_time_arg_val(0);
+    constexpr uint32_t page_size = get_compile_time_arg_val(1);
+    constexpr uint32_t num_input_tensors = get_compile_time_arg_val(2);
+
+    // --- Runtime: which input range this kernel instance processes ---
+    const uint32_t start_input_id = get_arg_val<uint32_t>(0);
+    const uint32_t end_input_id = get_arg_val<uint32_t>(1);
+
+    const uint32_t base_l1_write_addr = get_write_ptr(output_cb);
+    uint32_t arg_idx = 2;
+
+    for (uint32_t input_id = start_input_id; input_id < end_input_id; input_id++) {
+        const uint32_t num_pages = get_arg_val<uint32_t>(arg_idx++);
+        const uint32_t write_offset_pages = get_arg_val<uint32_t>(arg_idx++);
+
+        if (num_pages == 0) {
+            continue;
+        }
+
+        // Source: this core's shard of input_id (CB is backed by the input buffer).
+        uint32_t l1_read_addr = get_read_ptr(input_id);
+        const uint64_t noc_addr_src = get_noc_addr(l1_read_addr);
+
+        // Destination: output CB at the offset for this input in concat order.
+        const uint32_t l1_write_addr = base_l1_write_addr + (write_offset_pages * page_size);
+
+        // Copy this input's shard (num_pages pages) into the output region.
+        noc_async_read_one_packet_set_state(noc_addr_src, page_size);
+        for (uint32_t page = 0; page < num_pages; page++) {
+            noc_async_read_one_packet_with_state<true>(l1_read_addr, l1_write_addr + page * page_size);
+            l1_read_addr += page_size;
+        }
+        noc_async_read_barrier();
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_nd_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_nd_sharded.cpp
@@ -25,29 +25,48 @@ uint32_t g_copy_scratch_l1_addr = 0;
 
 inline void set_copy_tensor_data_scratch(uint32_t l1_addr) { g_copy_scratch_l1_addr = l1_addr; }
 
-// Copies all data from src to dest starting at byte offset in dest. Returns offset + size in bytes of src data.
+// Copies all data from src to dest in portions of amount_to_write bytes. First portion is written at
+// absolute_offset_to_start in dest; each next portion is written at (previous_dest_offset + amount_to_write +
+// amount_to_skip). Uses a single-page L1 scratch buffer; amount_to_write may be less, equal or greater than page size.
 // Requires set_copy_tensor_data_scratch() to be called with a valid L1 buffer (at least one page) before use.
 template <typename DestDSpec, typename SrcDSpec>
-uint32_t copy_tensor_data(
+void copy_tensor_data(
     const TensorAccessor<DestDSpec>& dest,
     const TensorAccessor<SrcDSpec>& src,
-    uint32_t offset,
-    uint32_t /*absolute_offset_to_start*/,
-    uint32_t /*amount_to_write*/,
-    uint32_t /*amount_to_skip*/) {
-    const uint32_t num_pages = src.dspec().tensor_volume();
+    uint32_t absolute_offset_to_start,
+    uint32_t amount_to_write,
+    uint32_t amount_to_skip) {
     const uint32_t src_page_size = src.page_size;
-    const uint32_t total_bytes = num_pages * src_page_size;
-    for (uint32_t page_id = 0; page_id < num_pages; ++page_id) {
-        const uint32_t dest_byte_offset = offset + page_id * src_page_size;
-        const uint32_t dest_page_id = dest_byte_offset / dest.page_size;
-        const uint32_t dest_offset_in_page = dest_byte_offset % dest.page_size;
-        noc_async_read(src.get_noc_addr(page_id, 0), g_copy_scratch_l1_addr, src_page_size);
-        noc_async_read_barrier();
-        noc_async_write(g_copy_scratch_l1_addr, dest.get_noc_addr(dest_page_id, dest_offset_in_page), src_page_size);
-        noc_async_write_barrier();
+    const uint32_t total_src_bytes = src.dspec().tensor_volume() * src_page_size;
+    uint32_t src_byte_offset = 0;
+    uint32_t dest_byte_offset = absolute_offset_to_start;
+
+    while (src_byte_offset < total_src_bytes) {
+        const uint32_t bytes_this_portion = (amount_to_write <= total_src_bytes - src_byte_offset)
+                                                ? amount_to_write
+                                                : (total_src_bytes - src_byte_offset);
+        uint32_t src_off = src_byte_offset;
+        uint32_t dest_off = dest_byte_offset;
+        uint32_t remaining = bytes_this_portion;
+
+        while (remaining > 0) {
+            const uint32_t chunk = (remaining <= src_page_size) ? remaining : src_page_size;
+            const uint32_t src_page_id = src_off / src_page_size;
+            const uint32_t src_offset_in_page = src_off % src_page_size;
+            noc_async_read(src.get_noc_addr(src_page_id, src_offset_in_page), g_copy_scratch_l1_addr, chunk);
+            noc_async_read_barrier();
+            const uint32_t dest_page_id = dest_off / dest.page_size;
+            const uint32_t dest_offset_in_page = dest_off % dest.page_size;
+            noc_async_write(g_copy_scratch_l1_addr, dest.get_noc_addr(dest_page_id, dest_offset_in_page), chunk);
+            noc_async_write_barrier();
+            remaining -= chunk;
+            src_off += chunk;
+            dest_off += chunk;
+        }
+
+        src_byte_offset += bytes_this_portion;
+        dest_byte_offset += amount_to_write + amount_to_skip;
     }
-    return offset + total_bytes;
 }
 
 // Compile-time layout: [0]=num_input_tensors, [1]=output_page_size, [2..17]=input_page_sizes,
@@ -117,39 +136,32 @@ void kernel_main() {
         DPRINT << ENDL();
     }
 
-    // Copy each input to output sequentially; initial offset 0, then use offset returned from previous copy.
-#define CONCAT_ND_DPRINT_INPUT(n)                                                                                  \
-    do {                                                                                                           \
-        const uint32_t initial_offset_##n = offset;                                                                \
-        constexpr uint32_t in_page_size_##n = get_compile_time_arg_val(CT_INPUT_PAGE_SIZE_BASE + (n));             \
-        const auto in##n##_accessor = TensorAccessor(in##n##_args, input_addrs[n], in_page_size_##n);              \
-        DPRINT << "input " << (n) << " source: shards=" << in##n##_accessor.dspec().num_banks()                    \
-               << " pages=" << in##n##_accessor.dspec().tensor_volume() << " page_size=" << in_page_size_##n       \
-               << " tile_size=" << in_page_size_##n << " absolute_offset_to_start=" << absolute_offset_to_start[n] \
-               << " amount_to_write=" << amount_to_write[n] << " amount_to_skip=" << amount_to_skip[n] << ENDL();  \
-        {                                                                                                          \
-            const uint32_t in_rank_##n = in##n##_accessor.dspec().rank();                                          \
-            DPRINT << "input " << (n) << " dimensions: rank=" << in_rank_##n;                                      \
-            for (uint32_t d = 0; d < in_rank_##n; ++d) {                                                           \
-                DPRINT << " dim" << d << "_ts=" << in##n##_accessor.dspec().tensor_shape()[d]                      \
-                       << "_ss=" << in##n##_accessor.dspec().shard_shape()[d]                                      \
-                       << "_sg=" << in##n##_accessor.dspec().shard_grid()[d];                                      \
-            }                                                                                                      \
-            DPRINT << ENDL();                                                                                      \
-        }                                                                                                          \
-        offset = copy_tensor_data(                                                                                 \
-            output_accessor,                                                                                       \
-            in##n##_accessor,                                                                                      \
-            offset,                                                                                                \
-            absolute_offset_to_start[n],                                                                           \
-            amount_to_write[n],                                                                                    \
-            amount_to_skip[n]);                                                                                    \
-        const uint32_t bytes_copied_##n = offset - initial_offset_##n;                                             \
-        DPRINT << "input " << (n) << ": copied " << bytes_copied_##n << " bytes to initial offset "                \
-               << initial_offset_##n << " (input tensor " << (n) << ")" << ENDL();                                 \
+    // Copy each input to output; each input uses its own absolute_offset_to_start and portion strides.
+#define CONCAT_ND_DPRINT_INPUT(n)                                                                                   \
+    do {                                                                                                            \
+        constexpr uint32_t in_page_size_##n = get_compile_time_arg_val(CT_INPUT_PAGE_SIZE_BASE + (n));              \
+        const auto in##n##_accessor = TensorAccessor(in##n##_args, input_addrs[n], in_page_size_##n);               \
+        DPRINT << "input " << (n) << " source: shards=" << in##n##_accessor.dspec().num_banks()                     \
+               << " pages=" << in##n##_accessor.dspec().tensor_volume() << " page_size=" << in_page_size_##n        \
+               << " tile_size=" << in_page_size_##n << " absolute_offset_to_start=" << absolute_offset_to_start[n]  \
+               << " amount_to_write=" << amount_to_write[n] << " amount_to_skip=" << amount_to_skip[n] << ENDL();   \
+        {                                                                                                           \
+            const uint32_t in_rank_##n = in##n##_accessor.dspec().rank();                                           \
+            DPRINT << "input " << (n) << " dimensions: rank=" << in_rank_##n;                                       \
+            for (uint32_t d = 0; d < in_rank_##n; ++d) {                                                            \
+                DPRINT << " dim" << d << "_ts=" << in##n##_accessor.dspec().tensor_shape()[d]                       \
+                       << "_ss=" << in##n##_accessor.dspec().shard_shape()[d]                                       \
+                       << "_sg=" << in##n##_accessor.dspec().shard_grid()[d];                                       \
+            }                                                                                                       \
+            DPRINT << ENDL();                                                                                       \
+        }                                                                                                           \
+        copy_tensor_data(                                                                                           \
+            output_accessor, in##n##_accessor, absolute_offset_to_start[n], amount_to_write[n], amount_to_skip[n]); \
+        const uint32_t bytes_copied_##n = in##n##_accessor.dspec().tensor_volume() * in_page_size_##n;              \
+        DPRINT << "input " << (n) << ": copied " << bytes_copied_##n << " bytes to offset "                         \
+               << absolute_offset_to_start[n] << " (input tensor " << (n) << ")" << ENDL();                         \
     } while (0)
 
-    uint32_t offset = 0;
     for (uint32_t i = 0; i < num_input_tensors; ++i) {
         switch (i) {
             case 0: CONCAT_ND_DPRINT_INPUT(0); break;

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_nd_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_nd_sharded.cpp
@@ -5,8 +5,8 @@
 /*
  * ND sharded concat reader: runs on each core, copies this core's input shards
  * (in concat order) into this core's output shard. Uses TensorAccessor for each
- * tensor; reads each input shard page-by-page into a scratch CB and writes to
- * the output shard sequentially.
+ * tensor; reads each input shard page-by-page into a host-allocated L1 scratch
+ * buffer and writes to the output shard sequentially.
  */
 
 #include <cstdint>
@@ -20,7 +20,7 @@ namespace {
 
 constexpr uint32_t CONCAT_ND_SHARDED_MAX_NUM_INPUTS = ttnn::kernel::CONCAT_ND_SHARDED_MAX_NUM_INPUTS;
 
-// Scratch L1 address for copy_tensor_data (set by kernel before first call, e.g. from scratch CB).
+// Scratch L1 address for copy_tensor_data (set from runtime arg: host-allocated L1 buffer).
 uint32_t g_copy_scratch_l1_addr = 0;
 
 inline void set_copy_tensor_data_scratch(uint32_t l1_addr) { g_copy_scratch_l1_addr = l1_addr; }
@@ -58,6 +58,9 @@ void kernel_main() {
     constexpr uint32_t output_page_size = get_compile_time_arg_val(CT_OUTPUT_PAGE_SIZE);
 
     uint32_t argidx = 0;
+    const uint32_t scratch_l1_addr = get_arg_val<uint32_t>(argidx++);
+    set_copy_tensor_data_scratch(scratch_l1_addr);
+
     const uint32_t output_addr = get_arg_val<uint32_t>(argidx++);
     uint32_t input_addrs[CONCAT_ND_SHARDED_MAX_NUM_INPUTS];
     for (uint32_t i = 0; i < CONCAT_ND_SHARDED_MAX_NUM_INPUTS; ++i) {
@@ -85,11 +88,6 @@ void kernel_main() {
     constexpr auto in15_args = TensorAccessorArgs<in14_args.next_compile_time_args_offset()>();
 
     const auto output_accessor = TensorAccessor(out_args, output_addr, output_page_size);
-
-    // Scratch CB for copy_tensor_data (page-sized).
-    constexpr uint32_t cb_scratch_id = 0;
-    cb_reserve_back(cb_scratch_id, 1);
-    set_copy_tensor_data_scratch(get_write_ptr(cb_scratch_id));
 
     // Copy each input to output sequentially; initial offset 0, then use offset returned from previous copy.
 #define CONCAT_ND_DPRINT_INPUT(n)                                                                      \

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_nd_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_nd_sharded.cpp
@@ -20,6 +20,30 @@ namespace {
 
 constexpr uint32_t CONCAT_ND_SHARDED_MAX_NUM_INPUTS = ttnn::kernel::CONCAT_ND_SHARDED_MAX_NUM_INPUTS;
 
+// Scratch L1 address for copy_tensor_data (set by kernel before first call, e.g. from scratch CB).
+uint32_t g_copy_scratch_l1_addr = 0;
+
+inline void set_copy_tensor_data_scratch(uint32_t l1_addr) { g_copy_scratch_l1_addr = l1_addr; }
+
+// Copies all data from src to dest starting at byte offset in dest. Returns offset + size in bytes of src data.
+// Requires set_copy_tensor_data_scratch() to be called with a valid L1 buffer (at least one page) before use.
+template <typename DestDSpec, typename SrcDSpec>
+uint32_t copy_tensor_data(const TensorAccessor<DestDSpec>& dest, const TensorAccessor<SrcDSpec>& src, uint32_t offset) {
+    const uint32_t num_pages = src.dspec().tensor_volume();
+    const uint32_t src_page_size = src.page_size;
+    const uint32_t total_bytes = num_pages * src_page_size;
+    for (uint32_t page_id = 0; page_id < num_pages; ++page_id) {
+        const uint32_t dest_byte_offset = offset + page_id * src_page_size;
+        const uint32_t dest_page_id = dest_byte_offset / dest.page_size;
+        const uint32_t dest_offset_in_page = dest_byte_offset % dest.page_size;
+        noc_async_read(src.get_noc_addr(page_id, 0), g_copy_scratch_l1_addr, src_page_size);
+        noc_async_read_barrier();
+        noc_async_write(g_copy_scratch_l1_addr, dest.get_noc_addr(dest_page_id, dest_offset_in_page), src_page_size);
+        noc_async_write_barrier();
+    }
+    return offset + total_bytes;
+}
+
 // Compile-time layout: [0]=num_input_tensors, [1]=output_page_size, [2..17]=input_page_sizes,
 // [18..]=output TensorAccessorArgs, then input0..input15 TensorAccessorArgs.
 constexpr uint32_t CT_NUM_INPUTS = 0;
@@ -62,18 +86,24 @@ void kernel_main() {
 
     const auto output_accessor = TensorAccessor(out_args, output_addr, output_page_size);
 
-    // Create TensorAccessor for each input and DPRINT: input data (pages), input page size,
-    // output data (pages), output page size.
+    // Scratch CB for copy_tensor_data (page-sized).
+    constexpr uint32_t cb_scratch_id = 0;
+    cb_reserve_back(cb_scratch_id, 1);
+    set_copy_tensor_data_scratch(get_write_ptr(cb_scratch_id));
+
+    // Copy each input to output sequentially; initial offset 0, then use offset returned from previous copy.
 #define CONCAT_ND_DPRINT_INPUT(n)                                                                      \
     do {                                                                                               \
+        const uint32_t initial_offset_##n = offset;                                                    \
         constexpr uint32_t in_page_size_##n = get_compile_time_arg_val(CT_INPUT_PAGE_SIZE_BASE + (n)); \
         const auto in##n##_accessor = TensorAccessor(in##n##_args, input_addrs[n], in_page_size_##n);  \
-        DPRINT << "input " << (n) << ": data (pages)=" << in##n##_accessor.dspec().tensor_volume()     \
-               << " page_size=" << in_page_size_##n                                                    \
-               << " output data (pages)=" << output_accessor.dspec().tensor_volume()                   \
-               << " output page_size=" << output_page_size << ENDL();                                  \
+        offset = copy_tensor_data(output_accessor, in##n##_accessor, offset);                          \
+        const uint32_t bytes_copied_##n = offset - initial_offset_##n;                                 \
+        DPRINT << "input " << (n) << ": copied " << bytes_copied_##n << " bytes to initial offset "    \
+               << initial_offset_##n << " (input tensor " << (n) << ")" << ENDL();                     \
     } while (0)
 
+    uint32_t offset = 0;
     for (uint32_t i = 0; i < num_input_tensors; ++i) {
         switch (i) {
             case 0: CONCAT_ND_DPRINT_INPUT(0); break;

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_nd_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_nd_sharded.cpp
@@ -47,14 +47,16 @@ uint32_t copy_tensor_data(const TensorAccessor<DestDSpec>& dest, const TensorAcc
 // Compile-time layout: [0]=num_input_tensors, [1]=output_page_size, [2..17]=input_page_sizes,
 // [18..]=output TensorAccessorArgs, then input0..input15 TensorAccessorArgs.
 constexpr uint32_t CT_NUM_INPUTS = 0;
-constexpr uint32_t CT_OUTPUT_PAGE_SIZE = 1;
-constexpr uint32_t CT_INPUT_PAGE_SIZE_BASE = 2;
-constexpr uint32_t CT_TENSOR_ACCESSOR_ARGS_BASE = 18;
+constexpr uint32_t CT_CONCAT_DIM = 1;
+constexpr uint32_t CT_OUTPUT_PAGE_SIZE = 2;
+constexpr uint32_t CT_INPUT_PAGE_SIZE_BASE = 3;
+constexpr uint32_t CT_TENSOR_ACCESSOR_ARGS_BASE = 19;
 
 }  // namespace
 
 void kernel_main() {
     constexpr uint32_t num_input_tensors = get_compile_time_arg_val(CT_NUM_INPUTS);
+    constexpr uint32_t concat_dim = get_compile_time_arg_val(CT_CONCAT_DIM);
     constexpr uint32_t output_page_size = get_compile_time_arg_val(CT_OUTPUT_PAGE_SIZE);
 
     uint32_t argidx = 0;

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_nd_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_nd_sharded.cpp
@@ -19,6 +19,9 @@
 
 #include <stdint.h>
 #include "api/debug/dprint.h"
+#include "ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
+#include "ttnn/kernel/kernel_utils.hpp"
+#include "concat_nd_sharded_args.hpp"
 
 void kernel_main() {
     // --- Compile-time: output CB, page size, total number of input tensors ---
@@ -37,6 +40,7 @@ void kernel_main() {
     DPRINT << "destination_shard_pos " << destination_shard_pos << " in_core_idx " << in_core_idx << ENDL();
     DPRINT << "in_tensor_pos " << in_tensor_pos << " shard_pos " << shard_pos << ENDL();
     DPRINT << "shard size " << shard_size << "test_value " << test_value << ENDL();
+    DPRINT << "destination page size " << page_size << ENDL();
 
     // const uint32_t base_l1_write_addr = get_write_ptr(output_cb);
     // uint32_t arg_idx = 2;
@@ -58,7 +62,7 @@ void kernel_main() {
     //     // Copy this input's shard (num_pages pages) into the output region.
     //     noc_async_read_one_packet_set_state(noc_addr_src, page_size);
     //     for (uint32_t page = 0; page < num_pages; ++page) {
-    //         noc_async_read_one_packet_with_state<true>(l1_read_addr, l1_write_addr + page * page_size);
+    //             noc_async_read_one_packet_with_state<true>(l1_read_addr, l1_write_addr + page * page_size);
     //         l1_read_addr += page_size;
     //     }
     //     noc_async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_nd_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_nd_sharded.cpp
@@ -32,9 +32,9 @@ uint32_t copy_tensor_data(
     const TensorAccessor<DestDSpec>& dest,
     const TensorAccessor<SrcDSpec>& src,
     uint32_t offset,
-    uint32_t /*first_shard_pos*/,
-    uint32_t /*shards_to_write*/,
-    uint32_t /*shards_to_skip*/) {
+    uint32_t /*absolute_offset_to_start*/,
+    uint32_t /*amount_to_write*/,
+    uint32_t /*amount_to_skip*/) {
     const uint32_t num_pages = src.dspec().tensor_volume();
     const uint32_t src_page_size = src.page_size;
     const uint32_t total_bytes = num_pages * src_page_size;
@@ -71,14 +71,14 @@ void kernel_main() {
 
     const uint32_t output_addr = get_arg_val<uint32_t>(argidx++);
     uint32_t input_addrs[CONCAT_ND_SHARDED_MAX_NUM_INPUTS];
-    uint32_t first_shard_pos[CONCAT_ND_SHARDED_MAX_NUM_INPUTS];
-    uint32_t shards_to_write[CONCAT_ND_SHARDED_MAX_NUM_INPUTS];
-    uint32_t shards_to_skip[CONCAT_ND_SHARDED_MAX_NUM_INPUTS];
+    uint32_t absolute_offset_to_start[CONCAT_ND_SHARDED_MAX_NUM_INPUTS];
+    uint32_t amount_to_write[CONCAT_ND_SHARDED_MAX_NUM_INPUTS];
+    uint32_t amount_to_skip[CONCAT_ND_SHARDED_MAX_NUM_INPUTS];
     for (uint32_t i = 0; i < CONCAT_ND_SHARDED_MAX_NUM_INPUTS; ++i) {
         input_addrs[i] = get_arg_val<uint32_t>(argidx++);
-        first_shard_pos[i] = get_arg_val<uint32_t>(argidx++);
-        shards_to_write[i] = get_arg_val<uint32_t>(argidx++);
-        shards_to_skip[i] = get_arg_val<uint32_t>(argidx++);
+        absolute_offset_to_start[i] = get_arg_val<uint32_t>(argidx++);
+        amount_to_write[i] = get_arg_val<uint32_t>(argidx++);
+        amount_to_skip[i] = get_arg_val<uint32_t>(argidx++);
     }
     const uint32_t shard_id = get_arg_val<uint32_t>(argidx++);
 
@@ -125,8 +125,8 @@ void kernel_main() {
         const auto in##n##_accessor = TensorAccessor(in##n##_args, input_addrs[n], in_page_size_##n);              \
         DPRINT << "input " << (n) << " source: shards=" << in##n##_accessor.dspec().num_banks()                    \
                << " pages=" << in##n##_accessor.dspec().tensor_volume() << " page_size=" << in_page_size_##n       \
-               << " tile_size=" << in_page_size_##n << " first_shard_pos=" << first_shard_pos[n]                   \
-               << " shards_to_write=" << shards_to_write[n] << " shards_to_skip=" << shards_to_skip[n] << ENDL();  \
+               << " tile_size=" << in_page_size_##n << " absolute_offset_to_start=" << absolute_offset_to_start[n] \
+               << " amount_to_write=" << amount_to_write[n] << " amount_to_skip=" << amount_to_skip[n] << ENDL();  \
         {                                                                                                          \
             const uint32_t in_rank_##n = in##n##_accessor.dspec().rank();                                          \
             DPRINT << "input " << (n) << " dimensions: rank=" << in_rank_##n;                                      \
@@ -138,7 +138,12 @@ void kernel_main() {
             DPRINT << ENDL();                                                                                      \
         }                                                                                                          \
         offset = copy_tensor_data(                                                                                 \
-            output_accessor, in##n##_accessor, offset, first_shard_pos[n], shards_to_write[n], shards_to_skip[n]); \
+            output_accessor,                                                                                       \
+            in##n##_accessor,                                                                                      \
+            offset,                                                                                                \
+            absolute_offset_to_start[n],                                                                           \
+            amount_to_write[n],                                                                                    \
+            amount_to_skip[n]);                                                                                    \
         const uint32_t bytes_copied_##n = offset - initial_offset_##n;                                             \
         DPRINT << "input " << (n) << ": copied " << bytes_copied_##n << " bytes to initial offset "                \
                << initial_offset_##n << " (input tensor " << (n) << ")" << ENDL();                                 \

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_nd_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_nd_sharded.cpp
@@ -28,7 +28,13 @@ inline void set_copy_tensor_data_scratch(uint32_t l1_addr) { g_copy_scratch_l1_a
 // Copies all data from src to dest starting at byte offset in dest. Returns offset + size in bytes of src data.
 // Requires set_copy_tensor_data_scratch() to be called with a valid L1 buffer (at least one page) before use.
 template <typename DestDSpec, typename SrcDSpec>
-uint32_t copy_tensor_data(const TensorAccessor<DestDSpec>& dest, const TensorAccessor<SrcDSpec>& src, uint32_t offset) {
+uint32_t copy_tensor_data(
+    const TensorAccessor<DestDSpec>& dest,
+    const TensorAccessor<SrcDSpec>& src,
+    uint32_t offset,
+    uint32_t /*first_shard_pos*/,
+    uint32_t /*shards_to_write*/,
+    uint32_t /*shards_to_skip*/) {
     const uint32_t num_pages = src.dspec().tensor_volume();
     const uint32_t src_page_size = src.page_size;
     const uint32_t total_bytes = num_pages * src_page_size;
@@ -65,8 +71,14 @@ void kernel_main() {
 
     const uint32_t output_addr = get_arg_val<uint32_t>(argidx++);
     uint32_t input_addrs[CONCAT_ND_SHARDED_MAX_NUM_INPUTS];
+    uint32_t first_shard_pos[CONCAT_ND_SHARDED_MAX_NUM_INPUTS];
+    uint32_t shards_to_write[CONCAT_ND_SHARDED_MAX_NUM_INPUTS];
+    uint32_t shards_to_skip[CONCAT_ND_SHARDED_MAX_NUM_INPUTS];
     for (uint32_t i = 0; i < CONCAT_ND_SHARDED_MAX_NUM_INPUTS; ++i) {
         input_addrs[i] = get_arg_val<uint32_t>(argidx++);
+        first_shard_pos[i] = get_arg_val<uint32_t>(argidx++);
+        shards_to_write[i] = get_arg_val<uint32_t>(argidx++);
+        shards_to_skip[i] = get_arg_val<uint32_t>(argidx++);
     }
     const uint32_t shard_id = get_arg_val<uint32_t>(argidx++);
 
@@ -106,28 +118,30 @@ void kernel_main() {
     }
 
     // Copy each input to output sequentially; initial offset 0, then use offset returned from previous copy.
-#define CONCAT_ND_DPRINT_INPUT(n)                                                                            \
-    do {                                                                                                     \
-        const uint32_t initial_offset_##n = offset;                                                          \
-        constexpr uint32_t in_page_size_##n = get_compile_time_arg_val(CT_INPUT_PAGE_SIZE_BASE + (n));       \
-        const auto in##n##_accessor = TensorAccessor(in##n##_args, input_addrs[n], in_page_size_##n);        \
-        DPRINT << "input " << (n) << " source: shards=" << in##n##_accessor.dspec().num_banks()              \
-               << " pages=" << in##n##_accessor.dspec().tensor_volume() << " page_size=" << in_page_size_##n \
-               << " tile_size=" << in_page_size_##n << ENDL();                                               \
-        {                                                                                                    \
-            const uint32_t in_rank_##n = in##n##_accessor.dspec().rank();                                    \
-            DPRINT << "input " << (n) << " dimensions: rank=" << in_rank_##n;                                \
-            for (uint32_t d = 0; d < in_rank_##n; ++d) {                                                     \
-                DPRINT << " dim" << d << "_ts=" << in##n##_accessor.dspec().tensor_shape()[d]                \
-                       << "_ss=" << in##n##_accessor.dspec().shard_shape()[d]                                \
-                       << "_sg=" << in##n##_accessor.dspec().shard_grid()[d];                                \
-            }                                                                                                \
-            DPRINT << ENDL();                                                                                \
-        }                                                                                                    \
-        offset = copy_tensor_data(output_accessor, in##n##_accessor, offset);                                \
-        const uint32_t bytes_copied_##n = offset - initial_offset_##n;                                       \
-        DPRINT << "input " << (n) << ": copied " << bytes_copied_##n << " bytes to initial offset "          \
-               << initial_offset_##n << " (input tensor " << (n) << ")" << ENDL();                           \
+#define CONCAT_ND_DPRINT_INPUT(n)                                                                                  \
+    do {                                                                                                           \
+        const uint32_t initial_offset_##n = offset;                                                                \
+        constexpr uint32_t in_page_size_##n = get_compile_time_arg_val(CT_INPUT_PAGE_SIZE_BASE + (n));             \
+        const auto in##n##_accessor = TensorAccessor(in##n##_args, input_addrs[n], in_page_size_##n);              \
+        DPRINT << "input " << (n) << " source: shards=" << in##n##_accessor.dspec().num_banks()                    \
+               << " pages=" << in##n##_accessor.dspec().tensor_volume() << " page_size=" << in_page_size_##n       \
+               << " tile_size=" << in_page_size_##n << " first_shard_pos=" << first_shard_pos[n]                   \
+               << " shards_to_write=" << shards_to_write[n] << " shards_to_skip=" << shards_to_skip[n] << ENDL();  \
+        {                                                                                                          \
+            const uint32_t in_rank_##n = in##n##_accessor.dspec().rank();                                          \
+            DPRINT << "input " << (n) << " dimensions: rank=" << in_rank_##n;                                      \
+            for (uint32_t d = 0; d < in_rank_##n; ++d) {                                                           \
+                DPRINT << " dim" << d << "_ts=" << in##n##_accessor.dspec().tensor_shape()[d]                      \
+                       << "_ss=" << in##n##_accessor.dspec().shard_shape()[d]                                      \
+                       << "_sg=" << in##n##_accessor.dspec().shard_grid()[d];                                      \
+            }                                                                                                      \
+            DPRINT << ENDL();                                                                                      \
+        }                                                                                                          \
+        offset = copy_tensor_data(                                                                                 \
+            output_accessor, in##n##_accessor, offset, first_shard_pos[n], shards_to_write[n], shards_to_skip[n]); \
+        const uint32_t bytes_copied_##n = offset - initial_offset_##n;                                             \
+        DPRINT << "input " << (n) << ": copied " << bytes_copied_##n << " bytes to initial offset "                \
+               << initial_offset_##n << " (input tensor " << (n) << ")" << ENDL();                                 \
     } while (0)
 
     uint32_t offset = 0;

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_nd_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_nd_sharded.cpp
@@ -12,132 +12,88 @@
 #include <cstdint>
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/debug/dprint.h"
 #include "api/tensor/tensor_accessor.h"
 #include "concat_nd_sharded_args.hpp"
 
 namespace {
 
 constexpr uint32_t CONCAT_ND_SHARDED_MAX_NUM_INPUTS = ttnn::kernel::CONCAT_ND_SHARDED_MAX_NUM_INPUTS;
-constexpr uint32_t NUM_TENSORS = 1u + CONCAT_ND_SHARDED_MAX_NUM_INPUTS;  // output + inputs
 
-// Compile-time: 0 = num_input_tensors, 1..17 = page_size, 18+ = TensorAccessorArgs (output, in0..in15)
-constexpr uint32_t CTA_NUM_INPUTS = 0;
-constexpr uint32_t CTA_PAGE_SIZE_BASE = 1;
-constexpr uint32_t CTA_TENSOR_ACCESSOR_ARGS_START = 18;
-
-// Runtime: 0..16 = buffer addresses (output, in0..in15), 17 = shard_id
-constexpr uint32_t RT_SHARD_ID = 17;
-
-constexpr uint32_t CB_ID_SCRATCH = 0;
-
-template <typename OutputAccessor, typename InputAccessor>
-void copy_one_input_shard_to_output(
-    const OutputAccessor& output_accessor,
-    const InputAccessor& input_accessor,
-    uint32_t shard_id,
-    uint32_t page_size,
-    uint32_t& output_page_offset_in_shard) {
-    auto input_pages = input_accessor.shard_pages(shard_id);
-    for (const auto& page : input_pages) {
-        cb_reserve_back(CB_ID_SCRATCH, 1);
-        uint32_t l1_addr = get_write_ptr(CB_ID_SCRATCH);
-        noc_async_read(page.noc_addr(), l1_addr, page_size);
-        noc_async_read_barrier();
-
-        uint64_t out_noc_addr = output_accessor.get_shard_noc_addr(shard_id, output_page_offset_in_shard * page_size);
-        noc_async_write(l1_addr, out_noc_addr, page_size);
-        noc_async_write_barrier();
-
-        cb_push_back(CB_ID_SCRATCH, 1);
-        ++output_page_offset_in_shard;
-    }
-}
+// Compile-time layout: [0]=num_input_tensors, [1]=output_page_size, [2..17]=input_page_sizes,
+// [18..]=output TensorAccessorArgs, then input0..input15 TensorAccessorArgs.
+constexpr uint32_t CT_NUM_INPUTS = 0;
+constexpr uint32_t CT_OUTPUT_PAGE_SIZE = 1;
+constexpr uint32_t CT_INPUT_PAGE_SIZE_BASE = 2;
+constexpr uint32_t CT_TENSOR_ACCESSOR_ARGS_BASE = 18;
 
 }  // namespace
 
 void kernel_main() {
-    const uint32_t num_input_tensors = get_compile_time_arg_val(CTA_NUM_INPUTS);
-    const uint32_t page_size = get_compile_time_arg_val(CTA_PAGE_SIZE_BASE);
-    const uint32_t shard_id = get_arg_val<uint32_t>(RT_SHARD_ID);
+    constexpr uint32_t num_input_tensors = get_compile_time_arg_val(CT_NUM_INPUTS);
+    constexpr uint32_t output_page_size = get_compile_time_arg_val(CT_OUTPUT_PAGE_SIZE);
 
-    constexpr auto tensor_accessor_args_tuple =
-        make_tensor_accessor_args_tuple<NUM_TENSORS, CTA_TENSOR_ACCESSOR_ARGS_START>();
+    uint32_t argidx = 0;
+    const uint32_t output_addr = get_arg_val<uint32_t>(argidx++);
+    uint32_t input_addrs[CONCAT_ND_SHARDED_MAX_NUM_INPUTS];
+    for (uint32_t i = 0; i < CONCAT_ND_SHARDED_MAX_NUM_INPUTS; ++i) {
+        input_addrs[i] = get_arg_val<uint32_t>(argidx++);
+    }
+    const uint32_t shard_id = get_arg_val<uint32_t>(argidx++);
 
-    auto accessors_tuple = tensor_accessor::detail::make_tensor_accessor_tuple(
-        tensor_accessor_args_tuple,
-        /*address_rt_arg_index_start=*/0,
-        /*page_size_ct_arg_index_start=*/CTA_PAGE_SIZE_BASE);
+    // Build TensorAccessorArgs chain: output at 18, then input0..input15
+    constexpr auto out_args = TensorAccessorArgs<CT_TENSOR_ACCESSOR_ARGS_BASE>();
+    constexpr auto in0_args = TensorAccessorArgs<out_args.next_compile_time_args_offset()>();
+    constexpr auto in1_args = TensorAccessorArgs<in0_args.next_compile_time_args_offset()>();
+    constexpr auto in2_args = TensorAccessorArgs<in1_args.next_compile_time_args_offset()>();
+    constexpr auto in3_args = TensorAccessorArgs<in2_args.next_compile_time_args_offset()>();
+    constexpr auto in4_args = TensorAccessorArgs<in3_args.next_compile_time_args_offset()>();
+    constexpr auto in5_args = TensorAccessorArgs<in4_args.next_compile_time_args_offset()>();
+    constexpr auto in6_args = TensorAccessorArgs<in5_args.next_compile_time_args_offset()>();
+    constexpr auto in7_args = TensorAccessorArgs<in6_args.next_compile_time_args_offset()>();
+    constexpr auto in8_args = TensorAccessorArgs<in7_args.next_compile_time_args_offset()>();
+    constexpr auto in9_args = TensorAccessorArgs<in8_args.next_compile_time_args_offset()>();
+    constexpr auto in10_args = TensorAccessorArgs<in9_args.next_compile_time_args_offset()>();
+    constexpr auto in11_args = TensorAccessorArgs<in10_args.next_compile_time_args_offset()>();
+    constexpr auto in12_args = TensorAccessorArgs<in11_args.next_compile_time_args_offset()>();
+    constexpr auto in13_args = TensorAccessorArgs<in12_args.next_compile_time_args_offset()>();
+    constexpr auto in14_args = TensorAccessorArgs<in13_args.next_compile_time_args_offset()>();
+    constexpr auto in15_args = TensorAccessorArgs<in14_args.next_compile_time_args_offset()>();
 
-    const auto& output_accessor = std::get<0>(accessors_tuple);
-    uint32_t output_page_offset_in_shard = 0;
+    const auto output_accessor = TensorAccessor(out_args, output_addr, output_page_size);
+
+    // Create TensorAccessor for each input and DPRINT: input data (pages), input page size,
+    // output data (pages), output page size.
+#define CONCAT_ND_DPRINT_INPUT(n)                                                                      \
+    do {                                                                                               \
+        constexpr uint32_t in_page_size_##n = get_compile_time_arg_val(CT_INPUT_PAGE_SIZE_BASE + (n)); \
+        const auto in##n##_accessor = TensorAccessor(in##n##_args, input_addrs[n], in_page_size_##n);  \
+        DPRINT << "input " << (n) << ": data (pages)=" << in##n##_accessor.dspec().tensor_volume()     \
+               << " page_size=" << in_page_size_##n                                                    \
+               << " output data (pages)=" << output_accessor.dspec().tensor_volume()                   \
+               << " output page_size=" << output_page_size << ENDL();                                  \
+    } while (0)
 
     for (uint32_t i = 0; i < num_input_tensors; ++i) {
         switch (i) {
-            case 0:
-                copy_one_input_shard_to_output(
-                    output_accessor, std::get<1>(accessors_tuple), shard_id, page_size, output_page_offset_in_shard);
-                break;
-            case 1:
-                copy_one_input_shard_to_output(
-                    output_accessor, std::get<2>(accessors_tuple), shard_id, page_size, output_page_offset_in_shard);
-                break;
-            case 2:
-                copy_one_input_shard_to_output(
-                    output_accessor, std::get<3>(accessors_tuple), shard_id, page_size, output_page_offset_in_shard);
-                break;
-            case 3:
-                copy_one_input_shard_to_output(
-                    output_accessor, std::get<4>(accessors_tuple), shard_id, page_size, output_page_offset_in_shard);
-                break;
-            case 4:
-                copy_one_input_shard_to_output(
-                    output_accessor, std::get<5>(accessors_tuple), shard_id, page_size, output_page_offset_in_shard);
-                break;
-            case 5:
-                copy_one_input_shard_to_output(
-                    output_accessor, std::get<6>(accessors_tuple), shard_id, page_size, output_page_offset_in_shard);
-                break;
-            case 6:
-                copy_one_input_shard_to_output(
-                    output_accessor, std::get<7>(accessors_tuple), shard_id, page_size, output_page_offset_in_shard);
-                break;
-            case 7:
-                copy_one_input_shard_to_output(
-                    output_accessor, std::get<8>(accessors_tuple), shard_id, page_size, output_page_offset_in_shard);
-                break;
-            case 8:
-                copy_one_input_shard_to_output(
-                    output_accessor, std::get<9>(accessors_tuple), shard_id, page_size, output_page_offset_in_shard);
-                break;
-            case 9:
-                copy_one_input_shard_to_output(
-                    output_accessor, std::get<10>(accessors_tuple), shard_id, page_size, output_page_offset_in_shard);
-                break;
-            case 10:
-                copy_one_input_shard_to_output(
-                    output_accessor, std::get<11>(accessors_tuple), shard_id, page_size, output_page_offset_in_shard);
-                break;
-            case 11:
-                copy_one_input_shard_to_output(
-                    output_accessor, std::get<12>(accessors_tuple), shard_id, page_size, output_page_offset_in_shard);
-                break;
-            case 12:
-                copy_one_input_shard_to_output(
-                    output_accessor, std::get<13>(accessors_tuple), shard_id, page_size, output_page_offset_in_shard);
-                break;
-            case 13:
-                copy_one_input_shard_to_output(
-                    output_accessor, std::get<14>(accessors_tuple), shard_id, page_size, output_page_offset_in_shard);
-                break;
-            case 14:
-                copy_one_input_shard_to_output(
-                    output_accessor, std::get<15>(accessors_tuple), shard_id, page_size, output_page_offset_in_shard);
-                break;
-            case 15:
-                copy_one_input_shard_to_output(
-                    output_accessor, std::get<16>(accessors_tuple), shard_id, page_size, output_page_offset_in_shard);
-                break;
+            case 0: CONCAT_ND_DPRINT_INPUT(0); break;
+            case 1: CONCAT_ND_DPRINT_INPUT(1); break;
+            case 2: CONCAT_ND_DPRINT_INPUT(2); break;
+            case 3: CONCAT_ND_DPRINT_INPUT(3); break;
+            case 4: CONCAT_ND_DPRINT_INPUT(4); break;
+            case 5: CONCAT_ND_DPRINT_INPUT(5); break;
+            case 6: CONCAT_ND_DPRINT_INPUT(6); break;
+            case 7: CONCAT_ND_DPRINT_INPUT(7); break;
+            case 8: CONCAT_ND_DPRINT_INPUT(8); break;
+            case 9: CONCAT_ND_DPRINT_INPUT(9); break;
+            case 10: CONCAT_ND_DPRINT_INPUT(10); break;
+            case 11: CONCAT_ND_DPRINT_INPUT(11); break;
+            case 12: CONCAT_ND_DPRINT_INPUT(12); break;
+            case 13: CONCAT_ND_DPRINT_INPUT(13); break;
+            case 14: CONCAT_ND_DPRINT_INPUT(14); break;
+            case 15: CONCAT_ND_DPRINT_INPUT(15); break;
             default: break;
         }
     }
+#undef CONCAT_ND_DPRINT_INPUT
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_nd_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_nd_sharded.cpp
@@ -2,69 +2,142 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-/**
- * Reader kernel for ND sharded concat.
- *
- * Each core holds a shard of every input and a shard of the output (same grid for all).
- * This kernel reads from a subset of input CBs in concat order and writes into the output CB.
- * The host splits work between reader and writer: reader handles inputs [start_input_id, end_input_id)
- * so that two RISC-V processors can run in parallel (reader on one, writer on the other).
- *
- * Compile-time args: [output_cb_id, page_size, num_input_tensors]
- * Runtime args: [start_input_id, end_input_id, (num_pages, write_offset_pages) for each input in [start, end)]
- *
- * Input CBs 0..num_input_tensors-1 are backed by the input buffers (each core sees its shard).
- * Output data is written to output_cb at byte offset (write_offset_pages * page_size).
+/*
+ * ND sharded concat reader: runs on each core, copies this core's input shards
+ * (in concat order) into this core's output shard. Uses TensorAccessor for each
+ * tensor; reads each input shard page-by-page into a scratch CB and writes to
+ * the output shard sequentially.
  */
 
-#include <stdint.h>
-#include "api/debug/dprint.h"
-#include "ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
-#include "ttnn/kernel/kernel_utils.hpp"
+#include <cstdint>
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/tensor/tensor_accessor.h"
 #include "concat_nd_sharded_args.hpp"
 
+namespace {
+
+constexpr uint32_t CONCAT_ND_SHARDED_MAX_NUM_INPUTS = ttnn::kernel::CONCAT_ND_SHARDED_MAX_NUM_INPUTS;
+constexpr uint32_t NUM_TENSORS = 1u + CONCAT_ND_SHARDED_MAX_NUM_INPUTS;  // output + inputs
+
+// Compile-time: 0 = num_input_tensors, 1..17 = page_size, 18+ = TensorAccessorArgs (output, in0..in15)
+constexpr uint32_t CTA_NUM_INPUTS = 0;
+constexpr uint32_t CTA_PAGE_SIZE_BASE = 1;
+constexpr uint32_t CTA_TENSOR_ACCESSOR_ARGS_START = 18;
+
+// Runtime: 0..16 = buffer addresses (output, in0..in15), 17 = shard_id
+constexpr uint32_t RT_SHARD_ID = 17;
+
+constexpr uint32_t CB_ID_SCRATCH = 0;
+
+template <typename OutputAccessor, typename InputAccessor>
+void copy_one_input_shard_to_output(
+    const OutputAccessor& output_accessor,
+    const InputAccessor& input_accessor,
+    uint32_t shard_id,
+    uint32_t page_size,
+    uint32_t& output_page_offset_in_shard) {
+    auto input_pages = input_accessor.shard_pages(shard_id);
+    for (const auto& page : input_pages) {
+        cb_reserve_back(CB_ID_SCRATCH, 1);
+        uint32_t l1_addr = get_write_ptr(CB_ID_SCRATCH);
+        noc_async_read(page.noc_addr(), l1_addr, page_size);
+        noc_async_read_barrier();
+
+        uint64_t out_noc_addr = output_accessor.get_shard_noc_addr(shard_id, output_page_offset_in_shard * page_size);
+        noc_async_write(l1_addr, out_noc_addr, page_size);
+        noc_async_write_barrier();
+
+        cb_push_back(CB_ID_SCRATCH, 1);
+        ++output_page_offset_in_shard;
+    }
+}
+
+}  // namespace
+
 void kernel_main() {
-    // --- Compile-time: output CB, page size, total number of input tensors ---
-    constexpr uint32_t output_cb = get_compile_time_arg_val(0);
-    constexpr uint32_t page_size = get_compile_time_arg_val(1);
-    constexpr uint32_t num_input_tensors = get_compile_time_arg_val(2);
+    const uint32_t num_input_tensors = get_compile_time_arg_val(CTA_NUM_INPUTS);
+    const uint32_t page_size = get_compile_time_arg_val(CTA_PAGE_SIZE_BASE);
+    const uint32_t shard_id = get_arg_val<uint32_t>(RT_SHARD_ID);
 
-    // --- Runtime: which input range this kernel instance processes ---
-    const uint32_t destination_shard_pos = get_arg_val<uint32_t>(0);
-    const uint32_t in_core_idx = get_arg_val<uint32_t>(1);
-    const uint32_t in_tensor_pos = get_arg_val<uint32_t>(2);
-    const uint32_t shard_pos = get_arg_val<uint32_t>(3);
-    const uint32_t shard_size = get_arg_val<uint32_t>(4);
-    const uint32_t test_value = get_arg_val<uint32_t>(5);
+    constexpr auto tensor_accessor_args_tuple =
+        make_tensor_accessor_args_tuple<NUM_TENSORS, CTA_TENSOR_ACCESSOR_ARGS_START>();
 
-    DPRINT << "destination_shard_pos " << destination_shard_pos << " in_core_idx " << in_core_idx << ENDL();
-    DPRINT << "in_tensor_pos " << in_tensor_pos << " shard_pos " << shard_pos << ENDL();
-    DPRINT << "shard size " << shard_size << "test_value " << test_value << ENDL();
-    DPRINT << "destination page size " << page_size << ENDL();
+    auto accessors_tuple = tensor_accessor::detail::make_tensor_accessor_tuple(
+        tensor_accessor_args_tuple,
+        /*address_rt_arg_index_start=*/0,
+        /*page_size_ct_arg_index_start=*/CTA_PAGE_SIZE_BASE);
 
-    // const uint32_t base_l1_write_addr = get_write_ptr(output_cb);
-    // uint32_t arg_idx = 2;
-    // for (uint32_t input_id = start_input_id; input_id < end_input_id; ++input_id) {
-    //     const uint32_t num_pages = get_arg_val<uint32_t>(arg_idx++);
-    //     const uint32_t write_offset_pages = get_arg_val<uint32_t>(arg_idx++);
+    const auto& output_accessor = std::get<0>(accessors_tuple);
+    uint32_t output_page_offset_in_shard = 0;
 
-    //     if (num_pages == 0) {
-    //         continue;
-    //     }
-
-    //     // Source: this core's shard of input_id (CB is backed by the input buffer).
-    //     uint32_t l1_read_addr = get_read_ptr(input_id);
-    //     const uint64_t noc_addr_src = get_noc_addr(l1_read_addr);
-
-    //     // Destination: output CB at the offset for this input in concat order.
-    //     const uint32_t l1_write_addr = base_l1_write_addr + (write_offset_pages * page_size);
-
-    //     // Copy this input's shard (num_pages pages) into the output region.
-    //     noc_async_read_one_packet_set_state(noc_addr_src, page_size);
-    //     for (uint32_t page = 0; page < num_pages; ++page) {
-    //             noc_async_read_one_packet_with_state<true>(l1_read_addr, l1_write_addr + page * page_size);
-    //         l1_read_addr += page_size;
-    //     }
-    //     noc_async_read_barrier();
-    // }
+    for (uint32_t i = 0; i < num_input_tensors; ++i) {
+        switch (i) {
+            case 0:
+                copy_one_input_shard_to_output(
+                    output_accessor, std::get<1>(accessors_tuple), shard_id, page_size, output_page_offset_in_shard);
+                break;
+            case 1:
+                copy_one_input_shard_to_output(
+                    output_accessor, std::get<2>(accessors_tuple), shard_id, page_size, output_page_offset_in_shard);
+                break;
+            case 2:
+                copy_one_input_shard_to_output(
+                    output_accessor, std::get<3>(accessors_tuple), shard_id, page_size, output_page_offset_in_shard);
+                break;
+            case 3:
+                copy_one_input_shard_to_output(
+                    output_accessor, std::get<4>(accessors_tuple), shard_id, page_size, output_page_offset_in_shard);
+                break;
+            case 4:
+                copy_one_input_shard_to_output(
+                    output_accessor, std::get<5>(accessors_tuple), shard_id, page_size, output_page_offset_in_shard);
+                break;
+            case 5:
+                copy_one_input_shard_to_output(
+                    output_accessor, std::get<6>(accessors_tuple), shard_id, page_size, output_page_offset_in_shard);
+                break;
+            case 6:
+                copy_one_input_shard_to_output(
+                    output_accessor, std::get<7>(accessors_tuple), shard_id, page_size, output_page_offset_in_shard);
+                break;
+            case 7:
+                copy_one_input_shard_to_output(
+                    output_accessor, std::get<8>(accessors_tuple), shard_id, page_size, output_page_offset_in_shard);
+                break;
+            case 8:
+                copy_one_input_shard_to_output(
+                    output_accessor, std::get<9>(accessors_tuple), shard_id, page_size, output_page_offset_in_shard);
+                break;
+            case 9:
+                copy_one_input_shard_to_output(
+                    output_accessor, std::get<10>(accessors_tuple), shard_id, page_size, output_page_offset_in_shard);
+                break;
+            case 10:
+                copy_one_input_shard_to_output(
+                    output_accessor, std::get<11>(accessors_tuple), shard_id, page_size, output_page_offset_in_shard);
+                break;
+            case 11:
+                copy_one_input_shard_to_output(
+                    output_accessor, std::get<12>(accessors_tuple), shard_id, page_size, output_page_offset_in_shard);
+                break;
+            case 12:
+                copy_one_input_shard_to_output(
+                    output_accessor, std::get<13>(accessors_tuple), shard_id, page_size, output_page_offset_in_shard);
+                break;
+            case 13:
+                copy_one_input_shard_to_output(
+                    output_accessor, std::get<14>(accessors_tuple), shard_id, page_size, output_page_offset_in_shard);
+                break;
+            case 14:
+                copy_one_input_shard_to_output(
+                    output_accessor, std::get<15>(accessors_tuple), shard_id, page_size, output_page_offset_in_shard);
+                break;
+            case 15:
+                copy_one_input_shard_to_output(
+                    output_accessor, std::get<16>(accessors_tuple), shard_id, page_size, output_page_offset_in_shard);
+                break;
+            default: break;
+        }
+    }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_nd_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_nd_sharded.cpp
@@ -91,16 +91,23 @@ void kernel_main() {
 
     const auto output_accessor = TensorAccessor(out_args, output_addr, output_page_size);
 
+    DPRINT << "output: shards=" << output_accessor.dspec().num_banks()
+           << " pages=" << output_accessor.dspec().tensor_volume() << " page_size=" << output_page_size
+           << " tile_size=" << output_page_size << ENDL();
+
     // Copy each input to output sequentially; initial offset 0, then use offset returned from previous copy.
-#define CONCAT_ND_DPRINT_INPUT(n)                                                                      \
-    do {                                                                                               \
-        const uint32_t initial_offset_##n = offset;                                                    \
-        constexpr uint32_t in_page_size_##n = get_compile_time_arg_val(CT_INPUT_PAGE_SIZE_BASE + (n)); \
-        const auto in##n##_accessor = TensorAccessor(in##n##_args, input_addrs[n], in_page_size_##n);  \
-        offset = copy_tensor_data(output_accessor, in##n##_accessor, offset);                          \
-        const uint32_t bytes_copied_##n = offset - initial_offset_##n;                                 \
-        DPRINT << "input " << (n) << ": copied " << bytes_copied_##n << " bytes to initial offset "    \
-               << initial_offset_##n << " (input tensor " << (n) << ")" << ENDL();                     \
+#define CONCAT_ND_DPRINT_INPUT(n)                                                                            \
+    do {                                                                                                     \
+        const uint32_t initial_offset_##n = offset;                                                          \
+        constexpr uint32_t in_page_size_##n = get_compile_time_arg_val(CT_INPUT_PAGE_SIZE_BASE + (n));       \
+        const auto in##n##_accessor = TensorAccessor(in##n##_args, input_addrs[n], in_page_size_##n);        \
+        DPRINT << "input " << (n) << " source: shards=" << in##n##_accessor.dspec().num_banks()              \
+               << " pages=" << in##n##_accessor.dspec().tensor_volume() << " page_size=" << in_page_size_##n \
+               << " tile_size=" << in_page_size_##n << ENDL();                                               \
+        offset = copy_tensor_data(output_accessor, in##n##_accessor, offset);                                \
+        const uint32_t bytes_copied_##n = offset - initial_offset_##n;                                       \
+        DPRINT << "input " << (n) << ": copied " << bytes_copied_##n << " bytes to initial offset "          \
+               << initial_offset_##n << " (input tensor " << (n) << ")" << ENDL();                           \
     } while (0)
 
     uint32_t offset = 0;

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_nd_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_nd_sharded.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <stdint.h>
+#include "api/debug/dprint.h"
 
 void kernel_main() {
     // --- Compile-time: output CB, page size, total number of input tensors ---
@@ -26,33 +27,40 @@ void kernel_main() {
     constexpr uint32_t num_input_tensors = get_compile_time_arg_val(2);
 
     // --- Runtime: which input range this kernel instance processes ---
-    const uint32_t start_input_id = get_arg_val<uint32_t>(0);
-    const uint32_t end_input_id = get_arg_val<uint32_t>(1);
+    const uint32_t destination_shard_pos = get_arg_val<uint32_t>(0);
+    const uint32_t in_core_idx = get_arg_val<uint32_t>(1);
+    const uint32_t in_tensor_pos = get_arg_val<uint32_t>(2);
+    const uint32_t shard_pos = get_arg_val<uint32_t>(3);
+    const uint32_t shard_size = get_arg_val<uint32_t>(4);
+    const uint32_t test_value = get_arg_val<uint32_t>(5);
 
-    const uint32_t base_l1_write_addr = get_write_ptr(output_cb);
-    uint32_t arg_idx = 2;
+    DPRINT << "destination_shard_pos " << destination_shard_pos << " in_core_idx " << in_core_idx << ENDL();
+    DPRINT << "in_tensor_pos " << in_tensor_pos << " shard_pos " << shard_pos << ENDL();
+    DPRINT << "shard size " << shard_size << "test_value " << test_value << ENDL();
 
-    for (uint32_t input_id = start_input_id; input_id < end_input_id; ++input_id) {
-        const uint32_t num_pages = get_arg_val<uint32_t>(arg_idx++);
-        const uint32_t write_offset_pages = get_arg_val<uint32_t>(arg_idx++);
+    // const uint32_t base_l1_write_addr = get_write_ptr(output_cb);
+    // uint32_t arg_idx = 2;
+    // for (uint32_t input_id = start_input_id; input_id < end_input_id; ++input_id) {
+    //     const uint32_t num_pages = get_arg_val<uint32_t>(arg_idx++);
+    //     const uint32_t write_offset_pages = get_arg_val<uint32_t>(arg_idx++);
 
-        if (num_pages == 0) {
-            continue;
-        }
+    //     if (num_pages == 0) {
+    //         continue;
+    //     }
 
-        // Source: this core's shard of input_id (CB is backed by the input buffer).
-        uint32_t l1_read_addr = get_read_ptr(input_id);
-        const uint64_t noc_addr_src = get_noc_addr(l1_read_addr);
+    //     // Source: this core's shard of input_id (CB is backed by the input buffer).
+    //     uint32_t l1_read_addr = get_read_ptr(input_id);
+    //     const uint64_t noc_addr_src = get_noc_addr(l1_read_addr);
 
-        // Destination: output CB at the offset for this input in concat order.
-        const uint32_t l1_write_addr = base_l1_write_addr + (write_offset_pages * page_size);
+    //     // Destination: output CB at the offset for this input in concat order.
+    //     const uint32_t l1_write_addr = base_l1_write_addr + (write_offset_pages * page_size);
 
-        // Copy this input's shard (num_pages pages) into the output region.
-        noc_async_read_one_packet_set_state(noc_addr_src, page_size);
-        for (uint32_t page = 0; page < num_pages; ++page) {
-            noc_async_read_one_packet_with_state<true>(l1_read_addr, l1_write_addr + page * page_size);
-            l1_read_addr += page_size;
-        }
-        noc_async_read_barrier();
-    }
+    //     // Copy this input's shard (num_pages pages) into the output region.
+    //     noc_async_read_one_packet_set_state(noc_addr_src, page_size);
+    //     for (uint32_t page = 0; page < num_pages; ++page) {
+    //         noc_async_read_one_packet_with_state<true>(l1_read_addr, l1_write_addr + page * page_size);
+    //         l1_read_addr += page_size;
+    //     }
+    //     noc_async_read_barrier();
+    // }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_nd_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_nd_sharded.cpp
@@ -94,6 +94,16 @@ void kernel_main() {
     DPRINT << "output: shards=" << output_accessor.dspec().num_banks()
            << " pages=" << output_accessor.dspec().tensor_volume() << " page_size=" << output_page_size
            << " tile_size=" << output_page_size << ENDL();
+    {
+        const uint32_t out_rank = output_accessor.dspec().rank();
+        DPRINT << "output dimensions: rank=" << out_rank;
+        for (uint32_t d = 0; d < out_rank; ++d) {
+            DPRINT << " dim" << d << "_ts=" << output_accessor.dspec().tensor_shape()[d]
+                   << "_ss=" << output_accessor.dspec().shard_shape()[d]
+                   << "_sg=" << output_accessor.dspec().shard_grid()[d];
+        }
+        DPRINT << ENDL();
+    }
 
     // Copy each input to output sequentially; initial offset 0, then use offset returned from previous copy.
 #define CONCAT_ND_DPRINT_INPUT(n)                                                                            \
@@ -104,6 +114,16 @@ void kernel_main() {
         DPRINT << "input " << (n) << " source: shards=" << in##n##_accessor.dspec().num_banks()              \
                << " pages=" << in##n##_accessor.dspec().tensor_volume() << " page_size=" << in_page_size_##n \
                << " tile_size=" << in_page_size_##n << ENDL();                                               \
+        {                                                                                                    \
+            const uint32_t in_rank_##n = in##n##_accessor.dspec().rank();                                    \
+            DPRINT << "input " << (n) << " dimensions: rank=" << in_rank_##n;                                \
+            for (uint32_t d = 0; d < in_rank_##n; ++d) {                                                     \
+                DPRINT << " dim" << d << "_ts=" << in##n##_accessor.dspec().tensor_shape()[d]                \
+                       << "_ss=" << in##n##_accessor.dspec().shard_shape()[d]                                \
+                       << "_sg=" << in##n##_accessor.dspec().shard_grid()[d];                                \
+            }                                                                                                \
+            DPRINT << ENDL();                                                                                \
+        }                                                                                                    \
         offset = copy_tensor_data(output_accessor, in##n##_accessor, offset);                                \
         const uint32_t bytes_copied_##n = offset - initial_offset_##n;                                       \
         DPRINT << "input " << (n) << ": copied " << bytes_copied_##n << " bytes to initial offset "          \

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/writer_concat_nd_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/writer_concat_nd_sharded.cpp
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Writer kernel for ND sharded concat.
+ *
+ * Same algorithm as reader_concat_nd_sharded: reads from a subset of input CBs in concat order
+ * and writes into the output CB. The host assigns the reader to inputs [0, mid) and the writer
+ * to inputs [mid, num_input_tensors), so both RISC-V processors run in parallel and the
+ * output CB (backed by the output buffer) is filled with the concatenated shard.
+ *
+ * Compile-time args: [output_cb_id, page_size, num_input_tensors]
+ * Runtime args: [start_input_id, end_input_id, (num_pages, write_offset_pages) for each input in [start, end)]
+ *
+ * No separate "read from CB and write to buffer" step: the output CB is the output buffer
+ * (set_globally_allocated_address), so writing to the CB is writing to the final output.
+ */
+
+#include <stdint.h>
+
+void kernel_main() {
+    constexpr uint32_t output_cb = get_compile_time_arg_val(0);
+    constexpr uint32_t page_size = get_compile_time_arg_val(1);
+    constexpr uint32_t num_input_tensors = get_compile_time_arg_val(2);
+
+    const uint32_t start_input_id = get_arg_val<uint32_t>(0);
+    const uint32_t end_input_id = get_arg_val<uint32_t>(1);
+
+    const uint32_t base_l1_write_addr = get_write_ptr(output_cb);
+    uint32_t arg_idx = 2;
+
+    for (uint32_t input_id = start_input_id; input_id < end_input_id; input_id++) {
+        const uint32_t num_pages = get_arg_val<uint32_t>(arg_idx++);
+        const uint32_t write_offset_pages = get_arg_val<uint32_t>(arg_idx++);
+
+        if (num_pages == 0) {
+            continue;
+        }
+
+        uint32_t l1_read_addr = get_read_ptr(input_id);
+        const uint64_t noc_addr_src = get_noc_addr(l1_read_addr);
+
+        const uint32_t l1_write_addr = base_l1_write_addr + (write_offset_pages * page_size);
+
+        noc_async_read_one_packet_set_state(noc_addr_src, page_size);
+        for (uint32_t page = 0; page < num_pages; page++) {
+            noc_async_read_one_packet_with_state<true>(l1_read_addr, l1_write_addr + page * page_size);
+            l1_read_addr += page_size;
+        }
+        noc_async_read_barrier();
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/writer_concat_nd_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/writer_concat_nd_sharded.cpp
@@ -30,7 +30,7 @@ void kernel_main() {
     const uint32_t base_l1_write_addr = get_write_ptr(output_cb);
     uint32_t arg_idx = 2;
 
-    for (uint32_t input_id = start_input_id; input_id < end_input_id; input_id++) {
+    for (uint32_t input_id = start_input_id; input_id < end_input_id; ++input_id) {
         const uint32_t num_pages = get_arg_val<uint32_t>(arg_idx++);
         const uint32_t write_offset_pages = get_arg_val<uint32_t>(arg_idx++);
 
@@ -44,7 +44,7 @@ void kernel_main() {
         const uint32_t l1_write_addr = base_l1_write_addr + (write_offset_pages * page_size);
 
         noc_async_read_one_packet_set_state(noc_addr_src, page_size);
-        for (uint32_t page = 0; page < num_pages; page++) {
+        for (uint32_t page = 0; page < num_pages; ++page) {
             noc_async_read_one_packet_with_state<true>(l1_read_addr, l1_write_addr + page * page_size);
             l1_read_addr += page_size;
         }

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/writer_concat_nd_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/writer_concat_nd_sharded.cpp
@@ -27,27 +27,5 @@ void kernel_main() {
     const uint32_t start_input_id = get_arg_val<uint32_t>(0);
     const uint32_t end_input_id = get_arg_val<uint32_t>(1);
 
-    const uint32_t base_l1_write_addr = get_write_ptr(output_cb);
-    uint32_t arg_idx = 2;
-
-    for (uint32_t input_id = start_input_id; input_id < end_input_id; ++input_id) {
-        const uint32_t num_pages = get_arg_val<uint32_t>(arg_idx++);
-        const uint32_t write_offset_pages = get_arg_val<uint32_t>(arg_idx++);
-
-        if (num_pages == 0) {
-            continue;
-        }
-
-        uint32_t l1_read_addr = get_read_ptr(input_id);
-        const uint64_t noc_addr_src = get_noc_addr(l1_read_addr);
-
-        const uint32_t l1_write_addr = base_l1_write_addr + (write_offset_pages * page_size);
-
-        noc_async_read_one_packet_set_state(noc_addr_src, page_size);
-        for (uint32_t page = 0; page < num_pages; ++page) {
-            noc_async_read_one_packet_with_state<true>(l1_read_addr, l1_write_addr + page * page_size);
-            l1_read_addr += page_size;
-        }
-        noc_async_read_barrier();
-    }
+    // TODO - TO implement
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/writer_concat_nd_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/writer_concat_nd_sharded.cpp
@@ -1,31 +1,8 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
-
-/**
- * Writer kernel for ND sharded concat.
- *
- * Same algorithm as reader_concat_nd_sharded: reads from a subset of input CBs in concat order
- * and writes into the output CB. The host assigns the reader to inputs [0, mid) and the writer
- * to inputs [mid, num_input_tensors), so both RISC-V processors run in parallel and the
- * output CB (backed by the output buffer) is filled with the concatenated shard.
- *
- * Compile-time args: [output_cb_id, page_size, num_input_tensors]
- * Runtime args: [start_input_id, end_input_id, (num_pages, write_offset_pages) for each input in [start, end)]
- *
- * No separate "read from CB and write to buffer" step: the output CB is the output buffer
- * (set_globally_allocated_address), so writing to the CB is writing to the final output.
- */
-
 #include <stdint.h>
 
 void kernel_main() {
-    constexpr uint32_t output_cb = get_compile_time_arg_val(0);
-    constexpr uint32_t page_size = get_compile_time_arg_val(1);
-    constexpr uint32_t num_input_tensors = get_compile_time_arg_val(2);
-
-    const uint32_t start_input_id = get_arg_val<uint32_t>(0);
-    const uint32_t end_input_id = get_arg_val<uint32_t>(1);
-
-    // TODO - TO implement
+    // To implement
 }


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:{{branch_name}})
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
