### PR TITLE
Fix TT_FATAL in set_custom_fabric_topology when topology is unchanged

### DIFF
--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -553,6 +553,13 @@ distributed::SystemMesh& MetalContext::get_system_mesh() {
 void MetalContext::set_custom_fabric_topology(
     const std::string& mesh_graph_desc_file,
     const std::map<tt_fabric::FabricNodeId, ChipId>& logical_mesh_chip_id_to_physical_chip_id_mapping) {
+    // If the custom topology is already set to the same values, nothing needs to change.
+    // This avoids the assertion on active devices when the topology is being re-applied
+    // between parameterized test iterations in the same suite (e.g., MultiMeshDeviceFabricFixture).
+    if (custom_mesh_graph_desc_path_.has_value() && custom_mesh_graph_desc_path_.value() == mesh_graph_desc_file &&
+        logical_mesh_chip_id_to_physical_chip_id_mapping_ == logical_mesh_chip_id_to_physical_chip_id_mapping) {
+        return;
+    }
     TT_FATAL(
         !device_manager_->is_initialized() || device_manager_->get_all_active_devices().empty(),
         "Modifying control plane requires no devices to be active");


### PR DESCRIPTION
## Problem

The `MetalContext::set_custom_fabric_topology` function asserts that no devices are active before modifying the control plane. When multiprocess test fixtures (e.g., `MultiMeshDeviceFabricFixture`) call this function in their `SetUp()` for each parameterized test iteration, the assertion fires on subsequent tests because the topology hasn't changed but devices are still active:

```
TT_FATAL: Modifying control plane requires no devices to be active
```

This was the immediate cause of the failure in the t3k TTNN multiprocess APC tests on `main`, leading to those tests being disabled via PR #39088.

## Fix

Make `set_custom_fabric_topology` **idempotent**: if the requested topology (mesh graph descriptor path + chip ID mapping) matches the currently configured one, return early without touching the control plane or triggering the assertion. The change is a 7-line early-return guard at the top of the function.

## Multiprocess tests remain disabled

While this fix resolves the `TT_FATAL` assertion, CI testing revealed **additional pre-existing issues** in the multiprocess tests that are unrelated to this assertion:

- **Dispatch timeout on rank [1,1]**: \~14 seconds after fabric initialization, the dispatch timeout callback fires, indicating a hung dispatch operation.
- **Socket connection timeout on rank [1,0]**: The MeshSocket handshake times out because the peer rank is unresponsive.
- **Cascading ARC core failures**: After the first test failure, subsequent tests fail with "ARC core failed to start" because the hardware is left in a bad state.

These issues require separate investigation and are tracked elsewhere. The multiprocess tests remain disabled in the CI workflow.