### PR TITLE
Fix spelling/typos in models code

### DIFF
--- a/models/common/utility_functions.py
+++ b/models/common/utility_functions.py
@@ -622,7 +622,7 @@ def comp_ulp(golden, calculated, ulp_threshold, allow_nonfinite=False):
 
     if not _comp_nonfinite(golden, calculated):
         return False, "Tensors are not finite at the same positions"
-    # nonfinite elments can intefere with ULP error calculation
+    # nonfinite elements can interfere with ULP error calculation
     # To avoid this, replace nan, +inf, -inf with 0
     # (we have already checked that both tensors have the same nonfinite elements)
     mask_finite = ~torch.isfinite(golden)

--- a/models/demos/llama3_70b_galaxy/demo/text_demo.py
+++ b/models/demos/llama3_70b_galaxy/demo/text_demo.py
@@ -68,7 +68,7 @@ def load_inputs(user_input, len_per_batch, instruct):
     cache_dir.mkdir(parents=True, exist_ok=True)
 
     # The demo supports a custom prompt file, where the context is provided by a link to a book from the gutenberg project
-    # It clips the excerpt to the max length provided to allow testing different long context lengthts
+    # It clips the excerpt to the max length provided to allow testing different long context lengths
     for i in range(len(user_input)):
         prompt = user_input[i]["prompt"]
         if "context" in user_input[i]:

--- a/models/demos/multimodal/gemma3/demo/text_demo.py
+++ b/models/demos/multimodal/gemma3/demo/text_demo.py
@@ -195,7 +195,7 @@ def load_inputs(user_input, batch, instruct):
     cache_dir.mkdir(parents=True, exist_ok=True)
 
     # The demo supports a custom prompt file, where the context is provided by a link to a book from the gutenberg project
-    # It clips the excerpt to the max length provided to allow testing different long context lengthts
+    # It clips the excerpt to the max length provided to allow testing different long context lengths
     for i in range(batch):
         prompt = user_input[i]["prompt"]
         if "context" in user_input[i]:

--- a/models/demos/t3000/falcon40b/tt/falcon_decoder.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_decoder.py
@@ -260,7 +260,7 @@ class TtFalconDecoderLayer:
         )
         attention_output, outputs = attn_outputs[0], attn_outputs[1:]
 
-        # Add attn output to residiual first in place to save memory
+        # Add attn output to residual first in place to save memory
         # Note that this is only correct in inference when dropout is disabled
         output = ttnn.add(
             output,
@@ -368,7 +368,7 @@ class TtFalconDecoderLayer:
         )
         attention_output, outputs = attn_outputs[0], attn_outputs[1:]
 
-        # Add attn output to residiual first in place to save memory
+        # Add attn output to residual first in place to save memory
         # Note that this is only correct in inference when dropout is disabled
         output = ttnn.add(
             output,

--- a/models/demos/t3000/llama2_70b/tt/llama_decoder_optimized.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_decoder_optimized.py
@@ -212,7 +212,7 @@ class TtLlamaDecoder_optimized:
         )
 
         ### Fractured residual add
-        # Add attn output to residiual first in place to save memory
+        # Add attn output to residual first in place to save memory
         output = xs
         output = ttnn.add(
             output,

--- a/models/docs/MODEL_UPDATES.md
+++ b/models/docs/MODEL_UPDATES.md
@@ -161,7 +161,7 @@
 
 ### [Llama 3.1/3.2](https://github.com/tenstorrent/tt-metal/tree/main/models/tt_transformers)
 - Added support for batch size 32 and the maximum context length (131072 tokens).
-- Added full hardware compatibilty for the 1B/3B/8B/11B/70B models (all models are now compatible with N150, N300, QuietBox, Galaxy except for 70B which is only supported on QuietBox and Galaxy due to its large size).
+- Added full hardware compatibility for the 1B/3B/8B/11B/70B models (all models are now compatible with N150, N300, QuietBox, Galaxy except for 70B which is only supported on QuietBox and Galaxy due to its large size).
 
 ## December 2, 2024
 

--- a/models/docs/model_bring_up.md
+++ b/models/docs/model_bring_up.md
@@ -34,7 +34,7 @@ After setting up the environment correctly, run a demo to test the environment.
   - First use a single device for simpler bring-up if models can fit on that single device; Wormhole has 12 GB DRAM storage and can support models of up to roughly 12B parameters in BFP8. If possible, use a smaller version of the model that fits on a single device. The model can be scaled up in size and on more devices.
 
 > [!NOTE]
-> In the llama3 demo implementation the decode stage supports batch=32. Each row is a separate user in 32x32 tiles used by the TT-Metalium stack. The prefill stage supports batch=1 where rows map to different iput tokens. Because prefill is compute-bound, multiple batches do not benefit performance. See [Converting Torch Model to TT-NN](https://docs.tenstorrent.com/docs-test/ttnn/latest/ttnn/converting_torch_model_to_ttnn.html) for model conversion.
+> In the llama3 demo implementation the decode stage supports batch=32. Each row is a separate user in 32x32 tiles used by the TT-Metalium stack. The prefill stage supports batch=1 where rows map to different input tokens. Because prefill is compute-bound, multiple batches do not benefit performance. See [Converting Torch Model to TT-NN](https://docs.tenstorrent.com/docs-test/ttnn/latest/ttnn/converting_torch_model_to_ttnn.html) for model conversion.
 
 ## Systematic Component-wise Large Language Model (LLM) Bring-Up
 
@@ -53,7 +53,7 @@ After setting up the environment correctly, run a demo to test the environment.
 6. Test the model configuration without a dedicated prefill implementation.
 7. Create a full model test. Use real inputs to produce real outputs; for LLMs, input text to output decoded tokens.
 8. Run the same inputs through the reference and TT-NN models to check the accuracy of your implementation. Teacher forcing is the ideal method to use with LLMs.
-9. Generate tokens from the reference and TT-NN models. Input the reference tokens into both models in the next interation. Depending on differences in the outputs, you can check accuracy metrics.
+9. Generate tokens from the reference and TT-NN models. Input the reference tokens into both models in the next iteration. Depending on differences in the outputs, you can check accuracy metrics.
 10. Verify the output tokens are:
     - Meaningful and coherent.
     - Similar to reference model tokens.

--- a/models/experimental/uniad/reference/encoder.py
+++ b/models/experimental/uniad/reference/encoder.py
@@ -360,7 +360,7 @@ class BEVFormerLayer(nn.Module):
                 query = self.norms[norm_index](query)
                 norm_index += 1
 
-            # spaital cross attention
+            # spatial cross attention
             elif layer == "cross_attn":
                 query = self.attentions[attn_index](
                     query,

--- a/models/experimental/uniad/reference/pan_segformer_head.py
+++ b/models/experimental/uniad/reference/pan_segformer_head.py
@@ -510,7 +510,7 @@ class PansegformerHead(nn.Module):
                 mask_pred.dtype
             )
             for i, scores in enumerate(scores_all):
-                # MDS: things and sutff have different threholds may perform a little bit better
+                # MDS: things and stuff have different thresholds may perform a little bit better
                 if labels_all[i] < self.num_things_classes and scores < self.quality_threshold_things:
                     continue
                 elif labels_all[i] >= self.num_things_classes and scores < self.quality_threshold_stuff:

--- a/models/experimental/uniad/tt/ttnn_encoder.py
+++ b/models/experimental/uniad/tt/ttnn_encoder.py
@@ -421,7 +421,7 @@ class TtBEVFormerLayer:
                 ttnn.deallocate(self.params.norms[f"norm{norm_index}"].bias)
                 norm_index += 1
 
-            # spaital cross attention
+            # spatial cross attention
             elif layer == "cross_attn":
                 query = self.attentions[attn_index](
                     query,

--- a/models/experimental/uniad/tt/ttnn_pan_segformer_head.py
+++ b/models/experimental/uniad/tt/ttnn_pan_segformer_head.py
@@ -376,7 +376,7 @@ class TtPansegformerHead(nn.Module):
             lane = ttnn.to_torch(lane).to(torch.int64)
             lane_score = ttnn.to_torch(lane_score).to(torch.float32)
             for i, scores in enumerate(scores_all):
-                # MDS: things and sutff have different threholds may perform a little bit better
+                # MDS: things and stuff have different thresholds may perform a little bit better
                 if labels_all[i] < self.num_things_classes and scores < self.quality_threshold_things:
                     continue
                 elif labels_all[i] >= self.num_things_classes and scores < self.quality_threshold_stuff:

--- a/models/experimental/vadv2/tt/tt_encoder.py
+++ b/models/experimental/vadv2/tt/tt_encoder.py
@@ -449,7 +449,7 @@ class TtBEVFormerLayer:
                 ttnn.deallocate(self.params.norms[f"norm{norm_index}"].bias)
                 norm_index += 1
 
-            # spaital cross attention
+            # spatial cross attention
             elif layer == "cross_attn":
                 query = self.attentions[attn_index](
                     query,

--- a/models/tt_dit/encoders/qwen25vl/model_qwen25vl.py
+++ b/models/tt_dit/encoders/qwen25vl/model_qwen25vl.py
@@ -490,7 +490,7 @@ def optimal_groups(group_count: int, group_size: int, device_count: int) -> tupl
     # 3. Split groups into smaller groups defined by a split factor.
     # For a particular split factor, padding sizes follow from the requirements that the padded
     # group size must be divisible by this factor and the new group count must be divisible by the
-    # device count. We choose this factor such that memory requirments are minimized.
+    # device count. We choose this factor such that memory requirements are minimized.
 
     best_split_factor = 1
     best_size = math.inf

--- a/models/tt_dit/layers/conv2d.py
+++ b/models/tt_dit/layers/conv2d.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 # TODO: Add support for coll and row parallel conv2d
 class Conv2d(Module):
     """
-    Conv2d with support for tensor parallelism. Data and Seqence Parallelism TBD.
+    Conv2d with support for tensor parallelism. Data and Sequence Parallelism TBD.
 
     """
 
@@ -89,7 +89,7 @@ class Conv2d(Module):
         (1024, 1024, 128, 3): 8,
     }
 
-    # TODO: Allow weight initilization?
+    # TODO: Allow weight initialization?
     def __init__(
         self,
         in_channels: int,
@@ -118,7 +118,7 @@ class Conv2d(Module):
             in_mesh_axis: Axis to shard input channels across mesh devices.
             out_mesh_axis: Axis to shard output channels across mesh devices.
             ccl_manager: CCL manager to use.
-            torch_ref: Reference to the torch layer. Paramaters from this will be used to iniitialize the layer
+            torch_ref: Reference to the torch layer. Parameters from this will be used to initialize the layer
 
         The arguments in_mesh_axis and out_mesh_axis control how weights and biases are sharded
         across the mesh devices and how the input and output tensors are sharded.

--- a/models/tt_dit/layers/normalization.py
+++ b/models/tt_dit/layers/normalization.py
@@ -370,7 +370,7 @@ Set mesh_axis to None to disable data parallelism.
 class GroupNorm(Module):
     default_num_out_blocks = {
         # (Batch, Height, Width, Channels): num_out_blocks
-    }  # used to overrride the num_out_blocks computed based on the input shape.
+    }  # used to override the num_out_blocks computed based on the input shape.
 
     def __init__(
         self,

--- a/models/tt_dit/models/vae/vae_sd35.py
+++ b/models/tt_dit/models/vae/vae_sd35.py
@@ -292,7 +292,7 @@ class Attention(Module):
 
         [b, h, w, c] = list(x.shape)
 
-        # No need to transpose like reference. x is alredy channel last
+        # No need to transpose like reference. x is already channel last
         x = self.group_norm(x)
         x = self.gather_if_sharded(x)
 

--- a/models/tt_dit/pipelines/qwenimage/pipeline_qwenimage.py
+++ b/models/tt_dit/pipelines/qwenimage/pipeline_qwenimage.py
@@ -78,7 +78,7 @@ class QwenImagePipeline:
         num_links: int,
         height: int = 1024,
         width: int = 1024,
-        is_fsdp: bool = False,  # This only appies to the transformer model.
+        is_fsdp: bool = False,  # This only applies to the transformer model.
         dynamic_load_encoder: bool = True,  # Set to true if it wouldn't fit with the transformer given the configuration
         dynamic_load_vae: bool = False,  # Set to true if it wouldn't fit with the transformer given the configuration
     ) -> None:
@@ -366,7 +366,7 @@ class QwenImagePipeline:
         dynamic_load_vae: bool | None = None,
     ) -> QwenImagePipeline:
         default_config = {
-            # The default cofigurations are the best found from sweeping the following: is_fsdp, dynamic_load_encoder, and dynamic_load_vae.
+            # The default configurations are the best found from sweeping the following: is_fsdp, dynamic_load_encoder, and dynamic_load_vae.
             # The encoder is currently hardcoded to always be FSDP as it is the most memory efficient configuration with little to no performance penalty.
             (2, 4): {
                 "cfg_config": (2, 0),

--- a/models/tt_dit/pipelines/stable_diffusion_35_large/pipeline_stable_diffusion_35_large.py
+++ b/models/tt_dit/pipelines/stable_diffusion_35_large/pipeline_stable_diffusion_35_large.py
@@ -350,7 +350,7 @@ class StableDiffusion3Pipeline:
         if model_checkpoint_path is not None:
             checkpoint_name = model_checkpoint_path
             logger.warning(f"DEPRECATED: model_checkpoint_path parameter is deprecated. Use checkpoint_name instead.")
-        # defatult config per mesh shape
+        # default config per mesh shape
         default_config = {
             (2, 4): {"cfg_config": (2, 1), "sp_config": (2, 0), "tp_config": (2, 1), "num_links": 1},
             (4, 8): {"cfg_config": (2, 1), "sp_config": (4, 0), "tp_config": (4, 1), "num_links": 4},

--- a/models/tt_dit/tests/dataset_eval/inception.py
+++ b/models/tt_dit/tests/dataset_eval/inception.py
@@ -28,7 +28,7 @@ class InceptionV3(nn.Module):
     # Maps feature dimensionality to their output blocks indices
     BLOCK_INDEX_BY_DIM = {
         64: 0,  # First max pooling features
-        192: 1,  # Second max pooling featurs
+        192: 1,  # Second max pooling features
         768: 2,  # Pre-aux classifier features
         2048: 3,  # Final average pooling features
     }
@@ -174,7 +174,7 @@ def _inception_v3(*args, **kwargs):
         # Just a caution against weird version strings
         version = (0,)
 
-    # Skips default weight inititialization if supported by torchvision
+    # Skips default weight initialization if supported by torchvision
     # version. See https://github.com/mseitzer/pytorch-fid/issues/28.
     if version >= (0, 6):
         kwargs["init_weights"] = False

--- a/models/tt_dit/utils/conv3d.py
+++ b/models/tt_dit/utils/conv3d.py
@@ -78,7 +78,7 @@ def count_convs(module: Module) -> int:
 
 def conv_pad_height(tensor_BTHWC, h_factor):
     """
-    For Wan2.2, in some parallism schemes height can't be fractured by the factor.
+    For Wan2.2, in some parallelism schemes height can't be fractured by the factor.
     This function pads the height to the next multiple of the factor.
     """
     B, T, H, W, C = tensor_BTHWC.shape

--- a/models/tt_dit/utils/tensor.py
+++ b/models/tt_dit/utils/tensor.py
@@ -261,7 +261,7 @@ def unflatten(x: ttnn.Tensor, dim: int, sizes: Sequence[int]) -> ttnn.Tensor:
     """
     assert (
         x.shape[dim] % abs(math.prod(sizes)) == 0
-    ), f"The total number of elements in the new shape {sizes} must be equal or a factor of the number of elements (when using infered dimensions) in the original shape {x.shape[dim]}"
+    ), f"The total number of elements in the new shape {sizes} must be equal or a factor of the number of elements (when using inferred dimensions) in the original shape {x.shape[dim]}"
     new_shape = list(x.shape)
     if dim == -1:
         new_shape[-1:] = sizes

--- a/models/tt_transformers/demo/multimodal_demo_text.py
+++ b/models/tt_transformers/demo/multimodal_demo_text.py
@@ -89,7 +89,7 @@ def test_multimodal_demo_text(
         [{"type": "image", "image": img}, {"type": "text", "text": "If I had to write a haiku for this one"}],
         [
             {"type": "image", "image": img2},
-            {"type": "text", "text": "Couting the number of individual spaghetti strands in this image"},
+            {"type": "text", "text": "Counting the number of individual spaghetti strands in this image"},
         ],
         [{"type": "image", "image": ocr_image}, {"type": "text", "text": "The full text in this image is as follows"}],
         [

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -164,7 +164,7 @@ def load_inputs(user_input, batch, instruct):
     cache_dir.mkdir(parents=True, exist_ok=True)
 
     # The demo supports a custom prompt file, where the context is provided by a link to a book from the gutenberg project
-    # It clips the excerpt to the max length provided to allow testing different long context lengthts
+    # It clips the excerpt to the max length provided to allow testing different long context lengths
     for i in range(len(user_input)):
         prompt = user_input[i]["prompt"]
         if "context" in user_input[i]:
@@ -745,7 +745,7 @@ def prepare_generator_args(
         "device-perf",  # Device perf
     ],
 )
-# NOTE: Please do not add new pytest parameters bewteen optimizations and the demo parameters above, certain tests ids depend on the order of the parameters.
+# NOTE: Please do not add new pytest parameters between optimizations and the demo parameters above, certain tests ids depend on the order of the parameters.
 @pytest.mark.parametrize(
     "optimizations",
     [

--- a/models/tt_transformers/tests/multimodal/test_llama_class_embedding.py
+++ b/models/tt_transformers/tests/multimodal/test_llama_class_embedding.py
@@ -19,7 +19,7 @@ from ttnn import ConcatMeshToTensor, ReplicateTensorToMesh
 ###### Torch op #####
 # Loading the whole Llama model can be avoided by copying this method [HF class embedding](https://github.com/huggingface/transformers/blob/b2feaa215f1f736a2c36c2198a4e3f089e72c564/src/transformers/models/mllama/modeling_mllama.py#L1030)
 # and pasting it into this custom ClassEmbedding. This allows to test only the class embedding method in HF, it generates the same identical tensor as before with meta lib.
-# HF uses transformers lib which applies the class embeddding with only pytorch operations as in the TT unit test here
+# HF uses transformers lib which applies the class embedding with only pytorch operations as in the TT unit test here
 class ClassEmbedding(nn.Module):
     def __init__(self, width):
         super().__init__()

--- a/models/tt_transformers/tests/multimodal/test_llama_cross_attention.py
+++ b/models/tt_transformers/tests/multimodal/test_llama_cross_attention.py
@@ -155,7 +155,7 @@ def test_cross_attention_inference(text_seq_len, batch, mesh_device, reset_seeds
         full_text_mask_expand = full_text_mask.expand(-1, n_heads // model_args.num_devices, -1, head_dim)
 
         # Key and Values projections are stored in cache thus the cross-attention features are replaced with None and only Query input is passed to compute its projection and proceed to the computation of attention.
-        # We wish to compare only the hidden state from reference model that outputs this layer so this is the 1st ouput of the subclass method indexed as [0].
+        # We wish to compare only the hidden state from reference model that outputs this layer so this is the 1st output of the subclass method indexed as [0].
         pt_out = reference_model.forward(
             pt_x, None, past_key_value=past_key_values, attention_mask=xattn_mask, cache_position=[layer_idx]
         )[0] * full_text_mask.squeeze(1)

--- a/models/tt_transformers/tests/multimodal/test_llama_cross_attention_transformer_text.py
+++ b/models/tt_transformers/tests/multimodal/test_llama_cross_attention_transformer_text.py
@@ -100,7 +100,7 @@ def test_cross_attention_transformer_text_inference(
         # [INFO] n_iter = 3 is sufficient to exercise both prefill and decode phases
         n_iter = 3
         if is_ci_env:
-            # Special case for 90B model in CI only 2 layers will be used for comparision regardless of the actual number of layers in the model.
+            # Special case for 90B model in CI only 2 layers will be used for comparison regardless of the actual number of layers in the model.
             # In CI, test only 2 layers with 1 being cross-attention layer to reduce runtime
             config.text_config.num_hidden_layers = 2
             config.text_config.cross_attention_layers = [0]

--- a/models/tt_transformers/tests/multimodal/test_llama_cross_attention_transformer_vision.py
+++ b/models/tt_transformers/tests/multimodal/test_llama_cross_attention_transformer_vision.py
@@ -24,7 +24,7 @@ from models.tt_transformers.tt.multimodal.llama_cross_attention_transformer_visi
 
 
 # Meta's lib crossattention vision transformer branch found in :https://github.com/meta-llama/llama-models/blob/0e0b8c519242d5833d8c11bffc1232b77ad7f301/models/llama3/multimodal/model.py#L1027
-# does not exist indepedently as a subclass in HF, instead it is implemented directly in the whole mLlama model graph.
+# does not exist independently as a subclass in HF, instead it is implemented directly in the whole mLlama model graph.
 # Thus the following custom class is adapted from mLlama model of HF https://github.com/huggingface/transformers/blob/d12672fc50c1393ef3bb0964aaebd4290d93e364/src/transformers/models/mllama/modeling_mllama.py#L1445
 # to create the same computational graph as in meta lib for this comparison with tt_model containing the vision model and the mutlimodal projector.
 class CrossAttentionTransformerVisionModel(MllamaPreTrainedModel):

--- a/models/tt_transformers/tests/multimodal/test_llama_image_attention.py
+++ b/models/tt_transformers/tests/multimodal/test_llama_image_attention.py
@@ -51,7 +51,7 @@ def test_attention_inference(batch, num_chunks, mesh_device, reset_seeds, ensure
     ntok = model_args.vision_chunk_ntok
 
     model_repo_name = os.getenv("HF_MODEL")
-    # config contains paramters for the whole multimodal network the subeset of vision branch is chosen instead
+    # config contains parameters for the whole multimodal network the subeset of vision branch is chosen instead
     config = AutoConfig.from_pretrained(model_repo_name)
     config.vision_config._attn_implementation = "sdpa"
     reference_model = MllamaVisionAttention(config.vision_config)

--- a/models/tt_transformers/tests/multimodal/test_llama_image_block.py
+++ b/models/tt_transformers/tests/multimodal/test_llama_image_block.py
@@ -60,7 +60,7 @@ def test_block_inference(batch, num_chunks, mesh_device, gated, reset_seeds, ens
     ntok = model_args.vision_chunk_ntok
 
     model_repo_name = os.getenv("HF_MODEL")
-    # config contains paramters for the whole multimodal network the subeset of vision branch is chosen instead
+    # config contains parameters for the whole multimodal network the subeset of vision branch is chosen instead
     config = AutoConfig.from_pretrained(model_repo_name)
     config.vision_config._attn_implementation = "sdpa"
     reference_model = MllamaVisionEncoderLayer(config.vision_config, is_gated=gated)

--- a/models/tt_transformers/tests/multimodal/test_llama_image_transformer.py
+++ b/models/tt_transformers/tests/multimodal/test_llama_image_transformer.py
@@ -163,7 +163,7 @@ def test_image_transformer_inference(batch, num_chunks, mesh_device, is_global):
         tt_out = tt_out.reshape(batch, num_chunks, ntok + npadtt, dim)
         tt_out = ttnn.slice(tt_out, (0, 0, 0, 0), (batch, num_chunks, ntok, dim))
         tt_output_torch = ttnn.to_torch(tt_out, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0))[0, :, :, :]
-        # below the same input to tt model is inputed to reference HF model
+        # below the same input to tt model is inputted to reference HF model
         tens_input = ttnn.to_torch(attention_input, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0))[
             0, :, :, :
         ].reshape(batch * num_chunks, ntok + npadtt, dim)

--- a/models/tt_transformers/tests/multimodal/test_llama_positional_embedding.py
+++ b/models/tt_transformers/tests/multimodal/test_llama_positional_embedding.py
@@ -88,7 +88,7 @@ def test_positional_embedding_inference(
 
     tt_aspect_ratios = aspect_ratios.tolist()
 
-    # config contains paramters for the whole multimodal network the subeset of vision branch is chosen instead
+    # config contains parameters for the whole multimodal network the subeset of vision branch is chosen instead
     model_repo_name = os.getenv("HF_MODEL")
     config = AutoConfig.from_pretrained(model_repo_name)
     reference_model = MllamaPrecomputedPositionEmbedding(config.vision_config)

--- a/models/tt_transformers/tests/multimodal/test_llama_vision_encoder.py
+++ b/models/tt_transformers/tests/multimodal/test_llama_vision_encoder.py
@@ -41,7 +41,7 @@ def test_vision_encoder_inference(mesh_device, reset_seeds):
     return_intermediate = [int(l) for l in return_intermediate.split(",")]
 
     model_repo_name = os.getenv("HF_MODEL")
-    # config contains paramters for the whole multimodal network the subeset of vision branch is chosen instead
+    # config contains parameters for the whole multimodal network the subeset of vision branch is chosen instead
     config = AutoConfig.from_pretrained(model_repo_name)
     config.vision_config._attn_implementation = "sdpa"
     reference_model = MllamaVisionModel(config.vision_config)

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -295,7 +295,7 @@ class Generator(WarmupForwardMixin):
 
         sampling_on_device_requested = sampling_params is not None
 
-        # we need this here becuase of tt-metal tests
+        # we need this here because of tt-metal tests
         if warmup_prefill:
             sampling_on_device_enabled = (
                 getattr(self.model[0], "_supports_on_device_sampling", False)
@@ -608,7 +608,7 @@ class Generator(WarmupForwardMixin):
                 )
 
                 # Select tokens for the current chunk.
-                # Cached tokens were allready excluded (not part of the input),
+                # Cached tokens were already excluded (not part of the input),
                 # so using relative indexes.
                 chunk_tokens = tokens[:, chunk_start_relative:chunk_end_relative]
 

--- a/models/tt_transformers/tt/mlp.py
+++ b/models/tt_transformers/tt/mlp.py
@@ -40,7 +40,7 @@ class MLP(LightweightModule):
         state_dict_prefix = state_dict_prefix or args.get_state_dict_prefix(self.__class__.__name__, layer_num)
         torch_weight = lambda name: torch.transpose(state_dict[f"{state_dict_prefix}.{name}.weight"], -2, -1)
         pad_hidden_dim = lambda tensor, dim: pad_to_size(tensor, dim=dim, size=args.hidden_dim)
-        # If pading was applied (e.g. via env var), add the unpadded hidden dim to the cache name to avoid loading incorrect weights
+        # If padding was applied (e.g. via env var), add the unpadded hidden dim to the cache name to avoid loading incorrect weights
         hidden_dim_string = f".hidden_dim_{args.hidden_dim}" if args.hidden_dim != args.unpadded_hidden_dim else ""
 
         if args.dummy_weights:
@@ -79,7 +79,7 @@ class MLP(LightweightModule):
         w1_dims = (-1, -2) if args.is_galaxy else (-2, -1)
         w2_dims = (-2, -1) if args.is_galaxy else (-1, -2)
 
-        layer_num = max(layer_num, 0)  # cross_block uses the configutation of the first decoder
+        layer_num = max(layer_num, 0)  # cross_block uses the configuration of the first decoder
 
         # When prefetcher is enabled, use consistent dtypes across all layers to avoid
         # race conditions caused by different block sizes
@@ -124,7 +124,7 @@ class MLP(LightweightModule):
         """
         seq_len = x.shape[-2]
         TG = self.args.is_galaxy
-        layer_num = max(self.layer_num, 0)  # cross_block uses the configutation of the first decoder
+        layer_num = max(self.layer_num, 0)  # cross_block uses the configuration of the first decoder
         activation_dtype = self.decoders_optimizations.get_tensor_dtype(
             decoder_id=layer_num, tensor=TensorGroup.ACTIVATION
         )

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -605,7 +605,7 @@ class ModelArgs:
 
         if device is not None:  # Avoid issue with test_torch.py not having a device
             # ============================================================================
-            # Parameter intialization
+            # Parameter initialization
             # ============================================================================
             # nlp_concat_heads_decode will shard the data across this number of cores
             assert (

--- a/models/tt_transformers/tt/multimodal/llama_image_mlp.py
+++ b/models/tt_transformers/tt/multimodal/llama_image_mlp.py
@@ -98,7 +98,7 @@ class TtLlamaImageFeedForward(LightweightModule):
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
         )
 
-        # NOTE: Need to reshape to 4D so that fast_reduce_nc hsa a dim1 to work on
+        # NOTE: Need to reshape to 4D so that fast_reduce_nc has a dim1 to work on
         c_proj_out = ttnn.reshape(c_proj_out, [1, 1, seq_len, -1])
 
         # All reduce

--- a/models/tt_transformers/tt/multimodal/llama_vision_model.py
+++ b/models/tt_transformers/tt/multimodal/llama_vision_model.py
@@ -160,7 +160,7 @@ class VariableSizeImageTransform(object):
     @staticmethod
     def get_factors(n: int) -> Set[int]:
         """
-        Calculate all factors of a given number, i.e. a dividor that leaves
+        Calculate all factors of a given number, i.e. a divisor that leaves
         no remainder. For example, if n=12, it will return {1, 2, 3, 4, 6, 12}.
 
         Args:
@@ -179,7 +179,7 @@ class VariableSizeImageTransform(object):
 
     def find_supported_resolutions(self, max_num_chunks: int, patch_size: int) -> torch.Tensor:
         """
-        Computes all of the allowed resoltuions for a fixed number of chunks
+        Computes all of the allowed resolutions for a fixed number of chunks
         and patch_size. Useful for when dividing an image into chunks.
 
         Args:


### PR DESCRIPTION
This PR fixes spelling and typo errors in models code.

This is part of relanding spelling fixes from commit 98ad3bab62ac1f66560c88c30b3f12d846dd4b54 in smaller, targeted PRs.

Files changed:
- models/ directory (including all subdirectories)