### PR TITLE
Add support for sampling on device for Deepseek

### DIFF
--- a/models/demos/deepseek_v3/demo/demo.py
+++ b/models/demos/deepseek_v3/demo/demo.py
@@ -143,6 +143,12 @@ def create_parser() -> argparse.ArgumentParser:
         default=False,
         help="Profile decode performance: skip prefill (use random tokens), and run only first dense layer + first MoE layer during decode.",
     )
+    p.add_argument(
+        "--sample-on-device",
+        action="store_true",
+        default=False,
+        help="Enable on-device sampling (default: host-side sampling).",
+    )
     return p
 
 
@@ -260,6 +266,7 @@ def run_demo(
     signpost: bool = False,
     prefill_max_tokens: int = None,
     profile_decode: bool = False,
+    sample_on_device: bool = False,
 ) -> dict:
     """Programmatic entrypoint for the DeepSeek-V3 demo.
 
@@ -322,6 +329,7 @@ def run_demo(
             )
             raise
 
+    gen = None
     try:
         # If random single-layer requested with 'moe', fail fast (Model1D demo is MLP-only)
         if random_weights and single_layer and single_layer.lower() == "moe":
@@ -359,6 +367,7 @@ def run_demo(
                 signpost=signpost,
                 prefill_max_tokens=prefill_max_tokens,
                 profile_decode=profile_decode,
+                sample_on_device=sample_on_device,
             )
         # Build the prompt list
         pre_tokenized_prompts = None
@@ -412,7 +421,8 @@ def run_demo(
     finally:
         # Clean up generator resources
         try:
-            gen.cleanup_all()
+            if gen is not None:
+                gen.cleanup_all()
         except Exception as e:
             logger.warning(f"Failed to cleanup generator: {e}")
         # Synchronize device before closing to flush pending ops (e.g. profiler data)
@@ -461,6 +471,7 @@ def main() -> None:
         signpost=args.signpost,
         prefill_max_tokens=args.prefill_max_tokens,
         profile_decode=args.profile_decode,
+        sample_on_device=args.sample_on_device,
     )
 
     # If prompts were loaded from a JSON file, save output to JSON file instead of printing

--- a/models/demos/deepseek_v3/tests/test_sampling.py
+++ b/models/demos/deepseek_v3/tests/test_sampling.py
@@ -49,6 +49,7 @@ def _sample_device_tokens(mesh_device, ccl, args, torch_input, user_params):
     sampling.reset_sampling_params(params)
     sampling.reset_prompt_tokens(torch.zeros((USERS_PER_ROW, 1), dtype=torch.int64))
     sampling.reset_output_state(torch.zeros((USERS_PER_ROW, 1), dtype=torch.int64))
+    sampling.seed_manager.reset_seed(params.seed, list(range(batch_size)))
     sampling.seed_manager.get_new_values()
     tt_tokens, _ = sampling.sample(tt_input, enable_trace=False)
     device_tokens = _extract_all_tokens(tt_tokens, mesh_device, USERS_PER_ROW)
@@ -126,15 +127,18 @@ def test_deepseek_device_sampling_stochastic_behavior(mesh_device, ccl, hf_confi
     sampling.reset_sampling_params(params)
     sampling.reset_prompt_tokens(torch.zeros((USERS_PER_ROW, 1), dtype=torch.int64))
     sampling.reset_output_state(torch.zeros((USERS_PER_ROW, 1), dtype=torch.int64))
+    sampling.seed_manager.reset_seed(params.seed, list(range(batch_size)))
 
     sampled_tokens = []
     try:
         for _ in range(num_samples):
             sampling.seed_manager.get_new_values()
-            tt_tokens, _ = sampling.sample(tt_input, enable_trace=False)
+            tt_tokens, tt_log_probs = sampling.sample(tt_input, enable_trace=False)
             device_tokens = _extract_all_tokens(tt_tokens, mesh_device, USERS_PER_ROW)
             sampled_tokens.append(int(device_tokens[0].item()))
             ttnn.deallocate(tt_tokens)
+            if tt_log_probs is not None:
+                ttnn.deallocate(tt_log_probs)
     finally:
         ttnn.deallocate(tt_input)
 

--- a/models/demos/deepseek_v3/tests/test_sampling.py
+++ b/models/demos/deepseek_v3/tests/test_sampling.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+import ttnn
+from models.common.sampling import SamplingGenerator, SamplingParams, format_sampling_params
+from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, make_deepseek_sampling_args
+
+
+def _make_lm_head_sharded_logits(torch_input, mesh_device):
+    return ttnn.from_torch(
+        torch_input,
+        device=mesh_device,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(-2, -1), mesh_shape=tuple(mesh_device.shape)),
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        layout=ttnn.TILE_LAYOUT,
+    )
+
+
+def _extract_all_tokens(tt_out_tok, mesh_device, batch_size_per_row):
+    composed = ttnn.to_torch(
+        tt_out_tok,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(1, -1), mesh_shape=tuple(mesh_device.shape)),
+    )
+    if composed.ndim == 4:
+        if tt_out_tok.shape[-2] == batch_size_per_row:
+            tokens = composed[:, :, :, 0]
+        elif tt_out_tok.shape[-1] == batch_size_per_row:
+            tokens = composed[:, :, 0, :batch_size_per_row]
+        else:
+            tokens = composed
+        tokens = tokens.reshape(-1)
+    else:
+        tokens = composed.reshape(-1)
+    batch_size = batch_size_per_row * int(mesh_device.shape[0])
+    return tokens[:batch_size].to(torch.int64)
+
+
+def _sample_device_tokens(mesh_device, ccl, args, torch_input, user_params):
+    batch_size = USERS_PER_ROW * int(mesh_device.shape[0])
+    tt_input = _make_lm_head_sharded_logits(torch_input, mesh_device)
+    sampling = SamplingGenerator(args=args, mesh_device=mesh_device, tt_ccl=ccl, enable_internal_trace=False)
+    params = format_sampling_params(user_params, max_batch_size=batch_size)
+    sampling.reset_sampling_params(params)
+    sampling.reset_prompt_tokens(torch.zeros((USERS_PER_ROW, 1), dtype=torch.int64))
+    sampling.reset_output_state(torch.zeros((USERS_PER_ROW, 1), dtype=torch.int64))
+    sampling.seed_manager.get_new_values()
+    tt_tokens, _ = sampling.sample(tt_input, enable_trace=False)
+    device_tokens = _extract_all_tokens(tt_tokens, mesh_device, USERS_PER_ROW)
+    ttnn.deallocate(tt_tokens)
+    ttnn.deallocate(tt_input)
+    return device_tokens
+
+
+@torch.no_grad()
+@pytest.mark.parametrize(
+    "sampling_params",
+    [
+        {"temperature": 0.0, "top_k": 32, "top_p": 0.00, "seed": 42},
+        {"temperature": 0.0, "top_k": 32, "top_p": 0.95, "seed": 42},
+        {"temperature": 1.0, "top_k": 1, "top_p": 0.00, "seed": 42},  # top-k=1 (always argmax)
+    ],
+)
+@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
+def test_deepseek_device_sampling_argmax_path(mesh_device, ccl, hf_config, device_params, sampling_params):
+    vocab_size = int(hf_config.vocab_size)
+    args = make_deepseek_sampling_args(mesh_device, vocab_size=vocab_size)
+    batch_size = USERS_PER_ROW * int(mesh_device.shape[0])
+    seed = int(sampling_params.get("seed", 0))
+    torch.manual_seed(seed)
+    torch_input = torch.randn(1, 1, batch_size, args.padded_vocab_size) * 0.01
+    forced_tokens = torch.tensor([(u * 1237 + 31) % vocab_size for u in range(batch_size)], dtype=torch.int64)
+    batch_indices = torch.arange(batch_size, dtype=torch.int64)
+    torch_input[0, 0, batch_indices, forced_tokens] = 50.0
+    if args.padded_vocab_size > vocab_size:
+        torch_input[:, :, :, vocab_size:] = -float("inf")
+
+    user_params = SamplingParams(
+        temperature=[sampling_params["temperature"]] * batch_size,
+        top_k=[sampling_params["top_k"]] * batch_size,
+        top_p=[sampling_params["top_p"]] * batch_size,
+        seed=[seed] * batch_size,
+    )
+    device_tokens = _sample_device_tokens(mesh_device, ccl, args, torch_input, user_params)
+
+    assert device_tokens.numel() == batch_size, (
+        f"Expected {batch_size} sampled tokens, got {device_tokens.numel()}. "
+        "This usually indicates incorrect mesh token reconstruction."
+    )
+    assert torch.equal(
+        device_tokens, forced_tokens
+    ), "Device sampling generator produced tokens mismatch for LM-head sharded DeepSeek logits."
+
+
+@torch.no_grad()
+@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
+def test_deepseek_device_sampling_stochastic_behavior(mesh_device, ccl, hf_config, device_params):
+    vocab_size = int(hf_config.vocab_size)
+    args = make_deepseek_sampling_args(mesh_device, vocab_size=vocab_size)
+    batch_size = USERS_PER_ROW * int(mesh_device.shape[0])
+
+    torch_input = torch.full((1, 1, batch_size, args.padded_vocab_size), -1e9, dtype=torch.float32)
+    candidate_tokens = torch.tensor([3, 7, 11, 19], dtype=torch.int64)
+    candidate_logits = torch.tensor([4.0, 3.0, 2.0, 1.0], dtype=torch.float32)
+    torch_input[0, 0, :, candidate_tokens] = candidate_logits
+    if args.padded_vocab_size > vocab_size:
+        torch_input[:, :, :, vocab_size:] = -float("inf")
+
+    num_samples = 100
+    per_user_seeds = [1000 + u for u in range(batch_size)]
+    user_params = SamplingParams(
+        temperature=[1.0] * batch_size,
+        top_k=[4] * batch_size,
+        top_p=[0.95] * batch_size,
+        seed=per_user_seeds,
+    )
+
+    tt_input = _make_lm_head_sharded_logits(torch_input, mesh_device)
+    sampling = SamplingGenerator(args=args, mesh_device=mesh_device, tt_ccl=ccl, enable_internal_trace=False)
+    params = format_sampling_params(user_params, max_batch_size=batch_size)
+    sampling.reset_sampling_params(params)
+    sampling.reset_prompt_tokens(torch.zeros((USERS_PER_ROW, 1), dtype=torch.int64))
+    sampling.reset_output_state(torch.zeros((USERS_PER_ROW, 1), dtype=torch.int64))
+
+    sampled_tokens = []
+    try:
+        for _ in range(num_samples):
+            sampling.seed_manager.get_new_values()
+            tt_tokens, _ = sampling.sample(tt_input, enable_trace=False)
+            device_tokens = _extract_all_tokens(tt_tokens, mesh_device, USERS_PER_ROW)
+            sampled_tokens.append(int(device_tokens[0].item()))
+            ttnn.deallocate(tt_tokens)
+    finally:
+        ttnn.deallocate(tt_input)
+
+    candidate_set = set(candidate_tokens.tolist())
+    sampled_set = set(sampled_tokens)
+    assert sampled_set.issubset(
+        candidate_set
+    ), f"Sampled tokens outside candidate set. got={sorted(sampled_set)}, expected subset of {sorted(candidate_set)}"
+    assert len(sampled_set) >= 2, (
+        f"Only {len(sampled_set)} unique token(s) in {num_samples} samples; sampling may be stuck. "
+        f"sampled_set={sorted(sampled_set)}"
+    )

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -12,14 +12,14 @@ from tracy import signpost
 from transformers import AutoConfig
 
 import ttnn
-from models.common.sampling.sampling_params import SamplingParams
+from models.common.sampling.generator import SamplingGenerator, SamplingParams, format_sampling_params
 from models.common.warmup import WarmupForwardMixin
 from models.demos.deepseek_v3.tt.ccl import CCL
 from models.demos.deepseek_v3.tt.mla.mla2d import MLA2D
 from models.demos.deepseek_v3.tt.model.row_batched_model import RowBatchedModel
 from models.demos.deepseek_v3.tt.rope import RotarySetup
 from models.demos.deepseek_v3.utils.config_dataclass import KvCacheConfig
-from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, even_int_div
+from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, even_int_div, make_deepseek_sampling_args
 from models.demos.deepseek_v3.utils.debug_utils import dump_ttnn_meminfo
 from models.demos.deepseek_v3.utils.run_config import create_run_config
 from models.demos.deepseek_v3.utils.weight_config import get_weight_config
@@ -86,10 +86,12 @@ class DeepseekGenerator(WarmupForwardMixin):
         prefill_max_tokens: int | None = None,
         force_recalculate: bool = False,
         profile_decode: bool = False,
+        sample_on_device: bool = False,
     ) -> None:
         self.mesh_device = mesh_device
         self.model_path = str(model_path)
         self.cache_dir = cache_dir
+        self.sample_on_device = sample_on_device
 
         # Load HF config + tokenizer
         self.hf_config = (
@@ -126,11 +128,30 @@ class DeepseekGenerator(WarmupForwardMixin):
         self.ccl = CCL(mesh_device)
         mesh_shape = list(mesh_device.shape)
         self.dp_factor = mesh_shape[1]
+        self.batch_size_per_row = USERS_PER_ROW
+        self.batch_size = self.batch_size_per_row * self.mesh_device.shape[0]
+
+        if sample_on_device and enable_trace:
+            raise ValueError("sample_on_device=True and enable_trace=True is not supported yet. Disable either one.")
+        # Configure sampling
+        if self.sample_on_device:
+            self.sampling_args = make_deepseek_sampling_args(mesh_device, self.hf_config.vocab_size)
+            self.sampling_generator = SamplingGenerator(
+                args=self.sampling_args, mesh_device=self.mesh_device, tt_ccl=self.ccl, enable_internal_trace=False
+            )
+            # Use default sampling params (top-k=1, top-p=0.0, temperature=1.0) i.e. argmax sampling for device sampling
+            self.sampling_params = SamplingParams(
+                temperature=[1.0] * self.batch_size,
+                top_k=[1] * self.batch_size,
+                top_p=[0.0] * self.batch_size,
+                seed=[42] * self.batch_size,
+            )
+            self._reset_sampling_state(self.sampling_params, self.batch_size, self.batch_size_per_row)
+
+        logger.info(f"Sampling mode: {'device' if self.sample_on_device else 'host'}")
         # Weight cache to avoid loading weights multiple times
         self._weight_ttnn_cache: dict[str, ttnn.Tensor] = {}
         # Paged attention setup
-        self.batch_size_per_row = USERS_PER_ROW
-        self.batch_size = self.batch_size_per_row * self.mesh_device.shape[0]
         self.paged_config = MLA2D.get_valid_paged_config(
             self.hf_config.max_seq_len, self.batch_size_per_row, self.dp_factor
         )
@@ -414,7 +435,7 @@ class DeepseekGenerator(WarmupForwardMixin):
 
     def _tt_from_tokens_step(self, tokens_step: torch.Tensor) -> ttnn.Tensor:
         """Tokens step: [B] -> TTNN tensor [1, 1, B] uint32, replicated to mesh."""
-        assert tokens_step.dim() == 1
+        assert tokens_step.dim() == 1, f"Expected 1D tensor, got shape {tokens_step.shape}"
         x = tokens_step.view(1, 1, -1).to(torch.int32)
         return ttnn.from_torch(
             x,
@@ -424,6 +445,41 @@ class DeepseekGenerator(WarmupForwardMixin):
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             layout=ttnn.ROW_MAJOR_LAYOUT,
         )
+
+    def _reset_sampling_state(self, sampling_params: SamplingParams, batch_size: int, batch_size_per_row: int) -> None:
+        sampling_params = format_sampling_params(sampling_params, max_batch_size=batch_size)
+        self.sampling_generator.reset_sampling_params(sampling_params)
+        self.sampling_generator.reset_prompt_tokens(torch.zeros((batch_size_per_row, 1), dtype=torch.int64))
+        self.sampling_generator.reset_output_state(torch.zeros((batch_size_per_row, 1), dtype=torch.int64))
+
+    def _sample_tokens_device(self, logits: ttnn.Tensor, enable_trace: bool = False) -> ttnn.Tensor:
+        tt_out = self.sampling_generator.sample(logits, enable_trace=enable_trace)
+
+        if isinstance(tt_out, tuple):
+            tt_tokens, tt_log_probs = tt_out
+            if tt_log_probs is not None:
+                ttnn.deallocate(tt_log_probs)
+            tt_out = tt_tokens
+
+        return tt_out
+
+    def _tokens_from_device(self, tt_out_tok, mesh_device, batch_size_per_row=USERS_PER_ROW) -> torch.Tensor:
+        composed = ttnn.to_torch(
+            tt_out_tok,
+            mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(1, -1), mesh_shape=tuple(mesh_device.shape)),
+        )
+        if composed.ndim == 4:
+            if tt_out_tok.shape[-2] == batch_size_per_row:
+                tokens = composed[:, :, :, 0]
+            elif tt_out_tok.shape[-1] == batch_size_per_row:
+                tokens = composed[:, :, 0, :batch_size_per_row]
+            else:
+                tokens = composed
+            tokens = tokens.reshape(-1)
+        else:
+            tokens = composed.reshape(-1)
+        batch_size = batch_size_per_row * int(mesh_device.shape[0])
+        return tokens[:batch_size].to(torch.int64)
 
     def _tt_from_positions(self, positions: torch.Tensor) -> Tuple[dict, ttnn.Tensor]:
         """Return rope tensors dict and TTNN positions shard for decode.
@@ -452,7 +508,7 @@ class DeepseekGenerator(WarmupForwardMixin):
         )
         return rope_tensors, tt_positions
 
-    def _get_page_tables(self) -> tuple[ttnn.Tensor, ...]:
+    def _get_page_tables(self) -> ttnn.Tensor | Tuple[ttnn.Tensor, ttnn.Tensor]:
         if hasattr(self, "page_tables_tt") and self.page_tables_tt is not None:
             return self.page_tables_tt
 
@@ -474,19 +530,21 @@ class DeepseekGenerator(WarmupForwardMixin):
         self,
         tokens_step: torch.Tensor,
         positions: torch.Tensor,
-        batch_size_per_row: int,
         page_tables: torch.Tensor | None = None,
-        return_rot_idxs: bool = False,
-    ) -> torch.Tensor | Tuple[torch.Tensor, ttnn.Tensor]:
-        """Run a single decode step and return logits on host as torch tensor [1, 1, B, V].
+        sample_on_device: bool = False,
+    ) -> torch.Tensor | ttnn.Tensor:
+        """Run a single decode step and return decode logits.
 
         Args:
-            tokens_step: Input tokens
-            positions: Position indices
-            batch_size_per_row: Batch size per row
+            tokens_step: Input token ids of shape [B].
+            positions: Position indices of shape [B].
+            page_tables: Optional vLLM-style page table tensor.
+            sample_on_device: If True, keep logits on device for on-device sampling.
+                If False, gather logits to host.
 
         Returns:
-            logits tensor
+            - torch.Tensor with shape [1, 1, B, V] when sample_on_device is False.
+            - ttnn.Tensor with shape [1, 1, B, V] when sample_on_device is True.
         """
         # Prepare TT inputs
         tt_tokens = self._tt_from_tokens_step(tokens_step)
@@ -510,7 +568,7 @@ class DeepseekGenerator(WarmupForwardMixin):
         else:
             page_tables_to_use = self._get_page_tables()
         # RowBatchedModel forward
-        logits_tt = RowBatchedModel.forward_decode(
+        decode_logits = RowBatchedModel.forward_decode(
             tt_tokens,
             tt_positions,
             self.model_run_config_decode,
@@ -518,18 +576,27 @@ class DeepseekGenerator(WarmupForwardMixin):
             page_tables=page_tables_to_use,
             profile_decode=self.profile_decode,
         )
-        # Gather to host
-        logits = ttnn.to_torch(
-            logits_tt,
-            mesh_composer=ttnn.ConcatMesh2dToTensor(self.mesh_device, dims=(-2, -1), mesh_shape=self.mesh_device.shape),
-        )
-        # Free device tensors for this step
+        if not sample_on_device:
+            # Gather to host
+            logits = (
+                ttnn.to_torch(
+                    decode_logits,
+                    mesh_composer=ttnn.ConcatMesh2dToTensor(
+                        self.mesh_device, dims=(-2, -1), mesh_shape=self.mesh_device.shape
+                    ),
+                )
+                .squeeze(0)
+                .squeeze(0)
+            )
+            ttnn.deallocate(decode_logits)
+        else:
+            logits = decode_logits
+
         ttnn.deallocate(tt_tokens)
-        ttnn.deallocate(logits_tt)
+        ttnn.deallocate(tt_positions)
+        return logits  # [B, V]
 
-        return logits  # [1, 1, B, V]
-
-    def _sample_greedy(self, logits: torch.Tensor) -> torch.Tensor:
+    def _sample_greedy_on_host(self, logits: torch.Tensor) -> torch.Tensor:
         return torch.argmax(logits, dim=-1)  # [B]
 
     def _pad_batch(self, tokens_list: List[List[int]], batch_size: int) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -645,7 +712,8 @@ class DeepseekGenerator(WarmupForwardMixin):
                 for user_id in range(num_of_users):
                     if lengths[user_id] == 0:
                         logger.info(f"Skipping prefill for user_id: {user_id} as prompt length is 0")
-                        last_logits.append(torch.zeros(self.hf_config.vocab_size))
+                        pad_token = self.tokenizer.pad_token_id if self.tokenizer is not None else 0
+                        last_logits.append(torch.tensor(int(pad_token), dtype=torch.int64))
                         continue
                     logger.info(f"Running prefill for user_id: {user_id}")
                     prompt_len = int(lengths[user_id].item())
@@ -660,9 +728,35 @@ class DeepseekGenerator(WarmupForwardMixin):
                             else str(tokens_batched[user_id][:prompt_len].tolist())
                         )
                     )
-                    user_out = self._prefill(tokens_batched[user_id], user_id=user_id)
-                    # Use logits at the *actual* last prompt token (not the padded tail).
-                    last_logits.append(user_out[0, 0, prompt_len - 1, :])
+                    prefill_logits = self._prefill(
+                        tokens_batched[user_id], user_id=user_id, sample_on_device=self.sample_on_device
+                    )
+                    assert prefill_logits is not None
+                    logger.info(f"prefill_logits.shape: {prefill_logits.shape}")
+
+                    if self.sample_on_device:
+                        # Device sampling
+                        prefill_logits = self._slice_last_token_logits(prefill_logits, prompt_len)
+                        logger.info(f"prefill_logits.shape after slice: {prefill_logits.shape}")
+                        prefill_logits = self._expand_prefill_logits(prefill_logits)
+                        logger.info(f"prefill_logits.shape after expand: {prefill_logits.shape}")
+                        prefill_logits_sampled_device = self._sample_tokens_device(prefill_logits)
+                        logger.info(f"prefill_logits_sampled_device.shape: {prefill_logits_sampled_device.shape}")
+                        prefill_logits_sampled_host = self._tokens_from_device(
+                            prefill_logits_sampled_device, self.mesh_device, batch_size_per_row=1
+                        )
+                        pred_token = prefill_logits_sampled_host[0]
+                        ttnn.deallocate(prefill_logits)
+                        ttnn.deallocate(prefill_logits_sampled_device)
+                    else:
+                        # Host sampling
+                        assert isinstance(
+                            prefill_logits, torch.Tensor
+                        ), "prefill_logits should be a torch.Tensor on host"
+                        # Sample only from the actual last prompt position for this user.
+                        last_token_logits = prefill_logits[0, 0, max(prompt_len - 1, 0), :]
+                        pred_token = self._sample_greedy_on_host(last_token_logits)
+                    last_logits.append(torch.tensor(pred_token, dtype=torch.int64))
                     self.ccl.reset_sem_counters()
                 last_logits = torch.stack(last_logits)
                 profiler.end("inference_prefill")
@@ -691,7 +785,8 @@ class DeepseekGenerator(WarmupForwardMixin):
                 if self.profile_decode:
                     next_tokens = next_tokens_override
                 else:
-                    next_tokens = self._sample_greedy(last_logits)
+                    # Prefill already produced one token per user.
+                    next_tokens = last_logits
                 if teacher_forcing is not None:
                     # Record user-0 prediction for accuracy, but force teacher token for alignment.
                     forced0 = teacher_forcing.collect_predicted_tokens(int(next_tokens[0].item()))
@@ -716,17 +811,29 @@ class DeepseekGenerator(WarmupForwardMixin):
                 for gen_idx in range(decode_steps):
                     logger.info(f"Decoding step {gen_idx} for {num_of_prompts} user(s)...")
                     profiler.start(f"decode_time_{gen_idx}")
-                    logits = self.decode_forward(
+                    decode_logits = self.decode_forward(
                         tokens=next_tokens,
                         start_pos=positions,
                         batch_size_per_row=self.batch_size_per_row,
                         profiler=profiler,
                         gen_idx=gen_idx,
                         enable_trace=self.enable_trace,
+                        sample_on_device=self.sample_on_device,
                     )
                     profiler.end(f"decode_time_{gen_idx}")
                     self.ccl.reset_sem_counters()
-                    pred_tokens = self._sample_greedy(logits)
+                    if self.sample_on_device:
+                        pred_tokens_device = self._sample_tokens_device(decode_logits)
+                        pred_tokens = self._tokens_from_device(
+                            pred_tokens_device, self.mesh_device, batch_size_per_row=self.batch_size_per_row
+                        )
+                        ttnn.deallocate(decode_logits)
+                        ttnn.deallocate(pred_tokens_device)
+
+                    else:
+                        assert isinstance(decode_logits, torch.Tensor), "decode_logits should be a torch.Tensor on host"
+                        pred_tokens = self._sample_greedy_on_host(decode_logits)
+
                     if teacher_forcing is not None:
                         # Record user-0 prediction for accuracy, then force teacher token.
                         forced = teacher_forcing.collect_predicted_tokens(int(pred_tokens[0].item()))
@@ -833,8 +940,9 @@ class DeepseekGenerator(WarmupForwardMixin):
         user_id: int,
         page_table: torch.Tensor | None = None,
         local_user_id: int | None = None,
-    ) -> torch.Tensor:
-        """Run prefill for the full prompt sequence and return logits for the last position.
+        sample_on_device: bool = False,
+    ) -> ttnn.Tensor | torch.Tensor:
+        """Run prefill for the full prompt sequence to populate caches.
 
         Args:
             tokens: [1, 1, seq_len] padded token sequences
@@ -842,7 +950,7 @@ class DeepseekGenerator(WarmupForwardMixin):
             local_user_id: local user id for page table lookup
 
         Returns:
-            logits: [1, 1, seq_len, V] logits for the full sequence
+            logits ttnn.Tensor on device if sample_on_device is True, otherwise logits torch.Tensor on host
         """
 
         tokens = tokens.view(1, 1, -1)
@@ -878,24 +986,68 @@ class DeepseekGenerator(WarmupForwardMixin):
             page_tables_to_use = self._get_page_tables()
 
         # RowBatchedModel forward prefill
-        logits_tt = RowBatchedModel.forward_prefill(
+        prefill_logits = RowBatchedModel.forward_prefill(
             x=tt_tokens,
             user_id=user_id,
             cfg=self.model_run_config_prefill,
             rope_tensors=rope_tensors,
             page_tables=page_tables_to_use,
         )
+        if not sample_on_device:
+            # Gather to host
+            logits = ttnn.to_torch(
+                prefill_logits,
+                mesh_composer=ttnn.ConcatMesh2dToTensor(
+                    self.mesh_device, dims=(-2, -1), mesh_shape=self.mesh_device.shape
+                ),
+            )
+            ttnn.deallocate(prefill_logits)
+        else:
+            logits = prefill_logits
 
-        # Gather to host
-        logits = ttnn.to_torch(
-            logits_tt,
-            mesh_composer=ttnn.ConcatMesh2dToTensor(self.mesh_device, dims=(-2, -1), mesh_shape=self.mesh_device.shape),
+        ttnn.deallocate(tt_tokens)
+        return logits
+
+    def _slice_last_token_logits(self, logits: ttnn.Tensor, prompt_len: int) -> ttnn.Tensor:
+        last_idx = max(prompt_len - 1, 0)
+        shard_len = logits.shape[2]
+        local_idx = last_idx % shard_len
+        row_idx = last_idx // shard_len
+
+        last_logits = ttnn.slice(
+            logits,
+            [0, 0, local_idx, 0],
+            [1, 1, local_idx + 1, logits.shape[-1]],
         )
 
-        # Free device tensors for this step
-        ttnn.deallocate(tt_tokens)
-        ttnn.deallocate(logits_tt)
-        return logits  # [1, 1, seq_len, V]
+        if self.mesh_device.shape[0] > 1:
+            gather_cfg = self.ccl.populate_all_gather_runtime_args(
+                {
+                    "cluster_axis": 0,
+                    "dim": 2,
+                    "memory_config": ttnn.DRAM_MEMORY_CONFIG,
+                    "topology": ttnn.Topology.Linear,
+                }
+            )
+            gathered = ttnn.experimental.all_gather_async(last_logits, **gather_cfg)
+            ttnn.deallocate(last_logits)
+            last_logits = ttnn.slice(
+                gathered,
+                [0, 0, row_idx, 0],
+                [1, 1, row_idx + 1, gathered.shape[-1]],
+            )
+            ttnn.deallocate(gathered)
+
+        return last_logits
+
+    def _expand_prefill_logits(self, logits: ttnn.Tensor) -> ttnn.Tensor:
+        if logits.shape[2] == self.batch_size_per_row:
+            return logits
+        if logits.shape[2] == 1:
+            expanded = ttnn.repeat(logits, (1, 1, self.batch_size_per_row, 1))
+            ttnn.deallocate(logits)
+            return expanded
+        return logits
 
     def _capture_decode_trace(
         self,
@@ -911,7 +1063,7 @@ class DeepseekGenerator(WarmupForwardMixin):
         logger.info("Running warm-up decode step (no trace)...")
         if self.signpost:
             signpost(header="decode_warmup")
-        _ = self._decode_step(init_tokens, positions, batch_size_per_row=batch_size_per_row, page_tables=page_tables)
+        _ = self._decode_step(init_tokens, positions, page_tables=page_tables, sample_on_device=False)
         ttnn.synchronize_device(self.mesh_device)
         if self.signpost:
             signpost(header="decode_warmup")
@@ -970,12 +1122,16 @@ class DeepseekGenerator(WarmupForwardMixin):
         kv_cache: None = None,
         read_from_device: bool = None,
         sampling_params: SamplingParams = None,
-    ) -> torch.Tensor:
+        sample_on_device: bool = False,
+    ) -> ttnn.Tensor | torch.Tensor:
         # vLLM does not pass enable_trace param while initializing the model.
         # vLLM sets it in decode/prefill calls only, so we need to set it here too.
         self.enable_trace = enable_trace
+        if sample_on_device and enable_trace:
+            raise ValueError("sample_on_device=True and enable_trace=True is not supported yet. Disable either one.")
+
         if not enable_trace:
-            return self._decode_step(tokens, start_pos, batch_size_per_row, page_table).squeeze(0).squeeze(0)
+            return self._decode_step(tokens, start_pos, page_table, sample_on_device)
         else:
             # Capture trace and return trace output
             if self._trace_id is None:

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -449,10 +449,17 @@ class DeepseekGenerator(WarmupForwardMixin):
     def _reset_sampling_state(self, sampling_params: SamplingParams, batch_size: int, batch_size_per_row: int) -> None:
         sampling_params = format_sampling_params(sampling_params, max_batch_size=batch_size)
         self.sampling_generator.reset_sampling_params(sampling_params)
+        seed = getattr(sampling_params, "seed", None)
+        if seed is not None:
+            user_ids = list(range(batch_size))
+            self.sampling_generator.seed_manager.reset_seed(seed, user_ids)
         self.sampling_generator.reset_prompt_tokens(torch.zeros((batch_size_per_row, 1), dtype=torch.int64))
         self.sampling_generator.reset_output_state(torch.zeros((batch_size_per_row, 1), dtype=torch.int64))
 
-    def _sample_tokens_device(self, logits: ttnn.Tensor, enable_trace: bool = False) -> ttnn.Tensor:
+    def _sample_tokens_device(
+        self, logits: ttnn.Tensor, enable_trace: bool = False, user_slots: list[int] | None = None
+    ) -> ttnn.Tensor:
+        self.sampling_generator.seed_manager.get_new_values(user_slots)
         tt_out = self.sampling_generator.sample(logits, enable_trace=enable_trace)
 
         if isinstance(tt_out, tuple):
@@ -508,7 +515,7 @@ class DeepseekGenerator(WarmupForwardMixin):
         )
         return rope_tensors, tt_positions
 
-    def _get_page_tables(self) -> ttnn.Tensor | Tuple[ttnn.Tensor, ttnn.Tensor]:
+    def _get_page_tables(self) -> tuple[ttnn.Tensor, ...]:
         if hasattr(self, "page_tables_tt") and self.page_tables_tt is not None:
             return self.page_tables_tt
 
@@ -543,8 +550,8 @@ class DeepseekGenerator(WarmupForwardMixin):
                 If False, gather logits to host.
 
         Returns:
-            - torch.Tensor with shape [1, 1, B, V] when sample_on_device is False.
-            - ttnn.Tensor with shape [1, 1, B, V] when sample_on_device is True.
+            - torch.Tensor when sample_on_device is False.
+            - ttnn.Tensor when sample_on_device is True.
         """
         # Prepare TT inputs
         tt_tokens = self._tt_from_tokens_step(tokens_step)
@@ -708,12 +715,12 @@ class DeepseekGenerator(WarmupForwardMixin):
                 if self.signpost:
                     signpost(header="prefill")
                 profiler.start("inference_prefill")
-                last_logits = []
+                prefill_tokens = []
                 for user_id in range(num_of_users):
                     if lengths[user_id] == 0:
                         logger.info(f"Skipping prefill for user_id: {user_id} as prompt length is 0")
                         pad_token = self.tokenizer.pad_token_id if self.tokenizer is not None else 0
-                        last_logits.append(torch.tensor(int(pad_token), dtype=torch.int64))
+                        prefill_tokens.append(torch.tensor(int(pad_token), dtype=torch.int64))
                         continue
                     logger.info(f"Running prefill for user_id: {user_id}")
                     prompt_len = int(lengths[user_id].item())
@@ -732,16 +739,11 @@ class DeepseekGenerator(WarmupForwardMixin):
                         tokens_batched[user_id], user_id=user_id, sample_on_device=self.sample_on_device
                     )
                     assert prefill_logits is not None
-                    logger.info(f"prefill_logits.shape: {prefill_logits.shape}")
 
                     if self.sample_on_device:
                         # Device sampling
-                        prefill_logits = self._slice_last_token_logits(prefill_logits, prompt_len)
-                        logger.info(f"prefill_logits.shape after slice: {prefill_logits.shape}")
-                        prefill_logits = self._expand_prefill_logits(prefill_logits)
-                        logger.info(f"prefill_logits.shape after expand: {prefill_logits.shape}")
-                        prefill_logits_sampled_device = self._sample_tokens_device(prefill_logits)
-                        logger.info(f"prefill_logits_sampled_device.shape: {prefill_logits_sampled_device.shape}")
+                        prefill_logits = self._slice_last_token_logits(prefill_logits, prompt_len, expand_to_batch=True)
+                        prefill_logits_sampled_device = self._sample_tokens_device(prefill_logits, user_slots=[user_id])
                         prefill_logits_sampled_host = self._tokens_from_device(
                             prefill_logits_sampled_device, self.mesh_device, batch_size_per_row=1
                         )
@@ -756,15 +758,15 @@ class DeepseekGenerator(WarmupForwardMixin):
                         # Sample only from the actual last prompt position for this user.
                         last_token_logits = prefill_logits[0, 0, max(prompt_len - 1, 0), :]
                         pred_token = self._sample_greedy_on_host(last_token_logits)
-                    last_logits.append(torch.tensor(pred_token, dtype=torch.int64))
+                    prefill_tokens.append(torch.tensor(pred_token, dtype=torch.int64))
                     self.ccl.reset_sem_counters()
-                last_logits = torch.stack(last_logits)
+                prefill_tokens = torch.stack(prefill_tokens)
                 profiler.end("inference_prefill")
                 if self.signpost:
                     signpost(header="prefill")
 
             if not self.profile_decode:
-                assert len(last_logits) == num_of_users
+                assert len(prefill_tokens) == num_of_users
 
             logger.info(
                 f"Finished prefill for all users..."
@@ -786,7 +788,7 @@ class DeepseekGenerator(WarmupForwardMixin):
                     next_tokens = next_tokens_override
                 else:
                     # Prefill already produced one token per user.
-                    next_tokens = last_logits
+                    next_tokens = prefill_tokens
                 if teacher_forcing is not None:
                     # Record user-0 prediction for accuracy, but force teacher token for alignment.
                     forced0 = teacher_forcing.collect_predicted_tokens(int(next_tokens[0].item()))
@@ -1008,7 +1010,9 @@ class DeepseekGenerator(WarmupForwardMixin):
         ttnn.deallocate(tt_tokens)
         return logits
 
-    def _slice_last_token_logits(self, logits: ttnn.Tensor, prompt_len: int) -> ttnn.Tensor:
+    def _slice_last_token_logits(
+        self, logits: ttnn.Tensor, prompt_len: int, *, expand_to_batch: bool = False
+    ) -> ttnn.Tensor:
         last_idx = max(prompt_len - 1, 0)
         shard_len = logits.shape[2]
         local_idx = last_idx % shard_len
@@ -1038,16 +1042,12 @@ class DeepseekGenerator(WarmupForwardMixin):
             )
             ttnn.deallocate(gathered)
 
-        return last_logits
+        if expand_to_batch and last_logits.shape[2] == 1 and self.batch_size_per_row > 1:
+            expanded = ttnn.repeat(last_logits, (1, 1, self.batch_size_per_row, 1))
+            ttnn.deallocate(last_logits)
+            last_logits = expanded
 
-    def _expand_prefill_logits(self, logits: ttnn.Tensor) -> ttnn.Tensor:
-        if logits.shape[2] == self.batch_size_per_row:
-            return logits
-        if logits.shape[2] == 1:
-            expanded = ttnn.repeat(logits, (1, 1, self.batch_size_per_row, 1))
-            ttnn.deallocate(logits)
-            return expanded
-        return logits
+        return last_logits
 
     def _capture_decode_trace(
         self,

--- a/models/demos/deepseek_v3/utils/config_dataclass.py
+++ b/models/demos/deepseek_v3/utils/config_dataclass.py
@@ -44,6 +44,17 @@ class SavedWeight:  # TODO: bring regular tensor saving back once Issue #26763 i
     memory_config: ttnn.MemoryConfig | None = None
 
 
+@dataclass
+class DeepseekSamplingArgs:
+    vocab_size: int
+    padded_vocab_size: int
+    max_top_k: int
+    max_batch_size: int
+    sampling_dp: int
+    cluster_shape: tuple[int, int]
+    sampling_all_gather_axis: int = 1
+
+
 ConfigDevice = ttnn.MeshDevice | MeshDeviceStub
 ConfigWeight = ttnn.Tensor | FromWeightConfig
 

--- a/models/demos/deepseek_v3/utils/config_helpers.py
+++ b/models/demos/deepseek_v3/utils/config_helpers.py
@@ -14,7 +14,7 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.demos.deepseek_v3.utils.config_dataclass import SavedWeight
+from models.demos.deepseek_v3.utils.config_dataclass import DeepseekSamplingArgs, SavedWeight
 from models.demos.deepseek_v3.utils.dequantize import dequantize_tensor
 from models.demos.deepseek_v3.utils.lazy_state_dict import LazyStateDict
 
@@ -23,6 +23,32 @@ NORM_CATEGORIES = {"attention_norm", "mlp_norm", "q_norm", "k_norm"}
 USERS_PER_ROW = 32
 SEQ_LEN_CHUNK_SIZE = 1024  # NOTE: should be 512 for blackhole (in case of future bring-up)
 TOPK_MIN_WIDTH = 64  # Minimum width of the topk input tensor
+MAX_TOP_K = 32
+
+
+def make_deepseek_sampling_args(
+    mesh_device,
+    vocab_size: int,
+    *,
+    max_top_k: int = MAX_TOP_K,
+    max_batch_size: int = USERS_PER_ROW,
+    sampling_all_gather_axis: int = 1,
+) -> DeepseekSamplingArgs:
+    cluster_shape = tuple(mesh_device.shape)
+    sampling_dp = int(cluster_shape[0])  # one sampling group per row
+    num_tp = int(cluster_shape[1])
+    per_device_vocab = int(math.ceil(vocab_size / num_tp))
+    padded_per_device_vocab = int(math.ceil(per_device_vocab / ttnn.TILE_SIZE) * ttnn.TILE_SIZE)
+    padded_vocab_size = padded_per_device_vocab * num_tp
+    return DeepseekSamplingArgs(
+        vocab_size=vocab_size,
+        padded_vocab_size=padded_vocab_size,
+        max_top_k=max_top_k,
+        max_batch_size=max_batch_size,
+        sampling_dp=sampling_dp,
+        cluster_shape=cluster_shape,
+        sampling_all_gather_axis=sampling_all_gather_axis,
+    )
 
 
 # Compute kernel configurations


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/35128

### What's changed

- Add on-device sampling support in DeepSeek demo + generator paths.
- Introduce DeepSeek sampling args/config helper.
- Add DeepSeek sampling tests (argmax + stochastic).
 - Initial results show about 65% increase in decode t/s/u (with 256 users total, 256 tokens generated per user), w/o trace mode
      "decode_t/s/u": 1.04 - sampling on device
      "decode_t/s/u": 0.63 - sampling on host

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=pprajapati/deepseek_device_sampling_prod)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:pprajapati/deepseek_device_sampling_prod)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pprajapati/deepseek_device_sampling_prod)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pprajapati/deepseek_device_sampling_prod)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pprajapati/deepseek_device_sampling_prod)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pprajapati/deepseek_device_sampling_prod)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pprajapati/deepseek_device_sampling_prod)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pprajapati/deepseek_device_sampling_prod)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pprajapati/deepseek_device_sampling_prod)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pprajapati/deepseek_device_sampling_prod)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pprajapati/deepseek_device_sampling_prod)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pprajapati/deepseek_device_sampling_prod)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
