### PR TITLE
Adding scalar input support to tilize_with_val_padding

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_tilize_with_val_padding.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_tilize_with_val_padding.py
@@ -576,13 +576,32 @@ def test_tilize_with_val_padding_interleaved_to_legacy_sharded(
     assert_equal(expected_torch_tensor, output_torch_tensor)
 
 
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
-@pytest.mark.parametrize("pad_value", [0.0, 42.0])
-def test_tilize_with_val_padding_scalar(device, dtype, pad_value):
+@pytest.mark.parametrize(
+    "dtype, scalar_val, pad_value",
+    [
+        (ttnn.bfloat16, 1.5, 0.0),
+        (ttnn.bfloat16, 1.5, 42.0),
+        (ttnn.bfloat16, 1.5, -32.5),
+        (ttnn.float32, 1.5, 0.0),
+        (ttnn.float32, 1.5, -0.0),
+        (ttnn.float32, 1.5, 42.0),
+        (ttnn.float32, 1.5, -32.5),
+        (ttnn.int32, 7, 0),
+        (ttnn.int32, 7, -32),
+        (ttnn.int32, 7, -0),
+        (ttnn.uint32, 7, 0),
+        (ttnn.uint32, 7, 42),
+    ],
+)
+def test_tilize_with_val_padding_scalar(device, dtype, scalar_val, pad_value):
     """tilize_with_val_padding: scalar (rank-0) input."""
     torch.manual_seed(0)
-    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
-    scalar_val = 0.0
+    torch_dtype = {
+        ttnn.bfloat16: torch.bfloat16,
+        ttnn.float32: torch.float32,
+        ttnn.int32: torch.int32,
+        ttnn.uint32: torch.int32,
+    }[dtype]
 
     input_torch_tensor = torch.tensor(scalar_val, dtype=torch_dtype)
     input_ttnn_tensor = ttnn.from_torch(input_torch_tensor, dtype=dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
@@ -593,4 +612,5 @@ def test_tilize_with_val_padding_scalar(device, dtype, pad_value):
 
     ref_input = input_torch_tensor.reshape(1, 1)
     expected_torch_tensor = pytorch_tilize_with_val_padding(ref_input, output_padded_shape, pad_value)
+    expected_torch_tensor = expected_torch_tensor.to(output_torch_tensor.dtype)
     assert_equal(expected_torch_tensor, output_torch_tensor)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_tilize_with_val_padding.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_tilize_with_val_padding.py
@@ -574,3 +574,23 @@ def test_tilize_with_val_padding_interleaved_to_legacy_sharded(
     output_torch_tensor = ttnn_output_tensor.cpu().to_torch_with_padded_shape()
     expected_torch_tensor = pytorch_tilize_with_val_padding(input_torch_tensor, output_padded_shape, pad_value)
     assert_equal(expected_torch_tensor, output_torch_tensor)
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+@pytest.mark.parametrize("pad_value", [0.0, 42.0])
+def test_tilize_with_val_padding_scalar(device, dtype, pad_value):
+    """tilize_with_val_padding: scalar (rank-0) input."""
+    torch.manual_seed(0)
+    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
+    scalar_val = 0.0
+
+    input_torch_tensor = torch.tensor(scalar_val, dtype=torch_dtype)
+    input_ttnn_tensor = ttnn.from_torch(input_torch_tensor, dtype=dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+
+    output_padded_shape = [32, 32]
+    ttnn_output_tensor = ttnn.tilize_with_val_padding(input_ttnn_tensor, output_padded_shape, pad_value)
+    output_torch_tensor = ttnn_output_tensor.cpu().to_torch_with_padded_shape()
+
+    ref_input = input_torch_tensor.reshape(1, 1)
+    expected_torch_tensor = pytorch_tilize_with_val_padding(ref_input, output_padded_shape, pad_value)
+    assert_equal(expected_torch_tensor, output_torch_tensor)

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_factory_helper.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_factory_helper.cpp
@@ -4,6 +4,8 @@
 
 #include "ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_factory_helper.hpp"
 
+#include <bit>
+
 #include <tt-metalium/bfloat16.hpp>
 #include "ttnn/tensor/types.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
@@ -25,11 +27,13 @@ uint32_t get_packed_value(const Tensor& tensor, const PadValue& pad_value) {
                     return ttnn::operations::data_movement::pack_two_uint16_into_uint32(
                         {uint16_pad_value, uint16_pad_value});
                 }
+                if (tensor.dtype() == DataType::FLOAT32) {
+                    return std::bit_cast<uint32_t>(static_cast<float>(pad_value));
+                }
                 TT_FATAL(
-                    tensor.dtype() == DataType::FLOAT32 or tensor.dtype() == DataType::UINT32 or
-                        tensor.dtype() == DataType::INT32,
+                    tensor.dtype() == DataType::UINT32 or tensor.dtype() == DataType::INT32,
                     "only supporting bfloat16, float32, and uint32/int32/uint16");
-                return (uint32_t)((pad_value));
+                return static_cast<uint32_t>(pad_value);
             }
             if constexpr (std::is_same_v<T, uint32_t>) {
                 if (tensor.dtype() == DataType::BFLOAT16) {

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.cpp
@@ -80,7 +80,7 @@ TilizeWithValPaddingDeviceOperation::program_factory_t TilizeWithValPaddingDevic
 
 void TilizeWithValPaddingDeviceOperation::validate_on_program_cache_miss(
     const TilizeWithValPaddingParams& operation_attributes, const Tensor& input_tensor) {
-    auto input_shape = input_tensor.logical_shape();
+    const auto& input_shape = input_tensor.logical_shape();
 
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands need to be on device!");
     TT_FATAL(input_tensor.buffer() != nullptr, "Operands need to be allocated in buffers on device!");

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.cpp
@@ -80,7 +80,7 @@ TilizeWithValPaddingDeviceOperation::program_factory_t TilizeWithValPaddingDevic
 
 void TilizeWithValPaddingDeviceOperation::validate_on_program_cache_miss(
     const TilizeWithValPaddingParams& operation_attributes, const Tensor& input_tensor) {
-    const auto& input_shape = input_tensor.logical_shape();
+    auto input_shape = input_tensor.logical_shape();
 
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands need to be on device!");
     TT_FATAL(input_tensor.buffer() != nullptr, "Operands need to be allocated in buffers on device!");
@@ -90,8 +90,6 @@ void TilizeWithValPaddingDeviceOperation::validate_on_program_cache_miss(
             input_tensor.dtype() == DataType::UINT32 or input_tensor.dtype() == DataType::FLOAT32 or
             input_tensor.dtype() == DataType::UINT16,
         "Can only tilize bfloat16/float32 or int32/uint32/uint16 tensors");
-
-    TT_FATAL(input_shape.rank() >= 1, "Input tensor must be of rank >= 1, but its shape is {}", input_shape);
 
     if (input_shape.rank() == 1) {
         // Special case: if input tensor is 1D row-major, output tiled tensor will have 1D logical shape

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_nd_shard_input_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_nd_shard_input_program_factory.cpp
@@ -132,7 +132,8 @@ UntilizeMultiCoreNDShardInputProgramFactory::cached_program_t UntilizeMultiCoreN
         output_tensor_width;  // In height-sharded and interleaved cases, the output page is the entire tensor row
     uint32_t output_num_blocks_across_width = 1;
     if (output.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED ||
-        output.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED) {
+        output.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED ||
+        output.memory_config().memory_layout() == TensorMemoryLayout::ND_SHARDED) {
         if (output.shard_spec().has_value()) {
             output_page_width = output.shard_spec().value().shape[1];
         } else {

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_program_factory.cpp
@@ -190,7 +190,8 @@ UntilizeMultiCoreProgramFactory::cached_program_t UntilizeMultiCoreProgramFactor
         tensor_width;  // In height-sharded and interleaved cases, the output page is the entire tensor row
     uint32_t output_num_blocks_across_width = 1;
     if (output.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED ||
-        output.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED) {
+        output.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED ||
+        output.memory_config().memory_layout() == TensorMemoryLayout::ND_SHARDED) {
         if (output.shard_spec().has_value()) {
             output_page_width = output.shard_spec().value().shape[1];
         } else {

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_single_core_program_factory.cpp
@@ -51,7 +51,8 @@ UntilizeSingleCoreProgramFactory::cached_program_t UntilizeSingleCoreProgramFact
     uint32_t num_blocks_across_height = a.physical_volume() / a.padded_shape()[-1] / tile_height;
     uint32_t num_columns_of_blocks = 1;
     if (output.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED ||
-        output.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED) {
+        output.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED ||
+        output.memory_config().memory_layout() == TensorMemoryLayout::ND_SHARDED) {
         uint32_t output_shard_width;
         if (output.shard_spec().has_value()) {
             output_shard_width = output.shard_spec().value().shape[1];

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_nd_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_nd_sharded_program_factory.cpp
@@ -133,7 +133,8 @@ UntilizeWithUnpaddingMultiCoreNDShardedProgramFactory::create(
         output_tensor_width;  // In height-sharded and interleaved cases, the output page is the entire tensor row
     uint32_t output_num_blocks_across_width = 1;
     if (output.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED ||
-        output.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED) {
+        output.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED ||
+        output.memory_config().memory_layout() == TensorMemoryLayout::ND_SHARDED) {
         if (output.shard_spec().has_value()) {
             output_page_width = output.shard_spec().value().shape[1];
         } else {


### PR DESCRIPTION
### Ticket
[#39502
](https://github.com/tenstorrent/tt-metal/issues/39502)
### Problem description

1. Currently `tilize_with_val_padding` does not support scalar inputs. 
2. Also, there is an existing bug regarding keeping the bitwise value of FLOAT32 padding values in `get_packed_value`. 
3. The PR [38377](https://github.com/tenstorrent/tt-metal/pull/38377) added a separate `TensorMemoryLayout::ND_SHARDED` enum field for ND sharded tensors with no legacy `shard_spec` equivalent. Some `untilize` and `untilize_with_val_padding` program factories were not updated to reflect this, resulting in failing tests.

### What's changed

1. Scalar inputs to `tilize_with_val_padding` have been enabled.
2. The bug for handling FLOAT32 padding values has been fixed to maintain the bit-value of FLOAT32s. The cast of the FLOAT32 padding value to a uint32 has been replaced with a std::bit_cast<uint32_t>.
3. The `untilize` and `untilize_with_val_padding` program factories were updated to reflect the new `TensorMemoryLayout::ND_SHARDED` enum field used for ND sharded tensors (was labelled `TensorMemoryLayout::BLOCK_SHARDED` before).

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=awliu/tilize_with_val_padding_scalars)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:awliu/tilize_with_val_padding_scalars)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=awliu/tilize_with_val_padding_scalars)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:awliu/tilize_with_val_padding_scalars) compared to [Main Results](https://github.com/tenstorrent/tt-metal/actions/runs/22892945622/job/66420560087)
- [x] New/Existing tests provide coverage for changes
- [x] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/runs/22892486519) on the PR branch to catch linting errors early