### PR TITLE
Add lightweight mask with partial tile support for ring joint SDPA

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -1312,6 +1312,79 @@ void matmul_reduce(uint32_t in1_cb, const uint32_t& out_cb) {
     }
 }
 
+/**
+ * Lightweight padded-K mask: L1-accumulate a single permanently-fronted -inf tile onto padded
+ * tile positions in out_cb. Runtime version for ring joint SDPA where num_padded varies per chunk.
+ *
+ * @param neginf_cb  CB holding a single permanently-fronted -inf tile
+ * @param out_cb     QK intermediate CB (Sq_chunk_t * Sk_chunk_t tiles, already wait-fronted)
+ * @param num_padded Number of fully padded K tile columns per row
+ * @param num_cols   Total K tiles per row (Sk_chunk_t)
+ * @param num_rows   Q tiles per chunk (Sq_chunk_t)
+ */
+void apply_padded_mask_lightweight_runtime(
+    uint32_t neginf_cb, uint32_t out_cb, uint32_t num_padded, uint32_t num_cols, uint32_t num_rows) {
+    uint32_t start = num_cols - num_padded;
+
+    copy_tile_to_dst_init_short(neginf_cb);
+    cb_wait_front(neginf_cb, 1);
+    PACK((llk_pack_reconfig_l1_acc(1)));
+
+    constexpr uint32_t DST_BATCH = 8;
+    for (uint32_t row = 0; row < num_rows; row++) {
+        uint32_t row_offset = row * num_cols;
+        for (uint32_t base = start; base < num_cols; base += DST_BATCH) {
+            uint32_t batch = (num_cols - base < DST_BATCH) ? (num_cols - base) : DST_BATCH;
+            tile_regs_acquire();
+            for (uint32_t i = 0; i < batch; i++) {
+                copy_tile(neginf_cb, 0, i);  // Always tile 0 — single -inf tile
+            }
+            tile_regs_commit();
+            tile_regs_wait();
+            for (uint32_t i = 0; i < batch; i++) {
+                pack_tile<true>(i, out_cb, row_offset + base + i);
+            }
+            tile_regs_release();
+        }
+    }
+
+    PACK((llk_pack_reconfig_l1_acc(0)));
+}
+
+/**
+ * Lightweight partial mask: L1-accumulate a partial mask tile (0 for valid, -inf for padded columns)
+ * onto the boundary tile position in out_cb. The partial tile is permanently fronted in partial_cb.
+ *
+ * @param partial_cb       CB holding partial mask tile(s), permanently fronted
+ * @param partial_tile_idx Index of the partial tile within partial_cb (0 or 1)
+ * @param out_cb           QK intermediate CB (already wait-fronted)
+ * @param boundary_col     Column index within the chunk where the boundary tile is
+ * @param num_cols         Total K tiles per row (Sk_chunk_t)
+ * @param num_rows         Q tiles per chunk (Sq_chunk_t)
+ */
+void apply_partial_mask_lightweight(
+    uint32_t partial_cb,
+    uint32_t partial_tile_idx,
+    uint32_t out_cb,
+    uint32_t boundary_col,
+    uint32_t num_cols,
+    uint32_t num_rows) {
+    copy_tile_to_dst_init_short(partial_cb);
+    cb_wait_front(partial_cb, partial_tile_idx + 1);
+    PACK((llk_pack_reconfig_l1_acc(1)));
+
+    for (uint32_t row = 0; row < num_rows; row++) {
+        tile_regs_acquire();
+        copy_tile(partial_cb, partial_tile_idx, 0);
+        tile_regs_commit();
+        tile_regs_wait();
+        pack_tile<true>(0, out_cb, row * num_cols + boundary_col);
+        tile_regs_release();
+    }
+
+    PACK((llk_pack_reconfig_l1_acc(0)));
+}
+
 enum SDPAType {
     STANDARD = 0,
     JOINT = 1,
@@ -1469,7 +1542,16 @@ void sdpa_inner_loop(
     const uint32_t cb_lse_in,
     const uint32_t cb_lse_out,
     const uint32_t cb_prev_out,
-    const uint32_t cb_out) {
+    const uint32_t cb_out,
+    const bool use_lightweight_mask = false,
+    const uint32_t global_n_padded_tiles = 0,
+    const uint32_t local_n_padded_tiles = 0,
+    const uint32_t joint_n_padded_tiles = 0,
+    const uint32_t cb_partial_mask = 0,
+    const uint32_t global_n_partial_col = 0,
+    const uint32_t joint_l_partial_col = 0,
+    const uint32_t global_n_partial_tile_idx = 0,
+    const uint32_t joint_l_partial_tile_idx = 0) {
     uint32_t KV_chunks_processed_in_iter = 0;
 
     for (uint32_t q_iter = iter_q_start; q_iter < iter_q_end; ++q_iter) {
@@ -1587,7 +1669,41 @@ void sdpa_inner_loop(
             if (apply_mask) {
                 /* QK += MASK */
                 reconfig_data_format(cb_qk_im, cb_mask_in);
-                add_block_inplace(cb_qk_im, cb_mask_in, qk_chunk_tiles);
+                if (use_lightweight_mask) {
+                    // Lightweight: L1-accumulate mask tiles onto padded positions
+                    uint32_t num_padded = 0;
+                    bool has_partial = false;
+                    uint32_t boundary_col = 0;
+                    uint32_t partial_tile_idx = 0;
+
+                    if (ring_iter_needs_global_n_mask && k_chunk == global_n_mask_chunk_id) {
+                        num_padded = global_n_padded_tiles;
+                        has_partial = (global_n_partial_col > 0);
+                        boundary_col = Sk_chunk_t - num_padded - (has_partial ? 1 : 0);
+                        partial_tile_idx = global_n_partial_tile_idx;
+                    } else if (local_n_needs_masking && k_chunk == local_n_mask_chunk_id) {
+                        num_padded = local_n_padded_tiles;
+                        // local_n is always tile-aligned, no partial needed
+                    } else if (
+                        ring_iter_needs_joint_n_mask && (k_chunk - num_local_k_chunks) == joint_n_mask_chunk_id) {
+                        num_padded = joint_n_padded_tiles;
+                        has_partial = (joint_l_partial_col > 0);
+                        boundary_col = Sk_chunk_t - num_padded - (has_partial ? 1 : 0);
+                        partial_tile_idx = joint_l_partial_tile_idx;
+                    }
+
+                    if (has_partial) {
+                        reconfig_data_format(cb_qk_im, cb_partial_mask);
+                        apply_partial_mask_lightweight(
+                            cb_partial_mask, partial_tile_idx, cb_qk_im, boundary_col, Sk_chunk_t, Sq_chunk_t);
+                    }
+                    if (num_padded > 0) {
+                        reconfig_data_format(cb_qk_im, cb_mask_in);
+                        apply_padded_mask_lightweight_runtime(cb_mask_in, cb_qk_im, num_padded, Sk_chunk_t, Sq_chunk_t);
+                    }
+                } else {
+                    add_block_inplace(cb_qk_im, cb_mask_in, qk_chunk_tiles);
+                }
             }
 
             /**
@@ -2121,7 +2237,15 @@ void sdpa_ring(
     const uint32_t cb_lse_in,
     const uint32_t cb_lse_out,
     const uint32_t cb_prev_out,
-    const uint32_t cb_out) {
+    const uint32_t cb_out,
+    const uint32_t global_n_padded_tiles,
+    const uint32_t local_n_padded_tiles,
+    const uint32_t joint_n_padded_tiles,
+    const uint32_t cb_partial_mask,
+    const uint32_t global_n_partial_col,
+    const uint32_t joint_l_partial_col,
+    const uint32_t global_n_partial_tile_idx,
+    const uint32_t joint_l_partial_tile_idx) {
     sdpa_inner_loop<
         RING,
         cb_qk_im,
@@ -2192,7 +2316,16 @@ void sdpa_ring(
         cb_lse_in,
         cb_lse_out,
         cb_prev_out,
-        cb_out);
+        cb_out,
+        true,  // use_lightweight_mask — always on for ring SDPA
+        global_n_padded_tiles,
+        local_n_padded_tiles,
+        joint_n_padded_tiles,
+        cb_partial_mask,
+        global_n_partial_col,
+        joint_l_partial_col,
+        global_n_partial_tile_idx,
+        joint_l_partial_tile_idx);
 }
 
 /**

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
@@ -46,6 +46,13 @@ void kernel_main() {
     constexpr uint32_t out_num_blocks = get_compile_time_arg_val(29);
 
     constexpr uint32_t scale_fp32 = get_compile_time_arg_val(30);
+    constexpr uint32_t global_n_partial_col = get_compile_time_arg_val(31);
+    constexpr uint32_t joint_l_partial_col = get_compile_time_arg_val(32);
+
+    constexpr uint32_t cb_partial_mask = tt::CBIndex::c_9;
+    constexpr uint32_t global_n_partial_tile_idx = 0;
+    constexpr uint32_t joint_l_partial_tile_idx = (global_n_partial_col > 0) ? 1 : 0;
+
     uint32_t argidx = 0;
     const uint32_t global_q_start = get_arg_val<uint32_t>(argidx++);
     const uint32_t global_q_end = get_arg_val<uint32_t>(argidx++);
@@ -113,6 +120,18 @@ void kernel_main() {
         const bool ring_iter_needs_joint_n_mask = joint_n_needs_masking && do_joint_kv;
         const uint32_t joint_n_mask_chunk_id = L / (Sk_chunk_t * tt::constants::TILE_HEIGHT);
 
+        // Compute padded tile counts for lightweight mask
+        constexpr uint32_t local_n_padded_tiles =
+            (local_padded_Nt % Sk_chunk_t != 0) ? (Sk_chunk_t - (local_padded_Nt % Sk_chunk_t)) : 0;
+        constexpr uint32_t joint_n_padded_tiles = (Lt % Sk_chunk_t != 0) ? (Sk_chunk_t - (Lt % Sk_chunk_t)) : 0;
+        uint32_t global_n_padded_tiles = 0;
+        if (ring_iter_needs_global_n_mask) {
+            const uint32_t unpadded_in_chunk = global_n_within_ring_iter % (Sk_chunk_t * tt::constants::TILE_HEIGHT);
+            const uint32_t valid_tiles =
+                (unpadded_in_chunk + tt::constants::TILE_HEIGHT - 1) / tt::constants::TILE_HEIGHT;
+            global_n_padded_tiles = Sk_chunk_t - valid_tiles;
+        }
+
         sdpa_ring<cb_qk_im, cb_identity_scale_in, cb_scale_in, Sq_chunk_t, Sk_chunk_t, DHt, scale_fp32>(
             qk_in0_block_w,
             qk_subblock_w,
@@ -160,6 +179,14 @@ void kernel_main() {
             cb_lse_in,
             cb_lse_out,
             cb_prev_out,
-            cb_out);
+            cb_out,
+            global_n_padded_tiles,
+            local_n_padded_tiles,
+            joint_n_padded_tiles,
+            cb_partial_mask,
+            global_n_partial_col,
+            joint_l_partial_col,
+            global_n_partial_tile_idx,
+            joint_l_partial_tile_idx);
     }
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
@@ -286,6 +286,75 @@ void fill_neginf_tile(uint32_t cb_id, uint32_t tile_id) {
     }
 }
 
+/**
+ * Fill a bf16 tile with a vertical partial mask: columns [0, unpad_col) = 0, columns [unpad_col, 32) = -inf.
+ * Used for lightweight mask when padding boundary falls inside a tile.
+ *
+ * bf16 tile layout: 4 faces of 16x16, each face row-major with 8 uint32 words per row (2 bf16 per uint32).
+ * Face 0: rows[0:16], cols[0:16]
+ * Face 1: rows[0:16], cols[16:32]
+ * Face 2: rows[16:32], cols[0:16]
+ * Face 3: rows[16:32], cols[16:32]
+ *
+ * Within each uint32 word: low 16 bits = even column, high 16 bits = odd column.
+ */
+template <uint32_t tile_bytes>
+void fill_vertical_tile_bf16(uint32_t cb_id, uint32_t tile_id, uint32_t unpad_col_in_tile) {
+    // Start with all zeros (valid)
+    fill_tile_zeros<tile_bytes>(cb_id, tile_id);
+
+    constexpr uint32_t NEGINF_PAIR = 0xFF80FF80;
+    constexpr uint32_t bf16_per_uint32 = 2;
+    constexpr uint32_t uint32_per_face_row = tt::constants::FACE_WIDTH / bf16_per_uint32;  // 8
+    constexpr uint32_t uint32_per_face = tt::constants::FACE_HW / bf16_per_uint32;         // 128
+
+    volatile tt_l1_ptr uint32_t* ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id) + tile_id * tile_bytes);
+
+    // Face offsets in uint32 words
+    constexpr uint32_t face_offsets[4] = {
+        0,                    // Face 0: rows[0:16], cols[0:16]
+        uint32_per_face,      // Face 1: rows[0:16], cols[16:32]
+        2 * uint32_per_face,  // Face 2: rows[16:32], cols[0:16]
+        3 * uint32_per_face   // Face 3: rows[16:32], cols[16:32]
+    };
+    constexpr uint32_t face_col_starts[4] = {0, 16, 0, 16};
+
+    for (uint32_t f = 0; f < 4; f++) {
+        uint32_t face_col_start = face_col_starts[f];
+
+        if (unpad_col_in_tile <= face_col_start) {
+            // Entire face is padded -> fill with -inf
+            for (uint32_t i = 0; i < uint32_per_face; i++) {
+                ptr[face_offsets[f] + i] = NEGINF_PAIR;
+            }
+        } else if (unpad_col_in_tile >= face_col_start + tt::constants::FACE_WIDTH) {
+            // Entire face is valid -> already zeros, skip
+        } else {
+            // Partial face: boundary falls within this face
+            uint32_t local_col = unpad_col_in_tile - face_col_start;  // 0-15
+            uint32_t boundary_word = local_col / bf16_per_uint32;     // which uint32
+            uint32_t boundary_pos = local_col % bf16_per_uint32;      // position within uint32
+
+            for (uint32_t row = 0; row < tt::constants::FACE_HEIGHT; row++) {
+                uint32_t row_base = face_offsets[f] + row * uint32_per_face_row;
+
+                // Handle boundary word (may have one valid + one -inf bf16)
+                if (boundary_pos != 0) {
+                    // Low 16 bits = even col (valid, 0), high 16 bits = odd col (-inf, 0xFF80)
+                    ptr[row_base + boundary_word] = 0xFF800000;
+                }
+
+                // Fill remaining words with -inf
+                uint32_t start_word = boundary_word + (boundary_pos != 0 ? 1 : 0);
+                for (uint32_t w = start_word; w < uint32_per_face_row; w++) {
+                    ptr[row_base + w] = NEGINF_PAIR;
+                }
+            }
+        }
+    }
+}
+
 template <uint32_t tile_bytes>
 inline void fill_custom_diagonal_tile_bfp4(
     uint32_t cb_id, uint32_t tile_id, int32_t leading_diagonal_offset, int32_t trailing_diagonal_offset) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
@@ -87,8 +87,10 @@ void kernel_main() {
     constexpr uint32_t identity_scalar_packed = get_compile_time_arg_val(17);
     constexpr uint32_t scale_val = get_compile_time_arg_val(18);
     constexpr uint32_t ring_size = get_compile_time_arg_val(19);
+    constexpr uint32_t global_n_partial_col = get_compile_time_arg_val(20);
+    constexpr uint32_t joint_l_partial_col = get_compile_time_arg_val(21);
 
-    constexpr auto out_args = TensorAccessorArgs<20>();
+    constexpr auto out_args = TensorAccessorArgs<22>();
     constexpr auto joint_out_args = TensorAccessorArgs<out_args.next_compile_time_args_offset()>();
     constexpr auto lse_args = TensorAccessorArgs<joint_out_args.next_compile_time_args_offset()>();
 
@@ -130,6 +132,39 @@ void kernel_main() {
     generate_bcast_unary_scalar(cb_scale_in, scale_val);
     generate_bcast_col_scalar(cb_col_identity, identity_scalar_packed);
     generate_reduce_scaler(cb_identity_scale_in, identity_scalar_packed);
+
+    // Lightweight mask: generate a single -inf tile once, leave permanently fronted.
+    // Only needed if padding actually exists (logical_n doesn't fill all local K tiles, or L has a partial chunk).
+    constexpr bool local_n_has_padding = local_padded_Nt % Sk_chunk_t != 0;
+    constexpr bool global_n_has_padding = logical_n % (Sk_chunk_t * tt::constants::TILE_HEIGHT) != 0;
+    constexpr bool joint_has_padding = L > 0 && L % (Sk_chunk_t * tt::constants::TILE_HEIGHT) != 0;
+    constexpr bool needs_neginf_tile = local_n_has_padding || global_n_has_padding || joint_has_padding;
+
+    if constexpr (needs_neginf_tile) {
+        constexpr uint32_t mask_tile_size_bytes = get_tile_size(cb_mask_in);
+        cb_reserve_back(cb_mask_in, 1);
+        auto* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_mask_in));
+        for (uint32_t i = 0; i < mask_tile_size_bytes / sizeof(uint32_t); i++) {
+            ptr[i] = 0xFF80FF80;  // -inf in bfloat16
+        }
+        cb_push_back(cb_mask_in, 1);
+    }
+
+    // Generate partial mask tiles for boundary tiles where padding falls inside a tile.
+    constexpr uint32_t partial_mask_tiles = (global_n_partial_col > 0 ? 1 : 0) + (joint_l_partial_col > 0 ? 1 : 0);
+    if constexpr (partial_mask_tiles > 0) {
+        constexpr uint32_t cb_partial_mask = tt::CBIndex::c_9;
+        constexpr uint32_t partial_tile_bytes = get_tile_size(cb_partial_mask);
+        uint32_t tile_idx = 0;
+        cb_reserve_back(cb_partial_mask, partial_mask_tiles);
+        if constexpr (global_n_partial_col > 0) {
+            fill_vertical_tile_bf16<partial_tile_bytes>(cb_partial_mask, tile_idx++, global_n_partial_col);
+        }
+        if constexpr (joint_l_partial_col > 0) {
+            fill_vertical_tile_bf16<partial_tile_bytes>(cb_partial_mask, tile_idx++, joint_l_partial_col);
+        }
+        cb_push_back(cb_partial_mask, partial_mask_tiles);
+    }
 
     for (uint32_t ring_iter = 0; ring_iter < ring_size; ++ring_iter) {
         uint32_t ring_id = fused_op_receiver.get_next_ring_id_and_sync();
@@ -185,16 +220,6 @@ void kernel_main() {
             const uint32_t nb = global_q_chunk / (NH * num_q_chunks);
             const uint32_t nq = (global_q_chunk % (NH * num_q_chunks)) / num_q_chunks;
             const uint32_t q_chunk = global_q_chunk % num_q_chunks;
-
-            generate_mask<false, false, 0, true, cb_mask_in>(
-                Sq_chunk_t,
-                Sk_chunk_t,
-                q_chunk,
-                0,
-                ring_iter_needs_global_n_mask || ring_iter_needs_local_n_mask,
-                ring_iter_needs_joint_n_mask,
-                ring_iter_needs_global_n_mask ? global_n_within_ring_iter : local_padded_N,
-                L);
 
             const bool is_joint_q = q_chunk >= num_local_q_chunks;
             Slice out_slice;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -169,6 +169,12 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     const uint32_t DHt = DH / tt::constants::TILE_WIDTH;
     const uint32_t logical_nt = tt::div_up(static_cast<uint32_t>(args.logical_n), tt::constants::TILE_HEIGHT);
 
+    // Partial mask tile support: when padding boundary falls inside a tile, we need a partial
+    // mask tile with 0 for valid columns and -inf for padded columns.
+    const uint32_t global_n_partial_col = args.logical_n % tt::constants::TILE_HEIGHT;
+    const uint32_t joint_l_partial_col = L % tt::constants::TILE_HEIGHT;
+    const uint32_t partial_mask_tiles = (global_n_partial_col != 0 ? 1 : 0) + (joint_l_partial_col != 0 ? 1 : 0);
+
     /*
     For non-causal case we must provide a padded mask if the K sequence length has been padded
     Note that we dont have this issue in non-causal case if Q is padded, since those pad tokens
@@ -257,7 +263,6 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     uint32_t q_tiles = Sq_chunk_t * DHt * q_buffer_factor;
     uint32_t k_tiles = Sk_chunk_t * DHt * 2;  // double buffer
     uint32_t v_tiles = Sk_chunk_t * DHt * 2;  // double buffer
-    uint32_t mask_tiles = Sq_chunk_t * Sk_chunk_t;
     uint32_t qk_tiles = Sq_chunk_t * Sk_chunk_t;
     uint32_t out_im_tiles = Sq_chunk_t * DHt;
     uint32_t out0_t = Sq_chunk_t * DHt;
@@ -268,7 +273,6 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     log_debug(tt::LogOp, "q_tiles: {}", q_tiles);
     log_debug(tt::LogOp, "k_tiles: {}", k_tiles);
     log_debug(tt::LogOp, "v_tiles: {}", v_tiles);
-    log_debug(tt::LogOp, "mask_tiles: {}", mask_tiles);
     log_debug(tt::LogOp, "qk_tiles: {}", qk_tiles);
     log_debug(tt::LogOp, "out0_t: {}", out0_t);
     log_debug(tt::LogOp, "scale_tiles: {}", scale_tiles);
@@ -397,7 +401,10 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
         num_q_chunks,
         packed_identity_scalar,
         scale_union.u,
-        args.all_gather_operation_attributes.ring_size};
+        args.all_gather_operation_attributes.ring_size,
+        global_n_partial_col,
+        joint_l_partial_col,
+    };
 
     TensorAccessorArgs(output_tensor.buffer()).append_to(writer_compile_time_args);
     TensorAccessorArgs(joint_output_tensor.buffer()).append_to(writer_compile_time_args);
@@ -434,7 +441,10 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
         out_in0_num_subblocks,
         out_in1_num_subblocks,
         out_num_blocks,
-        scale_union.u};
+        scale_union.u,
+        global_n_partial_col,
+        joint_l_partial_col,
+    };
 
     std::map<std::string, std::string> defines;
     defines["STATS_GRANULARITY"] = std::to_string(stats_granularity);
@@ -472,7 +482,6 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     tt::DataFormat q_df = tt::tt_metal::datatype_to_dataformat_converter(input_tensor_q.dtype());
     tt::DataFormat k_df = tt::tt_metal::datatype_to_dataformat_converter(gathered_input_tensor_k.dtype());
     tt::DataFormat v_df = tt::tt_metal::datatype_to_dataformat_converter(gathered_input_tensor_v.dtype());
-    tt::DataFormat mask_df = tt::DataFormat::Bfp4_b;
     tt::DataFormat out_df = tt::tt_metal::datatype_to_dataformat_converter(output_tensor.dtype());
     tt::DataFormat scalar_df = tt::DataFormat::Float16_b;
     tt::DataFormat im_df = tt::DataFormat::Float16_b;  // need to disable fp32 cbs (Issue #13364) fp32_dest_acc_en ?
@@ -482,7 +491,6 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     uint32_t q_tile_size = tt::tile_size(q_df);
     uint32_t k_tile_size = tt::tile_size(k_df);
     uint32_t v_tile_size = tt::tile_size(v_df);
-    uint32_t mask_tile_size = tt::tile_size(mask_df);
     uint32_t out_tile_size = tt::tile_size(out_df);
     uint32_t scalar_tile_size = tt::tile_size(scalar_df);
     uint32_t im_tile_size = tt::tile_size(im_df);
@@ -491,7 +499,6 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     log_debug(tt::LogOp, "q_data_format: {}", q_df);
     log_debug(tt::LogOp, "k_data_format: {}", k_df);
     log_debug(tt::LogOp, "v_data_format: {}", v_df);
-    log_debug(tt::LogOp, "mask_data_format: {}", mask_df);
     log_debug(tt::LogOp, "out_data_format: {}", out_df);
     log_debug(tt::LogOp, "scalar_data_format: {}", scalar_df);
     log_debug(tt::LogOp, "intermediate_data_format: {}", im_df);
@@ -511,10 +518,22 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
                             .set_page_size(tt::CBIndex::c_2, v_tile_size);
     CreateCircularBuffer(program, core_grid, c_in2_config);
 
-    // attn_mask input
-    auto c_in3_config = CircularBufferConfig(mask_tiles * mask_tile_size, {{tt::CB::c_in3, mask_df}})
-                            .set_page_size(tt::CB::c_in3, mask_tile_size);
+    // attn_mask input — lightweight mask uses a single Float16_b -inf tile
+    const tt::DataFormat lightweight_mask_df = tt::DataFormat::Float16_b;
+    const uint32_t lightweight_mask_tile_size = tt::tile_size(lightweight_mask_df);
+    auto c_in3_config = CircularBufferConfig(lightweight_mask_tile_size, {{tt::CB::c_in3, lightweight_mask_df}})
+                            .set_page_size(tt::CB::c_in3, lightweight_mask_tile_size);
     CreateCircularBuffer(program, core_grid, c_in3_config);
+
+    // Partial mask tile(s) for boundary tiles — Float16_b, same format as c_in3 lightweight mask
+    if (partial_mask_tiles > 0) {
+        const tt::DataFormat partial_df = tt::DataFormat::Float16_b;
+        const uint32_t partial_tile_size = tt::tile_size(partial_df);
+        auto c_in9_config =
+            CircularBufferConfig(partial_mask_tiles * partial_tile_size, {{tt::CBIndex::c_9, partial_df}})
+                .set_page_size(tt::CBIndex::c_9, partial_tile_size);
+        CreateCircularBuffer(program, core_grid, c_in9_config);
+    }
 
     // scale input
     auto c_in4_config = CircularBufferConfig(scale_tiles * scalar_tile_size, {{tt::CBIndex::c_4, scalar_df}})


### PR DESCRIPTION

### Problem description
  The full mask matrix consumes `Sq_chunk_t` * `Sk_chunk_t` tiles of L1, which is a significant amount of space that limits other optimizations for ring joint SDPA. By replacing it with at most 3 tiles (1 full -inf + up to 2 partial), we free nearly all of that L1 budget for other uses while maintaining correctness for all input shapes.

### What's changed
  - Replace the full mask matrix in ring joint SDPA with a lightweight two-tier approach to free L1 space needed for upcoming ring joint SDPA improvements
  - Full -inf tile (CB c_3): single permanently-fronted tile, L1-accumulated onto fully padded K tile positions
  - Partial mask tile (CB c_9, 1-2 tiles): handles non-tile-aligned boundaries (logical_n % 32 != 0 or L % 32 != 0) where padding falls inside a tile — columns [0, partial_col) = 0 (valid), columns [partial_col, 32) = -inf (masked)

### Checklist

 - [ ] APC https://github.com/tenstorrent/tt-metal/actions/runs/22645416895
 - [ ] BHPC https://github.com/tenstorrent/tt-metal/actions/runs/22645440199
 - [ ] L2 Nightly SDPA https://github.com/tenstorrent/tt-metal/actions/runs/22645491569
 - [ ] (Blackhole) Demo tests WAN2.2 https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml
 - [ ] (Galaxy) demo tests https://github.com/tenstorrent/tt-metal/actions/runs/22645766015
