### PR TITLE
Skip test_tt_fabric in t3k_tt_metal_multiprocess_tests (T3000 CI only)

### DIFF
--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -139,7 +139,8 @@ run_t3000_ttnn_udm_tests() {
 
 run_t3000_tt_metal_multiprocess_tests() {
   local mpi_args="--allow-run-as-root"
-  tt-run --mpi-args "$mpi_args" --rank-binding tests/tt_metal/distributed/config/2x2_multiprocess_rank_bindings.yaml ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_t3k_2x2.yaml
+  # Skipped on T3000: test_tt_fabric consistently times out with "Timeout waiting for Ethernet core service remote IO request flush" (Glean analysis)
+  # tt-run --mpi-args "$mpi_args" --rank-binding tests/tt_metal/distributed/config/2x2_multiprocess_rank_bindings.yaml ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_t3k_2x2.yaml
   tt-run --mpi-args "$mpi_args" --rank-binding tests/tt_metal/distributed/config/2x2_multiprocess_rank_bindings.yaml ./build/test/tt_metal/multi_host_fabric_tests
   tt-run --mpi-args "$mpi_args" --rank-binding tests/tt_metal/distributed/config/2x2_strict_connection_multi_process_rank_bindings.yaml  ./build/test/tt_metal/multi_host_fabric_tests
   tt-run --mpi-args "$mpi_args" --rank-binding tests/tt_metal/distributed/config/2x2_multiprocess_rank_bindings.yaml ./build/test/tt_metal/test_mesh_socket_main --test_config tests/tt_metal/multihost/fabric_tests/mesh_socket_t3k_2x2.yaml


### PR DESCRIPTION
### Ticket
N/A - Unblocking T3000 CI

### Problem description
The `test_tt_fabric` binary consistently fails in the `t3k_tt_metal_multiprocess_tests` job with `Timeout waiting for Ethernet core service remote IO request flush` (Glean analysis). Because it runs first in the function, its failure prevents downstream multiprocess tests (multi_host_fabric_tests, test_mesh_socket_main, etc.) from executing.

### What's changed
- Comment out the `test_tt_fabric` invocation in `run_t3000_tt_metal_multiprocess_tests`
- **T3K CI only** – `run_t3000_tt_metal_multiprocess_tests` is only invoked by the t3k_tt_metal_multiprocess_tests job; `test_tt_fabric` still runs elsewhere (e.g. `run_t3000_ttfabric_tests`, other workflows)
- Allows the rest of the multiprocess test suite to run and potentially surface any other issues

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=disable-t3k-multiprocess-test-tt-fabric)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:disable-t3k-multiprocess-test-tt-fabric)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=disable-t3k-multiprocess-test-tt-fabric)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:disable-t3k-multiprocess-test-tt-fabric)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=disable-t3k-multiprocess-test-tt-fabric)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:disable-t3k-multiprocess-test-tt-fabric)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early

#### Model tests

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=disable-t3k-multiprocess-test-tt-fabric)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:disable-t3k-multiprocess-test-tt-fabric)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))