### PR TITLE
Snijjar/fabric ubench efficient worker placement

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
@@ -401,6 +401,30 @@ public:
         return mesh_adjacency_map;
     }
 
+    CoreCoord get_router_virtual_coord(
+        const FabricNodeId& node_id, RoutingDirection direction, uint32_t link_idx) const override {
+        const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+        const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+        ChipId physical_chip_id = control_plane.get_physical_chip_id_from_fabric_node_id(node_id);
+        const auto& eth_channels = control_plane.get_active_fabric_eth_channels_in_direction(node_id, direction);
+        TT_FATAL(
+            link_idx < eth_channels.size(),
+            "link_idx {} out of range for direction {} on node {} (only {} channels available)",
+            link_idx,
+            static_cast<int>(direction),
+            node_id,
+            eth_channels.size());
+        return cluster.get_virtual_eth_core_from_channel(physical_chip_id, eth_channels[link_idx]);
+    }
+
+    CoreCoord get_noc_grid_size() const override {
+        const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+        auto any_node = get_local_node_ids().front();
+        const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+        ChipId physical_chip_id = control_plane.get_physical_chip_id_from_fabric_node_id(any_node);
+        return cluster.get_soc_desc(physical_chip_id).grid_size;
+    }
+
     /**
      * This function takes hop information and computes the actual destination nodes that would be visited during a ring
      * traversal multicast.

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.hpp
@@ -15,12 +15,16 @@
 #include <tt-metalium/experimental/fabric/fabric_types.hpp>
 #include <tt-metalium/experimental/fabric/mesh_graph.hpp>
 #include <tt-metalium/device.hpp>
+#include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/experimental/fabric/routing_table_generator.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>
 #include "tt_metal/fabric/fabric_edm_packet_header.hpp"
 #include <tt-metalium/tt_align.hpp>
 
 namespace tt::tt_fabric::fabric_tests {
+
+// Default NOC used by sender workers when not explicitly configured.
+static constexpr tt::tt_metal::NOC DEFAULT_SENDER_NOC = tt::tt_metal::RISCV_0_default;
 
 // Performance test mode - replaces separate latency_test_mode and benchmark_mode booleans
 enum class PerformanceTestMode {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.cpp
@@ -1255,6 +1255,9 @@ std::vector<TestConfig> TestConfigBuilder::expand_high_level_patterns(ParsedTest
         // by splitting senders with patterns going to different routing directions.
         split_senders_by_direction_for_benchmark(iteration_test);
 
+        // In benchmark mode, place workers near their connected routers on the NOC.
+        optimize_worker_placement_for_benchmark(iteration_test);
+
         // Convert to resolved TestConfig
         TestConfig resolved_test = resolve_test_config(iteration_test, i);
 
@@ -2160,6 +2163,89 @@ void TestConfigBuilder::split_senders_by_direction_for_benchmark(ParsedTestConfi
     }
 
     test.senders = std::move(new_senders);
+}
+
+void TestConfigBuilder::optimize_worker_placement_for_benchmark(ParsedTestConfig& test) {
+    if (test.performance_test_mode != PerformanceTestMode::BANDWIDTH) {
+        return;
+    }
+
+    // Build reverse map: virtual coord -> logical coord for all worker cores
+    const auto& available_cores = device_info_provider_.get_available_worker_cores();
+    std::map<std::pair<uint32_t, uint32_t>, CoreCoord> virtual_to_logical;
+    for (const auto& logical_core : available_cores) {
+        auto virtual_core = device_info_provider_.get_virtual_core_from_logical_core(logical_core);
+        virtual_to_logical[{virtual_core.x, virtual_core.y}] = logical_core;
+    }
+
+    const auto noc_grid = device_info_provider_.get_noc_grid_size();
+
+    for (auto& sender : test.senders) {
+        if (!sender.noc_id.has_value()) {
+            continue;
+        }
+
+        // Determine routing direction from patterns (post-split, all patterns go same direction)
+        FabricNodeId src_node = resolve_device_identifier(sender.device, device_info_provider_);
+        RoutingDirection dir;
+        bool found_direction = false;
+        for (const auto& pattern : sender.patterns) {
+            if (pattern.destination.has_value() && pattern.destination->hops.has_value()) {
+                dir = route_manager_.get_forwarding_direction(pattern.destination->hops.value());
+                found_direction = true;
+                break;
+            } else if (pattern.destination.has_value() && pattern.destination->device.has_value()) {
+                FabricNodeId dst_node =
+                    resolve_device_identifier(pattern.destination->device.value(), device_info_provider_);
+                dir = route_manager_.get_forwarding_direction(src_node, dst_node);
+                found_direction = true;
+                break;
+            }
+        }
+
+        if (!found_direction) {
+            continue;
+        }
+
+        uint32_t link_idx = sender.link_id.value_or(0);
+        auto router_virtual = device_info_provider_.get_router_virtual_coord(src_node, dir, link_idx);
+
+        // noc0: place worker above router (y - 1), noc1: place worker below router (y + 1)
+        bool is_noc1 = (sender.noc_id.value() == tt::tt_metal::NOC::RISCV_1);
+        int32_t target_y =
+            static_cast<int32_t>(router_virtual.y) + (is_noc1 ? 1 : -1);
+
+        // Wraparound using NOC grid size
+        if (target_y < 0) {
+            target_y = static_cast<int32_t>(noc_grid.y) + target_y;
+        } else if (static_cast<uint32_t>(target_y) >= noc_grid.y) {
+            target_y = target_y % static_cast<int32_t>(noc_grid.y);
+        }
+
+        auto it = virtual_to_logical.find({router_virtual.x, static_cast<uint32_t>(target_y)});
+        if (it != virtual_to_logical.end()) {
+            sender.core = it->second;
+            log_debug(
+                LogTest,
+                "Benchmark mode: placed sender on device {} at logical core ({}, {}) "
+                "near router virtual ({}, {}) direction={} noc={}",
+                src_node,
+                it->second.x,
+                it->second.y,
+                router_virtual.x,
+                router_virtual.y,
+                static_cast<int>(dir),
+                is_noc1 ? 1 : 0);
+        } else {
+            log_debug(
+                LogTest,
+                "Benchmark mode: no worker core found at virtual ({}, {}) for router at ({}, {})",
+                router_virtual.x,
+                target_y,
+                router_virtual.x,
+                router_virtual.y);
+        }
+    }
 }
 
 bool TestConfigBuilder::expand_link_duplicates(ParsedTestConfig& test) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.cpp
@@ -2205,9 +2205,11 @@ void TestConfigBuilder::optimize_worker_placement_for_benchmark(ParsedTestConfig
             }
         }
 
-        if (!dir.has_value()) {
-            continue;
-        }
+        TT_FATAL(
+            dir.has_value(),
+            "Benchmark mode: sender on device {} has no determinable routing direction. "
+            "Expected all senders to have destinations after split_senders_by_direction_for_benchmark.",
+            src_node);
 
         uint32_t link_idx = sender.link_id.value_or(0);
         auto router_virtual = device_info_provider_.get_router_virtual_coord(src_node, dir.value(), link_idx);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.cpp
@@ -2170,56 +2170,58 @@ void TestConfigBuilder::optimize_worker_placement_for_benchmark(ParsedTestConfig
         return;
     }
 
-    // Build reverse map: virtual coord -> logical coord for all worker cores
+    // Build reverse map: virtual coord -> logical coord for all worker cores,
+    // and compute the virtual Y boundaries of the worker grid.
     const auto& available_cores = device_info_provider_.get_available_worker_cores();
     std::map<std::pair<uint32_t, uint32_t>, CoreCoord> virtual_to_logical;
+    size_t min_virtual_y = std::numeric_limits<size_t>::max();
+    size_t max_virtual_y = 0;
     for (const auto& logical_core : available_cores) {
         auto virtual_core = device_info_provider_.get_virtual_core_from_logical_core(logical_core);
         virtual_to_logical[{virtual_core.x, virtual_core.y}] = logical_core;
+        min_virtual_y = std::min(min_virtual_y, virtual_core.y);
+        max_virtual_y = std::max(max_virtual_y, virtual_core.y);
     }
 
-    const auto noc_grid = device_info_provider_.get_noc_grid_size();
+    const size_t noc_grid_y = device_info_provider_.get_noc_grid_size().y;
+    const size_t worker_grid_span = max_virtual_y - min_virtual_y + 1;
 
     for (auto& sender : test.senders) {
-        if (!sender.noc_id.has_value()) {
-            continue;
-        }
+        tt::tt_metal::NOC noc_id = sender.noc_id.value_or(DEFAULT_SENDER_NOC);
 
         // Determine routing direction from patterns (post-split, all patterns go same direction)
         FabricNodeId src_node = resolve_device_identifier(sender.device, device_info_provider_);
-        RoutingDirection dir;
-        bool found_direction = false;
+        std::optional<RoutingDirection> dir;
         for (const auto& pattern : sender.patterns) {
             if (pattern.destination.has_value() && pattern.destination->hops.has_value()) {
                 dir = route_manager_.get_forwarding_direction(pattern.destination->hops.value());
-                found_direction = true;
                 break;
-            } else if (pattern.destination.has_value() && pattern.destination->device.has_value()) {
+            }
+            if (pattern.destination.has_value() && pattern.destination->device.has_value()) {
                 FabricNodeId dst_node =
                     resolve_device_identifier(pattern.destination->device.value(), device_info_provider_);
                 dir = route_manager_.get_forwarding_direction(src_node, dst_node);
-                found_direction = true;
                 break;
             }
         }
 
-        if (!found_direction) {
+        if (!dir.has_value()) {
             continue;
         }
 
         uint32_t link_idx = sender.link_id.value_or(0);
-        auto router_virtual = device_info_provider_.get_router_virtual_coord(src_node, dir, link_idx);
+        auto router_virtual = device_info_provider_.get_router_virtual_coord(src_node, dir.value(), link_idx);
 
         // noc0: place worker above router (y - 1), noc1: place worker below router (y + 1)
-        bool is_noc1 = (sender.noc_id.value() == tt::tt_metal::NOC::RISCV_1);
-        int32_t target_y =
-            static_cast<int32_t>(router_virtual.y) + (is_noc1 ? 1 : -1);
+        // Worker virtual coords may not start at 0 (e.g. WH starts at 18,18), so if the
+        // target falls outside the worker grid, wrap around within the worker grid span.
+        bool is_noc1 = (noc_id == tt::tt_metal::NOC_1);
+        int32_t offset = is_noc1 ? 1 : -1;
+        size_t target_y = (router_virtual.y + noc_grid_y + static_cast<size_t>(offset)) % noc_grid_y;
 
-        // Wraparound using NOC grid size
-        if (target_y < 0) {
-            target_y = static_cast<int32_t>(noc_grid.y) + target_y;
-        } else if (static_cast<uint32_t>(target_y) >= noc_grid.y) {
-            target_y = target_y % static_cast<int32_t>(noc_grid.y);
+        // If the target is outside the worker virtual Y range, wrap it into the worker grid
+        if (target_y < min_virtual_y || target_y > max_virtual_y) {
+            target_y = min_virtual_y + (target_y + noc_grid_y - min_virtual_y) % worker_grid_span;
         }
 
         auto it = virtual_to_logical.find({router_virtual.x, static_cast<uint32_t>(target_y)});
@@ -2234,7 +2236,7 @@ void TestConfigBuilder::optimize_worker_placement_for_benchmark(ParsedTestConfig
                 it->second.y,
                 router_virtual.x,
                 router_virtual.y,
-                static_cast<int>(dir),
+                static_cast<int>(dir.value()),
                 is_noc1 ? 1 : 0);
         } else {
             log_debug(

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.hpp
@@ -524,6 +524,11 @@ private:
     // one fabric connection. This prevents the worker from becoming the bottleneck.
     void split_senders_by_direction_for_benchmark(ParsedTestConfig& test);
 
+    // In benchmark mode, place each worker core as close as possible to its connected
+    // fabric router on the NOC. For noc0, the worker is placed one row above the router;
+    // for noc1, one row below (with wraparound).
+    void optimize_worker_placement_for_benchmark(ParsedTestConfig& test);
+
     bool expand_link_duplicates(ParsedTestConfig& test);
 
     void resolve_missing_params(ParsedTestConfig& test);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_device_setup.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_device_setup.cpp
@@ -958,11 +958,8 @@ void TestDevice::create_sender_kernels() {
                  sender_memory_map_->get_mux_termination_sync_size()});
         }
 
-        tt::tt_metal::NOC noc_id = tt::tt_metal::NOC::RISCV_0_default;
         // Each sender will have the same NOC used for every pattern when parsing, take the one defined in the first config
-        if (sender.configs_[0].first.noc_id.has_value()) {
-            noc_id = sender.configs_[0].first.noc_id.value();
-        }
+        tt::tt_metal::NOC noc_id = sender.configs_[0].first.noc_id.value_or(DEFAULT_SENDER_NOC);
 
         sender.create_kernel(
             coord_,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_interfaces.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_interfaces.hpp
@@ -56,6 +56,14 @@ public:
     virtual bool is_multi_mesh() const = 0;
     virtual std::unordered_map<MeshId, std::unordered_set<MeshId>> get_mesh_adjacency_map() const = 0;
 
+    // Returns the virtual (translated) coordinate of the ethernet router core for a given
+    // fabric node, routing direction, and link index.
+    virtual CoreCoord get_router_virtual_coord(
+        const FabricNodeId& node_id, RoutingDirection direction, uint32_t link_idx) const = 0;
+
+    // Returns the full NOC grid size (for coordinate wraparound calculations).
+    virtual CoreCoord get_noc_grid_size() const = 0;
+
     // Data reading helpers
     virtual std::unordered_map<CoreCoord, std::vector<uint32_t>> read_buffer_from_cores(
         const MeshCoordinate& device_coord,


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=snijjar/fabric-ubench-efficient-worker-placement)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:snijjar/fabric-ubench-efficient-worker-placement)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snijjar/fabric-ubench-efficient-worker-placement)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snijjar/fabric-ubench-efficient-worker-placement)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snijjar/fabric-ubench-efficient-worker-placement)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snijjar/fabric-ubench-efficient-worker-placement)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snijjar/fabric-ubench-efficient-worker-placement)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snijjar/fabric-ubench-efficient-worker-placement)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snijjar/fabric-ubench-efficient-worker-placement)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snijjar/fabric-ubench-efficient-worker-placement)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snijjar/fabric-ubench-efficient-worker-placement)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snijjar/fabric-ubench-efficient-worker-placement)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
