### PR TITLE
Avoid requiring a MeshGraph instance for build_logical_multi_mesh_adjacency_graph

### DIFF
--- a/tests/tt_metal/tt_fabric/fabric_router/test_topology_solver.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_topology_solver.cpp
@@ -116,6 +116,83 @@ TEST_F(TopologySolverTest, BuildAdjacencyMapLogicalWithSwitch) {
     EXPECT_EQ(switch_mesh_count, 1u) << "Should have 1 switch mesh (mesh_id 1)";
 }
 
+TEST_F(TopologySolverTest, BuildAdjacencyMapLogicalFromDescriptor) {
+    // Use 2x2 T3K multiprocess MGD (has 2 compute meshes: mesh_id 0 and 1)
+    const char* tt_metal_home = std::getenv("TT_METAL_HOME");
+    ASSERT_NE(tt_metal_home, nullptr) << "TT_METAL_HOME environment variable must be set";
+    const std::filesystem::path mesh_graph_desc_path =
+        std::filesystem::path(tt_metal_home) /
+        "tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_2x2_mesh_graph_descriptor.textproto";
+
+    // Create mesh graph from descriptor
+    auto mesh_graph_descriptor = MeshGraphDescriptor(mesh_graph_desc_path);
+    auto mesh_graph = MeshGraph(cluster_type, mesh_graph_desc_path.string());
+
+    // Build adjacency map logical (includes all meshes, including switches if present)
+    auto adjacency_map = build_adjacency_graph_logical(mesh_graph_descriptor);
+    auto adjacency_map_from_graph = build_adjacency_graph_logical(mesh_graph);
+
+    for (const auto& [mesh_id, adj_graph] : adjacency_map) {
+        ASSERT_TRUE(adjacency_map_from_graph.contains(mesh_id))
+            << "Mesh " << mesh_id.get() << " should exist in adjacency map from graph";
+        const auto& adj_graph_from_graph = adjacency_map_from_graph.find(mesh_id)->second;
+        EXPECT_EQ(adj_graph.get_nodes().size(), adj_graph_from_graph.get_nodes().size())
+            << "Mesh " << mesh_id.get() << " should have the same number of nodes";
+        for (int i = 0; i < adj_graph.get_nodes().size(); i++) {
+            EXPECT_EQ(
+                adj_graph.get_neighbors(adj_graph.get_nodes()[i]).size(),
+                adj_graph_from_graph.get_neighbors(adj_graph_from_graph.get_nodes()[i]).size())
+                << "Mesh " << mesh_id.get() << " should have the same number of neighbors for node "
+                << adj_graph.get_nodes()[i];
+        }
+    }
+
+    // For T3K 2x2 multiprocess, we expect 2 meshes (mesh_id 0 and 1)
+    // Note: This includes all meshes returned by get_all_mesh_ids() (compute meshes and switches if present)
+    EXPECT_EQ(adjacency_map.size(), 2u) << "Should have 2 meshes (mesh_id 0 and 1)";
+}
+
+TEST_F(TopologySolverTest, BuildAdjacencyMapLogicalFromDescriptor2) {
+    const char* tt_metal_home = std::getenv("TT_METAL_HOME");
+    ASSERT_NE(tt_metal_home, nullptr) << "TT_METAL_HOME environment variable must be set";
+    const std::filesystem::path mesh_graph_desc_path =
+        std::filesystem::path(tt_metal_home) /
+        "tests/tt_metal/tt_fabric/custom_mesh_descriptors/dual_8x2_mesh_graph_descriptor.textproto";
+
+    // Create mesh graph from descriptor
+    auto mesh_graph_descriptor = MeshGraphDescriptor(mesh_graph_desc_path);
+    auto mesh_graph = MeshGraph(cluster_type, mesh_graph_desc_path.string());
+
+    // Build adjacency map logical (includes all meshes, including switches if present)
+    auto adjacency_map = build_adjacency_graph_logical(mesh_graph_descriptor);
+    auto adjacency_map_from_graph = build_adjacency_graph_logical(mesh_graph);
+
+    for (const auto& [mesh_id, adj_graph] : adjacency_map) {
+        ASSERT_TRUE(adjacency_map_from_graph.contains(mesh_id))
+            << "Mesh " << mesh_id.get() << " should exist in adjacency map from graph";
+        const auto& adj_graph_from_graph = adjacency_map_from_graph.find(mesh_id)->second;
+        EXPECT_EQ(adj_graph.get_nodes().size(), adj_graph_from_graph.get_nodes().size())
+            << "Mesh " << mesh_id.get() << " should have the same number of nodes";
+        for (int i = 0; i < adj_graph.get_nodes().size(); i++) {
+            EXPECT_EQ(
+                adj_graph.get_neighbors(adj_graph.get_nodes()[i]).size(),
+                adj_graph_from_graph.get_neighbors(adj_graph_from_graph.get_nodes()[i]).size())
+                << "Mesh " << mesh_id.get() << " should have the same number of neighbors for node "
+                << adj_graph.get_nodes()[i];
+
+            for (const auto& neighbor : adj_graph.get_neighbors(adj_graph.get_nodes()[i])) {
+                EXPECT_TRUE(
+                    std::find(
+                        adj_graph_from_graph.get_neighbors(adj_graph_from_graph.get_nodes()[i]).begin(),
+                        adj_graph_from_graph.get_neighbors(adj_graph_from_graph.get_nodes()[i]).end(),
+                        neighbor) != adj_graph_from_graph.get_neighbors(adj_graph_from_graph.get_nodes()[i]).end())
+                    << "Mesh " << mesh_id.get() << " should have neighbor " << neighbor << " for node "
+                    << adj_graph.get_nodes()[i];
+            }
+        }
+    }
+}
+
 TEST_F(TopologySolverTest, BuildAdjacencyMapPhysical) {
     // Load PSD from pre-written test file
     const char* tt_metal_home = std::getenv("TT_METAL_HOME");

--- a/tt_metal/api/tt-metalium/experimental/fabric/topology_mapper_utils.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/topology_mapper_utils.hpp
@@ -316,6 +316,15 @@ struct LogicalMultiMeshGraph {
 LogicalMultiMeshGraph build_logical_multi_mesh_adjacency_graph(const ::tt::tt_fabric::MeshGraph& mesh_graph);
 
 /**
+ * @brief Build logical multi-mesh adjacency graph from MeshGraphDescriptor
+ *
+ * Same as above but takes MeshGraphDescriptor instead of MeshGraph. Prefer this overload when
+ * the descriptor is already available to avoid constructing a MeshGraph.
+ */
+LogicalMultiMeshGraph build_logical_multi_mesh_adjacency_graph(
+    const ::tt::tt_fabric::MeshGraphDescriptor& mesh_graph_descriptor);
+
+/**
  * @brief Represents a physical mesh node in a 2-layer adjacency graph
  *
  * Simplified to just be a MeshId. The internal adjacency graph is accessed via

--- a/tt_metal/api/tt-metalium/experimental/fabric/topology_solver.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/topology_solver.hpp
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include <tt-metalium/experimental/fabric/mesh_graph.hpp>
+#include <tt-metalium/experimental/fabric/mesh_graph_descriptor.hpp>
 #include <tt-metalium/experimental/fabric/fabric_types.hpp>
 
 namespace tt::tt_metal {
@@ -80,6 +81,7 @@ private:
 };
 
 std::map<MeshId, AdjacencyGraph<FabricNodeId>> build_adjacency_graph_logical(const MeshGraph& mesh_graph);
+std::map<MeshId, AdjacencyGraph<FabricNodeId>> build_adjacency_graph_logical(const MeshGraphDescriptor& mgd);
 
 std::map<MeshId, AdjacencyGraph<tt::tt_metal::AsicID>> build_adjacency_graph_physical(
     tt::tt_metal::ClusterType cluster_type,

--- a/tt_metal/fabric/topology_mapper_utils.cpp
+++ b/tt_metal/fabric/topology_mapper_utils.cpp
@@ -17,6 +17,7 @@
 #include <tt-logger/tt-logger.hpp>
 #include <fmt/format.h>
 #include <tt-metalium/experimental/fabric/mesh_graph.hpp>
+#include <tt-metalium/experimental/fabric/mesh_graph_descriptor.hpp>
 #include <tt-metalium/experimental/fabric/topology_solver.hpp>
 #include "tt_metal/fabric/physical_system_descriptor.hpp"
 #include "tt_metal/impl/context/metal_context.hpp"
@@ -236,7 +237,47 @@ std::map<MeshId, PhysicalAdjacencyMap> build_adjacency_map_physical(
     return result;
 }
 
-LogicalMultiMeshGraph build_logical_multi_mesh_adjacency_graph(const ::tt::tt_fabric::MeshGraph& mesh_graph) {
+namespace {
+
+// Extract requested inter-mesh connections and ports from MeshGraphDescriptor (same logic as
+// MeshGraph::initialize_from_mgd).
+std::pair<::tt::tt_fabric::RequestedIntermeshConnections, ::tt::tt_fabric::RequestedIntermeshPorts>
+get_requested_intermesh_from_mgd(const ::tt::tt_fabric::MeshGraphDescriptor& mgd) {
+    ::tt::tt_fabric::RequestedIntermeshConnections requested_intermesh_connections;
+    ::tt::tt_fabric::RequestedIntermeshPorts requested_intermesh_ports;
+
+    if (!mgd.has_connections_of_type("FABRIC")) {
+        return {requested_intermesh_connections, requested_intermesh_ports};
+    }
+
+    for (::tt::tt_fabric::ConnectionId conn_id : mgd.connections_by_type("FABRIC")) {
+        const auto& connection_data = mgd.get_connection(conn_id);
+        const auto& src_instance = mgd.get_instance(connection_data.nodes[0]);
+        const auto& dst_instance = mgd.get_instance(connection_data.nodes[1]);
+
+        bool is_device_level = (src_instance.kind == ::tt::tt_fabric::NodeKind::Device) &&
+                               (dst_instance.kind == ::tt::tt_fabric::NodeKind::Device);
+
+        if (is_device_level) {
+            const auto& src_mesh_instance = mgd.get_instance(src_instance.hierarchy.back());
+            const auto& dst_mesh_instance = mgd.get_instance(dst_instance.hierarchy.back());
+            uint32_t src_mesh_id_val = src_mesh_instance.local_id;
+            uint32_t dst_mesh_id_val = dst_mesh_instance.local_id;
+            requested_intermesh_ports[src_mesh_id_val][dst_mesh_id_val].push_back(
+                {src_instance.local_id, dst_instance.local_id, connection_data.count});
+        } else {
+            uint32_t src_mesh_id_val = src_instance.local_id;
+            uint32_t dst_mesh_id_val = dst_instance.local_id;
+            requested_intermesh_connections[src_mesh_id_val][dst_mesh_id_val] = connection_data.count;
+        }
+    }
+    return {requested_intermesh_connections, requested_intermesh_ports};
+}
+
+LogicalMultiMeshGraph build_logical_multi_mesh_adjacency_graph_impl(
+    const std::map<MeshId, ::tt::tt_fabric::AdjacencyGraph<FabricNodeId>>& mesh_adjacency_graphs,
+    const ::tt::tt_fabric::RequestedIntermeshConnections& requested_intermesh_connections,
+    const ::tt::tt_fabric::RequestedIntermeshPorts& requested_intermesh_ports) {
     // This function handles both strict mode (requested_intermesh_ports) and relaxed mode
     // (requested_intermesh_connections) intermesh connections:
     // - Strict mode: Creates fabric node-level exit nodes (LogicalExitNode with mesh_id and fabric_node_id)
@@ -245,30 +286,17 @@ LogicalMultiMeshGraph build_logical_multi_mesh_adjacency_graph(const ::tt::tt_fa
     // Currently, MGD validation prevents mixing policies, but when this feature is added,
     // this function will need to handle both simultaneously, creating appropriate exit node types
     // based on the connection type.
+    using namespace ::tt::tt_fabric;
 
-    // Build logical adjacency graphs for each mesh using topology solver's function
-    auto mesh_adjacency_graphs = ::tt::tt_fabric::build_adjacency_graph_logical(mesh_graph);
-
-    // Build logical multi-mesh adjacency graph
     LogicalMultiMeshGraph logical_multi_mesh_graph;
 
-    // Store mesh adjacency graphs once (no duplication)
     for (const auto& [mesh_id, adjacency_graph] : mesh_adjacency_graphs) {
         logical_multi_mesh_graph.mesh_adjacency_graphs_[mesh_id] = adjacency_graph;
     }
 
-    // Build mesh-level adjacency map using MeshIds (lightweight)
-    ::tt::tt_fabric::AdjacencyGraph<MeshId>::AdjacencyMap mesh_level_adjacency_map;
-
-    // Build exit node adjacency maps (only for strict mode)
+    AdjacencyGraph<MeshId>::AdjacencyMap mesh_level_adjacency_map;
     std::map<MeshId, AdjacencyGraph<LogicalExitNode>::AdjacencyMap> exit_node_adjacency_maps;
 
-    // Get requested inter-mesh connections (relaxed mode) and ports (strict mode)
-    const auto& requested_intermesh_connections = mesh_graph.get_requested_intermesh_connections();
-    const auto& requested_intermesh_ports = mesh_graph.get_requested_intermesh_ports();
-
-    // Process requested_intermesh_ports (strict mode) if it exists
-    // Mapping: src_mesh -> dst_mesh -> list of (src_device, dst_device, num_channels)
     if (!requested_intermesh_ports.empty()) {
         for (const auto& [src_mesh_id_val, dst_mesh_map] : requested_intermesh_ports) {
             MeshId src_mesh_id(src_mesh_id_val);
@@ -363,13 +391,8 @@ LogicalMultiMeshGraph build_logical_multi_mesh_adjacency_graph(const ::tt::tt_fa
     }
 
     // Build mesh-level graph from adjacency map
-    logical_multi_mesh_graph.mesh_level_graph_ = ::tt::tt_fabric::AdjacencyGraph<MeshId>(mesh_level_adjacency_map);
+    logical_multi_mesh_graph.mesh_level_graph_ = AdjacencyGraph<MeshId>(mesh_level_adjacency_map);
 
-    // Convert exit node adjacency maps to graphs
-    // Populated for:
-    // - Strict mode (requested_intermesh_ports): fabric node-level exit nodes
-    // - Relaxed mode (requested_intermesh_connections): mesh-level exit nodes
-    // Initialize exit node graphs for all meshes (even if empty) for consistency
     for (const auto& [mesh_id, _] : mesh_adjacency_graphs) {
         auto exit_node_it = exit_node_adjacency_maps.find(mesh_id);
         if (exit_node_it != exit_node_adjacency_maps.end() && !exit_node_it->second.empty()) {
@@ -380,8 +403,28 @@ LogicalMultiMeshGraph build_logical_multi_mesh_adjacency_graph(const ::tt::tt_fa
             logical_multi_mesh_graph.mesh_exit_node_graphs_[mesh_id] = AdjacencyGraph<LogicalExitNode>();
         }
     }
-
     return logical_multi_mesh_graph;
+}
+
+}  // namespace
+
+LogicalMultiMeshGraph build_logical_multi_mesh_adjacency_graph(
+    const ::tt::tt_fabric::MeshGraphDescriptor& mesh_graph_descriptor) {
+    auto mesh_adjacency_graphs = ::tt::tt_fabric::build_adjacency_graph_logical(mesh_graph_descriptor);
+    auto [requested_intermesh_connections, requested_intermesh_ports] =
+        get_requested_intermesh_from_mgd(mesh_graph_descriptor);
+    return build_logical_multi_mesh_adjacency_graph_impl(
+        mesh_adjacency_graphs, requested_intermesh_connections, requested_intermesh_ports);
+}
+
+LogicalMultiMeshGraph build_logical_multi_mesh_adjacency_graph(const ::tt::tt_fabric::MeshGraph& mesh_graph) {
+    // This function handles both strict mode (requested_intermesh_ports) and relaxed mode
+    // (requested_intermesh_connections) intermesh connections - see build_logical_multi_mesh_adjacency_graph_impl.
+    auto mesh_adjacency_graphs = ::tt::tt_fabric::build_adjacency_graph_logical(mesh_graph);
+    const auto& requested_intermesh_connections = mesh_graph.get_requested_intermesh_connections();
+    const auto& requested_intermesh_ports = mesh_graph.get_requested_intermesh_ports();
+    return build_logical_multi_mesh_adjacency_graph_impl(
+        mesh_adjacency_graphs, requested_intermesh_connections, requested_intermesh_ports);
 }
 
 /**

--- a/tt_metal/fabric/topology_solver.cpp
+++ b/tt_metal/fabric/topology_solver.cpp
@@ -6,10 +6,73 @@
 
 #include <tt-metalium/experimental/fabric/topology_solver.hpp>
 #include <tt-metalium/experimental/fabric/fabric_types.hpp>
+#include <tt-metalium/experimental/fabric/mesh_graph_descriptor.hpp>
+
 #include "tt_metal/fabric/physical_system_descriptor.hpp"
+
 #include <llrt/tt_cluster.hpp>
 
 namespace tt::tt_fabric {
+
+std::map<MeshId, AdjacencyGraph<FabricNodeId>> build_adjacency_graph_logical(const MeshGraphDescriptor& mgd) {
+    std::map<MeshId, AdjacencyGraph<FabricNodeId>::AdjacencyMap> adjacency_maps;
+
+    // Collect all mesh and switch instances (same order as MeshGraph: meshes then switches)
+    std::vector<GlobalNodeId> mesh_and_switch_instances;
+    for (GlobalNodeId id : mgd.all_meshes()) {
+        mesh_and_switch_instances.push_back(id);
+    }
+    for (GlobalNodeId id : mgd.all_switches()) {
+        mesh_and_switch_instances.push_back(id);
+    }
+
+    // Initialize nodes for each mesh/switch
+    for (GlobalNodeId mesh_global_id : mesh_and_switch_instances) {
+        const auto& instance = mgd.get_instance(mesh_global_id);
+        MeshId mesh_id(instance.local_id);
+        AdjacencyGraph<FabricNodeId>::AdjacencyMap& adj = adjacency_maps[mesh_id];
+        for (GlobalNodeId device_global_id : instance.sub_instances) {
+            const auto& device_inst = mgd.get_instance(device_global_id);
+            adj[FabricNodeId(mesh_id, device_inst.local_id)] = std::vector<FabricNodeId>();
+        }
+    }
+
+    // Add intra-mesh edges from MESH connections (device-device within a mesh, populated by descriptor)
+    if (mgd.has_connections_of_type("MESH")) {
+        for (ConnectionId conn_id : mgd.connections_by_type("MESH")) {
+            const auto& conn = mgd.get_connection(conn_id);
+            const auto& src_inst = mgd.get_instance(conn.nodes[0]);
+            const auto& dst_inst = mgd.get_instance(conn.nodes[1]);
+            if (src_inst.kind != NodeKind::Device || dst_inst.kind != NodeKind::Device) {
+                continue;
+            }
+            GlobalNodeId src_mesh_global = src_inst.hierarchy.back();
+            GlobalNodeId dst_mesh_global = dst_inst.hierarchy.back();
+            if (src_mesh_global != dst_mesh_global) {
+                continue;
+            }
+            const auto& mesh_inst = mgd.get_instance(src_mesh_global);
+            MeshId mesh_id(mesh_inst.local_id);
+            FabricNodeId src_node(mesh_id, src_inst.local_id);
+            FabricNodeId dst_node(mesh_id, dst_inst.local_id);
+            if (src_node == dst_node) {
+                continue;
+            }
+            auto it = adjacency_maps.find(mesh_id);
+            if (it != adjacency_maps.end()) {
+                for (uint32_t i = 0; i < conn.count; ++i) {
+                    it->second[src_node].push_back(dst_node);
+                }
+            }
+        }
+    }
+
+    std::map<MeshId, AdjacencyGraph<FabricNodeId>> result;
+    for (auto& [mesh_id, adj_map] : adjacency_maps) {
+        result[mesh_id] = AdjacencyGraph<FabricNodeId>(adj_map);
+    }
+    return result;
+}
 
 std::map<MeshId, AdjacencyGraph<FabricNodeId>> build_adjacency_graph_logical(const MeshGraph& mesh_graph) {
     std::map<MeshId, AdjacencyGraph<FabricNodeId>> adjacency_map;


### PR DESCRIPTION
### Problem description
`build_logical_multi_mesh_adjacency_graph` requires a `MeshGraph` instance. Whereas it could use a `MeshGraphDescriptor`, which is preferable especially when consuming the API outside metalium (e.g. in fabric manager).

### What's changed
Add a `build_logical_multi_mesh_adjacency_graph` which takes a `MeshGraphDescriptor` as argument.