### PR TITLE
Relax DiT T3K perf targets for OOM and conv2d slice fixes

### DIFF
--- a/models/tt_dit/tests/models/flux1/test_performance_flux1.py
+++ b/models/tt_dit/tests/models/flux1/test_performance_flux1.py
@@ -264,7 +264,7 @@ def test_flux1_pipeline_performance(
             "total_encoding_time": 0.3,
             "denoising_steps_time": 0.75 * num_inference_steps,
             "vae_decoding_time": 1.6,
-            "total_time": 22,
+            "total_time": 23,
         }
     elif tuple(mesh_device.shape) == (4, 8):
         expected_metrics = {

--- a/models/tt_dit/tests/models/motif/test_performance_motif.py
+++ b/models/tt_dit/tests/models/motif/test_performance_motif.py
@@ -241,9 +241,9 @@ def test_motif_pipeline_performance(
             "clip_encoding_time": 0.12,
             "t5_encoding_time": 0.15,
             "total_encoding_time": 0.45,
-            "denoising_steps_time": 0.45 * num_inference_steps,
+            "denoising_steps_time": 0.52 * num_inference_steps,
             "vae_decoding_time": 1.7,
-            "total_time": 14.6,
+            "total_time": 16.5,
         }
     elif tuple(mesh_device.shape) == (4, 8):
         expected_metrics = {

--- a/models/tt_dit/tests/models/qwenimage/test_performance_qwenimage.py
+++ b/models/tt_dit/tests/models/qwenimage/test_performance_qwenimage.py
@@ -219,9 +219,9 @@ def test_qwenimage_pipeline_performance(
     if tuple(mesh_device.shape) == (2, 4):
         expected_metrics = {
             "total_encoding_time": 0.35,
-            "denoising_steps_time": 72.0,
-            "vae_decoding_time": 0.65,
-            "total_time": 75,
+            "denoising_steps_time": 80.0,
+            "vae_decoding_time": 0.75,
+            "total_time": 88,
         }
     elif tuple(mesh_device.shape) == (4, 8):
         expected_metrics = {

--- a/models/tt_dit/tests/models/sd35/test_performance_sd35.py
+++ b/models/tt_dit/tests/models/sd35/test_performance_sd35.py
@@ -20,9 +20,9 @@ def get_expected_metrics(mesh_device):
             "clip_encoding_time": 0.15,
             "t5_encoding_time": 0.1,
             "total_encoding_time": 0.25,
-            "denoising_steps_time": 11.3,
+            "denoising_steps_time": 12.0,
             "vae_decoding_time": 1.6,
-            "total_time": 13.2,
+            "total_time": 14.0,
         }
     elif tuple(mesh_device.shape) == (4, 8):
         return {


### PR DESCRIPTION
Ticket: #39248, #39246

## Problem

PR #39302 enabled `dynamic_load_vae` for QwenImage on WH T3K (2x4) to fix DRAM OOM. This adds a VAE reload-from-cache step each pipeline run, slightly increasing denoising and total times.

The conv2d slice fix (`kevinmi/fix-conv2d-slice`) corrected `num_slices` from 8 to 4 for certain VAE configurations, changing decode performance characteristics for SD3.5, Motif, and Flux.

Both caused the existing perf targets to be exceeded.

## What's changed

Updated WH T3K (2x4) perf targets with margin to accommodate observed actuals:

| Model | Metric | Old | New | Actual |
|-------|--------|-----|-----|--------|
| QwenImage | denoising_steps_time | 72.0 | 80.0 | 76.2 |
| QwenImage | total_time | 75 | 88 | ~82 |
| SD3.5 | denoising_steps_time | 11.3 | 12.0 | 11.58 |
| SD3.5 | total_time | 13.2 | 14.0 | ~13.5 |
| Motif | denoising per-step | 0.45 | 0.52 | 0.508 |
| Motif | total_time | 14.6 | 16.5 | ~15.0 |
| Flux | total_time | 22 | 23 | 22.006 |

CI run: https://github.com/tenstorrent/tt-metal/actions/runs/22853055080

## Checklist

- [x] New/Existing tests provide coverage for changes
- Model tests
  - [x] (Single) Choose your pipeline
    - [x] `models-mandatory` preset (runs: Device perf regressions and Frequent model and ttnn tests)