### PR TITLE
Executor fork safety

### DIFF
--- a/tests/tt_metal/tt_metal/misc/sources.cmake
+++ b/tests/tt_metal/tt_metal/misc/sources.cmake
@@ -1,4 +1,7 @@
 # Source files for tt_metal misc tests
 # Module owners should update this file when adding/removing/renaming source files
 
-set(UNIT_TESTS_MISC_SRC test_tilize_untilize.cpp)
+set(UNIT_TESTS_MISC_SRC
+    test_tilize_untilize.cpp
+    test_executor.cpp
+)

--- a/tests/tt_metal/tt_metal/misc/test_executor.cpp
+++ b/tests/tt_metal/tt_metal/misc/test_executor.cpp
@@ -4,6 +4,7 @@
 
 #include <gtest/gtest.h>
 #include <sys/wait.h>
+#include <thread>
 #include <unistd.h>
 
 #include "common/executor.hpp"
@@ -15,6 +16,16 @@ TEST(ExecutorTest, AsyncRunsInline) {
     auto fut = detail::async([&value] { value.store(42); });
     fut.get();
     EXPECT_EQ(value.load(), 42);
+}
+
+TEST(ExecutorDeathTest, ForkWithInflightWorkAborts) {
+    ASSERT_DEATH(
+        {
+            detail::GetExecutor().silent_async([] { std::this_thread::sleep_for(std::chrono::seconds(5)); });
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+            fork();
+        },
+        "fork.*in-flight work");
 }
 
 TEST(ExecutorTest, ForkSafety) {

--- a/tests/tt_metal/tt_metal/misc/test_executor.cpp
+++ b/tests/tt_metal/tt_metal/misc/test_executor.cpp
@@ -18,16 +18,6 @@ TEST(ExecutorTest, AsyncRunsInline) {
     EXPECT_EQ(value.load(), 42);
 }
 
-TEST(ExecutorDeathTest, ForkWithInflightWorkAborts) {
-    ASSERT_DEATH(
-        {
-            detail::GetExecutor().silent_async([] { std::this_thread::sleep_for(std::chrono::seconds(5)); });
-            std::this_thread::sleep_for(std::chrono::milliseconds(50));
-            fork();
-        },
-        "fork.*in-flight work");
-}
-
 TEST(ExecutorTest, ForkSafety) {
     std::atomic<int> pre{0};
     detail::async([&pre] { pre.store(1); }).get();

--- a/tests/tt_metal/tt_metal/misc/test_executor.cpp
+++ b/tests/tt_metal/tt_metal/misc/test_executor.cpp
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "common/executor.hpp"
+
+namespace tt::tt_metal {
+
+TEST(ExecutorTest, AsyncRunsInline) {
+    std::atomic<int> value{0};
+    auto fut = detail::async([&value] { value.store(42); });
+    fut.get();
+    EXPECT_EQ(value.load(), 42);
+}
+
+TEST(ExecutorTest, ForkSafety) {
+    std::atomic<int> pre{0};
+    detail::async([&pre] { pre.store(1); }).get();
+    ASSERT_EQ(pre.load(), 1);
+
+    pid_t pid = fork();
+    ASSERT_NE(pid, -1) << "fork() failed";
+
+    if (pid == 0) {
+        // Child: the atfork handler should have replaced the dead executor.
+        std::atomic<int> child_val{0};
+        auto fut = detail::async([&child_val] { child_val.store(99); });
+        fut.get();
+        _exit(child_val.load() == 99 ? 0 : 1);
+    }
+
+    // Parent: verify the executor still works here too.
+    std::atomic<int> parent_val{0};
+    detail::async([&parent_val] { parent_val.store(77); }).get();
+    EXPECT_EQ(parent_val.load(), 77);
+
+    int status = 0;
+    ASSERT_EQ(waitpid(pid, &status, 0), pid);
+    ASSERT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(WEXITSTATUS(status), 0) << "Child failed: detail::async did not work after fork";
+}
+
+}  // namespace tt::tt_metal

--- a/tt_metal/common/executor.hpp
+++ b/tt_metal/common/executor.hpp
@@ -6,6 +6,7 @@
 
 #include <pthread.h>
 #include <taskflow/taskflow.hpp>
+#include <cstdlib>
 #include <thread>
 #include <tt_stl/assert.hpp>
 
@@ -24,6 +25,10 @@ inline Executor& GetExecutor() {
     // Also ensure that no work is in-flight on the main process before forking.
     static Executor* exec = [] {
         auto* e = new Executor(EXECUTOR_NTHREADS);
+        std::atexit([] {
+            delete exec;
+            exec = nullptr;
+        });
         pthread_atfork(
             /*prepare=*/
             [] {

--- a/tt_metal/common/executor.hpp
+++ b/tt_metal/common/executor.hpp
@@ -7,6 +7,7 @@
 #include <pthread.h>
 #include <taskflow/taskflow.hpp>
 #include <thread>
+#include <tt_stl/assert.hpp>
 
 namespace tt::tt_metal::detail {
 inline static const size_t EXECUTOR_NTHREADS = std::getenv("TT_METAL_THREADCOUNT")
@@ -19,12 +20,22 @@ using ExecTask = tf::Task;
 inline Executor& GetExecutor() {
     // Child process needs to reinitialize the executor after fork()
     // otherwise it will hang because it will try to reference stale thread state
-    // copied from the parent process
+    // copied from the parent process.
+    // Also ensure that no work is in-flight on the main process before forking.
     static Executor* exec = [] {
         auto* e = new Executor(EXECUTOR_NTHREADS);
         pthread_atfork(
-            /*prepare=*/nullptr,
-            /*parent=*/nullptr,
+            /*prepare=*/
+            [] {
+                TT_FATAL(
+                    exec->num_topologies() == 0,
+                    "fork() called while executor has in-flight work "
+                    "(num_topologies={}). All tasks must complete before forking.",
+                    exec->num_topologies());
+                delete exec;
+                exec = nullptr;
+            },
+            /*parent=*/[] { exec = new Executor(EXECUTOR_NTHREADS); },
             /*child=*/[] { exec = new Executor(EXECUTOR_NTHREADS); });
         return e;
     }();

--- a/tt_metal/common/executor.hpp
+++ b/tt_metal/common/executor.hpp
@@ -4,9 +4,9 @@
 
 #pragma once
 
+#include <pthread.h>
 #include <taskflow/taskflow.hpp>
 #include <thread>
-#include <stdexcept>
 
 namespace tt::tt_metal::detail {
 inline static const size_t EXECUTOR_NTHREADS = std::getenv("TT_METAL_THREADCOUNT")
@@ -17,8 +17,18 @@ using Executor = tf::Executor;
 using ExecTask = tf::Task;
 
 inline Executor& GetExecutor() {
-    static Executor exec(EXECUTOR_NTHREADS);
-    return exec;
+    // Child process needs to reinitialize the executor after fork()
+    // otherwise it will hang because it will try to reference stale thread state
+    // copied from the parent process
+    static Executor* exec = [] {
+        auto* e = new Executor(EXECUTOR_NTHREADS);
+        pthread_atfork(
+            /*prepare=*/nullptr,
+            /*parent=*/nullptr,
+            /*child=*/[] { exec = new Executor(EXECUTOR_NTHREADS); });
+        return e;
+    }();
+    return *exec;
 }
 
 inline std::mutex& GetExecutorMutex() {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/39229

### Problem description
Existing fork test (test_release_ownership) uses a fresh subprocess to launch runtime.

But if we run some things on the main process, close devices and then teardown runtime state, then we fork to a separate process we hang.

In the child process, we try to create a MeshDevice but initialize firmware hangs because the Executor is referring to threads which belong to the main proccess.

### What's changed
- Register a `pthread_atfork` handler so the child process will reinitialize its Executor and not refer to stale state from the parent.
- Add a unit test

### Checklist

New tests are passing. Failures in other test suites are same as main.

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=nhuang/executor-fork)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:nhuang/executor-fork)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nhuang/executor-fork)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nhuang/executor-fork)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nhuang/executor-fork)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nhuang/executor-fork)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nhuang/executor-fork)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nhuang/executor-fork)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nhuang/executor-fork)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nhuang/executor-fork)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nhuang/executor-fork)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nhuang/executor-fork)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
