### PR TITLE
#38903: move softmax and batch norm to device 2.0 api

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_kernel.cpp
@@ -33,7 +33,6 @@ ALWI void batchnorm_bcast_tiles(
     experimental::CircularBuffer cb_bcast_obj(cb_bcast);
     experimental::CircularBuffer cb_other_obj(cb_other);
     experimental::CircularBuffer cb_batch_var_obj(cb_batch_var);
-    experimental::CircularBuffer cb_eps_obj(cb_eps);
     experimental::CircularBuffer cb_den_obj(cb_den);
     experimental::CircularBuffer cb_weight_obj(cb_weight);
     experimental::CircularBuffer cb_bias_obj(cb_bias);

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_kernel.cpp
@@ -7,6 +7,8 @@
 
 #include <cstdint>
 
+#include "experimental/circular_buffer.h"
+
 ALWI void batchnorm_bcast_tiles(
     uint32_t cb_bcast,
     uint32_t cb_other,
@@ -28,9 +30,21 @@ ALWI void batchnorm_bcast_tiles(
     auto cb_affine_or_out = (weight_has_value || bias_has_value) ? cb_tmp_1 : cb_output_0;
     auto cb_scaled_output = (bias_has_value) ? cb_tmp_1 : cb_output_0;
 
+    experimental::CircularBuffer cb_bcast_obj(cb_bcast);
+    experimental::CircularBuffer cb_other_obj(cb_other);
+    experimental::CircularBuffer cb_batch_var_obj(cb_batch_var);
+    experimental::CircularBuffer cb_eps_obj(cb_eps);
+    experimental::CircularBuffer cb_den_obj(cb_den);
+    experimental::CircularBuffer cb_weight_obj(cb_weight);
+    experimental::CircularBuffer cb_bias_obj(cb_bias);
+    experimental::CircularBuffer cb_tmp_1_obj(cb_tmp_1);
+    experimental::CircularBuffer cb_output_0_obj(cb_output_0);
+    experimental::CircularBuffer cb_affine_or_out_obj(cb_affine_or_out);
+    experimental::CircularBuffer cb_scaled_output_obj(cb_scaled_output);
+
     // 1/(sqrt(batch_var + eps))
-    cb_reserve_back(cb_den, onetile);
-    cb_wait_front(cb_batch_var, onetile);
+    cb_den_obj.reserve_back(onetile);
+    cb_batch_var_obj.wait_front(onetile);
 
     tile_regs_acquire();
     add_tiles_init_with_dt(cb_batch_var, cb_eps);
@@ -43,21 +57,21 @@ ALWI void batchnorm_bcast_tiles(
     pack_tile_with_dt(dst0, cb_den);
     tile_regs_release();
 
-    cb_pop_front(cb_batch_var, onetile);
-    cb_push_back(cb_den, onetile);
+    cb_batch_var_obj.pop_front(onetile);
+    cb_den_obj.push_back(onetile);
 
-    cb_wait_front(cb_bcast, onetile);
-    cb_wait_front(cb_den, onetile);
+    cb_bcast_obj.wait_front(onetile);
+    cb_den_obj.wait_front(onetile);
     if (weight_has_value) {
-        cb_wait_front(cb_weight, onetile);
+        cb_weight_obj.wait_front(onetile);
     }
     if (bias_has_value) {
-        cb_wait_front(cb_bias, onetile);
+        cb_bias_obj.wait_front(onetile);
     }
     for (uint32_t j = tile_start; j < freq; ++j) {
         // input - batch_mean
-        cb_wait_front(cb_other, onetile);
-        cb_reserve_back(cb_affine_or_out, onetile);
+        cb_other_obj.wait_front(onetile);
+        cb_affine_or_out_obj.reserve_back(onetile);
 
         tile_regs_acquire();
         sub_tiles_init(cb_other, cb_bcast);
@@ -72,13 +86,13 @@ ALWI void batchnorm_bcast_tiles(
         pack_tile_with_dt(0, cb_affine_or_out);
         tile_regs_release();
 
-        cb_push_back(cb_affine_or_out, onetile);
-        cb_pop_front(cb_other, onetile);
+        cb_affine_or_out_obj.push_back(onetile);
+        cb_other_obj.pop_front(onetile);
 
         // result = result * weight
         if (weight_has_value) {
-            cb_reserve_back(cb_scaled_output, onetile);
-            cb_wait_front(cb_affine_or_out, 1);
+            cb_scaled_output_obj.reserve_back(onetile);
+            cb_affine_or_out_obj.wait_front(1);
 
             tile_regs_acquire();
             mul_tiles_init_with_dt(cb_affine_or_out, cb_weight);
@@ -89,14 +103,14 @@ ALWI void batchnorm_bcast_tiles(
             pack_tile_with_dt(dst0, cb_scaled_output);
             tile_regs_release();
 
-            cb_pop_front(cb_affine_or_out, 1);
-            cb_push_back(cb_scaled_output, onetile);
+            cb_affine_or_out_obj.pop_front(1);
+            cb_scaled_output_obj.push_back(onetile);
         }
 
         // result = result + bias
         if (bias_has_value) {
-            cb_reserve_back(cb_output_0, onetile);
-            cb_wait_front(cb_tmp_1, onetile);
+            cb_output_0_obj.reserve_back(onetile);
+            cb_tmp_1_obj.wait_front(onetile);
 
             tile_regs_acquire();
             add_tiles_init_with_dt(cb_tmp_1, cb_bias);
@@ -107,17 +121,17 @@ ALWI void batchnorm_bcast_tiles(
             pack_tile_with_dt(dst0, cb_output_0);
             tile_regs_release();
 
-            cb_pop_front(cb_tmp_1, onetile);
-            cb_push_back(cb_output_0, onetile);
+            cb_tmp_1_obj.pop_front(onetile);
+            cb_output_0_obj.push_back(onetile);
         }
     }
-    cb_pop_front(cb_bcast, onetile);
-    cb_pop_front(cb_den, onetile);
+    cb_bcast_obj.pop_front(onetile);
+    cb_den_obj.pop_front(onetile);
     if (weight_has_value) {
-        cb_pop_front(cb_weight, onetile);
+        cb_weight_obj.pop_front(onetile);
     }
     if (bias_has_value) {
-        cb_pop_front(cb_bias, onetile);
+        cb_bias_obj.pop_front(onetile);
     }
 }
 
@@ -152,7 +166,8 @@ void kernel_main() {
     uint32_t remaining_iterations = (num_tiles + tile_start) % tile_freq;
 
     constexpr uint32_t onetile = 1;
-    cb_wait_front(cb_eps, onetile);
+    experimental::CircularBuffer cb_eps_obj(cb_eps);
+    cb_eps_obj.wait_front(onetile);
 
     for (uint32_t i = 0; i < complete_iterations; ++i, tile_start = 0) {
         batchnorm_bcast_tiles(
@@ -187,5 +202,5 @@ void kernel_main() {
             bias_has_value);
     }
 
-    cb_pop_front(cb_eps, onetile);
+    cb_eps_obj.pop_front(onetile);
 }

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_sfpu_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_sfpu_kernel.cpp
@@ -36,7 +36,6 @@ ALWI void batchnorm_bcast_tiles(
     experimental::CircularBuffer cb_bcast_obj(cb_bcast);
     experimental::CircularBuffer cb_other_obj(cb_other);
     experimental::CircularBuffer cb_batch_var_obj(cb_batch_var);
-    experimental::CircularBuffer cb_eps_obj(cb_eps);
     experimental::CircularBuffer cb_den_obj(cb_den);
     experimental::CircularBuffer cb_weight_obj(cb_weight);
     experimental::CircularBuffer cb_bias_obj(cb_bias);

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_sfpu_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_sfpu_kernel.cpp
@@ -10,6 +10,8 @@
 
 #include <cstdint>
 
+#include "experimental/circular_buffer.h"
+
 ALWI void batchnorm_bcast_tiles(
     uint32_t cb_bcast,
     uint32_t cb_other,
@@ -31,9 +33,21 @@ ALWI void batchnorm_bcast_tiles(
     auto cb_affine_or_out = (weight_has_value || bias_has_value) ? cb_tmp_1 : cb_output_0;
     auto cb_scaled_output = (bias_has_value) ? cb_tmp_1 : cb_output_0;
 
+    experimental::CircularBuffer cb_bcast_obj(cb_bcast);
+    experimental::CircularBuffer cb_other_obj(cb_other);
+    experimental::CircularBuffer cb_batch_var_obj(cb_batch_var);
+    experimental::CircularBuffer cb_eps_obj(cb_eps);
+    experimental::CircularBuffer cb_den_obj(cb_den);
+    experimental::CircularBuffer cb_weight_obj(cb_weight);
+    experimental::CircularBuffer cb_bias_obj(cb_bias);
+    experimental::CircularBuffer cb_tmp_1_obj(cb_tmp_1);
+    experimental::CircularBuffer cb_output_0_obj(cb_output_0);
+    experimental::CircularBuffer cb_affine_or_out_obj(cb_affine_or_out);
+    experimental::CircularBuffer cb_scaled_output_obj(cb_scaled_output);
+
     // 1/(sqrt(batch_var + eps)) = cb_den
-    cb_reserve_back(cb_den, onetile);
-    cb_wait_front(cb_batch_var, onetile);
+    cb_den_obj.reserve_back(onetile);
+    cb_batch_var_obj.wait_front(onetile);
 
     tile_regs_acquire();
     tile_regs_wait();
@@ -56,20 +70,20 @@ ALWI void batchnorm_bcast_tiles(
     }
     tile_regs_commit();
     tile_regs_release();
-    cb_push_back(cb_den, onetile);
-    cb_pop_front(cb_batch_var, onetile);
+    cb_den_obj.push_back(onetile);
+    cb_batch_var_obj.pop_front(onetile);
 
-    cb_wait_front(cb_bcast, onetile);  // input - batch_mean
-    cb_wait_front(cb_den, onetile);    // (input - batch_mean)/(sqrt(batch_var + eps)) = result
+    cb_bcast_obj.wait_front(onetile);  // input - batch_mean
+    cb_den_obj.wait_front(onetile);    // (input - batch_mean)/(sqrt(batch_var + eps)) = result
     if (weight_has_value) {            // result = result * weight
-        cb_wait_front(cb_weight, onetile);
+        cb_weight_obj.wait_front(onetile);
     }
     if (bias_has_value) {  // result = result + bias
-        cb_wait_front(cb_bias, onetile);
+        cb_bias_obj.wait_front(onetile);
     }
     for (uint32_t j = tile_start; j < freq; ++j) {
         // input - batch_mean
-        cb_wait_front(cb_other, onetile);
+        cb_other_obj.wait_front(onetile);
         tile_regs_acquire();
         tile_regs_wait();
         copy_tile_to_dst_init_short_with_dt(cb_bcast, cb_other);
@@ -82,10 +96,10 @@ ALWI void batchnorm_bcast_tiles(
             copy_tile(cb_bcast, i, i * 2 + 1);
             sub_binary_tile(i * 2, i * 2 + 1, i * 2);
         }
-        cb_pop_front(cb_other, onetile);
+        cb_other_obj.pop_front(onetile);
 
         //(input - batch_mean)/(sqrt(batch_var + eps))
-        cb_reserve_back(cb_affine_or_out, onetile);
+        cb_affine_or_out_obj.reserve_back(onetile);
         mul_binary_tile_init();
         copy_tile_to_dst_init_short_with_dt(cb_bcast, cb_den);
         for (uint32_t i = 0; i < onetile; ++i) {
@@ -96,11 +110,11 @@ ALWI void batchnorm_bcast_tiles(
         }
         tile_regs_commit();
         tile_regs_release();
-        cb_push_back(cb_affine_or_out, onetile);
+        cb_affine_or_out_obj.push_back(onetile);
 
         if (weight_has_value) {  // result = result * weight
-            cb_wait_front(cb_affine_or_out, onetile);
-            cb_reserve_back(cb_scaled_output, onetile);
+            cb_affine_or_out_obj.wait_front(onetile);
+            cb_scaled_output_obj.reserve_back(onetile);
             tile_regs_acquire();
             tile_regs_wait();
             copy_tile_to_dst_init_short_with_dt(cb_weight, cb_affine_or_out);
@@ -117,13 +131,13 @@ ALWI void batchnorm_bcast_tiles(
             }
             tile_regs_commit();
             tile_regs_release();
-            cb_push_back(cb_scaled_output, onetile);
-            cb_pop_front(cb_affine_or_out, onetile);
+            cb_scaled_output_obj.push_back(onetile);
+            cb_affine_or_out_obj.pop_front(onetile);
         }
 
         if (bias_has_value) {  // result = result + bias
-            cb_wait_front(cb_tmp_1, onetile);
-            cb_reserve_back(cb_output_0, onetile);
+            cb_tmp_1_obj.wait_front(onetile);
+            cb_output_0_obj.reserve_back(onetile);
             tile_regs_acquire();
             tile_regs_wait();
             copy_tile_to_dst_init_short_with_dt(cb_bias, cb_tmp_1);
@@ -140,17 +154,17 @@ ALWI void batchnorm_bcast_tiles(
             }
             tile_regs_commit();
             tile_regs_release();
-            cb_push_back(cb_output_0, onetile);
-            cb_pop_front(cb_tmp_1, onetile);
+            cb_output_0_obj.push_back(onetile);
+            cb_tmp_1_obj.pop_front(onetile);
         }
     }
-    cb_pop_front(cb_bcast, onetile);
-    cb_pop_front(cb_den, onetile);
+    cb_bcast_obj.pop_front(onetile);
+    cb_den_obj.pop_front(onetile);
     if (weight_has_value) {
-        cb_pop_front(cb_weight, onetile);
+        cb_weight_obj.pop_front(onetile);
     }
     if (bias_has_value) {
-        cb_pop_front(cb_bias, onetile);
+        cb_bias_obj.pop_front(onetile);
     }
 }
 
@@ -185,7 +199,8 @@ void kernel_main() {
     uint32_t remaining_iterations = (num_tiles + tile_start) % tile_freq;
 
     constexpr uint32_t onetile = 1;
-    cb_wait_front(cb_eps, onetile);
+    experimental::CircularBuffer cb_eps_obj(cb_eps);
+    cb_eps_obj.wait_front(onetile);
 
     for (uint32_t i = 0; i < complete_iterations; ++i, tile_start = 0) {
         batchnorm_bcast_tiles(
@@ -220,5 +235,5 @@ void kernel_main() {
             bias_has_value);
     }
 
-    cb_pop_front(cb_eps, onetile);
+    cb_eps_obj.pop_front(onetile);
 }

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/running_statistics_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/running_statistics_kernel.cpp
@@ -6,6 +6,7 @@
 #include "api/compute/eltwise_binary.h"
 #include "api/compute/tile_move_copy.h"
 #include "ttnn/kernel/compute/moreh_common.hpp"
+#include "experimental/circular_buffer.h"
 
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
@@ -25,11 +26,15 @@ void kernel_main() {
     constexpr auto cb_tmp2 = get_compile_time_arg_val(12);                 // tmp 2
     constexpr auto cb_tmp3 = get_compile_time_arg_val(13);                 // tmp 3
 
+    experimental::CircularBuffer cb_out0_obj(cb_out0);
+    experimental::CircularBuffer cb_momentum_obj(cb_momentum);
+    experimental::CircularBuffer cb_one_obj(cb_one);
+
     binary_op_init_common(cb_batch_mean, cb_batch_var, cb_out0);
     constexpr uint32_t onetile = 1;
 
-    cb_wait_front(cb_one, 1);
-    cb_wait_front(cb_momentum, 1);
+    cb_one_obj.wait_front(1);
+    cb_momentum_obj.wait_front(1);
 
     for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
         tile_regs_acquire();
@@ -51,9 +56,9 @@ void kernel_main() {
         tile_regs_wait();
         pack_tile(0, cb_out0);
         tile_regs_release();
-        cb_push_back(cb_out0, 1);
+        cb_out0_obj.push_back(1);
     }
 
-    cb_pop_front(cb_one, 1);
-    cb_pop_front(cb_momentum, 1);
+    cb_one_obj.pop_front(1);
+    cb_momentum_obj.pop_front(1);
 }

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/running_statistics_sfpu_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/running_statistics_sfpu_kernel.cpp
@@ -9,6 +9,7 @@
 #include "api/compute/eltwise_binary_sfpu.h"
 #include "api/compute/eltwise_unary/sfpu_split_includes.h"
 #include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "experimental/circular_buffer.h"
 
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
@@ -28,23 +29,36 @@ void kernel_main() {
     constexpr auto cb_tmp2 = get_compile_time_arg_val(12);                 // tmp 2
     constexpr auto cb_tmp3 = get_compile_time_arg_val(13);                 // tmp 3
 
+    experimental::CircularBuffer cb_batch_mean_obj(cb_batch_mean);
+    experimental::CircularBuffer cb_batch_var_obj(cb_batch_var);
+    experimental::CircularBuffer cb_out0_obj(cb_out0);
+    experimental::CircularBuffer cb_old_running_mean_obj(cb_old_running_mean);
+    experimental::CircularBuffer cb_old_running_var_obj(cb_old_running_var);
+    experimental::CircularBuffer cb_updated_running_mean_obj(cb_updated_running_mean);
+    experimental::CircularBuffer cb_updated_running_var_obj(cb_updated_running_var);
+    experimental::CircularBuffer cb_momentum_obj(cb_momentum);
+    experimental::CircularBuffer cb_one_obj(cb_one);
+    experimental::CircularBuffer cb_tmp1_obj(cb_tmp1);
+    experimental::CircularBuffer cb_tmp2_obj(cb_tmp2);
+    experimental::CircularBuffer cb_tmp3_obj(cb_tmp3);
+
     unary_op_init_common(cb_batch_mean, cb_out0);
     constexpr uint32_t onetile = 1;
 
-    cb_wait_front(cb_momentum, 1);
-    cb_wait_front(cb_one, 1);
+    cb_momentum_obj.wait_front(1);
+    cb_one_obj.wait_front(1);
 
     // updated_running_stat = (1 − momentum) × running_stat + momentum × batch_stat
     for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
         // cb tile index
         constexpr uint32_t tile_index = 0;
 
-        cb_wait_front(cb_batch_mean, onetile);
-        cb_reserve_back(cb_out0, 1);
+        cb_batch_mean_obj.wait_front(onetile);
+        cb_out0_obj.reserve_back(1);
 
         if constexpr (old_running_mean_has_value) {
             // 1 - momentum
-            cb_reserve_back(cb_tmp1, onetile);
+            cb_tmp1_obj.reserve_back(onetile);
             sub_binary_tile_init();
             tile_regs_acquire();
             tile_regs_wait();
@@ -58,10 +72,10 @@ void kernel_main() {
             tile_regs_commit();
             pack_tile(tile_index * 2, cb_tmp1);
             tile_regs_release();
-            cb_push_back(cb_tmp1, onetile);
+            cb_tmp1_obj.push_back(onetile);
 
             // momentum * batch stat
-            cb_reserve_back(cb_tmp2, onetile);
+            cb_tmp2_obj.reserve_back(onetile);
             mul_binary_tile_init();
             tile_regs_acquire();
             tile_regs_wait();
@@ -75,12 +89,12 @@ void kernel_main() {
             tile_regs_commit();
             pack_tile(tile_index * 2, cb_tmp2);
             tile_regs_release();
-            cb_push_back(cb_tmp2, onetile);
+            cb_tmp2_obj.push_back(onetile);
 
             // cb_tmp1 * running stats --> (1 - momentum) * running stats
-            cb_wait_front(cb_tmp1, onetile);
-            cb_wait_front(cb_old_running_mean, onetile);
-            cb_reserve_back(cb_tmp3, onetile);
+            cb_tmp1_obj.wait_front(onetile);
+            cb_old_running_mean_obj.wait_front(onetile);
+            cb_tmp3_obj.reserve_back(onetile);
             tile_regs_acquire();
             tile_regs_wait();
 
@@ -93,15 +107,15 @@ void kernel_main() {
             tile_regs_commit();
             pack_tile(tile_index * 2, cb_tmp3);
             tile_regs_release();
-            cb_push_back(cb_tmp3, onetile);
+            cb_tmp3_obj.push_back(onetile);
 
-            cb_pop_front(cb_old_running_mean, onetile);
-            cb_pop_front(cb_tmp1, onetile);
+            cb_old_running_mean_obj.pop_front(onetile);
+            cb_tmp1_obj.pop_front(onetile);
 
             // cb_tmp2 + cb_tmp3 --> (momentum * batch stat) + ((1 - momentum) * running stats)
-            cb_wait_front(cb_tmp2, onetile);
-            cb_wait_front(cb_tmp3, onetile);
-            cb_reserve_back(cb_updated_running_mean, onetile);
+            cb_tmp2_obj.wait_front(onetile);
+            cb_tmp3_obj.wait_front(onetile);
+            cb_updated_running_mean_obj.reserve_back(onetile);
             add_binary_tile_init();
             tile_regs_acquire();
             tile_regs_wait();
@@ -119,17 +133,17 @@ void kernel_main() {
                 pack_tile(tile_index * 2, cb_out0);
             }
             tile_regs_release();
-            cb_push_back(cb_updated_running_mean, onetile);
+            cb_updated_running_mean_obj.push_back(onetile);
 
-            cb_pop_front(cb_tmp3, onetile);
-            cb_pop_front(cb_tmp2, onetile);
+            cb_tmp3_obj.pop_front(onetile);
+            cb_tmp2_obj.pop_front(onetile);
         }
 
-        cb_pop_front(cb_batch_mean, onetile);
+        cb_batch_mean_obj.pop_front(onetile);
 
         if constexpr (old_running_var_has_value) {
             // 1 - momentum
-            cb_reserve_back(cb_tmp1, onetile);
+            cb_tmp1_obj.reserve_back(onetile);
             sub_binary_tile_init();
             tile_regs_acquire();
             tile_regs_wait();
@@ -143,11 +157,11 @@ void kernel_main() {
             tile_regs_commit();
             pack_tile(tile_index * 2, cb_tmp1);
             tile_regs_release();
-            cb_push_back(cb_tmp1, onetile);
+            cb_tmp1_obj.push_back(onetile);
 
             // momentum * batch stat
-            cb_wait_front(cb_batch_var, onetile);
-            cb_reserve_back(cb_tmp2, onetile);
+            cb_batch_var_obj.wait_front(onetile);
+            cb_tmp2_obj.reserve_back(onetile);
             mul_binary_tile_init();
             tile_regs_acquire();
             tile_regs_wait();
@@ -161,14 +175,14 @@ void kernel_main() {
             tile_regs_commit();
             pack_tile(tile_index * 2, cb_tmp2);
             tile_regs_release();
-            cb_push_back(cb_tmp2, onetile);
+            cb_tmp2_obj.push_back(onetile);
 
-            cb_pop_front(cb_batch_var, onetile);
+            cb_batch_var_obj.pop_front(onetile);
 
             // cb_tmp1 * running stats --> (1 - momentum) * running stats
-            cb_wait_front(cb_tmp1, onetile);
-            cb_wait_front(cb_old_running_var, onetile);
-            cb_reserve_back(cb_tmp3, onetile);
+            cb_tmp1_obj.wait_front(onetile);
+            cb_old_running_var_obj.wait_front(onetile);
+            cb_tmp3_obj.reserve_back(onetile);
             tile_regs_acquire();
             tile_regs_wait();
 
@@ -181,15 +195,15 @@ void kernel_main() {
             tile_regs_commit();
             pack_tile(tile_index * 2, cb_tmp3);
             tile_regs_release();
-            cb_push_back(cb_tmp3, onetile);
+            cb_tmp3_obj.push_back(onetile);
 
-            cb_pop_front(cb_old_running_var, onetile);
-            cb_pop_front(cb_tmp1, onetile);
+            cb_old_running_var_obj.pop_front(onetile);
+            cb_tmp1_obj.pop_front(onetile);
 
             // cb_tmp2 + cb_tmp3 --> (momentum * batch stat) + ((1 - momentum) * running stats)
-            cb_wait_front(cb_tmp2, onetile);
-            cb_wait_front(cb_tmp3, onetile);
-            cb_reserve_back(cb_updated_running_var, onetile);
+            cb_tmp2_obj.wait_front(onetile);
+            cb_tmp3_obj.wait_front(onetile);
+            cb_updated_running_var_obj.reserve_back(onetile);
             add_binary_tile_init();
             tile_regs_acquire();
             tile_regs_wait();
@@ -204,14 +218,14 @@ void kernel_main() {
             pack_tile(tile_index * 2, cb_updated_running_var);
             pack_tile(tile_index * 2, cb_out0);
             tile_regs_release();
-            cb_push_back(cb_updated_running_var, onetile);
+            cb_updated_running_var_obj.push_back(onetile);
 
-            cb_pop_front(cb_tmp3, onetile);
-            cb_pop_front(cb_tmp2, onetile);
+            cb_tmp3_obj.pop_front(onetile);
+            cb_tmp2_obj.pop_front(onetile);
         }
 
-        cb_push_back(cb_out0, 1);
+        cb_out0_obj.push_back(1);
     }
-    cb_pop_front(cb_momentum, 1);
-    cb_pop_front(cb_one, 1);
+    cb_momentum_obj.pop_front(1);
+    cb_one_obj.pop_front(1);
 }

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_batch_norm.cpp
@@ -6,6 +6,9 @@
 #include <cstring>
 
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
 
@@ -29,13 +32,17 @@ void kernel_main() {
     const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
     const auto src = TensorAccessor(src_args, src_addr, src_tile_bytes);
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_id_src_obj(cb_id_src);
+    experimental::CircularBuffer cb_id_eps_obj(cb_id_eps);
+
     uint32_t tiles_per_batch = HtWt * C;
     uint32_t start_n = start_tile_id / tiles_per_batch;
     uint32_t start_remaining = start_tile_id % tiles_per_batch;
     uint32_t start_c = start_remaining / HtWt;
     uint32_t start_t = start_remaining % HtWt;
 
-    cb_reserve_back(cb_id_eps, onetile);
+    cb_id_eps_obj.reserve_back(onetile);
 #ifdef FILL_WITH_VALUE_FLOAT
     float eps_f = 0;
     std::memcpy(&eps_f, &eps, sizeof(float));  // Alternative for std::bit_cast
@@ -44,7 +51,7 @@ void kernel_main() {
 #ifdef FILL_WITH_VALUE
     FILL_WITH_VALUE(cb_id_eps, eps);
 #endif
-    cb_push_back(cb_id_eps, onetile);
+    cb_id_eps_obj.push_back(onetile);
 
     // Input tile offset
     uint32_t tile_offset = start_n * n_stride + start_c * c_stride + start_t;
@@ -56,11 +63,10 @@ void kernel_main() {
     for (uint32_t n = start_n; n < N && num_tiles_read < num_tiles; ++n, start_c = 0) {
         for (uint32_t c = start_c; c < C && num_tiles_read < num_tiles; ++c, start_t = 0) {
             for (uint32_t t = start_t; t < HtWt && num_tiles_read < num_tiles; ++t, ++num_tiles_read, ++tile_offset) {
-                cb_reserve_back(cb_id_src, onetile);
-                uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
-                noc_async_read_tile(tile_offset, src, l1_write_addr_src);
-                noc_async_read_barrier();
-                cb_push_back(cb_id_src, onetile);
+                cb_id_src_obj.reserve_back(onetile);
+                noc.async_read(src, cb_id_src_obj, src_tile_bytes, {.page_id = tile_offset}, {.offset_bytes = 0});
+                noc.async_read_barrier();
+                cb_id_src_obj.push_back(onetile);
             }
             tile_offset += next_channel_shift;
         }

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_running_statistics.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_running_statistics.cpp
@@ -6,6 +6,9 @@
 #include <cstring>
 
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 #include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
 
@@ -29,6 +32,10 @@ void kernel_main() {
     const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
     const auto src = TensorAccessor(src_args, src_addr, src_tile_bytes);
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_id_src_obj(cb_id_src);
+    experimental::CircularBuffer cb_id_momentum_obj(cb_id_momentum);
+
     uint32_t tiles_per_batch = HtWt * C;
     uint32_t start_n = start_tile_id / tiles_per_batch;
     uint32_t start_remaining = start_tile_id % tiles_per_batch;
@@ -47,7 +54,7 @@ void kernel_main() {
     fill_cb_with_value(cb_id_one, one_u);
 
     // momentum
-    cb_reserve_back(cb_id_momentum, onetile);
+    cb_id_momentum_obj.reserve_back(onetile);
 #ifdef FILL_WITH_VALUE_FLOAT
     float momentum_f = 0;
     std::memcpy(&momentum_f, &momentum, sizeof(float));  // Alternative for std::bit_cast
@@ -56,17 +63,16 @@ void kernel_main() {
 #ifdef FILL_WITH_VALUE
     FILL_WITH_VALUE(cb_id_momentum, momentum);
 #endif
-    cb_push_back(cb_id_momentum, onetile);
+    cb_id_momentum_obj.push_back(onetile);
 
     uint32_t num_tiles_read = 0;
     for (uint32_t n = start_n; n < N && num_tiles_read < num_tiles; ++n, start_c = 0) {
         for (uint32_t c = start_c; c < C && num_tiles_read < num_tiles; ++c, start_t = 0) {
             for (uint32_t t = start_t; t < HtWt && num_tiles_read < num_tiles; ++t, ++num_tiles_read, ++tile_offset) {
-                cb_reserve_back(cb_id_src, onetile);
-                uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
-                noc_async_read_tile(tile_offset, src, l1_write_addr_src);
-                noc_async_read_barrier();
-                cb_push_back(cb_id_src, onetile);
+                cb_id_src_obj.reserve_back(onetile);
+                noc.async_read(src, cb_id_src_obj, src_tile_bytes, {.page_id = tile_offset}, {.offset_bytes = 0});
+                noc.async_read_barrier();
+                cb_id_src_obj.push_back(onetile);
             }
             tile_offset += next_channel_shift;
         }

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_batch_norm.cpp
@@ -6,6 +6,9 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 
 void kernel_main() {
     uint32_t src_addr = get_arg_val<uint32_t>(0);        // batch_mean
@@ -56,6 +59,13 @@ void kernel_main() {
     const uint32_t bias_tile_bytes = get_tile_size(cb_id_bias);
     const auto bias = TensorAccessor(bias_args, bias_addr, bias_tile_bytes);
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_id_src_obj(cb_id_src);
+    experimental::CircularBuffer cb_id_dst_obj(cb_id_dst);
+    experimental::CircularBuffer cb_id_batch_var_obj(cb_id_batch_var);
+    experimental::CircularBuffer cb_id_weight_obj(cb_id_weight);
+    experimental::CircularBuffer cb_id_bias_obj(cb_id_bias);
+
     uint32_t tiles_per_batch = HtWt * C;
     uint32_t start_n = start_tile_id / tiles_per_batch;
     uint32_t start_remaining = start_tile_id % tiles_per_batch;
@@ -70,46 +80,48 @@ void kernel_main() {
     for (uint32_t n = start_n; n < N && num_tiles_written < num_tiles; ++n, start_c = 0) {
         for (uint32_t c = start_c; c < C && num_tiles_written < num_tiles; ++c, start_t = 0) {
             // read a tile from src
-            cb_reserve_back(cb_id_src, onetile);
-            uint32_t l1_write_addr = get_write_ptr(cb_id_src);
-            noc_async_read_tile(tile_offset, src, l1_write_addr);
-            noc_async_read_barrier();
+            cb_id_src_obj.reserve_back(onetile);
+            noc.async_read(src, cb_id_src_obj, src_tile_bytes, {.page_id = tile_offset}, {.offset_bytes = 0});
+            noc.async_read_barrier();
             FILL_TILE_WITH_FIRST_ELEMENT(cb_id_src);
-            cb_push_back(cb_id_src, onetile);
+            cb_id_src_obj.push_back(onetile);
 
             // read a tile from batch variance
-            cb_reserve_back(cb_id_batch_var, onetile);
-            uint32_t l1_batch_var_write_addr = get_write_ptr(cb_id_batch_var);
-            noc_async_read_tile(tile_offset, batch_var, l1_batch_var_write_addr);
-            noc_async_read_barrier();
+            cb_id_batch_var_obj.reserve_back(onetile);
+            noc.async_read(
+                batch_var, cb_id_batch_var_obj, batch_var_tile_bytes, {.page_id = tile_offset}, {.offset_bytes = 0});
+            noc.async_read_barrier();
             FILL_TILE_WITH_FIRST_ELEMENT(cb_id_batch_var);
-            cb_push_back(cb_id_batch_var, onetile);
+            cb_id_batch_var_obj.push_back(onetile);
 
             if constexpr (weight_has_value) {  // read a tile from weight tensor
-                cb_reserve_back(cb_id_weight, onetile);
-                uint32_t l1_weight_write_addr = get_write_ptr(cb_id_weight);
-                noc_async_read_tile(tile_offset, weight, l1_weight_write_addr);
-                noc_async_read_barrier();
+                cb_id_weight_obj.reserve_back(onetile);
+                noc.async_read(
+                    weight, cb_id_weight_obj, weight_tile_bytes, {.page_id = tile_offset}, {.offset_bytes = 0});
+                noc.async_read_barrier();
                 FILL_TILE_WITH_FIRST_ELEMENT(cb_id_weight);
-                cb_push_back(cb_id_weight, onetile);
+                cb_id_weight_obj.push_back(onetile);
             }
 
             if constexpr (bias_has_value) {  // read a tile from bias tensor
-                cb_reserve_back(cb_id_bias, onetile);
-                uint32_t l1_bias_write_addr = get_write_ptr(cb_id_bias);
-                noc_async_read_tile(tile_offset, bias, l1_bias_write_addr);
-                noc_async_read_barrier();
+                cb_id_bias_obj.reserve_back(onetile);
+                noc.async_read(bias, cb_id_bias_obj, bias_tile_bytes, {.page_id = tile_offset}, {.offset_bytes = 0});
+                noc.async_read_barrier();
                 FILL_TILE_WITH_FIRST_ELEMENT(cb_id_bias);
-                cb_push_back(cb_id_bias, onetile);
+                cb_id_bias_obj.push_back(onetile);
             }
 
             for (uint32_t t = start_t; t < HtWt && num_tiles_written < num_tiles; ++t, ++num_tiles_written) {
                 // write a tile to dst
-                cb_wait_front(cb_id_dst, onetile);
-                uint32_t l1_read_addr = get_read_ptr(cb_id_dst);
-                noc_async_write_tile(start_tile_id + num_tiles_written, dst, l1_read_addr);
-                noc_async_write_barrier();
-                cb_pop_front(cb_id_dst, onetile);
+                cb_id_dst_obj.wait_front(onetile);
+                noc.async_write(
+                    cb_id_dst_obj,
+                    dst,
+                    dst_tile_bytes,
+                    {.offset_bytes = 0},
+                    {.page_id = start_tile_id + num_tiles_written});
+                noc.async_write_barrier();
+                cb_id_dst_obj.pop_front(onetile);
             }
             tile_offset += c_stride;
         }

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_running_statistics.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_running_statistics.cpp
@@ -6,6 +6,9 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 
 void kernel_main() {
     uint32_t src_addr = get_arg_val<uint32_t>(0);               // batch_var
@@ -48,6 +51,14 @@ void kernel_main() {
     const uint32_t old_running_var_tile_bytes = get_tile_size(cb_id_old_running_var);
     const auto old_running_var = TensorAccessor(old_running_var_args, old_running_var_addr, old_running_var_tile_bytes);
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_id_src_obj(cb_id_src);
+    experimental::CircularBuffer cb_id_dst_obj(cb_id_dst);
+    experimental::CircularBuffer cb_id_old_running_mean_obj(cb_id_old_running_mean);
+    experimental::CircularBuffer cb_id_old_running_var_obj(cb_id_old_running_var);
+    experimental::CircularBuffer cb_id_updated_running_mean_obj(cb_id_updated_running_mean);
+    experimental::CircularBuffer cb_id_updated_running_var_obj(cb_id_updated_running_var);
+
     uint32_t tiles_per_batch = HtWt * C;
     uint32_t start_n = start_tile_id / tiles_per_batch;
     uint32_t start_remaining = start_tile_id % tiles_per_batch;
@@ -64,53 +75,72 @@ void kernel_main() {
         for (uint32_t c = start_c; c < C && num_tiles_written < num_tiles; ++c, start_t = 0) {
             for (uint32_t t = start_t; t < HtWt && num_tiles_written < num_tiles; ++t, ++num_tiles_written) {
                 // read a tile from src
-                cb_reserve_back(cb_id_src, onetile);
-                uint32_t l1_write_addr = get_write_ptr(cb_id_src);
-                noc_async_read_tile(tile_offset, src, l1_write_addr);
-                noc_async_read_barrier();
-                cb_push_back(cb_id_src, onetile);
+                cb_id_src_obj.reserve_back(onetile);
+                noc.async_read(src, cb_id_src_obj, src_tile_bytes, {.page_id = tile_offset}, {.offset_bytes = 0});
+                noc.async_read_barrier();
+                cb_id_src_obj.push_back(onetile);
 
                 if constexpr (old_running_mean_has_value) {
                     // read data
-                    cb_reserve_back(cb_id_old_running_mean, onetile);
-                    uint32_t l1_old_running_mean_write_addr = get_write_ptr(cb_id_old_running_mean);
-                    noc_async_read_tile(tile_offset, old_running_mean, l1_old_running_mean_write_addr);
-                    noc_async_read_barrier();
+                    cb_id_old_running_mean_obj.reserve_back(onetile);
+                    noc.async_read(
+                        old_running_mean,
+                        cb_id_old_running_mean_obj,
+                        old_running_mean_tile_bytes,
+                        {.page_id = tile_offset},
+                        {.offset_bytes = 0});
+                    noc.async_read_barrier();
                     FILL_TILE_WITH_FIRST_ELEMENT(cb_id_old_running_mean);
-                    cb_push_back(cb_id_old_running_mean, onetile);
+                    cb_id_old_running_mean_obj.push_back(onetile);
 
                     // write data
-                    cb_wait_front(cb_id_updated_running_mean, onetile);
-                    uint32_t l1_write_updated_mean_addr = get_read_ptr(cb_id_updated_running_mean);
-                    noc_async_write_tile(tile_offset, old_running_mean, l1_write_updated_mean_addr);
-                    noc_async_write_barrier();
-                    cb_pop_front(cb_id_updated_running_mean, onetile);
+                    cb_id_updated_running_mean_obj.wait_front(onetile);
+                    noc.async_write(
+                        cb_id_updated_running_mean_obj,
+                        old_running_mean,
+                        old_running_mean_tile_bytes,
+                        {.offset_bytes = 0},
+                        {.page_id = tile_offset});
+                    noc.async_write_barrier();
+                    cb_id_updated_running_mean_obj.pop_front(onetile);
                 }
 
                 if constexpr (old_running_var_has_value) {
                     // read data
-                    cb_reserve_back(cb_id_old_running_var, onetile);
-                    uint32_t l1_old_running_var_write_addr = get_write_ptr(cb_id_old_running_var);
-                    noc_async_read_tile(tile_offset, old_running_var, l1_old_running_var_write_addr);
-                    noc_async_read_barrier();
+                    cb_id_old_running_var_obj.reserve_back(onetile);
+                    noc.async_read(
+                        old_running_var,
+                        cb_id_old_running_var_obj,
+                        old_running_var_tile_bytes,
+                        {.page_id = tile_offset},
+                        {.offset_bytes = 0});
+                    noc.async_read_barrier();
                     FILL_TILE_WITH_FIRST_ELEMENT(cb_id_old_running_var);
-                    cb_push_back(cb_id_old_running_var, onetile);
+                    cb_id_old_running_var_obj.push_back(onetile);
 
                     // write data
-                    cb_wait_front(cb_id_updated_running_var, onetile);
-                    uint32_t l1_write_updated_var_addr = get_read_ptr(cb_id_updated_running_var);
-                    noc_async_write_tile(tile_offset, old_running_var, l1_write_updated_var_addr);
-                    noc_async_write_barrier();
-                    cb_pop_front(cb_id_updated_running_var, onetile);
+                    cb_id_updated_running_var_obj.wait_front(onetile);
+                    noc.async_write(
+                        cb_id_updated_running_var_obj,
+                        old_running_var,
+                        old_running_var_tile_bytes,
+                        {.offset_bytes = 0},
+                        {.page_id = tile_offset});
+                    noc.async_write_barrier();
+                    cb_id_updated_running_var_obj.pop_front(onetile);
                 }
                 ++tile_offset;
 
                 // write a tile to dst, since the dst shape is full, the tile offset simply grows linearly
-                cb_wait_front(cb_id_dst, onetile);
-                uint32_t l1_read_addr = get_read_ptr(cb_id_dst);
-                noc_async_write_tile(start_tile_id + num_tiles_written, dst, l1_read_addr);
-                noc_async_write_barrier();
-                cb_pop_front(cb_id_dst, onetile);
+                cb_id_dst_obj.wait_front(onetile);
+                noc.async_write(
+                    cb_id_dst_obj,
+                    dst,
+                    dst_tile_bytes,
+                    {.offset_bytes = 0},
+                    {.page_id = start_tile_id + num_tiles_written});
+                noc.async_write_barrier();
+                cb_id_dst_obj.pop_front(onetile);
             }
             tile_offset += next_channel_shift;
         }

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax.cpp
@@ -12,6 +12,7 @@
 #include "api/compute/bcast.h"
 #include "api/compute/softmax.h"
 #include "api/compute/reduce.h"
+#include "experimental/circular_buffer.h"
 
 // for scale+mask+softmax:
 // bcast HW (mul by 1 tile)  example: (  [2,1,1024,64] * [1,1,32,32]  )
@@ -22,14 +23,19 @@
 
 void calc_numeric_stable(
     uint32_t Wt, uint32_t ndst, uint32_t cb_in, uint32_t cb_bcast_scaler, uint32_t cb_max, uint32_t cb_out) {
+    experimental::CircularBuffer cb_in_obj(cb_in);
+    experimental::CircularBuffer cb_bcast_scaler_obj(cb_bcast_scaler);
+    experimental::CircularBuffer cb_max_obj(cb_max);
+    experimental::CircularBuffer cb_out_obj(cb_out);
+
     // calculate max val per row
     tile_regs_acquire();
     reconfig_data_format(cb_in, cb_bcast_scaler);
-    cb_reserve_back(cb_max, 1);
-    cb_wait_front(cb_bcast_scaler, 1);
+    cb_max_obj.reserve_back(1);
+    cb_bcast_scaler_obj.wait_front(1);
     reduce_init<PoolType::MAX, ReduceDim::REDUCE_ROW, ENABLE_FP32_DEST_ACC>(cb_in, cb_bcast_scaler, cb_max);
     for (uint32_t wt = 0; wt < Wt; wt++) {
-        cb_wait_front(cb_in, wt + 1);
+        cb_in_obj.wait_front(wt + 1);
         constexpr uint32_t bcast_scaler0 = 0;
         reduce_tile<PoolType::MAX, ReduceDim::REDUCE_ROW, ENABLE_FP32_DEST_ACC>(
             cb_in, cb_bcast_scaler, wt, bcast_scaler0, 0);
@@ -39,19 +45,19 @@ void calc_numeric_stable(
     tile_regs_wait();
     pack_tile(0, cb_max);
     tile_regs_release();
-    cb_push_back(cb_max, 1);
+    cb_max_obj.push_back(1);
 
     // calculate x-max(x)
     exp_tile_init<EXP_APPROX>();
     reconfig_data_format_srcb(cb_max);
-    cb_wait_front(cb_max, 1);
+    cb_max_obj.wait_front(1);
     sub_bcast_cols_init_short(cb_in, cb_max);
     for (uint32_t wt = 0; wt < Wt; wt += ndst) {
         tile_regs_acquire();
         for (uint32_t wt8 = 0; wt8 < ndst; wt8++) {
             sub_tiles_bcast_cols(cb_in, cb_max, wt + wt8, 0, wt8);
         }
-        cb_reserve_back(cb_out, ndst);
+        cb_out_obj.reserve_back(ndst);
         for (uint32_t wt8 = 0; wt8 < ndst; wt8++) {
             exp_tile<EXP_APPROX>(wt8);  // exp on DST[0]
         }
@@ -61,11 +67,11 @@ void calc_numeric_stable(
             pack_tile(wt8, cb_out);     // reuse the exps buffer again, this time in a circular manner
         }
         tile_regs_release();
-        cb_push_back(cb_out, ndst);
+        cb_out_obj.push_back(ndst);
     }
-    cb_pop_front(cb_in, Wt);
-    cb_pop_front(cb_max, 1);
-    cb_wait_front(cb_out, Wt);
+    cb_in_obj.pop_front(Wt);
+    cb_max_obj.pop_front(1);
+    cb_out_obj.wait_front(Wt);
 }
 
 void kernel_main() {
@@ -91,17 +97,28 @@ void kernel_main() {
     constexpr auto cb_recipsumexps = tt::CBIndex::c_7;
     constexpr auto cb_in0 = tt::CBIndex::c_0;
     constexpr auto cb_out0 = tt::CBIndex::c_11;
+    experimental::CircularBuffer cb_bcast_scaler_obj(cb_bcast_scaler);
+    experimental::CircularBuffer cb_fused_scale_obj(cb_fused_scale);
+    experimental::CircularBuffer cb_fused_attn_obj(cb_fused_attn);
+    experimental::CircularBuffer cb_mask_padded_obj(cb_mask_padded);
+    experimental::CircularBuffer cb_exps_obj(cb_exps);
+    experimental::CircularBuffer cb_scale_mask_obj(cb_scale_mask);
+    experimental::CircularBuffer cb_recipsumexps_obj(cb_recipsumexps);
+    experimental::CircularBuffer cb_in0_obj(cb_in0);
+    experimental::CircularBuffer cb_out0_obj(cb_out0);
 #ifdef NUMERIC_STABLE
     constexpr auto cb_max = tt::CBIndex::c_8;
     constexpr auto cb_x = tt::CBIndex::c_10;
+    experimental::CircularBuffer cb_max_obj(cb_max);
 #else
     constexpr auto cb_x = cb_exps;
 #endif
+    experimental::CircularBuffer cb_x_obj(cb_x);
 
-    cb_wait_front(cb_bcast_scaler, 1);  // comes from the reader
+    cb_bcast_scaler_obj.wait_front(1);  // comes from the reader
 
 #if FUSED_SCALE_MASK
-    cb_wait_front(cb_fused_scale, 1);
+    cb_fused_scale_obj.wait_front(1);
 #endif
 
     constexpr int dst0 = 0;
@@ -115,8 +132,8 @@ void kernel_main() {
         for (uint32_t wt = 0; wt < Wt; wt += ndst) {
             // apply fused scale [*= 1/sqrt(...)]
             tile_regs_acquire();
-            cb_wait_front(cb_in0, ndst);
-            cb_reserve_back(cb_scale_mask, ndst);
+            cb_in0_obj.wait_front(ndst);
+            cb_scale_mask_obj.reserve_back(ndst);
             for (uint32_t wt8 = 0; wt8 < ndst; wt8++) {
                 mul_tiles_bcast_scalar(cb_in0, cb_fused_scale, wt8, 0, wt8);  // mul bcast-HW -> DST[wt8]
             }
@@ -126,8 +143,8 @@ void kernel_main() {
                 pack_tile(wt8, cb_scale_mask);                                // reuse exps buffer
             }
             tile_regs_release();
-            cb_push_back(cb_scale_mask, ndst);
-            cb_pop_front(cb_in0, ndst);
+            cb_scale_mask_obj.push_back(ndst);
+            cb_in0_obj.pop_front(ndst);
         }
         reconfig_data_format(cb_scale_mask, cb_fused_attn);
 
@@ -142,23 +159,23 @@ void kernel_main() {
 #endif
         for (uint32_t wt = 0; wt < Wt; wt += ndst) {
             tile_regs_acquire();
-            cb_wait_front(cb_scale_mask, ndst);
+            cb_scale_mask_obj.wait_front(ndst);
 #ifdef CAUSAL_MASK
-            cb_wait_front(cb_fused_attn, wt + ndst);  // cumulative wait for up to Wt tiles
+            cb_fused_attn_obj.wait_front(wt + ndst);  // cumulative wait for up to Wt tiles
             for (uint32_t wt8 = 0; wt8 < ndst; wt8++) {
                 add_tiles(cb_scale_mask, cb_fused_attn, wt8, wt + wt8, wt8);  // tile *= 1/(sum(exp(x)))
             }
 #else
             if (wait_mask) {
-                cb_wait_front(cb_fused_attn, wt + ndst);  // cumulative wait for up to Wt tiles, only at first ht
+                cb_fused_attn_obj.wait_front(wt + ndst);  // cumulative wait for up to Wt tiles, only at first ht
             }
 
             for (uint32_t wt8 = 0; wt8 < ndst; wt8++) {
                 add_tiles_bcast_rows(cb_scale_mask, cb_fused_attn, wt8, wt + wt8, wt8);  // tile *= 1/(sum(exp(x)))
             }
 #endif
-            cb_pop_front(cb_scale_mask, ndst);
-            cb_reserve_back(cb_x, ndst);
+            cb_scale_mask_obj.pop_front(ndst);
+            cb_x_obj.reserve_back(ndst);
 #ifndef NUMERIC_STABLE
             for (uint32_t wt8 = 0; wt8 < ndst; wt8++) {
                 exp_tile<EXP_APPROX>(wt8);  // exp on DST[0]
@@ -170,7 +187,7 @@ void kernel_main() {
                 pack_tile(wt8, cb_x);  // reuse the exps buffer again, this time in a circular manner
             }
             tile_regs_release();
-            cb_push_back(cb_x, ndst);
+            cb_x_obj.push_back(ndst);
         }
 
 // add numeric_stable
@@ -180,14 +197,14 @@ void kernel_main() {
 #endif
 
 #ifdef CAUSAL_MASK
-        cb_pop_front(cb_fused_attn, Wt);
+        cb_fused_attn_obj.pop_front(Wt);
 #else
         if (wait_mask) {
             wait_mask = false;
         }
         ht++;
         if (ht == Ht) {
-            cb_pop_front(cb_fused_attn, Wt);
+            cb_fused_attn_obj.pop_front(Wt);
             ht = 0;
             wait_mask = true;
         }
@@ -204,20 +221,20 @@ void kernel_main() {
         if (mask_padded_data) {
             for (uint32_t wt = 0; wt < Wt; wt += ndst) {
                 tile_regs_acquire();
-                cb_wait_front(cb_in0, ndst);
+                cb_in0_obj.wait_front(ndst);
                 for (uint32_t wt8 = 0; wt8 < ndst; ++wt8) {
                     if (wt == (Wt - ndst) && (wt8 == ndst - 1)) {
                         reconfig_data_format(cb_in0, cb_mask_padded);
                         add_bcast_rows_init_short(cb_in0, cb_mask_padded);
-                        cb_wait_front(cb_mask_padded, 1);
+                        cb_mask_padded_obj.wait_front(1);
                         add_tiles_bcast_rows(cb_in0, cb_mask_padded, wt8, 0, wt8);
                     } else {
                         copy_tile(cb_in0, wt8, wt8);  // copy from c_in[0] to DST[0]
                     }
                 }
-                cb_pop_front(cb_in0, ndst);
+                cb_in0_obj.pop_front(ndst);
 
-                cb_reserve_back(cb_x, ndst);
+                cb_x_obj.reserve_back(ndst);
 #ifndef NUMERIC_STABLE
                 for (uint32_t wt8 = 0; wt8 < ndst; ++wt8) {
                     exp_tile<EXP_APPROX>(wt8);  // exp on DST[0]
@@ -229,7 +246,7 @@ void kernel_main() {
                     pack_tile(wt8, cb_x);  // DST[0]->cb_id[wt]
                 }
                 tile_regs_release();
-                cb_push_back(cb_x, ndst);
+                cb_x_obj.push_back(ndst);
             }
 
 // add numeric_stable
@@ -246,13 +263,13 @@ void kernel_main() {
 #else
             for (uint32_t wt = 0; wt < Wt; wt += ndst) {
                 tile_regs_acquire();
-                cb_wait_front(cb_in0, ndst);
+                cb_in0_obj.wait_front(ndst);
                 for (uint32_t wt8 = 0; wt8 < ndst; ++wt8) {
                     copy_tile(cb_in0, wt8, wt8);  // copy from c_in[0] to DST[0]
                 }
-                cb_pop_front(cb_in0, ndst);
+                cb_in0_obj.pop_front(ndst);
 
-                cb_reserve_back(cb_exps, ndst);
+                cb_exps_obj.reserve_back(ndst);
                 for (uint32_t wt8 = 0; wt8 < ndst; ++wt8) {
                     exp_tile<EXP_APPROX>(wt8);  // exp on DST[0]
                 }
@@ -262,7 +279,7 @@ void kernel_main() {
                     pack_tile(wt8, cb_exps);    // DST[0]->cb_id[wt]
                 }
                 tile_regs_release();
-                cb_push_back(cb_exps, ndst);
+                cb_exps_obj.push_back(ndst);
             }
 #endif
         }
@@ -271,11 +288,11 @@ void kernel_main() {
 #endif
 
         tile_regs_acquire();
-        cb_reserve_back(cb_recipsumexps, onetile);
+        cb_recipsumexps_obj.reserve_back(onetile);
         reduce_init<REDUCE_OP, REDUCE_DIM, ENABLE_FP32_DEST_ACC>(cb_exps, cb_bcast_scaler, cb_recipsumexps);
 
         for (uint32_t wt = 0; wt < Wt; wt++) {
-            cb_wait_front(cb_exps, wt + 1);        // must be a cumulative wait for correctness
+            cb_exps_obj.wait_front(wt + 1);        // must be a cumulative wait for correctness
             constexpr uint32_t bcast_scaler0 = 0;  // 0th index from bcast_scaler CB
             reduce_tile<REDUCE_OP, REDUCE_DIM, ENABLE_FP32_DEST_ACC>(
                 /*iCB=*/cb_exps,
@@ -291,9 +308,9 @@ void kernel_main() {
         tile_regs_wait();
         pack_tile(dst0, cb_recipsumexps);
         tile_regs_release();
-        cb_push_back(cb_recipsumexps, 1);
+        cb_recipsumexps_obj.push_back(1);
 
-        cb_wait_front(cb_recipsumexps, 1);  // will reuse Wt times for bcast
+        cb_recipsumexps_obj.wait_front(1);  // will reuse Wt times for bcast
 
         reconfig_data_format(cb_exps, cb_recipsumexps);
         pack_reconfig_data_format(cb_out0);
@@ -302,7 +319,7 @@ void kernel_main() {
         mul_bcast_cols_init_short(cb_exps, cb_recipsumexps);
         for (uint32_t wt = 0; wt < Wt; wt += ndst) {
             tile_regs_acquire();
-            cb_reserve_back(cb_out0, ndst);
+            cb_out0_obj.reserve_back(ndst);
             for (uint32_t wt8 = 0; wt8 < ndst; wt8++) {
                 // wt+wt8 since we pop Wt after the entire loop
                 mul_tiles_bcast<BroadcastType::COL>(
@@ -314,10 +331,10 @@ void kernel_main() {
                 pack_tile(wt8, cb_out0);
             }
             tile_regs_release();
-            cb_push_back(cb_out0, ndst);
+            cb_out0_obj.push_back(ndst);
         }
-        cb_pop_front(cb_recipsumexps, 1);
-        cb_pop_front(cb_exps, Wt);
+        cb_recipsumexps_obj.pop_front(1);
+        cb_exps_obj.pop_front(Wt);
     }  // NCHt loop
     // cb_pop_front(cb_bcast_scaler, 1); // we don't actually have to do this
     // cb_pop_front(cb_fused_scale, 1); // we don't actually have to do this

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax_large_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax_large_tensor.cpp
@@ -364,11 +364,9 @@ void kernel_main() {
     experimental::CircularBuffer cb_fused_attn_obj(cb_fused_attn);
     experimental::CircularBuffer cb_exps_obj(cb_exps);
     experimental::CircularBuffer cb_scale_mask_obj(cb_scale_mask);
-    experimental::CircularBuffer cb_sumexps_obj(cb_sumexps);
     experimental::CircularBuffer cb_prev_reduce_obj(cb_prev_reduce);
     experimental::CircularBuffer cb_in0_obj(cb_in0);
     experimental::CircularBuffer cb_out0_obj(cb_out0);
-    experimental::CircularBuffer cb_max_obj(cb_max);
     experimental::CircularBuffer cb_x_obj(cb_x);
     experimental::CircularBuffer cb_recip_obj(cb_recip);
     experimental::CircularBuffer cb_prev_max_obj(cb_prev_max);
@@ -432,7 +430,7 @@ void kernel_main() {
         cur_cb_length_t = cb_length_t;
 #endif
 #ifdef NUMERIC_STABLE
-        cb_max_obj.wait_front(1);
+        experimental::CircularBuffer(cb_max).wait_front(1);
 #endif
 
         /*
@@ -479,7 +477,7 @@ void kernel_main() {
          * --------------------------------------------------------
          * --------------------------------------------------------
          */
-        cb_sumexps_obj.wait_front(1);
+        experimental::CircularBuffer(cb_sumexps).wait_front(1);
 
         reconfig_data_format_srca(cb_sumexps);
         pack_reconfig_data_format(cb_sumexps, cb_recip);
@@ -487,7 +485,7 @@ void kernel_main() {
         copy_tile_init(cb_sumexps);
         copy_tile(cb_sumexps, 0, dst0);
 
-        cb_sumexps_obj.pop_front(1);
+        experimental::CircularBuffer(cb_sumexps).pop_front(1);
 
         recip_tile_init();
         recip_tile(dst0);
@@ -535,7 +533,7 @@ void kernel_main() {
         }
         cb_recip_obj.pop_front(1);
 #ifdef NUMERIC_STABLE
-        cb_max_obj.pop_front(1);
+        experimental::CircularBuffer(cb_max).pop_front(1);
 #endif
     }
     cb_mask_padded_obj.pop_front(1);

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax_large_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax_large_tensor.cpp
@@ -361,15 +361,7 @@ void kernel_main() {
     constexpr auto cb_mask_padded = tt::CBIndex::c_5;
     experimental::CircularBuffer cb_scaler_obj(cb_scaler);
     experimental::CircularBuffer cb_fused_scale_obj(cb_fused_scale);
-    experimental::CircularBuffer cb_fused_attn_obj(cb_fused_attn);
-    experimental::CircularBuffer cb_exps_obj(cb_exps);
-    experimental::CircularBuffer cb_scale_mask_obj(cb_scale_mask);
-    experimental::CircularBuffer cb_prev_reduce_obj(cb_prev_reduce);
-    experimental::CircularBuffer cb_in0_obj(cb_in0);
-    experimental::CircularBuffer cb_out0_obj(cb_out0);
-    experimental::CircularBuffer cb_x_obj(cb_x);
     experimental::CircularBuffer cb_recip_obj(cb_recip);
-    experimental::CircularBuffer cb_prev_max_obj(cb_prev_max);
     experimental::CircularBuffer cb_mask_padded_obj(cb_mask_padded);
     binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_6);
     init_sfpu(cb_mask_padded, cb_mask_padded);

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax_large_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax_large_tensor.cpp
@@ -19,6 +19,7 @@
 #include "api/compute/compute_kernel_api.h"
 
 #include "api/debug/assert.h"
+#include "experimental/circular_buffer.h"
 
 // clang-format off
 // 3 Loops in code
@@ -82,6 +83,8 @@ void apply_fused_scale_mask(
     // Requirements:
     //   cb_length_t of cb_in and cb_out are the same.
     //   blk is a divisor of cb_length_t
+    experimental::CircularBuffer cb_in_obj(cb_in);
+    experimental::CircularBuffer cb_out_obj(cb_out);
     reconfig_data_format(cb_in, cb_fused_scale_mask);
     pack_reconfig_data_format(cb_out);
     mul_tiles_bcast_scalar_init_short(cb_in, cb_fused_scale_mask);
@@ -90,8 +93,8 @@ void apply_fused_scale_mask(
             blk = cb_length_t- cur_blk;
         }
         tile_regs_acquire();
-        cb_wait_front(cb_in, blk);
-        cb_reserve_back(cb_out, blk);
+        cb_in_obj.wait_front(blk);
+        cb_out_obj.reserve_back(blk);
         if (cb_length_t - cur_blk < blk) {
             blk = cb_length_t - cur_blk;
         }
@@ -103,14 +106,18 @@ void apply_fused_scale_mask(
         for (uint32_t cur_dst = 0; cur_dst < blk; cur_dst++) {
             pack_tile(cur_dst, cb_out);
         }
-        cb_push_back(cb_out, blk);
-        cb_pop_front(cb_in, blk);
+        cb_out_obj.push_back(blk);
+        cb_in_obj.pop_front(blk);
         tile_regs_release();
     }
 }
 void apply_fused_attn_mask(
     uint32_t cb_in, uint32_t cb_fused_attn_mask, uint32_t cb_out, uint32_t cb_length_t, uint32_t blk, bool do_mask) {
     auto cb_mask_padded = tt::CBIndex::c_5;
+    experimental::CircularBuffer cb_in_obj(cb_in);
+    experimental::CircularBuffer cb_fused_attn_mask_obj(cb_fused_attn_mask);
+    experimental::CircularBuffer cb_out_obj(cb_out);
+    experimental::CircularBuffer cb_mask_padded_obj(cb_mask_padded);
     reconfig_data_format(cb_in, cb_fused_attn_mask);
     pack_reconfig_data_format(cb_out);
 #ifdef CAUSAL_MASK
@@ -124,9 +131,9 @@ void apply_fused_attn_mask(
             blk = cb_length_t- cur_blk;
         }
         tile_regs_wait();
-        cb_wait_front(cb_in, blk);
-        cb_wait_front(cb_fused_attn_mask, blk);  // cumulative wait for up to wt tiles
-        cb_reserve_back(cb_out, blk);
+        cb_in_obj.wait_front(blk);
+        cb_fused_attn_mask_obj.wait_front(blk);  // cumulative wait for up to wt tiles
+        cb_out_obj.reserve_back(blk);
         if (cb_length_t - cur_blk < blk) {
             blk = cb_length_t - cur_blk;
         }
@@ -143,16 +150,16 @@ void apply_fused_attn_mask(
             // add mask to the last register to pad with -inf
             reconfig_data_format_srca(cb_mask_padded);
             binary_dest_reuse_tiles_init<ELWADD, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(cb_mask_padded);
-            cb_wait_front(cb_mask_padded, 1);
+            cb_mask_padded_obj.wait_front(1);
             binary_dest_reuse_tiles<ELWADD, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(cb_mask_padded, 0, blk - 1);
         }
         tile_regs_commit();
         for (uint32_t cur_dst = 0; cur_dst < blk; cur_dst++) {
             pack_tile(cur_dst, cb_out);
         }
-        cb_push_back(cb_out, blk);
-        cb_pop_front(cb_in, blk);
-        cb_pop_front(cb_fused_attn_mask, blk);
+        cb_out_obj.push_back(blk);
+        cb_in_obj.pop_front(blk);
+        cb_fused_attn_mask_obj.pop_front(blk);
         tile_regs_release();
     }
 }
@@ -160,20 +167,23 @@ void apply_fused_attn_mask(
 // applies pad to the last pass cb if needed
 void pad_input(uint32_t cb_in, uint32_t cb_out, uint32_t cb_length_t, uint32_t blk) {
     auto cb_mask_padded = tt::CBIndex::c_5;
+    experimental::CircularBuffer cb_in_obj(cb_in);
+    experimental::CircularBuffer cb_out_obj(cb_out);
+    experimental::CircularBuffer cb_mask_padded_obj(cb_mask_padded);
     reconfig_data_format(cb_in, cb_mask_padded);
     pack_reconfig_data_format(cb_out);
     copy_tile_init(cb_in);  // need to copy from CB to DST to be able to run sfpu math
     for (uint32_t cur_blk = 0; cur_blk < cb_length_t; cur_blk += blk) {
         tile_regs_acquire();
-        cb_wait_front(cb_in, blk);
-        cb_reserve_back(cb_out, blk);
+        cb_in_obj.wait_front(blk);
+        cb_out_obj.reserve_back(blk);
         if (cb_length_t - cur_blk < blk) {
             blk = cb_length_t - cur_blk;
         }
         for (uint32_t cur_dst = 0; cur_dst < blk; cur_dst++) {
             if (cur_dst == blk - 1 && cur_blk == cb_length_t - blk) {
                 add_tiles_init(cb_in, cb_mask_padded);
-                cb_wait_front(cb_mask_padded, 1);
+                cb_mask_padded_obj.wait_front(1);
                 add_tiles(cb_in, cb_mask_padded, cur_dst, 0, cur_dst);
             } else {
                 copy_tile(cb_in, cur_dst, cur_dst);
@@ -184,8 +194,8 @@ void pad_input(uint32_t cb_in, uint32_t cb_out, uint32_t cb_length_t, uint32_t b
         for (uint32_t cur_dst = 0; cur_dst < blk; cur_dst++) {
             pack_tile(cur_dst, cb_out);
         }
-        cb_push_back(cb_out, blk);
-        cb_pop_front(cb_in, blk);
+        cb_out_obj.push_back(blk);
+        cb_in_obj.pop_front(blk);
         tile_regs_release();
     }
 }
@@ -198,6 +208,8 @@ void exp_cb(uint32_t cb_in, uint32_t cb_out, uint32_t cb_max, const uint32_t cb_
     //      Also if numeric stable calcs e^(cb_in- BCASTCOL(cb_max))
     ASSERT(cb_length_t % blk == 0);
 
+    experimental::CircularBuffer cb_in_obj(cb_in);
+    experimental::CircularBuffer cb_out_obj(cb_out);
     reconfig_data_format_srca(cb_in);
     pack_reconfig_data_format(cb_out);
 #ifdef NUMERIC_STABLE
@@ -212,8 +224,8 @@ void exp_cb(uint32_t cb_in, uint32_t cb_out, uint32_t cb_max, const uint32_t cb_
         if (cb_length_t - cur_blk < blk) {
             blk = cb_length_t - cur_blk;
         }
-        cb_wait_front(cb_in, blk);
-        cb_reserve_back(cb_out, blk);
+        cb_in_obj.wait_front(blk);
+        cb_out_obj.reserve_back(blk);
         tile_regs_acquire();
 #ifdef NUMERIC_STABLE
         for (uint32_t cur_dst = 0; cur_dst < blk; cur_dst++) {
@@ -224,7 +236,7 @@ void exp_cb(uint32_t cb_in, uint32_t cb_out, uint32_t cb_max, const uint32_t cb_
             copy_tile(cb_in, cur_dst, cur_dst);
         }
 #endif
-        cb_pop_front(cb_in, blk);
+        cb_in_obj.pop_front(blk);
         for (uint32_t cur_dst = 0; cur_dst < blk; cur_dst++) {
             exp_tile<EXP_APPROX>(cur_dst);  // exp on DST[0]
         }
@@ -233,7 +245,7 @@ void exp_cb(uint32_t cb_in, uint32_t cb_out, uint32_t cb_max, const uint32_t cb_
         for (uint32_t cur_dst = 0; cur_dst < blk; cur_dst++) {
             pack_tile(cur_dst, cb_out);
         }
-        cb_push_back(cb_out, blk);
+        cb_out_obj.push_back(blk);
         tile_regs_release();
     }
 }
@@ -251,20 +263,23 @@ void reduce_cb(
     //   len(Data) fed into cb_in, does not need all at once== cb_length_t
     //   len(cb_out) == 1
 
+    experimental::CircularBuffer cb_in_obj(cb_in);
+    experimental::CircularBuffer cb_prev_out_obj(cb_prev_out);
+    experimental::CircularBuffer cb_out_obj(cb_out);
     reconfig_data_format(cb_in, cb_scaler);
     pack_reconfig_data_format(cb_out);
     reduce_init<reduce_type, REDUCE_DIM, ENABLE_FP32_DEST_ACC>(cb_in, cb_scaler, cb_out);
     tile_regs_acquire();
-    cb_reserve_back(cb_out, 1);
+    cb_out_obj.reserve_back(1);
     for (uint32_t cur_tile = 0; cur_tile < cb_length_t; cur_tile++) {
-        cb_wait_front(cb_in, 1);
+        cb_in_obj.wait_front(1);
         reduce_tile<reduce_type, REDUCE_DIM, ENABLE_FP32_DEST_ACC>(cb_in, cb_scaler, 0, 0, 0);
-        cb_pop_front(cb_in, 1);
+        cb_in_obj.pop_front(1);
     }
 
     if (use_prev_reduce) {
         reconfig_data_format_srca(cb_prev_out);
-        cb_wait_front(cb_prev_out, 1);
+        cb_prev_out_obj.wait_front(1);
         copy_tile_init(cb_prev_out);
         copy_tile(cb_prev_out, 0, 1);
         if (reduce_type == PoolType::MAX) {
@@ -278,22 +293,25 @@ void reduce_cb(
             add_binary_tile_init();
             add_binary_tile(0, 1, 0);
         }
-        cb_pop_front(cb_prev_out, 1);
+        cb_prev_out_obj.pop_front(1);
     }
     tile_regs_wait();
     tile_regs_commit();
     pack_tile(0, cb_out);
-    cb_push_back(cb_out, 1);
+    cb_out_obj.push_back(1);
     tile_regs_release();
     reduce_uninit();
 }
 void apply_recip(uint32_t cb_in, uint32_t cb_recip, uint32_t cb_out, uint32_t cb_length_t, uint32_t blk) {
+    experimental::CircularBuffer cb_in_obj(cb_in);
+    experimental::CircularBuffer cb_recip_obj(cb_recip);
+    experimental::CircularBuffer cb_out_obj(cb_out);
     reconfig_data_format(cb_in, cb_recip);
     pack_reconfig_data_format(cb_out);
-    cb_wait_front(cb_recip, 1);
+    cb_recip_obj.wait_front(1);
     mul_bcast_cols_init_short(cb_in, cb_recip);
     for (uint32_t cur_blk = 0; cur_blk < cb_length_t; cur_blk += blk) {
-        cb_wait_front(cb_in, blk);
+        cb_in_obj.wait_front(blk);
         tile_regs_acquire();
         tile_regs_wait();
         if (cb_length_t - cur_blk < blk) {
@@ -303,12 +321,12 @@ void apply_recip(uint32_t cb_in, uint32_t cb_recip, uint32_t cb_out, uint32_t cb
             mul_tiles_bcast_cols(cb_in, cb_recip, cur_dst, 0, cur_dst);
         }
         tile_regs_commit();
-        cb_reserve_back(cb_out, blk);
+        cb_out_obj.reserve_back(blk);
         for (uint32_t cur_dst = 0; cur_dst < blk; cur_dst++) {
             pack_tile(cur_dst, cb_out);
         }
-        cb_pop_front(cb_in, blk);
-        cb_push_back(cb_out, blk);
+        cb_in_obj.pop_front(blk);
+        cb_out_obj.push_back(blk);
         tile_regs_release();
     }
 }
@@ -341,13 +359,27 @@ void kernel_main() {
     auto cb_recip = tt::CBIndex::c_16;
     auto cb_prev_max = tt::CBIndex::c_15;
     constexpr auto cb_mask_padded = tt::CBIndex::c_5;
+    experimental::CircularBuffer cb_scaler_obj(cb_scaler);
+    experimental::CircularBuffer cb_fused_scale_obj(cb_fused_scale);
+    experimental::CircularBuffer cb_fused_attn_obj(cb_fused_attn);
+    experimental::CircularBuffer cb_exps_obj(cb_exps);
+    experimental::CircularBuffer cb_scale_mask_obj(cb_scale_mask);
+    experimental::CircularBuffer cb_sumexps_obj(cb_sumexps);
+    experimental::CircularBuffer cb_prev_reduce_obj(cb_prev_reduce);
+    experimental::CircularBuffer cb_in0_obj(cb_in0);
+    experimental::CircularBuffer cb_out0_obj(cb_out0);
+    experimental::CircularBuffer cb_max_obj(cb_max);
+    experimental::CircularBuffer cb_x_obj(cb_x);
+    experimental::CircularBuffer cb_recip_obj(cb_recip);
+    experimental::CircularBuffer cb_prev_max_obj(cb_prev_max);
+    experimental::CircularBuffer cb_mask_padded_obj(cb_mask_padded);
     binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_6);
     init_sfpu(cb_mask_padded, cb_mask_padded);
 
-    cb_wait_front(tt::CBIndex::c_2, 1);  // comes from the reader
+    cb_scaler_obj.wait_front(1);  // comes from the reader
 
 #if FUSED_SCALE_MASK
-    cb_wait_front(cb_fused_scale, 1);
+    cb_fused_scale_obj.wait_front(1);
 #endif
 
     uint32_t num_cb_passes = 1 + ((Wt - 1) / cb_length_t);  // ceiling divide
@@ -400,7 +432,7 @@ void kernel_main() {
         cur_cb_length_t = cb_length_t;
 #endif
 #ifdef NUMERIC_STABLE
-        cb_wait_front(cb_max, 1);
+        cb_max_obj.wait_front(1);
 #endif
 
         /*
@@ -447,7 +479,7 @@ void kernel_main() {
          * --------------------------------------------------------
          * --------------------------------------------------------
          */
-        cb_wait_front(cb_sumexps, 1);
+        cb_sumexps_obj.wait_front(1);
 
         reconfig_data_format_srca(cb_sumexps);
         pack_reconfig_data_format(cb_sumexps, cb_recip);
@@ -455,7 +487,7 @@ void kernel_main() {
         copy_tile_init(cb_sumexps);
         copy_tile(cb_sumexps, 0, dst0);
 
-        cb_pop_front(cb_sumexps, 1);
+        cb_sumexps_obj.pop_front(1);
 
         recip_tile_init();
         recip_tile(dst0);
@@ -463,13 +495,13 @@ void kernel_main() {
         tile_regs_commit();
         tile_regs_wait();
 
-        cb_reserve_back(cb_recip, 1);
+        cb_recip_obj.reserve_back(1);
         pack_tile(dst0, cb_recip);
-        cb_push_back(cb_recip, 1);
+        cb_recip_obj.push_back(1);
 
         tile_regs_release();
 
-        cb_wait_front(cb_recip, 1);
+        cb_recip_obj.wait_front(1);
         /*
          * --------------------------------------------------------
          * --------------------------------------------------------
@@ -501,10 +533,10 @@ void kernel_main() {
             length_left_t -= cur_cb_length_t;
             cur_cb_length_t = std::min(cur_cb_length_t, length_left_t);
         }
-        cb_pop_front(cb_recip, 1);
+        cb_recip_obj.pop_front(1);
 #ifdef NUMERIC_STABLE
-        cb_pop_front(cb_max, 1);
+        cb_max_obj.pop_front(1);
 #endif
     }
-    cb_pop_front(cb_mask_padded, 1);
+    cb_mask_padded_obj.pop_front(1);
 }  // MAIN

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax_sharded.cpp
@@ -12,16 +12,22 @@
 #include "api/compute/bcast.h"
 #include "api/compute/softmax.h"
 #include "api/compute/reduce.h"
+#include "experimental/circular_buffer.h"
 
 template <uint32_t block_w, uint32_t num_subblocks_w, uint32_t subblock_w>
 ALWI void calc_numeric_stable(uint32_t cb_in, uint32_t cb_bcast_scaler, uint32_t cb_max, uint32_t cb_out) {
+    auto cb_in_obj = experimental::CircularBuffer(cb_in);
+    auto cb_bcast_scaler_obj = experimental::CircularBuffer(cb_bcast_scaler);
+    auto cb_max_obj = experimental::CircularBuffer(cb_max);
+    auto cb_out_obj = experimental::CircularBuffer(cb_out);
+
     // calculate max val per row
     tile_regs_acquire();
     reconfig_data_format(cb_in, cb_bcast_scaler);
     pack_reconfig_data_format(cb_max);
-    cb_reserve_back(cb_max, 1);
+    cb_max_obj.reserve_back(1);
     reduce_init<PoolType::MAX, ReduceDim::REDUCE_ROW, ENABLE_FP32_DEST_ACC>(cb_in, cb_bcast_scaler, cb_max);
-    cb_wait_front(cb_bcast_scaler, 1);
+    cb_bcast_scaler_obj.wait_front(1);
     for (uint32_t w = 0; w < block_w; w++) {
         constexpr uint32_t bcast_scaler0 = 0;
         reduce_tile<PoolType::MAX, ReduceDim::REDUCE_ROW, ENABLE_FP32_DEST_ACC>(
@@ -32,22 +38,22 @@ ALWI void calc_numeric_stable(uint32_t cb_in, uint32_t cb_bcast_scaler, uint32_t
     tile_regs_wait();
     pack_tile(0, cb_max);
     tile_regs_release();
-    cb_push_back(cb_max, 1);
+    cb_max_obj.push_back(1);
 
     // calculate x-max(x)
     exp_tile_init<EXP_APPROX>();
     reconfig_data_format_srcb(cb_max);
-    cb_wait_front(cb_max, 1);
+    cb_max_obj.wait_front(1);
     sub_bcast_cols_init_short(cb_in, cb_max);
     uint32_t index_subblock_w_offset = 0;
     for (uint32_t j = 0; j < num_subblocks_w; j++) {
         tile_regs_acquire();
-        cb_reserve_back(cb_out, subblock_w);
+        cb_out_obj.reserve_back(subblock_w);
         for (uint32_t w = 0; w < subblock_w; w++) {
             uint32_t index = w + index_subblock_w_offset;
             sub_tiles_bcast_cols(cb_in, cb_max, index, 0, w);
         }
-        cb_reserve_back(cb_out, subblock_w);
+        cb_out_obj.reserve_back(subblock_w);
         for (uint32_t w = 0; w < subblock_w; w++) {
             exp_tile<EXP_APPROX>(w);
         }
@@ -57,12 +63,12 @@ ALWI void calc_numeric_stable(uint32_t cb_in, uint32_t cb_bcast_scaler, uint32_t
             pack_tile(w, cb_out);
         }
         tile_regs_release();
-        cb_push_back(cb_out, subblock_w);
+        cb_out_obj.push_back(subblock_w);
         index_subblock_w_offset += subblock_w;
     }
-    cb_pop_front(cb_in, block_w);
-    cb_pop_front(cb_max, 1);
-    cb_wait_front(cb_out, block_w);
+    cb_in_obj.pop_front(block_w);
+    cb_max_obj.pop_front(1);
+    cb_out_obj.wait_front(block_w);
 }
 
 void kernel_main() {
@@ -88,6 +94,19 @@ void kernel_main() {
     constexpr auto cb_x = cb_exps;
 #endif
 
+    auto cb_in0_obj = experimental::CircularBuffer(cb_in0);
+    auto cb_bcast_scaler_obj = experimental::CircularBuffer(cb_bcast_scaler);
+    auto cb_fused_scale_obj = experimental::CircularBuffer(cb_fused_scale);
+    auto cb_fused_attn_obj = experimental::CircularBuffer(cb_fused_attn);
+    auto cb_exps_obj = experimental::CircularBuffer(cb_exps);
+    auto cb_recipsumexps_obj = experimental::CircularBuffer(cb_recipsumexps);
+    auto cb_scale_mask_obj = experimental::CircularBuffer(cb_scale_mask);
+    auto cb_out0_obj = experimental::CircularBuffer(cb_out0);
+    auto cb_x_obj = experimental::CircularBuffer(cb_x);
+#ifdef NUMERIC_STABLE
+    auto cb_max_obj = experimental::CircularBuffer(cb_max);
+#endif
+
     constexpr int dst0 = 0;
     int index_subblock_w_offset = 0;
     int index = 0;
@@ -97,12 +116,12 @@ void kernel_main() {
         // fused scale
         reconfig_data_format(cb_in0, cb_fused_scale);
         pack_reconfig_data_format(cb_scale_mask);
-        cb_wait_front(cb_fused_scale, 1);
+        cb_fused_scale_obj.wait_front(1);
         mul_tiles_bcast_scalar_init_short(cb_in0, cb_fused_scale);
         index_subblock_w_offset = 0;
         for (uint32_t j = 0; j < num_subblocks_w; j++) {
             tile_regs_acquire();
-            cb_reserve_back(cb_scale_mask, subblock_w);
+            cb_scale_mask_obj.reserve_back(subblock_w);
             for (uint32_t w = 0; w < subblock_w; w++) {
                 index = w + index_subblock_w_offset;
                 mul_tiles_bcast_scalar(cb_in0, cb_fused_scale, index, 0, w);
@@ -113,17 +132,17 @@ void kernel_main() {
                 pack_tile(w, cb_scale_mask);
             }
             tile_regs_release();
-            cb_push_back(cb_scale_mask, subblock_w);
+            cb_scale_mask_obj.push_back(subblock_w);
             index_subblock_w_offset += subblock_w;
         }
-        cb_pop_front(cb_in0, block_w);
+        cb_in0_obj.pop_front(block_w);
         reconfig_data_format(cb_scale_mask, cb_fused_attn);
 
         // fused attn
-        cb_wait_front(cb_scale_mask, block_w);
+        cb_scale_mask_obj.wait_front(block_w);
 
 #ifndef SHARDED_CAUSAL_MASK
-        cb_wait_front(cb_fused_attn, block_w);
+        cb_fused_attn_obj.wait_front(block_w);
 #endif
 
         index_subblock_w_offset = 0;
@@ -150,7 +169,7 @@ void kernel_main() {
                 add_tiles_bcast_rows(cb_scale_mask, cb_fused_attn, index, index, w);
             }
 #endif
-            cb_reserve_back(cb_x, subblock_w);
+            cb_x_obj.reserve_back(subblock_w);
 #ifndef NUMERIC_STABLE
             for (uint32_t w = 0; w < subblock_w; w++) {
                 exp_tile<EXP_APPROX>(w);
@@ -162,20 +181,20 @@ void kernel_main() {
                 pack_tile(w, cb_x);
             }
             tile_regs_release();
-            cb_push_back(cb_x, subblock_w);
+            cb_x_obj.push_back(subblock_w);
             index_subblock_w_offset += subblock_w;
         }
-        cb_pop_front(cb_scale_mask, block_w);
+        cb_scale_mask_obj.pop_front(block_w);
 
 // add numeric_stable
 // fuse exp with sub tiles
 #ifdef NUMERIC_STABLE
-        cb_wait_front(cb_x, block_w);
+        cb_x_obj.wait_front(block_w);
         calc_numeric_stable<block_w, num_subblocks_w, subblock_w>(cb_x, cb_bcast_scaler, cb_max, cb_exps);
 #endif
 
 #ifdef CAUSAL_MASK
-        cb_pop_front(cb_fused_attn, block_w);
+        cb_fused_attn_obj.pop_front(block_w);
 #endif
         reconfig_data_format(cb_exps, cb_bcast_scaler);
 
@@ -196,7 +215,7 @@ void kernel_main() {
                 index = w + index_subblock_w_offset;
                 copy_tile(cb_in0, index, w);
             }
-            cb_reserve_back(cb_exps, subblock_w);
+            cb_exps_obj.reserve_back(subblock_w);
             for (uint32_t w = 0; w < subblock_w; w++) {
                 exp_tile<EXP_APPROX>(w);
             }
@@ -206,10 +225,10 @@ void kernel_main() {
                 pack_tile(w, cb_exps);
             }
             tile_regs_release();
-            cb_push_back(cb_exps, subblock_w);
+            cb_exps_obj.push_back(subblock_w);
             index_subblock_w_offset += subblock_w;
         }
-        cb_pop_front(cb_in0, block_w);
+        cb_in0_obj.pop_front(block_w);
 #endif
         reconfig_data_format(cb_exps, cb_bcast_scaler);
 #endif  // FUSED_SCALE_MASK
@@ -217,9 +236,9 @@ void kernel_main() {
         // sum(exp(x))
         tile_regs_acquire();
         reduce_init<REDUCE_OP, REDUCE_DIM, ENABLE_FP32_DEST_ACC>(cb_exps, cb_bcast_scaler, cb_recipsumexps);
-        cb_wait_front(cb_exps, block_w);
-        cb_wait_front(cb_bcast_scaler, 1);
-        cb_reserve_back(cb_recipsumexps, 1);
+        cb_exps_obj.wait_front(block_w);
+        cb_bcast_scaler_obj.wait_front(1);
+        cb_recipsumexps_obj.reserve_back(1);
         for (uint32_t w = 0; w < block_w; w++) {
             constexpr uint32_t bcast_scaler0 = 0;
             reduce_tile<REDUCE_OP, REDUCE_DIM, ENABLE_FP32_DEST_ACC>(cb_exps, cb_bcast_scaler, w, bcast_scaler0, dst0);
@@ -231,17 +250,17 @@ void kernel_main() {
         tile_regs_wait();
         pack_tile(dst0, cb_recipsumexps);
         tile_regs_release();
-        cb_push_back(cb_recipsumexps, 1);
+        cb_recipsumexps_obj.push_back(1);
 
         // exp(x) / (sum(exp(x)))
         reconfig_data_format(cb_exps, cb_recipsumexps);
         pack_reconfig_data_format(cb_out0);
-        cb_wait_front(cb_recipsumexps, 1);
+        cb_recipsumexps_obj.wait_front(1);
         mul_bcast_cols_init_short(cb_exps, cb_recipsumexps);
         index_subblock_w_offset = 0;
         for (uint32_t j = 0; j < num_subblocks_w; j++) {
             tile_regs_acquire();
-            cb_reserve_back(cb_out0, subblock_w);
+            cb_out0_obj.reserve_back(subblock_w);
             for (uint32_t w = 0; w < subblock_w; w++) {
                 index = w + index_subblock_w_offset;
                 mul_tiles_bcast<BroadcastType::COL>(cb_exps, cb_recipsumexps, index, 0, w);
@@ -252,10 +271,10 @@ void kernel_main() {
                 pack_tile(w, cb_out0);
             }
             tile_regs_release();
-            cb_push_back(cb_out0, subblock_w);
+            cb_out0_obj.push_back(subblock_w);
             index_subblock_w_offset += subblock_w;
         }
-        cb_pop_front(cb_recipsumexps, 1);
-        cb_pop_front(cb_exps, block_w);
+        cb_recipsumexps_obj.pop_front(1);
+        cb_exps_obj.pop_front(block_w);
     }
 }

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/dataflow/reader_unary_interleaved_sm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/dataflow/reader_unary_interleaved_sm.cpp
@@ -5,6 +5,9 @@
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/kernel/dataflow/generate_reduce_scaler.hpp"
 #include "ttnn/kernel/dataflow/generate_bcast_scalar.hpp"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 
 void kernel_main() {
     const uint32_t src_addr = get_arg_val<uint32_t>(0);
@@ -29,6 +32,7 @@ void kernel_main() {
     constexpr auto mask_args = TensorAccessorArgs<src0_args.next_compile_time_args_offset()>();
 
     constexpr uint32_t cb_id_attn = 4;
+    experimental::CircularBuffer cb_id_attn_obj(cb_id_attn);
     uint32_t mask_tile_bytes = get_tile_size(cb_id_attn);
 
     const auto addr_mask = TensorAccessor(mask_args, mask_addr, mask_tile_bytes);
@@ -52,6 +56,9 @@ void kernel_main() {
 
     const auto src_a = TensorAccessor(src0_args, src_addr, src0_tile_bytes);
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_id_in0_obj(cb_id_in0);
+
     // TODO(AP): cleanup, probably with named args/param pack/reflection.
     {
         constexpr uint32_t cb_in_2 = tt::CBIndex::c_2;
@@ -65,16 +72,16 @@ void kernel_main() {
     for (uint32_t i = 0; i < num_blks; ++i) {
         for (uint32_t j = 0; j < Wt; j += blk) {
             uint32_t rem = blk;  // (i + blk > num_tiles) ? num_tiles - i : blk;
-            cb_reserve_back(cb_id_in0, rem);
-            uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
-
+            cb_id_in0_obj.reserve_back(rem);
+            uint32_t write_offset = 0;
             for (uint32_t r = 0; r < rem; ++r) {
-                noc_async_read_tile(curr_tile, src_a, l1_write_addr);  // TODO(AP): data type size
+                noc.async_read(
+                    src_a, cb_id_in0_obj, src0_tile_bytes, {.page_id = curr_tile}, {.offset_bytes = write_offset});
                 curr_tile++;
-                l1_write_addr += src0_tile_bytes;
+                write_offset += src0_tile_bytes;
             }
-            noc_async_read_barrier();
-            cb_push_back(cb_id_in0, rem);
+            noc.async_read_barrier();
+            cb_id_in0_obj.push_back(rem);
         }
 
 #if FUSED_SCALE_MASK
@@ -83,15 +90,20 @@ void kernel_main() {
 // of slice of tensor that was assigned to our core, then we skip to next batch
 #if CAUSAL_MASK
         for (uint32_t j = 0; j < Wt; j += blk) {
-            cb_reserve_back(cb_id_attn, blk);
-            uint32_t l1_write_addr = get_write_ptr(cb_id_attn);
+            cb_id_attn_obj.reserve_back(blk);
+            uint32_t mask_write_offset = 0;
             for (uint32_t wb = 0; wb < blk; ++wb) {
-                noc_async_read_tile(mask_id, addr_mask, l1_write_addr);
-                l1_write_addr += mask_tile_bytes;
+                noc.async_read(
+                    addr_mask,
+                    cb_id_attn_obj,
+                    mask_tile_bytes,
+                    {.page_id = mask_id},
+                    {.offset_bytes = mask_write_offset});
+                mask_write_offset += mask_tile_bytes;
                 ++mask_id;
             }
-            noc_async_read_barrier();
-            cb_push_back(cb_id_attn, blk);
+            noc.async_read_barrier();
+            cb_id_attn_obj.push_back(blk);
         }
         ++ht;
         ++mask_ht;
@@ -107,15 +119,20 @@ void kernel_main() {
         if (read_mask) {
             for (uint32_t j = 0; j < Wt; j += blk) {
                 // This is only executed every blk wts
-                cb_reserve_back(cb_id_attn, blk);
-                uint32_t l1_write_addr = get_write_ptr(cb_id_attn);
+                cb_id_attn_obj.reserve_back(blk);
+                uint32_t mask_write_offset = 0;
                 for (uint32_t wb = 0; wb < blk; ++wb) {
-                    noc_async_read_tile(mask_id, addr_mask, l1_write_addr);
-                    l1_write_addr += mask_tile_bytes;
+                    noc.async_read(
+                        addr_mask,
+                        cb_id_attn_obj,
+                        mask_tile_bytes,
+                        {.page_id = mask_id},
+                        {.offset_bytes = mask_write_offset});
+                    mask_write_offset += mask_tile_bytes;
                     ++mask_id;
                 }
-                noc_async_read_barrier();
-                cb_push_back(cb_id_attn, blk);
+                noc.async_read_barrier();
+                cb_id_attn_obj.push_back(blk);
             }
             read_mask = false;
         }

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/dataflow/reader_unary_interleaved_sm_large_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/dataflow/reader_unary_interleaved_sm_large_tensor.cpp
@@ -4,6 +4,9 @@
 #include "api/dataflow/dataflow_api.h"
 #include "cpp/ttnn/kernel/dataflow/generate_reduce_scaler.hpp"
 #include "cpp/ttnn/kernel/dataflow/generate_bcast_scalar.hpp"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 
 void kernel_main() {
     const uint32_t src_addr = get_arg_val<uint32_t>(0);
@@ -37,6 +40,7 @@ void kernel_main() {
     uint32_t mask_tile_bytes = get_tile_size(cb_id_attn);
 
     const auto addr_mask = TensorAccessor(mask_args, mask_addr, mask_tile_bytes);
+    experimental::CircularBuffer cb_id_attn_obj(cb_id_attn);
 
 #if CAUSAL_MASK
     constexpr uint32_t num_tiles_causal_mask = get_compile_time_arg_val(mask_args.next_compile_time_args_offset());
@@ -57,6 +61,9 @@ void kernel_main() {
         constexpr uint32_t cb_in_2 = tt::CBIndex::c_2;
         generate_reduce_scaler(cb_in_2, reduce_scaler);
     }
+
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_id_in0_obj(cb_id_in0);
 
     // read a ublock of tiles from src to CB, and then push the ublock to unpacker
 #if NUMERIC_STABLE
@@ -79,26 +86,32 @@ void kernel_main() {
             mask_index = mask_id_offset;
 #endif
             for (uint32_t wt = 0; wt < Wt; wt += blk) {
-                cb_reserve_back(cb_id_in0, blk);
-                uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
+                cb_id_in0_obj.reserve_back(blk);
+                uint32_t write_offset = 0;
 #if FUSED_SCALE_MASK
-                cb_reserve_back(cb_id_attn, blk);
-                uint32_t l1_write_addr_mask = get_write_ptr(cb_id_attn);
+                cb_id_attn_obj.reserve_back(blk);
+                uint32_t mask_write_offset = 0;
 #endif
                 for (uint32_t regs = 0; regs < blk; regs++) {
-                    noc_async_read_tile(tile_index, src_a, l1_write_addr);  // TODO(AP): data type size
+                    noc.async_read(
+                        src_a, cb_id_in0_obj, src0_tile_bytes, {.page_id = tile_index}, {.offset_bytes = write_offset});
                     tile_index++;
-                    l1_write_addr += src0_tile_bytes;
+                    write_offset += src0_tile_bytes;
 #if FUSED_SCALE_MASK
-                    noc_async_read_tile(mask_index, addr_mask, l1_write_addr_mask);  // TODO(AP): data type size
+                    noc.async_read(
+                        addr_mask,
+                        cb_id_attn_obj,
+                        mask_tile_bytes,
+                        {.page_id = mask_index},
+                        {.offset_bytes = mask_write_offset});
                     mask_index++;
-                    l1_write_addr_mask += mask_tile_bytes;
+                    mask_write_offset += mask_tile_bytes;
 #endif
                 }
-                noc_async_read_barrier();
-                cb_push_back(cb_id_in0, blk);
+                noc.async_read_barrier();
+                cb_id_in0_obj.push_back(blk);
 #if FUSED_SCALE_MASK
-                cb_push_back(cb_id_attn, blk);
+                cb_id_attn_obj.push_back(blk);
 
 #endif
             }

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/dataflow/reader_unary_sharded_sm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/dataflow/reader_unary_sharded_sm.cpp
@@ -5,15 +5,19 @@
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/kernel/dataflow/generate_reduce_scaler.hpp"
 #include "ttnn/kernel/dataflow/generate_bcast_scalar.hpp"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 
 // HW-bcast scale for fused scale-attn-softmax
 FORCE_INLINE void generate_inv_sqrt_hw_bcast_tile() {
     constexpr auto cb_fused_scale = tt::CBIndex::c_2;
+    experimental::CircularBuffer cb_fused_scale_obj(cb_fused_scale);
     uint32_t u = get_arg_val<uint32_t>(1);
-    cb_reserve_back(cb_fused_scale, 1);
-    auto ptr = reinterpret_cast<uint16_t*>(get_write_ptr(cb_fused_scale));
+    cb_fused_scale_obj.reserve_back(1);
+    auto ptr = reinterpret_cast<uint16_t*>(cb_fused_scale_obj.get_write_ptr());
     ptr[0] = u >> 16;
-    cb_push_back(cb_fused_scale, 1);
+    cb_fused_scale_obj.push_back(1);
 }
 
 void kernel_main() {
@@ -32,6 +36,9 @@ void kernel_main() {
 
     const auto addr_mask = TensorAccessor(mask_args, mask_addr, mask_tile_bytes);
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_attn_obj(cb_attn);
+
     constexpr auto cb_fused_scale = tt::CBIndex::c_2;
     const uint32_t pre_scale = get_arg_val<uint32_t>(1);
     generate_bcast_unary_scalar(cb_fused_scale, pre_scale);
@@ -45,15 +52,16 @@ void kernel_main() {
         mask_id = mask_start_tile_id;
 
         for (uint32_t h = 0; h < mask_block_ht; h++) {
-            cb_reserve_back(cb_attn, block_wt);
-            uint32_t l1_write_addr = get_write_ptr(cb_attn);
+            cb_attn_obj.reserve_back(block_wt);
+            uint32_t write_offset = 0;
             for (uint32_t w = 0; w < block_wt; w++) {
-                noc_async_read_tile(mask_id, addr_mask, l1_write_addr);
-                l1_write_addr += mask_tile_bytes;
+                noc.async_read(
+                    addr_mask, cb_attn_obj, mask_tile_bytes, {.page_id = mask_id}, {.offset_bytes = write_offset});
+                write_offset += mask_tile_bytes;
                 ++mask_id;
             }
-            noc_async_read_barrier();
-            cb_push_back(cb_attn, block_wt);
+            noc.async_read_barrier();
+            cb_attn_obj.push_back(block_wt);
 
             if (f == 0 && h == 0) {
                 generate_reduce_scaler(cb_reduce_scaler, reduce_scaler);
@@ -63,15 +71,15 @@ void kernel_main() {
 #elif defined(CAUSAL_MASK) && defined(SHARDED_CAUSAL_MASK)
     generate_reduce_scaler(cb_reduce_scaler, reduce_scaler);
 #else
-    cb_reserve_back(cb_attn, block_wt);
-    uint32_t l1_write_addr = get_write_ptr(cb_attn);
+    cb_attn_obj.reserve_back(block_wt);
+    uint32_t write_offset = 0;
     for (uint32_t w = 0; w < block_wt; w++) {
-        noc_async_read_tile(mask_id, addr_mask, l1_write_addr);
-        l1_write_addr += mask_tile_bytes;
+        noc.async_read(addr_mask, cb_attn_obj, mask_tile_bytes, {.page_id = mask_id}, {.offset_bytes = write_offset});
+        write_offset += mask_tile_bytes;
         ++mask_id;
     }
-    noc_async_read_barrier();
-    cb_push_back(cb_attn, block_wt);
+    noc.async_read_barrier();
+    cb_attn_obj.push_back(block_wt);
 
     generate_reduce_scaler(cb_reduce_scaler, reduce_scaler);
 #endif

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/dataflow/reader_unary_sharded_sm_causal_mask_hw_dims.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/dataflow/reader_unary_sharded_sm_causal_mask_hw_dims.cpp
@@ -5,15 +5,19 @@
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/kernel/dataflow/generate_reduce_scaler.hpp"
 #include "ttnn/kernel/dataflow/generate_bcast_scalar.hpp"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 
 // HW-bcast scale for fused scale-attn-softmax
 FORCE_INLINE void generate_inv_sqrt_hw_bcast_tile() {
     constexpr auto cb_fused_scale = tt::CBIndex::c_2;
+    experimental::CircularBuffer cb_fused_scale_obj(cb_fused_scale);
     uint32_t u = get_arg_val<uint32_t>(1);
-    cb_reserve_back(cb_fused_scale, 1);
-    auto ptr = reinterpret_cast<uint16_t*>(get_write_ptr(cb_fused_scale));
+    cb_fused_scale_obj.reserve_back(1);
+    auto ptr = reinterpret_cast<uint16_t*>(cb_fused_scale_obj.get_write_ptr());
     ptr[0] = u >> 16;
-    cb_push_back(cb_fused_scale, 1);
+    cb_fused_scale_obj.push_back(1);
 }
 
 void kernel_main() {
@@ -33,26 +37,30 @@ void kernel_main() {
 
     const auto addr_mask = TensorAccessor(mask_args, mask_addr, mask_tile_bytes);
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_attn_obj(cb_attn);
+
     constexpr auto cb_fused_scale = tt::CBIndex::c_2;
     const uint32_t pre_scale = get_arg_val<uint32_t>(1);
     generate_bcast_unary_scalar(cb_fused_scale, pre_scale);
 
     constexpr uint32_t block_ht = get_compile_time_arg_val(mask_args.next_compile_time_args_offset() + 2);
     for (uint32_t h = 0; h < block_ht; h++) {
-        cb_reserve_back(cb_attn, block_wt);
-        uint32_t l1_write_addr = get_write_ptr(cb_attn);
+        cb_attn_obj.reserve_back(block_wt);
+        uint32_t write_offset = 0;
         for (uint32_t w = 0; w < block_wt; w++) {
-            noc_async_read_tile(mask_id, addr_mask, l1_write_addr);
-            l1_write_addr += mask_tile_bytes;
+            noc.async_read(
+                addr_mask, cb_attn_obj, mask_tile_bytes, {.page_id = mask_id}, {.offset_bytes = write_offset});
+            write_offset += mask_tile_bytes;
             ++mask_id;
 
             if (h == 0 && w == 0) {
                 generate_reduce_scaler(cb_reduce_scaler, reduce_scaler);
             }
         }
-        noc_async_read_barrier();
+        noc.async_read_barrier();
 
-        cb_push_back(cb_attn, block_wt);
+        cb_attn_obj.push_back(block_wt);
         if (mask_id == mask_num_tiles) {
             mask_id = 0;
         }

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/dataflow/reader_unary_sharded_sm_rm_mask.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/dataflow/reader_unary_sharded_sm_rm_mask.cpp
@@ -35,7 +35,8 @@ void kernel_main() {
     constexpr uint32_t mask_read_tile_offset_bytes = FLOAT32_DTYPE ? 1024 : 512;
 
     cb_attn_obj.reserve_back(block_wt);
-    auto [my_x, my_y] = noc.get_noc_coords();
+    uint32_t local_noc_x = my_x[noc.get_noc_id()];
+    uint32_t local_noc_y = my_y[noc.get_noc_id()];
     uint32_t write_offset = 0;
     for (uint32_t w = 0; w < block_wt; w++) {
         noc.async_read(
@@ -50,7 +51,7 @@ void kernel_main() {
             experimental::UnicastEndpoint{},
             cb_attn_obj,
             mask_read_tile_face_bytes,
-            {.noc_x = my_x, .noc_y = my_y, .addr = src_addr},
+            {.noc_x = local_noc_x, .noc_y = local_noc_y, .addr = src_addr},
             {.offset_bytes = write_offset + mask_read_tile_offset_bytes});
         write_offset += mask_tile_bytes;
     }

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/dataflow/reader_unary_sharded_sm_rm_mask.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/dataflow/reader_unary_sharded_sm_rm_mask.cpp
@@ -5,6 +5,10 @@
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/kernel/dataflow/generate_reduce_scaler.hpp"
 #include "ttnn/kernel/dataflow/generate_bcast_scalar.hpp"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
+#include "experimental/endpoints.h"
 
 void kernel_main() {
 #if FUSED_SCALE_MASK
@@ -19,6 +23,9 @@ void kernel_main() {
 
     const auto addr_mask = TensorAccessor(mask_args, mask_addr, size);
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_attn_obj(cb_attn);
+
     constexpr auto cb_fused_scale = tt::CBIndex::c_2;
     const uint32_t pre_scale = get_arg_val<uint32_t>(1);
     generate_bcast_unary_scalar(cb_fused_scale, pre_scale);
@@ -27,18 +34,28 @@ void kernel_main() {
     constexpr uint32_t mask_read_tile_face_bytes = FLOAT32_DTYPE ? 64 : 32;
     constexpr uint32_t mask_read_tile_offset_bytes = FLOAT32_DTYPE ? 1024 : 512;
 
-    cb_reserve_back(cb_attn, block_wt);
-    uint32_t l1_write_addr = get_write_ptr(cb_attn);
+    cb_attn_obj.reserve_back(block_wt);
+    auto [my_x, my_y] = noc.get_noc_coords();
+    uint32_t write_offset = 0;
     for (uint32_t w = 0; w < block_wt; w++) {
-        uint64_t mask_noc_addr = get_noc_addr(mask_start_tile_id + w, addr_mask);
-        noc_async_read(mask_noc_addr, l1_write_addr, mask_read_tile_face_bytes * 2);
-        mask_noc_addr = get_noc_addr(l1_write_addr + mask_read_tile_face_bytes);
-        noc_async_read_barrier();
-        noc_async_read(mask_noc_addr, l1_write_addr + mask_read_tile_offset_bytes, mask_read_tile_face_bytes);
-        l1_write_addr += mask_tile_bytes;
+        noc.async_read(
+            addr_mask,
+            cb_attn_obj,
+            mask_read_tile_face_bytes * 2,
+            {.page_id = mask_start_tile_id + w},
+            {.offset_bytes = write_offset});
+        noc.async_read_barrier();
+        uint32_t src_addr = cb_attn_obj.get_write_ptr() + write_offset + mask_read_tile_face_bytes;
+        noc.async_read(
+            experimental::UnicastEndpoint{},
+            cb_attn_obj,
+            mask_read_tile_face_bytes,
+            {.noc_x = my_x, .noc_y = my_y, .addr = src_addr},
+            {.offset_bytes = write_offset + mask_read_tile_offset_bytes});
+        write_offset += mask_tile_bytes;
     }
-    noc_async_read_barrier();
-    cb_push_back(cb_attn, block_wt);
+    noc.async_read_barrier();
+    cb_attn_obj.push_back(block_wt);
 #endif
 
     {

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/dataflow/writer_unary_interleaved_start_id_blocked_sm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/dataflow/writer_unary_interleaved_start_id_blocked_sm.cpp
@@ -4,6 +4,9 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "../../../../../../kernel_helper_functions/pad_tile.hpp"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 
 void kernel_main() {
     using namespace tt::constants;
@@ -24,36 +27,40 @@ void kernel_main() {
     const uint32_t mask_padded_data = get_arg_val<uint32_t>(4);
     // const uint32_t num_datum_padded = get_arg_val<uint32_t>(5);
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_id_out0_obj(cb_id_out0);
+    experimental::CircularBuffer cb_id_mask_obj(cb_id_mask);
+
     // Adds -inf padding. Note: the value is the uint16 representation of bfloat16's -inf
     constexpr uint16_t mask_val = 0xFF80;
     constexpr uint32_t mask_val_32 = ((uint32_t)mask_val << 16) + mask_val;
     if (mask_padded_data) {
         // generate_bcast_row_mask(cb_id_mask, num_datum_padded, mask_val);
-        uint32_t ptr = (get_write_ptr(cb_id_mask));
+        uint32_t ptr = (cb_id_mask_obj.get_write_ptr());
         // same pointer, but for zeroing out the tile
         volatile tt_l1_ptr uint16_t* zero_ptr =
-            reinterpret_cast<volatile tt_l1_ptr uint16_t*>(get_write_ptr(cb_id_mask));
+            reinterpret_cast<volatile tt_l1_ptr uint16_t*>(cb_id_mask_obj.get_write_ptr());
         for (uint32_t i = 0; i < TILE_WIDTH * TILE_HEIGHT; i++) {
             zero_ptr[i] = 0.0f;
         }
         constexpr uint32_t num_datum_unpadded = 32 - num_datum_padded;
         fill_pad_tile<uint16_t, num_datum_unpadded, 32>(ptr, mask_val);
-        cb_push_back(cb_id_mask, 1);
+        cb_id_mask_obj.push_back(1);
     }
 
     const auto s = TensorAccessor(dst_args, dst_addr, tile_bytes);
 
     uint32_t tile_id = tile_offset;
     for (uint32_t i = 0; i < num_tiles; i += blk) {
-        cb_wait_front(cb_id_out0, blk);
+        cb_id_out0_obj.wait_front(blk);
 
-        uint32_t l1_read_addr = get_read_ptr(cb_id_out0);
+        uint32_t read_offset = 0;
         for (uint32_t j = 0; j < blk; j++) {
-            noc_async_write_tile(tile_id, s, l1_read_addr);
+            noc.async_write(cb_id_out0_obj, s, tile_bytes, {.offset_bytes = read_offset}, {.page_id = tile_id});
             tile_id++;
-            l1_read_addr += tile_bytes;
+            read_offset += tile_bytes;
         }
-        noc_async_write_barrier();
-        cb_pop_front(cb_id_out0, blk);
+        noc.async_write_barrier();
+        cb_id_out0_obj.pop_front(blk);
     }
 }


### PR DESCRIPTION
### Ticket
Link to Github Issue #38903

### Problem description
There's a new device api

### What's changed
Use the new device api in softmax and batch norm

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=bbradel-38903_fusedm20)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:bbradel-38903_fusedm20)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-38903_fusedm20)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-38903_fusedm20)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-38903_fusedm20)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-38903_fusedm20)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-38903_fusedm20)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-38903_fusedm20)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-38903_fusedm20)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-38903_fusedm20)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-38903_fusedm20)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-38903_fusedm20)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
