### PR TITLE
Global Pool Output Shape Fix

### DIFF
--- a/tests/ttnn/unit_tests/operations/pool/test_global_avg_pool2d.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_global_avg_pool2d.py
@@ -38,3 +38,48 @@ def test_run_average_pool2d(
     output_tensor = torch.permute(output_tensor, (0, 3, 1, 2))
 
     assert_with_pcc(torch_output_tensor, output_tensor)
+
+
+@pytest.mark.parametrize(
+    "input_shape",
+    (
+        [1, 144, 7, 7],  # EfficientNet case: 144 channels (not tile-aligned)
+        [12, 144, 56, 56],  # Larger batch with non-aligned channels
+        [1, 48, 14, 14],  # 48 channels (padded to 64)
+        [1, 80, 14, 14],  # 80 channels (padded to 96)
+        [1, 112, 14, 14],  # 112 channels (padded to 128)
+    ),
+    ids=["efficientnet_144", "efficientnet_144_batch12", "mobilenet_48", "mobilenet_80", "mobilenet_112"],
+)
+@pytest.mark.parametrize(
+    "dtype",
+    (ttnn.bfloat16,),
+)
+def test_global_avg_pool2d_non_tile_aligned(
+    input_shape,
+    dtype,
+    device,
+):
+    """
+    Regression test for non-tile-aligned channel dimensions.
+
+    This test ensures that global_avg_pool2d correctly handles tensors where
+    the channel dimension is not a multiple of 32 (tile size). Previously,
+    the operation would return the padded channel count in the output shape
+    instead of the logical (unpadded) channel count.
+
+    Example: Input with 144 channels would incorrectly output 160 channels
+    (144 padded to next multiple of 32) instead of preserving 144 channels.
+    """
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.randn(input_shape)
+    torch_output_tensor = torch.nn.functional.adaptive_avg_pool2d(torch_input_tensor, (1, 1))
+
+    input_tensor = torch.permute(torch_input_tensor, (0, 2, 3, 1))  # ttnn operates on channels-last tensors
+    input_tensor = ttnn.from_torch(input_tensor, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    output_tensor = ttnn.global_avg_pool2d(input_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+    output_tensor = torch.permute(output_tensor, (0, 3, 1, 2))
+
+    assert_with_pcc(torch_output_tensor, output_tensor)

--- a/ttnn/cpp/ttnn/operations/pool/global_avg_pool/global_avg_pool.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/global_avg_pool/global_avg_pool.cpp
@@ -64,6 +64,23 @@ Tensor global_avg_pool2d(
     output = ttnn::experimental::view(output, output_shape);
 
     output = pool_2d<PoolType::AVG>(output, memory_config, output_dtype);
+
+    // Fix the output shape to preserve the logical (unpadded) channel dimension
+    // The pool operation may have padded the channel dimension to tile boundaries,
+    // but the output should maintain the original logical channel count
+    auto output_padded_shape = output.padded_shape();
+
+    // Get the original logical channel count from the input
+    uint32_t logical_channels = logical_shape[-1];
+
+    // Create the correct output shape: [N, 1, 1, C] where C is the logical channel count
+    // Keep the padded shape for tile alignment
+    ttnn::Shape correct_logical_shape({output_padded_shape[0], 1, 1, logical_channels});
+    ttnn::Shape correct_padded_shape({output_padded_shape[0], 1, 1, output_padded_shape[3]});
+
+    // Use view to set the correct logical shape while keeping the same padded shape
+    output = ttnn::experimental::view(output, correct_logical_shape, correct_padded_shape);
+
     return output;
 }
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/31065

### Problem description
Global pool sometimes outputted the wrong stick size.

### What's changed
The logical shape of the output tensor has been updated.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/22734657610
- [x] [Nightly L2](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/22734672103
- [x] [Frequent model](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/22734682556
unrelated errors