### PR TITLE
Skip test_reduce_to_root_with_trace on all BH setups

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_reduce_to_root_trace.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_reduce_to_root_trace.py
@@ -87,6 +87,9 @@ def compute_reference_reduce_to_root(
     return torch.cat(l_final_cores, dim=1), torch.cat(s_final_cores, dim=1), torch.cat(m_final_cores, dim=1)
 
 
+@pytest.mark.skip(
+    reason="Consistently failing with data mismatch after trace replay on all BH multi-chip setups. See #39098"
+)
 @skip_for_wormhole_b0("This test is for blackhole")
 @pytest.mark.parametrize(
     "device_params",


### PR DESCRIPTION
## Summary

- Skip `test_reduce_to_root_with_trace` which is **consistently failing** across all Blackhole multi-chip configurations in the nightly e2e pipeline

The test fails with `AssertionError: L tensor output does not match reference after trace execution` — the trace replay produces incorrect data for the `reduce_to_root` operation.

## Failing runs (sample)

- [BH-QB-GE, Mar 4](https://github.com/tenstorrent/tt-metal/actions/runs/22648629127/job/65643304429)
- [BH-LLMBox, Mar 3](https://github.com/tenstorrent/tt-metal/actions/runs/22631873604/job/65606628947)
- [BH-QB-GE, Mar 3](https://github.com/tenstorrent/tt-metal/actions/runs/22631873604/job/65606637353)
- [BH-LoudBox, Mar 3](https://github.com/tenstorrent/tt-metal/actions/runs/22631873604/job/65606669578)
- [BH-LLMBox, Mar 3](https://github.com/tenstorrent/tt-metal/actions/runs/22613953331/job/65522971582)
- [BH-LLMBox, Mar 3](https://github.com/tenstorrent/tt-metal/actions/runs/22601696996/job/65485443016)
- [BH-QB-GE, Mar 3](https://github.com/tenstorrent/tt-metal/actions/runs/22601696996/job/65485446264)
- [BH-LLMBox, Mar 2](https://github.com/tenstorrent/tt-metal/actions/runs/22584522312/job/65443100616)
- [BH-LoudBox, Mar 2](https://github.com/tenstorrent/tt-metal/actions/runs/22584522312/job/65443100844)
- [BH-LLMBox, Mar 2](https://github.com/tenstorrent/tt-metal/actions/runs/22566960454/job/65365758252)
- [BH-QB-GE, Mar 2](https://github.com/tenstorrent/tt-metal/actions/runs/22566960454/job/65365760849)
- [BH-LoudBox, Mar 2](https://github.com/tenstorrent/tt-metal/actions/runs/22556072170/job/65356713096)
- [BH-LLMBox, Mar 2](https://github.com/tenstorrent/tt-metal/actions/runs/22556072170/job/65356713135)
- [BH-QB-GE, Mar 2](https://github.com/tenstorrent/tt-metal/actions/runs/22556072170/job/65356713222)
