### PR TITLE
Fix GPT-OSS vLLM nightly: disable batched prefill and fix page table sizing

### DIFF
--- a/models/demos/gpt_oss/tt/model_config.py
+++ b/models/demos/gpt_oss/tt/model_config.py
@@ -108,6 +108,7 @@ class ModelArgs:
             self.tokenizer = AutoTokenizer.from_pretrained(self.weights_path, trust_remote_code=True)
             self.processor = None  # GPT-OSS doesn't use vision processor
 
+        self.disable_batched_prefill = True
         self.capped_warmup_seq_len = 2048
         self.trace_prefill_supported_seq_lens = self.get_trace_prefill_supported_seq_lens()
 

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -2192,7 +2192,9 @@ class Generator(WarmupForwardMixin):
                 if page_table.shape[1] < num_blocks:
                     padding = torch.ones(page_table.shape[0], num_blocks - page_table.shape[1], dtype=torch.int32) * -1
                     page_table = torch.cat([page_table, padding], dim=1)
-            padded_page_table = torch.ones(32, page_table.shape[1], dtype=torch.int32) * -1
+            padded_page_table = (
+                torch.ones(self.model_args[0].max_batch_size, page_table.shape[1], dtype=torch.int32) * -1
+            )
             assert user_id is not None
             for i, user in enumerate(user_id):
                 padded_page_table[user, :] = page_table[i, :]

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -468,6 +468,7 @@ class Generator(WarmupForwardMixin):
             and len(set(prefill_seq_lens)) == 1
             and prefill_seq_lens[0] * batch_size < MAX_BATCHED_PREFILL_SEQ_LEN
             and self.data_parallel == 1
+            and not getattr(self.model_args[0], "disable_batched_prefill", False)
         )
 
         all_users = [0] if use_batched_prefill else empty_slots


### PR DESCRIPTION
## Summary
- Fix hardcoded batch size (32) in `_get_prefill_user_page_table` to use `self.model_args[0].max_batch_size`
- Disable batched prefill for GPT-OSS via new `disable_batched_prefill` model arg

## Problem
PR #35722 introduced batched prefill for tt-transformers. GPT-OSS inadvertently activates this path because it hardcodes `data_parallel=1`, satisfying all `use_batched_prefill` conditions. GPT-OSS does not support batched prefill, causing `TT_FATAL` crashes in `paged_fill_cache` during vLLM high-throughput serving (User 33+ prefill).

## Fix
- Add `disable_batched_prefill` model arg (default `False`) to tt-transformers `ModelArgs`
- Set `disable_batched_prefill = True` in GPT-OSS `ModelArgs`
- Check the flag in `generator.py` via `getattr` with `False` default, so models without the attribute still get batched prefill
- Also fix the hardcoded `torch.ones(32, ...)` in `_get_prefill_user_page_table` to use `max_batch_size`

https://github.com/tenstorrent/tt-metal/actions/runs/22904776527/job/66576348070