### PR TITLE
2x LB Model Bring up Llama 8b DP=16

### DIFF
--- a/.github/workflows/multi-host-physical.yaml
+++ b/.github/workflows/multi-host-physical.yaml
@@ -17,6 +17,11 @@ on:
         required: false
         default: false
         type: boolean
+      bh_lb_2x_multihost:
+        description: 'Run BH-Loudbox 2x multi-host job'
+        required: false
+        default: true
+        type: boolean
       platform:
         required: false
         type: choice
@@ -63,6 +68,59 @@ jobs:
       platform: ${{ inputs.platform || 'Ubuntu 22.04' }}
       enable-lto: ${{ inputs.enable-lto || false }}
       build-wheel: true
+
+  multi-host-bh-lb-2x:
+    if: ${{ github.event.inputs.bh_lb_2x_multihost == 'true' || github.event.schedule == '0 */3 * * *' }}
+    runs-on:
+      # A physical, multi-host BH-Loudbox that's in service
+      - multi-host-bh-lb-2x
+      - arch-blackhole
+      - bare-metal
+      - in-service
+    needs: build-artifact
+    steps:
+      - name: ⬇️ Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: ⬇️ Download Build
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
+        timeout-minutes: 10
+        with:
+          name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      - name: Extract files
+        run: tar --zstd -xvf ttm_any.tar.zst
+      - name: ⬇️ Download Wheel
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
+        timeout-minutes: 10
+        with:
+          name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      - name: Capture runner's home directory
+        id: capture-home
+        run: echo "home=${HOME}" >> $GITHUB_OUTPUT
+      - name: Run tests on multiple hosts
+        uses: ./.github/actions/docker-run
+        timeout-minutes: 60
+        with:
+          docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e PYTHONPATH=${{ github.workspace }}
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=blackhole
+            -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
+            -v /etc/mpirun:/etc/mpirun:ro
+            -v /mnt/MLPerf:/mnt/MLPerf:ro
+            -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
+            --device /dev/tenstorrent
+            --pid=host
+            --hostname=mpirun-host
+          install_wheel: true
+          run_args: |
+            # Setup shared venv and switch to it (handles multi-host race conditions)
+            eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
+            ./tests/scripts/multihost/run_dual_bh_lb_tests.sh
 
   multi-host-t3k:
     if: ${{ github.event.inputs.t3k_multihost == 'true' || github.event.schedule == '0 */3 * * *' }}

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -240,7 +240,7 @@ def slice_sampling_params_for_local_submeshes(sampling_params, batch_size, data_
 
 def get_default_mesh_device_param():
     """
-    Select a safe default mesh size for paramized tests.
+    Select a safe default mesh size for parameterized tests.
 
     In distributed runs, use the global system mesh size from the mesh graph descriptor
     instead of len(get_device_ids()), which can reflect host-local visibility.

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -16,7 +16,6 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.common.sampling import SamplingParams
 from models.common.utility_functions import is_wormhole_b0
 from models.demos.utils.llm_demo_utils import create_benchmark_data, verify_perf
 from models.perf.benchmarking_utils import BenchmarkProfiler
@@ -26,7 +25,7 @@ from models.tt_transformers.tt.common import (
     preprocess_inputs_prefill,
     sample_host,
 )
-from models.tt_transformers.tt.generator import Generator, create_submeshes
+from models.tt_transformers.tt.generator import Generator, SamplingParams, create_submeshes
 from models.tt_transformers.tt.model_config import DecodersPrecision, determine_device_name, parse_decoder_json
 from models.tt_transformers.tt.prefetcher import is_prefetcher_supported
 
@@ -200,6 +199,60 @@ def create_tt_page_table(global_batch_size, data_parallel, paged_attention_confi
     return page_table
 
 
+def submesh_has_local_devices(submesh):
+    """Return True if this submesh has at least one device local to the current host rank."""
+    view = submesh.get_view()
+    return any(
+        view.is_local(ttnn.MeshCoordinate(row, col))
+        for row in range(submesh.shape[0])
+        for col in range(submesh.shape[1])
+    )
+
+
+def get_local_submesh_indices(submesh_devices):
+    """Return indices of submeshes that own at least one local device on this host rank."""
+    return [i for i, submesh in enumerate(submesh_devices) if submesh_has_local_devices(submesh)]
+
+
+def select_local_data_parallel_items(items, batch_size, data_parallel, local_submesh_indices):
+    """Select the per-DP-group slices corresponding to local submeshes."""
+    assert (
+        len(items) >= batch_size * data_parallel
+    ), f"Expected at least {batch_size * data_parallel} items, got {len(items)}"
+    return [item for dp_idx in local_submesh_indices for item in items[dp_idx * batch_size : (dp_idx + 1) * batch_size]]
+
+
+def slice_sampling_params_for_local_submeshes(sampling_params, batch_size, data_parallel, local_submesh_indices):
+    """Slice list-valued sampling params so each host rank keeps only its local DP groups."""
+    result = dict(sampling_params)
+    total_items = batch_size * data_parallel
+
+    for key, value in sampling_params.items():
+        if not isinstance(value, list):
+            continue
+        if len(value) == total_items:
+            result[key] = select_local_data_parallel_items(value, batch_size, data_parallel, local_submesh_indices)
+        elif len(value) == data_parallel:
+            result[key] = [value[i] for i in local_submesh_indices]
+
+    return result
+
+
+def get_default_mesh_device_param():
+    """
+    Select a safe default mesh size for paramized tests.
+
+    In distributed runs, use the global system mesh size from the mesh graph descriptor
+    instead of len(get_device_ids()), which can reflect host-local visibility.
+    """
+    if ttnn.using_distributed_env():
+        try:
+            return ttnn._ttnn.multi_device.SystemMeshDescriptor().shape().mesh_size()
+        except Exception as e:
+            logger.warning(f"Falling back to local device count for default mesh sizing: {e}")
+    return len(ttnn.get_device_ids())
+
+
 def prepare_generator_args(
     num_devices,
     data_parallel,
@@ -214,7 +267,19 @@ def prepare_generator_args(
     use_prefetcher,
     use_hf_rope,
 ):
-    submesh_devices = create_submeshes(mesh_device, data_parallel)
+    all_submesh_devices = create_submeshes(mesh_device, data_parallel)
+    local_submesh_indices = get_local_submesh_indices(all_submesh_devices)
+    submesh_devices = [all_submesh_devices[i] for i in local_submesh_indices]
+
+    if not submesh_devices:
+        raise RuntimeError("No local submeshes available on this host rank for the requested configuration")
+
+    if len(submesh_devices) != len(all_submesh_devices):
+        logger.info(
+            f"Distributed mode detected: using local submeshes {local_submesh_indices} "
+            f"({len(submesh_devices)}/{len(all_submesh_devices)}) on this host rank"
+        )
+
     state_dict = None
 
     # Hybrid requires a model per submesh
@@ -231,11 +296,13 @@ def prepare_generator_args(
         else None
     )
 
+    max_batch_size_per_dp_group = global_batch_size // data_parallel
+
     for submesh in submesh_devices:
         model_args_i, model_i, tt_kv_cache_i, state_dict = create_tt_model(
             submesh,
             instruct=instruct,
-            max_batch_size=global_batch_size // data_parallel,
+            max_batch_size=max_batch_size_per_dp_group,
             optimizations=optimizations,
             max_seq_len=max_seq_len,
             paged_attention_config=paged_attention_config,
@@ -249,9 +316,11 @@ def prepare_generator_args(
         model.append(model_i)
         tt_kv_cache.append(tt_kv_cache_i)
 
+    local_data_parallel = len(submesh_devices)
+    local_batch_size = max_batch_size_per_dp_group * local_data_parallel
     page_table = create_tt_page_table(
-        global_batch_size=global_batch_size,
-        data_parallel=data_parallel,
+        global_batch_size=local_batch_size,
+        data_parallel=local_data_parallel,
         paged_attention_config=paged_attention_config,
     )
     # Host code, safe to reuse tokenizer from the 1st model
@@ -259,7 +328,7 @@ def prepare_generator_args(
         0
     ].tokenizer  # TODO Should we support Data Parallel different models? If so, we need to support multiple tokenizers
     processor = model_args[0].processor
-    return model_args, model, page_table, tt_kv_cache, tokenizer, processor
+    return model_args, model, page_table, tt_kv_cache, tokenizer, processor, local_data_parallel, local_submesh_indices
 
 
 # List of supported Parameters for demo.py
@@ -760,7 +829,7 @@ def prepare_generator_args(
 )
 @pytest.mark.parametrize(
     "device_params",
-    [{"fabric_config": True, "trace_region_size": 50000000, "num_command_queues": 1}],
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D, "trace_region_size": 50000000, "num_command_queues": 1}],
     indirect=True,
 )
 @pytest.mark.parametrize(
@@ -777,7 +846,7 @@ def prepare_generator_args(
             "P150x4": (1, 4),
             "P150x8": (1, 8),
             "BHGLX": (8, 4),
-        }.get(os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids()))
+        }.get(os.environ.get("MESH_DEVICE"), get_default_mesh_device_param())
     ],
     indirect=True,
 )
@@ -813,6 +882,7 @@ def test_demo_text(
     """
     hf_dir = os.getenv("HF_MODEL", "")
     num_devices = mesh_device.get_num_devices() if isinstance(mesh_device, ttnn.MeshDevice) else 1
+
     test_id = request.node.callspec.id
     if is_ci_env:
         if not ci_only:
@@ -930,12 +1000,20 @@ def test_demo_text(
     else:  # Inputs from file
         input_prompts, all_prompts = load_inputs(input_prompts, global_batch_size, instruct)
     profiler.end("loading_inputs")
-
     # To simulate a deployment environment, the demo supports repeating batched prompts.
     # This loop will rotate the prompts between the users for each batch, to simulate users sending different requests
     # If batch_size=1, the same prompt is repeated for each batch
 
-    model_args, model, page_table, tt_kv_cache, tokenizer, processor = prepare_generator_args(
+    (
+        model_args,
+        model,
+        page_table,
+        tt_kv_cache,
+        tokenizer,
+        processor,
+        local_data_parallel,
+        local_submesh_indices,
+    ) = prepare_generator_args(
         num_devices=num_devices,
         data_parallel=data_parallel,
         mesh_device=mesh_device,
@@ -948,6 +1026,12 @@ def test_demo_text(
         num_layers=num_layers,
         use_prefetcher=use_prefetcher,
         use_hf_rope=use_hf_rope,
+    )
+
+    global_batch_size = batch_size * local_data_parallel
+    input_prompts = select_local_data_parallel_items(input_prompts, batch_size, data_parallel, local_submesh_indices)
+    sampling_params = slice_sampling_params_for_local_submeshes(
+        sampling_params, batch_size, data_parallel, local_submesh_indices
     )
 
     # Skip ci-eval tests on P100 devices
@@ -974,8 +1058,13 @@ def test_demo_text(
         if token_accuracy:
             repeat_batch_prompts.append(input_prompts)
         else:
+            global_prompts_for_batch = [all_prompts[(j + i) % len(all_prompts)] for j in range(len(all_prompts))][
+                : batch_size * data_parallel
+            ]
             repeat_batch_prompts.append(
-                [all_prompts[(j + i) % len(all_prompts)] for j in range(len(all_prompts))][:global_batch_size]
+                select_local_data_parallel_items(
+                    global_prompts_for_batch, batch_size, data_parallel, local_submesh_indices
+                )
             )
 
     num_tokens_generated_decode = []

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -829,7 +829,7 @@ def prepare_generator_args(
 )
 @pytest.mark.parametrize(
     "device_params",
-    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D, "trace_region_size": 50000000, "num_command_queues": 1}],
+    [{"fabric_config": True, "trace_region_size": 50000000, "num_command_queues": 1}],
     indirect=True,
 )
 @pytest.mark.parametrize(

--- a/tests/scripts/multihost/run_dual_bh_lb_tests.sh
+++ b/tests/scripts/multihost/run_dual_bh_lb_tests.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+set -eo pipefail
+
+# Exit immediately if ARCH_NAME is not set or empty
+if [ -z "${ARCH_NAME}" ]; then
+  echo "Error: ARCH_NAME is not set. Exiting." >&2
+  exit 1
+fi
+
+run_dual_bh_lb_unit_tests() {
+  # Record the start time
+  fail=0
+  start_time=$(date +%s)
+
+  echo "LOG_METAL: Running run_dual_bh_lb_unit_tests"
+
+  # tcp flags are default for tt-run
+  local mpi_args="--hostfile /etc/mpirun/hostfile"
+  local mpirun_args="$mpi_args --mca btl_tcp_if_exclude docker0,lo"
+  local rank_binding_1x16="tests/tt_metal/distributed/config/bh_lbx2_1x16_rank_bindings.yaml"
+  local rank_binding_dual_bh_lb="tests/tt_metal/distributed/config/dual_bh_lb_rank_bindings.yaml"
+
+  mpirun $mpirun_args -x TT_METAL_HOME=$(pwd) -x LD_LIBRARY_PATH=$(pwd)/build/lib ./build/test/tt_metal/tt_fabric/test_physical_discovery ; fail+=$?
+  mpirun $mpirun_args -x TT_METAL_HOME=$(pwd) -x LD_LIBRARY_PATH=$(pwd)/build/lib ./build/tools/scaleout/run_cluster_validation  --print-connectivity --send-traffic --hard-fail ; fail+=$?
+
+  # These tests are not supported on 2x BH-LB and have been commented out
+  # tt-run --rank-binding "$rank_binding" --mpi-args "$mpi_args" ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/perf_microbenchmark/routing/test_dual_t3k.yaml ; fail+=$?
+  # tt-run --rank-binding "$rank_binding" --mpi-args "$mpi_args" ./build/test/tt_metal/multi_host_fabric_tests ; fail+=$?
+  # tt-run --rank-binding "$rank_binding" --mpi-args "$mpi_args" ./build/test/tt_metal/test_mesh_socket_main --test_config tests/tt_metal/multihost/fabric_tests/mesh_socket_dual_t3k.yaml ; fail+=$?
+  # tt-run --rank-binding "$strict_rank_binding" --mpi-args "$mpi_args" ./build/test/tt_metal/multi_host_fabric_tests ; fail+=$?
+
+  echo "LOG_METAL: Running CCL smoke test for 1x16 rank binding on 2x BH-LB"
+  tt-run --rank-binding "$rank_binding_1x16" --mpi-args "$mpi_args" pytest tests/ttnn/unit_tests/operations/ccl/blackhole_CI/Sys_eng_smoke_tests/test_ccl_smoke_test_lbx2.py ; fail+=$?
+
+  echo "LOG_METAL: Running microbenchmark tests for 1x16 rank binding on 2x BH-LB"
+  tt-run --rank-binding "$rank_binding_1x16" --mpi-args "$mpi_args" ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_stability_short_running.yaml ; fail+=$?
+
+  # Record the end time
+  end_time=$(date +%s)
+  duration=$((end_time - start_time))
+  echo "LOG_METAL: run_dual_bh_lb_unit_tests $duration seconds to complete"
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
+}
+
+run_dual_bh_lb_demo_tests() {
+  # Record the start time
+  fail=0
+  start_time=$(date +%s)
+
+  echo "LOG_METAL: Running run_dual_bh_lb_demo_tests"
+
+  # tcp flags are default for tt-run
+  local mpi_args="--hostfile /etc/mpirun/hostfile"
+  local mpirun_args="$mpi_args --mca btl_tcp_if_exclude docker0,lo"
+  local rank_binding_1x16="tests/tt_metal/distributed/config/bh_lbx2_1x16_rank_bindings.yaml"
+  local rank_binding_dual_bh_lb="tests/tt_metal/distributed/config/dual_bh_lb_rank_bindings.yaml"
+
+  tt-run --rank-binding "$rank_binding_dual_bh_lb" --mpi-args "$mpi_args" \
+    bash -c "export HF_MODEL=/mnt/MLPerf/tt_dnn-models/meta-llama/Llama-3.1-8B-Instruct && \
+             export TT_CACHE_PATH=/mnt/MLPerf/tt_dnn-models/meta-llama/Llama-3.1-8B-Instruct && \
+             pytest models/tt_transformers/demo/simple_text_demo.py -k 'performance and batch-1' --data_parallel 8" ; fail+=$?
+
+  # Record the end time
+  end_time=$(date +%s)
+  duration=$((end_time - start_time))
+  echo "LOG_METAL: run_dual_bh_lb_demo_tests $duration seconds to complete"
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
+}
+
+run_dual_bh_lb_tests() {
+  run_dual_bh_lb_unit_tests
+  run_dual_bh_lb_demo_tests
+}
+
+fail=0
+main() {
+  # For CI pipeline - source func commands but don't execute tests if not invoked directly
+  if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+    echo "Script is being sourced, not executing main function"
+    return 0
+  fi
+
+  if [[ -z "$TT_METAL_HOME" ]]; then
+    echo "Must provide TT_METAL_HOME in environment" 1>&2
+    exit 1
+  fi
+
+  if [[ -z "$ARCH_NAME" ]]; then
+    echo "Must provide ARCH_NAME in environment" 1>&2
+    exit 1
+  fi
+
+  # Run all tests
+  cd $TT_METAL_HOME
+  export PYTHONPATH=$TT_METAL_HOME
+
+  run_dual_bh_lb_tests
+
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
+}
+
+main "$@"

--- a/tests/tt_metal/distributed/config/bh_lbx2_1x16_rank_bindings.yaml
+++ b/tests/tt_metal/distributed/config/bh_lbx2_1x16_rank_bindings.yaml
@@ -1,0 +1,9 @@
+rank_bindings:
+  - rank: 0
+    mesh_id: 0
+    mesh_host_rank: 0
+  - rank: 1
+    mesh_id: 0
+    mesh_host_rank: 1
+
+mesh_graph_desc_path: "tt_metal/fabric/mesh_graph_descriptors/bh_lbx2_1x16_mesh_graph_descriptor.textproto"

--- a/tests/tt_metal/distributed/config/dual_bh_lb_rank_bindings.yaml
+++ b/tests/tt_metal/distributed/config/dual_bh_lb_rank_bindings.yaml
@@ -1,0 +1,9 @@
+rank_bindings:
+  - rank: 0
+    mesh_id: 0
+    mesh_host_rank: 0
+  - rank: 1
+    mesh_id: 1
+    mesh_host_rank: 0
+
+mesh_graph_desc_path: "tt_metal/fabric/mesh_graph_descriptors/dual_bh_lb_mesh_graph_descriptor.textproto"

--- a/tests/tt_metal/distributed/config/quad_bh_lb_rank_bindings.yaml
+++ b/tests/tt_metal/distributed/config/quad_bh_lb_rank_bindings.yaml
@@ -1,0 +1,15 @@
+rank_bindings:
+  - rank: 0
+    mesh_id: 0
+    mesh_host_rank: 0
+  - rank: 1
+    mesh_id: 1
+    mesh_host_rank: 0
+  - rank: 2
+    mesh_id: 2
+    mesh_host_rank: 0
+  - rank: 3
+    mesh_id: 3
+    mesh_host_rank: 0
+
+mesh_graph_desc_path: "tt_metal/fabric/mesh_graph_descriptors/quad_bh_lb_mesh_graph_descriptor.textproto"

--- a/tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/bh_lbx2_1x16_cluster_desc/bh_lbx2_1x16_cluster_desc_bh-lb-02_slot_0.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/bh_lbx2_1x16_cluster_desc/bh_lbx2_1x16_cluster_desc_bh-lb-02_slot_0.yaml
@@ -1,0 +1,306 @@
+arch:
+  0: blackhole
+  1: blackhole
+  2: blackhole
+  3: blackhole
+  4: blackhole
+  5: blackhole
+  6: blackhole
+  7: blackhole
+chips:
+  {}
+chip_unique_ids:
+  7: 143238002247072
+  6: 143238002246976
+  5: 143238002249376
+  4: 143238002247104
+  3: 143238002259552
+  2: 143238002259456
+  1: 143238002248448
+  0: 143238002258400
+ethernet_connections:
+  -
+    - chip: 0
+      chan: 4
+    - chip: 1
+      chan: 7
+  -
+    - chip: 0
+      chan: 5
+    - chip: 2
+      chan: 6
+  -
+    - chip: 0
+      chan: 6
+    - chip: 1
+      chan: 5
+  -
+    - chip: 0
+      chan: 7
+    - chip: 2
+      chan: 4
+  -
+    - chip: 0
+      chan: 8
+    - chip: 4
+      chan: 11
+  -
+    - chip: 0
+      chan: 10
+    - chip: 4
+      chan: 9
+  -
+    - chip: 1
+      chan: 8
+    - chip: 5
+      chan: 11
+  -
+    - chip: 1
+      chan: 10
+    - chip: 5
+      chan: 9
+  -
+    - chip: 2
+      chan: 5
+    - chip: 3
+      chan: 6
+  -
+    - chip: 2
+      chan: 7
+    - chip: 3
+      chan: 4
+  -
+    - chip: 2
+      chan: 8
+    - chip: 6
+      chan: 11
+  -
+    - chip: 2
+      chan: 10
+    - chip: 6
+      chan: 9
+  -
+    - chip: 3
+      chan: 8
+    - chip: 7
+      chan: 11
+  -
+    - chip: 3
+      chan: 10
+    - chip: 7
+      chan: 9
+  -
+    - chip: 4
+      chan: 4
+    - chip: 5
+      chan: 7
+  -
+    - chip: 4
+      chan: 5
+    - chip: 6
+      chan: 6
+  -
+    - chip: 4
+      chan: 6
+    - chip: 5
+      chan: 5
+  -
+    - chip: 4
+      chan: 7
+    - chip: 6
+      chan: 4
+  -
+    - chip: 6
+      chan: 5
+    - chip: 7
+      chan: 6
+  -
+    - chip: 6
+      chan: 7
+    - chip: 7
+      chan: 4
+ethernet_connections_to_remote_devices:
+  -
+    - chip: 3
+      chan: 11
+    - remote_chip_id: 143238002250816
+      chan: 8
+  -
+    - chip: 3
+      chan: 9
+    - remote_chip_id: 143238002250816
+      chan: 10
+  -
+    - chip: 2
+      chan: 11
+    - remote_chip_id: 143238002260768
+      chan: 8
+  -
+    - chip: 2
+      chan: 9
+    - remote_chip_id: 143238002260768
+      chan: 10
+  -
+    - chip: 0
+      chan: 11
+    - remote_chip_id: 143238002257728
+      chan: 8
+  -
+    - chip: 0
+      chan: 9
+    - remote_chip_id: 143238002257728
+      chan: 10
+  -
+    - chip: 1
+      chan: 11
+    - remote_chip_id: 143238002259488
+      chan: 8
+  -
+    - chip: 1
+      chan: 9
+    - remote_chip_id: 143238002259488
+      chan: 10
+chips_with_mmio:
+  - 0: 2
+  - 1: 3
+  - 2: 1
+  - 3: 0
+  - 4: 6
+  - 5: 7
+  - 6: 5
+  - 7: 4
+io_device_type: PCIe
+harvesting:
+  0:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+  1:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+  2:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+  3:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+  4:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+  5:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+  6:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+  7:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+chip_to_boardtype:
+  0: p150
+  1: p150
+  2: p150
+  3: p150
+  4: p150
+  5: p150
+  6: p150
+  7: p150
+chip_to_bus_id:
+  0: 0x0001
+  1: 0x0021
+  2: 0x0041
+  3: 0x0061
+  4: 0x0081
+  5: 0x00a1
+  6: 0x00c1
+  7: 0x00e1
+boards:
+  -
+    - board_id: 4476187570218
+    - board_type: p150
+    - chips:
+        - 6
+  -
+    - board_id: 4476187570221
+    - board_type: p150
+    - chips:
+        - 7
+  -
+    - board_id: 4476187570222
+    - board_type: p150
+    - chips:
+        - 4
+  -
+    - board_id: 4476187570264
+    - board_type: p150
+    - chips:
+        - 1
+  -
+    - board_id: 4476187570293
+    - board_type: p150
+    - chips:
+        - 5
+  -
+    - board_id: 4476187570575
+    - board_type: p150
+    - chips:
+        - 0
+  -
+    - board_id: 4476187570608
+    - board_type: p150
+    - chips:
+        - 2
+  -
+    - board_id: 4476187570611
+    - board_type: p150
+    - chips:
+        - 3
+asic_locations:
+  0: 0
+  1: 0
+  2: 0
+  3: 0
+  4: 0
+  5: 0
+  6: 0
+  7: 0
+chip_pci_bdfs:
+  0: 0000:01:00.0
+  1: 0000:21:00.0
+  2: 0000:41:00.0
+  3: 0000:61:00.0
+  4: 0000:81:00.0
+  5: 0000:a1:00.0
+  6: 0000:c1:00.0
+  7: 0000:e1:00.0

--- a/tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/bh_lbx2_1x16_cluster_desc/bh_lbx2_1x16_cluster_desc_bh-lb-03_slot_0.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/bh_lbx2_1x16_cluster_desc/bh_lbx2_1x16_cluster_desc_bh-lb-03_slot_0.yaml
@@ -1,0 +1,306 @@
+arch:
+  0: blackhole
+  1: blackhole
+  2: blackhole
+  3: blackhole
+  4: blackhole
+  5: blackhole
+  6: blackhole
+  7: blackhole
+chips:
+  {}
+chip_unique_ids:
+  7: 143238002250816
+  6: 143238002260768
+  5: 143238002259488
+  4: 143238002257728
+  3: 143238002257472
+  2: 143238002257504
+  1: 143238002257536
+  0: 143238002251040
+ethernet_connections:
+  -
+    - chip: 0
+      chan: 4
+    - chip: 1
+      chan: 7
+  -
+    - chip: 0
+      chan: 5
+    - chip: 2
+      chan: 6
+  -
+    - chip: 0
+      chan: 6
+    - chip: 1
+      chan: 5
+  -
+    - chip: 0
+      chan: 7
+    - chip: 2
+      chan: 4
+  -
+    - chip: 0
+      chan: 8
+    - chip: 4
+      chan: 11
+  -
+    - chip: 0
+      chan: 10
+    - chip: 4
+      chan: 9
+  -
+    - chip: 1
+      chan: 8
+    - chip: 5
+      chan: 11
+  -
+    - chip: 1
+      chan: 10
+    - chip: 5
+      chan: 9
+  -
+    - chip: 2
+      chan: 5
+    - chip: 3
+      chan: 6
+  -
+    - chip: 2
+      chan: 7
+    - chip: 3
+      chan: 4
+  -
+    - chip: 2
+      chan: 8
+    - chip: 6
+      chan: 11
+  -
+    - chip: 2
+      chan: 10
+    - chip: 6
+      chan: 9
+  -
+    - chip: 3
+      chan: 8
+    - chip: 7
+      chan: 11
+  -
+    - chip: 3
+      chan: 10
+    - chip: 7
+      chan: 9
+  -
+    - chip: 4
+      chan: 4
+    - chip: 5
+      chan: 7
+  -
+    - chip: 4
+      chan: 5
+    - chip: 6
+      chan: 6
+  -
+    - chip: 4
+      chan: 6
+    - chip: 5
+      chan: 5
+  -
+    - chip: 4
+      chan: 7
+    - chip: 6
+      chan: 4
+  -
+    - chip: 6
+      chan: 5
+    - chip: 7
+      chan: 6
+  -
+    - chip: 6
+      chan: 7
+    - chip: 7
+      chan: 4
+ethernet_connections_to_remote_devices:
+  -
+    - chip: 6
+      chan: 10
+    - remote_chip_id: 143238002259456
+      chan: 9
+  -
+    - chip: 6
+      chan: 8
+    - remote_chip_id: 143238002259456
+      chan: 11
+  -
+    - chip: 5
+      chan: 10
+    - remote_chip_id: 143238002248448
+      chan: 9
+  -
+    - chip: 5
+      chan: 8
+    - remote_chip_id: 143238002248448
+      chan: 11
+  -
+    - chip: 4
+      chan: 10
+    - remote_chip_id: 143238002258400
+      chan: 9
+  -
+    - chip: 4
+      chan: 8
+    - remote_chip_id: 143238002258400
+      chan: 11
+  -
+    - chip: 7
+      chan: 10
+    - remote_chip_id: 143238002259552
+      chan: 9
+  -
+    - chip: 7
+      chan: 8
+    - remote_chip_id: 143238002259552
+      chan: 11
+chips_with_mmio:
+  - 0: 2
+  - 1: 3
+  - 2: 1
+  - 3: 0
+  - 4: 6
+  - 5: 7
+  - 6: 5
+  - 7: 4
+io_device_type: PCIe
+harvesting:
+  0:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+  1:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+  2:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+  3:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+  4:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+  5:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+  6:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+  7:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+chip_to_boardtype:
+  0: p150
+  1: p150
+  2: p150
+  3: p150
+  4: p150
+  5: p150
+  6: p150
+  7: p150
+chip_to_bus_id:
+  0: 0x0001
+  1: 0x0021
+  2: 0x0041
+  3: 0x0061
+  4: 0x0081
+  5: 0x00a1
+  6: 0x00c1
+  7: 0x00e1
+boards:
+  -
+    - board_id: 4476187570338
+    - board_type: p150
+    - chips:
+        - 7
+  -
+    - board_id: 4476187570345
+    - board_type: p150
+    - chips:
+        - 0
+  -
+    - board_id: 4476187570546
+    - board_type: p150
+    - chips:
+        - 3
+  -
+    - board_id: 4476187570547
+    - board_type: p150
+    - chips:
+        - 2
+  -
+    - board_id: 4476187570548
+    - board_type: p150
+    - chips:
+        - 1
+  -
+    - board_id: 4476187570554
+    - board_type: p150
+    - chips:
+        - 4
+  -
+    - board_id: 4476187570609
+    - board_type: p150
+    - chips:
+        - 5
+  -
+    - board_id: 4476187570649
+    - board_type: p150
+    - chips:
+        - 6
+asic_locations:
+  0: 0
+  1: 0
+  2: 0
+  3: 0
+  4: 0
+  5: 0
+  6: 0
+  7: 0
+chip_pci_bdfs:
+  0: 0000:01:00.0
+  1: 0000:21:00.0
+  2: 0000:41:00.0
+  3: 0000:61:00.0
+  4: 0000:81:00.0
+  5: 0000:a1:00.0
+  6: 0000:c1:00.0
+  7: 0000:e1:00.0

--- a/tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/bh_lbx2_1x16_cluster_desc_mapping.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/bh_lbx2_1x16_cluster_desc_mapping.yaml
@@ -1,0 +1,3 @@
+rank_to_cluster_mock_cluster_desc:
+  0: "tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/bh_lbx2_1x16_cluster_desc/bh_lbx2_1x16_cluster_desc_bh-lb-02_slot_0.yaml"
+  1: "tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/bh_lbx2_1x16_cluster_desc/bh_lbx2_1x16_cluster_desc_bh-lb-03_slot_0.yaml"

--- a/tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/dual_bh_lb_cluster_desc/dual_bh_lb_cluster_desc_bh-lb-02_slot_0.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/dual_bh_lb_cluster_desc/dual_bh_lb_cluster_desc_bh-lb-02_slot_0.yaml
@@ -1,0 +1,306 @@
+arch:
+  0: blackhole
+  1: blackhole
+  2: blackhole
+  3: blackhole
+  4: blackhole
+  5: blackhole
+  6: blackhole
+  7: blackhole
+chips:
+  {}
+chip_unique_ids:
+  7: 143238002247072
+  6: 143238002246976
+  5: 143238002249376
+  4: 143238002247104
+  3: 143238002259552
+  2: 143238002259456
+  1: 143238002248448
+  0: 143238002258400
+ethernet_connections:
+  -
+    - chip: 0
+      chan: 4
+    - chip: 1
+      chan: 7
+  -
+    - chip: 0
+      chan: 5
+    - chip: 2
+      chan: 6
+  -
+    - chip: 0
+      chan: 6
+    - chip: 1
+      chan: 5
+  -
+    - chip: 0
+      chan: 7
+    - chip: 2
+      chan: 4
+  -
+    - chip: 0
+      chan: 8
+    - chip: 4
+      chan: 11
+  -
+    - chip: 0
+      chan: 10
+    - chip: 4
+      chan: 9
+  -
+    - chip: 1
+      chan: 8
+    - chip: 5
+      chan: 11
+  -
+    - chip: 1
+      chan: 10
+    - chip: 5
+      chan: 9
+  -
+    - chip: 2
+      chan: 5
+    - chip: 3
+      chan: 6
+  -
+    - chip: 2
+      chan: 7
+    - chip: 3
+      chan: 4
+  -
+    - chip: 2
+      chan: 8
+    - chip: 6
+      chan: 11
+  -
+    - chip: 2
+      chan: 10
+    - chip: 6
+      chan: 9
+  -
+    - chip: 3
+      chan: 8
+    - chip: 7
+      chan: 11
+  -
+    - chip: 3
+      chan: 10
+    - chip: 7
+      chan: 9
+  -
+    - chip: 4
+      chan: 4
+    - chip: 5
+      chan: 7
+  -
+    - chip: 4
+      chan: 5
+    - chip: 6
+      chan: 6
+  -
+    - chip: 4
+      chan: 6
+    - chip: 5
+      chan: 5
+  -
+    - chip: 4
+      chan: 7
+    - chip: 6
+      chan: 4
+  -
+    - chip: 6
+      chan: 5
+    - chip: 7
+      chan: 6
+  -
+    - chip: 6
+      chan: 7
+    - chip: 7
+      chan: 4
+ethernet_connections_to_remote_devices:
+  -
+    - chip: 3
+      chan: 11
+    - remote_chip_id: 143238002250816
+      chan: 8
+  -
+    - chip: 3
+      chan: 9
+    - remote_chip_id: 143238002250816
+      chan: 10
+  -
+    - chip: 2
+      chan: 11
+    - remote_chip_id: 143238002260768
+      chan: 8
+  -
+    - chip: 2
+      chan: 9
+    - remote_chip_id: 143238002260768
+      chan: 10
+  -
+    - chip: 0
+      chan: 11
+    - remote_chip_id: 143238002257728
+      chan: 8
+  -
+    - chip: 0
+      chan: 9
+    - remote_chip_id: 143238002257728
+      chan: 10
+  -
+    - chip: 1
+      chan: 11
+    - remote_chip_id: 143238002259488
+      chan: 8
+  -
+    - chip: 1
+      chan: 9
+    - remote_chip_id: 143238002259488
+      chan: 10
+chips_with_mmio:
+  - 0: 2
+  - 1: 3
+  - 2: 1
+  - 3: 0
+  - 4: 6
+  - 5: 7
+  - 6: 5
+  - 7: 4
+io_device_type: PCIe
+harvesting:
+  0:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+  1:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+  2:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+  3:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+  4:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+  5:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+  6:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+  7:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+chip_to_boardtype:
+  0: p150
+  1: p150
+  2: p150
+  3: p150
+  4: p150
+  5: p150
+  6: p150
+  7: p150
+chip_to_bus_id:
+  0: 0x0001
+  1: 0x0021
+  2: 0x0041
+  3: 0x0061
+  4: 0x0081
+  5: 0x00a1
+  6: 0x00c1
+  7: 0x00e1
+boards:
+  -
+    - board_id: 4476187570218
+    - board_type: p150
+    - chips:
+        - 6
+  -
+    - board_id: 4476187570221
+    - board_type: p150
+    - chips:
+        - 7
+  -
+    - board_id: 4476187570222
+    - board_type: p150
+    - chips:
+        - 4
+  -
+    - board_id: 4476187570264
+    - board_type: p150
+    - chips:
+        - 1
+  -
+    - board_id: 4476187570293
+    - board_type: p150
+    - chips:
+        - 5
+  -
+    - board_id: 4476187570575
+    - board_type: p150
+    - chips:
+        - 0
+  -
+    - board_id: 4476187570608
+    - board_type: p150
+    - chips:
+        - 2
+  -
+    - board_id: 4476187570611
+    - board_type: p150
+    - chips:
+        - 3
+asic_locations:
+  0: 0
+  1: 0
+  2: 0
+  3: 0
+  4: 0
+  5: 0
+  6: 0
+  7: 0
+chip_pci_bdfs:
+  0: 0000:01:00.0
+  1: 0000:21:00.0
+  2: 0000:41:00.0
+  3: 0000:61:00.0
+  4: 0000:81:00.0
+  5: 0000:a1:00.0
+  6: 0000:c1:00.0
+  7: 0000:e1:00.0

--- a/tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/dual_bh_lb_cluster_desc/dual_bh_lb_cluster_desc_bh-lb-03_slot_0.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/dual_bh_lb_cluster_desc/dual_bh_lb_cluster_desc_bh-lb-03_slot_0.yaml
@@ -1,0 +1,306 @@
+arch:
+  0: blackhole
+  1: blackhole
+  2: blackhole
+  3: blackhole
+  4: blackhole
+  5: blackhole
+  6: blackhole
+  7: blackhole
+chips:
+  {}
+chip_unique_ids:
+  7: 143238002250816
+  6: 143238002260768
+  5: 143238002259488
+  4: 143238002257728
+  3: 143238002257472
+  2: 143238002257504
+  1: 143238002257536
+  0: 143238002251040
+ethernet_connections:
+  -
+    - chip: 0
+      chan: 4
+    - chip: 1
+      chan: 7
+  -
+    - chip: 0
+      chan: 5
+    - chip: 2
+      chan: 6
+  -
+    - chip: 0
+      chan: 6
+    - chip: 1
+      chan: 5
+  -
+    - chip: 0
+      chan: 7
+    - chip: 2
+      chan: 4
+  -
+    - chip: 0
+      chan: 8
+    - chip: 4
+      chan: 11
+  -
+    - chip: 0
+      chan: 10
+    - chip: 4
+      chan: 9
+  -
+    - chip: 1
+      chan: 8
+    - chip: 5
+      chan: 11
+  -
+    - chip: 1
+      chan: 10
+    - chip: 5
+      chan: 9
+  -
+    - chip: 2
+      chan: 5
+    - chip: 3
+      chan: 6
+  -
+    - chip: 2
+      chan: 7
+    - chip: 3
+      chan: 4
+  -
+    - chip: 2
+      chan: 8
+    - chip: 6
+      chan: 11
+  -
+    - chip: 2
+      chan: 10
+    - chip: 6
+      chan: 9
+  -
+    - chip: 3
+      chan: 8
+    - chip: 7
+      chan: 11
+  -
+    - chip: 3
+      chan: 10
+    - chip: 7
+      chan: 9
+  -
+    - chip: 4
+      chan: 4
+    - chip: 5
+      chan: 7
+  -
+    - chip: 4
+      chan: 5
+    - chip: 6
+      chan: 6
+  -
+    - chip: 4
+      chan: 6
+    - chip: 5
+      chan: 5
+  -
+    - chip: 4
+      chan: 7
+    - chip: 6
+      chan: 4
+  -
+    - chip: 6
+      chan: 5
+    - chip: 7
+      chan: 6
+  -
+    - chip: 6
+      chan: 7
+    - chip: 7
+      chan: 4
+ethernet_connections_to_remote_devices:
+  -
+    - chip: 6
+      chan: 10
+    - remote_chip_id: 143238002259456
+      chan: 9
+  -
+    - chip: 6
+      chan: 8
+    - remote_chip_id: 143238002259456
+      chan: 11
+  -
+    - chip: 5
+      chan: 10
+    - remote_chip_id: 143238002248448
+      chan: 9
+  -
+    - chip: 5
+      chan: 8
+    - remote_chip_id: 143238002248448
+      chan: 11
+  -
+    - chip: 4
+      chan: 10
+    - remote_chip_id: 143238002258400
+      chan: 9
+  -
+    - chip: 4
+      chan: 8
+    - remote_chip_id: 143238002258400
+      chan: 11
+  -
+    - chip: 7
+      chan: 10
+    - remote_chip_id: 143238002259552
+      chan: 9
+  -
+    - chip: 7
+      chan: 8
+    - remote_chip_id: 143238002259552
+      chan: 11
+chips_with_mmio:
+  - 0: 2
+  - 1: 3
+  - 2: 1
+  - 3: 0
+  - 4: 6
+  - 5: 7
+  - 6: 5
+  - 7: 4
+io_device_type: PCIe
+harvesting:
+  0:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+  1:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+  2:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+  3:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+  4:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+  5:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+  6:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+  7:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+chip_to_boardtype:
+  0: p150
+  1: p150
+  2: p150
+  3: p150
+  4: p150
+  5: p150
+  6: p150
+  7: p150
+chip_to_bus_id:
+  0: 0x0001
+  1: 0x0021
+  2: 0x0041
+  3: 0x0061
+  4: 0x0081
+  5: 0x00a1
+  6: 0x00c1
+  7: 0x00e1
+boards:
+  -
+    - board_id: 4476187570338
+    - board_type: p150
+    - chips:
+        - 7
+  -
+    - board_id: 4476187570345
+    - board_type: p150
+    - chips:
+        - 0
+  -
+    - board_id: 4476187570546
+    - board_type: p150
+    - chips:
+        - 3
+  -
+    - board_id: 4476187570547
+    - board_type: p150
+    - chips:
+        - 2
+  -
+    - board_id: 4476187570548
+    - board_type: p150
+    - chips:
+        - 1
+  -
+    - board_id: 4476187570554
+    - board_type: p150
+    - chips:
+        - 4
+  -
+    - board_id: 4476187570609
+    - board_type: p150
+    - chips:
+        - 5
+  -
+    - board_id: 4476187570649
+    - board_type: p150
+    - chips:
+        - 6
+asic_locations:
+  0: 0
+  1: 0
+  2: 0
+  3: 0
+  4: 0
+  5: 0
+  6: 0
+  7: 0
+chip_pci_bdfs:
+  0: 0000:01:00.0
+  1: 0000:21:00.0
+  2: 0000:41:00.0
+  3: 0000:61:00.0
+  4: 0000:81:00.0
+  5: 0000:a1:00.0
+  6: 0000:c1:00.0
+  7: 0000:e1:00.0

--- a/tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/dual_bh_lb_cluster_desc_mapping.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/dual_bh_lb_cluster_desc_mapping.yaml
@@ -1,0 +1,3 @@
+rank_to_cluster_mock_cluster_desc:
+  0: "tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/dual_bh_lb_cluster_desc/dual_bh_lb_cluster_desc_bh-lb-02_slot_0.yaml"
+  1: "tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/dual_bh_lb_cluster_desc/dual_bh_lb_cluster_desc_bh-lb-03_slot_0.yaml"

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/Sys_eng_smoke_tests/test_ccl_smoke_test_lbx2.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/Sys_eng_smoke_tests/test_ccl_smoke_test_lbx2.py
@@ -6,9 +6,8 @@ import pytest
 import ttnn
 
 from tests.nightly.t3000.ccl.test_minimal_all_gather_async import run_all_gather_impl
-from models.common.utility_functions import skip_for_wormhole_b0, run_for_n_dev
+from models.common.utility_functions import skip_for_wormhole_b0
 from tests.ttnn.unit_tests.operations.ccl.blackhole_CI.box.nightly.test_all_gather_nightly import validate_test
-from conftest import get_updated_device_params, set_fabric, reset_fabric
 
 
 # Test for 1x16 mesh (16 devices in a row)

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/Sys_eng_smoke_tests/test_ccl_smoke_test_lbx2.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/Sys_eng_smoke_tests/test_ccl_smoke_test_lbx2.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import ttnn
+
+from tests.nightly.t3000.ccl.test_minimal_all_gather_async import run_all_gather_impl
+from models.common.utility_functions import skip_for_wormhole_b0, run_for_n_dev
+from tests.ttnn.unit_tests.operations.ccl.blackhole_CI.box.nightly.test_all_gather_nightly import validate_test
+from conftest import get_updated_device_params, set_fabric, reset_fabric
+
+
+# Test for 1x16 mesh (16 devices in a row)
+@skip_for_wormhole_b0()
+@pytest.mark.parametrize("num_links", [2])
+@pytest.mark.parametrize(
+    "num_devices, ag_output_shape, dim, layout, all_gather_topology, cluster_axis",
+    [
+        (16, [1, 1, 12000, 32768], 3, ttnn.TILE_LAYOUT, ttnn.Topology.Linear, 1),
+    ],
+    ids=[
+        "1x16_row_test",
+    ],
+)
+@pytest.mark.parametrize(
+    "ag_input_dtype",
+    [
+        ttnn.bfloat16,
+    ],
+    ids=[
+        "bfloat16",
+    ],
+)
+@pytest.mark.parametrize(
+    "mem_config_input, mem_config_ag",
+    [
+        (
+            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
+            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
+        ),
+    ],
+    ids=[
+        "DRAM_ONLY",
+    ],
+)
+@pytest.mark.parametrize(
+    "enable_trace, num_iters",
+    [
+        (False, 1),
+    ],
+    ids=["non-trace"],
+)
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_2D, "trace_region_size": 90112}),
+    ],
+    indirect=["device_params"],
+    ids=["fabric"],
+)
+@pytest.mark.parametrize("chunks_per_sync", [20])
+@pytest.mark.parametrize("num_workers_per_link", [2])
+@pytest.mark.parametrize("num_buffers_per_channel", [2])
+@pytest.mark.parametrize("mesh_device", [pytest.param((1, 16), id="1x16_grid")], indirect=True)
+def test_ccl_ddr_smoke_test_1x16(
+    mesh_device,
+    num_devices,
+    ag_output_shape,
+    cluster_axis,
+    dim,
+    num_links,
+    ag_input_dtype,
+    layout,
+    mem_config_input,
+    mem_config_ag,
+    enable_trace,
+    all_gather_topology,
+    num_iters,
+    chunks_per_sync,
+    num_workers_per_link,
+    num_buffers_per_channel,
+):
+    validate_test(num_devices, all_gather_topology, mesh_device.shape, cluster_axis)
+    submesh_device = mesh_device.create_submesh(ttnn.MeshShape((1, num_devices)))
+    run_all_gather_impl(
+        submesh_device,
+        num_devices,
+        ag_output_shape,
+        dim,
+        num_links,
+        ag_input_dtype,
+        layout,
+        mem_config_input,
+        mem_config_ag,
+        all_gather_topology=all_gather_topology,
+        enable_trace=enable_trace,
+        num_iters=num_iters,
+        cluster_axis=cluster_axis,
+        chunks_per_sync=chunks_per_sync,
+        num_workers_per_link=num_workers_per_link,
+        num_buffers_per_channel=num_buffers_per_channel,
+        allowed_pcc=0.9999,
+    )
+    ttnn.ReadDeviceProfiler(submesh_device)

--- a/tt_metal/fabric/mesh_graph_descriptors/bh_lbx2_1x16_mesh_graph_descriptor.textproto
+++ b/tt_metal/fabric/mesh_graph_descriptors/bh_lbx2_1x16_mesh_graph_descriptor.textproto
@@ -1,5 +1,5 @@
 # --- Meshes ---------------------------------------------------------------
-# Two independent 1x8 meshes, one per host (host 0 gets mesh_id 0, host 1 gets mesh_id 1)
+# One 1x16 mesh spanning 2 hosts (host 0 and host 1 share mesh_id 0)
 mesh_descriptors {
   name: "M0"
   arch: BLACKHOLE

--- a/tt_metal/fabric/mesh_graph_descriptors/bh_lbx2_1x16_mesh_graph_descriptor.textproto
+++ b/tt_metal/fabric/mesh_graph_descriptors/bh_lbx2_1x16_mesh_graph_descriptor.textproto
@@ -1,0 +1,15 @@
+# --- Meshes ---------------------------------------------------------------
+# Two independent 1x8 meshes, one per host (host 0 gets mesh_id 0, host 1 gets mesh_id 1)
+mesh_descriptors {
+  name: "M0"
+  arch: BLACKHOLE
+  device_topology { dims: [ 1, 16 ] }
+  host_topology   { dims: [ 1, 2 ] }
+  channels {
+    count: 2
+    policy: RELAXED
+  }
+}
+
+# --- Instantiation ----------------------------------------------------------
+top_level_instance { mesh { mesh_descriptor: "M0" mesh_id: 0 } }

--- a/tt_metal/fabric/mesh_graph_descriptors/dual_bh_lb_mesh_graph_descriptor.textproto
+++ b/tt_metal/fabric/mesh_graph_descriptors/dual_bh_lb_mesh_graph_descriptor.textproto
@@ -1,0 +1,23 @@
+# --- Meshes ---------------------------------------------------------------
+# Two independent 1x8 meshes, one per host (host 0 gets mesh_id 0, host 1 gets mesh_id 1)
+mesh_descriptors {
+  name: "M0"
+  arch: BLACKHOLE
+  device_topology { dims: [ 1, 8 ] }
+  host_topology   { dims: [ 1, 1 ] }
+  channels {
+    count: 2
+    policy: RELAXED
+  }
+}
+
+# --- Graph (groups the two meshes) ----------------------------------------
+graph_descriptors {
+  name: "G0"
+  type: "FABRIC"
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+}
+
+# --- Instantiation -------------------------------------------------------
+top_level_instance { graph { graph_descriptor: "G0" graph_id: 0 } }

--- a/tt_metal/fabric/mesh_graph_descriptors/dual_bh_lb_mesh_graph_descriptor.textproto
+++ b/tt_metal/fabric/mesh_graph_descriptors/dual_bh_lb_mesh_graph_descriptor.textproto
@@ -1,9 +1,9 @@
 # --- Meshes ---------------------------------------------------------------
-# Two independent 1x8 meshes, one per host (host 0 gets mesh_id 0, host 1 gets mesh_id 1)
+# Two independent 2x4 meshes, one per host (host 0 gets mesh_id 0, host 1 gets mesh_id 1)
 mesh_descriptors {
   name: "M0"
   arch: BLACKHOLE
-  device_topology { dims: [ 1, 8 ] }
+  device_topology { dims: [ 2, 4 ] }
   host_topology   { dims: [ 1, 1 ] }
   channels {
     count: 2

--- a/tt_metal/fabric/mesh_graph_descriptors/quad_bh_lb_mesh_graph_descriptor.textproto
+++ b/tt_metal/fabric/mesh_graph_descriptors/quad_bh_lb_mesh_graph_descriptor.textproto
@@ -1,0 +1,25 @@
+# --- Meshes ---------------------------------------------------------------
+# Four independent 2x4 meshes, one per host
+mesh_descriptors {
+  name: "M0"
+  arch: BLACKHOLE
+  device_topology { dims: [ 2, 4 ] }
+  host_topology   { dims: [ 1, 1 ] }
+  channels {
+    count: 2
+    policy: RELAXED
+  }
+}
+
+# --- Graph (groups the four meshes) ---------------------------------------
+graph_descriptors {
+  name: "G0"
+  type: "FABRIC"
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 2 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 3 } }
+}
+
+# --- Instantiation -------------------------------------------------------
+top_level_instance { graph { graph_descriptor: "G0" graph_id: 0 } }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/39122

### Problem description
Enabling running DP=16 (DP=8 on each host) through tt transformers

### What's changed
- new CCL smoke test for 1 x 16 mesh device
- created helper functions in `simple_text_demo` to allow each host to see which sub meshes are remote or local
- Added rank bindings and MGD for 2 types of possible workloads
1. 1 x 16 as a global mesh device  (for this workload this PR has a CCL smoke test that runs all gather tested with this configuration)
To run (change the host names accordingly):
```
tt-run \
  --tcp-interface cnx1 \
  --rank-binding $TT_METAL_HOME/tests/tt_metal/distributed/config/bh_lbx2_1x16_rank_bindings.yaml \
  --mpi-args "--host f02cs05,f02cs06" \
  pytest $TT_METAL_HOME/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/Sys_eng_smoke_tests/test_ccl_smoke_test_lbx2.py
```

2. 1 x 8 as 2 independent meshes (for this first pass of model validation we have validated that we can run DP=16 or DP=8 on 2 hosts with this MGD)
To run:
```
tt-run \
  --tcp-interface cnx1 \
  --rank-binding $TT_METAL_HOME/tests/tt_metal/distributed/config/dual_bh_lb_rank_bindings.yaml \
  --mpi-args "--host f02cs05,f02cs06" \
  pytest models/tt_transformers/demo/simple_text_demo.py -k "performance and batch-1" --data_parallel 8  
```

### Checklist
- BH demo tests