### PR TITLE
Allow mutation of tensor topology

### DIFF
--- a/tt_stl/tests/CMakeLists.txt
+++ b/tt_stl/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(
         test_span.cpp
         test_strong_type.cpp
         test_small_vector.cpp
+        test_type_visitor.cpp
 )
 target_link_libraries(
     unit_tests_stl_smoke

--- a/tt_stl/tests/test_type_visitor.cpp
+++ b/tt_stl/tests/test_type_visitor.cpp
@@ -1,0 +1,260 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <tt_stl/reflection.hpp>
+#include <array>
+#include <optional>
+#include <tuple>
+#include <vector>
+
+namespace test_types {
+
+struct TargetType {
+    int value;
+    bool operator==(const TargetType&) const = default;
+};
+
+// Reflectable struct containing only TargetType members
+struct PairOfTargets {
+    TargetType first;
+    TargetType second;
+};
+
+// Reflectable struct with nested TargetType in containers
+struct ContainerHolder {
+    std::vector<TargetType> targets;
+    std::optional<TargetType> maybe_target;
+};
+
+// Deeply nested Reflectable struct
+struct NestedHolder {
+    PairOfTargets pair;
+    TargetType single;
+};
+
+}  // namespace test_types
+
+namespace ttsl::reflection {
+namespace {
+
+using test_types::TargetType;
+
+// =============================================================================
+// update_object_of_type tests
+// =============================================================================
+
+TEST(UpdateObjectOfTypeTest, DirectTypeMatch) {
+    TargetType target{42};
+
+    update_object_of_type<TargetType>([](TargetType& t) { t.value *= 2; }, target);
+
+    EXPECT_EQ(target.value, 84);
+}
+
+TEST(UpdateObjectOfTypeTest, NonMatchingTypeThrows) {
+    int non_target = 123;
+    EXPECT_THROW(update_object_of_type<TargetType>([](TargetType&) {}, non_target), std::runtime_error);
+}
+
+TEST(UpdateObjectOfTypeTest, OptionalWithValue) {
+    std::optional<TargetType> opt_target = TargetType{50};
+
+    update_object_of_type<TargetType>([](TargetType& t) { t.value += 10; }, opt_target);
+
+    ASSERT_TRUE(opt_target.has_value());
+    EXPECT_EQ(opt_target->value, 60);
+}
+
+TEST(UpdateObjectOfTypeTest, OptionalWithoutValue) {
+    std::optional<TargetType> opt_target = std::nullopt;
+    bool callback_called = false;
+
+    update_object_of_type<TargetType>([&](TargetType&) { callback_called = true; }, opt_target);
+
+    EXPECT_FALSE(callback_called);
+    EXPECT_FALSE(opt_target.has_value());
+}
+
+TEST(UpdateObjectOfTypeTest, VectorOfTargetType) {
+    std::vector<TargetType> targets{{1}, {2}, {3}};
+
+    update_object_of_type<TargetType>([](TargetType& t) { t.value *= 10; }, targets);
+
+    ASSERT_EQ(targets.size(), 3);
+    EXPECT_EQ(targets[0].value, 10);
+    EXPECT_EQ(targets[1].value, 20);
+    EXPECT_EQ(targets[2].value, 30);
+}
+
+TEST(UpdateObjectOfTypeTest, ArrayOfTargetType) {
+    std::array<TargetType, 3> targets{{{5}, {10}, {15}}};
+
+    update_object_of_type<TargetType>([](TargetType& t) { t.value += 100; }, targets);
+
+    EXPECT_EQ(targets[0].value, 105);
+    EXPECT_EQ(targets[1].value, 110);
+    EXPECT_EQ(targets[2].value, 115);
+}
+
+TEST(UpdateObjectOfTypeTest, TupleOfTargetTypes) {
+    std::tuple<TargetType, TargetType, TargetType> tuple{TargetType{10}, TargetType{20}, TargetType{30}};
+
+    update_object_of_type<TargetType>([](TargetType& t) { t.value *= 2; }, tuple);
+
+    EXPECT_EQ(std::get<0>(tuple).value, 20);
+    EXPECT_EQ(std::get<1>(tuple).value, 40);
+    EXPECT_EQ(std::get<2>(tuple).value, 60);
+}
+
+TEST(UpdateObjectOfTypeTest, NestedOptionalInVector) {
+    std::vector<std::optional<TargetType>> targets{TargetType{1}, std::nullopt, TargetType{3}};
+
+    update_object_of_type<TargetType>([](TargetType& t) { t.value *= 100; }, targets);
+
+    ASSERT_EQ(targets.size(), 3);
+    ASSERT_TRUE(targets[0].has_value());
+    EXPECT_EQ(targets[0]->value, 100);
+    EXPECT_FALSE(targets[1].has_value());
+    ASSERT_TRUE(targets[2].has_value());
+    EXPECT_EQ(targets[2]->value, 300);
+}
+
+TEST(UpdateObjectOfTypeTest, NestedVectorInVector) {
+    std::vector<std::vector<TargetType>> nested{{{1}, {2}}, {{3}, {4}, {5}}};
+
+    update_object_of_type<TargetType>([](TargetType& t) { t.value += 10; }, nested);
+
+    ASSERT_EQ(nested.size(), 2);
+    ASSERT_EQ(nested[0].size(), 2);
+    EXPECT_EQ(nested[0][0].value, 11);
+    EXPECT_EQ(nested[0][1].value, 12);
+    ASSERT_EQ(nested[1].size(), 3);
+    EXPECT_EQ(nested[1][0].value, 13);
+    EXPECT_EQ(nested[1][1].value, 14);
+    EXPECT_EQ(nested[1][2].value, 15);
+}
+
+TEST(UpdateObjectOfTypeTest, ArrayOfOptionals) {
+    std::array<std::optional<TargetType>, 3> targets{TargetType{10}, std::nullopt, TargetType{30}};
+
+    update_object_of_type<TargetType>([](TargetType& t) { t.value = -t.value; }, targets);
+
+    ASSERT_TRUE(targets[0].has_value());
+    EXPECT_EQ(targets[0]->value, -10);
+    EXPECT_FALSE(targets[1].has_value());
+    ASSERT_TRUE(targets[2].has_value());
+    EXPECT_EQ(targets[2]->value, -30);
+}
+
+TEST(UpdateObjectOfTypeTest, EmptyVector) {
+    std::vector<TargetType> empty_targets;
+    bool callback_called = false;
+
+    update_object_of_type<TargetType>([&](TargetType&) { callback_called = true; }, empty_targets);
+
+    EXPECT_FALSE(callback_called);
+    EXPECT_TRUE(empty_targets.empty());
+}
+
+TEST(UpdateObjectOfTypeTest, CountingCallback) {
+    std::vector<TargetType> targets{{1}, {2}, {3}, {4}, {5}};
+    int call_count = 0;
+
+    update_object_of_type<TargetType>([&](TargetType&) { ++call_count; }, targets);
+
+    EXPECT_EQ(call_count, 5);
+}
+
+TEST(UpdateObjectOfTypeTest, TupleOfVectors) {
+    std::tuple<std::vector<TargetType>, std::vector<TargetType>> tuple{
+        std::vector<TargetType>{{1}, {2}}, std::vector<TargetType>{{3}, {4}, {5}}};
+
+    update_object_of_type<TargetType>([](TargetType& t) { t.value *= 10; }, tuple);
+
+    const auto& vec0 = std::get<0>(tuple);
+    const auto& vec1 = std::get<1>(tuple);
+    ASSERT_EQ(vec0.size(), 2);
+    EXPECT_EQ(vec0[0].value, 10);
+    EXPECT_EQ(vec0[1].value, 20);
+    ASSERT_EQ(vec1.size(), 3);
+    EXPECT_EQ(vec1[0].value, 30);
+    EXPECT_EQ(vec1[1].value, 40);
+    EXPECT_EQ(vec1[2].value, 50);
+}
+
+// =============================================================================
+// Tests for Reflectable structs containing TargetType members
+// =============================================================================
+
+using test_types::ContainerHolder;
+using test_types::NestedHolder;
+using test_types::PairOfTargets;
+
+TEST(UpdateObjectOfTypeTest, ReflectableWithTargetMembers) {
+    PairOfTargets pair{TargetType{10}, TargetType{20}};
+
+    update_object_of_type<TargetType>([](TargetType& t) { t.value *= 3; }, pair);
+
+    EXPECT_EQ(pair.first.value, 30);
+    EXPECT_EQ(pair.second.value, 60);
+}
+
+TEST(UpdateObjectOfTypeTest, ReflectableWithContainerMembers) {
+    ContainerHolder holder{.targets = {{1}, {2}, {3}}, .maybe_target = TargetType{100}};
+
+    update_object_of_type<TargetType>([](TargetType& t) { t.value += 10; }, holder);
+
+    ASSERT_EQ(holder.targets.size(), 3);
+    EXPECT_EQ(holder.targets[0].value, 11);
+    EXPECT_EQ(holder.targets[1].value, 12);
+    EXPECT_EQ(holder.targets[2].value, 13);
+    ASSERT_TRUE(holder.maybe_target.has_value());
+    EXPECT_EQ(holder.maybe_target->value, 110);
+}
+
+TEST(UpdateObjectOfTypeTest, ReflectableWithEmptyOptionalMember) {
+    ContainerHolder holder{.targets = {{5}}, .maybe_target = std::nullopt};
+
+    update_object_of_type<TargetType>([](TargetType& t) { t.value *= 2; }, holder);
+
+    ASSERT_EQ(holder.targets.size(), 1);
+    EXPECT_EQ(holder.targets[0].value, 10);
+    EXPECT_FALSE(holder.maybe_target.has_value());
+}
+
+TEST(UpdateObjectOfTypeTest, NestedReflectableStructs) {
+    NestedHolder nested{.pair = {TargetType{1}, TargetType{2}}, .single = TargetType{3}};
+
+    update_object_of_type<TargetType>([](TargetType& t) { t.value *= 100; }, nested);
+
+    EXPECT_EQ(nested.pair.first.value, 100);
+    EXPECT_EQ(nested.pair.second.value, 200);
+    EXPECT_EQ(nested.single.value, 300);
+}
+
+TEST(UpdateObjectOfTypeTest, VectorOfReflectable) {
+    std::vector<PairOfTargets> pairs{{TargetType{1}, TargetType{2}}, {TargetType{3}, TargetType{4}}};
+
+    update_object_of_type<TargetType>([](TargetType& t) { t.value += 100; }, pairs);
+
+    ASSERT_EQ(pairs.size(), 2);
+    EXPECT_EQ(pairs[0].first.value, 101);
+    EXPECT_EQ(pairs[0].second.value, 102);
+    EXPECT_EQ(pairs[1].first.value, 103);
+    EXPECT_EQ(pairs[1].second.value, 104);
+}
+
+TEST(UpdateObjectOfTypeTest, OptionalReflectable) {
+    std::optional<PairOfTargets> opt_pair = PairOfTargets{TargetType{7}, TargetType{8}};
+
+    update_object_of_type<TargetType>([](TargetType& t) { t.value = -t.value; }, opt_pair);
+
+    ASSERT_TRUE(opt_pair.has_value());
+    EXPECT_EQ(opt_pair->first.value, -7);
+    EXPECT_EQ(opt_pair->second.value, -8);
+}
+
+}  // namespace
+}  // namespace ttsl::reflection

--- a/tt_stl/tt_stl/reflection.hpp
+++ b/tt_stl/tt_stl/reflection.hpp
@@ -690,18 +690,6 @@ struct visit_object_of_type_t<T> {
 
     template <typename object_t>
         requires std::same_as<std::decay_t<T>, object_t>
-    void operator()(auto&& callback, T& value) const {
-        callback(value);
-    }
-
-    template <typename object_t>
-        requires(not std::same_as<std::decay_t<T>, object_t>)
-    void operator()(auto&& /*callback*/, T& /*value*/) const {
-        throw std::runtime_error(fmt::format("Unsupported visit of object of type: {}", get_type_name<T>()));
-    }
-
-    template <typename object_t>
-        requires std::same_as<std::decay_t<T>, object_t>
     void operator()(auto&& callback, const T& value) const {
         callback(value);
     }
@@ -721,13 +709,6 @@ struct visit_object_of_type_t<std::optional<T>> {
             visit_object_of_type<object_t>(callback, value.value());
         }
     }
-
-    template <typename object_t>
-    void operator()(auto&& callback, std::optional<T>& value) const {
-        if (value.has_value()) {
-            visit_object_of_type<object_t>(callback, value.value());
-        }
-    }
 };
 
 template <typename T>
@@ -735,13 +716,6 @@ struct visit_object_of_type_t<std::vector<T>> {
     template <typename object_t>
     void operator()(auto&& callback, const std::vector<T>& value) const {
         for (const auto& element : value) {
-            visit_object_of_type<object_t>(callback, element);
-        }
-    }
-
-    template <typename object_t>
-    void operator()(auto&& callback, std::vector<T>& value) const {
-        for (auto& element : value) {
             visit_object_of_type<object_t>(callback, element);
         }
     }
@@ -755,26 +729,12 @@ struct visit_object_of_type_t<std::array<T, N>> {
             visit_object_of_type<object_t>(callback, element);
         }
     }
-
-    template <typename object_t>
-    void operator()(auto&& callback, std::array<T, N>& value) const {
-        for (auto& element : value) {
-            visit_object_of_type<object_t>(callback, element);
-        }
-    }
 };
 
 template <typename... Ts>
 struct visit_object_of_type_t<std::tuple<Ts...>> {
     template <typename object_t>
     void operator()(auto&& callback, const std::tuple<Ts...>& value) const {
-        [&callback, &value]<size_t... Ns>(std::index_sequence<Ns...>) {
-            (visit_object_of_type<object_t>(callback, std::get<Ns>(value)), ...);
-        }(std::make_index_sequence<sizeof...(Ts)>{});
-    }
-
-    template <typename object_t>
-    void operator()(auto&& callback, std::tuple<Ts...>& value) const {
         [&callback, &value]<size_t... Ns>(std::index_sequence<Ns...>) {
             (visit_object_of_type<object_t>(callback, std::get<Ns>(value)), ...);
         }(std::make_index_sequence<sizeof...(Ts)>{});
@@ -793,19 +753,6 @@ struct visit_object_of_type_t<T> {
     template <typename object_t>
         requires(not std::same_as<std::decay_t<T>, object_t>)
     void operator()(auto&& callback, T&& object) const {
-        constexpr auto num_attributes = std::tuple_size_v<decltype(std::decay_t<T>::attribute_names)>;
-        visit_object_of_type<object_t>(callback, object.attribute_values());
-    }
-
-    template <typename object_t>
-        requires std::same_as<std::decay_t<T>, object_t>
-    void operator()(auto&& callback, T& value) const {
-        callback(value);
-    }
-
-    template <typename object_t>
-        requires(not std::same_as<std::decay_t<T>, object_t>)
-    void operator()(auto&& callback, T& object) const {
         constexpr auto num_attributes = std::tuple_size_v<decltype(std::decay_t<T>::attribute_names)>;
         visit_object_of_type<object_t>(callback, object.attribute_values());
     }
@@ -843,20 +790,6 @@ struct visit_object_of_type_t<T> {
 
     template <typename object_t>
         requires std::same_as<std::decay_t<T>, object_t>
-    void operator()(auto&& callback, T& value) const {
-        callback(value);
-    }
-
-    template <typename object_t>
-        requires(not std::same_as<std::decay_t<T>, object_t>)
-    void operator()(auto&& callback, T& object) const {
-        reflect::for_each(
-            [&callback, &object](auto I) { visit_object_of_type<object_t>(callback, reflect::get<I>(object)); },
-            object);
-    }
-
-    template <typename object_t>
-        requires std::same_as<std::decay_t<T>, object_t>
     void operator()(auto&& callback, const T& value) const {
         callback(value);
     }
@@ -866,6 +799,110 @@ struct visit_object_of_type_t<T> {
     void operator()(auto&& callback, const T& object) const {
         reflect::for_each(
             [&callback, &object](auto I) { visit_object_of_type<object_t>(callback, reflect::get<I>(object)); },
+            object);
+    }
+};
+
+template <typename T>
+struct update_object_of_type_t;
+
+/**
+* Recursively visits all elements in `object` that are instances of `object_t`,
+* calls the `callback` function with those instance in anticipation for an inplace modification.
+ */
+template <typename object_t, typename T>
+void update_object_of_type(auto&& callback, T& object) {
+    update_object_of_type_t<std::decay_t<T>>{}.template operator()<object_t>(
+        std::forward<decltype(callback)>(callback), object);
+}
+
+template <typename T>
+    requires(not ttsl::concepts::Reflectable<std::decay_t<T>>) and (not requires { std::decay_t<T>::attribute_names; })
+struct update_object_of_type_t<T> {
+    template <typename object_t>
+        requires std::same_as<std::decay_t<T>, object_t>
+    void operator()(auto&& callback, T& value) const {
+        callback(value);
+    }
+
+    template <typename object_t>
+        requires(not std::same_as<std::decay_t<T>, object_t>)
+    void operator()(auto&& /*callback*/, T& /*value*/) const {
+        throw std::runtime_error(fmt::format("Unsupported update of object of type: {}", get_type_name<T>()));
+    }
+};
+
+template <typename T>
+struct update_object_of_type_t<std::optional<T>> {
+    template <typename object_t>
+    void operator()(auto&& callback, std::optional<T>& value) const {
+        if (value.has_value()) {
+            update_object_of_type<object_t>(callback, value.value());
+        }
+    }
+};
+
+template <typename T>
+struct update_object_of_type_t<std::vector<T>> {
+    template <typename object_t>
+    void operator()(auto&& callback, std::vector<T>& value) const {
+        for (auto& element : value) {
+            update_object_of_type<object_t>(callback, element);
+        }
+    }
+};
+
+template <typename T, auto N>
+struct update_object_of_type_t<std::array<T, N>> {
+    template <typename object_t>
+    void operator()(auto&& callback, std::array<T, N>& value) const {
+        for (auto& element : value) {
+            update_object_of_type<object_t>(callback, element);
+        }
+    }
+};
+
+template <typename... Ts>
+struct update_object_of_type_t<std::tuple<Ts...>> {
+    template <typename object_t>
+    void operator()(auto&& callback, std::tuple<Ts...>& value) const {
+        [&callback, &value]<size_t... Ns>(std::index_sequence<Ns...>) {
+            (update_object_of_type<object_t>(callback, std::get<Ns>(value)), ...);
+        }(std::make_index_sequence<sizeof...(Ts)>{});
+    }
+};
+
+template <typename T>
+    requires requires { std::decay_t<T>::attribute_names; }
+struct update_object_of_type_t<T> {
+    template <typename object_t>
+        requires std::same_as<std::decay_t<T>, object_t>
+    void operator()(auto&& callback, T& value) const {
+        callback(value);
+    }
+
+    template <typename object_t>
+        requires(not std::same_as<std::decay_t<T>, object_t>)
+    void operator()(auto&& callback, T& object) const {
+        constexpr auto num_attributes = std::tuple_size_v<decltype(std::decay_t<T>::attribute_names)>;
+        update_object_of_type<object_t>(callback, object.attribute_values());
+    }
+};
+
+template <typename T>
+    requires ttsl::concepts::Reflectable<std::decay_t<T>>
+struct update_object_of_type_t<T> {
+    template <typename object_t>
+        requires std::same_as<std::decay_t<T>, object_t>
+    void operator()(auto&& callback, T& value) const {
+        callback(value);
+    }
+
+    template <typename object_t>
+        requires(not std::same_as<std::decay_t<T>, object_t>)
+    void operator()(auto&& callback, T& object) const {
+        reflect::for_each(
+            [&callback, &object](auto I) { update_object_of_type<object_t>(callback, reflect::get<I>(object)); },
             object);
     }
 };

--- a/tt_stl/tt_stl/reflection.hpp
+++ b/tt_stl/tt_stl/reflection.hpp
@@ -690,6 +690,18 @@ struct visit_object_of_type_t<T> {
 
     template <typename object_t>
         requires std::same_as<std::decay_t<T>, object_t>
+    void operator()(auto&& callback, T& value) const {
+        callback(value);
+    }
+
+    template <typename object_t>
+        requires(not std::same_as<std::decay_t<T>, object_t>)
+    void operator()(auto&& /*callback*/, T& /*value*/) const {
+        throw std::runtime_error(fmt::format("Unsupported visit of object of type: {}", get_type_name<T>()));
+    }
+
+    template <typename object_t>
+        requires std::same_as<std::decay_t<T>, object_t>
     void operator()(auto&& callback, const T& value) const {
         callback(value);
     }
@@ -709,14 +721,28 @@ struct visit_object_of_type_t<std::optional<T>> {
             visit_object_of_type<object_t>(callback, value.value());
         }
     }
+
+    template <typename object_t>
+    void operator()(auto&& callback, std::optional<T>& value) const {
+        if (value.has_value()) {
+            visit_object_of_type<object_t>(callback, value.value());
+        }
+    }
 };
 
 template <typename T>
 struct visit_object_of_type_t<std::vector<T>> {
     template <typename object_t>
     void operator()(auto&& callback, const std::vector<T>& value) const {
-        for (auto& tensor : value) {
-            visit_object_of_type<object_t>(callback, tensor);
+        for (const auto& element : value) {
+            visit_object_of_type<object_t>(callback, element);
+        }
+    }
+
+    template <typename object_t>
+    void operator()(auto&& callback, std::vector<T>& value) const {
+        for (auto& element : value) {
+            visit_object_of_type<object_t>(callback, element);
         }
     }
 };
@@ -725,8 +751,15 @@ template <typename T, auto N>
 struct visit_object_of_type_t<std::array<T, N>> {
     template <typename object_t>
     void operator()(auto&& callback, const std::array<T, N>& value) const {
-        for (auto& tensor : value) {
-            visit_object_of_type<object_t>(callback, tensor);
+        for (const auto& element : value) {
+            visit_object_of_type<object_t>(callback, element);
+        }
+    }
+
+    template <typename object_t>
+    void operator()(auto&& callback, std::array<T, N>& value) const {
+        for (auto& element : value) {
+            visit_object_of_type<object_t>(callback, element);
         }
     }
 };
@@ -735,6 +768,13 @@ template <typename... Ts>
 struct visit_object_of_type_t<std::tuple<Ts...>> {
     template <typename object_t>
     void operator()(auto&& callback, const std::tuple<Ts...>& value) const {
+        [&callback, &value]<size_t... Ns>(std::index_sequence<Ns...>) {
+            (visit_object_of_type<object_t>(callback, std::get<Ns>(value)), ...);
+        }(std::make_index_sequence<sizeof...(Ts)>{});
+    }
+
+    template <typename object_t>
+    void operator()(auto&& callback, std::tuple<Ts...>& value) const {
         [&callback, &value]<size_t... Ns>(std::index_sequence<Ns...>) {
             (visit_object_of_type<object_t>(callback, std::get<Ns>(value)), ...);
         }(std::make_index_sequence<sizeof...(Ts)>{});
@@ -753,6 +793,19 @@ struct visit_object_of_type_t<T> {
     template <typename object_t>
         requires(not std::same_as<std::decay_t<T>, object_t>)
     void operator()(auto&& callback, T&& object) const {
+        constexpr auto num_attributes = std::tuple_size_v<decltype(std::decay_t<T>::attribute_names)>;
+        visit_object_of_type<object_t>(callback, object.attribute_values());
+    }
+
+    template <typename object_t>
+        requires std::same_as<std::decay_t<T>, object_t>
+    void operator()(auto&& callback, T& value) const {
+        callback(value);
+    }
+
+    template <typename object_t>
+        requires(not std::same_as<std::decay_t<T>, object_t>)
+    void operator()(auto&& callback, T& object) const {
         constexpr auto num_attributes = std::tuple_size_v<decltype(std::decay_t<T>::attribute_names)>;
         visit_object_of_type<object_t>(callback, object.attribute_values());
     }
@@ -783,6 +836,20 @@ struct visit_object_of_type_t<T> {
     template <typename object_t>
         requires(not std::same_as<std::decay_t<T>, object_t>)
     void operator()(auto&& callback, T&& object) const {
+        reflect::for_each(
+            [&callback, &object](auto I) { visit_object_of_type<object_t>(callback, reflect::get<I>(object)); },
+            object);
+    }
+
+    template <typename object_t>
+        requires std::same_as<std::decay_t<T>, object_t>
+    void operator()(auto&& callback, T& value) const {
+        callback(value);
+    }
+
+    template <typename object_t>
+        requires(not std::same_as<std::decay_t<T>, object_t>)
+    void operator()(auto&& callback, T& object) const {
         reflect::for_each(
             [&callback, &object](auto I) { visit_object_of_type<object_t>(callback, reflect::get<I>(object)); },
             object);

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -397,10 +397,6 @@ void launch_operation_with_adapter(
     }
 }
 
-// get_output_placements_and_shape has been factored into the non-template function
-// compute_output_placements_and_shape() in device_operation_detail.hpp/cpp.
-// This eliminates ~100 lines of template code that was instantiated per operation type.
-
 template <DeviceOperationConcept device_operation_t>
 ttnn::MeshDevice* get_mesh_device(
     const typename device_operation_t::operation_attributes_t& operation_attributes,
@@ -441,11 +437,8 @@ typename device_operation_t::tensor_return_value_t launch(
     const auto operation_name = detail::get_operation_name<device_operation_t>(operation_attributes);
     tt::tt_metal::GraphTracker::instance().track_function_start(operation_name, operation_attributes, input_tensors);
 
-    auto first_tensor = ttsl::reflection::get_first_object_of_type<Tensor>(tensor_args);
-    if (first_tensor.has_value()) [[likely]] {
-        TT_FATAL(
-            tt::tt_metal::is_device_tensor(first_tensor.value()),
-            "Device Operations expect tensor with Device storage in inputs");
+    if (!input_tensors.empty()) {
+        TT_FATAL(is_device_tensor(input_tensors.front().get()), "Device Operations expect tensor with Device storage in inputs");
     }
 
     auto tensor_return_value = device_operation_t::create_output_tensors(operation_attributes, tensor_args);
@@ -465,8 +458,7 @@ typename device_operation_t::tensor_return_value_t launch(
             mesh_device_operation_utils::extract_tensor_coordinates(tensor_args, mesh_device), tensor_return_value);
     }
 
-    if (first_tensor.has_value()) [[likely]] {
-        // Check if op provides custom output topologies
+    if (!input_tensors.empty()) [[likely]] {
         std::vector<tt::tt_metal::TensorTopology> custom_topologies;
         if constexpr (requires {
                           {
@@ -476,31 +468,8 @@ typename device_operation_t::tensor_return_value_t launch(
             custom_topologies = device_operation_t::compute_output_topologies(operation_attributes, tensor_args);
         }
 
-        std::vector<std::reference_wrapper<Tensor>> output_tensors;
-        tt::stl::reflection::update_object_of_type<Tensor>(
-            [&output_tensors](Tensor& t) { output_tensors.push_back(std::ref(t)); }, tensor_return_value);
-
-        if (!custom_topologies.empty()) {
-            // Use custom topologies provided by the op
-            TT_FATAL(custom_topologies.size() == output_tensors.size(), "Number of custom topologies ({}) does not match number of output tensors ({})", custom_topologies.size(), output_tensors.size());
-
-            for (auto i = 0ul; i < custom_topologies.size(); i++) {
-                output_tensors[i].get().update_tensor_topology(std::move(custom_topologies[i]));
-            }
-        } else {
-            // Fall back to default topology imputation.
-            // Uses the pre-extracted input_tensors to avoid re-visiting the templated tensor_args struct.
-            auto output_topology_result =
-                detail::compute_output_placements_and_shape(input_tensors, first_tensor.value());
-
-            for (auto &tensor : output_tensors) {
-                auto topology = tt::tt_metal::TensorTopology(
-                    output_topology_result.second,
-                    output_topology_result.first,
-                    tensor.get().tensor_topology().mesh_coords());
-                tensor.get().update_tensor_topology(std::move(topology));
-            }
-        }
+        mesh_device_operation_utils::update_output_tensor_topologies(
+            tensor_return_value, input_tensors, std::move(custom_topologies));
     }
 
     detail::launch_operation_with_adapter<MeshDeviceOperationAdapter<device_operation_t>>(

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -478,7 +478,7 @@ typename device_operation_t::tensor_return_value_t launch(
 
         if (!custom_topologies.empty()) {
             // Use custom topologies provided by the op
-            ttsl::reflection::visit_object_of_type<Tensor>(
+            ttsl::reflection::update_object_of_type<Tensor>(
                 [&custom_topologies, topology_idx = size_t{0}](Tensor& output_tensor) mutable {
                     TT_FATAL(
                         topology_idx < custom_topologies.size(),
@@ -492,7 +492,7 @@ typename device_operation_t::tensor_return_value_t launch(
             auto output_topology_result =
                 detail::compute_output_placements_and_shape(input_tensors, first_tensor.value());
 
-            ttsl::reflection::visit_object_of_type<Tensor>(
+            ttsl::reflection::update_object_of_type<Tensor>(
                 [&output_topology_result](Tensor& output_tensor) {
                     auto topology = tt::tt_metal::TensorTopology(
                         output_topology_result.second,

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -476,31 +476,30 @@ typename device_operation_t::tensor_return_value_t launch(
             custom_topologies = device_operation_t::compute_output_topologies(operation_attributes, tensor_args);
         }
 
+        std::vector<std::reference_wrapper<Tensor>> output_tensors;
+        tt::stl::reflection::update_object_of_type<Tensor>(
+            [&output_tensors](Tensor& t) { output_tensors.push_back(std::ref(t)); }, tensor_return_value);
+
         if (!custom_topologies.empty()) {
             // Use custom topologies provided by the op
-            ttsl::reflection::update_object_of_type<Tensor>(
-                [&custom_topologies, topology_idx = size_t{0}](Tensor& output_tensor) mutable {
-                    TT_FATAL(
-                        topology_idx < custom_topologies.size(),
-                        "Not enough custom topologies provided for output tensors");
-                    output_tensor.update_tensor_topology(custom_topologies[topology_idx++]);
-                },
-                tensor_return_value);
+            TT_FATAL(custom_topologies.size() == output_tensors.size(), "Number of custom topologies ({}) does not match number of output tensors ({})", custom_topologies.size(), output_tensors.size());
+
+            for (auto i = 0ul; i < custom_topologies.size(); i++) {
+                output_tensors[i].get().update_tensor_topology(std::move(custom_topologies[i]));
+            }
         } else {
             // Fall back to default topology imputation.
             // Uses the pre-extracted input_tensors to avoid re-visiting the templated tensor_args struct.
             auto output_topology_result =
                 detail::compute_output_placements_and_shape(input_tensors, first_tensor.value());
 
-            ttsl::reflection::update_object_of_type<Tensor>(
-                [&output_topology_result](Tensor& output_tensor) {
-                    auto topology = tt::tt_metal::TensorTopology(
-                        output_topology_result.second,
-                        output_topology_result.first,
-                        output_tensor.tensor_topology().mesh_coords());
-                    output_tensor.update_tensor_topology(topology);
-                },
-                tensor_return_value);
+            for (auto &tensor : output_tensors) {
+                auto topology = tt::tt_metal::TensorTopology(
+                    output_topology_result.second,
+                    output_topology_result.first,
+                    tensor.get().tensor_topology().mesh_coords());
+                tensor.get().update_tensor_topology(std::move(topology));
+            }
         }
     }
 

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -478,12 +478,12 @@ typename device_operation_t::tensor_return_value_t launch(
 
         if (!custom_topologies.empty()) {
             // Use custom topologies provided by the op
-            tensor_return_value = ttsl::reflection::transform_object_of_type<Tensor>(
-                [&custom_topologies, topology_idx = size_t{0}](const Tensor& output_tensor) mutable {
+            ttsl::reflection::visit_object_of_type<Tensor>(
+                [&custom_topologies, topology_idx = size_t{0}](Tensor& output_tensor) mutable {
                     TT_FATAL(
                         topology_idx < custom_topologies.size(),
                         "Not enough custom topologies provided for output tensors");
-                    return output_tensor.with_tensor_topology(custom_topologies[topology_idx++]);
+                    output_tensor.update_tensor_topology(custom_topologies[topology_idx++]);
                 },
                 tensor_return_value);
         } else {
@@ -492,13 +492,13 @@ typename device_operation_t::tensor_return_value_t launch(
             auto output_topology_result =
                 detail::compute_output_placements_and_shape(input_tensors, first_tensor.value());
 
-            tensor_return_value = ttsl::reflection::transform_object_of_type<Tensor>(
-                [&output_topology_result](const Tensor& output_tensor) {
+            ttsl::reflection::visit_object_of_type<Tensor>(
+                [&output_topology_result](Tensor& output_tensor) {
                     auto topology = tt::tt_metal::TensorTopology(
                         output_topology_result.second,
                         output_topology_result.first,
                         output_tensor.tensor_topology().mesh_coords());
-                    return output_tensor.with_tensor_topology(topology);
+                    output_tensor.update_tensor_topology(topology);
                 },
                 tensor_return_value);
         }

--- a/ttnn/api/ttnn/device_operation_detail.hpp
+++ b/ttnn/api/ttnn/device_operation_detail.hpp
@@ -34,8 +34,7 @@ std::pair<
     ttsl::SmallVector<tt::tt_metal::distributed::MeshMapperConfig::Placement>,
     tt::tt_metal::distributed::MeshShape>
 compute_output_placements_and_shape(
-    const std::vector<std::reference_wrapper<const tt::tt_metal::Tensor>>& tensors,
-    const tt::tt_metal::Tensor& first_tensor);
+    const std::vector<std::reference_wrapper<const tt::tt_metal::Tensor>>& tensors);
 
 /**
  * Non-template implementation of tensor coordinate extraction.

--- a/ttnn/api/ttnn/mesh_device_operation_utils.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_utils.hpp
@@ -143,7 +143,7 @@ void update_output_tensor_topologies(
             output_tensors.size());
 
         for (auto i = 0ul; i < custom_topologies.size(); i++) {
-            output_tensors[i].get().update_tensor_topology(std::move(custom_topologies[i]));
+            output_tensors[i].get().update_tensor_topology(custom_topologies[i]);
         }
     } else {
         auto output_topology_result =
@@ -154,7 +154,7 @@ void update_output_tensor_topologies(
                 output_topology_result.second,
                 output_topology_result.first,
                 tensor.get().tensor_topology().mesh_coords());
-            tensor.get().update_tensor_topology(std::move(topology));
+            tensor.get().update_tensor_topology(topology);
         }
     }
 }

--- a/ttnn/api/ttnn/mesh_device_operation_utils.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_utils.hpp
@@ -119,4 +119,44 @@ void apply_override_runtime_arguments(
     }
 }
 
+/**
+ * Update output tensor topologies with either custom topologies or imputed defaults.
+ *
+ * @param tensor_return_value The output tensor(s) to update (mutated in place).
+ * @param input_tensors Pre-extracted input tensors for computing default topology.
+ * @param custom_topologies Optional custom topologies from the operation (empty if none provided).
+ */
+template <typename TensorReturnValue>
+void update_output_tensor_topologies(
+    TensorReturnValue& tensor_return_value,
+    const std::vector<std::reference_wrapper<const Tensor>>& input_tensors,
+    std::vector<tt::tt_metal::TensorTopology> custom_topologies) {
+    std::vector<std::reference_wrapper<Tensor>> output_tensors;
+    tt::stl::reflection::update_object_of_type<Tensor>(
+        [&output_tensors](Tensor& t) { output_tensors.push_back(std::ref(t)); }, tensor_return_value);
+
+    if (!custom_topologies.empty()) {
+        TT_FATAL(
+            custom_topologies.size() == output_tensors.size(),
+            "Number of custom topologies ({}) does not match number of output tensors ({})",
+            custom_topologies.size(),
+            output_tensors.size());
+
+        for (auto i = 0ul; i < custom_topologies.size(); i++) {
+            output_tensors[i].get().update_tensor_topology(std::move(custom_topologies[i]));
+        }
+    } else {
+        auto output_topology_result =
+            ttnn::device_operation::detail::compute_output_placements_and_shape(input_tensors);
+
+        for (auto& tensor : output_tensors) {
+            auto topology = tt::tt_metal::TensorTopology(
+                output_topology_result.second,
+                output_topology_result.first,
+                tensor.get().tensor_topology().mesh_coords());
+            tensor.get().update_tensor_topology(std::move(topology));
+        }
+    }
+}
+
 }  // namespace ttnn::device_operation::mesh_device_operation_utils

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -44,6 +44,7 @@ public:
 
     // Returns the host tensor.
     const HostTensor& host_tensor() const;
+    HostTensor& host_tensor();
 
     // Applies a transformation function to each device buffer in parallel, returning a new HostStorage.
     HostStorage transform(const std::function<HostBuffer(const HostBuffer&)>& callable) const;

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -192,7 +192,7 @@ public:
     [[nodiscard]] Tensor reshape(
         const tt::tt_metal::Shape& new_logical_shape, const tt::tt_metal::Shape& new_padded_shape) const;
 
-    void update_tensor_topology(TensorTopology tensor_topology);
+    void update_tensor_topology(const TensorTopology& tensor_topology);
     // ======================================================================================
     //                                      Getters
     // ======================================================================================

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -192,7 +192,7 @@ public:
     [[nodiscard]] Tensor reshape(
         const tt::tt_metal::Shape& new_logical_shape, const tt::tt_metal::Shape& new_padded_shape) const;
 
-    Tensor with_tensor_topology(TensorTopology tensor_topology) const;
+    void update_tensor_topology(TensorTopology tensor_topology);
     // ======================================================================================
     //                                      Getters
     // ======================================================================================

--- a/ttnn/api/ttnn/tensor/tensor_attributes.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_attributes.hpp
@@ -45,7 +45,7 @@ public:
     const TensorSpec& get_tensor_spec() const;
     const TensorTopology& get_tensor_topology() const;
 
-    void update_tensor_topology(TensorTopology tensor_topology);
+    void update_tensor_topology(const TensorTopology& tensor_topology);
 
 private:
     Storage storage_;

--- a/ttnn/api/ttnn/tensor/tensor_attributes.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_attributes.hpp
@@ -45,7 +45,7 @@ public:
     const TensorSpec& get_tensor_spec() const;
     const TensorTopology& get_tensor_topology() const;
 
-    TensorAttributes with_tensor_topology(TensorTopology tensor_topology) const;
+    void update_tensor_topology(TensorTopology tensor_topology);
 
 private:
     Storage storage_;

--- a/ttnn/core/device_operation_detail.cpp
+++ b/ttnn/core/device_operation_detail.cpp
@@ -53,6 +53,8 @@ compute_output_placements_and_shape(
     using Shard = tt::tt_metal::distributed::MeshMapperConfig::Shard;
     using Replicate = tt::tt_metal::distributed::MeshMapperConfig::Replicate;
 
+    TT_FATAL(!tensors.empty(), "Cannot compute output placements and shape with no tensors");
+
     std::vector<std::reference_wrapper<const Tensor>> sharded_tensors;
     for (const auto& tensor_ref : tensors) {
         if (!is_fully_replicated(tensor_ref.get())) {

--- a/ttnn/core/device_operation_detail.cpp
+++ b/ttnn/core/device_operation_detail.cpp
@@ -47,8 +47,7 @@ std::pair<
     ttsl::SmallVector<tt::tt_metal::distributed::MeshMapperConfig::Placement>,
     tt::tt_metal::distributed::MeshShape>
 compute_output_placements_and_shape(
-    const std::vector<std::reference_wrapper<const tt::tt_metal::Tensor>>& tensors,
-    const tt::tt_metal::Tensor& first_tensor) {
+    const std::vector<std::reference_wrapper<const tt::tt_metal::Tensor>>& tensors) {
     using Tensor = tt::tt_metal::Tensor;
     using Placement = tt::tt_metal::distributed::MeshMapperConfig::Placement;
     using Shard = tt::tt_metal::distributed::MeshMapperConfig::Shard;
@@ -70,6 +69,7 @@ compute_output_placements_and_shape(
                 std::max(max_distribution_rank, tensor_ref.get().tensor_topology().distribution_shape().dims());
         }
     } else {
+        const auto &first_tensor = tensors.front().get();
         max_distribution_rank = first_tensor.tensor_topology().distribution_shape().dims();
     }
 

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -41,6 +41,7 @@ HostStorage::HostStorage(HostStorage&& other, TensorSpec spec, TensorTopology to
 const DistributedHostBuffer& HostStorage::buffer() const { return tensor.buffer(); }
 
 const HostTensor& HostStorage::host_tensor() const { return tensor; }
+HostTensor& HostStorage::host_tensor() { return tensor; }
 
 HostStorage HostStorage::transform(const std::function<HostBuffer(const HostBuffer&)>& callable) const {
     return HostStorage(tensor.transform(callable));

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -476,11 +476,8 @@ Tensor Tensor::reshape(
     return view(*this, new_logical_shape, new_padded_shape);
 }
 
-Tensor Tensor::with_tensor_topology(TensorTopology tensor_topology) const {
-    Tensor result = *this;
-    result.tensor_attributes =
-        std::make_shared<TensorAttributes>(tensor_attributes->with_tensor_topology(std::move(tensor_topology)));
-    return result;
+void Tensor::update_tensor_topology(TensorTopology tensor_topology) {
+    tensor_attributes->update_tensor_topology(std::move(tensor_topology));
 }
 
 bool Tensor::is_allocated() const {

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -476,8 +476,8 @@ Tensor Tensor::reshape(
     return view(*this, new_logical_shape, new_padded_shape);
 }
 
-void Tensor::update_tensor_topology(TensorTopology tensor_topology) {
-    tensor_attributes->update_tensor_topology(std::move(tensor_topology));
+void Tensor::update_tensor_topology(const TensorTopology& tensor_topology) {
+    tensor_attributes->update_tensor_topology(tensor_topology);
 }
 
 bool Tensor::is_allocated() const {

--- a/ttnn/core/tensor/tensor_attributes.cpp
+++ b/ttnn/core/tensor/tensor_attributes.cpp
@@ -51,15 +51,11 @@ const TensorTopology& TensorAttributes::get_tensor_topology() const {
     return tensor_topology_;
 }
 
-TensorAttributes TensorAttributes::with_tensor_topology(TensorTopology tensor_topology) const {
-    // This needs to be moved to HostTensor after TODO(#39485)
-    if (const auto* host_storage = std::get_if<HostStorage>(&storage_)) {
-        HostStorage new_storage(*host_storage, tensor_spec_, tensor_topology);
-        return TensorAttributes(std::move(new_storage));
+void TensorAttributes::update_tensor_topology(TensorTopology tensor_topology) {
+    if (auto* host_storage = std::get_if<HostStorage>(&storage_)) {
+        host_storage->host_tensor().update_tensor_topology(std::move(tensor_topology));
     }
-    TensorAttributes result = *this;
-    result.tensor_topology_ = std::move(tensor_topology);
-    return result;
+    tensor_topology_ = std::move(tensor_topology);
 }
 
 }  // namespace tt::tt_metal

--- a/ttnn/core/tensor/tensor_attributes.cpp
+++ b/ttnn/core/tensor/tensor_attributes.cpp
@@ -51,10 +51,7 @@ const TensorTopology& TensorAttributes::get_tensor_topology() const {
     return tensor_topology_;
 }
 
-void TensorAttributes::update_tensor_topology(TensorTopology tensor_topology) {
-    if (auto* host_storage = std::get_if<HostStorage>(&storage_)) {
-        host_storage->host_tensor().update_tensor_topology(tensor_topology);
-    }
+void TensorAttributes::update_tensor_topology(const TensorTopology& tensor_topology) {
     tensor_topology_ = tensor_topology;
 }
 

--- a/ttnn/core/tensor/tensor_attributes.cpp
+++ b/ttnn/core/tensor/tensor_attributes.cpp
@@ -53,9 +53,9 @@ const TensorTopology& TensorAttributes::get_tensor_topology() const {
 
 void TensorAttributes::update_tensor_topology(TensorTopology tensor_topology) {
     if (auto* host_storage = std::get_if<HostStorage>(&storage_)) {
-        host_storage->host_tensor().update_tensor_topology(std::move(tensor_topology));
+        host_storage->host_tensor().update_tensor_topology(tensor_topology);
     }
-    tensor_topology_ = std::move(tensor_topology);
+    tensor_topology_ = tensor_topology;
 }
 
 }  // namespace tt::tt_metal


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-metal/issues/38693

### Kind

**Semantic Change** refactor

### Problem description

Runtime is lowering Tensor from TTNN to Metal Runtime by splitting existing Tensor into HostTensor and MeshTensor.

Current TTNN Tensor updates it's topology via copy-on-write.
The new MeshTensor is not copyable.
Thus current TTNN Tensor will not be able to be refactored to use MeshTensor.

### What's changed

- Replace `with_tensor_topology` with `update_tensor_topology`, the new function is available on a mutable tensor and is a simple member variable update.
- Added `update_object_of_type` overload in `tt_stl` which allows mutable recursive object visit. This is done over adding overloads to `visit_object_of_type` to prevent over-complicated value semantic overloads and surprises.
- Refactored the device operation slightly surrounding tensor topology to fight entropy. 

### Checklist

- [x] [APC](https://github.com/tenstorrent/tt-metal/actions/runs/22927363346)
- [x] [Sanity](https://github.com/tenstorrent/tt-metal/actions/runs/23171710317)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu/update-tensor-topology)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/update-tensor-topology)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/update-tensor-topology)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/update-tensor-topology)
- [x] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early
