### PR TITLE
Skip BH ring joint attention tests on 8xP150 LoudBox

### DIFF
--- a/tests/nightly/blackhole/ccl/test_ring_joint_attention.py
+++ b/tests/nightly/blackhole/ccl/test_ring_joint_attention.py
@@ -16,6 +16,15 @@ from models.tt_dit.tests.unit.test_ring_joint_attention import (
 )
 
 
+@pytest.fixture(autouse=True)
+def skip_on_large_clusters():
+    num_devices = ttnn.get_num_devices()
+    if num_devices > 4:
+        pytest.skip(
+            f"2x2 submesh fabric init not supported on clusters with {num_devices} devices (e.g. 8xP150 LoudBox)"
+        )
+
+
 @bh_qb_ge_unit_test_params
 @pytest.mark.parametrize(
     "device_params, all_gather_topology",


### PR DESCRIPTION
## Summary
- Skip ring joint attention tests on clusters with >4 devices (8xP150 LoudBox)
- The `bh_qb_ge` tests request a 2x2 mesh. On LoudBox (8 chips), carving a 2x2 submesh from the 2x4 topology causes a fabric router sync timeout (`Expected 0xa2b2c2d2, got 0xa1b1c1d1`)
- All other BH variants pass: QB-GE/LLMBox use all 4 chips; DeskBox/P300 skip via mesh_device fixture

## Test plan
- [ ] [![(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=pjosipovic/skip_8_p150_ring_sdpa_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:pjosipovic/skip_8_p150_ring_sdpa_tests) — ring joint attention tests should SKIP (not ERROR) on LoudBox

🤖 Generated with [Claude Code](https://claude.com/claude-code)