### PR TITLE
Fix MLA broadcast data corruption from ccl buffer reuse

### DIFF
--- a/models/demos/deepseek_v3_b1/circular_buffer_utils.py
+++ b/models/demos/deepseek_v3_b1/circular_buffer_utils.py
@@ -81,8 +81,8 @@ class CircularBufferIdManager:
         """
         descs = []
         for cb_id, (data_format, tile_desc) in self._id_to_format.items():
-            tile = ttnn.Tile([tile_desc.height, tile_desc.width])
-            page_size = tile.get_tile_size(data_format)
+            # Minimal page size for dummy descriptors
+            page_size = 1
 
             fmt = ttnn.CBFormatDescriptor(
                 buffer_index=cb_id,

--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
@@ -179,7 +179,6 @@ class AttentionBlock:
     @staticmethod
     def get_program_context(
         input_tensor_mesh,
-        intermediate_tensor_mesh,
         gamma_tensor,
         matmul_weights_tensor,
         rmsnorm2_gamma_tensor,
@@ -232,7 +231,6 @@ class AttentionBlock:
 
         Args:
             input_tensor_mesh: Input mesh tensor (must be sharded on single core per device)
-            intermediate_tensor_mesh: Intermediate mesh tensor for CCL broadcast destination
             gamma_tensor: OverlappedTensor for attn_norm gamma (shares fused o_proj/gate/gamma buffer)
             matmul_weights_tensor: OverlappedTensor for packed q_a_proj weights (shares fused buffer)
             rmsnorm2_gamma_tensor: OverlappedTensor for q_norm gamma (shares fused o_proj/gate/gamma buffer)
@@ -277,7 +275,6 @@ class AttentionBlock:
 
         # Get per-device tensors
         input_tensors_per_device = ttnn.get_device_tensors(input_tensor_mesh)
-        intermediate_tensors_per_device = ttnn.get_device_tensors(intermediate_tensor_mesh)
         gamma_fused_tensors_per_device = ttnn.get_device_tensors(gamma_tensor.fused_tensor)
         fused_weights_tensors_per_device = ttnn.get_device_tensors(matmul_weights_tensor.fused_tensor)
         kv_b12_fused_tensors_per_device = ttnn.get_device_tensors(matmul3_weights_tensor.fused_tensor)
@@ -1920,7 +1917,6 @@ class AttentionBlock:
 
                 # Get the device's tensors
                 input_tensor_device = input_tensors_per_device[device_idx]
-                intermediate_tensor_device = intermediate_tensors_per_device[device_idx]
                 gamma_fused_tensor_device = gamma_fused_tensors_per_device[device_idx]
                 fused_weights_tensor_device = fused_weights_tensors_per_device[device_idx]
                 kv_b12_fused_tensor_device = kv_b12_fused_tensors_per_device[device_idx]
@@ -2008,14 +2004,34 @@ class AttentionBlock:
                 ]
 
                 sdpa_out_interm_running_offset = 0
+                # CBs overlapped with sdpa_kv_cache L1 buffer (consumed before SDPA runs)
+                sdpa_kv_cache_running_offset = 0
+                # CBs overlapped with sdpa_kv_cache L1 buffer permanently allocated on the mcast core
+                # Nothing should reuse this space on the mcast core
+                sdpa_kv_cache_running_offset_mcast_core = 0
 
                 # Create circular buffer descriptors
                 # CB: Input (created from sharded tensor)
-                cb0_backing_tensor = input_tensor_device if skip_ccl else intermediate_tensor_device
-                in_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(input_cb, cb0_backing_tensor)
-                # Update the tile descriptor in the format descriptor
-                in_cb_descriptor.format_descriptors[0].tile = tile_descriptor
-                in_cb_descriptor.format_descriptors[0].page_size = cb_page_size
+                broadcast_address = 0
+                if skip_ccl:
+                    in_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(input_cb, input_tensor_device)
+                else:
+                    in_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+                        input_cb,
+                        sdpa_kv_cache_buffer_device,
+                        address_offset=sdpa_kv_cache_running_offset_mcast_core,
+                        total_size=num_tiles * cb_page_size,
+                    )
+                    broadcast_address = ttnn.get_cb_address(in_cb_descriptor)
+                    in_cb_descriptor.format_descriptors = [
+                        ttnn.CBFormatDescriptor(
+                            buffer_index=input_cb,
+                            data_format=data_format,
+                            page_size=cb_page_size,
+                            tile=tile_descriptor,
+                        )
+                    ]
+                    sdpa_kv_cache_running_offset_mcast_core += in_cb_descriptor.total_size
 
                 # CB: Gamma (backed by fused overlapped tensor)
                 gamma_cb_descriptor = cb_descriptor_from_overlapped_tensor(
@@ -2030,10 +2046,6 @@ class AttentionBlock:
                 )
                 rmsnorm2_gamma_cb_descriptor.format_descriptors[0].tile = rmsnorm2_tile_descriptor
                 rmsnorm2_gamma_cb_descriptor.format_descriptors[0].page_size = rmsnorm2_page_size
-
-                # CBs overlapped with sdpa_kv_cache L1 buffer (consumed before SDPA runs)
-                sdpa_kv_cache_running_offset = 0
-                sdpa_kv_cache_running_offset_mcast_core = 0
 
                 # CB: CCL broadcast packet buffer
                 bcast_pkt_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(bcast_pkt_cb, input_tensor_device)
@@ -2757,15 +2769,25 @@ class AttentionBlock:
                 running_address_offset += ccl_sender_in_cb_descriptor.total_size
                 post_sdpa_cb_list.append(ccl_sender_in_cb_descriptor)
 
-                # CB 9: CCL remote data (backed by intermediate tensor with 1x32 tiles)
+                # CB 9: CCL remote data (backed by intermediate tensor with 32x32 tiles)
                 # The intermediate tensor is where the CCL sender writes remote data
                 ccl_remote_data_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
-                    ccl_remote_data_cb, intermediate_tensor_device
+                    ccl_remote_data_cb,
+                    sdpa_kv_cache_buffer_device,
+                    address_offset=sdpa_kv_cache_running_offset_mcast_core,
+                    total_size=ccl_num_pages * tile_size,
                 )
-                ccl_remote_data_cb_descriptor.core_ranges = gather_core_grid
-                ccl_remote_data_cb_descriptor.format_descriptors[0].tile = tile_descriptor
-                ccl_remote_data_cb_descriptor.format_descriptors[0].page_size = cb_page_size
+                ccl_remote_data_cb_descriptor.format_descriptors = [
+                    ttnn.CBFormatDescriptor(
+                        buffer_index=ccl_remote_data_cb,
+                        data_format=data_format,
+                        page_size=tile_size,
+                        tile=tile_descriptor,
+                    )
+                ]
+                sdpa_kv_cache_running_offset_mcast_core += ccl_remote_data_cb_descriptor.total_size
                 post_sdpa_cb_list.append(ccl_remote_data_cb_descriptor)
+                ccl_send_addr = ttnn.get_cb_address(ccl_remote_data_cb_descriptor)
 
                 # CB 11: CCL temp scratch buffer (not backed by tensor)
                 ccl_temp_cb_format = ttnn.CBFormatDescriptor(
@@ -3124,7 +3146,7 @@ class AttentionBlock:
                     num_connections = len(dst_nodes)
 
                     ncrisc_bcast_common_args = [
-                        int(intermediate_tensor_device.buffer_address()),  # tensor_address0
+                        int(broadcast_address),  # tensor_address0
                         int(out_ready_sem_addr),  # out_ready_sem_bank_addr
                         int(wait_output_semaphore),
                         int(reset_global_semaphore),
@@ -3447,7 +3469,7 @@ class AttentionBlock:
                     gather3_receiver_data_addr,
                 ]
                 ccl_sender_brisc_common_rt_args = [
-                    intermediate_tensor_device.buffer_address(),
+                    ccl_send_addr,
                     ccl_sender_semaphore_addr,
                 ]
                 ccl_receiver_ncrisc_common_rt_args = [
@@ -3736,7 +3758,6 @@ class AttentionBlock:
     @staticmethod
     def op(
         input_tensor_mesh,
-        intermediate_tensor_mesh,
         gamma_tensor,
         matmul_weights_tensor,
         rmsnorm2_gamma_tensor,
@@ -3785,7 +3806,6 @@ class AttentionBlock:
     ):
         io_tensors = [
             input_tensor_mesh,
-            intermediate_tensor_mesh,
             gamma_tensor.fused_tensor,
             matmul_weights_tensor.fused_tensor,
             matmul3_weights_tensor.fused_tensor,
@@ -3804,7 +3824,6 @@ class AttentionBlock:
         cb_id_context = cb_id_manager.create_context()
         full_device_grid, attention_block_per_device_contexts = AttentionBlock.get_program_context(
             input_tensor_mesh,
-            intermediate_tensor_mesh,
             gamma_tensor,
             matmul_weights_tensor,
             rmsnorm2_gamma_tensor,

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_attention_block.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_attention_block.py
@@ -341,7 +341,6 @@ def test_attention_block(
     # Create mesh tensors for input and intermediate (CCL broadcast destination)
     sender_coord = ttnn.MeshCoordinate(sender_row, sender_col)
     device_tensors = []
-    intermediate_tensors = []
     for row in range(mesh_rows):
         for col in range(mesh_cols):
             if skip_ccl:
@@ -353,23 +352,11 @@ def test_attention_block(
             else:
                 # All other devices start with zeros
                 device_tensors.append(torch.zeros_like(torch_input))  # (1, 7168)
-            intermediate_tensors.append(torch.zeros_like(torch_input))
 
     mesh_tensor_torch = torch.cat(device_tensors, dim=0)
-    intermediate_mesh_tensor_torch = torch.cat(intermediate_tensors, dim=0)
 
     input_tensor_mesh = ttnn.from_torch(
         mesh_tensor_torch,
-        device=submesh,
-        layout=ttnn.TILE_LAYOUT,
-        tile=tile,
-        dtype=ttnn.bfloat16,
-        memory_config=mem_config,
-        mesh_mapper=ttnn.ShardTensorToMesh(submesh, dim=0),
-    )
-
-    intermediate_tensor_mesh = ttnn.from_torch(
-        intermediate_mesh_tensor_torch,
         device=submesh,
         layout=ttnn.TILE_LAYOUT,
         tile=tile,
@@ -804,18 +791,6 @@ def test_attention_block(
         mesh_mapper=mesh_mapper,
     )
 
-    # torch residual tensor is the same as the input tensor
-    mesh_residual_torch = torch.cat([torch_input] * num_devices, dim=0)
-    ttnn_residual = ttnn.from_torch(
-        mesh_residual_torch,
-        device=submesh,
-        layout=ttnn.TILE_LAYOUT,
-        tile=a_tile,
-        dtype=ttnn.bfloat16,
-        memory_config=output_mem_config,
-        mesh_mapper=mesh_mapper,
-    )
-
     # ========================================================================
     # Create SDPA tensors
     # ========================================================================
@@ -936,7 +911,6 @@ def test_attention_block(
     for i in range(num_iters):
         ttnn_output_result = AttentionBlock.op(
             input_tensor_mesh,
-            intermediate_tensor_mesh,
             gamma_overlapped,
             matmul_weights_overlapped,
             rmsnorm2_gamma_overlapped,

--- a/models/demos/deepseek_v3_b1/unified_kernels/broadcast.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/broadcast.hpp
@@ -265,11 +265,9 @@ struct Broadcast {
                     // between iterations will naturally sync the devices, but wait_min is a
                     // pragmatic choice to streamline standalone testing.
                     if (args.wait_output_semaphore) {
-                        WATCHER_RING_BUFFER_PUSH(0xA1);
                         volatile tt_l1_ptr uint32_t* sem_ptr =
                             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.out_ready_sem_bank_addr);
                         noc_semaphore_wait_min(sem_ptr, args.out_ready_sem_wait_value);
-                        WATCHER_RING_BUFFER_PUSH(0xA2);
                     }
 
                     // 4. global semaphore reset
@@ -284,11 +282,9 @@ struct Broadcast {
                     // Secondary sender: wait for data from primary sender, then broadcast along primary axis
                     // First wait for data to arrive from primary sender
                     if (args.wait_output_semaphore) {
-                        WATCHER_RING_BUFFER_PUSH(0xB1);
                         volatile tt_l1_ptr uint32_t* sem_ptr =
                             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.out_ready_sem_bank_addr);
                         noc_semaphore_wait_min(sem_ptr, args.out_ready_sem_wait_value);
-                        WATCHER_RING_BUFFER_PUSH(0xB2);
                     }
 
                     // Reset semaphore after receiving data
@@ -319,11 +315,9 @@ struct Broadcast {
                 } else {
                     // Receiver: wait for data from broadcaster
                     if (args.wait_output_semaphore) {
-                        WATCHER_RING_BUFFER_PUSH(0xC1);
                         volatile tt_l1_ptr uint32_t* sem_ptr =
                             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.out_ready_sem_bank_addr);
                         noc_semaphore_wait_min(sem_ptr, args.out_ready_sem_wait_value);
-                        WATCHER_RING_BUFFER_PUSH(0xC2);
                     }
 
                     // Reset global semaphore


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
MLA Broadcast and TP Reduce were using the same buffer. This can cause a race because columns of the 2x4 can run independently up to the TP reduce, so with slow dispatch, one column can actually start the TP reduce and write data into the other column before the other column starts, which means it overwrote the broadcast data.

### What's changed
Make broadcast and reduce use separate buffers. Remove some intermediate L1 tensor allocs that are no longer needed.
Reduce dummy cb size to just 1B for a page, instead of a tile size.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=aho/mla-cbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:aho/mla-cbs)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aho/mla-cbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/mla-cbs)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aho/mla-cbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/mla-cbs)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aho/mla-cbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/mla-cbs)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aho/mla-cbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/mla-cbs)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aho/mla-cbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/mla-cbs)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
