### PR TITLE
Incremental Inits

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_device.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device.cpp
@@ -208,5 +208,59 @@ TEST_F(MeshDeviceTest, CheckFabricNodeIds) {
     }
 }
 
+TEST(MeshDeviceInitTest, MultipleMeshDevice) {
+    auto pcie_ids_set = tt::tt_metal::MetalContext::instance().get_cluster().all_pci_chip_ids();
+    std::vector<int> pcie_ids(pcie_ids_set.begin(), pcie_ids_set.end());
+    size_t num_pcie = pcie_ids.size();
+    if (num_pcie < 2) {
+        GTEST_SKIP() << "Need at least 2 PCIe devices for this test";
+    }
+
+    size_t first_size = num_pcie / 2;
+    size_t second_size = num_pcie - first_size;
+    std::vector<int> first_half(pcie_ids.begin(), pcie_ids.begin() + first_size);
+    std::vector<int> second_half(pcie_ids.begin() + first_size, pcie_ids.end());
+
+    auto md_1 = distributed::MeshDevice::create(distributed::MeshDeviceConfig{
+        distributed::MeshShape(1, static_cast<uint32_t>(first_size)),
+        std::nullopt,
+        first_half,
+    });
+    auto md_2 = distributed::MeshDevice::create(distributed::MeshDeviceConfig{
+        distributed::MeshShape(1, static_cast<uint32_t>(second_size)),
+        std::nullopt,
+        second_half,
+    });
+
+    EXPECT_EQ(md_1->num_devices(), first_size);
+    EXPECT_EQ(md_2->num_devices(), second_size);
+}
+
+TEST(MeshDeviceInitTest, MultipleMeshDeviceWithSubMesh) {
+    auto pcie_ids_set = tt::tt_metal::MetalContext::instance().get_cluster().all_pci_chip_ids();
+    std::vector<int> pcie_ids(pcie_ids_set.begin(), pcie_ids_set.end());
+    size_t num_pcie = pcie_ids.size();
+    if (num_pcie < 2) {
+        GTEST_SKIP() << "Need at least 2 PCIe devices for this test";
+    }
+
+    auto mesh = distributed::MeshDevice::create(distributed::MeshDeviceConfig{
+        distributed::MeshShape(1, static_cast<uint32_t>(num_pcie)),
+        std::nullopt,
+        pcie_ids,
+    });
+    EXPECT_EQ(mesh->num_devices(), num_pcie);
+
+    size_t first_size = num_pcie / 2;
+    size_t second_size = num_pcie - first_size;
+
+    auto sub_1 = mesh->create_submesh(MeshShape{1, static_cast<uint32_t>(first_size)}, MeshCoordinate{0, 0});
+    auto sub_2 = mesh->create_submesh(
+        MeshShape{1, static_cast<uint32_t>(second_size)}, MeshCoordinate{0, static_cast<uint32_t>(first_size)});
+
+    EXPECT_EQ(sub_1->num_devices(), first_size);
+    EXPECT_EQ(sub_2->num_devices(), second_size);
+}
+
 }  // namespace
 }  // namespace tt::tt_metal::distributed

--- a/tests/tt_metal/distributed/test_mesh_device.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device.cpp
@@ -24,6 +24,7 @@
 #include "impl/context/metal_context.hpp"
 #include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
+#include <tt-metalium/experimental/fabric/fabric.hpp>
 #include <tt-metalium/experimental/device.hpp>
 #include <distributed/mesh_device_impl.hpp>
 #include <distributed/mesh_device_view_impl.hpp>
@@ -260,6 +261,62 @@ TEST(MeshDeviceInitTest, MultipleMeshDeviceWithSubMesh) {
 
     EXPECT_EQ(sub_1->num_devices(), first_size);
     EXPECT_EQ(sub_2->num_devices(), second_size);
+}
+
+TEST(MeshDeviceInitTest, FabricReconfigWhileDevicesOpen) {
+    auto pcie_ids_set = tt::tt_metal::MetalContext::instance().get_cluster().all_pci_chip_ids();
+    std::vector<int> pcie_ids(pcie_ids_set.begin(), pcie_ids_set.end());
+    size_t num_pcie = pcie_ids.size();
+    if (num_pcie < 2) {
+        GTEST_SKIP() << "Need at least 2 PCIe devices for this test";
+    }
+
+    size_t first_size = num_pcie / 2;
+    size_t second_size = num_pcie - first_size;
+    std::vector<int> first_half(pcie_ids.begin(), pcie_ids.begin() + first_size);
+    std::vector<int> second_half(pcie_ids.begin() + first_size, pcie_ids.end());
+
+    auto current_config = tt::tt_fabric::GetFabricConfig();
+    auto other_config = (current_config == tt::tt_fabric::FabricConfig::DISABLED)
+                            ? tt::tt_fabric::FabricConfig::FABRIC_1D
+                            : tt::tt_fabric::FabricConfig::DISABLED;
+
+    auto md_1 = distributed::MeshDevice::create(distributed::MeshDeviceConfig{
+        distributed::MeshShape(1, static_cast<uint32_t>(first_size)),
+        std::nullopt,
+        first_half,
+    });
+    auto md_2 = distributed::MeshDevice::create(distributed::MeshDeviceConfig{
+        distributed::MeshShape(1, static_cast<uint32_t>(second_size)),
+        std::nullopt,
+        second_half,
+    });
+
+    // Both meshes open: reconfigure must fail
+    EXPECT_ANY_THROW(tt::tt_fabric::SetFabricConfig(other_config));
+
+    // Close first mesh: reconfigure must still fail (second mesh still open)
+    md_1->close();
+    EXPECT_ANY_THROW(tt::tt_fabric::SetFabricConfig(other_config));
+
+    // Close second mesh: reconfigure should succeed now
+    md_2->close();
+    EXPECT_NO_THROW(tt::tt_fabric::SetFabricConfig(other_config));
+
+    // Reopen two meshes to verify everything still works after reconfiguration
+    md_1 = distributed::MeshDevice::create(distributed::MeshDeviceConfig{
+        distributed::MeshShape(1, static_cast<uint32_t>(first_size)),
+        std::nullopt,
+        first_half,
+    });
+    md_2 = distributed::MeshDevice::create(distributed::MeshDeviceConfig{
+        distributed::MeshShape(1, static_cast<uint32_t>(second_size)),
+        std::nullopt,
+        second_half,
+    });
+
+    EXPECT_EQ(md_1->num_devices(), first_size);
+    EXPECT_EQ(md_2->num_devices(), second_size);
 }
 
 }  // namespace

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -604,6 +604,17 @@ void MetalContext::set_fabric_config(
     // config, not through this function exposed in the detail API.
     force_reinit_ = true;
 
+    if (device_manager_ && fabric_config != this->fabric_config_) {
+        auto active_ids = device_manager_->get_all_active_device_ids();
+        TT_FATAL(
+            active_ids.empty(),
+            "Cannot change fabric config from {} to {} while {} device(s) are active. "
+            "Close all devices before changing the fabric config.",
+            this->fabric_config_,
+            fabric_config,
+            active_ids.size());
+    }
+
     // Export channel trimming capture data before fabric config changes.
     // Must happen while fabric_config_ is still active and fabric context is alive.
     bool is_tearing_down_fabric = fabric_config == tt_fabric::FabricConfig::DISABLED &&

--- a/tt_metal/impl/device/device_manager.cpp
+++ b/tt_metal/impl/device/device_manager.cpp
@@ -201,6 +201,22 @@ void DeviceManager::initialize(
 
     l1_bank_remap_.assign(descriptor_->l1_bank_remap().begin(), descriptor_->l1_bank_remap().end());
 
+    if (is_initialized_) {
+        // Incremental mode: only activate devices that are not yet active
+        // and extend existing firmware initializers for the new devices.
+        newly_activated_devices_.clear();
+        for (auto id : device_ids) {
+            if (!is_device_active(id)) {
+                activate_device(id);
+                newly_activated_devices_.push_back(get_device(id));
+            }
+        }
+        if (!newly_activated_devices_.empty() && initializers_.contains(CommandQueueInitializer::key)) {
+            initializers_[CommandQueueInitializer::key]->add_devices(newly_activated_devices_, init_done_);
+        }
+        return;
+    }
+
     open_devices(device_ids);
     is_initialized_ = true;
 }
@@ -458,6 +474,12 @@ void DeviceManager::add_devices_to_pool(const std::vector<ChipId>& device_ids) {
 }
 
 void DeviceManager::initialize_profiler() {
+    if (init_done_.contains(ProfilerInitializer::key) && !newly_activated_devices_.empty()) {
+        dynamic_cast<ProfilerInitializer*>(initializers_[ProfilerInitializer::key].get())
+            ->add_devices(newly_activated_devices_, init_done_);
+        return;
+    }
+
     auto& ctx = tt::tt_metal::MetalContext::instance();
     auto active_devices = this->get_all_active_devices_impl();
     initializers_[ProfilerInitializer::key] =
@@ -468,6 +490,16 @@ void DeviceManager::initialize_profiler() {
 }
 
 void DeviceManager::initialize_fabric_and_dispatch_fw() {
+    if (init_done_.contains(FabricFirmwareInitializer::key) && !newly_activated_devices_.empty()) {
+        // Incremental path: extend existing initializers with the new devices.
+        initializers_[FabricFirmwareInitializer::key]->add_devices(newly_activated_devices_, init_done_);
+        auto* dki = dynamic_cast<DispatchKernelInitializer*>(initializers_[DispatchKernelInitializer::key].get());
+        dki->add_devices(newly_activated_devices_, init_done_);
+        dki->configure_new_devices(newly_activated_devices_);
+        newly_activated_devices_.clear();
+        return;
+    }
+
     auto& ctx = tt::tt_metal::MetalContext::instance();
 
     if (using_fast_dispatch_ && ctx.get_cluster().is_galaxy_cluster()) {
@@ -692,29 +724,42 @@ bool DeviceManager::close_devices(const std::vector<IDevice*>& devices, bool /*s
         mmio_devices_to_close.insert(mmio_device_id);
     }
 
-    // Order matters
-    TT_ASSERT(init_done_.contains(DispatchKernelInitializer::key));
-    initializers_[DispatchKernelInitializer::key]->teardown(init_done_);
+    // Teardown firmware in order. When multiple MeshDevices share a DeviceManager,
+    // the first close tears down all firmware; subsequent closes skip gracefully.
+    if (init_done_.contains(DispatchKernelInitializer::key)) {
+        initializers_[DispatchKernelInitializer::key]->teardown(init_done_);
+    }
+    if (init_done_.contains(FabricFirmwareInitializer::key)) {
+        initializers_[FabricFirmwareInitializer::key]->teardown(init_done_);
+    }
+    if (init_done_.contains(ProfilerInitializer::key)) {
+        initializers_[ProfilerInitializer::key]->teardown(init_done_);
+    }
+    if (init_done_.contains(CommandQueueInitializer::key)) {
+        initializers_[CommandQueueInitializer::key]->teardown(init_done_);
+    }
 
-    TT_ASSERT(init_done_.contains(FabricFirmwareInitializer::key));
-    initializers_[FabricFirmwareInitializer::key]->teardown(init_done_);
-
-    TT_ASSERT(init_done_.contains(ProfilerInitializer::key));
-    initializers_[ProfilerInitializer::key]->teardown(init_done_);
-
-    TT_ASSERT(init_done_.contains(CommandQueueInitializer::key));
-    initializers_[CommandQueueInitializer::key]->teardown(init_done_);
-
-    TT_FATAL(init_done_.empty(), "All firmware initializers must remove themselves from init_done_ during teardown");
-    initializers_[DispatchKernelInitializer::key]->post_teardown();
-    initializers_[FabricFirmwareInitializer::key]->post_teardown();
-    initializers_[ProfilerInitializer::key]->post_teardown();
-    initializers_[CommandQueueInitializer::key]->post_teardown();
+    if (init_done_.empty()) {
+        if (initializers_.contains(DispatchKernelInitializer::key)) {
+            initializers_[DispatchKernelInitializer::key]->post_teardown();
+        }
+        if (initializers_.contains(FabricFirmwareInitializer::key)) {
+            initializers_[FabricFirmwareInitializer::key]->post_teardown();
+        }
+        if (initializers_.contains(ProfilerInitializer::key)) {
+            initializers_[ProfilerInitializer::key]->post_teardown();
+        }
+        if (initializers_.contains(CommandQueueInitializer::key)) {
+            initializers_[CommandQueueInitializer::key]->post_teardown();
+        }
+    }
 
     bool pass = true;
     for (const auto& dev_id : devices_to_close) {
-        auto* dev = this->get_active_device(dev_id);
-        pass &= dev->close();
+        auto* device = get_device(dev_id);
+        if (device && device->is_initialized()) {
+            pass &= device->close();
+        }
     }
 
     return pass;

--- a/tt_metal/impl/device/device_manager.cpp
+++ b/tt_metal/impl/device/device_manager.cpp
@@ -252,6 +252,21 @@ void DeviceManager::open_devices(const std::vector<ChipId>& device_ids) {
         }
     }
 
+    // Fabric requires all devices to be initialized regardless of dispatch mode
+    if (tt_fabric::is_tt_fabric_config(tt::tt_metal::MetalContext::instance().get_fabric_config())) {
+        device_ids_to_open.clear();
+        for (int id = 0; id < tt::tt_metal::MetalContext::instance().get_cluster().number_of_devices(); ++id) {
+            device_ids_to_open.push_back(id);
+        }
+        for (auto dev_id : device_ids_to_open) {
+            any_remote_devices |=
+                tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(dev_id) != dev_id;
+            if (any_remote_devices) {
+                break;
+            }
+        }
+    }
+
     std::vector<ChipId> target_mmio_ids;
     for (const auto& device_id : device_ids_to_open) {
         TT_FATAL(

--- a/tt_metal/impl/device/device_manager.hpp
+++ b/tt_metal/impl/device/device_manager.hpp
@@ -40,6 +40,10 @@ public:
 
     IDevice* get_active_device(ChipId device_id) const;
     std::vector<IDevice*> get_all_active_devices() const;
+    // Returns devices activated during the most recent incremental initialize() call. This is
+    // used to incremental initializing devices for the MeshDevice.
+    // Empty if the last initialize() was a fresh (non-incremental) init.
+    const std::vector<Device*>& get_newly_activated_devices() const { return newly_activated_devices_; }
     bool close_device(ChipId device_id);
     std::vector<ChipId> get_all_active_device_ids() const;
     std::unordered_map<ChipId, std::vector<uint32_t>> get_all_command_queue_event_infos() const;
@@ -72,6 +76,7 @@ private:
 
     mutable std::mutex lock_;
     std::vector<std::unique_ptr<Device>> devices_;
+    std::vector<Device*> newly_activated_devices_;
 
     bool skip_remote_devices_{};
     const std::unordered_set<CoreCoord> empty_container_;

--- a/tt_metal/impl/device/firmware/command_queue_initializer.cpp
+++ b/tt_metal/impl/device/firmware/command_queue_initializer.cpp
@@ -76,6 +76,23 @@ void CommandQueueInitializer::teardown(std::unordered_set<InitializerKey>& init_
 
 bool CommandQueueInitializer::is_initialized() const { return initialized_; }
 
+void CommandQueueInitializer::add_devices(
+    const std::vector<Device*>& new_devices, const std::unordered_set<InitializerKey>& /*init_done*/) {
+    if (descriptor_->is_mock_device()) {
+        for (auto* dev : new_devices) {
+            devices_.push_back(dev);
+        }
+        return;
+    }
+
+    for (auto* dev : new_devices) {
+        if (cluster_.get_associated_mmio_device(dev->id()) == dev->id()) {
+            initialize_host(dev);
+        }
+        devices_.push_back(dev);
+    }
+}
+
 void CommandQueueInitializer::initialize_host(Device* dev) const {
     detail::ClearProfilerControlBuffer(dev);
 

--- a/tt_metal/impl/device/firmware/command_queue_initializer.hpp
+++ b/tt_metal/impl/device/firmware/command_queue_initializer.hpp
@@ -18,6 +18,8 @@ public:
     void configure() override;
     void teardown(std::unordered_set<InitializerKey>& init_done) override;
     bool is_initialized() const override;
+    void add_devices(
+        const std::vector<Device*>& new_devices, const std::unordered_set<InitializerKey>& init_done) override;
 
 private:
     void initialize_host(Device* dev) const;

--- a/tt_metal/impl/device/firmware/dispatch_kernel_initializer.cpp
+++ b/tt_metal/impl/device/firmware/dispatch_kernel_initializer.cpp
@@ -123,13 +123,15 @@ void DispatchKernelInitializer::teardown(std::unordered_set<InitializerKey>& ini
 
 bool DispatchKernelInitializer::is_initialized() const { return initialized_; }
 
-void DispatchKernelInitializer::compile_dispatch_kernels() {
+void DispatchKernelInitializer::compile_dispatch_kernels() { compile_dispatch_kernels_for_devices(devices_); }
+
+void DispatchKernelInitializer::compile_dispatch_kernels_for_devices(const std::vector<Device*>& devices) {
     if (descriptor_->is_mock_device()) {
         return;
     }
 
     // Generate static args
-    for (auto* dev : devices_) {
+    for (auto* dev : devices) {
         if (cluster_.get_associated_mmio_device(dev->id()) != dev->id()) {
             continue;
         }
@@ -149,7 +151,7 @@ void DispatchKernelInitializer::compile_dispatch_kernels() {
     }
 
     // Create command queue programs
-    for (auto* dev : devices_) {
+    for (auto* dev : devices) {
         if (cluster_.get_associated_mmio_device(dev->id()) != dev->id()) {
             continue;
         }
@@ -172,30 +174,30 @@ void DispatchKernelInitializer::compile_dispatch_kernels() {
     dispatch_topology_->compile_cq_programs();
 }
 
-void DispatchKernelInitializer::init_device_command_queues() {
-    // Initialize device-side command queues (parallelized per MMIO device).
+void DispatchKernelInitializer::init_device_command_queues() { init_device_command_queues_for_devices(devices_); }
 
+void DispatchKernelInitializer::init_device_command_queues_for_devices(const std::vector<Device*>& devices) {
     if (descriptor_->is_mock_device()) {
         return;
     }
 
     std::vector<std::shared_future<void>> events;
-    for (auto* dev : devices_) {
+    for (auto* dev : devices) {
         if (cluster_.get_associated_mmio_device(dev->id()) != dev->id()) {
             continue;
         }
         ChipId mmio_device_id = dev->id();
-        events.emplace_back(detail::async([this, dev, mmio_device_id]() {
+        events.emplace_back(detail::async([this, dev, mmio_device_id, &devices]() {
             auto tunnels_from_mmio = cluster_.get_tunnels_from_mmio_device(mmio_device_id);
             dev->init_command_queue_device_with_topology(dispatch_topology_.get());
             log_debug(tt::LogMetal, "Command Queue initialized on Device {}", dev->id());
             for (const auto& tunnel : tunnels_from_mmio) {
                 for (uint32_t ts = tunnel.size() - 1; ts > 0; ts--) {
                     uint32_t mmio_controlled_device_id = tunnel[ts];
-                    auto it = std::find_if(devices_.begin(), devices_.end(), [&](IDevice* d) {
+                    auto it = std::find_if(devices.begin(), devices.end(), [&](IDevice* d) {
                         return d->id() == mmio_controlled_device_id;
                     });
-                    if (it != devices_.end()) {
+                    if (it != devices.end()) {
                         (*it)->init_command_queue_device_with_topology(dispatch_topology_.get());
                         log_debug(tt::LogMetal, "Command Queue initialized on Device {}", (*it)->id());
                     }
@@ -206,6 +208,44 @@ void DispatchKernelInitializer::init_device_command_queues() {
     for (const auto& event : events) {
         event.get();
     }
+}
+
+void DispatchKernelInitializer::add_devices(
+    const std::vector<Device*>& new_devices, const std::unordered_set<InitializerKey>& init_done) {
+    if (!using_fast_dispatch() || new_devices.empty()) {
+        for (auto* dev : new_devices) {
+            devices_.push_back(dev);
+        }
+        return;
+    }
+
+    populate_fd_kernels_only(new_devices);
+
+    for (auto* dev : new_devices) {
+        devices_.push_back(dev);
+    }
+
+    if (descriptor_->is_mock_device()) {
+        return;
+    }
+
+    TT_ASSERT(
+        init_done.contains(InitializerKey::Fabric), "Fabric firmware must be initialized before dispatch firmware");
+    TT_ASSERT(
+        init_done.contains(InitializerKey::Profiler), "Profiler firmware must be initialized before dispatch firmware");
+    TT_ASSERT(
+        init_done.contains(InitializerKey::CommandQueue),
+        "Host-side command queue firmware must be initialized before dispatch firmware");
+
+    compile_dispatch_kernels_for_devices(new_devices);
+}
+
+void DispatchKernelInitializer::configure_new_devices(const std::vector<Device*>& new_devices) {
+    if (!using_fast_dispatch()) {
+        return;
+    }
+
+    init_device_command_queues_for_devices(new_devices);
 }
 
 void DispatchKernelInitializer::terminate_command_queues() {

--- a/tt_metal/impl/device/firmware/dispatch_kernel_initializer.hpp
+++ b/tt_metal/impl/device/firmware/dispatch_kernel_initializer.hpp
@@ -35,10 +35,19 @@ public:
     // Populate the FD kernels only. This will cause dispatch cores to be allocated in dispatch_core_manager
     void populate_fd_kernels_only(const std::vector<Device*>& devices);
 
+    // Incrementally add new devices: allocate dispatch cores, compile dispatch kernels for them.
+    void add_devices(
+        const std::vector<Device*>& new_devices, const std::unordered_set<InitializerKey>& init_done) override;
+
+    // Configure (init device command queues) only for the specified devices.
+    void configure_new_devices(const std::vector<Device*>& new_devices);
+
 private:
     void compile_dispatch_kernels();
+    void compile_dispatch_kernels_for_devices(const std::vector<Device*>& devices);
 
     void init_device_command_queues();
+    void init_device_command_queues_for_devices(const std::vector<Device*>& devices);
 
     void terminate_command_queues();
 

--- a/tt_metal/impl/device/firmware/fabric_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/fabric_firmware_initializer.cpp
@@ -137,6 +137,13 @@ void FabricFirmwareInitializer::post_teardown() {
     tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::DISABLED);
 }
 
+void FabricFirmwareInitializer::add_devices(
+    const std::vector<Device*>& new_devices, const std::unordered_set<InitializerKey>& /*init_done*/) {
+    for (auto* dev : new_devices) {
+        devices_.push_back(dev);
+    }
+}
+
 bool FabricFirmwareInitializer::is_initialized() const { return initialized_; }
 
 void FabricFirmwareInitializer::compile_and_configure_fabric() {

--- a/tt_metal/impl/device/firmware/fabric_firmware_initializer.hpp
+++ b/tt_metal/impl/device/firmware/fabric_firmware_initializer.hpp
@@ -26,6 +26,8 @@ public:
     void teardown(std::unordered_set<InitializerKey>& init_done) override;
     void post_teardown() override;
     bool is_initialized() const override;
+    void add_devices(
+        const std::vector<Device*>& new_devices, const std::unordered_set<InitializerKey>& init_done) override;
 
 private:
     // Compile fabric on all devices, parallelized via async.

--- a/tt_metal/impl/device/firmware/firmware_initializer.hpp
+++ b/tt_metal/impl/device/firmware/firmware_initializer.hpp
@@ -51,6 +51,10 @@ public:
 
     virtual bool is_initialized() const = 0;
 
+    // Incrementally add new devices.
+    virtual void add_devices(
+        const std::vector<Device*>& new_devices, const std::unordered_set<InitializerKey>& init_done) = 0;
+
 protected:
     const Hal& hal_;
     Cluster& cluster_;

--- a/tt_metal/impl/device/firmware/profiler_initializer.cpp
+++ b/tt_metal/impl/device/firmware/profiler_initializer.cpp
@@ -101,4 +101,21 @@ void ProfilerInitializer::post_teardown() {
 
 bool ProfilerInitializer::is_initialized() const { return initialized_; }
 
+void ProfilerInitializer::add_devices(
+    const std::vector<Device*>& new_devices, const std::unordered_set<InitializerKey>& /*init_done*/) {
+#if defined(TRACY_ENABLE)
+    if (!devices_.empty() && getDeviceProfilerState()) {
+        for (auto* dev : new_devices) {
+            if (cluster_.get_associated_mmio_device(dev->id()) == dev->id()) {
+                detail::InitDeviceProfiler(dev);
+                log_info(tt::LogMetal, "Profiler started on device {}", dev->id());
+            }
+        }
+    }
+#endif
+    for (auto* dev : new_devices) {
+        devices_.push_back(dev);
+    }
+}
+
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/device/firmware/profiler_initializer.hpp
+++ b/tt_metal/impl/device/firmware/profiler_initializer.hpp
@@ -24,6 +24,8 @@ public:
     void teardown(std::unordered_set<InitializerKey>& init_done) override;
     void post_teardown() override;
     bool is_initialized() const override;
+    void add_devices(
+        const std::vector<Device*>& new_devices, const std::unordered_set<InitializerKey>& init_done) override;
 
 private:
     [[maybe_unused]] bool skip_remote_devices_;

--- a/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
@@ -169,6 +169,11 @@ void RiscFirmwareInitializer::run_launch_phase(const std::set<tt::ChipId>& devic
 
 void RiscFirmwareInitializer::configure() {}
 
+void RiscFirmwareInitializer::add_devices(
+    const std::vector<Device*>& /*new_devices*/, const std::unordered_set<InitializerKey>& /*init_done*/) {
+    TT_THROW("Cannot incrementally initialize Risc firmware at this time");
+}
+
 void RiscFirmwareInitializer::teardown_simulator_ethernet_cores() {
     // If simulator is enabled, force a teardown of active ethernet cores for WH
     if (rtoptions_.get_simulator_enabled()) {

--- a/tt_metal/impl/device/firmware/risc_firmware_initializer.hpp
+++ b/tt_metal/impl/device/firmware/risc_firmware_initializer.hpp
@@ -42,6 +42,8 @@ public:
     void configure() override;
     void teardown(std::unordered_set<InitializerKey>& init_done) override;
     bool is_initialized() const override;
+    void add_devices(
+        const std::vector<Device*>& new_devices, const std::unordered_set<InitializerKey>& init_done) override;
 
     void run_async_build_phase(const std::set<tt::ChipId>& device_ids);
     void run_launch_phase(const std::set<tt::ChipId>& device_ids);

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -387,17 +387,27 @@ std::map<ChipId, IDevice*> CreateDevices(
         init_profiler,
         initialize_fabric_and_dispatch_fw);
 
-    const auto devices = MetalContext::instance().device_manager()->get_all_active_devices();
-    std::map<ChipId, IDevice*> ret_devices;
-    // Only include the mmio device in the active devices set returned to the caller if we are not running
-    // on a Galaxy cluster.
-    // On Galaxy, gateway (mmio devices) cannot run compute workloads.
+    auto& dm = MetalContext::instance().device_manager();
+    const auto& newly_activated = dm->get_newly_activated_devices();
 
-    for (IDevice* dev : devices) {
-        if (is_galaxy and dev->is_mmio_capable()) {
-            continue;
+    std::map<ChipId, IDevice*> ret_devices;
+    if (!newly_activated.empty()) {
+        // Incremental init: return only the newly activated devices so that
+        // each ScopedDevices owns exactly the devices it opened.
+        for (auto* dev : newly_activated) {
+            if (is_galaxy and dev->is_mmio_capable()) {
+                continue;
+            }
+            ret_devices.insert({dev->id(), dev});
         }
-        ret_devices.insert({dev->id(), dev});
+    } else {
+        // Fresh init: return all active devices (may include fabric-expanded set).
+        for (IDevice* dev : dm->get_all_active_devices()) {
+            if (is_galaxy and dev->is_mmio_capable()) {
+                continue;
+            }
+            ret_devices.insert({dev->id(), dev});
+        }
     }
 
     return ret_devices;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/21500

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=nhuang/incremental-inits)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:nhuang/incremental-inits)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nhuang/incremental-inits)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nhuang/incremental-inits)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nhuang/incremental-inits)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nhuang/incremental-inits)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nhuang/incremental-inits)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nhuang/incremental-inits)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nhuang/incremental-inits)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nhuang/incremental-inits)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nhuang/incremental-inits)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nhuang/incremental-inits)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
