### PR TITLE
Disable t3k ttnn multiprocess tests

### DIFF
--- a/.github/workflows/t3000-fast-tests-impl.yaml
+++ b/.github/workflows/t3000-fast-tests-impl.yaml
@@ -102,19 +102,19 @@ jobs:
         with:
           slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
           owner: UJ45FEC7M #Allan Liu
-      - name: Run t3k ttnn multiprocess tests
-        id: t3k-ttnn-multiprocess-tests
-        timeout-minutes: 15
-        if: ${{ inputs.run-multiprocess-tests == 'true' }}
-        run: |
-          mkdir -p generated/test_reports
-          source tests/scripts/t3000/run_t3000_unit_tests.sh
-          run_t3000_ttnn_multiprocess_tests
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() && steps.t3k-ttnn-multiprocess-tests.outcome == 'failure' }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: UBHPP2NDP #Joseph Chu
+      # - name: Run t3k ttnn multiprocess tests
+      #   id: t3k-ttnn-multiprocess-tests
+      #   timeout-minutes: 15
+      #   if: ${{ inputs.run-multiprocess-tests == 'true' }}
+      #   run: |
+      #     mkdir -p generated/test_reports
+      #     source tests/scripts/t3000/run_t3000_unit_tests.sh
+      #     run_t3000_ttnn_multiprocess_tests
+      # - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
+      #   if: ${{ failure() && steps.t3k-ttnn-multiprocess-tests.outcome == 'failure' }}
+      #   with:
+      #     slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
+      #     owner: UBHPP2NDP #Joseph Chu
 
       - name: Run t3k ttnn ccl tests
         id: t3k-ttnn-ccl-tests

--- a/.github/workflows/t3000-fast-tests-impl.yaml
+++ b/.github/workflows/t3000-fast-tests-impl.yaml
@@ -102,6 +102,7 @@ jobs:
         with:
           slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
           owner: UJ45FEC7M #Allan Liu
+      # The multiprocess tests are currently disabled as they are not stable. We will re-enable them once we have improved their stability.
       # - name: Run t3k ttnn multiprocess tests
       #   id: t3k-ttnn-multiprocess-tests
       #   timeout-minutes: 15


### PR DESCRIPTION
### Problem description
APC is red because of this tests, so we need to disable them till they are fixed

### What's changed
Temporally comment 3k ttnn multiprocess tests

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=dpopov-disable-t3k-ttnn-multiprocess-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:dpopov-disable-t3k-ttnn-multiprocess-tests)
