### PR TITLE
ttsim: re-run failed pytests serially for clear diagnostics

### DIFF
--- a/.github/workflows/ttsim.yaml
+++ b/.github/workflows/ttsim.yaml
@@ -286,8 +286,7 @@ jobs:
           # If a worker crashes, pytest-xdist only reports "worker crashed"
           # which is useless for debugging. Re-run the failures serially to
           # get actionable output.
-          # TESTING: '&& false' forces the failure path to exercise serial re-run logic. REMOVE BEFORE MERGE.
-          if ${{ matrix.test-group.cmd }} -n 4 ${{ steps.skip-list.outputs.skip_args }} && false; then
+          if ${{ matrix.test-group.cmd }} -n 4 ${{ steps.skip-list.outputs.skip_args }}; then
             exit 0
           fi
           echo "::warning::Parallel run failed. Re-running failed tests serially for clear diagnostics..."

--- a/.github/workflows/ttsim.yaml
+++ b/.github/workflows/ttsim.yaml
@@ -286,7 +286,8 @@ jobs:
           # If a worker crashes, pytest-xdist only reports "worker crashed"
           # which is useless for debugging. Re-run the failures serially to
           # get actionable output.
-          if ${{ matrix.test-group.cmd }} -n 4 ${{ steps.skip-list.outputs.skip_args }}; then
+          # TESTING: '&& false' forces the failure path to exercise serial re-run logic. REMOVE BEFORE MERGE.
+          if ${{ matrix.test-group.cmd }} -n 4 ${{ steps.skip-list.outputs.skip_args }} && false; then
             exit 0
           fi
           echo "::warning::Parallel run failed. Re-running failed tests serially for clear diagnostics..."

--- a/.github/workflows/ttsim.yaml
+++ b/.github/workflows/ttsim.yaml
@@ -282,8 +282,15 @@ jobs:
 
       - name: Run TTNN Pytests - ${{ matrix.test-group.name }}
         run: |
-          # Run pytest with parallel execution and skip list
-          ${{ matrix.test-group.cmd }} -n 4 ${{ steps.skip-list.outputs.skip_args }}
+          # Run pytest with parallel execution and skip list.
+          # If a worker crashes, pytest-xdist only reports "worker crashed"
+          # which is useless for debugging. Re-run the failures serially to
+          # get actionable output.
+          if ${{ matrix.test-group.cmd }} -n 4 ${{ steps.skip-list.outputs.skip_args }}; then
+            exit 0
+          fi
+          echo "::warning::Parallel run failed. Re-running failed tests serially for clear diagnostics..."
+          ${{ matrix.test-group.cmd }} --lf --tb=long -v ${{ steps.skip-list.outputs.skip_args }}
 
   ttsim-cpp-unit-tests:
     if: ${{ inputs.run-metal-cpp-unit-tests }}

--- a/.github/workflows/ttsim.yaml
+++ b/.github/workflows/ttsim.yaml
@@ -290,7 +290,8 @@ jobs:
             exit 0
           fi
           echo "::warning::Parallel run failed. Re-running failed tests serially for clear diagnostics..."
-          ${{ matrix.test-group.cmd }} --lf --tb=long -v ${{ steps.skip-list.outputs.skip_args }}
+          ${{ matrix.test-group.cmd }} --lf --lfnf=all --tb=long -v ${{ steps.skip-list.outputs.skip_args }} || true
+          exit 1
 
   ttsim-cpp-unit-tests:
     if: ${{ inputs.run-metal-cpp-unit-tests }}

--- a/tests/ttnn/unit_tests/operations/eltwise/test_add.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_add.py
@@ -11,6 +11,13 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.common.utility_functions import skip_for_slow_dispatch
 
 
+# TESTING: Deliberate segfault to verify two-pass diagnostic logic. REMOVE BEFORE MERGE.
+def test_deliberate_segfault():
+    import ctypes
+
+    ctypes.string_at(0)  # dereference null pointer → SIGSEGV
+
+
 @pytest.mark.parametrize(
     "shapes",
     [

--- a/tests/ttnn/unit_tests/operations/eltwise/test_add.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_add.py
@@ -11,13 +11,6 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.common.utility_functions import skip_for_slow_dispatch
 
 
-# TESTING: Deliberate segfault to verify two-pass diagnostic logic. REMOVE BEFORE MERGE.
-def test_deliberate_segfault():
-    import ctypes
-
-    ctypes.string_at(0)  # dereference null pointer → SIGSEGV
-
-
 @pytest.mark.parametrize(
     "shapes",
     [


### PR DESCRIPTION
### Ticket
N/A — developer experience improvement

### Problem description

When TTSim TTNN pytests run with `pytest-xdist` (`-n 4` for parallel execution), a crashing test only produces a `"worker crashed"` message. This gives developers **zero actionable information** about what actually failed — no traceback, no assertion error, no test name. Debugging requires manually reproducing the failure locally or re-running serially by hand, which wastes significant developer time.

This has been a recurring source of frustration: a recent incident required a long debugging session before the team could identify what was ultimately a real failure in the PR.

### What's changed

Added a **two-pass strategy** to the TTSim TTNN pytest step in `ttsim.yaml`:

1. **First pass (parallel):** Tests run with `-n 4` as before — no change to the happy path.
2. **Second pass (serial, only on failure):** If the parallel run fails, **only the failed tests** are automatically re-run serially with full diagnostic output. The step still **always fails** — the serial re-run is purely for diagnostics, not to re-evaluate pass/fail.

The serial re-run uses these pytest flags:
- `--lf` ("last-failed") — re-runs **only** the tests that failed, using pytest's built-in `.pytest_cache`. This avoids re-running the entire suite.
- `--lfnf=all` ("last-failed-no-failures=all") — if a worker crashes early enough that the pytest cache is empty/incomplete, falls back to running **all** tests serially rather than running nothing.
- `--tb=long` — prints **full tracebacks** with source code context for every frame in the call stack.
- `-v` (verbose) — prints each test name and its pass/fail status.
- `|| true` on the serial command + `exit 1` — ensures the step **always fails** regardless of the serial re-run outcome. The re-run cannot mask the original failure.

**Impact:**
- **Happy path (no failures):** Zero overhead — identical behavior to today.
- **Failure path:** A few extra minutes to re-run the failing tests, but developers get a clear traceback instead of "worker crashed". Since a failure already means time spent debugging, this is a net win.

**Why `if` instead of `||`?**
GitHub Actions runs bash steps with `set -e` by default. A bare failing command would terminate the script immediately. Commands inside an `if` condition are [exempt from `set -e`](https://www.gnu.org/software/bash/manual/bash.html#The-Set-Builtin) — bash allows them to fail without aborting. This is the idiomatic way to handle an expected-possible-failure in a `set -e` script.

### Test results

Validated by injecting a deliberate `SIGSEGV` (via `ctypes.string_at(0)`) into `test_add.py` to simulate a real worker crash:
- [CI run: TTNN eltwise group 1 - blackhole](https://github.com/tenstorrent/tt-metal/actions/runs/22865947416/job/66338799020?pr=39465)
- ✅ Parallel run detected the worker crash
- ✅ `::warning::` annotation appeared in the Actions UI: *"Parallel run failed. Re-running failed tests serially for clear diagnostics..."*
- ✅ Serial re-run executed with `--lf --lfnf=all --tb=long -v`
- ✅ Step exited with code 1 — failure was not masked
- The deliberate segfault test has been removed in the final commit.

### Checklist

- [x] New/Existing tests provide coverage for changes