### PR TITLE
[Blaze DS] Consolidate prefill + decode into ModelPipeline.run_inference()

### DIFF
--- a/models/demos/deepseek_v3_b1/demo/cli.py
+++ b/models/demos/deepseek_v3_b1/demo/cli.py
@@ -95,7 +95,9 @@ def _fabric_config_for_num_procs(num_procs: int):
         return ttnn.FabricConfig.FABRIC_2D
     if num_procs == 16:
         return ttnn.FabricConfig.FABRIC_2D_TORUS_Y
-    raise ValueError(f"Unsupported num_procs for fabric config: {num_procs} (expected 4 or 16)")
+    if num_procs == 64:
+        return ttnn.FabricConfig.FABRIC_2D_TORUS_Y
+    raise ValueError(f"Unsupported num_procs for fabric config: {num_procs} (expected 4, 16, or 64)")
 
 
 @contextlib.contextmanager
@@ -280,7 +282,7 @@ def run_demo(
 
     with open_mesh_device() as mesh_device:
         num_procs = int(ttnn.distributed_context_get_size())
-        if num_procs not in (4, 16):
+        if num_procs not in (4, 16, 64):
             raise RuntimeError(f"Pod pipeline requires 4 or 16 distributed processes; got {num_procs}")
         ttnn.enable_asynchronous_slow_dispatch(mesh_device)
 

--- a/models/demos/deepseek_v3_b1/demo/cli.py
+++ b/models/demos/deepseek_v3_b1/demo/cli.py
@@ -19,101 +19,17 @@ import ttnn
 from conftest import bh_2d_mesh_device_context
 from models.common.utility_functions import is_slow_dispatch
 from models.demos.deepseek_v3_b1.demo.pipeline import (
-    WeightProvider,
     create_fabric_router_config,
     create_pipeline_configuration_from_num_procs,
 )
-from models.demos.deepseek_v3_b1.model import TOKEN_ID_BYTES, DeepSeekV3, page_size_bytes, to_padded_input
-from models.demos.deepseek_v3_b1.prepare_weights import (
-    NUM_ROUTED_EXPERTS,
-    DeepSeekV3DenseLayerWeights,
-    DeepSeekV3EmbeddingLayerWeights,
-    DeepSeekV3LMHeadWeights,
-    DeepSeekV3MoELayerWeights,
-    load_dense_decoder_layer,
-    load_embedding_weights,
-    load_lm_head_weights,
-    load_moe_decoder_layer,
-    load_moe_routed_experts,
-    prepare_dense_layer_weights,
-    prepare_embedding_weights,
-    prepare_lm_head_weights,
-    prepare_moe_layer_weights,
+from models.demos.deepseek_v3_b1.demo.weight_provider import (
+    CacheWeightProvider,
+    SyntheticWeightProvider,
+    WeightProvider,
 )
+from models.demos.deepseek_v3_b1.model import TOKEN_ID_BYTES, DeepSeekV3, page_size_bytes, to_padded_input
 
 DEFAULT_TOKENIZER = "deepseek-ai/DeepSeek-V3"
-FIRST_K_DENSE_REPLACE = 3
-
-
-def _layer_key(layer_id: int, suffix: str) -> str:
-    """State dict key under model.layers.{layer_id}."""
-    return f"model.layers.{layer_id}.{suffix}"
-
-
-def _build_synthetic_moe_state_dict(
-    layer_id: int,
-    *,
-    num_routed_experts: int = NUM_ROUTED_EXPERTS,
-) -> dict[str, torch.Tensor]:
-    """Build a synthetic MoE layer state dict with HF tensor shapes (randn for weights, ones for norms)."""
-    state_dict: dict[str, torch.Tensor] = {}
-    dtype = torch.bfloat16
-
-    # Attention weights (HF shapes)
-    state_dict[_layer_key(layer_id, "self_attn.q_a_proj.weight")] = torch.randn(1536, 7168, dtype=dtype)
-    state_dict[_layer_key(layer_id, "self_attn.q_b_proj.weight")] = torch.randn(24576, 1536, dtype=dtype)
-    state_dict[_layer_key(layer_id, "self_attn.kv_a_proj_with_mqa.weight")] = torch.randn(576, 7168, dtype=dtype)
-    state_dict[_layer_key(layer_id, "self_attn.kv_b_proj.weight")] = torch.randn(32768, 512, dtype=dtype)
-    state_dict[_layer_key(layer_id, "self_attn.o_proj.weight")] = torch.randn(7168, 16384, dtype=dtype)
-
-    # Norms (ones per plan)
-    state_dict[_layer_key(layer_id, "input_layernorm.weight")] = torch.ones(7168, dtype=dtype)
-    state_dict[_layer_key(layer_id, "self_attn.q_a_layernorm.weight")] = torch.ones(1536, dtype=dtype)
-    state_dict[_layer_key(layer_id, "self_attn.kv_a_layernorm.weight")] = torch.ones(512, dtype=dtype)
-    state_dict[_layer_key(layer_id, "post_attention_layernorm.weight")] = torch.ones(7168, dtype=dtype)
-
-    # MoE gate
-    state_dict[_layer_key(layer_id, "mlp.gate.weight")] = torch.randn(256, 7168, dtype=dtype)
-    state_dict[_layer_key(layer_id, "mlp.gate.e_score_correction_bias")] = torch.randn(256, dtype=dtype)
-
-    # Shared experts
-    state_dict[_layer_key(layer_id, "mlp.shared_experts.gate_proj.weight")] = torch.randn(2048, 7168, dtype=dtype)
-    state_dict[_layer_key(layer_id, "mlp.shared_experts.up_proj.weight")] = torch.randn(2048, 7168, dtype=dtype)
-    state_dict[_layer_key(layer_id, "mlp.shared_experts.down_proj.weight")] = torch.randn(7168, 2048, dtype=dtype)
-
-    # Routed experts
-    for e in range(num_routed_experts):
-        state_dict[_layer_key(layer_id, f"mlp.experts.{e}.gate_proj.weight")] = torch.randn(2048, 7168, dtype=dtype)
-        state_dict[_layer_key(layer_id, f"mlp.experts.{e}.up_proj.weight")] = torch.randn(2048, 7168, dtype=dtype)
-        state_dict[_layer_key(layer_id, f"mlp.experts.{e}.down_proj.weight")] = torch.randn(7168, 2048, dtype=dtype)
-
-    return state_dict
-
-
-def _build_synthetic_dense_state_dict(layer_id: int) -> dict[str, torch.Tensor]:
-    """Build a synthetic dense layer state dict with HF tensor shapes (randn for weights, ones for norms)."""
-    state_dict: dict[str, torch.Tensor] = {}
-    dtype = torch.bfloat16
-
-    # Attention weights (HF shapes)
-    state_dict[_layer_key(layer_id, "self_attn.q_a_proj.weight")] = torch.randn(1536, 7168, dtype=dtype)
-    state_dict[_layer_key(layer_id, "self_attn.q_b_proj.weight")] = torch.randn(24576, 1536, dtype=dtype)
-    state_dict[_layer_key(layer_id, "self_attn.kv_a_proj_with_mqa.weight")] = torch.randn(576, 7168, dtype=dtype)
-    state_dict[_layer_key(layer_id, "self_attn.kv_b_proj.weight")] = torch.randn(32768, 512, dtype=dtype)
-    state_dict[_layer_key(layer_id, "self_attn.o_proj.weight")] = torch.randn(7168, 16384, dtype=dtype)
-
-    # Norms (ones per plan)
-    state_dict[_layer_key(layer_id, "input_layernorm.weight")] = torch.ones(7168, dtype=dtype)
-    state_dict[_layer_key(layer_id, "self_attn.q_a_layernorm.weight")] = torch.ones(1536, dtype=dtype)
-    state_dict[_layer_key(layer_id, "self_attn.kv_a_layernorm.weight")] = torch.ones(512, dtype=dtype)
-    state_dict[_layer_key(layer_id, "post_attention_layernorm.weight")] = torch.ones(7168, dtype=dtype)
-
-    # Single MLP (used for both shared and routed in dense)
-    state_dict[_layer_key(layer_id, "mlp.gate_proj.weight")] = torch.randn(2048, 7168, dtype=dtype)
-    state_dict[_layer_key(layer_id, "mlp.up_proj.weight")] = torch.randn(2048, 7168, dtype=dtype)
-    state_dict[_layer_key(layer_id, "mlp.down_proj.weight")] = torch.randn(7168, 2048, dtype=dtype)
-
-    return state_dict
 
 
 def _fabric_config_for_num_procs(num_procs: int):
@@ -146,106 +62,6 @@ def open_mesh_device():
             mesh_device.shape,
         )
         yield mesh_device
-
-
-def decoder_layer_id_from_mesh_id(mesh_id: int) -> int:
-    """
-    Layer ID is the index of the layer in the original model (i.e. layer 0-3 are dense layers, layer 4-60 are MoE layers)
-    The mesh ID is the pipeline stage index (0 is embedding, 1-3 are dense layers, 4-61 are MoE, and 62 is LM head + sampling)
-    """
-    assert mesh_id > 0 and mesh_id <= 61, f"Cannot get layer ID from mesh ID: {mesh_id}"
-    return mesh_id - 1
-
-
-SYSTEM_MESH_ID_EMBEDDING = 0
-SYSTEM_MESH_ID_LM_HEAD = 62
-
-
-class CacheWeightProvider:
-    """Load embedding and LM head weights from cache; each host loads only what its stage needs."""
-
-    def __init__(self, cache_path: Path) -> None:
-        assert cache_path.exists(), f"Cache path does not exist: {cache_path}"
-        assert cache_path.is_dir(), f"Cache path is not a directory: {cache_path}"
-        self._path = cache_path
-
-    def load_embedding(self, device: ttnn.MeshDevice) -> DeepSeekV3EmbeddingLayerWeights:
-        return load_embedding_weights(self._path, device)
-
-    def load_lm_head(self, device: ttnn.MeshDevice) -> DeepSeekV3LMHeadWeights:
-        return load_lm_head_weights(self._path, device)
-
-    def load_moe_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3MoELayerWeights:
-        with ttnn.device.setup_fast_dispatch(device):
-            preloaded_experts = load_moe_routed_experts(self._path, device, layer_id)
-        return load_moe_decoder_layer(self._path, device, layer_id, preloaded_routed_experts=preloaded_experts)
-
-    def load_dense_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3DenseLayerWeights:
-        return load_dense_decoder_layer(self._path, device, layer_id)
-
-
-class SyntheticWeightProvider:
-    """Create deterministic synthetic embedding and LM head weights in place (no cache)."""
-
-    def load_embedding(self, device: ttnn.MeshDevice) -> DeepSeekV3EmbeddingLayerWeights:
-        emb_w = torch.zeros((129280, 7168), dtype=torch.bfloat16)
-        emb_w[torch.arange(129280), torch.arange(129280, dtype=torch.int64) % 7168] = 1
-        return prepare_embedding_weights({"model.embed_tokens.weight": emb_w}, device, move_to_device=True)
-
-    def load_lm_head(self, device: ttnn.MeshDevice) -> DeepSeekV3LMHeadWeights:
-        lm_w = torch.full((129280, 7168), -1.0, dtype=torch.bfloat16)
-        lm_w[torch.arange(7168, dtype=torch.int64) % 16160, torch.arange(7168)] = 1
-        return prepare_lm_head_weights(
-            {
-                "lm_head.weight": lm_w,
-                "model.norm.weight": torch.ones(7168, dtype=torch.bfloat16),
-            },
-            device,
-            move_to_device=True,
-        )
-
-    def load_moe_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3MoELayerWeights:
-        from models.demos.deepseek_v3_b1.blitz_decode_weights import BlitzDecodeWeights
-
-        sd = _build_synthetic_moe_state_dict(layer_id, num_routed_experts=NUM_ROUTED_EXPERTS)
-        bdw = BlitzDecodeWeights(device)
-        return prepare_moe_layer_weights(bdw, sd, layer_id, num_routed_experts=NUM_ROUTED_EXPERTS)
-
-    def load_dense_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3DenseLayerWeights:
-        from models.demos.deepseek_v3_b1.blitz_decode_weights import BlitzDecodeWeights
-
-        sd = _build_synthetic_dense_state_dict(layer_id)
-        bdw = BlitzDecodeWeights(device)
-        return prepare_dense_layer_weights(bdw, sd, layer_id, move_to_device=True)
-
-
-def load_weights_from_cache(
-    cache_path: Path,
-    mesh_device: ttnn.MeshDevice,
-    layer_offset: int,
-) -> (
-    DeepSeekV3EmbeddingLayerWeights | DeepSeekV3DenseLayerWeights | DeepSeekV3MoELayerWeights | DeepSeekV3LMHeadWeights
-):
-    """Load weights from cache (embedding, decoder layer, or lm_head)."""
-    mesh_id = mesh_device.get_system_mesh_id() + layer_offset
-    assert (
-        mesh_id >= SYSTEM_MESH_ID_EMBEDDING and mesh_id <= SYSTEM_MESH_ID_LM_HEAD
-    ), f"Mesh ID must be between {SYSTEM_MESH_ID_EMBEDDING} and {SYSTEM_MESH_ID_LM_HEAD} but got {mesh_id}"
-    if mesh_id == SYSTEM_MESH_ID_EMBEDDING:
-        logger.info("Loading embedding weights from cache")
-        return load_embedding_weights(cache_path, mesh_device)
-    elif mesh_id == SYSTEM_MESH_ID_LM_HEAD:
-        logger.info("Loading LM head weights from cache")
-        return load_lm_head_weights(cache_path, mesh_device)
-    else:
-        layer_id = decoder_layer_id_from_mesh_id(mesh_id)
-        is_moe = layer_id >= FIRST_K_DENSE_REPLACE
-        logger.info(f"Loading {'moe' if is_moe else 'dense'} layer weights from cache")
-        if is_moe:
-            with ttnn.device.setup_fast_dispatch(mesh_device):
-                preloaded_experts = load_moe_routed_experts(cache_path, mesh_device, layer_id)
-            return load_moe_decoder_layer(cache_path, mesh_device, layer_id, preloaded_routed_experts=preloaded_experts)
-        return load_dense_decoder_layer(cache_path, mesh_device, layer_id)
 
 
 def create_parser() -> argparse.ArgumentParser:

--- a/models/demos/deepseek_v3_b1/demo/cli.py
+++ b/models/demos/deepseek_v3_b1/demo/cli.py
@@ -23,7 +23,7 @@ from models.demos.deepseek_v3_b1.demo.pipeline import (
     create_fabric_router_config,
     create_pipeline_configuration_from_num_procs,
 )
-from models.demos.deepseek_v3_b1.demo.stage import token_page_size_bytes
+from models.demos.deepseek_v3_b1.demo.stage import TOKEN_PAGE_SIZE_BYTES
 from models.demos.deepseek_v3_b1.prepare_weights import (
     NUM_ROUTED_EXPERTS,
     DeepSeekV3DenseLayerWeights,
@@ -35,6 +35,7 @@ from models.demos.deepseek_v3_b1.prepare_weights import (
     load_lm_head_weights,
     load_moe_decoder_layer,
     load_moe_routed_experts,
+    prepare_dense_layer_weights,
     prepare_embedding_weights,
     prepare_lm_head_weights,
     prepare_moe_layer_weights,
@@ -89,6 +90,32 @@ def _build_synthetic_moe_state_dict(
     return state_dict
 
 
+def _build_synthetic_dense_state_dict(layer_id: int) -> dict[str, torch.Tensor]:
+    """Build a synthetic dense layer state dict with HF tensor shapes (randn for weights, ones for norms)."""
+    state_dict: dict[str, torch.Tensor] = {}
+    dtype = torch.bfloat16
+
+    # Attention weights (HF shapes)
+    state_dict[_layer_key(layer_id, "self_attn.q_a_proj.weight")] = torch.randn(1536, 7168, dtype=dtype)
+    state_dict[_layer_key(layer_id, "self_attn.q_b_proj.weight")] = torch.randn(24576, 1536, dtype=dtype)
+    state_dict[_layer_key(layer_id, "self_attn.kv_a_proj_with_mqa.weight")] = torch.randn(576, 7168, dtype=dtype)
+    state_dict[_layer_key(layer_id, "self_attn.kv_b_proj.weight")] = torch.randn(32768, 512, dtype=dtype)
+    state_dict[_layer_key(layer_id, "self_attn.o_proj.weight")] = torch.randn(7168, 16384, dtype=dtype)
+
+    # Norms (ones per plan)
+    state_dict[_layer_key(layer_id, "input_layernorm.weight")] = torch.ones(7168, dtype=dtype)
+    state_dict[_layer_key(layer_id, "self_attn.q_a_layernorm.weight")] = torch.ones(1536, dtype=dtype)
+    state_dict[_layer_key(layer_id, "self_attn.kv_a_layernorm.weight")] = torch.ones(512, dtype=dtype)
+    state_dict[_layer_key(layer_id, "post_attention_layernorm.weight")] = torch.ones(7168, dtype=dtype)
+
+    # Single MLP (used for both shared and routed in dense)
+    state_dict[_layer_key(layer_id, "mlp.gate_proj.weight")] = torch.randn(2048, 7168, dtype=dtype)
+    state_dict[_layer_key(layer_id, "mlp.up_proj.weight")] = torch.randn(2048, 7168, dtype=dtype)
+    state_dict[_layer_key(layer_id, "mlp.down_proj.weight")] = torch.randn(7168, 2048, dtype=dtype)
+
+    return state_dict
+
+
 def _fabric_config_for_num_procs(num_procs: int):
     """Infer fabric config from process count: 4 → FABRIC_2D, 16 → FABRIC_2D_TORUS_Y."""
     if num_procs == 4:
@@ -138,6 +165,8 @@ class CacheWeightProvider:
     """Load embedding and LM head weights from cache; each host loads only what its stage needs."""
 
     def __init__(self, cache_path: Path) -> None:
+        assert cache_path.exists(), f"Cache path does not exist: {cache_path}"
+        assert cache_path.is_dir(), f"Cache path is not a directory: {cache_path}"
         self._path = cache_path
 
     def load_embedding(self, device: ttnn.MeshDevice) -> DeepSeekV3EmbeddingLayerWeights:
@@ -150,6 +179,9 @@ class CacheWeightProvider:
         with ttnn.device.setup_fast_dispatch(device):
             preloaded_experts = load_moe_routed_experts(self._path, device, layer_id)
         return load_moe_decoder_layer(self._path, device, layer_id, preloaded_routed_experts=preloaded_experts)
+
+    def load_dense_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3DenseLayerWeights:
+        return load_dense_decoder_layer(self._path, device, layer_id)
 
 
 class SyntheticWeightProvider:
@@ -178,6 +210,13 @@ class SyntheticWeightProvider:
         sd = _build_synthetic_moe_state_dict(layer_id, num_routed_experts=NUM_ROUTED_EXPERTS)
         bdw = BlitzDecodeWeights(device)
         return prepare_moe_layer_weights(bdw, sd, layer_id, num_routed_experts=NUM_ROUTED_EXPERTS)
+
+    def load_dense_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3DenseLayerWeights:
+        from models.demos.deepseek_v3_b1.blitz_decode_weights import BlitzDecodeWeights
+
+        sd = _build_synthetic_dense_state_dict(layer_id)
+        bdw = BlitzDecodeWeights(device)
+        return prepare_dense_layer_weights(bdw, sd, layer_id, move_to_device=True)
 
 
 def load_weights_from_cache(
@@ -304,11 +343,11 @@ def run_demo(
         if pipeline.my_mesh_id == 0:
             for iteration in range(iterations):
                 logger.info(f"Writing token for iteration {iteration}")
-                torch_token = torch.zeros(1, token_page_size_bytes // 4, dtype=torch.uint32)
+                torch_token = torch.zeros(1, TOKEN_PAGE_SIZE_BYTES // 4, dtype=torch.uint32)
                 torch_token[0, 0] = iteration
                 token_tensor = ttnn.from_torch(torch_token, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
                 output_tensor = ttnn.from_torch(
-                    torch.zeros(1, token_page_size_bytes // 4, dtype=torch.uint32),
+                    torch.zeros(1, TOKEN_PAGE_SIZE_BYTES // 4, dtype=torch.uint32),
                     dtype=ttnn.uint32,
                     layout=ttnn.ROW_MAJOR_LAYOUT,
                 )

--- a/models/demos/deepseek_v3_b1/demo/cli.py
+++ b/models/demos/deepseek_v3_b1/demo/cli.py
@@ -250,7 +250,7 @@ def load_weights_from_cache(
 
 def create_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser("DeepSeek-V3-B1 Demo on TT-NN (pod pipeline)")
-    parser.add_argument("--prompt", type=str, default="", help="Prompt text (for future real decode loop)")
+    parser.add_argument("--prompt", type=str, default="Hello, world!", help="Prompt text (for future real decode loop)")
     parser.add_argument(
         "--max-new-tokens",
         type=int,
@@ -352,6 +352,9 @@ def run_demo(
             dense_layer_id_override=dense_layer_id_override,
             moe_layer_id_override=moe_layer_id_override,
         )
+        assert (
+            config.num_stages == num_procs
+        ), f"Pipeline configuration has {config.num_stages} stages but {num_procs} processes"
 
         logger.info(f"Building pipeline")
         pipeline = config.build_pipeline(mesh_device)
@@ -363,6 +366,7 @@ def run_demo(
             # Prefill + decode pattern per model.py: prefill(prompt) -> sample y0; decode_step(y_t) -> sample y_{t+1}.
             tokenizer = load_tokenizer(tokenizer_name_or_path)
             prompt_ids = tokenizer.encode(prompt, add_special_tokens=True)
+            logger.debug(f"Encoded prompt: {prompt_ids}")
             if not prompt_ids:
                 prompt_ids = [tokenizer.bos_token_id if tokenizer.bos_token_id is not None else 0]
             page_size_datums = page_size_bytes(1) // TOKEN_ID_BYTES
@@ -380,6 +384,7 @@ def run_demo(
                 batch_size=1,
             )
             # Prefill: send prompt tokens; discard outputs for i < S-1; use last output to sample y0.
+            logger.debug(f"Prefilling...")
             last_output = model.prefill(prompt_token_tensors)
             next_token_id = int(ttnn.to_torch(last_output).to(torch.int32)[0, 0].item())
             generated = [next_token_id]

--- a/models/demos/deepseek_v3_b1/demo/cli.py
+++ b/models/demos/deepseek_v3_b1/demo/cli.py
@@ -25,6 +25,7 @@ from models.demos.deepseek_v3_b1.demo.pipeline import (
 )
 from models.demos.deepseek_v3_b1.demo.stage import token_page_size_bytes
 from models.demos.deepseek_v3_b1.prepare_weights import (
+    NUM_ROUTED_EXPERTS,
     DeepSeekV3DenseLayerWeights,
     DeepSeekV3EmbeddingLayerWeights,
     DeepSeekV3LMHeadWeights,
@@ -36,10 +37,56 @@ from models.demos.deepseek_v3_b1.prepare_weights import (
     load_moe_routed_experts,
     prepare_embedding_weights,
     prepare_lm_head_weights,
+    prepare_moe_layer_weights,
 )
 
 DEFAULT_TOKENIZER = "deepseek-ai/DeepSeek-V3"
 FIRST_K_DENSE_REPLACE = 3
+
+
+def _layer_key(layer_id: int, suffix: str) -> str:
+    """State dict key under model.layers.{layer_id}."""
+    return f"model.layers.{layer_id}.{suffix}"
+
+
+def _build_synthetic_moe_state_dict(
+    layer_id: int,
+    *,
+    num_routed_experts: int = NUM_ROUTED_EXPERTS,
+) -> dict[str, torch.Tensor]:
+    """Build a synthetic MoE layer state dict with HF tensor shapes (randn for weights, ones for norms)."""
+    state_dict: dict[str, torch.Tensor] = {}
+    dtype = torch.bfloat16
+
+    # Attention weights (HF shapes)
+    state_dict[_layer_key(layer_id, "self_attn.q_a_proj.weight")] = torch.randn(1536, 7168, dtype=dtype)
+    state_dict[_layer_key(layer_id, "self_attn.q_b_proj.weight")] = torch.randn(24576, 1536, dtype=dtype)
+    state_dict[_layer_key(layer_id, "self_attn.kv_a_proj_with_mqa.weight")] = torch.randn(576, 7168, dtype=dtype)
+    state_dict[_layer_key(layer_id, "self_attn.kv_b_proj.weight")] = torch.randn(32768, 512, dtype=dtype)
+    state_dict[_layer_key(layer_id, "self_attn.o_proj.weight")] = torch.randn(7168, 16384, dtype=dtype)
+
+    # Norms (ones per plan)
+    state_dict[_layer_key(layer_id, "input_layernorm.weight")] = torch.ones(7168, dtype=dtype)
+    state_dict[_layer_key(layer_id, "self_attn.q_a_layernorm.weight")] = torch.ones(1536, dtype=dtype)
+    state_dict[_layer_key(layer_id, "self_attn.kv_a_layernorm.weight")] = torch.ones(512, dtype=dtype)
+    state_dict[_layer_key(layer_id, "post_attention_layernorm.weight")] = torch.ones(7168, dtype=dtype)
+
+    # MoE gate
+    state_dict[_layer_key(layer_id, "mlp.gate.weight")] = torch.randn(256, 7168, dtype=dtype)
+    state_dict[_layer_key(layer_id, "mlp.gate.e_score_correction_bias")] = torch.randn(256, dtype=dtype)
+
+    # Shared experts
+    state_dict[_layer_key(layer_id, "mlp.shared_experts.gate_proj.weight")] = torch.randn(2048, 7168, dtype=dtype)
+    state_dict[_layer_key(layer_id, "mlp.shared_experts.up_proj.weight")] = torch.randn(2048, 7168, dtype=dtype)
+    state_dict[_layer_key(layer_id, "mlp.shared_experts.down_proj.weight")] = torch.randn(7168, 2048, dtype=dtype)
+
+    # Routed experts
+    for e in range(num_routed_experts):
+        state_dict[_layer_key(layer_id, f"mlp.experts.{e}.gate_proj.weight")] = torch.randn(2048, 7168, dtype=dtype)
+        state_dict[_layer_key(layer_id, f"mlp.experts.{e}.up_proj.weight")] = torch.randn(2048, 7168, dtype=dtype)
+        state_dict[_layer_key(layer_id, f"mlp.experts.{e}.down_proj.weight")] = torch.randn(7168, 2048, dtype=dtype)
+
+    return state_dict
 
 
 def _fabric_config_for_num_procs(num_procs: int):
@@ -97,6 +144,11 @@ class CacheWeightProvider:
     def load_lm_head(self, device: ttnn.MeshDevice) -> DeepSeekV3LMHeadWeights:
         return load_lm_head_weights(self._path, device)
 
+    def load_moe_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3MoELayerWeights:
+        with ttnn.device.setup_fast_dispatch(device):
+            preloaded_experts = load_moe_routed_experts(self._path, device, layer_id)
+        return load_moe_decoder_layer(self._path, device, layer_id, preloaded_routed_experts=preloaded_experts)
+
 
 class SyntheticWeightProvider:
     """Create deterministic synthetic embedding and LM head weights in place (no cache)."""
@@ -117,6 +169,13 @@ class SyntheticWeightProvider:
             device,
             move_to_device=True,
         )
+
+    def load_moe_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3MoELayerWeights:
+        from models.demos.deepseek_v3_b1.blitz_decode_weights import BlitzDecodeWeights
+
+        sd = _build_synthetic_moe_state_dict(layer_id, num_routed_experts=NUM_ROUTED_EXPERTS)
+        bdw = BlitzDecodeWeights(device)
+        return prepare_moe_layer_weights(bdw, sd, layer_id, num_routed_experts=NUM_ROUTED_EXPERTS)
 
 
 def load_weights_from_cache(

--- a/models/demos/deepseek_v3_b1/demo/cli.py
+++ b/models/demos/deepseek_v3_b1/demo/cli.py
@@ -9,25 +9,14 @@ import contextlib
 import os
 import sys
 from pathlib import Path
-from typing import TextIO
 
-import torch
 from loguru import logger
 from transformers import AutoTokenizer
 
 import ttnn
 from conftest import bh_2d_mesh_device_context
-from models.common.utility_functions import is_slow_dispatch
-from models.demos.deepseek_v3_b1.demo.pipeline import (
-    create_fabric_router_config,
-    create_pipeline_configuration_from_num_procs,
-)
-from models.demos.deepseek_v3_b1.demo.weight_provider import (
-    CacheWeightProvider,
-    SyntheticWeightProvider,
-    WeightProvider,
-)
-from models.demos.deepseek_v3_b1.model import TOKEN_ID_BYTES, DeepSeekV3, page_size_bytes, to_padded_input
+from models.demos.deepseek_v3_b1.demo.model_pipeline import ModelPipeline
+from models.demos.deepseek_v3_b1.demo.pipeline import create_fabric_router_config
 
 DEFAULT_TOKENIZER = "deepseek-ai/DeepSeek-V3"
 
@@ -136,73 +125,35 @@ def run_demo(
     lm_head_persistent_mode: bool = True,
     dense_layer_id_override: int | None = None,
     moe_layer_id_override: int | None = None,
-    output_stream: TextIO,
 ) -> None:
-    """Run the pod pipeline. Requires 4 or 16 distributed processes."""
+    """Run the pod pipeline. Requires 4, 16, or 64 distributed processes."""
     iterations = max_new_tokens
-    logger.info(
-        "Starting DeepSeek V3 B1 demo pod pipeline (iterations={}, weights={}, lm_head_fp32={}, lm_head_persistent_mode={})",
-        iterations,
-        "real" if use_real_weights else "synthetic",
-        lm_head_fp32_dest_acc_en,
-        lm_head_persistent_mode,
-    )
-    if not is_slow_dispatch():
-        raise RuntimeError(
-            "DeepSeek V3 B1 demo requires slow dispatch mode. Set TT_METAL_SLOW_DISPATCH_MODE=1 and rerun."
-        )
+    logger.info(f"Starting DeepSeek V3 B1 demo (iterations={iterations})")
 
     with open_mesh_device() as mesh_device:
-        num_procs = int(ttnn.distributed_context_get_size())
-        if num_procs not in (4, 16, 64):
-            raise RuntimeError(f"Pod pipeline requires 4 or 16 distributed processes; got {num_procs}")
-        ttnn.enable_asynchronous_slow_dispatch(mesh_device)
-
-        # Each host loads/creates only the weights for its stage via the provider.
-        provider: WeightProvider = CacheWeightProvider(cache_path) if use_real_weights else SyntheticWeightProvider()
-        config = create_pipeline_configuration_from_num_procs(
-            num_procs,
-            provider,
+        # Initialize model pipeline
+        model_pipeline = ModelPipeline(
+            mesh_device=mesh_device,
+            cache_path=cache_path,
+            use_real_weights=use_real_weights,
             lm_head_fp32_dest_acc_en=lm_head_fp32_dest_acc_en,
             lm_head_persistent_mode=lm_head_persistent_mode,
             dense_layer_id_override=dense_layer_id_override,
             moe_layer_id_override=moe_layer_id_override,
         )
-        assert (
-            config.num_stages == num_procs
-        ), f"Pipeline configuration has {config.num_stages} stages but {num_procs} processes"
 
-        logger.info(f"Building pipeline")
-        pipeline = config.build_pipeline(mesh_device)
-
-        logger.info(f"Setting up and running pipeline")
-        pipeline.setup_and_run()
-
-        if pipeline.my_mesh_id == 0:
+        # Run prefill + decode loop
+        my_mesh_id = mesh_device.get_system_mesh_id()
+        if my_mesh_id == 0:
             # Prefill + decode pattern per model.py: prefill(prompt) -> sample y0; decode_step(y_t) -> sample y_{t+1}.
             tokenizer = load_tokenizer(tokenizer_name_or_path)
             prompt_ids = tokenizer.encode(prompt, add_special_tokens=True)
             logger.debug(f"Encoded prompt: {prompt_ids}")
             if not prompt_ids:
                 prompt_ids = [tokenizer.bos_token_id if tokenizer.bos_token_id is not None else 0]
-            page_size_datums = page_size_bytes(1) // TOKEN_ID_BYTES
-            prompt_token_tensors = [
-                to_padded_input(
-                    torch.tensor([[tid]], dtype=torch.int32),
-                    batch_size=1,
-                    page_size_datums=page_size_datums,
-                )
-                for tid in prompt_ids
-            ]
-            model = DeepSeekV3(
-                write_fn=pipeline.write_token,
-                read_fn=pipeline.read_output,
-                batch_size=1,
-            )
+
             # Prefill: send prompt tokens; discard outputs for i < S-1; use last output to sample y0.
-            logger.debug(f"Prefilling...")
-            last_output = model.prefill(prompt_token_tensors)
-            next_token_id = int(ttnn.to_torch(last_output).to(torch.int32)[0, 0].item())
+            next_token_id = model_pipeline.prefill_forward(prompt_ids)
             generated = [next_token_id]
             logger.info(
                 "Prefill done ({} prompt tokens); sampled y0: {}",
@@ -211,15 +162,12 @@ def run_demo(
             )
             # Generation loop: feed y[t], get output, sample y[t+1].
             for step in range(iterations - 1):
-                output = model.decode_step(
-                    torch.tensor([[next_token_id]], dtype=torch.int32),
-                )
-                next_token_id = int(ttnn.to_torch(output).to(torch.int32)[0, 0].item())
+                next_token_id = model_pipeline.decode_forward(next_token_id)
                 generated.append(next_token_id)
                 logger.info("Decode step {} output token: {}", step + 1, next_token_id)
             logger.info("Generated {} tokens total", len(generated))
 
-        pipeline.barrier()
+        model_pipeline.pipeline.barrier()
     logger.info("Pod pipeline complete")
 
 
@@ -238,7 +186,6 @@ def main(argv: list[str] | None = None) -> int:
         lm_head_persistent_mode=args.persistent_mode,
         dense_layer_id_override=args.dense_layer_id_override,
         moe_layer_id_override=args.moe_layer_id_override,
-        output_stream=sys.stdout,
     )
     print(file=sys.stdout, flush=True)
     return 0

--- a/models/demos/deepseek_v3_b1/demo/cli.py
+++ b/models/demos/deepseek_v3_b1/demo/cli.py
@@ -23,7 +23,7 @@ from models.demos.deepseek_v3_b1.demo.pipeline import (
     create_fabric_router_config,
     create_pipeline_configuration_from_num_procs,
 )
-from models.demos.deepseek_v3_b1.demo.stage import TOKEN_PAGE_SIZE_BYTES
+from models.demos.deepseek_v3_b1.model import TOKEN_ID_BYTES, DeepSeekV3, page_size_bytes, to_padded_input
 from models.demos.deepseek_v3_b1.prepare_weights import (
     NUM_ROUTED_EXPERTS,
     DeepSeekV3DenseLayerWeights,
@@ -267,13 +267,14 @@ def create_parser() -> argparse.ArgumentParser:
         "--cache-path",
         type=Path,
         required=True,
-        help="Path to the weight cache directory (for future real weights)",
+        help="Path to the weight cache directory (required for --weights real)",
     )
     parser.add_argument(
-        "--layer-id-offset",
-        type=int,
-        default=0,
-        help="Layer ID offset (for future multi-pod offset)",
+        "--weights",
+        type=str,
+        choices=("synthetic", "real"),
+        default="synthetic",
+        help="Use synthetic or real (cached) weights (default: synthetic)",
     )
     parser.add_argument(
         "--fp32",
@@ -286,6 +287,20 @@ def create_parser() -> argparse.ArgumentParser:
         action=argparse.BooleanOptionalAction,
         default=True,
         help="Use persistent mode for LMHead sampling kernel",
+    )
+    parser.add_argument(
+        "--dense-layer-id-override",
+        type=int,
+        default=None,
+        metavar="ID",
+        help="Force all dense stages to use this layer id (e.g. 0); default: use 0,1,2",
+    )
+    parser.add_argument(
+        "--moe-layer-id-override",
+        type=int,
+        default=None,
+        metavar="ID",
+        help="Force all MoE stages to use this layer id (e.g. 3); default: use stage-dependent layer ids",
     )
     return parser
 
@@ -300,19 +315,21 @@ def run_demo(
     max_new_tokens: int,
     tokenizer_name_or_path: str,
     cache_path: Path,
-    layer_id_offset: int = 0,
-    fp32: bool = True,
-    persistent_mode: bool = True,
+    use_real_weights: bool = False,
+    lm_head_fp32_dest_acc_en: bool = True,
+    lm_head_persistent_mode: bool = True,
+    dense_layer_id_override: int | None = None,
+    moe_layer_id_override: int | None = None,
     output_stream: TextIO,
 ) -> None:
-    """Run the pod pipeline (synthetic weights). Requires 4 or 16 distributed processes."""
+    """Run the pod pipeline. Requires 4 or 16 distributed processes."""
     iterations = max_new_tokens
     logger.info(
-        "Starting DeepSeek V3 B1 demo pod pipeline (iterations={}, layer_id_offset={}, fp32={}, persistent_mode={})",
+        "Starting DeepSeek V3 B1 demo pod pipeline (iterations={}, weights={}, lm_head_fp32={}, lm_head_persistent_mode={})",
         iterations,
-        layer_id_offset,
-        fp32,
-        persistent_mode,
+        "real" if use_real_weights else "synthetic",
+        lm_head_fp32_dest_acc_en,
+        lm_head_persistent_mode,
     )
     if not is_slow_dispatch():
         raise RuntimeError(
@@ -326,12 +343,14 @@ def run_demo(
         ttnn.enable_asynchronous_slow_dispatch(mesh_device)
 
         # Each host loads/creates only the weights for its stage via the provider.
-        provider: WeightProvider = SyntheticWeightProvider()
+        provider: WeightProvider = CacheWeightProvider(cache_path) if use_real_weights else SyntheticWeightProvider()
         config = create_pipeline_configuration_from_num_procs(
             num_procs,
             provider,
-            fp32_dest_acc_en=fp32,
-            persistent_mode=persistent_mode,
+            lm_head_fp32_dest_acc_en=lm_head_fp32_dest_acc_en,
+            lm_head_persistent_mode=lm_head_persistent_mode,
+            dense_layer_id_override=dense_layer_id_override,
+            moe_layer_id_override=moe_layer_id_override,
         )
 
         logger.info(f"Building pipeline")
@@ -341,20 +360,43 @@ def run_demo(
         pipeline.setup_and_run()
 
         if pipeline.my_mesh_id == 0:
-            for iteration in range(iterations):
-                logger.info(f"Writing token for iteration {iteration}")
-                torch_token = torch.zeros(1, TOKEN_PAGE_SIZE_BYTES // 4, dtype=torch.uint32)
-                torch_token[0, 0] = iteration
-                token_tensor = ttnn.from_torch(torch_token, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
-                output_tensor = ttnn.from_torch(
-                    torch.zeros(1, TOKEN_PAGE_SIZE_BYTES // 4, dtype=torch.uint32),
-                    dtype=ttnn.uint32,
-                    layout=ttnn.ROW_MAJOR_LAYOUT,
+            # Prefill + decode pattern per model.py: prefill(prompt) -> sample y0; decode_step(y_t) -> sample y_{t+1}.
+            tokenizer = load_tokenizer(tokenizer_name_or_path)
+            prompt_ids = tokenizer.encode(prompt, add_special_tokens=True)
+            if not prompt_ids:
+                prompt_ids = [tokenizer.bos_token_id if tokenizer.bos_token_id is not None else 0]
+            page_size_datums = page_size_bytes(1) // TOKEN_ID_BYTES
+            prompt_token_tensors = [
+                to_padded_input(
+                    torch.tensor([[tid]], dtype=torch.int32),
+                    batch_size=1,
+                    page_size_datums=page_size_datums,
                 )
-                pipeline.write_token(token_tensor)
-                pipeline.read_output(output_tensor)
-                got = ttnn.to_torch(output_tensor).to(torch.uint32)[0, 0].reshape(1, 1)
-                logger.info("Iteration {} output token: {}", iteration, got.item())
+                for tid in prompt_ids
+            ]
+            model = DeepSeekV3(
+                write_fn=pipeline.write_token,
+                read_fn=pipeline.read_output,
+                batch_size=1,
+            )
+            # Prefill: send prompt tokens; discard outputs for i < S-1; use last output to sample y0.
+            last_output = model.prefill(prompt_token_tensors)
+            next_token_id = int(ttnn.to_torch(last_output).to(torch.int32)[0, 0].item())
+            generated = [next_token_id]
+            logger.info(
+                "Prefill done ({} prompt tokens); sampled y0: {}",
+                len(prompt_ids),
+                next_token_id,
+            )
+            # Generation loop: feed y[t], get output, sample y[t+1].
+            for step in range(iterations - 1):
+                output = model.decode_step(
+                    torch.tensor([[next_token_id]], dtype=torch.int32),
+                )
+                next_token_id = int(ttnn.to_torch(output).to(torch.int32)[0, 0].item())
+                generated.append(next_token_id)
+                logger.info("Decode step {} output token: {}", step + 1, next_token_id)
+            logger.info("Generated {} tokens total", len(generated))
 
         pipeline.barrier()
     logger.info("Pod pipeline complete")
@@ -370,9 +412,11 @@ def main(argv: list[str] | None = None) -> int:
         max_new_tokens=args.max_new_tokens,
         tokenizer_name_or_path=args.tokenizer,
         cache_path=args.cache_path,
-        layer_id_offset=args.layer_id_offset,
-        fp32=args.fp32,
-        persistent_mode=args.persistent_mode,
+        use_real_weights=(args.weights == "real"),
+        lm_head_fp32_dest_acc_en=args.fp32,
+        lm_head_persistent_mode=args.persistent_mode,
+        dense_layer_id_override=args.dense_layer_id_override,
+        moe_layer_id_override=args.moe_layer_id_override,
         output_stream=sys.stdout,
     )
     print(file=sys.stdout, flush=True)

--- a/models/demos/deepseek_v3_b1/demo/cli.py
+++ b/models/demos/deepseek_v3_b1/demo/cli.py
@@ -142,30 +142,22 @@ def run_demo(
             moe_layer_id_override=moe_layer_id_override,
         )
 
-        # Run prefill + decode loop
         my_mesh_id = mesh_device.get_system_mesh_id()
         if my_mesh_id == 0:
-            # Prefill + decode pattern per model.py: prefill(prompt) -> sample y0; decode_step(y_t) -> sample y_{t+1}.
             tokenizer = load_tokenizer(tokenizer_name_or_path)
             prompt_ids = tokenizer.encode(prompt, add_special_tokens=True)
             logger.debug(f"Encoded prompt: {prompt_ids}")
             if not prompt_ids:
                 prompt_ids = [tokenizer.bos_token_id if tokenizer.bos_token_id is not None else 0]
 
-            # Prefill: send prompt tokens; discard outputs for i < S-1; use last output to sample y0.
-            next_token_id = model_pipeline.prefill_forward(prompt_ids)
-            generated = [next_token_id]
-            logger.info(
-                "Prefill done ({} prompt tokens); sampled y0: {}",
-                len(prompt_ids),
-                next_token_id,
+            generated = model_pipeline.run_inference(
+                prompt_token_ids=prompt_ids,
+                max_new_tokens=iterations,
+                on_token=lambda tid: logger.info("Generated token: {}", tid),
+                eos_token_id=tokenizer.eos_token_id,
             )
-            # Generation loop: feed y[t], get output, sample y[t+1].
-            for step in range(iterations - 1):
-                next_token_id = model_pipeline.decode_forward(next_token_id)
-                generated.append(next_token_id)
-                logger.info("Decode step {} output token: {}", step + 1, next_token_id)
             logger.info("Generated {} tokens total", len(generated))
+            logger.info("Output: {}", tokenizer.decode(generated, skip_special_tokens=True))
 
         model_pipeline.pipeline.barrier()
     logger.info("Pod pipeline complete")

--- a/models/demos/deepseek_v3_b1/demo/model_pipeline.py
+++ b/models/demos/deepseek_v3_b1/demo/model_pipeline.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
 
 import torch
@@ -47,7 +48,6 @@ class ModelPipeline:
             raise RuntimeError(f"Pod pipeline requires 4, 16, or 64 distributed processes; got {num_procs}")
         ttnn.enable_asynchronous_slow_dispatch(self.mesh_device)
 
-        # Each host loads/creates only the weights for its stage via the provider.
         provider: WeightProvider = CacheWeightProvider(cache_path) if use_real_weights else SyntheticWeightProvider()
         config = create_pipeline_configuration_from_num_procs(
             num_procs,
@@ -60,48 +60,69 @@ class ModelPipeline:
         if config.num_stages != num_procs:
             raise RuntimeError(f"Pipeline configuration has {config.num_stages} stages but {num_procs} processes")
 
-        logger.info(f"Building pipeline")
+        logger.info("Building pipeline")
         self.pipeline = config.build_pipeline(self.mesh_device)
 
-        logger.info(f"Setting up and running pipeline")
+        logger.info("Setting up and running pipeline")
         self.pipeline.setup_and_run()
 
+        self._model: DeepSeekV3 | None = None
+        self._page_size_datums: int = 0
         if self.pipeline.my_mesh_id == 0:
-            # Initialize host-side model interface for mesh id 0 (first stage)
-            self.model = DeepSeekV3(
+            self._model = DeepSeekV3(
                 write_fn=self.pipeline.write_token,
                 read_fn=self.pipeline.read_output,
                 batch_size=1,
             )
-        logger.info(f"Created ModelPipeline for mesh id {self.pipeline.my_mesh_id}.")
+            self._page_size_datums = page_size_bytes(1) // TOKEN_ID_BYTES
+        logger.info("Created ModelPipeline for mesh id {}.", self.pipeline.my_mesh_id)
 
-    def prefill_forward(self, tokens: list[int]) -> int:
-        """Prefill 1 user's prompt tokens and return the next token id."""
-        # Host-side model interface is only invoked on mesh id 0
-        if self.pipeline.my_mesh_id != 0:
-            raise RuntimeError("prefill_forward() should only be called on mesh id 0")
-        logger.debug(f"Prefilling with {len(tokens)} tokens...")
-        page_size_datums = page_size_bytes(1) // TOKEN_ID_BYTES
-        prompt_token_tensors = [
+    @property
+    def is_host(self) -> bool:
+        return self.pipeline.my_mesh_id == 0
+
+    def run_inference(
+        self,
+        prompt_token_ids: list[int],
+        max_new_tokens: int,
+        on_token: Callable[[int], None],
+        eos_token_id: int | None = None,
+    ) -> list[int]:
+        """Run full inference: prefill the prompt then decode until EOS or max_new_tokens.
+
+        Calls on_token(token_id) for each generated token (including the first
+        one sampled after prefill). Returns the list of all generated token IDs.
+
+        Must only be called on mesh_id == 0 (the host process).
+        """
+        if not self.is_host:
+            raise RuntimeError("run_inference() must only be called on mesh id 0")
+        assert self._model is not None
+
+        prompt_tensors = [
             to_padded_input(
                 torch.tensor([[tid]], dtype=torch.int32),
                 batch_size=1,
-                page_size_datums=page_size_datums,
+                page_size_datums=self._page_size_datums,
             )
-            for tid in tokens
+            for tid in prompt_token_ids
         ]
-        last_output = self.model.prefill(prompt_token_tensors)
+        last_output = self._model.prefill(prompt_tensors)
         next_token_id = int(ttnn.to_torch(last_output).to(torch.int32)[0, 0].item())
-        logger.debug(f"Done prefilling with {len(tokens)} tokens.")
-        return next_token_id
+        generated = [next_token_id]
+        on_token(next_token_id)
+        logger.info("Prefill done ({} prompt tokens); first token: {}", len(prompt_token_ids), next_token_id)
 
-    def decode_forward(self, input_token: int) -> int:
-        """Run 1 decode step and return the next token id."""
-        # Host-side model interface is only invoked on mesh id 0
-        if self.pipeline.my_mesh_id != 0:
-            raise RuntimeError("decode_forward() should only be called on mesh id 0")
-        output = self.model.decode_step(
-            torch.tensor([[input_token]], dtype=torch.int32),
-        )
-        next_token_id = int(ttnn.to_torch(output).to(torch.int32)[0, 0].item())
-        return next_token_id
+        for step in range(max_new_tokens - 1):
+            if eos_token_id is not None and next_token_id == eos_token_id:
+                logger.info("EOS token {} at decode step {}", eos_token_id, step)
+                break
+            output = self._model.decode_step(
+                torch.tensor([[next_token_id]], dtype=torch.int32),
+            )
+            next_token_id = int(ttnn.to_torch(output).to(torch.int32)[0, 0].item())
+            generated.append(next_token_id)
+            on_token(next_token_id)
+
+        logger.info("Generation complete ({} tokens generated)", len(generated))
+        return generated

--- a/models/demos/deepseek_v3_b1/demo/model_pipeline.py
+++ b/models/demos/deepseek_v3_b1/demo/model_pipeline.py
@@ -1,0 +1,94 @@
+from pathlib import Path
+
+import torch
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import is_slow_dispatch
+from models.demos.deepseek_v3_b1.demo.cli import CacheWeightProvider, SyntheticWeightProvider, open_mesh_device
+from models.demos.deepseek_v3_b1.demo.pipeline import WeightProvider, create_pipeline_configuration_from_num_procs
+from models.demos.deepseek_v3_b1.model import TOKEN_ID_BYTES, DeepSeekV3, page_size_bytes, to_padded_input
+
+
+class ModelPipeline:
+    def __init__(
+        self, use_real_weights: bool, lm_head_fp32_dest_acc_en: bool, lm_head_persistent_mode: str, cache_path: Path
+    ):
+        logger.info(
+            "Starting DeepSeek V3 B1 demo pod pipeline (weights={}, lm_head_fp32={}, lm_head_persistent_mode={})",
+            "real" if use_real_weights else "synthetic",
+            lm_head_fp32_dest_acc_en,
+            lm_head_persistent_mode,
+        )
+        if not is_slow_dispatch():
+            raise RuntimeError(
+                "DeepSeek V3 B1 demo requires slow dispatch mode. Set TT_METAL_SLOW_DISPATCH_MODE=1 and rerun."
+            )
+        self.mesh_device = open_mesh_device()
+        num_procs = int(ttnn.distributed_context_get_size())
+        if num_procs not in (4, 16, 64):
+            raise RuntimeError(f"Pod pipeline requires 4 or 16 distributed processes; got {num_procs}")
+        ttnn.enable_asynchronous_slow_dispatch(self.mesh_device)
+
+        self.provider: WeightProvider = (
+            CacheWeightProvider(cache_path) if use_real_weights else SyntheticWeightProvider()
+        )
+        config = create_pipeline_configuration_from_num_procs(
+            num_procs,
+            self.provider,
+            lm_head_fp32_dest_acc_en=lm_head_fp32_dest_acc_en,
+            lm_head_persistent_mode=lm_head_persistent_mode,
+            # dense_layer_id_override=dense_layer_id_override,
+            # moe_layer_id_override=moe_layer_id_override,
+        )
+        assert (
+            config.num_stages == num_procs
+        ), f"Pipeline configuration has {config.num_stages} stages but {num_procs} processes"
+
+        logger.info(f"Building pipeline")
+        self.pipeline = config.build_pipeline(self.mesh_device)
+
+        logger.info(f"Setting up and running pipeline")
+        self.pipeline.setup_and_run()
+        self.warmup()
+
+    def warmup(self):
+        if self.pipeline.my_mesh_id != 0:
+            print("Warmup: skipping on non-zero mesh ID")
+            return
+
+        self.model = DeepSeekV3(
+            write_fn=self.pipeline.write_token,
+            read_fn=self.pipeline.read_output,
+            batch_size=1,
+        )
+
+    def run_inference(self, prompt_ids, max_tokens):
+        print("running inference")
+        logger.debug(f"Prefilling...")
+        if not prompt_ids:
+            raise ValueError("No token ids provided")
+        page_size_datums = page_size_bytes(1) // TOKEN_ID_BYTES
+        prompt_token_tensors = [
+            to_padded_input(
+                torch.tensor([[tid]], dtype=torch.int32),
+                batch_size=1,
+                page_size_datums=page_size_datums,
+            )
+            for tid in prompt_ids
+        ]
+        last_output = self.model.prefill(prompt_token_tensors)
+        next_token_id = int(ttnn.to_torch(last_output).to(torch.int32)[0, 0].item())
+        generated = [next_token_id]
+        yield next_token_id
+
+        for step in range(max_tokens - 1):
+            output = self.model.decode_step(
+                torch.tensor([[next_token_id]], dtype=torch.int32),
+            )
+            next_token_id = int(ttnn.to_torch(output).to(torch.int32)[0, 0].item())
+            generated.append(next_token_id)
+            logger.info("Decode step {} output token: {}", step + 1, next_token_id)
+            yield next_token_id
+
+        logger.info("Generated {} tokens total", len(generated))

--- a/models/demos/deepseek_v3_b1/demo/model_pipeline.py
+++ b/models/demos/deepseek_v3_b1/demo/model_pipeline.py
@@ -24,7 +24,6 @@ from models.demos.deepseek_v3_b1.model import TOKEN_ID_BYTES, DeepSeekV3, page_s
 class ModelPipeline:
     def __init__(
         self,
-        mesh_device: ttnn.MeshDevice,
         cache_path: Path,
         use_real_weights: bool,
         lm_head_fp32_dest_acc_en: bool = True,
@@ -42,7 +41,7 @@ class ModelPipeline:
             raise RuntimeError(
                 "DeepSeek V3 B1 pod pipeline requires slow dispatch mode. Set TT_METAL_SLOW_DISPATCH_MODE=1 and rerun."
             )
-        self.mesh_device = mesh_device
+        self.mesh_device = self._open_mesh_device()
         num_procs = int(ttnn.distributed_context_get_size())
         if num_procs not in (4, 16, 64):
             raise RuntimeError(f"Pod pipeline requires 4, 16, or 64 distributed processes; got {num_procs}")
@@ -81,6 +80,20 @@ class ModelPipeline:
     def is_host(self) -> bool:
         return self.pipeline.my_mesh_id == 0
 
+    def _open_mesh_device():
+        fabric_router_config = ttnn._ttnn.fabric.FabricRouterConfig()
+        fabric_router_config.max_packet_payload_size_bytes = 7168
+        ttnn.set_fabric_config(
+            ttnn.FabricConfig.FABRIC_2D,
+            ttnn.FabricReliabilityMode.STRICT_INIT,
+            None,
+            ttnn.FabricTensixConfig.DISABLED,
+            ttnn.FabricUDMMode.DISABLED,
+            ttnn.FabricManagerMode.DEFAULT,
+            fabric_router_config,
+        )
+        return ttnn.open_mesh_device(mesh_shape=ttnn.MeshShape(4, 2))
+
     def run_inference(
         self,
         prompt_token_ids: list[int],
@@ -95,7 +108,7 @@ class ModelPipeline:
 
         Must only be called on mesh_id == 0 (the host process).
         """
-        if not self.is_host:
+        if self.pipeline.my_mesh_id != 0:
             raise RuntimeError("run_inference() must only be called on mesh id 0")
         assert self._model is not None
 

--- a/models/demos/deepseek_v3_b1/demo/model_pipeline.py
+++ b/models/demos/deepseek_v3_b1/demo/model_pipeline.py
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
 from pathlib import Path
 
 import torch
@@ -5,69 +11,76 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import is_slow_dispatch
-from models.demos.deepseek_v3_b1.demo.cli import CacheWeightProvider, SyntheticWeightProvider, open_mesh_device
-from models.demos.deepseek_v3_b1.demo.pipeline import WeightProvider, create_pipeline_configuration_from_num_procs
+from models.demos.deepseek_v3_b1.demo.pipeline import create_pipeline_configuration_from_num_procs
+from models.demos.deepseek_v3_b1.demo.weight_provider import (
+    CacheWeightProvider,
+    SyntheticWeightProvider,
+    WeightProvider,
+)
 from models.demos.deepseek_v3_b1.model import TOKEN_ID_BYTES, DeepSeekV3, page_size_bytes, to_padded_input
 
 
 class ModelPipeline:
     def __init__(
-        self, use_real_weights: bool, lm_head_fp32_dest_acc_en: bool, lm_head_persistent_mode: str, cache_path: Path
+        self,
+        mesh_device: ttnn.MeshDevice,
+        cache_path: Path,
+        use_real_weights: bool,
+        lm_head_fp32_dest_acc_en: bool = True,
+        lm_head_persistent_mode: bool = True,
+        dense_layer_id_override: int | None = None,
+        moe_layer_id_override: int | None = None,
     ):
         logger.info(
-            "Starting DeepSeek V3 B1 demo pod pipeline (weights={}, lm_head_fp32={}, lm_head_persistent_mode={})",
+            "Initializing DeepSeek V3 B1 pod pipeline (weights={}, lm_head_fp32={}, lm_head_persistent_mode={})",
             "real" if use_real_weights else "synthetic",
             lm_head_fp32_dest_acc_en,
             lm_head_persistent_mode,
         )
         if not is_slow_dispatch():
             raise RuntimeError(
-                "DeepSeek V3 B1 demo requires slow dispatch mode. Set TT_METAL_SLOW_DISPATCH_MODE=1 and rerun."
+                "DeepSeek V3 B1 pod pipeline requires slow dispatch mode. Set TT_METAL_SLOW_DISPATCH_MODE=1 and rerun."
             )
-        self.mesh_device = open_mesh_device()
+        self.mesh_device = mesh_device
         num_procs = int(ttnn.distributed_context_get_size())
         if num_procs not in (4, 16, 64):
-            raise RuntimeError(f"Pod pipeline requires 4 or 16 distributed processes; got {num_procs}")
+            raise RuntimeError(f"Pod pipeline requires 4, 16, or 64 distributed processes; got {num_procs}")
         ttnn.enable_asynchronous_slow_dispatch(self.mesh_device)
 
-        self.provider: WeightProvider = (
-            CacheWeightProvider(cache_path) if use_real_weights else SyntheticWeightProvider()
-        )
+        # Each host loads/creates only the weights for its stage via the provider.
+        provider: WeightProvider = CacheWeightProvider(cache_path) if use_real_weights else SyntheticWeightProvider()
         config = create_pipeline_configuration_from_num_procs(
             num_procs,
-            self.provider,
+            provider,
             lm_head_fp32_dest_acc_en=lm_head_fp32_dest_acc_en,
             lm_head_persistent_mode=lm_head_persistent_mode,
-            # dense_layer_id_override=dense_layer_id_override,
-            # moe_layer_id_override=moe_layer_id_override,
+            dense_layer_id_override=dense_layer_id_override,
+            moe_layer_id_override=moe_layer_id_override,
         )
-        assert (
-            config.num_stages == num_procs
-        ), f"Pipeline configuration has {config.num_stages} stages but {num_procs} processes"
+        if config.num_stages != num_procs:
+            raise RuntimeError(f"Pipeline configuration has {config.num_stages} stages but {num_procs} processes")
 
         logger.info(f"Building pipeline")
         self.pipeline = config.build_pipeline(self.mesh_device)
 
         logger.info(f"Setting up and running pipeline")
         self.pipeline.setup_and_run()
-        self.warmup()
 
-    def warmup(self):
+        if self.pipeline.my_mesh_id == 0:
+            # Initialize host-side model interface for mesh id 0 (first stage)
+            self.model = DeepSeekV3(
+                write_fn=self.pipeline.write_token,
+                read_fn=self.pipeline.read_output,
+                batch_size=1,
+            )
+        logger.info(f"Created ModelPipeline for mesh id {self.pipeline.my_mesh_id}.")
+
+    def prefill_forward(self, tokens: list[int]) -> int:
+        """Prefill 1 user's prompt tokens and return the next token id."""
+        # Host-side model interface is only invoked on mesh id 0
         if self.pipeline.my_mesh_id != 0:
-            print("Warmup: skipping on non-zero mesh ID")
-            return
-
-        self.model = DeepSeekV3(
-            write_fn=self.pipeline.write_token,
-            read_fn=self.pipeline.read_output,
-            batch_size=1,
-        )
-
-    def run_inference(self, prompt_ids, max_tokens):
-        print("running inference")
-        logger.debug(f"Prefilling...")
-        if not prompt_ids:
-            raise ValueError("No token ids provided")
+            raise RuntimeError("prefill_forward() should only be called on mesh id 0")
+        logger.debug(f"Prefilling with {len(tokens)} tokens...")
         page_size_datums = page_size_bytes(1) // TOKEN_ID_BYTES
         prompt_token_tensors = [
             to_padded_input(
@@ -75,20 +88,20 @@ class ModelPipeline:
                 batch_size=1,
                 page_size_datums=page_size_datums,
             )
-            for tid in prompt_ids
+            for tid in tokens
         ]
         last_output = self.model.prefill(prompt_token_tensors)
         next_token_id = int(ttnn.to_torch(last_output).to(torch.int32)[0, 0].item())
-        generated = [next_token_id]
-        yield next_token_id
+        logger.debug(f"Done prefilling with {len(tokens)} tokens.")
+        return next_token_id
 
-        for step in range(max_tokens - 1):
-            output = self.model.decode_step(
-                torch.tensor([[next_token_id]], dtype=torch.int32),
-            )
-            next_token_id = int(ttnn.to_torch(output).to(torch.int32)[0, 0].item())
-            generated.append(next_token_id)
-            logger.info("Decode step {} output token: {}", step + 1, next_token_id)
-            yield next_token_id
-
-        logger.info("Generated {} tokens total", len(generated))
+    def decode_forward(self, input_token: int) -> int:
+        """Run 1 decode step and return the next token id."""
+        # Host-side model interface is only invoked on mesh id 0
+        if self.pipeline.my_mesh_id != 0:
+            raise RuntimeError("decode_forward() should only be called on mesh id 0")
+        output = self.model.decode_step(
+            torch.tensor([[input_token]], dtype=torch.int32),
+        )
+        next_token_id = int(ttnn.to_torch(output).to(torch.int32)[0, 0].item())
+        return next_token_id

--- a/models/demos/deepseek_v3_b1/demo/pipeline.py
+++ b/models/demos/deepseek_v3_b1/demo/pipeline.py
@@ -21,7 +21,11 @@ from models.demos.deepseek_v3_b1.demo.stage import (
     StageKind,
 )
 from models.demos.deepseek_v3_b1.micro_ops.pipeline_block.op import PipelineBlock
-from models.demos.deepseek_v3_b1.prepare_weights import DeepSeekV3EmbeddingLayerWeights, DeepSeekV3LMHeadWeights
+from models.demos.deepseek_v3_b1.prepare_weights import (
+    DeepSeekV3EmbeddingLayerWeights,
+    DeepSeekV3LMHeadWeights,
+    DeepSeekV3MoELayerWeights,
+)
 
 
 class WeightProvider(Protocol):
@@ -31,6 +35,9 @@ class WeightProvider(Protocol):
         ...
 
     def load_lm_head(self, device: ttnn.MeshDevice) -> DeepSeekV3LMHeadWeights:
+        ...
+
+    def load_moe_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3MoELayerWeights:
         ...
 
 
@@ -96,6 +103,34 @@ def create_single_pod_pipeline_configuration(
     return PipelineConfiguration(stage_factories)
 
 
+def create_sp4_pipeline_configuration(
+    weight_provider: WeightProvider,
+    *,
+    fp32_dest_acc_en: bool = True,
+    persistent_mode: bool = True,
+) -> PipelineConfiguration:
+    """64-stage super-pod: Embed -> 63x Activation fwd -> LMHead -> Token fwd."""
+
+    def stage_0(device: ttnn.MeshDevice) -> StageKind:
+        return EmbeddingStage(weight_provider.load_embedding(device))
+
+    def stage_62(device: ttnn.MeshDevice) -> StageKind:
+        return LMHeadStage(
+            weights=weight_provider.load_lm_head(device),
+            fp32_dest_acc_en=fp32_dest_acc_en,
+            persistent_mode=persistent_mode,
+        )
+
+    passthrough_activation = lambda d: PassthroughStage(PassthroughPayload.ACTIVATION)
+    stage_factories: dict[int, Callable[[ttnn.MeshDevice], StageKind]] = {
+        0: stage_0,
+        **{i: passthrough_activation for i in range(1, 62)},
+        62: stage_62,
+        63: lambda d: PassthroughStage(PassthroughPayload.TOKEN),
+    }
+    return PipelineConfiguration(stage_factories)
+
+
 def create_pipeline_configuration_from_num_procs(
     num_procs: int,
     weight_provider: WeightProvider,
@@ -112,6 +147,12 @@ def create_pipeline_configuration_from_num_procs(
         )
     if num_procs == 16:
         return create_single_pod_pipeline_configuration(
+            weight_provider,
+            fp32_dest_acc_en=fp32_dest_acc_en,
+            persistent_mode=persistent_mode,
+        )
+    if num_procs == 64:
+        return create_sp4_pipeline_configuration(
             weight_provider,
             fp32_dest_acc_en=fp32_dest_acc_en,
             persistent_mode=persistent_mode,

--- a/models/demos/deepseek_v3_b1/demo/pipeline.py
+++ b/models/demos/deepseek_v3_b1/demo/pipeline.py
@@ -13,8 +13,10 @@ from typing import Any, Callable, Protocol
 
 import ttnn
 from models.demos.deepseek_v3_b1.demo.stage import (
+    DenseDecoderStage,
     EmbeddingStage,
     LMHeadStage,
+    MoEDecoderStage,
     PassthroughPayload,
     PassthroughStage,
     StageContext,
@@ -22,6 +24,7 @@ from models.demos.deepseek_v3_b1.demo.stage import (
 )
 from models.demos.deepseek_v3_b1.micro_ops.pipeline_block.op import PipelineBlock
 from models.demos.deepseek_v3_b1.prepare_weights import (
+    DeepSeekV3DenseLayerWeights,
     DeepSeekV3EmbeddingLayerWeights,
     DeepSeekV3LMHeadWeights,
     DeepSeekV3MoELayerWeights,
@@ -38,6 +41,9 @@ class WeightProvider(Protocol):
         ...
 
     def load_moe_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3MoELayerWeights:
+        ...
+
+    def load_dense_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3DenseLayerWeights:
         ...
 
 
@@ -69,8 +75,8 @@ def create_single_galaxy_pipeline_configuration(
         {
             0: stage_0,
             1: stage_1,
-            2: lambda d: PassthroughStage(PassthroughPayload.TOKEN),
-            3: lambda d: PassthroughStage(PassthroughPayload.TOKEN),
+            2: lambda d: DenseDecoderStage(weights=weight_provider.load_dense_layer(layer_id=0, device=d)),
+            3: lambda d: MoEDecoderStage(weights=weight_provider.load_moe_layer(layer_id=3, device=d)),
         }
     )
 
@@ -81,7 +87,7 @@ def create_single_pod_pipeline_configuration(
     fp32_dest_acc_en: bool = True,
     persistent_mode: bool = True,
 ) -> PipelineConfiguration:
-    """16-stage single-pod: Embed -> 13x Activation fwd -> LMHead -> Token fwd."""
+    """16-stage single-pod: Embed -> Dense(0,1,2) -> MoE(3..12) -> LMHead -> Token fwd."""
 
     def stage_0(device: ttnn.MeshDevice) -> StageKind:
         return EmbeddingStage(weight_provider.load_embedding(device))
@@ -93,10 +99,19 @@ def create_single_pod_pipeline_configuration(
             persistent_mode=persistent_mode,
         )
 
-    passthrough_activation = lambda d: PassthroughStage(PassthroughPayload.ACTIVATION)
+    # Same layout as SP4: stage i -> layer_id i-1 for decoder stages; fewer MoE stages (4-13 = layers 3-12)
+    def _dense_stage(layer_id: int):
+        return lambda d: DenseDecoderStage(weights=weight_provider.load_dense_layer(layer_id=layer_id, device=d))
+
+    def _moe_stage(layer_id: int):
+        return lambda d: MoEDecoderStage(weights=weight_provider.load_moe_layer(layer_id=layer_id, device=d))
+
     stage_factories: dict[int, Callable[[ttnn.MeshDevice], StageKind]] = {
         0: stage_0,
-        **{i: passthrough_activation for i in range(1, 14)},
+        1: _dense_stage(0),
+        2: _dense_stage(1),
+        3: _dense_stage(2),
+        **{i: _moe_stage(i - 1) for i in range(4, 14)},
         14: stage_14,
         15: lambda d: PassthroughStage(PassthroughPayload.TOKEN),
     }
@@ -109,7 +124,7 @@ def create_sp4_pipeline_configuration(
     fp32_dest_acc_en: bool = True,
     persistent_mode: bool = True,
 ) -> PipelineConfiguration:
-    """64-stage super-pod: Embed -> 63x Activation fwd -> LMHead -> Token fwd."""
+    """64-stage super-pod: Embed -> Dense(0,1,2) -> MoE(3..60) -> LMHead -> Token fwd."""
 
     def stage_0(device: ttnn.MeshDevice) -> StageKind:
         return EmbeddingStage(weight_provider.load_embedding(device))
@@ -121,10 +136,19 @@ def create_sp4_pipeline_configuration(
             persistent_mode=persistent_mode,
         )
 
-    passthrough_activation = lambda d: PassthroughStage(PassthroughPayload.ACTIVATION)
+    # Stage i -> layer_id i-1 for decoder stages (stage 1 = layer 0, ..., stage 61 = layer 60)
+    def _dense_stage(layer_id: int):
+        return lambda d: DenseDecoderStage(weights=weight_provider.load_dense_layer(layer_id=layer_id, device=d))
+
+    def _moe_stage(layer_id: int):
+        return lambda d: MoEDecoderStage(weights=weight_provider.load_moe_layer(layer_id=layer_id, device=d))
+
     stage_factories: dict[int, Callable[[ttnn.MeshDevice], StageKind]] = {
         0: stage_0,
-        **{i: passthrough_activation for i in range(1, 62)},
+        1: _dense_stage(0),
+        2: _dense_stage(1),
+        3: _dense_stage(2),
+        **{i: _moe_stage(i - 1) for i in range(4, 62)},
         62: stage_62,
         63: lambda d: PassthroughStage(PassthroughPayload.TOKEN),
     }

--- a/models/demos/deepseek_v3_b1/demo/pipeline.py
+++ b/models/demos/deepseek_v3_b1/demo/pipeline.py
@@ -56,8 +56,8 @@ def create_fabric_router_config(max_payload_size: int) -> Any:
 def create_single_galaxy_pipeline_configuration(
     weight_provider: WeightProvider,
     *,
-    fp32_dest_acc_en: bool = True,
-    persistent_mode: bool = True,
+    lm_head_fp32_dest_acc_en: bool = True,
+    lm_head_persistent_mode: bool = True,
 ) -> PipelineConfiguration:
     """4-stage single-galaxy: Embed -> LMHead -> Token fwd -> Token fwd."""
 
@@ -67,8 +67,8 @@ def create_single_galaxy_pipeline_configuration(
     def stage_1(device: ttnn.MeshDevice) -> StageKind:
         return LMHeadStage(
             weights=weight_provider.load_lm_head(device),
-            fp32_dest_acc_en=fp32_dest_acc_en,
-            persistent_mode=persistent_mode,
+            lm_head_fp32_dest_acc_en=lm_head_fp32_dest_acc_en,
+            lm_head_persistent_mode=lm_head_persistent_mode,
         )
 
     return PipelineConfiguration(
@@ -84,10 +84,16 @@ def create_single_galaxy_pipeline_configuration(
 def create_single_pod_pipeline_configuration(
     weight_provider: WeightProvider,
     *,
-    fp32_dest_acc_en: bool = True,
-    persistent_mode: bool = True,
+    lm_head_fp32_dest_acc_en: bool = True,
+    lm_head_persistent_mode: bool = True,
+    dense_layer_id_override: int | None = None,
+    moe_layer_id_override: int | None = None,
 ) -> PipelineConfiguration:
-    """16-stage single-pod: Embed -> Dense(0,1,2) -> MoE(3..12) -> LMHead -> Token fwd."""
+    """16-stage single-pod: Embed -> Dense(0,1,2) -> MoE(3..12) -> LMHead -> Token fwd.
+
+    If dense_layer_id_override is set (e.g. 0), all dense stages use that layer id.
+    If moe_layer_id_override is set (e.g. 3), all MoE stages use that layer id.
+    """
 
     def stage_0(device: ttnn.MeshDevice) -> StageKind:
         return EmbeddingStage(weight_provider.load_embedding(device))
@@ -95,8 +101,8 @@ def create_single_pod_pipeline_configuration(
     def stage_14(device: ttnn.MeshDevice) -> StageKind:
         return LMHeadStage(
             weights=weight_provider.load_lm_head(device),
-            fp32_dest_acc_en=fp32_dest_acc_en,
-            persistent_mode=persistent_mode,
+            lm_head_fp32_dest_acc_en=lm_head_fp32_dest_acc_en,
+            lm_head_persistent_mode=lm_head_persistent_mode,
         )
 
     # Same layout as SP4: stage i -> layer_id i-1 for decoder stages; fewer MoE stages (4-13 = layers 3-12)
@@ -106,12 +112,15 @@ def create_single_pod_pipeline_configuration(
     def _moe_stage(layer_id: int):
         return lambda d: MoEDecoderStage(weights=weight_provider.load_moe_layer(layer_id=layer_id, device=d))
 
+    dense_ids = (dense_layer_id_override,) * 3 if dense_layer_id_override is not None else (0, 1, 2)
+    moe_layer_id = moe_layer_id_override if moe_layer_id_override is not None else None
+
     stage_factories: dict[int, Callable[[ttnn.MeshDevice], StageKind]] = {
         0: stage_0,
-        1: _dense_stage(0),
-        2: _dense_stage(1),
-        3: _dense_stage(2),
-        **{i: _moe_stage(i - 1) for i in range(4, 14)},
+        1: _dense_stage(dense_ids[0]),
+        2: _dense_stage(dense_ids[1]),
+        3: _dense_stage(dense_ids[2]),
+        **{i: _moe_stage(moe_layer_id if moe_layer_id is not None else i - 1) for i in range(4, 14)},
         14: stage_14,
         15: lambda d: PassthroughStage(PassthroughPayload.TOKEN),
     }
@@ -121,10 +130,16 @@ def create_single_pod_pipeline_configuration(
 def create_sp4_pipeline_configuration(
     weight_provider: WeightProvider,
     *,
-    fp32_dest_acc_en: bool = True,
-    persistent_mode: bool = True,
+    lm_head_fp32_dest_acc_en: bool = True,
+    lm_head_persistent_mode: bool = True,
+    dense_layer_id_override: int | None = None,
+    moe_layer_id_override: int | None = None,
 ) -> PipelineConfiguration:
-    """64-stage super-pod: Embed -> Dense(0,1,2) -> MoE(3..60) -> LMHead -> Token fwd."""
+    """64-stage super-pod: Embed -> Dense(0,1,2) -> MoE(3..60) -> LMHead -> Token fwd.
+
+    If dense_layer_id_override is set (e.g. 0), all dense stages use that layer id.
+    If moe_layer_id_override is set (e.g. 3), all MoE stages use that layer id.
+    """
 
     def stage_0(device: ttnn.MeshDevice) -> StageKind:
         return EmbeddingStage(weight_provider.load_embedding(device))
@@ -132,8 +147,8 @@ def create_sp4_pipeline_configuration(
     def stage_62(device: ttnn.MeshDevice) -> StageKind:
         return LMHeadStage(
             weights=weight_provider.load_lm_head(device),
-            fp32_dest_acc_en=fp32_dest_acc_en,
-            persistent_mode=persistent_mode,
+            lm_head_fp32_dest_acc_en=lm_head_fp32_dest_acc_en,
+            lm_head_persistent_mode=lm_head_persistent_mode,
         )
 
     # Stage i -> layer_id i-1 for decoder stages (stage 1 = layer 0, ..., stage 61 = layer 60)
@@ -143,12 +158,15 @@ def create_sp4_pipeline_configuration(
     def _moe_stage(layer_id: int):
         return lambda d: MoEDecoderStage(weights=weight_provider.load_moe_layer(layer_id=layer_id, device=d))
 
+    dense_ids = (dense_layer_id_override,) * 3 if dense_layer_id_override is not None else (0, 1, 2)
+    moe_layer_id = moe_layer_id_override if moe_layer_id_override is not None else None
+
     stage_factories: dict[int, Callable[[ttnn.MeshDevice], StageKind]] = {
         0: stage_0,
-        1: _dense_stage(0),
-        2: _dense_stage(1),
-        3: _dense_stage(2),
-        **{i: _moe_stage(i - 1) for i in range(4, 62)},
+        1: _dense_stage(dense_ids[0]),
+        2: _dense_stage(dense_ids[1]),
+        3: _dense_stage(dense_ids[2]),
+        **{i: _moe_stage(moe_layer_id if moe_layer_id is not None else i - 1) for i in range(4, 62)},
         62: stage_62,
         63: lambda d: PassthroughStage(PassthroughPayload.TOKEN),
     }
@@ -159,27 +177,33 @@ def create_pipeline_configuration_from_num_procs(
     num_procs: int,
     weight_provider: WeightProvider,
     *,
-    fp32_dest_acc_en: bool = True,
-    persistent_mode: bool = True,
+    lm_head_fp32_dest_acc_en: bool = True,
+    lm_head_persistent_mode: bool = True,
+    dense_layer_id_override: int | None = None,
+    moe_layer_id_override: int | None = None,
 ) -> PipelineConfiguration:
-    """Pick topology from process count (4 -> single_galaxy, 16 -> single_pod)."""
+    """Pick topology from process count (4 -> single_galaxy, 16 -> single_pod, 64 -> sp4)."""
     if num_procs == 4:
         return create_single_galaxy_pipeline_configuration(
             weight_provider,
-            fp32_dest_acc_en=fp32_dest_acc_en,
-            persistent_mode=persistent_mode,
+            lm_head_fp32_dest_acc_en=lm_head_fp32_dest_acc_en,
+            lm_head_persistent_mode=lm_head_persistent_mode,
         )
     if num_procs == 16:
         return create_single_pod_pipeline_configuration(
             weight_provider,
-            fp32_dest_acc_en=fp32_dest_acc_en,
-            persistent_mode=persistent_mode,
+            lm_head_fp32_dest_acc_en=lm_head_fp32_dest_acc_en,
+            lm_head_persistent_mode=lm_head_persistent_mode,
+            dense_layer_id_override=dense_layer_id_override,
+            moe_layer_id_override=moe_layer_id_override,
         )
     if num_procs == 64:
         return create_sp4_pipeline_configuration(
             weight_provider,
-            fp32_dest_acc_en=fp32_dest_acc_en,
-            persistent_mode=persistent_mode,
+            lm_head_fp32_dest_acc_en=lm_head_fp32_dest_acc_en,
+            lm_head_persistent_mode=lm_head_persistent_mode,
+            dense_layer_id_override=dense_layer_id_override,
+            moe_layer_id_override=moe_layer_id_override,
         )
     raise ValueError(f"Unsupported num_procs: {num_procs}")
 

--- a/models/demos/deepseek_v3_b1/demo/pipeline.py
+++ b/models/demos/deepseek_v3_b1/demo/pipeline.py
@@ -9,7 +9,7 @@ Stage kinds (Embedding, LMHead, Passthrough) live in stage.py.
 
 from __future__ import annotations
 
-from typing import Any, Callable, Protocol
+from typing import Any, Callable
 
 import ttnn
 from models.demos.deepseek_v3_b1.demo.stage import (
@@ -22,29 +22,8 @@ from models.demos.deepseek_v3_b1.demo.stage import (
     StageContext,
     StageKind,
 )
+from models.demos.deepseek_v3_b1.demo.weight_provider import WeightProvider
 from models.demos.deepseek_v3_b1.micro_ops.pipeline_block.op import PipelineBlock
-from models.demos.deepseek_v3_b1.prepare_weights import (
-    DeepSeekV3DenseLayerWeights,
-    DeepSeekV3EmbeddingLayerWeights,
-    DeepSeekV3LMHeadWeights,
-    DeepSeekV3MoELayerWeights,
-)
-
-
-class WeightProvider(Protocol):
-    """Provides embedding and LM head weights on demand; each host loads only what its stage needs."""
-
-    def load_embedding(self, device: ttnn.MeshDevice) -> DeepSeekV3EmbeddingLayerWeights:
-        ...
-
-    def load_lm_head(self, device: ttnn.MeshDevice) -> DeepSeekV3LMHeadWeights:
-        ...
-
-    def load_moe_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3MoELayerWeights:
-        ...
-
-    def load_dense_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3DenseLayerWeights:
-        ...
 
 
 def create_fabric_router_config(max_payload_size: int) -> Any:

--- a/models/demos/deepseek_v3_b1/demo/pipeline.py
+++ b/models/demos/deepseek_v3_b1/demo/pipeline.py
@@ -75,8 +75,8 @@ def create_single_galaxy_pipeline_configuration(
         {
             0: stage_0,
             1: stage_1,
-            2: lambda d: DenseDecoderStage(weights=weight_provider.load_dense_layer(layer_id=0, device=d)),
-            3: lambda d: MoEDecoderStage(weights=weight_provider.load_moe_layer(layer_id=3, device=d)),
+            2: lambda d: PassthroughStage(PassthroughPayload.TOKEN),
+            3: lambda d: PassthroughStage(PassthroughPayload.TOKEN),
         }
     )
 

--- a/models/demos/deepseek_v3_b1/demo/stage.py
+++ b/models/demos/deepseek_v3_b1/demo/stage.py
@@ -176,12 +176,12 @@ class LMHeadStage(StageKind):
         self,
         weights: DeepSeekV3LMHeadWeights,
         *,
-        fp32_dest_acc_en: bool = True,
-        persistent_mode: bool = True,
+        lm_head_fp32_dest_acc_en: bool = True,
+        lm_head_persistent_mode: bool = True,
     ) -> None:
         self._weights = weights
-        self._fp32_dest_acc_en = fp32_dest_acc_en
-        self._persistent_mode = persistent_mode
+        self._lm_head_fp32_dest_acc_en = lm_head_fp32_dest_acc_en
+        self._lm_head_persistent_mode = lm_head_persistent_mode
         self._lmhead_state: dict[str, Any] = {}
 
     def create_pipeline_block(self, ctx: StageContext) -> PipelineBlock:
@@ -366,7 +366,7 @@ class LMHeadStage(StageKind):
             "global_semaphore": global_semaphore,
             "global_stage2_semaphore": global_stage2_semaphore,
         }
-        if self._persistent_mode:
+        if self._lm_head_persistent_mode:
             persistent_next_iter_semaphore = ttnn.create_global_semaphore(mesh_device, worker_crs, 1)
             self._lmhead_state["persistent_next_iter_semaphore"] = persistent_next_iter_semaphore
 
@@ -393,10 +393,10 @@ class LMHeadStage(StageKind):
             global_semaphore=d["global_semaphore"],
             global_stage2_semaphore=d["global_stage2_semaphore"],
             fabric_scratch_tensor=d["scratch_buffer"],
-            fp32_dest_acc_en=self._fp32_dest_acc_en,
+            fp32_dest_acc_en=self._lm_head_fp32_dest_acc_en,
             skip_ccl=False,
             socket_input=d["lmhead_input_socket"],
             socket_output=d["lmhead_output_socket"],
-            persistent_mode=self._persistent_mode,
+            persistent_mode=self._lm_head_persistent_mode,
             persistent_next_iter_semaphore=d.get("persistent_next_iter_semaphore"),
         )

--- a/models/demos/deepseek_v3_b1/demo/stage.py
+++ b/models/demos/deepseek_v3_b1/demo/stage.py
@@ -18,7 +18,11 @@ import torch
 import ttnn
 from models.demos.deepseek_v3_b1.fused_ops.lm_head_sampling.op import LMHeadSampling
 from models.demos.deepseek_v3_b1.micro_ops.pipeline_block.op import PipelineBlock
-from models.demos.deepseek_v3_b1.prepare_weights import DeepSeekV3EmbeddingLayerWeights, DeepSeekV3LMHeadWeights
+from models.demos.deepseek_v3_b1.prepare_weights import (
+    DeepSeekV3EmbeddingLayerWeights,
+    DeepSeekV3LMHeadWeights,
+    DeepSeekV3MoELayerWeights,
+)
 
 # Constants used by stage kinds (same as pipeline module)
 token_page_size_bytes = 64
@@ -113,6 +117,30 @@ class PassthroughStage(StageKind):
             upstream_d2d_socket_page_size=up_page,
             downstream_d2d_socket_page_size=down_page,
         )
+
+
+class MoEDecoderStage(StageKind):
+    """Decoder stage that runs an MoE layer; activation in, activation out. Compute stubbed for now."""
+
+    def __init__(self, weights: DeepSeekV3MoELayerWeights) -> None:
+        self._weights = weights
+
+    def create_pipeline_block(self, ctx: StageContext) -> PipelineBlock:
+        mesh_device = ctx.mesh_device
+        return PipelineBlock(
+            mesh_device,
+            pipeline_core_coord,
+            upstream_d2d_socket_fifo_size=activation_fifo_size,
+            downstream_d2d_socket_fifo_size=activation_fifo_size,
+            upstream_d2d_socket_page_size=activation_page_size_bytes,
+            downstream_d2d_socket_page_size=activation_page_size_bytes,
+        )
+
+    def setup(self, ctx: StageContext, pipeline_block: PipelineBlock) -> None:
+        pass
+
+    def launch_compute(self, ctx: StageContext, pipeline_block: PipelineBlock) -> None:
+        pass
 
 
 class LMHeadStage(StageKind):

--- a/models/demos/deepseek_v3_b1/demo/stage.py
+++ b/models/demos/deepseek_v3_b1/demo/stage.py
@@ -19,30 +19,19 @@ import ttnn
 from models.demos.deepseek_v3_b1.fused_ops.lm_head_sampling.op import LMHeadSampling
 from models.demos.deepseek_v3_b1.micro_ops.pipeline_block.op import PipelineBlock
 from models.demos.deepseek_v3_b1.prepare_weights import (
+    DeepSeekV3DenseLayerWeights,
     DeepSeekV3EmbeddingLayerWeights,
     DeepSeekV3LMHeadWeights,
     DeepSeekV3MoELayerWeights,
 )
 
-# Constants used by stage kinds (same as pipeline module)
-token_page_size_bytes = 64
-token_fifo_size = 1024
-activation_dim = 7168
-activation_page_size_bytes = activation_dim * 2
-activation_fifo_size = activation_page_size_bytes * 4
-
-M = 1
-K = activation_dim
-num_matmul_cores = 101
-n_per_core = 160
-n_total = num_matmul_cores * n_per_core
-
-a_tile = ttnn.Tile([1, 32])
-b_tile = ttnn.Tile([32, 32])
-out_tile = ttnn.Tile([1, 32])
-pipeline_core_coord = ttnn.CoreCoord(11, 0)
-argmax_final_core = ttnn.CoreCoord(0, 0)
-lmhead_input_core = ttnn.CoreCoord(10, 9)
+# Global constants used by multiple stage kinds (and exported to pipeline/cli)
+TOKEN_PAGE_SIZE_BYTES = 64
+TOKEN_FIFO_SIZE = 1024
+ACTIVATION_DIM = 7168
+ACTIVATION_PAGE_SIZE_BYTES = ACTIVATION_DIM * 2
+ACTIVATION_FIFO_SIZE = ACTIVATION_PAGE_SIZE_BYTES * 4
+PIPELINE_CORE_COORD = ttnn.CoreCoord(11, 0)
 
 
 @dataclass
@@ -78,14 +67,14 @@ class EmbeddingStage(StageKind):
         mesh_device = ctx.mesh_device
         return PipelineBlock(
             mesh_device,
-            pipeline_core_coord,
-            upstream_d2d_socket_fifo_size=token_fifo_size,
-            downstream_d2d_socket_fifo_size=activation_fifo_size,
-            upstream_d2d_socket_page_size=token_page_size_bytes,
-            downstream_d2d_socket_page_size=activation_page_size_bytes,
-            h2d_socket_fifo_size=token_fifo_size,
-            d2h_socket_fifo_size=token_fifo_size,
-            d2h_socket_page_size=token_page_size_bytes,
+            PIPELINE_CORE_COORD,
+            upstream_d2d_socket_fifo_size=TOKEN_FIFO_SIZE,
+            downstream_d2d_socket_fifo_size=ACTIVATION_FIFO_SIZE,
+            upstream_d2d_socket_page_size=TOKEN_PAGE_SIZE_BYTES,
+            downstream_d2d_socket_page_size=ACTIVATION_PAGE_SIZE_BYTES,
+            h2d_socket_fifo_size=TOKEN_FIFO_SIZE,
+            d2h_socket_fifo_size=TOKEN_FIFO_SIZE,
+            d2h_socket_page_size=TOKEN_PAGE_SIZE_BYTES,
             embedding_tensor=self._weights.embedding,
         )
 
@@ -104,14 +93,14 @@ class PassthroughStage(StageKind):
     def create_pipeline_block(self, ctx: StageContext) -> PipelineBlock:
         mesh_device = ctx.mesh_device
         if self._payload == PassthroughPayload.ACTIVATION:
-            up_fifo = down_fifo = activation_fifo_size
-            up_page = down_page = activation_page_size_bytes
+            up_fifo = down_fifo = ACTIVATION_FIFO_SIZE
+            up_page = down_page = ACTIVATION_PAGE_SIZE_BYTES
         else:
-            up_fifo = down_fifo = token_fifo_size
-            up_page = down_page = token_page_size_bytes
+            up_fifo = down_fifo = TOKEN_FIFO_SIZE
+            up_page = down_page = TOKEN_PAGE_SIZE_BYTES
         return PipelineBlock(
             mesh_device,
-            pipeline_core_coord,
+            PIPELINE_CORE_COORD,
             upstream_d2d_socket_fifo_size=up_fifo,
             downstream_d2d_socket_fifo_size=down_fifo,
             upstream_d2d_socket_page_size=up_page,
@@ -129,11 +118,35 @@ class MoEDecoderStage(StageKind):
         mesh_device = ctx.mesh_device
         return PipelineBlock(
             mesh_device,
-            pipeline_core_coord,
-            upstream_d2d_socket_fifo_size=activation_fifo_size,
-            downstream_d2d_socket_fifo_size=activation_fifo_size,
-            upstream_d2d_socket_page_size=activation_page_size_bytes,
-            downstream_d2d_socket_page_size=activation_page_size_bytes,
+            PIPELINE_CORE_COORD,
+            upstream_d2d_socket_fifo_size=ACTIVATION_FIFO_SIZE,
+            downstream_d2d_socket_fifo_size=ACTIVATION_FIFO_SIZE,
+            upstream_d2d_socket_page_size=ACTIVATION_PAGE_SIZE_BYTES,
+            downstream_d2d_socket_page_size=ACTIVATION_PAGE_SIZE_BYTES,
+        )
+
+    def setup(self, ctx: StageContext, pipeline_block: PipelineBlock) -> None:
+        pass
+
+    def launch_compute(self, ctx: StageContext, pipeline_block: PipelineBlock) -> None:
+        pass
+
+
+class DenseDecoderStage(StageKind):
+    """Decoder stage that runs a dense layer; activation in, activation out. Compute stubbed for now."""
+
+    def __init__(self, weights: DeepSeekV3DenseLayerWeights) -> None:
+        self._weights = weights
+
+    def create_pipeline_block(self, ctx: StageContext) -> PipelineBlock:
+        mesh_device = ctx.mesh_device
+        return PipelineBlock(
+            mesh_device,
+            PIPELINE_CORE_COORD,
+            upstream_d2d_socket_fifo_size=ACTIVATION_FIFO_SIZE,
+            downstream_d2d_socket_fifo_size=ACTIVATION_FIFO_SIZE,
+            upstream_d2d_socket_page_size=ACTIVATION_PAGE_SIZE_BYTES,
+            downstream_d2d_socket_page_size=ACTIVATION_PAGE_SIZE_BYTES,
         )
 
     def setup(self, ctx: StageContext, pipeline_block: PipelineBlock) -> None:
@@ -144,6 +157,19 @@ class MoEDecoderStage(StageKind):
 
 
 class LMHeadStage(StageKind):
+    """LMHead+Sampling stage: receive activation, run op, send token downstream."""
+
+    # LMHead-stage-specific constants (tiles, core coords, matmul layout)
+    M = 1
+    K = ACTIVATION_DIM
+    NUM_MATMUL_CORES = 101
+    N_PER_CORE = 160
+    N_TOTAL = NUM_MATMUL_CORES * N_PER_CORE
+    A_TILE = ttnn.Tile([1, 32])
+    B_TILE = ttnn.Tile([32, 32])
+    OUT_TILE = ttnn.Tile([1, 32])
+    ARGMAX_FINAL_CORE = ttnn.CoreCoord(0, 0)
+    LMHEAD_INPUT_CORE = ttnn.CoreCoord(10, 9)
     """LMHead+Sampling stage: receive activation, run op, send token downstream."""
 
     def __init__(
@@ -162,15 +188,19 @@ class LMHeadStage(StageKind):
         mesh_device = ctx.mesh_device
         my_mesh_id = ctx.my_mesh_id
         pipeline_config = ctx.pipeline_config
-        lmhead_entry_core = ttnn.MeshCoreCoord(pipeline_config[my_mesh_id].entry_node_coord, lmhead_input_core)
-        lmhead_exit_core = ttnn.MeshCoreCoord(pipeline_config[my_mesh_id].exit_node_coord, argmax_final_core)
+        lmhead_entry_core = ttnn.MeshCoreCoord(
+            pipeline_config[my_mesh_id].entry_node_coord, LMHeadStage.LMHEAD_INPUT_CORE
+        )
+        lmhead_exit_core = ttnn.MeshCoreCoord(
+            pipeline_config[my_mesh_id].exit_node_coord, LMHeadStage.ARGMAX_FINAL_CORE
+        )
         return PipelineBlock(
             mesh_device,
-            pipeline_core_coord,
-            upstream_d2d_socket_fifo_size=activation_fifo_size,
-            downstream_d2d_socket_fifo_size=token_fifo_size,
-            upstream_d2d_socket_page_size=activation_page_size_bytes,
-            downstream_d2d_socket_page_size=token_page_size_bytes,
+            PIPELINE_CORE_COORD,
+            upstream_d2d_socket_fifo_size=ACTIVATION_FIFO_SIZE,
+            downstream_d2d_socket_fifo_size=TOKEN_FIFO_SIZE,
+            upstream_d2d_socket_page_size=ACTIVATION_PAGE_SIZE_BYTES,
+            downstream_d2d_socket_page_size=TOKEN_PAGE_SIZE_BYTES,
             entry_node_downstream=lmhead_entry_core,
             exit_node_upstream=lmhead_exit_core,
         )
@@ -179,36 +209,40 @@ class LMHeadStage(StageKind):
         mesh_device = ctx.mesh_device
         my_mesh_id = ctx.my_mesh_id
         pipeline_config = ctx.pipeline_config
-        torch_a = torch.zeros((M, K), dtype=torch.bfloat16)
+        torch_a = torch.zeros((LMHeadStage.M, LMHeadStage.K), dtype=torch.bfloat16)
 
         mesh_shape = mesh_device.shape
         mesh_rows, mesh_cols = mesh_shape[0], mesh_shape[1]
         sender_coord = pipeline_config[my_mesh_id].entry_node_coord
         num_devices = mesh_rows * mesh_cols
 
-        mcast_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(lmhead_input_core, lmhead_input_core)])
+        mcast_core_grid = ttnn.CoreRangeSet(
+            [ttnn.CoreRange(LMHeadStage.LMHEAD_INPUT_CORE, LMHeadStage.LMHEAD_INPUT_CORE)]
+        )
         matmul_core_grid = ttnn.CoreRangeSet(
             [
                 ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(9, 9)),
                 ttnn.CoreRange(ttnn.CoreCoord(10, 0), ttnn.CoreCoord(10, 0)),
             ]
         )
-        argmax_final_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(argmax_final_core, argmax_final_core)])
+        argmax_final_core_grid = ttnn.CoreRangeSet(
+            [ttnn.CoreRange(LMHeadStage.ARGMAX_FINAL_CORE, LMHeadStage.ARGMAX_FINAL_CORE)]
+        )
 
         input_a_mem_config = ttnn.MemoryConfig(
             ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
             ttnn.BufferType.L1,
-            ttnn.ShardSpec(mcast_core_grid, (M, K), ttnn.ShardOrientation.ROW_MAJOR),
+            ttnn.ShardSpec(mcast_core_grid, (LMHeadStage.M, LMHeadStage.K), ttnn.ShardOrientation.ROW_MAJOR),
         )
         output_mem_config = ttnn.MemoryConfig(
             ttnn.TensorMemoryLayout.WIDTH_SHARDED,
             ttnn.BufferType.L1,
-            ttnn.ShardSpec(matmul_core_grid, (M, n_per_core), ttnn.ShardOrientation.ROW_MAJOR),
+            ttnn.ShardSpec(matmul_core_grid, (LMHeadStage.M, LMHeadStage.N_PER_CORE), ttnn.ShardOrientation.ROW_MAJOR),
         )
         indices_mem_config = ttnn.MemoryConfig(
             ttnn.TensorMemoryLayout.WIDTH_SHARDED,
             ttnn.BufferType.L1,
-            ttnn.ShardSpec(matmul_core_grid, (M, n_per_core), ttnn.ShardOrientation.ROW_MAJOR),
+            ttnn.ShardSpec(matmul_core_grid, (LMHeadStage.M, LMHeadStage.N_PER_CORE), ttnn.ShardOrientation.ROW_MAJOR),
         )
         output_index_mem_config = ttnn.MemoryConfig(
             ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
@@ -233,7 +267,7 @@ class LMHeadStage(StageKind):
             mesh_input,
             device=mesh_device,
             layout=ttnn.TILE_LAYOUT,
-            tile=a_tile,
+            tile=LMHeadStage.A_TILE,
             dtype=ttnn.bfloat16,
             memory_config=input_a_mem_config,
             mesh_mapper=mesh_mapper,
@@ -242,14 +276,14 @@ class LMHeadStage(StageKind):
             mesh_intermediate,
             device=mesh_device,
             layout=ttnn.TILE_LAYOUT,
-            tile=a_tile,
+            tile=LMHeadStage.A_TILE,
             dtype=ttnn.bfloat16,
             memory_config=input_a_mem_config,
             mesh_mapper=mesh_mapper,
         )
         ttnn_gamma = self._weights.final_norm
         ttnn_b = self._weights.lm_head
-        torch_indices_flat = torch.arange(n_total, dtype=torch.int32).reshape(1, n_total)
+        torch_indices_flat = torch.arange(LMHeadStage.N_TOTAL, dtype=torch.int32).reshape(1, LMHeadStage.N_TOTAL)
         ttnn_indices = ttnn.from_torch(
             torch_indices_flat.repeat(num_devices, 1, 1),
             dtype=ttnn.uint32,
@@ -259,12 +293,12 @@ class LMHeadStage(StageKind):
             mesh_mapper=mesh_mapper,
         )
         ttnn_scores = ttnn.from_torch(
-            torch.zeros((M, n_total), dtype=torch.bfloat16),
+            torch.zeros((LMHeadStage.M, LMHeadStage.N_TOTAL), dtype=torch.bfloat16),
             dtype=ttnn.bfloat16,
             layout=ttnn.TILE_LAYOUT,
             device=mesh_device,
             memory_config=output_mem_config,
-            tile=out_tile,
+            tile=LMHeadStage.OUT_TILE,
             mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
         )
         ttnn_output_index = ttnn.from_torch(
@@ -349,7 +383,7 @@ class LMHeadStage(StageKind):
             sender_coord=pipeline_config[my_mesh_id].entry_node_coord,
             indices_tensor=d["ttnn_indices"],
             output_index_tensor=d["ttnn_output_index"],
-            argmax_final_core_coord=argmax_final_core,
+            argmax_final_core_coord=LMHeadStage.ARGMAX_FINAL_CORE,
             argmax_final_mesh_coord=pipeline_config[my_mesh_id].exit_node_coord,
             semaphores=[
                 d["out_ready_semaphore"],

--- a/models/demos/deepseek_v3_b1/demo/weight_provider.py
+++ b/models/demos/deepseek_v3_b1/demo/weight_provider.py
@@ -1,0 +1,263 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Weight providers for the DeepSeek V3 B1 demo pipeline.
+CacheWeightProvider loads from disk; SyntheticWeightProvider builds deterministic synthetic weights.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol
+
+import torch
+
+import ttnn
+from models.demos.deepseek_v3_b1.prepare_weights import (
+    NUM_ROUTED_EXPERTS,
+    DeepSeekV3DenseLayerWeights,
+    DeepSeekV3EmbeddingLayerWeights,
+    DeepSeekV3LMHeadWeights,
+    DeepSeekV3MoELayerWeights,
+    load_dense_decoder_layer,
+    load_embedding_weights,
+    load_lm_head_weights,
+    load_moe_decoder_layer,
+    load_moe_routed_experts,
+    prepare_dense_layer_weights,
+    prepare_embedding_weights,
+    prepare_lm_head_weights,
+    prepare_moe_layer_weights,
+)
+
+
+class WeightProvider(Protocol):
+    """Provides embedding and LM head weights on demand; each host loads only what its stage needs."""
+
+    def load_embedding(self, device: ttnn.MeshDevice) -> DeepSeekV3EmbeddingLayerWeights:
+        ...
+
+    def load_lm_head(self, device: ttnn.MeshDevice) -> DeepSeekV3LMHeadWeights:
+        ...
+
+    def load_moe_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3MoELayerWeights:
+        ...
+
+    def load_dense_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3DenseLayerWeights:
+        ...
+
+
+class LogicalModelDimensions:
+    """HF / logical tensor dimensions for DeepSeek V3 B1. Must match prepare_weights and stage expectations."""
+
+    HIDDEN_SIZE = 7168
+    VOCAB_SIZE = 129280
+    Q_A_DIM = 1536
+    Q_B_OUT = 24576
+    KV_A_DIM = 576
+    KV_B_LORA_RANK = 512
+    KV_B_PROJ_OUT = 32768
+    O_PROJ_OUT = 16384
+    MLP_INTERMEDIATE_SIZE = 2048
+    GATE_NUM_INDICES = 256
+
+
+def _layer_key(layer_id: int, suffix: str) -> str:
+    """State dict key under model.layers.{layer_id}."""
+    return f"model.layers.{layer_id}.{suffix}"
+
+
+def _build_synthetic_moe_state_dict(
+    layer_id: int,
+    *,
+    num_routed_experts: int = NUM_ROUTED_EXPERTS,
+) -> dict[str, torch.Tensor]:
+    """Build a synthetic MoE layer state dict with HF tensor shapes (randn for weights, ones for norms)."""
+    state_dict: dict[str, torch.Tensor] = {}
+    dtype = torch.bfloat16
+
+    # Attention weights (HF shapes)
+    state_dict[_layer_key(layer_id, "self_attn.q_a_proj.weight")] = torch.randn(
+        LogicalModelDimensions.Q_A_DIM, LogicalModelDimensions.HIDDEN_SIZE, dtype=dtype
+    )
+    state_dict[_layer_key(layer_id, "self_attn.q_b_proj.weight")] = torch.randn(
+        LogicalModelDimensions.Q_B_OUT, LogicalModelDimensions.Q_A_DIM, dtype=dtype
+    )
+    state_dict[_layer_key(layer_id, "self_attn.kv_a_proj_with_mqa.weight")] = torch.randn(
+        LogicalModelDimensions.KV_A_DIM, LogicalModelDimensions.HIDDEN_SIZE, dtype=dtype
+    )
+    state_dict[_layer_key(layer_id, "self_attn.kv_b_proj.weight")] = torch.randn(
+        LogicalModelDimensions.KV_B_PROJ_OUT, LogicalModelDimensions.KV_B_LORA_RANK, dtype=dtype
+    )
+    state_dict[_layer_key(layer_id, "self_attn.o_proj.weight")] = torch.randn(
+        LogicalModelDimensions.HIDDEN_SIZE, LogicalModelDimensions.O_PROJ_OUT, dtype=dtype
+    )
+
+    # Norms (ones per plan)
+    state_dict[_layer_key(layer_id, "input_layernorm.weight")] = torch.ones(
+        LogicalModelDimensions.HIDDEN_SIZE, dtype=dtype
+    )
+    state_dict[_layer_key(layer_id, "self_attn.q_a_layernorm.weight")] = torch.ones(
+        LogicalModelDimensions.Q_A_DIM, dtype=dtype
+    )
+    state_dict[_layer_key(layer_id, "self_attn.kv_a_layernorm.weight")] = torch.ones(
+        LogicalModelDimensions.KV_B_LORA_RANK, dtype=dtype
+    )
+    state_dict[_layer_key(layer_id, "post_attention_layernorm.weight")] = torch.ones(
+        LogicalModelDimensions.HIDDEN_SIZE, dtype=dtype
+    )
+
+    # MoE gate
+    state_dict[_layer_key(layer_id, "mlp.gate.weight")] = torch.randn(
+        LogicalModelDimensions.GATE_NUM_INDICES, LogicalModelDimensions.HIDDEN_SIZE, dtype=dtype
+    )
+    state_dict[_layer_key(layer_id, "mlp.gate.e_score_correction_bias")] = torch.randn(
+        LogicalModelDimensions.GATE_NUM_INDICES, dtype=dtype
+    )
+
+    # Shared experts
+    state_dict[_layer_key(layer_id, "mlp.shared_experts.gate_proj.weight")] = torch.randn(
+        LogicalModelDimensions.MLP_INTERMEDIATE_SIZE, LogicalModelDimensions.HIDDEN_SIZE, dtype=dtype
+    )
+    state_dict[_layer_key(layer_id, "mlp.shared_experts.up_proj.weight")] = torch.randn(
+        LogicalModelDimensions.MLP_INTERMEDIATE_SIZE, LogicalModelDimensions.HIDDEN_SIZE, dtype=dtype
+    )
+    state_dict[_layer_key(layer_id, "mlp.shared_experts.down_proj.weight")] = torch.randn(
+        LogicalModelDimensions.HIDDEN_SIZE, LogicalModelDimensions.MLP_INTERMEDIATE_SIZE, dtype=dtype
+    )
+
+    # Routed experts
+    for e in range(num_routed_experts):
+        state_dict[_layer_key(layer_id, f"mlp.experts.{e}.gate_proj.weight")] = torch.randn(
+            LogicalModelDimensions.MLP_INTERMEDIATE_SIZE, LogicalModelDimensions.HIDDEN_SIZE, dtype=dtype
+        )
+        state_dict[_layer_key(layer_id, f"mlp.experts.{e}.up_proj.weight")] = torch.randn(
+            LogicalModelDimensions.MLP_INTERMEDIATE_SIZE, LogicalModelDimensions.HIDDEN_SIZE, dtype=dtype
+        )
+        state_dict[_layer_key(layer_id, f"mlp.experts.{e}.down_proj.weight")] = torch.randn(
+            LogicalModelDimensions.HIDDEN_SIZE, LogicalModelDimensions.MLP_INTERMEDIATE_SIZE, dtype=dtype
+        )
+
+    return state_dict
+
+
+def _build_synthetic_dense_state_dict(layer_id: int) -> dict[str, torch.Tensor]:
+    """Build a synthetic dense layer state dict with HF tensor shapes (randn for weights, ones for norms)."""
+    state_dict: dict[str, torch.Tensor] = {}
+    dtype = torch.bfloat16
+
+    # Attention weights (HF shapes)
+    state_dict[_layer_key(layer_id, "self_attn.q_a_proj.weight")] = torch.randn(
+        LogicalModelDimensions.Q_A_DIM, LogicalModelDimensions.HIDDEN_SIZE, dtype=dtype
+    )
+    state_dict[_layer_key(layer_id, "self_attn.q_b_proj.weight")] = torch.randn(
+        LogicalModelDimensions.Q_B_OUT, LogicalModelDimensions.Q_A_DIM, dtype=dtype
+    )
+    state_dict[_layer_key(layer_id, "self_attn.kv_a_proj_with_mqa.weight")] = torch.randn(
+        LogicalModelDimensions.KV_A_DIM, LogicalModelDimensions.HIDDEN_SIZE, dtype=dtype
+    )
+    state_dict[_layer_key(layer_id, "self_attn.kv_b_proj.weight")] = torch.randn(
+        LogicalModelDimensions.KV_B_PROJ_OUT, LogicalModelDimensions.KV_B_LORA_RANK, dtype=dtype
+    )
+    state_dict[_layer_key(layer_id, "self_attn.o_proj.weight")] = torch.randn(
+        LogicalModelDimensions.HIDDEN_SIZE, LogicalModelDimensions.O_PROJ_OUT, dtype=dtype
+    )
+
+    # Norms (ones per plan)
+    state_dict[_layer_key(layer_id, "input_layernorm.weight")] = torch.ones(
+        LogicalModelDimensions.HIDDEN_SIZE, dtype=dtype
+    )
+    state_dict[_layer_key(layer_id, "self_attn.q_a_layernorm.weight")] = torch.ones(
+        LogicalModelDimensions.Q_A_DIM, dtype=dtype
+    )
+    state_dict[_layer_key(layer_id, "self_attn.kv_a_layernorm.weight")] = torch.ones(
+        LogicalModelDimensions.KV_B_LORA_RANK, dtype=dtype
+    )
+    state_dict[_layer_key(layer_id, "post_attention_layernorm.weight")] = torch.ones(
+        LogicalModelDimensions.HIDDEN_SIZE, dtype=dtype
+    )
+
+    # Single MLP (used for both shared and routed in dense)
+    state_dict[_layer_key(layer_id, "mlp.gate_proj.weight")] = torch.randn(
+        LogicalModelDimensions.MLP_INTERMEDIATE_SIZE, LogicalModelDimensions.HIDDEN_SIZE, dtype=dtype
+    )
+    state_dict[_layer_key(layer_id, "mlp.up_proj.weight")] = torch.randn(
+        LogicalModelDimensions.MLP_INTERMEDIATE_SIZE, LogicalModelDimensions.HIDDEN_SIZE, dtype=dtype
+    )
+    state_dict[_layer_key(layer_id, "mlp.down_proj.weight")] = torch.randn(
+        LogicalModelDimensions.HIDDEN_SIZE, LogicalModelDimensions.MLP_INTERMEDIATE_SIZE, dtype=dtype
+    )
+
+    return state_dict
+
+
+class CacheWeightProvider:
+    """Load embedding and LM head weights from cache; each host loads only what its stage needs."""
+
+    def __init__(self, cache_path: Path) -> None:
+        assert cache_path.exists(), f"Cache path does not exist: {cache_path}"
+        assert cache_path.is_dir(), f"Cache path is not a directory: {cache_path}"
+        self._path = cache_path
+
+    def load_embedding(self, device: ttnn.MeshDevice) -> DeepSeekV3EmbeddingLayerWeights:
+        return load_embedding_weights(self._path, device)
+
+    def load_lm_head(self, device: ttnn.MeshDevice) -> DeepSeekV3LMHeadWeights:
+        return load_lm_head_weights(self._path, device)
+
+    def load_moe_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3MoELayerWeights:
+        with ttnn.device.setup_fast_dispatch(device):
+            preloaded_experts = load_moe_routed_experts(self._path, device, layer_id)
+        return load_moe_decoder_layer(self._path, device, layer_id, preloaded_routed_experts=preloaded_experts)
+
+    def load_dense_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3DenseLayerWeights:
+        return load_dense_decoder_layer(self._path, device, layer_id)
+
+
+class SyntheticWeightProvider:
+    """Create deterministic synthetic embedding and LM head weights in place (no cache)."""
+
+    def load_embedding(self, device: ttnn.MeshDevice) -> DeepSeekV3EmbeddingLayerWeights:
+        emb_w = torch.zeros(
+            (LogicalModelDimensions.VOCAB_SIZE, LogicalModelDimensions.HIDDEN_SIZE), dtype=torch.bfloat16
+        )
+        emb_w[
+            torch.arange(LogicalModelDimensions.VOCAB_SIZE),
+            torch.arange(LogicalModelDimensions.VOCAB_SIZE, dtype=torch.int64) % LogicalModelDimensions.HIDDEN_SIZE,
+        ] = 1
+        return prepare_embedding_weights({"model.embed_tokens.weight": emb_w}, device, move_to_device=True)
+
+    def load_lm_head(self, device: ttnn.MeshDevice) -> DeepSeekV3LMHeadWeights:
+        # Stride for synthetic one-hot pattern: 101 matmul cores × 160 per core (matches LM head sampling op layout).
+        _lm_head_n_synthetic = 101 * 160
+        lm_w = torch.full(
+            (LogicalModelDimensions.VOCAB_SIZE, LogicalModelDimensions.HIDDEN_SIZE), -1.0, dtype=torch.bfloat16
+        )
+        lm_w[
+            torch.arange(LogicalModelDimensions.HIDDEN_SIZE, dtype=torch.int64) % _lm_head_n_synthetic,
+            torch.arange(LogicalModelDimensions.HIDDEN_SIZE),
+        ] = 1
+        return prepare_lm_head_weights(
+            {
+                "lm_head.weight": lm_w,
+                "model.norm.weight": torch.ones(LogicalModelDimensions.HIDDEN_SIZE, dtype=torch.bfloat16),
+            },
+            device,
+            move_to_device=True,
+        )
+
+    def load_moe_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3MoELayerWeights:
+        from models.demos.deepseek_v3_b1.blitz_decode_weights import BlitzDecodeWeights
+
+        sd = _build_synthetic_moe_state_dict(layer_id, num_routed_experts=NUM_ROUTED_EXPERTS)
+        bdw = BlitzDecodeWeights(device)
+        return prepare_moe_layer_weights(bdw, sd, layer_id, num_routed_experts=NUM_ROUTED_EXPERTS)
+
+    def load_dense_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3DenseLayerWeights:
+        from models.demos.deepseek_v3_b1.blitz_decode_weights import BlitzDecodeWeights
+
+        sd = _build_synthetic_dense_state_dict(layer_id)
+        bdw = BlitzDecodeWeights(device)
+        return prepare_dense_layer_weights(bdw, sd, layer_id, move_to_device=True)

--- a/models/demos/deepseek_v3_b1/model.py
+++ b/models/demos/deepseek_v3_b1/model.py
@@ -39,7 +39,7 @@ import ttnn
 # Token IDs are int32 over the socket; payload size per step is B * TOKEN_ID_BYTES.
 TOKEN_ID_BYTES: int = 4
 
-# Socket page_size must be PCIe-aligned (see h2d_socket.cpp). Use 64 to work across devices.
+# Socket page_size must be PCIe-aligned (see h2d_socket.cpp). Must match demo stage TOKEN_PAGE_SIZE_BYTES (64).
 PCIE_PAGE_ALIGNMENT_BYTES: int = 64
 
 

--- a/models/demos/deepseek_v3_b1/prepare_weights.py
+++ b/models/demos/deepseek_v3_b1/prepare_weights.py
@@ -37,9 +37,9 @@ _DTYPE_TO_STR = {
 }
 _STR_TO_DTYPE = {v: k for k, v in _DTYPE_TO_STR.items()}
 
-# MoE gate bias: HEIGHT_SHARDED on sender core (10, 9), tile [16, 16]
-_MOE_SENDER_CORE = ttnn.CoreCoord(10, 9)
-_MOE_SENDER_CORE_GRID = ttnn.CoreRangeSet([ttnn.CoreRange(_MOE_SENDER_CORE, _MOE_SENDER_CORE)])
+# MoE sender core: hardcoded grid (13, 10) so cache layout is consistent across slow/fast dispatch.
+# Sender core = (grid.x - 1, grid.y - 1) = (12, 9); must match test_moe_mlp create_runtime_tensors.
+MOE_SENDER_GRID_SIZE = (13, 10)
 _GATE_BIAS_TILE = ttnn.Tile([16, 16])
 
 # Fusion group name per field (for grouping by fused_tensor)
@@ -207,6 +207,34 @@ def _key(layer_idx: int, suffix: str) -> str:
     return f"model.layers.{layer_idx}.{suffix}"
 
 
+def create_gate_bias_tensor(raw_tensor: torch.Tensor, device, *, move_to_device: bool = False) -> ttnn.Tensor:
+    """Build gate_bias (e_score_correction_bias) as HEIGHT_SHARDED on sender core, replicated across mesh.
+
+    raw_tensor: shape (256,) from state dict (model.layers.{i}.mlp.gate.e_score_correction_bias).
+    Returns ttnn.Tensor with layout expected by MoE op: (16, 16) on sender core, tile 16x16.
+    Sender core uses MOE_SENDER_GRID_SIZE so cache layout is consistent across slow/fast dispatch.
+    When move_to_device is False (default), tensor is not placed (device=None) for cache generation.
+    When move_to_device is True, tensor is placed on device so is_sharded() is true for runtime use.
+    """
+    sender_core = ttnn.CoreCoord(MOE_SENDER_GRID_SIZE[0] - 1, MOE_SENDER_GRID_SIZE[1] - 1)
+    sender_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(sender_core, sender_core)])
+    gate_bias_reshaped = raw_tensor.reshape(16, 16).T.contiguous().to(torch.bfloat16)
+    gate_bias_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(sender_core_grid, (16, 16), ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    return ttnn.from_torch(
+        gate_bias_reshaped,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device if move_to_device else None,
+        memory_config=gate_bias_mem_config,
+        tile=_GATE_BIAS_TILE,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(device),
+    )
+
+
 def _split_kv_b_proj(kv_b_proj: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
     """Split HF kv_b_proj (out_features, in_features) into kv_b1 and kv_b2.
 
@@ -342,46 +370,6 @@ _GATE_BIAS_INDICES_SHAPE = (16, 16)
 _GATE_NUM_INDICES = 256
 
 
-def create_gate_bias_tensor(
-    raw: torch.Tensor,
-    device: Any,
-    sender_core_grid: ttnn.CoreRangeSet,
-    *,
-    mesh_mapper: Any = None,
-) -> ttnn.Tensor:
-    """Build gate bias (e_score_correction_bias) as HEIGHT_SHARDED on sender core.
-
-    Args:
-        raw: Shape (256,) from state dict mlp.gate.e_score_correction_bias.
-        device: ttnn device or mesh device.
-        sender_core_grid: Single-core range set for the sender core.
-        mesh_mapper: Optional mesh mapper for multi-device.
-
-    Returns:
-        ttnn.Tensor with shape (16, 16), HEIGHT_SHARDED on sender_core_grid, tile 16x16, bfloat16.
-    """
-    assert raw.shape == (_GATE_NUM_INDICES,), f"gate bias raw must be ({_GATE_NUM_INDICES},), got {raw.shape}"
-    # (256,) -> (1, 8, 32) -> (16, 16) then transpose to match op layout
-    reshaped = raw.reshape(1, 8, 32).reshape(_GATE_BIAS_INDICES_SHAPE[0], _GATE_BIAS_INDICES_SHAPE[1])
-    transposed = torch.transpose(reshaped, 0, 1).contiguous().to(torch.bfloat16)
-    shard_spec = ttnn.ShardSpec(
-        sender_core_grid,
-        _GATE_BIAS_INDICES_SHAPE,
-        ttnn.ShardOrientation.ROW_MAJOR,
-    )
-    mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec)
-    kwargs = {"mesh_mapper": mesh_mapper} if mesh_mapper else {}
-    return ttnn.from_torch(
-        transposed,
-        dtype=ttnn.bfloat16,
-        layout=ttnn.TILE_LAYOUT,
-        device=device,
-        memory_config=mem_config,
-        tile=ttnn.Tile([16, 16]),
-        **kwargs,
-    )
-
-
 def create_gate_indices_tensor(
     device: Any,
     sender_core_grid: ttnn.CoreRangeSet,
@@ -448,8 +436,7 @@ def prepare_attention_weights(
         gate_bias_tt = create_gate_bias_tensor(
             state_dict[_key(layer_idx, "mlp.gate.e_score_correction_bias")],
             bdw._device,
-            _MOE_SENDER_CORE_GRID,
-            mesh_mapper=ttnn.ReplicateTensorToMesh(bdw._device),
+            move_to_device=move_to_device,
         )
         logger.debug("  convert o_proj_gate_mm_norms (MoE): {:.3f}s", time.perf_counter() - t0)
         return AttentionWeights(

--- a/models/demos/deepseek_v3_b1/prepare_weights.py
+++ b/models/demos/deepseek_v3_b1/prepare_weights.py
@@ -573,13 +573,15 @@ def prepare_dense_layer_weights(
     bdw: BlitzDecodeWeights,
     state_dict: dict[str, torch.Tensor],
     layer_idx: int,
+    *,
+    move_to_device: bool = False,
 ) -> DeepSeekV3DenseLayerWeights:
     """Prepare fused weights for a single dense decoder layer."""
     logger.info("Preparing dense layer {}...", layer_idx)
     t0 = time.perf_counter()
-    attn = prepare_attention_weights(bdw, state_dict, layer_idx, is_moe=False)
-    shared = prepare_shared_expert_weights(bdw, state_dict, layer_idx, is_moe=False)
-    routed = prepare_routed_expert_weights(bdw, state_dict, layer_idx, is_moe=False)
+    attn = prepare_attention_weights(bdw, state_dict, layer_idx, is_moe=False, move_to_device=move_to_device)
+    shared = prepare_shared_expert_weights(bdw, state_dict, layer_idx, is_moe=False, move_to_device=move_to_device)
+    routed = prepare_routed_expert_weights(bdw, state_dict, layer_idx, is_moe=False, move_to_device=move_to_device)
     assert isinstance(routed, DenseRoutedExpertWeights)
     return DeepSeekV3DenseLayerWeights(
         q_a_proj=attn.q_a_proj,

--- a/models/demos/deepseek_v3_b1/scripts/generate_cache.py
+++ b/models/demos/deepseek_v3_b1/scripts/generate_cache.py
@@ -5,17 +5,17 @@
 """
 Generate weight cache for DeepSeek V3 from HuggingFace safetensors.
 
+Runs in fast dispatch; weights are prepared and saved to disk (no device placement).
+
 Modes:
-  dense     - Full dense layer (layers 0-2). Requires slow dispatch.
-  moe       - Attention + shared experts only (layers 3-60). Requires slow dispatch.
-  experts   - Routed experts only (layers 3-60). Can run in fast dispatch.
+  dense     - Full dense layer (layers 0-2).
+  moe       - Full MoE layer (layers 3-60): attention + shared experts + routed experts.
   embedding - Embedding layer (model.embed_tokens). No --layer-num needed.
   lm_head   - LM head + final RMSNorm. No --layer-num needed.
 
 Usage:
   python generate_cache.py --model-path /path/to/DeepSeek-V3 --output-path /path/to/cache --layer-num 0 --type dense
   python generate_cache.py --model-path /path/to/DeepSeek-V3 --output-path /path/to/cache --layer-num 4 --type moe
-  python generate_cache.py --model-path /path/to/DeepSeek-V3 --output-path /path/to/cache --layer-num 4 --type experts
   python generate_cache.py --model-path /path/to/DeepSeek-V3 --output-path /path/to/cache --type embedding
   python generate_cache.py --model-path /path/to/DeepSeek-V3 --output-path /path/to/cache --type lm_head
 """
@@ -35,7 +35,6 @@ import ttnn
 
 # Same mesh device setup as test_prepare_weights.py (bh_2d_mesh_device fixture).
 from conftest import bh_2d_mesh_device_context
-from models.common.utility_functions import is_slow_dispatch
 from models.demos.deepseek_v3.utils.lazy_state_dict import LazyStateDict
 from models.demos.deepseek_v3_b1.blitz_decode_weights import BlitzDecodeWeights
 from models.demos.deepseek_v3_b1.prepare_weights import (
@@ -48,18 +47,13 @@ from models.demos.deepseek_v3_b1.prepare_weights import (
     load_embedding_weights,
     load_lm_head_weights,
     load_moe_decoder_layer,
-    prepare_attention_weights,
     prepare_dense_layer_weights,
     prepare_embedding_weights,
     prepare_lm_head_weights,
-    prepare_routed_expert_weights,
-    prepare_shared_expert_weights,
-    save_attention_weights,
+    prepare_moe_layer_weights,
     save_decoder_layer,
     save_embedding_weights,
     save_lm_head_weights,
-    save_routed_expert_weights,
-    save_shared_expert_weights,
 )
 
 NUM_LAYERS = 61
@@ -68,14 +62,6 @@ DEVICE_MESH_SHAPE = (4, 2)
 MANIFEST_VERSION = 1
 HF_MODEL_NAME = "deepseek-ai/DeepSeek-V3"
 HF_STATE_DICT_NAME = "lazy"
-
-# Fusion group tensorbin names written by save_attention_weights / save_shared_expert_weights (moe mode)
-MOE_FUSION_FILES = (
-    "q_ab_kv_a.tensorbin",
-    "o_proj_gate_mm_norms.tensorbin",
-    "kv_b12.tensorbin",
-    "gate_up.tensorbin",
-)
 
 # Expected tensor_topology() placements for 4x2 mesh (mla_tp=2, moe_tp=8); used by verify device load.
 _PLACEMENTS_SHARD_NONE_1 = [ttnn.PlacementReplicate(), ttnn.PlacementShard(1)]  # q_ab_kv_a, o_proj_gate_mm_norms
@@ -104,14 +90,14 @@ def _create_parser() -> argparse.ArgumentParser:
         "--layer-num",
         type=int,
         default=None,
-        help="Layer index (0-60); required for dense/moe/experts, ignored for embedding/lm_head",
+        help="Layer index (0-60); required for dense/moe, ignored for embedding/lm_head",
     )
     parser.add_argument(
         "--type",
         dest="mode",
-        choices=("dense", "moe", "experts", "embedding", "lm_head"),
+        choices=("dense", "moe", "embedding", "lm_head"),
         required=True,
-        help="Cache type: dense (layers 0-2), moe (attn+shared for 3-60), experts (routed only for 3-60), embedding, lm_head",
+        help="Cache type: dense (layers 0-2), moe (full layer for 3-60), embedding, lm_head",
     )
     parser.add_argument(
         "--force",
@@ -133,7 +119,7 @@ def _validate_args(args: argparse.Namespace) -> None:
     output_path = args.output_path.resolve()
 
     # Layer-num required and validated only for layer-based modes
-    if mode in ("dense", "moe", "experts"):
+    if mode in ("dense", "moe"):
         if layer_num is None:
             logger.error("--layer-num is required for type={}", mode)
             sys.exit(1)
@@ -152,8 +138,7 @@ def _validate_args(args: argparse.Namespace) -> None:
         else:
             if layer_num < FIRST_K_DENSE_REPLACE:
                 logger.error(
-                    "type={} requires layer-num >= {} (MoE layers are {}-{}), got {}",
-                    mode,
+                    "type=moe requires layer-num >= {} (MoE layers are {}-{}), got {}",
                     FIRST_K_DENSE_REPLACE,
                     FIRST_K_DENSE_REPLACE,
                     NUM_LAYERS - 1,
@@ -214,45 +199,13 @@ def _validate_args(args: argparse.Namespace) -> None:
                 sys.exit(1)
         else:
             layer_dir = output_path / f"layer_{layer_num:03d}"
-            if mode == "dense":
-                manifest = layer_dir / "manifest.json"
-                if manifest.exists():
-                    logger.error(
-                        "Layer {} cache already exists (manifest.json). Use --force to overwrite.",
-                        layer_num,
-                    )
-                    sys.exit(1)
-            elif mode == "moe":
-                for name in MOE_FUSION_FILES:
-                    f = layer_dir / name
-                    if f.exists():
-                        logger.error(
-                            "Layer {} already has {} (moe cache). Use --force to overwrite.",
-                            layer_num,
-                            name,
-                        )
-                        sys.exit(1)
-            else:
-                experts_dir = layer_dir / "experts"
-                if experts_dir.exists():
-                    logger.error(
-                        "Layer {} already has experts/ directory. Use --force to overwrite.",
-                        layer_num,
-                    )
-                    sys.exit(1)
-
-    # Dispatch mode: dense and moe require slow dispatch; experts can use either, warn if slow; embedding/lm_head no requirement
-    if mode in ("dense", "moe"):
-        if not is_slow_dispatch():
-            logger.warning(
-                "type={} requires slow dispatch mode. Set TT_METAL_SLOW_DISPATCH_MODE=1 and rerun.",
-                mode,
-            )
-    elif mode == "experts":
-        if is_slow_dispatch():
-            logger.warning(
-                "experts mode can run in fast dispatch; you have TT_METAL_SLOW_DISPATCH_MODE=1 set (slow dispatch)."
-            )
+            manifest = layer_dir / "manifest.json"
+            if manifest.exists():
+                logger.error(
+                    "Layer {} cache already exists (manifest.json). Use --force to overwrite.",
+                    layer_num,
+                )
+                sys.exit(1)
 
 
 def _check_file(path: Path, layer_dir: Path) -> bool:
@@ -494,8 +447,9 @@ def _verify_cache(output_path: Path, layer_num: int, mode: str) -> bool:
             logger.error("Expected layer_type 'dense', got '{}'", layer_type)
             return False
     else:
+        assert mode == "moe"
         if layer_type != "moe":
-            logger.error("Expected layer_type 'moe' for mode {}, got '{}'", mode, layer_type)
+            logger.error("Expected layer_type 'moe', got '{}'", layer_type)
             return False
 
     fusion_groups = manifest.get("fusion_groups", {})
@@ -520,21 +474,20 @@ def _verify_cache(output_path: Path, layer_num: int, mode: str) -> bool:
             if not _check_file(Path(standalone_tensors[name]), layer_dir):
                 return False
         logger.info("All dense layer files present")
-    elif mode == "moe":
+    else:
+        # Full MoE layer: fusion groups + standalone (incl. gate_bias) + routed experts
         for name in ("q_ab_kv_a", "o_proj_gate_mm_norms", "kv_b12", "gate_up"):
             if name not in fusion_groups:
                 logger.error("Missing fusion_groups['{}']", name)
                 return False
             if not _check_file(Path(fusion_groups[name]["tensorbin"]), layer_dir):
                 return False
-        if "shared_down_proj" not in standalone_tensors:
-            logger.error("Missing standalone_tensors['shared_down_proj']")
-            return False
-        if not _check_file(Path(standalone_tensors["shared_down_proj"]), layer_dir):
-            return False
-        logger.info("All moe (attn+shared) files present")
-    else:
-        assert mode == "experts"
+        for name in ("shared_down_proj", "gate_bias"):
+            if name not in standalone_tensors:
+                logger.error("Missing standalone_tensors['{}']", name)
+                return False
+            if not _check_file(Path(standalone_tensors[name]), layer_dir):
+                return False
         routed = manifest.get("routed_experts", {})
         num_experts = routed.get("num_experts", 0)
         if num_experts != NUM_ROUTED_EXPERTS:
@@ -552,20 +505,10 @@ def _verify_cache(output_path: Path, layer_num: int, mode: str) -> bool:
             for fname in ("gate_proj.tensorbin", "up_proj.tensorbin", "down_proj.tensorbin"):
                 if not _check_file(expert_dir / fname, layer_dir):
                     return False
-        logger.info("All {} expert files present", NUM_ROUTED_EXPERTS)
+        logger.info("All MoE layer files present (attn+shared+experts)")
 
     # 3. Optional device load when cache is a complete layer
-    full_layer = False
-    if mode == "dense":
-        full_layer = True
-    elif mode == "moe":
-        experts_dir = layer_dir / "experts"
-        if experts_dir.is_dir():
-            n = sum(1 for _ in experts_dir.iterdir() if _.is_dir())
-            if n >= NUM_ROUTED_EXPERTS:
-                full_layer = True
-
-    if full_layer:
+    if True:
         logger.info("Cache is complete layer; loading to device for sanity check...")
         if not os.environ.get("TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS"):
             os.environ["TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS"] = "30000"
@@ -611,8 +554,6 @@ def _verify_cache(output_path: Path, layer_num: int, mode: str) -> bool:
         except Exception as e:
             logger.error("Device load failed: {}", e)
             return False
-    else:
-        logger.info("Cache is partial (moe-only or experts-only); skipping device load")
 
     logger.info("Verify OK")
     return True
@@ -690,34 +631,21 @@ def main() -> int:
                 )
                 logger.info("save_decoder_layer took {:.3f}s", time.perf_counter() - t0)
             elif mode == "moe":
-                logger.info("Preparing attention weights (MoE)...")
+                logger.info("Preparing full MoE layer weights...")
                 t0 = time.perf_counter()
-                attn = prepare_attention_weights(bdw, state_dict, layer_num, is_moe=True)
-                logger.info("prepare_attention_weights took {:.3f}s", time.perf_counter() - t0)
-                logger.info("Saving attention weights...")
+                layer = prepare_moe_layer_weights(bdw, state_dict, layer_num)
+                logger.info("prepare_moe_layer_weights took {:.3f}s", time.perf_counter() - t0)
+                logger.info("Saving MoE layer to disk...")
                 t0 = time.perf_counter()
-                save_attention_weights(
-                    attn,
+                save_decoder_layer(
+                    layer,
                     output_path,
                     layer_num,
-                    is_moe=True,
-                    **manifest_kw,
+                    hf_model_name=manifest_kw["hf_model_name"],
+                    hf_state_dict_name=manifest_kw["hf_state_dict_name"],
+                    device_mesh_shape=manifest_kw["device_mesh_shape"],
                 )
-                logger.info("save_attention_weights took {:.3f}s", time.perf_counter() - t0)
-                logger.info("Preparing shared expert weights...")
-                t0 = time.perf_counter()
-                shared = prepare_shared_expert_weights(bdw, state_dict, layer_num, is_moe=True)
-                logger.info("prepare_shared_expert_weights took {:.3f}s", time.perf_counter() - t0)
-                logger.info("Saving shared expert weights...")
-                t0 = time.perf_counter()
-                save_shared_expert_weights(
-                    shared,
-                    output_path,
-                    layer_num,
-                    is_moe=True,
-                    **manifest_kw,
-                )
-                logger.info("save_shared_expert_weights took {:.3f}s", time.perf_counter() - t0)
+                logger.info("save_decoder_layer took {:.3f}s", time.perf_counter() - t0)
             elif mode == "embedding":
                 logger.info("Preparing embedding weights...")
                 t0 = time.perf_counter()
@@ -736,28 +664,6 @@ def main() -> int:
                 t0 = time.perf_counter()
                 save_lm_head_weights(weights, output_path, **manifest_kw)
                 logger.info("save_lm_head_weights took {:.3f}s", time.perf_counter() - t0)
-            else:
-                assert mode == "experts"
-                logger.info("Preparing routed expert weights (num_routed_experts={})...", NUM_ROUTED_EXPERTS)
-                t0 = time.perf_counter()
-                routed = prepare_routed_expert_weights(
-                    bdw,
-                    state_dict,
-                    layer_num,
-                    is_moe=True,
-                    num_routed_experts=NUM_ROUTED_EXPERTS,
-                )
-                logger.info("prepare_routed_expert_weights took {:.3f}s", time.perf_counter() - t0)
-                logger.info("Saving routed expert weights...")
-                t0 = time.perf_counter()
-                save_routed_expert_weights(
-                    routed,
-                    output_path,
-                    layer_num,
-                    is_moe=True,
-                    **manifest_kw,
-                )
-                logger.info("save_routed_expert_weights took {:.3f}s", time.perf_counter() - t0)
 
     elapsed = time.perf_counter() - total_t0
     if mode in ("embedding", "lm_head"):

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_mlp.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_mlp.py
@@ -461,7 +461,10 @@ def create_routed_expert_tensors(
         assert is_moe, "enable_routing=True is only supported with MoE weights"
         # Gate bias/indices from prepare_weights helpers.
         raw_bias = state_dict[f"{layer_key}.mlp.gate.e_score_correction_bias"]
-        ttnn_gate_bias = create_gate_bias_tensor(raw_bias, device, input_core_grid, mesh_mapper=mesh_mapper)
+        ttnn_gate_bias = create_gate_bias_tensor(raw_bias, device, move_to_device=True)
+        assert list(ttnn.corerange_to_cores(ttnn_gate_bias.memory_config().shard_spec.grid)) == list(
+            ttnn.corerange_to_cores(input_core_grid)
+        ), "gate_bias grid must match input_core_grid (MOE_SENDER_GRID_SIZE)"
         ttnn_gate_indices = create_gate_indices_tensor(device, input_core_grid, mesh_mapper=mesh_mapper)
         # Gate output buffers (scores and indices on sender core)
         tile_1x16 = ttnn.Tile((1, 16))


### PR DESCRIPTION
### Ticket
N/A

### What's changed
- Replaces the separate prefill_forward() and decode_forward() methods on ModelPipeline with a single run_inference() method that encapsulates the full inference loop (prefill followed by autoregressive decoding with EOS-based early stopping).
- Simplifies cli.py by moving the generation loop out of run_demo and into ModelPipeline, making the host-side call site a one-liner with a token callback.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ztorlak/changing_model_pipeline_class_methods)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ztorlak/changing_model_pipeline_class_methods)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ztorlak/changing_model_pipeline_class_methods)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ztorlak/changing_model_pipeline_class_methods)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ztorlak/changing_model_pipeline_class_methods)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ztorlak/changing_model_pipeline_class_methods)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ztorlak/changing_model_pipeline_class_methods)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ztorlak/changing_model_pipeline_class_methods)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ztorlak/changing_model_pipeline_class_methods)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ztorlak/changing_model_pipeline_class_methods)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ztorlak/changing_model_pipeline_class_methods)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ztorlak/changing_model_pipeline_class_methods)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
