### PR TITLE
[skip ci] docs: add ttnn.xielu to api.rst to fix ttnn-ops-docs-check

### DIFF
--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -223,6 +223,7 @@ Pointwise Unary
    ttnn.std_hw
    ttnn.swiglu
    ttnn.swish
+   ttnn.xielu
    ttnn.tan
    ttnn.tanh
    ttnn.tanhshrink

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -223,7 +223,6 @@ Pointwise Unary
    ttnn.std_hw
    ttnn.swiglu
    ttnn.swish
-   ttnn.xielu
    ttnn.tan
    ttnn.tanh
    ttnn.tanhshrink
@@ -233,6 +232,7 @@ Pointwise Unary
    ttnn.trunc
    ttnn.unary_chain
    ttnn.var_hw
+   ttnn.xielu
 
 Pointwise Binary
 ================


### PR DESCRIPTION
### Ticket
Fixes https://github.com/tenstorrent/tt-metal/issues/39311

### Problem description
The TTNN Ops Docs Check job in Nightly tt-metal L2 tests was failing because `ttnn.xielu` is registered but was missing from `docs/source/ttnn/ttnn/api.rst`. The `detect_undocumented_ttnn_ops.py` script exits with code 1 when it finds undocumented registered ops.

### What's changed
Added `ttnn.xielu` to the documented ops list in `api.rst` (alphabetically after `ttnn.swish`). This satisfies the docs check without disabling it or adding the op to SKIPPED_OPS. No behavioral change to the op or docs build—only the ops index used by the check.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=fix/ttnn-xielu-docs-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:fix/ttnn-xielu-docs-check)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fix/ttnn-xielu-docs-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fix/ttnn-xielu-docs-check)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/ttnn-xielu-docs-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/ttnn-xielu-docs-check)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early