### PR TITLE
Add PSD constructor from proto object

### DIFF
--- a/tt_metal/api/tt-metalium/experimental/fabric/physical_system_descriptor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/physical_system_descriptor.hpp
@@ -24,6 +24,10 @@ namespace tt {
 enum class TargetDevice : std::uint8_t;
 }
 
+namespace tt::fabric::proto {
+class PhysicalSystemDescriptor;
+}  // namespace tt::fabric::proto
+
 namespace tt::tt_metal {
 
 // Forward declaration for discovery setter interface
@@ -143,8 +147,12 @@ public:
     explicit PhysicalSystemDescriptor(tt::TargetDevice target_device_type);
 
     // Constructor generating a PhysicalSystemDescriptor based on a protobuf
-    // descriptor (can be used entirely offline).
+    // descriptor file (can be used entirely offline).
     PhysicalSystemDescriptor(const std::string& mock_proto_desc_path);
+
+    // Constructor generating a PhysicalSystemDescriptor based on a protobuf
+    // descriptor (can be used entirely offline).
+    PhysicalSystemDescriptor(const tt::fabric::proto::PhysicalSystemDescriptor& psd_proto);
 
     ~PhysicalSystemDescriptor();
 

--- a/tt_metal/fabric/physical_system_descriptor.cpp
+++ b/tt_metal/fabric/physical_system_descriptor.cpp
@@ -57,6 +57,23 @@ PhysicalSystemDescriptor::PhysicalSystemDescriptor(const std::string& mock_proto
     pcie_id_to_asic_location_ = std::move(proto_desc.get_pcie_id_to_asic_location());
 }
 
+PhysicalSystemDescriptor::PhysicalSystemDescriptor(const tt::fabric::proto::PhysicalSystemDescriptor& psd_proto) :
+    target_device_type_(tt::TargetDevice::Silicon) {
+    // Convert the protobuf descriptor to a PhysicalSystemDescriptor
+    auto proto_desc = deserialize_physical_system_descriptor_from_proto(psd_proto);
+
+    // Move all members directly from the deserialized descriptor using non-const getters
+    target_device_type_ = proto_desc.get_target_device_type();
+    system_graph_ = std::move(proto_desc.get_system_graph());
+    asic_descriptors_ = std::move(proto_desc.get_asic_descriptors());
+    host_to_mobo_name_ = std::move(proto_desc.get_host_mobo_name_map());
+    host_to_rank_ = std::move(proto_desc.get_host_to_rank_map());
+    exit_node_connection_table_ = std::move(proto_desc.get_exit_node_connection_table());
+    ethernet_firmware_version_ = proto_desc.get_ethernet_firmware_version();
+    pcie_devices_per_tray_ = std::move(proto_desc.get_pcie_devices_per_tray());
+    pcie_id_to_asic_location_ = std::move(proto_desc.get_pcie_id_to_asic_location());
+}
+
 PhysicalSystemDescriptor::~PhysicalSystemDescriptor() = default;
 
 void PhysicalSystemDescriptor::set_discovery_data(

--- a/tt_metal/fabric/serialization/physical_system_descriptor_serialization.cpp
+++ b/tt_metal/fabric/serialization/physical_system_descriptor_serialization.cpp
@@ -362,13 +362,18 @@ std::vector<uint8_t> serialize_physical_system_descriptor_to_bytes(const Physica
     return result;
 }
 
+PhysicalSystemDescriptor deserialize_physical_system_descriptor_from_proto(
+    const tt::fabric::proto::PhysicalSystemDescriptor& psd_proto) {
+    return std::move(*proto_to_physical_system_descriptor(psd_proto));
+}
+
 PhysicalSystemDescriptor deserialize_physical_system_descriptor_from_bytes(const std::vector<uint8_t>& data) {
     tt::fabric::proto::PhysicalSystemDescriptor proto_desc;
     if (!proto_desc.ParseFromArray(data.data(), data.size())) {
         throw std::runtime_error("Failed to parse PhysicalSystemDescriptor from protobuf binary format");
     }
 
-    return std::move(*proto_to_physical_system_descriptor(proto_desc));
+    return deserialize_physical_system_descriptor_from_proto(proto_desc);
 }
 
 PhysicalSystemDescriptor deserialize_physical_system_descriptor_from_text_proto_file(
@@ -385,6 +390,6 @@ PhysicalSystemDescriptor deserialize_physical_system_descriptor_from_text_proto_
         throw std::runtime_error("Failed to parse PhysicalSystemDescriptor from text proto file: " + text_proto_file);
     }
 
-    return std::move(*proto_to_physical_system_descriptor(physical_system_descriptor));
+    return deserialize_physical_system_descriptor_from_proto(physical_system_descriptor);
 }
 }  // namespace tt::tt_metal

--- a/tt_metal/fabric/serialization/physical_system_descriptor_serialization.hpp
+++ b/tt_metal/fabric/serialization/physical_system_descriptor_serialization.hpp
@@ -17,6 +17,10 @@ namespace tt::tt_metal::distributed::multihost {
 class DistributedContext;
 }
 
+namespace tt::fabric::proto {
+class PhysicalSystemDescriptor;
+}  // namespace tt::fabric::proto
+
 namespace tt::tt_metal {
 
 class PhysicalSystemDescriptor;
@@ -26,6 +30,10 @@ void emit_physical_system_descriptor_to_text_proto(
 
 // Serialize PhysicalSystemDescriptor to protobuf binary format (byte vector)
 std::vector<uint8_t> serialize_physical_system_descriptor_to_bytes(const PhysicalSystemDescriptor& descriptor);
+
+// Deserialize from protobuf object to PhysicalSystemDescriptor (protobuf)
+PhysicalSystemDescriptor deserialize_physical_system_descriptor_from_proto(
+    const tt::fabric::proto::PhysicalSystemDescriptor& psd_proto);
 
 // Deserialize from protobuf binary format to PhysicalSystemDescriptor (byte vector)
 PhysicalSystemDescriptor deserialize_physical_system_descriptor_from_bytes(const std::vector<uint8_t>& data);


### PR DESCRIPTION
### Problem description
Fabric manager needs to be able to build a PSD object from a PSD proto object. Currently we only support constructing PSDs straight from a file.

### What's changed
Add a PSD (`tt:tt_metal::PhysicalSystemDescriptor`) constructor which takes a PSD proto object as an argument.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=p1-0tr/psd-from-proto-obj)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:p1-0tr/psd-from-proto-obj)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=p1-0tr/psd-from-proto-obj)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:p1-0tr/psd-from-proto-obj)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=p1-0tr/psd-from-proto-obj)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:p1-0tr/psd-from-proto-obj)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early