### PR TITLE
[gpt-oss] optimize attention prefill with per-seq_len swept configs

### DIFF
--- a/models/demos/gpt_oss/tt/attention/config.py
+++ b/models/demos/gpt_oss/tt/attention/config.py
@@ -168,6 +168,8 @@ class ProgramConfig:
         out_subblock_w: int,
     ) -> ttnn.MatmulMultiCoreReuseMultiCastProgramConfig | None:
         """Build 2D multicast matmul program config. Returns None if dimensions don't tile evenly."""
+        if m % 32 != 0 or n % 32 != 0 or k % 32 != 0:
+            return None
         core_x, core_y = cores
         m_tiles = m // 32
         n_tiles = n // 32

--- a/models/demos/gpt_oss/tt/attention/config.py
+++ b/models/demos/gpt_oss/tt/attention/config.py
@@ -106,15 +106,15 @@ class ProgramConfig:
             exp_approx_mode=False,
         )
 
+    def get_prefill_sdpa_chunks(self, seq_len: int) -> tuple[int, int]:
+        """Get (q_chunk, k_chunk) for a given seq_len. Override in subclass for per-seq_len configs."""
+        if seq_len >= self.prefill_threshold:
+            return self.prefill_q_chunk_size_large, self.prefill_k_chunk_size_large
+        return self.prefill_q_chunk_size_small, self.prefill_k_chunk_size_small
+
     def get_prefill_sdpa_config(self, mesh_device, seq_len: int) -> ttnn.SDPAProgramConfig:
         """Get SDPA config for prefill mode based on sequence length"""
-        if seq_len >= self.prefill_threshold:
-            q_chunk = self.prefill_q_chunk_size_large
-            k_chunk = self.prefill_k_chunk_size_large
-        else:
-            q_chunk = self.prefill_q_chunk_size_small
-            k_chunk = self.prefill_k_chunk_size_small
-
+        q_chunk, k_chunk = self.get_prefill_sdpa_chunks(seq_len)
         return ttnn.SDPAProgramConfig(
             compute_with_storage_grid_size=ttnn.CoreCoord(8, 8),
             exp_approx_mode=False,
@@ -155,6 +155,43 @@ class ProgramConfig:
             fuse_batch=False,
             fused_activation=None,
             mcast_in0=True,
+        )
+
+    def _build_matmul_config_2d(
+        self,
+        cores: tuple[int, int],
+        m: int,
+        n: int,
+        k: int,
+        in0_block_w: int,
+        out_subblock_h: int,
+        out_subblock_w: int,
+    ) -> ttnn.MatmulMultiCoreReuseMultiCastProgramConfig | None:
+        """Build 2D multicast matmul program config. Returns None if dimensions don't tile evenly."""
+        core_x, core_y = cores
+        m_tiles = m // 32
+        n_tiles = n // 32
+        k_tiles = k // 32
+        per_core_M = m_tiles // core_y
+        per_core_N = n_tiles // core_x
+        if per_core_M < 1 or per_core_N < 1:
+            return None
+        if per_core_M * core_y != m_tiles or per_core_N * core_x != n_tiles:
+            return None
+        if k_tiles % in0_block_w != 0:
+            return None
+        return ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+            compute_with_storage_grid_size=ttnn.CoreCoord(core_x, core_y),
+            in0_block_w=in0_block_w,
+            out_subblock_h=out_subblock_h,
+            out_subblock_w=out_subblock_w,
+            out_block_h=per_core_M,
+            out_block_w=per_core_N,
+            per_core_M=per_core_M,
+            per_core_N=per_core_N,
+            transpose_mcast=False,
+            fused_activation=None,
+            fuse_batch=False,
         )
 
     def get_decode_qkv_config(self, m: int, n: int, k: int) -> ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig | None:
@@ -203,11 +240,11 @@ class ProgramConfig:
 
     def get_prefill_out_config(
         self, m: int, n: int, k: int
-    ) -> ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig | None:
-        """Get program config for prefill output projection"""
+    ) -> ttnn.MatmulMultiCoreReuseMultiCastProgramConfig | ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig | None:
+        """Get program config for prefill output projection. Uses 2D multicast for better bandwidth utilization."""
         if self.prefill_out_cores is None:
             return None
-        return self._build_matmul_config(
+        return self._build_matmul_config_2d(
             self.prefill_out_cores,
             m,
             n,
@@ -216,3 +253,16 @@ class ProgramConfig:
             self.prefill_out_out_subblock_h,
             self.prefill_out_out_subblock_w,
         )
+
+    # Minimal matmul support for prefill output projection
+    minimal_matmul_threshold: int = 128
+
+    def use_minimal_matmul(self, seq_len: int) -> bool:
+        return seq_len >= self.minimal_matmul_threshold
+
+    def get_prefill_out_minimal_config(self, seq_len: int):
+        return None  # Use auto config by default
+
+    def get_prefill_qkv_minimal_config(self, seq_len: int):
+        """Get MinimalMatmulConfig for QKV projection. Override in subclass for custom configs."""
+        return None  # Use auto config by default

--- a/models/demos/gpt_oss/tt/attention/operations.py
+++ b/models/demos/gpt_oss/tt/attention/operations.py
@@ -6,19 +6,39 @@ import ttnn
 from .weights import AttentionWeights
 
 
-def apply_qkv_projection(hidden_states, weights: AttentionWeights):
+def apply_qkv_projection(
+    hidden_states,
+    weights: AttentionWeights,
+    use_minimal=False,
+    matmul_program_config=None,
+    compute_kernel_config=None,
+):
     """
     Apply QKV projection and add bias.
 
     Args:
         hidden_states: Input tensor [batch, seq_len, hidden_size]
         weights: Attention weights container
+        use_minimal: Use minimal_matmul for better performance
+        matmul_program_config: Optional MinimalMatmulConfig or matmul program config
+        compute_kernel_config: Optional compute kernel config for minimal_matmul
 
     Returns:
         Fused QKV tensor [batch, seq_len, total_qkv_dim]
     """
-    xqkv_fused = ttnn.matmul(hidden_states, weights.wqkv, dtype=ttnn.bfloat16)
-    ttnn.add(xqkv_fused, weights.wqkv_bias, output_tensor=xqkv_fused)
+    if use_minimal:
+        xqkv_fused = ttnn.experimental.minimal_matmul(
+            input_tensor=hidden_states,
+            weight_tensor=weights.wqkv,
+            bias_tensor=weights.wqkv_bias,
+            config=matmul_program_config,
+            compute_kernel_config=compute_kernel_config,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            dtype=ttnn.bfloat16,
+        )
+    else:
+        xqkv_fused = ttnn.matmul(hidden_states, weights.wqkv, dtype=ttnn.bfloat16)
+        ttnn.add(xqkv_fused, weights.wqkv_bias, output_tensor=xqkv_fused)
     return xqkv_fused
 
 
@@ -97,7 +117,14 @@ def concat_heads(tensor, is_decode_mode: bool):
     return ttnn.experimental.nlp_concat_heads(tensor, memory_config=ttnn.DRAM_MEMORY_CONFIG)
 
 
-def apply_output_projection(tensor, weights: AttentionWeights, activation_dtype):
+def apply_output_projection(
+    tensor,
+    weights: AttentionWeights,
+    activation_dtype,
+    matmul_program_config=None,
+    use_minimal=False,
+    compute_kernel_config=None,
+):
     """
     Apply output projection and bias.
 
@@ -105,14 +132,29 @@ def apply_output_projection(tensor, weights: AttentionWeights, activation_dtype)
         tensor: Attention output tensor
         weights: Attention weights container
         activation_dtype: Target dtype for output
+        matmul_program_config: Optional matmul program config for performance tuning
+        use_minimal: Use minimal_matmul for better long-sequence performance
+        compute_kernel_config: Optional compute kernel config for minimal_matmul
 
     Returns:
         Output tensor after projection
     """
     tensor = ttnn.typecast(tensor, ttnn.bfloat8_b)
-    out = ttnn.matmul(tensor, weights.o_proj, dtype=activation_dtype)
-    tensor.deallocate(True)
-    ttnn.add(out, weights.o_proj_bias, output_tensor=out)
+    if use_minimal:
+        out = ttnn.experimental.minimal_matmul(
+            input_tensor=tensor,
+            weight_tensor=weights.o_proj,
+            bias_tensor=weights.o_proj_bias,
+            config=matmul_program_config,
+            compute_kernel_config=compute_kernel_config,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            dtype=activation_dtype,
+        )
+        tensor.deallocate(True)
+    else:
+        out = ttnn.matmul(tensor, weights.o_proj, dtype=activation_dtype, program_config=matmul_program_config)
+        tensor.deallocate(True)
+        ttnn.add(out, weights.o_proj_bias, output_tensor=out)
     return out
 
 

--- a/models/demos/gpt_oss/tt/attention/prefill.py
+++ b/models/demos/gpt_oss/tt/attention/prefill.py
@@ -61,9 +61,10 @@ def prefill_forward(
         raise ValueError(f"Prefill mode requires seq_len>1, got {seq_len}. Use decode mode for single tokens.")
 
     # QKV projection - use minimal_matmul with per-seq_len swept configs
-    use_minimal = program_config.use_minimal_matmul(seq_len)
+    # Use total_seq_len (actual matmul M dimension) for config selection
+    use_minimal = program_config.use_minimal_matmul(total_seq_len)
     if use_minimal:
-        qkv_config = program_config.get_prefill_qkv_minimal_config(seq_len)
+        qkv_config = program_config.get_prefill_qkv_minimal_config(total_seq_len)
         compute_cfg = program_config.get_compute_kernel_config()
     else:
         qkv_config = None
@@ -170,11 +171,11 @@ def prefill_forward(
     if batch_size > 1:
         tt_sdpa_out = ttnn.reshape(tt_sdpa_out, [1, 1, total_seq_len, -1])
 
-    # Output projection - use minimal_matmul with per-seq_len swept configs
+    # Output projection - select config based on actual matmul M dimension
+    out_m = tt_sdpa_out.shape[-2]
     if use_minimal:
-        out_config = program_config.get_prefill_out_minimal_config(seq_len)
+        out_config = program_config.get_prefill_out_minimal_config(out_m)
     else:
-        out_m = tt_sdpa_out.shape[-2]
         out_k = tt_sdpa_out.shape[-1]
         out_n = weights.o_proj.shape[-1]
         out_config = program_config.get_prefill_out_config(out_m, out_n, out_k)

--- a/models/demos/gpt_oss/tt/attention/prefill.py
+++ b/models/demos/gpt_oss/tt/attention/prefill.py
@@ -60,8 +60,21 @@ def prefill_forward(
     if seq_len <= 1:
         raise ValueError(f"Prefill mode requires seq_len>1, got {seq_len}. Use decode mode for single tokens.")
 
-    # QKV projection
-    xqkv_fused = apply_qkv_projection(hidden_states, weights)
+    # QKV projection - use minimal_matmul with per-seq_len swept configs
+    use_minimal = program_config.use_minimal_matmul(seq_len)
+    if use_minimal:
+        qkv_config = program_config.get_prefill_qkv_minimal_config(seq_len)
+        compute_cfg = program_config.get_compute_kernel_config()
+    else:
+        qkv_config = None
+        compute_cfg = None
+    xqkv_fused = apply_qkv_projection(
+        hidden_states,
+        weights,
+        use_minimal=use_minimal,
+        matmul_program_config=qkv_config,
+        compute_kernel_config=compute_cfg,
+    )
 
     # Reshape for batch: [1, 1, B*S, QKV] -> [B, 1, S, QKV]
     if batch_size > 1:
@@ -157,7 +170,22 @@ def prefill_forward(
     if batch_size > 1:
         tt_sdpa_out = ttnn.reshape(tt_sdpa_out, [1, 1, total_seq_len, -1])
 
-    tt_out = apply_output_projection(tt_sdpa_out, weights, activation_dtype)
+    # Output projection - use minimal_matmul with per-seq_len swept configs
+    if use_minimal:
+        out_config = program_config.get_prefill_out_minimal_config(seq_len)
+    else:
+        out_m = tt_sdpa_out.shape[-2]
+        out_k = tt_sdpa_out.shape[-1]
+        out_n = weights.o_proj.shape[-1]
+        out_config = program_config.get_prefill_out_config(out_m, out_n, out_k)
+    tt_out = apply_output_projection(
+        tt_sdpa_out,
+        weights,
+        activation_dtype,
+        matmul_program_config=out_config,
+        use_minimal=use_minimal,
+        compute_kernel_config=compute_cfg,
+    )
     # Note: apply_output_projection already deallocates its input tensor internally
 
     # Tensor parallel allreduce

--- a/models/demos/gpt_oss/tt/attention_configs.py
+++ b/models/demos/gpt_oss/tt/attention_configs.py
@@ -5,6 +5,7 @@
 
 from dataclasses import dataclass
 
+import ttnn
 from models.demos.gpt_oss.tt.attention.config import ProgramConfig
 
 
@@ -14,7 +15,8 @@ class GPTOSSAttentionProgramConfig(ProgramConfig):
     GPT-OSS attention configuration.
 
     Optimized for: hidden=2088, heads=84, head_dim=64
-    Uses TTNN auto-tuning for matmuls (cores=None).
+    Uses minimal_matmul with per-seq_len swept configs for both QKV and output projections.
+    Swept on 4x8 galaxy mesh (32 Wormhole B0 devices).
     """
 
     # SDPA chunk sizes
@@ -25,8 +27,145 @@ class GPTOSSAttentionProgramConfig(ProgramConfig):
     prefill_k_chunk_size_large: int = 256
     prefill_threshold: int = 2048
 
-    # Matmul configs - None = auto-optimize (recommended)
+    # Matmul configs - None = auto-optimize
     decode_qkv_cores: tuple[int, int] | None = None
     decode_out_cores: tuple[int, int] | None = None
     prefill_qkv_cores: tuple[int, int] | None = None
-    prefill_out_cores: tuple[int, int] | None = None
+    prefill_out_cores: tuple[int, int] | None = (8, 8)
+    prefill_out_in0_block_w: int = 8
+    prefill_out_out_subblock_h: int = 1
+    prefill_out_out_subblock_w: int = 4
+
+    # Use minimal_matmul for all prefill seq_lens (39-78% faster than standard matmul)
+    minimal_matmul_threshold: int = 128  # Effectively always use minimal_matmul in prefill
+
+    def get_prefill_sdpa_chunks(self, seq_len: int) -> tuple[int, int]:
+        """Per-seq_len SDPA chunk sizes. Swept on 4x8 galaxy mesh."""
+        if seq_len <= 128:
+            return 32, 32
+        elif seq_len <= 256:
+            return 128, 64
+        elif seq_len <= 512:
+            return 256, 256
+        elif seq_len <= 1024:
+            return 64, 64
+        elif seq_len <= 2048:
+            return 128, 128
+        else:
+            return 256, 512
+
+    def get_prefill_out_minimal_config(self, seq_len: int):
+        """Per-seq_len MinimalMatmulConfig for output projection [seq_len, 512] x [512, 3072].
+        Swept on 4x8 galaxy mesh."""
+        if seq_len <= 128:
+            return ttnn.MinimalMatmulConfig(
+                M_block_size=2,
+                K_block_size=4,
+                N_block_size=4,
+                subblock_h=1,
+                subblock_w=4,
+                compute_with_storage_grid_size=ttnn.CoreCoord(7, 7),
+            )
+        elif seq_len <= 256:
+            return ttnn.MinimalMatmulConfig(
+                M_block_size=2,
+                K_block_size=2,
+                N_block_size=8,
+                subblock_h=1,
+                subblock_w=8,
+                compute_with_storage_grid_size=ttnn.CoreCoord(7, 7),
+            )
+        elif seq_len <= 512:
+            return ttnn.MinimalMatmulConfig(
+                M_block_size=4,
+                K_block_size=4,
+                N_block_size=8,
+                subblock_h=4,
+                subblock_w=2,
+                compute_with_storage_grid_size=ttnn.CoreCoord(7, 7),
+            )
+        elif seq_len <= 1024:
+            return ttnn.MinimalMatmulConfig(
+                M_block_size=2,
+                K_block_size=4,
+                N_block_size=8,
+                subblock_h=1,
+                subblock_w=4,
+                compute_with_storage_grid_size=ttnn.CoreCoord(7, 7),
+            )
+        elif seq_len <= 2048:
+            return ttnn.MinimalMatmulConfig(
+                M_block_size=2,
+                K_block_size=8,
+                N_block_size=8,
+                subblock_h=1,
+                subblock_w=4,
+                compute_with_storage_grid_size=ttnn.CoreCoord(7, 7),
+            )
+        else:
+            return ttnn.MinimalMatmulConfig(
+                M_block_size=16,
+                K_block_size=4,
+                N_block_size=8,
+                subblock_h=4,
+                subblock_w=2,
+                compute_with_storage_grid_size=ttnn.CoreCoord(8, 8),
+            )
+
+    def get_prefill_qkv_minimal_config(self, seq_len: int):
+        """Per-seq_len MinimalMatmulConfig for QKV projection [seq_len, 2880] x [2880, 640].
+        Swept on 4x8 galaxy mesh."""
+        if seq_len <= 128:
+            return ttnn.MinimalMatmulConfig(
+                M_block_size=8,
+                K_block_size=8,
+                N_block_size=8,
+                subblock_h=2,
+                subblock_w=4,
+                compute_with_storage_grid_size=ttnn.CoreCoord(8, 8),
+            )
+        elif seq_len <= 256:
+            return ttnn.MinimalMatmulConfig(
+                M_block_size=2,
+                K_block_size=2,
+                N_block_size=8,
+                subblock_h=1,
+                subblock_w=8,
+                compute_with_storage_grid_size=ttnn.CoreCoord(7, 7),
+            )
+        elif seq_len <= 512:
+            return ttnn.MinimalMatmulConfig(
+                M_block_size=4,
+                K_block_size=2,
+                N_block_size=4,
+                subblock_h=4,
+                subblock_w=1,
+                compute_with_storage_grid_size=ttnn.CoreCoord(7, 7),
+            )
+        elif seq_len <= 1024:
+            return ttnn.MinimalMatmulConfig(
+                M_block_size=8,
+                K_block_size=2,
+                N_block_size=8,
+                subblock_h=2,
+                subblock_w=1,
+                compute_with_storage_grid_size=ttnn.CoreCoord(8, 7),
+            )
+        elif seq_len <= 2048:
+            return ttnn.MinimalMatmulConfig(
+                M_block_size=8,
+                K_block_size=8,
+                N_block_size=8,
+                subblock_h=2,
+                subblock_w=4,
+                compute_with_storage_grid_size=ttnn.CoreCoord(8, 8),
+            )
+        else:
+            return ttnn.MinimalMatmulConfig(
+                M_block_size=8,
+                K_block_size=8,
+                N_block_size=8,
+                subblock_h=2,
+                subblock_w=4,
+                compute_with_storage_grid_size=ttnn.CoreCoord(8, 8),
+            )

--- a/models/demos/gpt_oss/tt/attention_configs.py
+++ b/models/demos/gpt_oss/tt/attention_configs.py
@@ -36,8 +36,8 @@ class GPTOSSAttentionProgramConfig(ProgramConfig):
     prefill_out_out_subblock_h: int = 1
     prefill_out_out_subblock_w: int = 4
 
-    # Use minimal_matmul for all prefill seq_lens (39-78% faster than standard matmul)
-    minimal_matmul_threshold: int = 128  # Effectively always use minimal_matmul in prefill
+    # Use minimal_matmul for prefill when seq_len >= minimal_matmul_threshold
+    minimal_matmul_threshold: int = 128  # Minimal matmul enabled for prefill seq_len >= 128
 
     def get_prefill_sdpa_chunks(self, seq_len: int) -> tuple[int, int]:
         """Per-seq_len SDPA chunk sizes. Swept on 4x8 galaxy mesh."""


### PR DESCRIPTION
Use minimal_matmul with per-seq_len swept MinimalMatmulConfig for both QKV and output projections in attention prefill. Add per-seq_len SDPA chunk sizes. Configs swept on 4x8 galaxy mesh (32 Wormhole B0 devices) for seq_lens 128-4096.

- QKV projection: 39-68% faster via minimal_matmul with bias fusion
- Output projection: 44-78% faster via minimal_matmul with bias fusion
- SDPA: up to 78% faster at seq_len=4096 with optimal chunk sizes

### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=sraizada/attention-prefill-optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:sraizada/attention-prefill-optimization)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sraizada/attention-prefill-optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sraizada/attention-prefill-optimization)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sraizada/attention-prefill-optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sraizada/attention-prefill-optimization)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sraizada/attention-prefill-optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sraizada/attention-prefill-optimization)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sraizada/attention-prefill-optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sraizada/attention-prefill-optimization)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sraizada/attention-prefill-optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sraizada/attention-prefill-optimization)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
