### PR TITLE
#38281: Fix full MLA PCC

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/kernels/attention_block_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/kernels/attention_block_kernel.cpp
@@ -1232,11 +1232,11 @@ void kernel_main() {
     volatile tt_l1_ptr uint32_t* pos_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cur_pos_addr);
     uint32_t cur_pos = pos_ptr[0];
 
-    // const auto [skip_attention, skip_kv_cache_update, local_cur_pos] = get_device_mla_work_assignment(
-    //     cur_pos, Core::kv_cache_sp_device_idx, Core::kv_cache_device_chunk_size, Core::kv_cache_num_sp_devices);
-    const bool skip_attention = false;
-    const bool skip_kv_cache_update = false;
-    const uint32_t local_cur_pos = cur_pos;
+    const auto [skip_attention, skip_kv_cache_update, local_cur_pos] = get_device_mla_work_assignment(
+        cur_pos, Core::kv_cache_sp_device_idx, Core::kv_cache_device_chunk_size, Core::kv_cache_num_sp_devices);
+
+    using FlashMLAOp = deepseek_b1_ops::FlashMLADecode::
+        Op<FlashMLACTArgs, Core::is_mla_core, Core::is_kv_rmsnorm_core || Core::is_krope_core>;
 
     if (!skip_attention) {
         // ====================================================================
@@ -1402,11 +1402,17 @@ void kernel_main() {
         // ====================================================================
         {
             DeviceZoneScopedN("FLASH_MLA");
-            deepseek_b1_ops::FlashMLADecode::
-                Op<FlashMLACTArgs, Core::is_mla_core, Core::is_kv_rmsnorm_core || Core::is_krope_core>
-                    flash_mla;
+            FlashMLAOp flash_mla;
             flash_mla.set_local_cur_pos(flash_mla_args, local_cur_pos);
             flash_mla(flash_mla_args);
+        }
+    } else {
+        // This device has no sequence data (e.g. SP2/SP3 with seq_len = 2047 and per_device_chunk_size = 1024).
+        // Push dummy tiles into the hand-off CBs so SDPA reduce does not hang.
+        // TODO: Fuse the final SP reduce into Flash MLA and handle this internally,
+        // eliminating the need for this explicit dummy push.
+        if constexpr (Core::is_sdpa_worker_core) {
+            FlashMLAOp::push_dummy_sdpa_inputs();
         }
     }
     {

--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
@@ -66,6 +66,8 @@ class AttentionBlock:
         dkv_rmsnorm_gamma_tensor,
         kv_cache_tensor,
         scale,
+        post_sdpa_weights1,
+        post_sdpa_weights2,
         epsilon=1e-6,
         num_qnope_heads=64,
         num_qrope_heads=64,
@@ -92,6 +94,8 @@ class AttentionBlock:
             dkv_rmsnorm_gamma_tensor: kv_norm gamma [1, nope_dim]
             kv_cache_tensor: KV cache [1, 1, seq_len, nope_dim + rope_dim]
             scale: attention scale factor
+            post_sdpa_weights1: kv_b2_proj weights [num_qnope_heads, nope_dim]
+            post_sdpa_weights2: o_proj weights [intermediate, output_size]
             epsilon: RMSNorm epsilon (default 1e-6)
             num_qnope_heads: number of Q NoPE heads (default 64)
             num_qrope_heads: number of Q RoPE heads (default 64)
@@ -102,10 +106,10 @@ class AttentionBlock:
             rope_dim: KV RoPE dim (default 64)
 
         Returns:
-            Tuple of (full_q, new_kv, mla_output):
+            Tuple of (full_q, new_kv, output):
             - full_q: [1, 1, num_qnope_heads, nope_dim + rope_dim] combined Q heads
             - new_kv: [1, 1, 1, nope_dim + rope_dim] new KV entry written at position_ids[0]
-            - mla_output: [num_qnope_heads, nope_dim] FlashMLA attention output
+            - output: [1, output_size] post-SDPA output with residual added
         """
         from models.demos.deepseek_v3_b1.micro_ops.rope.op import RopeSingleCore
 
@@ -158,7 +162,17 @@ class AttentionBlock:
         new_kv = torch.cat([kv, k_rope], dim=-1).reshape(1, 1, 1, combined_head_dim).to(full_q.dtype)
         full_kv[:, :, position_id, :] = new_kv
 
-        output = FlashMLADecode.golden(full_q, full_kv, position_ids, nope_dim, scale).squeeze()
+        sdpa_output = FlashMLADecode.golden(full_q, full_kv, position_ids, nope_dim, scale).squeeze()
+
+        from models.demos.deepseek_v3_b1.fused_ops.post_sdpa.op import PostSDPA
+
+        post_sdpa_result = PostSDPA.golden(
+            sdpa_output.to(post_sdpa_weights1.dtype),
+            post_sdpa_weights1,
+            post_sdpa_weights2,
+        )
+
+        output = post_sdpa_result + input_tensor
         return full_q, new_kv, output
 
     @staticmethod
@@ -289,6 +303,8 @@ class AttentionBlock:
         post_sdpa_weights1_fused_tensors_per_device = ttnn.get_device_tensors(post_sdpa_weights1_tensor.fused_tensor)
         post_sdpa_weights2_fused_tensors_per_device = ttnn.get_device_tensors(post_sdpa_weights2_tensor.fused_tensor)
 
+        # Uncomment to debug local FlashMLA output
+        # output_tensors_per_device = ttnn.get_device_tensors(output_tensor)
         attention_block_output_tensors_per_device = ttnn.get_device_tensors(attention_block_output_tensor)
 
         assert (
@@ -1907,6 +1923,8 @@ class AttentionBlock:
                 post_sdpa_weights1_fused_tensor_device = post_sdpa_weights1_fused_tensors_per_device[device_idx]
                 post_sdpa_weights2_fused_tensor_device = post_sdpa_weights2_fused_tensors_per_device[device_idx]
                 attention_block_output_tensor_device = attention_block_output_tensors_per_device[device_idx]
+                # Uncomment to debug local FlashMLA output
+                # output_tensor_device = output_tensors_per_device[device_idx]
 
                 # Get worker core from per-device input tensor shard grid
                 device_local = input_tensor_device.device()
@@ -2601,6 +2619,14 @@ class AttentionBlock:
                         ],
                     )
                 )
+                # Uncomment to debug local FlashMLA output
+                # mla_out_o_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(mla_out_o_cb, output_tensor_device)
+                # mla_out_o_cb_descriptor.core_ranges = mla_core_grid
+                # mla_out_o_cb_descriptor.format_descriptors = [
+                #     ttnn.CBFormatDescriptor(mla_out_o_cb, stats_df, stats_tile_size, stats_tile_descriptor),
+                #     ttnn.CBFormatDescriptor(mla_interm_out_cb, stats_df, stats_tile_size, stats_tile_descriptor),
+                # ]
+                # mla_cb_descriptors.append(mla_out_o_cb_descriptor)
 
                 # cb_out_ms/cb_interm_ms: output m/s stats (tiny tile, shared for both m and s)
                 mla_cb_descriptors.append(
@@ -3530,7 +3556,9 @@ class AttentionBlock:
                 sdpa_worker_trisc_rt_args = ttnn.RuntimeArgs()
 
                 # Get matmul4 input buffer address for scatter destination
-                scatter_dest_l1_addr = input_tensor_device.buffer_address()
+                scatter_dest_l1_addr = (
+                    sdpa_kv_cache_buffer_device.buffer_address() + matmul4_in0_cb_descriptor.address_offset
+                )
 
                 # Type A/B worker split (like original sdpa_reduce_to_all op)
                 # This distributes R1/R2 traffic across both FWD and BWD forwarder instances

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_attention_block.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_attention_block.py
@@ -23,6 +23,7 @@ from models.demos.deepseek_v3_b1.blitz_decode_weights import (
     BlitzDecodeWeights,
 )
 from models.demos.deepseek_v3_b1.fused_ops.attention_block.op import AttentionBlock
+from models.demos.deepseek_v3_b1.fused_ops.pre_sdpa.op import PreSDPA
 from models.demos.deepseek_v3_b1.micro_ops.flash_mla.op import FlashMLADecode
 from models.demos.deepseek_v3_b1.tests.unit_tests.test_post_sdpa import compute_forwarder_scratch_size
 from models.demos.deepseek_v3_b1.tests.unit_tests.test_pre_sdpa import deinterleave_kv_cache
@@ -365,12 +366,10 @@ def test_attention_block(
         mesh_mapper=ttnn.ShardTensorToMesh(submesh, dim=0),
     )
 
-    # Weights are shared across all devices (replicated per TP slice)
-    torch_weights1 = torch.randn((K1, post_sdpa_intermediate), dtype=torch.bfloat16)
-    torch_weights2 = torch.randn((K2, output_size), dtype=torch.bfloat16)
-
-    torch_kv_b2_proj_weights = torch.cat([torch_weights1] * num_tp, dim=1) if num_tp > 1 else torch_weights1
-    torch_o_proj_weights = torch.cat([torch_weights2] * num_tp, dim=0) if num_tp > 1 else torch_weights2
+    # kv_b2_proj: [K1, intermediate * num_tp] — full TP width, split along output dim per column
+    torch_kv_b2_proj_weights = torch.randn((K1, post_sdpa_intermediate * num_tp), dtype=torch.bfloat16)
+    # o_proj: [K2 * num_tp, output_size] — full TP height, split along input dim per column
+    torch_o_proj_weights = torch.randn((K2 * num_tp, output_size), dtype=torch.bfloat16)
 
     # Fused matmul1 (q_a_proj packed), matmul2 (q_b_proj shuffled), and DKV matmul (kv_a_proj)
     # weights as overlapped tensors sharing a single L1 buffer via BlitzDecodeWeights.
@@ -565,7 +564,7 @@ def test_attention_block(
     dcs = program_config.device_chunk_size
     num_sp = mesh_rows
 
-    torch_kv_cache = torch.full(cache_shape, float("-inf"), dtype=torch.bfloat16)
+    torch_kv_cache = torch.zeros(cache_shape, dtype=torch.bfloat16)
     torch_kv_cache[:, :, :position_id, :] = torch.randn(1, 1, position_id, kvpe_dim, dtype=torch.bfloat16)
     torch_kv_cache_shuffled = deinterleave_kv_cache(torch_kv_cache, dcs, num_sp)
 
@@ -848,7 +847,6 @@ def test_attention_block(
     # Run pre-SDPA operation
     # ========================================================================
     logger.info(f"Running attention block operation with position_id={position_id}...")
-
     for i in range(num_iters):
         ttnn_output_result = AttentionBlock.op(
             input_tensor_mesh,
@@ -881,7 +879,7 @@ def test_attention_block(
             ttnn_sdpa_output_l,
             ttnn_sdpa_intermediate_recv,
             ttnn_sdpa_forwarder_scratch,
-            0,  # sdpa_per_device_chunk_size
+            program_config.device_chunk_size,  # sdpa_per_device_chunk_size
             ttnn_attention_block_output,
             # Shared semaphores, and some default values
             attention_block_semaphores,
@@ -900,8 +898,13 @@ def test_attention_block(
 
     kv_cache_output_torch = ttnn.to_torch(ttnn_kv_cache, mesh_composer=ttnn.ConcatMeshToTensor(submesh, dim=0))
 
-    # Read back the FlashMLA output (pre-post-SDPA) for SDPA validation
-    sdpa_output_torch = ttnn.to_torch(ttnn_output, mesh_composer=ttnn.ConcatMeshToTensor(submesh, dim=0))
+    # If True, validate the local FlashMLA output before SDPA AllReduce
+    # Need to uncomment and use ttnn_output_tensor as the backing buffer for mla_out_o_cb
+    validate_local_flash_mla = False
+
+    # Read back the FlashMLA output (pre-post-SDPA) for validation
+    if validate_local_flash_mla:
+        sdpa_output_torch = ttnn.to_torch(ttnn_output, mesh_composer=ttnn.ConcatMeshToTensor(submesh, dim=0))
 
     # Convert back to torch for verification
     output_torch = ttnn.to_torch(ttnn_output_result, mesh_composer=ttnn.ConcatMeshToTensor(submesh, dim=0))
@@ -932,6 +935,8 @@ def test_attention_block(
         torch_dkv_rmsnorm_gamma,
         torch_kv_cache,
         scale,
+        torch_kv_b2_proj_weights,
+        torch_o_proj_weights,
         epsilon=epsilon,
         num_qnope_heads=total_qnope_heads,
         num_qrope_heads=total_qrope_heads,
@@ -954,6 +959,71 @@ def test_attention_block(
         dev_contrib = max(0, min(remainder, dev_end) - dev_start)
         return num_full_blocks * device_chunk_size + dev_contrib
 
+    if validate_local_flash_mla:
+        # ========================================================================
+        # Compute per-SP golden for pre-SDPA output (before post-SDPA reduce)
+        # ========================================================================
+        def build_local_kv_cache(sp_idx):
+            """Extract sp_idx's local KV cache from torch_kv_cache_shuffled."""
+            sp_block = device_chunk_size * num_sp
+            num_full_blocks = position_id // sp_block
+            remainder = position_id % sp_block
+            dev_start = sp_idx * device_chunk_size
+            dev_end = dev_start + device_chunk_size
+            dev_contrib = max(0, min(remainder, dev_end) - dev_start)
+            local_len = num_full_blocks * device_chunk_size + dev_contrib
+            if local_len == 0:
+                return None, 0
+            shard_offset = sp_idx * per_device_max_seq_len
+            local_kv = torch_kv_cache_shuffled[:, :, shard_offset : shard_offset + local_len, :]
+            return local_kv, local_len
+
+        pre_sdpa_golden_args = dict(
+            input_tensor=torch_input,
+            gamma_tensor=torch_gamma,
+            matmul_weights_tensor=torch_matmul_weights,
+            rmsnorm2_gamma_tensor=torch_rmsnorm2_gamma,
+            matmul2_weights_tensor=torch_matmul2_weights_full_unshuffled,
+            matmul3_weights_tensor=torch_matmul3_weights,
+            sin_tensor=torch_sin,
+            cos_tensor=torch_cos,
+            dkv_matmul_weights_tensor=torch_dkv_matmul_weights,
+            dkv_rmsnorm_gamma_tensor=torch_dkv_rmsnorm_gamma,
+            scale=scale,
+            epsilon=epsilon,
+            num_qnope_heads=total_qnope_heads,
+            num_qrope_heads=total_qrope_heads,
+            qnope_head_dim=QNOPE_HEAD_DIM,
+            qrope_head_dim=QROPE_HEAD_DIM,
+            heads_per_row=HEADS_PER_ROW,
+            nope_dim=KNOPE_DIM,
+            rope_dim=KROPE_DIM,
+        )
+
+        golden_per_sp = {}
+        for sp_idx in range(num_sp):
+            local_kv, local_seq_len = build_local_kv_cache(sp_idx)
+            is_owner = sp_idx == owning_sp_device
+            if local_kv is None:
+                if is_owner:
+                    local_kv = torch.zeros(1, 1, 0, kvpe_dim, dtype=torch.bfloat16)
+                else:
+                    continue
+            local_pos = torch.tensor([local_seq_len if is_owner else local_seq_len - 1])
+            _, _, mla_output = PreSDPA.golden(
+                **pre_sdpa_golden_args,
+                local_position_ids=local_pos,
+                global_position_ids=torch.tensor([position_id]),
+                kv_cache_tensor=local_kv,
+                kv_cache_update=is_owner,
+            )
+            golden_per_sp[sp_idx] = mla_output
+
+        logger.info(
+            f"Per-SP golden computed for {len(golden_per_sp)} SP devices "
+            f"(owning_sp_device={owning_sp_device}, device_chunk_size={device_chunk_size})"
+        )
+
     # ========================================================================
     # Validate KV cache outputs (per SP device)
     # ========================================================================
@@ -961,7 +1031,7 @@ def test_attention_block(
         sp_group = device_idx // mesh_cols
         local_seq_len = get_local_seq_len(sp_group)
 
-        if local_seq_len == 0:
+        if local_seq_len == 0 and sp_group != owning_sp_device:
             logger.info(f"Device {device_idx} (SP={sp_group}) no data yet, skipped")
             continue
 
@@ -989,24 +1059,49 @@ def test_attention_block(
             assert rope_passing, f"Device {device_idx} (SP={sp_group}) KV Cache ROPE PCC check failed: {rope_pcc}"
 
     # ========================================================================
-    # Validate SDPA output (global golden: full KV cache, global position_id)
-    # Post-SDPA reduces all local FlashMLA outputs across SP devices, so the
-    # final MLA output corresponds to running attention over the full KV cache.
+    # Validate pre-SDPA output (per-SP golden: local KV cache per device)
+    # This is the FlashMLA output before post-SDPA reduce across SP devices.
     # ========================================================================
-    slice_size = sdpa_input_output_shape[0]  # 64 heads per device
+    if validate_local_flash_mla:
+        slice_size = sdpa_input_output_shape[0]  # 64 heads per device
+        for device_idx in range(mesh_rows * mesh_cols):
+            tp_group = device_idx % mesh_cols
+            sp_group = device_idx // mesh_cols
+
+            if sp_group not in golden_per_sp:
+                logger.info(f"Device {device_idx} (SP={sp_group}) no work, skipped")
+                continue
+
+            golden_mla_output = golden_per_sp[sp_group]
+
+            start = device_idx * slice_size
+            end = start + slice_size
+            received = sdpa_output_torch[start:end, :]
+
+            tp_start = tp_group * slice_size
+            tp_end = tp_start + slice_size
+            expected = golden_mla_output[tp_start:tp_end, :]
+            print(expected[:8, :32:8])
+
+            if received.shape != expected.shape:
+                logger.error(
+                    f"Device {device_idx} (TP={tp_group}, SP={sp_group}) output shape mismatch: "
+                    f"got {received.shape}, expected {expected.shape}"
+                )
+                continue
+
+            passing, pcc = comp_pcc(expected, received, 0.84)
+            logger.info(f"Device {device_idx} (TP={tp_group}, SP={sp_group}) PreSDPA Output PCC: {pcc}")
+            assert passing, f"Device {device_idx} (TP={tp_group}, SP={sp_group}) PreSDPA Output PCC check failed: {pcc}"
+
+    # ========================================================================
+    # Validate attention block output (full pipeline: SDPA -> kv_b2 -> o_proj -> all-reduce + residual)
+    # ========================================================================
     for device_idx in range(mesh_rows * mesh_cols):
-        tp_group = device_idx % mesh_cols
-        start = device_idx * slice_size
-        end = start + slice_size
-        received = sdpa_output_torch[start:end, :]
-
-        tp_start = tp_group * slice_size
-        tp_end = tp_start + slice_size
-        expected = torch_output_expected[tp_start:tp_end, :]
-
-        passing, pcc = comp_pcc(expected, received, 0.84)
-        logger.info(f"Device {device_idx} (TP={tp_group}) SDPA Output PCC: {pcc}")
-        assert passing, f"Device {device_idx} (TP={tp_group}) SDPA Output PCC check failed: {pcc}"
+        received = output_torch[device_idx : device_idx + 1, :]
+        passing, pcc = comp_pcc(torch_output_expected, received, 0.88)
+        logger.info(f"Device {device_idx} Attention Block Output PCC: {pcc}")
+        assert passing, f"Device {device_idx} Attention Block Output PCC check failed: {pcc}"
 
     logger.info("✓ Attention Block mesh test passed!")
 

--- a/models/demos/deepseek_v3_b1/unified_kernels/flash_mla.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/flash_mla.hpp
@@ -192,6 +192,29 @@ struct FlashMLADecode {
 
         void set_local_cur_pos(RTArgs& args, uint32_t local_cur_pos) { args.local_cur_pos = local_cur_pos; }
 
+        /**
+         * Push dummy tiles into the hand-off CBs (cb_out_o, cb_out_ms) so that
+         * downstream SDPA reduce does not hang when Flash MLA is skipped on this
+         * device (e.g. SP2/SP3 with no sequence data). Call on S1 cores only.
+         *
+         * TODO: Fuse the final SP reduce into Flash MLA and handle this internally,
+         * eliminating the need for callers to manage the dummy push.
+         */
+        static void push_dummy_sdpa_inputs() {
+#if defined(COMPILE_FOR_TRISC)
+            constexpr uint32_t cb_out_o = CTArgs::cb_out_o;
+            constexpr uint32_t cb_out_ms = CTArgs::cb_out_ms;
+            constexpr uint32_t Sq_chunk_t = get_named_compile_time_arg_val("PNHt");
+            constexpr uint32_t vDHt = get_named_compile_time_arg_val("vDHt");
+            constexpr uint32_t out_chunk_tiles = Sq_chunk_t * vDHt;
+
+            cb_reserve_back(cb_out_ms, 1);
+            cb_push_back(cb_out_ms, 1);
+            cb_reserve_back(cb_out_o, out_chunk_tiles);
+            cb_push_back(cb_out_o, out_chunk_tiles);
+#endif
+        }
+
     private:
         void impl([[maybe_unused]] const RTArgs& args) {
 // ====================================================================


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/38281)

### Problem description
Previously, we fused all of MLA but there were still PCC issues with KV cache and final output. This PR fixes those as well as switches to do proper SP4 KV cache scheme.

### What's changed
- Switch to torch zeros for kv cache initialization
- Fix edge case for pos 0 in test attention block
- Switch to TP2 for post-SDPA weights
- Fix scatter dest address in post-SDPA to match matmul4 buffer
- Enable proper SP4 in kernels
  * Use real interleaved kv cache assignment scheme for each SP device
  * Pass actual program_config.device_chunk_size to op for masking SDPA worker
- Add dummy push API for FlashMLA micro-op
  * Pushes dummy inputs for SDPA worker in post-SDPA
  * Needed when devices skip entire attention pre-SDPA + local attention

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=bliu/main)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:bliu/main): https://github.com/tenstorrent/tt-metal/actions/runs/22807182180
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bliu/main)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bliu/main): https://github.com/tenstorrent/tt-metal/actions/runs/22807187071
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bliu/main)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bliu/main)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bliu/main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bliu/main)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bliu/main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bliu/main)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bliu/main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bliu/main)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
