### PR TITLE
[WAN2.2] Replace BH_LB 1x8 config with 4x2 mesh across all WAN tests

### DIFF
--- a/models/tt_dit/pipelines/wan/pipeline_wan.py
+++ b/models/tt_dit/pipelines/wan/pipeline_wan.py
@@ -298,11 +298,11 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
                 "is_fsdp": True,
             }
             device_configs[(2, 2)] = device_configs[(1, 4)]
-            device_configs[(1, 8)] = {
-                "sp_axis": 0,
-                "tp_axis": 1,
+            device_configs[(2, 4)] = {
+                "sp_axis": 1,
+                "tp_axis": 0,
                 "num_links": 2,
-                "dynamic_load": False,
+                "dynamic_load": True,
                 "topology": ttnn.Topology.Linear,
                 "is_fsdp": False,
             }
@@ -388,6 +388,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             subfolder="transformer",
             parallel_config=self.parallel_config,
             mesh_shape=tuple(self.mesh_device.shape),
+            is_fsdp=self.is_fsdp,
             get_torch_state_dict=lambda: self.torch_transformer.state_dict(),
         )
 
@@ -398,6 +399,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             subfolder="transformer_2",
             parallel_config=self.parallel_config,
             mesh_shape=tuple(self.mesh_device.shape),
+            is_fsdp=self.is_fsdp,
             get_torch_state_dict=lambda: self.torch_transformer_2.state_dict(),
         )
 

--- a/models/tt_dit/tests/models/wan2_2/test_performance_wan.py
+++ b/models/tt_dit/tests/models/wan2_2/test_performance_wan.py
@@ -23,12 +23,20 @@ from ....utils.test import line_params, ring_params
 def t2v_metrics(mesh_device, height):
     expected_metrics = {}
     if tuple(mesh_device.shape) == (2, 4) and height == 480:
-        expected_metrics = {
-            "encoder": 0.1,
-            "denoising": 800.0,
-            "vae": 9.0,
-            "total": 850.0,
-        }
+        if is_blackhole():
+            expected_metrics = {
+                "encoder": 0.08,
+                "denoising": 240.0,
+                "vae": 5.0,
+                "total": 255.0,
+            }
+        else:
+            expected_metrics = {
+                "encoder": 0.1,
+                "denoising": 800.0,
+                "vae": 9.0,
+                "total": 850.0,
+            }
     elif tuple(mesh_device.shape) == (4, 8) and height == 480:
         expected_metrics = {
             "encoder": 0.1,
@@ -60,14 +68,6 @@ def t2v_metrics(mesh_device, height):
             "vae": 60.0,
             "total": 760.0,
         }
-    elif tuple(mesh_device.shape) == (1, 8) and height == 480:
-        assert is_blackhole(), "1x8 is only supported for blackhole"
-        expected_metrics = {
-            "encoder": 0.08,
-            "denoising": 426.6,
-            "vae": 10.0,
-            "total": 449.3,
-        }
     else:
         assert False, f"Unknown mesh device for performance comparison: {mesh_device}"
     return expected_metrics
@@ -86,7 +86,7 @@ def wan_pipeline_metrics_condimg(mesh_device, width, height, model_type):
     else:
         pipeline_cls = WanPipelineI2V
         expected_metrics = i2v_metrics(mesh_device, height)
-        image_prompt = Image.fromarray(np.random.randint(0, 256, (height, width, 3)), "RGB")
+        image_prompt = Image.fromarray(np.random.randint(0, 256, (height, width, 3), dtype=np.uint8), "RGB")
 
     return pipeline_cls, image_prompt, expected_metrics
 
@@ -97,7 +97,8 @@ def wan_pipeline_metrics_condimg(mesh_device, width, height, model_type):
         # FSDP is needed for 2x2 with encoder now on device
         [(2, 2), (2, 2), 0, 1, 2, False, line_params, ttnn.Topology.Linear, True],
         [(2, 4), (2, 4), 0, 1, 1, True, line_params, ttnn.Topology.Linear, True],
-        [(1, 8), (1, 8), 0, 1, 2, False, line_params, ttnn.Topology.Linear, False],
+        # BH on 2x4 with dynamic_load to avoid init-time DRAM OOM
+        [(2, 4), (2, 4), 1, 0, 2, True, line_params, ttnn.Topology.Linear, False],
         # WH (ring) on 4x8
         [(4, 8), (4, 8), 1, 0, 4, False, ring_params, ttnn.Topology.Ring, True],
         # BH (linear) on 4x8
@@ -106,7 +107,7 @@ def wan_pipeline_metrics_condimg(mesh_device, width, height, model_type):
     ids=[
         "2x2sp0tp1",
         "2x4sp0tp1",
-        "1x8sp0tp1",
+        "bh_2x4sp1tp0",
         "wh_4x8sp1tp0",
         "bh_4x8sp1tp0",
     ],
@@ -323,8 +324,7 @@ def test_pipeline_performance(
                 )
         device_name_map = {
             (2, 2): "BH_QB",
-            (2, 4): "WH_T3K",
-            (1, 8): "BH_LB",
+            (2, 4): "BH_LB" if is_blackhole() else "WH_T3K",
             (4, 8): "BH_GLX" if is_blackhole() else "WH_GLX",
         }
         benchmark_data.save_partial_run_json(

--- a/models/tt_dit/tests/models/wan2_2/test_pipeline_wan_i2v.py
+++ b/models/tt_dit/tests/models/wan2_2/test_pipeline_wan_i2v.py
@@ -19,7 +19,8 @@ from ....utils.test import line_params, ring_params
     [
         [(2, 2), (2, 2), 0, 1, 2, False, line_params, ttnn.Topology.Linear, True],
         [(2, 4), (2, 4), 0, 1, 1, True, line_params, ttnn.Topology.Linear, True],
-        [(1, 8), (1, 8), 0, 1, 2, False, line_params, ttnn.Topology.Linear, False],
+        # BH on 2x4 with dynamic_load to avoid init-time DRAM OOM
+        [(2, 4), (2, 4), 1, 0, 2, True, line_params, ttnn.Topology.Linear, False],
         # WH (ring) on 4x8
         [(4, 8), (4, 8), 1, 0, 4, False, ring_params, ttnn.Topology.Ring, True],
         # BH (linear) on 4x8
@@ -28,7 +29,7 @@ from ....utils.test import line_params, ring_params
     ids=[
         "2x2sp0tp1",
         "2x4sp0tp1",
-        "1x8sp0tp1",
+        "bh_2x4sp1tp0",
         "wh_4x8sp1tp0",
         "bh_4x8sp1tp0",
     ],

--- a/tests/pipeline_reorg/blackhole_demo_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_demo_tests.yaml
@@ -299,7 +299,7 @@
   model-name: wan2.2-t2v-a14b
 
 - name: Wan2.2-T2V-A14B BH LoudBox performance
-  cmd: HF_HUB_CACHE=/localdev/blackhole_demos/huggingface_data/Wan-AI TT_DIT_CACHE_DIR="/tmp/TT_DIT_CACHE" pytest models/tt_dit/tests/models/wan2_2/test_performance_wan.py -k "1x8sp0tp1 and resolution_480p and t2v" --timeout=1200
+  cmd: HF_HUB_CACHE=/localdev/blackhole_demos/huggingface_data/Wan-AI TT_DIT_CACHE_DIR="/tmp/TT_DIT_CACHE" pytest models/tt_dit/tests/models/wan2_2/test_performance_wan.py -k "bh_2x4sp1tp0 and resolution_480p and t2v" --timeout=1200
   skus:
     bh_loudbox:
       timeout: 20


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
The Blackhole loud box (BH_LB) WAN2.2 pipeline tests used a (1,8) SP=1 TP=8 mesh configuration, which is suboptimal for performance. Exploration showed that a (4,2) SP=4 TP=2 mesh with `dynamic_load=True` is 49% faster end-to-end (228s vs 449s) while avoiding init-time DRAM OOM that occurs with SP=4 TP=2 without dynamic_load.

Additionally, the transformer cache loading was not passing `is_fsdp`, causing incorrect cache directory resolution when FSDP is enabled.

### What's changed
- Replaced the (1,8) device config with (4,2) in `pipeline_wan.py`, with `dynamic_load=True` set as the default
- Replaced the (1,8) test parametrization with (4,2) across `test_performance_wan.py` and `test_pipeline_wan_i2v.py`
- Updated BH_LB performance thresholds based on measured results (encoder: 0.08s, denoising: 240s, vae: 5s, total: 255s)
- Pass `is_fsdp` to transformer cache loading in `_prepare_transformer1` and `_prepare_transformer2`

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=kevinmi/wan2.2-replace-bh-lb-1x8-with-4x2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:kevinmi/wan2.2-replace-bh-lb-1x8-with-4x2)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=kevinmi/wan2.2-replace-bh-lb-1x8-with-4x2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:kevinmi/wan2.2-replace-bh-lb-1x8-with-4x2)
- [ ] New/Existing tests provide coverage for changes

#### Model tests

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kevinmi/wan2.2-replace-bh-lb-1x8-with-4x2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kevinmi/wan2.2-replace-bh-lb-1x8-with-4x2)
  - [ ] `models-mandatory` preset
  - [ ] `models-extended` preset

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kevinmi/wan2.2-replace-bh-lb-1x8-with-4x2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kevinmi/wan2.2-replace-bh-lb-1x8-with-4x2)
  - [ ] `models-mandatory` preset
  - [ ] `models-extended` preset

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kevinmi/wan2.2-replace-bh-lb-1x8-with-4x2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kevinmi/wan2.2-replace-bh-lb-1x8-with-4x2)
  - [ ] `models-mandatory` preset
  - [ ] `models-extended` preset