### PR TITLE
Add API support for fp32 dest control for PACK

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
@@ -37,6 +37,8 @@ inline void llk_pack_mop_config(const uint32_t output, std::uint32_t num_tiles =
         pack_dst_format[output_id], face_r_dim, tile_c_dim, num_faces, partial_face, narrow_tile, num_tiles);
 }
 
+inline void llk_pack_set_fp32_dest_acc(bool enable) { _llk_pack_set_fp32_dest_acc_(enable); }
+
 template <bool is_fp32_dest_acc_en>
 inline void llk_pack_hw_configure(std::uint32_t pack_output) {
     const std::uint32_t output_id = get_output_id(pack_output);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
@@ -37,6 +37,8 @@ inline void llk_pack_mop_config(const uint32_t output) {
         pack_dst_format[output_id], face_r_dim, num_faces, partial_face, narrow_tile);
 }
 
+inline void llk_pack_set_fp32_dest_acc(bool enable) { _llk_pack_set_fp32_dest_acc_(enable); }
+
 template <bool is_fp32_dest_acc_en>
 inline void llk_pack_hw_configure(std::uint32_t pack_output) {
     const std::uint32_t output_id = get_output_id(pack_output);

--- a/tt_metal/hw/inc/api/compute/compute_kernel_hw_startup.h
+++ b/tt_metal/hw/inc/api/compute/compute_kernel_hw_startup.h
@@ -73,14 +73,15 @@ ALWI void compute_kernel_hw_startup(uint32_t icb0, uint32_t ocb) {
 
 // clang-format off
 /**
- * Enables FP32 accumulation in the destination register (ALU and SFPU).
+ * Enables FP32 accumulation in the destination register.
  *
- * This is a lightweight, standalone reconfiguration that only toggles the
- * ALU_ACC_CTRL Fp32_enabled and SFPU_Fp32_enabled bits. It does not touch
- * any unpacker or packer configuration, making it safe to call mid-kernel
- * without re-running compute_kernel_hw_startup.
+ * Configures both the math pipeline (ALU_ACC_CTRL Fp32_enabled and
+ * SFPU_Fp32_enabled) and the packer (PCK_DEST_RD_CTRL Read_32b_data)
+ * for 32-bit destination reads. This is a lightweight, standalone
+ * reconfiguration that is safe to call mid-kernel without re-running
+ * compute_kernel_hw_startup.
  *
- * Must be paired with math_disable_fp32_dest_acc() when switching back to
+ * Must be paired with disable_fp32_dest_acc() when switching back to
  * BF16 accumulation mode within the same kernel.
  *
  * Only available on Wormhole and Blackhole (no-op on Quasar).
@@ -88,30 +89,33 @@ ALWI void compute_kernel_hw_startup(uint32_t icb0, uint32_t ocb) {
  * Return value: None
  */
 // clang-format on
-ALWI void math_enable_fp32_dest_acc() {
+ALWI void enable_fp32_dest_acc() {
 #ifndef ARCH_QUASAR
     MATH((llk_math_set_fp32_dest_acc(true)));
+    PACK((llk_pack_set_fp32_dest_acc(true)));
 #endif
 }
 
 // clang-format off
 /**
- * Disables FP32 accumulation in the destination register (ALU and SFPU),
- * reverting to BF16 accumulation mode.
+ * Disables FP32 accumulation in the destination register, reverting to
+ * BF16 accumulation mode.
  *
- * This is a lightweight, standalone reconfiguration that only toggles the
- * ALU_ACC_CTRL Fp32_enabled and SFPU_Fp32_enabled bits. It does not touch
- * any unpacker or packer configuration, making it safe to call mid-kernel
- * without re-running compute_kernel_hw_startup.
+ * Configures both the math pipeline (ALU_ACC_CTRL Fp32_enabled and
+ * SFPU_Fp32_enabled) and the packer (PCK_DEST_RD_CTRL Read_32b_data)
+ * to disable 32-bit destination reads. This is a lightweight, standalone
+ * reconfiguration that is safe to call mid-kernel without re-running
+ * compute_kernel_hw_startup.
  *
  * Only available on Wormhole and Blackhole (no-op on Quasar).
  *
  * Return value: None
  */
 // clang-format on
-ALWI void math_disable_fp32_dest_acc() {
+ALWI void disable_fp32_dest_acc() {
 #ifndef ARCH_QUASAR
     MATH((llk_math_set_fp32_dest_acc(false)));
+    PACK((llk_pack_set_fp32_dest_acc(false)));
 #endif
 }
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/38923

### Problem description
To support the Deepseek effort, we need to implement API that allows the users to enable/disable float32 individually and add proper LLK support.

### What's changed
While https://github.com/tenstorrent/tt-metal/pull/38929 added support for the MATH thread, this PR adds support for the PACK thread as well. 

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=pmilenkovic/fp32-dest-control-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:pmilenkovic/fp32-dest-control-api) - Same as main
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pmilenkovic/fp32-dest-control-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pmilenkovic/fp32-dest-control-api) - Same as main
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pmilenkovic/fp32-dest-control-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pmilenkovic/fp32-dest-control-api)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early
