### PR TITLE
[skip ci] Update various upstream container tests

### DIFF
--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -213,9 +213,8 @@ test_suite_bh_glx_metal_unit_tests() {
 
     # BH Galaxy XY (2D) Torus System Validation (no fabric, simply validate that expected links are discovered and healthy)
     ./build/tools/scaleout/run_cluster_validation --cabling-descriptor-path tools/tests/scaleout/cabling_descriptors/bh_galaxy_xy_torus.textproto --hard-fail --send-traffic
-    # Fabric1D and Fabric2D unit tests skipped due to https://github.com/tenstorrent/tt-metal/issues/39491
-    # RELIABILITY_MODE=relaxed ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="*Fabric2D*.*"
-    # RELIABILITY_MODE=relaxed ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="*Fabric1D*.*":-NightlyFabric1DFixture.TestEDMConnectionStressTestQuick
+    RELIABILITY_MODE=relaxed ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="*Fabric2D*.*"
+    RELIABILITY_MODE=relaxed ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="*Fabric1D*.*":-NightlyFabric1DFixture.TestEDMConnectionStressTestQuick
     RELIABILITY_MODE=relaxed TT_METAL_CLEAR_L1=1 build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
     # Deadlock stability tests - These validate 2D Torus (QSFP Link) stability
     RELIABILITY_MODE=relaxed TT_METAL_CLEAR_L1=1 build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_deadlock_stability_bh_6U_galaxy.yaml

--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -187,13 +187,10 @@ test_suite_wh_6u_llama_demo_tests() {
 
     verify_llama_dir_
 
-    pytest models/demos/llama3_70b_galaxy/tests/test_llama_model.py -k "quick"
-    pytest models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_model_prefill.py
     pytest models/demos/llama3_70b_galaxy/demo/text_demo.py -k "repeat"
     # Some AssertionError: Throughput is out of targets 49 - 53 t/s/u in 200 iterations
     # assert 200 <= 20
     # pytest models/demos/llama3_70b_galaxy/demo/demo_decode.py -k "full"
-    pytest models/demos/llama3_70b_galaxy/demo/demo_decode.py -k "mini-stress-test"
 }
 
 test_suite_wh_6u_llama_long_stress_tests() {

--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -216,7 +216,7 @@ test_suite_bh_glx_metal_unit_tests() {
 
     # BH Galaxy XY (2D) Torus System Validation (no fabric, simply validate that expected links are discovered and healthy)
     ./build/tools/scaleout/run_cluster_validation --cabling-descriptor-path tools/tests/scaleout/cabling_descriptors/bh_galaxy_xy_torus.textproto --hard-fail --send-traffic
-    RELIABILITY_MODE=relaxed ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="*Fabric2D*.*"
+    # RELIABILITY_MODE=relaxed ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="*Fabric2D*.*"
     RELIABILITY_MODE=relaxed ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="*Fabric1D*.*":-NightlyFabric1DFixture.TestEDMConnectionStressTestQuick
     RELIABILITY_MODE=relaxed TT_METAL_CLEAR_L1=1 build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
     # Deadlock stability tests - These validate 2D Torus (QSFP Link) stability

--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -213,6 +213,7 @@ test_suite_bh_glx_metal_unit_tests() {
 
     # BH Galaxy XY (2D) Torus System Validation (no fabric, simply validate that expected links are discovered and healthy)
     ./build/tools/scaleout/run_cluster_validation --cabling-descriptor-path tools/tests/scaleout/cabling_descriptors/bh_galaxy_xy_torus.textproto --hard-fail --send-traffic
+    # Fabric1D and Fabric2D unit tests skipped due to https://github.com/tenstorrent/tt-metal/issues/39491
     # RELIABILITY_MODE=relaxed ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="*Fabric2D*.*"
     # RELIABILITY_MODE=relaxed ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="*Fabric1D*.*":-NightlyFabric1DFixture.TestEDMConnectionStressTestQuick
     RELIABILITY_MODE=relaxed TT_METAL_CLEAR_L1=1 build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml

--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -217,7 +217,7 @@ test_suite_bh_glx_metal_unit_tests() {
     # BH Galaxy XY (2D) Torus System Validation (no fabric, simply validate that expected links are discovered and healthy)
     ./build/tools/scaleout/run_cluster_validation --cabling-descriptor-path tools/tests/scaleout/cabling_descriptors/bh_galaxy_xy_torus.textproto --hard-fail --send-traffic
     # RELIABILITY_MODE=relaxed ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="*Fabric2D*.*"
-    RELIABILITY_MODE=relaxed ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="*Fabric1D*.*":-NightlyFabric1DFixture.TestEDMConnectionStressTestQuick
+    # RELIABILITY_MODE=relaxed ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="*Fabric1D*.*":-NightlyFabric1DFixture.TestEDMConnectionStressTestQuick
     RELIABILITY_MODE=relaxed TT_METAL_CLEAR_L1=1 build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
     # Deadlock stability tests - These validate 2D Torus (QSFP Link) stability
     RELIABILITY_MODE=relaxed TT_METAL_CLEAR_L1=1 build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_deadlock_stability_bh_6U_galaxy.yaml

--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -24,7 +24,7 @@ test_suite_bh_single_pcie_metal_unit_tests() {
 test_suite_bh_umd_unit_tests() {
     ./build/test/umd/blackhole/unit_tests
     # Filter out the test that is failing due to local YAML files, see: https://github.com/tenstorrent/tt-metal/issues/24359
-    gtest_filter="-ApiClusterTest.DifferentConstructors"
+    gtest_filter="-TestTTVisibleDevices.DifferentConstructors"
     ./build/test/umd/api/api_tests --gtest_filter="$gtest_filter"
 }
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Some container tests are failing for >2 weeks

### What's changed
WH galaxy:
- Per: https://tenstorrent.slack.com/archives/C08HAHXLLEP/p1773078899389229?thread_ts=1773065882.391339&cid=C08HAHXLLEP remove llama demo tests that don't run in Galaxy demo tests

BH single card:
- update gtest filter (UMD change renamed the test)

### Checklist

- [x] Upstream tests (BH galaxy, P150 passing: https://github.com/tenstorrent/tt-metal/actions/runs/22863159340/job/66360853854)
P100 failure: https://github.com/tenstorrent/tt-umd/issues/1582
WH galaxy llama failures being debugged