### PR TITLE
[tt-train] Replace deprecated tt-train aliases with ttsl and tt::tt_metal types

### DIFF
--- a/tt-train/sources/examples/nano_gpt/main.cpp
+++ b/tt-train/sources/examples/nano_gpt/main.cpp
@@ -543,7 +543,7 @@ int main(int argc, char **argv) {
                     const uint32_t BATCH_DIM = 0;
                     const uint32_t SEQUENCE_DIM_DATA = 3;
                     const uint32_t SEQUENCE_DIM_TARGETS = 1;
-                    tt::stl::SmallVector<ttnn::distributed::MeshMapperConfig::Placement> data_placements(
+                    ttsl::SmallVector<ttnn::distributed::MeshMapperConfig::Placement> data_placements(
                         mesh_device.shape().dims(), ttnn::distributed::MeshMapperConfig::Replicate{});
                     if (pctx.is_ddp_enabled()) {
                         data_placements[pctx.get_ddp_axis().value()] =
@@ -563,7 +563,7 @@ int main(int argc, char **argv) {
                             device,
                             ttnn::Layout::ROW_MAJOR,
                             data_mapper.get()));
-                    tt::stl::SmallVector<ttnn::distributed::MeshMapperConfig::Placement> targets_placements(
+                    ttsl::SmallVector<ttnn::distributed::MeshMapperConfig::Placement> targets_placements(
                         mesh_device.shape().dims(), ttnn::distributed::MeshMapperConfig::Replicate{});
                     if (pctx.is_ddp_enabled()) {
                         targets_placements[pctx.get_ddp_axis().value()] =

--- a/tt-train/sources/ttml/core/distributed/distributed.cpp
+++ b/tt-train/sources/ttml/core/distributed/distributed.cpp
@@ -15,7 +15,7 @@
 
 namespace ttml::core::distributed {
 
-ttnn::Tensor synchronize_tensor(const ttnn::Tensor& tensor, const ttnn::SmallVector<uint32_t>& cluster_axes) {
+ttnn::Tensor synchronize_tensor(const ttnn::Tensor& tensor, const ttsl::SmallVector<uint32_t>& cluster_axes) {
     auto* device = &autograd::ctx().get_device();
     if (cluster_axes.size() == 0) {
         return tensor;
@@ -42,7 +42,7 @@ void synchronize_gradients(const serialization::NamedParameters& parameters) {
         return;
     }
     const auto& pctx = autograd::ctx().get_parallelism_context();
-    ttnn::SmallVector<uint32_t> cluster_axes;
+    ttsl::SmallVector<uint32_t> cluster_axes;
     if (pctx.is_cp_enabled()) {
         cluster_axes.push_back(pctx.get_cp_axis().value());
     }

--- a/tt-train/sources/ttml/core/distributed/distributed.hpp
+++ b/tt-train/sources/ttml/core/distributed/distributed.hpp
@@ -14,7 +14,7 @@ using Rank = tt::tt_metal::distributed::multihost::Rank;
 using Tag = tt::tt_metal::distributed::multihost::Tag;
 using DistributedContext = tt::tt_metal::distributed::multihost::DistributedContext;
 
-ttnn::Tensor synchronize_tensor(const ttnn::Tensor& tensor, const ttnn::SmallVector<uint32_t>& cluster_axes);
+ttnn::Tensor synchronize_tensor(const ttnn::Tensor& tensor, const ttsl::SmallVector<uint32_t>& cluster_axes);
 
 void synchronize_gradients(const serialization::NamedParameters& parameters);
 

--- a/tt-train/sources/ttml/metal/ops/ring_sdpa_bw/device/ring_sdpa_bw_kv_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/ring_sdpa_bw/device/ring_sdpa_bw_kv_device_operation.cpp
@@ -62,10 +62,10 @@ RingSDPABwKVDeviceOperation::tensor_return_value_t RingSDPABwKVDeviceOperation::
     return {grad_key, grad_value};
 }
 
-tt::stl::hash::hash_t RingSDPABwKVDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t RingSDPABwKVDeviceOperation::compute_program_hash(
     const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
     // Hash based on operation configuration - buffer addresses are updated via override_runtime_arguments
-    return tt::stl::hash::hash_objects(
+    return ttsl::hash::hash_objects(
         1,  // KV marker (different from Q)
         attrs.ring_size,
         attrs.ring_axis,

--- a/tt-train/sources/ttml/metal/ops/ring_sdpa_bw/device/ring_sdpa_bw_q_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/ring_sdpa_bw/device/ring_sdpa_bw_q_device_operation.cpp
@@ -45,9 +45,9 @@ RingSDPABwQDeviceOperation::tensor_return_value_t RingSDPABwQDeviceOperation::cr
     return create_device_tensor(output_spec, tensor_args.query.device());
 }
 
-tt::stl::hash::hash_t RingSDPABwQDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t RingSDPABwQDeviceOperation::compute_program_hash(
     const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
-    return tt::stl::hash::hash_objects(
+    return ttsl::hash::hash_objects(
         0,  // Q marker (different from KV)
         attrs.ring_size,
         attrs.ring_axis,

--- a/tt-train/sources/ttml/metal/ops/ring_sdpa_fw/device/ring_sdpa_fw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/ring_sdpa_fw/device/ring_sdpa_fw_device_operation.cpp
@@ -63,10 +63,10 @@ RingSDPAFwDeviceOperation::tensor_return_value_t RingSDPAFwDeviceOperation::crea
     return {output, intermediates};
 }
 
-tt::stl::hash::hash_t RingSDPAFwDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t RingSDPAFwDeviceOperation::compute_program_hash(
     const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
     // Hash based on operation configuration - buffer addresses are updated via override_runtime_arguments
-    return tt::stl::hash::hash_objects(
+    return ttsl::hash::hash_objects(
         attrs.ring_size,
         attrs.ring_axis,
         attrs.step,

--- a/tt-train/sources/ttml/metal/ops/softmax_backward/device/softmax_backward_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/softmax_backward/device/softmax_backward_program_factory.cpp
@@ -40,26 +40,26 @@ constexpr const char* const kComputePath =
     "tt-train/sources/ttml/metal/ops/softmax_backward/device/kernels/compute/softmax_backward_kernel.cpp";
 
 struct CoreRowAssignment {
-    CoreCoord core;
+    tt::tt_metal::CoreCoord core;
     uint32_t start_row;
     uint32_t num_rows;
 };
 
-static std::vector<CoreCoord> get_worker_cores_in_order(
-    const std::optional<CoreRangeSet>& sub_core_grids, const tt::tt_metal::IDevice* device) {
+static std::vector<tt::tt_metal::CoreCoord> get_worker_cores_in_order(
+    const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids, const tt::tt_metal::IDevice* device) {
     if (sub_core_grids.has_value()) {
-        const CoreRangeSet& sub = *sub_core_grids;
-        std::vector<CoreCoord> cores;
+        const tt::tt_metal::CoreRangeSet& sub = *sub_core_grids;
+        std::vector<tt::tt_metal::CoreCoord> cores;
         cores.reserve(sub.num_cores());
-        for (const CoreRange& range : sub.ranges()) {
-            for (CoreCoord core : range) {
+        for (const tt::tt_metal::CoreRange& range : sub.ranges()) {
+            for (tt::tt_metal::CoreCoord core : range) {
                 cores.push_back(core);
             }
         }
         return cores;
     }
-    const CoreCoord grid_size = device->compute_with_storage_grid_size();
-    std::vector<CoreCoord> cores;
+    const tt::tt_metal::CoreCoord grid_size = device->compute_with_storage_grid_size();
+    std::vector<tt::tt_metal::CoreCoord> cores;
     cores.reserve(grid_size.x * grid_size.y);
     for (uint32_t x = 0; x < grid_size.x; ++x) {
         for (uint32_t y = 0; y < grid_size.y; ++y) {
@@ -70,9 +70,9 @@ static std::vector<CoreCoord> get_worker_cores_in_order(
 }
 
 static void assign_rows_to_cores(
-    const std::vector<CoreCoord>& cores_in_order,
+    const std::vector<tt::tt_metal::CoreCoord>& cores_in_order,
     uint32_t num_rows,
-    std::vector<CoreRange>& worker_core_ranges,
+    std::vector<tt::tt_metal::CoreRange>& worker_core_ranges,
     std::vector<CoreRowAssignment>& core_row_assignments) {
     const uint32_t num_cores = static_cast<uint32_t>(cores_in_order.size());
     if (num_cores == 0)
@@ -86,8 +86,8 @@ static void assign_rows_to_cores(
         const uint32_t num_rows_this_core = end_row - start_row;
         if (num_rows_this_core == 0)
             continue;
-        const CoreCoord& core = cores_in_order[core_idx];
-        worker_core_ranges.push_back(CoreRange(core, core));
+        const tt::tt_metal::CoreCoord& core = cores_in_order[core_idx];
+        worker_core_ranges.push_back(tt::tt_metal::CoreRange(core, core));
         core_row_assignments.push_back({core, start_row, num_rows_this_core});
     }
 }
@@ -204,13 +204,13 @@ SoftmaxBackwardFactory::cached_program_t SoftmaxBackwardFactory::create(
         required_memory_bytes / 1024);
 
     // Collect worker cores in deterministic order and assign rows to each.
-    std::vector<CoreRange> worker_core_ranges;
+    std::vector<tt::tt_metal::CoreRange> worker_core_ranges;
     std::vector<CoreRowAssignment> core_row_assignments;
-    const std::vector<CoreCoord> cores_in_order =
+    const std::vector<tt::tt_metal::CoreCoord> cores_in_order =
         get_worker_cores_in_order(operation_attributes.sub_core_grids, device);
     assign_rows_to_cores(cores_in_order, num_rows, worker_core_ranges, core_row_assignments);
     TT_FATAL(!worker_core_ranges.empty(), "SoftmaxBackward: no cores have work");
-    const CoreRangeSet worker_cores(worker_core_ranges);
+    const tt::tt_metal::CoreRangeSet worker_cores(worker_core_ranges);
 
     const uint32_t block_cb_size_in0 = buffering_multiplier * tiles_per_block * input_tile_size;
     const uint32_t block_cb_size_out = buffering_multiplier * tiles_per_block * output_tile_size;

--- a/tt-train/sources/ttml/ops/distributed/ring_attention_sdpa.cpp
+++ b/tt-train/sources/ttml/ops/distributed/ring_attention_sdpa.cpp
@@ -112,7 +112,7 @@ autograd::TensorPtr ring_attention_sdpa(
         std::ref(*mesh_device));
 
     // Pad to 32 columns each (adds 31 zeros on the right of last dim)
-    ttnn::SmallVector<ttnn::operations::data_movement::PadSpecDim> padding_spec = {
+    ttsl::SmallVector<ttnn::operations::data_movement::PadSpecDim> padding_spec = {
         {0, 0},  // batch
         {0, 0},  // heads
         {0, 0},  // seq_len
@@ -150,15 +150,15 @@ autograd::TensorPtr ring_attention_sdpa(
 
         // Extract max_val from column 0
         // Slice: [0:B, 0:H, 0:S, 0:1]
-        const ttnn::SmallVector<uint32_t> slice_step = {1, 1, 1, 1};
-        const ttnn::SmallVector<uint32_t> max_start = {0, 0, 0, 0};
-        const ttnn::SmallVector<uint32_t> max_end = {batch_num, heads, seq_len_local, 1};
+        const ttsl::SmallVector<uint32_t> slice_step = {1, 1, 1, 1};
+        const ttsl::SmallVector<uint32_t> max_start = {0, 0, 0, 0};
+        const ttsl::SmallVector<uint32_t> max_end = {batch_num, heads, seq_len_local, 1};
         ttnn::Tensor max_val_chunk = ttnn::slice(intermediate_tensor, max_start, max_end, slice_step);
 
         // Extract recip_sum_exp from column 32
         // Slice: [0:B, 0:H, 0:S, 32:33]
-        const ttnn::SmallVector<uint32_t> recip_start = {0, 0, 0, 32};
-        const ttnn::SmallVector<uint32_t> recip_end = {batch_num, heads, seq_len_local, 33};
+        const ttsl::SmallVector<uint32_t> recip_start = {0, 0, 0, 32};
+        const ttsl::SmallVector<uint32_t> recip_end = {batch_num, heads, seq_len_local, 33};
         ttnn::Tensor recip_sum_exp_chunk = ttnn::slice(intermediate_tensor, recip_start, recip_end, slice_step);
 
         // Step 1: Compute sum_exp_chunk = 1 / recip_sum_exp
@@ -250,11 +250,11 @@ autograd::TensorPtr ring_attention_sdpa(
         ttnn::Tensor recip_final_sum = ttnn::reciprocal(final_global_sum_exp);
 
         // Slice parameters for extracting max and sum_exp from intermediate
-        const ttnn::SmallVector<uint32_t> slice_step = {1, 1, 1, 1};
-        const ttnn::SmallVector<uint32_t> max_start = {0, 0, 0, 0};
-        const ttnn::SmallVector<uint32_t> max_end = {batch_num, heads, seq_len_local, 1};
-        const ttnn::SmallVector<uint32_t> recip_start = {0, 0, 0, 32};
-        const ttnn::SmallVector<uint32_t> recip_end = {batch_num, heads, seq_len_local, 33};
+        const ttsl::SmallVector<uint32_t> slice_step = {1, 1, 1, 1};
+        const ttsl::SmallVector<uint32_t> max_start = {0, 0, 0, 0};
+        const ttsl::SmallVector<uint32_t> max_end = {batch_num, heads, seq_len_local, 1};
+        const ttsl::SmallVector<uint32_t> recip_start = {0, 0, 0, 32};
+        const ttsl::SmallVector<uint32_t> recip_end = {batch_num, heads, seq_len_local, 33};
 
         // Loop over ring steps in reverse order (from last to first)
         for (int step = ring_size - 1; step >= 0; --step) {


### PR DESCRIPTION
Made-with: Cursor

### Ticket
N/A

### Problem description
`ttnn::SmallVector` and `tt::stl` aliases are deprecated in favor of `ttsl` (and explicit `tt::tt_metal` types for core coordinate/range aliases). `tt-train` still had deprecated alias usage in several runtime paths, producing deprecation warnings during `tt-train` build.

### What's changed
- **Code:** Replaced deprecated alias usage in `tt-train` with supported names:
  - `ttnn::SmallVector` -> `ttsl::SmallVector`
  - `tt::stl::SmallVector` -> `ttsl::SmallVector`
  - `tt::stl::hash::*` -> `ttsl::hash::*`
  - Deprecated unqualified `CoreCoord`/`CoreRange`/`CoreRangeSet` aliases -> explicit `tt::tt_metal::*` in the touched softmax backward factory file.
- **Scope:** Updates are in `tt-train` source files only (examples + distributed/metal ops paths).
- **Validation:** Rebuilt with:
  - `./build_metal.sh -b Release --build-tt-train`
  - Build completed successfully and reached install phase.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=mdragula/fix-tt-train-deprecations)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:mdragula/fix-tt-train-deprecations)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mdragula/fix-tt-train-deprecations)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mdragula/fix-tt-train-deprecations)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mdragula/fix-tt-train-deprecations)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mdragula/fix-tt-train-deprecations)
- [ ] New/Existing tests provide coverage for changes