### PR TITLE
Fix Mochi T3K DRAM OOM by passing reload_dit_model in test

### DIFF
--- a/models/tt_dit/tests/models/mochi/test_pipeline_mochi.py
+++ b/models/tt_dit/tests/models/mochi/test_pipeline_mochi.py
@@ -182,6 +182,7 @@ def test_tt_mochi_pipeline(
         num_links=num_links,
         use_reference_vae=False,
         model_name="genmo/mochi-1-preview",
+        reload_dit_model=mesh_device.get_num_devices() <= 8,
     )
 
     # Define test prompt (same as the diffusers test)


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/39222 - Direct fix for failing CI

### Problem description
The `t3k_mochi_tests` job has been consistently failing with a DRAM OOM since ~Feb 26:
https://github.com/tenstorrent/tt-metal/actions/runs/22649190849

The test `test_tt_mochi_pipeline[wormhole_b0-device_params0-dit_2x4sp0tp1_vae_1x8sp0tp1]` runs two phases on device:

1. **Denoising loop** (50 steps) — runs the Mochi transformer, loading ~710 MB of weights per DRAM bank
2. **VAE decode** — needs to allocate a ~174 MB contiguous block per DRAM bank

**Root cause:**

The test constructs `MochiPipeline` directly without passing `reload_dit_model=True`. Without this flag, the transformer weights stay in DRAM during VAE decode. Each DRAM bank is ~1 GB, and with ~710 MB occupied by the transformer, the largest contiguous free block is only ~146 MB — not enough for the VAE's ~174 MB allocation.

The `create_pipeline()` static method already sets `reload_dit_model=True` for the (2,4) T3K config, but the test wasn't using that helper.

### What's changed
**models/tt_dit/tests/models/mochi/test_pipeline_mochi.py:**

- Pass `reload_dit_model=mesh_device.get_num_devices() <= 8` to explicitly free transformer weights before VAE decode on T3K-sized meshes (≤ 8 devices), matching the behavior already defined in `create_pipeline()`

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:{{branch_name}})
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs