### PR TITLE
deepseek_v3: plumb recalculate-weights through demo path

### DIFF
--- a/models/demos/deepseek_v3/demo/demo.py
+++ b/models/demos/deepseek_v3/demo/demo.py
@@ -150,7 +150,9 @@ def create_parser() -> argparse.ArgumentParser:
         help="Enable on-device sampling (default: host-side sampling).",
     )
     p.add_argument(
+        "--force-recalculate",
         "--recalculate-weights",
+        dest="force_recalculate",
         action="store_true",
         default=False,
         help="Force regeneration of cached TTNN weight files and config.",
@@ -480,7 +482,7 @@ def main() -> None:
         prefill_max_tokens=args.prefill_max_tokens,
         profile_decode=args.profile_decode,
         sample_on_device=args.sample_on_device,
-        force_recalculate=bool(args.recalculate_weights),
+        force_recalculate=bool(args.force_recalculate),
     )
 
     # If prompts were loaded from a JSON file, save output to JSON file instead of printing

--- a/models/demos/deepseek_v3/demo/demo.py
+++ b/models/demos/deepseek_v3/demo/demo.py
@@ -149,6 +149,12 @@ def create_parser() -> argparse.ArgumentParser:
         default=False,
         help="Enable on-device sampling (default: host-side sampling).",
     )
+    p.add_argument(
+        "--recalculate-weights",
+        action="store_true",
+        default=False,
+        help="Force regeneration of cached TTNN weight files and config.",
+    )
     return p
 
 
@@ -267,6 +273,7 @@ def run_demo(
     prefill_max_tokens: int = None,
     profile_decode: bool = False,
     sample_on_device: bool = False,
+    force_recalculate: bool = False,
 ) -> dict:
     """Programmatic entrypoint for the DeepSeek-V3 demo.
 
@@ -366,6 +373,7 @@ def run_demo(
                 enable_mem_profile=enable_mem_profile,
                 signpost=signpost,
                 prefill_max_tokens=prefill_max_tokens,
+                force_recalculate=force_recalculate,
                 profile_decode=profile_decode,
                 sample_on_device=sample_on_device,
             )
@@ -472,6 +480,7 @@ def main() -> None:
         prefill_max_tokens=args.prefill_max_tokens,
         profile_decode=args.profile_decode,
         sample_on_device=args.sample_on_device,
+        force_recalculate=bool(args.recalculate_weights),
     )
 
     # If prompts were loaded from a JSON file, save output to JSON file instead of printing

--- a/models/demos/deepseek_v3/demo/demo.py
+++ b/models/demos/deepseek_v3/demo/demo.py
@@ -379,6 +379,8 @@ def run_demo(
                 profile_decode=profile_decode,
                 sample_on_device=sample_on_device,
             )
+        else:
+            raise ValueError(f"Unsupported generator: {generator}")
         # Build the prompt list
         pre_tokenized_prompts = None
         if random_weights:

--- a/models/demos/deepseek_v3/demo/test_demo.py
+++ b/models/demos/deepseek_v3/demo/test_demo.py
@@ -92,6 +92,7 @@ def test_demo(
     enable_trace: bool,
     artifact_name: str,
     profile_decode: bool,
+    force_recalculate_weight_config: bool,
 ):
     """
     DeepSeek v3 demo test with prompts loaded from JSON file.
@@ -119,6 +120,7 @@ def test_demo(
         max_new_tokens=max_new_tokens,
         repeat_batches=repeat_batches,
         profile_decode=profile_decode,
+        force_recalculate=force_recalculate_weight_config,
         signpost=True,
     )
     if override_num_layers is not None:

--- a/models/demos/deepseek_v3/demo/test_demo_teacher_forced.py
+++ b/models/demos/deepseek_v3/demo/test_demo_teacher_forced.py
@@ -35,7 +35,9 @@ REFERENCE_FILE = Path(__file__).with_name("gpqa_diamond_racemic.refpt")
 @pytest.mark.timeout(3600)
 @pytest.mark.parametrize("reference_file", [REFERENCE_FILE])
 @pytest.mark.parametrize("max_new_tokens", [128, 2048, 8192], ids=["128", "2048", "8192"])
-def test_demo_teacher_forcing_accuracy(reference_file: Path, max_new_tokens: int, is_ci_env: bool):
+def test_demo_teacher_forcing_accuracy(
+    reference_file: Path, max_new_tokens: int, is_ci_env: bool, force_recalculate_weight_config: bool
+):
     """
     Test DeepSeek v3 demo with teacher forcing to verify accuracy.
 
@@ -161,6 +163,7 @@ def test_demo_teacher_forcing_accuracy(reference_file: Path, max_new_tokens: int
         reference_file=REFERENCE_FILE,
         tf_prompt_len=tf_prompt_len,
         enable_trace=True,
+        force_recalculate=force_recalculate_weight_config,
     )
 
     # Check results

--- a/models/demos/deepseek_v3/demo/test_demo_teacher_forced.py
+++ b/models/demos/deepseek_v3/demo/test_demo_teacher_forced.py
@@ -64,9 +64,9 @@ def test_demo_teacher_forcing_accuracy(
     Expected accuracy: ~100% if TT model matches HF model behavior.
     """
 
-    if not REFERENCE_FILE.exists():
+    if not reference_file.exists():
         pytest.fail(
-            f"Reference file not found at {REFERENCE_FILE}. "
+            f"Reference file not found at {reference_file}. "
             "Generate it first by running "
             "`python generate_teacher_forced_file.py`."
         )
@@ -74,7 +74,7 @@ def test_demo_teacher_forcing_accuracy(
     if is_ci_env and max_new_tokens != 128:
         pytest.skip("CI runs only the 128-token teacher forcing test to keep runtime manageable.")
 
-    payload = torch.load(REFERENCE_FILE, weights_only=False)
+    payload = torch.load(reference_file, weights_only=False)
     assert "reference_tokens" in payload, "Reference file missing 'reference_tokens'"
     assert "prompt_tokens" in payload, "Reference file missing 'prompt_tokens'"
     assert "generated_tokens" in payload, "Reference file missing 'generated_tokens'"
@@ -138,16 +138,16 @@ def test_demo_teacher_forcing_accuracy(
     if max_new_tokens > saved_max_new_tokens:
         pytest.fail(
             f"Requested max_new_tokens={max_new_tokens} exceeds reference file max_new_tokens={saved_max_new_tokens} "
-            f"({REFERENCE_FILE}). Regenerate the reference with a larger max_new_tokens."
+            f"({reference_file}). Regenerate the reference with a larger max_new_tokens."
         )
     if max_new_tokens > available_gen_tokens:
         pytest.fail(
             f"Requested max_new_tokens={max_new_tokens} exceeds available generated tokens={available_gen_tokens} "
-            f"in {REFERENCE_FILE}. Regenerate the reference with a larger max_new_tokens."
+            f"in {reference_file}. Regenerate the reference with a larger max_new_tokens."
         )
 
     logger.info("=== Phase 2: Run teacher forcing ===")
-    logger.info("Loaded reference from: {}", REFERENCE_FILE)
+    logger.info("Loaded reference from: {}", reference_file)
     logger.info("Total reference tokens: {}, prompt length: {}", total_ref_tokens, tf_prompt_len)
     logger.info("Using max_new_tokens={}", max_new_tokens)
 
@@ -160,7 +160,7 @@ def test_demo_teacher_forcing_accuracy(
         max_new_tokens=max_new_tokens,
         repeat_batches=1,
         token_accuracy=True,
-        reference_file=REFERENCE_FILE,
+        reference_file=reference_file,
         tf_prompt_len=tf_prompt_len,
         enable_trace=True,
         force_recalculate=force_recalculate_weight_config,


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
The DeepSeek V3 demo path exposed a `force_recalculate` parameter on `run_demo(...)`, but the value was not forwarded into the generator. As a result, `pytest ... --recalculate-weights` had no effect for `models/demos/deepseek_v3/demo/test_demo.py`, even though the shared DeepSeek test fixture already supported it.

### What's changed
- add demo CLI flag `--recalculate-weights`
- forward `force_recalculate` from `run_demo(...)` into `DeepseekGenerator`
- wire `models/demos/deepseek_v3/demo/test_demo.py` to the shared `force_recalculate_weight_config` fixture
- wire `models/demos/deepseek_v3/demo/test_demo_teacher_forced.py` the same way for consistency

### Checklist

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=yieldthought/deepseek-v3-recalculate-demo-weights)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:yieldthought/deepseek-v3-recalculate-demo-weights)
- [ ] [![(Galaxy) demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml/badge.svg?branch=yieldthought/deepseek-v3-recalculate-demo-weights)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml?query=branch:yieldthought/deepseek-v3-recalculate-demo-weights)
- [ ] [![(Galaxy) DeepSeek tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml/badge.svg?branch=yieldthought/deepseek-v3-recalculate-demo-weights)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml?query=branch:yieldthought/deepseek-v3-recalculate-demo-weights)
- [x] New/Existing tests provide coverage for changes

### Validation
- `python -m py_compile models/demos/deepseek_v3/demo/demo.py models/demos/deepseek_v3/demo/test_demo.py models/demos/deepseek_v3/demo/test_demo_teacher_forced.py`
- `MESH_DEVICE=T3K pytest --collect-only -q models/demos/deepseek_v3/demo/test_demo.py --recalculate-weights`
