### PR TITLE
Add artifact name data

### DIFF
--- a/.github/scripts/data_analysis/create_pipeline_json.py
+++ b/.github/scripts/data_analysis/create_pipeline_json.py
@@ -7,6 +7,7 @@ if __name__ == "__main__":
     github_runner_environment = get_github_runner_environment()
     github_pipeline_json_filename = "workflow.json"
     github_jobs_json_filename = "workflow_jobs.json"
+    github_artifacts_json_filename = "workflow_artifacts.json"
 
     workflow_outputs_dir = pathlib.Path("generated/cicd").resolve()
     assert workflow_outputs_dir.is_dir()
@@ -17,6 +18,7 @@ if __name__ == "__main__":
         github_runner_environment,
         github_pipeline_json_filename,
         github_jobs_json_filename,
+        github_artifacts_json_filename,
     )
 
     cicd_json_filename = get_cicd_json_filename(pipeline)

--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -166,6 +166,13 @@ jobs:
         run: |
           ./infra/data_collection/github/download_cicd_logs_and_artifacts.sh --workflow-run-id ${{ steps.get-run-id-and-attempt.outputs.run-id }} --attempt-number ${{ steps.get-run-id-and-attempt.outputs.attempt-number }}
           find generated/cicd/ -type f
+      - name: Show artifacts metadata
+        run: |
+          echo "[Info] Artifacts uploaded in this workflow run:"
+          cat workflow_artifacts.json | jq '.artifacts[] | {name: .name, size_in_bytes: .size_in_bytes, created_at: .created_at, expired: .expired}'
+          echo ""
+          echo "[Info] Artifact names list:"
+          cat workflow_artifacts.json | jq -r '.artifacts[].name'
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
@@ -199,6 +206,7 @@ jobs:
               pipelinecopy_*.json
               workflow.json
               workflow_jobs.json
+              workflow_artifacts.json
       - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:

--- a/infra/data_collection/cicd.py
+++ b/infra/data_collection/cicd.py
@@ -34,12 +34,27 @@ def create_cicd_json_for_data_analysis(
     github_runner_environment,
     github_pipeline_json_filename,
     github_jobs_json_filename,
+    github_artifacts_json_filename=None,
 ):
     with open(github_pipeline_json_filename) as github_pipeline_json_file:
         github_pipeline_json = json.load(github_pipeline_json_file)
 
     with open(github_jobs_json_filename) as github_jobs_json_file:
         github_jobs_json = json.load(github_jobs_json_file)
+
+    # Load artifact names if the file exists
+    artifact_names = None
+    if github_artifacts_json_filename:
+        try:
+            with open(github_artifacts_json_filename) as github_artifacts_json_file:
+                github_artifacts_json = json.load(github_artifacts_json_file)
+                artifacts = github_artifacts_json.get("artifacts", [])
+                artifact_names = [artifact["name"] for artifact in artifacts]
+                logger.info(f"Loaded {len(artifact_names)} artifact names")
+        except FileNotFoundError:
+            logger.warning(f"Artifacts file {github_artifacts_json_filename} not found")
+        except Exception as e:
+            logger.warning(f"Error loading artifacts file: {e}")
 
     raw_pipeline = get_pipeline_row_from_github_info(github_runner_environment, github_pipeline_json, github_jobs_json)
 
@@ -103,6 +118,7 @@ def create_cicd_json_for_data_analysis(
 
     pipeline = pydantic_models.Pipeline(
         **raw_pipeline,
+        artifact_names=artifact_names,
         jobs=jobs,
     )
 

--- a/infra/data_collection/github/download_cicd_logs_and_artifacts.sh
+++ b/infra/data_collection/github/download_cicd_logs_and_artifacts.sh
@@ -18,7 +18,14 @@ download_artifacts() {
     local workflow_run_id=$2
 
     echo "[info] Downloading test reports for workflow run $workflow_run_id"
-    api_output=$(gh api --paginate /repos/$repo/actions/runs/$workflow_run_id/artifacts | jq -r '.artifacts[] | .name')
+
+    # Get and save full artifacts information to JSON file
+    artifacts_data=$(gh api --paginate /repos/$repo/actions/runs/$workflow_run_id/artifacts)
+    echo "$artifacts_data" | jq -s '{total_count: .[0].total_count, artifacts: map(.artifacts) | add}' > workflow_artifacts.json
+    echo "[info] Saved artifacts metadata to workflow_artifacts.json"
+
+    # Extract artifact names for downloading
+    api_output=$(echo "$artifacts_data" | jq -r '.artifacts[] | .name')
     if echo "$api_output" | grep -q "test_reports_"; then
         gh run download --repo $repo -D generated/cicd/$workflow_run_id/artifacts --pattern test_reports_* $workflow_run_id
     else

--- a/infra/data_collection/pydantic_models.py
+++ b/infra/data_collection/pydantic_models.py
@@ -175,6 +175,9 @@ class Pipeline(BaseModel):
     git_commit_hash: str = Field(description="Git commit that triggered the execution of the pipeline.")
     git_author: str = Field(description="Author of the Git commit.")
     orchestrator: Optional[str] = Field(None, description="CI/CD pipeline orchestration platform.")
+    artifact_names: Optional[List[str]] = Field(
+        None, description="List of artifact names uploaded in this pipeline run."
+    )
     jobs: List[Job] = []
 
     # Model validator to check the unique combination constraint


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=dpopov-add-artifact-names-to-data)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:dpopov-add-artifact-names-to-data)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dpopov-add-artifact-names-to-data)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dpopov-add-artifact-names-to-data)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dpopov-add-artifact-names-to-data)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dpopov-add-artifact-names-to-data)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dpopov-add-artifact-names-to-data)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dpopov-add-artifact-names-to-data)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dpopov-add-artifact-names-to-data)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dpopov-add-artifact-names-to-data)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dpopov-add-artifact-names-to-data)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dpopov-add-artifact-names-to-data)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
