### PR TITLE
Prevent shard grids with more cores than shards

### DIFF
--- a/tt_metal/impl/tensor/spec/layout/tensor_layout.cpp
+++ b/tt_metal/impl/tensor/spec/layout/tensor_layout.cpp
@@ -211,6 +211,11 @@ BufferShardingArgs TensorLayout::compute_buffer_sharding_args(const tt::tt_metal
             nd_shard_spec->grid,
             nd_shard_spec->orientation,
             nd_shard_spec->shard_distribution_strategy);
+        TT_FATAL(
+            nd_shard_spec->grid.num_cores() <= distribution_spec->num_shards(),
+            "Number of cores in ND shard grid {} must not exceed number of shards {}",
+            nd_shard_spec->grid.num_cores(),
+            distribution_spec->num_shards());
     }
     return BufferShardingArgs(
         std::move(distribution_spec), std::move(shard_spec_buffer), memory_config_.memory_layout());

--- a/tt_metal/impl/tensor/spec/tensor_spec.cpp
+++ b/tt_metal/impl/tensor/spec/tensor_spec.cpp
@@ -28,6 +28,14 @@ void validate_shard_spec_with_tensor_shape(const TensorSpec& tensor_spec) {
     const auto& shard_spec = memory_config.shard_spec().value();
     uint32_t num_cores = shard_spec.num_cores();
 
+    uint32_t num_shards = div_up(physical_height, physical_shard_height) * div_up(physical_width, physical_shard_width);
+
+    TT_FATAL(
+        num_shards == num_cores,
+        "Number of shards {} must equal number of cores {} for 2D sharding",
+        num_shards,
+        num_cores);
+
     // TODO (issue #17060): Flip to TT_FATAL
     if (memory_config.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) {
         TT_FATAL(


### PR DESCRIPTION
### Ticket
N/A
### Problem description
A lot of sharded program factories are written assuming that the provided shard core grid in the shard spec matches the number of shards. In many cases, when a shard spec (or ND shard spec) is given with more cores than shards, the program gets launched onto the extra kernels with no data, causing wrong outputs, hangs, and potential undefined behavior.
### What's changed
The shard spec or nd shard spec should be created with a grid representing all cores which have shards on them. Attempts to construct shard specs or nd shard specs with extra cores that have no data on them will result in a `TT_FATAL` with an appropriate error message notifying the user of this wrong configuration. This will prevent any undefined behavior resulting from having a shard grid that does not represent the actual sharding distribution across cores/banks.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=awliu/preventing_larger_shard_grid_than_shards)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:awliu/preventing_larger_shard_grid_than_shards)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=awliu/preventing_larger_shard_grid_than_shards)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:awliu/preventing_larger_shard_grid_than_shards)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=awliu/preventing_larger_shard_grid_than_shards)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:awliu/preventing_larger_shard_grid_than_shards)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early
