### PR TITLE
Fix streaming SDPA crash when q_num_subblocks == 1

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -309,7 +309,7 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     // Streaming v2 requires q_num_subblocks > 1 (Sq_chunk_t > subblock_h) because the Phase 2
     // pipeline assumes at least one q_subblock iteration for correct softmax drain + SALAD overlap.
     const bool use_streaming_compute = !fp32_dest_acc_en && qk_out_subblock_h <= 2 &&
-                                       Sk_chunk_t % (8 / qk_out_subblock_h) == 0 && Sq_chunk_t / qk_out_subblock_h > 1;
+                                       Sk_chunk_t % (8 / qk_out_subblock_h) == 0 && qk_in0_num_subblocks > 1;
     log_debug(tt::LogOp, "use_streaming_compute: {}", use_streaming_compute);
 
     // log all values

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -306,8 +306,10 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
 
     // Streaming compute v2: eliminates row buffers via cb_push_back_hold_wr_ptr.
     // Ring joint has no causal/mask/sink/sliding/chunked flags — gating is simpler.
-    const bool use_streaming_compute =
-        !fp32_dest_acc_en && qk_out_subblock_h <= 2 && Sk_chunk_t % (8 / qk_out_subblock_h) == 0;
+    // Streaming v2 requires q_num_subblocks > 1 (Sq_chunk_t > subblock_h) because the Phase 2
+    // pipeline assumes at least one q_subblock iteration for correct softmax drain + SALAD overlap.
+    const bool use_streaming_compute = !fp32_dest_acc_en && qk_out_subblock_h <= 2 &&
+                                       Sk_chunk_t % (8 / qk_out_subblock_h) == 0 && Sq_chunk_t / qk_out_subblock_h > 1;
     log_debug(tt::LogOp, "use_streaming_compute: {}", use_streaming_compute);
 
     // log all values

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -93,6 +93,11 @@ bool can_use_streaming_compute(
     if (qk_out_subblock_h > 2 || Sk_chunk_t % (8 / qk_out_subblock_h) != 0) {
         return false;
     }
+    // Streaming v2 requires q_num_subblocks > 1 (Sq_chunk_t > subblock_h) because the Phase 2
+    // pipeline assumes at least one q_subblock iteration for correct softmax drain + SALAD overlap.
+    if (Sq_chunk_t / qk_out_subblock_h <= 1) {
+        return false;
+    }
     // Non-tile-aligned K padding requires boundary tiles the streaming mask path doesn't support.
     const bool streaming_mask_unsupported = (padded_Sk != Sk) && (Sk % TILE_HEIGHT != 0 || Sq_chunk_t == 1);
     return !streaming_mask_unsupported;


### PR DESCRIPTION
## Summary
- Streaming compute v2 (`compute_streaming.hpp`) produces completely wrong results (PCC ~0.27) when `Sq_chunk_t / subblock_h == 1`, i.e., the Phase 2 `q_subblock 1..N-1` loop runs zero times
- Affects both single-chip SDPA and ring joint SDPA with `q_chunk_size=64` and typical head dims (d=64/128), e.g., SD3.5 with q64/k128
- Regression introduced by `08a5992cf1` ("Implement streaming SDPA compute for standard and ring joint SDPA", PR #38838), merged Mar 4
- Fix: gate streaming compute to require `q_num_subblocks > 1`, falling back to legacy compute for single-subblock configs
- Applied to both `sdpa_program_factory.cpp` and `ring_joint_sdpa_program_factory.cpp`

## Test plan
- [ ] [![T3000 e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=pjosipovic/fix-streaming-sdpa-single-subblock)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:pjosipovic/fix-streaming-sdpa-single-subblock)
- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=pjosipovic/fix-streaming-sdpa-single-subblock)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:pjosipovic/fix-streaming-sdpa-single-subblock)
- [x] `test_ring_joint_sdpa_program_cache[sd35-bf16]` — was PCC 0.27, now PCC 0.9997
- [x] `test_ring_joint_sdpa_program_cache[sd35-bf8_b]` — PASSED
- [x] `test_ring_joint_sdpa_program_cache[sd35-bf4_b]` — PASSED
- [x] Single-chip SDPA q64/k128 — was PCC 0.58, now PCC 0.9996

🤖 Generated with [Claude Code](https://claude.com/claude-code)