### PR TITLE
[MNIST, SWIN] Perf target bump

### DIFF
--- a/models/demos/vision/classification/mnist/tests/test_perf_mnist.py
+++ b/models/demos/vision/classification/mnist/tests/test_perf_mnist.py
@@ -100,7 +100,7 @@ def test_perf_device_bare_metal(batch_size, reset_seeds):
     subdir = "ttnn_mnist"
     num_iterations = 1
     margin = 0.04
-    expected_perf = 1075603
+    expected_perf = 1161176
 
     command = f"pytest tests/ttnn/integration_tests/mnist/test_mnist.py::test_mnist"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]

--- a/models/experimental/swin_s/tests/perf/test_perf.py
+++ b/models/experimental/swin_s/tests/perf/test_perf.py
@@ -10,7 +10,7 @@ from models.perf.device_perf_utils import check_device_perf, prep_device_perf_re
 @pytest.mark.parametrize(
     "batch_size, model_name, expected_perf",
     [
-        (1, "Swin_s", 11.5),
+        (1, "Swin_s", 12.70404),
     ],
 )
 @pytest.mark.models_device_performance_bare_metal


### PR DESCRIPTION
### Problem description
Perf for swin and mnist model seems to improve causing the[ Single Device perf](https://github.com/tenstorrent/tt-metal/actions/runs/22600022648/job/65489945185) pipeline to fail. This pr bumps the perf for these models. The value of the target perf was detected by averaging the last 5 runs. The table of sampled values for each run is given below.

<google-sheets-html-origin><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->
MNIST | SWIN
-- | --
1159861 | 12.7376
1173181 | 12.6907
1160587 | 12.7126
1159787 | 12.7182
1152467 | 12.6611
AVERAGE | AVERAGE
1161176.6 | 12.70404



### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml/badge.svg?branch=dstoiljkovic/mnist_swin_perf_bump)](https://github.com/tenstorrent/tt-metal/actions/runs/22635666570?query=branch:dstoiljkovic/mnist_swin_perf_bump)