### PR TITLE
Enable FSDP for Wan 2x2 Mesh test configs

### DIFF
--- a/models/tt_dit/tests/models/wan2_2/test_pipeline_wan.py
+++ b/models/tt_dit/tests/models/wan2_2/test_pipeline_wan.py
@@ -16,7 +16,7 @@ from ....utils.test import line_params, ring_params
 @pytest.mark.parametrize(
     "mesh_device, mesh_shape, sp_axis, tp_axis, num_links, dynamic_load, device_params, topology, is_fsdp",
     [
-        [(2, 2), (2, 2), 0, 1, 2, False, line_params, ttnn.Topology.Linear, False],
+        [(2, 2), (2, 2), 0, 1, 2, False, line_params, ttnn.Topology.Linear, True],
         [(2, 4), (2, 4), 0, 1, 1, True, line_params, ttnn.Topology.Linear, True],
         # WH (ring) on 4x8
         [(4, 8), (4, 8), 1, 0, 4, False, ring_params, ttnn.Topology.Ring, True],

--- a/models/tt_dit/tests/models/wan2_2/test_pipeline_wan_i2v.py
+++ b/models/tt_dit/tests/models/wan2_2/test_pipeline_wan_i2v.py
@@ -17,7 +17,7 @@ from ....utils.test import line_params, ring_params
 @pytest.mark.parametrize(
     "mesh_device, mesh_shape, sp_axis, tp_axis, num_links, dynamic_load, device_params, topology, is_fsdp",
     [
-        [(2, 2), (2, 2), 0, 1, 2, False, line_params, ttnn.Topology.Linear, False],
+        [(2, 2), (2, 2), 0, 1, 2, False, line_params, ttnn.Topology.Linear, True],
         [(2, 4), (2, 4), 0, 1, 1, True, line_params, ttnn.Topology.Linear, True],
         [(1, 8), (1, 8), 0, 1, 2, False, line_params, ttnn.Topology.Linear, False],
         # WH (ring) on 4x8


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/pull/37984

### Problem description
PR #37984 moved the UMT5 encoder on-device, requiring FSDP for the 2x2 (BH QB2) config due to increased memory pressure. That PR updated test_performance_wan.py but missed test_pipeline_wan.py and test_pipeline_wan_i2v.py.

### What's changed
Set is_fsdp=True for the 2x2 config in both files to match test_performance_wan.py.

### Checklist
- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=kevinmi/fix-wan-test-is-fsdp-2x2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:kevinmi/fix-wan-test-is-fsdp-2x2)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=kevinmi/fix-wan-test-is-fsdp-2x2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:kevinmi/fix-wan-test-is-fsdp-2x2)

#### Model tests

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kevinmi/fix-wan-test-is-fsdp-2x2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kevinmi/fix-wan-test-is-fsdp-2x2)
  - [ ] `models-mandatory` preset
  - [ ] other selection: [Blackhole Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-demo-tests.yaml) with `pytest models/tt_dit/tests/models/wan2_2/test_pipeline_wan.py -k "2x2"` and `pytest models/tt_dit/tests/models/wan2_2/test_pipeline_wan_i2v.py -k "2x2"`