### PR TITLE
Fix spelling/typos in ttnn operations code

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/ccl_op_fusion.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_op_fusion.cpp
@@ -381,10 +381,10 @@ void MatmulFusedOpSignaler::init_llama_rs_cores_mm(
     tt::tt_metal::Program& program,
     const tt::tt_metal::IDevice* device,
     int privilaged_index) {
-    // pick the privilaged core, record the number of matmul cores
+    // pick the privileged core, record the number of matmul cores
     TT_FATAL(initialized_llama_reduce_scatter_part1, "reduce scatter half needs to be initialized first");
     auto cores = corerange_to_cores(matmul_cores);
-    TT_FATAL(cores.size() > privilaged_index, "Privilaged index is out of range of the matmul cores");
+    TT_FATAL(cores.size() > privilaged_index, "Privileged index is out of range of the matmul cores");
     this->privilaged_core = cores.at(privilaged_index);
     this->privilaged_core_physical = device->worker_core_from_logical_core(this->privilaged_core);
     this->matmul_privilaged_semaphore = tt::tt_metal::CreateSemaphore(program, privilaged_core, 0);

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_op_fusion.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_op_fusion.hpp
@@ -206,7 +206,7 @@ struct MatmulFusedOpSignaler {
     // Write the semaphore ID
     void push_llama_rs_rt_args_for_rs(std::vector<uint32_t>& out_rt_args) const;
     // Is_privilaged, if yes: target_value, num_cores_to_signal, array_of_cores, if no: core_xy of signaler
-    // First core to run this is the privilaged core
+    // First core to run this is the privileged core
     void push_llama_rs_rt_args_for_mm(
         std::vector<uint32_t>& out_rt_args,
         CoreCoord current_core,

--- a/ttnn/cpp/ttnn/operations/ccl/common/host/ccl_worker_builder.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/host/ccl_worker_builder.cpp
@@ -705,11 +705,11 @@ void generate_ccl_command_stream_to_kernel_args(
 
             case ttnn::ccl::cmd::CclCommandCode::STREAM_EDM_TO_TENSOR:
                 TT_THROW(
-                    "CCL command STREAM_EDM_TO_TENSOR is not useable, supported, or intended to be supported in CCL "
+                    "CCL command STREAM_EDM_TO_TENSOR is not usable, supported, or intended to be supported in CCL "
                     "v2. This command is deprecated.");
                 break;
                 TT_THROW(
-                    "CCL command STREAM_TENSOR_TO_EDM is not useable, supported, or intended to be supported in CCL "
+                    "CCL command STREAM_TENSOR_TO_EDM is not usable, supported, or intended to be supported in CCL "
                     "v2. This command is deprecated.");
                 break;
 
@@ -1091,7 +1091,7 @@ void generate_multi_input_command_stream_kernel_rt_args(
             rt_args.push_back(tensors[i]->buffer()->address());
         } else {
             // take up the rt arg with filler value  in case user built a kernel across a core range
-            // set with multiple command streams/tensors, but this particular core doesn't actualy need/use
+            // set with multiple command streams/tensors, but this particular core doesn't actually need/use
             // both tensors/command streams
             rt_args.push_back(0xdeaddead);
         }

--- a/ttnn/cpp/ttnn/operations/ccl/common/host/moe_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/host/moe_utils.cpp
@@ -157,7 +157,7 @@ size_t get_num_links(const tt::tt_metal::distributed::MeshDevice& mesh_device, s
                     auto planes_in_direction =
                         tt::tt_fabric::get_num_available_routing_planes_in_direction(fabric_node_id, direction);
                     // if the device is not mmio capable then one link on some axis will be unavailable
-                    // ideally we only subtract if we're targetting that cluster axis, but we don't have access to that
+                    // ideally we only subtract if we're targeting that cluster axis, but we don't have access to that
                     // information here to be safe, we subtract 1 regardless of the axis when the axis is not available
                     log_debug(
                         tt::LogOp,

--- a/ttnn/cpp/ttnn/operations/ccl/common/kernels/ccl_send_reader_two_input.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/kernels/ccl_send_reader_two_input.cpp
@@ -874,7 +874,7 @@ void try_advance(command_context_t<Addrgen>& cmd_ctx) {
             cmd_ctx.complete_current_command();
             break;
         case ttnn::ccl::cmd::CclCommandCode::WAIT_VALUE:
-            // Technically we are implementating semaphore wait as WAIT_MIN. FUTURE work to make separate commands
+            // Technically we are implementing semaphore wait as WAIT_MIN. FUTURE work to make separate commands
             if (*reinterpret_cast<volatile uint32_t*>(cmd_ctx.src_addr_info.address) >=
                 cmd_ctx.cmd_specific_ctx.inline_value_ctx.value) {
                 DPRINT << "Completing waitval command\n";

--- a/ttnn/cpp/ttnn/operations/ccl/common/types/ccl_types.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/types/ccl_types.hpp
@@ -6,7 +6,7 @@
 
 /*
  *    ------   ATTENTION  ATTENTION  ATTENTION  ATTENTION  ATTENTION   ------
- * This file is intended to be useable across both host and device code. Therefore.
+ * This file is intended to be usable across both host and device code. Therefore.
  *
  * DO NOT include any headers that are not host/device agnostic.
  * DO NOT use any types that do not have fixed sizes across host and device.

--- a/ttnn/cpp/ttnn/operations/ccl/common/uops/ccl_command.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/uops/ccl_command.hpp
@@ -546,7 +546,7 @@ using CclCommandCoreDescriptorArgs = std::variant<
 // A command is composed of one or more arguments
 // This enum specifies the high level command
 // Future commands are to be added and will enable
-// functionalilty such as synchronizing
+// functionality such as synchronizing
 enum class CclCommandCode : uint8_t {
     STREAM_TENSOR_TO_EDM = 0,  // TODO: rename uses of to the below
     STREAM_TENSOR_TO_CB = 0,

--- a/ttnn/cpp/ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp
@@ -275,7 +275,7 @@ struct MatmulOpReceiver {
             // Index of the current tensor slice in a certain direction
             uint32_t tensor_slice_cnt = (this->curr_transfer_idx) / this->num_directions;
 
-            // Wait for a sempaphore signal to start processing the tensor slice
+            // Wait for a semaphore signal to start processing the tensor slice
             if (this->wait_for_op_signal) {
                 noc_semaphore_wait_min(this->signal_op_semaphore_addr_ptrs[this->curr_dir], tensor_slice_cnt + 1);
             }
@@ -312,7 +312,7 @@ struct MatmulOpReceiver {
             // Update the alignment
             block_id = this->ring_idxs[this->curr_dir];
 
-            // Wait for a sempaphore signal to start processing the tensor slice
+            // Wait for a semaphore signal to start processing the tensor slice
             if (this->wait_for_op_signal && block_id == sender_id) {
                 uint32_t tensor_slice_cnt = (this->curr_transfer_idx) / this->num_directions;
                 noc_semaphore_wait_min(this->signal_op_semaphore_addr_ptrs[this->curr_dir], 1);

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm/erisc_datamover.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm/erisc_datamover.cpp
@@ -330,7 +330,7 @@ void kernel_main() {
             // advance sender channel state as soon as we receive an ack. Since we
             // may be the last active channel, and advance to done state just from ack
             // from the receiver ("I got a payload"), then we need to wait for done
-            // at the very end here. Otherise if we invoke another erisc op back-to-back,
+            // at the very end here. Otherwise if we invoke another erisc op back-to-back,
             // we may mess up transaction state because it's possible for receiver of this
             // op to send the completion done after that one has already started.
             uint32_t wait_count = 0;

--- a/ttnn/cpp/ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp
@@ -12,7 +12,7 @@
 
 /*
  *    ------   ATTENTION  ATTENTION  ATTENTION  ATTENTION  ATTENTION   ------
- * This file is intended to be useable across both host and device code. Therefore.
+ * This file is intended to be usable across both host and device code. Therefore.
  *
  * DO NOT include any headers that are not host/device agnostic.
  * DO NOT use any types that do not have fixed sizes across host and device.

--- a/ttnn/cpp/ttnn/operations/ccl/shared_with_host/sharded_tensor_addr_gen.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/shared_with_host/sharded_tensor_addr_gen.hpp
@@ -11,7 +11,7 @@
 
 /*
  *    ------   ATTENTION  ATTENTION  ATTENTION  ATTENTION  ATTENTION   ------
- * This file is intended to be useable across both host and device code. Therefore.
+ * This file is intended to be usable across both host and device code. Therefore.
  *
  * DO NOT include any headers that are not host/device agnostic.
  * DO NOT use any types that do not have fixed sizes across host and device.

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_nanobind.cpp
@@ -326,7 +326,7 @@ void bind_conv2d(nb::module_& mod) {
 
     py_conv_config.def_rw("act_block_w_div", &Conv2dConfig::act_block_w_div, R"doc(
             Reduces the width of the activation block to reduce Circular Buffer sizes and prevent OOM. Valid only for Width Sharded Conv2d.
-            This is only useful when the input channels is greater than 32 * num_cores. For n150, thats 32 * 64 =  2048.
+            This is only useful when the input channels is greater than 32 * num_cores. For n150, that's 32 * 64 =  2048.
             This is a divisor of the activation block width.
             A value of 1 means no reduction, and a value of 2 means the activation block width is halved.
         )doc");

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -1323,8 +1323,8 @@ Tensor fold_input_tensor_if_required(
     std::array<uint32_t, 4>& padding_n4,
     bool& mm_conv,
     Conv2dConfig& conv_config) {
-    // Conv DRAM would fold the input tensor, but conv_config.enable_kernel_stride_folding would stil be true as weights
-    // also need to be folded.
+    // Conv DRAM would fold the input tensor, but conv_config.enable_kernel_stride_folding would still be true as
+    // weights also need to be folded.
     conv_config.enable_kernel_stride_folding = auto_enable_kernel_folding(
         input_tensor.memory_config(),
         input_tensor.layout(),

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp
@@ -36,7 +36,7 @@ struct Conv2dConfig {
     bool reallocate_halo_output = true;
 
     // If true, config tensors for Conv2D are stored in DRAM instead of L1_SMALL. L1_SMALL is persistent storage and
-    // get's quickly used up for large CNNs.
+    // gets quickly used up for large CNNs.
     bool config_tensors_in_dram = false;
 
     // Has to be a multiple of 32.

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize.cpp
@@ -76,7 +76,7 @@ inline void tilize_in_reuse_split_reader(uint32_t act_cb_start_address, uint32_t
     // with activation reuse, the activation buffers are sized to fit one output image width only,
     // so we need to interleave waits and pops on the two buffers to allow parallelization;
     // we reserve back tilized CB to store whole act block h - and then we update write pointers so that
-    // we fill in first row of the first hald (NCRISC), first row of the second half (BRISC) and so on
+    // we fill in first row of the first half (NCRISC), first row of the second half (BRISC) and so on
     cb_reserve_back(out_cb_id, out_cb_tiles);
     fast_tilize_init_with_dt(in1_cb_id, in_block_w, out_cb_id);
 
@@ -409,7 +409,7 @@ void kernel_main() {
                         for (uint32_t inner_dim_idx = 0; inner_dim_idx < in0_block_w; inner_dim_idx++) {
                             // matmul outer product of (out_subblock_h x out_subblock_w) tiles that fill dst
                             // accumulation is done by iterating matmul_block across inner dim
-                            // in0_block_w is passed as innder dim (kt) to matmul_block, interally used to stride in0
+                            // in0_block_w is passed as innder dim (kt) to matmul_block, internally used to stride in0
                             matmul_block(
                                 mm_in0_cb_id,
                                 in1_cb_id,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_reader_common.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_reader_common.hpp
@@ -232,7 +232,7 @@ FORCE_INLINE void read_sticks_activation_reuse(
             uint16_t second_row_width = leftover_row_width, third_row_width = 0;
             if constexpr (!output_image_width_full_tile) {
                 // If the output image width is not a multiple of the tile width, the first 'image width' might be split
-                // between three rows since we padd image width to tile size; otherwise, it is always split between
+                // between three rows since we pad image width to tile size; otherwise, it is always split between
                 // maximum two rows
                 const uint16_t interval_width = end_ind - start_ind + 1;
                 if (leftover_row_width > interval_width) {

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp
@@ -29,12 +29,12 @@ void multicast_data(
             noc_async_write_multicast_loopback_src(
                 src_l1_addr, multicast_write_addr, total_bytes, act_mcast_num_cores + 1, true);
         } else {
-            // In this case sender core is the only reciever in the grid,
+            // In this case sender core is the only receiver in the grid,
             // we can't use the multicast_loopback_src (hang)
             noc_async_write(get_noc_addr(src_l1_addr), get_noc_addr(dst_l1_addr), total_bytes);
         }
     } else {
-        // If sender core is not the reciever core as well we can't use the loopback mcast. (hang)
+        // If sender core is not the receiver core as well we can't use the loopback mcast. (hang)
         noc_async_write_multicast(src_l1_addr, multicast_write_addr, total_bytes, act_mcast_num_cores + 1, true);
     }
 }
@@ -45,7 +45,7 @@ void multicast_data(
 // multicast of NOC_MAX_BURST_SIZE size. This is because under the hood, the multicast splits the data into chunks of
 // NOC_MAX_BURST_SIZE size
 // It calls the multicast_data function for each chunk of maximum size NOC_MAX_BURST_SIZE bytes.
-// Said function does mcast loopback when the sender core is also a receiver core (it is both in ouput and input grids)
+// Said function does mcast loopback when the sender core is also a receiver core (it is both in output and input grids)
 // or mcast when the sender core is not a receiver core (it is only present in the input grid, mcast loopback will hang
 // if the core isn't one of receivers) or just local write when it is in both input and output grids but is the only
 // receiver core (will hang if mcast loopback is used)

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2.cpp
@@ -10,7 +10,7 @@ void kernel_main() {
     constexpr uint32_t dilation_w = get_compile_time_arg_val(1);
     constexpr uint32_t stride_w = get_compile_time_arg_val(2);
     constexpr uint32_t conv_act_c_read_bytes = get_compile_time_arg_val(3);
-    // need to have these as compile-time, they are inner loop bouds / unroll loops / constexpr conditionals based on
+    // need to have these as compile-time, they are inner loop bounds / unroll loops / constexpr conditionals based on
     // them
     constexpr uint32_t window_outer = get_compile_time_arg_val(4);
     constexpr uint32_t act_block_num_tiles = get_compile_time_arg_val(6);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_depthwise_conv1d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_depthwise_conv1d.cpp
@@ -10,7 +10,7 @@
 void kernel_main() {
     constexpr uint32_t stride_w = get_compile_time_arg_val(2);
     constexpr uint32_t conv_act_c_read_bytes = get_compile_time_arg_val(3);
-    // need to have these as compile-time, they are inner loop bouds / unroll loops / constexpr conditionals based on
+    // need to have these as compile-time, they are inner loop bounds / unroll loops / constexpr conditionals based on
     // them
     constexpr uint32_t window_outer = get_compile_time_arg_val(4);
     constexpr uint32_t window_inner = get_compile_time_arg_val(5);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -747,7 +747,7 @@ Converts convolution weights to grouped layout with padded zeros
 This function will take in a weight tensor with shape [out_channels, in_channels // groups, H, W] and return a newly
 allocated output tensor with shape [out_channels, in_channels, H, W] The extra channels in shape[1] will be padded with
 0 - then the entire weight tensor is convolved with the input tensor - equivalent to convolution if the input tensor was
-divided into num_groups for each groupped filter
+divided into num_groups for each grouped filter
 */
 Tensor convert_conv_weight_tensor_to_grouped_layout(
     const Tensor& conv_weight_tensor, uint32_t num_groups, DataType output_dtype) {

--- a/ttnn/cpp/ttnn/operations/core/work_split/work_split_tilize.hpp
+++ b/ttnn/cpp/ttnn/operations/core/work_split/work_split_tilize.hpp
@@ -415,7 +415,7 @@ inline BlockSplit split_blocks_for_tilize(CoreCoord grid_size, uint32_t nblocks)
 }
 
 // BlockRep represents a repeated sequence of data blocks, mixed blocks, and padding blocks.
-// It is convient to pass to the device kernels because a single data structure made of 4 ints
+// It is convenient to pass to the device kernels because a single data structure made of 4 ints
 // can represent pure data rows, pure padding rows or a mixture thereof.
 struct BlockRep {
     // number of data blocks
@@ -484,7 +484,7 @@ struct BlockRep {
 
 // FullRep is a repeated sequence of data rows followed by pure padding. It represents the row
 // pattern seen from the outer-most dimension of a 4D tensor when padding is added to the second
-// or the thrird dimension.
+// or the third dimension.
 struct FullRep {
     BlockRep rep;
     BlockRep pad;

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/bcast.cpp
@@ -78,7 +78,7 @@ Tensor BcastOperation::invoke(
         }
     }
 
-    // Bcast only works with tile layout, so we need to tilize the input tensors if neccessary
+    // Bcast only works with tile layout, so we need to tilize the input tensors if necessary
     auto padded_shape_a = ttnn::operations::data_movement::pad_to_tile_shape(input_tensor_a.padded_shape());
     auto padded_shape_b = ttnn::operations::data_movement::pad_to_tile_shape(input_tensor_b.padded_shape());
     Tensor formatted_a = ttnn::tilize_with_val_padding(

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_reader_single_row_single_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_reader_single_row_single_core.cpp
@@ -38,11 +38,11 @@ the input_index_tensor.
     - Wt_input represents the number of tiles in the last dimension of the input tensor.
     - Wt_index represents the number of tiles in the last dimension of the input index tensor.
     - A full row of tiles of input tensor (size `Wt_input`) is read from DRAM into L1 memory.
-    - One tile in the ouput buffer is reserved for each tile in the input index tensor.
+    - One tile in the output buffer is reserved for each tile in the input index tensor.
 
 2. **Computation mechanism**:
     - Tiles from Wt_index are read from L1 memory one by one.
-    - For each index tile the one ouput tile is reserved in the output buffer.
+    - For each index tile the one output tile is reserved in the output buffer.
     - Algorithm iterates over the values in the index tile (`global_index`) - these values represents the indexes of the
 values in the input tensor that should be gathered.
     - The values are read regardless of the datatype. The datatype of the tile determines read/write mechanism

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.hpp
@@ -98,8 +98,8 @@ struct PermuteDeviceOperation {
             tensor_return_value_t& tensor_return_value);
     };
 
-    // Implemention for when only one of the height dimension (rank - 2) and the width dimension is swapped with another
-    // dimension (dims = {..., rank - 2,
+    // Implementation for when only one of the height dimension (rank - 2) and the width dimension is swapped with
+    // another dimension (dims = {..., rank - 2,
     // ..., i, rank - 1})
     struct MultiCoreTileRowInvariant {
         // Shared variables are the variables that are shared between the create and override_runtime_arguments methods

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/permute_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/permute_nanobind.cpp
@@ -21,7 +21,7 @@ void bind_permute(nb::module_& mod) {
 
         Args:
             input_tensor (ttnn.Tensor): the input tensor.
-            dim (number): tthe permutation of the dimensions of the input tensor.
+            dim (number): the permutation of the dimensions of the input tensor.
 
         Keyword Args:
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_higher_dim_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_higher_dim_rm.cpp
@@ -9,7 +9,7 @@
 using namespace tt::data_movement::common;
 
 void kernel_main() {
-    // We are guranteed to be in 4D going to 4D
+    // We are guaranteed to be in 4D going to 4D
     //<higher_dim,rep_dim,lower_dim,page_size>
 
     const uint32_t src_addr = get_arg_val<uint32_t>(0);

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_last_dim_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_last_dim_rm.cpp
@@ -12,7 +12,7 @@ Function reads from RM and writes to RM repeating the last dimension
 using namespace tt::data_movement::common;
 
 void kernel_main() {
-    // We are guranteed to be in 2D going to 2D
+    // We are guaranteed to be in 2D going to 2D
 
     const uint32_t src_addr = get_arg_val<uint32_t>(0);
     const uint32_t dst_addr = get_arg_val<uint32_t>(1);
@@ -85,7 +85,7 @@ void kernel_main() {
             // and we don't want target offset to be allocated and the for loop bounds computed
             uint32_t target_offset = original_page_size_bytes;
             for (uint32_t j = 0; j < num_doublings; j++) {
-                // This ensures the cur_page_size will be alligned to 16B so future walk retains allignment
+                // This ensures the cur_page_size will be aligned to 16B so future walk retains alignment
                 tt_memmove<false, false, false, 16 * original_page_size_bytes>(
                     data_location + target_offset, data_location, cur_page_size);
                 target_offset += cur_page_size;

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_program_factory_higher_dim.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_program_factory_higher_dim.cpp
@@ -78,7 +78,7 @@ RepeatProgramFactoryHigherDim::cached_program_t RepeatProgramFactoryHigherDim::c
         total_cores,
         tt::tt_metal::ReaderDataMovementConfig(compile_time_args));
     uint32_t done = 0;
-    // Determine runtime argumens
+    // Determine runtime arguments
     bool divide_on_higher = number_of_higher_pages > number_of_lower_pages;
 
     uint32_t responsibility_chunk =

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/rm_reshape_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/rm_reshape_interleaved.cpp
@@ -13,18 +13,18 @@ Compile arguments
 2. log_base_2_of_page_size: log base 2 of page size
 3. write_size_is_pow2: 1 if write size is power of 2 else 0
 4. log_base_2_of_page_size: log base 2 of page size
-5. needs_read_allignment: 1 if read needs allignment else 0
+5. needs_read_allignment: 1 if read needs alignment else 0
 //Needed if BRAM and page size is not multiple of 64 bytes
 
 Runtime arguments
 0. src_addr: source address
 1. dst_addr: destination address
-2. source_read_size_bytes: source read size in bytes
-3. read_start_page: read start page
-4. read_end_page: read end page
-5. write_start_page: write start page
-6. write_start_offset: write start offset
-7. nop: 1 if this core should be skipped
+2. source_page_size_bytes: source page size in bytes
+3. dest_page_size_bytes: destination page size in bytes
+4. source_read_size_bytes: source read size in bytes
+5. read_start_page: read start page
+6. read_end_page: read end page
+7. write_start_page: write start page
 */
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
@@ -32,7 +32,7 @@ Runtime arguments
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
 
 void kernel_main() {
-    //We are guranteed to be in 2D going to 2D
+    // We are guaranteed to be in 2D going to 2D
 
     const uint32_t src_addr                 = get_arg_val<uint32_t>(0);
     const uint32_t dst_addr = get_arg_val<uint32_t>(1);
@@ -42,7 +42,7 @@ void kernel_main() {
     const uint32_t read_end_page = get_arg_val<uint32_t>(4);
     const uint32_t write_start_page = get_arg_val<uint32_t>(5);
     const uint32_t write_start_offset = get_arg_val<uint32_t>(6);
-    const uint32_t nop = get_arg_val<uint32_t>(7);
+    const uint32_t nop = get_arg_val<uint32_t>(9);
 
     constexpr bool src_aligned_to_64 = get_compile_time_arg_val(0) == 1;
     constexpr bool src_aligned_to_16 = get_compile_time_arg_val(1) == 1;
@@ -91,11 +91,11 @@ void kernel_main() {
             tt::data_movement::common::enhanced_noc_async_read<source_page_size_bytes, false>(
                 src_noc_addr, source_buffer, source_page_size_bytes);
             read_offset = 0;
-        } else if constexpr (src_args.is_dram) {  // DDR but not alligned to 64 (potentially also not alligned to 16)
+        } else if constexpr (src_args.is_dram) {  // DDR but not aligned to 64 (potentially also not aligned to 16)
             tt::data_movement::common::enhanced_noc_async_read<(source_page_size_bytes + 128), false>(
                 src_noc_addr & MASK_64, source_buffer, source_read_size_bytes);
             read_offset = src_noc_addr & OFFSET_64;
-        } else {  // L1 but not alligned to 16
+        } else {  // L1 but not aligned to 16
             tt::data_movement::common::enhanced_noc_async_read<(source_page_size_bytes + 128), false>(
                 src_noc_addr & MASK_16, source_buffer, source_read_size_bytes);
             read_offset = src_noc_addr & OFFSET_16;

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/rm_reshape_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/rm_reshape_interleaved.cpp
@@ -19,12 +19,12 @@ Compile arguments
 Runtime arguments
 0. src_addr: source address
 1. dst_addr: destination address
-2. source_page_size_bytes: source page size in bytes
-3. dest_page_size_bytes: destination page size in bytes
-4. source_read_size_bytes: source read size in bytes
-5. read_start_page: read start page
-6. read_end_page: read end page
-7. write_start_page: write start page
+2. source_read_size_bytes: source read size in bytes
+3. read_start_page: read start page
+4. read_end_page: read end page
+5. write_start_page: write start page
+6. write_start_offset: write start offset
+7. nop: 1 if this core should be skipped
 */
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
@@ -42,7 +42,7 @@ void kernel_main() {
     const uint32_t read_end_page = get_arg_val<uint32_t>(4);
     const uint32_t write_start_page = get_arg_val<uint32_t>(5);
     const uint32_t write_start_offset = get_arg_val<uint32_t>(6);
-    const uint32_t nop = get_arg_val<uint32_t>(9);
+    const uint32_t nop = get_arg_val<uint32_t>(7);
 
     constexpr bool src_aligned_to_64 = get_compile_time_arg_val(0) == 1;
     constexpr bool src_aligned_to_16 = get_compile_time_arg_val(1) == 1;

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/reader_single_row_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/reader_single_row_multi_core.cpp
@@ -39,7 +39,7 @@ void kernel_main() {
     const auto index_tensor_addr_gen =
         TensorAccessor(index_tensor_args, index_tensor_buffer_addr, index_tensor_output_tile_size_bytes);
 
-    // Sempahore setup
+    // Semaphore setup
     volatile tt_l1_ptr uint32_t* semaphore_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(coordinator_to_cores_semaphore_id);
     noc_semaphore_set(semaphore_ptr, VALID);  // Reset the semaphore (Valid - we wait for 0)

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/sort.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/sort.cpp
@@ -50,7 +50,7 @@ Tensor pre_sort_transform_tensor(
     // If dim is not last dimension transpose it
     const Tensor transposed_tensor = reduction_common::perform_transpose(input_tensor, is_dim_last_idx, dim, -1);
 
-    // If input is not rank 4 transorm it to 4D
+    // If input is not rank 4 transform it to 4D
     const Tensor transformed_tensor = reduction_common::transform_to_4d_tensor(transposed_tensor, is_rank_le_4d);
 
     // Fill implicit tile padding with the appropriate value

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -512,7 +512,7 @@ Tensor run_remainder(
     const std::optional<MemoryConfig>& output_mem_config,
     const std::optional<CoreRangeSet>& sub_core_grids) {
     using FusedActivations = tt::stl::Span<const unary::EltwiseUnaryWithParam>;
-    // explicitly using binary_ng to avoid fallback to legacy because of row boradcast
+    // explicitly using binary_ng to avoid fallback to legacy because of row broadcast
     Tensor result = ttnn::subtract(
         input_a,
         ttnn::multiply(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
@@ -362,7 +362,7 @@ BinaryDeviceOperation::create_op_performance_model(
     const auto& output_tensor = tensor_return_value;
     // GS specific parameters
     // 80 B/cycle unpacker BW shared
-    // 128 datums per cycle math, but unpacker cant keep up
+    // 128 datums per cycle math, but unpacker can't keep up
     constexpr uint32_t num_cores = 9 * 12;
 
     uint32_t total_bytes = 0;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_multi_core_sharded_optimized_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_multi_core_sharded_optimized_program_factory.cpp
@@ -159,7 +159,7 @@ BinaryDeviceOperation::BroadcastHeightMultiCoreShardedOptimized::create(
         tt_metal::ComputeConfig{.compile_args = {}, .defines = bcast_defines});
 
     uint32_t ncores_y = ncores / ncores_x;
-    TT_FATAL((NC * H / TILE_HEIGHT) % bN == 0, "N*C*H of input0 must be devisible by batch size of input1");
+    TT_FATAL((NC * H / TILE_HEIGHT) % bN == 0, "N*C*H of input0 must be divisible by batch size of input1");
     uint32_t Ht_per_batch_b = std::min((NC * H / TILE_HEIGHT) / bN, Ht);
     uint32_t batch_b = Ht / Ht_per_batch_b;
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
@@ -31,7 +31,7 @@ void preallocated_tensors_check(
     const Tensor& input,
     const Tensor& other,
     const std::array<bool, 2>& required_outputs) {
-    TT_FATAL(required_outputs[0] || required_outputs[1], "Atleast one gradient is expected to be calculated.");
+    TT_FATAL(required_outputs[0] || required_outputs[1], "At least one gradient is expected to be calculated.");
 
     if (required_outputs[0] && !input_grad.has_value()) {
         input_grad = ttnn::empty_like(input);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_nanobind.cpp
@@ -1142,7 +1142,7 @@ void py_module(nb::module_& mod) {
     bind_binary_backward_rsub(
         mod,
         ttnn::rsub_bw,
-        R"doc(Performs backward operations for subraction of :attr:`input_tensor_a` from :attr:`input_tensor_b` with given :attr:`grad_tensor` (reversed order of subtraction operator).)doc",
+        R"doc(Performs backward operations for subtraction of :attr:`input_tensor_a` from :attr:`input_tensor_b` with given :attr:`grad_tensor` (reversed order of subtraction operator).)doc",
         R"doc(BFLOAT16, BFLOAT8_B)doc");
 
     bind_binary_backward_ops(

--- a/ttnn/cpp/ttnn/operations/eltwise/quantization/quantization.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/quantization/quantization.cpp
@@ -165,7 +165,7 @@ void check_zero_point_tensor_args(
 
 ttnn::Tensor reshape_per_channel_vector_args(
     const ttnn::Tensor& vector, ttnn::Shape tensor_shape, const int32_t axis, const ttnn::DataType out_dtype) {
-    // This function is internal use only, use asserts instead of TT_FATAL to convey intented usage
+    // This function is internal use only, use asserts instead of TT_FATAL to convey intended usage
     const int32_t rank = static_cast<int32_t>(tensor_shape.rank());
     assert(axis >= -rank && axis < rank);
     assert(vector.logical_shape().rank() == 1);

--- a/ttnn/cpp/ttnn/operations/embedding_backward/device/kernels/compute/embedding_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/device/kernels/compute/embedding_backward.cpp
@@ -52,7 +52,7 @@ void kernel_main() {
 
                 reshuffle_rows_tile_init();
                 // reshuffle_rows_tile expects that tiles have a header of 16 bytes.
-                // This isn't true, so we have to substract 16 bytes from the address.
+                // This isn't true, so we have to subtract 16 bytes from the address.
                 // Check implementation of reshuffle_rows_tile in LLK for more details.
                 // tt_metal/third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_reshuffle_rows.h
                 reshuffle_rows_tile(0, idx_addr - 16);

--- a/ttnn/cpp/ttnn/operations/experimental/adaptive_pool/adaptive_pool_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/adaptive_pool/adaptive_pool_utils.cpp
@@ -73,7 +73,7 @@ std::vector<uint32_t> calculate_actual_stride_patterns(
 
 // Adaptive pool params carry the information which is needed by pool2d but not given as arguments of the adaptive pool
 // op This function calculates the kernel sizes the same way they would be produced by pytorch, analyzes the possibility
-// to make them uniform with padding if possible and needed, padds the input tesnor and then for the padded tensor
+// to make them uniform with padding if possible and needed, pads the input tesnor and then for the padded tensor
 // calculates strides to check if those would be uniform as well
 AdaptivePoolingParams calculate_adaptive_pool_params(
     uint32_t input_h, uint32_t input_w, uint32_t output_h, uint32_t output_w) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async.cpp
@@ -97,7 +97,7 @@ Tensor local_sum(
     return sum_tensor;
 }
 
-// moreh sum does not support float32 datatye
+// moreh sum does not support float32 datatype
 Tensor local_sum_float32(
     const ttnn::Tensor& gathered_tensor,
     int reduce_dim,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_program_factory.cpp
@@ -296,7 +296,7 @@ AllReduceAsyncMeshWorkloadFactory::cached_program_t AllReduceAsyncMeshWorkloadFa
     /*
         Overview of algorithm:
 
-        - Ouput: each link gets assigned a start and end core index, since multiple links
+        - Output: each link gets assigned a start and end core index, since multiple links
             may have to read different offesets within a shard on the same core
         - First, assign all the necessary cores needed for a link. This may result in the link
             containing extra pages. This will result in an overflow, which is used to detect

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_moe_reduce_scatter/deepseek_moe_reduce_scatter_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_moe_reduce_scatter/deepseek_moe_reduce_scatter_nanobind.cpp
@@ -55,7 +55,7 @@ void bind_deepseek_moe_reduce_scatter(nb::module_& mod) {
         Reduce-scatter operation across devices along a selected dimension and optional cluster axis. This operation reduces the mesh tensor across the devices in the mesh, along the specified dimension. It then scatters the reduced tensor back to the devices in the mesh, along the same dimension. When cluster axis is specified, we reduce and scatter along the cluster axis. When it is not specified, then we reduce and scatter across all devices in the mesh.
 
         Args:
-            input_tensors (List of ttnn.Tensor): the input tensors, which when concatted together on the scatter dim repesent the single logical input tensor.
+            input_tensors (List of ttnn.Tensor): the input tensors, which when concatted together on the scatter dim represent the single logical input tensor.
             output_memory_config (ttnn.MemoryConfig): output memory configuration.
             dim (int): dimension along which to scatter.
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_gathered.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_gathered.cpp
@@ -294,11 +294,11 @@ void kernel_main() {
                     uint32_t dst_index = 0;  // start at 0, each call to matmul_block internally increments dst_index
                     uint32_t in0_index = in0_index_subblock_offset;  // offset into in0 block
                     uint32_t in1_index = in1_index_subblock_offset;  // offset into in1 block
-                    // inner dim that we accumualte is the inner dim of in0/in1, which is in0_block_w
+                    // inner dim that we accumulate is the inner dim of in0/in1, which is in0_block_w
                     for (uint32_t inner_dim_idx = 0; inner_dim_idx < unpadded_in0_block_w; ++inner_dim_idx) {
                         // matmul outer product of (out_subblock_h x out_subblock_w) tiles that fill dst
                         // accumulation is done by iterating matmul_block across inner dim
-                        // in0_block_w is passed as innder dim (kt) to matmul_block, interally used to stride in0
+                        // in0_block_w is passed as innder dim (kt) to matmul_block, internally used to stride in0
                         matmul_block(
                             input0_cb_id,
                             in1_cb_id,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp
@@ -930,7 +930,7 @@ void kernel_main() {
             // Wait until previous chunk arrives on the matmul cores before reading in another chunk of tokens.
             // Since both the reader and writer use NoC1, we want writer to have priority access so that chunks
             // arrive at the matmul cores earlier. Also, to do linked mcast transactions we need NoC to be completely
-            // idle during mcast. The very last wait is technically redundent since we won't be reading in another chunk
+            // idle during mcast. The very last wait is technically redundant since we won't be reading in another chunk
             // of tokens, however it's still required so we don't use NoC1 to write out the output tensors until the
             // last linked mcast completes.
             noc_semaphore_wait(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_program_factory.cpp
@@ -302,7 +302,7 @@ MoEComputeMeshWorkloadFactory::create_at(
     auto metadata_ready_semaphore_id = tt::tt_metal::CreateSemaphore(program, tilize_matmul_core_range_set, INVALID);
 
     // Matmul cores signal to tilize drain-sync-core that the input chunk is free to be written to
-    // Tilize drain-sync-core propogates this to the tilize non-drain-sync cores
+    // Tilize drain-sync-core propagates this to the tilize non-drain-sync cores
     auto matmul_chunk_available_semaphore_id =
         tt::tt_metal::CreateSemaphore(program, tilize_matmul_core_range_set, INVALID);
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_op.cpp
@@ -195,7 +195,7 @@ std::vector<Tensor> ring_attention_all_gather_async_impl(
     const auto& mesh_view = mesh_device.get_view();
     TT_FATAL(
         mesh_view.is_mesh_2d(),
-        "all-gather invoked with cluster_axis API withou 2D mesh, which is currently unsupported");
+        "all-gather invoked with cluster_axis API without 2D mesh, which is currently unsupported");
     std::size_t num_devices = (cluster_axis == 0) ? mesh_view.num_rows() : mesh_view.num_cols();
     int32_t rank = input_tensors[0].logical_shape().rank();
     int32_t gather_dim = (dim < 0) ? rank + dim : dim;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async/device/send_async_op_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async/device/send_async_op_device_operation_types.hpp
@@ -13,7 +13,7 @@
 namespace ttnn::experimental::prim {
 
 struct SendAsyncParams {
-    const tt::tt_metal::distributed::MeshSocket mesh_socket;  // No default contructor
+    const tt::tt_metal::distributed::MeshSocket mesh_socket;  // No default constructor
     SendAsyncParams(const tt::tt_metal::distributed::MeshSocket& mesh_socket) : mesh_socket(mesh_socket) {}
     // Add attributes method for reflection
     auto attributes() const {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/slice_reshard_async_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/slice_reshard_async_nanobind.cpp
@@ -47,7 +47,7 @@ void bind_slice_reshard_async(nb::module_& mod) {
         ttnn::experimental::slice_reshard_async,
         R"doc(
 
-        Slice a multi-device tensor, and then reshard the tensor across devices.  The slice is computed in the space of the aggregate multi-device tensor, not in each device tensor individually.  The use case for this is when the input tensor is padded, and then after various operations changes in size in the dimension it is sharded on.  This could lead to unneccessary amounts of padding, so the padding is trimmed, and the resulting slice of the aggregate input tensor is resharded across devices.
+        Slice a multi-device tensor, and then reshard the tensor across devices.  The slice is computed in the space of the aggregate multi-device tensor, not in each device tensor individually.  The use case for this is when the input tensor is padded, and then after various operations changes in size in the dimension it is sharded on.  This could lead to unnecessary amounts of padding, so the padding is trimmed, and the resulting slice of the aggregate input tensor is resharded across devices.
 
         Args:
             input_tensor (ttnn.Tensor): multi-device tensor.

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/device/strided_all_gather_minimal_matmul_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/device/strided_all_gather_minimal_matmul_async_op.cpp
@@ -16,7 +16,7 @@ void StridedAllGatherMinimalMatmulAsync::validate_on_program_cache_miss(
     const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
     TT_FATAL(
         attributes.strided_all_gather_async_struct.dim == 3,
-        "StridedAllGatherMinimalMatmulAsync requires dim=3 for the AllGather operaitons.");
+        "StridedAllGatherMinimalMatmulAsync requires dim=3 for the AllGather operations.");
     TT_FATAL(
         tensor_args.input_tensor.padded_shape()[0] == 1 && tensor_args.input_tensor.padded_shape()[1] == 1,
         "StridedAllGatherMinimalMatmulAsync requires input tensor to have batch size of 1.");

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_program_factory.cpp
@@ -720,26 +720,25 @@ Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
         // Get is_reducer value from the stored arguments
         [[maybe_unused]] bool is_reducer = (writer_args[13] == 1);
 
-        // Add reducer core coordinates
-        if (reducer_core_ids[reduction_group_id] != UINT32_MAX) {
-            writer_args.push_back(reducer_core_physical_xs[reduction_group_id]);
-            writer_args.push_back(reducer_core_physical_ys[reduction_group_id]);
-        }
-
-        // Add worker cores count
+        // Add worker cores count first so the kernel can use it to conditionally read reduction args
         uint32_t num_workers = worker_core_ids[reduction_group_id].size();
         compute_args.push_back(num_workers);
         writer_args.push_back(num_workers);
 
-        // Add all worker core coordinates to runtime args
-        writer_args.insert(
-            writer_args.end(),
-            worker_core_physical_xs[reduction_group_id].begin(),
-            worker_core_physical_xs[reduction_group_id].end());
-        writer_args.insert(
-            writer_args.end(),
-            worker_core_physical_ys[reduction_group_id].begin(),
-            worker_core_physical_ys[reduction_group_id].end());
+        // Add reducer core coordinates and worker core coordinates only when there are workers
+        if (num_workers > 0) {
+            writer_args.push_back(reducer_core_physical_xs[reduction_group_id]);
+            writer_args.push_back(reducer_core_physical_ys[reduction_group_id]);
+
+            writer_args.insert(
+                writer_args.end(),
+                worker_core_physical_xs[reduction_group_id].begin(),
+                worker_core_physical_xs[reduction_group_id].end());
+            writer_args.insert(
+                writer_args.end(),
+                worker_core_physical_ys[reduction_group_id].begin(),
+                worker_core_physical_ys[reduction_group_id].end());
+        }
 
         // Prepare worker cores string for logging
         std::string worker_cores_str;

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_program_factory.cpp
@@ -720,25 +720,26 @@ Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
         // Get is_reducer value from the stored arguments
         [[maybe_unused]] bool is_reducer = (writer_args[13] == 1);
 
-        // Add worker cores count first so the kernel can use it to conditionally read reduction args
+        // Add reducer core coordinates
+        if (reducer_core_ids[reduction_group_id] != UINT32_MAX) {
+            writer_args.push_back(reducer_core_physical_xs[reduction_group_id]);
+            writer_args.push_back(reducer_core_physical_ys[reduction_group_id]);
+        }
+
+        // Add worker cores count
         uint32_t num_workers = worker_core_ids[reduction_group_id].size();
         compute_args.push_back(num_workers);
         writer_args.push_back(num_workers);
 
-        // Add reducer core coordinates and worker core coordinates only when there are workers
-        if (num_workers > 0) {
-            writer_args.push_back(reducer_core_physical_xs[reduction_group_id]);
-            writer_args.push_back(reducer_core_physical_ys[reduction_group_id]);
-
-            writer_args.insert(
-                writer_args.end(),
-                worker_core_physical_xs[reduction_group_id].begin(),
-                worker_core_physical_xs[reduction_group_id].end());
-            writer_args.insert(
-                writer_args.end(),
-                worker_core_physical_ys[reduction_group_id].begin(),
-                worker_core_physical_ys[reduction_group_id].end());
-        }
+        // Add all worker core coordinates to runtime args
+        writer_args.insert(
+            writer_args.end(),
+            worker_core_physical_xs[reduction_group_id].begin(),
+            worker_core_physical_xs[reduction_group_id].end());
+        writer_args.insert(
+            writer_args.end(),
+            worker_core_physical_ys[reduction_group_id].begin(),
+            worker_core_physical_ys[reduction_group_id].end());
 
         // Prepare worker cores string for logging
         std::string worker_cores_str;

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/compute.cpp
@@ -26,7 +26,7 @@ void matmul_blocks(
     const uint32_t subblock_w,
     const bool transpose) {
     // precondition: in0_cb has M*K produced
-    // preconditino: in1_cb has K*N produced
+    // precondition: in1_cb has K*N produced
     // postcondition: in0_cb is full, in1_cb is empty
     // postcondition: out_cb has M*N produced
     mm_block_init_short(

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/writer.cpp
@@ -45,18 +45,23 @@ void kernel_main() {
     const uint32_t w_out_start = get_arg_val<uint32_t>(argidx++);
     const uint32_t w_out_end = get_arg_val<uint32_t>(argidx++);
     const uint32_t is_reducer = get_arg_val<uint32_t>(argidx++);
-    const uint32_t reducer_core_x = get_arg_val<uint32_t>(argidx++);
-    const uint32_t reducer_core_y = get_arg_val<uint32_t>(argidx++);
     const uint32_t num_workers = get_arg_val<uint32_t>(argidx++);
 
-    const uint64_t reducer_semaphore_noc_addr = get_noc_addr(reducer_core_x, reducer_core_y, semaphore_addr);
     volatile tt_l1_ptr uint32_t* local_semaphore_addr_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(semaphore_addr);
 
-    // Get worker core coordinates
-    tt_l1_ptr uint32_t* worker_core_xs = (tt_l1_ptr uint32_t*)(get_arg_addr(argidx));
-    argidx += num_workers;
-    tt_l1_ptr uint32_t* worker_core_ys = (tt_l1_ptr uint32_t*)(get_arg_addr(argidx));
+    // Reducer coordinates and worker core coordinates are only present when num_workers > 0
+    uint64_t reducer_semaphore_noc_addr = 0;
+    tt_l1_ptr uint32_t* worker_core_xs = nullptr;
+    tt_l1_ptr uint32_t* worker_core_ys = nullptr;
+    if (num_workers > 0) {
+        const uint32_t reducer_core_x = get_arg_val<uint32_t>(argidx++);
+        const uint32_t reducer_core_y = get_arg_val<uint32_t>(argidx++);
+        reducer_semaphore_noc_addr = get_noc_addr(reducer_core_x, reducer_core_y, semaphore_addr);
+        worker_core_xs = (tt_l1_ptr uint32_t*)(get_arg_addr(argidx));
+        argidx += num_workers;
+        worker_core_ys = (tt_l1_ptr uint32_t*)(get_arg_addr(argidx));
+    }
 
     constexpr uint32_t tile_bytes = get_tile_size(cb_weight_tiled);
     constexpr auto out_args = TensorAccessorArgs<22>();

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/writer.cpp
@@ -45,23 +45,18 @@ void kernel_main() {
     const uint32_t w_out_start = get_arg_val<uint32_t>(argidx++);
     const uint32_t w_out_end = get_arg_val<uint32_t>(argidx++);
     const uint32_t is_reducer = get_arg_val<uint32_t>(argidx++);
+    const uint32_t reducer_core_x = get_arg_val<uint32_t>(argidx++);
+    const uint32_t reducer_core_y = get_arg_val<uint32_t>(argidx++);
     const uint32_t num_workers = get_arg_val<uint32_t>(argidx++);
 
+    const uint64_t reducer_semaphore_noc_addr = get_noc_addr(reducer_core_x, reducer_core_y, semaphore_addr);
     volatile tt_l1_ptr uint32_t* local_semaphore_addr_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(semaphore_addr);
 
-    // Reducer coordinates and worker core coordinates are only present when num_workers > 0
-    uint64_t reducer_semaphore_noc_addr = 0;
-    tt_l1_ptr uint32_t* worker_core_xs = nullptr;
-    tt_l1_ptr uint32_t* worker_core_ys = nullptr;
-    if (num_workers > 0) {
-        const uint32_t reducer_core_x = get_arg_val<uint32_t>(argidx++);
-        const uint32_t reducer_core_y = get_arg_val<uint32_t>(argidx++);
-        reducer_semaphore_noc_addr = get_noc_addr(reducer_core_x, reducer_core_y, semaphore_addr);
-        worker_core_xs = (tt_l1_ptr uint32_t*)(get_arg_addr(argidx));
-        argidx += num_workers;
-        worker_core_ys = (tt_l1_ptr uint32_t*)(get_arg_addr(argidx));
-    }
+    // Get worker core coordinates
+    tt_l1_ptr uint32_t* worker_core_xs = (tt_l1_ptr uint32_t*)(get_arg_addr(argidx));
+    argidx += num_workers;
+    tt_l1_ptr uint32_t* worker_core_ys = (tt_l1_ptr uint32_t*)(get_arg_addr(argidx));
 
     constexpr uint32_t tile_bytes = get_tile_size(cb_weight_tiled);
     constexpr auto out_args = TensorAccessorArgs<22>();
@@ -136,7 +131,7 @@ void kernel_main() {
                                 // Wait for reducer to ack that it has read our data
                                 noc_semaphore_wait(local_semaphore_addr_ptr, 1);
 
-                                // Hanshake with compute so it can continue
+                                // Handshake with compute so it can continue
                                 cb_pop_front(cb_reduction_tiled, output_tiles);
                                 cb_reserve_back(cb_worker_ack_back, 1);
                                 cb_push_back(cb_worker_ack_back, 1);

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.hpp
@@ -40,7 +40,7 @@ struct DropoutMeshWorkloadFactory {
     using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
 
     // Dropout generates N different programs, but they differ only in the per-device seed set as a runtime argument.
-    // TODO: when heterogenous runtime arguments are supported, create a single program for all devices, and only
+    // TODO: when heterogeneous runtime arguments are supported, create a single program for all devices, and only
     // override the runtime arguments for each device. In addition, use `CachedMeshWorkload` instead of
     // `AdaptedCachedMeshWorkload`, as only a single `shared_variables_t` is needed.
     static cached_mesh_workload_t create_mesh_workload(

--- a/ttnn/cpp/ttnn/operations/experimental/isin/device/kernels/dataflow/isin_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/isin/device/kernels/dataflow/isin_reader.cpp
@@ -14,7 +14,7 @@ namespace {
 /*
     This function compares two subchunks of data - one chunk is one stick, and one subchunk
     is the maximal length of a stick that can fit as much L1 memory as possible - this length
-    is shared betwen rows of `elements`, `test_elements` and `output` tensors.
+    is shared between rows of `elements`, `test_elements` and `output` tensors.
 */
 template <typename elements_number_type>
 FORCE_INLINE void isin_subchunks(

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_device_operation.cpp
@@ -45,7 +45,7 @@ void AttnMatmulDeviceOperation::validate_on_program_cache_miss(
         TT_FATAL(
             (args.num_tokens.has_value() and args.transpose_hw.has_value()),
             "Must provide num_tokens and transpose_hw flag if we are reading from cache for in1!");
-        TT_FATAL(args.num_tokens.value() % 32 == 0, "Number of tokens must be divisble by 32!");
+        TT_FATAL(args.num_tokens.value() % 32 == 0, "Number of tokens must be divisible by 32!");
         read_from_kv_cache = true;
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_device_operation.cpp
@@ -135,7 +135,7 @@ void GroupAttnMatmulDeviceOperation::validate_on_program_cache_miss(
         TT_FATAL(
             (operation_attributes.num_tokens.has_value() and operation_attributes.transpose_hw.has_value()),
             "Must provide num_tokens and transpose_hw flag if we are reading from cache for in1!");
-        TT_FATAL(operation_attributes.num_tokens.value() % 32 == 0, "Number of tokens must be divisble by 32!");
+        TT_FATAL(operation_attributes.num_tokens.value() % 32 == 0, "Number of tokens must be divisible by 32!");
         read_from_kv_cache = true;
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/kernels/compute/transformer_group_attn_matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/kernels/compute/transformer_group_attn_matmul.cpp
@@ -119,11 +119,11 @@ void kernel_main() {
                             // uint32_t dst_index = 0; // start at 0, each call to matmul_block internally increments dst_index
                             // uint32_t in0_index = in0_index_subblock_offset; // offset into in0 block
                             // uint32_t in1_index = in1_index_subblock_offset; // offset into in1 block
-                            // // inner dim that we accumualte is the inner dim of in0/in1, which is in0_block_w
+                            // // inner dim that we accumulate is the inner dim of in0/in1, which is in0_block_w
                             // for (uint32_t inner_dim_idx = 0; inner_dim_idx < in0_block_w; ++inner_dim_idx) {
                             //     // matmul outer product of (out_subblock_h x out_subblock_w) tiles that fill dst
                             //     // accumulation is done by iterating matmul_block across inner dim
-                            //     // in0_block_w is passed as innder dim (kt) to matmul_block, interally used to stride in0
+                            //     // in0_block_w is passed as innder dim (kt) to matmul_block, internally used to stride in0
                             //     matmul_block(cb_in0, cb_in1, in0_index, in1_index, dst_index, transpose_hw, out_subblock_w, out_subblock_h, in0_block_w);
                             //     in0_index ++;  // stride right by 1
                             //     in1_index += in1_per_core_w; // to stride down by 1 need to stride by in_per_core_w (should be called in1_block_w)

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_grouped_gate/device/kernels/compute/deepseek_grouped_gate.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_grouped_gate/device/kernels/compute/deepseek_grouped_gate.cpp
@@ -172,7 +172,7 @@ void topk_group_scores(
     pack_reconfig_data_format(cb_sorted_group_order);
     pack_tile(2, cb_sorted_group_order);
     cb_pop_front(cb_group_summed_scores, 1);
-    // don't pop group indices as it gets re-used for the next tile heights
+    // don't pop group indices as it gets reused for the next tile heights
     release_dst();
 
     cb_push_back(cb_sorted_group_order, 1);

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc/device/deepseek_moe_fast_reduce_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc/device/deepseek_moe_fast_reduce_nc_program_factory.cpp
@@ -209,7 +209,7 @@ DeepseekMoEFastReduceNCProgramFactory::cached_program_t DeepseekMoEFastReduceNCP
     ////////////////////////////////////////////////////////////////////////////
     // Each core is assigned an output work unit in a row wise round robin
     // fashion. For a given core, the first index is i, and all subsequent
-    // indicies are increments of num_cores_to_be_used. The total number of
+    // indices are increments of num_cores_to_be_used. The total number of
     // units is num_tiles_per_group times num_cores_to_be_used.
     // For example, with 130 output tiles to be processed on an 8x8 grid
     // - the increment is 64
@@ -221,7 +221,7 @@ DeepseekMoEFastReduceNCProgramFactory::cached_program_t DeepseekMoEFastReduceNCP
     // - etc
     // The first tile that needs to be reduced has the same as the output tile.
     // That is the starting point for the reader, which then processes all
-    // subsequent tiles to be reduced. The increment for the input indicies is
+    // subsequent tiles to be reduced. The increment for the input indices is
     // the size of the inner dimensions in tiles (inner_num_tiles). The number
     // of tiles to process is the size of the reduce dimension in tiles
     // (reduction_num_tiles).

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_program_factory.cpp
@@ -227,7 +227,7 @@ FastReduceNCProgramFactory::cached_program_t FastReduceNCProgramFactory::create(
     ////////////////////////////////////////////////////////////////////////////
     // Each core is assigned an output work unit in a row wise round robin
     // fashion. For a given core, the first index is i, and all subsequent
-    // indicies are increments of num_cores_to_be_used. The total number of
+    // indices are increments of num_cores_to_be_used. The total number of
     // units is num_tiles_per_group times num_cores_to_be_used.
     // For example, with 130 output tiles to be processed and no shards (shard
     // factor is 1) on an 8x8 grid
@@ -240,7 +240,7 @@ FastReduceNCProgramFactory::cached_program_t FastReduceNCProgramFactory::create(
     // - etc
     // The first tile that needs to be reduced has the same as the output tile.
     // That is the starting point for the reader, which then processes all
-    // subsequent tiles to be reduced. The increment for the input indicies is
+    // subsequent tiles to be reduced. The increment for the input indices is
     // the size of the inner dimensions in tiles (inner_tile_size). The number
     // of tiles to process is the size of the reduce dimension in tiles
     // (reduce_tile_size).

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_rm_sharded_input_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_rm_sharded_input_program_factory.cpp
@@ -108,7 +108,7 @@ SliceWriteRuntimeArgs get_slice_write_runtime_args_rm_sharded_input(
         "slice_write expects output start for the last dimension to be 0. Got {}",
         output_tensor_start[-1]);
 
-    log_debug(tt::LogOp, "Output Buffer adddress: {}", output_buffer->address());
+    log_debug(tt::LogOp, "Output Buffer address: {}", output_buffer->address());
     std::vector<uint32_t> common_writer_kernel_args = {
         output_buffer->address() + (output_tensor_start[-1] * output_tensor.element_size()),
         output_row_size_bytes,

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_tiled_sharded_input_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_tiled_sharded_input_program_factory.cpp
@@ -111,7 +111,7 @@ SliceWriteRuntimeArgs get_slice_write_runtime_args_tiled_sharded_input(
         "slice_write expects output start for the last dimension to be 0. Got {}",
         output_tensor_start[-1]);
 
-    log_debug(tt::LogOp, "Output Buffer adddress: {}", output_buffer->address());
+    log_debug(tt::LogOp, "Output Buffer address: {}", output_buffer->address());
     std::vector<uint32_t> common_writer_kernel_args = {
         output_buffer->address(),
         input_single_tile_size,

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/kernels/reader_ssm_eltwise_mul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/kernels/reader_ssm_eltwise_mul.cpp
@@ -57,7 +57,7 @@ void kernel_main() {
             cb_wait_front(cb_in1_transposed, onetile);
             uint64_t cb_in1_transposed_read_ptr = get_noc_addr(get_read_ptr(cb_in1_transposed));
 
-            // Manually unroll iterating across the tile to eliminate unncessary conditional checking
+            // Manually unroll iterating across the tile to eliminate unnecessary conditional checking
             // First + second face
             for (uint32_t tile_row_id = 0; tile_row_id < num_rows_in_face; tile_row_id++) {
                 cb_reserve_back(cb_in1_bcast_row, onetile);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/all_reduce_create_qkv_heads_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/all_reduce_create_qkv_heads_device_operation.cpp
@@ -180,7 +180,7 @@ void AllReduceCreateQkvHeadsDeviceOperation::validate_on_program_cache_miss(
     // 1 User Per Core Max and 32 users for now
     TT_FATAL(
         num_cores >= 2 * num_users,
-        "Input coregrid size is {}. Need cores atleast double of num_users={} for decode when q and k heads are not "
+        "Input coregrid size is {}. Need cores at least double of num_users={} for decode when q and k heads are not "
         "overlapping coregrid",
         num_cores,
         num_users);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/device/kernels/compute/rmsnorm_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/device/kernels/compute/rmsnorm_pre_allgather.cpp
@@ -58,7 +58,7 @@ void kernel_main() {
 
             tile_regs_wait();
             for (uint32_t i = 0; i < block_size && col_tile + i < num_tile_cols; i++) {
-                // Pack tiles onto eachother in the intermediate_cb
+                // Pack tiles onto each other in the intermediate_cb
                 pack_tile<true>(i /*index into DST*/, intermediate_cb, 0 /*index into intermediate CB*/);
 
                 if (col_tile == 0 && i == 0) {

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_program_factory.cpp
@@ -70,8 +70,8 @@ NLPConcatHeadsDecodeProgramFactory::cached_program_t NLPConcatHeadsDecodeProgram
         noc_y_coords.push_back(device->worker_core_from_logical_core({0, y}).y);
     }
 
-    // We parallize the reader on risc0 and risc1, where each risc reads a sub-tile of the input (phase1 and phase2 of a
-    // tile respectively)
+    // We parallelize the reader on risc0 and risc1, where each risc reads a sub-tile of the input (phase1 and phase2 of
+    // a tile respectively)
     std::vector<uint32_t> reader_compile_time_args = {
         (std::uint32_t)element_size,
         (std::uint32_t)sub_tile_line_bytes,

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_subcoregrids_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_subcoregrids_program_factory.cpp
@@ -76,7 +76,7 @@ NLPConcatHeadsDecodeSubcoregridsProgramFactory::cached_program_t NLPConcatHeadsD
         noc_y_coords.push_back(device->worker_core_from_logical_core(in_cores_vec[i]).y);
     }
 
-    // We parallize the reader on risc0 and risc1 as two phases, where each risc reads half-tile of the input (Phase 1
+    // We parallelize the reader on risc0 and risc1 as two phases, where each risc reads half-tile of the input (Phase 1
     // reads left half-tile and Phase 2 reads right half-tile respectively)
     std::vector<uint32_t> reader_compile_time_args = {
         (std::uint32_t)element_size,

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_device_operation.cpp
@@ -108,7 +108,7 @@ void NLPCreateQKVHeadsDecodeDeviceOperation::validate_on_program_cache_miss(
     } else {
         TT_FATAL(
             num_cores >= 2 * num_users,
-            "Input coregrid size is {}. Need cores atleast double of num_users for decode when q and k heads are not "
+            "Input coregrid size is {}. Need cores at least double of num_users for decode when q and k heads are not "
             "overlapping "
             "coregrid",
             num_cores);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_device_operation.cpp
@@ -119,7 +119,7 @@ void RotaryEmbeddingLlamaDeviceOperation::validate_on_program_cache_miss(
             "Transformation matrix must have 3rd dim equal to TILE_HEIGHT");
         TT_FATAL(
             trans_mat.shard_spec()->shape[1] == TILE_WIDTH,
-            "Transformation matrix must have 4rd dim equal to TILE_WIDTH");
+            "Transformation matrix must have 4th dim equal to TILE_WIDTH");
     } else {  // Prefill mode validation
         TT_FATAL(
             input_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
@@ -152,7 +152,7 @@ void RotaryEmbeddingLlamaDeviceOperation::validate_on_program_cache_miss(
             trans_mat.logical_shape()[-2] == TILE_HEIGHT,
             "Transformation matrix must have 3rd dim equal to TILE_HEIGHT");
         TT_FATAL(
-            trans_mat.logical_shape()[-1] == TILE_WIDTH, "Transformation matrix must have 4rd dim equal to TILE_WIDTH");
+            trans_mat.logical_shape()[-1] == TILE_WIDTH, "Transformation matrix must have 4th dim equal to TILE_WIDTH");
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.cpp
@@ -64,6 +64,23 @@ void UpdateKVCacheOperation::validate_on_program_cache_miss(
         // TODO: If we want to support mixed precision like decode, we need to add simple compute kernel for conversion
         TT_FATAL(input_tensor.dtype() == cache_tensor.dtype(), "Input and cache tensors must have same dtype!");
 
+        // TODO: For interleaved, assume each core handles 1 tile of seq_len if kv_heads > 1
+        // For 56 cores and 2 heads, this effectively caps max seq len at 56 / 2 * 32 = 896
+        // Can generalize interleaved to infer and check arbitrary number of tiles along seq_len per core; or, add more
+        // robust logic in reader/writer loops to handle generic blocking of work For sharded, we infer number of tiles
+        // each core handles from shard so no issues there
+        if (input_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED and
+            input_tensor.padded_shape()[1] > 1) {
+            const uint32_t num_blocks_of_work =
+                input_tensor.padded_shape()[1] * input_tensor.padded_shape()[-2] / TILE_HEIGHT;
+            const auto compute_with_storage_grid_size = input_tensor.device()->compute_with_storage_grid_size();
+            TT_FATAL(
+                (num_blocks_of_work <= compute_with_storage_grid_size.x * compute_with_storage_grid_size.y),
+                "Number of work blocks ({}) must be <= total grid size ({})",
+                num_blocks_of_work,
+                compute_with_storage_grid_size.x * compute_with_storage_grid_size.y);
+        }
+
         if (input_tensor.is_sharded()) {
             TT_FATAL(
                 input_tensor.memory_config().memory_layout() != TensorMemoryLayout::WIDTH_SHARDED,

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.cpp
@@ -64,23 +64,6 @@ void UpdateKVCacheOperation::validate_on_program_cache_miss(
         // TODO: If we want to support mixed precision like decode, we need to add simple compute kernel for conversion
         TT_FATAL(input_tensor.dtype() == cache_tensor.dtype(), "Input and cache tensors must have same dtype!");
 
-        // TODO: For interleaved, assume each core handles 1 tile of seq_len if kv_heads > 1
-        // For 56 cores and 2 heads, this effectively caps max seq len at 56 / 2 * 32 = 896
-        // Can generalize interleaved to infer and check arbitrary number of tiles along seq_len per core; or, add more
-        // robust logic in reader/writer loops to handle generic blocking of work For sharded, we infer number of tiles
-        // each core handles from shard so no issues there
-        if (input_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED and
-            input_tensor.padded_shape()[1] > 1) {
-            const uint32_t num_blocks_of_work =
-                input_tensor.padded_shape()[1] * input_tensor.padded_shape()[-2] / TILE_HEIGHT;
-            const auto compute_with_storage_grid_size = input_tensor.device()->compute_with_storage_grid_size();
-            TT_FATAL(
-                (num_blocks_of_work <= compute_with_storage_grid_size.x * compute_with_storage_grid_size.y),
-                "Number of work blocks ({}) must be <= total grid size ({})",
-                num_blocks_of_work,
-                compute_with_storage_grid_size.x * compute_with_storage_grid_size.y);
-        }
-
         if (input_tensor.is_sharded()) {
             TT_FATAL(
                 input_tensor.memory_config().memory_layout() != TensorMemoryLayout::WIDTH_SHARDED,

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
@@ -202,7 +202,7 @@ create_program_dram_sharded(
     uint32_t in1_block_tiles = per_core_N_in1_sender * in0_block_w;
     uint32_t in1_CB_tiles = in1_block_tiles;
     if (B * num_blocks > 1) {
-        in1_CB_tiles = in1_CB_tiles * 3;  // tripple buffer
+        in1_CB_tiles = in1_CB_tiles * 3;  // triple buffer
     }
     uint32_t in1_CB_size = in1_CB_tiles * in1_single_tile_size;
 
@@ -552,7 +552,7 @@ create_program_dram_sharded(
             interm0_CB_size / interm0_single_tile_size,
             interm0_CB_size);
     } else {
-        log_debug(tt::LogOp, "inplace interm and outout cb");
+        log_debug(tt::LogOp, "inplace interm and output cb");
         // share buffer
         std::map<uint8_t, tt::DataFormat> output_cb_data_format_spec{
             {output_cb_index, output_data_format}, {interm0_cb_index, interm0_data_format}};

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
@@ -278,11 +278,11 @@ void kernel_main() {
                                 0;  // start at 0, each call to matmul_block internally increments dst_index
                             uint32_t in0_index = in0_index_subblock_offset;  // offset into in0 block
                             uint32_t in1_index = in1_index_subblock_offset;  // offset into in1 block
-                            // inner dim that we accumualte is the inner dim of in0/in1, which is in0_block_w
+                            // inner dim that we accumulate is the inner dim of in0/in1, which is in0_block_w
                             for (uint32_t inner_dim_idx = 0; inner_dim_idx < in0_block_w; ++inner_dim_idx) {
                                 // matmul outer product of (out_subblock_h x out_subblock_w) tiles that fill dst
                                 // accumulation is done by iterating matmul_block across inner dim
-                                // in0_block_w is passed as innder dim (kt) to matmul_block, interally used to stride
+                                // in0_block_w is passed as innder dim (kt) to matmul_block, internally used to stride
                                 // in0
                                 matmul_block(
                                     in0_cb_id,

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_gathered.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_gathered.cpp
@@ -341,11 +341,11 @@ void kernel_main() {
                     uint32_t dst_index = 0;  // start at 0, each call to matmul_block internally increments dst_index
                     uint32_t in0_index = in0_index_subblock_offset;  // offset into in0 block
                     uint32_t in1_index = in1_index_subblock_offset;  // offset into in1 block
-                    // inner dim that we accumualte is the inner dim of in0/in1, which is in0_block_w
+                    // inner dim that we accumulate is the inner dim of in0/in1, which is in0_block_w
                     for (uint32_t inner_dim_idx = 0; inner_dim_idx < unpadded_in0_block_w; ++inner_dim_idx) {
                         // matmul outer product of (out_subblock_h x out_subblock_w) tiles that fill dst
                         // accumulation is done by iterating matmul_block across inner dim
-                        // in0_block_w is passed as innder dim (kt) to matmul_block, interally used to stride in0
+                        // in0_block_w is passed as innder dim (kt) to matmul_block, internally used to stride in0
                         matmul_block(
                             input0_cb_id,
                             in1_cb_id,

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -793,9 +793,13 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
                             K);
                         uint32_t batches_per_bank = in1_shard_height_in_tiles / K;
                         uint32_t B = get_batch_size(b_shape_padded);
+                        // The kernel addresses batch b via: bank_id = b / batches_per_bank.
+                        // Total shard capacity (batches_per_bank * num_banks) must be >= B
+                        // to ensure all batches map to valid banks. It may exceed B when the
+                        // batch dimension is padded up to distribute evenly across banks.
                         TT_FATAL(
-                            batches_per_bank * num_banks == B,
-                            "HEIGHT_SHARDED input B: batches_per_bank ({}) * num_banks ({}) = {} must equal "
+                            batches_per_bank * num_banks >= B,
+                            "HEIGHT_SHARDED input B: batches_per_bank ({}) * num_banks ({}) = {} must be >= "
                             "batch size B ({})",
                             batches_per_bank,
                             num_banks,

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -139,7 +139,7 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
         const auto& optional_output_tensor_shape = optional_output_tensor_c->logical_shape();
         TT_FATAL(
             optional_output_tensor_shape == output_tensor_spec.logical_shape(),
-            "Shape of Optional Output Tensor {} doesnt match Output Tensor {}",
+            "Shape of Optional Output Tensor {} doesn't match Output Tensor {}",
             optional_output_tensor_shape,
             output_tensor_spec.logical_shape());
         TT_FATAL(
@@ -793,13 +793,9 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
                             K);
                         uint32_t batches_per_bank = in1_shard_height_in_tiles / K;
                         uint32_t B = get_batch_size(b_shape_padded);
-                        // The kernel addresses batch b via: bank_id = b / batches_per_bank.
-                        // Total shard capacity (batches_per_bank * num_banks) must be >= B
-                        // to ensure all batches map to valid banks. It may exceed B when the
-                        // batch dimension is padded up to distribute evenly across banks.
                         TT_FATAL(
-                            batches_per_bank * num_banks >= B,
-                            "HEIGHT_SHARDED input B: batches_per_bank ({}) * num_banks ({}) = {} must be >= "
+                            batches_per_bank * num_banks == B,
+                            "HEIGHT_SHARDED input B: batches_per_bank ({}) * num_banks ({}) = {} must equal "
                             "batch size B ({})",
                             batches_per_bank,
                             num_banks,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_fold/device/fold_program_factory_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_fold/device/fold_program_factory_rm.cpp
@@ -82,7 +82,7 @@ MorehFoldOperation::ProgramFactory::cached_program_t MorehFoldOperation::Program
 
     uint32_t input_cb_index = tt::CBIndex::c_0;    // input
     uint32_t scratch_cb_index = tt::CBIndex::c_1;  // scratch for DRAM alignment
-    uint32_t output_cb_index = tt::CBIndex::c_16;  // ouput
+    uint32_t output_cb_index = tt::CBIndex::c_16;  // output
 
     CircularBufferConfig input_cb_config =
         CircularBufferConfig(aligned_input_cb_page_size * 2, {{input_cb_index, data_format}})

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_rm_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_rm_factory.cpp
@@ -119,7 +119,7 @@ MorehGetItemOperation::MorehGetItemRmFactory::cached_program_t MorehGetItemOpera
                               .set_page_size(out_cb_index, rounded_input_page_size);
     CreateCircularBuffer(program, all_cores, cb_out0_config);
 
-    // create read/wrtie kernel
+    // create read/write kernel
     std::map<std::string, std::string> reader_defines;
     std::map<std::string, std::string> writer_defines;
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_tilized_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_tilized_factory.cpp
@@ -154,7 +154,7 @@ MorehGetItemOperation::MorehGetItemTilizedFactory::create(
                                   .set_page_size(out_cb1_index, rounded_output_page_size);
         CreateCircularBuffer(program, all_cores, cb_out1_config);
 
-        // create read/wrtie kernel
+        // create read/write kernel
         std::map<std::string, std::string> reader_defines;
         std::map<std::string, std::string> writer_defines;
 
@@ -376,7 +376,7 @@ MorehGetItemOperation::MorehGetItemTilizedFactory::create(
                               .set_page_size(out_cb_index, rounded_input_page_size);
     CreateCircularBuffer(program, all_cores, cb_out0_config);
 
-    // create read/wrtie kernel
+    // create read/write kernel
     std::map<std::string, std::string> reader_defines;
     std::map<std::string, std::string> writer_defines;
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step1/device/moreh_nll_loss_step1_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step1/device/moreh_nll_loss_step1_device_operation.cpp
@@ -23,7 +23,7 @@ void MorehNllLossStep1DeviceOperation::validate_inputs(
         TT_FATAL(
             weight_tensor.value().buffer() != nullptr,
             "Operands to nll_loss need to be allocated in buffers on device!");
-        TT_FATAL(weight_tensor.value().dtype() == DataType::BFLOAT16, "weigth tensor dtype must be bfloat16");
+        TT_FATAL(weight_tensor.value().dtype() == DataType::BFLOAT16, "weight tensor dtype must be bfloat16");
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/moreh_nll_loss_step2_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/moreh_nll_loss_step2_program_factory.cpp
@@ -30,7 +30,7 @@ MorehNllLossStep2DeviceOperation::Factory::cached_program_t moreh_nll_loss_step2
 
     auto N = input_shape[0];
 
-    // copy 32 Btyes per core
+    // copy 32 Bytes per core
     uint32_t units_to_divide = N / tt::constants::TILE_HEIGHT;
     const auto& input_shape_without_padding = input.logical_shape();
     const auto origin_N = input_shape_without_padding[0];

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/moreh_nll_loss_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/moreh_nll_loss_backward_program_factory.cpp
@@ -76,7 +76,7 @@ MorehNllLossBackwardDeviceOperation::Factory::cached_program_t moreh_nll_loss_ba
     // Need another scratch CB for output_grad reading data from DRAM into L1.
     CreateCircularBuffer(program, all_cores, data_format, {tt::CBIndex::c_8, 1});
 
-    // create read/wrtie kernel
+    // create read/write kernel
     std::vector<uint32_t> reader_compile_time_args{};
     TensorAccessorArgs(target.buffer()).append_to(reader_compile_time_args);
     TensorAccessorArgs(weight.has_value() ? weight.value().buffer() : nullptr).append_to(reader_compile_time_args);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/moreh_nll_loss_unreduced_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/moreh_nll_loss_unreduced_backward_program_factory.cpp
@@ -60,7 +60,7 @@ MorehNllLossUnreducedBackwardDeviceOperation::Factory::cached_program_t moreh_nl
             {tt::CBIndex::c_16, 1},                                                // input_grad
         });
 
-    // create read/wrtie kernel
+    // create read/write kernel
     std::vector<uint32_t> reader_compile_time_args{};
     TensorAccessorArgs(target.buffer()).append_to(reader_compile_time_args);
     TensorAccessorArgs(output_grad.buffer()).append_to(reader_compile_time_args);
@@ -184,7 +184,7 @@ MorehNllLossUnreducedBackwardDeviceOperation::Factory::cached_program_t moreh_nl
             {tt::CBIndex::c_16, 1},                                                // input_grad
         });
 
-    // create read/wrtie kernel
+    // create read/write kernel
     std::vector<uint32_t> reader_compile_time_args{};
     TensorAccessorArgs(target.buffer()).append_to(reader_compile_time_args);
     TensorAccessorArgs(output_grad.buffer()).append_to(reader_compile_time_args);
@@ -311,7 +311,7 @@ MorehNllLossUnreducedBackwardDeviceOperation::Factory::cached_program_t moreh_nl
             {tt::CBIndex::c_16, 1},                                                // input_grad
         });
 
-    // create read/wrtie kernel
+    // create read/write kernel
     std::vector<uint32_t> reader_compile_time_args{};
     TensorAccessorArgs(target.buffer()).append_to(reader_compile_time_args);
     TensorAccessorArgs(output_grad.buffer()).append_to(reader_compile_time_args);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/kernels/moreh_norm_backward_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/kernels/moreh_norm_backward_kernel.cpp
@@ -149,7 +149,7 @@ void kernel_main() {
 
         cb_pop_front(cb_dy, onetile);
 
-        // muliply abs sign
+        // multiply abs sign
         mul_tiles_to_cb(cb_sign, cb_tmp4, cb_dx, 0, 0);
     }
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_c_large/softmax_c_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_c_large/softmax_c_large.cpp
@@ -68,7 +68,7 @@ MorehSoftmaxOperation::MorehSoftmaxCLargeFactory::create(
             {tt::CBIndex::c_28, 1, intermed_data_format},  // tmp
         });
 
-    // create read/wrtie kernel
+    // create read/write kernel
 
     std::map<std::string, std::string> reader_defines;
     std::map<std::string, std::string> writer_defines;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_large/softmax_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_large/softmax_h_large.cpp
@@ -69,7 +69,7 @@ MorehSoftmaxOperation::MorehSoftmaxHLargeFactory::create(
             {tt::CBIndex::c_28, 1, intermed_data_format},  // tmp
         });
 
-    // create read/wrtie kernel
+    // create read/write kernel
 
     std::map<std::string, std::string> reader_defines;
     std::map<std::string, std::string> writer_defines;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_small/softmax_h_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_small/softmax_h_small.cpp
@@ -71,7 +71,7 @@ MorehSoftmaxOperation::MorehSoftmaxHSmallFactory::create(
             {tt::CBIndex::c_28, 1, intermed_data_format}    // tmp
         });
 
-    // create read/wrtie kernel
+    // create read/write kernel
 
     std::map<std::string, std::string> reader_defines;
     std::map<std::string, std::string> writer_defines;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_large/softmax_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_large/softmax_w_large.cpp
@@ -71,7 +71,7 @@ MorehSoftmaxOperation::MorehSoftmaxWLargeFactory::create(
             {tt::CBIndex::c_28, 1, intermed_data_format},  // tmp
         });
 
-    // create read/wrtie kernel
+    // create read/write kernel
 
     std::map<std::string, std::string> reader_defines;
     std::map<std::string, std::string> writer_defines;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_small/softmax_w_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_small/softmax_w_small.cpp
@@ -71,7 +71,7 @@ MorehSoftmaxOperation::MorehSoftmaxWSmallFactory::create(
             {tt::CBIndex::c_28, 1, intermed_data_format}    // tmp
         });
 
-    // create read/wrtie kernel
+    // create read/write kernel
 
     std::map<std::string, std::string> reader_defines;
     std::map<std::string, std::string> writer_defines;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_c_large/softmax_backward_c_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_c_large/softmax_backward_c_large.cpp
@@ -61,7 +61,7 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardCLargeFactory::create(
             {tt::CBIndex::c_26, 1, fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},  // dy - sum
         });
 
-    // create read/wrtie kernel
+    // create read/write kernel
 
     std::map<std::string, std::string> reader_defines;
     std::map<std::string, std::string> writer_defines;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_h_large/softmax_backward_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_h_large/softmax_backward_h_large.cpp
@@ -66,7 +66,7 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardHLargeFactory::create(
              fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},  // add(output * output_grad)
         });
 
-    // create read/wrtie kernel
+    // create read/write kernel
 
     std::map<std::string, std::string> reader_defines;
     std::map<std::string, std::string> writer_defines;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_h_small/softmax_backward_h_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_h_small/softmax_backward_h_small.cpp
@@ -63,7 +63,7 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardHSmallFactory::create(
             {tt::CBIndex::c_26, 1, fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},   // dy - sum
         });
 
-    // create read/wrtie kernel
+    // create read/write kernel
 
     std::map<std::string, std::string> reader_defines;
     std::map<std::string, std::string> writer_defines;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_w_large/softmax_backward_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_w_large/softmax_backward_w_large.cpp
@@ -66,7 +66,7 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardWLargeFactory::create(
              fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},  // add(output * output_grad)
         });
 
-    // create read/wrtie kernel
+    // create read/write kernel
 
     std::map<std::string, std::string> reader_defines;
     std::map<std::string, std::string> writer_defines;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_w_small/softmax_backward_w_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_w_small/softmax_backward_w_small.cpp
@@ -62,7 +62,7 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardWSmallFactory::create(
             {tt::CBIndex::c_25, 1, fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},   // reduce
             {tt::CBIndex::c_26, 1, fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},   // dy - sum
         });
-    // create read/wrtie kernel
+    // create read/write kernel
 
     std::map<std::string, std::string> reader_defines;
     std::map<std::string, std::string> writer_defines;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_int_sum_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_int_sum_h_program_factory.cpp
@@ -65,7 +65,7 @@ MorehSumOperation::MorehSumHIntFactory::cached_program_t MorehSumOperation::More
 
     const uint32_t in0_t{2};        // input
     const uint32_t in1_t{1};        // mask
-    const uint32_t intermed0_t{1};  // accumalated sum
+    const uint32_t intermed0_t{1};  // accumulated sum
     const uint32_t out0_t{2};       // output
     const auto
         [num_cores, all_cores, core_group_1, core_group_2, num_cols_per_core_group_1, num_cols_per_core_group_2] =
@@ -89,7 +89,7 @@ MorehSumOperation::MorehSumHIntFactory::cached_program_t MorehSumOperation::More
         {
             {tt::CBIndex::c_0, in0_t},         // input
             {tt::CBIndex::c_1, in1_t},         // mask
-            {tt::CBIndex::c_24, intermed0_t},  // accumalated sum
+            {tt::CBIndex::c_24, intermed0_t},  // accumulated sum
             {tt::CBIndex::c_16, out0_t},       // output
         });
     ////////////////////////////////////////////////////////////////////////////

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_int_sum_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_int_sum_w_program_factory.cpp
@@ -67,7 +67,7 @@ MorehSumOperation::MorehSumWIntFactory::cached_program_t MorehSumOperation::More
 
     const uint32_t in0_t{2};        // input
     const uint32_t in1_t{1};        // mask
-    const uint32_t intermed0_t{1};  // accumalated sum
+    const uint32_t intermed0_t{1};  // accumulated sum
     const uint32_t out0_t{2};       // output
     const auto
         [num_cores, all_cores, core_group_1, core_group_2, num_rows_per_core_group_1, num_rows_per_core_group_2] =
@@ -91,7 +91,7 @@ MorehSumOperation::MorehSumWIntFactory::cached_program_t MorehSumOperation::More
         {
             {tt::CBIndex::c_0, in0_t},         // input
             {tt::CBIndex::c_1, in1_t},         // mask
-            {tt::CBIndex::c_24, intermed0_t},  // accumalated sum
+            {tt::CBIndex::c_24, intermed0_t},  // accumulated sum
             {tt::CBIndex::c_16, out0_t},       // output
         });
     ////////////////////////////////////////////////////////////////////////////

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm.cpp
@@ -41,7 +41,7 @@ void kernel_main() {
     //   receiver: This the cores that receive the aggregated results from sender, they only do
     //   local computations that they send to the sender for final aggregation
     //
-    // This is a high level desciption of the stages of this kernel, tags will be added to show where in the code each
+    // This is a high level description of the stages of this kernel, tags will be added to show where in the code each
     // stage starts and ends
     //
     // Batch Loop:
@@ -85,7 +85,7 @@ void kernel_main() {
     //           We add beta to this value
     //
     // We are now done! Nice
-    //   To look at where the code starts and stops seach for
+    //   To look at where the code starts and stops search for
     //   Start LABEL or End Label
     //   Ex: Start Local Reduce or End Local Reduce
     // clang-format on

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm.cpp
@@ -40,7 +40,7 @@ void kernel_main() {
      * ...last: If num_out_blocks does not divides block_h, the leftovers are put into a chunk of
      *          length last.
      *
-     * This is a high level desciption of the stages of this kernel, tags will be added to show
+     * This is a high level description of the stages of this kernel, tags will be added to show
      * where in the code each stage starts and ends.
      *
      * Welford's Online Algorithm for Group Normalization:

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_receiver_unary_gn.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_receiver_unary_gn.cpp
@@ -46,13 +46,13 @@ void kernel_main() {
     //               Send Global Average to all Receiver cores
     //     Second Read of data:
     //       If Receiver:
-    //           Send partial reduction of Varience to Sender Core
+    //           Send partial reduction of Variance to Sender Core
     //       If Sender:
     //           Pack Partials:
     //               Accumulate partial reductions into single tile
-    //               Calculates the Global Varience sum
+    //               Calculates the Global Variance sum
     //           Send Global:
-    //               Send Global Varience to all Receiver cores
+    //               Send Global Variance to all Receiver cores
     //          Third Read of data:
     //
     //      // clang-format on
@@ -204,7 +204,7 @@ void kernel_main() {
 
 #endif
                     if (cur_read_iteration == 0 || cur_read_iteration == 1) {
-                        //Section for wating for local reduce to be pushed to a cb_ex_partial
+                        //Section for waiting for local reduce to be pushed to a cb_ex_partial
                         noc_semaphore_set(reduce_sender_semaphore_addr_ptr, INVALID);
                         if (cur_read_iteration == 0) {
                             //Wait for local avg calculation

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_sender_unary_gn.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_sender_unary_gn.cpp
@@ -28,8 +28,8 @@ void kernel_main() {
     //   receiver: This the cores that receive the aggregated results from sender, they only do
     //   local computations that they send to the sender for final aggregation
     //
-    // GROUPNORM SENDER DESCIPTION
-    // This is a high level desciption of the stages of this kernel, tags will be added to show where in the code each
+    // GROUPNORM SENDER DESCRIPTION
+    // This is a high level description of the stages of this kernel, tags will be added to show where in the code each
     // stage starts and ends
     //
     // Batch Loop:
@@ -46,13 +46,13 @@ void kernel_main() {
     //               Send Global Average to all Receiver cores
     //     Second Read of data:
     //       If Receiver:
-    //           Send partial reduction of Varience to Sender Core
+    //           Send partial reduction of Variance to Sender Core
     //       If Sender:
     //           Pack Partials:
     //               Accumulate partial reductions into single tile
-    //               Calculates the Global Varience sum
+    //               Calculates the Global Variance sum
     //           Send Global:
-    //               Send Global Varience to all Receiver cores
+    //               Send Global Variance to all Receiver cores
     //          Third Read of data:
     //
     //      // clang-format on

--- a/ttnn/cpp/ttnn/operations/normalization/kernel_util/compute/numeric.h
+++ b/ttnn/cpp/ttnn/operations/normalization/kernel_util/compute/numeric.h
@@ -120,7 +120,7 @@ inline void accumulate_compute_loop(
  * @tparam Epilogue The type of the epilogue functor
  * @tparam AdditionalCBs The types of the additional input CBs (must be uint32_t)
  *
- * @note dst0 is used to accumuate the sum, so it
+ * @note dst0 is used to accumulate the sum, so it
  * will be overwritten here @anchor dst0_overwritten
  * @note It is up to the caller to ensure that the scalar tile
  * is correctly populated. If it doesn't contain 1's, the result

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_pre_allgather.cpp
@@ -202,6 +202,7 @@ void kernel_main() {
         reconfig_data_format_srca(cb_x2, cb_ex_external2);
         reconfig_data_format_srcb(cb_scaler, cb_scaler_global);
         reduce_init(cb_ex_external2, cb_scaler_global, cb_reduction_out);
+        pack_reconfig_data_format(cb_reduction_out);
         cb_reserve_back(cb_reduction_out, num_tiles_per_partial_result * num_tiles_per_allgather_worker);
 
         for (uint32_t i = 0; i < num_tiles_per_allgather_worker; i++) {  // loops over height

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_pre_allgather.cpp
@@ -202,7 +202,6 @@ void kernel_main() {
         reconfig_data_format_srca(cb_x2, cb_ex_external2);
         reconfig_data_format_srcb(cb_scaler, cb_scaler_global);
         reduce_init(cb_ex_external2, cb_scaler_global, cb_reduction_out);
-        pack_reconfig_data_format(cb_reduction_out);
         cb_reserve_back(cb_reduction_out, num_tiles_per_partial_result * num_tiles_per_allgather_worker);
 
         for (uint32_t i = 0; i < num_tiles_per_allgather_worker; i++) {  // loops over height

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core.cpp
@@ -291,7 +291,7 @@ tt::tt_metal::ProgramDescriptor LayerNormMultiCoreProgramFactory::create_descrip
         a.device()->l1_size_per_core());
     if (!use_row_major_kernel) {
         if ((gamma.has_value() or beta.has_value() or in_data_format == tt::DataFormat::Float32) and !cb_fits_in_L1) {
-            // In the case that the required space is larger than what can be handeled by the single pass
+            // In the case that the required space is larger than what can be handled by the single pass
             large_tensor_needed = true;
             Wt_next_block_up = with_weights_max_size;
         } else if (!cb_fits_in_L1) {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core_sharded.cpp
@@ -265,8 +265,13 @@ tt::tt_metal::ProgramDescriptor LayerNormShardedProgramFactory::create_descripto
 
     assert_subblock_compute_config_compatible(dst_full_sync_en, fp32_dest_acc_en, subblock_wt);
 
-    auto [out_data_format, cb_data_format, gamma_cb_data_format, beta_cb_data_format, reciprocal_cb_data_format] =
-        get_cb_data_formats(output, gamma, beta, fp32_dest_acc_en);
+    auto
+        [out_data_format,
+         cb_data_format,
+         gamma_cb_data_format,
+         beta_cb_data_format,
+         stats_cb_data_format,
+         reciprocal_cb_data_format] = get_cb_data_formats(output, gamma, beta, stats, fp32_dest_acc_en);
 
     // tile sizes
     uint32_t in_single_tile_size = tt::tile_size(in_data_format);
@@ -274,6 +279,7 @@ tt::tt_metal::ProgramDescriptor LayerNormShardedProgramFactory::create_descripto
     uint32_t out_single_tile_size = tt::tile_size(out_data_format);
     uint32_t gamma_single_tile_size = tt::tile_size(gamma_cb_data_format);
     uint32_t beta_single_tile_size = tt::tile_size(beta_cb_data_format);
+    uint32_t stats_single_tile_size = tt::tile_size(stats_cb_data_format);
     uint32_t bfloat16_tile_size = tt::tile_size(tt::DataFormat::Float16_b);
 
     // tensor shape
@@ -337,6 +343,7 @@ tt::tt_metal::ProgramDescriptor LayerNormShardedProgramFactory::create_descripto
         .out_single_tile_size = out_single_tile_size,
         .gamma_single_tile_size = gamma_single_tile_size,
         .beta_single_tile_size = beta_single_tile_size,
+        .stats_single_tile_size = stats_single_tile_size,
         .bfloat16_tile_size = bfloat16_tile_size,
         .reciprocal_CB_size_bytes = reciprocal_CB_size_bytes,
         .num_rows_per_all_to_all_worker = workers.num_rows_per_all_to_all_worker,
@@ -571,12 +578,14 @@ tt::tt_metal::ProgramDescriptor LayerNormShardedProgramFactory::create_descripto
     cb_config.out_data_format = out_data_format;
     cb_config.gamma_cb_data_format = gamma_cb_data_format;
     cb_config.beta_cb_data_format = beta_cb_data_format;
+    cb_config.stats_cb_data_format = stats_cb_data_format;
     cb_config.reciprocal_cb_data_format = reciprocal_cb_data_format;
     cb_config.in_single_tile_size = in_single_tile_size;
     cb_config.single_tile_size = single_tile_size;
     cb_config.out_single_tile_size = out_single_tile_size;
     cb_config.gamma_single_tile_size = gamma_single_tile_size;
     cb_config.beta_single_tile_size = beta_single_tile_size;
+    cb_config.stats_single_tile_size = stats_single_tile_size;
     cb_config.bfloat16_tile_size = bfloat16_tile_size;
     cb_config.a_buffer = a.buffer();
     cb_config.b_buffer = b.has_value() ? b.value().buffer() : nullptr;

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core_sharded.cpp
@@ -265,13 +265,8 @@ tt::tt_metal::ProgramDescriptor LayerNormShardedProgramFactory::create_descripto
 
     assert_subblock_compute_config_compatible(dst_full_sync_en, fp32_dest_acc_en, subblock_wt);
 
-    auto
-        [out_data_format,
-         cb_data_format,
-         gamma_cb_data_format,
-         beta_cb_data_format,
-         stats_cb_data_format,
-         reciprocal_cb_data_format] = get_cb_data_formats(output, gamma, beta, stats, fp32_dest_acc_en);
+    auto [out_data_format, cb_data_format, gamma_cb_data_format, beta_cb_data_format, reciprocal_cb_data_format] =
+        get_cb_data_formats(output, gamma, beta, fp32_dest_acc_en);
 
     // tile sizes
     uint32_t in_single_tile_size = tt::tile_size(in_data_format);
@@ -279,7 +274,6 @@ tt::tt_metal::ProgramDescriptor LayerNormShardedProgramFactory::create_descripto
     uint32_t out_single_tile_size = tt::tile_size(out_data_format);
     uint32_t gamma_single_tile_size = tt::tile_size(gamma_cb_data_format);
     uint32_t beta_single_tile_size = tt::tile_size(beta_cb_data_format);
-    uint32_t stats_single_tile_size = tt::tile_size(stats_cb_data_format);
     uint32_t bfloat16_tile_size = tt::tile_size(tt::DataFormat::Float16_b);
 
     // tensor shape
@@ -343,7 +337,6 @@ tt::tt_metal::ProgramDescriptor LayerNormShardedProgramFactory::create_descripto
         .out_single_tile_size = out_single_tile_size,
         .gamma_single_tile_size = gamma_single_tile_size,
         .beta_single_tile_size = beta_single_tile_size,
-        .stats_single_tile_size = stats_single_tile_size,
         .bfloat16_tile_size = bfloat16_tile_size,
         .reciprocal_CB_size_bytes = reciprocal_CB_size_bytes,
         .num_rows_per_all_to_all_worker = workers.num_rows_per_all_to_all_worker,
@@ -578,14 +571,12 @@ tt::tt_metal::ProgramDescriptor LayerNormShardedProgramFactory::create_descripto
     cb_config.out_data_format = out_data_format;
     cb_config.gamma_cb_data_format = gamma_cb_data_format;
     cb_config.beta_cb_data_format = beta_cb_data_format;
-    cb_config.stats_cb_data_format = stats_cb_data_format;
     cb_config.reciprocal_cb_data_format = reciprocal_cb_data_format;
     cb_config.in_single_tile_size = in_single_tile_size;
     cb_config.single_tile_size = single_tile_size;
     cb_config.out_single_tile_size = out_single_tile_size;
     cb_config.gamma_single_tile_size = gamma_single_tile_size;
     cb_config.beta_single_tile_size = beta_single_tile_size;
-    cb_config.stats_single_tile_size = stats_single_tile_size;
     cb_config.bfloat16_tile_size = bfloat16_tile_size;
     cb_config.a_buffer = a.buffer();
     cb_config.b_buffer = b.has_value() ? b.value().buffer() : nullptr;

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/sharded_layernorm_factory_helpers.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/sharded_layernorm_factory_helpers.cpp
@@ -47,10 +47,12 @@ void assert_subblock_compute_config_compatible(bool dst_full_sync_en, bool fp32_
     }
 }
 
-std::tuple<tt::DataFormat, tt::DataFormat, tt::DataFormat, tt::DataFormat, tt::DataFormat> get_cb_data_formats(
+std::tuple<tt::DataFormat, tt::DataFormat, tt::DataFormat, tt::DataFormat, tt::DataFormat, tt::DataFormat>
+get_cb_data_formats(
     const Tensor& output,
     const std::optional<const Tensor>& gamma,
     const std::optional<const Tensor>& beta,
+    const std::optional<const Tensor>& stats,
     bool fp32_dest_acc_en) {
     tt::DataFormat out_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
     tt::DataFormat cb_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
@@ -60,8 +62,17 @@ std::tuple<tt::DataFormat, tt::DataFormat, tt::DataFormat, tt::DataFormat, tt::D
     tt::DataFormat beta_cb_data_format = beta.has_value()
                                              ? tt::tt_metal::datatype_to_dataformat_converter(beta.value().dtype())
                                              : tt::DataFormat::Float16_b;
+    tt::DataFormat stats_cb_data_format = stats.has_value()
+                                              ? tt::tt_metal::datatype_to_dataformat_converter(stats.value().dtype())
+                                              : tt::DataFormat::Float16_b;
     tt::DataFormat reciprocal_cb_data_format = tt::DataFormat::Float32;
-    return {out_data_format, cb_data_format, gamma_cb_data_format, beta_cb_data_format, reciprocal_cb_data_format};
+    return {
+        out_data_format,
+        cb_data_format,
+        gamma_cb_data_format,
+        beta_cb_data_format,
+        stats_cb_data_format,
+        reciprocal_cb_data_format};
 }
 
 namespace {
@@ -549,7 +560,7 @@ CBSizeParams::Sizes CBSizeParams::compute() const {
     sizes.ex2pe_CB_size = num_rows_per_all_to_all_worker * single_tile_size;
 
     if (is_post_all_gather) {
-        sizes.stats_cb_size = post_all_gather_stats_block_tiles * single_tile_size;
+        sizes.stats_cb_size = post_all_gather_stats_block_tiles * stats_single_tile_size;
         sizes.stats_reduced_cb_size = pre_all_gather_stats_block_tiles * single_tile_size;
     }
 
@@ -1069,8 +1080,8 @@ void add_cb_descriptors(
         stats_cb_desc.core_ranges = core_ranges.sender_cores;
         stats_cb_desc.format_descriptors.push_back(CBFormatDescriptor{
             .buffer_index = tt::CBIndex::c_7,
-            .data_format = cb_config.cb_data_format,
-            .page_size = cb_config.single_tile_size});
+            .data_format = cb_config.stats_cb_data_format,
+            .page_size = cb_config.stats_single_tile_size});
         stats_cb_desc.buffer = cb_config.stats_buffer;
         program_descriptor.cbs.push_back(std::move(stats_cb_desc));
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/sharded_layernorm_factory_helpers.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/sharded_layernorm_factory_helpers.cpp
@@ -47,12 +47,10 @@ void assert_subblock_compute_config_compatible(bool dst_full_sync_en, bool fp32_
     }
 }
 
-std::tuple<tt::DataFormat, tt::DataFormat, tt::DataFormat, tt::DataFormat, tt::DataFormat, tt::DataFormat>
-get_cb_data_formats(
+std::tuple<tt::DataFormat, tt::DataFormat, tt::DataFormat, tt::DataFormat, tt::DataFormat> get_cb_data_formats(
     const Tensor& output,
     const std::optional<const Tensor>& gamma,
     const std::optional<const Tensor>& beta,
-    const std::optional<const Tensor>& stats,
     bool fp32_dest_acc_en) {
     tt::DataFormat out_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
     tt::DataFormat cb_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
@@ -62,17 +60,8 @@ get_cb_data_formats(
     tt::DataFormat beta_cb_data_format = beta.has_value()
                                              ? tt::tt_metal::datatype_to_dataformat_converter(beta.value().dtype())
                                              : tt::DataFormat::Float16_b;
-    tt::DataFormat stats_cb_data_format = stats.has_value()
-                                              ? tt::tt_metal::datatype_to_dataformat_converter(stats.value().dtype())
-                                              : tt::DataFormat::Float16_b;
     tt::DataFormat reciprocal_cb_data_format = tt::DataFormat::Float32;
-    return {
-        out_data_format,
-        cb_data_format,
-        gamma_cb_data_format,
-        beta_cb_data_format,
-        stats_cb_data_format,
-        reciprocal_cb_data_format};
+    return {out_data_format, cb_data_format, gamma_cb_data_format, beta_cb_data_format, reciprocal_cb_data_format};
 }
 
 namespace {
@@ -560,7 +549,7 @@ CBSizeParams::Sizes CBSizeParams::compute() const {
     sizes.ex2pe_CB_size = num_rows_per_all_to_all_worker * single_tile_size;
 
     if (is_post_all_gather) {
-        sizes.stats_cb_size = post_all_gather_stats_block_tiles * stats_single_tile_size;
+        sizes.stats_cb_size = post_all_gather_stats_block_tiles * single_tile_size;
         sizes.stats_reduced_cb_size = pre_all_gather_stats_block_tiles * single_tile_size;
     }
 
@@ -1080,8 +1069,8 @@ void add_cb_descriptors(
         stats_cb_desc.core_ranges = core_ranges.sender_cores;
         stats_cb_desc.format_descriptors.push_back(CBFormatDescriptor{
             .buffer_index = tt::CBIndex::c_7,
-            .data_format = cb_config.stats_cb_data_format,
-            .page_size = cb_config.stats_single_tile_size});
+            .data_format = cb_config.cb_data_format,
+            .page_size = cb_config.single_tile_size});
         stats_cb_desc.buffer = cb_config.stats_buffer;
         program_descriptor.cbs.push_back(std::move(stats_cb_desc));
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/sharded_layernorm_factory_helpers.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/sharded_layernorm_factory_helpers.hpp
@@ -32,10 +32,12 @@ struct CoreRanges;
 
 void assert_subblock_compute_config_compatible(bool dst_full_sync_en, bool fp32_dest_acc_en, uint32_t subblock_wt);
 
-std::tuple<tt::DataFormat, tt::DataFormat, tt::DataFormat, tt::DataFormat, tt::DataFormat> get_cb_data_formats(
+std::tuple<tt::DataFormat, tt::DataFormat, tt::DataFormat, tt::DataFormat, tt::DataFormat, tt::DataFormat>
+get_cb_data_formats(
     const Tensor& output,
     const std::optional<const Tensor>& gamma,
     const std::optional<const Tensor>& beta,
+    const std::optional<const Tensor>& stats,
     bool fp32_dest_acc_en);
 
 //////////////////////////////////////////////////////////////////////////////
@@ -149,6 +151,7 @@ struct CBSizeParams {
     uint32_t out_single_tile_size = 0;
     uint32_t gamma_single_tile_size = 0;
     uint32_t beta_single_tile_size = 0;
+    uint32_t stats_single_tile_size = 0;
     uint32_t bfloat16_tile_size = 0;
     uint32_t reciprocal_CB_size_bytes = 0;
     uint32_t num_rows_per_all_to_all_worker = 0;
@@ -322,6 +325,7 @@ struct CBConfig {
     tt::DataFormat out_data_format = tt::DataFormat::Float16_b;
     tt::DataFormat gamma_cb_data_format = tt::DataFormat::Float16_b;
     tt::DataFormat beta_cb_data_format = tt::DataFormat::Float16_b;
+    tt::DataFormat stats_cb_data_format = tt::DataFormat::Float16_b;
     tt::DataFormat reciprocal_cb_data_format = tt::DataFormat::Float32;
 
     // Tile sizes
@@ -330,6 +334,7 @@ struct CBConfig {
     uint32_t out_single_tile_size = 0;
     uint32_t gamma_single_tile_size = 0;
     uint32_t beta_single_tile_size = 0;
+    uint32_t stats_single_tile_size = 0;
     uint32_t bfloat16_tile_size = 0;
 
     // Buffers

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/sharded_layernorm_factory_helpers.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/sharded_layernorm_factory_helpers.hpp
@@ -32,12 +32,10 @@ struct CoreRanges;
 
 void assert_subblock_compute_config_compatible(bool dst_full_sync_en, bool fp32_dest_acc_en, uint32_t subblock_wt);
 
-std::tuple<tt::DataFormat, tt::DataFormat, tt::DataFormat, tt::DataFormat, tt::DataFormat, tt::DataFormat>
-get_cb_data_formats(
+std::tuple<tt::DataFormat, tt::DataFormat, tt::DataFormat, tt::DataFormat, tt::DataFormat> get_cb_data_formats(
     const Tensor& output,
     const std::optional<const Tensor>& gamma,
     const std::optional<const Tensor>& beta,
-    const std::optional<const Tensor>& stats,
     bool fp32_dest_acc_en);
 
 //////////////////////////////////////////////////////////////////////////////
@@ -151,7 +149,6 @@ struct CBSizeParams {
     uint32_t out_single_tile_size = 0;
     uint32_t gamma_single_tile_size = 0;
     uint32_t beta_single_tile_size = 0;
-    uint32_t stats_single_tile_size = 0;
     uint32_t bfloat16_tile_size = 0;
     uint32_t reciprocal_CB_size_bytes = 0;
     uint32_t num_rows_per_all_to_all_worker = 0;
@@ -325,7 +322,6 @@ struct CBConfig {
     tt::DataFormat out_data_format = tt::DataFormat::Float16_b;
     tt::DataFormat gamma_cb_data_format = tt::DataFormat::Float16_b;
     tt::DataFormat beta_cb_data_format = tt::DataFormat::Float16_b;
-    tt::DataFormat stats_cb_data_format = tt::DataFormat::Float16_b;
     tt::DataFormat reciprocal_cb_data_format = tt::DataFormat::Float32;
 
     // Tile sizes
@@ -334,7 +330,6 @@ struct CBConfig {
     uint32_t out_single_tile_size = 0;
     uint32_t gamma_single_tile_size = 0;
     uint32_t beta_single_tile_size = 0;
-    uint32_t stats_single_tile_size = 0;
     uint32_t bfloat16_tile_size = 0;
 
     // Buffers

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/reader_unary_interleaved_ln_rm_gb_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/reader_unary_interleaved_ln_rm_gb_post_allgather.cpp
@@ -163,7 +163,7 @@ void kernel_main() {
 }
 template <uint32_t t>
 void async_read_row_to_tile(const uint64_t DRAM_src_addr, uint32_t L1_dst_addr) {
-    noc_async_read(DRAM_src_addr, L1_dst_addr, 32 * 2);  // reads 32 elements (64 bytes) 16 usefull, the next bad
+    noc_async_read(DRAM_src_addr, L1_dst_addr, 32 * 2);  // reads 32 elements (64 bytes) 16 useful, the next bad
     if constexpr (t == 0) {                              // TILE LAYOUT
         noc_async_read(DRAM_src_addr + 512, L1_dst_addr + 512, 64);  // Fills the second face with next 16 elements
     } else if constexpr (t == 1) {                                   // ROW MAJOR LAYOUT

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax.cpp
@@ -298,7 +298,7 @@ void kernel_main() {
         reconfig_data_format(cb_exps, cb_recipsumexps);
         pack_reconfig_data_format(cb_out0);
         // now cb_sumexps has exp tiles, need to multiply by our DST[2]
-        // by now we already did a umulative wait for Wt tiles in cb_exps
+        // by now we already did a cumulative wait for Wt tiles in cb_exps
         mul_bcast_cols_init_short(cb_exps, cb_recipsumexps);
         for (uint32_t wt = 0; wt < Wt; wt += ndst) {
             tile_regs_acquire();

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax_large_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax_large_tensor.cpp
@@ -39,7 +39,7 @@
 //      3: (func: exp_cb) calculate cb e^x
 //
 //      4: (func: reduce_cb) Sums across the width dimension to
-//      calcualte ∑e^x
+//      calculate ∑e^x
 // 2: Loop till we have parsed all of WT
 // 3: Calculate Final value
 //      1: (func: apply_fused_scale_mask) Apply optional fused scale mask followed by apply (func:
@@ -48,7 +48,7 @@
 //      2: (func: pad_input) Pad tile if step 1 is not done, otherwise -inf
 //      padding is done by apply attention mask
 //
-//      3: (func: exp_cb) calcualte cb e^x
+//      3: (func: exp_cb) calculate cb e^x
 //
 //      4: (func: apply_recip) Apply_recip
 //      e^x * 1/∑e^x
@@ -157,7 +157,7 @@ void apply_fused_attn_mask(
     }
 }
 
-// applys pad to the last pass cb if needed
+// applies pad to the last pass cb if needed
 void pad_input(uint32_t cb_in, uint32_t cb_out, uint32_t cb_length_t, uint32_t blk) {
     auto cb_mask_padded = tt::CBIndex::c_5;
     reconfig_data_format(cb_in, cb_mask_padded);
@@ -270,7 +270,7 @@ void reduce_cb(
         if (reduce_type == PoolType::MAX) {
             // path if we are doing a max redudce
             binary_max_tile_init();
-            // garbage data will be in data outside the first collumn, but since we broadcast this column it shouldnt
+            // garbage data will be in data outside the first column, but since we broadcast this column it shouldn't
             // matter
             binary_max_tile(0, 1, 0);
         } else {

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/dataflow/reader_unary_interleaved_sm_large_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/dataflow/reader_unary_interleaved_sm_large_tensor.cpp
@@ -70,7 +70,7 @@ void kernel_main() {
 #endif
 
     for (uint32_t ncht = 0; ncht < NCht; ncht++) {
-        // We need to pass once in order to calcualte the sum and then to calculate the final value.
+        // We need to pass once in order to calculate the sum and then to calculate the final value.
         for (uint32_t cur_pass = 0; cur_pass < total_passes; cur_pass++) {
             // We want to fill up the CB for input, and do so in chunks of blk
             uint32_t tile_index = tile_offset + (ncht * Wt);

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.cpp
@@ -353,6 +353,22 @@ SoftmaxDeviceOperation::tensor_return_value_t SoftmaxDeviceOperation::create_out
 
 tt::tt_metal::operation::Hash SoftmaxDeviceOperation::compute_program_hash(
     const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
+    // When a mask is present, its dtype and memory_config influence the compiled program:
+    //   - mask dtype        → mask_cb_data_format → CB c_in4/c_in5 data format (compile-time)
+    //   - mask memory_config → TensorAccessorArgs IsDram flag (compile-time arg)
+    //
+    // mask padded_shape is NOT included, even though num_tiles_causal_mask (compile-time arg,
+    // is_causal_mask=True only) is derived from it. It is provably redundant: scale_mask_softmax
+    // enforces mask.padded_shape()[-1] == input.padded_shape()[-1] and mask.padded_shape()[-2]
+    // is always the tile height at the device op level (either already equal to the tile height or
+    // padded to it by tilize_with_val_padding). Therefore, using tile_height and tile_width from
+    // input_tensor.tensor_spec().tile():
+    //   num_tiles_causal_mask = input.padded_shape()[-1] * tile_height / (tile_height * tile_width) = Wt_of_input
+    // which is fully determined by input.logical_shape()[-1] already present in the hash.
+    std::optional<MemoryConfig> default_memory_config =
+        !tensor_args.mask.has_value() ? std::make_optional<MemoryConfig>() : std::nullopt;
+    const auto& mask_memory_config =
+        tensor_args.mask.has_value() ? tensor_args.mask->memory_config() : *default_memory_config;
     return operation::hash_operation<SoftmaxDeviceOperation>(
         select_program_factory(attributes, tensor_args).index(),
         attributes.softmax_type,
@@ -368,7 +384,9 @@ tt::tt_metal::operation::Hash SoftmaxDeviceOperation::compute_program_hash(
         tensor_args.input_tensor.logical_shape(),
         tensor_args.input_tensor.dtype(),
         tensor_args.input_tensor.memory_config(),
-        tensor_args.input_tensor.layout());
+        tensor_args.input_tensor.layout(),
+        tensor_args.mask.has_value() ? tensor_args.mask->dtype() : DataType::INVALID,
+        mask_memory_config);
 }
 
 tt::tt_metal::operation::OpPerformanceModelGeneral<SoftmaxDeviceOperation::tensor_return_value_t>

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.cpp
@@ -353,22 +353,6 @@ SoftmaxDeviceOperation::tensor_return_value_t SoftmaxDeviceOperation::create_out
 
 tt::tt_metal::operation::Hash SoftmaxDeviceOperation::compute_program_hash(
     const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
-    // When a mask is present, its dtype and memory_config influence the compiled program:
-    //   - mask dtype        → mask_cb_data_format → CB c_in4/c_in5 data format (compile-time)
-    //   - mask memory_config → TensorAccessorArgs IsDram flag (compile-time arg)
-    //
-    // mask padded_shape is NOT included, even though num_tiles_causal_mask (compile-time arg,
-    // is_causal_mask=True only) is derived from it. It is provably redundant: scale_mask_softmax
-    // enforces mask.padded_shape()[-1] == input.padded_shape()[-1] and mask.padded_shape()[-2]
-    // is always the tile height at the device op level (either already equal to the tile height or
-    // padded to it by tilize_with_val_padding). Therefore, using tile_height and tile_width from
-    // input_tensor.tensor_spec().tile():
-    //   num_tiles_causal_mask = input.padded_shape()[-1] * tile_height / (tile_height * tile_width) = Wt_of_input
-    // which is fully determined by input.logical_shape()[-1] already present in the hash.
-    std::optional<MemoryConfig> default_memory_config =
-        !tensor_args.mask.has_value() ? std::make_optional<MemoryConfig>() : std::nullopt;
-    const auto& mask_memory_config =
-        tensor_args.mask.has_value() ? tensor_args.mask->memory_config() : *default_memory_config;
     return operation::hash_operation<SoftmaxDeviceOperation>(
         select_program_factory(attributes, tensor_args).index(),
         attributes.softmax_type,
@@ -384,9 +368,7 @@ tt::tt_metal::operation::Hash SoftmaxDeviceOperation::compute_program_hash(
         tensor_args.input_tensor.logical_shape(),
         tensor_args.input_tensor.dtype(),
         tensor_args.input_tensor.memory_config(),
-        tensor_args.input_tensor.layout(),
-        tensor_args.mask.has_value() ? tensor_args.mask->dtype() : DataType::INVALID,
-        mask_memory_config);
+        tensor_args.input_tensor.layout());
 }
 
 tt::tt_metal::operation::OpPerformanceModelGeneral<SoftmaxDeviceOperation::tensor_return_value_t>

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_attention_optimized.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_attention_optimized.cpp
@@ -110,12 +110,11 @@ SoftmaxProgramFactoryAttentionOptimized::cached_program_t SoftmaxProgramFactoryA
     // Program specific checks
     if ((tensor_args.input_tensor.device()->l1_size_per_core() * 0.9) < cb_size_sum_bytes) {
         use_large_kernel = true;
-        uint32_t large_kernel_cb_size = (80 / block_size) * block_size;
-        cb_length = large_kernel_cb_size;
-        in0_t = large_kernel_cb_size;
-        im4_t = large_kernel_cb_size;
-        im0_t = large_kernel_cb_size;
-        im3_t = large_kernel_cb_size;
+        cb_length = 80;
+        in0_t = 80;
+        im4_t = 80;
+        im0_t = 80;
+        im3_t = 80;
         TT_FATAL(!attributes.inplace, "Tensor is too large to run softmax inplace, please use standard softmax");
     }
     if (!use_large_kernel) {
@@ -419,12 +418,11 @@ void SoftmaxProgramFactoryAttentionOptimized::override_runtime_arguments(
 
     if (use_large_kernel) {
         // Use fixed sizes matching create() for large kernel
-        uint32_t large_kernel_cb_size = (80 / block_size) * block_size;
-        in0_t = large_kernel_cb_size;
+        in0_t = 80;
         out0_t = block_size * 2;
-        im0_t = large_kernel_cb_size;
-        im3_t = large_kernel_cb_size;
-        im4_t = large_kernel_cb_size;
+        im0_t = 80;
+        im3_t = 80;
+        im4_t = 80;
     } else {
         // Standard calculation for regular kernel
         in0_t = attributes.numeric_stable ? tt::div_up(Wt, block_size) * block_size : block_size * 2;

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_attention_optimized.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_attention_optimized.cpp
@@ -110,11 +110,12 @@ SoftmaxProgramFactoryAttentionOptimized::cached_program_t SoftmaxProgramFactoryA
     // Program specific checks
     if ((tensor_args.input_tensor.device()->l1_size_per_core() * 0.9) < cb_size_sum_bytes) {
         use_large_kernel = true;
-        cb_length = 80;
-        in0_t = 80;
-        im4_t = 80;
-        im0_t = 80;
-        im3_t = 80;
+        uint32_t large_kernel_cb_size = (80 / block_size) * block_size;
+        cb_length = large_kernel_cb_size;
+        in0_t = large_kernel_cb_size;
+        im4_t = large_kernel_cb_size;
+        im0_t = large_kernel_cb_size;
+        im3_t = large_kernel_cb_size;
         TT_FATAL(!attributes.inplace, "Tensor is too large to run softmax inplace, please use standard softmax");
     }
     if (!use_large_kernel) {
@@ -418,11 +419,12 @@ void SoftmaxProgramFactoryAttentionOptimized::override_runtime_arguments(
 
     if (use_large_kernel) {
         // Use fixed sizes matching create() for large kernel
-        in0_t = 80;
+        uint32_t large_kernel_cb_size = (80 / block_size) * block_size;
+        in0_t = large_kernel_cb_size;
         out0_t = block_size * 2;
-        im0_t = 80;
-        im3_t = 80;
-        im4_t = 80;
+        im0_t = large_kernel_cb_size;
+        im3_t = large_kernel_cb_size;
+        im4_t = large_kernel_cb_size;
     } else {
         // Standard calculation for regular kernel
         in0_t = attributes.numeric_stable ? tt::div_up(Wt, block_size) * block_size : block_size * 2;

--- a/ttnn/cpp/ttnn/operations/point_to_point/device/host/send_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/point_to_point/device/host/send_program_factory.cpp
@@ -52,7 +52,7 @@ ttnn::device_operation::CachedProgram<PointToPointOp::SendReceive::shared_variab
             .set_page_size(sender_cb_id, aligned_input_page_size_bytes);
     CreateCircularBuffer(program, all_cores, cb_sender_config);
 
-    // allocate space for packet headers for payload sempahore
+    // allocate space for packet headers for payload semaphore
     constexpr auto packet_header_cb_id = tt::CBIndex::c_1;
     constexpr auto buffering_factor = 2;  // this is in other fabric kernels
     constexpr auto num_packet_headers_storable = 2;

--- a/ttnn/cpp/ttnn/operations/point_to_point/device/kernels/dataflow/writer_send.cpp
+++ b/ttnn/cpp/ttnn/operations/point_to_point/device/kernels/dataflow/writer_send.cpp
@@ -61,7 +61,7 @@ void kernel_main() {
     // wait for receiver to signal it is ready
     auto local_semaphore_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(receive_semaphore_addr);
     noc_semaphore_wait(local_semaphore_ptr, 1);
-    // clean up semaphore – needs to be done before the sender side semaphore increment if we're re-using the semaphore
+    // clean up semaphore – needs to be done before the sender side semaphore increment if we're reusing the semaphore
     // in subsequent program cache hits
     noc_semaphore_set(local_semaphore_ptr, 0);
 

--- a/ttnn/cpp/ttnn/operations/point_to_point/point_to_point_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/point_to_point/point_to_point_nanobind.cpp
@@ -34,7 +34,7 @@ void bind_point_to_point(nb::module_& mod) {
             Example:
 
                 >>> input_tensor_torch = torch.zeros((2,1,1,16), dtype=dtype)
-                >>> input_tensor_torch[0, :, :, :] = data # arbitary data in one shard
+                >>> input_tensor_torch[0, :, :, :] = data # arbitrary data in one shard
 
                 >>> input_tensor = ttnn.from_torch(
                 >>>     input_tensor_torch, device=mesh_device, mesh_mapper=ttnn.ShardTensorToMesh(mesh_device, dim=0)

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_mpwi.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_mpwi.cpp
@@ -139,7 +139,7 @@ ALWI void initialize_return_indices_data() {
     cb_push_back(in_idx_cb_id, 1);
 
     // initialize the increment CBs
-    // TODO we used to fill the 16 bit values two at a time, but this techincally resulted in overflow with odd
+    // TODO we used to fill the 16 bit values two at a time, but this technically resulted in overflow with odd
     // c dimensions so for now we do it one at a time for both 16 and 32 bit indexes
     if constexpr (indexes_32_bit) {
         auto fill_inc_32 = [&](uint32_t cb_id, uint32_t inc) __attribute__((always_inline)) {

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d.cpp
@@ -105,7 +105,7 @@ ALWI void read_kernel_with_top_left_index(uint32_t ind, uint32_t in_l1_read_base
             // Case where in_nbytes_leftover and in_nbytes_c is different is when we are dealing with
             // tesnors that have last tile as partial. Cb page size is multiple of tile but when the last
             // tile is partial we have to read the smaller stick width. Therefore we need to write out the next
-            // stick right bellow the previous one and this is when increment of the write pointer and the read
+            // stick right below the previous one and this is when increment of the write pointer and the read
             // stick size is not compliant.
             bool use_contiguous_read = !wide_reduction && in_nbytes_leftover == in_nbytes_c &&
                                        dilation_w == 1;  // read entire row as one chunk (only if no width dilation)

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
@@ -45,7 +45,7 @@ struct ScalarInfo {
 // scalar per core is not sufficient to create correct result. Those scenarios are ceil_mode == true and (ceil_pad_h > 0
 // || ceil_pad_w > 0) or count_include_pad == false || (pad_h > 0 || pad_w > 0). Both of these scenarios can be
 // irrelevant if the divisor_override is set, in which case we don't calculate the divisor since it is already passed as
-// an argument. It only adds scalars that are different than the scalar preeceding it not to have duplicates of data,
+// an argument. It only adds scalars that are different than the scalar preceding it not to have duplicates of data,
 // this is why we use start and end indices to know how many sequential output elements should be multiplied by the same
 // scalar value.
 std::vector<ScalarInfo> get_bf16_avg_pool_config_scalars(
@@ -60,7 +60,7 @@ std::vector<ScalarInfo> get_bf16_avg_pool_config_scalars(
             config.pad_t + config.pad_b,
             config.pad_l + config.pad_r,
             config.divisor_override),
-        "Avg pool scalars config should be calulated only for ceil_mode == true and "
+        "Avg pool scalars config should be calculated only for ceil_mode == true and "
         "(ceil_pad_h > 0 || ceil_pad_w > 0) or count_include_pad == false and (pad_h > 0 || pad_w > 0)");
 
     std::vector<ScalarInfo> scalars;
@@ -202,7 +202,7 @@ static Tensor create_scalar_config_tensor(
             break;
         }
         case TensorMemoryLayout::WIDTH_SHARDED: {
-            // With width sharded layout scalars should be calulated only once, so we push them back num_shards_c times
+            // With width sharded layout scalars should be calculated only once, so we push them back num_shards_c times
             // but have only one array of scalars
             uint32_t repeats = config_tensor_in_dram ? 1 : num_shards_c;
             push_back_scalar_info_or_zero(config_vector, scalars_per_core[0], max_scalars_cnt, repeats);

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
@@ -23,7 +23,7 @@
 
 namespace ttnn::operations::pool {
 
-// Generic invoke function for both max and avg pool operations. Most of the arguments are shared excpet for the
+// Generic invoke function for both max and avg pool operations. Most of the arguments are shared except for the
 // dilation which is set to (1,1) for avg pool and count_include_pad and divisor_override which have no effect on
 // maxpool.
 

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_utils.cpp
@@ -43,7 +43,7 @@ bool should_use_split_reader(
     }
 
     // On blackhole, for a lower number of channels, the bottleneck is the reading of the input image, so split reader
-    // is benefitial On higher number of channels, the bottleneck is on the unpacker side, where using split reader also
+    // is beneficial On higher number of channels, the bottleneck is on the unpacker side, where using split reader also
     // adds additional overhead, so it slows down the program
     if (arch == tt::ARCH::BLACKHOLE) {
         const uint32_t input_channels = input_tensor.padded_shape()[-1];

--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/kernels/reader_dram.cpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/kernels/reader_dram.cpp
@@ -100,7 +100,7 @@ void kernel_main() {
                     cb_reserve_back(
                         cb_id,
                         max_block_num_tiles *
-                            2);  // Reserve two blocks of spcae to issue multiple block reads in parallel
+                            2);  // Reserve two blocks of space to issue multiple block reads in parallel
                 }
             }
 

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/argmax_tile_layout.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/argmax_tile_layout.hpp
@@ -278,7 +278,7 @@ void write_to_output(AccessorType& output_accessor, OutputContext& output_ctx) {
     uint32_t sent_count = 0;
     while (collected_count > 0) {
         // When keepdim is true, argmax values are accumulated in an on-stack buffer.
-        // Otherwise, argmax values are accumulated directly in the outut CB.
+        // Otherwise, argmax values are accumulated directly in the output CB.
         if constexpr (keepdim) {
             auto* stack_ptr = output_ctx.stack_ptr;
             auto* dst_cb_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(dst_cb_addr);

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
@@ -20,7 +20,7 @@ namespace reduce_op_utils {
 std::map<std::string, std::string> get_defines(
     tt::tt_metal::ReduceOpMath reduce_op, tt::tt_metal::ReduceOpDim reduce_dim) {
     std::map<std::string, std::string> defines;
-    // TOOD(AP): need a sync with Reduce::Max from HLK headers
+    // TODO(AP): need a sync with Reduce::Max from HLK headers
     bool do_max = reduce_op == tt::tt_metal::ReduceOpMath::MAX;
     std::string reduce_dim_str;
     switch (reduce_dim) {
@@ -95,7 +95,7 @@ Tensor reduce(
         /*default_approx_mode=*/false,
         /*default_fp32_acc=*/true));
 
-    // Reduce only works with tile layout, so we need to tilize the input tensor if neccessary
+    // Reduce only works with tile layout, so we need to tilize the input tensor if necessary
     auto padded_shape = ttnn::operations::data_movement::pad_to_tile_shape(input_tensor.padded_shape());
     auto tilized_input =
         ttnn::tilize_with_val_padding(input_tensor, padded_shape, pad_value, input_tensor.memory_config());

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/dataflow/writer_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/dataflow/writer_interleaved.cpp
@@ -11,7 +11,7 @@
 /* This kernel does:
 Top-p Cumulative Probability Filtering:
 Iteratively accumulates probabilities, comparing them against the nucleus threshold p to determine the smallest set of
-tokens satisfying cumulative probabilty > p condition.
+tokens satisfying cumulative probability > p condition.
 
 Top-k Sampling:
 Samples from the top-k subset by comparing cumulative sums of probabilities with a random threshold to select the

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_local.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_local.cpp
@@ -90,7 +90,7 @@
  */
 
 void kernel_main() {
-    // Compiletime args
+    // Compile time args
     constexpr uint32_t input_cb_index = get_compile_time_arg_val(0);
     constexpr uint32_t index_cb_index = get_compile_time_arg_val(1);
     constexpr uint32_t input_transposed_cb_index = get_compile_time_arg_val(2);

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_create_index_local_topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_create_index_local_topk.cpp
@@ -15,7 +15,7 @@ void kernel_main() {
     const uint32_t start_wt = get_arg_val<uint32_t>(2);        // Starting width tile index for this core
     const bool is32_bit_data = get_arg_val<uint32_t>(3) == 1;  // Flag indicating if indices data is 32-bit
 
-    // Compiletime args
+    // Compile time args
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);  // Input values circular buffer
     constexpr uint32_t cb_id_in1 = get_compile_time_arg_val(1);  // Generated indices circular buffer
     constexpr uint32_t Ht = get_compile_time_arg_val(2);         // Total height tiles in tensor

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_final_topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_final_topk.cpp
@@ -6,7 +6,7 @@
 #include "api/dataflow/dataflow_api.h"
 
 void kernel_main() {
-    // Compiletime args
+    // Compile time args
     const uint32_t receiver_semaphore = get_semaphore(get_compile_time_arg_val(0));  // Ready-to-receive signal
     const uint32_t sender_semaphore = get_semaphore(get_compile_time_arg_val(1));    // Data-sent confirmation
     constexpr uint32_t noc_start_x = get_compile_time_arg_val(2);              // Starting X coordinate of core range

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_final_topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_final_topk.cpp
@@ -9,7 +9,7 @@ void kernel_main() {
     const uint32_t dst_addr0 = get_arg_val<uint32_t>(0);  // DRAM address for TopK values output tensor
     const uint32_t dst_addr1 = get_arg_val<uint32_t>(1);  // DRAM address for TopK indices output tensor
 
-    // Compiletime args
+    // Compile time args
     constexpr uint32_t values_cb_index = get_compile_time_arg_val(0);      // Final values circular buffer
     constexpr uint32_t output_ind_cb_index = get_compile_time_arg_val(1);  // Final indices circular buffer
     constexpr uint32_t Ht = get_compile_time_arg_val(2);

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_local_topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_local_topk.cpp
@@ -8,7 +8,7 @@ void kernel_main() {
     // Runtime args
     const uint32_t start_wt = get_arg_val<uint32_t>(0);
 
-    // Compiletime args
+    // Compile time args
     const uint32_t receiver_semaphore = get_semaphore(get_compile_time_arg_val(0));  // Final core readiness signal
     const uint32_t sender_semaphore = get_semaphore(get_compile_time_arg_val(1));    // Local core completion signal
     constexpr uint32_t noc_final_x = get_compile_time_arg_val(2);                    // Final core X coordinate

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_utils.cpp
@@ -64,6 +64,7 @@ std::optional<TopKCoreConfig> find_topk_core_config(
     // Calculate the maximum number of cores available in the core grid
     const auto max_cores =
         (core_range.end_coord.y - core_range.start_coord.y - 1) * (core_range.end_coord.x - core_range.start_coord.x);
+    TT_FATAL(max_cores > 0, "Core grid must contain at least one core. Got core range: {}", core_range.str());
 
     // Calculate conservative starting split size:
     // 1. Divide width by tile width to get number of tiles

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_utils.cpp
@@ -64,7 +64,6 @@ std::optional<TopKCoreConfig> find_topk_core_config(
     // Calculate the maximum number of cores available in the core grid
     const auto max_cores =
         (core_range.end_coord.y - core_range.start_coord.y - 1) * (core_range.end_coord.x - core_range.start_coord.x);
-    TT_FATAL(max_cores > 0, "Core grid must contain at least one core. Got core range: {}", core_range.str());
 
     // Calculate conservative starting split size:
     // 1. Divide width by tile width to get number of tiles

--- a/ttnn/cpp/ttnn/operations/sliding_window/op_slicing/op_slicing.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/op_slicing/op_slicing.cpp
@@ -66,7 +66,7 @@ static uint32_t compute_L1_usage_for_slice_config(
         const uint32_t this_output_slice_dim = output_slice_dim_end - output_slice_dim_start;
 
         if (this_output_slice_dim == 0) {
-            // No work to be done in this interation, so skip it.
+            // No work to be done in this iteration, so skip it.
             slice_index++;
             continue;
         }
@@ -90,7 +90,7 @@ static uint32_t compute_L1_usage_for_slice_config(
             input_slice_height_start = std::max<int>(0, input_slice_height_start);
             input_slice_height_end = std::min<int>(input_height, input_slice_height_end);
             if (input_slice_height_start >= input_slice_height_end) {
-                // No work to be done in this interation, so skip it.
+                // No work to be done in this iteration, so skip it.
                 slice_index++;
                 continue;
             }
@@ -110,7 +110,7 @@ static uint32_t compute_L1_usage_for_slice_config(
             input_slice_width_end = std::min<int>(input_width, input_slice_width_end);
 
             if (input_slice_width_start >= input_slice_width_end) {
-                // No work to be done in this interation, so skip it.
+                // No work to be done in this iteration, so skip it.
                 slice_index++;
                 continue;
             }
@@ -391,7 +391,7 @@ void run_sliced_op(
         const uint32_t this_output_slice_dim = output_slice_dim_end - output_slice_dim_start;
 
         if (this_output_slice_dim == 0) {
-            // No work to be done in this interation, so skip it.
+            // No work to be done in this iteration, so skip it.
             slice_index++;
             continue;
         }
@@ -415,7 +415,7 @@ void run_sliced_op(
             input_slice_height_start = std::max<int>(0, input_slice_height_start);
             input_slice_height_end = std::min<int>(input_height, input_slice_height_end);
             if (input_slice_height_start >= input_slice_height_end) {
-                // No work to be done in this interation, so skip it.
+                // No work to be done in this iteration, so skip it.
                 slice_index++;
                 continue;
             }
@@ -437,7 +437,7 @@ void run_sliced_op(
             input_slice_width_end = std::min<int>(input_width, input_slice_width_end);
 
             if (input_slice_width_start >= input_slice_width_end) {
-                // No work to be done in this interation, so skip it.
+                // No work to be done in this iteration, so skip it.
                 slice_index++;
                 continue;
             }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -1261,7 +1261,7 @@ ALWI void matmul_blocks(
 template <uint32_t M>
 void matmul_reduce(uint32_t in1_cb, const uint32_t& out_cb) {
     // precondition: in0_cb has M*K produced
-    // preconditino: in1_cb has K*N produced
+    // precondition: in1_cb has K*N produced
     // postcondition: in0_cb is full, in1_cb is empty
     // postcondition: out_cb has M*N produced
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/fused_op_receiver.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/fused_op_receiver.hpp
@@ -81,7 +81,7 @@ struct RingSDPAOpReceiver {
             }
         }
 
-        // Wait for a sempaphore signal to start processing the tensor slice
+        // Wait for a semaphore signal to start processing the tensor slice
 
         if (this->wait_for_op_signal) {
             noc_semaphore_wait_min(this->signal_op_semaphore_addr_ptrs[this->curr_dir], sem_wait_val);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -102,7 +102,7 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
     // q - [B, NHQ, Sq, DH_qk]
     // k - [B, 1, Sk, DH_qk]
     // v - [B, NVH, Sk, DH_v]
-    // k head is in latent space, and is reused accross all q heads
+    // k head is in latent space, and is reused across all q heads
 
     // Paged cache parameters when in chunked mode
     const bool flexible_chunked = operation_attributes.chunk_start_idx_tensor.has_value();

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
@@ -24,7 +24,7 @@ namespace ttnn::operations::transformer {
 void bind_sdpa(nb::module_& mod) {
     const auto* doc =
         R"doc(
-        Causal scaled dot product attention. This API mimicks the PyTorch API of the same name.
+        Causal scaled dot product attention. This API mimics the PyTorch API of the same name.
         The implementation is FlashAttention-2."
 
         Accepts a `SDPAProgramConfig` which specifies the grid size and chunk tiles in the Q and K sequence lengths. The op parallelizes over `b`, `nqh`, and Q's `s` dimension.

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
@@ -683,7 +683,7 @@ void read_kv_mask_chunks(
                 PSt, Sk_chunk_t, mask_chunk_tiles, mask_start_tile_id, mask_reader);
         }
 
-        // Read V chunk (tranpose of K), from K's L1 buffer
+        // Read V chunk (transpose of K), from K's L1 buffer
         if constexpr (reuse_k) {
             cb_reserve_back(cb_v_in, v_chunk_tiles);
             uint32_t v_write_ptr = get_write_ptr(cb_v_in);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/reader_decode_all.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/reader_decode_all.cpp
@@ -263,7 +263,7 @@ void kernel_main() {
                 page_table_addr,
                 page_table_page_size);
             page_table_ptr_u32 = page_table_ptr;
-        } else {  // Read page table from dyanmically allocated L1 buffer
+        } else {  // Read page table from dynamically allocated L1 buffer
             page_table_cb_wr_ptr =
                 get_write_ptr(cb_id_page_table) + (cur_batch / q_heads_parallel_factor) * page_table_page_size;
             page_table_ptr_u16 = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(page_table_cb_wr_ptr);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
@@ -78,7 +78,7 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
     // Use k_shape for S and DH since Q might be different for decode
     uint32_t B = q_shape[1], PNH = q_shape[2], S = k_shape[2], DH = k_shape[3];
 
-    // If MLA is enabled, vDH is overridded by head_dim_v. Otherwise, vDH is same as DH.
+    // If MLA is enabled, vDH is overridden by head_dim_v. Otherwise, vDH is same as DH.
     uint32_t vDH = use_mla ? head_dim_v : v_shape[3];
 
     uint32_t num_kv_heads = k_shape[1];
@@ -308,7 +308,7 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
 
     // These tile capacity counts for CBs need to match the number of tiles expected by the kernel (softmax.cpp)
 
-    // If using dyanmic chunk size, set it to some max number of tiles (less than DST for now)
+    // If using dynamic chunk size, set it to some max number of tiles (less than DST for now)
     const uint32_t dst_size = fp32_dest_acc_en ? 4 : 8;
     const uint32_t max_dynamic_chunk_size = dst_size;
     const uint32_t Sk_chunk_t_cb_size = Sk_chunk_t == 0 ? max_dynamic_chunk_size : Sk_chunk_t;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_windowed/device/kernels/dataflow/reader_windowed.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_windowed/device/kernels/dataflow/reader_windowed.cpp
@@ -394,7 +394,7 @@ void kernel_main() {
                                 continue;
                             }
 
-                            // cases: the tile covers at least a window (potentailly multiple windows)
+                            // cases: the tile covers at least a window (potentially multiple windows)
                             uint32_t covered_window_q_start_idx, covered_window_k_start_idx, covered_window_q_end_idx,
                                 covered_window_k_end_idx;
                             do {


### PR DESCRIPTION
This PR fixes spelling and typo errors in ttnn operations code.

This is part of relanding spelling fixes from commit 98ad3bab62ac1f66560c88c30b3f12d846dd4b54 in smaller, targeted PRs.

Files changed:
- ttnn/cpp/ttnn/operations/ directory (including all subdirectories)