### PR TITLE
[CB DISPATCH] Fix CB config dispatch corruption when the same CB index has different configs on different core groups

### DIFF
--- a/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_allocation.cpp
+++ b/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_allocation.cpp
@@ -33,8 +33,10 @@
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/xy_pair.hpp>
 
-// Access to internal API: ProgramImpl::get_cb_base_addr
+// Access to internal API: ProgramImpl::get_cb_base_addr, circular_buffers_unique_coreranges, etc.
 #include "impl/program/program_impl.hpp"
+// Access to CircularBufferImpl::size(), local_buffer_indices(), etc.
+#include "impl/buffers/circular_buffer.hpp"
 
 using std::vector;
 using namespace tt::tt_metal;
@@ -592,6 +594,100 @@ TEST_F(MeshDeviceFixture, TensixTestDataCopyWithUpdatedCircularBufferConfig) {
         detail::ReadFromDeviceL1(
             this->devices_.at(id)->get_devices()[0], core, global_cb_buffer->address(), buffer_size, second_cb_data);
         EXPECT_EQ(src_vec, second_cb_data);
+    }
+}
+
+// Regression test for CB config dispatch corruption bug (same pattern as argmax).
+// Replicates dispatch.cpp's CB config payload construction using
+// circular_buffers_unique_coreranges() and circular_buffers_on_corerange().
+TEST_F(MeshDispatchFixture, TensixTestCircularBufferConfigDispatchWithOverlappingCoreRanges) {
+    // The argmax factory creates:
+    //   1. CB index 0 on cores0 with size0   (first core group)
+    //   2. CB index 0 on cores1 with size1   (second core group, different size)
+    //   3. CB index 1 on all_cores           (union of cores0 + cores1)
+    //
+    // CreateCircularBuffer internally calls merge_ranges() on the input CoreRangeSet.
+    // When all_cores = {(0,0)-(2,0), (3,0)-(4,0)}, merge_ranges() combines these
+    // adjacent ranges into {(0,0)-(4,0)}.
+    //
+    // Without fix, circular_buffers_unique_coreranges() returns:
+    //   {(0,0)-(2,0)}, {(3,0)-(4,0)}, {(0,0)-(4,0)}
+    //                                   ^^^^^^^^^^^^^ overlaps both!
+    //
+    // Dispatch builds one multicast payload per unique range (dispatch.cpp:1046-1096).
+    // For the merged {(0,0)-(4,0)}, circular_buffers_on_corerange() returns all three
+    // CBs. CB#1 writes size0 for index 0, then CB#2 overwrites with size1.
+    // This payload gets multicast to ALL cores, corrupting cores0's config.
+    CBConfig cb_config;
+
+    // Two non-overlapping core groups, adjacent so merge_ranges() combines them.
+    CoreRange cores0_range({0, 0}, {2, 0});  // 3 cores
+    CoreRange cores1_range({3, 0}, {4, 0});  // 2 cores
+    CoreRangeSet cores0({cores0_range});
+    CoreRangeSet cores1({cores1_range});
+    // Two separate ranges — merge_ranges() inside CreateCircularBuffer will
+    // merge them into {(0,0)-(4,0)}.
+    CoreRangeSet all_cores(std::vector<CoreRange>{cores0_range, cores1_range});
+
+    Program program;
+
+    uint32_t size0 = cb_config.page_size;
+    uint32_t size1 = cb_config.page_size * 2;
+
+    // CB index 0 on cores0 with size0
+    CircularBufferConfig cfg0 =
+        CircularBufferConfig(size0, {{0, cb_config.data_format}}).set_page_size(0, cb_config.page_size);
+    CreateCircularBuffer(program, cores0, cfg0);
+
+    // CB index 0 on cores1 with size1 — different size, same index
+    CircularBufferConfig cfg1 =
+        CircularBufferConfig(size1, {{0, cb_config.data_format}}).set_page_size(0, cb_config.page_size);
+    CreateCircularBuffer(program, cores1, cfg1);
+
+    // CB index 1 spanning all_cores.
+    // merge_ranges() merges {(0,0)-(2,0), (3,0)-(4,0)} into {(0,0)-(4,0)}.
+    CircularBufferConfig spanning_cfg =
+        CircularBufferConfig(cb_config.page_size, {{1, cb_config.data_format}}).set_page_size(1, cb_config.page_size);
+    CreateCircularBuffer(program, all_cores, spanning_cfg);
+
+    // Replicate dispatch.cpp's CB config payload construction (lines 1046-1096).
+    // For each unique core range, dispatch builds a payload from all intersecting CBs
+    // via circular_buffers_on_corerange(), then multicasts it to all cores in that range.
+    const auto& unique_ranges = program.impl().circular_buffers_unique_coreranges();
+
+    // Simulate multicast: build per-range payload, write to all covered cores.
+    // Last range covering a core overwrites previous values (same as hardware multicast).
+    std::map<CoreCoord, uint32_t> core_to_cb0_size;
+    for (const CoreRange& range : unique_ranges) {
+        // Build payload for this range exactly like dispatch.cpp:1054-1066
+        uint32_t payload_cb0_size = 0;
+        const auto& cbs_on_range = program.impl().circular_buffers_on_corerange(range);
+        for (const auto& cb : cbs_on_range) {
+            for (const auto& buffer_index : cb->local_buffer_indices()) {
+                if (buffer_index == 0) {
+                    payload_cb0_size = cb->size();
+                }
+            }
+        }
+
+        // Simulate multicast to all cores in this range
+        for (uint32_t x = range.start_coord.x; x <= range.end_coord.x; x++) {
+            for (uint32_t y = range.start_coord.y; y <= range.end_coord.y; y++) {
+                core_to_cb0_size[CoreCoord(x, y)] = payload_cb0_size;
+            }
+        }
+    }
+
+    // Verify: cores0 should have size0, cores1 should have size1.
+    // Without the fix, cores0 gets size1 because the merged range's payload
+    // (with CB#2 overwriting CB#1 for index 0) is multicast last to all cores.
+    for (uint32_t x = cores0_range.start_coord.x; x <= cores0_range.end_coord.x; x++) {
+        EXPECT_EQ(size0, core_to_cb0_size[CoreCoord(x, 0)])
+            << "Core (" << x << ", 0) in cores0 got wrong size for CB index 0";
+    }
+    for (uint32_t x = cores1_range.start_coord.x; x <= cores1_range.end_coord.x; x++) {
+        EXPECT_EQ(size1, core_to_cb0_size[CoreCoord(x, 0)])
+            << "Core (" << x << ", 0) in cores1 got wrong size for CB index 0";
     }
 }
 

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -857,26 +857,44 @@ std::vector<CoreRange> detail::ProgramImpl::circular_buffers_unique_coreranges()
         return core_ranges;
     }
 
-    // Ensure all returned CoreRanges are non-overlapping. During dispatch, each
-    // CoreRange's CB config payload is built from all CBs whose core_ranges intersect
-    // it. When a superset range (e.g. all_cores) overlaps with sub-ranges that carry
-    // different configs for the same CB index, the payload can only hold one config
-    // per index — the last one written wins, and the multicast sends the wrong config
-    // to cores that need the other. By making ranges non-overlapping, each range's
-    // intersects()-based CB lookup returns only CBs that fully cover it, so every
-    // core receives exactly the correct set of configs in a single multicast.
+    // Make ranges non-overlapping so that each core is targeted by exactly one
+    // multicast during CB config dispatch.
     //
-    // Algorithm: process ranges in order. For each new range, subtract all
-    // previously claimed regions (using CoreRangeSet::subtract) and keep only the
-    // uncovered pieces.
-    CoreRangeSet claimed;
-    std::vector<CoreRange> result;
-    for (const auto& cr : core_ranges) {
-        CoreRangeSet uncovered = CoreRangeSet(cr).subtract(claimed);
-        for (const auto& piece : uncovered.ranges()) {
-            result.push_back(piece);
+    // During dispatch, each CoreRange's payload is built from all CBs whose
+    // core_ranges intersect it. If a range intersects two CBs with the same
+    // buffer index but different configs (valid when their core_ranges don't
+    // overlap), the second CB overwrites the first in the payload and the
+    // multicast sends the wrong config to cores that need the other.
+    //
+    // Split every overlapping pair into three non-overlapping pieces (A\B, A∩B,
+    // B\A) and repeat until no overlaps remain. Each resulting piece's boundaries
+    // align with all original CB CoreRange edges, so it cannot straddle two
+    // different configs for the same buffer index.
+    std::vector<CoreRange> result = std::move(core_ranges);
+    size_t i = 0;
+    while (i < result.size()) {
+        // Find the first range that overlaps with result[i].
+        size_t j = i + 1;
+        for (; j < result.size(); ++j) {
+            if (result[i].intersects(result[j])) {
+                break;
+            }
         }
-        claimed = claimed.merge(CoreRangeSet(cr));
+        if (j == result.size()) {
+            ++i;  // No overlap, advance.
+            continue;
+        }
+        // Split the overlapping pair into non-overlapping pieces: A\B, A∩B, B\A.
+        CoreRangeSet a_set(result[i]), b_set(result[j]);
+        result.erase(result.begin() + j);
+        result.erase(result.begin() + i);
+        auto a_only = a_set.subtract(b_set);
+        auto b_only = b_set.subtract(a_set);
+        auto common = a_set.intersection(b_set);
+        result.insert(result.end(), a_only.ranges().begin(), a_only.ranges().end());
+        result.insert(result.end(), b_only.ranges().begin(), b_only.ranges().end());
+        result.insert(result.end(), common.ranges().begin(), common.ranges().end());
+        i = 0;  // Restart — new pieces may overlap with earlier ranges.
     }
     return result;
 }

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -842,7 +842,43 @@ std::vector<CoreRange> detail::ProgramImpl::circular_buffers_unique_coreranges()
             }
         }
     }
-    return core_ranges;
+
+    // Fast path: if no ranges overlap, return as-is.
+    bool has_overlap = false;
+    for (size_t i = 0; i < core_ranges.size() && !has_overlap; ++i) {
+        for (size_t j = i + 1; j < core_ranges.size(); ++j) {
+            if (core_ranges[i].intersects(core_ranges[j])) {
+                has_overlap = true;
+                break;
+            }
+        }
+    }
+    if (!has_overlap) {
+        return core_ranges;
+    }
+
+    // Ensure all returned CoreRanges are non-overlapping. During dispatch, each
+    // CoreRange's CB config payload is built from all CBs whose core_ranges intersect
+    // it. When a superset range (e.g. all_cores) overlaps with sub-ranges that carry
+    // different configs for the same CB index, the payload can only hold one config
+    // per index — the last one written wins, and the multicast sends the wrong config
+    // to cores that need the other. By making ranges non-overlapping, each range's
+    // intersects()-based CB lookup returns only CBs that fully cover it, so every
+    // core receives exactly the correct set of configs in a single multicast.
+    //
+    // Algorithm: process ranges in order. For each new range, subtract all
+    // previously claimed regions (using CoreRangeSet::subtract) and keep only the
+    // uncovered pieces.
+    CoreRangeSet claimed;
+    std::vector<CoreRange> result;
+    for (const auto& cr : core_ranges) {
+        CoreRangeSet uncovered = CoreRangeSet(cr).subtract(claimed);
+        for (const auto& piece : uncovered.ranges()) {
+            result.push_back(piece);
+        }
+        claimed = claimed.merge(CoreRangeSet(cr));
+    }
+    return result;
 }
 
 void detail::ProgramImpl::invalidate_circular_buffer_allocation() {


### PR DESCRIPTION
### Problem description
There was an issue detected by [APC watcher run](https://github.com/tenstorrent/tt-metal/actions/runs/22883014985/job/66397631750) which stated that `NCRISC using noc1 tried to unicast read 384 bytes to local L1[0x01b200] from DRAM core w/ virtual coords (x=17,y=13) DRAM[addr=0x00493e40] (NOC transaction overflows a circular buffer). ` Investigating this I uncovered specific issue not that often hit when creating cb configs. `argmax_multi_core_program_factory.cpp` creates cb with same cb index on two different core ranges, these differ in size one is 384B and the other is 256B. First is created on cores0 and second on cores1 core range. These ranges don't overlap but together they cover all_cores core range. There are three more cbs created on all_cores core range c_1, c_2 and c_3. 

When circular buffers with the same buffer index (c_0) are created on non-overlapping core groups with different sizes, and other CB indices (c_1, c_2, c_3) are created on all_cores, the dispatch sends incorrect configs to some cores. During dispatch, _circular_buffers_unique_coreranges()_ returns all unique core range objects from all CBs. This includes the sub-ranges from cores0/cores1 alongside the superset range from all_cores. For each core range, the dispatch builds a zero-initialized payload from all CBs that intersect it, then multicasts the entire payload to all cores in the range.

When the superset all_cores range is processed, both c_0 CBs intersect it. The payload can only hold one config per index and it is the second c_0 which overwrites the first. This payload is multicast to all cores, and since it's the last multicast by insertion order, it overwrites the correct c_0 configs set by the earlier subrange multicasts. Cores in cores0 end up with c_0 size 256 instead of 384.

### What's changed
circular_buffers_unique_coreranges() now ensures all returned core range objects are non-overlapping. When an overlapping pair is found, it is split into three non-overlapping pieces (A\B, A∩B, B\A). This repeats until no overlaps remain. Each resulting piece's boundaries align with all original CB core ranges edges, so it cannot straddle two different configs for the same buffer index, the existing intersects() lookup in dispatch then finds exactly the right CBs for each piece.

A fast path check skips the subtraction logic entirely when no overlapping ranges exist, which is the common case.

### Checklist

- [x] [WH APC](https://github.com/tenstorrent/tt-metal/actions/runs/22900362772)
- [x] [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/runs/22859265997)
- [x] [BH APC](https://github.com/tenstorrent/tt-metal/actions/runs/22899375994)
- [x] [Model Perf tests](https://github.com/tenstorrent/tt-metal/actions/runs/22910904539)
