### PR TITLE
Improve accuracy of unary pow FP32

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
@@ -155,6 +155,35 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_21f_(sfpi::vFloat base, sfpi::vFloat 
     return y;
 }
 
+sfpi_inline sfpi::vFloat _sfpu_pow2_f32_accurate_(sfpi::vFloat z) {
+    sfpi::vFloat low = -127.0f;
+    // Handle underflow
+    sfpi::vec_min_max(low, z);
+
+    sfpi::vInt k_int;
+    sfpi::vFloat k = _sfpu_round_nearest_int32_(z, k_int);
+
+    // Compute val = z * ln(2), then r = val - k*ln(2) in extended precision.
+    constexpr float LN2 = 0.693147180559945309f;
+    constexpr float LN2_HI = -0.6931152343750000f;
+    constexpr float LN2_LO = -3.19461832987e-05f;
+
+    sfpi::vFloat val = z * LN2;
+    sfpi::vFloat r_hi = k * LN2_HI + val;
+    sfpi::vFloat r = k * LN2_LO + r_hi;
+
+    sfpi::vFloat p = PolynomialEvaluator::eval(
+        r, sfpi::vConst1, sfpi::vConst1, 0.5f, 1.0f / 6.0f, 1.0f / 24.0f, 1.0f / 120.0f, 1.0f / 720.0f, 1.0f / 5040.0f);
+
+    sfpi::vFloat result = sfpi::setexp(p, sfpi::exexp_nodebias(p) + k_int);
+
+    // Handle overflow
+    v_if(z >= 128.0f) { result = std::numeric_limits<float>::infinity(); }
+    v_endif;
+
+    return result;
+}
+
 template <bool IS_POSITIVE_EXPONENT>
 sfpi_inline sfpi::vFloat _sfpu_unary_power_61f_updated_(const sfpi::vFloat& base, const sfpi::vFloat& pow) {
     // The algorithm works in two steps:
@@ -169,9 +198,8 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_61f_updated_(const sfpi::vFloat& base
 
     // Range reduction: ensure m in [sqrt(2)/2, sqrt(2)] ≈ [0.707, 1.414]
     constexpr float SQRT2 = 1.4142135381698608f;
-    // If m >= sqrt(2), divide by 2 and increment exponent
     v_if(m >= SQRT2) {
-        m = m * 0.5f;
+        m = sfpi::addexp(m, -1);
         exp = exp + 1;
     }
     v_endif;
@@ -202,16 +230,8 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_61f_updated_(const sfpi::vFloat& base
     const sfpi::vFloat vConst1Ln2 = sfpi::vConstFloatPrgm0;
     sfpi::vFloat log2_result = exp_f32 + ln_m * vConst1Ln2;
 
-    // Step 2: base**pow = 2**(pow*log2(base)). Clamp z_f32 to -127 to avoid overflow when result should be 0 (e.g.
-    // 0**+inf, N**-inf).
-    sfpi::vFloat z_f32 = pow * log2_result;
-    const sfpi::vFloat low_threshold = sfpi::vConstFloatPrgm1;
-    v_if(z_f32 < low_threshold) { z_f32 = low_threshold; }
-    v_endif;
-
-    // 2^z_f32 = exp(z_f32 * ln(2)); use Cody-Waite + Taylor exp for <1 ULP float32 accuracy
-    constexpr float LN2 = 0.693147180559945309f;
-    sfpi::vFloat y = _sfpu_exp_f32_accurate_(z_f32 * LN2);
+    // Step 2: base**pow = 2**(pow*log2(base))
+    sfpi::vFloat y = _sfpu_pow2_f32_accurate_(pow * log2_result);
 
     // Division by 0 when base is 0 and pow is negative => set to NaN (only for negative exponents)
     if constexpr (!IS_POSITIVE_EXPONENT) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
@@ -156,7 +156,7 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_21f_(sfpi::vFloat base, sfpi::vFloat 
 }
 
 sfpi_inline sfpi::vFloat _sfpu_pow2_f32_accurate_(sfpi::vFloat z) {
-    sfpi::vFloat low = -127.0f;
+    sfpi::vFloat low = -126.99999237060546875f;
     // Handle underflow
     sfpi::vec_min_max(low, z);
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
@@ -158,7 +158,7 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_21f_(sfpi::vFloat base, sfpi::vFloat 
 }
 
 sfpi_inline sfpi::vFloat _sfpu_pow2_f32_accurate_(sfpi::vFloat z) {
-    sfpi::vFloat low = -127.0f;
+    sfpi::vFloat low = -126.99999237060546875f;
     // Handle underflow
     sfpi::vec_min_max(low, z);
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
@@ -157,6 +157,35 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_21f_(sfpi::vFloat base, sfpi::vFloat 
     return y;
 }
 
+sfpi_inline sfpi::vFloat _sfpu_pow2_f32_accurate_(sfpi::vFloat z) {
+    sfpi::vFloat low = -127.0f;
+    // Handle underflow
+    sfpi::vec_min_max(low, z);
+
+    sfpi::vInt k_int;
+    sfpi::vFloat k = _sfpu_round_nearest_int32_(z, k_int);
+
+    // Compute val = z * ln(2), then r = val - k*ln(2) in extended precision.
+    constexpr float LN2 = 0.693147180559945309f;
+    constexpr float LN2_HI = -0.6931152343750000f;
+    constexpr float LN2_LO = -3.19461832987e-05f;
+
+    sfpi::vFloat val = z * LN2;
+    sfpi::vFloat r_hi = k * LN2_HI + val;
+    sfpi::vFloat r = k * LN2_LO + r_hi;
+
+    sfpi::vFloat p = PolynomialEvaluator::eval(
+        r, sfpi::vConst1, sfpi::vConst1, 0.5f, 1.0f / 6.0f, 1.0f / 24.0f, 1.0f / 120.0f, 1.0f / 720.0f, 1.0f / 5040.0f);
+
+    sfpi::vFloat result = sfpi::setexp(p, sfpi::exexp_nodebias(p) + k_int);
+
+    // Handle overflow
+    v_if(z >= 128.0f) { result = std::numeric_limits<float>::infinity(); }
+    v_endif;
+
+    return result;
+}
+
 template <bool IS_POSITIVE_EXPONENT>
 sfpi_inline sfpi::vFloat _sfpu_unary_power_61f_updated_(const sfpi::vFloat& base, const sfpi::vFloat& pow) {
     // The algorithm works in two steps:
@@ -171,9 +200,8 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_61f_updated_(const sfpi::vFloat& base
 
     // Range reduction: ensure m in [sqrt(2)/2, sqrt(2)] ≈ [0.707, 1.414]
     constexpr float SQRT2 = 1.4142135381698608f;
-    // If m >= sqrt(2), divide by 2 and increment exponent
     v_if(m >= SQRT2) {
-        m = m * 0.5f;
+        m = sfpi::addexp(m, -1);
         exp = exp + 1;
     }
     v_endif;
@@ -204,16 +232,8 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_61f_updated_(const sfpi::vFloat& base
     const sfpi::vFloat vConst1Ln2 = sfpi::vConstFloatPrgm0;
     sfpi::vFloat log2_result = exp_f32 + ln_m * vConst1Ln2;
 
-    // Step 2: base**pow = 2**(pow*log2(base)). Clamp z_f32 to -127 to avoid overflow when result should be 0 (e.g.
-    // 0**+inf, N**-inf).
-    sfpi::vFloat z_f32 = pow * log2_result;
-    const sfpi::vFloat low_threshold = sfpi::vConstFloatPrgm1;
-    v_if(z_f32 < low_threshold) { z_f32 = low_threshold; }
-    v_endif;
-
-    // 2^z_f32 = exp(z_f32 * ln(2)); use Cody-Waite + Taylor exp for <1 ULP float32 accuracy
-    constexpr float LN2 = 0.693147180559945309f;
-    sfpi::vFloat y = _sfpu_exp_f32_accurate_(z_f32 * LN2);
+    // Step 2: base**pow = 2**(pow*log2(base))
+    sfpi::vFloat y = _sfpu_pow2_f32_accurate_(pow * log2_result);
 
     // Division by 0 when base is 0 and pow is negative => set to NaN (only for negative exponents)
     if constexpr (!IS_POSITIVE_EXPONENT) {


### PR DESCRIPTION
### Ticket
#39701

### Problem description
Addressing a previous [comment](https://github.com/tenstorrent/tt-metal/pull/37873#discussion_r2877387608) and check accuracy and perf difference

### What's changed

- The appraoch uses a `_sfpu_pow2_f32_accurate_(z)` to compute `2^z` directly instead of `_sfpu_exp_f32_accurate_(z * LN2)`. This removes the `z * LN2 * INV_LN2` round-trip
- ULP Improvement : 
<img width="1043" height="704" alt="Screenshot 2026-03-04 at 9 16 31 PM" src="https://github.com/user-attachments/assets/29dd9894-2fcf-4018-b484-2ffb1cf2e1ab" />

- Perf Difference : 
<img width="1264" height="520" alt="Screenshot 2026-03-04 at 9 17 45 PM" src="https://github.com/user-attachments/assets/8038896f-786a-45f0-a1d1-f7cf3fe6e1b6" />


### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=virdhatchani/unary_pow_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:virdhatchani/unary_pow_check)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=virdhatchani/unary_pow_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=virdhatchani/unary_pow_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:virdhatchani/unary_pow_check)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [x] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=virdhatchani/unary_pow_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:virdhatchani/unary_pow_check)
  - [x] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [x] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=virdhatchani/unary_pow_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:virdhatchani/unary_pow_check)
  - [x] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
