### PR TITLE
Fix spelling/typos in tt-train and tools code

### DIFF
--- a/tools/scaleout/cabling_generator/cabling_generator.cpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.cpp
@@ -1722,7 +1722,7 @@ void CablingGenerator::emit_cabling_guide_csv(const std::string& output_path, bo
         {tt::ARCH::BLACKHOLE, "400G"},
         {tt::ARCH::Invalid, "UNKNOWN"}};
 
-    // Unknown for lengths unable to be calculated (longer than avaiable cables, cross-aisle/hall, etc.)
+    // Unknown for lengths unable to be calculated (longer than available cables, cross-aisle/hall, etc.)
 
     // Vector of (Host,Tray,Port) Connection Pairs
     std::vector<std::pair<std::tuple<HostId, TrayId, PortId>, std::tuple<HostId, TrayId, PortId>>> conn_list;

--- a/tools/triage/run_checks.py
+++ b/tools/triage/run_checks.py
@@ -93,7 +93,7 @@ CoreType: TypeAlias = Literal[CORE_TYPES]
 class CheckResult:
     result: object = recurse_field()
 
-    # Hack to make result the last filed to perserve header order
+    # Hack to make result the last field to preserve header order
     def __post_init__(cls):
         cls.__dataclass_fields__["result"] = cls.__dataclass_fields__.pop("result")
 

--- a/tt-train/README.md
+++ b/tt-train/README.md
@@ -83,8 +83,8 @@ More information on available configuration options can be found in the [configs
 
 ### Nightly only tests
 If CI fails, but local tests pass as expected, please consider changing the
-is_nigthly_tt_train_tests_enabled in the nano_gpt_test.cpp
-TT-Train nightly tests are all tests with "NIGTHLY_" in the name.
+is_nightly_tt_train_tests_enabled in the nano_gpt_test.cpp
+TT-Train nightly tests are all tests with "NIGHTLY_" in the name.
 To run it in github please search for `Nightly tt-metal L2 tests`.
 
 ### wandb support

--- a/tt-train/docs/MEMORY_TRACKING.md
+++ b/tt-train/docs/MEMORY_TRACKING.md
@@ -198,7 +198,7 @@ python scripts/analyze_memory.py --logs <logfile> [options]
 ```
 
 **Required:**
-- `--logs`: A single log file containing memory usage summaries created by training script ([cpp](/tt-train/sources/examples/nano_gpt/main.cpp) or [python](/tt-train/sources/examples/nano_gpt/train_nanogpt.py)). Note: you can concatenate multiple trainig logs in one file, it would analyze them separately, and add all of them on the histogram
+- `--logs`: A single log file containing memory usage summaries created by training script ([cpp](/tt-train/sources/examples/nano_gpt/main.cpp) or [python](/tt-train/sources/examples/nano_gpt/train_nanogpt.py)). Note: you can concatenate multiple training logs in one file, it would analyze them separately, and add all of them on the histogram
 
 **Optional:**
 - `--device_memory`: Device memory in bytes (default: 12GB)

--- a/tt-train/sources/ttml/metal/ops/cross_entropy_bw/device/cross_entropy_bw_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_bw/device/cross_entropy_bw_program_factory.cpp
@@ -241,7 +241,7 @@ CrossEntropyBackwardProgramFactory::cached_program_t CrossEntropyBackwardProgram
         float32_single_tile_size_bytes,
         kNumExpSumBeforeReductionTiles);
 
-    [[maybe_unused]] auto cb_exp_sum_after_refuction = create_circular_buffer(
+    [[maybe_unused]] auto cb_exp_sum_after_reduction = create_circular_buffer(
         program,
         all_cores,
         KExpSumAfterReductionCbIndex,

--- a/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/cross_entropy_fw_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/cross_entropy_fw_program_factory.cpp
@@ -253,7 +253,7 @@ CrossEntropyForwardProgramFactory::cached_program_t CrossEntropyForwardProgramFa
         bfloat16_single_tile_size_bytes,
         kNumExpSumBeforeReductionTiles);
 
-    [[maybe_unused]] auto cb_exp_sum_after_refuction = create_circular_buffer(
+    [[maybe_unused]] auto cb_exp_sum_after_reduction = create_circular_buffer(
         program,
         all_cores,
         KExpSumAfterReductionCbIndex,

--- a/tt-train/sources/ttml/metal/ops/softmax/device/softmax_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/softmax/device/softmax_program_factory.cpp
@@ -225,7 +225,7 @@ SoftmaxProgramFactory::cached_program_t SoftmaxProgramFactory::create(
         float32_single_tile_size_bytes,
         kNumExpSumBeforeReductionTiles);
 
-    [[maybe_unused]] auto cb_exp_sum_after_refuction = create_circular_buffer(
+    [[maybe_unused]] auto cb_exp_sum_after_reduction = create_circular_buffer(
         program,
         all_cores,
         KExpSumAfterReductionCbIndex,

--- a/tt-train/tests/model/nano_gpt_test.cpp
+++ b/tt-train/tests/model/nano_gpt_test.cpp
@@ -22,9 +22,9 @@
 namespace {
 /*
 Nightly tests could be enabled by setting the environment variable ENABLE_NIGHTLY_TT_TRAIN_TESTS=1
-or setting 'is_nigthly_tt_train_tests_enabled' variable to true.
+or setting 'is_nightly_tt_train_tests_enabled' variable to true.
 */
-constexpr bool is_nigthly_tt_train_tests_enabled = false;
+constexpr bool is_nightly_tt_train_tests_enabled = false;
 
 [[nodiscard]] bool is_wormhole_b0() {
     static bool arch_is_wormhole_b0 = []() {
@@ -39,7 +39,7 @@ constexpr bool is_nigthly_tt_train_tests_enabled = false;
 [[nodiscard]] bool should_run_nightly_tests() {
     const char *env_var = std::getenv("ENABLE_NIGHTLY_TT_TRAIN_TESTS");
     bool is_whb0 = is_wormhole_b0();
-    bool is_ci = env_var && is_nigthly_tt_train_tests_enabled;
+    bool is_ci = env_var && is_nightly_tt_train_tests_enabled;
     return is_whb0 && is_ci;
 }
 

--- a/tt-train/tests/python/test_autograd.py
+++ b/tt-train/tests/python/test_autograd.py
@@ -48,18 +48,14 @@ def do_test_numpy_autograd_conversion(
     if autograd_type:
         if layout:
             try:
-                autograd_tensor = ttml.autograd.Tensor.from_numpy(
-                    numpy_tensor, layout=layout, new_type=autograd_type
-                )
+                autograd_tensor = ttml.autograd.Tensor.from_numpy(numpy_tensor, layout=layout, new_type=autograd_type)
             except TypeError as e:
                 type_error = handle_error(e, expect_type_exception, type_error)
             except RuntimeError as e:
                 runtime_error = handle_error(e, expect_runtime_exception, runtime_error)
         else:
             try:
-                autograd_tensor = ttml.autograd.Tensor.from_numpy(
-                    numpy_tensor, new_type=autograd_type
-                )
+                autograd_tensor = ttml.autograd.Tensor.from_numpy(numpy_tensor, new_type=autograd_type)
             except TypeError as e:
                 type_error = handle_error(e, expect_type_exception, type_error)
             except RuntimeError as e:
@@ -67,9 +63,7 @@ def do_test_numpy_autograd_conversion(
     else:
         if layout:
             try:
-                autograd_tensor = ttml.autograd.Tensor.from_numpy(
-                    numpy_tensor, layout=layout
-                )
+                autograd_tensor = ttml.autograd.Tensor.from_numpy(numpy_tensor, layout=layout)
             except TypeError as e:
                 type_error = handle_error(e, expect_type_exception, type_error)
             except RuntimeError as e:
@@ -87,14 +81,12 @@ def do_test_numpy_autograd_conversion(
         assert (autograd_tensor.to_numpy(new_type=autograd_type) == numpy_tensor).all()
         for new_type in supported_autograd_types_except(autograd_type):
             try:
-                assert (
-                    autograd_tensor.to_numpy(new_type=new_type) == numpy_tensor
-                ).all()
+                assert (autograd_tensor.to_numpy(new_type=new_type) == numpy_tensor).all()
             except TypeError as e:
                 type_error = handle_error(e, expect_type_exception, type_error)
             except RuntimeError as e:
                 runtime_error = handle_error(e, expect_runtime_exception, runtime_error)
-    # sanity check: the occurence of an exception implies we were expecting it
+    # sanity check: the occurrence of an exception implies we were expecting it
     assert (not type_error) or (type_error and expect_type_exception)
     assert (not runtime_error) or (runtime_error and expect_runtime_exception)
 
@@ -462,9 +454,7 @@ def test_numpy_autograd_conversion(tensor_data, numpy_type, autograd_type, layou
     "tensor_data, numpy_type, autograd_type, layout",
     unsupported_format_cases,
 )
-def test_numpy_autograd_conversion_expecting_type_error(
-    tensor_data, numpy_type, autograd_type, layout
-):
+def test_numpy_autograd_conversion_expecting_type_error(tensor_data, numpy_type, autograd_type, layout):
     return do_test_numpy_autograd_conversion(
         tensor_data=tensor_data,
         numpy_type=numpy_type,
@@ -479,9 +469,7 @@ def test_numpy_autograd_conversion_expecting_type_error(
     "tensor_data, numpy_type, autograd_type, layout",
     typecast_issue_cases,
 )
-def test_numpy_autograd_conversion_expecting_runtime_error(
-    tensor_data, numpy_type, autograd_type, layout
-):
+def test_numpy_autograd_conversion_expecting_runtime_error(tensor_data, numpy_type, autograd_type, layout):
     return do_test_numpy_autograd_conversion(
         tensor_data=tensor_data,
         numpy_type=numpy_type,
@@ -497,18 +485,12 @@ def make_tensors(tensor_data, numpy_type, autograd_type, layout):
 
     if autograd_type:
         if layout:
-            autograd_tensor = ttml.autograd.Tensor.from_numpy(
-                numpy_tensor, layout=layout, new_type=autograd_type
-            )
+            autograd_tensor = ttml.autograd.Tensor.from_numpy(numpy_tensor, layout=layout, new_type=autograd_type)
         else:
-            autograd_tensor = ttml.autograd.Tensor.from_numpy(
-                numpy_tensor, new_type=autograd_type
-            )
+            autograd_tensor = ttml.autograd.Tensor.from_numpy(numpy_tensor, new_type=autograd_type)
     else:
         if layout:
-            autograd_tensor = ttml.autograd.Tensor.from_numpy(
-                numpy_tensor, layout=layout
-            )
+            autograd_tensor = ttml.autograd.Tensor.from_numpy(numpy_tensor, layout=layout)
         else:
             autograd_tensor = ttml.autograd.Tensor.from_numpy(numpy_tensor)
     return (numpy_tensor, autograd_tensor)
@@ -526,9 +508,7 @@ def test_binary_operators_add(tensor_data, numpy_type, autograd_type, layout):
     if (tensor_data, numpy_type, autograd_type, layout) in typecast_issue_cases:
         pytest.skip("Known typecast issue")
 
-    numpy_tensor, autograd_tensor = make_tensors(
-        tensor_data, numpy_type, autograd_type, layout
-    )
+    numpy_tensor, autograd_tensor = make_tensors(tensor_data, numpy_type, autograd_type, layout)
 
     sum = autograd_tensor + autograd_tensor
     assert (sum.to_numpy() == (numpy_tensor + numpy_tensor)).all()
@@ -546,9 +526,7 @@ def test_binary_operators_diff(tensor_data, numpy_type, autograd_type, layout):
     if (tensor_data, numpy_type, autograd_type, layout) in typecast_issue_cases:
         pytest.skip("Known typecast issue")
 
-    numpy_tensor, autograd_tensor = make_tensors(
-        tensor_data, numpy_type, autograd_type, layout
-    )
+    numpy_tensor, autograd_tensor = make_tensors(tensor_data, numpy_type, autograd_type, layout)
 
     diff = autograd_tensor - autograd_tensor
 
@@ -570,9 +548,7 @@ def test_binary_operators_mul(tensor_data, numpy_type, autograd_type, layout):
     if (tensor_data, numpy_type, autograd_type, layout) in multiplication_issue_cases:
         pytest.skip("Known multiplication issue")
 
-    numpy_tensor, autograd_tensor = make_tensors(
-        tensor_data, numpy_type, autograd_type, layout
-    )
+    numpy_tensor, autograd_tensor = make_tensors(tensor_data, numpy_type, autograd_type, layout)
 
     mul = autograd_tensor * autograd_tensor
     mul_float = autograd_tensor * 10.0
@@ -596,9 +572,7 @@ def test_binary_operators_div(tensor_data, numpy_type, autograd_type, layout):
     if (tensor_data, numpy_type, autograd_type, layout) in division_issue_cases:
         pytest.skip("Known division issue")
 
-    numpy_tensor, autograd_tensor = make_tensors(
-        tensor_data, numpy_type, autograd_type, layout
-    )
+    numpy_tensor, autograd_tensor = make_tensors(tensor_data, numpy_type, autograd_type, layout)
 
     div = autograd_tensor.__div__(autograd_tensor)
 


### PR DESCRIPTION
This PR fixes spelling and typo errors in tt-train and tools code.

This is part of relanding spelling fixes from commit 98ad3bab62ac1f66560c88c30b3f12d846dd4b54 in smaller, targeted PRs.

Files changed:
- tt-train/ directory (including all subdirectories)
- tools/ directory (including all subdirectories)