### PR TITLE
[skip ci] Exclude MeshDevice1x4FabricFixture.TestGenericOpAllGather on T3000 CI only

### DIFF
--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -96,8 +96,7 @@ run_t3000_ttnn_tests() {
   start_time=$(date +%s)
 
   echo "LOG_METAL: Running run_t3000_ttnn_tests"
-  # Exclude MeshDevice1x4FabricFixture.TestGenericOpAllGather: consistently fails on T3000 with fabric/Ethernet issues (Glean analysis)
-  ./build/test/ttnn/unit_tests_ttnn --gtest_filter="*-MeshDevice1x4FabricFixture.TestGenericOpAllGather"
+  ./build/test/ttnn/unit_tests_ttnn
   ./build/test/ttnn/unit_tests_ttnn_tensor
   ./build/test/ttnn/unit_tests_ttnn_ccl
   ./build/test/ttnn/unit_tests_ttnn_ccl_multi_tensor

--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -96,7 +96,8 @@ run_t3000_ttnn_tests() {
   start_time=$(date +%s)
 
   echo "LOG_METAL: Running run_t3000_ttnn_tests"
-  ./build/test/ttnn/unit_tests_ttnn
+  # Exclude MeshDevice1x4FabricFixture.TestGenericOpAllGather: consistently fails on T3000 with fabric/Ethernet issues (Glean analysis)
+  ./build/test/ttnn/unit_tests_ttnn --gtest_filter="*-MeshDevice1x4FabricFixture.TestGenericOpAllGather"
   ./build/test/ttnn/unit_tests_ttnn_tensor
   ./build/test/ttnn/unit_tests_ttnn_ccl
   ./build/test/ttnn/unit_tests_ttnn_ccl_multi_tensor

--- a/tests/ttnn/unit_tests/gtests/test_generic_op.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_generic_op.cpp
@@ -18,6 +18,7 @@
 #include <tt-logger/tt-logger.hpp>
 #include "hostdevcommon/fabric_common.h"
 #include "ttnn_test_fixtures.hpp"
+#include "tt_metal/api/tt-metalium/cluster.hpp"
 #include "tt_metal/tt_metal/common/multi_device_fixture.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/types.hpp"
@@ -1039,6 +1040,11 @@ protected:
 };
 
 TEST_F(MeshDevice1x4FabricFixture, TestGenericOpAllGather) {
+    // Skipped on T3K: kernel compilation failure in minimal_default_writer. See
+    // https://github.com/tenstorrent/tt-metal/issues/39242
+    if (tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() == tt::tt_metal::ClusterType::T3K) {
+        GTEST_SKIP() << "Disabled on T3K. See https://github.com/tenstorrent/tt-metal/issues/39242";
+    }
     // This test replicates AllGatherReturnedTensor test in test_multi_tensor_ccl.cpp but with the generic op.
     // Hardcoded for 1x4 linear topology with 1 worker per direction and 1 link.
     log_info(tt::LogTest, "Running {}: all_gather via generic_op with MUX", __func__);


### PR DESCRIPTION
### Ticket
N/A - Unblocking T3000 CI

### Problem description
The `MeshDevice1x4FabricFixture.TestGenericOpAllGather` test consistently fails in the `t3k_ttnn_tests` job across multiple T3000 unit test runs. A Glean agent analysis of workflow failures identified this as a recurring fabric/Ethernet-related failure on T3000.

### What's changed
- Add negative gtest filter (`--gtest_filter="*-MeshDevice1x4FabricFixture.TestGenericOpAllGather"`) to the `unit_tests_ttnn` invocation in `run_t3000_ttnn_tests`
- **T3K CI only** – the test continues to run on other platforms (single card, Galaxy) and locally
- Unblocks the t3k_ttnn_tests job while the root cause is investigated

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=disable-t3k-test-generic-op-all-gather)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:disable-t3k-test-generic-op-all-gather)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=disable-t3k-test-generic-op-all-gather)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:disable-t3k-test-generic-op-all-gather)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=disable-t3k-test-generic-op-all-gather)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:disable-t3k-test-generic-op-all-gather)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early

#### Model tests

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=disable-t3k-test-generic-op-all-gather)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:disable-t3k-test-generic-op-all-gather)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))