### PR TITLE
fix Deepseek embedding after API change

### DIFF
--- a/models/demos/deepseek_v3/tt/embedding/embedding1d.py
+++ b/models/demos/deepseek_v3/tt/embedding/embedding1d.py
@@ -218,8 +218,6 @@ class Embedding1D(AbstractModule):
             embeddings = ttnn.embedding(x_padded, **cfg["embedding"])
             ttnn.deallocate(x_padded)
 
-        embeddings = ttnn.unsqueeze(embeddings, 0)
-
         embeddings_tc = ttnn.typecast(embeddings, **cfg["typecast"])
         ttnn.deallocate(embeddings)
 


### PR DESCRIPTION
### Problem description
Deepseek tests were failing ([link](https://github.com/tenstorrent/tt-metal/actions/runs/22748133162)) after https://github.com/tenstorrent/tt-metal/pull/37899

### What's changed
Removed unsqueeze since new ttnn.embedding API returns 4D tensor while input is 3D

### Checklist

- [Deepseek tests](https://github.com/tenstorrent/tt-metal/actions/runs/22760953202) - In progress
