### PR TITLE
ring causal attention

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -111,8 +111,8 @@ models:
     wh_n300: 30
     wh_galaxy: 30
   unit:
-    wh_llmbox: 305
-    wh_llmbox_perf: 90
+    wh_llmbox: 315
+    wh_llmbox_perf: 60
     wh_n150: 30
     wh_n300: 30
     wh_galaxy: 30

--- a/.github/workflows/t3000-unit-tests.yaml
+++ b/.github/workflows/t3000-unit-tests.yaml
@@ -28,6 +28,7 @@ on:
           - gemma3-small
           - dits
           - deepseek
+          - deepseek prefill
           - gpt-oss
           - tttv2 modules
       platform:

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py
@@ -1,0 +1,498 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.tt_dit.utils.padding import get_padded_vision_seq_len
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
+from tests.ttnn.unit_tests.operations.sdpa.sdpa_test_utils import fa_rand
+
+
+def create_global_semaphores(mesh_device, cores, initial_value):
+    # create global semaphore handles
+    ccl_semaphore_handles = [ttnn.create_global_semaphore(mesh_device, cores, initial_value) for _ in range(2)]
+    return ccl_semaphore_handles
+
+
+def create_ring_joint_sdpa_submesh(mesh_device, rp_axis, rp_factor, up_axis, up_factor):
+    submesh_shape = [0, 0]
+    submesh_shape[rp_axis] = rp_factor
+    submesh_shape[up_axis] = up_factor
+    submesh_device = mesh_device.create_submesh(ttnn.MeshShape(submesh_shape[0], submesh_shape[1]))
+    return submesh_device
+
+
+def create_balanced_chunk_order(rp_factor):
+    """Create balanced chunk order for sequence reordering.
+
+    For rp_factor=4, creates 2*4=8 chunks with order: 0,7,1,6,2,5,3,4
+    This interleaves chunks from start and end to balance workload.
+    """
+    num_chunks = 2 * rp_factor
+    balanced_order = []
+
+    left = 0
+    right = num_chunks - 1
+
+    for i in range(num_chunks):
+        if i % 2 == 0:
+            balanced_order.append(left)
+            left += 1
+        else:
+            balanced_order.append(right)
+            right -= 1
+
+    return balanced_order
+
+
+def reorder_tensor_chunks(tensor, chunk_order, seq_dim=2):
+    """Reorder tensor chunks along sequence dimension according to chunk_order."""
+    seq_len = tensor.shape[seq_dim]
+    num_chunks = len(chunk_order)
+    chunk_size = seq_len // num_chunks
+
+    # Split into chunks
+    chunks = []
+    for i in range(num_chunks):
+        start = i * chunk_size
+        end = start + chunk_size
+        if seq_dim == 2:
+            chunks.append(tensor[:, :, start:end, :])
+        else:
+            raise NotImplementedError(f"Reordering for seq_dim={seq_dim} not implemented")
+
+    # Reorder chunks according to chunk_order
+    reordered_chunks = [chunks[i] for i in chunk_order]
+
+    # Concatenate reordered chunks
+    return torch.cat(reordered_chunks, dim=seq_dim)
+
+
+def reverse_reorder_tensor_chunks(tensor, chunk_order, seq_dim=2):
+    """Reverse the chunk reordering to restore original order."""
+    # Create inverse permutation
+    inverse_order = [0] * len(chunk_order)
+    for new_pos, orig_pos in enumerate(chunk_order):
+        inverse_order[orig_pos] = new_pos
+
+    logger.debug(f"inverse order: {inverse_order}")
+    return reorder_tensor_chunks(tensor, inverse_order, seq_dim)
+
+
+def run_ring_joint_sdpa(
+    submesh,
+    b,
+    nhq,
+    nhk,
+    nhv,
+    base_seq_len,
+    padded_seq_len,
+    joint_seq_len,
+    head_dim_q,
+    head_dim_k,
+    head_dim_v,
+    q_chunk_size,
+    k_chunk_size,
+    q_dtype,
+    kv_dtype,
+    n_iters,
+    trace_enabled,
+    num_links,
+    rp_axis,
+    up_axis,
+    all_gather_topology,
+    skip_check,
+    pcc_threshold,
+    max_mse=None,
+    is_causal=False,
+    is_balanced=False,
+):
+    full_compute_grid = submesh.compute_with_storage_grid_size()
+    sdpa_compute_grid = (full_compute_grid.x, full_compute_grid.y - 1)
+    ccl_core_grid_offset = (0, full_compute_grid.y - 1)
+
+    # Basic CCL setup
+    ccl_sub_device_crs = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(full_compute_grid.x - 1, full_compute_grid.y - 1))}
+    )
+    worker_sub_device = ttnn.SubDevice(
+        [
+            ccl_sub_device_crs,
+        ]
+    )
+    worker_sub_device_id = ttnn.SubDeviceId(0)
+    sub_device_stall_group = [worker_sub_device_id]
+
+    sub_device_manager = submesh.create_sub_device_manager([worker_sub_device], 0)
+    submesh.load_sub_device_manager(sub_device_manager)
+    submesh.set_sub_device_stall_group(sub_device_stall_group)
+
+    # create global semaphore handles
+    ccl_semaphore_handles = [create_global_semaphores(submesh, ccl_sub_device_crs, 0) for _ in range(n_iters)]
+
+    kv_shard_dims = [None, None]
+    kv_shard_dims[rp_axis] = None  # Output of AllGather is not sharded on RP axis
+    kv_shard_dims[up_axis] = 1  # UP shards on heads dim1
+
+    # Create persistent output buffers
+    # Check sharding on these
+    ag_output_shape_k = (b, nhk, padded_seq_len, head_dim_k)
+    ag_output_shape_v = (b, nhv, padded_seq_len, head_dim_v)
+
+    persistent_k_output_shard_dims = [None, None]
+    if nhk != 1:
+        persistent_k_output_shard_dims[up_axis] = 1
+
+    persistent_output_buffers = [
+        [
+            ttnn.from_torch(
+                torch.zeros(ag_output_shape_k),
+                device=submesh,
+                layout=ttnn.TILE_LAYOUT,
+                dtype=kv_dtype,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                mesh_mapper=ttnn.ShardTensor2dMesh(
+                    submesh, mesh_shape=tuple(submesh.shape), dims=persistent_k_output_shard_dims
+                ),
+            ),
+            ttnn.from_torch(
+                torch.zeros(ag_output_shape_v),
+                device=submesh,
+                layout=ttnn.TILE_LAYOUT,
+                dtype=kv_dtype,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                mesh_mapper=ttnn.ShardTensor2dMesh(submesh, mesh_shape=tuple(submesh.shape), dims=kv_shard_dims),
+            ),
+        ]
+        for _ in range(n_iters)
+    ]
+
+    program_config = ttnn.SDPAProgramConfig(
+        compute_with_storage_grid_size=sdpa_compute_grid,
+        q_chunk_size=q_chunk_size,
+        k_chunk_size=k_chunk_size,
+        exp_approx_mode=False,
+    )
+
+    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi2,
+        math_approx_mode=False,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=False,
+    )
+
+    Q = fa_rand(b, nhq, base_seq_len, head_dim_q)
+    K = fa_rand(b, nhk, base_seq_len, head_dim_k)
+    V = fa_rand(b, nhv, base_seq_len, head_dim_v)
+
+    padded_Q = torch.cat([Q, torch.zeros(b, nhq, padded_seq_len - base_seq_len, head_dim_q)], dim=2)
+    padded_K = torch.cat([K, torch.zeros(b, nhk, padded_seq_len - base_seq_len, head_dim_k)], dim=2)
+    padded_V = torch.cat([V, torch.zeros(b, nhv, padded_seq_len - base_seq_len, head_dim_v)], dim=2)
+
+    # Apply balanced reordering if requested
+    chunk_order = None
+    if is_balanced:
+        rp_factor = submesh.shape[rp_axis]
+        chunk_order = create_balanced_chunk_order(rp_factor)
+        logger.info(f"Balanced reordering: rp_factor={rp_factor}, num_chunks={2*rp_factor}, order={chunk_order}")
+
+        padded_Q = reorder_tensor_chunks(padded_Q, chunk_order, seq_dim=2)
+        padded_K = reorder_tensor_chunks(padded_K, chunk_order, seq_dim=2)
+        padded_V = reorder_tensor_chunks(padded_V, chunk_order, seq_dim=2)
+
+    # Always create joint tensors (use dummy tensors when joint_seq_len = 0)
+    joint_Q = fa_rand(b, nhq, joint_seq_len, head_dim_q)
+    joint_K = fa_rand(b, nhk, joint_seq_len, head_dim_k)
+    joint_V = fa_rand(b, nhv, joint_seq_len, head_dim_v)
+    logger.debug(f"jointQ: {joint_Q.shape}")
+    logger.debug(f"jointK: {joint_K.shape}")
+    logger.debug(f"jointV: {joint_V.shape}")
+
+    # Print shapes of all inputs along with input names
+    logger.debug(f"padded_Q: {padded_Q.shape}")
+    logger.debug(f"padded_K: {padded_K.shape}")
+    logger.debug(f"padded_V: {padded_V.shape}")
+    if is_balanced:
+        logger.debug(f"Balanced reordering applied with chunk order: {chunk_order}")
+
+    sdpa_input_shard_dims = [None, None]
+    sdpa_input_shard_dims[rp_axis] = 2  # sequence dim
+    sdpa_input_shard_dims[up_axis] = 1  # head dim
+
+    # Joint input only sharded on head dim
+    sdpa_joint_shard_dims = [None, None]
+    sdpa_joint_shard_dims[up_axis] = 1  # head dim
+
+    sdpa_k_input_shard_dims = [None, None]
+    sdpa_k_input_shard_dims[rp_axis] = 2  # sequence dim
+    if nhk == 1:
+        sdpa_k_input_shard_dims[up_axis] = None  # Do not shard on head_dim, as there is 1 k head for all q heads in MLA
+    else:
+        sdpa_k_input_shard_dims[up_axis] = 1  # head dim
+
+    tt_Q = ttnn.from_torch(
+        padded_Q,
+        dtype=q_dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=submesh,
+        mesh_mapper=ttnn.ShardTensor2dMesh(submesh, mesh_shape=tuple(submesh.shape), dims=sdpa_input_shard_dims),
+    )
+    tt_K = ttnn.from_torch(
+        padded_K,
+        dtype=kv_dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=submesh,
+        mesh_mapper=ttnn.ShardTensor2dMesh(submesh, mesh_shape=tuple(submesh.shape), dims=sdpa_k_input_shard_dims),
+    )
+    tt_V = ttnn.from_torch(
+        padded_V,
+        dtype=kv_dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=submesh,
+        mesh_mapper=ttnn.ShardTensor2dMesh(submesh, mesh_shape=tuple(submesh.shape), dims=sdpa_input_shard_dims),
+    )
+    # Always convert joint tensors to ttnn (including dummy tensors)
+    tt_joint_Q = ttnn.from_torch(
+        joint_Q,
+        dtype=q_dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=submesh,
+        mesh_mapper=ttnn.ShardTensor2dMesh(submesh, mesh_shape=tuple(submesh.shape), dims=sdpa_joint_shard_dims),
+    )
+    # split on head if there is nh > 1, else replicate
+    joint_k_mesh_mapper = (
+        ttnn.ShardTensor2dMesh(submesh, mesh_shape=tuple(submesh.shape), dims=sdpa_k_input_shard_dims)
+        if nhk > 1
+        else ttnn.ReplicateTensorToMesh(submesh)
+    )
+    tt_joint_K = ttnn.from_torch(
+        joint_K,
+        dtype=kv_dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=submesh,
+        mesh_mapper=joint_k_mesh_mapper,
+    )
+    tt_joint_V = ttnn.from_torch(
+        joint_V,
+        dtype=kv_dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=submesh,
+        mesh_mapper=ttnn.ShardTensor2dMesh(submesh, mesh_shape=tuple(submesh.shape), dims=sdpa_joint_shard_dims),
+    )
+
+    tt_out_list = []
+
+    def run_iters(tt_out_list):
+        for i in range(n_iters):
+            logger.debug("Running ring-joint sdpa with the following shapes:")
+            logger.debug(f"tt_Q: {tt_Q.shape}")
+            logger.debug(f"tt_K: {tt_K.shape}")
+            logger.debug(f"tt_V: {tt_V.shape}")
+            logger.debug(f"tt_joint_Q: {tt_joint_Q.shape}")
+            logger.debug(f"tt_joint_K: {tt_joint_K.shape}")
+            logger.debug(f"tt_joint_V: {tt_joint_V.shape}")
+            if joint_seq_len == 0:
+                logger.debug("Using dummy joint tensors (joint_seq_len = 0)")
+
+            # Always call with joint tensors and strategy (use dummy tensors when joint_seq_len = 0)
+            tt_out, _, _ = ttnn.transformer.ring_joint_scaled_dot_product_attention(
+                tt_Q,
+                tt_K,
+                tt_V,
+                tt_joint_Q,
+                tt_joint_K,
+                tt_joint_V,
+                persistent_output_buffer_k=persistent_output_buffers[i][0],
+                persistent_output_buffer_v=persistent_output_buffers[i][1],
+                joint_strategy="rear",
+                logical_n=base_seq_len,
+                program_config=program_config,
+                compute_kernel_config=compute_kernel_config,
+                dim=2,
+                multi_device_global_semaphore=ccl_semaphore_handles[i],
+                num_links=num_links,
+                cluster_axis=rp_axis,
+                mesh_device=submesh,
+                topology=all_gather_topology,
+                subdevice_id=worker_sub_device_id,
+                ccl_core_grid_offset=ccl_core_grid_offset,
+                is_causal=is_causal,
+                is_balanced=is_balanced,
+            )
+            tt_out_list.append(tt_out)
+
+    if trace_enabled:
+        logger.info("Compile run")
+        run_iters([])
+        logger.info("Capture trace")
+        trace_id = ttnn.begin_trace_capture(submesh, cq_id=0)
+        run_iters(tt_out_list)
+        ttnn.end_trace_capture(submesh, trace_id, cq_id=0)
+        ttnn.synchronize_device(submesh)
+        logger.info("Execute trace")
+        ttnn.execute_trace(submesh, trace_id, blocking=False)
+        ttnn.release_trace(submesh, trace_id)
+        ttnn.synchronize_device(submesh)
+
+    else:
+        logger.info("Run without trace")
+        run_iters(tt_out_list)
+
+    if not skip_check:
+        # Only use main tensors for host reference (no joint tensors since joint_seq_len=0)
+        logger.debug("Running on host...")
+        gt_out = torch.nn.functional.scaled_dot_product_attention(Q, K, V, is_causal=is_causal)
+        logger.debug("Done running on host...")
+        logger.debug("Host output shape: ", gt_out.shape)
+
+        for i in range(n_iters):
+            logger.debug("Synchronize call...")
+            ttnn.synchronize_device(submesh)
+            logger.debug("Done synchronizing...")
+            tt_out = ttnn.to_torch(
+                tt_out_list[i],
+                mesh_composer=ttnn.ConcatMesh2dToTensor(
+                    submesh, mesh_shape=tuple(submesh.shape), dims=sdpa_input_shard_dims
+                ),
+            )
+
+            # Reverse reordering for TT output if balanced reordering was applied
+            if is_balanced and chunk_order is not None:
+                logger.debug("Reversing balanced reordering for TT output")
+                # First slice to padded sequence length, then reverse reorder
+                tt_out_padded = tt_out[:, :, :padded_seq_len, :]
+                tt_out_reordered = reverse_reorder_tensor_chunks(tt_out_padded, chunk_order, seq_dim=2)
+                tt_out = tt_out_reordered[:, :, :base_seq_len, :]
+            else:
+                # Slice out any tile-padding
+                tt_out = tt_out[:, :, :base_seq_len, :]
+
+            logger.debug(f"tt_out: {tt_out.shape}")
+
+            passing = True
+            out_pass, out_pcc = comp_pcc(tt_out, gt_out, pcc_threshold)
+            logger.debug(f"{out_pcc}")
+            mse = ((gt_out - tt_out) ** 2).mean()
+            logger.debug(f"mse: {mse}")
+            if max_mse is not None and mse > max_mse:
+                passing = False
+            passing = passing and out_pass
+
+            assert passing
+
+
+@pytest.mark.parametrize("q_dtype, kv_dtype", [(ttnn.bfloat16, ttnn.bfloat8_b)], ids=["q_bf16_kv_bf8"])
+@pytest.mark.parametrize(
+    "b, nhq, nhk, nhv, base_seq_len, head_dim_q, head_dim_k, head_dim_v",
+    [
+        (1, 64, 1, 64, 4 * 4 * 1024, 576, 576, 128),
+    ],
+)
+@pytest.mark.parametrize("q_chunk_size", [32], ids=["q32"])
+@pytest.mark.parametrize("k_chunk_size", [32], ids=["k32"])
+@pytest.mark.parametrize(
+    "n_iters, trace_enabled, skip_check",
+    [
+        (1, False, False),
+    ],
+    ids=["no_trace"],
+)
+@pytest.mark.parametrize("num_links", [1], ids=["1link"])
+@pytest.mark.parametrize(
+    "device_params, all_gather_topology",
+    [
+        (
+            {"worker_l1_size": 1344544, "trace_region_size": 1000000, "fabric_config": ttnn.FabricConfig.FABRIC_1D},
+            ttnn.Topology.Linear,
+        ),
+    ],
+    indirect=["device_params"],
+    ids=[
+        "line",
+    ],
+)
+@pytest.mark.parametrize(
+    "mesh_device",
+    [(2, 4)],
+    ids=["2x4"],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "rp_axis, rp_factor, up_axis, up_factor",
+    [
+        [1, 4, 0, 2],
+    ],
+    ids=[
+        "4rpx2p",
+    ],
+)
+@pytest.mark.parametrize("is_balanced", [False, True], ids=["no_balancing", "balanced"])
+def test_mla_sdpa(
+    mesh_device,
+    b,
+    nhq,
+    nhk,
+    nhv,
+    base_seq_len,
+    head_dim_q,
+    head_dim_k,
+    head_dim_v,
+    q_chunk_size,
+    k_chunk_size,
+    q_dtype,
+    kv_dtype,
+    n_iters,
+    trace_enabled,
+    num_links,
+    rp_axis,
+    rp_factor,
+    up_axis,
+    up_factor,
+    all_gather_topology,
+    skip_check,
+    is_balanced,
+    reset_seeds,
+):
+    mesh_device_shape = list(mesh_device.shape)
+    assert mesh_device_shape[rp_axis] >= rp_factor and mesh_device_shape[up_axis] >= up_factor
+
+    submesh = create_ring_joint_sdpa_submesh(mesh_device, rp_axis, rp_factor, up_axis, up_factor)
+
+    padded_seq_len = get_padded_vision_seq_len(base_seq_len, mesh_device_shape[rp_axis])
+
+    logger.debug(f"RP axis: {rp_axis} factor: {rp_factor}, UP axis: {up_axis} factor: {up_factor}")
+    logger.debug(f"submesh: {submesh.shape}")
+
+    joint_seq_len = 0  # causality is enabled only for non-joint cases
+
+    run_ring_joint_sdpa(
+        submesh,
+        b,
+        nhq,
+        nhk,
+        nhv,
+        base_seq_len,
+        padded_seq_len,
+        joint_seq_len,
+        head_dim_q,
+        head_dim_k,
+        head_dim_v,
+        q_chunk_size,
+        k_chunk_size,
+        q_dtype,
+        kv_dtype,
+        n_iters,
+        trace_enabled,
+        num_links,
+        rp_axis,
+        up_axis,
+        all_gather_topology,
+        skip_check,
+        0.999,
+        is_causal=True,
+        is_balanced=is_balanced,
+    )

--- a/tests/pipeline_reorg/t3k_unit_tests.yaml
+++ b/tests/pipeline_reorg/t3k_unit_tests.yaml
@@ -206,6 +206,15 @@
   team: models
   model-name: deepseek
 
+- name: t3k_deepseek_prefill_tests
+  cmd: run_t3000_deepseek_prefill_tests
+  skus:
+    wh_llmbox:
+      timeout: 10
+  owner_id: U07N3CUUN05 # Iva Potkonjak
+  team: models
+  model-name: deepseek prefill
+
 - name: t3k_tttv2_fast_unit_tests
   cmd: run_t3000_tttv2_fast_unit_tests
   skus:

--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -567,6 +567,10 @@ run_t3000_deepseek_tests() {
   MESH_DEVICE=T3K pytest models/demos/deepseek_v3/tests/unit --timeout 60 --durations=0
 }
 
+run_t3000_deepseek_prefill_tests() {
+  pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests --timeout 600 --durations=0
+}
+
 run_t3000_ccl_tests() {
   # Record the start time
   fail=0

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
@@ -38,16 +38,27 @@ void kernel_main() {
     ///////////////////////////////////////////////////
     uint32_t arg_idx = 0;
     // Load the input tensor spec
-    uint32_t input_tensor_Wt = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t input_tensor_Ht = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t output_tensor_Wt = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t output_tensor_Ht = get_arg_val<uint32_t>(arg_idx++);
     uint32_t gather_dim = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t input_batch_head_count = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t input_tile_id_start = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t input_tile_id_end = get_arg_val<uint32_t>(arg_idx++);
     uint32_t ring_size = get_arg_val<uint32_t>(arg_idx++);
     size_t out_ready_sem = get_arg_val<uint32_t>(arg_idx++);
+
+    std::array<uint32_t, num_inputs> input_tensor_Wt;
+    std::array<uint32_t, num_inputs> input_tensor_Ht;
+    std::array<uint32_t, num_inputs> output_tensor_Wt;
+    std::array<uint32_t, num_inputs> output_tensor_Ht;
+    std::array<uint32_t, num_inputs> input_batch_head_count;
+    std::array<uint32_t, num_inputs> input_tile_id_start;
+    std::array<uint32_t, num_inputs> input_tile_id_end;
+
+    for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
+        input_tensor_Wt[input_idx] = get_arg_val<uint32_t>(arg_idx++);
+        input_tensor_Ht[input_idx] = get_arg_val<uint32_t>(arg_idx++);
+        output_tensor_Wt[input_idx] = get_arg_val<uint32_t>(arg_idx++);
+        output_tensor_Ht[input_idx] = get_arg_val<uint32_t>(arg_idx++);
+        input_batch_head_count[input_idx] = get_arg_val<uint32_t>(arg_idx++);
+        input_tile_id_start[input_idx] = get_arg_val<uint32_t>(arg_idx++);
+        input_tile_id_end[input_idx] = get_arg_val<uint32_t>(arg_idx++);
+    }
 
     auto inputs_tuple = make_tensor_accessor_tuple(inputs_args, arg_idx, page_size_base_idx);
     arg_idx += num_inputs;
@@ -64,11 +75,12 @@ void kernel_main() {
     const uint32_t payload_size_bytes = input_tensor_page_size * contig_pages_advanced;
     // Push out our local slice
 
-    uint32_t tiles_read = input_tile_id_start;
-    uint32_t tiles_to_read = input_tile_id_end;
     uint32_t output_tile_id_start = 0;
+    // Read local slice to our buffers, before sending them over
     for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
-        for (uint32_t bh_idx = 0; bh_idx < input_batch_head_count; bh_idx++) {
+        uint32_t tiles_read = input_tile_id_start[input_idx];
+        uint32_t tiles_to_read = input_tile_id_end[input_idx];
+        for (uint32_t bh_idx = 0; bh_idx < input_batch_head_count[input_idx]; bh_idx++) {
             while (tiles_read < tiles_to_read) {
                 uint32_t num_pages_to_read = std::min(tiles_to_read - tiles_read, packet_size_in_pages);
                 cb_reserve_back(cb_output_id, packet_size_in_pages);
@@ -83,9 +95,9 @@ void kernel_main() {
                 noc_async_read_barrier();
                 cb_push_back(cb_output_id, packet_size_in_pages);
             }
-            tiles_read = input_tile_id_start;
-            tiles_to_read = input_tile_id_end;
-            output_tile_id_start += input_tensor_Wt * input_tensor_Ht;
+            tiles_read = input_tile_id_start[input_idx];
+            tiles_to_read = input_tile_id_end[input_idx];
+            output_tile_id_start += input_tensor_Wt[input_idx] * input_tensor_Ht[input_idx];
         }
         output_tile_id_start = 0;
     }
@@ -147,21 +159,22 @@ void kernel_main() {
         if ((topology == Topology::Linear && writes_expected > 0) ||
             (topology == Topology::Ring && (slices_received < (writes_expected + 1)))) {
             for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
-                // read the next backward slice out of memory, and put it in CB
-                tiles_read = input_tile_id_start;
-                tiles_to_read = input_tile_id_end;
+                uint32_t tiles_read = input_tile_id_start[input_idx];
+                uint32_t tiles_to_read = input_tile_id_end[input_idx];
 
                 uint32_t output_tile_id_start = 0;
-                uint32_t pages_read_in_row = input_tile_id_start % input_tensor_Wt;
-                uint32_t row_offset = (input_tile_id_start / input_tensor_Wt) * output_tensor_Wt;
-                uint32_t slice_Wt = input_tensor_Wt;
-                uint32_t stride_Wt = output_tensor_Wt;
+                uint32_t pages_read_in_row = input_tile_id_start[input_idx] % input_tensor_Wt[input_idx];
+                uint32_t row_offset =
+                    (input_tile_id_start[input_idx] / input_tensor_Wt[input_idx]) * output_tensor_Wt[input_idx];
+                uint32_t slice_Wt = input_tensor_Wt[input_idx];
+                uint32_t stride_Wt = output_tensor_Wt[input_idx];
                 if (gather_dim == 3) {
-                    output_tile_id_start = actual_sender_chip_id * input_tensor_Wt;
+                    output_tile_id_start = actual_sender_chip_id * input_tensor_Wt[input_idx];
                 } else {
-                    output_tile_id_start = actual_sender_chip_id * input_tensor_Ht * input_tensor_Wt;
+                    output_tile_id_start =
+                        actual_sender_chip_id * input_tensor_Ht[input_idx] * input_tensor_Wt[input_idx];
                 }
-                for (uint32_t bh_idx = 0; bh_idx < input_batch_head_count; bh_idx++) {
+                for (uint32_t bh_idx = 0; bh_idx < input_batch_head_count[input_idx]; bh_idx++) {
                     while (tiles_read < tiles_to_read) {
                         uint32_t num_pages_to_read = std::min(tiles_to_read - tiles_read, packet_size_in_pages);  // 2
                         cb_reserve_back(cb_output_id, packet_size_in_pages);
@@ -182,16 +195,16 @@ void kernel_main() {
                         noc_async_read_barrier();
                         cb_push_back(cb_output_id, packet_size_in_pages);
                     }
-                    pages_read_in_row = input_tile_id_start % input_tensor_Wt;
-                    row_offset = (input_tile_id_start / input_tensor_Wt) * output_tensor_Wt;
-                    tiles_read = input_tile_id_start;
-                    tiles_to_read = input_tile_id_end;
-                    output_tile_id_start += output_tensor_Wt * output_tensor_Ht;
+                    pages_read_in_row = input_tile_id_start[input_idx] % input_tensor_Wt[input_idx];
+                    row_offset =
+                        (input_tile_id_start[input_idx] / input_tensor_Wt[input_idx]) * output_tensor_Wt[input_idx];
+                    tiles_read = input_tile_id_start[input_idx];
+                    tiles_to_read = input_tile_id_end[input_idx];
+                    output_tile_id_start += output_tensor_Wt[input_idx] * output_tensor_Ht[input_idx];
                 }
             }
         }
     }
-
     const uint64_t dest_noc_addr = get_noc_addr(my_x[0], my_y[0], out_ready_sem);
     noc_inline_dw_write(dest_noc_addr, 0);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_writer.cpp
@@ -42,24 +42,35 @@ void kernel_main() {
     // ARGS
     ///////////////////////////////////////////////////
     uint32_t arg_idx = 0;
-    uint32_t input_tensor_Wt = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t input_tensor_Ht = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t output_tensor_Wt = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t output_tensor_Ht = get_arg_val<uint32_t>(arg_idx++);
     uint32_t gather_dim = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t input_batch_head_count = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t input_tile_id_start = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t input_tile_id_end = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t out_ready_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t out_ready_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
     uint32_t ring_size = get_arg_val<uint32_t>(arg_idx++);
     size_t out_ready_sem = get_arg_val<uint32_t>(arg_idx++);
+
+    std::array<uint32_t, num_inputs> input_tensor_Wt;
+    std::array<uint32_t, num_inputs> input_tensor_Ht;
+    std::array<uint32_t, num_inputs> output_tensor_Wt;
+    std::array<uint32_t, num_inputs> output_tensor_Ht;
+    std::array<uint32_t, num_inputs> input_batch_head_count;
+    std::array<uint32_t, num_inputs> input_tile_id_start;
+    std::array<uint32_t, num_inputs> input_tile_id_end;
+
+    for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
+        input_tensor_Wt[input_idx] = get_arg_val<uint32_t>(arg_idx++);
+        input_tensor_Ht[input_idx] = get_arg_val<uint32_t>(arg_idx++);
+        output_tensor_Wt[input_idx] = get_arg_val<uint32_t>(arg_idx++);
+        output_tensor_Ht[input_idx] = get_arg_val<uint32_t>(arg_idx++);
+        input_batch_head_count[input_idx] = get_arg_val<uint32_t>(arg_idx++);
+        input_tile_id_start[input_idx] = get_arg_val<uint32_t>(arg_idx++);
+        input_tile_id_end[input_idx] = get_arg_val<uint32_t>(arg_idx++);
+    }
+
     auto outputs_tuple = make_tensor_accessor_tuple(outputs_args, arg_idx, page_size_base_idx);
     arg_idx += num_inputs;
     auto output_addrgens = make_abstract_tensor_accessor_wrappers(outputs_tuple);
     size_t arg_for_fab = arg_idx;
     auto fabric_connection = FabricConnectionManager::build_from_args(arg_for_fab);
-
     /* Args for overlapped all gather */
     OpSignaler op_signaler_sender;
 
@@ -92,7 +103,6 @@ void kernel_main() {
     uint32_t slice_writes = 0;
 
     uint32_t row_offset = 0;
-    uint32_t tile_id_start = my_chip_id * input_tensor_Wt;
     for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
         /**
          * Write out the local slice to forward and backward devices
@@ -101,17 +111,20 @@ void kernel_main() {
          * when accessing the local slice. This is a performance optimization
          * to remove startup latency from the fused op.
          */
-        uint32_t pages_read_in_row = input_tile_id_start % input_tensor_Wt;
-        uint32_t row_offset = (input_tile_id_start / input_tensor_Wt) * output_tensor_Wt;
-        uint32_t tiles_read = input_tile_id_start;
-        uint32_t tiles_to_read = input_tile_id_end;
-        uint32_t tile_id_start = my_chip_id * input_tensor_Wt;
+
+        uint32_t tile_id_start = my_chip_id * input_tensor_Wt[input_idx];
+        uint32_t pages_read_in_row = input_tile_id_start[input_idx] % input_tensor_Wt[input_idx];
+        uint32_t row_offset =
+            (input_tile_id_start[input_idx] / input_tensor_Wt[input_idx]) * output_tensor_Wt[input_idx];
+        uint32_t tiles_read = input_tile_id_start[input_idx];
+        uint32_t tiles_to_read = input_tile_id_end[input_idx];
         if (gather_dim == 3) {
-            tile_id_start = my_chip_id * input_tensor_Wt;
+            tile_id_start = my_chip_id * input_tensor_Wt[input_idx];
         } else {
-            tile_id_start = my_chip_id * input_tensor_Ht * input_tensor_Wt;
+            tile_id_start = my_chip_id * input_tensor_Ht[input_idx] * input_tensor_Wt[input_idx];
         }
-        for (uint32_t bh_idx = 0; bh_idx < input_batch_head_count; bh_idx++) {
+
+        for (uint32_t bh_idx = 0; bh_idx < input_batch_head_count[input_idx]; bh_idx++) {
             while (tiles_read < tiles_to_read) {
                 uint32_t num_pages_to_read = std::min(tiles_to_read - tiles_read, packet_size_in_pages);
                 cb_wait_front(cb_output_id, packet_size_in_pages);
@@ -122,8 +135,8 @@ void kernel_main() {
                 uint32_t tile_id = tile_id_start + row_offset + pages_read_in_row;
 
                 pages_read_in_row++;
-                if (pages_read_in_row >= input_tensor_Wt) {
-                    row_offset += output_tensor_Wt;
+                if (pages_read_in_row >= input_tensor_Wt[input_idx]) {
+                    row_offset += output_tensor_Wt[input_idx];
                     pages_read_in_row = 0;
                 }
 
@@ -142,8 +155,8 @@ void kernel_main() {
                     }
 
                     pages_read_in_row++;
-                    if (pages_read_in_row >= input_tensor_Wt) {
-                        row_offset += output_tensor_Wt;
+                    if (pages_read_in_row >= input_tensor_Wt[input_idx]) {
+                        row_offset += output_tensor_Wt[input_idx];
                         pages_read_in_row = 0;
                     }
                 } else {
@@ -162,14 +175,13 @@ void kernel_main() {
                 }
 
                 tiles_read += num_pages_to_read;
-
                 cb_pop_front(cb_output_id, packet_size_in_pages);
             }
-            tile_id_start += output_tensor_Wt * output_tensor_Ht;
-            tiles_read = input_tile_id_start;
-            tiles_to_read = input_tile_id_end;
-            pages_read_in_row = input_tile_id_start % input_tensor_Wt;
-            row_offset = (input_tile_id_start / input_tensor_Wt) * output_tensor_Wt;
+            tile_id_start += output_tensor_Wt[input_idx] * output_tensor_Ht[input_idx];
+            tiles_read = input_tile_id_start[input_idx];
+            tiles_to_read = input_tile_id_end[input_idx];
+            pages_read_in_row = input_tile_id_start[input_idx] % input_tensor_Wt[input_idx];
+            row_offset = (input_tile_id_start[input_idx] / input_tensor_Wt[input_idx]) * output_tensor_Wt[input_idx];
         }
     }
 
@@ -237,20 +249,21 @@ void kernel_main() {
             actual_slice_chip_id = (slice_chip_id < 0) ? ring_size + slice_chip_id : slice_chip_id;
         }
         for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
-            uint32_t tiles_read = input_tile_id_start;
-            uint32_t tiles_to_read = input_tile_id_end;
-            uint32_t tile_id_start = actual_slice_chip_id * input_tensor_Wt;
-            uint32_t row_offset = (input_tile_id_start / input_tensor_Wt) * output_tensor_Wt;
-            uint32_t pages_read_in_row = (input_tile_id_start % input_tensor_Wt);
-            uint32_t slice_Wt = input_tensor_Wt;
-            uint32_t stride_Wt = output_tensor_Wt;
+            uint32_t tiles_read = input_tile_id_start[input_idx];
+            uint32_t tiles_to_read = input_tile_id_end[input_idx];
+            uint32_t tile_id_start = actual_slice_chip_id * input_tensor_Wt[input_idx];
+            uint32_t row_offset =
+                (input_tile_id_start[input_idx] / input_tensor_Wt[input_idx]) * output_tensor_Wt[input_idx];
+            uint32_t pages_read_in_row = (input_tile_id_start[input_idx] % input_tensor_Wt[input_idx]);
+            uint32_t slice_Wt = input_tensor_Wt[input_idx];
+            uint32_t stride_Wt = output_tensor_Wt[input_idx];
 
             if (gather_dim == 3) {
-                tile_id_start = actual_slice_chip_id * input_tensor_Wt;
+                tile_id_start = actual_slice_chip_id * input_tensor_Wt[input_idx];
             } else {
-                tile_id_start = actual_slice_chip_id * input_tensor_Ht * input_tensor_Wt;
+                tile_id_start = actual_slice_chip_id * input_tensor_Ht[input_idx] * input_tensor_Wt[input_idx];
             }
-            for (uint32_t bh_idx = 0; bh_idx < input_batch_head_count; bh_idx++) {
+            for (uint32_t bh_idx = 0; bh_idx < input_batch_head_count[input_idx]; bh_idx++) {
                 while (tiles_read < tiles_to_read) {
                     uint32_t num_pages_to_read = std::min(tiles_to_read - tiles_read, packet_size_in_pages);
                     cb_wait_front(cb_output_id, packet_size_in_pages);
@@ -292,11 +305,12 @@ void kernel_main() {
                     tiles_read += num_pages_to_read;
                     cb_pop_front(cb_output_id, packet_size_in_pages);
                 }
-                tile_id_start += output_tensor_Wt * output_tensor_Ht;
-                tiles_read = input_tile_id_start;
-                tiles_to_read = input_tile_id_end;
-                row_offset = (input_tile_id_start / input_tensor_Wt) * output_tensor_Wt;
-                pages_read_in_row = (input_tile_id_start % input_tensor_Wt);
+                tile_id_start += output_tensor_Wt[input_idx] * output_tensor_Ht[input_idx];
+                tiles_read = input_tile_id_start[input_idx];
+                tiles_to_read = input_tile_id_end[input_idx];
+                row_offset =
+                    (input_tile_id_start[input_idx] / input_tensor_Wt[input_idx]) * output_tensor_Wt[input_idx];
+                pages_read_in_row = (input_tile_id_start[input_idx] % input_tensor_Wt[input_idx]);
             }
         }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_device_operation.cpp
@@ -105,8 +105,8 @@ RingAttentionAllGatherAsyncDeviceOperation::compute_output_specs(
     auto shape = input_tensor.logical_shape();
     std::vector<ttnn::TensorSpec> output_specs;
     output_specs.reserve(input_tensors.size());
-    for (uint32_t i = 0; i < input_tensors.size(); i++) {
-        auto shape = input_tensors[i].logical_shape();
+    for (const auto& input_item : input_tensors) {
+        auto shape = input_item.logical_shape();
         shape[operation_attributes.dim] *= operation_attributes.ring_size;
         output_specs.push_back(TensorSpec(
             shape,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_device_operation.cpp
@@ -22,7 +22,6 @@ void RingAttentionAllGatherAsyncDeviceOperation::validate_on_program_cache_miss(
     const auto& first_input_tensor = input_tensors[0];
     const auto& dtype = first_input_tensor.dtype();
     const auto& memory_config = first_input_tensor.memory_config();
-    const auto& input_shape = first_input_tensor.logical_shape();
 
     // Validate all input tensors
     for (size_t i = 0; i < input_tensors.size(); ++i) {
@@ -42,11 +41,6 @@ void RingAttentionAllGatherAsyncDeviceOperation::validate_on_program_cache_miss(
         TT_FATAL(
             input_tensor.memory_config() == memory_config,
             "All input tensors must have the same memory config. Input tensor {} has different memory config",
-            i);
-
-        TT_FATAL(
-            input_tensor.logical_shape() == input_shape,
-            "All input tensors must have the same shape. Input tensor {} has different shape",
             i);
     }
 
@@ -89,7 +83,7 @@ void RingAttentionAllGatherAsyncDeviceOperation::validate_on_program_cache_miss(
 
                 // Check output tensor shape
                 auto output_shape = output_tensor.logical_shape();
-                auto expected_output_shape = input_shape;
+                auto expected_output_shape = input_tensors[i].logical_shape();
                 expected_output_shape[operation_attributes.dim] *= operation_attributes.ring_size;
 
                 TT_FATAL(
@@ -109,10 +103,11 @@ RingAttentionAllGatherAsyncDeviceOperation::compute_output_specs(
     const auto& input_tensors = tensor_args.input_tensor;
     const auto& input_tensor = input_tensors[0];
     auto shape = input_tensor.logical_shape();
-    shape[operation_attributes.dim] *= operation_attributes.ring_size;
     std::vector<ttnn::TensorSpec> output_specs;
     output_specs.reserve(input_tensors.size());
     for (uint32_t i = 0; i < input_tensors.size(); i++) {
+        auto shape = input_tensors[i].logical_shape();
+        shape[operation_attributes.dim] *= operation_attributes.ring_size;
         output_specs.push_back(TensorSpec(
             shape,
             TensorLayout(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.cpp
@@ -247,9 +247,6 @@ ring_attention_all_gather_async_multi_core_with_workers_helper(
     CreateCircularBuffer(program, sender_backward_core_ranges, cb_reserved_packet_header_backward_config);
 
     // Tensor Info
-    const auto input_tensor_num_pages = input_tensor[0].buffer()->num_pages();
-    const auto input_tensor_shape = input_tensor[0].padded_shape();
-    const auto output_tensor_shape = output_tensor[0].padded_shape();
     const uint32_t num_inputs = input_tensor.size();
 
     uint32_t tiles_to_write_per_packet = 1;
@@ -402,33 +399,44 @@ ring_attention_all_gather_async_multi_core_with_workers_helper(
     uint32_t writer_sender_rt_offset = 0;
     for (uint32_t link = 0; link < num_links; link++) {
         // Set Sender Reader runtime args
-        const uint32_t batch_head_size = input_tensor_shape[0] * input_tensor_shape[1];
 
-        uint32_t single_batch_head_num_pages = input_tensor_num_pages / batch_head_size;
-        const uint32_t base_pages_per_worker = single_batch_head_num_pages / num_links;
-        const uint32_t remainder = single_batch_head_num_pages % num_links;
-        const uint32_t input_tile_id_start = (link * base_pages_per_worker) + std::min(link, remainder);
-        const uint32_t input_tile_id_end = ((link + 1) * base_pages_per_worker) + std::min(link + 1, remainder);
+        std::vector<uint32_t> tensor_descriptor_args;
+        for (uint32_t i = 0; i < num_inputs; i++) {
+            const auto input_tensor_num_pages = input_tensor[i].buffer()->num_pages();
+            const auto input_tensor_shape = input_tensor[i].padded_shape();
+            const auto output_tensor_shape = output_tensor[i].padded_shape();
+            const uint32_t batch_head_size = input_tensor_shape[0] * input_tensor_shape[1];
 
-        TT_ASSERT(!(input_tensor_shape[3] % tt::constants::TILE_WIDTH));
-        TT_ASSERT(!(output_tensor_shape[3] % tt::constants::TILE_WIDTH));
-        const uint32_t input_tensor_Wt = input_tensor_shape[3] / tt::constants::TILE_WIDTH;
-        const uint32_t input_tensor_Ht = input_tensor_shape[2] / tt::constants::TILE_WIDTH;
-        const uint32_t output_tensor_Wt = output_tensor_shape[3] / tt::constants::TILE_WIDTH;
-        const uint32_t output_tensor_Ht = output_tensor_shape[2] / tt::constants::TILE_WIDTH;
+            uint32_t single_batch_head_num_pages = input_tensor_num_pages / batch_head_size;
+            const uint32_t base_pages_per_worker = single_batch_head_num_pages / num_links;
+            const uint32_t remainder = single_batch_head_num_pages % num_links;
+            const uint32_t input_tile_id_start = (link * base_pages_per_worker) + std::min(link, remainder);
+            const uint32_t input_tile_id_end = ((link + 1) * base_pages_per_worker) + std::min(link + 1, remainder);
+
+            const uint32_t input_tensor_Wt = input_tensor_shape[3] / tt::constants::TILE_WIDTH;
+            const uint32_t input_tensor_Ht = input_tensor_shape[2] / tt::constants::TILE_WIDTH;
+            const uint32_t output_tensor_Wt = output_tensor_shape[3] / tt::constants::TILE_WIDTH;
+            const uint32_t output_tensor_Ht = output_tensor_shape[2] / tt::constants::TILE_WIDTH;
+            TT_ASSERT(!(input_tensor_shape[3] % tt::constants::TILE_WIDTH));
+            TT_ASSERT(!(output_tensor_shape[3] % tt::constants::TILE_WIDTH));
+
+            tensor_descriptor_args.push_back(input_tensor_Wt);      // 0 == input_tensor_Wt
+            tensor_descriptor_args.push_back(input_tensor_Ht);      // 1 == input_tensor_Ht
+            tensor_descriptor_args.push_back(output_tensor_Wt);     // 2 == output_tensor_Wt
+            tensor_descriptor_args.push_back(output_tensor_Ht);     // 3 == output_tensor_Ht
+            tensor_descriptor_args.push_back(batch_head_size);      // 4 == batch_head_size
+            tensor_descriptor_args.push_back(input_tile_id_start);  // 5 == input_tile_id_start
+            tensor_descriptor_args.push_back(input_tile_id_end);    // 6 == input_tile_id_end
+        }
 
         std::vector<uint32_t> reader_forward_rt_args = {
-            input_tensor_Wt,            // width in tiles of the input shard
-            input_tensor_Ht,            // height in tiles of the input shard
-            output_tensor_Wt,           // width in tiles of the entire output
-            output_tensor_Ht,           // height in tiles of the entire output
             dim,                        // dim to gather on
-            batch_head_size,            // product of the first two dims
-            input_tile_id_start,        //
-            input_tile_id_end,          // slice_num_pages
             ring_size,                  // ring_size
             semaphore.at(1).address(),  // out_ready_semaphore_backward
         };
+        for (uint32_t i = 0; i < tensor_descriptor_args.size(); i++) {
+            reader_forward_rt_args.push_back(tensor_descriptor_args[i]);
+        }
         reader_sender_rt_offset = reader_forward_rt_args.size();
         for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
             reader_forward_rt_args.push_back(input_tensor[input_idx].buffer()->address());
@@ -446,17 +454,13 @@ ring_attention_all_gather_async_multi_core_with_workers_helper(
             reader_forward_rt_args);
 
         std::vector<uint32_t> reader_backward_rt_args = {
-            input_tensor_Wt,            // width in tiles of the input shard
-            input_tensor_Ht,            // height in tiles of the input shard
-            output_tensor_Wt,           // width in tiles of the entire output
-            output_tensor_Ht,           // height in tiles of the entire output
             dim,                        // dim to gather on
-            batch_head_size,            // product of the first two dims
-            input_tile_id_start,        // slice_num_pages
-            input_tile_id_end,          // slice_num_pages
             ring_size,                  // ring_size
             semaphore.at(0).address(),  // out_ready_semaphore_backward
         };
+        for (uint32_t i = 0; i < tensor_descriptor_args.size(); i++) {
+            reader_backward_rt_args.push_back(tensor_descriptor_args[i]);
+        }
         for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
             reader_backward_rt_args.push_back(input_tensor[input_idx].buffer()->address());
         }
@@ -476,19 +480,15 @@ ring_attention_all_gather_async_multi_core_with_workers_helper(
 
         // Writer
         std::vector<uint32_t> writer_forward_rt_args = {
-            input_tensor_Wt,               // width in tiles of the input shard
-            input_tensor_Ht,               // height in tiles of the input shard
-            output_tensor_Wt,              // width in tiles of entire output
-            output_tensor_Ht,              // height in tiles of entire output
             dim,                           // dim to gather on
-            batch_head_size,               // product of the first two dims
-            input_tile_id_start,           //
-            input_tile_id_end,             //
             sender_forward_worker_core.x,  // out_ready_sem_noc0_x
             sender_forward_worker_core.y,  // out_ready_sem_noc0_y
             ring_size,                     // ring_size
             semaphore.at(1).address()      // out_ready_semaphore_backward
         };
+        for (uint32_t i = 0; i < tensor_descriptor_args.size(); i++) {
+            writer_forward_rt_args.push_back(tensor_descriptor_args[i]);
+        }
         writer_sender_rt_offset = writer_forward_rt_args.size();
         for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
             writer_forward_rt_args.push_back(output_tensor[input_idx].buffer()->address());
@@ -517,19 +517,15 @@ ring_attention_all_gather_async_multi_core_with_workers_helper(
             writer_forward_rt_args);
 
         std::vector<uint32_t> writer_backward_rt_args = {
-            input_tensor_Wt,                // width in tiles of the input shard
-            input_tensor_Ht,                // height in tiles of the input shard
-            output_tensor_Wt,               // width in tiles of entire output
-            output_tensor_Ht,               // height in tiles of entire output
             dim,                            // dim to gather on
-            batch_head_size,                // product of the first two dims
-            input_tile_id_start,            //
-            input_tile_id_end,              //
             sender_backward_worker_core.x,  // out_ready_sem_noc0_x
             sender_backward_worker_core.y,  // out_ready_sem_noc0_y
             ring_size,                      // ring_size
             semaphore.at(0).address()       // out_ready_semaphore_backward
         };
+        for (uint32_t i = 0; i < tensor_descriptor_args.size(); i++) {
+            writer_backward_rt_args.push_back(tensor_descriptor_args[i]);
+        }
         for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
             writer_backward_rt_args.push_back(output_tensor[input_idx].buffer()->address());
         }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.cpp
@@ -434,8 +434,8 @@ ring_attention_all_gather_async_multi_core_with_workers_helper(
             ring_size,                  // ring_size
             semaphore.at(1).address(),  // out_ready_semaphore_backward
         };
-        for (uint32_t i = 0; i < tensor_descriptor_args.size(); i++) {
-            reader_forward_rt_args.push_back(tensor_descriptor_args[i]);
+        for (auto tensor_descriptor_arg : tensor_descriptor_args) {
+            reader_forward_rt_args.push_back(tensor_descriptor_arg);
         }
         reader_sender_rt_offset = reader_forward_rt_args.size();
         for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
@@ -458,8 +458,8 @@ ring_attention_all_gather_async_multi_core_with_workers_helper(
             ring_size,                  // ring_size
             semaphore.at(0).address(),  // out_ready_semaphore_backward
         };
-        for (uint32_t i = 0; i < tensor_descriptor_args.size(); i++) {
-            reader_backward_rt_args.push_back(tensor_descriptor_args[i]);
+        for (auto tensor_descriptor_arg : tensor_descriptor_args) {
+            reader_backward_rt_args.push_back(tensor_descriptor_arg);
         }
         for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
             reader_backward_rt_args.push_back(input_tensor[input_idx].buffer()->address());
@@ -486,8 +486,8 @@ ring_attention_all_gather_async_multi_core_with_workers_helper(
             ring_size,                     // ring_size
             semaphore.at(1).address()      // out_ready_semaphore_backward
         };
-        for (uint32_t i = 0; i < tensor_descriptor_args.size(); i++) {
-            writer_forward_rt_args.push_back(tensor_descriptor_args[i]);
+        for (auto tensor_descriptor_arg : tensor_descriptor_args) {
+            writer_forward_rt_args.push_back(tensor_descriptor_arg);
         }
         writer_sender_rt_offset = writer_forward_rt_args.size();
         for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
@@ -523,8 +523,8 @@ ring_attention_all_gather_async_multi_core_with_workers_helper(
             ring_size,                      // ring_size
             semaphore.at(0).address()       // out_ready_semaphore_backward
         };
-        for (uint32_t i = 0; i < tensor_descriptor_args.size(); i++) {
-            writer_backward_rt_args.push_back(tensor_descriptor_args[i]);
+        for (auto tensor_descriptor_arg : tensor_descriptor_args) {
+            writer_backward_rt_args.push_back(tensor_descriptor_arg);
         }
         for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
             writer_backward_rt_args.push_back(output_tensor[input_idx].buffer()->address());

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -1582,10 +1582,10 @@ template <
     uint32_t cb_scale_in,
     uint32_t Sq_chunk_t,
     uint32_t Sk_chunk_t,
+    uint32_t NH,
     uint32_t DHt,
     uint32_t vDHt,
     bool use_attention_sink,
-    bool is_causal,
     bool use_provided_mask,
     bool use_padded_mask,
     bool use_joint_mask,
@@ -1615,6 +1615,7 @@ void sdpa_inner_loop(
     const uint32_t iter_k_chunk_end,
     const uint32_t q_chunk_tiles,
     const uint32_t k_chunk_tiles,
+    const uint32_t v_chunk_tiles,
     const uint32_t qk_chunk_tiles,
     const uint32_t out_chunk_tiles,
     const uint32_t mask_chunk_0,
@@ -1646,7 +1647,9 @@ void sdpa_inner_loop(
     const uint32_t cb_lse_out,
     const uint32_t cb_prev_out,
     const uint32_t cb_out,
-    const LightweightMaskContext& lw_mask = {}) {
+    const LightweightMaskContext& lw_mask = {},
+    const bool is_causal = false,
+    const bool is_balanced = false) {
     uint32_t KV_chunks_processed_in_iter = 0;
 
     for (uint32_t q_iter = iter_q_start; q_iter < iter_q_end; ++q_iter) {
@@ -1670,10 +1673,23 @@ void sdpa_inner_loop(
                 q_chunk = chunked_q_chunk_offset + q_chunk;
             }
             q_low_idx = q_chunk * Sq_chunk_t;  // This is the sequence index of the first tile of this chunk
-            if constexpr (is_causal) {
+            if (is_causal) {
                 q_high_idx = q_low_idx + Sq_chunk_t;
             } else {
                 q_high_idx = Skt;
+            }
+        } else if (sdpa_type == RING) {
+            const uint32_t q_chunk = q_iter % q_num_chunks;
+
+            if (is_causal) {
+                q_low_idx = q_chunk * Sq_chunk_t;
+                q_high_idx = q_low_idx + Sq_chunk_t;
+                q_high_idx = (q_high_idx + Sk_chunk_t - 1) / Sk_chunk_t;
+            }
+            if (is_balanced) {
+                if (q_chunk < q_num_chunks / 2) {
+                    continue;
+                }
             }
         }
 
@@ -1708,6 +1724,15 @@ void sdpa_inner_loop(
 
             KV_chunks_processed_in_iter++;
 
+            if (sdpa_type == RING && k_chunk >= q_high_idx && is_causal) {
+                cb_wait_front(cb_k_in, k_chunk_tiles);
+                cb_wait_front(cb_v_in, v_chunk_tiles);
+                cb_pop_front(cb_k_in, k_chunk_tiles);
+                cb_pop_front(cb_v_in, v_chunk_tiles);
+
+                continue;
+            }
+
             /**
              * QK = Q_CHUNK @ K_CHUNK
              *
@@ -1737,11 +1762,11 @@ void sdpa_inner_loop(
              */
 
             bool apply_mask = false;
-            if constexpr (sdpa_type == RING) {
+            if (sdpa_type == RING && !is_causal) {
                 apply_mask = (ring_iter_needs_global_n_mask && k_chunk == global_n_mask_chunk_id) ||
                              (local_n_needs_masking && k_chunk == local_n_mask_chunk_id) ||
                              (ring_iter_needs_joint_n_mask && (k_chunk - num_local_k_chunks) == joint_n_mask_chunk_id);
-            } else if constexpr (is_causal || sliding_window_size > 0) {
+            } else if (is_causal || sliding_window_size > 0) {
                 // Finding the diagonal is harder now that q_chunk_size and k_chunk_size can differ
                 // Q-range = [q_low, q_high)
                 // K-range = [k_low, k_high)
@@ -1949,7 +1974,7 @@ void sdpa_inner_loop(
                 sub_block(cb_prev_out, alias_cur_out, alias_sub, out_chunk_tiles);
                 // alias_sub *= alias_sig
                 reconfig_data_format(alias_sub, alias_sig);
-                mul_block_bcast_cols_inplace<Sq_chunk_t, DHt>(alias_sub, alias_sig);
+                mul_block_bcast_cols_inplace<Sq_chunk_t, vDHt>(alias_sub, alias_sig);
                 // cb_out = cb_prev_out - alias_sub
                 reconfig_data_format(cb_prev_out, alias_sub);
                 pack_reconfig_data_format(cb_out);
@@ -1993,9 +2018,9 @@ void sdpa_inner_loop(
     if constexpr (sdpa_type == RING) {
         if (KV_chunks_processed_in_iter % 2 == 0) {
             cb_wait_front(cb_k_in, k_chunk_tiles);
-            cb_wait_front(cb_v_in, k_chunk_tiles);
+            cb_wait_front(cb_v_in, v_chunk_tiles);
             cb_pop_front(cb_k_in, k_chunk_tiles);
-            cb_pop_front(cb_v_in, k_chunk_tiles);
+            cb_pop_front(cb_v_in, v_chunk_tiles);
         }
     }
 
@@ -2048,6 +2073,7 @@ void sdpa_standard(
     const uint32_t k_num_chunks,
     const uint32_t q_chunk_tiles,
     const uint32_t k_chunk_tiles,
+    const uint32_t v_chunk_tiles,
     const uint32_t qk_chunk_tiles,
     const uint32_t out_chunk_tiles,
     const uint32_t cb_q_in,
@@ -2071,10 +2097,10 @@ void sdpa_standard(
         0,  // cb_scale_in (not used)
         Sq_chunk_t,
         Sk_chunk_t,
+        0,  // NH (not used)
         DHt,
         vDHt,
         use_attention_sink,
-        is_causal,
         use_provided_mask,
         use_padded_mask,
         false,  // use_joint_mask (not used)
@@ -2103,6 +2129,7 @@ void sdpa_standard(
         k_num_chunks,  // iter_k_chunk_end
         q_chunk_tiles,
         k_chunk_tiles,
+        v_chunk_tiles,
         qk_chunk_tiles,
         out_chunk_tiles,
         0,      // mask_chunk_0 (not used)
@@ -2133,7 +2160,9 @@ void sdpa_standard(
         0,  // cb_lse_in (not used)
         0,  // cb_lse_out (not used)
         0,  // cb_prev_out (not used)
-        cb_out);
+        cb_out,
+        {},  // lw_mask (not used)
+        is_causal);
 }
 
 /**
@@ -2191,10 +2220,10 @@ void sdpa_joint(
         0,  // cb_scale_in (not used)
         Sq_chunk_t,
         Sk_chunk_t,
+        0,  // NH (not used)
         DHt,
         DHt,    // vDHt = DHt
         false,  // use_attention_sink (not used)
-        false,  // is_causal (not used)
         false,  // use_provided_mask (not used)
         false,  // use_padded_mask (not used)
         use_joint_mask,
@@ -2222,6 +2251,7 @@ void sdpa_joint(
         0,             // iter_k_chunk_start
         k_num_chunks,  // iter_k_chunk_end
         q_chunk_tiles,
+        k_chunk_tiles,
         k_chunk_tiles,
         qk_chunk_tiles,
         out_chunk_tiles,
@@ -2265,7 +2295,9 @@ template <
     uint32_t cb_scale_in,
     uint32_t Sq_chunk_t,
     uint32_t Sk_chunk_t,
+    uint32_t NH,
     uint32_t DHt,
+    uint32_t vDHt,
     uint32_t scale_fp32>
 void sdpa_ring(
     const uint32_t qk_in0_block_w,
@@ -2282,10 +2314,12 @@ void sdpa_ring(
     const uint32_t out_num_blocks,
     const uint32_t global_q_start,
     const uint32_t global_q_end,
+    const uint32_t q_num_chunks,
     const uint32_t iter_k_chunk_start,
     const uint32_t iter_k_chunk_end,
     const uint32_t q_chunk_tiles,
     const uint32_t k_chunk_tiles,
+    const uint32_t v_chunk_tiles,
     const uint32_t qk_chunk_tiles,
     const uint32_t out_chunk_tiles,
     const uint32_t ring_iter,
@@ -2315,7 +2349,9 @@ void sdpa_ring(
     const uint32_t cb_lse_out,
     const uint32_t cb_prev_out,
     const uint32_t cb_out,
-    const LightweightMaskContext& lw_mask) {
+    const LightweightMaskContext& lw_mask,
+    const bool is_causal,
+    const bool is_balanced) {
     sdpa_inner_loop<
         RING,
         cb_qk_im,
@@ -2324,10 +2360,10 @@ void sdpa_ring(
         cb_scale_in,
         Sq_chunk_t,
         Sk_chunk_t,
+        NH,
         DHt,
-        DHt,    // vDHt = DHt
+        vDHt,
         false,  // use_attention_sink (not used)
-        false,  // is_causal (not used)
         false,  // use_provided_mask (not used)
         false,  // use_padded_mask (not used)
         false,  // use_joint_mask (not used)
@@ -2349,13 +2385,14 @@ void sdpa_ring(
         out_num_blocks,
         global_q_start,  // iter_q_start
         global_q_end,    // iter_q_end
-        0,               // q_num_chunks (not used)
+        q_num_chunks,    // q_num_chunks (number of local q chunks)
         0,               // local_q_start (not used)
         0,               // chunked_q_chunk_offset (not used)
-        iter_k_chunk_start,
+        0,
         iter_k_chunk_end,
         q_chunk_tiles,
         k_chunk_tiles,
+        v_chunk_tiles,
         qk_chunk_tiles,
         out_chunk_tiles,
         0,  // mask_chunk_0 (not used)
@@ -2387,7 +2424,9 @@ void sdpa_ring(
         cb_lse_out,
         cb_prev_out,
         cb_out,
-        lw_mask);
+        lw_mask,
+        is_causal,
+        is_balanced);
 }
 
 /**
@@ -2441,10 +2480,10 @@ void sdpa_windowed(
         0,  // cb_scale_in (not used)
         Sq_chunk_t,
         Sk_chunk_t,
+        0,  // NH (not used)
         DHt,
         DHt,    // vDHt = DHt
         false,  // use_attention_sink (not used)
-        false,  // is_causal (not used)
         true,   // use_provided_mask (used)
         false,  // use_padded_mask (not used)
         false,  // use_joint_mask (not used)
@@ -2472,6 +2511,7 @@ void sdpa_windowed(
         0,  // iter_k_chunk_start
         0,  // iter_k_chunk_end (not used -- uses Skt)
         q_chunk_tiles,
+        k_chunk_tiles,
         k_chunk_tiles,
         qk_chunk_tiles,
         out_chunk_tiles,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
@@ -16,41 +16,44 @@
 void kernel_main() {
     constexpr uint32_t B = get_compile_time_arg_val(0);
     constexpr uint32_t NH = get_compile_time_arg_val(1);
-    constexpr uint32_t DHt = get_compile_time_arg_val(2);
-    constexpr uint32_t Sq_chunk_t = get_compile_time_arg_val(3);
-    constexpr uint32_t Sk_chunk_t = get_compile_time_arg_val(4);
-    constexpr uint32_t local_padded_N = get_compile_time_arg_val(5);
-    constexpr uint32_t local_padded_Nt = get_compile_time_arg_val(6);
-    constexpr uint32_t padded_Nt = get_compile_time_arg_val(7);
-    constexpr uint32_t logical_n = get_compile_time_arg_val(8);
-    constexpr uint32_t logical_nt = get_compile_time_arg_val(9);
-    constexpr uint32_t Lt = get_compile_time_arg_val(10);
-    constexpr uint32_t L = get_compile_time_arg_val(11);
-    constexpr uint32_t num_local_q_chunks = get_compile_time_arg_val(12);
-    constexpr uint32_t num_joint_q_chunks = get_compile_time_arg_val(13);
-    constexpr uint32_t num_local_k_chunks = get_compile_time_arg_val(14);
-    constexpr uint32_t num_joint_k_chunks = get_compile_time_arg_val(15);
-    constexpr uint32_t num_q_chunks = get_compile_time_arg_val(16);
-    constexpr uint32_t ring_size = get_compile_time_arg_val(17);
+    constexpr uint32_t NHK = get_compile_time_arg_val(2);
+    constexpr uint32_t DHt = get_compile_time_arg_val(3);
+    constexpr uint32_t vDHt = get_compile_time_arg_val(4);
+    constexpr uint32_t Sq_chunk_t = get_compile_time_arg_val(5);
+    constexpr uint32_t Sk_chunk_t = get_compile_time_arg_val(6);
+    constexpr uint32_t local_padded_N = get_compile_time_arg_val(7);
+    constexpr uint32_t local_padded_Nt = get_compile_time_arg_val(8);
+    constexpr uint32_t padded_Nt = get_compile_time_arg_val(9);
+    constexpr uint32_t logical_n = get_compile_time_arg_val(10);
+    constexpr uint32_t logical_nt = get_compile_time_arg_val(11);
+    constexpr uint32_t Lt = get_compile_time_arg_val(12);
+    constexpr uint32_t L = get_compile_time_arg_val(13);
+    constexpr uint32_t num_local_q_chunks = get_compile_time_arg_val(14);
+    constexpr uint32_t num_joint_q_chunks = get_compile_time_arg_val(15);
+    constexpr uint32_t num_local_k_chunks = get_compile_time_arg_val(16);
+    constexpr uint32_t num_joint_k_chunks = get_compile_time_arg_val(17);
+    constexpr uint32_t num_q_chunks = get_compile_time_arg_val(18);
+    constexpr uint32_t ring_size = get_compile_time_arg_val(19);
+    constexpr uint32_t qk_in0_block_w = get_compile_time_arg_val(20);
+    constexpr uint32_t qk_subblock_w = get_compile_time_arg_val(21);
+    constexpr uint32_t qk_subblock_h = get_compile_time_arg_val(22);
+    constexpr uint32_t qk_in0_num_subblocks = get_compile_time_arg_val(23);
+    constexpr uint32_t qk_in1_num_subblocks = get_compile_time_arg_val(24);
+    constexpr uint32_t qk_num_blocks = get_compile_time_arg_val(25);
+    constexpr uint32_t out_in0_block_w = get_compile_time_arg_val(26);
+    constexpr uint32_t out_subblock_w = get_compile_time_arg_val(27);
+    constexpr uint32_t out_subblock_h = get_compile_time_arg_val(28);
+    constexpr uint32_t out_in0_num_subblocks = get_compile_time_arg_val(29);
+    constexpr uint32_t out_in1_num_subblocks = get_compile_time_arg_val(30);
+    constexpr uint32_t out_num_blocks = get_compile_time_arg_val(31);
 
-    constexpr uint32_t qk_in0_block_w = get_compile_time_arg_val(18);
-    constexpr uint32_t qk_subblock_w = get_compile_time_arg_val(19);
-    constexpr uint32_t qk_subblock_h = get_compile_time_arg_val(20);
-    constexpr uint32_t qk_in0_num_subblocks = get_compile_time_arg_val(21);
-    constexpr uint32_t qk_in1_num_subblocks = get_compile_time_arg_val(22);
-    constexpr uint32_t qk_num_blocks = get_compile_time_arg_val(23);
-    constexpr uint32_t out_in0_block_w = get_compile_time_arg_val(24);
-    constexpr uint32_t out_subblock_w = get_compile_time_arg_val(25);
-    constexpr uint32_t out_subblock_h = get_compile_time_arg_val(26);
-    constexpr uint32_t out_in0_num_subblocks = get_compile_time_arg_val(27);
-    constexpr uint32_t out_in1_num_subblocks = get_compile_time_arg_val(28);
-    constexpr uint32_t out_num_blocks = get_compile_time_arg_val(29);
-
-    constexpr uint32_t scale_fp32 = get_compile_time_arg_val(30);
-    constexpr bool use_streaming_compute = get_compile_time_arg_val(31) == 1;
-    constexpr uint32_t global_n_partial_col = get_compile_time_arg_val(32);
-    constexpr uint32_t joint_l_partial_col = get_compile_time_arg_val(33);
-    constexpr bool uniform_dataformat = get_compile_time_arg_val(34) == 1;
+    constexpr uint32_t scale_fp32 = get_compile_time_arg_val(32);
+    constexpr bool use_streaming_compute = get_compile_time_arg_val(33) == 1;
+    constexpr uint32_t global_n_partial_col = get_compile_time_arg_val(34);
+    constexpr uint32_t joint_l_partial_col = get_compile_time_arg_val(35);
+    constexpr bool uniform_dataformat = get_compile_time_arg_val(36) == 1;
+    constexpr bool is_causal = get_compile_time_arg_val(37) == 1;
+    constexpr bool is_balanced = get_compile_time_arg_val(38) == 1;
 
     // Lightweight mask: all mask tiles live in cb_mask_in (c_3).
     // Layout: [neginf(0)] [global_n_partial?(1)] [joint_l_partial?(1 or 2)]
@@ -58,7 +61,7 @@ void kernel_main() {
     constexpr bool local_n_has_padding = local_padded_Nt % Sk_chunk_t != 0;
     constexpr bool global_n_has_padding = logical_n % (Sk_chunk_t * tt::constants::TILE_HEIGHT) != 0;
     constexpr bool joint_has_padding = L > 0 && L % (Sk_chunk_t * tt::constants::TILE_HEIGHT) != 0;
-    constexpr bool needs_lightweight_mask = local_n_has_padding || global_n_has_padding || joint_has_padding;
+    constexpr bool needs_lightweight_mask = (local_n_has_padding || global_n_has_padding || joint_has_padding) && !is_causal;
 
     constexpr uint32_t neginf_tile_idx = 0;
     constexpr uint32_t global_n_partial_tile_idx = (global_n_partial_col > 0) ? 1 : 0;
@@ -75,8 +78,9 @@ void kernel_main() {
 
     constexpr uint32_t q_chunk_tiles = Sq_chunk_t * DHt;
     constexpr uint32_t k_chunk_tiles = Sk_chunk_t * DHt;
+    constexpr uint32_t v_chunk_tiles = Sk_chunk_t * vDHt;
     constexpr uint32_t qk_chunk_tiles = Sq_chunk_t * Sk_chunk_t;
-    constexpr uint32_t out_chunk_tiles = Sq_chunk_t * DHt;
+    constexpr uint32_t out_chunk_tiles = Sq_chunk_t * vDHt;
 
     constexpr uint32_t cb_q_in = tt::CBIndex::c_0;
     constexpr uint32_t cb_k_in = tt::CBIndex::c_1;
@@ -133,6 +137,8 @@ void kernel_main() {
     const uint32_t last_active_ring_iter =
         find_last_active_ring_iter(fused_op_indexer.seq, local_padded_Nt, logical_n / tt::constants::TILE_HEIGHT, L);
 
+    uint32_t ring_index = fused_op_indexer.seq.ring_index;
+    uint32_t half_sequence = num_q_chunks / 2;
     for (uint32_t ring_iter = 0; ring_iter < ring_size; ++ring_iter) {
         uint32_t ring_id = fused_op_indexer.get_next_ring_id_and_sync();
         const bool do_joint_kv = ring_id == ring_size - 1;
@@ -143,7 +149,8 @@ void kernel_main() {
         const uint32_t ring_iter_kv_end_tile = ring_iter_kv_start_tile + num_local_k_chunks * Sk_chunk_t;
         const uint32_t global_n_tile_id = logical_n / tt::constants::TILE_HEIGHT;
         const bool ring_iter_processes_KV_chunks = ring_iter_kv_start_tile <= global_n_tile_id;
-        const bool ring_iter_does_work = ring_iter_processes_KV_chunks || (do_joint_kv && L != 0);
+        const bool ring_iter_does_work = (ring_iter_processes_KV_chunks || (do_joint_kv && L != 0)) &&
+                                         !(is_causal && ring_index < ring_id && !is_balanced);
 
         if (!ring_iter_does_work) {
             continue;
@@ -233,7 +240,15 @@ void kernel_main() {
                 q_per_core,
                 lw_mask);
         } else {
-            sdpa_ring<cb_qk_im, cb_identity_scale_in, cb_scale_in, Sq_chunk_t, Sk_chunk_t, DHt, scale_fp32>(
+            bool causality = (ring_iter == 0 ? is_causal : false);
+
+            uint32_t iter_num_kv_chunks = num_kv_chunks;
+            if (is_causal && is_balanced && ring_index > ring_id) {
+                iter_num_kv_chunks /= 2;
+            }
+            bool balancing = (ring_index >= ring_id ? false : is_balanced);
+
+            sdpa_ring<cb_qk_im, cb_identity_scale_in, cb_scale_in, Sq_chunk_t, Sk_chunk_t, NH, DHt, vDHt, scale_fp32>(
                 qk_in0_block_w,
                 qk_subblock_w,
                 qk_subblock_h,
@@ -248,10 +263,12 @@ void kernel_main() {
                 out_num_blocks,
                 global_q_start,
                 global_q_end,
+                num_local_q_chunks,
                 0,
-                num_kv_chunks,
+                iter_num_kv_chunks,
                 q_chunk_tiles,
                 k_chunk_tiles,
+                v_chunk_tiles,
                 qk_chunk_tiles,
                 out_chunk_tiles,
                 ring_iter,
@@ -281,7 +298,9 @@ void kernel_main() {
                 cb_lse_out,
                 cb_prev_out,
                 cb_out,
-                lw_mask);
+                lw_mask,
+                causality,
+                balancing);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
@@ -69,6 +69,7 @@ void kernel_main() {
 
     constexpr uint32_t q_chunk_tiles = Sq_chunk_t * DHt;
     constexpr uint32_t k_chunk_tiles = Sk_chunk_t * DHt;
+    constexpr uint32_t v_chunk_tiles = Sk_chunk_t * vDHt;
     constexpr uint32_t qk_chunk_tiles = Sq_chunk_t * Sk_chunk_t;
     constexpr uint32_t out_chunk_tiles = Sq_chunk_t * vDHt;
 
@@ -200,6 +201,7 @@ void kernel_main() {
                         k_num_chunks,
                         q_chunk_tiles,
                         k_chunk_tiles,
+                        v_chunk_tiles,
                         qk_chunk_tiles,
                         out_chunk_tiles,
                         cb_q_in,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
@@ -1077,12 +1077,7 @@ void fill_attention_sink_tiles(uint32_t cb_id, uint32_t num_tiles, uint32_t sour
     }
 }
 
-template <
-    bool is_causal,
-    bool is_chunked,
-    uint32_t sliding_window_size,
-    bool padded_or_joint_masks,
-    uint32_t cb_mask_in>
+template <bool is_chunked, uint32_t sliding_window_size, bool padded_or_joint_masks, uint32_t cb_mask_in>
 void generate_mask(
     const uint32_t Sq_chunk_t,
     const uint32_t Sk_chunk_t,
@@ -1091,8 +1086,9 @@ void generate_mask(
     const bool generate_mask_0,
     const bool generate_mask_1,
     const uint32_t unpadded_Sk_mask_0,
-    const uint32_t unpadded_Sk_mask_1) {
-    if constexpr (is_causal || sliding_window_size > 0) {
+    const uint32_t unpadded_Sk_mask_1,
+    const bool is_causal) {
+    if (is_causal || sliding_window_size > 0) {
         uint32_t offset_q_chunk = q_chunk;
         if constexpr (is_chunked) {
             // Bump it up to the chunk start

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/joint_writer.cpp
@@ -63,7 +63,7 @@ void kernel_main() {
     for (uint32_t nb = local_batch_start; nb < local_batch_end; ++nb) {
         for (uint32_t nq = local_nh_start; nq < local_nh_end; ++nq) {
             for (uint32_t q_chunk = local_q_start; q_chunk < local_q_end; ++q_chunk) {
-                generate_mask<false, false, 0, use_joint_mask, cb_mask_in>(
+                generate_mask<false, 0, use_joint_mask, cb_mask_in>(
                     Sq_chunk_t,
                     Sk_chunk_t,
                     q_chunk,
@@ -71,7 +71,8 @@ void kernel_main() {
                     mask_chunk_0 != (uint32_t)(-1),
                     mask_chunk_1 != (uint32_t)(-1),
                     unpadded_N,
-                    unpadded_L);
+                    unpadded_L,
+                    false);
 
                 const uint32_t out_row_start_tile = q_chunk * Sq_chunk_t;
                 const auto dst_slice = Slice(nb, nq, out_row_start_tile, out_row_start_tile + Sq_chunk_t, 0, DHt);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
@@ -10,25 +10,29 @@
 void kernel_main() {
     constexpr uint32_t B = get_compile_time_arg_val(0);
     constexpr uint32_t NH = get_compile_time_arg_val(1);
-    constexpr uint32_t DHt = get_compile_time_arg_val(2);
-    constexpr uint32_t Sq_chunk_t = get_compile_time_arg_val(3);
-    constexpr uint32_t Sk_chunk_t = get_compile_time_arg_val(4);
-    constexpr uint32_t local_padded_N = get_compile_time_arg_val(5);
-    constexpr uint32_t local_padded_Nt = get_compile_time_arg_val(6);
-    constexpr uint32_t padded_Nt = get_compile_time_arg_val(7);
-    constexpr uint32_t logical_n = get_compile_time_arg_val(8);
-    constexpr uint32_t logical_nt = get_compile_time_arg_val(9);
-    constexpr uint32_t Lt = get_compile_time_arg_val(10);
-    constexpr uint32_t L = get_compile_time_arg_val(11);
-    constexpr uint32_t num_local_q_chunks = get_compile_time_arg_val(12);
-    constexpr uint32_t num_joint_q_chunks = get_compile_time_arg_val(13);
-    constexpr uint32_t num_local_k_chunks = get_compile_time_arg_val(14);
-    constexpr uint32_t num_joint_k_chunks = get_compile_time_arg_val(15);
-    constexpr uint32_t num_q_chunks = get_compile_time_arg_val(16);
-    constexpr uint32_t ring_size = get_compile_time_arg_val(17);
-    constexpr uint32_t qk_subblock_h = get_compile_time_arg_val(18);
+    constexpr uint32_t NHK = get_compile_time_arg_val(2);
+    constexpr uint32_t DHt = get_compile_time_arg_val(3);
+    constexpr uint32_t vDHt = get_compile_time_arg_val(4);
+    constexpr uint32_t Sq_chunk_t = get_compile_time_arg_val(5);
+    constexpr uint32_t Sk_chunk_t = get_compile_time_arg_val(6);
+    constexpr uint32_t local_padded_N = get_compile_time_arg_val(7);
+    constexpr uint32_t local_padded_Nt = get_compile_time_arg_val(8);
+    constexpr uint32_t padded_Nt = get_compile_time_arg_val(9);
+    constexpr uint32_t logical_n = get_compile_time_arg_val(10);
+    constexpr uint32_t logical_nt = get_compile_time_arg_val(11);
+    constexpr uint32_t Lt = get_compile_time_arg_val(12);
+    constexpr uint32_t L = get_compile_time_arg_val(13);
+    constexpr uint32_t num_local_q_chunks = get_compile_time_arg_val(14);
+    constexpr uint32_t num_joint_q_chunks = get_compile_time_arg_val(15);
+    constexpr uint32_t num_local_k_chunks = get_compile_time_arg_val(16);
+    constexpr uint32_t num_joint_k_chunks = get_compile_time_arg_val(17);
+    constexpr uint32_t num_q_chunks = get_compile_time_arg_val(18);
+    constexpr uint32_t ring_size = get_compile_time_arg_val(19);
+    constexpr uint32_t qk_subblock_h = get_compile_time_arg_val(20);
+    constexpr uint32_t is_causal = get_compile_time_arg_val(21);
+    constexpr uint32_t is_balanced = get_compile_time_arg_val(22);
 
-    constexpr auto q_args = TensorAccessorArgs<19>();
+    constexpr auto q_args = TensorAccessorArgs<23>();
     constexpr auto k_args = TensorAccessorArgs<q_args.next_compile_time_args_offset()>();
     constexpr auto v_args = TensorAccessorArgs<k_args.next_compile_time_args_offset()>();
     constexpr auto gathered_k_args = TensorAccessorArgs<v_args.next_compile_time_args_offset()>();
@@ -122,9 +126,10 @@ void kernel_main() {
     constexpr uint32_t v_tile_bytes = get_tile_size(cb_v_in);
 
     constexpr uint32_t k_chunk_tiles = Sk_chunk_t * DHt;
-    constexpr uint32_t v_chunk_tiles = Sk_chunk_t * DHt;
+    constexpr uint32_t v_chunk_tiles = Sk_chunk_t * vDHt;
     constexpr uint32_t q_num_subblocks = Sq_chunk_t / qk_subblock_h;
     constexpr bool use_q_subblock_push = (q_num_subblocks > 1);
+    constexpr uint32_t q_heads_per_k = NH / NHK;
 
     const auto q_reader = TensorAccessor(q_args, q_addr, q_tile_bytes);
     const auto local_k_reader = TensorAccessor(k_args, k_addr, k_tile_bytes);
@@ -135,15 +140,18 @@ void kernel_main() {
     const auto joint_k_reader = TensorAccessor(joint_k_args, joint_k_addr, k_tile_bytes);
     const auto joint_v_reader = TensorAccessor(joint_v_args, joint_v_addr, v_tile_bytes);
 
-    const auto input_tile_logical = TensorTileShape(B, NH, local_padded_Nt, DHt);
-    const auto gathered_kv_input_tile_logical = TensorTileShape(B, NH, padded_Nt, DHt);
+    const auto input_q_tile_logical = TensorTileShape(B, NH, local_padded_Nt, DHt);
+    const auto input_k_tile_logical = TensorTileShape(B, NHK, local_padded_Nt, DHt);
+    const auto input_v_tile_logical = TensorTileShape(B, NH, local_padded_Nt, vDHt);
+    const auto gathered_k_input_tile_logical = TensorTileShape(B, NHK, padded_Nt, DHt);
+    const auto gathered_v_input_tile_logical = TensorTileShape(B, NH, padded_Nt, vDHt);
     const auto joint_input_tile_logical = TensorTileShape(B, NH, Lt, DHt);
 
-    const auto q_generator = PaddedAddrGenerator(q_reader, input_tile_logical);
-    const auto local_k_generator = PaddedAddrGenerator(local_k_reader, input_tile_logical);
-    const auto local_v_generator = PaddedAddrGenerator(local_v_reader, input_tile_logical);
-    const auto gathered_k_generator = PaddedAddrGenerator(gathered_k_reader, gathered_kv_input_tile_logical);
-    const auto gathered_v_generator = PaddedAddrGenerator(gathered_v_reader, gathered_kv_input_tile_logical);
+    const auto q_generator = PaddedAddrGenerator(q_reader, input_q_tile_logical);
+    const auto local_k_generator = PaddedAddrGenerator(local_k_reader, input_k_tile_logical);
+    const auto local_v_generator = PaddedAddrGenerator(local_v_reader, input_v_tile_logical);
+    const auto gathered_k_generator = PaddedAddrGenerator(gathered_k_reader, gathered_k_input_tile_logical);
+    const auto gathered_v_generator = PaddedAddrGenerator(gathered_v_reader, gathered_v_input_tile_logical);
     const auto joint_q_generator = PaddedAddrGenerator(joint_q_reader, joint_input_tile_logical);
     const auto joint_k_generator = PaddedAddrGenerator(joint_k_reader, joint_input_tile_logical);
     const auto joint_v_generator = PaddedAddrGenerator(joint_v_reader, joint_input_tile_logical);
@@ -153,6 +161,8 @@ void kernel_main() {
      * On the first iteration, read from local K, V.
      * On subsequent iterations, read from gathered K, V. Sync with AllGather fused signaler.
      */
+    uint32_t ring_index = fused_op_receiver.seq.ring_index;
+    uint32_t half_sequence = num_q_chunks / 2;
     for (uint32_t ring_iter = 0; ring_iter < ring_size; ++ring_iter) {
         // find out which is the latest ring_id that synchronized
         uint32_t ring_id = fused_op_receiver.get_next_ring_id_and_sync();
@@ -164,11 +174,31 @@ void kernel_main() {
         const uint32_t global_n_tile_id = logical_n / tt::constants::TILE_HEIGHT;  // Floor division to get tile ID
         const uint32_t ring_iter_kv_start_tile = ring_id * local_padded_Nt;
         const bool ring_iter_processes_KV_chunks = ring_iter_kv_start_tile <= global_n_tile_id;
-        const bool ring_iter_does_work = ring_iter_processes_KV_chunks || (do_joint_kv && L != 0);
+
+        // In causal non balanced case when processing KV received from other devices:
+        // - skip over KV received from subsequent devices
+        // - do non-causal attention on the KV from preceding devices
+        const bool ring_iter_does_work = (ring_iter_processes_KV_chunks || (do_joint_kv && L != 0)) &&
+                                         !(is_causal && ring_index < ring_id && !is_balanced);
 
         uint32_t KV_chunks_processed_in_iter = 0;
         if (!ring_iter_does_work) {
             continue;
+        }
+
+        uint32_t iter_num_kv_chunks = num_kv_chunks;
+
+        // In causal balanced case processing KV received from other devices:
+        //
+        // We will have two logical chunks of the input sequence, logical indexes are:
+        // ring_index and (seq_len / 2 * num_devices) - ring_index
+        //
+        // With this in mind we have two distinct cases when receiving from other device:
+        // - 1st part of the sequence precedes both chunks on the sender device, 2nd part attends to both
+        // - both chunks preced 2nd part of the sequence in received KV
+        // Indexes are updated accordingly; compute is skipped
+        if (is_causal && is_balanced && ring_index > ring_id) {
+            iter_num_kv_chunks /= 2;
         }
 
         for (uint32_t global_q_chunk = global_q_start; global_q_chunk < global_q_end; ++global_q_chunk) {
@@ -178,6 +208,10 @@ void kernel_main() {
             const uint32_t q_chunk = global_q_chunk % num_q_chunks;
             const auto q_row_start_tile = q_chunk * Sq_chunk_t;
             const bool is_joint_q = q_chunk >= num_local_q_chunks;
+
+            if (q_chunk < half_sequence && is_balanced && ring_index < ring_id) {
+                continue;
+            }
 
             Slice q_slice;
             uint32_t q_end_seq_tile;
@@ -198,7 +232,7 @@ void kernel_main() {
                                         (q_iter_local < next_core_q_chunks);
             const bool should_receive = is_chain_participant && !is_injector && (nb == chain_batch && nq == chain_head);
 
-            for (uint32_t k_chunk = 0; k_chunk < num_kv_chunks; ++k_chunk) {
+            for (uint32_t k_chunk = 0; k_chunk < iter_num_kv_chunks; ++k_chunk) {
                 /**
                  * Iterate over all KV chunks for this Q chunk.
                  * If this is the last ring ID, we will also read from joint KV.
@@ -215,25 +249,32 @@ void kernel_main() {
                 }
                 KV_chunks_processed_in_iter++;
 
-                Slice kv_slice;
+                Slice k_slice;
+                Slice v_slice;
                 uint32_t
                     end_seq_tile;  // further information to `read_block` to determine whether it should pad with zeros.
 
+                const uint32_t nk = nq / q_heads_per_k;
                 if (kv_chunk_is_joint) {
                     const uint32_t joint_k_chunk = k_chunk - num_local_k_chunks;
                     const uint32_t joint_k_row_start_tile = joint_k_chunk * Sk_chunk_t;
-                    kv_slice = Slice(nb, nq, joint_k_row_start_tile, joint_k_row_start_tile + Sk_chunk_t, 0, DHt);
+
+                    k_slice = Slice(nb, nk, joint_k_row_start_tile, joint_k_row_start_tile + Sk_chunk_t, 0, DHt);
+                    v_slice = Slice(nb, nq, joint_k_row_start_tile, joint_k_row_start_tile + Sk_chunk_t, 0, vDHt);
                     end_seq_tile = Lt;
                 } else {
                     if (ring_iter == 0) {
                         // Local KV
                         const uint32_t local_k_row_start_tile = k_chunk * Sk_chunk_t;
-                        kv_slice = Slice(nb, nq, local_k_row_start_tile, local_k_row_start_tile + Sk_chunk_t, 0, DHt);
+
+                        k_slice = Slice(nb, nk, local_k_row_start_tile, local_k_row_start_tile + Sk_chunk_t, 0, DHt);
+                        v_slice = Slice(nb, nq, local_k_row_start_tile, local_k_row_start_tile + Sk_chunk_t, 0, vDHt);
                         end_seq_tile = std::min(logical_nt, local_padded_Nt);
                     } else {
                         // Gathered KV
                         const uint32_t gathered_kv_start_tile = ring_iter_kv_start_tile + k_chunk * Sk_chunk_t;
-                        kv_slice = Slice(nb, nq, gathered_kv_start_tile, gathered_kv_start_tile + Sk_chunk_t, 0, DHt);
+                        k_slice = Slice(nb, nk, gathered_kv_start_tile, gathered_kv_start_tile + Sk_chunk_t, 0, DHt);
+                        v_slice = Slice(nb, nq, gathered_kv_start_tile, gathered_kv_start_tile + Sk_chunk_t, 0, vDHt);
                         end_seq_tile = std::min(logical_nt, local_padded_Nt * (ring_id + 1));
                     }
                 }
@@ -251,7 +292,7 @@ void kernel_main() {
                     read_block(
                         kv_chunk_is_joint ? joint_k_generator
                                           : (ring_iter == 0 ? local_k_generator : gathered_k_generator),
-                        kv_slice,
+                        k_slice,
                         end_seq_tile,
                         cb_k_in,
                         k_tile_bytes,
@@ -288,13 +329,17 @@ void kernel_main() {
                 // (noc_async_read_barrier inside subblock read would deadlock with in-flight writes).
                 if (k_chunk == 0) {
                     if constexpr (use_q_subblock_push) {
-                        const auto& q_gen = is_joint_q ? joint_q_generator : q_generator;
                         for (uint32_t q_sub = 0; q_sub < q_num_subblocks; ++q_sub) {
                             const uint32_t sb_row_start = q_slice.d2_start + q_sub * qk_subblock_h;
                             const uint32_t sb_row_end = sb_row_start + qk_subblock_h;
                             Slice q_sub_slice(q_slice.d0, q_slice.d1, sb_row_start, sb_row_end, 0, DHt);
                             read_block(
-                                q_gen, q_sub_slice, q_end_seq_tile, cb_q_in, q_tile_bytes, false /*transpose*/
+                                is_joint_q ? joint_q_generator : q_generator,
+                                q_sub_slice,
+                                q_end_seq_tile,
+                                cb_q_in,
+                                q_tile_bytes,
+                                false /*transpose*/
                             );
                         }
                     } else {
@@ -322,7 +367,7 @@ void kernel_main() {
                     read_block(
                         kv_chunk_is_joint ? joint_v_generator
                                           : (ring_iter == 0 ? local_v_generator : gathered_v_generator),
-                        kv_slice,
+                        v_slice,
                         end_seq_tile,
                         cb_v_in,
                         v_tile_bytes,
@@ -355,9 +400,9 @@ void kernel_main() {
         }
         if (KV_chunks_processed_in_iter % 2 == 0) {
             cb_reserve_back(cb_k_in, k_chunk_tiles);
-            cb_reserve_back(cb_v_in, k_chunk_tiles);
+            cb_reserve_back(cb_v_in, v_chunk_tiles);
             cb_push_back(cb_k_in, k_chunk_tiles);
-            cb_push_back(cb_v_in, k_chunk_tiles);
+            cb_push_back(cb_v_in, v_chunk_tiles);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
@@ -283,29 +283,34 @@ inline QChunkInfo get_q_chunk_info(
 void kernel_main() {
     constexpr uint32_t B = get_compile_time_arg_val(0);
     constexpr uint32_t NH = get_compile_time_arg_val(1);
-    constexpr uint32_t DHt = get_compile_time_arg_val(2);
-    constexpr uint32_t Sq_chunk_t = get_compile_time_arg_val(3);
-    constexpr uint32_t Sk_chunk_t = get_compile_time_arg_val(4);
-    constexpr uint32_t local_padded_N = get_compile_time_arg_val(5);
-    constexpr uint32_t local_padded_Nt = get_compile_time_arg_val(6);
-    constexpr uint32_t padded_Nt = get_compile_time_arg_val(7);
-    constexpr uint32_t logical_n = get_compile_time_arg_val(8);
-    constexpr uint32_t logical_nt = get_compile_time_arg_val(9);
-    constexpr uint32_t Lt = get_compile_time_arg_val(10);
-    constexpr uint32_t L = get_compile_time_arg_val(11);
-    constexpr uint32_t num_local_q_chunks = get_compile_time_arg_val(12);
-    constexpr uint32_t num_joint_q_chunks = get_compile_time_arg_val(13);
-    constexpr uint32_t num_local_k_chunks = get_compile_time_arg_val(14);
-    constexpr uint32_t num_joint_k_chunks = get_compile_time_arg_val(15);
-    constexpr uint32_t num_q_chunks = get_compile_time_arg_val(16);
-    constexpr uint32_t identity_scalar_packed = get_compile_time_arg_val(17);
-    constexpr uint32_t scale_val = get_compile_time_arg_val(18);
-    constexpr uint32_t ring_size = get_compile_time_arg_val(19);
-    constexpr uint32_t global_n_partial_col = get_compile_time_arg_val(20);
-    constexpr uint32_t joint_l_partial_col = get_compile_time_arg_val(21);
-    constexpr bool use_streaming_compute = get_compile_time_arg_val(22) == 1;
+    constexpr uint32_t NHK = get_compile_time_arg_val(2);
+    constexpr uint32_t DHt = get_compile_time_arg_val(3);
+    constexpr uint32_t vDHt = get_compile_time_arg_val(4);
+    constexpr uint32_t Sq_chunk_t = get_compile_time_arg_val(5);
+    constexpr uint32_t Sk_chunk_t = get_compile_time_arg_val(6);
+    constexpr uint32_t local_padded_N = get_compile_time_arg_val(7);
+    constexpr uint32_t local_padded_Nt = get_compile_time_arg_val(8);
+    constexpr uint32_t padded_Nt = get_compile_time_arg_val(9);
+    constexpr uint32_t logical_n = get_compile_time_arg_val(10);
+    constexpr uint32_t logical_nt = get_compile_time_arg_val(11);
+    constexpr uint32_t Lt = get_compile_time_arg_val(12);
+    constexpr uint32_t L = get_compile_time_arg_val(13);
+    constexpr uint32_t num_local_q_chunks = get_compile_time_arg_val(14);
 
-    constexpr auto out_args = TensorAccessorArgs<23>();
+    constexpr uint32_t num_joint_q_chunks = get_compile_time_arg_val(15);
+    constexpr uint32_t num_local_k_chunks = get_compile_time_arg_val(16);
+    constexpr uint32_t num_joint_k_chunks = get_compile_time_arg_val(17);
+    constexpr uint32_t num_q_chunks = get_compile_time_arg_val(18);
+    constexpr uint32_t identity_scalar_packed = get_compile_time_arg_val(19);
+    constexpr uint32_t scale_val = get_compile_time_arg_val(20);
+    constexpr uint32_t ring_size = get_compile_time_arg_val(21);
+    constexpr uint32_t global_n_partial_col = get_compile_time_arg_val(22);
+    constexpr uint32_t joint_l_partial_col = get_compile_time_arg_val(23);
+    constexpr bool use_streaming_compute = get_compile_time_arg_val(24) == 1;
+    constexpr uint32_t is_causal = get_compile_time_arg_val(25) == 1;
+    constexpr uint32_t is_balanced = get_compile_time_arg_val(26) == 1;
+
+    constexpr auto out_args = TensorAccessorArgs<27>();
     constexpr auto joint_out_args = TensorAccessorArgs<out_args.next_compile_time_args_offset()>();
     constexpr auto stats_args = TensorAccessorArgs<joint_out_args.next_compile_time_args_offset()>();
 
@@ -338,8 +343,8 @@ void kernel_main() {
     const auto joint_out_writer = TensorAccessor(joint_out_args, joint_out_addr, tile_bytes);
     const auto stats_writer = TensorAccessor(stats_args, stats_addr, stats_tile_bytes);
 
-    const auto output_tile_logical = TensorTileShape(B, NH, local_padded_Nt, DHt);
-    const auto joint_tile_logical = TensorTileShape(B, NH, Lt, DHt);
+    const auto output_tile_logical = TensorTileShape(B, NH, local_padded_Nt, vDHt);
+    const auto joint_tile_logical = TensorTileShape(B, NH, Lt, vDHt);
     // stats tensor is 2× the sequence length: first half stores max (used by both eager and
     // deferred-norm paths), second half stores sum (deferred-norm only).
     const auto stats_tile_logical = TensorTileShape(B, NH, (local_padded_Nt + Lt) * 2, 1);
@@ -360,7 +365,7 @@ void kernel_main() {
     constexpr bool local_n_has_padding = local_padded_Nt % Sk_chunk_t != 0;
     constexpr bool global_n_has_padding = logical_n % (Sk_chunk_t * tt::constants::TILE_HEIGHT) != 0;
     constexpr bool joint_has_padding = L > 0 && L % (Sk_chunk_t * tt::constants::TILE_HEIGHT) != 0;
-    constexpr bool needs_lightweight_mask = local_n_has_padding || global_n_has_padding || joint_has_padding;
+    constexpr bool needs_lightweight_mask = (local_n_has_padding || global_n_has_padding || joint_has_padding) && !is_causal;
     if constexpr (needs_lightweight_mask) {
         generate_lightweight_mask_tiles<global_n_partial_col, joint_l_partial_col, cb_mask_in>();
     }
@@ -368,6 +373,8 @@ void kernel_main() {
     const uint32_t last_active_ring_iter =
         find_last_active_ring_iter(fused_op_receiver.seq, local_padded_Nt, logical_n / tt::constants::TILE_HEIGHT, L);
 
+    uint32_t ring_index = fused_op_receiver.seq.ring_index;
+    uint32_t half_sequence = num_q_chunks / 2;
     for (uint32_t ring_iter = 0; ring_iter < ring_size; ++ring_iter) {
         uint32_t ring_id = fused_op_receiver.get_next_ring_id_and_sync();
         const bool do_joint_kv = ring_id == ring_size - 1;
@@ -377,7 +384,8 @@ void kernel_main() {
         const uint32_t ring_iter_kv_end_tile = ring_iter_kv_start_tile + num_local_k_chunks * Sk_chunk_t;
         const uint32_t global_n_tile_id = logical_n / tt::constants::TILE_HEIGHT;
         const bool ring_iter_processes_KV_chunks = ring_iter_kv_start_tile <= global_n_tile_id;
-        const bool ring_iter_does_work = ring_iter_processes_KV_chunks || (do_joint_kv && L != 0);
+        const bool ring_iter_does_work = (ring_iter_processes_KV_chunks || (do_joint_kv && L != 0)) &&
+                                         !(is_causal && ring_index < ring_id && !is_balanced);
         if (!ring_iter_does_work) {
             continue;
         }
@@ -432,7 +440,7 @@ void kernel_main() {
                 const uint32_t q_chunk = global_q_chunk % num_q_chunks;
 
                 const auto qi = get_q_chunk_info(
-                    q_chunk, nb, nq, ring_id, num_local_q_chunks, Sq_chunk_t, DHt, Lt, local_padded_Nt);
+                    q_chunk, nb, nq, ring_id, num_local_q_chunks, Sq_chunk_t, vDHt, Lt, local_padded_Nt);
 
                 constexpr uint32_t sum_offset = local_padded_Nt + Lt;
 
@@ -492,7 +500,28 @@ void kernel_main() {
                 const uint32_t q_chunk = global_q_chunk % num_q_chunks;
 
                 const auto qi = get_q_chunk_info(
-                    q_chunk, nb, nq, ring_id, num_local_q_chunks, Sq_chunk_t, DHt, Lt, local_padded_Nt);
+                    q_chunk, nb, nq, ring_id, num_local_q_chunks, Sq_chunk_t, vDHt, Lt, local_padded_Nt);
+
+                // Only truly causal case appear in the iteration with local KV
+                // Other iterations will just skip the computation with subsequent KV chunks
+                bool causality = (ring_iter == 0 ? is_causal : false);
+
+                if (q_chunk < half_sequence && is_balanced && ring_index < ring_id) {
+                    continue;
+                }
+
+                if (is_causal) {
+                    generate_mask<false, 0, true, cb_mask_in>(
+                        Sq_chunk_t,
+                        Sk_chunk_t,
+                        q_chunk,
+                        0,
+                        ring_iter_needs_global_n_mask || ring_iter_needs_local_n_mask,
+                        ring_iter_needs_joint_n_mask,
+                        ring_iter_needs_global_n_mask ? global_n_within_ring_iter : local_padded_N,
+                        L,
+                        causality);
+                }
 
                 // If not on the first iteration, read LSE and previous output chunk.
                 // No race condition because writer kernel writes previous output before reading it again

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/writer_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/writer_interleaved.cpp
@@ -129,8 +129,16 @@ void kernel_main() {
                     // Generate mask only when user didn't provide one.
                     // Lightweight path already has a single -inf tile fronted — skip generate_mask.
                     if constexpr (!use_provided_mask && !use_lightweight_mask) {
-                        generate_mask<is_causal, is_chunked, sliding_window_size, use_padded_mask, cb_mask_in>(
-                            Sq_chunk_t, Sk_chunk_t, q_chunk, chunk_start_t_in_q_chunks, true, false, unpadded_Sk, 0);
+                        generate_mask<is_chunked, sliding_window_size, use_padded_mask, cb_mask_in>(
+                            Sq_chunk_t,
+                            Sk_chunk_t,
+                            q_chunk,
+                            chunk_start_t_in_q_chunks,
+                            true,
+                            false,
+                            unpadded_Sk,
+                            0,
+                            is_causal);
                     }
 
                     // Wait for compute to deliver output chunk

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
@@ -65,12 +65,14 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
 
     // Validate all tensors have the same dtype
     const auto dtype = input_tensor_q.dtype();
-    for (const auto& tensor : sdpa_input_tensors) {
-        TT_FATAL(
-            tensor.dtype() == dtype,
-            "All tensors must have the same dtype. Expected {}, got {}",
-            dtype,
-            tensor.dtype());
+    if (!args.is_causal) {
+        for (const auto& tensor : sdpa_input_tensors) {
+            TT_FATAL(
+                tensor.dtype() == dtype,
+                "All tensors must have the same dtype. Expected {}, got {}",
+                dtype,
+                tensor.dtype());
+        }
     }
 
     // Get shapes
@@ -99,10 +101,20 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
     const auto B = q_shape[0];
     const auto NQH = q_shape[1];
     const auto NKH = k_shape[1];
+    const auto NVH = v_shape[1];
     const auto N_local = q_shape[2];
     const auto N_global = k_shape[2];
     const auto L = joint_q_shape[2];
     const auto DH = q_shape[3];
+
+    auto q_chunk_size = args.get_q_chunk_size();
+    auto k_chunk_size = args.get_k_chunk_size();
+
+    TT_FATAL(!(L != 0 && args.is_causal), "Causality is enabled only for ring attention");
+
+    TT_FATAL(
+        !(args.is_balanced && (N_local / 2) % q_chunk_size != 0),
+        "q_chunk_size must divide half of local q seq_len in balanced case");
 
     TT_FATAL(
         k_shape[0] == B && v_shape[0] == B && joint_q_shape[0] == B && joint_k_shape[0] == B && joint_v_shape[0] == B,
@@ -115,26 +127,24 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
         joint_v_shape[0]);
 
     // Validate head dimensions match
-    TT_FATAL(
-        k_shape[3] == DH && v_shape[3] == DH && joint_q_shape[3] == DH && joint_k_shape[3] == DH &&
-            joint_v_shape[3] == DH,
-        "Head dimensions must match. Got Q: {}, K: {}, V: {}, joint_Q: {}, joint_K: {}, joint_V: {}",
-        DH,
-        k_shape[3],
-        v_shape[3],
-        joint_q_shape[3],
-        joint_k_shape[3],
-        joint_v_shape[3]);
-
-    TT_FATAL(
-        v_shape[1] == NKH && joint_q_shape[1] == NQH && joint_k_shape[1] == NKH && joint_v_shape[1] == NKH,
-        "Num heads must match. Got Q: {}, K: {}, V: {}, joint_Q: {}, joint_K: {}, joint_V: {}",
-        NQH,
-        NKH,
-        v_shape[1],
-        joint_q_shape[1],
-        joint_k_shape[1],
-        joint_v_shape[1]);
+    if (!args.is_causal) {
+        TT_FATAL(
+            k_shape[3] == DH && v_shape[3] == DH && joint_q_shape[3] == DH && joint_k_shape[3] == DH &&
+                joint_v_shape[3] == DH,
+            "Head dimensions must match. Got Q: {}, K: {}, V: {}, joint_Q: {}, joint_K: {}, joint_V: {}",
+            DH,
+            k_shape[3],
+            v_shape[3],
+            joint_q_shape[3],
+            joint_k_shape[3],
+            joint_v_shape[3]);
+    } else {
+        TT_FATAL(
+            k_shape[3] == DH && joint_k_shape[3] == DH,
+            "Q/K head dimensions must match. Got Q: {}, K: {}",
+            DH,
+            k_shape[3]);
+    }
 
     TT_FATAL(
         v_shape[2] == N_global,
@@ -185,11 +195,10 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
         k_shape[2],
         v_shape[2]);
 
-    TT_FATAL(NQH == NKH, "Q num_heads must be equal to K num_heads. Got Q: {}, K: {}", NQH, NKH);
+    TT_FATAL(NQH == NVH, "Q num_heads must be equal to V num_heads. Got Q: {}, V: {}", NQH, NVH);
+    TT_FATAL(NKH == NVH || NKH == 1, "K num_heads must be equal to V num_heads or 1. Got K: {}, V: {}", NKH, NVH);
 
     // Validate chunk sizes if program config is provided
-    auto q_chunk_size = args.get_q_chunk_size();
-    auto k_chunk_size = args.get_k_chunk_size();
 
     TT_FATAL(
         q_chunk_size % tt::constants::TILE_WIDTH == 0,
@@ -232,15 +241,16 @@ RingJointSDPAResultSpec RingJointSDPADeviceOperation::compute_output_specs(
     // Used as DRAM scratch for multi-Q-chunk deferred norm round-trips between ring iterations.
     stats_shape[2] = (input.padded_shape()[2] + joint_input.padded_shape()[2]) * 2;
 
+    auto out_shape = input.logical_shape();
+    // head dim as v head dim
+    out_shape[3] = tensor_args.input_v.logical_shape()[3];
+
     return {
-        TensorSpec(
-            input.logical_shape(),
-            TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), args.output_memory_config)),
+        TensorSpec(out_shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), args.output_memory_config)),
         TensorSpec(
             joint_input.logical_shape(),
             TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), args.output_memory_config)),
         TensorSpec(stats_shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), args.output_memory_config))};
-
 }
 
 RingJointSDPAResult RingJointSDPADeviceOperation::create_output_tensors(
@@ -269,6 +279,8 @@ ttsl::hash::hash_t RingJointSDPADeviceOperation::compute_program_hash(
         input_tensors,
         args.joint_strategy,
         args.scale,
+        args.is_causal,
+        args.is_balanced,
         args.logical_n,
         args.ring_size,
         args.compute_kernel_config,
@@ -353,6 +365,8 @@ RingJointSDPAResult ring_joint_scaled_dot_product_attention(
     const ttnn::ccl::Topology topology,
     const CoreCoord ccl_core_grid_offset,
     std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
+    const bool is_causal,
+    const bool is_balanced,
     const std::optional<float> scale,
     const std::optional<DeviceComputeKernelConfig> compute_kernel_config,
     const ttnn::ccl::CoreAllocationStrategy core_allocation_strategy) {
@@ -397,6 +411,8 @@ RingJointSDPAResult ring_joint_scaled_dot_product_attention(
     auto operation_attributes = OperationType::operation_attributes_t(
         joint_strategy,
         scale,
+        is_causal,
+        is_balanced,
         logical_n,
         num_devices,
         tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.hpp
@@ -49,6 +49,8 @@ RingJointSDPAResult ring_joint_scaled_dot_product_attention(
     ttnn::ccl::Topology topology,
     CoreCoord ccl_core_grid_offset,
     std::optional<tt::tt_metal::SubDeviceId> subdevice_id = std::nullopt,
+    bool is_causal = false,
+    bool is_balanced = false,
     std::optional<float> scale = std::nullopt,
     std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
     ttnn::ccl::CoreAllocationStrategy core_allocation_strategy = ttnn::ccl::CoreAllocationStrategy::ROW_MAJOR);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation_types.hpp
@@ -18,6 +18,8 @@ namespace ttnn::prim {
 struct RingJointSDPAParams {
     std::string joint_strategy;
     std::optional<float> scale;
+    bool is_causal = false;
+    bool is_balanced = false;
     std::size_t logical_n = 0;
     std::size_t ring_size = 0;
     tt::tt_metal::MemoryConfig output_memory_config;
@@ -31,6 +33,8 @@ struct RingJointSDPAParams {
     RingJointSDPAParams(
         std::string joint_strategy,
         std::optional<float> scale,
+        bool is_causal,
+        bool is_balanced,
         std::size_t logical_n,
         std::size_t ring_size,
         tt::tt_metal::MemoryConfig output_memory_config,
@@ -41,6 +45,8 @@ struct RingJointSDPAParams {
         CoreCoord ccl_core_grid_offset) :
         joint_strategy(std::move(joint_strategy)),
         scale(scale),
+        is_causal(is_causal),
+        is_balanced(is_balanced),
         logical_n(logical_n),
         ring_size(ring_size),
         output_memory_config(std::move(output_memory_config)),
@@ -54,6 +60,8 @@ struct RingJointSDPAParams {
         using ttsl::reflection::Attribute;
         std::vector<std::tuple<std::string, Attribute>> attrs;
         attrs.emplace_back("joint_strategy", joint_strategy);
+        attrs.emplace_back("is_causal", is_causal);
+        attrs.emplace_back("is_balanced", is_balanced);
         attrs.emplace_back("logical_n", logical_n);
         attrs.emplace_back("ring_size", ring_size);
         attrs.emplace_back("output_memory_config", output_memory_config);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -127,6 +127,10 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
         args.all_gather_operation_attributes.topology,
         args.all_gather_operation_attributes.cluster_axis);
 
+    log_debug(tt::LogOp, "device index: {}", device_index);
+    log_debug(tt::LogOp, "is_causal: {}", args.is_causal);
+    log_debug(tt::LogOp, "is_balanced: {}", args.is_balanced);
+
     auto scale = args.scale;
     if (not scale.has_value()) {
         scale = 1.0f / std::sqrt(static_cast<float>(input_tensor_q.logical_shape()[-1]));
@@ -161,15 +165,23 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     const auto& q_shape = input_tensor_q.logical_shape();
     const auto& k_shape = gathered_input_tensor_k.logical_shape();
     const auto& joint_q_shape = joint_tensor_q.logical_shape();
-    const uint32_t B = q_shape[0], NH = q_shape[1], local_padded_N = q_shape[2], DH = q_shape[3];
+    const auto& v_shape = gathered_input_tensor_v.logical_shape();
+
+    log_debug(tt::LogOp, "q_shape: {}", q_shape);
+    log_debug(tt::LogOp, "k_shape (gathered): {}", k_shape);
+    log_debug(tt::LogOp, "v_shape (gathered): {}", v_shape);
+
+    const uint32_t B = q_shape[0], NH = q_shape[1], NHK = k_shape[1], local_padded_N = q_shape[2], DH = q_shape[3];
     const uint32_t padded_N = k_shape[2];
     const uint32_t L = joint_q_shape[2];
+    const uint32_t vDH = v_shape[3];
 
     const uint32_t local_padded_Nt = local_padded_N / tt::constants::TILE_HEIGHT;
     const uint32_t padded_Nt = padded_N / tt::constants::TILE_HEIGHT;
     // Find unpadded sequence lengths in tiles
     const uint32_t Lt = tt::div_up(L, tt::constants::TILE_HEIGHT);
     const uint32_t DHt = DH / tt::constants::TILE_WIDTH;
+    const uint32_t vDHt = vDH / tt::constants::TILE_WIDTH;
     const uint32_t logical_nt = tt::div_up(static_cast<uint32_t>(args.logical_n), tt::constants::TILE_HEIGHT);
 
     /*
@@ -186,7 +198,7 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     const bool local_n_has_padding = (local_padded_Nt % Sk_chunk_t) != 0;
     const bool global_n_has_padding = (args.logical_n % (Sk_chunk_t * tt::constants::TILE_HEIGHT)) != 0;
     const bool joint_has_padding = L > 0 && (L % (Sk_chunk_t * tt::constants::TILE_HEIGHT)) != 0;
-    const bool needs_lightweight_mask = local_n_has_padding || global_n_has_padding || joint_has_padding;
+    const bool needs_lightweight_mask = (local_n_has_padding || global_n_has_padding || joint_has_padding) && !args.is_causal;
 
     // Partial tile support when padding boundary falls inside a tile.
     const uint32_t global_n_partial_col = args.logical_n % tt::constants::TILE_HEIGHT;
@@ -203,8 +215,10 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
 
     log_debug(tt::LogOp, "B: {}", B);
     log_debug(tt::LogOp, "NH: {}", NH);
+    log_debug(tt::LogOp, "NHK: {}", NHK);
     log_debug(tt::LogOp, "L: {}", L);
     log_debug(tt::LogOp, "DH: {}", DH);
+    log_debug(tt::LogOp, "vDH: {}", vDH);
 
     // Log padded dimensions
     log_debug(tt::LogOp, "local_padded_N: {}", local_padded_N);
@@ -213,6 +227,7 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
 
     // Log tile dimensions
     log_debug(tt::LogOp, "DHt: {}", DHt);
+    log_debug(tt::LogOp, "vDHt: {}", vDHt);
     log_debug(tt::LogOp, "local_padded_Nt: {}", local_padded_Nt);
     log_debug(tt::LogOp, "padded_Nt: {}", padded_Nt);
     log_debug(tt::LogOp, "Lt: {}", Lt);
@@ -272,10 +287,11 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     // These tile capacity counts for CBs need to match the number of tiles expected by the kernel (softmax.cpp)
     uint32_t q_tiles = Sq_chunk_t * DHt * q_buffer_factor;
     uint32_t k_tiles = Sk_chunk_t * DHt * 2;  // double buffer
-    uint32_t v_tiles = Sk_chunk_t * DHt * 2;  // double buffer
+    uint32_t v_tiles = Sk_chunk_t * vDHt * 2;  // double buffer
+    uint32_t mask_tiles = Sq_chunk_t * Sk_chunk_t;
     uint32_t qk_tiles = Sq_chunk_t * Sk_chunk_t;
-    uint32_t out_im_tiles = Sq_chunk_t * DHt;
-    uint32_t out0_t = Sq_chunk_t * DHt;
+    uint32_t out_im_tiles = Sq_chunk_t * vDHt;
+    uint32_t out0_t = Sq_chunk_t * vDHt;
     uint32_t scale_tiles = 1;
     uint32_t statistics_tiles = Sq_chunk_t;  // Single column of values in each iteration
 
@@ -283,6 +299,7 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     log_debug(tt::LogOp, "q_tiles: {}", q_tiles);
     log_debug(tt::LogOp, "k_tiles: {}", k_tiles);
     log_debug(tt::LogOp, "v_tiles: {}", v_tiles);
+    log_debug(tt::LogOp, "mask_tiles: {}", mask_tiles);
     log_debug(tt::LogOp, "qk_tiles: {}", qk_tiles);
     log_debug(tt::LogOp, "out0_t: {}", out0_t);
     log_debug(tt::LogOp, "scale_tiles: {}", scale_tiles);
@@ -306,18 +323,19 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     // now for out0
     const uint32_t out_in0_block_w = Sk_chunk_t;
 
-    auto [out_out_subblock_h, out_out_subblock_w] = detail::determine_largest_subblock_size(Sq_chunk_t, DHt, dst_size);
+    auto [out_out_subblock_h, out_out_subblock_w] = detail::determine_largest_subblock_size(Sq_chunk_t, vDHt, dst_size);
 
     const uint32_t out_in0_num_subblocks = Sq_chunk_t / out_out_subblock_h;
-    const uint32_t out_in1_num_subblocks = DHt / out_out_subblock_w;
+    const uint32_t out_in1_num_subblocks = vDHt / out_out_subblock_w;
     const uint32_t out_num_blocks = Sk_chunk_t / out_in0_block_w;
 
+    // This is done only in the non-causal case:
     // Streaming compute v2: eliminates row buffers via cb_push_back_hold_wr_ptr.
     // Ring joint has no causal/mask/sink/sliding/chunked flags — gating is simpler.
     // Streaming v2 requires q_num_subblocks > 1 (Sq_chunk_t > subblock_h) because the Phase 2
     // pipeline assumes at least one q_subblock iteration for correct softmax drain + SALAD overlap.
     const bool use_streaming_compute = !fp32_dest_acc_en && qk_out_subblock_h <= 2 &&
-                                       Sk_chunk_t % (8 / qk_out_subblock_h) == 0 && qk_in0_num_subblocks > 1;
+                                       Sk_chunk_t % (8 / qk_out_subblock_h) == 0 && qk_in0_num_subblocks > 1 && !args.is_causal;
     log_debug(tt::LogOp, "use_streaming_compute: {}", use_streaming_compute);
 
     // log all values
@@ -340,7 +358,12 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     const uint32_t stats_granularity = detail::find_valid_granularity(Sq_chunk_t, dst_size);
     const uint32_t sub_exp_granularity = detail::find_valid_granularity(Sk_chunk_t, dst_size);
     const uint32_t mul_bcast_granularity = detail::find_valid_granularity(Sq_chunk_t * Sk_chunk_t, dst_size);
-    const uint32_t dht_granularity = detail::find_valid_granularity(DHt, dst_size);
+    // DHT_GRANULARITY is used in the kernel with both DHt and vDHt as the cols parameter,
+    // so the granularity must evenly divide both to avoid dropping tiles.
+    uint32_t dht_granularity = std::min({DHt, vDHt, dst_size});
+    while (dht_granularity > 1 && (DHt % dht_granularity != 0 || vDHt % dht_granularity != 0)) {
+        dht_granularity--;
+    }
     const uint32_t reduce_granularity = detail::find_valid_granularity(Sq_chunk_t, dst_size / 2);
 
     // Log these
@@ -366,7 +389,9 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     std::vector<uint32_t> reader_compile_time_args = {
         B,
         NH,
+        NHK,
         DHt,
+        vDHt,
         Sq_chunk_t,
         Sk_chunk_t,
         local_padded_N,
@@ -382,7 +407,9 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
         num_joint_k_chunks,
         num_q_chunks,
         args.all_gather_operation_attributes.ring_size,
-        qk_out_subblock_h};
+        qk_out_subblock_h,
+        args.is_causal,
+        args.is_balanced};
 
     TensorAccessorArgs(input_tensor_q.buffer()).append_to(reader_compile_time_args);
     TensorAccessorArgs(input_tensor_k.buffer()).append_to(reader_compile_time_args);
@@ -410,7 +437,9 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     std::vector<uint32_t> writer_compile_time_args = {
         B,
         NH,
+        NHK,
         DHt,
+        vDHt,
         Sq_chunk_t,
         Sk_chunk_t,
         local_padded_N,
@@ -431,6 +460,8 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
         global_n_partial_col,
         joint_l_partial_col,
         (std::uint32_t)use_streaming_compute,
+        args.is_causal,
+        args.is_balanced,
     };
 
     TensorAccessorArgs(output_tensor.buffer()).append_to(writer_compile_time_args);
@@ -443,7 +474,7 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     const tt::DataFormat v_df_early = tt::tt_metal::datatype_to_dataformat_converter(gathered_input_tensor_v.dtype());
     const tt::DataFormat out_df_early = tt::tt_metal::datatype_to_dataformat_converter(output_tensor.dtype());
     const tt::DataFormat im_df_early = tt::DataFormat::Float16_b;
-    const tt::DataFormat mask_df_early = tt::DataFormat::Float16_b;
+    const tt::DataFormat mask_df_early = (args.is_causal ? tt::DataFormat::Bfp4_b : tt::DataFormat::Float16_b);
     const bool uniform_dataformat =
         (q_df_early == k_df_early && q_df_early == v_df_early && q_df_early == out_df_early &&
          q_df_early == mask_df_early && q_df_early == im_df_early);
@@ -451,7 +482,9 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     std::vector<uint32_t> compute_compile_time_args = {
         B,
         NH,
+        NHK,
         DHt,
+        vDHt,
         Sq_chunk_t,
         Sk_chunk_t,
         local_padded_N,
@@ -484,7 +517,8 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
         global_n_partial_col,
         joint_l_partial_col,
         (std::uint32_t)uniform_dataformat,
-    };
+        args.is_causal,
+        args.is_balanced};
 
     std::map<std::string, std::string> defines;
     defines["STATS_GRANULARITY"] = std::to_string(stats_granularity);
@@ -502,9 +536,11 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     tt::DataFormat q_df = tt::tt_metal::datatype_to_dataformat_converter(input_tensor_q.dtype());
     tt::DataFormat k_df = tt::tt_metal::datatype_to_dataformat_converter(gathered_input_tensor_k.dtype());
     tt::DataFormat v_df = tt::tt_metal::datatype_to_dataformat_converter(gathered_input_tensor_v.dtype());
+
+    // This is done only in the non-causal case:
     // Lightweight mask: both streaming and non-streaming paths use Float16_b
     // to support L1-accumulation and avoid Bfp4_b precision loss.
-    tt::DataFormat mask_df = tt::DataFormat::Float16_b;
+    tt::DataFormat mask_df = (args.is_causal ? tt::DataFormat::Bfp4_b : tt::DataFormat::Float16_b);
     tt::DataFormat out_df = tt::tt_metal::datatype_to_dataformat_converter(output_tensor.dtype());
     tt::DataFormat scalar_df = tt::DataFormat::Float16_b;
     tt::DataFormat im_df = tt::DataFormat::Float16_b;  // need to disable fp32 cbs (Issue #13364) fp32_dest_acc_en ?
@@ -543,12 +579,20 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
                             .set_page_size(tt::CBIndex::c_2, v_tile_size);
     CreateCircularBuffer(program, core_grid, c_in2_config);
 
-    // Lightweight mask: single CB holds 1 neginf tile + up to 2 partial mask tiles
-    if (needs_lightweight_mask) {
-        auto c_in3_config =
-            CircularBufferConfig(total_lightweight_mask_tiles * mask_tile_size, {{tt::CB::c_in3, mask_df}})
-                .set_page_size(tt::CB::c_in3, mask_tile_size);
+    if (args.is_causal) {
+        // attn_mask input
+        auto c_in3_config = CircularBufferConfig(mask_tiles * mask_tile_size, {{tt::CB::c_in3, mask_df}})
+                                .set_page_size(tt::CB::c_in3, mask_tile_size);
         CreateCircularBuffer(program, core_grid, c_in3_config);
+    }
+    else {
+        // Lightweight mask: single CB holds 1 neginf tile + up to 2 partial mask tiles
+        if (needs_lightweight_mask) {
+            auto c_in3_config =
+                CircularBufferConfig(total_lightweight_mask_tiles * mask_tile_size, {{tt::CB::c_in3, mask_df}})
+                    .set_page_size(tt::CB::c_in3, mask_tile_size);
+            CreateCircularBuffer(program, core_grid, c_in3_config);
+        }
     }
 
     // scale input
@@ -770,7 +814,7 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     // Injector reselection for DRAM channel spreading is deferred to the
     // mcast eligibility pass below.
     for (auto& segments : head_segments) {
-        if (segments.size() < 2) {
+        if (segments.size() < 2 || args.is_balanced) {
             continue;
         }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
@@ -169,6 +169,8 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> ring_joint_scaled_dot_produ
     const ttnn::ccl::Topology topology,
     std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
     const CoreCoord ccl_core_grid_offset,
+    bool is_causal,
+    bool is_balanced,
     std::optional<float> scale,
     std::optional<DeviceComputeKernelConfig> compute_kernel_config,
     ttnn::ccl::CoreAllocationStrategy core_allocation_strategy) {
@@ -192,6 +194,8 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> ring_joint_scaled_dot_produ
         topology,
         ccl_core_grid_offset,
         subdevice_id,
+        is_causal,
+        is_balanced,
         scale,
         compute_kernel_config,
         core_allocation_strategy);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.hpp
@@ -84,6 +84,8 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> ring_joint_scaled_dot_produ
     ttnn::ccl::Topology topology,
     std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
     CoreCoord ccl_core_grid_offset,
+    bool is_causal = false,
+    bool is_balanced = false,
     std::optional<float> scale = std::nullopt,
     std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
     ttnn::ccl::CoreAllocationStrategy core_allocation_strategy = ttnn::ccl::CoreAllocationStrategy::ROW_MAJOR);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
@@ -45,7 +45,9 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> ring_joint_scaled_dot_produ
     ttnn::ccl::Topology topology,
     std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
     CoreCoord ccl_core_grid_offset,
-    bool use_column_major_ccl) {
+    bool use_column_major_ccl,
+    bool is_causal,
+    bool is_balanced) {
     auto strategy = use_column_major_ccl ? ttnn::ccl::CoreAllocationStrategy::COL_MAJOR
                                          : ttnn::ccl::CoreAllocationStrategy::ROW_MAJOR;
     auto outputs = ttnn::transformer::ring_joint_scaled_dot_product_attention(
@@ -68,6 +70,8 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> ring_joint_scaled_dot_produ
         topology,
         subdevice_id,
         ccl_core_grid_offset,
+        is_causal,
+        is_balanced,
         scale,
         compute_kernel_config,
         strategy);
@@ -324,11 +328,13 @@ void bind_sdpa(nb::module_& mod) {
         nb::arg("compute_kernel_config").noconvert() = nb::none());
 
     const auto* const ring_joint_doc = R"doc(
-        RingJointAttention operation that efficiently performs non-causal attention over two
-        sets of query, key, and value tensors, where the first set is sharded across devices in the sequence dimension.
-        Internally, these are concatenated in the sequence dimension (joint_strategy = "rear"),
-        then attention is computed once. The output is split ("sliced") into two parts: one for the original Q/K/V chunk,
-        and one for the joint Q/K/V chunk.
+        RingJointAttention operation supports both:
+
+        - efficient non-causal attention over two sets of query, key, and value tensors, where the first set is sharded across devices in the sequence dimension.
+          Internally, these are concatenated in the sequence dimension (joint_strategy = "rear"),
+          then attention is computed once. The output is split ("sliced") into two parts: one for the original Q/K/V chunk,
+          and one for the joint Q/K/V chunk.
+        - funtional causal attention over a single set of query, key and value tensors with the option of handling zig-zag load balancing across devices.
 
         This op handles optional padding via an attention mask to omit padded tokens from
         both the "original" and "joint" sequences.
@@ -363,6 +369,8 @@ void bind_sdpa(nb::module_& mod) {
             use_column_major_ccl (bool, optional): If True, allocate CCL worker cores in column-major order.
                 This places CCL workers in a column (useful when reserving the last column for CCL).
                 If False (default), uses row-major allocation. Defaults to False.
+            is_causal (bool): Whether to use causal attention masking. Defaults to False.
+            is_balanced (bool): Whether to use balanced attention computation. Defaults to False.
 
         Returns:
             (ttnn.Tensor, ttnn.Tensor, ttnn.Tensor):
@@ -397,7 +405,9 @@ void bind_sdpa(nb::module_& mod) {
         nb::arg("topology"),
         nb::arg("subdevice_id") = nb::none(),
         nb::arg("ccl_core_grid_offset"),
-        nb::arg("use_column_major_ccl") = false);
+        nb::arg("use_column_major_ccl") = false,
+        nb::arg("is_causal").noconvert() = false,
+        nb::arg("is_balanced").noconvert() = false);
 
     const auto* const mla_doc =
         R"doc(


### PR DESCRIPTION
### Ticket
#39286
#39613

### Problem description
No support for causality and MLA in `ttnn.transformer.ring_joint_scaled_dot_product_attention`.

### What's changed
This PR has the functional implementation of causal ring mla attention (/w mirrored index load balancing).

The following changes are made to the `ttnn.transformer.ring_joint_scaled_dot_product_attention` op:

- Different data types of Q/K/V tensors enabled (DS Prefill will for now have Q as bf16 and KV as bfp8 tensors)
- [Key change] Support for MLA attention is added (this entails enablement of different number of heads/head dimension for K/V tensors)
- [Key change] Support for causality in the op /w balancing (`is_causal` and `is_balanced` parameters added to the op API)
- [Key change] Ring all gather kernels modified to support exchange of several tensors (MLA attention will communicate both K and V tensors)

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ipotkonjak/causal_ring_sdpa_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ipotkonjak/causal_ring_sdpa_pr)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ipotkonjak/causal_ring_sdpa_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ipotkonjak/causal_ring_sdpa_pr)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ipotkonjak/causal_ring_sdpa_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ipotkonjak/causal_ring_sdpa_pr)
- [x] [(T3K) T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/22760882254)


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ipotkonjak/causal_ring_sdpa_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ipotkonjak/causal_ring_sdpa_pr)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ipotkonjak/causal_ring_sdpa_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ipotkonjak/causal_ring_sdpa_pr)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ipotkonjak/causal_ring_sdpa_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ipotkonjak/causal_ring_sdpa_pr)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
