### PR TITLE
SDXL unet perf target relaxed

### DIFF
--- a/models/demos/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -119,7 +119,7 @@ def test_refiner_unet(
         ),
         (
             'pytest models/demos/stable_diffusion_xl_base/tests/test_sdxl_perf.py::test_unet -k "512x512"',
-            90_553_421 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
+            91_053_421 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
             "sdxl_unet_512x512",
             "sdxl_unet_512x512",
             1,

--- a/models/demos/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -109,7 +109,7 @@ def test_refiner_unet(
     [
         (
             'pytest models/demos/stable_diffusion_xl_base/tests/test_sdxl_perf.py::test_unet -k "1024x1024"',
-            190_201_442 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
+            191_201_442 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
             "sdxl_unet_1024x1024",
             "sdxl_unet_1024x1024",
             1,


### PR DESCRIPTION
### Ticket


### Problem description
Currently device perf for unet is very close to upper threshold - resulting in flaky fails in metal CI:
[example link](https://github.com/tenstorrent/tt-metal/actions/runs/22842866558/job/66253092411)

### What's changed
SDXL Unet perf targets modified slightly - so new regressions can be captured easily

### Checklist
- [x] [SDXL device perf](https://github.com/tenstorrent/tt-metal/actions/runs/22862702704)
