### PR TITLE
#33587: Add row_column mixed bcast support for ternary

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/eltwise/test_ternary_bcast.py
+++ b/tests/ttnn/nightly/unit_tests/operations/eltwise/test_ternary_bcast.py
@@ -6,9 +6,7 @@ import torch
 import ttnn
 import pytest
 
-
-def torch_equal_nan(a, b):
-    return torch.all((a == b) | (torch.isnan(a) & torch.isnan(b))).item()
+from tests.ttnn.utils_for_testing import assert_with_ulp
 
 
 @pytest.mark.parametrize(
@@ -30,18 +28,18 @@ def torch_equal_nan(a, b):
 )
 def test_ttnn_where_row_col_mixed_bcast(c_shape, t_shape, f_shape, device):
     torch.manual_seed(0)
-    C = torch.randint(0, 2, c_shape, dtype=torch.float32)
-    T = torch.randn(t_shape, dtype=torch.float32)
-    F = torch.ones(f_shape, dtype=torch.float32) * 10
+    C = torch.randint(0, 2, c_shape).to(torch.bfloat16)
+    T = torch.randn(t_shape, dtype=torch.bfloat16)
+    F = torch.ones(f_shape, dtype=torch.bfloat16) * 10
     golden = torch.where(C.bool(), T, F)
 
-    ttnn_C = ttnn.from_torch(C, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
-    ttnn_T = ttnn.from_torch(T, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
-    ttnn_F = ttnn.from_torch(F, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn_C = ttnn.from_torch(C, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn_T = ttnn.from_torch(T, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn_F = ttnn.from_torch(F, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
     ttnn_result = ttnn.where(ttnn_C, ttnn_T, ttnn_F)
     result = ttnn.to_torch(ttnn_result)
 
-    assert torch_equal_nan(result, golden)
+    assert torch.equal(result, golden)
 
 
 @pytest.mark.parametrize(
@@ -53,17 +51,17 @@ def test_ttnn_where_row_col_mixed_bcast(c_shape, t_shape, f_shape, device):
 )
 def test_ttnn_where_row_col_mixed_bcast_tts(c_shape, t_shape, device):
     torch.manual_seed(0)
-    C = torch.randint(0, 2, c_shape, dtype=torch.float32)
-    T = torch.randn(t_shape, dtype=torch.float32)
+    C = torch.randint(0, 2, c_shape).to(torch.bfloat16)
+    T = torch.randn(t_shape, dtype=torch.bfloat16)
     F = 10.0
     golden = torch.where(C.bool(), T, F)
 
-    ttnn_C = ttnn.from_torch(C, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
-    ttnn_T = ttnn.from_torch(T, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn_C = ttnn.from_torch(C, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn_T = ttnn.from_torch(T, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
     ttnn_result = ttnn.where(ttnn_C, ttnn_T, F)
     result = ttnn.to_torch(ttnn_result)
 
-    assert torch_equal_nan(result, golden)
+    assert torch.equal(result, golden)
 
 
 @pytest.mark.parametrize(
@@ -75,14 +73,122 @@ def test_ttnn_where_row_col_mixed_bcast_tts(c_shape, t_shape, device):
 )
 def test_ttnn_where_row_col_mixed_bcast_tst(c_shape, f_shape, device):
     torch.manual_seed(0)
-    C = torch.randint(0, 2, c_shape, dtype=torch.float32)
+    C = torch.randint(0, 2, c_shape).to(torch.bfloat16)
     T = 10.0
-    F = torch.randn(f_shape, dtype=torch.float32)
+    F = torch.randn(f_shape, dtype=torch.bfloat16)
     golden = torch.where(C.bool(), T, F)
 
-    ttnn_C = ttnn.from_torch(C, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
-    ttnn_F = ttnn.from_torch(F, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn_C = ttnn.from_torch(C, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn_F = ttnn.from_torch(F, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
     ttnn_result = ttnn.where(ttnn_C, T, ttnn_F)
     result = ttnn.to_torch(ttnn_result)
 
-    assert torch_equal_nan(result, golden)
+    assert torch.equal(result, golden)
+
+
+@pytest.mark.parametrize(
+    "a_shape, b_shape, c_shape",
+    [
+        ((8, 4, 768), (8, 4, 768), (8, 4, 768)),  # full, full, full
+        ((8, 4, 1), (8, 4, 768), (8, 4, 768)),  # acol, bfull, cfull
+        ((8, 1, 768), (8, 4, 768), (8, 4, 768)),  # arow, bfull, cfull
+        ((8, 4, 768), (8, 4, 1), (8, 1, 768)),  # afull, bcol, crow
+        ((8, 4, 768), (8, 1, 768), (8, 4, 1)),  # afull, brow, ccol
+        ((8, 4, 1), (8, 1, 768), (8, 4, 768)),  # acol, brow, cfull
+        ((8, 1, 768), (8, 4, 1), (8, 4, 768)),  # arow, bcol, cfull
+        ((8, 1, 768), (8, 4, 768), (8, 4, 1)),  # arow, bfull, ccol
+        ((8, 4, 1), (8, 4, 768), (8, 1, 768)),  # acol, bfull, crow
+        ((1, 1, 1), (8, 4, 1), (8, 1, 768)),  # ascalar, bcol, crow
+        ((1, 1, 1), (8, 1, 768), (8, 4, 1)),  # ascalar, brow, ccol
+        ((8, 1, 768), (1, 1, 1), (8, 4, 1)),  # arow, bscalar, ccol
+        ((8, 4, 1), (1, 1, 1), (8, 1, 768)),  # acol, bscalar, crow
+    ],
+)
+@pytest.mark.parametrize("value", [1.5, 0.5, -0.25])
+@pytest.mark.parametrize("ttnn_op", [ttnn.addcmul, ttnn.addcdiv])
+def test_ttnn_addc_ops_row_col_mixed_bcast(a_shape, b_shape, c_shape, value, ttnn_op, device):
+    torch.manual_seed(0)
+    in_data1 = torch.empty(a_shape, dtype=torch.bfloat16).uniform_(-100, 100)
+    in_data2 = torch.empty(b_shape, dtype=torch.bfloat16).uniform_(-100, 100)
+    in_data3 = torch.empty(c_shape, dtype=torch.bfloat16).uniform_(-100, 100)
+
+    golden_fn = ttnn.get_golden_function(ttnn_op)
+    golden = golden_fn(in_data1, in_data2, in_data3, value=value)
+
+    input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor2 = ttnn.from_torch(in_data2, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor3 = ttnn.from_torch(in_data3, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn_result = ttnn_op(input_tensor1, input_tensor2, input_tensor3, value=value)
+    result = ttnn.to_torch(ttnn_result)
+
+    # For addcdiv: if denominator (in_data3) is zero, golden is nan but ttnn may return inf; normalize to nan
+    if ttnn_op is ttnn.addcdiv:
+        zero_mask = in_data3 == 0
+        golden_nan_mask = torch.isnan(golden)
+        result_inf_mask = torch.isinf(result)
+        normalize_mask = zero_mask & golden_nan_mask & result_inf_mask
+        if normalize_mask.any():
+            result = torch.where(
+                normalize_mask,
+                torch.tensor(float("nan"), dtype=result.dtype, device=result.device),
+                result,
+            )
+
+    assert_with_ulp(golden, result, ulp_threshold=10, allow_nonfinite=True)
+
+
+@pytest.mark.parametrize(
+    "c_shape, t_shape",
+    [
+        ((8, 4, 1), (8, 1, 768)),  # Ccol, Trow
+        ((8, 1, 768), (8, 4, 1)),  # Crow, Tcol
+    ],
+)
+@pytest.mark.parametrize("weight", [0.0, 0.25, 0.5, 0.75, 1.0])
+def test_ttnn_lerp_tts_scalar_weight(c_shape, t_shape, weight, device):
+    torch.manual_seed(0)
+    in_data1 = torch.empty(c_shape, dtype=torch.bfloat16).uniform_(-100, 100)
+    in_data2 = torch.empty(t_shape, dtype=torch.bfloat16).uniform_(-100, 100)
+    golden = torch.lerp(in_data1, in_data2, weight)
+
+    input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor2 = ttnn.from_torch(in_data2, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn_result = ttnn.lerp(input_tensor1, input_tensor2, weight)
+    result = ttnn.to_torch(ttnn_result)
+
+    assert_with_ulp(golden, result, ulp_threshold=10)
+
+
+@pytest.mark.parametrize(
+    "input_shape, end_shape, weight_shape",
+    [
+        ((8, 4, 768), (8, 4, 768), (8, 4, 768)),  # full, full, full
+        ((8, 4, 1), (8, 4, 768), (8, 4, 768)),  # acol, bfull, cfull
+        ((8, 1, 768), (8, 4, 768), (8, 4, 768)),  # arow, bfull, cfull
+        ((8, 4, 768), (8, 4, 1), (8, 1, 768)),  # afull, bcol, crow
+        ((8, 4, 768), (8, 1, 768), (8, 4, 1)),  # afull, brow, ccol
+        ((8, 4, 1), (8, 1, 768), (8, 4, 768)),  # acol, brow, cfull
+        ((8, 1, 768), (8, 4, 1), (8, 4, 768)),  # arow, bcol, cfull
+        ((8, 1, 768), (8, 4, 768), (8, 4, 1)),  # arow, bfull, ccol
+        ((8, 4, 1), (8, 4, 768), (8, 1, 768)),  # acol, bfull, crow
+        ((1, 1, 1), (8, 4, 1), (8, 1, 768)),  # ascalar, bcol, crow
+        ((1, 1, 1), (8, 1, 768), (8, 4, 1)),  # ascalar, brow, ccol
+        ((8, 1, 768), (1, 1, 1), (8, 4, 1)),  # arow, bscalar, ccol
+        ((8, 4, 1), (1, 1, 1), (8, 1, 768)),  # acol, bscalar, crow
+    ],
+)
+def test_ttnn_lerp_ttt_row_col_mixed_bcast(input_shape, end_shape, weight_shape, device):
+    torch.manual_seed(0)
+    in_data1 = torch.empty(input_shape, dtype=torch.bfloat16).uniform_(-100, 100)
+    in_data2 = torch.empty(end_shape, dtype=torch.bfloat16).uniform_(-100, 100)
+    # Weight in [0, 1] for lerp
+    in_data3 = torch.empty(weight_shape, dtype=torch.bfloat16).uniform_(0, 1)
+    golden = torch.lerp(in_data1, in_data2, in_data3)
+
+    input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor2 = ttnn.from_torch(in_data2, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor3 = ttnn.from_torch(in_data3, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn_result = ttnn.lerp(input_tensor1, input_tensor2, input_tensor3)
+    result = ttnn.to_torch(ttnn_result)
+
+    assert_with_ulp(golden, result, ulp_threshold=10)

--- a/tests/ttnn/nightly/unit_tests/operations/eltwise/test_ternary_bcast.py
+++ b/tests/ttnn/nightly/unit_tests/operations/eltwise/test_ternary_bcast.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import ttnn
+import pytest
+
+
+def torch_equal_nan(a, b):
+    return torch.all((a == b) | (torch.isnan(a) & torch.isnan(b))).item()
+
+
+@pytest.mark.parametrize(
+    "c_shape, t_shape, f_shape",
+    [
+        ((8, 4, 1), (8, 4, 768), (1, 1, 1)),  # Ccol, Tfull, Fscalar
+        ((8, 1, 768), (8, 4, 768), (1, 1, 1)),  # Crow, Tfull, Fscalar
+        ((8, 4, 768), (8, 4, 1), (8, 1, 768)),  # Cfull, Tcol, Frow
+        ((8, 4, 768), (8, 1, 768), (8, 4, 1)),  # Cfull, Trow, Fcol
+        ((8, 4, 1), (8, 1, 768), (8, 4, 768)),  # Ccol, Trow, Ffull
+        ((8, 1, 768), (8, 4, 1), (8, 4, 768)),  # Crow, Tcol, Ffull
+        ((8, 1, 768), (8, 4, 768), (8, 4, 1)),  # Crow, Tfull, Fcol
+        ((8, 4, 1), (8, 4, 768), (8, 1, 768)),  # Ccol, Tfull, Frow
+        ((1, 1, 1), (8, 4, 1), (8, 1, 768)),  # Cscalar, Tcol, Frow
+        ((1, 1, 1), (8, 1, 768), (8, 4, 1)),  # Cscalar, Trow, Fcol
+        ((8, 1, 768), (1, 1, 1), (8, 4, 1)),  # Crow, Tscalar, Fcol
+        ((8, 4, 1), (1, 1, 1), (8, 1, 768)),  # Ccol, Tscalar, Frow
+    ],
+)
+def test_ttnn_where_row_col_mixed_bcast(c_shape, t_shape, f_shape, device):
+    torch.manual_seed(0)
+    C = torch.randint(0, 2, c_shape, dtype=torch.float32)
+    T = torch.randn(t_shape, dtype=torch.float32)
+    F = torch.ones(f_shape, dtype=torch.float32) * 10
+    golden = torch.where(C.bool(), T, F)
+
+    ttnn_C = ttnn.from_torch(C, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn_T = ttnn.from_torch(T, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn_F = ttnn.from_torch(F, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn_result = ttnn.where(ttnn_C, ttnn_T, ttnn_F)
+    result = ttnn.to_torch(ttnn_result)
+
+    assert torch_equal_nan(result, golden)
+
+
+@pytest.mark.parametrize(
+    "c_shape, t_shape",
+    [
+        ((8, 4, 1), (8, 1, 768)),  # Ccol, Trow
+        ((8, 1, 768), (8, 4, 1)),  # Crow, Tcol
+    ],
+)
+def test_ttnn_where_row_col_mixed_bcast_tts(c_shape, t_shape, device):
+    torch.manual_seed(0)
+    C = torch.randint(0, 2, c_shape, dtype=torch.float32)
+    T = torch.randn(t_shape, dtype=torch.float32)
+    F = 10.0
+    golden = torch.where(C.bool(), T, F)
+
+    ttnn_C = ttnn.from_torch(C, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn_T = ttnn.from_torch(T, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn_result = ttnn.where(ttnn_C, ttnn_T, F)
+    result = ttnn.to_torch(ttnn_result)
+
+    assert torch_equal_nan(result, golden)
+
+
+@pytest.mark.parametrize(
+    "c_shape, f_shape",
+    [
+        ((8, 4, 1), (8, 1, 768)),  # Ccol, Frow
+        ((8, 1, 768), (8, 4, 1)),  # Crow, Fcol
+    ],
+)
+def test_ttnn_where_row_col_mixed_bcast_tst(c_shape, f_shape, device):
+    torch.manual_seed(0)
+    C = torch.randint(0, 2, c_shape, dtype=torch.float32)
+    T = 10.0
+    F = torch.randn(f_shape, dtype=torch.float32)
+    golden = torch.where(C.bool(), T, F)
+
+    ttnn_C = ttnn.from_torch(C, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn_F = ttnn.from_torch(F, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn_result = ttnn.where(ttnn_C, T, ttnn_F)
+    result = ttnn.to_torch(ttnn_result)
+
+    assert torch_equal_nan(result, golden)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_where.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_where.py
@@ -634,10 +634,13 @@ def test_addcdiv_edgcase_fp32(device):
     assert torch_equal_nan(output_tensor1, golden_tensor)
 
 
-def test_ttnn_where_forge_nan(device):
-    C = torch.ones(1, 4, 1, dtype=torch.float32)
-    T = torch.randn(1, 4, 768, dtype=torch.float32)
-    F = torch.ones(1, 4, 768, dtype=torch.float32) * float("nan")
+@pytest.mark.parametrize(
+    "a_shape, b_shape, c_shape", [((1, 4, 1), (1, 1, 768), (1, 4, 768)), ((1, 4, 768), (1, 4, 768), (1, 4, 768))]
+)
+def test_ttnn_where_forge_nan(device, a_shape, b_shape, c_shape):
+    C = torch.ones(a_shape, dtype=torch.float32)
+    T = torch.randn(b_shape, dtype=torch.float32)
+    F = torch.ones(c_shape, dtype=torch.float32) * float("nan")
     golden = torch.where(C != 0, T, F)
 
     ttnn_C = ttnn.from_torch(C, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/common/ternary_op_types.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/common/ternary_op_types.hpp
@@ -39,6 +39,7 @@ enum class TernaryBroadcastType {
     COL_BCAST,       // bcast for W-dim and outer dims -5, -4, -3.
     ROW_BCAST,       // Row broadcast for H-dim
     SCALAR_BCAST,    // Scalar broadcast for TTT: Either A or B or C can be (1,1)
+    ROW_COL_BCAST,   // Mixed row+col broadcast: some tensors broadcast H, others broadcast W
     SCALAR_A_BCAST,  // A = (1,1) B = (H,W )
     SCALAR_B_BCAST,  // A = (H,W) B = (1,1)
     INVALID_BCAST,   // All other unsupported bcast cases go here for now

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_row_col_bcast_ttt.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_row_col_bcast_ttt.cpp
@@ -1,0 +1,299 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/dataflow/dataflow_api.h"
+#include "ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
+
+void kernel_main() {
+    const uint32_t src0_addr = get_arg_val<uint32_t>(0);
+    const uint32_t src1_addr = get_arg_val<uint32_t>(1);
+    const uint32_t src2_addr = get_arg_val<uint32_t>(2);
+    const uint32_t num_tiles = get_arg_val<uint32_t>(3);
+    const uint32_t start_id = get_arg_val<uint32_t>(4);
+
+    const uint32_t nD_stride = get_arg_val<uint32_t>(5);
+    const uint32_t d_stride = get_arg_val<uint32_t>(6);
+    const uint32_t n_stride = get_arg_val<uint32_t>(7);
+    const uint32_t c_stride = get_arg_val<uint32_t>(8);
+    const uint32_t D = get_arg_val<uint32_t>(9);
+    const uint32_t N = get_arg_val<uint32_t>(10);
+    const uint32_t C = get_arg_val<uint32_t>(11);
+    const uint32_t Ht = get_arg_val<uint32_t>(12);
+    const uint32_t Wt = get_arg_val<uint32_t>(13);
+    const uint32_t cND = get_arg_val<uint32_t>(14);
+
+    const uint32_t nD_stride_b = get_arg_val<uint32_t>(15);
+    const uint32_t d_stride_b = get_arg_val<uint32_t>(16);
+    const uint32_t n_stride_b = get_arg_val<uint32_t>(17);
+    const uint32_t c_stride_b = get_arg_val<uint32_t>(18);
+    const uint32_t src_num_tiles_b = get_arg_val<uint32_t>(19);
+
+    const uint32_t nD_stride_c = get_arg_val<uint32_t>(20);
+    const uint32_t d_stride_c = get_arg_val<uint32_t>(21);
+    const uint32_t n_stride_c = get_arg_val<uint32_t>(22);
+    const uint32_t c_stride_c = get_arg_val<uint32_t>(23);
+    const uint32_t src_num_tiles_c = get_arg_val<uint32_t>(24);
+
+    const uint32_t dst_shard_width = get_arg_val<uint32_t>(25);
+    const uint32_t src_num_tiles = get_arg_val<uint32_t>(26);
+
+    const uint32_t start_tile_id = start_id;
+    const uint32_t dst_num_tiles = num_tiles;
+
+    constexpr auto predicate_cb = get_compile_time_arg_val(0);
+    constexpr auto true_cb = get_compile_time_arg_val(1);
+    constexpr auto false_cb = get_compile_time_arg_val(2);
+
+    constexpr auto src0_args = TensorAccessorArgs<3, 0>();
+    constexpr auto src1_args =
+        TensorAccessorArgs<src0_args.next_compile_time_args_offset(), src0_args.next_common_runtime_args_offset()>();
+    constexpr auto src2_args =
+        TensorAccessorArgs<src1_args.next_compile_time_args_offset(), src1_args.next_common_runtime_args_offset()>();
+
+#if SRC_SHARDED_A
+    cb_reserve_back(predicate_cb, src_num_tiles);
+    cb_push_back(predicate_cb, src_num_tiles);
+#else
+    const uint32_t src0_tile_bytes = get_tile_size(predicate_cb);
+    const auto s0 = TensorAccessor(src0_args, src0_addr, src0_tile_bytes);
+#endif
+#if SRC_SHARDED_B
+    cb_reserve_back(true_cb, src_num_tiles_b);
+    cb_push_back(true_cb, src_num_tiles_b);
+#else
+    const uint32_t src1_tile_bytes = get_tile_size(true_cb);
+    const auto s1 = TensorAccessor(src1_args, src1_addr, src1_tile_bytes);
+#endif
+#if SRC_SHARDED_C
+    cb_reserve_back(false_cb, src_num_tiles_c);
+    cb_push_back(false_cb, src_num_tiles_c);
+#else
+    const uint32_t src2_tile_bytes = get_tile_size(false_cb);
+    const auto s2 = TensorAccessor(src2_args, src2_addr, src2_tile_bytes);
+#endif
+
+    constexpr uint32_t onetile = 1;
+    constexpr bool has_sharding = get_compile_time_arg_val(src2_args.next_compile_time_args_offset()) == 1;
+    const uint32_t HtWt = Ht * Wt;
+
+    const uint32_t tiles_per_n = C * HtWt;
+    const uint32_t tiles_per_d = N * tiles_per_n;
+    const uint32_t tiles_per_nd = D * tiles_per_d;
+    const uint32_t offset_nd = start_tile_id % tiles_per_nd;
+    const uint32_t offset_d = offset_nd % tiles_per_d;
+    const uint32_t offset_n = offset_d % tiles_per_n;
+    const uint32_t offset_c = offset_n % HtWt;
+    uint32_t start_nd = start_tile_id / tiles_per_nd;
+    uint32_t start_d = offset_nd / tiles_per_d;
+    uint32_t start_n = offset_d / tiles_per_n;
+    uint32_t start_c = offset_n / HtWt;
+    uint32_t start_th = offset_c / Wt;
+    uint32_t start_tw = offset_c % Wt;
+    uint32_t end_tw = has_sharding ? (start_tw + dst_shard_width) : Wt;
+
+    // Predicate offset: col/scalar bcast tensors skip start_th*Wt, row/full include it
+    uint32_t tile_offset = start_nd * nD_stride + start_d * d_stride + start_n * n_stride + start_c * c_stride;
+#if !SRC_BCAST_A && !SRC_ROW_BCAST_A
+    tile_offset += start_th * Wt;
+#endif
+    uint32_t next_c_shift = c_stride - HtWt;
+    uint32_t next_n_shift = n_stride - c_stride * C;
+    uint32_t next_d_shift = d_stride - n_stride * N;
+    uint32_t next_nd_shift = nD_stride - d_stride * D;
+
+    // True tensor offset
+    uint32_t tile_offset_b =
+        start_nd * nD_stride_b + start_d * d_stride_b + start_n * n_stride_b + start_c * c_stride_b;
+#if !SRC_BCAST_B && !SRC_ROW_BCAST_B
+    tile_offset_b += start_th * Wt;
+#endif
+    uint32_t next_c_shift_b = c_stride_b - HtWt;
+    uint32_t next_n_shift_b = n_stride_b - c_stride_b * C;
+    uint32_t next_d_shift_b = d_stride_b - n_stride_b * N;
+    uint32_t next_nd_shift_b = nD_stride_b - d_stride_b * D;
+
+    // False tensor offset
+    uint32_t tile_offset_c =
+        start_nd * nD_stride_c + start_d * d_stride_c + start_n * n_stride_c + start_c * c_stride_c;
+#if !SRC_BCAST_C && !SRC_ROW_BCAST_C
+    tile_offset_c += start_th * Wt;
+#endif
+    uint32_t next_c_shift_c = c_stride_c - HtWt;
+    uint32_t next_n_shift_c = n_stride_c - c_stride_c * C;
+    uint32_t next_d_shift_c = d_stride_c - n_stride_c * N;
+    uint32_t next_nd_shift_c = nD_stride_c - d_stride_c * D;
+
+    uint32_t num_tiles_read = 0;
+    for (uint32_t nd = start_nd; nd < cND && num_tiles_read < dst_num_tiles; ++nd, start_d = 0) {
+        for (uint32_t d = start_d; d < D && num_tiles_read < dst_num_tiles; ++d, start_n = 0) {
+            for (uint32_t n = start_n; n < N && num_tiles_read < dst_num_tiles; ++n, start_c = 0) {
+                for (uint32_t c = start_c; c < C && num_tiles_read < dst_num_tiles; ++c, start_th = 0) {
+                    for (uint32_t th = start_th; th < Ht && num_tiles_read < dst_num_tiles; ++th) {
+                        // --- Col broadcast / scalar tensors: push one tile per row ---
+#if SRC_BCAST_A
+                        cb_reserve_back(predicate_cb, onetile);
+#if !SRC_SHARDED_A
+                        uint32_t l1_addr_a = get_write_ptr(predicate_cb);
+#if SRC_SCALAR_A
+                        noc_async_read_page(tile_offset, s0, l1_addr_a);
+#else
+                        noc_async_read_page(tile_offset + th, s0, l1_addr_a);
+#endif
+                        noc_async_read_barrier();
+#endif
+#if SRC_SCALAR_A
+                        FILL_TILE_WITH_FIRST_ELEMENT(predicate_cb);
+#else
+                        FILL_TILE_WITH_FIRST_COLUMN(predicate_cb);
+#endif
+                        cb_push_back(predicate_cb, onetile);
+#endif
+
+#if SRC_BCAST_B
+                        cb_reserve_back(true_cb, onetile);
+#if !SRC_SHARDED_B
+                        uint32_t l1_addr_b = get_write_ptr(true_cb);
+#if SRC_SCALAR_B
+                        noc_async_read_page(tile_offset_b, s1, l1_addr_b);
+#else
+                        noc_async_read_page(tile_offset_b + th, s1, l1_addr_b);
+#endif
+                        noc_async_read_barrier();
+#endif
+#if SRC_SCALAR_B
+                        FILL_TILE_WITH_FIRST_ELEMENT_B(true_cb);
+#else
+                        FILL_TILE_WITH_FIRST_COLUMN_B(true_cb);
+#endif
+                        cb_push_back(true_cb, onetile);
+#endif
+
+#if SRC_BCAST_C
+                        cb_reserve_back(false_cb, onetile);
+#if !SRC_SHARDED_C
+                        uint32_t l1_addr_c = get_write_ptr(false_cb);
+#if SRC_SCALAR_C
+                        noc_async_read_page(tile_offset_c, s2, l1_addr_c);
+#else
+                        noc_async_read_page(tile_offset_c + th, s2, l1_addr_c);
+#endif
+                        noc_async_read_barrier();
+#endif
+#if SRC_SCALAR_C
+                        FILL_TILE_WITH_FIRST_ELEMENT_C(false_cb);
+#else
+                        FILL_TILE_WITH_FIRST_COLUMN_C(false_cb);
+#endif
+                        cb_push_back(false_cb, onetile);
+#endif
+                        // --- Inner loop: row broadcast and full tensors ---
+                        for (uint32_t tw = start_tw; tw < end_tw && num_tiles_read < dst_num_tiles;
+                             ++tw, ++num_tiles_read) {
+#if !SRC_BCAST_A
+                            cb_reserve_back(predicate_cb, onetile);
+#if !SRC_SHARDED_A
+                            uint32_t l1_addr_a_inner = get_write_ptr(predicate_cb);
+                            noc_async_read_page(tile_offset + tw, s0, l1_addr_a_inner);
+                            noc_async_read_barrier();
+#endif
+#if SRC_ROW_BCAST_A
+                            FILL_TILE_WITH_FIRST_ROW(predicate_cb);
+#endif
+                            cb_push_back(predicate_cb, onetile);
+#endif
+
+#if !SRC_BCAST_B
+                            cb_reserve_back(true_cb, onetile);
+#if !SRC_SHARDED_B
+                            uint32_t l1_addr_b_inner = get_write_ptr(true_cb);
+                            noc_async_read_page(tile_offset_b + tw, s1, l1_addr_b_inner);
+                            noc_async_read_barrier();
+#endif
+#if SRC_ROW_BCAST_B
+                            FILL_TILE_WITH_FIRST_ROW_B(true_cb);
+#endif
+                            cb_push_back(true_cb, onetile);
+#endif
+
+#if !SRC_BCAST_C
+                            cb_reserve_back(false_cb, onetile);
+#if !SRC_SHARDED_C
+                            uint32_t l1_addr_c_inner = get_write_ptr(false_cb);
+                            noc_async_read_page(tile_offset_c + tw, s2, l1_addr_c_inner);
+                            noc_async_read_barrier();
+#endif
+#if SRC_ROW_BCAST_C
+                            FILL_TILE_WITH_FIRST_ROW_C(false_cb);
+#endif
+                            cb_push_back(false_cb, onetile);
+#endif
+                        }
+                        if constexpr (!has_sharding) {
+                            start_tw = 0;
+                        }
+                        // Advance tile offsets for next row: only full tensors advance by Wt
+#if !SRC_BCAST_A && !SRC_ROW_BCAST_A && !SRC_SHARDED_A
+                        tile_offset += Wt;
+#endif
+#if !SRC_BCAST_B && !SRC_ROW_BCAST_B && !SRC_SHARDED_B
+                        tile_offset_b += Wt;
+#endif
+#if !SRC_BCAST_C && !SRC_ROW_BCAST_C && !SRC_SHARDED_C
+                        tile_offset_c += Wt;
+#endif
+                    }
+                    // After all rows in a C block: advance to next C block
+#if !SRC_SHARDED_A
+#if SRC_BCAST_A || SRC_ROW_BCAST_A
+                    tile_offset += c_stride;
+#else
+                    tile_offset += next_c_shift;
+#endif
+#endif
+#if !SRC_SHARDED_B
+#if SRC_BCAST_B || SRC_ROW_BCAST_B
+                    tile_offset_b += c_stride_b;
+#else
+                    tile_offset_b += next_c_shift_b;
+#endif
+#endif
+#if !SRC_SHARDED_C
+#if SRC_BCAST_C || SRC_ROW_BCAST_C
+                    tile_offset_c += c_stride_c;
+#else
+                    tile_offset_c += next_c_shift_c;
+#endif
+#endif
+                }
+#if !SRC_SHARDED_A
+                tile_offset += next_n_shift;
+#endif
+#if !SRC_SHARDED_B
+                tile_offset_b += next_n_shift_b;
+#endif
+#if !SRC_SHARDED_C
+                tile_offset_c += next_n_shift_c;
+#endif
+            }
+#if !SRC_SHARDED_A
+            tile_offset += next_d_shift;
+#endif
+#if !SRC_SHARDED_B
+            tile_offset_b += next_d_shift_b;
+#endif
+#if !SRC_SHARDED_C
+            tile_offset_c += next_d_shift_c;
+#endif
+        }
+#if !SRC_SHARDED_A
+        tile_offset += next_nd_shift;
+#endif
+#if !SRC_SHARDED_B
+        tile_offset_b += next_nd_shift_b;
+#endif
+#if !SRC_SHARDED_C
+        tile_offset_c += next_nd_shift_c;
+#endif
+    }
+}

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_row_col_bcast_ttt.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_row_col_bcast_ttt.cpp
@@ -2,15 +2,19 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
 
 void kernel_main() {
-    const uint32_t src0_addr = get_arg_val<uint32_t>(0);
-    const uint32_t src1_addr = get_arg_val<uint32_t>(1);
-    const uint32_t src2_addr = get_arg_val<uint32_t>(2);
-    const uint32_t num_tiles = get_arg_val<uint32_t>(3);
-    const uint32_t start_id = get_arg_val<uint32_t>(4);
+    uint32_t src0_addr = get_arg_val<uint32_t>(0);
+    uint32_t src1_addr = get_arg_val<uint32_t>(1);
+    uint32_t src2_addr = get_arg_val<uint32_t>(2);
+    uint32_t num_tiles = get_arg_val<uint32_t>(3);
+    uint32_t start_id = get_arg_val<uint32_t>(4);
 
     const uint32_t nD_stride = get_arg_val<uint32_t>(5);
     const uint32_t d_stride = get_arg_val<uint32_t>(6);
@@ -51,23 +55,28 @@ void kernel_main() {
     constexpr auto src2_args =
         TensorAccessorArgs<src1_args.next_compile_time_args_offset(), src1_args.next_common_runtime_args_offset()>();
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_pred(predicate_cb);
+    experimental::CircularBuffer cb_true(true_cb);
+    experimental::CircularBuffer cb_false(false_cb);
+
 #if SRC_SHARDED_A
-    cb_reserve_back(predicate_cb, src_num_tiles);
-    cb_push_back(predicate_cb, src_num_tiles);
+    cb_pred.reserve_back(src_num_tiles);
+    cb_pred.push_back(src_num_tiles);
 #else
     const uint32_t src0_tile_bytes = get_tile_size(predicate_cb);
     const auto s0 = TensorAccessor(src0_args, src0_addr, src0_tile_bytes);
 #endif
 #if SRC_SHARDED_B
-    cb_reserve_back(true_cb, src_num_tiles_b);
-    cb_push_back(true_cb, src_num_tiles_b);
+    cb_true.reserve_back(src_num_tiles_b);
+    cb_true.push_back(src_num_tiles_b);
 #else
     const uint32_t src1_tile_bytes = get_tile_size(true_cb);
     const auto s1 = TensorAccessor(src1_args, src1_addr, src1_tile_bytes);
 #endif
 #if SRC_SHARDED_C
-    cb_reserve_back(false_cb, src_num_tiles_c);
-    cb_push_back(false_cb, src_num_tiles_c);
+    cb_false.reserve_back(src_num_tiles_c);
+    cb_false.push_back(src_num_tiles_c);
 #else
     const uint32_t src2_tile_bytes = get_tile_size(false_cb);
     const auto s2 = TensorAccessor(src2_args, src2_addr, src2_tile_bytes);
@@ -132,101 +141,101 @@ void kernel_main() {
                     for (uint32_t th = start_th; th < Ht && num_tiles_read < dst_num_tiles; ++th) {
                         // --- Col broadcast / scalar tensors: push one tile per row ---
 #if SRC_BCAST_A
-                        cb_reserve_back(predicate_cb, onetile);
+                        cb_pred.reserve_back(onetile);
 #if !SRC_SHARDED_A
-                        uint32_t l1_addr_a = get_write_ptr(predicate_cb);
 #if SRC_SCALAR_A
-                        noc_async_read_page(tile_offset, s0, l1_addr_a);
+                        noc.async_read(s0, cb_pred, src0_tile_bytes, {.page_id = tile_offset}, {.offset_bytes = 0});
 #else
-                        noc_async_read_page(tile_offset + th, s0, l1_addr_a);
+                        noc.async_read(
+                            s0, cb_pred, src0_tile_bytes, {.page_id = tile_offset + th}, {.offset_bytes = 0});
 #endif
-                        noc_async_read_barrier();
+                        noc.async_read_barrier();
 #endif
 #if SRC_SCALAR_A
                         FILL_TILE_WITH_FIRST_ELEMENT(predicate_cb);
 #else
                         FILL_TILE_WITH_FIRST_COLUMN(predicate_cb);
 #endif
-                        cb_push_back(predicate_cb, onetile);
+                        cb_pred.push_back(onetile);
 #endif
 
 #if SRC_BCAST_B
-                        cb_reserve_back(true_cb, onetile);
+                        cb_true.reserve_back(onetile);
 #if !SRC_SHARDED_B
-                        uint32_t l1_addr_b = get_write_ptr(true_cb);
 #if SRC_SCALAR_B
-                        noc_async_read_page(tile_offset_b, s1, l1_addr_b);
+                        noc.async_read(s1, cb_true, src1_tile_bytes, {.page_id = tile_offset_b}, {.offset_bytes = 0});
 #else
-                        noc_async_read_page(tile_offset_b + th, s1, l1_addr_b);
+                        noc.async_read(
+                            s1, cb_true, src1_tile_bytes, {.page_id = tile_offset_b + th}, {.offset_bytes = 0});
 #endif
-                        noc_async_read_barrier();
+                        noc.async_read_barrier();
 #endif
 #if SRC_SCALAR_B
                         FILL_TILE_WITH_FIRST_ELEMENT_B(true_cb);
 #else
                         FILL_TILE_WITH_FIRST_COLUMN_B(true_cb);
 #endif
-                        cb_push_back(true_cb, onetile);
+                        cb_true.push_back(onetile);
 #endif
 
 #if SRC_BCAST_C
-                        cb_reserve_back(false_cb, onetile);
+                        cb_false.reserve_back(onetile);
 #if !SRC_SHARDED_C
-                        uint32_t l1_addr_c = get_write_ptr(false_cb);
 #if SRC_SCALAR_C
-                        noc_async_read_page(tile_offset_c, s2, l1_addr_c);
+                        noc.async_read(s2, cb_false, src2_tile_bytes, {.page_id = tile_offset_c}, {.offset_bytes = 0});
 #else
-                        noc_async_read_page(tile_offset_c + th, s2, l1_addr_c);
+                        noc.async_read(
+                            s2, cb_false, src2_tile_bytes, {.page_id = tile_offset_c + th}, {.offset_bytes = 0});
 #endif
-                        noc_async_read_barrier();
+                        noc.async_read_barrier();
 #endif
 #if SRC_SCALAR_C
                         FILL_TILE_WITH_FIRST_ELEMENT_C(false_cb);
 #else
                         FILL_TILE_WITH_FIRST_COLUMN_C(false_cb);
 #endif
-                        cb_push_back(false_cb, onetile);
+                        cb_false.push_back(onetile);
 #endif
                         // --- Inner loop: row broadcast and full tensors ---
                         for (uint32_t tw = start_tw; tw < end_tw && num_tiles_read < dst_num_tiles;
                              ++tw, ++num_tiles_read) {
 #if !SRC_BCAST_A
-                            cb_reserve_back(predicate_cb, onetile);
+                            cb_pred.reserve_back(onetile);
 #if !SRC_SHARDED_A
-                            uint32_t l1_addr_a_inner = get_write_ptr(predicate_cb);
-                            noc_async_read_page(tile_offset + tw, s0, l1_addr_a_inner);
-                            noc_async_read_barrier();
+                            noc.async_read(
+                                s0, cb_pred, src0_tile_bytes, {.page_id = tile_offset + tw}, {.offset_bytes = 0});
+                            noc.async_read_barrier();
 #endif
 #if SRC_ROW_BCAST_A
                             FILL_TILE_WITH_FIRST_ROW(predicate_cb);
 #endif
-                            cb_push_back(predicate_cb, onetile);
+                            cb_pred.push_back(onetile);
 #endif
 
 #if !SRC_BCAST_B
-                            cb_reserve_back(true_cb, onetile);
+                            cb_true.reserve_back(onetile);
 #if !SRC_SHARDED_B
-                            uint32_t l1_addr_b_inner = get_write_ptr(true_cb);
-                            noc_async_read_page(tile_offset_b + tw, s1, l1_addr_b_inner);
-                            noc_async_read_barrier();
+                            noc.async_read(
+                                s1, cb_true, src1_tile_bytes, {.page_id = tile_offset_b + tw}, {.offset_bytes = 0});
+                            noc.async_read_barrier();
 #endif
 #if SRC_ROW_BCAST_B
                             FILL_TILE_WITH_FIRST_ROW_B(true_cb);
 #endif
-                            cb_push_back(true_cb, onetile);
+                            cb_true.push_back(onetile);
 #endif
 
 #if !SRC_BCAST_C
-                            cb_reserve_back(false_cb, onetile);
+                            cb_false.reserve_back(onetile);
 #if !SRC_SHARDED_C
-                            uint32_t l1_addr_c_inner = get_write_ptr(false_cb);
-                            noc_async_read_page(tile_offset_c + tw, s2, l1_addr_c_inner);
-                            noc_async_read_barrier();
+                            noc.async_read(
+                                s2, cb_false, src2_tile_bytes, {.page_id = tile_offset_c + tw}, {.offset_bytes = 0});
+                            noc.async_read_barrier();
 #endif
 #if SRC_ROW_BCAST_C
                             FILL_TILE_WITH_FIRST_ROW_C(false_cb);
 #endif
-                            cb_push_back(false_cb, onetile);
+                            cb_false.push_back(onetile);
 #endif
                         }
                         if constexpr (!has_sharding) {

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tts_tst_reader_row_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tts_tst_reader_row_col_bcast.cpp
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/dataflow/dataflow_api.h"
+#include "ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
+
+void kernel_main() {
+    const uint32_t src0_addr = get_arg_val<uint32_t>(0);
+    const uint32_t src1_addr = get_arg_val<uint32_t>(1);
+    const uint32_t src2_addr = get_arg_val<uint32_t>(2);
+    const uint32_t num_tiles = get_arg_val<uint32_t>(3);
+    const uint32_t start_id = get_arg_val<uint32_t>(4);
+
+    const uint32_t nD_stride = get_arg_val<uint32_t>(5);
+    const uint32_t d_stride = get_arg_val<uint32_t>(6);
+    const uint32_t n_stride = get_arg_val<uint32_t>(7);
+    const uint32_t c_stride = get_arg_val<uint32_t>(8);
+    const uint32_t D = get_arg_val<uint32_t>(9);
+    const uint32_t N = get_arg_val<uint32_t>(10);
+    const uint32_t C = get_arg_val<uint32_t>(11);
+    const uint32_t Ht = get_arg_val<uint32_t>(12);
+    const uint32_t Wt = get_arg_val<uint32_t>(13);
+    const uint32_t cND = get_arg_val<uint32_t>(14);
+    const uint32_t tensor_nD_stride = get_arg_val<uint32_t>(15);
+    const uint32_t tensor_d_stride = get_arg_val<uint32_t>(16);
+    const uint32_t tensor_n_stride = get_arg_val<uint32_t>(17);
+    const uint32_t tensor_c_stride = get_arg_val<uint32_t>(18);
+    const uint32_t tensor_num_tiles = get_arg_val<uint32_t>(19);
+    const uint32_t dst_shard_width = get_arg_val<uint32_t>(25);
+    const uint32_t src_num_tiles = get_arg_val<uint32_t>(26);
+
+    constexpr auto predicate_cb = get_compile_time_arg_val(0);
+    constexpr auto tensor_cb = get_compile_time_arg_val(1);
+
+#define SRC_BCAST_CB1 (SRC_BCAST_B || SRC_BCAST_C)
+
+    constexpr auto src0_args = TensorAccessorArgs<2, 0>();
+    constexpr auto src1_args =
+        TensorAccessorArgs<src0_args.next_compile_time_args_offset(), src0_args.next_common_runtime_args_offset()>();
+
+    const auto s0 = TensorAccessor(src0_args, src0_addr, get_tile_size(predicate_cb));
+    const auto s1 = TensorAccessor(src1_args, src1_addr, get_tile_size(tensor_cb));
+
+    constexpr uint32_t onetile = 1;
+    const uint32_t HtWt = Ht * Wt;
+
+    const uint32_t tiles_per_n = C * HtWt;
+    const uint32_t tiles_per_d = N * tiles_per_n;
+    const uint32_t tiles_per_nd = D * tiles_per_d;
+    const uint32_t offset_nd = start_id % tiles_per_nd;
+    const uint32_t offset_d = offset_nd % tiles_per_d;
+    const uint32_t offset_n = offset_d % tiles_per_n;
+    const uint32_t offset_c = offset_n % HtWt;
+    uint32_t start_nd = start_id / tiles_per_nd;
+    uint32_t start_d = offset_nd / tiles_per_d;
+    uint32_t start_n = offset_d / tiles_per_n;
+    uint32_t start_c = offset_n / HtWt;
+    uint32_t start_th = offset_c / Wt;
+    uint32_t start_tw = offset_c % Wt;
+    uint32_t end_tw = (dst_shard_width != 0) ? (start_tw + dst_shard_width) : Wt;
+
+    uint32_t tile_offset = start_nd * nD_stride + start_d * d_stride + start_n * n_stride + start_c * c_stride;
+#if !SRC_BCAST_A && !SRC_ROW_BCAST_A
+    tile_offset += start_th * Wt;
+#endif
+    uint32_t next_c_shift = c_stride - HtWt;
+    uint32_t next_n_shift = n_stride - c_stride * C;
+    uint32_t next_d_shift = d_stride - n_stride * N;
+    uint32_t next_nd_shift = nD_stride - d_stride * D;
+
+    uint32_t tensor_tile_offset =
+        start_nd * tensor_nD_stride + start_d * tensor_d_stride + start_n * tensor_n_stride + start_c * tensor_c_stride;
+#if !SRC_BCAST_CB1 && !SRC_ROW_BCAST_CB1
+    tensor_tile_offset += start_th * Wt;
+#endif
+    uint32_t tensor_next_c_shift = tensor_c_stride - HtWt;
+    uint32_t tensor_next_n_shift = tensor_n_stride - tensor_c_stride * C;
+    uint32_t tensor_next_d_shift = tensor_d_stride - tensor_n_stride * N;
+    uint32_t tensor_next_nd_shift = tensor_nD_stride - tensor_d_stride * D;
+
+    uint32_t num_tiles_read = 0;
+    for (uint32_t nd = start_nd; nd < cND && num_tiles_read < num_tiles; ++nd, start_d = 0) {
+        for (uint32_t d = start_d; d < D && num_tiles_read < num_tiles; ++d, start_n = 0) {
+            for (uint32_t n = start_n; n < N && num_tiles_read < num_tiles; ++n, start_c = 0) {
+                for (uint32_t c = start_c; c < C && num_tiles_read < num_tiles; ++c, start_th = 0) {
+                    for (uint32_t th = start_th; th < Ht && num_tiles_read < num_tiles; ++th) {
+#if SRC_BCAST_A
+                        cb_reserve_back(predicate_cb, onetile);
+                        uint32_t l1_addr_a = get_write_ptr(predicate_cb);
+#if SRC_SCALAR_A
+                        noc_async_read_page(tile_offset, s0, l1_addr_a);
+                        noc_async_read_barrier();
+                        FILL_TILE_WITH_FIRST_ELEMENT(predicate_cb);
+#else
+                        noc_async_read_page(tile_offset + th, s0, l1_addr_a);
+                        noc_async_read_barrier();
+                        FILL_TILE_WITH_FIRST_COLUMN(predicate_cb);
+#endif
+                        cb_push_back(predicate_cb, onetile);
+#endif
+
+#if SRC_BCAST_CB1
+                        cb_reserve_back(tensor_cb, onetile);
+                        uint32_t l1_addr_t = get_write_ptr(tensor_cb);
+#if SRC_SCALAR_CB1
+                        noc_async_read_page(tensor_tile_offset, s1, l1_addr_t);
+                        noc_async_read_barrier();
+                        FILL_TILE_WITH_FIRST_ELEMENT_B(tensor_cb);
+#else
+                        noc_async_read_page(tensor_tile_offset + th, s1, l1_addr_t);
+                        noc_async_read_barrier();
+                        FILL_TILE_WITH_FIRST_COLUMN_B(tensor_cb);
+#endif
+                        cb_push_back(tensor_cb, onetile);
+#endif
+
+                        for (uint32_t tw = start_tw; tw < end_tw && num_tiles_read < num_tiles;
+                             ++tw, ++num_tiles_read) {
+#if !SRC_BCAST_A
+                            cb_reserve_back(predicate_cb, onetile);
+                            uint32_t l1_addr_a_inner = get_write_ptr(predicate_cb);
+                            noc_async_read_page(tile_offset + tw, s0, l1_addr_a_inner);
+                            noc_async_read_barrier();
+#if SRC_ROW_BCAST_A
+                            FILL_TILE_WITH_FIRST_ROW(predicate_cb);
+#endif
+                            cb_push_back(predicate_cb, onetile);
+#endif
+
+#if !SRC_BCAST_CB1
+                            cb_reserve_back(tensor_cb, onetile);
+                            uint32_t l1_addr_t_inner = get_write_ptr(tensor_cb);
+                            noc_async_read_page(tensor_tile_offset + tw, s1, l1_addr_t_inner);
+                            noc_async_read_barrier();
+#if SRC_ROW_BCAST_CB1
+                            FILL_TILE_WITH_FIRST_ROW_B(tensor_cb);
+#endif
+                            cb_push_back(tensor_cb, onetile);
+#endif
+                        }
+                        if (dst_shard_width == 0) {
+                            start_tw = 0;
+                        }
+#if !SRC_BCAST_A && !SRC_ROW_BCAST_A
+                        tile_offset += Wt;
+#endif
+#if !SRC_BCAST_CB1 && !SRC_ROW_BCAST_CB1
+                        tensor_tile_offset += Wt;
+#endif
+                    }
+#if SRC_BCAST_A || SRC_ROW_BCAST_A
+                    tile_offset += c_stride;
+#else
+                    tile_offset += next_c_shift;
+#endif
+#if SRC_BCAST_CB1 || SRC_ROW_BCAST_CB1
+                    tensor_tile_offset += tensor_c_stride;
+#else
+                    tensor_tile_offset += tensor_next_c_shift;
+#endif
+                }
+                tile_offset += next_n_shift;
+                tensor_tile_offset += tensor_next_n_shift;
+            }
+            tile_offset += next_d_shift;
+            tensor_tile_offset += tensor_next_d_shift;
+        }
+        tile_offset += next_nd_shift;
+        tensor_tile_offset += tensor_next_nd_shift;
+    }
+}

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tts_tst_reader_row_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tts_tst_reader_row_col_bcast.cpp
@@ -2,15 +2,19 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
 
 void kernel_main() {
-    const uint32_t src0_addr = get_arg_val<uint32_t>(0);
-    const uint32_t src1_addr = get_arg_val<uint32_t>(1);
-    const uint32_t src2_addr = get_arg_val<uint32_t>(2);
-    const uint32_t num_tiles = get_arg_val<uint32_t>(3);
-    const uint32_t start_id = get_arg_val<uint32_t>(4);
+    uint32_t src0_addr = get_arg_val<uint32_t>(0);
+    uint32_t src1_addr = get_arg_val<uint32_t>(1);
+    uint32_t src2_addr = get_arg_val<uint32_t>(2);
+    uint32_t num_tiles = get_arg_val<uint32_t>(3);
+    uint32_t start_id = get_arg_val<uint32_t>(4);
 
     const uint32_t nD_stride = get_arg_val<uint32_t>(5);
     const uint32_t d_stride = get_arg_val<uint32_t>(6);
@@ -39,8 +43,14 @@ void kernel_main() {
     constexpr auto src1_args =
         TensorAccessorArgs<src0_args.next_compile_time_args_offset(), src0_args.next_common_runtime_args_offset()>();
 
-    const auto s0 = TensorAccessor(src0_args, src0_addr, get_tile_size(predicate_cb));
-    const auto s1 = TensorAccessor(src1_args, src1_addr, get_tile_size(tensor_cb));
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_pred(predicate_cb);
+    experimental::CircularBuffer cb_tensor(tensor_cb);
+
+    const uint32_t src0_tile_bytes = get_tile_size(predicate_cb);
+    const uint32_t src1_tile_bytes = get_tile_size(tensor_cb);
+    const auto s0 = TensorAccessor(src0_args, src0_addr, src0_tile_bytes);
+    const auto s1 = TensorAccessor(src1_args, src1_addr, src1_tile_bytes);
 
     constexpr uint32_t onetile = 1;
     const uint32_t HtWt = Ht * Wt;
@@ -86,57 +96,66 @@ void kernel_main() {
                 for (uint32_t c = start_c; c < C && num_tiles_read < num_tiles; ++c, start_th = 0) {
                     for (uint32_t th = start_th; th < Ht && num_tiles_read < num_tiles; ++th) {
 #if SRC_BCAST_A
-                        cb_reserve_back(predicate_cb, onetile);
-                        uint32_t l1_addr_a = get_write_ptr(predicate_cb);
+                        cb_pred.reserve_back(onetile);
 #if SRC_SCALAR_A
-                        noc_async_read_page(tile_offset, s0, l1_addr_a);
-                        noc_async_read_barrier();
+                        noc.async_read(s0, cb_pred, src0_tile_bytes, {.page_id = tile_offset}, {.offset_bytes = 0});
+#else
+                        noc.async_read(
+                            s0, cb_pred, src0_tile_bytes, {.page_id = tile_offset + th}, {.offset_bytes = 0});
+#endif
+                        noc.async_read_barrier();
+#if SRC_SCALAR_A
                         FILL_TILE_WITH_FIRST_ELEMENT(predicate_cb);
 #else
-                        noc_async_read_page(tile_offset + th, s0, l1_addr_a);
-                        noc_async_read_barrier();
                         FILL_TILE_WITH_FIRST_COLUMN(predicate_cb);
 #endif
-                        cb_push_back(predicate_cb, onetile);
+                        cb_pred.push_back(onetile);
 #endif
 
 #if SRC_BCAST_CB1
-                        cb_reserve_back(tensor_cb, onetile);
-                        uint32_t l1_addr_t = get_write_ptr(tensor_cb);
+                        cb_tensor.reserve_back(onetile);
 #if SRC_SCALAR_CB1
-                        noc_async_read_page(tensor_tile_offset, s1, l1_addr_t);
-                        noc_async_read_barrier();
+                        noc.async_read(
+                            s1, cb_tensor, src1_tile_bytes, {.page_id = tensor_tile_offset}, {.offset_bytes = 0});
+#else
+                        noc.async_read(
+                            s1, cb_tensor, src1_tile_bytes, {.page_id = tensor_tile_offset + th}, {.offset_bytes = 0});
+#endif
+                        noc.async_read_barrier();
+#if SRC_SCALAR_CB1
                         FILL_TILE_WITH_FIRST_ELEMENT_B(tensor_cb);
 #else
-                        noc_async_read_page(tensor_tile_offset + th, s1, l1_addr_t);
-                        noc_async_read_barrier();
                         FILL_TILE_WITH_FIRST_COLUMN_B(tensor_cb);
 #endif
-                        cb_push_back(tensor_cb, onetile);
+                        cb_tensor.push_back(onetile);
 #endif
 
                         for (uint32_t tw = start_tw; tw < end_tw && num_tiles_read < num_tiles;
                              ++tw, ++num_tiles_read) {
 #if !SRC_BCAST_A
-                            cb_reserve_back(predicate_cb, onetile);
-                            uint32_t l1_addr_a_inner = get_write_ptr(predicate_cb);
-                            noc_async_read_page(tile_offset + tw, s0, l1_addr_a_inner);
-                            noc_async_read_barrier();
+                            cb_pred.reserve_back(onetile);
+                            noc.async_read(
+                                s0, cb_pred, src0_tile_bytes, {.page_id = tile_offset + tw}, {.offset_bytes = 0});
+                            noc.async_read_barrier();
 #if SRC_ROW_BCAST_A
                             FILL_TILE_WITH_FIRST_ROW(predicate_cb);
 #endif
-                            cb_push_back(predicate_cb, onetile);
+                            cb_pred.push_back(onetile);
 #endif
 
 #if !SRC_BCAST_CB1
-                            cb_reserve_back(tensor_cb, onetile);
-                            uint32_t l1_addr_t_inner = get_write_ptr(tensor_cb);
-                            noc_async_read_page(tensor_tile_offset + tw, s1, l1_addr_t_inner);
-                            noc_async_read_barrier();
+                            cb_tensor.reserve_back(onetile);
+                            noc.async_read(
+                                s1,
+                                cb_tensor,
+                                src1_tile_bytes,
+                                {.page_id = tensor_tile_offset + tw},
+                                {.offset_bytes = 0});
+                            noc.async_read_barrier();
 #if SRC_ROW_BCAST_CB1
                             FILL_TILE_WITH_FIRST_ROW_B(tensor_cb);
 #endif
-                            cb_push_back(tensor_cb, onetile);
+                            cb_tensor.push_back(onetile);
 #endif
                         }
                         if (dst_shard_width == 0) {

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_op_utils.cpp
@@ -99,7 +99,7 @@ bool is_native_L1_sharding(
             return false;
         }
         // Check if output grid differs from input grids - if so, cannot use native sharding
-        if (output_memory_config.is_sharded() && output_memory_config.shard_spec().has_value()) {
+        if (output_memory_config.shard_spec().has_value()) {
             const auto& out_grid = output_memory_config.shard_spec()->grid;
             if (predicate_spec.memory_config().is_sharded() &&
                 predicate_spec.memory_config().shard_spec().has_value() &&
@@ -125,7 +125,7 @@ bool is_native_L1_sharding(
         if (false_spec->memory_config().is_sharded() && false_spec->memory_config().buffer_type() == BufferType::L1) {
             return true;
         }
-        if (output_memory_config.is_sharded() && output_memory_config.buffer_type() == BufferType::L1) {
+        if (output_memory_config.buffer_type() == BufferType::L1) {
             return true;
         }
     }
@@ -173,6 +173,9 @@ static const std::unordered_map<KernelLookupKey, KernelConfigEntry, KernelLookup
      {KernelName::ReaderScalarBcastTTT, KernelName::ComputeBcastTTT, KernelName::WriterNoBcastTernary}},
     {{TernaryOpType::WHERE, TernaryVariant::TTT, TernaryBroadcastType::NONE},
      {KernelName::ReaderNoBcastTTT, KernelName::ComputeNoBcastTTT, KernelName::WriterNoBcastTernary}},
+    // TTT ROW_COL_BCAST for WHERE
+    {{TernaryOpType::WHERE, TernaryVariant::TTT, TernaryBroadcastType::ROW_COL_BCAST},
+     {KernelName::ReaderRowColBcastTTT, KernelName::ComputeBcastTTT, KernelName::WriterNoBcastTernary}},
 
     // TTS configurations for WHERE
     {{TernaryOpType::WHERE, TernaryVariant::TTS, TernaryBroadcastType::COL_BCAST},
@@ -187,6 +190,9 @@ static const std::unordered_map<KernelLookupKey, KernelConfigEntry, KernelLookup
      {KernelName::ReaderScalarBcastTTS, KernelName::ComputeBcastTTS_TST, KernelName::WriterNoBcast}},
     {{TernaryOpType::WHERE, TernaryVariant::TTS, TernaryBroadcastType::NONE},
      {KernelName::ReaderNoBcastTTS, KernelName::ComputeNoBcastTTS_TST, KernelName::WriterNoBcast}},
+    // TTS ROW_COL_BCAST for WHERE
+    {{TernaryOpType::WHERE, TernaryVariant::TTS, TernaryBroadcastType::ROW_COL_BCAST},
+     {KernelName::ReaderRowColBcastTTS, KernelName::ComputeBcastTTS_TST, KernelName::WriterNoBcast}},
 
     // TST configurations for WHERE
     {{TernaryOpType::WHERE, TernaryVariant::TST, TernaryBroadcastType::COL_BCAST},
@@ -201,6 +207,9 @@ static const std::unordered_map<KernelLookupKey, KernelConfigEntry, KernelLookup
      {KernelName::ReaderScalarBcastTST, KernelName::ComputeBcastTTS_TST, KernelName::WriterNoBcast}},
     {{TernaryOpType::WHERE, TernaryVariant::TST, TernaryBroadcastType::NONE},
      {KernelName::ReaderNoBcastTST, KernelName::ComputeNoBcastTTS_TST, KernelName::WriterNoBcast}},
+    // TST ROW_COL_BCAST for WHERE
+    {{TernaryOpType::WHERE, TernaryVariant::TST, TernaryBroadcastType::ROW_COL_BCAST},
+     {KernelName::ReaderRowColBcastTST, KernelName::ComputeBcastTTS_TST, KernelName::WriterNoBcast}},
 
     // TTT configurations for LERP - same kernels, different compute operation
     {{TernaryOpType::LERP, TernaryVariant::TTT, TernaryBroadcastType::COL_BCAST},
@@ -213,6 +222,9 @@ static const std::unordered_map<KernelLookupKey, KernelConfigEntry, KernelLookup
      {KernelName::ReaderScalarBcastTTT, KernelName::ComputeBcastTTT, KernelName::WriterNoBcastTernary}},
     {{TernaryOpType::LERP, TernaryVariant::TTT, TernaryBroadcastType::NONE},
      {KernelName::ReaderNoBcastTTT, KernelName::ComputeNoBcastTTT, KernelName::WriterNoBcastTernary}},
+    // TTT ROW_COL_BCAST for LERP
+    {{TernaryOpType::LERP, TernaryVariant::TTT, TernaryBroadcastType::ROW_COL_BCAST},
+     {KernelName::ReaderRowColBcastTTT, KernelName::ComputeBcastTTT, KernelName::WriterNoBcastTernary}},
 
     // TTT configurations for ADDCMUL (shared addc_ops kernels)
     {{TernaryOpType::ADDCMUL, TernaryVariant::TTT, TernaryBroadcastType::NONE},
@@ -225,6 +237,9 @@ static const std::unordered_map<KernelLookupKey, KernelConfigEntry, KernelLookup
      {KernelName::ReaderScalarBcastTTT, KernelName::ComputeBcastAddcOp, KernelName::WriterNoBcastTernary}},
     {{TernaryOpType::ADDCMUL, TernaryVariant::TTT, TernaryBroadcastType::COL_BCAST},
      {KernelName::ReaderColBcastTTT, KernelName::ComputeBcastAddcOp, KernelName::WriterNoBcastTernary}},
+    // TTT ROW_COL_BCAST for ADDCMUL
+    {{TernaryOpType::ADDCMUL, TernaryVariant::TTT, TernaryBroadcastType::ROW_COL_BCAST},
+     {KernelName::ReaderRowColBcastTTT, KernelName::ComputeBcastAddcOp, KernelName::WriterNoBcastTernary}},
 
     // TTT configurations for ADDCDIV (shared addc_ops kernels)
     {{TernaryOpType::ADDCDIV, TernaryVariant::TTT, TernaryBroadcastType::NONE},
@@ -237,6 +252,9 @@ static const std::unordered_map<KernelLookupKey, KernelConfigEntry, KernelLookup
      {KernelName::ReaderScalarBcastTTT, KernelName::ComputeBcastAddcOp, KernelName::WriterNoBcastTernary}},
     {{TernaryOpType::ADDCDIV, TernaryVariant::TTT, TernaryBroadcastType::COL_BCAST},
      {KernelName::ReaderColBcastTTT, KernelName::ComputeBcastAddcOp, KernelName::WriterNoBcastTernary}},
+    // TTT ROW_COL_BCAST for ADDCDIV
+    {{TernaryOpType::ADDCDIV, TernaryVariant::TTT, TernaryBroadcastType::ROW_COL_BCAST},
+     {KernelName::ReaderRowColBcastTTT, KernelName::ComputeBcastAddcOp, KernelName::WriterNoBcastTernary}},
 
     // TTS configurations for LERP
     {{TernaryOpType::LERP, TernaryVariant::TTS, TernaryBroadcastType::COL_BCAST},
@@ -251,6 +269,10 @@ static const std::unordered_map<KernelLookupKey, KernelConfigEntry, KernelLookup
      {KernelName::ReaderScalarBcastTTS, KernelName::ComputeBcastTTS_TST, KernelName::WriterNoBcast}},
     {{TernaryOpType::LERP, TernaryVariant::TTS, TernaryBroadcastType::NONE},
      {KernelName::ReaderNoBcastTTS, KernelName::ComputeNoBcastTTS_TST, KernelName::WriterNoBcast}},
+    // TTS ROW_COL_BCAST for LERP
+    {{TernaryOpType::LERP, TernaryVariant::TTS, TernaryBroadcastType::ROW_COL_BCAST},
+     {KernelName::ReaderRowColBcastTTS, KernelName::ComputeBcastTTS_TST, KernelName::WriterNoBcast}},
+
 };
 
 TernaryKernelConfig::TernaryKernelConfig(
@@ -294,6 +316,10 @@ std::string get_kernel_file_path(KernelName kernel_name, bool is_fpu) {
         case KernelName::ReaderRowBcastTTT: return fmt::format(dataflow, root, "ternary_reader_rowbcast_ttt.cpp");
         case KernelName::ReaderRowBcastTST:
         case KernelName::ReaderRowBcastTTS: return fmt::format(dataflow, root, "tts_tst_reader_row_bcast.cpp");
+        case KernelName::ReaderRowColBcastTTT:
+            return fmt::format(dataflow, root, "ternary_reader_row_col_bcast_ttt.cpp");
+        case KernelName::ReaderRowColBcastTTS:
+        case KernelName::ReaderRowColBcastTST: return fmt::format(dataflow, root, "tts_tst_reader_row_col_bcast.cpp");
         case KernelName::WriterNoBcastTernary:
         case KernelName::WriterNoBcast:
         case KernelName::WriterColBcastTTT: return fmt::format(dataflow, root, "ternary_writer_nobcast.cpp");
@@ -508,6 +534,20 @@ TernaryBroadcastType get_broadcast_type(const ttnn::Shape& predicate_shape, cons
             return TernaryBroadcastType::SCALAR_A_BCAST;
         }
 
+        bool is_pred_row = (pred_row_bcast && !pred_col_bcast);
+        bool is_pred_col = (!pred_row_bcast && pred_col_bcast);
+        bool is_b_row = (b_row_bcast && !b_col_bcast);
+        bool is_b_col = (!b_row_bcast && b_col_bcast);
+        bool is_pred_full = (pred_h == max_h && pred_w == max_w);
+        bool is_b_full = (b_h == max_h && b_w == max_w);
+
+        bool pred_ok = is_pred_row || is_pred_col || is_pred_full;
+        bool b_ok = is_b_row || is_b_col || is_b_full;
+
+        if (pred_ok && b_ok) {
+            return TernaryBroadcastType::ROW_COL_BCAST;
+        }
+
         return TernaryBroadcastType::INVALID_BCAST;
     }
 
@@ -611,6 +651,22 @@ TernaryBroadcastType get_broadcast_type(
         if ((is_pred_scalar || is_pred_non_bcast) && (is_true_scalar || is_true_non_bcast) &&
             (is_false_scalar || is_false_non_bcast)) {
             return TernaryBroadcastType::SCALAR_BCAST;
+        }
+
+        // Mixed row+col broadcast: each tensor is one of scalar(1,1), row(1,W), col(H,1), or full(H,W)
+        bool is_pred_row = (pred_row_bcast && !pred_col_bcast);
+        bool is_pred_col = (!pred_row_bcast && pred_col_bcast);
+        bool is_true_row = (true_row_bcast && !true_col_bcast);
+        bool is_true_col = (!true_row_bcast && true_col_bcast);
+        bool is_false_row = (false_row_bcast && !false_col_bcast);
+        bool is_false_col = (!false_row_bcast && false_col_bcast);
+
+        bool pred_valid = is_pred_scalar || is_pred_non_bcast || is_pred_row || is_pred_col;
+        bool true_valid = is_true_scalar || is_true_non_bcast || is_true_row || is_true_col;
+        bool false_valid = is_false_scalar || is_false_non_bcast || is_false_row || is_false_col;
+
+        if (pred_valid && true_valid && false_valid) {
+            return TernaryBroadcastType::ROW_COL_BCAST;
         }
 
         return TernaryBroadcastType::INVALID_BCAST;

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_op_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_op_utils.hpp
@@ -31,6 +31,9 @@ enum class KernelName {
     ReaderRowBcastTTT,
     ReaderRowBcastTST,
     ReaderRowBcastTTS,
+    ReaderRowColBcastTTT,
+    ReaderRowColBcastTTS,
+    ReaderRowColBcastTST,
     WriterNoBcastTernary,
     WriterColBcastTTT,
     ComputeNoBcastTTT,      // TTT: no bcast, outer dim and row bcast cases

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_program_factory.cpp
@@ -121,6 +121,35 @@ void detect_broadcasts(
         pred_is_bcast = (pred_row_bcast && pred_col_bcast);
         true_is_bcast = (true_row_bcast && true_col_bcast);
         false_is_bcast = (false_row_bcast && false_col_bcast);
+    } else if (broadcast_type == TernaryBroadcastType::ROW_COL_BCAST) {
+        // Mixed row+col broadcast: is_bcast = true for col-broadcast (W=1) tensors,
+        // which are pushed before the tw loop and waited on outside the compute freq loop.
+        auto pred_w = pred_shape[-1];
+
+        if (variant == TernaryVariant::TTT) {
+            auto true_shape = value_true_tensor.value().logical_shape();
+            auto false_shape = value_false_tensor.value().logical_shape();
+            auto true_w = true_shape[-1];
+            auto false_w = false_shape[-1];
+            auto max_w = std::max({pred_w, true_w, false_w});
+            pred_is_bcast = (pred_w == 1 && max_w > 1);
+            true_is_bcast = (true_w == 1 && max_w > 1);
+            false_is_bcast = (false_w == 1 && max_w > 1);
+        } else if (variant == TernaryVariant::TTS) {
+            auto true_shape = value_true_tensor.value().logical_shape();
+            auto true_w = true_shape[-1];
+            auto max_w = std::max(pred_w, true_w);
+            pred_is_bcast = (pred_w == 1 && max_w > 1);
+            true_is_bcast = (true_w == 1 && max_w > 1);
+            false_is_bcast = false;
+        } else if (variant == TernaryVariant::TST) {
+            auto false_shape = value_false_tensor.value().logical_shape();
+            auto false_w = false_shape[-1];
+            auto max_w = std::max(pred_w, false_w);
+            pred_is_bcast = (pred_w == 1 && max_w > 1);
+            true_is_bcast = false;
+            false_is_bcast = (false_w == 1 && max_w > 1);
+        }
     } else if (broadcast_type == TernaryBroadcastType::SCALAR_A_BCAST) {
         // Scalar broadcast detection (H and W dimensions of condition tensor must be broadcast for TTS/TST)
         pred_is_bcast = true;
@@ -742,9 +771,7 @@ void set_or_update_runtime_arguments(
         }
         auto [freq, counter] = [&] {
             switch (broadcast_type) {
-                // TODO: test for TTS and TST
-                // case TernaryBroadcastType::ROW_B_COL_A:
-                // case TernaryBroadcastType::ROW_A_COL_B:
+                case TernaryBroadcastType::ROW_COL_BCAST:
                 case TernaryBroadcastType::COL_BCAST: {
                     uint32_t start_t = start_tile_id % (output_dims.Ht * output_dims.Wt);
                     uint32_t start_tw = start_t % output_dims.Wt;
@@ -1000,6 +1027,50 @@ TernaryDeviceOperation::TernaryProgramFactory::cached_program_t TernaryDeviceOpe
         false_is_bcast,
         has_sharding);
 
+    // For mixed row+col broadcast: add per-tensor row-bcast and scalar defines for the reader
+    if (broadcast_type == TernaryBroadcastType::ROW_COL_BCAST) {
+        auto pred_shape = predicate_tensor.logical_shape();
+        auto pred_h = pred_shape[-2];
+        auto pred_w = pred_shape[-1];
+
+        if (variant == TernaryVariant::TTT) {
+            auto true_shape = value_true_tensor.value().logical_shape();
+            auto false_shape = value_false_tensor.value().logical_shape();
+            auto max_h = std::max({pred_h, true_shape[-2], false_shape[-2]});
+            auto max_w = std::max({pred_w, true_shape[-1], false_shape[-1]});
+
+            bool pred_h1 = (pred_h == 1 && max_h > 1);
+            bool pred_w1 = (pred_w == 1 && max_w > 1);
+            bool true_h1 = (true_shape[-2] == 1 && max_h > 1);
+            bool true_w1 = (true_shape[-1] == 1 && max_w > 1);
+            bool false_h1 = (false_shape[-2] == 1 && max_h > 1);
+            bool false_w1 = (false_shape[-1] == 1 && max_w > 1);
+
+            reader_defines["SRC_ROW_BCAST_A"] = (pred_h1 && !pred_w1) ? "1" : "0";
+            reader_defines["SRC_ROW_BCAST_B"] = (true_h1 && !true_w1) ? "1" : "0";
+            reader_defines["SRC_ROW_BCAST_C"] = (false_h1 && !false_w1) ? "1" : "0";
+            reader_defines["SRC_SCALAR_A"] = (pred_h1 && pred_w1) ? "1" : "0";
+            reader_defines["SRC_SCALAR_B"] = (true_h1 && true_w1) ? "1" : "0";
+            reader_defines["SRC_SCALAR_C"] = (false_h1 && false_w1) ? "1" : "0";
+        } else {
+            const auto& tensor_op =
+                (variant == TernaryVariant::TTS) ? value_true_tensor.value() : value_false_tensor.value();
+            auto tensor_shape = tensor_op.logical_shape();
+            auto max_h = std::max(pred_h, tensor_shape[-2]);
+            auto max_w = std::max(pred_w, tensor_shape[-1]);
+
+            bool pred_h1 = (pred_h == 1 && max_h > 1);
+            bool pred_w1 = (pred_w == 1 && max_w > 1);
+            bool tensor_h1 = (tensor_shape[-2] == 1 && max_h > 1);
+            bool tensor_w1 = (tensor_shape[-1] == 1 && max_w > 1);
+
+            reader_defines["SRC_ROW_BCAST_A"] = (pred_h1 && !pred_w1) ? "1" : "0";
+            reader_defines["SRC_SCALAR_A"] = (pred_h1 && pred_w1) ? "1" : "0";
+            reader_defines["SRC_ROW_BCAST_CB1"] = (tensor_h1 && !tensor_w1) ? "1" : "0";
+            reader_defines["SRC_SCALAR_CB1"] = (tensor_h1 && tensor_w1) ? "1" : "0";
+        }
+    }
+
     std::map<std::string, std::string> kernel_defines;
     if (variant == TernaryVariant::TTT) {
         if (CMAKE_UNIQUE_NAMESPACE::is_llk_bcast(
@@ -1136,8 +1207,8 @@ TernaryDeviceOperation::TernaryProgramFactory::cached_program_t TernaryDeviceOpe
         kernel_defines["BCAST_C"] = false_is_bcast ? "1" : "0";
     } else if (
         (variant == TernaryVariant::TTS || variant == TernaryVariant::TST) &&
-        broadcast_type == TernaryBroadcastType::COL_BCAST) {
-        // Unified TTS/TST column broadcast configuration
+        (broadcast_type == TernaryBroadcastType::COL_BCAST || broadcast_type == TernaryBroadcastType::ROW_COL_BCAST)) {
+        // Unified TTS/TST column and mixed broadcast configuration
         kernel_defines["BCAST_A"] = pred_is_bcast ? "1" : "0";
         if (variant == TernaryVariant::TTS) {
             kernel_defines["BCAST_B"] = true_is_bcast ? "1" : "0";


### PR DESCRIPTION
### Ticket
Link to Github Issue #33587

### Problem Description

Currently, the ternary infra does not support mixed Row–Column broadcast.

### What's Changed

Added support for mixed Row–Column broadcast in the ternary infra.

### Checklist
- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mouliraj/ternary_broadcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mouliraj/ternary_broadcast)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mouliraj/ternary_broadcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mouliraj/ternary_broadcast)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mouliraj/ternary_broadcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mouliraj/ternary_broadcast)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
