### PR TITLE
Replaces bit cast by union trick with std::bit_cast/std::memcpy

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_batch_norm.cpp
@@ -35,10 +35,10 @@ void kernel_main() {
     uint32_t start_c = start_remaining / HtWt;
     uint32_t start_t = start_remaining % HtWt;
 
-    float eps_f;
-    std::memcpy(&eps_f, &eps, sizeof(float));  // Alternative for std::bit_cast
     cb_reserve_back(cb_id_eps, onetile);
 #ifdef FILL_WITH_VALUE_FLOAT
+    float eps_f = 0;
+    std::memcpy(&eps_f, &eps, sizeof(float));  // Alternative for std::bit_cast
     FILL_WITH_VALUE_FLOAT(cb_id_eps, eps_f);
 #endif
 #ifdef FILL_WITH_VALUE

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_batch_norm.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
+#include <cstring>
 
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
@@ -34,14 +35,11 @@ void kernel_main() {
     uint32_t start_c = start_remaining / HtWt;
     uint32_t start_t = start_remaining % HtWt;
 
-    union {
-        float f;
-        uint32_t u;
-    } scalar;
-    scalar.u = eps;
+    float eps_f;
+    std::memcpy(&eps_f, &eps, sizeof(float));  // Alternative for std::bit_cast
     cb_reserve_back(cb_id_eps, onetile);
 #ifdef FILL_WITH_VALUE_FLOAT
-    FILL_WITH_VALUE_FLOAT(cb_id_eps, scalar.f);
+    FILL_WITH_VALUE_FLOAT(cb_id_eps, eps_f);
 #endif
 #ifdef FILL_WITH_VALUE
     FILL_WITH_VALUE(cb_id_eps, eps);

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_running_statistics.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_running_statistics.cpp
@@ -41,16 +41,16 @@ void kernel_main() {
     uint32_t next_channel_shift = c_stride - HtWt;
     uint32_t next_batch_shift = n_stride - c_stride * C;
 
-    uint32_t one_u;
-    float momentum_f;
+    uint32_t one_u = 0;
     const float one_f = 1.0f;
     std::memcpy(&one_u, &one_f, sizeof(uint32_t));  // Alternative for std::bit_cast
-    std::memcpy(&momentum_f, &momentum, sizeof(float));
     fill_cb_with_value(cb_id_one, one_u);
 
     // momentum
     cb_reserve_back(cb_id_momentum, onetile);
 #ifdef FILL_WITH_VALUE_FLOAT
+    float momentum_f = 0;
+    std::memcpy(&momentum_f, &momentum, sizeof(float));  // Alternative for std::bit_cast
     FILL_WITH_VALUE_FLOAT(cb_id_momentum, momentum_f);
 #endif
 #ifdef FILL_WITH_VALUE

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_running_statistics.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_running_statistics.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
+#include <cstring>
 
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
@@ -40,18 +41,17 @@ void kernel_main() {
     uint32_t next_channel_shift = c_stride - HtWt;
     uint32_t next_batch_shift = n_stride - c_stride * C;
 
-    union {
-        float f;
-        uint32_t u;
-    } scalar_one, scalar_momentum;
-    scalar_one.f = 1.0f;
-    fill_cb_with_value(cb_id_one, scalar_one.u);
+    uint32_t one_u;
+    float momentum_f;
+    const float one_f = 1.0f;
+    std::memcpy(&one_u, &one_f, sizeof(uint32_t));  // Alternative for std::bit_cast
+    std::memcpy(&momentum_f, &momentum, sizeof(float));
+    fill_cb_with_value(cb_id_one, one_u);
 
     // momentum
-    scalar_momentum.u = momentum;
     cb_reserve_back(cb_id_momentum, onetile);
 #ifdef FILL_WITH_VALUE_FLOAT
-    FILL_WITH_VALUE_FLOAT(cb_id_momentum, scalar_momentum.f);
+    FILL_WITH_VALUE_FLOAT(cb_id_momentum, momentum_f);
 #endif
 #ifdef FILL_WITH_VALUE
     FILL_WITH_VALUE(cb_id_momentum, momentum);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
@@ -721,7 +721,7 @@ GroupNormMcastProgramFactory::cached_program_t GroupNormMcastProgramFactory::cre
     float cinv = 1.0f / std::sqrt(num_cores_per_batch * num_cores_per_group);
     bfloat16 bfloat_cinv_value = bfloat16::truncate(cinv);
     uint32_t packed_cinv_value = pack_two_bfloat16_into_uint32({bfloat_cinv_value, bfloat_cinv_value});
-    uint32_t e_u = std::bit_cast<uint32_t>(eps);
+    uint32_t eps_u = std::bit_cast<uint32_t>(eps);
 
     for (size_t i = 0; i < mcast_groups.size(); ++i) {
         auto group = mcast_groups[i];
@@ -853,7 +853,7 @@ GroupNormMcastProgramFactory::cached_program_t GroupNormMcastProgramFactory::cre
         std::vector<uint32_t> writer_mcast_sender_args;
         writer_mcast_sender_args.push_back(packed_cinv_value);
         writer_mcast_sender_args.push_back(packed_winv_value_group_1);
-        writer_mcast_sender_args.push_back(e_u);
+        writer_mcast_sender_args.push_back(eps_u);
         writer_mcast_sender_args.push_back(out_dram_addr);
         writer_mcast_sender_args.push_back(gamma_dram_addr);
         writer_mcast_sender_args.push_back(beta_dram_addr);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
@@ -5,6 +5,7 @@
 #include "groupnorm_mcast_program_factory.hpp"
 #include "groupnorm_program_utils.hpp"
 
+#include <bit>
 #include <string>
 #include <optional>
 
@@ -720,11 +721,7 @@ GroupNormMcastProgramFactory::cached_program_t GroupNormMcastProgramFactory::cre
     float cinv = 1.0f / std::sqrt(num_cores_per_batch * num_cores_per_group);
     bfloat16 bfloat_cinv_value = bfloat16::truncate(cinv);
     uint32_t packed_cinv_value = pack_two_bfloat16_into_uint32({bfloat_cinv_value, bfloat_cinv_value});
-    union {
-        float f;
-        uint32_t u;
-    } e{};
-    e.f = eps;
+    uint32_t e_u = std::bit_cast<uint32_t>(eps);
 
     for (size_t i = 0; i < mcast_groups.size(); ++i) {
         auto group = mcast_groups[i];
@@ -856,7 +853,7 @@ GroupNormMcastProgramFactory::cached_program_t GroupNormMcastProgramFactory::cre
         std::vector<uint32_t> writer_mcast_sender_args;
         writer_mcast_sender_args.push_back(packed_cinv_value);
         writer_mcast_sender_args.push_back(packed_winv_value_group_1);
-        writer_mcast_sender_args.push_back(e.u);
+        writer_mcast_sender_args.push_back(e_u);
         writer_mcast_sender_args.push_back(out_dram_addr);
         writer_mcast_sender_args.push_back(gamma_dram_addr);
         writer_mcast_sender_args.push_back(beta_dram_addr);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.cpp
@@ -932,7 +932,7 @@ GroupNormNoMcastProgramFactory::cached_program_t GroupNormNoMcastProgramFactory:
     float cinv = 1.0f / std::sqrt(num_cores_per_batch * num_cores_per_group);
     bfloat16 bfloat_cinv_value = bfloat16::truncate(cinv);
     uint32_t packed_cinv_value = pack_two_bfloat16_into_uint32({bfloat_cinv_value, bfloat_cinv_value});
-    uint32_t e_u = std::bit_cast<uint32_t>(eps);
+    uint32_t eps_u = std::bit_cast<uint32_t>(eps);
 
     for (size_t i = 0; i < mcast_groups.size(); ++i) {
         auto group = mcast_groups[i];
@@ -1070,7 +1070,7 @@ GroupNormNoMcastProgramFactory::cached_program_t GroupNormNoMcastProgramFactory:
         } else {
             writer_mcast_sender_args.push_back(packed_winv_value_group_2);
         }
-        writer_mcast_sender_args.push_back(e_u);
+        writer_mcast_sender_args.push_back(eps_u);
         writer_mcast_sender_args.push_back(out_dram_addr);
         writer_mcast_sender_args.push_back(gamma_dram_addr);
         writer_mcast_sender_args.push_back(beta_dram_addr);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.cpp
@@ -5,6 +5,7 @@
 #include "groupnorm_no_mcast_program_factory.hpp"
 #include "groupnorm_program_utils.hpp"
 
+#include <bit>
 #include <string>
 #include <optional>
 
@@ -931,11 +932,7 @@ GroupNormNoMcastProgramFactory::cached_program_t GroupNormNoMcastProgramFactory:
     float cinv = 1.0f / std::sqrt(num_cores_per_batch * num_cores_per_group);
     bfloat16 bfloat_cinv_value = bfloat16::truncate(cinv);
     uint32_t packed_cinv_value = pack_two_bfloat16_into_uint32({bfloat_cinv_value, bfloat_cinv_value});
-    union {
-        float f;
-        uint32_t u;
-    } e{};
-    e.f = eps;
+    uint32_t e_u = std::bit_cast<uint32_t>(eps);
 
     for (size_t i = 0; i < mcast_groups.size(); ++i) {
         auto group = mcast_groups[i];
@@ -1073,7 +1070,7 @@ GroupNormNoMcastProgramFactory::cached_program_t GroupNormNoMcastProgramFactory:
         } else {
             writer_mcast_sender_args.push_back(packed_winv_value_group_2);
         }
-        writer_mcast_sender_args.push_back(e.u);
+        writer_mcast_sender_args.push_back(e_u);
         writer_mcast_sender_args.push_back(out_dram_addr);
         writer_mcast_sender_args.push_back(gamma_dram_addr);
         writer_mcast_sender_args.push_back(beta_dram_addr);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
@@ -5,6 +5,7 @@
 #include "groupnorm_sharded_program_factory.hpp"
 #include "groupnorm_program_utils.hpp"
 
+#include <bit>
 #include <string>
 #include <optional>
 
@@ -867,11 +868,7 @@ GroupNormShardedProgramFactory::cached_program_t GroupNormShardedProgramFactory:
     float cinv = 1.0f / std::sqrt(num_cores_per_batch * num_cores_per_group);  // bcast-cores scaler
     bfloat16 bfloat_cinv_value = bfloat16::truncate(cinv);
     uint32_t packed_cinv_value = pack_two_bfloat16_into_uint32({bfloat_cinv_value, bfloat_cinv_value});
-    union {
-        float f;
-        uint32_t u;
-    } e{};
-    e.f = eps;
+    uint32_t e_u = std::bit_cast<uint32_t>(eps);
 
     log_debug(tt::LogOp, "num_rows_per_batch_per_core: {}", num_rows_per_batch_per_core);
     log_debug(tt::LogOp, "num_datum_row_per_group: {}", num_datum_row_per_group);
@@ -998,7 +995,7 @@ GroupNormShardedProgramFactory::cached_program_t GroupNormShardedProgramFactory:
         std::vector<uint32_t> writer_mcast_sender_args;
         writer_mcast_sender_args.push_back(packed_cinv_value);
         writer_mcast_sender_args.push_back(packed_winv_value);
-        writer_mcast_sender_args.push_back(e.u);
+        writer_mcast_sender_args.push_back(e_u);
         writer_mcast_sender_args.push_back(gamma_dram_addr);
         writer_mcast_sender_args.push_back(beta_dram_addr);
         writer_mcast_sender_args.push_back(input_mask_dram_addr);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
@@ -868,7 +868,7 @@ GroupNormShardedProgramFactory::cached_program_t GroupNormShardedProgramFactory:
     float cinv = 1.0f / std::sqrt(num_cores_per_batch * num_cores_per_group);  // bcast-cores scaler
     bfloat16 bfloat_cinv_value = bfloat16::truncate(cinv);
     uint32_t packed_cinv_value = pack_two_bfloat16_into_uint32({bfloat_cinv_value, bfloat_cinv_value});
-    uint32_t e_u = std::bit_cast<uint32_t>(eps);
+    uint32_t eps_u = std::bit_cast<uint32_t>(eps);
 
     log_debug(tt::LogOp, "num_rows_per_batch_per_core: {}", num_rows_per_batch_per_core);
     log_debug(tt::LogOp, "num_datum_row_per_group: {}", num_datum_row_per_group);
@@ -995,7 +995,7 @@ GroupNormShardedProgramFactory::cached_program_t GroupNormShardedProgramFactory:
         std::vector<uint32_t> writer_mcast_sender_args;
         writer_mcast_sender_args.push_back(packed_cinv_value);
         writer_mcast_sender_args.push_back(packed_winv_value);
-        writer_mcast_sender_args.push_back(e_u);
+        writer_mcast_sender_args.push_back(eps_u);
         writer_mcast_sender_args.push_back(gamma_dram_addr);
         writer_mcast_sender_args.push_back(beta_dram_addr);
         writer_mcast_sender_args.push_back(input_mask_dram_addr);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core_sharded.cpp
@@ -445,7 +445,7 @@ tt::tt_metal::ProgramDescriptor LayerNormShardedProgramFactory::create_descripto
     auto compile_time_args = CompileTimeArgs::build(ct_ctx);
 
     // Pack eps for later use
-    uint32_t e_u = std::bit_cast<uint32_t>(eps);
+    uint32_t eps_u = std::bit_cast<uint32_t>(eps);
 
     // Build runtime args using helper
     const auto& cores = corerange_to_cores(core_ranges.all_cores, core_ranges.all_cores.num_cores(), grid.row_wise);
@@ -481,7 +481,7 @@ tt::tt_metal::ProgramDescriptor LayerNormShardedProgramFactory::create_descripto
         .packed_cinv_value = pack_two_bfloat16_into_uint32({bfloat_cinv, bfloat_cinv}),
         .packed_cinv_value_one = pack_two_bfloat16_into_uint32({bfloat_cinv_one, bfloat_cinv_one}),
         .packed_winv_value = pack_two_bfloat16_into_uint32({bfloat_winv, bfloat_winv}),
-        .eps_u = e_u,
+        .eps_u = eps_u,
         .gamma_dram_addr = gamma_dram_addr,
         .beta_dram_addr = beta_dram_addr,
         .single_tile_size = single_tile_size,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core_sharded.cpp
@@ -445,11 +445,7 @@ tt::tt_metal::ProgramDescriptor LayerNormShardedProgramFactory::create_descripto
     auto compile_time_args = CompileTimeArgs::build(ct_ctx);
 
     // Pack eps for later use
-    union {
-        float f;
-        uint32_t u;
-    } e{};
-    e.f = eps;
+    uint32_t e_u = std::bit_cast<uint32_t>(eps);
 
     // Build runtime args using helper
     const auto& cores = corerange_to_cores(core_ranges.all_cores, core_ranges.all_cores.num_cores(), grid.row_wise);
@@ -485,7 +481,7 @@ tt::tt_metal::ProgramDescriptor LayerNormShardedProgramFactory::create_descripto
         .packed_cinv_value = pack_two_bfloat16_into_uint32({bfloat_cinv, bfloat_cinv}),
         .packed_cinv_value_one = pack_two_bfloat16_into_uint32({bfloat_cinv_one, bfloat_cinv_one}),
         .packed_winv_value = pack_two_bfloat16_into_uint32({bfloat_winv, bfloat_winv}),
-        .eps_u = e.u,
+        .eps_u = e_u,
         .gamma_dram_addr = gamma_dram_addr,
         .beta_dram_addr = beta_dram_addr,
         .single_tile_size = single_tile_size,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_pre_allgather_welford.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_pre_allgather_welford.cpp
@@ -10,6 +10,7 @@
  */
 
 #include <cstdint>
+#include <cstring>
 
 #define REDUCE_OP PoolType::SUM
 #define REDUCE_DIM ReduceDim::REDUCE_ROW
@@ -30,14 +31,9 @@ inline To _bit_cast_(const From& from) noexcept {
     static_assert(sizeof(To) == sizeof(From), "Types must have same size");
     static_assert(std::is_trivially_copyable_v<From>, "From must be trivially copyable");
     static_assert(std::is_trivially_copyable_v<To>, "To must be trivially copyable");
-
-    union {
-        From f;
-        To t;
-    } u;
-
-    u.f = from;
-    return u.t;
+    To to;
+    std::memcpy(&to, &from, sizeof(To));
+    return to;
 }
 void kernel_main() {
     uint32_t NCHt = get_arg_val<uint32_t>(0);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_program_factory.cpp
@@ -434,7 +434,7 @@ LayerNormPostAllGatherProgramFactory::cached_program_t LayerNormPostAllGatherPro
     float winv = 1.0f / (W * num_devices);  // bcast-w scaler
     auto bfloat_winv_value = bfloat16(winv);
     uint32_t packed_winv_value = pack_two_bfloat16_into_uint32({bfloat_winv_value, bfloat_winv_value});
-    uint32_t e_u = std::bit_cast<uint32_t>(operation_attributes.eps);  // epsilon
+    uint32_t eps = std::bit_cast<uint32_t>(operation_attributes.eps);  // epsilon
 
     // Set runtime arguments based on kernel layout type
     if (use_2d_kernel) {
@@ -461,7 +461,7 @@ LayerNormPostAllGatherProgramFactory::cached_program_t LayerNormPostAllGatherPro
                      tile_offset,
                      stats_offset,
                      packed_winv_value,
-                     e_u,
+                     eps,
                      gamma_dram_addr,
                      beta_dram_addr,
                      stats_addr,
@@ -498,7 +498,7 @@ LayerNormPostAllGatherProgramFactory::cached_program_t LayerNormPostAllGatherPro
                  tile_offset,
                  stats_offset,
                  packed_winv_value,
-                 e_u,
+                 eps,
                  gamma_dram_addr,
                  beta_dram_addr,
                  stats_addr,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_program_factory.cpp
@@ -11,6 +11,7 @@
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/math.hpp"
 
+#include <bit>
 #include <optional>
 #include <string>
 #include <variant>
@@ -433,11 +434,7 @@ LayerNormPostAllGatherProgramFactory::cached_program_t LayerNormPostAllGatherPro
     float winv = 1.0f / (W * num_devices);  // bcast-w scaler
     auto bfloat_winv_value = bfloat16(winv);
     uint32_t packed_winv_value = pack_two_bfloat16_into_uint32({bfloat_winv_value, bfloat_winv_value});
-    union {
-        float f;
-        uint32_t u;
-    } e{};
-    e.f = operation_attributes.eps;  // epsilon
+    uint32_t e_u = std::bit_cast<uint32_t>(operation_attributes.eps);  // epsilon
 
     // Set runtime arguments based on kernel layout type
     if (use_2d_kernel) {
@@ -464,7 +461,7 @@ LayerNormPostAllGatherProgramFactory::cached_program_t LayerNormPostAllGatherPro
                      tile_offset,
                      stats_offset,
                      packed_winv_value,
-                     e.u,
+                     e_u,
                      gamma_dram_addr,
                      beta_dram_addr,
                      stats_addr,
@@ -501,7 +498,7 @@ LayerNormPostAllGatherProgramFactory::cached_program_t LayerNormPostAllGatherPro
                  tile_offset,
                  stats_offset,
                  packed_winv_value,
-                 e.u,
+                 e_u,
                  gamma_dram_addr,
                  beta_dram_addr,
                  stats_addr,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_welford_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_welford_program_factory.cpp
@@ -11,6 +11,7 @@
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/math.hpp"
 
+#include <bit>
 #include <optional>
 #include <string>
 #include <variant>
@@ -451,11 +452,7 @@ LayerNormPostAllGatherWelfordProgramFactory::cached_program_t LayerNormPostAllGa
     float winv = 1.0f / (W * num_devices);  // bcast-w scaler
     auto bfloat_winv_value = bfloat16(winv);
     uint32_t packed_winv_value = pack_two_bfloat16_into_uint32({bfloat_winv_value, bfloat_winv_value});
-    union {
-        float f;
-        uint32_t u;
-    } e{};
-    e.f = operation_attributes.eps;  // epsilon
+    uint32_t e_u = std::bit_cast<uint32_t>(operation_attributes.eps);  // epsilon
 
     // Set runtime arguments based on kernel layout type
     if (use_2d_kernel) {
@@ -482,7 +479,7 @@ LayerNormPostAllGatherWelfordProgramFactory::cached_program_t LayerNormPostAllGa
                      tile_offset,
                      stats_offset,
                      packed_winv_value,
-                     e.u,
+                     e_u,
                      gamma_dram_addr,
                      beta_dram_addr,
                      stats_addr,
@@ -519,7 +516,7 @@ LayerNormPostAllGatherWelfordProgramFactory::cached_program_t LayerNormPostAllGa
                  tile_offset,
                  stats_offset,
                  packed_winv_value,
-                 e.u,
+                 e_u,
                  gamma_dram_addr,
                  beta_dram_addr,
                  stats_addr,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_welford_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_welford_program_factory.cpp
@@ -452,7 +452,7 @@ LayerNormPostAllGatherWelfordProgramFactory::cached_program_t LayerNormPostAllGa
     float winv = 1.0f / (W * num_devices);  // bcast-w scaler
     auto bfloat_winv_value = bfloat16(winv);
     uint32_t packed_winv_value = pack_two_bfloat16_into_uint32({bfloat_winv_value, bfloat_winv_value});
-    uint32_t e_u = std::bit_cast<uint32_t>(operation_attributes.eps);  // epsilon
+    uint32_t eps = std::bit_cast<uint32_t>(operation_attributes.eps);  // epsilon
 
     // Set runtime arguments based on kernel layout type
     if (use_2d_kernel) {
@@ -479,7 +479,7 @@ LayerNormPostAllGatherWelfordProgramFactory::cached_program_t LayerNormPostAllGa
                      tile_offset,
                      stats_offset,
                      packed_winv_value,
-                     e_u,
+                     eps,
                      gamma_dram_addr,
                      beta_dram_addr,
                      stats_addr,
@@ -516,7 +516,7 @@ LayerNormPostAllGatherWelfordProgramFactory::cached_program_t LayerNormPostAllGa
                  tile_offset,
                  stats_offset,
                  packed_winv_value,
-                 e_u,
+                 eps,
                  gamma_dram_addr,
                  beta_dram_addr,
                  stats_addr,

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_attention_optimized.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_attention_optimized.cpp
@@ -283,7 +283,8 @@ SoftmaxProgramFactoryAttentionOptimized::cached_program_t SoftmaxProgramFactoryA
     uint32_t out_addr = out0_buffer->address();
 
     uint32_t curr_row = 0;
-    uint32_t s_u = std::bit_cast<uint32_t>(attributes.scale.value_or(1.0f));  // scale for fused scale-mask-softmax
+    uint32_t scale_value =
+        std::bit_cast<uint32_t>(attributes.scale.value_or(1.0f));  // scale for fused scale-mask-softmax
     for (uint32_t i = 0; i < grid_size.x * grid_size.y; ++i) {
         CoreCoord core = {i % grid_size.x, i / grid_size.x};
         if (i >= num_cores) {
@@ -321,7 +322,7 @@ SoftmaxProgramFactoryAttentionOptimized::cached_program_t SoftmaxProgramFactoryA
                 core,
                 {src_addr,
                  block_size,
-                 s_u,
+                 scale_value,
                  num_tile_rows_per_core,
                  tile_offset,
                  Wt,
@@ -340,7 +341,7 @@ SoftmaxProgramFactoryAttentionOptimized::cached_program_t SoftmaxProgramFactoryA
                 core,
                 {src_addr,
                  block_size,
-                 s_u,
+                 scale_value,
                  num_tile_rows_per_core,
                  tile_offset,
                  Wt,
@@ -501,7 +502,8 @@ void SoftmaxProgramFactoryAttentionOptimized::override_runtime_arguments(
     }
 
     uint32_t curr_row = 0;
-    uint32_t s_u = std::bit_cast<uint32_t>(attributes.scale.value_or(1.0f));  // scale for fused scale-mask-softmax
+    uint32_t scale_value =
+        std::bit_cast<uint32_t>(attributes.scale.value_or(1.0f));  // scale for fused scale-mask-softmax
 
     auto& cached_reader_args =
         GetRuntimeArgs(cached_program.program, cached_program.shared_variables.reader_kernels_id);
@@ -545,7 +547,7 @@ void SoftmaxProgramFactoryAttentionOptimized::override_runtime_arguments(
 
         reader_kernel_args[0] = src_buffer_address;
         reader_kernel_args[1] = block_size;
-        reader_kernel_args[2] = s_u;
+        reader_kernel_args[2] = scale_value;
         reader_kernel_args[3] = num_tile_rows_per_core;
         reader_kernel_args[4] = tile_offset;
         reader_kernel_args[5] = Wt;

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_attention_optimized.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_attention_optimized.cpp
@@ -12,6 +12,7 @@
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/work_split.hpp>
 
+#include <bit>
 #include <utility>
 
 namespace ttnn::prim {
@@ -282,11 +283,7 @@ SoftmaxProgramFactoryAttentionOptimized::cached_program_t SoftmaxProgramFactoryA
     uint32_t out_addr = out0_buffer->address();
 
     uint32_t curr_row = 0;
-    union {
-        float f;
-        uint32_t u;
-    } s{};
-    s.f = attributes.scale.value_or(1.0f);  // scale for fused scale-mask-softmax
+    uint32_t s_u = std::bit_cast<uint32_t>(attributes.scale.value_or(1.0f));  // scale for fused scale-mask-softmax
     for (uint32_t i = 0; i < grid_size.x * grid_size.y; ++i) {
         CoreCoord core = {i % grid_size.x, i / grid_size.x};
         if (i >= num_cores) {
@@ -324,7 +321,7 @@ SoftmaxProgramFactoryAttentionOptimized::cached_program_t SoftmaxProgramFactoryA
                 core,
                 {src_addr,
                  block_size,
-                 s.u,
+                 s_u,
                  num_tile_rows_per_core,
                  tile_offset,
                  Wt,
@@ -343,7 +340,7 @@ SoftmaxProgramFactoryAttentionOptimized::cached_program_t SoftmaxProgramFactoryA
                 core,
                 {src_addr,
                  block_size,
-                 s.u,
+                 s_u,
                  num_tile_rows_per_core,
                  tile_offset,
                  Wt,
@@ -504,11 +501,7 @@ void SoftmaxProgramFactoryAttentionOptimized::override_runtime_arguments(
     }
 
     uint32_t curr_row = 0;
-    union {
-        float f;
-        uint32_t u;
-    } s{};
-    s.f = attributes.scale.value_or(1.0f);  // scale for fused scale-mask-softmax
+    uint32_t s_u = std::bit_cast<uint32_t>(attributes.scale.value_or(1.0f));  // scale for fused scale-mask-softmax
 
     auto& cached_reader_args =
         GetRuntimeArgs(cached_program.program, cached_program.shared_variables.reader_kernels_id);
@@ -552,7 +545,7 @@ void SoftmaxProgramFactoryAttentionOptimized::override_runtime_arguments(
 
         reader_kernel_args[0] = src_buffer_address;
         reader_kernel_args[1] = block_size;
-        reader_kernel_args[2] = s.u;
+        reader_kernel_args[2] = s_u;
         reader_kernel_args[3] = num_tile_rows_per_core;
         reader_kernel_args[4] = tile_offset;
         reader_kernel_args[5] = Wt;

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_attention_optimized_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_attention_optimized_sharded.cpp
@@ -269,7 +269,8 @@ SoftmaxShardedProgramFactoryAttentionOptimized::cached_program_t SoftmaxShardedP
 
     // Runtime Args
     uint32_t mask_addr = tensor_args.mask.has_value() ? tensor_args.mask->buffer()->address() : 0;
-    uint32_t s_u = std::bit_cast<uint32_t>(attributes.scale.value_or(1.0f));  // scale for fused scale-mask-softmax
+    uint32_t scale_value =
+        std::bit_cast<uint32_t>(attributes.scale.value_or(1.0f));  // scale for fused scale-mask-softmax
     uint32_t mask_start_tile_id = 0;
 
     uint32_t num_tiles_in_attn_mask = 0;
@@ -289,7 +290,7 @@ SoftmaxShardedProgramFactoryAttentionOptimized::cached_program_t SoftmaxShardedP
                 // reader args
                 std::vector<uint32_t> reader_args;
                 reader_args.push_back(0x3f803f80);
-                reader_args.push_back(s_u);
+                reader_args.push_back(scale_value);
                 reader_args.push_back(mask_addr);
                 reader_args.push_back(mask_start_tile_id);
                 if (attributes.is_scale_causal_mask_hw_dims_softmax) {
@@ -329,7 +330,7 @@ SoftmaxShardedProgramFactoryAttentionOptimized::cached_program_t SoftmaxShardedP
                 // reader args
                 std::vector<uint32_t> reader_args;
                 reader_args.push_back(0x3f803f80);
-                reader_args.push_back(s_u);
+                reader_args.push_back(scale_value);
                 reader_args.push_back(mask_addr);
                 reader_args.push_back(mask_start_tile_id);
                 if (attributes.is_scale_causal_mask_hw_dims_softmax) {

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_attention_optimized_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_attention_optimized_sharded.cpp
@@ -11,6 +11,7 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 
+#include <bit>
 #include <utility>
 
 namespace ttnn::prim {
@@ -268,11 +269,7 @@ SoftmaxShardedProgramFactoryAttentionOptimized::cached_program_t SoftmaxShardedP
 
     // Runtime Args
     uint32_t mask_addr = tensor_args.mask.has_value() ? tensor_args.mask->buffer()->address() : 0;
-    union {
-        float f;
-        uint32_t u;
-    } s{};
-    s.f = attributes.scale.value_or(1.0f);  // scale for fused scale-mask-softmax
+    uint32_t s_u = std::bit_cast<uint32_t>(attributes.scale.value_or(1.0f));  // scale for fused scale-mask-softmax
     uint32_t mask_start_tile_id = 0;
 
     uint32_t num_tiles_in_attn_mask = 0;
@@ -292,7 +289,7 @@ SoftmaxShardedProgramFactoryAttentionOptimized::cached_program_t SoftmaxShardedP
                 // reader args
                 std::vector<uint32_t> reader_args;
                 reader_args.push_back(0x3f803f80);
-                reader_args.push_back(s.u);
+                reader_args.push_back(s_u);
                 reader_args.push_back(mask_addr);
                 reader_args.push_back(mask_start_tile_id);
                 if (attributes.is_scale_causal_mask_hw_dims_softmax) {
@@ -332,7 +329,7 @@ SoftmaxShardedProgramFactoryAttentionOptimized::cached_program_t SoftmaxShardedP
                 // reader args
                 std::vector<uint32_t> reader_args;
                 reader_args.push_back(0x3f803f80);
-                reader_args.push_back(s.u);
+                reader_args.push_back(s_u);
                 reader_args.push_back(mask_addr);
                 reader_args.push_back(mask_start_tile_id);
                 if (attributes.is_scale_causal_mask_hw_dims_softmax) {

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/dataflow/accumulation_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/dataflow/accumulation_reader.cpp
@@ -36,11 +36,9 @@ void kernel_main() {
     cb_start_obj.reserve_back(ONE_TILE);
     uint32_t data_start_addr = cb_start_obj.get_write_ptr();
 
-    int32_t acc_start_val_u;
     const float one_f = 1.0f;
-    std::memcpy(&acc_start_val_u, &one_f, sizeof(int32_t));
-
-    const int32_t ACC_START_VALUE_F32{acc_start_val_u};
+    int32_t ACC_START_VALUE_F32 = 0;
+    std::memcpy(&ACC_START_VALUE_F32, &one_f, sizeof(int32_t));
     constexpr int32_t ACC_START_VALUE_F16{0x3F80};
     // TODO(jbbieniekTT): the below ones will work only if applied LLK is preconfigured appropriately for those (issue
     // #21108)

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/dataflow/accumulation_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/dataflow/accumulation_reader.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <cstring>
+
 #include "api/dataflow/dataflow_api.h"
 #include "experimental/noc.h"
 #include "experimental/circular_buffer.h"
@@ -9,15 +11,6 @@
 #include "experimental/tensor.h"
 
 #include "../accumulation_common.hpp"
-
-namespace {
-
-constexpr union {
-    float f;
-    int32_t u;
-} caster{.f = 1.0f};
-
-}  // namespace
 
 void kernel_main() {
     uint32_t input_base_addr = get_arg_val<uint32_t>(0);
@@ -43,7 +36,11 @@ void kernel_main() {
     cb_start_obj.reserve_back(ONE_TILE);
     uint32_t data_start_addr = cb_start_obj.get_write_ptr();
 
-    const int32_t ACC_START_VALUE_F32{caster.u};
+    int32_t acc_start_val_u;
+    const float one_f = 1.0f;
+    std::memcpy(&acc_start_val_u, &one_f, sizeof(int32_t));
+
+    const int32_t ACC_START_VALUE_F32{acc_start_val_u};
     constexpr int32_t ACC_START_VALUE_F16{0x3F80};
     // TODO(jbbieniekTT): the below ones will work only if applied LLK is preconfigured appropriately for those (issue
     // #21108)

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/kernels/dataflow/reader_prod_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/kernels/dataflow/reader_prod_nc.cpp
@@ -25,10 +25,10 @@ void kernel_main() {
     constexpr uint32_t onetile = 1;
     constexpr uint32_t cb_id_in1 = tt::CBIndex::c_1;
 
-    uint32_t scaler_u;
+    uint32_t scaler = 0;
     const float one_f = 1.0f;
-    std::memcpy(&scaler_u, &one_f, sizeof(uint32_t));  // Alternative to std::bit_cast
-    fill_cb_with_value(cb_id_in1, scaler_u);
+    std::memcpy(&scaler, &one_f, sizeof(uint32_t));  // Alternative to std::bit_cast
+    fill_cb_with_value(cb_id_in1, scaler);
 
     experimental::Noc noc;
     experimental::CircularBuffer cb_in0(tt::CBIndex::c_0);

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/kernels/dataflow/reader_prod_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/kernels/dataflow/reader_prod_nc.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
+#include <cstring>
 
 #include "api/dataflow/dataflow_api.h"
 #include "experimental/noc.h"
@@ -24,12 +25,10 @@ void kernel_main() {
     constexpr uint32_t onetile = 1;
     constexpr uint32_t cb_id_in1 = tt::CBIndex::c_1;
 
-    union {
-        float f;
-        uint32_t u;
-    } scaler;
-    scaler.f = 1.0f;
-    fill_cb_with_value(cb_id_in1, scaler.u);
+    uint32_t scaler_u;
+    const float one_f = 1.0f;
+    std::memcpy(&scaler_u, &one_f, sizeof(uint32_t));  // Alternative to std::bit_cast
+    fill_cb_with_value(cb_id_in1, scaler_u);
 
     experimental::Noc noc;
     experimental::CircularBuffer cb_in0(tt::CBIndex::c_0);

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/compute/sampling.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/compute/sampling.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
+#include <cstring>
 #define REDUCE_OP (PoolType::SUM)
 #define REDUCE_DIM (ReduceDim::REDUCE_ROW)
 #include "api/compute/compute_kernel_api.h"
@@ -26,11 +27,9 @@ using namespace ckernel;
 void generate_rand_tile(const uint32_t cb_id, const uint32_t seed) {
     init_sfpu(cb_id, cb_id);
 
-    union f2u {
-        float f;
-        uint32_t u;
-    } rand_scale;
-    rand_scale.f = 1;
+    uint32_t rand_scale_u;
+    const float one_f = 1.0f;
+    std::memcpy(&rand_scale_u, &one_f, sizeof(uint32_t));  // Alternative to std::bit_cast
     uint32_t rand_from = 0;
 
     if (seed != 0) {
@@ -39,7 +38,7 @@ void generate_rand_tile(const uint32_t cb_id, const uint32_t seed) {
     cb_reserve_back(cb_id, 1);
 
     tile_regs_acquire();
-    rand_tile(0, rand_from, rand_scale.u);
+    rand_tile(0, rand_from, rand_scale_u);
     tile_regs_commit();
 
     tile_regs_wait();

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/compute/sampling.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/compute/sampling.cpp
@@ -27,9 +27,9 @@ using namespace ckernel;
 void generate_rand_tile(const uint32_t cb_id, const uint32_t seed) {
     init_sfpu(cb_id, cb_id);
 
-    uint32_t rand_scale_u;
+    uint32_t rand_scale = 0;
     const float one_f = 1.0f;
-    std::memcpy(&rand_scale_u, &one_f, sizeof(uint32_t));  // Alternative to std::bit_cast
+    std::memcpy(&rand_scale, &one_f, sizeof(uint32_t));  // Alternative to std::bit_cast
     uint32_t rand_from = 0;
 
     if (seed != 0) {
@@ -38,7 +38,7 @@ void generate_rand_tile(const uint32_t cb_id, const uint32_t seed) {
     cb_reserve_back(cb_id, 1);
 
     tile_regs_acquire();
-    rand_tile(0, rand_from, rand_scale_u);
+    rand_tile(0, rand_from, rand_scale);
     tile_regs_commit();
 
     tile_regs_wait();


### PR DESCRIPTION
### Ticket

Code uses union trick to do a bitcast between float and uint32_t, but this is UB #33816 

### Problem description
Some kernel related files uses `std::union` to bit cast between `float` and `uint32_t`. This is UB in C++ and needs to be updated to either use `std::bit_cast` when supported or use `std::memcpy`.

##### Directories to include:
```
ttnn/cpp/ttnn/operations/matmul/
ttnn/cpp/ttnn/operations/reduction/
ttnn/cpp/ttnn/operations/normalization/
```

### What's changed
Host side code is now updated to use `std::bit_cast`.
Where ever C++20 is not supported falling back to `std::memcpy`.


### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ign/navaneeth_bit_cast_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ign/navaneeth_bit_cast_fix)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ign/navaneeth_bit_cast_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ign/navaneeth_bit_cast_fix)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/navaneeth_bit_cast_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/navaneeth_bit_cast_fix)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/navaneeth_bit_cast_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/navaneeth_bit_cast_fix)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/navaneeth_bit_cast_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/navaneeth_bit_cast_fix)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/navaneeth_bit_cast_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/navaneeth_bit_cast_fix)
  - [x] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
