### PR TITLE
DRAM Prefetcher Integration PR into TTT Part 2

### DIFF
--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -851,9 +851,8 @@ def test_demo_text(
     num_layers = request.config.getoption("--num_layers") or num_layers
     mode = request.config.getoption("--mode") or mode
     use_prefetcher = request.config.getoption("--use_prefetcher") or use_prefetcher
-    use_prefetcher = (
-        use_prefetcher and is_prefetcher_supported(hf_dir, num_devices) and "Llama" in hf_dir and "8B" in hf_dir
-    )
+    use_prefetcher = use_prefetcher and is_prefetcher_supported(hf_dir, num_devices)
+
     global_batch_size = batch_size * data_parallel  # input batch_size is interpreted as size per DP group
     use_hf_rope = request.config.getoption("--use_hf_rope")
 

--- a/models/tt_transformers/tests/test_attention.py
+++ b/models/tt_transformers/tests/test_attention.py
@@ -21,7 +21,7 @@ from models.tt_transformers.tt.rope import HfRotarySetup, RotarySetup
 @torch.no_grad()
 @pytest.mark.parametrize(
     "use_prefetcher",
-    ([False]),
+    ([True]),
 )
 @pytest.mark.parametrize(
     "mesh_device",
@@ -160,9 +160,6 @@ def test_attention_inference(
 
     if prefetcher is not None and mode == Mode.DECODE:
         prefetcher.prefetch()
-        # Prefetcher global CB size must be set to the max tensor block size amongst all 5 matmul weights
-        # 700 is an arbitrary value that is sufficient and avoids memory clobberring
-        prefetcher.max_tensor_block_size = 700 * 1088
 
     cos, sin = precompute_freqs(
         model_args.head_dim,

--- a/models/tt_transformers/tests/test_decoder.py
+++ b/models/tt_transformers/tests/test_decoder.py
@@ -21,7 +21,7 @@ from models.tt_transformers.tt.rope import HfRotarySetup, RotarySetup
 @torch.no_grad()
 @pytest.mark.parametrize(
     "use_prefetcher",
-    ([False]),
+    ([True]),
 )
 @pytest.mark.parametrize(
     "mesh_device",
@@ -207,7 +207,6 @@ def test_decoder_inference(
             * 2
         ) - 1
         tt_decode_input = pt_decode_input.clone()
-
         decode_input = model_args.prepare_residual_tensor_decode(
             tt_decode_input,
             model_args.get_residual_mem_config(mode, prefetcher),

--- a/models/tt_transformers/tests/test_mlp.py
+++ b/models/tt_transformers/tests/test_mlp.py
@@ -21,7 +21,7 @@ from models.tt_transformers.tt.prefetcher import Prefetcher
 @torch.no_grad()
 @pytest.mark.parametrize(
     "use_prefetcher",
-    ([False]),
+    ([True]),
 )
 @pytest.mark.parametrize(
     "mesh_device",
@@ -117,8 +117,7 @@ def test_mlp_inference(seq_len, batch_size, mesh_device, reset_seeds, ensure_gc,
         tt_output,
         mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(1, 3), mesh_shape=model_args.cluster_shape),
     )
-
-    tt_output_torch = tt_output_torch[:, :1, :, :]
+    tt_output_torch = tt_output_torch[:, :1, :, : reference_output.shape[3]]
 
     pcc_required = 0.99
     passing, pcc_message = comp_pcc(reference_output, tt_output_torch, pcc_required)

--- a/models/tt_transformers/tt/attention.py
+++ b/models/tt_transformers/tt/attention.py
@@ -11,7 +11,8 @@ from models.common.lightweightmodule import LightweightModule
 from models.common.rmsnorm import RMSNorm
 from models.common.utility_functions import nearest_32
 from models.tt_transformers.tt.ccl import tt_all_gather, tt_all_reduce
-from models.tt_transformers.tt.common import Mode
+from models.tt_transformers.tt.common import Mode, pad_to_size
+from models.tt_transformers.tt.mlp import ModeWeight
 from models.tt_transformers.tt.model_config import OpGroup, TensorGroup, num_to_corerange
 
 
@@ -237,28 +238,32 @@ class Attention(LightweightModule):
         assert configuration.qkv_size % self.num_devices_per_group == 0
         assert configuration.dim % self.num_devices_per_group == 0
 
-        # wqkv: 4096 x 3072 (2 devices): width-sharded on 12 banks, 3072 over 12 banks.
+        use_pf = prefetcher is not None
+        ring = prefetcher.ring_size if use_pf else 1
+        pad = lambda x: args._pad_total_width(x, ring) if use_pf else x
+        ring_str = f".ring_{ring}" if use_pf else ""
+
+        # QKV: [dim, qkv_size] -> N-sharded on qkv_size
+        # NOTE: QKV output must NOT be padded - it needs exact head structure for nlp_create_qkv_heads
+        qkv_n_per_device = configuration.qkv_size // configuration.num_devices
         wqkv_mem_config = configuration.create_dram_sharded_mem_config(
-            configuration.dim, configuration.qkv_size // configuration.num_devices
+            configuration.dim, qkv_n_per_device, prefetcher=prefetcher
         )
 
         qkv_list = []
         for i in range(self.num_devices_per_group):
-            # Chunk weights
-            wq_selected = torch.chunk(state_dict[f"{wq_str}.weight"], self.num_devices_per_group, dim=0)[i]
-            wk_selected = torch.chunk(state_dict[f"{wk_str}.weight"], self.num_devices_per_group, dim=0)[i]
-            wv_selected = torch.chunk(state_dict[f"{wv_str}.weight"], self.num_devices_per_group, dim=0)[i]
-
-            # Transpose the selected chunks
-            wq = torch.transpose(wq_selected, -2, -1)
-            wk = torch.transpose(wk_selected, -2, -1)
-            wv = torch.transpose(wv_selected, -2, -1)
-
-            qkv = torch.cat([wq, wk, wv], dim=-1)
-            qkv_list.append(qkv)
+            wq = torch.transpose(
+                torch.chunk(state_dict[f"{wq_str}.weight"], self.num_devices_per_group, dim=0)[i], -2, -1
+            )
+            wk = torch.transpose(
+                torch.chunk(state_dict[f"{wk_str}.weight"], self.num_devices_per_group, dim=0)[i], -2, -1
+            )
+            wv = torch.transpose(
+                torch.chunk(state_dict[f"{wv_str}.weight"], self.num_devices_per_group, dim=0)[i], -2, -1
+            )
+            qkv_list.append(torch.cat([wq, wk, wv], dim=-1))
 
         qkv_cat = torch.cat(qkv_list, dim=-1).unsqueeze(0).unsqueeze(0)
-
         self.wqkv = ttnn.as_tensor(
             qkv_cat,
             dtype=self.wqkv_dtype,
@@ -268,11 +273,10 @@ class Attention(LightweightModule):
             mesh_mapper=ttnn.ShardTensor2dMesh(
                 self.mesh_device, dims=(3, 2) if self.TG else (2, 3), mesh_shape=configuration.cluster_shape
             ),
-            cache_file_name=cache_name("wqkv_sharded_2d"),
+            cache_file_name=cache_name(f"wqkv_sharded_2d{ring_str}"),
         )
 
         def norm_reshard(x, norm, mode, norm_config):
-            """Hack until RMSNorm supports height-sharded output config"""
             if mode == Mode.DECODE:
                 mem_cfg = x.memory_config()
                 x = ttnn.to_memory_config(x, ttnn.L1_MEMORY_CONFIG, dtype=x.dtype)
@@ -287,7 +291,7 @@ class Attention(LightweightModule):
                 dim=self.head_dim,
                 eps=configuration.norm_eps,
                 state_dict=state_dict,
-                state_dict_prefix=None,  # we already prefix q_norm_str
+                state_dict_prefix=None,
                 weight_cache_path=None if configuration.dummy_weights else weight_cache_path,
                 weight_dtype=ttnn.bfloat16,
                 weight_key=q_norm_str,
@@ -305,7 +309,7 @@ class Attention(LightweightModule):
                 dim=self.head_dim,
                 eps=configuration.norm_eps,
                 state_dict=state_dict,
-                state_dict_prefix=None,  # we already prefix k_norm_str
+                state_dict_prefix=None,
                 weight_cache_path=None if configuration.dummy_weights else weight_cache_path,
                 weight_dtype=ttnn.bfloat16,
                 weight_key=k_norm_str,
@@ -317,67 +321,57 @@ class Attention(LightweightModule):
         else:
             self.k_norm = lambda x, mode, norm_config: x
 
-        # For ring topology we can use all gather matmul for wo
+        # WO: [n_heads*head_dim, dim] -> K-sharded on n_heads*head_dim, pad N (output dim)
         self.use_fused_all_gather_matmul = self.args.use_fused_all_gather_matmul
-        pt_wo = state_dict[f"{wo_str}.weight"].transpose(-1, -2).unsqueeze(0).unsqueeze(0)
-
-        wo_mem_config = configuration.create_dram_sharded_mem_config(
-            (configuration.n_heads * configuration.head_dim) // configuration.num_devices, configuration.dim
+        pt_wo_raw = state_dict[f"{wo_str}.weight"].transpose(-1, -2)
+        self.shard_wo_dims = (2, 3) if (self.use_fused_all_gather_matmul or self.TG) else (3, 2)
+        wo_mapper = ttnn.ShardTensor2dMesh(
+            self.mesh_device, dims=self.shard_wo_dims, mesh_shape=configuration.cluster_shape
         )
 
-        self.shard_wo_dims = (2, 3) if (self.use_fused_all_gather_matmul or self.TG) else (3, 2)
-
-        if self.prefetcher is not None:
-            self.wo_sharded_ring = ttnn.as_tensor(
-                pt_wo,
+        def wo_to_ttnn(w, mem, cache):
+            return ttnn.as_tensor(
+                w.unsqueeze(0).unsqueeze(0),
                 dtype=self.wo_dtype,
                 layout=ttnn.TILE_LAYOUT,
                 device=self.mesh_device,
-                memory_config=self.args.get_sharded_wo_ring_mem_config(),
-                mesh_mapper=ttnn.ShardTensor2dMesh(
-                    self.mesh_device,
-                    dims=self.shard_wo_dims,
-                    mesh_shape=configuration.cluster_shape,
-                ),
-                cache_file_name=(cache_name("wo_sharded_ring")),
+                memory_config=mem,
+                mesh_mapper=wo_mapper,
+                cache_file_name=cache_name(cache),
             )
 
-        def get_wo_memory_config():
-            if self.use_fused_all_gather_matmul or self.TG:
-                return ttnn.DRAM_MEMORY_CONFIG
-            else:
-                return wo_mem_config
+        # Decode: ring-padded + DRAM-sharded when prefetcher, else standard layout
+        if use_pf:
+            wo_dec_data = pad_to_size(pt_wo_raw, dim=-1, size=pad(configuration.dim))
+            wo_dec_mem = self.args.get_sharded_wo_ring_mem_config(prefetcher=prefetcher)
+            wo_dec_cache = f"wo_sharded_ring{ring_str}"
+        else:
+            wo_dec_data = pt_wo_raw
+            wo_k_per_dev = (configuration.n_heads * configuration.head_dim) // configuration.num_devices
+            wo_mem_cfg = configuration.create_dram_sharded_mem_config(wo_k_per_dev, configuration.dim)
+            wo_dec_mem = ttnn.DRAM_MEMORY_CONFIG if (self.use_fused_all_gather_matmul or self.TG) else wo_mem_cfg
+            wo_dec_cache = "wo_width_sharded_2d" if (self.use_fused_all_gather_matmul or self.TG) else "wo"
 
-        self.wo = ttnn.as_tensor(
-            pt_wo,
-            dtype=self.wo_dtype,
-            layout=ttnn.TILE_LAYOUT,
-            device=self.mesh_device,
-            memory_config=get_wo_memory_config(),
-            mesh_mapper=ttnn.ShardTensor2dMesh(
-                self.mesh_device,
-                dims=self.shard_wo_dims,
-                mesh_shape=configuration.cluster_shape,
-            ),
-            cache_file_name=(
-                cache_name("wo_width_sharded_2d") if (self.use_fused_all_gather_matmul or self.TG) else cache_name("wo")
-            ),
+        # Prefill: unpadded, DRAM interleaved
+        self.wo = ModeWeight(
+            wo_to_ttnn(wo_dec_data, wo_dec_mem, wo_dec_cache),
+            wo_to_ttnn(pt_wo_raw, ttnn.DRAM_MEMORY_CONFIG, "wo.prefill"),
         )
+
         if not use_paged_kv_cache:
-            # vLLM provides its own kv cache
             self.init_kv_cache(configuration, weight_cache_path)
 
-        if configuration.query_pre_attn_scalar is not None:
-            self.scale = configuration.query_pre_attn_scalar**-0.5
-        else:
-            self.scale = self.head_dim**-0.5
+        self.scale = (
+            configuration.query_pre_attn_scalar**-0.5
+            if configuration.query_pre_attn_scalar
+            else self.head_dim**-0.5
+        )
 
-        # Insert the tensors into the prefetcher only in decode mode, we do not use prefetcher in prefill mode
-        if self.prefetcher is not None:
+        if use_pf:
 
             def register_weights():
                 self.prefetcher.insert_tensor(self.wqkv)
-                self.prefetcher.insert_tensor(self.wo_sharded_ring)
+                self.prefetcher.insert_tensor(self.wo.decode)
 
             self.prefetcher.register_callback(register_weights)
 
@@ -661,6 +655,13 @@ class Attention(LightweightModule):
             xqkv_fused, (1, 1, self.batch_size_per_device_group, fqkv_shape[3]), (1, 1, 32, fqkv_shape[3])
         )
 
+        # Reshard to compatible grid for nlp_create_qkv_heads_decode when using prefetcher
+        if self.prefetcher is not None:
+            xqkv_fused = ttnn.to_memory_config(
+                xqkv_fused,
+                self.args.get_attn_create_head_input_mem_config(Mode.DECODE, self.prefetcher),
+            )
+
         ###
         # Reshape and rotary embeddings
         ###
@@ -686,6 +687,7 @@ class Attention(LightweightModule):
 
         ttnn.deallocate(q_heads_pre_rot_1BQD)
         ttnn.deallocate(k_heads_pre_rot_1BKD)
+
         ###
         # KV update
         ###
@@ -743,7 +745,6 @@ class Attention(LightweightModule):
                 compute_kernel_config=self.sdpa_decode_compute_kernel_cfg,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,  # FIXME: why not L1 height sharded e.g. SCORES_BATCHED_MM_OUTPUT_MEMCFG?
             )
-
         ttnn.deallocate(q_heads_1BQD)
         attn_output_11BH = ttnn.to_memory_config(
             attn_output_1G4D,
@@ -757,6 +758,7 @@ class Attention(LightweightModule):
             num_heads=self.n_local_heads,
             sub_core_grids=self.prefetcher.all_worker_cores_range_set if self.prefetcher is not None else None,
         )
+
         ttnn.deallocate(attn_output_11BH)
         ttnn.deallocate(attn_output_1G4D)
 
@@ -770,7 +772,7 @@ class Attention(LightweightModule):
             if self.ccl_topology == ttnn.Topology.Ring and self.prefetcher is None:
                 _, dense_out_sharded = ttnn.experimental.all_gather_matmul_async(
                     attn_output_cat,
-                    self.wo,
+                    self.wo(Mode.DECODE),
                     persistent_output_buffer=None,
                     dim=3,
                     multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(),
@@ -803,7 +805,7 @@ class Attention(LightweightModule):
                 )
                 dense_out_sharded = ttnn.linear(
                     all_gather_output,
-                    self.wo_sharded_ring if self.prefetcher is not None else self.wo,
+                    self.wo(Mode.DECODE),
                     memory_config=self.args.get_attn_dense_output_mem_config(Mode.DECODE, self.prefetcher),
                     program_config=self.args.get_attn_all_gather_matmul_program_config(Mode.DECODE, self.prefetcher),
                     compute_kernel_config=self.li_o_decode_compute_kernel_cfg,
@@ -812,11 +814,8 @@ class Attention(LightweightModule):
                 )
                 ttnn.deallocate(all_gather_output)
             ttnn.deallocate(attn_output_cat)
-            dense_out_sharded = ttnn.to_memory_config(
-                dense_out_sharded,
-                self.args.get_attn_dense_output_mem_config(Mode.DECODE, self.prefetcher),
-            )
-            return dense_out_sharded
+
+            return self.args.unpad_to_residual(dense_out_sharded, Mode.DECODE, self.prefetcher)
 
         else:
             attn_output = tt_all_gather(
@@ -847,7 +846,7 @@ class Attention(LightweightModule):
             # TODO: Fix this once self.TG supports dram-sharded matmuls
             dense_out_sharded = ttnn.linear(
                 attn_output,
-                self.wo,
+                self.wo(Mode.DECODE),
                 core_grid=ttnn.CoreGrid(y=4, x=8) if self.TG else None,
                 program_config=self.args.get_attn_wo_program_config(Mode.DECODE, 1, self.prefetcher),
                 memory_config=self.args.get_attn_wo_output_mem_config(Mode.DECODE, self.prefetcher),
@@ -1151,7 +1150,7 @@ class Attention(LightweightModule):
 
         output_11SH = ttnn.linear(
             attn_output_11SH,
-            self.wo,
+            self.wo(Mode.PREFILL),
             compute_kernel_config=self.li_o_prefill_compute_kernel_cfg,
             dtype=self.activation_dtype or ttnn.bfloat8_b,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,

--- a/models/tt_transformers/tt/decoder.py
+++ b/models/tt_transformers/tt/decoder.py
@@ -207,7 +207,7 @@ class TransformerBlock(LightweightModule):
         rot_mats_global=None,
         rot_mats_local=None,
         user_id=0,
-        mode="decode",
+        mode=Mode.DECODE,
         page_table=None,
         chunk_page_table=None,
         chunk_start_idx=None,
@@ -262,7 +262,7 @@ class TransformerBlock(LightweightModule):
                 residual, attn_out, memory_config=skip_mem_cfg, dtype=ttnn.bfloat16 if TG else None
             )
             residual = hidden_states
-            if mode == "prefill":
+            if mode == Mode.PREFILL:
                 x.deallocate(True)
         else:
             hidden_states = attn_out
@@ -289,7 +289,7 @@ class TransformerBlock(LightweightModule):
 
         ttnn.deallocate(attn_out)
 
-        if TG and mode == "decode":
+        if TG and mode == Mode.DECODE:
             hidden_states = ttnn.to_memory_config(hidden_states, memory_config=self.args.get_mlp_act_mem_config(mode))
         # MLP takes replicated inputs and produces fractured outputs
 
@@ -310,6 +310,7 @@ class TransformerBlock(LightweightModule):
                     cluster_axis=1,
                 )
 
+        hidden_states = self.args.unpad_to_residual(hidden_states, mode, self.prefetcher)
         out = ttnn.add(
             residual,
             hidden_states,

--- a/models/tt_transformers/tt/distributed_norm.py
+++ b/models/tt_transformers/tt/distributed_norm.py
@@ -55,7 +55,6 @@ class DistributedNorm(LightweightModule):
         """Apply a norm, possibly gathering inputs if required."""
 
         sharded_output_config = norm_config.get("sharded_output_config") if norm_config else None
-
         if self.TG:
             if mode == Mode.DECODE:
                 return tt_sharded_distributed_rmsnorm(

--- a/models/tt_transformers/tt/lm_head.py
+++ b/models/tt_transformers/tt/lm_head.py
@@ -144,7 +144,7 @@ class LMHead(LightweightModule):
             packer_l1_acc=True,
         )
 
-    def forward(self, x: ttnn.Tensor, debug_input_torch=None, debug_weight_torch=None):
+    def forward(self, x: ttnn.Tensor):
         outputs = []
         use_prefetcher = self.prefetcher is not None and self.prefetcher.mode == Mode.DECODE
         split_sizes = self.split_sizes_ring_mm if use_prefetcher else self.split_sizes_dram_sharded

--- a/models/tt_transformers/tt/mlp.py
+++ b/models/tt_transformers/tt/mlp.py
@@ -11,6 +11,17 @@ from models.tt_transformers.tt.common import Mode, pad_to_size
 from models.tt_transformers.tt.model_config import OpGroup, TensorGroup
 
 
+class ModeWeight:
+    """Weight tensor accessor that returns decode (ring-padded) or prefill (unpadded) versions."""
+
+    def __init__(self, decode, prefill=None):
+        self.decode = decode
+        self.prefill = prefill if prefill is not None else decode
+
+    def __call__(self, mode):
+        return self.decode if mode == Mode.DECODE else self.prefill
+
+
 class MLP(LightweightModule):
     def __init__(
         self,
@@ -38,80 +49,83 @@ class MLP(LightweightModule):
         self.prefetcher = prefetcher
 
         state_dict_prefix = state_dict_prefix or args.get_state_dict_prefix(self.__class__.__name__, layer_num)
-        torch_weight = lambda name: torch.transpose(state_dict[f"{state_dict_prefix}.{name}.weight"], -2, -1)
-        pad_hidden_dim = lambda tensor, dim: pad_to_size(tensor, dim=dim, size=args.hidden_dim)
-        # If padding was applied (e.g. via env var), add the unpadded hidden dim to the cache name to avoid loading incorrect weights
-        hidden_dim_string = f".hidden_dim_{args.hidden_dim}" if args.hidden_dim != args.unpadded_hidden_dim else ""
-
-        if args.dummy_weights:
-            cache_name = lambda _: None
-        else:
-            cache_name = lambda name: weight_cache_path / f"{state_dict_prefix}.{name}{hidden_dim_string}"
-
-        w1_w3_mem_config = args.create_dram_sharded_mem_config(args.dim, args.hidden_dim // args.num_devices)
-        w2_mem_config = args.create_dram_sharded_mem_config(args.hidden_dim // args.num_devices, args.dim)
-
-        # TODO Clean up this code. With sharding, we load the normal weights and then shard them
-        # Note: unsqueeze(0).unsqueeze(0) makes weights 4D [1, 1, H, W] to match attention weights
-        # This is required for the dram_prefetcher to correctly interpret all weights
-        def as_sharded_tensor(name, type, dims):
-            # First get the raw weight and transpose it
-            raw_weight = torch_weight(name[:2])  # This is 2D: [H, W]
-            # Pad if needed
-            padded_weight = pad_hidden_dim(raw_weight, dims[0] if args.is_galaxy else dims[-1])
-            # Make 4D: [1, 1, H, W] - CRITICAL for prefetcher to work correctly
-            torch_tensor = padded_weight.unsqueeze(0).unsqueeze(0)
-
-            result = ttnn.as_tensor(
-                torch_tensor,
-                dtype=type,
-                device=self.mesh_device,
-                mesh_mapper=ttnn.ShardTensor2dMesh(self.mesh_device, dims=dims, mesh_shape=args.cluster_shape),
-                layout=ttnn.TILE_LAYOUT,
-                memory_config=(
-                    ttnn.DRAM_MEMORY_CONFIG if args.is_galaxy else w2_mem_config if "w2" in name else w1_w3_mem_config
-                ),
-                cache_file_name=cache_name(name),
-            )
-            return result
-
-        # Sharded weights
-        w1_dims = (-1, -2) if args.is_galaxy else (-2, -1)
-        w2_dims = (-2, -1) if args.is_galaxy else (-1, -2)
-
-        layer_num = max(layer_num, 0)  # cross_block uses the configuration of the first decoder
-
-        # When prefetcher is enabled, use consistent dtypes across all layers to avoid
-        # race conditions caused by different block sizes
-        use_prefetcher = prefetcher is not None
-
+        layer_num = max(layer_num, 0)
         self.decoders_optimizations = self.args.decoders_optimizations
+        use_pf = prefetcher is not None
 
-        ff1_3_dtype = self.decoders_optimizations.get_tensor_dtype(
-            decoder_id=layer_num, tensor=TensorGroup.FF1_FF3, prefetcher=use_prefetcher
+        # Ring padding sizes for prefetcher
+        ring = prefetcher.ring_size if use_pf else 1
+        pad_ring = lambda x: args._pad_total_width(x // args.num_devices, ring) * args.num_devices
+        ff1_3_n_pad = pad_ring(args.hidden_dim) if use_pf else None
+        ff2_k_pad = ff1_3_n_pad
+        ff2_n_pad = args._pad_total_width(args.dim, ring) if use_pf else None
+
+        w1_dims, w2_dims = ((-1, -2), (-2, -1)) if args.is_galaxy else ((-2, -1), (-1, -2))
+        ff1_3_dtype = self.decoders_optimizations.get_tensor_dtype(layer_num, TensorGroup.FF1_FF3, use_pf)
+        ff2_dtype = self.decoders_optimizations.get_tensor_dtype(layer_num, TensorGroup.FF2, use_pf)
+
+        # Cache naming
+        hdim_str = f".hidden_dim_{args.hidden_dim}" if args.hidden_dim != args.unpadded_hidden_dim else ""
+        ring_str = f".ring_{ring}" if use_pf else ""
+
+        def cache_name(name, suffix=""):
+            if args.dummy_weights:
+                return None
+            return weight_cache_path / f"{state_dict_prefix}.{name}_sharded{hdim_str}{suffix}"
+
+        # Decode memory configs (DRAM-sharded for matmul)
+        ff1_3_mem = args.create_dram_sharded_mem_config(
+            args.dim, args.hidden_dim // args.num_devices, prefetcher=prefetcher
         )
-        ff2_dtype = self.decoders_optimizations.get_tensor_dtype(
-            decoder_id=layer_num, tensor=TensorGroup.FF2, prefetcher=use_prefetcher
-        )
+        ff2_k_per_dev = (ff1_3_n_pad or args.hidden_dim) // args.num_devices
+        ff2_mem = args.create_dram_sharded_mem_config(ff2_k_per_dev, args.dim, prefetcher=prefetcher)
 
-        self.w1 = as_sharded_tensor(
-            "w1_sharded", ff1_3_dtype, dims=w1_dims
-        )  # bfp4 normally ok here but sub .99 pcc for llama 3.1 weights
-        self.w2 = as_sharded_tensor("w2_sharded", ff2_dtype, dims=w2_dims)
-        self.w3 = as_sharded_tensor("w3_sharded", ff1_3_dtype, dims=w1_dims)
+        def to_ttnn(w, dims, dtype, mem, cache):
+            return ttnn.as_tensor(
+                w.unsqueeze(0).unsqueeze(0),
+                dtype=dtype,
+                device=self.mesh_device,
+                layout=ttnn.TILE_LAYOUT,
+                mesh_mapper=ttnn.ShardTensor2dMesh(self.mesh_device, dims=dims, mesh_shape=args.cluster_shape),
+                memory_config=mem,
+                cache_file_name=cache,
+            )
 
-        # Default activation is SILU
+        def load_weight(name, dims, dtype, k_pad=None, n_pad=None):
+            w = torch.transpose(state_dict[f"{state_dict_prefix}.{name}.weight"], -2, -1)
+            hdim_dim = dims[0] if args.is_galaxy else dims[-1]
+            # Decode version: ring-padded for prefetcher, or standard DRAM-sharded
+            if use_pf:
+                w_dec = w
+                if k_pad:
+                    w_dec = pad_to_size(w_dec, dim=-2, size=k_pad)
+                if n_pad:
+                    w_dec = pad_to_size(w_dec, dim=-1, size=n_pad)
+                dec_mem = ff2_mem if name == "w2" else ff1_3_mem
+            else:
+                w_dec = pad_to_size(w, dim=hdim_dim, size=args.hidden_dim)
+                dec_mem = ttnn.DRAM_MEMORY_CONFIG if args.is_galaxy else (ff2_mem if name == "w2" else ff1_3_mem)
+            decode = to_ttnn(w_dec, dims, dtype, dec_mem, cache_name(name, ring_str))
+            # Prefill version: standard padding, DRAM interleaved
+            w_pf = pad_to_size(w, dim=hdim_dim, size=args.hidden_dim)
+            prefill = to_ttnn(w_pf, dims, dtype, ttnn.DRAM_MEMORY_CONFIG, cache_name(name, ".prefill"))
+
+            return ModeWeight(decode, prefill)
+
+        self.w1 = load_weight("w1", w1_dims, ff1_3_dtype, n_pad=ff1_3_n_pad)
+        self.w3 = load_weight("w3", w1_dims, ff1_3_dtype, n_pad=ff1_3_n_pad)
+        self.w2 = load_weight("w2", w2_dims, ff2_dtype, k_pad=ff2_k_pad, n_pad=ff2_n_pad)
+
         self.activation_type = (
             args.mlp_activation_type if hasattr(args, "mlp_activation_type") else ttnn.UnaryOpType.SILU
         )
 
-        # Insert the tensors into the prefetcher if it is used
         if self.prefetcher is not None:
 
             def register_weights():
-                self.prefetcher.insert_tensor(self.w1)
-                self.prefetcher.insert_tensor(self.w3)
-                self.prefetcher.insert_tensor(self.w2)
+                self.prefetcher.insert_tensor(self.w1.decode)
+                self.prefetcher.insert_tensor(self.w3.decode)
+                self.prefetcher.insert_tensor(self.w2.decode)
 
             self.prefetcher.register_callback(register_weights)
 
@@ -141,10 +155,9 @@ class MLP(LightweightModule):
         pc_1 = self.args.get_mlp_ff1_3_prg_config(mode, seq_len, self.prefetcher)
         pc_2 = self.args.get_mlp_ff2_prg_config(mode, seq_len, self.prefetcher)
         pc_3 = self.args.get_mlp_ff1_3_prg_config(mode, seq_len, self.prefetcher)
-
         w1_out = ttnn.linear(
             x,
-            self.w1,
+            self.w1(mode),
             dtype=ttnn.bfloat8_b if TG else activation_dtype or ttnn.bfloat16,
             core_grid=None,  # FIXME: validate on TG ttnn.CoreGrid(y=8, x=8) if not pc_1 else None,
             compute_kernel_config=li_ff1_3_compute_kernel_cfg,
@@ -155,9 +168,10 @@ class MLP(LightweightModule):
             if self.prefetcher is not None and mode == Mode.DECODE
             else None,
         )
+
         w3_out = ttnn.linear(
             x,
-            self.w3,
+            self.w3(mode),
             dtype=ttnn.bfloat8_b if TG else activation_dtype or ttnn.bfloat16,
             core_grid=None,  # FIXME: validate on TG ttnn.CoreGrid(y=8, x=8) if not pc_3 else None,
             compute_kernel_config=li_ff1_3_compute_kernel_cfg,
@@ -274,7 +288,7 @@ class MLP(LightweightModule):
 
         w2_out = ttnn.linear(
             w2_in,
-            self.w2,
+            self.w2(mode),
             compute_kernel_config=li_ff2_compute_kernel_cfg,
             dtype=self.args.ccl_dtype if TG else activation_dtype or ttnn.bfloat16,
             program_config=pc_2,
@@ -286,7 +300,6 @@ class MLP(LightweightModule):
             else None,
         )
         ttnn.deallocate(w2_in)
-
         w2_out_reduced = tt_all_reduce(
             w2_out,
             self.mesh_device,
@@ -310,6 +323,7 @@ class MLP(LightweightModule):
             else None,
         )
         # Ensure dim 0 and 1 are 1
+
         original_shape = w2_out_reduced.shape
         w2_out_reduced = ttnn.reshape(
             w2_out_reduced, (1, 1, original_shape[-4] * original_shape[-3] * original_shape[-2], original_shape[-1])

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -1088,6 +1088,18 @@ class ModelArgs:
         return to_warmup_seq_lens
 
     # =========================================================================
+    # PREFETCHER PADDING HELPERS
+    # =========================================================================
+    def _pad_shard_width(self, size: int, ring_size: int) -> int:
+        """Pad shard width to be tile-aligned: nearest_32(ceil(size / ring_size))."""
+        return nearest_32(math.ceil(size / ring_size))
+
+    def _pad_total_width(self, size: int, ring_size: int) -> int:
+        """Pad total width to be divisible by ring_size * TILE_SIZE."""
+        per_core = nearest_32(math.ceil(size / ring_size))
+        return per_core * ring_size
+
+    # =========================================================================
     # RESIDUAL MEMORY CONFIGS
     # =========================================================================
     @lru_cache(maxsize=None)
@@ -1095,7 +1107,16 @@ class ModelArgs:
         """Get the memory config for decode residual tensors."""
         if mode == Mode.DECODE:
             if prefetcher is not None:
-                num_residual_worker_cores = 32 if self.num_devices == 4 else 16
+                # Choose num_cores so that per-device shard width is tile-aligned (multiple of 32)
+                dim_per_device = self.dim // self.cluster_shape[1]
+                num_residual_worker_cores = None
+                for n in range(40, 0, -8):
+                    if dim_per_device % n == 0 and (dim_per_device // n) % self.tile_size == 0:
+                        num_residual_worker_cores = n
+                        break
+                assert (
+                    num_residual_worker_cores is not None
+                ), f"Cannot find tile-aligned core count for dim_per_device={dim_per_device}"
                 return ttnn.create_sharded_memory_config(
                     shape=(
                         32,
@@ -1127,6 +1148,25 @@ class ModelArgs:
         else:
             raise ValueError(f"Invalid mode: {mode}")
 
+    def unpad_to_residual(self, tensor, mode: Mode, prefetcher: Prefetcher = None):
+        """Strip ring-matmul width padding and reshard to residual config.
+
+        When the prefetcher pads the matmul output wider than dim_per_device,
+        move to DRAM, slice off the padding, then reshard to the residual grid.
+        No-op when the tensor already matches the residual width.
+        """
+        residual_width = self.dim // self.cluster_shape[1]
+        if prefetcher is not None and tensor.shape[-1] > residual_width:
+            tensor = ttnn.to_memory_config(tensor, ttnn.DRAM_MEMORY_CONFIG)
+            tensor = ttnn.slice(
+                tensor,
+                (0, 0, 0, 0),
+                (1, 1, tensor.shape[2], residual_width),
+                sub_core_grids=prefetcher.dynamic_worker_core_grid(8),
+            )
+        tensor = ttnn.to_memory_config(tensor, self.get_residual_mem_config(mode, prefetcher))
+        return tensor
+
     # =========================================================================
     # MLP PROGRAM AND MEMORY CONFIGS
     # =========================================================================
@@ -1138,7 +1178,7 @@ class ModelArgs:
                 return self.get_mlp_act_mem_config("decode")
             elif prefetcher is not None:
                 return ttnn.create_sharded_memory_config(
-                    shape=(32, self.dim // prefetcher.ring_size),
+                    shape=(32, self._pad_shard_width(self.dim, prefetcher.ring_size)),
                     core_grid=prefetcher.to_core_range_set(
                         prefetcher.receiver_cores(sender_active=True, receiver_active=True)
                     ),
@@ -1182,11 +1222,12 @@ class ModelArgs:
                 )
             else:
                 if prefetcher is not None:
+                    n_per_device = self.hidden_dim // self.cluster_shape[1]
                     return self.matmul_1d_ring_config(
                         1,
                         32,
                         self.dim,
-                        self.hidden_dim // self.cluster_shape[1],  # Use padded N
+                        self._pad_total_width(n_per_device, prefetcher.ring_size),
                         prefetcher.ring_size,
                         num_global_cb_receivers=prefetcher.num_receiver_cores,
                     )
@@ -1233,11 +1274,13 @@ class ModelArgs:
                 )
             else:
                 if prefetcher is not None:
+                    # K must match FF1/FF3 output N (padded hidden_dim per device)
+                    k_padded = self._pad_total_width(self.hidden_dim // self.cluster_shape[1], prefetcher.ring_size)
                     return self.matmul_1d_ring_config(
                         1,
                         32,
-                        self.hidden_dim // self.cluster_shape[1],
-                        self.dim,  # Use padded N
+                        k_padded,
+                        self._pad_total_width(self.dim, prefetcher.ring_size),
                         prefetcher.ring_size,
                         num_global_cb_receivers=prefetcher.num_receiver_cores,
                     )
@@ -1265,8 +1308,9 @@ class ModelArgs:
     def get_mlp_ff1_3_mem_config(self, mode: Mode, prefetcher: Prefetcher = None):
         if mode == Mode.DECODE:
             if prefetcher is not None:
+                n_per_device = self.hidden_dim // self.cluster_shape[1]
                 return ttnn.create_sharded_memory_config(
-                    shape=(32, self.hidden_dim // self.cluster_shape[1] // prefetcher.ring_size),  # Use padded N
+                    shape=(32, self._pad_shard_width(n_per_device, prefetcher.ring_size)),
                     core_grid=prefetcher.to_core_range_set(
                         prefetcher.receiver_cores(sender_active=True, receiver_active=True)
                     ),
@@ -1286,7 +1330,7 @@ class ModelArgs:
         if mode == Mode.DECODE:
             if prefetcher is not None:
                 return ttnn.create_sharded_memory_config(
-                    shape=(32, self.dim // prefetcher.ring_size),  # Use padded N
+                    shape=(32, self._pad_shard_width(self.dim, prefetcher.ring_size)),
                     core_grid=prefetcher.to_core_range_set(
                         prefetcher.receiver_cores(sender_active=True, receiver_active=True)
                     ),
@@ -1354,8 +1398,10 @@ class ModelArgs:
         if mode == Mode.DECODE:
             if prefetcher is not None:
                 num_mlp_output_cores = 32 if self.num_devices == 4 else 16
+                dim_per_device = self.dim // self.cluster_shape[1]
+                shard_width = nearest_32(math.ceil(dim_per_device / num_mlp_output_cores))
                 return ttnn.create_sharded_memory_config(
-                    shape=(1, 1, 32, self.dim // self.cluster_shape[1] // num_mlp_output_cores),
+                    shape=(1, 1, 32, shard_width),
                     core_grid=prefetcher.dynamic_worker_core_grid(num_mlp_output_cores),
                     strategy=ttnn.ShardStrategy.WIDTH,
                     use_height_and_width_as_shard_shape=True,
@@ -1449,7 +1495,7 @@ class ModelArgs:
             return ttnn.SDPAProgramConfig(
                 compute_with_storage_grid_size=sdpa_grid_size,
                 sub_core_grids=ttnn.num_cores_to_corerangeset_in_subcoregrids(
-                    start_core, num_sdpa_cores, prefetcher.all_worker_cores_range_set, row_wise=True
+                    start_core, num_sdpa_cores, prefetcher.dynamic_worker_core_grid(num_sdpa_cores), row_wise=True
                 ),
                 exp_approx_mode=False,
                 q_chunk_size=0,
@@ -1479,8 +1525,9 @@ class ModelArgs:
     def get_attn_input_mem_config(self, mode: Mode, prefetcher: Prefetcher = None):
         if mode == Mode.DECODE:
             if prefetcher is not None:
+                k_per_device = self.dim // self.cluster_shape[0]
                 return ttnn.create_sharded_memory_config(
-                    shape=(32, self.dim // self.cluster_shape[0] // prefetcher.ring_size),
+                    shape=(32, self._pad_shard_width(k_per_device, prefetcher.ring_size)),
                     core_grid=prefetcher.to_core_range_set(
                         prefetcher.receiver_cores(sender_active=True, receiver_active=True)
                     ),
@@ -1521,11 +1568,12 @@ class ModelArgs:
         """Get the program config for the QKV matmul in attention."""
         if mode == Mode.DECODE:
             if prefetcher is not None:
+                n_per_device = self.qkv_size // self.cluster_shape[1]
                 return self.matmul_1d_ring_config(
                     1,
                     32,
                     self.dim // self.cluster_shape[0],
-                    self.qkv_size // self.cluster_shape[1],  # Use padded N
+                    self._pad_total_width(n_per_device, prefetcher.ring_size),
                     prefetcher.ring_size,
                     num_global_cb_receivers=prefetcher.num_receiver_cores,
                     untilize_out=True,
@@ -1567,12 +1615,9 @@ class ModelArgs:
         """Get the memory config for QKV matmul output in attention."""
         if mode == Mode.DECODE:
             if prefetcher is not None:
-                qkv_out_shard_shape_ring = (
-                    32,
-                    self.qkv_size // self.cluster_shape[1] // prefetcher.ring_size,
-                )  # Use padded N
+                n_per_device = self.qkv_size // self.cluster_shape[1]
                 return ttnn.create_sharded_memory_config(
-                    shape=qkv_out_shard_shape_ring,
+                    shape=(32, self._pad_shard_width(n_per_device, prefetcher.ring_size)),
                     core_grid=prefetcher.to_core_range_set(
                         prefetcher.receiver_cores(sender_active=True, receiver_active=True)
                     ),
@@ -1617,9 +1662,36 @@ class ModelArgs:
             raise ValueError(f"Invalid mode: {mode}")
 
     @lru_cache(maxsize=None)
-    def get_attn_create_head_input_mem_config(self, mode: Mode):
+    def get_attn_create_head_input_mem_config(self, mode: Mode, prefetcher: Prefetcher = None):
         """Get the memory config for create_head input (TG specific)."""
         if mode == Mode.DECODE:
+            if prefetcher is not None:
+                # nlp_create_qkv_heads_decode requires input core count to evenly divide total QKV tiles
+                # Total QKV tiles = head_tiles * (n_local_heads + 2 * n_local_kv_heads)
+                head_tiles = self.head_dim // 32  # tiles per head
+                total_heads = self.n_local_heads + 2 * (self.n_kv_heads // self.cluster_shape[1])
+                total_qkv_tiles = head_tiles * total_heads
+                # Find largest divisor of total_qkv_tiles that is <= 64 and multiple of 8
+                # (dynamic_worker_core_grid requires multiple of 8)
+                num_cores = 8
+                for candidate in range(64, 7, -8):  # 64, 56, 48, 40, 32, 24, 16, 8
+                    if total_qkv_tiles % candidate == 0:
+                        num_cores = candidate
+                        break
+                else:
+                    # No multiple of 8 divides evenly, find any divisor <= 64
+                    for candidate in range(64, 0, -1):
+                        if total_qkv_tiles % candidate == 0:
+                            num_cores = candidate
+                            break
+                shard_width = (total_qkv_tiles * 32) // num_cores
+                return ttnn.create_sharded_memory_config(
+                    shape=(32, shard_width),
+                    core_grid=prefetcher.dynamic_worker_core_grid(num_cores),
+                    strategy=ttnn.ShardStrategy.WIDTH,
+                    orientation=ttnn.ShardOrientation.ROW_MAJOR,
+                    use_height_and_width_as_shard_shape=True,
+                )
             return self.model_config["CREATE_HEAD_INPUT_MEMCFG"]
         elif mode == Mode.PREFILL:
             return ttnn.DRAM_MEMORY_CONFIG
@@ -1635,7 +1707,7 @@ class ModelArgs:
                     ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
                     ttnn.BufferType.L1,
                     ttnn.ShardSpec(
-                        prefetcher.all_worker_cores_range_set,
+                        prefetcher.dynamic_worker_core_grid(32),
                         [32, self.head_dim],
                         ttnn.ShardOrientation.ROW_MAJOR,
                     ),
@@ -1695,12 +1767,10 @@ class ModelArgs:
         """Get the memory config for attention concat_heads output before WO matmul."""
         if mode == Mode.DECODE:
             if prefetcher is not None:
-                wo_out_shard_shape_ring = (
-                    32,
-                    self.dim // self.cluster_shape[1] // prefetcher.ring_size,
-                )  # Use padded N
+                # This is WO input (K dimension), so use _pad_shard_width
+                k_per_device = self.dim // self.cluster_shape[1]
                 return ttnn.create_sharded_memory_config(
-                    shape=wo_out_shard_shape_ring,
+                    shape=(32, self._pad_shard_width(k_per_device, prefetcher.ring_size)),
                     core_grid=prefetcher.to_core_range_set(
                         prefetcher.receiver_cores(sender_active=True, receiver_active=True)
                     ),
@@ -1731,8 +1801,14 @@ class ModelArgs:
         """Get the memory config for attention all-gather output."""
         if mode == Mode.DECODE:
             if prefetcher is not None:
+                # After all_gather, total width = padded_per_device * num_devices_gathered
+                # Input uses _pad_shard_width for per-shard width, times ring_size cores
+                k_per_device = self.dim // self.cluster_shape[1]
+                input_shard_width = self._pad_shard_width(k_per_device, prefetcher.ring_size)
+                # Output shard width = input_shard_width * num_devices_in_gather
+                output_shard_width = input_shard_width * self.cluster_shape[1]
                 return ttnn.create_sharded_memory_config(
-                    shape=(32, self.dim // prefetcher.ring_size),  # Use padded N
+                    shape=(32, output_shard_width),
                     core_grid=prefetcher.to_core_range_set(
                         prefetcher.receiver_cores(sender_active=True, receiver_active=True)
                     ),
@@ -1771,7 +1847,7 @@ class ModelArgs:
                     1,
                     32,
                     k_wo,
-                    n_wo,
+                    self._pad_total_width(n_wo, prefetcher.ring_size),
                     prefetcher.ring_size,
                     num_global_cb_receivers=prefetcher.num_receiver_cores,
                 )
@@ -1832,7 +1908,7 @@ class ModelArgs:
                     1,
                     32,
                     k_wo,
-                    n_wo,
+                    self._pad_total_width(n_wo, prefetcher.ring_size),
                     prefetcher.ring_size,
                     num_global_cb_receivers=prefetcher.num_receiver_cores,
                 )
@@ -1880,9 +1956,8 @@ class ModelArgs:
         """Get the memory config for WO matmul output in attention."""
         if mode == Mode.DECODE:
             if prefetcher is not None:
-                wo_out_shard_shape_ring = (32, self.dim // prefetcher.ring_size)
                 return ttnn.create_sharded_memory_config(
-                    shape=wo_out_shard_shape_ring,
+                    shape=(32, self._pad_shard_width(self.dim, prefetcher.ring_size)),
                     core_grid=prefetcher.to_core_range_set(
                         prefetcher.receiver_cores(sender_active=True, receiver_active=True)
                     ),
@@ -1905,12 +1980,9 @@ class ModelArgs:
                 return self.get_residual_mem_config(Mode.DECODE, None)
             else:
                 if prefetcher is not None:
-                    wo_out_shard_shape_ring = (
-                        32,
-                        self.dim // self.cluster_shape[1] // prefetcher.ring_size,
-                    )
+                    n_per_device = self.dim // self.cluster_shape[1]
                     return ttnn.create_sharded_memory_config(
-                        shape=wo_out_shard_shape_ring,
+                        shape=(32, self._pad_shard_width(n_per_device, prefetcher.ring_size)),
                         core_grid=prefetcher.to_core_range_set(
                             prefetcher.receiver_cores(sender_active=True, receiver_active=True)
                         ),
@@ -1938,8 +2010,9 @@ class ModelArgs:
                     return self.model_config["SELF_OUT_GATHERED_MEMCFG"](mesh_rows)
             else:
                 if prefetcher is not None:
+                    n_per_device = self.dim // self.cluster_shape[1]
                     return ttnn.create_sharded_memory_config(
-                        shape=(1, 1, 32, self.dim // self.cluster_shape[1] // prefetcher.ring_size),
+                        shape=(1, 1, 32, self._pad_shard_width(n_per_device, prefetcher.ring_size)),
                         core_grid=prefetcher.to_core_range_set(
                             prefetcher.receiver_cores(sender_active=True, receiver_active=True)
                         ),
@@ -1958,12 +2031,9 @@ class ModelArgs:
         """Get the memory config for gather users in attention (TG path)."""
         if mode == Mode.DECODE:
             if prefetcher is not None:
-                wo_out_shard_shape_ring = (
-                    32,
-                    self.dim // self.cluster_shape[1] // prefetcher.ring_size,
-                )
+                n_per_device = self.dim // self.cluster_shape[1]
                 return ttnn.create_sharded_memory_config(
-                    shape=wo_out_shard_shape_ring,
+                    shape=(32, self._pad_shard_width(n_per_device, prefetcher.ring_size)),
                     core_grid=prefetcher.to_core_range_set(
                         prefetcher.receiver_cores(sender_active=True, receiver_active=True)
                     ),
@@ -1995,7 +2065,7 @@ class ModelArgs:
     @lru_cache(maxsize=None)
     def get_norm_config(self, norm_type: str, mode: Mode, prefetcher: Prefetcher = None):
         """Get the norm config dict for attention, ff, or lm_head norms."""
-        prefetcher_norm_grid = ttnn.CoreGrid(y=8, x=4)
+        prefetcher_norm_grid = ttnn.CoreGrid(y=8, x=5)
         match norm_type:
             case "attn":
                 if mode == Mode.DECODE and prefetcher is not None:
@@ -2006,15 +2076,15 @@ class ModelArgs:
                                 32,
                                 self.dim
                                 // self.cluster_shape[0]
-                                // prefetcher.dynamic_worker_core_grid(32).num_cores(),
+                                // prefetcher.dynamic_worker_core_grid(40).num_cores(),
                             ),
-                            core_grid=prefetcher.dynamic_worker_core_grid(32),
+                            core_grid=prefetcher.dynamic_worker_core_grid(40),
                             strategy=ttnn.ShardStrategy.WIDTH,
                             orientation=ttnn.ShardOrientation.ROW_MAJOR,
                             use_height_and_width_as_shard_shape=True,
                         ),
                         "output_mem_config": ttnn.create_sharded_memory_config(
-                            shape=(32, self.dim // self.cluster_shape[0] // prefetcher.ring_size),
+                            shape=(32, self._pad_shard_width(self.dim // self.cluster_shape[0], prefetcher.ring_size)),
                             core_grid=prefetcher.to_core_range_set(
                                 prefetcher.receiver_cores(sender_active=True, receiver_active=True)
                             ),
@@ -2034,14 +2104,14 @@ class ModelArgs:
                     return {
                         "sharded_program_config": self.create_sharded_norm_config(prefetcher_norm_grid),
                         "sharded_output_config": ttnn.create_sharded_memory_config(
-                            shape=(32, self.dim // prefetcher.dynamic_worker_core_grid(32).num_cores()),
-                            core_grid=prefetcher.dynamic_worker_core_grid(32),
+                            shape=(32, self.dim // prefetcher.dynamic_worker_core_grid(40).num_cores()),
+                            core_grid=prefetcher.dynamic_worker_core_grid(40),
                             strategy=ttnn.ShardStrategy.WIDTH,
                             orientation=ttnn.ShardOrientation.ROW_MAJOR,
                             use_height_and_width_as_shard_shape=True,
                         ),
                         "output_mem_config": ttnn.create_sharded_memory_config(
-                            shape=(32, self.dim // self.cluster_shape[0] // prefetcher.ring_size),
+                            shape=(32, self._pad_shard_width(self.dim // self.cluster_shape[0], prefetcher.ring_size)),
                             core_grid=prefetcher.to_core_range_set(
                                 prefetcher.receiver_cores(sender_active=True, receiver_active=True)
                             ),
@@ -2067,8 +2137,8 @@ class ModelArgs:
                     return {
                         "sharded_program_config": self.create_sharded_norm_config(prefetcher_norm_grid),
                         "sharded_output_config": ttnn.create_sharded_memory_config(
-                            shape=(32, self.dim // prefetcher.dynamic_worker_core_grid(32).num_cores()),
-                            core_grid=prefetcher.dynamic_worker_core_grid(32),
+                            shape=(32, self.dim // prefetcher.dynamic_worker_core_grid(40).num_cores()),
+                            core_grid=prefetcher.dynamic_worker_core_grid(40),
                             strategy=ttnn.ShardStrategy.WIDTH,
                             orientation=ttnn.ShardOrientation.ROW_MAJOR,
                             use_height_and_width_as_shard_shape=True,
@@ -2117,7 +2187,7 @@ class ModelArgs:
         if mode == Mode.DECODE:
             if prefetcher is not None:
                 return ttnn.create_sharded_memory_config(
-                    shape=(32, self.dim // prefetcher.ring_size),
+                    shape=(32, self._pad_shard_width(self.dim, prefetcher.ring_size)),
                     core_grid=prefetcher.to_core_range_set(
                         prefetcher.receiver_cores(sender_active=True, receiver_active=True)
                     ),
@@ -2177,6 +2247,7 @@ class ModelArgs:
         """Get the memory config for LM head output."""
         if mode == Mode.DECODE:
             if prefetcher is not None:
+                # max_columns_per_device_lm_head is already padded to ring_size * tile_size
                 return ttnn.create_sharded_memory_config(
                     shape=(32, self.max_columns_per_device_lm_head // prefetcher.ring_size),
                     core_grid=prefetcher.to_core_range_set(
@@ -2206,12 +2277,6 @@ class ModelArgs:
         """Get the memory config for LM head output resharding."""
         if prefetcher is None:
             return ttnn.L1_MEMORY_CONFIG
-        lm_head_output_core_range_set = ttnn.CoreRangeSet(
-            [
-                ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(prefetcher.num_receiver_cores, 7)),
-                ttnn.CoreRange(ttnn.CoreCoord(8, 0), ttnn.CoreCoord(8 + prefetcher.num_receiver_cores - 1, 7)),
-            ]
-        )
 
         def next_power_of_2(n):
             if n <= 0:
@@ -2229,16 +2294,13 @@ class ModelArgs:
         )
 
     # NOTE: These attention helpers are placed here for historical reasons
-    def get_sharded_wo_ring_mem_config(self):
-        """Get the memory config for WO weights in ring mode."""
-        wo_shape_ring = (
-            self.dim // self.cluster_shape[0],
-            self.dim // self.cluster_shape[1],
-        )
-        return self.create_dram_sharded_mem_config(
-            k=wo_shape_ring[0],
-            n=wo_shape_ring[1],
-        )
+    def get_sharded_wo_ring_mem_config(self, prefetcher=None):
+        """Get the memory config for WO weights in ring mode.
+        WO: [n_heads*head_dim, dim] with dims=(2,3) -> N-sharded on dim, each device gets [K, N/num_devices]
+        """
+        wo_k = self.n_heads * self.head_dim
+        wo_n = self.dim // self.num_devices
+        return self.create_dram_sharded_mem_config(k=wo_k, n=wo_n, prefetcher=prefetcher)
 
     def get_attn_weights_layout(self):
         """Get the layout for attention weights."""
@@ -2980,11 +3042,18 @@ class ModelArgs:
     # =========================================================================
     # MATMUL / CONFIG HELPERS
     # =========================================================================
-    def create_dram_sharded_mem_config(self, k, n, dram_grid=None):
-        """Create DRAM-sharded memory config for width-sharded tensors"""
+    def create_dram_sharded_mem_config(self, k, n, dram_grid=None, prefetcher: Prefetcher = None):
+        """Create DRAM-sharded memory config for width-sharded tensors.
+
+        When prefetcher is provided, N is padded to ring_size * tile_size instead of dram_cores * tile_size.
+        """
         dram_cores = self.dram_grid_size.x  # WH has 12 dram cores, P150 has 8, P100 has 7
         assert self.dram_grid_size.y == 1, "Current dram sharding assumes y dim is 1"
-        padded_size = math.ceil(n / (self.tile_size * dram_cores)) * (self.tile_size * dram_cores)
+        if prefetcher is not None:
+            # Pad N to ring_size * tile_size for prefetcher compatibility
+            padded_size = self._pad_total_width(n, prefetcher.ring_size)
+        else:
+            padded_size = math.ceil(n / (self.tile_size * dram_cores)) * (self.tile_size * dram_cores)
         if dram_grid is None:
             dram_grid = self.dram_weight_grid
         shard_spec = ttnn.ShardSpec(dram_grid, (k, padded_size // dram_cores), ttnn.ShardOrientation.ROW_MAJOR)
@@ -3173,7 +3242,14 @@ class ModelArgs:
     ):
         M *= B  # Fuse batch always enabled
 
+        # Calculate in0_block_w with fallback to ensure K_tiles % in0_block_w == 0
+        K_tiles = K // ttnn.TILE_SIZE
         in0_block_w = K // num_cores // ttnn.TILE_SIZE
+        while in0_block_w > 0 and K_tiles % in0_block_w != 0:
+            in0_block_w -= 1
+        if in0_block_w == 0:
+            in0_block_w = 1
+
         out_block_h = M // ttnn.TILE_SIZE
         out_block_w = N // num_cores // ttnn.TILE_SIZE
 
@@ -4184,6 +4260,12 @@ class DecodersPrecision:
             if prefetcher and tensor != TensorGroup.ACTIVATION:
                 return ttnn.bfloat8_b
             return None
+
+        # When prefetcher is enabled, force BFP8 for prefetched weight tensors (WQKV, WO, FF1_FF3, FF2)
+        # to avoid mixed-dtype cross-product inflating the global CB size beyond L1 capacity.
+        # KV_CACHE and ACTIVATION are not prefetched and can use their configured dtype.
+        if prefetcher and tensor not in (TensorGroup.ACTIVATION, TensorGroup.KV_CACHE):
+            return ttnn.bfloat8_b
 
         return precision_setting_lookup[key]
 

--- a/models/tt_transformers/tt/prefetcher.py
+++ b/models/tt_transformers/tt/prefetcher.py
@@ -252,6 +252,8 @@ class Prefetcher(LightweightModule):
         self.num_senders: int = len(self.pf_config["dram_banks"])
         self.global_cb_size: int = 0  # Size of the global circular buffer in bytes storing prefetched matmul weights
         self.max_tensor_block_size: int = 0  # Max tensor block size is the largest block size of a tensor in bytes
+        self._max_block_tiles: int = 0  # Max tiles per block across all tensors (for C++ cross-product sizing)
+        self._max_tile_size: int = 0  # Max tile size in bytes across all tensors (for C++ cross-product sizing)
         self.receiver_mapping_override: Optional[dict] = None
         self.model_name = os.getenv("HF_MODEL", "")
         assert self.model_name != "", "HF_MODEL is not set. DRAM Prefetcher must be run with a model."
@@ -449,10 +451,20 @@ class Prefetcher(LightweightModule):
             )
         h, w = tensor.shape[-2], tensor.shape[-1]
         h_tiles, w_tiles = math.ceil(h / ttnn.TILE_SIZE), math.ceil(w / ttnn.TILE_SIZE)
+        # Pad height to ring_size to match C++ round_up(height_in_tiles, num_blocks)
         h_tiles_padded = math.ceil(h_tiles / self.ring_size) * self.ring_size
-        w_tiles_padded = math.ceil(w_tiles / self.ring_size) * self.ring_size
-        max_tensor_tiles = (h_tiles_padded * w_tiles_padded) // self.ring_size
-        self.max_tensor_block_size = max(max_tensor_tiles * bytes_in_tile[tensor.dtype], self.max_tensor_block_size)
+        # block_tiles using full tensor width (includes all DRAM shards)
+        # C++ uses shard width * num_readers which equals full tensor width
+        block_tiles = (h_tiles_padded * w_tiles) // self.ring_size
+        tile_size = bytes_in_tile[tensor.dtype]
+        # Track max block tiles and max tile size independently.
+        # C++ reader CB is configured with a single tile size (max_tile_size) for all tensors,
+        # so CB size = max_tile_size * max_block_tiles * 3 (triple buffered).
+        # Global CB must be >= max_tile_size * max_block_tiles_full.
+        # When all prefetched tensors use the same dtype, this equals per-tensor max.
+        self._max_block_tiles = max(block_tiles, self._max_block_tiles)
+        self._max_tile_size = max(tile_size, self._max_tile_size)
+        self.max_tensor_block_size = self._max_block_tiles * self._max_tile_size
         self.prefetched_tensors.append(tensor)
         self.prefetched_tensor_addr.append(tensor.buffer_address())
         logger.info(

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH.py
@@ -641,11 +641,9 @@ def test_prefetcher_BH(
     - FF2: TP on hidden_dim dimension (K-sharded)
     """
     mesh_shape = tuple(mesh_device.shape)
-    if not is_prefetcher_supported(
-        model_name, mesh_device.get_num_devices(), num_receiver_cores * 8
-    ) or mesh_device.get_num_devices() not in [2, 4, 8]:
+    if not is_prefetcher_supported(model_name, mesh_device.get_num_devices(), num_receiver_cores * 8) or mesh_device.get_num_devices() not in [2, 4, 8]:
         pytest.skip(
-            f"Model {model_name} does not fit in global CB with {mesh_device.get_num_devices()} devices and num_receiver_cores={num_receiver_cores}. DRAM Prefetcher is only supported on multi device configurations with 2, 4, or 8 devices."
+            f"Model {model_name} does not fit in global CB with {mesh_device.get_num_devices()} devices and num_receiver_cores={num_receiver_cores}"
         )
     logger.info(
         f"Testing DRAM Prefetcher + Ring Matmul for model {model_name} with dimensions: {VERIFIED_MODEL_CONFIGS[model_name]}"


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:{{branch_name}})
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
