### PR TITLE
Ensure downstream CCLs in MLA wait for broadcast to finish

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/kernels/attention_block_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/kernels/attention_block_kernel.cpp
@@ -49,6 +49,7 @@
 // Defined at namespace scope (local classes cannot have static data members)
 struct Core {
     static constexpr bool is_input_core = get_named_compile_time_arg_val("is_input_core") == 1;
+    static constexpr bool is_full_mcast_grid_core = get_named_compile_time_arg_val("is_full_mcast_grid_core") == 1;
     static constexpr bool is_matmul_core = get_named_compile_time_arg_val("is_matmul_core") == 1;
     static constexpr bool is_matmul2_core = get_named_compile_time_arg_val("is_matmul2_core") == 1;
     // Qnope/Qrope core differentiation for interleaved Q head layout after matmul2
@@ -84,8 +85,6 @@ struct Core {
     static constexpr bool is_matmul4_core = get_named_compile_time_arg_val("is_matmul4_core") == 1;
     // Gather core (12, 9) - receives gather2, sends mcast3, receives gather3, CCL receiver
     static constexpr bool is_gather_receiver_core = get_named_compile_time_arg_val("is_gather_receiver_core") == 1;
-    // Mcast3 receiver grid (13x10 = 130 cores) - receives mcast3 data
-    static constexpr bool is_mcast3_receiver_core = get_named_compile_time_arg_val("is_mcast3_receiver_core") == 1;
     // Active matmul5 cores (112 cores: o_proj grid 12x8 + 8x2)
     static constexpr bool is_matmul5_core = get_named_compile_time_arg_val("is_matmul5_core") == 1;
     // CCL sender core (11, 9) - reads from gather core, sends via fabric
@@ -151,7 +150,7 @@ void kernel_main() {
     // Mcast2 receiver args (for matmul2 cores to receive matmul2 input from input core)
     // Uses same semaphore as first mcast
     deepseek_b1_ops::Mcast::ReceiverArgs mcast2_args{
-        get_named_compile_time_arg_val("mcast_data_receiver_semaphore_addr"),
+        get_named_compile_time_arg_val("mcast2_data_receiver_semaphore_addr"),
         get_named_compile_time_arg_val("matmul2_in0"),
         get_named_compile_time_arg_val("mcast2_dst_num_pages"),
     };
@@ -308,7 +307,6 @@ void kernel_main() {
     };
 
     // Mcast3 receiver args
-    using Mcast3CTArgs = deepseek_b1_ops::Mcast::ReceiverCTArgs;
     deepseek_b1_ops::Mcast::ReceiverArgs mcast3_args{
         get_semaphore(get_named_compile_time_arg_val("mcast3_data_receiver_semaphore")),
         get_named_compile_time_arg_val("mcast3_dst_cb"),
@@ -478,7 +476,7 @@ void kernel_main() {
     using McastCTArgs = deepseek_b1_ops::Mcast::SenderCTArgs<
         get_named_compile_time_arg_val("mcast_num_cores"),
         get_named_compile_time_arg_val("mcast_is_part_of_receiver_grid"),
-        Core::is_input_core && Core::is_matmul2_core>;  // Always mcast to the main grid
+        Core::is_input_core && Core::is_full_mcast_grid_core>;  // loopback = false
 
     // RMSNorm writer args (BRISC is no-op)
     deepseek_b1_ops::RMSNorm::WriterArgs rmsnorm_args{};
@@ -563,7 +561,7 @@ void kernel_main() {
         get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
         get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
         get_named_compile_time_arg_val("mcast_data_sender_semaphore_addr"),
-        get_named_compile_time_arg_val("mcast_data_receiver_semaphore_addr"),
+        get_named_compile_time_arg_val("mcast2_data_receiver_semaphore_addr"),
         get_named_compile_time_arg_val("mcast2_data_size_bytes"),
         mcast2_src_cb,  // Wait for rmsnorm2_output_cb
         get_named_compile_time_arg_val("mcast2_src_num_pages"),
@@ -689,19 +687,14 @@ void kernel_main() {
     };
 
     // Mcast3 sender args
-    using Mcast3CTArgs = deepseek_b1_ops::Mcast::SenderCTArgs<
-        get_named_compile_time_arg_val("mcast3_num_cores"),
-        get_named_compile_time_arg_val("mcast3_is_part_of_receiver_grid") == 1,
-        false>;  // loopback = false
-
     constexpr uint32_t mcast3_src_cb = get_named_compile_time_arg_val("mcast3_src_cb");
     constexpr uint32_t mcast3_dst_cb = get_named_compile_time_arg_val("mcast3_dst_cb");
     deepseek_b1_ops::Mcast::SenderArgs mcast3_args{
-        get_named_compile_time_arg_val("mcast3_dest_noc_start_x"),
-        get_named_compile_time_arg_val("mcast3_dest_noc_start_y"),
-        get_named_compile_time_arg_val("mcast3_dest_noc_end_x"),
-        get_named_compile_time_arg_val("mcast3_dest_noc_end_y"),
-        get_named_compile_time_arg_val("mcast3_data_sender_semaphore_addr"),
+        get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
+        get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
+        get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
+        get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
+        get_named_compile_time_arg_val("mcast_data_sender_semaphore_addr"),
         get_semaphore(get_named_compile_time_arg_val("mcast3_data_receiver_semaphore")),
         get_named_compile_time_arg_val("mcast3_data_size_bytes"),
         mcast3_src_cb,
@@ -1067,7 +1060,6 @@ void kernel_main() {
     deepseek_b1_ops::Gather::ComputeArgs gather2_args{};
 
     // Mcast3 CTArgs (no-op)
-    using Mcast3CTArgs = deepseek_b1_ops::Mcast::ComputeCTArgs;
     deepseek_b1_ops::Mcast::ComputeArgs mcast3_args{};
 
     // Matmul5 CTArgs
@@ -1188,7 +1180,7 @@ void kernel_main() {
 #endif
 
 #if defined(COMPILE_FOR_BRISC)
-     uint32_t cur_pos_addr = get_common_arg_val<uint32_t>(1);
+    uint32_t cur_pos_addr = get_common_arg_val<uint32_t>(1);
 #elif defined(COMPILE_FOR_NCRISC)
     uint32_t cur_pos_addr = get_common_arg_val<uint32_t>(14);
 #elif defined(COMPILE_FOR_TRISC)
@@ -1201,7 +1193,8 @@ void kernel_main() {
     deepseek_b1_ops::Mcast::Op<
         McastCTArgs,
         Core::is_input_core,
-        Core::is_matmul2_core,
+        // Receive on the whole grid. This is used to block downstream ccls
+        Core::is_full_mcast_grid_core,
         Core::is_matmul_core || Core::is_dkv_matmul_core,
         true>
         mcast;
@@ -1428,6 +1421,23 @@ void kernel_main() {
                 }
                 if constexpr (Core::is_sdpa_forwarder_core) {
                     deepseek_b1_ops::SdpaReduceForwarder::Op<SdpaReduceForwarderCTArgs> sdpa_reduce_forwarder;
+                    // We need to make sure both riscs wait for the initial broadcast CCL to complete since
+                    // reduce forwarder uses both riscs to send over fabric
+                    // The first mcast syncs the ncrisc, so we need to also make sure brisc waits for the first mcast
+#if defined(COMPILE_FOR_NCRISC)
+                    volatile tt_l1_ptr uint32_t* sync_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+                        get_named_compile_time_arg_val("mcast_data_receiver_semaphore_addr"));
+                    // Make sure the value is different from the mcasted value
+                    // The wait below is for safety if this runs on the same core as another doing the same sync
+                    // If that is the case we don't actually need to do another sync
+                    noc_semaphore_wait(sync_sem, 0);
+                    noc_semaphore_set(sync_sem, 2);
+#elif defined(COMPILE_FOR_BRISC)
+                    volatile tt_l1_ptr uint32_t* sync_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+                        get_named_compile_time_arg_val("mcast_data_receiver_semaphore_addr"));
+                    noc_semaphore_wait(sync_sem, 2);
+                    noc_semaphore_set(sync_sem, 0);
+#endif
                     sdpa_reduce_forwarder(sdpa_reduce_forwarder_args);
                 }
 #if defined(COMPILE_FOR_NCRISC)
@@ -1469,11 +1479,9 @@ void kernel_main() {
             // Source: gather2_dst_cb (CB 3), Destination: mcast3_dst_cb = matmul5_in0 (CB 4)
             // Note: 18 inactive grid cores only do semaphore handshake; only matmul5 cores do full CB receive
             // ========================================================================
-            constexpr bool is_mcast3_grid_core = Core::is_mcast3_receiver_core && !Core::is_gather_receiver_core;
             deepseek_b1_ops::Mcast::
-                Op<Mcast3CTArgs, Core::is_gather_receiver_core, is_mcast3_grid_core, Core::is_matmul5_core, true>
+                Op<McastCTArgs, Core::is_gather_receiver_core, Core::is_matmul5_core, Core::is_matmul5_core, true>
                     mcast3;
-            // mcast3.init(mcast3_args);
             {
                 DeviceZoneScopedN("MCAST3");
                 mcast3(mcast3_args);
@@ -1526,9 +1534,19 @@ void kernel_main() {
             // gather3 already pushed to CB7 (gather3_dst_cb). The receiver just
             // needs to wait for remote data and perform the reduction.
             // ========================================================================
-#if defined(COMPILE_FOR_NCRISC)
             if constexpr (Core::is_ccl_sender_core) {
-                DeviceZoneScopedN("CCL_SENDER_READ");
+                DeviceZoneScopedN("CCL_SENDER_SEND");
+#if defined(COMPILE_FOR_NCRISC)
+                // We need to make sure brisc waits for the initial broadcast CCL to complete before connecting
+                // to fabric. Alternative is to move brisc connection logic after the cb wait
+                // The first mcast syncs the ncrisc, so we need to also make sure brisc waits for the first mcast
+                volatile tt_l1_ptr uint32_t* sync_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+                    get_named_compile_time_arg_val("mcast_data_receiver_semaphore_addr"));
+                // Make sure the value is different from the mcasted value
+                // The wait below is for safety if this runs on the same core as another doing the same sync
+                // If that is the case we don't actually need to do another sync
+                noc_semaphore_wait(sync_sem, 0);
+                noc_semaphore_set(sync_sem, 2);
 
                 // Wait for gather3 to complete before reading from gather core
                 constexpr uint32_t gather3_completion_semaphore_id =
@@ -1540,35 +1558,29 @@ void kernel_main() {
 
                 deepseek_b1_ops::AllReduceSender::Op<CCLSenderReaderCTArgs, DummyWriterCTArgs> ccl_sender_reader;
                 ccl_sender_reader(ccl_sender_args);
+#elif defined(COMPILE_FOR_BRISC)
+                volatile tt_l1_ptr uint32_t* sync_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+                    get_named_compile_time_arg_val("mcast_data_receiver_semaphore_addr"));
+                noc_semaphore_wait(sync_sem, 2);
+                noc_semaphore_set(sync_sem, 0);
+                deepseek_b1_ops::AllReduceSender::Op<DummyReaderCTArgs, CCLSenderWriterCTArgs> ccl_sender_writer;
+                ccl_sender_writer(ccl_sender_args);
+#endif
             }
 
             if constexpr (Core::is_ccl_receiver_core) {
-                DeviceZoneScopedN("CCL_RECEIVER_WAIT");
+                DeviceZoneScopedN("CCL_RECEIVER");
+#if defined(COMPILE_FOR_NCRISC)
                 // TODO: We're popping the RMSNorm input and then re-pushing it here as the residual
                 // Should avoid this and not pop in RMSNorm
                 deepseek_b1_ops::AllReduceReceiver::Op<CCLReceiverReaderCTArgs, DummyComputeCTArgs> ccl_receiver_reader;
                 ccl_receiver_reader(ccl_receiver_args);
-            }
-
-#elif defined(COMPILE_FOR_BRISC)
-            if constexpr (Core::is_ccl_sender_core) {
-                DeviceZoneScopedN("CCL_SENDER_SEND");
-
-                deepseek_b1_ops::AllReduceSender::Op<DummyReaderCTArgs, CCLSenderWriterCTArgs> ccl_sender_writer;
-                ccl_sender_writer(ccl_sender_args);
-            }
-            // CCL Receiver BRISC is no-op
-
 #elif defined(COMPILE_FOR_TRISC)
-            if constexpr (Core::is_ccl_receiver_core) {
-                DeviceZoneScopedN("CCL_RECEIVER_COMPUTE");
-
                 deepseek_b1_ops::AllReduceReceiver::Op<DummyReaderCTArgs, CCLReceiverComputeCTArgs>
                     ccl_receiver_compute;
                 ccl_receiver_compute(ccl_receiver_args);
-            }
-            // CCL Sender TRISC is no-op
 #endif
+            }
     }
 
     // ====================================================================

--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
@@ -3136,7 +3136,7 @@ class AttentionBlock:
 
                     # Secondary axis connection (for sender to secondary sender)
                     if has_secondary_target:
-                        secondary_coord = ttnn.MeshCoordinate(row, 1)
+                        secondary_coord = ttnn.MeshCoordinate(row, 1 - col)
                         dst_nodes.append(mesh_device.get_fabric_node_id(secondary_coord))
 
                     num_connections = len(dst_nodes)

--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
@@ -163,8 +163,8 @@ class AttentionBlock:
 
     @staticmethod
     def get_num_semaphores():
-        # 13 form pre sdpa, 4 from post
-        return 17
+        # 14 form pre sdpa, 4 from post
+        return 18
 
     @staticmethod
     def create_semaphores(mesh_device):
@@ -537,19 +537,15 @@ class AttentionBlock:
         gather2_sender_idx_per_core = [(core, idx) for idx, core in enumerate(matmul4_cores)]
 
         # Gather/CCL receiver core: (12, 9)
-        gather_core = ttnn.CoreCoord(12, 9)
-        gather_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(gather_core, gather_core)])
+        gather_core = rmsnorm_core
+        gather_core_grid = rmsnorm_core_grid
 
         # CCL sender core: (11, 9) - adjacent to gather core
         ccl_sender_core = ttnn.CoreCoord(11, 9)
         ccl_sender_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ccl_sender_core, ccl_sender_core)])
 
-        mcast3_grid = ttnn.CoreRange(
-            ttnn.CoreCoord(MCAST_GRID_START_X, MCAST_GRID_START_Y),
-            ttnn.CoreCoord(MCAST_GRID_END_X, MCAST_GRID_END_Y),
-        )
-        mcast3_core_grid = ttnn.CoreRangeSet([mcast3_grid])
-        num_mcast3_cores = mcast3_grid.grid_size().x * mcast3_grid.grid_size().y  # 130
+        # TODO: Subtract the pipeline core
+        is_full_mcast_grid_core = ttnn.CoreRangeSet([main_grid]).subtract(rmsnorm_core_grid)
 
         # Active Matmul5 cores: o_proj cores (12×8 + 8×2 = 112 cores)
         o_proj_spec = O_PROJ_GATE_MM_RMSNORM_GAMMA_SingleDeviceOverlapSpec()
@@ -563,7 +559,8 @@ class AttentionBlock:
         gather3_sender_idx_per_core = [(core, idx) for idx, core in enumerate(matmul5_cores)]
 
         # Full grid (union of all cores for semaphore allocation)
-        full_grid = matmul4_core_grid.merge(gather_core_grid).merge(mcast3_core_grid).merge(ccl_sender_core_grid)
+        # TODO: Subtract the pipeline core
+        full_grid = rmsnorm_core_grid.merge(ttnn.CoreRangeSet([main_grid])).merge(ccl_sender_core_grid)
 
         # SDPA tensor properties - use same calculation as original sdpa_reduce_to_all op
         sdpa_input_l_sample = ttnn.get_device_tensors(sdpa_input_l_mesh)[0]
@@ -731,7 +728,10 @@ class AttentionBlock:
         )
         semaphore_index += 1
 
-        mcast3_data_sender_semaphore_addr = mcast_data_sender_semaphore_addr
+        mcast2_data_receiver_semaphore_addr = ttnn.get_global_semaphore_address(
+            attention_block_semaphores[semaphore_index]
+        )
+        semaphore_index += 1
 
         # Semaphore IDs for gather synchronization
         # Senders on NCRISC use NOC_0, receiver on BRISC uses NOC_1
@@ -1621,12 +1621,8 @@ class AttentionBlock:
 
         # Get NOC coordinates for this device
         gather_dest_noc_core = device.worker_core_from_logical_core(gather_core)
-        mcast3_dest_noc_start_core = device.worker_core_from_logical_core(mcast3_grid.start)
-        mcast3_dest_noc_end_core = device.worker_core_from_logical_core(mcast3_grid.end)
         ccl_sender_noc_core = device.worker_core_from_logical_core(ccl_sender_core)
         ccl_receiver_noc_core = gather_dest_noc_core  # Same as gather core
-
-        mcast3_is_part_of_receiver_grid = mcast3_grid.contains(gather_core)
 
         # ========================================================================
         # NCRISC compile-time args
@@ -1732,18 +1728,11 @@ class AttentionBlock:
             ("gather2_dst_cb", gather2_dst_cb),
             ("gather2_dst_num_pages", gather2_dst_num_pages),
             # Mcast3 sender
-            ("mcast3_dest_noc_start_x", mcast3_dest_noc_start_core.x),
-            ("mcast3_dest_noc_start_y", mcast3_dest_noc_start_core.y),
-            ("mcast3_dest_noc_end_x", mcast3_dest_noc_end_core.x),
-            ("mcast3_dest_noc_end_y", mcast3_dest_noc_end_core.y),
-            ("mcast3_num_cores", num_mcast3_cores),
-            ("mcast3_data_sender_semaphore_addr", mcast3_data_sender_semaphore_addr),
             ("mcast3_data_receiver_semaphore", mcast3_data_receiver_semaphore_id),
             ("mcast3_data_size_bytes", mcast3_data_size_bytes),
             ("mcast3_src_cb", gather2_dst_cb),
             ("mcast3_src_num_pages", mcast3_src_num_pages),
             ("mcast3_dst_cb", matmul5_in0_cb),
-            ("mcast3_is_part_of_receiver_grid", mcast3_is_part_of_receiver_grid),
             # Gather3 receiver
             ("gather3_noc0_num_senders", gather3_noc0_num_senders),
             ("gather3_noc1_num_senders", gather3_noc1_num_senders),
@@ -2697,7 +2686,6 @@ class AttentionBlock:
                     page_size=tile_1x32_size,
                     tile=matmul4_out_tile_descriptor,
                 )
-                matmul5_in0_cb_grid = mcast3_core_grid.merge(gather_core_grid)
                 matmul5_in0_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     matmul5_in0_cb,
                     sdpa_kv_cache_buffer_device,
@@ -3007,12 +2995,14 @@ class AttentionBlock:
                 # ========================================================================
                 # BRISC sender: data_size_bytes, src_num_pages, rmsnorm2_output_cb (grid/semaphores reused from mcast)
                 mcast2_brisc_named_compile_time_args = [
+                    ("mcast2_data_receiver_semaphore_addr", mcast2_data_receiver_semaphore_addr),
                     ("mcast2_data_size_bytes", mcast2_data_size_bytes),
                     ("mcast2_src_num_pages", mcast2_src_num_pages),
                     ("rmsnorm2_output_cb", rmsnorm2_output_cb),  # Source CB for mcast2 sender
                 ]
                 # NCRISC receiver: dst_num_pages (semaphore reused from mcast)
                 mcast2_ncrisc_named_compile_time_args = [
+                    ("mcast2_data_receiver_semaphore_addr", mcast2_data_receiver_semaphore_addr),
                     ("mcast2_dst_num_pages", mcast2_dst_num_pages),
                 ]
 
@@ -3385,8 +3375,8 @@ class AttentionBlock:
                         other_value=0,
                     ),
                     UnifiedCompileTimeCoreDescriptor(
-                        named_compile_time_arg="is_mcast3_receiver_core",
-                        core_range=mcast3_core_grid,
+                        named_compile_time_arg="is_full_mcast_grid_core",
+                        core_range=is_full_mcast_grid_core,
                         value=1,
                         other_value=0,
                     ),

--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
@@ -163,7 +163,7 @@ class AttentionBlock:
 
     @staticmethod
     def get_num_semaphores():
-        # 14 form pre sdpa, 4 from post
+        # 14 from pre-SDPA, 4 from post
         return 18
 
     @staticmethod
@@ -536,7 +536,7 @@ class AttentionBlock:
         matmul4_cores = ttnn.corerange_to_cores(matmul4_core_grid, row_wise=True)
         gather2_sender_idx_per_core = [(core, idx) for idx, core in enumerate(matmul4_cores)]
 
-        # Gather/CCL receiver core: (12, 9)
+        # Gather/CCL receiver core: same as rmsnorm_core
         gather_core = rmsnorm_core
         gather_core_grid = rmsnorm_core_grid
 
@@ -2993,7 +2993,7 @@ class AttentionBlock:
                 # =======================================================================
                 # Mcast2 compile-time args (uses same grid and semaphores as first mcast)
                 # ========================================================================
-                # BRISC sender: data_size_bytes, src_num_pages, rmsnorm2_output_cb (grid/semaphores reused from mcast)
+                # BRISC sender: data_size_bytes, src_num_pages, rmsnorm2_output_cb (grid reused from mcast)
                 mcast2_brisc_named_compile_time_args = [
                     ("mcast2_data_receiver_semaphore_addr", mcast2_data_receiver_semaphore_addr),
                     ("mcast2_data_size_bytes", mcast2_data_size_bytes),

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
@@ -2164,7 +2164,7 @@ class PreSDPA:
 
                     # Secondary axis connection (for sender to secondary sender)
                     if has_secondary_target:
-                        secondary_coord = ttnn.MeshCoordinate(row, 1)
+                        secondary_coord = ttnn.MeshCoordinate(row, 1 - col)
                         dst_nodes.append(mesh_device.get_fabric_node_id(secondary_coord))
 
                     num_connections = len(dst_nodes)

--- a/models/demos/deepseek_v3_b1/unified_kernels/sdpa_reduce_forwarder.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/sdpa_reduce_forwarder.hpp
@@ -139,7 +139,8 @@ struct SdpaReduceForwarder {
                 r2_sent_mask = process_ready_slots(r2_sem_ptr, r2_sent_mask, r2_buffer_base, fabric_connection);
 
             } while (r1_sent_mask != CT::all_sent_mask || r2_sent_mask != CT::all_sent_mask);
-
+            noc_semaphore_set(r1_sem_ptr, 0);
+            noc_semaphore_set(r2_sem_ptr, 0);
             fabric_connection.close();
 
             noc_async_full_barrier();


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
MLA has a broadcast followed by 2 ccls. The sdpa reduce and the tp reduce don't have conflicts with each other since they operate on different axes, but they could conflict with the broadcast.

### What's changed
Update the initial mcast to have all cores wait for signal. This ensures NCRISC on those cores waited for the signal.
Add specific syncs so that BRISC waits for NCRISC to signal it's okay to connect to fabric for the sdpa and tp reduce ccls, since BRISC does not currently stall for the mcast signal.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=aho/overlap)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:aho/overlap)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aho/overlap)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/overlap)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aho/overlap)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/overlap)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aho/overlap)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/overlap)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aho/overlap)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/overlap)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aho/overlap)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/overlap)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
