### PR TITLE
Add support for num_q_heads > 32 in nlp_create_qkv_heads

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads_decode.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads_decode.py
@@ -185,7 +185,15 @@ def run_test_create_head_max_width_shard(device, n_local_heads, n_local_kv_heads
 
 @pytest.mark.parametrize(
     "n_local_heads, n_local_kv_heads, head_dim, batch",
-    ((8, 1, 128, 32), (8, 4, 96, 32), (16, 2, 64, 32), (8, 1, 128, 16), (8, 1, 128, 8), (32, 8, 128, 4)),
+    (
+        (8, 1, 128, 32),
+        (8, 4, 96, 32),
+        (16, 2, 64, 32),
+        (8, 1, 128, 16),
+        (8, 1, 128, 8),
+        (32, 8, 128, 4),
+        (64, 8, 96, 1),
+    ),
 )
 def test_create_head_max_width_shard(
     n_local_heads,

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/reader_interleaved_tm_tile_layout_nlp_create_qkv_heads_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/reader_interleaved_tm_tile_layout_nlp_create_qkv_heads_decode.cpp
@@ -4,7 +4,9 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include <tt-metalium/constants.hpp>
 
+using namespace tt::constants;
 void kernel_main() {
     uint32_t in_tile_offset_by_batch = get_arg_val<uint32_t>(0);
     uint32_t q_start_addr = get_arg_val<uint32_t>(1);
@@ -30,8 +32,14 @@ void kernel_main() {
     uint32_t q_write_addr = 0;
     uint32_t qkv_tile_id = 0;
 
+    constexpr uint32_t HALF_TILE_ELEMENTS = FACE_HEIGHT * TILE_WIDTH;
     for (uint32_t q = 0; q < num_q_heads; ++q) {
-        uint32_t wptr_offset = q < 16 ? q * SUBTILE_LINE_BYTES : (q - 16) * SUBTILE_LINE_BYTES + 512 * ELEMENT_SIZE;
+        uint32_t tile_row_index = q / TILE_HEIGHT;
+        uint32_t row_in_tile = q % TILE_HEIGHT;
+        uint32_t offset_in_tile = row_in_tile < FACE_HEIGHT ? row_in_tile * SUBTILE_LINE_BYTES
+                                                            : (row_in_tile - FACE_HEIGHT) * SUBTILE_LINE_BYTES +
+                                                                  HALF_TILE_ELEMENTS * ELEMENT_SIZE;
+        uint32_t wptr_offset = tile_row_index * head_size + offset_in_tile;
         uint32_t q_write_addr = get_write_ptr(cb_id_q_out) + wptr_offset;
 
         for (uint32_t i = 0; i < head_size_num_tiles; ++i) {
@@ -60,7 +68,12 @@ void kernel_main() {
 
     // Read 2 phases per tile, where there are num_q_heads * q_num_tiles tiles
     for (uint32_t k = 0; k < num_kv_heads; ++k) {
-        uint32_t wptr_offset = k < 16 ? k * SUBTILE_LINE_BYTES : (k - 16) * SUBTILE_LINE_BYTES + 512 * ELEMENT_SIZE;
+        uint32_t tile_row_index = k / TILE_HEIGHT;
+        uint32_t row_in_tile = k % TILE_HEIGHT;
+        uint32_t offset_in_tile = row_in_tile < FACE_HEIGHT ? row_in_tile * SUBTILE_LINE_BYTES
+                                                            : (row_in_tile - FACE_HEIGHT) * SUBTILE_LINE_BYTES +
+                                                                  HALF_TILE_ELEMENTS * ELEMENT_SIZE;
+        uint32_t wptr_offset = tile_row_index * head_size + offset_in_tile;
         uint32_t k_write_addr = get_write_ptr(cb_id_k_out) + wptr_offset;
 
         for (uint32_t i = 0; i < head_size_num_tiles; ++i) {
@@ -89,7 +102,12 @@ void kernel_main() {
 
     // Read 2 phases per tile, where there are num_q_heads * q_num_tiles tiles
     for (uint32_t v = 0; v < num_kv_heads; ++v) {
-        uint32_t wptr_offset = v < 16 ? v * SUBTILE_LINE_BYTES : (v - 16) * SUBTILE_LINE_BYTES + 512 * ELEMENT_SIZE;
+        uint32_t tile_row_index = v / TILE_HEIGHT;
+        uint32_t row_in_tile = v % TILE_HEIGHT;
+        uint32_t offset_in_tile = row_in_tile < FACE_HEIGHT ? row_in_tile * SUBTILE_LINE_BYTES
+                                                            : (row_in_tile - FACE_HEIGHT) * SUBTILE_LINE_BYTES +
+                                                                  HALF_TILE_ELEMENTS * ELEMENT_SIZE;
+        uint32_t wptr_offset = tile_row_index * head_size + offset_in_tile;
         uint32_t v_write_addr = get_write_ptr(cb_id_v_out) + wptr_offset;
 
         for (uint32_t i = 0; i < head_size_num_tiles; ++i) {

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/reader_interleaved_tm_tile_layout_nlp_create_qkv_heads_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/reader_interleaved_tm_tile_layout_nlp_create_qkv_heads_decode.cpp
@@ -6,7 +6,6 @@
 #include "api/dataflow/dataflow_api.h"
 #include <tt-metalium/constants.hpp>
 
-using namespace tt::constants;
 void kernel_main() {
     uint32_t in_tile_offset_by_batch = get_arg_val<uint32_t>(0);
     uint32_t q_start_addr = get_arg_val<uint32_t>(1);
@@ -32,13 +31,14 @@ void kernel_main() {
     uint32_t q_write_addr = 0;
     uint32_t qkv_tile_id = 0;
 
-    constexpr uint32_t HALF_TILE_ELEMENTS = FACE_HEIGHT * TILE_WIDTH;
+    constexpr uint32_t HALF_TILE_ELEMENTS = tt::constants::FACE_HEIGHT * tt::constants::TILE_WIDTH;
     for (uint32_t q = 0; q < num_q_heads; ++q) {
-        uint32_t tile_row_index = q / TILE_HEIGHT;
-        uint32_t row_in_tile = q % TILE_HEIGHT;
-        uint32_t offset_in_tile = row_in_tile < FACE_HEIGHT ? row_in_tile * SUBTILE_LINE_BYTES
-                                                            : (row_in_tile - FACE_HEIGHT) * SUBTILE_LINE_BYTES +
-                                                                  HALF_TILE_ELEMENTS * ELEMENT_SIZE;
+        uint32_t tile_row_index = q / tt::constants::TILE_HEIGHT;
+        uint32_t row_in_tile = q % tt::constants::TILE_HEIGHT;
+        uint32_t offset_in_tile =
+            row_in_tile < tt::constants::FACE_HEIGHT
+                ? row_in_tile * SUBTILE_LINE_BYTES
+                : (row_in_tile - tt::constants::FACE_HEIGHT) * SUBTILE_LINE_BYTES + HALF_TILE_ELEMENTS * ELEMENT_SIZE;
         uint32_t wptr_offset = tile_row_index * head_size + offset_in_tile;
         uint32_t q_write_addr = get_write_ptr(cb_id_q_out) + wptr_offset;
 
@@ -68,11 +68,12 @@ void kernel_main() {
 
     // Read 2 phases per tile, where there are num_q_heads * q_num_tiles tiles
     for (uint32_t k = 0; k < num_kv_heads; ++k) {
-        uint32_t tile_row_index = k / TILE_HEIGHT;
-        uint32_t row_in_tile = k % TILE_HEIGHT;
-        uint32_t offset_in_tile = row_in_tile < FACE_HEIGHT ? row_in_tile * SUBTILE_LINE_BYTES
-                                                            : (row_in_tile - FACE_HEIGHT) * SUBTILE_LINE_BYTES +
-                                                                  HALF_TILE_ELEMENTS * ELEMENT_SIZE;
+        uint32_t tile_row_index = k / tt::constants::TILE_HEIGHT;
+        uint32_t row_in_tile = k % tt::constants::TILE_HEIGHT;
+        uint32_t offset_in_tile =
+            row_in_tile < tt::constants::FACE_HEIGHT
+                ? row_in_tile * SUBTILE_LINE_BYTES
+                : (row_in_tile - tt::constants::FACE_HEIGHT) * SUBTILE_LINE_BYTES + HALF_TILE_ELEMENTS * ELEMENT_SIZE;
         uint32_t wptr_offset = tile_row_index * head_size + offset_in_tile;
         uint32_t k_write_addr = get_write_ptr(cb_id_k_out) + wptr_offset;
 
@@ -102,11 +103,12 @@ void kernel_main() {
 
     // Read 2 phases per tile, where there are num_q_heads * q_num_tiles tiles
     for (uint32_t v = 0; v < num_kv_heads; ++v) {
-        uint32_t tile_row_index = v / TILE_HEIGHT;
-        uint32_t row_in_tile = v % TILE_HEIGHT;
-        uint32_t offset_in_tile = row_in_tile < FACE_HEIGHT ? row_in_tile * SUBTILE_LINE_BYTES
-                                                            : (row_in_tile - FACE_HEIGHT) * SUBTILE_LINE_BYTES +
-                                                                  HALF_TILE_ELEMENTS * ELEMENT_SIZE;
+        uint32_t tile_row_index = v / tt::constants::TILE_HEIGHT;
+        uint32_t row_in_tile = v % tt::constants::TILE_HEIGHT;
+        uint32_t offset_in_tile =
+            row_in_tile < tt::constants::FACE_HEIGHT
+                ? row_in_tile * SUBTILE_LINE_BYTES
+                : (row_in_tile - tt::constants::FACE_HEIGHT) * SUBTILE_LINE_BYTES + HALF_TILE_ELEMENTS * ELEMENT_SIZE;
         uint32_t wptr_offset = tile_row_index * head_size + offset_in_tile;
         uint32_t v_write_addr = get_write_ptr(cb_id_v_out) + wptr_offset;
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/reader_tm_tile_layout_nlp_create_qkv_heads_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/reader_tm_tile_layout_nlp_create_qkv_heads_decode.cpp
@@ -75,7 +75,12 @@ void kernel_main() {
     // Skip Q section if PROCESS_QV is False
     if constexpr (PROCESS_QV == 1) {
         for (uint32_t q = 0; q < num_q_heads; ++q) {
-            uint32_t wptr_offset = q < SUBTILE_ROWS ? q * SUBTILE_LINE_BYTES : (q - SUBTILE_ROWS) * SUBTILE_LINE_BYTES + HALF_TILE_ELEMENTS * ELEMENT_SIZE;
+            uint32_t tile_row_index = q / TILE_HEIGHT;
+            uint32_t row_in_tile = q % TILE_HEIGHT;
+            uint32_t offset_in_tile = row_in_tile < SUBTILE_ROWS ? row_in_tile * SUBTILE_LINE_BYTES
+                                                                 : (row_in_tile - SUBTILE_ROWS) * SUBTILE_LINE_BYTES +
+                                                                       HALF_TILE_ELEMENTS * ELEMENT_SIZE;
+            uint32_t wptr_offset = tile_row_index * head_size + offset_in_tile;
             uint32_t q_write_addr = get_write_ptr(cb_id_q_out) + wptr_offset;
             for (uint32_t i = 0; i < head_size_num_tiles; ++i) {
                 // Read first phase
@@ -116,7 +121,12 @@ void kernel_main() {
 
         // Read 2 phases per tile, where there are num_q_heads * q_num_tiles tiles
         for (uint32_t k = 0; k < num_kv_heads; ++k) {
-            uint32_t wptr_offset = k < SUBTILE_ROWS ? k * SUBTILE_LINE_BYTES : (k - SUBTILE_ROWS) * SUBTILE_LINE_BYTES + HALF_TILE_ELEMENTS * ELEMENT_SIZE;
+            uint32_t tile_row_index = k / TILE_HEIGHT;
+            uint32_t row_in_tile = k % TILE_HEIGHT;
+            uint32_t offset_in_tile = row_in_tile < SUBTILE_ROWS ? row_in_tile * SUBTILE_LINE_BYTES
+                                                                 : (row_in_tile - SUBTILE_ROWS) * SUBTILE_LINE_BYTES +
+                                                                       HALF_TILE_ELEMENTS * ELEMENT_SIZE;
+            uint32_t wptr_offset = tile_row_index * head_size + offset_in_tile;
             uint32_t k_write_addr = get_write_ptr(cb_id_k_out) + wptr_offset;
             for (uint32_t i = 0; i < head_size_num_tiles; ++i) {
                 // Read first phase
@@ -156,7 +166,12 @@ void kernel_main() {
 
         // Read 2 phases per tile, where there are num_q_heads * q_num_tiles tiles
         for (uint32_t v = 0; v < num_kv_heads; ++v) {
-            uint32_t wptr_offset = v < SUBTILE_ROWS ? v * SUBTILE_LINE_BYTES : (v - SUBTILE_ROWS) * SUBTILE_LINE_BYTES + HALF_TILE_ELEMENTS * ELEMENT_SIZE;
+            uint32_t tile_row_index = v / TILE_HEIGHT;
+            uint32_t row_in_tile = v % TILE_HEIGHT;
+            uint32_t offset_in_tile = row_in_tile < SUBTILE_ROWS ? row_in_tile * SUBTILE_LINE_BYTES
+                                                                 : (row_in_tile - SUBTILE_ROWS) * SUBTILE_LINE_BYTES +
+                                                                       HALF_TILE_ELEMENTS * ELEMENT_SIZE;
+            uint32_t wptr_offset = tile_row_index * head_size + offset_in_tile;
             uint32_t v_write_addr = get_write_ptr(cb_id_v_out) + wptr_offset;
             for (uint32_t i = 0; i < head_size_num_tiles; ++i) {
                 // Read first phase

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/reader_tm_tile_layout_nlp_create_qkv_heads_decode_on_subcoregrids.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/reader_tm_tile_layout_nlp_create_qkv_heads_decode_on_subcoregrids.cpp
@@ -72,9 +72,12 @@ void kernel_main() {
     // Skip Q section if PROCESS_QV is False
     if constexpr (PROCESS_QV == 1) {
         for (uint32_t q = 0; q < num_q_heads; ++q) {
-            uint32_t wptr_offset = q < SUBTILE_ROWS
-                                       ? q * SUBTILE_LINE_BYTES
-                                       : (q - SUBTILE_ROWS) * SUBTILE_LINE_BYTES + HALF_TILE_ELEMENTS * ELEMENT_SIZE;
+            uint32_t tile_row_index = q / TILE_HEIGHT;
+            uint32_t row_in_tile = q % TILE_HEIGHT;
+            uint32_t offset_in_tile = row_in_tile < SUBTILE_ROWS ? row_in_tile * SUBTILE_LINE_BYTES
+                                                                 : (row_in_tile - SUBTILE_ROWS) * SUBTILE_LINE_BYTES +
+                                                                       HALF_TILE_ELEMENTS * ELEMENT_SIZE;
+            uint32_t wptr_offset = tile_row_index * head_size + offset_in_tile;
             uint32_t q_write_addr = get_write_ptr(cb_id_q_out) + wptr_offset;
             for (uint32_t i = 0; i < head_size_num_tiles; ++i) {
                 // Read first phase
@@ -114,9 +117,12 @@ void kernel_main() {
 
         // Read 2 phases per tile, where there are num_q_heads * q_num_tiles tiles
         for (uint32_t k = 0; k < num_kv_heads; ++k) {
-            uint32_t wptr_offset = k < SUBTILE_ROWS
-                                       ? k * SUBTILE_LINE_BYTES
-                                       : (k - SUBTILE_ROWS) * SUBTILE_LINE_BYTES + HALF_TILE_ELEMENTS * ELEMENT_SIZE;
+            uint32_t tile_row_index = k / TILE_HEIGHT;
+            uint32_t row_in_tile = k % TILE_HEIGHT;
+            uint32_t offset_in_tile = row_in_tile < SUBTILE_ROWS ? row_in_tile * SUBTILE_LINE_BYTES
+                                                                 : (row_in_tile - SUBTILE_ROWS) * SUBTILE_LINE_BYTES +
+                                                                       HALF_TILE_ELEMENTS * ELEMENT_SIZE;
+            uint32_t wptr_offset = tile_row_index * head_size + offset_in_tile;
             uint32_t k_write_addr = get_write_ptr(cb_id_k_out) + wptr_offset;
             for (uint32_t i = 0; i < head_size_num_tiles; ++i) {
                 // Read first phase
@@ -156,9 +162,12 @@ void kernel_main() {
 
         // Read 2 phases per tile, where there are num_q_heads * q_num_tiles tiles
         for (uint32_t v = 0; v < num_kv_heads; ++v) {
-            uint32_t wptr_offset = v < SUBTILE_ROWS
-                                       ? v * SUBTILE_LINE_BYTES
-                                       : (v - SUBTILE_ROWS) * SUBTILE_LINE_BYTES + HALF_TILE_ELEMENTS * ELEMENT_SIZE;
+            uint32_t tile_row_index = v / TILE_HEIGHT;
+            uint32_t row_in_tile = v % TILE_HEIGHT;
+            uint32_t offset_in_tile = row_in_tile < SUBTILE_ROWS ? row_in_tile * SUBTILE_LINE_BYTES
+                                                                 : (row_in_tile - SUBTILE_ROWS) * SUBTILE_LINE_BYTES +
+                                                                       HALF_TILE_ELEMENTS * ELEMENT_SIZE;
+            uint32_t wptr_offset = tile_row_index * head_size + offset_in_tile;
             uint32_t v_write_addr = get_write_ptr(cb_id_v_out) + wptr_offset;
             for (uint32_t i = 0; i < head_size_num_tiles; ++i) {
                 // Read first phase

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_device_operation.cpp
@@ -91,10 +91,6 @@ void NLPCreateQKVHeadsDecodeDeviceOperation::validate_on_program_cache_miss(
 
     // Support maximum 32 heads for now
     TT_FATAL(
-        operation_attributes.num_q_heads <= 32,
-        "There are {} q heads only 32 are supported",
-        operation_attributes.num_q_heads);
-    TT_FATAL(
         operation_attributes.num_q_heads >= operation_attributes.num_kv_heads,
         "num_q_heads={} must be greater than or equal to num_kv_heads={}",
         operation_attributes.num_q_heads,
@@ -133,7 +129,7 @@ std::vector<ttnn::TensorSpec> NLPCreateQKVHeadsDecodeDeviceOperation::compute_ou
     const Shape& k_output_shape = v_output_shape;
 
     auto num_q_heads_padded = ((operation_attributes.num_q_heads - 1) / TILE_HEIGHT + 1) * TILE_HEIGHT;
-    auto num_kv_heads_padded = ((operation_attributes.num_q_heads - 1) / TILE_HEIGHT + 1) * TILE_HEIGHT;
+    auto num_kv_heads_padded = ((operation_attributes.num_kv_heads - 1) / TILE_HEIGHT + 1) * TILE_HEIGHT;
 
     CoreRangeSet output_core_grid = operation_attributes.output_mem_config.shard_spec().value().grid;
     CoreRangeSet q_shard_grid, k_shard_grid, v_shard_grid;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_sharded_program_factory.cpp
@@ -91,8 +91,8 @@ NLPCreateQKVHeadsDecodeShardedProgramFactory::cached_program_t NLPCreateQKVHeads
             .set_globally_allocated_address(*output[1].buffer());
     auto cb_k_output = CreateCircularBuffer(program, k_cores, cb_k_output_config);
 
-    auto v_shard_spec = output[0].shard_spec().value();
-    auto v_cores = q_shard_spec.grid;
+    auto v_shard_spec = output[2].shard_spec().value();
+    auto v_cores = v_shard_spec.grid;
     auto v_num_tiles = v_shard_spec.shape[0] * v_shard_spec.shape[1] / TILE_HW;
 
     uint32_t v_output_cb_index = CBIndex::c_18;


### PR DESCRIPTION
### Problem description
nlp_create_qkv_heads_decode doesn't support num_q_heads > 32, as the kernels currently only support writing to a single tile height.

### What's changed
Removed assert for num_q_heads <=32. 
Enabled support for num_q_heads > 32 by updating the kernels for multi tile output height.

### Checklist


- [x] Nightly L2 tests Group 4 of FD Unit Tests [passes](https://github.com/tenstorrent/tt-metal/actions/runs/23285443917/job/67708328429)
- [x] New/Existing tests provide coverage for changes
