### PR TITLE
chore: add logs

### DIFF
--- a/models/tt_dit/layers/module.py
+++ b/models/tt_dit/layers/module.py
@@ -4,10 +4,12 @@
 
 from __future__ import annotations
 
+import time
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import TYPE_CHECKING, NamedTuple, overload
 
+from loguru import logger as _module_logger
 from typing_extensions import deprecated
 
 import ttnn
@@ -150,6 +152,11 @@ class Module(ABC):
         Returns:
             `IncompatibleKeys` containing lists of missing and unexpected keys.
         """
+        _t0 = time.perf_counter()
+        _module_logger.info(
+            f"[TIMING] {type(self).__name__}.load_torch_state_dict: on_host={on_host}, num_keys={len(state_dict)}"
+        )
+
         missing_keys = []
         unexpected_keys = []
 
@@ -170,6 +177,9 @@ class Module(ABC):
             raise ValueError("; ".join(parts))
 
         self._is_loaded = True
+        _module_logger.info(
+            f"[TIMING] {type(self).__name__}.load_torch_state_dict took {time.perf_counter() - _t0:.2f}s"
+        )
         return IncompatibleKeys(missing_keys, unexpected_keys)
 
     @deprecated("Use load_torch_state_dict instead")
@@ -177,6 +187,9 @@ class Module(ABC):
         self.load_torch_state_dict(state_dict)
 
     def save(self, directory: str | Path, /, *, prefix: str = "") -> None:
+        _t0 = time.perf_counter()
+        if not prefix:
+            _module_logger.info(f"[TIMING] {type(self).__name__}.save to: {directory}")
         directory = Path(directory)
         directory.mkdir(exist_ok=True, parents=True)
 
@@ -186,21 +199,37 @@ class Module(ABC):
         for name, parameter in self.named_parameters():
             parameter.save(directory / f"{prefix}{name}.tensorbin")
 
+        if not prefix:
+            _module_logger.info(f"[TIMING] {type(self).__name__}.save total took {time.perf_counter() - _t0:.2f}s")
+
     def load(self, directory: str | Path, /, *, prefix: str = "") -> None:
+        _t0 = time.perf_counter()
+        if not prefix:
+            _module_logger.info(f"[TIMING] {type(self).__name__}.load from cache dir: {directory}")
         directory = Path(directory)
 
         for name, child in self.named_children():
             child.load(directory, prefix=f"{prefix}{name}.")
 
+        _t_params = time.perf_counter()
+        _param_count = 0
         for name, parameter in self.named_parameters():
             path = directory / f"{prefix}{name}.tensorbin"
             try:
                 parameter.load(path)
+                _param_count += 1
             except LoadingError as err:
                 msg = f"{err} while loading '{path}'"
                 raise LoadingError(msg) from err
 
+        if _param_count > 0:
+            _module_logger.debug(
+                f"[TIMING] {type(self).__name__}.load: loaded {_param_count} params at prefix='{prefix}' in {time.perf_counter() - _t_params:.2f}s"
+            )
+
         self._is_loaded = True
+        if not prefix:
+            _module_logger.info(f"[TIMING] {type(self).__name__}.load total took {time.perf_counter() - _t0:.2f}s")
 
     def deallocate_weights(self) -> None:
         """Deallocate all parameter weights from device memory recursively."""

--- a/models/tt_dit/models/vae/vae_sd35.py
+++ b/models/tt_dit/models/vae/vae_sd35.py
@@ -4,7 +4,10 @@
 
 from __future__ import annotations
 
+import time
 from typing import TYPE_CHECKING
+
+from loguru import logger as _vae_logger
 
 import ttnn
 
@@ -471,6 +474,8 @@ class VAEDecoder(Module):
         parallel_config: VAEParallelConfig,
         ccl_manager: CCLManager,
     ) -> VAEDecoder:
+        _t0 = time.perf_counter()
+        _vae_logger.info("[TIMING] VAEDecoder.__init__...")
         model = cls(
             block_out_channels=[block.resnets[0].conv2.out_channels for block in torch_ref.up_blocks][::-1],
             in_channels=torch_ref.conv_in.in_channels,
@@ -481,7 +486,13 @@ class VAEDecoder(Module):
             parallel_config=parallel_config,
             ccl_manager=ccl_manager,
         )
+        _vae_logger.info(f"[TIMING] VAEDecoder.__init__ took {time.perf_counter() - _t0:.2f}s")
+
+        _t1 = time.perf_counter()
+        _vae_logger.info("[TIMING] VAEDecoder.load_torch_state_dict...")
         model.load_torch_state_dict(torch_ref.state_dict())
+        _vae_logger.info(f"[TIMING] VAEDecoder.load_torch_state_dict took {time.perf_counter() - _t1:.2f}s")
+        _vae_logger.info(f"[TIMING] VAEDecoder.from_torch total took {time.perf_counter() - _t0:.2f}s")
         return model
 
     def forward(self, x: ttnn.Tensor) -> ttnn.Tensor:

--- a/models/tt_dit/parallel/manager.py
+++ b/models/tt_dit/parallel/manager.py
@@ -2,7 +2,10 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import time
+
 import torch
+from loguru import logger as _ccl_logger
 
 import ttnn
 
@@ -24,24 +27,31 @@ class CCLManager:
         num_links=1,
         topology=None,
     ):
+        _t_init = time.perf_counter()
+        _ccl_logger.info(
+            f"[TIMING] CCLManager.__init__: mesh_shape={tuple(mesh_device.shape)}, num_links={num_links}, topology={topology}"
+        )
         self.mesh_device = mesh_device
         self.num_links = num_links
         self.topology = topology
 
-        # Cache for ping pong buffers: key = (shape_tuple, dim, mesh_axis), value = [buffer1, buffer2]
         self._ping_pong_buffer_cache = {}
         self._ping_pong_buffer_indices = {}
 
-        # Setup semaphores
+        _t0 = time.perf_counter()
         self._init_subdevice()
+        _ccl_logger.info(f"[TIMING] CCLManager._init_subdevice took {time.perf_counter() - _t0:.2f}s")
 
-        # Initialize semaphores for reduce scatter and all gather and neighbor pad
+        _t0 = time.perf_counter()
         self._init_semaphores()
+        _ccl_logger.info(f"[TIMING] CCLManager._init_semaphores took {time.perf_counter() - _t0:.2f}s")
+
         self.rs_ping_pong_idx = [0, 0]
         self.ag_ping_pong_idx = [0, 0]
         self.np_ping_pong_idx = [0, 0]
         self.sr_ping_pong_idx = [0, 0]
         self.barrier_idx = [0, 0]
+        _ccl_logger.info(f"[TIMING] CCLManager.__init__ total took {time.perf_counter() - _t_init:.2f}s")
 
     def _init_subdevice(self):
         compute_grid_size = self.mesh_device.compute_with_storage_grid_size()

--- a/models/tt_dit/pipelines/flux1/pipeline_flux1.py
+++ b/models/tt_dit/pipelines/flux1/pipeline_flux1.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import os
+import time
 from contextlib import nullcontext
 from dataclasses import dataclass
 
@@ -86,6 +87,8 @@ class Flux1Pipeline:
                 )
             )
 
+        _t_init_start = time.perf_counter()
+
         # No CFG. Create submeshes based on SP and TP
         submesh_shape = list(mesh_device.shape)
         submesh_shape[parallel_config.sequence_parallel.mesh_axis] = parallel_config.sequence_parallel.factor
@@ -93,13 +96,18 @@ class Flux1Pipeline:
         logger.info(f"Parallel config: {parallel_config}")
         logger.info(f"Original mesh shape: {mesh_device.shape}")
         logger.info(f"Creating submeshes with shape {submesh_shape}")
+        _t0 = time.perf_counter()
         self._submesh_devices = self._mesh_device.create_submeshes(ttnn.MeshShape(*submesh_shape))[
             0:1
         ]  # Only create one submesh for now. This can be used to support batching in the future.
+        logger.info(f"[TIMING] create_submeshes took {time.perf_counter() - _t0:.2f}s")
+
+        _t0 = time.perf_counter()
         self._ccl_managers = [
             CCLManager(submesh_device, num_links=num_links, topology=topology)
             for submesh_device in self._submesh_devices
         ]
+        logger.info(f"[TIMING] CCLManager init took {time.perf_counter() - _t0:.2f}s")
 
         self.encoder_device = self._submesh_devices[0]
         self.original_submesh_shape = tuple(self.encoder_device.shape)
@@ -108,21 +116,40 @@ class Flux1Pipeline:
         self.vae_submesh_idx = 0  # Use submesh 0 for VAE
 
         logger.info("loading models...")
+        _t0 = time.perf_counter()
         self._tokenizer_1 = CLIPTokenizer.from_pretrained(checkpoint_name, subfolder="tokenizer")
+        logger.info(f"[TIMING] CLIPTokenizer.from_pretrained took {time.perf_counter() - _t0:.2f}s")
+
+        _t0 = time.perf_counter()
         self._t5_tokenizer = T5TokenizerFast.from_pretrained(checkpoint_name, subfolder="tokenizer_2")
+        logger.info(f"[TIMING] T5TokenizerFast.from_pretrained took {time.perf_counter() - _t0:.2f}s")
+
+        _t0 = time.perf_counter()
         torch_text_encoder_1 = CLIPTextModel.from_pretrained(checkpoint_name, subfolder="text_encoder")
         torch_text_encoder_1.eval()
-        if enable_t5_text_encoder:
-            torch_t5_text_encoder = T5EncoderModel.from_pretrained(checkpoint_name, subfolder="text_encoder_2")
-        self._scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(checkpoint_name, subfolder="scheduler")
-        self._torch_vae = AutoencoderKL.from_pretrained(checkpoint_name, subfolder="vae")
+        logger.info(f"[TIMING] CLIPTextModel.from_pretrained took {time.perf_counter() - _t0:.2f}s")
 
+        if enable_t5_text_encoder:
+            _t0 = time.perf_counter()
+            torch_t5_text_encoder = T5EncoderModel.from_pretrained(checkpoint_name, subfolder="text_encoder_2")
+            logger.info(f"[TIMING] T5EncoderModel.from_pretrained took {time.perf_counter() - _t0:.2f}s")
+
+        _t0 = time.perf_counter()
+        self._scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(checkpoint_name, subfolder="scheduler")
+        logger.info(f"[TIMING] FlowMatchEulerDiscreteScheduler.from_pretrained took {time.perf_counter() - _t0:.2f}s")
+
+        _t0 = time.perf_counter()
+        self._torch_vae = AutoencoderKL.from_pretrained(checkpoint_name, subfolder="vae")
+        logger.info(f"[TIMING] AutoencoderKL.from_pretrained took {time.perf_counter() - _t0:.2f}s")
+
+        _t0 = time.perf_counter()
         torch_transformer = FluxTransformer2DModel.from_pretrained(
             checkpoint_name,
             subfolder="transformer",
             torch_dtype=torch.bfloat16,  # bfloat16 is the native datatype of the model
         )
         torch_transformer.eval()
+        logger.info(f"[TIMING] FluxTransformer2DModel.from_pretrained took {time.perf_counter() - _t0:.2f}s")
 
         logger.info("creating TT-NN transformer...")
 
@@ -137,6 +164,8 @@ class Flux1Pipeline:
 
         self.transformers = []
         for i, submesh_device in enumerate(self._submesh_devices):
+            logger.info(f"[TIMING] Creating Flux1Transformer for submesh {i}...")
+            _t0 = time.perf_counter()
             tt_transformer = Flux1Transformer(
                 patch_size=torch_transformer.config.patch_size,
                 in_channels=torch_transformer.config.in_channels,
@@ -154,8 +183,11 @@ class Flux1Pipeline:
                 parallel_config=parallel_config,
                 padding_config=padding_config,
             )
+            logger.info(f"[TIMING] Flux1Transformer.__init__ for submesh {i} took {time.perf_counter() - _t0:.2f}s")
 
             model_name = os.path.basename(checkpoint_name)
+            logger.info(f"[TIMING] Loading transformer weights for submesh {i} (cache.load_model)...")
+            _t0 = time.perf_counter()
             cache.load_model(
                 tt_transformer,
                 get_torch_state_dict=torch_transformer.state_dict,
@@ -164,9 +196,17 @@ class Flux1Pipeline:
                 parallel_config=parallel_config,
                 mesh_shape=tuple(submesh_device.shape),
             )
+            logger.info(
+                f"[TIMING] cache.load_model (transformer) for submesh {i} took {time.perf_counter() - _t0:.2f}s"
+            )
 
             self.transformers.append(tt_transformer)
+            logger.info(f"[TIMING] Synchronizing submesh device {i}...")
+            _t0 = time.perf_counter()
             ttnn.synchronize_device(submesh_device)
+            logger.info(
+                f"[TIMING] synchronize_device (transformer) for submesh {i} took {time.perf_counter() - _t0:.2f}s"
+            )
 
         self._pos_embed = torch_transformer.pos_embed
 
@@ -185,6 +225,7 @@ class Flux1Pipeline:
         logger.info("creating TT-NN CLIP text encoder...")
 
         if use_torch_clip_text_encoder:
+            logger.info("[TIMING] Using torch CLIP text encoder (no TT-NN conversion)")
             self._text_encoder_1 = torch_text_encoder_1
         else:
             clip_config_1 = CLIPConfig(
@@ -199,6 +240,7 @@ class Flux1Pipeline:
                 hidden_act=torch_text_encoder_1.config.hidden_act,
             )
 
+            _t0 = time.perf_counter()
             self._text_encoder_1 = CLIPEncoder(
                 config=clip_config_1,
                 mesh_device=self.encoder_device,
@@ -206,14 +248,18 @@ class Flux1Pipeline:
                 parallel_config=encoder_parallel_config,
                 eos_token_id=2,  # default EOS token ID for CLIP
             )
+            logger.info(f"[TIMING] CLIPEncoder.__init__ took {time.perf_counter() - _t0:.2f}s")
 
+            _t0 = time.perf_counter()
             self._text_encoder_1.load_torch_state_dict(torch_text_encoder_1.state_dict())
+            logger.info(f"[TIMING] CLIPEncoder.load_torch_state_dict took {time.perf_counter() - _t0:.2f}s")
 
         if enable_t5_text_encoder:
             if use_torch_t5_text_encoder:
+                logger.info("[TIMING] Using torch T5 text encoder (no TT-NN conversion)")
                 self._t5_text_encoder = torch_t5_text_encoder
             else:
-                logger.info("creating TT-NN text encoder...")
+                logger.info("creating TT-NN T5 text encoder...")
 
                 t5_config = T5Config(
                     vocab_size=torch_t5_text_encoder.config.vocab_size,
@@ -228,13 +274,17 @@ class Flux1Pipeline:
                     relative_attention_max_distance=torch_t5_text_encoder.config.relative_attention_max_distance,
                 )
 
+                _t0 = time.perf_counter()
                 self._t5_text_encoder = T5Encoder(
                     config=t5_config,
                     mesh_device=self.encoder_device,
                     ccl_manager=self._ccl_managers[self.encoder_submesh_idx],
                     parallel_config=encoder_parallel_config,
                 )
+                logger.info(f"[TIMING] T5Encoder.__init__ took {time.perf_counter() - _t0:.2f}s")
 
+                logger.info("[TIMING] Loading T5 text encoder weights (cache.load_model)...")
+                _t0 = time.perf_counter()
                 cache.load_model(
                     self._t5_text_encoder,
                     get_torch_state_dict=torch_t5_text_encoder.state_dict,
@@ -243,24 +293,38 @@ class Flux1Pipeline:
                     parallel_config=encoder_parallel_config,
                     mesh_shape=tuple(self.encoder_device.shape),
                 )
+                logger.info(f"[TIMING] cache.load_model (T5) took {time.perf_counter() - _t0:.2f}s")
         else:
             self._t5_text_encoder = None
 
         self._traces = None
 
+        logger.info("[TIMING] Synchronizing encoder device...")
+        _t0 = time.perf_counter()
         ttnn.synchronize_device(self.encoder_device)
+        logger.info(f"[TIMING] synchronize_device (encoder) took {time.perf_counter() - _t0:.2f}s")
 
+        logger.info("[TIMING] Creating VAEDecoder from torch...")
+        _t0 = time.perf_counter()
         self._vae_decoder = VAEDecoder.from_torch(
             torch_ref=self._torch_vae.decoder,
             mesh_device=self.vae_device,
             parallel_config=self._vae_parallel_config,
             ccl_manager=self._ccl_managers[self.vae_submesh_idx],
         )
+        logger.info(f"[TIMING] VAEDecoder.from_torch took {time.perf_counter() - _t0:.2f}s")
 
-        # warmup for safe tracing.
-        logger.info("warming up for tracing...")
+        logger.info(f"[TIMING] Total model loading took {time.perf_counter() - _t_init_start:.2f}s")
+
+        logger.info("[TIMING] Starting warmup inference (1 step, untraced)...")
+        _t0 = time.perf_counter()
         self.run_single_prompt(prompt="", num_inference_steps=1, seed=0, traced=False)
+        logger.info(f"[TIMING] Warmup run_single_prompt took {time.perf_counter() - _t0:.2f}s")
+
+        _t0 = time.perf_counter()
         self.synchronize_devices()
+        logger.info(f"[TIMING] synchronize_devices (warmup) took {time.perf_counter() - _t0:.2f}s")
+        logger.info(f"[TIMING] Flux1Pipeline.__init__ total took {time.perf_counter() - _t_init_start:.2f}s")
 
     @staticmethod
     def create_pipeline(
@@ -276,6 +340,11 @@ class Flux1Pipeline:
         num_links=None,
         topology=ttnn.Topology.Linear,
     ):
+        _t_create_start = time.perf_counter()
+        logger.info(
+            f"[TIMING] create_pipeline called: checkpoint={checkpoint_name}, mesh_shape={tuple(mesh_device.shape)}, is_blackhole={is_blackhole()}"
+        )
+
         wh_config = {
             (1, 4): {"sp": (1, 0), "tp": (4, 1), "encoder_tp": (4, 1), "vae_tp": (4, 1), "num_links": 1},
             (2, 4): {"sp": (2, 0), "tp": (4, 1), "encoder_tp": (4, 1), "vae_tp": (4, 1), "num_links": 1},
@@ -289,11 +358,20 @@ class Flux1Pipeline:
         }
 
         default_config = bh_config if is_blackhole() else wh_config
+        mesh_shape_key = tuple(mesh_device.shape)
+        if mesh_shape_key not in default_config:
+            logger.error(
+                f"[TIMING] mesh shape {mesh_shape_key} not found in {'bh_config' if is_blackhole() else 'wh_config'}! Available: {list(default_config.keys())}"
+            )
         sp_factor, sp_axis = dit_sp or default_config[tuple(mesh_device.shape)]["sp"]
         tp_factor, tp_axis = dit_tp or default_config[tuple(mesh_device.shape)]["tp"]
         encoder_tp_factor, encoder_tp_axis = encoder_tp or default_config[tuple(mesh_device.shape)]["encoder_tp"]
         vae_tp_factor, vae_tp_axis = vae_tp or default_config[tuple(mesh_device.shape)]["vae_tp"]
         num_links = num_links or default_config[tuple(mesh_device.shape)]["num_links"]
+
+        logger.info(
+            f"[TIMING] Resolved config: SP=({sp_factor},{sp_axis}), TP=({tp_factor},{tp_axis}), encoder_TP=({encoder_tp_factor},{encoder_tp_axis}), vae_TP=({vae_tp_factor},{vae_tp_axis}), num_links={num_links}"
+        )
 
         dit_parallel_config = DiTParallelConfig(
             cfg_parallel=ParallelFactor(factor=1, mesh_axis=0),
@@ -307,6 +385,7 @@ class Flux1Pipeline:
             tensor_parallel=ParallelFactor(factor=vae_tp_factor, mesh_axis=vae_tp_axis)
         )
 
+        logger.info("[TIMING] Calling Flux1Pipeline.__init__...")
         pipeline = Flux1Pipeline(
             checkpoint_name=checkpoint_name,
             mesh_device=mesh_device,
@@ -320,6 +399,7 @@ class Flux1Pipeline:
             num_links=num_links,
         )
 
+        logger.info(f"[TIMING] create_pipeline total took {time.perf_counter() - _t_create_start:.2f}s")
         return pipeline
 
     def run_single_prompt(
@@ -368,6 +448,8 @@ class Flux1Pipeline:
         profiler: BenchmarkProfiler = None,
         profiler_iteration: int = 0,
     ) -> list[Image.Image]:
+        _t_call_start = time.perf_counter()
+        logger.info(f"[TIMING] __call__: width={width}, height={height}, steps={num_inference_steps}, traced={traced}")
         prompt_count = len(prompt_1)
 
         sp_axis = self._parallel_config.sequence_parallel.mesh_axis
@@ -386,7 +468,8 @@ class Flux1Pipeline:
             latents_width = width // self._vae_scale_factor
             spatial_sequence_length = latents_height * latents_width
 
-            logger.info("encoding prompts...")
+            logger.info("[TIMING] encoding prompts...")
+            _t_enc = time.perf_counter()
 
             with profiler("encoder", profiler_iteration) if profiler else nullcontext():
                 prompt_embeds, pooled_prompt_embeds = self._encode_prompts(
@@ -402,7 +485,8 @@ class Flux1Pipeline:
                 )
                 _, prompt_sequence_length, _ = prompt_embeds.shape
 
-            logger.info("preparing timesteps...")
+            logger.info(f"[TIMING] Encoding prompts took {time.perf_counter() - _t_enc:.2f}s")
+            logger.info("[TIMING] preparing timesteps...")
 
             self._scheduler.set_timesteps(
                 sigmas=np.linspace(1.0, 1 / num_inference_steps, num_inference_steps),
@@ -421,7 +505,8 @@ class Flux1Pipeline:
                 else None
             )
 
-            logger.info("preparing latents...")
+            logger.info("[TIMING] preparing latents...")
+            _t_prep = time.perf_counter()
 
             if seed is not None:
                 torch.manual_seed(seed)
@@ -589,10 +674,13 @@ class Flux1Pipeline:
                 tt_prompt_rope_cos_list.append(tt_prompt_rope_cos)
                 tt_prompt_rope_sin_list.append(tt_prompt_rope_sin)
 
-            logger.info("denoising...")
+            logger.info(f"[TIMING] Tensor preparation took {time.perf_counter() - _t_prep:.2f}s")
+            logger.info("[TIMING] denoising...")
 
+            _t_denoise = time.perf_counter()
             with profiler("denoising", profiler_iteration) if profiler else nullcontext():
                 for i, t in enumerate(tqdm.tqdm(self._scheduler.timesteps)):
+                    _t_step = time.perf_counter()
                     with profiler(f"denoising_step_{i}", profiler_iteration) if profiler else nullcontext():
                         sigma_difference = self._scheduler.sigmas[i + 1] - self._scheduler.sigmas[i]
 
@@ -637,19 +725,25 @@ class Flux1Pipeline:
                             prompt_sequence_length=prompt_sequence_length,
                             traced=traced,
                         )
+                    logger.info(f"[TIMING] Denoising step {i} took {time.perf_counter() - _t_step:.2f}s")
 
-            logger.info("decoding image...")
+            logger.info(
+                f"[TIMING] Total denoising ({num_inference_steps} steps) took {time.perf_counter() - _t_denoise:.2f}s"
+            )
+            logger.info("[TIMING] decoding image...")
 
+            _t_vae = time.perf_counter()
             with profiler("vae", profiler_iteration) if profiler else nullcontext():
-                # Sync because we don't pass a persistent buffer or a barrier semaphore.
                 ttnn.synchronize_device(self.vae_device)
 
+                _t0 = time.perf_counter()
                 tt_latents = self._ccl_managers[self.vae_submesh_idx].all_gather_persistent_buffer(
                     tt_latents_step_list[self.vae_submesh_idx],
                     dim=1,
                     mesh_axis=sp_axis,
                     use_hyperparams=True,
                 )
+                logger.info(f"[TIMING] VAE all_gather took {time.perf_counter() - _t0:.2f}s")
 
                 torch_latents = ttnn.to_torch(ttnn.get_device_tensors(tt_latents)[0])
                 torch_latents = (torch_latents / self._latents_scaling) + self._latents_shift
@@ -662,13 +756,18 @@ class Flux1Pipeline:
                     device=self.vae_device,
                     mesh_mapper=ttnn.ReplicateTensorToMesh(self.vae_device),
                 )
+                _t0 = time.perf_counter()
                 tt_decoded_output = self._vae_decoder(tt_latents)
+                logger.info(f"[TIMING] VAE decode forward took {time.perf_counter() - _t0:.2f}s")
                 decoded_output = ttnn.to_torch(ttnn.get_device_tensors(tt_decoded_output)[0]).permute(0, 3, 1, 2)
 
                 image = self._image_processor.postprocess(decoded_output, output_type="pt")
                 assert isinstance(image, torch.Tensor)
 
                 output = self._image_processor.numpy_to_pil(self._image_processor.pt_to_numpy(image))
+
+            logger.info(f"[TIMING] VAE total took {time.perf_counter() - _t_vae:.2f}s")
+            logger.info(f"[TIMING] __call__ total took {time.perf_counter() - _t_call_start:.2f}s")
 
         return output
 

--- a/models/tt_dit/utils/cache.py
+++ b/models/tt_dit/utils/cache.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import os
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING, NamedTuple
 
@@ -74,12 +75,20 @@ def load_model(
         `MissingCacheError`: Cache does not exist and `get_torch_state_dict` is `None`.
         `RuntimeError`: `TT_DIT_CACHE_DIR` is not set and `get_torch_state_dict` is `None`.
     """
+    _t_load_start = time.perf_counter()
+    logger.info(
+        f"[TIMING] cache.load_model called: model_name={model_name}, subfolder={subfolder}, mesh_shape={mesh_shape}, dtype={dtype}"
+    )
+
     if tt_model.is_loaded():
+        logger.info("[TIMING] Model already loaded, skipping")
         return
 
-    # unload any modules that need to be unloaded before loading this module
     for module in tt_model.unload_set or []:
+        logger.info(f"[TIMING] Deallocating weights for unload_set module: {type(module).__name__}")
+        _t0 = time.perf_counter()
         module.deallocate_weights()
+        logger.info(f"[TIMING] deallocate_weights took {time.perf_counter() - _t0:.2f}s")
 
     cache_dir = model_cache_dir(
         model_name=model_name,
@@ -90,34 +99,54 @@ def load_model(
         is_fsdp=is_fsdp,
         required=get_torch_state_dict is None,
     )
+    logger.info(f"[TIMING] Resolved cache_dir: {cache_dir}")
 
     if cache_dir is None:
         assert get_torch_state_dict is not None
 
+        logger.info("[TIMING] No cache dir (TT_DIT_CACHE_DIR not set). Loading from PyTorch state dict directly...")
+        _t0 = time.perf_counter()
+        state_dict = get_torch_state_dict()
         logger.info(
-            "Loading transformer weights from PyTorch state dict. "
-            "To use caching, set the TT_DIT_CACHE_DIR environment variable."
+            f"[TIMING] get_torch_state_dict() took {time.perf_counter() - _t0:.2f}s (num keys: {len(state_dict)})"
         )
-        tt_model.load_torch_state_dict(get_torch_state_dict())
+        _t0 = time.perf_counter()
+        tt_model.load_torch_state_dict(state_dict)
+        logger.info(f"[TIMING] load_torch_state_dict (no cache) took {time.perf_counter() - _t0:.2f}s")
+        logger.info(f"[TIMING] cache.load_model total took {time.perf_counter() - _t_load_start:.2f}s")
         return
 
     if Path(cache_dir).is_dir():
-        logger.info(f"loading cache at '{cache_dir}'.")
+        logger.info(f"[TIMING] Cache exists at '{cache_dir}'. Loading from cache...")
+        _t0 = time.perf_counter()
         tt_model.load(cache_dir)
+        logger.info(f"[TIMING] tt_model.load (from cache) took {time.perf_counter() - _t0:.2f}s")
+        logger.info(f"[TIMING] cache.load_model total took {time.perf_counter() - _t_load_start:.2f}s")
         return
 
     if get_torch_state_dict is None:
         raise MissingCacheError(cache_dir)
 
-    logger.info("Cache does not exist. Loading PyTorch state dict.")
-    # Create host tensors when creating the cache to circumvent the issue that replicated device
-    # tensors lead to redundant copies when saved to disk.
-    tt_model.load_torch_state_dict(get_torch_state_dict(), on_host=create_cache)
+    logger.info(f"[TIMING] Cache does not exist at '{cache_dir}'. Loading PyTorch state dict and creating cache...")
+    _t0 = time.perf_counter()
+    state_dict = get_torch_state_dict()
+    logger.info(f"[TIMING] get_torch_state_dict() took {time.perf_counter() - _t0:.2f}s (num keys: {len(state_dict)})")
+
+    _t0 = time.perf_counter()
+    tt_model.load_torch_state_dict(state_dict, on_host=create_cache)
+    logger.info(f"[TIMING] load_torch_state_dict (on_host={create_cache}) took {time.perf_counter() - _t0:.2f}s")
 
     if create_cache:
-        logger.info(f"Writing cache to '{cache_dir}'.")
+        _t0 = time.perf_counter()
+        logger.info(f"[TIMING] Writing cache to '{cache_dir}'...")
         tt_model.save(cache_dir)
-        tt_model.load(cache_dir)  # move to device
+        logger.info(f"[TIMING] tt_model.save took {time.perf_counter() - _t0:.2f}s")
+
+        _t0 = time.perf_counter()
+        tt_model.load(cache_dir)
+        logger.info(f"[TIMING] tt_model.load (move to device after cache write) took {time.perf_counter() - _t0:.2f}s")
+
+    logger.info(f"[TIMING] cache.load_model total took {time.perf_counter() - _t_load_start:.2f}s")
 
 
 def model_cache_dir(


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=fivanovic/additional-loggers)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:fivanovic/additional-loggers)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fivanovic/additional-loggers)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fivanovic/additional-loggers)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fivanovic/additional-loggers)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fivanovic/additional-loggers)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fivanovic/additional-loggers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fivanovic/additional-loggers)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fivanovic/additional-loggers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fivanovic/additional-loggers)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fivanovic/additional-loggers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fivanovic/additional-loggers)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
