### PR TITLE
[skip ci] perf: update sdxl_unet_512x512 device perf baseline after SDPA optimization

### DIFF
--- a/models/demos/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -119,7 +119,7 @@ def test_refiner_unet(
         ),
         (
             'pytest models/demos/stable_diffusion_xl_base/tests/test_sdxl_perf.py::test_unet -k "512x512"',
-            91_053_421 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
+            89_300_000 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
             "sdxl_unet_512x512",
             "sdxl_unet_512x512",
             1,


### PR DESCRIPTION
### Problem description

Commit 93b1879c improved SDPA performance by ~2%, causing `test_sdxl_perf_device[test_sdxl_unet_512x512]` to fail because the measured kernel duration now falls below the old lower threshold.

This is a **performance improvement, not a regression**:
```
AVG DEVICE KERNEL DURATION [ns] 89283447.0 is outside of expected range (89687619.685, 92419222.315)
```

### What's changed

Updated `expected_device_perf_ns_per_iteration` for `sdxl_unet_512x512`:
- **Old baseline**: `91_053_421` ns → range `(89_687_619, 92_419_222)` at 1.5% margin
- **New baseline**: `89_300_000` ns → range `(87_960_500, 90_639_500)` at 1.5% margin
- **Measured**: ~89_283_447 ns (confirmed deterministic across 3 runs + 1 retry)

Failing runs: https://github.com/tenstorrent/tt-metal/actions/runs/22879060423

### CI Validation

✅ perf-device-models passed on this branch (WH B0, stable-diffusion-xl):
https://github.com/tenstorrent/tt-metal/actions/runs/22885781889