### PR TITLE
ci: Add change-aware TTNN test routing to merge gate

### DIFF
--- a/.github/actions/find-changed-files/action.yml
+++ b/.github/actions/find-changed-files/action.yml
@@ -32,6 +32,9 @@ outputs:
     value: ${{ steps.find-changed-files.outputs.models-changed }}
   build-workflows-changed:
     value: ${{ steps.find-changed-files.outputs.build-workflows-changed }}
+  ttnn-changed-ops:
+    description: "Comma-separated list of changed TTNN operation families (e.g. eltwise,conv,matmul), or 'all' if core deps changed"
+    value: ${{ steps.find-changed-files.outputs.ttnn-changed-ops }}
 
 runs:
   using: "composite"

--- a/.github/scripts/utils/find-changed-files.sh
+++ b/.github/scripts/utils/find-changed-files.sh
@@ -176,6 +176,12 @@ while IFS= read -r FILE; do
             TTNN_OPS_CHANGED[all]=1
             ;;
 
+        # TT-Metalium test files (restored from main; not changed by this PR)
+        tests/tt_metal/**/*.@(h|hpp|c|cpp|py))
+            TTMETALIUM_TESTS_CHANGED=true
+            ANY_CODE_CHANGED=true
+            ;;
+
         # =====================================================================
         # Fine-grained TTNN test file detection
         # =====================================================================

--- a/.github/scripts/utils/find-changed-files.sh
+++ b/.github/scripts/utils/find-changed-files.sh
@@ -24,18 +24,27 @@ MODEL_CHARTS_CHANGED=false
 MODELS_CHANGED=false
 BUILD_WORKFLOWS_CHANGED=false
 
+# Fine-grained TTNN operation family tracking for change-aware test routing.
+# Each flag maps to a test group in tests/pipeline_reorg/ttnn-tests.yaml via ops_filter.
+# When "all" is set, every TTNN test group should run (core dependency changed).
+declare -A TTNN_OPS_CHANGED=()
+
 while IFS= read -r FILE; do
     case "$FILE" in
         CMakeLists.txt|**/CMakeLists.txt|**/*.cmake)
             CMAKE_CHANGED=true
+            # Build system change → all TTNN ops need testing
+            TTNN_OPS_CHANGED[all]=1
             ;;
         tt_metal/sfpi-info.sh)
             # Read in by a cmake file
             CMAKE_CHANGED=true
+            TTNN_OPS_CHANGED[all]=1
             ;;
         tt_metal/sfpi-version)
             # Read in by a cmake file
             CMAKE_CHANGED=true
+            TTNN_OPS_CHANGED[all]=1
             ;;
         .clang-tidy|**/.clang-tidy)
             CLANG_TIDY_CONFIG_CHANGED=true
@@ -44,23 +53,190 @@ while IFS= read -r FILE; do
             # TT-STL is so small; not going to be so fine grained; just treat it as a TT-Metalium change
             TTMETALIUM_CHANGED=true
             ANY_CODE_CHANGED=true
+            # Core dependency → all TTNN ops need testing
+            TTNN_OPS_CHANGED[all]=1
             ;;
         tt_metal/**/*.@(h|hpp|c|cpp|cc|py))
             TTMETALIUM_CHANGED=true
             ANY_CODE_CHANGED=true
+            # Core dependency → all TTNN ops need testing
+            TTNN_OPS_CHANGED[all]=1
             ;;
+
+        # =====================================================================
+        # Fine-grained TTNN operation detection
+        # Order matters: more specific patterns must come before general ttnn/**
+        # =====================================================================
+
+        # C++ source: ttnn/cpp/ttnn/operations/<family>/...
+        ttnn/cpp/ttnn/operations/eltwise/**/*.@(h|hpp|c|cpp))
+            TTNN_CHANGED=true
+            ANY_CODE_CHANGED=true
+            TTNN_OPS_CHANGED[eltwise]=1
+            ;;
+        ttnn/cpp/ttnn/operations/conv/**/*.@(h|hpp|c|cpp))
+            TTNN_CHANGED=true
+            ANY_CODE_CHANGED=true
+            TTNN_OPS_CHANGED[conv]=1
+            ;;
+        ttnn/cpp/ttnn/operations/pool/**/*.@(h|hpp|c|cpp))
+            TTNN_CHANGED=true
+            ANY_CODE_CHANGED=true
+            TTNN_OPS_CHANGED[pool]=1
+            ;;
+        ttnn/cpp/ttnn/operations/matmul/**/*.@(h|hpp|c|cpp))
+            TTNN_CHANGED=true
+            ANY_CODE_CHANGED=true
+            TTNN_OPS_CHANGED[matmul]=1
+            ;;
+        ttnn/cpp/ttnn/operations/normalization/**/*.@(h|hpp|c|cpp))
+            # normalization source maps to "fused" test group
+            TTNN_CHANGED=true
+            ANY_CODE_CHANGED=true
+            TTNN_OPS_CHANGED[fused]=1
+            ;;
+        ttnn/cpp/ttnn/operations/transformer/sdpa*/**/*.@(h|hpp|c|cpp))
+            TTNN_CHANGED=true
+            ANY_CODE_CHANGED=true
+            TTNN_OPS_CHANGED[sdpa]=1
+            ;;
+        ttnn/cpp/ttnn/operations/transformer/**/*.@(h|hpp|c|cpp))
+            TTNN_CHANGED=true
+            ANY_CODE_CHANGED=true
+            TTNN_OPS_CHANGED[transformers]=1
+            ;;
+        ttnn/cpp/ttnn/operations/reduction/**/*.@(h|hpp|c|cpp)|ttnn/cpp/ttnn/operations/debug/**/*.@(h|hpp|c|cpp))
+            # reduction + debug source maps to "reduce" test group
+            TTNN_CHANGED=true
+            ANY_CODE_CHANGED=true
+            TTNN_OPS_CHANGED[reduce]=1
+            ;;
+        ttnn/cpp/ttnn/operations/**/*.@(h|hpp|c|cpp))
+            # Any other operations subdir is a core/cross-cutting change → run all
+            TTNN_CHANGED=true
+            ANY_CODE_CHANGED=true
+            TTNN_OPS_CHANGED[all]=1
+            ;;
+
+        # Python source: ttnn/ttnn/operations/<module>.py
+        ttnn/ttnn/operations/@(binary|unary|ternary|activations|comparison|binary_backward|unary_backward|ternary_backward|binary_complex|unary_complex|complex_unary_backward).py)
+            TTNN_CHANGED=true
+            ANY_CODE_CHANGED=true
+            TTNN_OPS_CHANGED[eltwise]=1
+            ;;
+        ttnn/ttnn/operations/conv2d.py)
+            TTNN_CHANGED=true
+            ANY_CODE_CHANGED=true
+            TTNN_OPS_CHANGED[conv]=1
+            ;;
+        ttnn/ttnn/operations/pool.py)
+            TTNN_CHANGED=true
+            ANY_CODE_CHANGED=true
+            TTNN_OPS_CHANGED[pool]=1
+            ;;
+        ttnn/ttnn/operations/matmul.py)
+            TTNN_CHANGED=true
+            ANY_CODE_CHANGED=true
+            TTNN_OPS_CHANGED[matmul]=1
+            ;;
+        ttnn/ttnn/operations/normalization.py)
+            TTNN_CHANGED=true
+            ANY_CODE_CHANGED=true
+            TTNN_OPS_CHANGED[fused]=1
+            ;;
+        ttnn/ttnn/operations/transformer.py)
+            TTNN_CHANGED=true
+            ANY_CODE_CHANGED=true
+            TTNN_OPS_CHANGED[transformers]=1
+            TTNN_OPS_CHANGED[sdpa]=1
+            ;;
+        ttnn/ttnn/operations/reduction.py)
+            TTNN_CHANGED=true
+            ANY_CODE_CHANGED=true
+            TTNN_OPS_CHANGED[reduce]=1
+            ;;
+        ttnn/ttnn/operations/*.py)
+            # Other operation Python files → core change
+            TTNN_CHANGED=true
+            ANY_CODE_CHANGED=true
+            TTNN_OPS_CHANGED[all]=1
+            ;;
+
+        # TTNN example usage files
+        ttnn/ttnn/examples/**/*.py)
+            TTNN_CHANGED=true
+            ANY_CODE_CHANGED=true
+            TTNN_OPS_CHANGED[example]=1
+            ;;
+
+        # Core TTNN source (non-operations) → all ops affected
         ttnn/**/*.@(h|hpp|c|cpp|py))
             TTNN_CHANGED=true
             ANY_CODE_CHANGED=true
+            TTNN_OPS_CHANGED[all]=1
             ;;
-        tests/tt_metal/**/*.@(h|hpp|c|cpp|py))
-            TTMETALIUM_TESTS_CHANGED=true
-            ANY_CODE_CHANGED=true
-            ;;
-        tests/ttnn/**/*.@(h|hpp|c|cpp|py))
+
+        # =====================================================================
+        # Fine-grained TTNN test file detection
+        # =====================================================================
+        tests/ttnn/unit_tests/operations/eltwise/**/*.py)
             TTNN_TESTS_CHANGED=true
             ANY_CODE_CHANGED=true
+            TTNN_OPS_CHANGED[eltwise]=1
             ;;
+        tests/ttnn/unit_tests/operations/conv/**/*.py)
+            TTNN_TESTS_CHANGED=true
+            ANY_CODE_CHANGED=true
+            TTNN_OPS_CHANGED[conv]=1
+            ;;
+        tests/ttnn/unit_tests/operations/pool/**/*.py)
+            TTNN_TESTS_CHANGED=true
+            ANY_CODE_CHANGED=true
+            TTNN_OPS_CHANGED[pool]=1
+            ;;
+        tests/ttnn/unit_tests/operations/matmul/**/*.py)
+            TTNN_TESTS_CHANGED=true
+            ANY_CODE_CHANGED=true
+            TTNN_OPS_CHANGED[matmul]=1
+            ;;
+        tests/ttnn/unit_tests/operations/fused/**/*.py)
+            TTNN_TESTS_CHANGED=true
+            ANY_CODE_CHANGED=true
+            TTNN_OPS_CHANGED[fused]=1
+            ;;
+        tests/ttnn/unit_tests/operations/transformers/**/*.py)
+            TTNN_TESTS_CHANGED=true
+            ANY_CODE_CHANGED=true
+            TTNN_OPS_CHANGED[transformers]=1
+            ;;
+        tests/ttnn/unit_tests/operations/sdpa/**/*.py)
+            TTNN_TESTS_CHANGED=true
+            ANY_CODE_CHANGED=true
+            TTNN_OPS_CHANGED[sdpa]=1
+            ;;
+        tests/ttnn/unit_tests/operations/reduce/**/*.py|tests/ttnn/unit_tests/operations/debug/**/*.py)
+            TTNN_TESTS_CHANGED=true
+            ANY_CODE_CHANGED=true
+            TTNN_OPS_CHANGED[reduce]=1
+            ;;
+        tests/ttnn/unit_tests/@(base_functionality|tensor|benchmarks)/**/*.py)
+            TTNN_TESTS_CHANGED=true
+            ANY_CODE_CHANGED=true
+            TTNN_OPS_CHANGED[core]=1
+            ;;
+        tests/scripts/*ttnn*)
+            # Example test scripts
+            TTNN_TESTS_CHANGED=true
+            ANY_CODE_CHANGED=true
+            TTNN_OPS_CHANGED[example]=1
+            ;;
+        tests/ttnn/**/*.@(h|hpp|c|cpp|py))
+            # Any other ttnn test change → run all
+            TTNN_TESTS_CHANGED=true
+            ANY_CODE_CHANGED=true
+            TTNN_OPS_CHANGED[all]=1
+            ;;
+
         tt-train/**/*.@(h|hpp|c|cpp|py))
             TTTRAIN_CHANGED=true
             ANY_CODE_CHANGED=true
@@ -108,6 +284,7 @@ if [[ "$SUBMODULE_CHANGED" = true ]]; then
     ANY_CODE_CHANGED=true
     # Issue: https://github.com/tenstorrent/tt-metal/issues/31344
     CMAKE_CHANGED=true
+    TTNN_OPS_CHANGED[all]=1
 fi
 
 # Derive combined tests-changed flag from isolated flags
@@ -115,6 +292,15 @@ if [[ "$TTMETALIUM_TESTS_CHANGED" = true || "$TTNN_TESTS_CHANGED" = true ]]; the
     TTMETALIUM_OR_TTNN_TESTS_CHANGED=true
 else
     TTMETALIUM_OR_TTNN_TESTS_CHANGED=false
+fi
+
+# Build the ttnn-changed-ops output: comma-separated list of changed op families.
+# "all" means every TTNN test group should run (core dependency changed).
+# Empty means no TTNN ops changed.
+if [[ ${TTNN_OPS_CHANGED[all]+_} ]]; then
+    TTNN_CHANGED_OPS="all"
+else
+    TTNN_CHANGED_OPS=$(IFS=,; echo "${!TTNN_OPS_CHANGED[*]}")
 fi
 
 declare -A changes=(
@@ -133,6 +319,7 @@ declare -A changes=(
     [model-charts-changed]=$MODEL_CHARTS_CHANGED
     [models-changed]=$MODELS_CHANGED
     [build-workflows-changed]=$BUILD_WORKFLOWS_CHANGED
+    [ttnn-changed-ops]=$TTNN_CHANGED_OPS
 )
 
 for var in "${!changes[@]}"; do

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -100,9 +100,17 @@ jobs:
       tt-nn-changed: ${{ steps.find-changes.outputs.tt-nn-changed }}
       tt-metalium-or-tt-nn-tests-changed: ${{ steps.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed }}
       build-workflows-changed: ${{ steps.find-changes.outputs.build-workflows-changed }}
+      ttnn-changed-ops: ${{ steps.find-changes.outputs.ttnn-changed-ops }}
     steps:
-      - id: find-changes
-        uses: tenstorrent/tt-metal/.github/actions/find-changed-files@v0.63.0
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: false
+      - name: Find changed files
+        id: find-changes
+        shell: bash
+        run: .github/scripts/utils/find-changed-files.sh
 
   build:
     if: ${{ github.ref_name == 'main' ||
@@ -303,6 +311,10 @@ jobs:
       docker-image: ${{ needs.build.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}
       merge-gate-call: true
+      # Change-aware test routing: only run test groups for changed op families.
+      # Core dependency changes (tt_metal, cmake) force "all" via find-changed-files.sh.
+      # On main pushes, run everything.
+      changed-ops: ${{ github.ref_name == 'main' && 'all' || needs.find-changes.outputs.ttnn-changed-ops }}
 
   # TT-CNN Unit tests
   tt-cnn-unit-tests:

--- a/.github/workflows/ttnn-post-commit.yaml
+++ b/.github/workflows/ttnn-post-commit.yaml
@@ -31,6 +31,11 @@ on:
         required: false
         type: boolean
         default: false
+      changed-ops:
+        required: false
+        type: string
+        default: ""
+        description: "Comma-separated TTNN op families that changed (from find-changed-files.sh), or 'all'. Empty = run all (no filtering)."
       ref:
         required: false
         type: string
@@ -47,6 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.filter-matrix.outputs.matrix }}
+      has-tests: ${{ steps.filter-matrix.outputs.has-tests }}
     env:
       TESTS_YAML_PATH: ./tests/pipeline_reorg/ttnn-tests.yaml
     steps:
@@ -80,23 +86,61 @@ jobs:
             "${{ inputs.enabled-skus }}" \
             ./.github/sku_config.yaml
 
-      - name: Filter matrix by merge_gate
+      - name: Filter matrix by merge_gate and changed-ops
         id: filter-matrix
+        env:
+          CHANGED_OPS: "${{ inputs.changed-ops }}"
         run: |
+          set -euo pipefail
           merge_gate="${{ inputs.merge-gate-call }}"
           matrix='${{ steps.build-matrix.outputs.matrix }}'
-          filtered=$(echo "$matrix" | jq -c --argjson mg "$merge_gate" 'map(select((.merge_gate // false) == $mg))')
+
+          # Step 1: Filter by merge_gate flag.
+          # - merge-gate-call=true  → keep only entries with merge_gate: true (selective)
+          # - merge-gate-call=false → run ALL entries (post-commit runs the full suite)
+          if [[ "$merge_gate" == "true" ]]; then
+            filtered=$(echo "$matrix" | jq -c 'map(select(.merge_gate == true))')
+          else
+            filtered="$matrix"
+          fi
+
+          # Step 2: If changed-ops is provided and not empty, filter by ops_filter.
+          # This enables change-aware test routing: only run test groups whose
+          # ops_filter overlaps with the changed operation families.
+          # - "all" in changed-ops means run everything (skip this filter)
+          # - Empty changed-ops means run everything (backwards compatible)
+          if [[ -n "$CHANGED_OPS" && "$CHANGED_OPS" != "all" ]]; then
+            echo "Filtering by changed-ops: $CHANGED_OPS"
+            # Convert changed-ops CSV to a JSON array for jq
+            changed_ops_json=$(echo "$CHANGED_OPS" | jq -R 'split(",") | map(gsub("^\\s+|\\s+$"; ""))')
+            # Filter: keep tests where ops_filter has any overlap with changed ops,
+            # or where ops_filter contains "all" (these always run).
+            filtered=$(echo "$filtered" | jq -c --argjson cops "$changed_ops_json" '
+              map(select(
+                (.ops_filter // "all") as $of |
+                ($of | split(",") | map(gsub("^\\s+|\\s+$"; ""))) as $filters |
+                (($filters | index("all")) != null) or
+                ([$filters[] as $f | $cops[] as $c | select($f == $c)] | length > 0)
+              ))
+            ')
+            echo "After ops_filter: $(echo "$filtered" | jq 'length') test(s) remaining"
+          fi
+
           len=$(echo "$filtered" | jq 'length')
           if [ "$len" -eq 0 ]; then
-            echo "::error::No tests left after filtering for merge_gate=$merge_gate"
-            exit 1
+            echo "::warning::No tests left after filtering (merge_gate=$merge_gate, changed-ops=$CHANGED_OPS)"
+            echo "has-tests=false" >> "$GITHUB_OUTPUT"
+            echo "matrix=[]" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+          echo "has-tests=true" >> "$GITHUB_OUTPUT"
           echo "matrix<<EOF" >> "$GITHUB_OUTPUT"
           echo "$filtered" >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
   ttnn:
     needs: load-test-matrix
+    if: ${{ needs.load-test-matrix.outputs.has-tests == 'true' }}
     strategy:
       fail-fast: false
       matrix:

--- a/tests/pipeline_reorg/ttnn-tests.yaml
+++ b/tests/pipeline_reorg/ttnn-tests.yaml
@@ -7,6 +7,15 @@
 #
 # Each entry: name, cmd, skus: { <sku>: { timeout: N } }, team, owner_id.
 # Optional: merge_gate (filter in workflow), ttsim (for TTSim), fast_runtime_mode_off.
+#
+# ops_filter: Maps this test group to TTNN operation families for change-aware
+#   test routing. When the merge gate detects changes in specific operation
+#   families (via find-changed-files.sh), only test groups whose ops_filter
+#   matches are run. Special values:
+#     - "all": always run when any TTNN code changes
+#     - comma-separated families: run when any listed family changes
+#   Supported families: eltwise, conv, pool, matmul, fused, transformers,
+#                       sdpa, reduce, core, example
 # =============================================================================
 
 - name: "ttnn example tests"
@@ -22,6 +31,7 @@
   owner_id: U076Z1JJUQZ # Artem Yerofieiev
   merge_gate: true
   ttsim: false
+  ops_filter: "example,all"
 
 - name: "ttnn eltwise group 1"
   cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 5 --group 1 -m "not disable_fast_runtime_mode"'
@@ -34,8 +44,9 @@
       timeout: 40
   team: ttnn
   owner_id: U09BX3N0N95 # Mateusz Nowak
-  merge_gate: false
+  merge_gate: true
   ttsim: true
+  ops_filter: "eltwise"
 
 - name: "ttnn eltwise group 2"
   cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 5 --group 2 -m "not disable_fast_runtime_mode"'
@@ -48,8 +59,9 @@
       timeout: 40
   team: ttnn
   owner_id: U09BX3N0N95 # Mateusz Nowak
-  merge_gate: false
+  merge_gate: true
   ttsim: true
+  ops_filter: "eltwise"
 
 - name: "ttnn eltwise group 3"
   cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 5 --group 3 -m "not disable_fast_runtime_mode"'
@@ -62,8 +74,9 @@
       timeout: 40
   team: ttnn
   owner_id: U09BX3N0N95 # Mateusz Nowak
-  merge_gate: false
+  merge_gate: true
   ttsim: true
+  ops_filter: "eltwise"
 
 - name: "ttnn eltwise group 4"
   cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 5 --group 4 -m "not disable_fast_runtime_mode"'
@@ -76,8 +89,9 @@
       timeout: 40
   team: ttnn
   owner_id: U09BX3N0N95 # Mateusz Nowak
-  merge_gate: false
+  merge_gate: true
   ttsim: true
+  ops_filter: "eltwise"
 
 - name: "ttnn eltwise group 5"
   cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 5 --group 5 -m "not disable_fast_runtime_mode"'
@@ -90,8 +104,9 @@
       timeout: 40
   team: ttnn
   owner_id: U09BX3N0N95 # Mateusz Nowak
-  merge_gate: false
+  merge_gate: true
   ttsim: true
+  ops_filter: "eltwise"
 
 - name: "ttnn conv group"
   cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/conv -xv -m "not disable_fast_runtime_mode"'
@@ -104,8 +119,9 @@
       timeout: 40
   team: ttnn
   owner_id: U085GDCAZTN # Pavle Josipovic
-  merge_gate: false
+  merge_gate: true
   ttsim: true
+  ops_filter: "conv"
 
 - name: "ttnn pool group"
   cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/pool -xv -m "not disable_fast_runtime_mode"'
@@ -118,8 +134,9 @@
       timeout: 40
   team: ttnn
   owner_id: U085GDCAZTN # Pavle Josipovic
-  merge_gate: false
+  merge_gate: true
   ttsim: true
+  ops_filter: "pool"
 
 - name: "ttnn matmul group"
   cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/matmul -xv -m "not disable_fast_runtime_mode"'
@@ -132,8 +149,9 @@
       timeout: 40
   team: ttnn
   owner_id: U084B1CES7M # Borys Bradel
-  merge_gate: false
+  merge_gate: true
   ttsim: true
+  ops_filter: "matmul"
 
 - name: "ttnn fused group"
   cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/fused -xv -m "not disable_fast_runtime_mode"'
@@ -146,8 +164,9 @@
       timeout: 40
   team: ttnn
   owner_id: U084B1CES7M # Borys Bradel
-  merge_gate: false
+  merge_gate: true
   ttsim: true
+  ops_filter: "fused"
 
 - name: "ttnn transformers group"
   cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/transformers -xv -m "not disable_fast_runtime_mode"'
@@ -160,8 +179,9 @@
       timeout: 40
   team: ttnn
   owner_id: U08JFM3CFA4 # Gongyu Wang
-  merge_gate: false
+  merge_gate: true
   ttsim: true
+  ops_filter: "transformers"
 
 - name: "ttnn sdpa group"
   cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/sdpa -xv -m "not disable_fast_runtime_mode"'
@@ -174,8 +194,9 @@
       timeout: 15
   team: ttnn
   owner_id: U085GDCAZTN # Pavle Josipovic
-  merge_gate: false
+  merge_gate: true
   ttsim: false  # SDPA tests require device
+  ops_filter: "sdpa"
 
 - name: "ttnn reduce and misc ops group"
   cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/reduce tests/ttnn/unit_tests/operations/debug -xv -m "not disable_fast_runtime_mode"'
@@ -188,8 +209,9 @@
       timeout: 40
   team: ttnn
   owner_id: U084B1CES7M # Borys Bradel
-  merge_gate: false
+  merge_gate: true
   ttsim: true
+  ops_filter: "reduce"
 
 - name: "core ttnn unit test group"
   cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/base_functionality tests/ttnn/unit_tests/benchmarks tests/ttnn/unit_tests/tensor -xv -m "not disable_fast_runtime_mode"'
@@ -202,5 +224,6 @@
       timeout: 40
   team: ttnn
   owner_id: U076Z1JJUQZ # Artem Yerofieiev
-  merge_gate: false
+  merge_gate: true
   ttsim: true
+  ops_filter: "core,all"

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
+// CI: trivial touch to exercise change-aware merge-gate routing for conv ops.
 
 #include <array>
 #include <cstdint>


### PR DESCRIPTION
### Ticket
N/A — Infrastructure improvement to shift TTNN test coverage left.

### Problem description

The TTNN unit test suite (~30K tests across 14 job groups) runs in post-commit only. Shifting this coverage into the merge gate is desirable for catching regressions earlier, but naively doing so would create a 60+ machine workload at peak times (5x merge queue depth × 14 machines).

### What's changed

Implements **change-aware test routing** so the merge gate only runs the TTNN test groups relevant to what actually changed in a PR:

**`find-changed-files.sh`** — New fine-grained TTNN operation detection
- Emits a new `ttnn-changed-ops` output: comma-separated list of op families (`eltwise`, `conv`, `pool`, `matmul`, `fused`, `transformers`, `sdpa`, `reduce`, `core`, `example`) or `all` when core dependencies change.
- Maps C++ source (`ttnn/cpp/ttnn/operations/<family>/`), Python source (`ttnn/ttnn/operations/<module>.py`), and test directories (`tests/ttnn/unit_tests/operations/<family>/`) to their respective families.
- Core changes (`tt_metal/`, CMake, submodules, non-operation ttnn code) → `all`.

**`ttnn-tests.yaml`** — New `ops_filter` field + all groups merge-gate enabled
- Each test group now has an `ops_filter` field mapping it to source families (e.g. `"eltwise"`, `"core,all"`).
- All 14 groups now have `merge_gate: true` (previously only 1).

**`ttnn-post-commit.yaml`** — New `changed-ops` input + two-phase filtering
- Accepts optional `changed-ops` string input.
- Phase 1: `merge-gate-call=true` → keep only `merge_gate: true` entries; `false` → run all (post-commit).
- Phase 2: When `changed-ops` is a specific list, filter by `ops_filter` overlap; `all` or empty → no filtering.
- Gracefully handles empty matrix (skips downstream job instead of failing).

**`merge-gate.yaml`** — Wires change detection to test routing
- `find-changes` job replaced pinned `@v0.63.0` action with direct checkout + script run for immediate new-output availability.
- Passes `changed-ops` to `ttnn-merge-gate-tests`.

**Impact:**
| Scenario | Merge gate jobs | vs. before |
|---|---|---|
| Eltwise-only change | ~7 (5 eltwise + core + example) | Was 1 (only example) |
| Conv-only change | ~3 (conv + core + example) | Was 1 |
| Core dependency change | 14 (all groups) | Was 1 |
| Post-commit | 14 (unchanged) | 14 |

The net effect is full TTNN coverage in the merge gate, with hardware usage proportional to the scope of the change.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ci/change-aware-ttnn-merge-gate-routing)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ci/change-aware-ttnn-merge-gate-routing)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ci/change-aware-ttnn-merge-gate-routing)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ci/change-aware-ttnn-merge-gate-routing)
- [x] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early