### PR TITLE
Enhance program_config_to_dict function in tensor_utils.py

### DIFF
--- a/models/common/tensor_utils.py
+++ b/models/common/tensor_utils.py
@@ -153,13 +153,21 @@ def program_config_to_str(program_config: ttnn.MatmulMultiCoreReuseMultiCastDRAM
     return serialize_config(cfg)
 
 
-def program_config_to_dict(program_config: ttnn.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig):
-    return {
-        "in0_block_w": program_config.in0_block_w,
-        "per_core_M": program_config.per_core_M,
-        "per_core_N": program_config.per_core_N,
-        "fused_activation": str(program_config.fused_activation),
-    }
+def program_config_to_dict(program_config):
+    if hasattr(program_config, "to_json"):
+        d = json.loads(program_config.to_json())
+        d["type"] = type(program_config).__name__
+        return d
+    elif isinstance(program_config, ttnn.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig):
+        return {
+            "type": "MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig",
+            "in0_block_w": program_config.in0_block_w,
+            "per_core_M": program_config.per_core_M,
+            "per_core_N": program_config.per_core_N,
+            "fused_activation": str(program_config.fused_activation),
+        }
+    else:
+        return {"type": type(program_config).__name__, "repr": repr(program_config)}
 
 
 def serialize_config(cfg_dict: dict, fmt: str = "json") -> str:

--- a/models/common/tensor_utils.py
+++ b/models/common/tensor_utils.py
@@ -158,14 +158,6 @@ def program_config_to_dict(program_config):
         d = json.loads(program_config.to_json())
         d["type"] = type(program_config).__name__
         return d
-    elif isinstance(program_config, ttnn.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig):
-        return {
-            "type": "MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig",
-            "in0_block_w": program_config.in0_block_w,
-            "per_core_M": program_config.per_core_M,
-            "per_core_N": program_config.per_core_N,
-            "fused_activation": str(program_config.fused_activation),
-        }
     else:
         return {"type": type(program_config).__name__, "repr": repr(program_config)}
 

--- a/models/common/tests/modules/test_tensor_utils.py
+++ b/models/common/tests/modules/test_tensor_utils.py
@@ -10,6 +10,8 @@ from models.common.tensor_utils import (
     pad_dim_to_size,
     pad_to_shape,
     parse_shard_dims_from_mesh_mapper_config,
+    program_config_to_dict,
+    program_config_to_str,
     zeros_like_kv_cache,
     zeros_like_paged_cache,
 )
@@ -243,6 +245,57 @@ def test_zeros_like_paged_cache():
     assert torch.all(result == 0)
 
 
+def test_program_config_to_dict_with_to_json():
+    """Test program_config_to_dict for a config that has to_json (matmul configs)."""
+    import json
+
+    cfg = ttnn.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig(in0_block_w=4, per_core_M=1, per_core_N=2)
+    d = program_config_to_dict(cfg)
+
+    assert isinstance(d, dict)
+    assert d["type"] == "MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig"
+    assert d["in0_block_w"] == 4
+    assert d["per_core_M"] == 1
+    assert d["per_core_N"] == 2
+    assert "fused_activation" in d
+
+    json_str = json.dumps(d, sort_keys=True)
+    roundtrip = json.loads(json_str)
+    assert roundtrip == d
+
+
+def test_program_config_to_dict_without_to_json():
+    """Test program_config_to_dict for a config that lacks to_json (SDPAProgramConfig)."""
+    cfg = ttnn.SDPAProgramConfig(
+        compute_with_storage_grid_size=ttnn.CoreCoord(8, 8),
+        q_chunk_size=256,
+        k_chunk_size=256,
+    )
+    d = program_config_to_dict(cfg)
+
+    assert isinstance(d, dict)
+    assert d["type"] == "SDPAProgramConfig"
+    assert "repr" in d
+    assert "SDPAProgramConfig" in d["repr"]
+    assert "q_chunk_size=256" in d["repr"]
+    assert "k_chunk_size=256" in d["repr"]
+
+
+def test_program_config_to_str():
+    """Test program_config_to_str returns valid sorted JSON."""
+    import json
+
+    cfg = ttnn.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig(in0_block_w=2, per_core_M=3, per_core_N=4)
+    result = program_config_to_str(cfg)
+
+    parsed = json.loads(result)
+    assert parsed["in0_block_w"] == 2
+    assert parsed["per_core_M"] == 3
+    assert parsed["per_core_N"] == 4
+
+    assert result == json.dumps(parsed, sort_keys=True)
+
+
 if __name__ == "__main__":
     test_pad_dim_to_size()
     print("  ✓ test_pad_dim_to_size")
@@ -278,5 +331,14 @@ if __name__ == "__main__":
 
     test_zeros_like_paged_cache()
     print("  ✓ test_zeros_like_paged_cache")
+
+    test_program_config_to_dict_with_to_json()
+    print("  ✓ test_program_config_to_dict_with_to_json")
+
+    test_program_config_to_dict_without_to_json()
+    print("  ✓ test_program_config_to_dict_without_to_json")
+
+    test_program_config_to_str()
+    print("  ✓ test_program_config_to_str")
 
     print("\nAll tensor_utils tests passed! ✓")


### PR DESCRIPTION
### Ticket
NA

### Problem description
program_config_to_dict() is not fully reproducing the parameters

### What's changed
Updated the program_config_to_dict function to support serialization of various program configuration types. The function now checks for a to_json method while also providing a default representation for other types. This improves flexibility and usability in configuration management.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=Aswinmcw/fix_program_config_repr)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:Aswinmcw/fix_program_config_repr)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=Aswinmcw/fix_program_config_repr)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:Aswinmcw/fix_program_config_repr)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=Aswinmcw/fix_program_config_repr)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:Aswinmcw/fix_program_config_repr)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=Aswinmcw/fix_program_config_repr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:Aswinmcw/fix_program_config_repr)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=Aswinmcw/fix_program_config_repr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:Aswinmcw/fix_program_config_repr)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=Aswinmcw/fix_program_config_repr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:Aswinmcw/fix_program_config_repr)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
