### PR TITLE
Fix SFTP upload action path in T3K perf tests workflow

### DIFF
--- a/.github/workflows/t3000-perf-tests-impl.yaml
+++ b/.github/workflows/t3000-perf-tests-impl.yaml
@@ -131,7 +131,7 @@ jobs:
           fi
       - name: Upload benchmark data
         if: ${{ matrix.test-group.save-perf-data && !cancelled() && steps.save-environment-data.conclusion == 'success' && steps.save-environment-data.outputs.has_benchmark_data == 'true' }}
-        uses: ./.github/actions/upload-data-via-sftp
+        uses: ./docker-job/.github/actions/upload-data-via-sftp
         with:
           ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}
           sftp-batchfile: .github/actions/upload-data-via-sftp/benchmark_data_batchfile.txt


### PR DESCRIPTION
Ticket: N/A — Direct fix for failing CI

## Problem

All T3K perf test jobs with `save-perf-data: true` (SD3.5, Mochi, Wan2.2, Flux, Motif, QwenImage) fail at the "Upload benchmark data" step with:

```
Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under
'/home/ubuntu/actions-runner/_work/tt-metal/tt-metal/.github/actions/upload-data-via-sftp'
```

This causes jobs to report as failed even when all tests pass.

**Failing runs:**
- https://github.com/tenstorrent/tt-metal/actions/runs/22853055080/job/66288249325 (SD3.5)
- https://github.com/tenstorrent/tt-metal/actions/runs/22853055080/job/66288249358 (Mochi — tests passed, job failed)
- https://github.com/tenstorrent/tt-metal/actions/runs/22853055080/job/66288249368 (Wan2.2 — tests passed, job failed)

## Root cause

The repo is checked out to `path: docker-job` (line 99), so local action references must use `./docker-job/.github/actions/...`. The `setup-job` reference on line 104 already does this correctly, but the `upload-data-via-sftp` reference on line 134 was missing the `docker-job/` prefix.

## What's changed

`.github/workflows/t3000-perf-tests-impl.yaml`: Changed `uses: ./.github/actions/upload-data-via-sftp` to `uses: ./docker-job/.github/actions/upload-data-via-sftp`.

## Validation

Ran T3K perf tests (Wan2.2 model) on this branch — job succeeded with no SFTP error:
https://github.com/tenstorrent/tt-metal/actions/runs/22861482215/job/66317493486

## Checklist

- [x] New/Existing tests provide coverage for changes