### PR TITLE
Deepseek MLA - Remove Output Shard Spec from Certain Matmuls

### DIFF
--- a/models/demos/deepseek_v3/tt/mla/mla1d.py
+++ b/models/demos/deepseek_v3/tt/mla/mla1d.py
@@ -694,13 +694,8 @@ class MLA1D(AbstractModule):
             "orientation": ttnn.ShardOrientation.ROW_MAJOR,
         }
 
-        # Output L1 WIDTH sharded memory config for qkv_a (using padded n)
-        qkv_a_out_memory_config = ttnn.create_sharded_memory_config(
-            [1, 1, ttnn.core.roundup(USERS_PER_ROW, tile_size), qkv_a_n_padded],
-            core_grid=qkv_a_out_core_grid,
-            strategy=ttnn.ShardStrategy.WIDTH,
-            orientation=ttnn.ShardOrientation.ROW_MAJOR,
-        )
+        # Output L1 WIDTH sharded memory config for qkv_a (shard spec computed by the op)
+        qkv_a_out_memory_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1)
 
         wq_kv_a_config = LinearConfig(
             input_tensor_b=FromWeightConfig(mesh_device),
@@ -741,13 +736,8 @@ class MLA1D(AbstractModule):
             "orientation": ttnn.ShardOrientation.ROW_MAJOR,
         }
 
-        # Output L1 WIDTH sharded memory config for wq_b (using padded n)
-        wq_b_out_memory_config = ttnn.create_sharded_memory_config(
-            [1, 1, ttnn.core.roundup(USERS_PER_ROW, tile_size), wq_b_n_padded],
-            core_grid=wq_b_out_core_grid,
-            strategy=ttnn.ShardStrategy.WIDTH,
-            orientation=ttnn.ShardOrientation.ROW_MAJOR,
-        )
+        # Output L1 WIDTH sharded memory config for wq_b (shard spec computed by the op)
+        wq_b_out_memory_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1)
 
         wq_b_config = LinearConfig(
             input_tensor_b=FromWeightConfig(mesh_device),
@@ -908,13 +898,8 @@ class MLA1D(AbstractModule):
             "orientation": ttnn.ShardOrientation.ROW_MAJOR,
         }
 
-        # Output L1 WIDTH sharded memory config for wo (using padded n)
-        wo_out_memory_config = ttnn.create_sharded_memory_config(
-            [1, 1, ttnn.core.roundup(USERS_PER_ROW, tile_size), wo_n_padded],
-            core_grid=wo_out_core_grid,
-            strategy=ttnn.ShardStrategy.WIDTH,
-            orientation=ttnn.ShardOrientation.ROW_MAJOR,
-        )
+        # Output L1 WIDTH sharded memory config for wo (shard spec computed by the op)
+        wo_out_memory_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1)
 
         wo_config = LinearConfig(
             input_tensor_b=FromWeightConfig(mesh_device),

--- a/models/demos/deepseek_v3/tt/mla/mla1d.py
+++ b/models/demos/deepseek_v3/tt/mla/mla1d.py
@@ -695,10 +695,7 @@ class MLA1D(AbstractModule):
         }
 
         # Output L1 WIDTH sharded memory config for qkv_a (shard spec computed by the op)
-        qkv_a_out_memory_config = ttnn.MemoryConfig(
-            memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
-            buffer_type=ttnn.BufferType.L1,
-        )
+        qkv_a_out_memory_config = ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG
 
         wq_kv_a_config = LinearConfig(
             input_tensor_b=FromWeightConfig(mesh_device),
@@ -740,10 +737,7 @@ class MLA1D(AbstractModule):
         }
 
         # Output L1 WIDTH sharded memory config for wq_b (shard spec computed by the op)
-        wq_b_out_memory_config = ttnn.MemoryConfig(
-            memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
-            buffer_type=ttnn.BufferType.L1,
-        )
+        wq_b_out_memory_config = ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG
 
         wq_b_config = LinearConfig(
             input_tensor_b=FromWeightConfig(mesh_device),
@@ -905,10 +899,7 @@ class MLA1D(AbstractModule):
         }
 
         # Output L1 WIDTH sharded memory config for wo (shard spec computed by the op)
-        wo_out_memory_config = ttnn.MemoryConfig(
-            memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
-            buffer_type=ttnn.BufferType.L1,
-        )
+        wo_out_memory_config = ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG
 
         wo_config = LinearConfig(
             input_tensor_b=FromWeightConfig(mesh_device),

--- a/models/demos/deepseek_v3/tt/mla/mla1d.py
+++ b/models/demos/deepseek_v3/tt/mla/mla1d.py
@@ -695,7 +695,10 @@ class MLA1D(AbstractModule):
         }
 
         # Output L1 WIDTH sharded memory config for qkv_a (shard spec computed by the op)
-        qkv_a_out_memory_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1)
+        qkv_a_out_memory_config = ttnn.MemoryConfig(
+            memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            buffer_type=ttnn.BufferType.L1,
+        )
 
         wq_kv_a_config = LinearConfig(
             input_tensor_b=FromWeightConfig(mesh_device),
@@ -737,7 +740,10 @@ class MLA1D(AbstractModule):
         }
 
         # Output L1 WIDTH sharded memory config for wq_b (shard spec computed by the op)
-        wq_b_out_memory_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1)
+        wq_b_out_memory_config = ttnn.MemoryConfig(
+            memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            buffer_type=ttnn.BufferType.L1,
+        )
 
         wq_b_config = LinearConfig(
             input_tensor_b=FromWeightConfig(mesh_device),
@@ -899,7 +905,10 @@ class MLA1D(AbstractModule):
         }
 
         # Output L1 WIDTH sharded memory config for wo (shard spec computed by the op)
-        wo_out_memory_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1)
+        wo_out_memory_config = ttnn.MemoryConfig(
+            memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            buffer_type=ttnn.BufferType.L1,
+        )
 
         wo_config = LinearConfig(
             input_tensor_b=FromWeightConfig(mesh_device),

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul_deepseek.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul_deepseek.py
@@ -350,7 +350,10 @@ def test_matmul_l1_dram_sharded(device, test_case, num_iters):
     )
 
     # Output: L1 width-sharded (shard spec computed by the op)
-    out_memory_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1)
+    out_memory_config = ttnn.MemoryConfig(
+        memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        buffer_type=ttnn.BufferType.L1,
+    )
 
     # Program config
     program_config = ttnn.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig(
@@ -382,6 +385,10 @@ def test_matmul_l1_dram_sharded(device, test_case, num_iters):
 
         if itr != num_iters - 1:
             output_t.deallocate()
+
+    # Validate output memory config
+    assert output_t.memory_config().memory_layout == ttnn.TensorMemoryLayout.WIDTH_SHARDED
+    assert output_t.memory_config().buffer_type == ttnn.BufferType.L1
 
     # Convert to torch and validate
     output_tensor = ttnn.to_torch(output_t)

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul_deepseek.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul_deepseek.py
@@ -349,13 +349,8 @@ def test_matmul_l1_dram_sharded(device, test_case, num_iters):
         memory_config=in1_memory_config,
     )
 
-    # Output: L1 width-sharded memory config using padded dimensions
-    out_memory_config = ttnn.create_sharded_memory_config(
-        [1, 1, m, n_padded],
-        core_grid=out_core_grid,
-        strategy=ttnn.ShardStrategy.WIDTH,
-        orientation=ttnn.ShardOrientation.ROW_MAJOR,
-    )
+    # Output: L1 width-sharded (shard spec computed by the op)
+    out_memory_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1)
 
     # Program config
     program_config = ttnn.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig(

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul_deepseek.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul_deepseek.py
@@ -350,10 +350,7 @@ def test_matmul_l1_dram_sharded(device, test_case, num_iters):
     )
 
     # Output: L1 width-sharded (shard spec computed by the op)
-    out_memory_config = ttnn.MemoryConfig(
-        memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
-        buffer_type=ttnn.BufferType.L1,
-    )
+    out_memory_config = ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG
 
     # Program config
     program_config = ttnn.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig(


### PR DESCRIPTION
### Problem description
MLA decode matmuls specified the output memory config sharding for all five matmuls. For three of these matmuls, the op will also autocalculate its own idea for the output shard spec and give a warning when it differed from the user specified one. This will usually differ from user grids because the op likes to fill out the grid row major (e.g. 8 + 1 = 9) while it's easier for user grids to just be rectangular (e.g. 3 * 3 = 9). 

As the same matmuls run 61 times across different layers, the same warning would be issued many times and there was a concern that these warnings would slow down the program.

### What's changed
For the three unbatched matmuls, just remove the output memory shard spec from the Python. The computed ones look correct, and where they differed significantly the op was already using its own instead of the user one (so minimal change is expected)

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=edwinlee/mla_auto_out_mem_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:edwinlee/mla_auto_out_mem_config)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
