### PR TITLE
[skip ci] Remove BH loudbox llama8b DP=4 (already running DP=8)

### DIFF
--- a/tests/pipeline_reorg/blackhole_demo_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_demo_tests.yaml
@@ -104,8 +104,6 @@
   skus:
     bh_llmbox:
       timeout: 10
-    bh_loudbox:
-      timeout: 10
     bh_quietbox_2:
       timeout: 10
   owner_id: U03PUAKE719 # Miguel Tairum


### PR DESCRIPTION
### Ticket
None

### What's changed
Accidentally added BH-loudbox to llama8b data-parallel=4 testcase which is not needed since it already runs in data-parallel=8

### Checklist

- [x] New/Existing tests provide coverage for changes


