### PR TITLE
[skip ci] Add GitHub Action to Notify Slack on Mentions and Comments

### DIFF
--- a/.github/workflows/codeowners-group-analysis.yaml
+++ b/.github/workflows/codeowners-group-analysis.yaml
@@ -2389,48 +2389,12 @@ jobs:
 
             PING_MESSAGE="$PING_MESSAGE, this PR **[""$PR_TITLE""](${{ github.server_url }}/${{ github.repository }}/pull/$PR_NUMBER)** by $PR_AUTHOR_FULL_NAME (@$PR_AUTHOR_LOGIN) needs your approval/review to merge this."
 
-            if [ "$PING_OWNERS" = "true" ]; then
-              # Create new ping comment
-              echo "Creating ping comment..."
-
-              # Create temporary file to avoid shell interpretation of JSON
-              TEMP_JSON_FILE=$(mktemp)
-              if jq -n --arg body "$PING_MESSAGE" '{"body": $body}' > "$TEMP_JSON_FILE"; then
-                echo "JSON file created successfully"
-              else
-                echo "Failed to create JSON file"
-                exit 1
-              fi
-              RESPONSE=$(curl -s -w "HTTPSTATUS:%{http_code};" -X POST \
-                -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
-                -H "Accept: application/vnd.github.v3+json" \
-                -H "Content-Type: application/json" \
-                --data-binary @"$TEMP_JSON_FILE" \
-                "$COMMENTS_API")
-              # Clean up temp file
-              rm -f "$TEMP_JSON_FILE"
-
-              # Extract HTTP status code
-              HTTP_STATUS=$(echo "$RESPONSE" | tr -d '\n' | sed -e 's/.*HTTPSTATUS://' | sed 's/;//')
-              RESPONSE_BODY=$(echo "$RESPONSE" | sed -e 's/HTTPSTATUS:.*//')
-
-              if [ "$HTTP_STATUS" = "201" ]; then
-                echo "✅ Ping comment created successfully for PR #$PR_NUMBER"
-                echo "📋 Pinged users: $SELECTED_OWNERS"
-              else
-                echo "❌ ERROR: Failed to create ping comment (HTTP $HTTP_STATUS)"
-                echo "Response body: $RESPONSE_BODY"
-                echo "Full response: $RESPONSE"
-                exit 1
-              fi
+            # Log the ping message (comment posting to PR is disabled)
+            echo "Ping message (comment posting disabled, Slack-only):"
+            if [ ${#PING_MESSAGE} -gt 2000 ]; then
+              echo "${PING_MESSAGE:0:2000}... (truncated)"
             else
-              # Just output the ping message to workflow logs (truncated for large messages)
-              echo "Ping message (not sent):"
-              if [ ${#PING_MESSAGE} -gt 2000 ]; then
-                echo "${PING_MESSAGE:0:2000}... (truncated)"
-              else
-                echo "$PING_MESSAGE"
-              fi
+              echo "$PING_MESSAGE"
             fi
           else
             echo "No pending owners to ping"

--- a/.github/workflows/notify-slack-on-mention.yaml
+++ b/.github/workflows/notify-slack-on-mention.yaml
@@ -1,0 +1,285 @@
+name: Notify Slack on Comment or Mention
+
+on:
+  issue_comment:
+    types: [created]
+  issues:
+    types: [opened, edited]
+  pull_request_target:
+    types: [opened, edited]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  notify-slack:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for @ mentions
+        id: check-mention
+        run: |
+          BODY=$(cat <<'EOF'
+          ${{ github.event.comment.body || github.event.issue.body || github.event.pull_request.body }}
+          EOF
+          )
+
+          if echo "$BODY" | grep -qP '@[a-zA-Z0-9][-a-zA-Z0-9]*'; then
+            echo "has_mention=true" >> "$GITHUB_OUTPUT"
+            MENTIONED=$(echo "$BODY" | grep -oP '@[a-zA-Z0-9][-a-zA-Z0-9]*' | sed 's/^@//' | sort -u | paste -sd ',' )
+            echo "mentioned=$MENTIONED" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_mention=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Fetch Slack users
+        if: steps.check-mention.outputs.has_mention == 'true'
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.CODEOWNERS_PING_BOT }}
+        run: |
+          echo "Fetching all Slack users..."
+          TEMP_USERS_FILE=$(mktemp)
+          echo "[]" > "$TEMP_USERS_FILE"
+          CURSOR=""
+          PAGE_COUNT=0
+
+          while true; do
+            if [ -n "$CURSOR" ]; then
+              API_URL="https://slack.com/api/users.list?limit=1000&cursor=$CURSOR"
+            else
+              API_URL="https://slack.com/api/users.list?limit=1000"
+            fi
+
+            USER_SEARCH_RESPONSE=$(curl -s -X GET \
+              -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+              -H "Content-Type: application/json" \
+              "$API_URL")
+
+            RESPONSE_FILE=$(mktemp)
+            echo "$USER_SEARCH_RESPONSE" > "$RESPONSE_FILE"
+
+            if [ "$(jq -r '.ok' "$RESPONSE_FILE")" = "true" ]; then
+              MERGE_FILE=$(mktemp)
+              jq -s '.[0] + .[1]' "$TEMP_USERS_FILE" <(jq '.members' "$RESPONSE_FILE") > "$MERGE_FILE"
+              mv "$MERGE_FILE" "$TEMP_USERS_FILE"
+              PAGE_COUNT=$((PAGE_COUNT + 1))
+
+              CURSOR=$(jq -r '.response_metadata.next_cursor // ""' "$RESPONSE_FILE")
+              rm -f "$RESPONSE_FILE"
+              if [ -z "$CURSOR" ] || [ "$CURSOR" = "null" ]; then
+                break
+              fi
+            else
+              ERROR_MSG=$(jq -r '.error // "Unknown error"' "$RESPONSE_FILE")
+              echo "Error: Failed to fetch Slack users: $ERROR_MSG"
+              rm -f "$RESPONSE_FILE"
+              break
+            fi
+          done
+
+          USER_COUNT=$(jq '. | length' "$TEMP_USERS_FILE")
+          echo "Fetched $USER_COUNT Slack users across $PAGE_COUNT pages"
+          mv "$TEMP_USERS_FILE" "${RUNNER_TEMP}/slack_users.json"
+
+      - name: Send notification to Slack
+        if: steps.check-mention.outputs.has_mention == 'true'
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.CODEOWNERS_PING_BOT }}
+          SLACK_CHANNEL_ID: "C0AJF4YF5QF"
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          EVENT_NAME="${{ github.event_name }}"
+          SENDER="${{ github.event.sender.login }}"
+          REPO="${{ github.repository }}"
+          MENTIONED_CSV="${{ steps.check-mention.outputs.mentioned }}"
+          SLACK_USERS_FILE="${RUNNER_TEMP}/slack_users.json"
+
+          find_slack_user_id() {
+            local full_name="$1"
+            local github_username="$2"
+            local USERS_FILE="$3"
+
+            case "$github_username" in
+              "mradosavljevicTT") echo "U0837MYG788"; return 0 ;;
+              "nsextonTT") echo "U08TVGQGGAE"; return 0 ;;
+              "ncvetkovicTT") echo "U07AUABTEP6"; return 0 ;;
+              "jvegaTT") echo "U07M7QZ0BQA"; return 0 ;;
+            esac
+
+            USER_ID=$(jq -r --arg name "$full_name" \
+              '.[] | select(.real_name == $name or .profile.real_name == $name) | .id' "$USERS_FILE" | head -n1)
+
+            if [ -z "$USER_ID" ] || [ "$USER_ID" = "null" ]; then
+              USER_ID=$(jq -r --arg name "$full_name" \
+                '.[] | select(.profile.display_name == $name) | .id' "$USERS_FILE" | head -n1)
+            fi
+
+            if [ -z "$USER_ID" ] || [ "$USER_ID" = "null" ]; then
+              USER_ID=$(jq -r --arg username "$github_username" \
+                '.[] | select(.name == $username or .profile.display_name == $username) | .id' "$USERS_FILE" | head -n1)
+            fi
+
+            if [ -z "$USER_ID" ] || [ "$USER_ID" = "null" ]; then
+              IFS=' ' read -ra NAME_WORDS <<< "$full_name"
+              for word in "${NAME_WORDS[@]}"; do
+                if [ ${#word} -ge 3 ]; then
+                  WORD_MATCHES=$(jq -r --arg word "$word" \
+                    '.[] | select(
+                      (.real_name // "" | ascii_downcase | contains($word | ascii_downcase)) or
+                      (.profile.real_name // "" | ascii_downcase | contains($word | ascii_downcase)) or
+                      (.profile.display_name // "" | ascii_downcase | contains($word | ascii_downcase))
+                    ) | .id + "|" + (.real_name // .profile.real_name // .name)' "$USERS_FILE")
+
+                  if [ -n "$WORD_MATCHES" ]; then
+                    MATCH_COUNT=$(echo "$WORD_MATCHES" | wc -l)
+                    if [ "$MATCH_COUNT" -eq 1 ]; then
+                      USER_ID=$(echo "$WORD_MATCHES" | cut -d'|' -f1)
+                      break
+                    fi
+                  fi
+                fi
+              done
+            fi
+
+            if [ -n "$USER_ID" ] && [ "$USER_ID" != "null" ]; then
+              echo "$USER_ID"
+            else
+              echo ""
+            fi
+          }
+
+          SLACK_MENTIONS=""
+          IFS=',' read -ra MENTIONED_ARRAY <<< "$MENTIONED_CSV"
+          for gh_user in "${MENTIONED_ARRAY[@]}"; do
+            gh_user=$(echo "$gh_user" | xargs)
+            [ -z "$gh_user" ] && continue
+
+            USER_DATA=$(curl -s -H "Authorization: Bearer $GH_TOKEN" \
+              "https://api.github.com/users/$gh_user" 2>/dev/null || echo "{}")
+            USER_NAME=$(echo "$USER_DATA" | jq -r '.name // empty' 2>/dev/null)
+            [ -z "$USER_NAME" ] || [ "$USER_NAME" = "null" ] && USER_NAME="$gh_user"
+
+            SLACK_ID=$(find_slack_user_id "$USER_NAME" "$gh_user" "$SLACK_USERS_FILE")
+
+            if [ -n "$SLACK_ID" ]; then
+              SLACK_MENTIONS="$SLACK_MENTIONS <@$SLACK_ID>"
+              echo "Resolved @$gh_user -> Slack <@$SLACK_ID>"
+            else
+              SLACK_MENTIONS="$SLACK_MENTIONS @$gh_user"
+              echo "Could not resolve @$gh_user to Slack, using GitHub username fallback"
+            fi
+          done
+          SLACK_MENTIONS=$(echo "$SLACK_MENTIONS" | xargs)
+
+          # Resolve author: fetch full name and Slack ID
+          SENDER_DATA=$(curl -s -H "Authorization: Bearer $GH_TOKEN" \
+            "https://api.github.com/users/$SENDER" 2>/dev/null || echo "{}")
+          SENDER_FULL_NAME=$(echo "$SENDER_DATA" | jq -r '.name // empty' 2>/dev/null)
+          [ -z "$SENDER_FULL_NAME" ] || [ "$SENDER_FULL_NAME" = "null" ] && SENDER_FULL_NAME="$SENDER"
+
+          AUTHOR_DISPLAY="$SENDER_FULL_NAME [$SENDER]"
+
+          NL=$'\n'
+
+          if [ "$EVENT_NAME" = "issue_comment" ]; then
+            COMMENT_BODY=$(cat <<'EOF'
+          ${{ github.event.comment.body }}
+          EOF
+          )
+            ISSUE_TITLE="${{ github.event.issue.title }}"
+            ISSUE_NUMBER="${{ github.event.issue.number }}"
+            COMMENT_URL="${{ github.event.comment.html_url }}"
+
+            if [ -n "${{ github.event.issue.pull_request }}" ]; then
+              CONTEXT_TYPE="PR"
+            else
+              CONTEXT_TYPE="Issue"
+            fi
+
+            HEADER=":speech_balloon: *New mention on ${CONTEXT_TYPE}* <${COMMENT_URL}|#${ISSUE_NUMBER} - ${ISSUE_TITLE}>"
+            BODY_TEXT="${COMMENT_BODY}"
+
+          elif [ "$EVENT_NAME" = "issues" ]; then
+            ACTION="${{ github.event.action }}"
+            ISSUE_TITLE="${{ github.event.issue.title }}"
+            ISSUE_NUMBER="${{ github.event.issue.number }}"
+            ISSUE_URL="${{ github.event.issue.html_url }}"
+            ISSUE_BODY=$(cat <<'EOF'
+          ${{ github.event.issue.body }}
+          EOF
+          )
+
+            if [ "$ACTION" = "opened" ]; then
+              HEADER=":memo: *New issue with mention* <${ISSUE_URL}|#${ISSUE_NUMBER} - ${ISSUE_TITLE}>"
+            else
+              HEADER=":pencil2: *Issue edited with mention* <${ISSUE_URL}|#${ISSUE_NUMBER} - ${ISSUE_TITLE}>"
+            fi
+            BODY_TEXT="${ISSUE_BODY}"
+
+          elif [ "$EVENT_NAME" = "pull_request_target" ]; then
+            ACTION="${{ github.event.action }}"
+            PR_TITLE="${{ github.event.pull_request.title }}"
+            PR_NUMBER="${{ github.event.pull_request.number }}"
+            PR_URL="${{ github.event.pull_request.html_url }}"
+            PR_BODY=$(cat <<'EOF'
+          ${{ github.event.pull_request.body }}
+          EOF
+          )
+
+            if [ "$ACTION" = "opened" ]; then
+              HEADER=":twisted_rightwards_arrows: *New PR with mention* <${PR_URL}|#${PR_NUMBER} - ${PR_TITLE}>"
+            else
+              HEADER=":pencil2: *PR edited with mention* <${PR_URL}|#${PR_NUMBER} - ${PR_TITLE}>"
+            fi
+            BODY_TEXT="${PR_BODY}"
+
+          elif [ "$EVENT_NAME" = "pull_request_review_comment" ]; then
+            COMMENT_BODY=$(cat <<'EOF'
+          ${{ github.event.comment.body }}
+          EOF
+          )
+            PR_TITLE="${{ github.event.pull_request.title }}"
+            PR_NUMBER="${{ github.event.pull_request.number }}"
+            COMMENT_URL="${{ github.event.comment.html_url }}"
+
+            HEADER=":speech_balloon: *New review comment with mention* on PR <${COMMENT_URL}|#${PR_NUMBER} - ${PR_TITLE}>"
+            BODY_TEXT="${COMMENT_BODY}"
+          fi
+
+          # Trim body text if too long
+          if [ ${#BODY_TEXT} -gt 2000 ]; then
+            BODY_TEXT="${BODY_TEXT:0:1990}... _(truncated)_"
+          fi
+
+          # Build the full message with real newlines
+          TEXT="${HEADER}${NL}*Author:* ${AUTHOR_DISPLAY}${NL}*Tagged:* ${SLACK_MENTIONS}${NL}${NL}${BODY_TEXT}"
+
+          # Write payload to a temp file to avoid ARG_MAX issues with curl -d
+          PAYLOAD_FILE=$(mktemp)
+          jq -n \
+            --arg channel "$SLACK_CHANNEL_ID" \
+            --arg text "$TEXT" \
+            '{
+              channel: $channel,
+              text: $text,
+              unfurl_links: false,
+              unfurl_media: false
+            }' > "$PAYLOAD_FILE"
+
+          SLACK_RESPONSE=$(curl -s --max-time 30 -X POST \
+            -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+            -H "Content-type: application/json" \
+            -d @"$PAYLOAD_FILE" \
+            "https://slack.com/api/chat.postMessage")
+          rm -f "$PAYLOAD_FILE"
+
+          if [ "$(echo "$SLACK_RESPONSE" | jq -r '.ok')" = "true" ]; then
+            echo "Slack notification sent successfully"
+          else
+            ERROR=$(echo "$SLACK_RESPONSE" | jq -r '.error // "unknown error"')
+            echo "::error::Failed to send Slack notification: $ERROR"
+            exit 1
+          fi

--- a/.github/workflows/notify-slack-on-mention.yaml
+++ b/.github/workflows/notify-slack-on-mention.yaml
@@ -22,14 +22,11 @@ jobs:
       - name: Check for @ mentions
         id: check-mention
         run: |
-          BODY=$(cat <<'EOF'
-          ${{ github.event.comment.body || github.event.issue.body || github.event.pull_request.body }}
-          EOF
-          )
+          BODY=$(jq -r '(.comment.body // .issue.body // .pull_request.body // "")' "$GITHUB_EVENT_PATH")
 
-          if echo "$BODY" | grep -qP '@[a-zA-Z0-9][-a-zA-Z0-9]*'; then
+          if echo "$BODY" | grep -qP '(?<![A-Za-z0-9_])@[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9]))*'; then
             echo "has_mention=true" >> "$GITHUB_OUTPUT"
-            MENTIONED=$(echo "$BODY" | grep -oP '@[a-zA-Z0-9][-a-zA-Z0-9]*' | sed 's/^@//' | sort -u | paste -sd ',' )
+            MENTIONED=$(echo "$BODY" | grep -oP '(?<![A-Za-z0-9_])@[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9]))*' | sed 's/^@//' | sort -u | paste -sd ',')
             echo "mentioned=$MENTIONED" >> "$GITHUB_OUTPUT"
           else
             echo "has_mention=false" >> "$GITHUB_OUTPUT"
@@ -92,7 +89,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           EVENT_NAME="${{ github.event_name }}"
-          SENDER="${{ github.event.sender.login }}"
+          SENDER=$(jq -r '.sender.login // ""' "$GITHUB_EVENT_PATH")
           REPO="${{ github.repository }}"
           MENTIONED_CSV="${{ steps.check-mention.outputs.mentioned }}"
           SLACK_USERS_FILE="${RUNNER_TEMP}/slack_users.json"
@@ -184,70 +181,62 @@ jobs:
 
           NL=$'\n'
 
-          if [ "$EVENT_NAME" = "issue_comment" ]; then
-            COMMENT_BODY=$(cat <<'EOF'
-          ${{ github.event.comment.body }}
-          EOF
-          )
-            ISSUE_TITLE="${{ github.event.issue.title }}"
-            ISSUE_NUMBER="${{ github.event.issue.number }}"
-            COMMENT_URL="${{ github.event.comment.html_url }}"
+          # Safely read event data via jq from GITHUB_EVENT_PATH
+          EVENT_JSON="$GITHUB_EVENT_PATH"
 
-            if [ -n "${{ github.event.issue.pull_request }}" ]; then
+          if [ "$EVENT_NAME" = "issue_comment" ]; then
+            BODY_TEXT=$(jq -r '.comment.body // ""' "$EVENT_JSON")
+            ISSUE_TITLE=$(jq -r '.issue.title // ""' "$EVENT_JSON")
+            ISSUE_NUMBER=$(jq -r '.issue.number // ""' "$EVENT_JSON")
+            COMMENT_URL=$(jq -r '.comment.html_url // ""' "$EVENT_JSON")
+            HAS_PR=$(jq -r '.issue.pull_request // empty' "$EVENT_JSON")
+
+            if [ -n "$HAS_PR" ]; then
               CONTEXT_TYPE="PR"
             else
               CONTEXT_TYPE="Issue"
             fi
 
             HEADER=":speech_balloon: *New mention on ${CONTEXT_TYPE}* <${COMMENT_URL}|#${ISSUE_NUMBER} - ${ISSUE_TITLE}>"
-            BODY_TEXT="${COMMENT_BODY}"
 
           elif [ "$EVENT_NAME" = "issues" ]; then
-            ACTION="${{ github.event.action }}"
-            ISSUE_TITLE="${{ github.event.issue.title }}"
-            ISSUE_NUMBER="${{ github.event.issue.number }}"
-            ISSUE_URL="${{ github.event.issue.html_url }}"
-            ISSUE_BODY=$(cat <<'EOF'
-          ${{ github.event.issue.body }}
-          EOF
-          )
+            ACTION=$(jq -r '.action // ""' "$EVENT_JSON")
+            BODY_TEXT=$(jq -r '.issue.body // ""' "$EVENT_JSON")
+            ISSUE_TITLE=$(jq -r '.issue.title // ""' "$EVENT_JSON")
+            ISSUE_NUMBER=$(jq -r '.issue.number // ""' "$EVENT_JSON")
+            ISSUE_URL=$(jq -r '.issue.html_url // ""' "$EVENT_JSON")
 
             if [ "$ACTION" = "opened" ]; then
               HEADER=":memo: *New issue with mention* <${ISSUE_URL}|#${ISSUE_NUMBER} - ${ISSUE_TITLE}>"
             else
               HEADER=":pencil2: *Issue edited with mention* <${ISSUE_URL}|#${ISSUE_NUMBER} - ${ISSUE_TITLE}>"
             fi
-            BODY_TEXT="${ISSUE_BODY}"
 
           elif [ "$EVENT_NAME" = "pull_request_target" ]; then
-            ACTION="${{ github.event.action }}"
-            PR_TITLE="${{ github.event.pull_request.title }}"
-            PR_NUMBER="${{ github.event.pull_request.number }}"
-            PR_URL="${{ github.event.pull_request.html_url }}"
-            PR_BODY=$(cat <<'EOF'
-          ${{ github.event.pull_request.body }}
-          EOF
-          )
+            ACTION=$(jq -r '.action // ""' "$EVENT_JSON")
+            BODY_TEXT=$(jq -r '.pull_request.body // ""' "$EVENT_JSON")
+            PR_TITLE=$(jq -r '.pull_request.title // ""' "$EVENT_JSON")
+            PR_NUMBER=$(jq -r '.pull_request.number // ""' "$EVENT_JSON")
+            PR_URL=$(jq -r '.pull_request.html_url // ""' "$EVENT_JSON")
 
             if [ "$ACTION" = "opened" ]; then
               HEADER=":twisted_rightwards_arrows: *New PR with mention* <${PR_URL}|#${PR_NUMBER} - ${PR_TITLE}>"
             else
               HEADER=":pencil2: *PR edited with mention* <${PR_URL}|#${PR_NUMBER} - ${PR_TITLE}>"
             fi
-            BODY_TEXT="${PR_BODY}"
 
           elif [ "$EVENT_NAME" = "pull_request_review_comment" ]; then
-            COMMENT_BODY=$(cat <<'EOF'
-          ${{ github.event.comment.body }}
-          EOF
-          )
-            PR_TITLE="${{ github.event.pull_request.title }}"
-            PR_NUMBER="${{ github.event.pull_request.number }}"
-            COMMENT_URL="${{ github.event.comment.html_url }}"
+            BODY_TEXT=$(jq -r '.comment.body // ""' "$EVENT_JSON")
+            PR_TITLE=$(jq -r '.pull_request.title // ""' "$EVENT_JSON")
+            PR_NUMBER=$(jq -r '.pull_request.number // ""' "$EVENT_JSON")
+            COMMENT_URL=$(jq -r '.comment.html_url // ""' "$EVENT_JSON")
 
             HEADER=":speech_balloon: *New review comment with mention* on PR <${COMMENT_URL}|#${PR_NUMBER} - ${PR_TITLE}>"
-            BODY_TEXT="${COMMENT_BODY}"
           fi
+
+          # Escape Slack special sequences in user-supplied body to prevent injection
+          BODY_TEXT=$(echo "$BODY_TEXT" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g')
+          BODY_TEXT=$(echo "$BODY_TEXT" | sed 's/<!here>/&lt;!here&gt;/g; s/<!channel>/&lt;!channel&gt;/g; s/<!everyone>/&lt;!everyone&gt;/g')
 
           # Trim body text if too long
           if [ ${#BODY_TEXT} -gt 2000 ]; then


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow that triggers notifications to a specified Slack channel when a user is mentioned in issue comments, issues, or pull requests. The workflow checks for mentions, fetches Slack user information, and sends a formatted notification including the mention details.

Key features include:
- Triggering on issue comments, issues, and pull request events.
- Fetching Slack users dynamically to resolve GitHub usernames to Slack IDs.
- Sending notifications with relevant context to the designated Slack channel.

This enhancement aims to improve team communication and responsiveness to mentions in GitHub discussions.


### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=Aswinmcw/notify_gh_tag)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:Aswinmcw/notify_gh_tag)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=Aswinmcw/notify_gh_tag)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:Aswinmcw/notify_gh_tag)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=Aswinmcw/notify_gh_tag)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:Aswinmcw/notify_gh_tag)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=Aswinmcw/notify_gh_tag)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:Aswinmcw/notify_gh_tag)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=Aswinmcw/notify_gh_tag)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:Aswinmcw/notify_gh_tag)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=Aswinmcw/notify_gh_tag)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:Aswinmcw/notify_gh_tag)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
