### PR TITLE
Esmal/weight cleanup

### DIFF
--- a/models/demos/deepseek_v3_b1/demo/cli.py
+++ b/models/demos/deepseek_v3_b1/demo/cli.py
@@ -95,7 +95,9 @@ def _fabric_config_for_num_procs(num_procs: int):
         return ttnn.FabricConfig.FABRIC_2D
     if num_procs == 16:
         return ttnn.FabricConfig.FABRIC_2D_TORUS_Y
-    raise ValueError(f"Unsupported num_procs for fabric config: {num_procs} (expected 4 or 16)")
+    if num_procs == 64:
+        return ttnn.FabricConfig.FABRIC_2D_TORUS_Y
+    raise ValueError(f"Unsupported num_procs for fabric config: {num_procs} (expected 4, 16, or 64)")
 
 
 @contextlib.contextmanager
@@ -280,7 +282,7 @@ def run_demo(
 
     with open_mesh_device() as mesh_device:
         num_procs = int(ttnn.distributed_context_get_size())
-        if num_procs not in (4, 16):
+        if num_procs not in (4, 16, 64):
             raise RuntimeError(f"Pod pipeline requires 4 or 16 distributed processes; got {num_procs}")
         ttnn.enable_asynchronous_slow_dispatch(mesh_device)
 

--- a/models/demos/deepseek_v3_b1/demo/cli.py
+++ b/models/demos/deepseek_v3_b1/demo/cli.py
@@ -19,101 +19,17 @@ import ttnn
 from conftest import bh_2d_mesh_device_context
 from models.common.utility_functions import is_slow_dispatch
 from models.demos.deepseek_v3_b1.demo.pipeline import (
-    WeightProvider,
     create_fabric_router_config,
     create_pipeline_configuration_from_num_procs,
 )
-from models.demos.deepseek_v3_b1.model import TOKEN_ID_BYTES, DeepSeekV3, page_size_bytes, to_padded_input
-from models.demos.deepseek_v3_b1.prepare_weights import (
-    NUM_ROUTED_EXPERTS,
-    DeepSeekV3DenseLayerWeights,
-    DeepSeekV3EmbeddingLayerWeights,
-    DeepSeekV3LMHeadWeights,
-    DeepSeekV3MoELayerWeights,
-    load_dense_decoder_layer,
-    load_embedding_weights,
-    load_lm_head_weights,
-    load_moe_decoder_layer,
-    load_moe_routed_experts,
-    prepare_dense_layer_weights,
-    prepare_embedding_weights,
-    prepare_lm_head_weights,
-    prepare_moe_layer_weights,
+from models.demos.deepseek_v3_b1.demo.weight_provider import (
+    CacheWeightProvider,
+    SyntheticWeightProvider,
+    WeightProvider,
 )
+from models.demos.deepseek_v3_b1.model import TOKEN_ID_BYTES, DeepSeekV3, page_size_bytes, to_padded_input
 
 DEFAULT_TOKENIZER = "deepseek-ai/DeepSeek-V3"
-FIRST_K_DENSE_REPLACE = 3
-
-
-def _layer_key(layer_id: int, suffix: str) -> str:
-    """State dict key under model.layers.{layer_id}."""
-    return f"model.layers.{layer_id}.{suffix}"
-
-
-def _build_synthetic_moe_state_dict(
-    layer_id: int,
-    *,
-    num_routed_experts: int = NUM_ROUTED_EXPERTS,
-) -> dict[str, torch.Tensor]:
-    """Build a synthetic MoE layer state dict with HF tensor shapes (randn for weights, ones for norms)."""
-    state_dict: dict[str, torch.Tensor] = {}
-    dtype = torch.bfloat16
-
-    # Attention weights (HF shapes)
-    state_dict[_layer_key(layer_id, "self_attn.q_a_proj.weight")] = torch.randn(1536, 7168, dtype=dtype)
-    state_dict[_layer_key(layer_id, "self_attn.q_b_proj.weight")] = torch.randn(24576, 1536, dtype=dtype)
-    state_dict[_layer_key(layer_id, "self_attn.kv_a_proj_with_mqa.weight")] = torch.randn(576, 7168, dtype=dtype)
-    state_dict[_layer_key(layer_id, "self_attn.kv_b_proj.weight")] = torch.randn(32768, 512, dtype=dtype)
-    state_dict[_layer_key(layer_id, "self_attn.o_proj.weight")] = torch.randn(7168, 16384, dtype=dtype)
-
-    # Norms (ones per plan)
-    state_dict[_layer_key(layer_id, "input_layernorm.weight")] = torch.ones(7168, dtype=dtype)
-    state_dict[_layer_key(layer_id, "self_attn.q_a_layernorm.weight")] = torch.ones(1536, dtype=dtype)
-    state_dict[_layer_key(layer_id, "self_attn.kv_a_layernorm.weight")] = torch.ones(512, dtype=dtype)
-    state_dict[_layer_key(layer_id, "post_attention_layernorm.weight")] = torch.ones(7168, dtype=dtype)
-
-    # MoE gate
-    state_dict[_layer_key(layer_id, "mlp.gate.weight")] = torch.randn(256, 7168, dtype=dtype)
-    state_dict[_layer_key(layer_id, "mlp.gate.e_score_correction_bias")] = torch.randn(256, dtype=dtype)
-
-    # Shared experts
-    state_dict[_layer_key(layer_id, "mlp.shared_experts.gate_proj.weight")] = torch.randn(2048, 7168, dtype=dtype)
-    state_dict[_layer_key(layer_id, "mlp.shared_experts.up_proj.weight")] = torch.randn(2048, 7168, dtype=dtype)
-    state_dict[_layer_key(layer_id, "mlp.shared_experts.down_proj.weight")] = torch.randn(7168, 2048, dtype=dtype)
-
-    # Routed experts
-    for e in range(num_routed_experts):
-        state_dict[_layer_key(layer_id, f"mlp.experts.{e}.gate_proj.weight")] = torch.randn(2048, 7168, dtype=dtype)
-        state_dict[_layer_key(layer_id, f"mlp.experts.{e}.up_proj.weight")] = torch.randn(2048, 7168, dtype=dtype)
-        state_dict[_layer_key(layer_id, f"mlp.experts.{e}.down_proj.weight")] = torch.randn(7168, 2048, dtype=dtype)
-
-    return state_dict
-
-
-def _build_synthetic_dense_state_dict(layer_id: int) -> dict[str, torch.Tensor]:
-    """Build a synthetic dense layer state dict with HF tensor shapes (randn for weights, ones for norms)."""
-    state_dict: dict[str, torch.Tensor] = {}
-    dtype = torch.bfloat16
-
-    # Attention weights (HF shapes)
-    state_dict[_layer_key(layer_id, "self_attn.q_a_proj.weight")] = torch.randn(1536, 7168, dtype=dtype)
-    state_dict[_layer_key(layer_id, "self_attn.q_b_proj.weight")] = torch.randn(24576, 1536, dtype=dtype)
-    state_dict[_layer_key(layer_id, "self_attn.kv_a_proj_with_mqa.weight")] = torch.randn(576, 7168, dtype=dtype)
-    state_dict[_layer_key(layer_id, "self_attn.kv_b_proj.weight")] = torch.randn(32768, 512, dtype=dtype)
-    state_dict[_layer_key(layer_id, "self_attn.o_proj.weight")] = torch.randn(7168, 16384, dtype=dtype)
-
-    # Norms (ones per plan)
-    state_dict[_layer_key(layer_id, "input_layernorm.weight")] = torch.ones(7168, dtype=dtype)
-    state_dict[_layer_key(layer_id, "self_attn.q_a_layernorm.weight")] = torch.ones(1536, dtype=dtype)
-    state_dict[_layer_key(layer_id, "self_attn.kv_a_layernorm.weight")] = torch.ones(512, dtype=dtype)
-    state_dict[_layer_key(layer_id, "post_attention_layernorm.weight")] = torch.ones(7168, dtype=dtype)
-
-    # Single MLP (used for both shared and routed in dense)
-    state_dict[_layer_key(layer_id, "mlp.gate_proj.weight")] = torch.randn(2048, 7168, dtype=dtype)
-    state_dict[_layer_key(layer_id, "mlp.up_proj.weight")] = torch.randn(2048, 7168, dtype=dtype)
-    state_dict[_layer_key(layer_id, "mlp.down_proj.weight")] = torch.randn(7168, 2048, dtype=dtype)
-
-    return state_dict
 
 
 def _fabric_config_for_num_procs(num_procs: int):
@@ -146,106 +62,6 @@ def open_mesh_device():
             mesh_device.shape,
         )
         yield mesh_device
-
-
-def decoder_layer_id_from_mesh_id(mesh_id: int) -> int:
-    """
-    Layer ID is the index of the layer in the original model (i.e. layer 0-3 are dense layers, layer 4-60 are MoE layers)
-    The mesh ID is the pipeline stage index (0 is embedding, 1-3 are dense layers, 4-61 are MoE, and 62 is LM head + sampling)
-    """
-    assert mesh_id > 0 and mesh_id <= 61, f"Cannot get layer ID from mesh ID: {mesh_id}"
-    return mesh_id - 1
-
-
-SYSTEM_MESH_ID_EMBEDDING = 0
-SYSTEM_MESH_ID_LM_HEAD = 62
-
-
-class CacheWeightProvider:
-    """Load embedding and LM head weights from cache; each host loads only what its stage needs."""
-
-    def __init__(self, cache_path: Path) -> None:
-        assert cache_path.exists(), f"Cache path does not exist: {cache_path}"
-        assert cache_path.is_dir(), f"Cache path is not a directory: {cache_path}"
-        self._path = cache_path
-
-    def load_embedding(self, device: ttnn.MeshDevice) -> DeepSeekV3EmbeddingLayerWeights:
-        return load_embedding_weights(self._path, device)
-
-    def load_lm_head(self, device: ttnn.MeshDevice) -> DeepSeekV3LMHeadWeights:
-        return load_lm_head_weights(self._path, device)
-
-    def load_moe_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3MoELayerWeights:
-        with ttnn.device.setup_fast_dispatch(device):
-            preloaded_experts = load_moe_routed_experts(self._path, device, layer_id)
-        return load_moe_decoder_layer(self._path, device, layer_id, preloaded_routed_experts=preloaded_experts)
-
-    def load_dense_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3DenseLayerWeights:
-        return load_dense_decoder_layer(self._path, device, layer_id)
-
-
-class SyntheticWeightProvider:
-    """Create deterministic synthetic embedding and LM head weights in place (no cache)."""
-
-    def load_embedding(self, device: ttnn.MeshDevice) -> DeepSeekV3EmbeddingLayerWeights:
-        emb_w = torch.zeros((129280, 7168), dtype=torch.bfloat16)
-        emb_w[torch.arange(129280), torch.arange(129280, dtype=torch.int64) % 7168] = 1
-        return prepare_embedding_weights({"model.embed_tokens.weight": emb_w}, device, move_to_device=True)
-
-    def load_lm_head(self, device: ttnn.MeshDevice) -> DeepSeekV3LMHeadWeights:
-        lm_w = torch.full((129280, 7168), -1.0, dtype=torch.bfloat16)
-        lm_w[torch.arange(7168, dtype=torch.int64) % 16160, torch.arange(7168)] = 1
-        return prepare_lm_head_weights(
-            {
-                "lm_head.weight": lm_w,
-                "model.norm.weight": torch.ones(7168, dtype=torch.bfloat16),
-            },
-            device,
-            move_to_device=True,
-        )
-
-    def load_moe_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3MoELayerWeights:
-        from models.demos.deepseek_v3_b1.blitz_decode_weights import BlitzDecodeWeights
-
-        sd = _build_synthetic_moe_state_dict(layer_id, num_routed_experts=NUM_ROUTED_EXPERTS)
-        bdw = BlitzDecodeWeights(device)
-        return prepare_moe_layer_weights(bdw, sd, layer_id, num_routed_experts=NUM_ROUTED_EXPERTS)
-
-    def load_dense_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3DenseLayerWeights:
-        from models.demos.deepseek_v3_b1.blitz_decode_weights import BlitzDecodeWeights
-
-        sd = _build_synthetic_dense_state_dict(layer_id)
-        bdw = BlitzDecodeWeights(device)
-        return prepare_dense_layer_weights(bdw, sd, layer_id, move_to_device=True)
-
-
-def load_weights_from_cache(
-    cache_path: Path,
-    mesh_device: ttnn.MeshDevice,
-    layer_offset: int,
-) -> (
-    DeepSeekV3EmbeddingLayerWeights | DeepSeekV3DenseLayerWeights | DeepSeekV3MoELayerWeights | DeepSeekV3LMHeadWeights
-):
-    """Load weights from cache (embedding, decoder layer, or lm_head)."""
-    mesh_id = mesh_device.get_system_mesh_id() + layer_offset
-    assert (
-        mesh_id >= SYSTEM_MESH_ID_EMBEDDING and mesh_id <= SYSTEM_MESH_ID_LM_HEAD
-    ), f"Mesh ID must be between {SYSTEM_MESH_ID_EMBEDDING} and {SYSTEM_MESH_ID_LM_HEAD} but got {mesh_id}"
-    if mesh_id == SYSTEM_MESH_ID_EMBEDDING:
-        logger.info("Loading embedding weights from cache")
-        return load_embedding_weights(cache_path, mesh_device)
-    elif mesh_id == SYSTEM_MESH_ID_LM_HEAD:
-        logger.info("Loading LM head weights from cache")
-        return load_lm_head_weights(cache_path, mesh_device)
-    else:
-        layer_id = decoder_layer_id_from_mesh_id(mesh_id)
-        is_moe = layer_id >= FIRST_K_DENSE_REPLACE
-        logger.info(f"Loading {'moe' if is_moe else 'dense'} layer weights from cache")
-        if is_moe:
-            with ttnn.device.setup_fast_dispatch(mesh_device):
-                preloaded_experts = load_moe_routed_experts(cache_path, mesh_device, layer_id)
-            return load_moe_decoder_layer(cache_path, mesh_device, layer_id, preloaded_routed_experts=preloaded_experts)
-        return load_dense_decoder_layer(cache_path, mesh_device, layer_id)
 
 
 def create_parser() -> argparse.ArgumentParser:

--- a/models/demos/deepseek_v3_b1/demo/cli.py
+++ b/models/demos/deepseek_v3_b1/demo/cli.py
@@ -23,7 +23,7 @@ from models.demos.deepseek_v3_b1.demo.pipeline import (
     create_fabric_router_config,
     create_pipeline_configuration_from_num_procs,
 )
-from models.demos.deepseek_v3_b1.demo.stage import token_page_size_bytes
+from models.demos.deepseek_v3_b1.demo.stage import TOKEN_PAGE_SIZE_BYTES
 from models.demos.deepseek_v3_b1.prepare_weights import (
     NUM_ROUTED_EXPERTS,
     DeepSeekV3DenseLayerWeights,
@@ -35,6 +35,7 @@ from models.demos.deepseek_v3_b1.prepare_weights import (
     load_lm_head_weights,
     load_moe_decoder_layer,
     load_moe_routed_experts,
+    prepare_dense_layer_weights,
     prepare_embedding_weights,
     prepare_lm_head_weights,
     prepare_moe_layer_weights,
@@ -89,6 +90,32 @@ def _build_synthetic_moe_state_dict(
     return state_dict
 
 
+def _build_synthetic_dense_state_dict(layer_id: int) -> dict[str, torch.Tensor]:
+    """Build a synthetic dense layer state dict with HF tensor shapes (randn for weights, ones for norms)."""
+    state_dict: dict[str, torch.Tensor] = {}
+    dtype = torch.bfloat16
+
+    # Attention weights (HF shapes)
+    state_dict[_layer_key(layer_id, "self_attn.q_a_proj.weight")] = torch.randn(1536, 7168, dtype=dtype)
+    state_dict[_layer_key(layer_id, "self_attn.q_b_proj.weight")] = torch.randn(24576, 1536, dtype=dtype)
+    state_dict[_layer_key(layer_id, "self_attn.kv_a_proj_with_mqa.weight")] = torch.randn(576, 7168, dtype=dtype)
+    state_dict[_layer_key(layer_id, "self_attn.kv_b_proj.weight")] = torch.randn(32768, 512, dtype=dtype)
+    state_dict[_layer_key(layer_id, "self_attn.o_proj.weight")] = torch.randn(7168, 16384, dtype=dtype)
+
+    # Norms (ones per plan)
+    state_dict[_layer_key(layer_id, "input_layernorm.weight")] = torch.ones(7168, dtype=dtype)
+    state_dict[_layer_key(layer_id, "self_attn.q_a_layernorm.weight")] = torch.ones(1536, dtype=dtype)
+    state_dict[_layer_key(layer_id, "self_attn.kv_a_layernorm.weight")] = torch.ones(512, dtype=dtype)
+    state_dict[_layer_key(layer_id, "post_attention_layernorm.weight")] = torch.ones(7168, dtype=dtype)
+
+    # Single MLP (used for both shared and routed in dense)
+    state_dict[_layer_key(layer_id, "mlp.gate_proj.weight")] = torch.randn(2048, 7168, dtype=dtype)
+    state_dict[_layer_key(layer_id, "mlp.up_proj.weight")] = torch.randn(2048, 7168, dtype=dtype)
+    state_dict[_layer_key(layer_id, "mlp.down_proj.weight")] = torch.randn(7168, 2048, dtype=dtype)
+
+    return state_dict
+
+
 def _fabric_config_for_num_procs(num_procs: int):
     """Infer fabric config from process count: 4 → FABRIC_2D, 16 → FABRIC_2D_TORUS_Y."""
     if num_procs == 4:
@@ -138,6 +165,8 @@ class CacheWeightProvider:
     """Load embedding and LM head weights from cache; each host loads only what its stage needs."""
 
     def __init__(self, cache_path: Path) -> None:
+        assert cache_path.exists(), f"Cache path does not exist: {cache_path}"
+        assert cache_path.is_dir(), f"Cache path is not a directory: {cache_path}"
         self._path = cache_path
 
     def load_embedding(self, device: ttnn.MeshDevice) -> DeepSeekV3EmbeddingLayerWeights:
@@ -150,6 +179,9 @@ class CacheWeightProvider:
         with ttnn.device.setup_fast_dispatch(device):
             preloaded_experts = load_moe_routed_experts(self._path, device, layer_id)
         return load_moe_decoder_layer(self._path, device, layer_id, preloaded_routed_experts=preloaded_experts)
+
+    def load_dense_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3DenseLayerWeights:
+        return load_dense_decoder_layer(self._path, device, layer_id)
 
 
 class SyntheticWeightProvider:
@@ -178,6 +210,13 @@ class SyntheticWeightProvider:
         sd = _build_synthetic_moe_state_dict(layer_id, num_routed_experts=NUM_ROUTED_EXPERTS)
         bdw = BlitzDecodeWeights(device)
         return prepare_moe_layer_weights(bdw, sd, layer_id, num_routed_experts=NUM_ROUTED_EXPERTS)
+
+    def load_dense_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3DenseLayerWeights:
+        from models.demos.deepseek_v3_b1.blitz_decode_weights import BlitzDecodeWeights
+
+        sd = _build_synthetic_dense_state_dict(layer_id)
+        bdw = BlitzDecodeWeights(device)
+        return prepare_dense_layer_weights(bdw, sd, layer_id, move_to_device=True)
 
 
 def load_weights_from_cache(
@@ -304,11 +343,11 @@ def run_demo(
         if pipeline.my_mesh_id == 0:
             for iteration in range(iterations):
                 logger.info(f"Writing token for iteration {iteration}")
-                torch_token = torch.zeros(1, token_page_size_bytes // 4, dtype=torch.uint32)
+                torch_token = torch.zeros(1, TOKEN_PAGE_SIZE_BYTES // 4, dtype=torch.uint32)
                 torch_token[0, 0] = iteration
                 token_tensor = ttnn.from_torch(torch_token, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
                 output_tensor = ttnn.from_torch(
-                    torch.zeros(1, token_page_size_bytes // 4, dtype=torch.uint32),
+                    torch.zeros(1, TOKEN_PAGE_SIZE_BYTES // 4, dtype=torch.uint32),
                     dtype=ttnn.uint32,
                     layout=ttnn.ROW_MAJOR_LAYOUT,
                 )

--- a/models/demos/deepseek_v3_b1/demo/cli.py
+++ b/models/demos/deepseek_v3_b1/demo/cli.py
@@ -250,7 +250,7 @@ def load_weights_from_cache(
 
 def create_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser("DeepSeek-V3-B1 Demo on TT-NN (pod pipeline)")
-    parser.add_argument("--prompt", type=str, default="", help="Prompt text (for future real decode loop)")
+    parser.add_argument("--prompt", type=str, default="Hello, world!", help="Prompt text (for future real decode loop)")
     parser.add_argument(
         "--max-new-tokens",
         type=int,
@@ -352,6 +352,9 @@ def run_demo(
             dense_layer_id_override=dense_layer_id_override,
             moe_layer_id_override=moe_layer_id_override,
         )
+        assert (
+            config.num_stages == num_procs
+        ), f"Pipeline configuration has {config.num_stages} stages but {num_procs} processes"
 
         logger.info(f"Building pipeline")
         pipeline = config.build_pipeline(mesh_device)
@@ -363,6 +366,7 @@ def run_demo(
             # Prefill + decode pattern per model.py: prefill(prompt) -> sample y0; decode_step(y_t) -> sample y_{t+1}.
             tokenizer = load_tokenizer(tokenizer_name_or_path)
             prompt_ids = tokenizer.encode(prompt, add_special_tokens=True)
+            logger.debug(f"Encoded prompt: {prompt_ids}")
             if not prompt_ids:
                 prompt_ids = [tokenizer.bos_token_id if tokenizer.bos_token_id is not None else 0]
             page_size_datums = page_size_bytes(1) // TOKEN_ID_BYTES
@@ -380,6 +384,7 @@ def run_demo(
                 batch_size=1,
             )
             # Prefill: send prompt tokens; discard outputs for i < S-1; use last output to sample y0.
+            logger.debug(f"Prefilling...")
             last_output = model.prefill(prompt_token_tensors)
             next_token_id = int(ttnn.to_torch(last_output).to(torch.int32)[0, 0].item())
             generated = [next_token_id]

--- a/models/demos/deepseek_v3_b1/demo/cli.py
+++ b/models/demos/deepseek_v3_b1/demo/cli.py
@@ -25,6 +25,7 @@ from models.demos.deepseek_v3_b1.demo.pipeline import (
 )
 from models.demos.deepseek_v3_b1.demo.stage import token_page_size_bytes
 from models.demos.deepseek_v3_b1.prepare_weights import (
+    NUM_ROUTED_EXPERTS,
     DeepSeekV3DenseLayerWeights,
     DeepSeekV3EmbeddingLayerWeights,
     DeepSeekV3LMHeadWeights,
@@ -36,10 +37,56 @@ from models.demos.deepseek_v3_b1.prepare_weights import (
     load_moe_routed_experts,
     prepare_embedding_weights,
     prepare_lm_head_weights,
+    prepare_moe_layer_weights,
 )
 
 DEFAULT_TOKENIZER = "deepseek-ai/DeepSeek-V3"
 FIRST_K_DENSE_REPLACE = 3
+
+
+def _layer_key(layer_id: int, suffix: str) -> str:
+    """State dict key under model.layers.{layer_id}."""
+    return f"model.layers.{layer_id}.{suffix}"
+
+
+def _build_synthetic_moe_state_dict(
+    layer_id: int,
+    *,
+    num_routed_experts: int = NUM_ROUTED_EXPERTS,
+) -> dict[str, torch.Tensor]:
+    """Build a synthetic MoE layer state dict with HF tensor shapes (randn for weights, ones for norms)."""
+    state_dict: dict[str, torch.Tensor] = {}
+    dtype = torch.bfloat16
+
+    # Attention weights (HF shapes)
+    state_dict[_layer_key(layer_id, "self_attn.q_a_proj.weight")] = torch.randn(1536, 7168, dtype=dtype)
+    state_dict[_layer_key(layer_id, "self_attn.q_b_proj.weight")] = torch.randn(24576, 1536, dtype=dtype)
+    state_dict[_layer_key(layer_id, "self_attn.kv_a_proj_with_mqa.weight")] = torch.randn(576, 7168, dtype=dtype)
+    state_dict[_layer_key(layer_id, "self_attn.kv_b_proj.weight")] = torch.randn(32768, 512, dtype=dtype)
+    state_dict[_layer_key(layer_id, "self_attn.o_proj.weight")] = torch.randn(7168, 16384, dtype=dtype)
+
+    # Norms (ones per plan)
+    state_dict[_layer_key(layer_id, "input_layernorm.weight")] = torch.ones(7168, dtype=dtype)
+    state_dict[_layer_key(layer_id, "self_attn.q_a_layernorm.weight")] = torch.ones(1536, dtype=dtype)
+    state_dict[_layer_key(layer_id, "self_attn.kv_a_layernorm.weight")] = torch.ones(512, dtype=dtype)
+    state_dict[_layer_key(layer_id, "post_attention_layernorm.weight")] = torch.ones(7168, dtype=dtype)
+
+    # MoE gate
+    state_dict[_layer_key(layer_id, "mlp.gate.weight")] = torch.randn(256, 7168, dtype=dtype)
+    state_dict[_layer_key(layer_id, "mlp.gate.e_score_correction_bias")] = torch.randn(256, dtype=dtype)
+
+    # Shared experts
+    state_dict[_layer_key(layer_id, "mlp.shared_experts.gate_proj.weight")] = torch.randn(2048, 7168, dtype=dtype)
+    state_dict[_layer_key(layer_id, "mlp.shared_experts.up_proj.weight")] = torch.randn(2048, 7168, dtype=dtype)
+    state_dict[_layer_key(layer_id, "mlp.shared_experts.down_proj.weight")] = torch.randn(7168, 2048, dtype=dtype)
+
+    # Routed experts
+    for e in range(num_routed_experts):
+        state_dict[_layer_key(layer_id, f"mlp.experts.{e}.gate_proj.weight")] = torch.randn(2048, 7168, dtype=dtype)
+        state_dict[_layer_key(layer_id, f"mlp.experts.{e}.up_proj.weight")] = torch.randn(2048, 7168, dtype=dtype)
+        state_dict[_layer_key(layer_id, f"mlp.experts.{e}.down_proj.weight")] = torch.randn(7168, 2048, dtype=dtype)
+
+    return state_dict
 
 
 def _fabric_config_for_num_procs(num_procs: int):
@@ -97,6 +144,11 @@ class CacheWeightProvider:
     def load_lm_head(self, device: ttnn.MeshDevice) -> DeepSeekV3LMHeadWeights:
         return load_lm_head_weights(self._path, device)
 
+    def load_moe_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3MoELayerWeights:
+        with ttnn.device.setup_fast_dispatch(device):
+            preloaded_experts = load_moe_routed_experts(self._path, device, layer_id)
+        return load_moe_decoder_layer(self._path, device, layer_id, preloaded_routed_experts=preloaded_experts)
+
 
 class SyntheticWeightProvider:
     """Create deterministic synthetic embedding and LM head weights in place (no cache)."""
@@ -117,6 +169,13 @@ class SyntheticWeightProvider:
             device,
             move_to_device=True,
         )
+
+    def load_moe_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3MoELayerWeights:
+        from models.demos.deepseek_v3_b1.blitz_decode_weights import BlitzDecodeWeights
+
+        sd = _build_synthetic_moe_state_dict(layer_id, num_routed_experts=NUM_ROUTED_EXPERTS)
+        bdw = BlitzDecodeWeights(device)
+        return prepare_moe_layer_weights(bdw, sd, layer_id, num_routed_experts=NUM_ROUTED_EXPERTS)
 
 
 def load_weights_from_cache(

--- a/models/demos/deepseek_v3_b1/demo/cli.py
+++ b/models/demos/deepseek_v3_b1/demo/cli.py
@@ -23,7 +23,7 @@ from models.demos.deepseek_v3_b1.demo.pipeline import (
     create_fabric_router_config,
     create_pipeline_configuration_from_num_procs,
 )
-from models.demos.deepseek_v3_b1.demo.stage import TOKEN_PAGE_SIZE_BYTES
+from models.demos.deepseek_v3_b1.model import TOKEN_ID_BYTES, DeepSeekV3, page_size_bytes, to_padded_input
 from models.demos.deepseek_v3_b1.prepare_weights import (
     NUM_ROUTED_EXPERTS,
     DeepSeekV3DenseLayerWeights,
@@ -267,13 +267,14 @@ def create_parser() -> argparse.ArgumentParser:
         "--cache-path",
         type=Path,
         required=True,
-        help="Path to the weight cache directory (for future real weights)",
+        help="Path to the weight cache directory (required for --weights real)",
     )
     parser.add_argument(
-        "--layer-id-offset",
-        type=int,
-        default=0,
-        help="Layer ID offset (for future multi-pod offset)",
+        "--weights",
+        type=str,
+        choices=("synthetic", "real"),
+        default="synthetic",
+        help="Use synthetic or real (cached) weights (default: synthetic)",
     )
     parser.add_argument(
         "--fp32",
@@ -286,6 +287,20 @@ def create_parser() -> argparse.ArgumentParser:
         action=argparse.BooleanOptionalAction,
         default=True,
         help="Use persistent mode for LMHead sampling kernel",
+    )
+    parser.add_argument(
+        "--dense-layer-id-override",
+        type=int,
+        default=None,
+        metavar="ID",
+        help="Force all dense stages to use this layer id (e.g. 0); default: use 0,1,2",
+    )
+    parser.add_argument(
+        "--moe-layer-id-override",
+        type=int,
+        default=None,
+        metavar="ID",
+        help="Force all MoE stages to use this layer id (e.g. 3); default: use stage-dependent layer ids",
     )
     return parser
 
@@ -300,19 +315,21 @@ def run_demo(
     max_new_tokens: int,
     tokenizer_name_or_path: str,
     cache_path: Path,
-    layer_id_offset: int = 0,
-    fp32: bool = True,
-    persistent_mode: bool = True,
+    use_real_weights: bool = False,
+    lm_head_fp32_dest_acc_en: bool = True,
+    lm_head_persistent_mode: bool = True,
+    dense_layer_id_override: int | None = None,
+    moe_layer_id_override: int | None = None,
     output_stream: TextIO,
 ) -> None:
-    """Run the pod pipeline (synthetic weights). Requires 4 or 16 distributed processes."""
+    """Run the pod pipeline. Requires 4 or 16 distributed processes."""
     iterations = max_new_tokens
     logger.info(
-        "Starting DeepSeek V3 B1 demo pod pipeline (iterations={}, layer_id_offset={}, fp32={}, persistent_mode={})",
+        "Starting DeepSeek V3 B1 demo pod pipeline (iterations={}, weights={}, lm_head_fp32={}, lm_head_persistent_mode={})",
         iterations,
-        layer_id_offset,
-        fp32,
-        persistent_mode,
+        "real" if use_real_weights else "synthetic",
+        lm_head_fp32_dest_acc_en,
+        lm_head_persistent_mode,
     )
     if not is_slow_dispatch():
         raise RuntimeError(
@@ -326,12 +343,14 @@ def run_demo(
         ttnn.enable_asynchronous_slow_dispatch(mesh_device)
 
         # Each host loads/creates only the weights for its stage via the provider.
-        provider: WeightProvider = SyntheticWeightProvider()
+        provider: WeightProvider = CacheWeightProvider(cache_path) if use_real_weights else SyntheticWeightProvider()
         config = create_pipeline_configuration_from_num_procs(
             num_procs,
             provider,
-            fp32_dest_acc_en=fp32,
-            persistent_mode=persistent_mode,
+            lm_head_fp32_dest_acc_en=lm_head_fp32_dest_acc_en,
+            lm_head_persistent_mode=lm_head_persistent_mode,
+            dense_layer_id_override=dense_layer_id_override,
+            moe_layer_id_override=moe_layer_id_override,
         )
 
         logger.info(f"Building pipeline")
@@ -341,20 +360,43 @@ def run_demo(
         pipeline.setup_and_run()
 
         if pipeline.my_mesh_id == 0:
-            for iteration in range(iterations):
-                logger.info(f"Writing token for iteration {iteration}")
-                torch_token = torch.zeros(1, TOKEN_PAGE_SIZE_BYTES // 4, dtype=torch.uint32)
-                torch_token[0, 0] = iteration
-                token_tensor = ttnn.from_torch(torch_token, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
-                output_tensor = ttnn.from_torch(
-                    torch.zeros(1, TOKEN_PAGE_SIZE_BYTES // 4, dtype=torch.uint32),
-                    dtype=ttnn.uint32,
-                    layout=ttnn.ROW_MAJOR_LAYOUT,
+            # Prefill + decode pattern per model.py: prefill(prompt) -> sample y0; decode_step(y_t) -> sample y_{t+1}.
+            tokenizer = load_tokenizer(tokenizer_name_or_path)
+            prompt_ids = tokenizer.encode(prompt, add_special_tokens=True)
+            if not prompt_ids:
+                prompt_ids = [tokenizer.bos_token_id if tokenizer.bos_token_id is not None else 0]
+            page_size_datums = page_size_bytes(1) // TOKEN_ID_BYTES
+            prompt_token_tensors = [
+                to_padded_input(
+                    torch.tensor([[tid]], dtype=torch.int32),
+                    batch_size=1,
+                    page_size_datums=page_size_datums,
                 )
-                pipeline.write_token(token_tensor)
-                pipeline.read_output(output_tensor)
-                got = ttnn.to_torch(output_tensor).to(torch.uint32)[0, 0].reshape(1, 1)
-                logger.info("Iteration {} output token: {}", iteration, got.item())
+                for tid in prompt_ids
+            ]
+            model = DeepSeekV3(
+                write_fn=pipeline.write_token,
+                read_fn=pipeline.read_output,
+                batch_size=1,
+            )
+            # Prefill: send prompt tokens; discard outputs for i < S-1; use last output to sample y0.
+            last_output = model.prefill(prompt_token_tensors)
+            next_token_id = int(ttnn.to_torch(last_output).to(torch.int32)[0, 0].item())
+            generated = [next_token_id]
+            logger.info(
+                "Prefill done ({} prompt tokens); sampled y0: {}",
+                len(prompt_ids),
+                next_token_id,
+            )
+            # Generation loop: feed y[t], get output, sample y[t+1].
+            for step in range(iterations - 1):
+                output = model.decode_step(
+                    torch.tensor([[next_token_id]], dtype=torch.int32),
+                )
+                next_token_id = int(ttnn.to_torch(output).to(torch.int32)[0, 0].item())
+                generated.append(next_token_id)
+                logger.info("Decode step {} output token: {}", step + 1, next_token_id)
+            logger.info("Generated {} tokens total", len(generated))
 
         pipeline.barrier()
     logger.info("Pod pipeline complete")
@@ -370,9 +412,11 @@ def main(argv: list[str] | None = None) -> int:
         max_new_tokens=args.max_new_tokens,
         tokenizer_name_or_path=args.tokenizer,
         cache_path=args.cache_path,
-        layer_id_offset=args.layer_id_offset,
-        fp32=args.fp32,
-        persistent_mode=args.persistent_mode,
+        use_real_weights=(args.weights == "real"),
+        lm_head_fp32_dest_acc_en=args.fp32,
+        lm_head_persistent_mode=args.persistent_mode,
+        dense_layer_id_override=args.dense_layer_id_override,
+        moe_layer_id_override=args.moe_layer_id_override,
         output_stream=sys.stdout,
     )
     print(file=sys.stdout, flush=True)

--- a/models/demos/deepseek_v3_b1/demo/pipeline.py
+++ b/models/demos/deepseek_v3_b1/demo/pipeline.py
@@ -21,7 +21,11 @@ from models.demos.deepseek_v3_b1.demo.stage import (
     StageKind,
 )
 from models.demos.deepseek_v3_b1.micro_ops.pipeline_block.op import PipelineBlock
-from models.demos.deepseek_v3_b1.prepare_weights import DeepSeekV3EmbeddingLayerWeights, DeepSeekV3LMHeadWeights
+from models.demos.deepseek_v3_b1.prepare_weights import (
+    DeepSeekV3EmbeddingLayerWeights,
+    DeepSeekV3LMHeadWeights,
+    DeepSeekV3MoELayerWeights,
+)
 
 
 class WeightProvider(Protocol):
@@ -31,6 +35,9 @@ class WeightProvider(Protocol):
         ...
 
     def load_lm_head(self, device: ttnn.MeshDevice) -> DeepSeekV3LMHeadWeights:
+        ...
+
+    def load_moe_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3MoELayerWeights:
         ...
 
 
@@ -96,6 +103,34 @@ def create_single_pod_pipeline_configuration(
     return PipelineConfiguration(stage_factories)
 
 
+def create_sp4_pipeline_configuration(
+    weight_provider: WeightProvider,
+    *,
+    fp32_dest_acc_en: bool = True,
+    persistent_mode: bool = True,
+) -> PipelineConfiguration:
+    """64-stage super-pod: Embed -> 63x Activation fwd -> LMHead -> Token fwd."""
+
+    def stage_0(device: ttnn.MeshDevice) -> StageKind:
+        return EmbeddingStage(weight_provider.load_embedding(device))
+
+    def stage_62(device: ttnn.MeshDevice) -> StageKind:
+        return LMHeadStage(
+            weights=weight_provider.load_lm_head(device),
+            fp32_dest_acc_en=fp32_dest_acc_en,
+            persistent_mode=persistent_mode,
+        )
+
+    passthrough_activation = lambda d: PassthroughStage(PassthroughPayload.ACTIVATION)
+    stage_factories: dict[int, Callable[[ttnn.MeshDevice], StageKind]] = {
+        0: stage_0,
+        **{i: passthrough_activation for i in range(1, 62)},
+        62: stage_62,
+        63: lambda d: PassthroughStage(PassthroughPayload.TOKEN),
+    }
+    return PipelineConfiguration(stage_factories)
+
+
 def create_pipeline_configuration_from_num_procs(
     num_procs: int,
     weight_provider: WeightProvider,
@@ -112,6 +147,12 @@ def create_pipeline_configuration_from_num_procs(
         )
     if num_procs == 16:
         return create_single_pod_pipeline_configuration(
+            weight_provider,
+            fp32_dest_acc_en=fp32_dest_acc_en,
+            persistent_mode=persistent_mode,
+        )
+    if num_procs == 64:
+        return create_sp4_pipeline_configuration(
             weight_provider,
             fp32_dest_acc_en=fp32_dest_acc_en,
             persistent_mode=persistent_mode,

--- a/models/demos/deepseek_v3_b1/demo/pipeline.py
+++ b/models/demos/deepseek_v3_b1/demo/pipeline.py
@@ -13,8 +13,10 @@ from typing import Any, Callable, Protocol
 
 import ttnn
 from models.demos.deepseek_v3_b1.demo.stage import (
+    DenseDecoderStage,
     EmbeddingStage,
     LMHeadStage,
+    MoEDecoderStage,
     PassthroughPayload,
     PassthroughStage,
     StageContext,
@@ -22,6 +24,7 @@ from models.demos.deepseek_v3_b1.demo.stage import (
 )
 from models.demos.deepseek_v3_b1.micro_ops.pipeline_block.op import PipelineBlock
 from models.demos.deepseek_v3_b1.prepare_weights import (
+    DeepSeekV3DenseLayerWeights,
     DeepSeekV3EmbeddingLayerWeights,
     DeepSeekV3LMHeadWeights,
     DeepSeekV3MoELayerWeights,
@@ -38,6 +41,9 @@ class WeightProvider(Protocol):
         ...
 
     def load_moe_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3MoELayerWeights:
+        ...
+
+    def load_dense_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3DenseLayerWeights:
         ...
 
 
@@ -69,8 +75,8 @@ def create_single_galaxy_pipeline_configuration(
         {
             0: stage_0,
             1: stage_1,
-            2: lambda d: PassthroughStage(PassthroughPayload.TOKEN),
-            3: lambda d: PassthroughStage(PassthroughPayload.TOKEN),
+            2: lambda d: DenseDecoderStage(weights=weight_provider.load_dense_layer(layer_id=0, device=d)),
+            3: lambda d: MoEDecoderStage(weights=weight_provider.load_moe_layer(layer_id=3, device=d)),
         }
     )
 
@@ -81,7 +87,7 @@ def create_single_pod_pipeline_configuration(
     fp32_dest_acc_en: bool = True,
     persistent_mode: bool = True,
 ) -> PipelineConfiguration:
-    """16-stage single-pod: Embed -> 13x Activation fwd -> LMHead -> Token fwd."""
+    """16-stage single-pod: Embed -> Dense(0,1,2) -> MoE(3..12) -> LMHead -> Token fwd."""
 
     def stage_0(device: ttnn.MeshDevice) -> StageKind:
         return EmbeddingStage(weight_provider.load_embedding(device))
@@ -93,10 +99,19 @@ def create_single_pod_pipeline_configuration(
             persistent_mode=persistent_mode,
         )
 
-    passthrough_activation = lambda d: PassthroughStage(PassthroughPayload.ACTIVATION)
+    # Same layout as SP4: stage i -> layer_id i-1 for decoder stages; fewer MoE stages (4-13 = layers 3-12)
+    def _dense_stage(layer_id: int):
+        return lambda d: DenseDecoderStage(weights=weight_provider.load_dense_layer(layer_id=layer_id, device=d))
+
+    def _moe_stage(layer_id: int):
+        return lambda d: MoEDecoderStage(weights=weight_provider.load_moe_layer(layer_id=layer_id, device=d))
+
     stage_factories: dict[int, Callable[[ttnn.MeshDevice], StageKind]] = {
         0: stage_0,
-        **{i: passthrough_activation for i in range(1, 14)},
+        1: _dense_stage(0),
+        2: _dense_stage(1),
+        3: _dense_stage(2),
+        **{i: _moe_stage(i - 1) for i in range(4, 14)},
         14: stage_14,
         15: lambda d: PassthroughStage(PassthroughPayload.TOKEN),
     }
@@ -109,7 +124,7 @@ def create_sp4_pipeline_configuration(
     fp32_dest_acc_en: bool = True,
     persistent_mode: bool = True,
 ) -> PipelineConfiguration:
-    """64-stage super-pod: Embed -> 63x Activation fwd -> LMHead -> Token fwd."""
+    """64-stage super-pod: Embed -> Dense(0,1,2) -> MoE(3..60) -> LMHead -> Token fwd."""
 
     def stage_0(device: ttnn.MeshDevice) -> StageKind:
         return EmbeddingStage(weight_provider.load_embedding(device))
@@ -121,10 +136,19 @@ def create_sp4_pipeline_configuration(
             persistent_mode=persistent_mode,
         )
 
-    passthrough_activation = lambda d: PassthroughStage(PassthroughPayload.ACTIVATION)
+    # Stage i -> layer_id i-1 for decoder stages (stage 1 = layer 0, ..., stage 61 = layer 60)
+    def _dense_stage(layer_id: int):
+        return lambda d: DenseDecoderStage(weights=weight_provider.load_dense_layer(layer_id=layer_id, device=d))
+
+    def _moe_stage(layer_id: int):
+        return lambda d: MoEDecoderStage(weights=weight_provider.load_moe_layer(layer_id=layer_id, device=d))
+
     stage_factories: dict[int, Callable[[ttnn.MeshDevice], StageKind]] = {
         0: stage_0,
-        **{i: passthrough_activation for i in range(1, 62)},
+        1: _dense_stage(0),
+        2: _dense_stage(1),
+        3: _dense_stage(2),
+        **{i: _moe_stage(i - 1) for i in range(4, 62)},
         62: stage_62,
         63: lambda d: PassthroughStage(PassthroughPayload.TOKEN),
     }

--- a/models/demos/deepseek_v3_b1/demo/pipeline.py
+++ b/models/demos/deepseek_v3_b1/demo/pipeline.py
@@ -56,8 +56,8 @@ def create_fabric_router_config(max_payload_size: int) -> Any:
 def create_single_galaxy_pipeline_configuration(
     weight_provider: WeightProvider,
     *,
-    fp32_dest_acc_en: bool = True,
-    persistent_mode: bool = True,
+    lm_head_fp32_dest_acc_en: bool = True,
+    lm_head_persistent_mode: bool = True,
 ) -> PipelineConfiguration:
     """4-stage single-galaxy: Embed -> LMHead -> Token fwd -> Token fwd."""
 
@@ -67,8 +67,8 @@ def create_single_galaxy_pipeline_configuration(
     def stage_1(device: ttnn.MeshDevice) -> StageKind:
         return LMHeadStage(
             weights=weight_provider.load_lm_head(device),
-            fp32_dest_acc_en=fp32_dest_acc_en,
-            persistent_mode=persistent_mode,
+            lm_head_fp32_dest_acc_en=lm_head_fp32_dest_acc_en,
+            lm_head_persistent_mode=lm_head_persistent_mode,
         )
 
     return PipelineConfiguration(
@@ -84,10 +84,16 @@ def create_single_galaxy_pipeline_configuration(
 def create_single_pod_pipeline_configuration(
     weight_provider: WeightProvider,
     *,
-    fp32_dest_acc_en: bool = True,
-    persistent_mode: bool = True,
+    lm_head_fp32_dest_acc_en: bool = True,
+    lm_head_persistent_mode: bool = True,
+    dense_layer_id_override: int | None = None,
+    moe_layer_id_override: int | None = None,
 ) -> PipelineConfiguration:
-    """16-stage single-pod: Embed -> Dense(0,1,2) -> MoE(3..12) -> LMHead -> Token fwd."""
+    """16-stage single-pod: Embed -> Dense(0,1,2) -> MoE(3..12) -> LMHead -> Token fwd.
+
+    If dense_layer_id_override is set (e.g. 0), all dense stages use that layer id.
+    If moe_layer_id_override is set (e.g. 3), all MoE stages use that layer id.
+    """
 
     def stage_0(device: ttnn.MeshDevice) -> StageKind:
         return EmbeddingStage(weight_provider.load_embedding(device))
@@ -95,8 +101,8 @@ def create_single_pod_pipeline_configuration(
     def stage_14(device: ttnn.MeshDevice) -> StageKind:
         return LMHeadStage(
             weights=weight_provider.load_lm_head(device),
-            fp32_dest_acc_en=fp32_dest_acc_en,
-            persistent_mode=persistent_mode,
+            lm_head_fp32_dest_acc_en=lm_head_fp32_dest_acc_en,
+            lm_head_persistent_mode=lm_head_persistent_mode,
         )
 
     # Same layout as SP4: stage i -> layer_id i-1 for decoder stages; fewer MoE stages (4-13 = layers 3-12)
@@ -106,12 +112,15 @@ def create_single_pod_pipeline_configuration(
     def _moe_stage(layer_id: int):
         return lambda d: MoEDecoderStage(weights=weight_provider.load_moe_layer(layer_id=layer_id, device=d))
 
+    dense_ids = (dense_layer_id_override,) * 3 if dense_layer_id_override is not None else (0, 1, 2)
+    moe_layer_id = moe_layer_id_override if moe_layer_id_override is not None else None
+
     stage_factories: dict[int, Callable[[ttnn.MeshDevice], StageKind]] = {
         0: stage_0,
-        1: _dense_stage(0),
-        2: _dense_stage(1),
-        3: _dense_stage(2),
-        **{i: _moe_stage(i - 1) for i in range(4, 14)},
+        1: _dense_stage(dense_ids[0]),
+        2: _dense_stage(dense_ids[1]),
+        3: _dense_stage(dense_ids[2]),
+        **{i: _moe_stage(moe_layer_id if moe_layer_id is not None else i - 1) for i in range(4, 14)},
         14: stage_14,
         15: lambda d: PassthroughStage(PassthroughPayload.TOKEN),
     }
@@ -121,10 +130,16 @@ def create_single_pod_pipeline_configuration(
 def create_sp4_pipeline_configuration(
     weight_provider: WeightProvider,
     *,
-    fp32_dest_acc_en: bool = True,
-    persistent_mode: bool = True,
+    lm_head_fp32_dest_acc_en: bool = True,
+    lm_head_persistent_mode: bool = True,
+    dense_layer_id_override: int | None = None,
+    moe_layer_id_override: int | None = None,
 ) -> PipelineConfiguration:
-    """64-stage super-pod: Embed -> Dense(0,1,2) -> MoE(3..60) -> LMHead -> Token fwd."""
+    """64-stage super-pod: Embed -> Dense(0,1,2) -> MoE(3..60) -> LMHead -> Token fwd.
+
+    If dense_layer_id_override is set (e.g. 0), all dense stages use that layer id.
+    If moe_layer_id_override is set (e.g. 3), all MoE stages use that layer id.
+    """
 
     def stage_0(device: ttnn.MeshDevice) -> StageKind:
         return EmbeddingStage(weight_provider.load_embedding(device))
@@ -132,8 +147,8 @@ def create_sp4_pipeline_configuration(
     def stage_62(device: ttnn.MeshDevice) -> StageKind:
         return LMHeadStage(
             weights=weight_provider.load_lm_head(device),
-            fp32_dest_acc_en=fp32_dest_acc_en,
-            persistent_mode=persistent_mode,
+            lm_head_fp32_dest_acc_en=lm_head_fp32_dest_acc_en,
+            lm_head_persistent_mode=lm_head_persistent_mode,
         )
 
     # Stage i -> layer_id i-1 for decoder stages (stage 1 = layer 0, ..., stage 61 = layer 60)
@@ -143,12 +158,15 @@ def create_sp4_pipeline_configuration(
     def _moe_stage(layer_id: int):
         return lambda d: MoEDecoderStage(weights=weight_provider.load_moe_layer(layer_id=layer_id, device=d))
 
+    dense_ids = (dense_layer_id_override,) * 3 if dense_layer_id_override is not None else (0, 1, 2)
+    moe_layer_id = moe_layer_id_override if moe_layer_id_override is not None else None
+
     stage_factories: dict[int, Callable[[ttnn.MeshDevice], StageKind]] = {
         0: stage_0,
-        1: _dense_stage(0),
-        2: _dense_stage(1),
-        3: _dense_stage(2),
-        **{i: _moe_stage(i - 1) for i in range(4, 62)},
+        1: _dense_stage(dense_ids[0]),
+        2: _dense_stage(dense_ids[1]),
+        3: _dense_stage(dense_ids[2]),
+        **{i: _moe_stage(moe_layer_id if moe_layer_id is not None else i - 1) for i in range(4, 62)},
         62: stage_62,
         63: lambda d: PassthroughStage(PassthroughPayload.TOKEN),
     }
@@ -159,27 +177,33 @@ def create_pipeline_configuration_from_num_procs(
     num_procs: int,
     weight_provider: WeightProvider,
     *,
-    fp32_dest_acc_en: bool = True,
-    persistent_mode: bool = True,
+    lm_head_fp32_dest_acc_en: bool = True,
+    lm_head_persistent_mode: bool = True,
+    dense_layer_id_override: int | None = None,
+    moe_layer_id_override: int | None = None,
 ) -> PipelineConfiguration:
-    """Pick topology from process count (4 -> single_galaxy, 16 -> single_pod)."""
+    """Pick topology from process count (4 -> single_galaxy, 16 -> single_pod, 64 -> sp4)."""
     if num_procs == 4:
         return create_single_galaxy_pipeline_configuration(
             weight_provider,
-            fp32_dest_acc_en=fp32_dest_acc_en,
-            persistent_mode=persistent_mode,
+            lm_head_fp32_dest_acc_en=lm_head_fp32_dest_acc_en,
+            lm_head_persistent_mode=lm_head_persistent_mode,
         )
     if num_procs == 16:
         return create_single_pod_pipeline_configuration(
             weight_provider,
-            fp32_dest_acc_en=fp32_dest_acc_en,
-            persistent_mode=persistent_mode,
+            lm_head_fp32_dest_acc_en=lm_head_fp32_dest_acc_en,
+            lm_head_persistent_mode=lm_head_persistent_mode,
+            dense_layer_id_override=dense_layer_id_override,
+            moe_layer_id_override=moe_layer_id_override,
         )
     if num_procs == 64:
         return create_sp4_pipeline_configuration(
             weight_provider,
-            fp32_dest_acc_en=fp32_dest_acc_en,
-            persistent_mode=persistent_mode,
+            lm_head_fp32_dest_acc_en=lm_head_fp32_dest_acc_en,
+            lm_head_persistent_mode=lm_head_persistent_mode,
+            dense_layer_id_override=dense_layer_id_override,
+            moe_layer_id_override=moe_layer_id_override,
         )
     raise ValueError(f"Unsupported num_procs: {num_procs}")
 

--- a/models/demos/deepseek_v3_b1/demo/pipeline.py
+++ b/models/demos/deepseek_v3_b1/demo/pipeline.py
@@ -9,7 +9,7 @@ Stage kinds (Embedding, LMHead, Passthrough) live in stage.py.
 
 from __future__ import annotations
 
-from typing import Any, Callable, Protocol
+from typing import Any, Callable
 
 import ttnn
 from models.demos.deepseek_v3_b1.demo.stage import (
@@ -22,29 +22,8 @@ from models.demos.deepseek_v3_b1.demo.stage import (
     StageContext,
     StageKind,
 )
+from models.demos.deepseek_v3_b1.demo.weight_provider import WeightProvider
 from models.demos.deepseek_v3_b1.micro_ops.pipeline_block.op import PipelineBlock
-from models.demos.deepseek_v3_b1.prepare_weights import (
-    DeepSeekV3DenseLayerWeights,
-    DeepSeekV3EmbeddingLayerWeights,
-    DeepSeekV3LMHeadWeights,
-    DeepSeekV3MoELayerWeights,
-)
-
-
-class WeightProvider(Protocol):
-    """Provides embedding and LM head weights on demand; each host loads only what its stage needs."""
-
-    def load_embedding(self, device: ttnn.MeshDevice) -> DeepSeekV3EmbeddingLayerWeights:
-        ...
-
-    def load_lm_head(self, device: ttnn.MeshDevice) -> DeepSeekV3LMHeadWeights:
-        ...
-
-    def load_moe_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3MoELayerWeights:
-        ...
-
-    def load_dense_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3DenseLayerWeights:
-        ...
 
 
 def create_fabric_router_config(max_payload_size: int) -> Any:

--- a/models/demos/deepseek_v3_b1/demo/pipeline.py
+++ b/models/demos/deepseek_v3_b1/demo/pipeline.py
@@ -75,8 +75,8 @@ def create_single_galaxy_pipeline_configuration(
         {
             0: stage_0,
             1: stage_1,
-            2: lambda d: DenseDecoderStage(weights=weight_provider.load_dense_layer(layer_id=0, device=d)),
-            3: lambda d: MoEDecoderStage(weights=weight_provider.load_moe_layer(layer_id=3, device=d)),
+            2: lambda d: PassthroughStage(PassthroughPayload.TOKEN),
+            3: lambda d: PassthroughStage(PassthroughPayload.TOKEN),
         }
     )
 

--- a/models/demos/deepseek_v3_b1/demo/stage.py
+++ b/models/demos/deepseek_v3_b1/demo/stage.py
@@ -176,12 +176,12 @@ class LMHeadStage(StageKind):
         self,
         weights: DeepSeekV3LMHeadWeights,
         *,
-        fp32_dest_acc_en: bool = True,
-        persistent_mode: bool = True,
+        lm_head_fp32_dest_acc_en: bool = True,
+        lm_head_persistent_mode: bool = True,
     ) -> None:
         self._weights = weights
-        self._fp32_dest_acc_en = fp32_dest_acc_en
-        self._persistent_mode = persistent_mode
+        self._lm_head_fp32_dest_acc_en = lm_head_fp32_dest_acc_en
+        self._lm_head_persistent_mode = lm_head_persistent_mode
         self._lmhead_state: dict[str, Any] = {}
 
     def create_pipeline_block(self, ctx: StageContext) -> PipelineBlock:
@@ -366,7 +366,7 @@ class LMHeadStage(StageKind):
             "global_semaphore": global_semaphore,
             "global_stage2_semaphore": global_stage2_semaphore,
         }
-        if self._persistent_mode:
+        if self._lm_head_persistent_mode:
             persistent_next_iter_semaphore = ttnn.create_global_semaphore(mesh_device, worker_crs, 1)
             self._lmhead_state["persistent_next_iter_semaphore"] = persistent_next_iter_semaphore
 
@@ -393,10 +393,10 @@ class LMHeadStage(StageKind):
             global_semaphore=d["global_semaphore"],
             global_stage2_semaphore=d["global_stage2_semaphore"],
             fabric_scratch_tensor=d["scratch_buffer"],
-            fp32_dest_acc_en=self._fp32_dest_acc_en,
+            fp32_dest_acc_en=self._lm_head_fp32_dest_acc_en,
             skip_ccl=False,
             socket_input=d["lmhead_input_socket"],
             socket_output=d["lmhead_output_socket"],
-            persistent_mode=self._persistent_mode,
+            persistent_mode=self._lm_head_persistent_mode,
             persistent_next_iter_semaphore=d.get("persistent_next_iter_semaphore"),
         )

--- a/models/demos/deepseek_v3_b1/demo/stage.py
+++ b/models/demos/deepseek_v3_b1/demo/stage.py
@@ -18,7 +18,11 @@ import torch
 import ttnn
 from models.demos.deepseek_v3_b1.fused_ops.lm_head_sampling.op import LMHeadSampling
 from models.demos.deepseek_v3_b1.micro_ops.pipeline_block.op import PipelineBlock
-from models.demos.deepseek_v3_b1.prepare_weights import DeepSeekV3EmbeddingLayerWeights, DeepSeekV3LMHeadWeights
+from models.demos.deepseek_v3_b1.prepare_weights import (
+    DeepSeekV3EmbeddingLayerWeights,
+    DeepSeekV3LMHeadWeights,
+    DeepSeekV3MoELayerWeights,
+)
 
 # Constants used by stage kinds (same as pipeline module)
 token_page_size_bytes = 64
@@ -113,6 +117,30 @@ class PassthroughStage(StageKind):
             upstream_d2d_socket_page_size=up_page,
             downstream_d2d_socket_page_size=down_page,
         )
+
+
+class MoEDecoderStage(StageKind):
+    """Decoder stage that runs an MoE layer; activation in, activation out. Compute stubbed for now."""
+
+    def __init__(self, weights: DeepSeekV3MoELayerWeights) -> None:
+        self._weights = weights
+
+    def create_pipeline_block(self, ctx: StageContext) -> PipelineBlock:
+        mesh_device = ctx.mesh_device
+        return PipelineBlock(
+            mesh_device,
+            pipeline_core_coord,
+            upstream_d2d_socket_fifo_size=activation_fifo_size,
+            downstream_d2d_socket_fifo_size=activation_fifo_size,
+            upstream_d2d_socket_page_size=activation_page_size_bytes,
+            downstream_d2d_socket_page_size=activation_page_size_bytes,
+        )
+
+    def setup(self, ctx: StageContext, pipeline_block: PipelineBlock) -> None:
+        pass
+
+    def launch_compute(self, ctx: StageContext, pipeline_block: PipelineBlock) -> None:
+        pass
 
 
 class LMHeadStage(StageKind):

--- a/models/demos/deepseek_v3_b1/demo/stage.py
+++ b/models/demos/deepseek_v3_b1/demo/stage.py
@@ -19,30 +19,19 @@ import ttnn
 from models.demos.deepseek_v3_b1.fused_ops.lm_head_sampling.op import LMHeadSampling
 from models.demos.deepseek_v3_b1.micro_ops.pipeline_block.op import PipelineBlock
 from models.demos.deepseek_v3_b1.prepare_weights import (
+    DeepSeekV3DenseLayerWeights,
     DeepSeekV3EmbeddingLayerWeights,
     DeepSeekV3LMHeadWeights,
     DeepSeekV3MoELayerWeights,
 )
 
-# Constants used by stage kinds (same as pipeline module)
-token_page_size_bytes = 64
-token_fifo_size = 1024
-activation_dim = 7168
-activation_page_size_bytes = activation_dim * 2
-activation_fifo_size = activation_page_size_bytes * 4
-
-M = 1
-K = activation_dim
-num_matmul_cores = 101
-n_per_core = 160
-n_total = num_matmul_cores * n_per_core
-
-a_tile = ttnn.Tile([1, 32])
-b_tile = ttnn.Tile([32, 32])
-out_tile = ttnn.Tile([1, 32])
-pipeline_core_coord = ttnn.CoreCoord(11, 0)
-argmax_final_core = ttnn.CoreCoord(0, 0)
-lmhead_input_core = ttnn.CoreCoord(10, 9)
+# Global constants used by multiple stage kinds (and exported to pipeline/cli)
+TOKEN_PAGE_SIZE_BYTES = 64
+TOKEN_FIFO_SIZE = 1024
+ACTIVATION_DIM = 7168
+ACTIVATION_PAGE_SIZE_BYTES = ACTIVATION_DIM * 2
+ACTIVATION_FIFO_SIZE = ACTIVATION_PAGE_SIZE_BYTES * 4
+PIPELINE_CORE_COORD = ttnn.CoreCoord(11, 0)
 
 
 @dataclass
@@ -78,14 +67,14 @@ class EmbeddingStage(StageKind):
         mesh_device = ctx.mesh_device
         return PipelineBlock(
             mesh_device,
-            pipeline_core_coord,
-            upstream_d2d_socket_fifo_size=token_fifo_size,
-            downstream_d2d_socket_fifo_size=activation_fifo_size,
-            upstream_d2d_socket_page_size=token_page_size_bytes,
-            downstream_d2d_socket_page_size=activation_page_size_bytes,
-            h2d_socket_fifo_size=token_fifo_size,
-            d2h_socket_fifo_size=token_fifo_size,
-            d2h_socket_page_size=token_page_size_bytes,
+            PIPELINE_CORE_COORD,
+            upstream_d2d_socket_fifo_size=TOKEN_FIFO_SIZE,
+            downstream_d2d_socket_fifo_size=ACTIVATION_FIFO_SIZE,
+            upstream_d2d_socket_page_size=TOKEN_PAGE_SIZE_BYTES,
+            downstream_d2d_socket_page_size=ACTIVATION_PAGE_SIZE_BYTES,
+            h2d_socket_fifo_size=TOKEN_FIFO_SIZE,
+            d2h_socket_fifo_size=TOKEN_FIFO_SIZE,
+            d2h_socket_page_size=TOKEN_PAGE_SIZE_BYTES,
             embedding_tensor=self._weights.embedding,
         )
 
@@ -104,14 +93,14 @@ class PassthroughStage(StageKind):
     def create_pipeline_block(self, ctx: StageContext) -> PipelineBlock:
         mesh_device = ctx.mesh_device
         if self._payload == PassthroughPayload.ACTIVATION:
-            up_fifo = down_fifo = activation_fifo_size
-            up_page = down_page = activation_page_size_bytes
+            up_fifo = down_fifo = ACTIVATION_FIFO_SIZE
+            up_page = down_page = ACTIVATION_PAGE_SIZE_BYTES
         else:
-            up_fifo = down_fifo = token_fifo_size
-            up_page = down_page = token_page_size_bytes
+            up_fifo = down_fifo = TOKEN_FIFO_SIZE
+            up_page = down_page = TOKEN_PAGE_SIZE_BYTES
         return PipelineBlock(
             mesh_device,
-            pipeline_core_coord,
+            PIPELINE_CORE_COORD,
             upstream_d2d_socket_fifo_size=up_fifo,
             downstream_d2d_socket_fifo_size=down_fifo,
             upstream_d2d_socket_page_size=up_page,
@@ -129,11 +118,35 @@ class MoEDecoderStage(StageKind):
         mesh_device = ctx.mesh_device
         return PipelineBlock(
             mesh_device,
-            pipeline_core_coord,
-            upstream_d2d_socket_fifo_size=activation_fifo_size,
-            downstream_d2d_socket_fifo_size=activation_fifo_size,
-            upstream_d2d_socket_page_size=activation_page_size_bytes,
-            downstream_d2d_socket_page_size=activation_page_size_bytes,
+            PIPELINE_CORE_COORD,
+            upstream_d2d_socket_fifo_size=ACTIVATION_FIFO_SIZE,
+            downstream_d2d_socket_fifo_size=ACTIVATION_FIFO_SIZE,
+            upstream_d2d_socket_page_size=ACTIVATION_PAGE_SIZE_BYTES,
+            downstream_d2d_socket_page_size=ACTIVATION_PAGE_SIZE_BYTES,
+        )
+
+    def setup(self, ctx: StageContext, pipeline_block: PipelineBlock) -> None:
+        pass
+
+    def launch_compute(self, ctx: StageContext, pipeline_block: PipelineBlock) -> None:
+        pass
+
+
+class DenseDecoderStage(StageKind):
+    """Decoder stage that runs a dense layer; activation in, activation out. Compute stubbed for now."""
+
+    def __init__(self, weights: DeepSeekV3DenseLayerWeights) -> None:
+        self._weights = weights
+
+    def create_pipeline_block(self, ctx: StageContext) -> PipelineBlock:
+        mesh_device = ctx.mesh_device
+        return PipelineBlock(
+            mesh_device,
+            PIPELINE_CORE_COORD,
+            upstream_d2d_socket_fifo_size=ACTIVATION_FIFO_SIZE,
+            downstream_d2d_socket_fifo_size=ACTIVATION_FIFO_SIZE,
+            upstream_d2d_socket_page_size=ACTIVATION_PAGE_SIZE_BYTES,
+            downstream_d2d_socket_page_size=ACTIVATION_PAGE_SIZE_BYTES,
         )
 
     def setup(self, ctx: StageContext, pipeline_block: PipelineBlock) -> None:
@@ -144,6 +157,19 @@ class MoEDecoderStage(StageKind):
 
 
 class LMHeadStage(StageKind):
+    """LMHead+Sampling stage: receive activation, run op, send token downstream."""
+
+    # LMHead-stage-specific constants (tiles, core coords, matmul layout)
+    M = 1
+    K = ACTIVATION_DIM
+    NUM_MATMUL_CORES = 101
+    N_PER_CORE = 160
+    N_TOTAL = NUM_MATMUL_CORES * N_PER_CORE
+    A_TILE = ttnn.Tile([1, 32])
+    B_TILE = ttnn.Tile([32, 32])
+    OUT_TILE = ttnn.Tile([1, 32])
+    ARGMAX_FINAL_CORE = ttnn.CoreCoord(0, 0)
+    LMHEAD_INPUT_CORE = ttnn.CoreCoord(10, 9)
     """LMHead+Sampling stage: receive activation, run op, send token downstream."""
 
     def __init__(
@@ -162,15 +188,19 @@ class LMHeadStage(StageKind):
         mesh_device = ctx.mesh_device
         my_mesh_id = ctx.my_mesh_id
         pipeline_config = ctx.pipeline_config
-        lmhead_entry_core = ttnn.MeshCoreCoord(pipeline_config[my_mesh_id].entry_node_coord, lmhead_input_core)
-        lmhead_exit_core = ttnn.MeshCoreCoord(pipeline_config[my_mesh_id].exit_node_coord, argmax_final_core)
+        lmhead_entry_core = ttnn.MeshCoreCoord(
+            pipeline_config[my_mesh_id].entry_node_coord, LMHeadStage.LMHEAD_INPUT_CORE
+        )
+        lmhead_exit_core = ttnn.MeshCoreCoord(
+            pipeline_config[my_mesh_id].exit_node_coord, LMHeadStage.ARGMAX_FINAL_CORE
+        )
         return PipelineBlock(
             mesh_device,
-            pipeline_core_coord,
-            upstream_d2d_socket_fifo_size=activation_fifo_size,
-            downstream_d2d_socket_fifo_size=token_fifo_size,
-            upstream_d2d_socket_page_size=activation_page_size_bytes,
-            downstream_d2d_socket_page_size=token_page_size_bytes,
+            PIPELINE_CORE_COORD,
+            upstream_d2d_socket_fifo_size=ACTIVATION_FIFO_SIZE,
+            downstream_d2d_socket_fifo_size=TOKEN_FIFO_SIZE,
+            upstream_d2d_socket_page_size=ACTIVATION_PAGE_SIZE_BYTES,
+            downstream_d2d_socket_page_size=TOKEN_PAGE_SIZE_BYTES,
             entry_node_downstream=lmhead_entry_core,
             exit_node_upstream=lmhead_exit_core,
         )
@@ -179,36 +209,40 @@ class LMHeadStage(StageKind):
         mesh_device = ctx.mesh_device
         my_mesh_id = ctx.my_mesh_id
         pipeline_config = ctx.pipeline_config
-        torch_a = torch.zeros((M, K), dtype=torch.bfloat16)
+        torch_a = torch.zeros((LMHeadStage.M, LMHeadStage.K), dtype=torch.bfloat16)
 
         mesh_shape = mesh_device.shape
         mesh_rows, mesh_cols = mesh_shape[0], mesh_shape[1]
         sender_coord = pipeline_config[my_mesh_id].entry_node_coord
         num_devices = mesh_rows * mesh_cols
 
-        mcast_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(lmhead_input_core, lmhead_input_core)])
+        mcast_core_grid = ttnn.CoreRangeSet(
+            [ttnn.CoreRange(LMHeadStage.LMHEAD_INPUT_CORE, LMHeadStage.LMHEAD_INPUT_CORE)]
+        )
         matmul_core_grid = ttnn.CoreRangeSet(
             [
                 ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(9, 9)),
                 ttnn.CoreRange(ttnn.CoreCoord(10, 0), ttnn.CoreCoord(10, 0)),
             ]
         )
-        argmax_final_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(argmax_final_core, argmax_final_core)])
+        argmax_final_core_grid = ttnn.CoreRangeSet(
+            [ttnn.CoreRange(LMHeadStage.ARGMAX_FINAL_CORE, LMHeadStage.ARGMAX_FINAL_CORE)]
+        )
 
         input_a_mem_config = ttnn.MemoryConfig(
             ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
             ttnn.BufferType.L1,
-            ttnn.ShardSpec(mcast_core_grid, (M, K), ttnn.ShardOrientation.ROW_MAJOR),
+            ttnn.ShardSpec(mcast_core_grid, (LMHeadStage.M, LMHeadStage.K), ttnn.ShardOrientation.ROW_MAJOR),
         )
         output_mem_config = ttnn.MemoryConfig(
             ttnn.TensorMemoryLayout.WIDTH_SHARDED,
             ttnn.BufferType.L1,
-            ttnn.ShardSpec(matmul_core_grid, (M, n_per_core), ttnn.ShardOrientation.ROW_MAJOR),
+            ttnn.ShardSpec(matmul_core_grid, (LMHeadStage.M, LMHeadStage.N_PER_CORE), ttnn.ShardOrientation.ROW_MAJOR),
         )
         indices_mem_config = ttnn.MemoryConfig(
             ttnn.TensorMemoryLayout.WIDTH_SHARDED,
             ttnn.BufferType.L1,
-            ttnn.ShardSpec(matmul_core_grid, (M, n_per_core), ttnn.ShardOrientation.ROW_MAJOR),
+            ttnn.ShardSpec(matmul_core_grid, (LMHeadStage.M, LMHeadStage.N_PER_CORE), ttnn.ShardOrientation.ROW_MAJOR),
         )
         output_index_mem_config = ttnn.MemoryConfig(
             ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
@@ -233,7 +267,7 @@ class LMHeadStage(StageKind):
             mesh_input,
             device=mesh_device,
             layout=ttnn.TILE_LAYOUT,
-            tile=a_tile,
+            tile=LMHeadStage.A_TILE,
             dtype=ttnn.bfloat16,
             memory_config=input_a_mem_config,
             mesh_mapper=mesh_mapper,
@@ -242,14 +276,14 @@ class LMHeadStage(StageKind):
             mesh_intermediate,
             device=mesh_device,
             layout=ttnn.TILE_LAYOUT,
-            tile=a_tile,
+            tile=LMHeadStage.A_TILE,
             dtype=ttnn.bfloat16,
             memory_config=input_a_mem_config,
             mesh_mapper=mesh_mapper,
         )
         ttnn_gamma = self._weights.final_norm
         ttnn_b = self._weights.lm_head
-        torch_indices_flat = torch.arange(n_total, dtype=torch.int32).reshape(1, n_total)
+        torch_indices_flat = torch.arange(LMHeadStage.N_TOTAL, dtype=torch.int32).reshape(1, LMHeadStage.N_TOTAL)
         ttnn_indices = ttnn.from_torch(
             torch_indices_flat.repeat(num_devices, 1, 1),
             dtype=ttnn.uint32,
@@ -259,12 +293,12 @@ class LMHeadStage(StageKind):
             mesh_mapper=mesh_mapper,
         )
         ttnn_scores = ttnn.from_torch(
-            torch.zeros((M, n_total), dtype=torch.bfloat16),
+            torch.zeros((LMHeadStage.M, LMHeadStage.N_TOTAL), dtype=torch.bfloat16),
             dtype=ttnn.bfloat16,
             layout=ttnn.TILE_LAYOUT,
             device=mesh_device,
             memory_config=output_mem_config,
-            tile=out_tile,
+            tile=LMHeadStage.OUT_TILE,
             mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
         )
         ttnn_output_index = ttnn.from_torch(
@@ -349,7 +383,7 @@ class LMHeadStage(StageKind):
             sender_coord=pipeline_config[my_mesh_id].entry_node_coord,
             indices_tensor=d["ttnn_indices"],
             output_index_tensor=d["ttnn_output_index"],
-            argmax_final_core_coord=argmax_final_core,
+            argmax_final_core_coord=LMHeadStage.ARGMAX_FINAL_CORE,
             argmax_final_mesh_coord=pipeline_config[my_mesh_id].exit_node_coord,
             semaphores=[
                 d["out_ready_semaphore"],

--- a/models/demos/deepseek_v3_b1/demo/weight_provider.py
+++ b/models/demos/deepseek_v3_b1/demo/weight_provider.py
@@ -1,0 +1,263 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Weight providers for the DeepSeek V3 B1 demo pipeline.
+CacheWeightProvider loads from disk; SyntheticWeightProvider builds deterministic synthetic weights.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol
+
+import torch
+
+import ttnn
+from models.demos.deepseek_v3_b1.prepare_weights import (
+    NUM_ROUTED_EXPERTS,
+    DeepSeekV3DenseLayerWeights,
+    DeepSeekV3EmbeddingLayerWeights,
+    DeepSeekV3LMHeadWeights,
+    DeepSeekV3MoELayerWeights,
+    load_dense_decoder_layer,
+    load_embedding_weights,
+    load_lm_head_weights,
+    load_moe_decoder_layer,
+    load_moe_routed_experts,
+    prepare_dense_layer_weights,
+    prepare_embedding_weights,
+    prepare_lm_head_weights,
+    prepare_moe_layer_weights,
+)
+
+
+class WeightProvider(Protocol):
+    """Provides embedding and LM head weights on demand; each host loads only what its stage needs."""
+
+    def load_embedding(self, device: ttnn.MeshDevice) -> DeepSeekV3EmbeddingLayerWeights:
+        ...
+
+    def load_lm_head(self, device: ttnn.MeshDevice) -> DeepSeekV3LMHeadWeights:
+        ...
+
+    def load_moe_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3MoELayerWeights:
+        ...
+
+    def load_dense_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3DenseLayerWeights:
+        ...
+
+
+class LogicalModelDimensions:
+    """HF / logical tensor dimensions for DeepSeek V3 B1. Must match prepare_weights and stage expectations."""
+
+    HIDDEN_SIZE = 7168
+    VOCAB_SIZE = 129280
+    Q_A_DIM = 1536
+    Q_B_OUT = 24576
+    KV_A_DIM = 576
+    KV_B_LORA_RANK = 512
+    KV_B_PROJ_OUT = 32768
+    O_PROJ_OUT = 16384
+    MLP_INTERMEDIATE_SIZE = 2048
+    GATE_NUM_INDICES = 256
+
+
+def _layer_key(layer_id: int, suffix: str) -> str:
+    """State dict key under model.layers.{layer_id}."""
+    return f"model.layers.{layer_id}.{suffix}"
+
+
+def _build_synthetic_moe_state_dict(
+    layer_id: int,
+    *,
+    num_routed_experts: int = NUM_ROUTED_EXPERTS,
+) -> dict[str, torch.Tensor]:
+    """Build a synthetic MoE layer state dict with HF tensor shapes (randn for weights, ones for norms)."""
+    state_dict: dict[str, torch.Tensor] = {}
+    dtype = torch.bfloat16
+
+    # Attention weights (HF shapes)
+    state_dict[_layer_key(layer_id, "self_attn.q_a_proj.weight")] = torch.randn(
+        LogicalModelDimensions.Q_A_DIM, LogicalModelDimensions.HIDDEN_SIZE, dtype=dtype
+    )
+    state_dict[_layer_key(layer_id, "self_attn.q_b_proj.weight")] = torch.randn(
+        LogicalModelDimensions.Q_B_OUT, LogicalModelDimensions.Q_A_DIM, dtype=dtype
+    )
+    state_dict[_layer_key(layer_id, "self_attn.kv_a_proj_with_mqa.weight")] = torch.randn(
+        LogicalModelDimensions.KV_A_DIM, LogicalModelDimensions.HIDDEN_SIZE, dtype=dtype
+    )
+    state_dict[_layer_key(layer_id, "self_attn.kv_b_proj.weight")] = torch.randn(
+        LogicalModelDimensions.KV_B_PROJ_OUT, LogicalModelDimensions.KV_B_LORA_RANK, dtype=dtype
+    )
+    state_dict[_layer_key(layer_id, "self_attn.o_proj.weight")] = torch.randn(
+        LogicalModelDimensions.HIDDEN_SIZE, LogicalModelDimensions.O_PROJ_OUT, dtype=dtype
+    )
+
+    # Norms (ones per plan)
+    state_dict[_layer_key(layer_id, "input_layernorm.weight")] = torch.ones(
+        LogicalModelDimensions.HIDDEN_SIZE, dtype=dtype
+    )
+    state_dict[_layer_key(layer_id, "self_attn.q_a_layernorm.weight")] = torch.ones(
+        LogicalModelDimensions.Q_A_DIM, dtype=dtype
+    )
+    state_dict[_layer_key(layer_id, "self_attn.kv_a_layernorm.weight")] = torch.ones(
+        LogicalModelDimensions.KV_B_LORA_RANK, dtype=dtype
+    )
+    state_dict[_layer_key(layer_id, "post_attention_layernorm.weight")] = torch.ones(
+        LogicalModelDimensions.HIDDEN_SIZE, dtype=dtype
+    )
+
+    # MoE gate
+    state_dict[_layer_key(layer_id, "mlp.gate.weight")] = torch.randn(
+        LogicalModelDimensions.GATE_NUM_INDICES, LogicalModelDimensions.HIDDEN_SIZE, dtype=dtype
+    )
+    state_dict[_layer_key(layer_id, "mlp.gate.e_score_correction_bias")] = torch.randn(
+        LogicalModelDimensions.GATE_NUM_INDICES, dtype=dtype
+    )
+
+    # Shared experts
+    state_dict[_layer_key(layer_id, "mlp.shared_experts.gate_proj.weight")] = torch.randn(
+        LogicalModelDimensions.MLP_INTERMEDIATE_SIZE, LogicalModelDimensions.HIDDEN_SIZE, dtype=dtype
+    )
+    state_dict[_layer_key(layer_id, "mlp.shared_experts.up_proj.weight")] = torch.randn(
+        LogicalModelDimensions.MLP_INTERMEDIATE_SIZE, LogicalModelDimensions.HIDDEN_SIZE, dtype=dtype
+    )
+    state_dict[_layer_key(layer_id, "mlp.shared_experts.down_proj.weight")] = torch.randn(
+        LogicalModelDimensions.HIDDEN_SIZE, LogicalModelDimensions.MLP_INTERMEDIATE_SIZE, dtype=dtype
+    )
+
+    # Routed experts
+    for e in range(num_routed_experts):
+        state_dict[_layer_key(layer_id, f"mlp.experts.{e}.gate_proj.weight")] = torch.randn(
+            LogicalModelDimensions.MLP_INTERMEDIATE_SIZE, LogicalModelDimensions.HIDDEN_SIZE, dtype=dtype
+        )
+        state_dict[_layer_key(layer_id, f"mlp.experts.{e}.up_proj.weight")] = torch.randn(
+            LogicalModelDimensions.MLP_INTERMEDIATE_SIZE, LogicalModelDimensions.HIDDEN_SIZE, dtype=dtype
+        )
+        state_dict[_layer_key(layer_id, f"mlp.experts.{e}.down_proj.weight")] = torch.randn(
+            LogicalModelDimensions.HIDDEN_SIZE, LogicalModelDimensions.MLP_INTERMEDIATE_SIZE, dtype=dtype
+        )
+
+    return state_dict
+
+
+def _build_synthetic_dense_state_dict(layer_id: int) -> dict[str, torch.Tensor]:
+    """Build a synthetic dense layer state dict with HF tensor shapes (randn for weights, ones for norms)."""
+    state_dict: dict[str, torch.Tensor] = {}
+    dtype = torch.bfloat16
+
+    # Attention weights (HF shapes)
+    state_dict[_layer_key(layer_id, "self_attn.q_a_proj.weight")] = torch.randn(
+        LogicalModelDimensions.Q_A_DIM, LogicalModelDimensions.HIDDEN_SIZE, dtype=dtype
+    )
+    state_dict[_layer_key(layer_id, "self_attn.q_b_proj.weight")] = torch.randn(
+        LogicalModelDimensions.Q_B_OUT, LogicalModelDimensions.Q_A_DIM, dtype=dtype
+    )
+    state_dict[_layer_key(layer_id, "self_attn.kv_a_proj_with_mqa.weight")] = torch.randn(
+        LogicalModelDimensions.KV_A_DIM, LogicalModelDimensions.HIDDEN_SIZE, dtype=dtype
+    )
+    state_dict[_layer_key(layer_id, "self_attn.kv_b_proj.weight")] = torch.randn(
+        LogicalModelDimensions.KV_B_PROJ_OUT, LogicalModelDimensions.KV_B_LORA_RANK, dtype=dtype
+    )
+    state_dict[_layer_key(layer_id, "self_attn.o_proj.weight")] = torch.randn(
+        LogicalModelDimensions.HIDDEN_SIZE, LogicalModelDimensions.O_PROJ_OUT, dtype=dtype
+    )
+
+    # Norms (ones per plan)
+    state_dict[_layer_key(layer_id, "input_layernorm.weight")] = torch.ones(
+        LogicalModelDimensions.HIDDEN_SIZE, dtype=dtype
+    )
+    state_dict[_layer_key(layer_id, "self_attn.q_a_layernorm.weight")] = torch.ones(
+        LogicalModelDimensions.Q_A_DIM, dtype=dtype
+    )
+    state_dict[_layer_key(layer_id, "self_attn.kv_a_layernorm.weight")] = torch.ones(
+        LogicalModelDimensions.KV_B_LORA_RANK, dtype=dtype
+    )
+    state_dict[_layer_key(layer_id, "post_attention_layernorm.weight")] = torch.ones(
+        LogicalModelDimensions.HIDDEN_SIZE, dtype=dtype
+    )
+
+    # Single MLP (used for both shared and routed in dense)
+    state_dict[_layer_key(layer_id, "mlp.gate_proj.weight")] = torch.randn(
+        LogicalModelDimensions.MLP_INTERMEDIATE_SIZE, LogicalModelDimensions.HIDDEN_SIZE, dtype=dtype
+    )
+    state_dict[_layer_key(layer_id, "mlp.up_proj.weight")] = torch.randn(
+        LogicalModelDimensions.MLP_INTERMEDIATE_SIZE, LogicalModelDimensions.HIDDEN_SIZE, dtype=dtype
+    )
+    state_dict[_layer_key(layer_id, "mlp.down_proj.weight")] = torch.randn(
+        LogicalModelDimensions.HIDDEN_SIZE, LogicalModelDimensions.MLP_INTERMEDIATE_SIZE, dtype=dtype
+    )
+
+    return state_dict
+
+
+class CacheWeightProvider:
+    """Load embedding and LM head weights from cache; each host loads only what its stage needs."""
+
+    def __init__(self, cache_path: Path) -> None:
+        assert cache_path.exists(), f"Cache path does not exist: {cache_path}"
+        assert cache_path.is_dir(), f"Cache path is not a directory: {cache_path}"
+        self._path = cache_path
+
+    def load_embedding(self, device: ttnn.MeshDevice) -> DeepSeekV3EmbeddingLayerWeights:
+        return load_embedding_weights(self._path, device)
+
+    def load_lm_head(self, device: ttnn.MeshDevice) -> DeepSeekV3LMHeadWeights:
+        return load_lm_head_weights(self._path, device)
+
+    def load_moe_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3MoELayerWeights:
+        with ttnn.device.setup_fast_dispatch(device):
+            preloaded_experts = load_moe_routed_experts(self._path, device, layer_id)
+        return load_moe_decoder_layer(self._path, device, layer_id, preloaded_routed_experts=preloaded_experts)
+
+    def load_dense_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3DenseLayerWeights:
+        return load_dense_decoder_layer(self._path, device, layer_id)
+
+
+class SyntheticWeightProvider:
+    """Create deterministic synthetic embedding and LM head weights in place (no cache)."""
+
+    def load_embedding(self, device: ttnn.MeshDevice) -> DeepSeekV3EmbeddingLayerWeights:
+        emb_w = torch.zeros(
+            (LogicalModelDimensions.VOCAB_SIZE, LogicalModelDimensions.HIDDEN_SIZE), dtype=torch.bfloat16
+        )
+        emb_w[
+            torch.arange(LogicalModelDimensions.VOCAB_SIZE),
+            torch.arange(LogicalModelDimensions.VOCAB_SIZE, dtype=torch.int64) % LogicalModelDimensions.HIDDEN_SIZE,
+        ] = 1
+        return prepare_embedding_weights({"model.embed_tokens.weight": emb_w}, device, move_to_device=True)
+
+    def load_lm_head(self, device: ttnn.MeshDevice) -> DeepSeekV3LMHeadWeights:
+        # Stride for synthetic one-hot pattern: 101 matmul cores × 160 per core (matches LM head sampling op layout).
+        _lm_head_n_synthetic = 101 * 160
+        lm_w = torch.full(
+            (LogicalModelDimensions.VOCAB_SIZE, LogicalModelDimensions.HIDDEN_SIZE), -1.0, dtype=torch.bfloat16
+        )
+        lm_w[
+            torch.arange(LogicalModelDimensions.HIDDEN_SIZE, dtype=torch.int64) % _lm_head_n_synthetic,
+            torch.arange(LogicalModelDimensions.HIDDEN_SIZE),
+        ] = 1
+        return prepare_lm_head_weights(
+            {
+                "lm_head.weight": lm_w,
+                "model.norm.weight": torch.ones(LogicalModelDimensions.HIDDEN_SIZE, dtype=torch.bfloat16),
+            },
+            device,
+            move_to_device=True,
+        )
+
+    def load_moe_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3MoELayerWeights:
+        from models.demos.deepseek_v3_b1.blitz_decode_weights import BlitzDecodeWeights
+
+        sd = _build_synthetic_moe_state_dict(layer_id, num_routed_experts=NUM_ROUTED_EXPERTS)
+        bdw = BlitzDecodeWeights(device)
+        return prepare_moe_layer_weights(bdw, sd, layer_id, num_routed_experts=NUM_ROUTED_EXPERTS)
+
+    def load_dense_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3DenseLayerWeights:
+        from models.demos.deepseek_v3_b1.blitz_decode_weights import BlitzDecodeWeights
+
+        sd = _build_synthetic_dense_state_dict(layer_id)
+        bdw = BlitzDecodeWeights(device)
+        return prepare_dense_layer_weights(bdw, sd, layer_id, move_to_device=True)

--- a/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
@@ -357,6 +357,8 @@ class MoeRoutedExpertOp:
     ):
         """
         Set up parameters and CB descriptors for a DRAM streaming matmul operation.
+        weights_tensor is the first expert's tensor (list[0]); kernel uses its buffer
+        address as base and strides by per-expert size. Single-expert K = shard_shape[0].
         When working_buf_tensor is None, CB in1 descriptor and buf_addr are deferred
         to the overlap function (backed by SDPA buffer instead).
         When output_tensor is None, CB out descriptor is deferred to overlap function.
@@ -369,6 +371,7 @@ class MoeRoutedExpertOp:
 
         subblock_k = Kt // num_subblocks_k
         assert Kt % num_subblocks_k == 0, f"Kt ({Kt}) must be divisible by num_subblocks ({num_subblocks_k})"
+        assert subblock_k > 0, f"subblock_k is 0 (K={K}, Kt={Kt}, num_subblocks_k={num_subblocks_k})"
 
         weights_tile_size = weights_tile.get_tile_size(weights_tensor.dtype)
         in1_page_size, in1_num_pages = MoeOp.get_max_page_size_and_num_pages(device, subblock_k, weights_tile_size)
@@ -1069,7 +1072,7 @@ class MoeRoutedExpertOp:
             expert_scale_mcast_data_size_bytes = index_tile_size
 
         # ==================================================================
-        # DRAM Streaming Matmul: gate_proj
+        # DRAM Streaming Matmul: gate_proj (weights_tensor = list[0], single-expert K)
         # ==================================================================
         gate_proj_params = MoeRoutedExpertOp.setup_dram_matmul(
             device=device,
@@ -4323,7 +4326,8 @@ class MoeOp:
 
         Args:
             shared_residual_mcast_src_tensor: Input activation on sender core (provides device, dtype, K)
-            gate_proj_weights_tensor, up_proj_weights_tensor, down_proj_weights_tensor: Expert weights
+            gate_proj_weights_tensor, up_proj_weights_tensor, down_proj_weights_tensor: First expert
+            weight tensor per projection (base address; kernel strides by per-expert size)
             final_output_tensor: Final output tensor
             rmsnorm_gamma_tensor: RMSNorm gamma weights on sender core
             shared_gate_weights_overlapped: Gate proj OverlappedTensor

--- a/models/demos/deepseek_v3_b1/model.py
+++ b/models/demos/deepseek_v3_b1/model.py
@@ -39,7 +39,7 @@ import ttnn
 # Token IDs are int32 over the socket; payload size per step is B * TOKEN_ID_BYTES.
 TOKEN_ID_BYTES: int = 4
 
-# Socket page_size must be PCIe-aligned (see h2d_socket.cpp). Use 64 to work across devices.
+# Socket page_size must be PCIe-aligned (see h2d_socket.cpp). Must match demo stage TOKEN_PAGE_SIZE_BYTES (64).
 PCIE_PAGE_ALIGNMENT_BYTES: int = 64
 
 

--- a/models/demos/deepseek_v3_b1/prepare_weights.py
+++ b/models/demos/deepseek_v3_b1/prepare_weights.py
@@ -19,7 +19,6 @@ import time
 from dataclasses import dataclass, fields
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
 
 import torch
 from loguru import logger
@@ -62,20 +61,26 @@ _FIELD_TO_FUSION_GROUP: dict[str, str] = {
 
 @dataclass
 class AttentionWeights:
-    """Attention fusion groups: q_ab_kv_a + kv_b12 + o_proj_gate_mm_norms."""
+    """Attention fusion groups: q_ab_kv_a + kv_b12 + o_proj_gate_mm_norms (no gate routing)."""
 
     q_a_proj: OverlappedTensor
     q_b_proj: OverlappedTensor
     kv_a_proj: OverlappedTensor
     o_proj: OverlappedTensor
-    gate_mm: OverlappedTensor | None  # None for dense layers
     attn_norm: OverlappedTensor
     q_norm: OverlappedTensor
     kv_norm: OverlappedTensor
     ffn_norm: OverlappedTensor
     kv_b1_proj: OverlappedTensor
     kv_b2_proj: OverlappedTensor
-    gate_bias: ttnn.Tensor | None  # e_score_correction_bias for MoE only
+
+
+@dataclass
+class GateWeights:
+    """MoE gate routing weights."""
+
+    gate_mm: OverlappedTensor
+    gate_bias: ttnn.Tensor
 
 
 @dataclass
@@ -88,17 +93,13 @@ class SharedExpertWeights:
 
 
 @dataclass
-class DenseRoutedExpertWeights:
-    """Routed expert weights for dense layers (single tensor per proj)."""
+class RoutedExpertWeights:
+    """Routed expert weights — list of tensors per projection (one per expert).
 
-    routed_gate_proj: ttnn.Tensor
-    routed_up_proj: ttnn.Tensor
-    routed_down_proj: ttnn.Tensor
-
-
-@dataclass
-class MoERoutedExpertWeights:
-    """Routed expert weights for MoE layers (list of tensors, one per expert)."""
+    Dense: 1 element per list (single mesh-sharded tensor).
+    MoE: 256 elements per list (one ttnn.Tensor per expert).
+    Kernel uses list[0].buffer_address() as base and strides by per-expert size.
+    """
 
     routed_gate_proj: list[ttnn.Tensor]
     routed_up_proj: list[ttnn.Tensor]
@@ -107,74 +108,24 @@ class MoERoutedExpertWeights:
 
 @dataclass
 class DeepSeekV3DenseLayerWeights:
-    """Weights for a dense layer (0..first_k_dense_replace-1).
+    """Weights for a dense layer (0..first_k_dense_replace-1)."""
 
-    Has the 3 attention fusion groups and o_proj + norms (no gate_mm).
-    """
-
-    # From get_tt_q_ab_proj_and_kv_a_proj_weights
-    q_a_proj: OverlappedTensor
-    q_b_proj: OverlappedTensor
-    kv_a_proj: OverlappedTensor
-
-    # From get_tt_o_proj_and_gate_mm_weights (no gate_mm for dense)
-    o_proj: OverlappedTensor
-    attn_norm: OverlappedTensor
-    q_norm: OverlappedTensor
-    kv_norm: OverlappedTensor
-    ffn_norm: OverlappedTensor
-
-    # From get_tt_kv_b12_proj_weights
-    kv_b1_proj: OverlappedTensor
-    kv_b2_proj: OverlappedTensor
-
-    # From get_tt_mlp_shared_expert_weights
-    shared_gate_proj: OverlappedTensor
-    shared_up_proj: OverlappedTensor
-    shared_down_proj: ttnn.Tensor
-
-    # From get_tt_mlp_routed_expert_weights (1 DRAM expert per device)
-    routed_gate_proj: ttnn.Tensor
-    routed_up_proj: ttnn.Tensor
-    routed_down_proj: ttnn.Tensor
+    attention: AttentionWeights
+    shared_expert: SharedExpertWeights
+    routed_expert: RoutedExpertWeights
 
 
 @dataclass
 class DeepSeekV3MoELayerWeights:
-    """Weights for an MoE layer (first_k_dense_replace..num_layers-1).
+    """Weights for an MoE layer (first_k_dense_replace..num_layers-1)."""
 
-    Extends dense with gate_mm and shared expert projections.
-    """
+    attention: AttentionWeights
+    gate: GateWeights
+    shared_expert: SharedExpertWeights
+    routed_expert: RoutedExpertWeights
 
-    # From get_tt_q_ab_proj_and_kv_a_proj_weights
-    q_a_proj: OverlappedTensor
-    q_b_proj: OverlappedTensor
-    kv_a_proj: OverlappedTensor
 
-    # From get_tt_o_proj_and_gate_mm_weights (includes gate_mm)
-    o_proj: OverlappedTensor
-    gate_mm: OverlappedTensor
-    attn_norm: OverlappedTensor
-    q_norm: OverlappedTensor
-    kv_norm: OverlappedTensor
-    ffn_norm: OverlappedTensor
-
-    # MoE gate e_score_correction_bias (standalone)
-    gate_bias: ttnn.Tensor
-
-    # From get_tt_kv_b12_proj_weights
-    kv_b1_proj: OverlappedTensor
-    kv_b2_proj: OverlappedTensor
-
-    # From get_tt_moe_shared_expert_weights (replaces get_tt_gate_up_proj_weights)
-    shared_gate_proj: OverlappedTensor
-    shared_up_proj: OverlappedTensor
-    shared_down_proj: ttnn.Tensor
-
-    # From get_tt_moe_routed_expert_weights (256 DRAM experts)
-    routed_gate_proj: list[ttnn.Tensor]
-    routed_up_proj: list[ttnn.Tensor]
-    routed_down_proj: list[ttnn.Tensor]
+DeepSeekV3DecoderLayerWeights = DeepSeekV3MoELayerWeights | DeepSeekV3DenseLayerWeights
 
 
 @dataclass
@@ -194,6 +145,7 @@ class DeepSeekV3LMHeadWeights:
 
 # Constants for kv_b_proj split (HF stores one matrix; we split into kv_b1 and kv_b2).
 _NUM_HEADS = 64
+
 # MoE routed experts (DeepSeek V3 config: n_routed_experts=256).
 NUM_ROUTED_EXPERTS = 256
 _QK_NOPE_HEAD_DIM = 128
@@ -365,43 +317,6 @@ def _get_layer_raw_tensors(
     return q_a, q_b, kv_a, kv_b1, kv_b2, o_proj, attn_norm, q_norm, kv_norm, ffn_norm
 
 
-# Gate routing constants (bias/indices layout on sender core)
-_GATE_BIAS_INDICES_SHAPE = (16, 16)
-_GATE_NUM_INDICES = 256
-
-
-def create_gate_indices_tensor(
-    device: Any,
-    sender_core_grid: ttnn.CoreRangeSet,
-    *,
-    mesh_mapper: Any = None,
-) -> ttnn.Tensor:
-    """Build constant gate indices 0..255 as HEIGHT_SHARDED on sender core.
-
-    Same layout as gate_bias: (16, 16), HEIGHT_SHARDED, tile 16x16, uint16.
-    """
-    indices = torch.arange(_GATE_NUM_INDICES, dtype=torch.int32).reshape(
-        _GATE_BIAS_INDICES_SHAPE[0], _GATE_BIAS_INDICES_SHAPE[1]
-    )
-    transposed = torch.transpose(indices, 0, 1).contiguous().to(torch.uint16)
-    shard_spec = ttnn.ShardSpec(
-        sender_core_grid,
-        _GATE_BIAS_INDICES_SHAPE,
-        ttnn.ShardOrientation.ROW_MAJOR,
-    )
-    mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec)
-    kwargs = {"mesh_mapper": mesh_mapper} if mesh_mapper else {}
-    return ttnn.from_torch(
-        transposed,
-        dtype=ttnn.uint16,
-        layout=ttnn.TILE_LAYOUT,
-        device=device,
-        memory_config=mem_config,
-        tile=ttnn.Tile([16, 16]),
-        **kwargs,
-    )
-
-
 def prepare_attention_weights(
     bdw: BlitzDecodeWeights,
     state_dict: dict[str, torch.Tensor],
@@ -409,8 +324,10 @@ def prepare_attention_weights(
     *,
     is_moe: bool,
     move_to_device: bool = False,
-) -> AttentionWeights:
-    """Prepare attention fusion groups for one layer (q_ab_kv_a, kv_b12, o_proj_gate_mm_norms)."""
+) -> tuple[AttentionWeights, GateWeights | None]:
+    """Prepare attention fusion groups for one layer (q_ab_kv_a, kv_b12, o_proj_gate_mm_norms).
+    Returns (AttentionWeights, GateWeights | None). GateWeights is non-None only for MoE layers.
+    """
     logger.debug("Loading raw tensors from state dict for layer {}", layer_idx)
     t0 = time.perf_counter()
     q_a, q_b, kv_a, kv_b1, kv_b2, o_proj, attn_norm, q_norm, kv_norm, ffn_norm = _get_layer_raw_tensors(
@@ -439,20 +356,20 @@ def prepare_attention_weights(
             move_to_device=move_to_device,
         )
         logger.debug("  convert o_proj_gate_mm_norms (MoE): {:.3f}s", time.perf_counter() - t0)
-        return AttentionWeights(
+        attn = AttentionWeights(
             q_a_proj=q_a_proj,
             q_b_proj=q_b_proj,
             kv_a_proj=kv_a_proj,
             o_proj=o_proj_ot,
-            gate_mm=gate_mm_ot,
             attn_norm=attn_norm_ot,
             q_norm=q_norm_ot,
             kv_norm=kv_norm_ot,
             ffn_norm=ffn_norm_ot,
             kv_b1_proj=kv_b1_proj,
             kv_b2_proj=kv_b2_proj,
-            gate_bias=gate_bias_tt,
         )
+        gate = GateWeights(gate_mm=gate_mm_ot, gate_bias=gate_bias_tt)
+        return attn, gate
     else:
         gate_mm_dummy = torch.zeros(7168, 256, dtype=torch.bfloat16, device=next(iter(state_dict.values())).device)
         o_norms = bdw.get_tt_o_proj_and_gate_mm_weights(
@@ -460,20 +377,19 @@ def prepare_attention_weights(
         )
         o_proj_ot, _gate_mm_ot, attn_norm_ot, q_norm_ot, kv_norm_ot, ffn_norm_ot = o_norms
         logger.debug("  convert o_proj_gate_mm_norms (dense): {:.3f}s", time.perf_counter() - t0)
-        return AttentionWeights(
+        attn = AttentionWeights(
             q_a_proj=q_a_proj,
             q_b_proj=q_b_proj,
             kv_a_proj=kv_a_proj,
             o_proj=o_proj_ot,
-            gate_mm=None,
             attn_norm=attn_norm_ot,
             q_norm=q_norm_ot,
             kv_norm=kv_norm_ot,
             ffn_norm=ffn_norm_ot,
             kv_b1_proj=kv_b1_proj,
             kv_b2_proj=kv_b2_proj,
-            gate_bias=None,
         )
+        return attn, None
 
 
 def prepare_shared_expert_weights(
@@ -521,8 +437,8 @@ def prepare_routed_expert_weights(
     is_moe: bool,
     num_routed_experts: int = NUM_ROUTED_EXPERTS,
     move_to_device: bool = False,
-) -> DenseRoutedExpertWeights | MoERoutedExpertWeights:
-    """Prepare routed expert weights for one layer (dense: single MLP; MoE: num_routed_experts experts)."""
+) -> RoutedExpertWeights:
+    """Prepare routed expert weights for one layer (dense: single MLP; MoE: num_routed_experts experts stacked)."""
     if is_moe:
         logger.info(
             "Loading and converting {} routed experts for layer {} (this may be slow)...",
@@ -550,7 +466,7 @@ def prepare_routed_expert_weights(
             gate_stacked, up_stacked, down_stacked, move_to_device=move_to_device
         )
         logger.info("  converted routed experts in {:.3f}s", time.perf_counter() - t0)
-        return MoERoutedExpertWeights(
+        return RoutedExpertWeights(
             routed_gate_proj=routed_gate_proj,
             routed_up_proj=routed_up_proj,
             routed_down_proj=routed_down_proj,
@@ -559,14 +475,54 @@ def prepare_routed_expert_weights(
         mlp_gate = state_dict[_key(layer_idx, "mlp.gate_proj.weight")].T.contiguous()
         mlp_up = state_dict[_key(layer_idx, "mlp.up_proj.weight")].T.contiguous()
         mlp_down = state_dict[_key(layer_idx, "mlp.down_proj.weight")].T.contiguous()
-        routed_gate_proj, routed_up_proj, routed_down_proj = bdw.get_tt_mlp_routed_expert_weights(
+        gate_t, up_t, down_t = bdw.get_tt_mlp_routed_expert_weights(
             mlp_gate, mlp_up, mlp_down, move_to_device=move_to_device
         )
-        return DenseRoutedExpertWeights(
-            routed_gate_proj=routed_gate_proj,
-            routed_up_proj=routed_up_proj,
-            routed_down_proj=routed_down_proj,
+        return RoutedExpertWeights(
+            routed_gate_proj=[gate_t],
+            routed_up_proj=[up_t],
+            routed_down_proj=[down_t],
         )
+
+
+def prepare_decoder_layer_weights(
+    bdw: BlitzDecodeWeights,
+    state_dict: dict[str, torch.Tensor],
+    layer_idx: int,
+    *,
+    is_moe: bool,
+    move_to_device: bool = False,
+    num_routed_experts: int = NUM_ROUTED_EXPERTS,
+) -> DeepSeekV3DecoderLayerWeights:
+    """Prepare fused weights for a single decoder layer (dense or MoE)."""
+    logger.info("Preparing {} layer {}...", "MoE" if is_moe else "dense", layer_idx)
+    t0 = time.perf_counter()
+    attn, gate = prepare_attention_weights(bdw, state_dict, layer_idx, is_moe=is_moe, move_to_device=move_to_device)
+    shared = prepare_shared_expert_weights(bdw, state_dict, layer_idx, is_moe=is_moe, move_to_device=move_to_device)
+    routed = prepare_routed_expert_weights(
+        bdw,
+        state_dict,
+        layer_idx,
+        is_moe=is_moe,
+        num_routed_experts=num_routed_experts,
+        move_to_device=move_to_device,
+    )
+    if is_moe:
+        assert gate is not None
+        result: DeepSeekV3DecoderLayerWeights = DeepSeekV3MoELayerWeights(
+            attention=attn,
+            gate=gate,
+            shared_expert=shared,
+            routed_expert=routed,
+        )
+    else:
+        result = DeepSeekV3DenseLayerWeights(
+            attention=attn,
+            shared_expert=shared,
+            routed_expert=routed,
+        )
+    logger.info("  layer {} done in {:.3f}s", layer_idx, time.perf_counter() - t0)
+    return result
 
 
 def prepare_dense_layer_weights(
@@ -577,31 +533,9 @@ def prepare_dense_layer_weights(
     move_to_device: bool = False,
 ) -> DeepSeekV3DenseLayerWeights:
     """Prepare fused weights for a single dense decoder layer."""
-    logger.info("Preparing dense layer {}...", layer_idx)
-    t0 = time.perf_counter()
-    attn = prepare_attention_weights(bdw, state_dict, layer_idx, is_moe=False, move_to_device=move_to_device)
-    shared = prepare_shared_expert_weights(bdw, state_dict, layer_idx, is_moe=False, move_to_device=move_to_device)
-    routed = prepare_routed_expert_weights(bdw, state_dict, layer_idx, is_moe=False, move_to_device=move_to_device)
-    assert isinstance(routed, DenseRoutedExpertWeights)
-    return DeepSeekV3DenseLayerWeights(
-        q_a_proj=attn.q_a_proj,
-        q_b_proj=attn.q_b_proj,
-        kv_a_proj=attn.kv_a_proj,
-        o_proj=attn.o_proj,
-        attn_norm=attn.attn_norm,
-        q_norm=attn.q_norm,
-        kv_norm=attn.kv_norm,
-        ffn_norm=attn.ffn_norm,
-        kv_b1_proj=attn.kv_b1_proj,
-        kv_b2_proj=attn.kv_b2_proj,
-        shared_gate_proj=shared.shared_gate_proj,
-        shared_up_proj=shared.shared_up_proj,
-        shared_down_proj=shared.shared_down_proj,
-        routed_gate_proj=routed.routed_gate_proj,
-        routed_up_proj=routed.routed_up_proj,
-        routed_down_proj=routed.routed_down_proj,
-    )
-    logger.info("  dense layer {} done in {:.3f}s", layer_idx, time.perf_counter() - t0)
+    layer = prepare_decoder_layer_weights(bdw, state_dict, layer_idx, is_moe=False, move_to_device=move_to_device)
+    assert isinstance(layer, DeepSeekV3DenseLayerWeights)
+    return layer
 
 
 def prepare_moe_layer_weights(
@@ -612,37 +546,15 @@ def prepare_moe_layer_weights(
     num_routed_experts: int = NUM_ROUTED_EXPERTS,
 ) -> DeepSeekV3MoELayerWeights:
     """Prepare fused weights for a single MoE decoder layer."""
-    logger.info("Preparing MoE layer {}...", layer_idx)
-    t0 = time.perf_counter()
-    attn = prepare_attention_weights(bdw, state_dict, layer_idx, is_moe=True)
-    shared = prepare_shared_expert_weights(bdw, state_dict, layer_idx, is_moe=True)
-    routed = prepare_routed_expert_weights(
-        bdw, state_dict, layer_idx, is_moe=True, num_routed_experts=num_routed_experts
+    layer = prepare_decoder_layer_weights(
+        bdw,
+        state_dict,
+        layer_idx,
+        is_moe=True,
+        num_routed_experts=num_routed_experts,
     )
-    assert isinstance(attn.gate_mm, OverlappedTensor)
-    assert attn.gate_bias is not None
-    assert isinstance(routed, MoERoutedExpertWeights)
-    return DeepSeekV3MoELayerWeights(
-        q_a_proj=attn.q_a_proj,
-        q_b_proj=attn.q_b_proj,
-        kv_a_proj=attn.kv_a_proj,
-        o_proj=attn.o_proj,
-        gate_mm=attn.gate_mm,
-        attn_norm=attn.attn_norm,
-        q_norm=attn.q_norm,
-        kv_norm=attn.kv_norm,
-        ffn_norm=attn.ffn_norm,
-        gate_bias=attn.gate_bias,
-        kv_b1_proj=attn.kv_b1_proj,
-        kv_b2_proj=attn.kv_b2_proj,
-        shared_gate_proj=shared.shared_gate_proj,
-        shared_up_proj=shared.shared_up_proj,
-        shared_down_proj=shared.shared_down_proj,
-        routed_gate_proj=routed.routed_gate_proj,
-        routed_up_proj=routed.routed_up_proj,
-        routed_down_proj=routed.routed_down_proj,
-    )
-    logger.info("  MoE layer {} done in {:.3f}s", layer_idx, time.perf_counter() - t0)
+    assert isinstance(layer, DeepSeekV3MoELayerWeights)
+    return layer
 
 
 def _to_tt_embedding(embedding_torch: torch.Tensor, device, *, move_to_device: bool = False) -> ttnn.Tensor:
@@ -972,11 +884,14 @@ def save_attention_weights(
     layer_idx: int,
     *,
     is_moe: bool,
+    gate: GateWeights | None = None,
     hf_model_name: str = "",
     hf_state_dict_name: str = "",
     device_mesh_shape: tuple[int, int] = (1, 1),
 ) -> None:
-    """Save attention fusion groups to layer dir; merge into existing manifest if present."""
+    """Save attention fusion groups to layer dir; merge into existing manifest if present.
+    When is_moe is True, gate must be provided and gate_mm/gate_bias are saved from it.
+    """
     logger.debug("Saving attention weights for layer {}...", layer_idx)
     t0 = time.perf_counter()
     path = Path(path)
@@ -1003,12 +918,12 @@ def save_attention_weights(
         ("kv_b1_proj", attn.kv_b1_proj),
         ("kv_b2_proj", attn.kv_b2_proj),
     ]
-    if attn.gate_mm is not None:
-        field_tuples.append(("gate_mm", attn.gate_mm))
+    if gate is not None:
+        field_tuples.append(("gate_mm", gate.gate_mm))
     new_groups = _dump_overlapped_fusion_groups(layer_dir, field_tuples)
     manifest.setdefault("fusion_groups", {}).update(new_groups)
-    if attn.gate_bias is not None:
-        ttnn.dump_tensor(layer_dir / "gate_bias.tensorbin", attn.gate_bias)
+    if gate is not None:
+        ttnn.dump_tensor(layer_dir / "gate_bias.tensorbin", gate.gate_bias)
         manifest.setdefault("standalone_tensors", {})["gate_bias"] = "gate_bias.tensorbin"
     with open(layer_dir / "manifest.json", "w") as f:
         json.dump(manifest, f, indent=2)
@@ -1057,7 +972,7 @@ def save_shared_expert_weights(
 
 
 def save_routed_expert_weights(
-    routed: DenseRoutedExpertWeights | MoERoutedExpertWeights,
+    routed: RoutedExpertWeights,
     path: str | Path,
     layer_idx: int,
     *,
@@ -1066,7 +981,10 @@ def save_routed_expert_weights(
     hf_state_dict_name: str = "",
     device_mesh_shape: tuple[int, int] = (1, 1),
 ) -> None:
-    """Save routed expert weights to layer dir; merge into existing manifest if present."""
+    """Save routed expert weights to layer dir; merge into existing manifest if present.
+    MoE: experts/e_NNN/{gate,up,down}_proj.tensorbin (one dir per expert, 3 files each).
+    Dense: 1 file per projection in layer_dir (routed_gate_proj.tensorbin, etc.).
+    """
     path = Path(path)
     path.mkdir(parents=True, exist_ok=True)
     layer_dir = path / f"layer_{layer_idx:03d}"
@@ -1080,12 +998,10 @@ def save_routed_expert_weights(
         device_mesh_shape=device_mesh_shape,
     )
     standalone = manifest.setdefault("standalone_tensors", {})
+    logger.debug("Saving routed expert weights for layer {}...", layer_idx)
     if is_moe:
-        assert isinstance(routed, MoERoutedExpertWeights)
         num_experts = len(routed.routed_gate_proj)
         manifest["routed_experts"] = {"num_experts": num_experts}
-        logger.info("Saving {} routed experts for layer {} to disk (this may be slow)...", num_experts, layer_idx)
-        t0 = time.perf_counter()
         experts_dir = layer_dir / "experts"
         experts_dir.mkdir(parents=True, exist_ok=True)
         for e in range(num_experts):
@@ -1096,13 +1012,10 @@ def save_routed_expert_weights(
             ttnn.dump_tensor(expert_dir / "gate_proj.tensorbin", routed.routed_gate_proj[e])
             ttnn.dump_tensor(expert_dir / "up_proj.tensorbin", routed.routed_up_proj[e])
             ttnn.dump_tensor(expert_dir / "down_proj.tensorbin", routed.routed_down_proj[e])
-        logger.info("  saved {} routed experts in {:.3f}s", num_experts, time.perf_counter() - t0)
     else:
-        assert isinstance(routed, DenseRoutedExpertWeights)
-        logger.debug("Saving dense routed MLP for layer {}...", layer_idx)
-        ttnn.dump_tensor(layer_dir / "routed_gate_proj.tensorbin", routed.routed_gate_proj)
-        ttnn.dump_tensor(layer_dir / "routed_up_proj.tensorbin", routed.routed_up_proj)
-        ttnn.dump_tensor(layer_dir / "routed_down_proj.tensorbin", routed.routed_down_proj)
+        ttnn.dump_tensor(layer_dir / "routed_gate_proj.tensorbin", routed.routed_gate_proj[0])
+        ttnn.dump_tensor(layer_dir / "routed_up_proj.tensorbin", routed.routed_up_proj[0])
+        ttnn.dump_tensor(layer_dir / "routed_down_proj.tensorbin", routed.routed_down_proj[0])
         standalone["routed_gate_proj"] = "routed_gate_proj.tensorbin"
         standalone["routed_up_proj"] = "routed_up_proj.tensorbin"
         standalone["routed_down_proj"] = "routed_down_proj.tensorbin"
@@ -1111,7 +1024,7 @@ def save_routed_expert_weights(
 
 
 def save_decoder_layer(
-    layer: DeepSeekV3DenseLayerWeights | DeepSeekV3MoELayerWeights,
+    layer: DeepSeekV3DecoderLayerWeights,
     path: str | Path,
     layer_idx: int,
     *,
@@ -1129,42 +1042,16 @@ def save_decoder_layer(
     logger.info(f"Saving layer {layer_idx} to {layer_dir}...")
     is_moe = isinstance(layer, DeepSeekV3MoELayerWeights)
     save_decoder_layer_t0 = time.perf_counter()
-    attn = AttentionWeights(
-        q_a_proj=layer.q_a_proj,
-        q_b_proj=layer.q_b_proj,
-        kv_a_proj=layer.kv_a_proj,
-        o_proj=layer.o_proj,
-        gate_mm=getattr(layer, "gate_mm", None),
-        attn_norm=layer.attn_norm,
-        q_norm=layer.q_norm,
-        kv_norm=layer.kv_norm,
-        ffn_norm=layer.ffn_norm,
-        kv_b1_proj=layer.kv_b1_proj,
-        kv_b2_proj=layer.kv_b2_proj,
-        gate_bias=getattr(layer, "gate_bias", None),
-    )
-    shared = SharedExpertWeights(
-        shared_gate_proj=layer.shared_gate_proj,
-        shared_up_proj=layer.shared_up_proj,
-        shared_down_proj=layer.shared_down_proj,
-    )
-    if is_moe:
-        routed = MoERoutedExpertWeights(
-            routed_gate_proj=layer.routed_gate_proj,
-            routed_up_proj=layer.routed_up_proj,
-            routed_down_proj=layer.routed_down_proj,
-        )
-    else:
-        routed = DenseRoutedExpertWeights(
-            routed_gate_proj=layer.routed_gate_proj,
-            routed_up_proj=layer.routed_up_proj,
-            routed_down_proj=layer.routed_down_proj,
-        )
+    attn = layer.attention
+    shared = layer.shared_expert
+    routed = layer.routed_expert
+    gate = layer.gate if is_moe else None
     save_attention_weights(
         attn,
         path,
         layer_idx,
         is_moe=is_moe,
+        gate=gate,
         hf_model_name=hf_model_name,
         hf_state_dict_name=hf_state_dict_name,
         device_mesh_shape=device_mesh_shape,
@@ -1194,16 +1081,14 @@ def load_moe_routed_experts(
     path: str | Path,
     device,
     layer_idx: int,
-    *,
-    num_experts: int = NUM_ROUTED_EXPERTS,
-) -> MoERoutedExpertWeights:
+) -> RoutedExpertWeights:
     """Load only the routed expert weights for an MoE layer from cache.
 
     Reads experts/e_NNN/{gate,up,down}_proj.tensorbin. Since setup_fast_dispatch can
     only be used once per program, call this under setup_fast_dispatch and pass the
     result to load_moe_decoder_layer(..., preloaded_routed_experts=...). If you do
     not use fast dispatch, omit preloaded_routed_experts and load_moe_decoder_layer
-    will load experts from disk in the current dispatch mode.
+    will load from disk.
     """
     path = Path(path)
     layer_dir = path / f"layer_{layer_idx:03d}"
@@ -1214,9 +1099,9 @@ def load_moe_routed_experts(
         manifest = json.load(f)
     if manifest.get("layer_type") != "moe":
         raise ValueError(f"Layer {layer_idx} is not MoE (layer_type={manifest.get('layer_type')})")
-    num_experts = manifest.get("routed_experts", {}).get("num_experts", num_experts)
+    num_experts = manifest.get("routed_experts", {}).get("num_experts", NUM_ROUTED_EXPERTS)
     experts_dir = layer_dir / "experts"
-    logger.info("Loading {} routed experts for layer {} from cache...", num_experts, layer_idx)
+    logger.info("Loading routed experts for layer {} from cache...", layer_idx)
     t0 = time.perf_counter()
     routed_gate_proj = []
     routed_up_proj = []
@@ -1225,23 +1110,11 @@ def load_moe_routed_experts(
         if e > 0 and e % 64 == 0:
             logger.debug("  loaded experts 0..{}", e - 1)
         expert_dir = experts_dir / f"e_{e:03d}"
-        t_load_gate_t0 = time.perf_counter()
         routed_gate_proj.append(ttnn.load_tensor(expert_dir / "gate_proj.tensorbin", device=device))
-        t_load_gate = time.perf_counter() - t_load_gate_t0
-
-        t_load_up_t0 = time.perf_counter()
         routed_up_proj.append(ttnn.load_tensor(expert_dir / "up_proj.tensorbin", device=device))
-        t_load_up = time.perf_counter() - t_load_up_t0
-
-        t_load_down_t0 = time.perf_counter()
         routed_down_proj.append(ttnn.load_tensor(expert_dir / "down_proj.tensorbin", device=device))
-        t_load_down = time.perf_counter() - t_load_down_t0
-
-        logger.debug(
-            f"    Loaded expert {e}: gate_proj.tensorbin in {t_load_gate:.3f}s, up_proj.tensorbin in {t_load_up:.3f}s, down_proj.tensorbin in {t_load_down:.3f}s"
-        )
     logger.info("  routed experts for layer {} loaded in {:.3f}s", layer_idx, time.perf_counter() - t0)
-    return MoERoutedExpertWeights(
+    return RoutedExpertWeights(
         routed_gate_proj=routed_gate_proj,
         routed_up_proj=routed_up_proj,
         routed_down_proj=routed_down_proj,
@@ -1299,12 +1172,12 @@ def load_dense_decoder_layer(
 
     standalone = manifest.get("standalone_tensors", {})
     shared_down_proj = ttnn.load_tensor(layer_dir / standalone["shared_down_proj"], device=device)
-    routed_gate_proj = ttnn.load_tensor(layer_dir / standalone["routed_gate_proj"], device=device)
-    routed_up_proj = ttnn.load_tensor(layer_dir / standalone["routed_up_proj"], device=device)
-    routed_down_proj = ttnn.load_tensor(layer_dir / standalone["routed_down_proj"], device=device)
+    routed_gate_proj = [ttnn.load_tensor(layer_dir / standalone["routed_gate_proj"], device=device)]
+    routed_up_proj = [ttnn.load_tensor(layer_dir / standalone["routed_up_proj"], device=device)]
+    routed_down_proj = [ttnn.load_tensor(layer_dir / standalone["routed_down_proj"], device=device)]
     logger.info("  layer {} loaded in {:.3f}s", layer_idx, time.perf_counter() - load_t0)
 
-    return DeepSeekV3DenseLayerWeights(
+    attention = AttentionWeights(
         q_a_proj=q_a_proj,
         q_b_proj=q_b_proj,
         kv_a_proj=kv_a_proj,
@@ -1315,12 +1188,21 @@ def load_dense_decoder_layer(
         ffn_norm=ffn_norm,
         kv_b1_proj=kv_b1_proj,
         kv_b2_proj=kv_b2_proj,
+    )
+    shared_expert = SharedExpertWeights(
         shared_gate_proj=shared_gate_proj,
         shared_up_proj=shared_up_proj,
         shared_down_proj=shared_down_proj,
+    )
+    routed_expert = RoutedExpertWeights(
         routed_gate_proj=routed_gate_proj,
         routed_up_proj=routed_up_proj,
         routed_down_proj=routed_down_proj,
+    )
+    return DeepSeekV3DenseLayerWeights(
+        attention=attention,
+        shared_expert=shared_expert,
+        routed_expert=routed_expert,
     )
 
 
@@ -1329,12 +1211,12 @@ def load_moe_decoder_layer(
     device,
     layer_idx: int,
     *,
-    preloaded_routed_experts: MoERoutedExpertWeights | None = None,
+    preloaded_routed_experts: RoutedExpertWeights | None = None,
 ) -> DeepSeekV3MoELayerWeights:
     """Deserialize an MoE decoder layer from <path>/layer_{layer_idx:03d}/.
 
     If preloaded_routed_experts is provided (e.g. from load_moe_routed_experts under
-    setup_fast_dispatch, which can only be used once per program), those experts are
+    setup_fast_dispatch, which can only be used once per program), those weights are
     used. Otherwise routed experts are loaded from disk in the current dispatch mode.
     Fusion groups and standalone tensors are always loaded in the current dispatch mode.
     """
@@ -1388,28 +1270,30 @@ def load_moe_decoder_layer(
     standalone = manifest.get("standalone_tensors", {})
     shared_down_proj = ttnn.load_tensor(layer_dir / standalone["shared_down_proj"], device=device)
     gate_bias = ttnn.load_tensor(layer_dir / standalone["gate_bias"], device=device)
-    routed_gate_proj = preloaded_routed_experts.routed_gate_proj
-    routed_up_proj = preloaded_routed_experts.routed_up_proj
-    routed_down_proj = preloaded_routed_experts.routed_down_proj
+    routed_expert = preloaded_routed_experts
     logger.info("  layer {} loaded in {:.3f}s", layer_idx, time.perf_counter() - load_t0)
 
-    return DeepSeekV3MoELayerWeights(
+    attention = AttentionWeights(
         q_a_proj=q_a_proj,
         q_b_proj=q_b_proj,
         kv_a_proj=kv_a_proj,
         o_proj=o_proj,
-        gate_mm=gate_mm,
         attn_norm=attn_norm,
         q_norm=q_norm,
         kv_norm=kv_norm,
         ffn_norm=ffn_norm,
-        gate_bias=gate_bias,
         kv_b1_proj=kv_b1_proj,
         kv_b2_proj=kv_b2_proj,
+    )
+    gate = GateWeights(gate_mm=gate_mm, gate_bias=gate_bias)
+    shared_expert = SharedExpertWeights(
         shared_gate_proj=shared_gate_proj,
         shared_up_proj=shared_up_proj,
         shared_down_proj=shared_down_proj,
-        routed_gate_proj=routed_gate_proj,
-        routed_up_proj=routed_up_proj,
-        routed_down_proj=routed_down_proj,
+    )
+    return DeepSeekV3MoELayerWeights(
+        attention=attention,
+        gate=gate,
+        shared_expert=shared_expert,
+        routed_expert=routed_expert,
     )

--- a/models/demos/deepseek_v3_b1/prepare_weights.py
+++ b/models/demos/deepseek_v3_b1/prepare_weights.py
@@ -37,9 +37,9 @@ _DTYPE_TO_STR = {
 }
 _STR_TO_DTYPE = {v: k for k, v in _DTYPE_TO_STR.items()}
 
-# MoE gate bias: HEIGHT_SHARDED on sender core (10, 9), tile [16, 16]
-_MOE_SENDER_CORE = ttnn.CoreCoord(10, 9)
-_MOE_SENDER_CORE_GRID = ttnn.CoreRangeSet([ttnn.CoreRange(_MOE_SENDER_CORE, _MOE_SENDER_CORE)])
+# MoE sender core: hardcoded grid (13, 10) so cache layout is consistent across slow/fast dispatch.
+# Sender core = (grid.x - 1, grid.y - 1) = (12, 9); must match test_moe_mlp create_runtime_tensors.
+MOE_SENDER_GRID_SIZE = (13, 10)
 _GATE_BIAS_TILE = ttnn.Tile([16, 16])
 
 # Fusion group name per field (for grouping by fused_tensor)
@@ -207,6 +207,34 @@ def _key(layer_idx: int, suffix: str) -> str:
     return f"model.layers.{layer_idx}.{suffix}"
 
 
+def create_gate_bias_tensor(raw_tensor: torch.Tensor, device, *, move_to_device: bool = False) -> ttnn.Tensor:
+    """Build gate_bias (e_score_correction_bias) as HEIGHT_SHARDED on sender core, replicated across mesh.
+
+    raw_tensor: shape (256,) from state dict (model.layers.{i}.mlp.gate.e_score_correction_bias).
+    Returns ttnn.Tensor with layout expected by MoE op: (16, 16) on sender core, tile 16x16.
+    Sender core uses MOE_SENDER_GRID_SIZE so cache layout is consistent across slow/fast dispatch.
+    When move_to_device is False (default), tensor is not placed (device=None) for cache generation.
+    When move_to_device is True, tensor is placed on device so is_sharded() is true for runtime use.
+    """
+    sender_core = ttnn.CoreCoord(MOE_SENDER_GRID_SIZE[0] - 1, MOE_SENDER_GRID_SIZE[1] - 1)
+    sender_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(sender_core, sender_core)])
+    gate_bias_reshaped = raw_tensor.reshape(16, 16).T.contiguous().to(torch.bfloat16)
+    gate_bias_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(sender_core_grid, (16, 16), ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    return ttnn.from_torch(
+        gate_bias_reshaped,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device if move_to_device else None,
+        memory_config=gate_bias_mem_config,
+        tile=_GATE_BIAS_TILE,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(device),
+    )
+
+
 def _split_kv_b_proj(kv_b_proj: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
     """Split HF kv_b_proj (out_features, in_features) into kv_b1 and kv_b2.
 
@@ -342,46 +370,6 @@ _GATE_BIAS_INDICES_SHAPE = (16, 16)
 _GATE_NUM_INDICES = 256
 
 
-def create_gate_bias_tensor(
-    raw: torch.Tensor,
-    device: Any,
-    sender_core_grid: ttnn.CoreRangeSet,
-    *,
-    mesh_mapper: Any = None,
-) -> ttnn.Tensor:
-    """Build gate bias (e_score_correction_bias) as HEIGHT_SHARDED on sender core.
-
-    Args:
-        raw: Shape (256,) from state dict mlp.gate.e_score_correction_bias.
-        device: ttnn device or mesh device.
-        sender_core_grid: Single-core range set for the sender core.
-        mesh_mapper: Optional mesh mapper for multi-device.
-
-    Returns:
-        ttnn.Tensor with shape (16, 16), HEIGHT_SHARDED on sender_core_grid, tile 16x16, bfloat16.
-    """
-    assert raw.shape == (_GATE_NUM_INDICES,), f"gate bias raw must be ({_GATE_NUM_INDICES},), got {raw.shape}"
-    # (256,) -> (1, 8, 32) -> (16, 16) then transpose to match op layout
-    reshaped = raw.reshape(1, 8, 32).reshape(_GATE_BIAS_INDICES_SHAPE[0], _GATE_BIAS_INDICES_SHAPE[1])
-    transposed = torch.transpose(reshaped, 0, 1).contiguous().to(torch.bfloat16)
-    shard_spec = ttnn.ShardSpec(
-        sender_core_grid,
-        _GATE_BIAS_INDICES_SHAPE,
-        ttnn.ShardOrientation.ROW_MAJOR,
-    )
-    mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec)
-    kwargs = {"mesh_mapper": mesh_mapper} if mesh_mapper else {}
-    return ttnn.from_torch(
-        transposed,
-        dtype=ttnn.bfloat16,
-        layout=ttnn.TILE_LAYOUT,
-        device=device,
-        memory_config=mem_config,
-        tile=ttnn.Tile([16, 16]),
-        **kwargs,
-    )
-
-
 def create_gate_indices_tensor(
     device: Any,
     sender_core_grid: ttnn.CoreRangeSet,
@@ -448,8 +436,7 @@ def prepare_attention_weights(
         gate_bias_tt = create_gate_bias_tensor(
             state_dict[_key(layer_idx, "mlp.gate.e_score_correction_bias")],
             bdw._device,
-            _MOE_SENDER_CORE_GRID,
-            mesh_mapper=ttnn.ReplicateTensorToMesh(bdw._device),
+            move_to_device=move_to_device,
         )
         logger.debug("  convert o_proj_gate_mm_norms (MoE): {:.3f}s", time.perf_counter() - t0)
         return AttentionWeights(

--- a/models/demos/deepseek_v3_b1/prepare_weights.py
+++ b/models/demos/deepseek_v3_b1/prepare_weights.py
@@ -573,13 +573,15 @@ def prepare_dense_layer_weights(
     bdw: BlitzDecodeWeights,
     state_dict: dict[str, torch.Tensor],
     layer_idx: int,
+    *,
+    move_to_device: bool = False,
 ) -> DeepSeekV3DenseLayerWeights:
     """Prepare fused weights for a single dense decoder layer."""
     logger.info("Preparing dense layer {}...", layer_idx)
     t0 = time.perf_counter()
-    attn = prepare_attention_weights(bdw, state_dict, layer_idx, is_moe=False)
-    shared = prepare_shared_expert_weights(bdw, state_dict, layer_idx, is_moe=False)
-    routed = prepare_routed_expert_weights(bdw, state_dict, layer_idx, is_moe=False)
+    attn = prepare_attention_weights(bdw, state_dict, layer_idx, is_moe=False, move_to_device=move_to_device)
+    shared = prepare_shared_expert_weights(bdw, state_dict, layer_idx, is_moe=False, move_to_device=move_to_device)
+    routed = prepare_routed_expert_weights(bdw, state_dict, layer_idx, is_moe=False, move_to_device=move_to_device)
     assert isinstance(routed, DenseRoutedExpertWeights)
     return DeepSeekV3DenseLayerWeights(
         q_a_proj=attn.q_a_proj,

--- a/models/demos/deepseek_v3_b1/scripts/generate_cache.py
+++ b/models/demos/deepseek_v3_b1/scripts/generate_cache.py
@@ -5,17 +5,17 @@
 """
 Generate weight cache for DeepSeek V3 from HuggingFace safetensors.
 
+Runs in fast dispatch; weights are prepared and saved to disk (no device placement).
+
 Modes:
-  dense     - Full dense layer (layers 0-2). Requires slow dispatch.
-  moe       - Attention + shared experts only (layers 3-60). Requires slow dispatch.
-  experts   - Routed experts only (layers 3-60). Can run in fast dispatch.
+  dense     - Full dense layer (layers 0-2).
+  moe       - Full MoE layer (layers 3-60): attention + shared experts + routed experts.
   embedding - Embedding layer (model.embed_tokens). No --layer-num needed.
   lm_head   - LM head + final RMSNorm. No --layer-num needed.
 
 Usage:
   python generate_cache.py --model-path /path/to/DeepSeek-V3 --output-path /path/to/cache --layer-num 0 --type dense
   python generate_cache.py --model-path /path/to/DeepSeek-V3 --output-path /path/to/cache --layer-num 4 --type moe
-  python generate_cache.py --model-path /path/to/DeepSeek-V3 --output-path /path/to/cache --layer-num 4 --type experts
   python generate_cache.py --model-path /path/to/DeepSeek-V3 --output-path /path/to/cache --type embedding
   python generate_cache.py --model-path /path/to/DeepSeek-V3 --output-path /path/to/cache --type lm_head
 """
@@ -35,7 +35,6 @@ import ttnn
 
 # Same mesh device setup as test_prepare_weights.py (bh_2d_mesh_device fixture).
 from conftest import bh_2d_mesh_device_context
-from models.common.utility_functions import is_slow_dispatch
 from models.demos.deepseek_v3.utils.lazy_state_dict import LazyStateDict
 from models.demos.deepseek_v3_b1.blitz_decode_weights import BlitzDecodeWeights
 from models.demos.deepseek_v3_b1.prepare_weights import (
@@ -48,18 +47,13 @@ from models.demos.deepseek_v3_b1.prepare_weights import (
     load_embedding_weights,
     load_lm_head_weights,
     load_moe_decoder_layer,
-    prepare_attention_weights,
     prepare_dense_layer_weights,
     prepare_embedding_weights,
     prepare_lm_head_weights,
-    prepare_routed_expert_weights,
-    prepare_shared_expert_weights,
-    save_attention_weights,
+    prepare_moe_layer_weights,
     save_decoder_layer,
     save_embedding_weights,
     save_lm_head_weights,
-    save_routed_expert_weights,
-    save_shared_expert_weights,
 )
 
 NUM_LAYERS = 61
@@ -68,14 +62,6 @@ DEVICE_MESH_SHAPE = (4, 2)
 MANIFEST_VERSION = 1
 HF_MODEL_NAME = "deepseek-ai/DeepSeek-V3"
 HF_STATE_DICT_NAME = "lazy"
-
-# Fusion group tensorbin names written by save_attention_weights / save_shared_expert_weights (moe mode)
-MOE_FUSION_FILES = (
-    "q_ab_kv_a.tensorbin",
-    "o_proj_gate_mm_norms.tensorbin",
-    "kv_b12.tensorbin",
-    "gate_up.tensorbin",
-)
 
 # Expected tensor_topology() placements for 4x2 mesh (mla_tp=2, moe_tp=8); used by verify device load.
 _PLACEMENTS_SHARD_NONE_1 = [ttnn.PlacementReplicate(), ttnn.PlacementShard(1)]  # q_ab_kv_a, o_proj_gate_mm_norms
@@ -104,14 +90,14 @@ def _create_parser() -> argparse.ArgumentParser:
         "--layer-num",
         type=int,
         default=None,
-        help="Layer index (0-60); required for dense/moe/experts, ignored for embedding/lm_head",
+        help="Layer index (0-60); required for dense/moe, ignored for embedding/lm_head",
     )
     parser.add_argument(
         "--type",
         dest="mode",
-        choices=("dense", "moe", "experts", "embedding", "lm_head"),
+        choices=("dense", "moe", "embedding", "lm_head"),
         required=True,
-        help="Cache type: dense (layers 0-2), moe (attn+shared for 3-60), experts (routed only for 3-60), embedding, lm_head",
+        help="Cache type: dense (layers 0-2), moe (full layer for 3-60), embedding, lm_head",
     )
     parser.add_argument(
         "--force",
@@ -133,7 +119,7 @@ def _validate_args(args: argparse.Namespace) -> None:
     output_path = args.output_path.resolve()
 
     # Layer-num required and validated only for layer-based modes
-    if mode in ("dense", "moe", "experts"):
+    if mode in ("dense", "moe"):
         if layer_num is None:
             logger.error("--layer-num is required for type={}", mode)
             sys.exit(1)
@@ -152,8 +138,7 @@ def _validate_args(args: argparse.Namespace) -> None:
         else:
             if layer_num < FIRST_K_DENSE_REPLACE:
                 logger.error(
-                    "type={} requires layer-num >= {} (MoE layers are {}-{}), got {}",
-                    mode,
+                    "type=moe requires layer-num >= {} (MoE layers are {}-{}), got {}",
                     FIRST_K_DENSE_REPLACE,
                     FIRST_K_DENSE_REPLACE,
                     NUM_LAYERS - 1,
@@ -214,45 +199,13 @@ def _validate_args(args: argparse.Namespace) -> None:
                 sys.exit(1)
         else:
             layer_dir = output_path / f"layer_{layer_num:03d}"
-            if mode == "dense":
-                manifest = layer_dir / "manifest.json"
-                if manifest.exists():
-                    logger.error(
-                        "Layer {} cache already exists (manifest.json). Use --force to overwrite.",
-                        layer_num,
-                    )
-                    sys.exit(1)
-            elif mode == "moe":
-                for name in MOE_FUSION_FILES:
-                    f = layer_dir / name
-                    if f.exists():
-                        logger.error(
-                            "Layer {} already has {} (moe cache). Use --force to overwrite.",
-                            layer_num,
-                            name,
-                        )
-                        sys.exit(1)
-            else:
-                experts_dir = layer_dir / "experts"
-                if experts_dir.exists():
-                    logger.error(
-                        "Layer {} already has experts/ directory. Use --force to overwrite.",
-                        layer_num,
-                    )
-                    sys.exit(1)
-
-    # Dispatch mode: dense and moe require slow dispatch; experts can use either, warn if slow; embedding/lm_head no requirement
-    if mode in ("dense", "moe"):
-        if not is_slow_dispatch():
-            logger.warning(
-                "type={} requires slow dispatch mode. Set TT_METAL_SLOW_DISPATCH_MODE=1 and rerun.",
-                mode,
-            )
-    elif mode == "experts":
-        if is_slow_dispatch():
-            logger.warning(
-                "experts mode can run in fast dispatch; you have TT_METAL_SLOW_DISPATCH_MODE=1 set (slow dispatch)."
-            )
+            manifest = layer_dir / "manifest.json"
+            if manifest.exists():
+                logger.error(
+                    "Layer {} cache already exists (manifest.json). Use --force to overwrite.",
+                    layer_num,
+                )
+                sys.exit(1)
 
 
 def _check_file(path: Path, layer_dir: Path) -> bool:
@@ -494,8 +447,9 @@ def _verify_cache(output_path: Path, layer_num: int, mode: str) -> bool:
             logger.error("Expected layer_type 'dense', got '{}'", layer_type)
             return False
     else:
+        assert mode == "moe"
         if layer_type != "moe":
-            logger.error("Expected layer_type 'moe' for mode {}, got '{}'", mode, layer_type)
+            logger.error("Expected layer_type 'moe', got '{}'", layer_type)
             return False
 
     fusion_groups = manifest.get("fusion_groups", {})
@@ -520,21 +474,20 @@ def _verify_cache(output_path: Path, layer_num: int, mode: str) -> bool:
             if not _check_file(Path(standalone_tensors[name]), layer_dir):
                 return False
         logger.info("All dense layer files present")
-    elif mode == "moe":
+    else:
+        # Full MoE layer: fusion groups + standalone (incl. gate_bias) + routed experts
         for name in ("q_ab_kv_a", "o_proj_gate_mm_norms", "kv_b12", "gate_up"):
             if name not in fusion_groups:
                 logger.error("Missing fusion_groups['{}']", name)
                 return False
             if not _check_file(Path(fusion_groups[name]["tensorbin"]), layer_dir):
                 return False
-        if "shared_down_proj" not in standalone_tensors:
-            logger.error("Missing standalone_tensors['shared_down_proj']")
-            return False
-        if not _check_file(Path(standalone_tensors["shared_down_proj"]), layer_dir):
-            return False
-        logger.info("All moe (attn+shared) files present")
-    else:
-        assert mode == "experts"
+        for name in ("shared_down_proj", "gate_bias"):
+            if name not in standalone_tensors:
+                logger.error("Missing standalone_tensors['{}']", name)
+                return False
+            if not _check_file(Path(standalone_tensors[name]), layer_dir):
+                return False
         routed = manifest.get("routed_experts", {})
         num_experts = routed.get("num_experts", 0)
         if num_experts != NUM_ROUTED_EXPERTS:
@@ -552,20 +505,10 @@ def _verify_cache(output_path: Path, layer_num: int, mode: str) -> bool:
             for fname in ("gate_proj.tensorbin", "up_proj.tensorbin", "down_proj.tensorbin"):
                 if not _check_file(expert_dir / fname, layer_dir):
                     return False
-        logger.info("All {} expert files present", NUM_ROUTED_EXPERTS)
+        logger.info("All MoE layer files present (attn+shared+experts)")
 
     # 3. Optional device load when cache is a complete layer
-    full_layer = False
-    if mode == "dense":
-        full_layer = True
-    elif mode == "moe":
-        experts_dir = layer_dir / "experts"
-        if experts_dir.is_dir():
-            n = sum(1 for _ in experts_dir.iterdir() if _.is_dir())
-            if n >= NUM_ROUTED_EXPERTS:
-                full_layer = True
-
-    if full_layer:
+    if True:
         logger.info("Cache is complete layer; loading to device for sanity check...")
         if not os.environ.get("TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS"):
             os.environ["TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS"] = "30000"
@@ -611,8 +554,6 @@ def _verify_cache(output_path: Path, layer_num: int, mode: str) -> bool:
         except Exception as e:
             logger.error("Device load failed: {}", e)
             return False
-    else:
-        logger.info("Cache is partial (moe-only or experts-only); skipping device load")
 
     logger.info("Verify OK")
     return True
@@ -690,34 +631,21 @@ def main() -> int:
                 )
                 logger.info("save_decoder_layer took {:.3f}s", time.perf_counter() - t0)
             elif mode == "moe":
-                logger.info("Preparing attention weights (MoE)...")
+                logger.info("Preparing full MoE layer weights...")
                 t0 = time.perf_counter()
-                attn = prepare_attention_weights(bdw, state_dict, layer_num, is_moe=True)
-                logger.info("prepare_attention_weights took {:.3f}s", time.perf_counter() - t0)
-                logger.info("Saving attention weights...")
+                layer = prepare_moe_layer_weights(bdw, state_dict, layer_num)
+                logger.info("prepare_moe_layer_weights took {:.3f}s", time.perf_counter() - t0)
+                logger.info("Saving MoE layer to disk...")
                 t0 = time.perf_counter()
-                save_attention_weights(
-                    attn,
+                save_decoder_layer(
+                    layer,
                     output_path,
                     layer_num,
-                    is_moe=True,
-                    **manifest_kw,
+                    hf_model_name=manifest_kw["hf_model_name"],
+                    hf_state_dict_name=manifest_kw["hf_state_dict_name"],
+                    device_mesh_shape=manifest_kw["device_mesh_shape"],
                 )
-                logger.info("save_attention_weights took {:.3f}s", time.perf_counter() - t0)
-                logger.info("Preparing shared expert weights...")
-                t0 = time.perf_counter()
-                shared = prepare_shared_expert_weights(bdw, state_dict, layer_num, is_moe=True)
-                logger.info("prepare_shared_expert_weights took {:.3f}s", time.perf_counter() - t0)
-                logger.info("Saving shared expert weights...")
-                t0 = time.perf_counter()
-                save_shared_expert_weights(
-                    shared,
-                    output_path,
-                    layer_num,
-                    is_moe=True,
-                    **manifest_kw,
-                )
-                logger.info("save_shared_expert_weights took {:.3f}s", time.perf_counter() - t0)
+                logger.info("save_decoder_layer took {:.3f}s", time.perf_counter() - t0)
             elif mode == "embedding":
                 logger.info("Preparing embedding weights...")
                 t0 = time.perf_counter()
@@ -736,28 +664,6 @@ def main() -> int:
                 t0 = time.perf_counter()
                 save_lm_head_weights(weights, output_path, **manifest_kw)
                 logger.info("save_lm_head_weights took {:.3f}s", time.perf_counter() - t0)
-            else:
-                assert mode == "experts"
-                logger.info("Preparing routed expert weights (num_routed_experts={})...", NUM_ROUTED_EXPERTS)
-                t0 = time.perf_counter()
-                routed = prepare_routed_expert_weights(
-                    bdw,
-                    state_dict,
-                    layer_num,
-                    is_moe=True,
-                    num_routed_experts=NUM_ROUTED_EXPERTS,
-                )
-                logger.info("prepare_routed_expert_weights took {:.3f}s", time.perf_counter() - t0)
-                logger.info("Saving routed expert weights...")
-                t0 = time.perf_counter()
-                save_routed_expert_weights(
-                    routed,
-                    output_path,
-                    layer_num,
-                    is_moe=True,
-                    **manifest_kw,
-                )
-                logger.info("save_routed_expert_weights took {:.3f}s", time.perf_counter() - t0)
 
     elapsed = time.perf_counter() - total_t0
     if mode in ("embedding", "lm_head"):

--- a/models/demos/deepseek_v3_b1/scripts/generate_cache.py
+++ b/models/demos/deepseek_v3_b1/scripts/generate_cache.py
@@ -259,72 +259,71 @@ def _verify_layer_on_4x2_grid(
 ) -> bool:
     """Verify all tensors are on device and have correct tensor_topology() for 4x2 mesh. Returns False on first failure."""
     seen_fused: set[int] = set()
+    attn = loaded.attention
+    shared = loaded.shared_expert
+    routed = loaded.routed_expert
     # q_ab_kv_a
-    if not _check_on_device(loaded.q_a_proj.fused_tensor, "q_a_proj.fused_tensor"):
+    if not _check_on_device(attn.q_a_proj.fused_tensor, "q_a_proj.fused_tensor"):
         return False
-    fid = id(loaded.q_a_proj.fused_tensor)
+    fid = id(attn.q_a_proj.fused_tensor)
     if fid not in seen_fused:
         seen_fused.add(fid)
-        if not _check_topology(loaded.q_a_proj.fused_tensor, _PLACEMENTS_SHARD_NONE_1, "q_ab_kv_a"):
+        if not _check_topology(attn.q_a_proj.fused_tensor, _PLACEMENTS_SHARD_NONE_1, "q_ab_kv_a"):
             return False
     # o_proj_gate_mm_norms
-    if not _check_on_device(loaded.o_proj.fused_tensor, "o_proj.fused_tensor"):
+    if not _check_on_device(attn.o_proj.fused_tensor, "o_proj.fused_tensor"):
         return False
-    fid = id(loaded.o_proj.fused_tensor)
+    fid = id(attn.o_proj.fused_tensor)
     if fid not in seen_fused:
         seen_fused.add(fid)
-        if not _check_topology(loaded.o_proj.fused_tensor, _PLACEMENTS_SHARD_NONE_1, "o_proj_gate_mm_norms"):
+        if not _check_topology(attn.o_proj.fused_tensor, _PLACEMENTS_SHARD_NONE_1, "o_proj_gate_mm_norms"):
+            return False
+    # MoE gate (optional)
+    if isinstance(loaded, DeepSeekV3MoELayerWeights):
+        if not _check_on_device(loaded.gate.gate_mm.fused_tensor, "gate_mm.fused_tensor"):
+            return False
+        if not _check_on_device(loaded.gate.gate_bias, "gate_bias"):
             return False
     # kv_b12
-    if not _check_on_device(loaded.kv_b1_proj.fused_tensor, "kv_b1_proj.fused_tensor"):
+    if not _check_on_device(attn.kv_b1_proj.fused_tensor, "kv_b1_proj.fused_tensor"):
         return False
-    fid = id(loaded.kv_b1_proj.fused_tensor)
+    fid = id(attn.kv_b1_proj.fused_tensor)
     if fid not in seen_fused:
         seen_fused.add(fid)
-        if not _check_topology(loaded.kv_b1_proj.fused_tensor, _PLACEMENTS_SHARD_NONE_0, "kv_b12"):
+        if not _check_topology(attn.kv_b1_proj.fused_tensor, _PLACEMENTS_SHARD_NONE_0, "kv_b12"):
             return False
     # gate_up
-    if not _check_on_device(loaded.shared_gate_proj.fused_tensor, "shared_gate_proj.fused_tensor"):
+    if not _check_on_device(shared.shared_gate_proj.fused_tensor, "shared_gate_proj.fused_tensor"):
         return False
-    fid = id(loaded.shared_gate_proj.fused_tensor)
+    fid = id(shared.shared_gate_proj.fused_tensor)
     if fid not in seen_fused:
         seen_fused.add(fid)
-        if not _check_topology(loaded.shared_gate_proj.fused_tensor, _PLACEMENTS_SHARD_0_1, "gate_up"):
+        if not _check_topology(shared.shared_gate_proj.fused_tensor, _PLACEMENTS_SHARD_0_1, "gate_up"):
             return False
     # shared_down_proj
-    if not _check_on_device(loaded.shared_down_proj, "shared_down_proj"):
+    if not _check_on_device(shared.shared_down_proj, "shared_down_proj"):
         return False
-    if not _check_topology(loaded.shared_down_proj, _PLACEMENTS_SHARD_0_1, "shared_down_proj"):
+    if not _check_topology(shared.shared_down_proj, _PLACEMENTS_SHARD_0_1, "shared_down_proj"):
         return False
-    # Routed experts
-    if isinstance(loaded, DeepSeekV3DenseLayerWeights):
-        if not _check_on_device(loaded.routed_gate_proj, "routed_gate_proj"):
+    # Routed experts (list of tensors per projection)
+    for i, t in enumerate(routed.routed_gate_proj):
+        if not _check_on_device(t, f"routed_gate_proj[{i}]"):
             return False
-        if not _check_on_device(loaded.routed_up_proj, "routed_up_proj"):
+    for i, t in enumerate(routed.routed_up_proj):
+        if not _check_on_device(t, f"routed_up_proj[{i}]"):
             return False
-        if not _check_on_device(loaded.routed_down_proj, "routed_down_proj"):
+    for i, t in enumerate(routed.routed_down_proj):
+        if not _check_on_device(t, f"routed_down_proj[{i}]"):
             return False
-        if not _check_topology(loaded.routed_gate_proj, _PLACEMENTS_SHARD_0_1, "routed_gate_proj"):
-            return False
-        if not _check_topology(loaded.routed_up_proj, _PLACEMENTS_SHARD_0_1, "routed_up_proj"):
-            return False
-        if not _check_topology(loaded.routed_down_proj, _PLACEMENTS_SHARD_0_1, "routed_down_proj"):
-            return False
-    else:
-        assert isinstance(loaded, DeepSeekV3MoELayerWeights)
-        for e in range(len(loaded.routed_gate_proj)):
-            if not _check_on_device(loaded.routed_gate_proj[e], f"routed_gate_proj[{e}]"):
-                return False
-            if not _check_on_device(loaded.routed_up_proj[e], f"routed_up_proj[{e}]"):
-                return False
-            if not _check_on_device(loaded.routed_down_proj[e], f"routed_down_proj[{e}]"):
-                return False
-            if not _check_topology(loaded.routed_gate_proj[e], _PLACEMENTS_REPLICATE, f"routed_gate_proj[{e}]"):
-                return False
-            if not _check_topology(loaded.routed_up_proj[e], _PLACEMENTS_REPLICATE, f"routed_up_proj[{e}]"):
-                return False
-            if not _check_topology(loaded.routed_down_proj[e], _PLACEMENTS_REPLICATE, f"routed_down_proj[{e}]"):
-                return False
+    routed_placements = (
+        _PLACEMENTS_SHARD_0_1 if isinstance(loaded, DeepSeekV3DenseLayerWeights) else _PLACEMENTS_REPLICATE
+    )
+    if not _check_topology(routed.routed_gate_proj[0], routed_placements, "routed_gate_proj"):
+        return False
+    if not _check_topology(routed.routed_up_proj[0], routed_placements, "routed_up_proj"):
+        return False
+    if not _check_topology(routed.routed_down_proj[0], routed_placements, "routed_down_proj"):
+        return False
     return True
 
 
@@ -475,14 +474,15 @@ def _verify_cache(output_path: Path, layer_num: int, mode: str) -> bool:
                 return False
         logger.info("All dense layer files present")
     else:
-        # Full MoE layer: fusion groups + standalone (incl. gate_bias) + routed experts
+        # Full MoE layer: fusion groups + standalone (incl. gate_bias) + stacked routed experts
         for name in ("q_ab_kv_a", "o_proj_gate_mm_norms", "kv_b12", "gate_up"):
             if name not in fusion_groups:
                 logger.error("Missing fusion_groups['{}']", name)
                 return False
             if not _check_file(Path(fusion_groups[name]["tensorbin"]), layer_dir):
                 return False
-        for name in ("shared_down_proj", "gate_bias"):
+        required_standalone_moe = ("shared_down_proj", "gate_bias")
+        for name in required_standalone_moe:
             if name not in standalone_tensors:
                 logger.error("Missing standalone_tensors['{}']", name)
                 return False
@@ -493,19 +493,15 @@ def _verify_cache(output_path: Path, layer_num: int, mode: str) -> bool:
         if num_experts != NUM_ROUTED_EXPERTS:
             logger.error("Expected routed_experts.num_experts={}, got {}", NUM_ROUTED_EXPERTS, num_experts)
             return False
+        # Per-expert routed weight files (experts/e_NNN/{gate,up,down}_proj.tensorbin)
         experts_dir = layer_dir / "experts"
-        if not experts_dir.is_dir():
-            logger.error("experts/ directory missing: {}", experts_dir)
-            return False
-        for e in range(NUM_ROUTED_EXPERTS):
+        for e in range(num_experts):
             expert_dir = experts_dir / f"e_{e:03d}"
-            if not expert_dir.is_dir():
-                logger.error("Expert dir missing: {}", expert_dir)
-                return False
-            for fname in ("gate_proj.tensorbin", "up_proj.tensorbin", "down_proj.tensorbin"):
-                if not _check_file(expert_dir / fname, layer_dir):
+            for name in ("gate_proj.tensorbin", "up_proj.tensorbin", "down_proj.tensorbin"):
+                if not _check_file(Path(name), expert_dir):
+                    logger.error("Missing MoE routed file {}", f"experts/e_{e:03d}/{name}")
                     return False
-        logger.info("All MoE layer files present (attn+shared+experts)")
+        logger.info("All MoE layer files present (attn+shared+experts/e_NNN)")
 
     # 3. Optional device load when cache is a complete layer
     if True:

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/conftest.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/conftest.py
@@ -32,7 +32,7 @@ def _reference_layer_state_dict(
     *,
     is_moe: bool,
     seed: int = 42,
-    num_routed_experts: int = 4,
+    num_routed_experts: int = 256,
 ) -> dict[str, torch.Tensor]:
     """Build one layer state_dict in HF key convention with deterministic random weights (Generator)."""
     g = torch.Generator().manual_seed(seed)
@@ -77,23 +77,23 @@ def _reference_layer_state_dict(
         state[f"model.layers.{layer_idx}.mlp.shared_experts.down_proj.weight"] = torch.randn(
             7168, _REF_HF_SHARED_GATE_UP[0], generator=g, dtype=torch.bfloat16
         )
-        # Expert weights: deterministic per-expert seeds (gate_seed, up_seed, down_seed) for golden parity
+        # Expert weights: batched RNG (one randn+clamp per projection) then slice into state
         gate_seed = seed + 0
         up_seed = seed + 256
         down_seed = seed + 512
-        for e in range(num_routed_experts):
-            g_gate = torch.Generator().manual_seed(gate_seed + e)
-            g_up = torch.Generator().manual_seed(up_seed + e)
-            g_down = torch.Generator().manual_seed(down_seed + e)
-            state[f"model.layers.{layer_idx}.mlp.experts.{e}.gate_proj.weight"] = torch.randn(
-                2048, _REF_K, generator=g_gate, dtype=torch.bfloat16
-            ).clamp(-2, 2)
-            state[f"model.layers.{layer_idx}.mlp.experts.{e}.up_proj.weight"] = torch.randn(
-                2048, _REF_K, generator=g_up, dtype=torch.bfloat16
-            ).clamp(-2, 2)
-            state[f"model.layers.{layer_idx}.mlp.experts.{e}.down_proj.weight"] = torch.randn(
-                7168, 2048, generator=g_down, dtype=torch.bfloat16
-            ).clamp(-2, 2)
+        if num_routed_experts > 0:
+            g_gate = torch.Generator().manual_seed(gate_seed)
+            g_up = torch.Generator().manual_seed(up_seed)
+            g_down = torch.Generator().manual_seed(down_seed)
+            gate_all = torch.randn(num_routed_experts, 2048, _REF_K, generator=g_gate, dtype=torch.bfloat16).clamp(
+                -2, 2
+            )
+            up_all = torch.randn(num_routed_experts, 2048, _REF_K, generator=g_up, dtype=torch.bfloat16).clamp(-2, 2)
+            down_all = torch.randn(num_routed_experts, 7168, 2048, generator=g_down, dtype=torch.bfloat16).clamp(-2, 2)
+            for e in range(num_routed_experts):
+                state[f"model.layers.{layer_idx}.mlp.experts.{e}.gate_proj.weight"] = gate_all[e]
+                state[f"model.layers.{layer_idx}.mlp.experts.{e}.up_proj.weight"] = up_all[e]
+                state[f"model.layers.{layer_idx}.mlp.experts.{e}.down_proj.weight"] = down_all[e]
     else:
         state[f"model.layers.{layer_idx}.mlp.gate_proj.weight"] = torch.randn(
             18432, _REF_K, generator=g, dtype=torch.bfloat16
@@ -148,6 +148,10 @@ def get_reference_model_state_dict():
     When random_weights=True (or USE_RANDOM_WEIGHTS=True): returns a dict of deterministic
     random weights. When random_weights=False: loads from DEEPSEEK_V3_HF_MODEL via
     LazyStateDict (read-only; tests never mutate it).
+
+    Callers should pass the minimum num_routed_experts they need (e.g. 1 for single-device
+    or no routing, 8 for 4x2 mesh with hardcoded expert index, 256 when comparing to
+    full gate-based reference).
 
     Usage:
         get = get_reference_model_state_dict

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_mlp.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_mlp.py
@@ -12,6 +12,7 @@ Run:
     pytest models/demos/deepseek_v3_b1/tests/unit_tests/test_moe.py -v -s
 """
 
+import time
 from typing import Any, NamedTuple
 
 import pytest
@@ -26,11 +27,41 @@ from models.demos.deepseek_v3_b1.fused_ops.moe.op import MoeOp
 from models.demos.deepseek_v3_b1.fused_ops.shared_expert.op import SharedExpertOp
 from models.demos.deepseek_v3_b1.prepare_weights import (
     create_gate_bias_tensor,
-    create_gate_indices_tensor,
     prepare_attention_weights,
     prepare_routed_expert_weights,
     prepare_shared_expert_weights,
 )
+
+# Gate indices: constant 0..255 on sender core (same layout as gate_bias). Not a weight.
+_GATE_INDICES_SHAPE = (16, 16)
+_NUM_GATE_INDICES = 256
+
+
+def _create_gate_indices_tensor(
+    device: Any,
+    sender_core_grid: ttnn.CoreRangeSet,
+    *,
+    mesh_mapper: Any = None,
+) -> ttnn.Tensor:
+    """Build constant gate indices 0..255 as HEIGHT_SHARDED on sender core. Same layout as gate_bias."""
+    indices = torch.arange(_NUM_GATE_INDICES, dtype=torch.int32).reshape(_GATE_INDICES_SHAPE[0], _GATE_INDICES_SHAPE[1])
+    transposed = torch.transpose(indices, 0, 1).contiguous().to(torch.uint16)
+    shard_spec = ttnn.ShardSpec(
+        sender_core_grid,
+        _GATE_INDICES_SHAPE,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec)
+    kwargs = {"mesh_mapper": mesh_mapper} if mesh_mapper else {}
+    return ttnn.from_torch(
+        transposed,
+        dtype=ttnn.uint16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=mem_config,
+        tile=ttnn.Tile([16, 16]),
+        **kwargs,
+    )
 
 
 # ============================================================================
@@ -234,7 +265,6 @@ def create_shared_expert_tensors(
     shared_weights = prepare_shared_expert_weights(
         bdw, state_dict, layer_idx=layer_idx, is_moe=is_moe, move_to_device=True
     )
-
     return SharedExpertTensors(
         shared_gate_weights_overlapped=shared_weights.shared_gate_proj,
         shared_up_weights_overlapped=shared_weights.shared_up_proj,
@@ -361,8 +391,8 @@ def create_routed_expert_tensors(
     num_gate_proj_cores = len(gate_proj_worker_cores)
 
     # Build attention-side overlapped tensors from state dict via prepare_weights.
-    attn = prepare_attention_weights(bdw, state_dict, layer_idx=layer_idx, is_moe=is_moe, move_to_device=True)
-    ttnn_gate_mm_weights = attn.gate_mm
+    attn, gate = prepare_attention_weights(bdw, state_dict, layer_idx=layer_idx, is_moe=is_moe, move_to_device=True)
+    ttnn_gate_mm_weights = gate.gate_mm if gate is not None else None
     ttnn_rmsnorm_gamma = attn.ffn_norm
     if ttnn_gate_mm_weights is not None:
         compute_core_grid = ttnn_gate_mm_weights.core_range_set
@@ -417,12 +447,12 @@ def create_routed_expert_tensors(
             num_routed_experts=num_experts,
             move_to_device=True,
         )
-        gate_proj_expert_tensors = routed_weights.routed_gate_proj
-        up_proj_expert_tensors = routed_weights.routed_up_proj
-        down_proj_expert_tensors = routed_weights.routed_down_proj
-        gate_proj_weights = gate_proj_expert_tensors[0]
-        up_proj_weights = up_proj_expert_tensors[0]
-        down_proj_weights = down_proj_expert_tensors[0]
+        gate_proj_weights = routed_weights.routed_gate_proj
+        up_proj_weights = routed_weights.routed_up_proj
+        down_proj_weights = routed_weights.routed_down_proj
+        gate_proj_expert_tensors = None
+        up_proj_expert_tensors = None
+        down_proj_expert_tensors = None
     else:
         # Dense MLP: slice gate/up (7168, 18432) and down (18432, 7168) into 8 experts of 2048 each
         gate_key = f"{layer_key}.mlp.gate_proj.weight"
@@ -449,11 +479,10 @@ def create_routed_expert_tensors(
             num_routed_experts=8,
             move_to_device=True,
         )
-        # DenseRoutedExpertWeights: single tensor per projection (mesh-shaped), no list
         gate_proj_weights = routed_weights.routed_gate_proj
         up_proj_weights = routed_weights.routed_up_proj
         down_proj_weights = routed_weights.routed_down_proj
-        gate_proj_expert_tensors = None  # unused when is_moe=False
+        gate_proj_expert_tensors = None
         up_proj_expert_tensors = None
         down_proj_expert_tensors = None
 
@@ -465,7 +494,7 @@ def create_routed_expert_tensors(
         assert list(ttnn.corerange_to_cores(ttnn_gate_bias.memory_config().shard_spec.grid)) == list(
             ttnn.corerange_to_cores(input_core_grid)
         ), "gate_bias grid must match input_core_grid (MOE_SENDER_GRID_SIZE)"
-        ttnn_gate_indices = create_gate_indices_tensor(device, input_core_grid, mesh_mapper=mesh_mapper)
+        ttnn_gate_indices = _create_gate_indices_tensor(device, input_core_grid, mesh_mapper=mesh_mapper)
         # Gate output buffers (scores and indices on sender core)
         tile_1x16 = ttnn.Tile((1, 16))
         gate_output_shard_spec = ttnn.ShardSpec(
@@ -702,17 +731,18 @@ def create_reference_mlp_models(state_dict, layer_idx):
 @pytest.mark.requires_grid_size((13, 10))
 def test_moe_fused(device, use_hardcoded_expert_index, reconfig_moe_cbs, noc_mode, get_reference_model_state_dict):
     """Test fused MoE: run both routed expert and shared expert, validate combined output."""
-
+    test_t0 = time.perf_counter()
     M = RoutedExpert.M
     K = RoutedExpert.K
 
     logger.info(f"Testing fused MoE: K={K}, use_hardcoded_expert_index={use_hardcoded_expert_index}")
 
+    num_routed_experts = 1 if use_hardcoded_expert_index else 256
     state_dict = get_reference_model_state_dict(
         layer_idx=ROUTED_EXPERT_LAYER_IDX,
         is_moe=True,
         seed=RoutedExpert.SEED,
-        num_routed_experts=256,
+        num_routed_experts=num_routed_experts,
         include_global=False,
     )
 
@@ -787,9 +817,9 @@ def test_moe_fused(device, use_hardcoded_expert_index, reconfig_moe_cbs, noc_mod
         r.ttnn_gate_indices,
         r.gate_output_scores_tensor,
         r.gate_output_indices_tensor,
-        r.gate_proj_weights,
-        r.up_proj_weights,
-        r.down_proj_weights,
+        r.gate_proj_weights[0],
+        r.up_proj_weights[0],
+        r.down_proj_weights[0],
         r.final_output_tensor,
         r.ttnn_rmsnorm_gamma,
         # Shared expert tensors
@@ -898,6 +928,7 @@ def test_moe_fused_with_reduce(
             f"{bh_2d_mesh_device.shape[0] * bh_2d_mesh_device.shape[1]}"
         )
 
+    test_t0 = time.perf_counter()
     submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
     logger.info(f"Created submesh with shape: {submesh.shape}")
 
@@ -906,11 +937,12 @@ def test_moe_fused_with_reduce(
 
     logger.info(f"Testing fused MoE with reduce: K={K}")
 
+    num_routed_experts = 8 if use_hardcoded_expert_index else 256
     state_dict = get_reference_model_state_dict(
         layer_idx=ROUTED_EXPERT_LAYER_IDX,
         is_moe=True,
         seed=RoutedExpert.SEED,
-        num_routed_experts=256,
+        num_routed_experts=num_routed_experts,
         include_global=False,
     )
 
@@ -1050,9 +1082,9 @@ def test_moe_fused_with_reduce(
         r.ttnn_gate_indices,
         r.gate_output_scores_tensor,
         r.gate_output_indices_tensor,
-        r.gate_proj_weights,
-        r.up_proj_weights,
-        r.down_proj_weights,
+        r.gate_proj_weights[0],
+        r.up_proj_weights[0],
+        r.down_proj_weights[0],
         r.final_output_tensor,
         r.ttnn_rmsnorm_gamma,
         # Shared expert tensors
@@ -1193,7 +1225,7 @@ def test_moe_fused_with_reduce(
 @pytest.mark.requires_grid_size((13, 10))
 def test_mlp(device, reconfig_moe_cbs, noc_mode, get_reference_model_state_dict):
     """Test MoeOp with enable_routing=False: same as MLP (dense mode), no routing logic."""
-
+    test_t0 = time.perf_counter()
     M = RoutedExpert.M
     K = RoutedExpert.K
 
@@ -1203,7 +1235,7 @@ def test_mlp(device, reconfig_moe_cbs, noc_mode, get_reference_model_state_dict)
         layer_idx=ROUTED_EXPERT_LAYER_IDX,
         is_moe=True,
         seed=RoutedExpert.SEED,
-        num_routed_experts=256,
+        num_routed_experts=1,
         include_global=False,
     )
 
@@ -1273,9 +1305,9 @@ def test_mlp(device, reconfig_moe_cbs, noc_mode, get_reference_model_state_dict)
     ttnn_result_final = MoeOp.op(
         r.ttnn_residual_mcast_src,
         # No routing tensors
-        gate_proj_weights_tensor=r.gate_proj_weights,
-        up_proj_weights_tensor=r.up_proj_weights,
-        down_proj_weights_tensor=r.down_proj_weights,
+        gate_proj_weights_tensor=r.gate_proj_weights[0],
+        up_proj_weights_tensor=r.up_proj_weights[0],
+        down_proj_weights_tensor=r.down_proj_weights[0],
         final_output_tensor=r.final_output_tensor,
         rmsnorm_gamma_tensor=r.ttnn_rmsnorm_gamma,
         shared_gate_weights_overlapped=s.shared_gate_weights_overlapped,
@@ -1357,6 +1389,7 @@ def test_mlp_with_reduce(
             f"{bh_2d_mesh_device.shape[0] * bh_2d_mesh_device.shape[1]}"
         )
 
+    test_t0 = time.perf_counter()
     submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
     logger.info(f"Created submesh with shape: {submesh.shape}")
 
@@ -1367,11 +1400,13 @@ def test_mlp_with_reduce(
 
     logger.info(f"Testing MoeOp no-routing with reduce: K={K}, use_mlp_weights={use_mlp_weights}")
 
+    # MoE: state dict has per-expert keys; we need 8 experts (one per device on 4x2) for the reduce test.
+    # Dense: state dict has full gate/up/down matrices; num_routed_experts is unused.
     state_dict = get_reference_model_state_dict(
         layer_idx=layer_idx,
         is_moe=is_moe,
         seed=RoutedExpert.SEED,
-        num_routed_experts=256 if is_moe else 4,
+        num_routed_experts=(8 if is_moe else 0),
         include_global=False,
     )
 
@@ -1506,9 +1541,9 @@ def test_mlp_with_reduce(
     ttnn_result_reduce = MoeOp.op(
         r.ttnn_residual_mcast_src,
         # No routing tensors
-        gate_proj_weights_tensor=r.gate_proj_weights,
-        up_proj_weights_tensor=r.up_proj_weights,
-        down_proj_weights_tensor=r.down_proj_weights,
+        gate_proj_weights_tensor=r.gate_proj_weights[0],
+        up_proj_weights_tensor=r.up_proj_weights[0],
+        down_proj_weights_tensor=r.down_proj_weights[0],
         final_output_tensor=r.final_output_tensor,
         rmsnorm_gamma_tensor=r.ttnn_rmsnorm_gamma,
         shared_gate_weights_overlapped=s.shared_gate_weights_overlapped,

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_mlp.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_mlp.py
@@ -461,7 +461,10 @@ def create_routed_expert_tensors(
         assert is_moe, "enable_routing=True is only supported with MoE weights"
         # Gate bias/indices from prepare_weights helpers.
         raw_bias = state_dict[f"{layer_key}.mlp.gate.e_score_correction_bias"]
-        ttnn_gate_bias = create_gate_bias_tensor(raw_bias, device, input_core_grid, mesh_mapper=mesh_mapper)
+        ttnn_gate_bias = create_gate_bias_tensor(raw_bias, device, move_to_device=True)
+        assert list(ttnn.corerange_to_cores(ttnn_gate_bias.memory_config().shard_spec.grid)) == list(
+            ttnn.corerange_to_cores(input_core_grid)
+        ), "gate_bias grid must match input_core_grid (MOE_SENDER_GRID_SIZE)"
         ttnn_gate_indices = create_gate_indices_tensor(device, input_core_grid, mesh_mapper=mesh_mapper)
         # Gate output buffers (scores and indices on sender core)
         tile_1x16 = ttnn.Tile((1, 16))

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_prepare_weights.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_prepare_weights.py
@@ -23,18 +23,16 @@ import ttnn
 from models.common.utility_functions import is_slow_dispatch
 from models.demos.deepseek_v3_b1.blitz_decode_weights import BlitzDecodeWeights, OverlappedTensor
 from models.demos.deepseek_v3_b1.prepare_weights import (
-    AttentionWeights,
     DeepSeekV3DenseLayerWeights,
     DeepSeekV3EmbeddingLayerWeights,
     DeepSeekV3LMHeadWeights,
     DeepSeekV3MoELayerWeights,
-    DenseRoutedExpertWeights,
-    MoERoutedExpertWeights,
-    SharedExpertWeights,
+    RoutedExpertWeights,
     load_dense_decoder_layer,
     load_embedding_weights,
     load_lm_head_weights,
     load_moe_decoder_layer,
+    load_moe_routed_experts,
     prepare_attention_weights,
     prepare_dense_layer_weights,
     prepare_embedding_weights,
@@ -54,6 +52,7 @@ from models.demos.deepseek_v3_b1.prepare_weights import (
 def _deallocate_layer(layer: DeepSeekV3DenseLayerWeights | DeepSeekV3MoELayerWeights) -> None:
     """Deallocate all tensors in a single decoder layer (for tests that save then load)."""
     seen: set[int] = set()
+    attn = layer.attention
     for f in (
         "q_a_proj",
         "q_b_proj",
@@ -65,28 +64,31 @@ def _deallocate_layer(layer: DeepSeekV3DenseLayerWeights | DeepSeekV3MoELayerWei
         "ffn_norm",
         "kv_b1_proj",
         "kv_b2_proj",
-        "shared_gate_proj",
-        "shared_up_proj",
     ):
-        ot = getattr(layer, f, None)
+        ot = getattr(attn, f, None)
         if ot is not None and hasattr(ot, "fused_tensor"):
             fid = id(ot.fused_tensor)
             if fid not in seen:
                 seen.add(fid)
                 ttnn.deallocate(ot.fused_tensor, force=True)
-    ttnn.deallocate(layer.shared_down_proj, force=True)
+    shared = layer.shared_expert
+    for f in ("shared_gate_proj", "shared_up_proj"):
+        ot = getattr(shared, f, None)
+        if ot is not None and hasattr(ot, "fused_tensor"):
+            fid = id(ot.fused_tensor)
+            if fid not in seen:
+                seen.add(fid)
+                ttnn.deallocate(ot.fused_tensor, force=True)
+    ttnn.deallocate(shared.shared_down_proj, force=True)
+    routed = layer.routed_expert
     if isinstance(layer, DeepSeekV3MoELayerWeights):
-        ttnn.deallocate(layer.gate_bias, force=True)
-        for t in layer.routed_gate_proj:
-            ttnn.deallocate(t, force=True)
-        for t in layer.routed_up_proj:
-            ttnn.deallocate(t, force=True)
-        for t in layer.routed_down_proj:
-            ttnn.deallocate(t, force=True)
-    else:
-        ttnn.deallocate(layer.routed_gate_proj, force=True)
-        ttnn.deallocate(layer.routed_up_proj, force=True)
-        ttnn.deallocate(layer.routed_down_proj, force=True)
+        ttnn.deallocate(layer.gate.gate_bias, force=True)
+    for t in routed.routed_gate_proj:
+        ttnn.deallocate(t, force=True)
+    for t in routed.routed_up_proj:
+        ttnn.deallocate(t, force=True)
+    for t in routed.routed_down_proj:
+        ttnn.deallocate(t, force=True)
 
 
 def _core_range_set_to_tuples(crs):
@@ -137,52 +139,51 @@ def _assert_layer_on_device_with_topology(
 ) -> None:
     """Assert all tensors in a loaded layer are on device and have correct topology for 4x2 mesh."""
     seen_fused: set[int] = set()
-    # Check fusion groups via one representative OverlappedTensor per group
+    attn = layer.attention
+    shared = layer.shared_expert
+    routed = layer.routed_expert
     # q_ab_kv_a
-    _assert_on_device(layer.q_a_proj.fused_tensor)
-    fid = id(layer.q_a_proj.fused_tensor)
+    _assert_on_device(attn.q_a_proj.fused_tensor)
+    fid = id(attn.q_a_proj.fused_tensor)
     if fid not in seen_fused:
         seen_fused.add(fid)
-        _assert_topology(layer.q_a_proj.fused_tensor, _PLACEMENTS_SHARD_NONE_1)
+        _assert_topology(attn.q_a_proj.fused_tensor, _PLACEMENTS_SHARD_NONE_1)
     # o_proj_gate_mm_norms
-    _assert_on_device(layer.o_proj.fused_tensor)
-    fid = id(layer.o_proj.fused_tensor)
+    _assert_on_device(attn.o_proj.fused_tensor)
+    fid = id(attn.o_proj.fused_tensor)
     if fid not in seen_fused:
         seen_fused.add(fid)
-        _assert_topology(layer.o_proj.fused_tensor, _PLACEMENTS_SHARD_NONE_1)
+        _assert_topology(attn.o_proj.fused_tensor, _PLACEMENTS_SHARD_NONE_1)
     # kv_b12
-    _assert_on_device(layer.kv_b1_proj.fused_tensor)
-    fid = id(layer.kv_b1_proj.fused_tensor)
+    _assert_on_device(attn.kv_b1_proj.fused_tensor)
+    fid = id(attn.kv_b1_proj.fused_tensor)
     if fid not in seen_fused:
         seen_fused.add(fid)
-        _assert_topology(layer.kv_b1_proj.fused_tensor, _PLACEMENTS_SHARD_NONE_0)
+        _assert_topology(attn.kv_b1_proj.fused_tensor, _PLACEMENTS_SHARD_NONE_0)
     # gate_up
-    _assert_on_device(layer.shared_gate_proj.fused_tensor)
-    fid = id(layer.shared_gate_proj.fused_tensor)
+    _assert_on_device(shared.shared_gate_proj.fused_tensor)
+    fid = id(shared.shared_gate_proj.fused_tensor)
     if fid not in seen_fused:
         seen_fused.add(fid)
-        _assert_topology(layer.shared_gate_proj.fused_tensor, _PLACEMENTS_SHARD_0_1)
+        _assert_topology(shared.shared_gate_proj.fused_tensor, _PLACEMENTS_SHARD_0_1)
     # Standalone: shared_down_proj
-    _assert_on_device(layer.shared_down_proj)
-    _assert_topology(layer.shared_down_proj, _PLACEMENTS_SHARD_0_1)
-    # Routed experts
-    if isinstance(layer, DeepSeekV3DenseLayerWeights):
-        _assert_on_device(layer.routed_gate_proj)
-        _assert_on_device(layer.routed_up_proj)
-        _assert_on_device(layer.routed_down_proj)
-        _assert_topology(layer.routed_gate_proj, _PLACEMENTS_SHARD_0_1)
-        _assert_topology(layer.routed_up_proj, _PLACEMENTS_SHARD_0_1)
-        _assert_topology(layer.routed_down_proj, _PLACEMENTS_SHARD_0_1)
-    else:
-        assert isinstance(layer, DeepSeekV3MoELayerWeights)
-        _assert_topology(layer.gate_bias, _PLACEMENTS_REPLICATE)
-        for e in range(len(layer.routed_gate_proj)):
-            _assert_on_device(layer.routed_gate_proj[e])
-            _assert_on_device(layer.routed_up_proj[e])
-            _assert_on_device(layer.routed_down_proj[e])
-            _assert_topology(layer.routed_gate_proj[e], _PLACEMENTS_REPLICATE)
-            _assert_topology(layer.routed_up_proj[e], _PLACEMENTS_REPLICATE)
-            _assert_topology(layer.routed_down_proj[e], _PLACEMENTS_REPLICATE)
+    _assert_on_device(shared.shared_down_proj)
+    _assert_topology(shared.shared_down_proj, _PLACEMENTS_SHARD_0_1)
+    # Routed experts (list of tensors per projection)
+    for t in routed.routed_gate_proj:
+        _assert_on_device(t)
+    for t in routed.routed_up_proj:
+        _assert_on_device(t)
+    for t in routed.routed_down_proj:
+        _assert_on_device(t)
+    routed_placements = (
+        _PLACEMENTS_SHARD_0_1 if isinstance(layer, DeepSeekV3DenseLayerWeights) else _PLACEMENTS_REPLICATE
+    )
+    _assert_topology(routed.routed_gate_proj[0], routed_placements)
+    _assert_topology(routed.routed_up_proj[0], routed_placements)
+    _assert_topology(routed.routed_down_proj[0], routed_placements)
+    if isinstance(layer, DeepSeekV3MoELayerWeights):
+        _assert_topology(layer.gate.gate_bias, _PLACEMENTS_REPLICATE)
 
 
 # HF state dict shapes (out_features, in_features) for linears; full logical for 4x2 mesh. See DEEPSEEK_PREPARE_WEIGHTS_DESIGN_DOC.md §5.
@@ -193,6 +194,10 @@ HF_SHARED_GATE_UP_FULL_LOGICAL = (2048, 7168)
 
 # Don't use all the experts in tests to avoid taking too long
 NUM_ROUTED_EXPERTS = 4
+
+# MoE per-expert tensors from get_tt_moe_routed_expert_weights are 4D (1, 1, K, N_padded)
+MOE_ROUTED_GATE_UP_SHAPE = (1, 1, 7168, 2048)
+MOE_ROUTED_DOWN_SHAPE = (1, 1, 2048, 7168)
 
 
 def _layer_state_dict(
@@ -294,8 +299,8 @@ def test_prepare_attention_weights_dense_4x2(bh_2d_mesh_device):
     submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
     state = _layer_state_dict(0, is_moe=False)
     bdw = BlitzDecodeWeights(submesh)
-    attn = prepare_attention_weights(bdw, state, 0, is_moe=False)
-    assert attn.gate_mm is None
+    attn, gate = prepare_attention_weights(bdw, state, 0, is_moe=False)
+    assert gate is None
     assert attn.q_a_proj.tensor_shape == (3584, 3072)
     assert attn.q_b_proj.tensor_shape == (1536, 12288)
     assert attn.kv_a_proj.tensor_shape == (7168, 576)
@@ -316,11 +321,10 @@ def test_prepare_attention_weights_moe_4x2(bh_2d_mesh_device):
     submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
     state = _layer_state_dict(0, is_moe=True, seed=43)
     bdw = BlitzDecodeWeights(submesh)
-    attn = prepare_attention_weights(bdw, state, 0, is_moe=True)
-    assert attn.gate_mm is not None
-    assert attn.gate_mm.tensor_shape == (7168, 256)
-    assert attn.gate_bias is not None
-    assert attn.gate_bias.shape == (16, 16)
+    attn, gate = prepare_attention_weights(bdw, state, 0, is_moe=True)
+    assert gate is not None
+    assert gate.gate_mm.tensor_shape == (7168, 256)
+    assert gate.gate_bias.shape == (16, 16)
     assert attn.q_a_proj.tensor_shape == (3584, 3072)
     assert attn.o_proj.tensor_shape == (8192, 7168)
 
@@ -371,10 +375,14 @@ def test_prepare_routed_expert_weights_dense_4x2(bh_2d_mesh_device):
     state = _layer_state_dict(0, is_moe=False)
     bdw = BlitzDecodeWeights(submesh)
     routed = prepare_routed_expert_weights(bdw, state, 0, is_moe=False)
-    assert isinstance(routed, DenseRoutedExpertWeights)
-    assert routed.routed_gate_proj.shape is not None
-    assert routed.routed_up_proj.shape is not None
-    assert routed.routed_down_proj.shape is not None
+    assert isinstance(routed, RoutedExpertWeights)
+    assert isinstance(routed.routed_gate_proj, list)
+    assert len(routed.routed_gate_proj) == 1
+    assert routed.routed_gate_proj[0].shape is not None
+    assert isinstance(routed.routed_up_proj, list) and len(routed.routed_up_proj) == 1
+    assert routed.routed_up_proj[0].shape is not None
+    assert isinstance(routed.routed_down_proj, list) and len(routed.routed_down_proj) == 1
+    assert routed.routed_down_proj[0].shape is not None
 
 
 @pytest.mark.parametrize(
@@ -389,10 +397,26 @@ def test_prepare_routed_expert_weights_moe_4x2(bh_2d_mesh_device):
     state = _layer_state_dict(0, is_moe=True, seed=43)
     bdw = BlitzDecodeWeights(submesh)
     routed = prepare_routed_expert_weights(bdw, state, 0, is_moe=True, num_routed_experts=NUM_ROUTED_EXPERTS)
-    assert isinstance(routed, MoERoutedExpertWeights)
+    assert isinstance(routed, RoutedExpertWeights)
+    assert isinstance(routed.routed_gate_proj, list)
     assert len(routed.routed_gate_proj) == NUM_ROUTED_EXPERTS
-    assert len(routed.routed_up_proj) == NUM_ROUTED_EXPERTS
-    assert len(routed.routed_down_proj) == NUM_ROUTED_EXPERTS
+    assert routed.routed_gate_proj[0].shape is not None
+    assert routed.routed_up_proj[0].shape is not None
+    assert routed.routed_down_proj[0].shape is not None
+    # Per-expert tensors are 4D (1, 1, K, N_padded)
+    for t in routed.routed_gate_proj:
+        assert len(t.shape) == 4, f"expected 4D shape, got {t.shape}"
+        assert t.shape == MOE_ROUTED_GATE_UP_SHAPE, f"gate_proj shape {t.shape} != {MOE_ROUTED_GATE_UP_SHAPE}"
+    for t in routed.routed_up_proj:
+        assert len(t.shape) == 4, f"expected 4D shape, got {t.shape}"
+        assert t.shape == MOE_ROUTED_GATE_UP_SHAPE, f"up_proj shape {t.shape} != {MOE_ROUTED_GATE_UP_SHAPE}"
+    for t in routed.routed_down_proj:
+        assert len(t.shape) == 4, f"expected 4D shape, got {t.shape}"
+        assert t.shape == MOE_ROUTED_DOWN_SHAPE, f"down_proj shape {t.shape} != {MOE_ROUTED_DOWN_SHAPE}"
+    # Per-expert shard: (K, per_core_N); .shape may be mesh-aware, so use shard_spec
+    assert routed.routed_gate_proj[0].memory_config().shard_spec.shape[0] == 7168
+    assert routed.routed_up_proj[0].memory_config().shard_spec.shape[0] == 7168
+    assert routed.routed_down_proj[0].memory_config().shard_spec.shape[0] == 2048
 
 
 @pytest.mark.parametrize(
@@ -410,30 +434,9 @@ def test_incremental_save_load_dense_4x2(bh_2d_mesh_device, tmp_path):
     bdw = BlitzDecodeWeights(submesh)
     layer = prepare_dense_layer_weights(bdw, state, 0)
     assert isinstance(layer, DeepSeekV3DenseLayerWeights)
-    attn = AttentionWeights(
-        q_a_proj=layer.q_a_proj,
-        q_b_proj=layer.q_b_proj,
-        kv_a_proj=layer.kv_a_proj,
-        o_proj=layer.o_proj,
-        gate_mm=None,
-        attn_norm=layer.attn_norm,
-        q_norm=layer.q_norm,
-        kv_norm=layer.kv_norm,
-        ffn_norm=layer.ffn_norm,
-        kv_b1_proj=layer.kv_b1_proj,
-        kv_b2_proj=layer.kv_b2_proj,
-        gate_bias=None,
-    )
-    shared = SharedExpertWeights(
-        shared_gate_proj=layer.shared_gate_proj,
-        shared_up_proj=layer.shared_up_proj,
-        shared_down_proj=layer.shared_down_proj,
-    )
-    routed = DenseRoutedExpertWeights(
-        routed_gate_proj=layer.routed_gate_proj,
-        routed_up_proj=layer.routed_up_proj,
-        routed_down_proj=layer.routed_down_proj,
-    )
+    attn = layer.attention
+    shared = layer.shared_expert
+    routed = layer.routed_expert
     manifest_kw = dict(
         hf_model_name="test-incremental-dense-4x2",
         hf_state_dict_name="test-incremental-dense.safetensors",
@@ -442,13 +445,14 @@ def test_incremental_save_load_dense_4x2(bh_2d_mesh_device, tmp_path):
     save_attention_weights(attn, tmp_path, 0, is_moe=False, **manifest_kw)
     save_shared_expert_weights(shared, tmp_path, 0, is_moe=False, **manifest_kw)
     save_routed_expert_weights(routed, tmp_path, 0, is_moe=False, **manifest_kw)
-    expected_routed_shape = layer.routed_gate_proj.shape
+    expected_routed_shape = layer.routed_expert.routed_gate_proj[0].shape
     _deallocate_layer(layer)
     loaded = load_dense_decoder_layer(tmp_path, submesh, 0)
     assert isinstance(loaded, DeepSeekV3DenseLayerWeights)
-    _assert_overlapped_tensors_match(layer.q_a_proj, loaded.q_a_proj)
-    _assert_overlapped_tensors_match(layer.shared_gate_proj, loaded.shared_gate_proj)
-    assert loaded.routed_gate_proj.shape == expected_routed_shape
+    _assert_overlapped_tensors_match(attn.q_a_proj, loaded.attention.q_a_proj)
+    _assert_overlapped_tensors_match(shared.shared_gate_proj, loaded.shared_expert.shared_gate_proj)
+    assert len(loaded.routed_expert.routed_gate_proj) == 1
+    assert loaded.routed_expert.routed_gate_proj[0].shape == expected_routed_shape
     _assert_layer_on_device_with_topology(loaded)
 
 
@@ -467,47 +471,27 @@ def test_incremental_save_load_moe_4x2(bh_2d_mesh_device, tmp_path):
     bdw = BlitzDecodeWeights(submesh)
     layer = prepare_moe_layer_weights(bdw, state, 0, num_routed_experts=NUM_ROUTED_EXPERTS)
     assert isinstance(layer, DeepSeekV3MoELayerWeights)
-    attn = AttentionWeights(
-        q_a_proj=layer.q_a_proj,
-        q_b_proj=layer.q_b_proj,
-        kv_a_proj=layer.kv_a_proj,
-        o_proj=layer.o_proj,
-        gate_mm=layer.gate_mm,
-        attn_norm=layer.attn_norm,
-        q_norm=layer.q_norm,
-        kv_norm=layer.kv_norm,
-        ffn_norm=layer.ffn_norm,
-        kv_b1_proj=layer.kv_b1_proj,
-        kv_b2_proj=layer.kv_b2_proj,
-        gate_bias=layer.gate_bias,
-    )
-    shared = SharedExpertWeights(
-        shared_gate_proj=layer.shared_gate_proj,
-        shared_up_proj=layer.shared_up_proj,
-        shared_down_proj=layer.shared_down_proj,
-    )
-    routed = MoERoutedExpertWeights(
-        routed_gate_proj=layer.routed_gate_proj,
-        routed_up_proj=layer.routed_up_proj,
-        routed_down_proj=layer.routed_down_proj,
-    )
+    attn = layer.attention
+    gate = layer.gate
+    shared = layer.shared_expert
+    routed = layer.routed_expert
     manifest_kw = dict(
         hf_model_name="test-incremental-moe-4x2",
         hf_state_dict_name="test-incremental-moe.safetensors",
         device_mesh_shape=(4, 2),
     )
-    save_attention_weights(attn, tmp_path, 0, is_moe=True, **manifest_kw)
+    save_attention_weights(attn, tmp_path, 0, is_moe=True, gate=gate, **manifest_kw)
     save_shared_expert_weights(shared, tmp_path, 0, is_moe=True, **manifest_kw)
     save_routed_expert_weights(routed, tmp_path, 0, is_moe=True, **manifest_kw)
-    expected_routed_expert_shape = layer.routed_gate_proj[0].shape
+    expected_routed_shape = layer.routed_expert.routed_gate_proj[0].shape
     _deallocate_layer(layer)
     loaded = load_moe_decoder_layer(tmp_path, submesh, 0)
     assert isinstance(loaded, DeepSeekV3MoELayerWeights)
-    _assert_overlapped_tensors_match(layer.gate_mm, loaded.gate_mm)
-    assert loaded.gate_bias.shape == layer.gate_bias.shape
-    _assert_overlapped_tensors_match(layer.shared_gate_proj, loaded.shared_gate_proj)
-    assert len(loaded.routed_gate_proj) == NUM_ROUTED_EXPERTS
-    assert loaded.routed_gate_proj[0].shape == expected_routed_expert_shape
+    _assert_overlapped_tensors_match(gate.gate_mm, loaded.gate.gate_mm)
+    assert loaded.gate.gate_bias.shape == gate.gate_bias.shape
+    _assert_overlapped_tensors_match(shared.shared_gate_proj, loaded.shared_expert.shared_gate_proj)
+    assert len(loaded.routed_expert.routed_gate_proj) == len(layer.routed_expert.routed_gate_proj)
+    assert loaded.routed_expert.routed_gate_proj[0].shape == expected_routed_shape
     _assert_layer_on_device_with_topology(loaded)
 
 
@@ -527,7 +511,7 @@ def _moe_routed_expert_stacked_tensors(seed: int = 43):
     indirect=True,
 )
 def test_dump_load_routed_expert_weights_4x2(bh_2d_mesh_device, tmp_path):
-    """Test dump/load round-trip for MoE routed expert weights on 4x2 mesh. Uses BlitzDecodeWeights directly so it can run in slow dispatch."""
+    """Test dump/load round-trip for MoE routed expert weights on 4x2 mesh (list of tensors per projection)."""
     _skip_unless_4x2_mesh(bh_2d_mesh_device)
     submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
 
@@ -538,52 +522,47 @@ def test_dump_load_routed_expert_weights_4x2(bh_2d_mesh_device, tmp_path):
         gate_stacked, up_stacked, down_stacked
     )
 
-    # Capture shapes before dump
-    expected_gate_shapes = [routed_gate_proj[e].shape for e in range(NUM_ROUTED_EXPERTS)]
-    expected_up_shapes = [routed_up_proj[e].shape for e in range(NUM_ROUTED_EXPERTS)]
-    expected_down_shapes = [routed_down_proj[e].shape for e in range(NUM_ROUTED_EXPERTS)]
+    routed = RoutedExpertWeights(
+        routed_gate_proj=routed_gate_proj,
+        routed_up_proj=routed_up_proj,
+        routed_down_proj=routed_down_proj,
+    )
+    expected_gate_shape = routed_gate_proj[0].shape
+    expected_up_shape = routed_up_proj[0].shape
+    expected_down_shape = routed_down_proj[0].shape
 
-    # Dump only routed experts (same layout as save_layer for MoE)
+    save_routed_expert_weights(routed, tmp_path, 0, is_moe=True)
     layer_dir = tmp_path / "layer_000"
-    experts_dir = layer_dir / "experts"
-    experts_dir.mkdir(parents=True, exist_ok=True)
-    for e in range(NUM_ROUTED_EXPERTS):
-        logger.info("Dumping expert {}...", e)
-        expert_dir = experts_dir / f"e_{e:03d}"
-        expert_dir.mkdir(parents=True, exist_ok=True)
-        ttnn.dump_tensor(expert_dir / "gate_proj.tensorbin", routed_gate_proj[e])
-        ttnn.dump_tensor(expert_dir / "up_proj.tensorbin", routed_up_proj[e])
-        ttnn.dump_tensor(expert_dir / "down_proj.tensorbin", routed_down_proj[e])
+    assert (layer_dir / "experts" / "e_000" / "gate_proj.tensorbin").exists()
+    assert (layer_dir / "experts" / "e_000" / "up_proj.tensorbin").exists()
+    assert (layer_dir / "experts" / "e_000" / "down_proj.tensorbin").exists()
 
-    # Allow original tensors to be freed; load back onto the same submesh
-    del routed_gate_proj, routed_up_proj, routed_down_proj
-    routed_gate_proj = []
-    routed_up_proj = []
-    routed_down_proj = []
+    del routed, routed_gate_proj, routed_up_proj, routed_down_proj
     logger.info("Loading routed experts back onto the same submesh...")
     t0 = time.perf_counter()
-    for e in range(NUM_ROUTED_EXPERTS):
-        expert_dir = experts_dir / f"e_{e:03d}"
-        logger.info("Loading expert {}...", e)
-        routed_gate_proj.append(ttnn.load_tensor(expert_dir / "gate_proj.tensorbin", device=submesh))
-        routed_up_proj.append(ttnn.load_tensor(expert_dir / "up_proj.tensorbin", device=submesh))
-        routed_down_proj.append(ttnn.load_tensor(expert_dir / "down_proj.tensorbin", device=submesh))
+    loaded = load_moe_routed_experts(tmp_path, submesh, 0)
     elapsed = time.perf_counter() - t0
     logger.info("Loaded routed experts back onto the same submesh in {:.3f}s", elapsed)
 
-    assert len(routed_gate_proj) == NUM_ROUTED_EXPERTS
-    assert len(routed_up_proj) == NUM_ROUTED_EXPERTS
-    assert len(routed_down_proj) == NUM_ROUTED_EXPERTS
-    for e in range(NUM_ROUTED_EXPERTS):
-        assert routed_gate_proj[e].shape == expected_gate_shapes[e]
-        assert routed_up_proj[e].shape == expected_up_shapes[e]
-        assert routed_down_proj[e].shape == expected_down_shapes[e]
-        _assert_on_device(routed_gate_proj[e])
-        _assert_on_device(routed_up_proj[e])
-        _assert_on_device(routed_down_proj[e])
-        _assert_topology(routed_gate_proj[e], _PLACEMENTS_REPLICATE)
-        _assert_topology(routed_up_proj[e], _PLACEMENTS_REPLICATE)
-        _assert_topology(routed_down_proj[e], _PLACEMENTS_REPLICATE)
+    assert isinstance(loaded, RoutedExpertWeights)
+    assert isinstance(loaded.routed_gate_proj, list)
+    assert len(loaded.routed_gate_proj) == NUM_ROUTED_EXPERTS
+    assert loaded.routed_gate_proj[0].shape == expected_gate_shape
+    assert loaded.routed_up_proj[0].shape == expected_up_shape
+    assert loaded.routed_down_proj[0].shape == expected_down_shape
+    assert len(loaded.routed_gate_proj[0].shape) == 4
+    assert loaded.routed_gate_proj[0].shape == MOE_ROUTED_GATE_UP_SHAPE
+    assert loaded.routed_up_proj[0].shape == MOE_ROUTED_GATE_UP_SHAPE
+    assert loaded.routed_down_proj[0].shape == MOE_ROUTED_DOWN_SHAPE
+    for t in loaded.routed_gate_proj:
+        _assert_on_device(t)
+    for t in loaded.routed_up_proj:
+        _assert_on_device(t)
+    for t in loaded.routed_down_proj:
+        _assert_on_device(t)
+    _assert_topology(loaded.routed_gate_proj[0], _PLACEMENTS_REPLICATE)
+    _assert_topology(loaded.routed_up_proj[0], _PLACEMENTS_REPLICATE)
+    _assert_topology(loaded.routed_down_proj[0], _PLACEMENTS_REPLICATE)
 
 
 @pytest.mark.parametrize(
@@ -602,21 +581,23 @@ def test_prepare_dense_layer_single_layer_4x2(bh_2d_mesh_device):
     elapsed = time.perf_counter() - t0
     logger.info("prepare_dense_layer_weights (1 dense layer, 4x2 mesh): {:.3f} s", elapsed)
     assert isinstance(layer, DeepSeekV3DenseLayerWeights)
-    assert layer.q_a_proj.tensor_shape == (3584, 3072)
-    assert layer.q_b_proj.tensor_shape == (1536, 12288)
-    assert layer.kv_a_proj.tensor_shape == (7168, 576)
-    assert layer.o_proj.tensor_shape == (8192, 7168)
-    assert layer.attn_norm.tensor_shape == (1, 7168)
-    assert layer.q_norm.tensor_shape == (1, 1536)
-    assert layer.kv_norm.tensor_shape == (1, 512)
-    assert layer.ffn_norm.tensor_shape == (1, 7168)
-    assert layer.kv_b1_proj.tensor_shape == (8192, 512)
-    assert layer.kv_b2_proj.tensor_shape == (512, 8192)
-    assert hasattr(layer, "shared_gate_proj") and layer.shared_gate_proj is not None
-    assert hasattr(layer, "shared_up_proj") and layer.shared_up_proj is not None
-    assert hasattr(layer, "routed_gate_proj") and layer.routed_gate_proj is not None
-    assert hasattr(layer, "routed_up_proj") and layer.routed_up_proj is not None
-    assert hasattr(layer, "routed_down_proj") and layer.routed_down_proj is not None
+    attn = layer.attention
+    assert attn.q_a_proj.tensor_shape == (3584, 3072)
+    assert attn.q_b_proj.tensor_shape == (1536, 12288)
+    assert attn.kv_a_proj.tensor_shape == (7168, 576)
+    assert attn.o_proj.tensor_shape == (8192, 7168)
+    assert attn.attn_norm.tensor_shape == (1, 7168)
+    assert attn.q_norm.tensor_shape == (1, 1536)
+    assert attn.kv_norm.tensor_shape == (1, 512)
+    assert attn.ffn_norm.tensor_shape == (1, 7168)
+    assert attn.kv_b1_proj.tensor_shape == (8192, 512)
+    assert attn.kv_b2_proj.tensor_shape == (512, 8192)
+    assert layer.shared_expert.shared_gate_proj is not None
+    assert layer.shared_expert.shared_up_proj is not None
+    assert isinstance(layer.routed_expert.routed_gate_proj, list) and len(layer.routed_expert.routed_gate_proj) >= 1
+    assert layer.routed_expert.routed_gate_proj[0] is not None
+    assert isinstance(layer.routed_expert.routed_up_proj, list) and len(layer.routed_expert.routed_up_proj) >= 1
+    assert isinstance(layer.routed_expert.routed_down_proj, list) and len(layer.routed_expert.routed_down_proj) >= 1
 
 
 @pytest.mark.parametrize(
@@ -638,24 +619,24 @@ def test_save_load_dense_layer_single_layer_4x2(bh_2d_mesh_device, tmp_path):
     elapsed = time.perf_counter() - t0
     logger.info("prepare_dense_layer_weights (1 dense layer, 4x2 mesh): {:.3f} s", elapsed)
     assert isinstance(orig, DeepSeekV3DenseLayerWeights)
-    assert orig.q_a_proj.tensor_shape == (3584, 3072)
-    assert orig.q_b_proj.tensor_shape == (1536, 12288)
-    assert orig.kv_a_proj.tensor_shape == (7168, 576)
-    assert orig.o_proj.tensor_shape == (8192, 7168)
-    assert orig.attn_norm.tensor_shape == (1, 7168)
-    assert orig.q_norm.tensor_shape == (1, 1536)
-    assert orig.kv_norm.tensor_shape == (1, 512)
-    assert orig.ffn_norm.tensor_shape == (1, 7168)
-    assert orig.kv_b1_proj.tensor_shape == (8192, 512)
-    assert orig.kv_b2_proj.tensor_shape == (512, 8192)
-    assert hasattr(orig, "shared_gate_proj") and orig.shared_gate_proj is not None
-    assert hasattr(orig, "shared_up_proj") and orig.shared_up_proj is not None
-    assert hasattr(orig, "routed_gate_proj") and orig.routed_gate_proj is not None
-    assert hasattr(orig, "routed_up_proj") and orig.routed_up_proj is not None
-    assert hasattr(orig, "routed_down_proj") and orig.routed_down_proj is not None
+    assert orig.attention.q_a_proj.tensor_shape == (3584, 3072)
+    assert orig.attention.q_b_proj.tensor_shape == (1536, 12288)
+    assert orig.attention.kv_a_proj.tensor_shape == (7168, 576)
+    assert orig.attention.o_proj.tensor_shape == (8192, 7168)
+    assert orig.attention.attn_norm.tensor_shape == (1, 7168)
+    assert orig.attention.q_norm.tensor_shape == (1, 1536)
+    assert orig.attention.kv_norm.tensor_shape == (1, 512)
+    assert orig.attention.ffn_norm.tensor_shape == (1, 7168)
+    assert orig.attention.kv_b1_proj.tensor_shape == (8192, 512)
+    assert orig.attention.kv_b2_proj.tensor_shape == (512, 8192)
+    assert orig.shared_expert.shared_gate_proj is not None
+    assert orig.shared_expert.shared_up_proj is not None
+    assert isinstance(orig.routed_expert.routed_gate_proj, list) and len(orig.routed_expert.routed_gate_proj) >= 1
+    assert isinstance(orig.routed_expert.routed_up_proj, list) and len(orig.routed_expert.routed_up_proj) >= 1
+    assert isinstance(orig.routed_expert.routed_down_proj, list) and len(orig.routed_expert.routed_down_proj) >= 1
     # Early access to q_ab_kv_a fused_tensor (same as first tensor touched in save_layer)
-    logger.info("Early access: touching q_ab_kv_a fused_tensor (orig.q_a_proj.fused_tensor)...")
-    q_ab_kv_a_fused = orig.q_a_proj.fused_tensor
+    logger.info("Early access: touching q_ab_kv_a fused_tensor (orig.attention.q_a_proj.fused_tensor)...")
+    q_ab_kv_a_fused = orig.attention.q_a_proj.fused_tensor
     _ = q_ab_kv_a_fused.shape
     logger.info("Early access: got shape {}", q_ab_kv_a_fused.shape)
     save_decoder_layer(
@@ -684,27 +665,28 @@ def test_save_load_dense_layer_single_layer_4x2(bh_2d_mesh_device, tmp_path):
     logger.info("load_dense_decoder_layer (dense, 4x2 submesh): {:.3f} s", elapsed)
     assert isinstance(layer, DeepSeekV3DenseLayerWeights)
 
-    _assert_overlapped_tensors_match(orig.q_a_proj, layer.q_a_proj)
-    _assert_overlapped_tensors_match(orig.q_b_proj, layer.q_b_proj)
-    _assert_overlapped_tensors_match(orig.kv_a_proj, layer.kv_a_proj)
-    _assert_overlapped_tensors_match(orig.o_proj, layer.o_proj)
-    _assert_overlapped_tensors_match(orig.attn_norm, layer.attn_norm)
-    _assert_overlapped_tensors_match(orig.q_norm, layer.q_norm)
-    _assert_overlapped_tensors_match(orig.kv_norm, layer.kv_norm)
-    _assert_overlapped_tensors_match(orig.ffn_norm, layer.ffn_norm)
-    _assert_overlapped_tensors_match(orig.kv_b1_proj, layer.kv_b1_proj)
-    _assert_overlapped_tensors_match(orig.kv_b2_proj, layer.kv_b2_proj)
-    _assert_overlapped_tensors_match(orig.shared_gate_proj, layer.shared_gate_proj)
-    _assert_overlapped_tensors_match(orig.shared_up_proj, layer.shared_up_proj)
-    assert layer.routed_gate_proj.shape == orig.routed_gate_proj.shape
-    assert layer.routed_up_proj.shape == orig.routed_up_proj.shape
-    assert layer.routed_down_proj.shape == orig.routed_down_proj.shape
+    _assert_overlapped_tensors_match(orig.attention.q_a_proj, layer.attention.q_a_proj)
+    _assert_overlapped_tensors_match(orig.attention.q_b_proj, layer.attention.q_b_proj)
+    _assert_overlapped_tensors_match(orig.attention.kv_a_proj, layer.attention.kv_a_proj)
+    _assert_overlapped_tensors_match(orig.attention.o_proj, layer.attention.o_proj)
+    _assert_overlapped_tensors_match(orig.attention.attn_norm, layer.attention.attn_norm)
+    _assert_overlapped_tensors_match(orig.attention.q_norm, layer.attention.q_norm)
+    _assert_overlapped_tensors_match(orig.attention.kv_norm, layer.attention.kv_norm)
+    _assert_overlapped_tensors_match(orig.attention.ffn_norm, layer.attention.ffn_norm)
+    _assert_overlapped_tensors_match(orig.attention.kv_b1_proj, layer.attention.kv_b1_proj)
+    _assert_overlapped_tensors_match(orig.attention.kv_b2_proj, layer.attention.kv_b2_proj)
+    _assert_overlapped_tensors_match(orig.shared_expert.shared_gate_proj, layer.shared_expert.shared_gate_proj)
+    _assert_overlapped_tensors_match(orig.shared_expert.shared_up_proj, layer.shared_expert.shared_up_proj)
+    assert len(layer.routed_expert.routed_gate_proj) == len(orig.routed_expert.routed_gate_proj)
+    assert layer.routed_expert.routed_gate_proj[0].shape == orig.routed_expert.routed_gate_proj[0].shape
+    assert layer.routed_expert.routed_up_proj[0].shape == orig.routed_expert.routed_up_proj[0].shape
+    assert layer.routed_expert.routed_down_proj[0].shape == orig.routed_expert.routed_down_proj[0].shape
 
-    assert id(layer.q_a_proj.fused_tensor) == id(layer.q_b_proj.fused_tensor)
-    assert id(layer.q_b_proj.fused_tensor) == id(layer.kv_a_proj.fused_tensor)
-    assert id(layer.o_proj.fused_tensor) == id(layer.attn_norm.fused_tensor)
-    assert id(layer.kv_b1_proj.fused_tensor) == id(layer.kv_b2_proj.fused_tensor)
-    assert id(layer.shared_gate_proj.fused_tensor) == id(layer.shared_up_proj.fused_tensor)
+    assert id(layer.attention.q_a_proj.fused_tensor) == id(layer.attention.q_b_proj.fused_tensor)
+    assert id(layer.attention.q_b_proj.fused_tensor) == id(layer.attention.kv_a_proj.fused_tensor)
+    assert id(layer.attention.o_proj.fused_tensor) == id(layer.attention.attn_norm.fused_tensor)
+    assert id(layer.attention.kv_b1_proj.fused_tensor) == id(layer.attention.kv_b2_proj.fused_tensor)
+    assert id(layer.shared_expert.shared_gate_proj.fused_tensor) == id(layer.shared_expert.shared_up_proj.fused_tensor)
     _assert_layer_on_device_with_topology(layer)
 
 
@@ -727,24 +709,30 @@ def test_prepare_moe_layer_single_layer_4x2(bh_2d_mesh_device):
     elapsed = time.perf_counter() - t0
     logger.info("prepare_moe_layer_weights (1 MoE layer, 4x2 mesh): {:.3f} s", elapsed)
     assert isinstance(layer, DeepSeekV3MoELayerWeights)
-    assert layer.q_a_proj.tensor_shape == (3584, 3072)
-    assert layer.q_b_proj.tensor_shape == (1536, 12288)
-    assert layer.kv_a_proj.tensor_shape == (7168, 576)
-    assert layer.o_proj.tensor_shape == (8192, 7168)
-    assert layer.gate_mm.tensor_shape == (7168, 256)
-    assert layer.gate_bias.shape == (16, 16)
-    assert layer.attn_norm.tensor_shape == (1, 7168)
-    assert layer.q_norm.tensor_shape == (1, 1536)
-    assert layer.kv_norm.tensor_shape == (1, 512)
-    assert layer.ffn_norm.tensor_shape == (1, 7168)
-    assert layer.kv_b1_proj.tensor_shape == (8192, 512)
-    assert layer.kv_b2_proj.tensor_shape == (512, 8192)
-    assert layer.shared_gate_proj.tensor_shape == (7168, 256)
-    assert layer.shared_up_proj.tensor_shape == (7168, 256)
-    assert hasattr(layer, "shared_down_proj")
-    assert len(layer.routed_gate_proj) == NUM_ROUTED_EXPERTS
-    assert len(layer.routed_up_proj) == NUM_ROUTED_EXPERTS
-    assert len(layer.routed_down_proj) == NUM_ROUTED_EXPERTS
+    attn = layer.attention
+    assert attn.q_a_proj.tensor_shape == (3584, 3072)
+    assert attn.q_b_proj.tensor_shape == (1536, 12288)
+    assert attn.kv_a_proj.tensor_shape == (7168, 576)
+    assert attn.o_proj.tensor_shape == (8192, 7168)
+    assert layer.gate.gate_mm.tensor_shape == (7168, 256)
+    assert layer.gate.gate_bias.shape == (16, 16)
+    assert attn.attn_norm.tensor_shape == (1, 7168)
+    assert attn.q_norm.tensor_shape == (1, 1536)
+    assert attn.kv_norm.tensor_shape == (1, 512)
+    assert attn.ffn_norm.tensor_shape == (1, 7168)
+    assert attn.kv_b1_proj.tensor_shape == (8192, 512)
+    assert attn.kv_b2_proj.tensor_shape == (512, 8192)
+    assert layer.shared_expert.shared_gate_proj.tensor_shape == (7168, 256)
+    assert layer.shared_expert.shared_up_proj.tensor_shape == (7168, 256)
+    assert layer.shared_expert.shared_down_proj is not None
+    assert len(layer.routed_expert.routed_gate_proj) == NUM_ROUTED_EXPERTS
+    assert len(layer.routed_expert.routed_gate_proj[0].shape) == 4
+    assert layer.routed_expert.routed_gate_proj[0].shape == MOE_ROUTED_GATE_UP_SHAPE
+    assert layer.routed_expert.routed_up_proj[0].shape == MOE_ROUTED_GATE_UP_SHAPE
+    assert layer.routed_expert.routed_down_proj[0].shape == MOE_ROUTED_DOWN_SHAPE
+    assert layer.routed_expert.routed_gate_proj[0].memory_config().shard_spec.shape[0] == 7168
+    assert layer.routed_expert.routed_up_proj[0].memory_config().shard_spec.shape[0] == 7168
+    assert layer.routed_expert.routed_down_proj[0].memory_config().shard_spec.shape[0] == 2048
 
 
 @pytest.mark.parametrize(
@@ -766,29 +754,27 @@ def test_save_load_moe_layer_single_layer_4x2(bh_2d_mesh_device, tmp_path):
     elapsed = time.perf_counter() - t0
     logger.info("prepare_moe_layer_weights (1 MoE layer, 4x2 mesh): {:.3f} s", elapsed)
     assert isinstance(orig, DeepSeekV3MoELayerWeights)
-    assert orig.q_a_proj.tensor_shape == (3584, 3072)
-    assert orig.q_b_proj.tensor_shape == (1536, 12288)
-    assert orig.kv_a_proj.tensor_shape == (7168, 576)
-    assert orig.o_proj.tensor_shape == (8192, 7168)
-    assert orig.gate_mm.tensor_shape == (7168, 256)
-    assert orig.gate_bias.shape == (16, 16)
-    assert orig.attn_norm.tensor_shape == (1, 7168)
-    assert orig.q_norm.tensor_shape == (1, 1536)
-    assert orig.kv_norm.tensor_shape == (1, 512)
-    assert orig.ffn_norm.tensor_shape == (1, 7168)
-    assert orig.kv_b1_proj.tensor_shape == (8192, 512)
-    assert orig.kv_b2_proj.tensor_shape == (512, 8192)
-    assert orig.shared_gate_proj.tensor_shape == (7168, 256)
-    assert orig.shared_up_proj.tensor_shape == (7168, 256)
-    assert hasattr(orig, "shared_down_proj")
-    assert len(orig.routed_gate_proj) == NUM_ROUTED_EXPERTS
-    assert len(orig.routed_up_proj) == NUM_ROUTED_EXPERTS
-    assert len(orig.routed_down_proj) == NUM_ROUTED_EXPERTS
-    # Early access to q_ab_kv_a fused_tensor (same as first tensor touched in save_layer)
-    logger.info("Early access: touching q_ab_kv_a fused_tensor (orig.q_a_proj.fused_tensor)...")
-    q_ab_kv_a_fused = orig.q_a_proj.fused_tensor
-    _ = q_ab_kv_a_fused.shape
-    logger.info("Early access: got shape {}", q_ab_kv_a_fused.shape)
+    assert orig.attention.q_a_proj.tensor_shape == (3584, 3072)
+    assert orig.attention.q_b_proj.tensor_shape == (1536, 12288)
+    assert orig.attention.kv_a_proj.tensor_shape == (7168, 576)
+    assert orig.attention.o_proj.tensor_shape == (8192, 7168)
+    assert orig.gate.gate_mm.tensor_shape == (7168, 256)
+    assert orig.gate.gate_bias.shape == (16, 16)
+    assert orig.attention.attn_norm.tensor_shape == (1, 7168)
+    assert orig.attention.q_norm.tensor_shape == (1, 1536)
+    assert orig.attention.kv_norm.tensor_shape == (1, 512)
+    assert orig.attention.ffn_norm.tensor_shape == (1, 7168)
+    assert orig.attention.kv_b1_proj.tensor_shape == (8192, 512)
+    assert orig.attention.kv_b2_proj.tensor_shape == (512, 8192)
+    assert orig.shared_expert.shared_gate_proj.tensor_shape == (7168, 256)
+    assert orig.shared_expert.shared_up_proj.tensor_shape == (7168, 256)
+    assert orig.shared_expert.shared_down_proj is not None
+    assert len(orig.routed_expert.routed_gate_proj) == NUM_ROUTED_EXPERTS
+    assert len(orig.routed_expert.routed_gate_proj[0].shape) == 4
+    assert orig.routed_expert.routed_gate_proj[0].shape == MOE_ROUTED_GATE_UP_SHAPE
+    assert orig.routed_expert.routed_down_proj[0].shape == MOE_ROUTED_DOWN_SHAPE
+    assert orig.routed_expert.routed_gate_proj[0].memory_config().shard_spec.shape[0] == 7168
+    assert orig.routed_expert.routed_down_proj[0].memory_config().shard_spec.shape[0] == 2048
     save_decoder_layer(
         orig,
         tmp_path,
@@ -803,12 +789,9 @@ def test_save_load_moe_layer_single_layer_4x2(bh_2d_mesh_device, tmp_path):
     assert (layer_dir / "gate_up.tensorbin").exists()
     assert (layer_dir / "gate_bias.tensorbin").exists()
     assert (layer_dir / "shared_down_proj.tensorbin").exists()
-    experts_dir = layer_dir / "experts"
-    for e in range(NUM_ROUTED_EXPERTS):
-        expert_dir = experts_dir / f"e_{e:03d}"
-        assert (expert_dir / "gate_proj.tensorbin").exists()
-        assert (expert_dir / "up_proj.tensorbin").exists()
-        assert (expert_dir / "down_proj.tensorbin").exists()
+    assert (layer_dir / "experts" / "e_000" / "gate_proj.tensorbin").exists()
+    assert (layer_dir / "experts" / "e_000" / "up_proj.tensorbin").exists()
+    assert (layer_dir / "experts" / "e_000" / "down_proj.tensorbin").exists()
 
     _deallocate_layer(orig)
     t0 = time.perf_counter()
@@ -817,30 +800,27 @@ def test_save_load_moe_layer_single_layer_4x2(bh_2d_mesh_device, tmp_path):
     logger.info("load_moe_decoder_layer (moe, 4x2 submesh): {:.3f} s", elapsed)
     assert isinstance(layer, DeepSeekV3MoELayerWeights)
 
-    _assert_overlapped_tensors_match(orig.q_a_proj, layer.q_a_proj)
-    _assert_overlapped_tensors_match(orig.q_b_proj, layer.q_b_proj)
-    _assert_overlapped_tensors_match(orig.kv_a_proj, layer.kv_a_proj)
-    _assert_overlapped_tensors_match(orig.o_proj, layer.o_proj)
-    _assert_overlapped_tensors_match(orig.gate_mm, layer.gate_mm)
-    assert layer.gate_bias.shape == orig.gate_bias.shape
-    _assert_overlapped_tensors_match(orig.attn_norm, layer.attn_norm)
-    _assert_overlapped_tensors_match(orig.q_norm, layer.q_norm)
-    _assert_overlapped_tensors_match(orig.kv_norm, layer.kv_norm)
-    _assert_overlapped_tensors_match(orig.ffn_norm, layer.ffn_norm)
-    _assert_overlapped_tensors_match(orig.kv_b1_proj, layer.kv_b1_proj)
-    _assert_overlapped_tensors_match(orig.kv_b2_proj, layer.kv_b2_proj)
-    _assert_overlapped_tensors_match(orig.shared_gate_proj, layer.shared_gate_proj)
-    _assert_overlapped_tensors_match(orig.shared_up_proj, layer.shared_up_proj)
-    assert layer.shared_down_proj.shape == orig.shared_down_proj.shape
-    assert len(layer.routed_gate_proj) == NUM_ROUTED_EXPERTS
-    assert len(layer.routed_up_proj) == NUM_ROUTED_EXPERTS
-    assert len(layer.routed_down_proj) == NUM_ROUTED_EXPERTS
-    for e in range(NUM_ROUTED_EXPERTS):
-        assert layer.routed_gate_proj[e].shape == orig.routed_gate_proj[e].shape
-        assert layer.routed_up_proj[e].shape == orig.routed_up_proj[e].shape
-        assert layer.routed_down_proj[e].shape == orig.routed_down_proj[e].shape
+    _assert_overlapped_tensors_match(orig.attention.q_a_proj, layer.attention.q_a_proj)
+    _assert_overlapped_tensors_match(orig.attention.q_b_proj, layer.attention.q_b_proj)
+    _assert_overlapped_tensors_match(orig.attention.kv_a_proj, layer.attention.kv_a_proj)
+    _assert_overlapped_tensors_match(orig.attention.o_proj, layer.attention.o_proj)
+    _assert_overlapped_tensors_match(orig.gate.gate_mm, layer.gate.gate_mm)
+    assert layer.gate.gate_bias.shape == orig.gate.gate_bias.shape
+    _assert_overlapped_tensors_match(orig.attention.attn_norm, layer.attention.attn_norm)
+    _assert_overlapped_tensors_match(orig.attention.q_norm, layer.attention.q_norm)
+    _assert_overlapped_tensors_match(orig.attention.kv_norm, layer.attention.kv_norm)
+    _assert_overlapped_tensors_match(orig.attention.ffn_norm, layer.attention.ffn_norm)
+    _assert_overlapped_tensors_match(orig.attention.kv_b1_proj, layer.attention.kv_b1_proj)
+    _assert_overlapped_tensors_match(orig.attention.kv_b2_proj, layer.attention.kv_b2_proj)
+    _assert_overlapped_tensors_match(orig.shared_expert.shared_gate_proj, layer.shared_expert.shared_gate_proj)
+    _assert_overlapped_tensors_match(orig.shared_expert.shared_up_proj, layer.shared_expert.shared_up_proj)
+    assert layer.shared_expert.shared_down_proj.shape == orig.shared_expert.shared_down_proj.shape
+    assert len(layer.routed_expert.routed_gate_proj) == len(orig.routed_expert.routed_gate_proj)
+    assert layer.routed_expert.routed_gate_proj[0].shape == orig.routed_expert.routed_gate_proj[0].shape
+    assert layer.routed_expert.routed_up_proj[0].shape == orig.routed_expert.routed_up_proj[0].shape
+    assert layer.routed_expert.routed_down_proj[0].shape == orig.routed_expert.routed_down_proj[0].shape
 
-    assert id(layer.shared_gate_proj.fused_tensor) == id(layer.shared_up_proj.fused_tensor)
+    assert id(layer.shared_expert.shared_gate_proj.fused_tensor) == id(layer.shared_expert.shared_up_proj.fused_tensor)
     _assert_layer_on_device_with_topology(layer)
 
 
@@ -872,22 +852,29 @@ def test_load_moe_decoder_layer_4x2(bh_2d_mesh_device, tmp_path):
 
     layer = load_moe_decoder_layer(tmp_path, submesh, 0)
     assert isinstance(layer, DeepSeekV3MoELayerWeights)
-    assert layer.q_a_proj.tensor_shape == (3584, 3072)
-    assert layer.q_b_proj.tensor_shape == (1536, 12288)
-    assert layer.kv_a_proj.tensor_shape == (7168, 576)
-    assert layer.o_proj.tensor_shape == (8192, 7168)
-    assert layer.gate_mm.tensor_shape == (7168, 256)
-    assert layer.gate_bias.shape == (16, 16)
-    assert layer.attn_norm.tensor_shape == (1, 7168)
-    assert layer.shared_gate_proj.tensor_shape == (7168, 256)
-    assert layer.shared_up_proj.tensor_shape == (7168, 256)
-    assert len(layer.routed_gate_proj) == NUM_ROUTED_EXPERTS
-    assert len(layer.routed_up_proj) == NUM_ROUTED_EXPERTS
-    assert len(layer.routed_down_proj) == NUM_ROUTED_EXPERTS
-    for e in range(NUM_ROUTED_EXPERTS):
-        _assert_on_device(layer.routed_gate_proj[e])
-        _assert_on_device(layer.routed_up_proj[e])
-        _assert_on_device(layer.routed_down_proj[e])
+    assert layer.attention.q_a_proj.tensor_shape == (3584, 3072)
+    assert layer.attention.q_b_proj.tensor_shape == (1536, 12288)
+    assert layer.attention.kv_a_proj.tensor_shape == (7168, 576)
+    assert layer.attention.o_proj.tensor_shape == (8192, 7168)
+    assert layer.gate.gate_mm.tensor_shape == (7168, 256)
+    assert layer.gate.gate_bias.shape == (16, 16)
+    assert layer.attention.attn_norm.tensor_shape == (1, 7168)
+    assert layer.shared_expert.shared_gate_proj.tensor_shape == (7168, 256)
+    assert layer.shared_expert.shared_up_proj.tensor_shape == (7168, 256)
+    assert len(layer.routed_expert.routed_gate_proj) == NUM_ROUTED_EXPERTS
+    assert len(layer.routed_expert.routed_gate_proj[0].shape) == 4
+    assert layer.routed_expert.routed_gate_proj[0].shape == MOE_ROUTED_GATE_UP_SHAPE
+    assert layer.routed_expert.routed_up_proj[0].shape == MOE_ROUTED_GATE_UP_SHAPE
+    assert layer.routed_expert.routed_down_proj[0].shape == MOE_ROUTED_DOWN_SHAPE
+    assert layer.routed_expert.routed_gate_proj[0].memory_config().shard_spec.shape[0] == 7168
+    assert layer.routed_expert.routed_up_proj[0].memory_config().shard_spec.shape[0] == 7168
+    assert layer.routed_expert.routed_down_proj[0].memory_config().shard_spec.shape[0] == 2048
+    for t in layer.routed_expert.routed_gate_proj:
+        _assert_on_device(t)
+    for t in layer.routed_expert.routed_up_proj:
+        _assert_on_device(t)
+    for t in layer.routed_expert.routed_down_proj:
+        _assert_on_device(t)
     _assert_layer_on_device_with_topology(layer)
 
 
@@ -976,87 +963,3 @@ def test_save_load_embedding_and_lm_head_weights_4x2(bh_2d_mesh_device, tmp_path
     assert loaded_lm_head.final_norm.shape == expected_norm_shape
     _assert_on_device(loaded_lm_head.lm_head)
     _assert_on_device(loaded_lm_head.final_norm)
-
-
-@pytest.mark.skip(reason="Too slow for CI; use for manual multi-submesh validation")
-@pytest.mark.parametrize(
-    "device_params",
-    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
-    indirect=True,
-)
-def test_load_4_layers_across_4_submeshes_4x2(bh_2d_mesh_device, tmp_path):
-    """Prepare each of 4 layers on a different 4x2 submesh, save them, then load each on the same submesh.
-
-    Uses create_submeshes to get 4 disjoint (4x2) submeshes; requires 32 devices.
-    Each layer is prepared on its own submesh to avoid OOM. Layers 0,1,2 are dense, layer 3 is MoE.
-    """
-    if not is_slow_dispatch():
-        pytest.skip("load_dense_decoder_layer/load_moe_decoder_layer require slow dispatch")
-    num_submeshes = 4
-    devices_per_submesh = 4 * 2
-    num_devices_required = num_submeshes * devices_per_submesh  # 32
-    if bh_2d_mesh_device.shape[0] * bh_2d_mesh_device.shape[1] < num_devices_required:
-        pytest.skip(
-            f"Test requires {num_devices_required} devices (4 submeshes x 4x2), "
-            f"mesh has {bh_2d_mesh_device.shape[0] * bh_2d_mesh_device.shape[1]}"
-        )
-    submeshes = bh_2d_mesh_device.create_submeshes(ttnn.MeshShape((4, 2)))
-    assert len(submeshes) >= num_submeshes, f"Expected at least {num_submeshes} submeshes"
-
-    num_layers = 4
-    first_k_dense_replace = 3  # layers 0,1,2 dense; layer 3 MoE
-    for layer_idx in range(num_layers):
-        is_moe = layer_idx >= first_k_dense_replace
-        submesh = submeshes[layer_idx]
-        bdw = BlitzDecodeWeights(submesh)
-        # State for "layer 0" (prepare_*_layer_weights take layer_idx for key lookup)
-        state = _layer_state_dict(0, is_moe=is_moe, seed=42 + layer_idx)
-        t0 = time.perf_counter()
-        if is_moe:
-            layer = prepare_moe_layer_weights(bdw, state, 0, num_routed_experts=NUM_ROUTED_EXPERTS)
-        else:
-            layer = prepare_dense_layer_weights(bdw, state, 0)
-        elapsed = time.perf_counter() - t0
-        logger.info(
-            "prepare (layer %d, %s, on submesh %d): {:.3f} s",
-            layer_idx,
-            "moe" if is_moe else "dense",
-            layer_idx,
-            elapsed,
-        )
-        save_decoder_layer(
-            layer,
-            tmp_path,
-            layer_idx,
-            hf_model_name="test-4layer-model",
-            hf_state_dict_name="test-4layer-state-dict.safetensors",
-            device_mesh_shape=(4, 2),
-        )
-        _deallocate_layer(layer)
-
-    loaded = []
-    t0 = time.time()
-    for layer_idx in range(num_layers):
-        submesh = submeshes[layer_idx]
-        if layer_idx >= first_k_dense_replace:
-            layer = load_moe_decoder_layer(tmp_path, submesh, layer_idx)
-        else:
-            layer = load_dense_decoder_layer(tmp_path, submesh, layer_idx)
-        loaded.append(layer)
-    elapsed = time.time() - t0
-    logger.info("load_decoder_layer (4 layers, 4x2 submesh): %s s", elapsed)
-
-    assert isinstance(loaded[0], DeepSeekV3DenseLayerWeights)
-    assert isinstance(loaded[1], DeepSeekV3DenseLayerWeights)
-    assert isinstance(loaded[2], DeepSeekV3DenseLayerWeights)
-    assert isinstance(loaded[3], DeepSeekV3MoELayerWeights)
-    for i in range(3):
-        assert hasattr(loaded[i], "shared_gate_proj") and loaded[i].shared_gate_proj is not None
-        assert hasattr(loaded[i], "routed_gate_proj") and loaded[i].routed_gate_proj is not None
-        assert loaded[i].routed_gate_proj.shape is not None
-    assert len(loaded[3].routed_gate_proj) == NUM_ROUTED_EXPERTS
-    assert len(loaded[3].routed_up_proj) == NUM_ROUTED_EXPERTS
-    assert len(loaded[3].routed_down_proj) == NUM_ROUTED_EXPERTS
-    assert loaded[3].shared_down_proj is not None
-    for i in range(num_layers):
-        _assert_layer_on_device_with_topology(loaded[i])


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=esmal/weight-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:esmal/weight-cleanup)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=esmal/weight-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:esmal/weight-cleanup)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=esmal/weight-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:esmal/weight-cleanup)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=esmal/weight-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:esmal/weight-cleanup)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=esmal/weight-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:esmal/weight-cleanup)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=esmal/weight-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:esmal/weight-cleanup)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
