### PR TITLE
UNet optimizations for 512x512 image resolution

### DIFF
--- a/models/demos/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -119,7 +119,7 @@ def test_refiner_unet(
         ),
         (
             'pytest models/demos/stable_diffusion_xl_base/tests/test_sdxl_perf.py::test_unet -k "512x512"',
-            89_300_000 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
+            83_531_333 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
             "sdxl_unet_512x512",
             "sdxl_unet_512x512",
             1,

--- a/models/demos/stable_diffusion_xl_base/tt/model_configs/__init__.py
+++ b/models/demos/stable_diffusion_xl_base/tt/model_configs/__init__.py
@@ -10,6 +10,36 @@ from models.demos.stable_diffusion_xl_base.tt.model_configs.model_configs_1024x1
 )
 
 
+def get_image_resolution_from_model_config(model_config):
+    """
+    Get the image resolution from a ModelOptimisations instance.
+
+    Args:
+        model_config: A ModelOptimisations instance (either ModelOptimisations512x512 or
+            ModelOptimisations1024x1024).
+
+    Returns:
+        tuple: A tuple of (height, width) representing the image resolution.
+
+    Raises:
+        ValueError: If the model_config type is not recognized.
+
+    Example:
+        >>> model_opt = ModelOptimisations512x512()
+        >>> resolution = get_image_resolution_from_model_config(model_opt)
+        >>> print(resolution)  # (512, 512)
+    """
+    if isinstance(model_config, ModelOptimisations512x512):
+        return (512, 512)
+    elif isinstance(model_config, ModelOptimisations1024x1024):
+        return (1024, 1024)
+    else:
+        raise ValueError(
+            f"Unsupported model_config type: {type(model_config).__name__}. "
+            "Expected ModelOptimisations512x512 or ModelOptimisations1024x1024."
+        )
+
+
 def load_model_optimisations(
     image_resolution,
     conv_act_dtype=None,

--- a/models/demos/stable_diffusion_xl_base/tt/model_configs/model_configs_512x512.py
+++ b/models/demos/stable_diffusion_xl_base/tt/model_configs/model_configs_512x512.py
@@ -330,17 +330,17 @@ class ModelOptimisations512x512:
         # region MATMUL CONFIGS
         self.matmul_versions = {
             "40_cores": {
-                "2D_FF2_SEQ_LEN_1024": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
-                    compute_with_storage_grid_size=(5, 8),
-                    in0_block_w=4,
+                "2D_FF2_SEQ_LEN_256": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                    compute_with_storage_grid_size=(8, 4),
+                    in0_block_w=10,
                     out_subblock_h=1,
-                    out_subblock_w=8,
-                    per_core_M=1,
-                    per_core_N=8,
+                    out_subblock_w=1,
+                    per_core_M=2,
+                    per_core_N=5,
                     transpose_mcast=False,
                     fused_activation=None,
                 ),
-                "2D_FF2_SEQ_LEN_4096": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                "2D_FF2_SEQ_LEN_1024": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
                     compute_with_storage_grid_size=(5, 8),
                     in0_block_w=4,
                     out_subblock_h=1,
@@ -382,22 +382,22 @@ class ModelOptimisations512x512:
                     fused_activation=[ttnn.UnaryOpType.GELU, True],
                 ),
                 "2D_GEGLU_LINEAR_1280_SPLIT": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
-                    compute_with_storage_grid_size=(5, 8),
-                    in0_block_w=4,
-                    per_core_M=1,
-                    per_core_N=32,
+                    compute_with_storage_grid_size=(8, 4),
+                    in0_block_w=5,
+                    per_core_M=2,
+                    per_core_N=20,
                     out_subblock_h=1,
-                    out_subblock_w=8,
+                    out_subblock_w=4,
                     transpose_mcast=False,
                     fused_activation=None,
                 ),
                 "2D_GEGLU_LINEAR_1280_SPLIT_GELU": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
-                    compute_with_storage_grid_size=(5, 8),
-                    in0_block_w=4,
-                    per_core_M=1,
-                    per_core_N=32,
+                    compute_with_storage_grid_size=(8, 4),
+                    in0_block_w=5,
+                    per_core_M=2,
+                    per_core_N=20,
                     out_subblock_h=1,
-                    out_subblock_w=8,
+                    out_subblock_w=4,
                     transpose_mcast=False,
                     fused_activation=[ttnn.UnaryOpType.GELU, True],
                 ),
@@ -518,38 +518,38 @@ class ModelOptimisations512x512:
                 ),
                 "2D_RESNET_CONV_1920_1280": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
                     compute_with_storage_grid_size=(5, 8),
-                    in0_block_w=5,
+                    in0_block_w=12,
                     per_core_M=1,
                     per_core_N=8,
                     out_subblock_h=1,
-                    out_subblock_w=8,
+                    out_subblock_w=4,
                     transpose_mcast=False,
                     fused_activation=None,
                     fuse_batch=False,
                 ),
                 "2D_RESNET_CONV_1920_640": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
                     compute_with_storage_grid_size=(5, 8),
-                    in0_block_w=3,
+                    in0_block_w=6,
                     per_core_M=4,
                     per_core_N=4,
-                    out_subblock_h=2,
+                    out_subblock_h=1,
                     out_subblock_w=4,
                     transpose_mcast=False,
                     fused_activation=None,
                 ),
                 "2D_RESNET_CONV_1280_640": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
                     compute_with_storage_grid_size=(5, 8),
-                    in0_block_w=1,
+                    in0_block_w=2,
                     per_core_M=4,
                     per_core_N=4,
-                    out_subblock_h=2,
+                    out_subblock_h=1,
                     out_subblock_w=4,
                     transpose_mcast=False,
                     fused_activation=None,
                 ),
                 "2D_RESNET_CONV_960_640": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
                     compute_with_storage_grid_size=(5, 8),
-                    in0_block_w=2,
+                    in0_block_w=3,
                     per_core_M=4,
                     per_core_N=4,
                     out_subblock_h=1,
@@ -801,16 +801,16 @@ class ModelOptimisations512x512:
                 return self.matmul_configs["2D_TM_LINEAR_1280"]
 
         # # # ATTN OUT LINEAR # # #
-        if "attn1.to_out" in matmul_path or "attn2.to_out" in matmul_path or "attn2.to_q" in matmul_path:
-            if "down_blocks.1" in matmul_path or "up_blocks.1" in matmul_path:
-                return self.matmul_configs["2D_ATTN_OUT_LINEAR_640"]
-            else:
-                return self.matmul_configs["2D_ATTN_OUT_LINEAR_1280"]
         if "attn1.to_q" in matmul_path:
             if "down_blocks.1" in matmul_path or "up_blocks.1" in matmul_path:
                 return self.matmul_configs["2D_ATTN_QKV_LINEAR_640"]
             else:
                 return self.matmul_configs["2D_ATTN_QKV_LINEAR_1280"]
+        if "attn1.to_out" in matmul_path or "attn2.to_q" in matmul_path or "attn2.to_out" in matmul_path:
+            if "down_blocks.1" in matmul_path or "up_blocks.1" in matmul_path:
+                return self.matmul_configs["2D_ATTN_OUT_LINEAR_640"]
+            else:
+                return self.matmul_configs["2D_ATTN_OUT_LINEAR_1280"]
         if (
             "attn1.to_k" in matmul_path
             or "attn1.to_v" in matmul_path
@@ -828,7 +828,7 @@ class ModelOptimisations512x512:
 
         # 4 occurrences
         if pattern_down_blocks_1_ff2.search(matmul_path):
-            return self.matmul_configs["2D_FF2_SEQ_LEN_4096"]
+            return self.matmul_configs["2D_FF2_SEQ_LEN_1024"]
 
         pattern_down_blockcs_2_ff2 = re.compile(
             r"down_blocks\.2\.attentions\.[01]\.transformer_blocks\.[0123456789]\.ff\.net\.2"
@@ -836,14 +836,14 @@ class ModelOptimisations512x512:
 
         # 20 occurrences
         if pattern_down_blockcs_2_ff2.search(matmul_path):
-            return self.matmul_configs["2D_FF2_SEQ_LEN_1024"]
+            return self.matmul_configs["2D_FF2_SEQ_LEN_256"]
 
         # # # Mid block  # # #
         pattern_mid_block_ff2 = re.compile(r"mid_block\.attentions\.0\.transformer_blocks\.[0123456789]\.ff\.net\.2")
 
         # 10 occurrences
         if pattern_mid_block_ff2.search(matmul_path):
-            return self.matmul_configs["2D_FF2_SEQ_LEN_1024"]
+            return self.matmul_configs["2D_FF2_SEQ_LEN_256"]
 
         pattern_up_blocks_0_ff2 = re.compile(
             r"up_blocks\.0\.attentions\.[012]\.transformer_blocks\.[0123456789]\.ff\.net\.2"
@@ -851,13 +851,13 @@ class ModelOptimisations512x512:
 
         # 30 occurrences
         if pattern_up_blocks_0_ff2.search(matmul_path):
-            return self.matmul_configs["2D_FF2_SEQ_LEN_1024"]
+            return self.matmul_configs["2D_FF2_SEQ_LEN_256"]
 
         pattern_up_blocks_1_ff2 = re.compile(r"up_blocks\.1\.attentions\.[012]\.transformer_blocks\.[01]\.ff\.net\.2")
 
         # 6 occurrences
         if pattern_up_blocks_1_ff2.search(matmul_path):
-            return self.matmul_configs["2D_FF2_SEQ_LEN_4096"]
+            return self.matmul_configs["2D_FF2_SEQ_LEN_1024"]
 
         pattern_resnet_linear = re.compile(
             r"(down_blocks\.[012]\.resnets\.[01]\.linear|up_blocks\.[012]\.resnets\.[012]\.linear|mid_block\.resnets\.[01]\.linear)"
@@ -878,10 +878,7 @@ class ModelOptimisations512x512:
             if not "to_out" in module_path:
                 return ttnn.L1_MEMORY_CONFIG
             else:
-                if "down_blocks.1" in module_path or "up_blocks.1" in module_path:
-                    return ttnn.L1_MEMORY_CONFIG
-                else:
-                    return ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG
+                return ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG
         if "ff.net" in module_path:
             return ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG
         if "attentions" in module_path and "proj_in" in module_path:

--- a/models/demos/stable_diffusion_xl_base/tt/tt_feedforward.py
+++ b/models/demos/stable_diffusion_xl_base/tt/tt_feedforward.py
@@ -4,6 +4,7 @@
 
 import ttnn
 from models.common.lightweightmodule import LightweightModule
+from models.demos.stable_diffusion_xl_base.tt.model_configs import get_image_resolution_from_model_config
 from models.demos.stable_diffusion_xl_base.tt.sdxl_utility import prepare_linear_params
 from models.demos.stable_diffusion_xl_base.tt.tt_geglu import TtGEGLU
 
@@ -20,6 +21,7 @@ class TtFeedForward(LightweightModule):
         super().__init__()
 
         self.device = device
+        self.image_resolution = get_image_resolution_from_model_config(model_config)
         self.tt_geglu = TtGEGLU(
             device, state_dict, f"{module_path}.net.0", model_config, lora_weights_manager=lora_weights_manager
         )
@@ -40,8 +42,20 @@ class TtFeedForward(LightweightModule):
         self.ff2_memory_config = model_config.get_mm_output_memory_config(f"{module_path}.net.2")
 
     def forward(self, hidden_states):
+        # Reshard hidden_states to the appropriate grid_size used in feedforward layer
+        if self.image_resolution == (512, 512) and hidden_states.shape[-1] == 1280:
+            mem_cfg = ttnn.create_sharded_memory_config(
+                shape=hidden_states.shape,
+                core_grid=ttnn.CoreGrid(x=8, y=4),
+                strategy=ttnn.ShardStrategy.BLOCK,
+                orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            )
+            hidden_states = ttnn.to_memory_config(hidden_states, mem_cfg)
+
+        # GEGLU
         hidden_states = self.tt_geglu(hidden_states)
 
+        # ff.net.2 linear
         hidden_states = ttnn.linear(
             hidden_states,
             self.tt_weights,
@@ -50,5 +64,15 @@ class TtFeedForward(LightweightModule):
             memory_config=self.ff2_memory_config,
             compute_kernel_config=self.default_compute_kernel_config,
         )
+
+        # In order not to break the following layers, we need to reshard back to the original grid size
+        if self.image_resolution == (512, 512) and hidden_states.shape[-1] == 1280:
+            mem_cfg = ttnn.create_sharded_memory_config(
+                shape=hidden_states.shape,
+                core_grid=ttnn.CoreGrid(x=5, y=8),
+                strategy=ttnn.ShardStrategy.BLOCK,
+                orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            )
+            hidden_states = ttnn.to_memory_config(hidden_states, mem_cfg)
 
         return hidden_states


### PR DESCRIPTION
### Ticket
#35733

### Problem description
The goal of this PR is to further improve the perf of UNet base on 512x512 image resolution. This was achieved by changing the shape of core grid on which the matmuls from Feedforward layers run. This change only affect Feedforward layers in 512x512 image resolution and `down_blocks.2` block.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/22772210435)
- [ ] [(Single-card) Demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/22772259329)
- [ ] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/22842732827)
- [ ] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/22842767869)
- [ ] [TT-metal L2 nightly](https://github.com/tenstorrent/tt-metal/actions/runs/22772377007)
