### PR TITLE
Fix DiT T3K DRAM OOM for Mochi, QwenImage, and Wan2.2

### DIFF
--- a/models/tt_dit/pipelines/qwenimage/pipeline_qwenimage.py
+++ b/models/tt_dit/pipelines/qwenimage/pipeline_qwenimage.py
@@ -377,7 +377,7 @@ class QwenImagePipeline:
                 "num_links": 1,
                 "is_fsdp": False,
                 "dynamic_load_encoder": True,
-                "dynamic_load_vae": False,
+                "dynamic_load_vae": not ttnn.device.is_blackhole(),
             },
             (4, 8): {
                 "cfg_config": (2, 1),

--- a/models/tt_dit/pipelines/wan/pipeline_wan.py
+++ b/models/tt_dit/pipelines/wan/pipeline_wan.py
@@ -256,10 +256,16 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
         if self.dynamic_load:
             # setup models that cannot be loaded together with the corresponding model.
             # The module loading utility will take care of the necessary unloading.
-            # This is the best dynamic loading strategy across all supported device configurations.
             self.tt_umt5_encoder.set_unload_set(self.transformer_2)
-            self.transformer.set_unload_set(self.transformer_2)
-            self.transformer_2.set_unload_set(self.transformer, self.tt_umt5_encoder)
+            if ttnn.device.is_blackhole():
+                self.transformer.set_unload_set(self.transformer_2)
+                self.transformer_2.set_unload_set(self.transformer, self.tt_umt5_encoder)
+            else:
+                # WH T3K has tighter DRAM — include VAE in the unload chain so
+                # transformers and VAE never coexist in DRAM across pipeline runs.
+                self.transformer.set_unload_set(self.transformer_2, self.tt_vae)
+                self.transformer_2.set_unload_set(self.transformer, self.tt_umt5_encoder, self.tt_vae)
+                self.tt_vae.set_unload_set(self.transformer, self.transformer_2)
 
         # Cache warmup: Load in reverse order of use to ensure the earliest required models stay loaded before call.
         self._prepare_transformer2()

--- a/models/tt_dit/tests/models/mochi/test_pipeline_mochi.py
+++ b/models/tt_dit/tests/models/mochi/test_pipeline_mochi.py
@@ -133,11 +133,16 @@ def test_tt_mochi_pipeline(
     vae_sp_axis: int,
     vae_tp_axis: int,
     num_links: int,
+    is_ci_env: bool,
+    monkeypatch: pytest.MonkeyPatch,
 ):
     """
     Test that creates the modified TT MochiPipeline and runs it on a prompt.
     This uses the TT transformer instead of the diffusers one.
     """
+    if is_ci_env:
+        monkeypatch.setenv("TT_DIT_CACHE_DIR", "/tmp/TT_DIT_CACHE")
+
     try:
         from ....parallel.config import DiTParallelConfig, MochiVAEParallelConfig, ParallelFactor
         from ....pipelines.mochi.pipeline_mochi import MochiPipeline as TTMochiPipeline
@@ -182,6 +187,7 @@ def test_tt_mochi_pipeline(
         num_links=num_links,
         use_reference_vae=False,
         model_name="genmo/mochi-1-preview",
+        reload_dit_model=mesh_device.get_num_devices() <= 8,
     )
 
     # Define test prompt (same as the diffusers test)


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/39222
https://github.com/tenstorrent/tt-metal/issues/39247
https://github.com/tenstorrent/tt-metal/issues/39248

Direct fix for failing CI

### Problem description

Three DiT models have been consistently failing with DRAM OOM on T3K (2x4 mesh):

**Mochi** (demo + perf) — The demo test constructs `MochiPipeline` directly without using `create_pipeline()`, which already defaults `reload_dit_model=True` for WH (2,4). Without this flag, transformer weights (~710 MB/bank) stay in DRAM during VAE decode, leaving only ~146 MB free — not enough for the VAE's ~174 MB allocation.

**QwenImage** (demo + perf) — The `create_pipeline()` helper defaulted `dynamic_load_vae=False` for the (2,4) mesh. Without dynamic VAE loading, transformers stay in DRAM during VAE decode, exhausting available memory. BH has enough DRAM headroom and doesn't need this.

**Wan2.2** (perf only) — The `dynamic_load=True` unload chain covered encoder↔transformer swapping but excluded the VAE. On the second pipeline run (perf warmup + measurement), the VAE stays resident from the first run while transformers reload for denoising, causing OOM. Demo passes because a single run barely fits. BH is unaffected due to larger DRAM banks.

### What's changed

**models/tt_dit/tests/models/mochi/test_pipeline_mochi.py:**
- Pass `reload_dit_model=mesh_device.get_num_devices() <= 8` to free transformer weights before VAE decode on T3K. This is needed because the demo test constructs the pipeline directly instead of using `create_pipeline()` (which already sets this default).
- Add `monkeypatch.setenv("TT_DIT_CACHE_DIR", ...)` in CI so `reload_dit_model=True` doesn't fail the cache-dir check when running outside the wrapper script.

**models/tt_dit/pipelines/qwenimage/pipeline_qwenimage.py:**
- Change `create_pipeline()` default from `"dynamic_load_vae": False` to `"dynamic_load_vae": not ttnn.device.is_blackhole()` for the (2,4) mesh. WH T3K gets dynamic VAE loading to prevent OOM; BH keeps it disabled to avoid unnecessary reload overhead.

**models/tt_dit/pipelines/wan/pipeline_wan.py:**
- Add VAE to the bidirectional dynamic load unload chain on WH only: loading transformers now unloads VAE, and loading VAE now unloads transformers. BH is excluded since its larger DRAM can hold both simultaneously.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=kevinmi/fix-dit-perf-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:kevinmi/fix-dit-perf-tests)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=kevinmi/fix-dit-perf-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:kevinmi/fix-dit-perf-tests)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kevinmi/fix-dit-perf-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kevinmi/fix-dit-perf-tests)
- [x] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kevinmi/fix-dit-perf-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kevinmi/fix-dit-perf-tests)
  - [x] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)