### PR TITLE
fabric sender benchmark mode optimizations

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_latency_responder.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_latency_responder.cpp
@@ -17,9 +17,10 @@
 constexpr bool enable_fused_payload_with_sync = get_compile_time_arg_val(0) != 0;
 constexpr bool sem_inc_only = get_compile_time_arg_val(1) != 0;
 constexpr bool is_2d_fabric = get_compile_time_arg_val(2) != 0;
+constexpr bool enable_l1_dcache = get_compile_time_arg_val(3) != 0;
 
 void kernel_main() {
-    set_l1_data_cache<false>();
+    set_l1_data_cache<enable_l1_dcache>();
     using namespace tt::tt_fabric;
     size_t arg_idx = 0;
 
@@ -86,7 +87,7 @@ void kernel_main() {
     }
 
     auto send_seminc_packet = [&fabric_connection, sem_inc_packet_header]() {
-        fabric_connection.wait_for_empty_write_slot();
+        fabric_connection.wait_for_empty_write_slot<enable_l1_dcache>();
         fabric_connection.send_payload_flush_non_blocking_from_address(
             (uint32_t)sem_inc_packet_header, sizeof(PACKET_HEADER_TYPE));
     };
@@ -165,4 +166,8 @@ void kernel_main() {
 
     noc_semaphore_set(reinterpret_cast<volatile uint32_t*>(semaphore_address), 0);
     noc_async_full_barrier();
+    
+    if constexpr (enable_l1_dcache) {
+        set_l1_data_cache<false>();
+    }
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_latency_sender.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_latency_sender.cpp
@@ -18,9 +18,10 @@
 constexpr bool enable_fused_payload_with_sync = get_compile_time_arg_val(0) != 0;
 constexpr bool sem_inc_only = get_compile_time_arg_val(1) != 0;
 constexpr bool is_2d_fabric = get_compile_time_arg_val(2) != 0;
+constexpr bool enable_l1_dcache = get_compile_time_arg_val(3) != 0;
 
 void kernel_main() {
-    set_l1_data_cache<false>();
+    set_l1_data_cache<enable_l1_dcache>();
     using namespace tt::tt_fabric;
     size_t arg_idx = 0;
 
@@ -91,13 +92,13 @@ void kernel_main() {
     }
 
     auto send_seminc_packet = [&fabric_connection, sem_inc_packet_header]() {
-        fabric_connection.wait_for_empty_write_slot();
+        fabric_connection.wait_for_empty_write_slot<enable_l1_dcache>();
         fabric_connection.send_payload_flush_non_blocking_from_address(
             (uint32_t)sem_inc_packet_header, sizeof(PACKET_HEADER_TYPE));
     };
 
     auto send_payload_packet = [&fabric_connection, payload_packet_header, send_buffer_address, payload_size_bytes]() {
-        fabric_connection.wait_for_empty_write_slot();
+        fabric_connection.wait_for_empty_write_slot<enable_l1_dcache>();
         if (payload_size_bytes > 0) {
             fabric_connection.send_payload_without_header_non_blocking_from_address(
                 send_buffer_address, payload_size_bytes);
@@ -180,4 +181,8 @@ void kernel_main() {
 
     noc_semaphore_set(reinterpret_cast<volatile uint32_t*>(semaphore_address), 0);
     noc_async_full_barrier();
+    
+    if constexpr (enable_l1_dcache) {
+        set_l1_data_cache<false>();
+    }
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_kernels_utils.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_kernels_utils.hpp
@@ -1027,6 +1027,27 @@ struct SenderKernelTrafficConfig {
 
     bool has_packets_to_send() const { return num_packets_processed < metadata.num_packets; }
 
+    template <bool BENCHMARK_MODE>
+    FORCE_INLINE void send_packets_stateful (
+        SenderKernelTrafficConfig* const traffic_config,
+        tt::tt_fabric::WorkerToFabricEdmSenderImpl<false, 0>* const conn,
+        const uint32_t num_packets,
+        const uint32_t num_warmup) {
+        // Perform stateful noc send by filling buffers with headers, first, then performing credit-only NOC sends
+        // Phase 1: Warmup — send actual headers to fill all buffer slots
+        const uint32_t warmup_end = (num_packets < num_warmup) ? num_packets : num_warmup;
+        for (uint32_t pkt = 0; pkt < warmup_end; pkt++) {
+            traffic_config->template send_one_packet<BENCHMARK_MODE, false, false>();
+        }
+
+        conn->setup_credit_update_noc_state();
+
+        // Phase 2: Steady state — credit-only sends with stateful NOC
+        for (uint32_t pkt = warmup_end; pkt < num_packets; pkt++) {
+            traffic_config->template send_one_packet<BENCHMARK_MODE, true, false>();
+        }
+    }
+
     // Send exactly one packet per call (round-robin scheduling)
     // Returns: true if packet was sent, false if blocked (no credits)
     // In BENCHMARK_MODE, accumulators and prev_t are passed by reference to avoid L1 traffic.
@@ -1059,7 +1080,6 @@ struct SenderKernelTrafficConfig {
                 // noc_accum += (prev_t - t2);
             }
         } else {
-            connection_manager_->wait_for_empty_write_slot<BENCHMARK_MODE, enable_l1_dcache>(connection_ptr_, connection_idx_);
 
             // STEP 3: Send packet
             if (payload_size_bytes > 0 && payload_buffer_) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_kernels_utils.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_kernels_utils.hpp
@@ -1029,7 +1029,7 @@ struct SenderKernelTrafficConfig {
 
     // Send exactly one packet per call (round-robin scheduling)
     // Returns: true if packet was sent, false if blocked (no credits)
-    template <bool BENCHMARK_MODE>
+    template <bool BENCHMARK_MODE, bool STATEFUL_NOC = false>
     bool send_one_packet() {
         // STEP 1: Check credits BEFORE sending (non-benchmark mode only)
         if constexpr (!BENCHMARK_MODE) {
@@ -1039,10 +1039,25 @@ struct SenderKernelTrafficConfig {
         }
 
         // STEP 2: Wait for space
-        connection_manager_->wait_for_empty_write_slot<BENCHMARK_MODE>(connection_ptr_, connection_idx_);
-
-        // STEP 3: Send packet
-        if constexpr (!BENCHMARK_MODE) {
+        if constexpr (BENCHMARK_MODE){
+            connection_manager_->wait_for_empty_write_slot<BENCHMARK_MODE>(connection_ptr_, connection_idx_);
+            // STEP 3: Send packet
+            auto* conn = static_cast<WorkerToFabricEdmSender*>(connection_ptr_);
+            if (num_packets_processed < conn->num_buffers_per_channel) {
+                conn->send_payload_flush_non_blocking_from_address((uint32_t)packet_header, sizeof(PACKET_HEADER_TYPE));
+                // prev_t = get_timestamp_32b();
+                // advance_accum += (prev_t - t1);
+            } else {
+                conn->advance_buffer_slot_write_index();
+                // uint32_t t2 = get_timestamp_32b();
+                // advance_accum += (t2 - t1);
+                conn->update_edm_buffer_free_slots<STATEFUL_NOC>();
+                // prev_t = get_timestamp_32b();
+                // noc_accum += (prev_t - t2);
+            }
+        } else {
+            connection_manager_->wait_for_empty_write_slot<BENCHMARK_MODE>(connection_ptr_, connection_idx_);
+            // STEP 3: Send packet
             if (payload_size_bytes > 0 && payload_buffer_) {
                 payload_buffer_->fill_data(metadata.seed);
 
@@ -1050,11 +1065,11 @@ struct SenderKernelTrafficConfig {
                 connection_manager_->send_payload_without_header<BENCHMARK_MODE>(
                     connection_ptr_, connection_idx_, payload_buffer_->get_physical_address(), payload_size_bytes);
             }
+            // Send header
+            connection_manager_->send_header_non_blocking<BENCHMARK_MODE>(
+                connection_ptr_, connection_idx_, (uint32_t)packet_header);
         }
 
-        // Send header
-        connection_manager_->send_header_non_blocking<BENCHMARK_MODE>(
-            connection_ptr_, connection_idx_, (uint32_t)packet_header);
 
         // STEP 4: Update state (after successful send)
         if constexpr (!BENCHMARK_MODE) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_kernels_utils.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_kernels_utils.hpp
@@ -612,17 +612,17 @@ struct FabricConnectionArray {
     // Unified send operations (dispatch hidden from callers)
 
     // Wait for connection to have space
-    template <bool BENCHMARK_MODE = false>
+    template <bool BENCHMARK_MODE = false, bool enable_l1_dcache = true>
     FORCE_INLINE void wait_for_empty_write_slot(void* conn_ptr, uint8_t idx) {
         if constexpr (BENCHMARK_MODE) {
             // Fast path: no runtime check, direct cast
-            static_cast<WorkerToFabricEdmSender*>(conn_ptr)->wait_for_empty_write_slot();
+            static_cast<WorkerToFabricEdmSender*>(conn_ptr)->wait_for_empty_write_slot<enable_l1_dcache>();
         } else {
             // Normal path: runtime dispatch using cached is_mux array
             if (is_mux[idx]) {
-                static_cast<MuxConnectionType*>(conn_ptr)->wait_for_empty_write_slot();
+                static_cast<MuxConnectionType*>(conn_ptr)->wait_for_empty_write_slot<enable_l1_dcache>();
             } else {
-                static_cast<WorkerToFabricEdmSender*>(conn_ptr)->wait_for_empty_write_slot();
+                static_cast<WorkerToFabricEdmSender*>(conn_ptr)->wait_for_empty_write_slot<enable_l1_dcache>();
             }
         }
     }
@@ -1029,8 +1029,12 @@ struct SenderKernelTrafficConfig {
 
     // Send exactly one packet per call (round-robin scheduling)
     // Returns: true if packet was sent, false if blocked (no credits)
-    template <bool BENCHMARK_MODE, bool STATEFUL_NOC = false>
-    bool send_one_packet() {
+    // In BENCHMARK_MODE, accumulators and prev_t are passed by reference to avoid L1 traffic.
+    // All timestamps are local variables (registers), deltas accumulated directly.
+    // STATEFUL_NOC: when true, uses pre-configured NOC cmd buf state for credit updates.
+    template <bool BENCHMARK_MODE, bool STATEFUL_NOC = false, bool enable_l1_dcache = true>
+    FORCE_INLINE bool send_one_packet(
+        uint32_t& wait_accum, uint32_t& advance_accum, uint32_t& noc_accum, uint32_t& loop_accum, uint32_t& prev_t) {
         // STEP 1: Check credits BEFORE sending (non-benchmark mode only)
         if constexpr (!BENCHMARK_MODE) {
             if (!credit_manager_.has_credits_available(num_packets_processed)) {
@@ -1040,7 +1044,7 @@ struct SenderKernelTrafficConfig {
 
         // STEP 2: Wait for space
         if constexpr (BENCHMARK_MODE){
-            connection_manager_->wait_for_empty_write_slot<BENCHMARK_MODE>(connection_ptr_, connection_idx_);
+            connection_manager_->wait_for_empty_write_slot<BENCHMARK_MODE, enable_l1_dcache>(connection_ptr_, connection_idx_);
             // STEP 3: Send packet
             auto* conn = static_cast<WorkerToFabricEdmSender*>(connection_ptr_);
             if (num_packets_processed < conn->num_buffers_per_channel) {
@@ -1056,7 +1060,8 @@ struct SenderKernelTrafficConfig {
                 // noc_accum += (prev_t - t2);
             }
         } else {
-            connection_manager_->wait_for_empty_write_slot<BENCHMARK_MODE>(connection_ptr_, connection_idx_);
+            connection_manager_->wait_for_empty_write_slot<BENCHMARK_MODE, enable_l1_dcache>(connection_ptr_, connection_idx_);
+
             // STEP 3: Send packet
             if (payload_size_bytes > 0 && payload_buffer_) {
                 payload_buffer_->fill_data(metadata.seed);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_kernels_utils.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_kernels_utils.hpp
@@ -1033,8 +1033,7 @@ struct SenderKernelTrafficConfig {
     // All timestamps are local variables (registers), deltas accumulated directly.
     // STATEFUL_NOC: when true, uses pre-configured NOC cmd buf state for credit updates.
     template <bool BENCHMARK_MODE, bool STATEFUL_NOC = false, bool enable_l1_dcache = true>
-    FORCE_INLINE bool send_one_packet(
-        uint32_t& wait_accum, uint32_t& advance_accum, uint32_t& noc_accum, uint32_t& loop_accum, uint32_t& prev_t) {
+    FORCE_INLINE bool send_one_packet() {
         // STEP 1: Check credits BEFORE sending (non-benchmark mode only)
         if constexpr (!BENCHMARK_MODE) {
             if (!credit_manager_.has_credits_available(num_packets_processed)) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_receiver.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_receiver.cpp
@@ -15,6 +15,7 @@ constexpr uint32_t KERNEL_CONFIG_BUFFER_SIZE = get_compile_time_arg_val(3);
 constexpr uint8_t NUM_CREDIT_CONNECTIONS = get_compile_time_arg_val(4);
 constexpr bool HAS_MUX_CONNECTIONS = get_compile_time_arg_val(5);
 constexpr uint8_t NUM_MUXES_TO_TERMINATE = get_compile_time_arg_val(6);
+constexpr bool enable_l1_dcache = get_compile_time_arg_val(7);
 
 using ReceiverKernelConfigType = ReceiverKernelConfig<NUM_TRAFFIC_CONFIGS, NUM_CREDIT_CONNECTIONS, IS_2D_FABRIC>;
 
@@ -28,6 +29,8 @@ static_assert(
     NUM_CREDIT_CONNECTIONS <= MAX_NUM_FABRIC_CONNECTIONS, "NUM_CREDIT_CONNECTIONS exceeds MAX_NUM_FABRIC_CONNECTIONS");
 
 void kernel_main() {
+    set_l1_data_cache<enable_l1_dcache>();
+
     size_t rt_args_idx = 0;
     size_t local_args_idx = 0;
 
@@ -105,4 +108,8 @@ void kernel_main() {
     write_test_status(receiver_config->get_result_buffer_address(), final_status);
 
     noc_async_full_barrier();
+
+    if constexpr (enable_l1_dcache){
+        set_l1_data_cache<false>();
+    }
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_sender.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_sender.cpp
@@ -77,19 +77,10 @@ void kernel_main() {
         auto* conn = static_cast<WorkerToFabricEdmSender*>(traffic_config->connection_ptr_); 
         const uint32_t num_packets = traffic_config->metadata.num_packets; 
         const uint32_t num_warmup = conn->num_buffers_per_channel;
-        
-        const uint32_t warmup_end = (num_packets < num_warmup) ? num_packets : num_warmup;
-        for(uint32_t pkt = 0; pkt < warmup_end; ++pkt){
-            traffic_config->template send_one_packet<BENCHMARK_MODE, false, false>();
-        } 
 
-        conn->setup_credit_update_noc_state(); 
+        traffic_config->template send_packets_stateful<BENCHMARK_MODE>(traffic_config, conn, num_packets, num_warmup);
 
-        for(uint32_t pkt = warmup_end; pkt < num_packets; ++pkt){
-            traffic_config->template send_one_packet<BENCHMARK_MODE, true, false>();            
-        } 
-    }
-    else{
+    } else {
         while (packets_left_to_send) {
             packets_left_to_send = false;
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_sender.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_sender.cpp
@@ -66,40 +66,61 @@ void kernel_main() {
     // Round-robin packet sending: send one packet from each config per iteration
     uint64_t start_timestamp = get_timestamp();
     constexpr uint32_t PROGRESS_UPDATE_INTERVAL = 1000;  // Write progress every 1000 loops
+                                                         //
 
-    while (packets_left_to_send) {
-        packets_left_to_send = false;
+    if constexpr (NUM_TRAFFIC_CONFIGS == 1 && BENCHMARK_MODE){
+        
+        auto* traffic_config = sender_config->traffic_config_ptrs[0];
+        auto* conn = static_cast<WorkerToFabricEdmSender*>(traffic_config->connection_ptr_); 
+        const uint32_t num_packets = traffic_config->metadata.num_packets; 
+        const uint32_t num_warmup = conn->num_buffers_per_channel;
+        
+        const uint32_t warmup_end = (num_packets < num_warmup) ? num_packets : num_warmup;
+        for(uint32_t pkt = 0; pkt < warmup_end; ++pkt){
+            traffic_config->template send_one_packet<BENCHMARK_MODE, false>();
+        } 
 
-        for (uint8_t i = 0; i < NUM_TRAFFIC_CONFIGS; i++) {
-            auto* traffic_config = sender_config->traffic_config_ptrs[i];
-            if (!traffic_config->has_packets_to_send()) {
-                continue;
-            }
+        conn->setup_credit_update_noc_state(); 
 
-            // Send one packet (credit management is automatic, inside send_one_packet)
-            bool sent = traffic_config->template send_one_packet<BENCHMARK_MODE>();
+        for(uint32_t pkt = warmup_end; pkt < num_packets; ++pkt){
+            traffic_config->template send_one_packet<BENCHMARK_MODE, true>();            
+        } 
+    }
+    else{
+        while (packets_left_to_send) {
+            packets_left_to_send = false;
 
-            if (!sent) {
-                // Packet blocked (no credits) - keep trying
-                packets_left_to_send = true;
-                continue;
-            }
-
-            // Check if more packets remain
-            packets_left_to_send |= traffic_config->has_packets_to_send();
-        }
-
-        loop_count++;
-
-        // Periodically write progress updates (skip in BENCHMARK_MODE for performance)
-        if constexpr (!BENCHMARK_MODE) {
-            if (loop_count % PROGRESS_UPDATE_INTERVAL == 0) {
-                // Calculate total packets sent across all traffic configs
-                uint64_t progress_packets_sent = 0;
-                for (uint8_t i = 0; i < NUM_TRAFFIC_CONFIGS; i++) {
-                    progress_packets_sent += sender_config->traffic_config_ptrs[i]->num_packets_processed;
+            for (uint8_t i = 0; i < NUM_TRAFFIC_CONFIGS; i++) {
+                auto* traffic_config = sender_config->traffic_config_ptrs[i];
+                if (!traffic_config->has_packets_to_send()) {
+                    continue;
                 }
-                write_test_packets(sender_config->get_result_buffer_address(), progress_packets_sent);
+
+                // Send one packet (credit management is automatic, inside send_one_packet)
+                bool sent = traffic_config->template send_one_packet<BENCHMARK_MODE>();
+
+                if (!sent) {
+                    // Packet blocked (no credits) - keep trying
+                    packets_left_to_send = true;
+                    continue;
+                }
+
+                // Check if more packets remain
+                packets_left_to_send |= traffic_config->has_packets_to_send();
+            }
+
+            loop_count++;
+
+            // Periodically write progress updates (skip in BENCHMARK_MODE for performance)
+            if constexpr (!BENCHMARK_MODE) {
+                if (loop_count % PROGRESS_UPDATE_INTERVAL == 0) {
+                    // Calculate total packets sent across all traffic configs
+                    uint64_t progress_packets_sent = 0;
+                    for (uint8_t i = 0; i < NUM_TRAFFIC_CONFIGS; i++) {
+                        progress_packets_sent += sender_config->traffic_config_ptrs[i]->num_packets_processed;
+                    }
+                    write_test_packets(sender_config->get_result_buffer_address(), progress_packets_sent);
+                }
             }
         }
     }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_sender.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_sender.cpp
@@ -17,6 +17,7 @@ constexpr uint8_t NUM_LOCAL_SYNC_CORES = get_compile_time_arg_val(5);
 constexpr uint32_t KERNEL_CONFIG_BUFFER_SIZE = get_compile_time_arg_val(6);
 constexpr bool HAS_MUX_CONNECTIONS = get_compile_time_arg_val(7);
 constexpr uint8_t NUM_MUXES_TO_TERMINATE = get_compile_time_arg_val(8);
+constexpr bool enable_l1_dcache = get_compile_time_arg_val(9);
 
 using SenderKernelConfigType =
     SenderKernelConfig<NUM_TRAFFIC_CONFIGS, IS_2D_FABRIC, LINE_SYNC, NUM_LOCAL_SYNC_CORES>;
@@ -31,6 +32,8 @@ static_assert(
     NUM_FABRIC_CONNECTIONS <= MAX_NUM_FABRIC_CONNECTIONS, "NUM_FABRIC_CONNECTIONS exceeds MAX_NUM_FABRIC_CONNECTIONS");
 
 void kernel_main() {
+    set_l1_data_cache<enable_l1_dcache>();
+
     size_t rt_args_idx = 0;
     size_t local_args_idx = 0;  // Initialize local args index
 
@@ -77,13 +80,13 @@ void kernel_main() {
         
         const uint32_t warmup_end = (num_packets < num_warmup) ? num_packets : num_warmup;
         for(uint32_t pkt = 0; pkt < warmup_end; ++pkt){
-            traffic_config->template send_one_packet<BENCHMARK_MODE, false>();
+            traffic_config->template send_one_packet<BENCHMARK_MODE, false, false>();
         } 
 
         conn->setup_credit_update_noc_state(); 
 
         for(uint32_t pkt = warmup_end; pkt < num_packets; ++pkt){
-            traffic_config->template send_one_packet<BENCHMARK_MODE, true>();            
+            traffic_config->template send_one_packet<BENCHMARK_MODE, true, false>();            
         } 
     }
     else{
@@ -97,7 +100,7 @@ void kernel_main() {
                 }
 
                 // Send one packet (credit management is automatic, inside send_one_packet)
-                bool sent = traffic_config->template send_one_packet<BENCHMARK_MODE>();
+                bool sent = traffic_config->template send_one_packet<BENCHMARK_MODE, false, false>();
 
                 if (!sent) {
                     // Packet blocked (no credits) - keep trying
@@ -151,4 +154,8 @@ void kernel_main() {
     write_test_status(sender_config->get_result_buffer_address(), TT_FABRIC_STATUS_PASS);
 
     noc_async_full_barrier();
+    
+    if constexpr (enable_l1_dcache){
+        set_l1_data_cache<false>();
+    }
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_device_setup.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_device_setup.cpp
@@ -880,7 +880,8 @@ void TestDevice::create_sender_kernels() {
             num_local_sync_cores,                                /* num local sync cores */
             sender_memory_map_->common.get_kernel_config_size(), /* kernel config buffer size */
             has_mux_connections ? 1u : 0u,                       /* HAS_MUX_CONNECTIONS */
-            num_muxes_to_terminate                               /* NUM_MUXES_TO_TERMINATE */
+            num_muxes_to_terminate,                              /* NUM_MUXES_TO_TERMINATE */
+            false                                                /* enable l1 data cache */
         };
 
         // Runtime args with connection type information
@@ -999,7 +1000,8 @@ void TestDevice::create_receiver_kernels() {
             receiver_memory_map_->common.get_kernel_config_size(), /* KERNEL_CONFIG_BUFFER_SIZE */
             (uint32_t)num_connections,                             /* NUM_CREDIT_CONNECTIONS */
             has_mux_connections ? 1u : 0u,                         /* HAS_MUX_CONNECTIONS */
-            num_muxes_to_terminate                                 /* NUM_MUXES_TO_TERMINATE */
+            num_muxes_to_terminate,                                /* NUM_MUXES_TO_TERMINATE */
+            false                                                  /* enable l1 data cache */
         };
 
         // Runtime args: memory map args + credit connection args + traffic-to-connection mapping
@@ -1308,7 +1310,7 @@ void TestDevice::create_latency_sender_kernel(
     bool enable_fused_payload_with_sync = (noc_send_type == NocSendType::NOC_FUSED_UNICAST_ATOMIC_INC);
     bool sem_inc_only = (payload_size == 0);
     std::vector<uint32_t> ct_args = {
-        enable_fused_payload_with_sync ? 1u : 0u, sem_inc_only ? 1u : 0u, is_2d_fabric ? 1u : 0u};
+        enable_fused_payload_with_sync ? 1u : 0u, sem_inc_only ? 1u : 0u, is_2d_fabric ? 1u : 0u, false /* enable l1 dcache */};
 
     // Runtime args
     // Calculate send and receive buffer addresses after timestamp storage
@@ -1407,7 +1409,7 @@ void TestDevice::create_latency_responder_kernel(
     bool enable_fused_payload_with_sync = (noc_send_type == NocSendType::NOC_FUSED_UNICAST_ATOMIC_INC);
     bool sem_inc_only = (payload_size == 0);
     std::vector<uint32_t> ct_args = {
-        enable_fused_payload_with_sync ? 1u : 0u, sem_inc_only ? 1u : 0u, is_2d_fabric ? 1u : 0u};
+        enable_fused_payload_with_sync ? 1u : 0u, sem_inc_only ? 1u : 0u, is_2d_fabric ? 1u : 0u, false /* enable l1 data cache*/};
 
     // Runtime args
     // Calculate responder's receive buffer and sender's receive buffer addresses

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
@@ -254,7 +254,7 @@ struct WorkerToFabricEdmSenderImpl {
     // templatized num_slots to let callers implement bubble flow control without runtime overheads.
     template <size_t num_slots = 1>
     FORCE_INLINE bool edm_has_space_for_packet() const {
-        invalidate_l1_cache();
+        // invalidate_l1_cache();
         if constexpr (!I_USE_STREAM_REG_FOR_CREDIT_RECEIVE) {
             auto used_slots = this->buffer_slot_write_counter.counter - *this->edm_buffer_local_free_slots_read_ptr;
             if constexpr (num_slots == 1) {
@@ -499,7 +499,6 @@ struct WorkerToFabricEdmSenderImpl {
     uint8_t data_noc_cmd_buf;
     uint8_t sync_noc_cmd_buf;
 
-private:
     template <bool stateful_api = false, bool enable_deadlock_avoidance = false>
     FORCE_INLINE void update_edm_buffer_free_slots(uint8_t noc = get_fabric_worker_noc()) {
         if constexpr (stateful_api) {
@@ -510,7 +509,7 @@ private:
                     this->sync_noc_cmd_buf,
                     noc);
             } else {
-                noc_inline_dw_write_with_state<false, false, true, false, false, InlineWriteDst::REG>(
+                noc_inline_dw_write_with_state<false, false, false, false, false, InlineWriteDst::REG>(
                     0,  // val unused
                     0,  // addr unused
                     this->sync_noc_cmd_buf,
@@ -570,6 +569,18 @@ private:
         this->advance_buffer_slot_write_index();
         this->update_edm_buffer_free_slots<stateful_api, enable_deadlock_avoidance>(noc);
     }
+
+    // One-time setup for stateful NOC credit updates.
+    // Call this once before using update_edm_buffer_free_slots<true>.
+    FORCE_INLINE void setup_credit_update_noc_state(uint8_t noc = get_fabric_worker_noc()) {
+        auto packed_val = pack_value_for_inc_on_write_stream_reg_write(-1);
+        const uint64_t noc_sem_addr =
+            get_noc_addr(this->edm_noc_x, this->edm_noc_y, this->edm_buffer_remote_free_slots_update_addr, noc);
+        noc_inline_dw_write_set_state<false /*posted*/, true /*set_val*/>(
+            noc_sem_addr, packed_val, 0xf, this->sync_noc_cmd_buf, noc);
+    }
+
+private:
 
     template <EDM_IO_BLOCKING_MODE blocking_mode>
     FORCE_INLINE void send_payload_without_header_from_address_impl(uint32_t source_address, size_t size_bytes) {

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
@@ -251,10 +251,21 @@ struct WorkerToFabricEdmSenderImpl {
             sync_noc_cmd_buf);
     }
 
+    template <bool RISC_CPU_DATA_CACHE_ENABLED = true>
+    FORCE_INLINE void worker_invalidate_l1_cache() const {
+        if constexpr (RISC_CPU_DATA_CACHE_ENABLED) {
+            invalidate_l1_cache();
+        }
+    }
+
     // templatized num_slots to let callers implement bubble flow control without runtime overheads.
-    template <size_t num_slots = 1>
+    // template enable_l1_dcache to conditionally invalidate l1 cache without runtime overhead 
+    // Usually BRSIC does not use data cache, but default `enable_l1_dcache` to true so its opt-in for non-l1 invalidation optimization and its not a correctness bug 
+    template <size_t num_slots = 1, bool enable_l1_dcache = true>
     FORCE_INLINE bool edm_has_space_for_packet() const {
-        // invalidate_l1_cache();
+        // Workers (BRISC) don't have dcache enabled by default fence is usually unnecessary
+        worker_invalidate_l1_cache<enable_l1_dcache>();
+
         if constexpr (!I_USE_STREAM_REG_FOR_CREDIT_RECEIVE) {
             auto used_slots = this->buffer_slot_write_counter.counter - *this->edm_buffer_local_free_slots_read_ptr;
             if constexpr (num_slots == 1) {
@@ -267,9 +278,10 @@ struct WorkerToFabricEdmSenderImpl {
         }
     }
 
+    template <bool enable_l1_dcache = true>
     FORCE_INLINE void wait_for_empty_write_slot() const {
         WAYPOINT("FWSW");
-        while (!this->edm_has_space_for_packet<1>());
+        while (!this->edm_has_space_for_packet<1, enable_l1_dcache>());
         WAYPOINT("FWSD");
     }
 
@@ -608,6 +620,8 @@ private:
         post_send_payload_increment_pointers();
     }
 };
+
+
 
 using WorkerToFabricEdmSender = WorkerToFabricEdmSenderImpl<false, 0>;
 

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
@@ -24,6 +24,10 @@
 
 namespace tt::tt_fabric {
 
+namespace fabric_tests {
+    struct SenderKernelTrafficConfig;
+}
+
 /*
  * The WorkerToFabricEdmSenderImpl acts as an adapter between the worker and the EDM, it hides details
  * of the communication between worker and EDM to provide flexibility for the implementation to change
@@ -582,9 +586,12 @@ struct WorkerToFabricEdmSenderImpl {
         this->update_edm_buffer_free_slots<stateful_api, enable_deadlock_avoidance>(noc);
     }
 
+    friend struct fabric_tests::SenderKernelTrafficConfig;
+
+protected:
     // One-time setup for stateful NOC credit updates.
     // Call this once before using update_edm_buffer_free_slots<true>.
-    FORCE_INLINE void setup_credit_update_noc_state(uint8_t noc = get_fabric_worker_noc()) {
+    FORCE_INLINE void setup_credit_update_noc_state(uint8_t noc = get_fabric_worker_noc()) const {
         auto packed_val = pack_value_for_inc_on_write_stream_reg_write(-1);
         const uint64_t noc_sem_addr =
             get_noc_addr(this->edm_noc_x, this->edm_noc_y, this->edm_buffer_remote_free_slots_update_addr, noc);


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/38390)

### Problem description
Fabric tests may report artificially low bandwidth due to inefficiencies in test infrastructure. In particular neighbor exchange pattern is limited.

### What's changed
- Use stateful noc APIs once we've filled up the sender channel buffer
- if one traffic config (usually the case), calculate the number of messages and transform to a closed loop (rather than querying the traffic config repeatedly for remaining messages
- Remove unnecessary clear of L1 data cache on workers as it is usually **not ** enabled, making it a compile time arg which is passed in on kernel creation.

### Checklist

- [ ] [![fabric tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tm-fabric-tests.yaml/badge.svg?branch=nzhao/fabric-sender-benchmark-mode-opts)](https://github.com/tenstorrent/tt-metal/actions/workflows/tm-fabric-tests.yaml?query=branch:nzhao/fabric-sender-benchmark-mode-opts)

### Results 
Main branch 
<img width="1173" height="503" alt="image" src="https://github.com/user-attachments/assets/7092f77c-2195-4e4a-a74a-5cb2c4090f92" />

After changes 
<img width="1180" height="497" alt="image" src="https://github.com/user-attachments/assets/eb93e07f-4b69-4b59-be7c-9bbf8e17d3cb" />


#### Model tests
N/A