### PR TITLE
first cursor iteration

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_concat.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_concat.py
@@ -411,3 +411,307 @@ def test_concat_sub_core_grids(device, layout, dim, input_shapes, sub_core_grids
     output = ttnn.to_torch(output)
 
     assert_with_pcc(torch_output_tensor, output, 0.99)
+
+
+# ------------------------------------------------------------------------------
+# ND-sharding concat tests (Step 8 of add-nd-sharding-support.md)
+# ------------------------------------------------------------------------------
+
+
+def _make_nd_sharded_tensor(
+    torch_tensor, shape, shard_shape, grid, device, dtype, orientation, layout=ttnn.ROW_MAJOR_LAYOUT
+):
+    """Create ND-sharded ttnn tensor from torch tensor. Supports ROW_MAJOR_LAYOUT and TILE_LAYOUT."""
+    nd_shard_spec = ttnn.NdShardSpec(shard_shape=shard_shape, grid=grid, orientation=orientation)
+    mem_config = ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1, nd_shard_spec=nd_shard_spec)
+    spec = ttnn.TensorSpec(
+        shape=shape,
+        dtype=dtype,
+        layout=layout,
+        nd_shard_spec=nd_shard_spec,
+        buffer_type=ttnn.BufferType.L1,
+    )
+    return ttnn.from_torch(torch_tensor, spec=spec, device=device)
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
+@pytest.mark.parametrize(
+    "input_shard_orientation",
+    [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR],
+)
+@pytest.mark.parametrize(
+    "tensor_shapes, input_shard_shape, output_shard_shape, shard_grid, dim",
+    [
+        # ND -> ND: width concat (dim=3), same shard grid (tile-aligned for TILE_LAYOUT)
+        (
+            [(1, 1, 32, 32), (1, 1, 32, 32)],
+            (1, 1, 32, 16),
+            (1, 1, 32, 32),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 1))}),
+            3,
+        ),
+        (
+            [(1, 1, 64, 64), (1, 1, 64, 32)],
+            (1, 1, 32, 32),
+            (1, 1, 32, 48),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1))}),
+            3,
+        ),
+    ],
+)
+def test_concat_nd_sharded_input_to_nd_sharded_output(
+    device,
+    tensor_shapes,
+    input_shard_shape,
+    output_shard_shape,
+    shard_grid,
+    dim,
+    dtype,
+    layout,
+    input_shard_orientation,
+):
+    """1. ND-sharded input -> ND-sharded output."""
+    if layout == ttnn.TILE_LAYOUT and (tensor_shapes[0][-2] % 32 != 0 or tensor_shapes[0][-1] % 32 != 0):
+        pytest.skip("TILE_LAYOUT requires height and width multiple of 32")
+    torch_inputs = [random_torch_tensor(dtype, s) for s in tensor_shapes]
+    expected = torch.concat(torch_inputs, dim=dim)
+
+    input_tensors = [
+        _make_nd_sharded_tensor(t, s, input_shard_shape, shard_grid, device, dtype, input_shard_orientation, layout)
+        for t, s in zip(torch_inputs, tensor_shapes)
+    ]
+    output_nd_spec = ttnn.NdShardSpec(
+        shard_shape=output_shard_shape, grid=shard_grid, orientation=input_shard_orientation
+    )
+    output_mem_config = ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1, nd_shard_spec=output_nd_spec)
+
+    output = ttnn.concat(input_tensors, dim=dim, memory_config=output_mem_config)
+    actual = ttnn.to_torch(output)
+    assert_equal(expected, actual)
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
+@pytest.mark.parametrize(
+    "input_shard_orientation",
+    [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR],
+)
+@pytest.mark.parametrize(
+    "tensor_shapes, input_shard_shape, shard_grid, dim",
+    [
+        (
+            [(1, 1, 32, 32), (1, 1, 32, 32)],
+            (1, 1, 32, 16),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 1))}),
+            3,
+        ),
+        (
+            [(1, 1, 64, 48), (1, 1, 64, 48)],
+            (1, 1, 32, 24),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1))}),
+            3,
+        ),
+    ],
+)
+def test_concat_nd_sharded_input_to_interleaved_output(
+    device, tensor_shapes, input_shard_shape, shard_grid, dim, dtype, layout, input_shard_orientation
+):
+    """2. ND-sharded input -> interleaved output."""
+    if layout == ttnn.TILE_LAYOUT and (tensor_shapes[0][-2] % 32 != 0 or tensor_shapes[0][-1] % 32 != 0):
+        pytest.skip("TILE_LAYOUT requires height and width multiple of 32")
+    torch_inputs = [random_torch_tensor(dtype, s) for s in tensor_shapes]
+    expected = torch.concat(torch_inputs, dim=dim)
+
+    input_tensors = [
+        _make_nd_sharded_tensor(t, s, input_shard_shape, shard_grid, device, dtype, input_shard_orientation, layout)
+        for t, s in zip(torch_inputs, tensor_shapes)
+    ]
+    output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1)
+
+    output = ttnn.concat(input_tensors, dim=dim, memory_config=output_mem_config)
+    actual = ttnn.to_torch(output)
+    assert_equal(expected, actual)
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize(
+    "tensor_shapes, output_shard_shape, shard_grid, dim",
+    [
+        (
+            [(1, 1, 32, 32), (1, 1, 32, 32)],
+            (1, 1, 32, 32),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 1))}),
+            3,
+        ),
+        (
+            [(1, 1, 64, 48), (1, 1, 64, 48)],
+            (1, 1, 32, 48),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1))}),
+            3,
+        ),
+    ],
+)
+def test_concat_interleaved_input_to_nd_sharded_output(
+    device, tensor_shapes, output_shard_shape, shard_grid, dim, dtype
+):
+    """3. Interleaved input -> ND-sharded output."""
+    torch_inputs = [random_torch_tensor(dtype, s) for s in tensor_shapes]
+    expected = torch.concat(torch_inputs, dim=dim)
+
+    input_tensors = [ttnn.from_torch(t, dtype=dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device) for t in torch_inputs]
+    output_nd_spec = ttnn.NdShardSpec(
+        shard_shape=output_shard_shape, grid=shard_grid, orientation=ttnn.ShardOrientation.ROW_MAJOR
+    )
+    output_mem_config = ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1, nd_shard_spec=output_nd_spec)
+
+    output = ttnn.concat(input_tensors, dim=dim, memory_config=output_mem_config)
+    actual = ttnn.to_torch(output)
+    assert_equal(expected, actual)
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize(
+    "tensor_shapes, input_shard_shape, output_shard_shape_2d, shard_grid, dim",
+    [
+        # Output (1,1,32,64), 2 cores HEIGHT_SHARDED -> (16, 64) per core
+        (
+            [(1, 1, 32, 32), (1, 1, 32, 32)],
+            (1, 1, 32, 16),
+            (16, 64),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 1))}),
+            3,
+        ),
+    ],
+)
+def test_concat_nd_sharded_input_to_legacy_2d_sharded_output(
+    device, tensor_shapes, input_shard_shape, output_shard_shape_2d, shard_grid, dim, dtype
+):
+    """4. ND-sharded input -> legacy 2D sharded output (HEIGHT_SHARDED for width concat)."""
+    torch_inputs = [random_torch_tensor(dtype, s) for s in tensor_shapes]
+    expected = torch.concat(torch_inputs, dim=dim)
+
+    input_tensors = [
+        _make_nd_sharded_tensor(t, s, input_shard_shape, shard_grid, device, dtype, ttnn.ShardOrientation.ROW_MAJOR)
+        for t, s in zip(torch_inputs, tensor_shapes)
+    ]
+    output_legacy_mem_config = ttnn.create_sharded_memory_config(
+        output_shard_shape_2d,
+        core_grid=shard_grid,
+        strategy=ttnn.ShardStrategy.HEIGHT,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+    output = ttnn.concat(input_tensors, dim=dim, memory_config=output_legacy_mem_config)
+    actual = ttnn.to_torch(output)
+    assert_equal(expected, actual)
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize(
+    "tensor_shapes, input_shard_shape_2d, output_shard_shape, shard_grid, dim",
+    [
+        # 2 cores, (1,1,32,32) each -> input (16, 32) per core; output ND (1,1,32,32) per core
+        (
+            [(1, 1, 32, 32), (1, 1, 32, 32)],
+            (16, 32),
+            (1, 1, 32, 32),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 1))}),
+            3,
+        ),
+    ],
+)
+def test_concat_legacy_2d_sharded_input_to_nd_sharded_output(
+    device, tensor_shapes, input_shard_shape_2d, output_shard_shape, shard_grid, dim, dtype
+):
+    """5. Legacy 2D sharded input -> ND-sharded output."""
+    torch_inputs = [random_torch_tensor(dtype, s) for s in tensor_shapes]
+    expected = torch.concat(torch_inputs, dim=dim)
+
+    # Legacy HEIGHT_SHARDED inputs
+    legacy_mem_config = ttnn.create_sharded_memory_config(
+        input_shard_shape_2d,
+        core_grid=shard_grid,
+        strategy=ttnn.ShardStrategy.HEIGHT,
+        use_height_and_width_as_shard_shape=True,
+    )
+    input_tensors = [ttnn.from_torch(t, dtype=dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device) for t in torch_inputs]
+    input_tensors = [ttnn.to_memory_config(t, legacy_mem_config) for t in input_tensors]
+
+    output_nd_spec = ttnn.NdShardSpec(
+        shard_shape=output_shard_shape, grid=shard_grid, orientation=ttnn.ShardOrientation.ROW_MAJOR
+    )
+    output_mem_config = ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1, nd_shard_spec=output_nd_spec)
+
+    output = ttnn.concat(input_tensors, dim=dim, memory_config=output_mem_config)
+    actual = ttnn.to_torch(output)
+    assert_equal(expected, actual)
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize(
+    "tensor_shapes, input_shard_shape_2d, shard_grid, dim",
+    [
+        (
+            [(1, 1, 32, 32), (1, 1, 32, 32)],
+            (16, 32),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 1))}),
+            3,
+        ),
+    ],
+)
+def test_concat_legacy_2d_sharded_input_to_interleaved_output(
+    device, tensor_shapes, input_shard_shape_2d, shard_grid, dim, dtype
+):
+    """6. Legacy 2D sharded input -> interleaved output."""
+    torch_inputs = [random_torch_tensor(dtype, s) for s in tensor_shapes]
+    expected = torch.concat(torch_inputs, dim=dim)
+
+    legacy_mem_config = ttnn.create_sharded_memory_config(
+        input_shard_shape_2d,
+        core_grid=shard_grid,
+        strategy=ttnn.ShardStrategy.HEIGHT,
+        use_height_and_width_as_shard_shape=True,
+    )
+    input_tensors = [ttnn.from_torch(t, dtype=dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device) for t in torch_inputs]
+    input_tensors = [ttnn.to_memory_config(t, legacy_mem_config) for t in input_tensors]
+
+    output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1)
+
+    output = ttnn.concat(input_tensors, dim=dim, memory_config=output_mem_config)
+    actual = ttnn.to_torch(output)
+    assert_equal(expected, actual)
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize(
+    "tensor_shapes, output_shard_shape_2d, shard_grid, dim",
+    [
+        # Output (1,1,32,64), 2 cores HEIGHT_SHARDED -> (16, 64) per core
+        (
+            [(1, 1, 32, 32), (1, 1, 32, 32)],
+            (16, 64),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 1))}),
+            3,
+        ),
+    ],
+)
+def test_concat_interleaved_input_to_legacy_2d_sharded_output(
+    device, tensor_shapes, output_shard_shape_2d, shard_grid, dim, dtype
+):
+    """7. Interleaved input -> legacy 2D sharded output."""
+    torch_inputs = [random_torch_tensor(dtype, s) for s in tensor_shapes]
+    expected = torch.concat(torch_inputs, dim=dim)
+
+    input_tensors = [ttnn.from_torch(t, dtype=dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device) for t in torch_inputs]
+
+    output_legacy_mem_config = ttnn.create_sharded_memory_config(
+        output_shard_shape_2d,
+        core_grid=shard_grid,
+        strategy=ttnn.ShardStrategy.HEIGHT,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+    output = ttnn.concat(input_tensors, dim=dim, memory_config=output_legacy_mem_config)
+    actual = ttnn.to_torch(output)
+    assert_equal(expected, actual)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_concat.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_concat.py
@@ -535,6 +535,7 @@ def test_concat_nd_sharded_input_to_interleaved_output(
 
 
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize(
     "tensor_shapes, output_shard_shape, shard_grid, dim",
     [
@@ -553,13 +554,15 @@ def test_concat_nd_sharded_input_to_interleaved_output(
     ],
 )
 def test_concat_interleaved_input_to_nd_sharded_output(
-    device, tensor_shapes, output_shard_shape, shard_grid, dim, dtype
+    device, tensor_shapes, output_shard_shape, shard_grid, dim, dtype, layout
 ):
     """3. Interleaved input -> ND-sharded output."""
+    if layout == ttnn.TILE_LAYOUT and (tensor_shapes[0][-2] % 32 != 0 or tensor_shapes[0][-1] % 32 != 0):
+        pytest.skip("TILE_LAYOUT requires height and width multiple of 32")
     torch_inputs = [random_torch_tensor(dtype, s) for s in tensor_shapes]
     expected = torch.concat(torch_inputs, dim=dim)
 
-    input_tensors = [ttnn.from_torch(t, dtype=dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device) for t in torch_inputs]
+    input_tensors = [ttnn.from_torch(t, dtype=dtype, layout=layout, device=device) for t in torch_inputs]
     output_nd_spec = ttnn.NdShardSpec(
         shard_shape=output_shard_shape, grid=shard_grid, orientation=ttnn.ShardOrientation.ROW_MAJOR
     )
@@ -571,6 +574,7 @@ def test_concat_interleaved_input_to_nd_sharded_output(
 
 
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize(
     "tensor_shapes, input_shard_shape, output_shard_shape_2d, shard_grid, dim",
     [
@@ -585,14 +589,18 @@ def test_concat_interleaved_input_to_nd_sharded_output(
     ],
 )
 def test_concat_nd_sharded_input_to_legacy_2d_sharded_output(
-    device, tensor_shapes, input_shard_shape, output_shard_shape_2d, shard_grid, dim, dtype
+    device, tensor_shapes, input_shard_shape, output_shard_shape_2d, shard_grid, dim, dtype, layout
 ):
     """4. ND-sharded input -> legacy 2D sharded output (HEIGHT_SHARDED for width concat)."""
+    if layout == ttnn.TILE_LAYOUT and (tensor_shapes[0][-2] % 32 != 0 or tensor_shapes[0][-1] % 32 != 0):
+        pytest.skip("TILE_LAYOUT requires height and width multiple of 32")
     torch_inputs = [random_torch_tensor(dtype, s) for s in tensor_shapes]
     expected = torch.concat(torch_inputs, dim=dim)
 
     input_tensors = [
-        _make_nd_sharded_tensor(t, s, input_shard_shape, shard_grid, device, dtype, ttnn.ShardOrientation.ROW_MAJOR)
+        _make_nd_sharded_tensor(
+            t, s, input_shard_shape, shard_grid, device, dtype, ttnn.ShardOrientation.ROW_MAJOR, layout
+        )
         for t, s in zip(torch_inputs, tensor_shapes)
     ]
     output_legacy_mem_config = ttnn.create_sharded_memory_config(
@@ -608,6 +616,7 @@ def test_concat_nd_sharded_input_to_legacy_2d_sharded_output(
 
 
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize(
     "tensor_shapes, input_shard_shape_2d, output_shard_shape, shard_grid, dim",
     [
@@ -622,9 +631,11 @@ def test_concat_nd_sharded_input_to_legacy_2d_sharded_output(
     ],
 )
 def test_concat_legacy_2d_sharded_input_to_nd_sharded_output(
-    device, tensor_shapes, input_shard_shape_2d, output_shard_shape, shard_grid, dim, dtype
+    device, tensor_shapes, input_shard_shape_2d, output_shard_shape, shard_grid, dim, dtype, layout
 ):
     """5. Legacy 2D sharded input -> ND-sharded output."""
+    if layout == ttnn.TILE_LAYOUT and (tensor_shapes[0][-2] % 32 != 0 or tensor_shapes[0][-1] % 32 != 0):
+        pytest.skip("TILE_LAYOUT requires height and width multiple of 32")
     torch_inputs = [random_torch_tensor(dtype, s) for s in tensor_shapes]
     expected = torch.concat(torch_inputs, dim=dim)
 
@@ -635,7 +646,7 @@ def test_concat_legacy_2d_sharded_input_to_nd_sharded_output(
         strategy=ttnn.ShardStrategy.HEIGHT,
         use_height_and_width_as_shard_shape=True,
     )
-    input_tensors = [ttnn.from_torch(t, dtype=dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device) for t in torch_inputs]
+    input_tensors = [ttnn.from_torch(t, dtype=dtype, layout=layout, device=device) for t in torch_inputs]
     input_tensors = [ttnn.to_memory_config(t, legacy_mem_config) for t in input_tensors]
 
     output_nd_spec = ttnn.NdShardSpec(
@@ -649,6 +660,7 @@ def test_concat_legacy_2d_sharded_input_to_nd_sharded_output(
 
 
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize(
     "tensor_shapes, input_shard_shape_2d, shard_grid, dim",
     [
@@ -661,9 +673,11 @@ def test_concat_legacy_2d_sharded_input_to_nd_sharded_output(
     ],
 )
 def test_concat_legacy_2d_sharded_input_to_interleaved_output(
-    device, tensor_shapes, input_shard_shape_2d, shard_grid, dim, dtype
+    device, tensor_shapes, input_shard_shape_2d, shard_grid, dim, dtype, layout
 ):
     """6. Legacy 2D sharded input -> interleaved output."""
+    if layout == ttnn.TILE_LAYOUT and (tensor_shapes[0][-2] % 32 != 0 or tensor_shapes[0][-1] % 32 != 0):
+        pytest.skip("TILE_LAYOUT requires height and width multiple of 32")
     torch_inputs = [random_torch_tensor(dtype, s) for s in tensor_shapes]
     expected = torch.concat(torch_inputs, dim=dim)
 
@@ -673,7 +687,7 @@ def test_concat_legacy_2d_sharded_input_to_interleaved_output(
         strategy=ttnn.ShardStrategy.HEIGHT,
         use_height_and_width_as_shard_shape=True,
     )
-    input_tensors = [ttnn.from_torch(t, dtype=dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device) for t in torch_inputs]
+    input_tensors = [ttnn.from_torch(t, dtype=dtype, layout=layout, device=device) for t in torch_inputs]
     input_tensors = [ttnn.to_memory_config(t, legacy_mem_config) for t in input_tensors]
 
     output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1)
@@ -684,6 +698,7 @@ def test_concat_legacy_2d_sharded_input_to_interleaved_output(
 
 
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize(
     "tensor_shapes, output_shard_shape_2d, shard_grid, dim",
     [
@@ -697,13 +712,15 @@ def test_concat_legacy_2d_sharded_input_to_interleaved_output(
     ],
 )
 def test_concat_interleaved_input_to_legacy_2d_sharded_output(
-    device, tensor_shapes, output_shard_shape_2d, shard_grid, dim, dtype
+    device, tensor_shapes, output_shard_shape_2d, shard_grid, dim, dtype, layout
 ):
     """7. Interleaved input -> legacy 2D sharded output."""
+    if layout == ttnn.TILE_LAYOUT and (tensor_shapes[0][-2] % 32 != 0 or tensor_shapes[0][-1] % 32 != 0):
+        pytest.skip("TILE_LAYOUT requires height and width multiple of 32")
     torch_inputs = [random_torch_tensor(dtype, s) for s in tensor_shapes]
     expected = torch.concat(torch_inputs, dim=dim)
 
-    input_tensors = [ttnn.from_torch(t, dtype=dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device) for t in torch_inputs]
+    input_tensors = [ttnn.from_torch(t, dtype=dtype, layout=layout, device=device) for t in torch_inputs]
 
     output_legacy_mem_config = ttnn.create_sharded_memory_config(
         output_shard_shape_2d,

--- a/ttnn/cpp/ttnn/kernel/dataflow/writer_unary_stick_layout_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/kernel/dataflow/writer_unary_stick_layout_interleaved_start_id.cpp
@@ -26,7 +26,7 @@ void kernel_main() {
 #endif
         cb_wait_front(cb_id_out0, 1);
         uint32_t l1_read_addr = get_read_ptr(cb_id_out0);
-        uint64_t dst_noc_addr = get_noc_addr(i, s0);
+        uint64_t dst_noc_addr = s0.get_noc_addr(i);
         noc_async_write(l1_read_addr, dst_noc_addr, stick_size);
         noc_async_write_barrier();
         cb_pop_front(cb_id_out0, 1);

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
@@ -12,10 +12,85 @@
 #include <tt-logger/tt-logger.hpp>
 #include "ttnn/operations/data_movement/common/common.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
+#include <tt-metalium/hal.hpp>
 
 using namespace tt::tt_metal;
 
 namespace ttnn::prim {
+
+namespace {
+
+// Returns true only when all inputs use legacy 2D ShardSpec and satisfy the constraints
+// required by the optimized S2S/S2I factories. All other sharded cases (e.g. ND-sharded)
+// use ConcatProgramFactory (default path with page-based addressing).
+bool can_use_legacy_sharded_factories(
+    const ConcatDeviceOperation::operation_attributes_t& args,
+    const ConcatDeviceOperation::tensor_args_t& tensor_args) {
+    const auto& input_tensors = tensor_args.input_tensors;
+    const auto& first_input = input_tensors[0];
+    const auto shape_first = first_input.padded_shape();
+    const uint32_t dim = args.dim;
+
+    // Legacy factories require ShardSpec (not NdShardSpec)
+    if (!first_input.shard_spec().has_value()) {
+        return false;
+    }
+    const auto memory_layout = first_input.memory_config().memory_layout();
+    if (memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
+        return false;
+    }
+    // Two-tensor concat legacy path does not support width sharded
+    if (input_tensors.size() == 2 && memory_layout == TensorMemoryLayout::WIDTH_SHARDED) {
+        return false;
+    }
+
+    for (size_t i = 1; i < input_tensors.size(); ++i) {
+        const auto& in_ref = input_tensors[i];
+        if (!in_ref.shard_spec().has_value()) {
+            return false;
+        }
+        if (in_ref.shard_spec().value().grid != first_input.shard_spec().value().grid) {
+            return false;
+        }
+        if (in_ref.memory_config().memory_layout() != memory_layout) {
+            return false;
+        }
+    }
+
+    const bool output_is_sharded = args.output_mem_config.is_sharded();
+    if (output_is_sharded) {
+        if (!args.output_mem_config.shard_spec().has_value()) {
+            return false;
+        }
+        if (args.output_mem_config.memory_layout() != memory_layout) {
+            return false;
+        }
+        if (args.output_mem_config.shard_spec().value().grid != first_input.shard_spec().value().grid) {
+            return false;
+        }
+    }
+
+    // Dim-specific constraints expected by legacy factories
+    if (dim == shape_first.rank() - 1) {
+        if (memory_layout != TensorMemoryLayout::HEIGHT_SHARDED) {
+            return false;
+        }
+    } else if (dim == shape_first.rank() - 2) {
+        if (memory_layout != TensorMemoryLayout::WIDTH_SHARDED) {
+            return false;
+        }
+    } else {
+        return false;
+    }
+
+    if (args.groups != 1 && memory_layout != TensorMemoryLayout::HEIGHT_SHARDED) {
+        return false;
+    }
+
+    return true;
+}
+
+}  // namespace
 
 ConcatDeviceOperation::program_factory_t ConcatDeviceOperation::select_program_factory(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
@@ -30,13 +105,16 @@ ConcatDeviceOperation::program_factory_t ConcatDeviceOperation::select_program_f
         return ConcatProgramFactory{};
     }
 
-    // Sharded cases - determine which specific factory to use
+    // ND-sharded or other sharded cases that don't match legacy factories use default path
+    if (!can_use_legacy_sharded_factories(args, tensor_args)) {
+        return ConcatProgramFactory{};
+    }
+
+    // Legacy 2D sharded cases - use optimized factories
     const bool output_is_sharded = args.output_mem_config.is_sharded();
 
     if (output_is_sharded) {
-        // Sharded-to-sharded (s2s) cases
         if (input_tensors.size() == 2) {
-            // Optimized 2-tensor case
             TT_FATAL(
                 input_tensors[0].layout() == input_tensors[1].layout(),
                 "Expected all input tensors to have the same layout for 2-tensor sharded concat");
@@ -45,11 +123,9 @@ ConcatDeviceOperation::program_factory_t ConcatDeviceOperation::select_program_f
                 return ConcatS2SRMProgramFactory{};
             }
             return ConcatS2STiledProgramFactory{};
-
-        }  // Multi-tensor s2s case
+        }
         return ConcatS2SMultiProgramFactory{};
     }
-    // Sharded-to-interleaved (s2i) case
     return ConcatS2IProgramFactory{};
 }
 
@@ -88,20 +164,26 @@ void ConcatDeviceOperation::validate_on_program_cache_miss(
         TT_FATAL(curr_shape == shape_first, "concat tensors differ in shape across non-concat dimensions.");
         TT_FATAL(in_ref.is_sharded() == shard_first, "All tensors must be sharded or all must be interleaved");
         if (shard_first) {
-            TT_FATAL(in_ref.shard_spec().has_value(), "Sharded tensors must have a shard spec.");
             TT_FATAL(
-                in_ref.shard_spec().value().grid == first_input.shard_spec().value().grid,
-                "Sharded tensors must have the same grid.");
-            TT_FATAL(
-                in_ref.memory_config().memory_layout() == first_input.memory_config().memory_layout(),
-                "Sharded tensors must have the same memory layout.");
-            // TODO(jerrysky3): Remove this when we replace the two tensors concat kernel with the general one.
-            TT_FATAL(
-                input_tensors.size() > 2 || in_ref.memory_config().memory_layout() != TensorMemoryLayout::WIDTH_SHARDED,
-                "Width sharded inputs are not supported for two tensors concat yet");
-            TT_FATAL(
-                in_ref.memory_config().memory_layout() != TensorMemoryLayout::BLOCK_SHARDED,
-                "Block sharded inputs are not supported");
+                in_ref.shard_spec().has_value() || in_ref.nd_shard_spec().has_value(),
+                "Sharded tensors must have a shard spec or nd_shard_spec.");
+            if (first_input.shard_spec().has_value()) {
+                TT_FATAL(
+                    in_ref.shard_spec().has_value(), "All sharded tensors must use the same spec type (shard_spec).");
+                TT_FATAL(
+                    in_ref.shard_spec().value().grid == first_input.shard_spec().value().grid,
+                    "Sharded tensors must have the same grid.");
+                TT_FATAL(
+                    in_ref.memory_config().memory_layout() == first_input.memory_config().memory_layout(),
+                    "Sharded tensors must have the same memory layout.");
+            } else {
+                TT_FATAL(
+                    in_ref.nd_shard_spec().has_value(),
+                    "All sharded tensors must use the same spec type (nd_shard_spec).");
+                TT_FATAL(
+                    in_ref.nd_shard_spec().value().grid == first_input.nd_shard_spec().value().grid,
+                    "Sharded tensors must have the same grid.");
+            }
         }
     }
     if (warn_about_alignment) {
@@ -113,30 +195,23 @@ void ConcatDeviceOperation::validate_on_program_cache_miss(
             args.dim);
     }
     if (shard_first) {
-        const auto memory_layout = first_input.memory_config().memory_layout();
-        TT_FATAL(
-            args.output_mem_config.memory_layout() == memory_layout,
-            "Sharded output and inputs must have the same memory layout.");
-        TT_FATAL(args.output_mem_config.is_sharded(), "Output must be sharded if input is sharded.");
-        TT_FATAL(
-            args.output_mem_config.shard_spec().value().grid == first_input.shard_spec().value().grid,
-            "Sharded output and inputs must have the same grid.");
-        if (args.dim == shape_first.rank() - 1) {
-            TT_FATAL(
-                memory_layout == TensorMemoryLayout::HEIGHT_SHARDED,
-                "Only support width concat on height-sharded tensors.");
-        } else if (args.dim == shape_first.rank() - 2) {
-            TT_FATAL(
-                memory_layout == TensorMemoryLayout::WIDTH_SHARDED,
-                "Only support height concat on width-sharded tensors.");
-        } else {
-            TT_FATAL(false, "Only width or height concat on sharded tensors");
+        // L1 alignment for row-major sharded tensors (page-based reads/writes)
+        const bool rm_layout = first_input.layout() == Layout::ROW_MAJOR;
+        if (rm_layout) {
+            for (const auto& in_ref : input_tensors) {
+                const uint32_t shard_width = in_ref.shard_spec().has_value()
+                                                 ? in_ref.shard_spec().value().shape[1]
+                                                 : in_ref.nd_shard_spec().value().shard_shape[-1];
+                const uint32_t page_size_bytes = in_ref.buffer()->page_size();
+                const uint32_t alignment_requirement = hal::get_l1_alignment();
+                TT_FATAL(
+                    page_size_bytes == in_ref.buffer()->aligned_page_size(),
+                    "Input row-major shard width {} gives page size {} bytes, which must be aligned to {} bytes",
+                    shard_width,
+                    page_size_bytes,
+                    alignment_requirement);
+            }
         }
-        TT_FATAL(
-            args.groups == 1 || memory_layout == TensorMemoryLayout::HEIGHT_SHARDED,
-            "Groups > 1 is only supported on height-sharded tensors (groups={} and memory_layout={} was provided)",
-            args.groups,
-            memory_layout);
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_program_factory.cpp
@@ -11,6 +11,7 @@
 #include <tt-metalium/tt_align.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/work_split.hpp>
+#include <tt-metalium/hal.hpp>
 
 namespace ttnn::prim {
 
@@ -127,6 +128,8 @@ ConcatProgramFactory::cached_program_t ConcatProgramFactory::create(
     std::vector<uint32_t> num_pages_per_block(num_input_tensors);
     std::vector<uint32_t> page_id_per_tensor(num_input_tensors);
     std::vector<uint32_t> page_size_per_tensor(num_input_tensors);
+    std::vector<uint32_t> num_pages_in_row_per_tensor(num_input_tensors, 1);
+    std::vector<uint32_t> size_of_valid_data_in_last_page_per_tensor(num_input_tensors);
 
     uint32_t num_accum_pages = 1;
     uint32_t scale_factor = 1;
@@ -159,14 +162,25 @@ ConcatProgramFactory::cached_program_t ConcatProgramFactory::create(
 
     if (rm_layout) {
         for (uint32_t i = 0; i < num_input_tensors; ++i) {
-            auto* buffer = input_tensors[i].buffer();
+            const auto& in = input_tensors[i];
+            auto* buffer = in.buffer();
             src_addr[i] = buffer->address();
             page_size_per_tensor[i] = buffer->page_size();
+            size_of_valid_data_in_last_page_per_tensor[i] = buffer->page_size();
+            if (in.is_sharded()) {
+                const uint32_t shard_width = in.shard_spec().has_value() ? in.shard_spec().value().shape[1]
+                                                                         : in.nd_shard_spec().value().shard_shape[-1];
+                const uint32_t logical_width = in.logical_shape()[-1];
+                num_pages_in_row_per_tensor[i] = tt::div_up(logical_width, shard_width);
+                const uint32_t unpadded_row_bytes = logical_width * in.element_size();
+                size_of_valid_data_in_last_page_per_tensor[i] =
+                    unpadded_row_bytes - (num_pages_in_row_per_tensor[i] - 1) * buffer->page_size();
+            }
             if (dim == num_dims - 1) {
-                num_pages_per_block[i] = num_accum_pages;
+                num_pages_per_block[i] = num_accum_pages * num_pages_in_row_per_tensor[i];
             } else {
-                uint32_t dim_pages = input_tensors[i].padded_shape()[dim];
-                num_pages_per_block[i] = num_accum_pages * dim_pages;
+                uint32_t dim_pages = in.padded_shape()[dim];
+                num_pages_per_block[i] = num_accum_pages * dim_pages * num_pages_in_row_per_tensor[i];
                 num_output_pages_per_block += num_accum_pages * dim_pages;
             }
         }
@@ -188,11 +202,18 @@ ConcatProgramFactory::cached_program_t ConcatProgramFactory::create(
     common_reader_kernel_args.insert(
         common_reader_kernel_args.end(), num_pages_per_block.cbegin(), num_pages_per_block.cend());
 
-    // Reader compile-time args
-    // Data is 32 byte aligned
+    // Reader compile-time args (for RM: include per-tensor page params for sharded/ND-sharded inputs)
     std::vector<uint32_t> reader_compile_time_args = {src0_cb_index, num_input_tensors};
     reader_compile_time_args.insert(
         reader_compile_time_args.end(), page_size_per_tensor.cbegin(), page_size_per_tensor.cend());
+    if (rm_layout) {
+        reader_compile_time_args.insert(
+            reader_compile_time_args.end(), num_pages_in_row_per_tensor.cbegin(), num_pages_in_row_per_tensor.cend());
+        reader_compile_time_args.insert(
+            reader_compile_time_args.end(),
+            size_of_valid_data_in_last_page_per_tensor.cbegin(),
+            size_of_valid_data_in_last_page_per_tensor.cend());
+    }
     for (uint32_t i = 0; i < num_input_tensors; ++i) {
         TensorAccessorArgs(*input_tensors[i].buffer()).append_to(reader_compile_time_args);
     }
@@ -203,9 +224,35 @@ ConcatProgramFactory::cached_program_t ConcatProgramFactory::create(
         concat_defines["WIDTH_CONCAT"] = "1";
     }
 
+    uint32_t num_pages_in_row_out = 1;
+    uint32_t size_of_valid_data_in_last_page_out = dst_buffer->page_size();
+    const bool output_sharded_rm = rm_layout && output.is_sharded();
+    if (output_sharded_rm) {
+        const uint32_t shard_width = output.shard_spec().has_value() ? output.shard_spec().value().shape[1]
+                                                                     : output.nd_shard_spec().value().shard_shape[-1];
+        const uint32_t logical_width = output.logical_shape()[-1];
+        num_pages_in_row_out = tt::div_up(logical_width, shard_width);
+        const uint32_t unpadded_row_bytes = logical_width * output.element_size();
+        size_of_valid_data_in_last_page_out = unpadded_row_bytes - (num_pages_in_row_out - 1) * dst_buffer->page_size();
+        TT_FATAL(
+            dst_buffer->page_size() == dst_buffer->aligned_page_size(),
+            "Output row-major shard width {} gives page size {} bytes, which must be aligned to {} bytes",
+            shard_width,
+            dst_buffer->page_size(),
+            hal::get_l1_alignment());
+    }
+
     std::vector<uint32_t> writer_compile_time_args;
     if (rm_layout) {
-        writer_compile_time_args = {(std::uint32_t)src0_cb_index, dst_buffer->page_size()};
+        if (output_sharded_rm) {
+            writer_compile_time_args = {
+                (std::uint32_t)src0_cb_index,
+                dst_buffer->page_size(),
+                num_pages_in_row_out,
+                size_of_valid_data_in_last_page_out};
+        } else {
+            writer_compile_time_args = {(std::uint32_t)src0_cb_index, dst_buffer->page_size()};
+        }
     } else {
         writer_compile_time_args = {(std::uint32_t)src0_cb_index};
     }
@@ -221,11 +268,14 @@ ConcatProgramFactory::cached_program_t ConcatProgramFactory::create(
         all_cores,
         ReaderDataMovementConfig(reader_compile_time_args, concat_defines));
 
+    const bool use_concat_writer = rm_layout && output.is_sharded();
     writer_kernel_id = CreateKernel(
         program,
-        rm_layout
-            ? "ttnn/cpp/ttnn/kernel/dataflow/writer_unary_stick_layout_interleaved_start_id.cpp"
-            : "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp",
+        use_concat_writer
+            ? "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/writer_concat_stick_layout.cpp"
+            : (rm_layout ? "ttnn/cpp/ttnn/kernel/dataflow/writer_unary_stick_layout_interleaved_start_id.cpp"
+                         : "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/"
+                           "writer_unary_interleaved_start_id.cpp"),
         all_cores,
         WriterDataMovementConfig(writer_compile_time_args));
 
@@ -268,10 +318,11 @@ ConcatProgramFactory::cached_program_t ConcatProgramFactory::create(
         reader_kernel_args[2] = curr_tensor_id;
         reader_kernel_args.insert(reader_kernel_args.end(), page_id_per_tensor.begin(), page_id_per_tensor.end());
 
+        const uint32_t writer_start_page_id =
+            rm_layout && output.is_sharded() ? num_pages_written * num_pages_in_row_out : num_pages_written;
         std::vector<uint32_t> writer_kernel_args;
         if (rm_layout) {
-            writer_kernel_args = {
-                dst_buffer->address(), output.buffer()->page_size(), num_pages_per_core, num_pages_written};
+            writer_kernel_args = {dst_buffer->address(), single_page_size, num_pages_per_core, writer_start_page_id};
         } else {
             writer_kernel_args = {dst_buffer->address(), num_pages_per_core, num_pages_written};
         }

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_stick_layout_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_stick_layout_interleaved_start_id.cpp
@@ -7,7 +7,7 @@
 
 // Make n reads defined by num_reads
 // Writes to Specified Circular Buffers in L1
-// Expects n provided src_addr, src_noc_x, src_noc_y, and cb_id_in
+// Supports interleaved and sharded/ND-sharded inputs (page-based addressing).
 void kernel_main() {
     const uint32_t num_pages = get_arg_val<uint32_t>(0);
     const uint32_t start_tensor = get_arg_val<uint32_t>(1);
@@ -16,8 +16,10 @@ void kernel_main() {
     constexpr uint32_t cb_id_in = get_compile_time_arg_val(0);
     constexpr uint32_t num_tensors = get_compile_time_arg_val(1);
     constexpr uint32_t page_size_base_idx = 2;
-    constexpr auto tensor_accessor_args =
-        make_tensor_accessor_args_tuple<num_tensors, page_size_base_idx + num_tensors>();
+    constexpr uint32_t num_pages_in_row_base_idx = page_size_base_idx + num_tensors;
+    constexpr uint32_t size_of_valid_data_base_idx = num_pages_in_row_base_idx + num_tensors;
+    constexpr uint32_t tensor_accessor_args_base_idx = size_of_valid_data_base_idx + num_tensors;
+    constexpr auto tensor_accessor_args = make_tensor_accessor_args_tuple<num_tensors, tensor_accessor_args_base_idx>();
 
     // ublocks size defined in pages
     constexpr uint32_t ublock_size_pages = 1;
@@ -40,23 +42,32 @@ void kernel_main() {
 
     uint32_t curr_tensor = start_tensor;
     uint32_t curr_tensor_id = start_tensor_id;
-    // FIX RM CONCAT WIDTH
     for (uint32_t i = 0; i < num_pages; ++i) {
         cb_reserve_back(cb_id_in, ublock_size_pages);
         uint32_t l1_write_addr = get_write_ptr(cb_id_in);
 #ifdef WIDTH_CONCAT
-        // For width concat we know we start at curr_tensor=0
-        // num_pages_per_block[curr_tensor] is always one for width concat
+        // For width concat read from each tensor in order; support multi-page per row (sharded/ND-sharded)
         for (uint32_t j = 0; j < num_tensors; ++j) {
-            auto read_addr =
-                abstract_tensor_accessor_wrappers[curr_tensor].get_noc_addr(page_id_per_tensor[curr_tensor]);
-            auto page_size = kernel_compile_time_args[page_size_base_idx + curr_tensor];
-            noc_async_read(read_addr, l1_write_addr, page_size);
-            l1_write_addr += page_size;
-            page_id_per_tensor[curr_tensor]++;
-            curr_tensor++;
+            const uint32_t npir = kernel_compile_time_args[num_pages_in_row_base_idx + j];
+            const uint32_t page_sz = kernel_compile_time_args[page_size_base_idx + j];
+            const uint32_t size_last = kernel_compile_time_args[size_of_valid_data_base_idx + j];
+            const uint32_t base_page_id = page_id_per_tensor[j];
+            if (npir == 1) {
+                uint64_t read_addr = abstract_tensor_accessor_wrappers[j].get_noc_addr(base_page_id);
+                noc_async_read(read_addr, l1_write_addr, page_sz);
+                l1_write_addr += page_sz;
+            } else {
+                for (uint32_t p = 0; p < npir - 1; ++p) {
+                    uint64_t read_addr = abstract_tensor_accessor_wrappers[j].get_noc_addr(base_page_id + p);
+                    noc_async_read(read_addr, l1_write_addr, page_sz);
+                    l1_write_addr += page_sz;
+                }
+                uint64_t read_addr = abstract_tensor_accessor_wrappers[j].get_noc_addr(base_page_id + npir - 1);
+                noc_async_read(read_addr, l1_write_addr, size_last);
+                l1_write_addr += size_last;
+            }
+            page_id_per_tensor[j] += npir;
         }
-        curr_tensor = 0;
 #else
         auto read_addr = abstract_tensor_accessor_wrappers[curr_tensor].get_noc_addr(page_id_per_tensor[curr_tensor]);
         auto page_size = kernel_compile_time_args[page_size_base_idx + curr_tensor];


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=AlexeyZaytsev-epam/issue/36707/concat_nd_sharding_mdv)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:AlexeyZaytsev-epam/issue/36707/concat_nd_sharding_mdv)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=AlexeyZaytsev-epam/issue/36707/concat_nd_sharding_mdv)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:AlexeyZaytsev-epam/issue/36707/concat_nd_sharding_mdv)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/issue/36707/concat_nd_sharding_mdv)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/issue/36707/concat_nd_sharding_mdv)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/issue/36707/concat_nd_sharding_mdv)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/issue/36707/concat_nd_sharding_mdv)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/issue/36707/concat_nd_sharding_mdv)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/issue/36707/concat_nd_sharding_mdv)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/issue/36707/concat_nd_sharding_mdv)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/issue/36707/concat_nd_sharding_mdv)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
