### PR TITLE
Validate program with MeshDevice when required

### DIFF
--- a/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_allocation.cpp
+++ b/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_allocation.cpp
@@ -589,4 +589,47 @@ TEST_F(MeshDeviceFixture, TensixTestDataCopyWithUpdatedCircularBufferConfig) {
     }
 }
 
+TEST_F(MeshDeviceFixture, TensixTestCircularBuffersAndMeshL1BuffersCollision) {
+    for (unsigned int id = 0; id < num_devices_; id++) {
+        auto& mesh_device = devices_.at(id);
+        auto& cq = mesh_device->mesh_command_queue();
+        distributed::MeshWorkload workload;
+        auto zero_coord = distributed::MeshCoordinate(0, 0);
+        auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+        Program program;
+        workload.add_program(device_range, std::move(program));
+        auto& program_ = workload.get_programs().at(device_range);
+        uint32_t page_size = tt::tile_size(tt::DataFormat::Float16_b);
+
+        auto buffer_size = page_size * 128;
+        distributed::ReplicatedBufferConfig replicated_config = {
+            .size = buffer_size,
+        };
+        distributed::DeviceLocalBufferConfig local_config = {
+            .page_size = buffer_size,
+            .buffer_type = tt::tt_metal::BufferType::L1,
+        };
+        auto l1_mesh_buffer = distributed::MeshBuffer::create(replicated_config, local_config, mesh_device.get());
+
+        auto core = mesh_device->allocator()->get_logical_core_from_bank_id(0);
+        CoreRange cr(core, core);
+        CoreRangeSet cr_set({cr});
+        initialize_program(program_, cr_set);
+
+        uint32_t num_pages =
+            ((l1_mesh_buffer->address() - mesh_device->allocator()->get_base_allocator_addr(HalMemType::L1)) /
+             max_cbs_ / page_size) +
+            1;
+        CBConfig cb_config = {.num_pages = num_pages};
+        for (uint32_t buffer_id = 0; buffer_id < max_cbs_; buffer_id++) {
+            CircularBufferConfig config1 =
+                CircularBufferConfig(cb_config.page_size * cb_config.num_pages, {{buffer_id, cb_config.data_format}})
+                    .set_page_size(buffer_id, cb_config.page_size);
+            CreateCircularBuffer(program_, core, config1);
+        }
+
+        EXPECT_ANY_THROW(distributed::EnqueueMeshWorkload(cq, workload, false));
+    }
+}
+
 }  // end namespace basic_tests::circular_buffer

--- a/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_allocation.cpp
+++ b/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_allocation.cpp
@@ -601,7 +601,14 @@ TEST_F(MeshDeviceFixture, TensixTestCircularBuffersAndMeshL1BuffersCollision) {
         auto& program_ = workload.get_programs().at(device_range);
         uint32_t page_size = tt::tile_size(tt::DataFormat::Float16_b);
 
-        auto buffer_size = page_size * 128;
+        DeviceAddr l1_unreserved_base = mesh_device->allocator()->get_base_allocator_addr(HalMemType::L1);
+        DeviceAddr l1_max_size = mesh_device->get_devices()[0]->l1_size_per_core();
+        DeviceAddr l1_bank_size = l1_max_size - l1_unreserved_base;
+
+        // Allocate a MeshBuffer that consumes most of L1 bank 0 (top-down), leaving room for
+        // only one tile worth of CBs. The buffer occupies [l1_unreserved_base + page_size, l1_max_size).
+        uint32_t alignment = mesh_device->allocator()->get_alignment(BufferType::L1);
+        DeviceAddr buffer_size = (l1_bank_size - page_size) / alignment * alignment;
         distributed::ReplicatedBufferConfig replicated_config = {
             .size = buffer_size,
         };
@@ -616,14 +623,12 @@ TEST_F(MeshDeviceFixture, TensixTestCircularBuffersAndMeshL1BuffersCollision) {
         CoreRangeSet cr_set({cr});
         initialize_program(program_, cr_set);
 
-        uint32_t num_pages =
-            ((l1_mesh_buffer->address() - mesh_device->allocator()->get_base_allocator_addr(HalMemType::L1)) /
-             max_cbs_ / page_size) +
-            1;
-        CBConfig cb_config = {.num_pages = num_pages};
-        for (uint32_t buffer_id = 0; buffer_id < max_cbs_; buffer_id++) {
+        // Create two CBs each of page_size. The second CB will push the CB region past the
+        // MeshBuffer's lowest occupied address, triggering the collision.
+        CBConfig cb_config;
+        for (uint32_t buffer_id = 0; buffer_id < 2; buffer_id++) {
             CircularBufferConfig config1 =
-                CircularBufferConfig(cb_config.page_size * cb_config.num_pages, {{buffer_id, cb_config.data_format}})
+                CircularBufferConfig(cb_config.page_size, {{buffer_id, cb_config.data_format}})
                     .set_page_size(buffer_id, cb_config.page_size);
             CreateCircularBuffer(program_, core, config1);
         }

--- a/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_allocation.cpp
+++ b/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_allocation.cpp
@@ -212,7 +212,8 @@ TEST_F(MeshDeviceFixture, TensixTestValidCircularBufferAddress) {
 
 TEST_F(MeshDeviceFixture, TensixTestCircularBuffersAndL1BuffersCollision) {
     for (unsigned int id = 0; id < num_devices_; id++) {
-        auto& cq = devices_.at(id)->mesh_command_queue();
+        auto& mesh_device = devices_.at(id);
+        auto& cq = mesh_device->mesh_command_queue();
         distributed::MeshWorkload workload;
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
@@ -221,28 +222,34 @@ TEST_F(MeshDeviceFixture, TensixTestCircularBuffersAndL1BuffersCollision) {
         auto& program_ = workload.get_programs().at(device_range);
         uint32_t page_size = tt::tile_size(tt::DataFormat::Float16_b);
 
-        auto buffer_size = page_size * 128;
-        tt::tt_metal::InterleavedBufferConfig buff_config{
-            .device = this->devices_.at(id)->get_devices()[0],
-            .size = buffer_size,
-            .page_size = buffer_size,
-            .buffer_type = tt::tt_metal::BufferType::L1};
-        auto l1_buffer = CreateBuffer(buff_config);
+        DeviceAddr l1_unreserved_base = mesh_device->allocator()->get_base_allocator_addr(HalMemType::L1);
+        DeviceAddr l1_max_size = mesh_device->get_devices()[0]->l1_size_per_core();
+        DeviceAddr l1_bank_size = l1_max_size - l1_unreserved_base;
 
-        // L1 buffer is entirely in bank 0
-        auto core = l1_buffer->allocator()->get_logical_core_from_bank_id(0);
+        // Allocate a MeshBuffer that consumes most of L1 bank 0 (top-down), leaving room for
+        // only one tile worth of CBs.
+        uint32_t alignment = mesh_device->allocator()->get_alignment(BufferType::L1);
+        DeviceAddr buffer_size = (l1_bank_size - page_size) / alignment * alignment;
+        distributed::ReplicatedBufferConfig replicated_config = {
+            .size = buffer_size,
+        };
+        distributed::DeviceLocalBufferConfig local_config = {
+            .page_size = buffer_size,
+            .buffer_type = tt::tt_metal::BufferType::L1,
+        };
+        auto l1_mesh_buffer = distributed::MeshBuffer::create(replicated_config, local_config, mesh_device.get());
+
+        auto core = mesh_device->allocator()->get_logical_core_from_bank_id(0);
         CoreRange cr(core, core);
         CoreRangeSet cr_set({cr});
         initialize_program(program_, cr_set);
 
-        uint32_t num_pages =
-            ((l1_buffer->address() - devices_.at(id)->allocator()->get_base_allocator_addr(HalMemType::L1)) / max_cbs_ /
-             page_size) +
-            1;
-        CBConfig cb_config = {.num_pages = num_pages};
-        for (uint32_t buffer_id = 0; buffer_id < max_cbs_; buffer_id++) {
+        // Two CBs of page_size each will push the CB region past the MeshBuffer's lowest
+        // occupied address, triggering the collision.
+        CBConfig cb_config;
+        for (uint32_t buffer_id = 0; buffer_id < 2; buffer_id++) {
             CircularBufferConfig config1 =
-                CircularBufferConfig(cb_config.page_size * cb_config.num_pages, {{buffer_id, cb_config.data_format}})
+                CircularBufferConfig(cb_config.page_size, {{buffer_id, cb_config.data_format}})
                     .set_page_size(buffer_id, cb_config.page_size);
             CreateCircularBuffer(program_, core, config1);
         }
@@ -586,54 +593,6 @@ TEST_F(MeshDeviceFixture, TensixTestDataCopyWithUpdatedCircularBufferConfig) {
         detail::ReadFromDeviceL1(
             this->devices_.at(id)->get_devices()[0], core, global_cb_buffer->address(), buffer_size, second_cb_data);
         EXPECT_EQ(src_vec, second_cb_data);
-    }
-}
-
-TEST_F(MeshDeviceFixture, TensixTestCircularBuffersAndMeshL1BuffersCollision) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        auto& mesh_device = devices_.at(id);
-        auto& cq = mesh_device->mesh_command_queue();
-        distributed::MeshWorkload workload;
-        auto zero_coord = distributed::MeshCoordinate(0, 0);
-        auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-        Program program;
-        workload.add_program(device_range, std::move(program));
-        auto& program_ = workload.get_programs().at(device_range);
-        uint32_t page_size = tt::tile_size(tt::DataFormat::Float16_b);
-
-        DeviceAddr l1_unreserved_base = mesh_device->allocator()->get_base_allocator_addr(HalMemType::L1);
-        DeviceAddr l1_max_size = mesh_device->get_devices()[0]->l1_size_per_core();
-        DeviceAddr l1_bank_size = l1_max_size - l1_unreserved_base;
-
-        // Allocate a MeshBuffer that consumes most of L1 bank 0 (top-down), leaving room for
-        // only one tile worth of CBs. The buffer occupies [l1_unreserved_base + page_size, l1_max_size).
-        uint32_t alignment = mesh_device->allocator()->get_alignment(BufferType::L1);
-        DeviceAddr buffer_size = (l1_bank_size - page_size) / alignment * alignment;
-        distributed::ReplicatedBufferConfig replicated_config = {
-            .size = buffer_size,
-        };
-        distributed::DeviceLocalBufferConfig local_config = {
-            .page_size = buffer_size,
-            .buffer_type = tt::tt_metal::BufferType::L1,
-        };
-        auto l1_mesh_buffer = distributed::MeshBuffer::create(replicated_config, local_config, mesh_device.get());
-
-        auto core = mesh_device->allocator()->get_logical_core_from_bank_id(0);
-        CoreRange cr(core, core);
-        CoreRangeSet cr_set({cr});
-        initialize_program(program_, cr_set);
-
-        // Create two CBs each of page_size. The second CB will push the CB region past the
-        // MeshBuffer's lowest occupied address, triggering the collision.
-        CBConfig cb_config;
-        for (uint32_t buffer_id = 0; buffer_id < 2; buffer_id++) {
-            CircularBufferConfig config1 =
-                CircularBufferConfig(cb_config.page_size, {{buffer_id, cb_config.data_format}})
-                    .set_page_size(buffer_id, cb_config.page_size);
-            CreateCircularBuffer(program_, core, config1);
-        }
-
-        EXPECT_ANY_THROW(distributed::EnqueueMeshWorkload(cq, workload, false));
     }
 }
 

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -820,11 +820,16 @@ bool ConfigureDeviceWithProgram(IDevice* device, Program& program, bool force_sl
 
     auto device_id = device->id();
 
-    program.impl().allocate_circular_buffers(device);
-    program.impl().validate_circular_buffer_core_ranges(device);
-    program.impl().validate_circular_buffer_region(device);
-    program.impl().allocate_dataflow_buffers(device);
-    program.impl().validate_dataflow_buffer_region(device);
+    // Individual device allocators don't track mesh buffer allocations, so use the
+    // MeshDevice for validation when available to correctly detect CB/L1 buffer overlaps.
+    auto mesh_device = device->get_mesh_device();
+    const IDevice* validation_device = mesh_device ? mesh_device.get() : device;
+
+    program.impl().allocate_circular_buffers(validation_device);
+    program.impl().validate_circular_buffer_core_ranges(validation_device);
+    program.impl().validate_circular_buffer_region(validation_device);
+    program.impl().allocate_dataflow_buffers(validation_device);
+    program.impl().validate_dataflow_buffer_region(validation_device);
 
     std::vector<std::vector<CoreCoord>> logical_cores_used_in_program = program.impl().logical_cores();
     const auto& hal = MetalContext::instance().hal();


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/39104

### Problem description
https://github.com/tenstorrent/tt-metal/issues/39104

### What's changed
- If the IDevice is a mesh device, validate using `MeshDevice`. Otherwise, use `Device`.
- Add unit test

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=nhuang/mesh-device-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:nhuang/mesh-device-validation)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nhuang/mesh-device-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nhuang/mesh-device-validation)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nhuang/mesh-device-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nhuang/mesh-device-validation)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nhuang/mesh-device-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nhuang/mesh-device-validation)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nhuang/mesh-device-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nhuang/mesh-device-validation)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nhuang/mesh-device-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nhuang/mesh-device-validation)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
