### PR TITLE
Make large-tensor softmax use CB sizes that are multiples of block size

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/test_softmax.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_softmax.py
@@ -486,6 +486,39 @@ def test_softmax_accuracy(device, shape, fp32_acc_en, math_approx_mode, expected
     assert_with_ulp(torch_output, output_torch, expected_ulp)
 
 
+@pytest.mark.parametrize(
+    "Wt",
+    [
+        193,  # block_size=1
+        194,  # block_size=2
+        195,  # block_size=3
+        196,  # block_size=4
+    ],
+)
+def test_softmax_large_kernel_block_size(device, Wt):
+    """Large tensors trigger a large-kernel code path that caps CB sizes.
+    The capped size must be rounded to a multiple of block_size.
+    Regression test for block_size values that do not evenly divide 80.
+    """
+    torch.manual_seed(0)
+
+    W = Wt * 32
+    shape = (1, 1, 32, W)
+    torch_input = torch.randn(shape, dtype=torch.bfloat16)
+    torch_output = F.softmax(torch_input, dim=-1, dtype=torch.bfloat16)
+
+    compute_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        fp32_dest_acc_en=True,
+    )
+
+    ttnn_input = ttnn.from_torch(torch_input, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn_output = ttnn.softmax(ttnn_input, dim=-1, compute_kernel_config=compute_config, numeric_stable=True)
+    ttnn_output = ttnn.to_torch(ttnn_output)
+
+    assert_with_pcc(torch_output, ttnn_output, 0.997)
+
+
 def test_softmax_4096x4096_fp32(device):
     if is_watcher_enabled():
         pytest.skip("Skipping test with watcher enabled, see #37269")

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_attention_optimized.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_attention_optimized.cpp
@@ -110,11 +110,12 @@ SoftmaxProgramFactoryAttentionOptimized::cached_program_t SoftmaxProgramFactoryA
     // Program specific checks
     if ((tensor_args.input_tensor.device()->l1_size_per_core() * 0.9) < cb_size_sum_bytes) {
         use_large_kernel = true;
-        cb_length = 80;
-        in0_t = 80;
-        im4_t = 80;
-        im0_t = 80;
-        im3_t = 80;
+        uint32_t large_kernel_cb_size = (80 / block_size) * block_size;
+        cb_length = large_kernel_cb_size;
+        in0_t = large_kernel_cb_size;
+        im4_t = large_kernel_cb_size;
+        im0_t = large_kernel_cb_size;
+        im3_t = large_kernel_cb_size;
         TT_FATAL(!attributes.inplace, "Tensor is too large to run softmax inplace, please use standard softmax");
     }
     if (!use_large_kernel) {
@@ -418,11 +419,12 @@ void SoftmaxProgramFactoryAttentionOptimized::override_runtime_arguments(
 
     if (use_large_kernel) {
         // Use fixed sizes matching create() for large kernel
-        in0_t = 80;
+        uint32_t large_kernel_cb_size = (80 / block_size) * block_size;
+        in0_t = large_kernel_cb_size;
         out0_t = block_size * 2;
-        im0_t = 80;
-        im3_t = 80;
-        im4_t = 80;
+        im0_t = large_kernel_cb_size;
+        im3_t = large_kernel_cb_size;
+        im4_t = large_kernel_cb_size;
     } else {
         // Standard calculation for regular kernel
         in0_t = attributes.numeric_stable ? tt::div_up(Wt, block_size) * block_size : block_size * 2;


### PR DESCRIPTION
### Ticket
[38626
](https://github.com/tenstorrent/tt-metal/issues/38626)

### Problem description
Large-tensor softmax uses a hardcoded value of 80 tiles to size its CBs (chosen to maximize buffer size while staying in L1). However, not all block sizes (computed from `find_max_divisor()`) will evenly divide into 80, which will trigger asserts.

### What's changed
Instead of always using 80 for large-tensor softmax, use the largest multiple of the block size that is less than or equal to 80:

`uint32_t large_kernel_cb_size = (80 / block_size) * block_size;`

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=rmillerTT/38626_softmax_block_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:rmillerTT/38626_softmax_block_size)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=rmillerTT/38626_softmax_block_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:rmillerTT/38626_softmax_block_size)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rmillerTT/38626_softmax_block_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rmillerTT/38626_softmax_block_size)
- [x] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rmillerTT/38626_softmax_block_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rmillerTT/38626_softmax_block_size)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rmillerTT/38626_softmax_block_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rmillerTT/38626_softmax_block_size)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rmillerTT/38626_softmax_block_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rmillerTT/38626_softmax_block_size)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
