### PR TITLE
all_to_all_dispatch_metadata and moe_compute linearized_mesh_coord bug fix 

### DIFF
--- a/tests/nightly/tg/ccl/moe/test_all_to_all_dispatch_metadata_6U.py
+++ b/tests/nightly/tg/ccl/moe/test_all_to_all_dispatch_metadata_6U.py
@@ -14,6 +14,7 @@ from tests.nightly.t3000.ccl.test_all_to_all_dispatch import (
     gen_tensors,
     tt_to_torch_dtype,
 )
+from tests.nightly.tg.ccl.moe.test_moe_compute_6U import gen_expert_mapping
 
 
 # Mesh graph descriptor paths for different mesh configurations
@@ -43,38 +44,6 @@ from models.perf.benchmarking_utils import BenchmarkProfiler
 from tracy import signpost
 
 
-def gen_expert_mapping_new_format_from_old(expert_mapping_old, mesh_shape):
-    """
-    Convert old format expert mapping to new format.
-
-    Old format: [1, 1, experts, devices] - one-hot encoding where expert_mapping_old[0, 0, e, d] = 1
-                means expert e is on device d.
-    New format: [devices, experts] - direct device ID lookup where expert_mapping_new[src_device, e] = d
-                means expert e is on device d (from the perspective of src_device).
-
-    For now, all devices see the same mapping (no replicated experts), so we just replicate
-    the same row for each source device.
-
-    In the future, this can be extended to support replicated experts where each device
-    sees the "optimal" device (e.g., shortest distance) for each expert.
-    """
-    devices = mesh_shape[0] * mesh_shape[1]
-    experts = expert_mapping_old.shape[2]
-
-    # Extract device assignment from one-hot encoding
-    # expert_mapping_old has shape [1, 1, experts, devices]
-    # For each expert, find which device has the 1
-    expert_mapping_new = torch.zeros(1, experts, dtype=torch.uint16)
-    for e in range(experts):
-        device_assignment = expert_mapping_old[0, 0, e, :]
-        device_id = torch.where(device_assignment == 1)[0].item()
-        expert_mapping_new[0, e] = device_id
-
-    # Replicate across all devices (same mapping for now)
-    expert_mapping_new = expert_mapping_new.repeat(devices, 1)
-    return expert_mapping_new
-
-
 def gen_tensors_for_metadata_op(
     batch,
     experts,
@@ -99,12 +68,17 @@ def gen_tensors_for_metadata_op(
         input_tokens: [batch, 1, seq_len, hidden_size] - input tokens per device
         expert_indices: [batch, 1, seq_len, selected_experts_k] - expert indices per device
         expert_scores: [batch, 1, seq_len, selected_experts_k] - expert scores per device
-        expert_mapping_old: [1, 1, experts, devices] - old format expert to device mapping (one-hot)
         expert_mapping_new: [devices, experts] - new format expert to device mapping (direct device ID)
         sparse_output_token_tensor: [devices, total_tokens, hidden_size] - golden output tokens
         metadata_tensor: [devices, total_tokens, selected_experts_k] - golden indices (all-gathered)
         scores_tensor: [devices, total_tokens, selected_experts_k] - golden scores (all-gathered)
     """
+
+    num_dispatch_devices = mesh_shape[cluster_axis] if cluster_axis is not None else devices
+    num_replicated_devices = devices // num_dispatch_devices
+    experts_per_cluster = experts // num_replicated_devices
+    experts_per_device = experts // devices
+
     # Use original gen_tensors to get base tensors
     input_tokens, expert_indices, expert_mapping_old, sparse_output_orig, metadata_orig = gen_tensors(
         batch, experts, selected_experts_k, hidden_size, seq_len, mesh_shape, devices, scheme=scheme, dtype=dtype
@@ -112,7 +86,9 @@ def gen_tensors_for_metadata_op(
 
     # Convert old format expert mapping to new format: [devices, experts] with device IDs
     # This ensures the new format matches the scheme (random vs sequential)
-    expert_mapping_new = gen_expert_mapping_new_format_from_old(expert_mapping_old, mesh_shape)
+    expert_mapping_new = gen_expert_mapping(
+        devices, num_replicated_devices, cluster_axis, experts, experts_per_cluster, experts_per_device
+    )
 
     total_tokens = batch * seq_len
 
@@ -140,7 +116,6 @@ def gen_tensors_for_metadata_op(
         input_tokens,
         expert_indices,
         expert_scores,
-        expert_mapping_old,
         expert_mapping_new,
         sparse_output_token_tensor,
         metadata_tensor,
@@ -176,11 +151,9 @@ def run_all_to_all_dispatch_metadata_test(
 
     expert_indices_tensors = []
     expert_scores_tensors = []
-    expert_mapping_tensors = []
     expert_mapping_new_tensors = []  # New format mapping tensors
     input_tensors = []
 
-    torch_expert_mappings = []
     torch_expert_mappings_new = []  # New format mappings
     torch_expert_scores_list = []
 
@@ -233,7 +206,6 @@ def run_all_to_all_dispatch_metadata_test(
             input_tokens,
             expert_indices,
             expert_scores,
-            expert_mapping_old,
             expert_mapping_new,
             sparse_output_token_tensor,
             metadata_tensor,
@@ -255,7 +227,6 @@ def run_all_to_all_dispatch_metadata_test(
             logger.info(f"input_tokens shape: {input_tokens.shape}")
             logger.info(f"expert_indices shape: {expert_indices.shape}")
             logger.info(f"expert_scores shape: {expert_scores.shape}")
-            logger.info(f"expert_mapping_old shape: {expert_mapping_old.shape}")
             logger.info(f"expert_mapping_new shape: {expert_mapping_new.shape}")
             logger.info(f"sparse_output_token_tensor shape: {sparse_output_token_tensor.shape}")
             logger.info(f"metadata_tensor shape: {metadata_tensor.shape}")
@@ -264,7 +235,6 @@ def run_all_to_all_dispatch_metadata_test(
         output_tensor_goldens_list.append(sparse_output_token_tensor)
         output_metadata_goldens_list.append(metadata_tensor)
         output_scores_goldens_list.append(scores_tensor)
-        torch_expert_mappings.append(expert_mapping_old)
         torch_expert_mappings_new.append(expert_mapping_new)
         torch_expert_scores_list.append(expert_scores)
 
@@ -297,16 +267,6 @@ def run_all_to_all_dispatch_metadata_test(
             mesh_mapper=mesh_mapper,
         )
 
-        # Old format expert mapping: [1, 1, experts, devices] - one-hot encoding
-        tt_expert_mapping = ttnn.from_torch(
-            expert_mapping_old,
-            device=mesh_device,
-            layout=ttnn.ROW_MAJOR_LAYOUT,
-            dtype=ttnn.uint16,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(None, None), mesh_shape=mesh_shape),
-        )
-
         # New format expert mapping: [devices, experts] - direct device ID lookup
         # Each entry expert_mapping_new[d, e] = device_id that owns expert e
         # Replicate across all devices so each device has the full mapping table
@@ -323,13 +283,11 @@ def run_all_to_all_dispatch_metadata_test(
             logger.info(f"tt_input shape: {tt_input.shape}")
             logger.info(f"tt_expert_indices shape: {tt_expert_indices.shape}")
             logger.info(f"tt_expert_scores shape: {tt_expert_scores.shape}")
-            logger.info(f"tt_expert_mapping (old) shape: {tt_expert_mapping.shape}")
             logger.info(f"tt_expert_mapping_new shape: {tt_expert_mapping_new.shape}")
 
         input_tensors.append(tt_input)
         expert_indices_tensors.append(tt_expert_indices)
         expert_scores_tensors.append(tt_expert_scores)
-        expert_mapping_tensors.append(tt_expert_mapping)
         expert_mapping_new_tensors.append(tt_expert_mapping_new)
 
     tt_out_tensor_list = []

--- a/tests/nightly/tg/ccl/moe/test_all_to_all_dispatch_metadata_6U.py
+++ b/tests/nightly/tg/ccl/moe/test_all_to_all_dispatch_metadata_6U.py
@@ -84,8 +84,6 @@ def gen_tensors_for_metadata_op(
         batch, experts, selected_experts_k, hidden_size, seq_len, mesh_shape, devices, scheme=scheme, dtype=dtype
     )
 
-    # Convert old format expert mapping to new format: [devices, experts] with device IDs
-    # This ensures the new format matches the scheme (random vs sequential)
     expert_mapping_new = gen_expert_mapping(
         devices, num_replicated_devices, cluster_axis, experts, experts_per_cluster, experts_per_device
     )

--- a/tests/nightly/tg/ccl/moe/test_moe_compute_6U.py
+++ b/tests/nightly/tg/ccl/moe/test_moe_compute_6U.py
@@ -562,7 +562,20 @@ def tt_to_torch_dtype(tt_dtype):
         raise ValueError(f"Invalid dtype: {tt_dtype}")
 
 
-def gen_expert_mapping(experts, mesh_shape, cluster_axis):
+def get_linearized_mesh_coord(num_replicated_devices, cluster_axis, expert_id, experts_per_cluster, experts_per_device):
+    if cluster_axis == 0:
+        cluster_id = expert_id // experts_per_cluster
+        expert_id_within_cluster = expert_id % experts_per_cluster
+        device_id_within_cluster = expert_id_within_cluster // experts_per_device
+
+        return device_id_within_cluster * num_replicated_devices + cluster_id
+    else:
+        return expert_id // experts_per_device
+
+
+def gen_expert_mapping(
+    num_devices, num_replicated_devices, cluster_axis, experts, experts_per_cluster, experts_per_device
+):
     """
     Create per-device expert mapping tensor that maps each expert to the device it belongs to.
     Shape: [num_devices, experts] where each entry is the linearized mesh coordinate of the device
@@ -577,11 +590,11 @@ def gen_expert_mapping(experts, mesh_shape, cluster_axis):
 
     This tensor is replicated on every device (even devices not along the dispatch axis).
     """
-    num_devices = mesh_shape[0] * mesh_shape[1]
-    experts_per_device = experts // num_devices
     expert_mapping = torch.zeros(1, experts, dtype=torch.uint16)
     for e in range(experts):
-        expert_mapping[0, e] = e // experts_per_device
+        expert_mapping[0, e] = get_linearized_mesh_coord(
+            num_replicated_devices, cluster_axis, e, experts_per_cluster, experts_per_device
+        )
     # Replicate across all devices (same mapping for now)
     expert_mapping = expert_mapping.repeat(num_devices, 1)
     return expert_mapping
@@ -976,7 +989,9 @@ def test_moe_compute(
 
     num_devices = mesh_shape[0] * mesh_shape[1]
     num_dispatch_devices = mesh_shape[cluster_axis] if cluster_axis is not None else num_devices
+    num_replicated_devices = num_devices // num_dispatch_devices
     total_tokens = tokens_per_device * num_dispatch_devices
+    experts_per_cluster = experts // num_replicated_devices
     experts_per_device = experts // num_devices
 
     logger.info(f"Test configuration:")
@@ -1001,7 +1016,9 @@ def test_moe_compute(
     # Each device gets its own row after sharding, but since it's replicated,
     # we give each device the full tensor and it uses its own row.
     # Expert mapping is constant across all runs.
-    expert_mapping = gen_expert_mapping(experts, mesh_shape, cluster_axis)
+    expert_mapping = gen_expert_mapping(
+        num_devices, num_replicated_devices, cluster_axis, experts, experts_per_cluster, experts_per_device
+    )
     expert_mapping_mem_config = ttnn.L1_MEMORY_CONFIG
     tt_expert_mapping = ttnn.from_torch(
         expert_mapping,

--- a/tests/nightly/tg/ccl/moe/test_moe_compute_6U.py
+++ b/tests/nightly/tg/ccl/moe/test_moe_compute_6U.py
@@ -153,25 +153,6 @@ def validate_activation(
                         )
                         activation_all_passed = False
 
-        # Validate sentinel row (token_id = -1 = 0xFFFFFFFF as uint32)
-        sentinel_row_idx = num_expected_rows
-        if sentinel_row_idx >= max_rows:
-            logger.warning(f"  Device {device_idx}: sentinel row {sentinel_row_idx} out of bounds")
-            activation_all_passed = False
-        else:
-            sentinel_row_start = sentinel_row_idx * aligned_row_elements
-            sentinel_token_id = device_activation[sentinel_row_start].item()
-            # -1 as uint32 (0xFFFFFFFF) becomes -1 when sign-extended to int64
-            is_sentinel = (sentinel_token_id == -1) or (sentinel_token_id == 0xFFFFFFFF)
-
-            if not is_sentinel:
-                logger.warning(
-                    f"  Device {device_idx}: sentinel row token_id mismatch - " f"expected -1, got {sentinel_token_id}"
-                )
-                activation_all_passed = False
-            else:
-                logger.info(f"  Device {device_idx}: {num_expected_rows} tokens validated, sentinel PASSED")
-
     return activation_all_passed
 
 

--- a/ttnn/cpp/ttnn/operations/ccl/common/kernels/moe_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/kernels/moe_utils.hpp
@@ -310,6 +310,17 @@ bool is_configured_target(uint32_t linearized_dest_mesh_coord) {
     }
 }
 
+template <uint32_t MeshRows, uint32_t MeshCols, ReplicateGroup Axis>
+uint32_t get_intra_cluster_id(uint32_t linearized_dest_mesh_coord) {
+    if constexpr (Axis == ReplicateGroup::COLS) {
+        return linearized_dest_mesh_coord / MeshCols;
+    } else if constexpr (Axis == ReplicateGroup::ROWS) {
+        return linearized_dest_mesh_coord / MeshCols;
+    } else {
+        return linearized_dest_mesh_coord;
+    }
+}
+
 template <tt::tt_fabric::Topology Topology>
 constexpr bool has_wrap_around() {
     return Topology == tt::tt_fabric::Topology::Ring || Topology == tt::tt_fabric::Topology::Torus;

--- a/ttnn/cpp/ttnn/operations/ccl/common/kernels/moe_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/kernels/moe_utils.hpp
@@ -315,7 +315,7 @@ uint32_t get_intra_cluster_id_from_linearized_mesh_coord(uint32_t linearized_des
     if constexpr (Axis == ReplicateGroup::COLS) {
         return linearized_dest_mesh_coord / MeshCols;
     } else if constexpr (Axis == ReplicateGroup::ROWS) {
-        return linearized_dest_mesh_coord / MeshCols;
+        return linearized_dest_mesh_coord % MeshCols;
     } else {
         return linearized_dest_mesh_coord;
     }

--- a/ttnn/cpp/ttnn/operations/ccl/common/kernels/moe_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/kernels/moe_utils.hpp
@@ -311,7 +311,7 @@ bool is_configured_target(uint32_t linearized_dest_mesh_coord) {
 }
 
 template <uint32_t MeshRows, uint32_t MeshCols, ReplicateGroup Axis>
-uint32_t get_intra_cluster_id(uint32_t linearized_dest_mesh_coord) {
+uint32_t get_intra_cluster_id_from_linearized_mesh_coord(uint32_t linearized_dest_mesh_coord) {
     if constexpr (Axis == ReplicateGroup::COLS) {
         return linearized_dest_mesh_coord / MeshCols;
     } else if constexpr (Axis == ReplicateGroup::ROWS) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/all_to_all_dispatch_metadata_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/all_to_all_dispatch_metadata_device_operation.cpp
@@ -14,6 +14,8 @@
 namespace ttnn::operations::experimental::ccl {
 void AllToAllDispatchMetadataDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    TT_FATAL(operation_attributes.axis.has_value(), "Cluster axis argument required");
+
     auto input_tensor = tensor_args.input_tensor;
     auto indices_tensor = tensor_args.expert_indices_tensor;
     auto scores_tensor = tensor_args.expert_scores_tensor;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/all_to_all_dispatch_metadata_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/all_to_all_dispatch_metadata_program_factory.cpp
@@ -279,6 +279,10 @@ AllToAllDispatchMetadataDeviceOperation::AllToAllDispatchMetadataSparse::create_
         operation_attributes.axis.has_value()
             ? operation_attributes.axis.value() == 0 ? mesh_view.num_rows() : mesh_view.num_cols()
             : mesh_view.num_devices();
+    uint32_t replicated_devices =
+        operation_attributes.axis.has_value()
+            ? operation_attributes.axis.value() == 0 ? mesh_view.num_cols() : mesh_view.num_rows()
+            : 1;
 
     uint32_t hidden_size = input_shape[-1];
     uint32_t batch_size = input_shape[0] * dispatch_devices;
@@ -542,6 +546,9 @@ AllToAllDispatchMetadataDeviceOperation::AllToAllDispatchMetadataSparse::create_
         0,
         linearized_mesh_coord,
 
+        dispatch_devices,
+        replicated_devices,
+
         // scores tensor args
         scores_tensor_cb_id,
         scores_pages,
@@ -558,10 +565,6 @@ AllToAllDispatchMetadataDeviceOperation::AllToAllDispatchMetadataSparse::create_
 
     const auto& writer_compile_time_args = reader_compile_time_args;
 
-    std::map<std::string, std::string> reader_defines = {
-        {"AXIS", std::to_string(operation_attributes.axis.has_value() ? operation_attributes.axis.value() : -1)},
-    };
-
     tt::tt_metal::KernelHandle ternary_reader_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/"
@@ -570,8 +573,7 @@ AllToAllDispatchMetadataDeviceOperation::AllToAllDispatchMetadataSparse::create_
         tt::tt_metal::DataMovementConfig{
             .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
             .noc = tt::tt_metal::NOC::NOC_1,
-            .compile_args = reader_compile_time_args,
-            .defines = reader_defines});
+            .compile_args = reader_compile_time_args});
 
     // Code-gen a mesh-position to fabric chip ID array for the writer kernel
     // Code-gen a mesh-position to mesh-id array for the writer kernel

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/all_to_all_dispatch_metadata_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/all_to_all_dispatch_metadata_program_factory.cpp
@@ -279,10 +279,6 @@ AllToAllDispatchMetadataDeviceOperation::AllToAllDispatchMetadataSparse::create_
         operation_attributes.axis.has_value()
             ? operation_attributes.axis.value() == 0 ? mesh_view.num_rows() : mesh_view.num_cols()
             : mesh_view.num_devices();
-    uint32_t replicated_devices =
-        operation_attributes.axis.has_value()
-            ? operation_attributes.axis.value() == 0 ? mesh_view.num_cols() : mesh_view.num_rows()
-            : 1;
 
     uint32_t hidden_size = input_shape[-1];
     uint32_t batch_size = input_shape[0] * dispatch_devices;
@@ -547,7 +543,6 @@ AllToAllDispatchMetadataDeviceOperation::AllToAllDispatchMetadataSparse::create_
         linearized_mesh_coord,
 
         dispatch_devices,
-        replicated_devices,
 
         // scores tensor args
         scores_tensor_cb_id,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/reader_all_to_all_dispatch_metadata.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/reader_all_to_all_dispatch_metadata.cpp
@@ -41,15 +41,14 @@ void kernel_main() {
     constexpr uint32_t linearized_mesh_coord = get_compile_time_arg_val(36);
 
     constexpr uint32_t dispatch_devices = get_compile_time_arg_val(37);
-    constexpr uint32_t replicated_devices = get_compile_time_arg_val(38);
 
     // scores tensor compile time args
-    constexpr uint32_t scores_tensor_cb_id = get_compile_time_arg_val(39);
-    constexpr uint32_t scores_pages = get_compile_time_arg_val(40);
-    constexpr uint32_t scores_page_size = get_compile_time_arg_val(41);
-    constexpr uint32_t aligned_scores_page_size = get_compile_time_arg_val(42);
+    constexpr uint32_t scores_tensor_cb_id = get_compile_time_arg_val(38);
+    constexpr uint32_t scores_pages = get_compile_time_arg_val(39);
+    constexpr uint32_t scores_page_size = get_compile_time_arg_val(40);
+    constexpr uint32_t aligned_scores_page_size = get_compile_time_arg_val(41);
 
-    constexpr auto input_args = TensorAccessorArgs<43>();
+    constexpr auto input_args = TensorAccessorArgs<42>();
     constexpr auto indices_args = TensorAccessorArgs<input_args.next_compile_time_args_offset()>();
     constexpr auto scores_args = TensorAccessorArgs<indices_args.next_compile_time_args_offset()>();
     constexpr auto mapping_args = TensorAccessorArgs<scores_args.next_compile_time_args_offset()>();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/reader_all_to_all_dispatch_metadata.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/reader_all_to_all_dispatch_metadata.cpp
@@ -40,29 +40,22 @@ void kernel_main() {
     constexpr bool write_page_by_page = get_compile_time_arg_val(35);
     constexpr uint32_t linearized_mesh_coord = get_compile_time_arg_val(36);
 
-    // scores tensor compile time args
-    constexpr uint32_t scores_tensor_cb_id = get_compile_time_arg_val(37);
-    constexpr uint32_t scores_pages = get_compile_time_arg_val(38);
-    constexpr uint32_t scores_page_size = get_compile_time_arg_val(39);
-    constexpr uint32_t aligned_scores_page_size = get_compile_time_arg_val(40);
+    constexpr uint32_t dispatch_devices = get_compile_time_arg_val(37);
+    constexpr uint32_t replicated_devices = get_compile_time_arg_val(38);
 
-    constexpr auto input_args = TensorAccessorArgs<41>();
+    // scores tensor compile time args
+    constexpr uint32_t scores_tensor_cb_id = get_compile_time_arg_val(39);
+    constexpr uint32_t scores_pages = get_compile_time_arg_val(40);
+    constexpr uint32_t scores_page_size = get_compile_time_arg_val(41);
+    constexpr uint32_t aligned_scores_page_size = get_compile_time_arg_val(42);
+
+    constexpr auto input_args = TensorAccessorArgs<43>();
     constexpr auto indices_args = TensorAccessorArgs<input_args.next_compile_time_args_offset()>();
     constexpr auto scores_args = TensorAccessorArgs<indices_args.next_compile_time_args_offset()>();
     constexpr auto mapping_args = TensorAccessorArgs<scores_args.next_compile_time_args_offset()>();
     constexpr auto output_args = TensorAccessorArgs<mapping_args.next_compile_time_args_offset()>();
     constexpr auto metadata_args = TensorAccessorArgs<output_args.next_compile_time_args_offset()>();
 
-#ifdef AXIS
-    constexpr ReplicateGroup axis = ReplicateGroup(AXIS);
-    constexpr uint32_t dispatch_devices = axis == ReplicateGroup::COLS ? mesh_rows : mesh_cols;
-    constexpr uint32_t dispatch_index =
-        axis == ReplicateGroup::COLS ? linearized_mesh_coord / mesh_cols : linearized_mesh_coord % mesh_cols;
-#else
-    constexpr ReplicateGroup axis = ReplicateGroup::NONE;
-    constexpr uint32_t dispatch_devices = num_devices;
-    constexpr uint32_t dispatch_index = linearized_mesh_coord;
-#endif
     uint32_t rt_ags = 0;
     uint32_t input_tensor_address = get_arg_val<uint32_t>(rt_ags++);
     uint32_t indices_tensor_address = get_arg_val<uint32_t>(rt_ags++);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/writer_all_to_all_dispatch_metadata.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/writer_all_to_all_dispatch_metadata.cpp
@@ -787,6 +787,7 @@ template <
     uint32_t MeshRows,
     uint32_t MeshCols,
     ttnn::operations::ccl::common::ReplicateGroup Axis,
+    uint32_t DispatchDevices,
     typename FabricConnectionsType>
 FORCE_INLINE void dispatch_token_bidirectional_multicast(
     FabricConnectionsType& fabric_connections,
@@ -801,7 +802,8 @@ FORCE_INLINE void dispatch_token_bidirectional_multicast(
         LinearizedSrcMeshCoord,
         MeshRows,
         MeshCols,
-        Axis>(
+        Axis,
+        DispatchDevices>(
         fabric_connections,
         packet_header_pos,
         packet_header_neg,
@@ -1066,8 +1068,9 @@ void kernel_main() {
         linearized_mesh_coord,
         mesh_rows,
         mesh_cols,
-        dispatch_devices,
-        axis>(fabric_connections, atomic_inc_packet_header_pos, atomic_inc_packet_header_neg, init_noc_semaphore_addr);
+        axis,
+        dispatch_devices>(
+        fabric_connections, atomic_inc_packet_header_pos, atomic_inc_packet_header_neg, init_noc_semaphore_addr);
     noc_async_writes_flushed();
 
     // Wait for all devices to complete initialization synchronization
@@ -1131,7 +1134,8 @@ void kernel_main() {
                 linearized_mesh_coord,
                 mesh_rows,
                 mesh_cols,
-                axis>(
+                axis,
+                dispatch_devices>(
                 fabric_connections,
                 unicast_packet_header_pos,
                 unicast_packet_header_neg,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/writer_all_to_all_dispatch_metadata.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/writer_all_to_all_dispatch_metadata.cpp
@@ -309,7 +309,7 @@ FORCE_INLINE bool dispatch_token_point_to_point_unicast(
         uint16_t target_device = expert_mapping[expert_chosen];
 
         // Check if we've already sent to this device for this token (avoid duplicate sends)
-        uint16_t intra_cluster_target_device_id =
+        uint32_t intra_cluster_target_device_id =
             get_intra_cluster_id_from_linearized_mesh_coord<MeshRows, MeshCols, Axis>(target_device);
         if (send_preparation_buffer
                 [(local_token - token_start_idx) * DispatchDevices + intra_cluster_target_device_id] == 0) {
@@ -410,7 +410,7 @@ FORCE_INLINE bool dispatch_token_sparse_multicast(
         uint16_t target_device = expert_mapping[expert_chosen];
 
         // Check if we've already processed this device for this token
-        uint16_t intra_cluster_target_device_id =
+        uint32_t intra_cluster_target_device_id =
             get_intra_cluster_id_from_linearized_mesh_coord<MeshRows, MeshCols, Axis>(target_device);
         if (send_preparation_buffer
                 [(local_token - token_start_idx) * DispatchDevices + intra_cluster_target_device_id] == 0) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/writer_all_to_all_dispatch_metadata.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/writer_all_to_all_dispatch_metadata.cpp
@@ -990,7 +990,7 @@ void kernel_main() {
 
     uint32_t send_preparation_buffer_address = get_write_ptr(send_preparation_buffer_cb_id);
     detail::zero_buffer_async(
-        send_preparation_buffer_address, (token_end_idx - token_start_idx) * dispatch_devices * sizeof(uint8_t));
+        send_preparation_buffer_address, (token_end_idx - token_start_idx) * num_devices * sizeof(uint8_t));
 
     constexpr ReplicateGroup axis = ReplicateGroup(AXIS);
     constexpr uint32_t row = linearized_mesh_coord / mesh_cols;
@@ -1143,7 +1143,7 @@ void kernel_main() {
                 mesh_cols,
                 axis,
                 fabric_max_packet_size,
-                dispatch_devices,
+                num_devices,
                 selected_experts_k>(
                 fabric_connections,
                 unicast_packet_header_neg,
@@ -1168,7 +1168,7 @@ void kernel_main() {
                 mesh_cols,
                 axis,
                 fabric_max_packet_size,
-                dispatch_devices,
+                num_devices,
                 selected_experts_k>(
                 fabric_connections,
                 unicast_packet_header_neg,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/writer_all_to_all_dispatch_metadata.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/writer_all_to_all_dispatch_metadata.cpp
@@ -266,7 +266,7 @@ FORCE_INLINE void fabric_multicast_bidirectional_scatter_write_ring_1d_async(
 //   MeshRows, MeshCols - Mesh dimensions
 //   Axis - Dispatch axis (ROWS or COLS)
 //   FabricMaxPacketSize - Maximum fabric packet size in bytes
-//   DispatchDevices - Total number of dispatch devices in a single cluster
+//   NumDevices - Total number of devices
 //   SelectedExpertsK - Number of experts selected per token
 //   OutputAddrGenT - Type of the output address generator (TensorAccessor)
 // ============================================================================
@@ -277,7 +277,7 @@ template <
     uint32_t MeshCols,
     ttnn::operations::ccl::common::ReplicateGroup Axis,
     uint32_t FabricMaxPacketSize,
-    uint32_t DispatchDevices,
+    uint32_t NumDevices,
     uint32_t SelectedExpertsK,
     typename OutputAddrGenT,
     typename FabricConnectionsType>
@@ -297,7 +297,6 @@ FORCE_INLINE bool dispatch_token_point_to_point_unicast(
     uint32_t alignment,
     uint32_t payload_offset = 0) {
     using ttnn::operations::ccl::common::fabric_send_chip_unicast_noc_unicast_1d;
-    using ttnn::operations::ccl::common::get_intra_cluster_id_from_linearized_mesh_coord;
     using ttnn::operations::ccl::common::is_configured_target;
 
     bool needs_barrier = false;
@@ -309,12 +308,9 @@ FORCE_INLINE bool dispatch_token_point_to_point_unicast(
         uint16_t target_device = expert_mapping[expert_chosen];
 
         // Check if we've already sent to this device for this token (avoid duplicate sends)
-        uint32_t intra_cluster_target_device_id =
-            get_intra_cluster_id_from_linearized_mesh_coord<MeshRows, MeshCols, Axis>(target_device);
-        if (send_preparation_buffer
-                [(local_token - token_start_idx) * DispatchDevices + intra_cluster_target_device_id] == 0) {
-            send_preparation_buffer
-                [(local_token - token_start_idx) * DispatchDevices + intra_cluster_target_device_id] = 1;
+        if (send_preparation_buffer[(local_token - token_start_idx) * NumDevices + intra_cluster_target_device_id] ==
+            0) {
+            send_preparation_buffer[(local_token - token_start_idx) * NumDevices + intra_cluster_target_device_id] = 1;
 
             if (target_device == LinearizedSrcMeshCoord) {
                 // If the expert lives on the current device, we dispatch the input token to it
@@ -364,7 +360,7 @@ FORCE_INLINE bool dispatch_token_point_to_point_unicast(
 //   MeshRows, MeshCols - Mesh dimensions
 //   Axis - Dispatch axis (ROWS or COLS)
 //   FabricMaxPacketSize - Maximum fabric packet size in bytes
-//   DispatchDevices - Total number of dispatch devices in a single cluster
+//   NumDevices - Total number of devices
 //   SelectedExpertsK - Number of experts selected per token
 //   OutputAddrGenT - Type of the output address generator (TensorAccessor)
 // ============================================================================
@@ -375,7 +371,7 @@ template <
     uint32_t MeshCols,
     ttnn::operations::ccl::common::ReplicateGroup Axis,
     uint32_t FabricMaxPacketSize,
-    uint32_t DispatchDevices,
+    uint32_t NumDevices,
     uint32_t SelectedExpertsK,
     typename OutputAddrGenT,
     typename FabricConnectionsType>
@@ -395,13 +391,12 @@ FORCE_INLINE bool dispatch_token_sparse_multicast(
     uint32_t alignment,
     uint32_t payload_offset = 0) {
     using ttnn::operations::ccl::common::fabric_send_chip_sparse_multicast_noc_unicast_1d;
-    using ttnn::operations::ccl::common::get_intra_cluster_id_from_linearized_mesh_coord;
     using ttnn::operations::ccl::common::is_configured_target;
 
     bool needs_barrier = false;
 
     // Collect all unique remote destinations for this token
-    uint32_t remote_token_destinations[DispatchDevices];
+    uint32_t remote_token_destinations[NumDevices];
     uint32_t num_remote_token_destinations = 0;
 
     for (uint32_t k = 0; k < SelectedExpertsK; k++) {
@@ -410,12 +405,9 @@ FORCE_INLINE bool dispatch_token_sparse_multicast(
         uint16_t target_device = expert_mapping[expert_chosen];
 
         // Check if we've already processed this device for this token
-        uint32_t intra_cluster_target_device_id =
-            get_intra_cluster_id_from_linearized_mesh_coord<MeshRows, MeshCols, Axis>(target_device);
-        if (send_preparation_buffer
-                [(local_token - token_start_idx) * DispatchDevices + intra_cluster_target_device_id] == 0) {
-            send_preparation_buffer
-                [(local_token - token_start_idx) * DispatchDevices + intra_cluster_target_device_id] = 1;
+        if (send_preparation_buffer[(local_token - token_start_idx) * NumDevices + intra_cluster_target_device_id] ==
+            0) {
+            send_preparation_buffer[(local_token - token_start_idx) * NumDevices + intra_cluster_target_device_id] = 1;
 
             if (target_device == LinearizedSrcMeshCoord) {
                 // If the expert lives on the current device, dispatch locally
@@ -435,7 +427,7 @@ FORCE_INLINE bool dispatch_token_sparse_multicast(
             Topology,
             MeshRows,
             MeshCols,
-            DispatchDevices,
+            NumDevices,
             FabricMaxPacketSize>(
             output_addr_gen,
             fabric_connections,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/writer_all_to_all_dispatch_metadata.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/writer_all_to_all_dispatch_metadata.cpp
@@ -297,7 +297,7 @@ FORCE_INLINE bool dispatch_token_point_to_point_unicast(
     uint32_t alignment,
     uint32_t payload_offset = 0) {
     using ttnn::operations::ccl::common::fabric_send_chip_unicast_noc_unicast_1d;
-    using ttnn::operations::ccl::common::get_intra_cluster_id;
+    using ttnn::operations::ccl::common::get_intra_cluster_id_from_linearized_mesh_coord;
     using ttnn::operations::ccl::common::is_configured_target;
 
     bool needs_barrier = false;
@@ -309,7 +309,8 @@ FORCE_INLINE bool dispatch_token_point_to_point_unicast(
         uint16_t target_device = expert_mapping[expert_chosen];
 
         // Check if we've already sent to this device for this token (avoid duplicate sends)
-        uint16_t intra_cluster_target_device = get_intra_cluster_id<MeshRows, MeshCols, Axis>(target_device);
+        uint16_t intra_cluster_target_device =
+            get_intra_cluster_id_from_linearized_mesh_coord<MeshRows, MeshCols, Axis>(target_device);
         if (send_preparation_buffer[(local_token - token_start_idx) * DispatchDevices + intra_cluster_target_device] ==
             0) {
             send_preparation_buffer[(local_token - token_start_idx) * DispatchDevices + intra_cluster_target_device] =
@@ -394,7 +395,7 @@ FORCE_INLINE bool dispatch_token_sparse_multicast(
     uint32_t alignment,
     uint32_t payload_offset = 0) {
     using ttnn::operations::ccl::common::fabric_send_chip_sparse_multicast_noc_unicast_1d;
-    using ttnn::operations::ccl::common::get_intra_cluster_id;
+    using ttnn::operations::ccl::common::get_intra_cluster_id_from_linearized_mesh_coord;
     using ttnn::operations::ccl::common::is_configured_target;
 
     bool needs_barrier = false;
@@ -409,7 +410,8 @@ FORCE_INLINE bool dispatch_token_sparse_multicast(
         uint16_t target_device = expert_mapping[expert_chosen];
 
         // Check if we've already processed this device for this token
-        uint16_t intra_cluster_target_device = get_intra_cluster_id<MeshRows, MeshCols, Axis>(target_device);
+        uint16_t intra_cluster_target_device =
+            get_intra_cluster_id_from_linearized_mesh_coord<MeshRows, MeshCols, Axis>(target_device);
         if (send_preparation_buffer[(local_token - token_start_idx) * DispatchDevices + intra_cluster_target_device] ==
             0) {
             send_preparation_buffer[(local_token - token_start_idx) * DispatchDevices + intra_cluster_target_device] =
@@ -503,7 +505,7 @@ FORCE_INLINE bool dispatch_token_sparse_multicast_bidirectional(
     uint32_t alignment,
     uint32_t payload_offset = 0) {
     using ttnn::operations::ccl::common::fabric_send_chip_sparse_multicast_noc_unicast_1d_in_direction;
-    using ttnn::operations::ccl::common::get_intra_cluster_id;
+    using ttnn::operations::ccl::common::get_intra_cluster_id_from_linearized_mesh_coord;
     using ttnn::operations::ccl::common::is_configured_target;
     using ttnn::operations::ccl::common::Polarity;
 
@@ -531,8 +533,10 @@ FORCE_INLINE bool dispatch_token_sparse_multicast_bidirectional(
             // pos_distance: going EAST/SOUTH (ascending, with wrap)
             // neg_distance: going WEST/NORTH (descending, with wrap)
 
-            uint16_t intra_cluster_target_device = get_intra_cluster_id<MeshRows, MeshCols, Axis>(target_device);
-            uint16_t intra_cluster_src_device = get_intra_cluster_id<MeshRows, MeshCols, Axis>(LinearizedSrcMeshCoord);
+            uint16_t intra_cluster_target_device =
+                get_intra_cluster_id_from_linearized_mesh_coord<MeshRows, MeshCols, Axis>(target_device);
+            uint16_t intra_cluster_src_device =
+                get_intra_cluster_id_from_linearized_mesh_coord<MeshRows, MeshCols, Axis>(LinearizedSrcMeshCoord);
 
             uint32_t pos_distance =
                 (intra_cluster_target_device - intra_cluster_src_device + DispatchDevices) % DispatchDevices;
@@ -654,7 +658,7 @@ FORCE_INLINE bool dispatch_token_split_bandwidth(
     ttnn::operations::ccl::common::Polarity first_half_polarity,
     uint32_t alignment) {
     using ttnn::operations::ccl::common::fabric_send_chip_sparse_multicast_noc_unicast_1d_in_direction;
-    using ttnn::operations::ccl::common::get_intra_cluster_id;
+    using ttnn::operations::ccl::common::get_intra_cluster_id_from_linearized_mesh_coord;
     using ttnn::operations::ccl::common::is_configured_target;
     using ttnn::operations::ccl::common::Polarity;
 
@@ -689,8 +693,10 @@ FORCE_INLINE bool dispatch_token_split_bandwidth(
             // Remote device on our axis - add to BOTH masks (same dest, different directions)
             // OR handles dedup: if bit already set, setting again is harmless
 
-            uint16_t intra_cluster_target_device = get_intra_cluster_id<MeshRows, MeshCols, Axis>(target_device);
-            uint16_t intra_cluster_src_device = get_intra_cluster_id<MeshRows, MeshCols, Axis>(LinearizedSrcMeshCoord);
+            uint16_t intra_cluster_target_device =
+                get_intra_cluster_id_from_linearized_mesh_coord<MeshRows, MeshCols, Axis>(target_device);
+            uint16_t intra_cluster_src_device =
+                get_intra_cluster_id_from_linearized_mesh_coord<MeshRows, MeshCols, Axis>(LinearizedSrcMeshCoord);
 
             uint32_t pos_distance =
                 (intra_cluster_target_device - intra_cluster_src_device + DispatchDevices) % DispatchDevices;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/writer_all_to_all_dispatch_metadata.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/writer_all_to_all_dispatch_metadata.cpp
@@ -863,15 +863,14 @@ void kernel_main() {
     constexpr uint32_t linearized_mesh_coord = get_compile_time_arg_val(36);
 
     constexpr uint32_t dispatch_devices = get_compile_time_arg_val(37);
-    constexpr uint32_t replicated_devices = get_compile_time_arg_val(38);
 
     // scores tensor compile time args
-    constexpr uint32_t scores_tensor_cb_id = get_compile_time_arg_val(39);
-    constexpr uint32_t scores_pages = get_compile_time_arg_val(40);
-    constexpr uint32_t scores_page_size = get_compile_time_arg_val(41);
-    constexpr uint32_t aligned_scores_page_size = get_compile_time_arg_val(42);
+    constexpr uint32_t scores_tensor_cb_id = get_compile_time_arg_val(38);
+    constexpr uint32_t scores_pages = get_compile_time_arg_val(39);
+    constexpr uint32_t scores_page_size = get_compile_time_arg_val(40);
+    constexpr uint32_t aligned_scores_page_size = get_compile_time_arg_val(41);
 
-    constexpr auto input_args = TensorAccessorArgs<43>();
+    constexpr auto input_args = TensorAccessorArgs<42>();
     constexpr auto indices_args = TensorAccessorArgs<input_args.next_compile_time_args_offset()>();
     constexpr auto scores_args = TensorAccessorArgs<indices_args.next_compile_time_args_offset()>();
     constexpr auto mapping_args = TensorAccessorArgs<scores_args.next_compile_time_args_offset()>();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/writer_all_to_all_dispatch_metadata.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/writer_all_to_all_dispatch_metadata.cpp
@@ -309,12 +309,12 @@ FORCE_INLINE bool dispatch_token_point_to_point_unicast(
         uint16_t target_device = expert_mapping[expert_chosen];
 
         // Check if we've already sent to this device for this token (avoid duplicate sends)
-        uint16_t intra_cluster_target_device =
+        uint16_t intra_cluster_target_device_id =
             get_intra_cluster_id_from_linearized_mesh_coord<MeshRows, MeshCols, Axis>(target_device);
-        if (send_preparation_buffer[(local_token - token_start_idx) * DispatchDevices + intra_cluster_target_device] ==
-            0) {
-            send_preparation_buffer[(local_token - token_start_idx) * DispatchDevices + intra_cluster_target_device] =
-                1;
+        if (send_preparation_buffer
+                [(local_token - token_start_idx) * DispatchDevices + intra_cluster_target_device_id] == 0) {
+            send_preparation_buffer
+                [(local_token - token_start_idx) * DispatchDevices + intra_cluster_target_device_id] = 1;
 
             if (target_device == LinearizedSrcMeshCoord) {
                 // If the expert lives on the current device, we dispatch the input token to it
@@ -410,12 +410,12 @@ FORCE_INLINE bool dispatch_token_sparse_multicast(
         uint16_t target_device = expert_mapping[expert_chosen];
 
         // Check if we've already processed this device for this token
-        uint16_t intra_cluster_target_device =
+        uint16_t intra_cluster_target_device_id =
             get_intra_cluster_id_from_linearized_mesh_coord<MeshRows, MeshCols, Axis>(target_device);
-        if (send_preparation_buffer[(local_token - token_start_idx) * DispatchDevices + intra_cluster_target_device] ==
-            0) {
-            send_preparation_buffer[(local_token - token_start_idx) * DispatchDevices + intra_cluster_target_device] =
-                1;
+        if (send_preparation_buffer
+                [(local_token - token_start_idx) * DispatchDevices + intra_cluster_target_device_id] == 0) {
+            send_preparation_buffer
+                [(local_token - token_start_idx) * DispatchDevices + intra_cluster_target_device_id] = 1;
 
             if (target_device == LinearizedSrcMeshCoord) {
                 // If the expert lives on the current device, dispatch locally
@@ -517,6 +517,9 @@ FORCE_INLINE bool dispatch_token_sparse_multicast_bidirectional(
     uint16_t neg_hop_mask = 0;  // WEST (negative direction)
     bool sent_local = false;
 
+    uint32_t intra_cluster_src_device_id =
+        get_intra_cluster_id_from_linearized_mesh_coord<MeshRows, MeshCols, Axis>(LinearizedSrcMeshCoord);
+
     for (uint32_t k = 0; k < SelectedExpertsK; k++) {
         uint16_t expert_chosen = token_indices[k];
         uint16_t target_device = expert_mapping[expert_chosen];
@@ -533,15 +536,13 @@ FORCE_INLINE bool dispatch_token_sparse_multicast_bidirectional(
             // pos_distance: going EAST/SOUTH (ascending, with wrap)
             // neg_distance: going WEST/NORTH (descending, with wrap)
 
-            uint16_t intra_cluster_target_device =
+            uint32_t intra_cluster_target_device_id =
                 get_intra_cluster_id_from_linearized_mesh_coord<MeshRows, MeshCols, Axis>(target_device);
-            uint16_t intra_cluster_src_device =
-                get_intra_cluster_id_from_linearized_mesh_coord<MeshRows, MeshCols, Axis>(LinearizedSrcMeshCoord);
 
             uint32_t pos_distance =
-                (intra_cluster_target_device - intra_cluster_src_device + DispatchDevices) % DispatchDevices;
+                (intra_cluster_target_device_id - intra_cluster_src_device_id + DispatchDevices) % DispatchDevices;
             uint32_t neg_distance =
-                (intra_cluster_src_device - intra_cluster_target_device + DispatchDevices) % DispatchDevices;
+                (intra_cluster_src_device_id - intra_cluster_target_device_id + DispatchDevices) % DispatchDevices;
             // Determine shortest path direction
             if (pos_distance < neg_distance) {
                 // Shorter via positive direction (EAST/SOUTH)
@@ -678,6 +679,9 @@ FORCE_INLINE bool dispatch_token_split_bandwidth(
     uint16_t neg_hop_mask = 0;
     bool sent_local = false;
 
+    uint32_t intra_cluster_src_device_id =
+        get_intra_cluster_id_from_linearized_mesh_coord<MeshRows, MeshCols, Axis>(LinearizedSrcMeshCoord);
+
     for (uint32_t k = 0; k < SelectedExpertsK; k++) {
         uint16_t expert_chosen = token_indices[k];
         uint16_t target_device = expert_mapping[expert_chosen];
@@ -693,15 +697,13 @@ FORCE_INLINE bool dispatch_token_split_bandwidth(
             // Remote device on our axis - add to BOTH masks (same dest, different directions)
             // OR handles dedup: if bit already set, setting again is harmless
 
-            uint16_t intra_cluster_target_device =
+            uint32_t intra_cluster_target_device_id =
                 get_intra_cluster_id_from_linearized_mesh_coord<MeshRows, MeshCols, Axis>(target_device);
-            uint16_t intra_cluster_src_device =
-                get_intra_cluster_id_from_linearized_mesh_coord<MeshRows, MeshCols, Axis>(LinearizedSrcMeshCoord);
 
             uint32_t pos_distance =
-                (intra_cluster_target_device - intra_cluster_src_device + DispatchDevices) % DispatchDevices;
+                (intra_cluster_target_device_id - intra_cluster_src_device_id + DispatchDevices) % DispatchDevices;
             uint32_t neg_distance =
-                (intra_cluster_src_device - intra_cluster_target_device + DispatchDevices) % DispatchDevices;
+                (intra_cluster_src_device_id - intra_cluster_target_device_id + DispatchDevices) % DispatchDevices;
 
             // Add to both masks - each destination reachable from both directions
             pos_hop_mask |= (1 << (pos_distance - 1));

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/writer_all_to_all_dispatch_metadata.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/writer_all_to_all_dispatch_metadata.cpp
@@ -308,9 +308,8 @@ FORCE_INLINE bool dispatch_token_point_to_point_unicast(
         uint16_t target_device = expert_mapping[expert_chosen];
 
         // Check if we've already sent to this device for this token (avoid duplicate sends)
-        if (send_preparation_buffer[(local_token - token_start_idx) * NumDevices + intra_cluster_target_device_id] ==
-            0) {
-            send_preparation_buffer[(local_token - token_start_idx) * NumDevices + intra_cluster_target_device_id] = 1;
+        if (send_preparation_buffer[(local_token - token_start_idx) * NumDevices + target_device] == 0) {
+            send_preparation_buffer[(local_token - token_start_idx) * NumDevices + target_device] = 1;
 
             if (target_device == LinearizedSrcMeshCoord) {
                 // If the expert lives on the current device, we dispatch the input token to it
@@ -405,9 +404,8 @@ FORCE_INLINE bool dispatch_token_sparse_multicast(
         uint16_t target_device = expert_mapping[expert_chosen];
 
         // Check if we've already processed this device for this token
-        if (send_preparation_buffer[(local_token - token_start_idx) * NumDevices + intra_cluster_target_device_id] ==
-            0) {
-            send_preparation_buffer[(local_token - token_start_idx) * NumDevices + intra_cluster_target_device_id] = 1;
+        if (send_preparation_buffer[(local_token - token_start_idx) * NumDevices + target_device] == 0) {
+            send_preparation_buffer[(local_token - token_start_idx) * NumDevices + target_device] = 1;
 
             if (target_device == LinearizedSrcMeshCoord) {
                 // If the expert lives on the current device, dispatch locally

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/writer_all_to_all_dispatch_metadata.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/writer_all_to_all_dispatch_metadata.cpp
@@ -51,6 +51,7 @@ template <
     uint32_t MeshRows,
     uint32_t MeshCols,
     ttnn::operations::ccl::common::ReplicateGroup Axis,
+    uint32_t DispatchDevices,
     bool DoubleAntipodalAtomicInc = false,
     typename FabricConnectionsType>
 FORCE_INLINE void fabric_multicast_bidirectional_atomic_inc_ring_1d(
@@ -61,19 +62,13 @@ FORCE_INLINE void fabric_multicast_bidirectional_atomic_inc_ring_1d(
     using ttnn::operations::ccl::common::ReplicateGroup;
     const auto cmd_header = tt::tt_fabric::NocUnicastAtomicIncCommandHeader{semaphore_noc_addr, 1, true};
 
-    // ReplicateGroup::COLS (axis=0): targets on same column, dispatch vertically (SOUTH/NORTH),
-    // dispatch_devices=MeshRows ReplicateGroup::ROWS (axis=1): targets on same row, dispatch horizontally (EAST/WEST),
-    // dispatch_devices=MeshCols
-    constexpr uint32_t dispatch_devices =
-        Axis == ttnn::operations::ccl::common::ReplicateGroup::COLS ? MeshRows : MeshCols;
-
     // Split the ring: positive direction gets half, negative direction gets the other half
     // For dispatch_devices = 16: positive gets 8, negative gets 7 (total 15 = dispatch_devices - 1) if
     // DoubleAntipodalAtomicInc is false For dispatch_devices = 16: positive gets 8, negative gets 8 (total 16 =
     // dispatch_devices) if DoubleAntipodalAtomicInc is true
-    constexpr uint32_t positive_range = DoubleAntipodalAtomicInc ? (dispatch_devices + 1) / 2 : dispatch_devices / 2;
+    constexpr uint32_t positive_range = DoubleAntipodalAtomicInc ? (DispatchDevices + 1) / 2 : DispatchDevices / 2;
     constexpr uint32_t negative_range =
-        DoubleAntipodalAtomicInc ? dispatch_devices - positive_range : (dispatch_devices - 1) - positive_range;
+        DoubleAntipodalAtomicInc ? DispatchDevices - positive_range : (DispatchDevices - 1) - positive_range;
 
     // Determine directions based on axis:
     // COLS (axis=0): dispatch along column → SOUTH is positive, NORTH is negative
@@ -112,6 +107,7 @@ template <
     uint32_t MeshRows,
     uint32_t MeshCols,
     ttnn::operations::ccl::common::ReplicateGroup Axis,
+    uint32_t DispatchDevices,
     typename FabricConnectionsType>
 FORCE_INLINE void fabric_multicast_bidirectional_write_ring_1d_async(
     FabricConnectionsType& fabric_connections,
@@ -123,15 +119,10 @@ FORCE_INLINE void fabric_multicast_bidirectional_write_ring_1d_async(
     uint32_t alignment) {
     using ttnn::operations::ccl::common::ReplicateGroup;
 
-    // ReplicateGroup::COLS (axis=0): targets on same column, dispatch vertically (SOUTH/NORTH),
-    // dispatch_devices=MeshRows ReplicateGroup::ROWS (axis=1): targets on same row, dispatch horizontally (EAST/WEST),
-    // dispatch_devices=MeshCols
-    constexpr uint32_t dispatch_devices = Axis == ReplicateGroup::COLS ? MeshRows : MeshCols;
-
     // Split the ring: positive direction gets half, negative direction gets the other half
     // For dispatch_devices = 16: positive gets 8, negative gets 7 (total 15 = dispatch_devices - 1)
-    constexpr uint32_t positive_range = dispatch_devices / 2;
-    constexpr uint32_t negative_range = (dispatch_devices - 1) - positive_range;
+    constexpr uint32_t positive_range = DispatchDevices / 2;
+    constexpr uint32_t negative_range = (DispatchDevices - 1) - positive_range;
 
     constexpr uint32_t positive_direction =
         Axis == ReplicateGroup::COLS ? eth_chan_directions::SOUTH : eth_chan_directions::EAST;
@@ -200,6 +191,7 @@ template <
     uint32_t MeshRows,
     uint32_t MeshCols,
     ttnn::operations::ccl::common::ReplicateGroup Axis,
+    uint32_t DispatchDevices,
     typename FabricConnectionsType>
 FORCE_INLINE void fabric_multicast_bidirectional_scatter_write_ring_1d_async(
     FabricConnectionsType& fabric_connections,
@@ -210,15 +202,10 @@ FORCE_INLINE void fabric_multicast_bidirectional_scatter_write_ring_1d_async(
     const std::array<uint16_t, 2>& chunk_sizes) {
     using ttnn::operations::ccl::common::ReplicateGroup;
 
-    // ReplicateGroup::COLS (axis=0): targets on same column, dispatch vertically (SOUTH/NORTH),
-    // dispatch_devices=MeshRows ReplicateGroup::ROWS (axis=1): targets on same row, dispatch horizontally (EAST/WEST),
-    // dispatch_devices=MeshCols
-    constexpr uint32_t dispatch_devices = Axis == ReplicateGroup::COLS ? MeshRows : MeshCols;
-
     // Split the ring: positive direction gets half, negative direction gets the other half
     // For dispatch_devices = 16: positive gets 8, negative gets 7 (total 15 = dispatch_devices - 1)
-    constexpr uint32_t positive_range = dispatch_devices / 2;
-    constexpr uint32_t negative_range = (dispatch_devices - 1) - positive_range;
+    constexpr uint32_t positive_range = DispatchDevices / 2;
+    constexpr uint32_t negative_range = (DispatchDevices - 1) - positive_range;
 
     constexpr uint32_t positive_direction =
         Axis == ReplicateGroup::COLS ? eth_chan_directions::SOUTH : eth_chan_directions::EAST;
@@ -279,7 +266,7 @@ FORCE_INLINE void fabric_multicast_bidirectional_scatter_write_ring_1d_async(
 //   MeshRows, MeshCols - Mesh dimensions
 //   Axis - Dispatch axis (ROWS or COLS)
 //   FabricMaxPacketSize - Maximum fabric packet size in bytes
-//   NumDevices - Total number of devices
+//   DispatchDevices - Total number of dispatch devices in a single cluster
 //   SelectedExpertsK - Number of experts selected per token
 //   OutputAddrGenT - Type of the output address generator (TensorAccessor)
 // ============================================================================
@@ -290,7 +277,7 @@ template <
     uint32_t MeshCols,
     ttnn::operations::ccl::common::ReplicateGroup Axis,
     uint32_t FabricMaxPacketSize,
-    uint32_t NumDevices,
+    uint32_t DispatchDevices,
     uint32_t SelectedExpertsK,
     typename OutputAddrGenT,
     typename FabricConnectionsType>
@@ -310,6 +297,7 @@ FORCE_INLINE bool dispatch_token_point_to_point_unicast(
     uint32_t alignment,
     uint32_t payload_offset = 0) {
     using ttnn::operations::ccl::common::fabric_send_chip_unicast_noc_unicast_1d;
+    using ttnn::operations::ccl::common::get_intra_cluster_id;
     using ttnn::operations::ccl::common::is_configured_target;
 
     bool needs_barrier = false;
@@ -321,8 +309,11 @@ FORCE_INLINE bool dispatch_token_point_to_point_unicast(
         uint16_t target_device = expert_mapping[expert_chosen];
 
         // Check if we've already sent to this device for this token (avoid duplicate sends)
-        if (send_preparation_buffer[(local_token - token_start_idx) * NumDevices + target_device] == 0) {
-            send_preparation_buffer[(local_token - token_start_idx) * NumDevices + target_device] = 1;
+        uint16_t intra_cluster_target_device = get_intra_cluster_id<MeshRows, MeshCols, Axis>(target_device);
+        if (send_preparation_buffer[(local_token - token_start_idx) * DispatchDevices + intra_cluster_target_device] ==
+            0) {
+            send_preparation_buffer[(local_token - token_start_idx) * DispatchDevices + intra_cluster_target_device] =
+                1;
 
             if (target_device == LinearizedSrcMeshCoord) {
                 // If the expert lives on the current device, we dispatch the input token to it
@@ -372,7 +363,7 @@ FORCE_INLINE bool dispatch_token_point_to_point_unicast(
 //   MeshRows, MeshCols - Mesh dimensions
 //   Axis - Dispatch axis (ROWS or COLS)
 //   FabricMaxPacketSize - Maximum fabric packet size in bytes
-//   NumDevices - Total number of devices
+//   DispatchDevices - Total number of dispatch devices in a single cluster
 //   SelectedExpertsK - Number of experts selected per token
 //   OutputAddrGenT - Type of the output address generator (TensorAccessor)
 // ============================================================================
@@ -383,7 +374,7 @@ template <
     uint32_t MeshCols,
     ttnn::operations::ccl::common::ReplicateGroup Axis,
     uint32_t FabricMaxPacketSize,
-    uint32_t NumDevices,
+    uint32_t DispatchDevices,
     uint32_t SelectedExpertsK,
     typename OutputAddrGenT,
     typename FabricConnectionsType>
@@ -403,12 +394,13 @@ FORCE_INLINE bool dispatch_token_sparse_multicast(
     uint32_t alignment,
     uint32_t payload_offset = 0) {
     using ttnn::operations::ccl::common::fabric_send_chip_sparse_multicast_noc_unicast_1d;
+    using ttnn::operations::ccl::common::get_intra_cluster_id;
     using ttnn::operations::ccl::common::is_configured_target;
 
     bool needs_barrier = false;
 
     // Collect all unique remote destinations for this token
-    uint32_t remote_token_destinations[NumDevices];
+    uint32_t remote_token_destinations[DispatchDevices];
     uint32_t num_remote_token_destinations = 0;
 
     for (uint32_t k = 0; k < SelectedExpertsK; k++) {
@@ -417,8 +409,11 @@ FORCE_INLINE bool dispatch_token_sparse_multicast(
         uint16_t target_device = expert_mapping[expert_chosen];
 
         // Check if we've already processed this device for this token
-        if (send_preparation_buffer[(local_token - token_start_idx) * NumDevices + target_device] == 0) {
-            send_preparation_buffer[(local_token - token_start_idx) * NumDevices + target_device] = 1;
+        uint16_t intra_cluster_target_device = get_intra_cluster_id<MeshRows, MeshCols, Axis>(target_device);
+        if (send_preparation_buffer[(local_token - token_start_idx) * DispatchDevices + intra_cluster_target_device] ==
+            0) {
+            send_preparation_buffer[(local_token - token_start_idx) * DispatchDevices + intra_cluster_target_device] =
+                1;
 
             if (target_device == LinearizedSrcMeshCoord) {
                 // If the expert lives on the current device, dispatch locally
@@ -438,7 +433,7 @@ FORCE_INLINE bool dispatch_token_sparse_multicast(
             Topology,
             MeshRows,
             MeshCols,
-            NumDevices,
+            DispatchDevices,
             FabricMaxPacketSize>(
             output_addr_gen,
             fabric_connections,
@@ -478,7 +473,7 @@ FORCE_INLINE bool dispatch_token_sparse_multicast(
 //   MeshRows, MeshCols - Mesh dimensions
 //   Axis - Dispatch axis (ROWS or COLS)
 //   FabricMaxPacketSize - Maximum fabric packet size in bytes
-//   NumDevices - Total number of devices
+//   DispatchDevices - Total number of dispatch devices in a single cluster
 //   SelectedExpertsK - Number of experts selected per token
 //   OutputAddrGenT - Type of the output address generator (TensorAccessor)
 // ============================================================================
@@ -489,7 +484,7 @@ template <
     uint32_t MeshCols,
     ttnn::operations::ccl::common::ReplicateGroup Axis,
     uint32_t FabricMaxPacketSize,
-    uint32_t NumDevices,
+    uint32_t DispatchDevices,
     uint32_t SelectedExpertsK,
     typename OutputAddrGenT,
     typename FabricConnectionsType>
@@ -508,6 +503,7 @@ FORCE_INLINE bool dispatch_token_sparse_multicast_bidirectional(
     uint32_t alignment,
     uint32_t payload_offset = 0) {
     using ttnn::operations::ccl::common::fabric_send_chip_sparse_multicast_noc_unicast_1d_in_direction;
+    using ttnn::operations::ccl::common::get_intra_cluster_id;
     using ttnn::operations::ccl::common::is_configured_target;
     using ttnn::operations::ccl::common::Polarity;
 
@@ -534,8 +530,14 @@ FORCE_INLINE bool dispatch_token_sparse_multicast_bidirectional(
             // Remote device on our axis - calculate distance in both directions
             // pos_distance: going EAST/SOUTH (ascending, with wrap)
             // neg_distance: going WEST/NORTH (descending, with wrap)
-            uint32_t pos_distance = (target_device - LinearizedSrcMeshCoord + NumDevices) % NumDevices;
-            uint32_t neg_distance = (LinearizedSrcMeshCoord - target_device + NumDevices) % NumDevices;
+
+            uint16_t intra_cluster_target_device = get_intra_cluster_id<MeshRows, MeshCols, Axis>(target_device);
+            uint16_t intra_cluster_src_device = get_intra_cluster_id<MeshRows, MeshCols, Axis>(LinearizedSrcMeshCoord);
+
+            uint32_t pos_distance =
+                (intra_cluster_target_device - intra_cluster_src_device + DispatchDevices) % DispatchDevices;
+            uint32_t neg_distance =
+                (intra_cluster_src_device - intra_cluster_target_device + DispatchDevices) % DispatchDevices;
             // Determine shortest path direction
             if (pos_distance < neg_distance) {
                 // Shorter via positive direction (EAST/SOUTH)
@@ -624,7 +626,7 @@ FORCE_INLINE bool dispatch_token_sparse_multicast_bidirectional(
 //   MeshRows, MeshCols - Mesh dimensions
 //   Axis - Dispatch axis (ROWS or COLS)
 //   FabricMaxPacketSize - Maximum fabric packet size in bytes
-//   NumDevices - Total number of devices
+//   DispatchDevices - Total number of dispatch devices in a single cluster
 //   SelectedExpertsK - Number of experts selected per token
 //   OutputAddrGenT - Type of the output address generator (TensorAccessor)
 // ============================================================================
@@ -634,7 +636,7 @@ template <
     uint32_t MeshCols,
     ttnn::operations::ccl::common::ReplicateGroup Axis,
     uint32_t FabricMaxPacketSize,
-    uint32_t NumDevices,
+    uint32_t DispatchDevices,
     uint32_t SelectedExpertsK,
     typename OutputAddrGenT,
     typename FabricConnectionsType>
@@ -652,6 +654,7 @@ FORCE_INLINE bool dispatch_token_split_bandwidth(
     ttnn::operations::ccl::common::Polarity first_half_polarity,
     uint32_t alignment) {
     using ttnn::operations::ccl::common::fabric_send_chip_sparse_multicast_noc_unicast_1d_in_direction;
+    using ttnn::operations::ccl::common::get_intra_cluster_id;
     using ttnn::operations::ccl::common::is_configured_target;
     using ttnn::operations::ccl::common::Polarity;
 
@@ -686,10 +689,13 @@ FORCE_INLINE bool dispatch_token_split_bandwidth(
             // Remote device on our axis - add to BOTH masks (same dest, different directions)
             // OR handles dedup: if bit already set, setting again is harmless
 
-            // Calculate distance in positive direction (e.g., EAST/SOUTH)
-            uint32_t pos_distance = (target_device - LinearizedSrcMeshCoord + NumDevices) % NumDevices;
-            // Calculate distance in negative direction (e.g., WEST/NORTH)
-            uint32_t neg_distance = (LinearizedSrcMeshCoord - target_device + NumDevices) % NumDevices;
+            uint16_t intra_cluster_target_device = get_intra_cluster_id<MeshRows, MeshCols, Axis>(target_device);
+            uint16_t intra_cluster_src_device = get_intra_cluster_id<MeshRows, MeshCols, Axis>(LinearizedSrcMeshCoord);
+
+            uint32_t pos_distance =
+                (intra_cluster_target_device - intra_cluster_src_device + DispatchDevices) % DispatchDevices;
+            uint32_t neg_distance =
+                (intra_cluster_src_device - intra_cluster_target_device + DispatchDevices) % DispatchDevices;
 
             // Add to both masks - each destination reachable from both directions
             pos_hop_mask |= (1 << (pos_distance - 1));
@@ -848,13 +854,16 @@ void kernel_main() {
     constexpr uint32_t write_page_by_page = get_compile_time_arg_val(35);
     constexpr uint32_t linearized_mesh_coord = get_compile_time_arg_val(36);
 
-    // scores tensor compile time args
-    constexpr uint32_t scores_tensor_cb_id = get_compile_time_arg_val(37);
-    constexpr uint32_t scores_pages = get_compile_time_arg_val(38);
-    constexpr uint32_t scores_page_size = get_compile_time_arg_val(39);
-    constexpr uint32_t aligned_scores_page_size = get_compile_time_arg_val(40);
+    constexpr uint32_t dispatch_devices = get_compile_time_arg_val(37);
+    constexpr uint32_t replicated_devices = get_compile_time_arg_val(38);
 
-    constexpr auto input_args = TensorAccessorArgs<41>();
+    // scores tensor compile time args
+    constexpr uint32_t scores_tensor_cb_id = get_compile_time_arg_val(39);
+    constexpr uint32_t scores_pages = get_compile_time_arg_val(40);
+    constexpr uint32_t scores_page_size = get_compile_time_arg_val(41);
+    constexpr uint32_t aligned_scores_page_size = get_compile_time_arg_val(42);
+
+    constexpr auto input_args = TensorAccessorArgs<43>();
     constexpr auto indices_args = TensorAccessorArgs<input_args.next_compile_time_args_offset()>();
     constexpr auto scores_args = TensorAccessorArgs<indices_args.next_compile_time_args_offset()>();
     constexpr auto mapping_args = TensorAccessorArgs<scores_args.next_compile_time_args_offset()>();
@@ -982,10 +991,9 @@ void kernel_main() {
 
     uint32_t send_preparation_buffer_address = get_write_ptr(send_preparation_buffer_cb_id);
     detail::zero_buffer_async(
-        send_preparation_buffer_address, (token_end_idx - token_start_idx) * num_devices * sizeof(uint8_t));
+        send_preparation_buffer_address, (token_end_idx - token_start_idx) * dispatch_devices * sizeof(uint8_t));
 
     constexpr ReplicateGroup axis = ReplicateGroup(AXIS);
-    constexpr uint32_t dispatch_devices = axis == ReplicateGroup::COLS ? mesh_rows : mesh_cols;
     constexpr uint32_t row = linearized_mesh_coord / mesh_cols;
     constexpr uint32_t col = linearized_mesh_coord % mesh_cols;
 
@@ -1048,8 +1056,12 @@ void kernel_main() {
     // - The cross_device_semaphore is double-buffered externally to avoid races between iterations
 #ifndef SKIP_INIT_SEMAPHORE
     const uint64_t init_noc_semaphore_addr = get_noc_addr(init_semaphore_address);
-    detail::fabric_multicast_bidirectional_atomic_inc_ring_1d<linearized_mesh_coord, mesh_rows, mesh_cols, axis>(
-        fabric_connections, atomic_inc_packet_header_pos, atomic_inc_packet_header_neg, init_noc_semaphore_addr);
+    detail::fabric_multicast_bidirectional_atomic_inc_ring_1d<
+        linearized_mesh_coord,
+        mesh_rows,
+        mesh_cols,
+        dispatch_devices,
+        axis>(fabric_connections, atomic_inc_packet_header_pos, atomic_inc_packet_header_neg, init_noc_semaphore_addr);
     noc_async_writes_flushed();
 
     // Wait for all devices to complete initialization synchronization
@@ -1130,7 +1142,7 @@ void kernel_main() {
                 mesh_cols,
                 axis,
                 fabric_max_packet_size,
-                num_devices,
+                dispatch_devices,
                 selected_experts_k>(
                 fabric_connections,
                 unicast_packet_header_neg,
@@ -1155,7 +1167,7 @@ void kernel_main() {
                 mesh_cols,
                 axis,
                 fabric_max_packet_size,
-                num_devices,
+                dispatch_devices,
                 selected_experts_k>(
                 fabric_connections,
                 unicast_packet_header_neg,
@@ -1181,7 +1193,7 @@ void kernel_main() {
                 mesh_cols,
                 axis,
                 fabric_max_packet_size,
-                num_devices,
+                dispatch_devices,
                 selected_experts_k>(
                 fabric_connections,
                 unicast_packet_header_pos,
@@ -1209,7 +1221,7 @@ void kernel_main() {
                 mesh_cols,
                 axis,
                 fabric_max_packet_size,
-                num_devices,
+                dispatch_devices,
                 selected_experts_k>(
                 fabric_connections,
                 unicast_packet_header_pos,
@@ -1281,7 +1293,8 @@ void kernel_main() {
             linearized_mesh_coord,
             mesh_rows,
             mesh_cols,
-            axis>(
+            axis,
+            dispatch_devices>(
             fabric_connections,
             metadata_packet_header_pos,
             metadata_packet_header_neg,
@@ -1291,12 +1304,17 @@ void kernel_main() {
         cb_pop_front(metadata_buffer_id, tokens_per_device);
         // Use DoubleAntipodalAtomicInc=true to increment semaphore on all devices including twice on the antipodal
         // device
-        detail::
-            fabric_multicast_bidirectional_atomic_inc_ring_1d<linearized_mesh_coord, mesh_rows, mesh_cols, axis, true>(
-                fabric_connections,
-                atomic_inc_packet_header_pos,
-                atomic_inc_packet_header_neg,
-                global_noc_semaphore_address);
+        detail::fabric_multicast_bidirectional_atomic_inc_ring_1d<
+            linearized_mesh_coord,
+            mesh_rows,
+            mesh_cols,
+            axis,
+            dispatch_devices,
+            true>(
+            fabric_connections,
+            atomic_inc_packet_header_pos,
+            atomic_inc_packet_header_neg,
+            global_noc_semaphore_address);
     }
 
     cb_pop_front(mapping_tensor_cb_id, mapping_pages);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp
@@ -730,14 +730,8 @@ void kernel_main() {
         cb_push_back(total_chunks_cb_id, one_page);
 
         // ========== Write expert_activation buffer to DRAM ==========
-        // Write activated rows + sentinel row (with -1 in token_id) to DRAM
-        // Cap off expert_activation buffer with sentinel row
-        uint32_t* sentinel_row_ptr =
-            reinterpret_cast<uint32_t*>(expert_activation_base + num_activated_tokens * aligned_activation_row_bytes);
-        sentinel_row_ptr[0] = static_cast<uint32_t>(-1);  // token_id = -1 indicates end
-
-        // Write to DRAM: activated rows + sentinel = (num_activated_tokens + 1) rows
-        uint32_t expert_activation_write_size = (num_activated_tokens + 1) * aligned_activation_row_bytes;
+        // Write to DRAM: activated rows (num_activated_tokens) rows
+        uint32_t expert_activation_write_size = num_activated_tokens * aligned_activation_row_bytes;
         uint64_t expert_activation_dram_addr = get_noc_addr(0, expert_activation_output_tensor_addr_gen);
         noc_async_write(expert_activation_base, expert_activation_dram_addr, expert_activation_write_size);
         // Barrier for this write is at the very end of the kernel

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation.cpp
@@ -72,7 +72,7 @@ MoEComputeDeviceOperation::spec_return_value_t MoEComputeDeviceOperation::comput
     // Total size: (tokens + 1) * aligned_row_bytes for sentinel row, stored as single DRAM page
     uint32_t activation_row_elements = (2 * experts_per_device) + 1;
     uint32_t activation_row_bytes = tt::align(activation_row_elements * sizeof(uint32_t), l1_alignment);
-    uint32_t activation_total_bytes = (total_tokens + 1) * activation_row_bytes;  // +1 to account for sentinel row
+    uint32_t activation_total_bytes = total_tokens * activation_row_bytes;
     auto tilize_expert_activation_shape = ttnn::Shape({1, activation_total_bytes / sizeof(uint32_t)});
     auto tilize_expert_activation_spec = TensorSpec(
         Shape(tilize_expert_activation_shape),

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation.cpp
@@ -69,7 +69,7 @@ MoEComputeDeviceOperation::spec_return_value_t MoEComputeDeviceOperation::comput
     // Output 1: Expert activation tensor
     // Each row: [token_id, k_indices[experts_per_device], scores[experts_per_device]]
     // Row size in uint32_t elements: 2 * experts_per_device + 1
-    // Total size: (tokens + 1) * aligned_row_bytes for sentinel row, stored as single DRAM page
+    // Total size: total_tokens * aligned_row_bytes, stored as a single DRAM page
     uint32_t activation_row_elements = (2 * experts_per_device) + 1;
     uint32_t activation_row_bytes = tt::align(activation_row_elements * sizeof(uint32_t), l1_alignment);
     uint32_t activation_total_bytes = total_tokens * activation_row_bytes;


### PR DESCRIPTION
### What's changed
- Dispatch and compute used multi-device APIs that expected `linearized_mesh_coords`
- However the target device id extracted from the expert mapping tensor were "cluster major ids" (i.e. assume we iterate through devices one cluster at a time)
- Fix was to change the expert mapping tensor to be in terms of `linearized_mesh_coords`
- This subsequently meant we also had to fix some device distance calculations in dispatch
- Note that this bug only appears when running tests with multiple clusters
- Auxiliary change one: 
  - `moe_compute` was adding a `-1` sentinel value at the end of the `expert_activation` metadata tensor it produced
  - this value is not needed by combine, so it was removed
- Auxiliary change two:
  - Added a fatal to dispatch requiring a cluster axis argument be provided (was previously optional), as the kernel logic breaks without a cluster axis
  - Can revisit properly supporting the op when no cluster axis is provided at a later date



Tests:
- Tested all dispatch algs manually on 6U on both cluster axises
- Tested all dispatch algs manually with the E2E test on quad

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=grechsteiner/linearized_mesh_coord_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:grechsteiner/linearized_mesh_coord_fix)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=grechsteiner/linearized_mesh_coord_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:grechsteiner/linearized_mesh_coord_fix)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=grechsteiner/linearized_mesh_coord_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:grechsteiner/linearized_mesh_coord_fix)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=grechsteiner/linearized_mesh_coord_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:grechsteiner/linearized_mesh_coord_fix)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=grechsteiner/linearized_mesh_coord_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:grechsteiner/linearized_mesh_coord_fix)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=grechsteiner/linearized_mesh_coord_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:grechsteiner/linearized_mesh_coord_fix)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
