### PR TITLE
Update custom_mm to use CFGSHIFTMASK (#38518)

### DIFF
--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_custom_mm_api.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_custom_mm_api.h
@@ -13,7 +13,7 @@
  * in0 tile shape: [{1, 2, 4, 8}, 32]
  * in1 tile shape: [32, 32]
  * rt_dim: 1
- * ct_dim: {1, 2, 3, 4, 5, 6, 8, 10, 12, 14, 16}
+ * ct_dim: any integer from 1 to 16
  * kt_dim: even number from 2 to 256 (inclusive)
  * fidelity: LoFi only
  * throttle: not supported

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_custom_mm_api.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_custom_mm_api.h
@@ -13,7 +13,7 @@
  * in0 tile shape: [{1, 2, 4, 8}, 32]
  * in1 tile shape: [32, 32]
  * rt_dim: 1
- * ct_dim: {1, 2, 3, 4, 5, 6, 8, 10, 12, 14, 16}
+ * ct_dim: any integer from 1 to 16
  * kt_dim: even number from 2 to 256 (inclusive)
  * fidelity: LoFi only
  * throttle: not supported
@@ -25,10 +25,12 @@ template <bool transpose = false>
 inline void llk_unpack_AB_custom_mm_init(
     const std::uint32_t operand0, const std::uint32_t operand1, const std::uint32_t ct_dim = 1) {
     // Swap operands, for matmul operand0 goes to SrcB and operand1 goes to SrcA
+    const std::uint32_t operandA_id = get_operand_id(operand1);
     const std::uint32_t operandB_id = get_operand_id(operand0);
     const std::uint32_t operandB_face_r_dim = get_operand_face_r_dim(operandB_id);
+    const std::uint32_t operandA_unpack_dst_format = unpack_dst_format[operandA_id];
 
-    _llk_unpack_AB_custom_mm_init_<transpose>(operandB_face_r_dim, ct_dim);
+    _llk_unpack_AB_custom_mm_init_<transpose>(operandB_face_r_dim, operandA_unpack_dst_format, ct_dim);
 }
 
 template <bool read_transposed = false>

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_custom_mm_api.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_custom_mm_api.h
@@ -33,7 +33,7 @@ inline void llk_unpack_AB_custom_mm_init(
     _llk_unpack_AB_custom_mm_init_<transpose>(operandB_face_r_dim, operandA_unpack_dst_format, ct_dim);
 }
 
-template <bool read_transposed = false>
+template <bool read_transposed = false, bool clear_src = true>
 inline void llk_unpack_AB_custom_mm(
     const std::uint32_t operand0,
     const std::uint32_t operand1,
@@ -51,6 +51,6 @@ inline void llk_unpack_AB_custom_mm(
     const std::uint32_t tile_size_A = get_local_cb_interface(operandA_id).fifo_page_size;
     const std::uint32_t tile_size_B = get_local_cb_interface(operandB_id).fifo_page_size;
 
-    _llk_unpack_AB_custom_mm_<read_transposed>(
+    _llk_unpack_AB_custom_mm_<read_transposed, clear_src>(
         base_address_A, base_address_B, tile_index_A, tile_index_B, tile_size_A, tile_size_B, kt_dim, ct_dim);
 }

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/custom_mm.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/custom_mm.h
@@ -193,7 +193,7 @@ ALWI void custom_mm_block_unpack(
     const std::uint32_t in1_tile_index,
     const std::uint32_t kt_dim,
     const std::uint32_t ct_dim = 1) {
-    UNPACK((llk_unpack_AB_custom_mm<read_transposed, clear_srcs>(
+    UNPACK((llk_unpack_AB_custom_mm<read_transposed, clear_src>(
         in0_cb_id, in1_cb_id, in0_tile_index, in1_tile_index, kt_dim, ct_dim)));
 }
 

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/custom_mm.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/custom_mm.h
@@ -131,6 +131,7 @@ ALWI void custom_mm_block_init_short(
  * |-----------------|-----------------------------------------------------------------------------------------------------------------|----------|--------------------------------------------------|-----------------------|
  * | finalize        | Whether to perform the finalization step which merges split_accumulation partials                               | bool     | true/false (must be false if split_acc is false) | False (default true)  |
  * | read_transposed | Whether to read in1 tiles in transposed order (read ct tiles with a stride of kt, then move over a single tile) | bool     | true/false                                       | False (default false) |
+ * | clear_src       | Whether to clear SrcB before unpacking (saves power as only 1/8 FPU rows are used)                              | bool     | true/false                                       | False (default true)  |
  * | in0_cb_id       | The identifier of the first input circular buffer (CB)                                                          | uint32_t | 0 to 31                                          | True                  |
  * | in1_cb_id       | The identifier of the second input circular buffer (CB)                                                         | uint32_t | 0 to 31                                          | True                  |
  * | in0_tile_index  | The index of the tile in block A from the first input CB                                                        | uint32_t | Must be less than the size of the CB             | True                  |
@@ -140,7 +141,7 @@ ALWI void custom_mm_block_init_short(
  * | ct_dim          | The width of the output matrix in tiles                                                                         | uint32_t | 1 to 16                                          | False (default 1)     |
  */
 // clang-format on
-template <bool finalize = true, bool read_transposed = false>
+template <bool finalize = true, bool read_transposed = false, bool clear_src = true>
 ALWI void custom_mm_block(
     const std::uint32_t in0_cb_id,
     const std::uint32_t in1_cb_id,
@@ -149,7 +150,7 @@ ALWI void custom_mm_block(
     const std::uint32_t dst_index,
     const std::uint32_t kt_dim,
     const std::uint32_t ct_dim = 1) {
-    UNPACK((llk_unpack_AB_custom_mm<read_transposed>(
+    UNPACK((llk_unpack_AB_custom_mm<read_transposed, clear_src>(
         in0_cb_id, in1_cb_id, in0_tile_index, in1_tile_index, kt_dim, ct_dim)));
     MATH((llk_math_custom_mm<finalize>(in0_cb_id, in1_cb_id, dst_index, kt_dim, ct_dim)));
 }
@@ -175,6 +176,7 @@ ALWI void custom_mm_block(
  * | Argument        | Description                                                                                                     | Type     | Valid Range                                      | Required              |
  * |-----------------|-----------------------------------------------------------------------------------------------------------------|----------|--------------------------------------------------|-----------------------|
  * | read_transposed | Whether to read in1 tiles in transposed order (read ct tiles with a stride of kt, then move over a single tile) | bool     | true/false                                       | False (default false) |
+ * | clear_src       | Whether to clear SrcB before unpacking (saves power as only 1/8 FPU rows are used)                              | bool     | true/false                                       | False (default true)  |
  * | in0_cb_id       | The identifier of the first input circular buffer (CB)                                                          | uint32_t | 0 to 31                                          | True                  |
  * | in1_cb_id       | The identifier of the second input circular buffer (CB)                                                         | uint32_t | 0 to 31                                          | True                  |
  * | in0_tile_index  | The index of the tile in block A from the first input CB                                                        | uint32_t | Must be less than the size of the CB             | True                  |
@@ -183,7 +185,7 @@ ALWI void custom_mm_block(
  * | ct_dim          | The width of the output matrix in tiles                                                                         | uint32_t | 1 to 16                                          | False (default 1)     |
  */
 // clang-format on
-template <bool read_transposed = false>
+template <bool read_transposed = false, bool clear_src = true>
 ALWI void custom_mm_block_unpack(
     const std::uint32_t in0_cb_id,
     const std::uint32_t in1_cb_id,
@@ -191,7 +193,7 @@ ALWI void custom_mm_block_unpack(
     const std::uint32_t in1_tile_index,
     const std::uint32_t kt_dim,
     const std::uint32_t ct_dim = 1) {
-    UNPACK((llk_unpack_AB_custom_mm<read_transposed>(
+    UNPACK((llk_unpack_AB_custom_mm<read_transposed, clear_srcs>(
         in0_cb_id, in1_cb_id, in0_tile_index, in1_tile_index, kt_dim, ct_dim)));
 }
 

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/custom_mm.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/custom_mm.h
@@ -22,7 +22,7 @@ namespace ckernel {
  * in0 tile shape: [{1, 2, 4, 8}, 32]
  * in1 tile shape: [32, 32]
  * rt_dim: 1
- * ct_dim: {1, 2, 3, 4, 5, 6, 8, 10, 12, 14, 16}
+ * ct_dim: any integer from 1 to 16
  * kt_dim: even number from 2 to 256 (inclusive)
  * fidelity: LoFi only
  * throttle: not supported
@@ -37,7 +37,7 @@ namespace ckernel {
  * | in0_cb_id      | The identifier of the first input circular buffer (CB)                                 | uint32_t | 0 to 31                               | True                  |
  * | in1_cb_id      | The identifier of the second input circular buffer (CB)                                | uint32_t | 0 to 31                               | True                  |
  * | out_cb_id      | The identifier of the output circular buffer (CB)                                      | uint32_t | 0 to 31                               | True                  |
- * | ct_dim         | The width of the output matrix in tiles                                                | uint32_t | {1, 2, 3, 4, 5, 6, 8, 10, 12, 14, 16} | False (default 1)     |
+ * | ct_dim         | The width of the output matrix in tiles                                                | uint32_t | 1 to 16                               | False (default 1)     |
  */
 // clang-format on
 template <bool transpose = false, bool split_acc = false, bool dense_packing = false, bool fp32_dest_acc_en = DST_ACCUM_MODE>
@@ -73,7 +73,7 @@ ALWI void custom_mm_block_init(
  * in0 tile shape: [{1, 2, 4, 8}, 32]
  * in1 tile shape: [32, 32]
  * rt_dim: 1
- * ct_dim: {1, 2, 3, 4, 5, 6, 8, 10, 12, 14, 16}
+ * ct_dim: any integer from 1 to 16
  * kt_dim: even number from 2 to 256 (inclusive)
  * fidelity: LoFi only
  * throttle: not supported
@@ -88,7 +88,7 @@ ALWI void custom_mm_block_init(
  * | in0_cb_id      | The identifier of the first input circular buffer (CB)                                 | uint32_t | 0 to 31                               | True                  |
  * | in1_cb_id      | The identifier of the second input circular buffer (CB)                                | uint32_t | 0 to 31                               | True                  |
  * | out_cb_id      | The identifier of the output circular buffer (CB)                                      | uint32_t | 0 to 31                               | True                  |
- * | ct_dim         | The width of the output matrix in tiles                                                | uint32_t | {1, 2, 3, 4, 5, 6, 8, 10, 12, 14, 16} | False (default 1)     |
+ * | ct_dim         | The width of the output matrix in tiles                                                | uint32_t | 1 to 16                               | False (default 1)     |
  */
 // clang-format on
 template <bool transpose = false, bool split_acc = false, bool dense_packing = false>
@@ -120,7 +120,7 @@ ALWI void custom_mm_block_init_short(
  * in0 tile shape: [{1, 2, 4, 8}, 32]
  * in1 tile shape: [32, 32]
  * rt_dim: 1
- * ct_dim: {1, 2, 3, 4, 5, 6, 8, 10, 12, 14, 16}
+ * ct_dim: any integer from 1 to 16
  * kt_dim: even number from 2 to 256 (inclusive)
  * fidelity: LoFi only
  * throttle: not supported
@@ -137,7 +137,7 @@ ALWI void custom_mm_block_init_short(
  * | in1_tile_index  | The index of the tile in block B from the second input CB                                                       | uint32_t | Must be less than the size of the CB             | True                  |
  * | dst_index       | The index of the tile in DST REG to which the result C will be written                                          | uint32_t | Must be less than the acquired size of DST REG   | True                  |
  * | kt_dim          | The inner dimension in tiles                                                                                    | uint32_t | Must be an even number from 2 to 256 (inclusive) | True                  |
- * | ct_dim          | The width of the output matrix in tiles                                                                         | uint32_t | {1, 2, 3, 4, 5, 6, 8, 10, 12, 14, 16}            | False (default 1)     |
+ * | ct_dim          | The width of the output matrix in tiles                                                                         | uint32_t | 1 to 16                                          | False (default 1)     |
  */
 // clang-format on
 template <bool finalize = true, bool read_transposed = false>
@@ -165,7 +165,7 @@ ALWI void custom_mm_block(
  * in0 tile shape: [{1, 2, 4, 8}, 32]
  * in1 tile shape: [32, 32]
  * rt_dim: 1
- * ct_dim: {1, 2, 3, 4, 5, 6, 8, 10, 12, 14, 16}
+ * ct_dim: any integer from 1 to 16
  * kt_dim: even number from 2 to 256 (inclusive)
  * fidelity: LoFi only
  * throttle: not supported
@@ -180,7 +180,7 @@ ALWI void custom_mm_block(
  * | in0_tile_index  | The index of the tile in block A from the first input CB                                                        | uint32_t | Must be less than the size of the CB             | True                  |
  * | in1_tile_index  | The index of the tile in block B from the second input CB                                                       | uint32_t | Must be less than the size of the CB             | True                  |
  * | kt_dim          | The inner dimension in tiles                                                                                    | uint32_t | Must be an even number from 2 to 256 (inclusive) | True                  |
- * | ct_dim          | The width of the output matrix in tiles                                                                         | uint32_t | {1, 2, 3, 4, 5, 6, 8, 10, 12, 14, 16}            | False (default 1)     |
+ * | ct_dim          | The width of the output matrix in tiles                                                                         | uint32_t | 1 to 16                                          | False (default 1)     |
  */
 // clang-format on
 template <bool read_transposed = false>
@@ -206,7 +206,7 @@ ALWI void custom_mm_block_unpack(
  * in0 tile shape: [{1, 2, 4, 8}, 32]
  * in1 tile shape: [32, 32]
  * rt_dim: 1
- * ct_dim: {1, 2, 3, 4, 5, 6, 8, 10, 12, 14, 16}
+ * ct_dim: any integer from 1 to 16
  * kt_dim: even number from 2 to 256 (inclusive)
  * fidelity: LoFi only
  * throttle: not supported
@@ -220,7 +220,7 @@ ALWI void custom_mm_block_unpack(
  * | in1_cb_id       | The identifier of the second input circular buffer (CB)                                                        | uint32_t | 0 to 31                                          | True                  |
  * | dst_index       | The index of the tile in DST REG to which the result C will be written                                         | uint32_t | Must be less than the acquired size of DST REG   | True                  |
  * | kt_dim          | The inner dimension in tiles                                                                                   | uint32_t | Must be an even number from 2 to 256 (inclusive) | True                  |
- * | ct_dim          | The width of the output matrix in tiles                                                                        | uint32_t | {1, 2, 3, 4, 5, 6, 8, 10, 12, 14, 16}            | False (default 1)     |
+ * | ct_dim          | The width of the output matrix in tiles                                                                        | uint32_t | 1 to 16                                          | False (default 1)     |
  */
 // clang-format on
 template <bool finalize = true>

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_math_custom_mm.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_math_custom_mm.h
@@ -21,7 +21,7 @@ using namespace ckernel::math;
 // in0 tile shape: [{1, 2, 4, 8}, 32]
 // in1 tile shape: [32, 32]
 // rt_dim: 1
-// ct_dim: {1, 2, 3, 4, 5, 6, 8, 10, 12, 14, 16}
+// ct_dim: any integer from 1 to 16
 // kt_dim: even number from 2 to 256 (inclusive)
 // fidelity: LoFi only
 // throttle: not supported

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_custom_mm.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_custom_mm.h
@@ -74,13 +74,13 @@ inline void _llk_unpack_AB_custom_mm_mop_config_(const std::uint32_t ct_dim, con
 
         // Loop 8 times to fill up the replay buffer
         for (std::uint32_t i = 0; i < 8; i++) {
-            // Reuse unpack (unpacks only SrA, SrcB is reused across width dim)
+            // Reuse unpack (unpacks only SrcA, SrcB is reused across width dim)
             TTI_UNPACR_COMMON(SrcA, 0b00000000, 1);  // Also set dvalid
             TTI_CFGSHIFTMASK(1, 3, 32 - 1, 0, 0, THCON_SEC0_REG3_Base_address_ADDR32);
             TTI_NOP;
         }
 
-        // Reuse unpack (unpacks only SrA, SrcB is reused across width dim)
+        // Reuse unpack (unpacks only SrcA, SrcB is reused across width dim)
         TTI_UNPACR_COMMON(SrcA, 0b00000000, 1);  // Also set dvalid
         // This last iteration uses inner_increment instead of block_increment
         TTI_CFGSHIFTMASK(1, 3, 32 - 1, 0, 1, THCON_SEC0_REG3_Base_address_ADDR32);

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_custom_mm.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_custom_mm.h
@@ -21,161 +21,149 @@ using namespace ckernel::unpacker;
 // in0 tile shape: [{1, 2, 4, 8}, 32]
 // in1 tile shape: [32, 32]
 // rt_dim: 1
-// ct_dim: {1, 2, 3, 4, 5, 6, 8, 10, 12, 14, 16}
+// ct_dim: any integer from 1 to 16
 // kt_dim: even number from 2 to 256 (inclusive)
 // fidelity: LoFi only
 // throttle: not supported
 
-inline void _llk_unpack_AB_custom_mm_mop_config_(const std::uint32_t ct_dim) {
-    const std::uint32_t replay_buf_prog_len = ct_dim % 2 == 1 ? 28 : 32;
+inline void _llk_unpack_AB_custom_mm_iter_insns(const bool post1) {
+    if (post1) {
+        // This nop is not actually used, it just ensures both tunings are of the same length when recoding
+        // When playing back the replay it is omitted
+        TTI_NOP;
+    }
 
-    load_replay_buf(0, replay_buf_prog_len, [ct_dim] {
-        // === Context 0 full ===
-        // Wait for context available
-        t6_semaphore_wait_on_zero<p_stall::STALL_UNPACK>(semaphore::UNPACK_SYNC);
+    // Unpack SrcA (in1, full tile, uses CFGSHIFTMASK to manipulate L1 addr and keeps SrcA addr fixed at 0)
+    TTI_UNPACR_COMMON(SrcA, 0b00000000, 1);  // Also set dvalid
 
-        // Unpack SrcA (in1, full tile, uses contexts to manipulate L1 address and keeps SrcA address fixed at 0)
-        TTI_UNPACR_COMMON_EXPLICIT_CONTEXT(SrcA, 0b00000000, 0, 1);  // Also set dvalid
+    // Unpack SrcB (in0, one instruction per face, uses counters to manipulate addresses for both L1 and SrcB)
+    // Counters of interest are CH0 Y and Z (both with a stride of a single face in L1
+    // (datum_size * 16 * face_r_dim) and CH1 Y with a stride of a face in SrcB (16 rows)
+    // Each unpack instruction we move to next face in L1, but this is split among Y and Z counters
+    // Because they are 8 bit counters and to cover max inner dim of 256
+    // we need to increment face counter 512 times thus overflowing if we use a single counter,
+    // using both counters allows us to cover exactly 512 needed increments
+    // For SrcB first unpack has to land at index 0 and second one at index 16,
+    // increment from first to second is straightforward, but moving back to 0 after second requires us to exploit
+    // counter overflow as CH1 counters only use low 6 bits and wrap at the number of rows in a Src reg (64)
+    // thus an increment of 48 rows or 3 CH1 Y increments wraps us back to 0
+    // (which is conveniently the max we can increment in a single instruction)
 
-        // Unpack SrcB (in0, one instruction per face, uses counters to manipulate addresses for both L1 and SrcB)
-        // Counters of interest are CH0 Y and Z (both with a stride of a single face in L1
-        // (datum_size * 16 * face_r_dim) and CH1 Y with a stride of a face in SrcB (16 rows)
-        // Each unpack instruction we move to next face in L1, but this is split among Y and Z counters
-        // Because they are 8 bit counters and to cover max inner dim of 256
-        // we need to increment face counter 512 times thus overflowing if we use a single counter,
-        // using both counters allows us to cover exactly 512 needed increments
-        // For SrcB first unpack has to land at index 0 and second one at index 16,
-        // increment from first to second is straightforward, but moving back to 0 after second requires us to exploit
-        // counter overflow as CH1 counters only use low 6 bits and wrap at the number of rows in a Src reg (64)
-        // thus an increment of 48 rows or 3 CH1 Y increments wraps us back to 0
-        // (which is conveniently the max we can increment in a single instruction)
-
-        TTI_UNPACR_COMMON(SrcB, 0b00010001, 0);
+    TTI_UNPACR_COMMON(SrcB, 0b00010001, 0);
+    if (!post1) {
+        // Unpack second face of SrcB before CFGSHIFTMASK in post0 tuning
         TTI_UNPACR_COMMON(SrcB, 0b00110100, 1);  // Also set dvalid
+    }
 
-        // Signal context done
-        t6_semaphore_get(semaphore::UNPACK_SYNC);
+    // Increment UnpA L1 address
+    TTI_CFGSHIFTMASK(1, 3, 32 - 1, 0, 0, THCON_SEC0_REG3_Base_address_ADDR32);
+    if (post1) {
+        // Unpack second face of SrcB after CFGSHIFTMASK in post1 tuning
+        TTI_UNPACR_COMMON(SrcB, 0b00110100, 1);  // Also set dvalid;
+    } else {
+        // This nop is required in post0 as CFGSHIFTMASK is a 2 cycle instruction
+        // And first instruction in next iteration is unpack into SrcA which uses this value
+        TTI_NOP;
+    }
+}
 
-        if (ct_dim % 2 == 1) {
-            // === Context 1 full ===
-            // Wait for context available
-            t6_semaphore_wait_on_zero<p_stall::STALL_UNPACK>(semaphore::UNPACK_SYNC);
+inline void _llk_unpack_AB_custom_mm_mop_config_(const std::uint32_t ct_dim, const bool post1) {
+    load_replay_buf(0, 32, [post1] {
+        // Full unpack (both SrcA and SrcB)
+        _llk_unpack_AB_custom_mm_iter_insns(post1);
 
-            // Unpack SrcA (in1, full tile, uses contexts to manipulate L1 address and keeps SrcA address fixed at 0)
-            TTI_UNPACR_COMMON_EXPLICIT_CONTEXT(SrcA, 0b00000000, 1, 1);  // Also set dvalid
-
-            // Unpack SrcB (in0, one instruction per face, uses counters to manipulate addresses for both L1 and SrcB)
-            // Same counter shenanigans as described above
-            TTI_UNPACR_COMMON(SrcB, 0b00010001, 0);
-            TTI_UNPACR_COMMON(SrcB, 0b00110100, 1);  // Also set dvalid
-
-            // Signal context done
-            t6_semaphore_get(semaphore::UNPACK_SYNC);
-        } else {
-            // === Context 1 reuse ===
-            // Wait for context available
-            t6_semaphore_wait_on_zero<p_stall::STALL_UNPACK>(semaphore::UNPACK_SYNC);
-
-            // Unpack SrcA (in1, full tile, uses contexts to manipulate L1 address and keeps SrcA address fixed at 0)
-            TTI_UNPACR_COMMON_EXPLICIT_CONTEXT(SrcA, 0b00000000, 1, 1);  // Also set dvalid
-
-            // Signal context done
-            t6_semaphore_get(semaphore::UNPACK_SYNC);
-
-            // === Context 0 reuse ===
-            // Wait for context available
-            t6_semaphore_wait_on_zero<p_stall::STALL_UNPACK>(semaphore::UNPACK_SYNC);
-
-            // Unpack SrcA (in1, full tile, uses contexts to manipulate L1 address)
-            TTI_UNPACR_COMMON_EXPLICIT_CONTEXT(SrcA, 0b00000000, 0, 1);  // Also set dvalid
-
-            // Signal context done
-            t6_semaphore_get(semaphore::UNPACK_SYNC);
-
-            // === Context 1 reuse ===
-            // Wait for context available
-            t6_semaphore_wait_on_zero<p_stall::STALL_UNPACK>(semaphore::UNPACK_SYNC);
-
-            // Unpack SrcA (in1, full tile, uses contexts to manipulate L1 address)
-            TTI_UNPACR_COMMON_EXPLICIT_CONTEXT(SrcA, 0b00000000, 1, 1);  // Also set dvalid
-
-            // Signal context done
-            t6_semaphore_get(semaphore::UNPACK_SYNC);
+        // Loop 8 times to fill up the replay buffer
+        for (std::uint32_t i = 0; i < 8; i++) {
+            // Reuse unpack (unpacks only SrA, SrcB is reused across width dim)
+            TTI_UNPACR_COMMON(SrcA, 0b00000000, 1);  // Also set dvalid
+            TTI_CFGSHIFTMASK(1, 3, 32 - 1, 0, 0, THCON_SEC0_REG3_Base_address_ADDR32);
+            TTI_NOP;
         }
 
-        for (std::uint32_t i = 0; i < 3; i++) {
-            // === Context 0 reuse ===
-            // Wait for context available
-            t6_semaphore_wait_on_zero<p_stall::STALL_UNPACK>(semaphore::UNPACK_SYNC);
-
-            // Unpack SrcA (in1, full tile, uses contexts to manipulate L1 address)
-            TTI_UNPACR_COMMON_EXPLICIT_CONTEXT(SrcA, 0b00000000, 0, 1);  // Also set dvalid
-
-            // Signal context done
-            t6_semaphore_get(semaphore::UNPACK_SYNC);
-
-            // === Context 1 reuse ===
-            // Wait for context available
-            t6_semaphore_wait_on_zero<p_stall::STALL_UNPACK>(semaphore::UNPACK_SYNC);
-
-            // Unpack SrcA (in1, full tile, uses contexts to manipulate L1 address)
-            TTI_UNPACR_COMMON_EXPLICIT_CONTEXT(SrcA, 0b00000000, 1, 1);  // Also set dvalid
-
-            // Signal context done
-            t6_semaphore_get(semaphore::UNPACK_SYNC);
-        }
+        // Reuse unpack (unpacks only SrA, SrcB is reused across width dim)
+        TTI_UNPACR_COMMON(SrcA, 0b00000000, 1);  // Also set dvalid
+        // This last iteration uses inner_increment instead of block_increment
+        TTI_CFGSHIFTMASK(1, 3, 32 - 1, 0, 1, THCON_SEC0_REG3_Base_address_ADDR32);
+        TTI_NOP;
     });
 
-    // Mop is configured to always cover two iterations of the inner dim loop, providing two benefits:
-    // 1. With max mop iterations (128) we can cover up to 256 kt_dim (max supported by this API)
-    // 2. No need for different templates for contexts 0 and 1 since they're always executed as a pair
+    // Mop is configured to always cover two iterations of the inner (kt) dim loop, allowing us to
+    // cover up to 256 kt_dim (max supported by this API) with max mop iterations (128)
     // To usefully issue up to 128 mop iterations we're limited to only using 0s in zmask
     // (not using SKIP_A/B instructions) since iterations beyond 32 always use 0s for zmask
     //
-    // Replay buffer layout:
-    // Odd ct_dim (1, 3, 5) uses 28 instructions:
-    //   0-4: full ctx0, 5-9: full ctx1, 10-27: {reuse ctx0, reuse ctx1} x 3 pairs
-    // Even ct_dim (2, 4, 6, 8, 10, 12, 14, 16) uses 32 instructions:
-    //   0-4: full ctx0, 5-7: reuse ctx1, 8-31: {reuse ctx0, reuse ctx1} x 4 pairs
+    // Replay buffer layout (always 32 instructions):
+    // post0: [0-4]: full unpack, [5-28]: 8 reuse blocks (3 insns each), [29-31]: final reuse w/ inner_increment
+    // post1: [0]: NOP (skipped), [1-4]: full unpack, [5-28]: 8 reuses, [29-31]: final reuse w/ inner_increment
+    // Where:
+    //   - full unpack = SrcA + SrcB + address increment (new k-tile)
+    //   - reuse = SrcA only + address increment (same k-tile, next c-tile)
+    //   - final reuse = uses inner_increment to jump to next k-row instead of block_increment
     //
-    // Desired instruction sequences per mop iteration (covering 2 inner dim loops):
-    // ct_dim == 1: full ctx0, full ctx1
-    // ct_dim == 2: full ctx0, reuse ctx1, full ctx0, reuse ctx1
-    // Odd ct_dim (3, 5): full ctx0, {reuse ctx1, reuse ctx0} x ((ct_dim-1)/2) times,
-    //                    full ctx1, {reuse ctx0, reuse ctx1} x ((ct_dim-1)/2) times
-    // Even ct_dim (4, 6, 8, 10, 12, 14, 16): full ctx0, reuse ctx1, {reuse ctx0, reuse ctx1} x ((ct_dim/2)-1) times,
-    //                                        full ctx0, reuse ctx1, {reuse ctx0, reuse ctx1} x ((ct_dim/2)-1) times
+    // Instruction sequence per mop iteration (covering 2 kt_dim loops):
+    // Each kt_dim iteration produces ct_dim output tiles, all sharing the same SrcB tile.
+    // ct_dim == 1:
+    //   Sequence: [full] x 2 times
+    //   (block_increment == inner_increment, so no specific full_with_inner_inc needed)
+    // ct_dim == 2:
+    //   Sequence: [full, reuse_with_inner_inc] x 2 times
+    //   (first tile unpacks SrcB, second tile reuses SrcB and uses inner_increment)
+    // ct_dim >= 3:
+    //   Sequence: [full, reuse x (ct_dim-2) times, reuse_with_inner_inc] x 2 times
+    //   Where middle reuses use block_increment, last reuse uses inner_increment
+    //   Examples:
+    //     ct_dim=3: [full, reuse, reuse_with_inner_inc] x 2 times
+    //     ct_dim=4: [full, reuse x 2 times, reuse_with_inner_inc] x 2 times
+    //     ct_dim=5: [full, reuse x 3 times, reuse_with_inner_inc] x 2 times
     //
-    // Mop template parameter assignment (breaking sequences into replay parts):
-    // ct_dim == 1: A0=ctx0_full, B=ctx1_full (uses unpackB)
-    // ct_dim == 2: A0=ct_dim_2,  B=ct_dim_2 (uses unpackB)
-    //              ct_dim_2 captures: full ctx0, reuse ctx1
-    // Odd ct_dim (3, 5): A0=ctx0_full, A1=ctx1_r_tail, A2=ctx1_full, A3=ctx0_r_tail (uses unpackHalo)
-    //                    ctx1_r_tail captures: {reuse ctx1, reuse ctx0} x ((ct_dim-1)/2) times
-    //                    ctx0_r_tail captures: {reuse ctx0, reuse ctx1} x ((ct_dim-1)/2) times
-    // Even ct_dim: A0=first_half, A1=second_half, A2=first_half, A3=second_half (uses unpackHalo)
-    //              first_half captures: full ctx0, reuse ctx1, {reuse ctx0, reuse ctx1} x ((ct_dim/2)-1) times
-    //              second_half captures: {reuse ctx0, reuse ctx1} x (ct_dim/2) times
+    // Mop template parameter assignment (selecting replay buffer instruction ranges):
+    // First, tiles per kt_dim iteration are divided between two halves:
+    //   first_half_iterations = ceil(ct_dim/2)   // Rounds up for odd ct_dim
+    //   second_half_iterations = floor(ct_dim/2)  // Rounds down for odd ct_dim
+    //
+    // Division examples:
+    //   ct_dim=1: first_half=1 tile, second_half=0 tiles
+    //   ct_dim=2: first_half=1 tile, second_half=1 tile
+    //   ct_dim=3: first_half=2 tiles, second_half=1 tile
+    //   ct_dim=4: first_half=2 tiles, second_half=2 tiles
+    //   ct_dim=5: first_half=3 tiles, second_half=2 tiles
+    //
+    // These iteration counts are converted to replay buffer instruction ranges:
+    //   first_half: starts at buffer beginning (offset by post1),
+    //       captures full unpack + (first_half_iterations-1) reuses
+    //               Length = (4 or 5 for full) + (first_half_iterations-1) * 3
+    //   second_half: starts from buffer end, counts backwards second_half_iterations * 3 instructions
+    //                Always includes the final reuse with inner_increment
+    //
+    // For ct_dim == 1:
+    //   second_half is empty (0 instructions), so we use unpackB mode (2 template slots per mop iteration)
+    //   Template: A0=first_half (just full unpack), B=first_half
+    //   Sequence: A0, B → [full] x 2 times
+    //
+    // For ct_dim >= 2:
+    //   Both halves have instructions, so we use unpackHalo mode (4 template slots per mop iteration)
+    //   Template: A0=first_half, A1=second_half, A2=first_half, A3=second_half
+    //   Sequence: A0, A1, A2, A3 → first_half, second_half, first_half, second_half
+    //   Where A0+A1 covers first kt_dim iteration (ct_dim tiles), A2+A3 covers second kt_dim iteration
 
-    const std::uint32_t ctx0_full = lltt::replay_insn(0, 5);
-    const std::uint32_t ctx1_full = lltt::replay_insn(5, 5);
-    const std::uint32_t ct_dim_2 = lltt::replay_insn(0, 8);
-    const std::uint32_t ctx1_r_tail = lltt::replay_insn(13, (ct_dim - 1) * 3);
-    const std::uint32_t ctx0_r_tail = lltt::replay_insn(10, (ct_dim - 1) * 3);
-    const std::uint32_t first_half = lltt::replay_insn(0, 2 + (ct_dim / 2) * 3);
-    const std::uint32_t second_half = lltt::replay_insn(8, (ct_dim / 2) * 3);
-    const std::uint32_t even_A0 = ct_dim == 2 ? ct_dim_2 : first_half;
+    const std::uint32_t first_half_iterations = ct_dim + 1 >> 1;  // Round up for odd ct_dim
+    const std::uint32_t second_half_iterations = ct_dim >> 1;     // Round down for odd ct_dim
+    // Both halves can take up to 9 iterations, meaning max of 18 tiles in width with full odd dim support
+    // Although 16 is still the practical limit due to size of dst
+    const std::uint32_t first_half = lltt::replay_insn(post1 ? 1 : 0, (post1 ? 1 : 2) + (first_half_iterations) * 3);
+    // Second half has to count backwards to always encompass final iteration which uses inner_increment
+    const std::uint32_t second_half = lltt::replay_insn(32 - second_half_iterations * 3, second_half_iterations * 3);
 
     ckernel_unpack_template tmp = ckernel_unpack_template(
-        ct_dim <= 2,                                  // Use UNPACR_B and SKIP_B instructions?
-        ct_dim > 2,                                   // Use UNPACR_A1/2/3 instructions?
-        ct_dim % 2 == 1 ? ctx0_full : even_A0,        // A0
-        ct_dim % 2 == 1 ? ctx1_r_tail : second_half,  // A1
-        ct_dim % 2 == 1 ? ctx1_full : first_half,     // A2
-        ct_dim % 2 == 1 ? ctx0_r_tail : second_half,  // A3
-        0,                                            // Skip A
-        ct_dim == 1 ? ctx1_full : ct_dim_2,           // B
-        0                                             // Skip B
+        ct_dim == 1,  // Use UNPACR_B and SKIP_B instructions?
+        ct_dim != 1,  // Use UNPACR_A1/2/3 instructions?
+        first_half,   // A0
+        second_half,  // A1
+        first_half,   // A2
+        second_half,  // A3
+        0,            // Skip A
+        first_half,   // B
+        0             // Skip B
     );
 
     tmp.program();
@@ -183,7 +171,8 @@ inline void _llk_unpack_AB_custom_mm_mop_config_(const std::uint32_t ct_dim) {
 }
 
 template <bool transpose = false>
-inline void _llk_unpack_AB_custom_mm_init_(const std::uint32_t unpB_face_r_dim, const std::uint32_t ct_dim = 1) {
+inline void _llk_unpack_AB_custom_mm_init_(
+    const std::uint32_t unpB_face_r_dim, const std::uint32_t unpA_dst_format, const std::uint32_t ct_dim = 1) {
     cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(transpose ? 1 : 0);
 
     // UnpA unpacks full tiles
@@ -194,7 +183,11 @@ inline void _llk_unpack_AB_custom_mm_init_(const std::uint32_t unpB_face_r_dim, 
     TTI_SETADCXX(p_setadc::UNP_A, unpA_x_end, 0x0);
     TT_SETADCXX(p_setadc::UNP_B, unpB_x_end, 0x0);
 
-    _llk_unpack_AB_custom_mm_mop_config_(ct_dim);
+    // This is a profiling guided heuristic that slightly tunes the instruction sequence
+    // More details under tt-metal#38518
+    const bool post1 = unpA_dst_format == to_underlying(DataFormat::Bfp4_b);
+
+    _llk_unpack_AB_custom_mm_mop_config_(ct_dim, post1);
 
     // Reset counters here since reset in the execute API is at the end
     TTI_SETADCZW(0b011, 0, 0, 0, 0, 0b1111);
@@ -211,77 +204,22 @@ inline void _llk_unpack_AB_custom_mm_run_(
     const std::uint32_t ct_dim) {
     // Program SrcB address once, its updated using counters for up to 256 kt_dim
     cfg[THCON_SEC1_REG3_Base_address_ADDR32] = address_b;
+    // Program SrcA address once, its updated using CFGSHIFTMASK
+    cfg[THCON_SEC0_REG3_Base_address_ADDR32] = address_a;
+    // Setup CFGSHIFTMASK increments
+    // block_increment moves to next tile in tile_row
+    cfg[SCRATCH_SEC0_val_ADDR32] = block_increment;
+    // inner_increment moves to next tile_row (next inner_dim)
+    cfg[SCRATCH_SEC1_val_ADDR32] = inner_increment;
+
+    semaphore_post(semaphore::UNPACK_SYNC);
+
+    TTI_STALLWAIT(p_stall::STALL_UNPACK, p_stall::TRISC_CFG);
 
     // We can issue mop only once for up to 256 kt_dim
     TT_MOP(0, (kt_dim / 2) - 1, 0);
 
-    if (ct_dim == 1) {
-#pragma GCC unroll 8
-        for (std::uint32_t k = 0; k < kt_dim; k += 2) {
-            wait_for_next_context(2);
-            cfg[THCON_SEC0_REG3_Base_address_ADDR32] = address_a;
-            address_a += inner_increment;
-            semaphore_post(semaphore::UNPACK_SYNC);
-            wait_for_next_context(2);
-            cfg[THCON_SEC0_REG3_Base_cntx1_address_ADDR32] = address_a;
-            address_a += inner_increment;
-            semaphore_post(semaphore::UNPACK_SYNC);
-        }
-    } else if (ct_dim % 2 == 0) {
-        for (std::uint32_t k = 0; k < kt_dim; k++) {
-            std::uint32_t block_start_address = address_a;
-#pragma GCC unroll 8
-            for (std::uint32_t ct = 0; ct < ct_dim; ct += 2) {
-                wait_for_next_context(2);
-                cfg[THCON_SEC0_REG3_Base_address_ADDR32] = block_start_address;
-                block_start_address += block_increment;
-                semaphore_post(semaphore::UNPACK_SYNC);
-                wait_for_next_context(2);
-                cfg[THCON_SEC0_REG3_Base_cntx1_address_ADDR32] = block_start_address;
-                block_start_address += block_increment;
-                semaphore_post(semaphore::UNPACK_SYNC);
-            }
-            address_a += inner_increment;
-        }
-    } else {
-        for (std::uint32_t k = 0; k < kt_dim; k += 2) {
-            std::uint32_t block_start_address = address_a;
-#pragma GCC unroll 8
-            for (std::uint32_t ct = 0; ct + 1 < ct_dim; ct += 2) {
-                wait_for_next_context(2);
-                cfg[THCON_SEC0_REG3_Base_address_ADDR32] = block_start_address;
-                block_start_address += block_increment;
-                semaphore_post(semaphore::UNPACK_SYNC);
-                wait_for_next_context(2);
-                cfg[THCON_SEC0_REG3_Base_cntx1_address_ADDR32] = block_start_address;
-                block_start_address += block_increment;
-                semaphore_post(semaphore::UNPACK_SYNC);
-            }
-            wait_for_next_context(2);
-            cfg[THCON_SEC0_REG3_Base_address_ADDR32] = block_start_address;
-            block_start_address += block_increment;
-            semaphore_post(semaphore::UNPACK_SYNC);
-            address_a += inner_increment;
-
-            block_start_address = address_a;
-#pragma GCC unroll 8
-            for (std::uint32_t ct = 0; ct + 1 < ct_dim; ct += 2) {
-                wait_for_next_context(2);
-                cfg[THCON_SEC0_REG3_Base_cntx1_address_ADDR32] = block_start_address;
-                block_start_address += block_increment;
-                semaphore_post(semaphore::UNPACK_SYNC);
-                wait_for_next_context(2);
-                cfg[THCON_SEC0_REG3_Base_address_ADDR32] = block_start_address;
-                block_start_address += block_increment;
-                semaphore_post(semaphore::UNPACK_SYNC);
-            }
-            wait_for_next_context(2);
-            cfg[THCON_SEC0_REG3_Base_cntx1_address_ADDR32] = block_start_address;
-            block_start_address += block_increment;
-            semaphore_post(semaphore::UNPACK_SYNC);
-            address_a += inner_increment;
-        }
-    }
+    t6_semaphore_get(semaphore::UNPACK_SYNC);
 
     // Wait for all contexts to be free
     wait_for_next_context(1);
@@ -303,8 +241,9 @@ inline void _llk_unpack_AB_custom_mm_(
     const std::uint32_t kt_dim,
     const std::uint32_t ct_dim = 1) {
     volatile uint* cfg = get_cfg_pointer();
+
     const std::uint32_t block_increment = read_transposed ? kt_dim * tile_size_a : tile_size_a;
-    const std::uint32_t inner_increment = read_transposed ? tile_size_a : ct_dim * tile_size_a;
+    const std::uint32_t inner_increment = read_transposed ? -(((ct_dim - 1) * kt_dim) - 1) * tile_size_a : tile_size_a;
 
     const std::uint32_t address_a = base_address_a + tile_size_a * tile_index_a;
     const std::uint32_t address_b = base_address_b + tile_size_b * tile_index_b;

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_custom_mm.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_custom_mm.h
@@ -229,7 +229,7 @@ inline void _llk_unpack_AB_custom_mm_run_(
     TTI_SETADCXY(0b011, 0, 0, 0, 0, 0b1010);
 }
 
-template <bool read_transposed = false>
+template <bool read_transposed = false, bool clear_src = true>
 inline void _llk_unpack_AB_custom_mm_(
     const std::uint32_t base_address_a,
     const std::uint32_t base_address_b,
@@ -250,6 +250,12 @@ inline void _llk_unpack_AB_custom_mm_(
     // Wait for all contexts to be free
     wait_for_next_context(1);
     reset_config_context();
+
+    if constexpr (clear_src) {
+        // Clear SrcB as we only unpack into 1/8 FPU rows so zeroing them gives power savings
+        // This particular instruction clears both banks after waiting for both of them to be free
+        TTI_UNPACR_NOP(SrcB, 0, 0, 0, 0, 0, 1, 0, p_unpacr_nop::CLR_SRC);
+    }
 
     _llk_unpack_AB_custom_mm_run_(cfg, address_a, address_b, block_increment, inner_increment, kt_dim);
 }

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_custom_mm.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_custom_mm.h
@@ -28,7 +28,7 @@ using namespace ckernel::unpacker;
 
 inline void _llk_unpack_AB_custom_mm_iter_insns(const bool post1) {
     if (post1) {
-        // This nop is not actually used, it just ensures both tunings are of the same length when recoding
+        // This nop is not actually used, it just ensures both tunings are of the same length when recording
         // When playing back the replay it is omitted
         TTI_NOP;
     }
@@ -200,8 +200,7 @@ inline void _llk_unpack_AB_custom_mm_run_(
     const std::uint32_t address_b,
     const std::uint32_t block_increment,
     const std::uint32_t inner_increment,
-    const std::uint32_t kt_dim,
-    const std::uint32_t ct_dim) {
+    const std::uint32_t kt_dim) {
     // Program SrcB address once, its updated using counters for up to 256 kt_dim
     cfg[THCON_SEC1_REG3_Base_address_ADDR32] = address_b;
     // Program SrcA address once, its updated using CFGSHIFTMASK
@@ -252,5 +251,5 @@ inline void _llk_unpack_AB_custom_mm_(
     wait_for_next_context(1);
     reset_config_context();
 
-    _llk_unpack_AB_custom_mm_run_(cfg, address_a, address_b, block_increment, inner_increment, kt_dim, ct_dim);
+    _llk_unpack_AB_custom_mm_run_(cfg, address_a, address_b, block_increment, inner_increment, kt_dim);
 }

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_sdpa_custom_mm.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_sdpa_custom_mm.h
@@ -31,7 +31,7 @@ inline void _llk_unpack_AB_sdpa_custom_mm_(
     const bool mask_chunk = false) {
     volatile uint* cfg = get_cfg_pointer();
     const std::uint32_t block_increment = read_transposed ? kt_dim * tile_size_a : tile_size_a;
-    const std::uint32_t inner_increment = read_transposed ? tile_size_a : ct_dim * tile_size_a;
+    const std::uint32_t inner_increment = read_transposed ? -(((ct_dim - 1) * kt_dim) - 1) * tile_size_a : tile_size_a;
 
     const std::uint32_t address_a = base_address_a + tile_size_a * tile_index_a;
     const std::uint32_t address_b = base_address_b + tile_size_b * tile_index_b;

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_sdpa_custom_mm.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_sdpa_custom_mm.h
@@ -45,5 +45,5 @@ inline void _llk_unpack_AB_sdpa_custom_mm_(
         TTI_UNPACR_COMMON_EXPLICIT_CONTEXT(SrcB, 0b00000000, 1, 1);
     }
 
-    _llk_unpack_AB_custom_mm_run_(cfg, address_a, address_b, block_increment, inner_increment, kt_dim, ct_dim);
+    _llk_unpack_AB_custom_mm_run_(cfg, address_a, address_b, block_increment, inner_increment, kt_dim);
 }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/38518
https://github.com/tenstorrent/tt-metal/issues/38519


### Problem description
The custom matrix multiplication kernel in DeepSeek V3 had limitations on supported `ct_dim` (output matrix width) values, restricting it to a discrete set `{1, 2, 3, 4, 5, 6, 8, 10, 12, 14, 16}`. Additionally, the unpacker implementation used a complex context-switching approach that resulted in intricate branching logic and different replay buffer layouts for odd/even dimensions, making the code difficult to maintain and potentially suboptimal for performance.

### What's changed
**Kernel Refactoring**:
- Completely rewrote the unpacker layer (`llk_unpack_AB_custom_mm.h`) to support arbitrary `ct_dim` values from 1 to 16
- Replaced explicit context-switching with `CFGSHIFTMASK` instructions to manipulate L1 addresses, unifying the approach across all ct_dim values
- Simplified the replay buffer layout from variable-length (28 or 32 instructions) to a uniform 32-instruction layout
- Dramatically simplified `_llk_unpack_AB_custom_mm_run_` by eliminating all ct_dim-specific branching and loops in favor of MOP-driven execution

**Performance Optimization**:
- Added profiling-guided tuning for BFP4 data format (`post1` mode) that adjusts instruction ordering based on `unpA_dst_format`
- Updated `inner_increment` calculation to work correctly with the new CFGSHIFTMASK-based addressing scheme

**API Updates**:
- Added `unpA_dst_format` parameter to `_llk_unpack_AB_custom_mm_init_` and `llk_unpack_AB_custom_mm_init` to support format-specific optimizations
- Updated documentation across all affected files to reflect the expanded ct_dim support

**Impact**:
- Enables flexible matrix shapes previously unsupported (e.g., ct_dim = 7, 9, 11, 13, 15)
- Cleaner, more maintainable code with unified logic paths
- Potential performance improvements through optimized instruction sequences

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=lpremovic/custom_mm_cfgsm)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:lpremovic/custom_mm_cfgsm)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=lpremovic/custom_mm_cfgsm)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:lpremovic/custom_mm_cfgsm)
- [N/A] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=lpremovic/custom_mm_cfgsm)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:lpremovic/custom_mm_cfgsm)
- [x] New/Existing tests provide coverage for changes
- [N/A] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [N/A] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=lpremovic/custom_mm_cfgsm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:lpremovic/custom_mm_cfgsm)
  - [N/A] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [N/A] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [N/A] other selection - specify runs

- [N/A] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=lpremovic/custom_mm_cfgsm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:lpremovic/custom_mm_cfgsm)
  - [N/A] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [N/A] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [N/A] other selection - specify runs

- [N/A] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=lpremovic/custom_mm_cfgsm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:lpremovic/custom_mm_cfgsm)
  - [N/A] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [N/A] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [N/A] other selection - specify runs