### PR TITLE
dragonstrike: remove dead Grayskull arrays from test_print_config_register

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_config_register.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_config_register.cpp
@@ -139,65 +139,6 @@ const std::vector<std::string> field_names_dest_rd_ctrl_all = {
 const std::vector<uint32_t> field_values_dest_rd_ctrl_all = {1, 0, 1, 1, 0};
 
 // UNPACK TILE DESCRIPTOR
-const std::vector<std::string> field_names_unpack_tile_descriptor_grayskull = {
-    "in_data_format",
-    "uncompressed",
-    "reserved_0",
-    "blobs_per_xy_plane",
-    "reserved_1",
-    "x_dim",
-    "y_dim",
-    "z_dim",
-    "w_dim",
-    "blobs_y_start",
-    "digest_type",
-    "digest_size"};
-const std::vector<uint32_t> field_values_unpack_tile_descriptor_grayskull = {5, 1, 0, 10, 7, 2, 4, 8, 16, 32, 0, 0};
-
-// UNPACK CONFIG
-const std::vector<std::string> field_names_unpack_config_grayskull = {
-    "out_data_format",
-    "throttle_mode",
-    "context_count",
-    "haloize_mode",
-    "tileize_mode",
-    "force_shared_exp",
-    "reserved_0",
-    "upsample_rate",
-    "upsample_and_interlave",
-    "shift_amount",
-    "uncompress_cntx0_3",
-    "reserved_1",
-    "uncompress_cntx4_7",
-    "reserved_2",
-    "limit_addr",
-    "fifo_size"};
-const std::vector<uint32_t> field_values_unpack_config_grayskull = {0, 1, 2, 0, 1, 0, 0, 3, 0, 16, 5, 0, 2, 0, 28, 29};
-
-// PACK CONFIG
-const std::vector<std::string> field_names_pack_config_grayskull = {
-    "row_ptr_section_size",
-    "exp_section_size",
-    "l1_dest_addr",
-    "uncompress",
-    "add_l1_dest_addr_offset",
-    "reserved_0",
-    "out_data_format",
-    "in_data_format",
-    "reserved_1",
-    "src_if_sel",
-    "pack_per_xy_plane",
-    "l1_src_addr",
-    "downsample_mask",
-    "downsample_shift_count",
-    "read_mode",
-    "exp_threshold_en",
-    "reserved_2",
-    "exp_threshold"};
-const std::vector<uint32_t> field_values_pack_config_grayskull = {
-    12, 24, 16, 0, 1, 0, 5, 5, 0, 1, 0, 8, 12, 4, 0, 1, 0, 12};
-
-// UNPACK TILE DESCRIPTOR
 const std::vector<std::string> field_names_unpack_tile_descriptor_wormhole_or_blackhole = {
     "in_data_format",
     "uncompressed",


### PR DESCRIPTION
## Summary

Grayskull is an EOL platform. This PR removes six dead `*_grayskull` constant arrays from `tests/tt_metal/tt_metal/debug_tools/dprint/test_print_config_register.cpp` that were never referenced in any test body.

All three dprint config register tests (`unpack_tile_descriptor`, `unpack_config`, `pack_config`) unconditionally use the `*_wormhole_or_blackhole`, `*_wormhole`, and `*_blackhole` variants — the `*_grayskull` arrays were dead code.

## What changed

- Removed `field_names_unpack_tile_descriptor_grayskull` and `field_values_unpack_tile_descriptor_grayskull`
- Removed `field_names_unpack_config_grayskull` and `field_values_unpack_config_grayskull`
- Removed `field_names_pack_config_grayskull` and `field_values_pack_config_grayskull`
- Net: ~57 lines removed, zero functional change

## Validation

- Confirmed all six arrays have zero references in the test body before removal
- Built locally with `build_metal.sh --build-tests` using clang-20 on Debian 12 — clean build, no errors

## Part of

Full Grayskull EOL cleanup tracked in #39394.

---
*Authored by BrAIn — AI SW Infrastructure team assistant*