### PR TITLE
tt-train: Replace core/ttnn_all_includes.hpp with specific headers in .cpp files

### DIFF
--- a/tt-train/sources/examples/graph_capture/main.cpp
+++ b/tt-train/sources/examples/graph_capture/main.cpp
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <core/ttnn_all_includes.hpp>
 #include <fstream>
 
 #include "autograd/auto_context.hpp"

--- a/tt-train/sources/examples/linear_regression/main.cpp
+++ b/tt-train/sources/examples/linear_regression/main.cpp
@@ -4,7 +4,6 @@
 
 #include <fmt/format.h>
 
-#include <core/ttnn_all_includes.hpp>
 #include <ttnn/tensor/tensor.hpp>
 
 #include "autograd/auto_context.hpp"

--- a/tt-train/sources/examples/linear_regression_ddp/main.cpp
+++ b/tt-train/sources/examples/linear_regression_ddp/main.cpp
@@ -5,7 +5,6 @@
 #include <fmt/format.h>
 
 #include <CLI/CLI.hpp>
-#include <core/ttnn_all_includes.hpp>
 #include <cstdlib>
 #include <string>
 
@@ -20,6 +19,7 @@
 #include "modules/linear_module.hpp"
 #include "ops/losses.hpp"
 #include "optimizers/sgd.hpp"
+#include "ttnn/distributed/distributed_tensor.hpp"
 #include "ttnn_fixed/distributed/tt_metal.hpp"
 
 using ttml::autograd::TensorPtr;

--- a/tt-train/sources/examples/linear_regression_tp_dp/main.cpp
+++ b/tt-train/sources/examples/linear_regression_tp_dp/main.cpp
@@ -5,7 +5,6 @@
 #include <fmt/format.h>
 
 #include <CLI/CLI.hpp>
-#include <core/ttnn_all_includes.hpp>
 #include <string>
 
 #include "autograd/auto_context.hpp"
@@ -19,6 +18,7 @@
 #include "modules/distributed/linear.hpp"
 #include "ops/losses.hpp"
 #include "optimizers/sgd.hpp"
+#include "ttnn/distributed/distributed_tensor.hpp"
 #include "ttnn_fixed/distributed/tt_metal.hpp"
 
 using ttml::autograd::TensorPtr;

--- a/tt-train/sources/examples/mnist_mlp/main.cpp
+++ b/tt-train/sources/examples/mnist_mlp/main.cpp
@@ -6,7 +6,6 @@
 
 #include <CLI/CLI.hpp>
 #include <chrono>
-#include <core/ttnn_all_includes.hpp>
 #include <cstdint>
 #include <functional>
 #include <memory>

--- a/tt-train/sources/examples/nano_gpt/llama_inference.cpp
+++ b/tt-train/sources/examples/nano_gpt/llama_inference.cpp
@@ -4,7 +4,6 @@
 
 #include <CLI/CLI.hpp>
 #include <chrono>
-#include <core/ttnn_all_includes.hpp>
 #include <cstdint>
 #include <vector>
 
@@ -13,6 +12,7 @@
 #include "core/tt_tensor_utils.hpp"
 #include "models/common/transformer_common.hpp"
 #include "models/llama.hpp"
+#include "ttnn/distributed/types.hpp"
 #include "utils.hpp"
 
 using ttml::autograd::TensorPtr;

--- a/tt-train/sources/examples/nano_gpt/main.cpp
+++ b/tt-train/sources/examples/nano_gpt/main.cpp
@@ -4,7 +4,6 @@
 
 #include <CLI/CLI.hpp>
 #include <chrono>
-#include <core/ttnn_all_includes.hpp>
 #include <csignal>
 #include <cstdint>
 #include <tt-metalium/experimental/fabric/fabric.hpp>
@@ -30,6 +29,8 @@
 #include "optimizers/no_op.hpp"
 #include "optimizers/remote_optimizer.hpp"
 #include "tokenizers/char_tokenizer.hpp"
+#include "ttnn/distributed/create_socket.hpp"
+#include "ttnn/distributed/distributed_tensor.hpp"
 #include "ttnn_fixed/distributed/tt_metal.hpp"
 #include "ttnn_fixed/trivial_ttnn_ops.hpp"
 #include "utils.hpp"

--- a/tt-train/sources/examples/sample_app/main.cpp
+++ b/tt-train/sources/examples/sample_app/main.cpp
@@ -2,10 +2,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <core/ttnn_all_includes.hpp>
 #include <iostream>
 
+#include "tt-metalium/bfloat16.hpp"
+#include "tt-metalium/host_api.hpp"
 #include "ttml.hpp"
+#include "ttnn/operations/eltwise/unary/unary.hpp"
+#include "ttnn/tensor/host_buffer/functions.hpp"
+#include "ttnn/tensor/tensor.hpp"
 
 std::shared_ptr<tt::tt_metal::distributed::MeshDevice> device;
 

--- a/tt-train/sources/ttml/core/clip_grad_norm.cpp
+++ b/tt-train/sources/ttml/core/clip_grad_norm.cpp
@@ -4,10 +4,10 @@
 
 #include "core/clip_grad_norm.hpp"
 
-#include <core/ttnn_all_includes.hpp>
-
 #include "core/compute_kernel_config.hpp"
 #include "serialization/serializable.hpp"
+#include "ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm.hpp"
+#include "ttnn/tensor/tensor.hpp"
 
 namespace ttml::core {
 

--- a/tt-train/sources/ttml/core/device.cpp
+++ b/tt-train/sources/ttml/core/device.cpp
@@ -4,7 +4,7 @@
 
 #include "device.hpp"
 
-#include <core/ttnn_all_includes.hpp>
+#include "tt-metalium/device.hpp"
 
 namespace ttml::core {
 

--- a/tt-train/sources/ttml/core/distributed/distributed.cpp
+++ b/tt-train/sources/ttml/core/distributed/distributed.cpp
@@ -4,12 +4,13 @@
 
 #include "core/distributed/distributed.hpp"
 
-#include <core/ttnn_all_includes.hpp>
 #include <ttnn/operations/creation.hpp>
 #include <ttnn/operations/eltwise/binary/binary.hpp>
 
 #include "autograd/auto_context.hpp"
 #include "core/tt_tensor_utils.hpp"
+#include "ttnn/operations/ccl/all_reduce/all_reduce.hpp"
+#include "ttnn/tensor/tensor.hpp"
 #include "ttnn_fixed/distributed/ttnn_ops.hpp"
 
 namespace ttml::core::distributed {

--- a/tt-train/sources/ttml/core/mesh_device.cpp
+++ b/tt-train/sources/ttml/core/mesh_device.cpp
@@ -4,7 +4,9 @@
 
 #include "mesh_device.hpp"
 
-#include <core/ttnn_all_includes.hpp>
+#include "hostdevcommon/common_values.hpp"
+#include "ttnn/distributed/api.hpp"
+#include "ttnn/distributed/types.hpp"
 
 namespace ttml::core {
 

--- a/tt-train/sources/ttml/metal/ops/layernorm_fw/device/layernorm_fw_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/layernorm_fw/device/layernorm_fw_program_factory.cpp
@@ -5,10 +5,11 @@
 #include "layernorm_fw_program_factory.hpp"
 
 #include <cstdint>
-#include <metal/ttnn_all_includes.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 
 #include "metal/common/program_utils.hpp"
+#include "tt-metalium/device.hpp"
+#include "tt-metalium/host_api.hpp"
 
 namespace {
 

--- a/tt-train/sources/ttml/metal/ops/layernorm_fw/layernorm_fw.cpp
+++ b/tt-train/sources/ttml/metal/ops/layernorm_fw/layernorm_fw.cpp
@@ -4,10 +4,9 @@
 
 #include "layernorm_fw.hpp"
 
-#include <core/ttnn_all_includes.hpp>
-
 #include "core/compute_kernel_config.hpp"
 #include "device/layernorm_fw_device_operation.hpp"
+#include "ttnn/tensor/tensor.hpp"
 
 namespace ttml::metal {
 

--- a/tt-train/sources/ttml/metal/ops/profiler_no_op/device/profiler_no_op_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/profiler_no_op/device/profiler_no_op_program_factory.cpp
@@ -4,12 +4,13 @@
 
 #include "profiler_no_op_program_factory.hpp"
 
-#include <core/ttnn_all_includes.hpp>
 #include <enchantum/enchantum.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 
 #include "metal/common/program_utils.hpp"
 #include "profiler_no_op_device_operation_types.hpp"
+#include "tt-metalium/host_api.hpp"
+#include "ttnn/types.hpp"
 
 namespace {
 

--- a/tt-train/sources/ttml/modules/embedding_module.cpp
+++ b/tt-train/sources/ttml/modules/embedding_module.cpp
@@ -4,7 +4,6 @@
 
 #include "embedding_module.hpp"
 
-#include <core/ttnn_all_includes.hpp>
 #include <stdexcept>
 
 #include "autograd/auto_context.hpp"

--- a/tt-train/sources/ttml/modules/grouped_query_attention.cpp
+++ b/tt-train/sources/ttml/modules/grouped_query_attention.cpp
@@ -4,14 +4,13 @@
 
 #include "grouped_query_attention.hpp"
 
-#include <core/ttnn_all_includes.hpp>
-
 #include "autograd/auto_context.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "dropout_module.hpp"
 #include "linear_module.hpp"
 #include "ops/multi_head_utils.hpp"
 #include "ops/scaled_dot_product_attention.hpp"
+#include "ttnn/operations/data_movement/slice/slice.hpp"
 
 namespace ttml::modules {
 

--- a/tt-train/sources/ttml/modules/linear_module.cpp
+++ b/tt-train/sources/ttml/modules/linear_module.cpp
@@ -5,7 +5,6 @@
 #include "linear_module.hpp"
 
 #include <cmath>
-#include <core/ttnn_all_includes.hpp>
 
 #include "autograd/auto_context.hpp"
 #include "autograd/tensor.hpp"

--- a/tt-train/sources/ttml/modules/lora_linear_module.cpp
+++ b/tt-train/sources/ttml/modules/lora_linear_module.cpp
@@ -5,7 +5,6 @@
 #include "lora_linear_module.hpp"
 
 #include <cmath>
-#include <core/ttnn_all_includes.hpp>
 
 #include "autograd/auto_context.hpp"
 #include "autograd/tensor.hpp"

--- a/tt-train/sources/ttml/nanobind/__init__.cpp
+++ b/tt-train/sources/ttml/nanobind/__init__.cpp
@@ -9,7 +9,6 @@
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
 
-#include "core/ttnn_all_includes.hpp"
 #include "serialization/serializable.hpp"
 
 // Make NamedParameters opaque so we can bind it explicitly

--- a/tt-train/sources/ttml/nanobind/nb_autograd.cpp
+++ b/tt-train/sources/ttml/nanobind/nb_autograd.cpp
@@ -13,7 +13,6 @@
 #include <nanobind/stl/unique_ptr.h>
 #include <nanobind/stl/vector.h>
 
-#include <core/ttnn_all_includes.hpp>
 #include <ttnn/tensor/layout/layout.hpp>
 #include <ttnn/tensor/types.hpp>
 
@@ -24,6 +23,9 @@
 #include "nanobind/nb_export_enum.hpp"
 #include "nanobind/nb_util.hpp"
 #include "ops/binary_ops.hpp"
+#include "tt-metalium/distributed_context.hpp"
+#include "ttnn/distributed/distributed_tensor.hpp"
+#include "ttnn/tensor/tensor.hpp"
 
 namespace ttml::nanobind::autograd {
 using namespace ttml::autograd;

--- a/tt-train/sources/ttml/nanobind/nb_core.cpp
+++ b/tt-train/sources/ttml/nanobind/nb_core.cpp
@@ -18,13 +18,17 @@
 
 #include "nanobind/nb_export_enum.hpp"
 #include "serialization/serializable.hpp"
+#include "tt-metalium/distributed_context.hpp"
+#include "ttnn/distributed/create_socket.hpp"
+#include "ttnn/distributed/types.hpp"
+#include "ttnn/operations/creation.hpp"
+#include "ttnn/operations/full_like/full_like.hpp"
+#include "ttnn/tensor/tensor.hpp"
 
 // Make NamedParameters opaque - must be before unordered_map include
 NB_MAKE_OPAQUE(ttml::serialization::NamedParameters)
 
 #include <nanobind/stl/unordered_map.h>
-
-#include <core/ttnn_all_includes.hpp>
 
 #include "autograd/tensor.hpp"
 #include "core/clip_grad_norm.hpp"

--- a/tt-train/sources/ttml/nanobind/nb_modules.cpp
+++ b/tt-train/sources/ttml/nanobind/nb_modules.cpp
@@ -12,8 +12,6 @@
 #include <nanobind/stl/vector.h>
 #include <nanobind/trampoline.h>
 
-#include <core/ttnn_all_includes.hpp>
-
 #include "autograd/autocast_tensor.hpp"
 #include "autograd/tensor.hpp"
 #include "modules/grouped_query_attention.hpp"

--- a/tt-train/sources/ttml/ops/binary_ops.cpp
+++ b/tt-train/sources/ttml/ops/binary_ops.cpp
@@ -4,7 +4,6 @@
 
 #include "binary_ops.hpp"
 
-#include <core/ttnn_all_includes.hpp>
 #include <memory>
 #include <ttnn/operations/eltwise/binary/binary.hpp>
 #include <ttnn/operations/eltwise/binary_backward/binary_backward.hpp>
@@ -19,6 +18,8 @@
 #include "autograd/tensor.hpp"
 #include "core/compute_kernel_config.hpp"
 #include "core/tt_tensor_utils.hpp"
+#include "ttnn/operations/eltwise/unary/unary.hpp"
+#include "ttnn/operations/moreh/moreh_sum/moreh_sum.hpp"
 #include "ttnn_fixed/trivial_ttnn_ops.hpp"
 
 namespace ttml::ops {

--- a/tt-train/sources/ttml/ops/distributed/comm_ops.cpp
+++ b/tt-train/sources/ttml/ops/distributed/comm_ops.cpp
@@ -4,11 +4,10 @@
 
 #include "comm_ops.hpp"
 
-#include <core/ttnn_all_includes.hpp>
-
 #include "autograd/auto_context.hpp"
 #include "autograd/graph.hpp"
 #include "autograd/graph_utils.hpp"
+#include "ttnn/operations/eltwise/binary/binary.hpp"
 #include "ttnn_fixed/distributed/ttnn_ops.hpp"
 
 namespace ttml::ops::distributed {

--- a/tt-train/sources/ttml/ops/distributed/ring_attention_sdpa.cpp
+++ b/tt-train/sources/ttml/ops/distributed/ring_attention_sdpa.cpp
@@ -6,7 +6,6 @@
 
 #include <fmt/core.h>
 
-#include <core/ttnn_all_includes.hpp>
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/hal.hpp>
 #include <umd/device/cluster.hpp>
@@ -22,7 +21,16 @@
 #include "ops/binary_ops.hpp"
 #include "ops/distributed/comm_ops.hpp"
 #include "ops/scaled_dot_product_attention.hpp"
+#include "ttnn/operations/creation.hpp"
+#include "ttnn/operations/data_movement/concat/concat.hpp"
+#include "ttnn/operations/data_movement/copy/copy.hpp"
+#include "ttnn/operations/data_movement/pad/pad.hpp"
+#include "ttnn/operations/data_movement/slice/slice.hpp"
+#include "ttnn/operations/eltwise/binary/binary.hpp"
 #include "ttnn/operations/eltwise/binary/binary_composite.hpp"
+#include "ttnn/operations/eltwise/unary/unary.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/types.hpp"
 #include "ttnn_fixed/distributed/tt_metal.hpp"
 #include "ttnn_fixed/distributed/ttnn_ops.hpp"
 

--- a/tt-train/sources/ttml/ops/dropout_op.cpp
+++ b/tt-train/sources/ttml/ops/dropout_op.cpp
@@ -4,7 +4,6 @@
 
 #include "dropout_op.hpp"
 
-#include <core/ttnn_all_includes.hpp>
 #include <ttnn/operations/eltwise/binary/binary.hpp>
 #include <ttnn/operations/eltwise/unary/unary.hpp>
 
@@ -12,6 +11,7 @@
 #include "autograd/graph.hpp"
 #include "autograd/graph_utils.hpp"
 #include "core/tt_tensor_utils.hpp"
+#include "ttnn/operations/experimental/dropout/dropout.hpp"
 
 namespace ttml::ops {
 

--- a/tt-train/sources/ttml/ops/embedding_op.cpp
+++ b/tt-train/sources/ttml/ops/embedding_op.cpp
@@ -4,11 +4,12 @@
 
 #include "embedding_op.hpp"
 
-#include <core/ttnn_all_includes.hpp>
-
 #include "autograd/auto_context.hpp"
 #include "autograd/graph_utils.hpp"
 #include "core/tt_tensor_utils.hpp"
+#include "ttnn/operations/data_movement/untilize/untilize.hpp"
+#include "ttnn/operations/embedding/embedding.hpp"
+#include "ttnn/operations/embedding_backward/embedding_backward.hpp"
 
 namespace ttml::ops {
 

--- a/tt-train/sources/ttml/ops/layernorm_op.cpp
+++ b/tt-train/sources/ttml/ops/layernorm_op.cpp
@@ -4,7 +4,6 @@
 
 #include "layernorm_op.hpp"
 
-#include <core/ttnn_all_includes.hpp>
 #include <cstdint>
 #include <optional>
 
@@ -15,6 +14,13 @@
 #include "core/compute_kernel_config.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "metal/operations.hpp"
+#include "ttnn/operations/creation.hpp"
+#include "ttnn/operations/eltwise/binary/binary.hpp"
+#include "ttnn/operations/eltwise/unary/unary.hpp"
+#include "ttnn/operations/moreh/moreh_layer_norm/moreh_layer_norm.hpp"
+#include "ttnn/operations/moreh/moreh_layer_norm_backward/moreh_layer_norm_backward.hpp"
+#include "ttnn/operations/moreh/moreh_mean/moreh_mean.hpp"
+#include "ttnn/operations/moreh/moreh_sum/moreh_sum.hpp"
 
 namespace ttml::ops {
 

--- a/tt-train/sources/ttml/ops/linear_op.cpp
+++ b/tt-train/sources/ttml/ops/linear_op.cpp
@@ -4,11 +4,13 @@
 
 #include "linear_op.hpp"
 
-#include <core/ttnn_all_includes.hpp>
-
 #include "autograd/auto_context.hpp"
 #include "autograd/graph_utils.hpp"
 #include "core/compute_kernel_config.hpp"
+#include "ttnn/operations/creation.hpp"
+#include "ttnn/operations/matmul/matmul.hpp"
+#include "ttnn/operations/moreh/moreh_linear_backward/moreh_linear_backward.hpp"
+#include "ttnn/types.hpp"
 #include "ttnn_fixed/matmuls.hpp"
 #include "ttnn_fixed/trivial_ttnn_ops.hpp"
 

--- a/tt-train/sources/ttml/ops/losses.cpp
+++ b/tt-train/sources/ttml/ops/losses.cpp
@@ -4,7 +4,6 @@
 
 #include "losses.hpp"
 
-#include <core/ttnn_all_includes.hpp>
 #include <stdexcept>
 #include <ttnn/types.hpp>
 
@@ -15,6 +14,9 @@
 #include "metal/operations.hpp"
 #include "ops/binary_ops.hpp"
 #include "ops/unary_ops.hpp"
+#include "ttnn/operations/moreh/moreh_mean/moreh_mean.hpp"
+#include "ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss.hpp"
+#include "ttnn/operations/moreh/moreh_nll_loss_backward/moreh_nll_loss_backward.hpp"
 #include "ttnn_fixed/trivial_ttnn_ops.hpp"
 
 namespace ttml::ops {

--- a/tt-train/sources/ttml/ops/multi_head_utils.cpp
+++ b/tt-train/sources/ttml/ops/multi_head_utils.cpp
@@ -4,12 +4,15 @@
 
 #include "multi_head_utils.hpp"
 
-#include <core/ttnn_all_includes.hpp>
-
 #include "autograd/auto_context.hpp"
 #include "autograd/graph.hpp"
 #include "autograd/graph_utils.hpp"
 #include "core/tt_tensor_utils.hpp"
+#include "ttnn/operations/data_movement/concat/concat.hpp"
+#include "ttnn/operations/data_movement/transpose/transpose.hpp"
+#include "ttnn/operations/experimental/transformer/nlp_concat_heads/nlp_concat_heads.hpp"
+#include "ttnn/operations/experimental/transformer/nlp_create_qkv_heads/nlp_create_qkv_heads.hpp"
+#include "ttnn/tensor/tensor.hpp"
 
 namespace ttml::ops {
 

--- a/tt-train/sources/ttml/ops/reshape_op.cpp
+++ b/tt-train/sources/ttml/ops/reshape_op.cpp
@@ -4,8 +4,6 @@
 
 #include "reshape_op.hpp"
 
-#include <core/ttnn_all_includes.hpp>
-
 #include "autograd/auto_context.hpp"
 #include "autograd/graph_utils.hpp"
 #include "autograd/tensor.hpp"

--- a/tt-train/sources/ttml/ops/rmsnorm_op.cpp
+++ b/tt-train/sources/ttml/ops/rmsnorm_op.cpp
@@ -5,7 +5,6 @@
 #include "rmsnorm_op.hpp"
 
 #include <cassert>
-#include <core/ttnn_all_includes.hpp>
 #include <cstdint>
 #include <optional>
 #include <stdexcept>
@@ -16,6 +15,10 @@
 #include "autograd/tensor.hpp"
 #include "core/compute_kernel_config.hpp"
 #include "metal/operations.hpp"
+#include "ttnn/operations/eltwise/binary/binary.hpp"
+#include "ttnn/operations/eltwise/unary/unary.hpp"
+#include "ttnn/operations/reduction/generic/generic_reductions.hpp"
+#include "ttnn/tensor/tensor.hpp"
 #include "ttnn_fixed/trivial_ttnn_ops.hpp"
 
 namespace ttml::ops {

--- a/tt-train/sources/ttml/ops/rope_op.cpp
+++ b/tt-train/sources/ttml/ops/rope_op.cpp
@@ -4,7 +4,6 @@
 
 #include "ops/rope_op.hpp"
 
-#include <core/ttnn_all_includes.hpp>
 #include <numbers>
 
 #include "autograd/auto_context.hpp"
@@ -13,6 +12,11 @@
 #include "autograd/tensor.hpp"
 #include "core/compute_kernel_config.hpp"
 #include "core/tt_tensor_utils.hpp"
+#include "ttnn/distributed/distributed_tensor.hpp"
+#include "ttnn/operations/data_movement/slice/slice.hpp"
+#include "ttnn/operations/eltwise/unary/unary.hpp"
+#include "ttnn/operations/experimental/transformer/rotary_embedding_llama/rotary_embedding_llama.hpp"
+#include "ttnn/types.hpp"
 
 namespace ttml::ops {
 

--- a/tt-train/sources/ttml/ops/swiglu_op.cpp
+++ b/tt-train/sources/ttml/ops/swiglu_op.cpp
@@ -4,7 +4,6 @@
 
 #include "swiglu_op.hpp"
 
-#include <core/ttnn_all_includes.hpp>
 #include <ttnn/operations/eltwise/binary/binary.hpp>
 
 #include "autograd/auto_context.hpp"
@@ -13,6 +12,10 @@
 #include "metal/operations.hpp"
 #include "ops/binary_ops.hpp"
 #include "ops/unary_ops.hpp"
+#include "ttnn/operations/creation.hpp"
+#include "ttnn/operations/eltwise/unary/unary.hpp"
+#include "ttnn/operations/reduction/generic/generic_reductions.hpp"
+#include "ttnn/tensor/tensor.hpp"
 #include "ttnn_fixed/matmuls.hpp"
 
 namespace ttml::ops {

--- a/tt-train/sources/ttml/ops/unary_ops.cpp
+++ b/tt-train/sources/ttml/ops/unary_ops.cpp
@@ -5,7 +5,6 @@
 #include "ops/unary_ops.hpp"
 
 #include <array>
-#include <core/ttnn_all_includes.hpp>
 #include <optional>
 
 #include "autograd/auto_context.hpp"
@@ -15,6 +14,16 @@
 #include "core/compute_kernel_config.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "metal/operations.hpp"
+#include "ttnn/operations/data_movement/repeat/repeat.hpp"
+#include "ttnn/operations/eltwise/binary/binary.hpp"
+#include "ttnn/operations/eltwise/unary/unary.hpp"
+#include "ttnn/operations/eltwise/unary_backward/unary_backward.hpp"
+#include "ttnn/operations/experimental/unary_backward/gelu_backward/gelu_backward.hpp"
+#include "ttnn/operations/moreh/moreh_mean/moreh_mean.hpp"
+#include "ttnn/operations/moreh/moreh_mean_backward/moreh_mean_backward.hpp"
+#include "ttnn/operations/moreh/moreh_softmax/moreh_softmax.hpp"
+#include "ttnn/operations/moreh/moreh_softmax_backward/moreh_softmax_backward.hpp"
+#include "ttnn/tensor/tensor.hpp"
 #include "ttnn_fixed/trivial_ttnn_ops.hpp"
 
 namespace ttml::ops {

--- a/tt-train/sources/ttml/serialization/serialization.cpp
+++ b/tt-train/sources/ttml/serialization/serialization.cpp
@@ -4,7 +4,6 @@
 
 #include "serialization.hpp"
 
-#include <core/ttnn_all_includes.hpp>
 #include <cstdint>
 #include <enchantum/enchantum.hpp>
 #include <filesystem>
@@ -19,6 +18,7 @@
 #include "optimizers/optimizer_base.hpp"
 #include "optimizers/sgd.hpp"
 #include "ttnn/tensor/serialization.hpp"
+#include "ttnn/tensor/tensor.hpp"
 
 namespace ttml::serialization {
 

--- a/tt-train/sources/ttml/ttnn_fixed/distributed/tt_metal.cpp
+++ b/tt-train/sources/ttml/ttnn_fixed/distributed/tt_metal.cpp
@@ -6,12 +6,13 @@
 
 #include <fmt/core.h>
 
-#include <core/ttnn_all_includes.hpp>
 #include <cstdlib>
 #include <filesystem>
 #include <stdexcept>
 #include <string>
 #include <tt-metalium/experimental/fabric/mesh_graph_descriptor.hpp>
+
+#include "tt-metalium/experimental/fabric/fabric.hpp"
 
 namespace ttml::ttnn_fixed::distributed {
 

--- a/tt-train/sources/ttml/ttnn_fixed/distributed/ttnn_ops.cpp
+++ b/tt-train/sources/ttml/ttnn_fixed/distributed/ttnn_ops.cpp
@@ -4,7 +4,6 @@
 
 #include "ttnn_ops.hpp"
 
-#include <core/ttnn_all_includes.hpp>
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/experimental/fabric/fabric_types.hpp>
 #include <umd/device/cluster.hpp>
@@ -13,6 +12,15 @@
 #include "core/compute_kernel_config.hpp"
 #include "core/distributed/socket_manager.hpp"
 #include "core/tt_tensor_utils.hpp"
+#include "tt-metalium/experimental/fabric/fabric.hpp"
+#include "ttnn/distributed/types.hpp"
+#include "ttnn/operations/ccl/common/host/moe_utils.hpp"
+#include "ttnn/operations/creation.hpp"
+#include "ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.hpp"
+#include "ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async.hpp"
+#include "ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.hpp"
+#include "ttnn/operations/reduction/generic/generic_reductions.hpp"
+#include "ttnn/tensor/tensor.hpp"
 
 namespace ttml::ttnn_fixed::distributed {
 

--- a/tt-train/sources/ttml/ttnn_fixed/trivial_ttnn_ops.cpp
+++ b/tt-train/sources/ttml/ttnn_fixed/trivial_ttnn_ops.cpp
@@ -4,11 +4,21 @@
 
 #include "trivial_ttnn_ops.hpp"
 
-#include <core/ttnn_all_includes.hpp>
-
 #include "autograd/auto_context.hpp"
 #include "core/compute_kernel_config.hpp"
 #include "core/tt_tensor_utils.hpp"
+#include "ttnn/operations/core/core.hpp"
+#include "ttnn/operations/data_movement/untilize/untilize.hpp"
+#include "ttnn/operations/eltwise/binary/binary.hpp"
+#include "ttnn/operations/eltwise/unary/unary.hpp"
+#include "ttnn/operations/moreh/moreh_mean/moreh_mean.hpp"
+#include "ttnn/operations/moreh/moreh_sum/moreh_sum.hpp"
+#include "ttnn/operations/normalization/softmax/softmax.hpp"
+#include "ttnn/operations/rand/rand.hpp"
+#include "ttnn/operations/reduction/argmax/argmax.hpp"
+#include "ttnn/operations/reduction/generic/generic_reductions.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/types.hpp"
 
 namespace ttml::ttnn_fixed {
 

--- a/tt-train/tests/autograd/autograd_tensor.cpp
+++ b/tt-train/tests/autograd/autograd_tensor.cpp
@@ -4,8 +4,6 @@
 
 #include <gtest/gtest.h>
 
-#include <core/ttnn_all_includes.hpp>
-
 #include "autograd/auto_context.hpp"
 #include "autograd/autocast_tensor.hpp"
 #include "autograd/tensor.hpp"

--- a/tt-train/tests/autograd/autograd_test.cpp
+++ b/tt-train/tests/autograd/autograd_test.cpp
@@ -5,7 +5,6 @@
 #include <gtest/gtest.h>
 
 #include <array>
-#include <core/ttnn_all_includes.hpp>
 #include <cstdint>
 #include <memory>
 #include <vector>

--- a/tt-train/tests/core/clip_grad_norm_test.cpp
+++ b/tt-train/tests/core/clip_grad_norm_test.cpp
@@ -6,7 +6,6 @@
 
 #include <gtest/gtest.h>
 
-#include <core/ttnn_all_includes.hpp>
 #include <xtensor/containers/xarray.hpp>
 #include <xtensor/views/xview.hpp>
 

--- a/tt-train/tests/core/n300_utils_test.cpp
+++ b/tt-train/tests/core/n300_utils_test.cpp
@@ -4,7 +4,6 @@
 
 #include <gtest/gtest.h>
 
-#include <core/ttnn_all_includes.hpp>
 #include <core/xtensor_utils.hpp>
 #include <umd/device/cluster.hpp>
 #include <xtensor-blas/xlinalg.hpp>
@@ -14,6 +13,11 @@
 #include "core/random.hpp"
 #include "core/system_utils.hpp"
 #include "core/tt_tensor_utils.hpp"
+#include "ttnn/distributed/distributed_tensor.hpp"
+#include "ttnn/operations/eltwise/binary/binary.hpp"
+#include "ttnn/operations/experimental/dropout/dropout.hpp"
+#include "ttnn/operations/matmul/matmul.hpp"
+#include "ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm.hpp"
 #include "ttnn_fixed/distributed/tt_metal.hpp"
 #include "ttnn_fixed/distributed/ttnn_ops.hpp"
 

--- a/tt-train/tests/core/random_tests.cpp
+++ b/tt-train/tests/core/random_tests.cpp
@@ -7,7 +7,6 @@
 
 #include <algorithm>
 #include <chrono>
-#include <core/ttnn_all_includes.hpp>
 #include <random>
 
 #include "autograd/auto_context.hpp"

--- a/tt-train/tests/core/scoped_test.cpp
+++ b/tt-train/tests/core/scoped_test.cpp
@@ -6,8 +6,6 @@
 
 #include <gtest/gtest.h>
 
-#include <core/ttnn_all_includes.hpp>
-
 TEST(ScopedTest, Scoped) {
     int variable = 0;
 

--- a/tt-train/tests/core/tensor_utils_test.cpp
+++ b/tt-train/tests/core/tensor_utils_test.cpp
@@ -4,7 +4,6 @@
 
 #include <gtest/gtest.h>
 
-#include <core/ttnn_all_includes.hpp>
 #include <cstdint>
 #include <limits>
 #include <vector>
@@ -12,6 +11,8 @@
 #include "autograd/auto_context.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "core/xtensor_utils.hpp"
+#include "tt-metalium/bfloat16.hpp"
+#include "ttnn/operations/data_movement/copy/copy.hpp"
 #include "ttnn/types.hpp"
 
 class TensorUtilsTest : public ::testing::Test {

--- a/tt-train/tests/model/gpt2s_test.cpp
+++ b/tt-train/tests/model/gpt2s_test.cpp
@@ -4,11 +4,10 @@
 
 #include <gtest/gtest.h>
 
-#include <core/ttnn_all_includes.hpp>
-
 #include "autograd/auto_context.hpp"
 #include "core/compute_kernel_config.hpp"
 #include "core/tt_tensor_utils.hpp"
+#include "ttnn/operations/matmul/matmul.hpp"
 
 enum class ExpectedResult { OK, ERROR };
 

--- a/tt-train/tests/model/linear_regression_ddp_test.cpp
+++ b/tt-train/tests/model/linear_regression_ddp_test.cpp
@@ -4,7 +4,6 @@
 
 #include <gtest/gtest.h>
 
-#include <core/ttnn_all_includes.hpp>
 #include <core/xtensor_utils.hpp>
 #include <umd/device/cluster.hpp>
 
@@ -19,6 +18,7 @@
 #include "modules/linear_module.hpp"
 #include "ops/losses.hpp"
 #include "optimizers/sgd.hpp"
+#include "ttnn/distributed/distributed_tensor.hpp"
 #include "ttnn_fixed/distributed/tt_metal.hpp"
 
 namespace {

--- a/tt-train/tests/model/linear_regression_full_test.cpp
+++ b/tt-train/tests/model/linear_regression_full_test.cpp
@@ -5,8 +5,6 @@
 #include <fmt/format.h>
 #include <gtest/gtest.h>
 
-#include <core/ttnn_all_includes.hpp>
-
 #include "autograd/auto_context.hpp"
 #include "core/system_utils.hpp"
 #include "core/tt_tensor_utils.hpp"

--- a/tt-train/tests/model/nano_gpt_test.cpp
+++ b/tt-train/tests/model/nano_gpt_test.cpp
@@ -5,7 +5,6 @@
 #include <fmt/format.h>
 #include <gtest/gtest.h>
 
-#include <core/ttnn_all_includes.hpp>
 #include <fstream>
 
 #include "autograd/auto_context.hpp"
@@ -19,6 +18,8 @@
 #include "ops/losses.hpp"
 #include "optimizers/adamw.hpp"
 #include "tokenizers/char_tokenizer.hpp"
+#include "tt-metalium/host_api.hpp"
+#include "ttnn/distributed/distributed_tensor.hpp"
 namespace {
 /*
 Nightly tests could be enabled by setting the environment variable ENABLE_NIGHTLY_TT_TRAIN_TESTS=1

--- a/tt-train/tests/modules/distributed/linear_test.cpp
+++ b/tt-train/tests/modules/distributed/linear_test.cpp
@@ -6,7 +6,6 @@
 
 #include <gtest/gtest.h>
 
-#include <core/ttnn_all_includes.hpp>
 #include <core/xtensor_utils.hpp>
 #include <umd/device/cluster.hpp>
 #include <xtensor-blas/xlinalg.hpp>
@@ -16,6 +15,9 @@
 #include "core/system_utils.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "modules/linear_module.hpp"
+#include "ttnn/distributed/distributed_tensor.hpp"
+#include "ttnn/operations/creation.hpp"
+#include "ttnn/operations/eltwise/binary/binary.hpp"
 #include "ttnn_fixed/distributed/tt_metal.hpp"
 
 namespace {

--- a/tt-train/tests/ops/cross_entropy_bw_op_test.cpp
+++ b/tt-train/tests/ops/cross_entropy_bw_op_test.cpp
@@ -6,7 +6,6 @@
 #include <sys/types.h>
 
 #include <cassert>
-#include <core/ttnn_all_includes.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <ttnn/operations/reduction/generic/generic_reductions.hpp>

--- a/tt-train/tests/ops/cross_entropy_fw_op_test.cpp
+++ b/tt-train/tests/ops/cross_entropy_fw_op_test.cpp
@@ -7,7 +7,6 @@
 #include <sys/types.h>
 
 #include <cassert>
-#include <core/ttnn_all_includes.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <ttnn/operations/reduction/generic/generic_reductions.hpp>

--- a/tt-train/tests/ops/distributed/comm_ops_test.cpp
+++ b/tt-train/tests/ops/distributed/comm_ops_test.cpp
@@ -6,7 +6,6 @@
 
 #include <gtest/gtest.h>
 
-#include <core/ttnn_all_includes.hpp>
 #include <core/xtensor_utils.hpp>
 #include <umd/device/cluster.hpp>
 
@@ -14,6 +13,7 @@
 #include "core/random.hpp"
 #include "core/system_utils.hpp"
 #include "core/tt_tensor_utils.hpp"
+#include "ttnn/distributed/distributed_tensor.hpp"
 #include "ttnn_fixed/distributed/tt_metal.hpp"
 
 namespace {

--- a/tt-train/tests/ops/distributed/ring_sdpa_test.cpp
+++ b/tt-train/tests/ops/distributed/ring_sdpa_test.cpp
@@ -11,7 +11,6 @@
 
 #include <gtest/gtest.h>
 
-#include <core/ttnn_all_includes.hpp>
 #include <core/xtensor_utils.hpp>
 #include <tt-metalium/distributed_context.hpp>
 #include <umd/device/cluster.hpp>
@@ -22,6 +21,8 @@
 #include "core/tt_tensor_utils.hpp"
 #include "ops/distributed/ring_attention_sdpa.hpp"
 #include "ops/scaled_dot_product_attention.hpp"
+#include "ttnn/distributed/create_socket.hpp"
+#include "ttnn/distributed/distributed_tensor.hpp"
 #include "ttnn_fixed/distributed/tt_metal.hpp"
 
 static bool check_32_chips() {

--- a/tt-train/tests/ops/distributed/ring_shift_test.cpp
+++ b/tt-train/tests/ops/distributed/ring_shift_test.cpp
@@ -12,7 +12,6 @@
 
 #include <gtest/gtest.h>
 
-#include <core/ttnn_all_includes.hpp>
 #include <core/xtensor_utils.hpp>
 #include <tt-metalium/distributed_context.hpp>
 #include <umd/device/cluster.hpp>
@@ -22,6 +21,8 @@
 #include "core/random.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "ops/distributed/comm_ops.hpp"
+#include "ttnn/distributed/create_socket.hpp"
+#include "ttnn/distributed/distributed_tensor.hpp"
 #include "ttnn_fixed/distributed/tt_metal.hpp"
 #include "ttnn_fixed/distributed/ttnn_ops.hpp"
 

--- a/tt-train/tests/ops/embedding_op_test.cpp
+++ b/tt-train/tests/ops/embedding_op_test.cpp
@@ -6,8 +6,6 @@
 
 #include <gtest/gtest.h>
 
-#include <core/ttnn_all_includes.hpp>
-
 #include "autograd/auto_context.hpp"
 #include "autograd/tensor.hpp"
 #include "core/system_utils.hpp"

--- a/tt-train/tests/ops/layer_norm_composite_test.cpp
+++ b/tt-train/tests/ops/layer_norm_composite_test.cpp
@@ -4,7 +4,6 @@
 
 #include <gtest/gtest.h>
 
-#include <core/ttnn_all_includes.hpp>
 #include <random>
 
 #include "autograd/auto_context.hpp"

--- a/tt-train/tests/ops/layernorm_bw_fused_op_test.cpp
+++ b/tt-train/tests/ops/layernorm_bw_fused_op_test.cpp
@@ -5,7 +5,6 @@
 #include <gtest/gtest.h>
 
 #include <cmath>
-#include <core/ttnn_all_includes.hpp>
 #include <tuple>
 
 #include "autograd/auto_context.hpp"

--- a/tt-train/tests/ops/layernorm_fw_fused_op_test.cpp
+++ b/tt-train/tests/ops/layernorm_fw_fused_op_test.cpp
@@ -5,7 +5,6 @@
 #include <gtest/gtest.h>
 
 #include <cmath>
-#include <core/ttnn_all_includes.hpp>
 #include <tuple>
 
 #include "autograd/auto_context.hpp"

--- a/tt-train/tests/ops/positional_embedding_test.cpp
+++ b/tt-train/tests/ops/positional_embedding_test.cpp
@@ -4,8 +4,6 @@
 
 #include <gtest/gtest.h>
 
-#include <core/ttnn_all_includes.hpp>
-
 #include "autograd/tensor.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "modules/positional_embeddings.hpp"

--- a/tt-train/tests/ops/profiler_no_op_test.cpp
+++ b/tt-train/tests/ops/profiler_no_op_test.cpp
@@ -6,7 +6,6 @@
 #include <sys/types.h>
 
 #include <cassert>
-#include <core/ttnn_all_includes.hpp>
 #include <cstdint>
 #include <ttnn/operations/reduction/generic/generic_reductions.hpp>
 #include <ttnn/tensor/shape/shape.hpp>

--- a/tt-train/tests/ops/rmsnorm_op_test.cpp
+++ b/tt-train/tests/ops/rmsnorm_op_test.cpp
@@ -7,7 +7,6 @@
 #include <gtest/gtest.h>
 
 #include <cassert>
-#include <core/ttnn_all_includes.hpp>
 #include <umd/device/cluster.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>
 

--- a/tt-train/tests/ops/rope_test.cpp
+++ b/tt-train/tests/ops/rope_test.cpp
@@ -3,8 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 #include <gtest/gtest.h>
 
-#include <core/ttnn_all_includes.hpp>
-
 #include "autograd/tensor.hpp"
 #include "core/system_utils.hpp"
 #include "core/tt_tensor_utils.hpp"

--- a/tt-train/tests/ops/sdpa_bw_op_test.cpp
+++ b/tt-train/tests/ops/sdpa_bw_op_test.cpp
@@ -6,7 +6,6 @@
 #include <sys/types.h>
 
 #include <cmath>
-#include <core/ttnn_all_includes.hpp>
 #include <xtensor-blas/xlinalg.hpp>
 
 #include "autograd/auto_context.hpp"
@@ -14,6 +13,13 @@
 #include "core/random.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "metal/operations.hpp"
+#include "ttnn/operations/data_movement/concat/concat.hpp"
+#include "ttnn/operations/data_movement/repeat/repeat.hpp"
+#include "ttnn/operations/eltwise/binary/binary.hpp"
+#include "ttnn/operations/eltwise/unary/unary.hpp"
+#include "ttnn/operations/moreh/moreh_softmax_backward/moreh_softmax_backward.hpp"
+#include "ttnn/operations/reduction/generic/generic_reductions.hpp"
+#include "ttnn/tensor/tensor.hpp"
 #include "ttnn_fixed/matmuls.hpp"
 #include "ttnn_fixed/trivial_ttnn_ops.hpp"
 

--- a/tt-train/tests/ops/sdpa_fw_op_test.cpp
+++ b/tt-train/tests/ops/sdpa_fw_op_test.cpp
@@ -8,7 +8,6 @@
 #include <algorithm>
 #include <cassert>
 #include <cmath>
-#include <core/ttnn_all_includes.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <stdexcept>
@@ -25,6 +24,10 @@
 #include "core/tt_tensor_utils.hpp"
 #include "metal/common/const_utils.hpp"
 #include "metal/operations.hpp"
+#include "ttnn/operations/data_movement/concat/concat.hpp"
+#include "ttnn/operations/data_movement/repeat/repeat.hpp"
+#include "ttnn/operations/eltwise/binary/binary.hpp"
+#include "ttnn/operations/eltwise/unary/unary.hpp"
 #include "ttnn_fixed/matmuls.hpp"
 #include "ttnn_fixed/trivial_ttnn_ops.hpp"
 #include "xtensor/generators/xbuilder.hpp"

--- a/tt-train/tests/ops/silu_op_test.cpp
+++ b/tt-train/tests/ops/silu_op_test.cpp
@@ -5,7 +5,6 @@
 #include <gtest/gtest.h>
 
 #include <cassert>
-#include <core/ttnn_all_includes.hpp>
 #include <numeric>
 
 #include "autograd/auto_context.hpp"

--- a/tt-train/tests/ops/softmax_backward_op_test.cpp
+++ b/tt-train/tests/ops/softmax_backward_op_test.cpp
@@ -5,7 +5,6 @@
 #include <gtest/gtest.h>
 
 #include <array>
-#include <core/ttnn_all_includes.hpp>
 #include <optional>
 #include <string_view>
 #include <tt-metalium/core_coord.hpp>
@@ -16,6 +15,9 @@
 #include "core/random.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "metal/operations.hpp"
+#include "tt-metalium/bfloat16.hpp"
+#include "ttnn/distributed/types.hpp"
+#include "ttnn/tensor/tensor.hpp"
 
 namespace {
 

--- a/tt-train/tests/ops/softmax_test.cpp
+++ b/tt-train/tests/ops/softmax_test.cpp
@@ -6,7 +6,6 @@
 #include <sys/types.h>
 
 #include <cassert>
-#include <core/ttnn_all_includes.hpp>
 #include <cstdint>
 #include <ttnn/operations/reduction/generic/generic_reductions.hpp>
 #include <ttnn/tensor/shape/shape.hpp>

--- a/tt-train/tests/ops/unary_ops_test.cpp
+++ b/tt-train/tests/ops/unary_ops_test.cpp
@@ -8,7 +8,6 @@
 #include <sys/random.h>
 
 #include <algorithm>
-#include <core/ttnn_all_includes.hpp>
 #include <cstdint>
 #include <limits>
 #include <random>

--- a/tt-train/tests/optimizers/adamw_full_precision_test.cpp
+++ b/tt-train/tests/optimizers/adamw_full_precision_test.cpp
@@ -8,13 +8,16 @@
 #include <gtest/gtest.h>
 
 #include <cmath>
-#include <core/ttnn_all_includes.hpp>
 #include <cstdlib>
 
 #include "autograd/auto_context.hpp"
 #include "autograd/autocast_tensor.hpp"
 #include "core/random.hpp"
 #include "core/tt_tensor_utils.hpp"
+#include "tt-metalium/bfloat16.hpp"
+#include "ttnn/operations/core/core.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/tensor/xtensor/conversion_utils.hpp"
 #include "xtensor/core/xtensor_forward.hpp"
 
 struct AdamWFullPrecisionCase {

--- a/tt-train/tests/optimizers/adamw_fused_test.cpp
+++ b/tt-train/tests/optimizers/adamw_fused_test.cpp
@@ -8,12 +8,12 @@
 #include <gtest/gtest.h>
 
 #include <cmath>
-#include <core/ttnn_all_includes.hpp>
 #include <cstdlib>
 
 #include "autograd/auto_context.hpp"
 #include "core/random.hpp"
 #include "core/tt_tensor_utils.hpp"
+#include "ttnn/tensor/tensor.hpp"
 #include "xtensor/core/xtensor_forward.hpp"
 
 struct AdamWCase {

--- a/tt-train/tests/optimizers/adamw_test.cpp
+++ b/tt-train/tests/optimizers/adamw_test.cpp
@@ -7,8 +7,6 @@
 #include <fmt/format.h>
 #include <gtest/gtest.h>
 
-#include <core/ttnn_all_includes.hpp>
-
 #include "autograd/auto_context.hpp"
 #include "core/system_utils.hpp"
 #include "core/tt_tensor_utils.hpp"

--- a/tt-train/tests/optimizers/no_op_test.cpp
+++ b/tt-train/tests/optimizers/no_op_test.cpp
@@ -6,8 +6,6 @@
 
 #include <gtest/gtest.h>
 
-#include <core/ttnn_all_includes.hpp>
-
 #include "autograd/auto_context.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "modules/linear_module.hpp"

--- a/tt-train/tests/optimizers/sgd_fused_test.cpp
+++ b/tt-train/tests/optimizers/sgd_fused_test.cpp
@@ -7,13 +7,13 @@
 #include <fmt/format.h>
 #include <gtest/gtest.h>
 
-#include <core/ttnn_all_includes.hpp>
 #include <cstdlib>
 
 #include "autograd/auto_context.hpp"
 #include "core/random.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "optimizers/sgd.hpp"
+#include "ttnn/tensor/tensor.hpp"
 #include "xtensor/core/xtensor_forward.hpp"
 
 struct ParityCase {

--- a/tt-train/tests/serialization/flatbuffer_serializer_test.cpp
+++ b/tt-train/tests/serialization/flatbuffer_serializer_test.cpp
@@ -21,8 +21,11 @@
 #include "autograd/auto_context.hpp"
 #include "core/random.hpp"
 #include "core/tt_tensor_utils.hpp"
-#include "core/ttnn_all_includes.hpp"
 #include "serialization/serialization.hpp"
+#include "ttnn/distributed/types.hpp"
+#include "ttnn/operations/core/core.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/tensor/types.hpp"
 
 namespace {
 // Concept for trivially copyable types

--- a/tt-train/tests/serialization/tensor_serializer_test.cpp
+++ b/tt-train/tests/serialization/tensor_serializer_test.cpp
@@ -4,7 +4,6 @@
 
 #include <gtest/gtest.h>
 
-#include <core/ttnn_all_includes.hpp>
 #include <filesystem>
 #include <fstream>
 #include <random>
@@ -17,6 +16,7 @@
 #include "modules/multi_layer_perceptron.hpp"
 #include "serialization/flatbuffer_file.hpp"
 #include "serialization/serialization.hpp"
+#include "ttnn/tensor/tensor.hpp"
 
 namespace {
 std::string generate_unique_temp_dir_name() {

--- a/tt-train/tests/ttnn_fixed/concat_op_test.cpp
+++ b/tt-train/tests/ttnn_fixed/concat_op_test.cpp
@@ -4,12 +4,13 @@
 
 #include <gtest/gtest.h>
 
-#include <core/ttnn_all_includes.hpp>
 #include <ttnn/operations/core/compute_kernel/compute_kernel_config.hpp>
 #include <ttnn/operations/reduction/generic/generic_reductions.hpp>
 
 #include "autograd/auto_context.hpp"
 #include "core/tt_tensor_utils.hpp"
+#include "ttnn/operations/data_movement/concat/concat.hpp"
+#include "ttnn/tensor/tensor.hpp"
 
 class ConcatOpTest : public ::testing::Test {
 protected:

--- a/tt-train/tests/ttnn_fixed/distributed/distributed_ttnn_ops_test.cpp
+++ b/tt-train/tests/ttnn_fixed/distributed/distributed_ttnn_ops_test.cpp
@@ -4,7 +4,6 @@
 
 #include <gtest/gtest.h>
 
-#include <core/ttnn_all_includes.hpp>
 #include <memory>
 #include <umd/device/cluster.hpp>
 #include <vector>

--- a/tt-train/tests/ttnn_fixed/dropout_op_test.cpp
+++ b/tt-train/tests/ttnn_fixed/dropout_op_test.cpp
@@ -5,12 +5,12 @@
 #include <gtest/gtest.h>
 
 #include <array>
-#include <core/ttnn_all_includes.hpp>
 
 #include "autograd/auto_context.hpp"
 #include "core/device.hpp"
 #include "core/random.hpp"
 #include "core/tt_tensor_utils.hpp"
+#include "ttnn/operations/experimental/dropout/dropout.hpp"
 #include "ttnn_fixed/trivial_ttnn_ops.hpp"
 
 class DropoutTest : public ::testing::Test {

--- a/tt-train/tests/ttnn_fixed/matmuls_test.cpp
+++ b/tt-train/tests/ttnn_fixed/matmuls_test.cpp
@@ -6,7 +6,6 @@
 
 #include <gtest/gtest.h>
 
-#include <core/ttnn_all_includes.hpp>
 #include <ttnn/operations/core/compute_kernel/compute_kernel_config.hpp>
 #include <ttnn/operations/reduction/generic/generic_reductions.hpp>
 #include <xtensor-blas/xlinalg.hpp>

--- a/tt-train/tests/ttnn_fixed/reduce_ops_test.cpp
+++ b/tt-train/tests/ttnn_fixed/reduce_ops_test.cpp
@@ -4,7 +4,6 @@
 
 #include <gtest/gtest.h>
 
-#include <core/ttnn_all_includes.hpp>
 #include <memory>
 #include <ttnn/operations/core/compute_kernel/compute_kernel_config.hpp>
 #include <ttnn/operations/reduction/generic/generic_reductions.hpp>

--- a/tt-train/tests/ttnn_fixed/slice_op_test.cpp
+++ b/tt-train/tests/ttnn_fixed/slice_op_test.cpp
@@ -4,10 +4,9 @@
 
 #include <gtest/gtest.h>
 
-#include <core/ttnn_all_includes.hpp>
-
 #include "autograd/auto_context.hpp"
 #include "core/tt_tensor_utils.hpp"
+#include "ttnn/operations/data_movement/slice/slice.hpp"
 
 class SliceOpTest : public ::testing::Test {
 protected:

--- a/tt-train/tests/ttnn_fixed/trivial_ttnn_ops_test.cpp
+++ b/tt-train/tests/ttnn_fixed/trivial_ttnn_ops_test.cpp
@@ -6,7 +6,6 @@
 
 #include <gtest/gtest.h>
 
-#include <core/ttnn_all_includes.hpp>
 #include <memory>
 #include <vector>
 
@@ -14,6 +13,8 @@
 #include "core/compute_kernel_config.hpp"
 #include "core/device.hpp"
 #include "core/tt_tensor_utils.hpp"
+#include "ttnn/operations/normalization/softmax/softmax.hpp"
+#include "ttnn/operations/reduction/generic/generic_reductions.hpp"
 #include "ttnn_fixed/trivial_ttnn_ops.hpp"
 
 class TrivialTnnFixedTest : public ::testing::Test {

--- a/tt-train/tests/utils/memory_utils_test.cpp
+++ b/tt-train/tests/utils/memory_utils_test.cpp
@@ -6,12 +6,14 @@
 
 #include <gtest/gtest.h>
 
-#include <core/ttnn_all_includes.hpp>
-
 #include "autograd/auto_context.hpp"
 #include "core/system_utils.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "ops/scaled_dot_product_attention.hpp"
+#include "ttnn/operations/core/core.hpp"
+#include "ttnn/operations/eltwise/binary/binary.hpp"
+#include "ttnn/operations/matmul/matmul.hpp"
+#include "ttnn/tensor/tensor.hpp"
 #include "ttnn/types.hpp"
 
 class MemoryUtilsTest : public ::testing::Test {


### PR DESCRIPTION
### Ticket
N/A — Code hygiene / include cleanup

### Problem description
`core/ttnn_all_includes.hpp` is an umbrella header that pulls in 80+ TTNN/metalium headers. It is used widely across tt-train `.cpp` files even when only a small subset of those headers is actually needed. This increases compile times, creates hidden dependencies, and makes it harder to understand what each translation unit actually depends on.

### What's changed
Removed `#include <core/ttnn_all_includes.hpp>` from **87 `.cpp` files** across `tt-train/sources/` and `tt-train/tests/`, replacing each with only the specific headers that translation unit actually uses (as determined by `clang-tidy misc-include-cleaner`).

**Summary:**
- **87 removals** of the umbrella `core/ttnn_all_includes.hpp` include
- **168 additions** of specific headers from the set provided by `ttnn_all_includes.hpp`
- Files that did not need any of the umbrella's headers simply had the include removed
- No functional changes — only include directives were modified

**Scope:** Only `.cpp` files were changed. Header files (`.hpp`) that still reference `ttnn_all_includes.hpp` are left for a follow-up.

**Verification:** Clean build confirmed with:
```
./build_metal.sh --clean
./build_metal.sh --disable-pch --build-all --debug
```

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=tt-train-remove-ttnn-all-includes-from-cpp)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:tt-train-remove-ttnn-all-includes-from-cpp)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=tt-train-remove-ttnn-all-includes-from-cpp)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:tt-train-remove-ttnn-all-includes-from-cpp)
- [ ] New/Existing tests provide coverage for changes
- [x] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early
