### PR TITLE
[Blaze DS] Consolidate prefill + decode into ModelPipeline.run_inference()

### DIFF
--- a/models/demos/deepseek_v3_b1/demo/cli.py
+++ b/models/demos/deepseek_v3_b1/demo/cli.py
@@ -142,30 +142,22 @@ def run_demo(
             moe_layer_id_override=moe_layer_id_override,
         )
 
-        # Run prefill + decode loop
         my_mesh_id = mesh_device.get_system_mesh_id()
         if my_mesh_id == 0:
-            # Prefill + decode pattern per model.py: prefill(prompt) -> sample y0; decode_step(y_t) -> sample y_{t+1}.
             tokenizer = load_tokenizer(tokenizer_name_or_path)
             prompt_ids = tokenizer.encode(prompt, add_special_tokens=True)
             logger.debug(f"Encoded prompt: {prompt_ids}")
             if not prompt_ids:
                 prompt_ids = [tokenizer.bos_token_id if tokenizer.bos_token_id is not None else 0]
 
-            # Prefill: send prompt tokens; discard outputs for i < S-1; use last output to sample y0.
-            next_token_id = model_pipeline.prefill_forward(prompt_ids)
-            generated = [next_token_id]
-            logger.info(
-                "Prefill done ({} prompt tokens); sampled y0: {}",
-                len(prompt_ids),
-                next_token_id,
+            generated = model_pipeline.run_inference(
+                prompt_token_ids=prompt_ids,
+                max_new_tokens=iterations,
+                on_token=lambda tid: logger.info("Generated token: {}", tid),
+                eos_token_id=tokenizer.eos_token_id,
             )
-            # Generation loop: feed y[t], get output, sample y[t+1].
-            for step in range(iterations - 1):
-                next_token_id = model_pipeline.decode_forward(next_token_id)
-                generated.append(next_token_id)
-                logger.info("Decode step {} output token: {}", step + 1, next_token_id)
             logger.info("Generated {} tokens total", len(generated))
+            logger.info("Output: {}", tokenizer.decode(generated, skip_special_tokens=True))
 
         model_pipeline.barrier()
     logger.info("Pod pipeline complete")

--- a/models/demos/deepseek_v3_b1/demo/cli.py
+++ b/models/demos/deepseek_v3_b1/demo/cli.py
@@ -157,6 +157,7 @@ def run_demo(
                 eos_token_id=tokenizer.eos_token_id,
                 return_generated_tokens=True,
             )
+            assert generated_tokens is not None
             generated_text = tokenizer.decode(generated_tokens, skip_special_tokens=True)
             logger.info("Output ({} tokens): {}", len(generated_tokens), generated_text)
 

--- a/models/demos/deepseek_v3_b1/demo/cli.py
+++ b/models/demos/deepseek_v3_b1/demo/cli.py
@@ -150,14 +150,15 @@ def run_demo(
             if not prompt_ids:
                 prompt_ids = [tokenizer.bos_token_id if tokenizer.bos_token_id is not None else 0]
 
-            generated = model_pipeline.run_inference(
+            logger.info("Running inference on prompt with {} tokens", len(prompt_ids))
+            generated_tokens = model_pipeline.run_inference(
                 prompt_token_ids=prompt_ids,
                 max_new_tokens=iterations,
-                on_token=lambda tid: logger.info("Generated token: {}", tid),
                 eos_token_id=tokenizer.eos_token_id,
+                return_generated_tokens=True,
             )
-            logger.info("Generated {} tokens total", len(generated))
-            logger.info("Output: {}", tokenizer.decode(generated, skip_special_tokens=True))
+            generated_text = tokenizer.decode(generated_tokens, skip_special_tokens=True)
+            logger.info("Output ({} tokens): {}", len(generated_tokens), generated_text)
 
         model_pipeline.barrier()
     logger.info("Pod pipeline complete")

--- a/models/demos/deepseek_v3_b1/demo/model_pipeline.py
+++ b/models/demos/deepseek_v3_b1/demo/model_pipeline.py
@@ -106,6 +106,25 @@ class ModelPipeline:
         next_token_id = int(ttnn.to_torch(output).to(torch.int32)[0, 0].item())
         return next_token_id
 
+    def run_inference(
+        self,
+        prompt_token_ids: list[int],
+        max_new_tokens: int,
+        on_token: Callable[[int], None],
+        eos_token_id: int | None = None,
+    ) -> None:
+        if self.pipeline.my_mesh_id != 0:
+            raise RuntimeError("run_inference() must only be called on mesh id 0")
+        next_token_id = self.prefill_forward(prompt_token_ids)
+        on_token(next_token_id)
+        for i in range(max_new_tokens):
+            if eos_token_id is not None and next_token_id == eos_token_id:
+                logger.debug("EOS token {} at decode step {}", eos_token_id, i)
+                break
+            next_token_id = self.decode_forward(next_token_id)
+            on_token(next_token_id)
+        logger.debug("Generation complete ({} tokens generated)", i + 1)
+
     def barrier(self) -> None:
         self.pipeline.barrier()
 

--- a/models/demos/deepseek_v3_b1/demo/model_pipeline.py
+++ b/models/demos/deepseek_v3_b1/demo/model_pipeline.py
@@ -124,7 +124,7 @@ class ModelPipeline:
         """
         if self.pipeline.my_mesh_id != 0:
             raise RuntimeError("run_inference() should only be called on mesh id 0")
-        assert max_new_tokens >= 2, f"max_new_tokens must be >= 2, got {max_new_tokens}"
+        assert max_new_tokens >= 1, f"max_new_tokens must be >= 1, got {max_new_tokens}"
 
         # Prefill: send prompt tokens; discard outputs for i < S-1; use last output to sample y0.
         next_token_id = self.prefill_forward(prompt_token_ids)
@@ -134,18 +134,20 @@ class ModelPipeline:
             generated_tokens = [next_token_id]
 
         # Generation loop: feed y[t], get output, sample y[t+1].
+        num_decode_steps = 0
         for i in range(max_new_tokens - 1):
             if eos_token_id is not None and next_token_id == eos_token_id:
                 logger.debug("EOS token {} at decode step {}", eos_token_id, i)
                 break
             next_token_id = self.decode_forward(next_token_id)
+            num_decode_steps += 1
             if on_token is not None:
                 on_token(next_token_id)
             if return_generated_tokens:
                 generated_tokens.append(next_token_id)
             logger.debug("Decode step {} output token: {}", i + 1, next_token_id)
 
-        logger.debug("Generation complete ({} tokens generated)", i + 1)
+        logger.debug("Generation complete ({} tokens generated)", 1 + num_decode_steps)
         if return_generated_tokens:
             return generated_tokens
 

--- a/models/demos/deepseek_v3_b1/demo/model_pipeline.py
+++ b/models/demos/deepseek_v3_b1/demo/model_pipeline.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
 
 import torch
@@ -60,12 +61,14 @@ class ModelPipeline:
         if config.num_stages != num_procs:
             raise RuntimeError(f"Pipeline configuration has {config.num_stages} stages but {num_procs} processes")
 
-        logger.info(f"Building pipeline")
+        logger.info("Building pipeline")
         self.pipeline = config.build_pipeline(self.mesh_device)
 
-        logger.info(f"Setting up and running pipeline")
+        logger.info("Setting up and running pipeline")
         self.pipeline.setup_and_run()
 
+        self._page_size_datums = page_size_bytes(1) // TOKEN_ID_BYTES
+        self.model: DeepSeekV3 | None = None
         if self.pipeline.my_mesh_id == 0:
             # Initialize host-side model interface for mesh id 0 (first stage)
             self.model = DeepSeekV3(
@@ -80,13 +83,13 @@ class ModelPipeline:
         # Host-side model interface is only invoked on mesh id 0
         if self.pipeline.my_mesh_id != 0:
             raise RuntimeError("prefill_forward() should only be called on mesh id 0")
+        assert self.model is not None
         logger.debug(f"Prefilling with {len(tokens)} tokens...")
-        page_size_datums = page_size_bytes(1) // TOKEN_ID_BYTES
         prompt_token_tensors = [
             to_padded_input(
                 torch.tensor([[tid]], dtype=torch.int32),
                 batch_size=1,
-                page_size_datums=page_size_datums,
+                page_size_datums=self._page_size_datums,
             )
             for tid in tokens
         ]
@@ -100,6 +103,7 @@ class ModelPipeline:
         # Host-side model interface is only invoked on mesh id 0
         if self.pipeline.my_mesh_id != 0:
             raise RuntimeError("decode_forward() should only be called on mesh id 0")
+        assert self.model is not None
         output = self.model.decode_step(
             torch.tensor([[input_token]], dtype=torch.int32),
         )
@@ -110,21 +114,40 @@ class ModelPipeline:
         self,
         prompt_token_ids: list[int],
         max_new_tokens: int,
-        on_token: Callable[[int], None],
+        on_token: Callable[[int], None] | None = None,
         eos_token_id: int | None = None,
-    ) -> None:
+        return_generated_tokens: bool = False,
+    ) -> list[int] | None:
+        """Run full inference: prefill the prompt then decode until EOS or max_new_tokens.
+        Calls on_token(token_id) for each generated token (including the first
+        one sampled after prefill). Optionally returns the list of all generated token IDs.
+        """
         if self.pipeline.my_mesh_id != 0:
-            raise RuntimeError("run_inference() must only be called on mesh id 0")
+            raise RuntimeError("run_inference() should only be called on mesh id 0")
+        assert max_new_tokens >= 2, f"max_new_tokens must be >= 2, got {max_new_tokens}"
+
+        # Prefill: send prompt tokens; discard outputs for i < S-1; use last output to sample y0.
         next_token_id = self.prefill_forward(prompt_token_ids)
-        on_token(next_token_id)
+        if on_token is not None:
+            on_token(next_token_id)
+        if return_generated_tokens:
+            generated_tokens = [next_token_id]
+
+        # Generation loop: feed y[t], get output, sample y[t+1].
         for i in range(max_new_tokens - 1):
             if eos_token_id is not None and next_token_id == eos_token_id:
                 logger.debug("EOS token {} at decode step {}", eos_token_id, i)
                 break
             next_token_id = self.decode_forward(next_token_id)
-            logger.debug("Decoded token {} at decode step {}", next_token_id, i)
-            on_token(next_token_id)
+            if on_token is not None:
+                on_token(next_token_id)
+            if return_generated_tokens:
+                generated_tokens.append(next_token_id)
+            logger.debug("Decode step {} output token: {}", i + 1, next_token_id)
+
         logger.debug("Generation complete ({} tokens generated)", i + 1)
+        if return_generated_tokens:
+            return generated_tokens
 
     def barrier(self) -> None:
         self.pipeline.barrier()

--- a/models/demos/deepseek_v3_b1/demo/model_pipeline.py
+++ b/models/demos/deepseek_v3_b1/demo/model_pipeline.py
@@ -124,7 +124,7 @@ class ModelPipeline:
             next_token_id = self.decode_forward(next_token_id)
             logger.debug("Decoded token {} at decode step {}", next_token_id, i)
             on_token(next_token_id)
-        logger.debug("Generation complete ({} tokens generated)", max_new_tokens)
+        logger.debug("Generation complete ({} tokens generated)", i + 1)
 
     def barrier(self) -> None:
         self.pipeline.barrier()

--- a/models/demos/deepseek_v3_b1/demo/model_pipeline.py
+++ b/models/demos/deepseek_v3_b1/demo/model_pipeline.py
@@ -117,13 +117,14 @@ class ModelPipeline:
             raise RuntimeError("run_inference() must only be called on mesh id 0")
         next_token_id = self.prefill_forward(prompt_token_ids)
         on_token(next_token_id)
-        for i in range(max_new_tokens):
+        for i in range(max_new_tokens - 1):
             if eos_token_id is not None and next_token_id == eos_token_id:
                 logger.debug("EOS token {} at decode step {}", eos_token_id, i)
                 break
             next_token_id = self.decode_forward(next_token_id)
+            logger.debug("Decoded token {} at decode step {}", next_token_id, i)
             on_token(next_token_id)
-        logger.debug("Generation complete ({} tokens generated)", i + 1)
+        logger.debug("Generation complete ({} tokens generated)", max_new_tokens)
 
     def barrier(self) -> None:
         self.pipeline.barrier()


### PR DESCRIPTION
### Ticket
N/A

### Problem description
N/A

### What's changed
- Added run_inference() method that encapsulates the full inference loop (prefill followed by autoregressive decoding with EOS-based early stopping)
- Updated cli.py to call run_inference instead of prefill and decode separately

Tested with single-glx pipeline via cmd:

```
TT_METAL_SLOW_DISPATCH_MODE=1 tt-run --rank-binding bh_4x2_multi_mesh_rank_binding.yaml  python -m models.demos.deepseek_v3_b1.demo.cli --cache-path /mnt/models/deepseek-ai/cache-mar3-2/ --max-new-tokens 1024 --weights synthetic --dense-layer-id-override 0 --moe-layer-id-override 3
```