### PR TITLE
[skip ci] Add model CI tiers docs and improve all-model-tests filter system

### DIFF
--- a/.github/workflows/all-model-tests.yaml
+++ b/.github/workflows/all-model-tests.yaml
@@ -1,38 +1,45 @@
 name: "All Model Tests"
 
+run-name: >-
+  All Model Tests —
+  Tiers[${{ inputs.tier-1 && '1' || '' }}${{ inputs.tier-1 && inputs.tier-2 && ',' || '' }}${{ inputs.tier-2 && '2' || '' }}${{ (inputs.tier-1 || inputs.tier-2) && inputs.tier-3 && ',' || '' }}${{ inputs.tier-3 && '3' || '' }}]
+  Tests[${{ inputs.run-unit-tests && 'unit' || '' }}${{ inputs.run-unit-tests && inputs.run-e2e-tests && ',' || '' }}${{ inputs.run-e2e-tests && 'e2e' || '' }}${{ (inputs.run-unit-tests || inputs.run-e2e-tests) && inputs.run-sweep-tests && ',' || '' }}${{ inputs.run-sweep-tests && 'sweep' || '' }}]
+  Model[${{ inputs.model || 'all' }}]
+  SKUs[${{ inputs.skus }}]
+
 on:
   workflow_dispatch:
     inputs:
-      # ── Tier selection (checkboxes) ───────────────────────────────
-      tier-1:
-        description: "Tier 1"
-        required: false
-        type: boolean
-        default: true
-      tier-2:
-        description: "Tier 2"
-        required: false
-        type: boolean
-        default: true
-      tier-3:
-        description: "Tier 3"
-        required: false
-        type: boolean
-        default: false
-
       # ── Test type selection (checkboxes) ──────────────────────────
       run-unit-tests:
-        description: "Unit tests"
+        description: "Model Unit tests"
         required: false
         type: boolean
         default: true
       run-e2e-tests:
-        description: "End-to-end tests"
+        description: "Model End-to-end tests"
         required: false
         type: boolean
         default: true
       run-sweep-tests:
-        description: "Sweep tests"
+        description: "Model Sweep tests"
+        required: false
+        type: boolean
+        default: false
+
+      # ── Tier selection (checkboxes) ───────────────────────────────
+      tier-1:
+        description: "Tier 1 (Critical Models)"
+        required: false
+        type: boolean
+        default: true
+      tier-2:
+        description: "Tier 2 (Standard Models)"
+        required: false
+        type: boolean
+        default: true
+      tier-3:
+        description: "Tier 3 (Lower Priority Models)"
         required: false
         type: boolean
         default: false
@@ -46,7 +53,7 @@ on:
 
       # ── Other filters ─────────────────────────────────────────────
       model:
-        description: "Model filter (e.g. llama3.1-8b). Leave 'all' to run everything."
+        description: "Model filter — substring match (e.g. 'llama' matches llama3.1-8b, llama3.2-70b). See models/model_ci_tiers.md for the full list. Leave 'all' to run everything."
         required: false
         default: all
         type: string
@@ -146,12 +153,32 @@ jobs:
 
       - name: Check which tier/test-type combos have matching tests
         id: check
+        env:
+          ENABLED_SKUS: ${{ steps.resolve-skus.outputs.enabled-skus }}
+          MODEL_FILTER: ${{ inputs.model || 'all' }}
+          TIER_1: ${{ inputs.tier-1 }}
+          TIER_2: ${{ inputs.tier-2 }}
+          TIER_3: ${{ inputs.tier-3 }}
+          RUN_UNIT: ${{ inputs.run-unit-tests }}
+          RUN_E2E: ${{ inputs.run-e2e-tests }}
+          RUN_SWEEP: ${{ inputs.run-sweep-tests }}
         run: |
           python3 - <<'PYEOF'
           import yaml, os, sys
 
-          enabled_skus = "${{ steps.resolve-skus.outputs.enabled-skus }}".split(",")
-          model_filter = "${{ inputs.model || 'all' }}"
+          enabled_skus = os.environ["ENABLED_SKUS"].split(",")
+          model_filter = os.environ["MODEL_FILTER"]
+
+          # Which tiers and test types did the user select?
+          enabled_tiers = set()
+          if os.environ.get("TIER_1") == "true": enabled_tiers.add(1)
+          if os.environ.get("TIER_2") == "true": enabled_tiers.add(2)
+          if os.environ.get("TIER_3") == "true": enabled_tiers.add(3)
+
+          enabled_test_types = set()
+          if os.environ.get("RUN_UNIT") == "true": enabled_test_types.add("unit")
+          if os.environ.get("RUN_E2E") == "true": enabled_test_types.add("e2e")
+          if os.environ.get("RUN_SWEEP") == "true": enabled_test_types.add("sweep")
 
           # Map of test-type -> YAML file
           test_files = {
@@ -159,6 +186,12 @@ jobs:
               "e2e":   "tests/pipeline_reorg/models_e2e_tests.yaml",
               "sweep": "tests/pipeline_reorg/models_sweep_tests.yaml",
           }
+
+          def model_matches(test_model, filter_str):
+              """Substring match: 'llama' matches 'llama3.1-8b', 'llama3.2-70b', etc."""
+              if filter_str == "all":
+                  return True
+              return filter_str.lower() in test_model.lower()
 
           github_output = os.environ.get("GITHUB_OUTPUT", "")
           results = {}
@@ -183,14 +216,15 @@ jobs:
                       # Check if any SKU matches both the enabled list and the tier
                       for sku_name, sku_cfg in skus.items():
                           if sku_name in enabled_skus and sku_cfg.get("tier") == tier:
-                              # Check model filter
-                              if model_filter == "all" or test.get("model") == model_filter:
+                              # Check model filter (substring match)
+                              if model_matches(test.get("model", ""), model_filter):
                                   found = True
                                   break
                       if found:
                           break
                   results[key] = "true" if found else "false"
-                  if found:
+                  # Only count toward any_tests if the user actually selected this tier and test type
+                  if found and tier in enabled_tiers and test_type in enabled_test_types:
                       any_tests = True
 
           results["has-any-tests"] = "true" if any_tests else "false"
@@ -207,7 +241,20 @@ jobs:
               print(f"  {icon} {k} = {v}")
 
           if not any_tests:
-              print("\n::warning::No tests match the selected combination of tiers, test types, SKUs, and model filter. Nothing will run.")
+              missing = []
+              if not enabled_test_types:
+                  missing.append("test group")
+              if not enabled_tiers:
+                  missing.append("tier")
+              if not enabled_skus or enabled_skus == [""]:
+                  missing.append("SKU")
+              if not model_filter:
+                  missing.append("model")
+              if missing:
+                  print(f"\n::error::No tests to run. Please select at least one: {', '.join(missing)}.")
+              else:
+                  print(f"\n::error::No tests to run. No tests match the selected filters (tiers={sorted(enabled_tiers)}, test groups={sorted(enabled_test_types)}, SKUs={enabled_skus}, model={model_filter}).")
+              sys.exit(1)
           PYEOF
 
   # ── Build (only if at least one combo has tests) ─────────────────

--- a/.github/workflows/models-e2e-tests-impl.yaml
+++ b/.github/workflows/models-e2e-tests-impl.yaml
@@ -67,9 +67,9 @@ jobs:
           MATRIX='${{ steps.build-matrix.outputs.matrix }}'
           # Filter by tier
           FILTERED=$(echo "$MATRIX" | jq -c --argjson tier ${{ inputs.tier }} '[.[] | select(.tier == $tier)]')
-          # Filter by model
+          # Filter by model (substring match, case-insensitive)
           if [ "${{ inputs.model }}" != "all" ]; then
-            FILTERED=$(echo "$FILTERED" | jq -c --arg m "${{ inputs.model }}" '[.[] | select(.model == $m)]')
+            FILTERED=$(echo "$FILTERED" | jq -c --arg m "${{ inputs.model }}" '[.[] | select(.model | test($m; "i"))]')
           fi
           if [ "$FILTERED" = "[]" ]; then
             echo "::warning::No tests found for tier=${{ inputs.tier }}, model=${{ inputs.model }}. Pipeline will be skipped."

--- a/.github/workflows/models-sweep-tests-impl.yaml
+++ b/.github/workflows/models-sweep-tests-impl.yaml
@@ -67,9 +67,9 @@ jobs:
           MATRIX='${{ steps.build-matrix.outputs.matrix }}'
           # Filter by tier
           FILTERED=$(echo "$MATRIX" | jq -c --argjson tier ${{ inputs.tier }} '[.[] | select(.tier == $tier)]')
-          # Filter by model
+          # Filter by model (substring match, case-insensitive)
           if [ "${{ inputs.model }}" != "all" ]; then
-            FILTERED=$(echo "$FILTERED" | jq -c --arg m "${{ inputs.model }}" '[.[] | select(.model == $m)]')
+            FILTERED=$(echo "$FILTERED" | jq -c --arg m "${{ inputs.model }}" '[.[] | select(.model | test($m; "i"))]')
           fi
           if [ "$FILTERED" = "[]" ]; then
             echo "::warning::No tests found for tier=${{ inputs.tier }}, model=${{ inputs.model }}. Pipeline will be skipped."

--- a/.github/workflows/models-unit-tests-impl.yaml
+++ b/.github/workflows/models-unit-tests-impl.yaml
@@ -67,9 +67,9 @@ jobs:
           MATRIX='${{ steps.build-matrix.outputs.matrix }}'
           # Filter by tier
           FILTERED=$(echo "$MATRIX" | jq -c --argjson tier ${{ inputs.tier }} '[.[] | select(.tier == $tier)]')
-          # Filter by model
+          # Filter by model (substring match, case-insensitive)
           if [ "${{ inputs.model }}" != "all" ]; then
-            FILTERED=$(echo "$FILTERED" | jq -c --arg m "${{ inputs.model }}" '[.[] | select(.model == $m)]')
+            FILTERED=$(echo "$FILTERED" | jq -c --arg m "${{ inputs.model }}" '[.[] | select(.model | test($m; "i"))]')
           fi
           if [ "$FILTERED" = "[]" ]; then
             echo "::warning::No tests found for tier=${{ inputs.tier }}, model=${{ inputs.model }}. Pipeline will be skipped."

--- a/models/model_ci_tiers.md
+++ b/models/model_ci_tiers.md
@@ -1,0 +1,141 @@
+# Model CI Testing Tiers
+
+This document aims to explain our new approach to internal testing of supported models. It does not aim to replace the list of supported models in Tenstorrent hardware. Please refer to the main README file for that.
+
+TT-Metal uses a 3-tier system to classify models for CI testing. Each tier defines a different level of test coverage and frequency, allowing us to prioritize CI/CD resources where they matter most while maintaining broad coverage across the model portfolio.
+
+All models deemed supported by TT-Metal are guaranteed to be compatible with the latest software release, regardless of their tier. If a bug is introduced that breaks model compatibility, it will be addressed in order of priority according to its tier.
+
+The current classification addresses both models and target systems. As such, the same model might belong to different tiers, if targeting different systems. In many cases, a model is compatible across our full range of systems and architectures, even if it is not explicitly listed here.
+
+# Definitions
+
+## Coverage at a Glance
+
+| Test Type | Tier 1 | Tier 2 | Tier 3 |
+|-----------|--------|--------|--------|
+| End-to-End Tests | Full (perf, determinism, accuracy) | Full | Accuracy only |
+| Unit Tests | All required modules | All required modules | Most critical module only |
+| Sweep Tests | Comprehensive | Reduced | — |
+| Device OP Perf Tests | Yes | — | — |
+| vLLM Integration Tests | Yes | Yes | — |
+| PR/Merge Gate Tests | Yes | — | — |
+| Stress Tests | Yes | — | — |
+
+## Tier 1 — Full Coverage
+Tier 1 models receive the highest priority for developer time and bug fixing. They run the full CI test suite on a frequent schedule, including comprehensive sweeps, per-OP device performance tracking, commit-level gate tests, and multi-hour stress runs.
+
+## Tier 2 — Standard Coverage
+Tier 2 models share most test types with Tier 1 but at reduced scope. Sweep tests cover fewer sequence lengths and parameters. Stress tests, PR/merge gate tests, and device OP performance tests are excluded.
+
+## Tier 3 — Minimum Coverage
+Tier 3 models are compatible with the latest TT-Metal releases but are not optimized for best performance. Testing is kept to the minimum needed to confirm the models remain functional and accurate: an end-to-end accuracy check and a unit test for the most critical module.
+
+
+# Current Model Assignments
+
+The initial release of the 3-tier model CI includes models owned by the models-team. We plan to onboard the remaining models incrementally to reduce CI load. The current list of models and systems in the new pipelines can be seen below.
+
+
+## Tier 1 Models
+| Model | Systems |
+|-------|---------|
+| Llama3.3-70B | WH Galaxy, BH Galaxy |
+| Qwen3-32B | WH Galaxy, BH Galaxy |
+| Deepseek | WH Galaxy |
+| GPT-OSS | WH Galaxy |
+| llama3.1-8B | N150, P150 |
+| Whisper | N150, P150 |
+## Tier 2 Models
+| Model | Systems |
+|-------|---------|
+| GPT-OSS 120B batch=1 | WH Galaxy |
+| GPT-OSS 20B | WH LoudBox |
+| Llama70B (TTT) | WH/BH LoudBox |
+| Qwen3-32B (TTT) | WH/BH LoudBox |
+| Qwen2.5 32B (TTT) | WH LoudBox |
+| llama90B-VL | WH LoudBox |
+| Qwen2.5-72B-VL | WH LoudBox |
+| Shallow-UNet | N150 |
+| Mistral-7B | N150 |
+| Mixtral 8x7B | WH LoudBox |
+| Gemma-3-27B | WH LoudBox |
+## Tier 3 Models
+| Model | Systems |
+|-------|---------|
+| Falcon-7B | N150 |
+| Falcon-40B | WH LoudBox |
+| Mamba | N150 |
+| Llama 1B | N150 |
+| Llama 3B | N150 |
+| Llama 11B text | N150 |
+| Llama 11B-VL | WH LoudBox |
+| Qwen 2.5B-7B | N150 |
+| Qwen 2.5B-72B | WH LoudBox |
+| Qwen2.5-VL-32B-Instruct | WH LoudBox |
+| Phi 1.5 | N150 |
+| Phi 1.4 | N150 |
+
+
+# Pipelines
+
+Each test type has a per-tier GitHub Actions workflow and a shared configuration file. The workflows are separated by tier to allow independent scheduling, but the test definitions live in a single config YAML per pipeline.
+
+## End-to-End Tests
+
+This pipeline covers two areas:
+- **Performance evaluation** — Runs multiple batch-32 requests, reports TTFT and tokens/sec/user, and validates determinism by comparing outputs across batches.
+- **Accuracy validation** — Uses teacher forcing against a reference to report top-1/top-5 accuracy against pre-established targets.
+
+| Tier | Workflow |
+|------|----------|
+| Tier 1 | [`[Tier 1] Models End-To-End Tests`](../.github/workflows/models-t1-e2e-tests.yaml) |
+| Tier 2 | [`[Tier 2] Models End-To-End Tests`](../.github/workflows/models-t2-e2e-tests.yaml) |
+| Tier 3 | [`[Tier 3] Models End-To-End Tests`](../.github/workflows/models-t3-e2e-tests.yaml) |
+| Config | [`models_e2e_tests.yaml`](../tests/pipeline_reorg/models_e2e_tests.yaml) |
+
+## Unit Tests
+
+Short module-level tests that compare PCC against the reference implementation. Tier 1 and 2 models should cover most components; Tier 3 requires only the most critical module (typically a single decoder layer for LLMs).
+
+| Tier | Workflow |
+|------|----------|
+| Tier 1 | [`[Tier 1] Models Unit Tests`](../.github/workflows/models-t1-unit-tests.yaml) |
+| Tier 2 | [`[Tier 2] Models Unit Tests`](../.github/workflows/models-t2-unit-tests.yaml) |
+| Tier 3 | [`[Tier 3] Models Unit Tests`](../.github/workflows/models-t3-unit-tests.yaml) |
+| Config | [`models_unit_tests.yaml`](../tests/pipeline_reorg/models_unit_tests.yaml) |
+
+## Sweep Tests
+
+Parameter sweeps across the configurations each model supports. Currently includes:
+- **Sequence length** — From short contexts up to the model's maximum supported length
+- **Sampling parameters** — Logprobs, seeds, penalties, and other sampling features
+- **Prefetcher** — Runs with prefetcher enabled and disabled to isolate model-specific issues
+
+| Tier | Workflow |
+|------|----------|
+| Tier 1 | [`[Tier 1] Models Sweep Tests`](../.github/workflows/models-t1-sweep-tests.yaml) |
+| Tier 2 | [`[Tier 2] Models Sweep Tests`](../.github/workflows/models-t2-sweep-tests.yaml) |
+| Config | [`models_sweep_tests.yaml`](../tests/pipeline_reorg/models_sweep_tests.yaml) |
+
+> **Note:** Tier 3 does not include sweep tests.
+
+## Device Perf Tests
+
+Captures device timing for a single layer of each target model, used to track performance for models under active optimization. Tier 1 only.
+
+> **TODO:** Add pipeline links once merged to main.
+
+## Other Pipelines
+
+> **TODO:** Expand descriptions for the pipelines below.
+
+| Pipeline | Workflow |
+|----------|----------|
+| Models post-commit | [`[internal] models tests impl`](../.github/workflows/models-post-commit.yaml) |
+| PR Gate | [`PR Gate`](../.github/workflows/pr-gate.yaml) |
+| Merge Gate | [`Merge Gate`](../.github/workflows/merge-gate.yaml) |
+| vLLM nightly tests | [`vLLM nightly tests`](../.github/workflows/vllm-nightly-tests.yaml) |
+| vLLM nightly impl | [`[internal] vLLM nightly tests impl`](../.github/workflows/vllm-nightly-tests-impl.yaml) |
+| Galaxy stress tests | [`(Galaxy) Stress`](../.github/workflows/galaxy-stress-tests.yaml) |
+| TTNN stress tests | [`ttnn stress tests`](../.github/workflows/ttnn-stress-tests.yaml) |


### PR DESCRIPTION
Issue: #39322

## Summary
- Adds `models/model_ci_tiers.md` documenting the 3-tier model CI testing classification (tier definitions, model/system assignments, pipeline references)
- Improves the `all-model-tests.yaml` workflow filter system:
  - Use env vars instead of string interpolation in preflight Python (robustness)
  - Add substring model filtering, case-insensitive (e.g. `llama` matches `llama3.1-8b`, `llama3.2-70b`)
  - Add dynamic `run-name` showing selected tiers, test groups, model filter, and SKUs
  - Reorder and clarify input descriptions in the dispatch UI
  - Reference `models/model_ci_tiers.md` in the model filter description
- Updates all 3 impl workflows (`models-unit-tests-impl`, `models-e2e-tests-impl`, `models-sweep-tests-impl`) to use substring model matching via jq `test()`