### PR TITLE
Fix L1 sanitizer false positive in CoreLocalMem::operator[] (#36546)

### DIFF
--- a/tt_metal/hw/inc/experimental/core_local_mem.h
+++ b/tt_metal/hw/inc/experimental/core_local_mem.h
@@ -78,7 +78,7 @@ public:
      * @return Reference to the element at the given index
      */
     T& operator[](uint32_t index) const {
-        DEBUG_SANITIZE_L1_ADDR(address_ + (index + 1) * sizeof(T), sizeof(T));
+        DEBUG_SANITIZE_L1_ADDR(address_ + index * sizeof(T), sizeof(T));
         return get_unsafe_ptr()[index];
     }
 


### PR DESCRIPTION
### Ticket
Fixes #36546

### Problem description
`GenericBinaryReaderMatmulLargeBlock` fails when run with `TT_METAL_WATCHER=1` due to a false L1 overflow reported by the sanitizer in `CoreLocalMem::operator[]`. The test allocates an L1 buffer that ends exactly at the L1 limit (0x16e000). The sanitizer was checking the wrong address region and incorrectly flagged an overflow.

### Root cause
Bug in `tt_metal/hw/inc/experimental/core_local_mem.h`: `DEBUG_SANITIZE_L1_ADDR` in `operator[]` used `address_ + (index + 1) * sizeof(T)` instead of `address_ + index * sizeof(T)`. The sanitizer validates that the *start* of the accessed region plus its size fits within L1. Using `(index+1)*sizeof(T)` effectively checked one element past the actual access, causing a false overflow when the buffer ended exactly at the L1 boundary.

**Note:** The +1 indexing for memory addressing was already removed in [#35457](https://github.com/tenstorrent/tt-metal/pull/35457) (Log local memory reads and writes, by Nigel Huang) for the Proxy-based `operator[]`; the sanitizer check was not updated in that PR. This PR completes the fix by updating the sanitizer to match.

### What's changed
- **Fix**: Changed `DEBUG_SANITIZE_L1_ADDR(address_ + (index + 1) * sizeof(T), sizeof(T))` to `DEBUG_SANITIZE_L1_ADDR(address_ + index * sizeof(T), sizeof(T))` so the sanitizer validates the actual access address.
- **Impact**: `GenericBinaryReaderMatmulLargeBlock` now passes with `TT_METAL_WATCHER=1`. No functional change to non-watcher builds.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ebanerjee/36546-watcher-l1-issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ebanerjee/36546-watcher-l1-issue)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ebanerjee/36546-watcher-l1-issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ebanerjee/36546-watcher-l1-issue)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ebanerjee/36546-watcher-l1-issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ebanerjee/36546-watcher-l1-issue)
- [x] New/Existing tests provide coverage for changes (GenericBinaryReaderMatmulLargeBlock exercises the fix)
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early

#### Model tests
N/A – change is limited to L1 sanitizer logic in `CoreLocalMem`; no model-related code touched.