### PR TITLE
refine fast neighbour exchange enable to work when VC1 is active

### DIFF
--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -1269,10 +1269,10 @@ FabricEriscDatamoverBuilder::CompileTimeArgs FabricEriscDatamoverBuilder::get_co
     }
 
     // Credit amortization named compile-time args
-    // Only enabled when there is a single sender channel (common 1D case)
+    // Only enabled when there is a single sender channel on VC0 (common 1D case)
     uint32_t sender_amort_freq = 0;
     uint32_t receiver_amort_freq = 0;
-    if (num_sender_channels == 1) {
+    if (actual_sender_channels_vc0 == 1) {
         auto* static_alloc =
             dynamic_cast<tt::tt_fabric::FabricStaticSizedChannelsAllocator*>(config.channel_allocator.get());
         if (static_alloc != nullptr) {

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -1269,7 +1269,6 @@ FabricEriscDatamoverBuilder::CompileTimeArgs FabricEriscDatamoverBuilder::get_co
     }
 
     // Credit amortization named compile-time args
-    // Only enabled when there is a single sender channel on VC0 (common 1D case)
     uint32_t sender_amort_freq = 0;
     uint32_t receiver_amort_freq = 0;
     if (actual_sender_channels_vc0 == 1) {

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -2300,7 +2300,7 @@ FORCE_INLINE void run_fabric_edm_main_loop(
                             local_fabric_telemetry);
 #endif
                     }
-                } else {
+                } else {  // non-speedy mode
                     router_invalidate_l1_cache<ENABLE_RISC_CPU_DATA_CACHE>();
                     // Capture these to see if we made progress
 
@@ -2395,79 +2395,81 @@ FORCE_INLINE void run_fabric_edm_main_loop(
                                 inner_loop_perf_telemetry_collector,
                                 local_fabric_telemetry);
                         }
-#if defined(FABRIC_2D_VC1_SERVICED)
-                        tx_progress |= run_sender_channel_step<
-                            VC1_RECEIVER_CHANNEL,
-                            ACTUAL_VC0_SENDER_CHANNELS,
-                            ENABLE_FIRST_LEVEL_ACK_VC1>(
-                            local_sender_channels,
-                            local_sender_channel_worker_interfaces,
-                            outbound_to_receiver_channel_pointer_ch1,
-                            remote_receiver_channels,
-                            channel_connection_established,
-                            local_sender_channel_free_slots_stream_ids,
-                            sender_channel_from_receiver_credits,
-                            inner_loop_perf_telemetry_collector,
-                            local_fabric_telemetry);
-                        tx_progress |= run_sender_channel_step<
-                            VC1_RECEIVER_CHANNEL,
-                            ACTUAL_VC0_SENDER_CHANNELS + 1,
-                            ENABLE_FIRST_LEVEL_ACK_VC1>(
-                            local_sender_channels,
-                            local_sender_channel_worker_interfaces,
-                            outbound_to_receiver_channel_pointer_ch1,
-                            remote_receiver_channels,
-                            channel_connection_established,
-                            local_sender_channel_free_slots_stream_ids,
-                            sender_channel_from_receiver_credits,
-                            inner_loop_perf_telemetry_collector,
-                            local_fabric_telemetry);
-                        tx_progress |= run_sender_channel_step<
-                            VC1_RECEIVER_CHANNEL,
-                            ACTUAL_VC0_SENDER_CHANNELS + 2,
-                            ENABLE_FIRST_LEVEL_ACK_VC1>(
-                            local_sender_channels,
-                            local_sender_channel_worker_interfaces,
-                            outbound_to_receiver_channel_pointer_ch1,
-                            remote_receiver_channels,
-                            channel_connection_established,
-                            local_sender_channel_free_slots_stream_ids,
-                            sender_channel_from_receiver_credits,
-                            inner_loop_perf_telemetry_collector,
-                            local_fabric_telemetry);
-                        if constexpr (ACTUAL_VC1_SENDER_CHANNELS > 3) {
-                            tx_progress |= run_sender_channel_step<
-                                VC1_RECEIVER_CHANNEL,
-                                ACTUAL_VC0_SENDER_CHANNELS + 3,
-                                ENABLE_FIRST_LEVEL_ACK_VC1>(
-                                local_sender_channels,
-                                local_sender_channel_worker_interfaces,
-                                outbound_to_receiver_channel_pointer_ch1,
-                                remote_receiver_channels,
-                                channel_connection_established,
-                                local_sender_channel_free_slots_stream_ids,
-                                sender_channel_from_receiver_credits,
-                                inner_loop_perf_telemetry_collector,
-                                local_fabric_telemetry);
-                        }
-                        rx_progress |= run_receiver_channel_step<
-                            1,
-                            ENABLE_FIRST_LEVEL_ACK_VC1,
-                            VC1_DOWNSTREAM_EDM_SIZE,  // Explicit size for VC1 downstream interfaces
-                            DownstreamSenderVC1T,
-                            decltype(local_relay_interface)>(
-                            local_receiver_channels,
-                            downstream_edm_noc_interfaces_vc1,
-                            local_relay_interface,
-                            receiver_channel_pointers_ch1,
-                            receiver_channel_1_trid_tracker,
-                            port_direction_table,
-                            receiver_channel_response_credit_senders,
-                            routing_table,
-                            local_fabric_telemetry);
-#endif  // FABRIC_2D_VC1_SERVICED
                     }
-                }  // end else (non-speedy path)
+                }  // end of if constexpr (super_speedy_mode) else block
+                if constexpr (is_2d_fabric) {
+#if defined(FABRIC_2D_VC1_SERVICED)
+                    tx_progress |= run_sender_channel_step<
+                        VC1_RECEIVER_CHANNEL,
+                        ACTUAL_VC0_SENDER_CHANNELS,
+                        ENABLE_FIRST_LEVEL_ACK_VC1>(
+                        local_sender_channels,
+                        local_sender_channel_worker_interfaces,
+                        outbound_to_receiver_channel_pointer_ch1,
+                        remote_receiver_channels,
+                        channel_connection_established,
+                        local_sender_channel_free_slots_stream_ids,
+                        sender_channel_from_receiver_credits,
+                        inner_loop_perf_telemetry_collector,
+                        local_fabric_telemetry);
+                    tx_progress |= run_sender_channel_step<
+                        VC1_RECEIVER_CHANNEL,
+                        ACTUAL_VC0_SENDER_CHANNELS + 1,
+                        ENABLE_FIRST_LEVEL_ACK_VC1>(
+                        local_sender_channels,
+                        local_sender_channel_worker_interfaces,
+                        outbound_to_receiver_channel_pointer_ch1,
+                        remote_receiver_channels,
+                        channel_connection_established,
+                        local_sender_channel_free_slots_stream_ids,
+                        sender_channel_from_receiver_credits,
+                        inner_loop_perf_telemetry_collector,
+                        local_fabric_telemetry);
+                    tx_progress |= run_sender_channel_step<
+                        VC1_RECEIVER_CHANNEL,
+                        ACTUAL_VC0_SENDER_CHANNELS + 2,
+                        ENABLE_FIRST_LEVEL_ACK_VC1>(
+                        local_sender_channels,
+                        local_sender_channel_worker_interfaces,
+                        outbound_to_receiver_channel_pointer_ch1,
+                        remote_receiver_channels,
+                        channel_connection_established,
+                        local_sender_channel_free_slots_stream_ids,
+                        sender_channel_from_receiver_credits,
+                        inner_loop_perf_telemetry_collector,
+                        local_fabric_telemetry);
+                    if constexpr (ACTUAL_VC1_SENDER_CHANNELS > 3) {
+                        tx_progress |= run_sender_channel_step<
+                            VC1_RECEIVER_CHANNEL,
+                            ACTUAL_VC0_SENDER_CHANNELS + 3,
+                            ENABLE_FIRST_LEVEL_ACK_VC1>(
+                            local_sender_channels,
+                            local_sender_channel_worker_interfaces,
+                            outbound_to_receiver_channel_pointer_ch1,
+                            remote_receiver_channels,
+                            channel_connection_established,
+                            local_sender_channel_free_slots_stream_ids,
+                            sender_channel_from_receiver_credits,
+                            inner_loop_perf_telemetry_collector,
+                            local_fabric_telemetry);
+                    }
+                    rx_progress |= run_receiver_channel_step<
+                        1,
+                        ENABLE_FIRST_LEVEL_ACK_VC1,
+                        VC1_DOWNSTREAM_EDM_SIZE,  // Explicit size for VC1 downstream interfaces
+                        DownstreamSenderVC1T,
+                        decltype(local_relay_interface)>(
+                        local_receiver_channels,
+                        downstream_edm_noc_interfaces_vc1,
+                        local_relay_interface,
+                        receiver_channel_pointers_ch1,
+                        receiver_channel_1_trid_tracker,
+                        port_direction_table,
+                        receiver_channel_response_credit_senders,
+                        routing_table,
+                        local_fabric_telemetry);
+#endif  // FABRIC_2D_VC1_SERVICED
+                }
             }
 
             if constexpr (FABRIC_TELEMETRY_BANDWIDTH) {


### PR DESCRIPTION
Previously, the fast VC was only enabled if VC1 was disabled, which was not desired. VCs are isolated, so we can treat them independently.

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=snijjar/refine-ne-enable-with-vc1)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:snijjar/refine-ne-enable-with-vc1)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snijjar/refine-ne-enable-with-vc1)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snijjar/refine-ne-enable-with-vc1)
- [x] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early : https://github.com/tenstorrent/tt-metal/actions/runs/22698523730

