### PR TITLE
Fix conv3d crash with non tile-aligned patch_size

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv3d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv3d.py
@@ -212,6 +212,31 @@ def test_conv3d_sweep_blocks(device, input_shape, out_channels, kernel_size, str
 
 
 @pytest.mark.parametrize(
+    "input_shape, out_channels, kernel_size, stride, padding, padding_mode",
+    [
+        # C_in=4, kernel=3x3x3 → patch_size=3*3*3*32=864 (C_in padded to 32)
+        [(1, 4, 8, 28, 28), 16, (3, 3, 3), (1, 1, 1), (0, 0, 0), "zeros"],
+        # C_in=3, kernel=3x3x3 → patch_size=3*3*3*32=864 (C_in padded to 32)
+        [(1, 3, 8, 14, 14), 32, (3, 3, 3), (1, 1, 1), (1, 1, 1), "zeros"],
+        # C_in=12, kernel=3x3x3 → patch_size=3*3*3*12=324 (not multiple of 32)
+        [(1, 12, 8, 10, 10), 32, (3, 3, 3), (1, 1, 1), (0, 1, 1), "zeros"],
+        # C_in=12, kernel=1x1x1 → patch_size=1*1*1*12=12 (not multiple of 32)
+        [(1, 12, 8, 10, 10), 32, (1, 1, 1), (1, 1, 1), (0, 0, 0), "zeros"],
+    ],
+    ids=[
+        "issue_39103_C4_k333",
+        "C3_k333_pad",
+        "C12_k333_non_aligned_patch",
+        "C12_k111_non_aligned_patch",
+    ],
+)
+def test_conv3d_non_aligned_patch_size(device, input_shape, out_channels, kernel_size, stride, padding, padding_mode):
+    """Regression test for issue #39103: conv3d with non tile-aligned patch_size (kD*kH*kW*C_in_block)."""
+    grid_size = device.compute_with_storage_grid_size()
+    run_conv3d_test(device, input_shape, out_channels, kernel_size, stride, padding, padding_mode, grid_size=grid_size)
+
+
+@pytest.mark.parametrize(
     "input_shape, out_channels, kernel_size, stride, padding, padding_mode, blocking",
     [
         [

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_program_factory.cpp
@@ -76,6 +76,7 @@ Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
 
     uint32_t patch_size = operation_attributes.kernel_size[0] * operation_attributes.kernel_size[1] *
                           operation_attributes.kernel_size[2] * C_in_block;
+    uint32_t padded_patch_size = tt::round_up(patch_size, tt::constants::TILE_WIDTH);
     uint32_t num_patches = config.T_out_block * config.H_out_block * config.W_out_block;
 
     uint32_t C_in_num_blocks = tt::div_up(C_in, C_in_block);
@@ -88,27 +89,15 @@ Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
         C_out_num_blocks,
         C_out_block);
 
-    // Both the reader (vol2col row layout) and writer (weight tile offsets) assume patch_size
-    // is tile-aligned. The reader writes patches contiguously but tilize_block expects rows at
-    // page_size stride; the writer indexes weight tiles at c_in_block * matmul_K_t assuming
-    // blocks don't share tile rows. Both break when patch_size % TILE_WIDTH != 0.
-    TT_FATAL(
-        patch_size % tt::constants::TILE_WIDTH == 0,
-        "patch_size (kD*kH*kW*C_in_block = {}*{}*{}*{} = {}) must be a multiple of TILE_WIDTH ({})",
-        operation_attributes.kernel_size[0],
-        operation_attributes.kernel_size[1],
-        operation_attributes.kernel_size[2],
-        C_in_block,
-        patch_size,
-        tt::constants::TILE_WIDTH);
-
     uint32_t matmul_M_t = tt::div_up(num_patches, tt::constants::TILE_HEIGHT);
     uint32_t matmul_K_t = tt::div_up(patch_size, tt::constants::TILE_WIDTH);
     uint32_t matmul_N_t = tt::div_up(C_out_block, tt::constants::TILE_WIDTH);
 
     uint32_t num_patches_tile_padded = tt::round_up(num_patches, tt::constants::TILE_HEIGHT);
 
-    uint32_t patch_size_bytes = patch_size * dtype_bytes;    // bytes per patch row (tile-aligned by assert above)
+    uint32_t patch_size_bytes = patch_size * dtype_bytes;                // bytes of actual data per patch row
+    uint32_t padded_patch_size_bytes = padded_patch_size * dtype_bytes;  // bytes per CB page (tile-aligned)
+    uint32_t patch_pad_bytes = padded_patch_size_bytes - patch_size_bytes;
     uint32_t C_out_block_bytes = C_out_block * dtype_bytes;  // bytes per output channel row
     uint32_t C_in_block_bytes = C_in_block * dtype_bytes;    // bytes per input channel row
 
@@ -133,7 +122,8 @@ Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
     // that many patches. The reader pushes in matching chunks.
     uint32_t vol2col_rm_pages = std::min(num_patches, 2 * tt::constants::TILE_HEIGHT);
     uint32_t cb_vol2col_rm_id = next_cb_index++;
-    tt::tt_metal::create_cb(cb_vol2col_rm_id, program, core_grid, patch_size_bytes, vol2col_rm_pages, data_format);
+    tt::tt_metal::create_cb(
+        cb_vol2col_rm_id, program, core_grid, padded_patch_size_bytes, vol2col_rm_pages, data_format);
 
     uint32_t cb_vol2col_tiled_id = next_cb_index++;
     tt::tt_metal::create_cb(cb_vol2col_tiled_id, program, core_grid, tile_size, matmul_M_t * matmul_K_t, data_format);
@@ -177,7 +167,12 @@ Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
         tt::tt_metal::create_cb(cb_bias_tiled_id, program, core_grid, tile_size, matmul_N_t, data_format);
     }
 
-    log_debug(tt::LogOp, "CB vol2col_rm: page_size={} bytes, num_pages={}", patch_size_bytes, vol2col_rm_pages);
+    log_debug(
+        tt::LogOp,
+        "CB vol2col_rm: page_size={} bytes (padded from {}), num_pages={}",
+        padded_patch_size_bytes,
+        patch_size_bytes,
+        vol2col_rm_pages);
     log_debug(tt::LogOp, "CB vol2col_tiled: page_size={} bytes, num_pages={}", tile_size, matmul_M_t * matmul_K_t);
     log_debug(tt::LogOp, "CB weight_tiled: page_size={} bytes, num_pages={}", tile_size, matmul_K_t * matmul_N_t);
     log_debug(
@@ -195,11 +190,11 @@ Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
     constexpr uint32_t L1_PREFETCH_HARD_CAP = 500 * 1024;
     const uint32_t l1_usable_for_cbs = tt::tt_metal::hal::get_max_worker_l1_unreserved_size() - L1_KERNEL_CODE_RESERVE;
 
-    uint32_t other_cbs_bytes = (patch_size_bytes * vol2col_rm_pages) +  // vol2col_rm
-                               (tile_size * matmul_M_t * matmul_K_t) +  // vol2col_tiled
-                               (tile_size * matmul_K_t * matmul_N_t) +  // weight_tiled
-                               (tile_size * matmul_M_t * matmul_N_t) +  // matmul_interm
-                               (tile_size * matmul_M_t * matmul_N_t);   // matmul_result_rm
+    uint32_t other_cbs_bytes = (padded_patch_size_bytes * vol2col_rm_pages) +  // vol2col_rm
+                               (tile_size * matmul_M_t * matmul_K_t) +         // vol2col_tiled
+                               (tile_size * matmul_K_t * matmul_N_t) +         // weight_tiled
+                               (tile_size * matmul_M_t * matmul_N_t) +         // matmul_interm
+                               (tile_size * matmul_M_t * matmul_N_t);          // matmul_result_rm
     if (C_in_num_blocks > 1) {
         other_cbs_bytes += tile_size * matmul_M_t * matmul_N_t;  // reduction
         other_cbs_bytes += tile_size;                            // worker_ack
@@ -336,7 +331,8 @@ Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
         cb_input_shard_id,
         T_shard_max,
         H_shard_max,
-        W_shard_max};
+        W_shard_max,
+        patch_pad_bytes};
     tt::tt_metal::TensorAccessorArgs(*input_tensor.buffer()).append_to(reader_compile_time_args);
 
     auto reader_kernels_id = CreateKernel(

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/reader_vol2col.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/reader_vol2col.cpp
@@ -5,6 +5,26 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 
+// Pre-zero CB pages via NOC DMA from MEM_ZEROS so tile-alignment padding is zero.
+// Uses MEM_ZEROS_SIZE-aligned transactions (same pattern as zero_out_tiles in conv_reader_common.hpp).
+// padded_page_bytes must be a multiple of 16 to guarantee remainder alignment.
+template <uint32_t padded_page_bytes>
+FORCE_INLINE void pre_zero_pages(uint32_t write_addr, uint32_t num_pages) {
+    static_assert(padded_page_bytes % 16 == 0, "CB page size must be 16-byte aligned for NOC transactions");
+    const uint64_t zeros_noc_addr = get_noc_addr(MEM_ZEROS_BASE);
+    uint32_t total = num_pages * padded_page_bytes;
+    noc_async_read_one_packet_set_state(zeros_noc_addr, MEM_ZEROS_SIZE);
+    while (total >= MEM_ZEROS_SIZE) {
+        noc_async_read_one_packet_with_state<true>(zeros_noc_addr, write_addr);
+        write_addr += MEM_ZEROS_SIZE;
+        total -= MEM_ZEROS_SIZE;
+    }
+    if (total > 0) {
+        noc_async_read(zeros_noc_addr, write_addr, total);
+    }
+    noc_async_read_barrier();
+}
+
 inline int32_t clampIndex(int32_t idx, int32_t lower_bound, int32_t upper_bound) {
     // If we're doing replicate padding, clamp idx into [lower_bound, upper_bound].
     if (idx < lower_bound) {
@@ -71,6 +91,10 @@ void kernel_main() {
     constexpr uint32_t H_shard_max = get_compile_time_arg_val(33);
     constexpr uint32_t W_shard_max = get_compile_time_arg_val(34);
 
+    // Padding bytes to append after each patch row to reach tile-aligned CB page width
+    constexpr uint32_t patch_pad_bytes = get_compile_time_arg_val(35);
+    constexpr uint32_t padded_page_bytes = kT * kH * kW * C_in_block_bytes + patch_pad_bytes;
+
     // Load input/output addresses and range parameters
     uint32_t argidx = 0;
     const uint32_t in_addr = get_arg_val<uint32_t>(argidx++);
@@ -86,7 +110,7 @@ void kernel_main() {
     const uint32_t w_out_end = get_arg_val<uint32_t>(argidx++);
 
     // Tensor accessor for input tensor
-    constexpr auto in_args = TensorAccessorArgs<35>();
+    constexpr auto in_args = TensorAccessorArgs<36>();
     const auto in_reader = TensorAccessor(in_args, in_addr, in_row_size_bytes);
 
     constexpr uint32_t num_patches = T_block_size * H_block_size * W_block_size;
@@ -234,13 +258,15 @@ void kernel_main() {
                                 // Use stateful NOC read: L1->L1 with constexpr transfer size.
                                 constexpr uint32_t kW_bytes = kW * C_in_block_bytes;
                                 static_assert(kW_bytes <= NOC_MAX_BURST_SIZE, "kW_bytes exceeds NOC_MAX_BURST_SIZE");
-                                noc_async_read_one_packet_set_state(shard_noc_base, kW_bytes);
-
                                 constexpr uint32_t chunk_max = 32;  // TILE_HEIGHT
                                 uint32_t patches_remaining = num_patches;
                                 uint32_t chunk_size = patches_remaining < chunk_max ? patches_remaining : chunk_max;
                                 cb_reserve_back(cb_vol2col, chunk_size);
                                 uint32_t cb_write_addr = get_write_ptr(cb_vol2col);
+                                if constexpr (patch_pad_bytes > 0) {
+                                    pre_zero_pages<padded_page_bytes>(cb_write_addr, chunk_size);
+                                }
+                                noc_async_read_one_packet_set_state(shard_noc_base, kW_bytes);
                                 uint32_t patches_in_chunk = 0;
 
                                 for (uint32_t t = t_block; t < t_block_end; t++) {
@@ -263,6 +289,10 @@ void kernel_main() {
                                                 }
                                             }
 
+                                            if constexpr (patch_pad_bytes > 0) {
+                                                cb_write_addr += patch_pad_bytes;
+                                            }
+
                                             patches_in_chunk++;
                                             if (patches_in_chunk == chunk_size) {
                                                 noc_async_read_barrier();
@@ -274,6 +304,10 @@ void kernel_main() {
                                                         patches_remaining < chunk_max ? patches_remaining : chunk_max;
                                                     cb_reserve_back(cb_vol2col, chunk_size);
                                                     cb_write_addr = get_write_ptr(cb_vol2col);
+                                                    if constexpr (patch_pad_bytes > 0) {
+                                                        pre_zero_pages<padded_page_bytes>(cb_write_addr, chunk_size);
+                                                    }
+                                                    noc_async_read_one_packet_set_state(shard_noc_base, kW_bytes);
                                                 }
                                             }
                                         }
@@ -313,6 +347,9 @@ void kernel_main() {
                                 uint32_t chunk_size = patches_remaining < chunk_max ? patches_remaining : chunk_max;
                                 cb_reserve_back(cb_vol2col, chunk_size);
                                 uint32_t cb_write_addr = get_write_ptr(cb_vol2col);
+                                if constexpr (patch_pad_bytes > 0) {
+                                    pre_zero_pages<padded_page_bytes>(cb_write_addr, chunk_size);
+                                }
                                 uint32_t patches_in_chunk = 0;
 
                                 for (uint32_t t = t_block_s_start; t < t_block_s_end; t += stride_t) {
@@ -360,6 +397,10 @@ void kernel_main() {
                                                 }
                                             }
 
+                                            if constexpr (patch_pad_bytes > 0) {
+                                                cb_write_addr += patch_pad_bytes;
+                                            }
+
                                             patches_in_chunk++;
                                             if (patches_in_chunk == chunk_size) {
                                                 noc_async_read_barrier();
@@ -371,6 +412,9 @@ void kernel_main() {
                                                         patches_remaining < chunk_max ? patches_remaining : chunk_max;
                                                     cb_reserve_back(cb_vol2col, chunk_size);
                                                     cb_write_addr = get_write_ptr(cb_vol2col);
+                                                    if constexpr (patch_pad_bytes > 0) {
+                                                        pre_zero_pages<padded_page_bytes>(cb_write_addr, chunk_size);
+                                                    }
                                                 }
                                             }
                                         }


### PR DESCRIPTION
## Summary
- Fix `conv3d` crash (`TT_FATAL`) when `patch_size` (`kD*kH*kW*C_in_block`) is not a multiple of `TILE_WIDTH` (32)
- Pad vol2col CB page size to tile alignment and pre-zero pages via NOC DMA from `MEM_ZEROS`
- Add nightly regression tests for non-aligned patch sizes (C_in=3, 4, 12)

Closes #39103

## Details
The root cause was that the vol2col CB page size and `tilize_block` both require tile-aligned row widths, but the kernel asserted exact multiples of 32. With small `C_in` values (e.g. `C_in=4`, `kernel=3×3×3` → `patch_size=108`), the assert fired.

The fix pads the CB page size to `round_up(patch_size, TILE_WIDTH)` and pre-zeros reserved CB pages at chunk boundaries using `MEM_ZEROS_SIZE`-aligned NOC DMA transactions (same pattern as `zero_out_tiles` in conv2d). The weight tensor is already zero-padded by tilization, so the matmul result is correct.

## Test plan
- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=pjosipovic/fix_39103)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:pjosipovic/fix_39103)
- [ ] [![Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/fix_39103)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/fix_39103)
- [ ] [![Nightly L2 conv tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/fix_39103)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/fix_39103)
- [x] Repro script from issue passes
- [x] PCC > 0.999 against PyTorch reference
- [x] Existing conv3d unit tests pass (no_config, non_aligned_output_channels, cache)
- [x] New nightly regression tests pass (4 cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)