### PR TITLE
LoRA support for SDXL

### DIFF
--- a/.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
+++ b/.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
@@ -69,7 +69,7 @@ jobs:
             {"model":"retinanet"},
             {"model":"ufld_v2"},
             {"model":"ttt-mistral-7B-v0.3"},
-            {"model":"stable_diffusion_xl_base","timeout":75},
+            {"model":"stable_diffusion_xl_base","timeout": 100},
             {"model":"stable_diffusion","timeout":45}
           ]'
 

--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -237,6 +237,7 @@ jobs:
           device_perf_model_name: "stable_diffusion_xl"
           commands: |
             ${{ matrix.test-info.arch == 'wormhole_b0' && 'pytest models/demos/stable_diffusion_xl_base/tests/test_sdxl_perf.py -m models_device_performance_bare_metal' || '' }}
+            ${{ matrix.test-info.arch == 'wormhole_b0' && 'pytest models/demos/stable_diffusion_xl_base/lora/tests/test_lora_perf.py -m models_device_performance_bare_metal' || '' }}
         if: ${{ !cancelled() && matrix.test-info.civ2-compatible && (matrix.test-info.job-set1 || matrix.test-info.job-blackhole-set1) && fromJSON(needs.define-models.outputs.models-to-run)['stable-diffusion-xl'] }}
         timeout-minutes: ${{ matrix.test-info.timeout }}
 

--- a/.github/workflows/tt-metal-l2-nightly-impl.yaml
+++ b/.github/workflows/tt-metal-l2-nightly-impl.yaml
@@ -500,6 +500,7 @@ jobs:
         run: |
           pytest models/demos/stable_diffusion_xl_base/tests/pcc/test_unet_loop.py --loop-iter-num=50 -xv -m "not disable_fast_runtime_mode" --timeout=${{ env.TEST_BUDGET_SECONDS }}
           pytest models/demos/stable_diffusion_xl_base/refiner/tests/pcc/test_unet_loop.py --loop-iter-num=50 -xv -m "not disable_fast_runtime_mode" --timeout=${{ env.TEST_BUDGET_SECONDS }}
+          pytest models/demos/stable_diffusion_xl_base/lora/tests/test_lora_rollback.py -xv -m "not disable_fast_runtime_mode" --timeout=${{ env.TEST_BUDGET_SECONDS }}
       - name: ttnn nightly sdxl demo cfg parallel test (N300 only)
         if: ${{ inputs.runner-label == 'N300' }}
         timeout-minutes: ${{ inputs.timeout }}

--- a/models/demos/stable_diffusion_xl_base/conftest.py
+++ b/models/demos/stable_diffusion_xl_base/conftest.py
@@ -1,9 +1,13 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
+from pathlib import Path
+
 import pytest
+from loguru import logger
 
 from conftest import is_galaxy
+from models.demos.stable_diffusion_xl_base.lora.config import TEST_LORA_FILENAME, TEST_LORA_REPO_ID
 
 
 def pytest_configure(config):
@@ -49,6 +53,24 @@ def pytest_addoption(parser):
         action="store_true",
         default=False,
         help="Run SDXL in debug mode (default: False)",
+    )
+    parser.addoption(
+        "--lora-weights",
+        action="store",
+        default=None,
+        help="Full path to a local .safetensors file with LoRA weights. Overrides --lora-hf-repo and --lora-hf-filename",
+    )
+    parser.addoption(
+        "--lora-hf-repo",
+        action="store",
+        default=None,
+        help="Hugging Face repo id for LoRA (e.g. 'user/repo'). Required together with --lora-hf-filename",
+    )
+    parser.addoption(
+        "--lora-hf-filename",
+        action="store",
+        default=None,
+        help="Filename in the Hugging Face repo (e.g. 'lora.safetensors'). Required together with --lora-hf-repo",
     )
 
 
@@ -135,3 +157,54 @@ def validate_fabric_compatibility(request):
             requested_devices = total_devices
 
         assert requested_devices == total_devices, "Requested devices must be equal to total devices"
+
+
+def _resolve_local_lora_file_path(path_input):
+    if not path_input or not path_input.strip():
+        return None
+    resolved_path = Path(path_input).expanduser().resolve()
+    if not resolved_path.exists() or not resolved_path.is_file():
+        return None
+    return str(resolved_path)
+
+
+@pytest.fixture(scope="function")
+def lora_path(request, is_ci_env, is_ci_v2_env):
+    """
+    Resolve LoRA weights path.
+    1) --lora-weights: full path to a local .safetensors file.
+    2) --lora-hf-repo and --lora-hf-filename: download from Hugging Face.
+    3) If nothing provided: use default weights (HF download).
+    """
+    lora_weights_cli_path = request.config.getoption("--lora-weights", default=None)
+    hf_repo_id = request.config.getoption("--lora-hf-repo", default=None)
+    hf_filename = request.config.getoption("--lora-hf-filename", default=None)
+
+    # Local file path via --lora-weights
+    if lora_weights_cli_path is not None and str(lora_weights_cli_path).strip():
+        resolved_lora_path = _resolve_local_lora_file_path(lora_weights_cli_path)
+        if resolved_lora_path:
+            return resolved_lora_path
+        pytest.skip(
+            f"LoRA path must be an existing .safetensors file: {lora_weights_cli_path}. "
+            f"Provide a full path to the file (not a directory)."
+        )
+
+    if not (hf_repo_id and hf_filename):
+        logger.warning(
+            f"No LoRA weights provided. Using default weights. Repo: {TEST_LORA_REPO_ID}, File: {TEST_LORA_FILENAME}"
+        )
+        hf_repo_id = TEST_LORA_REPO_ID
+        hf_filename = TEST_LORA_FILENAME
+
+    try:
+        from huggingface_hub import hf_hub_download
+
+        return hf_hub_download(
+            repo_id=hf_repo_id, filename=hf_filename, local_files_only=is_ci_env and not is_ci_v2_env
+        )
+    except Exception as _:
+        pytest.skip(
+            f"LoRA weights not available from HF ({hf_repo_id}, {hf_filename}). "
+            f"Use --lora-weights for a local file path, or ensure network/cache for HF."
+        )

--- a/models/demos/stable_diffusion_xl_base/conftest.py
+++ b/models/demos/stable_diffusion_xl_base/conftest.py
@@ -189,6 +189,7 @@ def lora_path(request, is_ci_env, is_ci_v2_env):
             f"LoRA path must be an existing .safetensors file: {lora_weights_cli_path}. "
             f"Provide a full path to the file (not a directory)."
         )
+        return
 
     if not (hf_repo_id and hf_filename):
         logger.warning(
@@ -208,3 +209,4 @@ def lora_path(request, is_ci_env, is_ci_v2_env):
             f"LoRA weights not available from HF ({hf_repo_id}, {hf_filename}). "
             f"Use --lora-weights for a local file path, or ensure network/cache for HF."
         )
+        return

--- a/models/demos/stable_diffusion_xl_base/demo/demo_lora.py
+++ b/models/demos/stable_diffusion_xl_base/demo/demo_lora.py
@@ -1,28 +1,29 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
 
+import os
+
 import pytest
-import ttnn
 import torch
 from diffusers import DiffusionPipeline
 from loguru import logger
-from transformers import CLIPTextModelWithProjection, CLIPTextModel
+from transformers import CLIPTextModel, CLIPTextModelWithProjection
+
+import ttnn
+from conftest import is_galaxy
+from models.common.utility_functions import profiler
 from models.demos.stable_diffusion_xl_base.tests.test_common import (
+    CONCATENATED_TEXT_EMBEDINGS_SIZE,
+    MAX_SEQUENCE_LENGTH,
+    SDXL_FABRIC_CONFIG,
     SDXL_L1_SMALL_SIZE,
     SDXL_TRACE_REGION_SIZE,
-    SDXL_FABRIC_CONFIG,
-    MAX_SEQUENCE_LENGTH,
     TEXT_ENCODER_2_PROJECTION_DIM,
-    CONCATENATED_TEXT_EMBEDINGS_SIZE,
     determinate_min_batch_size,
     prepare_device,
 )
-import os
-from models.common.utility_functions import profiler
-from conftest import is_galaxy
-
 from models.demos.stable_diffusion_xl_base.tt.tt_sdxl_pipeline import TtSDXLPipeline, TtSDXLPipelineConfig
 
 

--- a/models/demos/stable_diffusion_xl_base/demo/demo_lora.py
+++ b/models/demos/stable_diffusion_xl_base/demo/demo_lora.py
@@ -1,0 +1,350 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+import pytest
+import ttnn
+import torch
+from diffusers import DiffusionPipeline
+from loguru import logger
+from transformers import CLIPTextModelWithProjection, CLIPTextModel
+from models.demos.stable_diffusion_xl_base.tests.test_common import (
+    SDXL_L1_SMALL_SIZE,
+    SDXL_TRACE_REGION_SIZE,
+    SDXL_FABRIC_CONFIG,
+    MAX_SEQUENCE_LENGTH,
+    TEXT_ENCODER_2_PROJECTION_DIM,
+    CONCATENATED_TEXT_EMBEDINGS_SIZE,
+    determinate_min_batch_size,
+    prepare_device,
+)
+import os
+from models.common.utility_functions import profiler
+from conftest import is_galaxy
+
+from models.demos.stable_diffusion_xl_base.tt.tt_sdxl_pipeline import TtSDXLPipeline, TtSDXLPipelineConfig
+
+
+@torch.no_grad()
+def run_demo_inference(
+    ttnn_device,
+    is_ci_env,
+    image_resolution,
+    prompts,
+    negative_prompts,
+    num_inference_steps,
+    vae_on_device,
+    encoders_on_device,
+    evaluation_range,
+    capture_trace,
+    guidance_scale,
+    use_cfg_parallel,
+    fixed_seed_for_batch,
+    prompt_2=None,
+    negative_prompt_2=None,
+    crop_coords_top_left=(0, 0),
+    guidance_rescale=0.0,
+    timesteps=None,
+    sigmas=None,
+    lora_path=None,
+):
+    batch_size = determinate_min_batch_size(ttnn_device, use_cfg_parallel)
+
+    start_from, _ = evaluation_range
+
+    assert 0.0 <= guidance_rescale <= 1.0, f"guidance_rescale must be in [0.0, 1.0], got {guidance_rescale}"
+
+    assert not (timesteps is not None and sigmas is not None), "Cannot pass both timesteps and sigmas. Choose one."
+
+    if isinstance(prompts, str):
+        prompts = [prompts]
+
+    if prompt_2 is not None and isinstance(prompt_2, str):
+        prompt_2 = [prompt_2]
+
+    needed_padding = (batch_size - len(prompts) % batch_size) % batch_size
+    if isinstance(negative_prompts, list):
+        assert len(negative_prompts) == len(prompts), "prompts and negative_prompt lists must be the same length"
+
+    prompts = prompts + [""] * needed_padding
+    if prompt_2 is not None:
+        prompt_2 = prompt_2 + [""] * needed_padding
+    if isinstance(negative_prompts, list):
+        negative_prompts = negative_prompts + [""] * needed_padding
+
+    # 1. Load components
+    profiler.start("diffusion_pipeline_from_pretrained")
+    pipeline = DiffusionPipeline.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0",
+        torch_dtype=torch.float32,
+        use_safetensors=True,
+        local_files_only=is_ci_env,
+    )
+    profiler.end("diffusion_pipeline_from_pretrained")
+
+    assert isinstance(pipeline.text_encoder, CLIPTextModel), "pipeline.text_encoder is not a CLIPTextModel"
+    assert isinstance(
+        pipeline.text_encoder_2, CLIPTextModelWithProjection
+    ), "pipeline.text_encoder_2 is not a CLIPTextModelWithProjection"
+
+    tt_sdxl = TtSDXLPipeline(
+        ttnn_device=ttnn_device,
+        torch_pipeline=pipeline,
+        pipeline_config=TtSDXLPipelineConfig(
+            image_resolution=image_resolution,
+            capture_trace=capture_trace,
+            vae_on_device=vae_on_device,
+            encoders_on_device=encoders_on_device,
+            num_inference_steps=num_inference_steps,
+            guidance_scale=guidance_scale,
+            is_galaxy=is_galaxy(),
+            use_cfg_parallel=use_cfg_parallel,
+            crop_coords_top_left=crop_coords_top_left,
+            guidance_rescale=guidance_rescale,
+        ),
+    )
+
+    ttnn.synchronize_device(ttnn_device)
+
+    if encoders_on_device:
+        tt_sdxl.compile_text_encoding()
+
+    tt_latents, tt_prompt_embeds, tt_add_text_embeds = tt_sdxl.generate_input_tensors(
+        all_prompt_embeds_torch=torch.randn(batch_size, 2, MAX_SEQUENCE_LENGTH, CONCATENATED_TEXT_EMBEDINGS_SIZE),
+        torch_add_text_embeds=torch.randn(batch_size, 2, TEXT_ENCODER_2_PROJECTION_DIM),
+        timesteps=timesteps,
+        sigmas=sigmas,
+    )
+
+    tt_sdxl.compile_image_processing()
+
+    profiler.start("load_lora_weights")
+    tt_sdxl.load_lora_weights(lora_path)
+    profiler.end("load_lora_weights")
+
+    profiler.start("fuse_lora")
+    tt_sdxl.fuse_lora()
+    profiler.end("fuse_lora")
+
+    logger.info("=" * 80)
+    for key, data in profiler.times.items():
+        logger.info(f"{key}: {data[-1]:.2f} seconds")
+    logger.info("=" * 80)
+
+    profiler.clear()
+
+    if not is_ci_env and not os.path.exists("output"):
+        os.mkdir("output")
+
+    images = []
+    logger.info("Starting ttnn inference...")
+    for iter in range(len(prompts) // batch_size):
+        logger.info(
+            f"Running inference for prompts {iter * batch_size + 1}-{iter * batch_size + batch_size}/{len(prompts)}"
+        )
+
+        prompts_batch = prompts[iter * batch_size : (iter + 1) * batch_size]
+        negative_prompts_batch = (
+            negative_prompts[iter * batch_size : (iter + 1) * batch_size]
+            if isinstance(negative_prompts, list)
+            else negative_prompts
+        )
+
+        prompts_2_batch = (
+            prompt_2[iter * batch_size : (iter + 1) * batch_size] if isinstance(prompt_2, list) else prompt_2
+        )
+        negative_prompts_2_batch = (
+            negative_prompt_2[iter * batch_size : (iter + 1) * batch_size]
+            if isinstance(negative_prompt_2, list)
+            else negative_prompt_2
+        )
+
+        profiler.start("end_to_end_generation")
+        (
+            all_prompt_embeds_torch,
+            torch_add_text_embeds,
+        ) = tt_sdxl.encode_prompts(prompts_batch, negative_prompts_batch, prompts_2_batch, negative_prompts_2_batch)
+
+        tt_latents, tt_prompt_embeds, tt_add_text_embeds = tt_sdxl.generate_input_tensors(
+            all_prompt_embeds_torch,
+            torch_add_text_embeds,
+            start_latent_seed=0,
+            fixed_seed_for_batch=fixed_seed_for_batch,
+            timesteps=timesteps,
+            sigmas=sigmas,
+        )
+
+        tt_sdxl.prepare_input_tensors(
+            [
+                tt_latents,
+                tt_prompt_embeds[0],
+                tt_add_text_embeds[0],
+            ]
+        )
+
+        imgs = tt_sdxl.generate_images()
+        profiler.end("end_to_end_generation")
+
+        logger.info(
+            f"Prepare input tensors for {batch_size} prompts completed in {profiler.times['prepare_input_tensors'][-1]:.2f} seconds"
+        )
+        logger.info(
+            f"Image gen for {batch_size} prompts completed in {profiler.times['end_to_end_generation'][-1]:.2f} seconds"
+        )
+
+        logger.info(
+            f"Denoising loop for {batch_size} prompts completed in {profiler.times['denoising_loop'][-1]:.2f} seconds"
+        )
+        logger.info(
+            f"{'On device VAE' if vae_on_device else 'Host VAE'} decoding completed in {profiler.times['vae_decode'][-1]:.2f} seconds"
+        )
+        logger.info(f"Output tensor read completed in {profiler.times['read_output_tensor'][-1]:.2f} seconds")
+
+        for idx, img in enumerate(imgs):
+            if iter == len(prompts) // batch_size - 1 and idx >= batch_size - needed_padding:
+                break
+            img = img.unsqueeze(0)
+            img = pipeline.image_processor.postprocess(img, output_type="pil")[0]
+            images.append(img)
+            skip_saving = os.getenv("TT_SDXL_SKIP_CHECK_AND_SAVE", "0") == "1"
+            if is_ci_env or skip_saving:
+                logger.info(f"Image {len(images)}/{len(prompts) // batch_size} generated successfully")
+            else:
+                img.save(f"output/output{len(images) + start_from}.png")
+                logger.info(f"Image saved to output/output{len(images) + start_from}.png")
+
+    tt_sdxl.unload_lora_weights()
+
+    return images
+
+
+@pytest.mark.parametrize(
+    "image_resolution",
+    [
+        (1024, 1024),
+        (512, 512),
+    ],
+    ids=["1024x1024", "512x512"],
+)
+# Note: The 'fabric_config' parameter is only required when running with cfg_parallel enabled,
+# as the all_gather_async operation used in this mode depends on fabric being set.
+@pytest.mark.parametrize(
+    "device_params, use_cfg_parallel",
+    [
+        (
+            {
+                "l1_small_size": SDXL_L1_SMALL_SIZE,
+                "trace_region_size": SDXL_TRACE_REGION_SIZE,
+                "fabric_config": SDXL_FABRIC_CONFIG,
+            },
+            True,
+        ),
+        (
+            {
+                "l1_small_size": SDXL_L1_SMALL_SIZE,
+                "trace_region_size": SDXL_TRACE_REGION_SIZE,
+            },
+            False,
+        ),
+    ],
+    indirect=["device_params"],
+    ids=["use_cfg_parallel", "no_cfg_parallel"],
+)
+@pytest.mark.parametrize(
+    "fixed_seed_for_batch",
+    (False,),
+)
+@pytest.mark.parametrize(
+    "prompt",
+    (("A Coloring Book of an astronaut riding a green horse"),),
+)
+@pytest.mark.parametrize(
+    "negative_prompt",
+    (["disturbing"],),
+)
+@pytest.mark.parametrize(
+    "num_inference_steps",
+    ((50),),
+)
+@pytest.mark.parametrize(
+    "guidance_scale",
+    ((5.0),),
+)
+@pytest.mark.parametrize(
+    "vae_on_device",
+    [
+        (True),
+        (False),
+    ],
+    ids=("device_vae", "host_vae"),
+)
+@pytest.mark.parametrize(
+    "encoders_on_device",
+    [
+        (True),
+        (False),
+    ],
+    ids=("device_encoders", "host_encoders"),
+)
+@pytest.mark.parametrize(
+    "capture_trace",
+    [
+        (True),
+        (False),
+    ],
+    ids=("with_trace", "no_trace"),
+)
+@pytest.mark.parametrize(
+    "prompt_2, negative_prompt_2, crop_coords_top_left, guidance_rescale, timesteps, sigmas",
+    [
+        (None, None, (0, 0), 0.0, None, None),
+    ],
+    ids=["default_additional_parameters"],
+)
+def test_demo(
+    validate_fabric_compatibility,
+    mesh_device,
+    is_ci_env,
+    image_resolution,
+    prompt,
+    negative_prompt,
+    num_inference_steps,
+    vae_on_device,
+    encoders_on_device,
+    capture_trace,
+    evaluation_range,
+    guidance_scale,
+    use_cfg_parallel,
+    fixed_seed_for_batch,
+    prompt_2,
+    negative_prompt_2,
+    crop_coords_top_left,
+    guidance_rescale,
+    timesteps,
+    sigmas,
+    lora_path,
+):
+    prepare_device(mesh_device, use_cfg_parallel)
+    return run_demo_inference(
+        mesh_device,
+        is_ci_env,
+        image_resolution,
+        prompt,
+        negative_prompt,
+        num_inference_steps,
+        vae_on_device,
+        encoders_on_device,
+        evaluation_range,
+        capture_trace,
+        guidance_scale,
+        use_cfg_parallel,
+        fixed_seed_for_batch,
+        prompt_2,
+        negative_prompt_2,
+        crop_coords_top_left,
+        guidance_rescale,
+        timesteps,
+        sigmas,
+        lora_path,
+    )

--- a/models/demos/stable_diffusion_xl_base/lora/config.py
+++ b/models/demos/stable_diffusion_xl_base/lora/config.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/models/demos/stable_diffusion_xl_base/lora/config.py
+++ b/models/demos/stable_diffusion_xl_base/lora/config.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+
+# Default LoRA weights
+TEST_LORA_REPO_ID = "artificialguybr/ColoringBookRedmond-V2"
+TEST_LORA_FILENAME = "ColoringBookRedmond-ColoringBook-ColoringBookAF.safetensors"

--- a/models/demos/stable_diffusion_xl_base/lora/tests/pcc/test_lora_tt_attention.py
+++ b/models/demos/stable_diffusion_xl_base/lora/tests/pcc/test_lora_tt_attention.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/models/demos/stable_diffusion_xl_base/lora/tests/pcc/test_lora_tt_attention.py
+++ b/models/demos/stable_diffusion_xl_base/lora/tests/pcc/test_lora_tt_attention.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import gc
+
+import pytest
+import torch
+from diffusers import DiffusionPipeline
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import torch_random
+from models.demos.stable_diffusion_xl_base.lora.tt_lora_weights_manager import TtLoRAWeightsManager
+from models.demos.stable_diffusion_xl_base.tests.test_common import SDXL_L1_SMALL_SIZE
+from models.demos.stable_diffusion_xl_base.tt.model_configs import load_model_optimisations
+from models.demos.stable_diffusion_xl_base.tt.tt_attention import TtAttention
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+def _get_diffusers_pipeline(is_ci_env):
+    pipeline = DiffusionPipeline.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0",
+        torch_dtype=torch.float32,
+        use_safetensors=True,
+        local_files_only=is_ci_env,
+    )
+    return pipeline
+
+
+@pytest.mark.parametrize(
+    "image_resolution, input_shape, encoder_shape, attn_id, down_block_id, query_dim, num_attn_heads, out_dim, pcc",
+    [
+        ((1024, 1024), (1, 4096, 640), None, 1, 1, 640, 10, 640, 0.999),
+        ((1024, 1024), (1, 4096, 640), (1, 77, 2048), 2, 1, 640, 10, 640, 0.999),
+        ((1024, 1024), (1, 1024, 1280), None, 1, 2, 1280, 20, 1280, 0.999),
+        ((1024, 1024), (1, 1024, 1280), (1, 77, 2048), 2, 2, 1280, 20, 1280, 0.999),
+        ((512, 512), (1, 1024, 640), None, 1, 1, 640, 10, 640, 0.999),
+        ((512, 512), (1, 1024, 640), (1, 77, 2048), 2, 1, 640, 10, 640, 0.999),
+        ((512, 512), (1, 256, 1280), None, 1, 2, 1280, 20, 1280, 0.999),
+        ((512, 512), (1, 256, 1280), (1, 77, 2048), 2, 2, 1280, 20, 1280, 0.999),
+    ],
+)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
+def test_attention(
+    device,
+    image_resolution,
+    input_shape,
+    encoder_shape,
+    attn_id,
+    down_block_id,
+    query_dim,
+    num_attn_heads,
+    out_dim,
+    pcc,
+    is_ci_env,
+    reset_seeds,
+    lora_path,
+):
+    pipeline = _get_diffusers_pipeline(is_ci_env)
+    pipeline.unet.eval()
+
+    pipeline_for_tt = _get_diffusers_pipeline(is_ci_env)
+    state_dict = pipeline_for_tt.unet.state_dict()
+
+    lora_mgr = TtLoRAWeightsManager(device, pipeline_for_tt)
+    module_path = f"down_blocks.{down_block_id}.attentions.0.transformer_blocks.0.attn{attn_id}"
+    tt_attention = TtAttention(
+        device,
+        state_dict,
+        module_path,
+        load_model_optimisations(image_resolution),
+        query_dim,
+        num_attn_heads,
+        out_dim,
+        lora_weights_manager=lora_mgr,
+    )
+
+    lora_mgr.load_lora_weights(lora_path)
+    lora_mgr.fuse_lora(lora_scale=1.0)
+    pipeline.load_lora_weights(lora_path)
+    pipeline.fuse_lora(lora_scale=1.0)
+
+    if attn_id == 1:
+        torch_attention = pipeline.unet.down_blocks[down_block_id].attentions[0].transformer_blocks[0].attn1
+    else:
+        torch_attention = pipeline.unet.down_blocks[down_block_id].attentions[0].transformer_blocks[0].attn2
+
+    torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)
+    torch_encoder_tensor = (
+        torch_random(encoder_shape, -0.1, 0.1, dtype=torch.float32) if encoder_shape is not None else None
+    )
+    torch_output_tensor = torch_attention(torch_input_tensor, torch_encoder_tensor).unsqueeze(0)
+
+    ttnn_input_tensor = ttnn.from_torch(
+        torch_input_tensor.unsqueeze(0),
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    ttnn_encoder_tensor = (
+        ttnn.from_torch(
+            torch_encoder_tensor,
+            dtype=ttnn.bfloat16,
+            device=device,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        if encoder_shape is not None
+        else None
+    )
+    ttnn_output_tensor = tt_attention.forward(ttnn_input_tensor, None, ttnn_encoder_tensor)
+    output_tensor = ttnn.to_torch(ttnn_output_tensor)
+
+    del pipeline, pipeline_for_tt, tt_attention, lora_mgr
+    gc.collect()
+
+    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+    logger.info(f"PCC is {pcc_message}")

--- a/models/demos/stable_diffusion_xl_base/lora/tests/pcc/test_lora_tt_crossattndownblock2d.py
+++ b/models/demos/stable_diffusion_xl_base/lora/tests/pcc/test_lora_tt_crossattndownblock2d.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/models/demos/stable_diffusion_xl_base/lora/tests/pcc/test_lora_tt_crossattndownblock2d.py
+++ b/models/demos/stable_diffusion_xl_base/lora/tests/pcc/test_lora_tt_crossattndownblock2d.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import gc
+
+import pytest
+import torch
+from diffusers import DiffusionPipeline
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import torch_random
+from models.demos.stable_diffusion_xl_base.lora.tt_lora_weights_manager import TtLoRAWeightsManager
+from models.demos.stable_diffusion_xl_base.tests.test_common import SDXL_L1_SMALL_SIZE
+from models.demos.stable_diffusion_xl_base.tt.model_configs import load_model_optimisations
+from models.demos.stable_diffusion_xl_base.tt.tt_crossattndownblock2d import TtCrossAttnDownBlock2D
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+def _get_diffusers_pipeline(is_ci_env):
+    pipeline = DiffusionPipeline.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0",
+        torch_dtype=torch.float32,
+        use_safetensors=True,
+        local_files_only=is_ci_env,
+    )
+    return pipeline
+
+
+@pytest.mark.parametrize(
+    "image_resolution, input_shape, temb_shape, encoder_shape, query_dim, num_attn_heads, out_dim, down_block_id, pcc",
+    [
+        ((1024, 1024), (1, 320, 64, 64), (1, 1280), (1, 77, 2048), 640, 10, 640, 1, 0.996),
+        ((1024, 1024), (1, 640, 32, 32), (1, 1280), (1, 77, 2048), 1280, 20, 1280, 2, 0.997),
+        ((512, 512), (1, 320, 32, 32), (1, 1280), (1, 77, 2048), 640, 10, 640, 1, 0.997),
+        ((512, 512), (1, 640, 16, 16), (1, 1280), (1, 77, 2048), 1280, 20, 1280, 2, 0.997),
+    ],
+)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
+def test_crossattndown(
+    device,
+    image_resolution,
+    input_shape,
+    temb_shape,
+    encoder_shape,
+    query_dim,
+    num_attn_heads,
+    out_dim,
+    down_block_id,
+    pcc,
+    debug_mode,
+    is_ci_env,
+    reset_seeds,
+    lora_path,
+):
+    pipeline = _get_diffusers_pipeline(is_ci_env)
+    pipeline.unet.eval()
+
+    pipeline_for_tt = _get_diffusers_pipeline(is_ci_env)
+    state_dict = pipeline_for_tt.unet.state_dict()
+
+    lora_mgr = TtLoRAWeightsManager(device, pipeline_for_tt)
+    tt_crosattn = TtCrossAttnDownBlock2D(
+        device,
+        state_dict,
+        f"down_blocks.{down_block_id}",
+        load_model_optimisations(image_resolution),
+        query_dim,
+        num_attn_heads,
+        out_dim,
+        down_block_id == 1,
+        debug_mode=debug_mode,
+        lora_weights_manager=lora_mgr,
+    )
+
+    lora_mgr.load_lora_weights(lora_path)
+    lora_mgr.fuse_lora(lora_scale=1.0)
+    pipeline.load_lora_weights(lora_path)
+    pipeline.fuse_lora(lora_scale=1.0)
+
+    torch_crosattn = pipeline.unet.down_blocks[down_block_id]
+
+    torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)
+    torch_temb_tensor = torch_random(temb_shape, -0.1, 0.1, dtype=torch.float32)
+    torch_encoder_tensor = torch_random(encoder_shape, -0.1, 0.1, dtype=torch.float32)
+
+    torch_output_tensor, _ = torch_crosattn(
+        torch_input_tensor, temb=torch_temb_tensor, encoder_hidden_states=torch_encoder_tensor
+    )
+
+    ttnn_input_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    B, C, H, W = list(ttnn_input_tensor.shape)
+
+    ttnn_input_tensor = ttnn.permute(ttnn_input_tensor, (0, 2, 3, 1))
+    ttnn_input_tensor = ttnn.reshape(ttnn_input_tensor, (B, 1, H * W, C))
+
+    ttnn_temb_tensor = ttnn.from_torch(
+        torch_temb_tensor,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+    )
+    ttnn_temb_tensor = ttnn.silu(ttnn_temb_tensor)
+    ttnn_encoder_tensor = ttnn.from_torch(
+        torch_encoder_tensor,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+    )
+    ttnn_output_tensor, output_shape, _ = tt_crosattn.forward(
+        ttnn_input_tensor, [B, C, H, W], temb=ttnn_temb_tensor, encoder_hidden_states=ttnn_encoder_tensor
+    )
+
+    output_tensor = ttnn.to_torch(ttnn_output_tensor)
+    output_tensor = output_tensor.reshape(B, output_shape[1], output_shape[2], output_shape[0])
+    output_tensor = torch.permute(output_tensor, (0, 3, 1, 2))
+
+    del pipeline, pipeline_for_tt, tt_crosattn, lora_mgr
+    gc.collect()
+
+    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+    logger.info(f"PCC is {pcc_message}")

--- a/models/demos/stable_diffusion_xl_base/lora/tests/pcc/test_lora_tt_crossattnmidblock2d.py
+++ b/models/demos/stable_diffusion_xl_base/lora/tests/pcc/test_lora_tt_crossattnmidblock2d.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/models/demos/stable_diffusion_xl_base/lora/tests/pcc/test_lora_tt_crossattnmidblock2d.py
+++ b/models/demos/stable_diffusion_xl_base/lora/tests/pcc/test_lora_tt_crossattnmidblock2d.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import gc
+
+import pytest
+import torch
+from diffusers import DiffusionPipeline
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import torch_random
+from models.demos.stable_diffusion_xl_base.lora.tt_lora_weights_manager import TtLoRAWeightsManager
+from models.demos.stable_diffusion_xl_base.tests.test_common import SDXL_L1_SMALL_SIZE
+from models.demos.stable_diffusion_xl_base.tt.model_configs import load_model_optimisations
+from models.demos.stable_diffusion_xl_base.tt.tt_crossattnmidblock2d import TtUNetMidBlock2DCrossAttn
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+def _get_diffusers_pipeline(is_ci_env):
+    pipeline = DiffusionPipeline.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0",
+        torch_dtype=torch.float32,
+        use_safetensors=True,
+        local_files_only=is_ci_env,
+    )
+    return pipeline
+
+
+@pytest.mark.parametrize(
+    "image_resolution, input_shape, temb_shape, encoder_shape, query_dim, num_attn_heads, out_dim, pcc",
+    [
+        ((1024, 1024), (1, 1280, 32, 32), (1, 1280), (1, 77, 2048), 1280, 20, 1280, 0.996),
+        ((512, 512), (1, 1280, 16, 16), (1, 1280), (1, 77, 2048), 1280, 20, 1280, 0.996),
+    ],
+)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
+def test_crossattnmid(
+    device,
+    image_resolution,
+    input_shape,
+    temb_shape,
+    encoder_shape,
+    query_dim,
+    num_attn_heads,
+    out_dim,
+    pcc,
+    debug_mode,
+    is_ci_env,
+    reset_seeds,
+    lora_path,
+):
+    pipeline = _get_diffusers_pipeline(is_ci_env)
+    pipeline.unet.eval()
+
+    pipeline_for_tt = _get_diffusers_pipeline(is_ci_env)
+    state_dict = pipeline_for_tt.unet.state_dict()
+
+    lora_mgr = TtLoRAWeightsManager(device, pipeline_for_tt)
+    tt_crosattn = TtUNetMidBlock2DCrossAttn(
+        device,
+        state_dict,
+        "mid_block",
+        load_model_optimisations(image_resolution),
+        query_dim,
+        num_attn_heads,
+        out_dim,
+        debug_mode=debug_mode,
+        lora_weights_manager=lora_mgr,
+    )
+
+    lora_mgr.load_lora_weights(lora_path)
+    lora_mgr.fuse_lora(lora_scale=1.0)
+    pipeline.load_lora_weights(lora_path)
+    pipeline.fuse_lora(lora_scale=1.0)
+
+    torch_crosattn = pipeline.unet.mid_block
+
+    torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)
+    torch_temb_tensor = torch_random(temb_shape, -0.1, 0.1, dtype=torch.float32)
+    torch_encoder_tensor = torch_random(encoder_shape, -0.1, 0.1, dtype=torch.float32)
+
+    torch_output_tensor = torch_crosattn(
+        torch_input_tensor, temb=torch_temb_tensor, encoder_hidden_states=torch_encoder_tensor
+    )
+
+    ttnn_input_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    B, C, H, W = list(ttnn_input_tensor.shape)
+
+    ttnn_input_tensor = ttnn.permute(ttnn_input_tensor, (0, 2, 3, 1))
+    ttnn_input_tensor = ttnn.reshape(ttnn_input_tensor, (B, 1, H * W, C))
+
+    ttnn_temb_tensor = ttnn.from_torch(
+        torch_temb_tensor,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+    )
+    ttnn_temb_tensor = ttnn.silu(ttnn_temb_tensor)
+    ttnn_encoder_tensor = ttnn.from_torch(
+        torch_encoder_tensor,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+    )
+    ttnn_output_tensor, output_shape = tt_crosattn.forward(
+        ttnn_input_tensor, [B, C, H, W], temb=ttnn_temb_tensor, encoder_hidden_states=ttnn_encoder_tensor
+    )
+
+    output_tensor = ttnn.to_torch(ttnn_output_tensor)
+    output_tensor = output_tensor.reshape(B, output_shape[1], output_shape[2], output_shape[0])
+    output_tensor = torch.permute(output_tensor, (0, 3, 1, 2))
+
+    del pipeline, pipeline_for_tt, tt_crosattn, lora_mgr
+    gc.collect()
+
+    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+    logger.info(f"PCC is {pcc_message}")

--- a/models/demos/stable_diffusion_xl_base/lora/tests/pcc/test_lora_tt_crossattnupblock2d.py
+++ b/models/demos/stable_diffusion_xl_base/lora/tests/pcc/test_lora_tt_crossattnupblock2d.py
@@ -1,0 +1,177 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import gc
+
+import pytest
+import torch
+from diffusers import DiffusionPipeline
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import torch_random
+from models.demos.stable_diffusion_xl_base.lora.tt_lora_weights_manager import TtLoRAWeightsManager
+from models.demos.stable_diffusion_xl_base.tests.test_common import SDXL_L1_SMALL_SIZE
+from models.demos.stable_diffusion_xl_base.tt.model_configs import load_model_optimisations
+from models.demos.stable_diffusion_xl_base.tt.tt_crossattnupblock2d import TtCrossAttnUpBlock2D
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+def _get_diffusers_pipeline(is_ci_env):
+    pipeline = DiffusionPipeline.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0",
+        torch_dtype=torch.float32,
+        use_safetensors=True,
+        local_files_only=is_ci_env,
+    )
+    return pipeline
+
+
+@pytest.mark.parametrize(
+    "image_resolution, input_shape, temb_shape, residuals, encoder_shape, query_dim, num_attn_heads, out_dim, block_id, pcc",
+    [
+        (
+            (1024, 1024),
+            (1, 1280, 32, 32),
+            (1, 1280),
+            ((1, 640, 32, 32), (1, 1280, 32, 32), (1, 1280, 32, 32)),
+            (1, 77, 2048),
+            1280,
+            20,
+            1280,
+            0,
+            0.975,
+        ),
+        (
+            (1024, 1024),
+            (1, 1280, 64, 64),
+            (1, 1280),
+            ((1, 320, 64, 64), (1, 640, 64, 64), (1, 640, 64, 64)),
+            (1, 77, 2048),
+            640,
+            10,
+            640,
+            1,
+            0.993,
+        ),
+        (
+            (512, 512),
+            (1, 1280, 16, 16),
+            (1, 1280),
+            ((1, 640, 16, 16), (1, 1280, 16, 16), (1, 1280, 16, 16)),
+            (1, 77, 2048),
+            1280,
+            20,
+            1280,
+            0,
+            0.988,
+        ),
+        (
+            (512, 512),
+            (1, 1280, 32, 32),
+            (1, 1280),
+            ((1, 320, 32, 32), (1, 640, 32, 32), (1, 640, 32, 32)),
+            (1, 77, 2048),
+            640,
+            10,
+            640,
+            1,
+            0.993,
+        ),
+    ],
+)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
+def test_crossattnup(
+    device,
+    image_resolution,
+    input_shape,
+    temb_shape,
+    residuals,
+    encoder_shape,
+    query_dim,
+    num_attn_heads,
+    out_dim,
+    block_id,
+    pcc,
+    debug_mode,
+    is_ci_env,
+    reset_seeds,
+    lora_path,
+):
+    pipeline = _get_diffusers_pipeline(is_ci_env)
+    pipeline.unet.eval()
+
+    pipeline_for_tt = _get_diffusers_pipeline(is_ci_env)
+    state_dict = pipeline_for_tt.unet.state_dict()
+
+    lora_mgr = TtLoRAWeightsManager(device, pipeline_for_tt)
+    tt_crosattn = TtCrossAttnUpBlock2D(
+        device,
+        state_dict,
+        f"up_blocks.{block_id}",
+        load_model_optimisations(image_resolution),
+        query_dim,
+        num_attn_heads,
+        out_dim,
+        True,
+        debug_mode=debug_mode,
+        lora_weights_manager=lora_mgr,
+    )
+
+    lora_mgr.load_lora_weights(lora_path)
+    lora_mgr.fuse_lora(lora_scale=1.0)
+    pipeline.load_lora_weights(lora_path)
+    pipeline.fuse_lora(lora_scale=1.0)
+
+    torch_crosattn = pipeline.unet.up_blocks[block_id]
+
+    torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)
+    torch_temb_tensor = torch_random(temb_shape, -0.1, 0.1, dtype=torch.float32)
+    torch_encoder_tensor = torch_random(encoder_shape, -0.1, 0.1, dtype=torch.float32)
+
+    torch_residual_tensors = ()
+    for r in residuals:
+        residual = torch_random(r, -0.1, 0.1, dtype=torch.float32)
+        torch_residual_tensors = torch_residual_tensors + (residual,)
+
+    torch_output_tensor = torch_crosattn(
+        torch_input_tensor, torch_residual_tensors, temb=torch_temb_tensor, encoder_hidden_states=torch_encoder_tensor
+    )
+
+    ttnn_input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT)
+    B, C, H, W = list(ttnn_input_tensor.shape)
+
+    ttnn_input_tensor = ttnn.permute(ttnn_input_tensor, (0, 2, 3, 1))
+    ttnn_input_tensor = ttnn.reshape(ttnn_input_tensor, (B, 1, H * W, C))
+
+    ttnn_residual_tensors = ()
+    for torch_residual in torch_residual_tensors:
+        ttnn_residual = ttnn.from_torch(torch_residual, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT)
+        Br, Cr, Hr, Wr = list(ttnn_residual.shape)
+        ttnn_residual = ttnn.permute(ttnn_residual, (0, 2, 3, 1))
+        ttnn_residual = ttnn.reshape(ttnn_residual, (Br, 1, Hr * Wr, Cr))
+        ttnn_residual_tensors = ttnn_residual_tensors + (ttnn_residual,)
+
+    ttnn_temb_tensor = ttnn.from_torch(torch_temb_tensor, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT)
+    ttnn_temb_tensor = ttnn.silu(ttnn_temb_tensor)
+    ttnn_encoder_tensor = ttnn.from_torch(
+        torch_encoder_tensor, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT
+    )
+    ttnn_output_tensor, output_shape = tt_crosattn.forward(
+        ttnn_input_tensor,
+        ttnn_residual_tensors,
+        [B, C, H, W],
+        temb=ttnn_temb_tensor,
+        encoder_hidden_states=ttnn_encoder_tensor,
+    )
+
+    output_tensor = ttnn.to_torch(ttnn_output_tensor)
+    output_tensor = output_tensor.reshape(B, output_shape[1], output_shape[2], output_shape[0])
+    output_tensor = torch.permute(output_tensor, (0, 3, 1, 2))
+
+    del pipeline, pipeline_for_tt, tt_crosattn, lora_mgr
+    gc.collect()
+
+    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+    logger.info(f"PCC is {pcc_message}")

--- a/models/demos/stable_diffusion_xl_base/lora/tests/pcc/test_lora_tt_crossattnupblock2d.py
+++ b/models/demos/stable_diffusion_xl_base/lora/tests/pcc/test_lora_tt_crossattnupblock2d.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -41,7 +41,7 @@ def _get_diffusers_pipeline(is_ci_env):
             20,
             1280,
             0,
-            0.975,
+            0.974,
         ),
         (
             (1024, 1024),

--- a/models/demos/stable_diffusion_xl_base/lora/tests/pcc/test_lora_tt_feedforward.py
+++ b/models/demos/stable_diffusion_xl_base/lora/tests/pcc/test_lora_tt_feedforward.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/models/demos/stable_diffusion_xl_base/lora/tests/pcc/test_lora_tt_feedforward.py
+++ b/models/demos/stable_diffusion_xl_base/lora/tests/pcc/test_lora_tt_feedforward.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import gc
+
+import pytest
+import torch
+from diffusers import DiffusionPipeline
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import torch_random
+from models.demos.stable_diffusion_xl_base.lora.tt_lora_weights_manager import TtLoRAWeightsManager
+from models.demos.stable_diffusion_xl_base.tests.test_common import SDXL_L1_SMALL_SIZE
+from models.demos.stable_diffusion_xl_base.tt.model_configs import load_model_optimisations
+from models.demos.stable_diffusion_xl_base.tt.tt_feedforward import TtFeedForward
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+def _get_diffusers_pipeline(is_ci_env):
+    pipeline = DiffusionPipeline.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0",
+        torch_dtype=torch.float32,
+        use_safetensors=True,
+        local_files_only=is_ci_env,
+    )
+    return pipeline
+
+
+@pytest.mark.parametrize(
+    "image_resolution, input_shape, block_id, transformer_block_id, pcc",
+    [
+        ((1024, 1024), (1024, 1280), 2, 0, 0.997),
+        ((1024, 1024), (4096, 640), 1, 0, 0.999),
+        ((512, 512), (256, 1280), 2, 0, 0.997),
+        ((512, 512), (1024, 640), 1, 0, 0.999),
+    ],
+)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
+def test_feedforward(
+    device, image_resolution, input_shape, block_id, transformer_block_id, pcc, is_ci_env, reset_seeds, lora_path
+):
+    pipeline = _get_diffusers_pipeline(is_ci_env)
+    pipeline.unet.eval()
+
+    pipeline_for_tt = _get_diffusers_pipeline(is_ci_env)
+    state_dict = pipeline_for_tt.unet.state_dict()
+
+    lora_mgr = TtLoRAWeightsManager(device, pipeline_for_tt)
+    module_path = f"down_blocks.{block_id}.attentions.0.transformer_blocks.{transformer_block_id}.ff"
+    tt_ff = TtFeedForward(
+        device, state_dict, module_path, load_model_optimisations(image_resolution), lora_weights_manager=lora_mgr
+    )
+
+    lora_mgr.load_lora_weights(lora_path)
+    lora_mgr.fuse_lora(lora_scale=1.0)
+    pipeline.load_lora_weights(lora_path)
+    pipeline.fuse_lora(lora_scale=1.0)
+
+    torch_ff = pipeline.unet.down_blocks[block_id].attentions[0].transformer_blocks[transformer_block_id].ff
+
+    torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)
+    torch_output_tensor = torch_ff(torch_input_tensor)
+
+    ttnn_input_tensor = ttnn.from_torch(
+        torch_input_tensor.unsqueeze(0).unsqueeze(0),
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    ttnn_output_tensor = tt_ff.forward(ttnn_input_tensor)
+    output_tensor = ttnn.to_torch(ttnn_output_tensor).squeeze()
+
+    del pipeline, pipeline_for_tt, tt_ff, lora_mgr
+    gc.collect()
+
+    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+    logger.info(f"PCC is {pcc_message}")

--- a/models/demos/stable_diffusion_xl_base/lora/tests/pcc/test_lora_tt_geglu.py
+++ b/models/demos/stable_diffusion_xl_base/lora/tests/pcc/test_lora_tt_geglu.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/models/demos/stable_diffusion_xl_base/lora/tests/pcc/test_lora_tt_geglu.py
+++ b/models/demos/stable_diffusion_xl_base/lora/tests/pcc/test_lora_tt_geglu.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import gc
+from functools import reduce
+
+import pytest
+import torch
+from diffusers import DiffusionPipeline
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import torch_random
+from models.demos.stable_diffusion_xl_base.lora.tt_lora_weights_manager import TtLoRAWeightsManager
+from models.demos.stable_diffusion_xl_base.tests.test_common import SDXL_L1_SMALL_SIZE
+from models.demos.stable_diffusion_xl_base.tt.model_configs import load_model_optimisations
+from models.demos.stable_diffusion_xl_base.tt.tt_geglu import TtGEGLU
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+def _get_diffusers_pipeline(is_ci_env):
+    pipeline = DiffusionPipeline.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0",
+        torch_dtype=torch.float32,
+        use_safetensors=True,
+        local_files_only=is_ci_env,
+    )
+    return pipeline
+
+
+@pytest.mark.parametrize(
+    "image_resolution, input_shape, module_path, pcc",
+    [
+        ((1024, 1024), (1024, 1280), "down_blocks.2.attentions.0.transformer_blocks.0.ff.net.0", 0.948),
+        ((1024, 1024), (4096, 640), "down_blocks.1.attentions.0.transformer_blocks.0.ff.net.0", 0.950),
+        ((512, 512), (256, 1280), "down_blocks.2.attentions.0.transformer_blocks.0.ff.net.0", 0.948),
+        ((512, 512), (1024, 640), "down_blocks.1.attentions.0.transformer_blocks.0.ff.net.0", 0.950),
+    ],
+)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
+def test_geglu(device, image_resolution, input_shape, module_path, pcc, is_ci_env, reset_seeds, lora_path):
+    pipeline = _get_diffusers_pipeline(is_ci_env)
+    pipeline.unet.eval()
+
+    pipeline_for_tt = _get_diffusers_pipeline(is_ci_env)
+    state_dict = pipeline_for_tt.unet.state_dict()
+
+    lora_mgr = TtLoRAWeightsManager(device, pipeline_for_tt)
+    tt_geglu = TtGEGLU(
+        device, state_dict, module_path, load_model_optimisations(image_resolution), lora_weights_manager=lora_mgr
+    )
+
+    lora_mgr.load_lora_weights(lora_path)
+    lora_mgr.fuse_lora(lora_scale=1.0)
+    pipeline.load_lora_weights(lora_path)
+    pipeline.fuse_lora(lora_scale=1.0)
+
+    try:
+        torch_geglu = reduce(
+            lambda obj, key: obj[int(key)] if key.isdigit() else getattr(obj, key),
+            module_path.split("."),
+            pipeline.unet,
+        )
+    except (AttributeError, IndexError, TypeError):
+        torch_geglu = None
+    assert torch_geglu is not None, f"{module_path} is not a valid UNet module"
+
+    torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)
+    torch_output_tensor = torch_geglu(torch_input_tensor)
+
+    ttnn_input_tensor = ttnn.from_torch(
+        torch_input_tensor.unsqueeze(0).unsqueeze(0),
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    ttnn_output_tensor = tt_geglu.forward(ttnn_input_tensor)
+    output_tensor = ttnn.to_torch(ttnn_output_tensor).squeeze()
+
+    del pipeline, pipeline_for_tt, tt_geglu, lora_mgr
+    gc.collect()
+
+    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+    logger.info(f"PCC is {pcc_message}")

--- a/models/demos/stable_diffusion_xl_base/lora/tests/pcc/test_lora_tt_transformerblock.py
+++ b/models/demos/stable_diffusion_xl_base/lora/tests/pcc/test_lora_tt_transformerblock.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/models/demos/stable_diffusion_xl_base/lora/tests/pcc/test_lora_tt_transformerblock.py
+++ b/models/demos/stable_diffusion_xl_base/lora/tests/pcc/test_lora_tt_transformerblock.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import gc
+
+import pytest
+import torch
+from diffusers import DiffusionPipeline
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import torch_random
+from models.demos.stable_diffusion_xl_base.lora.tt_lora_weights_manager import TtLoRAWeightsManager
+from models.demos.stable_diffusion_xl_base.tests.test_common import SDXL_L1_SMALL_SIZE
+from models.demos.stable_diffusion_xl_base.tt.model_configs import load_model_optimisations
+from models.demos.stable_diffusion_xl_base.tt.tt_transformerblock import TtBasicTransformerBlock
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+def _get_diffusers_pipeline(is_ci_env):
+    pipeline = DiffusionPipeline.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0",
+        torch_dtype=torch.float32,
+        use_safetensors=True,
+        local_files_only=is_ci_env,
+    )
+    return pipeline
+
+
+@pytest.mark.parametrize(
+    "image_resolution, input_shape, encoder_shape, down_block_id, block_id, query_dim, num_attn_heads, out_dim, pcc",
+    [
+        ((1024, 1024), (1, 4096, 640), (1, 77, 2048), 1, 0, 640, 10, 640, 0.999),
+        ((1024, 1024), (1, 4096, 640), (1, 77, 2048), 1, 1, 640, 10, 640, 0.998),
+        ((1024, 1024), (1, 1024, 1280), (1, 77, 2048), 2, 0, 1280, 20, 1280, 0.999),
+        ((1024, 1024), (1, 1024, 1280), (1, 77, 2048), 2, 1, 1280, 20, 1280, 0.998),
+        ((512, 512), (1, 1024, 640), (1, 77, 2048), 1, 0, 640, 10, 640, 0.999),
+        ((512, 512), (1, 1024, 640), (1, 77, 2048), 1, 1, 640, 10, 640, 0.998),
+        ((512, 512), (1, 256, 1280), (1, 77, 2048), 2, 0, 1280, 20, 1280, 0.999),
+        ((512, 512), (1, 256, 1280), (1, 77, 2048), 2, 1, 1280, 20, 1280, 0.998),
+    ],
+)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
+def test_transformerblock(
+    device,
+    image_resolution,
+    input_shape,
+    encoder_shape,
+    down_block_id,
+    block_id,
+    query_dim,
+    num_attn_heads,
+    out_dim,
+    pcc,
+    is_ci_env,
+    reset_seeds,
+    lora_path,
+):
+    pipeline = _get_diffusers_pipeline(is_ci_env)
+    pipeline.unet.eval()
+
+    pipeline_for_tt = _get_diffusers_pipeline(is_ci_env)
+    state_dict = pipeline_for_tt.unet.state_dict()
+
+    lora_mgr = TtLoRAWeightsManager(device, pipeline_for_tt)
+    tt_transformerblock = TtBasicTransformerBlock(
+        device,
+        state_dict,
+        f"down_blocks.{down_block_id}.attentions.0.transformer_blocks.{block_id}",
+        load_model_optimisations(image_resolution),
+        query_dim,
+        num_attn_heads,
+        out_dim,
+        lora_weights_manager=lora_mgr,
+    )
+
+    lora_mgr.load_lora_weights(lora_path)
+    lora_mgr.fuse_lora(lora_scale=1.0)
+    pipeline.load_lora_weights(lora_path)
+    pipeline.fuse_lora(lora_scale=1.0)
+
+    torch_transformerblock = pipeline.unet.down_blocks[down_block_id].attentions[0].transformer_blocks[block_id]
+
+    torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)
+    torch_encoder_tensor = torch_random(encoder_shape, -0.1, 0.1, dtype=torch.float32)
+
+    torch_output_tensor = torch_transformerblock(torch_input_tensor, None, torch_encoder_tensor).unsqueeze(0)
+
+    ttnn_encoder_tensor = ttnn.from_torch(
+        torch_encoder_tensor,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+    )
+    ttnn_input_tensor = ttnn.from_torch(
+        torch_input_tensor.unsqueeze(0),
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    ttnn_output_tensor = tt_transformerblock.forward(ttnn_input_tensor, None, ttnn_encoder_tensor)
+    output_tensor = ttnn.to_torch(ttnn_output_tensor)
+
+    del pipeline, pipeline_for_tt, tt_transformerblock, lora_mgr
+    gc.collect()
+
+    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+    logger.info(f"PCC is {pcc_message}")

--- a/models/demos/stable_diffusion_xl_base/lora/tests/pcc/test_lora_tt_transformermodel.py
+++ b/models/demos/stable_diffusion_xl_base/lora/tests/pcc/test_lora_tt_transformermodel.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/models/demos/stable_diffusion_xl_base/lora/tests/pcc/test_lora_tt_transformermodel.py
+++ b/models/demos/stable_diffusion_xl_base/lora/tests/pcc/test_lora_tt_transformermodel.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import gc
+
+import pytest
+import torch
+from diffusers import DiffusionPipeline
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import torch_random
+from models.demos.stable_diffusion_xl_base.lora.tt_lora_weights_manager import TtLoRAWeightsManager
+from models.demos.stable_diffusion_xl_base.tests.test_common import SDXL_L1_SMALL_SIZE
+from models.demos.stable_diffusion_xl_base.tt.model_configs import load_model_optimisations
+from models.demos.stable_diffusion_xl_base.tt.tt_transformermodel import TtTransformer2DModel
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+def _get_diffusers_pipeline(is_ci_env):
+    pipeline = DiffusionPipeline.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0",
+        torch_dtype=torch.float32,
+        use_safetensors=True,
+        local_files_only=is_ci_env,
+    )
+    return pipeline
+
+
+@pytest.mark.parametrize(
+    "image_resolution, input_shape, encoder_shape, down_block_id, query_dim, num_attn_heads, out_dim, pcc",
+    [
+        ((1024, 1024), (1, 640, 64, 64), (1, 77, 2048), 1, 640, 10, 640, 0.998),
+        ((1024, 1024), (1, 1280, 32, 32), (1, 77, 2048), 2, 1280, 20, 1280, 0.997),
+        ((512, 512), (1, 640, 32, 32), (1, 77, 2048), 1, 640, 10, 640, 0.998),
+        ((512, 512), (1, 1280, 16, 16), (1, 77, 2048), 2, 1280, 20, 1280, 0.997),
+    ],
+)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
+def test_transformermodel(
+    device,
+    image_resolution,
+    input_shape,
+    encoder_shape,
+    down_block_id,
+    query_dim,
+    num_attn_heads,
+    out_dim,
+    pcc,
+    is_ci_env,
+    reset_seeds,
+    lora_path,
+):
+    pipeline = _get_diffusers_pipeline(is_ci_env)
+    pipeline.unet.eval()
+
+    pipeline_for_tt = _get_diffusers_pipeline(is_ci_env)
+    state_dict = pipeline_for_tt.unet.state_dict()
+
+    lora_mgr = TtLoRAWeightsManager(device, pipeline_for_tt)
+    tt_transformerblock = TtTransformer2DModel(
+        device,
+        state_dict,
+        f"down_blocks.{down_block_id}.attentions.0",
+        load_model_optimisations(image_resolution),
+        query_dim,
+        num_attn_heads,
+        out_dim,
+        lora_weights_manager=lora_mgr,
+    )
+
+    lora_mgr.load_lora_weights(lora_path)
+    lora_mgr.fuse_lora(lora_scale=1.0)
+    pipeline.load_lora_weights(lora_path)
+    pipeline.fuse_lora(lora_scale=1.0)
+
+    torch_transformerblock = pipeline.unet.down_blocks[down_block_id].attentions[0]
+
+    torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)
+    torch_encoder_tensor = torch_random(encoder_shape, -0.1, 0.1, dtype=torch.float32)
+
+    torch_output_tensor = torch_transformerblock(torch_input_tensor, encoder_hidden_states=torch_encoder_tensor).sample
+
+    ttnn_encoder_tensor = ttnn.from_torch(
+        torch_encoder_tensor,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    ttnn_input_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    B, C, H, W = list(ttnn_input_tensor.shape)
+
+    ttnn_input_tensor = ttnn.permute(ttnn_input_tensor, (0, 2, 3, 1))
+    ttnn_input_tensor = ttnn.reshape(ttnn_input_tensor, (B, 1, H * W, C))
+
+    ttnn_output_tensor = tt_transformerblock.forward(ttnn_input_tensor, [B, C, H, W], None, ttnn_encoder_tensor)
+    output_tensor = ttnn.to_torch(ttnn_output_tensor)
+    output_tensor = output_tensor.reshape(B, H, W, C)
+    output_tensor = torch.permute(output_tensor, (0, 3, 1, 2))
+
+    del pipeline, pipeline_for_tt, tt_transformerblock, lora_mgr
+    gc.collect()
+
+    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+    logger.info(f"PCC is {pcc_message}")

--- a/models/demos/stable_diffusion_xl_base/lora/tests/pcc/test_lora_tt_unet.py
+++ b/models/demos/stable_diffusion_xl_base/lora/tests/pcc/test_lora_tt_unet.py
@@ -1,18 +1,20 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 import gc
-from loguru import logger
-import torch
+
 import pytest
-import ttnn
-from models.demos.stable_diffusion_xl_base.tt.tt_unet import TtUNet2DConditionModel
-from models.demos.stable_diffusion_xl_base.tt.model_configs import load_model_optimisations
-from models.demos.stable_diffusion_xl_base.lora.tt_lora_weights_manager import TtLoRAWeightsManager
+import torch
 from diffusers import DiffusionPipeline
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from loguru import logger
+
+import ttnn
 from models.common.utility_functions import torch_random
+from models.demos.stable_diffusion_xl_base.lora.tt_lora_weights_manager import TtLoRAWeightsManager
 from models.demos.stable_diffusion_xl_base.tests.test_common import SDXL_L1_SMALL_SIZE
+from models.demos.stable_diffusion_xl_base.tt.model_configs import load_model_optimisations
+from models.demos.stable_diffusion_xl_base.tt.tt_unet import TtUNet2DConditionModel
+from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
 def _get_diffusers_pipeline(is_ci_env):
@@ -204,7 +206,7 @@ def run_unet_model(
     "image_resolution, input_shape, timestep_shape, encoder_shape, temb_shape, time_ids_shape, pcc",
     [
         ((1024, 1024), (1, 4, 128, 128), (1,), (1, 77, 2048), (1, 1280), (1, 6), 0.9969),
-        ((512, 512), (1, 4, 64, 64), (1,), (1, 77, 2048), (1, 1280), (1, 6), 0.9961),
+        ((512, 512), (1, 4, 64, 64), (1,), (1, 77, 2048), (1, 1280), (1, 6), 0.9960),
         # TODO: Add test for 9x128x128 input shape if needed (inpainting)
     ],
 )

--- a/models/demos/stable_diffusion_xl_base/lora/tests/pcc/test_lora_tt_unet.py
+++ b/models/demos/stable_diffusion_xl_base/lora/tests/pcc/test_lora_tt_unet.py
@@ -1,0 +1,240 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+import gc
+from loguru import logger
+import torch
+import pytest
+import ttnn
+from models.demos.stable_diffusion_xl_base.tt.tt_unet import TtUNet2DConditionModel
+from models.demos.stable_diffusion_xl_base.tt.model_configs import load_model_optimisations
+from models.demos.stable_diffusion_xl_base.lora.tt_lora_weights_manager import TtLoRAWeightsManager
+from diffusers import DiffusionPipeline
+from tests.ttnn.utils_for_testing import assert_with_pcc
+from models.common.utility_functions import torch_random
+from models.demos.stable_diffusion_xl_base.tests.test_common import SDXL_L1_SMALL_SIZE
+
+
+def _get_diffusers_pipeline(is_ci_env):
+    pipeline = DiffusionPipeline.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0",
+        torch_dtype=torch.float32,
+        use_safetensors=True,
+        local_files_only=is_ci_env,
+    )
+    return pipeline
+
+
+def prepare_ttnn_tensors(
+    device, torch_input_tensor, torch_timestep_tensor, torch_temb_tensor, torch_encoder_tensor, torch_time_ids
+):
+    torch.manual_seed(2025)
+
+    ttnn_timestep_tensor = ttnn.from_torch(
+        torch_timestep_tensor,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+    )
+    ttnn_encoder_tensor = ttnn.from_torch(
+        torch_encoder_tensor,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+    )
+
+    ttnn_text_embeds = ttnn.from_torch(
+        torch_temb_tensor,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+    )
+    ttnn_time_ids = ttnn.from_torch(
+        torch_time_ids,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+    )
+    ttnn_added_cond_kwargs = {
+        "text_embeds": ttnn_text_embeds,
+        "time_ids": ttnn_time_ids,
+    }
+
+    ttnn_input_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+    )
+    B, C, H, W = list(ttnn_input_tensor.shape)
+
+    ttnn_input_tensor = ttnn.permute(ttnn_input_tensor, (0, 2, 3, 1))
+    ttnn_input_tensor = ttnn.reshape(ttnn_input_tensor, (B, 1, H * W, C))
+
+    return ttnn_input_tensor, [B, C, H, W], ttnn_timestep_tensor, ttnn_encoder_tensor, ttnn_added_cond_kwargs
+
+
+def run_unet_model(
+    device,
+    image_resolution,
+    input_shape,
+    timestep_shape,
+    encoder_shape,
+    temb_shape,
+    time_ids_shape,
+    pcc,
+    debug_mode,
+    is_ci_env,
+    is_ci_v2_env,
+    lora_path,
+    iterations=1,
+):
+    assert not (is_ci_v2_env and input_shape[1] != 4), "Currently only vanilla SDXL UNet is supported in CI v2"
+    pipeline = _get_diffusers_pipeline(is_ci_env)
+    pipeline.unet.eval()
+
+    pipeline_for_tt = _get_diffusers_pipeline(is_ci_env)
+    state_dict = pipeline_for_tt.unet.state_dict()
+
+    lora_mgr = TtLoRAWeightsManager(device, pipeline_for_tt)
+    model_config = load_model_optimisations(image_resolution)
+    tt_unet = TtUNet2DConditionModel(
+        device,
+        state_dict,
+        "unet",
+        model_config=model_config,
+        debug_mode=debug_mode,
+        lora_weights_manager=lora_mgr,
+    )
+
+    lora_mgr.load_lora_weights(lora_path)
+    lora_mgr.fuse_lora(lora_scale=1.0)
+    pipeline.load_lora_weights(lora_path)
+    pipeline.fuse_lora(lora_scale=1.0)
+
+    torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)
+    torch_timestep_tensor = torch_random(timestep_shape, -0.1, 0.1, dtype=torch.float32)
+    torch_temb_tensor = torch_random(temb_shape, -0.1, 0.1, dtype=torch.float32)
+    torch_encoder_tensor = torch_random(encoder_shape, -0.1, 0.1, dtype=torch.float32)
+    torch_time_ids = torch.tensor([1024, 1024, 0, 0, 1024, 1024])
+
+    added_cond_kwargs = {
+        "text_embeds": torch_temb_tensor,
+        "time_ids": torch_time_ids,
+    }
+
+    torch_output_tensor = pipeline.unet(
+        torch_input_tensor,
+        timestep=torch_timestep_tensor,
+        encoder_hidden_states=torch_encoder_tensor,
+        added_cond_kwargs=added_cond_kwargs,
+    ).sample
+
+    (
+        ttnn_input_tensor,
+        [B, C, H, W],
+        ttnn_timestep_tensor,
+        ttnn_encoder_tensor,
+        ttnn_added_cond_kwargs,
+    ) = prepare_ttnn_tensors(
+        device, torch_input_tensor, torch_timestep_tensor, torch_temb_tensor, torch_encoder_tensor, torch_time_ids
+    )
+    ttnn_output_tensor, output_shape = tt_unet.forward(
+        ttnn_input_tensor,
+        [B, C, H, W],
+        timestep=ttnn_timestep_tensor,
+        encoder_hidden_states=ttnn_encoder_tensor,
+        time_ids=ttnn_added_cond_kwargs["time_ids"],
+        text_embeds=ttnn_added_cond_kwargs["text_embeds"],
+    )
+
+    output_tensor = ttnn.to_torch(ttnn_output_tensor.cpu())
+    output_tensor = output_tensor.reshape(B, output_shape[1], output_shape[2], output_shape[0])
+    output_tensor = torch.permute(output_tensor, (0, 3, 1, 2))
+
+    ttnn.deallocate(ttnn_input_tensor)
+    ttnn.deallocate(ttnn_output_tensor)
+    ttnn.deallocate(ttnn_timestep_tensor)
+    ttnn.deallocate(ttnn_encoder_tensor)
+    ttnn.deallocate(ttnn_added_cond_kwargs["text_embeds"])
+    ttnn.deallocate(ttnn_added_cond_kwargs["time_ids"])
+
+    ttnn.ReadDeviceProfiler(device)
+
+    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+    logger.info(f"PCC of first iteration is: {pcc_message}")
+
+    for _ in range(iterations - 1):
+        (
+            ttnn_input_tensor,
+            [B, C, H, W],
+            ttnn_timestep_tensor,
+            ttnn_encoder_tensor,
+            ttnn_added_cond_kwargs,
+        ) = prepare_ttnn_tensors(
+            device, torch_input_tensor, torch_timestep_tensor, torch_temb_tensor, torch_encoder_tensor, torch_time_ids
+        )
+        ttnn_output_tensor, output_shape = tt_unet.forward(
+            ttnn_input_tensor,
+            [B, C, H, W],
+            timestep=ttnn_timestep_tensor,
+            encoder_hidden_states=ttnn_encoder_tensor,
+            time_ids=ttnn_added_cond_kwargs["time_ids"],
+            text_embeds=ttnn_added_cond_kwargs["text_embeds"],
+        )
+        ttnn.deallocate(ttnn_input_tensor)
+        ttnn.deallocate(ttnn_output_tensor)
+        ttnn.deallocate(ttnn_timestep_tensor)
+        ttnn.deallocate(ttnn_encoder_tensor)
+        ttnn.deallocate(ttnn_added_cond_kwargs["text_embeds"])
+        ttnn.deallocate(ttnn_added_cond_kwargs["time_ids"])
+
+        ttnn.ReadDeviceProfiler(device)
+
+    del pipeline, pipeline_for_tt, tt_unet, lora_mgr
+    gc.collect()
+
+
+@pytest.mark.parametrize(
+    "image_resolution, input_shape, timestep_shape, encoder_shape, temb_shape, time_ids_shape, pcc",
+    [
+        ((1024, 1024), (1, 4, 128, 128), (1,), (1, 77, 2048), (1, 1280), (1, 6), 0.9969),
+        ((512, 512), (1, 4, 64, 64), (1,), (1, 77, 2048), (1, 1280), (1, 6), 0.9961),
+        # TODO: Add test for 9x128x128 input shape if needed (inpainting)
+    ],
+)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
+def test_unet(
+    device,
+    image_resolution,
+    input_shape,
+    timestep_shape,
+    encoder_shape,
+    temb_shape,
+    time_ids_shape,
+    pcc,
+    debug_mode,
+    is_ci_env,
+    is_ci_v2_env,
+    reset_seeds,
+    lora_path,
+):
+    run_unet_model(
+        device,
+        image_resolution,
+        input_shape,
+        timestep_shape,
+        encoder_shape,
+        temb_shape,
+        time_ids_shape,
+        pcc,
+        debug_mode,
+        is_ci_env,
+        is_ci_v2_env,
+        lora_path,
+    )

--- a/models/demos/stable_diffusion_xl_base/lora/tests/test_lora_fusion.py
+++ b/models/demos/stable_diffusion_xl_base/lora/tests/test_lora_fusion.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/models/demos/stable_diffusion_xl_base/lora/tests/test_lora_fusion.py
+++ b/models/demos/stable_diffusion_xl_base/lora/tests/test_lora_fusion.py
@@ -1,0 +1,162 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import re
+
+import pytest
+import torch
+from diffusers import DiffusionPipeline
+from loguru import logger
+
+import ttnn
+from conftest import is_galaxy
+from models.demos.stable_diffusion_xl_base.conftest import get_device_name
+from models.demos.stable_diffusion_xl_base.tests.test_common import (
+    SDXL_BASE_REFINER_TRACE_REGION_SIZE,
+    SDXL_L1_SMALL_SIZE,
+)
+from models.demos.stable_diffusion_xl_base.tt.tt_sdxl_pipeline import TtSDXLPipeline, TtSDXLPipelineConfig
+from tests.ttnn.utils_for_testing import assert_allclose, assert_with_pcc
+
+
+def _get_lora_impacted_weights(sd):
+    """
+    Returns a dict of LoRA impacted weights. Weight names are cleaned up to match TT naming convention.
+    """
+    out = {}
+    for k, tensor in sd.items():
+        if ".lora_A." in k or ".lora_B." in k:
+            continue
+        clean = re.sub(r"^base_model\.model\.", "", k)
+        clean = clean.replace(".base_layer.", ".")
+        out[clean] = tensor
+    return out
+
+
+def _build_reference_weights(peft_sd):
+    """
+    Transforms weights from PEFT state dict to match TT weights format. Returns a dict of weights that can be compared to TT weights.
+    """
+    ref = {}
+    self_attention_paths = set()
+
+    # Identify self-attention blocks and build their QKV concatenations
+    for key, torch_tensor in peft_sd.items():
+        if key.endswith(".to_q.weight"):
+            attn_path = key.replace(".to_q.weight", "")
+            k_key = f"{attn_path}.to_k.weight"
+            v_key = f"{attn_path}.to_v.weight"
+
+            if k_key not in peft_sd or v_key not in peft_sd:
+                continue
+
+            q_weights = torch_tensor
+            k_weights = peft_sd[k_key]
+            v_weights = peft_sd[v_key]
+            is_self_attention = (
+                q_weights.shape[-1] == k_weights.shape[-1] and q_weights.shape[-1] == v_weights.shape[-1]
+            )
+
+            if is_self_attention:
+                q_w = q_weights.unsqueeze(0).unsqueeze(0).transpose(-2, -1)
+                k_w = k_weights.unsqueeze(0).unsqueeze(0).transpose(-2, -1)
+                v_w = v_weights.unsqueeze(0).unsqueeze(0).transpose(-2, -1)
+
+                qkv = torch.cat([q_w, k_w, v_w], dim=-1)
+                ref[f"{attn_path}.to_qkv.weight"] = qkv
+                self_attention_paths.add(attn_path)
+
+    # Handle other weights
+    for key, torch_tensor in peft_sd.items():
+        # Skip self-attention Q/K/V
+        if key.endswith((".to_q.weight", ".to_k.weight", ".to_v.weight")):
+            attn_path = key.replace(".to_q.weight", "").replace(".to_k.weight", "").replace(".to_v.weight", "")
+            if attn_path in self_attention_paths:
+                continue
+
+        # Split single proj weight into linear_1 + linear_2
+        if key.endswith(".net.0.proj.weight"):
+            w = torch_tensor.unsqueeze(0).unsqueeze(0)
+            w1, w2 = w.chunk(2, dim=-2)
+            prefix = key.replace(".proj.weight", ".proj")
+            ref[f"{prefix}.linear_1.weight"] = w1.movedim(-1, -2)
+            ref[f"{prefix}.linear_2.weight"] = w2.movedim(-1, -2)
+
+        elif any(
+            key.endswith(f"{suffix}.weight")
+            for suffix in ("to_q", "to_k", "to_v", "to_out.0", "proj_in", "proj_out", "ff.net.2")
+        ):
+            ref[key] = torch_tensor.unsqueeze(0).unsqueeze(0).movedim(-1, -2)
+
+    return ref
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "l1_small_size": SDXL_L1_SMALL_SIZE,
+            "trace_region_size": SDXL_BASE_REFINER_TRACE_REGION_SIZE,
+        },
+    ],
+    indirect=True,
+)
+@pytest.mark.skipif(
+    get_device_name() != "n150",
+    reason="test_lora_fusion runs only on n150",
+)
+@torch.no_grad()
+def test_lora_fusion_pcc(mesh_device, lora_path):
+    torch_pipeline = DiffusionPipeline.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0",
+        torch_dtype=torch.float32,
+        use_safetensors=True,
+    )
+
+    torch_pipeline_for_tt = DiffusionPipeline.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0",
+        torch_dtype=torch.float32,
+        use_safetensors=True,
+    )
+
+    pipeline_config = TtSDXLPipelineConfig(num_inference_steps=50, guidance_scale=5.0, is_galaxy=is_galaxy())
+
+    tt_pipeline = TtSDXLPipeline(mesh_device, torch_pipeline_for_tt, pipeline_config)
+    lora_manager = tt_pipeline._lora_weights_manager
+
+    lora_manager.load_lora_weights(lora_path)
+    assert lora_manager.has_lora_adapter(), "No LoRA adapter found"
+
+    lora_manager.fuse_lora(lora_scale=1.0)
+
+    # Build PEFT reference
+    torch_pipeline.load_lora_weights(lora_path)
+    torch_pipeline.fuse_lora()
+
+    peft_unet_state_dict = torch_pipeline.unet.state_dict()
+    peft_state_dict = _get_lora_impacted_weights(peft_unet_state_dict)
+    ref_weights_dict = _build_reference_weights(peft_state_dict)
+
+    skipped_keys = []
+    for weights_name, ref_tensor in ref_weights_dict.items():
+        if weights_name not in lora_manager._base_weights_device:
+            skipped_keys.append(weights_name)
+            continue
+
+        tt_tensor = lora_manager._base_weights_device[weights_name]
+        # Tensors on a mesh device are sharded; use mesh_composer to concatenate shards when converting to torch.
+        is_mesh_device = isinstance(mesh_device, ttnn._ttnn.multi_device.MeshDevice)
+        mesh_composer = ttnn.ConcatMeshToTensor(mesh_device, dim=-1) if is_mesh_device else None
+        tt_torch_tensor = ttnn.to_torch(tt_tensor, mesh_composer=mesh_composer)
+
+        if tt_torch_tensor.shape != ref_tensor.shape:
+            logger.warning(f"Shape mismatch for {weights_name}: TT={tt_torch_tensor.shape} vs ref={ref_tensor.shape}")
+            continue
+
+        assert_with_pcc(ref_tensor, tt_torch_tensor, pcc=0.999)
+        assert_allclose(ref_tensor, tt_torch_tensor, atol=1e-2, rtol=1e-2)
+
+    assert (
+        not skipped_keys
+    ), f"{len(skipped_keys)} LoRA impacted weights were not fused into base weights. Following weights were not fused: {skipped_keys}"

--- a/models/demos/stable_diffusion_xl_base/lora/tests/test_lora_perf.py
+++ b/models/demos/stable_diffusion_xl_base/lora/tests/test_lora_perf.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
 import os
@@ -6,12 +6,12 @@ import os
 os.environ["TT_METAL_PROFILER_PROGRAM_SUPPORT_COUNT"] = "15000"
 
 import gc
+
 import pytest
 import torch
-import ttnn
-
 from diffusers import DiffusionPipeline
 
+import ttnn
 from models.demos.stable_diffusion_xl_base.lora.tt_lora_weights_manager import TtLoRAWeightsManager
 from models.demos.stable_diffusion_xl_base.tests.test_common import SDXL_L1_SMALL_SIZE
 from models.demos.stable_diffusion_xl_base.tt.model_configs import ModelOptimisations1024x1024
@@ -70,7 +70,7 @@ def test_lora_fuse(
     [
         (
             "pytest models/demos/stable_diffusion_xl_base/lora/tests/test_lora_perf.py::test_lora_fuse",
-            102_565_757,
+            166_329_976,
             "sdxl_lora_fuse",
             "sdxl_lora_fuse",
             1,

--- a/models/demos/stable_diffusion_xl_base/lora/tests/test_lora_perf.py
+++ b/models/demos/stable_diffusion_xl_base/lora/tests/test_lora_perf.py
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+os.environ["TT_METAL_PROFILER_PROGRAM_SUPPORT_COUNT"] = "15000"
+
+import gc
+import pytest
+import torch
+import ttnn
+
+from diffusers import DiffusionPipeline
+
+from models.demos.stable_diffusion_xl_base.lora.tt_lora_weights_manager import TtLoRAWeightsManager
+from models.demos.stable_diffusion_xl_base.tests.test_common import SDXL_L1_SMALL_SIZE
+from models.demos.stable_diffusion_xl_base.tt.model_configs import ModelOptimisations1024x1024
+from models.demos.stable_diffusion_xl_base.tt.tt_unet import TtUNet2DConditionModel
+from models.perf.device_perf_utils import run_model_device_perf_test
+
+
+def _get_diffusers_pipeline(model_location_generator, is_ci_env, is_ci_v2_env):
+    model_location = model_location_generator(
+        "stable-diffusion-xl-base-1.0", download_if_ci_v2=True, ci_v2_timeout_in_s=1800
+    )
+    pipeline = DiffusionPipeline.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0" if not is_ci_v2_env else model_location,
+        torch_dtype=torch.float32,
+        use_safetensors=True,
+        local_files_only=is_ci_env or is_ci_v2_env,
+    )
+
+    return pipeline
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
+def test_lora_fuse(
+    device,
+    model_location_generator,
+    is_ci_env,
+    is_ci_v2_env,
+    lora_path,
+):
+    pipeline_for_tt = _get_diffusers_pipeline(model_location_generator, is_ci_env, is_ci_v2_env)
+    pipeline_for_tt.unet.eval()
+    state_dict = pipeline_for_tt.unet.state_dict()
+
+    lora_mgr = TtLoRAWeightsManager(device, pipeline_for_tt)
+    model_config = ModelOptimisations1024x1024()
+    tt_unet = TtUNet2DConditionModel(
+        device,
+        state_dict,
+        "unet",
+        model_config=model_config,
+        debug_mode=False,
+        lora_weights_manager=lora_mgr,
+    )
+
+    lora_mgr.load_lora_weights(lora_path)
+    ttnn.ReadDeviceProfiler(device)
+    lora_mgr.fuse_lora(lora_scale=1.0)
+    ttnn.ReadDeviceProfiler(device)
+
+    del pipeline_for_tt, tt_unet, lora_mgr
+    gc.collect()
+
+
+@pytest.mark.parametrize(
+    "command, expected_device_perf_ns_per_iteration, subdir, model_name, num_iterations, batch_size, margin, comments",
+    [
+        (
+            "pytest models/demos/stable_diffusion_xl_base/lora/tests/test_lora_perf.py::test_lora_fuse",
+            102_565_757,
+            "sdxl_lora_fuse",
+            "sdxl_lora_fuse",
+            1,
+            1,
+            0.015,
+            "",
+        ),
+    ],
+    ids=["test_lora_fuse"],
+)
+@pytest.mark.models_device_performance_bare_metal
+def test_lora_perf_device(
+    command, expected_device_perf_ns_per_iteration, subdir, model_name, num_iterations, batch_size, margin, comments
+):
+    os.environ["TT_MM_THROTTLE_PERF"] = "5"
+
+    run_model_device_perf_test(
+        command=command,
+        expected_device_perf_ns_per_iteration=expected_device_perf_ns_per_iteration,
+        subdir=subdir,
+        model_name=model_name,
+        num_iterations=num_iterations,
+        batch_size=batch_size,
+        margin=margin,
+        comments=comments,
+    )

--- a/models/demos/stable_diffusion_xl_base/lora/tests/test_lora_rollback.py
+++ b/models/demos/stable_diffusion_xl_base/lora/tests/test_lora_rollback.py
@@ -1,27 +1,24 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-import ttnn
 import torch
 from diffusers import DiffusionPipeline
-from transformers import CLIPTextModelWithProjection, CLIPTextModel
+from transformers import CLIPTextModel, CLIPTextModelWithProjection
 
+import ttnn
+from conftest import is_galaxy
 from models.demos.stable_diffusion_xl_base.tests.test_common import (
+    CONCATENATED_TEXT_EMBEDINGS_SIZE,
+    MAX_SEQUENCE_LENGTH,
     SDXL_L1_SMALL_SIZE,
     SDXL_TRACE_REGION_SIZE,
-    determinate_min_batch_size,
-    MAX_SEQUENCE_LENGTH,
     TEXT_ENCODER_2_PROJECTION_DIM,
-    CONCATENATED_TEXT_EMBEDINGS_SIZE,
+    determinate_min_batch_size,
     prepare_device,
 )
-from conftest import is_galaxy
-from models.demos.stable_diffusion_xl_base.tt.tt_sdxl_pipeline import (
-    TtSDXLPipeline,
-    TtSDXLPipelineConfig,
-)
+from models.demos.stable_diffusion_xl_base.tt.tt_sdxl_pipeline import TtSDXLPipeline, TtSDXLPipelineConfig
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 

--- a/models/demos/stable_diffusion_xl_base/lora/tests/test_lora_rollback.py
+++ b/models/demos/stable_diffusion_xl_base/lora/tests/test_lora_rollback.py
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import ttnn
+import torch
+from diffusers import DiffusionPipeline
+from transformers import CLIPTextModelWithProjection, CLIPTextModel
+
+from models.demos.stable_diffusion_xl_base.tests.test_common import (
+    SDXL_L1_SMALL_SIZE,
+    SDXL_TRACE_REGION_SIZE,
+    determinate_min_batch_size,
+    MAX_SEQUENCE_LENGTH,
+    TEXT_ENCODER_2_PROJECTION_DIM,
+    CONCATENATED_TEXT_EMBEDINGS_SIZE,
+    prepare_device,
+)
+from conftest import is_galaxy
+from models.demos.stable_diffusion_xl_base.tt.tt_sdxl_pipeline import (
+    TtSDXLPipeline,
+    TtSDXLPipelineConfig,
+)
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+def _run_forward_pass(tt_sdxl, pipeline, prompt, negative_prompt, batch_size):
+    prompts = [prompt] + [""] * (batch_size - 1)
+    negative_prompts = [negative_prompt] + [""] * (batch_size - 1)
+    all_prompt_embeds_torch, torch_add_text_embeds = tt_sdxl.encode_prompts(prompts, negative_prompts)
+    tt_latents, tt_prompt_embeds, tt_add_text_embeds = tt_sdxl.generate_input_tensors(
+        all_prompt_embeds_torch, torch_add_text_embeds, start_latent_seed=0
+    )
+    tt_sdxl.prepare_input_tensors([tt_latents, tt_prompt_embeds[0], tt_add_text_embeds[0]])
+    imgs = tt_sdxl.generate_images()
+    img = imgs[0].unsqueeze(0)
+    out = pipeline.image_processor.postprocess(img, output_type="pt")
+    return out[0]
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"l1_small_size": SDXL_L1_SMALL_SIZE, "trace_region_size": SDXL_TRACE_REGION_SIZE}],
+    indirect=["device_params"],
+)
+@pytest.mark.parametrize(
+    "prompt, negative_prompt, lora_prompt",
+    [
+        (
+            "An astronaut riding a green horse",
+            "disturbing",
+            "A Coloring Book of an astronaut riding a green horse",
+        )
+    ],
+)
+@torch.no_grad()
+def test_lora_rollback(mesh_device, is_ci_env, lora_path, prompt, negative_prompt, lora_prompt):
+    prepare_device(mesh_device, use_cfg_parallel=False)
+    batch_size = determinate_min_batch_size(mesh_device, use_cfg_parallel=False)
+
+    pipeline = DiffusionPipeline.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0",
+        torch_dtype=torch.float32,
+        use_safetensors=True,
+        local_files_only=is_ci_env,
+    )
+    assert isinstance(pipeline.text_encoder, CLIPTextModel)
+    assert isinstance(pipeline.text_encoder_2, CLIPTextModelWithProjection)
+
+    tt_sdxl = TtSDXLPipeline(
+        ttnn_device=mesh_device,
+        torch_pipeline=pipeline,
+        pipeline_config=TtSDXLPipelineConfig(
+            capture_trace=False,
+            vae_on_device=True,
+            encoders_on_device=True,
+            num_inference_steps=50,
+            guidance_scale=5.0,
+            is_galaxy=is_galaxy(),
+            use_cfg_parallel=False,
+            crop_coords_top_left=(0, 0),
+            guidance_rescale=0.0,
+        ),
+    )
+
+    tt_sdxl.compile_text_encoding()
+    tt_sdxl.generate_input_tensors(
+        all_prompt_embeds_torch=torch.randn(batch_size, 2, MAX_SEQUENCE_LENGTH, CONCATENATED_TEXT_EMBEDINGS_SIZE),
+        torch_add_text_embeds=torch.randn(batch_size, 2, TEXT_ENCODER_2_PROJECTION_DIM),
+        timesteps=None,
+        sigmas=None,
+    )
+    tt_sdxl.compile_image_processing()
+
+    img_base = _run_forward_pass(tt_sdxl, pipeline, prompt, negative_prompt, batch_size)
+
+    tt_sdxl.load_lora_weights(lora_path)
+    tt_sdxl.fuse_lora()
+    _run_forward_pass(tt_sdxl, pipeline, lora_prompt, negative_prompt, batch_size)
+
+    tt_sdxl.unload_lora_weights()
+    img_rollback = _run_forward_pass(tt_sdxl, pipeline, prompt, negative_prompt, batch_size)
+
+    ttnn.synchronize_device(mesh_device)
+
+    assert_with_pcc(img_base, img_rollback, pcc=1.0)

--- a/models/demos/stable_diffusion_xl_base/lora/tt_lora_weights_manager.py
+++ b/models/demos/stable_diffusion_xl_base/lora/tt_lora_weights_manager.py
@@ -1,0 +1,202 @@
+import re
+from loguru import logger
+from collections import defaultdict
+import ttnn
+
+
+class TtLoRAWeightsManager:
+    def __init__(self, device, torch_pipeline):
+        self._device = device
+        self._torch_pipeline = torch_pipeline
+
+        self._base_weights_host = {}
+        self._base_weights_device = {}
+
+        self._mm_compute_config = ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.HiFi2,
+            math_approx_mode=False,
+            fp32_dest_acc_en=False,
+            packer_l1_acc=True,
+        )
+
+    def prepare_lora_linear_params(self, device, weights, bias, dtype, name, permute_weights=True):
+        if permute_weights:
+            weights = weights.movedim(-1, -2)
+        tt_weights_host = ttnn.from_torch(weights, dtype, layout=ttnn.TILE_LAYOUT)
+        tt_weights_device = ttnn.allocate_tensor_on_device(tt_weights_host.spec, device)
+        ttnn.copy_host_to_device_tensor(tt_weights_host, tt_weights_device)
+        tt_bias = ttnn.from_torch(bias, dtype, device=device, layout=ttnn.TILE_LAYOUT) if bias is not None else None
+
+        self._base_weights_host[f"{name}.weight"] = tt_weights_host
+        self._base_weights_device[f"{name}.weight"] = tt_weights_device
+        return tt_weights_device, tt_bias
+
+    def get_lora_adapters(self):
+        return self._torch_pipeline.get_list_adapters()
+
+    def has_lora_adapter(self):
+        return any(self.get_lora_adapters().values())
+
+    def _uses_dora(self):
+        adapters = self.get_lora_adapters()
+        unet_adapters = adapters.get("unet", [])
+        if not unet_adapters:
+            return False
+
+        adapter_name = unet_adapters[0]
+        unet = self._torch_pipeline.unet
+
+        for _, module in unet.named_modules():
+            use_dora_dict = getattr(module, "use_dora", None)
+            if use_dora_dict and use_dora_dict.get(adapter_name, False):
+                return True
+
+        return False
+
+    def _affects_non_unet(self):
+        adapters = self.get_lora_adapters()
+        return any(component != "unet" and adapter_list for component, adapter_list in adapters.items())
+
+    def load_lora_weights(self, lora_path):
+        if self.has_lora_adapter():
+            logger.info("LoRA weights already loaded, skipping.")
+            return
+
+        self._torch_pipeline.load_lora_weights(lora_path)
+
+        if self._affects_non_unet():
+            logger.warning("Only LoRA affecting the UNet is supported, skipping loading LoRA weights")
+            self._torch_pipeline.unload_lora_weights()
+            return
+
+        if self._uses_dora():
+            logger.warning("DoRA is not supported, skipping loading LoRA weights")
+            self._torch_pipeline.unload_lora_weights()
+            return
+
+    def fuse_lora(self, lora_scale=1.0):
+        if not self.has_lora_adapter():
+            logger.warning("No LoRA weights loaded. Please load LoRA weights with load_lora_weights() before fusing.")
+            return
+
+        lora_params = self._get_lora_params()
+        if not lora_params:
+            logger.info("No LoRA parameters affecting the UNet were found. LoRA will have no effect.")
+            return
+
+        # Process self-attention Q, K and V matrices separately
+        self_attention_matrices = defaultdict(dict)
+
+        for layer_path, (lora_a, lora_b, scaling) in lora_params.items():
+            scale = scaling * lora_scale
+            # (B@A)^T = A^T @ B^T
+            # lora_a: [rank, in] -> lora_a_T: [in, rank]
+            # lora_b: [out, rank] -> lora_b_T: [rank, out]
+            lora_a_T = lora_a.movedim(-1, -2).unsqueeze(0).unsqueeze(0)
+            lora_b_T = lora_b.movedim(-1, -2).unsqueeze(0).unsqueeze(0)
+
+            # Collect self-attention QKV weights matrices
+            if layer_path.endswith((".to_q", ".to_k", ".to_v")):
+                attn_path, component = layer_path.rsplit(".", 1)
+                if f"{attn_path}.to_qkv.weight" in self._base_weights_device:
+                    lora_a_tt = ttnn.from_torch(
+                        lora_a_T, dtype=ttnn.bfloat8_b, device=self._device, layout=ttnn.TILE_LAYOUT
+                    )
+                    lora_b_tt = ttnn.from_torch(
+                        lora_b_T, dtype=ttnn.bfloat8_b, device=self._device, layout=ttnn.TILE_LAYOUT
+                    )
+                    delta_tt = ttnn.mul(
+                        ttnn.matmul(lora_a_tt, lora_b_tt, compute_kernel_config=self._mm_compute_config), scale
+                    )
+                    self_attention_matrices[attn_path][component] = delta_tt
+                    continue
+
+            # Process GEGLU weights
+            if (
+                f"{layer_path}.linear_1.weight" in self._base_weights_device
+                and f"{layer_path}.linear_2.weight" in self._base_weights_device
+            ):
+                lora_b1_T, lora_b2_T = lora_b_T.chunk(2, dim=-1)
+                lora_a_tt = ttnn.from_torch(
+                    lora_a_T, dtype=ttnn.bfloat8_b, device=self._device, layout=ttnn.TILE_LAYOUT
+                )
+                lora_b1_tt = ttnn.from_torch(
+                    lora_b1_T, dtype=ttnn.bfloat8_b, device=self._device, layout=ttnn.TILE_LAYOUT
+                )
+                lora_b2_tt = ttnn.from_torch(
+                    lora_b2_T, dtype=ttnn.bfloat8_b, device=self._device, layout=ttnn.TILE_LAYOUT
+                )
+                delta_1 = ttnn.mul(
+                    ttnn.matmul(lora_a_tt, lora_b1_tt, compute_kernel_config=self._mm_compute_config), scale
+                )
+                delta_2 = ttnn.mul(
+                    ttnn.matmul(lora_a_tt, lora_b2_tt, compute_kernel_config=self._mm_compute_config), scale
+                )
+                self._apply_delta(f"{layer_path}.linear_1.weight", delta_1)
+                self._apply_delta(f"{layer_path}.linear_2.weight", delta_2)
+                continue
+
+            # Process cross-attn Q/K/V, to_out, proj_in/out, ff.net.2 weights
+            lora_a_tt = ttnn.from_torch(lora_a_T, dtype=ttnn.bfloat8_b, device=self._device, layout=ttnn.TILE_LAYOUT)
+            lora_b_tt = ttnn.from_torch(lora_b_T, dtype=ttnn.bfloat8_b, device=self._device, layout=ttnn.TILE_LAYOUT)
+            delta_tt = ttnn.mul(ttnn.matmul(lora_a_tt, lora_b_tt, compute_kernel_config=self._mm_compute_config), scale)
+            self._apply_delta(f"{layer_path}.weight", delta_tt)
+
+        self._apply_qkv_deltas(self_attention_matrices)
+
+        ttnn.synchronize_device(self._device)
+
+    def _get_lora_params(self):
+        unet = self._torch_pipeline.unet
+        lora_params = {}
+
+        for name, module in unet.named_modules():
+            if not (hasattr(module, "lora_A") and hasattr(module, "lora_B")):
+                continue
+
+            clean_name = re.sub(r"^base_model\.model\.", "", name)
+
+            adapter_names = list(module.lora_A.keys())
+            if not adapter_names:
+                continue
+            # TODO: Handle multiple adapters
+            adapter_name = adapter_names[0]
+
+            lora_a = module.lora_A[adapter_name].weight.data
+            lora_b = module.lora_B[adapter_name].weight.data
+            scaling = module.scaling.get(adapter_name, 1.0) if hasattr(module, "scaling") else 1.0
+
+            lora_params[clean_name] = (lora_a, lora_b, scaling)
+
+        return lora_params
+
+    def _apply_delta(self, base_key, delta):
+        if base_key not in self._base_weights_device:
+            logger.debug(f"Base weight key {base_key} not found, skipping LoRA fusion for this layer.")
+            return
+
+        ttnn.add_(self._base_weights_device[base_key], delta)
+
+    def _apply_qkv_deltas(self, qkv_pending):
+        for attn_path, components in qkv_pending.items():
+            qkv_key = f"{attn_path}.to_qkv.weight"
+            if qkv_key not in self._base_weights_device:
+                logger.debug(f"Base weight key {qkv_key} not found, skipping LoRA fusion for this layer.")
+                continue
+
+            to_q = components["to_q"]
+            to_k = components["to_k"]
+            to_v = components["to_v"]
+
+            qkv_delta_tt = ttnn.concat([to_q, to_k, to_v], dim=-1)
+
+            ttnn.add_(self._base_weights_device[qkv_key], qkv_delta_tt)
+
+    def unload_lora_weights(self):
+        # Restore original base weights to the device
+        for key in self._base_weights_device.keys():
+            host_tensor = self._base_weights_host[key]
+            device_tensor = self._base_weights_device[key]
+            ttnn.copy_host_to_device_tensor(host_tensor, device_tensor)
+
+        self._torch_pipeline.unload_lora_weights()

--- a/models/demos/stable_diffusion_xl_base/lora/tt_lora_weights_manager.py
+++ b/models/demos/stable_diffusion_xl_base/lora/tt_lora_weights_manager.py
@@ -1,6 +1,12 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
 import re
-from loguru import logger
 from collections import defaultdict
+
+from loguru import logger
+
 import ttnn
 
 
@@ -18,6 +24,8 @@ class TtLoRAWeightsManager:
             fp32_dest_acc_en=False,
             packer_l1_acc=True,
         )
+
+        self._is_fused = False
 
     def prepare_lora_linear_params(self, device, weights, bias, dtype, name, permute_weights=True):
         if permute_weights:
@@ -79,6 +87,10 @@ class TtLoRAWeightsManager:
             logger.warning("No LoRA weights loaded. Please load LoRA weights with load_lora_weights() before fusing.")
             return
 
+        if self._is_fused:
+            logger.info("LoRA weights already fused. Skipping fusion.")
+            return
+
         lora_params = self._get_lora_params()
         if not lora_params:
             logger.info("No LoRA parameters affecting the UNet were found. LoRA will have no effect.")
@@ -100,10 +112,10 @@ class TtLoRAWeightsManager:
                 attn_path, component = layer_path.rsplit(".", 1)
                 if f"{attn_path}.to_qkv.weight" in self._base_weights_device:
                     lora_a_tt = ttnn.from_torch(
-                        lora_a_T, dtype=ttnn.bfloat8_b, device=self._device, layout=ttnn.TILE_LAYOUT
+                        lora_a_T, dtype=ttnn.bfloat16, device=self._device, layout=ttnn.TILE_LAYOUT
                     )
                     lora_b_tt = ttnn.from_torch(
-                        lora_b_T, dtype=ttnn.bfloat8_b, device=self._device, layout=ttnn.TILE_LAYOUT
+                        lora_b_T, dtype=ttnn.bfloat16, device=self._device, layout=ttnn.TILE_LAYOUT
                     )
                     delta_tt = ttnn.mul(
                         ttnn.matmul(lora_a_tt, lora_b_tt, compute_kernel_config=self._mm_compute_config), scale
@@ -117,14 +129,12 @@ class TtLoRAWeightsManager:
                 and f"{layer_path}.linear_2.weight" in self._base_weights_device
             ):
                 lora_b1_T, lora_b2_T = lora_b_T.chunk(2, dim=-1)
-                lora_a_tt = ttnn.from_torch(
-                    lora_a_T, dtype=ttnn.bfloat8_b, device=self._device, layout=ttnn.TILE_LAYOUT
-                )
+                lora_a_tt = ttnn.from_torch(lora_a_T, dtype=ttnn.bfloat16, device=self._device, layout=ttnn.TILE_LAYOUT)
                 lora_b1_tt = ttnn.from_torch(
-                    lora_b1_T, dtype=ttnn.bfloat8_b, device=self._device, layout=ttnn.TILE_LAYOUT
+                    lora_b1_T, dtype=ttnn.bfloat16, device=self._device, layout=ttnn.TILE_LAYOUT
                 )
                 lora_b2_tt = ttnn.from_torch(
-                    lora_b2_T, dtype=ttnn.bfloat8_b, device=self._device, layout=ttnn.TILE_LAYOUT
+                    lora_b2_T, dtype=ttnn.bfloat16, device=self._device, layout=ttnn.TILE_LAYOUT
                 )
                 delta_1 = ttnn.mul(
                     ttnn.matmul(lora_a_tt, lora_b1_tt, compute_kernel_config=self._mm_compute_config), scale
@@ -137,14 +147,15 @@ class TtLoRAWeightsManager:
                 continue
 
             # Process cross-attn Q/K/V, to_out, proj_in/out, ff.net.2 weights
-            lora_a_tt = ttnn.from_torch(lora_a_T, dtype=ttnn.bfloat8_b, device=self._device, layout=ttnn.TILE_LAYOUT)
-            lora_b_tt = ttnn.from_torch(lora_b_T, dtype=ttnn.bfloat8_b, device=self._device, layout=ttnn.TILE_LAYOUT)
+            lora_a_tt = ttnn.from_torch(lora_a_T, dtype=ttnn.bfloat16, device=self._device, layout=ttnn.TILE_LAYOUT)
+            lora_b_tt = ttnn.from_torch(lora_b_T, dtype=ttnn.bfloat16, device=self._device, layout=ttnn.TILE_LAYOUT)
             delta_tt = ttnn.mul(ttnn.matmul(lora_a_tt, lora_b_tt, compute_kernel_config=self._mm_compute_config), scale)
             self._apply_delta(f"{layer_path}.weight", delta_tt)
 
         self._apply_qkv_deltas(self_attention_matrices)
 
         ttnn.synchronize_device(self._device)
+        self._is_fused = True
 
     def _get_lora_params(self):
         unet = self._torch_pipeline.unet
@@ -200,3 +211,4 @@ class TtLoRAWeightsManager:
             ttnn.copy_host_to_device_tensor(host_tensor, device_tensor)
 
         self._torch_pipeline.unload_lora_weights()
+        self._is_fused = False

--- a/models/demos/stable_diffusion_xl_base/tt/tt_attention.py
+++ b/models/demos/stable_diffusion_xl_base/tt/tt_attention.py
@@ -21,6 +21,7 @@ class TtAttention(LightweightModule):
         out_dim: int = None,
         kv_heads=None,
         dim_head: int = 64,
+        lora_weights_manager=None,
     ):
         super().__init__()
         self.device = device
@@ -64,13 +65,34 @@ class TtAttention(LightweightModule):
                 ],
                 dim=-1,
             )
-            self.tt_qkv_weights = ttnn.from_torch(
-                fused_qkv_weights, attention_weights_dtype, device=device, layout=ttnn.TILE_LAYOUT
-            )
+            if lora_weights_manager:
+                self.tt_qkv_weights, _ = lora_weights_manager.prepare_lora_linear_params(
+                    device,
+                    fused_qkv_weights,
+                    None,
+                    attention_weights_dtype,
+                    f"{module_path}.to_qkv",
+                    permute_weights=False,
+                )
+            else:
+                self.tt_qkv_weights = ttnn.from_torch(
+                    fused_qkv_weights, attention_weights_dtype, device=device, layout=ttnn.TILE_LAYOUT
+                )
         else:
-            self.tt_q_weights, _ = prepare_linear_params(device, q_weights, None, attention_weights_dtype)
-            self.tt_k_weights, _ = prepare_linear_params(device, k_weights, None, attention_weights_dtype)
-            self.tt_v_weights, _ = prepare_linear_params(device, v_weights, None, attention_weights_dtype)
+            if lora_weights_manager:
+                self.tt_q_weights, _ = lora_weights_manager.prepare_lora_linear_params(
+                    device, q_weights, None, attention_weights_dtype, f"{module_path}.to_q"
+                )
+                self.tt_k_weights, _ = lora_weights_manager.prepare_lora_linear_params(
+                    device, k_weights, None, attention_weights_dtype, f"{module_path}.to_k"
+                )
+                self.tt_v_weights, _ = lora_weights_manager.prepare_lora_linear_params(
+                    device, v_weights, None, attention_weights_dtype, f"{module_path}.to_v"
+                )
+            else:
+                self.tt_q_weights, _ = prepare_linear_params(device, q_weights, None, attention_weights_dtype)
+                self.tt_k_weights, _ = prepare_linear_params(device, k_weights, None, attention_weights_dtype)
+                self.tt_v_weights, _ = prepare_linear_params(device, v_weights, None, attention_weights_dtype)
 
             self.k_program_config = model_config.get_matmul_config(f"{module_path}.to_k")
             self.v_program_config = model_config.get_matmul_config(f"{module_path}.to_v")
@@ -78,9 +100,14 @@ class TtAttention(LightweightModule):
             self.k_memory_config = model_config.get_mm_output_memory_config(f"{module_path}.to_k")
             self.v_memory_config = model_config.get_mm_output_memory_config(f"{module_path}.to_v")
 
-        self.tt_out_weights, self.tt_out_bias = prepare_linear_params(
-            device, out_weights, out_bias, attention_weights_dtype
-        )
+        if lora_weights_manager:
+            self.tt_out_weights, self.tt_out_bias = lora_weights_manager.prepare_lora_linear_params(
+                device, out_weights, out_bias, attention_weights_dtype, f"{module_path}.to_out.0"
+            )
+        else:
+            self.tt_out_weights, self.tt_out_bias = prepare_linear_params(
+                device, out_weights, out_bias, attention_weights_dtype
+            )
 
         self.q_program_config = model_config.get_matmul_config(f"{module_path}.to_q")
         self.q_compute_kernel_config = model_config.get_mm_compute_config(f"{module_path}.to_q")

--- a/models/demos/stable_diffusion_xl_base/tt/tt_crossattndownblock2d.py
+++ b/models/demos/stable_diffusion_xl_base/tt/tt_crossattndownblock2d.py
@@ -21,6 +21,7 @@ class TtCrossAttnDownBlock2D(LightweightModule):
         out_dim,
         has_downsample=False,
         debug_mode=False,
+        lora_weights_manager=None,
     ):
         super().__init__()
 
@@ -39,6 +40,7 @@ class TtCrossAttnDownBlock2D(LightweightModule):
                     query_dim,
                     num_attn_heads,
                     out_dim,
+                    lora_weights_manager=lora_weights_manager,
                 )
             )
 

--- a/models/demos/stable_diffusion_xl_base/tt/tt_crossattnmidblock2d.py
+++ b/models/demos/stable_diffusion_xl_base/tt/tt_crossattnmidblock2d.py
@@ -18,6 +18,7 @@ class TtUNetMidBlock2DCrossAttn(LightweightModule):
         num_attn_heads,
         out_dim,
         debug_mode=False,
+        lora_weights_manager=None,
     ):
         super().__init__()
 
@@ -36,6 +37,7 @@ class TtUNetMidBlock2DCrossAttn(LightweightModule):
                     query_dim,
                     num_attn_heads,
                     out_dim,
+                    lora_weights_manager=lora_weights_manager,
                 )
             )
 

--- a/models/demos/stable_diffusion_xl_base/tt/tt_crossattnupblock2d.py
+++ b/models/demos/stable_diffusion_xl_base/tt/tt_crossattnupblock2d.py
@@ -21,6 +21,7 @@ class TtCrossAttnUpBlock2D(LightweightModule):
         out_dim,
         has_upsample=False,
         debug_mode=False,
+        lora_weights_manager=None,
     ):
         super().__init__()
 
@@ -39,6 +40,7 @@ class TtCrossAttnUpBlock2D(LightweightModule):
                     query_dim,
                     num_attn_heads,
                     out_dim,
+                    lora_weights_manager=lora_weights_manager,
                 )
             )
 

--- a/models/demos/stable_diffusion_xl_base/tt/tt_feedforward.py
+++ b/models/demos/stable_diffusion_xl_base/tt/tt_feedforward.py
@@ -15,17 +15,25 @@ class TtFeedForward(LightweightModule):
         state_dict,
         module_path,
         model_config,
+        lora_weights_manager=None,
     ):
         super().__init__()
 
         self.device = device
-        self.tt_geglu = TtGEGLU(device, state_dict, f"{module_path}.net.0", model_config)
+        self.tt_geglu = TtGEGLU(
+            device, state_dict, f"{module_path}.net.0", model_config, lora_weights_manager=lora_weights_manager
+        )
 
         weights = state_dict[f"{module_path}.net.2.weight"].unsqueeze(0).unsqueeze(0)
         bias = state_dict[f"{module_path}.net.2.bias"]
 
         ff_weights_dtype = model_config.ff_weights_dtype
-        self.tt_weights, self.tt_bias = prepare_linear_params(device, weights, bias, ff_weights_dtype)
+        if lora_weights_manager:
+            self.tt_weights, self.tt_bias = lora_weights_manager.prepare_lora_linear_params(
+                device, weights, bias, ff_weights_dtype, f"{module_path}.net.2"
+            )
+        else:
+            self.tt_weights, self.tt_bias = prepare_linear_params(device, weights, bias, ff_weights_dtype)
 
         self.ff2_model_config = model_config.get_matmul_config(f"{module_path}.net.2")
         self.default_compute_kernel_config = model_config.get_mm_compute_config(module_path)

--- a/models/demos/stable_diffusion_xl_base/tt/tt_geglu.py
+++ b/models/demos/stable_diffusion_xl_base/tt/tt_geglu.py
@@ -9,7 +9,7 @@ from models.demos.stable_diffusion_xl_base.tt.sdxl_utility import prepare_linear
 
 
 class TtGEGLU(LightweightModule):
-    def __init__(self, device, state_dict, module_path, model_config):
+    def __init__(self, device, state_dict, module_path, model_config, lora_weights_manager=None):
         super().__init__()
         self.device = device
 
@@ -26,8 +26,16 @@ class TtGEGLU(LightweightModule):
         w2 = w2.unsqueeze(0).unsqueeze(0)  # same
 
         ff_weights_dtype = model_config.ff_weights_dtype
-        self.tt_weights_1, self.tt_bias_1 = prepare_linear_params(device, w1, b1, ff_weights_dtype)
-        self.tt_weights_2, self.tt_bias_2 = prepare_linear_params(device, w2, b2, ff_weights_dtype)
+        if lora_weights_manager:
+            self.tt_weights_1, self.tt_bias_1 = lora_weights_manager.prepare_lora_linear_params(
+                device, w1, b1, ff_weights_dtype, f"{module_path}.proj.linear_1"
+            )
+            self.tt_weights_2, self.tt_bias_2 = lora_weights_manager.prepare_lora_linear_params(
+                device, w2, b2, ff_weights_dtype, f"{module_path}.proj.linear_2"
+            )
+        else:
+            self.tt_weights_1, self.tt_bias_1 = prepare_linear_params(device, w1, b1, ff_weights_dtype)
+            self.tt_weights_2, self.tt_bias_2 = prepare_linear_params(device, w2, b2, ff_weights_dtype)
 
         self.program_config = model_config.get_matmul_config(matmul_path=f"{module_path}.proj.split")
         self.program_config_gelu = model_config.get_matmul_config(matmul_path=f"{module_path}.proj.split.gelu")

--- a/models/demos/stable_diffusion_xl_base/tt/tt_sdxl_pipeline.py
+++ b/models/demos/stable_diffusion_xl_base/tt/tt_sdxl_pipeline.py
@@ -27,7 +27,7 @@ from models.demos.stable_diffusion_xl_base.tt.tt_euler_discrete_scheduler import
 from models.demos.stable_diffusion_xl_base.tt.tt_unet import TtUNet2DConditionModel
 from models.demos.stable_diffusion_xl_base.vae.tt.model_configs import load_vae_model_optimisations
 from models.demos.stable_diffusion_xl_base.vae.tt.tt_autoencoder_kl import TtAutoencoderKL
-
+from models.demos.stable_diffusion_xl_base.lora.tt_lora_weights_manager import TtLoRAWeightsManager
 
 @dataclass
 class TtSDXLPipelineConfig:
@@ -72,6 +72,9 @@ class TtSDXLPipeline(LightweightModule):
             "`_debug_mode` and `capture_trace` cannot both be enabled at the same time. "
             "Please set only one of them to True."
         )
+        assert len(torch_pipeline.get_list_adapters()) == 0, (
+            "Torch pipeline must not have LoRA weights loaded. " "Use TtSDXLPipeline interface to manage LoRA weights."
+        )
 
         self.ttnn_device = ttnn_device
         self.cpu_device = "cpu"
@@ -79,6 +82,8 @@ class TtSDXLPipeline(LightweightModule):
         self.torch_pipeline = torch_pipeline
         self.pipeline_config = pipeline_config
         self._reset_num_inference_steps()
+
+        self._lora_weights_manager = TtLoRAWeightsManager(self.ttnn_device, self.torch_pipeline)
 
         # Validate config parameters once at initialization
         self.__validate_config()
@@ -173,6 +178,19 @@ class TtSDXLPipeline(LightweightModule):
             int(width) // self.torch_pipeline.vae_scale_factor,
         )
         return shape
+
+    def fuse_lora(self, lora_scale=1.0):
+        if self._lora_weights_manager.has_lora_adapter():
+            logger.info("Fusing LoRA weights on TT device...")
+            with ttnn.distribute(ttnn.ReplicateTensorToMesh(self.ttnn_device)):
+                self._lora_weights_manager.fuse_lora(lora_scale=lora_scale)
+
+    def load_lora_weights(self, lora_path):
+        self._lora_weights_manager.load_lora_weights(lora_path)
+
+    def unload_lora_weights(self):
+        with ttnn.distribute(ttnn.ReplicateTensorToMesh(self.ttnn_device)):
+            self._lora_weights_manager.unload_lora_weights()
 
     def set_num_inference_steps(self, num_inference_steps: int):
         # When changing num_inference_steps, the timesteps and latents need to be recreated.
@@ -761,6 +779,7 @@ class TtSDXLPipeline(LightweightModule):
                 "unet",
                 model_config=self.tt_unet_model_config,
                 debug_mode=pipeline_config._debug_mode,
+                lora_weights_manager=self._lora_weights_manager,
             )
 
             # 2. Load tt_vae

--- a/models/demos/stable_diffusion_xl_base/tt/tt_sdxl_pipeline.py
+++ b/models/demos/stable_diffusion_xl_base/tt/tt_sdxl_pipeline.py
@@ -13,6 +13,7 @@ from transformers import CLIPTextModel, CLIPTextModelWithProjection
 import ttnn
 from models.common.lightweightmodule import LightweightModule
 from models.common.utility_functions import profiler
+from models.demos.stable_diffusion_xl_base.lora.tt_lora_weights_manager import TtLoRAWeightsManager
 from models.demos.stable_diffusion_xl_base.refiner.tt.model_configs import load_refiner_model_optimisations
 from models.demos.stable_diffusion_xl_base.tests.test_common import (
     batch_encode_prompt_on_device,
@@ -27,7 +28,7 @@ from models.demos.stable_diffusion_xl_base.tt.tt_euler_discrete_scheduler import
 from models.demos.stable_diffusion_xl_base.tt.tt_unet import TtUNet2DConditionModel
 from models.demos.stable_diffusion_xl_base.vae.tt.model_configs import load_vae_model_optimisations
 from models.demos.stable_diffusion_xl_base.vae.tt.tt_autoencoder_kl import TtAutoencoderKL
-from models.demos.stable_diffusion_xl_base.lora.tt_lora_weights_manager import TtLoRAWeightsManager
+
 
 @dataclass
 class TtSDXLPipelineConfig:
@@ -72,7 +73,7 @@ class TtSDXLPipeline(LightweightModule):
             "`_debug_mode` and `capture_trace` cannot both be enabled at the same time. "
             "Please set only one of them to True."
         )
-        assert len(torch_pipeline.get_list_adapters()) == 0, (
+        assert not any(torch_pipeline.get_list_adapters().values()), (
             "Torch pipeline must not have LoRA weights loaded. " "Use TtSDXLPipeline interface to manage LoRA weights."
         )
 

--- a/models/demos/stable_diffusion_xl_base/tt/tt_transformerblock.py
+++ b/models/demos/stable_diffusion_xl_base/tt/tt_transformerblock.py
@@ -19,6 +19,7 @@ class TtBasicTransformerBlock(LightweightModule):
         query_dim,
         num_attn_heads,
         out_dim,
+        lora_weights_manager=None,
     ):
         super().__init__()
 
@@ -33,6 +34,7 @@ class TtBasicTransformerBlock(LightweightModule):
             query_dim,
             num_attn_heads,
             out_dim,
+            lora_weights_manager=lora_weights_manager,
         )
         self.attn2 = TtAttention(
             device,
@@ -42,9 +44,12 @@ class TtBasicTransformerBlock(LightweightModule):
             query_dim,
             num_attn_heads,
             out_dim,
+            lora_weights_manager=lora_weights_manager,
         )
 
-        self.ff = TtFeedForward(device, state_dict, f"{module_path}.ff", model_config)
+        self.ff = TtFeedForward(
+            device, state_dict, f"{module_path}.ff", model_config, lora_weights_manager=lora_weights_manager
+        )
 
         norm1_weights = state_dict[f"{module_path}.norm1.weight"]
         norm1_bias = state_dict[f"{module_path}.norm1.bias"]

--- a/models/demos/stable_diffusion_xl_base/tt/tt_transformermodel.py
+++ b/models/demos/stable_diffusion_xl_base/tt/tt_transformermodel.py
@@ -11,11 +11,20 @@ from models.demos.stable_diffusion_xl_base.tt.tt_transformerblock import TtBasic
 
 
 class TtTransformer2DModel(LightweightModule):
-    def __init__(self, device, state_dict, module_path, model_config, query_dim, num_attn_heads, out_dim):
+    def __init__(
+        self,
+        device,
+        state_dict,
+        module_path,
+        model_config,
+        query_dim,
+        num_attn_heads,
+        out_dim,
+        lora_weights_manager=None,
+    ):
         super().__init__()
 
         self.device = device
-
         self.norm_groups = 32
         self.norm_eps = 1e-6
 
@@ -34,6 +43,7 @@ class TtTransformer2DModel(LightweightModule):
                     query_dim,
                     num_attn_heads,
                     out_dim,
+                    lora_weights_manager=lora_weights_manager,
                 )
             )
 
@@ -57,11 +67,22 @@ class TtTransformer2DModel(LightweightModule):
         )  # keep this same as attention weights dtype at the moment
         weights = state_dict[f"{module_path}.proj_in.weight"].unsqueeze(0).unsqueeze(0)
         bias = state_dict[f"{module_path}.proj_in.bias"]
-        self.tt_weights_in, self.tt_bias_in = prepare_linear_params(device, weights, bias, proj_weights_dtype)
+        if lora_weights_manager:
+            self.tt_weights_in, self.tt_bias_in = lora_weights_manager.prepare_lora_linear_params(
+                device, weights, bias, proj_weights_dtype, f"{module_path}.proj_in"
+            )
+        else:
+            self.tt_weights_in, self.tt_bias_in = prepare_linear_params(device, weights, bias, proj_weights_dtype)
 
         weights = state_dict[f"{module_path}.proj_out.weight"].unsqueeze(0).unsqueeze(0)
         bias = state_dict[f"{module_path}.proj_out.bias"]
-        self.tt_weights_out, self.tt_bias_out = prepare_linear_params(device, weights, bias, proj_weights_dtype)
+
+        if lora_weights_manager:
+            self.tt_weights_out, self.tt_bias_out = lora_weights_manager.prepare_lora_linear_params(
+                device, weights, bias, proj_weights_dtype, f"{module_path}.proj_out"
+            )
+        else:
+            self.tt_weights_out, self.tt_bias_out = prepare_linear_params(device, weights, bias, proj_weights_dtype)
 
         self.program_config_in = model_config.get_matmul_config(matmul_path=f"{module_path}.proj_in")
         self.compute_config_in = model_config.get_mm_compute_config(f"{module_path}.proj_in")

--- a/models/demos/stable_diffusion_xl_base/tt/tt_unet.py
+++ b/models/demos/stable_diffusion_xl_base/tt/tt_unet.py
@@ -24,6 +24,7 @@ class TtUNet2DConditionModel(LightweightModule):
         module_path,
         model_config,
         debug_mode=False,
+        lora_weights_manager=None,
     ):
         super().__init__()
 
@@ -152,6 +153,7 @@ class TtUNet2DConditionModel(LightweightModule):
                     640,
                     True,
                     debug_mode=debug_mode,
+                    lora_weights_manager=lora_weights_manager,
                 )
             )
             self.down_blocks.append(
@@ -165,6 +167,7 @@ class TtUNet2DConditionModel(LightweightModule):
                     1280,
                     False,
                     debug_mode=debug_mode,
+                    lora_weights_manager=lora_weights_manager,
                 )
             )
 
@@ -177,6 +180,7 @@ class TtUNet2DConditionModel(LightweightModule):
                 20,
                 1280,
                 debug_mode=debug_mode,
+                lora_weights_manager=lora_weights_manager,
             )
 
             self.up_blocks.append(
@@ -190,6 +194,7 @@ class TtUNet2DConditionModel(LightweightModule):
                     1280,
                     True,
                     debug_mode=debug_mode,
+                    lora_weights_manager=lora_weights_manager,
                 )
             )
             self.up_blocks.append(
@@ -203,6 +208,7 @@ class TtUNet2DConditionModel(LightweightModule):
                     640,
                     True,
                     debug_mode=debug_mode,
+                    lora_weights_manager=lora_weights_manager,
                 )
             )
             self.up_blocks.append(TtUpBlock2D(device, state_dict, "up_blocks.2", model_config, debug_mode=debug_mode))

--- a/tests/nightly/single_card/stable_diffusion_xl_base/lora/test_lora_fusion.py
+++ b/tests/nightly/single_card/stable_diffusion_xl_base/lora/test_lora_fusion.py
@@ -1,0 +1,1 @@
+../../../../../models/demos/stable_diffusion_xl_base/lora/tests/test_lora_fusion.py

--- a/tests/nightly/single_card/stable_diffusion_xl_base/lora/test_lora_tt_attention.py
+++ b/tests/nightly/single_card/stable_diffusion_xl_base/lora/test_lora_tt_attention.py
@@ -1,0 +1,1 @@
+../../../../../models/demos/stable_diffusion_xl_base/lora/tests/pcc/test_lora_tt_attention.py

--- a/tests/nightly/single_card/stable_diffusion_xl_base/lora/test_lora_tt_crossattndownblock2d.py
+++ b/tests/nightly/single_card/stable_diffusion_xl_base/lora/test_lora_tt_crossattndownblock2d.py
@@ -1,0 +1,1 @@
+../../../../../models/demos/stable_diffusion_xl_base/lora/tests/pcc/test_lora_tt_crossattndownblock2d.py

--- a/tests/nightly/single_card/stable_diffusion_xl_base/lora/test_lora_tt_crossattnmidblock2d.py
+++ b/tests/nightly/single_card/stable_diffusion_xl_base/lora/test_lora_tt_crossattnmidblock2d.py
@@ -1,0 +1,1 @@
+../../../../../models/demos/stable_diffusion_xl_base/lora/tests/pcc/test_lora_tt_crossattnmidblock2d.py

--- a/tests/nightly/single_card/stable_diffusion_xl_base/lora/test_lora_tt_crossattnupblock2d.py
+++ b/tests/nightly/single_card/stable_diffusion_xl_base/lora/test_lora_tt_crossattnupblock2d.py
@@ -1,0 +1,1 @@
+../../../../../models/demos/stable_diffusion_xl_base/lora/tests/pcc/test_lora_tt_crossattnupblock2d.py

--- a/tests/nightly/single_card/stable_diffusion_xl_base/lora/test_lora_tt_feedforward.py
+++ b/tests/nightly/single_card/stable_diffusion_xl_base/lora/test_lora_tt_feedforward.py
@@ -1,0 +1,1 @@
+../../../../../models/demos/stable_diffusion_xl_base/lora/tests/pcc/test_lora_tt_feedforward.py

--- a/tests/nightly/single_card/stable_diffusion_xl_base/lora/test_lora_tt_geglu.py
+++ b/tests/nightly/single_card/stable_diffusion_xl_base/lora/test_lora_tt_geglu.py
@@ -1,0 +1,1 @@
+../../../../../models/demos/stable_diffusion_xl_base/lora/tests/pcc/test_lora_tt_geglu.py

--- a/tests/nightly/single_card/stable_diffusion_xl_base/lora/test_lora_tt_transformerblock.py
+++ b/tests/nightly/single_card/stable_diffusion_xl_base/lora/test_lora_tt_transformerblock.py
@@ -1,0 +1,1 @@
+../../../../../models/demos/stable_diffusion_xl_base/lora/tests/pcc/test_lora_tt_transformerblock.py

--- a/tests/nightly/single_card/stable_diffusion_xl_base/lora/test_lora_tt_transformermodel.py
+++ b/tests/nightly/single_card/stable_diffusion_xl_base/lora/test_lora_tt_transformermodel.py
@@ -1,0 +1,1 @@
+../../../../../models/demos/stable_diffusion_xl_base/lora/tests/pcc/test_lora_tt_transformermodel.py

--- a/tests/nightly/single_card/stable_diffusion_xl_base/lora/test_lora_tt_unet.py
+++ b/tests/nightly/single_card/stable_diffusion_xl_base/lora/test_lora_tt_unet.py
@@ -1,0 +1,1 @@
+../../../../../models/demos/stable_diffusion_xl_base/lora/tests/pcc/test_lora_tt_unet.py

--- a/tests/scripts/single_card/run_single_card_demo_tests.sh
+++ b/tests/scripts/single_card/run_single_card_demo_tests.sh
@@ -207,6 +207,7 @@ run_sdxl_func() {
   TT_MM_THROTTLE_PERF=5 $PYTEST_CMD models/demos/stable_diffusion_xl_base/demo/demo_base_and_refiner.py -k "device_vae and device_encoders and with_trace and no_cfg_parallel"
   TT_MM_THROTTLE_PERF=5 $PYTEST_CMD models/demos/stable_diffusion_xl_base/demo/demo_img2img.py -k "device_vae and device_encoders and with_trace and no_cfg_parallel"
   TT_MM_THROTTLE_PERF=5 $PYTEST_CMD models/demos/stable_diffusion_xl_base/demo/demo_inpainting.py -k "device_vae and device_encoders and with_trace and no_cfg_parallel"
+  TT_MM_THROTTLE_PERF=5 $PYTEST_CMD models/demos/stable_diffusion_xl_base/demo/demo_lora.py -k "device_vae and device_encoders and with_trace and no_cfg_parallel"
 }
 
 run_distilbert_func() {

--- a/tt_metal/python_env/requirements-dev.txt
+++ b/tt_metal/python_env/requirements-dev.txt
@@ -60,6 +60,7 @@ timm>=1.0.0
 opencv-python-headless==4.8.1.78
 diffusers==0.35.1
 accelerate==1.7.0
+peft==0.18.1
 ftfy==6.1.1
 gitpython==3.1.41
 einops==0.6.1


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/38732

### Problem description
TT should support LoRA adapters in the SDXL model by offering interface for loading, fusing and unloading weights. In the first iteration, only LoRA adapters that impact Unet model should be supported. Only one LoRA adapter at the time should be supported. Fusion should be performed in-place of base weights on the device.

### What's changed
This PR adds LoRA support to the TT SDXL pipeline so LoRA adapter can be loaded, fused, and unloaded on TT devices.

1. LoRA Weights Manager (`lora/tt_lora_weights_manager.py`)

- **`TtLoRAWeightsManager`**:
  - Keeps references to weights on host and device (`base_weights_host`, `base_weights_device`).
  - **`prepare_lora_linear_params()`**: Used by TT SDXL modules to register weights so `TtLoRAWeightsManager` can perform fusion and rollback.
  -   LoRA impacted Unet modules call `lora_weights_manager.prepare_lora_linear_params()` so their linear weights are registered for fusion (values in those tensors will be changed after the fusion).
  - **`load_lora_weights(lora_path)`**: Loads LoRA via the torch pipeline (diffusers). Only UNet LoRA is supported, CLIP encoder LoRAs and DoRA are unsupported.
  - **`fuse_lora(lora_scale=1.0)`**: Computes LoRA deltas (A@B with scaling) on device and adds them to the registered base weights.
  - **`unload_lora_weights()`**: Restores base weights from host to device and unloads LoRA from the torch pipeline.

2. SDXL pipeline integration (`tt/tt_sdxl_pipeline.py`)

- Pipeline constructs a **`TtLoRAWeightsManager`** and passes it when building the UNet (object is later propagated to all LoRA impacted Unet modules.
- `tt/tt_sdxl_pipeline.py` API is changed:
  - **`load_lora_weights(lora_path)`** - lora_path is path to the weights kept on the host.
  - **`fuse_lora(lora_scale=1.0)`**
  - **`unload_lora_weights()`**
- Torch pipeline must not have LoRA loaded; LoRA is managed only through this API.

3. Tests

- `test_lora_fusion.py` - Loads same LoRA in TT and torch pipelines, fuses both, compares TT fused weights to PEFT reference (PCC and tolerances); runs on n150. Added to the _Frequent model and ttnn tests pipeline_.
- `test_lora_rollback.py` - Generates image with base weights (1st output), generated images with LoRA weights fused (2nd output), generates image with base weights again (3rd output); checks if the  first and the third images are the same. Added to the _Nightly tt-metal L2 tests_ pipeline.
- `test_lora_perf.py` - Performance test with LoRA fused. Added to the _(Single-card) Device perf regressions_ pipeline.
- PCC tests (`lora/tests/pcc/`) - Module-level PCC for TT UNet, transformer model/block, attention, GEGLU, feedforward, cross-attn blocks with LoRA loaded and fused vs torch+PEFT. Added to the _Frequent model and ttnn tests pipeline_.
- 'lora_demo.py' - Demo that loads a LoRA, fuses it, runs inference, and unloads LoRA. Added to _(Single-card) Demo tests._

### Checklist

- [x] [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/22819524137) CI passes
- [x] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/22819530342) CI passes
- [x] [(Single-card) Demo tests (perf runs)](https://github.com/tenstorrent/tt-metal/actions/runs/22819535726) CI passes
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/22819542614) CI passes
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/22819546508) CI passes