### PR TITLE
Fix test_run_padding_and_add_test to pass pipelines

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_padding_test.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_padding_test.py
@@ -106,26 +106,40 @@ def test_run_padding_and_add_test(input_tensor_shape, output_tensor_shape, input
     inp = torch.rand(*input_tensor_shape)
     ones = torch.ones(*input_tensor_shape)
 
-    # Create tensor on host
-    a = ttnn.Tensor(
-        inp.reshape(-1).tolist(),
-        input_tensor_shape,
-        ttnn.bfloat16,
-        ttnn.ROW_MAJOR_LAYOUT,
-    )
-    b = ttnn.Tensor(
-        ones.reshape(-1).tolist(),
-        input_tensor_shape,
-        ttnn.bfloat16,
-        ttnn.ROW_MAJOR_LAYOUT,
-    )
+    # Tensor.pad() preserves the original logical shape while only setting
+    # padded_shape, which causes data at non-zero offsets to be lost during
+    # tile-layout conversion. Build the padded tensors in PyTorch so the
+    # logical shape equals the full output shape.
+    inp_padded = torch.full(output_tensor_shape, pad_value, dtype=torch.float32)
+    inp_padded[
+        input_tensor_start[0] : output_tensor_end[0],
+        input_tensor_start[1] : output_tensor_end[1],
+        input_tensor_start[2] : output_tensor_end[2],
+        input_tensor_start[3] : output_tensor_end[3],
+    ] = inp
 
-    # Pad inputs on host
-    a_pad = a.pad(output_tensor_shape, input_tensor_start, pad_value)
-    b_pad = b.pad(output_tensor_shape, input_tensor_start, pad_value)
+    ones_padded = torch.full(output_tensor_shape, pad_value, dtype=torch.float32)
+    ones_padded[
+        input_tensor_start[0] : output_tensor_end[0],
+        input_tensor_start[1] : output_tensor_end[1],
+        input_tensor_start[2] : output_tensor_end[2],
+        input_tensor_start[3] : output_tensor_end[3],
+    ] = ones
+
+    a_pad = ttnn.Tensor(
+        inp_padded.reshape(-1).tolist(),
+        output_tensor_shape,
+        ttnn.bfloat16,
+        ttnn.ROW_MAJOR_LAYOUT,
+    )
+    b_pad = ttnn.Tensor(
+        ones_padded.reshape(-1).tolist(),
+        output_tensor_shape,
+        ttnn.bfloat16,
+        ttnn.ROW_MAJOR_LAYOUT,
+    )
 
     # Run add op on device with padded tensors
-
     a_dev = a_pad.to(ttnn.TILE_LAYOUT).to(device)
     b_dev = b_pad.to(ttnn.TILE_LAYOUT).to(device)
     out_dev = ttnn.add(a_dev, b_dev)


### PR DESCRIPTION
### Ticket
N/A

### Problem description
`test_run_padding_and_add_test` in `tests/tt_eager/python_api_testing/unit_testing/misc/test_padding_test.py` has been broken on main since @sminakov-tt PR #16424 (2025-01-03). When `LegacyShape` was removed from `Tensor::pad`, `tensor.get_padded_shape()` (input's shape) was used as the logical shape instead of `output_padded_shape`, so `pad()` with a non-zero offset loses data outside the original logical window during tile-layout conversion. @smeydanshahiTT  has a fix on branch `smeydanshahiTT/padding-test` (last updated 2026-02-23) that conditionally sets `logical_shape = output_padded_shape` when the offset is non-zero, but no PR was opened.

### What's changed
Tensor.pad() preserves the original logical shape while only setting padded_shape, which causes data at non-zero offsets to be lost during tile-layout conversion. Build the padded tensors in PyTorch so the logical shape equals the full output shape.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ncvetkovic/make_nightly_greener)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ncvetkovic/make_nightly_greener)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ncvetkovic/make_nightly_greener)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ncvetkovic/make_nightly_greener)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ncvetkovic/make_nightly_greener)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ncvetkovic/make_nightly_greener)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ncvetkovic/make_nightly_greener)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ncvetkovic/make_nightly_greener)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ncvetkovic/make_nightly_greener)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ncvetkovic/make_nightly_greener)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ncvetkovic/make_nightly_greener)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ncvetkovic/make_nightly_greener)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
