### PR TITLE
[skip ci] Handle aggregate workflow regression payloads via artifacts

### DIFF
--- a/.github/actions/analyze-workflow-data/action.yml
+++ b/.github/actions/analyze-workflow-data/action.yml
@@ -36,14 +36,20 @@ inputs:
     required: false
 
 outputs:
-  failed_workflows:
-    description: 'JSON array of workflow names that have failed their latest run on the main branch'
   report:
     description: 'The generated workflow report in markdown format, containing workflow statistics and failure details'
-  regressed_workflows:
-    description: 'JSON array of objects {name, run_id, run_url, created_at} for workflows that regressed (success -> fail)'
-  alert_all_message:
-    description: 'Slack-ready alert message listing all currently failing workflows with owner mentions (set when alert-all=true)'
+  has_failed_workflows:
+    description: 'True when at least one tracked workflow is currently failing'
+  has_regressions:
+    description: 'True when at least one workflow regressed from passing to failing'
+  failed_workflows_path:
+    description: 'Path to the JSON file containing failed workflow names'
+  regressed_workflows_path:
+    description: 'Path to the JSON file containing regressed workflow details'
+  alert_all_message_path:
+    description: 'Path to the text file containing the Slack-ready alert message'
+  status_changes_path:
+    description: 'Path to the JSON file containing workflow status changes'
 
 runs:
   using: 'node20'

--- a/.github/actions/analyze-workflow-data/analyze-workflow-data.js
+++ b/.github/actions/analyze-workflow-data/analyze-workflow-data.js
@@ -206,11 +206,23 @@ async function run() {
     // This identifies NEW failing jobs in pipelines that were already failing
     await detectJobLevelRegressions(stayedFailingDetails, regressedDetails, errorSnippetsCache, github.context);
 
-    // upload the changes json to the artifact space
+    // Persist generated payloads to files so downstream jobs can consume them
+    // without pushing large JSON strings through workflow outputs/env vars.
     const outputDir = process.env.GITHUB_WORKSPACE || process.cwd();
     const statusChangesPath = path.join(outputDir, 'workflow-status-changes.json');
+    const failedWorkflowsPath = path.join(outputDir, 'failed-workflows.json');
+    const regressedWorkflowsPath = path.join(outputDir, 'regressed-workflows.json');
+    const alertAllMessagePath = path.join(outputDir, 'alert-all-message.txt');
+
     fs.writeFileSync(statusChangesPath, JSON.stringify(changes));
+    fs.writeFileSync(failedWorkflowsPath, JSON.stringify(failedWorkflows));
+    fs.writeFileSync(regressedWorkflowsPath, JSON.stringify(regressedDetails));
+    fs.writeFileSync(alertAllMessagePath, alertAllMessage || '');
+
     core.setOutput('status_changes_path', statusChangesPath);
+    core.setOutput('failed_workflows_path', failedWorkflowsPath);
+    core.setOutput('regressed_workflows_path', regressedWorkflowsPath);
+    core.setOutput('alert_all_message_path', alertAllMessagePath);
 
     // Build report sections
     let regressionsSection = '';
@@ -229,10 +241,9 @@ async function run() {
       .join('\n');
 
     // Set outputs
-    core.setOutput('failed_workflows', JSON.stringify(failedWorkflows));
     core.setOutput('report', finalReport);
-    core.setOutput('alert_all_message', alertAllMessage || '');
-    core.setOutput('regressed_workflows', JSON.stringify(regressedDetails));
+    core.setOutput('has_failed_workflows', failedWorkflows.length > 0 ? 'true' : 'false');
+    core.setOutput('has_regressions', regressedDetails.length > 0 ? 'true' : 'false');
 
     await core.summary.addRaw(finalReport).write();
 

--- a/.github/actions/slack-report-analyze-workflow-data/action.yaml
+++ b/.github/actions/slack-report-analyze-workflow-data/action.yaml
@@ -9,9 +9,15 @@ inputs:
     required: false
   regressed_workflows:
     description: "JSON array from analyze step output 'regressed_workflows'"
-    required: true
+    required: false
+  regressed_workflows_path:
+    description: "Path to a JSON file containing regressed workflows"
+    required: false
   alert_all_message:
     description: "Optional Slack-ready alert text from analyze step output 'alert_all_message'"
+    required: false
+  alert_all_message_path:
+    description: "Path to a text file containing the Slack-ready alert text"
     required: false
 outputs:
   slack_ts:
@@ -24,12 +30,28 @@ runs:
       id: build
       shell: bash
       env:
-        ALERT_RAW: ${{ inputs.alert_all_message }}
-        REGRESSED_RAW: ${{ inputs.regressed_workflows }}
+        ALERT_PATH: ${{ inputs.alert_all_message_path }}
+        REGRESSED_PATH: ${{ inputs.regressed_workflows_path }}
       run: |
         set -euo pipefail
         tmp_file="$(mktemp)"
-        printf '%s' "$REGRESSED_RAW" > "$tmp_file"
+        cleanup_tmp_file() {
+          rm -f "$tmp_file"
+        }
+        trap cleanup_tmp_file EXIT
+
+        if [ -n "${REGRESSED_PATH:-}" ] && [ -f "$REGRESSED_PATH" ]; then
+          cp "$REGRESSED_PATH" "$tmp_file"
+        else
+          printf '%s' '[]' > "$tmp_file"
+        fi
+
+        if [ -n "${ALERT_PATH:-}" ] && [ -f "$ALERT_PATH" ]; then
+          ALERT_RAW="$(cat "$ALERT_PATH")"
+        else
+          ALERT_RAW=""
+        fi
+
         if ! jq -e . "$tmp_file" >/dev/null 2>&1; then
           echo "⚠️ Failed to parse regression list JSON. Skipping Slack notification."
           echo "has_regressions=false" >> "$GITHUB_OUTPUT"

--- a/.github/actions/slack-report-analyze-workflow-data/action.yaml
+++ b/.github/actions/slack-report-analyze-workflow-data/action.yaml
@@ -7,14 +7,8 @@ inputs:
   channel_id:
     description: "Channel ID for the Slack channel (required if using Bot Token)"
     required: false
-  regressed_workflows:
-    description: "JSON array from analyze step output 'regressed_workflows'"
-    required: false
   regressed_workflows_path:
     description: "Path to a JSON file containing regressed workflows"
-    required: false
-  alert_all_message:
-    description: "Optional Slack-ready alert text from analyze step output 'alert_all_message'"
     required: false
   alert_all_message_path:
     description: "Path to a text file containing the Slack-ready alert text"

--- a/.github/actions/trigger-auto-triage-for-regressions/action.yml
+++ b/.github/actions/trigger-auto-triage-for-regressions/action.yml
@@ -1,8 +1,8 @@
 name: 'Trigger Auto-Triage for Regressions'
 description: 'Triggers auto-triage workflow for each regressed job'
 inputs:
-  regressed_workflows:
-    description: 'JSON array of regressed workflows with failing jobs'
+  regressed_workflows_path:
+    description: 'Path to a JSON file containing regressed workflows with failing jobs'
     required: true
   github_token:
     description: 'GitHub token for triggering workflows'

--- a/.github/actions/trigger-auto-triage-for-regressions/index.js
+++ b/.github/actions/trigger-auto-triage-for-regressions/index.js
@@ -1,6 +1,7 @@
 const core = require('@actions/core');
 const github = require('@actions/github');
 const https = require('https');
+const fs = require('fs');
 
 /**
  * Send a Slack message to a thread
@@ -66,7 +67,7 @@ async function sendSlackMessage(channelId, botToken, message, threadTs) {
 
 async function run() {
   try {
-    const regressedWorkflowsJson = core.getInput('regressed_workflows', { required: true });
+    const regressedWorkflowsPath = core.getInput('regressed_workflows_path', { required: true });
     const githubToken = core.getInput('github_token', { required: true });
     const slackTs = core.getInput('slack_ts') || '';
     const slackChannelId = core.getInput('slack_channel_id') || '';
@@ -82,6 +83,11 @@ async function run() {
     // while still defaulting to main when invoked from main.
     const dispatchRef = github.context.ref || 'refs/heads/main';
 
+    if (!fs.existsSync(regressedWorkflowsPath)) {
+      throw new Error(`Regressed workflows file not found: ${regressedWorkflowsPath}`);
+    }
+
+    const regressedWorkflowsJson = fs.readFileSync(regressedWorkflowsPath, 'utf8');
     const regressedWorkflows = JSON.parse(regressedWorkflowsJson);
     const octokit = github.getOctokit(githubToken);
 

--- a/.github/workflows/aggregate-workflow-data.yaml
+++ b/.github/workflows/aggregate-workflow-data.yaml
@@ -283,7 +283,7 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/slack-report-analyze-workflow-data
         with:
-          channel_id: ${{ secrets.SLACK_METAL_INFRA_CHANNEL_ID }}
+          channel_id: 'C09EC0QNSB0'
           regressed_workflows_path: ${{ github.workspace }}/regression-notification-inputs/regressed-workflows.json
           alert_all_message_path: ${{ github.workspace }}/regression-notification-inputs/alert-all-message.txt
         env:
@@ -299,32 +299,32 @@ jobs:
             echo "status=failed" >> "$GITHUB_OUTPUT"
           fi
 
-  trigger-auto-triage:
-    needs: [analyze-data, handle-failures]
-    if: ${{ always() && needs.analyze-data.result == 'success' && needs.analyze-data.outputs.has_regressions == 'true' && needs.handle-failures.outputs.slack_notification_status == 'success' }}
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          sparse-checkout: .github/actions
-          sparse-checkout-cone-mode: true
-      - name: Install dependencies
-        working-directory: .github/actions/trigger-auto-triage-for-regressions
-        run: npm install
-      - name: Download regression notification inputs
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
-        with:
-          name: workflow-regression-notification-inputs
-          path: ${{ github.workspace }}/regression-notification-inputs
-      - name: Trigger auto-triage for regressed jobs
-        uses: ./.github/actions/trigger-auto-triage-for-regressions
-        with:
-          regressed_workflows_path: ${{ github.workspace }}/regression-notification-inputs/regressed-workflows.json
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          slack_ts: ${{ needs.handle-failures.outputs.slack_ts }}
-          slack_channel_id: ${{ secrets.SLACK_METAL_INFRA_CHANNEL_ID }}
-          slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
-          send-slack-message: true
+  # trigger-auto-triage:
+  #   needs: [analyze-data, handle-failures]
+  #   if: ${{ always() && needs.analyze-data.result == 'success' && needs.analyze-data.outputs.has_regressions == 'true' && needs.handle-failures.outputs.slack_notification_status == 'success' }}
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     actions: write
+  #     contents: read
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         sparse-checkout: .github/actions
+  #         sparse-checkout-cone-mode: true
+  #     - name: Install dependencies
+  #       working-directory: .github/actions/trigger-auto-triage-for-regressions
+  #       run: npm install
+  #     - name: Download regression notification inputs
+  #       uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
+  #       with:
+  #         name: workflow-regression-notification-inputs
+  #         path: ${{ github.workspace }}/regression-notification-inputs
+  #     - name: Trigger auto-triage for regressed jobs
+  #       uses: ./.github/actions/trigger-auto-triage-for-regressions
+  #       with:
+  #         regressed_workflows_path: ${{ github.workspace }}/regression-notification-inputs/regressed-workflows.json
+  #         github_token: ${{ secrets.GITHUB_TOKEN }}
+  #         slack_ts: ${{ needs.handle-failures.outputs.slack_ts }}
+  #         slack_channel_id: ${{ secrets.SLACK_METAL_INFRA_CHANNEL_ID }}
+  #         slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+  #         send-slack-message: true

--- a/.github/workflows/aggregate-workflow-data.yaml
+++ b/.github/workflows/aggregate-workflow-data.yaml
@@ -138,9 +138,8 @@ jobs:
     needs: fetch-data
     runs-on: ubuntu-latest
     outputs:
-      failed_workflows: ${{ steps.analyze.outputs.failed_workflows }}
-      regressed_workflows: ${{ steps.analyze.outputs.regressed_workflows }}
-      alert_all_message: ${{ steps.analyze.outputs.alert_all_message }}
+      has_failed_workflows: ${{ steps.analyze.outputs.has_failed_workflows }}
+      has_regressions: ${{ steps.analyze.outputs.has_regressions }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -246,37 +245,63 @@ jobs:
           name: workflow-status-changes
           path: ${{ steps.analyze.outputs.status_changes_path }}
           retention-days: 1
+      - name: Upload regression notification inputs artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #@v4
+        with:
+          name: workflow-regression-notification-inputs
+          path: |
+            ${{ steps.analyze.outputs.failed_workflows_path }}
+            ${{ steps.analyze.outputs.regressed_workflows_path }}
+            ${{ steps.analyze.outputs.alert_all_message_path }}
+          retention-days: 1
 
 
   handle-failures:
     needs: analyze-data
-    if: ${{ fromJson(needs.analyze-data.outputs.failed_workflows) != '[]' }}
+    if: ${{ needs.analyze-data.outputs.has_failed_workflows == 'true' }}
     runs-on: ubuntu-latest
     outputs:
       slack_ts: ${{ steps.slack-report.outputs.slack_ts }}
+      slack_notification_status: ${{ steps.slack-status.outputs.status }}
     steps:
       - uses: actions/checkout@v4
         with:
           sparse-checkout: .github/actions
           sparse-checkout-cone-mode: true
+      - name: Download regression notification inputs
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
+        with:
+          name: workflow-regression-notification-inputs
+          path: ${{ github.workspace }}/regression-notification-inputs
       - name: Handle failed workflows
         run: |
           echo "The following workflows have failed:"
-          echo '${{ needs.analyze-data.outputs.failed_workflows }}' | jq -r '.[]'
+          jq -r '.[]' "${GITHUB_WORKSPACE}/regression-notification-inputs/failed-workflows.json"
           # Add any additional failure handling steps here
       - name: Post regressions to Slack
         id: slack-report
+        continue-on-error: true
         uses: ./.github/actions/slack-report-analyze-workflow-data
         with:
           channel_id: ${{ secrets.SLACK_METAL_INFRA_CHANNEL_ID }}
-          regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
-          alert_all_message: ${{ needs.analyze-data.outputs.alert_all_message }}
+          regressed_workflows_path: ${{ github.workspace }}/regression-notification-inputs/regressed-workflows.json
+          alert_all_message_path: ${{ github.workspace }}/regression-notification-inputs/alert-all-message.txt
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      - name: Record Slack notification status
+        if: ${{ always() }}
+        id: slack-status
+        shell: bash
+        run: |
+          if [ "${{ steps.slack-report.outcome }}" = "success" ]; then
+            echo "status=success" >> "$GITHUB_OUTPUT"
+          else
+            echo "status=failed" >> "$GITHUB_OUTPUT"
+          fi
 
   trigger-auto-triage:
     needs: [analyze-data, handle-failures]
-    if: ${{ always() && needs.analyze-data.result == 'success' && fromJson(needs.analyze-data.outputs.regressed_workflows) != '[]' }}
+    if: ${{ always() && needs.analyze-data.result == 'success' && needs.analyze-data.outputs.has_regressions == 'true' && needs.handle-failures.outputs.slack_notification_status == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       actions: write
@@ -289,10 +314,15 @@ jobs:
       - name: Install dependencies
         working-directory: .github/actions/trigger-auto-triage-for-regressions
         run: npm install
+      - name: Download regression notification inputs
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
+        with:
+          name: workflow-regression-notification-inputs
+          path: ${{ github.workspace }}/regression-notification-inputs
       - name: Trigger auto-triage for regressed jobs
         uses: ./.github/actions/trigger-auto-triage-for-regressions
         with:
-          regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
+          regressed_workflows_path: ${{ github.workspace }}/regression-notification-inputs/regressed-workflows.json
           github_token: ${{ secrets.GITHUB_TOKEN }}
           slack_ts: ${{ needs.handle-failures.outputs.slack_ts }}
           slack_channel_id: ${{ secrets.SLACK_METAL_INFRA_CHANNEL_ID }}

--- a/.github/workflows/aggregate-workflow-data.yaml
+++ b/.github/workflows/aggregate-workflow-data.yaml
@@ -293,7 +293,8 @@ jobs:
         id: slack-status
         shell: bash
         run: |
-          if [ "${{ steps.slack-report.outcome }}" = "success" ]; then
+          slack_ts="${{ steps.slack-report.outputs.slack_ts }}"
+          if [ -n "$slack_ts" ]; then
             echo "status=success" >> "$GITHUB_OUTPUT"
           else
             echo "status=failed" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/aggregate-workflow-data.yaml
+++ b/.github/workflows/aggregate-workflow-data.yaml
@@ -283,7 +283,7 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/slack-report-analyze-workflow-data
         with:
-          channel_id: 'C09EC0QNSB0'
+          channel_id: ${{ secrets.SLACK_METAL_INFRA_CHANNEL_ID }}
           regressed_workflows_path: ${{ github.workspace }}/regression-notification-inputs/regressed-workflows.json
           alert_all_message_path: ${{ github.workspace }}/regression-notification-inputs/alert-all-message.txt
         env:
@@ -299,32 +299,32 @@ jobs:
             echo "status=failed" >> "$GITHUB_OUTPUT"
           fi
 
-  # trigger-auto-triage:
-  #   needs: [analyze-data, handle-failures]
-  #   if: ${{ always() && needs.analyze-data.result == 'success' && needs.analyze-data.outputs.has_regressions == 'true' && needs.handle-failures.outputs.slack_notification_status == 'success' }}
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     actions: write
-  #     contents: read
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #       with:
-  #         sparse-checkout: .github/actions
-  #         sparse-checkout-cone-mode: true
-  #     - name: Install dependencies
-  #       working-directory: .github/actions/trigger-auto-triage-for-regressions
-  #       run: npm install
-  #     - name: Download regression notification inputs
-  #       uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
-  #       with:
-  #         name: workflow-regression-notification-inputs
-  #         path: ${{ github.workspace }}/regression-notification-inputs
-  #     - name: Trigger auto-triage for regressed jobs
-  #       uses: ./.github/actions/trigger-auto-triage-for-regressions
-  #       with:
-  #         regressed_workflows_path: ${{ github.workspace }}/regression-notification-inputs/regressed-workflows.json
-  #         github_token: ${{ secrets.GITHUB_TOKEN }}
-  #         slack_ts: ${{ needs.handle-failures.outputs.slack_ts }}
-  #         slack_channel_id: ${{ secrets.SLACK_METAL_INFRA_CHANNEL_ID }}
-  #         slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
-  #         send-slack-message: true
+  trigger-auto-triage:
+    needs: [analyze-data, handle-failures]
+    if: ${{ always() && needs.analyze-data.result == 'success' && needs.analyze-data.outputs.has_regressions == 'true' && needs.handle-failures.outputs.slack_notification_status == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: true
+      - name: Install dependencies
+        working-directory: .github/actions/trigger-auto-triage-for-regressions
+        run: npm install
+      - name: Download regression notification inputs
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
+        with:
+          name: workflow-regression-notification-inputs
+          path: ${{ github.workspace }}/regression-notification-inputs
+      - name: Trigger auto-triage for regressed jobs
+        uses: ./.github/actions/trigger-auto-triage-for-regressions
+        with:
+          regressed_workflows_path: ${{ github.workspace }}/regression-notification-inputs/regressed-workflows.json
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          slack_ts: ${{ needs.handle-failures.outputs.slack_ts }}
+          slack_channel_id: ${{ secrets.SLACK_METAL_INFRA_CHANNEL_ID }}
+          slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          send-slack-message: true


### PR DESCRIPTION
### Ticket
N/A

### Problem description
`aggregate-workflow-data` could fail in `handle-failures` before the Slack action even started running because large regression JSON and alert text were passed through workflow outputs and composite action inputs. When those values grew large enough, the runner hit the OS argument/environment limit and the scheduled workflow stalled until a later fresh run recovered it.

### What's changed
This routes regression notification data through artifact-backed files instead of large inline job outputs. `analyze-workflow-data` now writes failed workflow names, regressed workflow details, and the Slack alert text to files, uploads them as an artifact, and downstream jobs download those files for Slack reporting and auto-triage.

`handle-failures` now treats the Slack notification as non-fatal and records whether it succeeded. Auto-triage only runs when regressions exist and the Slack notification completed successfully, so a Slack failure no longer wedges the pipeline or triggers triage without the Slack thread.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ebanerjee/switch-to-json-artifact)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ebanerjee/switch-to-json-artifact)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ebanerjee/switch-to-json-artifact)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ebanerjee/switch-to-json-artifact)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ebanerjee/switch-to-json-artifact)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ebanerjee/switch-to-json-artifact)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early

#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). \"Choose your pipeline\" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.

The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ebanerjee/switch-to-json-artifact)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ebanerjee/switch-to-json-artifact)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ebanerjee/switch-to-json-artifact)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ebanerjee/switch-to-json-artifact)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ebanerjee/switch-to-json-artifact)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ebanerjee/switch-to-json-artifact)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

Made with [Cursor](https://cursor.com)