### PR TITLE
Groupnorm - Improve Validation, Make Gamma/Beta Optional, Add Interleaved Grid Helper

### DIFF
--- a/tests/ttnn/docs_examples/test_normalization_examples.py
+++ b/tests/ttnn/docs_examples/test_normalization_examples.py
@@ -57,8 +57,7 @@ def test_group_norm(device):
         ttnn.ShardOrientation.ROW_MAJOR,
     )
 
-    # Now create the input tensors, starting with the input mask
-    # This is needed for each group to be able to select the correct elements of the input tensor
+    # Create the input mask which helps each group select the correct elements of the input tensor
     # In general, it will have dimensions of [1, num_groups, 32, 32*block_wt]
 
     # In this example, C=64 and num_groups=2, so each group is 32 channels (i.e. one tile) wide

--- a/tests/ttnn/docs_examples/test_normalization_examples.py
+++ b/tests/ttnn/docs_examples/test_normalization_examples.py
@@ -30,7 +30,8 @@ def test_group_norm(device):
     torch_output_tensor = torch_output_tensor.permute(0, 2, 3, 1).view(N, 1, W * H, C)
 
     # Prepare TTNN input
-    # Determine how to shard the input tensor
+    # Determine how to shard the input tensor.
+    # For interleaved (non-sharded) tensors, use ttnn.determine_expected_group_norm_dram_grid_size instead to determine the grid size.
     sharded_mem_config, grid_size = ttnn.determine_expected_group_norm_sharded_config_and_grid_size(
         device=device,
         num_channels=C,

--- a/tests/ttnn/docs_examples/test_normalization_examples.py
+++ b/tests/ttnn/docs_examples/test_normalization_examples.py
@@ -61,7 +61,7 @@ def test_group_norm(device):
     # While [0][1][:][:] would be a 32x32 tensor where the left half is 0 and the right half is 1
     # Determine how many cores split the channel dimension.
     # For height sharding this is always 1; for block sharding it depends on the shard orientation.
-    num_cores_across_channel = get_group_norm_cores_across_channel(
+    num_cores_across_channel = ttnn.get_group_norm_cores_across_channel(
         ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED,
         grid_size,
         ttnn.ShardOrientation.ROW_MAJOR,

--- a/tests/ttnn/docs_examples/test_normalization_examples.py
+++ b/tests/ttnn/docs_examples/test_normalization_examples.py
@@ -30,7 +30,7 @@ def test_group_norm(device):
     torch_output_tensor = torch_output_tensor.permute(0, 2, 3, 1).view(N, 1, W * H, C)
 
     # Prepare TTNN input
-    # Determine how to shard the input tensor.
+    # Determine how to shard the input tensor - this example uses height sharding
     # For interleaved (non-sharded) tensors, use ttnn.determine_expected_group_norm_dram_grid_size instead to determine the grid size.
     sharded_mem_config, grid_size = ttnn.determine_expected_group_norm_sharded_config_and_grid_size(
         device=device,
@@ -49,7 +49,16 @@ def test_group_norm(device):
         memory_config=sharded_mem_config,
     )
 
-    # Input mask - this is needed for each group to be able to select the correct elements of the input tensor
+    # To prepare the input tensors, we need to know how many cores split the channel dimension.
+    # For height sharding (as in this example) this is always 1; for block sharding it depends on the shard orientation.
+    num_cores_across_channel = ttnn.get_group_norm_cores_across_channel(
+        ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED,
+        grid_size,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+
+    # Now create the input tensors, starting with the input mask
+    # This is needed for each group to be able to select the correct elements of the input tensor
     # In general, it will have dimensions of [1, num_groups, 32, 32*block_wt]
 
     # In this example, C=64 and num_groups=2, so each group is 32 channels (i.e. one tile) wide
@@ -59,14 +68,6 @@ def test_group_norm(device):
     # As a result, the input_mask_tensor would be a [1, 4, 32, 32] tensor that selects either the first or second half of the tile
     # e.g. The mask at [0][0][:][:] would be a 32x32 tensor where the left half is 1 and the right half is 0
     # While [0][1][:][:] would be a 32x32 tensor where the left half is 0 and the right half is 1
-    # Determine how many cores split the channel dimension.
-    # For height sharding this is always 1; for block sharding it depends on the shard orientation.
-    num_cores_across_channel = ttnn.get_group_norm_cores_across_channel(
-        ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED,
-        grid_size,
-        ttnn.ShardOrientation.ROW_MAJOR,
-    )
-
     input_mask_tensor = ttnn.create_group_norm_input_mask(
         num_channel=C,
         num_groups=num_groups,

--- a/tests/ttnn/docs_examples/test_normalization_examples.py
+++ b/tests/ttnn/docs_examples/test_normalization_examples.py
@@ -59,10 +59,18 @@ def test_group_norm(device):
     # As a result, the input_mask_tensor would be a [1, 4, 32, 32] tensor that selects either the first or second half of the tile
     # e.g. The mask at [0][0][:][:] would be a 32x32 tensor where the left half is 1 and the right half is 0
     # While [0][1][:][:] would be a 32x32 tensor where the left half is 0 and the right half is 1
+    # Determine how many cores split the channel dimension.
+    # For height sharding this is always 1; for block sharding it depends on the shard orientation.
+    num_cores_across_channel = get_group_norm_cores_across_channel(
+        ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED,
+        grid_size,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+
     input_mask_tensor = ttnn.create_group_norm_input_mask(
         num_channel=C,
         num_groups=num_groups,
-        num_cores_across_channel=1,  # As explained in the Limitations, supply 1 for height sharded input tensors
+        num_cores_across_channel=num_cores_across_channel,
         data_type=ttnn.bfloat8_b,
     )
     input_mask_tensor = ttnn.to_device(input_mask_tensor, device)
@@ -70,10 +78,12 @@ def test_group_norm(device):
     # Prepare gamma and beta for TTNN. Currently these are just 1D tensors of size [C], which isn't compatible with tile based processing
     # First they will zero padded if needed (does not apply to this example)
     # Then reshaped to be [1, 1, tiles_per_core_total, 32], which in this case will be [1, 1, 2, 32]
-
-    # As with the input mask, we supply a core count of 1 for height sharded input tensors
-    gamma = ttnn.create_group_norm_weight_bias_rm(input_tensor=torch_weight, num_channels=C, num_cores_x=1)
-    beta = ttnn.create_group_norm_weight_bias_rm(input_tensor=torch_bias, num_channels=C, num_cores_x=1)
+    gamma = ttnn.create_group_norm_weight_bias_rm(
+        input_tensor=torch_weight, num_channels=C, num_cores_x=num_cores_across_channel
+    )
+    beta = ttnn.create_group_norm_weight_bias_rm(
+        input_tensor=torch_bias, num_channels=C, num_cores_x=num_cores_across_channel
+    )
 
     gamma_t = ttnn.from_torch(
         gamma,

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
@@ -1066,4 +1066,4 @@ def test_group_norm_optional_weight_bias(device, N, C, H, W, num_groups, use_wel
     tt_output = ttnn.from_device(tt_output)
     tt_output = ttnn.to_torch(tt_output)
 
-    assert_with_pcc(torch_output, tt_output, 0.999)
+    assert_with_pcc(torch_output, tt_output, 0.998 if use_welford else 0.999)

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
@@ -970,3 +970,100 @@ def test_group_norm_dram_grid_size(device, N, C, H, W, num_groups):
     tt_output = ttnn.to_torch(tt_output)
 
     assert_with_pcc(torch_output, tt_output, 0.999)
+
+
+@pytest.mark.parametrize(
+    "N, C, H, W, num_groups",
+    [
+        (1, 128, 64, 1, 32),
+    ],
+)
+@pytest.mark.parametrize("use_welford", welford_flavors, ids=welford_ids)
+@pytest.mark.parametrize(
+    "has_weight, has_bias",
+    [
+        (False, False),
+        (True, False),
+        (False, True),
+    ],
+    ids=["no_affine", "weight_only", "bias_only"],
+)
+def test_group_norm_optional_weight_bias(device, N, C, H, W, num_groups, use_welford, has_weight, has_bias):
+    """Verify group_norm with all combinations of optional weight/bias, for both welford and legacy."""
+    torch.manual_seed(0)
+
+    grid_size = ttnn.determine_expected_group_norm_dram_grid_size(
+        device=device,
+        num_channels=C,
+        num_groups=num_groups,
+        input_nhw=N * H * W,
+    )
+
+    num_virtual_cols = ttnn.operations.normalization.dram_group_norm_virtual_columns(grid_size, C, num_groups)
+    input_mask = ttnn.create_group_norm_input_mask(C, num_groups, num_virtual_cols, ttnn.bfloat16)
+    input_mask = ttnn.to_device(input_mask, device)
+
+    torch_input = torch.rand((N, C, H, W), dtype=torch.bfloat16)
+    torch_weight = torch.rand((C,), dtype=torch.bfloat16) if has_weight else None
+    torch_bias = torch.rand((C,), dtype=torch.bfloat16) if has_bias else None
+    epsilon = 1e-5
+
+    torch_output = torch.nn.functional.group_norm(
+        torch_input.float(),
+        num_groups,
+        weight=torch_weight.float() if torch_weight is not None else None,
+        bias=torch_bias.float() if torch_bias is not None else None,
+        eps=epsilon,
+    )
+    torch_output = torch_output.to(torch.bfloat16)
+    torch_output = torch_output.permute(0, 2, 3, 1).view(N, 1, H * W, C)
+
+    gamma_t, beta_t = None, None
+    if has_weight or has_bias:
+        params_list = []
+        if has_weight:
+            params_list.append(torch_weight.float())
+        if has_bias:
+            params_list.append(torch_bias.float())
+
+        tt_params = ttnn.dram_group_norm_params_from_torch(
+            params_list if len(params_list) > 1 else params_list[0],
+            C,
+            num_groups,
+            device,
+            core_grid=grid_size,
+            return_mask=False,
+        )
+        if has_weight and has_bias:
+            gamma_t, beta_t = tt_params
+        elif has_weight:
+            gamma_t = tt_params
+        else:
+            beta_t = tt_params
+
+    tt_input = torch_input.permute(0, 2, 3, 1).view(N, 1, H * W, C)
+    tt_input = ttnn.from_torch(
+        tt_input,
+        dtype=ttnn.DataType.BFLOAT16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_output = ttnn.group_norm(
+        tt_input,
+        num_groups=num_groups,
+        epsilon=epsilon,
+        input_mask=input_mask,
+        weight=gamma_t,
+        bias=beta_t,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        core_grid=grid_size,
+        inplace=False,
+        use_welford=use_welford,
+    )
+
+    tt_output = ttnn.from_device(tt_output)
+    tt_output = ttnn.to_torch(tt_output)
+
+    assert_with_pcc(torch_output, tt_output, 0.999)

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
@@ -906,3 +906,66 @@ def test_group_norm_negative_tests(
             core_grid=ttnn.CoreGrid(y=1, x=1),
             inplace=False,
         )
+
+
+@pytest.mark.parametrize(
+    "N, C, H, W, num_groups",
+    [
+        (1, 480, 8, 8, 32),
+        (1, 320, 32, 32, 32),
+        (1, 1280, 16, 16, 32),
+    ],
+)
+def test_group_norm_dram_grid_size(device, N, C, H, W, num_groups):
+    """Use determine_expected_group_norm_dram_grid_size to pick a grid, then
+    run DRAM-interleaved group norm and compare against torch."""
+    torch.manual_seed(0)
+
+    grid_size = ttnn.determine_expected_group_norm_dram_grid_size(
+        device=device,
+        num_channels=C,
+        num_groups=num_groups,
+        input_nhw=N * H * W,
+    )
+
+    torch_input = torch.rand((N, C, H, W), dtype=torch.bfloat16)
+    torch_weight = torch.rand((C,), dtype=torch.bfloat16)
+    torch_bias = torch.rand((C,), dtype=torch.bfloat16)
+
+    torch_output = torch.nn.functional.group_norm(torch_input, num_groups, weight=torch_weight, bias=torch_bias)
+    torch_output = torch_output.permute(0, 2, 3, 1).view(N, 1, H * W, C)
+
+    [gamma_t, beta_t], input_mask = ttnn.dram_group_norm_params_from_torch(
+        [torch_weight.float(), torch_bias.float()],
+        C,
+        num_groups,
+        device,
+        core_grid=grid_size,
+        return_mask=True,
+    )
+
+    tt_input = torch_input.permute(0, 2, 3, 1).view(N, 1, H * W, C)
+    tt_input = ttnn.from_torch(
+        tt_input,
+        dtype=ttnn.DataType.BFLOAT16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_output = ttnn.group_norm(
+        tt_input,
+        num_groups=num_groups,
+        input_mask=input_mask,
+        weight=gamma_t,
+        bias=beta_t,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        core_grid=grid_size,
+        inplace=False,
+        num_out_blocks=1,
+    )
+
+    tt_output = ttnn.from_device(tt_output)
+    tt_output = ttnn.to_torch(tt_output)
+
+    assert_with_pcc(torch_output, tt_output, 0.999)

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
@@ -911,7 +911,7 @@ def test_group_norm_negative_tests(
 @pytest.mark.parametrize(
     "N, C, H, W, num_groups",
     [
-        (1, 480, 8, 8, 32),
+        (1, 480, 8, 8, 16),
         (1, 320, 32, 32, 32),
         (1, 1280, 16, 16, 32),
     ],
@@ -963,6 +963,7 @@ def test_group_norm_dram_grid_size(device, N, C, H, W, num_groups):
         core_grid=grid_size,
         inplace=False,
         num_out_blocks=1,
+        use_welford=True,
     )
 
     tt_output = ttnn.from_device(tt_output)

--- a/ttnn/cpp/ttnn/operations/normalization/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/normalization/CMakeLists.txt
@@ -64,6 +64,7 @@ target_sources(
         groupnorm/device/groupnorm_mcast_program_factory.cpp
         groupnorm/groupnorm.cpp
         groupnorm/groupnorm_input_mask.cpp
+        groupnorm/groupnorm_grid_utils.cpp
         layernorm/device/layernorm_device_operation.cpp
         layernorm/device/layernorm_common.cpp
         layernorm/device/layernorm_op_multi_core.cpp

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
@@ -109,10 +109,15 @@ GroupNormMcastProgramFactory::cached_program_t GroupNormMcastProgramFactory::cre
     auto all_cores = tt::tt_metal::num_cores_to_corerangeset(num_cores, grid_size, row_wise);
 
     TT_FATAL(
-        H >= num_virtual_rows,
-        "Total size of a slice across channel dimension:({}) must be >= num_virtual_rows: ({})",
-        H,
-        num_virtual_rows);
+        Ht >= num_virtual_rows,
+        "Height in tiles (Ht={}) must be >= num_virtual_rows ({}). "
+        "The core grid (x={}, y={}) is too large for the input spatial dimensions (H={}). "
+        "Use a smaller core_grid or increase the input spatial size.",
+        Ht,
+        num_virtual_rows,
+        grid_size.x,
+        grid_size.y,
+        H);
 
     uint32_t per_core_Mt_group_1 = Ht / num_virtual_rows;
     uint32_t per_core_M_group_1 = per_core_Mt_group_1 * tile_height;
@@ -145,12 +150,31 @@ GroupNormMcastProgramFactory::cached_program_t GroupNormMcastProgramFactory::cre
         }
     }
 
+    TT_FATAL(
+        num_batches_per_core_group_1 > 0,
+        "num_batches_per_core_group_1 must be > 0 (got 0). This indicates an internal grid sizing error.");
     uint32_t num_rows_per_batch_per_core_group_1 = per_core_M_group_1 / num_batches_per_core_group_1;
     auto [block_wt, num_groups_per_reset] = find_max_tile_span(per_core_N, num_channels_per_group);
     uint32_t block_ht_group_1 = per_core_Mt_group_1 / num_batches_per_core_group_1;
     uint32_t subblock_wt = get_max_subblock(block_wt, 8);
     uint32_t num_subblocks_w = block_wt / subblock_wt;
     bool block_wt_last = (per_core_Nt + num_groups_per_core - 1) / num_groups_per_core;
+
+    TT_FATAL(
+        block_ht_group_1 > 0,
+        "block_h (tile height per core per batch) is 0. The core grid is too large for the input spatial dimensions. "
+        "per_core_Mt={}, num_batches_per_core={}, grid=({},{}), Ht={}.",
+        per_core_Mt_group_1,
+        num_batches_per_core_group_1,
+        grid_size.x,
+        grid_size.y,
+        Ht);
+    TT_FATAL(
+        num_out_blocks > 0 && num_out_blocks <= block_ht_group_1,
+        "num_out_blocks ({}) must be in [1, block_h ({})]. "
+        "Reduce num_out_blocks or increase input spatial dimensions.",
+        num_out_blocks,
+        block_ht_group_1);
 
     bool equal_batches_per_core = true;
     uint32_t last_row_with_extra_batch = 0;
@@ -167,6 +191,17 @@ GroupNormMcastProgramFactory::cached_program_t GroupNormMcastProgramFactory::cre
     bool tilize_in = a.layout() == Layout::ROW_MAJOR;
     bool untilize_out = output.layout() == Layout::ROW_MAJOR;
 
+    TT_FATAL(num_channels_per_group > 0, "num_channels_per_group must be > 0 (W={}, num_groups={})", W, num_groups);
+    TT_FATAL(
+        num_rows_per_batch_per_core_group_1 > 0,
+        "num_rows_per_batch_per_core_group_1 must be > 0 (per_core_M={}, num_batches_per_core={})",
+        per_core_M_group_1,
+        num_batches_per_core_group_1);
+    TT_FATAL(
+        num_cores_per_batch > 0 && num_cores_per_group > 0,
+        "num_cores_per_batch ({}) and num_cores_per_group ({}) must both be > 0",
+        num_cores_per_batch,
+        num_cores_per_group);
     TT_FATAL(
         per_core_N % num_channels_per_group == 0,
         "per_core_N ({}) must be divisible by num_channels_per_group ({})",

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
@@ -118,6 +118,17 @@ GroupNormMcastProgramFactory::cached_program_t GroupNormMcastProgramFactory::cre
         grid_size.x,
         grid_size.y,
         H);
+    TT_FATAL(
+        Ht % num_virtual_rows == 0,
+        "Height in tiles (Ht={}) must be divisible by num_virtual_rows ({}). "
+        "Remainder tiles would be silently dropped, producing incorrect results. "
+        "core_grid=({},{}), num_virtual_cols={}, rows_per_y={}.",
+        Ht,
+        num_virtual_rows,
+        grid_size.x,
+        grid_size.y,
+        num_virtual_cols,
+        grid_size.x / num_virtual_cols);
 
     uint32_t per_core_Mt_group_1 = Ht / num_virtual_rows;
     uint32_t per_core_M_group_1 = per_core_Mt_group_1 * tile_height;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.cpp
@@ -124,6 +124,17 @@ GroupNormNoMcastProgramFactory::cached_program_t GroupNormNoMcastProgramFactory:
         grid_size.x,
         grid_size.y,
         H);
+    TT_FATAL(
+        Ht % num_virtual_rows == 0,
+        "Height in tiles (Ht={}) must be divisible by num_virtual_rows ({}). "
+        "Remainder tiles would be silently dropped, producing incorrect results. "
+        "core_grid=({},{}), num_virtual_cols={}, rows_per_y={}.",
+        Ht,
+        num_virtual_rows,
+        grid_size.x,
+        grid_size.y,
+        num_virtual_cols,
+        grid_size.x / num_virtual_cols);
 
     uint32_t per_core_Mt_group_1 = Ht / num_virtual_rows;
     uint32_t per_core_M_group_1 = per_core_Mt_group_1 * tile_height;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.cpp
@@ -115,11 +115,15 @@ GroupNormNoMcastProgramFactory::cached_program_t GroupNormNoMcastProgramFactory:
     auto all_cores = tt::tt_metal::num_cores_to_corerangeset(num_cores, grid_size, row_wise);
 
     TT_FATAL(
-        H >= num_virtual_rows,
-        "Total size of a slice across channel dimension:({}) must be greater than or equal to num_virtual_rows: ({}). "
-        "Reduce grid_size as needed",
-        H,
-        num_virtual_rows);
+        Ht >= num_virtual_rows,
+        "Height in tiles (Ht={}) must be >= num_virtual_rows ({}). "
+        "The core grid (x={}, y={}) is too large for the input spatial dimensions (H={}). "
+        "Use a smaller core_grid or increase the input spatial size.",
+        Ht,
+        num_virtual_rows,
+        grid_size.x,
+        grid_size.y,
+        H);
 
     uint32_t per_core_Mt_group_1 = Ht / num_virtual_rows;
     uint32_t per_core_M_group_1 = per_core_Mt_group_1 * tile_height;
@@ -199,12 +203,57 @@ GroupNormNoMcastProgramFactory::cached_program_t GroupNormNoMcastProgramFactory:
         block_ht_group_2 = per_batch_tiles;
     }
 
+    TT_FATAL(
+        block_ht_group_1 > 0,
+        "block_h (tile height per core per batch) for group 1 is 0. The core grid is too large for the input spatial "
+        "dimensions. per_core_Mt={}, num_batches_per_core={}, grid=({},{}), Ht={}.",
+        per_core_Mt_group_1,
+        num_batches_per_core_group_1,
+        grid_size.x,
+        grid_size.y,
+        Ht);
+    if (!equal_batches_per_core) {
+        TT_FATAL(
+            block_ht_group_2 > 0,
+            "block_h (tile height per core per batch) for group 2 is 0. The core grid is too large for the input "
+            "spatial dimensions. per_core_Mt={}, num_batches_per_core={}, grid=({},{}), Ht={}.",
+            per_core_Mt_group_2,
+            num_batches_per_core_group_2,
+            grid_size.x,
+            grid_size.y,
+            Ht);
+    }
+    TT_FATAL(
+        num_out_blocks > 0 && num_out_blocks <= block_ht_group_1,
+        "num_out_blocks ({}) must be in [1, block_h ({})]. "
+        "Reduce num_out_blocks or increase input spatial dimensions.",
+        num_out_blocks,
+        block_ht_group_1);
+    if (!equal_batches_per_core && block_ht_group_2 > 0) {
+        TT_FATAL(
+            num_out_blocks <= block_ht_group_2,
+            "num_out_blocks ({}) must be <= block_h_group_2 ({}).",
+            num_out_blocks,
+            block_ht_group_2);
+    }
+
     // shard shape per core
     uint32_t per_core_N_bytes_padded = tt::round_up(per_core_N * datum_size_bytes, output.buffer()->alignment());
     bool reader_repack_output = (per_core_N % tile_width) != 0;
     bool tilize_in = a.layout() == Layout::ROW_MAJOR;
     bool untilize_out = output.layout() == Layout::ROW_MAJOR;
 
+    TT_FATAL(num_channels_per_group > 0, "num_channels_per_group must be > 0 (W={}, num_groups={})", W, num_groups);
+    TT_FATAL(
+        num_rows_per_batch_per_core_group_1 > 0,
+        "num_rows_per_batch_per_core_group_1 must be > 0 (per_core_M={}, num_batches_per_core={})",
+        per_core_M_group_1,
+        num_batches_per_core_group_1);
+    TT_FATAL(
+        num_cores_per_batch > 0 && num_cores_per_group > 0,
+        "num_cores_per_batch ({}) and num_cores_per_group ({}) must both be > 0",
+        num_cores_per_batch,
+        num_cores_per_group);
     TT_FATAL(
         per_core_N % num_channels_per_group == 0,
         "per_core_N ({}) must be divisible by num_channels_per_group ({})",

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm.cpp
@@ -166,9 +166,7 @@ void kernel_main() {
 #ifdef UNTILIZE_OUT
     constexpr uint32_t cb_out = tt::CBIndex::c_30;
 #else
-    constexpr uint32_t cb_out = (do_gamma or do_beta)
-                                    ? (((do_gamma and not do_beta) or (not do_gamma and do_beta)) ? cb_in : cb_out0)
-                                    : cb_out0;
+    constexpr uint32_t cb_out = (do_gamma or do_beta) ? cb_out0 : cb_reread_write_out;
 #endif
 
     // tile offset
@@ -191,9 +189,11 @@ void kernel_main() {
 
 #ifdef UNTILIZE_OUT
     constexpr int cb_outgamma = cb_in;
-    constexpr int cb_inbeta = do_gamma ? cb_outgamma : cb_out;
+    constexpr int cb_inbeta = do_gamma ? cb_outgamma : cb_reread_write_out;
     constexpr int cb_outbeta = do_gamma ? cb_out : cb_in;
-    constexpr int cb_untilize_in = (do_gamma and not do_beta) ? cb_outgamma : do_beta ? cb_outbeta : cb_out;
+    constexpr int cb_untilize_in = (do_gamma and not do_beta) ? cb_outgamma
+                                   : do_beta                  ? cb_outbeta
+                                                              : cb_reread_write_out;
     constexpr int cb_untilize_out =
 #ifdef READER_REPACK
         cb_repack_out;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm.cpp
@@ -143,16 +143,16 @@ void kernel_main() {
 #ifdef UNTILIZE_OUT
     constexpr uint32_t cb_out = tt::CBIndex::c_30;
 #else
-    constexpr uint32_t cb_out = (do_gamma or do_beta)
-                                    ? (((do_gamma and not do_beta) or (not do_gamma and do_beta)) ? cb_in : cb_out0)
-                                    : cb_out0;
+    constexpr uint32_t cb_out = (do_gamma or do_beta) ? cb_out0 : cb_reread_write_out;
 #endif
 
 #ifdef UNTILIZE_OUT
     constexpr int cb_outgamma = cb_in;
-    constexpr int cb_inbeta = do_gamma ? cb_outgamma : cb_out;
+    constexpr int cb_inbeta = do_gamma ? cb_outgamma : cb_reread_write_out;
     constexpr int cb_outbeta = do_gamma ? cb_out : cb_in;
-    constexpr int cb_untilize_in = (do_gamma and not do_beta) ? cb_outgamma : do_beta ? cb_outbeta : cb_out;
+    constexpr int cb_untilize_in = (do_gamma and not do_beta) ? cb_outgamma
+                                   : do_beta                  ? cb_outbeta
+                                                              : cb_reread_write_out;
     constexpr int cb_untilize_out =
 #ifdef READER_REPACK
         cb_repack_out;
@@ -520,11 +520,11 @@ void kernel_main() {
                     copy_tile(cb_x, 0, dst0);
                     tile_regs_commit();
                     cb_pop_front(cb_x, 1);
-                    cb_reserve_back(cb_out0, 1);
+                    cb_reserve_back(cb_out, 1);
                     tile_regs_wait();
-                    pack_tile(dst0, cb_out0);
+                    pack_tile(dst0, cb_out);
                     tile_regs_release();
-                    cb_push_back(cb_out0, 1);
+                    cb_push_back(cb_out, 1);
                 }
             }
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_writer_unary_gn_rm_gb.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_writer_unary_gn_rm_gb.cpp
@@ -68,18 +68,16 @@ void kernel_main() {
     constexpr uint32_t cb_input_mask = tt::CBIndex::c_28;
     constexpr uint32_t cb_in = tt::CBIndex::c_29;
 
-    constexpr uint32_t single_tile_size_bytes = get_tile_size(cb_gamma);
-    constexpr uint32_t input_mask_single_tile_size_bytes = get_tile_size(cb_input_mask);
-
+    constexpr uint32_t cb_reread_write_out = tt::CBIndex::c_22;
     constexpr uint32_t cb_out0 = tt::CBIndex::c_16;
 #ifdef UNTILIZE_OUT
     constexpr uint32_t cb_out = tt::CBIndex::c_30;
 #else
-    constexpr uint32_t cb_out =
-        (fuse_gamma or fuse_beta)
-            ? (((fuse_gamma and not fuse_beta) or (not fuse_gamma and fuse_beta)) ? cb_in : cb_out0)
-            : cb_out0;
+    constexpr uint32_t cb_out = (fuse_gamma or fuse_beta) ? cb_out0 : cb_reread_write_out;
 #endif
+
+    constexpr uint32_t single_tile_size_bytes = get_tile_size(cb_out);
+    constexpr uint32_t input_mask_single_tile_size_bytes = get_tile_size(cb_input_mask);
 
     // input mask
     const auto mask = TensorAccessor(input_mask_args, input_mask_addr, input_mask_single_tile_size_bytes);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_gn_rm_gb.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_gn_rm_gb.cpp
@@ -68,19 +68,16 @@ void kernel_main() {
     constexpr uint32_t cb_input_mask = tt::CBIndex::c_28;
     constexpr uint32_t cb_in = tt::CBIndex::c_29;
 
-    // constexpr uint32_t block_w = 4;
-    const uint32_t single_tile_size_bytes = get_tile_size(cb_gamma);
-    const uint32_t input_mask_single_tile_size_bytes = get_tile_size(cb_input_mask);
-
+    constexpr uint32_t cb_reread_write_out = tt::CBIndex::c_22;
     constexpr uint32_t cb_out0 = tt::CBIndex::c_16;
 #ifdef UNTILIZE_OUT
     constexpr uint32_t cb_out = tt::CBIndex::c_30;
 #else
-    constexpr uint32_t cb_out =
-        (fuse_gamma or fuse_beta)
-            ? (((fuse_gamma and not fuse_beta) or (not fuse_gamma and fuse_beta)) ? cb_in : cb_out0)
-            : cb_out0;
+    constexpr uint32_t cb_out = (fuse_gamma or fuse_beta) ? cb_out0 : cb_reread_write_out;
 #endif
+
+    const uint32_t single_tile_size_bytes = get_tile_size(cb_out);
+    const uint32_t input_mask_single_tile_size_bytes = get_tile_size(cb_input_mask);
 
     // input mask
     const auto mask = TensorAccessor(input_mask_args, input_mask_addr, input_mask_single_tile_size_bytes);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
@@ -4,6 +4,7 @@
 
 #include "groupnorm.hpp"
 #include "device/groupnorm_device_operation.hpp"
+#include "groupnorm_grid_utils.hpp"
 #include "groupnorm_input_mask.hpp"
 
 #include "ttnn/operations/core/core.hpp"
@@ -11,26 +12,11 @@
 
 namespace {
 
-// Computes the number of virtual columns for a given grid width, replicating the
-// same logic used by the mcast and no-mcast program factories. The result satisfies:
-//   (W / nvc) % TILE_SIZE == 0  &&  num_groups % nvc == 0
-// Returns 0 if no valid value exists for the given grid_x.
-uint32_t compute_num_virtual_cols(uint32_t grid_x, int num_groups, uint32_t W) {
-    uint32_t nvc = std::min<uint32_t>(grid_x, num_groups);
-    while (nvc > 0 && ((W / nvc) % ttnn::types::TILE_SIZE != 0 || (num_groups % nvc) != 0)) {
-        nvc -= 1;
-    }
-    return nvc;
-}
+using ttnn::operations::normalization::compute_num_virtual_cols;
+using ttnn::operations::normalization::find_expected_dram_grid;
 
-// Validates that the requested core grid satisfies the DRAM group-norm constraints:
-//   1. num_virtual_rows = (grid_x / num_virtual_cols) * grid_y  <=  Ht
-//   2. Ht % num_virtual_rows == 0
-// where Ht is the input height in tiles (NHW / TILE_SIZE).
-// Constraint (1) prevents per_core_Mt == 0 (division-by-zero in kernels).
-// Constraint (2) prevents remainder tile rows from being silently dropped.
-// If the requested grid is invalid, this function fatals with an error message
-// that suggests the largest valid grid that fits within the requested bounds.
+// Validates that the requested core grid satisfies the DRAM group-norm constraints.
+// If the requested grid is invalid, fatals with an error suggesting the largest valid sub-grid.
 void validate_dram_grid(const ttnn::CoreGrid& requested, uint32_t W, uint32_t Ht, int num_groups) {
     uint32_t nvc = compute_num_virtual_cols(requested.x, num_groups, W);
     if (nvc > 0) {
@@ -38,38 +24,17 @@ void validate_dram_grid(const ttnn::CoreGrid& requested, uint32_t W, uint32_t Ht
         if (rows_per_y > 0) {
             uint32_t num_virtual_rows = rows_per_y * requested.y;
             if (Ht >= num_virtual_rows && Ht % num_virtual_rows == 0) {
+                // Valid grid found
                 return;
             }
         }
     }
 
-    // Grid is invalid -- find the largest valid sub-grid to suggest in the error.
-    uint32_t suggested_x = 0, suggested_y = 0;
-    for (uint32_t gx = requested.x; gx >= 1; --gx) {
-        uint32_t nvc_inner = compute_num_virtual_cols(gx, num_groups, W);
-        if (nvc_inner == 0) {
-            continue;
-        }
-        uint32_t rows_per_y_inner = gx / nvc_inner;
-        if (rows_per_y_inner == 0) {
-            continue;
-        }
-        uint32_t max_y = std::min<uint32_t>(Ht / rows_per_y_inner, requested.y);
-        for (uint32_t gy = max_y; gy >= 1; --gy) {
-            if (Ht % (rows_per_y_inner * gy) == 0) {
-                suggested_x = gx;
-                suggested_y = gy;
-                break;
-            }
-        }
-        if (suggested_x > 0) {
-            break;
-        }
-    }
+    auto suggested = find_expected_dram_grid(requested.x, requested.y, W, num_groups, Ht * ttnn::types::TILE_SIZE);
 
-    if (suggested_x > 0) {
-        TT_FATAL(
-            false,
+    // User supplied invalid grid, but suggested a valid grid
+    if (suggested.has_value()) {
+        TT_THROW(
             "group_norm: Requested core_grid (x={}, y={}) is invalid for the input dimensions "
             "(Ht={}, W={}, num_groups={}). The grid must satisfy "
             "num_virtual_rows = (grid_x / num_virtual_cols) * grid_y <= Ht, and "
@@ -80,11 +45,10 @@ void validate_dram_grid(const ttnn::CoreGrid& requested, uint32_t W, uint32_t Ht
             Ht,
             W,
             num_groups,
-            suggested_x,
-            suggested_y);
+            suggested->x,
+            suggested->y);
     } else {
-        TT_FATAL(
-            false,
+        TT_THROW(
             "group_norm: Cannot find any valid core grid for the given configuration. "
             "Input height in tiles (Ht={}) is too small for any grid with W={}, num_groups={}. "
             "Requested grid was (x={}, y={}).",
@@ -112,7 +76,16 @@ ttnn::Tensor get_mask_tensor(
         int64_t num_channel = input_tensor.padded_shape()[-1];
         int64_t num_cores_across_channel;
         if (input_tensor.memory_config().buffer_type() == BufferType::L1) {
-            num_cores_across_channel = core_grid.has_value() ? core_grid.value().y : 1;
+            auto mem_layout = input_tensor.memory_config().memory_layout();
+            if (mem_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
+                num_cores_across_channel = 1;
+            } else if (mem_layout == TensorMemoryLayout::BLOCK_SHARDED && core_grid.has_value()) {
+                auto shard_spec = input_tensor.memory_config().shard_spec();
+                bool is_row_major = shard_spec.has_value() && shard_spec->orientation == ShardOrientation::ROW_MAJOR;
+                num_cores_across_channel = is_row_major ? core_grid.value().x : core_grid.value().y;
+            } else {
+                num_cores_across_channel = core_grid.has_value() ? core_grid.value().y : 1;
+            }
         } else {
             uint32_t num_virtual_cols =
                 compute_num_virtual_cols(core_grid.value().x, num_groups, static_cast<uint32_t>(num_channel));

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
@@ -23,12 +23,13 @@ uint32_t compute_num_virtual_cols(uint32_t grid_x, int num_groups, uint32_t W) {
     return nvc;
 }
 
-// Validates that the requested core grid satisfies the DRAM group-norm constraint:
-//   num_virtual_rows = (grid_x / num_virtual_cols) * grid_y  <=  Ht
+// Validates that the requested core grid satisfies the DRAM group-norm constraints:
+//   1. num_virtual_rows = (grid_x / num_virtual_cols) * grid_y  <=  Ht
+//   2. Ht % num_virtual_rows == 0
 // where Ht is the input height in tiles (NHW / TILE_SIZE).
-// When this is violated the factories compute per_core_Mt == 0 and block_h == 0,
-// leading to division-by-zero in kernels.
-// If the requested grid is too large, this function fatals with an error message
+// Constraint (1) prevents per_core_Mt == 0 (division-by-zero in kernels).
+// Constraint (2) prevents remainder tile rows from being silently dropped.
+// If the requested grid is invalid, this function fatals with an error message
 // that suggests the largest valid grid that fits within the requested bounds.
 void validate_dram_grid(const ttnn::CoreGrid& requested, uint32_t W, uint32_t Ht, int num_groups) {
     uint32_t nvc = compute_num_virtual_cols(requested.x, num_groups, W);
@@ -36,13 +37,13 @@ void validate_dram_grid(const ttnn::CoreGrid& requested, uint32_t W, uint32_t Ht
         uint32_t rows_per_y = requested.x / nvc;
         if (rows_per_y > 0) {
             uint32_t num_virtual_rows = rows_per_y * requested.y;
-            if (Ht >= num_virtual_rows) {
+            if (Ht >= num_virtual_rows && Ht % num_virtual_rows == 0) {
                 return;
             }
         }
     }
 
-    // Grid is too large -- find the largest valid sub-grid to suggest in the error.
+    // Grid is invalid -- find the largest valid sub-grid to suggest in the error.
     uint32_t suggested_x = 0, suggested_y = 0;
     for (uint32_t gx = requested.x; gx >= 1; --gx) {
         uint32_t nvc_inner = compute_num_virtual_cols(gx, num_groups, W);
@@ -53,21 +54,26 @@ void validate_dram_grid(const ttnn::CoreGrid& requested, uint32_t W, uint32_t Ht
         if (rows_per_y_inner == 0) {
             continue;
         }
-        uint32_t max_y = Ht / rows_per_y_inner;
-        if (max_y == 0) {
-            continue;
+        uint32_t max_y = std::min<uint32_t>(Ht / rows_per_y_inner, requested.y);
+        for (uint32_t gy = max_y; gy >= 1; --gy) {
+            if (Ht % (rows_per_y_inner * gy) == 0) {
+                suggested_x = gx;
+                suggested_y = gy;
+                break;
+            }
         }
-        suggested_x = gx;
-        suggested_y = std::min<uint32_t>(max_y, requested.y);
-        break;
+        if (suggested_x > 0) {
+            break;
+        }
     }
 
     if (suggested_x > 0) {
         TT_FATAL(
             false,
-            "group_norm: Requested core_grid (x={}, y={}) is too large for the input dimensions "
+            "group_norm: Requested core_grid (x={}, y={}) is invalid for the input dimensions "
             "(Ht={}, W={}, num_groups={}). The grid must satisfy "
-            "num_virtual_rows = (grid_x / num_virtual_cols) * grid_y <= Ht. "
+            "num_virtual_rows = (grid_x / num_virtual_cols) * grid_y <= Ht, and "
+            "Ht must be divisible by num_virtual_rows (otherwise remainder tiles are dropped). "
             "The largest valid grid that fits is (x={}, y={}).",
             requested.x,
             requested.y,

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
@@ -9,6 +9,91 @@
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/data_movement/clone/clone.hpp"
 
+namespace {
+
+// Computes the number of virtual columns for a given grid width, replicating the
+// same logic used by the mcast and no-mcast program factories. The result satisfies:
+//   (W / nvc) % TILE_SIZE == 0  &&  num_groups % nvc == 0
+// Returns 0 if no valid value exists for the given grid_x.
+uint32_t compute_num_virtual_cols(uint32_t grid_x, int num_groups, uint32_t W) {
+    uint32_t nvc = std::min<uint32_t>(grid_x, num_groups);
+    while (nvc > 0 && ((W / nvc) % ttnn::types::TILE_SIZE != 0 || (num_groups % nvc) != 0)) {
+        nvc -= 1;
+    }
+    return nvc;
+}
+
+// Validates that the requested core grid satisfies the DRAM group-norm constraint:
+//   num_virtual_rows = (grid_x / num_virtual_cols) * grid_y  <=  Ht
+// where Ht is the input height in tiles (NHW / TILE_SIZE).
+// When this is violated the factories compute per_core_Mt == 0 and block_h == 0,
+// leading to division-by-zero in kernels.
+// If the requested grid is too large, this function fatals with an error message
+// that suggests the largest valid grid that fits within the requested bounds.
+void validate_dram_grid(const ttnn::CoreGrid& requested, uint32_t W, uint32_t Ht, int num_groups) {
+    uint32_t nvc = compute_num_virtual_cols(requested.x, num_groups, W);
+    if (nvc > 0) {
+        uint32_t rows_per_y = requested.x / nvc;
+        if (rows_per_y > 0) {
+            uint32_t num_virtual_rows = rows_per_y * requested.y;
+            if (Ht >= num_virtual_rows) {
+                return;
+            }
+        }
+    }
+
+    // Grid is too large -- find the largest valid sub-grid to suggest in the error.
+    uint32_t suggested_x = 0, suggested_y = 0;
+    for (uint32_t gx = requested.x; gx >= 1; --gx) {
+        uint32_t nvc_inner = compute_num_virtual_cols(gx, num_groups, W);
+        if (nvc_inner == 0) {
+            continue;
+        }
+        uint32_t rows_per_y_inner = gx / nvc_inner;
+        if (rows_per_y_inner == 0) {
+            continue;
+        }
+        uint32_t max_y = Ht / rows_per_y_inner;
+        if (max_y == 0) {
+            continue;
+        }
+        suggested_x = gx;
+        suggested_y = std::min<uint32_t>(max_y, requested.y);
+        break;
+    }
+
+    if (suggested_x > 0) {
+        TT_FATAL(
+            false,
+            "group_norm: Requested core_grid (x={}, y={}) is too large for the input dimensions "
+            "(Ht={}, W={}, num_groups={}). The largest valid grid that fits is (x={}, y={}). "
+            "Use ttnn.determine_expected_group_norm_dram_grid_size() to select a compatible grid "
+            "for DRAM interleaved inputs, or ttnn.determine_expected_group_norm_sharded_config_and_grid_size() "
+            "for sharded inputs.",
+            requested.x,
+            requested.y,
+            Ht,
+            W,
+            num_groups,
+            suggested_x,
+            suggested_y);
+    } else {
+        TT_FATAL(
+            false,
+            "group_norm: Cannot find any valid core grid for the given configuration. "
+            "Input height in tiles (Ht={}) is too small for any grid with W={}, num_groups={}. "
+            "Requested grid was (x={}, y={}). "
+            "Use ttnn.determine_expected_group_norm_dram_grid_size() to select a compatible grid.",
+            Ht,
+            W,
+            num_groups,
+            requested.x,
+            requested.y);
+    }
+}
+
+}  // namespace
+
 namespace ttnn::operations::normalization {
 
 ttnn::Tensor get_mask_tensor(
@@ -139,6 +224,16 @@ Tensor group_norm(
     const auto fp32_acc = use_welford;
     auto kernel_config_val =
         init_device_compute_kernel_config(arch, compute_kernel_config, math_fidelity, approx_mode, fp32_acc);
+
+    // For non-sharded DRAM tensors, validate that the requested core grid is not too
+    // large for the input spatial dimensions. The constraint is Ht >= num_virtual_rows,
+    // where num_virtual_rows = (grid_x / num_virtual_cols) * grid_y and Ht = NHW / TILE_SIZE.
+    // Violating this leads to per_core_Mt == 0, causing division-by-zero in kernels.
+    if (!input_tensor.is_sharded()) {
+        const uint32_t W = input_padded_shape[3];
+        const uint32_t Ht = nhw / ttnn::types::TILE_SIZE;
+        validate_dram_grid(core_grid.value(), W, Ht, num_groups);
+    }
 
     // auto generate mask tensor if both input_mask and negative_mask are not provided
     ttnn::Tensor mask =

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
@@ -66,10 +66,9 @@ void validate_dram_grid(const ttnn::CoreGrid& requested, uint32_t W, uint32_t Ht
         TT_FATAL(
             false,
             "group_norm: Requested core_grid (x={}, y={}) is too large for the input dimensions "
-            "(Ht={}, W={}, num_groups={}). The largest valid grid that fits is (x={}, y={}). "
-            "Use ttnn.determine_expected_group_norm_dram_grid_size() to select a compatible grid "
-            "for DRAM interleaved inputs, or ttnn.determine_expected_group_norm_sharded_config_and_grid_size() "
-            "for sharded inputs.",
+            "(Ht={}, W={}, num_groups={}). The grid must satisfy "
+            "num_virtual_rows = (grid_x / num_virtual_cols) * grid_y <= Ht. "
+            "The largest valid grid that fits is (x={}, y={}).",
             requested.x,
             requested.y,
             Ht,
@@ -82,8 +81,7 @@ void validate_dram_grid(const ttnn::CoreGrid& requested, uint32_t W, uint32_t Ht
             false,
             "group_norm: Cannot find any valid core grid for the given configuration. "
             "Input height in tiles (Ht={}) is too small for any grid with W={}, num_groups={}. "
-            "Requested grid was (x={}, y={}). "
-            "Use ttnn.determine_expected_group_norm_dram_grid_size() to select a compatible grid.",
+            "Requested grid was (x={}, y={}).",
             Ht,
             W,
             num_groups,
@@ -110,17 +108,17 @@ ttnn::Tensor get_mask_tensor(
         if (input_tensor.memory_config().buffer_type() == BufferType::L1) {
             num_cores_across_channel = core_grid.has_value() ? core_grid.value().y : 1;
         } else {
-            // Choose number of virtual columns for DRAM params/mask generation.
-            // Tries to find the largest number of virtual columns that will evenly divide the number of channels into
-            // tiles.
-            int num_virtual_cols = std::min(static_cast<int>(core_grid.value().x), num_groups);
-            while ((num_virtual_cols > 0) && (num_channel / num_virtual_cols) % ttnn::types::TILE_SIZE != 0) {
-                num_virtual_cols -= 1;
-            }
-            if (num_virtual_cols == 0) {
-                TT_THROW("Core Grid resulted in virtual cores x = 0, Please try another core grid");
-            }
-            num_cores_across_channel = num_virtual_cols;
+            uint32_t num_virtual_cols =
+                compute_num_virtual_cols(core_grid.value().x, num_groups, static_cast<uint32_t>(num_channel));
+            TT_FATAL(
+                num_virtual_cols > 0,
+                "group_norm: Cannot determine num_virtual_cols for core_grid x={}, num_groups={}, "
+                "num_channels={}. num_virtual_cols must satisfy (num_channels / nvc) %% TILE_SIZE == 0 "
+                "and num_groups %% nvc == 0.",
+                core_grid.value().x,
+                num_groups,
+                num_channel);
+            num_cores_across_channel = static_cast<int64_t>(num_virtual_cols);
         }
         mask = create_group_norm_input_mask(
             num_channel,

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
@@ -92,8 +92,8 @@ ttnn::Tensor get_mask_tensor(
             TT_FATAL(
                 num_virtual_cols > 0,
                 "group_norm: Cannot determine num_virtual_cols for core_grid x={}, num_groups={}, "
-                "num_channels={}. num_virtual_cols must satisfy (num_channels / nvc) %% TILE_SIZE == 0 "
-                "and num_groups %% nvc == 0.",
+                "num_channels={}. num_virtual_cols must satisfy (num_channels / nvc) % TILE_SIZE == 0 "
+                "and num_groups % nvc == 0.",
                 core_grid.value().x,
                 num_groups,
                 num_channel);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_grid_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_grid_utils.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_grid_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_grid_utils.cpp
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "groupnorm_grid_utils.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+namespace ttnn::operations::normalization {
+
+uint32_t compute_num_virtual_cols(uint32_t grid_x, int num_groups, uint32_t num_channels) {
+    uint32_t nvc = std::min<uint32_t>(grid_x, num_groups);
+    while (nvc > 0 && ((num_channels / nvc) % ttnn::types::TILE_SIZE != 0 || (num_groups % nvc) != 0)) {
+        nvc -= 1;
+    }
+    return nvc;
+}
+
+std::optional<ttnn::CoreGrid> find_expected_dram_grid(
+    uint32_t max_x, uint32_t max_y, uint32_t num_channels, int num_groups, uint32_t input_nhw) {
+    uint32_t Ht = static_cast<uint32_t>(std::ceil(static_cast<double>(input_nhw) / ttnn::types::TILE_SIZE));
+
+    for (uint32_t gx = max_x; gx >= 1; --gx) {
+        uint32_t nvc = compute_num_virtual_cols(gx, num_groups, num_channels);
+        if (nvc == 0) {
+            continue;
+        }
+        uint32_t rows_per_y = gx / nvc;
+        if (rows_per_y == 0) {
+            continue;
+        }
+        uint32_t max_gy = std::min<uint32_t>(Ht / rows_per_y, max_y);
+        for (uint32_t gy = max_gy; gy >= 1; --gy) {
+            uint32_t num_virtual_rows = rows_per_y * gy;
+            if (Ht % num_virtual_rows == 0) {
+                return ttnn::CoreGrid(gx, gy);
+            }
+        }
+    }
+    return std::nullopt;
+}
+
+}  // namespace ttnn::operations::normalization

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_grid_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_grid_utils.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_grid_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_grid_utils.hpp
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include "ttnn/types.hpp"
+
+namespace ttnn::operations::normalization {
+
+// Compute the number of virtual columns for DRAM group-norm.
+// Finds the largest nvc <= min(grid_x, num_groups) such that:
+//   (num_channels / nvc) % TILE_SIZE == 0  &&  num_groups % nvc == 0
+// Returns 0 if no valid value exists for the given grid_x.
+uint32_t compute_num_virtual_cols(uint32_t grid_x, int num_groups, uint32_t num_channels);
+
+// Find the largest valid CoreGrid within (max_x, max_y) bounds for DRAM group-norm.
+// The grid must satisfy:
+//   num_virtual_rows = (grid_x / num_virtual_cols) * grid_y  <=  Ht
+//   Ht % num_virtual_rows == 0
+// where Ht = ceil(input_nhw / TILE_SIZE).
+// Returns std::nullopt if no valid grid exists.
+std::optional<ttnn::CoreGrid> find_expected_dram_grid(
+    uint32_t max_x, uint32_t max_y, uint32_t num_channels, int num_groups, uint32_t input_nhw);
+
+}  // namespace ttnn::operations::normalization

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_input_mask.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_input_mask.cpp
@@ -42,8 +42,7 @@ ttnn::Tensor create_group_norm_input_mask_impl(
     TT_FATAL(
         num_groups % num_cores_across_channel == 0,
         "create_group_norm_input_mask: num_groups ({}) must be divisible by num_cores_across_channel ({}). "
-        "This typically means the core grid produced an invalid num_virtual_cols. "
-        "Ensure that dram_group_norm_virtual_columns selects a value that evenly divides both "
+        "The num_virtual_cols / num_cores_across_channel value must evenly divide both "
         "the channels into tiles and the number of groups.",
         num_groups,
         num_cores_across_channel);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_input_mask.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_input_mask.cpp
@@ -38,6 +38,15 @@ ttnn::Tensor create_group_norm_input_mask_impl(
     bool is_negative_mask,
     int64_t tile_height,
     int64_t tile_width) {
+    TT_FATAL(num_cores_across_channel > 0, "create_group_norm_input_mask: num_cores_across_channel must be > 0.");
+    TT_FATAL(
+        num_groups % num_cores_across_channel == 0,
+        "create_group_norm_input_mask: num_groups ({}) must be divisible by num_cores_across_channel ({}). "
+        "This typically means the core grid produced an invalid num_virtual_cols. "
+        "Ensure that dram_group_norm_virtual_columns selects a value that evenly divides both "
+        "the channels into tiles and the number of groups.",
+        num_groups,
+        num_cores_across_channel);
     int64_t block_wt = find_max_tile_span(num_channel, num_channel / num_groups, tile_width);
 
     const int64_t out_num_groups = num_groups;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_nanobind.cpp
@@ -33,8 +33,10 @@ void bind_normalization_group_norm_operation(nb::module_& mod) {
                 This implementation is slightly different, in that it forms the groups using the tensor's last dimension.
                 Concretely, the input tensor is expected to have a shape of [N, 1, H*W, C], where C is the dimension along which the groups are formed.
 
-                TTNN provides utility functions to help prepare this op's inputs.
+                TTNN provides utility functions to help prepare this op's inputs for different types of input tensors:
                     - When using sharded input tensors, :func:`ttnn.determine_expected_group_norm_sharded_config_and_grid_size` can provide the appropriate memory configuration and grid size.
+                    - When using interleaved (DRAM) input tensors, :func:`ttnn.determine_expected_group_norm_dram_grid_size` can provide the appropriate grid size.
+                    - :func:`ttnn.dram_group_norm_params_from_torch` is a convenience function that prepares the weight, bias, and input mask from PyTorch tensors for interleaved inputs.
                     - :func:`ttnn.create_group_norm_input_mask` creates the appropriate input mask for a given tensor dimension and group size.
                     - :func:`ttnn.create_group_norm_weight_bias_rm` converts the weight and bias tensors into appropriately padded and tiled inputs
 
@@ -54,7 +56,7 @@ void bind_normalization_group_norm_operation(nb::module_& mod) {
                 core_grid (CoreGrid, optional): Defaults to `None`.
                 inplace (bool, optional): Defaults to `True`.
                 output_layout (ttnn.Layout, optional): Defaults to `None`.
-                num_out_blocks (int, optional): Defaults to `None`.
+                num_out_blocks (int, optional): Allows the output to be processed in multiple smaller chunks, to reduce the amount of L1 required at a time. Should only be used if need to relieve L1 pressure, as this negatively impacts performance. Defaults to `None`.
                 compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): Compute kernel configuration for the op. Defaults to `None`.
                 negative_mask (ttnn.Tensor, optional): Defaults to `None`. Can be used only in row-major sharded input/output tensors. Used to reduce the number of CB's used in the sharded version of the kernel by overlapping the CB's used for tilized input and output. (The kernel is in fact row major variant, but is internally tilizing RM into tilized inputs).
                 use_welford (bool, optional): Defaults to `False`. If `True`, the Welford's algorithm is used to compute the mean and variance.

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_nanobind.cpp
@@ -49,14 +49,14 @@ void bind_normalization_group_norm_operation(nb::module_& mod) {
                 num_groups (int): Number of groups to split the tensor's channels into.
                 epsilon (float): Defaults to 1e-12.
                 input_mask (ttnn.Tensor, optional): Defaults to `None`. When processing the inputs, the mask is used to only look at the elements of the current group.
-                weight (ttnn.Tensor, optional): Defaults to `None`.
-                bias (ttnn.Tensor, optional): Defaults to `None`.
+                weight (ttnn.Tensor, optional): Must be provided (see limitations). Defaults to `None`.
+                bias (ttnn.Tensor, optional): Must be provided (see limitations). Defaults to `None`.
                 memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
                 dtype (ttnn.DataType, optional): Defaults to `None`.
-                core_grid (CoreGrid, optional): Defaults to `None`.
+                core_grid (CoreGrid, optional): Must be provided (see limitations). Defaults to `None`.
                 inplace (bool, optional): Defaults to `True`.
                 output_layout (ttnn.Layout, optional): Defaults to `None`.
-                num_out_blocks (int, optional): Allows the output to be processed in multiple smaller chunks, to reduce the amount of L1 required at a time. Should only be used if need to relieve L1 pressure, as this negatively impacts performance. Defaults to `None`.
+                num_out_blocks (int, optional): Allows the output to be processed in multiple smaller chunks, to reduce the amount of L1 required at a time. Should only be used if needed to relieve L1 pressure, as this negatively impacts performance. Defaults to `None`.
                 compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): Compute kernel configuration for the op. Defaults to `None`.
                 negative_mask (ttnn.Tensor, optional): Defaults to `None`. Can be used only in row-major sharded input/output tensors. Used to reduce the number of CB's used in the sharded version of the kernel by overlapping the CB's used for tilized input and output. (The kernel is in fact row major variant, but is internally tilizing RM into tilized inputs).
                 use_welford (bool, optional): Defaults to `False`. If `True`, the Welford's algorithm is used to compute the mean and variance.
@@ -102,7 +102,7 @@ void bind_normalization_group_norm_operation(nb::module_& mod) {
               - :attr:`input_tensor` is a 4D tensor of shape [N, 1, H*W, C] and is allocated on the device
               - For the :attr:`input_tensor`, H*W must be a multiple of the tile size (32) and C must be a multiple of the tile size and divide evenly into :attr:`num_groups`.
               - For the :attr:`input_mask`, C must match the number of groups, H must match a tile's height, and W must be a multiple of a tile's width.
-              - :attr:`gamma` and :attr:`beta` must be provided
+              - :attr:core_grid`, :attr:`gamma`, and :attr:`beta` must be provided
               - :attr:`inplace` is not supported for TILE-layout inputs and requires input and output layouts to be identical.
               - When generating inputs (e.g. weight, bias) for block sharded tensors, the number of cores in a column should draw upon core.x rather than core.y.
               - When generating inputs (e.g. weight, bias) for height sharded tensors, the number of cores in a column should be 1 rather than core.y.

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_nanobind.cpp
@@ -11,6 +11,7 @@
 
 #include "ttnn-nanobind/bind_function.hpp"
 #include "groupnorm.hpp"
+#include "groupnorm_grid_utils.hpp"
 #include "groupnorm_input_mask.hpp"
 
 namespace ttnn::operations::normalization::detail {
@@ -173,6 +174,42 @@ void bind_normalization_group_norm_operation(nb::module_& mod) {
         R"doc(
             C++ implementation of create_group_norm_input_negative_mask.
             Returns a ttnn.Tensor of shape [1, num_groups, 32, 32*block_wt], dtype=ttnn.DataType.BFLOAT16.
+        )doc");
+    mod.def(
+        "_compute_num_virtual_cols",
+        [](uint32_t grid_x, int num_groups, uint32_t num_channels) -> uint32_t {
+            return compute_num_virtual_cols(grid_x, num_groups, num_channels);
+        },
+        nb::arg("grid_x"),
+        nb::arg("num_groups"),
+        nb::arg("num_channels"),
+        R"doc(
+            Compute the number of virtual columns for DRAM group-norm.
+            Finds the largest nvc <= min(grid_x, num_groups) such that
+            (num_channels / nvc) % TILE_SIZE == 0 and num_groups % nvc == 0.
+            Returns 0 if no valid value exists.
+        )doc");
+    mod.def(
+        "_find_expected_dram_grid",
+        [](uint32_t max_x, uint32_t max_y, uint32_t num_channels, int num_groups, uint32_t input_nhw)
+            -> ttnn::CoreGrid {
+            auto result = find_expected_dram_grid(max_x, max_y, num_channels, num_groups, input_nhw);
+            if (!result.has_value()) {
+                throw std::runtime_error(
+                    "Cannot find a valid DRAM group-norm grid for num_channels=" + std::to_string(num_channels) +
+                    ", num_groups=" + std::to_string(num_groups) + ", input_nhw=" + std::to_string(input_nhw) +
+                    ", max_grid=(" + std::to_string(max_x) + ", " + std::to_string(max_y) + ")");
+            }
+            return result.value();
+        },
+        nb::arg("max_x"),
+        nb::arg("max_y"),
+        nb::arg("num_channels"),
+        nb::arg("num_groups"),
+        nb::arg("input_nhw"),
+        R"doc(
+            Find the largest valid CoreGrid within (max_x, max_y) bounds
+            for DRAM interleaved group-norm. Raises if no valid grid exists.
         )doc");
 }
 }  // namespace

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_nanobind.cpp
@@ -49,8 +49,8 @@ void bind_normalization_group_norm_operation(nb::module_& mod) {
                 num_groups (int): Number of groups to split the tensor's channels into.
                 epsilon (float): Defaults to 1e-12.
                 input_mask (ttnn.Tensor, optional): Defaults to `None`. When processing the inputs, the mask is used to only look at the elements of the current group.
-                weight (ttnn.Tensor, optional): Must be provided (see limitations). Defaults to `None`.
-                bias (ttnn.Tensor, optional): Must be provided (see limitations). Defaults to `None`.
+                weight (ttnn.Tensor, optional): Gamma (scale) parameter for the affine transformation. When omitted, no scaling is applied. Defaults to `None`.
+                bias (ttnn.Tensor, optional): Beta (shift) parameter for the affine transformation. When omitted, no shift is applied. Defaults to `None`.
                 memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
                 dtype (ttnn.DataType, optional): Defaults to `None`.
                 core_grid (CoreGrid, optional): Must be provided (see limitations). Defaults to `None`.
@@ -102,7 +102,7 @@ void bind_normalization_group_norm_operation(nb::module_& mod) {
               - :attr:`input_tensor` is a 4D tensor of shape [N, 1, H*W, C] and is allocated on the device
               - For the :attr:`input_tensor`, H*W must be a multiple of the tile size (32) and C must be a multiple of the tile size and divide evenly into :attr:`num_groups`.
               - For the :attr:`input_mask`, C must match the number of groups, H must match a tile's height, and W must be a multiple of a tile's width.
-              - :attr:core_grid`, :attr:`gamma`, and :attr:`beta` must be provided
+              - :attr:`core_grid` must be provided
               - :attr:`inplace` is not supported for TILE-layout inputs and requires input and output layouts to be identical.
               - When generating inputs (e.g. weight, bias) for block sharded tensors, the number of cores in a column should draw upon core.x rather than core.y.
               - When generating inputs (e.g. weight, bias) for height sharded tensors, the number of cores in a column should be 1 rather than core.y.

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_nanobind.cpp
@@ -37,6 +37,7 @@ void bind_normalization_group_norm_operation(nb::module_& mod) {
                     - When using sharded input tensors, :func:`ttnn.determine_expected_group_norm_sharded_config_and_grid_size` can provide the appropriate memory configuration and grid size.
                     - When using interleaved (DRAM) input tensors, :func:`ttnn.determine_expected_group_norm_dram_grid_size` can provide the appropriate grid size.
                     - :func:`ttnn.dram_group_norm_params_from_torch` is a convenience function that prepares the weight, bias, and input mask from PyTorch tensors for interleaved inputs.
+                    - :func:`ttnn.get_group_norm_cores_across_channel` returns the number of cores that split the channel axis for a given memory layout, grid, and shard orientation. This value must be passed consistently to :func:`ttnn.create_group_norm_input_mask` and :func:`ttnn.create_group_norm_weight_bias_rm`. For HEIGHT_SHARDED inputs this is always 1; for BLOCK_SHARDED inputs it is ``core_grid.x`` when using ROW_MAJOR shard orientation, or ``core_grid.y`` when using COL_MAJOR.
                     - :func:`ttnn.create_group_norm_input_mask` creates the appropriate input mask for a given tensor dimension and group size.
                     - :func:`ttnn.create_group_norm_weight_bias_rm` converts the weight and bias tensors into appropriately padded and tiled inputs
 

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -425,6 +425,7 @@ from ttnn.operations.normalization import (
     create_group_norm_reciprocals,
     create_layer_norm_reciprocals,
     determine_expected_group_norm_sharded_config_and_grid_size,
+    determine_expected_group_norm_dram_grid_size,
     dram_group_norm_params_from_torch,
     layernorm_default_compute_config,
     rmsnorm_default_compute_config,

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -426,6 +426,7 @@ from ttnn.operations.normalization import (
     create_layer_norm_reciprocals,
     determine_expected_group_norm_sharded_config_and_grid_size,
     determine_expected_group_norm_dram_grid_size,
+    get_group_norm_cores_across_channel,
     dram_group_norm_params_from_torch,
     layernorm_default_compute_config,
     rmsnorm_default_compute_config,

--- a/ttnn/ttnn/operations/normalization.py
+++ b/ttnn/ttnn/operations/normalization.py
@@ -238,8 +238,10 @@ def determine_expected_group_norm_sharded_config_and_grid_size(
         num_cores_channels = device_grid_size[1]
         # num_channels_tiles = num_channels // 16
         num_channels_tiles = num_channels // 8
-        while (num_channels_tiles % num_cores_channels != 0) or (
-            ((num_channels // num_cores_channels) % group_size) != 0
+        while (
+            (num_channels_tiles % num_cores_channels != 0)
+            or ((num_channels // num_cores_channels) % group_size != 0)
+            or (num_channels // num_cores_channels < 32)
         ):
             num_cores_channels -= 1
             assert num_cores_channels > 0
@@ -495,12 +497,18 @@ def create_group_norm_reciprocals(N, C, H, W, num_groups, core_grid):
     return create_group_norm_reciprocals_impl(N, C, H, W, num_groups, core_grid)
 
 
-def get_group_norm_cores_across_channel(memory_layout, core_grid):
+def get_group_norm_cores_across_channel(memory_layout, core_grid, shard_orientation=None):
     """Compute effective cores that split the channel axis.
-    Used to reshape gamma/beta per-core views in the golden code.
+
+    For BLOCK_SHARDED, the channel axis lives in grid.y (COL_MAJOR)
+    or grid.x (ROW_MAJOR).  When *shard_orientation* is not supplied
+    the legacy COL_MAJOR behaviour is assumed.
     """
     if memory_layout == ttnn.types.TensorMemoryLayout.BLOCK_SHARDED:
-        num_cores_across_channel = core_grid.y
+        if shard_orientation == ttnn.ShardOrientation.ROW_MAJOR:
+            num_cores_across_channel = core_grid.x
+        else:
+            num_cores_across_channel = core_grid.y
     elif memory_layout == ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED:
         num_cores_across_channel = 1
     else:
@@ -524,7 +532,10 @@ def _golden_function(
     import torch
 
     num_channels = input_tensor.shape[-1]
-    num_cores_across_channel = get_group_norm_cores_across_channel(memory_config.memory_layout, core_grid)
+    shard_orientation = getattr(memory_config.shard_spec, "orientation", None) if memory_config.shard_spec else None
+    num_cores_across_channel = get_group_norm_cores_across_channel(
+        memory_config.memory_layout, core_grid, shard_orientation
+    )
     weight = weight.reshape((num_cores_across_channel, -1))
     weight = weight[:, : num_channels // num_cores_across_channel].flatten()
     if bias is not None:

--- a/ttnn/ttnn/operations/normalization.py
+++ b/ttnn/ttnn/operations/normalization.py
@@ -284,11 +284,12 @@ def determine_expected_group_norm_dram_grid_size(*, device, num_channels, num_gr
                             (num_channels // nvc) % TILE_SIZE == 0  and  num_groups % nvc == 0
         num_virtual_rows  = (grid_x // num_virtual_cols) * grid_y
 
-    The constraint is  num_virtual_rows <= Ht  where Ht = ceil(input_nhw / TILE_SIZE).
-    Violating it causes per_core_Mt == 0 and division-by-zero in the kernels.
+    Constraints:
+        1. num_virtual_rows <= Ht  (otherwise per_core_Mt == 0)
+        2. Ht % num_virtual_rows == 0  (otherwise remainder tile rows are never processed)
 
     This function finds the largest grid (x then y) within the device compute grid
-    that satisfies this constraint.
+    that satisfies these constraints.
 
     Returns: CoreGrid
     """
@@ -307,10 +308,10 @@ def determine_expected_group_norm_dram_grid_size(*, device, num_channels, num_gr
         rows_per_y = gx // nvc
         if rows_per_y == 0:
             continue
-        gy = min(Ht // rows_per_y, max_y)
-        if gy == 0:
-            continue
-        return ttnn.CoreGrid(y=gy, x=gx)
+        for gy in range(min(Ht // rows_per_y, max_y), 0, -1):
+            num_virtual_rows = rows_per_y * gy
+            if Ht % num_virtual_rows == 0:
+                return ttnn.CoreGrid(y=gy, x=gx)
 
     raise ValueError(
         f"determine_expected_group_norm_dram_grid_size: Cannot find a valid grid for "

--- a/ttnn/ttnn/operations/normalization.py
+++ b/ttnn/ttnn/operations/normalization.py
@@ -293,7 +293,7 @@ def determine_expected_group_norm_dram_grid_size(*, device, num_channels, num_gr
     Returns: CoreGrid
     """
     assert num_channels % num_groups == 0
-    assert num_channels % 32 == 0
+    assert num_channels % ttnn.TILE_SIZE == 0
     compute_grid = device.compute_with_storage_grid_size()
     max_x, max_y = compute_grid.x, compute_grid.y
     Ht = math.ceil(input_nhw / ttnn.TILE_SIZE)

--- a/ttnn/ttnn/operations/normalization.py
+++ b/ttnn/ttnn/operations/normalization.py
@@ -9,7 +9,12 @@ import ttnn
 
 import math
 
-from ttnn._ttnn.operations.normalization import create_group_norm_input_mask, create_group_norm_input_negative_mask
+from ttnn._ttnn.operations.normalization import (
+    create_group_norm_input_mask,
+    create_group_norm_input_negative_mask,
+    _compute_num_virtual_cols,
+    _find_expected_dram_grid,
+)
 
 
 def find_closest_largest_divisor(num: int, start_divisor: int):
@@ -281,45 +286,15 @@ def determine_expected_group_norm_sharded_config_and_grid_size(
 def determine_expected_group_norm_dram_grid_size(*, device, num_channels, num_groups, input_nhw):
     """Determine a valid core grid for DRAM interleaved (non-sharded) group norm.
 
-    In the DRAM path the core grid defines a virtual grid where:
-        num_virtual_cols  = largest nvc <= min(grid_x, num_groups) such that
-                            (num_channels // nvc) % TILE_SIZE == 0  and  num_groups % nvc == 0
-        num_virtual_rows  = (grid_x // num_virtual_cols) * grid_y
-
-    Constraints:
-        1. num_virtual_rows <= Ht  (otherwise per_core_Mt == 0)
-        2. Ht % num_virtual_rows == 0  (otherwise remainder tile rows are never processed)
-
-    This function finds the largest grid (x then y) within the device compute grid
-    that satisfies these constraints.
+    Delegates to the C++ implementation which finds the largest grid (x then y)
+    within the device compute grid that satisfies the DRAM group-norm constraints.
 
     Returns: CoreGrid
     """
     assert num_channels % num_groups == 0
     assert num_channels % ttnn.TILE_SIZE == 0
     compute_grid = device.compute_with_storage_grid_size()
-    max_x, max_y = compute_grid.x, compute_grid.y
-    Ht = math.ceil(input_nhw / ttnn.TILE_SIZE)
-
-    for gx in range(max_x, 0, -1):
-        nvc = min(gx, num_groups)
-        while nvc > 0 and ((num_channels // nvc) % ttnn.TILE_SIZE != 0 or num_groups % nvc != 0):
-            nvc -= 1
-        if nvc == 0:
-            continue
-        rows_per_y = gx // nvc
-        if rows_per_y == 0:
-            continue
-        for gy in range(min(Ht // rows_per_y, max_y), 0, -1):
-            num_virtual_rows = rows_per_y * gy
-            if Ht % num_virtual_rows == 0:
-                return ttnn.CoreGrid(y=gy, x=gx)
-
-    raise ValueError(
-        f"determine_expected_group_norm_dram_grid_size: Cannot find a valid grid for "
-        f"num_channels={num_channels}, num_groups={num_groups}, input_nhw={input_nhw}, "
-        f"device grid=({max_x}, {max_y})"
-    )
+    return _find_expected_dram_grid(compute_grid.x, compute_grid.y, num_channels, num_groups, input_nhw)
 
 
 def create_group_norm_weight_bias_rm(input_tensor, num_channels, num_cores_x):
@@ -346,20 +321,14 @@ def create_group_norm_weight_bias_rm(input_tensor, num_channels, num_cores_x):
 def dram_group_norm_virtual_columns(core_grid, num_channels, num_groups):
     """Choose number of virtual columns for DRAM params/mask generation.
 
-    Finds the largest num_virtual_cols (<= min(grid_x, num_groups)) such that
-    channels divide evenly into tiles and groups divide evenly across cores:
-        (num_channels / nvc) % TILE_SIZE == 0  and  num_groups % nvc == 0
+    Delegates to the C++ implementation of compute_num_virtual_cols.
     """
-    num_virtual_cols = min(core_grid.x, num_groups)
-    while num_virtual_cols > 0 and (
-        (num_channels // num_virtual_cols) % ttnn.TILE_SIZE != 0 or num_groups % num_virtual_cols != 0
-    ):
-        num_virtual_cols -= 1
-    assert num_virtual_cols > 0, (
+    result = _compute_num_virtual_cols(core_grid.x, num_groups, num_channels)
+    assert result > 0, (
         f"dram_group_norm_virtual_columns: could not find a valid num_virtual_cols for "
         f"grid_x={core_grid.x}, num_channels={num_channels}, num_groups={num_groups}"
     )
-    return num_virtual_cols
+    return result
 
 
 def dram_group_norm_params_from_torch(

--- a/ttnn/ttnn/operations/normalization.py
+++ b/ttnn/ttnn/operations/normalization.py
@@ -276,6 +276,49 @@ def determine_expected_group_norm_sharded_config_and_grid_size(
     ), ttnn.CoreGrid(y=grid_size[1], x=grid_size[0])
 
 
+def determine_expected_group_norm_dram_grid_size(*, device, num_channels, num_groups, input_nhw):
+    """Determine a valid core grid for DRAM interleaved (non-sharded) group norm.
+
+    In the DRAM path the core grid defines a virtual grid where:
+        num_virtual_cols  = largest nvc <= min(grid_x, num_groups) such that
+                            (num_channels // nvc) % TILE_SIZE == 0  and  num_groups % nvc == 0
+        num_virtual_rows  = (grid_x // num_virtual_cols) * grid_y
+
+    The constraint is  num_virtual_rows <= Ht  where Ht = ceil(input_nhw / TILE_SIZE).
+    Violating it causes per_core_Mt == 0 and division-by-zero in the kernels.
+
+    This function finds the largest grid (x then y) within the device compute grid
+    that satisfies this constraint.
+
+    Returns: CoreGrid
+    """
+    assert num_channels % num_groups == 0
+    assert num_channels % 32 == 0
+    compute_grid = device.compute_with_storage_grid_size()
+    max_x, max_y = compute_grid.x, compute_grid.y
+    Ht = math.ceil(input_nhw / ttnn.TILE_SIZE)
+
+    for gx in range(max_x, 0, -1):
+        nvc = min(gx, num_groups)
+        while nvc > 0 and ((num_channels // nvc) % ttnn.TILE_SIZE != 0 or num_groups % nvc != 0):
+            nvc -= 1
+        if nvc == 0:
+            continue
+        rows_per_y = gx // nvc
+        if rows_per_y == 0:
+            continue
+        gy = min(Ht // rows_per_y, max_y)
+        if gy == 0:
+            continue
+        return ttnn.CoreGrid(y=gy, x=gx)
+
+    raise ValueError(
+        f"determine_expected_group_norm_dram_grid_size: Cannot find a valid grid for "
+        f"num_channels={num_channels}, num_groups={num_groups}, input_nhw={input_nhw}, "
+        f"device grid=({max_x}, {max_y})"
+    )
+
+
 def create_group_norm_weight_bias_rm(input_tensor, num_channels, num_cores_x):
     """Prepares a gamma/beta tensor in a padded [1,1,-1,32] format.
 
@@ -300,11 +343,19 @@ def create_group_norm_weight_bias_rm(input_tensor, num_channels, num_cores_x):
 def dram_group_norm_virtual_columns(core_grid, num_channels, num_groups):
     """Choose number of virtual columns for DRAM params/mask generation.
 
-    Tries to find the largest number of virtual columns that will evenly divide the number of channels into tiles.
+    Finds the largest num_virtual_cols (<= min(grid_x, num_groups)) such that
+    channels divide evenly into tiles and groups divide evenly across cores:
+        (num_channels / nvc) % TILE_SIZE == 0  and  num_groups % nvc == 0
     """
     num_virtual_cols = min(core_grid.x, num_groups)
-    while (num_channels / num_virtual_cols) % ttnn.TILE_SIZE != 0:
+    while num_virtual_cols > 0 and (
+        (num_channels // num_virtual_cols) % ttnn.TILE_SIZE != 0 or num_groups % num_virtual_cols != 0
+    ):
         num_virtual_cols -= 1
+    assert num_virtual_cols > 0, (
+        f"dram_group_norm_virtual_columns: could not find a valid num_virtual_cols for "
+        f"grid_x={core_grid.x}, num_channels={num_channels}, num_groups={num_groups}"
+    )
     return num_virtual_cols
 
 


### PR DESCRIPTION
### Ticket
#37852
https://github.com/tenstorrent/tt-metal/issues/39529
https://github.com/tenstorrent/tt-metal/issues/33974

### Problem description
1. Forge needs to use group norm, but it is too easy to create invalid group norm arguments that result in unclear errors (for example, providing invalid grids can result in a division by zero with no further context, or silently dropping tiles resulting in inaccurate results).

2. GN has optional arguments for gamma and beta, but its a limitation that they have to be provided. There is no validation for this either, so the op just hangs if they are missing.

3. The sharded helper function (`determine_expected_group_norm_sharded_config_and_grid_size`) can create invalid grids that would map to having less than one tile of channels per core. We also rely on the user to properly calculate the number of channels per core, which is error prone.

### What's changed

1. Added validation to catch common errors, such as when core grids or large `num_out_blocks` would result in division by zero.
2. Added new `determine_expected_group_norm_dram_grid_size` function to make it easier for interleaved users to get a working core grid
3. Updated documentation to reference the new functionality, and provide some context on what `num_out_blocks` will do.
4. Updated GN so that gamma and beta become actually optional, added unit test running GN with either and with both missing 
5. Fixed up the sharded helper and added a bit more validation. 
6. Exposed `get_group_norm_cores_across_channel` and updated the docs and examples to use this

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=edwinlee/37852/gn_forge_usage)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:edwinlee/37852/gn_forge_usage)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=edwinlee/37852/gn_forge_usage)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:edwinlee/37852/gn_forge_usage) matches Main with Profiler regression failing
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=edwinlee/37852/gn_forge_usage)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:edwinlee/37852/gn_forge_usage)
- [x] New/Existing tests provide coverage for changes
- [x] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=edwinlee/37852/gn_forge_usage)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:edwinlee/37852/gn_forge_usage)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=edwinlee/37852/gn_forge_usage)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:edwinlee/37852/gn_forge_usage)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=edwinlee/37852/gn_forge_usage)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:edwinlee/37852/gn_forge_usage)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
