### PR TITLE
Bug Fix: ttnn.min has worse accuracy with row-major inputs #32829

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction_min.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction_min.py
@@ -9,7 +9,7 @@ pytestmark = pytest.mark.use_module_device
 import torch
 
 import ttnn
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_with_pcc, assert_equal, assert_with_ulp
 from models.common.utility_functions import torch_random
 
 
@@ -68,3 +68,5 @@ def test_min_row_major(device, input_shape, dim, keepdim):
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.999)
+    assert_equal(torch_output_tensor, output_tensor)
+    assert_with_ulp(torch_output_tensor, output_tensor, ulp_threshold=1)

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction_min.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction_min.py
@@ -54,3 +54,17 @@ def test_min_global(device, batch_size, h, w):
     output_tensor = output_tensor
 
     assert_with_pcc(torch_output_tensor, output_tensor)
+
+
+@pytest.mark.parametrize("input_shape, dim, keepdim", [((512, 1024, 1, 2), -1, False), ((64, 512), -1, False)])
+def test_min_row_major(device, input_shape, dim, keepdim):
+    """Test ttnn.min with ROW_MAJOR layout (issue #32829: +inf padding during tilization)."""
+    torch.manual_seed(0)
+    torch_input_tensor = torch_random(input_shape, -100, 100, dtype=torch.bfloat16)
+    torch_output_tensor, _ = torch.min(torch_input_tensor, dim=dim, keepdim=keepdim)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.bfloat16, device=device)
+    output_tensor = ttnn.min(input_tensor, dim=dim, keepdim=keepdim)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.999)

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction_min.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction_min.py
@@ -9,7 +9,7 @@ pytestmark = pytest.mark.use_module_device
 import torch
 
 import ttnn
-from tests.ttnn.utils_for_testing import assert_with_pcc, assert_equal, assert_with_ulp
+from tests.ttnn.utils_for_testing import assert_with_pcc, assert_equal
 from models.common.utility_functions import torch_random
 
 
@@ -67,6 +67,4 @@ def test_min_row_major(device, input_shape, dim, keepdim):
     output_tensor = ttnn.min(input_tensor, dim=dim, keepdim=keepdim)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.999)
     assert_equal(torch_output_tensor, output_tensor)
-    assert_with_ulp(torch_output_tensor, output_tensor, ulp_threshold=1)

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
@@ -1685,14 +1685,14 @@ std::vector<Tensor> ExecuteUnaryBackwardRepeat::invoke(
 }
 
 // Autoformat support
-Tensor change_layout_to_tile(const Tensor& input_tensor, const MemoryConfig& /*output_mem_config*/) {
-    auto formatted_input_tensor = input_tensor;
+Tensor change_layout_to_tile(const Tensor& temp, const MemoryConfig& /*output_mem_config*/) {
+    auto formatted_input_tensor = temp;
     if (formatted_input_tensor.layout() == Layout::ROW_MAJOR) {
-        auto a_pad_shape = ttnn::operations::data_movement::pad_to_tile_shape(input_tensor.padded_shape());
-        auto need_format = input_tensor.padded_shape() != a_pad_shape;
+        auto a_pad_shape = ttnn::operations::data_movement::pad_to_tile_shape(temp.padded_shape());
+        auto need_format = temp.layout() != Layout::TILE || temp.padded_shape() != a_pad_shape;
         if (need_format) {
             formatted_input_tensor =
-                ttnn::tilize_with_val_padding(input_tensor, a_pad_shape, PadValue(1.0f), input_tensor.memory_config());
+                ttnn::tilize_with_val_padding(temp, a_pad_shape, PadValue(1.0f), temp.memory_config());
         }
     }
     return formatted_input_tensor;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
@@ -1685,14 +1685,14 @@ std::vector<Tensor> ExecuteUnaryBackwardRepeat::invoke(
 }
 
 // Autoformat support
-Tensor change_layout_to_tile(const Tensor& temp, const MemoryConfig& /*output_mem_config*/) {
-    auto formatted_input_tensor = temp;
+Tensor change_layout_to_tile(const Tensor& input_tensor, const MemoryConfig& /*output_mem_config*/) {
+    auto formatted_input_tensor = input_tensor;
     if (formatted_input_tensor.layout() == Layout::ROW_MAJOR) {
-        auto a_pad_shape = ttnn::operations::data_movement::pad_to_tile_shape(temp.padded_shape());
-        auto need_format = temp.layout() != Layout::TILE || temp.padded_shape() != a_pad_shape;
+        auto a_pad_shape = ttnn::operations::data_movement::pad_to_tile_shape(input_tensor.padded_shape());
+        auto need_format = input_tensor.padded_shape() != a_pad_shape;
         if (need_format) {
             formatted_input_tensor =
-                ttnn::tilize_with_val_padding(temp, a_pad_shape, PadValue(1.0f), temp.memory_config());
+                ttnn::tilize_with_val_padding(input_tensor, a_pad_shape, PadValue(1.0f), input_tensor.memory_config());
         }
     }
     return formatted_input_tensor;

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
@@ -51,7 +51,7 @@ Tensor reduce_min(
     Tensor input = input_tensor;
     if (input.layout() == tt::tt_metal::Layout::ROW_MAJOR &&
         input.storage_type() == tt::tt_metal::StorageType::DEVICE) {
-        // Use +inf padding when tilizing to avoid affecting min-reduction results
+        // Changing layout to TILE with +inf padding
         auto pad_shape = ttnn::operations::data_movement::pad_to_tile_shape(input.padded_shape());
         input =
             ttnn::tilize_with_val_padding(input, pad_shape, std::numeric_limits<float>::infinity(), output_mem_config);

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
@@ -51,7 +51,10 @@ Tensor reduce_min(
     Tensor input = input_tensor;
     if (input.layout() == tt::tt_metal::Layout::ROW_MAJOR &&
         input.storage_type() == tt::tt_metal::StorageType::DEVICE) {
-        input = ttnn::operations::unary_backward::change_layout_to_tile(input, output_mem_config);
+        // Use +inf padding when tilizing to avoid affecting min-reduction results
+        auto pad_shape = ttnn::operations::data_movement::pad_to_tile_shape(input.padded_shape());
+        input =
+            ttnn::tilize_with_val_padding(input, pad_shape, std::numeric_limits<float>::infinity(), output_mem_config);
     }
     return detail::reduce(
         input,


### PR DESCRIPTION
Use +inf padding during tilization to avoid incorrect min results.

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/32829)

### Problem description
ttnn.min with row-major device inputs could be wrong because tilization used 1.0f padding, so those padded elements affected the `min = -max(-x)` reduction.

### What's changed
In reduce_min (in reduce_op.cpp), when the input is ROW_MAJOR, we tilize with +inf as the padding value before calling the existing max reduction. So padded elements don’t affect the result and row-major min matches PyTorch.

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ign/kernel_bugfix_branch)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ign/kernel_bugfix_branch)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ign/kernel_bugfix_branch)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ign/kernel_bugfix_branch)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/kernel_bugfix_branch)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/kernel_bugfix_branch)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/kernel_bugfix_branch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/kernel_bugfix_branch)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/kernel_bugfix_branch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/kernel_bugfix_branch)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/kernel_bugfix_branch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/kernel_bugfix_branch)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
