### PR TITLE
Revert mcast-based synchronization in neighbor_pad_async

### DIFF
--- a/tests/nightly/tg/ccl/test_neighbor_pad_async.py
+++ b/tests/nightly/tg/ccl/test_neighbor_pad_async.py
@@ -5,7 +5,6 @@
 
 import pytest
 import ttnn
-from models.common.utility_functions import is_blackhole
 from tests.nightly.t3000.ccl.test_neighbor_pad_async import run_neighbor_pad_1d_impl, run_neighbor_pad_2d_impl
 
 
@@ -115,9 +114,6 @@ def test_neighbor_pad_async_1d(
     if is_ci_env:
         if skip_for_ci_env:
             pytest.skip("Skipping certain shapes in CI to reduce pipeline time")
-
-    if is_blackhole() and num_links > 2:
-        pytest.skip("Skipping num_links > 2 on BH (only 2 ethernet channels available)")
 
     run_neighbor_pad_1d_impl(
         mesh_device,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/kernels/minimal_default_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/kernels/minimal_default_writer.cpp
@@ -13,12 +13,10 @@
 #include "tt_metal/fabric/hw/inc/tt_fabric_status.h"
 #include "tt_metal/fabric/hw/inc/packet_header_pool.h"
 #include "cpp/ttnn/operations/ccl/common/kernels/minimal_ccl_common.hpp"
-#include "tt_metal/fabric/hw/inc/linear/api.h"
 #include <cstdint>
 #include <utility>
 
 using address_t = uint32_t;
-using namespace tt::tt_fabric::linear::experimental;
 
 constexpr bool is_first_chip = get_compile_time_arg_val(0);
 constexpr bool is_last_chip = get_compile_time_arg_val(1);
@@ -35,10 +33,6 @@ constexpr bool handle_incoming_writes = get_compile_time_arg_val(ct_after_dst + 
 constexpr bool is_w_fabric_writer = get_compile_time_arg_val(ct_after_dst + 3);
 // Unicast route info: {dst_mesh_id, distance_in_hops} for 1D, {mesh_id, chip_id} for 2D
 constexpr auto unicast_route_info = ccl_routing_utils::get_line_unicast_route_info_from_args<ct_after_dst + 4>();
-// Barrier multicast route info (6 args) and ring_size for full-mesh startup barrier
-constexpr auto barrier_multicast_route_info =
-    ccl_routing_utils::get_line_multicast_route_info_from_args<ct_after_dst + 6>();
-constexpr uint32_t ring_size = get_compile_time_arg_val(ct_after_dst + 12);
 
 void kernel_main() {
     ///////////////////////////////////////////////////
@@ -93,67 +87,46 @@ void kernel_main() {
     ccl_routing_utils::fabric_set_line_unicast_route(pkt_hdr, unicast_route_info);
     auto pkt_hdr_sem_inc = PacketHeaderPool::allocate_header();
 
-    // H writers: always open fabric at start (for data transfer in main loop).
-    // W writers: open at start only when startup barrier is enabled (defer data transfer until CB ready).
+    // H writers: open fabric at kernel start for initial barrier exchange.
+    // W writers: defer fabric open until first cb_wait_front in main loop
+    // (implicitly gated by Phase 2 barrier via CB dependency with W reader).
     bool fabric_opened = false;
-    if (!is_w_fabric_writer || use_barrier_sem) {
+    if constexpr (!is_w_fabric_writer) {
         fabric_connection.open();
         fabric_opened = true;
-    }
 
-    // Startup barrier: full-mesh multicast sync.
-    // H writers: sync with all H-axis devices (same column).
-    // W writers: sync with all W-axis devices (same row).
-    // Together these transitively synchronize all devices in the mesh,
-    // ensuring the previous dispatch has completed before new fabric data is sent.
-    // Each direction's writer multicasts atomic inc to both same-direction and opposite-direction
-    // cores on all reachable devices. Every core waits for ring_size-1 total increments.
-    if (use_barrier_sem) {
-        auto pkt_hdr_barrier_sem_inc = PacketHeaderPool::allocate_header();
+        // Barrier semaphore (H writers only): pairwise sync with H neighbor
+        if (use_barrier_sem) {
+            auto pkt_hdr_barrier_sem_inc = PacketHeaderPool::allocate_header();
 
-        if constexpr (!is_last_chip) {
-            // Set up multicast routing and atomic inc state
-            ccl_routing_utils::fabric_set_line_multicast_route(pkt_hdr_barrier_sem_inc, barrier_multicast_route_info);
-            fabric_multicast_noc_unicast_atomic_inc_set_state<
-                UnicastAtomicIncUpdateMask::Val | UnicastAtomicIncUpdateMask::Flush>(
-                pkt_hdr_barrier_sem_inc,
-                static_cast<uint8_t>(barrier_multicast_route_info.start_distance_in_hops),
-                static_cast<uint8_t>(barrier_multicast_route_info.range_hops),
-                tt::tt_fabric::NocUnicastAtomicIncCommandHeader{0, static_cast<uint32_t>(1)});
-
-            // Multicast to same-direction cores on all reachable devices
-            uint64_t same_dir_noc_addr = safe_get_noc_addr(neighbor_sem_noc0_x, neighbor_sem_noc0_y, barrier_sem, 0);
-            if constexpr (direction) {
-                fabric_multicast_noc_unicast_atomic_inc_with_state<UnicastAtomicIncUpdateMask::DstAddr>(
-                    &fabric_connection.get_backward_connection(),
-                    pkt_hdr_barrier_sem_inc,
-                    tt::tt_fabric::NocUnicastAtomicIncCommandHeader{same_dir_noc_addr, 0});
-            } else {
-                fabric_multicast_noc_unicast_atomic_inc_with_state<UnicastAtomicIncUpdateMask::DstAddr>(
-                    &fabric_connection.get_forward_connection(),
-                    pkt_hdr_barrier_sem_inc,
-                    tt::tt_fabric::NocUnicastAtomicIncCommandHeader{same_dir_noc_addr, 0});
+            if (!is_last_chip) {
+                uint64_t barrier_sem_noc_addr_in_pkt =
+                    safe_get_noc_addr(barrier_sem_noc0_x, barrier_sem_noc0_y, barrier_sem, 0);
+                pkt_hdr_barrier_sem_inc->to_noc_unicast_atomic_inc(tt::tt_fabric::NocUnicastAtomicIncCommandHeader{
+                    barrier_sem_noc_addr_in_pkt, static_cast<uint32_t>(1)});
+                if (direction) {
+                    if (fabric_connection.has_backward_connection()) {
+                        fabric_connection.get_backward_connection().wait_for_empty_write_slot();
+                        ccl_routing_utils::fabric_set_line_unicast_route(pkt_hdr_barrier_sem_inc, unicast_route_info);
+                        fabric_connection.get_backward_connection().send_payload_flush_blocking_from_address(
+                            (uint32_t)pkt_hdr_barrier_sem_inc, sizeof(PACKET_HEADER_TYPE));
+                    }
+                } else {
+                    if (fabric_connection.has_forward_connection()) {
+                        fabric_connection.get_forward_connection().wait_for_empty_write_slot();
+                        ccl_routing_utils::fabric_set_line_unicast_route(pkt_hdr_barrier_sem_inc, unicast_route_info);
+                        fabric_connection.get_forward_connection().send_payload_flush_blocking_from_address(
+                            (uint32_t)pkt_hdr_barrier_sem_inc, sizeof(PACKET_HEADER_TYPE));
+                    }
+                }
+                noc_async_writes_flushed();
             }
 
-            // Multicast to opposite-direction cores on all reachable devices
-            uint64_t opp_dir_noc_addr = safe_get_noc_addr(barrier_sem_noc0_x, barrier_sem_noc0_y, barrier_sem, 0);
-            if constexpr (direction) {
-                fabric_multicast_noc_unicast_atomic_inc_with_state<UnicastAtomicIncUpdateMask::DstAddr>(
-                    &fabric_connection.get_backward_connection(),
-                    pkt_hdr_barrier_sem_inc,
-                    tt::tt_fabric::NocUnicastAtomicIncCommandHeader{opp_dir_noc_addr, 0});
-            } else {
-                fabric_multicast_noc_unicast_atomic_inc_with_state<UnicastAtomicIncUpdateMask::DstAddr>(
-                    &fabric_connection.get_forward_connection(),
-                    pkt_hdr_barrier_sem_inc,
-                    tt::tt_fabric::NocUnicastAtomicIncCommandHeader{opp_dir_noc_addr, 0});
+            if (!is_last_chip) {
+                noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), 1);
             }
+            noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), 0);
         }
-
-        if constexpr (ring_size > 1) {
-            noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), ring_size - 1);
-        }
-        noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), 0);
     }
 
     uint32_t outer_dim_offset = outer_dim_offset_start_id;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/neighbor_pad_async_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/neighbor_pad_async_program_factory.cpp
@@ -135,10 +135,6 @@ void NeighborPadAsyncMeshWorkloadFactory::override_runtime_arguments(
             w_writer_args[0] = output.buffer()->address();
             w_writer_args[1] = output.buffer()->address();
             w_writer_args[13] = operation_attributes.w_neighbor_semaphore.address();
-            w_writer_args[14] = true;  // use_barrier_semaphore (W-axis startup barrier)
-            // Use h_neighbor_semaphore (not barrier_semaphore) — W reader on same core uses
-            // barrier_semaphore for Phase 2 barrier, so they must use different addresses.
-            w_writer_args[17] = operation_attributes.h_neighbor_semaphore.address();
         }
     }
 }
@@ -148,11 +144,9 @@ void NeighborPadAsyncMeshWorkloadFactory::override_runtime_arguments(
 // Input: [B,T,H,W,C] fractured across 2D mesh (H across rows, W across columns)
 // Output: [B,T,H+2pH,W+2pW,C]
 //
-// Phase 0 — Startup barrier (multicast sync across all devices):
-//   H fabric writers multicast barrier with all H-axis devices (same column).
-//   W fabric writers multicast barrier with all W-axis devices (same row).
-//   Together these transitively synchronize all devices, ensuring the previous
-//   dispatch has completed before any new fabric data is sent.
+// Phase 0 — H writer startup barrier (skipped when using persistent output buffers):
+//   H fabric writers do a pairwise semaphore exchange with their H neighbor via fabric
+//   to ensure both sides have allocated their output buffers before any fabric data is sent.
 //
 // Phase 1 — Interior copy + H halo exchange (all ~120 cores active):
 //   Local copy cores: read input sticks → write to output DRAM at (h+pH, w+pW) offset.
@@ -468,12 +462,6 @@ NeighborPadAsyncMeshWorkloadFactory::cached_program_t NeighborPadAsyncMeshWorklo
         ::ttnn::ccl::get_forward_backward_line_unicast_configuration(
             mesh_coordinate, forward_coord, backward_coord, mesh_device);
 
-    // Compute H fabric multicast barrier route configuration
-    auto [num_targets_forward, num_targets_backward] = ::ttnn::ccl::get_forward_backward_line_mcast_distance(
-        operation_attributes.ring_size, device_index, operation_attributes.topology, false);
-    auto [h_mcast_forward_args, h_mcast_backward_args] = ::ttnn::ccl::get_forward_backward_line_mcast_configuration(
-        mesh_coordinate, forward_coord, backward_coord, num_targets_forward, num_targets_backward, mesh_device);
-
     // KERNEL CREATION
     std::vector<KernelHandle> reader_kernel_ids;
     std::vector<KernelHandle> writer_kernel_ids;
@@ -549,11 +537,6 @@ NeighborPadAsyncMeshWorkloadFactory::cached_program_t NeighborPadAsyncMeshWorklo
             const auto& h_unicast_args = direction ? h_unicast_backward_args : h_unicast_forward_args;
             writer_kernel_config.compile_args.insert(
                 writer_kernel_config.compile_args.end(), h_unicast_args.begin(), h_unicast_args.end());
-            // Barrier multicast route info (6 args) and ring_size for full-mesh startup barrier
-            const auto& h_mcast_args = direction ? h_mcast_backward_args : h_mcast_forward_args;
-            writer_kernel_config.compile_args.insert(
-                writer_kernel_config.compile_args.end(), h_mcast_args.begin(), h_mcast_args.end());
-            writer_kernel_config.compile_args.push_back(operation_attributes.ring_size);
             auto worker_writer_kernel_id = CreateKernel(
                 program,
                 "ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/kernels/"
@@ -772,24 +755,6 @@ NeighborPadAsyncMeshWorkloadFactory::cached_program_t NeighborPadAsyncMeshWorklo
             num_sticks_per_halo_dim,
             operation_attributes.pad2_left);
 
-        // W-axis startup barrier: compute ring size, device index, and multicast routes.
-        // W writers use this barrier to synchronize with all W-axis devices (same row),
-        // ensuring the previous dispatch has completed before sending new fabric data.
-        const auto& mesh_view_w = mesh_device->get_view();
-        uint32_t w_ring_size =
-            (operation_attributes.pad2_cluster_axis.value() == 0) ? mesh_view_w.num_rows() : mesh_view_w.num_cols();
-        uint32_t w_device_index = ::ttnn::ccl::get_linearized_index_from_physical_coord(
-            tensor_args.input_tensor, mesh_coordinate, operation_attributes.pad2_cluster_axis);
-        auto [w_num_targets_forward, w_num_targets_backward] = ::ttnn::ccl::get_forward_backward_line_mcast_distance(
-            w_ring_size, w_device_index, operation_attributes.topology, false);
-        auto [w_mcast_forward_args, w_mcast_backward_args] = ::ttnn::ccl::get_forward_backward_line_mcast_configuration(
-            mesh_coordinate,
-            w_forward_coord,
-            w_backward_coord,
-            w_num_targets_forward,
-            w_num_targets_backward,
-            mesh_device);
-
         for (uint32_t w_link = 0; w_link < pad2_num_links; w_link++) {
             // Per-link work distribution: split w_outer_dim_size rows across pad2_num_links
             uint32_t w_link_start = (w_link * w_rows_per_link) + std::min(w_link, w_extra_rows);
@@ -858,11 +823,6 @@ NeighborPadAsyncMeshWorkloadFactory::cached_program_t NeighborPadAsyncMeshWorklo
                 uint32_t w_device_offset = w_direction ? w_backward_device_offset : w_forward_device_offset;
                 w_writer_kernel_config.compile_args.push_back(0);                // dst_mesh_id (unused for 1D)
                 w_writer_kernel_config.compile_args.push_back(w_device_offset);  // distance_in_hops
-                // W barrier multicast route info (6 args) + ring_size for W-axis startup barrier
-                const auto& w_mcast_args = w_direction ? w_mcast_backward_args : w_mcast_forward_args;
-                w_writer_kernel_config.compile_args.insert(
-                    w_writer_kernel_config.compile_args.end(), w_mcast_args.begin(), w_mcast_args.end());
-                w_writer_kernel_config.compile_args.push_back(w_ring_size);
                 auto w_writer_kernel_id = CreateKernel(
                     program,
                     "ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/kernels/"
@@ -886,13 +846,10 @@ NeighborPadAsyncMeshWorkloadFactory::cached_program_t NeighborPadAsyncMeshWorklo
                     w_virtual_core.x,  // neighbor_sem_noc0_x
                     w_virtual_core.y,  // neighbor_sem_noc0_y
                     operation_attributes.w_neighbor_semaphore.address(),
-                    true,  // use_barrier_semaphore (W writers: W-axis startup barrier)
-                    w_fabric_virtual_cores[(w_link * 2) + (1 - w_direction)].x,  // barrier_sem_noc0_x (opp W dir)
-                    w_fabric_virtual_cores[(w_link * 2) + (1 - w_direction)].y,  // barrier_sem_noc0_y (opp W dir)
-                    // Use h_neighbor_semaphore (not barrier_semaphore) for W startup barrier:
-                    // W reader (NCRISC) on the same core uses barrier_semaphore for Phase 2 barrier.
-                    // Using the same address would cause cross-contamination of increment counts.
-                    operation_attributes.h_neighbor_semaphore.address()};  // barrier_sem
+                    false,  // use_barrier_semaphore (W writers: no startup barrier)
+                    0,      // barrier_sem_noc0_x (unused)
+                    0,      // barrier_sem_noc0_y (unused)
+                    0};     // barrier_sem (unused)
                 // No Phase 2 signal targets (W writers ARE Phase 2)
                 constexpr uint32_t MAX_PHASE2_SIGNAL_TARGETS = 8;
                 w_writer_rt_args.push_back(0);


### PR DESCRIPTION
### Ticket
Related to #38580

### Problem description
The multicast-based startup barrier introduced in #38580 (commit ff4f3c6d6c93) causes hangs and failures in distributed multi-host configurations. The mcast barrier replaced the original pairwise unicast H-writer barrier with a full-mesh multicast sync across both H and W axes. This change is suspected to cause issues when neighbor_pad is used in multi-host ring attention workloads.

### What's changed
Reverts the mcast barrier back to the original pairwise unicast barrier:

- **minimal_default_writer.cpp**: Removed mcast API includes/namespace, removed `barrier_multicast_route_info` and `ring_size` compile-time args, restored `if constexpr (!is_w_fabric_writer)` fabric open guard with pairwise unicast barrier logic (H writers only).
- **neighbor_pad_async_program_factory.cpp**: Removed H/W mcast route computation (`get_forward_backward_line_mcast_distance`, `get_forward_backward_line_mcast_configuration`), removed mcast compile args from H/W writer kernels, restored W writer barrier to disabled (`false`/zeros), removed W writer barrier semaphore override in `override_runtime_arguments`.
- **test_neighbor_pad_async.py** (tg): Removed BH num_links > 2 skip guard and associated import.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=revert-mcast-neighbor-pad)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:revert-mcast-neighbor-pad)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=revert-mcast-neighbor-pad)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:revert-mcast-neighbor-pad)
- [ ] New/Existing tests provide coverage for changes