### PR TITLE
[Feature] Allow Configuring MetalContext instances with a given MetalEnv

### DIFF
--- a/tests/tt_metal/tt_metal/context/sources.cmake
+++ b/tests/tt_metal/tt_metal/context/sources.cmake
@@ -1,4 +1,7 @@
 # Source files for tt_metal context tests
 # Module owners should update this file when adding/removing/renaming source files
 
-set(UNIT_TESTS_CONTEXT_SMOKE_SOURCES test_metal_env_api.cpp)
+set(UNIT_TESTS_CONTEXT_SMOKE_SOURCES
+    test_metal_env_api.cpp
+    test_metal_context_api.cpp
+)

--- a/tests/tt_metal/tt_metal/context/test_metal_context_api.cpp
+++ b/tests/tt_metal/tt_metal/context/test_metal_context_api.cpp
@@ -1,0 +1,198 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <thread>
+#include <cstdlib>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "context/context_descriptor.hpp"
+#include <tt-metalium/experimental/context/metal_env.hpp>
+#include "impl/context/metal_context.hpp"
+#include "tt_cluster.hpp"
+#include "impl/device/mock_device_util.hpp"
+
+namespace tt::tt_metal {
+
+class MetalContextTest : public ::testing::Test {
+protected:
+    void TearDown() override { MetalContext::destroy_all_instances(); }
+};
+
+TEST_F(MetalContextTest, CreateSiliconInstance) {
+    MetalEnv env;
+    ContextId context_id = MetalContext::create_instance(env);
+    EXPECT_EQ(context_id, DEFAULT_CONTEXT_ID);
+}
+
+TEST_F(MetalContextTest, AccessInvalidContextId) {
+    EXPECT_THROW(MetalContext::instance(ContextId{-1}), std::runtime_error);
+    EXPECT_THROW(MetalContext::instance(ContextId{MAX_CONTEXT_COUNT}), std::runtime_error);
+}
+
+TEST_F(MetalContextTest, MultipleSiliconInstancesSameEnv) {
+    MetalEnv env;
+    ContextId context_id = MetalContext::create_instance(env);
+    EXPECT_EQ(context_id, DEFAULT_CONTEXT_ID);
+    EXPECT_THROW(MetalContext::create_instance(env), std::runtime_error);
+}
+
+TEST_F(MetalContextTest, LegacyImplicitSiliconInstance) {
+    // Implicit init to support legacy behaviour
+    auto& context = MetalContext::instance();
+    EXPECT_FALSE(context.rtoptions().get_mock_enabled());
+}
+
+TEST_F(MetalContextTest, CreateMockInstances) {
+    MetalEnv env_wh{MetalEnvDescriptor(experimental::get_mock_cluster_desc_name(tt::ARCH::WORMHOLE_B0, 1).value())};
+    ContextId context_id_wh = MetalContext::create_instance(env_wh);
+    EXPECT_EQ(context_id_wh, ContextId{1});
+
+    MetalEnv env_bh{MetalEnvDescriptor(experimental::get_mock_cluster_desc_name(tt::ARCH::BLACKHOLE, 1).value())};
+    ContextId context_id_bh = MetalContext::create_instance(env_bh);
+    EXPECT_EQ(context_id_bh, ContextId{2});
+}
+
+TEST_F(MetalContextTest, CreateSiliconInstanceWithMockInstances) {
+    MetalEnv env;
+    ContextId context_id = MetalContext::create_instance(env);
+    EXPECT_EQ(context_id, DEFAULT_CONTEXT_ID);
+
+    MetalEnv env_wh{MetalEnvDescriptor(experimental::get_mock_cluster_desc_name(tt::ARCH::WORMHOLE_B0, 1).value())};
+    ContextId context_id_wh = MetalContext::create_instance(env_wh);
+
+    MetalEnv env_bh{MetalEnvDescriptor(experimental::get_mock_cluster_desc_name(tt::ARCH::BLACKHOLE, 1).value())};
+    ContextId context_id_bh = MetalContext::create_instance(env_bh);
+
+    ASSERT_EQ(MetalContext::instance(context_id_wh).get_cluster().arch(), tt::ARCH::WORMHOLE_B0);
+    ASSERT_EQ(MetalContext::instance(context_id_bh).get_cluster().arch(), tt::ARCH::BLACKHOLE);
+}
+
+TEST_F(MetalContextTest, DestroyInstanceExplicit) {
+    // Instance should not exist after being destroyed
+    MetalEnv env_wh{MetalEnvDescriptor(experimental::get_mock_cluster_desc_name(tt::ARCH::WORMHOLE_B0, 1).value())};
+    ContextId context_id_wh = MetalContext::create_instance(env_wh);
+    ASSERT_EQ(MetalContext::instance(context_id_wh).get_cluster().arch(), tt::ARCH::WORMHOLE_B0);
+    MetalContext::destroy_instance(false, context_id_wh);
+    EXPECT_THROW(MetalContext::instance(context_id_wh), std::runtime_error);
+}
+
+TEST_F(MetalContextTest, CreateImplicitAfterDestroy) {
+    ContextId context_id;
+    {
+        MetalEnv env;
+        context_id = MetalContext::create_instance(env);
+        MetalContext::destroy_instance(false, context_id);
+    }
+    EXPECT_EQ(context_id, DEFAULT_CONTEXT_ID);
+    auto& context = MetalContext::instance(context_id);
+    EXPECT_EQ(context.rtoptions().get_mock_enabled(), false);
+}
+
+TEST_F(MetalContextTest, ThreadIsolation) {
+    ContextId mock_context_id{};
+    ContextId DEFAULT_CONTEXT_ID{};
+    bool mock_ok{false};
+    bool silicon_ok{false};
+
+    std::thread mock_thread([&]() {
+        MetalEnv env{MetalEnvDescriptor(experimental::get_mock_cluster_desc_name(tt::ARCH::WORMHOLE_B0, 1).value())};
+        ContextId id = MetalContext::create_instance(env);
+        mock_context_id = id;
+        mock_ok = MetalContext::instance(id).rtoptions().get_mock_enabled() &&
+                  MetalContext::instance(id).get_cluster().arch() == tt::ARCH::WORMHOLE_B0;
+        MetalContext::destroy_instance(false, id);
+    });
+    std::thread silicon_thread([&]() {
+        MetalEnv env;
+        ContextId id = MetalContext::create_instance(env);
+        DEFAULT_CONTEXT_ID = id;
+        silicon_ok = (id == DEFAULT_CONTEXT_ID) && !MetalContext::instance(id).rtoptions().get_mock_enabled();
+        MetalContext::destroy_instance(false, id);
+    });
+
+    mock_thread.join();
+    silicon_thread.join();
+
+    EXPECT_TRUE(mock_ok);
+    EXPECT_TRUE(silicon_ok);
+    EXPECT_EQ(DEFAULT_CONTEXT_ID, DEFAULT_CONTEXT_ID);
+    EXPECT_GE(mock_context_id, ContextId{1});
+}
+
+TEST_F(MetalContextTest, ForkIsolation) {
+    // Try to open a mock cluster on the parent process while the child process as a mock cluster open.
+    int pipe_fd[2];
+    ASSERT_EQ(pipe(pipe_fd), 0) << "pipe() failed";
+
+    pid_t pid = fork();
+    if (pid == -1) {
+        close(pipe_fd[0]);
+        close(pipe_fd[1]);
+        FAIL() << "Failed to fork";
+    }
+    if (pid == 0) {
+        close(pipe_fd[1]);
+        MetalEnv child_mock_env{
+            MetalEnvDescriptor(experimental::get_mock_cluster_desc_name(tt::ARCH::WORMHOLE_B0, 1).value())};
+        ContextId child_mock_id = MetalContext::create_instance(child_mock_env);
+        if (child_mock_id.get() < 1 || !MetalContext::instance(child_mock_id).rtoptions().get_mock_enabled()) {
+            MetalContext::destroy_all_instances(false);
+            _exit(1);
+        }
+        char byte = 0;
+        if (read(pipe_fd[0], &byte, 1) != 1) {
+            MetalContext::destroy_all_instances(false);
+            _exit(1);
+        }
+        close(pipe_fd[0]);
+        MetalContext::destroy_instance(false, child_mock_id);
+        _exit(0);
+    }
+
+    close(pipe_fd[0]);
+    MetalEnv parent_mock_env{
+        MetalEnvDescriptor(experimental::get_mock_cluster_desc_name(tt::ARCH::WORMHOLE_B0, 1).value())};
+    ContextId parent_mock_id = MetalContext::create_instance(parent_mock_env);
+    ASSERT_GT(parent_mock_id, DEFAULT_CONTEXT_ID);
+    ASSERT_TRUE(MetalContext::instance(parent_mock_id).rtoptions().get_mock_enabled());
+
+    // Signal child to exit
+    char byte = 1;
+    ASSERT_EQ(write(pipe_fd[1], &byte, 1), 1) << "write(pipe) failed";
+    close(pipe_fd[1]);
+
+    int status = 0;
+    ASSERT_EQ(waitpid(pid, &status, 0), pid);
+    ASSERT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(WEXITSTATUS(status), 0);
+
+    EXPECT_TRUE(MetalContext::instance(parent_mock_id).rtoptions().get_mock_enabled());
+    EXPECT_EQ(MetalContext::instance(parent_mock_id).get_cluster().arch(), tt::ARCH::WORMHOLE_B0);
+}
+
+TEST_F(MetalContextTest, MaxContexts) {
+    std::vector<ContextId> context_ids;
+    context_ids.reserve(MAX_CONTEXT_COUNT - 1);
+
+    auto mock_cluster_desc_path = experimental::get_mock_cluster_desc_name(tt::ARCH::WORMHOLE_B0, 1).value();
+    for (int i = 0; i < MAX_CONTEXT_COUNT - 1; ++i) {
+        MetalEnv env{MetalEnvDescriptor(mock_cluster_desc_path)};
+        context_ids.push_back(MetalContext::create_instance(env));
+    }
+    MetalEnv env{MetalEnvDescriptor(mock_cluster_desc_path)};
+    EXPECT_THROW(MetalContext::create_instance(env), std::runtime_error);
+}
+
+TEST_F(MetalContextTest, ReuseEnvAfterDestroy) {
+    auto mock_path = experimental::get_mock_cluster_desc_name(tt::ARCH::WORMHOLE_B0, 1).value();
+    MetalEnv env{MetalEnvDescriptor(mock_path)};
+    ContextId id = MetalContext::create_instance(env);
+    MetalContext::destroy_instance(false, id);
+    ContextId id2 = MetalContext::create_instance(env);
+    EXPECT_EQ(MetalContext::instance(id2).get_cluster().arch(), tt::ARCH::WORMHOLE_B0);
+}
+
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/context/test_metal_context_api.cpp
+++ b/tests/tt_metal/tt_metal/context/test_metal_context_api.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
+#include <memory>
 #include <thread>
 #include <cstdlib>
 #include <sys/wait.h>
@@ -25,6 +26,7 @@ TEST_F(MetalContextTest, CreateSiliconInstance) {
     MetalEnv env;
     ContextId context_id = MetalContext::create_instance(env);
     EXPECT_EQ(context_id, DEFAULT_CONTEXT_ID);
+    MetalContext::destroy_instance(false, context_id);
 }
 
 TEST_F(MetalContextTest, AccessInvalidContextId) {
@@ -37,6 +39,7 @@ TEST_F(MetalContextTest, MultipleSiliconInstancesSameEnv) {
     ContextId context_id = MetalContext::create_instance(env);
     EXPECT_EQ(context_id, DEFAULT_CONTEXT_ID);
     EXPECT_THROW(MetalContext::create_instance(env), std::runtime_error);
+    MetalContext::destroy_instance(false, context_id);
 }
 
 TEST_F(MetalContextTest, LegacyImplicitSiliconInstance) {
@@ -53,6 +56,9 @@ TEST_F(MetalContextTest, CreateMockInstances) {
     MetalEnv env_bh{MetalEnvDescriptor(experimental::get_mock_cluster_desc_name(tt::ARCH::BLACKHOLE, 1).value())};
     ContextId context_id_bh = MetalContext::create_instance(env_bh);
     EXPECT_EQ(context_id_bh, ContextId{2});
+
+    MetalContext::destroy_instance(false, context_id_wh);
+    MetalContext::destroy_instance(false, context_id_bh);
 }
 
 TEST_F(MetalContextTest, CreateSiliconInstanceWithMockInstances) {
@@ -68,6 +74,10 @@ TEST_F(MetalContextTest, CreateSiliconInstanceWithMockInstances) {
 
     ASSERT_EQ(MetalContext::instance(context_id_wh).get_cluster().arch(), tt::ARCH::WORMHOLE_B0);
     ASSERT_EQ(MetalContext::instance(context_id_bh).get_cluster().arch(), tt::ARCH::BLACKHOLE);
+
+    MetalContext::destroy_instance(false, context_id);
+    MetalContext::destroy_instance(false, context_id_wh);
+    MetalContext::destroy_instance(false, context_id_bh);
 }
 
 TEST_F(MetalContextTest, DestroyInstanceExplicit) {
@@ -93,7 +103,7 @@ TEST_F(MetalContextTest, CreateImplicitAfterDestroy) {
 
 TEST_F(MetalContextTest, ThreadIsolation) {
     ContextId mock_context_id{};
-    ContextId DEFAULT_CONTEXT_ID{};
+    ContextId phy_context_id{};
     bool mock_ok{false};
     bool silicon_ok{false};
 
@@ -108,7 +118,7 @@ TEST_F(MetalContextTest, ThreadIsolation) {
     std::thread silicon_thread([&]() {
         MetalEnv env;
         ContextId id = MetalContext::create_instance(env);
-        DEFAULT_CONTEXT_ID = id;
+        phy_context_id = id;
         silicon_ok = (id == DEFAULT_CONTEXT_ID) && !MetalContext::instance(id).rtoptions().get_mock_enabled();
         MetalContext::destroy_instance(false, id);
     });
@@ -118,7 +128,7 @@ TEST_F(MetalContextTest, ThreadIsolation) {
 
     EXPECT_TRUE(mock_ok);
     EXPECT_TRUE(silicon_ok);
-    EXPECT_EQ(DEFAULT_CONTEXT_ID, DEFAULT_CONTEXT_ID);
+    EXPECT_EQ(phy_context_id, DEFAULT_CONTEXT_ID);
     EXPECT_GE(mock_context_id, ContextId{1});
 }
 
@@ -171,6 +181,8 @@ TEST_F(MetalContextTest, ForkIsolation) {
 
     EXPECT_TRUE(MetalContext::instance(parent_mock_id).rtoptions().get_mock_enabled());
     EXPECT_EQ(MetalContext::instance(parent_mock_id).get_cluster().arch(), tt::ARCH::WORMHOLE_B0);
+
+    MetalContext::destroy_instance(false, parent_mock_id);
 }
 
 TEST_F(MetalContextTest, MaxContexts) {
@@ -178,12 +190,18 @@ TEST_F(MetalContextTest, MaxContexts) {
     context_ids.reserve(MAX_CONTEXT_COUNT - 1);
 
     auto mock_cluster_desc_path = experimental::get_mock_cluster_desc_name(tt::ARCH::WORMHOLE_B0, 1).value();
+    std::vector<std::unique_ptr<MetalEnv>> envs;
+    envs.reserve(MAX_CONTEXT_COUNT);
     for (int i = 0; i < MAX_CONTEXT_COUNT - 1; ++i) {
-        MetalEnv env{MetalEnvDescriptor(mock_cluster_desc_path)};
-        context_ids.push_back(MetalContext::create_instance(env));
+        envs.push_back(std::make_unique<MetalEnv>(MetalEnvDescriptor(mock_cluster_desc_path)));
+        context_ids.push_back(MetalContext::create_instance(*envs.back()));
     }
-    MetalEnv env{MetalEnvDescriptor(mock_cluster_desc_path)};
-    EXPECT_THROW(MetalContext::create_instance(env), std::runtime_error);
+    envs.push_back(std::make_unique<MetalEnv>(MetalEnvDescriptor(mock_cluster_desc_path)));
+    EXPECT_THROW(MetalContext::create_instance(*envs.back()), std::runtime_error);
+
+    for (auto id : context_ids) {
+        MetalContext::destroy_instance(false, id);
+    }
 }
 
 TEST_F(MetalContextTest, ReuseEnvAfterDestroy) {
@@ -193,6 +211,7 @@ TEST_F(MetalContextTest, ReuseEnvAfterDestroy) {
     MetalContext::destroy_instance(false, id);
     ContextId id2 = MetalContext::create_instance(env);
     EXPECT_EQ(MetalContext::instance(id2).get_cluster().arch(), tt::ARCH::WORMHOLE_B0);
+    MetalContext::destroy_instance(false, id2);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/context/test_metal_env_api.cpp
+++ b/tests/tt_metal/tt_metal/context/test_metal_env_api.cpp
@@ -15,7 +15,13 @@
 
 namespace tt::tt_metal {
 
-TEST(MetalEnv, Init) { auto env = MetalEnv(); }
+TEST(MetalEnv, Init) {
+    // If anywhere along the initialization path calls MetalContext::instance() then
+    // this will hang because we will try to create 2 umd clusters
+    // All child objects of the MetalEnv must take in dependencies (Hal, RuntimeOptions, Cluster, etc.)
+    // explicitly rather than calling MetalContext::instance() (being deprecated)
+    auto env = MetalEnv();
+}
 
 TEST(MetalEnv, Mock) {
     auto mock_path = experimental::get_mock_cluster_desc_name(tt::ARCH::WORMHOLE_B0, 1).value();

--- a/tt_metal/impl/context/context_types.hpp
+++ b/tt_metal/impl/context/context_types.hpp
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+#include <tt_stl/strong_type.hpp>
+#include <tt-metalium/device.hpp>
+
+namespace tt::tt_metal {
+
+// Due to the number of existing MetalContext instance calls in the codebase,
+// we use a ContextId for objects to access the corresponding MetalContext instance to make the
+// migration easier.
+// TODO: Remove the ContextId in favor of directly passing around the MetalContext reference.
+using ContextId = ttsl::StrongType<int, struct ContextIdTag>;
+
+// The default context is implicitly created the first time MetalContext::instance(DEFAULT_CONTEXT_ID) is called.
+constexpr ContextId DEFAULT_CONTEXT_ID = ContextId{0};
+
+// Limit the number of context IDs so they can be stored in an array
+constexpr size_t MAX_CONTEXT_COUNT = 32;
+
+// Helper function to extract the context ID from the public API device type by casting it to the concrete type
+// The IDevice does not have a get_context_id() method because Context ID is an internal concept.
+ContextId extract_context_id(IDevice* device);
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -18,7 +18,7 @@
 
 #include "metal_context.hpp"
 #include "context/metal_env_accessor.hpp"
-#include "metal_env_impl.hpp"
+#include <tt-metalium/experimental/context/metal_env.hpp>
 #include "context_descriptor.hpp"
 #include "core_coord.hpp"
 #include "device/firmware/risc_firmware_initializer.hpp"
@@ -54,7 +54,34 @@
 
 namespace tt::tt_metal {
 
+// MetalContext destructor is private, so we can't use a unique_ptr to manage the instance.
+std::array<std::atomic<MetalContext*>, MAX_CONTEXT_COUNT> g_instances{};
+std::atomic<MetalEnv*> g_default_env =
+    nullptr;  // used for implicit creation of the default context -- legacy behaviour
+std::mutex g_instance_mutex;
+bool registered_handlers = false;
+
 namespace {
+
+void check_context_id(ContextId context_id) {
+    TT_FATAL(context_id.get() >= 0, "context_id {} is invalid.", context_id);
+    TT_FATAL(
+        context_id.get() < MAX_CONTEXT_COUNT,
+        "context_id {} is out of range (max {}).",
+        context_id.get(),
+        MAX_CONTEXT_COUNT);
+}
+
+ContextId find_free_context_id_locked() {
+    // Slot 0 is reserved for the silicon context.
+    for (int index = DEFAULT_CONTEXT_ID.get() + 1; index < MAX_CONTEXT_COUNT; ++index) {
+        if (g_instances[index] == nullptr) {
+            return ContextId{index};
+        }
+    }
+    TT_THROW("Maximum MetalContext count ({}) reached.", MAX_CONTEXT_COUNT);
+}
+
 // Helper function to validate worker_l1_size, also updates it if it's 0.
 void validate_worker_l1_size(size_t& worker_l1_size, const Hal& hal) {
     if (worker_l1_size == 0) {
@@ -287,15 +314,14 @@ void MetalContext::teardown() {
     noc_debug_state_.reset();
 }
 
-// MetalContext destructor is private, so we can't use a unique_ptr to manage the instance.
-std::atomic<MetalContext*> g_instance{nullptr};
-std::mutex g_instance_mutex;
-bool registered_atexit = false;
+bool MetalContext::instance_exists(ContextId context_id) {
+    return g_instances[context_id.get()].load(std::memory_order_acquire) != nullptr;
+}
 
-bool MetalContext::instance_exists() { return g_instance.load(std::memory_order_acquire) != nullptr; }
-
-MetalContext& MetalContext::instance() {
-    MetalContext* instance = g_instance.load(std::memory_order_acquire);
+MetalContext& MetalContext::instance(ContextId context_id) {
+    check_context_id(context_id);
+    int index = context_id.get();
+    MetalContext* instance = g_instances[index].load(std::memory_order_acquire);
     if (instance) {
         // There is a potential race condition here if the instance is being torn down while this call is running or
         // while the caller is using the instance. We assume that if teardown is in progress, this call must be coming
@@ -304,26 +330,65 @@ MetalContext& MetalContext::instance() {
     }
     std::lock_guard lock(g_instance_mutex);
     // Check again in case another thread created the instance while we were waiting for the lock.
-    instance = g_instance.load(std::memory_order_acquire);
+    instance = g_instances[index].load(std::memory_order_acquire);
     if (!instance) {
-        instance = new MetalContext();
-        g_instance.store(instance, std::memory_order_release);
-        if (!registered_atexit) {
-            std::atexit([]() {
-                // Don't check device count because the destruction order is complicated and we can't guarantee that the
-                // client isn't holding onto devices on process exit.
-                MetalContext::destroy_instance(false);
-            });
-            registered_atexit = true;
-        }
+        // SILICON_CONTEXT_ID is implictly created to match legacy behaviour
+        TT_FATAL(
+            context_id == DEFAULT_CONTEXT_ID,
+            "No MetalContext instance for context_id {}. Create one via create_instance().",
+            context_id);
+        create_default_instance_implicit_locked();
+        register_handlers_locked();
+        instance = g_instances[DEFAULT_CONTEXT_ID.get()].load(std::memory_order_acquire);
     }
     return *instance;
 }
 
-void MetalContext::destroy_instance(bool check_device_count) {
+ContextId MetalContext::create_default_instance_implicit_locked() {
+    if (g_instances[DEFAULT_CONTEXT_ID.get()].load(std::memory_order_acquire) != nullptr) {
+        TT_THROW("Only one silicon MetalContext instance may exist; context_id 0 is already in use.");
+    }
+
+    MetalEnvDescriptor desc{};
+    if (auto mock_cluster_desc = experimental::get_mock_cluster_desc()) {
+        log_info(tt::LogMetal, "Using programmatically configured mock mode: {}", *mock_cluster_desc);
+        desc = MetalEnvDescriptor(*mock_cluster_desc);
+    }
+    g_default_env = new MetalEnv(std::move(desc));
+    MetalContext* instance = new MetalContext(DEFAULT_CONTEXT_ID, *g_default_env);
+    // Set the env_owned_ to true so the MetalContext destructor will delete the env_
+    instance->env_owned_ = true;
+
+    g_instances[DEFAULT_CONTEXT_ID.get()].store(instance, std::memory_order_release);
+    return DEFAULT_CONTEXT_ID;
+}
+
+ContextId MetalContext::create_instance(MetalEnv& env_to_use) {
+    std::lock_guard lock(g_instance_mutex);
+    register_handlers_locked();
+
+    // Allow only one instance connected to a silicon cluster
+    if (!MetalEnvAccessor(env_to_use).get_rtoptions().get_mock_enabled()) {
+        if (g_instances[DEFAULT_CONTEXT_ID.get()].load(std::memory_order_acquire) != nullptr) {
+            TT_THROW("Only one silicon MetalContext instance may exist; context_id 0 is already in use.");
+        }
+        MetalContext* instance = new MetalContext(DEFAULT_CONTEXT_ID, env_to_use);
+        g_instances[DEFAULT_CONTEXT_ID.get()].store(instance, std::memory_order_release);
+        return DEFAULT_CONTEXT_ID;
+    }
+
+    ContextId context_id = find_free_context_id_locked();
+    MetalContext* instance = new MetalContext(context_id, env_to_use);
+    g_instances[context_id.get()].store(instance, std::memory_order_release);
+    return context_id;
+}
+
+void MetalContext::destroy_instance(bool check_device_count, ContextId context_id) {
+    check_context_id(context_id);
     // Don't lock g_instance_mutex to avoid deadlocking with instance() calls. Teardown should only ever be called from
     // one thread while no work is being done on the MetalContext.
-    MetalContext* instance = g_instance.load(std::memory_order_acquire);
+    int index = context_id.get();
+    MetalContext* instance = g_instances[index].load(std::memory_order_acquire);
     if (!instance) {
         return;
     }
@@ -334,7 +399,24 @@ void MetalContext::destroy_instance(bool check_device_count) {
     delete instance;
     // Only store to g_instance after the instance is deleted to allow MetalContext::instance() calls during teardown to
     // return the old instance.
-    g_instance.store(nullptr, std::memory_order_release);
+    g_instances[index].store(nullptr, std::memory_order_release);
+}
+
+void MetalContext::destroy_all_instances(bool check_device_count) {
+    for (int index = 0; index < MAX_CONTEXT_COUNT; ++index) {
+        destroy_instance(check_device_count, ContextId{index});
+    }
+}
+
+void MetalContext::register_handlers_locked() {
+    if (!registered_handlers) {
+        std::atexit([]() {
+            // Don't check device count because the destruction order is complicated and we can't guarantee that the
+            // client isn't holding onto devices on process exit.
+            MetalContext::destroy_all_instances(false);
+        });
+        registered_handlers = true;
+    }
 }
 
 void MetalContext::teardown_base_objects() {
@@ -358,6 +440,7 @@ void MetalContext::teardown_dispatch_state() {
 }
 
 void MetalContext::initialize_base_objects() {
+<<<<<<< HEAD
     MetalEnvDescriptor settings;
     if (auto mock_cluster_desc = experimental::get_mock_cluster_desc()) {
         log_info(tt::LogMetal, "Using programmatically configured mock mode: {}", *mock_cluster_desc);
@@ -365,9 +448,14 @@ void MetalContext::initialize_base_objects() {
     }
     env_ = new tt::tt_metal::MetalEnv(std::move(settings));
     env_owned_ = true;
+=======
+    distributed_context_ = distributed::multihost::DistributedContext::get_current_world();
+>>>>>>> 90d32aee70 (Multiple MetalContext)
 }
 
-MetalContext::MetalContext() {
+MetalContext::MetalContext(ContextId context_id, tt::tt_metal::MetalEnv& metal_env) :
+    env_(&metal_env), context_id_(context_id) {
+    check_context_id(context_id);
     initialize_base_objects();
     device_manager_ = std::make_unique<DeviceManager>();
 }
@@ -375,7 +463,16 @@ MetalContext::MetalContext() {
 MetalContext::~MetalContext() {
     teardown();
     device_manager_.reset();
-    teardown_base_objects();
+    // Teardown in backward order of dependencies to avoid dereferencing uninitialized objects
+    system_mesh_.reset();
+    control_plane_.reset();
+    distributed_context_.reset();
+    // Destroy inspector before cluster to prevent RPC handlers from accessing destroyed cluster
+    inspector_data_.reset();
+    if (env_owned_) {
+        delete env_;
+    }
+    env_ = nullptr;
 }
 
 tt::tt_metal::MetalEnv& MetalContext::get_env() {

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -315,6 +315,7 @@ void MetalContext::teardown() {
 }
 
 bool MetalContext::instance_exists(ContextId context_id) {
+    check_context_id(context_id);
     return g_instances[context_id.get()].load(std::memory_order_acquire) != nullptr;
 }
 
@@ -332,7 +333,7 @@ MetalContext& MetalContext::instance(ContextId context_id) {
     // Check again in case another thread created the instance while we were waiting for the lock.
     instance = g_instances[index].load(std::memory_order_acquire);
     if (!instance) {
-        // SILICON_CONTEXT_ID is implictly created to match legacy behaviour
+        // SILICON_CONTEXT_ID is implicitly created to match legacy behaviour
         TT_FATAL(
             context_id == DEFAULT_CONTEXT_ID,
             "No MetalContext instance for context_id {}. Create one via create_instance().",

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -308,7 +308,7 @@ void MetalContext::teardown() {
 
     // Clear dispatch, dispatch_s and prefetcher core info in inspector data
     Inspector::clear_all_core_info();
-    // Deinitialize inspector
+    // Destroy inspector before cluster to prevent RPC handlers from accessing destroyed cluster
     inspector_data_.reset();
 
     noc_debug_state_.reset();
@@ -369,7 +369,7 @@ ContextId MetalContext::create_instance(MetalEnv& env_to_use) {
     register_handlers_locked();
 
     // Allow only one instance connected to a silicon cluster
-    if (!MetalEnvAccessor(env_to_use).get_rtoptions().get_mock_enabled()) {
+    if (!MetalEnvAccessor(env_to_use).impl().get_rtoptions().get_mock_enabled()) {
         if (g_instances[DEFAULT_CONTEXT_ID.get()].load(std::memory_order_acquire) != nullptr) {
             TT_THROW("Only one silicon MetalContext instance may exist; context_id 0 is already in use.");
         }
@@ -420,15 +420,6 @@ void MetalContext::register_handlers_locked() {
     }
 }
 
-void MetalContext::teardown_base_objects() {
-    inspector_data_.reset();
-    if (env_owned_) {
-        delete env_;
-    }
-    env_ = nullptr;
-    env_owned_ = false;
-}
-
 void MetalContext::teardown_dispatch_state() {
     for (auto& mem_map : dispatch_mem_map_) {
         if (mem_map) {
@@ -440,36 +431,15 @@ void MetalContext::teardown_dispatch_state() {
     dispatch_core_manager_.reset();
 }
 
-void MetalContext::initialize_base_objects() {
-<<<<<<< HEAD
-    MetalEnvDescriptor settings;
-    if (auto mock_cluster_desc = experimental::get_mock_cluster_desc()) {
-        log_info(tt::LogMetal, "Using programmatically configured mock mode: {}", *mock_cluster_desc);
-        settings = MetalEnvDescriptor(*mock_cluster_desc);
-    }
-    env_ = new tt::tt_metal::MetalEnv(std::move(settings));
-    env_owned_ = true;
-=======
-    distributed_context_ = distributed::multihost::DistributedContext::get_current_world();
->>>>>>> 90d32aee70 (Multiple MetalContext)
-}
-
 MetalContext::MetalContext(ContextId context_id, tt::tt_metal::MetalEnv& metal_env) :
     env_(&metal_env), context_id_(context_id) {
     check_context_id(context_id);
-    initialize_base_objects();
     device_manager_ = std::make_unique<DeviceManager>();
 }
 
 MetalContext::~MetalContext() {
     teardown();
     device_manager_.reset();
-    // Teardown in backward order of dependencies to avoid dereferencing uninitialized objects
-    system_mesh_.reset();
-    control_plane_.reset();
-    distributed_context_.reset();
-    // Destroy inspector before cluster to prevent RPC handlers from accessing destroyed cluster
-    inspector_data_.reset();
     if (env_owned_) {
         delete env_;
     }

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -192,9 +192,7 @@ private:
     // Reinitialize dispatch managers when transitioning dispatch modes (SD<->FD)
     // This updates cached dispatch/compute core allocations to match current dispatch mode
     void reinitialize_dispatch_managers();
-    void teardown_base_objects();
     void teardown_dispatch_state();
-    void initialize_base_objects();
 
     void init_context_descriptor(int num_hw_cqs, size_t l1_small_size, size_t trace_region_size, size_t worker_l1_size);
     void init_risc_fw_context_descriptor(int num_hw_cqs, size_t worker_l1_size);

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -58,7 +58,7 @@ public:
     MetalContext(MetalContext&& other) noexcept = delete;
 
     // Access the MetalContext for a given context id.
-    // The context can be created beforehand using MetalContext::create_context(). Otherwise an exception is thrown.
+    // The context can be created beforehand using MetalContext::create_instance(). Otherwise an exception is thrown.
     // NOTE: To maintain legacy behavior, the default context id is automatically created if not already initialized
     static MetalContext& instance(ContextId context_id = DEFAULT_CONTEXT_ID);
 
@@ -216,8 +216,9 @@ private:
     std::mutex dispatch_timeout_detection_mutex_;
     bool dispatch_timeout_detection_processed_ = false;
 
-    // The MetalEnv is owned by the user.
-    // For the legacy code, we initialize it in the MetalContext constructor.
+    // The MetalEnv is normally owned by the user
+    // For the legacy code, we will initialize it in the MetalContext constructor and own the env
+    // This means MetalContext will delete the env in the MetalContext destructor.
     tt::tt_metal::MetalEnv* env_;
     bool env_owned_ = false;
     ContextId context_id_;

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -13,6 +13,7 @@
 #include <umd/device/types/cluster_descriptor_types.hpp>
 #include <tt-metalium/experimental/context/metal_env.hpp>
 #include "hostdevcommon/api/hostdevcommon/common_values.hpp"
+#include "context_types.hpp"
 
 namespace tt::tt_fabric {
 class ControlPlane;
@@ -55,11 +56,23 @@ public:
     MetalContext& operator=(MetalContext&& other) noexcept = delete;
     MetalContext(const MetalContext&) = delete;
     MetalContext(MetalContext&& other) noexcept = delete;
-    static MetalContext& instance();
 
-    static void destroy_instance(bool check_device_count = true);
+    // Access the MetalContext for a given context id.
+    // The context can be created beforehand using MetalContext::create_context(). Otherwise an exception is thrown.
+    // NOTE: To maintain legacy behavior, the default context id is automatically created if not already initialized
+    static MetalContext& instance(ContextId context_id = DEFAULT_CONTEXT_ID);
 
-    static bool instance_exists();
+    // Create a MetalContext instance which will use the given MetalEnv to facilitate runtime.
+    static ContextId create_instance(MetalEnv& env_to_use);
+
+    // Destroy the MetalContext for a given context id.
+    static void destroy_instance(bool check_device_count = true, ContextId context_id = DEFAULT_CONTEXT_ID);
+
+    // Destroy all MetalContext instances.
+    static void destroy_all_instances(bool check_device_count = true);
+
+    // Check if a MetalContext for a given context id exists.
+    static bool instance_exists(ContextId context_id = DEFAULT_CONTEXT_ID);
 
     [[deprecated("Use MetalEnv instead")]] Cluster& get_cluster();
     [[deprecated("Use MetalEnv instead")]] llrt::RunTimeOptions& rtoptions();
@@ -162,9 +175,22 @@ public:
 
 private:
     friend class tt::stl::Indestructible<MetalContext>;
-    MetalContext();
+
+    // Construct MetalContext to use the given MetalEnv and assign it context id. The MetalEnv must not be
+    // destroyed while its associated MetalContext instance is alive.
+    MetalContext(ContextId context_id, tt::tt_metal::MetalEnv& metal_env);
     ~MetalContext();
 
+    // This will create a MetalContext instance and create a default MetalEnv owned by the context.
+    // Usually the MetalEnv is owned by the user, but in this case of legacy behaviour, the context will own it.
+    // Caller holds the g_instance mutex.
+    static ContextId create_default_instance_implicit_locked();
+
+    // Register handlers -- caller already holds the instance lock
+    static void register_handlers_locked();
+
+    // Reinitialize dispatch managers when transitioning dispatch modes (SD<->FD)
+    // This updates cached dispatch/compute core allocations to match current dispatch mode
     void reinitialize_dispatch_managers();
     void teardown_base_objects();
     void teardown_dispatch_state();
@@ -194,6 +220,7 @@ private:
     // For the legacy code, we initialize it in the MetalContext constructor.
     tt::tt_metal::MetalEnv* env_;
     bool env_owned_ = false;
+    ContextId context_id_;
 
     std::unique_ptr<dispatch_core_manager> dispatch_core_manager_;
     std::unique_ptr<DispatchQueryManager> dispatch_query_manager_;

--- a/tt_metal/impl/context/metal_env.cpp
+++ b/tt_metal/impl/context/metal_env.cpp
@@ -121,6 +121,7 @@ void MetalEnvImpl::initialize_base_objects() {
     this->rtoptions_ = std::make_unique<llrt::RunTimeOptions>();
 
     if (descriptor_.is_mock_device()) {
+        log_info(tt::LogMetal, "Using programmatically configured mock mode: {}", descriptor_.mock_cluster_desc_path());
         this->rtoptions_->set_mock_cluster_desc(std::string(descriptor_.mock_cluster_desc_path()));
     }
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/33849

### Problem description
- MetalContext refactoring to support mock device open at the same time as silicon device
- Want to eventually be explicitly passing MetalContext/MetalEnv references into functions that need it in favor of them calling MetalContext::instance().
- As a temp workaround, we can have multiple MetalContext instances managed in the singleton.

### What's changed
- Update MetalContext to be able to track multiple instances through explicit `create_instance` and `destroy_instance` APIs. The `create_instance()` function accepts a MetalEnv (HAL/Cluster) which the MetalContext will be bound to and used by the runtime to interact with the cluster.  It returns a ContextID which is passed into the child objects that call MetalContext::instance(id).

- When the application exits, all instances still active are destroyed through a `std::atexit` handler.

- Added `tests/tt_metal/tt_metal/context/test_metal_context_api.cpp`

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=nhuang/metal-object-5)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:nhuang/metal-object-5)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nhuang/metal-object-5)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nhuang/metal-object-5)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nhuang/metal-object-5)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nhuang/metal-object-5)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early

Sanity Tests
https://github.com/tenstorrent/tt-metal/actions/runs/22979321695

Merge Gate
https://github.com/tenstorrent/tt-metal/actions/runs/22977448955

WH Galaxy Quick
https://github.com/tenstorrent/tt-metal/actions/runs/22977437401

BH Galaxy Quick
https://github.com/tenstorrent/tt-metal/actions/runs/23009772371

Galaxy Deepseek Tests
https://github.com/tenstorrent/tt-metal/actions/runs/23011899806

Galaxy demo tests
https://github.com/tenstorrent/tt-metal/actions/runs/23011893511

#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nhuang/metal-object-5)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nhuang/metal-object-5)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nhuang/metal-object-5)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nhuang/metal-object-5)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nhuang/metal-object-5)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nhuang/metal-object-5)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
