### PR TITLE
TTT: Support deferred device read for async scheduling

### DIFF
--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -53,6 +53,7 @@ jobs:
               "arch": "arch-wormhole_b0",
               "mesh-device": "T3K",
               "override-tt-config": "{\"sample_on_device_mode\": \"decode_only\", \"fabric_config\": \"FABRIC_1D\", \"l1_small_size\": 4096}",
+              "additional-benchmark-args": "--async-scheduling",
               "tt-llama-text-ver": "tt_transformers",
               "multimodal": true,
               "co-owner-1-id": "U08E1JCDVNX",
@@ -85,7 +86,7 @@ jobs:
               "multimodal": false,
               "tt-llama-text-ver": "tt_transformers",
               "override-tt-config": "{\"sample_on_device_mode\": \"all\"}",
-              "additional-server-args": "--max_num_seqs 1",
+              "additional-server-args": "--max_num_seqs 1 --async-scheduling",
               "structured-output": true,
               "additional-structured-output-args": "--backend openai-chat --endpoint /v1/chat/completions --dataset json",
               "co-owner-1-id": "U08TJ70UFRT",
@@ -118,6 +119,7 @@ jobs:
               "mesh-device": "T3K",
               "tt-llama-text-ver": "tt_transformers",
               "override-tt-config": "{\"fabric_config\": \"FABRIC_1D\", \"sample_on_device_mode\": \"all\"}",
+              "additional-server-args": "--async-scheduling",
               "structured-output": true,
               "sampling-tests": true,
               "multimodal": false,
@@ -135,7 +137,7 @@ jobs:
               "tt-llama-text-ver": "tt_transformers",
               "override-tt-config": "{\"fabric_config\": \"FABRIC_1D\"}",
               "multimodal": false,
-              "additional-benchmark-args": "--random-prefix-len 128",
+              "additional-benchmark-args": "--random-prefix-len 128 --async-scheduling",
               "co-owner-1-id": "U08E1JCDVNX",
               "co-owner-2-id": "U08CEGF78ET"
             },
@@ -163,6 +165,7 @@ jobs:
               "arch": "arch-blackhole",
               "mesh-device": "P150x4",
               "tt-llama-text-ver": "tt_transformers",
+              "additional-server-args": "--async-scheduling",
               "structured-output": true,
               "multimodal": false,
               "owner_id": "U08GELBB1AP"
@@ -256,7 +259,7 @@ jobs:
               "override-tt-config": "{\"fabric_config\": \"FABRIC_1D\", \"trace_region_size\": 28467200}",
               "structured-output": true,
               "multimodal": true,
-              "additional-server-args": "--max_model_len 2048",
+              "additional-server-args": "--max_model_len 2048 --async-scheduling",
               "co-owner-1-id": "U07RY6B5FLJ"
             },
             {
@@ -271,6 +274,7 @@ jobs:
               "override-tt-config": "{\"fabric_config\": \"FABRIC_1D\", \"trace_region_size\": 28467200}",
               "structured-output": true,
               "multimodal": true,
+              "additional-server-args": "--async-scheduling",
               "co-owner-1-id": "U08H31YMN4Q"
             },
             {
@@ -296,7 +300,7 @@ jobs:
               "arch": "arch-wormhole_b0",
               "mesh-device": "N300",
               "override-tt-config": "{\"register_test_models\": true, \"sample_on_device_mode\": \"all\"}",
-              "additional-server-args": "--tokenizer meta-llama/Llama-3.1-8B-Instruct --input-queue-batching-delay 0",
+              "additional-server-args": "--tokenizer meta-llama/Llama-3.1-8B-Instruct --input-queue-batching-delay 0 --async-scheduling",
               "additional-benchmark-args": "--tokenizer meta-llama/Llama-3.1-8B-Instruct",
               "multimodal": false,
               "owner_id": "U08CEGF78ET"

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -275,7 +275,6 @@ jobs:
               "override-tt-config": "{\"fabric_config\": \"FABRIC_1D\", \"trace_region_size\": 28467200}",
               "structured-output": true,
               "multimodal": true,
-              "additional-server-args": "--async-scheduling",
               "co-owner-1-id": "U08H31YMN4Q"
             },
             {

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -53,7 +53,7 @@ jobs:
               "arch": "arch-wormhole_b0",
               "mesh-device": "T3K",
               "override-tt-config": "{\"sample_on_device_mode\": \"decode_only\", \"fabric_config\": \"FABRIC_1D\", \"l1_small_size\": 4096}",
-              "additional-benchmark-args": "--async-scheduling",
+              "additional-server-args": "--async-scheduling",
               "tt-llama-text-ver": "tt_transformers",
               "multimodal": true,
               "co-owner-1-id": "U08E1JCDVNX",
@@ -137,7 +137,8 @@ jobs:
               "tt-llama-text-ver": "tt_transformers",
               "override-tt-config": "{\"fabric_config\": \"FABRIC_1D\"}",
               "multimodal": false,
-              "additional-benchmark-args": "--random-prefix-len 128 --async-scheduling",
+              "additional-benchmark-args": "--random-prefix-len 128",
+              "additional-server-args": "--async-scheduling",
               "co-owner-1-id": "U08E1JCDVNX",
               "co-owner-2-id": "U08CEGF78ET"
             },

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -1572,6 +1572,7 @@ class Generator(WarmupForwardMixin):
         Used by the async decode path: the caller submitted a trace with
         read_from_device=False and now needs to collect the results.
         """
+        # Sync should not be needed, as the reading itself will force a sync.
         # for i in range(self.data_parallel):
         #     ttnn.synchronize_device(self.model[i].mesh_device)
         to_host = self.read_decode_output(tt_decode_output)

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -1565,6 +1565,18 @@ class Generator(WarmupForwardMixin):
                 raise ValueError(f"Invalid type of tt_out: {type(tt_out[i])}")
         return (torch.cat(logits, 0), torch.cat(log_probs, 0))
 
+    # Note: This function is called by vLLM
+    def sync_and_read_decode_output(self, tt_decode_output, is_tokens=False):
+        """Synchronize all devices, read decode output to host, and process.
+
+        Used by the async decode path: the caller submitted a trace with
+        read_from_device=False and now needs to collect the results.
+        """
+        # for i in range(self.data_parallel):
+        #     ttnn.synchronize_device(self.model[i].mesh_device)
+        to_host = self.read_decode_output(tt_decode_output)
+        return self.process_decode_output_host(to_host, is_tokens=is_tokens)
+
     def _decode_forward_no_trace(
         self,
         position_id,

--- a/models/tt_transformers/tt/generator_vllm.py
+++ b/models/tt_transformers/tt/generator_vllm.py
@@ -140,6 +140,7 @@ class MllamaForConditionalGeneration(Generator, SupportsMultiModal):
     # Note: Mllama doesn't support prefix caching (it's V0 only)
     model_capabilities = {
         "supports_prefix_caching": False,
+        "supports_async_decode": True,
     }
 
     def __init__(self, *args, **kwargs):
@@ -236,6 +237,7 @@ class LlamaForCausalLM(Generator):
     # Class-level capabilities
     model_capabilities = {
         "supports_prefix_caching": True,
+        "supports_async_decode": True,
     }
 
     def __init__(self, *args, **kwargs):
@@ -297,6 +299,7 @@ class QwenForCausalLM(Generator):
     # Class-level capabilities
     model_capabilities = {
         "supports_prefix_caching": True,
+        "supports_async_decode": True,
     }
 
     def __init__(self, *args, **kwargs):
@@ -345,6 +348,7 @@ class MistralForCausalLM(Generator):
     # Class-level capabilities
     model_capabilities = {
         "supports_prefix_caching": True,
+        "supports_async_decode": True,
     }
 
     def __init__(self, *args, **kwargs):
@@ -398,6 +402,7 @@ class Gemma3ForConditionalGeneration(Generator, SupportsMultiModal):
     # Class-level capabilities
     model_capabilities = {
         "supports_prefix_caching": False,
+        "supports_async_decode": True,
     }
 
     def __init__(self, *args, **kwargs):
@@ -460,6 +465,7 @@ class GptOssForCausalLM(Generator):
     # Class-level capabilities
     model_capabilities = {
         "supports_prefix_caching": False,  # Sliding window => no prefix caching
+        "supports_async_decode": True,
     }
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
### Ticket
TBD

### Problem description
Reduce ITL by overlapping CPU and device work. Specifically, VLLM's AsyncScheduler is able to run on step N+1 even before step N has finished. And while N+1 is running on device, AsyncScheduler is able to accept the results from step N.

### What's changed

This PR supports that by adding `sync_and_read_decode_output()` for deferred reading. Main work and more details in VLLM PR https://github.com/tenstorrent/vllm/pull/337 .

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=viktorpus/async-sched)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:viktorpus/async-sched)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=viktorpus/async-sched)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:viktorpus/async-sched)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=viktorpus/async-sched)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:viktorpus/async-sched)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=viktorpus/async-sched)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:viktorpus/async-sched)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=viktorpus/async-sched)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:viktorpus/async-sched)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=viktorpus/async-sched)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:viktorpus/async-sched)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
