### PR TITLE
fix graph tracing on ttnn.topk operation

### DIFF
--- a/tests/ttnn/unit_tests/base_functionality/test_graph_capture.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_graph_capture.py
@@ -36,6 +36,24 @@ def test_graph_capture(tmp_path, device, scalar, size, mode):
     ttnn.graph.visualize(captured_graph, file_name=tmp_path / pathlib.Path("graph.svg"))
 
 
+@pytest.mark.parametrize("k", [2])
+@pytest.mark.parametrize("mode", [ttnn.graph.RunMode.NO_DISPATCH, ttnn.graph.RunMode.NORMAL])
+def test_graph_capture_topk(device, k, mode):
+    """Sanity check that graph capture doesn't fail"""
+    torch.manual_seed(0)
+
+    input_shape = (1, 1, 32, 128)
+    torch_input = torch.randn(input_shape, dtype=torch.bfloat16)
+    tt_input = ttnn.from_torch(torch_input, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    ttnn.graph.begin_graph_capture(mode)
+    _ = ttnn.topk(tt_input, k, dim=-1, largest=True, sorted=True)
+    captured_graph = ttnn.graph.end_graph_capture()
+
+    assert captured_graph[0]["node_type"] == "capture_start"
+    assert captured_graph[-1]["node_type"] == "capture_end"
+
+
 def test_graph_capture_with_all_parameters(device):
     # Create input tensor
     torch_input = torch.rand((1, 1, 2048, 512), dtype=torch.bfloat16)

--- a/ttnn/api/ttnn/graph/graph_serialization.hpp
+++ b/ttnn/api/ttnn/graph/graph_serialization.hpp
@@ -49,6 +49,9 @@ void serialize_member(std::ostringstream& oss, const MemberT& member) {
         oss << ", ";
         serialize_member(oss, member.second);
         oss << "}";
+    } else if constexpr (std::is_same_v<MemberT, int8_t> || std::is_same_v<MemberT, uint8_t>) {
+        // Cast to int so the numeric value is printed, not the raw byte (which may be invalid UTF-8)
+        oss << static_cast<int>(member);
     } else if constexpr (requires { oss << member; }) {
         oss << member;
     } else if constexpr (ttsl::concepts::Reflectable<MemberT>) {
@@ -82,6 +85,9 @@ std::string serialize_tracked_arg(const std::any& a) {
         oss << "<incomplete type>";
     } else if constexpr (ttsl::is_specialization_v<CleanT, std::vector>) {
         ttsl::reflection::operator<<(oss, val);
+    } else if constexpr (std::is_same_v<CleanT, int8_t> || std::is_same_v<CleanT, uint8_t>) {
+        // Cast to int so the numeric value is printed, not the raw byte (which may be invalid UTF-8)
+        oss << static_cast<int>(val);
     } else if constexpr (requires { oss << val; }) {
         oss << val;
     } else if constexpr (ttsl::concepts::Reflectable<CleanT>) {


### PR DESCRIPTION
### Problem description
ttnn.graph.end_graph_capture() failed on ttnn.topk operation with `invalid UTF-8 byte at index 0: 0xFF`
Same issue is here https://github.com/tenstorrent/tt-metal/issues/36464#issuecomment-3807794405 (didn't investigate the reason)

### What's changed
Added correct casting to serialize int8_t and uint8_t dtypes.
Added unit test for graph tracing of ttnn.topk operation.

### Checklist

- [X] [APC ttnn unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/22721326697) - CI passes