### PR TITLE
[DFB]: Enable multi-tensix support and have compute increment by tile strides

### DIFF
--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
@@ -96,23 +96,9 @@ void run_single_dfb_program(
     DFBPorCType producer_type,
     DFBPorCType consumer_type) {
 
-    if (dfb_config.num_producers > 1 and producer_type == DFBPorCType::TENSIX) {
-        GTEST_SKIP() << "Skipping DFB test until api to init kernels on multiple tensix is available";
-    }
-    if (dfb_config.num_consumers > 1 and consumer_type == DFBPorCType::TENSIX) {
-        GTEST_SKIP() << "Skipping DFB test until api to init kernels on multiple tensix is available";
-    }
-
     TT_FATAL(
         !(producer_type == DFBPorCType::TENSIX && consumer_type == DFBPorCType::TENSIX),
         "Both producer and consumer cannot be Tensix. At least one must be a DM kernel for NOC transfers.");
-
-    if (dfb_config.num_producers > 1 and producer_type == DFBPorCType::TENSIX) {
-        GTEST_SKIP() << "Skipping DFB test until api to init kernels on multiple tensix is available";
-    }
-    if (dfb_config.num_consumers > 1 and consumer_type == DFBPorCType::TENSIX) {
-        GTEST_SKIP() << "Skipping DFB test until api to init kernels on multiple tensix is available";
-    }
 
     Program program = CreateProgram();
 
@@ -145,7 +131,7 @@ void run_single_dfb_program(
             program,
             "tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_producer.cpp",
             logical_core,
-            experimental::quasar::QuasarComputeConfig{.num_threads_per_cluster = 1, .compile_args = producer_cta});
+            experimental::quasar::QuasarComputeConfig{.num_threads_per_cluster = dfb_config.num_producers, .compile_args = producer_cta});
     }
 
     uint32_t num_entries_per_consumer = dfb_config.cap == ::experimental::AccessPattern::STRIDED
@@ -170,7 +156,7 @@ void run_single_dfb_program(
             program,
             "tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_consumer.cpp",
             logical_core,
-            experimental::quasar::QuasarComputeConfig{.num_threads_per_cluster = 1, .compile_args = consumer_cta});
+            experimental::quasar::QuasarComputeConfig{.num_threads_per_cluster = dfb_config.num_consumers, .compile_args = consumer_cta});
     }
 
     auto logical_dfb_id = experimental::dfb::CreateDataflowBuffer(program, logical_core, dfb_config);
@@ -623,6 +609,8 @@ TEST_F(MeshDeviceFixture, TensixDMTest1xDFB4Sx2S) {
         .enable_implicit_sync = false};
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::TENSIX, DFBPorCType::DM);
 }
+
+// Blocked
 
 TEST_F(MeshDeviceFixture, DMTest1xDFB1Sx4B) {
     if (devices_.at(0)->arch() != ARCH::QUASAR) {

--- a/tt_metal/hw/ckernels/quasar/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_io/llk_io_pack.h
@@ -37,7 +37,7 @@ inline void llk_push_tiles(const std::int32_t dfb_id, const std::int32_t num_til
     const std::uint32_t num_words = num_tiles * local_dfb_interface.stride_size;
 
     local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].wr_ptr += num_words;
-    local_dfb_interface.wr_entry_idx += num_tiles;
+    local_dfb_interface.wr_entry_idx += (num_tiles * local_dfb_interface.stride_size_tiles);
     local_dfb_interface.wr_entry_ptr = 0;
 
     if (local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].wr_ptr == local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].limit) {

--- a/tt_metal/hw/ckernels/quasar/metal/llk_io/llk_io_unpack.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_io/llk_io_unpack.h
@@ -39,7 +39,7 @@ inline void llk_pop_tiles(const std::int32_t dfb_id, const std::int32_t num_tile
     const std::uint32_t num_words = num_tiles * local_dfb_interface.stride_size;
 
     local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].rd_ptr += num_words;
-    local_dfb_interface.rd_entry_idx += num_tiles;
+    local_dfb_interface.rd_entry_idx += (num_tiles * local_dfb_interface.stride_size_tiles);
     if (local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].rd_ptr == local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].limit) {
         local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].rd_ptr = local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].base_addr;
         // rd_entry_idx is a global index, not per-tc for a given DFB. Only reset it when we reached the limit for the entire buffer, not just for the current tc.

--- a/tt_metal/hw/inc/experimental/dataflow_buffer.h
+++ b/tt_metal/hw/inc/experimental/dataflow_buffer.h
@@ -50,9 +50,25 @@ public:
         //     } while (entries_freed < num_entries);
         // })
 #elif !defined(COMPILE_FOR_TRISC)
-        uint8_t tensix_id = get_tensix_id(packed_tc);
-        while (llk_intf_get_free_space(tensix_id, tc_id) < num_entries);
-        // DPRINT << "reserve_back: tc_id: " << static_cast<uint32_t>(tc_id) << " free space: " << static_cast<uint32_t>(llk_intf_get_free_space(tensix_id, tc_id)) << ENDL();
+        if (__builtin_expect(local_dfb_interface_.broadcast_tc, 0)) {
+            // DM-DM BLOCKED: wait until every consumer TC has free space (throttled by slowest consumer)
+            bool ready = false;
+            while (!ready) {
+                ready = true;
+                for (uint8_t i = 0; i < local_dfb_interface_.num_tcs_to_rr; i++) {
+                    PackedTileCounter ptc = local_dfb_interface_.tc_slots[i].packed_tile_counter;
+                    // DPRINT << "reserve_back: tc_id: " << static_cast<uint32_t>(tc_id) << " free space: " << static_cast<uint32_t>(llk_intf_get_free_space(get_tensix_id(ptc), get_counter_id(ptc))) << ENDL();
+                    if (llk_intf_get_free_space(get_tensix_id(ptc), get_counter_id(ptc)) < num_entries) {
+                        ready = false;
+                        break;
+                    }
+                }
+            }
+        } else {
+            uint8_t tensix_id = get_tensix_id(packed_tc);
+            while (llk_intf_get_free_space(tensix_id, tc_id) < num_entries);
+            // DPRINT << "reserve_back: tc_id: " << static_cast<uint32_t>(tc_id) << " free space: " << static_cast<uint32_t>(llk_intf_get_free_space(tensix_id, tc_id)) << ENDL();
+        }
 #endif
     }
 
@@ -73,18 +89,32 @@ public:
         //     local_dfb_interface_.tc_idx = (local_dfb_interface_.tc_idx + 1) % local_dfb_interface_.num_tcs_to_rr;
         // })
 #elif !defined(COMPILE_FOR_TRISC)
-        uint8_t tensix_id = get_tensix_id(packed_tc);
-        llk_intf_inc_posted(tensix_id, tc_id, num_entries);
-        // DPRINT << "push_back: tensix_id: " << static_cast<uint32_t>(tensix_id) << " tc_id: " << static_cast<uint32_t>(tc_id) << " capacity: "
-        //         << static_cast<uint32_t>(llk_intf_get_capacity(tensix_id, tc_id))
-        //         << " posted: " << static_cast<uint32_t>(llk_intf_get_posted(tensix_id, tc_id)) << ENDL();
+        if (__builtin_expect(local_dfb_interface_.broadcast_tc, 0)) {
+            // DM-DM BLOCKED: post to all N TCs; wr_ptr tracked on slot 0
+            for (uint8_t i = 0; i < local_dfb_interface_.num_tcs_to_rr; i++) {
+                PackedTileCounter ptc = local_dfb_interface_.tc_slots[i].packed_tile_counter;
+                // DPRINT << "push_back: tc_id: " << static_cast<uint32_t>(tc_id) << " posted: " << static_cast<uint32_t>(llk_intf_get_posted(get_tensix_id(ptc), get_counter_id(ptc))) << ENDL();
+                llk_intf_inc_posted(get_tensix_id(ptc), get_counter_id(ptc), num_entries);
+            }
+            local_dfb_interface_.tc_slots[0].wr_ptr += (num_entries * local_dfb_interface_.stride_size);
+            if (local_dfb_interface_.tc_slots[0].wr_ptr == local_dfb_interface_.tc_slots[0].limit) {
+                local_dfb_interface_.tc_slots[0].wr_ptr = local_dfb_interface_.tc_slots[0].base_addr;
+            }
+            // tc_idx deliberately not advanced
+        } else {
+            uint8_t tensix_id = get_tensix_id(packed_tc);
+            llk_intf_inc_posted(tensix_id, tc_id, num_entries);
+            // DPRINT << "push_back: tensix_id: " << static_cast<uint32_t>(tensix_id) << " tc_id: " << static_cast<uint32_t>(tc_id) << " capacity: "
+            //         << static_cast<uint32_t>(llk_intf_get_capacity(tensix_id, tc_id))
+            //         << " posted: " << static_cast<uint32_t>(llk_intf_get_posted(tensix_id, tc_id)) << ENDL();
 
-        local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr += (num_entries * local_dfb_interface_.stride_size);
-        if (local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr == local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].limit) {
-            local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].base_addr;
+            local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr += (num_entries * local_dfb_interface_.stride_size);
+            if (local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr == local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].limit) {
+                local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].base_addr;
+            }
+
+            local_dfb_interface_.tc_idx = (local_dfb_interface_.tc_idx + 1) % local_dfb_interface_.num_tcs_to_rr;
         }
-
-        local_dfb_interface_.tc_idx = (local_dfb_interface_.tc_idx + 1) % local_dfb_interface_.num_tcs_to_rr;
 #endif
     }
 
@@ -97,9 +127,6 @@ public:
             return;
         }
         llk_wait_tiles(logical_dfb_id_, num_entries);
-        // DPRINT << "wait_front: tc_id: " << static_cast<uint32_t>(tc_id)
-        //        << " capacity: " << static_cast<uint32_t>(tile_counters[tc_id].f.buf_capacity)
-        //        << " posted: " << static_cast<uint32_t>(tile_counters[tc_id].f.posted) << ENDL();
 
         // UNPACK({
         //     uint16_t entries_received;
@@ -109,11 +136,11 @@ public:
         // })
 #elif !defined(COMPILE_FOR_TRISC)
         uint8_t tensix_id = get_tensix_id(packed_tc);
-        while (llk_intf_get_occupancy(tensix_id, tc_id) < num_entries);
         // DPRINT << "wait_front: tensix_id: " << static_cast<uint32_t>(tensix_id)
         //        << " capacity: " << static_cast<uint32_t>(llk_intf_get_capacity(tensix_id, tc_id))
         //        << " tc_id: " << static_cast<uint32_t>(tc_id)
         //        << " occupancy: " << static_cast<uint32_t>(llk_intf_get_occupancy(tensix_id, tc_id)) << ENDL();
+        while (llk_intf_get_occupancy(tensix_id, tc_id) < num_entries);
 #endif
     }
 
@@ -142,7 +169,7 @@ public:
             local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].base_addr;
         }
         local_dfb_interface_.tc_idx = (local_dfb_interface_.tc_idx + 1) % local_dfb_interface_.num_tcs_to_rr;
-        // DPRINT << "pop_front: free spae: " << (uint32_t)llk_intf_get_free_space(tensix_id, tc_id) << ENDL();
+        // DPRINT << "pop_front: free space: " << (uint32_t)llk_intf_get_free_space(tensix_id, tc_id) << ENDL();
 #endif
     }
     // Explicit sync APIs end

--- a/tt_metal/hw/inc/internal/dataflow_buffer_init.h
+++ b/tt_metal/hw/inc/internal/dataflow_buffer_init.h
@@ -8,9 +8,9 @@
 
 #include "internal/dataflow_buffer_interface.h"
 #include "internal/circular_buffer_interface.h"  // for cb_addr_shift
+#include "internal/tt-2xx/quasar/overlay/remapper_api.hpp"
 #ifndef COMPILE_FOR_TRISC
 #include "internal/tt-2xx/quasar/overlay/llk_intf_api.hpp"
-#include "internal/tt-2xx/quasar/overlay/remapper_api.hpp"
 #else
 #include "ckernel_trisc_common.h"
 #endif
@@ -42,10 +42,7 @@ FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base
         local_dfb_mask;  // kernel config holds local_cb_mask but it gets hijacked to hold number of dfbs
     volatile uint8_t* base_ptr = reinterpret_cast<volatile uint8_t*>(dfb_config_base);
 
-#ifndef COMPILE_FOR_TRISC
-    bool enable_remapper = false;  // if remapper used once then needs to be globally set
-#endif
-
+    // each RISC populates its own g_dfb_interface entry
     for (uint32_t logical_dfb_id = 0; logical_dfb_id < num_dfbs; logical_dfb_id++) {
         // Read dfb_initializer_t (shared config)
         volatile dfb_initializer_t* init_ptr = reinterpret_cast<volatile dfb_initializer_t*>(base_ptr);
@@ -79,11 +76,11 @@ FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base
                 dfb_interface.tc_slots[i].wr_ptr = base;
                 dfb_interface.tc_slots[i].packed_tile_counter = per_risc_ptr->packed_tile_counter[i];
             }
-            dfb_interface.entry_size = init_ptr->entry_size;
+            dfb_interface.entry_size = init_ptr->entry_size >> cb_addr_shift;
             // DPRINT << "entry_size: " << static_cast<uint32_t>(dfb_interface.entry_size) << ENDL();
-            dfb_interface.stride_size = init_ptr->stride_size >> cb_addr_shift;
+            dfb_interface.stride_size_tiles = init_ptr->stride_in_entries;
+            dfb_interface.stride_size = dfb_interface.entry_size * init_ptr->stride_in_entries;
             // DPRINT << "stride_size: " << static_cast<uint32_t>(dfb_interface.stride_size) << ENDL();
-
             dfb_interface.rd_entry_idx = 0;
             dfb_interface.wr_entry_idx = 0;
             dfb_interface.wr_entry_ptr = 0;
@@ -97,49 +94,7 @@ FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base
 
             dfb_interface.tc_idx = 0;
             dfb_interface.tensix_trisc_mask = init_ptr->risc_mask_bits.tensix_trisc_mask;
-
-            // DPRINT << "remapper_pair_index: " << static_cast<uint32_t>(per_risc_ptr->flags.remapper_pair_index) << ENDL();
-
-#ifndef COMPILE_FOR_TRISC
-            // Configure remapper if needed (must be done before TC init)
-            if (per_risc_ptr->flags.is_producer && per_risc_ptr->flags.remapper_en) {
-                if (risc_index == 0) {  // update this
-                    enable_remapper = true;
-                }
-                // remapper_consumer_ids_mask is a bitmask of clientTypes (id_R) for BLOCKED consumers
-                uint8_t remapper_consumer_ids_mask = per_risc_ptr->remapper_consumer_ids_mask;
-                uint8_t producer_client_type = per_risc_ptr->producer_client_type;  // clientL for this producer
-                uint8_t num_clientRs = static_cast<uint8_t>(__builtin_popcount(remapper_consumer_ids_mask));
-                uint8_t clientR_valid_mask = (1u << num_clientRs) - 1;
-                g_remapper_configurator.set_pair_index(static_cast<uint32_t>(per_risc_ptr->flags.remapper_pair_index));
-                // DPRINT << "Setting clientL fields clientL=" << static_cast<uint32_t>(producer_client_type)
-                //        << " tc: " << static_cast<uint32_t>(get_counter_id(per_risc_ptr->packed_tile_counter[0]))
-                //        << " mask: " << static_cast<uint32_t>(clientR_valid_mask) << ENDL();
-                g_remapper_configurator.configure_clientL_all_fields(
-                    producer_client_type,                                  // id_L
-                    get_counter_id(per_risc_ptr->packed_tile_counter[0]),  // in SxB mode, producers have 1 TC
-                    clientR_valid_mask,
-                    1,  // is_producer
-                    1,  // group mode
-                    0   // distribute mode
-                );
-                // Program each consumer's R slot by extracting set bits from mask
-                uint8_t mask_remaining = remapper_consumer_ids_mask;
-                for (uint8_t clientR_idx = 0; clientR_idx < num_clientRs; clientR_idx++) {
-                    // Extract id_R: position of lowest set bit in remaining mask = clientType
-                    uint8_t id_R = static_cast<uint8_t>(__builtin_ctz(mask_remaining));
-                    mask_remaining &= mask_remaining - 1;  // Clear lowest set bit
-                    uint8_t tc_R =
-                        (per_risc_ptr->consumer_tcs >> (clientR_idx * 5)) & 0x1F;  // TC can be value between 0 and 31
-                    // DPRINT << "Setting clientR slot " << static_cast<uint32_t>(clientR_idx)
-                    //        << " id: " << static_cast<uint32_t>(id_R) << " tc: " << static_cast<uint32_t>(tc_R)
-                    //        << ENDL();
-                    g_remapper_configurator.set_clientR_slot(clientR_idx, id_R, tc_R);
-                }
-                // DPRINT << "Writing all remapper configs" << ENDL();
-                g_remapper_configurator.write_all_configs();
-            }
-#endif
+            dfb_interface.broadcast_tc = per_risc_ptr->num_tcs_and_init.broadcast_tc;
         }
 
         // Jump to next DFB: skip dfb_initializer_t + (num_riscs * dfb_initializer_per_risc_t)
@@ -147,14 +102,66 @@ FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base
     }
 
 #ifndef COMPILE_FOR_TRISC
-    // all DFBs were initialized, safe to enable remapper if used
-    if (enable_remapper && hartid == 0) {  // update how one risc enables the remapper
-        // DPRINT << "Enabling remapper" << ENDL();
-        g_remapper_configurator.enable_remapper();
-    }
+    // DM0 handles all remapper configuration and DM producer TC initialization
+    if (hartid == 0) {
+        // Pass A: configure remapper for all DM producers across all DFBs, then enable
+        bool enable_remapper = false;
+        base_ptr = reinterpret_cast<volatile uint8_t*>(dfb_config_base);
+        for (uint32_t logical_dfb_id = 0; logical_dfb_id < num_dfbs; logical_dfb_id++) {
+            volatile dfb_initializer_t* init_ptr = reinterpret_cast<volatile dfb_initializer_t*>(base_ptr);
+            uint16_t risc_mask = (init_ptr->risc_mask_bits.tensix_mask << 8) | init_ptr->risc_mask_bits.dm_mask;
+            uint8_t num_riscs = static_cast<uint8_t>(__builtin_popcount(risc_mask));
+
+            volatile dfb_initializer_per_risc_t* per_risc_base =
+                reinterpret_cast<volatile dfb_initializer_per_risc_t*>(base_ptr + sizeof(dfb_initializer_t));
+
+            // Configure remapper for all producers with remapper_en (DM and Tensix, e.g. Tensix producer + BLOCKED).
+            for (uint8_t i = 0; i < num_riscs; i++) {
+                volatile dfb_initializer_per_risc_t* per_risc_ptr = per_risc_base + i;
+                if (per_risc_ptr->flags.is_producer && per_risc_ptr->flags.remapper_en) {
+                    enable_remapper = true;
+                    uint8_t remapper_consumer_ids_mask = per_risc_ptr->remapper_consumer_ids_mask;
+                    uint8_t producer_client_type = per_risc_ptr->producer_client_type;
+                    uint8_t num_clientRs = static_cast<uint8_t>(__builtin_popcount(remapper_consumer_ids_mask));
+                    uint8_t clientR_valid_mask = (1u << num_clientRs) - 1;
+                    g_remapper_configurator.set_pair_index(static_cast<uint32_t>(per_risc_ptr->flags.remapper_pair_index));
+                    // DPRINT << "Setting clientL fields clientL=" << static_cast<uint32_t>(producer_client_type)
+                    //        << " tc: " << static_cast<uint32_t>(get_counter_id(per_risc_ptr->packed_tile_counter[0]))
+                    //        << " mask: " << static_cast<uint32_t>(clientR_valid_mask) << ENDL();
+                    g_remapper_configurator.configure_clientL_all_fields(
+                        producer_client_type,
+                        get_counter_id(per_risc_ptr->packed_tile_counter[0]),
+                        clientR_valid_mask,
+                        1,  // is_producer
+                        1,  // group mode
+                        0   // distribute mode
+                    );
+                    uint8_t mask_remaining = remapper_consumer_ids_mask;
+                    for (uint8_t clientR_idx = 0; clientR_idx < num_clientRs; clientR_idx++) {
+                        uint8_t id_R = static_cast<uint8_t>(__builtin_ctz(mask_remaining));
+                        mask_remaining &= mask_remaining - 1;
+                        uint8_t tc_R = (per_risc_ptr->consumer_tcs >> (clientR_idx * 5)) & 0x1F;
+                        // DPRINT << "Setting clientR slot " << static_cast<uint32_t>(clientR_idx)
+                        //        << " id: " << static_cast<uint32_t>(id_R) << " tc: " << static_cast<uint32_t>(tc_R)
+                        //        << ENDL();
+                        g_remapper_configurator.set_clientR_slot(clientR_idx, id_R, tc_R);
+                    }
+                    // DPRINT << "Writing all remapper configs" << ENDL();
+                    g_remapper_configurator.write_all_configs();
+                }
+            }
+
+            base_ptr += sizeof(dfb_initializer_t) + (num_riscs * sizeof(dfb_initializer_per_risc_t));
+        }
+
+        if (enable_remapper) {
+            // DPRINT << "Enabling remapper" << ENDL();
+            g_remapper_configurator.enable_remapper();
+        }
+    }  // end if (hartid == 0)
 #endif
 
-    // Initialize TCs after remapper is enabled - only producers should initialize TCs
+    // Each DM and Tensix producer initialized their own TC
     base_ptr = reinterpret_cast<volatile uint8_t*>(dfb_config_base);
     for (uint32_t logical_dfb_id = 0; logical_dfb_id < num_dfbs; logical_dfb_id++) {
         volatile dfb_initializer_t* init_ptr = reinterpret_cast<volatile dfb_initializer_t*>(base_ptr);
@@ -169,32 +176,36 @@ FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base
             volatile dfb_initializer_per_risc_t* per_risc_ptr = per_risc_base + risc_index;
 
             if (per_risc_ptr->flags.is_producer) {
+                while (per_risc_ptr->flags.remapper_en && !RemapperAPI::is_remapper_enabled());
+
+                // Note: resetting tile counters does not reset the buffer capacity to 0
                 for (uint8_t tc = 0; tc < per_risc_ptr->num_tcs_and_init.num_tcs_to_rr; tc++) {
                     PackedTileCounter ptc = per_risc_ptr->packed_tile_counter[tc];
                     uint8_t tc_id = get_counter_id(ptc);
-
-
 #if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_PACK)
-                    // DPRINT << "dfb " << static_cast<uint32_t>(logical_dfb_id) << " initializing tc : " << static_cast<uint32_t>(tc_id) << ENDL();
+                    // DPRINT << "dfb " << static_cast<uint32_t>(logical_dfb_id)
+                    //         << " initializing tc_id: " << static_cast<uint32_t>(tc_id) << ENDL();
                     ckernel::trisc::tile_counters[tc_id].f.reset = 1;
                     ckernel::trisc::tile_counters[tc_id].f.buf_capacity = init_ptr->capacity;
 #elif !defined(COMPILE_FOR_TRISC)
                     uint8_t tensix_id = get_tensix_id(ptc);
-                    // DPRINT << "dfb " << static_cast<uint32_t>(logical_dfb_id) << " initializing tc tensix_id: " << static_cast<uint32_t>(tensix_id)
-                    //        << " tc_id: " << static_cast<uint32_t>(tc_id) << ENDL();
+                    // DPRINT << "dfb " << static_cast<uint32_t>(logical_dfb_id)
+                    //         << " initializing tc tensix_id: " << static_cast<uint32_t>(tensix_id)
+                    //         << " tc_id: " << static_cast<uint32_t>(tc_id) << ENDL();
                     llk_intf_reset(tensix_id, tc_id);
                     llk_intf_set_capacity(tensix_id, tc_id, init_ptr->capacity);
+                    // DPRINT << " capacity: "
+                    //         << static_cast<uint32_t>(llk_intf_get_capacity(tensix_id, tc_id))
+                    //         << " free space: " << static_cast<uint32_t>(llk_intf_get_free_space(tensix_id, tc_id)) << ENDL();
 #endif
                 }
-
-                // Single writer: this RISC only writes its own per_risc; no atomic, no cache line bouncing
+                // Single writer per per_risc entry; no atomic needed
                 per_risc_ptr->num_tcs_and_init.tc_init_done = 1;
             }
         }
 
         base_ptr += sizeof(dfb_initializer_t) + (num_riscs * sizeof(dfb_initializer_per_risc_t));
     }
-
 
     // After setting up g_dfb_interface, wait for all TCs to be initialized
     bool all_tcs_initialized = false;
@@ -223,6 +234,7 @@ FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base
             base_ptr += sizeof(dfb_initializer_t) + (num_riscs * sizeof(dfb_initializer_per_risc_t));
         }
     }
+    // DPRINT << "all_tcs_initialized" << ENDL();
 }
 
 }  // namespace experimental

--- a/tt_metal/hw/inc/internal/dataflow_buffer_interface.h
+++ b/tt_metal/hw/inc/internal/dataflow_buffer_interface.h
@@ -23,7 +23,7 @@ constexpr uint8_t NUM_REMAPPER_PAIRINGS = 64;
 constexpr uint8_t NUM_TXN_IDS = 4;
 constexpr uint8_t MAX_NUM_TILE_COUNTERS_TO_RR = 4;
 
-constexpr uint16_t TENSIX_RISC_OFFSET = 0x100;
+constexpr uint16_t TENSIX_RISC_OFFSET = 8; // First 8 represent DMs
 
 using PackedTileCounter = uint8_t;  // bits 5-6: tensix_id (2 bits), bits 0-4: counter_id (5 bits)
 
@@ -66,7 +66,7 @@ inline __attribute__((always_inline)) constexpr uint8_t get_counter_id(PackedTil
 struct dfb_initializer_t {  // 24 bytes
     uint32_t logical_id;
     uint32_t entry_size;
-    uint32_t stride_size;
+    uint32_t stride_in_entries;
     uint16_t capacity;
     struct {
         uint16_t dm_mask : 8;         // bits 0-7: DM RISC mask
@@ -89,7 +89,8 @@ struct dfb_initializer_per_risc_t {  // 44 bytes
     struct {
         uint8_t num_tcs_to_rr : 4;   // 0..8, number of TCs to round-robin (max 4 but keeping space)
         uint8_t tc_init_done : 1;
-        uint8_t reserved : 3;
+        uint8_t broadcast_tc : 1;    // DM-DM BLOCKED: producer posts to all TCs instead of round-robin
+        uint8_t reserved : 2;
     } __attribute__((packed)) num_tcs_and_init;
     struct {
         uint8_t remapper_pair_index : 6;  // bits 0-5: 0..63
@@ -126,23 +127,24 @@ struct DFBTCSlot {
 struct LocalDFBInterface {
     DFBTCSlot tc_slots[MAX_NUM_TILE_COUNTERS_TO_RR];
 
-    uint32_t entry_size;   // shared across riscs so can be factored out and put into sep initialization struct
-    uint32_t stride_size;  // shared across riscs so can be factored out and put into sep initialization struct
+    uint32_t entry_size;
+    uint32_t stride_size;
 
     // Entry indices tracking how many entries from DFB base the rd/wr pointers are
+    uint32_t stride_size_tiles; // used by triscs to calculate tile offset from base L1 address
     uint32_t rd_entry_idx;
     uint32_t wr_entry_idx;
     uint32_t wr_entry_ptr;
 
-    uint8_t txn_ids[NUM_TXN_IDS];  // shared across riscs so can be factored out and put into sep initialization struct
+    uint8_t txn_ids[NUM_TXN_IDS];
     uint8_t
-        num_entries_per_txn_id;  // shared across riscs so can be factored out and put into sep initialization struct
-    uint8_t num_entries_per_txn_id_per_tc;  // shared across riscs so can be factored out and put into sep
-                                            // initialization struct
+        num_entries_per_txn_id;
+    uint8_t num_entries_per_txn_id_per_tc;
     uint8_t num_tcs_to_rr;
-    uint8_t num_txn_ids;  // shared across riscs so can be factored out and put into sep initialization struct
+    uint8_t num_txn_ids;
     uint8_t tc_idx;
     uint8_t tensix_trisc_mask;  // which TRISC(s) use this DFB (bit N = trisc N); for runtime gate on TRISC
+    uint8_t broadcast_tc;       // DM-DM BLOCKED producer: post to all TCs instead of round-robin
 
 } __attribute__((packed));
 
@@ -150,6 +152,6 @@ static_assert(sizeof(DFBTCSlot) == 17, "DFBTCSlot size is incorrect");
 static_assert(sizeof(dfb_initializer_t) == 24, "dfb_initializer_t size is incorrect");
 static_assert(sizeof(dfb_initializer_per_risc_t) == 44, "dfb_initializer_per_risc_t size is incorrect");
 static_assert(sizeof(dfb_initializer_intra_tensix_t) == 24, "dfb_initializer_intra_tensix_t size is incorrect");
-static_assert(sizeof(LocalDFBInterface) == 98, "LocalDFBInterface size is incorrect");
+static_assert(sizeof(LocalDFBInterface) == 103, "LocalDFBInterface size is incorrect");
 
 }  // namespace experimental

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/overlay/remapper_api.hpp
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/overlay/remapper_api.hpp
@@ -684,7 +684,7 @@ public:
      * @brief Read the remapper enable status
      * @return true if remapper is enabled, false otherwise
      */
-    bool is_remapper_enabled() { return (READ_REG32(REMAP_GLOBAL_CONTROL_REG_ADDR32) & 0x1) != 0; }
+    static bool is_remapper_enabled() { return (READ_REG32(REMAP_GLOBAL_CONTROL_REG_ADDR32) & 0x1) != 0; }
 
     // ========================================================================
     // Combined Configuration Methods

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
@@ -43,10 +43,17 @@ void BindDataflowBufferToProducerConsumerKernels(Program& program, uint32_t dfb_
     TT_FATAL(consumer_kernel != nullptr, "Consumer kernel not found");
 
     if (auto compute_producer = std::dynamic_pointer_cast<experimental::quasar::QuasarComputeKernel>(producer_kernel)) {
-        TT_FATAL(dfb->config.num_producers == 1, "Only one Tensix is supported for now");
-        dfb->config.producer_risc_mask = ::experimental::TENSIX_RISC_OFFSET;
+        TT_FATAL(
+            dfb->config.num_producers >= 1 && dfb->config.num_producers <= 4,
+            "Tensix producer count must be between 1 and 4, got {}",
+            dfb->config.num_producers);
+        dfb->config.producer_risc_mask = static_cast<uint16_t>(((1u << dfb->config.num_producers) - 1u) << ::experimental::TENSIX_RISC_OFFSET);
         dfb->tensix_trisc_mask |= (1u << 2);  // Tensix producer uses trisc2
     } else if (auto dm_producer = std::dynamic_pointer_cast<experimental::quasar::QuasarDataMovementKernel>(producer_kernel)) {
+        TT_FATAL(
+            dfb->config.num_producers >= 1 && dfb->config.num_producers <= 8,
+            "DM producer count must be between 1 and 8, got {}",
+            dfb->config.num_producers);
         const auto& producer_dm_riscvs = dm_producer->get_dm_processors();
         for (DataMovementProcessor dm : producer_dm_riscvs) {
             dfb->config.producer_risc_mask |= (1u << static_cast<std::underlying_type_t<DataMovementProcessor>>(dm));
@@ -56,10 +63,17 @@ void BindDataflowBufferToProducerConsumerKernels(Program& program, uint32_t dfb_
     }
 
     if (auto compute_consumer = std::dynamic_pointer_cast<experimental::quasar::QuasarComputeKernel>(consumer_kernel)) {
-        TT_FATAL(dfb->config.num_consumers == 1, "Only one Tensix is supported for now");
-        dfb->config.consumer_risc_mask = ::experimental::TENSIX_RISC_OFFSET;
+        TT_FATAL(
+            dfb->config.num_consumers >= 1 && dfb->config.num_consumers <= 4,
+            "Tensix consumer count must be between 1 and 4, got {}",
+            dfb->config.num_consumers);
+        dfb->config.consumer_risc_mask = static_cast<uint16_t>(((1u << dfb->config.num_consumers) - 1u) << ::experimental::TENSIX_RISC_OFFSET);
         dfb->tensix_trisc_mask |= (1u << 0);  // Default: Tensix consumer uses trisc0; use (1u << 3) for trisc3
     } else if (auto dm_consumer = std::dynamic_pointer_cast<experimental::quasar::QuasarDataMovementKernel>(consumer_kernel)) {
+        TT_FATAL(
+            dfb->config.num_consumers >= 1 && dfb->config.num_consumers <= 8,
+            "DM consumer count must be between 1 and 8, got {}",
+            dfb->config.num_consumers);
         const auto& consumer_dm_riscvs = dm_consumer->get_dm_processors();
         for (DataMovementProcessor dm : consumer_dm_riscvs) {
             dfb->config.consumer_risc_mask |= (1u << static_cast<std::underlying_type_t<DataMovementProcessor>>(dm));
@@ -95,43 +109,53 @@ uint8_t RemapperIndexAllocator::allocate(const CoreCoord& core_coord) {
 
 void RemapperIndexAllocator::reset() { next_index_.clear(); }
 
-uint8_t ClientTypeAllocator::allocate_for_consumer(uint8_t producer_tensix_id, uint8_t consumer_risc_id) {
+uint8_t ClientTypeAllocator::allocate_for_consumer(uint8_t producer_client_type, uint8_t consumer_risc_id) {
     uint8_t client_type;
 
     if (consumer_risc_id >= 8) {
-        // Tensix RISC: risc_id 8-11 -> clientType 4-7 (NEO_0 to NEO_3)
-        // Derive id_R directly from consumer's RISC ID
+        // Tensix RISC: risc_id 8-11 -> clientType 4-7 (NEO_0 to NEO_3).
+        // Each Tensix RISC maps to a unique id, so duplicates indicate a bug.
         client_type = 4 + (consumer_risc_id - 8);
-
-        // Validate: Tensix consumer's tensix_id must not conflict with producer's tensix_id
-        TT_FATAL(
-            (client_type % 4) != producer_tensix_id,
-            "Tensix consumer risc_id {} (tensix_id={}) conflicts with producer tensix_id {}",
-            consumer_risc_id,
-            client_type % 4,
-            producer_tensix_id);
+        uint8_t bit = client_type - 4;
+        TT_FATAL(!(tensix_used_mask_ & (1u << bit)), "Tensix clientType {} already used", client_type);
+        tensix_used_mask_ |= (1u << bit);
     } else {
-        // DM RISC: find first available clientType whose tensix_id != producer_tensix_id
-        client_type = 0xFF;  // Invalid until found
-        for (uint8_t ct = 0; ct < 8; ct++) {
-            if (!(used_mask_ & (1u << ct)) && (ct % 4) != producer_tensix_id) {
-                client_type = ct;
-                break;
+        // DM consumer: clientType must be in [0, 3] (DM TC groups only).
+        // clientL != clientR but DM clientR IDs may repeat across consumers
+        uint8_t available[4];
+        uint8_t count = 0;
+        for (uint8_t ct = 0; ct < 4; ct++) {
+            if (ct != producer_client_type) {
+                available[count++] = ct;
             }
         }
-        TT_FATAL(client_type != 0xFF, "Out of client types for BLOCKED DM consumer allocation");
+        // count is always > 0: producer_client_type is in [4,7] (Tensix) or one of [0,3] (DM),
+        // leaving at least 3 eligible DM groups.
+        client_type = available[dm_alloc_count_ % count];
+        dm_alloc_count_++;
     }
-
-    // Mark this clientType as used
-    TT_FATAL(!(used_mask_ & (1u << client_type)), "ClientType {} already used", client_type);
-    used_mask_ |= (1u << client_type);
 
     return client_type;
 }
 
+bool has_dm_risc(uint16_t risc_mask) { return (risc_mask & 0xFF) != 0; }
+
+bool has_tensix_risc(uint16_t risc_mask) { return (risc_mask & 0x0F00) != 0; }
+
 uint8_t calculate_num_tile_counters(const DataflowBufferConfig& config, bool is_producer) {
     if (config.cap == ::experimental::AccessPattern::BLOCKED) {
-        return is_producer ? 1 : config.num_producers;
+        bool producer_has_dm = has_dm_risc(config.producer_risc_mask);
+        bool consumer_has_dm = has_dm_risc(config.consumer_risc_mask);
+        bool producer_is_tensix_only = !producer_has_dm && has_tensix_risc(config.producer_risc_mask);
+        bool consumer_is_tensix_only = !consumer_has_dm && has_tensix_risc(config.consumer_risc_mask);
+        bool dm_dm_blocked = !producer_is_tensix_only && !consumer_is_tensix_only;
+        if (is_producer) {
+            if (dm_dm_blocked) {
+                return config.num_consumers;
+            }
+            return 1;
+        }
+        return config.num_producers;
     }
     // Strided mode:
     // Producer: num_consumers / num_producers (number of consumers each producer is paired with)
@@ -179,10 +203,6 @@ std::vector<uint8_t> extract_tensix_ids(uint16_t risc_mask) {
 // Round-robins through 0-3 based on pair index
 uint8_t get_dm_tensix_id_for_pair(uint8_t pair_index) { return pair_index % 4; }
 
-bool has_dm_risc(uint16_t risc_mask) { return (risc_mask & 0xFF) != 0; }
-
-bool has_tensix_risc(uint16_t risc_mask) { return (risc_mask & 0x0F00) != 0; }
-
 // Holds tile counters allocated together for a producer-consumer group
 struct TileCounterGroup {
     ::experimental::PackedTileCounter producer_tc{};
@@ -204,7 +224,7 @@ std::vector<uint8_t> DataflowBufferImpl::serialize() const {
     ::experimental::dfb_initializer_t init = {};
     init.logical_id = this->id;
     init.entry_size = this->entry_size;
-    init.stride_size = this->stride_size;
+    init.stride_in_entries = this->stride_in_entries;
     init.capacity = this->capacity;
     init.risc_mask_bits.dm_mask = this->risc_mask & 0xFF;
     init.risc_mask_bits.tensix_mask = (this->risc_mask >> 8) & 0x0F;
@@ -227,7 +247,7 @@ std::vector<uint8_t> DataflowBufferImpl::serialize() const {
         this->use_remapper);
 
     log_info(tt::LogMetal, "Entry size: {}", this->entry_size);
-    log_info(tt::LogMetal, "Stride size: {}", this->stride_size);
+    log_info(tt::LogMetal, "Stride in entries: {}", this->stride_in_entries);
     log_info(tt::LogMetal, "Capacity: {}", this->capacity);
     log_info(tt::LogMetal, "Risc mask: 0x{:x}", this->risc_mask);
     log_info(tt::LogMetal, "Num txn ids: {}", this->num_txn_ids);
@@ -259,6 +279,7 @@ std::vector<uint8_t> DataflowBufferImpl::serialize() const {
 
         per_risc.num_tcs_and_init.num_tcs_to_rr = rc->config.num_tcs_to_rr;
         per_risc.num_tcs_and_init.tc_init_done = 0;  // set by device when this producer finishes TC init
+        per_risc.num_tcs_and_init.broadcast_tc = rc->config.broadcast_tc;
         log_info(tt::LogMetal, "Num tcs to rr: {}", rc->config.num_tcs_to_rr);
         // Copy per-risc arrays
         for (int i = 0; i < rc->config.num_tcs_to_rr; i++) {
@@ -390,12 +411,10 @@ uint32_t ProgramImpl::add_dataflow_buffer(const CoreRangeSet& core_range_set, co
 
     log_info(
         tt::LogMetal,
-        "Creating DFB {} with {} producers (mask 0x{:x}) and {} consumers (mask 0x{:x})",
+        "Creating DFB {} with {} producers and {} consumers",
         dfb->id,
         config.num_producers,
-        config.producer_risc_mask,
-        config.num_consumers,
-        config.consumer_risc_mask);
+        config.num_consumers);
 
     uint32_t capacity;
     switch (config.cap) {
@@ -406,7 +425,7 @@ uint32_t ProgramImpl::add_dataflow_buffer(const CoreRangeSet& core_range_set, co
                 config.num_entries,
                 std::max(config.num_producers, config.num_consumers));
             capacity = config.num_entries / std::max(config.num_producers, config.num_consumers);
-            dfb->stride_size = config.entry_size * std::max(config.num_producers, config.num_consumers);
+            dfb->stride_in_entries = std::max(config.num_producers, config.num_consumers);
             break;
         case ::experimental::AccessPattern::BLOCKED:
             TT_FATAL(
@@ -415,7 +434,7 @@ uint32_t ProgramImpl::add_dataflow_buffer(const CoreRangeSet& core_range_set, co
                 config.num_entries,
                 config.num_producers);
             capacity = config.num_entries / config.num_producers;
-            dfb->stride_size = config.entry_size;
+            dfb->stride_in_entries = 1;
             break;
         default: TT_FATAL(false, "Invalid access pattern", (uint32_t)config.cap);
     }
@@ -472,8 +491,13 @@ void ProgramImpl::finalize_dataflow_buffer_configs() {
         bool core_needs_remapper = false;
         for (const auto& dfb : core_dfbs) {
             if (dfb->config.cap == ::experimental::AccessPattern::BLOCKED) {
-                core_needs_remapper = true;
-                break;
+                // DM-DM BLOCKED uses software broadcast (no remapper needed)
+                bool dm_dm_blocked = !has_tensix_risc(dfb->config.producer_risc_mask) &&
+                                     !has_tensix_risc(dfb->config.consumer_risc_mask);
+                if (!dm_dm_blocked) {
+                    core_needs_remapper = true;
+                    break;
+                }
             }
         }
 
@@ -492,7 +516,7 @@ void ProgramImpl::finalize_dataflow_buffer_configs() {
 }
 
 void ProgramImpl::finalize_single_dfb_config(
-    std::shared_ptr<DataflowBufferImpl>& dfb, const CoreCoord& core, bool use_remapper) {
+    std::shared_ptr<DataflowBufferImpl>& dfb, const CoreCoord& core, bool core_has_remapper) {
     const auto& config = dfb->config;
 
     TT_FATAL(config.producer_risc_mask != 0, "producer_risc_mask must be set before program launch. Either set it in DataflowBufferConfig or call BindDataflowBufferToProducerConsumerKernels after creating kernels");
@@ -515,6 +539,18 @@ void ProgramImpl::finalize_single_dfb_config(
         "Tensix producer with BLOCKED consumer pattern is not supported");
 
     dfb->risc_mask = config.producer_risc_mask | config.consumer_risc_mask;
+
+    // DM-DM BLOCKED: producer broadcasts to N TCs (one per consumer) instead of using remapper.
+    // No Tensix involved on either side.
+    bool dm_dm_blocked = (config.cap == ::experimental::AccessPattern::BLOCKED) &&
+                         !producer_is_tensix_only && !consumer_is_tensix_only;
+
+    // Remapper is needed only for BLOCKED 1-to-many with Tensix
+    // Adding a TC to a remapper config entry removes it from the default Tensix<->DM mirror group, even with
+    // remapper enabled the default mirroring holds for STRIDED cases
+    bool use_remapper = core_has_remapper &&
+                        (config.cap == ::experimental::AccessPattern::BLOCKED) &&
+                        !dm_dm_blocked;
 
     uint8_t num_producer_tcs = calculate_num_tile_counters(config, true);
     uint8_t num_consumer_tcs = calculate_num_tile_counters(config, false);
@@ -578,11 +614,11 @@ void ProgramImpl::finalize_single_dfb_config(
                 producer_client_type);
         }
 
-        // Then allocate consumer clientTypes (clientR) - must differ from producer's clientL
-        uint8_t producer_tensix_id = producer_risc_ids[0] % 4;
+        // Then allocate consumer clientTypes (clientR)
+        // Pass the producer's actual clientL so DM consumers can avoid it (hardware: clientL != clientR).
         for (size_t consumer_idx = 0; consumer_idx < consumer_risc_ids.size(); consumer_idx++) {
             uint8_t consumer_risc_id = consumer_risc_ids[consumer_idx];
-            uint8_t client_type = client_type_allocator.allocate_for_consumer(producer_tensix_id, consumer_risc_id);
+            uint8_t client_type = client_type_allocator.allocate_for_consumer(producer_client_types[0], consumer_risc_id);
             consumer_client_types.push_back(client_type);
 
             log_info(
@@ -637,27 +673,41 @@ void ProgramImpl::finalize_single_dfb_config(
                     consumer_risc_id,
                     use_remapper);
             } else if (config.cap == ::experimental::AccessPattern::BLOCKED) {
-                // Producer TC: use producer's risc_id % 4 as tensix_id
-                uint8_t producer_tensix_id = producer_risc_ids[producer_idx] % 4;
+                if (dm_dm_blocked) {
+                    // DM-DM BLOCKED: allocate one TC per consumer (tc_slot == consumer_idx).
+                    // The TC is shared between producer and consumer i -- no remapper needed.
+                    uint8_t tensix_id = get_dm_tensix_id_for_pair(pair_counter++);
+                    group.producer_tc = tile_counter_allocator_.allocate(tensix_id);
+                    group.consumer_tcs.push_back(group.producer_tc);  // shared
 
-                group.producer_tc = tile_counter_allocator_.allocate(producer_tensix_id);
+                    log_info(
+                        tt::LogMetal,
+                        "Blocked DM-DM: Producer[{}] TC[{}] (tensix_id={}) shared with Consumer[{}]",
+                        producer_idx,
+                        tc_slot,
+                        tensix_id,
+                        tc_slot);
+                } else {
+                    // Tensix-involved BLOCKED: use remapper for 1-to-many
+                    uint8_t producer_tensix_id = producer_risc_ids[producer_idx] % 4;
+                    group.producer_tc = tile_counter_allocator_.allocate(producer_tensix_id);
 
-                // Allocate separate consumer TCs for Remapper 1-to-many mapping
-                for (size_t consumer_idx = 0; consumer_idx < consumer_risc_ids.size(); consumer_idx++) {
-                    uint8_t consumer_tensix_id =
-                        ClientTypeAllocator::get_tensix_id(consumer_client_types[consumer_idx]);
-                    ::experimental::PackedTileCounter consumer_tc =
-                        tile_counter_allocator_.allocate(consumer_tensix_id);
-                    group.consumer_tcs.push_back(consumer_tc);
+                    for (size_t consumer_idx = 0; consumer_idx < consumer_risc_ids.size(); consumer_idx++) {
+                        uint8_t consumer_tensix_id =
+                            ClientTypeAllocator::get_tensix_id(consumer_client_types[consumer_idx]);
+                        ::experimental::PackedTileCounter consumer_tc =
+                            tile_counter_allocator_.allocate(consumer_tensix_id);
+                        group.consumer_tcs.push_back(consumer_tc);
+                    }
+
+                    log_info(
+                        tt::LogMetal,
+                        "Blocked: Producer[{}] TC[{}] (tensix_id={}) maps to {} consumer TCs via Remapper",
+                        producer_idx,
+                        tc_slot,
+                        producer_tensix_id,
+                        group.consumer_tcs.size());
                 }
-
-                log_info(
-                    tt::LogMetal,
-                    "Blocked: Producer[{}] TC[{}] (tensix_id={}) maps to {} consumer TCs via Remapper",
-                    producer_idx,
-                    tc_slot,
-                    producer_tensix_id,
-                    group.consumer_tcs.size());
             } else {
                 TT_FATAL(false, "Unsupported consumer access pattern");
             }
@@ -688,6 +738,7 @@ void ProgramImpl::finalize_single_dfb_config(
                 (uint32_t)::experimental::get_counter_id(risc_config.config.packed_tile_counter[tc]));
         }
         risc_config.config.num_tcs_to_rr = num_producer_tcs;
+        risc_config.config.broadcast_tc = dm_dm_blocked;
 
         if (use_remapper) {
             risc_config.config.remapper_pair_index = remapper_index_allocator_.allocate(core);
@@ -768,10 +819,19 @@ void ProgramImpl::finalize_single_dfb_config(
                     risc_config.config.packed_tile_counter[tc] = tc_groups[producer_idx][producer_tc_slot].producer_tc;
                 }
             } else if (config.cap == ::experimental::AccessPattern::BLOCKED) {
-                uint8_t producer_idx = tc;
-                uint8_t producer_tc_slot = 0;
-                risc_config.config.packed_tile_counter[tc] =
-                    tc_groups[producer_idx][producer_tc_slot].consumer_tcs[consumer_idx];
+                if (dm_dm_blocked) {
+                    // DM-DM BLOCKED: consumer[consumer_idx] TC[tc] = shared TC from producer[tc][consumer_idx].
+                    // tc iterates over num_consumer_tcs = num_producers.
+                    uint8_t producer_idx = tc;
+                    risc_config.config.packed_tile_counter[tc] =
+                        tc_groups[producer_idx][consumer_idx].consumer_tcs[0];
+                } else {
+                    // Tensix-involved BLOCKED: consumer gets its remapper-translated TC
+                    uint8_t producer_idx = tc;
+                    uint8_t producer_tc_slot = 0;
+                    risc_config.config.packed_tile_counter[tc] =
+                        tc_groups[producer_idx][producer_tc_slot].consumer_tcs[consumer_idx];
+                }
             } else {
                 TT_FATAL(false, "Unsupported consumer access pattern");
             }
@@ -856,7 +916,11 @@ void ProgramImpl::allocate_dataflow_buffers(const IDevice* device) {
                     rc.config.base_addr[tc] = base_addr;
                     rc.config.limit[tc] =
                         rc.config.base_addr[tc] + ((entry_size * max_prod_cons) * (dfb->capacity - 1)) + entry_size;
-                    base_addr += entry_size;
+                    // DM-DM BLOCKED broadcast: all producer TC slots map to the same physical buffer,
+                    // so base_addr must not advance between slots.
+                    if (!rc.config.broadcast_tc) {
+                        base_addr += entry_size;
+                    }
                 }
             }
         }
@@ -877,7 +941,9 @@ void ProgramImpl::allocate_dataflow_buffers(const IDevice* device) {
                 rc.config.base_addr[tc] = base_addr;
                 rc.config.limit[tc] =
                     rc.config.base_addr[tc] + ((entry_size * max_prod_cons) * (dfb->capacity - 1)) + entry_size;
-                if (dfb->config.cap == ::experimental::AccessPattern::STRIDED && tc < rc.config.num_tcs_to_rr) {
+                if ((dfb->config.cap == ::experimental::AccessPattern::STRIDED ||
+                     (dfb->config.cap == ::experimental::AccessPattern::BLOCKED && dfb->config.num_producers > 1)) &&
+                    tc < rc.config.num_tcs_to_rr) {
                     base_addr += entry_size;
                 }
             }

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp
@@ -28,6 +28,7 @@ struct LocalDFBInterfaceHost {
     std::array<uint32_t, 4> limit = {0};
     std::array<::experimental::PackedTileCounter, 4> packed_tile_counter = {0};
     uint8_t num_tcs_to_rr = 1;
+    bool broadcast_tc = false;  // DM-DM BLOCKED producer: post to all TCs instead of round-robin
     uint8_t remapper_pair_index = 0;
     uint32_t consumer_tcs = 0;
     uint8_t remapper_consumer_ids_mask = 0;
@@ -52,7 +53,7 @@ struct DataflowBufferImpl {
 
     // Shared config fields (written to dfb_initializer_t)
     uint32_t entry_size = 0;
-    uint32_t stride_size = 0;
+    uint32_t stride_in_entries = 0;
     std::array<uint8_t, 4> txn_ids = {0};
     uint8_t num_entries_per_txn_id = 0;
     uint8_t num_entries_per_txn_id_per_tc = 0;
@@ -88,25 +89,35 @@ private:
     std::unordered_map<CoreCoord, uint8_t> next_index_;
 };
 
-// Allocates clientTypes for BLOCKED consumer mode based on consumer RISC ID
-// ClientTypes map to tensix_id: tensix_id = clientType % 4
-// For Tensix RISCs (risc_id 8-11): id_R derived from risc_id = 4 + (risc_id - 8) = NEO_0-NEO_3
-// For DM RISCs (risc_id 0-7): allocate first unused clientType avoiding producer's tensix_id
+// Allocates Remapper clientTypes for BLOCKED consumer mode.
+//
+// Hardware access rules:
+//   - DM RISCs (risc_id 0-7):    clientR must be in [0, 3] (DM TC groups 0-3)
+//   - Tensix RISCs (risc_id 8-11): clientR must be in [4, 7] (NEO_0 to NEO_3)
+//   - clientL (producer) must not equal clientR (consumer)
+//
+// Allocation:
+//   - Tensix consumer: clientR = 4 + (risc_id - 8), and unique per Tensix neo.
+//   - DM consumer: cycle through [0, 3] \ {producer_client_type} in round-robin order.
+//     DM clientR IDs may repeat across consumers; uniqueness is provided by the tc_id
+//     (cnt_sel) within each clientR group, which is assigned by TileCounterAllocator.
 class ClientTypeAllocator {
 public:
-    // Allocates a unique clientType for consumer based on consumer's RISC ID
-    // - Tensix RISCs (8-11): id_R derived from risc_id = 4 + (risc_id - 8)
-    // - DM RISCs (0-7): allocate first unused clientType avoiding producer's tensix_id
-    // Returns clientType in [0,7]
-    uint8_t allocate_for_consumer(uint8_t producer_tensix_id, uint8_t consumer_risc_id);
+    // producer_client_type: the clientL already assigned to the producer.
+    // consumer_risc_id: RISC ID of the consumer being allocated.
+    // Returns clientType in [0, 3] for DM consumers, [4, 7] for Tensix consumers.
+    uint8_t allocate_for_consumer(uint8_t producer_client_type, uint8_t consumer_risc_id);
 
-    // Get tensix_id from clientType
     static uint8_t get_tensix_id(uint8_t client_type) { return client_type % 4; }
 
-    void reset() { used_mask_ = 0; }
+    void reset() {
+        tensix_used_mask_ = 0;
+        dm_alloc_count_ = 0;
+    }
 
 private:
-    uint8_t used_mask_ = 0;  // Bitmask of used clientTypes
+    uint8_t tensix_used_mask_ = 0;  // Bitmask of used Tensix clientTypes (bits 0-3 → ids 4-7)
+    uint8_t dm_alloc_count_ = 0;    // Counts DM consumers allocated; used for round-robin cycling
 };
 
 uint32_t finalize_dfbs(

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -401,7 +401,7 @@ private:
     void finalize_single_dfb_config(
         std::shared_ptr<tt::tt_metal::experimental::dfb::detail::DataflowBufferImpl>& dfb,
         const CoreCoord& core,
-        bool use_remapper);
+        bool core_has_remapper);
 
     CBHandle add_circular_buffer_(const std::shared_ptr<CircularBufferImpl>& circular_buffer);
 


### PR DESCRIPTION
Continuation of DFB integration. The changes here help enable multi-threaded datacopy in [abhullar/multi-tensix](https://github.com/tenstorrent/tt-metal/tree/abhullar/multi-tensix)

### What's changed
Added support for multi-threaded tensix producer/consumers of DFB and updated llk unpack/packs to account for tile strides. 
Testing this led to several bug fixes:
- Updated DM strided - to - DM blocked to not use the remapper (this isn't supported by the [HW](https://tenstorrent.atlassian.net/browse/AIHWE-673)
- Updated DM strided to - DM strided ot not use remapper even if the remapper is configured. This is because programming the remapper does not remove the default Tile Counters mirroring to the Overlay
- Updated tensix + dm producers to wait for remapper to be enabled before they configure their tile counters to ensure that the mapped tile counters see this

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=abhullar/nt6-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:abhullar/nt6-fixes)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=abhullar/nt6-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:abhullar/nt6-fixes)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early
