### PR TITLE
Jmalone/bod finetune

### DIFF
--- a/tt-train/configs/model_configs/gpt2s.yaml
+++ b/tt-train/configs/model_configs/gpt2s.yaml
@@ -1,6 +1,6 @@
 transformer_config:
   model_type: "gpt2"
-  runner_type: memory_efficient
+  runner_type: default
   num_heads: 12
   embedding_dim: 768
   dropout_prob: 0.2

--- a/tt-train/sources/examples/gsm8k_finetune/gsm8k_finetune.py
+++ b/tt-train/sources/examples/gsm8k_finetune/gsm8k_finetune.py
@@ -597,23 +597,24 @@ def train():
             postfix["val_loss"] = f"{float(last_val_loss):.4f}"
         bar.set_postfix(postfix, refresh=False)
 
+        # Disable validation by commenting out for demo
         # Validation every eval_every steps
-        if (
-            total_steps % training_config.eval_every == 0
-            or total_steps + 1 == training_config.steps
-        ):
-            last_val_loss = validate(
-                tt_model,
-                tokenizer,
-                val_batch_generator,
-                testing_data,
-                loss_fn,
-                causal_mask,
-                logits_mask_tensor,
-                max_sequence_length,
-                total_steps,
-            )
-            val_losses.append(last_val_loss)
+        # if (
+        #     total_steps % training_config.eval_every == 0
+        #     or total_steps + 1 == training_config.steps
+        # ):
+        #     last_val_loss = validate(
+        #         tt_model,
+        #         tokenizer,
+        #         val_batch_generator,
+        #         testing_data,
+        #         loss_fn,
+        #         causal_mask,
+        #         logits_mask_tensor,
+        #         max_sequence_length,
+        #         total_steps,
+        #     )
+        #     val_losses.append(last_val_loss)
 
         with open("output.txt", "a") as f:
             f.write(
@@ -638,7 +639,11 @@ def train():
     axs.set_ylabel("Loss")
     axs.legend()
     plt.savefig("training_curves.png")
-    plt.show()
+    # Don't show when called from dashboard - breaks repeatable jobs on one machine
+    # plt.show()
+
+    # Cleanup
+    ttml.autograd.AutoContext.get_instance().close_device()
 
 
 if __name__ == "__main__":

--- a/tt-train/sources/examples/gsm8k_finetune/job_manager.py
+++ b/tt-train/sources/examples/gsm8k_finetune/job_manager.py
@@ -144,8 +144,8 @@ SLURM_SCRIPT_TEMPLATE = """#!/bin/bash
 {nodelist_directive}
 
 # Set environmental variables
-export HOME="/data/${{USER}}/llama"
-export TT_METAL_HOME="/data/${{USER}}/llama/tt-metal"
+export HOME="/data/${{USER}}"
+export TT_METAL_HOME="/data/${{USER}}/tt-metal"
 export TT_METAL_RUNTIME_ROOT=$TT_METAL_HOME
 export PYTHONPATH="${{TT_METAL_HOME}}"
 source ${{TT_METAL_HOME}}/python_env/bin/activate

--- a/tt-train/sources/examples/gsm8k_finetune/job_manager.py
+++ b/tt-train/sources/examples/gsm8k_finetune/job_manager.py
@@ -83,8 +83,8 @@ PARTITION_DEVICE_MAPPING = {
 
 # Available Galaxy nodes for non-lb partitions
 GALAXY_NODES = [
-    # "bh-glx-c01u02",
-    # "bh-glx-c01u08",
+    "bh-glx-c01u02",
+    "bh-glx-c01u08",
     "bh-glx-c02u02",
     "bh-glx-c02u08",
 ]
@@ -144,8 +144,8 @@ SLURM_SCRIPT_TEMPLATE = """#!/bin/bash
 {nodelist_directive}
 
 # Set environmental variables
-export HOME="/data/${{USER}}"
-export TT_METAL_HOME="/data/${{USER}}/tt-metal"
+export HOME="/data/${{USER}}/llama"
+export TT_METAL_HOME="/data/${{USER}}/llama/tt-metal"
 export TT_METAL_RUNTIME_ROOT=$TT_METAL_HOME
 export PYTHONPATH="${{TT_METAL_HOME}}"
 source ${{TT_METAL_HOME}}/python_env/bin/activate
@@ -312,8 +312,8 @@ class JobManager:
 
         # For non-lb partitions, add nodelist directive if a node is selected
         nodelist_directive = ""
-        if not is_lb_partition and selected_node:
-            nodelist_directive = f"#SBATCH --nodelist={selected_node}"
+        if not is_lb_partition:
+            nodelist_directive = f"#SBATCH --nodelist={','.join(GALAXY_NODES)}"
 
         # Paths to job-specific config files
         mesh_graph_desc_path = output_dir / "mesh_graph_descriptor.textproto"

--- a/tt-train/sources/ttml/core/distributed/distributed.cpp
+++ b/tt-train/sources/ttml/core/distributed/distributed.cpp
@@ -29,7 +29,7 @@ ttnn::Tensor synchronize_tensor(const ttnn::Tensor& tensor, const ttnn::SmallVec
     }
     auto result = tensor;
     for (const auto& cluster_axis : cluster_axes) {
-        result = ttnn::all_reduce(result, cluster_axis);
+        result = ttml::ttnn_fixed::distributed::all_reduce(result, cluster_axis);
     }
 
     result = ttnn::multiply(result, 1.0F / static_cast<float>(scaler));

--- a/tt-train/sources/ttml/models/gpt2.cpp
+++ b/tt-train/sources/ttml/models/gpt2.cpp
@@ -122,6 +122,11 @@ Transformer::Transformer(const TransformerConfig &config) {
 }
 
 ttml::autograd::TensorPtr Transformer::operator()(
+    const ttml::autograd::TensorPtr &x, const ttml::autograd::TensorPtr &mask) {
+    return (*this)(x, std::optional<ttml::autograd::TensorPtr>(mask));
+}
+
+ttml::autograd::TensorPtr Transformer::operator()(
     const ttml::autograd::TensorPtr &x, const std::optional<ttml::autograd::TensorPtr> &mask) {
     auto tok_emb_out = (*tok_emb)(x);
     auto out = (*pos_emb)(tok_emb_out);

--- a/tt-train/sources/ttml/models/gpt2.hpp
+++ b/tt-train/sources/ttml/models/gpt2.hpp
@@ -58,6 +58,8 @@ public:
     void load_from_safetensors(const std::filesystem::path& model_path) override;
     ttml::autograd::TensorPtr operator()(
         const ttml::autograd::TensorPtr& x, const std::optional<ttml::autograd::TensorPtr>& mask) override;
+    ttml::autograd::TensorPtr operator()(
+        const ttml::autograd::TensorPtr& x, const ttml::autograd::TensorPtr& mask) override;
 };
 
 [[nodiscard]] TransformerConfig read_config(const YAML::Node& config);


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=jmalone/bod-finetune)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:jmalone/bod-finetune)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jmalone/bod-finetune)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jmalone/bod-finetune)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jmalone/bod-finetune)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jmalone/bod-finetune)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jmalone/bod-finetune)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jmalone/bod-finetune)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jmalone/bod-finetune)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jmalone/bod-finetune)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jmalone/bod-finetune)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jmalone/bod-finetune)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
