### PR TITLE
Add performance model to ring distributed SDPA

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/transformer/CMakeLists.txt
@@ -39,6 +39,7 @@ target_sources(
         sdpa/device/ring_distributed_sdpa_device_operation.cpp
         sdpa/device/ring_distributed_sdpa_program_factory.cpp
         sdpa/device/sdpa_device_operation.cpp
+        sdpa/device/sdpa_perf_model.cpp
         sdpa/device/sdpa_program_factory.cpp
         sdpa/sdpa.cpp
         sdpa_decode/device/sdpa_decode_device_operation.cpp

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/joint_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/joint_sdpa_device_operation.cpp
@@ -158,9 +158,9 @@ JointSDPAResultSpec JointSDPADeviceOperation::compute_output_specs(
     const auto& input = tensor_args.input_q;
     const auto& joint_input = tensor_args.joint_q;
     return {
-        .output = TensorSpec(
+        TensorSpec(
             input.logical_shape(), TensorLayout(input.dtype(), PageConfig(Layout::TILE), args.output_memory_config)),
-        .joint_output = TensorSpec(
+        TensorSpec(
             joint_input.logical_shape(),
             TensorLayout(joint_input.dtype(), PageConfig(Layout::TILE), args.output_memory_config))};
 }
@@ -169,12 +169,11 @@ JointSDPAResult JointSDPADeviceOperation::create_output_tensors(
     const JointSDPAParams& args, const JointSDPAInputs& tensor_args) {
     auto output_specs = compute_output_specs(args, tensor_args);
     return {
-        .output = create_device_tensor(output_specs.output, tensor_args.input_q.device()),
-        .joint_output = create_device_tensor(output_specs.joint_output, tensor_args.joint_q.device())};
+        create_device_tensor(output_specs[JOINT_SDPA_OUTPUT_IDX], tensor_args.input_q.device()),
+        create_device_tensor(output_specs[JOINT_SDPA_JOINT_OUTPUT_IDX], tensor_args.joint_q.device())};
 }
 
-tt::tt_metal::operation::OpPerformanceModelGeneral<JointSDPAResult>
-JointSDPADeviceOperation::create_op_performance_model(
+tt::tt_metal::operation::OpPerformanceModelGeneral<Tensors> JointSDPADeviceOperation::create_op_performance_model(
     const JointSDPAParams& args, const JointSDPAInputs& tensor_args, JointSDPAResult& output_tensors) {
     Tensors input_tensors = {
         tensor_args.input_q,
@@ -184,12 +183,13 @@ JointSDPADeviceOperation::create_op_performance_model(
         tensor_args.joint_k,
         tensor_args.joint_v};
 
-    auto arch = output_tensors.output.storage_type() == StorageType::DEVICE ? output_tensors.output.device()->arch()
-                                                                            : ttnn::GetDefaultDevice()->arch();
+    auto& output_tensor = output_tensors[JOINT_SDPA_OUTPUT_IDX];
+    auto arch = output_tensor.storage_type() == StorageType::DEVICE ? output_tensor.device()->arch()
+                                                                    : ttnn::GetDefaultDevice()->arch();
 
     if (arch != tt::ARCH::WORMHOLE_B0 && arch != tt::ARCH::BLACKHOLE) {
         log_warning(tt::LogOp, "JointSDPA perf model does not support arch '{}'", enchantum::to_string(arch));
-        return operation::OpPerformanceModelGeneral<JointSDPAResult>(input_tensors, output_tensors, 0);
+        return operation::OpPerformanceModelGeneral<Tensors>(input_tensors, output_tensors, 0);
     }
 
     const auto& q_shape = tensor_args.input_q.logical_shape();
@@ -197,7 +197,7 @@ JointSDPADeviceOperation::create_op_performance_model(
     const auto& v_shape = tensor_args.input_v.logical_shape();
     const auto& joint_q_shape = tensor_args.joint_q.logical_shape();
 
-    CoreCoord grid = output_tensors.output.device()->compute_with_storage_grid_size();
+    CoreCoord grid = output_tensor.device()->compute_with_storage_grid_size();
     MathFidelity fidelity = ttnn::get_math_fidelity(args.compute_kernel_config);
 
     const uint32_t B = q_shape[0];
@@ -217,7 +217,7 @@ JointSDPADeviceOperation::create_op_performance_model(
     int ideal_cycles = operations::transformer::sdpa::compute_sdpa_ideal_cycles(
         B, NQH, cat_Sq, cat_Sk, DH, DV, false, fidelity, grid.x * grid.y);
 
-    return operation::OpPerformanceModelGeneral<JointSDPAResult>(input_tensors, output_tensors, ideal_cycles);
+    return operation::OpPerformanceModelGeneral<Tensors>(input_tensors, output_tensors, ideal_cycles);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/joint_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/joint_sdpa_device_operation.cpp
@@ -197,7 +197,8 @@ tt::tt_metal::operation::OpPerformanceModelGeneral<Tensors> JointSDPADeviceOpera
     const auto& v_shape = tensor_args.input_v.logical_shape();
     const auto& joint_q_shape = tensor_args.joint_q.logical_shape();
 
-    CoreCoord grid = output_tensor.device()->compute_with_storage_grid_size();
+    CoreCoord grid = args.program_config.has_value() ? args.program_config->compute_with_storage_grid_size
+                                                     : output_tensor.device()->compute_with_storage_grid_size();
     MathFidelity fidelity = ttnn::get_math_fidelity(args.compute_kernel_config);
 
     const uint32_t B = q_shape[0];

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/joint_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/joint_sdpa_device_operation.cpp
@@ -9,9 +9,11 @@
 #include <tt-metalium/constants.hpp>
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/device.hpp"
+#include "ttnn/operation.hpp"
 
 #include "ttnn/operations/transformer/sdpa/device/joint_sdpa_device_operation_types.hpp"
 #include "ttnn/operations/transformer/sdpa/device/joint_sdpa_program_factory.hpp"
+#include "ttnn/operations/transformer/sdpa/device/sdpa_perf_model.hpp"
 
 using namespace tt::tt_metal;
 
@@ -169,6 +171,53 @@ JointSDPAResult JointSDPADeviceOperation::create_output_tensors(
     return {
         .output = create_device_tensor(output_specs.output, tensor_args.input_q.device()),
         .joint_output = create_device_tensor(output_specs.joint_output, tensor_args.joint_q.device())};
+}
+
+tt::tt_metal::operation::OpPerformanceModelGeneral<JointSDPAResult>
+JointSDPADeviceOperation::create_op_performance_model(
+    const JointSDPAParams& args, const JointSDPAInputs& tensor_args, JointSDPAResult& output_tensors) {
+    Tensors input_tensors = {
+        tensor_args.input_q,
+        tensor_args.input_k,
+        tensor_args.input_v,
+        tensor_args.joint_q,
+        tensor_args.joint_k,
+        tensor_args.joint_v};
+
+    auto arch = output_tensors.output.storage_type() == StorageType::DEVICE ? output_tensors.output.device()->arch()
+                                                                            : ttnn::GetDefaultDevice()->arch();
+
+    if (arch != tt::ARCH::WORMHOLE_B0 && arch != tt::ARCH::BLACKHOLE) {
+        log_warning(tt::LogOp, "JointSDPA perf model does not support arch '{}'", enchantum::to_string(arch));
+        return operation::OpPerformanceModelGeneral<JointSDPAResult>(input_tensors, output_tensors, 0);
+    }
+
+    const auto& q_shape = tensor_args.input_q.logical_shape();
+    const auto& k_shape = tensor_args.input_k.logical_shape();
+    const auto& v_shape = tensor_args.input_v.logical_shape();
+    const auto& joint_q_shape = tensor_args.joint_q.logical_shape();
+
+    CoreCoord grid = output_tensors.output.device()->compute_with_storage_grid_size();
+    MathFidelity fidelity = ttnn::get_math_fidelity(args.compute_kernel_config);
+
+    const uint32_t B = q_shape[0];
+    const uint32_t NQH = q_shape[1];
+    const uint32_t Sq = q_shape[2];
+    const uint32_t Sk = k_shape[2];
+    const uint32_t Sj = joint_q_shape[2];
+    const uint32_t DH = q_shape[3];
+    const uint32_t DV = v_shape[3];
+
+    // JointSDPA operates on concatenated sequences (validated in program factory)
+    // cat_Sq = Sq + Sj, cat_Sk = Sk + Sj
+    const uint32_t cat_Sq = Sq + Sj;
+    const uint32_t cat_Sk = Sk + Sj;
+
+    // Single attention pass over concatenated dimensions, non-causal
+    int ideal_cycles = operations::transformer::sdpa::compute_sdpa_ideal_cycles(
+        B, NQH, cat_Sq, cat_Sk, DH, DV, false, fidelity, grid.x * grid.y);
+
+    return operation::OpPerformanceModelGeneral<JointSDPAResult>(input_tensors, output_tensors, ideal_cycles);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/joint_sdpa_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/joint_sdpa_device_operation.hpp
@@ -24,6 +24,8 @@ struct JointSDPADeviceOperation {
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+    static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
+        const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensors);
 };
 
 JointSDPAResult joint_scaled_dot_product_attention(

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/joint_sdpa_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/joint_sdpa_device_operation.hpp
@@ -24,7 +24,7 @@ struct JointSDPADeviceOperation {
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
+    static tt::tt_metal::operation::OpPerformanceModelGeneral<Tensors> create_op_performance_model(
         const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensors);
 };
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/joint_sdpa_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/joint_sdpa_device_operation_types.hpp
@@ -33,14 +33,14 @@ struct JointSDPAInputs {
     Tensor joint_v;
 };
 
-struct JointSDPAResult {
-    Tensor output;
-    Tensor joint_output;
-};
+// Index constants for JointSDPAResult vector
+constexpr size_t JOINT_SDPA_OUTPUT_IDX = 0;
+constexpr size_t JOINT_SDPA_JOINT_OUTPUT_IDX = 1;
 
-struct JointSDPAResultSpec {
-    TensorSpec output;
-    TensorSpec joint_output;
-};
+// JointSDPAResult is a vector of 2 tensors: [output, joint_output]
+using JointSDPAResult = Tensors;
+
+// JointSDPAResultSpec is a vector of 2 TensorSpecs: [output, joint_output]
+using JointSDPAResultSpec = std::vector<TensorSpec>;
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/joint_sdpa_program_factory.cpp
@@ -40,8 +40,8 @@ JointSDPAProgramFactory::cached_program_t JointSDPAProgramFactory::create(
     const Tensor& joint_tensor_q = tensor_args.joint_q;
     const Tensor& joint_tensor_k = tensor_args.joint_k;
     const Tensor& joint_tensor_v = tensor_args.joint_v;
-    const Tensor& output_tensor = output_tensors.output;
-    const Tensor& joint_output_tensor = output_tensors.joint_output;
+    const Tensor& output_tensor = output_tensors[JOINT_SDPA_OUTPUT_IDX];
+    const Tensor& joint_output_tensor = output_tensors[JOINT_SDPA_JOINT_OUTPUT_IDX];
 
     std::size_t q_chunk_size = args.get_q_chunk_size();
     std::size_t k_chunk_size = args.get_k_chunk_size();
@@ -581,8 +581,8 @@ void JointSDPAProgramFactory::override_runtime_arguments(
     auto* joint_v_buffer = tensor_args.joint_v.buffer();
 
     // Get addresses for output tensors
-    auto* out_buffer = output_tensors.output.buffer();
-    auto* joint_out_buffer = output_tensors.joint_output.buffer();
+    auto* out_buffer = output_tensors[JOINT_SDPA_OUTPUT_IDX].buffer();
+    auto* joint_out_buffer = output_tensors[JOINT_SDPA_JOINT_OUTPUT_IDX].buffer();
 
     uint32_t q_addr = q_buffer->address();
     uint32_t k_addr = k_buffer->address();

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_device_operation.cpp
@@ -285,8 +285,6 @@ Tensor RingDistributedSdpaDeviceOperation::create_output_tensors(
 tt::tt_metal::operation::OpPerformanceModelGeneral<RingDistributedSdpaDeviceOperation::tensor_return_value_t>
 RingDistributedSdpaDeviceOperation::create_op_performance_model(
     const RingDistributedSDPAParams& args, const RingDistributedSDPAInputs& tensor_args, Tensor& output_tensor) {
-    using namespace tt::tt_metal;
-
     Tensors input_tensors = {tensor_args.q, tensor_args.k, tensor_args.v};
 
     auto arch = output_tensor.storage_type() == StorageType::DEVICE ? output_tensor.device()->arch()
@@ -294,6 +292,7 @@ RingDistributedSdpaDeviceOperation::create_op_performance_model(
 
     // Performance model only supports Wormhole B0 and Blackhole architectures
     if (arch != tt::ARCH::WORMHOLE_B0 && arch != tt::ARCH::BLACKHOLE) {
+        log_warning(tt::LogOp, "SDPA perf model does not support tt::arch '{}'", enchantum::to_string(arch));
         return operation::OpPerformanceModelGeneral<tensor_return_value_t>(input_tensors, output_tensor, 0);
     }
 
@@ -305,13 +304,18 @@ RingDistributedSdpaDeviceOperation::create_op_performance_model(
     CoreCoord grid = output_tensor.device()->compute_with_storage_grid_size();
     MathFidelity fidelity = ttnn::get_math_fidelity(args.compute_kernel_config);
 
+    // In chunked/paged-KV mode, k_shape[2] is the page block size, not the full KV sequence length.
+    // Use chunk_start_idx + q_shape[2] as the effective Sk (similar to SDPAOperation).
+    const bool is_chunked = args.chunk_start_idx.has_value();
+    const uint32_t Sk = is_chunked ? (q_shape[2] + args.chunk_start_idx.value()) : k_shape[2];
+
     // For ring distributed SDPA, use local output sequence length (Sq) and full K sequence length (Sk)
     // Ring distributed SDPA is always causal
     int ideal_cycles = operations::transformer::sdpa::compute_sdpa_ideal_cycles(
         q_shape[0],       // batch
         q_shape[1],       // num_heads_q
         output_shape[2],  // Sq (local output seq len)
-        k_shape[2],       // Sk (full K seq len)
+        Sk,               // Sk (effective K seq len, adjusted for chunked mode)
         q_shape[3],       // DH
         v_shape[3],       // DV
         true,             // is_causal (always true for ring distributed)

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_device_operation.cpp
@@ -301,7 +301,8 @@ RingDistributedSdpaDeviceOperation::create_op_performance_model(
     const auto& v_shape = tensor_args.v.logical_shape();
     const auto& output_shape = output_tensor.logical_shape();
 
-    CoreCoord grid = output_tensor.device()->compute_with_storage_grid_size();
+    CoreCoord grid = args.program_config.has_value() ? args.program_config->compute_with_storage_grid_size
+                                                     : output_tensor.device()->compute_with_storage_grid_size();
     MathFidelity fidelity = ttnn::get_math_fidelity(args.compute_kernel_config);
 
     // In chunked/paged-KV mode, k_shape[2] is the page block size, not the full KV sequence length.

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_device_operation.cpp
@@ -7,10 +7,13 @@
 #include "ttnn/device_operation.hpp"
 
 #include "ring_distributed_sdpa_program_factory.hpp"
+#include "sdpa_perf_model.hpp"
 
 #include <tt-metalium/constants.hpp>
 
 #include "ttnn/operation.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/device.hpp"
 
 using namespace tt::tt_metal;
 
@@ -277,6 +280,45 @@ TensorSpec RingDistributedSdpaDeviceOperation::compute_output_specs(
 Tensor RingDistributedSdpaDeviceOperation::create_output_tensors(
     const RingDistributedSDPAParams& operation_attributes, const RingDistributedSDPAInputs& tensor_args) {
     return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.q.device());
+}
+
+tt::tt_metal::operation::OpPerformanceModelGeneral<RingDistributedSdpaDeviceOperation::tensor_return_value_t>
+RingDistributedSdpaDeviceOperation::create_op_performance_model(
+    const RingDistributedSDPAParams& args, const RingDistributedSDPAInputs& tensor_args, Tensor& output_tensor) {
+    using namespace tt::tt_metal;
+
+    Tensors input_tensors = {tensor_args.q, tensor_args.k, tensor_args.v};
+
+    auto arch = output_tensor.storage_type() == StorageType::DEVICE ? output_tensor.device()->arch()
+                                                                    : ttnn::GetDefaultDevice()->arch();
+
+    // Performance model only supports Wormhole B0 and Blackhole architectures
+    if (arch != tt::ARCH::WORMHOLE_B0 && arch != tt::ARCH::BLACKHOLE) {
+        return operation::OpPerformanceModelGeneral<tensor_return_value_t>(input_tensors, output_tensor, 0);
+    }
+
+    const auto& q_shape = tensor_args.q.logical_shape();
+    const auto& k_shape = tensor_args.k.logical_shape();
+    const auto& v_shape = tensor_args.v.logical_shape();
+    const auto& output_shape = output_tensor.logical_shape();
+
+    CoreCoord grid = output_tensor.device()->compute_with_storage_grid_size();
+    MathFidelity fidelity = ttnn::get_math_fidelity(args.compute_kernel_config);
+
+    // For ring distributed SDPA, use local output sequence length (Sq) and full K sequence length (Sk)
+    // Ring distributed SDPA is always causal
+    int ideal_cycles = operations::transformer::sdpa::compute_sdpa_ideal_cycles(
+        q_shape[0],       // batch
+        q_shape[1],       // num_heads_q
+        output_shape[2],  // Sq (local output seq len)
+        k_shape[2],       // Sk (full K seq len)
+        q_shape[3],       // DH
+        v_shape[3],       // DV
+        true,             // is_causal (always true for ring distributed)
+        fidelity,
+        grid.x * grid.y);
+
+    return operation::OpPerformanceModelGeneral<tensor_return_value_t>(input_tensors, output_tensor, ideal_cycles);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_device_operation.hpp
@@ -9,6 +9,7 @@
 
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/decorators.hpp"
+#include "ttnn/operation.hpp"
 
 #include "ring_distributed_sdpa_device_operation_types.hpp"
 #include "ring_distributed_sdpa_program_factory.hpp"
@@ -32,6 +33,9 @@ struct RingDistributedSdpaDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
+
+    static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
+        const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensor);
 };
 
 Tensor ring_distributed_sdpa(

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
@@ -16,6 +16,7 @@
 #include "ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_device_operation.hpp"
 #include "ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation_types.hpp"
 #include "ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.hpp"
+#include "ttnn/operations/transformer/sdpa/device/sdpa_perf_model.hpp"
 #include "ttnn/tensor/types.hpp"
 
 using namespace tt::tt_metal;
@@ -276,6 +277,55 @@ tt::stl::hash::hash_t RingJointSDPADeviceOperation::compute_program_hash(
         ttnn::experimental::prim::RingAttentionAllGatherAsyncDeviceOperation::compute_program_hash(
             args.all_gather_operation_attributes, args.all_gather_tensor_args) /*all_gather input tensors*/
     );
+}
+
+tt::tt_metal::operation::OpPerformanceModelGeneral<RingJointSDPAResult>
+RingJointSDPADeviceOperation::create_op_performance_model(
+    const RingJointSDPAParams& args, const RingJointSDPAInputs& tensor_args, RingJointSDPAResult& output_tensors) {
+    Tensors input_tensors = {
+        tensor_args.input_q,
+        tensor_args.input_k,
+        tensor_args.input_v,
+        tensor_args.joint_q,
+        tensor_args.joint_k,
+        tensor_args.joint_v,
+        tensor_args.gathered_k,
+        tensor_args.gathered_v};
+
+    auto arch = output_tensors.output.storage_type() == StorageType::DEVICE ? output_tensors.output.device()->arch()
+                                                                            : ttnn::GetDefaultDevice()->arch();
+
+    if (arch != tt::ARCH::WORMHOLE_B0 && arch != tt::ARCH::BLACKHOLE) {
+        log_warning(tt::LogOp, "RingJointSDPA perf model does not support arch '{}'", enchantum::to_string(arch));
+        return operation::OpPerformanceModelGeneral<RingJointSDPAResult>(input_tensors, output_tensors, 0);
+    }
+
+    const auto& q_shape = tensor_args.input_q.logical_shape();
+    const auto& gathered_k_shape = tensor_args.gathered_k.logical_shape();
+    const auto& v_shape = tensor_args.gathered_v.logical_shape();
+    const auto& joint_q_shape = tensor_args.joint_q.logical_shape();
+
+    CoreCoord grid = output_tensors.output.device()->compute_with_storage_grid_size();
+    MathFidelity fidelity = ttnn::get_math_fidelity(args.compute_kernel_config);
+
+    const uint32_t B = q_shape[0];
+    const uint32_t NQH = q_shape[1];
+    const uint32_t N_local = q_shape[2];
+    const uint32_t N_global = gathered_k_shape[2];
+    const uint32_t L = joint_q_shape[2];
+    const uint32_t DH = q_shape[3];
+    const uint32_t DV = v_shape[3];
+
+    // RingJointSDPA: local Q and joint Q attend to (gathered K + joint K)
+    // Total Q dimension: N_local + L, Total K dimension: N_global + L
+    const uint32_t cat_Sq = N_local + L;
+    const uint32_t cat_Sk = N_global + L;
+
+    // Single attention pass over concatenated dimensions, non-causal
+    int ideal_cycles = operations::transformer::sdpa::compute_sdpa_ideal_cycles(
+        B, NQH, cat_Sq, cat_Sk, DH, DV, false, fidelity, grid.x * grid.y);
+
+    return operation::OpPerformanceModelGeneral<RingJointSDPAResult>(input_tensors, output_tensors, ideal_cycles);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
@@ -233,23 +233,23 @@ RingJointSDPAResultSpec RingJointSDPADeviceOperation::compute_output_specs(
     stats_shape[2] = (input.padded_shape()[2] + joint_input.padded_shape()[2]) * 2;
 
     return {
-        .output = TensorSpec(
+        TensorSpec(
             input.logical_shape(),
             TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), args.output_memory_config)),
-        .joint_output = TensorSpec(
+        TensorSpec(
             joint_input.logical_shape(),
             TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), args.output_memory_config)),
-        .stats_output = TensorSpec(
-            stats_shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), args.output_memory_config))};
+        TensorSpec(stats_shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), args.output_memory_config))};
+
 }
 
 RingJointSDPAResult RingJointSDPADeviceOperation::create_output_tensors(
     const RingJointSDPAParams& args, const RingJointSDPAInputs& tensor_args) {
     auto output_specs = compute_output_specs(args, tensor_args);
     return {
-        .output = create_device_tensor(output_specs.output, tensor_args.input_q.device()),
-        .joint_output = create_device_tensor(output_specs.joint_output, tensor_args.joint_q.device()),
-        .stats_output = create_device_tensor(output_specs.stats_output, tensor_args.input_q.device()),
+        create_device_tensor(output_specs[RING_JOINT_SDPA_OUTPUT_IDX], tensor_args.input_q.device()),
+        create_device_tensor(output_specs[RING_JOINT_SDPA_JOINT_OUTPUT_IDX], tensor_args.joint_q.device()),
+        create_device_tensor(output_specs[RING_JOINT_SDPA_STATS_OUTPUT_IDX], tensor_args.input_q.device()),
     };
 }
 
@@ -279,8 +279,7 @@ tt::stl::hash::hash_t RingJointSDPADeviceOperation::compute_program_hash(
     );
 }
 
-tt::tt_metal::operation::OpPerformanceModelGeneral<RingJointSDPAResult>
-RingJointSDPADeviceOperation::create_op_performance_model(
+tt::tt_metal::operation::OpPerformanceModelGeneral<Tensors> RingJointSDPADeviceOperation::create_op_performance_model(
     const RingJointSDPAParams& args, const RingJointSDPAInputs& tensor_args, RingJointSDPAResult& output_tensors) {
     Tensors input_tensors = {
         tensor_args.input_q,
@@ -292,12 +291,13 @@ RingJointSDPADeviceOperation::create_op_performance_model(
         tensor_args.gathered_k,
         tensor_args.gathered_v};
 
-    auto arch = output_tensors.output.storage_type() == StorageType::DEVICE ? output_tensors.output.device()->arch()
-                                                                            : ttnn::GetDefaultDevice()->arch();
+    auto& output_tensor = output_tensors[RING_JOINT_SDPA_OUTPUT_IDX];
+    auto arch = output_tensor.storage_type() == StorageType::DEVICE ? output_tensor.device()->arch()
+                                                                    : ttnn::GetDefaultDevice()->arch();
 
     if (arch != tt::ARCH::WORMHOLE_B0 && arch != tt::ARCH::BLACKHOLE) {
         log_warning(tt::LogOp, "RingJointSDPA perf model does not support arch '{}'", enchantum::to_string(arch));
-        return operation::OpPerformanceModelGeneral<RingJointSDPAResult>(input_tensors, output_tensors, 0);
+        return operation::OpPerformanceModelGeneral<Tensors>(input_tensors, output_tensors, 0);
     }
 
     const auto& q_shape = tensor_args.input_q.logical_shape();
@@ -305,7 +305,7 @@ RingJointSDPADeviceOperation::create_op_performance_model(
     const auto& v_shape = tensor_args.gathered_v.logical_shape();
     const auto& joint_q_shape = tensor_args.joint_q.logical_shape();
 
-    CoreCoord grid = output_tensors.output.device()->compute_with_storage_grid_size();
+    CoreCoord grid = output_tensor.device()->compute_with_storage_grid_size();
     MathFidelity fidelity = ttnn::get_math_fidelity(args.compute_kernel_config);
 
     const uint32_t B = q_shape[0];
@@ -325,7 +325,7 @@ RingJointSDPADeviceOperation::create_op_performance_model(
     int ideal_cycles = operations::transformer::sdpa::compute_sdpa_ideal_cycles(
         B, NQH, cat_Sq, cat_Sk, DH, DV, false, fidelity, grid.x * grid.y);
 
-    return operation::OpPerformanceModelGeneral<RingJointSDPAResult>(input_tensors, output_tensors, ideal_cycles);
+    return operation::OpPerformanceModelGeneral<Tensors>(input_tensors, output_tensors, ideal_cycles);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
@@ -305,7 +305,8 @@ tt::tt_metal::operation::OpPerformanceModelGeneral<Tensors> RingJointSDPADeviceO
     const auto& v_shape = tensor_args.gathered_v.logical_shape();
     const auto& joint_q_shape = tensor_args.joint_q.logical_shape();
 
-    CoreCoord grid = output_tensor.device()->compute_with_storage_grid_size();
+    CoreCoord grid = args.program_config.has_value() ? args.program_config->compute_with_storage_grid_size
+                                                     : output_tensor.device()->compute_with_storage_grid_size();
     MathFidelity fidelity = ttnn::get_math_fidelity(args.compute_kernel_config);
 
     const uint32_t B = q_shape[0];

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.hpp
@@ -25,7 +25,7 @@ struct RingJointSDPADeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
-    static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
+    static tt::tt_metal::operation::OpPerformanceModelGeneral<Tensors> create_op_performance_model(
         const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensors);
 };
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.hpp
@@ -25,6 +25,8 @@ struct RingJointSDPADeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
+        const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensors);
 };
 
 RingJointSDPAResult ring_joint_scaled_dot_product_attention(

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation_types.hpp
@@ -84,16 +84,15 @@ struct RingJointSDPAInputs {
     Tensor gathered_v;
 };
 
-struct RingJointSDPAResult {
-    Tensor output;
-    Tensor joint_output;
-    Tensor stats_output;
-};
+// Index constants for RingJointSDPAResult vector
+constexpr size_t RING_JOINT_SDPA_OUTPUT_IDX = 0;
+constexpr size_t RING_JOINT_SDPA_JOINT_OUTPUT_IDX = 1;
+constexpr size_t RING_JOINT_SDPA_STATS_OUTPUT_IDX = 2;
 
-struct RingJointSDPAResultSpec {
-    TensorSpec output;
-    TensorSpec joint_output;
-    TensorSpec stats_output;
-};
+// RingJointSDPAResult is a vector of 3 tensors: [output, joint_output, stats_output]
+using RingJointSDPAResult = Tensors;
+
+// RingJointSDPAResultSpec is a vector of 3 TensorSpecs: [output, joint_output, stats_output]
+using RingJointSDPAResultSpec = std::vector<TensorSpec>;
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -100,9 +100,9 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     const auto& gathered_input_tensor_k = tensor_args.gathered_k;
     const auto& gathered_input_tensor_v = tensor_args.gathered_v;
 
-    auto& output_tensor = output_tensors.output;
-    auto& joint_output_tensor = output_tensors.joint_output;
-    auto& stats_output_tensor = output_tensors.stats_output;
+    auto& output_tensor = output_tensors[RING_JOINT_SDPA_OUTPUT_IDX];
+    auto& joint_output_tensor = output_tensors[RING_JOINT_SDPA_JOINT_OUTPUT_IDX];
+    auto& stats_output_tensor = output_tensors[RING_JOINT_SDPA_STATS_OUTPUT_IDX];
 
     std::size_t q_chunk_size = args.get_q_chunk_size();
     std::size_t k_chunk_size = args.get_k_chunk_size();
@@ -1203,9 +1203,9 @@ void RingJointSDPAProgramFactory::override_runtime_arguments(
         auto* joint_v_buffer = tensor_args.joint_v.buffer();
 
         // Get addresses for output tensors
-        auto* out_buffer = output_tensors.output.buffer();
-        auto* joint_out_buffer = output_tensors.joint_output.buffer();
-        auto* stats_buffer = output_tensors.stats_output.buffer();
+        auto* out_buffer = output_tensors[RING_JOINT_SDPA_OUTPUT_IDX].buffer();
+        auto* joint_out_buffer = output_tensors[RING_JOINT_SDPA_JOINT_OUTPUT_IDX].buffer();
+        auto* stats_buffer = output_tensors[RING_JOINT_SDPA_STATS_OUTPUT_IDX].buffer();
 
         uint32_t q_addr = q_buffer->address();
         uint32_t k_addr = k_buffer->address();

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_device_operation.cpp
@@ -6,6 +6,7 @@
 #include "ttnn/tensor/tensor_ops.hpp"
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/transformer/sdpa/device/sdpa_program_factory.hpp"
+#include "ttnn/operations/transformer/sdpa/device/sdpa_perf_model.hpp"
 #include "ttnn/operation.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
 #include "ttnn/device.hpp"
@@ -411,14 +412,15 @@ SDPAOperation::create_op_performance_model(
         log_warning(tt::LogOp, "Output tensor not on DEVICE?!");
     }
 
-    // calculate arch specific parameters
-    MathFidelity math_fidelity = ttnn::get_math_fidelity(args.compute_kernel_config);
-    auto arch = output_tensor.storage_type() == StorageType::DEVICE ? output_tensor.device()->arch()
-                                                                    : ttnn::GetDefaultDevice()->arch();
+    // Build input tensors list
     Tensors input_tensors = {tensor_args.q, tensor_args.k};
     if (tensor_args.v.has_value()) {
         input_tensors.emplace_back(tensor_args.v.value());
     }
+
+    // Calculate arch specific parameters
+    auto arch = output_tensor.storage_type() == StorageType::DEVICE ? output_tensor.device()->arch()
+                                                                    : ttnn::GetDefaultDevice()->arch();
     if (arch != tt::ARCH::WORMHOLE_B0 && arch != tt::ARCH::BLACKHOLE) {
         log_warning(tt::LogOp, "SDPA perf model does not support tt::arch '{}'", enchantum::to_string(arch));
         return operation::OpPerformanceModelGeneral<SDPAOperation::tensor_return_value_t>(
@@ -437,59 +439,42 @@ SDPAOperation::create_op_performance_model(
 
     bool is_chunked_prefill = args.chunk_start_idx.has_value() || args.chunk_start_idx_tensor.has_value();
 
-    uint32_t batch_size_q = q_shape[0];
-    uint32_t batch_size_k = k_shape[0];
-    // NB: number of Q heads determines the shape of first matmul; K is broadcast to match Q's shape
+    uint32_t batch_size = q_shape[0];
     uint32_t num_heads_q = q_shape[1];
+    const uint32_t Sq = q_shape[2];
+    const uint32_t DH = q_shape[3];
 
-    const auto Sq = q_shape[2];
-    const auto Sk = (is_chunked_prefill) ? (args.chunk_start_idx.has_value()
-                                                ? q_shape[2] + args.chunk_start_idx.value()
-                                                : k_shape[2])  // flexible: use K length as upper bound for perf model
-                                         : k_shape[2];
-    const auto DH = q_shape[3];
+    // Compute Sk based on chunked mode
+    const uint32_t Sk = (is_chunked_prefill)
+                            ? (args.chunk_start_idx.has_value() ? q_shape[2] + args.chunk_start_idx.value()
+                                                                : k_shape[2])  // flexible: use K length as upper bound
+                            : k_shape[2];
 
-    uint32_t Sv, DV;
-    if (args.use_mla && !has_v) {
-        Sv = k_shape[2];
-        DV = k_shape[3];
-    } else {
-        Sv = v_shape[3];
-        DV = v_shape[2];
-    }
+    // Compute DV based on MLA mode
+    // Note: For MLA without V, use K's head dimension; otherwise use V's head dimension
+    const uint32_t DV = (args.use_mla && !has_v) ? k_shape[3] : v_shape[3];
 
-    TT_ASSERT(batch_size_q == batch_size_k, "ScaledDotProductAttention perf model: Q and K have unequal batch size!");
+    TT_ASSERT(q_shape[0] == k_shape[0], "ScaledDotProductAttention perf model: Q and K have unequal batch size!");
     TT_ASSERT(q_shape[3] == k_shape[3], "ScaledDotProductAttention perf model: Q and K have unequal hidden dim!");
 
-    // Compute number of FLOPS for the two main matmuls
-    constexpr int64_t FLOPS_PER_FMA = 2;  // each FMA is 2 FLOPS
-    int64_t num_mul_adds = 0;
-    // Q * K matmul for raw attention scores
-    num_mul_adds += FLOPS_PER_FMA * DH * Sq * Sk * num_heads_q * batch_size_q;
-    // attention scores * V matmul
-    num_mul_adds += FLOPS_PER_FMA * DV * Sq * Sv * num_heads_q * batch_size_q;
-
-    // if causal, only half of the FMAs are actually performed
-    if (args.is_causal) {
-        num_mul_adds /= 2;
-    }
-
     CoreCoord compute_grid_dims = output_tensor.device()->compute_with_storage_grid_size();
-    int num_cores = compute_grid_dims.x * compute_grid_dims.y;
+    MathFidelity math_fidelity = ttnn::get_math_fidelity(args.compute_kernel_config);
 
-    // wormhole and blackhole have identical matmul throughput per cycle
-    const int tensix_mul_adds_per_cycle_lofi = 4096;
-
-    // ideal total cycles is ESTIMATED_FLOPS / IDEAL_THROUGHPUT
-    int ideal_dev_clock_cycles = std::ceil(
-        ((float)num_mul_adds / (float)(num_cores * tensix_mul_adds_per_cycle_lofi)) *
-        (float)operation::OpPerformanceModel::fidelity_multiplier(math_fidelity));
+    int ideal_dev_clock_cycles = operations::transformer::sdpa::compute_sdpa_ideal_cycles(
+        batch_size,
+        num_heads_q,
+        Sq,
+        Sk,
+        DH,
+        DV,
+        args.is_causal,
+        math_fidelity,
+        compute_grid_dims.x * compute_grid_dims.y);
 
     // TODO: somehow account for overhead of fused masking and softmax?
 
-    operation::OpPerformanceModelGeneral<SDPAOperation::tensor_return_value_t> result(
+    return operation::OpPerformanceModelGeneral<SDPAOperation::tensor_return_value_t>(
         input_tensors, output_tensor, ideal_dev_clock_cycles);
-    return result;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_device_operation.cpp
@@ -457,7 +457,9 @@ SDPAOperation::create_op_performance_model(
     TT_ASSERT(q_shape[0] == k_shape[0], "ScaledDotProductAttention perf model: Q and K have unequal batch size!");
     TT_ASSERT(q_shape[3] == k_shape[3], "ScaledDotProductAttention perf model: Q and K have unequal hidden dim!");
 
-    CoreCoord compute_grid_dims = output_tensor.device()->compute_with_storage_grid_size();
+    CoreCoord compute_grid_dims = args.program_config.has_value()
+                                      ? args.program_config->compute_with_storage_grid_size
+                                      : output_tensor.device()->compute_with_storage_grid_size();
     MathFidelity math_fidelity = ttnn::get_math_fidelity(args.compute_kernel_config);
 
     int ideal_dev_clock_cycles = operations::transformer::sdpa::compute_sdpa_ideal_cycles(

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_perf_model.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_perf_model.cpp
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sdpa_perf_model.hpp"
+#include "ttnn/operation.hpp"
+#include <cmath>
+
+namespace ttnn::operations::transformer::sdpa {
+
+int compute_sdpa_ideal_cycles(
+    uint32_t batch_size,
+    uint32_t num_heads_q,
+    uint32_t Sq,
+    uint32_t Sk,
+    uint32_t DH,
+    uint32_t DV,
+    bool is_causal,
+    MathFidelity math_fidelity,
+    int num_cores) {
+    constexpr int64_t FLOPS_PER_FMA = 2;  // Each FMA is 2 FLOPS
+    int64_t num_mul_adds = 0;
+
+    // Q * K matmul: [B, NQH, Sq, DH] x [B, NKV, DH, Sk] -> [B, NQH, Sq, Sk]
+    num_mul_adds += FLOPS_PER_FMA * DH * Sq * Sk * num_heads_q * batch_size;
+
+    // attention * V matmul: [B, NQH, Sq, Sk] x [B, NKV, Sk, DV] -> [B, NQH, Sq, DV]
+    num_mul_adds += FLOPS_PER_FMA * DV * Sq * Sk * num_heads_q * batch_size;
+
+    // If causal, only half of the FMAs are actually performed
+    if (is_causal) {
+        num_mul_adds /= 2;
+    }
+
+    // Wormhole and Blackhole have identical matmul throughput per cycle
+    const int tensix_mul_adds_per_cycle_lofi = 4096;
+
+    // Ideal total cycles is ESTIMATED_FLOPS / IDEAL_THROUGHPUT
+    return static_cast<int>(std::ceil(
+        (static_cast<float>(num_mul_adds) / static_cast<float>(num_cores * tensix_mul_adds_per_cycle_lofi)) *
+        static_cast<float>(tt::tt_metal::operation::OpPerformanceModel::fidelity_multiplier(math_fidelity))));
+}
+
+}  // namespace ttnn::operations::transformer::sdpa

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_perf_model.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_perf_model.hpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <tt-metalium/base_types.hpp>
+
+namespace ttnn::operations::transformer::sdpa {
+
+// Compute ideal clock cycles for SDPA operations based on FLOP count and hardware capabilities.
+// This helper is shared across different SDPA operation variants for consistent performance modeling.
+//
+// Parameters:
+//   batch_size   - Batch dimension
+//   num_heads_q  - Number of query heads (determines matmul shape)
+//   Sq           - Query sequence length (local for distributed variants)
+//   Sk           - Key sequence length
+//   DH           - Head dimension for Q/K
+//   DV           - Head dimension for V (output)
+//   is_causal    - If true, only half of FMAs are performed due to causal masking
+//   math_fidelity - Compute fidelity affecting cycles per operation
+//   num_cores    - Number of compute cores for parallelization
+//
+// Returns ideal_compute_cycles suitable for OpPerformanceModelGeneral constructor.
+int compute_sdpa_ideal_cycles(
+    uint32_t batch_size,
+    uint32_t num_heads_q,
+    uint32_t Sq,
+    uint32_t Sk,
+    uint32_t DH,
+    uint32_t DV,
+    bool is_causal,
+    MathFidelity math_fidelity,
+    int num_cores);
+
+}  // namespace ttnn::operations::transformer::sdpa

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
@@ -146,7 +146,7 @@ std::tuple<ttnn::Tensor, ttnn::Tensor> ExecuteJointAttention::invoke(
         program_config,
         scale,
         compute_kernel_config);
-    return {output_tensors.output, output_tensors.joint_output};
+    return {output_tensors[prim::JOINT_SDPA_OUTPUT_IDX], output_tensors[prim::JOINT_SDPA_JOINT_OUTPUT_IDX]};
 }
 
 std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> ExecuteRingJointAttention::invoke(
@@ -195,7 +195,10 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> ExecuteRingJointAttention::
         scale,
         compute_kernel_config,
         core_allocation_strategy);
-    return {output_tensors.output, output_tensors.joint_output, output_tensors.stats_output};
+    return {
+        output_tensors[prim::RING_JOINT_SDPA_OUTPUT_IDX],
+        output_tensors[prim::RING_JOINT_SDPA_JOINT_OUTPUT_IDX],
+        output_tensors[prim::RING_JOINT_SDPA_STATS_OUTPUT_IDX]};
 }
 
 ttnn::Tensor ExecuteFlashMLAPrefill::invoke(


### PR DESCRIPTION
### Ticket
[Related to Llama 70B profiling](https://github.com/tenstorrent/tt-metal/issues/38090)

### Problem description
When profiling RingDistributedSdpaDeviceOperation, the PM (Performance Model) values showed as 1 for compute and bandwidth, resulting in 0% FPU utilization. This occurred because the operation was missing the create_op_performance_model method - the profiler falls back to an
empty default model when this method is absent.

### What's changed
1. Added performance model to RingDistributedSDPA

Created a shared helper function (compute_sdpa_ideal_cycles) for SDPA FLOP calculation based on existing SDPAOperation::create_op_performance_model, then added performance model support to RingDistributedSdpaDeviceOperation and refactored SDPAOperation to use the same helper.

2. Added performance model to JointSDPA and RingJointSDPA

Implemented create_op_performance_model for both operations. These use concatenated sequence dimensions for FLOP calculation:
- JointSDPA: cat_Sq = Sq + Sj, cat_Sk = Sk + Sj
- RingJointSDPA: cat_Sq = N_local + L, cat_Sk = N_global + L

Both are non-causal attention patterns.

3. Replaced custom output structs with vectors

Replaced JointSDPAResult and RingJointSDPAResult structs with Tensors (std::vector<Tensor>) type aliases to ensure compatibility with OpPerformanceModelGeneral template which only supports standard types. Added named index constants for readability.

4. Fixed performance model grid size bug

The performance models were always using the device's full compute grid instead of respecting program_config->compute_with_storage_grid_size when provided. This caused cycle estimates to be inaccurate when users specified a custom grid. Now all four SDPA variants use the same grid selection logic as their program factories.

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=mvasilijevic/sdpa-pm)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:mvasilijevic/sdpa-pm)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mvasilijevic/sdpa-pm)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mvasilijevic/sdpa-pm)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mvasilijevic/sdpa-pm)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mvasilijevic/sdpa-pm)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mvasilijevic/sdpa-pm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mvasilijevic/sdpa-pm)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mvasilijevic/sdpa-pm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mvasilijevic/sdpa-pm)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mvasilijevic/sdpa-pm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mvasilijevic/sdpa-pm)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
