### PR TITLE
Combine-write layout: follow DeepSeek moe_compute design

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_combine_writer_standalone.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_combine_writer_standalone.py
@@ -1,0 +1,401 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Standalone kernel-level test for the combine-write data path of moe_gpt_fused.
+
+Isolates ONLY the combine-write from matmul_dm1.cpp (lines 143-208).
+No ring A2A, no matmul, no tilize. Runs on a single Wormhole device.
+
+Tests that 12 sender cores correctly scatter untilized ROW_MAJOR data
+from cb_c2s_out (c_14) to 12 combine cores in a 4x3 block-sharded layout.
+
+Dimensions (from moe_gpt_fused_ring_common.h):
+  K = 2880 (hidden_size) -> 90 tiles
+  E = 4 experts per device
+  tokens_per_chunk = 32
+  combine grid: 4 height x 3 width = 12 cores
+  combine shard: [32, 960] per core (32 tokens x 30 tiles x 32 tile_width)
+  source_width_tiles = 8 (max tiles per ring core)
+  W2_TILES_PER_CORE_A = [8,8,7,7,8,8,7,7,8,8,7,7]
+"""
+
+import pytest
+import torch
+import ttnn
+from loguru import logger
+
+
+# Constants from moe_gpt_fused_ring_common.h
+NUM_CORES = 12
+NUM_EXPERTS = 4
+TOKENS_PER_CHUNK = 32
+HIDDEN_SIZE = 2880
+K_TILES = HIDDEN_SIZE // 32  # 90
+COMBINE_WIDTH_SHARD_DIM = 3
+COMBINE_HEIGHT_SHARD_DIM = 4
+COMBINE_SHARD_WIDTH_TILES = K_TILES // COMBINE_WIDTH_SHARD_DIM  # 30
+SOURCE_WIDTH_TILES = 8
+TILE_WIDTH = 32
+TILE_WIDTH_SIZE_BYTES = TILE_WIDTH * 2  # bfloat16 = 2 bytes
+
+# Per-core W2 tile count (from W2_TILES_PER_CORE_A)
+W2_TILES_PER_CORE = [8, 8, 7, 7, 8, 8, 7, 7, 8, 8, 7, 7]
+
+# Prefix-sum: combine width offset per ring core
+COMBINE_W_OFFSET = []
+_s = 0
+for t in W2_TILES_PER_CORE:
+    COMBINE_W_OFFSET.append(_s)
+    _s += t
+
+RING_CORES_PER_COMBINE_COL = NUM_CORES // COMBINE_WIDTH_SHARD_DIM  # 4
+
+
+def serialize_physical_core_coords(logical_cores, device):
+    """
+    Replicate C++ serialize_physical_core_coords:
+    Returns "{x0, y0, x1, y1, ...}" for use as OUTPUT_SHARD_CORE_MAP define.
+    """
+    coords = []
+    for c in logical_cores:
+        pc = device.worker_core_from_logical_core(c)
+        coords.append(str(pc.x))
+        coords.append(str(pc.y))
+    return "{" + ", ".join(coords) + "}"
+
+
+TOKENS_PER_HEIGHT_SHARD = TOKENS_PER_CHUNK // COMBINE_HEIGHT_SHARD_DIM  # 8
+
+
+def build_golden(input_data):
+    """
+    Build golden reference output matching the DeepSeek moe_compute combine-write layout.
+
+    Tokens are distributed round-robin across height shards. Within each shard,
+    expert blocks are stacked: [E0 block][E1 block][E2 block][E3 block].
+
+    input_data: dict mapping ring_core_id -> torch tensor of shape
+                [NUM_EXPERTS * TOKENS_PER_CHUNK, SOURCE_WIDTH_TILES * TILE_WIDTH]
+                (i.e. [128, 256])
+
+    Returns: torch tensor of shape [NUM_EXPERTS * TOKENS_PER_CHUNK, HIDDEN_SIZE]
+             i.e. [128, 2880]
+    """
+    # Output shard layout per shard (32 rows):
+    #   Expert 0: rows 0..7   (TOKENS_PER_HEIGHT_SHARD rows)
+    #   Expert 1: rows 8..15
+    #   Expert 2: rows 16..23
+    #   Expert 3: rows 24..31
+    # 4 shards × 32 rows = 128 total rows
+    output = torch.zeros(NUM_EXPERTS * TOKENS_PER_CHUNK, HIDDEN_SIZE, dtype=torch.bfloat16)
+
+    shard_rows_per_shard = NUM_EXPERTS * TOKENS_PER_HEIGHT_SHARD  # 4 * 8 = 32
+
+    for ring_core_id in range(NUM_CORES):
+        w_offset = COMBINE_W_OFFSET[ring_core_id]
+        tiles = W2_TILES_PER_CORE[ring_core_id]
+        src = input_data[ring_core_id]
+
+        for e in range(NUM_EXPERTS):
+            max_tokens_per_height_shard = (TOKENS_PER_CHUNK + COMBINE_HEIGHT_SHARD_DIM - 1) // COMBINE_HEIGHT_SHARD_DIM
+            expert_offset_rows = e * max_tokens_per_height_shard  # e * 8
+
+            for bt in range(TOKENS_PER_CHUNK):
+                # Which height shard does this token go to?
+                dest_shard = bt // max_tokens_per_height_shard
+                shard_row = bt % max_tokens_per_height_shard
+
+                # Destination row in the flattened output tensor
+                dst_row = dest_shard * shard_rows_per_shard + expert_offset_rows + shard_row
+
+                src_row = e * TOKENS_PER_CHUNK + bt
+                src_start = 0
+                src_end = tiles * TILE_WIDTH
+                dst_start = w_offset * TILE_WIDTH
+                dst_end = (w_offset + tiles) * TILE_WIDTH
+                output[dst_row, dst_start:dst_end] = src[src_row, src_start:src_end]
+
+    return output
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        pytest.param(
+            {"dispatch_core_axis": ttnn.DispatchCoreAxis.ROW},
+            id="dispatch_row",
+        )
+    ],
+    indirect=True,
+)
+def test_combine_writer_standalone(device):
+    """
+    Test the combine-write data path in isolation using generic_op.
+
+    Sets up:
+    - 12 sender cores running combine_writer_test_kernel.cpp
+    - 12 combine cores running combine_dm1.cpp
+    - Validates output matches golden reference (exact match, no compute)
+    """
+    logger.info("Setting up combine writer standalone test")
+
+    # =========================================================================
+    # Core assignments (same as moe_gpt_fused_program_factory.cpp)
+    # =========================================================================
+
+    # Sender (matmul) cores: 12 cores aligned to DRAM banks
+    matmul_logical_cores = device.get_optimal_dram_bank_to_logical_worker_assignment(0)
+    assert len(matmul_logical_cores) == NUM_CORES, f"Expected {NUM_CORES} matmul cores, got {len(matmul_logical_cores)}"
+
+    # Ring ordering: sort by physical (y desc, x desc) - same as production
+    core2bank = {}
+    for bank_id, core in enumerate(matmul_logical_cores):
+        core2bank[(core.x, core.y)] = bank_id
+
+    bank_ids_sorted = list(range(NUM_CORES))
+    bank_ids_sorted.sort(
+        key=lambda b: (
+            -device.worker_core_from_logical_core(matmul_logical_cores[b]).y,
+            -device.worker_core_from_logical_core(matmul_logical_cores[b]).x,
+        )
+    )
+    # bank_ids_sorted[ring_pos] = bank_id
+    # We need: ring_pos -> bank_id mapping and inverse
+    ring2bank = {ring_pos: bank_id for ring_pos, bank_id in enumerate(bank_ids_sorted)}
+    bank2ring = {bank_id: ring_pos for ring_pos, bank_id in ring2bank.items()}
+
+    matmul_core_range_set = ttnn.CoreRangeSet(
+        [ttnn.CoreRange(ttnn.CoreCoord(c.x, c.y), ttnn.CoreCoord(c.x, c.y)) for c in matmul_logical_cores]
+    )
+
+    # Combine cores: CoreRange({1,0},{3,3}) = 12 cores, sorted by (y asc, x asc)
+    combine_core_range = ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 3))
+    combine_core_range_set = ttnn.CoreRangeSet([combine_core_range])
+
+    # Get sorted combine cores (y asc, x asc) - same as production
+    combine_logical_cores = []
+    for y in range(0, 4):
+        for x in range(1, 4):
+            combine_logical_cores.append(ttnn.CoreCoord(x, y))
+    assert len(combine_logical_cores) == 12
+
+    # Verify no overlap between sender and combine core sets
+    sender_set = {(c.x, c.y) for c in matmul_logical_cores}
+    combine_set = {(c.x, c.y) for c in combine_logical_cores}
+    assert sender_set.isdisjoint(combine_set), "Sender and combine cores must not overlap"
+
+    logger.info(f"Sender cores: {[(c.x, c.y) for c in matmul_logical_cores]}")
+    logger.info(f"Combine cores: {[(c.x, c.y) for c in combine_logical_cores]}")
+
+    # =========================================================================
+    # Serialize combine core physical coords for OUTPUT_SHARD_CORE_MAP define
+    # =========================================================================
+    output_shard_core_map_str = serialize_physical_core_coords(combine_logical_cores, device)
+    logger.info(f"OUTPUT_SHARD_CORE_MAP = {output_shard_core_map_str}")
+
+    # =========================================================================
+    # Create input data on sender cores
+    # HEIGHT_SHARDED L1 tensor, shard = [128, 256] per core
+    # 128 = NUM_EXPERTS * TOKENS_PER_CHUNK, 256 = SOURCE_WIDTH_TILES * TILE_WIDTH
+    # =========================================================================
+    shard_height = NUM_EXPERTS * TOKENS_PER_CHUNK  # 128
+    shard_width = SOURCE_WIDTH_TILES * TILE_WIDTH  # 256
+
+    # Create deterministic input: value = ring_core_id * 1000 + expert * 100 + token + tile * 0.01
+    # We need to lay out data in the order the cores appear in the shard spec
+    input_per_ring_core = {}
+    all_shards = []
+
+    for bank_id in range(NUM_CORES):
+        ring_pos = bank2ring[bank_id]
+        shard_data = torch.zeros(shard_height, shard_width, dtype=torch.bfloat16)
+
+        for e in range(NUM_EXPERTS):
+            for bt in range(TOKENS_PER_CHUNK):
+                row = e * TOKENS_PER_CHUNK + bt
+                for t in range(SOURCE_WIDTH_TILES):
+                    col_start = t * TILE_WIDTH
+                    col_end = (t + 1) * TILE_WIDTH
+                    val = ring_pos * 1000 + e * 100 + bt + t * 0.01
+                    shard_data[row, col_start:col_end] = val
+
+        input_per_ring_core[ring_pos] = shard_data
+        all_shards.append(shard_data)
+
+    # Stack shards into full tensor: [NUM_CORES * shard_height, shard_width]
+    full_input = torch.cat(all_shards, dim=0)  # [1536, 256]
+
+    input_shard_spec = ttnn.ShardSpec(
+        matmul_core_range_set,
+        [shard_height, shard_width],
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    input_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, input_shard_spec)
+
+    # Create on DRAM first, then reshard to L1
+    tt_input_dram = ttnn.from_torch(
+        full_input,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+    )
+    tt_input = ttnn.to_memory_config(tt_input_dram, input_mem_config)
+    ttnn.deallocate(tt_input_dram)
+
+    logger.info(f"Input tensor shape: {tt_input.shape}, memory: {tt_input.memory_config()}")
+
+    # =========================================================================
+    # Create output tensor on combine cores
+    # BLOCK_SHARDED L1, shape [128, 2880], shard [32, 960]
+    # =========================================================================
+    output_shard_height = TOKENS_PER_CHUNK  # 32
+    output_shard_width = COMBINE_SHARD_WIDTH_TILES * TILE_WIDTH  # 960
+    output_shape = [NUM_EXPERTS * TOKENS_PER_CHUNK, HIDDEN_SIZE]  # [128, 2880]
+
+    output_shard_spec = ttnn.ShardSpec(
+        combine_core_range_set,
+        [output_shard_height, output_shard_width],
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1, output_shard_spec)
+
+    # Allocate output tensor initialized to zeros
+    tt_output = ttnn.from_torch(
+        torch.zeros(output_shape, dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        memory_config=output_mem_config,
+    )
+
+    output_base_l1_addr = tt_output.buffer_address()
+    logger.info(f"Output tensor shape: {tt_output.shape}, memory: {tt_output.memory_config()}")
+    logger.info(f"Output buffer L1 addr: {output_base_l1_addr}")
+
+    # =========================================================================
+    # Circular Buffers
+    # =========================================================================
+
+    # c_14 on sender cores: backed by input tensor (SOURCE_WIDTH_TILES * TILE_WIDTH * 2 = 512 bytes per page)
+    c14_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(14, tt_input)
+
+    # c_0 on combine cores: backed by output tensor
+    c0_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(0, tt_output)
+
+    # =========================================================================
+    # Semaphore: combine_semaphore on combine cores
+    # =========================================================================
+    combine_semaphore_id = 0
+    combine_semaphore = ttnn.SemaphoreDescriptor(
+        id=combine_semaphore_id,
+        core_ranges=combine_core_range_set,
+        initial_value=0,
+    )
+
+    # =========================================================================
+    # Named compile-time args for the test kernel (same as production dm1)
+    # =========================================================================
+    named_compile_args = [
+        ("num_experts", NUM_EXPERTS),
+        ("height_shard_dim", COMBINE_HEIGHT_SHARD_DIM),
+        ("width_shard_dim", COMBINE_WIDTH_SHARD_DIM),
+        ("combine_shard_width_tiles", COMBINE_SHARD_WIDTH_TILES),
+        ("tile_width", TILE_WIDTH),
+        ("tile_width_size_bytes", TILE_WIDTH_SIZE_BYTES),
+        ("num_tokens_total", TOKENS_PER_CHUNK),
+    ]
+
+    # =========================================================================
+    # Build per-core runtime args for sender kernel
+    # =========================================================================
+    sender_rt_args = ttnn.RuntimeArgs()
+
+    for bank_id in range(NUM_CORES):
+        ring_pos = bank2ring[bank_id]
+        core = matmul_logical_cores[bank_id]
+        vchannel = bank_id & 0x3
+
+        sender_rt_args[core.x][core.y] = [
+            ring_pos,  # [0] ring_core_id
+            combine_semaphore_id,  # [1] combine_semaphore_id
+            output_base_l1_addr,  # [2] output_base_l1_addr
+            vchannel,  # [3] vchannel
+        ]
+
+    # =========================================================================
+    # Define kernels
+    # =========================================================================
+    kernel_path = "ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt_fused/device/kernels"
+
+    # Sender kernel: our test kernel on matmul cores (RISCV_0 / NOC_1)
+    sender_kernel = ttnn.KernelDescriptor(
+        kernel_source=f"{kernel_path}/combine_writer_test_kernel.cpp",
+        source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
+        core_ranges=matmul_core_range_set,
+        named_compile_time_args=named_compile_args,
+        defines=[("OUTPUT_SHARD_CORE_MAP", output_shard_core_map_str)],
+        runtime_args=sender_rt_args,
+        config=ttnn.DataMovementConfigDescriptor(
+            processor=ttnn.DataMovementProcessor.RISCV_0,
+            noc=ttnn.NOC.NOC_1,
+        ),
+    )
+
+    # Receiver kernel: real combine_dm1.cpp on combine cores (RISCV_0 / NOC_1)
+    combine_rt_args = ttnn.RuntimeArgs()
+    for c in combine_logical_cores:
+        combine_rt_args[c.x][c.y] = [combine_semaphore_id]
+
+    receiver_kernel = ttnn.KernelDescriptor(
+        kernel_source=f"{kernel_path}/combine_dm1.cpp",
+        source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
+        core_ranges=combine_core_range_set,
+        runtime_args=combine_rt_args,
+        config=ttnn.DataMovementConfigDescriptor(
+            processor=ttnn.DataMovementProcessor.RISCV_0,
+            noc=ttnn.NOC.NOC_1,
+        ),
+    )
+
+    # =========================================================================
+    # Build and run program
+    # =========================================================================
+    program_descriptor = ttnn.ProgramDescriptor(
+        kernels=[sender_kernel, receiver_kernel],
+        cbs=[c14_cb_descriptor, c0_cb_descriptor],
+        semaphores=[combine_semaphore],
+    )
+
+    logger.info("Running combine writer test kernel...")
+    ttnn.generic_op([tt_input, tt_output], program_descriptor)
+    logger.info("Kernel execution complete")
+
+    # =========================================================================
+    # Validate output
+    # =========================================================================
+    output_torch = ttnn.to_torch(tt_output)
+    logger.info(f"Output shape: {output_torch.shape}")
+
+    # Build golden reference
+    golden = build_golden(input_per_ring_core)
+
+    # Exact match since no compute, just data movement
+    if torch.equal(output_torch, golden):
+        logger.info("PASS: Output exactly matches golden reference")
+    else:
+        # Find mismatches for debugging
+        mismatch_mask = output_torch != golden
+        num_mismatches = mismatch_mask.sum().item()
+        total_elements = output_torch.numel()
+        logger.error(f"FAIL: {num_mismatches}/{total_elements} elements mismatch")
+
+        # Show first few mismatches
+        mismatch_indices = torch.nonzero(mismatch_mask)
+        for i in range(min(10, len(mismatch_indices))):
+            idx = tuple(mismatch_indices[i].tolist())
+            logger.error(f"  [{idx}] got={output_torch[idx].item():.4f}, expected={golden[idx].item():.4f}")
+
+    assert torch.equal(output_torch, golden), "Output does not match golden reference"
+    logger.info("Combine writer standalone test PASSED")

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_moe_gpt_fused.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_moe_gpt_fused.py
@@ -74,7 +74,6 @@ def run_test_moe_gpt_fused(device, total_tokens, H, N, E, check_accuracy):
     for ring_pos, core_coord in enumerate(in0_core_coords_sorted):
         ring2cores[ring_pos] = (core_coord, core2dram[core_coord], 1 if ring_pos in PAD_CORES else 0)
 
-    num_dram_banks = 12
     dram_core_coords = [ttnn.CoreCoord(ring2cores[i][1], 0) for i in range(in0_num_cores)]
     dram_core_range = [ttnn.CoreRange(dram_core_coord, dram_core_coord) for dram_core_coord in dram_core_coords]
     dram_core_range_set = ttnn.CoreRangeSet(dram_core_range)
@@ -189,17 +188,59 @@ def run_test_moe_gpt_fused(device, total_tokens, H, N, E, check_accuracy):
     )
 
     # --------------------------------------------------------------------------
+    # Verify output shard layout
+    # --------------------------------------------------------------------------
+    output_tensor = tt_outputs[0]
+    output_mem_config = output_tensor.memory_config()
+
+    # Assert BLOCK_SHARDED on L1
+    assert (
+        output_mem_config.memory_layout == ttnn.TensorMemoryLayout.BLOCK_SHARDED
+    ), f"Expected BLOCK_SHARDED, got {output_mem_config.memory_layout}"
+    assert output_mem_config.buffer_type == ttnn.BufferType.L1, f"Expected L1, got {output_mem_config.buffer_type}"
+
+    # TODO(T=128): Shard shape becomes [128, 960] = [E * T/height_shard_dim, K/width_shard_dim]
+    shard_spec = output_mem_config.shard_spec
+    expected_shard_shape = [total_tokens, H // 3]  # [32, 960]
+    assert (
+        list(shard_spec.shape) == expected_shard_shape
+    ), f"Expected shard shape {expected_shard_shape}, got {list(shard_spec.shape)}"
+
+    # Assert shard grid matches combine cores at CoreRange({1,0},{3,3})
+    shard_grid_ranges = shard_spec.grid.ranges()
+    assert len(shard_grid_ranges) == 1, f"Expected 1 core range, got {len(shard_grid_ranges)}"
+    actual_range = shard_grid_ranges[0]
+    assert (actual_range.start.x, actual_range.start.y) == (
+        1,
+        0,
+    ), f"Expected start (1,0), got ({actual_range.start.x},{actual_range.start.y})"
+    assert (actual_range.end.x, actual_range.end.y) == (
+        3,
+        3,
+    ), f"Expected end (3,3), got ({actual_range.end.x},{actual_range.end.y})"
+
+    logger.info(
+        f"Output layout verified: BLOCK_SHARDED L1, shard={list(shard_spec.shape)}, "
+        f"grid=({actual_range.start.x},{actual_range.start.y})->({actual_range.end.x},{actual_range.end.y})"
+    )
+
+    # --------------------------------------------------------------------------
     # Verify accuracy
     # --------------------------------------------------------------------------
     accuracy_metrics = {}
 
     if check_accuracy:
         # Output is BLOCK_SHARDED L1 ROW_MAJOR: [E * total_tokens, H] = [128, 2880]
-        tt_output_torch = ttnn.to_torch(tt_outputs[0])
-        logger.info(f"Output shape: {tt_output_torch.shape}, memory: {tt_outputs[0].memory_config()}")
+        # DeepSeek moe_compute layout: 4 shards × (E expert blocks × tokens_per_height_shard rows)
+        # Shard layout: [E0 T0..T7][E1 T0..T7][E2 T0..T7][E3 T0..T7]
+        tt_output_torch = ttnn.to_torch(output_tensor)
+        logger.info(f"Output shape: {tt_output_torch.shape}, memory: {output_mem_config}")
 
-        # Reshape to [E, total_tokens, H] for per-expert comparison
-        tt_output_torch = tt_output_torch.reshape(E, total_tokens, H)
+        # TODO(T=128): tokens_per_shard = T / height_shard_dim (= 32 for T=128)
+        height_shard_dim = 4
+        tokens_per_shard = total_tokens // height_shard_dim  # 8
+        tt_output_torch = tt_output_torch.reshape(height_shard_dim, E, tokens_per_shard, H)
+        tt_output_torch = tt_output_torch.permute(1, 0, 2, 3).reshape(E, total_tokens, H)
 
         for e in range(E):
             x = input_tokens.float()

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt_fused/device/kernels/combine_writer_test_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt_fused/device/kernels/combine_writer_test_kernel.cpp
@@ -1,0 +1,150 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//
+// Standalone test kernel for the combine-write data path.
+//
+// Uses the DeepSeek moe_compute layout: tokens distributed round-robin
+// across height shards, with per-expert blocks within each shard.
+//
+// No ring all-to-all, no matmul, no tilize — just the data movement.
+//
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "moe_gpt_fused_ring_common.h"
+
+namespace detail {
+inline uint32_t div_up(const uint32_t a, const uint32_t b) { return (a + b - 1) / b; }
+}  // namespace detail
+
+void kernel_main() {
+    // Named compile-time args (same as matmul_dm1.cpp)
+    constexpr uint32_t num_experts = get_named_compile_time_arg_val("num_experts");
+    constexpr uint32_t height_shard_dim = get_named_compile_time_arg_val("height_shard_dim");
+    constexpr uint32_t width_shard_dim = get_named_compile_time_arg_val("width_shard_dim");
+    constexpr uint32_t combine_shard_width_tiles = get_named_compile_time_arg_val("combine_shard_width_tiles");
+    constexpr uint32_t tile_width = get_named_compile_time_arg_val("tile_width");
+    constexpr uint32_t tile_width_size_bytes = get_named_compile_time_arg_val("tile_width_size_bytes");
+    constexpr uint32_t num_tokens_total = get_named_compile_time_arg_val("num_tokens_total");
+
+    // Expert block offset within each shard (same as DeepSeek dm1.cpp line 113)
+    constexpr uint32_t shard_offset_per_expert_bytes =
+        num_tokens_total / height_shard_dim * combine_shard_width_tiles * tile_width_size_bytes;
+
+    // OUTPUT_SHARD_CORE_MAP define injected by host (serialized physical coords of combine cores)
+    std::array<uint32_t, 2 * height_shard_dim * width_shard_dim> output_shard_core_map = OUTPUT_SHARD_CORE_MAP;
+
+    // Runtime args
+    uint32_t argidx = 0;
+    const auto ring_core_id = get_arg_val<uint32_t>(argidx++);
+    const auto combine_semaphore_id = get_arg_val<uint32_t>(argidx++);
+    const auto output_base_l1_addr = get_arg_val<uint32_t>(argidx++);
+    const auto vchannel = get_arg_val<uint32_t>(argidx++);
+
+    // CB alias (same as matmul_dm1.cpp)
+    constexpr auto cb_c2s_out = tt::CBIndex::c_14;
+
+    // Constants from moe_gpt_fused_ring_common.h
+    constexpr uint32_t source_width_tiles = moe_gpt_fused_ring::SOURCE_WIDTH_TILES;                  // 8
+    constexpr uint32_t tokens_per_chunk = moe_gpt_fused_ring::TOKENS_PER_CHUNK;                      // 32
+    constexpr uint32_t RING_CORES_PER_COMBINE_COL = moe_gpt_fused_ring::RING_CORES_PER_COMBINE_COL;  // 4
+
+    const uint32_t output_width_tiles_core = moe_gpt_fused_ring::W2_TILES_PER_CORE_A[ring_core_id];
+    const uint32_t width_tile_base = moe_gpt_fused_ring::COMBINE_W_OFFSET_PER_CORE_A[ring_core_id];
+    const uint32_t combine_core_x = ring_core_id / RING_CORES_PER_COMBINE_COL;
+
+    // Semaphore for signaling combine cores
+    uint32_t combine_semaphore_addr = get_semaphore(combine_semaphore_id);
+
+    //-------------------------------------------------------------------------
+    // Setup sharded buffer: make pre-loaded data available via CB.
+    // cb_descriptor_from_sharded_tensor binds the CB to the tensor's L1 buffer,
+    // but cb_wait_front requires pages to be "pushed" first.
+    //-------------------------------------------------------------------------
+    constexpr uint32_t total_pages = num_experts * tokens_per_chunk;  // 4 * 32 = 128
+    cb_reserve_back(cb_c2s_out, total_pages);
+    cb_push_back(cb_c2s_out, total_pages);
+
+    //-------------------------------------------------------------------------
+    // Combine-write loop (DeepSeek moe_compute layout)
+    // Tokens distributed round-robin across height shards.
+    // Each shard: [E0 block][E1 block][E2 block][E3 block]
+    //-------------------------------------------------------------------------
+    for (uint32_t e = 0; e < num_experts; ++e) {
+        // TODO(T=128): Replace with per-expert active token count from gather metadata
+        const uint32_t active_tokens = tokens_per_chunk;
+        const uint32_t max_tokens_per_height_shard = detail::div_up(active_tokens, height_shard_dim);
+        const uint32_t expert_offset_bytes = shard_offset_per_expert_bytes * e;
+
+        // TODO(T=128): Add chunk loop here. For chunk c:
+        //   dest_height_shard_start = (c * tile_height) / max_tokens_per_height_shard
+        //   shard_row_start = (c * tile_height) % max_tokens_per_height_shard
+        const uint32_t dest_height_shard_start = 0;
+        const uint32_t shard_row_start = 0;
+
+        cb_wait_front(cb_c2s_out, tokens_per_chunk);  // 32 pages of untilized data
+        const uint32_t source_base_l1_addr = get_read_ptr(cb_c2s_out);
+
+        uint32_t width_tiles_to_send = output_width_tiles_core;
+        uint32_t width_tiles_sent = 0;
+
+        while (width_tiles_to_send > 0) {
+            const uint32_t width_tile_start = width_tile_base + width_tiles_sent;
+            const uint32_t dest_width_shard = width_tile_start / combine_shard_width_tiles;
+            const uint32_t dest_width_offset_tiles = width_tile_start % combine_shard_width_tiles;
+            const uint32_t dest_width_offset_bytes = dest_width_offset_tiles * tile_width_size_bytes;
+
+            const uint32_t width_transfer_tiles = std::min(
+                combine_shard_width_tiles - dest_width_offset_tiles, output_width_tiles_core - width_tiles_sent);
+            const uint32_t width_transfer_bytes = width_transfer_tiles * tile_width_size_bytes;
+
+            // Token-by-token: dest core changes when height shard changes
+            uint32_t dest_height_shard = dest_height_shard_start;
+            uint32_t shard_row = shard_row_start;
+
+            for (uint32_t bt = 0; bt < tokens_per_chunk; ++bt) {
+                const uint32_t shard_row_offset_bytes = shard_row * combine_shard_width_tiles * tile_width_size_bytes;
+
+                const auto dest_noc_x =
+                    output_shard_core_map[2 * (dest_height_shard * width_shard_dim + dest_width_shard)];
+                const auto dest_noc_y =
+                    output_shard_core_map[2 * (dest_height_shard * width_shard_dim + dest_width_shard) + 1];
+
+                const uint64_t dest_noc_addr_base = get_noc_addr(dest_noc_x, dest_noc_y, output_base_l1_addr, 1);
+                noc_async_write_one_packet_set_state</*posted=*/true>(
+                    dest_noc_addr_base, width_transfer_bytes, /*noc=*/1, vchannel);
+
+                const uint32_t dest_l1_addr =
+                    output_base_l1_addr + expert_offset_bytes + dest_width_offset_bytes + shard_row_offset_bytes;
+
+                const uint32_t source_l1_addr =
+                    source_base_l1_addr + (bt * source_width_tiles + width_tiles_sent) * tile_width_size_bytes;
+
+                noc_async_write_one_packet_with_state</*posted=*/true>(source_l1_addr, dest_l1_addr);
+
+                if (++shard_row == max_tokens_per_height_shard) {
+                    ++dest_height_shard;
+                    shard_row = 0;
+                }
+            }
+            width_tiles_sent += width_transfer_tiles;
+            width_tiles_to_send -= width_transfer_tiles;
+        }
+
+        noc_async_posted_writes_flushed(1);
+        cb_pop_front(cb_c2s_out, tokens_per_chunk);
+    }
+
+    //-------------------------------------------------------------------------
+    // Signal combine cores in this sender's width column
+    //-------------------------------------------------------------------------
+    for (uint32_t y = 0; y < height_shard_dim; ++y) {
+        uint32_t idx = combine_core_x + y * width_shard_dim;
+        uint64_t dest_sem_noc_addr =
+            get_noc_addr(output_shard_core_map[2 * idx], output_shard_core_map[2 * idx + 1], combine_semaphore_addr);
+        noc_semaphore_inc(dest_sem_noc_addr, 1, /*noc_id=*/1, vchannel);
+    }
+    noc_async_atomic_barrier(/*noc_idx=*/1);
+}

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt_fused/device/kernels/matmul_dm1.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt_fused/device/kernels/matmul_dm1.cpp
@@ -3,11 +3,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // DM1 (RISCV_0 / NOC_1) for moe_gpt_fused
-// Ring A2A + DRAM output write (same as moe_gpt dm1 with enable_dram_output)
+// Ring A2A + combine core output write (DeepSeek moe_compute layout)
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "moe_gpt_fused_ring_common.h"
+
+namespace detail {
+inline uint32_t div_up(const uint32_t a, const uint32_t b) { return (a + b - 1) / b; }
+}  // namespace detail
 
 void kernel_main() {
     constexpr uint32_t num_experts = get_named_compile_time_arg_val("num_experts");
@@ -138,12 +142,21 @@ void kernel_main() {
     }
 
     //-------------------------------------------------------------------------
-    // Combine core output write
+    // Combine core output write (DeepSeek moe_compute layout)
     // Untilized ROW_MAJOR data from c_14 → combine core L1
+    //
+    // Each shard contains E expert blocks of max_tokens_per_height_shard rows.
+    // Tokens are distributed round-robin across height shards.
+    // Layout per shard: [E0 rows][E1 rows][E2 rows][E3 rows]
     //-------------------------------------------------------------------------
     constexpr uint32_t source_width_tiles = moe_gpt_fused_ring::SOURCE_WIDTH_TILES;  // 8
     constexpr uint32_t tokens_per_chunk = moe_gpt_fused_ring::TOKENS_PER_CHUNK;
     constexpr uint32_t RING_CORES_PER_COMBINE_COL = moe_gpt_fused_ring::RING_CORES_PER_COMBINE_COL;
+    constexpr uint32_t num_tokens_total = get_named_compile_time_arg_val("num_tokens_total");
+
+    // Expert block offset within each shard (same as DeepSeek dm1.cpp line 113)
+    constexpr uint32_t shard_offset_per_expert_bytes =
+        num_tokens_total / height_shard_dim * combine_shard_width_tiles * tile_width_size_bytes;
 
     const uint32_t output_width_tiles_core = tiles_per_core;
     const uint32_t width_tile_base = moe_gpt_fused_ring::COMBINE_W_OFFSET_PER_CORE_A[ring_core_id];
@@ -152,10 +165,17 @@ void kernel_main() {
     // Semaphore for signaling combine cores
     uint32_t combine_semaphore_addr = get_semaphore(combine_semaphore_id);
 
-    // Each expert maps to one height shard (expert e → height_shard e)
-    // Shard layout: [TOKENS_PER_CHUNK, COMBINE_SHARD_WIDTH_TILES * tile_width] per shard
     for (uint32_t e = 0; e < num_experts; ++e) {
-        const uint32_t dest_height_shard = e;
+        // TODO(T=128): Replace with per-expert active token count from gather metadata
+        const uint32_t active_tokens = tokens_per_chunk;
+        const uint32_t max_tokens_per_height_shard = detail::div_up(active_tokens, height_shard_dim);
+        const uint32_t expert_offset_bytes = shard_offset_per_expert_bytes * e;
+
+        // TODO(T=128): Add chunk loop here. For chunk c:
+        //   dest_height_shard_start = (c * tile_height) / max_tokens_per_height_shard
+        //   shard_row_start = (c * tile_height) % max_tokens_per_height_shard
+        const uint32_t dest_height_shard_start = 0;
+        const uint32_t shard_row_start = 0;
 
         cb_wait_front(cb_c2s_out, tokens_per_chunk);  // 32 pages of untilized data
         const uint32_t source_base_l1_addr = get_read_ptr(cb_c2s_out);
@@ -173,23 +193,35 @@ void kernel_main() {
                 combine_shard_width_tiles - dest_width_offset_tiles, output_width_tiles_core - width_tiles_sent);
             const uint32_t width_transfer_bytes = width_transfer_tiles * tile_width_size_bytes;
 
-            const auto dest_noc_x = output_shard_core_map[2 * (dest_height_shard * width_shard_dim + dest_width_shard)];
-            const auto dest_noc_y =
-                output_shard_core_map[2 * (dest_height_shard * width_shard_dim + dest_width_shard) + 1];
-
-            const uint64_t dest_noc_addr_base = get_noc_addr(dest_noc_x, dest_noc_y, output_base_l1_addr, 1);
-            noc_async_write_one_packet_set_state</*posted=*/true>(
-                dest_noc_addr_base, width_transfer_bytes, /*noc=*/1, vchannel);
+            // Token-by-token: dest core changes when height shard changes
+            // (follows DeepSeek dm1.cpp lines 282-308)
+            uint32_t dest_height_shard = dest_height_shard_start;
+            uint32_t shard_row = shard_row_start;
 
             for (uint32_t bt = 0; bt < tokens_per_chunk; ++bt) {
-                const uint32_t shard_row_offset_bytes = bt * combine_shard_width_tiles * tile_width_size_bytes;
+                const uint32_t shard_row_offset_bytes = shard_row * combine_shard_width_tiles * tile_width_size_bytes;
 
-                const uint32_t dest_l1_addr = output_base_l1_addr + dest_width_offset_bytes + shard_row_offset_bytes;
+                const auto dest_noc_x =
+                    output_shard_core_map[2 * (dest_height_shard * width_shard_dim + dest_width_shard)];
+                const auto dest_noc_y =
+                    output_shard_core_map[2 * (dest_height_shard * width_shard_dim + dest_width_shard) + 1];
+
+                const uint64_t dest_noc_addr_base = get_noc_addr(dest_noc_x, dest_noc_y, output_base_l1_addr, 1);
+                noc_async_write_one_packet_set_state</*posted=*/true>(
+                    dest_noc_addr_base, width_transfer_bytes, /*noc=*/1, vchannel);
+
+                const uint32_t dest_l1_addr =
+                    output_base_l1_addr + expert_offset_bytes + dest_width_offset_bytes + shard_row_offset_bytes;
 
                 const uint32_t source_l1_addr =
                     source_base_l1_addr + (bt * source_width_tiles + width_tiles_sent) * tile_width_size_bytes;
 
                 noc_async_write_one_packet_with_state</*posted=*/true>(source_l1_addr, dest_l1_addr);
+
+                if (++shard_row == max_tokens_per_height_shard) {
+                    ++dest_height_shard;
+                    shard_row = 0;
+                }
             }
             width_tiles_sent += width_transfer_tiles;
             width_tiles_to_send -= width_transfer_tiles;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt_fused/device/kernels/moe_gpt_fused_ring_common.h
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt_fused/device/kernels/moe_gpt_fused_ring_common.h
@@ -106,9 +106,11 @@ constexpr uint32_t NUM_A2A_ITERS_A = *std::max_element(
 // Max output tiles per expert per core (for legacy reference)
 constexpr uint32_t MAX_OUTPUT_TILES_PER_EXPERT = NUM_A2A_ITERS_A * 4;  // 8
 
-// Combine output constants
-// Each height shard = one expert = TOKENS_PER_CHUNK tokens
-// Shard shape: [TOKENS_PER_CHUNK, K / COMBINE_WIDTH_SHARD_DIM] = [32, 960]
+// Combine output constants (DeepSeek moe_compute layout)
+// Each height shard contains E expert blocks of TOKENS_PER_HEIGHT_SHARD rows each.
+// Shard shape: [E * TOKENS_PER_HEIGHT_SHARD, K / COMBINE_WIDTH_SHARD_DIM] = [32, 960]
+// TODO(T=128): Shard shape becomes [E * (T/height_shard_dim), K/width_shard_dim] = [128, 960]
+constexpr uint32_t TOKENS_PER_HEIGHT_SHARD = TOKENS_PER_CHUNK / COMBINE_HEIGHT_SHARD_DIM;  // 32/4 = 8
 constexpr uint32_t COMBINE_SHARD_WIDTH_TILES = K_TILES / COMBINE_WIDTH_SHARD_DIM;  // 90/3 = 30
 constexpr uint32_t SOURCE_WIDTH_TILES = IN2_TILES_PER_STEP_A;                      // 8 (max tiles per core)
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt_fused/device/moe_gpt_fused_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt_fused/device/moe_gpt_fused_program_factory.cpp
@@ -181,6 +181,8 @@ MoEGPTFusedProgramFactory::cached_program_t MoEGPTFusedProgramFactory::create(
         {"combine_shard_width_tiles", combine_shard_width_tiles},
         {"tile_width", 32u},
         {"tile_width_size_bytes", 64u},
+        // TODO(T=128): Change to actual batch size when chunk loop is added
+        {"num_tokens_total", TOKENS_PER_CHUNK},
     };
 
     //=========================================================================


### PR DESCRIPTION
## Summary
- Restructure the combine-write in `matmul_dm1.cpp` to distribute tokens round-robin across height shards with per-expert blocks within each shard (DeepSeek `moe_compute` layout), matching the format expected by `selective_reduce_combine`
- Add standalone combine-writer test kernel (`combine_writer_test_kernel.cpp`) and pytest (`test_combine_writer_standalone.py`) that validates the data movement in isolation (exact match, no compute)
- Update E2E test (`test_moe_gpt_fused.py`) output reshape to decode the new shard layout
- Add `TODO(T=128)` markers at all sites that need changes for chunk loop integration

## Test plan
- [x] `test_combine_writer_standalone.py` — exact match (pure data movement, no compute)
- [x] `test_moe_gpt_fused.py` — 2/2 passed (check_accuracy=True PCC > 0.984, check_accuracy=False layout assertions)