### PR TITLE
Deepseek: Switch to HiFi4 with FP32 accumulation for RMSNorm

### DIFF
--- a/models/demos/deepseek_v3/tests/unit/test_rmsnorm.py
+++ b/models/demos/deepseek_v3/tests/unit/test_rmsnorm.py
@@ -8,7 +8,7 @@ from loguru import logger
 
 import ttnn
 from models.demos.deepseek_v3.tests.unit.utils import run_test
-from models.demos.deepseek_v3.utils.config_helpers import COMPUTE_KERNEL_CONFIG_LOFI, create_sharded_norm_config
+from models.demos.deepseek_v3.utils.config_helpers import COMPUTE_KERNEL_CONFIG_HIFI4, create_sharded_norm_config
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 # =============================================================================
@@ -61,7 +61,7 @@ def test_rmsnorm_pre_all_gather_single_device(device):
     kernel_config = ttnn.WormholeComputeKernelConfig(
         math_fidelity=ttnn.MathFidelity.HiFi4,
         math_approx_mode=True,
-        fp32_dest_acc_en=False,
+        fp32_dest_acc_en=True,
         packer_l1_acc=False,
     )
 
@@ -149,7 +149,7 @@ def test_rmsnorm_pre_all_gather_mesh_device(mesh_device, enable_trace, device_pa
     kernel_config = ttnn.WormholeComputeKernelConfig(
         math_fidelity=ttnn.MathFidelity.HiFi4,
         math_approx_mode=True,
-        fp32_dest_acc_en=False,
+        fp32_dest_acc_en=True,
         packer_l1_acc=False,
     )
 
@@ -251,7 +251,7 @@ def test_rmsnorm_post_all_gather(device):
     kernel_config = ttnn.WormholeComputeKernelConfig(
         math_fidelity=ttnn.MathFidelity.HiFi4,
         math_approx_mode=True,
-        fp32_dest_acc_en=False,
+        fp32_dest_acc_en=True,
         packer_l1_acc=False,
     )
 
@@ -401,7 +401,7 @@ def test_rmsnorm_distributed_mesh_device(mesh_device, enable_trace, device_param
     kernel_config = ttnn.WormholeComputeKernelConfig(
         math_fidelity=ttnn.MathFidelity.HiFi4,
         math_approx_mode=True,
-        fp32_dest_acc_en=False,
+        fp32_dest_acc_en=True,
         packer_l1_acc=False,
     )
 
@@ -556,7 +556,7 @@ def test_rmsnorm_single_device(device, inp_shape, weight_shape):
     Test configuration:
     - Input: bfloat16, DRAM INTERLEAVED, TILE layout
     - Weight: bfloat16, DRAM INTERLEAVED, ROW_MAJOR layout
-    - LoFi compute kernel (math_approx_mode=False, fp32_dest_acc_en=False, packer_l1_acc=True)
+    - HiFi4 compute kernel (math_approx_mode=False, fp32_dest_acc_en=True, packer_l1_acc=True)
     - LayerNormDefaultProgramConfig
     - epsilon: 1e-6
     """
@@ -591,12 +591,12 @@ def test_rmsnorm_single_device(device, inp_shape, weight_shape):
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
 
-    # Run rms_norm with LoFi compute kernel and default program config
+    # Run rms_norm with HiFi4 compute kernel and default program config
     tt_out = ttnn.rms_norm(
         tt_inp,
         epsilon=epsilon,
         weight=tt_gamma,
-        compute_kernel_config=COMPUTE_KERNEL_CONFIG_LOFI,
+        compute_kernel_config=COMPUTE_KERNEL_CONFIG_HIFI4,
         program_config=ttnn.LayerNormDefaultProgramConfig(),
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
@@ -627,7 +627,7 @@ def test_rmsnorm_mesh_device(mesh_device, inp_shape, weight_shape, enable_trace,
     Test configuration:
     - Input: bfloat16, DRAM INTERLEAVED, TILE layout
     - Weight: bfloat16, DRAM INTERLEAVED, ROW_MAJOR layout
-    - LoFi compute kernel (math_approx_mode=False, fp32_dest_acc_en=False, packer_l1_acc=True)
+    - HiFi4 compute kernel (math_approx_mode=False, fp32_dest_acc_en=True, packer_l1_acc=True)
     - LayerNormDefaultProgramConfig
     - epsilon: 1e-6
     """
@@ -669,7 +669,7 @@ def test_rmsnorm_mesh_device(mesh_device, inp_shape, weight_shape, enable_trace,
             tt_inp,
             epsilon=epsilon,
             weight=tt_gamma,
-            compute_kernel_config=COMPUTE_KERNEL_CONFIG_LOFI,
+            compute_kernel_config=COMPUTE_KERNEL_CONFIG_HIFI4,
             program_config=ttnn.LayerNormDefaultProgramConfig(),
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
         )

--- a/models/demos/deepseek_v3/tt/rms_norm/distributed_rms_norm.py
+++ b/models/demos/deepseek_v3/tt/rms_norm/distributed_rms_norm.py
@@ -18,7 +18,13 @@ from models.demos.deepseek_v3.utils.config_dataclass import (
     RMSNormPostAllGatherConfig,
     RMSNormPreAllGatherConfig,
 )
-from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, even_int_div, get_state_dicts, shard_and_save
+from models.demos.deepseek_v3.utils.config_helpers import (
+    COMPUTE_KERNEL_CONFIG_HIFI4,
+    USERS_PER_ROW,
+    even_int_div,
+    get_state_dicts,
+    shard_and_save,
+)
 from models.demos.deepseek_v3.utils.run_config import (
     MESH_DEVICE_STATE_DICT_KEY,
     ModelDecodeConfig,
@@ -129,6 +135,7 @@ class DistributedRMSNorm(RMSNormBase):
             "input_memory_config": memory_config,
             "rms_norm_pre_all_gather": RMSNormPreAllGatherConfig(
                 dtype=ttnn.bfloat16,
+                compute_kernel_config=COMPUTE_KERNEL_CONFIG_HIFI4,
             ),
             "all_gather": AllGatherAsyncConfig(
                 dim=3,
@@ -140,6 +147,7 @@ class DistributedRMSNorm(RMSNormBase):
                 epsilon=hf_config.rms_norm_eps,
                 weight=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
                 dtype=ttnn.bfloat16,
+                compute_kernel_config=COMPUTE_KERNEL_CONFIG_HIFI4,
             ),
         }
 

--- a/models/demos/deepseek_v3/tt/rms_norm/rms_norm.py
+++ b/models/demos/deepseek_v3/tt/rms_norm/rms_norm.py
@@ -10,7 +10,7 @@ from transformers.configuration_utils import PretrainedConfig
 import ttnn
 from models.demos.deepseek_v3.tt.rms_norm.rms_norm_base import RMSNormBase
 from models.demos.deepseek_v3.utils.config_dataclass import FromWeightConfig, MeshDeviceStub, RMSNormConfig
-from models.demos.deepseek_v3.utils.config_helpers import COMPUTE_KERNEL_CONFIG_LOFI, get_state_dicts, shard_and_save
+from models.demos.deepseek_v3.utils.config_helpers import COMPUTE_KERNEL_CONFIG_HIFI4, get_state_dicts, shard_and_save
 from models.demos.deepseek_v3.utils.run_config import (
     ModelDecodeConfig,
     ModelPrefillConfig,
@@ -54,7 +54,7 @@ class RMSNorm(RMSNormBase):
         return RMSNormConfig(
             epsilon=hf_config.rms_norm_eps,
             weight=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
-            compute_kernel_config=COMPUTE_KERNEL_CONFIG_LOFI,
+            compute_kernel_config=COMPUTE_KERNEL_CONFIG_HIFI4,
         )
 
     @classmethod
@@ -62,7 +62,7 @@ class RMSNorm(RMSNormBase):
         return RMSNormConfig(
             epsilon=hf_config.rms_norm_eps,
             weight=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
-            compute_kernel_config=COMPUTE_KERNEL_CONFIG_LOFI,
+            compute_kernel_config=COMPUTE_KERNEL_CONFIG_HIFI4,
         )
 
     @classmethod

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_post_allgather.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_post_allgather.py
@@ -165,8 +165,6 @@ def run_layernorm_part_2(inp_shape, n_devices, is_rmsnorm, input_dtype, output_d
 def test_layernorm_part_2_with_program_cache(
     inp_shape, n_devices, is_rmsnorm, input_dtype, output_dtype, fp32_enabled, device
 ):
-    if fp32_enabled == False:
-        pytest.skip("Skipping when fp32_enabled=False due to unexpected kernel behavior")
     run_layernorm_part_2(inp_shape, n_devices, is_rmsnorm, input_dtype, output_dtype, device, fp32_enabled)
 
 
@@ -190,7 +188,6 @@ def test_layernorm_part_2_with_program_cache(
     [True, False],
     ids=["rmsnorm", "layernorm"],
 )
-@pytest.mark.skip(reason="#34410")
 def test_layernorm_part_2_with_program_cache2(inp_shape, n_devices, is_rmsnorm, dtype, device):
     dummy_tensors = []
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_pre_allgather.cpp
@@ -202,6 +202,7 @@ void kernel_main() {
         reconfig_data_format_srca(cb_x2, cb_ex_external2);
         reconfig_data_format_srcb(cb_scaler, cb_scaler_global);
         reduce_init(cb_ex_external2, cb_scaler_global, cb_reduction_out);
+        pack_reconfig_data_format(cb_reduction_out);
         cb_reserve_back(cb_reduction_out, num_tiles_per_partial_result * num_tiles_per_allgather_worker);
 
         for (uint32_t i = 0; i < num_tiles_per_allgather_worker; i++) {  // loops over height

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core_sharded.cpp
@@ -265,8 +265,13 @@ tt::tt_metal::ProgramDescriptor LayerNormShardedProgramFactory::create_descripto
 
     assert_subblock_compute_config_compatible(dst_full_sync_en, fp32_dest_acc_en, subblock_wt);
 
-    auto [out_data_format, cb_data_format, gamma_cb_data_format, beta_cb_data_format, reciprocal_cb_data_format] =
-        get_cb_data_formats(output, gamma, beta, fp32_dest_acc_en);
+    auto
+        [out_data_format,
+         cb_data_format,
+         gamma_cb_data_format,
+         beta_cb_data_format,
+         stats_cb_data_format,
+         reciprocal_cb_data_format] = get_cb_data_formats(output, gamma, beta, stats, fp32_dest_acc_en);
 
     // tile sizes
     uint32_t in_single_tile_size = tt::tile_size(in_data_format);
@@ -274,6 +279,7 @@ tt::tt_metal::ProgramDescriptor LayerNormShardedProgramFactory::create_descripto
     uint32_t out_single_tile_size = tt::tile_size(out_data_format);
     uint32_t gamma_single_tile_size = tt::tile_size(gamma_cb_data_format);
     uint32_t beta_single_tile_size = tt::tile_size(beta_cb_data_format);
+    uint32_t stats_single_tile_size = tt::tile_size(stats_cb_data_format);
     uint32_t bfloat16_tile_size = tt::tile_size(tt::DataFormat::Float16_b);
 
     // tensor shape
@@ -337,6 +343,7 @@ tt::tt_metal::ProgramDescriptor LayerNormShardedProgramFactory::create_descripto
         .out_single_tile_size = out_single_tile_size,
         .gamma_single_tile_size = gamma_single_tile_size,
         .beta_single_tile_size = beta_single_tile_size,
+        .stats_single_tile_size = stats_single_tile_size,
         .bfloat16_tile_size = bfloat16_tile_size,
         .reciprocal_CB_size_bytes = reciprocal_CB_size_bytes,
         .num_rows_per_all_to_all_worker = workers.num_rows_per_all_to_all_worker,
@@ -571,12 +578,14 @@ tt::tt_metal::ProgramDescriptor LayerNormShardedProgramFactory::create_descripto
     cb_config.out_data_format = out_data_format;
     cb_config.gamma_cb_data_format = gamma_cb_data_format;
     cb_config.beta_cb_data_format = beta_cb_data_format;
+    cb_config.stats_cb_data_format = stats_cb_data_format;
     cb_config.reciprocal_cb_data_format = reciprocal_cb_data_format;
     cb_config.in_single_tile_size = in_single_tile_size;
     cb_config.single_tile_size = single_tile_size;
     cb_config.out_single_tile_size = out_single_tile_size;
     cb_config.gamma_single_tile_size = gamma_single_tile_size;
     cb_config.beta_single_tile_size = beta_single_tile_size;
+    cb_config.stats_single_tile_size = stats_single_tile_size;
     cb_config.bfloat16_tile_size = bfloat16_tile_size;
     cb_config.a_buffer = a.buffer();
     cb_config.b_buffer = b.has_value() ? b.value().buffer() : nullptr;

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/sharded_layernorm_factory_helpers.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/sharded_layernorm_factory_helpers.cpp
@@ -47,10 +47,12 @@ void assert_subblock_compute_config_compatible(bool dst_full_sync_en, bool fp32_
     }
 }
 
-std::tuple<tt::DataFormat, tt::DataFormat, tt::DataFormat, tt::DataFormat, tt::DataFormat> get_cb_data_formats(
+std::tuple<tt::DataFormat, tt::DataFormat, tt::DataFormat, tt::DataFormat, tt::DataFormat, tt::DataFormat>
+get_cb_data_formats(
     const Tensor& output,
     const std::optional<const Tensor>& gamma,
     const std::optional<const Tensor>& beta,
+    const std::optional<const Tensor>& stats,
     bool fp32_dest_acc_en) {
     tt::DataFormat out_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
     tt::DataFormat cb_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
@@ -60,8 +62,17 @@ std::tuple<tt::DataFormat, tt::DataFormat, tt::DataFormat, tt::DataFormat, tt::D
     tt::DataFormat beta_cb_data_format = beta.has_value()
                                              ? tt::tt_metal::datatype_to_dataformat_converter(beta.value().dtype())
                                              : tt::DataFormat::Float16_b;
+    tt::DataFormat stats_cb_data_format = stats.has_value()
+                                              ? tt::tt_metal::datatype_to_dataformat_converter(stats.value().dtype())
+                                              : tt::DataFormat::Float16_b;
     tt::DataFormat reciprocal_cb_data_format = tt::DataFormat::Float32;
-    return {out_data_format, cb_data_format, gamma_cb_data_format, beta_cb_data_format, reciprocal_cb_data_format};
+    return {
+        out_data_format,
+        cb_data_format,
+        gamma_cb_data_format,
+        beta_cb_data_format,
+        stats_cb_data_format,
+        reciprocal_cb_data_format};
 }
 
 namespace {
@@ -549,7 +560,7 @@ CBSizeParams::Sizes CBSizeParams::compute() const {
     sizes.ex2pe_CB_size = num_rows_per_all_to_all_worker * single_tile_size;
 
     if (is_post_all_gather) {
-        sizes.stats_cb_size = post_all_gather_stats_block_tiles * single_tile_size;
+        sizes.stats_cb_size = post_all_gather_stats_block_tiles * stats_single_tile_size;
         sizes.stats_reduced_cb_size = pre_all_gather_stats_block_tiles * single_tile_size;
     }
 
@@ -1069,8 +1080,8 @@ void add_cb_descriptors(
         stats_cb_desc.core_ranges = core_ranges.sender_cores;
         stats_cb_desc.format_descriptors.push_back(CBFormatDescriptor{
             .buffer_index = tt::CBIndex::c_7,
-            .data_format = cb_config.cb_data_format,
-            .page_size = cb_config.single_tile_size});
+            .data_format = cb_config.stats_cb_data_format,
+            .page_size = cb_config.stats_single_tile_size});
         stats_cb_desc.buffer = cb_config.stats_buffer;
         program_descriptor.cbs.push_back(std::move(stats_cb_desc));
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/sharded_layernorm_factory_helpers.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/sharded_layernorm_factory_helpers.hpp
@@ -32,10 +32,12 @@ struct CoreRanges;
 
 void assert_subblock_compute_config_compatible(bool dst_full_sync_en, bool fp32_dest_acc_en, uint32_t subblock_wt);
 
-std::tuple<tt::DataFormat, tt::DataFormat, tt::DataFormat, tt::DataFormat, tt::DataFormat> get_cb_data_formats(
+std::tuple<tt::DataFormat, tt::DataFormat, tt::DataFormat, tt::DataFormat, tt::DataFormat, tt::DataFormat>
+get_cb_data_formats(
     const Tensor& output,
     const std::optional<const Tensor>& gamma,
     const std::optional<const Tensor>& beta,
+    const std::optional<const Tensor>& stats,
     bool fp32_dest_acc_en);
 
 //////////////////////////////////////////////////////////////////////////////
@@ -149,6 +151,7 @@ struct CBSizeParams {
     uint32_t out_single_tile_size = 0;
     uint32_t gamma_single_tile_size = 0;
     uint32_t beta_single_tile_size = 0;
+    uint32_t stats_single_tile_size = 0;
     uint32_t bfloat16_tile_size = 0;
     uint32_t reciprocal_CB_size_bytes = 0;
     uint32_t num_rows_per_all_to_all_worker = 0;
@@ -322,6 +325,7 @@ struct CBConfig {
     tt::DataFormat out_data_format = tt::DataFormat::Float16_b;
     tt::DataFormat gamma_cb_data_format = tt::DataFormat::Float16_b;
     tt::DataFormat beta_cb_data_format = tt::DataFormat::Float16_b;
+    tt::DataFormat stats_cb_data_format = tt::DataFormat::Float16_b;
     tt::DataFormat reciprocal_cb_data_format = tt::DataFormat::Float32;
 
     // Tile sizes
@@ -330,6 +334,7 @@ struct CBConfig {
     uint32_t out_single_tile_size = 0;
     uint32_t gamma_single_tile_size = 0;
     uint32_t beta_single_tile_size = 0;
+    uint32_t stats_single_tile_size = 0;
     uint32_t bfloat16_tile_size = 0;
 
     // Buffers


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/38753

### Problem description
Distributed RMS Norm did not work when `fp32_dest_acc_en` was set.

### What's changed
1. Fixed `rms_norm_pre_all_gather`: needed a pack configure to pack the accumulated stats values in bf16 when the dst regs have the value in fp32.
2. Fixed `rms_norm_post_all_gather`: Needed stats CB to be retained as bf16 even when the intemediate values in compute kernel switch to fp32.
3. Moved compute config is deepseek tests and deepseek code to HiFi4 with fp32 enabled, inline with the changes proposed in https://github.com/tenstorrent/tt-metal/pull/38547
4. Re-enable unit tests that were previously disabled.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:{{branch_name}})
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
