### PR TITLE
Streaming SDPA v2: WH fixes, BH gating, and k-padding skip

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -402,6 +402,7 @@ void mul_block_bcast_cols_acc(
         tile_regs_commit();
         tile_regs_wait();
         dst_index = 0;
+#ifdef ARCH_BLACKHOLE
         PACK((llk_pack_mop_config<false, false, false>(out_cb, cur_cols)));
         for (uint32_t i = 0; i < tiles_per_row; i++) {
             uint32_t out_tile_index = (write_row_base + i) * tiles_per_column + col_base;
@@ -409,6 +410,14 @@ void mul_block_bcast_cols_acc(
             dst_index += cur_cols;
         }
         PACK((llk_pack_mop_config<false, false, false>(out_cb, 1)));
+#else
+        for (uint32_t i = 0; i < tiles_per_row; i++) {
+            for (uint32_t j = 0; j < cur_cols; j++) {
+                uint32_t out_tile_index = (write_row_base + i) * tiles_per_column + col_base + j;
+                pack_tile<true>(dst_index++, out_cb, out_tile_index);
+            }
+        }
+#endif
         tile_regs_release();
     }
 }
@@ -439,12 +448,13 @@ void normalize_row_streaming(
             cb_reserve_back(scratch_cb, 1);
             tile_regs_acquire();
             matmul_block(cur_sum_cb, col_identity_cb, 0, 0, 0, 0, N, 1, N);
-            // legacy_compat=false uses hardware SFPARECIP + loadmacro pipeline instead of
-            // the slow SFPI Newton-Raphson loop. Full-tile RC mode is safe: only column 0
-            // has meaningful data (from the matmul), and mul_tiles_bcast_cols downstream
-            // only reads column 0.
+#ifdef ARCH_BLACKHOLE
             recip_tile_init<false>();
             MATH((recip_tile<false>(0)));
+#else
+            recip_tile_init();
+            MATH((recip_tile(0)));
+#endif
             tile_regs_commit();
 
             tile_regs_wait();
@@ -734,9 +744,9 @@ static void sdpa_inner_loop_step(
                 }
                 {
                     MaybeDeviceZoneScopedN(PROFILING_ENABLED, "Q@KT MM+Pack (partial)");
-                    PACK((llk_pack_mop_config<false, false, false>(cb_qkt_im, kt_remainder)));
 #ifdef ARCH_BLACKHOLE
-                mm_no_mop_init_short(cb_q_in, cb_kt_in, true, kt_remainder, sbh, in0_block_w);
+                    PACK((llk_pack_mop_config<false, false, false>(cb_qkt_im, kt_remainder)));
+                    mm_no_mop_init_short(cb_q_in, cb_kt_in, true, kt_remainder, sbh, in0_block_w);
 #else
                 mm_block_init_short(cb_q_in, cb_kt_in, true, kt_remainder, sbh, in0_block_w);
 #endif

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -57,23 +57,22 @@ ALWI void cb_push_back_hold_wr_ptr(uint32_t cb_id, uint32_t num_tiles) {
  * Blocked subblock matmul with absolute offset packing.
  * Always uses pack_tile<true> at row-major positions in out_cb.
  */
-template <
-    bool TRANSPOSE,
-    uint32_t SUBBLOCK_W,
-    uint32_t SUBBLOCK_H,
-    uint32_t INNER_DIM,
-    uint32_t IN1_STRIDE,
-    uint32_t OUT_NUM_COLS,
-    bool blocked_pack = false,
-    uint32_t KT_DIM_MATMUL = INNER_DIM>
-void blocked_matmul_and_pack(
+template <bool TRANSPOSE, uint32_t IN1_STRIDE, uint32_t OUT_NUM_COLS, bool blocked_pack = false>
+__attribute__((noinline, noclone)) void blocked_matmul_and_pack(
     uint32_t in0_cb,
     uint32_t in1_cb,
     uint32_t out_cb,
     uint32_t in0_index_start,
     uint32_t in1_index_start,
     uint32_t q_subblock,
-    uint32_t out_col_offset) {
+    uint32_t out_col_offset,
+    uint32_t SUBBLOCK_W,
+    uint32_t SUBBLOCK_H,
+    uint32_t INNER_DIM,
+    uint32_t KT_DIM_MATMUL = 0) {
+    if (KT_DIM_MATMUL == 0) {
+        KT_DIM_MATMUL = INNER_DIM;
+    }
     tile_regs_acquire();
     uint32_t dst_index = 0;
     uint32_t in0_index = in0_index_start;
@@ -117,16 +116,10 @@ void blocked_matmul_and_pack(
  * Per-row-group max reduction with optional eltwise_max against prev values.
  * Reads from in0_cb at row group offset, writes to out_cb sequentially.
  */
-template <
-    PoolType pool_type,
-    ReduceDim reduce_dim,
-    uint32_t scale_cb,
-    uint32_t cols,
-    uint32_t SBH,
-    uint32_t ROW_STRIDE = cols>
+template <PoolType pool_type, ReduceDim reduce_dim, uint32_t scale_cb, uint32_t cols, uint32_t ROW_STRIDE = cols>
 void reduce_c_row_group(
-    uint32_t in0_cb, uint32_t out_cb, uint32_t prev_cb, uint32_t row_group_index, bool do_eltwise_max = false) {
-    constexpr uint32_t GROUP_SIZE = SBH;
+    uint32_t in0_cb, uint32_t out_cb, uint32_t prev_cb, uint32_t row_group_index, bool do_eltwise_max, uint32_t SBH) {
+    const uint32_t GROUP_SIZE = SBH;
     const uint32_t row_start = row_group_index * GROUP_SIZE;
 
     // ROW_STRIDE: physical row width in the CB (may exceed cols on the reduced path).
@@ -175,21 +168,20 @@ void reduce_c_row_group(
 template <
     bool PROFILING_ENABLED,
     uint32_t scale_fp32,
-    uint32_t SBH,
-    uint32_t SBW,
     bool do_reduce,
     int vector_mode = (int)VectorMode::RC,
     bool blocked_pack = false>
-void sub_exp_block_bcast_cols(
+__attribute__((noinline, noclone)) void sub_exp_block_bcast_cols(
     uint32_t inout_cb,
     uint32_t max_cb,
     uint32_t reduce_cb,
     uint32_t cols_in_row,
     uint32_t q_subblock,
-    uint32_t global_col_base) {
-    constexpr uint32_t tiles_per_row = SBH;
-    constexpr uint32_t tiles_per_column = SBW;
-    static_assert(tiles_per_row * tiles_per_column <= 8, "SBH * SBW must fit in DST (max 8 tiles)");
+    uint32_t global_col_base,
+    uint32_t SBH,
+    uint32_t SBW) {
+    const uint32_t tiles_per_row = SBH;
+    const uint32_t tiles_per_column = SBW;
     const uint32_t max_row_base = q_subblock * tiles_per_row;
 
     {
@@ -255,7 +247,9 @@ void sub_exp_block_bcast_cols(
         } else
 #endif
         {
+#pragma GCC unroll 1
             for (uint32_t i = 0; i < tiles_per_row; i++) {
+#pragma GCC unroll 1
                 for (uint32_t j = 0; j < tiles_per_column; ++j) {
                     uint32_t in0_tile_index = (max_row_base + i) * cols_in_row + global_col_base + j;
                     pack_tile<true>(dst_index++, inout_cb, in0_tile_index);
@@ -271,12 +265,14 @@ void sub_exp_block_bcast_cols(
             }
 #endif
             dst_index = 0;
+#pragma GCC unroll 1
             for (uint32_t i = 0; i < tiles_per_row; i++) {
                 if (global_col_base > 0) {
                     PACK((llk_pack_reconfig_l1_acc(1)));
                 } else {
                     PACK((llk_pack_reconfig_l1_acc(0)));
                 }
+#pragma GCC unroll 1
                 for (uint32_t j = 0; j < tiles_per_column; ++j) {
                     pack_tile<true>(dst_index++, reduce_cb, max_row_base + i);
                     if (global_col_base == 0 && j == 0) {
@@ -305,9 +301,10 @@ void sub_exp_block_bcast_cols(
  * Column-only exp(prev_max - cur_max) for SALAD corrections.
  * Operates on first-column subset of tiles.
  */
-template <bool PROFILING_ENABLED, uint32_t scale_fp32, uint32_t SBH>
-void sub_exp_first_col_blocks(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t q_subblock) {
-    constexpr uint32_t tiles_per_row = SBH;
+template <bool PROFILING_ENABLED, uint32_t scale_fp32>
+__attribute__((noinline, noclone)) void sub_exp_first_col_blocks(
+    uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t q_subblock, uint32_t SBH) {
+    const uint32_t tiles_per_row = SBH;
     const uint32_t global_row_base = q_subblock * tiles_per_row;
     constexpr uint16_t scale_bf16 = scale_fp32 >> 16;
 
@@ -344,10 +341,9 @@ void sub_exp_first_col_blocks(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb,
  * SALAD sum correction: out_cb[row] += in0_cb[row] * bcast_cols(in1_cb[row])
  * with L1 accumulate at explicit offset.
  */
-template <uint32_t SBH>
-void mul_bcast_cols_l1_acc(
-    uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t q_subblock, uint32_t write_q_subblock) {
-    constexpr uint32_t tiles_per_row = SBH;
+inline void mul_bcast_cols_l1_acc(
+    uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t q_subblock, uint32_t write_q_subblock, uint32_t SBH) {
+    const uint32_t tiles_per_row = SBH;
     const uint32_t read_row_base = q_subblock * tiles_per_row;
     const uint32_t write_row_base = write_q_subblock * tiles_per_row;
 
@@ -372,14 +368,13 @@ void mul_bcast_cols_l1_acc(
 /**
  * SALAD output correction: block multiply with bcast_cols and L1 accumulate.
  */
-template <uint32_t SBH, uint32_t SBW>
+template <uint32_t SBW>
 void mul_block_bcast_cols_acc(
-    uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t q_subblock, uint32_t write_q_subblock) {
-    constexpr uint32_t tiles_per_row = SBH;
+    uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t q_subblock, uint32_t write_q_subblock, uint32_t SBH) {
+    const uint32_t tiles_per_row = SBH;
     constexpr uint32_t tiles_per_column = SBW;
     // Process columns in batches that fit SBH rows in DST (8 tiles max).
-    constexpr uint32_t COL_BATCH = (8 / SBH < SBW) ? 8 / SBH : SBW;
-    static_assert(COL_BATCH >= 1, "SBH must be <= 8");
+    const uint32_t COL_BATCH = (8 / SBH < SBW) ? 8 / SBH : SBW;
     const uint32_t read_row_base = q_subblock * tiles_per_row;
     const uint32_t write_row_base = write_q_subblock * tiles_per_row;
     mul_bcast_cols_init_short(in0_cb, in1_cb);
@@ -388,7 +383,7 @@ void mul_block_bcast_cols_acc(
     cb_wait_front(in1_cb, (q_subblock + 1) * tiles_per_row);
 
     for (uint32_t col_base = 0; col_base < tiles_per_column; col_base += COL_BATCH) {
-        constexpr uint32_t last_batch = tiles_per_column % COL_BATCH;
+        const uint32_t last_batch = tiles_per_column % COL_BATCH;
         const uint32_t cur_cols =
             (col_base + COL_BATCH <= tiles_per_column) ? COL_BATCH : (last_batch > 0 ? last_batch : COL_BATCH);
         tile_regs_acquire();
@@ -427,13 +422,14 @@ void mul_block_bcast_cols_acc(
  * Consumes (pops) sum and output tiles, writes normalized output.
  * scratch_cb is a 1-tile CB reused for the reciprocal intermediate.
  */
-template <bool PROFILING_ENABLED, uint32_t SBH, uint32_t head_dim_t_>
+template <bool PROFILING_ENABLED, uint32_t head_dim_t_>
 void normalize_row_streaming(
     uint32_t cur_sum_cb,
     uint32_t cur_out_cb,
     uint32_t col_identity_cb,
     uint32_t scratch_cb,
-    uint32_t normalized_out_cb) {
+    uint32_t normalized_out_cb,
+    uint32_t SBH) {
     for (uint32_t s = 0; s < SBH; s++) {
         // 1+2. Fused matmul_reduce + recip: sum × col_identity → recip → 1/sum in scratch
         {
@@ -503,8 +499,8 @@ void normalize_row_streaming(
  * L1-accumulate ring mask tiles onto QKT for one row group (q_subblock).
  * Copies mask tiles from cb_mask_in and adds them in-place to cb_qkt_im using L1 accumulation.
  */
-template <uint32_t Sk_chunk_t, uint32_t sbh, uint32_t cb_mask_in, uint32_t cb_qkt_im>
-static void apply_ring_mask_to_qkt(uint32_t q_subblock) {
+template <uint32_t Sk_chunk_t, uint32_t cb_mask_in, uint32_t cb_qkt_im>
+static void apply_ring_mask_to_qkt(uint32_t q_subblock, uint32_t sbh) {
     constexpr uint32_t DST_BATCH = 8;
     for (uint32_t row = 0; row < sbh; row++) {
         uint32_t out_row_offset = (q_subblock * sbh + row) * Sk_chunk_t;
@@ -547,14 +543,15 @@ static inline void l1_acc_single_tile(uint32_t mask_cb, uint32_t tile_idx, uint3
  * Caller must set up copy_tile_to_dst_init_short and llk_pack_reconfig_l1_acc(1) before calling,
  * and llk_pack_reconfig_l1_acc(0) after calling.
  */
-template <uint32_t num_cols, uint32_t SBH>
-static __attribute__((noinline)) void apply_lightweight_mask_streaming(
+template <uint32_t num_cols>
+static __attribute__((noinline, noclone)) void apply_lightweight_mask_streaming(
     uint32_t mask_cb,
     uint32_t out_cb,
     uint32_t q_subblock,
     uint32_t num_padded,
     bool has_partial,
-    uint32_t partial_tile_idx) {
+    uint32_t partial_tile_idx,
+    uint32_t SBH) {
     uint32_t boundary_col = num_cols - num_padded - (has_partial ? 1 : 0);
     for (uint32_t row = 0; row < SBH; row++) {
         uint32_t row_offset = (q_subblock * SBH + row) * num_cols;
@@ -611,23 +608,21 @@ static void sdpa_inner_loop_step(
     [[maybe_unused]] const bool apply_mask = false,
     const uint32_t lw_num_padded = 0,
     const uint32_t lw_partial_tile_idx = 0,
-    const uint32_t effective_kt_subblocks = 0) {
+    const uint32_t effective_Sk = 0) {
     constexpr uint32_t sbh = subblock_h;
     constexpr uint32_t in0_block_w = DHt;
     constexpr uint32_t qkt_subblock_w = 8 / sbh;
     constexpr uint32_t q_num_subblocks = Sq_chunk_t / sbh;
-    constexpr uint32_t kt_num_full_subblocks = Sk_chunk_t / qkt_subblock_w;
-    constexpr uint32_t kt_remainder = Sk_chunk_t % qkt_subblock_w;
-    constexpr bool has_partial_subblock = (kt_remainder > 0);
-    // Runtime k-padding skip: when effective_kt_subblocks > 0, only process that many
-    // subblocks in Phase 1 and Phase 2 drain. Skipped subblocks are handled by ring mask.
-    const uint32_t runtime_kt_subblocks = (effective_kt_subblocks > 0) ? effective_kt_subblocks : kt_num_full_subblocks;
-    const bool runtime_has_partial = (effective_kt_subblocks > 0) ? false : has_partial_subblock;
+    // K-padding skip: active_Sk = useful K tiles in this chunk.
+    // Tile-level granularity: full subblocks + partial subblock for the tail.
+    // V matmul narrowed to sub_exp'd width. Reduce runs at full Sk_chunk_t.
+    const uint32_t active_Sk = (effective_Sk > 0) ? effective_Sk : Sk_chunk_t;
+    const uint32_t kt_num_full_subblocks = active_Sk / qkt_subblock_w;
+    const uint32_t kt_remainder = active_Sk % qkt_subblock_w;
+    const bool has_partial_subblock = (kt_remainder > 0);
     constexpr uint32_t q_subblock_num_tiles = sbh * in0_block_w;
     constexpr uint32_t row_tiles = sbh * KT_stride;  // Use KT_stride for cb_qkt_im row width
 
-    static_assert(sbh * qkt_subblock_w <= 8, "sbh * qkt_subblock_w must fit in DST (max 8 tiles)");
-    static_assert(Sq_chunk_t % sbh == 0, "Sq_chunk_t must be divisible by subblock_h");
     static_assert(!(use_padded_mask && use_ring_mask), "use_padded_mask and use_ring_mask are mutually exclusive");
 
     // When all CBs share the same data format (e.g. all Float16_b for bf16 models),
@@ -674,21 +669,21 @@ static void sdpa_inner_loop_step(
 #else
         mm_block_init_short(cb_q_in, cb_kt_in, true, qkt_subblock_w, sbh, in0_block_w);
 #endif
-        for (uint32_t kt_subblock = 0; kt_subblock < runtime_kt_subblocks; ++kt_subblock) {
+        for (uint32_t kt_subblock = 0; kt_subblock < kt_num_full_subblocks; ++kt_subblock) {
             if (q_subblock > 0) {
                 uint32_t prev_q_subblock = q_subblock - 1;
                 if constexpr (!uniform_unpack_format) {
                     reconfig_data_format(cb_kt_in, cb_qkt_im, cb_q_in, cb_qkt_im);
                 }
-                sub_exp_block_bcast_cols<
-                    PROFILING_ENABLED,
-                    scale_fp32,
+                sub_exp_block_bcast_cols<PROFILING_ENABLED, scale_fp32, true, VectorMode::RC, true /*blocked_pack*/>(
+                    cb_qkt_im,
+                    cur_max,
+                    cur_sum,
+                    KT_stride,
+                    prev_q_subblock,
+                    kt_subblock * qkt_subblock_w,
                     sbh,
-                    qkt_subblock_w,
-                    true,
-                    VectorMode::RC,
-                    true /*blocked_pack*/>(
-                    cb_qkt_im, cur_max, cur_sum, KT_stride, prev_q_subblock, kt_subblock * qkt_subblock_w);
+                    qkt_subblock_w);
 #ifdef ARCH_BLACKHOLE
                 mm_no_mop_reinit_short(cb_q_in, cb_kt_in, true, qkt_subblock_w, sbh, in0_block_w);
 #else
@@ -700,28 +695,23 @@ static void sdpa_inner_loop_step(
                 if constexpr (!uniform_unpack_format) {
                     reconfig_data_format(cb_qkt_im, cb_kt_in, cb_qkt_im, cb_q_in);
                 }
-                blocked_matmul_and_pack<
-                    true,
-                    qkt_subblock_w,
-                    sbh,
-                    in0_block_w,
-                    KT_stride,
-                    KT_stride,
-                    true /*blocked_pack*/>(
+                blocked_matmul_and_pack<true, KT_stride, KT_stride, true /*blocked_pack*/>(
                     cb_q_in,
                     cb_kt_in,
                     cb_qkt_im,
                     q_index_offset,
                     kt_index_offset,
                     q_subblock,
-                    kt_subblock * qkt_subblock_w);
+                    kt_subblock * qkt_subblock_w,
+                    qkt_subblock_w,
+                    sbh,
+                    in0_block_w);
                 kt_index_offset += qkt_subblock_w;
             }
         }
-        // Partial last subblock: only present on the reduced path (effective_Sk % qkt_subblock_w != 0).
-        // Skipped when runtime k-padding skip is active (runtime_has_partial = false).
-        if constexpr (has_partial_subblock) {
-            if (runtime_has_partial) {
+        // Partial last subblock: handles tile-level tail when active_Sk % qkt_subblock_w != 0.
+        if (has_partial_subblock) {
+            {
 #ifdef ARCH_BLACKHOLE
                 PACK((llk_pack_mop_config<false, false, false>(cb_qkt_im, kt_remainder)));
 #endif
@@ -733,8 +723,6 @@ static void sdpa_inner_loop_step(
                     sub_exp_block_bcast_cols<
                         PROFILING_ENABLED,
                         scale_fp32,
-                        sbh,
-                        kt_remainder,
                         true,
                         VectorMode::RC,
                         true /*blocked_pack*/>(
@@ -743,7 +731,9 @@ static void sdpa_inner_loop_step(
                         cur_sum,
                         KT_stride,
                         prev_q_subblock,
-                        kt_num_full_subblocks * qkt_subblock_w);
+                        kt_num_full_subblocks * qkt_subblock_w,
+                        sbh,
+                        kt_remainder);
                 }
                 {
                     MaybeDeviceZoneScopedN(PROFILING_ENABLED, "Q@KT MM+Pack (partial)");
@@ -755,21 +745,17 @@ static void sdpa_inner_loop_step(
                 if constexpr (!uniform_unpack_format) {
                     reconfig_data_format(cb_qkt_im, cb_kt_in, cb_qkt_im, cb_q_in);
                 }
-                blocked_matmul_and_pack<
-                    true,
-                    kt_remainder,
-                    sbh,
-                    in0_block_w,
-                    KT_stride,
-                    KT_stride,
-                    true /*blocked_pack*/>(
+                blocked_matmul_and_pack<true, KT_stride, KT_stride, true /*blocked_pack*/>(
                     cb_q_in,
                     cb_kt_in,
                     cb_qkt_im,
                     q_index_offset,
                     kt_index_offset,
                     q_subblock,
-                    kt_num_full_subblocks * qkt_subblock_w);
+                    kt_num_full_subblocks * qkt_subblock_w,
+                    kt_remainder,
+                    sbh,
+                    in0_block_w);
                 }
             }
         }
@@ -783,8 +769,14 @@ static void sdpa_inner_loop_step(
             if (apply_mask && (lw_partial_tile_idx > 0 || lw_num_padded > 0)) {
                 copy_tile_to_dst_init_short(cb_mask_in);
                 PACK((llk_pack_reconfig_l1_acc(1)));
-                apply_lightweight_mask_streaming<KT_stride, sbh>(
-                    cb_mask_in, cb_qkt_im, q_subblock, lw_num_padded, lw_partial_tile_idx > 0, lw_partial_tile_idx);
+                apply_lightweight_mask_streaming<KT_stride>(
+                    cb_mask_in,
+                    cb_qkt_im,
+                    q_subblock,
+                    lw_num_padded,
+                    lw_partial_tile_idx > 0,
+                    lw_partial_tile_idx,
+                    sbh);
                 PACK((llk_pack_reconfig_l1_acc(0)));
             }
         }
@@ -799,8 +791,8 @@ static void sdpa_inner_loop_step(
 #ifdef ARCH_BLACKHOLE
             PACK((llk_pack_mop_config<false, false, false>(cur_max, 1)));
 #endif
-            reduce_c_row_group<PoolType::MAX, ReduceDim::REDUCE_ROW, cb_identity_scale_in, Sk_chunk_t, sbh, KT_stride>(
-                cb_qkt_im, cur_max, prev_max, q_subblock, !is_first_iter /*do_eltwise_max*/);
+            reduce_c_row_group<PoolType::MAX, ReduceDim::REDUCE_ROW, cb_identity_scale_in, Sk_chunk_t, KT_stride>(
+                cb_qkt_im, cur_max, prev_max, q_subblock, !is_first_iter /*do_eltwise_max*/, sbh);
             cb_push_back(cur_max, sbh);
 #ifdef ARCH_BLACKHOLE
             PACK((llk_pack_mop_config<false, false, false>(cur_max, qkt_subblock_w)));
@@ -828,14 +820,18 @@ static void sdpa_inner_loop_step(
     // After Phase 1: all rows are pushed (via hold_wr_ptr) in cb_qkt_im.
     // Rows 0..N-2 are softmax'd in-place; row N-1 has raw matmul output.
     {
-        constexpr uint32_t qktv_subblock_h = sbh;
+        const uint32_t qktv_subblock_h = sbh;
         constexpr uint32_t qktv_subblock_w = (vDHt < 4) ? vDHt : 4;
-        constexpr uint32_t qktv_in0_block_w = Sk_chunk_t;  // V matmul inner dim (= effective_Sk on reduced path)
-        constexpr uint32_t qktv_q_num_subblocks = Sq_chunk_t / qktv_subblock_h;
+        constexpr uint32_t qktv_in0_block_w = Sk_chunk_t;
+        // V matmul narrowed to sub_exp'd width. Tile-level when partial subblock is used,
+        // subblock-aligned otherwise (when partial was rounded up to avoid code size).
+        const uint32_t v_matmul_dim =
+            kt_num_full_subblocks * qkt_subblock_w + (has_partial_subblock ? kt_remainder : 0);
+        const uint32_t qktv_q_num_subblocks = Sq_chunk_t / qktv_subblock_h;
         constexpr uint32_t qktv_v_num_subblocks = vDHt / qktv_subblock_w;
         constexpr uint32_t qktv_output_num_tiles = Sq_chunk_t * vDHt;
         // cb_qkt_im row width is KT_stride (for pointer alignment), not Sk_chunk_t
-        constexpr uint32_t qktv_in0_row_tiles = qktv_subblock_h * KT_stride;
+        const uint32_t qktv_in0_row_tiles = qktv_subblock_h * KT_stride;
 
         uint32_t qktv_in0_index_offset = 0;
         uint32_t qktv_in0_wait_tiles = qktv_in0_row_tiles;
@@ -852,11 +848,19 @@ static void sdpa_inner_loop_step(
             MaybeDeviceZoneScopedN(PROFILING_ENABLED, "Softmax(Q@KT)@V");
             // sbh=1 with no partial subblock: split-drain (sub_exp interleaved with V matmul).
             // sbh>1 or partial subblock: non-split drain (all sub_exp first, then full V matmul).
-            if constexpr (sbh == 1 && !has_partial_subblock) {
-                constexpr uint32_t matmul_inner = qktv_in0_block_w / kt_num_full_subblocks;
-                for (uint32_t kt_sub = 0; kt_sub < runtime_kt_subblocks; ++kt_sub) {
-                    sub_exp_block_bcast_cols<PROFILING_ENABLED, scale_fp32, sbh, qkt_subblock_w, true>(
-                        cb_qkt_im, cur_max, cur_sum, KT_stride, q_num_subblocks - 1, kt_sub * qkt_subblock_w);
+            // Note: constexpr on sbh eliminates the dead branch; has_partial_subblock is runtime.
+            if (sbh == 1 && !has_partial_subblock) {
+                const uint32_t matmul_inner = qktv_in0_block_w / kt_num_full_subblocks;
+                for (uint32_t kt_sub = 0; kt_sub < kt_num_full_subblocks; ++kt_sub) {
+                    sub_exp_block_bcast_cols<PROFILING_ENABLED, scale_fp32, true>(
+                        cb_qkt_im,
+                        cur_max,
+                        cur_sum,
+                        KT_stride,
+                        q_num_subblocks - 1,
+                        kt_sub * qkt_subblock_w,
+                        sbh,
+                        qkt_subblock_w);
 
                     if (kt_sub == 0) {
                         cb_wait_front(cb_qkt_im, qktv_in0_wait_tiles);
@@ -878,22 +882,18 @@ static void sdpa_inner_loop_step(
                         mm_block_init_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, qktv_subblock_h, matmul_inner);
 #endif
                         for (uint32_t v_subblock = 0; v_subblock < qktv_v_num_subblocks; ++v_subblock) {
-                            blocked_matmul_and_pack<
-                                false,
-                                qktv_subblock_w,
-                                qktv_subblock_h,
-                                matmul_inner,
-                                vDHt,
-                                vDHt,
-                                false,
-                                KT_stride>(
+                            blocked_matmul_and_pack<false, vDHt, vDHt>(
                                 cb_qkt_im,
                                 cb_v_in,
                                 cur_out,
                                 qktv_in0_index_offset + kt_sub * matmul_inner,
                                 kt_sub * matmul_inner * vDHt + v_index_offset,
                                 0,
-                                v_subblock * qktv_subblock_w);
+                                v_subblock * qktv_subblock_w,
+                                qktv_subblock_w,
+                                qktv_subblock_h,
+                                matmul_inner,
+                                KT_stride);
                             v_index_offset += qktv_subblock_w;
                         }
                         if constexpr (!uniform_unpack_format) {
@@ -907,20 +907,27 @@ static void sdpa_inner_loop_step(
                 }
             } else {
                 // Non-split drain: drain all sub_exp in-place, then full matmul.
-                for (uint32_t kt_sub = 0; kt_sub < runtime_kt_subblocks; ++kt_sub) {
-                    sub_exp_block_bcast_cols<PROFILING_ENABLED, scale_fp32, sbh, qkt_subblock_w, true>(
-                        cb_qkt_im, cur_max, cur_sum, KT_stride, q_num_subblocks - 1, kt_sub * qkt_subblock_w);
+                for (uint32_t kt_sub = 0; kt_sub < kt_num_full_subblocks; ++kt_sub) {
+                    sub_exp_block_bcast_cols<PROFILING_ENABLED, scale_fp32, true>(
+                        cb_qkt_im,
+                        cur_max,
+                        cur_sum,
+                        KT_stride,
+                        q_num_subblocks - 1,
+                        kt_sub * qkt_subblock_w,
+                        sbh,
+                        qkt_subblock_w);
                 }
-                if constexpr (has_partial_subblock) {
-                    if (runtime_has_partial) {
-                        sub_exp_block_bcast_cols<PROFILING_ENABLED, scale_fp32, sbh, kt_remainder, true>(
-                            cb_qkt_im,
-                            cur_max,
-                            cur_sum,
-                            KT_stride,
-                            q_num_subblocks - 1,
-                            kt_num_full_subblocks * qkt_subblock_w);
-                    }
+                if (has_partial_subblock) {
+                    sub_exp_block_bcast_cols<PROFILING_ENABLED, scale_fp32, true>(
+                        cb_qkt_im,
+                        cur_max,
+                        cur_sum,
+                        KT_stride,
+                        q_num_subblocks - 1,
+                        kt_num_full_subblocks * qkt_subblock_w,
+                        sbh,
+                        kt_remainder);
                 }
 
                 cb_wait_front(cb_qkt_im, qktv_in0_wait_tiles);
@@ -932,27 +939,23 @@ static void sdpa_inner_loop_step(
                         reconfig_data_format(cur_out, cb_v_in, cur_out, cb_qkt_im);
                     }
 #ifdef ARCH_BLACKHOLE
-                    mm_no_mop_reinit_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, qktv_subblock_h, KT_stride);
+                    mm_no_mop_reinit_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, qktv_subblock_h, v_matmul_dim);
 #else
-                    mm_block_init_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, qktv_subblock_h, KT_stride);
+                    mm_block_init_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, qktv_subblock_h, v_matmul_dim);
 #endif
                     for (uint32_t v_subblock = 0; v_subblock < qktv_v_num_subblocks; ++v_subblock) {
-                        blocked_matmul_and_pack<
-                            false,
-                            qktv_subblock_w,
-                            qktv_subblock_h,
-                            qktv_in0_block_w,
-                            vDHt,
-                            vDHt,
-                            false,
-                            KT_stride>(
+                        blocked_matmul_and_pack<false, vDHt, vDHt>(
                             cb_qkt_im,
                             cb_v_in,
                             cur_out,
                             qktv_in0_index_offset,
                             v_index_offset,
                             0,
-                            v_subblock * qktv_subblock_w);
+                            v_subblock * qktv_subblock_w,
+                            qktv_subblock_w,
+                            qktv_subblock_h,
+                            v_matmul_dim,
+                            KT_stride);
                         v_index_offset += qktv_subblock_w;
                     }
                     if constexpr (!uniform_unpack_format) {
@@ -970,8 +973,8 @@ static void sdpa_inner_loop_step(
                 MaybeDeviceZoneScopedN(PROFILING_ENABLED, "ROW_NORM");
                 cb_push_back(cur_sum, sbh);
                 cb_push_back(cur_out, sbh * vDHt);
-                normalize_row_streaming<PROFILING_ENABLED, sbh, vDHt>(
-                    cur_sum, cur_out, cb_col_identity, cb_recip_scratch, cb_normalized_out);
+                normalize_row_streaming<PROFILING_ENABLED, vDHt>(
+                    cur_sum, cur_out, cb_col_identity, cb_recip_scratch, cb_normalized_out, sbh);
                 pushed++;
             }
         };
@@ -981,11 +984,11 @@ static void sdpa_inner_loop_step(
             PACK((llk_pack_reconfig_l1_acc(1)));
             {
                 MaybeDeviceZoneScopedN(PROFILING_ENABLED, "S_SUM_CORR");
-                mul_bcast_cols_l1_acc<sbh>(prev_sum, cb_exp_max_diff, cur_sum, salad_row, w_salad);
+                mul_bcast_cols_l1_acc(prev_sum, cb_exp_max_diff, cur_sum, salad_row, w_salad, sbh);
             }
             {
                 MaybeDeviceZoneScopedN(PROFILING_ENABLED, "S_OUT_CORR");
-                mul_block_bcast_cols_acc<sbh, vDHt>(prev_out, cb_exp_max_diff, cur_out, salad_row, w_salad);
+                mul_block_bcast_cols_acc<vDHt>(prev_out, cb_exp_max_diff, cur_out, salad_row, w_salad, sbh);
             }
             PACK((llk_pack_reconfig_l1_acc(0)));
             if (last_iter) {
@@ -1003,8 +1006,8 @@ static void sdpa_inner_loop_step(
 
             if (!is_first_iter) {
                 cb_reserve_back(cb_exp_max_diff, sbh);
-                sub_exp_first_col_blocks<PROFILING_ENABLED, scale_fp32, sbh>(
-                    prev_max, cur_max, cb_exp_max_diff, salad_row);
+                sub_exp_first_col_blocks<PROFILING_ENABLED, scale_fp32>(
+                    prev_max, cur_max, cb_exp_max_diff, salad_row, sbh);
                 cb_push_back(cb_exp_max_diff, sbh);
             }
 
@@ -1017,27 +1020,23 @@ static void sdpa_inner_loop_step(
                     reconfig_data_format(cur_out, cb_v_in, cur_out, cb_qkt_im);
                 }
 #ifdef ARCH_BLACKHOLE
-                mm_no_mop_init_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, qktv_subblock_h, KT_stride);
+                mm_no_mop_init_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, qktv_subblock_h, v_matmul_dim);
 #else
-                mm_block_init_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, qktv_subblock_h, KT_stride);
+                mm_block_init_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, qktv_subblock_h, v_matmul_dim);
 #endif
                 for (uint32_t v_subblock = 0; v_subblock < qktv_v_num_subblocks; ++v_subblock) {
-                    blocked_matmul_and_pack<
-                        false,
-                        qktv_subblock_w,
-                        qktv_subblock_h,
-                        qktv_in0_block_w,
-                        vDHt,
-                        vDHt,
-                        false,
-                        KT_stride>(
+                    blocked_matmul_and_pack<false, vDHt, vDHt>(
                         cb_qkt_im,
                         cb_v_in,
                         cur_out,
                         qktv_in0_index_offset,
                         v_index_offset,
                         w_q,
-                        v_subblock * qktv_subblock_w);
+                        v_subblock * qktv_subblock_w,
+                        qktv_subblock_w,
+                        qktv_subblock_h,
+                        v_matmul_dim,
+                        KT_stride);
                     v_index_offset += qktv_subblock_w;
                 }
                 if constexpr (!uniform_unpack_format) {
@@ -1058,13 +1057,13 @@ static void sdpa_inner_loop_step(
 
         // Pipeline drain: SALAD for last row
         {
-            constexpr uint32_t salad_row = qktv_q_num_subblocks - 1;
+            const uint32_t salad_row = qktv_q_num_subblocks - 1;
             uint32_t w_salad = salad_row - pushed_rows;
 
             if (!is_first_iter) {
                 cb_reserve_back(cb_exp_max_diff, sbh);
-                sub_exp_first_col_blocks<PROFILING_ENABLED, scale_fp32, sbh>(
-                    prev_max, cur_max, cb_exp_max_diff, salad_row);
+                sub_exp_first_col_blocks<PROFILING_ENABLED, scale_fp32>(
+                    prev_max, cur_max, cb_exp_max_diff, salad_row, sbh);
                 cb_push_back(cb_exp_max_diff, sbh);
 
                 salad_correct_row(salad_row, w_salad, is_last_iter, pushed_rows);
@@ -1073,8 +1072,8 @@ static void sdpa_inner_loop_step(
                     MaybeDeviceZoneScopedN(PROFILING_ENABLED, "ROW_NORM");
                     cb_push_back(cur_sum, sbh);
                     cb_push_back(cur_out, sbh * vDHt);
-                    normalize_row_streaming<PROFILING_ENABLED, sbh, vDHt>(
-                        cur_sum, cur_out, cb_col_identity, cb_recip_scratch, cb_normalized_out);
+                    normalize_row_streaming<PROFILING_ENABLED, vDHt>(
+                        cur_sum, cur_out, cb_col_identity, cb_recip_scratch, cb_normalized_out, sbh);
                     pushed_rows++;
                 }
             }
@@ -1139,7 +1138,7 @@ void sdpa_standard_v2(
         uint32_t alias_prev_max = cb_max_A, alias_cur_max = cb_max_B;
         uint32_t alias_prev_out = cb_out_im_A, alias_cur_out = cb_out_im_B;
 
-        auto call_step = [&](auto profiling_tag, bool is_last, bool is_first) {
+        auto call_step = [&](auto profiling_tag, bool is_last, bool is_first, uint32_t eff_Sk) {
             sdpa_inner_loop_step<
                 decltype(profiling_tag)::value,
                 Sq_chunk_t,
@@ -1170,55 +1169,21 @@ void sdpa_standard_v2(
                 alias_prev_out,
                 alias_cur_out,
                 is_last,
-                is_first);
-        };
-
-        // Reduced path for last K chunk with padding: compute with effective_Sk,
-        // skip padded-tile computation. KT_stride = original Sk for CB layout.
-        auto call_step_reduced = [&](auto profiling_tag, bool is_last, bool is_first) {
-            sdpa_inner_loop_step<
-                decltype(profiling_tag)::value,
-                Sq_chunk_t,
-                effective_Sk,
-                Skt,
-                DHt,
-                vDHt,
-                scale_fp32,
-                subblock_h,
-                use_padded_mask,
-                false,  // ring_mode
-                false,  // use_ring_mask
-                uniform_dataformat,
-                cb_q_in,
-                cb_kt_in,
-                cb_v_in,
-                cb_qkt_im,
-                cb_identity_scale_in,
-                cb_exp_max_diff,
-                cb_col_identity,
-                cb_recip_scratch,
-                cb_normalized_out,
-                cb_mask_in,
-                Sk_chunk_t>(  // KT_stride = original Sk for KT CB indexing
-                alias_prev_max,
-                alias_cur_max,
-                alias_prev_sum,
-                alias_cur_sum,
-                alias_prev_out,
-                alias_cur_out,
-                is_last,
-                is_first);
+                is_first,
+                false,  // apply_mask
+                0,      // lw_num_padded
+                0,      // lw_partial_tile_idx
+                eff_Sk);
         };
 
         for (uint32_t k_chunk = 0; k_chunk < k_num_chunks; k_chunk++) {
             bool is_first = (k_chunk == 0);
             bool is_last = (k_chunk == k_num_chunks - 1);
 
-            if (is_last && padded_k_tiles_inner > 0) {
-                call_step_reduced(std::false_type{}, is_last, is_first);
-            } else {
-                call_step(std::false_type{}, is_last, is_first);
-            }
+            // Last chunk with padding: pass effective_Sk to narrow Q@KT and V matmul.
+            // Non-padded chunks: pass 0 (= use full Sk_chunk_t).
+            uint32_t eff_Sk = (is_last && padded_k_tiles_inner > 0) ? effective_Sk : 0;
+            call_step(std::false_type{}, is_last, is_first, eff_Sk);
 
             // Post-iteration cleanup
             if (!is_first) {
@@ -1298,14 +1263,6 @@ void sdpa_ring_v2(
     constexpr uint32_t out_chunk_tiles = Sq_chunk_t * vDHt;
     constexpr bool uniform_format = uniform_dataformat;
 
-    // Runtime k-padding skip: compute effective K subblocks for padded local/joint chunks.
-    // Uses the larger padding (= fewer useful subblocks) for both local and joint.
-    constexpr uint32_t qkt_sbw = 8 / subblock_h;
-    constexpr uint32_t max_padded =
-        (local_n_padded_tiles_ct > joint_n_padded_tiles_ct) ? local_n_padded_tiles_ct : joint_n_padded_tiles_ct;
-    constexpr uint32_t effective_Sk = Sk_chunk_t - max_padded;
-    constexpr uint32_t effective_kt_subs = (effective_Sk + qkt_sbw - 1) / qkt_sbw;
-
     uint32_t KV_chunks_processed_in_iter = 0;
 
     for (uint32_t q = global_q_start; q < global_q_end; q++) {
@@ -1347,15 +1304,15 @@ void sdpa_ring_v2(
                 }
             }
 
-            // Runtime k-padding skip: pass effective_kt_subs for local/joint padded chunks
-            bool is_local_n_mask_chunk = local_n_needs_masking && k_chunk == local_n_mask_chunk_id;
-            bool is_joint_n_mask_chunk = ring_iter_needs_joint_n_mask && kv_chunk_is_joint &&
-                                         (k_chunk - num_local_k_chunks) == joint_n_mask_chunk_id;
-            bool global_n_also_applies = ring_iter_needs_global_n_mask && k_chunk == global_n_mask_chunk_id;
-            uint32_t kt_skip_param = 0;  // 0 = use all subblocks (no skip)
-            if constexpr (max_padded > 0) {
+            // Per-chunk-type effective_Sk: tile-level skip for padded chunks.
+            uint32_t effective_Sk_param = 0;  // 0 = no skip, use full Sk_chunk_t
+            if (lw_num_padded > 0) {
+                bool is_local_n_mask_chunk = local_n_needs_masking && k_chunk == local_n_mask_chunk_id;
+                bool is_joint_n_mask_chunk = ring_iter_needs_joint_n_mask && kv_chunk_is_joint &&
+                                             (k_chunk - num_local_k_chunks) == joint_n_mask_chunk_id;
+                bool global_n_also_applies = ring_iter_needs_global_n_mask && k_chunk == global_n_mask_chunk_id;
                 if ((is_local_n_mask_chunk && !global_n_also_applies) || is_joint_n_mask_chunk) {
-                    kt_skip_param = effective_kt_subs;
+                    effective_Sk_param = Sk_chunk_t - lw_num_padded;
                 }
             }
 
@@ -1393,7 +1350,7 @@ void sdpa_ring_v2(
                 apply_mask,
                 lw_num_padded,
                 lw_partial_tile_idx,
-                kt_skip_param);
+                effective_Sk_param);
 
             // Post-iteration cleanup: pop previous values and swap aliases
             if (!is_first) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -68,8 +68,6 @@ void blocked_matmul_and_pack(
     uint32_t in1_index_start,
     uint32_t q_subblock,
     uint32_t out_col_offset) {
-    mm_block_init_short(in0_cb, in1_cb, TRANSPOSE, SUBBLOCK_W, SUBBLOCK_H, INNER_DIM);
-
     tile_regs_acquire();
     uint32_t dst_index = 0;
     uint32_t in0_index = in0_index_start;
@@ -106,7 +104,8 @@ void reduce_c_row_group(
     const uint32_t cumulative_input_tiles = (row_group_index + 1) * GROUP_SIZE * cols;
     const uint32_t cumulative_prev_tiles = (row_group_index + 1) * GROUP_SIZE;
 
-    cb_wait_front(scale_cb, 1);
+    // scale_cb assumed ready (waited once at kernel init)
+    // cb_wait_front(scale_cb, 1);
     cb_wait_front(in0_cb, cumulative_input_tiles);
 
     tile_regs_acquire();
@@ -166,13 +165,13 @@ void sub_exp_block_bcast_cols(
         PACK((llk_pack_relu_config(ReluType::ZERO_RELU)));
     }
 
-    // Cumulative wait on full CB up through this q_subblock's row
-    cb_wait_front(inout_cb, (q_subblock + 1) * tiles_per_row * cols_in_row);
+    // inout_cb assumed ready (max_cb was already computed from it)
+    // cb_wait_front(inout_cb, (q_subblock + 1) * tiles_per_row * cols_in_row);
     cb_wait_front(max_cb, (q_subblock + 1) * tiles_per_row);
 
+    tile_regs_acquire();
     {
         MaybeDeviceZoneScopedN(PROFILING_ENABLED, "SUB");
-        tile_regs_acquire();
         uint32_t dst_index = 0;
         for (uint32_t i = 0; i < tiles_per_row; i++) {
             for (uint32_t j = 0; j < tiles_per_column; j++) {
@@ -181,12 +180,12 @@ void sub_exp_block_bcast_cols(
                 sub_tiles_bcast_cols(inout_cb, max_cb, in0_tile_index, max_row_base + i, dst_index++);
             }
         }
-        tile_regs_commit();
     }
+    tile_regs_commit();
 
+    tile_regs_wait();
     {
         MaybeDeviceZoneScopedN(PROFILING_ENABLED, "EXP");
-        tile_regs_wait();
         uint32_t dst_index = 0;
         constexpr int iterations = (vector_mode == (int)VectorMode::RC) ? 32 : 8;
         constexpr int vector_mode_exp = (vector_mode == (int)VectorMode::RC) ? (int)VectorMode::None : vector_mode;
@@ -229,9 +228,10 @@ void sub_exp_block_bcast_cols(
         }
     }
 
-    PACK((llk_pack_relu_config(ReluType::NO_RELU)));
-
     tile_regs_release();
+
+    // Restore packer ReLU config after all exp operations complete
+    PACK((llk_pack_relu_config(ReluType::NO_RELU)));
     if constexpr (do_reduce) {
         PACK((llk_pack_reconfig_l1_acc(0)));
     }
@@ -248,7 +248,6 @@ void sub_exp_first_col_blocks(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb,
     constexpr uint16_t scale_bf16 = scale_fp32 >> 16;
 
     sub_tiles_init(in0_cb, in1_cb);
-    exp_packthread_tile_init<EXP_APPROX_MODE, false>();
 
     cb_wait_front(in0_cb, (q_subblock + 1) * tiles_per_row);
     cb_wait_front(in1_cb, (q_subblock + 1) * tiles_per_row);
@@ -642,6 +641,7 @@ static void sdpa_inner_loop_step(
                 if constexpr (!uniform_unpack_format) {
                     reconfig_data_format(cb_qkt_im, cb_kt_in, cb_qkt_im, cb_q_in);
                 }
+                mm_block_init_short(cb_q_in, cb_kt_in, true, qkt_subblock_w, sbh, in0_block_w);
                 blocked_matmul_and_pack<true, qkt_subblock_w, sbh, in0_block_w, Sk_chunk_t, Sk_chunk_t>(
                     cb_q_in,
                     cb_kt_in,
@@ -747,12 +747,13 @@ static void sdpa_inner_loop_step(
 
                     // Matmul — FPU overlaps with SFPU EXP
                     {
+                        MaybeDeviceZoneScopedN(PROFILING_ENABLED, "QKT@V MM+Pack");
                         uint32_t v_index_offset = 0;
                         if constexpr (!uniform_unpack_format) {
                             reconfig_data_format(cur_out, cb_v_in, cur_out, cb_qkt_im);
                         }
+                        mm_block_init_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, qktv_subblock_h, matmul_inner);
                         for (uint32_t v_subblock = 0; v_subblock < qktv_v_num_subblocks; ++v_subblock) {
-                            MaybeDeviceZoneScopedN(PROFILING_ENABLED, "QKT@V MM+Pack");
                             blocked_matmul_and_pack<false, qktv_subblock_w, qktv_subblock_h, matmul_inner, vDHt, vDHt>(
                                 cb_qkt_im,
                                 cb_v_in,
@@ -782,12 +783,13 @@ static void sdpa_inner_loop_step(
 
                 cb_wait_front(cb_qkt_im, qktv_in0_wait_tiles);
                 {
+                    MaybeDeviceZoneScopedN(PROFILING_ENABLED, "QKT@V MM+Pack");
                     uint32_t v_index_offset = 0;
                     if constexpr (!uniform_unpack_format) {
                         reconfig_data_format(cur_out, cb_v_in, cur_out, cb_qkt_im);
                     }
+                    mm_block_init_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, qktv_subblock_h, qktv_in0_block_w);
                     for (uint32_t v_subblock = 0; v_subblock < qktv_v_num_subblocks; ++v_subblock) {
-                        MaybeDeviceZoneScopedN(PROFILING_ENABLED, "QKT@V MM+Pack");
                         blocked_matmul_and_pack<false, qktv_subblock_w, qktv_subblock_h, qktv_in0_block_w, vDHt, vDHt>(
                             cb_qkt_im,
                             cb_v_in,
@@ -835,6 +837,7 @@ static void sdpa_inner_loop_step(
         };
 
         // q_subblock 1..N-1: SALAD(prev) overlapped with matmul(cur)
+        exp_packthread_tile_init<EXP_APPROX_MODE, false>();
         for (uint32_t q_subblock = 1; q_subblock < qktv_q_num_subblocks; ++q_subblock) {
             MaybeDeviceZoneScopedN(PROFILING_ENABLED, "Softmax(Q@KT)@V");
             uint32_t salad_row = q_subblock - 1;
@@ -852,12 +855,13 @@ static void sdpa_inner_loop_step(
 
             // Full matmul for current row
             {
+                MaybeDeviceZoneScopedN(PROFILING_ENABLED, "QKT@V MM+Pack");
                 uint32_t v_index_offset = 0;
                 if constexpr (!uniform_unpack_format) {
                     reconfig_data_format(cur_out, cb_v_in, cur_out, cb_qkt_im);
                 }
+                mm_block_init_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, qktv_subblock_h, qktv_in0_block_w);
                 for (uint32_t v_subblock = 0; v_subblock < qktv_v_num_subblocks; ++v_subblock) {
-                    MaybeDeviceZoneScopedN(PROFILING_ENABLED, "QKT@V MM+Pack");
                     blocked_matmul_and_pack<false, qktv_subblock_w, qktv_subblock_h, qktv_in0_block_w, vDHt, vDHt>(
                         cb_qkt_im,
                         cb_v_in,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -118,7 +118,16 @@ __attribute__((noinline, noclone)) void blocked_matmul_and_pack(
  */
 template <PoolType pool_type, ReduceDim reduce_dim, uint32_t scale_cb, uint32_t cols, uint32_t ROW_STRIDE = cols>
 void reduce_c_row_group(
-    uint32_t in0_cb, uint32_t out_cb, uint32_t prev_cb, uint32_t row_group_index, bool do_eltwise_max, uint32_t SBH) {
+    uint32_t in0_cb,
+    uint32_t out_cb,
+    uint32_t prev_cb,
+    uint32_t row_group_index,
+    bool do_eltwise_max,
+    uint32_t SBH,
+    uint32_t reduce_cols = 0) {
+    if (reduce_cols == 0) {
+        reduce_cols = cols;
+    }
     const uint32_t GROUP_SIZE = SBH;
     const uint32_t row_start = row_group_index * GROUP_SIZE;
 
@@ -144,12 +153,12 @@ void reduce_c_row_group(
     // with in0_cb data arrival.
     cb_wait_front(in0_cb, cumulative_input_tiles);
 
-    reduce_block_max_row_init<cols>();
+    reduce_block_max_row_init_runtime(reduce_cols);
     for (uint32_t i = 0; i < GROUP_SIZE; i++) {
         const uint32_t input_tile_start = (row_start + i) * ROW_STRIDE;
-        reduce_block_max_row<cols>(in0_cb, scale_cb, input_tile_start, i);
+        reduce_block_max_row_runtime(in0_cb, scale_cb, input_tile_start, i);
     }
-    reduce_block_max_row_uninit(in0_cb);
+    reduce_block_max_row_uninit_runtime(in0_cb);
 
     tile_regs_commit();
     tile_regs_wait();
@@ -764,17 +773,20 @@ static void sdpa_inner_loop_step(
             reconfig_data_format(cb_kt_in, cb_qkt_im, cb_q_in, cb_qkt_im);
         }
 
-        // Ring mask: L1-accumulate lightweight mask tiles onto cb_qkt_im for this row group.
+        // Ring mask: L1-accumulate partial-tile mask onto cb_qkt_im for this row group.
+        // Full-tile padding masking is no longer needed: reduce is narrowed to active_Sk,
+        // sub_exp only processes active_Sk tiles, and V matmul is narrowed to v_matmul_dim.
+        // Only partial tiles (where some columns within a tile are padding) still need masking.
         if constexpr (use_ring_mask) {
-            if (apply_mask && (lw_partial_tile_idx > 0 || lw_num_padded > 0)) {
+            if (apply_mask && lw_partial_tile_idx > 0) {
                 copy_tile_to_dst_init_short(cb_mask_in);
                 PACK((llk_pack_reconfig_l1_acc(1)));
                 apply_lightweight_mask_streaming<KT_stride>(
                     cb_mask_in,
                     cb_qkt_im,
                     q_subblock,
-                    lw_num_padded,
-                    lw_partial_tile_idx > 0,
+                    0,  // no full-tile padding needed
+                    true,
                     lw_partial_tile_idx,
                     sbh);
                 PACK((llk_pack_reconfig_l1_acc(0)));
@@ -792,7 +804,7 @@ static void sdpa_inner_loop_step(
             PACK((llk_pack_mop_config<false, false, false>(cur_max, 1)));
 #endif
             reduce_c_row_group<PoolType::MAX, ReduceDim::REDUCE_ROW, cb_identity_scale_in, Sk_chunk_t, KT_stride>(
-                cb_qkt_im, cur_max, prev_max, q_subblock, !is_first_iter /*do_eltwise_max*/, sbh);
+                cb_qkt_im, cur_max, prev_max, q_subblock, !is_first_iter /*do_eltwise_max*/, sbh, active_Sk);
             cb_push_back(cur_max, sbh);
 #ifdef ARCH_BLACKHOLE
             PACK((llk_pack_mop_config<false, false, false>(cur_max, qkt_subblock_w)));

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -349,7 +349,6 @@ void mul_bcast_cols_l1_acc(
     cb_wait_front(in0_cb, (q_subblock + 1) * tiles_per_row);
     cb_wait_front(in1_cb, (q_subblock + 1) * tiles_per_row);
 
-    PACK((llk_pack_reconfig_l1_acc(1)));
     tile_regs_acquire();
     for (uint32_t i = 0; i < tiles_per_row; i++) {
         uint32_t src_tile_index = read_row_base + i;
@@ -362,7 +361,6 @@ void mul_bcast_cols_l1_acc(
         pack_tile<true>(i, out_cb, write_row_base + i);
     }
     tile_regs_release();
-    PACK((llk_pack_reconfig_l1_acc(0)));
 }
 
 /**
@@ -383,7 +381,6 @@ void mul_block_bcast_cols_acc(
     cb_wait_front(in0_cb, (q_subblock + 1) * tiles_per_row * tiles_per_column);
     cb_wait_front(in1_cb, (q_subblock + 1) * tiles_per_row);
 
-    PACK((llk_pack_reconfig_l1_acc(1)));
     for (uint32_t col_base = 0; col_base < tiles_per_column; col_base += COL_BATCH) {
         constexpr uint32_t last_batch = tiles_per_column % COL_BATCH;
         const uint32_t cur_cols =
@@ -399,15 +396,15 @@ void mul_block_bcast_cols_acc(
         tile_regs_commit();
         tile_regs_wait();
         dst_index = 0;
+        PACK((llk_pack_mop_config<false, false, false>(out_cb, cur_cols)));
         for (uint32_t i = 0; i < tiles_per_row; i++) {
-            for (uint32_t j = 0; j < cur_cols; j++) {
-                uint32_t out_tile_index = (write_row_base + i) * tiles_per_column + col_base + j;
-                pack_tile<true>(dst_index++, out_cb, out_tile_index);
-            }
+            uint32_t out_tile_index = (write_row_base + i) * tiles_per_column + col_base;
+            pack_tile<true>(dst_index, out_cb, out_tile_index);
+            dst_index += cur_cols;
         }
+        PACK((llk_pack_mop_config<false, false, false>(out_cb, 1)));
         tile_regs_release();
     }
-    PACK((llk_pack_reconfig_l1_acc(0)));
 }
 
 /**
@@ -478,8 +475,12 @@ void normalize_row_streaming(
             cb_reserve_back(scratch_cb, 1);
             tile_regs_acquire();
             matmul_block(cur_sum_cb, col_identity_cb, 0, 0, 0, 0, N, 1, N);
-            recip_tile_init();
-            MATH((recip_tile_first_column(0)));
+            // legacy_compat=false uses hardware SFPARECIP + loadmacro pipeline instead of
+            // the slow SFPI Newton-Raphson loop. Full-tile RC mode is safe: only column 0
+            // has meaningful data (from the matmul), and mul_tiles_bcast_cols downstream
+            // only reads column 0.
+            recip_tile_init<false>();
+            MATH((recip_tile<false>(0)));
             tile_regs_commit();
 
             tile_regs_wait();
@@ -937,6 +938,7 @@ static void sdpa_inner_loop_step(
 
         // SALAD correction + optional normalization lambda
         auto salad_correct_row = [&](uint32_t salad_row, uint32_t w_salad, bool last_iter, uint32_t& pushed) {
+            PACK((llk_pack_reconfig_l1_acc(1)));
             {
                 MaybeDeviceZoneScopedN(PROFILING_ENABLED, "S_SUM_CORR");
                 mul_bcast_cols_l1_acc<sbh>(prev_sum, cb_exp_max_diff, cur_sum, salad_row, w_salad);
@@ -945,6 +947,7 @@ static void sdpa_inner_loop_step(
                 MaybeDeviceZoneScopedN(PROFILING_ENABLED, "S_OUT_CORR");
                 mul_block_bcast_cols_acc<sbh, vDHt>(prev_out, cb_exp_max_diff, cur_out, salad_row, w_salad);
             }
+            PACK((llk_pack_reconfig_l1_acc(0)));
             if (last_iter) {
                 normalize_row(w_salad, pushed);
             }
@@ -958,8 +961,6 @@ static void sdpa_inner_loop_step(
             uint32_t w_salad = salad_row - pushed_rows;
             uint32_t w_q = q_subblock - pushed_rows;
 
-            cb_wait_front(cb_qkt_im, qktv_in0_wait_tiles);
-
             if (!is_first_iter) {
                 cb_reserve_back(cb_exp_max_diff, sbh);
                 sub_exp_first_col_blocks<PROFILING_ENABLED, scale_fp32, sbh>(
@@ -967,6 +968,7 @@ static void sdpa_inner_loop_step(
                 cb_push_back(cb_exp_max_diff, sbh);
             }
 
+            cb_wait_front(cb_qkt_im, qktv_in0_wait_tiles);
             // Full matmul for current row
             {
                 MaybeDeviceZoneScopedN(PROFILING_ENABLED, "QKT@V MM+Pack");

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -722,6 +722,9 @@ static void sdpa_inner_loop_step(
         // Skipped when runtime k-padding skip is active (runtime_has_partial = false).
         if constexpr (has_partial_subblock) {
             if (runtime_has_partial) {
+#ifdef ARCH_BLACKHOLE
+                PACK((llk_pack_mop_config<false, false, false>(cb_qkt_im, kt_remainder)));
+#endif
                 if (q_subblock > 0) {
                     uint32_t prev_q_subblock = q_subblock - 1;
                     if constexpr (!uniform_unpack_format) {
@@ -745,7 +748,6 @@ static void sdpa_inner_loop_step(
                 {
                     MaybeDeviceZoneScopedN(PROFILING_ENABLED, "Q@KT MM+Pack (partial)");
 #ifdef ARCH_BLACKHOLE
-                    PACK((llk_pack_mop_config<false, false, false>(cb_qkt_im, kt_remainder)));
                     mm_no_mop_init_short(cb_q_in, cb_kt_in, true, kt_remainder, sbh, in0_block_w);
 #else
                 mm_block_init_short(cb_q_in, cb_kt_in, true, kt_remainder, sbh, in0_block_w);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -452,10 +452,10 @@ void normalize_row_streaming(
             matmul_block(cur_sum_cb, col_identity_cb, 0, 0, 0, 0, N, 1, N);
 #ifdef ARCH_BLACKHOLE
             recip_tile_init<false>();
-            MATH((recip_tile<false>(0)));
+            MATH((recip_tile<false>(0, (int)VectorMode::C)));
 #else
             recip_tile_init();
-            MATH((recip_tile(0)));
+            MATH((recip_tile_first_column(0)));
 #endif
             tile_regs_commit();
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -720,7 +720,6 @@ static void sdpa_inner_loop_step(
                 if constexpr (!uniform_unpack_format) {
                     reconfig_data_format(cb_qkt_im, cb_kt_in, cb_qkt_im, cb_q_in);
                 }
-                mm_block_init_short(cb_q_in, cb_kt_in, true, qkt_subblock_w, sbh, in0_block_w);
                 blocked_matmul_and_pack<
                     true,
                     qkt_subblock_w,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -117,13 +117,20 @@ void blocked_matmul_and_pack(
  * Per-row-group max reduction with optional eltwise_max against prev values.
  * Reads from in0_cb at row group offset, writes to out_cb sequentially.
  */
-template <PoolType pool_type, ReduceDim reduce_dim, uint32_t scale_cb, uint32_t cols, uint32_t SBH>
+template <
+    PoolType pool_type,
+    ReduceDim reduce_dim,
+    uint32_t scale_cb,
+    uint32_t cols,
+    uint32_t SBH,
+    uint32_t ROW_STRIDE = cols>
 void reduce_c_row_group(
     uint32_t in0_cb, uint32_t out_cb, uint32_t prev_cb, uint32_t row_group_index, bool do_eltwise_max = false) {
     constexpr uint32_t GROUP_SIZE = SBH;
     const uint32_t row_start = row_group_index * GROUP_SIZE;
 
-    const uint32_t cumulative_input_tiles = (row_group_index + 1) * GROUP_SIZE * cols;
+    // ROW_STRIDE: physical row width in the CB (may exceed cols on the reduced path).
+    const uint32_t cumulative_input_tiles = (row_group_index + 1) * GROUP_SIZE * ROW_STRIDE;
     const uint32_t cumulative_prev_tiles = (row_group_index + 1) * GROUP_SIZE;
 
     // scale_cb assumed ready (waited once at kernel init)
@@ -146,7 +153,7 @@ void reduce_c_row_group(
 
     reduce_block_max_row_init<cols>();
     for (uint32_t i = 0; i < GROUP_SIZE; i++) {
-        const uint32_t input_tile_start = (row_start + i) * cols;
+        const uint32_t input_tile_start = (row_start + i) * ROW_STRIDE;
         reduce_block_max_row<cols>(in0_cb, scale_cb, input_tile_start, i);
     }
     reduce_block_max_row_uninit(in0_cb);
@@ -407,48 +414,6 @@ void mul_block_bcast_cols_acc(
 }
 
 /**
- * Lightweight padded-K mask: L1-accumulate a single permanently-fronted -inf tile onto padded
- * tile positions in cb_qkt_im. No full mask matrix needed — just 1 tile in neginf_cb.
- *
- * Ported from sdpa_benchmark branch's apply_padded_mask.
- *
- * @tparam num_padded  Number of padded K tiles per row (must be > 0)
- * @tparam num_cols    Total K tiles per row (Sk_chunk_t)
- * @tparam SBH         Sub-rows per row group (subblock_h)
- * @tparam DST_BATCH   Max tiles per DST batch (8 for fp16b half-sync)
- */
-template <bool PROFILING_ENABLED, uint32_t num_padded, uint32_t num_cols, uint32_t SBH = 1, uint32_t DST_BATCH = 8>
-static void apply_padded_mask_lightweight(uint32_t neginf_cb, uint32_t out_cb, uint32_t q_subblock = 0) {
-    MaybeDeviceZoneScopedN(PROFILING_ENABLED, "PAD_MASK");
-    static_assert(num_padded > 0, "num_padded must be > 0");
-    static_assert(num_padded < num_cols, "num_padded must be less than num_cols");
-    constexpr uint32_t start = num_cols - num_padded;
-
-    copy_tile_to_dst_init_short(neginf_cb);
-    // neginf_cb tile is permanently fronted — cb_wait_front hoisted to op-level entry point.
-    PACK((llk_pack_reconfig_l1_acc(1)));
-
-    for (uint32_t row = 0; row < SBH; row++) {
-        uint32_t row_offset = (q_subblock * SBH + row) * num_cols;
-        for (uint32_t base = start; base < num_cols; base += DST_BATCH) {
-            uint32_t batch = (num_cols - base < DST_BATCH) ? (num_cols - base) : DST_BATCH;
-            tile_regs_acquire();
-            for (uint32_t i = 0; i < batch; i++) {
-                copy_tile(neginf_cb, 0, i);  // Always tile 0 — single -inf tile
-            }
-            tile_regs_commit();
-            tile_regs_wait();
-            for (uint32_t i = 0; i < batch; i++) {
-                pack_tile<true>(i, out_cb, row_offset + base + i);
-            }
-            tile_regs_release();
-        }
-    }
-
-    PACK((llk_pack_reconfig_l1_acc(0)));
-}
-
-/**
  * Per-row streaming normalization: matmul_reduce + recip-in-DST + mul_bcast_cols.
  * Consumes (pops) sum and output tiles, writes normalized output.
  * scratch_cb is a 1-tile CB reused for the reciprocal intermediate.
@@ -623,8 +588,7 @@ template <
     uint32_t cb_recip_scratch = 0,
     uint32_t cb_normalized_out = 0,
     uint32_t cb_mask_in = 0,
-    uint32_t KT_stride = Sk_chunk_t,
-    uint32_t padded_k_tiles = (Sk_chunk_t - (Skt % Sk_chunk_t)) % Sk_chunk_t>
+    uint32_t KT_stride = Sk_chunk_t>
 static void sdpa_inner_loop_step(
     const uint32_t prev_max,
     const uint32_t cur_max,
@@ -802,18 +766,6 @@ static void sdpa_inner_loop_step(
             reconfig_data_format(cb_kt_in, cb_qkt_im, cb_q_in, cb_qkt_im);
         }
 
-        // Apply mask on last K chunk: L1-accumulate single -inf tile onto padded K positions.
-        // In ring_mode, is_last_iter is always false — skip entirely.
-        if constexpr (padded_k_tiles > 0 && !ring_mode) {
-            if (is_last_iter) {
-#ifdef ARCH_BLACKHOLE
-                PACK((llk_pack_mop_config<false, false, false>(cb_mask_in, 1)));
-#endif
-                apply_padded_mask_lightweight<PROFILING_ENABLED, padded_k_tiles, KT_stride, sbh>(
-                    cb_mask_in, cb_qkt_im, q_subblock);
-            }
-        }
-
         // Ring mask: L1-accumulate lightweight mask tiles onto cb_qkt_im for this row group.
         if constexpr (use_ring_mask) {
             if (apply_mask && (lw_partial_tile_idx > 0 || lw_num_padded > 0)) {
@@ -835,7 +787,7 @@ static void sdpa_inner_loop_step(
 #ifdef ARCH_BLACKHOLE
             PACK((llk_pack_mop_config<false, false, false>(cur_max, 1)));
 #endif
-            reduce_c_row_group<PoolType::MAX, ReduceDim::REDUCE_ROW, cb_identity_scale_in, KT_stride, sbh>(
+            reduce_c_row_group<PoolType::MAX, ReduceDim::REDUCE_ROW, cb_identity_scale_in, Sk_chunk_t, sbh, KT_stride>(
                 cb_qkt_im, cur_max, prev_max, q_subblock, !is_first_iter /*do_eltwise_max*/);
             cb_push_back(cur_max, sbh);
 #ifdef ARCH_BLACKHOLE
@@ -1235,9 +1187,7 @@ void sdpa_standard_v2(
                 cb_recip_scratch,
                 cb_normalized_out,
                 cb_mask_in,
-                Sk_chunk_t,           // KT_stride = original Sk for KT CB indexing
-                padded_k_tiles_inner  // Explicit: masking still needed for KT_stride-wide layout
-                >(
+                Sk_chunk_t>(  // KT_stride = original Sk for KT CB indexing
                 alias_prev_max,
                 alias_cur_max,
                 alias_prev_sum,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -10,6 +10,8 @@
 
 #include <type_traits>
 
+#include "api/compute/experimental/matmul_custom.h"
+#include "api/compute/experimental/sdpa_sub_custom.h"
 #include "tools/profiler/kernel_profiler.hpp"
 
 // Template-driven profiling: MaybeDeviceZoneScopedN(ENABLED, name)
@@ -59,7 +61,8 @@ template <
     uint32_t SUBBLOCK_H,
     uint32_t INNER_DIM,
     uint32_t IN1_STRIDE,
-    uint32_t OUT_NUM_COLS>
+    uint32_t OUT_NUM_COLS,
+    bool blocked_pack = false>
 void blocked_matmul_and_pack(
     uint32_t in0_cb,
     uint32_t in1_cb,
@@ -73,7 +76,12 @@ void blocked_matmul_and_pack(
     uint32_t in0_index = in0_index_start;
     uint32_t in1_index = in1_index_start;
     for (uint32_t inner = 0; inner < INNER_DIM; ++inner) {
+#ifdef ARCH_BLACKHOLE
+        matmul_block_no_mop(
+            in0_cb, in1_cb, in0_index, in1_index, dst_index, TRANSPOSE, SUBBLOCK_W, SUBBLOCK_H, INNER_DIM);
+#else
         matmul_block(in0_cb, in1_cb, in0_index, in1_index, dst_index, TRANSPOSE, SUBBLOCK_W, SUBBLOCK_H, INNER_DIM);
+#endif
         in0_index++;
         in1_index += IN1_STRIDE;
     }
@@ -81,11 +89,22 @@ void blocked_matmul_and_pack(
 
     tile_regs_wait();
     uint32_t dst_idx = 0;
-    for (uint32_t r = 0; r < SUBBLOCK_H; r++) {
-        uint32_t out_row_offset = (r + q_subblock * SUBBLOCK_H) * OUT_NUM_COLS;
-        for (uint32_t c = 0; c < SUBBLOCK_W; c++) {
-            pack_tile<true>(dst_idx, out_cb, out_row_offset + out_col_offset + c);
-            dst_idx++;
+#ifdef ARCH_BLACKHOLE
+    if constexpr (blocked_pack) {
+        for (uint32_t r = 0; r < SUBBLOCK_H; r++) {
+            uint32_t out_row_offset = (r + q_subblock * SUBBLOCK_H) * OUT_NUM_COLS;
+            pack_tile<true>(dst_idx, out_cb, out_row_offset + out_col_offset);
+            dst_idx += SUBBLOCK_W;
+        }
+    } else
+#endif
+    {
+        for (uint32_t r = 0; r < SUBBLOCK_H; r++) {
+            uint32_t out_row_offset = (r + q_subblock * SUBBLOCK_H) * OUT_NUM_COLS;
+            for (uint32_t c = 0; c < SUBBLOCK_W; c++) {
+                pack_tile<true>(dst_idx, out_cb, out_row_offset + out_col_offset + c);
+                dst_idx++;
+            }
         }
     }
     tile_regs_release();
@@ -106,7 +125,6 @@ void reduce_c_row_group(
 
     // scale_cb assumed ready (waited once at kernel init)
     // cb_wait_front(scale_cb, 1);
-    cb_wait_front(in0_cb, cumulative_input_tiles);
 
     tile_regs_acquire();
 
@@ -117,6 +135,11 @@ void reduce_c_row_group(
             copy_tile(prev_cb, row_start + i, i);
         }
     }
+
+    // Deferred: wait for in0_cb just before its first use (reduce_block_max_row).
+    // When do_eltwise_max=true, the prev_cb wait + copy_tile work above can overlap
+    // with in0_cb data arrival.
+    cb_wait_front(in0_cb, cumulative_input_tiles);
 
     reduce_block_max_row_init<cols>();
     for (uint32_t i = 0; i < GROUP_SIZE; i++) {
@@ -145,7 +168,8 @@ template <
     uint32_t SBH,
     uint32_t SBW,
     bool do_reduce,
-    int vector_mode = (int)VectorMode::RC>
+    int vector_mode = (int)VectorMode::RC,
+    bool blocked_pack = false>
 void sub_exp_block_bcast_cols(
     uint32_t inout_cb,
     uint32_t max_cb,
@@ -161,7 +185,11 @@ void sub_exp_block_bcast_cols(
 
     {
         MaybeDeviceZoneScopedN(PROFILING_ENABLED, "SUB_EXP_BLOCK_INIT");
+#ifdef ARCH_BLACKHOLE
+        sub_bcast_cols_init_short_custom(inout_cb, max_cb, tiles_per_column);
+#else
         sub_bcast_cols_init_short(inout_cb, max_cb);
+#endif
         PACK((llk_pack_relu_config(ReluType::ZERO_RELU)));
     }
 
@@ -174,11 +202,18 @@ void sub_exp_block_bcast_cols(
         MaybeDeviceZoneScopedN(PROFILING_ENABLED, "SUB");
         uint32_t dst_index = 0;
         for (uint32_t i = 0; i < tiles_per_row; i++) {
+#ifdef ARCH_BLACKHOLE
+            uint32_t in0_tile_index = (max_row_base + i) * cols_in_row + global_col_base;
+            sub_tiles_bcast_cols_custom(
+                inout_cb, max_cb, in0_tile_index, max_row_base + i, dst_index, tiles_per_column);
+            dst_index += tiles_per_column;
+#else
             for (uint32_t j = 0; j < tiles_per_column; j++) {
                 // Absolute position in cb_qkt_im
                 uint32_t in0_tile_index = (max_row_base + i) * cols_in_row + global_col_base + j;
                 sub_tiles_bcast_cols(inout_cb, max_cb, in0_tile_index, max_row_base + i, dst_index++);
             }
+#endif
         }
     }
     tile_regs_commit();
@@ -202,15 +237,31 @@ void sub_exp_block_bcast_cols(
         MaybeDeviceZoneScopedN(PROFILING_ENABLED, "PACK SUB_EXP");
         // Pack back to inout_cb at the same absolute positions
         uint32_t dst_index = 0;
-        for (uint32_t i = 0; i < tiles_per_row; i++) {
-            for (uint32_t j = 0; j < tiles_per_column; ++j) {
-                uint32_t in0_tile_index = (max_row_base + i) * cols_in_row + global_col_base + j;
-                pack_tile<true>(dst_index++, inout_cb, in0_tile_index);
+#ifdef ARCH_BLACKHOLE
+        if constexpr (blocked_pack) {
+            for (uint32_t i = 0; i < tiles_per_row; i++) {
+                uint32_t in0_tile_index = (max_row_base + i) * cols_in_row + global_col_base;
+                pack_tile<true>(dst_index, inout_cb, in0_tile_index);
+                dst_index += tiles_per_column;
+            }
+        } else
+#endif
+        {
+            for (uint32_t i = 0; i < tiles_per_row; i++) {
+                for (uint32_t j = 0; j < tiles_per_column; ++j) {
+                    uint32_t in0_tile_index = (max_row_base + i) * cols_in_row + global_col_base + j;
+                    pack_tile<true>(dst_index++, inout_cb, in0_tile_index);
+                }
             }
         }
 
         // Reduce to reduce_cb: first tile of first kt_subblock overwrites, rest accumulate
         if constexpr (do_reduce) {
+#ifdef ARCH_BLACKHOLE
+            if constexpr (blocked_pack) {
+                PACK((llk_pack_mop_config<false, false, false>(reduce_cb, 1)));
+            }
+#endif
             dst_index = 0;
             for (uint32_t i = 0; i < tiles_per_row; i++) {
                 if (global_col_base > 0) {
@@ -233,6 +284,11 @@ void sub_exp_block_bcast_cols(
     // Restore packer ReLU config after all exp operations complete
     PACK((llk_pack_relu_config(ReluType::NO_RELU)));
     if constexpr (do_reduce) {
+#ifdef ARCH_BLACKHOLE
+        if constexpr (blocked_pack) {
+            PACK((llk_pack_mop_config<false, false, false>(reduce_cb, tiles_per_column)));
+        }
+#endif
         PACK((llk_pack_reconfig_l1_acc(0)));
     }
 }
@@ -613,17 +669,26 @@ static void sdpa_inner_loop_step(
     }
     cb_reserve_back(cb_qkt_im, Sq_chunk_t * Sk_chunk_t);
 
-    cb_wait_front(cb_kt_in, DHt * Sk_chunk_t);
     cb_reserve_back(cur_sum, Sq_chunk_t);
 
     // ========== PHASE 1: Q@KT directly into cb_qkt_im ==========
     // All matmul output goes to cb_qkt_im at absolute offsets via pack_tile<true>.
     // cb_push_back_hold_wr_ptr makes each row visible to UNPACK without advancing wr_ptr.
+    PACK((llk_pack_mop_config<false, false, false>(cb_qkt_im, qkt_subblock_w)));
     for (uint32_t q_subblock = 0; q_subblock < q_num_subblocks; q_subblock++) {
         MaybeDeviceZoneScopedN(PROFILING_ENABLED, "Softmax(Q@KT)");
         cb_wait_front(cb_q_in, q_wait_tiles);
+        // Deferred KT wait: reader pushes Q before KT, so waiting for Q first
+        // allows reserves + MOP config + Q wait to overlap with KT DMA.
+        if (q_subblock == 0) {
+            cb_wait_front(cb_kt_in, DHt * Sk_chunk_t);
+        }
         kt_index_offset = 0;
-
+#ifdef ARCH_BLACKHOLE
+        mm_no_mop_init_short(cb_q_in, cb_kt_in, true, qkt_subblock_w, sbh, in0_block_w);
+#else
+        mm_block_init_short(cb_q_in, cb_kt_in, true, qkt_subblock_w, sbh, in0_block_w);
+#endif
         for (uint32_t kt_subblock = 0; kt_subblock < kt_num_subblocks; ++kt_subblock) {
             if (q_subblock > 0) {
                 uint32_t prev_q_subblock = q_subblock - 1;
@@ -631,10 +696,20 @@ static void sdpa_inner_loop_step(
                 if constexpr (!uniform_unpack_format) {
                     reconfig_data_format(cb_kt_in, cb_qkt_im, cb_q_in, cb_qkt_im);
                 }
-                sub_exp_block_bcast_cols<PROFILING_ENABLED, scale_fp32, sbh, qkt_subblock_w, true>(
-                    cb_qkt_im, cur_max, cur_sum, Sk_chunk_t, prev_q_subblock, kt_subblock);
+                sub_exp_block_bcast_cols<
+                    PROFILING_ENABLED,
+                    scale_fp32,
+                    sbh,
+                    qkt_subblock_w,
+                    true,
+                    VectorMode::RC,
+                    true /*blocked_pack*/>(cb_qkt_im, cur_max, cur_sum, Sk_chunk_t, prev_q_subblock, kt_subblock);
+#ifdef ARCH_BLACKHOLE
+                mm_no_mop_reinit_short(cb_q_in, cb_kt_in, true, qkt_subblock_w, sbh, in0_block_w);
+#else
+                mm_block_init_short(cb_q_in, cb_kt_in, true, qkt_subblock_w, sbh, in0_block_w);
+#endif
             }
-
             {
                 MaybeDeviceZoneScopedN(PROFILING_ENABLED, "Q@KT MM+Pack");
                 // Setup matmul UNPACK (early-exit if already set, e.g., q_subblock==0 consecutive calls).
@@ -642,7 +717,14 @@ static void sdpa_inner_loop_step(
                     reconfig_data_format(cb_qkt_im, cb_kt_in, cb_qkt_im, cb_q_in);
                 }
                 mm_block_init_short(cb_q_in, cb_kt_in, true, qkt_subblock_w, sbh, in0_block_w);
-                blocked_matmul_and_pack<true, qkt_subblock_w, sbh, in0_block_w, Sk_chunk_t, Sk_chunk_t>(
+                blocked_matmul_and_pack<
+                    true,
+                    qkt_subblock_w,
+                    sbh,
+                    in0_block_w,
+                    Sk_chunk_t,
+                    Sk_chunk_t,
+                    true /*blocked_pack*/>(
                     cb_q_in,
                     cb_kt_in,
                     cb_qkt_im,
@@ -650,8 +732,8 @@ static void sdpa_inner_loop_step(
                     kt_index_offset,
                     q_subblock,
                     kt_subblock * qkt_subblock_w);
+                kt_index_offset += qkt_subblock_w;
             }
-            kt_index_offset += qkt_subblock_w;
         }
         // Restore float16b for mask/reduce after Q@KT.
         if constexpr (!uniform_unpack_format) {
@@ -662,6 +744,7 @@ static void sdpa_inner_loop_step(
         // In ring_mode, is_last_iter is always false — skip entirely.
         if constexpr (padded_k_tiles > 0 && !ring_mode) {
             if (is_last_iter) {
+                PACK((llk_pack_mop_config<false, false, false>(cb_mask_in, 1)));
                 apply_padded_mask_lightweight<PROFILING_ENABLED, padded_k_tiles, Sk_chunk_t, sbh>(
                     cb_mask_in, cb_qkt_im, q_subblock);
             }
@@ -685,9 +768,11 @@ static void sdpa_inner_loop_step(
         {
             MaybeDeviceZoneScopedN(PROFILING_ENABLED, "Reduce max");
             cb_reserve_back(cur_max, sbh);
+            PACK((llk_pack_mop_config<false, false, false>(cur_max, 1)));
             reduce_c_row_group<PoolType::MAX, ReduceDim::REDUCE_ROW, cb_identity_scale_in, Sk_chunk_t, sbh>(
                 cb_qkt_im, cur_max, prev_max, q_subblock, !is_first_iter /*do_eltwise_max*/);
             cb_push_back(cur_max, sbh);
+            PACK((llk_pack_mop_config<false, false, false>(cur_max, qkt_subblock_w)));
         }
 
         q_index_offset += sbh * in0_block_w;
@@ -722,10 +807,12 @@ static void sdpa_inner_loop_step(
         uint32_t qktv_in0_index_offset = 0;
         uint32_t qktv_in0_wait_tiles = qktv_in0_subblock_num_tiles;
 
-        cb_wait_front(cb_v_in, Sk_chunk_t * vDHt);
+        // V wait deferred: don't block here. The sub_exp drain loop below
+        // doesn't touch V, so the reader's V DMA can overlap with the drain.
         cb_reserve_back(cur_out, qktv_output_num_tiles);
 
         // q_subblock 0: drain last row's sub_exp in-place + first QKT@V matmul
+        PACK((llk_pack_mop_config<false, false, false>(cb_qkt_im, 1)));
         {
             MaybeDeviceZoneScopedN(PROFILING_ENABLED, "Softmax(Q@KT)@V");
             static_assert(kt_num_subblocks >= 1, "kt_num_subblocks must be >= 1");
@@ -738,8 +825,12 @@ static void sdpa_inner_loop_step(
                     sub_exp_block_bcast_cols<PROFILING_ENABLED, scale_fp32, sbh, qkt_subblock_w, true>(
                         cb_qkt_im, cur_max, cur_sum, Sk_chunk_t, q_num_subblocks - 1, kt_sub);
 
+                    // Before first matmul: wait for softmax'd QKT tiles and V tiles.
+                    // V wait deferred from Phase 2 start — the drain loop above
+                    // doesn't touch V, so the reader's V DMA overlaps with it.
                     if (kt_sub == 0) {
                         cb_wait_front(cb_qkt_im, qktv_in0_wait_tiles);
+                        cb_wait_front(cb_v_in, Sk_chunk_t * vDHt);
                     }
                     if (kt_sub > 0) {
                         PACK((llk_pack_reconfig_l1_acc(1)));
@@ -752,7 +843,11 @@ static void sdpa_inner_loop_step(
                         if constexpr (!uniform_unpack_format) {
                             reconfig_data_format(cur_out, cb_v_in, cur_out, cb_qkt_im);
                         }
+#ifdef ARCH_BLACKHOLE
+                        mm_no_mop_init_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, qktv_subblock_h, matmul_inner);
+#else
                         mm_block_init_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, qktv_subblock_h, matmul_inner);
+#endif
                         for (uint32_t v_subblock = 0; v_subblock < qktv_v_num_subblocks; ++v_subblock) {
                             blocked_matmul_and_pack<false, qktv_subblock_w, qktv_subblock_h, matmul_inner, vDHt, vDHt>(
                                 cb_qkt_im,
@@ -782,13 +877,21 @@ static void sdpa_inner_loop_step(
                 }
 
                 cb_wait_front(cb_qkt_im, qktv_in0_wait_tiles);
+                // V wait deferred from Phase 2 start — the drain loop above
+                // doesn't touch V, so the reader's V DMA overlaps with it.
+                cb_wait_front(cb_v_in, Sk_chunk_t * vDHt);
                 {
                     MaybeDeviceZoneScopedN(PROFILING_ENABLED, "QKT@V MM+Pack");
                     uint32_t v_index_offset = 0;
                     if constexpr (!uniform_unpack_format) {
                         reconfig_data_format(cur_out, cb_v_in, cur_out, cb_qkt_im);
                     }
+#ifdef ARCH_BLACKHOLE
+                    mm_no_mop_reinit_short(
+                        cb_qkt_im, cb_v_in, false, qktv_subblock_w, qktv_subblock_h, qktv_in0_block_w);
+#else
                     mm_block_init_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, qktv_subblock_h, qktv_in0_block_w);
+#endif
                     for (uint32_t v_subblock = 0; v_subblock < qktv_v_num_subblocks; ++v_subblock) {
                         blocked_matmul_and_pack<false, qktv_subblock_w, qktv_subblock_h, qktv_in0_block_w, vDHt, vDHt>(
                             cb_qkt_im,
@@ -860,7 +963,11 @@ static void sdpa_inner_loop_step(
                 if constexpr (!uniform_unpack_format) {
                     reconfig_data_format(cur_out, cb_v_in, cur_out, cb_qkt_im);
                 }
+#ifdef ARCH_BLACKHOLE
+                mm_no_mop_init_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, qktv_subblock_h, qktv_in0_block_w);
+#else
                 mm_block_init_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, qktv_subblock_h, qktv_in0_block_w);
+#endif
                 for (uint32_t v_subblock = 0; v_subblock < qktv_v_num_subblocks; ++v_subblock) {
                     blocked_matmul_and_pack<false, qktv_subblock_w, qktv_subblock_h, qktv_in0_block_w, vDHt, vDHt>(
                         cb_qkt_im,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -211,7 +211,6 @@ void sub_exp_block_bcast_cols(
             dst_index += tiles_per_column;
 #else
             for (uint32_t j = 0; j < tiles_per_column; j++) {
-                // Absolute position in cb_qkt_im
                 uint32_t in0_tile_index = (max_row_base + i) * cols_in_row + global_col_base + j;
                 sub_tiles_bcast_cols(inout_cb, max_cb, in0_tile_index, max_row_base + i, dst_index++);
             }
@@ -637,7 +636,8 @@ static void sdpa_inner_loop_step(
     const bool is_first_iter,
     [[maybe_unused]] const bool apply_mask = false,
     const uint32_t lw_num_padded = 0,
-    const uint32_t lw_partial_tile_idx = 0) {
+    const uint32_t lw_partial_tile_idx = 0,
+    const uint32_t effective_kt_subblocks = 0) {
     constexpr uint32_t sbh = subblock_h;
     constexpr uint32_t in0_block_w = DHt;
     constexpr uint32_t qkt_subblock_w = 8 / sbh;
@@ -645,6 +645,10 @@ static void sdpa_inner_loop_step(
     constexpr uint32_t kt_num_full_subblocks = Sk_chunk_t / qkt_subblock_w;
     constexpr uint32_t kt_remainder = Sk_chunk_t % qkt_subblock_w;
     constexpr bool has_partial_subblock = (kt_remainder > 0);
+    // Runtime k-padding skip: when effective_kt_subblocks > 0, only process that many
+    // subblocks in Phase 1 and Phase 2 drain. Skipped subblocks are handled by ring mask.
+    const uint32_t runtime_kt_subblocks = (effective_kt_subblocks > 0) ? effective_kt_subblocks : kt_num_full_subblocks;
+    const bool runtime_has_partial = (effective_kt_subblocks > 0) ? false : has_partial_subblock;
     constexpr uint32_t q_subblock_num_tiles = sbh * in0_block_w;
     constexpr uint32_t row_tiles = sbh * KT_stride;  // Use KT_stride for cb_qkt_im row width
 
@@ -696,7 +700,7 @@ static void sdpa_inner_loop_step(
 #else
         mm_block_init_short(cb_q_in, cb_kt_in, true, qkt_subblock_w, sbh, in0_block_w);
 #endif
-        for (uint32_t kt_subblock = 0; kt_subblock < kt_num_full_subblocks; ++kt_subblock) {
+        for (uint32_t kt_subblock = 0; kt_subblock < runtime_kt_subblocks; ++kt_subblock) {
             if (q_subblock > 0) {
                 uint32_t prev_q_subblock = q_subblock - 1;
                 if constexpr (!uniform_unpack_format) {
@@ -741,25 +745,32 @@ static void sdpa_inner_loop_step(
             }
         }
         // Partial last subblock: only present on the reduced path (effective_Sk % qkt_subblock_w != 0).
+        // Skipped when runtime k-padding skip is active (runtime_has_partial = false).
         if constexpr (has_partial_subblock) {
-            if (q_subblock > 0) {
-                uint32_t prev_q_subblock = q_subblock - 1;
-                if constexpr (!uniform_unpack_format) {
-                    reconfig_data_format(cb_kt_in, cb_qkt_im, cb_q_in, cb_qkt_im);
+            if (runtime_has_partial) {
+                if (q_subblock > 0) {
+                    uint32_t prev_q_subblock = q_subblock - 1;
+                    if constexpr (!uniform_unpack_format) {
+                        reconfig_data_format(cb_kt_in, cb_qkt_im, cb_q_in, cb_qkt_im);
+                    }
+                    sub_exp_block_bcast_cols<
+                        PROFILING_ENABLED,
+                        scale_fp32,
+                        sbh,
+                        kt_remainder,
+                        true,
+                        VectorMode::RC,
+                        true /*blocked_pack*/>(
+                        cb_qkt_im,
+                        cur_max,
+                        cur_sum,
+                        KT_stride,
+                        prev_q_subblock,
+                        kt_num_full_subblocks * qkt_subblock_w);
                 }
-                sub_exp_block_bcast_cols<
-                    PROFILING_ENABLED,
-                    scale_fp32,
-                    sbh,
-                    kt_remainder,
-                    true,
-                    VectorMode::RC,
-                    true /*blocked_pack*/>(
-                    cb_qkt_im, cur_max, cur_sum, KT_stride, prev_q_subblock, kt_num_full_subblocks * qkt_subblock_w);
-            }
-            {
-                MaybeDeviceZoneScopedN(PROFILING_ENABLED, "Q@KT MM+Pack (partial)");
-                PACK((llk_pack_mop_config<false, false, false>(cb_qkt_im, kt_remainder)));
+                {
+                    MaybeDeviceZoneScopedN(PROFILING_ENABLED, "Q@KT MM+Pack (partial)");
+                    PACK((llk_pack_mop_config<false, false, false>(cb_qkt_im, kt_remainder)));
 #ifdef ARCH_BLACKHOLE
                 mm_no_mop_init_short(cb_q_in, cb_kt_in, true, kt_remainder, sbh, in0_block_w);
 #else
@@ -783,6 +794,7 @@ static void sdpa_inner_loop_step(
                     kt_index_offset,
                     q_subblock,
                     kt_num_full_subblocks * qkt_subblock_w);
+                }
             }
         }
         // Restore float16b for mask/reduce after Q@KT.
@@ -807,7 +819,7 @@ static void sdpa_inner_loop_step(
             if (apply_mask && (lw_partial_tile_idx > 0 || lw_num_padded > 0)) {
                 copy_tile_to_dst_init_short(cb_mask_in);
                 PACK((llk_pack_reconfig_l1_acc(1)));
-                apply_lightweight_mask_streaming<Sk_chunk_t, sbh>(
+                apply_lightweight_mask_streaming<KT_stride, sbh>(
                     cb_mask_in, cb_qkt_im, q_subblock, lw_num_padded, lw_partial_tile_idx > 0, lw_partial_tile_idx);
                 PACK((llk_pack_reconfig_l1_acc(0)));
             }
@@ -878,7 +890,7 @@ static void sdpa_inner_loop_step(
             // sbh>1 or partial subblock: non-split drain (all sub_exp first, then full V matmul).
             if constexpr (sbh == 1 && !has_partial_subblock) {
                 constexpr uint32_t matmul_inner = qktv_in0_block_w / kt_num_full_subblocks;
-                for (uint32_t kt_sub = 0; kt_sub < kt_num_full_subblocks; ++kt_sub) {
+                for (uint32_t kt_sub = 0; kt_sub < runtime_kt_subblocks; ++kt_sub) {
                     sub_exp_block_bcast_cols<PROFILING_ENABLED, scale_fp32, sbh, qkt_subblock_w, true>(
                         cb_qkt_im, cur_max, cur_sum, KT_stride, q_num_subblocks - 1, kt_sub * qkt_subblock_w);
 
@@ -931,18 +943,20 @@ static void sdpa_inner_loop_step(
                 }
             } else {
                 // Non-split drain: drain all sub_exp in-place, then full matmul.
-                for (uint32_t kt_sub = 0; kt_sub < kt_num_full_subblocks; ++kt_sub) {
+                for (uint32_t kt_sub = 0; kt_sub < runtime_kt_subblocks; ++kt_sub) {
                     sub_exp_block_bcast_cols<PROFILING_ENABLED, scale_fp32, sbh, qkt_subblock_w, true>(
                         cb_qkt_im, cur_max, cur_sum, KT_stride, q_num_subblocks - 1, kt_sub * qkt_subblock_w);
                 }
                 if constexpr (has_partial_subblock) {
-                    sub_exp_block_bcast_cols<PROFILING_ENABLED, scale_fp32, sbh, kt_remainder, true>(
-                        cb_qkt_im,
-                        cur_max,
-                        cur_sum,
-                        KT_stride,
-                        q_num_subblocks - 1,
-                        kt_num_full_subblocks * qkt_subblock_w);
+                    if (runtime_has_partial) {
+                        sub_exp_block_bcast_cols<PROFILING_ENABLED, scale_fp32, sbh, kt_remainder, true>(
+                            cb_qkt_im,
+                            cur_max,
+                            cur_sum,
+                            KT_stride,
+                            q_num_subblocks - 1,
+                            kt_num_full_subblocks * qkt_subblock_w);
+                    }
                 }
 
                 cb_wait_front(cb_qkt_im, qktv_in0_wait_tiles);
@@ -1294,7 +1308,9 @@ template <
     uint32_t cb_lse_out,
     uint32_t cb_prev_out,
     uint32_t cb_out,
-    bool uniform_dataformat = false>
+    bool uniform_dataformat = false,
+    uint32_t local_n_padded_tiles_ct = 0,
+    uint32_t joint_n_padded_tiles_ct = 0>
 void sdpa_ring_v2(
     const uint32_t global_q_start,
     const uint32_t global_q_end,
@@ -1319,6 +1335,14 @@ void sdpa_ring_v2(
     const LightweightMaskContext& lw_mask = {}) {
     constexpr uint32_t out_chunk_tiles = Sq_chunk_t * vDHt;
     constexpr bool uniform_format = uniform_dataformat;
+
+    // Runtime k-padding skip: compute effective K subblocks for padded local/joint chunks.
+    // Uses the larger padding (= fewer useful subblocks) for both local and joint.
+    constexpr uint32_t qkt_sbw = 8 / subblock_h;
+    constexpr uint32_t max_padded =
+        (local_n_padded_tiles_ct > joint_n_padded_tiles_ct) ? local_n_padded_tiles_ct : joint_n_padded_tiles_ct;
+    constexpr uint32_t effective_Sk = Sk_chunk_t - max_padded;
+    constexpr uint32_t effective_kt_subs = (effective_Sk + qkt_sbw - 1) / qkt_sbw;
 
     uint32_t KV_chunks_processed_in_iter = 0;
 
@@ -1361,8 +1385,18 @@ void sdpa_ring_v2(
                 }
             }
 
-            // Call streaming step with ring_mode=true (skip normalization, always push)
-            // is_last_iter=false: Q pop and finalization handled by this outer loop.
+            // Runtime k-padding skip: pass effective_kt_subs for local/joint padded chunks
+            bool is_local_n_mask_chunk = local_n_needs_masking && k_chunk == local_n_mask_chunk_id;
+            bool is_joint_n_mask_chunk = ring_iter_needs_joint_n_mask && kv_chunk_is_joint &&
+                                         (k_chunk - num_local_k_chunks) == joint_n_mask_chunk_id;
+            bool global_n_also_applies = ring_iter_needs_global_n_mask && k_chunk == global_n_mask_chunk_id;
+            uint32_t kt_skip_param = 0;  // 0 = use all subblocks (no skip)
+            if constexpr (max_padded > 0) {
+                if ((is_local_n_mask_chunk && !global_n_also_applies) || is_joint_n_mask_chunk) {
+                    kt_skip_param = effective_kt_subs;
+                }
+            }
+
             sdpa_inner_loop_step<
                 false,  // PROFILING_ENABLED
                 Sq_chunk_t,
@@ -1396,7 +1430,8 @@ void sdpa_ring_v2(
                 is_first,
                 apply_mask,
                 lw_num_padded,
-                lw_partial_tile_idx);
+                lw_partial_tile_idx,
+                kt_skip_param);
 
             // Post-iteration cleanup: pop previous values and swap aliases
             if (!is_first) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -1307,10 +1307,12 @@ void sdpa_ring_v2(
                 }
             }
 
-            // Tile-level matmul skip for local_n or joint_n padding.
+            // Tile-level matmul skip for global_n, local_n, or joint_n padding.
             // Runtime reduce narrows to active_Sk; matmul/sub_exp/V also need narrowing.
             uint32_t effective_Sk_param = 0;  // 0 = use full Sk_chunk_t
-            if (is_local_n_mask_chunk && !is_global_n_mask_chunk) {
+            if (is_global_n_mask_chunk) {
+                effective_Sk_param = Sk_chunk_t - lw_mask.global_n_padded_tiles;
+            } else if (is_local_n_mask_chunk) {
                 effective_Sk_param = Sk_chunk_t - lw_mask.local_n_padded_tiles;
             } else if (is_joint_n_mask_chunk) {
                 effective_Sk_param = Sk_chunk_t - lw_mask.joint_n_padded_tiles;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -1242,9 +1242,7 @@ template <
     uint32_t cb_lse_out,
     uint32_t cb_prev_out,
     uint32_t cb_out,
-    bool uniform_dataformat = false,
-    uint32_t local_n_padded_tiles_ct = 0,
-    uint32_t joint_n_padded_tiles_ct = 0>
+    bool uniform_dataformat = false>
 void sdpa_ring_v2(
     const uint32_t global_q_start,
     const uint32_t global_q_end,
@@ -1267,7 +1265,6 @@ void sdpa_ring_v2(
     const uint32_t cb_sum_A,
     const uint32_t cb_sum_B,
     const LightweightMaskContext& lw_mask = {}) {
-    constexpr uint32_t out_chunk_tiles = Sq_chunk_t * vDHt;
     constexpr bool uniform_format = uniform_dataformat;
 
     uint32_t KV_chunks_processed_in_iter = 0;
@@ -1292,35 +1289,31 @@ void sdpa_ring_v2(
 
             bool is_first = (KV_chunks_processed == 1);
 
-            // Determine if this K chunk needs masking
-            bool apply_mask = (ring_iter_needs_global_n_mask && k_chunk == global_n_mask_chunk_id) ||
-                              (local_n_needs_masking && k_chunk == local_n_mask_chunk_id) ||
-                              (ring_iter_needs_joint_n_mask && (k_chunk - num_local_k_chunks) == joint_n_mask_chunk_id);
+            // Determine if this K chunk needs masking (partial tile within a tile boundary)
+            const bool is_global_n_mask_chunk = ring_iter_needs_global_n_mask && k_chunk == global_n_mask_chunk_id;
+            const bool is_local_n_mask_chunk = local_n_needs_masking && k_chunk == local_n_mask_chunk_id;
+            const bool is_joint_n_mask_chunk = ring_iter_needs_joint_n_mask && kv_chunk_is_joint &&
+                                               (k_chunk - num_local_k_chunks) == joint_n_mask_chunk_id;
 
-            // Resolve lightweight mask params once per K chunk
-            uint32_t lw_num_padded = 0, lw_partial_tile_idx = 0;
+            bool apply_mask = is_global_n_mask_chunk || is_joint_n_mask_chunk;
+
+            // Resolve lightweight mask params for partial tile masking
+            uint32_t lw_partial_tile_idx = 0;
             if (apply_mask && lw_mask.enabled) {
-                if (ring_iter_needs_global_n_mask && k_chunk == global_n_mask_chunk_id) {
-                    lw_num_padded = lw_mask.global_n_padded_tiles;
+                if (is_global_n_mask_chunk) {
                     lw_partial_tile_idx = lw_mask.global_n_partial_tile_idx;
-                } else if (local_n_needs_masking && k_chunk == local_n_mask_chunk_id) {
-                    lw_num_padded = lw_mask.local_n_padded_tiles;
-                } else if (ring_iter_needs_joint_n_mask && (k_chunk - num_local_k_chunks) == joint_n_mask_chunk_id) {
-                    lw_num_padded = lw_mask.joint_n_padded_tiles;
+                } else if (is_joint_n_mask_chunk) {
                     lw_partial_tile_idx = lw_mask.joint_l_partial_tile_idx;
                 }
             }
 
-            // Per-chunk-type effective_Sk: tile-level skip for padded chunks.
-            uint32_t effective_Sk_param = 0;  // 0 = no skip, use full Sk_chunk_t
-            if (lw_num_padded > 0) {
-                bool is_local_n_mask_chunk = local_n_needs_masking && k_chunk == local_n_mask_chunk_id;
-                bool is_joint_n_mask_chunk = ring_iter_needs_joint_n_mask && kv_chunk_is_joint &&
-                                             (k_chunk - num_local_k_chunks) == joint_n_mask_chunk_id;
-                bool global_n_also_applies = ring_iter_needs_global_n_mask && k_chunk == global_n_mask_chunk_id;
-                if ((is_local_n_mask_chunk && !global_n_also_applies) || is_joint_n_mask_chunk) {
-                    effective_Sk_param = Sk_chunk_t - lw_num_padded;
-                }
+            // Tile-level matmul skip for local_n or joint_n padding.
+            // Runtime reduce narrows to active_Sk; matmul/sub_exp/V also need narrowing.
+            uint32_t effective_Sk_param = 0;  // 0 = use full Sk_chunk_t
+            if (is_local_n_mask_chunk && !is_global_n_mask_chunk) {
+                effective_Sk_param = Sk_chunk_t - lw_mask.local_n_padded_tiles;
+            } else if (is_joint_n_mask_chunk) {
+                effective_Sk_param = Sk_chunk_t - lw_mask.joint_n_padded_tiles;
             }
 
             sdpa_inner_loop_step<
@@ -1408,8 +1401,6 @@ void sdpa_ring_v2(
                 mul_block_bcast_cols_inplace<Sq_chunk_t, DHt>(alias_sub, alias_sig);
                 if constexpr (!uniform_format) {
                     reconfig_data_format(cb_prev_out, alias_sub);
-                }
-                if constexpr (!uniform_format) {
                     pack_reconfig_data_format(cb_out);
                 }
                 sub_block(cb_prev_out, alias_sub, cb_out, out_chunk_tiles);
@@ -1419,8 +1410,6 @@ void sdpa_ring_v2(
 
                 if constexpr (!uniform_format) {
                     pack_reconfig_data_format(alias_sig);
-                }
-                if constexpr (!uniform_format) {
                     reconfig_data_format(cb_lse_in, alias_cur_lse);
                 }
                 logsigmoid_sub(cb_lse_in, alias_cur_lse, alias_sig, Sq_chunk_t);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -10,8 +10,10 @@
 
 #include <type_traits>
 
+#ifdef ARCH_BLACKHOLE
 #include "api/compute/experimental/matmul_custom.h"
 #include "api/compute/experimental/sdpa_sub_custom.h"
+#endif
 #include "tools/profiler/kernel_profiler.hpp"
 
 // Template-driven profiling: MaybeDeviceZoneScopedN(ENABLED, name)
@@ -674,7 +676,9 @@ static void sdpa_inner_loop_step(
     // ========== PHASE 1: Q@KT directly into cb_qkt_im ==========
     // All matmul output goes to cb_qkt_im at absolute offsets via pack_tile<true>.
     // cb_push_back_hold_wr_ptr makes each row visible to UNPACK without advancing wr_ptr.
+#ifdef ARCH_BLACKHOLE
     PACK((llk_pack_mop_config<false, false, false>(cb_qkt_im, qkt_subblock_w)));
+#endif
     for (uint32_t q_subblock = 0; q_subblock < q_num_subblocks; q_subblock++) {
         MaybeDeviceZoneScopedN(PROFILING_ENABLED, "Softmax(Q@KT)");
         cb_wait_front(cb_q_in, q_wait_tiles);
@@ -744,7 +748,9 @@ static void sdpa_inner_loop_step(
         // In ring_mode, is_last_iter is always false — skip entirely.
         if constexpr (padded_k_tiles > 0 && !ring_mode) {
             if (is_last_iter) {
+#ifdef ARCH_BLACKHOLE
                 PACK((llk_pack_mop_config<false, false, false>(cb_mask_in, 1)));
+#endif
                 apply_padded_mask_lightweight<PROFILING_ENABLED, padded_k_tiles, Sk_chunk_t, sbh>(
                     cb_mask_in, cb_qkt_im, q_subblock);
             }
@@ -768,11 +774,15 @@ static void sdpa_inner_loop_step(
         {
             MaybeDeviceZoneScopedN(PROFILING_ENABLED, "Reduce max");
             cb_reserve_back(cur_max, sbh);
+#ifdef ARCH_BLACKHOLE
             PACK((llk_pack_mop_config<false, false, false>(cur_max, 1)));
+#endif
             reduce_c_row_group<PoolType::MAX, ReduceDim::REDUCE_ROW, cb_identity_scale_in, Sk_chunk_t, sbh>(
                 cb_qkt_im, cur_max, prev_max, q_subblock, !is_first_iter /*do_eltwise_max*/);
             cb_push_back(cur_max, sbh);
+#ifdef ARCH_BLACKHOLE
             PACK((llk_pack_mop_config<false, false, false>(cur_max, qkt_subblock_w)));
+#endif
         }
 
         q_index_offset += sbh * in0_block_w;
@@ -812,7 +822,9 @@ static void sdpa_inner_loop_step(
         cb_reserve_back(cur_out, qktv_output_num_tiles);
 
         // q_subblock 0: drain last row's sub_exp in-place + first QKT@V matmul
+#ifdef ARCH_BLACKHOLE
         PACK((llk_pack_mop_config<false, false, false>(cb_qkt_im, 1)));
+#endif
         {
             MaybeDeviceZoneScopedN(PROFILING_ENABLED, "Softmax(Q@KT)@V");
             static_assert(kt_num_subblocks >= 1, "kt_num_subblocks must be >= 1");

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -770,9 +770,9 @@ static void sdpa_inner_loop_step(
         }
 
         // Ring mask: L1-accumulate partial-tile mask onto cb_qkt_im for this row group.
-        // Full-tile padding masking is no longer needed: reduce is narrowed to active_Sk,
-        // sub_exp only processes active_Sk tiles, and V matmul is narrowed to v_matmul_dim.
-        // Only partial tiles (where some columns within a tile are padding) still need masking.
+        // Full-tile padding handled by active_Sk narrowing (reduce/sub_exp/V skip padded tiles),
+        // but num_padded must still reflect the actual count so boundary_col places the partial
+        // mask at active_Sk-1 instead of Sk_chunk_t-1.
         if constexpr (use_ring_mask) {
             if (apply_mask && lw_partial_tile_idx > 0) {
                 copy_tile_to_dst_init_short(cb_mask_in);
@@ -781,8 +781,8 @@ static void sdpa_inner_loop_step(
                     cb_mask_in,
                     cb_qkt_im,
                     q_subblock,
-                    0,     // no full-tile padding needed
-                    true,  // has_partial — guaranteed by outer guard (lw_partial_tile_idx > 0)
+                    Sk_chunk_t - active_Sk,  // padded tile count for correct boundary_col
+                    true,                    // has_partial — guaranteed by outer guard (lw_partial_tile_idx > 0)
                     lw_partial_tile_idx,
                     sbh);
                 PACK((llk_pack_reconfig_l1_acc(0)));

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -124,10 +124,7 @@ void reduce_c_row_group(
     uint32_t row_group_index,
     bool do_eltwise_max,
     uint32_t SBH,
-    uint32_t reduce_cols = 0) {
-    if (reduce_cols == 0) {
-        reduce_cols = cols;
-    }
+    uint32_t reduce_cols = cols) {
     const uint32_t GROUP_SIZE = SBH;
     const uint32_t row_start = row_group_index * GROUP_SIZE;
 
@@ -615,7 +612,6 @@ static void sdpa_inner_loop_step(
     const bool is_last_iter,
     const bool is_first_iter,
     [[maybe_unused]] const bool apply_mask = false,
-    const uint32_t lw_num_padded = 0,
     const uint32_t lw_partial_tile_idx = 0,
     const uint32_t effective_Sk = 0) {
     constexpr uint32_t sbh = subblock_h;
@@ -624,7 +620,7 @@ static void sdpa_inner_loop_step(
     constexpr uint32_t q_num_subblocks = Sq_chunk_t / sbh;
     // K-padding skip: active_Sk = useful K tiles in this chunk.
     // Tile-level granularity: full subblocks + partial subblock for the tail.
-    // V matmul narrowed to sub_exp'd width. Reduce runs at full Sk_chunk_t.
+    // V matmul narrowed to sub_exp'd width. Reduce narrowed to active_Sk via runtime LLK.
     const uint32_t active_Sk = (effective_Sk > 0) ? effective_Sk : Sk_chunk_t;
     const uint32_t kt_num_full_subblocks = active_Sk / qkt_subblock_w;
     const uint32_t kt_remainder = active_Sk % qkt_subblock_w;
@@ -785,8 +781,8 @@ static void sdpa_inner_loop_step(
                     cb_mask_in,
                     cb_qkt_im,
                     q_subblock,
-                    0,  // no full-tile padding needed
-                    true,
+                    0,     // no full-tile padding needed
+                    true,  // has_partial — guaranteed by outer guard (lw_partial_tile_idx > 0)
                     lw_partial_tile_idx,
                     sbh);
                 PACK((llk_pack_reconfig_l1_acc(0)));
@@ -1183,7 +1179,6 @@ void sdpa_standard_v2(
                 is_last,
                 is_first,
                 false,  // apply_mask
-                0,      // lw_num_padded
                 0,      // lw_partial_tile_idx
                 eff_Sk);
         };
@@ -1360,7 +1355,6 @@ void sdpa_ring_v2(
                 false,  // is_last_iter
                 is_first,
                 apply_mask,
-                lw_num_padded,
                 lw_partial_tile_idx,
                 effective_Sk_param);
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -64,7 +64,8 @@ template <
     uint32_t INNER_DIM,
     uint32_t IN1_STRIDE,
     uint32_t OUT_NUM_COLS,
-    bool blocked_pack = false>
+    bool blocked_pack = false,
+    uint32_t KT_DIM_MATMUL = INNER_DIM>
 void blocked_matmul_and_pack(
     uint32_t in0_cb,
     uint32_t in1_cb,
@@ -80,9 +81,9 @@ void blocked_matmul_and_pack(
     for (uint32_t inner = 0; inner < INNER_DIM; ++inner) {
 #ifdef ARCH_BLACKHOLE
         matmul_block_no_mop(
-            in0_cb, in1_cb, in0_index, in1_index, dst_index, TRANSPOSE, SUBBLOCK_W, SUBBLOCK_H, INNER_DIM);
+            in0_cb, in1_cb, in0_index, in1_index, dst_index, TRANSPOSE, SUBBLOCK_W, SUBBLOCK_H, KT_DIM_MATMUL);
 #else
-        matmul_block(in0_cb, in1_cb, in0_index, in1_index, dst_index, TRANSPOSE, SUBBLOCK_W, SUBBLOCK_H, INNER_DIM);
+        matmul_block(in0_cb, in1_cb, in0_index, in1_index, dst_index, TRANSPOSE, SUBBLOCK_W, SUBBLOCK_H, KT_DIM_MATMUL);
 #endif
         in0_index++;
         in1_index += IN1_STRIDE;
@@ -178,12 +179,11 @@ void sub_exp_block_bcast_cols(
     uint32_t reduce_cb,
     uint32_t cols_in_row,
     uint32_t q_subblock,
-    uint32_t kt_subblock) {
+    uint32_t global_col_base) {
     constexpr uint32_t tiles_per_row = SBH;
     constexpr uint32_t tiles_per_column = SBW;
     static_assert(tiles_per_row * tiles_per_column <= 8, "SBH * SBW must fit in DST (max 8 tiles)");
     const uint32_t max_row_base = q_subblock * tiles_per_row;
-    const uint32_t global_col_base = kt_subblock * tiles_per_column;
 
     {
         MaybeDeviceZoneScopedN(PROFILING_ENABLED, "SUB_EXP_BLOCK_INIT");
@@ -623,7 +623,9 @@ template <
     uint32_t cb_col_identity = 0,
     uint32_t cb_recip_scratch = 0,
     uint32_t cb_normalized_out = 0,
-    uint32_t cb_mask_in = 0>
+    uint32_t cb_mask_in = 0,
+    uint32_t KT_stride = Sk_chunk_t,
+    uint32_t padded_k_tiles = (Sk_chunk_t - (Skt % Sk_chunk_t)) % Sk_chunk_t>
 static void sdpa_inner_loop_step(
     const uint32_t prev_max,
     const uint32_t cur_max,
@@ -639,15 +641,14 @@ static void sdpa_inner_loop_step(
     constexpr uint32_t sbh = subblock_h;
     constexpr uint32_t in0_block_w = DHt;
     constexpr uint32_t qkt_subblock_w = 8 / sbh;
-    // Compute padded K tiles from compile-time Skt and Sk_chunk_t
-    constexpr uint32_t padded_k_tiles = (Sk_chunk_t - (Skt % Sk_chunk_t)) % Sk_chunk_t;
     constexpr uint32_t q_num_subblocks = Sq_chunk_t / sbh;
-    constexpr uint32_t kt_num_subblocks = Sk_chunk_t / qkt_subblock_w;
+    constexpr uint32_t kt_num_full_subblocks = Sk_chunk_t / qkt_subblock_w;
+    constexpr uint32_t kt_remainder = Sk_chunk_t % qkt_subblock_w;
+    constexpr bool has_partial_subblock = (kt_remainder > 0);
     constexpr uint32_t q_subblock_num_tiles = sbh * in0_block_w;
-    constexpr uint32_t row_tiles = sbh * Sk_chunk_t;
+    constexpr uint32_t row_tiles = sbh * KT_stride;  // Use KT_stride for cb_qkt_im row width
 
     static_assert(sbh * qkt_subblock_w <= 8, "sbh * qkt_subblock_w must fit in DST (max 8 tiles)");
-    static_assert(Sk_chunk_t % qkt_subblock_w == 0, "Sk_chunk_t must be divisible by qkt_subblock_w");
     static_assert(Sq_chunk_t % sbh == 0, "Sq_chunk_t must be divisible by subblock_h");
     static_assert(!(use_padded_mask && use_ring_mask), "use_padded_mask and use_ring_mask are mutually exclusive");
 
@@ -670,7 +671,8 @@ static void sdpa_inner_loop_step(
     if constexpr (!uniform_unpack_format) {
         reconfig_data_format(cb_kt_in, cb_q_in);
     }
-    cb_reserve_back(cb_qkt_im, Sq_chunk_t * Sk_chunk_t);
+    // Use KT_stride for cb_qkt_im layout to keep CB pointers aligned across iterations
+    cb_reserve_back(cb_qkt_im, Sq_chunk_t * KT_stride);
 
     cb_reserve_back(cur_sum, Sq_chunk_t);
 
@@ -686,7 +688,7 @@ static void sdpa_inner_loop_step(
         // Deferred KT wait: reader pushes Q before KT, so waiting for Q first
         // allows reserves + MOP config + Q wait to overlap with KT DMA.
         if (q_subblock == 0) {
-            cb_wait_front(cb_kt_in, DHt * Sk_chunk_t);
+            cb_wait_front(cb_kt_in, DHt * KT_stride);
         }
         kt_index_offset = 0;
 #ifdef ARCH_BLACKHOLE
@@ -694,10 +696,9 @@ static void sdpa_inner_loop_step(
 #else
         mm_block_init_short(cb_q_in, cb_kt_in, true, qkt_subblock_w, sbh, in0_block_w);
 #endif
-        for (uint32_t kt_subblock = 0; kt_subblock < kt_num_subblocks; ++kt_subblock) {
+        for (uint32_t kt_subblock = 0; kt_subblock < kt_num_full_subblocks; ++kt_subblock) {
             if (q_subblock > 0) {
                 uint32_t prev_q_subblock = q_subblock - 1;
-                // Restore float16b UNPACK for sub_exp (early-exit if already float16b).
                 if constexpr (!uniform_unpack_format) {
                     reconfig_data_format(cb_kt_in, cb_qkt_im, cb_q_in, cb_qkt_im);
                 }
@@ -708,7 +709,8 @@ static void sdpa_inner_loop_step(
                     qkt_subblock_w,
                     true,
                     VectorMode::RC,
-                    true /*blocked_pack*/>(cb_qkt_im, cur_max, cur_sum, Sk_chunk_t, prev_q_subblock, kt_subblock);
+                    true /*blocked_pack*/>(
+                    cb_qkt_im, cur_max, cur_sum, KT_stride, prev_q_subblock, kt_subblock * qkt_subblock_w);
 #ifdef ARCH_BLACKHOLE
                 mm_no_mop_reinit_short(cb_q_in, cb_kt_in, true, qkt_subblock_w, sbh, in0_block_w);
 #else
@@ -717,7 +719,6 @@ static void sdpa_inner_loop_step(
             }
             {
                 MaybeDeviceZoneScopedN(PROFILING_ENABLED, "Q@KT MM+Pack");
-                // Setup matmul UNPACK (early-exit if already set, e.g., q_subblock==0 consecutive calls).
                 if constexpr (!uniform_unpack_format) {
                     reconfig_data_format(cb_qkt_im, cb_kt_in, cb_qkt_im, cb_q_in);
                 }
@@ -726,8 +727,8 @@ static void sdpa_inner_loop_step(
                     qkt_subblock_w,
                     sbh,
                     in0_block_w,
-                    Sk_chunk_t,
-                    Sk_chunk_t,
+                    KT_stride,
+                    KT_stride,
                     true /*blocked_pack*/>(
                     cb_q_in,
                     cb_kt_in,
@@ -737,6 +738,51 @@ static void sdpa_inner_loop_step(
                     q_subblock,
                     kt_subblock * qkt_subblock_w);
                 kt_index_offset += qkt_subblock_w;
+            }
+        }
+        // Partial last subblock: only present on the reduced path (effective_Sk % qkt_subblock_w != 0).
+        if constexpr (has_partial_subblock) {
+            if (q_subblock > 0) {
+                uint32_t prev_q_subblock = q_subblock - 1;
+                if constexpr (!uniform_unpack_format) {
+                    reconfig_data_format(cb_kt_in, cb_qkt_im, cb_q_in, cb_qkt_im);
+                }
+                sub_exp_block_bcast_cols<
+                    PROFILING_ENABLED,
+                    scale_fp32,
+                    sbh,
+                    kt_remainder,
+                    true,
+                    VectorMode::RC,
+                    true /*blocked_pack*/>(
+                    cb_qkt_im, cur_max, cur_sum, KT_stride, prev_q_subblock, kt_num_full_subblocks * qkt_subblock_w);
+            }
+            {
+                MaybeDeviceZoneScopedN(PROFILING_ENABLED, "Q@KT MM+Pack (partial)");
+                PACK((llk_pack_mop_config<false, false, false>(cb_qkt_im, kt_remainder)));
+#ifdef ARCH_BLACKHOLE
+                mm_no_mop_init_short(cb_q_in, cb_kt_in, true, kt_remainder, sbh, in0_block_w);
+#else
+                mm_block_init_short(cb_q_in, cb_kt_in, true, kt_remainder, sbh, in0_block_w);
+#endif
+                if constexpr (!uniform_unpack_format) {
+                    reconfig_data_format(cb_qkt_im, cb_kt_in, cb_qkt_im, cb_q_in);
+                }
+                blocked_matmul_and_pack<
+                    true,
+                    kt_remainder,
+                    sbh,
+                    in0_block_w,
+                    KT_stride,
+                    KT_stride,
+                    true /*blocked_pack*/>(
+                    cb_q_in,
+                    cb_kt_in,
+                    cb_qkt_im,
+                    q_index_offset,
+                    kt_index_offset,
+                    q_subblock,
+                    kt_num_full_subblocks * qkt_subblock_w);
             }
         }
         // Restore float16b for mask/reduce after Q@KT.
@@ -751,7 +797,7 @@ static void sdpa_inner_loop_step(
 #ifdef ARCH_BLACKHOLE
                 PACK((llk_pack_mop_config<false, false, false>(cb_mask_in, 1)));
 #endif
-                apply_padded_mask_lightweight<PROFILING_ENABLED, padded_k_tiles, Sk_chunk_t, sbh>(
+                apply_padded_mask_lightweight<PROFILING_ENABLED, padded_k_tiles, KT_stride, sbh>(
                     cb_mask_in, cb_qkt_im, q_subblock);
             }
         }
@@ -777,7 +823,7 @@ static void sdpa_inner_loop_step(
 #ifdef ARCH_BLACKHOLE
             PACK((llk_pack_mop_config<false, false, false>(cur_max, 1)));
 #endif
-            reduce_c_row_group<PoolType::MAX, ReduceDim::REDUCE_ROW, cb_identity_scale_in, Sk_chunk_t, sbh>(
+            reduce_c_row_group<PoolType::MAX, ReduceDim::REDUCE_ROW, cb_identity_scale_in, KT_stride, sbh>(
                 cb_qkt_im, cur_max, prev_max, q_subblock, !is_first_iter /*do_eltwise_max*/);
             cb_push_back(cur_max, sbh);
 #ifdef ARCH_BLACKHOLE
@@ -789,7 +835,7 @@ static void sdpa_inner_loop_step(
         q_wait_tiles += q_subblock_num_tiles;
     }
 
-    cb_pop_front(cb_kt_in, DHt * Sk_chunk_t);
+    cb_pop_front(cb_kt_in, DHt * KT_stride);
 
     // Q is no longer needed after Phase 1. On the last K chunk, pop early so the
     // reader can start fetching the next Q chunk during Phase 2.
@@ -808,14 +854,15 @@ static void sdpa_inner_loop_step(
     {
         constexpr uint32_t qktv_subblock_h = sbh;
         constexpr uint32_t qktv_subblock_w = (vDHt < 4) ? vDHt : 4;
-        constexpr uint32_t qktv_in0_block_w = Sk_chunk_t;
+        constexpr uint32_t qktv_in0_block_w = Sk_chunk_t;  // V matmul inner dim (= effective_Sk on reduced path)
         constexpr uint32_t qktv_q_num_subblocks = Sq_chunk_t / qktv_subblock_h;
         constexpr uint32_t qktv_v_num_subblocks = vDHt / qktv_subblock_w;
         constexpr uint32_t qktv_output_num_tiles = Sq_chunk_t * vDHt;
-        constexpr uint32_t qktv_in0_subblock_num_tiles = qktv_subblock_h * qktv_in0_block_w;
+        // cb_qkt_im row width is KT_stride (for pointer alignment), not Sk_chunk_t
+        constexpr uint32_t qktv_in0_row_tiles = qktv_subblock_h * KT_stride;
 
         uint32_t qktv_in0_index_offset = 0;
-        uint32_t qktv_in0_wait_tiles = qktv_in0_subblock_num_tiles;
+        uint32_t qktv_in0_wait_tiles = qktv_in0_row_tiles;
 
         // V wait deferred: don't block here. The sub_exp drain loop below
         // doesn't touch V, so the reader's V DMA can overlap with the drain.
@@ -827,19 +874,14 @@ static void sdpa_inner_loop_step(
 #endif
         {
             MaybeDeviceZoneScopedN(PROFILING_ENABLED, "Softmax(Q@KT)@V");
-            static_assert(kt_num_subblocks >= 1, "kt_num_subblocks must be >= 1");
-
-            if constexpr (sbh == 1) {
-                // sbh=1: split-matmul overlap (inner dim split across kt_num_subblocks)
-                constexpr uint32_t matmul_inner = qktv_in0_block_w / kt_num_subblocks;
-                for (uint32_t kt_sub = 0; kt_sub < kt_num_subblocks; ++kt_sub) {
-                    // sub_exp drain in-place on cb_qkt_im
+            // sbh=1 with no partial subblock: split-drain (sub_exp interleaved with V matmul).
+            // sbh>1 or partial subblock: non-split drain (all sub_exp first, then full V matmul).
+            if constexpr (sbh == 1 && !has_partial_subblock) {
+                constexpr uint32_t matmul_inner = qktv_in0_block_w / kt_num_full_subblocks;
+                for (uint32_t kt_sub = 0; kt_sub < kt_num_full_subblocks; ++kt_sub) {
                     sub_exp_block_bcast_cols<PROFILING_ENABLED, scale_fp32, sbh, qkt_subblock_w, true>(
-                        cb_qkt_im, cur_max, cur_sum, Sk_chunk_t, q_num_subblocks - 1, kt_sub);
+                        cb_qkt_im, cur_max, cur_sum, KT_stride, q_num_subblocks - 1, kt_sub * qkt_subblock_w);
 
-                    // Before first matmul: wait for softmax'd QKT tiles and V tiles.
-                    // V wait deferred from Phase 2 start — the drain loop above
-                    // doesn't touch V, so the reader's V DMA overlaps with it.
                     if (kt_sub == 0) {
                         cb_wait_front(cb_qkt_im, qktv_in0_wait_tiles);
                         cb_wait_front(cb_v_in, Sk_chunk_t * vDHt);
@@ -848,7 +890,6 @@ static void sdpa_inner_loop_step(
                         PACK((llk_pack_reconfig_l1_acc(1)));
                     }
 
-                    // Matmul — FPU overlaps with SFPU EXP
                     {
                         MaybeDeviceZoneScopedN(PROFILING_ENABLED, "QKT@V MM+Pack");
                         uint32_t v_index_offset = 0;
@@ -861,7 +902,15 @@ static void sdpa_inner_loop_step(
                         mm_block_init_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, qktv_subblock_h, matmul_inner);
 #endif
                         for (uint32_t v_subblock = 0; v_subblock < qktv_v_num_subblocks; ++v_subblock) {
-                            blocked_matmul_and_pack<false, qktv_subblock_w, qktv_subblock_h, matmul_inner, vDHt, vDHt>(
+                            blocked_matmul_and_pack<
+                                false,
+                                qktv_subblock_w,
+                                qktv_subblock_h,
+                                matmul_inner,
+                                vDHt,
+                                vDHt,
+                                false,
+                                KT_stride>(
                                 cb_qkt_im,
                                 cb_v_in,
                                 cur_out,
@@ -881,16 +930,22 @@ static void sdpa_inner_loop_step(
                     }
                 }
             } else {
-                // sbh > 1: drain all sub_exp in-place, then full matmul (no split)
-                // Can't split inner dim because matmul_block uses INNER_DIM as in0 row stride
-                for (uint32_t kt_sub = 0; kt_sub < kt_num_subblocks; ++kt_sub) {
+                // Non-split drain: drain all sub_exp in-place, then full matmul.
+                for (uint32_t kt_sub = 0; kt_sub < kt_num_full_subblocks; ++kt_sub) {
                     sub_exp_block_bcast_cols<PROFILING_ENABLED, scale_fp32, sbh, qkt_subblock_w, true>(
-                        cb_qkt_im, cur_max, cur_sum, Sk_chunk_t, q_num_subblocks - 1, kt_sub);
+                        cb_qkt_im, cur_max, cur_sum, KT_stride, q_num_subblocks - 1, kt_sub * qkt_subblock_w);
+                }
+                if constexpr (has_partial_subblock) {
+                    sub_exp_block_bcast_cols<PROFILING_ENABLED, scale_fp32, sbh, kt_remainder, true>(
+                        cb_qkt_im,
+                        cur_max,
+                        cur_sum,
+                        KT_stride,
+                        q_num_subblocks - 1,
+                        kt_num_full_subblocks * qkt_subblock_w);
                 }
 
                 cb_wait_front(cb_qkt_im, qktv_in0_wait_tiles);
-                // V wait deferred from Phase 2 start — the drain loop above
-                // doesn't touch V, so the reader's V DMA overlaps with it.
                 cb_wait_front(cb_v_in, Sk_chunk_t * vDHt);
                 {
                     MaybeDeviceZoneScopedN(PROFILING_ENABLED, "QKT@V MM+Pack");
@@ -899,13 +954,20 @@ static void sdpa_inner_loop_step(
                         reconfig_data_format(cur_out, cb_v_in, cur_out, cb_qkt_im);
                     }
 #ifdef ARCH_BLACKHOLE
-                    mm_no_mop_reinit_short(
-                        cb_qkt_im, cb_v_in, false, qktv_subblock_w, qktv_subblock_h, qktv_in0_block_w);
+                    mm_no_mop_reinit_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, qktv_subblock_h, KT_stride);
 #else
-                    mm_block_init_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, qktv_subblock_h, qktv_in0_block_w);
+                    mm_block_init_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, qktv_subblock_h, KT_stride);
 #endif
                     for (uint32_t v_subblock = 0; v_subblock < qktv_v_num_subblocks; ++v_subblock) {
-                        blocked_matmul_and_pack<false, qktv_subblock_w, qktv_subblock_h, qktv_in0_block_w, vDHt, vDHt>(
+                        blocked_matmul_and_pack<
+                            false,
+                            qktv_subblock_w,
+                            qktv_subblock_h,
+                            qktv_in0_block_w,
+                            vDHt,
+                            vDHt,
+                            false,
+                            KT_stride>(
                             cb_qkt_im,
                             cb_v_in,
                             cur_out,
@@ -920,8 +982,8 @@ static void sdpa_inner_loop_step(
                     }
                 }
             }
-            qktv_in0_index_offset += qktv_subblock_h * qktv_in0_block_w;
-            qktv_in0_wait_tiles += qktv_in0_subblock_num_tiles;
+            qktv_in0_index_offset += qktv_subblock_h * KT_stride;
+            qktv_in0_wait_tiles += qktv_in0_row_tiles;
         }
 
         // Per-row normalization lambda — only compiled for non-ring mode
@@ -977,12 +1039,20 @@ static void sdpa_inner_loop_step(
                     reconfig_data_format(cur_out, cb_v_in, cur_out, cb_qkt_im);
                 }
 #ifdef ARCH_BLACKHOLE
-                mm_no_mop_init_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, qktv_subblock_h, qktv_in0_block_w);
+                mm_no_mop_init_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, qktv_subblock_h, KT_stride);
 #else
-                mm_block_init_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, qktv_subblock_h, qktv_in0_block_w);
+                mm_block_init_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, qktv_subblock_h, KT_stride);
 #endif
                 for (uint32_t v_subblock = 0; v_subblock < qktv_v_num_subblocks; ++v_subblock) {
-                    blocked_matmul_and_pack<false, qktv_subblock_w, qktv_subblock_h, qktv_in0_block_w, vDHt, vDHt>(
+                    blocked_matmul_and_pack<
+                        false,
+                        qktv_subblock_w,
+                        qktv_subblock_h,
+                        qktv_in0_block_w,
+                        vDHt,
+                        vDHt,
+                        false,
+                        KT_stride>(
                         cb_qkt_im,
                         cb_v_in,
                         cur_out,
@@ -1004,8 +1074,8 @@ static void sdpa_inner_loop_step(
                 normalize_row(w_salad, pushed_rows);
             }
 
-            qktv_in0_index_offset += qktv_subblock_h * qktv_in0_block_w;
-            qktv_in0_wait_tiles += qktv_in0_subblock_num_tiles;
+            qktv_in0_index_offset += qktv_subblock_h * KT_stride;
+            qktv_in0_wait_tiles += qktv_in0_row_tiles;
         }
 
         // Pipeline drain: SALAD for last row
@@ -1039,8 +1109,8 @@ static void sdpa_inner_loop_step(
             cb_push_back(cur_out, qktv_output_num_tiles);
         }
 
-        cb_pop_front(cb_v_in, Sk_chunk_t * vDHt);
-        cb_pop_front(cb_qkt_im, Sq_chunk_t * Sk_chunk_t);
+        cb_pop_front(cb_v_in, KT_stride * vDHt);
+        cb_pop_front(cb_qkt_im, Sq_chunk_t * KT_stride);
     }
 }
 
@@ -1083,14 +1153,14 @@ void sdpa_standard_v2(
         cb_wait_front(cb_mask_in, 1);
     }
 
+    constexpr uint32_t padded_k_tiles_inner = (Sk_chunk_t - (Skt % Sk_chunk_t)) % Sk_chunk_t;
+    constexpr uint32_t effective_Sk = Sk_chunk_t - padded_k_tiles_inner;
+
     for (uint32_t q = 0; q < q_chunks_per_core; q++) {
         uint32_t alias_prev_sum = cb_sum_A, alias_cur_sum = cb_sum_B;
         uint32_t alias_prev_max = cb_max_A, alias_cur_max = cb_max_B;
         uint32_t alias_prev_out = cb_out_im_A, alias_cur_out = cb_out_im_B;
 
-        // Per-iteration profiling via call_step: pass std::true_type{} to enable
-        // MaybeDeviceZoneScopedN in sdpa_inner_loop_step, std::false_type{} to disable.
-        // To profile specific iterations, change the gating condition below.
         auto call_step = [&](auto profiling_tag, bool is_last, bool is_first) {
             sdpa_inner_loop_step<
                 decltype(profiling_tag)::value,
@@ -1123,6 +1193,56 @@ void sdpa_standard_v2(
                 alias_cur_out,
                 is_last,
                 is_first);
+        };
+
+        // Reduced path for last K chunk with padding: compute with effective_Sk,
+        // skip padded-tile computation. KT_stride = original Sk for CB layout.
+        auto call_step_reduced = [&](auto profiling_tag, bool is_last, bool is_first) {
+            sdpa_inner_loop_step<
+                decltype(profiling_tag)::value,
+                Sq_chunk_t,
+                effective_Sk,
+                Skt,
+                DHt,
+                vDHt,
+                scale_fp32,
+                subblock_h,
+                use_padded_mask,
+                false,  // ring_mode
+                false,  // use_ring_mask
+                uniform_dataformat,
+                cb_q_in,
+                cb_kt_in,
+                cb_v_in,
+                cb_qkt_im,
+                cb_identity_scale_in,
+                cb_exp_max_diff,
+                cb_col_identity,
+                cb_recip_scratch,
+                cb_normalized_out,
+                cb_mask_in,
+                Sk_chunk_t,           // KT_stride = original Sk for KT CB indexing
+                padded_k_tiles_inner  // Explicit: masking still needed for KT_stride-wide layout
+                >(
+                alias_prev_max,
+                alias_cur_max,
+                alias_prev_sum,
+                alias_cur_sum,
+                alias_prev_out,
+                alias_cur_out,
+                is_last,
+                is_first);
+        };
+
+        for (uint32_t k_chunk = 0; k_chunk < k_num_chunks; k_chunk++) {
+            bool is_first = (k_chunk == 0);
+            bool is_last = (k_chunk == k_num_chunks - 1);
+
+            if (is_last && padded_k_tiles_inner > 0) {
+                call_step_reduced(std::false_type{}, is_last, is_first);
+            } else {
+                call_step(std::false_type{}, is_last, is_first);
+            }
 
             // Post-iteration cleanup
             if (!is_first) {
@@ -1139,19 +1259,6 @@ void sdpa_standard_v2(
                 std::swap(alias_prev_sum, alias_cur_sum);
                 std::swap(alias_prev_out, alias_cur_out);
             }
-        };
-
-        for (uint32_t k_chunk = 0; k_chunk < k_num_chunks; k_chunk++) {
-            bool is_first = (k_chunk == 0);
-            bool is_last = (k_chunk == k_num_chunks - 1);
-
-            // Default: profiling disabled. To profile specific iterations:
-            // if (is_first) {
-            //     call_step(std::true_type{}, is_last, is_first);
-            // } else {
-            //     call_step(std::false_type{}, is_last, is_first);
-            // }
-            call_step(std::false_type{}, is_last, is_first);
         }
         // Q already popped inside sdpa_inner_loop_step after Phase 1 of the last K chunk.
     }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
@@ -191,9 +191,7 @@ void kernel_main() {
                 cb_lse_out,
                 cb_prev_out,
                 cb_out,
-                uniform_dataformat,
-                local_n_padded_tiles,
-                joint_n_padded_tiles>(
+                uniform_dataformat>(
                 global_q_start,
                 global_q_end,
                 num_kv_chunks,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
@@ -188,7 +188,9 @@ void kernel_main() {
                 cb_lse_out,
                 cb_prev_out,
                 cb_out,
-                uniform_dataformat>(
+                uniform_dataformat,
+                local_n_padded_tiles,
+                joint_n_padded_tiles>(
                 global_q_start,
                 global_q_end,
                 num_kv_chunks,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
@@ -104,6 +104,9 @@ void kernel_main() {
 
     mm_init(cb_q_in, cb_k_in, cb_qk_im);
 
+    // Wait once for identity scale; streaming v2 removes per-call waits inside reduce_c_row_group.
+    cb_wait_front(cb_identity_scale_in, 1);
+
     // Wait for all lightweight mask tiles once before the ring loop.
     // Writer generates them once and they stay permanently fronted.
     if constexpr (needs_lightweight_mask) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
@@ -113,6 +113,9 @@ void kernel_main() {
         // No row buffers needed. c_4 used only as 1-tile recip scratch for normalization.
         constexpr uint32_t cb_recip_scratch = tt::CBIndex::c_4;
 
+        // Wait once for identity scale; v2 removes per-call waits inside reduce_c_row_group
+        cb_wait_front(cb_identity_scale_in, 1);
+
         for (uint32_t phase = 0; phase < num_phases; ++phase) {
             for (uint32_t nb = local_batch_start; nb < local_batch_end; ++nb) {
                 for (uint32_t nq = local_nh_start; nq < local_nh_end; ++nq) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -585,7 +585,7 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
         B,
         NQH,
         NKH,
-        Skt,
+        valid_Skt,  // Unpadded K tile count — enables skip-padding optimization in v2
         DHt,
         vDHt,
         Sq_chunk_t,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -585,7 +585,7 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
         B,
         NQH,
         NKH,
-        valid_Skt,  // Unpadded K tile count — enables skip-padding optimization in v2
+        Skt,  // Padded K tile count — used by standard SDPA path for loop bounds
         DHt,
         vDHt,
         Sq_chunk_t,


### PR DESCRIPTION
## Summary

Series of optimizations to the streaming SDPA compute kernel that together yield ~5% FPU utilization improvement on Wan2.2 shapes for single-chip tests. Changes apply to both standard and ring joint SDPA codepaths with WH/BH compatibility maintained.

- Runtime reduce narrowing: Replace -inf garbage masking with runtime LLK reduce_block_max_row_runtime() that only scans active_Sk tiles — garbage columns beyond valid K are never read (+2.3% math utilization on ring path, ~1.5KB code savings from removing full-tile mask code)
- Tile-level matmul skip on K-padding: Pass effective_Sk (unpadded tile count) so Q@KT and V matmuls skip padded tiles entirely rather than computing and masking; eliminates dual-dispatch template instantiation in standard path (~12KB code savings)
- MOP-free matmul on BH: Use matmul_block_no_mop / mm_no_mop_init_short / mm_no_mop_reinit_short to bypass Macro Operation Processor overhead for the small block sizes used in SDPA                                                                                
- Blocked column-broadcast subtraction on BH: Replace per-tile sub_tiles_bcast_cols loop with single blocked sub_tiles_bcast_cols_custom call, reducing loop overhead and improving MATH/PACK pipeline occupancy
- Blocked packing on BH: Single pack_tile<true> per row instead of per-tile in blocked_matmul_and_pack and sub_exp_block_bcast_cols — packer hardware handles the stride internally                                                                                 
- MOP config at operation transitions: Explicit llk_pack_mop_config calls at phase boundaries (Q@KT → mask → reduce → sub_exp → QKT@V) to set correct packer output stride without implicit reconfiguration stalls
- Hardware reciprocal on BH: Use recip_tile<false> (hardware SFPARECIP) in normalize_row_streaming instead of Newton-Raphson iterative approximation, gated behind ARCH_BLACKHOLE with legacy recip_tile fallback on WH
- Deferred CB waits: Hoist identity-scale cb_wait_front to kernel init (removing per-call waits in reduce), defer cb_wait_front(cb_qkt_im) past sub_exp_first_col_blocks for DMA overlap, toggle L1 accumulation mode outside hot loops
- Code size control: Convert SUBBLOCK_W/H, INNER_DIM from compile-time template params to runtime args in blocked_matmul_and_pack; add noinline/noclone on hot helpers to prevent GCC constprop cloning (~5KB savings, fits ring path within code size budget)
- Cleanup: Remove dead mask params (joint_n_mask, local_n_mask), remove apply_padded_mask_lightweight (superseded by runtime reduce), simplify ring SDPA mask resolution to only retain global_n_mask

#Pipelines
- [ ] [![Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml/badge.svg?branch=pjosipovic/sdpa_wan_integration_v8)](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml?query=branch:pjosipovic/sdpa_wan_integration_v8)
- [ ] [![Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml/badge.svg?branch=pjosipovic/sdpa_wan_integration_v8)](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml?query=branch:pjosipovic/sdpa_wan_integration_v8)
- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=pjosipovic/sdpa_wan_integration_v8)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:pjosipovic/sdpa_wan_integration_v8)
- [ ] [![Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/sdpa_wan_integration_v8)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/sdpa_wan_integration_v8)
- [ ] [![Blackhole Demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-demo-tests.yaml/badge.svg?branch=pjosipovic/sdpa_wan_integration_v8)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-demo-tests.yaml?query=branch:pjosipovic/sdpa_wan_integration_v8)
- [ ] [![Galaxy demo tests (wan22)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml/badge.svg?branch=pjosipovic/sdpa_wan_integration_v8)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml?query=branch:pjosipovic/sdpa_wan_integration_v8)
- [ ] [![Galaxy e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-e2e-tests.yaml/badge.svg?branch=pjosipovic/sdpa_wan_integration_v8)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-e2e-tests.yaml?query=branch:pjosipovic/sdpa_wan_integration_v8)
- [ ] [![T3K T3000 e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=pjosipovic/sdpa_wan_integration_v8)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:pjosipovic/sdpa_wan_integration_v8)
- [ ] [![Nightly L2 tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/sdpa_wan_integration_v8)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/sdpa_wan_integration_v8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)