### PR TITLE
Run p150b triage tests with prio runner

### DIFF
--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -391,8 +391,8 @@ jobs:
       fail-fast: false
       matrix:
         platform: [
-          "N150",
-          "P150b",
+          "N150-viommu",
+          "P150b-viommu-prio",
         ]
     uses: ./.github/workflows/triage.yaml
     with:

--- a/.github/workflows/triage.yaml
+++ b/.github/workflows/triage.yaml
@@ -51,7 +51,7 @@ jobs:
         shell: bash
         working-directory: /work # https://github.com/actions/runner/issues/878
     runs-on: >-
-      ${{ format('tt-ubuntu-2204-{0}-viommu-stable', inputs.runner-label) }}
+      ${{ format('tt-ubuntu-2204-{0}-stable', inputs.runner-label) }}
     steps:
       - name: 🧬 Checkout Repository
         uses: actions/checkout@v4


### PR DESCRIPTION
### Ticket
None

### Problem description
Merge gate p150 jobs should use prio runners to avoid getting stuck in queue.

### What's changed
Change p150 to p150-viommu-prio for triage-tests.
Pull the `-viommu` suffix out of the default runner workflow file.

### Checklist

- [ ] Merge gate: https://github.com/tenstorrent/tt-metal/actions/runs/22771027323

