### PR TITLE
Overlap the mcast core CBs with KV cache buffer

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
@@ -1423,16 +1423,16 @@ class PreSDPA:
 
                 # CBs overlapped with sdpa_kv_cache L1 buffer (consumed before SDPA runs)
                 sdpa_kv_cache_running_offset = 0
+                sdpa_kv_cache_running_offset_mcast_core = 0
 
                 # CB: CCL broadcast packet buffer
                 bcast_pkt_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(bcast_pkt_cb, input_tensor_device)
-                sdpa_kv_cache_running_offset += bcast_pkt_cb_descriptor.total_size
 
                 # CB: RMSNorm output buffer
                 rmsnorm_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     rmsnorm_output_cb,
                     sdpa_kv_cache_buffer_device,
-                    address_offset=sdpa_kv_cache_running_offset,
+                    address_offset=sdpa_kv_cache_running_offset_mcast_core,
                     total_size=num_tiles * cb_page_size,
                 )
                 rmsnorm_output_cb_descriptor.format_descriptors = [
@@ -1443,6 +1443,7 @@ class PreSDPA:
                         tile=tile_descriptor,
                     )
                 ]
+                sdpa_kv_cache_running_offset_mcast_core += rmsnorm_output_cb_descriptor.total_size
 
                 # CB: Matmul weights (backed by fused overlapped tensor)
                 matmul_weights_cb_descriptor = cb_descriptor_from_overlapped_tensor(
@@ -1453,12 +1454,12 @@ class PreSDPA:
                 # Senders will query the write pointer of this CB to get the receiver address.
                 # Tensor-backed on full device grid (superset of sender/receiver grids) so senders
                 # can use get_write_ptr to get receiver address. This CB is consumed before SDPA runs.
-                # CB: Matmul input — overlap with kv_cache L1 buffer at offset 14336 B.
+                # CB: Matmul input — overlap with kv_cache L1 buffer.
                 matmul_input_tile_descriptor = ttnn.TileDescriptor(TILE_1x32)
                 matmul_input_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     matmul_input_cb,
                     sdpa_out_interm_buffer_device,
-                    address_offset=sdpa_out_interm_running_offset,  # 0 B
+                    address_offset=sdpa_out_interm_running_offset,
                     total_size=matmul_input_total_size,
                 )
                 matmul_input_cb_descriptor.format_descriptors = [
@@ -1469,16 +1470,15 @@ class PreSDPA:
                         tile=matmul_input_tile_descriptor,
                     )
                 ]
-                sdpa_out_interm_running_offset += matmul_input_cb_descriptor.total_size  # +14336 B
-
+                sdpa_out_interm_running_offset += matmul_input_cb_descriptor.total_size
                 # CB: Matmul output buffer (single tile) — overlap with sdpa_out_interm L1 buffer
-                # at offset 0 B. This CB is consumed before SDPA runs.
+                # This CB is consumed before SDPA runs.
                 matmul_output_tile_descriptor = ttnn.TileDescriptor(TILE_1x32)
                 matmul_output_page_size = TILE_1x32.get_tile_size(data_format)
                 matmul_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     matmul_output_cb,
                     sdpa_out_interm_buffer_device,
-                    address_offset=sdpa_out_interm_running_offset,  # 14336 B
+                    address_offset=sdpa_out_interm_running_offset,
                     total_size=matmul_output_page_size,
                 )
                 matmul_output_cb_descriptor.format_descriptors = [
@@ -1489,14 +1489,13 @@ class PreSDPA:
                         tile=matmul_output_tile_descriptor,
                     )
                 ]
-                sdpa_out_interm_running_offset += matmul_output_cb_descriptor.total_size  # +64 B
-
-                # CB 7: RMSNorm2 input buffer (3 tiles) — overlap with sdpa_out_interm L1 buffer
-                # at offset 64 B. This CB is consumed before SDPA runs.
+                sdpa_out_interm_running_offset += matmul_output_cb_descriptor.total_size
+                # CB 7: RMSNorm2 input buffer (3 tiles) — overlap with sdpa_kv_cache L1 buffer
+                # This CB is consumed before SDPA runs.
                 rmsnorm2_input_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     rmsnorm2_input_cb,
-                    sdpa_out_interm_buffer_device,
-                    address_offset=sdpa_out_interm_running_offset,  # 14400 B
+                    sdpa_kv_cache_buffer_device,
+                    address_offset=sdpa_kv_cache_running_offset_mcast_core,
                     total_size=rmsnorm2_num_tiles * rmsnorm2_page_size,
                 )
                 rmsnorm2_input_cb_descriptor.format_descriptors = [
@@ -1507,18 +1506,17 @@ class PreSDPA:
                         tile=rmsnorm2_tile_descriptor,
                     )
                 ]
-                sdpa_out_interm_running_offset += rmsnorm2_input_cb_descriptor.total_size  # +3072 B
-
+                sdpa_kv_cache_running_offset_mcast_core += rmsnorm2_input_cb_descriptor.total_size
                 # CB9 lifecycle:
                 # 1) RMSNorm2 writes normalized output here
                 # 2) Mcast2 reads from CB9 and writes to matmul2 input CB
 
                 # CB 8: gather_reduce half1 scratch buffer (3 tiles) — overlap with sdpa_out_interm L1 buffer
-                # at offset 3136 B. This CB is consumed before SDPA runs.
+                # This CB is consumed before SDPA runs.
                 gather_reduce_half1_scratch_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     gather_reduce_half1_scratch_cb,
-                    sdpa_out_interm_buffer_device,
-                    address_offset=sdpa_out_interm_running_offset,  # 17472 B
+                    sdpa_kv_cache_buffer_device,
+                    address_offset=sdpa_kv_cache_running_offset_mcast_core,
                     total_size=rmsnorm2_num_tiles * rmsnorm2_page_size,
                 )
                 gather_reduce_half1_scratch_cb_descriptor.format_descriptors = [
@@ -1529,21 +1527,12 @@ class PreSDPA:
                         tile=rmsnorm2_tile_descriptor,
                     )
                 ]
-                sdpa_out_interm_running_offset += gather_reduce_half1_scratch_cb_descriptor.total_size  # +3072 B
-
+                sdpa_kv_cache_running_offset_mcast_core += gather_reduce_half1_scratch_cb_descriptor.total_size
                 # CB: RMSNorm2 output buffer (3 tiles)
-                rmsnorm2_output_cb_format = ttnn.CBFormatDescriptor(
-                    buffer_index=rmsnorm2_output_cb,
-                    data_format=data_format,
-                    page_size=rmsnorm2_page_size,
-                    tile=rmsnorm2_tile_descriptor,
-                )
-                rmsnorm2_output_cb_core_ranges = rmsnorm_core_grid
-
                 rmsnorm2_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     rmsnorm2_output_cb,
-                    sdpa_out_interm_buffer_device,
-                    address_offset=sdpa_out_interm_running_offset,  # 20544 B
+                    sdpa_kv_cache_buffer_device,
+                    address_offset=sdpa_kv_cache_running_offset_mcast_core,
                     total_size=rmsnorm2_num_tiles * rmsnorm2_page_size,
                 )
                 rmsnorm2_output_cb_descriptor.format_descriptors = [
@@ -1554,15 +1543,14 @@ class PreSDPA:
                         tile=rmsnorm2_tile_descriptor,
                     )
                 ]
-                sdpa_out_interm_running_offset += rmsnorm2_output_cb_descriptor.total_size  # +3072 B
-
+                sdpa_kv_cache_running_offset_mcast_core += rmsnorm2_output_cb_descriptor.total_size
                 # CB: Matmul2 input buffer (1x1536 with 1x32 tiles = 48 tiles) — overlap with
-                # sdpa_out_interm L1 buffer at offset 9280 B. This CB is consumed before SDPA runs.
+                # sdpa_out_interm L1 buffer. This CB is consumed before SDPA runs.
                 matmul2_input_total_size = matmul2_num_tiles_k * matmul_input_page_size  # 48 * 64 bytes
                 matmul2_input_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     matmul2_input_cb,
                     sdpa_out_interm_buffer_device,
-                    address_offset=sdpa_out_interm_running_offset,  # 23616 B
+                    address_offset=sdpa_out_interm_running_offset,
                     total_size=matmul2_input_total_size,
                 )
                 matmul2_input_cb_descriptor.format_descriptors = [
@@ -1573,20 +1561,19 @@ class PreSDPA:
                         tile=matmul_input_tile_descriptor,
                     )
                 ]
-                sdpa_out_interm_running_offset += matmul2_input_cb_descriptor.total_size  # +3072 B
-
+                sdpa_out_interm_running_offset += matmul2_input_cb_descriptor.total_size
                 # CB: Matmul2 weights (backed by fused overlapped tensor)
                 matmul2_weights_cb_descriptor = cb_descriptor_from_overlapped_tensor(
                     matmul2_weights_cb, matmul2_weights_tensor, fused_weights_tensor_device
                 )
 
                 # CB 12: Matmul2 output buffer — overlap with sdpa_out_interm L1 buffer
-                # at offset 12352 B. This CB is consumed before SDPA runs.
+                # This CB is consumed before SDPA runs.
                 matmul2_output_total_size = matmul2_out_w * matmul_output_page_size  # 4 * 64 = 256 bytes per core
                 matmul2_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     matmul2_output_cb,
                     sdpa_out_interm_buffer_device,
-                    address_offset=sdpa_out_interm_running_offset,  # 26688 B
+                    address_offset=sdpa_out_interm_running_offset,
                     total_size=matmul2_output_total_size,
                 )
                 matmul2_output_cb_descriptor.format_descriptors = [
@@ -1597,22 +1584,21 @@ class PreSDPA:
                         tile=matmul_output_tile_descriptor,
                     )
                 ]
-                sdpa_out_interm_running_offset += matmul2_output_cb_descriptor.total_size  # +256 B
-
+                sdpa_out_interm_running_offset += matmul2_output_cb_descriptor.total_size
                 # CB 13: Matmul3 weights (backed by fused kv_b12 overlapped tensor)
                 matmul3_weights_cb_descriptor = cb_descriptor_from_overlapped_tensor(
                     matmul3_weights_cb, matmul3_weights_tensor, kv_b12_fused_tensor_device
                 )
 
                 # CB 14: Matmul3 output buffer — overlap with sdpa_out_interm L1 buffer
-                # at offset 12608 B. This CB is consumed before SDPA runs.
+                # This CB is consumed before SDPA runs.
                 matmul3_output_tile_descriptor = ttnn.TileDescriptor(TILE_1x32)
                 matmul3_output_page_size = TILE_1x32.get_tile_size(data_format)
                 matmul3_output_total_size = matmul3_out_w * matmul3_output_page_size  # 16 tiles
                 matmul3_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     matmul3_output_cb,
                     sdpa_out_interm_buffer_device,
-                    address_offset=sdpa_out_interm_running_offset,  # 26944 B
+                    address_offset=sdpa_out_interm_running_offset,
                     total_size=matmul3_output_total_size,
                 )
                 matmul3_output_cb_descriptor.format_descriptors = [
@@ -1623,17 +1609,16 @@ class PreSDPA:
                         tile=matmul3_output_tile_descriptor,
                     )
                 ]
-                sdpa_out_interm_running_offset += matmul3_output_cb_descriptor.total_size  # +1024 B
-
+                sdpa_out_interm_running_offset += matmul3_output_cb_descriptor.total_size
                 # CB 15: Qrope output buffer — overlap with sdpa_out_interm L1 buffer
-                # at offset 13632 B. This CB is consumed before SDPA runs.
+                # This CB is consumed before SDPA runs.
                 qrope_output_tile_descriptor = ttnn.TileDescriptor(TILE_1x32)
                 qrope_output_page_size = TILE_1x32.get_tile_size(data_format)
                 qrope_output_total_size = matmul2_out_w * qrope_output_page_size  # 4 tiles
                 qrope_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     qrope_output_cb,
                     sdpa_out_interm_buffer_device,
-                    address_offset=sdpa_out_interm_running_offset,  # 27968 B
+                    address_offset=sdpa_out_interm_running_offset,
                     total_size=qrope_output_total_size,
                 )
                 qrope_output_cb_descriptor.format_descriptors = [
@@ -1644,8 +1629,7 @@ class PreSDPA:
                         tile=qrope_output_tile_descriptor,
                     )
                 ]
-                sdpa_out_interm_running_offset += qrope_output_cb_descriptor.total_size  # +256 B
-
+                sdpa_out_interm_running_offset += qrope_output_cb_descriptor.total_size
                 # CB 17: Cos (DRAM, read by NCRISC)
                 qrope_rope_tile_descriptor = ttnn.TileDescriptor(TILE_1x32)
                 qrope_cos_cb_format = ttnn.CBFormatDescriptor(
@@ -1679,12 +1663,12 @@ class PreSDPA:
                 )
 
                 # CB 20: Rotated input intermediate CB — overlap with sdpa_out_interm L1 buffer
-                # at offset 13888 B. This CB is consumed before SDPA runs.
+                # This CB is consumed before SDPA runs.
                 qrope_interm_tile_size = qrope_head_dim_per_core_t * TILE_1x32.get_tile_size(data_format)
                 qrope_rotated_input_interm_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     qrope_rotated_input_interm_cb,
                     sdpa_out_interm_buffer_device,
-                    address_offset=sdpa_out_interm_running_offset,  # 28224 B
+                    address_offset=sdpa_out_interm_running_offset,
                     total_size=qrope_interm_tile_size,
                 )
                 qrope_rotated_input_interm_cb_descriptor.format_descriptors = [
@@ -1695,14 +1679,13 @@ class PreSDPA:
                         tile=ttnn.TileDescriptor(TILE_1x32),
                     )
                 ]
-                sdpa_out_interm_running_offset += qrope_rotated_input_interm_cb_descriptor.total_size  # +128 B
-
+                sdpa_out_interm_running_offset += qrope_rotated_input_interm_cb_descriptor.total_size
                 # CB 21: Cos intermediate CB — overlap with sdpa_out_interm L1 buffer
-                # at offset 14016 B. This CB is consumed before SDPA runs.
+                # This CB is consumed before SDPA runs.
                 qrope_cos_interm_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     qrope_cos_interm_cb,
                     sdpa_out_interm_buffer_device,
-                    address_offset=sdpa_out_interm_running_offset,  # 28352 B
+                    address_offset=sdpa_out_interm_running_offset,
                     total_size=qrope_interm_tile_size,
                 )
                 qrope_cos_interm_cb_descriptor.format_descriptors = [
@@ -1713,14 +1696,13 @@ class PreSDPA:
                         tile=ttnn.TileDescriptor(TILE_1x32),
                     )
                 ]
-                sdpa_out_interm_running_offset += qrope_cos_interm_cb_descriptor.total_size  # +128 B
-
+                sdpa_out_interm_running_offset += qrope_cos_interm_cb_descriptor.total_size
                 # CB 22: Sin intermediate CB — overlap with sdpa_out_interm L1 buffer
-                # at offset 14144 B. This CB is consumed before SDPA runs.
+                # This CB is consumed before SDPA runs.
                 qrope_sin_interm_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     qrope_sin_interm_cb,
                     sdpa_out_interm_buffer_device,
-                    address_offset=sdpa_out_interm_running_offset,  # 28480 B
+                    address_offset=sdpa_out_interm_running_offset,
                     total_size=qrope_interm_tile_size,
                 )
                 qrope_sin_interm_cb_descriptor.format_descriptors = [
@@ -1731,8 +1713,7 @@ class PreSDPA:
                         tile=ttnn.TileDescriptor(TILE_1x32),
                     )
                 ]
-                sdpa_out_interm_running_offset += qrope_sin_interm_cb_descriptor.total_size  # +128 B
-
+                sdpa_out_interm_running_offset += qrope_sin_interm_cb_descriptor.total_size
                 # CB 31: CreateQHeads intermediate buffer (row-major data before tilization)
                 # Senders write row-major data here via NOC, receiver marks pages, TRISC tilizes to output
                 # Allocated on union of sender (QNOPE/QROPE) and receiver (SDPA Input) grids
@@ -1746,7 +1727,7 @@ class PreSDPA:
                 create_q_heads_interm_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     create_q_heads_receiver_in_cb,
                     sdpa_out_interm_buffer_device,
-                    address_offset=sdpa_out_interm_running_offset,  # 28608 B
+                    address_offset=sdpa_out_interm_running_offset,
                     total_size=create_q_heads_interm_total_size,
                 )
                 create_q_heads_interm_cb_descriptor.format_descriptors = [
@@ -1757,8 +1738,7 @@ class PreSDPA:
                         tile=create_q_heads_interm_tile_descriptor,
                     )
                 ]
-                sdpa_out_interm_running_offset += create_q_heads_interm_cb_descriptor.total_size  # +9216 B
-
+                sdpa_out_interm_running_offset += create_q_heads_interm_cb_descriptor.total_size
                 # CB 16: CreateQHeads output buffer (tilized data, backed by output tensor)
                 # Only allocated on receiver cores (SDPA Input grid) - senders no longer write here
                 # This CB is input to SDPA, put it on all cores but only 8 cores have data
@@ -1784,13 +1764,13 @@ class PreSDPA:
                 )
 
                 # CB 24: DKV Matmul output — overlap with sdpa_out_interm L1 buffer
-                # at offset 14272 B. This CB is consumed before SDPA runs.
+                # This CB is consumed before SDPA runs.
                 dkv_matmul_output_tile_descriptor = ttnn.TileDescriptor(TILE_1x32)
                 dkv_matmul_output_page_size = TILE_1x32.get_tile_size(data_format)
                 dkv_matmul_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     dkv_matmul_output_cb,
                     sdpa_out_interm_buffer_device,
-                    address_offset=sdpa_out_interm_running_offset,  # 37824 B
+                    address_offset=sdpa_out_interm_running_offset,
                     total_size=dkv_matmul_output_page_size,
                 )
                 dkv_matmul_output_cb_descriptor.format_descriptors = [
@@ -1801,16 +1781,15 @@ class PreSDPA:
                         tile=dkv_matmul_output_tile_descriptor,
                     )
                 ]
-                sdpa_out_interm_running_offset += dkv_matmul_output_cb_descriptor.total_size  # +64 B
-
+                sdpa_out_interm_running_offset += dkv_matmul_output_cb_descriptor.total_size
                 # CB 25: KV RMSNorm input buffer — overlap with sdpa_out_interm L1 buffer
-                # at offset 14336 B. This CB is consumed before SDPA runs.
+                # This CB is consumed before SDPA runs.
                 kv_rmsnorm_tile_descriptor = ttnn.TileDescriptor(TILE_16x32)
                 kv_rmsnorm_page_size = TILE_16x32.get_tile_size(input_tensor_sample.dtype)
                 kv_rmsnorm_input_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     kv_rmsnorm_input_cb,
                     sdpa_out_interm_buffer_device,
-                    address_offset=sdpa_out_interm_running_offset,  # 37888 B
+                    address_offset=sdpa_out_interm_running_offset,
                     total_size=1 * kv_rmsnorm_page_size,
                 )
                 kv_rmsnorm_input_cb_descriptor.format_descriptors = [
@@ -1821,8 +1800,7 @@ class PreSDPA:
                         tile=kv_rmsnorm_tile_descriptor,
                     )
                 ]
-                sdpa_out_interm_running_offset += kv_rmsnorm_input_cb_descriptor.total_size  # +1024 B
-
+                sdpa_out_interm_running_offset += kv_rmsnorm_input_cb_descriptor.total_size
                 # CB: KV RMSNorm gamma buffer (backed by fused overlapped tensor)
                 kv_rmsnorm_gamma_cb_descriptor = cb_descriptor_from_overlapped_tensor(
                     kv_rmsnorm_gamma_cb, dkv_rmsnorm_gamma_tensor, gamma_fused_tensor_device
@@ -1831,11 +1809,11 @@ class PreSDPA:
                 kv_rmsnorm_gamma_cb_descriptor.format_descriptors[0].page_size = kv_rmsnorm_page_size
 
                 # CB 27: KV RMSNorm output buffer — overlap with sdpa_out_interm L1 buffer
-                # at offset 15360 B. This CB is consumed before SDPA runs.
+                # This CB is consumed before SDPA runs.
                 kv_rmsnorm_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     kv_rmsnorm_output_cb,
                     sdpa_out_interm_buffer_device,
-                    address_offset=sdpa_out_interm_running_offset,  # 38912 B
+                    address_offset=sdpa_out_interm_running_offset,
                     total_size=kv_rmsnorm_num_tiles * kv_rmsnorm_page_size,
                 )
                 kv_rmsnorm_output_cb_descriptor.format_descriptors = [
@@ -1846,8 +1824,7 @@ class PreSDPA:
                         tile=kv_rmsnorm_tile_descriptor,
                     )
                 ]
-                sdpa_out_interm_running_offset += kv_rmsnorm_output_cb_descriptor.total_size  # +1024 B
-
+                sdpa_out_interm_running_offset += kv_rmsnorm_output_cb_descriptor.total_size
                 # CB 29: Cos (DRAM, read by NCRISC)
                 krope_rope_tile_descriptor = ttnn.TileDescriptor(TILE_1x32)
                 krope_cos_cb_format = ttnn.CBFormatDescriptor(
@@ -1875,12 +1852,12 @@ class PreSDPA:
                 )
 
                 # CB 28: KRoPE output — overlap with sdpa_out_interm L1 buffer
-                # at offset 16384 B. This CB is consumed before SDPA runs.
+                # This CB is consumed before SDPA runs.
                 krope_tile_size = TILE_1x32.get_tile_size(data_format)
                 krope_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     krope_output_cb,
                     sdpa_out_interm_buffer_device,
-                    address_offset=sdpa_out_interm_running_offset,  # 39936 B
+                    address_offset=sdpa_out_interm_running_offset,
                     total_size=1 * krope_tile_size,
                 )
                 krope_output_cb_descriptor.format_descriptors = [
@@ -1891,8 +1868,7 @@ class PreSDPA:
                         tile=ttnn.TileDescriptor(TILE_1x32),
                     )
                 ]
-                sdpa_out_interm_running_offset += krope_output_cb_descriptor.total_size  # +64 B
-
+                sdpa_out_interm_running_offset += krope_output_cb_descriptor.total_size
                 TILE_32x32 = ttnn.Tile((32, 32))
                 kv_cache_page_size = TILE_32x32.get_tile_size(ttnn.bfloat8_b)
                 kv_cache_num_tiles = 16

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py
@@ -269,12 +269,14 @@ def test_pre_sdpa(
         mesh_mapper=ttnn.ReplicateTensorToMesh(submesh),
     )
 
+    # TODO: Reduce to 3 slots
     # SDPA output intermediate tensor declared here to overlap with remaining pre-SDPA CBs.
-    # Matches flash_mla's cb_out_im sizing: 85 tiles of [8, 32] at bfloat16 = 43520 B per core.
-    # Shard shape (40, 544) = 5 tile-rows x 17 tile-cols = 85 tiles per core.
+    # Matches flash_mla's cb_out_im sizing: 68 tiles of [8, 32] at bfloat16 = 43520 B per core.
+    # Shard shape (32, 544) = 4 tile-rows x 17 tile-cols = 68 tiles per core.
     sdpa_out_interm_num_cores = device_grid_size.x * device_grid_size.y
-    sdpa_out_interm_shard_height = 40  # 5 tile-rows of [8, 32]
-    sdpa_out_interm_shard_width = 544  # 17 tile-cols of [8, 32]
+    sdpa_out_interm_num_slots = 4
+    sdpa_out_interm_shard_height = sdpa_out_interm_num_slots * 8  # 4 tile-rows of [8, 32]
+    sdpa_out_interm_shard_width = 17 * 32  # 17 tile-cols of [8, 32]
     sdpa_out_interm_total_height = sdpa_out_interm_shard_height * sdpa_out_interm_num_cores
 
     sdpa_out_interm_shard_spec = ttnn.ShardSpec(


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
SDPA interm cb should be reduced to 3 slots for just local reductions, as ccl reductions are allocated as a separate buffer.

### What's changed
Move mcast core CBs from overlapping SDPA interm cb to overlapping kv cache cb.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=aho/cbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:aho/cbs)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aho/cbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/cbs)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aho/cbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/cbs)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aho/cbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/cbs)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aho/cbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/cbs)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aho/cbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/cbs)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
