### PR TITLE
Galaxy demo tests reorg

### DIFF
--- a/.github/workflows/galaxy-demo-tests.yaml
+++ b/.github/workflows/galaxy-demo-tests.yaml
@@ -15,9 +15,7 @@ on:
           # - llama3_evals
           - llama3_8b_dp
           - llama3_70b_dp
-          - falcon7b
           - sentence_bert
-          - whisper
           - sd35
           - flux1
           - gpt-oss

--- a/.github/workflows/galaxy-unit-tests-impl.yaml
+++ b/.github/workflows/galaxy-unit-tests-impl.yaml
@@ -228,6 +228,7 @@ jobs:
           mkdir -p generated/test_reports
           pytest tests/ttnn/distributed/test_distributed_layernorm_TG.py
 
+      # GPT-OSS 20B tests are currently commented out to reduce runtime and resource usage
       - name: Run GPT-OSS unit tests
         if: ${{ matrix.test-group.model == 'gpt-oss' }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
@@ -235,8 +236,8 @@ jobs:
           mkdir -p generated/test_reports
           uv pip install -r models/demos/gpt_oss/requirements.txt
 
-          TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/openai--gpt-oss-20b/ HF_MODEL=/mnt/MLPerf/tt_dnn-models/openai/gpt-oss-20b/ \
-            pytest models/demos/gpt_oss/tests/unit -k "4x8" --timeout 300
+          # TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/openai--gpt-oss-20b/ HF_MODEL=/mnt/MLPerf/tt_dnn-models/openai/gpt-oss-20b/ \
+          #  pytest models/demos/gpt_oss/tests/unit -k "4x8" --timeout 300
 
           TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/openai--gpt-oss-120b/ HF_MODEL=/mnt/MLPerf/tt_dnn-models/openai/gpt-oss-120b/ \
             pytest models/demos/gpt_oss/tests/unit -k "4x8" --timeout 300

--- a/tests/pipeline_reorg/galaxy_demo_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_demo_tests.yaml
@@ -14,6 +14,7 @@
 - name: Galaxy Llama3 demo tests
   cmd: |
     export TT_CACHE_HOME=/mnt/MLPerf/huggingface/tt_cache LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ FAKE_DEVICE=TG
+    # pytest models/demos/llama3_70b_galaxy/demo/demo_decode.py -k "full" --timeout 1000
     pytest models/demos/llama3_70b_galaxy/demo/text_demo.py -k "repeat" --timeout 1000
     pytest models/demos/llama3_70b_galaxy/demo/text_demo.py -k "pcc-80L" --timeout 1000
     pytest models/demos/llama3_70b_galaxy/demo/text_demo.py -k "batch-32-non-uniform-sampling" --timeout 500
@@ -81,6 +82,8 @@
   cmd: |
     export TT_CACHE_HOME=/mnt/MLPerf/huggingface/tt_cache
     uv pip install -r models/demos/gpt_oss/requirements.txt
+    # TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/openai--gpt-oss-20b/ HF_MODEL=/mnt/MLPerf/tt_dnn-models/openai/gpt-oss-20b/ pytest models/demos/gpt_oss/demo/text_demo.py -k "4x8" --timeout 1000
+    # TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/openai--gpt-oss-20b/ HF_MODEL=/mnt/MLPerf/tt_dnn-models/openai/gpt-oss-20b/ pytest models/demos/gpt_oss/tests/accuracy/test_model.py -k "4x8" --timeout 900
     TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/openai--gpt-oss-120b/ HF_MODEL=/mnt/MLPerf/tt_dnn-models/openai/gpt-oss-120b/ pytest models/demos/gpt_oss/demo/text_demo.py -k "4x8" --timeout 1000
     TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/openai--gpt-oss-120b/ HF_MODEL=/mnt/MLPerf/tt_dnn-models/openai/gpt-oss-120b/ pytest models/demos/gpt_oss/tests/accuracy/test_model.py -k "4x8" --timeout 900
   model: gpt-oss
@@ -126,6 +129,7 @@
 - name: Galaxy DeepSeek v3 demo tests
   cmd: |
     export DEEPSEEK_V3_HF_MODEL=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528 DEEPSEEK_V3_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI MESH_DEVICE=TG
+    pytest models/demos/deepseek_v3/demo/test_demo.py -k "tg_stress" --timeout 900
   model: deepseek_v3
   skus:
     wh_galaxy:
@@ -147,7 +151,9 @@
 - name: Galaxy Qwen3-32B demo tests
   cmd: |
     export TT_CACHE_HOME=/mnt/MLPerf/huggingface/tt_cache HF_MODEL=Qwen/Qwen3-32B TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen3-32B MESH_DEVICE=TG
-    pytest models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py -k "batch-32" --timeout 1000
+    # pytest models/demos/llama3_70b_galaxy/demo/demo_qwen_decode.py -k "full" --timeout 1000
+    # pytest models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py -k "batch-32" --timeout 1000
+    pytest models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py -k "repeat2" --timeout 1000
   model: qwen3_32b
   skus:
     wh_galaxy:
@@ -158,6 +164,8 @@
 - name: Galaxy Qwen3-32B long context demo tests
   cmd: |
     export TT_CACHE_HOME=/mnt/MLPerf/huggingface/tt_cache HF_MODEL=Qwen/Qwen3-32B TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen3-32B MESH_DEVICE=TG
+    # pytest models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py -k "long-8k-b1" --timeout 1000
+    # pytest models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py -k "long-32k-b1" --timeout 1000
     pytest models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py -k "long-128k-b1" --timeout 1000
   model: qwen3_32b_long_context
   skus:

--- a/tests/pipeline_reorg/galaxy_demo_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_demo_tests.yaml
@@ -14,7 +14,6 @@
 - name: Galaxy Llama3 demo tests
   cmd: |
     export TT_CACHE_HOME=/mnt/MLPerf/huggingface/tt_cache LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ FAKE_DEVICE=TG
-    pytest models/demos/llama3_70b_galaxy/demo/demo_decode.py -k "full" --timeout 1000
     pytest models/demos/llama3_70b_galaxy/demo/text_demo.py -k "repeat" --timeout 1000
     pytest models/demos/llama3_70b_galaxy/demo/text_demo.py -k "pcc-80L" --timeout 1000
     pytest models/demos/llama3_70b_galaxy/demo/text_demo.py -k "batch-32-non-uniform-sampling" --timeout 500
@@ -47,15 +46,6 @@
   owner_id: U08BH66EXAL # Radoica Draskic
   team: models
 
-- name: Galaxy Falcon7b demo tests
-  cmd: pytest --disable-warnings -q -s --input-method=json --input-path='models/demos/tg/falcon7b/input_data_tg.json' models/demos/tg/falcon7b/demo_tg.py --timeout=1500
-  model: falcon7b
-  skus:
-    wh_galaxy:
-      timeout: 10
-  owner_id: U05RWH3QUPM # Salar Hosseini
-  team: models
-
 - name: Galaxy SentenceBert demo tests
   cmd: pytest models/demos/tg/sentence_bert/tests/test_sentence_bert_e2e_performant.py --timeout=1500
   model: sentence_bert
@@ -63,15 +53,6 @@
     wh_galaxy:
       timeout: 5
   owner_id: U088413NP0Q # Ashai Reddy
-  team: models
-
-- name: Galaxy Whisper demo tests
-  cmd: pytest models/demos/audio/whisper/demo/demo.py::test_demo_for_conditional_generation --timeout 1500
-  model: whisper
-  skus:
-    wh_galaxy:
-      timeout: 5
-  owner_id: U08HL8X1ECD # Aniruddha Tupe
   team: models
 
 - name: Galaxy Stable Diffusion 3.5 Large demo tests
@@ -100,8 +81,6 @@
   cmd: |
     export TT_CACHE_HOME=/mnt/MLPerf/huggingface/tt_cache
     uv pip install -r models/demos/gpt_oss/requirements.txt
-    TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/openai--gpt-oss-20b/ HF_MODEL=/mnt/MLPerf/tt_dnn-models/openai/gpt-oss-20b/ pytest models/demos/gpt_oss/demo/text_demo.py -k "4x8" --timeout 1000
-    TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/openai--gpt-oss-20b/ HF_MODEL=/mnt/MLPerf/tt_dnn-models/openai/gpt-oss-20b/ pytest models/demos/gpt_oss/tests/accuracy/test_model.py -k "4x8" --timeout 900
     TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/openai--gpt-oss-120b/ HF_MODEL=/mnt/MLPerf/tt_dnn-models/openai/gpt-oss-120b/ pytest models/demos/gpt_oss/demo/text_demo.py -k "4x8" --timeout 1000
     TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/openai--gpt-oss-120b/ HF_MODEL=/mnt/MLPerf/tt_dnn-models/openai/gpt-oss-120b/ pytest models/demos/gpt_oss/tests/accuracy/test_model.py -k "4x8" --timeout 900
   model: gpt-oss
@@ -147,7 +126,6 @@
 - name: Galaxy DeepSeek v3 demo tests
   cmd: |
     export DEEPSEEK_V3_HF_MODEL=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528 DEEPSEEK_V3_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI MESH_DEVICE=TG
-    pytest models/demos/deepseek_v3/demo/test_demo.py -k "tg_stress" --timeout 900
   model: deepseek_v3
   skus:
     wh_galaxy:
@@ -169,9 +147,7 @@
 - name: Galaxy Qwen3-32B demo tests
   cmd: |
     export TT_CACHE_HOME=/mnt/MLPerf/huggingface/tt_cache HF_MODEL=Qwen/Qwen3-32B TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen3-32B MESH_DEVICE=TG
-    pytest models/demos/llama3_70b_galaxy/demo/demo_qwen_decode.py -k "full" --timeout 1000
     pytest models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py -k "batch-32" --timeout 1000
-    pytest models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py -k "repeat2" --timeout 1000
   model: qwen3_32b
   skus:
     wh_galaxy:
@@ -182,8 +158,6 @@
 - name: Galaxy Qwen3-32B long context demo tests
   cmd: |
     export TT_CACHE_HOME=/mnt/MLPerf/huggingface/tt_cache HF_MODEL=Qwen/Qwen3-32B TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen3-32B MESH_DEVICE=TG
-    pytest models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py -k "long-8k-b1" --timeout 1000
-    pytest models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py -k "long-32k-b1" --timeout 1000
     pytest models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py -k "long-128k-b1" --timeout 1000
   model: qwen3_32b_long_context
   skus:

--- a/tests/pipeline_reorg/release_tests.yaml
+++ b/tests/pipeline_reorg/release_tests.yaml
@@ -597,8 +597,8 @@
   cmd: |
     export TT_CACHE_HOME=/mnt/MLPerf/huggingface/tt_cache
     uv pip install -r models/demos/gpt_oss/requirements.txt
-    TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/openai--gpt-oss-20b/ HF_MODEL=/mnt/MLPerf/tt_dnn-models/openai/gpt-oss-20b/ pytest models/demos/gpt_oss/demo/text_demo.py -k "4x8" --timeout 1000
-    TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/openai--gpt-oss-20b/ HF_MODEL=/mnt/MLPerf/tt_dnn-models/openai/gpt-oss-20b/ pytest models/demos/gpt_oss/tests/accuracy/test_model.py -k "4x8" --timeout 900
+    # TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/openai--gpt-oss-20b/ HF_MODEL=/mnt/MLPerf/tt_dnn-models/openai/gpt-oss-20b/ pytest models/demos/gpt_oss/demo/text_demo.py -k "4x8" --timeout 1000
+    # TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/openai--gpt-oss-20b/ HF_MODEL=/mnt/MLPerf/tt_dnn-models/openai/gpt-oss-20b/ pytest models/demos/gpt_oss/tests/accuracy/test_model.py -k "4x8" --timeout 900
     TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/openai--gpt-oss-120b/ HF_MODEL=/mnt/MLPerf/tt_dnn-models/openai/gpt-oss-120b/ pytest models/demos/gpt_oss/demo/text_demo.py -k "4x8" --timeout 1000
     TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/openai--gpt-oss-120b/ HF_MODEL=/mnt/MLPerf/tt_dnn-models/openai/gpt-oss-120b/ pytest models/demos/gpt_oss/tests/accuracy/test_model.py -k "4x8" --timeout 900
   model-name: gpt-oss

--- a/tests/pipeline_reorg/release_tests.yaml
+++ b/tests/pipeline_reorg/release_tests.yaml
@@ -531,17 +531,6 @@
   owner_id: U08BH66EXAL # Radoica Draskic
   team: models
 
-- name: Galaxy Falcon7b demo tests
-  cmd: |
-    export TT_CACHE_HOME=/mnt/MLPerf/huggingface/tt_cache
-    pytest --disable-warnings -q -s --input-method=json --input-path='models/demos/tg/falcon7b/input_data_tg.json' models/demos/tg/falcon7b/demo_tg.py --timeout 600
-  model-name: falcon7b
-  skus:
-    wh_galaxy_release:
-      timeout: 18
-  owner_id: U05RWH3QUPM # Salar Hosseini
-  team: models
-
 - name: Galaxy Llama3 70B data-parallel demo tests
   cmd: |
     export TT_CACHE_HOME=/mnt/MLPerf/huggingface/tt_cache HF_MODEL=meta-llama/Llama-3.3-70B-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/meta-llama/Llama-3.3-70B-Instruct MESH_DEVICE=TG
@@ -560,15 +549,6 @@
     wh_galaxy_release:
       timeout: 6
   owner_id: U088413NP0Q # Ashai Reddy
-  team: models
-
-- name: Galaxy Whisper demo tests
-  cmd: pytest models/demos/audio/whisper/demo/demo.py::test_demo_for_conditional_generation --timeout 1500
-  model-name: whisper
-  skus:
-    wh_galaxy_release:
-      timeout: 6
-  owner_id: U08HL8X1ECD # Aniruddha Tupe
   team: models
 
 - name: Galaxy Stable Diffusion 3.5 Large demo tests


### PR DESCRIPTION
### Problem description
There was an timeout and hang issues on Galaxy demo pipeline and this needs to be fixed.

### What's changed
Falcon 7B and Whisper tests are removed. GPT-OSS 20B is also removed and only 120B is tested. Deepseek and Qwen3 also have reduced number of tests now.

Removed GPT-OSS-20b unit tests from galaxy tests (coverage from 120b tests and 20b unit tests on T3K)
