### PR TITLE
[skip ci] fix run_single_test arch default and tensix-reset logic in common.py

### DIFF
--- a/tests/scripts/common.py
+++ b/tests/scripts/common.py
@@ -200,7 +200,7 @@ def run_single_test(
     namespace: str,
     test_entry: TestEntry,
     timeout,
-    tt_arch="grayskull",
+    tt_arch="wormhole_b0",
     capture_output=False,
     build_full_path_to_test=default_build_full_path_to_test,
 ):
@@ -224,9 +224,7 @@ def run_single_test(
 
     if reset_tensix:
         logger.warning("Detected error on test that uses silicon - resetting")
-        if tt_arch == "grayskull":
-            run_process_and_get_result("tt-smi -tr all")
-        elif tt_arch == "wormhole_b0":
+        if tt_arch in ("wormhole_b0", "blackhole"):
             run_process_and_get_result("tt-smi -wr all wait")
         else:
             raise Exception(f"Unrecognized arch for tensix-reset: {tt_arch}")


### PR DESCRIPTION
## Summary

Grayskull is EOL. `tests/scripts/common.py` had two stale Grayskull references in `run_single_test()` that caused real operational problems:

1. **Wrong default arch** — `tt_arch="grayskull"` was the default, so any caller omitting `--arch` would silently run tests assuming a dead platform.
2. **Blackhole raises Exception** — the tensix-reset block handled GS and WH only; Blackhole would hit the `else` branch and raise `Exception: Unrecognized arch for tensix-reset: blackhole`.

## What changed

```python
# Before
def run_single_test(
    ...
    tt_arch="grayskull",   # ← wrong default
    ...
):
    ...
    if tt_arch == "grayskull":
        run_process_and_get_result("tt-smi -tr all")   # ← dead GS reset
    elif tt_arch == "wormhole_b0":
        run_process_and_get_result("tt-smi -wr all wait")
    else:
        raise Exception(f"Unrecognized arch for tensix-reset: {tt_arch}")  # ← BH hits this

# After
def run_single_test(
    ...
    tt_arch="wormhole_b0",  # ✓ current default platform
    ...
):
    ...
    if tt_arch in ("wormhole_b0", "blackhole"):   # ✓ BH uses same warm-reset command
        run_process_and_get_result("tt-smi -wr all wait")
    else:
        raise Exception(f"Unrecognized arch for tensix-reset: {tt_arch}")
```

## Part of

Full Grayskull EOL cleanup tracked in #39394.

---
*Authored by BrAIn — AI SW Infrastructure team assistant*