### PR TITLE
Optimize ring joint SDPA data movement with mcast support and chain deadlock fix

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
@@ -26,8 +26,9 @@ void kernel_main() {
     constexpr uint32_t num_joint_k_chunks = get_compile_time_arg_val(15);
     constexpr uint32_t num_q_chunks = get_compile_time_arg_val(16);
     constexpr uint32_t ring_size = get_compile_time_arg_val(17);
+    constexpr uint32_t qk_subblock_h = get_compile_time_arg_val(18);
 
-    constexpr auto q_args = TensorAccessorArgs<18>();
+    constexpr auto q_args = TensorAccessorArgs<19>();
     constexpr auto k_args = TensorAccessorArgs<q_args.next_compile_time_args_offset()>();
     constexpr auto v_args = TensorAccessorArgs<k_args.next_compile_time_args_offset()>();
     constexpr auto gathered_k_args = TensorAccessorArgs<v_args.next_compile_time_args_offset()>();
@@ -60,6 +61,8 @@ void kernel_main() {
     const uint32_t next_physical_x = get_arg_val<uint32_t>(argidx++);
     const uint32_t next_physical_y = get_arg_val<uint32_t>(argidx++);
     const uint32_t next_core_q_chunks = get_arg_val<uint32_t>(argidx++);
+    const uint32_t mcast_num_dests = get_arg_val<uint32_t>(argidx++);
+    const uint32_t mcast_sender_wait = get_arg_val<uint32_t>(argidx++);
 
     RingSDPAOpReceiver fused_op_receiver = RingSDPAOpReceiver(
         true, /* wait_for_op_signal */
@@ -67,13 +70,14 @@ void kernel_main() {
 
     // After fused-op receiver consumed its runtime args, remaining RT args are S&F chain metadata
 
-    // Compile-time semaphore ids are appended after all TensorAccessorArgs()
+    // Compile-time semaphore ids and mcast flag are appended after all TensorAccessorArgs()
     uint32_t sender_semaphore_addr =
         get_semaphore(get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset()));
     uint32_t receiver_semaphore_addr =
         get_semaphore(get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset() + 1));
     uint32_t valid_semaphore_addr =
         get_semaphore(get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset() + 2));
+    constexpr bool mcast_enabled = get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset() + 3) == 1;
 
     // VALID sem used to write L1-L1 valid semaphore
     volatile tt_l1_ptr uint32_t* valid_semaphore_addr_ptr =
@@ -85,9 +89,29 @@ void kernel_main() {
 
     volatile tt_l1_ptr uint32_t* sender_semaphore_addr_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sender_semaphore_addr);
+
+    uint64_t receiver_semaphore_noc_addr = 0;
+    uint64_t mcast_base_noc_addr = 0;
+    uint64_t mcast_sem_noc_addr = 0;
+    uint32_t sender_wait_count = 1;
+
     const uint64_t sender_semaphore_noc_addr = get_noc_addr(prev_physical_x, prev_physical_y, sender_semaphore_addr);
-    const uint64_t receiver_semaphore_noc_addr =
-        get_noc_addr(next_physical_x, next_physical_y, receiver_semaphore_addr);
+
+    if constexpr (mcast_enabled) {
+        if (is_injector) {
+            // prev_physical = mcast_start (first receiver), next_physical = mcast_end (last receiver)
+            mcast_base_noc_addr = get_noc_multicast_addr(
+                prev_physical_x,
+                prev_physical_y,
+                next_physical_x,
+                next_physical_y,
+                0);  // addr=0; will OR in actual L1 addr at use site
+            mcast_sem_noc_addr = mcast_base_noc_addr | receiver_semaphore_addr;
+            sender_wait_count = mcast_sender_wait;
+        }
+    } else {
+        receiver_semaphore_noc_addr = get_noc_addr(next_physical_x, next_physical_y, receiver_semaphore_addr);
+    }
 
     constexpr uint32_t cb_q_in = tt::CBIndex::c_0;
     constexpr uint32_t cb_k_in = tt::CBIndex::c_1;
@@ -99,6 +123,8 @@ void kernel_main() {
 
     constexpr uint32_t k_chunk_tiles = Sk_chunk_t * DHt;
     constexpr uint32_t v_chunk_tiles = Sk_chunk_t * DHt;
+    constexpr uint32_t q_num_subblocks = Sq_chunk_t / qk_subblock_h;
+    constexpr bool use_q_subblock_push = (q_num_subblocks > 1);
 
     const auto q_reader = TensorAccessor(q_args, q_addr, q_tile_bytes);
     const auto local_k_reader = TensorAccessor(k_args, k_addr, k_tile_bytes);
@@ -154,26 +180,23 @@ void kernel_main() {
             const bool is_joint_q = q_chunk >= num_local_q_chunks;
 
             Slice q_slice;
-            uint32_t end_seq_tile;
+            uint32_t q_end_seq_tile;
             if (is_joint_q) {
                 // Get row index into the joint Q tensor
                 const uint32_t joint_q_row_start_tile = (q_chunk - num_local_q_chunks) * Sq_chunk_t;
                 q_slice = Slice(nb, nq, joint_q_row_start_tile, joint_q_row_start_tile + Sq_chunk_t, 0, DHt);
-                end_seq_tile = Lt;
+                q_end_seq_tile = Lt;
             } else {
                 // Index into the Q input tensor
                 q_slice = Slice(nb, nq, q_row_start_tile, q_row_start_tile + Sq_chunk_t, 0, DHt);
-                end_seq_tile = local_padded_Nt;
+                q_end_seq_tile = local_padded_Nt;
             }
 
-            read_block(
-                is_joint_q ? joint_q_generator : q_generator,
-                q_slice,
-                end_seq_tile,
-                cb_q_in,
-                q_tile_bytes,
-                false /*transpose*/
-            );
+            // Chain forwarding conditions are k_chunk-invariant — compute once before the KV loop
+            const uint32_t q_iter_local = global_q_chunk - global_q_start;
+            const bool should_forward = is_chain_participant && !is_sink && (nb == chain_batch && nq == chain_head) &&
+                                        (q_iter_local < next_core_q_chunks);
+            const bool should_receive = is_chain_participant && !is_injector && (nb == chain_batch && nq == chain_head);
 
             for (uint32_t k_chunk = 0; k_chunk < num_kv_chunks; ++k_chunk) {
                 /**
@@ -209,20 +232,22 @@ void kernel_main() {
                         end_seq_tile = std::min(logical_nt, local_padded_Nt);
                     } else {
                         // Gathered KV
-                        const uint32_t ring_iter_kv_start_tile = ring_id * local_padded_Nt;
                         const uint32_t gathered_kv_start_tile = ring_iter_kv_start_tile + k_chunk * Sk_chunk_t;
                         kv_slice = Slice(nb, nq, gathered_kv_start_tile, gathered_kv_start_tile + Sk_chunk_t, 0, DHt);
                         end_seq_tile = std::min(logical_nt, local_padded_Nt * (ring_id + 1));
                     }
                 }
 
-                // Determine if this Q iteration is within this core's chain segment for (batch, head)
-                const uint32_t q_iter_local = global_q_chunk - global_q_start;
-
                 // K: either read locally (injector or not participant) or receive from previous core
                 cb_reserve_back(cb_k_in, k_chunk_tiles);
                 uint32_t cb_k_start_address = get_write_ptr(cb_k_in);
-                if (is_injector || !is_chain_participant || (nb != chain_batch || nq != chain_head)) {
+                if (should_receive) {
+                    // Receive forwarded K chunk from previous core
+                    noc_semaphore_set(receiver_semaphore_addr_ptr, INVALID);
+                    noc_semaphore_inc(sender_semaphore_noc_addr, 1);
+                    noc_semaphore_wait(receiver_semaphore_addr_ptr, VALID);
+                    cb_push_back(cb_k_in, k_chunk_tiles);
+                } else {
                     read_block(
                         kv_chunk_is_joint ? joint_k_generator
                                           : (ring_iter == 0 ? local_k_generator : gathered_k_generator),
@@ -232,29 +257,68 @@ void kernel_main() {
                         k_tile_bytes,
                         true /*transpose*/
                     );
-                } else {
-                    // Receive forwarded K chunk from previous core
-                    noc_semaphore_set(receiver_semaphore_addr_ptr, INVALID);
-                    noc_semaphore_inc(sender_semaphore_noc_addr, 1);
-                    noc_semaphore_wait(receiver_semaphore_addr_ptr, VALID);
-                    cb_push_back(cb_k_in, k_chunk_tiles);
                 }
 
-                // Forward K chunk to next core if applicable
-                if (is_chain_participant && !is_sink && (nb == chain_batch && nq == chain_head) &&
-                    (q_iter_local < next_core_q_chunks)) {
-                    noc_semaphore_wait(sender_semaphore_addr_ptr, 1);
+                // Forward K chunk to next core(s): initiate async write (NOC write channel)
+                // For mcast: send linked data + companion semaphore back-to-back.
+                if (should_forward) {
+                    noc_semaphore_wait(sender_semaphore_addr_ptr, sender_wait_count);
                     noc_semaphore_set(sender_semaphore_addr_ptr, 0);
-                    uint64_t k_unicast_data_addr = get_noc_addr(next_physical_x, next_physical_y, cb_k_start_address);
-                    noc_async_write(cb_k_start_address, k_unicast_data_addr, k_chunk_tiles * k_tile_bytes);
-                    noc_async_writes_flushed();
-                    noc_semaphore_set_remote(valid_semaphore_addr, receiver_semaphore_noc_addr);
+                    if constexpr (mcast_enabled) {
+                        uint64_t k_mcast_addr = mcast_base_noc_addr | cb_k_start_address;
+                        noc_async_write_multicast(
+                            cb_k_start_address,
+                            k_mcast_addr,
+                            k_chunk_tiles * k_tile_bytes,
+                            mcast_num_dests,
+                            true /* linked: semaphore mcast follows */);
+                        noc_semaphore_set_multicast(valid_semaphore_addr, mcast_sem_noc_addr, mcast_num_dests);
+                    } else {
+                        uint64_t k_unicast_data_addr =
+                            get_noc_addr(next_physical_x, next_physical_y, cb_k_start_address);
+                        noc_async_write(cb_k_start_address, k_unicast_data_addr, k_chunk_tiles * k_tile_bytes);
+                        noc_async_writes_flushed();
+                        noc_semaphore_set_remote(valid_semaphore_addr, receiver_semaphore_noc_addr);
+                    }
+                }
+
+                // Download Q on the first K iteration — after K is downloaded and forwarded.
+                // Push Q one subblock at a time so compute can start QK matmul incrementally.
+                // Placed after K forward so no outstanding NOC writes remain
+                // (noc_async_read_barrier inside subblock read would deadlock with in-flight writes).
+                if (k_chunk == 0) {
+                    if constexpr (use_q_subblock_push) {
+                        const auto& q_gen = is_joint_q ? joint_q_generator : q_generator;
+                        for (uint32_t q_sub = 0; q_sub < q_num_subblocks; ++q_sub) {
+                            const uint32_t sb_row_start = q_slice.d2_start + q_sub * qk_subblock_h;
+                            const uint32_t sb_row_end = sb_row_start + qk_subblock_h;
+                            Slice q_sub_slice(q_slice.d0, q_slice.d1, sb_row_start, sb_row_end, 0, DHt);
+                            read_block(
+                                q_gen, q_sub_slice, q_end_seq_tile, cb_q_in, q_tile_bytes, false /*transpose*/
+                            );
+                        }
+                    } else {
+                        read_block(
+                            is_joint_q ? joint_q_generator : q_generator,
+                            q_slice,
+                            q_end_seq_tile,
+                            cb_q_in,
+                            q_tile_bytes,
+                            false /*transpose*/
+                        );
+                    }
                 }
 
                 // V: either read locally (injector or not participant) or receive from previous core
                 cb_reserve_back(cb_v_in, v_chunk_tiles);
                 uint32_t cb_v_start_address = get_write_ptr(cb_v_in);
-                if (is_injector || !is_chain_participant || (nb != chain_batch || nq != chain_head)) {
+                if (should_receive) {
+                    // Receive forwarded V chunk from previous core
+                    noc_semaphore_set(receiver_semaphore_addr_ptr, INVALID);
+                    noc_semaphore_inc(sender_semaphore_noc_addr, 1);
+                    noc_semaphore_wait(receiver_semaphore_addr_ptr, VALID);
+                    cb_push_back(cb_v_in, v_chunk_tiles);
+                } else {
                     read_block(
                         kv_chunk_is_joint ? joint_v_generator
                                           : (ring_iter == 0 ? local_v_generator : gathered_v_generator),
@@ -264,23 +328,28 @@ void kernel_main() {
                         v_tile_bytes,
                         false /*transpose*/
                     );
-                } else {
-                    // Receive forwarded V chunk from previous core
-                    noc_semaphore_set(receiver_semaphore_addr_ptr, INVALID);
-                    noc_semaphore_inc(sender_semaphore_noc_addr, 1);
-                    noc_semaphore_wait(receiver_semaphore_addr_ptr, VALID);
-                    cb_push_back(cb_v_in, v_chunk_tiles);
                 }
 
-                // Forward V chunk to next core if applicable
-                if (is_chain_participant && !is_sink && (nb == chain_batch && nq == chain_head) &&
-                    (q_iter_local < next_core_q_chunks)) {
-                    noc_semaphore_wait(sender_semaphore_addr_ptr, 1);
+                // Forward V chunk to next core(s) if applicable
+                if (should_forward) {
+                    noc_semaphore_wait(sender_semaphore_addr_ptr, sender_wait_count);
                     noc_semaphore_set(sender_semaphore_addr_ptr, 0);
-                    uint64_t v_unicast_data_addr = get_noc_addr(next_physical_x, next_physical_y, cb_v_start_address);
-                    noc_async_write(cb_v_start_address, v_unicast_data_addr, v_chunk_tiles * v_tile_bytes);
-                    noc_async_writes_flushed();
-                    noc_semaphore_set_remote(valid_semaphore_addr, receiver_semaphore_noc_addr);
+                    if constexpr (mcast_enabled) {
+                        uint64_t v_mcast_addr = mcast_base_noc_addr | cb_v_start_address;
+                        noc_async_write_multicast(
+                            cb_v_start_address,
+                            v_mcast_addr,
+                            v_chunk_tiles * v_tile_bytes,
+                            mcast_num_dests,
+                            true /* linked: semaphore mcast follows */);
+                        noc_semaphore_set_multicast(valid_semaphore_addr, mcast_sem_noc_addr, mcast_num_dests);
+                    } else {
+                        uint64_t v_unicast_data_addr =
+                            get_noc_addr(next_physical_x, next_physical_y, cb_v_start_address);
+                        noc_async_write(cb_v_start_address, v_unicast_data_addr, v_chunk_tiles * v_tile_bytes);
+                        noc_async_writes_flushed();
+                        noc_semaphore_set_remote(valid_semaphore_addr, receiver_semaphore_noc_addr);
+                    }
                 }
             }
         }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -5,6 +5,7 @@
 #include "ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.hpp"
 #include "ttnn/operations/transformer/sdpa/device/sdpa_subblock_utils.hpp"
 
+#include <algorithm>
 #include <optional>
 #include <cmath>
 #include <string>
@@ -291,6 +292,11 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     auto [qk_out_subblock_h, qk_out_subblock_w] =
         detail::determine_largest_subblock_size(Sq_chunk_t, Sk_chunk_t, dst_size);
 
+    TT_FATAL(
+        Sq_chunk_t % qk_out_subblock_h == 0,
+        "Sq_chunk_t ({}) must be divisible by qk_out_subblock_h ({})",
+        Sq_chunk_t,
+        qk_out_subblock_h);
     const uint32_t qk_in0_num_subblocks = Sq_chunk_t / qk_out_subblock_h;
     const uint32_t qk_in1_num_subblocks = Sk_chunk_t / qk_out_subblock_w;
     const uint32_t qk_num_blocks = DHt / qk_in0_block_w;
@@ -373,7 +379,8 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
         num_local_k_chunks,
         num_joint_k_chunks,
         num_q_chunks,
-        args.all_gather_operation_attributes.ring_size};
+        args.all_gather_operation_attributes.ring_size,
+        qk_out_subblock_h};
 
     TensorAccessorArgs(input_tensor_q.buffer()).append_to(reader_compile_time_args);
     TensorAccessorArgs(input_tensor_k.buffer()).append_to(reader_compile_time_args);
@@ -392,9 +399,11 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     auto valid_semaphore_id = CreateSemaphore(program, core_grid, VALID);
 
     // Append semaphore ids to reader compile-time args (must match reader kernel expectations)
+    const auto sem_args_offset = reader_compile_time_args.size();
     reader_compile_time_args.push_back(sender_semaphore_id);
     reader_compile_time_args.push_back(receiver_semaphore_id);
     reader_compile_time_args.push_back(valid_semaphore_id);
+    reader_compile_time_args.push_back(0);  // mcast_enabled placeholder (patched after chain construction)
 
     std::vector<uint32_t> writer_compile_time_args = {
         B,
@@ -482,28 +491,8 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     defines["REDUCE_GRANULARITY"] = std::to_string(reduce_granularity);
     defines["EXP_APPROX_MODE"] = std::to_string(exp_approx_mode);
 
-    auto reader_kernels_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp",
-        core_grid,
-        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args, defines));
-
-    auto writer_kernels_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp",
-        core_grid,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args, defines));
-
-    auto compute_kernels_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp",
-        core_grid,
-        tt::tt_metal::ComputeConfig{
-            .math_fidelity = math_fidelity,
-            .fp32_dest_acc_en = fp32_dest_acc_en,
-            .math_approx_mode = math_approx_mode,
-            .compile_args = compute_compile_time_args,
-            .defines = defines});
+    // NOTE: CreateKernel calls are deferred until after chain construction so that
+    // the mcast_enabled compile-time arg can be determined first.
 
     // Create circular buffers
 
@@ -688,6 +677,9 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
         CoreCoord prev_physical = CoreCoord{0, 0};
         CoreCoord next_physical = CoreCoord{0, 0};
         uint32_t next_core_q_chunks = 0;
+        bool use_mcast = false;
+        uint32_t mcast_num_dests = 0;
+        uint32_t mcast_sender_wait = 0;
     };
 
     std::vector<CoreWork> core_work(num_cores);
@@ -754,7 +746,12 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
         next_global_chunk += chunk_count;
     }
 
-    // Construct chains: for each head that spans >= 2 cores, pick first core with single head segment as injector
+    // Construct chains: for each head that spans >= 2 cores, pick first core
+    // with single head segment as injector. Linear forward traversal only —
+    // no wrap-around (wrapping back would pull in straddling cores whose
+    // q_iter_local is inflated by prior-head work, causing deadlock).
+    // Injector reselection for DRAM channel spreading is deferred to the
+    // mcast eligibility pass below.
     for (auto& segments : head_segments) {
         if (segments.size() < 2) {
             continue;
@@ -809,6 +806,233 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
             }
         }
     }
+
+    // Third pass: Check multicast eligibility and configure mcast for eligible chains
+    uint32_t mcast_chains = 0;
+    {
+        struct McastCandidate {
+            std::vector<uint32_t> core_indices;
+            uint32_t ref_q_chunks;
+        };
+        std::vector<McastCandidate> candidates;
+        bool all_eligible = true;
+
+        for (uint32_t head_id = 0; head_id < head_segments.size(); ++head_id) {
+            const auto& segments = head_segments[head_id];
+            if (segments.size() < 2) {
+                continue;
+            }
+
+            std::vector<uint32_t> chain_core_indices;
+            for (const auto& seg : segments) {
+                if (seg.core_idx < core_chain_info.size() && core_chain_info[seg.core_idx].participates &&
+                    core_chain_info[seg.core_idx].batch == (head_id / NH) &&
+                    core_chain_info[seg.core_idx].head == (head_id % NH)) {
+                    chain_core_indices.push_back(seg.core_idx);
+                }
+            }
+
+            if (chain_core_indices.size() < 2) {
+                continue;
+            }
+
+            // Eligibility condition 1: All physical cores share the same Y coordinate
+            const uint32_t ref_y = core_work[chain_core_indices[0]].physical_core.y;
+            bool same_row = true;
+            for (size_t ci = 1; ci < chain_core_indices.size(); ++ci) {
+                if (core_work[chain_core_indices[ci]].physical_core.y != ref_y) {
+                    same_row = false;
+                    break;
+                }
+            }
+
+            if (!same_row) {
+                all_eligible = false;
+                log_debug(tt::LogOp, "Head {}: mcast ineligible - cores span multiple rows", head_id);
+                break;
+            }
+
+            // Eligibility condition 2: no non-chain worker cores inside the mcast rectangle.
+            uint32_t min_x = core_work[chain_core_indices[0]].physical_core.x;
+            uint32_t max_x = min_x;
+            for (const auto& ci : chain_core_indices) {
+                uint32_t x = core_work[ci].physical_core.x;
+                min_x = std::min(min_x, x);
+                max_x = std::max(max_x, x);
+            }
+
+            bool has_gap = false;
+            for (uint32_t ci = 0; ci < num_cores; ++ci) {
+                const auto& phys = core_work[ci].physical_core;
+                if (phys.y == ref_y && phys.x >= min_x && phys.x <= max_x) {
+                    bool in_chain = false;
+                    for (const auto& chain_ci : chain_core_indices) {
+                        if (chain_ci == ci) {
+                            in_chain = true;
+                            break;
+                        }
+                    }
+                    if (!in_chain) {
+                        has_gap = true;
+                        break;
+                    }
+                }
+            }
+
+            if (has_gap) {
+                all_eligible = false;
+                log_debug(
+                    tt::LogOp, "Head {}: mcast ineligible - non-chain worker core inside mcast rectangle", head_id);
+                break;
+            }
+
+            // Eligibility condition 3: All chain cores must have the same q_chunk_count.
+            const uint32_t ref_q_chunks = core_chain_info[chain_core_indices[0]].q_chunk_count;
+            bool uniform_q_mcast = true;
+            for (size_t ci = 1; ci < chain_core_indices.size(); ++ci) {
+                if (core_chain_info[chain_core_indices[ci]].q_chunk_count != ref_q_chunks) {
+                    uniform_q_mcast = false;
+                    break;
+                }
+            }
+
+            if (!uniform_q_mcast) {
+                all_eligible = false;
+                log_debug(tt::LogOp, "Head {}: mcast ineligible - mixed q_chunk_counts", head_id);
+                break;
+            }
+
+            candidates.push_back(McastCandidate{std::move(chain_core_indices), ref_q_chunks});
+        }
+
+        if (all_eligible && !candidates.empty()) {
+            mcast_chains = candidates.size();
+            // Track injector physical X columns for DRAM channel spreading
+            std::vector<uint32_t> injector_phys_x;
+            for (const auto& cand : candidates) {
+                const uint32_t chain_size = cand.core_indices.size();
+                const uint32_t num_receivers = chain_size - 1;
+
+                // Find current injector
+                uint32_t injector_idx = cand.core_indices[0];
+                for (const auto& ci : cand.core_indices) {
+                    if (core_chain_info[ci].is_injector) {
+                        injector_idx = ci;
+                        break;
+                    }
+                }
+
+                // Reselect injector for DRAM channel spreading: pick the core
+                // whose physical X is furthest from all previously chosen injectors.
+                {
+                    uint32_t best_idx = injector_idx;
+                    uint32_t best_dist = 0;
+                    for (const auto& ci : cand.core_indices) {
+                        const uint32_t phys_x = core_work[ci].physical_core.x;
+                        uint32_t min_dist = UINT32_MAX;
+                        for (uint32_t ix : injector_phys_x) {
+                            uint32_t d = (phys_x > ix) ? (phys_x - ix) : (ix - phys_x);
+                            min_dist = std::min(min_dist, d);
+                        }
+                        if (min_dist > best_dist) {
+                            best_dist = min_dist;
+                            best_idx = ci;
+                        }
+                    }
+                    if (best_idx != injector_idx) {
+                        // Clear old injector, set new one
+                        core_chain_info[injector_idx].is_injector = false;
+                        core_chain_info[injector_idx].is_sink = true;
+                        core_chain_info[best_idx].is_injector = true;
+                        core_chain_info[best_idx].is_sink = false;
+                        injector_idx = best_idx;
+                    }
+                }
+                injector_phys_x.push_back(core_work[injector_idx].physical_core.x);
+
+                uint32_t min_x = core_work[cand.core_indices[0]].physical_core.x;
+                uint32_t max_x = min_x;
+                for (size_t ci = 1; ci < cand.core_indices.size(); ++ci) {
+                    uint32_t x = core_work[cand.core_indices[ci]].physical_core.x;
+                    min_x = std::min(min_x, x);
+                    max_x = std::max(max_x, x);
+                }
+                const uint32_t injector_y = core_work[injector_idx].physical_core.y;
+                const CoreCoord rect_start = CoreCoord{min_x, injector_y};
+                const CoreCoord rect_end = CoreCoord{max_x, injector_y};
+
+                const uint32_t injector_x = core_work[injector_idx].physical_core.x;
+                const bool injector_inside_rect = (injector_x > min_x && injector_x < max_x);
+                const uint32_t mcast_num_dests = injector_inside_rect ? chain_size : num_receivers;
+
+                auto& injector_chain = core_chain_info[injector_idx];
+                injector_chain.use_mcast = true;
+                injector_chain.prev_physical = rect_start;
+                injector_chain.next_physical = rect_end;
+                injector_chain.mcast_num_dests = mcast_num_dests;
+                injector_chain.mcast_sender_wait = num_receivers;
+                injector_chain.next_core_q_chunks = cand.ref_q_chunks;
+
+                for (const auto& ci : cand.core_indices) {
+                    if (ci == injector_idx) {
+                        continue;
+                    }
+                    auto& receiver_chain = core_chain_info[ci];
+                    receiver_chain.use_mcast = true;
+                    receiver_chain.prev_physical = core_work[injector_idx].physical_core;
+                    receiver_chain.next_physical = CoreCoord{0, 0};
+                    receiver_chain.next_core_q_chunks = 0;
+                    receiver_chain.is_sink = true;
+                }
+
+                log_debug(
+                    tt::LogOp,
+                    "Head: mcast enabled - {} receivers, injector core {} (phys_x={}), num_dests={} -> rect "
+                    "({},{}) to ({},{})",
+                    num_receivers,
+                    injector_idx,
+                    core_work[injector_idx].physical_core.x,
+                    mcast_num_dests,
+                    rect_start.x,
+                    rect_start.y,
+                    rect_end.x,
+                    rect_end.y);
+            }
+        }
+
+        log_debug(
+            tt::LogOp,
+            "Multicast eligibility: {}/{} chains using mcast (all-or-nothing)",
+            mcast_chains,
+            static_cast<uint32_t>(candidates.size()));
+    }
+
+    // Update mcast_enabled compile-time arg now that chain construction is complete
+    reader_compile_time_args[sem_args_offset + 3] = (mcast_chains > 0) ? 1 : 0;
+
+    // Create kernels (deferred until after chain construction for mcast_enabled flag)
+    auto reader_kernels_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp",
+        core_grid,
+        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args, defines));
+
+    auto writer_kernels_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp",
+        core_grid,
+        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args, defines));
+
+    auto compute_kernels_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp",
+        core_grid,
+        tt::tt_metal::ComputeConfig{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .math_approx_mode = math_approx_mode,
+            .compile_args = compute_compile_time_args,
+            .defines = defines});
 
     // Set reader rt args
     for (uint32_t i = 0; i < num_cores; ++i) {
@@ -871,6 +1095,8 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
         reader_args.push_back(static_cast<uint32_t>(chain.next_physical.x));
         reader_args.push_back(static_cast<uint32_t>(chain.next_physical.y));
         reader_args.push_back(chain.next_core_q_chunks);
+        reader_args.push_back(chain.mcast_num_dests);
+        reader_args.push_back(chain.mcast_sender_wait);
 
         // Inject fused-op synchronization RT args (AllGather) here; it will append to reader_args
         sdpa_fused_op_signaler->push_ring_sdpa_fused_op_rt_args(reader_args);


### PR DESCRIPTION
## Summary

Data movement optimizations for the ring joint SDPA reader kernel to improve KV forwarding latency and compute overlap, with multicast support for eligible chain topologies.

## Optimizations

### 1. K-first download ordering
Previously, the reader downloaded Q first and then K for each iteration. Now K is fetched and forwarded to chain peers **before** Q is downloaded. This lets DRAM reads for Q overlap with the NOC transfer of K, hiding latency that was previously sequential.

### 2. Q subblock push to compute
Instead of downloading the entire Q chunk and pushing it to compute as a single block, Q is now pushed one **matmul subblock** (`qk_subblock_h` rows) at a time. This allows the compute kernel to begin the QK matmul incrementally while the reader is still fetching remaining Q subblocks.

### 3. NOC multicast for KV chain forwarding
When all cores in a store-and-forward chain sit on the same physical row (eligible for multicast), the injector core now multicasts K/V to all receiver cores simultaneously via `noc_async_write_multicast` + linked `noc_semaphore_set_multicast`. This replaces the serial unicast chain where data hopped through N-1 cores sequentially — reducing it to a single hop. Mcast eligibility is all-or-nothing across chains: all chains must be eligible or all fall back to unicast (since `mcast_enabled` is a compile-time arg).

### 4. Injector DRAM channel spreading
When multicast is enabled, the injector is reselected per chain so that injector physical X positions are spread across different columns, reducing DRAM channel contention when multiple chains read KV simultaneously.

## Other Changes

- Hoisted chain forwarding condition (`should_forward` / `should_receive`) out of the k_chunk loop since it is k_chunk-invariant.
- Added `TT_FATAL` for `Sq_chunk_t % qk_out_subblock_h` divisibility (required for Q subblock push).
- Linear-only chain traversal (no wrap-around) to avoid deadlocks from inflated `q_iter_local` on straddling cores.
- Mcast gap detection checks all worker cores (not just chain segment cores) to prevent data corruption from non-chain cores inside the mcast rectangle.

## Test plan
- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=skrstic/ring-joint-sdpa-dm-optimizations)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:skrstic/ring-joint-sdpa-dm-optimizations)
- [ ] [![Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=skrstic/ring-joint-sdpa-dm-optimizations)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:skrstic/ring-joint-sdpa-dm-optimizations)
- [ ] [![Nightly L2 tests (SDPA)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/ring-joint-sdpa-dm-optimizations)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skrstic/ring-joint-sdpa-dm-optimizations)
- [ ] [![T3000 e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=skrstic/ring-joint-sdpa-dm-optimizations)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:skrstic/ring-joint-sdpa-dm-optimizations)
- [ ] [![T3000 integration tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-integration-tests.yaml/badge.svg?branch=skrstic/ring-joint-sdpa-dm-optimizations)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-integration-tests.yaml?query=branch:skrstic/ring-joint-sdpa-dm-optimizations)
- [ ] [![Galaxy e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-e2e-tests.yaml/badge.svg?branch=skrstic/ring-joint-sdpa-dm-optimizations)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-e2e-tests.yaml?query=branch:skrstic/ring-joint-sdpa-dm-optimizations)
- [ ] [![Galaxy demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml/badge.svg?branch=skrstic/ring-joint-sdpa-dm-optimizations)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml?query=branch:skrstic/ring-joint-sdpa-dm-optimizations)
- [ ] [![Blackhole demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-demo-tests.yaml/badge.svg?branch=skrstic/ring-joint-sdpa-dm-optimizations)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-demo-tests.yaml?query=branch:skrstic/ring-joint-sdpa-dm-optimizations)