### PR TITLE
Fix BH LLK API to avoid hitting LLK_ASSERTs

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
@@ -329,7 +329,7 @@ inline void llk_init_packer_dest_offset_registers(const std::uint32_t pack_outpu
 }
 
 template <bool is_fp32_dest_acc_en, bool untilize = false>
-inline void llk_pack_dest_init(const std::uint32_t pack_output = 16) {
+inline void llk_pack_dest_init([[maybe_unused]] const std::uint32_t pack_output = 16) {
     _llk_pack_dest_init_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
 }
 
@@ -350,7 +350,9 @@ inline void llk_pack_reconfig_data_format(const std::uint32_t new_output) {
         get_local_cb_interface(output_id).fifo_page_size,
         face_r_dim,
         tile_c_dim,
-        num_faces);
+        num_faces,
+        false,   // partial_face
+        false);  // narrow_tile
 }
 
 // TODO NC: Clean up as the part of tt-metal#34499

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
@@ -44,7 +44,6 @@ inline void llk_pack_hw_configure(std::uint32_t pack_output) {
     const std::uint32_t tile_c_dim = get_output_tile_c_dim(output_id);
     const std::uint32_t num_faces = get_output_num_faces(output_id);
     const bool partial_face = get_output_partial_face(output_id);
-    const bool narrow_tile = get_output_narrow_tile(output_id);
 
     const std::uint32_t tile_size = get_local_cb_interface(output_id).fifo_page_size;
 
@@ -56,7 +55,7 @@ inline void llk_pack_hw_configure(std::uint32_t pack_output) {
         tile_c_dim,
         num_faces,
         partial_face,
-        narrow_tile,
+        false,  // narrow_tile,
         0 /*relu_config*/);
 }
 
@@ -66,7 +65,6 @@ inline void llk_pack_untilize_hw_configure(
     const std::uint32_t output_id = get_output_id(pack_params->pack_output);
     const std::uint32_t tile_c_dim = get_output_tile_c_dim(output_id);
     const bool partial_face = get_output_partial_face(output_id);
-    const bool narrow_tile = get_output_narrow_tile(output_id);
 
     const std::uint32_t tile_size = get_local_cb_interface(output_id).fifo_page_size;
 
@@ -78,7 +76,7 @@ inline void llk_pack_untilize_hw_configure(
         tile_c_dim,
         num_faces,
         partial_face,
-        narrow_tile,
+        false,  // narrow_tile,
         pack_params->relu_config.val);
 }
 
@@ -107,8 +105,6 @@ inline void llk_pack_init(const std::uint32_t pack_output = 16, std::uint32_t nu
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
     const std::uint32_t tile_c_dim = get_output_tile_c_dim(output_id);
     const std::uint32_t num_faces = get_output_num_faces(output_id);
-    const bool partial_face = get_output_partial_face(output_id);
-    const bool narrow_tile = get_output_narrow_tile(output_id);
 
     LLK_ASSERT(
         (are_packers_configured_correctly<PackerProgramType::ProgramByFace>(
@@ -121,8 +117,8 @@ inline void llk_pack_init(const std::uint32_t pack_output = 16, std::uint32_t nu
         face_r_dim,
         tile_c_dim,
         num_faces,
-        partial_face,
-        narrow_tile,
+        false,  // partial_face,
+        false,  // narrow_tile,
         num_tiles);
 }
 
@@ -334,11 +330,7 @@ inline void llk_init_packer_dest_offset_registers(const std::uint32_t pack_outpu
 
 template <bool is_fp32_dest_acc_en, bool untilize = false>
 inline void llk_pack_dest_init(const std::uint32_t pack_output = 16) {
-    const std::uint32_t output_id = get_output_id(pack_output);
-    const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
-    const bool narrow_tile = get_output_narrow_tile(output_id);
-
-    _llk_pack_dest_init_<DST_SYNC_MODE, is_fp32_dest_acc_en>(face_r_dim, narrow_tile);
+    _llk_pack_dest_init_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
 }
 
 inline void llk_pack_debug_dump(std::uint8_t* data, std::uint32_t byte_size) { _llk_pack_debug_dump_(data, byte_size); }
@@ -351,8 +343,6 @@ inline void llk_pack_reconfig_data_format(const std::uint32_t new_output) {
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
     const std::uint32_t tile_c_dim = get_output_tile_c_dim(output_id);
     const std::uint32_t num_faces = get_output_num_faces(output_id);
-    const bool partial_face = get_output_partial_face(output_id);
-    const bool narrow_tile = get_output_narrow_tile(output_id);
 
     _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en, is_tile_dim_reconfig_en>(
         pack_src_format[output_id],
@@ -360,9 +350,7 @@ inline void llk_pack_reconfig_data_format(const std::uint32_t new_output) {
         get_local_cb_interface(output_id).fifo_page_size,
         face_r_dim,
         tile_c_dim,
-        num_faces,
-        partial_face,
-        narrow_tile);
+        num_faces);
 }
 
 // TODO NC: Clean up as the part of tt-metal#34499
@@ -402,7 +390,6 @@ inline void llk_pack_reduce_config_v2(uint32_t icb_out) {
         const std::uint32_t tile_c_dim = get_output_tile_c_dim(output_id);
         const std::uint32_t num_faces = get_output_num_faces(output_id);
         const bool partial_face = get_output_partial_face(output_id);
-        const bool narrow_tile = get_output_narrow_tile(output_id);
         const std::uint32_t tile_size = get_local_cb_interface(output_id).fifo_page_size;
         const llk_relu_config_u relu_config = {
             .f = {
@@ -418,7 +405,7 @@ inline void llk_pack_reduce_config_v2(uint32_t icb_out) {
             tile_c_dim,
             num_faces,
             partial_face,
-            narrow_tile,
+            false,  // narrow_tile,
             relu_config.val);
     }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
@@ -83,17 +83,16 @@ inline void llk_unpack_tilizeA_B_init(
     const std::uint32_t operandA_id = get_operand_id(operandA);
     const bool narrow_tile = get_operand_narrow_tile(operandA_id);
 
-    LLK_ASSERT(
-        (are_unpacker_AB_configured_correctly<UnpackerProgramType::ProgramByFace>(
-            unpack_src_format[operandA_id],
-            unpack_dst_format[operandA_id],
-            unpack_src_format[get_operand_id(operandB)],
-            unpack_dst_format[get_operand_id(operandB)],
-            unpA_face_r_dim,
-            unpB_face_r_dim,
-            num_faces,
-            get_operand_num_faces(get_operand_id(operandB)))),
-        "");
+    LLK_ASSERT((are_unpacker_AB_configured_correctly<UnpackerProgramType::ProgramByFace>(
+        unpack_src_format[operandA_id],
+        unpack_dst_format[operandA_id],
+        unpack_src_format[get_operand_id(operandB)],
+        unpack_dst_format[get_operand_id(operandB)],
+        unpA_face_r_dim,
+        unpB_face_r_dim,
+        num_faces,
+        get_operand_num_faces(get_operand_id(operandB)))),
+    "");
 
     _llk_unpack_tilizeA_B_init_<neginf_srcA, reload_srcB, zero_srcA, zero_srcA_reduce>(
         unpack_src_format[operandA_id],

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
@@ -83,16 +83,17 @@ inline void llk_unpack_tilizeA_B_init(
     const std::uint32_t operandA_id = get_operand_id(operandA);
     const bool narrow_tile = get_operand_narrow_tile(operandA_id);
 
-    LLK_ASSERT((are_unpacker_AB_configured_correctly<UnpackerProgramType::ProgramByFace>(
-        unpack_src_format[operandA_id],
-        unpack_dst_format[operandA_id],
-        unpack_src_format[get_operand_id(operandB)],
-        unpack_dst_format[get_operand_id(operandB)],
-        unpA_face_r_dim,
-        unpB_face_r_dim),
-        num_faces,
-        get_operand_num_faces(get_operand_id(operandB))),
-    "");
+    LLK_ASSERT(
+        (are_unpacker_AB_configured_correctly<UnpackerProgramType::ProgramByFace>(
+            unpack_src_format[operandA_id],
+            unpack_dst_format[operandA_id],
+            unpack_src_format[get_operand_id(operandB)],
+            unpack_dst_format[get_operand_id(operandB)],
+            unpA_face_r_dim,
+            unpB_face_r_dim,
+            num_faces,
+            get_operand_num_faces(get_operand_id(operandB)))),
+        "");
 
     _llk_unpack_tilizeA_B_init_<neginf_srcA, reload_srcB, zero_srcA, zero_srcA_reduce>(
         unpack_src_format[operandA_id],


### PR DESCRIPTION
### Ticket
#39435 

### Problem description
Some of parameters in LLK LIB are not used. To mark them unused, LLK_ASSERT-s are added to expose these parameters. However, it happens that in LLK_API, there are getters for these parameters which get non-default value and pass to LLK LIB effectively triggering LLK_ASSERT-s.

### What's changed
Added fixes for calling LLK LIB from LLK API for parameters which are not used. Ensured that default values are passed for those parameters.

### Checklist

- [] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ndivnic/fix_BH_llk_api_for_llk_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ndivnic/fix_BH_llk_api_for_llk_asserts)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ndivnic/fix_BH_llk_api_for_llk_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ndivnic/fix_BH_llk_api_for_llk_asserts)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/fix_BH_llk_api_for_llk_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/fix_BH_llk_api_for_llk_asserts)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/fix_BH_llk_api_for_llk_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/fix_BH_llk_api_for_llk_asserts)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/fix_BH_llk_api_for_llk_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/fix_BH_llk_api_for_llk_asserts)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/fix_BH_llk_api_for_llk_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/fix_BH_llk_api_for_llk_asserts)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
