### PR TITLE
Assign a team responsible for optimizers in tt-train

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -412,7 +412,7 @@ tt-train/sources/ttml/metal/** @mdragulaTT @vmelnykovTT @dyurshevichTT @zbaczews
 # ops
 tt-train/sources/ttml/ops/** @mdragulaTT @vmelnykovTT @dyurshevichTT @tenstorrent/codeowner-bypass
 # optimizers
-tt-train/sources/ttml/optimizers/** @zbaczewskiTT @tenstorrent/codeowner-bypass
+tt-train/sources/ttml/optimizers/** @tenstorrent/tt-train-optimizers @tenstorrent/codeowner-bypass
 # tests
 tt-train/tests/** @mdragulaTT @vmelnykovTT @dyurshevichTT @zbaczewskiTT @abustamanteTT @tenstorrent/codeowner-bypass
 


### PR DESCRIPTION
### Problem description
`tt-train/sources/ttml/optimizers/**` had only one code owner which blocked me from merging my own PR's.

### What's changed
Assign a team responsible for `tt-train/sources/ttml/optimizers/**`.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=zbaczewski/codeowners-optimizers)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:zbaczewski/codeowners-optimizers)