### PR TITLE
[skip ci] Set timeout to 45min for sdxl in release tests

### DIFF
--- a/tests/pipeline_reorg/release_tests.yaml
+++ b/tests/pipeline_reorg/release_tests.yaml
@@ -66,7 +66,7 @@
   cmd: run_sdxl_func
   skus:
     wh_n150:
-      timeout: 24
+      timeout: 45
   owner_id: U0837MYG788 # Marko Radosavljevic
   team: models
   model-name: sdxl


### PR DESCRIPTION
### Problem description
Currently sdxl is timeouting on Package and release workflow

### What's changed
Setting timeout to 45 mins

