### PR TITLE
Implement DISABLE_SFPLOADMACRO paths for unary and binary min/max

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_max_min.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_max_min.h
@@ -20,6 +20,16 @@ inline void calculate_binary_max_min(const uint dst_index_in0, const uint dst_in
     uint offset1 = (dst_index_in1 * 32) << 1;
     uint offset2 = (dst_index_out * 32) << 1;
 
+#ifdef DISABLE_SFPLOADMACRO
+#pragma GCC unroll 0
+    for (int d = 0; d < ITERATIONS; d++) {
+        // Swap and store maximum in lreg1, minimum in lreg0
+        TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, offset0);
+        TT_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::DEFAULT, ADDR_MOD_7, offset1);
+        TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, sfpi::SFPSWAP_MOD1_VEC_MIN_MAX);
+        TT_SFPSTORE(IS_MAX_OP ? p_sfpu::LREG1 : p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_6, offset2);
+    }
+#else
     // This uses SFPLOADMACRO to achieve a throughput of 3 cycles per input row.
     //
     // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
@@ -47,6 +57,7 @@ inline void calculate_binary_max_min(const uint dst_index_in0, const uint dst_in
     TTI_SFPNOP;
     TTI_SFPNOP;
     TTI_SFPNOP;
+#endif
 }
 
 template <bool IS_MAX_OP = true, bool IS_UNSIGNED = false, int ITERATIONS = 8>
@@ -56,6 +67,23 @@ inline void calculate_binary_max_min_int32(
     uint offset1 = (dst_index_in1 * 32) << 1;
     uint offset2 = (dst_index_out * 32) << 1;
 
+#ifdef DISABLE_SFPLOADMACRO
+#pragma GCC unroll 0
+    for (int d = 0; d < ITERATIONS; d++) {
+        // Swap and store maximum in lreg1, minimum in lreg0 (or reversed if unsigned)
+        TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, offset0);
+        TT_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::INT32, ADDR_MOD_7, offset1);
+        TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, IS_UNSIGNED ? 9 : sfpi::SFPSWAP_MOD1_VEC_MIN_MAX);
+
+        // Conditionally swap again to fix the cases where SFPSWAP got the result backwards
+        TTI_SFPSETCC(0, p_sfpu::LREG0, 0, IS_UNSIGNED ? sfpi::SFPSETCC_MOD1_LREG_GTE0 : sfpi::SFPSETCC_MOD1_LREG_LT0);
+        TTI_SFPSETCC(0, p_sfpu::LREG1, 0, IS_UNSIGNED ? sfpi::SFPSETCC_MOD1_LREG_GTE0 : sfpi::SFPSETCC_MOD1_LREG_LT0);
+        TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, sfpi::SFPSWAP_MOD1_SWAP);
+        TTI_SFPENCC(0, 0, 0, 0);
+
+        TT_SFPSTORE(IS_MAX_OP ? p_sfpu::LREG1 : p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_6, offset2);
+    }
+#else
     // This uses SFPLOADMACRO to achieve a throughput of 5 cycles per input row.
     //
     // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
@@ -112,10 +140,12 @@ inline void calculate_binary_max_min_int32(
     }
 
     TTI_SFPNOP;
+#endif
 }
 
 template <bool IS_MAX_OP = true>
 inline void binary_max_min_init() {
+#ifndef DISABLE_SFPLOADMACRO
     constexpr int b = p_sfpu::LREG2;
 
     // InstructionTemplate[0]
@@ -154,10 +184,12 @@ inline void binary_max_min_init() {
     //   UnitDelayKind: {1,1}, (WaitForElapsedInstructions=1)
     // }
     TTI_SFPCONFIG(0x330, 8, 1);
+#endif
 }
 
 template <bool IS_MAX_OP = true, bool IS_UNSIGNED = false>
 inline void binary_max_min_int32_init() {
+#ifndef DISABLE_SFPLOADMACRO
     constexpr int b0 = p_sfpu::LREG1;
     constexpr int b1 = p_sfpu::LREG3;
 
@@ -229,6 +261,7 @@ inline void binary_max_min_int32_init() {
     //   UnitDelayKind: {1,1,1,1}, (WaitForElapsedInstructions=1)
     // }
     TTI_SFPCONFIG(0xff0, 8, 1);
+#endif
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
@@ -40,6 +40,13 @@ inline void calculate_unary_max_min(uint value) {
     //  1 | ...  |                     |     |       | [a]   |
 
     load_value_param_float(value);
+#ifdef DISABLE_SFPLOADMACRO
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        calculate_unary_max_min_float_body<IS_MAX_OP>();
+        sfpi::dst_reg++;
+    }
+#else
     constexpr int offset = 0;
 
 #pragma GCC unroll 8
@@ -50,6 +57,7 @@ inline void calculate_unary_max_min(uint value) {
     }
     TTI_SFPNOP;
     TTI_SFPNOP;
+#endif
 }
 
 template <bool IS_UNSIGNED = false>
@@ -58,17 +66,17 @@ sfpi_inline void load_value_param_int(uint value) {
     sfpi::vConstIntPrgm0 = IS_UNSIGNED ^ ((int)value >= 0) ? value : ~value;
 }
 
-template <bool IS_MAX_OP>
+template <bool IS_MAX_OP, bool IS_UNSIGNED = false>
 sfpi_inline void calculate_unary_max_min_int32_body(uint value) {
     TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
 
-    if ((int)value >= 0) {
+    if (IS_UNSIGNED ^ ((int)value >= 0)) {
         // if msb(value) == 0, we can safely use SFPSWAP even though it expects sign-magnitude integers
         TTI_SFPSWAP(
             0,
             p_sfpu::LREG12,
             p_sfpu::LREG0,
-            IS_MAX_OP ? 9 : sfpi::SFPSWAP_MOD1_VEC_MIN_MAX);  // mod1=9 means set VD=max and VC=min
+            IS_MAX_OP ^ IS_UNSIGNED ? 9 : sfpi::SFPSWAP_MOD1_VEC_MIN_MAX);  // mod1=9 means set VD=max and VC=min
     } else {
         // if msb(value) == 1, we need to invert both values for SFPSWAP to work
         TTI_SFPNOT(0, p_sfpu::LREG0, p_sfpu::LREG0, 0);
@@ -76,7 +84,7 @@ sfpi_inline void calculate_unary_max_min_int32_body(uint value) {
             0,
             p_sfpu::LREG12,
             p_sfpu::LREG0,
-            IS_MAX_OP ? sfpi::SFPSWAP_MOD1_VEC_MIN_MAX : 9);  // mod1=9 means set VD=max and VC=min
+            IS_MAX_OP ^ IS_UNSIGNED ? sfpi::SFPSWAP_MOD1_VEC_MIN_MAX : 9);  // mod1=9 means set VD=max and VC=min
         TTI_SFPNOT(0, p_sfpu::LREG0, p_sfpu::LREG0, 0);
     }
     TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
@@ -86,6 +94,13 @@ template <bool IS_MAX_OP = true, bool IS_UNSIGNED = false, bool APPROXIMATION_MO
 inline void calculate_unary_max_min_int32(uint value) {
     load_value_param_int<IS_UNSIGNED>(value);
 
+#ifdef DISABLE_SFPLOADMACRO
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        calculate_unary_max_min_int32_body<IS_MAX_OP, IS_UNSIGNED>(value);
+        sfpi::dst_reg++;
+    }
+#else
     constexpr int offset = 0;
 
     if (IS_UNSIGNED ^ ((int)value < 0)) {
@@ -135,10 +150,12 @@ inline void calculate_unary_max_min_int32(uint value) {
     }
     TTI_SFPNOP;
     TTI_SFPNOP;
+#endif
 }
 
 template <bool IS_MAX_OP = true>
 inline void unary_max_min_init() {
+#ifndef DISABLE_SFPLOADMACRO
     // InstructionTemplate[0]
     TTI_SFPSWAP(
         0,
@@ -164,10 +181,12 @@ inline void unary_max_min_init() {
     //   UnitDelayKind: {1}, (WaitForElapsedInstructions=1)
     // }
     TTI_SFPCONFIG(0x110, 8, 1);
+#endif
 }
 
 template <bool IS_MAX_OP = true, bool IS_UNSIGNED = false>
 inline void unary_max_min_int32_init() {
+#ifndef DISABLE_SFPLOADMACRO
     // InstructionTemplate[0]
     TTI_SFPSWAP(
         0,
@@ -208,5 +227,6 @@ inline void unary_max_min_int32_init() {
     //   UnitDelayKind: {1,1}, (WaitForElapsedInstructions=1)
     // }
     TTI_SFPCONFIG(0x330, 8, 1);
+#endif
 }
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_max_min.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_max_min.h
@@ -20,6 +20,16 @@ inline void calculate_binary_max_min(const uint dst_index_in0, const uint dst_in
     uint offset1 = (dst_index_in1 * 32) << 1;
     uint offset2 = (dst_index_out * 32) << 1;
 
+#ifdef DISABLE_SFPLOADMACRO
+#pragma GCC unroll 0
+    for (int d = 0; d < ITERATIONS; d++) {
+        // Swap and store maximum in lreg1, minimum in lreg0
+        TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, offset0);
+        TT_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::DEFAULT, ADDR_MOD_3, offset1);
+        TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, sfpi::SFPSWAP_MOD1_VEC_MIN_MAX);
+        TT_SFPSTORE(IS_MAX_OP ? p_sfpu::LREG1 : p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_2, offset2);
+    }
+#else
     // This uses SFPLOADMACRO to achieve a throughput of 3 cycles per input row.
     //
     // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
@@ -47,6 +57,7 @@ inline void calculate_binary_max_min(const uint dst_index_in0, const uint dst_in
     TTI_SFPNOP;
     TTI_SFPNOP;
     TTI_SFPNOP;
+#endif
 }
 
 template <bool IS_MAX_OP = true, bool IS_UNSIGNED = false, int ITERATIONS = 8>
@@ -56,6 +67,23 @@ inline void calculate_binary_max_min_int32(
     uint offset1 = (dst_index_in1 * 32) << 1;
     uint offset2 = (dst_index_out * 32) << 1;
 
+#ifdef DISABLE_SFPLOADMACRO
+#pragma GCC unroll 0
+    for (int d = 0; d < ITERATIONS; d++) {
+        // Swap and store maximum in lreg1, minimum in lreg0 (or reversed if unsigned)
+        TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, offset0);
+        TT_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::INT32, ADDR_MOD_3, offset1);
+        TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, IS_UNSIGNED ? 9 : sfpi::SFPSWAP_MOD1_VEC_MIN_MAX);
+
+        // Conditionally swap again to fix the cases where SFPSWAP got the result backwards
+        TTI_SFPSETCC(0, p_sfpu::LREG0, 0, IS_UNSIGNED ? sfpi::SFPSETCC_MOD1_LREG_GTE0 : sfpi::SFPSETCC_MOD1_LREG_LT0);
+        TTI_SFPSETCC(0, p_sfpu::LREG1, 0, IS_UNSIGNED ? sfpi::SFPSETCC_MOD1_LREG_GTE0 : sfpi::SFPSETCC_MOD1_LREG_LT0);
+        TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, sfpi::SFPSWAP_MOD1_SWAP);
+        TTI_SFPENCC(0, 0, 0, 0);
+
+        TT_SFPSTORE(IS_MAX_OP ? p_sfpu::LREG1 : p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_2, offset2);
+    }
+#else
     // This uses SFPLOADMACRO to achieve a throughput of 5 cycles per input row.
     //
     // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
@@ -112,10 +140,12 @@ inline void calculate_binary_max_min_int32(
     }
 
     TTI_SFPNOP;
+#endif
 }
 
 template <bool IS_MAX_OP = true>
 inline void binary_max_min_init() {
+#ifndef DISABLE_SFPLOADMACRO
     constexpr int b = p_sfpu::LREG2;
 
     // InstructionTemplate[0]
@@ -154,10 +184,12 @@ inline void binary_max_min_init() {
     //   UnitDelayKind: {1,1}, (WaitForElapsedInstructions=1)
     // }
     TTI_SFPCONFIG(0x330, 8, 1);
+#endif
 }
 
 template <bool IS_MAX_OP = true, bool IS_UNSIGNED = false>
 inline void binary_max_min_int32_init() {
+#ifndef DISABLE_SFPLOADMACRO
     constexpr int b0 = p_sfpu::LREG1;
     constexpr int b1 = p_sfpu::LREG3;
 
@@ -229,6 +261,7 @@ inline void binary_max_min_int32_init() {
     //   UnitDelayKind: {1,1,1,1}, (WaitForElapsedInstructions=1)
     // }
     TTI_SFPCONFIG(0xff0, 8, 1);
+#endif
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
@@ -40,6 +40,13 @@ inline void calculate_unary_max_min(uint value) {
     //  1 | ...  |                     |     |       | [a]   |
 
     load_value_param_float(value);
+#ifdef DISABLE_SFPLOADMACRO
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        calculate_unary_max_min_float_body<IS_MAX_OP>();
+        sfpi::dst_reg++;
+    }
+#else
     constexpr int offset = 0;
 
 #pragma GCC unroll 8
@@ -50,6 +57,7 @@ inline void calculate_unary_max_min(uint value) {
     }
     TTI_SFPNOP;
     TTI_SFPNOP;
+#endif
 }
 
 template <bool IS_UNSIGNED = false>
@@ -58,17 +66,17 @@ sfpi_inline void load_value_param_int(uint value) {
     sfpi::vConstIntPrgm0 = IS_UNSIGNED ^ ((int)value >= 0) ? value : ~value;
 }
 
-template <bool IS_MAX_OP>
+template <bool IS_MAX_OP, bool IS_UNSIGNED = false>
 sfpi_inline void calculate_unary_max_min_int32_body(uint value) {
     TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
 
-    if ((int)value >= 0) {
+    if (IS_UNSIGNED ^ ((int)value >= 0)) {
         // if msb(value) == 0, we can safely use SFPSWAP even though it expects sign-magnitude integers
         TTI_SFPSWAP(
             0,
             p_sfpu::LREG12,
             p_sfpu::LREG0,
-            IS_MAX_OP ? 9 : sfpi::SFPSWAP_MOD1_VEC_MIN_MAX);  // mod1=9 means set VD=max and VC=min
+            IS_MAX_OP ^ IS_UNSIGNED ? 9 : sfpi::SFPSWAP_MOD1_VEC_MIN_MAX);  // mod1=9 means set VD=max and VC=min
     } else {
         // if msb(value) == 1, we need to invert both values for SFPSWAP to work
         TTI_SFPNOT(0, p_sfpu::LREG0, p_sfpu::LREG0, 0);
@@ -76,7 +84,7 @@ sfpi_inline void calculate_unary_max_min_int32_body(uint value) {
             0,
             p_sfpu::LREG12,
             p_sfpu::LREG0,
-            IS_MAX_OP ? sfpi::SFPSWAP_MOD1_VEC_MIN_MAX : 9);  // mod1=9 means set VD=max and VC=min
+            IS_MAX_OP ^ IS_UNSIGNED ? sfpi::SFPSWAP_MOD1_VEC_MIN_MAX : 9);  // mod1=9 means set VD=max and VC=min
         TTI_SFPNOT(0, p_sfpu::LREG0, p_sfpu::LREG0, 0);
     }
     TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
@@ -86,6 +94,13 @@ template <bool IS_MAX_OP = true, bool IS_UNSIGNED = false, bool APPROXIMATION_MO
 inline void calculate_unary_max_min_int32(uint value) {
     load_value_param_int<IS_UNSIGNED>(value);
 
+#ifdef DISABLE_SFPLOADMACRO
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        calculate_unary_max_min_int32_body<IS_MAX_OP, IS_UNSIGNED>(value);
+        sfpi::dst_reg++;
+    }
+#else
     constexpr int offset = 0;
 
     if (IS_UNSIGNED ^ ((int)value < 0)) {
@@ -135,10 +150,12 @@ inline void calculate_unary_max_min_int32(uint value) {
     }
     TTI_SFPNOP;
     TTI_SFPNOP;
+#endif
 }
 
 template <bool IS_MAX_OP = true>
 inline void unary_max_min_init() {
+#ifndef DISABLE_SFPLOADMACRO
     // InstructionTemplate[0]
     TTI_SFPSWAP(
         0,
@@ -164,10 +181,12 @@ inline void unary_max_min_init() {
     //   UnitDelayKind: {1}, (WaitForElapsedInstructions=1)
     // }
     TTI_SFPCONFIG(0x110, 8, 1);
+#endif
 }
 
 template <bool IS_MAX_OP = true, bool IS_UNSIGNED = false>
 inline void unary_max_min_int32_init() {
+#ifndef DISABLE_SFPLOADMACRO
     // InstructionTemplate[0]
     TTI_SFPSWAP(
         0,
@@ -208,5 +227,6 @@ inline void unary_max_min_int32_init() {
     //   UnitDelayKind: {1,1}, (WaitForElapsedInstructions=1)
     // }
     TTI_SFPCONFIG(0x330, 8, 1);
+#endif
 }
 }  // namespace ckernel::sfpu


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-llk/issues/1241

### Problem description
Min/max code paths were unconditionally using SFPLOADMACRO.

### What's changed
Add non-SFPLOADMACRO paths. Should be exactly equivalent and no effect unless DISABLE_SFPLOADMACRO set.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=mcraighead/disable-sfploadmacro-min-max)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:mcraighead/disable-sfploadmacro-min-max)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mcraighead/disable-sfploadmacro-min-max)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mcraighead/disable-sfploadmacro-min-max)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/disable-sfploadmacro-min-max)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/disable-sfploadmacro-min-max)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/disable-sfploadmacro-min-max)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/disable-sfploadmacro-min-max)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/disable-sfploadmacro-min-max)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/disable-sfploadmacro-min-max)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/disable-sfploadmacro-min-max)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/disable-sfploadmacro-min-max)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
