### PR TITLE
Fix spelling/typos in test code

### DIFF
--- a/tests/tt_metal/tt_metal/eth/eth_test_common.hpp
+++ b/tests/tt_metal/tt_metal/eth/eth_test_common.hpp
@@ -14,7 +14,7 @@ inline void set_arch_specific_eth_config(tt_metal::EthernetConfig& config) {
     if (!tt::tt_metal::MetalContext::instance().hal().get_eth_fw_is_cooperative()) {
         if (tt::tt_metal::MetalContext::instance().hal().get_num_risc_processors(HalProgrammableCoreType::ACTIVE_ETH) >
             1) {
-            // Ensure noc index == processor index to not cross eachother
+            // Ensure noc index == processor index to not cross each other
             config.noc = static_cast<tt_metal::NOC>(config.processor);
         } else {
             // Ensure it's using NOC1 as Base FW is using NOC0

--- a/tests/tt_metal/tt_metal/eth/test_erisc_app_direct_send.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_erisc_app_direct_send.cpp
@@ -247,7 +247,7 @@ bool send_over_eth(
             receiver_device->id(), eth_core, zero, app_sync_info_base_addr);
     }
 
-    // TODO: is it possible that receiver core app is stil running when we push inputs here???
+    // TODO: is it possible that receiver core app is still running when we push inputs here???
     auto inputs = generate_uniform_random_vector<uint32_t>(0, 100, byte_size / sizeof(uint32_t));
     tt::tt_metal::MetalContext::instance().get_cluster().write_core(
         sender_device->id(), sender_core, inputs, erisc_unreserved_base_addr);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/test_pull_from_pcie.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/test_pull_from_pcie.cpp
@@ -443,7 +443,7 @@ int main(int argc, char** argv) {
 
     if (pass) {
         // goal is 70% of PCI-e Gen3 x16 for grayskull
-        // TODO: check the theoritical peak of wormhole
+        // TODO: check the theoretical peak of wormhole
         double target_bandwidth = 16.0 * 0.7;
 
         if (avg_h2d_bandwidth < target_bandwidth) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/test_rw_buffer.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/test_rw_buffer.cpp
@@ -206,7 +206,7 @@ int main(int argc, char** argv) {
     auto avg_h2d_bandwidth = calculate_average(h2d_bandwidth);
     auto avg_d2h_bandwidth = calculate_average(d2h_bandwidth);
     if (pass && !bypass_check) {
-        // TODO: check the theoritical peak of wormhole
+        // TODO: check the theoretical peak of wormhole
         static constexpr double k_PcieMax = 16.0;  // GB/s
         double target_read_bandwidth;
         double target_write_bandwidth;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_mux_bandwidth.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_mux_bandwidth.cpp
@@ -502,12 +502,12 @@ int main(int argc, char** argv) {
     }
 
     log_info(tt::LogTest, "Workers done, terminating mux kernel");
-    std::vector<uint32_t> termiation_signal(1, tt::tt_fabric::TerminationSignal::IMMEDIATELY_TERMINATE);
+    std::vector<uint32_t> termination_signal(1, tt::tt_fabric::TerminationSignal::IMMEDIATELY_TERMINATE);
     tt::tt_metal::detail::WriteToDeviceL1(
-        device, mux_logical_core, mux_kernel_config.get_termination_signal_address(), termiation_signal);
+        device, mux_logical_core, mux_kernel_config.get_termination_signal_address(), termination_signal);
 
     log_info(tt::LogTest, "Waiting for mux kernel to terminate");
-    // need to wait before terminating driner core otherwise the mux kernel will hang while closing connection
+    // need to wait before terminating driver core otherwise the mux kernel will hang while closing connection
     std::vector<uint32_t> mux_status(1, 0);
     while (mux_status[0] != tt::tt_fabric::EDMStatus::TERMINATED) {
         tt::tt_metal::detail::ReadFromDeviceL1(
@@ -516,7 +516,7 @@ int main(int argc, char** argv) {
 
     log_info(tt::LogTest, "Terminating drainer kernel");
     tt::tt_metal::detail::WriteToDeviceL1(
-        device, drainer_logical_core, drainer_kernel_config.get_termination_signal_address(), termiation_signal);
+        device, drainer_logical_core, drainer_kernel_config.get_termination_signal_address(), termination_signal);
 
     log_info(tt::LogTest, "Waiting for programs");
     tt::tt_metal::distributed::Finish(cq);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/softmax.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/softmax.cpp
@@ -141,7 +141,7 @@ void kernel_main() {
         cb_wait_front(cb_recipsumexps, 1);  // will reuse Wt times for bcast
 
         // now cb_sumexps has exp tiles, need to multiply by our DST[2]
-        // by now we already did a umulative wait for Wt tiles in cb_exps
+        // by now we already did a cumulative wait for Wt tiles in cb_exps
         mul_bcast_cols_init_short(cb_exps, cb_recipsumexps);
         for (uint32_t wt = 0; wt < Wt; wt += ndst) {
             ACQ();

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/sender_intermediate_stage.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/sender_intermediate_stage.cpp
@@ -56,7 +56,7 @@ void kernel_main() {
             // noc_async_write and noc_semaphore_set_remote are ordered
             noc_semaphore_set_remote(l1_valid_value_addr, receiver_semaphore_noc_addr);
 
-            // this barrier is not needed, sempahore inter-lock already guarantees that we won't overwrite local CB with
+            // this barrier is not needed, semaphore inter-lock already guarantees that we won't overwrite local CB with
             // new data ie, it is safe to pop here, because the data in the CB won't actually be overwritten until the
             // receiver has set the semaphore (which means it was received) this barrier would hurt performance for
             // smaller transfers (<16KB), but for larger transfers it wouldn't make a difference

--- a/tests/ttnn/integration_tests/falcon7b/test_falcon_rotary_embeddings.py
+++ b/tests/ttnn/integration_tests/falcon7b/test_falcon_rotary_embeddings.py
@@ -114,7 +114,7 @@ def test_ttnn_functional_apply_rotary_embeddings(
     ],
 )
 def test_torch_functional_falcon_generate_rotary_embeddings(model_name, input_shape, device):
-    # TODO: test reseting of cossin cache
+    # TODO: test resetting of cossin cache
     batch, num_kv_heads, query_length, head_dim = input_shape
     config = transformers.FalconConfig.from_pretrained(model_name)
     model = transformers.models.falcon.modeling_falcon.FalconRotaryEmbedding(config).eval()

--- a/tests/ttnn/unit_tests/operations/data_movement/test_core.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_core.py
@@ -142,7 +142,7 @@ from enum import Enum
             None,
             None,
         ),
-        # (1, 1, 32, 8192) (32 to 8 cores width shardrd)
+        # (1, 1, 32, 8192) (32 to 8 cores width sharded)
         (
             32,
             8192,
@@ -152,7 +152,7 @@ from enum import Enum
             (32, 256),
             None,
         ),
-        # (1, 1, 32, 8192) (64 to 8 cores width shardrd)
+        # (1, 1, 32, 8192) (64 to 8 cores width sharded)
         (
             32,
             8192,
@@ -162,7 +162,7 @@ from enum import Enum
             (32, 128),
             None,
         ),
-        # (1, 1, 32, 1280) (8 to 1 cores width shardrd)
+        # (1, 1, 32, 1280) (8 to 1 cores width sharded)
         (
             32,
             1280,

--- a/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_selu.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_selu.py
@@ -88,7 +88,7 @@ def test_eltwise_selu(input_shape, dtype, dlayout, in_mem_config, out_mem_config
 
 
 def test_selu_arange(device):
-    # Generate all possible bit pattersn for bf16
+    # Generate all possible bit patterns for bf16
     all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
     input_tensor = all_bitpatterns.view(torch.bfloat16)
     input_tensor = input_tensor.to(torch.float32)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_exp2.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_exp2.py
@@ -14,7 +14,7 @@ def test_exp2_arange_masking(device):
     low = -126.0
     high = 127.0
 
-    # Generate all possible bit pattersn for bf16
+    # Generate all possible bit patterns for bf16
     all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
     input_tensor = all_bitpatterns.view(torch.bfloat16)
     input_tensor_f32 = input_tensor.to(torch.float32)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_exp_21f.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_exp_21f.py
@@ -16,7 +16,7 @@ def test_exp_arange_masking(device):
     low = -87.0
     high = 88.5
 
-    # Generate all possible bit pattersn for bf16
+    # Generate all possible bit patterns for bf16
     all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
     input_tensor = all_bitpatterns.view(torch.bfloat16)
     input_tensor_f32 = input_tensor.to(torch.float32)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -1812,7 +1812,7 @@ def test_unary_hardmish(input_shapes, torch_dtype, ttnn_dtype, device):
 
 
 def test_hardmish_bfloat16_ulp(device):
-    # Generate all possible bit pattersn for bf16
+    # Generate all possible bit patterns for bf16
     all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
     input_tensor = all_bitpatterns.view(torch.bfloat16)
     input_tensor = input_tensor.to(torch.float32)
@@ -1843,7 +1843,7 @@ def test_hardmish_bfloat16_ulp(device):
 
 
 def test_hardmish_bfloat16_allclose(device):
-    # Generate all possible bit pattersn for bf16
+    # Generate all possible bit patterns for bf16
     all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
     input_tensor = all_bitpatterns.view(torch.bfloat16)
     input_tensor = input_tensor.to(torch.float32)


### PR DESCRIPTION
This PR fixes spelling and typo errors in test code.

This is part of relanding spelling fixes from commit 98ad3bab62ac1f66560c88c30b3f12d846dd4b54 in smaller, targeted PRs.

Files changed:
- tests/ directory (including all subdirectories)