### PR TITLE
[#39411] Support Bools in DPRINT

### DIFF
--- a/docs/source/tt-metalium/tools/kernel_print.rst
+++ b/docs/source/tt-metalium/tools/kernel_print.rst
@@ -39,8 +39,12 @@ An example with the different features available is shown below:
     #include "api/debug/dprint.h"  // required in all kernels using DPRINT
 
     void kernel_main() {
-        // Direct printing is supported for const char*/char/uint32_t/float
+        // Supported scalar types: bool (prints 0/1), char, all fixed-width integer types
+        // (uint8_t–uint64_t, int8_t–int64_t), float, and const char*.
         DPRINT << "Test string" << 'a' << 5 << 0.123456f << ENDL();
+        // bool prints as 0 or 1
+        bool flag = true;
+        DPRINT << flag << ENDL();  // prints: 1
         // BF16 type printing is supported via a macro
         uint16_t my_bf16_val = 0x3dfb; // Equivalent to 0.122559
         DPRINT << BF16(my_bf16_val) << ENDL();

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_eth_cores.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_eth_cores.cpp
@@ -35,8 +35,9 @@ const std::string golden_output =
     R"(Test Debug Print: ERISC
 Basic Types:
 101-1.618@0.122559
-e5551234569123456789
+1015551234569123456789
 -17-343-44444-5123456789
+10
 Pointer:
 123
 456

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_all_harts.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_all_harts.cpp
@@ -37,8 +37,9 @@ const std::vector<std::string> golden_output = {
     R"(Test Debug Print: Data0
 Basic Types:
 101-1.618@0.122559
-e5551234569123456789
+1015551234569123456789
 -17-343-44444-5123456789
+10
 Pointer:
 123
 456
@@ -67,8 +68,9 @@ Tried printing CBIndex::c_1: Unsupported data format (Bfp2_b)
     R"(Test Debug Print: Data1
 Basic Types:
 101-1.618@0.122559
-e5551234569123456789
+1015551234569123456789
 -17-343-44444-5123456789
+10
 Pointer:
 123
 456
@@ -97,8 +99,9 @@ Tried printing CBIndex::c_1: Unsupported data format (Bfp2_b)
     R"(Test Debug Print: Unpack
 Basic Types:
 101-1.618@0.122559
-e5551234569123456789
+1015551234569123456789
 -17-343-44444-5123456789
+10
 Pointer:
 123
 456
@@ -127,8 +130,9 @@ Tried printing CBIndex::c_1: Unsupported data format (Bfp2_b)
     R"(Test Debug Print: Math
 Basic Types:
 101-1.618@0.122559
-e5551234569123456789
+1015551234569123456789
 -17-343-44444-5123456789
+10
 Pointer:
 123
 456
@@ -150,8 +154,9 @@ Warning: MATH core does not support TileSlice printing, omitting print...
     R"(Test Debug Print: Pack
 Basic Types:
 101-1.618@0.122559
-e5551234569123456789
+1015551234569123456789
 -17-343-44444-5123456789
+10
 Pointer:
 123
 456

--- a/tt_metal/hw/inc/api/debug/dprint.h
+++ b/tt_metal/hw/inc/api/debug/dprint.h
@@ -468,6 +468,11 @@ template DebugPrinter operator<< <BF16>(DebugPrinter, BF16 val);
 template DebugPrinter operator<< <F32>(DebugPrinter, F32 val);
 template DebugPrinter operator<< <U32>(DebugPrinter, U32 val);
 
+// bool has no DebugPrintTypeToId specialization; cast to uint8_t (0 or 1) and reuse that path.
+inline DebugPrinter operator<<(DebugPrinter dp, bool val) {
+    return dp << static_cast<uint8_t>(val);
+}
+
 // This allows printing of any (non char) pointer types as uint32_t
 template <typename T, typename = std::enable_if_t<!std::is_same_v<std::remove_cv_t<T>, char>>>
 DebugPrinter operator<<(DebugPrinter dp, T* val) {

--- a/tt_metal/hw/inc/internal/debug/dprint_test_common.h
+++ b/tt_metal/hw/inc/internal/debug/dprint_test_common.h
@@ -16,6 +16,8 @@ inline void print_test_data() {
     int32_t my_int32 = -44444;
     int64_t my_int64 = -5123456789;
     float my_float = 3.14159f;
+    bool my_bool_true = true;
+    bool my_bool_false = false;
     int* my_int_ptr = reinterpret_cast<int*>(123);
     float* my_float_ptr = reinterpret_cast<float*>(456);
     uint16_t* my_uint16_ptr = reinterpret_cast<uint16_t*>(789);
@@ -23,6 +25,7 @@ inline void print_test_data() {
     DPRINT << "Basic Types:\n" << 101 << -1.6180034f << '@' << BF16(0x3dfb) << ENDL();
     DPRINT << my_uint8 << my_uint16 << my_uint32 << my_uint64 << ENDL();
     DPRINT << my_int8 << my_int16 << my_int32 << my_int64 << ENDL();
+    DPRINT << my_bool_true << my_bool_false << ENDL();
     DPRINT << "Pointer:\n" << my_int_ptr << "\n" << my_float_ptr << "\n" << my_uint16_ptr << ENDL();
     DPRINT << "SETPRECISION/FIXED/DEFAULTFLOAT:\n";
     DPRINT << SETPRECISION(5) << my_float << ENDL();

--- a/tt_metal/impl/debug/dprint_parser.cpp
+++ b/tt_metal/impl/debug/dprint_parser.cpp
@@ -369,7 +369,7 @@ DPrintParser::ParseResult DPrintParser::parse(const uint8_t* data, size_t len) {
                 memcpy(&value, ptr, sizeof(uint8_t));
                 intermediate_stream_ << static_cast<uint32_t>(value);  // uint8_t is unsigned char; widen to print as number
                 AssertSize(sz, 1);
-            } break; 
+            } break;
             case DPrintUINT16: {
                 uint16_t value;
                 memcpy(&value, ptr, sizeof(uint16_t));

--- a/tt_metal/impl/debug/dprint_parser.cpp
+++ b/tt_metal/impl/debug/dprint_parser.cpp
@@ -364,11 +364,12 @@ DPrintParser::ParseResult DPrintParser::parse(const uint8_t* data, size_t len) {
                 intermediate_stream_ << std::dec;
                 AssertSize(sz, 1);
                 break;
-            case DPrintUINT8:
-                // iostream default uint8_t printing is as char, not an int
-                intermediate_stream_ << *reinterpret_cast<const uint8_t*>(ptr);
+            case DPrintUINT8: {
+                uint8_t value;
+                memcpy(&value, ptr, sizeof(uint8_t));
+                intermediate_stream_ << static_cast<uint32_t>(value);  // uint8_t is unsigned char; widen to print as number
                 AssertSize(sz, 1);
-                break;
+            } break; 
             case DPrintUINT16: {
                 uint16_t value;
                 memcpy(&value, ptr, sizeof(uint16_t));


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/39411

## Problem description
- `DPRINT << bool_val` failed to compile — no `operator<<` overload or `DebugPrintTypeToId` specialization existed for `bool`.
- `DPrintUINT8` in the parser streamed raw `uint8_t` (an alias for `unsigned char`) directly to `iostream`, causing both `uint8_t` and `bool` values to print as characters rather than numbers.

## What's changed
- Added a non-template `operator<<(DebugPrinter, bool)` to `dprint.h` that casts to `uint8_t` and delegates to the existing overload; updated `dprint_parser.cpp` to widen `uint8_t` to `uint32_t` before streaming so numeric values print correctly.
- Updated `dprint_test_common.h` to exercise `bool` printing, fixed all affected golden outputs in `test_print_all_harts.cpp` and `test_eth_cores.cpp`, and updated `kernel_print.rst` to document the full set of supported scalar types including `bool`.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=jpanasiuk/bool_dprint)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:jpanasiuk/bool_dprint)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jpanasiuk/bool_dprint)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jpanasiuk/bool_dprint)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jpanasiuk/bool_dprint)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jpanasiuk/bool_dprint)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jpanasiuk/bool_dprint)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jpanasiuk/bool_dprint)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jpanasiuk/bool_dprint)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jpanasiuk/bool_dprint)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jpanasiuk/bool_dprint)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jpanasiuk/bool_dprint)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
