### PR TITLE
#38763: move layernorm kernels to device 2.0

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm.cpp
@@ -27,6 +27,7 @@
 #include "api/compute/eltwise_unary/sfpu_split_includes.h"
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "experimental/circular_buffer.h"
 
 #include "layernorm_compute_utils.h"
 
@@ -62,11 +63,23 @@ void kernel_main() {
 #else
     constexpr uint32_t cb_xmm = tt::CBIndex::c_24;  // x minus mean
 #endif
+    experimental::CircularBuffer cb_xmm_obj(cb_xmm);
     constexpr auto cb_ex = tt::CBIndex::c_18;      // E[x]
     constexpr auto cb_ex2 = tt::CBIndex::c_19;     // E[(x-E[x])^2]
     constexpr auto cb_xmm2 = tt::CBIndex::c_20;    // xmm^2
     constexpr auto cb_ex2pe = tt::CBIndex::c_21;   // E[(x-E[x])^2]+eps
     constexpr auto cb_fusion = tt::CBIndex::c_22;  // stream gamma/beta
+    experimental::CircularBuffer cb_eps_obj(cb_eps);
+    experimental::CircularBuffer cb_in_obj(cb_in);
+    experimental::CircularBuffer cb_inb_obj(cb_inb);
+    experimental::CircularBuffer cb_out_obj(cb_out);
+    experimental::CircularBuffer cb_gamma_obj(cb_gamma);
+    experimental::CircularBuffer cb_beta_obj(cb_beta);
+    experimental::CircularBuffer cb_ex_obj(cb_ex);
+    experimental::CircularBuffer cb_ex2_obj(cb_ex2);
+    experimental::CircularBuffer cb_xmm2_obj(cb_xmm2);
+    experimental::CircularBuffer cb_ex2pe_obj(cb_ex2pe);
+    experimental::CircularBuffer cb_fusion_obj(cb_fusion);
 
     constexpr auto cb_in_rm = tt::CBIndex::c_27;  // input row-major (if row-major input, otherwise unused)
 
@@ -84,6 +97,7 @@ void kernel_main() {
 #else
     constexpr uint32_t cb_x = cb_in;
 #endif
+    experimental::CircularBuffer cb_x_obj(cb_x);
 
 #ifdef TILIZE_IN
     binary_op_init_common(cb_in_rm, cb_in_rm, cb_in);
@@ -95,9 +109,10 @@ void kernel_main() {
     binary_op_init_common(cb_x, cb_scaler, cb_ex);
 #endif
 
-    cb_wait_front(cb_eps, 1);     // comes from the reader
+    cb_eps_obj.wait_front(1);  // comes from the reader
 
     constexpr int cb_im_or_out = (do_gamma | do_beta) ? cb_fusion : cb_out;
+    experimental::CircularBuffer cb_im_or_out_obj(cb_im_or_out);
 
     // Intermediate buffers need to be reserved/pushed/popped
     // in full blocks
@@ -128,17 +143,17 @@ void kernel_main() {
             // synced on full block size. Keep cb_x aligned
             // to full block size as well so pre-add/no-pre-add
             // can be handled the same way.
-            cb_wait_front(cb_in, block.full_block_size());
-            cb_wait_front(cb_inb, block.full_block_size());
-            cb_reserve_back(cb_x, block.full_block_size());
+            cb_in_obj.wait_front(block.full_block_size());
+            cb_inb_obj.wait_front(block.full_block_size());
+            cb_x_obj.reserve_back(block.full_block_size());
             for (auto i : block.local()) {
                 add_tiles(cb_in, cb_inb, i, i, i);
                 pack_tile(i, cb_x);
             }
             REL();
-            cb_push_back(cb_x, block.full_block_size());  // push the sum into the same buffer
-            cb_pop_front(cb_in, block.full_block_size());
-            cb_pop_front(cb_inb, block.full_block_size());
+            cb_x_obj.push_back(block.full_block_size());  // push the sum into the same buffer
+            cb_in_obj.pop_front(block.full_block_size());
+            cb_inb_obj.pop_front(block.full_block_size());
         }
 #ifndef RMSNORM
         reconfig_data_format(cb_in, cb_x, cb_inb, cb_scaler);
@@ -160,7 +175,7 @@ void kernel_main() {
 
         // x - E[x]
         reconfig_data_format(cb_x, cb_ex);
-        cb_reserve_back(cb_xmm, total_buffer_size);
+        cb_xmm_obj.reserve_back(total_buffer_size);
         sub_bcast_cols_init_short(cb_x, cb_ex);
         for (auto block : generic::blocks(Wt, block_size)) {
             ACQ();
@@ -168,11 +183,11 @@ void kernel_main() {
                 sub_tiles_bcast_cols(cb_x, cb_ex, i, 0, i);
                 pack_tile(i, cb_xmm);
             }
-            cb_push_back(cb_xmm, block.full_block_size());
-            cb_pop_front(cb_x, block.full_block_size());
+            cb_xmm_obj.push_back(block.full_block_size());
+            cb_x_obj.pop_front(block.full_block_size());
             REL();
         }
-        cb_pop_front(cb_ex, 1);
+        cb_ex_obj.pop_front(1);
 
 #ifndef FUSE_PRE_ADD
         reconfig_data_format_srca(cb_x, cb_xmm);
@@ -185,18 +200,18 @@ void kernel_main() {
         mul_tiles_init(cb_xmm, cb_xmm);
         for (auto block : generic::blocks(Wt, block_size)) {
 #ifndef RMSNORM
-            cb_wait_front(cb_xmm, block.start() + block.size());
+            cb_xmm_obj.wait_front(block.start() + block.size());
 #else
-            cb_wait_front(cb_xmm, block.start() + block.full_block_size());
+            cb_xmm_obj.wait_front(block.start() + block.full_block_size());
 #endif
-            cb_reserve_back(cb_xmm2, block.full_block_size());
+            cb_xmm2_obj.reserve_back(block.full_block_size());
             ACQ();
             for (auto i : block.local()) {
                 const auto global_i = block.to_global(i);
                 mul_tiles(cb_xmm, cb_xmm, global_i, global_i, i);
                 pack_tile(i, cb_xmm2);
             }
-            cb_push_back(cb_xmm2, block.full_block_size());
+            cb_xmm2_obj.push_back(block.full_block_size());
             REL();
         }
 #if defined RMSNORM and not defined FUSED_PRE_ADD
@@ -208,23 +223,23 @@ void kernel_main() {
             cb_xmm2, cb_scaler, cb_ex2, W, Wt, block_size);
 
         // Var[x] + eps
-        cb_wait_front(cb_ex2, 1);
+        cb_ex2_obj.wait_front(1);
         reconfig_data_format(cb_ex2, cb_eps);
         ACQ();
         add_tiles_init(cb_ex2, cb_eps);
         add_tiles(cb_ex2, cb_eps, 0, 0, dst0);
 
-        cb_reserve_back(cb_ex2pe, 1);  // 1
+        cb_ex2pe_obj.reserve_back(1);  // 1
         rsqrt_tile_init<LEGACY_RSQRT>();
         rsqrt_tile<LEGACY_RSQRT>(dst0);
         pack_reconfig_data_format(cb_ex2pe);
         pack_tile(dst0, cb_ex2pe);
-        cb_push_back(cb_ex2pe, 1);
+        cb_ex2pe_obj.push_back(1);
         REL();
-        cb_pop_front(cb_ex2, 1);
+        cb_ex2_obj.pop_front(1);
 
         // (x-E[x]) / sqrt(Var[x] + eps) * gamma + beta
-        cb_wait_front(cb_ex2pe, 1);
+        cb_ex2pe_obj.wait_front(1);
         for (auto block : generic::blocks(Wt, block_size)) {
             reconfig_data_format(cb_xmm, cb_ex2pe);
             if constexpr (do_gamma == 0 && do_beta == 0) {
@@ -232,7 +247,7 @@ void kernel_main() {
             } else {
                 pack_reconfig_data_format(cb_fusion);
             }
-            cb_reserve_back(cb_im_or_out, block.full_block_size());
+            cb_im_or_out_obj.reserve_back(block.full_block_size());
 #if defined RMSNORM and not defined FUSE_PRE_ADD
             reconfig_data_format_srca(cb_fusion, cb_xmm);
 #endif
@@ -251,8 +266,7 @@ void kernel_main() {
 #endif
                 pack_tile(i, cb_im_or_out);  // pack either to intermediate (cb_fusion or out0)
             }
-            cb_push_back(
-                cb_im_or_out,
+            cb_im_or_out_obj.push_back(
                 block.full_block_size());  // if no gamma/beta are provided, this will be passed on to the writer
             REL();
 
@@ -269,11 +283,12 @@ void kernel_main() {
                 reconfig_data_format_srcb(cb_ex2pe, cb_gamma);
                 ACQ();
                 uint32_t cb_outg = do_beta ? cb_fusion : cb_out;
+                experimental::CircularBuffer cb_outg_obj(cb_outg);
                 mul_bcast_rows_init_short(cb_fusion, cb_gamma);
-                cb_reserve_back(cb_outg, block.full_block_size());
-                cb_wait_front(
-                    cb_gamma, block.start() + block.full_block_size());  // we don't pop, TODO: only wait on first ht
-                cb_wait_front(cb_fusion, block.full_block_size());
+                cb_outg_obj.reserve_back(block.full_block_size());
+                cb_gamma_obj.wait_front(
+                    block.start() + block.full_block_size());  // we don't pop, TODO: only wait on first ht
+                cb_fusion_obj.wait_front(block.full_block_size());
                 for (auto i : block.local()) {
                     mul_tiles_bcast_rows(cb_fusion, cb_gamma, i, block.to_global(i), i);  // tile *= 1/(sum(exp(x)))
 #ifdef SFPU_OP_INIT_ACTIVATION
@@ -287,9 +302,9 @@ void kernel_main() {
 #endif
                     pack_tile(i, cb_outg);  // pack either to intermediate (cb_fusion or out0)
                 }
-                cb_pop_front(cb_fusion, block.full_block_size());
+                cb_fusion_obj.pop_front(block.full_block_size());
                 // we don't pop gamma
-                cb_push_back(cb_outg, block.full_block_size());
+                cb_outg_obj.push_back(block.full_block_size());
                 // We don't pop gamma since it's 1,1,1,Wt and we reuse it for all NCHt
                 REL();
             }
@@ -302,10 +317,10 @@ void kernel_main() {
                 }
                 ACQ();
                 add_bcast_rows_init_short(cb_fusion, cb_beta);
-                cb_reserve_back(cb_out, block.full_block_size());
-                cb_wait_front(
-                    cb_beta, block.start() + block.full_block_size());  // TODO: optimization - only wait on first ht
-                cb_wait_front(cb_fusion, block.full_block_size());
+                cb_out_obj.reserve_back(block.full_block_size());
+                cb_beta_obj.wait_front(
+                    block.start() + block.full_block_size());  // TODO: optimization - only wait on first ht
+                cb_fusion_obj.wait_front(block.full_block_size());
                 for (auto i : block.local()) {
                     add_tiles_bcast_rows(cb_fusion, cb_beta, i, block.to_global(i), i);  // tile *= 1/(sum(exp(x)))
 #ifdef SFPU_OP_INIT_ACTIVATION
@@ -314,14 +329,14 @@ void kernel_main() {
 #endif
                     pack_tile(i, cb_out);  // pack either to intermediate (cb_fusion or out0)
                 }
-                cb_pop_front(cb_fusion, block.full_block_size());
+                cb_fusion_obj.pop_front(block.full_block_size());
                 // We don't pop beta since it's 1,1,1,Wt and we reuse it for all NCHt
-                cb_push_back(cb_out, block.full_block_size());
+                cb_out_obj.push_back(block.full_block_size());
                 REL();
             }
         }
-        cb_pop_front(cb_ex2pe, 1);
-        cb_pop_front(cb_xmm, total_buffer_size);
+        cb_ex2pe_obj.pop_front(1);
+        cb_xmm_obj.pop_front(total_buffer_size);
 
 #ifdef UNTILIZE_OUT
         constexpr auto cb_out_rm = tt::CBIndex::c_28;

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_large_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_large_tensor.cpp
@@ -18,6 +18,7 @@
 #include "api/compute/tile_move_copy.h"
 #include "ttnn/operations/normalization/kernel_util/compute/numeric.h"
 #include "ttnn/operations/normalization/kernel_util/generic/blocked_range.h"
+#include "experimental/circular_buffer.h"
 
 #include "layernorm_compute_utils.h"
 
@@ -67,6 +68,19 @@ void kernel_main() {
     constexpr uint32_t cb_x = cb_in;
 #endif
 
+    experimental::CircularBuffer cb_eps_obj(cb_eps);
+    experimental::CircularBuffer cb_in_obj(cb_in);
+    experimental::CircularBuffer cb_inb_obj(cb_inb);
+    experimental::CircularBuffer cb_out_obj(cb_out);
+    experimental::CircularBuffer cb_gamma_obj(cb_gamma);
+    experimental::CircularBuffer cb_beta_obj(cb_beta);
+    experimental::CircularBuffer cb_xmm_obj(cb_xmm);
+    experimental::CircularBuffer cb_ex_obj(cb_ex);
+    experimental::CircularBuffer cb_ex2_obj(cb_ex2);
+    experimental::CircularBuffer cb_xmm2_obj(cb_xmm2);
+    experimental::CircularBuffer cb_ex2pe_obj(cb_ex2pe);
+    experimental::CircularBuffer cb_accumulate_obj(cb_accumulate);
+
 #ifdef FUSE_PRE_ADD
     binary_op_init_common(cb_in, cb_inb, cb_x);
 #else
@@ -76,7 +90,7 @@ void kernel_main() {
     // internal llk_math_wait_for_dest_available() spins forever (deadlock).
     binary_op_init_common(cb_in, cb_scaler, cb_ex);
 #endif
-    cb_wait_front(cb_eps, 1);     // comes from the reader
+    cb_eps_obj.wait_front(1);  // comes from the reader
 
     for (uint32_t ncht = 0; ncht < NCHt; ncht++) {
         constexpr int onetile = 1;
@@ -110,7 +124,7 @@ void kernel_main() {
             // the subsequent tile_regs_acquire() and the next tilize_block don't deadlock.
             binary_op_init_common(cb_in, cb_scaler, cb_ex);
 #endif
-            cb_wait_front(cb_in, block.full_block_size());
+            cb_in_obj.wait_front(block.full_block_size());
             tile_regs_acquire();
 #ifdef RMSNORM
             reconfig_data_format_srca(cb_in);
@@ -126,15 +140,15 @@ void kernel_main() {
                 sub_tiles_bcast_cols(cb_in, cb_ex, i, 0, i);
             }
 #endif
-            cb_pop_front(cb_in, block.full_block_size());
+            cb_in_obj.pop_front(block.full_block_size());
 #ifdef FUSE_PRE_ADD
-            cb_wait_front(cb_inb, block.full_block_size());
+            cb_inb_obj.wait_front(block.full_block_size());
             reconfig_data_format_srca(cb_in, cb_inb);
             binary_dest_reuse_tiles_init<ELWADD, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(cb_inb);
             for (auto i : block.local()) {
                 binary_dest_reuse_tiles<ELWADD, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(cb_inb, i, i);
             }
-            cb_pop_front(cb_inb, block.full_block_size());
+            cb_inb_obj.pop_front(block.full_block_size());
 #endif
             // (x-E[x])^2. Pack to CB
             square_tile_init();
@@ -143,23 +157,23 @@ void kernel_main() {
             }
             tile_regs_commit();
             tile_regs_wait();
-            cb_reserve_back(cb_xmm2, block.full_block_size());
+            cb_xmm2_obj.reserve_back(block.full_block_size());
             pack_reconfig_data_format(cb_xmm2);
             for (auto i : block.local()) {
                 pack_tile(i, cb_xmm2);
             }
             tile_regs_release();
-            cb_push_back(cb_xmm2, block.full_block_size());
+            cb_xmm2_obj.push_back(block.full_block_size());
 
             tile_regs_acquire();
             if (!block.is_first()) {
-                cb_wait_front(cb_accumulate, onetile);
+                cb_accumulate_obj.wait_front(onetile);
                 reconfig_data_format_srca(cb_accumulate);
                 copy_tile_init(cb_accumulate);
                 copy_tile(cb_accumulate, 0, dst0);
-                cb_pop_front(cb_accumulate, onetile);
+                cb_accumulate_obj.pop_front(onetile);
             }
-            cb_wait_front(cb_xmm2, block.full_block_size());
+            cb_xmm2_obj.wait_front(block.full_block_size());
 
             // Accumulate (x-E[x])^2
             reconfig_data_format(cb_xmm2, cb_scaler);
@@ -169,7 +183,7 @@ void kernel_main() {
                 reduce_tile<REDUCE_OP, REDUCE_DIM, FLOAT32_REDUCTION>(cb_xmm2, cb_scaler, i, scaler_tile_idx, dst0);
             }
 
-            cb_pop_front(cb_xmm2, block.full_block_size());
+            cb_xmm2_obj.pop_front(block.full_block_size());
 
             const auto final_iter = block.last() == Wt;
             const auto pack_cb = final_iter ? cb_ex2 : cb_accumulate;
@@ -183,11 +197,11 @@ void kernel_main() {
             tile_regs_commit();
             tile_regs_wait();
 
-            cb_reserve_back(pack_cb, onetile);
+            experimental::CircularBuffer(pack_cb).reserve_back(onetile);
             pack_reconfig_data_format(pack_cb);
             pack_tile(dst0, pack_cb);
             tile_regs_release();
-            cb_push_back(pack_cb, onetile);
+            experimental::CircularBuffer(pack_cb).push_back(onetile);
         }
 
         // End of
@@ -200,7 +214,7 @@ void kernel_main() {
         //                     1
         //  cb_ex2pe =   -------------
         //               √(Var(X) + ε)
-        cb_wait_front(cb_ex2, onetile);
+        cb_ex2_obj.wait_front(onetile);
         reconfig_data_format(cb_ex2, cb_eps);
         tile_regs_acquire();
 
@@ -215,24 +229,24 @@ void kernel_main() {
         pack_reconfig_data_format(cb_ex2pe);
         pack_tile(dst0, cb_ex2pe);
         tile_regs_release();
-        cb_push_back(cb_ex2pe, onetile);
-        cb_pop_front(cb_ex2, onetile);
+        cb_ex2pe_obj.push_back(onetile);
+        cb_ex2_obj.pop_front(onetile);
 
         // broadcasts the tile since cb_ex2pe is a column vector that contains the important data
-        cb_wait_front(cb_ex2pe, onetile);
+        cb_ex2pe_obj.wait_front(onetile);
         tile_regs_acquire();
         reconfig_data_format_srca(cb_ex2pe);
 
         unary_bcast_init<BroadcastType::COL>(cb_ex2pe, cb_ex2pe);
         unary_bcast<BroadcastType::COL>(cb_ex2pe, 0, dst0);
-        cb_pop_front(cb_ex2pe, onetile);
+        cb_ex2pe_obj.pop_front(onetile);
 
         tile_regs_commit();
         tile_regs_wait();
         pack_tile(dst0, cb_ex2pe);
         tile_regs_release();
-        cb_push_back(cb_ex2pe, onetile);
-        cb_wait_front(cb_ex2pe, onetile);
+        cb_ex2pe_obj.push_back(onetile);
+        cb_ex2pe_obj.wait_front(onetile);
 
         // End of
         // Calculation
@@ -254,7 +268,7 @@ void kernel_main() {
             binary_op_init_common(cb_in, cb_scaler, cb_ex);
 #endif
             tile_regs_acquire();
-            cb_wait_front(cb_in, block.full_block_size());
+            cb_in_obj.wait_front(block.full_block_size());
 #ifdef RMSNORM
             reconfig_data_format_srca(cb_in);
             copy_tile_init(cb_in);
@@ -262,7 +276,7 @@ void kernel_main() {
                 copy_tile(cb_in, i, i);
             }
 #else
-            cb_wait_front(cb_ex, 1);
+            cb_ex_obj.wait_front(1);
             reconfig_data_format(cb_in, cb_ex);
             sub_bcast_cols_init_short(cb_in, cb_ex);
             // x-E[x]
@@ -270,15 +284,15 @@ void kernel_main() {
                 sub_tiles_bcast_cols(cb_in, cb_ex, i, 0, i);
             }
 #endif
-            cb_pop_front(cb_in, block.full_block_size());
+            cb_in_obj.pop_front(block.full_block_size());
 #ifdef FUSE_PRE_ADD
-            cb_wait_front(cb_inb, block.full_block_size());
+            cb_inb_obj.wait_front(block.full_block_size());
             reconfig_data_format_srca(cb_inb);
             binary_dest_reuse_tiles_init<ELWADD, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(cb_inb);
             for (auto i : block.local()) {
                 binary_dest_reuse_tiles<ELWADD, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(cb_inb, i, i);
             }
-            cb_pop_front(cb_inb, block.full_block_size());
+            cb_inb_obj.pop_front(block.full_block_size());
 #endif
             tile_regs_commit();
             tile_regs_wait();
@@ -287,15 +301,15 @@ void kernel_main() {
             // do a binary dest with reuse (as we used
             // to). However, tt-llk #868 is preventing
             // that from working at the moment.
-            cb_reserve_back(cb_xmm, block.full_block_size());
+            cb_xmm_obj.reserve_back(block.full_block_size());
             pack_reconfig_data_format(cb_xmm);
             for (auto i : block.local()) {
                 pack_tile(i, cb_xmm);
             }
-            cb_push_back(cb_xmm, block.full_block_size());
+            cb_xmm_obj.push_back(block.full_block_size());
             tile_regs_release();
 
-            cb_wait_front(cb_xmm, block.full_block_size());
+            cb_xmm_obj.wait_front(block.full_block_size());
             reconfig_data_format(cb_xmm, cb_ex2pe);
             tile_regs_acquire();
 
@@ -318,14 +332,14 @@ void kernel_main() {
             if constexpr (!(do_gamma == 1 or do_beta == 1)) {
                 cb_fusion = cb_out;
             }
-            cb_reserve_back(cb_fusion, block.full_block_size());
+            experimental::CircularBuffer(cb_fusion).reserve_back(block.full_block_size());
             pack_reconfig_data_format(cb_fusion);
             for (auto i : block.local()) {
                 pack_tile(i, cb_fusion);
             }
             tile_regs_release();
-            cb_push_back(cb_fusion, block.full_block_size());
-            cb_pop_front(cb_xmm, block.full_block_size());
+            experimental::CircularBuffer(cb_fusion).push_back(block.full_block_size());
+            cb_xmm_obj.pop_front(block.full_block_size());
 
             if constexpr (do_gamma == 1) {
                 tile_regs_acquire();
@@ -334,8 +348,8 @@ void kernel_main() {
                 if constexpr (!do_beta) {
                     pack_reconfig_data_format(cb_out);
                 }
-                cb_wait_front(cb_gamma, block.full_block_size());
-                cb_wait_front(cb_fusion, block.full_block_size());
+                cb_gamma_obj.wait_front(block.full_block_size());
+                experimental::CircularBuffer(cb_fusion).wait_front(block.full_block_size());
                 mul_bcast_rows_init_short(cb_fusion, cb_gamma);
                 for (auto i : block.local()) {
                     mul_tiles_bcast_rows(cb_fusion, cb_gamma, i, i, i);
@@ -350,20 +364,20 @@ void kernel_main() {
 #endif
                 }
                 tile_regs_commit();
-                cb_pop_front(cb_gamma, block.full_block_size());
-                cb_pop_front(cb_fusion, block.full_block_size());
+                cb_gamma_obj.pop_front(block.full_block_size());
+                experimental::CircularBuffer(cb_fusion).pop_front(block.full_block_size());
                 if constexpr (!do_beta) {
-                    cb_reserve_back(cb_out, block.full_block_size());
+                    cb_out_obj.reserve_back(block.full_block_size());
                     for (auto i : block.local()) {
                         pack_tile(i, cb_out);
                     }
-                    cb_push_back(cb_out, block.full_block_size());
+                    cb_out_obj.push_back(block.full_block_size());
                 } else {
-                    cb_reserve_back(cb_fusion, block.full_block_size());
+                    experimental::CircularBuffer(cb_fusion).reserve_back(block.full_block_size());
                     for (auto i : block.local()) {
                         pack_tile(i, cb_fusion);
                     }
-                    cb_push_back(cb_fusion, block.full_block_size());
+                    experimental::CircularBuffer(cb_fusion).push_back(block.full_block_size());
                 }
 
                 tile_regs_release();
@@ -373,8 +387,8 @@ void kernel_main() {
                 tile_regs_wait();
                 reconfig_data_format(cb_fusion, cb_beta);
                 pack_reconfig_data_format(cb_out);
-                cb_wait_front(cb_beta, block.full_block_size());
-                cb_wait_front(cb_fusion, block.full_block_size());
+                cb_beta_obj.wait_front(block.full_block_size());
+                experimental::CircularBuffer(cb_fusion).wait_front(block.full_block_size());
                 add_bcast_rows_init_short(cb_fusion, cb_beta);
                 for (auto i : block.local()) {
                     add_tiles_bcast_rows(cb_fusion, cb_beta, i, i, i);
@@ -384,14 +398,14 @@ void kernel_main() {
 #endif
                 }
                 tile_regs_commit();
-                cb_pop_front(cb_beta, block.full_block_size());
-                cb_pop_front(cb_fusion, block.full_block_size());
-                cb_reserve_back(cb_out, block.full_block_size());
+                cb_beta_obj.pop_front(block.full_block_size());
+                experimental::CircularBuffer(cb_fusion).pop_front(block.full_block_size());
+                cb_out_obj.reserve_back(block.full_block_size());
                 for (auto i : block.local()) {
                     pack_tile(i, cb_out);
                 }
                 tile_regs_release();
-                cb_push_back(cb_out, block.full_block_size());
+                cb_out_obj.push_back(block.full_block_size());
             }
 
 #ifdef UNTILIZE_OUT
@@ -405,8 +419,8 @@ void kernel_main() {
         //(---------------*𝛄)+ß
         //  √(Var(X)+ε)
 #ifndef RMSNORM
-        cb_pop_front(cb_ex, onetile);
+        cb_ex_obj.pop_front(onetile);
 #endif
-        cb_pop_front(cb_ex2pe, onetile);
+        cb_ex2pe_obj.pop_front(onetile);
     }  // NCHt loop
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_large_tensor_welford.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_large_tensor_welford.cpp
@@ -18,6 +18,7 @@
 #include "api/compute/transpose_wh.h"
 #include "ttnn/operations/normalization/kernel_util/compute/memory.h"
 #include "ttnn/operations/normalization/kernel_util/generic/blocked_range.h"
+#include "experimental/circular_buffer.h"
 
 namespace generic = norm::kernel_util::generic;
 
@@ -35,6 +36,12 @@ template <
     uint32_t W,
     uint32_t blk>
 void welford_fuse_pre_add(const std::array<uint32_t, W>& reciprocal_lut) {
+    experimental::CircularBuffer cb_in_obj(cb_in);
+    experimental::CircularBuffer cb_inb_obj(cb_inb);
+    experimental::CircularBuffer cb_interm_pre_add_obj(cb_interm_pre_add);
+    experimental::CircularBuffer cb_ex_obj(cb_ex);
+    experimental::CircularBuffer cb_ex2_obj(cb_ex2);
+
     // The number of valid rows in the last tile in width dimension
     constexpr uint32_t last_tile_rows = W % tile_width;
     constexpr bool is_last_tile_full = (last_tile_rows == 0);
@@ -46,45 +53,45 @@ void welford_fuse_pre_add(const std::array<uint32_t, W>& reciprocal_lut) {
     welford_save_state(mean_dst);
     tile_regs_commit();
 
-    cb_reserve_back(cb_ex, 1);
-    cb_reserve_back(cb_ex2, 1);
+    cb_ex_obj.reserve_back(1);
+    cb_ex2_obj.reserve_back(1);
     tile_regs_wait();
     pack_reconfig_data_format(cb_ex);
     pack_tile(mean_dst, cb_ex);
     pack_tile(var_dst, cb_ex2);
     tile_regs_release();
-    cb_push_back(cb_ex, 1);
-    cb_push_back(cb_ex2, 1);
+    cb_ex_obj.push_back(1);
+    cb_ex2_obj.push_back(1);
 
     for (auto block : generic::blocks(Wt, blk)) {
         // Fused pre-add
         reconfig_data_format(cb_in, cb_inb);
         add_tiles_init(cb_in, cb_inb);
-        cb_wait_front(cb_in, block.full_block_size());
-        cb_wait_front(cb_inb, block.full_block_size());
+        cb_in_obj.wait_front(block.full_block_size());
+        cb_inb_obj.wait_front(block.full_block_size());
         tile_regs_acquire();
         for (auto i : block.local()) {
             add_tiles(cb_in, cb_inb, i, i, i);
         }
         tile_regs_commit();
-        cb_pop_front(cb_in, block.full_block_size());
-        cb_pop_front(cb_inb, block.full_block_size());
+        cb_in_obj.pop_front(block.full_block_size());
+        cb_inb_obj.pop_front(block.full_block_size());
 
         // Pack to intermediate CB (needed
         // to workaround transpose_wh_dest bug)
         pack_reconfig_data_format(cb_interm_pre_add);
-        cb_reserve_back(cb_interm_pre_add, block.full_block_size());
+        cb_interm_pre_add_obj.reserve_back(block.full_block_size());
         tile_regs_wait();
         for (auto i : block.local()) {
             pack_tile(i, cb_interm_pre_add);
         }
         tile_regs_release();
-        cb_push_back(cb_interm_pre_add, block.full_block_size());
+        cb_interm_pre_add_obj.push_back(block.full_block_size());
 
         // Now run Welfords in these blk number of tiles
-        cb_wait_front(cb_interm_pre_add, block.full_block_size());
-        cb_wait_front(cb_ex, 1);
-        cb_wait_front(cb_ex2, 1);
+        cb_interm_pre_add_obj.wait_front(block.full_block_size());
+        cb_ex_obj.wait_front(1);
+        cb_ex2_obj.wait_front(1);
         tile_regs_acquire();
         reconfig_data_format_srca(cb_in, cb_ex);
         copy_tile_init(cb_ex);
@@ -115,23 +122,23 @@ void welford_fuse_pre_add(const std::array<uint32_t, W>& reciprocal_lut) {
         }
         welford_save_state(mean_dst);
         tile_regs_commit();
-        cb_pop_front(cb_interm_pre_add, block.full_block_size());
-        cb_pop_front(cb_ex, 1);
-        cb_pop_front(cb_ex2, 1);
+        cb_interm_pre_add_obj.pop_front(block.full_block_size());
+        cb_ex_obj.pop_front(1);
+        cb_ex2_obj.pop_front(1);
 
-        cb_reserve_back(cb_ex, 1);
-        cb_reserve_back(cb_ex2, 1);
+        cb_ex_obj.reserve_back(1);
+        cb_ex2_obj.reserve_back(1);
         tile_regs_wait();
         pack_reconfig_data_format(cb_interm_pre_add, cb_ex);
         pack_tile(mean_dst, cb_ex);
         pack_tile(var_dst, cb_ex2);
         tile_regs_release();
-        cb_push_back(cb_ex, 1);
-        cb_push_back(cb_ex2, 1);
+        cb_ex_obj.push_back(1);
+        cb_ex2_obj.push_back(1);
     }
 
-    cb_wait_front(cb_ex, 1);
-    cb_wait_front(cb_ex2, 1);
+    cb_ex_obj.wait_front(1);
+    cb_ex2_obj.wait_front(1);
     tile_regs_acquire();
     copy_tile_init(cb_ex);
     copy_tile(cb_ex, 0, mean_dst);
@@ -141,8 +148,8 @@ void welford_fuse_pre_add(const std::array<uint32_t, W>& reciprocal_lut) {
     // Store the mean and variance to the destination registers
     welford_finalize_to_row<W>(mean_dst, W - 1, reciprocal_lut);
     tile_regs_commit();
-    cb_pop_front(cb_ex, 1);
-    cb_pop_front(cb_ex2, 1);
+    cb_ex_obj.pop_front(1);
+    cb_ex2_obj.pop_front(1);
 }
 
 /* @brief: Welford's algorithm for no fused pre-add
@@ -163,6 +170,8 @@ template <
     uint32_t W,
     uint32_t blk>
 void welford_no_fuse_pre_add(const std::array<uint32_t, W>& reciprocal_lut) {
+    experimental::CircularBuffer cb_in_obj(cb_in);
+
     // The number of valid rows in the last tile in width dimension
     constexpr uint32_t last_tile_rows = W % tile_width;
     constexpr bool is_last_tile_full = (last_tile_rows == 0);
@@ -175,13 +184,13 @@ void welford_no_fuse_pre_add(const std::array<uint32_t, W>& reciprocal_lut) {
 
     // Process all but the last tile
     for (uint32_t wt = 0; wt < (Wt - 1); ++wt) {
-        cb_wait_front(cb_in, 1);
+        cb_in_obj.wait_front(1);
         // Welford's needs transposed input tile
         transpose_wh_tile(cb_in, 0, input_dst);
         welford_update<W>(input_dst, sample_idx, reciprocal_lut);
 
         // Pop the input
-        cb_pop_front(cb_in, 1);
+        cb_in_obj.pop_front(1);
         sample_idx += tile_width;
     }
 
@@ -189,7 +198,7 @@ void welford_no_fuse_pre_add(const std::array<uint32_t, W>& reciprocal_lut) {
     // Reader is sending full blocks, so we need to stay in sync.
     // wait/pop the last tile + any remaining in the last block
     const auto num_to_sync = generic::blocks(Wt, blk).back().remainder() + 1;
-    cb_wait_front(cb_in, num_to_sync);
+    cb_in_obj.wait_front(num_to_sync);
     transpose_wh_tile(cb_in, 0, input_dst);
 
     if constexpr (is_last_tile_full) {
@@ -203,7 +212,7 @@ void welford_no_fuse_pre_add(const std::array<uint32_t, W>& reciprocal_lut) {
 
     tile_regs_commit();
 
-    cb_pop_front(cb_in, num_to_sync);
+    cb_in_obj.pop_front(num_to_sync);
 }
 
 void kernel_main() {
@@ -234,6 +243,16 @@ void kernel_main() {
     constexpr auto cb_interm_pre_add = tt::CBIndex::c_23;  // intermediate for fused pre-add
     constexpr auto cb_reciprocals = tt::CBIndex::c_25;     // Pre-computed reciprocals for Welford's algorithm
 
+    experimental::CircularBuffer cb_eps_obj(cb_eps);
+    experimental::CircularBuffer cb_in_obj(cb_in);
+    experimental::CircularBuffer cb_inb_obj(cb_inb);
+    experimental::CircularBuffer cb_out_obj(cb_out);
+    experimental::CircularBuffer cb_gamma_obj(cb_gamma);
+    experimental::CircularBuffer cb_beta_obj(cb_beta);
+    experimental::CircularBuffer cb_ex_obj(cb_ex);
+    experimental::CircularBuffer cb_ex2_obj(cb_ex2);
+    experimental::CircularBuffer cb_ex2pe_obj(cb_ex2pe);
+
     constexpr uint32_t onetile = 1;
 
     // Initialize the hardware based on the first op
@@ -247,7 +266,7 @@ void kernel_main() {
         unary_op_init_common(cb_in, first_out_cb);
     }
 
-    cb_wait_front(cb_eps, onetile);     // comes from the reader
+    cb_eps_obj.wait_front(onetile);  // comes from the reader
 
     constexpr uint32_t dst0 = 0;
     constexpr uint32_t input_dst = 0;  // Input tile for Welford's algorithm
@@ -281,40 +300,40 @@ void kernel_main() {
         // We should expect that either of the two would have have populated dst regs with mean and
         // variance in mean_dst and var_dst respectively.
 
-        cb_reserve_back(cb_ex, onetile);
-        cb_reserve_back(cb_ex2, onetile);
+        cb_ex_obj.reserve_back(onetile);
+        cb_ex2_obj.reserve_back(onetile);
         tile_regs_wait();
         pack_reconfig_data_format(cb_ex);
         pack_tile(mean_dst, cb_ex);
         pack_tile(var_dst, cb_ex2);
         tile_regs_release();
-        cb_push_back(cb_ex, onetile);
-        cb_push_back(cb_ex2, onetile);
+        cb_ex_obj.push_back(onetile);
+        cb_ex2_obj.push_back(onetile);
 
         // Transpose mean and variance back to
         // columns and pack back to CBs
         reconfig_data_format_srca(cb_ex);
         transpose_wh_init_short(cb_ex);
 
-        cb_wait_front(cb_ex, onetile);
-        cb_wait_front(cb_ex2, onetile);
+        cb_ex_obj.wait_front(onetile);
+        cb_ex2_obj.wait_front(onetile);
         tile_regs_acquire();
         transpose_wh_tile(cb_ex, 0, mean_dst);
         transpose_wh_tile(cb_ex2, 0, var_dst);
         tile_regs_commit();
-        cb_pop_front(cb_ex, onetile);
-        cb_pop_front(cb_ex2, onetile);
+        cb_ex_obj.pop_front(onetile);
+        cb_ex2_obj.pop_front(onetile);
 
-        cb_reserve_back(cb_ex, onetile);
-        cb_reserve_back(cb_ex2, onetile);
+        cb_ex_obj.reserve_back(onetile);
+        cb_ex2_obj.reserve_back(onetile);
         tile_regs_wait();
         pack_reconfig_data_format(cb_ex);
         pack_tile(mean_dst, cb_ex);
         pack_reconfig_data_format(cb_ex2);
         pack_tile(var_dst, cb_ex2);
         tile_regs_release();
-        cb_push_back(cb_ex, onetile);
-        cb_push_back(cb_ex2, onetile);
+        cb_ex_obj.push_back(onetile);
+        cb_ex2_obj.push_back(onetile);
 
         // =====================================
         // Calculate 1/(√(Var(X) + ε))
@@ -322,34 +341,34 @@ void kernel_main() {
         reconfig_data_format(cb_ex2, cb_eps);
         add_tiles_init(cb_ex2, cb_eps);
 
-        cb_wait_front(cb_ex2, onetile);
+        cb_ex2_obj.wait_front(onetile);
         tile_regs_acquire();
         add_tiles(cb_ex2, cb_eps, 0, 0, dst0);
         rsqrt_tile_init();
         rsqrt_tile(dst0);
         tile_regs_commit();
-        cb_pop_front(cb_ex2, onetile);
+        cb_ex2_obj.pop_front(onetile);
 
-        cb_reserve_back(cb_ex2pe, onetile);
+        cb_ex2pe_obj.reserve_back(onetile);
         tile_regs_wait();
         pack_tile(dst0, cb_ex2pe);
         tile_regs_release();
-        cb_push_back(cb_ex2pe, onetile);
+        cb_ex2pe_obj.push_back(onetile);
 
         // broadcasts the tile since cb_ex2pe is a column vector that contains the important data
-        cb_wait_front(cb_ex2pe, onetile);
+        cb_ex2pe_obj.wait_front(onetile);
         tile_regs_acquire();
         reconfig_data_format_srca(cb_ex2pe);
         unary_bcast_init<BroadcastType::COL>(cb_ex2pe, cb_ex2pe);
         unary_bcast<BroadcastType::COL>(cb_ex2pe, 0, dst0);
-        cb_pop_front(cb_ex2pe, onetile);
+        cb_ex2pe_obj.pop_front(onetile);
         tile_regs_commit();
 
-        cb_reserve_back(cb_ex2pe, onetile);
+        cb_ex2pe_obj.reserve_back(onetile);
         tile_regs_wait();
         pack_tile(dst0, cb_ex2pe);
         tile_regs_release();
-        cb_push_back(cb_ex2pe, onetile);
+        cb_ex2pe_obj.push_back(onetile);
 
         // =====================================
         // Second pass over the input.
@@ -358,14 +377,14 @@ void kernel_main() {
         //(---------------*𝛄)+ß
         //  √(Var(x)+ε)
         // =====================================
-        cb_wait_front(cb_ex2pe, onetile);
-        cb_wait_front(cb_ex, onetile);
+        cb_ex2pe_obj.wait_front(onetile);
+        cb_ex_obj.wait_front(onetile);
 
         for (auto block : generic::blocks(Wt, blk)) {
             // Last block may only be partially-filled,
             // and only tiles that have data in them are
             // processed, but need to sync with reader on full blocks
-            cb_wait_front(cb_in, block.full_block_size());
+            cb_in_obj.wait_front(block.full_block_size());
             tile_regs_acquire();
             reconfig_data_format(cb_in, cb_ex);
             sub_bcast_cols_init_short(cb_in, cb_ex);
@@ -373,17 +392,17 @@ void kernel_main() {
             for (auto i : block.local()) {
                 sub_tiles_bcast_cols(cb_in, cb_ex, i, 0, i);
             }
-            cb_pop_front(cb_in, block.full_block_size());
+            cb_in_obj.pop_front(block.full_block_size());
 
             if constexpr (fuse_pre_add) {
                 // Fuse in = in + b
                 reconfig_data_format_srca(cb_in, cb_inb);
                 binary_dest_reuse_tiles_init<ELWADD, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(cb_inb);
-                cb_wait_front(cb_inb, block.full_block_size());
+                cb_inb_obj.wait_front(block.full_block_size());
                 for (auto i : block.local()) {
                     binary_dest_reuse_tiles<ELWADD, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(cb_inb, i, i);
                 }
-                cb_pop_front(cb_inb, block.full_block_size());
+                cb_inb_obj.pop_front(block.full_block_size());
                 reconfig_data_format_srca(cb_inb, cb_ex2pe);
             }
 
@@ -401,44 +420,44 @@ void kernel_main() {
 
             pack_reconfig_data_format(cb_xmm);
             // Sync with writer on full blocks
-            cb_reserve_back(cb_xmm, block.full_block_size());
+            experimental::CircularBuffer(cb_xmm).reserve_back(block.full_block_size());
             tile_regs_wait();
             for (auto i : block.local()) {
                 pack_tile(i, cb_xmm);
             }
-            cb_push_back(cb_xmm, block.full_block_size());
+            experimental::CircularBuffer(cb_xmm).push_back(block.full_block_size());
             tile_regs_release();
 
             if constexpr (do_gamma == 1) {
                 // Multiply by gamma
                 reconfig_data_format(cb_xmm, cb_gamma);
                 tile_regs_acquire();
-                cb_wait_front(cb_gamma, block.full_block_size());
-                cb_wait_front(cb_xmm, block.full_block_size());
+                cb_gamma_obj.wait_front(block.full_block_size());
+                experimental::CircularBuffer(cb_xmm).wait_front(block.full_block_size());
                 mul_bcast_rows_init_short(cb_xmm, cb_gamma);
                 for (auto i : block.local()) {
                     mul_tiles_bcast_rows(cb_xmm, cb_gamma, i, i, i);
                 }
                 tile_regs_commit();
-                cb_pop_front(cb_gamma, block.full_block_size());
-                cb_pop_front(cb_xmm, block.full_block_size());
+                cb_gamma_obj.pop_front(block.full_block_size());
+                experimental::CircularBuffer(cb_xmm).pop_front(block.full_block_size());
 
                 if constexpr (!do_beta) {
                     pack_reconfig_data_format(cb_out);
                 }
                 tile_regs_wait();
                 if constexpr (!do_beta) {
-                    cb_reserve_back(cb_out, block.full_block_size());
+                    cb_out_obj.reserve_back(block.full_block_size());
                     for (auto i : block.local()) {
                         pack_tile(i, cb_out);
                     }
-                    cb_push_back(cb_out, block.full_block_size());
+                    cb_out_obj.push_back(block.full_block_size());
                 } else {
-                    cb_reserve_back(cb_xmm, block.full_block_size());
+                    experimental::CircularBuffer(cb_xmm).reserve_back(block.full_block_size());
                     for (auto i : block.local()) {
                         pack_tile(i, cb_xmm);
                     }
-                    cb_push_back(cb_xmm, block.full_block_size());
+                    experimental::CircularBuffer(cb_xmm).push_back(block.full_block_size());
                 }
                 tile_regs_release();
             }
@@ -448,28 +467,28 @@ void kernel_main() {
                 tile_regs_acquire();
                 reconfig_data_format(cb_xmm, cb_beta);
                 add_bcast_rows_init_short(cb_xmm, cb_beta);
-                cb_wait_front(cb_xmm, block.full_block_size());
-                cb_wait_front(cb_beta, block.full_block_size());
+                experimental::CircularBuffer(cb_xmm).wait_front(block.full_block_size());
+                cb_beta_obj.wait_front(block.full_block_size());
                 for (auto i : block.local()) {
                     add_tiles_bcast_rows(cb_xmm, cb_beta, i, i, i);
                 }
                 tile_regs_commit();
-                cb_pop_front(cb_beta, block.full_block_size());
-                cb_pop_front(cb_xmm, block.full_block_size());
+                cb_beta_obj.pop_front(block.full_block_size());
+                experimental::CircularBuffer(cb_xmm).pop_front(block.full_block_size());
 
                 pack_reconfig_data_format(cb_out);
-                cb_reserve_back(cb_out, block.full_block_size());
+                cb_out_obj.reserve_back(block.full_block_size());
                 tile_regs_wait();
                 for (auto i : block.local()) {
                     pack_tile(i, cb_out);
                 }
                 tile_regs_release();
-                cb_push_back(cb_out, block.full_block_size());
+                cb_out_obj.push_back(block.full_block_size());
             }
         }
 
         cb_xmm = tt::CBIndex::c_24;  // x minus mean
-        cb_pop_front(cb_ex2pe, onetile);
-        cb_pop_front(cb_ex, onetile);
+        cb_ex2pe_obj.pop_front(onetile);
+        cb_ex_obj.pop_front(onetile);
     }  // NCHt loop
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded.cpp
@@ -14,6 +14,7 @@
 #include "api/compute/layernorm.h"
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/eltwise_unary/sfpu_split_includes.h"
+#include "experimental/circular_buffer.h"
 
 // SPLIT REDUCE across Cores
 void kernel_main() {
@@ -83,6 +84,23 @@ void kernel_main() {
     constexpr uint32_t cb_fusion = tt::CBIndex::c_18;     // stream gamma/beta
     constexpr uint32_t cb_out = tt::CBIndex::c_16;
 
+    experimental::CircularBuffer cb_scaler_obj(cb_scaler);
+    experimental::CircularBuffer cb_scaler_global_obj(cb_scaler_global);
+    experimental::CircularBuffer cb_gamma_obj(cb_gamma);
+    experimental::CircularBuffer cb_beta_obj(cb_beta);
+    experimental::CircularBuffer cb_xmm_obj(cb_xmm);
+    experimental::CircularBuffer cb_ex_partial_obj(cb_ex_partial);
+    experimental::CircularBuffer cb_ex_obj(cb_ex);
+    experimental::CircularBuffer cb_ex_external_obj(cb_ex_external);
+    experimental::CircularBuffer cb_ex_partial2_obj(cb_ex_partial2);
+    experimental::CircularBuffer cb_ex2_obj(cb_ex2);
+    experimental::CircularBuffer cb_ex_external2_obj(cb_ex_external2);
+    experimental::CircularBuffer cb_ex_global_obj(cb_ex_global);
+    experimental::CircularBuffer cb_xmm2_obj(cb_xmm2);
+    experimental::CircularBuffer cb_ex2pe_obj(cb_ex2pe);
+    experimental::CircularBuffer cb_fusion_obj(cb_fusion);
+    experimental::CircularBuffer cb_out_obj(cb_out);
+
     binary_op_init_common(cb_in0, cb_in0, cb_x);
 
     // set block_h to volatile to disable automatically unroll of the loops, avoid code overflow
@@ -102,14 +120,17 @@ void kernel_main() {
 #else
     constexpr uint32_t cb_in = cb_in0;
 #endif
+    experimental::CircularBuffer cb_in_obj(cb_in);
     constexpr uint32_t cb_im = do_gamma ? cb_x : (do_beta ? cb_fusion : cb_out);
+    experimental::CircularBuffer cb_im_obj(cb_im);
     constexpr uint32_t cb_outgamma = do_beta ? cb_fusion : cb_out;
+    experimental::CircularBuffer cb_outgamma_obj(cb_outgamma);
 
 // pre-add x + y
 #ifdef FUSE_PRE_ADD
     reconfig_data_format_srcb(cb_in0, cb_in1);
     add_tiles_init(cb_in0, cb_in1);
-    cb_reserve_back(cb_in, num_tiles_per_block);
+    cb_in_obj.reserve_back(num_tiles_per_block);
     for (uint32_t i = 0; i < block_h; i++) {
         index_subblock_w_offset = 0;
         for (uint32_t j = 0; j < num_subblocks_w; j++) {
@@ -128,13 +149,13 @@ void kernel_main() {
         }
         index_h_offset += block_w;
     }
-    cb_push_back(cb_in, num_tiles_per_block);
+    cb_in_obj.push_back(num_tiles_per_block);
 #ifndef RMSNORM
     reconfig_data_format(cb_in0, cb_in, cb_in1, cb_scaler);
 #else
     reconfig_data_format(cb_in0, cb_in, cb_in1, cb_in);
 #endif
-    cb_wait_front(cb_in, num_tiles_per_block);
+    cb_in_obj.wait_front(num_tiles_per_block);
 #else
 #ifndef RMSNORM
     reconfig_data_format_srcb(cb_in0, cb_scaler);
@@ -145,8 +166,8 @@ void kernel_main() {
     // E[x],
     index_h_offset = 0;
     reduce_init<REDUCE_OP, REDUCE_DIM, FLOAT32_REDUCTION>(cb_in, cb_scaler, cb_ex_partial);
-    cb_wait_front(cb_scaler, 1);
-    cb_reserve_back(cb_ex_partial, block_h);
+    cb_scaler_obj.wait_front(1);
+    cb_ex_partial_obj.reserve_back(block_h);
     for (uint32_t i = 0; i < block_h; i++) {
         tile_regs_acquire();
         for (uint32_t w = 0; w < num_reduce_tiles_per_block_h; w++) {
@@ -159,27 +180,27 @@ void kernel_main() {
         index_h_offset += block_w;
     }
     reduce_uninit();
-    cb_push_back(cb_ex_partial, block_h);
+    cb_ex_partial_obj.push_back(block_h);
 
     reconfig_data_format_srca(cb_in, cb_ex_external);
 
     // global reduce, cb_ex <-- cb_ex_external, cb_ex_partial
     if constexpr (is_allgather_worker) {
         reduce_init<REDUCE_OP, REDUCE_DIM, FLOAT32_REDUCTION>(cb_ex_external, cb_scaler_global, cb_ex);
-        cb_reserve_back(cb_ex, num_tiles_per_allgather_worker);
+        cb_ex_obj.reserve_back(num_tiles_per_allgather_worker);
 
         for (uint32_t i = 0; i < num_tiles_per_allgather_worker; i++) {
-            cb_wait_front(cb_scaler_global, 1);
+            cb_scaler_global_obj.wait_front(1);
             tile_regs_acquire();
             for (uint32_t w = 0; w < num_blocks_reduce; w++) {
-                cb_wait_front(cb_ex_external, 1);
+                cb_ex_external_obj.wait_front(1);
                 reduce_tile<REDUCE_OP, REDUCE_DIM, FLOAT32_REDUCTION>(
                     cb_ex_external, cb_scaler_global, 0, scaler0, dst0);
-                cb_pop_front(cb_ex_external, 1);
+                cb_ex_external_obj.pop_front(1);
             }
             if (use_two_stage_reduce && !is_second_stage_reader) {
-                cb_wait_front(cb_ex_external, num_blocks_second_stage - 1);
-                cb_pop_front(cb_ex_external, num_blocks_second_stage - 1);
+                cb_ex_external_obj.wait_front(num_blocks_second_stage - 1);
+                cb_ex_external_obj.pop_front(num_blocks_second_stage - 1);
             }
             tile_regs_commit();
             tile_regs_wait();
@@ -187,8 +208,8 @@ void kernel_main() {
             tile_regs_release();
         }
         reduce_uninit();
-        cb_push_back(cb_ex, num_tiles_per_allgather_worker);
-        cb_wait_front(cb_ex, num_tiles_per_allgather_worker);
+        cb_ex_obj.push_back(num_tiles_per_allgather_worker);
+        cb_ex_obj.wait_front(num_tiles_per_allgather_worker);
     }
 
     // x - E[x]
@@ -198,10 +219,10 @@ void kernel_main() {
     index_h_offset = 0;
     reconfig_data_format_srca(cb_ex_external, cb_in);
     sub_bcast_cols_init_short(cb_in, cb_ex_global);
-    cb_reserve_back(cb_xmm, num_tiles_per_block);
+    cb_xmm_obj.reserve_back(num_tiles_per_block);
     for (uint32_t i = 0; i < block_h; i++) {
         index_subblock_w_offset = 0;
-        cb_wait_front(cb_ex_global, 1);
+        cb_ex_global_obj.wait_front(1);
         for (uint32_t j = 0; j < num_subblocks_w; j++) {
             tile_regs_acquire();
             for (uint32_t w = 0; w < subblock_w; w++) {
@@ -216,20 +237,20 @@ void kernel_main() {
             tile_regs_release();
             index_subblock_w_offset += subblock_w;
         }
-        cb_pop_front(cb_ex_global, 1);
-        cb_pop_front(cb_in, block_w);
+        cb_ex_global_obj.pop_front(1);
+        cb_in_obj.pop_front(block_w);
     }
-    cb_push_back(cb_xmm, num_tiles_per_block);
+    cb_xmm_obj.push_back(num_tiles_per_block);
 #ifndef FUSE_PRE_ADD
     reconfig_data_format_srca(cb_in, cb_xmm);
 #endif
-    cb_wait_front(cb_xmm, num_tiles_per_block);
+    cb_xmm_obj.wait_front(num_tiles_per_block);
 #endif
 
     // (x - E[x])^2, cb_mm2 <-- cb_xmm
     mul_tiles_init(cb_xmm, cb_xmm);
     index_h_offset = 0;
-    cb_reserve_back(cb_xmm2, num_tiles_per_block);
+    cb_xmm2_obj.reserve_back(num_tiles_per_block);
     for (uint32_t i = 0; i < block_h; i++) {
         index_subblock_w_offset = 0;
         for (uint32_t j = 0; j < num_subblocks_w; j++) {
@@ -248,7 +269,7 @@ void kernel_main() {
         }
         index_h_offset += block_w;
     }
-    cb_push_back(cb_xmm2, num_tiles_per_block);
+    cb_xmm2_obj.push_back(num_tiles_per_block);
 
 #if defined RMSNORM and not defined FUSED_PRE_ADD
     reconfig_data_format(cb_xmm, cb_xmm2, cb_xmm, cb_scaler);
@@ -258,13 +279,13 @@ void kernel_main() {
     }
 #endif
 
-    cb_wait_front(cb_xmm2, num_tiles_per_block);
+    cb_xmm2_obj.wait_front(num_tiles_per_block);
 
 // Var(x)
 #ifdef RMSNORM
-    cb_wait_front(cb_scaler, 1);
+    cb_scaler_obj.wait_front(1);
 #endif
-    cb_reserve_back(cb_ex_partial2, block_h);
+    cb_ex_partial2_obj.reserve_back(block_h);
     reduce_init<REDUCE_OP, REDUCE_DIM, FLOAT32_REDUCTION>(cb_xmm2, cb_scaler, cb_ex_partial2);
     index_h_offset = 0;
     for (uint32_t i = 0; i < block_h; i++) {
@@ -280,27 +301,27 @@ void kernel_main() {
         index_h_offset += block_w;
     }
     reduce_uninit();
-    cb_pop_front(cb_xmm2, num_tiles_per_block);
-    cb_push_back(cb_ex_partial2, block_h);
+    cb_xmm2_obj.pop_front(num_tiles_per_block);
+    cb_ex_partial2_obj.push_back(block_h);
 
     // global reduce, cb_ex <-- cb_ex_external, cb_ex_partial
     if constexpr (is_allgather_worker) {
         reduce_init<REDUCE_OP, REDUCE_DIM, FLOAT32_REDUCTION>(cb_ex_external2, cb_scaler_global, cb_ex2);
-        cb_reserve_back(cb_ex2, num_tiles_per_allgather_worker);
+        cb_ex2_obj.reserve_back(num_tiles_per_allgather_worker);
 
         for (uint32_t i = 0; i < num_tiles_per_allgather_worker; i++) {
-            cb_wait_front(cb_scaler_global, 1);
+            cb_scaler_global_obj.wait_front(1);
 
             tile_regs_acquire();
             for (uint32_t w = 0; w < num_blocks_reduce; w++) {
-                cb_wait_front(cb_ex_external2, 1);
+                cb_ex_external2_obj.wait_front(1);
                 reduce_tile<REDUCE_OP, REDUCE_DIM, FLOAT32_REDUCTION>(
                     cb_ex_external2, cb_scaler_global, 0, scaler0, dst0);
-                cb_pop_front(cb_ex_external2, 1);
+                cb_ex_external2_obj.pop_front(1);
             }
             if (use_two_stage_reduce && !is_second_stage_reader) {
-                cb_wait_front(cb_ex_external2, num_blocks_second_stage - 1);
-                cb_pop_front(cb_ex_external2, num_blocks_second_stage - 1);
+                cb_ex_external2_obj.wait_front(num_blocks_second_stage - 1);
+                cb_ex_external2_obj.pop_front(num_blocks_second_stage - 1);
             }
             tile_regs_commit();
             tile_regs_wait();
@@ -308,13 +329,13 @@ void kernel_main() {
             tile_regs_release();
         }
         reduce_uninit();
-        cb_push_back(cb_ex2, num_tiles_per_allgather_worker);
+        cb_ex2_obj.push_back(num_tiles_per_allgather_worker);
 
         if (enable_sqrt) {
             for (uint32_t i = 0; i < num_tiles_per_allgather_worker; i++) {
                 // 1/[sqrt(Var + eps)],
-                cb_wait_front(cb_ex2, 1);
-                cb_reserve_back(cb_ex2pe, 1);
+                cb_ex2_obj.wait_front(1);
+                cb_ex2pe_obj.reserve_back(1);
                 tile_regs_acquire();
                 add_tiles_init(cb_ex2, cb_eps);
                 add_tiles(cb_ex2, cb_eps, i, 0, dst0);
@@ -324,7 +345,7 @@ void kernel_main() {
                 tile_regs_commit();
                 tile_regs_wait();
                 pack_tile(dst0, cb_ex2pe);
-                cb_push_back(cb_ex2pe, 1);
+                cb_ex2pe_obj.push_back(1);
                 tile_regs_release();
             }
         }
@@ -347,10 +368,10 @@ void kernel_main() {
 #endif
     mul_bcast_cols_init_short(cb_xmm, cb_ex_global);
     index_h_offset = 0;
-    cb_reserve_back(cb_im, num_tiles_per_block);
+    cb_im_obj.reserve_back(num_tiles_per_block);
     for (uint32_t i = 0; i < block_h; i++) {
         index_subblock_w_offset = 0;
-        cb_wait_front(cb_ex_global, 1);
+        cb_ex_global_obj.wait_front(1);
         for (uint32_t j = 0; j < num_subblocks_w; j++) {
             tile_regs_acquire();
             for (uint32_t w = 0; w < subblock_w; w++) {
@@ -378,12 +399,12 @@ void kernel_main() {
             index_subblock_w_offset += subblock_w;
         }
         index_h_offset += block_w;
-        cb_pop_front(cb_ex_global, 1);
+        cb_ex_global_obj.pop_front(1);
     }
-    cb_push_back(cb_im, num_tiles_per_block);
+    cb_im_obj.push_back(num_tiles_per_block);
 
-    cb_pop_front(cb_xmm, num_tiles_per_block);
-    cb_wait_front(cb_im, num_tiles_per_block);
+    cb_xmm_obj.pop_front(num_tiles_per_block);
+    cb_im_obj.wait_front(num_tiles_per_block);
 
     if constexpr (do_gamma) {
         reconfig_data_format(cb_im, cb_gamma);
@@ -391,9 +412,9 @@ void kernel_main() {
             pack_reconfig_data_format(cb_out);
         }
         mul_bcast_rows_init_short(cb_im, cb_gamma);
-        cb_wait_front(cb_gamma, block_w);
+        cb_gamma_obj.wait_front(block_w);
         index_h_offset = 0;
-        cb_reserve_back(cb_outgamma, num_tiles_per_block);
+        cb_outgamma_obj.reserve_back(num_tiles_per_block);
         for (uint32_t i = 0; i < block_h; i++) {
             index_subblock_w_offset = 0;
             for (uint32_t j = 0; j < num_subblocks_w; j++) {
@@ -421,18 +442,18 @@ void kernel_main() {
             }
             index_h_offset += block_w;
         }
-        cb_push_back(cb_outgamma, num_tiles_per_block);
-        cb_pop_front(cb_im, num_tiles_per_block);
-        cb_wait_front(cb_outgamma, num_tiles_per_block);
+        cb_outgamma_obj.push_back(num_tiles_per_block);
+        cb_im_obj.pop_front(num_tiles_per_block);
+        cb_outgamma_obj.wait_front(num_tiles_per_block);
     }
 
     if constexpr (do_beta) {
         reconfig_data_format(cb_fusion, cb_beta);
         pack_reconfig_data_format(cb_out);
         add_bcast_rows_init_short(cb_fusion, cb_beta);
-        cb_wait_front(cb_beta, block_w);
+        cb_beta_obj.wait_front(block_w);
         index_h_offset = 0;
-        cb_reserve_back(cb_out, num_tiles_per_block);
+        cb_out_obj.reserve_back(num_tiles_per_block);
         for (uint32_t i = 0; i < block_h; i++) {
             index_subblock_w_offset = 0;
             for (uint32_t j = 0; j < num_subblocks_w; j++) {
@@ -455,8 +476,8 @@ void kernel_main() {
             }
             index_h_offset += block_w;
         }
-        cb_push_back(cb_out, num_tiles_per_block);
-        cb_pop_front(cb_fusion, num_tiles_per_block);
-        cb_wait_front(cb_out, num_tiles_per_block);
+        cb_out_obj.push_back(num_tiles_per_block);
+        cb_fusion_obj.pop_front(num_tiles_per_block);
+        cb_out_obj.wait_front(num_tiles_per_block);
     }
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_post_allgather.cpp
@@ -13,6 +13,7 @@
 #include "api/compute/eltwise_binary.h"
 #include "api/compute/layernorm.h"
 #include "api/compute/tile_move_copy.h"
+#include "experimental/circular_buffer.h"
 
 // SPLIT REDUCE across Cores
 void kernel_main() {
@@ -77,6 +78,20 @@ void kernel_main() {
     constexpr uint32_t cb_var = tt::CBIndex::c_19;
     constexpr uint32_t cb_ex_sqr = tt::CBIndex::c_24;  // E[x]^2
 
+    experimental::CircularBuffer cb_in0_obj(cb_in0);
+    experimental::CircularBuffer cb_eps_obj(cb_eps);
+    experimental::CircularBuffer cb_scaler_global_obj(cb_scaler_global);
+    experimental::CircularBuffer cb_gamma_obj(cb_gamma);
+    experimental::CircularBuffer cb_beta_obj(cb_beta);
+    experimental::CircularBuffer cb_ex2_obj(cb_ex2);
+    experimental::CircularBuffer cb_stats_obj(cb_stats);
+    experimental::CircularBuffer cb_stats_reduced_obj(cb_stats_reduced);
+    experimental::CircularBuffer cb_ex_global_obj(cb_ex_global);
+    experimental::CircularBuffer cb_fusion_obj(cb_fusion);
+    experimental::CircularBuffer cb_out_obj(cb_out);
+    experimental::CircularBuffer cb_var_obj(cb_var);
+    experimental::CircularBuffer cb_ex_sqr_obj(cb_ex_sqr);
+
 #ifdef RMSNORM
     binary_op_init_common(cb_stats, cb_scaler_global, cb_var);
     constexpr uint32_t stats_tiles = 1;
@@ -86,6 +101,7 @@ void kernel_main() {
     constexpr uint32_t stats_tiles = 2;
     constexpr uint32_t cb_xmm = tt::CBIndex::c_18;  // x minus mean
 #endif
+    experimental::CircularBuffer cb_xmm_obj(cb_xmm);
 
     // set block_h to volatile to disable automatically unroll of the loops, avoid code overflow
     const uint32_t block_h = (block_w == 1) ? block_h_volatile : block_h_const;
@@ -96,19 +112,21 @@ void kernel_main() {
     int index = 0;
 
     constexpr uint32_t cb_im = (do_gamma | do_beta) ? cb_ex_sqr : cb_out;
+    experimental::CircularBuffer cb_im_obj(cb_im);
     constexpr uint32_t cb_outgamma = do_beta ? cb_fusion : cb_out;
+    experimental::CircularBuffer cb_outgamma_obj(cb_outgamma);
 
     // global reduce, cb_ex <-- cb_ex_external, cb_ex_partial
     if constexpr (is_allgather_worker) {
         if (enable_sqrt) {
 #ifdef RMSNORM
-            cb_reserve_back(cb_var, 1);
+            cb_var_obj.reserve_back(1);
 #else
-            cb_reserve_back(cb_stats_reduced, 1);
-            cb_reserve_back(cb_ex2, 1);
+            cb_stats_reduced_obj.reserve_back(1);
+            cb_ex2_obj.reserve_back(1);
 #endif
 
-            cb_wait_front(cb_scaler_global, 1);
+            cb_scaler_global_obj.wait_front(1);
             reduce_init<REDUCE_OP, REDUCE_DIM, FLOAT32_REDUCTION>(cb_stats, cb_scaler_global, cb_var);
             tile_regs_acquire();
             // striding over cb_stats, consisting [E(X), E(X^2)] from all the distributed devices in interleaved order
@@ -119,7 +137,7 @@ void kernel_main() {
                     0,
                     scaler0,
                     w % stats_tiles);  // reducing E(x) and E(x^2) separately to different dst
-                cb_pop_front(cb_stats, 1);
+                cb_stats_obj.pop_front(1);
             }
             tile_regs_commit();
             tile_regs_wait();
@@ -133,52 +151,52 @@ void kernel_main() {
             tile_regs_release();
             reduce_uninit();
 #ifdef RMSNORM
-            cb_push_back(cb_var, stats_tiles);
+            cb_var_obj.push_back(stats_tiles);
 #else
-            cb_push_back(cb_stats_reduced, 1);
-            cb_push_back(cb_ex2, 1);
+            cb_stats_reduced_obj.push_back(1);
+            cb_ex2_obj.push_back(1);
 #endif
 
 #ifndef RMSNORM
             // calculate var = E(x^2) - E(x)^2
             // E(x)^2
             reconfig_data_format(cb_stats_reduced, cb_stats_reduced);
-            cb_reserve_back(cb_ex_sqr, 1);
-            cb_wait_front(cb_stats_reduced, 1);
+            cb_ex_sqr_obj.reserve_back(1);
+            cb_stats_reduced_obj.wait_front(1);
             tile_regs_acquire();
             mul_tiles_init(cb_stats_reduced, cb_stats_reduced);
             mul_tiles(cb_stats_reduced, cb_stats_reduced, 0, 0, dst0);  // first tile in stats is always E(x)
             tile_regs_commit();
             tile_regs_wait();
             pack_tile(dst0, cb_ex_sqr);
-            cb_push_back(cb_ex_sqr, 1);
+            cb_ex_sqr_obj.push_back(1);
             tile_regs_release();
 
             // E(x^2) - E(x)^2
             reconfig_data_format_srca(cb_stats_reduced, cb_ex2);
             reconfig_data_format_srcb(cb_stats_reduced, cb_ex_sqr);
             pack_reconfig_data_format(cb_var);
-            cb_wait_front(cb_ex2, 1);
-            cb_wait_front(cb_ex_sqr, 1);
-            cb_reserve_back(cb_var, 1);
+            cb_ex2_obj.wait_front(1);
+            cb_ex_sqr_obj.wait_front(1);
+            cb_var_obj.reserve_back(1);
             tile_regs_acquire();
             sub_tiles_init(cb_ex2, cb_ex_sqr);
             sub_tiles(cb_ex2, cb_ex_sqr, 0, 0, dst0);
             tile_regs_commit();
             tile_regs_wait();
             pack_tile(dst0, cb_var);
-            cb_push_back(cb_var, 1);
+            cb_var_obj.push_back(1);
             tile_regs_release();
-            cb_pop_front(cb_ex2, 1);
-            cb_pop_front(cb_ex_sqr, 1);
+            cb_ex2_obj.pop_front(1);
+            cb_ex_sqr_obj.pop_front(1);
 #endif
 
             // 1/[sqrt(Var + eps)],
             reconfig_data_format(cb_var, cb_eps);  // cb_var is cb_stats in case of RMS norm
             pack_reconfig_data_format(cb_stats_reduced);
-            cb_wait_front(cb_var, 1);
-            cb_wait_front(cb_eps, 1);
-            cb_reserve_back(cb_stats_reduced, 1);
+            cb_var_obj.wait_front(1);
+            cb_eps_obj.wait_front(1);
+            cb_stats_reduced_obj.reserve_back(1);
 
             add_tiles_init(cb_var, cb_eps);
             tile_regs_acquire();
@@ -190,9 +208,9 @@ void kernel_main() {
             tile_regs_wait();
             pack_tile(dst0, cb_stats_reduced);
             tile_regs_release();
-            cb_pop_front(cb_var, 1);
-            cb_pop_front(cb_eps, 1);
-            cb_push_back(cb_stats_reduced, 1);
+            cb_var_obj.pop_front(1);
+            cb_eps_obj.pop_front(1);
+            cb_stats_reduced_obj.push_back(1);
         }
     }
 
@@ -202,10 +220,10 @@ void kernel_main() {
     pack_reconfig_data_format(cb_xmm);
     index_h_offset = 0;
     sub_bcast_cols_init_short(cb_in0, cb_ex_global);
-    cb_reserve_back(cb_xmm, num_tiles_per_block);
+    cb_xmm_obj.reserve_back(num_tiles_per_block);
     for (uint32_t i = 0; i < block_h; i++) {
         index_subblock_w_offset = 0;
-        cb_wait_front(cb_ex_global, 1);
+        cb_ex_global_obj.wait_front(1);
         for (uint32_t j = 0; j < num_subblocks_w; j++) {
             tile_regs_acquire();
             for (uint32_t w = 0; w < subblock_w; w++) {
@@ -220,10 +238,10 @@ void kernel_main() {
             tile_regs_release();
             index_subblock_w_offset += subblock_w;
         }
-        cb_pop_front(cb_ex_global, 1);
-        cb_pop_front(cb_in0, block_w);
+        cb_ex_global_obj.pop_front(1);
+        cb_in0_obj.pop_front(block_w);
     }
-    cb_push_back(cb_xmm, num_tiles_per_block);
+    cb_xmm_obj.push_back(num_tiles_per_block);
 #endif
 
     if constexpr (do_gamma == 0 && do_beta == 0) {
@@ -236,13 +254,13 @@ void kernel_main() {
     reconfig_data_format(cb_xmm, cb_ex_global);
     mul_bcast_cols_init_short(cb_xmm, cb_ex_global);
     index_h_offset = 0;
-    cb_reserve_back(cb_im, num_tiles_per_block);
+    cb_im_obj.reserve_back(num_tiles_per_block);
 #ifndef RMSNORM
-    cb_wait_front(cb_xmm, num_tiles_per_block);
+    cb_xmm_obj.wait_front(num_tiles_per_block);
 #endif
     for (uint32_t i = 0; i < block_h; i++) {
         index_subblock_w_offset = 0;
-        cb_wait_front(cb_ex_global, 1);
+        cb_ex_global_obj.wait_front(1);
         for (uint32_t j = 0; j < num_subblocks_w; j++) {
             tile_regs_acquire();
             for (uint32_t w = 0; w < subblock_w; w++) {
@@ -260,12 +278,12 @@ void kernel_main() {
             index_subblock_w_offset += subblock_w;
         }
         index_h_offset += block_w;
-        cb_pop_front(cb_ex_global, 1);
+        cb_ex_global_obj.pop_front(1);
     }
-    cb_push_back(cb_im, num_tiles_per_block);
+    cb_im_obj.push_back(num_tiles_per_block);
 
-    cb_pop_front(cb_xmm, num_tiles_per_block);
-    cb_wait_front(cb_im, num_tiles_per_block);
+    cb_xmm_obj.pop_front(num_tiles_per_block);
+    cb_im_obj.wait_front(num_tiles_per_block);
 
     if constexpr (do_gamma) {
         reconfig_data_format(cb_im, cb_gamma);
@@ -273,9 +291,9 @@ void kernel_main() {
             pack_reconfig_data_format(cb_out);
         }
         mul_bcast_rows_init_short(cb_im, cb_gamma);
-        cb_wait_front(cb_gamma, block_w);
+        cb_gamma_obj.wait_front(block_w);
         index_h_offset = 0;
-        cb_reserve_back(cb_outgamma, num_tiles_per_block);
+        cb_outgamma_obj.reserve_back(num_tiles_per_block);
         for (uint32_t i = 0; i < block_h; i++) {
             index_subblock_w_offset = 0;
             for (uint32_t j = 0; j < num_subblocks_w; j++) {
@@ -291,21 +309,21 @@ void kernel_main() {
                 }
                 tile_regs_release();
                 index_subblock_w_offset += subblock_w;
-                cb_push_back(cb_outgamma, subblock_w);
+                cb_outgamma_obj.push_back(subblock_w);
             }
             index_h_offset += block_w;
         }
-        cb_pop_front(cb_im, num_tiles_per_block);
+        cb_im_obj.pop_front(num_tiles_per_block);
     }
 
     if constexpr (do_beta) {
-        cb_wait_front(cb_outgamma, num_tiles_per_block);
+        cb_outgamma_obj.wait_front(num_tiles_per_block);
         reconfig_data_format(cb_fusion, cb_beta);
         pack_reconfig_data_format(cb_out);
         add_bcast_rows_init_short(cb_fusion, cb_beta);
-        cb_wait_front(cb_beta, block_w);
+        cb_beta_obj.wait_front(block_w);
         index_h_offset = 0;
-        cb_reserve_back(cb_out, num_tiles_per_block);
+        cb_out_obj.reserve_back(num_tiles_per_block);
         for (uint32_t i = 0; i < block_h; i++) {
             index_subblock_w_offset = 0;
             for (uint32_t j = 0; j < num_subblocks_w; j++) {
@@ -324,7 +342,7 @@ void kernel_main() {
             }
             index_h_offset += block_w;
         }
-        cb_push_back(cb_out, num_tiles_per_block);
-        cb_pop_front(cb_fusion, num_tiles_per_block);
+        cb_out_obj.push_back(num_tiles_per_block);
+        cb_fusion_obj.pop_front(num_tiles_per_block);
     }
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_pre_allgather.cpp
@@ -13,6 +13,7 @@
 #include "api/compute/eltwise_binary.h"
 #include "api/compute/layernorm.h"
 #include "api/compute/tile_move_copy.h"
+#include "experimental/circular_buffer.h"
 
 // SPLIT REDUCE across Cores
 void kernel_main() {
@@ -55,6 +56,7 @@ void kernel_main() {
 #else
     constexpr uint32_t cb_in = cb_in0;
 #endif
+    experimental::CircularBuffer cb_in_obj(cb_in);
     constexpr uint32_t cb_scaler = tt::CBIndex::c_2;
     constexpr uint32_t cb_scaler_global = tt::CBIndex::c_4;
     constexpr uint32_t cb_x = tt::CBIndex::c_24;  // x minus mean
@@ -67,6 +69,12 @@ void kernel_main() {
     constexpr uint32_t cb_ex_partial2 = tt::CBIndex::c_11;   // E[x^2] partial reduce
     constexpr uint32_t cb_ex_external2 = tt::CBIndex::c_13;  // E[x^2] partials received from other cores
     const uint32_t cb_reduction_out = (!use_two_stage_reduce or is_second_stage_reader) ? cb_out : cb_ex2;
+
+    experimental::CircularBuffer cb_scaler_obj(cb_scaler);
+    experimental::CircularBuffer cb_x2_obj(cb_x2);
+    experimental::CircularBuffer cb_ex_partial2_obj(cb_ex_partial2);
+    experimental::CircularBuffer cb_scaler_global_obj(cb_scaler_global);
+    experimental::CircularBuffer cb_ex_external2_obj(cb_ex_external2);
 
     // set block_h to volatile to disable automatically unroll of the loops, avoid code overflow
     const uint32_t block_h = (block_w == 1) ? block_h_volatile : block_h_const;
@@ -85,7 +93,7 @@ void kernel_main() {
 #ifdef FUSE_PRE_ADD
     binary_op_init_common(cb_in0, cb_in1, cb_in);
     add_tiles_init(cb_in0, cb_in1);
-    cb_reserve_back(cb_in, num_tiles_per_block);
+    cb_in_obj.reserve_back(num_tiles_per_block);
     for (uint32_t i = 0; i < block_h; i++) {
         index_subblock_w_offset = 0;
         for (uint32_t j = 0; j < num_subblocks_w; j++) {
@@ -104,15 +112,15 @@ void kernel_main() {
         }
         index_h_offset += block_w;
     }
-    cb_push_back(cb_in, num_tiles_per_block);
-    cb_wait_front(cb_in, num_tiles_per_block);
+    cb_in_obj.push_back(num_tiles_per_block);
+    cb_in_obj.wait_front(num_tiles_per_block);
     pack_reconfig_data_format(cb_in, cb_x2);
 #else
     binary_op_init_common(cb_in, cb_in, cb_x2);
 #endif
 
 #ifndef RMSNORM
-    cb_wait_front(cb_scaler, 1);
+    cb_scaler_obj.wait_front(1);
 #ifdef FUSE_PRE_ADD
     reconfig_data_format(cb_in0, cb_in, cb_in1, cb_scaler);
 #else
@@ -122,7 +130,7 @@ void kernel_main() {
     index_h_offset = 0;
     reduce_init<REDUCE_OP, REDUCE_DIM, FLOAT32_REDUCTION>(cb_in0, cb_scaler, cb_ex_partial2);
 
-    cb_reserve_back(cb_ex_partial2, block_h);
+    cb_ex_partial2_obj.reserve_back(block_h);
     for (uint32_t i = 0; i < block_h; i++) {
         tile_regs_acquire();
         for (uint32_t w = 0; w < num_reduce_tiles_per_block_h; w++) {
@@ -135,7 +143,7 @@ void kernel_main() {
         index_h_offset += block_w;
     }
     reduce_uninit();
-    cb_push_back(cb_ex_partial2, block_h);
+    cb_ex_partial2_obj.push_back(block_h);
     reconfig_data_format_srcb(cb_scaler, cb_in);
 #else
 #ifdef FUSE_PRE_ADD
@@ -146,7 +154,7 @@ void kernel_main() {
     // X^2
     mul_tiles_init(cb_in0, cb_in0);
     index_h_offset = 0;
-    cb_reserve_back(cb_x2, num_tiles_per_block);
+    cb_x2_obj.reserve_back(num_tiles_per_block);
     for (uint32_t i = 0; i < block_h; i++) {
         index_subblock_w_offset = 0;
         for (uint32_t j = 0; j < num_subblocks_w; j++) {
@@ -165,18 +173,18 @@ void kernel_main() {
         }
         index_h_offset += block_w;
     }
-    cb_push_back(cb_x2, num_tiles_per_block);
+    cb_x2_obj.push_back(num_tiles_per_block);
 
     // E(x^2)
     reconfig_data_format_srca(cb_in, cb_x2);
     reconfig_data_format_srcb(cb_in, cb_scaler);
 
-    cb_wait_front(cb_x2, num_tiles_per_block);
+    cb_x2_obj.wait_front(num_tiles_per_block);
 #ifdef RMSNORM
-    cb_wait_front(cb_scaler, 1);
+    cb_scaler_obj.wait_front(1);
 #endif  // RMSNORM
 
-    cb_reserve_back(cb_ex_partial2, block_h);  // RMS E(x2) #Layernorm //E(x) and E(x^2)
+    cb_ex_partial2_obj.reserve_back(block_h);  // RMS E(x2) #Layernorm //E(x) and E(x^2)
 
     reduce_init<REDUCE_OP, REDUCE_DIM, FLOAT32_REDUCTION>(cb_x2, cb_scaler, cb_ex_partial2);
     index_h_offset = 0;
@@ -193,23 +201,24 @@ void kernel_main() {
         index_h_offset += block_w;
     }
     reduce_uninit();
-    cb_pop_front(cb_x2, num_tiles_per_block);
-    cb_push_back(cb_ex_partial2, block_h);
+    cb_x2_obj.pop_front(num_tiles_per_block);
+    cb_ex_partial2_obj.push_back(block_h);
 
     // global reduce, cb_ex <-- cb_ex_external2, cb_ex_partial2
     if constexpr (is_allgather_worker) {
-        cb_wait_front(cb_scaler_global, 1);
+        cb_scaler_global_obj.wait_front(1);
         reconfig_data_format_srca(cb_x2, cb_ex_external2);
         reconfig_data_format_srcb(cb_scaler, cb_scaler_global);
         reduce_init(cb_ex_external2, cb_scaler_global, cb_reduction_out);
         pack_reconfig_data_format(cb_reduction_out);
-        cb_reserve_back(cb_reduction_out, num_tiles_per_partial_result * num_tiles_per_allgather_worker);
+        experimental::CircularBuffer(cb_reduction_out)
+            .reserve_back(num_tiles_per_partial_result * num_tiles_per_allgather_worker);
 
         for (uint32_t i = 0; i < num_tiles_per_allgather_worker; i++) {  // loops over height
             tile_regs_acquire();
             for (uint32_t w = 0; w < num_tiles_per_partial_result * num_blocks_reduce;
                  w++) {  // Need to read this interleaved now, we have SUM(X) and SUM(X^2) interleaved
-                cb_wait_front(cb_ex_external2, 1);
+                cb_ex_external2_obj.wait_front(1);
                 reduce_tile(
                     cb_ex_external2,
                     cb_scaler_global,
@@ -217,7 +226,7 @@ void kernel_main() {
                     scaler0,
                     w % num_tiles_per_partial_result);  // E(x) and E(x^2) interleaved so we reduce each one into
                                                         // different dest reg
-                cb_pop_front(cb_ex_external2, 1);
+                cb_ex_external2_obj.pop_front(1);
             }
             tile_regs_commit();
             tile_regs_wait();
@@ -228,6 +237,7 @@ void kernel_main() {
             tile_regs_release();
         }
         reduce_uninit();
-        cb_push_back(cb_reduction_out, num_tiles_per_partial_result * num_tiles_per_allgather_worker);
+        experimental::CircularBuffer(cb_reduction_out)
+            .push_back(num_tiles_per_partial_result * num_tiles_per_allgather_worker);
     }
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_welford.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_welford.cpp
@@ -16,6 +16,7 @@
 #include "api/compute/eltwise_binary.h"
 #include "ttnn/operations/normalization/kernel_util/compute/combine_welford.h"
 #include "ttnn/operations/normalization/kernel_util/compute/memory.h"
+#include "experimental/circular_buffer.h"
 
 /**
  * @brief This kernel computes layernorm for sharded tensors using
@@ -142,13 +143,28 @@ void kernel_main() {
     constexpr uint32_t cb_fusion = tt::CBIndex::c_18;     // stream gamma/beta
     constexpr uint32_t cb_out = tt::CBIndex::c_16;
     constexpr uint32_t cb_reciprocals = tt::CBIndex::c_25;  // LUT of pre-computed reciprocals for Welford's algorithm
+
+    experimental::CircularBuffer cb_gamma_obj(cb_gamma);
+    experimental::CircularBuffer cb_beta_obj(cb_beta);
+    experimental::CircularBuffer cb_xmm_obj(cb_xmm);
+    experimental::CircularBuffer cb_ex_partial_obj(cb_ex_partial);
+    experimental::CircularBuffer cb_ex_obj(cb_ex);
+    experimental::CircularBuffer cb_ex_external_obj(cb_ex_external);
+    experimental::CircularBuffer cb_ex_global_obj(cb_ex_global);
+    experimental::CircularBuffer cb_transpose_obj(cb_transpose);
+    experimental::CircularBuffer cb_fusion_obj(cb_fusion);
+    experimental::CircularBuffer cb_out_obj(cb_out);
+
     constexpr uint32_t cb_im = (do_gamma | do_beta) ? cb_x : cb_out;
+    experimental::CircularBuffer cb_im_obj(cb_im);
     constexpr uint32_t cb_outgamma = do_beta ? cb_fusion : cb_out;
+    experimental::CircularBuffer cb_outgamma_obj(cb_outgamma);
 #ifdef FUSE_PRE_ADD
     constexpr uint32_t cb_in = cb_x;
 #else
     constexpr uint32_t cb_in = cb_in0;
 #endif
+    experimental::CircularBuffer cb_in_obj(cb_in);
 
     // ---------------------------------------------------------------------------
     // Derived quantities
@@ -228,7 +244,7 @@ void kernel_main() {
 #ifdef FUSE_PRE_ADD
     reconfig_data_format_srcb(cb_in0, cb_in1);
     add_tiles_init(cb_in0, cb_in1);
-    cb_reserve_back(cb_in, num_tiles_per_block);
+    cb_in_obj.reserve_back(num_tiles_per_block);
     for (uint32_t i = 0; i < block_ht; i++) {
         index_subblock_w_offset = 0;
         for (uint32_t j = 0; j < num_subblocks_w; j++) {
@@ -247,15 +263,15 @@ void kernel_main() {
         }
         index_h_offset += block_wt;
     }
-    cb_push_back(cb_in, num_tiles_per_block);
-    cb_wait_front(cb_in, num_tiles_per_block);
+    cb_in_obj.push_back(num_tiles_per_block);
+    cb_in_obj.wait_front(num_tiles_per_block);
 #endif
 
     // ---------------------------------------------------------------------------
     // Compute E[x] and Var[x] using Welford's algorithm
     // ---------------------------------------------------------------------------
     reconfig_data_format_srca(cb_in);
-    cb_reserve_back(cb_ex_partial, num_block_ht_result_tiles);
+    cb_ex_partial_obj.reserve_back(num_block_ht_result_tiles);
     transpose_wh_init_short(cb_in);
     welford_init();
     index_h_offset = 0;
@@ -287,8 +303,8 @@ void kernel_main() {
         tile_regs_release();
         index_h_offset += block_wt;
     }
-    cb_push_back(cb_ex_partial, num_block_ht_result_tiles);
-    cb_wait_front(cb_ex_partial, num_block_ht_result_tiles);
+    cb_ex_partial_obj.push_back(num_block_ht_result_tiles);
+    cb_ex_partial_obj.wait_front(num_block_ht_result_tiles);
 
     // ---------------------------------------------------------------------------
     // Combine Welford local partials with external partials
@@ -299,7 +315,7 @@ void kernel_main() {
     // ---------------------------------------------------------------------------
     reconfig_data_format_srca(cb_ex_partial);
     if constexpr (is_allgather_worker) {
-        cb_reserve_back(cb_ex, 2 * num_tiles_per_allgather_worker);
+        cb_ex_obj.reserve_back(2 * num_tiles_per_allgather_worker);
         for (uint32_t i = 0; i < num_tiles_per_allgather_worker; i++) {
             norm::kernel_util::compute::combine_welford_partials(
                 cb_ex_external,
@@ -324,19 +340,19 @@ void kernel_main() {
                 // between first stage (row) and second stage (column) (if row major).
                 // The factor of 2 is because each block has 2 tiles (mean, var).
                 constexpr uint32_t num_second_stage_tiles = 2 * (num_blocks_second_stage - 1);
-                cb_wait_front(cb_ex_external, num_second_stage_tiles);
-                cb_pop_front(cb_ex_external, num_second_stage_tiles);
+                cb_ex_external_obj.wait_front(num_second_stage_tiles);
+                cb_ex_external_obj.pop_front(num_second_stage_tiles);
             }
         }
-        cb_push_back(cb_ex, 2 * num_tiles_per_allgather_worker);
-        cb_wait_front(cb_ex, 2 * num_tiles_per_allgather_worker);
+        cb_ex_obj.push_back(2 * num_tiles_per_allgather_worker);
+        cb_ex_obj.wait_front(2 * num_tiles_per_allgather_worker);
     }
 
     // ---------------------------------------------------------------------------
     // Receive the global reduce result and transpose back to columns
     // ---------------------------------------------------------------------------
-    cb_wait_front(cb_ex_global, num_block_ht_result_tiles);
-    cb_reserve_back(cb_transpose, num_block_ht_result_tiles);
+    cb_ex_global_obj.wait_front(num_block_ht_result_tiles);
+    cb_transpose_obj.reserve_back(num_block_ht_result_tiles);
     transpose_wh_init_short(cb_ex_global);
     uint32_t processed_tiles = 0;
     while (processed_tiles < num_block_ht_result_tiles) {
@@ -353,10 +369,10 @@ void kernel_main() {
         tile_regs_release();
         processed_tiles += tiles_to_load;
     }
-    cb_push_back(cb_transpose, num_block_ht_result_tiles);
-    cb_pop_front(cb_ex_global, num_block_ht_result_tiles);
+    cb_transpose_obj.push_back(num_block_ht_result_tiles);
+    cb_ex_global_obj.pop_front(num_block_ht_result_tiles);
 
-    cb_wait_front(cb_transpose, num_block_ht_result_tiles);
+    cb_transpose_obj.wait_front(num_block_ht_result_tiles);
 
     // ---------------------------------------------------------------------------
     // Compute x - E[x]
@@ -366,11 +382,11 @@ void kernel_main() {
     }
     index_h_offset = 0;
     sub_bcast_cols_init_short(cb_in, cb_transpose);
-    cb_reserve_back(cb_xmm, num_tiles_per_block);
+    cb_xmm_obj.reserve_back(num_tiles_per_block);
     for (uint32_t i = 0; i < block_ht; i++) {
         index_subblock_w_offset = 0;
         const auto mean_idx = 2 * i;
-        cb_wait_front(cb_transpose, mean_idx + 1);
+        cb_transpose_obj.wait_front(mean_idx + 1);
         for (uint32_t j = 0; j < num_subblocks_w; j++) {
             tile_regs_acquire();
             for (uint32_t w = 0; w < subblock_wt; w++) {
@@ -385,14 +401,14 @@ void kernel_main() {
             tile_regs_release();
             index_subblock_w_offset += subblock_wt;
         }
-        cb_pop_front(cb_in, block_wt);
+        cb_in_obj.pop_front(block_wt);
         // Don't pop transpose buffer until after the mul below
     }
-    cb_push_back(cb_xmm, num_tiles_per_block);
+    cb_xmm_obj.push_back(num_tiles_per_block);
 #ifndef FUSE_PRE_ADD
     reconfig_data_format_srca(cb_in, cb_xmm);
 #endif
-    cb_wait_front(cb_xmm, num_tiles_per_block);
+    cb_xmm_obj.wait_front(num_tiles_per_block);
 
     if constexpr (do_gamma == 0 && do_beta == 0) {
         pack_reconfig_data_format(cb_out);
@@ -406,7 +422,7 @@ void kernel_main() {
     }
     mul_bcast_cols_init_short(cb_xmm, cb_transpose);
     index_h_offset = 0;
-    cb_reserve_back(cb_im, num_tiles_per_block);
+    cb_im_obj.reserve_back(num_tiles_per_block);
     for (uint32_t i = 0; i < block_ht; i++) {
         index_subblock_w_offset = 0;
         for (uint32_t j = 0; j < num_subblocks_w; j++) {
@@ -424,24 +440,24 @@ void kernel_main() {
             index_subblock_w_offset += subblock_wt;
         }
         index_h_offset += block_wt;
-        cb_pop_front(cb_transpose, 2);
+        cb_transpose_obj.pop_front(2);
     }
-    cb_push_back(cb_im, num_tiles_per_block);
-    cb_pop_front(cb_xmm, num_tiles_per_block);
+    cb_im_obj.push_back(num_tiles_per_block);
+    cb_xmm_obj.pop_front(num_tiles_per_block);
 
     // ---------------------------------------------------------------------------
     // Scale by gamma
     // ---------------------------------------------------------------------------
-    cb_wait_front(cb_im, num_tiles_per_block);
+    cb_im_obj.wait_front(num_tiles_per_block);
     if constexpr (do_gamma) {
         reconfig_data_format(cb_im, cb_gamma);
         if constexpr (do_beta == 0) {
             pack_reconfig_data_format(cb_out);
         }
         mul_bcast_rows_init_short(cb_im, cb_gamma);
-        cb_wait_front(cb_gamma, block_wt);
+        cb_gamma_obj.wait_front(block_wt);
         index_h_offset = 0;
-        cb_reserve_back(cb_outgamma, num_tiles_per_block);
+        cb_outgamma_obj.reserve_back(num_tiles_per_block);
         for (uint32_t i = 0; i < block_ht; i++) {
             index_subblock_w_offset = 0;
             for (uint32_t j = 0; j < num_subblocks_w; j++) {
@@ -460,9 +476,9 @@ void kernel_main() {
             }
             index_h_offset += block_wt;
         }
-        cb_push_back(cb_outgamma, num_tiles_per_block);
-        cb_pop_front(cb_im, num_tiles_per_block);
-        cb_wait_front(cb_outgamma, num_tiles_per_block);
+        cb_outgamma_obj.push_back(num_tiles_per_block);
+        cb_im_obj.pop_front(num_tiles_per_block);
+        cb_outgamma_obj.wait_front(num_tiles_per_block);
     }
 
     // ---------------------------------------------------------------------------
@@ -472,9 +488,9 @@ void kernel_main() {
         reconfig_data_format(cb_fusion, cb_beta);
         pack_reconfig_data_format(cb_out);
         add_bcast_rows_init_short(cb_fusion, cb_beta);
-        cb_wait_front(cb_beta, block_wt);
+        cb_beta_obj.wait_front(block_wt);
         index_h_offset = 0;
-        cb_reserve_back(cb_out, num_tiles_per_block);
+        cb_out_obj.reserve_back(num_tiles_per_block);
         for (uint32_t i = 0; i < block_ht; i++) {
             index_subblock_w_offset = 0;
             for (uint32_t j = 0; j < num_subblocks_w; j++) {
@@ -493,8 +509,8 @@ void kernel_main() {
             }
             index_h_offset += block_wt;
         }
-        cb_push_back(cb_out, num_tiles_per_block);
-        cb_pop_front(cb_fusion, num_tiles_per_block);
-        cb_wait_front(cb_out, num_tiles_per_block);
+        cb_out_obj.push_back(num_tiles_per_block);
+        cb_fusion_obj.pop_front(num_tiles_per_block);
+        cb_out_obj.wait_front(num_tiles_per_block);
     }
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_welford.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_welford.cpp
@@ -16,6 +16,7 @@
 #include "api/compute/compute_kernel_hw_startup.h"
 #include "ttnn/operations/normalization/kernel_util/compute/memory.h"
 #include "ttnn/operations/normalization/kernel_util/generic/blocked_range.h"
+#include "experimental/circular_buffer.h"
 
 namespace kutil = norm::kernel_util;
 namespace generic = kutil::generic;
@@ -46,7 +47,20 @@ void kernel_main() {
     constexpr auto cb_ex2pe = tt::CBIndex::c_21;        // E[(x-E[x])^2]+eps
     constexpr auto cb_fusion = tt::CBIndex::c_22;       // stream gamma/beta
     constexpr auto cb_reciprocals = tt::CBIndex::c_25;  // Pre-computed reciprocals for Welford's algorithm
+    experimental::CircularBuffer cb_eps_obj(cb_eps);
+    experimental::CircularBuffer cb_in_obj(cb_in);
+    experimental::CircularBuffer cb_inb_obj(cb_inb);
+    experimental::CircularBuffer cb_out_obj(cb_out);
+    experimental::CircularBuffer cb_gamma_obj(cb_gamma);
+    experimental::CircularBuffer cb_beta_obj(cb_beta);
+    experimental::CircularBuffer cb_xmm_obj(cb_xmm);
+    experimental::CircularBuffer cb_ex_obj(cb_ex);
+    experimental::CircularBuffer cb_ex2_obj(cb_ex2);
+    experimental::CircularBuffer cb_ex2pe_obj(cb_ex2pe);
+    experimental::CircularBuffer cb_fusion_obj(cb_fusion);
+
     constexpr auto cb_im_or_out = (do_gamma | do_beta) ? cb_fusion : cb_out;
+    experimental::CircularBuffer cb_im_or_out_obj(cb_im_or_out);
 
     //  Either in or in + b if doing fused pre-add
     constexpr auto cb_x = []() -> auto {
@@ -56,6 +70,7 @@ void kernel_main() {
             return cb_in;
         }
     }();
+    experimental::CircularBuffer cb_x_obj(cb_x);
 
     constexpr uint32_t dst0 = 0;
     constexpr uint32_t input_dst = 0;  // Input tile for Welford's algorithm
@@ -65,7 +80,7 @@ void kernel_main() {
     // The number of valid rows in the last tile in width dimension
     constexpr uint32_t last_tile_rows = (W % tile_width) == 0 ? tile_width : W % tile_width;
 
-    cb_wait_front(cb_eps, 1);     // comes from the reader
+    cb_eps_obj.wait_front(1);  // comes from the reader
 
     if constexpr (fuse_pre_add) {
         binary_op_init_common(cb_in, cb_inb, cb_x);
@@ -94,23 +109,23 @@ void kernel_main() {
                 // synced on full block size. Keep cb_x aligned
                 // to full block size as well so pre-add/no-pre-add
                 // can be handled the same way.
-                cb_wait_front(cb_in, block.full_block_size());
-                cb_wait_front(cb_inb, block.full_block_size());
+                cb_in_obj.wait_front(block.full_block_size());
+                cb_inb_obj.wait_front(block.full_block_size());
                 tile_regs_acquire();
                 for (auto i : block.local()) {
                     add_tiles(cb_in, cb_inb, i, i, i);
                 }
                 tile_regs_commit();
-                cb_pop_front(cb_in, block.full_block_size());
-                cb_pop_front(cb_inb, block.full_block_size());
+                cb_in_obj.pop_front(block.full_block_size());
+                cb_inb_obj.pop_front(block.full_block_size());
 
-                cb_reserve_back(cb_x, block.full_block_size());
+                cb_x_obj.reserve_back(block.full_block_size());
                 tile_regs_wait();
                 for (auto i : block.local()) {
                     pack_tile(i, cb_x);
                 }
                 tile_regs_release();
-                cb_push_back(cb_x, block.full_block_size());  // push the sum into the same buffer
+                cb_x_obj.push_back(block.full_block_size());  // push the sum into the same buffer
             }
             reconfig_data_format(cb_in, cb_x, cb_inb, cb_ex);
         }
@@ -123,7 +138,7 @@ void kernel_main() {
         welford_init();
         // Process all but the last tile
         for (uint32_t wt = 0; wt < (Wt - 1); ++wt) {
-            cb_wait_front(cb_x, wt + 1);
+            cb_x_obj.wait_front(wt + 1);
             // Welford's needs transposed input tile
             transpose_wh_tile(cb_x, wt, input_dst);
             welford_update<W>(input_dst, start_N, *p_reciprocals);
@@ -134,7 +149,7 @@ void kernel_main() {
         // cb_x is synced on full blocks, so we need to wait for the
         // last tile + any remaining in the last block
         const auto num_to_wait = generic::blocks(Wt, blk).total_with_remainder();
-        cb_wait_front(cb_x, num_to_wait);
+        cb_x_obj.wait_front(num_to_wait);
         transpose_wh_tile(cb_x, Wt - 1, input_dst);
         welford_update_rows<W>(input_dst, start_N, 0, last_tile_rows, *p_reciprocals);
 
@@ -143,19 +158,19 @@ void kernel_main() {
         tile_regs_commit();
 
         // Transpose mean and var back to columns
-        cb_reserve_back(cb_ex, onetile);
-        cb_reserve_back(cb_ex2, onetile);
+        cb_ex_obj.reserve_back(onetile);
+        cb_ex2_obj.reserve_back(onetile);
         tile_regs_wait();
         pack_reconfig_data_format(cb_ex);
         pack_tile(mean_dst, cb_ex);
         pack_reconfig_data_format(cb_ex2);
         pack_tile(var_dst, cb_ex2);
         tile_regs_release();
-        cb_push_back(cb_ex, onetile);
-        cb_push_back(cb_ex2, onetile);
+        cb_ex_obj.push_back(onetile);
+        cb_ex2_obj.push_back(onetile);
 
-        cb_wait_front(cb_ex, onetile);
-        cb_wait_front(cb_ex2, onetile);
+        cb_ex_obj.wait_front(onetile);
+        cb_ex2_obj.wait_front(onetile);
         reconfig_data_format_srca(cb_ex);
         transpose_wh_init_short(cb_ex);
         tile_regs_acquire();
@@ -163,11 +178,11 @@ void kernel_main() {
         transpose_wh_tile(cb_ex2, 0, var_dst);
         tile_regs_commit();
 
-        cb_pop_front(cb_ex, onetile);
-        cb_pop_front(cb_ex2, onetile);
+        cb_ex_obj.pop_front(onetile);
+        cb_ex2_obj.pop_front(onetile);
 
-        cb_reserve_back(cb_ex, onetile);
-        cb_reserve_back(cb_ex2, onetile);
+        cb_ex_obj.reserve_back(onetile);
+        cb_ex2_obj.reserve_back(onetile);
 
         pack_reconfig_data_format(cb_ex);
         tile_regs_wait();
@@ -176,16 +191,16 @@ void kernel_main() {
         pack_tile(var_dst, cb_ex2);
         tile_regs_release();
 
-        cb_push_back(cb_ex, onetile);
-        cb_push_back(cb_ex2, onetile);
+        cb_ex_obj.push_back(onetile);
+        cb_ex2_obj.push_back(onetile);
 
         // x - E[x]
         // Reuse cb_x since we didn't pop anything from it
         if constexpr (FLOAT32_DTYPE) {
             reconfig_data_format(cb_x, cb_ex);
         }
-        cb_wait_front(cb_ex, onetile);  // should have 1 tile
-        cb_reserve_back(cb_xmm, total_buffer_size);
+        cb_ex_obj.wait_front(onetile);  // should have 1 tile
+        cb_xmm_obj.reserve_back(total_buffer_size);
         sub_bcast_cols_init_short(cb_x, cb_ex);
         for (auto block : generic::blocks(Wt, blk)) {
             tile_regs_acquire();
@@ -198,11 +213,11 @@ void kernel_main() {
                 pack_tile(i, cb_xmm);
             }
             tile_regs_release();
-            cb_push_back(cb_xmm, block.full_block_size());
-            cb_pop_front(cb_x, block.full_block_size());
+            cb_xmm_obj.push_back(block.full_block_size());
+            cb_x_obj.pop_front(block.full_block_size());
         }
-        cb_pop_front(cb_ex, 1);
-        cb_wait_front(cb_xmm, total_buffer_size);
+        cb_ex_obj.pop_front(1);
+        cb_xmm_obj.wait_front(total_buffer_size);
 
         if constexpr (!fuse_pre_add) {
             reconfig_data_format_srca(cb_x, cb_xmm);
@@ -212,26 +227,26 @@ void kernel_main() {
         if constexpr (FLOAT32_DTYPE) {
             reconfig_data_format(cb_ex2, cb_eps);
         }
-        cb_wait_front(cb_ex2, onetile);  // should have 1 tile
+        cb_ex2_obj.wait_front(onetile);  // should have 1 tile
         tile_regs_acquire();
         add_tiles_init(cb_ex2, cb_eps);
         add_tiles(cb_ex2, cb_eps, 0, 0, dst0);
         rsqrt_tile_init();
         rsqrt_tile(dst0);
         tile_regs_commit();
-        cb_pop_front(cb_ex2, onetile);
+        cb_ex2_obj.pop_front(onetile);
 
-        cb_reserve_back(cb_ex2pe, onetile);
+        cb_ex2pe_obj.reserve_back(onetile);
         tile_regs_wait();
         pack_tile(dst0, cb_ex2pe);
         tile_regs_release();
-        cb_push_back(cb_ex2pe, onetile);
+        cb_ex2pe_obj.push_back(onetile);
 
         // Remainder of the layernorm operation
         // norm(x) * gamma + beta,
         // where norm(x) is:
         // (x - E[x]) / sqrt(E[(x-E[x])^2] + eps)
-        cb_wait_front(cb_ex2pe, onetile);
+        cb_ex2pe_obj.wait_front(onetile);
         for (auto block : generic::blocks(Wt, blk)) {
             reconfig_data_format(cb_xmm, cb_ex2pe);
             if constexpr (do_gamma == 0 && do_beta == 0) {
@@ -248,14 +263,13 @@ void kernel_main() {
             }
             tile_regs_commit();
 
-            cb_reserve_back(cb_im_or_out, block.full_block_size());
+            cb_im_or_out_obj.reserve_back(block.full_block_size());
             tile_regs_wait();
             for (auto i : block.local()) {
                 pack_tile(i, cb_im_or_out);  // pack either to intermediate (cb_fusion or out0)
             }
             tile_regs_release();
-            cb_push_back(
-                cb_im_or_out,
+            cb_im_or_out_obj.push_back(
                 block.full_block_size());  // if no gamma/beta are provided, this will be passed on to the writer
 
             if constexpr (do_gamma) {
@@ -264,25 +278,26 @@ void kernel_main() {
                 }
                 reconfig_data_format_srcb(cb_ex2pe, cb_gamma);
                 uint32_t cb_outg = do_beta ? cb_fusion : cb_out;
+                experimental::CircularBuffer cb_outg_obj(cb_outg);
                 mul_bcast_rows_init_short(cb_fusion, cb_gamma);
-                cb_wait_front(
-                    cb_gamma, block.start() + block.full_block_size());  // we don't pop, TODO: only wait on first ht
-                cb_wait_front(cb_fusion, block.full_block_size());
+                cb_gamma_obj.wait_front(
+                    block.start() + block.full_block_size());  // we don't pop, TODO: only wait on first ht
+                cb_fusion_obj.wait_front(block.full_block_size());
                 tile_regs_acquire();
                 for (auto i : block.local()) {
                     mul_tiles_bcast_rows(cb_fusion, cb_gamma, i, block.to_global(i), i);  // tile *= 1/(sum(exp(x)))
                 }
                 tile_regs_commit();
                 // We don't pop gamma since it's 1,1,1,Wt and we reuse it for all NCHt
-                cb_pop_front(cb_fusion, block.full_block_size());
+                cb_fusion_obj.pop_front(block.full_block_size());
 
-                cb_reserve_back(cb_outg, block.full_block_size());
+                cb_outg_obj.reserve_back(block.full_block_size());
                 tile_regs_wait();
                 for (auto i : block.local()) {
                     pack_tile(i, cb_outg);  // pack either to intermediate (cb_fusion or out0)
                 }
                 tile_regs_release();
-                cb_push_back(cb_outg, block.full_block_size());
+                cb_outg_obj.push_back(block.full_block_size());
             }
             if constexpr (do_beta) {
                 pack_reconfig_data_format(cb_out);
@@ -293,28 +308,28 @@ void kernel_main() {
                 }
 
                 add_bcast_rows_init_short(cb_fusion, cb_beta);
-                cb_wait_front(
-                    cb_beta, block.start() + block.full_block_size());  // TODO: optimization - only wait on first ht
-                cb_wait_front(cb_fusion, block.full_block_size());
+                cb_beta_obj.wait_front(
+                    block.start() + block.full_block_size());  // TODO: optimization - only wait on first ht
+                cb_fusion_obj.wait_front(block.full_block_size());
                 tile_regs_acquire();
                 for (auto i : block.local()) {
                     add_tiles_bcast_rows(cb_fusion, cb_beta, i, block.to_global(i), i);  // tile *= 1/(sum(exp(x)))
                 }
                 tile_regs_commit();
-                cb_pop_front(cb_fusion, block.full_block_size());
+                cb_fusion_obj.pop_front(block.full_block_size());
                 // We don't pop beta since it's 1,1,1,Wt and we reuse it for all NCHt
 
-                cb_reserve_back(cb_out, block.full_block_size());
+                cb_out_obj.reserve_back(block.full_block_size());
                 tile_regs_wait();
                 for (auto i : block.local()) {
                     pack_tile(i, cb_out);  // pack either to intermediate (cb_fusion or out0)
                 }
                 tile_regs_release();
-                cb_push_back(cb_out, block.full_block_size());
+                cb_out_obj.push_back(block.full_block_size());
             }
         }
-        cb_pop_front(cb_ex2pe, onetile);
-        cb_pop_front(cb_xmm, total_buffer_size);
+        cb_ex2pe_obj.pop_front(onetile);
+        cb_xmm_obj.pop_front(total_buffer_size);
 
     }  // NCHt loop
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/layernorm_dataflow_utils.h
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/layernorm_dataflow_utils.h
@@ -173,6 +173,9 @@ inline void read_block_to_cb(
     const uint32_t tile_bytes,
     const uint32_t offset,
     const Block& block) {
+    // Need to reserve/push on intervals that nicely
+    // divide the CB size. The CB and block size has been
+    // configured to ensure this in the program setup
     cb.reserve_back(block.full_block_size());
     uint32_t idx = 0;
     for (auto r : block.local()) {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/layernorm_dataflow_utils.h
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/layernorm_dataflow_utils.h
@@ -11,6 +11,9 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include <tt-metalium/constants.hpp>
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 
 #include "ttnn/operations/normalization/kernel_util/generic/blocked_range.h"
 #include "ttnn/operations/normalization/kernel_util/dataflow/custom_tiles.h"
@@ -19,17 +22,20 @@ namespace norm::layernorm::device::kernels::dataflow {
 
 using NumNocAddrs = uint32_t;
 
-// Would be better to use std::array, but it
-// was causing the program to hang
+struct RemoteNocCoord {
+    uint32_t x;
+    uint32_t y;
+};
+
 template <NumNocAddrs N>
-using RemoteNocAddrs = uint64_t[N];
+using RemoteNocCoords = RemoteNocCoord[N];
 
 using L1Ptr = volatile tt_l1_ptr uint32_t*;
 
 /**
- * @brief Compute NOC addresses for a two-stage reduce.
- *        Populates `remote_noc_addrs_first_stage` and
- *        `remote_noc_addrs_second_stage` with the NOC addresses
+ * @brief Compute NOC coordinates for a two-stage reduce.
+ *        Populates `remote_coords_first_stage` and
+ *        `remote_coords_second_stage` with the NOC coordinates
  *        of the remote cores in its all-to-all or multicast
  *        network.
  * @tparam row_major Whether the cores should be indexed in
@@ -38,10 +44,10 @@ using L1Ptr = volatile tt_l1_ptr uint32_t*;
  *         workers in the first stage
  * @tparam num_remote_workers_second_stage The number of remote
  *         workers in the second stage
- * @param remote_noc_addrs_first_stage The array to populate with
- *        the NOC addresses of the remote workers in the first stage
- * @param remote_noc_addrs_second_stage The array to populate with
- *        the NOC addresses of the remote workers in the second stage
+ * @param remote_coords_first_stage The array to populate with
+ *        the NOC coordinates of the remote workers in the first stage
+ * @param remote_coords_second_stage The array to populate with
+ *        the NOC coordinates of the remote workers in the second stage
  * @param p_remote_noc_x Pointer to L1 memory pointing to an
  *        array of X coordinates of device worker cores
  * @param p_remote_noc_y Pointer to L1 memory pointing to an
@@ -53,8 +59,8 @@ using L1Ptr = volatile tt_l1_ptr uint32_t*;
  */
 template <bool row_major, NumNocAddrs num_remote_workers_first_stage, NumNocAddrs num_remote_workers_second_stage>
 inline void compute_two_stage_noc_addrs(
-    RemoteNocAddrs<num_remote_workers_first_stage>& remote_noc_addrs_first_stage,
-    RemoteNocAddrs<num_remote_workers_second_stage>& remote_noc_addrs_second_stage,
+    RemoteNocCoords<num_remote_workers_first_stage>& remote_coords_first_stage,
+    RemoteNocCoords<num_remote_workers_second_stage>& remote_coords_second_stage,
     L1Ptr p_remote_noc_x,
     L1Ptr p_remote_noc_y,
     uint32_t start_core_x,
@@ -63,7 +69,7 @@ inline void compute_two_stage_noc_addrs(
     uint32_t num_cores_y) {
     uint32_t x = start_core_x, y = start_core_y;
     for (uint32_t i = 0; i < num_remote_workers_first_stage; ++i) {
-        remote_noc_addrs_first_stage[i] = get_noc_addr(p_remote_noc_x[x], p_remote_noc_y[y], 0);
+        remote_coords_first_stage[i] = {p_remote_noc_x[x], p_remote_noc_y[y]};
         if constexpr (row_major) {
             ++x;
             if (x == num_cores_x) {
@@ -84,7 +90,7 @@ inline void compute_two_stage_noc_addrs(
         y = start_core_y;
     }
     for (uint32_t i = 0; i < num_remote_workers_second_stage; ++i) {
-        remote_noc_addrs_second_stage[i] = get_noc_addr(p_remote_noc_x[x], p_remote_noc_y[y], 0);
+        remote_coords_second_stage[i] = {p_remote_noc_x[x], p_remote_noc_y[y]};
         if constexpr (row_major) {
             ++y;
         } else {
@@ -94,18 +100,13 @@ inline void compute_two_stage_noc_addrs(
 }
 
 /**
- * @brief Compute NOC addresses of a core's communication network
+ * @brief Compute NOC coordinates of a core's communication network
  *        for a single-stage reduce
  * @tparam row_major Whether the cores should be indexed in
  *         row-major order
- * @tparam num_remote_workers_first_stage The number of remote
- *        workers in the first stage
- * @tparam num_remote_workers_second_stage The number of remote
- *        workers in the second stage
- * @param remote_noc_addrs_first_stage The array to populate with
- *        the NOC addresses of the remote workers in the first stage
- * @param remote_noc_addrs_second_stage The array to populate with
- *        the NOC addresses of the remote workers in the second stage
+ * @tparam num_remote_workers The number of remote workers
+ * @param remote_coords The array to populate with
+ *        the NOC coordinates of the remote workers
  * @param p_remote_noc_x Pointer to L1 memory pointing to an
  *        array of X coordinates of device worker cores
  * @param p_remote_noc_y Pointer to L1 memory pointing to an
@@ -117,7 +118,7 @@ inline void compute_two_stage_noc_addrs(
  */
 template <bool row_major, NumNocAddrs num_remote_workers>
 inline void compute_single_stage_noc_addrs(
-    RemoteNocAddrs<num_remote_workers>& remote_noc_addrs,
+    RemoteNocCoords<num_remote_workers>& remote_coords,
     L1Ptr p_remote_noc_x,
     L1Ptr p_remote_noc_y,
     uint32_t start_core_x,
@@ -126,7 +127,7 @@ inline void compute_single_stage_noc_addrs(
     uint32_t num_cores_y) {
     uint32_t x = start_core_x, y = start_core_y;
     for (uint32_t i = 0; i < num_remote_workers; ++i) {
-        remote_noc_addrs[i] = get_noc_addr(p_remote_noc_x[x], p_remote_noc_y[y], 0);
+        remote_coords[i] = {p_remote_noc_x[x], p_remote_noc_y[y]};
         if constexpr (row_major) {
             ++x;
             if (x == num_cores_x) {
@@ -155,29 +156,31 @@ inline void compute_single_stage_noc_addrs(
  * block of tiles for synchronization purposes, but
  * only reads tiles that contain data
  *
- * @tparam T Type of the AddrGen object
+ * @tparam T Type of the TensorAccessor object
  * @tparam Block The block type
- * @param cb_id The ID of the CB
- * @param addr AddrGen object for accessing tensor data
+ * @param noc The Noc object to use for data transfer
+ * @param cb The CircularBuffer to read into
+ * @param addr TensorAccessor object for accessing tensor data
  * @param tile_bytes The size of a tile in bytes
- * @param offset Global offset for transaction ID
+ * @param offset Global offset for page ID
  * @param block Block object that defines the number of tiles to read
  */
 template <typename T, typename Block>
 inline void read_block_to_cb(
-    const uint32_t cb_id, const T& addr, const uint32_t tile_bytes, const uint32_t offset, const Block& block) {
-    // Need to reserve/push on intervals that nicely
-    // divide the CB size. The CB and block size has been
-    // configured to ensure this in the program setup
-    cb_reserve_back(cb_id, block.full_block_size());
-    uint32_t l1_write_addr = get_write_ptr(cb_id);
-    // Only read in the part of the block that has data
+    experimental::Noc& noc,
+    experimental::CircularBuffer& cb,
+    const T& addr,
+    const uint32_t tile_bytes,
+    const uint32_t offset,
+    const Block& block) {
+    cb.reserve_back(block.full_block_size());
+    uint32_t idx = 0;
     for (auto r : block.local()) {
-        noc_async_read_tile(offset + r, addr, l1_write_addr);
-        l1_write_addr += tile_bytes;
+        noc.async_read(addr, cb, tile_bytes, {.page_id = offset + r}, {.offset_bytes = idx * tile_bytes});
+        idx++;
     }
-    noc_async_read_barrier();
-    cb_push_back(cb_id, block.full_block_size());
+    noc.async_read_barrier();
+    cb.push_back(block.full_block_size());
 }
 
 /**

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln.cpp
@@ -6,6 +6,8 @@
 #include "hostdevcommon/common_values.hpp"
 #include "api/dataflow/dataflow_api.h"
 #include "layernorm_dataflow_utils.h"
+#include "experimental/noc_semaphore.h"
+#include "experimental/endpoints.h"
 
 namespace df = norm::layernorm::device::kernels::dataflow;
 
@@ -34,8 +36,6 @@ void kernel_main() {
     // ---------------------------------------------------------------------------
     // Compile-time arguments
     // ---------------------------------------------------------------------------
-    uint32_t reduce_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(0));
-    uint32_t reduce_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(1));
     constexpr uint32_t num_blocks = get_compile_time_arg_val(2);
     constexpr uint32_t block_h = get_compile_time_arg_val(3);
     const bool is_all_to_all_worker = get_compile_time_arg_val(4) == 1;
@@ -48,7 +48,6 @@ void kernel_main() {
     constexpr bool use_two_stage_reduce = (bool)get_compile_time_arg_val(11);
     constexpr uint32_t num_blocks_first_stage = get_compile_time_arg_val(12);
     constexpr uint32_t num_blocks_second_stage = get_compile_time_arg_val(13);
-    uint32_t reduce_second_stage_semaphore_addr = get_semaphore(get_compile_time_arg_val(14));
     constexpr bool rms_norm = get_compile_time_arg_val(15) == 1;
     constexpr bool use_welford = get_compile_time_arg_val(16) == 1;
 
@@ -76,26 +75,30 @@ void kernel_main() {
     constexpr uint32_t cb_ex_global = tt::CBIndex::c_15;  // E[x] global reduce
 
     // ---------------------------------------------------------------------------
-    // Set up constants for the kernel
+    // Set up experimental API objects
     // ---------------------------------------------------------------------------
-    // This is actually "num_tile_rows_to_read" but since column-major
-    // reads columns instead of rows, that's not a great name.
-    const uint32_t num_tiles_to_read = is_last_all_to_all_worker ? num_tiles_per_worker_last : num_tiles_per_worker;
-    const uint32_t single_tile_size_bytes = get_tile_size(rms_norm ? cb_ex_partial2 : cb_ex_partial);  // tile size
+    experimental::Noc noc;
+    experimental::Semaphore<> reduce_receiver_sem(get_compile_time_arg_val(0));
+    experimental::Semaphore<> reduce_sender_sem(get_compile_time_arg_val(1));
+    experimental::Semaphore<> reduce_second_stage_sem(get_compile_time_arg_val(14));
+    experimental::UnicastEndpoint remote_ep;
 
-    // Compute the NOC addresses for remote cores that interact with this core
+    const uint32_t num_tiles_to_read = is_last_all_to_all_worker ? num_tiles_per_worker_last : num_tiles_per_worker;
+    const uint32_t single_tile_size_bytes = get_tile_size(rms_norm ? cb_ex_partial2 : cb_ex_partial);
+
+    // Compute the NOC coordinates for remote cores that interact with this core
     constexpr df::NumNocAddrs num_remote_noc_addrs_first_stage = is_all_to_all_worker ? num_blocks_first_stage : 1;
     constexpr df::NumNocAddrs num_remote_noc_addrs_second_stage = is_all_to_all_worker ? num_blocks_second_stage : 1;
-    df::RemoteNocAddrs<num_remote_noc_addrs_first_stage> remote_noc_addrs_first_stage{};
-    df::RemoteNocAddrs<num_remote_noc_addrs_second_stage> remote_noc_addrs_second_stage{};
+    df::RemoteNocCoords<num_remote_noc_addrs_first_stage> remote_coords_first_stage{};
+    df::RemoteNocCoords<num_remote_noc_addrs_second_stage> remote_coords_second_stage{};
     if constexpr (is_all_to_all_worker) {
         if constexpr (use_two_stage_reduce) {
             df::compute_two_stage_noc_addrs<
                 row_major,
                 num_remote_noc_addrs_first_stage,
                 num_remote_noc_addrs_second_stage>(
-                remote_noc_addrs_first_stage,
-                remote_noc_addrs_second_stage,
+                remote_coords_first_stage,
+                remote_coords_second_stage,
                 in0_remote_noc_x,
                 in0_remote_noc_y,
                 start_x,
@@ -104,111 +107,92 @@ void kernel_main() {
                 num_y);
         } else {
             df::compute_single_stage_noc_addrs<row_major, num_remote_noc_addrs_first_stage>(
-                remote_noc_addrs_first_stage, in0_remote_noc_x, in0_remote_noc_y, start_x, start_y, num_x, num_y);
+                remote_coords_first_stage, in0_remote_noc_x, in0_remote_noc_y, start_x, start_y, num_x, num_y);
         }
     } else {
-        remote_noc_addrs_first_stage[0] = get_noc_addr(in0_remote_noc_x[0], in0_remote_noc_y[0], 0);
+        remote_coords_first_stage[0] = {in0_remote_noc_x[0], in0_remote_noc_y[0]};
     }
-
-    volatile tt_l1_ptr uint32_t* reduce_receiver_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_receiver_semaphore_addr);
-    volatile tt_l1_ptr uint32_t* reduce_sender_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_sender_semaphore_addr);
-    volatile tt_l1_ptr uint32_t* reduce_second_stage_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_second_stage_semaphore_addr);
-
-    const uint64_t reduce_receiver_semaphore_noc_addr =
-        get_noc_addr(in0_remote_noc_x[0], in0_remote_noc_y[0], reduce_receiver_semaphore_addr);
-    const uint64_t reduce_second_stage_receiver_semaphore_noc_addr =
-        remote_noc_addrs_second_stage[0] | reduce_second_stage_semaphore_addr;
 
     // ============================================================================
     // Main kernel worker function
     // Waits on partial reduction, syncs with coordinator, reads
     // from other cores, signals when combine is done, receives multicast
     // ============================================================================
-    const auto& global_reduce_receiver = [&](const uint32_t cb_partial,
-                                             const uint32_t cb_external,
-                                             const uint32_t cb_ex,
-                                             const uint32_t cb_ex_global,
-                                             const uint32_t cb_reduce_first_stage,
+    const auto& global_reduce_receiver = [&](const uint32_t cb_partial_id,
+                                             const uint32_t cb_external_id,
+                                             const uint32_t cb_ex_id,
+                                             const uint32_t cb_ex_global_id,
+                                             const uint32_t cb_reduce_first_stage_id,
                                              const uint32_t num_tiles_scaler) __attribute__((always_inline)) {
+        experimental::CircularBuffer cb_partial_obj(cb_partial_id);
+        experimental::CircularBuffer cb_external_obj(cb_external_id);
+        experimental::CircularBuffer cb_ex_obj(cb_ex_id);
+        experimental::CircularBuffer cb_ex_global_obj(cb_ex_global_id);
+        experimental::CircularBuffer cb_reduce_first_stage_obj(cb_reduce_first_stage_id);
+
         // ============================================================================
         // Partial reduction
-        // Partials stored `cb_partial`
         // ============================================================================
 
-        // Wait for this core's partial results to be ready
-        cb_wait_front(cb_partial, block_h * num_tiles_scaler);
+        cb_partial_obj.wait_front(block_h * num_tiles_scaler);
 
-        // Notify the sender that this core's partial results are ready
-        noc_semaphore_set(reduce_sender_semaphore_addr_ptr, INVALID);
-        noc_semaphore_inc(reduce_receiver_semaphore_noc_addr, 1);
-        noc_semaphore_wait(reduce_sender_semaphore_addr_ptr, VALID);
+        reduce_sender_sem.set(INVALID);
+        reduce_receiver_sem.up(noc, in0_remote_noc_x[0], in0_remote_noc_y[0], 1);
+        reduce_sender_sem.wait(VALID);
 
         // ============================================================================
         // Combine partial results
-        // Read from the partial buffers into the external buffer `cb_external`.
-        // Will read a total of:
-        // (num_blocks_first_stage + num_blocks_second_stage - 1) * num_tiles_scaler
-        // tiles for each assigned tile row (or column, if not row-major).
-        // For the second stage, read from `cb_reduce_first_stage` instead of `cb_partial`,
-        // as it will contain the combined results from the first stage.
-        // Combined results written to `cb_ex`.
         // ============================================================================
         if constexpr (is_all_to_all_worker) {
-            // ---------------------------------------------------------------------------
-            // Read remote partial data
-            // ---------------------------------------------------------------------------
-            uint32_t l1_read_addr_ex_par = get_read_ptr(cb_partial);
+            uint32_t l1_read_addr_ex_par = cb_partial_obj.get_read_ptr();
             l1_read_addr_ex_par += all_to_all_tile_offset_bytes * num_tiles_scaler;
             uint32_t l1_read_addr_ex = 0;
             if constexpr (use_two_stage_reduce) {
-                l1_read_addr_ex = get_read_ptr(cb_reduce_first_stage);
+                l1_read_addr_ex = cb_reduce_first_stage_obj.get_read_ptr();
             }
             for (uint32_t i = 0; i < num_tiles_to_read; i++) {
-                // Read from other cores in our core row
-                cb_reserve_back(cb_external, num_blocks_first_stage * num_tiles_scaler);
-                uint32_t l1_write_addr_external = get_write_ptr(cb_external);
+                cb_external_obj.reserve_back(num_blocks_first_stage * num_tiles_scaler);
+                uint32_t write_offset = 0;
                 for (uint32_t block = 0; block < num_blocks_first_stage; block++) {
-                    uint64_t noc_addr_ex_par = remote_noc_addrs_first_stage[block] | l1_read_addr_ex_par;
-                    noc_async_read_one_packet(
-                        noc_addr_ex_par, l1_write_addr_external, num_tiles_scaler * single_tile_size_bytes);
-                    l1_write_addr_external += num_tiles_scaler * single_tile_size_bytes;
+                    noc.async_read<experimental::Noc::TxnIdMode::DISABLED, NOC_MAX_BURST_SIZE>(
+                        remote_ep,
+                        cb_external_obj,
+                        num_tiles_scaler * single_tile_size_bytes,
+                        {.noc_x = remote_coords_first_stage[block].x,
+                         .noc_y = remote_coords_first_stage[block].y,
+                         .addr = l1_read_addr_ex_par},
+                        {.offset_bytes = write_offset});
+                    write_offset += num_tiles_scaler * single_tile_size_bytes;
                 }
                 l1_read_addr_ex_par += num_tiles_scaler * single_tile_size_bytes;
-                noc_async_read_barrier();
-                cb_push_back(cb_external, num_blocks_first_stage * num_tiles_scaler);
+                noc.async_read_barrier();
+                cb_external_obj.push_back(num_blocks_first_stage * num_tiles_scaler);
 
-                // ---------------------------------------------------------------------------
-                // Handle the two-stage reduce
-                // ---------------------------------------------------------------------------
                 if constexpr (use_two_stage_reduce) {
                     if (is_second_stage_reader) {
-                        // Wait for the signal that the combined results
-                        // from the first stage are ready
                         if (i == 0) {
-                            noc_semaphore_wait(reduce_second_stage_semaphore_addr_ptr, num_blocks_second_stage - 1);
-                            noc_semaphore_set(reduce_second_stage_semaphore_addr_ptr, 0);
+                            reduce_second_stage_sem.wait(num_blocks_second_stage - 1);
+                            reduce_second_stage_sem.set(0);
                         }
 
-                        // Read from other cores in our core column
-                        cb_reserve_back(cb_external, (num_blocks_second_stage - 1) * num_tiles_scaler);
+                        cb_external_obj.reserve_back((num_blocks_second_stage - 1) * num_tiles_scaler);
                         for (uint32_t block = 0; block < num_blocks_second_stage - 1; ++block) {
-                            uint64_t noc_addr_ex = remote_noc_addrs_second_stage[block + 1] | l1_read_addr_ex;
-                            noc_async_read_one_packet(
-                                noc_addr_ex, l1_write_addr_external, num_tiles_scaler * single_tile_size_bytes);
-                            l1_write_addr_external += num_tiles_scaler * single_tile_size_bytes;
+                            noc.async_read<experimental::Noc::TxnIdMode::DISABLED, NOC_MAX_BURST_SIZE>(
+                                remote_ep,
+                                cb_external_obj,
+                                num_tiles_scaler * single_tile_size_bytes,
+                                {.noc_x = remote_coords_second_stage[block + 1].x,
+                                 .noc_y = remote_coords_second_stage[block + 1].y,
+                                 .addr = l1_read_addr_ex},
+                                {.offset_bytes = write_offset});
+                            write_offset += num_tiles_scaler * single_tile_size_bytes;
                         }
                         l1_read_addr_ex += num_tiles_scaler * single_tile_size_bytes;
-                        noc_async_read_barrier();
-                        cb_push_back(cb_external, (num_blocks_second_stage - 1) * num_tiles_scaler);
+                        noc.async_read_barrier();
+                        cb_external_obj.push_back((num_blocks_second_stage - 1) * num_tiles_scaler);
                     } else {
-                        // If we're not a second stage reader (i.e. we're not in the top
-                        // row of cores), we don't do any additional combines, so we just
-                        // do a dummy push so that we move in lockstep with the other cores
-                        cb_reserve_back(cb_external, (num_blocks_second_stage - 1) * num_tiles_scaler);
-                        cb_push_back(cb_external, (num_blocks_second_stage - 1) * num_tiles_scaler);
+                        cb_external_obj.reserve_back((num_blocks_second_stage - 1) * num_tiles_scaler);
+                        cb_external_obj.push_back((num_blocks_second_stage - 1) * num_tiles_scaler);
                     }
                 }
             }
@@ -218,15 +202,16 @@ void kernel_main() {
             // ---------------------------------------------------------------------------
             if constexpr (use_two_stage_reduce) {
                 if (is_second_stage_reader) {
-                    cb_wait_front(cb_ex, num_tiles_to_read * num_tiles_scaler);
-                    noc_semaphore_inc(reduce_receiver_semaphore_noc_addr, 1);
+                    cb_ex_obj.wait_front(num_tiles_to_read * num_tiles_scaler);
+                    reduce_receiver_sem.up(noc, in0_remote_noc_x[0], in0_remote_noc_y[0], 1);
                 } else {
-                    cb_wait_front(cb_reduce_first_stage, num_tiles_to_read * num_tiles_scaler);
-                    noc_semaphore_inc(reduce_second_stage_receiver_semaphore_noc_addr, 1);
+                    cb_reduce_first_stage_obj.wait_front(num_tiles_to_read * num_tiles_scaler);
+                    reduce_second_stage_sem.up(
+                        noc, remote_coords_second_stage[0].x, remote_coords_second_stage[0].y, 1);
                 }
             } else {
-                cb_wait_front(cb_ex, num_tiles_to_read * num_tiles_scaler);
-                noc_semaphore_inc(reduce_receiver_semaphore_noc_addr, 1);
+                cb_ex_obj.wait_front(num_tiles_to_read * num_tiles_scaler);
+                reduce_receiver_sem.up(noc, in0_remote_noc_x[0], in0_remote_noc_y[0], 1);
             }
         }
 
@@ -235,9 +220,9 @@ void kernel_main() {
         // ============================================================================
         for (uint32_t block = 0; block < num_all_to_all_workers; ++block) {
             uint32_t num_tiles = block == num_all_to_all_workers - 1 ? num_tiles_per_worker_last : num_tiles_per_worker;
-            cb_reserve_back(cb_ex_global, num_tiles * num_tiles_scaler);
-            noc_semaphore_wait_min(reduce_sender_semaphore_addr_ptr, block + 2);
-            cb_push_back(cb_ex_global, num_tiles * num_tiles_scaler);
+            cb_ex_global_obj.reserve_back(num_tiles * num_tiles_scaler);
+            reduce_sender_sem.wait_min(block + 2);
+            cb_ex_global_obj.push_back(num_tiles * num_tiles_scaler);
         }
     };
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln.cpp
@@ -142,6 +142,13 @@ void kernel_main() {
 
         // ============================================================================
         // Combine partial results
+        // Read from the partial buffers into the external buffer `cb_external`.
+        // Will read a total of:
+        // (num_blocks_first_stage + num_blocks_second_stage - 1) * num_tiles_scaler
+        // tiles for each assigned tile row (or column, if not row-major).
+        // For the second stage, read from `cb_reduce_first_stage` instead of `cb_partial`,
+        // as it will contain the combined results from the first stage.
+        // Combined results written to `cb_ex`.
         // ============================================================================
         if constexpr (is_all_to_all_worker) {
             uint32_t l1_read_addr_ex_par = cb_partial_obj.get_read_ptr();
@@ -168,6 +175,9 @@ void kernel_main() {
                 noc.async_read_barrier();
                 cb_external_obj.push_back(num_blocks_first_stage * num_tiles_scaler);
 
+                // ---------------------------------------------------------------------------
+                // Handle the two-stage reduce
+                // ---------------------------------------------------------------------------
                 if constexpr (use_two_stage_reduce) {
                     if (is_second_stage_reader) {
                         if (i == 0) {
@@ -192,6 +202,9 @@ void kernel_main() {
                         noc.async_read_barrier();
                         cb_external_obj.push_back((num_blocks_second_stage - 1) * num_tiles_scaler);
                     } else {
+                        // If we're not a second stage reader (i.e. we're not in the top
+                        // row of cores), we don't do any additional combines, so we just
+                        // do a dummy push so that we move in lockstep with the other cores
                         cb_external_obj.reserve_back((num_blocks_second_stage - 1) * num_tiles_scaler);
                         cb_external_obj.push_back((num_blocks_second_stage - 1) * num_tiles_scaler);
                     }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln.cpp
@@ -176,6 +176,7 @@ void kernel_main() {
                         }
 
                         cb_external_obj.reserve_back((num_blocks_second_stage - 1) * num_tiles_scaler);
+                        write_offset = 0;
                         for (uint32_t block = 0; block < num_blocks_second_stage - 1; ++block) {
                             noc.async_read<experimental::Noc::TxnIdMode::DISABLED, NOC_MAX_BURST_SIZE>(
                                 remote_ep,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln_post_allgather.cpp
@@ -5,24 +5,23 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
+#include "experimental/noc_semaphore.h"
+#include "experimental/circular_buffer.h"
 
 // split REDUCE across cores
 void kernel_main() {
-    uint32_t reduce_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(1));
     constexpr uint32_t block_h = get_compile_time_arg_val(3);
     constexpr bool rms_norm = get_compile_time_arg_val(15) == 1;
 
-    constexpr uint32_t cb_ex_global = tt::CBIndex::c_15;  // [E[x], E[X^2]] global to all cores
+    constexpr uint32_t cb_ex_global = tt::CBIndex::c_15;
 
     constexpr uint32_t stats_tiles = rms_norm ? 1 : 2;
 
-    volatile tt_l1_ptr uint32_t* reduce_sender_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_sender_semaphore_addr);
+    experimental::Semaphore<> reduce_sender_sem(get_compile_time_arg_val(1));
+    experimental::CircularBuffer cb_ex_global_obj(cb_ex_global);
 
-    // inc mcast sender
-    noc_semaphore_set(reduce_sender_semaphore_addr_ptr, INVALID);
-    // inc remote sem
-    cb_reserve_back(cb_ex_global, stats_tiles * block_h);
-    noc_semaphore_wait(reduce_sender_semaphore_addr_ptr, VALID);
-    cb_push_back(cb_ex_global, stats_tiles * block_h);
+    reduce_sender_sem.set(INVALID);
+    cb_ex_global_obj.reserve_back(stats_tiles * block_h);
+    reduce_sender_sem.wait(VALID);
+    cb_ex_global_obj.push_back(stats_tiles * block_h);
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln_pre_allgather.cpp
@@ -170,12 +170,14 @@ void kernel_main() {
                 noc.async_read_barrier();
                 cb_external_obj.push_back(num_tiles_per_partial_result * num_blocks_first_stage);
 
+                // read data from other cores - reduce first stage
                 if constexpr (use_two_stage_reduce) {
-                    if (is_second_stage_reader) {
+                    if (is_second_stage_reader) {  // gather data from a column of cores (if row major)
                         if (i == 0) {
                             reduce_second_stage_sem.wait(num_blocks_second_stage - 1);
                             reduce_second_stage_sem.set(0);
                         }
+                        // read data from other cores - second stage reduce
 
                         write_offset = 0;
                         for (uint32_t block = 0; block < num_blocks_second_stage - 1; ++block) {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln_pre_allgather.cpp
@@ -5,11 +5,18 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/noc_semaphore.h"
+#include "experimental/endpoints.h"
+
+struct RemoteCoord {
+    uint32_t x;
+    uint32_t y;
+};
 
 // split REDUCE across cores
 void kernel_main() {
-    uint32_t reduce_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(0));
-    uint32_t reduce_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(1));
     constexpr uint32_t num_blocks = get_compile_time_arg_val(2);
     constexpr uint32_t block_h = get_compile_time_arg_val(3);
     const bool is_all_to_all_worker = get_compile_time_arg_val(4) == 1;
@@ -22,7 +29,6 @@ void kernel_main() {
     constexpr bool use_two_stage_reduce = (bool)get_compile_time_arg_val(11);
     constexpr uint32_t num_blocks_first_stage = get_compile_time_arg_val(12);
     constexpr uint32_t num_blocks_second_stage = get_compile_time_arg_val(13);
-    uint32_t reduce_second_stage_semaphore_addr = get_semaphore(get_compile_time_arg_val(14));
     constexpr bool rms_norm = get_compile_time_arg_val(15) == 1;
 
     const bool is_last_all_to_all_worker = get_arg_val<uint32_t>(0);
@@ -35,20 +41,26 @@ void kernel_main() {
 
     const uint32_t num_tiles_to_read = is_last_all_to_all_worker ? num_tiles_per_worker_last : num_tiles_per_worker;
 
-    constexpr uint32_t cb_ex_partial2 = tt::CBIndex::c_11;  // E[(x-E[x])^2] partial reduce
-    constexpr uint32_t cb_ex2 = tt::CBIndex::c_12;          // E[(x-E[x])^2] global reduce
+    constexpr uint32_t cb_ex_partial2 = tt::CBIndex::c_11;
+    constexpr uint32_t cb_ex2 = tt::CBIndex::c_12;
     constexpr uint32_t cb_ex_external2 = tt::CBIndex::c_13;
 
-    const uint32_t single_tile_size_bytes = get_tile_size(cb_ex_partial2);  // tile size
-    const DataFormat data_format = get_dataformat(cb_ex_partial2);          // data format
+    experimental::Noc noc;
+    experimental::Semaphore<> reduce_receiver_sem(get_compile_time_arg_val(0));
+    experimental::Semaphore<> reduce_sender_sem(get_compile_time_arg_val(1));
+    experimental::Semaphore<> reduce_second_stage_sem(get_compile_time_arg_val(14));
+    experimental::UnicastEndpoint remote_ep;
 
-    uint64_t remote_noc_addrs_first_stage[is_all_to_all_worker ? num_blocks_first_stage : 1];
-    uint64_t remote_noc_addrs_second_stage[is_all_to_all_worker ? num_blocks_second_stage : 1];
+    const uint32_t single_tile_size_bytes = get_tile_size(cb_ex_partial2);
+    const DataFormat data_format = get_dataformat(cb_ex_partial2);
+
+    RemoteCoord remote_coords_first_stage[is_all_to_all_worker ? num_blocks_first_stage : 1];
+    RemoteCoord remote_coords_second_stage[is_all_to_all_worker ? num_blocks_second_stage : 1];
     if constexpr (is_all_to_all_worker) {
         if constexpr (use_two_stage_reduce) {
             uint32_t x = start_x, y = start_y;
             for (uint32_t i = 0; i < num_blocks_first_stage; ++i) {
-                remote_noc_addrs_first_stage[i] = get_noc_addr(in0_remote_noc_x[x], in0_remote_noc_y[y], 0);
+                remote_coords_first_stage[i] = {in0_remote_noc_x[x], in0_remote_noc_y[y]};
                 if constexpr (row_major) {
                     ++x;
                     if (x == num_x) {
@@ -69,7 +81,7 @@ void kernel_main() {
                 y = start_y;
             }
             for (uint32_t i = 0; i < num_blocks_second_stage; ++i) {
-                remote_noc_addrs_second_stage[i] = get_noc_addr(in0_remote_noc_x[x], in0_remote_noc_y[y], 0);
+                remote_coords_second_stage[i] = {in0_remote_noc_x[x], in0_remote_noc_y[y]};
                 if constexpr (row_major) {
                     ++y;
                 } else {
@@ -79,7 +91,7 @@ void kernel_main() {
         } else {
             uint32_t x = start_x, y = start_y;
             for (uint32_t i = 0; i < num_blocks; ++i) {
-                remote_noc_addrs_first_stage[i] = get_noc_addr(in0_remote_noc_x[x], in0_remote_noc_y[y], 0);
+                remote_coords_first_stage[i] = {in0_remote_noc_x[x], in0_remote_noc_y[y]};
                 if constexpr (row_major) {
                     ++x;
                     if (x == num_x) {
@@ -102,97 +114,91 @@ void kernel_main() {
             }
         }
     } else {
-        remote_noc_addrs_first_stage[0] = get_noc_addr(in0_remote_noc_x[0], in0_remote_noc_y[0], 0);
-        remote_noc_addrs_second_stage[0] = get_noc_addr(in0_remote_noc_x[0], in0_remote_noc_y[0], 0);
+        remote_coords_first_stage[0] = {in0_remote_noc_x[0], in0_remote_noc_y[0]};
+        remote_coords_second_stage[0] = {in0_remote_noc_x[0], in0_remote_noc_y[0]};
     }
 
-    volatile tt_l1_ptr uint32_t* reduce_receiver_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_receiver_semaphore_addr);
-    volatile tt_l1_ptr uint32_t* reduce_sender_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_sender_semaphore_addr);
-    volatile tt_l1_ptr uint32_t* reduce_second_stage_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_second_stage_semaphore_addr);
+    const auto& global_reduce_receiver = [&](const uint32_t cb_partial_id,
+                                             const uint32_t cb_external_id,
+                                             const uint32_t cb_reduce_first_stage_id) __attribute__((always_inline)) {
+        experimental::CircularBuffer cb_partial_obj(cb_partial_id);
+        experimental::CircularBuffer cb_external_obj(cb_external_id);
+        experimental::CircularBuffer cb_reduce_first_stage_obj(cb_reduce_first_stage_id);
 
-    const uint64_t reduce_receiver_semaphore_noc_addr =
-        get_noc_addr(in0_remote_noc_x[0], in0_remote_noc_y[0], reduce_receiver_semaphore_addr);
-    const uint64_t reduce_second_stage_receiver_semaphore_noc_addr =
-        remote_noc_addrs_second_stage[0] | reduce_second_stage_semaphore_addr;
-
-    const auto& global_reduce_receiver = [&](const uint32_t cb_partial,
-                                             const uint32_t cb_external,
-                                             const uint32_t cb_reduce_first_stage) __attribute__((always_inline)) {
         uint32_t num_tiles_per_partial_result = 2;
         if constexpr (rms_norm) {
             num_tiles_per_partial_result = 1;
         }
-        // global reduce
-        // wait for local data ready
-        cb_wait_front(cb_partial, num_tiles_per_partial_result * block_h);  // two tiles * block_h
 
-        // inc mcast sender
-        noc_semaphore_set(reduce_sender_semaphore_addr_ptr, INVALID);
-        noc_semaphore_inc(reduce_receiver_semaphore_noc_addr, 1);
-        noc_semaphore_wait(reduce_sender_semaphore_addr_ptr, VALID);
+        cb_partial_obj.wait_front(num_tiles_per_partial_result * block_h);
+
+        reduce_sender_sem.set(INVALID);
+        reduce_receiver_sem.up(noc, in0_remote_noc_x[0], in0_remote_noc_y[0], 1);
+        reduce_sender_sem.wait(VALID);
 
         if constexpr (is_all_to_all_worker) {
-            // read data from other cores - reduce first stage
-            uint32_t l1_read_addr_ex_par = get_read_ptr(cb_partial);
+            uint32_t l1_read_addr_ex_par = cb_partial_obj.get_read_ptr();
             l1_read_addr_ex_par += all_to_all_tile_offset_bytes;
-            // read data from other cores - second stage reduce
             uint32_t l1_read_addr_ex = 0;
             uint32_t block_index_stride = 0;
             if constexpr (use_two_stage_reduce) {
-                l1_read_addr_ex = get_read_ptr(cb_reduce_first_stage);
+                l1_read_addr_ex = cb_reduce_first_stage_obj.get_read_ptr();
                 if constexpr (row_major) {
                     block_index_stride = num_x;
                 } else {
                     block_index_stride = num_y;
                 }
             }
+            uint32_t write_offset = 0;
             for (uint32_t i = 0; i < num_tiles_to_read; i++) {
-                cb_reserve_back(cb_external, num_tiles_per_partial_result * num_blocks_first_stage);
-                uint32_t l1_write_addr_external = get_write_ptr(cb_external);
+                cb_external_obj.reserve_back(num_tiles_per_partial_result * num_blocks_first_stage);
+                write_offset = 0;
                 for (uint32_t block = 0; block < num_blocks_first_stage; block++) {
-                    for (uint32_t tile_idx = 0; tile_idx < num_tiles_per_partial_result;
-                         tile_idx++) {  // loops over Sum(X), Sum(X2) --> 2x
-                        uint64_t noc_addr_ex_par =
-                            remote_noc_addrs_first_stage[block] |
-                            (l1_read_addr_ex_par +
-                             tile_idx * single_tile_size_bytes);  // Updating read address for reading SUm(X) and
-                                                                  // Sum(X2) per core
-                        noc_async_read_one_packet(noc_addr_ex_par, l1_write_addr_external, single_tile_size_bytes);
-                        l1_write_addr_external += single_tile_size_bytes;
+                    for (uint32_t tile_idx = 0; tile_idx < num_tiles_per_partial_result; tile_idx++) {
+                        noc.async_read<experimental::Noc::TxnIdMode::DISABLED, NOC_MAX_BURST_SIZE>(
+                            remote_ep,
+                            cb_external_obj,
+                            single_tile_size_bytes,
+                            {.noc_x = remote_coords_first_stage[block].x,
+                             .noc_y = remote_coords_first_stage[block].y,
+                             .addr = l1_read_addr_ex_par + tile_idx * single_tile_size_bytes},
+                            {.offset_bytes = write_offset});
+                        write_offset += single_tile_size_bytes;
                     }
                 }
                 l1_read_addr_ex_par += single_tile_size_bytes;
-                noc_async_read_barrier();
-                cb_push_back(cb_external, num_tiles_per_partial_result * num_blocks_first_stage);
+                noc.async_read_barrier();
+                cb_external_obj.push_back(num_tiles_per_partial_result * num_blocks_first_stage);
 
-                // read data from other cores - reduce first stage
                 if constexpr (use_two_stage_reduce) {
-                    if (is_second_stage_reader) {  // gather data from a column of cores (if row major)
+                    if (is_second_stage_reader) {
                         if (i == 0) {
-                            noc_semaphore_wait(reduce_second_stage_semaphore_addr_ptr, num_blocks_second_stage - 1);
-                            noc_semaphore_set(reduce_second_stage_semaphore_addr_ptr, 0);
+                            reduce_second_stage_sem.wait(num_blocks_second_stage - 1);
+                            reduce_second_stage_sem.set(0);
                         }
-                        // read data from other cores - second stage reduce
+
                         for (uint32_t block = 0; block < num_blocks_second_stage - 1; ++block) {
-                            uint64_t noc_addr_ex = remote_noc_addrs_second_stage[block + 1] | l1_read_addr_ex;
-                            noc_async_read_one_packet(noc_addr_ex, l1_write_addr_external, single_tile_size_bytes);
-                            l1_write_addr_external += single_tile_size_bytes;
+                            noc.async_read<experimental::Noc::TxnIdMode::DISABLED, NOC_MAX_BURST_SIZE>(
+                                remote_ep,
+                                cb_external_obj,
+                                single_tile_size_bytes,
+                                {.noc_x = remote_coords_second_stage[block + 1].x,
+                                 .noc_y = remote_coords_second_stage[block + 1].y,
+                                 .addr = l1_read_addr_ex},
+                                {.offset_bytes = write_offset});
+                            write_offset += single_tile_size_bytes;
                         }
                         l1_read_addr_ex += single_tile_size_bytes;
-                        noc_async_read_barrier();
-                        cb_push_back(cb_external, num_blocks_second_stage - 1);
+                        noc.async_read_barrier();
+                        cb_external_obj.push_back(num_blocks_second_stage - 1);
                     }
                 }
             }
 
-            // sync with the gather worker
-            cb_wait_front(cb_reduce_first_stage, num_tiles_per_partial_result * num_tiles_to_read);
-            noc_semaphore_inc(reduce_second_stage_receiver_semaphore_noc_addr, 1);
+            cb_reduce_first_stage_obj.wait_front(num_tiles_per_partial_result * num_tiles_to_read);
+            reduce_second_stage_sem.up(noc, remote_coords_second_stage[0].x, remote_coords_second_stage[0].y, 1);
         }
     };
     global_reduce_receiver(cb_ex_partial2, cb_ex_external2, cb_ex2);
-    noc_async_atomic_barrier();
+    noc.async_atomic_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln_pre_allgather.cpp
@@ -177,6 +177,7 @@ void kernel_main() {
                             reduce_second_stage_sem.set(0);
                         }
 
+                        write_offset = 0;
                         for (uint32_t block = 0; block < num_blocks_second_stage - 1; ++block) {
                             noc.async_read<experimental::Noc::TxnIdMode::DISABLED, NOC_MAX_BURST_SIZE>(
                                 remote_ep,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln.cpp
@@ -6,6 +6,8 @@
 #include "api/dataflow/dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
 #include "layernorm_dataflow_utils.h"
+#include "experimental/noc_semaphore.h"
+#include "experimental/endpoints.h"
 
 namespace df = norm::layernorm::device::kernels::dataflow;
 
@@ -36,8 +38,6 @@ void kernel_main() {
     // ---------------------------------------------------------------------------
     // Compile-time arguments
     // ---------------------------------------------------------------------------
-    uint32_t reduce_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(0));
-    uint32_t reduce_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(1));
     constexpr uint32_t num_blocks = get_compile_time_arg_val(2);
     constexpr uint32_t block_h = get_compile_time_arg_val(3);
     constexpr uint32_t block_h_size_bytes = get_compile_time_arg_val(4);
@@ -52,7 +52,6 @@ void kernel_main() {
     constexpr bool use_two_stage_reduce = (bool)get_compile_time_arg_val(13);
     constexpr uint32_t num_blocks_first_stage = get_compile_time_arg_val(14);
     constexpr uint32_t num_blocks_second_stage = get_compile_time_arg_val(15);
-    uint32_t reduce_second_stage_semaphore_addr = get_semaphore(get_compile_time_arg_val(16));
     constexpr bool rms_norm = get_compile_time_arg_val(17) == 1;
     constexpr bool use_welford = get_compile_time_arg_val(18) == 1;
 
@@ -82,76 +81,65 @@ void kernel_main() {
     constexpr uint32_t cb_ex_global = tt::CBIndex::c_15;  // E[x] global reduce
 
     // ---------------------------------------------------------------------------
-    // Set up constants for the kernel
+    // Set up experimental API objects
     // ---------------------------------------------------------------------------
+    experimental::Noc noc;
+    experimental::Semaphore<> reduce_receiver_sem(get_compile_time_arg_val(0));
+    experimental::Semaphore<> reduce_sender_sem(get_compile_time_arg_val(1));
+    experimental::Semaphore<> reduce_second_stage_sem(get_compile_time_arg_val(16));
+    experimental::UnicastEndpoint remote_ep;
+    experimental::MulticastEndpoint mcast_ep;
+
     const uint32_t single_tile_size_bytes = get_tile_size(rms_norm ? cb_ex_partial2 : cb_ex_partial);
 
-    // Compute the NOC addresses for remote cores that interact with this core
-    df::RemoteNocAddrs<num_blocks> remote_noc_addrs{};
+    // Compute the NOC coordinates for remote cores that interact with this core
+    df::RemoteNocCoords<num_blocks> remote_coords{};
     df::compute_single_stage_noc_addrs<row_major, num_blocks>(
-        remote_noc_addrs, in0_remote_noc_x, in0_remote_noc_y, start_x, start_y, num_x, num_y);
-
-    const uint64_t multicast_data_noc = get_noc_multicast_addr(
-        mcast_dest_noc_start_x, mcast_dest_noc_start_y, mcast_dest_noc_end_x, mcast_dest_noc_end_y, 0);
-
-    const uint64_t reduce_sender_semaphore_noc_addr = multicast_data_noc | reduce_sender_semaphore_addr;
-
-    volatile tt_l1_ptr uint32_t* reduce_sender_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_sender_semaphore_addr);
-    volatile tt_l1_ptr uint32_t* reduce_receiver_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_receiver_semaphore_addr);
-    volatile tt_l1_ptr uint32_t* reduce_second_stage_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_second_stage_semaphore_addr);
+        remote_coords, in0_remote_noc_x, in0_remote_noc_y, start_x, start_y, num_x, num_y);
 
     // ============================================================================
     // Main kernel worker function
-    // Performs partial reduction for its assigned tiles, coordinates
-    // the waiting on partial and combined results for all cores, and performs
-    // the multicast of the final results to all cores
     // ============================================================================
-    const auto& global_reduce_sender = [&](const uint32_t cb_partial,
-                                           const uint32_t cb_external,
-                                           const uint32_t cb_ex,
-                                           const uint32_t cb_ex_global,
-                                           const uint32_t cb_reduce_first_stage,
+    const auto& global_reduce_sender = [&](const uint32_t cb_partial_id,
+                                           const uint32_t cb_external_id,
+                                           const uint32_t cb_ex_id,
+                                           const uint32_t cb_ex_global_id,
+                                           const uint32_t cb_reduce_first_stage_id,
                                            const uint32_t num_tiles_scaler) __attribute__((always_inline)) {
+        experimental::CircularBuffer cb_partial_obj(cb_partial_id);
+        experimental::CircularBuffer cb_external_obj(cb_external_id);
+        experimental::CircularBuffer cb_ex_obj(cb_ex_id);
+        experimental::CircularBuffer cb_ex_global_obj(cb_ex_global_id);
+        experimental::CircularBuffer cb_reduce_first_stage_obj(cb_reduce_first_stage_id);
+
         // ============================================================================
         // Partial reduction
-        // Partials stored `cb_partial`
         // ============================================================================
 
-        // Wait for this core's partial results to be ready
-        cb_wait_front(cb_partial, block_h * num_tiles_scaler);
+        cb_partial_obj.wait_front(block_h * num_tiles_scaler);
 
-        // Wait for partial results from the other cores to be ready.
-        // Once all cores finish partials, notify the cores to
-        // start reading remote data and doing their global combines
         if constexpr (num_blocks > 1) {
-            *reduce_sender_semaphore_addr_ptr = VALID;
-            noc_semaphore_wait(reduce_receiver_semaphore_addr_ptr, num_blocks - 1);
-            noc_semaphore_set(reduce_receiver_semaphore_addr_ptr, 0);
-            noc_semaphore_set_multicast(reduce_sender_semaphore_addr, reduce_sender_semaphore_noc_addr, num_blocks - 1);
+            reduce_sender_sem.set(VALID);
+            reduce_receiver_sem.wait(num_blocks - 1);
+            reduce_receiver_sem.set(0);
+            reduce_sender_sem.set_multicast(
+                noc,
+                mcast_dest_noc_start_x,
+                mcast_dest_noc_start_y,
+                mcast_dest_noc_end_x,
+                mcast_dest_noc_end_y,
+                num_blocks - 1);
         }
 
         // ============================================================================
         // Combine partial results
-        // Read from the partial buffers into the external buffer `cb_external`.
-        // Will read a total of:
-        // (num_blocks_first_stage + num_blocks_second_stage - 1) * num_tiles_scaler
-        // tiles for each assigned tile row (or column, if not row-major).
-        // For the second stage, read from `cb_reduce_first_stage` instead of `cb_partial`,
-        // as it will contain the combined results from the first stage.
-        // Combined results written to `cb_ex`.
         // ============================================================================
 
-        // ---------------------------------------------------------------------------
-        // Read remote partial data
-        // ---------------------------------------------------------------------------
-        uint32_t l1_read_addr_ex_par = get_read_ptr(cb_partial);
+        uint32_t l1_read_addr_ex_par = cb_partial_obj.get_read_ptr();
         uint32_t l1_read_addr_ex = 0;
         uint32_t block_index_stride = 0;
         if constexpr (use_two_stage_reduce) {
-            l1_read_addr_ex = get_read_ptr(cb_reduce_first_stage);
+            l1_read_addr_ex = cb_reduce_first_stage_obj.get_read_ptr();
             if constexpr (row_major) {
                 block_index_stride = num_x;
             } else {
@@ -159,44 +147,44 @@ void kernel_main() {
             }
         }
         for (uint32_t i = 0; i < num_tiles_per_worker; ++i) {
-            // Read in the partials from the cores in the same row
-            cb_reserve_back(cb_external, num_blocks_first_stage * num_tiles_scaler);
-            uint32_t l1_write_addr_external = get_write_ptr(cb_external);
+            cb_external_obj.reserve_back(num_blocks_first_stage * num_tiles_scaler);
+            uint32_t write_offset = 0;
             for (uint32_t block = 0; block < num_blocks_first_stage; ++block) {
-                uint64_t noc_addr_ex_par = remote_noc_addrs[block] | l1_read_addr_ex_par;
-                noc_async_read_one_packet(
-                    noc_addr_ex_par, l1_write_addr_external, num_tiles_scaler * single_tile_size_bytes);
-                l1_write_addr_external += num_tiles_scaler * single_tile_size_bytes;
+                noc.async_read<experimental::Noc::TxnIdMode::DISABLED, NOC_MAX_BURST_SIZE>(
+                    remote_ep,
+                    cb_external_obj,
+                    num_tiles_scaler * single_tile_size_bytes,
+                    {.noc_x = remote_coords[block].x, .noc_y = remote_coords[block].y, .addr = l1_read_addr_ex_par},
+                    {.offset_bytes = write_offset});
+                write_offset += num_tiles_scaler * single_tile_size_bytes;
             }
             l1_read_addr_ex_par += num_tiles_scaler * single_tile_size_bytes;
-            noc_async_read_barrier();
-            cb_push_back(cb_external, num_blocks_first_stage * num_tiles_scaler);
+            noc.async_read_barrier();
+            cb_external_obj.push_back(num_blocks_first_stage * num_tiles_scaler);
 
-            // ---------------------------------------------------------------------------
-            // Handle the two-stage reduce
-            // ---------------------------------------------------------------------------
             if constexpr (use_two_stage_reduce) {
-                // Wait for the signal to read in the combined results from
-                // the first stage (from cores in our core column) are ready
                 if (i == 0) {
-                    noc_semaphore_wait(reduce_second_stage_semaphore_addr_ptr, num_blocks_second_stage - 1);
-                    noc_semaphore_set(reduce_second_stage_semaphore_addr_ptr, 0);
+                    reduce_second_stage_sem.wait(num_blocks_second_stage - 1);
+                    reduce_second_stage_sem.set(0);
                 }
 
-                // Read in the combined results from the cores in our column
-                // into the external buffer
                 uint32_t curr_block_index = block_index_stride;
-                cb_reserve_back(cb_external, (num_blocks_second_stage - 1) * num_tiles_scaler);
+                cb_external_obj.reserve_back((num_blocks_second_stage - 1) * num_tiles_scaler);
                 for (uint32_t block = 0; block < num_blocks_second_stage - 1; ++block) {
-                    uint64_t noc_addr_ex = remote_noc_addrs[curr_block_index] | l1_read_addr_ex;
-                    noc_async_read_one_packet(
-                        noc_addr_ex, l1_write_addr_external, num_tiles_scaler * single_tile_size_bytes);
+                    noc.async_read<experimental::Noc::TxnIdMode::DISABLED, NOC_MAX_BURST_SIZE>(
+                        remote_ep,
+                        cb_external_obj,
+                        num_tiles_scaler * single_tile_size_bytes,
+                        {.noc_x = remote_coords[curr_block_index].x,
+                         .noc_y = remote_coords[curr_block_index].y,
+                         .addr = l1_read_addr_ex},
+                        {.offset_bytes = write_offset});
                     curr_block_index += block_index_stride;
-                    l1_write_addr_external += num_tiles_scaler * single_tile_size_bytes;
+                    write_offset += num_tiles_scaler * single_tile_size_bytes;
                 }
                 l1_read_addr_ex += num_tiles_scaler * single_tile_size_bytes;
-                noc_async_read_barrier();
-                cb_push_back(cb_external, (num_blocks_second_stage - 1) * num_tiles_scaler);
+                noc.async_read_barrier();
+                cb_external_obj.push_back((num_blocks_second_stage - 1) * num_tiles_scaler);
             }
         }
 
@@ -204,61 +192,80 @@ void kernel_main() {
         // Wait for all final combined results to be ready
         // ---------------------------------------------------------------------------
 
-        // Our results
-        cb_wait_front(cb_ex, num_tiles_per_worker * num_tiles_scaler);
+        cb_ex_obj.wait_front(num_tiles_per_worker * num_tiles_scaler);
 
-        // Other cores' results
         if constexpr (num_all_to_all_workers_first_stage > 1) {
-            noc_semaphore_wait(reduce_receiver_semaphore_addr_ptr, num_all_to_all_workers_first_stage - 1);
-            noc_semaphore_set(reduce_receiver_semaphore_addr_ptr, 0);
+            reduce_receiver_sem.wait(num_all_to_all_workers_first_stage - 1);
+            reduce_receiver_sem.set(0);
         }
 
         // ============================================================================
         // Gather all final combined results and multicast to all cores.
-        // Read from `cb_ex` into `cb_ex_global`, multicast `cb_ex_global` to all cores
         // ============================================================================
 
-        // Gather final results
-        l1_read_addr_ex = get_read_ptr(cb_ex);
-        uint32_t l1_write_addr_ex_global = get_write_ptr(cb_ex_global);
-        cb_reserve_back(cb_ex_global, block_h * num_tiles_scaler);
+        uint32_t l1_read_addr_ex_remote = cb_ex_obj.get_read_ptr();
+        cb_ex_global_obj.reserve_back(block_h * num_tiles_scaler);
+        uint32_t gather_write_offset = 0;
         for (uint32_t block = 0; block < num_all_to_all_workers_first_stage; ++block) {
-            uint64_t noc_addr_ex = remote_noc_addrs[block] | l1_read_addr_ex;
             uint32_t num_tiles_bytes = block == num_all_to_all_workers_first_stage - 1 ? num_tiles_per_worker_last_bytes
                                                                                        : num_tiles_per_worker_bytes;
-            noc_async_read(noc_addr_ex, l1_write_addr_ex_global, num_tiles_scaler * num_tiles_bytes);
-            l1_write_addr_ex_global += num_tiles_scaler * num_tiles_bytes;
+            if constexpr (num_tiles_per_worker_bytes <= NOC_MAX_BURST_SIZE) {
+                noc.async_read<experimental::Noc::TxnIdMode::DISABLED, NOC_MAX_BURST_SIZE>(
+                    remote_ep,
+                    cb_ex_global_obj,
+                    num_tiles_scaler * num_tiles_bytes,
+                    {.noc_x = remote_coords[block].x, .noc_y = remote_coords[block].y, .addr = l1_read_addr_ex_remote},
+                    {.offset_bytes = gather_write_offset});
+            } else {
+                noc.async_read(
+                    remote_ep,
+                    cb_ex_global_obj,
+                    num_tiles_scaler * num_tiles_bytes,
+                    {.noc_x = remote_coords[block].x, .noc_y = remote_coords[block].y, .addr = l1_read_addr_ex_remote},
+                    {.offset_bytes = gather_write_offset});
+            }
+            gather_write_offset += num_tiles_scaler * num_tiles_bytes;
         }
-        noc_async_read_barrier();
+        noc.async_read_barrier();
 
-        // Multicast
-        uint32_t l1_read_addr_ex_global = get_read_ptr(cb_ex_global);
-        cb_push_back(cb_ex_global, block_h * num_tiles_scaler);
+        uint32_t l1_read_addr_ex_global = cb_ex_global_obj.get_read_ptr();
+        cb_ex_global_obj.push_back(block_h * num_tiles_scaler);
         if constexpr (num_blocks > 1) {
+            uint32_t mcast_src_offset = 0;
             for (uint32_t block = 0; block < num_all_to_all_workers_first_stage; ++block) {
-                *reduce_sender_semaphore_addr_ptr = block + 2;
+                reduce_sender_sem.set(block + 2);
 
                 uint32_t num_tiles_bytes = block == num_all_to_all_workers_first_stage - 1
                                                ? num_tiles_per_worker_last_bytes
                                                : num_tiles_per_worker_bytes;
 
-                noc_async_write_multicast(
-                    l1_read_addr_ex_global,
-                    multicast_data_noc | l1_read_addr_ex_global,
+                noc.async_write_multicast(
+                    cb_ex_global_obj,
+                    mcast_ep,
                     num_tiles_scaler * num_tiles_bytes,
                     num_blocks - 1,
+                    {.offset_bytes = mcast_src_offset},
+                    {.noc_x_start = mcast_dest_noc_start_x,
+                     .noc_y_start = mcast_dest_noc_start_y,
+                     .noc_x_end = mcast_dest_noc_end_x,
+                     .noc_y_end = mcast_dest_noc_end_y,
+                     .addr = l1_read_addr_ex_global + mcast_src_offset},
                     true);
-                noc_semaphore_set_multicast(
-                    reduce_sender_semaphore_addr, reduce_sender_semaphore_noc_addr, num_blocks - 1);
+                reduce_sender_sem.set_multicast(
+                    noc,
+                    mcast_dest_noc_start_x,
+                    mcast_dest_noc_start_y,
+                    mcast_dest_noc_end_x,
+                    mcast_dest_noc_end_y,
+                    num_blocks - 1);
 
-                l1_read_addr_ex_global += num_tiles_scaler * num_tiles_bytes;
-                noc_async_write_barrier();
+                mcast_src_offset += num_tiles_scaler * num_tiles_bytes;
+                noc.async_write_barrier();
             }
         }
     };
 
     if constexpr (!rms_norm) {
-        // Welford processes 2 tiles at a time (mean and var)
         global_reduce_sender(cb_ex_partial, cb_ex_external, cb_ex, cb_ex_global, cb_ex, use_welford ? 2 : 1);
     }
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln.cpp
@@ -170,6 +170,7 @@ void kernel_main() {
 
                 uint32_t curr_block_index = block_index_stride;
                 cb_external_obj.reserve_back((num_blocks_second_stage - 1) * num_tiles_scaler);
+                write_offset = 0;
                 for (uint32_t block = 0; block < num_blocks_second_stage - 1; ++block) {
                     noc.async_read<experimental::Noc::TxnIdMode::DISABLED, NOC_MAX_BURST_SIZE>(
                         remote_ep,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln.cpp
@@ -99,6 +99,9 @@ void kernel_main() {
 
     // ============================================================================
     // Main kernel worker function
+    // Performs partial reduction for its assigned tiles, coordinates
+    // the waiting on partial and combined results for all cores, and performs
+    // the multicast of the final results to all cores
     // ============================================================================
     const auto& global_reduce_sender = [&](const uint32_t cb_partial_id,
                                            const uint32_t cb_external_id,
@@ -133,8 +136,18 @@ void kernel_main() {
 
         // ============================================================================
         // Combine partial results
+        // Read from the partial buffers into the external buffer `cb_external`.
+        // Will read a total of:
+        // (num_blocks_first_stage + num_blocks_second_stage - 1) * num_tiles_scaler
+        // tiles for each assigned tile row (or column, if not row-major).
+        // For the second stage, read from `cb_reduce_first_stage` instead of `cb_partial`,
+        // as it will contain the combined results from the first stage.
+        // Combined results written to `cb_ex`.
         // ============================================================================
 
+        // ---------------------------------------------------------------------------
+        // Read remote partial data
+        // ---------------------------------------------------------------------------
         uint32_t l1_read_addr_ex_par = cb_partial_obj.get_read_ptr();
         uint32_t l1_read_addr_ex = 0;
         uint32_t block_index_stride = 0;
@@ -162,6 +175,9 @@ void kernel_main() {
             noc.async_read_barrier();
             cb_external_obj.push_back(num_blocks_first_stage * num_tiles_scaler);
 
+            // ---------------------------------------------------------------------------
+            // Handle the two-stage reduce
+            // ---------------------------------------------------------------------------
             if constexpr (use_two_stage_reduce) {
                 if (i == 0) {
                     reduce_second_stage_sem.wait(num_blocks_second_stage - 1);
@@ -202,6 +218,7 @@ void kernel_main() {
 
         // ============================================================================
         // Gather all final combined results and multicast to all cores.
+        // Read from `cb_ex` into `cb_ex_global`, multicast `cb_ex_global` to all cores
         // ============================================================================
 
         uint32_t l1_read_addr_ex_remote = cb_ex_obj.get_read_ptr();

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_post_allgather.cpp
@@ -5,10 +5,13 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/noc_semaphore.h"
+#include "experimental/endpoints.h"
 
 // split REDUCE across cores
 void kernel_main() {
-    uint32_t reduce_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(1));
     constexpr uint32_t num_blocks = get_compile_time_arg_val(2);
     constexpr uint32_t block_h = get_compile_time_arg_val(3);
     constexpr uint32_t block_h_size_bytes = get_compile_time_arg_val(4);
@@ -21,42 +24,53 @@ void kernel_main() {
     const uint32_t mcast_dest_noc_end_x = get_arg_val<uint32_t>(2);
     const uint32_t mcast_dest_noc_end_y = get_arg_val<uint32_t>(3);
 
-    constexpr uint32_t cb_stats_reduced = tt::CBIndex::c_21;  // [E[x], E[x^2]] local to sender
-    constexpr uint32_t cb_ex_global = tt::CBIndex::c_15;      // [E[x], E[X^2]] global to all cores
+    constexpr uint32_t cb_stats_reduced = tt::CBIndex::c_21;
+    constexpr uint32_t cb_ex_global = tt::CBIndex::c_15;
 
-    const uint64_t multicast_data_noc = get_noc_multicast_addr(
-        mcast_dest_noc_start_x, mcast_dest_noc_start_y, mcast_dest_noc_end_x, mcast_dest_noc_end_y, 0);
+    experimental::Noc noc;
+    experimental::Semaphore<> reduce_sender_sem(get_compile_time_arg_val(1));
+    experimental::CircularBuffer cb_stats_reduced_obj(cb_stats_reduced);
+    experimental::CircularBuffer cb_ex_global_obj(cb_ex_global);
+    experimental::MulticastEndpoint mcast_ep;
 
-    const uint64_t reduce_sender_semaphore_noc_addr = multicast_data_noc | reduce_sender_semaphore_addr;
     constexpr uint32_t stats_tiles = rms_norm ? 1 : 2;
 
-    volatile tt_l1_ptr uint32_t* reduce_sender_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_sender_semaphore_addr);
     const auto& global_semaphore_set = [&]() __attribute__((always_inline)) {
-        *reduce_sender_semaphore_addr_ptr = VALID;
-
-        noc_semaphore_set_multicast_loopback_src(
-            reduce_sender_semaphore_addr, reduce_sender_semaphore_noc_addr, num_blocks, false);
-        noc_async_write_barrier();
-    };
-
-    const auto& global_reduce_sender = [&](const uint32_t cb_ex, const uint32_t cb_ex_global)
-        __attribute__((always_inline)) {
-        uint32_t l1_read_addr_ex = get_read_ptr(cb_ex);
-        uint32_t l1_read_addr_ex_global = get_read_ptr(cb_ex_global);
-        noc_async_write_multicast_loopback_src(
-            l1_read_addr_ex,
-            multicast_data_noc | l1_read_addr_ex_global,
-            stats_tiles * num_tiles_per_worker_bytes,
+        reduce_sender_sem.set(VALID);
+        reduce_sender_sem.set_multicast<experimental::Noc::McastMode::INCLUDE_SRC>(
+            noc,
+            mcast_dest_noc_start_x,
+            mcast_dest_noc_start_y,
+            mcast_dest_noc_end_x,
+            mcast_dest_noc_end_y,
             num_blocks,
             false);
-        noc_async_write_barrier();
+        noc.async_write_barrier();
     };
 
-    cb_wait_front(cb_stats_reduced, stats_tiles * block_h);
-    cb_reserve_back(cb_ex_global, block_h);
-    global_reduce_sender(cb_stats_reduced, cb_ex_global);
-    cb_push_back(cb_ex_global, stats_tiles * block_h);
-    cb_pop_front(cb_stats_reduced, stats_tiles * block_h);
+    const auto& global_reduce_sender =
+        [&](experimental::CircularBuffer& cb_ex_obj, experimental::CircularBuffer& cb_ex_global_obj_inner)
+            __attribute__((always_inline)) {
+                uint32_t l1_read_addr_ex_global = cb_ex_global_obj_inner.get_read_ptr();
+                noc.async_write_multicast<experimental::Noc::McastMode::INCLUDE_SRC>(
+                    cb_ex_obj,
+                    mcast_ep,
+                    stats_tiles * num_tiles_per_worker_bytes,
+                    num_blocks,
+                    {},
+                    {.noc_x_start = mcast_dest_noc_start_x,
+                     .noc_y_start = mcast_dest_noc_start_y,
+                     .noc_x_end = mcast_dest_noc_end_x,
+                     .noc_y_end = mcast_dest_noc_end_y,
+                     .addr = l1_read_addr_ex_global},
+                    false);
+                noc.async_write_barrier();
+            };
+
+    cb_stats_reduced_obj.wait_front(stats_tiles * block_h);
+    cb_ex_global_obj.reserve_back(block_h);
+    global_reduce_sender(cb_stats_reduced_obj, cb_ex_global_obj);
+    cb_ex_global_obj.push_back(stats_tiles * block_h);
+    cb_stats_reduced_obj.pop_front(stats_tiles * block_h);
     global_semaphore_set();
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_post_allgather.cpp
@@ -68,7 +68,7 @@ void kernel_main() {
             };
 
     cb_stats_reduced_obj.wait_front(stats_tiles * block_h);
-    cb_ex_global_obj.reserve_back(block_h);
+    cb_ex_global_obj.reserve_back(stats_tiles * block_h);
     global_reduce_sender(cb_stats_reduced_obj, cb_ex_global_obj);
     cb_ex_global_obj.push_back(stats_tiles * block_h);
     cb_stats_reduced_obj.pop_front(stats_tiles * block_h);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_post_allgather.cpp
@@ -24,8 +24,8 @@ void kernel_main() {
     const uint32_t mcast_dest_noc_end_x = get_arg_val<uint32_t>(2);
     const uint32_t mcast_dest_noc_end_y = get_arg_val<uint32_t>(3);
 
-    constexpr uint32_t cb_stats_reduced = tt::CBIndex::c_21;
-    constexpr uint32_t cb_ex_global = tt::CBIndex::c_15;
+    constexpr uint32_t cb_stats_reduced = tt::CBIndex::c_21;  // [E[x], E[x^2]] local to sender
+    constexpr uint32_t cb_ex_global = tt::CBIndex::c_15;      // [E[x], E[X^2]] global to all cores
 
     experimental::Noc noc;
     experimental::Semaphore<> reduce_sender_sem(get_compile_time_arg_val(1));

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_pre_allgather.cpp
@@ -126,7 +126,7 @@ void kernel_main() {
                 }
                 uint32_t write_offset = 0;
                 for (uint32_t i = 0; i < num_tiles_per_worker; ++i) {
-                    cb_external_obj.reserve_back(num_blocks_first_stage);
+                    cb_external_obj.reserve_back(num_tiles_per_partial_result * num_blocks_first_stage);
                     write_offset = 0;
                     for (uint32_t block = 0; block < num_blocks_first_stage; ++block) {
                         for (uint32_t tile_idx = 0; tile_idx < num_tiles_per_partial_result; ++tile_idx) {
@@ -153,6 +153,7 @@ void kernel_main() {
                         }
 
                         uint32_t curr_block_index = block_index_stride;
+                        cb_external_obj.reserve_back(num_tiles_per_partial_result * (num_blocks_second_stage - 1));
                         write_offset = 0;
                         for (uint32_t block = 0; block < num_blocks_second_stage - 1; ++block) {
                             for (uint32_t tile_idx = 0; tile_idx < num_tiles_per_partial_result; ++tile_idx) {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_pre_allgather.cpp
@@ -148,6 +148,7 @@ void kernel_main() {
                         }
 
                         uint32_t curr_block_index = block_index_stride;
+                        write_offset = 0;
                         for (uint32_t block = 0; block < num_blocks_second_stage - 1; ++block) {
                             for (uint32_t tile_idx = 0; tile_idx < num_tiles_per_partial_result; ++tile_idx) {
                                 noc.async_read<experimental::Noc::TxnIdMode::DISABLED, NOC_MAX_BURST_SIZE>(

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_pre_allgather.cpp
@@ -94,8 +94,11 @@ void kernel_main() {
                     num_tiles_per_partial_result = 1;
                 }
 
+                // global reduce
+                // wait for local data ready
                 cb_partial_obj.wait_front(num_tiles_per_partial_result * block_h);
 
+                // inc semaphore of other cores, tell other all-to-all workers to start
                 if constexpr (num_blocks > 1) {
                     reduce_sender_sem.set(VALID);
                     reduce_receiver_sem.wait(num_blocks - 1);
@@ -109,6 +112,7 @@ void kernel_main() {
                         num_blocks - 1);
                 }
 
+                // read data from other cores
                 uint32_t l1_read_addr_ex_par = cb_partial_obj.get_read_ptr();
                 uint32_t l1_read_addr_ex = 0;
                 uint32_t block_index_stride = 0;
@@ -141,6 +145,7 @@ void kernel_main() {
                     noc.async_read_barrier();
                     cb_external_obj.push_back(num_tiles_per_partial_result * num_blocks_first_stage);
 
+                    // sync with second-stage all-to-all workers
                     if constexpr (use_two_stage_reduce) {
                         if (i == 0) {
                             reduce_second_stage_sem.wait(num_blocks_second_stage - 1);
@@ -165,7 +170,10 @@ void kernel_main() {
                         }
                         l1_read_addr_ex += single_tile_size_bytes;
                         noc.async_read_barrier();
-                        cb_external_obj.push_back(num_tiles_per_partial_result * (num_blocks_second_stage - 1));
+                        cb_external_obj.push_back(
+                            num_tiles_per_partial_result *
+                            (num_blocks_second_stage -
+                             1));  // push back partials from all cores -> compute can start reducing now
                     }
                 }
             };

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_pre_allgather.cpp
@@ -5,11 +5,18 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/noc_semaphore.h"
+#include "experimental/endpoints.h"
+
+struct RemoteCoord {
+    uint32_t x;
+    uint32_t y;
+};
 
 // split REDUCE across cores
 void kernel_main() {
-    uint32_t reduce_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(0));
-    uint32_t reduce_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(1));
     constexpr uint32_t num_blocks = get_compile_time_arg_val(2);
     constexpr uint32_t block_h = get_compile_time_arg_val(3);
     constexpr uint32_t block_h_size_bytes = get_compile_time_arg_val(4);
@@ -24,7 +31,6 @@ void kernel_main() {
     constexpr bool use_two_stage_reduce = (bool)get_compile_time_arg_val(13);
     constexpr uint32_t num_blocks_first_stage = get_compile_time_arg_val(14);
     constexpr uint32_t num_blocks_second_stage = get_compile_time_arg_val(15);
-    uint32_t reduce_second_stage_semaphore_addr = get_semaphore(get_compile_time_arg_val(16));
     constexpr bool rms_norm = get_compile_time_arg_val(17) == 1;
 
     const uint32_t mcast_dest_noc_start_x = get_arg_val<uint32_t>(0);
@@ -40,16 +46,21 @@ void kernel_main() {
     constexpr uint32_t cb_ex_partial2 = tt::CBIndex::c_11;
     constexpr uint32_t cb_ex2 = tt::CBIndex::c_12;
     constexpr uint32_t cb_ex_external2 = tt::CBIndex::c_13;
-    constexpr uint32_t cb_ex2_global = tt::CBIndex::c_14;  // E[x2] global reduce
+    constexpr uint32_t cb_ex2_global = tt::CBIndex::c_14;
+
+    experimental::Noc noc;
+    experimental::Semaphore<> reduce_receiver_sem(get_compile_time_arg_val(0));
+    experimental::Semaphore<> reduce_sender_sem(get_compile_time_arg_val(1));
+    experimental::Semaphore<> reduce_second_stage_sem(get_compile_time_arg_val(16));
+    experimental::UnicastEndpoint remote_ep;
 
     const uint32_t single_tile_size_bytes = get_tile_size(cb_ex_partial2);
     const DataFormat data_format = get_dataformat(cb_ex_partial2);
 
-    uint64_t remote_noc_addrs[num_blocks];
-
+    RemoteCoord remote_coords[num_blocks];
     uint32_t x = start_x, y = start_y;
     for (uint32_t i = 0; i < num_blocks; ++i) {
-        remote_noc_addrs[i] = get_noc_addr(in0_remote_noc_x[x], in0_remote_noc_y[y], 0);
+        remote_coords[i] = {in0_remote_noc_x[x], in0_remote_noc_y[y]};
         if constexpr (row_major) {
             ++x;
             if (x == num_x) {
@@ -71,95 +82,92 @@ void kernel_main() {
         }
     }
 
-    const uint64_t multicast_data_noc = get_noc_multicast_addr(
-        mcast_dest_noc_start_x, mcast_dest_noc_start_y, mcast_dest_noc_end_x, mcast_dest_noc_end_y, 0);
+    const auto& global_reduce_sender =
+        [&](const uint32_t cb_partial_id, const uint32_t cb_external_id, const uint32_t cb_reduce_first_stage_id)
+            __attribute__((always_inline)) {
+                experimental::CircularBuffer cb_partial_obj(cb_partial_id);
+                experimental::CircularBuffer cb_external_obj(cb_external_id);
+                experimental::CircularBuffer cb_reduce_first_stage_obj(cb_reduce_first_stage_id);
 
-    const uint64_t reduce_sender_semaphore_noc_addr = multicast_data_noc | reduce_sender_semaphore_addr;
-
-    volatile tt_l1_ptr uint32_t* reduce_sender_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_sender_semaphore_addr);
-    volatile tt_l1_ptr uint32_t* reduce_receiver_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_receiver_semaphore_addr);
-    volatile tt_l1_ptr uint32_t* reduce_second_stage_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_second_stage_semaphore_addr);
-
-    const auto& global_reduce_sender = [&](
-        const uint32_t cb_partial, const uint32_t cb_external, const uint32_t cb_reduce_first_stage)
-        __attribute__((always_inline)) {
-        uint32_t num_tiles_per_partial_result = 2;
-        if constexpr (rms_norm) {
-            num_tiles_per_partial_result = 1;
-        }
-
-        // global reduce
-        // wait for local data ready
-        cb_wait_front(cb_partial, num_tiles_per_partial_result * block_h);  // TODO test for layernorm
-
-        // inc semaphore of other cores, tell other all-to-all workers to start
-        if constexpr (num_blocks > 1) {
-            *reduce_sender_semaphore_addr_ptr = VALID;
-            noc_semaphore_wait(reduce_receiver_semaphore_addr_ptr, num_blocks - 1);
-            noc_semaphore_set(reduce_receiver_semaphore_addr_ptr, 0);
-            noc_semaphore_set_multicast(reduce_sender_semaphore_addr, reduce_sender_semaphore_noc_addr, num_blocks - 1);
-        }
-
-        // read data from other cores - first stage reduce
-        uint32_t l1_read_addr_ex_par = get_read_ptr(cb_partial);
-        // read data from other cores - second stage reduce
-        uint32_t l1_read_addr_ex = 0;
-        uint32_t block_index_stride = 0;
-        if constexpr (use_two_stage_reduce) {
-            l1_read_addr_ex = get_read_ptr(cb_reduce_first_stage);
-            if constexpr (row_major) {
-                block_index_stride = num_x;
-            } else {
-                block_index_stride = num_y;
-            }
-        }
-        // read from both stage
-        for (uint32_t i = 0; i < num_tiles_per_worker; ++i) {
-            // first stage
-            cb_reserve_back(cb_external, num_blocks_first_stage);
-            uint32_t l1_write_addr_external = get_write_ptr(cb_external);
-            for (uint32_t block = 0; block < num_blocks_first_stage; ++block) {
-                for (uint32_t tile_idx = 0; tile_idx < num_tiles_per_partial_result; ++tile_idx) {
-                    uint64_t noc_addr_ex_par =
-                        remote_noc_addrs[block] | (l1_read_addr_ex_par + tile_idx * single_tile_size_bytes);
-                    noc_async_read_one_packet(noc_addr_ex_par, l1_write_addr_external, single_tile_size_bytes);
-                    l1_write_addr_external += single_tile_size_bytes;
-                }
-            }
-            l1_read_addr_ex_par += single_tile_size_bytes;
-            noc_async_read_barrier();
-            cb_push_back(cb_external, num_tiles_per_partial_result * num_blocks_first_stage);
-
-            // sync with second-stage all-to-all workers
-            if constexpr (use_two_stage_reduce) {
-                if (i == 0) {
-                    noc_semaphore_wait(reduce_second_stage_semaphore_addr_ptr, num_blocks_second_stage - 1);
-                    noc_semaphore_set(reduce_second_stage_semaphore_addr_ptr, 0);
+                uint32_t num_tiles_per_partial_result = 2;
+                if constexpr (rms_norm) {
+                    num_tiles_per_partial_result = 1;
                 }
 
-                uint32_t curr_block_index = block_index_stride;
-                for (uint32_t block = 0; block < num_blocks_second_stage - 1; ++block) {
-                    for (uint32_t tile_idx = 0; tile_idx < num_tiles_per_partial_result; ++tile_idx) {
-                        uint64_t noc_addr_ex =
-                            remote_noc_addrs[curr_block_index] | (l1_read_addr_ex + tile_idx * single_tile_size_bytes);
-                        noc_async_read_one_packet(noc_addr_ex, l1_write_addr_external, single_tile_size_bytes);
-                        l1_write_addr_external += single_tile_size_bytes;
+                cb_partial_obj.wait_front(num_tiles_per_partial_result * block_h);
+
+                if constexpr (num_blocks > 1) {
+                    reduce_sender_sem.set(VALID);
+                    reduce_receiver_sem.wait(num_blocks - 1);
+                    reduce_receiver_sem.set(0);
+                    reduce_sender_sem.set_multicast(
+                        noc,
+                        mcast_dest_noc_start_x,
+                        mcast_dest_noc_start_y,
+                        mcast_dest_noc_end_x,
+                        mcast_dest_noc_end_y,
+                        num_blocks - 1);
+                }
+
+                uint32_t l1_read_addr_ex_par = cb_partial_obj.get_read_ptr();
+                uint32_t l1_read_addr_ex = 0;
+                uint32_t block_index_stride = 0;
+                if constexpr (use_two_stage_reduce) {
+                    l1_read_addr_ex = cb_reduce_first_stage_obj.get_read_ptr();
+                    if constexpr (row_major) {
+                        block_index_stride = num_x;
+                    } else {
+                        block_index_stride = num_y;
                     }
-                    curr_block_index += block_index_stride;
                 }
-                l1_read_addr_ex += single_tile_size_bytes;
-                noc_async_read_barrier();
-                cb_push_back(
-                    cb_external,
-                    num_tiles_per_partial_result *
-                        (num_blocks_second_stage -
-                         1));  // push back partials from all cores -> compute can start reducing now
-            }
-        }
-    };
+                uint32_t write_offset = 0;
+                for (uint32_t i = 0; i < num_tiles_per_worker; ++i) {
+                    cb_external_obj.reserve_back(num_blocks_first_stage);
+                    write_offset = 0;
+                    for (uint32_t block = 0; block < num_blocks_first_stage; ++block) {
+                        for (uint32_t tile_idx = 0; tile_idx < num_tiles_per_partial_result; ++tile_idx) {
+                            noc.async_read<experimental::Noc::TxnIdMode::DISABLED, NOC_MAX_BURST_SIZE>(
+                                remote_ep,
+                                cb_external_obj,
+                                single_tile_size_bytes,
+                                {.noc_x = remote_coords[block].x,
+                                 .noc_y = remote_coords[block].y,
+                                 .addr = l1_read_addr_ex_par + tile_idx * single_tile_size_bytes},
+                                {.offset_bytes = write_offset});
+                            write_offset += single_tile_size_bytes;
+                        }
+                    }
+                    l1_read_addr_ex_par += single_tile_size_bytes;
+                    noc.async_read_barrier();
+                    cb_external_obj.push_back(num_tiles_per_partial_result * num_blocks_first_stage);
+
+                    if constexpr (use_two_stage_reduce) {
+                        if (i == 0) {
+                            reduce_second_stage_sem.wait(num_blocks_second_stage - 1);
+                            reduce_second_stage_sem.set(0);
+                        }
+
+                        uint32_t curr_block_index = block_index_stride;
+                        for (uint32_t block = 0; block < num_blocks_second_stage - 1; ++block) {
+                            for (uint32_t tile_idx = 0; tile_idx < num_tiles_per_partial_result; ++tile_idx) {
+                                noc.async_read<experimental::Noc::TxnIdMode::DISABLED, NOC_MAX_BURST_SIZE>(
+                                    remote_ep,
+                                    cb_external_obj,
+                                    single_tile_size_bytes,
+                                    {.noc_x = remote_coords[curr_block_index].x,
+                                     .noc_y = remote_coords[curr_block_index].y,
+                                     .addr = l1_read_addr_ex + tile_idx * single_tile_size_bytes},
+                                    {.offset_bytes = write_offset});
+                                write_offset += single_tile_size_bytes;
+                            }
+                            curr_block_index += block_index_stride;
+                        }
+                        l1_read_addr_ex += single_tile_size_bytes;
+                        noc.async_read_barrier();
+                        cb_external_obj.push_back(num_tiles_per_partial_result * (num_blocks_second_stage - 1));
+                    }
+                }
+            };
     global_reduce_sender(cb_ex_partial2, cb_ex_external2, cb_ex2);
-    noc_async_write_barrier();
+    noc.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln.cpp
@@ -66,6 +66,18 @@ void kernel_main() {
     constexpr uint32_t cb_id_gamma = tt::CBIndex::c_5;
     constexpr uint32_t cb_id_beta = tt::CBIndex::c_6;
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_in0(cb_id_in0);
+#ifdef FUSE_PRE_ADD
+    experimental::CircularBuffer cb_in1(cb_id_in1);
+#endif
+#ifdef FUSE_GAMMA
+    experimental::CircularBuffer cb_gamma(cb_id_gamma);
+#endif
+#ifdef FUSE_BETA
+    experimental::CircularBuffer cb_beta(cb_id_beta);
+#endif
+
     constexpr uint32_t block_size = get_compile_time_arg_val(0);
     constexpr bool use_welford = get_compile_time_arg_val(1) == 1;
     constexpr auto src0_args = TensorAccessorArgs<2>();
@@ -133,16 +145,16 @@ void kernel_main() {
 #ifdef FUSE_PRE_ADD
         for (auto block : generic::blocks(Wt, block_size)) {
             layernorm_dataflow_utils::read_block_to_cb(
-                cb_id_in1, src_b, src1_tile_bytes, curr_tile_row * Wt + block.start(), block);
+                noc, cb_in1, src_b, src1_tile_bytes, curr_tile_row * Wt + block.start(), block);
         }
 #endif
 #else
         // TILE: read input a and b (if present) interleaved per block.
         for (auto block : generic::blocks(Wt, block_size)) {
             const uint32_t flat_offset = curr_tile_row * Wt + block.start();
-            layernorm_dataflow_utils::read_block_to_cb(cb_id_in0, src_a, src0_page_bytes, flat_offset, block);
+            layernorm_dataflow_utils::read_block_to_cb(noc, cb_in0, src_a, src0_page_bytes, flat_offset, block);
 #ifdef FUSE_PRE_ADD
-            layernorm_dataflow_utils::read_block_to_cb(cb_id_in1, src_b, src1_tile_bytes, flat_offset, block);
+            layernorm_dataflow_utils::read_block_to_cb(noc, cb_in1, src_b, src1_tile_bytes, flat_offset, block);
 #endif
         }
 #endif
@@ -152,10 +164,10 @@ void kernel_main() {
         if (ncht == 0) {
             for (auto block : generic::blocks(Wt, block_size)) {
 #ifdef FUSE_GAMMA
-                layernorm_dataflow_utils::read_block_to_cb(cb_id_gamma, addrg, gamma_tile_bytes, block.start(), block);
+                layernorm_dataflow_utils::read_block_to_cb(noc, cb_gamma, addrg, gamma_tile_bytes, block.start(), block);
 #endif
 #ifdef FUSE_BETA
-                layernorm_dataflow_utils::read_block_to_cb(cb_id_beta, addrb, beta_tile_bytes, block.start(), block);
+                layernorm_dataflow_utils::read_block_to_cb(noc, cb_beta, addrb, beta_tile_bytes, block.start(), block);
 #endif
             }  // wt loop
         }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln_large_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln_large_tensor.cpp
@@ -65,6 +65,18 @@ void kernel_main() {
     constexpr uint32_t cb_id_gamma = tt::CBIndex::c_5;
     constexpr uint32_t cb_id_beta = tt::CBIndex::c_6;
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_in0(cb_id_in0);
+#ifdef FUSE_PRE_ADD
+    experimental::CircularBuffer cb_in1(cb_id_in1);
+#endif
+#ifdef FUSE_GAMMA
+    experimental::CircularBuffer cb_gamma(cb_id_gamma);
+#endif
+#ifdef FUSE_BETA
+    experimental::CircularBuffer cb_beta(cb_id_beta);
+#endif
+
     // No use_welford slot (large-tensor + Welford uses a separate kernel).
     constexpr uint32_t block_size = get_compile_time_arg_val(0);
     constexpr auto src0_args = TensorAccessorArgs<1>();
@@ -129,13 +141,13 @@ void kernel_main() {
 #else
         for (auto block : generic::blocks(Wt, block_size)) {
             layernorm_dataflow_utils::read_block_to_cb(
-                cb_id_in0, src_a, src0_page_bytes, curr_tile_row * Wt + block.start(), block);
+                noc, cb_in0, src_a, src0_page_bytes, curr_tile_row * Wt + block.start(), block);
         }
 #endif
 #ifdef FUSE_PRE_ADD
         for (auto block : generic::blocks(Wt, block_size)) {
             layernorm_dataflow_utils::read_block_to_cb(
-                cb_id_in1, src_b, src1_tile_bytes, curr_tile_row * Wt + block.start(), block);
+                noc, cb_in1, src_b, src1_tile_bytes, curr_tile_row * Wt + block.start(), block);
         }
 #endif
 #endif
@@ -152,16 +164,16 @@ void kernel_main() {
 #ifdef FUSE_PRE_ADD
         for (auto block : generic::blocks(Wt, block_size)) {
             layernorm_dataflow_utils::read_block_to_cb(
-                cb_id_in1, src_b, src1_tile_bytes, curr_tile_row * Wt + block.start(), block);
+                noc, cb_in1, src_b, src1_tile_bytes, curr_tile_row * Wt + block.start(), block);
         }
 #endif
 #else  // TILE path: interleaved per block
         for (auto block : generic::blocks(Wt, block_size)) {
             layernorm_dataflow_utils::read_block_to_cb(
-                cb_id_in0, src_a, src0_page_bytes, curr_tile_row * Wt + block.start(), block);
+                noc, cb_in0, src_a, src0_page_bytes, curr_tile_row * Wt + block.start(), block);
 #ifdef FUSE_PRE_ADD
             layernorm_dataflow_utils::read_block_to_cb(
-                cb_id_in1, src_b, src1_tile_bytes, curr_tile_row * Wt + block.start(), block);
+                noc, cb_in1, src_b, src1_tile_bytes, curr_tile_row * Wt + block.start(), block);
 #endif
         }
 #endif
@@ -197,20 +209,20 @@ void kernel_main() {
                 block);
 #else
             layernorm_dataflow_utils::read_block_to_cb(
-                cb_id_in0, src_a, src0_page_bytes, curr_tile_row * Wt + block.start(), block);
+                noc, cb_in0, src_a, src0_page_bytes, curr_tile_row * Wt + block.start(), block);
 #endif
 
             // Gamma/beta and b-tensor for this block — pushed immediately after input so
             // compute finds them in the CB when it reaches the per-block multiply step.
 #ifdef FUSE_PRE_ADD
             layernorm_dataflow_utils::read_block_to_cb(
-                cb_id_in1, src_b, src1_tile_bytes, curr_tile_row * Wt + block.start(), block);
+                noc, cb_in1, src_b, src1_tile_bytes, curr_tile_row * Wt + block.start(), block);
 #endif
 #ifdef FUSE_GAMMA
-            layernorm_dataflow_utils::read_block_to_cb(cb_id_gamma, addrg, gamma_tile_bytes, block.start(), block);
+            layernorm_dataflow_utils::read_block_to_cb(noc, cb_gamma, addrg, gamma_tile_bytes, block.start(), block);
 #endif
 #ifdef FUSE_BETA
-            layernorm_dataflow_utils::read_block_to_cb(cb_id_beta, addrb, beta_tile_bytes, block.start(), block);
+            layernorm_dataflow_utils::read_block_to_cb(noc, cb_beta, addrb, beta_tile_bytes, block.start(), block);
 #endif
         }  // wt loop
     }  // ncht loop

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln_large_tensor_welford.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln_large_tensor_welford.cpp
@@ -24,6 +24,18 @@ void kernel_main() {
     constexpr uint32_t cb_id_gamma = 5;
     constexpr uint32_t cb_id_beta = 6;
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_in0(cb_id_in0);
+#ifdef FUSE_PRE_ADD
+    experimental::CircularBuffer cb_in1(cb_id_in1);
+#endif
+#ifdef FUSE_GAMMA
+    experimental::CircularBuffer cb_gamma(cb_id_gamma);
+#endif
+#ifdef FUSE_BETA
+    experimental::CircularBuffer cb_beta(cb_id_beta);
+#endif
+
     // ublocks size defined in tiles
     const uint32_t src0_tile_bytes = get_tile_size(cb_id_in0);
 
@@ -58,10 +70,10 @@ void kernel_main() {
         // Calculate E[x] and Var[x]
         for (auto block : generic::blocks(Wt, blk)) {
             layernorm_dataflow_utils::read_block_to_cb(
-                cb_id_in0, src_a, src0_tile_bytes, offs + block.start() + tile_offset, block);
+                noc, cb_in0, src_a, src0_tile_bytes, offs + block.start() + tile_offset, block);
 #ifdef FUSE_PRE_ADD
             layernorm_dataflow_utils::read_block_to_cb(
-                cb_id_in1, src_b, src1_tile_bytes, offs + block.start() + tile_offset, block);
+                noc, cb_in1, src_b, src1_tile_bytes, offs + block.start() + tile_offset, block);
 #endif
         }  // wt loop
 
@@ -69,20 +81,21 @@ void kernel_main() {
         // Calculate final output
         for (auto block : generic::blocks(Wt, blk)) {
             layernorm_dataflow_utils::read_block_to_cb(
-                cb_id_in0, src_a, src0_tile_bytes, offs + block.start() + tile_offset, block);
+                noc, cb_in0, src_a, src0_tile_bytes, offs + block.start() + tile_offset, block);
 #ifdef FUSE_PRE_ADD
             layernorm_dataflow_utils::read_block_to_cb(
-                cb_id_in1, src_b, src1_tile_bytes, offs + block.start() + tile_offset, block);
+                noc, cb_in1, src_b, src1_tile_bytes, offs + block.start() + tile_offset, block);
 #endif
 #ifdef FUSE_GAMMA
             {
-                layernorm_dataflow_utils::read_block_to_cb(cb_id_gamma, addrg, gamma_tile_bytes, block.start(), block);
+                layernorm_dataflow_utils::read_block_to_cb(
+                    noc, cb_gamma, addrg, gamma_tile_bytes, block.start(), block);
             }
 #endif
 
 #ifdef FUSE_BETA
             {
-                layernorm_dataflow_utils::read_block_to_cb(cb_id_beta, addrb, beta_tile_bytes, block.start(), block);
+                layernorm_dataflow_utils::read_block_to_cb(noc, cb_beta, addrb, beta_tile_bytes, block.start(), block);
             }
 #endif
         }  // wt loop

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln_rm_gb.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln_rm_gb.cpp
@@ -7,6 +7,10 @@
 #include "ttnn/kernel/dataflow/generate_reduce_scaler.hpp"
 #include "ttnn/kernel/dataflow/generate_bcast_scalar.hpp"
 #include "ttnn/operations/normalization/kernel_util/generic/blocked_range.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
+#include "experimental/endpoints.h"
 
 namespace generic = norm::kernel_util::generic;
 
@@ -23,6 +27,18 @@ void kernel_main() {
     constexpr uint32_t cb_id_in0 = tt::CBIndex::c_0, cb_id_in1 = tt::CBIndex::c_1;
     constexpr uint32_t cb_id_gamma = tt::CBIndex::c_5;
     constexpr uint32_t cb_id_beta = tt::CBIndex::c_6;
+
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_in0(cb_id_in0);
+#ifdef FUSE_PRE_ADD
+    experimental::CircularBuffer cb_in1(cb_id_in1);
+#endif
+#ifdef FUSE_GAMMA
+    experimental::CircularBuffer cb_gamma(cb_id_gamma);
+#endif
+#ifdef FUSE_BETA
+    experimental::CircularBuffer cb_beta(cb_id_beta);
+#endif
 
     // ublocks size defined in tiles
     const uint32_t src0_tile_bytes = get_tile_size(cb_id_in0);
@@ -66,26 +82,34 @@ void kernel_main() {
 
     for (uint32_t ncht = 0; ncht < NCHt; ncht++) {
         for (auto block : generic::blocks(Wt, blk)) {
-            cb_reserve_back(cb_id_in0, block.full_block_size());
-            uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
-
+            cb_in0.reserve_back(block.full_block_size());
+            uint32_t idx = 0;
             for (auto r : block.local()) {
-                noc_async_read_tile(offs + block.start() + r + tile_offset, src_a, l1_write_addr);
-                l1_write_addr += src0_tile_bytes;
+                noc.async_read(
+                    src_a,
+                    cb_in0,
+                    src0_tile_bytes,
+                    {.page_id = offs + block.start() + r + tile_offset},
+                    {.offset_bytes = idx * src0_tile_bytes});
+                idx++;
             }
-            noc_async_read_barrier();
-            cb_push_back(cb_id_in0, block.full_block_size());
+            noc.async_read_barrier();
+            cb_in0.push_back(block.full_block_size());
 
 #ifdef FUSE_PRE_ADD
-            // TODO(AP): refactor the ifdefs
-            cb_reserve_back(cb_id_in1, block.full_block_size());
-            l1_write_addr = get_write_ptr(cb_id_in1);
+            cb_in1.reserve_back(block.full_block_size());
+            idx = 0;
             for (auto r : block.local()) {
-                noc_async_read_tile(offs + block.start() + r + tile_offset, src_b, l1_write_addr);
-                l1_write_addr += src1_tile_bytes;
+                noc.async_read(
+                    src_b,
+                    cb_in1,
+                    src1_tile_bytes,
+                    {.page_id = offs + block.start() + r + tile_offset},
+                    {.offset_bytes = idx * src1_tile_bytes});
+                idx++;
             }
-            noc_async_read_barrier();
-            cb_push_back(cb_id_in1, block.full_block_size());
+            noc.async_read_barrier();
+            cb_in1.push_back(block.full_block_size());
 #endif
         }  // wt loop
 
@@ -94,35 +118,57 @@ void kernel_main() {
             for (auto block : generic::blocks(Wt, blk)) {
 #ifdef FUSE_GAMMA
                 {
-                    cb_reserve_back(cb_id_gamma, block.full_block_size());
-                    uint32_t l1_write_addr = get_write_ptr(cb_id_gamma);
+                    cb_gamma.reserve_back(block.full_block_size());
+                    experimental::UnicastEndpoint local_ep;
+                    uint32_t idx = 0;
                     for (auto r : block.local()) {
-                        uint64_t gamma_noc_addr = get_noc_addr(block.start() + r, addrg);
-                        noc_async_read(gamma_noc_addr, l1_write_addr, 64);
-                        gamma_noc_addr = get_noc_addr(l1_write_addr + 32);
-                        noc_async_read_barrier();
-                        noc_async_read(gamma_noc_addr, l1_write_addr + 512, 32);
-                        l1_write_addr += gamma_tile_bytes;
+                        noc.async_read(
+                            addrg,
+                            cb_gamma,
+                            64,
+                            {.page_id = block.start() + r},
+                            {.offset_bytes = idx * gamma_tile_bytes});
+                        noc.async_read_barrier();
+                        noc.async_read(
+                            local_ep,
+                            cb_gamma,
+                            32,
+                            {.noc_x = my_x[noc.get_noc_id()],
+                             .noc_y = my_y[noc.get_noc_id()],
+                             .addr = cb_gamma.get_write_ptr() + idx * gamma_tile_bytes + 32},
+                            {.offset_bytes = idx * gamma_tile_bytes + 512});
+                        idx++;
                     }
-                    noc_async_read_barrier();
-                    cb_push_back(cb_id_gamma, block.full_block_size());
+                    noc.async_read_barrier();
+                    cb_gamma.push_back(block.full_block_size());
                 }
 #endif
 
 #ifdef FUSE_BETA
                 {
-                    cb_reserve_back(cb_id_beta, block.full_block_size());
-                    uint32_t l1_write_addr = get_write_ptr(cb_id_beta);
+                    cb_beta.reserve_back(block.full_block_size());
+                    experimental::UnicastEndpoint local_ep;
+                    uint32_t idx = 0;
                     for (auto r : block.local()) {
-                        uint64_t beta_noc_addr = get_noc_addr(block.start() + r, addrb);
-                        noc_async_read(beta_noc_addr, l1_write_addr, 64);
-                        beta_noc_addr = get_noc_addr(l1_write_addr + 32);
-                        noc_async_read_barrier();
-                        noc_async_read(beta_noc_addr, l1_write_addr + 512, 32);
-                        l1_write_addr += beta_tile_bytes;
+                        noc.async_read(
+                            addrb,
+                            cb_beta,
+                            64,
+                            {.page_id = block.start() + r},
+                            {.offset_bytes = idx * beta_tile_bytes});
+                        noc.async_read_barrier();
+                        noc.async_read(
+                            local_ep,
+                            cb_beta,
+                            32,
+                            {.noc_x = my_x[noc.get_noc_id()],
+                             .noc_y = my_y[noc.get_noc_id()],
+                             .addr = cb_beta.get_write_ptr() + idx * beta_tile_bytes + 32},
+                            {.offset_bytes = idx * beta_tile_bytes + 512});
+                        idx++;
                     }
-                    noc_async_read_barrier();
-                    cb_push_back(cb_id_beta, block.full_block_size());
+                    noc.async_read_barrier();
+                    cb_beta.push_back(block.full_block_size());
                 }
 #endif
             }  // wt loop

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reshard_writer.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reshard_writer.hpp
@@ -6,22 +6,25 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/endpoints.h"
 
 inline void write_resharded_data(
-    uint32_t cb_out,
-    uint32_t cb_out_resharded,
+    experimental::Noc& noc,
+    experimental::CircularBuffer& cb_out,
+    experimental::CircularBuffer& cb_out_resharded,
     uint32_t num_segments_to_write_back,
     uint32_t storage_core_start_offset,
     tt_l1_ptr uint32_t* segment_args,
     uint32_t worker_core_stride_w_bytes,
     uint32_t storage_core_stride_w_bytes,
     uint32_t block_ht) {
-    const uint32_t out_single_tile_size_bytes = get_tile_size(cb_out);
+    const uint32_t out_single_tile_size_bytes = get_tile_size(cb_out.get_cb_id());
     uint32_t args_idx = 0;
     uint32_t worker_core_read_offset = 0;
 
-    uint32_t cb_out_read_base_addr = get_read_ptr(cb_out);
-    uint32_t cb_out_reshard_write_base_addr = get_write_ptr(cb_out_resharded);
+    experimental::UnicastEndpoint remote;
 
     uint32_t num_tiles_in_write_queue = 0;
 
@@ -32,28 +35,29 @@ inline void write_resharded_data(
 
         uint32_t num_tiles_to_write_in_current_segment = write_size / out_single_tile_size_bytes * block_ht;
 
-        uint32_t worker_core_read_addr = cb_out_read_base_addr + worker_core_read_offset;
-        uint32_t local_storage_core_write_addr = cb_out_reshard_write_base_addr;
-        if (i == 0) {  // For the first segment we need to add the start offset; the following segments will start at 0
-                       // offset
-            local_storage_core_write_addr += storage_core_start_offset;
+        uint32_t src_offset = worker_core_read_offset;
+        uint32_t dst_addr = cb_out_resharded.get_write_ptr();
+        if (i == 0) {
+            dst_addr += storage_core_start_offset;
         }
-
-        uint64_t remote_storage_core_write_addr =
-            get_noc_addr(storage_core_x, storage_core_y, local_storage_core_write_addr);
 
         for (uint32_t h = 0; h < block_ht; ++h) {
             for (uint32_t w = 0; w < num_tiles_to_write_in_current_segment; ++w) {
                 num_tiles_in_write_queue += 1;
-                cb_wait_front(cb_out, num_tiles_in_write_queue);
-                noc_async_write(worker_core_read_addr, remote_storage_core_write_addr, out_single_tile_size_bytes);
-                worker_core_read_addr += out_single_tile_size_bytes;
-                remote_storage_core_write_addr += out_single_tile_size_bytes;
+                cb_out.wait_front(num_tiles_in_write_queue);
+                noc.async_write(
+                    cb_out,
+                    remote,
+                    out_single_tile_size_bytes,
+                    {.offset_bytes = src_offset},
+                    {.noc_x = storage_core_x, .noc_y = storage_core_y, .addr = dst_addr});
+                src_offset += out_single_tile_size_bytes;
+                dst_addr += out_single_tile_size_bytes;
             }
-            worker_core_read_addr += worker_core_stride_w_bytes;
-            remote_storage_core_write_addr += storage_core_stride_w_bytes;
+            src_offset += worker_core_stride_w_bytes;
+            dst_addr += storage_core_stride_w_bytes;
         }
         worker_core_read_offset += write_size;
     }
-    noc_async_write_barrier();
+    noc.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reshard_writer.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reshard_writer.hpp
@@ -37,7 +37,8 @@ inline void write_resharded_data(
 
         uint32_t src_offset = worker_core_read_offset;
         uint32_t dst_addr = cb_out_resharded.get_write_ptr();
-        if (i == 0) {
+        if (i == 0) {  // For the first segment we need to add the start offset; the following segments will start at 0
+                       // offset
             dst_addr += storage_core_start_offset;
         }
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/writer_unary_interleaved_start_id_blocked.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/writer_unary_interleaved_start_id_blocked.cpp
@@ -4,6 +4,9 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/operations/normalization/kernel_util/generic/blocked_range.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 
 namespace generic = norm::kernel_util::generic;
 
@@ -20,20 +23,23 @@ void kernel_main() {
     constexpr uint32_t onetile = 1;
     const uint32_t tile_bytes = get_tile_size(cb_id_out0);
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_out0(cb_id_out0);
+
     const auto s = TensorAccessor(dst_args, dst_addr, tile_bytes);
 
     uint32_t tile_id = tile_offset;
     for (uint32_t h = 0; h < num_tile_rows; h++) {
         for (auto block : generic::blocks(Wt, blk)) {
-            cb_wait_front(cb_id_out0, block.full_block_size());
-            uint32_t l1_read_addr = get_read_ptr(cb_id_out0);
+            cb_out0.wait_front(block.full_block_size());
+            uint32_t idx = 0;
             for (auto i : block.local()) {
-                noc_async_write_tile(tile_id, s, l1_read_addr);
+                noc.async_write(cb_out0, s, tile_bytes, {.offset_bytes = idx * tile_bytes}, {.page_id = tile_id});
                 tile_id++;
-                l1_read_addr += tile_bytes;
+                idx++;
             }
-            noc_async_write_barrier();
-            cb_pop_front(cb_id_out0, block.full_block_size());
+            noc.async_write_barrier();
+            cb_out0.pop_front(block.full_block_size());
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/writer_unary_sharded_ln.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/writer_unary_sharded_ln.cpp
@@ -43,6 +43,12 @@ void kernel_main() {
     constexpr uint32_t cb_out = tt::CBIndex::c_16;
     constexpr uint32_t cb_out_resharded = tt::CBIndex::c_17;
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_gamma_obj(cb_gamma);
+    experimental::CircularBuffer cb_beta_obj(cb_beta);
+    experimental::CircularBuffer cb_out_obj(cb_out);
+    experimental::CircularBuffer cb_out_resharded_obj(cb_out_resharded);
+
     const uint32_t out_single_tile_size_bytes = get_tile_size(cb_out);
 
     if constexpr (!use_welford) {
@@ -65,36 +71,35 @@ void kernel_main() {
         const uint32_t gamma_tile_bytes = get_tile_size(cb_gamma);
         const auto gamma = TensorAccessor(gamma_args, gamma_addr, gamma_tile_bytes);
 
-        uint32_t l1_write_addr_gamma = get_write_ptr(cb_gamma);
-        cb_reserve_back(cb_gamma, block_w);
+        cb_gamma_obj.reserve_back(block_w);
         for (uint32_t w = 0; w < block_w; w++) {
             uint32_t tile_id = gamma_tile_start_id + w;
-            noc_async_read_tile(tile_id, gamma, l1_write_addr_gamma);
-            l1_write_addr_gamma += gamma_tile_bytes;
+            noc.async_read(
+                gamma, cb_gamma_obj, gamma_tile_bytes, {.page_id = tile_id}, {.offset_bytes = w * gamma_tile_bytes});
         }
-        noc_async_read_barrier();
-        cb_push_back(cb_gamma, block_w);
+        noc.async_read_barrier();
+        cb_gamma_obj.push_back(block_w);
     }
 
     if constexpr (fuse_beta) {
         const uint32_t beta_tile_bytes = get_tile_size(cb_beta);
         const auto beta = TensorAccessor(beta_args, beta_addr, beta_tile_bytes);
 
-        uint32_t l1_write_addr_beta = get_write_ptr(cb_beta);
-        cb_reserve_back(cb_beta, block_w);
+        cb_beta_obj.reserve_back(block_w);
         for (uint32_t w = 0; w < block_w; w++) {
             uint32_t tile_id = beta_tile_start_id + w;
-            noc_async_read_tile(tile_id, beta, l1_write_addr_beta);
-            l1_write_addr_beta += beta_tile_bytes;
+            noc.async_read(
+                beta, cb_beta_obj, beta_tile_bytes, {.page_id = tile_id}, {.offset_bytes = w * beta_tile_bytes});
         }
-        noc_async_read_barrier();
-        cb_push_back(cb_beta, block_w);
+        noc.async_read_barrier();
+        cb_beta_obj.push_back(block_w);
     }
 
 #ifndef SKIP_WRITE_BACK
     write_resharded_data(
-        cb_out,
-        cb_out_resharded,
+        noc,
+        cb_out_obj,
+        cb_out_resharded_obj,
         num_segments_to_write_back,
         storage_core_start_offset,
         segment_args,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/writer_unary_sharded_ln.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/writer_unary_sharded_ln.cpp
@@ -8,6 +8,7 @@
 #include "ttnn/kernel/dataflow/generate_reduce_scaler.hpp"
 #include "ttnn/kernel/dataflow/generate_bcast_scalar.hpp"
 #include "reshard_writer.hpp"
+#include "experimental/tensor.h"
 
 void kernel_main() {
     constexpr bool is_all_to_all_worker = get_compile_time_arg_val(0) == 1;

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/writer_unary_sharded_ln_rm_gb.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/writer_unary_sharded_ln_rm_gb.cpp
@@ -7,6 +7,7 @@
 #include "hostdevcommon/common_values.hpp"
 #include "ttnn/kernel/dataflow/generate_reduce_scaler.hpp"
 #include "ttnn/kernel/dataflow/generate_bcast_scalar.hpp"
+#include "experimental/tensor.h"
 #include "experimental/endpoints.h"
 #include "reshard_writer.hpp"
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/writer_unary_sharded_ln_rm_gb.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/writer_unary_sharded_ln_rm_gb.cpp
@@ -7,6 +7,7 @@
 #include "hostdevcommon/common_values.hpp"
 #include "ttnn/kernel/dataflow/generate_reduce_scaler.hpp"
 #include "ttnn/kernel/dataflow/generate_bcast_scalar.hpp"
+#include "experimental/endpoints.h"
 #include "reshard_writer.hpp"
 
 void kernel_main() {
@@ -46,6 +47,12 @@ void kernel_main() {
     constexpr uint32_t cb_out = tt::CBIndex::c_16;
     constexpr uint32_t cb_out_resharded = tt::CBIndex::c_17;
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_gamma_obj(cb_gamma);
+    experimental::CircularBuffer cb_beta_obj(cb_beta);
+    experimental::CircularBuffer cb_out_obj(cb_out);
+    experimental::CircularBuffer cb_out_resharded_obj(cb_out_resharded);
+
     const uint32_t out_single_tile_size_bytes = get_tile_size(cb_out);
 
     if constexpr (!use_welford) {
@@ -71,20 +78,28 @@ void kernel_main() {
         constexpr uint32_t mask_read_tile_face_bytes = FLOAT32_DTYPE_GAMMA ? 64 : 32;
         constexpr uint32_t mask_read_tile_offset_bytes = FLOAT32_DTYPE_GAMMA ? 1024 : 512;
 
-        uint32_t l1_write_addr_gamma = get_write_ptr(cb_gamma);
-        cb_reserve_back(cb_gamma, block_w);
+        experimental::UnicastEndpoint local_ep;
+        cb_gamma_obj.reserve_back(block_w);
         for (uint32_t w = 0; w < block_w; w++) {
             uint32_t tile_id = gamma_tile_start_id + w;
-            uint64_t gamma_noc_addr = get_noc_addr(tile_id, gamma);
-            noc_async_read(gamma_noc_addr, l1_write_addr_gamma, mask_read_tile_face_bytes * 2);
-            gamma_noc_addr = get_noc_addr(l1_write_addr_gamma + mask_read_tile_face_bytes);
-            noc_async_read_barrier();
-            noc_async_read(
-                gamma_noc_addr, l1_write_addr_gamma + mask_read_tile_offset_bytes, mask_read_tile_face_bytes);
-            l1_write_addr_gamma += gamma_tile_bytes;
+            noc.async_read(
+                gamma,
+                cb_gamma_obj,
+                mask_read_tile_face_bytes * 2,
+                {.page_id = tile_id},
+                {.offset_bytes = w * gamma_tile_bytes});
+            noc.async_read_barrier();
+            noc.async_read(
+                local_ep,
+                cb_gamma_obj,
+                mask_read_tile_face_bytes,
+                {.noc_x = my_x[noc.get_noc_id()],
+                 .noc_y = my_y[noc.get_noc_id()],
+                 .addr = cb_gamma_obj.get_write_ptr() + w * gamma_tile_bytes + mask_read_tile_face_bytes},
+                {.offset_bytes = w * gamma_tile_bytes + mask_read_tile_offset_bytes});
         }
-        noc_async_read_barrier();
-        cb_push_back(cb_gamma, block_w);
+        noc.async_read_barrier();
+        cb_gamma_obj.push_back(block_w);
     }
 
     if constexpr (fuse_beta) {
@@ -94,25 +109,35 @@ void kernel_main() {
         uint32_t mask_read_tile_face_bytes = FLOAT32_DTYPE_BETA ? 64 : 32;
         uint32_t mask_read_tile_offset_bytes = FLOAT32_DTYPE_BETA ? 1024 : 512;
 
-        uint32_t l1_write_addr_beta = get_write_ptr(cb_beta);
-        cb_reserve_back(cb_beta, block_w);
+        experimental::UnicastEndpoint local_ep;
+        cb_beta_obj.reserve_back(block_w);
         for (uint32_t w = 0; w < block_w; w++) {
             uint32_t tile_id = beta_tile_start_id + w;
-            uint64_t beta_noc_addr = get_noc_addr(tile_id, beta);
-            noc_async_read(beta_noc_addr, l1_write_addr_beta, mask_read_tile_face_bytes * 2);
-            beta_noc_addr = get_noc_addr(l1_write_addr_beta + mask_read_tile_face_bytes);
-            noc_async_read_barrier();
-            noc_async_read(beta_noc_addr, l1_write_addr_beta + mask_read_tile_offset_bytes, mask_read_tile_face_bytes);
-            l1_write_addr_beta += beta_tile_bytes;
+            noc.async_read(
+                beta,
+                cb_beta_obj,
+                mask_read_tile_face_bytes * 2,
+                {.page_id = tile_id},
+                {.offset_bytes = w * beta_tile_bytes});
+            noc.async_read_barrier();
+            noc.async_read(
+                local_ep,
+                cb_beta_obj,
+                mask_read_tile_face_bytes,
+                {.noc_x = my_x[noc.get_noc_id()],
+                 .noc_y = my_y[noc.get_noc_id()],
+                 .addr = cb_beta_obj.get_write_ptr() + w * beta_tile_bytes + mask_read_tile_face_bytes},
+                {.offset_bytes = w * beta_tile_bytes + mask_read_tile_offset_bytes});
         }
-        noc_async_read_barrier();
-        cb_push_back(cb_beta, block_w);
+        noc.async_read_barrier();
+        cb_beta_obj.push_back(block_w);
     }
 
 #ifndef SKIP_WRITE_BACK
     write_resharded_data(
-        cb_out,
-        cb_out_resharded,
+        noc,
+        cb_out_obj,
+        cb_out_resharded_obj,
         num_segments_to_write_back,
         storage_core_start_offset,
         segment_args,


### PR DESCRIPTION
### Ticket
Link to Github Issue #38763

### Problem description
Device 2.0 (renamed to 1.1) API has been released

### What's changed
- Use new API in LayerNorm
- Fixed up reserve back usage and layer norm pre all gather kernel based on Github Copilot comments

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:{{branch_name}})
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
