### PR TITLE
refactor some builder and router code to index channels by VC rather than by flat index

### DIFF
--- a/tt_metal/fabric/builder/fabric_builder_config.cpp
+++ b/tt_metal/fabric/builder/fabric_builder_config.cpp
@@ -45,13 +45,16 @@ uint32_t get_downstream_edm_count(bool is_2D_routing) {
     return is_2D_routing ? builder_config::max_downstream_edms : builder_config::num_downstream_edms_1d;
 }
 
-uint32_t get_vc0_downstream_edm_count(bool is_2D_routing) {
-    return is_2D_routing ? builder_config::num_downstream_edms_2d_vc0 : builder_config::num_downstream_edms_vc0;
-}
-
-uint32_t get_vc1_downstream_edm_count(bool is_2D_routing) {
-    TT_FATAL(is_2D_routing, "VC1 is only supported for 2D routing");
-    return builder_config::num_downstream_edms_2d_vc1;
+uint32_t get_downstream_edm_count_for_vc(uint32_t vc, bool is_2D_routing) {
+    switch (vc) {
+        case 0:
+            return is_2D_routing ? builder_config::num_downstream_edms_2d_per_vc[0]
+                                 : builder_config::num_downstream_edms_vc0;
+        case 1:
+            TT_FATAL(is_2D_routing, "VC1 is only supported for 2D routing");
+            return builder_config::num_downstream_edms_2d_per_vc[1];
+        default: TT_THROW("VC {} out of bounds (max {})", vc, builder_config::MAX_NUM_VCS);
+    }
 }
 
 }  // namespace tt::tt_fabric::builder_config

--- a/tt_metal/fabric/builder/fabric_builder_config.cpp
+++ b/tt_metal/fabric/builder/fabric_builder_config.cpp
@@ -53,7 +53,7 @@ uint32_t get_downstream_edm_count_for_vc(uint32_t vc, bool is_2D_routing) {
         case 1:
             TT_FATAL(is_2D_routing, "VC1 is only supported for 2D routing");
             return builder_config::num_downstream_edms_2d_per_vc[1];
-        default: TT_THROW("VC {} out of bounds (max {})", vc, builder_config::MAX_NUM_VCS);
+        default: TT_THROW("VC {} out of bounds (size {})", vc, builder_config::MAX_NUM_VCS);
     }
 }
 

--- a/tt_metal/fabric/builder/fabric_builder_config.hpp
+++ b/tt_metal/fabric/builder/fabric_builder_config.hpp
@@ -10,6 +10,8 @@
 #include <tt-metalium/experimental/fabric/fabric_types.hpp>
 #include <tt-metalium/experimental/fabric/fabric_edm_types.hpp>
 #include "tt_metal/hostdevcommon/api/hostdevcommon/fabric_common.h"
+#include <array>
+#include <numeric>
 #include <vector>
 #include <algorithm>
 
@@ -51,12 +53,15 @@ static constexpr std::size_t num_sender_channels_1d_neighbor_exchange = 1;
 static constexpr std::size_t num_sender_channels_1d_linear = 2;
 static constexpr std::size_t num_sender_channels_2d_mesh = 4;
 
-// Z router channel counts
+// Z router channel counts per VC
 // VC0: 5 sender channels (mesh→Z: 0=Worker, 1-4=E/W/N/S mesh directions) + 1 receiver
 // VC1: 4 sender channels (Z→mesh, one per direction: 0=E, 1=W, 2=N, 3=S) + 0 receiver (skipped)
-static constexpr std::size_t num_sender_channels_z_router_vc0 = 5;
-static constexpr std::size_t num_sender_channels_z_router_vc1 = 4;
-static constexpr std::size_t num_sender_channels_z_router = num_sender_channels_z_router_vc0 + num_sender_channels_z_router_vc1;
+static constexpr std::array<std::size_t, MAX_NUM_VCS> num_sender_channels_z_router_per_vc = {5, 4};
+// Legacy aliases
+static constexpr std::size_t num_sender_channels_z_router_vc0 = num_sender_channels_z_router_per_vc[0];
+static constexpr std::size_t num_sender_channels_z_router_vc1 = num_sender_channels_z_router_per_vc[1];
+static constexpr std::size_t num_sender_channels_z_router =
+    num_sender_channels_z_router_per_vc[0] + num_sender_channels_z_router_per_vc[1];
 static constexpr std::size_t num_receiver_channels_z_router = 2;  // 1 for VC0, 1 for VC1
 
 static constexpr std::size_t num_sender_channels_1d = 2;
@@ -70,12 +75,17 @@ static constexpr std::size_t num_receiver_channels_1d = 1;
 static constexpr std::size_t num_receiver_channels_2d = 2;
 static constexpr std::size_t num_max_receiver_channels = std::max({num_receiver_channels_1d, num_receiver_channels_2d, num_receiver_channels_z_router});
 
+// Downstream EDM counts per VC
+// 1D: VC0=1, VC1=0; 2D: VC0=3, VC1=3 (XY intermesh), VC1=4 (Z intermesh: 3 mesh + Z)
 static constexpr std::size_t num_downstream_edms_vc0 = 1;
-static constexpr std::size_t num_downstream_edms_2d_vc0 = 3;
-static constexpr std::size_t num_downstream_edms_2d_vc1 = 3;  // XY intermesh: 3 mesh directions
+static constexpr std::array<std::size_t, MAX_NUM_VCS> num_downstream_edms_2d_per_vc = {3, 3};
+// Legacy aliases
+static constexpr std::size_t num_downstream_edms_2d_vc0 = num_downstream_edms_2d_per_vc[0];
+static constexpr std::size_t num_downstream_edms_2d_vc1 = num_downstream_edms_2d_per_vc[1];
 static constexpr std::size_t num_downstream_edms_2d_vc1_with_z = 4;  // Z intermesh: 3 mesh + Z
 static constexpr std::size_t num_downstream_edms_1d = num_downstream_edms_vc0;
-static constexpr std::size_t num_downstream_edms_2d = num_downstream_edms_2d_vc0 + num_downstream_edms_2d_vc1;
+static constexpr std::size_t num_downstream_edms_2d =
+    num_downstream_edms_2d_per_vc[0] + num_downstream_edms_2d_per_vc[1];
 static constexpr std::size_t max_downstream_edms = 8;
 
 // 2D mesh directions (N, E, S, W)
@@ -91,9 +101,15 @@ uint32_t get_num_tensix_sender_channels(Topology topology, tt::tt_fabric::Fabric
 
 uint32_t get_downstream_edm_count(bool is_2D_routing);
 
-uint32_t get_vc0_downstream_edm_count(bool is_2D_routing);
+uint32_t get_downstream_edm_count_for_vc(uint32_t vc, bool is_2D_routing);
 
-uint32_t get_vc1_downstream_edm_count(bool is_2D_routing);
+// Legacy per-VC helpers (prefer get_downstream_edm_count_for_vc)
+inline uint32_t get_vc0_downstream_edm_count(bool is_2D_routing) {
+    return get_downstream_edm_count_for_vc(0, is_2D_routing);
+}
+inline uint32_t get_vc1_downstream_edm_count(bool is_2D_routing) {
+    return get_downstream_edm_count_for_vc(1, is_2D_routing);
+}
 
 }  // namespace builder_config
 

--- a/tt_metal/fabric/builder/fabric_remote_channels_allocator.cpp
+++ b/tt_metal/fabric/builder/fabric_remote_channels_allocator.cpp
@@ -28,11 +28,16 @@ void FabricRemoteChannelsAllocator::emit_ct_args(std::vector<uint32_t>& ct_args)
     // Emit per-entry data in ChannelBufferEntry format for all VCs sequentially (VC0 first, then VC1)
     // Format: for each receiver channel per VC: (base_address, num_buffers, remote_address, remote_num_buffers)
     for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
-        for (size_t i = 0; i < this->num_used_receiver_channels_per_vc_[vc]; ++i) {
-            ct_args.push_back(static_cast<uint32_t>(this->remote_receiver_channels_base_address_[vc][i]));
-            ct_args.push_back(static_cast<uint32_t>(this->remote_receiver_channels_num_buffers_[vc][i]));
+        if (this->num_used_receiver_channels_per_vc_[vc] > 0) {
+            ct_args.push_back(static_cast<uint32_t>(this->remote_receiver_channels_base_address_[vc][0]));
+            ct_args.push_back(static_cast<uint32_t>(this->remote_receiver_channels_num_buffers_[vc][0]));
             ct_args.push_back(0);  // remote_address (unused for remote pools)
             ct_args.push_back(0);  // remote_num_buffers (unused for remote pools)
+        } else {
+            ct_args.push_back(0);  // base_address (inactive VC)
+            ct_args.push_back(0);  // num_buffers (inactive VC)
+            ct_args.push_back(0);  // remote_address (inactive VC)
+            ct_args.push_back(0);  // remote_num_buffers (inactive VC)
         }
     }
 }

--- a/tt_metal/fabric/builder/fabric_remote_channels_allocator.hpp
+++ b/tt_metal/fabric/builder/fabric_remote_channels_allocator.hpp
@@ -11,6 +11,7 @@
 #include <array>
 #include <cstddef>
 #include <sstream>
+#include <numeric>
 #include <vector>
 
 namespace tt::tt_fabric {
@@ -107,9 +108,7 @@ public:
      * Legacy getter: Get total number of used receiver channels across all VCs.
      * @return Total number of used receiver channels
      */
-    size_t get_num_receiver_channels() const {
-        return num_used_receiver_channels_per_vc_[0] + num_used_receiver_channels_per_vc_[1];
-    }
+    size_t get_num_receiver_channels() const { return builder_config::MAX_NUM_VCS; }
 
     /**
      * Override virtual print method from base class
@@ -122,7 +121,7 @@ private:
         remote_receiver_channels_base_address_ = {};
     std::array<std::array<size_t, builder_config::num_max_receiver_channels>, builder_config::MAX_NUM_VCS>
         remote_receiver_channels_num_buffers_ = {};
-    std::array<size_t, builder_config::MAX_NUM_VCS> num_used_receiver_channels_per_vc_ = {0, 0};
+    std::array<size_t, builder_config::MAX_NUM_VCS> num_used_receiver_channels_per_vc_ = {};
 };
 
 inline void FabricRemoteChannelsAllocator::print(std::ostream& os) const {

--- a/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
+++ b/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
@@ -285,116 +285,113 @@ void FabricStaticSizedChannelsAllocator::configure_buffer_slots_helper(
         num_receiver_buffer_slots_per_vc,
     std::array<std::array<size_t, builder_config::num_max_receiver_channels>, builder_config::MAX_NUM_VCS>&
         num_remote_receiver_buffer_slots_per_vc) {
-    // Per-VC buffer slot configuration: {vc0_sender, vc0_receiver, vc1_sender, vc1_receiver}
+    // Per-VC buffer slot configuration: sender_slots[vc] and receiver_slots[vc]
     struct PerVcBufferSlots {
-        size_t vc0_sender_slots;
-        size_t vc0_receiver_slots;
-        size_t vc1_sender_slots;
-        size_t vc1_receiver_slots;
+        std::array<size_t, builder_config::MAX_NUM_VCS> sender_slots;
+        std::array<size_t, builder_config::MAX_NUM_VCS> receiver_slots;
     };
 
     // fabric with tensix extension uses different buffer slots options, since only one or two sender channels are
     // used by fabric router, while other sender channels are skipped and have 0 buffer slots.
-    // Format: {vc0_sender, vc0_receiver, vc1_sender, vc1_receiver}
+    // Format: {sender_slots={vc0, vc1, ...}, receiver_slots={vc0, vc1, ...}}
     static const std::vector<std::vector<PerVcBufferSlots>> default_with_tensix_buffer_slot_options = {
         // WORMHOLE_B0
         {
-            {16, 16, 0, 0},  // Option 1
-            {8, 16, 0, 0},   // Option 2
-            {8, 8, 0, 0},    // Option 3
-            {4, 8, 0, 0},    // Option 4
-            {4, 4, 0, 0},    // Option 5: VC0 only, smaller
-            {2, 4, 0, 0},    // Option 6: VC0 only, smaller
-            {2, 2, 0, 0},    // Option 7: VC0 only, smaller
-            {1, 2, 0, 0},    // Option 8: VC0 only, smallest
-            {1, 1, 0, 0},    // Option 9: VC0 only, smallest
-            {4, 8, 4, 4},    // Option 10: supports both VCs
-            {4, 8, 2, 2},    // Option 11: supports both VCs
-            {4, 4, 2, 2},    // Option 12: supports both VCs
-            {2, 2, 2, 2}     // Option 13: supports both VCs
+            {{16, 0}, {16, 0}},  // Option 1
+            {{8, 0}, {16, 0}},   // Option 2
+            {{8, 0}, {8, 0}},    // Option 3
+            {{4, 0}, {8, 0}},    // Option 4
+            {{4, 0}, {4, 0}},    // Option 5: VC0 only, smaller
+            {{2, 0}, {4, 0}},    // Option 6: VC0 only, smaller
+            {{2, 0}, {2, 0}},    // Option 7: VC0 only, smaller
+            {{1, 0}, {2, 0}},    // Option 8: VC0 only, smallest
+            {{1, 0}, {1, 0}},    // Option 9: VC0 only, smallest
+            {{4, 4}, {8, 4}},    // Option 10: supports both VCs
+            {{4, 2}, {8, 2}},    // Option 11: supports both VCs
+            {{4, 2}, {4, 2}},    // Option 12: supports both VCs
+            {{2, 2}, {2, 2}}     // Option 13: supports both VCs
         },
         // BLACKHOLE
         {
-            {32, 32, 0, 0},  // Option 1
-            {16, 32, 0, 0},  // Option 2
-            {16, 16, 0, 0},  // Option 3
-            {8, 16, 0, 0},   // Option 4
-            {8, 8, 0, 0},    // Option 5
-            {4, 8, 0, 0},    // Option 6
-            {4, 4, 0, 0},    // Option 7
-            {2, 4, 0, 0},    // Option 8
-            {2, 2, 0, 0},    // Option 9
-            {1, 2, 0, 0},    // Option 10
-            {1, 1, 0, 0},    // Option 11
-            {4, 8, 2, 4},    // Option 12: supports both VCs
-            {4, 8, 2, 2},    // Option 13: supports both VCs, smaller VC1 receiver
-            {2, 4, 2, 2},    // Option 14: supports both VCs, smaller overall
-            {2, 4, 1, 1},    // Option 15: supports both VCs, smaller overall
-            {2, 2, 1, 1},    // Option 16: supports both VCs, smaller overall
-            {1, 1, 1, 1}     // Option 17: supports both VCs, smaller overall
-
+            {{32, 0}, {32, 0}},  // Option 1
+            {{16, 0}, {32, 0}},  // Option 2
+            {{16, 0}, {16, 0}},  // Option 3
+            {{8, 0}, {16, 0}},   // Option 4
+            {{8, 0}, {8, 0}},    // Option 5
+            {{4, 0}, {8, 0}},    // Option 6
+            {{4, 0}, {4, 0}},    // Option 7
+            {{2, 0}, {4, 0}},    // Option 8
+            {{2, 0}, {2, 0}},    // Option 9
+            {{1, 0}, {2, 0}},    // Option 10
+            {{1, 0}, {1, 0}},    // Option 11
+            {{4, 2}, {8, 4}},    // Option 12: supports both VCs
+            {{4, 2}, {8, 2}},    // Option 13: supports both VCs, smaller VC1 receiver
+            {{2, 2}, {4, 2}},    // Option 14: supports both VCs, smaller overall
+            {{2, 1}, {4, 1}},    // Option 15: supports both VCs, smaller overall
+            {{2, 1}, {2, 1}},    // Option 16: supports both VCs, smaller overall
+            {{1, 1}, {1, 1}}     // Option 17: supports both VCs, smaller overall
         }};
 
     auto get_num_buffer_slots = [](Topology topology, size_t arch_index) -> const std::vector<PerVcBufferSlots>& {
         // Architecture-specific buffer slot configurations per VC
-        // Format: {vc0_sender, vc0_receiver, vc1_sender, vc1_receiver}
+        // Format: {sender_slots={vc0, vc1, ...}, receiver_slots={vc0, vc1, ...}}
         static const std::vector<std::vector<PerVcBufferSlots>> mesh_buffer_slot_options = {
             // WORMHOLE_B0
             {
-                {7, 11, 0, 0},  // Option 1: VC0 only
-                {4, 8, 0, 0},   // Option 2: VC0 only, smaller
-                {4, 4, 0, 0},   // Option 3: VC0 only, smaller
-                {2, 4, 0, 0},   // Option 4: VC0 only, smaller
-                {2, 2, 0, 0},   // Option 5: VC0 only, smaller
-                {1, 2, 0, 0},   // Option 6: VC0 only, smallest
-                {1, 1, 0, 0},   // Option 7: VC0 only, smallest
-                {4, 8, 2, 4},   // Option 8: supports both VCs
-                {4, 8, 2, 2},   // Option 9: supports both VCs, smaller VC1 receiver
-                {2, 4, 2, 2},   // Option 10: supports both VCs, smaller overall
-                {2, 4, 1, 1},   // Option 11: supports both VCs, smaller overall
-                {2, 2, 1, 1},   // Option 12: supports both VCs, smaller overall
-                {1, 1, 1, 1}    // Option 13: supports both VCs, smaller overall
+                {{7, 0}, {11, 0}},  // Option 1: VC0 only
+                {{4, 0}, {8, 0}},   // Option 2: VC0 only, smaller
+                {{4, 0}, {4, 0}},   // Option 3: VC0 only, smaller
+                {{2, 0}, {4, 0}},   // Option 4: VC0 only, smaller
+                {{2, 0}, {2, 0}},   // Option 5: VC0 only, smaller
+                {{1, 0}, {2, 0}},   // Option 6: VC0 only, smallest
+                {{1, 0}, {1, 0}},   // Option 7: VC0 only, smallest
+                {{4, 2}, {8, 4}},   // Option 8: supports both VCs
+                {{4, 2}, {8, 2}},   // Option 9: supports both VCs, smaller VC1 receiver
+                {{2, 2}, {4, 2}},   // Option 10: supports both VCs, smaller overall
+                {{2, 1}, {4, 1}},   // Option 11: supports both VCs, smaller overall
+                {{2, 1}, {2, 1}},   // Option 12: supports both VCs, smaller overall
+                {{1, 1}, {1, 1}}    // Option 13: supports both VCs, smaller overall
             },
             // BLACKHOLE
             {
-                {8, 16, 0, 0},  // Option 1: VC0 only
-                {8, 8, 0, 0},   // Option 2: VC0 only
-                {4, 8, 0, 0},   // Option 3: VC0 only
-                {4, 4, 0, 0},   // Option 4: VC0 only, smaller
-                {2, 4, 0, 0},   // Option 5: VC0 only, smaller
-                {2, 2, 0, 0},   // Option 6: VC0 only, smaller
-                {1, 2, 0, 0},   // Option 7: VC0 only, smallest
-                {1, 1, 0, 0},   // Option 8: VC0 only, smallest
-                {4, 8, 2, 4},   // Option 9: supports both VCs
-                {4, 8, 2, 2},   // Option 10: supports both VCs, smaller VC1 receiver
-                {2, 4, 2, 2},   // Option 11: supports both VCs, smaller overall
-                {2, 4, 1, 1},   // Option 12: supports both VCs, smaller overall
-                {2, 2, 1, 1},   // Option 13: supports both VCs, smaller overall
-                {1, 1, 1, 1}    // Option 14: supports both VCs, smaller overall
+                {{8, 0}, {16, 0}},  // Option 1: VC0 only
+                {{8, 0}, {8, 0}},   // Option 2: VC0 only
+                {{4, 0}, {8, 0}},   // Option 3: VC0 only
+                {{4, 0}, {4, 0}},   // Option 4: VC0 only, smaller
+                {{2, 0}, {4, 0}},   // Option 5: VC0 only, smaller
+                {{2, 0}, {2, 0}},   // Option 6: VC0 only, smaller
+                {{1, 0}, {2, 0}},   // Option 7: VC0 only, smallest
+                {{1, 0}, {1, 0}},   // Option 8: VC0 only, smallest
+                {{4, 2}, {8, 4}},   // Option 9: supports both VCs
+                {{4, 2}, {8, 2}},   // Option 10: supports both VCs, smaller VC1 receiver
+                {{2, 2}, {4, 2}},   // Option 11: supports both VCs, smaller overall
+                {{2, 1}, {4, 1}},   // Option 12: supports both VCs, smaller overall
+                {{2, 1}, {2, 1}},   // Option 13: supports both VCs, smaller overall
+                {{1, 1}, {1, 1}}    // Option 14: supports both VCs, smaller overall
             }};
         static const std::vector<std::vector<PerVcBufferSlots>> other_buffer_slot_options = {
             // WORMHOLE_B0
-            {{16, 16, 0, 0},  // Only VC0 for non-mesh topologies.
-             {8, 16, 0, 0},
-             {8, 8, 0, 0},
-             {4, 8, 0, 0},
-             {4, 4, 0, 0},
-             {2, 4, 0, 0},
-             {2, 2, 0, 0},
-             {1, 2, 0, 0},
-             {1, 1, 0, 0}},
+            {{{16, 0}, {16, 0}},  // Only VC0 for non-mesh topologies.
+             {{8, 0}, {16, 0}},
+             {{8, 0}, {8, 0}},
+             {{4, 0}, {8, 0}},
+             {{4, 0}, {4, 0}},
+             {{2, 0}, {4, 0}},
+             {{2, 0}, {2, 0}},
+             {{1, 0}, {2, 0}},
+             {{1, 0}, {1, 0}}},
             // BLACKHOLE
-            {{32, 32, 0, 0},  // Only VC0 for non-mesh topologies.
-             {16, 32, 0, 0},
-             {16, 16, 0, 0},
-             {8, 16, 0, 0},
-             {8, 8, 0, 0},
-             {4, 8, 0, 0},
-             {4, 4, 0, 0},
-             {2, 4, 0, 0},
-             {2, 2, 0, 0},
-             {1, 2, 0, 0},
-             {1, 1, 0, 0}}};
+            {{{32, 0}, {32, 0}},  // Only VC0 for non-mesh topologies.
+             {{16, 0}, {32, 0}},
+             {{16, 0}, {16, 0}},
+             {{8, 0}, {16, 0}},
+             {{8, 0}, {8, 0}},
+             {{4, 0}, {8, 0}},
+             {{4, 0}, {4, 0}},
+             {{2, 0}, {4, 0}},
+             {{2, 0}, {2, 0}},
+             {{1, 0}, {2, 0}},
+             {{1, 0}, {1, 0}}}};
 
         static tt::stl::Indestructible<std::vector<std::vector<PerVcBufferSlots>>> mesh_slots(mesh_buffer_slot_options);
         static tt::stl::Indestructible<std::vector<std::vector<PerVcBufferSlots>>> other_slots(
@@ -406,66 +403,67 @@ void FabricStaticSizedChannelsAllocator::configure_buffer_slots_helper(
         return other_slots.get()[arch_index];
     };
 
-    auto get_optimal_num_slots_per_vc = [this](
-                                            auto& buffer_slot_options,
-                                            size_t num_vc0_sender_channels,
-                                            size_t num_vc0_receiver_channels,
-                                            size_t num_vc1_sender_channels,
-                                            size_t num_vc1_receiver_channels,
-                                            size_t& vc0_sender_buffer_slots,
-                                            size_t& vc0_receiver_buffer_slots,
-                                            size_t& vc1_sender_buffer_slots,
-                                            size_t& vc1_receiver_buffer_slots) {
-        bool vc1_needed = (num_vc1_sender_channels > 0) || (num_vc1_receiver_channels > 0);
-        bool found_valid_option = false;
-        for (auto& option : buffer_slot_options) {
-            vc0_sender_buffer_slots = option.vc0_sender_slots;
-            vc0_receiver_buffer_slots = option.vc0_receiver_slots;
-            vc1_sender_buffer_slots = option.vc1_sender_slots;
-            vc1_receiver_buffer_slots = option.vc1_receiver_slots;
-            // skip the VC0 only options if VC1 is needed (either sender or receiver channels)
-            if (vc1_needed) {
-                // Check if we need VC1 sender channels but this option doesn't provide them
-                bool skip_due_to_vc1_sender = (num_vc1_sender_channels > 0) && (vc1_sender_buffer_slots == 0);
-                // Check if we need VC1 receiver channels but this option doesn't provide them
-                bool skip_due_to_vc1_receiver = (num_vc1_receiver_channels > 0) && (vc1_receiver_buffer_slots == 0);
-
-                if (skip_due_to_vc1_sender || skip_due_to_vc1_receiver) {
-                    continue;  // Skip this option - VC1 is needed but this option doesn't support it
+    auto get_optimal_num_slots_per_vc =
+        [this](
+            const auto& buffer_slot_options,
+            const std::array<size_t, builder_config::MAX_NUM_VCS>& num_sender_channels,
+            const std::array<size_t, builder_config::MAX_NUM_VCS>& num_receiver_channels,
+            std::array<size_t, builder_config::MAX_NUM_VCS>& sender_buffer_slots,
+            std::array<size_t, builder_config::MAX_NUM_VCS>& receiver_buffer_slots) {
+            // Check if any VC beyond VC0 is needed
+            bool higher_vc_needed = false;
+            for (size_t vc = 1; vc < builder_config::MAX_NUM_VCS; ++vc) {
+                if (num_sender_channels[vc] > 0 || num_receiver_channels[vc] > 0) {
+                    higher_vc_needed = true;
+                    break;
                 }
             }
 
-            // Calculate total slots across both VCs
-            auto vc0_total_sender_slots = num_vc0_sender_channels * vc0_sender_buffer_slots;
-            auto vc0_total_receiver_slots = num_vc0_receiver_channels * vc0_receiver_buffer_slots;
-            auto vc1_total_sender_slots = num_vc1_sender_channels * vc1_sender_buffer_slots;
-            auto vc1_total_receiver_slots = num_vc1_receiver_channels * vc1_receiver_buffer_slots;
+            bool found_valid_option = false;
+            for (const auto& option : buffer_slot_options) {
+                sender_buffer_slots = option.sender_slots;
+                receiver_buffer_slots = option.receiver_slots;
 
-            auto total_num_bytes = (vc0_total_sender_slots + vc0_total_receiver_slots + vc1_total_sender_slots +
-                                    vc1_total_receiver_slots) *
-                                   this->channel_buffer_size_bytes;
+                // Skip options that don't provide slots for VCs that need them
+                if (higher_vc_needed) {
+                    bool skip = false;
+                    for (size_t vc = 1; vc < builder_config::MAX_NUM_VCS; ++vc) {
+                        if ((num_sender_channels[vc] > 0) && (sender_buffer_slots[vc] == 0)) {
+                            skip = true;
+                            break;
+                        }
+                        if ((num_receiver_channels[vc] > 0) && (receiver_buffer_slots[vc] == 0)) {
+                            skip = true;
+                            break;
+                        }
+                    }
+                    if (skip) {
+                        continue;
+                    }
+                }
 
-            if (total_num_bytes <= this->available_channel_buffering_space) {
-                found_valid_option = true;
-                break;  // Found a configuration that fits
+                // Calculate total slots across all VCs
+                size_t total_num_bytes = 0;
+                for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
+                    total_num_bytes += num_sender_channels[vc] * sender_buffer_slots[vc];
+                    total_num_bytes += num_receiver_channels[vc] * receiver_buffer_slots[vc];
+                }
+                total_num_bytes *= this->channel_buffer_size_bytes;
+
+                if (total_num_bytes <= this->available_channel_buffering_space) {
+                    found_valid_option = true;
+                    break;
+                }
             }
-        }
 
-        // Validate that we found a valid option, especially if VC1 is needed
-        if (!found_valid_option) {
-            TT_THROW(
-                "Failed to find suitable buffer slot configuration. VC1 needed: {}, VC0 channels: {} senders/{} "
-                "receivers, VC1 channels: {} senders/{} receivers, Available space: {} bytes",
-                vc1_needed,
-                num_vc0_sender_channels,
-                num_vc0_receiver_channels,
-                num_vc1_sender_channels,
-                num_vc1_receiver_channels,
-                this->available_channel_buffering_space);
-        }
-
-        // Additional validation: ensure VC1 buffer slots are non-zero if VC1 channels are needed
-    };
+            if (!found_valid_option) {
+                TT_THROW(
+                    "Failed to find suitable buffer slot configuration. "
+                    "Higher VCs needed: {}, Available space: {} bytes",
+                    higher_vc_needed,
+                    this->available_channel_buffering_space);
+            }
+        };
 
     // auto axis_index = static_cast<std::size_t>(options.edm_axis);
     auto arch = tt::tt_metal::MetalContext::instance().hal().get_arch();
@@ -482,61 +480,48 @@ void FabricStaticSizedChannelsAllocator::configure_buffer_slots_helper(
         case tt::tt_fabric::FabricTensixConfig::MUX: {
             // MUX mode: Only VC0 channel 0 is used for worker
             uint32_t target_channel = get_worker_connected_sender_channel();
-            size_t vc0_sender_buffer_slots, vc0_receiver_buffer_slots;
-            size_t vc1_sender_buffer_slots, vc1_receiver_buffer_slots;
+            std::array<size_t, builder_config::MAX_NUM_VCS> sender_buffer_slots{};
+            std::array<size_t, builder_config::MAX_NUM_VCS> receiver_buffer_slots{};
 
-            // get the optimal buffer slots for MUX mode (per-VC)
             get_optimal_num_slots_per_vc(
                 default_with_tensix_buffer_slot_options[arch_index],
-                num_used_sender_channels_per_vc[0],
-                num_used_receiver_channels_per_vc[0],
-                num_used_sender_channels_per_vc[1],
-                num_used_receiver_channels_per_vc[1],
-                vc0_sender_buffer_slots,
-                vc0_receiver_buffer_slots,
-                vc1_sender_buffer_slots,
-                vc1_receiver_buffer_slots);
+                num_used_sender_channels_per_vc,
+                num_used_receiver_channels_per_vc,
+                sender_buffer_slots,
+                receiver_buffer_slots);
 
             // set buffer slots for VC0 worker channel only
-            num_sender_buffer_slots_per_vc[0][target_channel] = vc0_sender_buffer_slots;
-            num_remote_sender_buffer_slots_per_vc[0][target_channel] = vc0_sender_buffer_slots;
+            num_sender_buffer_slots_per_vc[0][target_channel] = sender_buffer_slots[0];
+            num_remote_sender_buffer_slots_per_vc[0][target_channel] = sender_buffer_slots[0];
 
-            // Fill receiver buffer slots for both VCs
-            num_receiver_buffer_slots_per_vc[0].fill(vc0_receiver_buffer_slots);
-            num_remote_receiver_buffer_slots_per_vc[0].fill(vc0_receiver_buffer_slots);
-            num_receiver_buffer_slots_per_vc[1].fill(vc1_receiver_buffer_slots);
-            num_remote_receiver_buffer_slots_per_vc[1].fill(vc1_receiver_buffer_slots);
+            // Fill receiver buffer slots for all VCs
+            for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
+                num_receiver_buffer_slots_per_vc[vc].fill(receiver_buffer_slots[vc]);
+                num_remote_receiver_buffer_slots_per_vc[vc].fill(receiver_buffer_slots[vc]);
+            }
             return;
         }
         default: break;
     }
 
     // Default case: Configure buffer slots with per-VC options
-    size_t vc0_sender_buffer_slots, vc0_receiver_buffer_slots;
-    size_t vc1_sender_buffer_slots, vc1_receiver_buffer_slots;
+    std::array<size_t, builder_config::MAX_NUM_VCS> sender_buffer_slots{};
+    std::array<size_t, builder_config::MAX_NUM_VCS> receiver_buffer_slots{};
 
-    // Get optimal buffer slots considering both VCs
     get_optimal_num_slots_per_vc(
         get_num_buffer_slots(topology, arch_index),
-        num_used_sender_channels_per_vc[0],
-        num_used_receiver_channels_per_vc[0],
-        num_used_sender_channels_per_vc[1],
-        num_used_receiver_channels_per_vc[1],
-        vc0_sender_buffer_slots,
-        vc0_receiver_buffer_slots,
-        vc1_sender_buffer_slots,
-        vc1_receiver_buffer_slots);
+        num_used_sender_channels_per_vc,
+        num_used_receiver_channels_per_vc,
+        sender_buffer_slots,
+        receiver_buffer_slots);
 
     // Apply the buffer slot configuration to each VC
-    num_sender_buffer_slots_per_vc[0].fill(vc0_sender_buffer_slots);
-    num_remote_sender_buffer_slots_per_vc[0].fill(vc0_sender_buffer_slots);
-    num_receiver_buffer_slots_per_vc[0].fill(vc0_receiver_buffer_slots);
-    num_remote_receiver_buffer_slots_per_vc[0].fill(vc0_receiver_buffer_slots);
-
-    num_sender_buffer_slots_per_vc[1].fill(vc1_sender_buffer_slots);
-    num_remote_sender_buffer_slots_per_vc[1].fill(vc1_sender_buffer_slots);
-    num_receiver_buffer_slots_per_vc[1].fill(vc1_receiver_buffer_slots);
-    num_remote_receiver_buffer_slots_per_vc[1].fill(vc1_receiver_buffer_slots);
+    for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
+        num_sender_buffer_slots_per_vc[vc].fill(sender_buffer_slots[vc]);
+        num_remote_sender_buffer_slots_per_vc[vc].fill(sender_buffer_slots[vc]);
+        num_receiver_buffer_slots_per_vc[vc].fill(receiver_buffer_slots[vc]);
+        num_remote_receiver_buffer_slots_per_vc[vc].fill(receiver_buffer_slots[vc]);
+    }
 }
 
 void FabricStaticSizedChannelsAllocator::emit_ct_args(std::vector<uint32_t>& ct_args) const {
@@ -550,13 +535,18 @@ void FabricStaticSizedChannelsAllocator::emit_ct_args(std::vector<uint32_t>& ct_
         }
     }
 
-    // Emit receiver channel args for all VCs
+    // Emit receiver channel args for all VCs (always exactly 1 entry per VC)
     for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
-        for (size_t i = 0; i < this->num_used_receiver_channels_per_vc[vc]; ++i) {
-            ct_args.push_back(static_cast<uint32_t>(this->receiver_channels_base_address[vc][i]));
-            ct_args.push_back(this->receiver_channels_num_buffers[vc][i]);
-            ct_args.push_back(static_cast<uint32_t>(this->remote_receiver_channels_base_address[vc][i]));
-            ct_args.push_back(this->remote_receiver_channels_num_buffers[vc][i]);
+        if (this->num_used_receiver_channels_per_vc[vc] > 0) {
+            ct_args.push_back(static_cast<uint32_t>(this->receiver_channels_base_address[vc][0]));
+            ct_args.push_back(this->receiver_channels_num_buffers[vc][0]);
+            ct_args.push_back(static_cast<uint32_t>(this->remote_receiver_channels_base_address[vc][0]));
+            ct_args.push_back(this->remote_receiver_channels_num_buffers[vc][0]);
+        } else {
+            ct_args.push_back(0);  // base_address (inactive VC)
+            ct_args.push_back(0);  // num_buffers (inactive VC)
+            ct_args.push_back(0);  // remote_base_address (inactive VC)
+            ct_args.push_back(0);  // remote_num_buffers (inactive VC)
         }
     }
 }

--- a/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.hpp
+++ b/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.hpp
@@ -11,6 +11,7 @@
 #include "tt_metal/hostdevcommon/api/hostdevcommon/fabric_common.h"
 
 #include <vector>
+#include <numeric>
 #include <ostream>
 
 namespace tt::tt_fabric {
@@ -107,11 +108,10 @@ public:
     }
     // For total counts: return sum across all VCs
     size_t get_num_sender_channels() const {
-        return num_used_sender_channels_per_vc[0] + num_used_sender_channels_per_vc[1];
+        return std::accumulate(
+            num_used_sender_channels_per_vc.begin(), num_used_sender_channels_per_vc.end(), size_t{0});
     }
-    size_t get_num_receiver_channels() const {
-        return num_used_receiver_channels_per_vc[0] + num_used_receiver_channels_per_vc[1];
-    }
+    size_t get_num_receiver_channels() const { return builder_config::MAX_NUM_VCS; }
 
     // Override virtual print method from base class
     void print(std::ostream& os) const override;
@@ -138,8 +138,8 @@ private:
             builder_config::MAX_NUM_VCS>& num_remote_receiver_buffer_slots_per_vc);
 
     // Configuration parameters
-    std::array<size_t, builder_config::MAX_NUM_VCS> num_used_sender_channels_per_vc = {0, 0};
-    std::array<size_t, builder_config::MAX_NUM_VCS> num_used_receiver_channels_per_vc = {0, 0};
+    std::array<size_t, builder_config::MAX_NUM_VCS> num_used_sender_channels_per_vc = {};
+    std::array<size_t, builder_config::MAX_NUM_VCS> num_used_receiver_channels_per_vc = {};
     size_t channel_buffer_size_bytes = 0;
     size_t available_channel_buffering_space = 0;
     size_t max_l1_loading_size = 0;
@@ -188,10 +188,22 @@ inline void FabricStaticSizedChannelsAllocator::print(std::ostream& os) const {
 
     // Configuration parameters
     os << "  Configuration:\n";
-    os << "    num_used_sender_channels_per_vc: [" << num_used_sender_channels_per_vc[0] << ", "
-       << num_used_sender_channels_per_vc[1] << "]\n";
-    os << "    num_used_receiver_channels_per_vc: [" << num_used_receiver_channels_per_vc[0] << ", "
-       << num_used_receiver_channels_per_vc[1] << "]\n";
+    os << "    num_used_sender_channels_per_vc: [";
+    for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
+        if (vc > 0) {
+            os << ", ";
+        }
+        os << num_used_sender_channels_per_vc[vc];
+    }
+    os << "]\n";
+    os << "    num_used_receiver_channels_per_vc: [";
+    for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
+        if (vc > 0) {
+            os << ", ";
+        }
+        os << num_used_receiver_channels_per_vc[vc];
+    }
+    os << "]\n";
     os << "    channel_buffer_size_bytes: " << channel_buffer_size_bytes << " B\n";
     os << "    available_channel_buffering_space: " << available_channel_buffering_space << " B\n";
     os << "    buffer_region_start: 0x" << std::hex << buffer_region_start << std::dec << "\n";

--- a/tt_metal/fabric/builder/router_connection_mapping.cpp
+++ b/tt_metal/fabric/builder/router_connection_mapping.cpp
@@ -120,7 +120,9 @@ RouterConnectionMapping RouterConnectionMapping::for_mesh_router(
         //    continue to use VC0, while inter-mesh connections use VC1
         // 5. The VC assignment is determined by the connection type, not the router capabilities
         //
-        TT_FATAL(outbound_directions.size() <= builder_config::num_downstream_edms_2d_vc0, "Outbound directions size must be less than or equal to num_downstream_edms_2d_vc0");
+        TT_FATAL(
+            outbound_directions.size() <= builder_config::num_downstream_edms_2d_per_vc[0],
+            "Outbound directions size must be less than or equal to num_downstream_edms_2d_per_vc[0]");
 
         // Add VC0 targets for intra-mesh traffic
         for (size_t i = 0; i < outbound_directions.size(); ++i) {

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -727,14 +727,11 @@ FabricEriscDatamoverBuilder::FabricEriscDatamoverBuilder(
             uint32_t worker_channel = get_worker_connected_sender_channel();
             this->is_sender_channel_serviced_[risc_id][worker_channel] = true;
 
-            // All receiver channels serviced in MUX mode
-            size_t receiver_offset = 0;
+            // All receiver channels serviced in MUX mode (indexed by VC directly)
             for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
-                size_t num_channels = receiver_counts[vc];
-                for (size_t i = 0; i < num_channels; ++i) {
-                    this->is_receiver_channel_serviced_[risc_id][receiver_offset + i] = true;
+                if (receiver_counts[vc] > 0) {
+                    this->is_receiver_channel_serviced_[risc_id][vc] = true;
                 }
-                receiver_offset += num_channels;
             }
         } else {
             // Normal mode: Enable channels based on per-VC counts AND this RISC's responsibility
@@ -753,13 +750,11 @@ FabricEriscDatamoverBuilder::FabricEriscDatamoverBuilder(
             }
 
             if (services_receivers) {
-                size_t receiver_offset = 0;
+                // Index receiver channels by VC directly (no flat offset)
                 for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
-                    size_t num_channels = receiver_counts[vc];
-                    for (size_t i = 0; i < num_channels; ++i) {
-                        this->is_receiver_channel_serviced_[risc_id][receiver_offset + i] = true;
+                    if (receiver_counts[vc] > 0) {
+                        this->is_receiver_channel_serviced_[risc_id][vc] = true;
                     }
-                    receiver_offset += num_channels;
                 }
             }
         }
@@ -900,7 +895,8 @@ FabricEriscDatamoverBuilder::CompileTimeArgs FabricEriscDatamoverBuilder::get_co
     // are waiting for the handshake to complete.
     const size_t default_handshake_context_switch_timeout = 4096;
     size_t num_sender_channels = config.num_used_sender_channels;
-    size_t num_receiver_channels = config.num_used_receiver_channels;
+    // Receiver channels always = MAX_NUM_VCS (1 per VC, inactive VCs have 0 buffers)
+    constexpr size_t num_receiver_channels = builder_config::MAX_NUM_VCS;
 
     auto dispatch_core_type = get_core_type_from_config(
         tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config());
@@ -969,22 +965,23 @@ FabricEriscDatamoverBuilder::CompileTimeArgs FabricEriscDatamoverBuilder::get_co
     const auto [is_intermesh_router_on_edge, is_intramesh_router_on_edge] =
         compute_edge_facing_flags(control_plane, this->local_fabric_node_id, this->my_eth_channel);
 
-    // Get actual downstream EDM counts from the adapter (actual connections made)
-    uint32_t num_vc0_downstream_edms = this->receiver_channel_to_downstream_adapter->get_downstream_edm_count_for_vc(0);
+    // VC0 is always active; higher VCs are active only if they have receiver channels configured
+    auto is_vc_active = [&](size_t vc) { return (vc == 0) || (config.num_used_receiver_channels_per_vc[vc] > 0); };
 
-    bool needs_vc1 = config.num_used_receiver_channels_per_vc[1] > 0;
-    // Get actual VC1 downstream EDM count from adapter (only relevant for multi-mesh 2D routing)
-    uint32_t num_vc1_downstream_edms =
-        needs_vc1 ? this->receiver_channel_to_downstream_adapter->get_downstream_edm_count_for_vc(1) : 0;
+    // Get actual downstream EDM counts from the adapter (actual connections made) per VC
+    std::array<uint32_t, builder_config::MAX_NUM_VCS> num_downstream_edms_per_vc = {};
+    for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
+        num_downstream_edms_per_vc[vc] =
+            is_vc_active(vc) ? this->receiver_channel_to_downstream_adapter->get_downstream_edm_count_for_vc(vc) : 0;
+    }
     bool z_router_enabled = fabric_context.has_z_router_on_device(control_plane, local_fabric_node_id);
 
     log_debug(
         LogFabric,
-        "z_router_enabled: {}, needs_vc1: {}, num_vc0_downstream_edms: {}, num_vc1_downstream_edms: {}",
+        "z_router_enabled: {}, num_downstream_edms_per_vc: [{}, {}]",
         z_router_enabled,
-        needs_vc1,
-        num_vc0_downstream_edms,
-        num_vc1_downstream_edms);
+        num_downstream_edms_per_vc[0],
+        num_downstream_edms_per_vc[1]);
     // Calculate array sizes for downstream EDMs based on masks
     // Size = position of highest set bit + 1 (e.g., mask 0x5 = size 3, mask 0x3 = size 2)
     auto calc_array_size_from_mask = [](uint32_t mask) -> uint32_t {
@@ -995,28 +992,24 @@ FabricEriscDatamoverBuilder::CompileTimeArgs FabricEriscDatamoverBuilder::get_co
         return 32 - __builtin_clz(mask);
     };
 
-    uint32_t vc0_downstream_edm_size =
-        calc_array_size_from_mask(this->receiver_channel_to_downstream_adapter->get_downstream_edm_mask_for_vc(0));
-    uint32_t vc1_downstream_edm_size =
-        needs_vc1
-            ? calc_array_size_from_mask(this->receiver_channel_to_downstream_adapter->get_downstream_edm_mask_for_vc(1))
-            : 0;
-
-    // Ensure minimum size of 1 to avoid zero-sized arrays (causes undefined behavior when accessed)
-    // Even if mask is 0 (no downstream connections), we need at least 1 element for the array template
-    if (vc0_downstream_edm_size == 0) {
-        vc0_downstream_edm_size = 1;
-    }
-    if (needs_vc1 && vc1_downstream_edm_size == 0) {
-        vc1_downstream_edm_size = 1;
+    std::array<uint32_t, builder_config::MAX_NUM_VCS> downstream_edm_size_per_vc = {};
+    for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
+        downstream_edm_size_per_vc[vc] =
+            is_vc_active(vc) ? calc_array_size_from_mask(
+                                   this->receiver_channel_to_downstream_adapter->get_downstream_edm_mask_for_vc(vc))
+                             : 0;
+        // Ensure minimum size of 1 to avoid zero-sized arrays (causes undefined behavior when accessed)
+        if (is_vc_active(vc) && downstream_edm_size_per_vc[vc] == 0) {
+            downstream_edm_size_per_vc[vc] = 1;
+        }
     }
 
-    auto actual_sender_channels_vc0 = actual_sender_channels_per_vc_.has_value()
-                                          ? actual_sender_channels_per_vc_.value()[0]
-                                          : config.num_used_sender_channels_per_vc[0];
-    auto actual_sender_channels_vc1 = actual_sender_channels_per_vc_.has_value()
-                                          ? actual_sender_channels_per_vc_.value()[1]
-                                          : config.num_used_sender_channels_per_vc[1];
+    std::array<size_t, builder_config::MAX_NUM_VCS> actual_sender_channels_per_vc = {};
+    for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
+        actual_sender_channels_per_vc[vc] = actual_sender_channels_per_vc_.has_value()
+                                                ? actual_sender_channels_per_vc_.value()[vc]
+                                                : config.num_used_sender_channels_per_vc[vc];
+    }
 
     // ===== Build named compile-time args (all non-pool/channel-mapping args) =====
     std::unordered_map<std::string, uint32_t> named_args;
@@ -1058,6 +1051,7 @@ FabricEriscDatamoverBuilder::CompileTimeArgs FabricEriscDatamoverBuilder::get_co
     named_args["ETH_RETRAIN_LINK_SYNC_STREAM_ID"] = stream_ids[32];
 
     // --- Max channel counts ---
+    named_args["MAX_NUM_VCS"] = builder_config::MAX_NUM_VCS;
     named_args["MAX_NUM_SENDER_CHANNELS"] = builder_config::num_max_sender_channels;
     named_args["MAX_NUM_RECEIVER_CHANNELS"] = builder_config::num_max_receiver_channels;
 
@@ -1068,8 +1062,9 @@ FabricEriscDatamoverBuilder::CompileTimeArgs FabricEriscDatamoverBuilder::get_co
     named_args["NUM_SENDER_CHANNELS"] = static_cast<uint32_t>(num_sender_channels);
     named_args["NUM_RECEIVER_CHANNELS"] = static_cast<uint32_t>(num_receiver_channels);
     named_args["NUM_DOWNSTREAM_CHANNELS"] = static_cast<uint32_t>(config.num_fwd_paths);
-    named_args["NUM_DOWNSTREAM_SENDERS_VC0"] = num_vc0_downstream_edms;
-    named_args["NUM_DOWNSTREAM_SENDERS_VC1"] = num_vc1_downstream_edms;
+    for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
+        named_args[fmt::format("NUM_DOWNSTREAM_SENDERS_VC{}", vc)] = num_downstream_edms_per_vc[vc];
+    }
     named_args["WAIT_FOR_HOST_SIGNAL"] = static_cast<uint32_t>(this->wait_for_host_signal ? 1 : 0);
     named_args["SWITCH_INTERVAL"] = static_cast<uint32_t>(this->firmware_context_switch_interval);
     named_args["FUSE_RECEIVER_FLUSH_AND_COMPLETION_PTR"] = this->fuse_receiver_flush_and_completion_ptr;
@@ -1079,14 +1074,17 @@ FabricEriscDatamoverBuilder::CompileTimeArgs FabricEriscDatamoverBuilder::get_co
     named_args["HANDSHAKE_ADDR"] = static_cast<uint32_t>(this->handshake_address);
     named_args["CHANNEL_BUFFER_SIZE"] = static_cast<uint32_t>(this->channel_buffer_size);
     named_args["FABRIC_TENSIX_EXTENSION_MUX_MODE"] = this->has_tensix_extension;
-    named_args["ENABLE_FIRST_LEVEL_ACK_VC0"] = this->enable_first_level_ack;
-    named_args["ENABLE_FIRST_LEVEL_ACK_VC1"] = 0;  // VC1 does not use bubble flow control
+    // Per-VC first level ack: VC0 may use bubble flow control, VC1+ does not
+    for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
+        named_args[fmt::format("ENABLE_FIRST_LEVEL_ACK_VC{}", vc)] = (vc == 0) ? this->enable_first_level_ack : 0;
+    }
     named_args["ENABLE_RISC_CPU_DATA_CACHE"] = enable_risc_cpu_data_cache;
     named_args["Z_ROUTER_ENABLED"] = z_router_enabled;
-    named_args["VC0_DOWNSTREAM_EDM_SIZE"] = vc0_downstream_edm_size;
-    named_args["VC1_DOWNSTREAM_EDM_SIZE"] = vc1_downstream_edm_size;
-    named_args["ACTUAL_VC0_SENDER_CHANNELS"] = static_cast<uint32_t>(actual_sender_channels_vc0);
-    named_args["ACTUAL_VC1_SENDER_CHANNELS"] = static_cast<uint32_t>(actual_sender_channels_vc1);
+    for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
+        named_args[fmt::format("VC{}_DOWNSTREAM_EDM_SIZE", vc)] = downstream_edm_size_per_vc[vc];
+        named_args[fmt::format("ACTUAL_VC{}_SENDER_CHANNELS", vc)] =
+            static_cast<uint32_t>(actual_sender_channels_per_vc[vc]);
+    }
 
     // --- Remote channel info (always emitted; 0 when inactive) ---
     named_args["SKIP_SRC_CH_ID_UPDATE"] = skip_src_ch_id_update ? 1 : 0;
@@ -1221,20 +1219,19 @@ FabricEriscDatamoverBuilder::CompileTimeArgs FabricEriscDatamoverBuilder::get_co
         named_args["RESOURCE_USAGE_CAPTURE_OUTPUT_L1_ADDRESS"] =
             static_cast<uint32_t>(config.datapath_usage_l1_address);
     }
-    if (channel_trimming_overrides_.has_value()) {
-        named_args["DISABLE_RX_CH0_FORWARDING"] =
-            channel_trimming_overrides_->is_receiver_channel_data_forwarded(0) ? 0 : 1;
-        named_args["DISABLE_RX_CH1_FORWARDING"] =
-            channel_trimming_overrides_->is_receiver_channel_data_forwarded(1) ? 0 : 1;
-    } else {
-        named_args["DISABLE_RX_CH0_FORWARDING"] = 0;
-        named_args["DISABLE_RX_CH1_FORWARDING"] = 0;
+    for (size_t ch = 0; ch < builder_config::num_max_receiver_channels; ++ch) {
+        if (channel_trimming_overrides_.has_value()) {
+            named_args[fmt::format("DISABLE_RX_CH{}_FORWARDING", ch)] =
+                channel_trimming_overrides_->is_receiver_channel_data_forwarded(ch) ? 0 : 1;
+        } else {
+            named_args[fmt::format("DISABLE_RX_CH{}_FORWARDING", ch)] = 0;
+        }
     }
 
     // Credit amortization named compile-time args
     uint32_t sender_amort_freq = 0;
     uint32_t receiver_amort_freq = 0;
-    if (actual_sender_channels_vc0 == 1) {
+    if (actual_sender_channels_per_vc[0] == 1) {
         auto* static_alloc =
             dynamic_cast<tt::tt_fabric::FabricStaticSizedChannelsAllocator*>(config.channel_allocator.get());
         if (static_alloc != nullptr) {
@@ -1254,7 +1251,7 @@ FabricEriscDatamoverBuilder::CompileTimeArgs FabricEriscDatamoverBuilder::get_co
     auto* static_alloc_ptr = dynamic_cast<FabricStaticSizedChannelsAllocator*>(config.channel_allocator.get());
     TT_FATAL(static_alloc_ptr != nullptr, "Channel allocator must be a FabricStaticSizedChannelsAllocator");
     static_alloc_ptr->emit_channel_allocations_ct_args(
-        ct_args, actual_sender_channels_vc0, actual_sender_channels_vc1, num_receiver_channels);
+        ct_args, actual_sender_channels_per_vc[0], actual_sender_channels_per_vc[1], num_receiver_channels);
 
     // Emit remote channel allocations
     ct_args.push_back(0xabaddad6);
@@ -1316,14 +1313,11 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_runtime_args() const {
             this->downstream_vcs_sender_channel_buffer_index_semaphore_id[8]),  // 9th channel for Z routers
     };
 
-    // Pack VC0 runtime args
-    receiver_channel_to_downstream_adapter->pack_inbound_channel_rt_args(0, rt_args);
-
-    // Pack VC1 runtime args if VC1 is configured
-    // Both inter-mesh and intra-mesh routers have VC1 in multi-mesh topologies
-    bool needs_vc1 = config.num_used_receiver_channels_per_vc[1] > 0;
-    if (needs_vc1) {
-        receiver_channel_to_downstream_adapter->pack_inbound_channel_rt_args(1, rt_args);
+    // Pack per-VC runtime args
+    for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
+        if (config.num_used_receiver_channels_per_vc[vc] > 0) {
+            receiver_channel_to_downstream_adapter->pack_inbound_channel_rt_args(vc, rt_args);
+        }
     }
 
     // Pack runtime args - device side reads fixed MAX_NUM_SENDER_CHANNELS values

--- a/tt_metal/fabric/erisc_datamover_builder.hpp
+++ b/tt_metal/fabric/erisc_datamover_builder.hpp
@@ -127,16 +127,6 @@ struct StreamRegAssignments {
     // Receiver channel free slots stream IDs (per-VC, 4 edges each)
     static constexpr std::array<std::array<uint32_t, 4>, builder_config::MAX_NUM_VCS>
         vc_free_slots_from_downstream_edge = {{{14, 15, 16, 17}, {18, 19, 20, 21}}};
-    // Legacy aliases
-    // TODO - SNIJJAR - REVIEW. PREVIOUSLY WAS HARDCODED TO BE THE VALUES ABOVE!
-    static constexpr uint32_t vc_0_free_slots_from_downstream_edge_1 = vc_free_slots_from_downstream_edge[0][0];
-    static constexpr uint32_t vc_0_free_slots_from_downstream_edge_2 = vc_free_slots_from_downstream_edge[0][1];
-    static constexpr uint32_t vc_0_free_slots_from_downstream_edge_3 = vc_free_slots_from_downstream_edge[0][2];
-    static constexpr uint32_t vc_0_free_slots_from_downstream_edge_4 = vc_free_slots_from_downstream_edge[0][3];
-    static constexpr uint32_t vc_1_free_slots_from_downstream_edge_1 = vc_free_slots_from_downstream_edge[1][0];
-    static constexpr uint32_t vc_1_free_slots_from_downstream_edge_2 = vc_free_slots_from_downstream_edge[1][1];
-    static constexpr uint32_t vc_1_free_slots_from_downstream_edge_3 = vc_free_slots_from_downstream_edge[1][2];
-    static constexpr uint32_t vc_1_free_slots_from_downstream_edge_4 = vc_free_slots_from_downstream_edge[1][3];
     // Sender channel free slots stream IDs.
     // Decremented by respective upstream senders.
     static constexpr uint32_t sender_channel_0_free_slots_stream_id = 22;  // for upstream tensix worker
@@ -179,14 +169,14 @@ struct StreamRegAssignments {
             to_sender_5_pkts_completed_id,
             to_sender_6_pkts_completed_id,
             to_sender_7_pkts_completed_id,
-            vc_0_free_slots_from_downstream_edge_1,
-            vc_0_free_slots_from_downstream_edge_2,
-            vc_0_free_slots_from_downstream_edge_3,
-            vc_0_free_slots_from_downstream_edge_4,
-            vc_1_free_slots_from_downstream_edge_1,
-            vc_1_free_slots_from_downstream_edge_2,
-            vc_1_free_slots_from_downstream_edge_3,
-            vc_1_free_slots_from_downstream_edge_4,
+            vc_free_slots_from_downstream_edge[0][0],
+            vc_free_slots_from_downstream_edge[0][1],
+            vc_free_slots_from_downstream_edge[0][2],
+            vc_free_slots_from_downstream_edge[0][3],
+            vc_free_slots_from_downstream_edge[1][0],
+            vc_free_slots_from_downstream_edge[1][1],
+            vc_free_slots_from_downstream_edge[1][2],
+            vc_free_slots_from_downstream_edge[1][3],
             sender_channel_0_free_slots_stream_id,
             sender_channel_1_free_slots_stream_id,
             sender_channel_2_free_slots_stream_id,

--- a/tt_metal/fabric/erisc_datamover_builder.hpp
+++ b/tt_metal/fabric/erisc_datamover_builder.hpp
@@ -107,7 +107,9 @@ Receiver channel side registers are defined here to receive free-slot credits fr
                                    South Router
 */
 struct StreamRegAssignments {
-    // Packet send/ack/complete stream IDs
+    // Packet send/ack/complete stream IDs (per-VC receiver)
+    static constexpr std::array<uint32_t, builder_config::MAX_NUM_VCS> to_receiver_pkts_sent_id = {0, 1};
+    // Legacy aliases
     static constexpr uint32_t to_receiver_0_pkts_sent_id = 0;      // VC0 Ethernet Rx
     static constexpr uint32_t to_receiver_1_pkts_sent_id = 1;      // VC1 Ethernet Rx
     static constexpr uint32_t to_sender_0_pkts_acked_id = 2;       // VC0 Ethernet Sender Channel 0
@@ -122,23 +124,19 @@ struct StreamRegAssignments {
     static constexpr uint32_t to_sender_5_pkts_completed_id = 11;  // VC1 Passthrough from upstream device X/Y edge
     static constexpr uint32_t to_sender_6_pkts_completed_id = 12;  // VC1 Passthrough from upstream device X/Y edge
     static constexpr uint32_t to_sender_7_pkts_completed_id = 13;  // VC1 Passthrough from upstream device X/Y edge
-    // Receiver channel free slots stream IDs
-    static constexpr uint32_t vc_0_free_slots_from_downstream_edge_1 =
-        14;  // for downstream E/W/N/S edge on: 2D X/Y Router->VC0, E edge on: 2D Z Router->VC0
-    static constexpr uint32_t vc_0_free_slots_from_downstream_edge_2 =
-        15;  // for downstream E/W/N/S edge on: 2D X/Y Router->VC0, W edge on: 2D Z Router->VC0
-    static constexpr uint32_t vc_0_free_slots_from_downstream_edge_3 =
-        16;  // for downstream E/W/N/S edge on: 2D X/Y Router->VC0, N edge on: 2D Z Router->VC0
-    static constexpr uint32_t vc_0_free_slots_from_downstream_edge_4 =
-        17;  // for downstream Z edge on: 2D+Z X/Y Router->VC0, S edge on: 2D Z Router->VC0
-    static constexpr uint32_t vc_1_free_slots_from_downstream_edge_1 =
-        18;  // for downstream E/W/N/S edge on: 2D X/Y Router->VC1
-    static constexpr uint32_t vc_1_free_slots_from_downstream_edge_2 =
-        19;  // for downstream E/W/N/S edge on: 2D X/Y Router->VC1
-    static constexpr uint32_t vc_1_free_slots_from_downstream_edge_3 =
-        20;  // for downstream E/W/N/S edge on: 2D X/Y Router->VC1
-    static constexpr uint32_t vc_1_free_slots_from_downstream_edge_4 =
-        21;  // for downstream Z edge on: 2D+Z X/Y Router->VC1, S edge on: 2D Z Router->VC1
+    // Receiver channel free slots stream IDs (per-VC, 4 edges each)
+    static constexpr std::array<std::array<uint32_t, 4>, builder_config::MAX_NUM_VCS>
+        vc_free_slots_from_downstream_edge = {{{14, 15, 16, 17}, {18, 19, 20, 21}}};
+    // Legacy aliases
+    // TODO - SNIJJAR - REVIEW. PREVIOUSLY WAS HARDCODED TO BE THE VALUES ABOVE!
+    static constexpr uint32_t vc_0_free_slots_from_downstream_edge_1 = vc_free_slots_from_downstream_edge[0][0];
+    static constexpr uint32_t vc_0_free_slots_from_downstream_edge_2 = vc_free_slots_from_downstream_edge[0][1];
+    static constexpr uint32_t vc_0_free_slots_from_downstream_edge_3 = vc_free_slots_from_downstream_edge[0][2];
+    static constexpr uint32_t vc_0_free_slots_from_downstream_edge_4 = vc_free_slots_from_downstream_edge[0][3];
+    static constexpr uint32_t vc_1_free_slots_from_downstream_edge_1 = vc_free_slots_from_downstream_edge[1][0];
+    static constexpr uint32_t vc_1_free_slots_from_downstream_edge_2 = vc_free_slots_from_downstream_edge[1][1];
+    static constexpr uint32_t vc_1_free_slots_from_downstream_edge_3 = vc_free_slots_from_downstream_edge[1][2];
+    static constexpr uint32_t vc_1_free_slots_from_downstream_edge_4 = vc_free_slots_from_downstream_edge[1][3];
     // Sender channel free slots stream IDs.
     // Decremented by respective upstream senders.
     static constexpr uint32_t sender_channel_0_free_slots_stream_id = 22;  // for upstream tensix worker
@@ -318,8 +316,10 @@ struct FabricEriscDatamoverConfig {
 
     std::size_t num_used_sender_channels = 0;    // Total across all VCs (duplicate in allocator... don't modify)
     std::size_t num_used_receiver_channels = 0;  // Total across all VCs (duplicate in allocator... don't modify)
-    std::array<std::size_t, builder_config::MAX_NUM_VCS> num_used_sender_channels_per_vc = {0, 0};    // Per-VC sender channel counts
-    std::array<std::size_t, builder_config::MAX_NUM_VCS> num_used_receiver_channels_per_vc = {0, 0};  // Per-VC receiver channel counts
+    std::array<std::size_t, builder_config::MAX_NUM_VCS> num_used_sender_channels_per_vc =
+        {};  // Per-VC sender channel counts
+    std::array<std::size_t, builder_config::MAX_NUM_VCS> num_used_receiver_channels_per_vc =
+        {};  // Per-VC receiver channel counts
     std::size_t num_fwd_paths = 0;
     std::size_t sender_txq_id = 0;
     std::size_t receiver_txq_id = 0;

--- a/tt_metal/fabric/fabric_router_channel_mapping.cpp
+++ b/tt_metal/fabric/fabric_router_channel_mapping.cpp
@@ -25,109 +25,111 @@ FabricRouterChannelMapping::FabricRouterChannelMapping(
 }
 
 void FabricRouterChannelMapping::initialize_mappings() {
-    initialize_vc0_mappings();
-    initialize_vc1_mappings();
+    for (uint32_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
+        initialize_vc_mappings(vc);
+    }
 }
 
-void FabricRouterChannelMapping::initialize_vc0_mappings() {
+void FabricRouterChannelMapping::initialize_vc_mappings(uint32_t vc) {
     const bool is_2d = is_2D_topology(topology_);
 
-    if (is_2d) {
-        // 2D topology VC0 sender channels:
-        //   Z_ROUTER: 5 channels (0=Worker, 1-4=E/W/N/S)
-        //   MESH: 4 channels (0=Worker, 1-3=mesh directions)
-        auto num_sender_channels = is_z_router() ? builder_config::num_sender_channels_z_router_vc0  // 5 channels
-                                                 : builder_config::num_sender_channels_2d_mesh;      // 4 channels
+    if (vc == 0) {
+        // VC0 sender channel setup
+        if (is_2d) {
+            // 2D topology VC0 sender channels:
+            //   Z_ROUTER: 5 channels (0=Worker, 1-4=E/W/N/S)
+            //   MESH: 4 channels (0=Worker, 1-3=mesh directions)
+            auto num_sender_channels = is_z_router()
+                                           ? builder_config::num_sender_channels_z_router_per_vc[0]  // 5 channels
+                                           : builder_config::num_sender_channels_2d_mesh;            // 4 channels
 
-        log_debug(
-            LogFabric,
-            "initialize_vc0_mappings: variant={}, is_z_router={}, num_sender_channels={}",
-            static_cast<int>(variant_),
-            is_z_router(),
-            num_sender_channels);
+            log_debug(
+                LogFabric,
+                "initialize_vc_mappings: vc={}, variant={}, is_z_router={}, num_sender_channels={}",
+                vc,
+                static_cast<int>(variant_),
+                is_z_router(),
+                num_sender_channels);
 
-        for (uint32_t i = 0; i < num_sender_channels; ++i) {
-            // When mux extension is enabled, ALL VC0 channels go to TENSIX mux
-            BuilderType builder_type = downstream_is_tensix_builder_ ? BuilderType::TENSIX : BuilderType::ERISC;
-            sender_channel_map_[LogicalSenderChannelKey{0, i}] =
-                InternalSenderChannelMapping{builder_type, i};
+            for (uint32_t i = 0; i < num_sender_channels; ++i) {
+                // When mux extension is enabled, ALL VC0 channels go to TENSIX mux
+                BuilderType builder_type = downstream_is_tensix_builder_ ? BuilderType::TENSIX : BuilderType::ERISC;
+                sender_channel_map_[LogicalSenderChannelKey{vc, i}] = InternalSenderChannelMapping{builder_type, i};
+            }
+        } else if (topology_ == Topology::NeighborExchange) {
+            // Neighbor Exchange topology VC0 has 1 sender channel:
+            //  [0] = local worker channel
+            TT_FATAL(!downstream_is_tensix_builder_, "Neighbor Exchange topology does not support mux extension");
+            sender_channel_map_[LogicalSenderChannelKey{vc, 0}] = InternalSenderChannelMapping{BuilderType::ERISC, 0};
+        } else {
+            // 1D topology VC0 has 2 sender channels (relative indices within VC0):
+            //   [0] = local worker channel
+            //   [1] = forwarding channel from upstream router
+            BuilderType vc0_builder_type = downstream_is_tensix_builder_ ? BuilderType::TENSIX : BuilderType::ERISC;
+            sender_channel_map_[LogicalSenderChannelKey{vc, 0}] =
+                InternalSenderChannelMapping{vc0_builder_type, 0};  // worker channel
+            sender_channel_map_[LogicalSenderChannelKey{vc, 1}] =
+                InternalSenderChannelMapping{vc0_builder_type, 1};  // forward channel
         }
-    } else if (topology_ == Topology::NeighborExchange) {
-        // Neighbor Exchange topology VC0 has 1 sender channel:
-        //  [0] = local worker channel
-        // Neighbor Exchange topology currently does not support mux extension
-        TT_FATAL(!downstream_is_tensix_builder_, "Neighbor Exchange topology does not support mux extension");
-        sender_channel_map_[LogicalSenderChannelKey{0, 0}] = InternalSenderChannelMapping{BuilderType::ERISC, 0};
-    } else {
-        // 1D topology VC0 has 2 sender channels (relative indices within VC0):
-        //   [0] = local worker channel
-        //   [1] = forwarding channel from upstream router
-        // When mux extension is enabled, ALL VC0 channels go to TENSIX mux
-        BuilderType vc0_builder_type = downstream_is_tensix_builder_ ? BuilderType::TENSIX : BuilderType::ERISC;
-        sender_channel_map_[LogicalSenderChannelKey{0, 0}] =
-            InternalSenderChannelMapping{vc0_builder_type, 0};  // worker channel
-        sender_channel_map_[LogicalSenderChannelKey{0, 1}] =
-            InternalSenderChannelMapping{vc0_builder_type, 1};  // forward channel
-    }
-    // Receiver channel (typically single receiver channel per VC)
-    receiver_channel_map_[LogicalReceiverChannelKey{0, 0}] = InternalReceiverChannelMapping{BuilderType::ERISC, 0};
-}
-
-void FabricRouterChannelMapping::initialize_vc1_mappings() {
-    const bool is_2d = is_2D_topology(topology_);
-    if (!is_2d) {
-        // VC1 (intermesh) only exists for 2D topologies and Z routers
-        return;
-    }
-
-    if (is_z_router()) {
-        // Z routers exist only for intermesh connectivity - validate config
-        TT_FATAL(
-            intermesh_vc_config_ != nullptr,
-            "Z router requires intermesh VC config (Z routers only exist for intermesh connectivity)");
-        TT_FATAL(
-            intermesh_vc_config_->requires_vc1,
-            "Z router requires intermesh VC to be enabled (requires_vc1 must be true)");
-
-        // Z Router VC1 layout:
-        // - Sender channels 0-3: Map to erisc internal channels 5-8 (mesh→Z traffic)
-        // - Receiver channel 0: Maps to erisc internal channel 1 (Z→mesh traffic)
-
-        constexpr uint32_t z_router_vc1_sender_count = builder_config::num_sender_channels_z_router_vc1;
-        constexpr uint32_t z_router_vc1_base_sender_channel = builder_config::num_sender_channels_z_router_vc0;
-        constexpr uint32_t z_router_vc1_receiver_channel = 1;
-
-        for (uint32_t i = 0; i < z_router_vc1_sender_count; ++i) {
-            sender_channel_map_[LogicalSenderChannelKey{1, i}] =
-                InternalSenderChannelMapping{BuilderType::ERISC, z_router_vc1_base_sender_channel + i};
+        // Receiver channel (typically single receiver channel per VC)
+        receiver_channel_map_[LogicalReceiverChannelKey{vc, 0}] = InternalReceiverChannelMapping{BuilderType::ERISC, 0};
+    } else if (vc == 1) {
+        // VC1+ (intermesh) only exists for 2D topologies and Z routers
+        if (!is_2d) {
+            return;
         }
 
-        receiver_channel_map_[LogicalReceiverChannelKey{1, 0}] =
-            InternalReceiverChannelMapping{BuilderType::ERISC, z_router_vc1_receiver_channel};
-    } else {
-        // Standard mesh router VC1: create if intermesh VC is required
-        // Both inter-mesh and intra-mesh routers have VC1
-        if (intermesh_vc_config_ && intermesh_vc_config_->requires_vc1) {
-            // Determine sender count based on whether device has Z router
-            // Mesh with Z: 4 sender channels (3 mesh directions + 1 for Z router connection)
-            // Mesh without Z: 3 sender channels (3 mesh directions only)
-            uint32_t mesh_vc1_sender_count = has_z_on_device_ ? 4 : 3;
+        if (is_z_router()) {
+            // Z routers exist only for intermesh connectivity - validate config
+            TT_FATAL(
+                intermesh_vc_config_ != nullptr,
+                "Z router requires intermesh VC config (Z routers only exist for intermesh connectivity)");
+            TT_FATAL(
+                intermesh_vc_config_->requires_vc1,
+                "Z router requires intermesh VC to be enabled (requires_vc1 must be true)");
 
-            uint32_t mesh_vc1_base_sender_channel = builder_config::num_sender_channels_2d_mesh;
-            constexpr uint32_t mesh_vc1_receiver_channel = 1;
+            // Z Router VC1 layout:
+            // - Sender channels 0-3: Map to erisc internal channels 5-8 (mesh→Z traffic)
+            // - Receiver channel 0: Maps to erisc internal channel 1 (Z→mesh traffic)
+            uint32_t vc1_sender_count = builder_config::num_sender_channels_z_router_per_vc[vc];
+            // Compute base sender channel as prefix sum of all previous VCs' sender counts
+            uint32_t base_sender_channel = 0;
+            for (uint32_t v = 0; v < vc; ++v) {
+                base_sender_channel += builder_config::num_sender_channels_z_router_per_vc[v];
+            }
+            uint32_t receiver_channel = vc;  // VC0=0, VC1=1, etc.
 
-            // Create sender channels (3 or 4 depending on router type)
-            for (uint32_t i = 0; i < mesh_vc1_sender_count; ++i) {
-                sender_channel_map_[LogicalSenderChannelKey{1, i}] =
-                    InternalSenderChannelMapping{BuilderType::ERISC, mesh_vc1_base_sender_channel + i};
+            for (uint32_t i = 0; i < vc1_sender_count; ++i) {
+                sender_channel_map_[LogicalSenderChannelKey{vc, i}] =
+                    InternalSenderChannelMapping{BuilderType::ERISC, base_sender_channel + i};
             }
 
-            // Create ONE receiver channel for VC1
-            // A receiver channel forwards to multiple downstream sender channels
-            receiver_channel_map_[LogicalReceiverChannelKey{1, 0}] =
-                InternalReceiverChannelMapping{BuilderType::ERISC, mesh_vc1_receiver_channel};
+            receiver_channel_map_[LogicalReceiverChannelKey{vc, 0}] =
+                InternalReceiverChannelMapping{BuilderType::ERISC, receiver_channel};
+        } else {
+            // Standard mesh router VC1+: create if intermesh VC is required
+            if (intermesh_vc_config_ && intermesh_vc_config_->requires_vc1) {
+                // Determine sender count based on whether device has Z router
+                // Mesh with Z: 4 sender channels (3 mesh directions + 1 for Z router connection)
+                // Mesh without Z: 3 sender channels (3 mesh directions only)
+                uint32_t mesh_vc1_sender_count = has_z_on_device_ ? 4 : 3;
+
+                uint32_t mesh_vc1_base_sender_channel = builder_config::num_sender_channels_2d_mesh;
+                uint32_t mesh_vc1_receiver_channel = vc;  // VC0=0, VC1=1, etc.
+
+                // Create sender channels (3 or 4 depending on router type)
+                for (uint32_t i = 0; i < mesh_vc1_sender_count; ++i) {
+                    sender_channel_map_[LogicalSenderChannelKey{vc, i}] =
+                        InternalSenderChannelMapping{BuilderType::ERISC, mesh_vc1_base_sender_channel + i};
+                }
+
+                // Create ONE receiver channel for this VC
+                receiver_channel_map_[LogicalReceiverChannelKey{vc, 0}] =
+                    InternalReceiverChannelMapping{BuilderType::ERISC, mesh_vc1_receiver_channel};
+            }
         }
-        // If intermesh VC not required, don't create VC1 mappings
+    } else {
+        TT_FATAL(false, "Invalid VC: {}. Currently unsupported", vc);
     }
 }
 
@@ -176,16 +178,16 @@ uint32_t FabricRouterChannelMapping::get_num_sender_channels_for_vc(uint32_t vc)
         case 0:  // VC0
             if (is_z_router()) {
                 // Only Z routers have 5 VC0 channels (0=Worker, 1-4=E/W/N/S)
-                return builder_config::num_sender_channels_z_router_vc0;  // 5 channels
+                return builder_config::num_sender_channels_z_router_per_vc[0];  // 5 channels
             } else {
                 // All mesh routers (MESH and MESH_AND_Z_ROUTER) have 4 VC0 channels
                 return builder_config::get_num_used_sender_channel_count(get_topology());  // 4 channels
             }
         case 1:  // VC1
             if (is_z_router()) {
-                return builder_config::num_sender_channels_z_router_vc1;
+                return builder_config::num_sender_channels_z_router_per_vc[1];
             } else if (is_2D_topology(topology_)) {
-                // Check if VC1 mappings were actually created in initialize_vc1_mappings()
+                // Check if VC1 mappings were actually created in initialize_vc_mappings()
                 // Count how many sender channels exist for VC1
                 LogicalSenderChannelKey test_key{vc1_index, 0};
                 if (!sender_channel_map_.contains(test_key)) {

--- a/tt_metal/fabric/fabric_router_channel_mapping.hpp
+++ b/tt_metal/fabric/fabric_router_channel_mapping.hpp
@@ -129,8 +129,7 @@ private:
     std::map<LogicalReceiverChannelKey, InternalReceiverChannelMapping> receiver_channel_map_;
 
     void initialize_mappings();
-    void initialize_vc0_mappings();
-    void initialize_vc1_mappings();
+    void initialize_vc_mappings(uint32_t vc);
 };
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/fabric/fabric_tensix_builder.cpp
+++ b/tt_metal/fabric/fabric_tensix_builder.cpp
@@ -482,7 +482,8 @@ std::map<ChannelTypes, uint32_t> FabricTensixDatamoverConfig::calculate_mux_chan
         bool is_2D_routing = fabric_context.is_2D_routing_enabled();
 
         // Router channel count: 1 for 1D topologies, 3 for 2D topologies
-        channel_counts[ChannelTypes::ROUTER_CHANNEL] = builder_config::get_vc0_downstream_edm_count(is_2D_routing);
+        channel_counts[ChannelTypes::ROUTER_CHANNEL] =
+            builder_config::get_downstream_edm_count_for_vc(0, is_2D_routing);
         channel_counts[ChannelTypes::WORKER_CHANNEL] = 1;  // Always 1 worker channel in legacy mode
     }
 

--- a/tt_metal/fabric/hw/inc/edm_fabric/compile_time_arg_tmp.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/compile_time_arg_tmp.hpp
@@ -52,9 +52,11 @@ constexpr auto initialize_receiver_channel_trid_starts() -> std::array<uint8_t, 
 template <size_t NUM_TO_TAKE, size_t IN_ARRAY_SIZE, typename T>
 constexpr auto take_first_n_elements(const std::array<T, IN_ARRAY_SIZE>& arr_in) -> std::array<T, NUM_TO_TAKE> {
     std::array<T, NUM_TO_TAKE> arr{};
-    for (size_t i = 0; i < NUM_TO_TAKE; i++) {
+    constexpr size_t copy_count = NUM_TO_TAKE < IN_ARRAY_SIZE ? NUM_TO_TAKE : IN_ARRAY_SIZE;
+    for (size_t i = 0; i < copy_count; i++) {
         arr[i] = arr_in[i];
     }
+    // Elements beyond IN_ARRAY_SIZE are value-initialized to T{} (from arr{} above)
     return arr;
 }
 

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_flow_control_helpers.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_flow_control_helpers.hpp
@@ -212,11 +212,16 @@ struct OutboundReceiverChannelPointers {
     }
 
     FORCE_INLINE void init(uint32_t const remote_receiver_buffer_address, uint32_t const slot_size_bytes) {
-        this->slot_size_bytes = slot_size_bytes;
-        this->remote_receiver_channel_address_base = remote_receiver_buffer_address;
-        this->remote_receiver_channel_address_ptr = remote_receiver_buffer_address;
-        this->remote_receiver_channel_address_last = remote_receiver_buffer_address + ((RECEIVER_NUM_BUFFERS - 1U) * slot_size_bytes);
-        this->num_free_slots = RECEIVER_NUM_BUFFERS;
+        if constexpr (RECEIVER_NUM_BUFFERS == 0) {
+            init();
+        } else {
+            this->slot_size_bytes = slot_size_bytes;
+            this->remote_receiver_channel_address_base = remote_receiver_buffer_address;
+            this->remote_receiver_channel_address_ptr = remote_receiver_buffer_address;
+            this->remote_receiver_channel_address_last =
+                remote_receiver_buffer_address + ((RECEIVER_NUM_BUFFERS - 1U) * slot_size_bytes);
+            this->num_free_slots = RECEIVER_NUM_BUFFERS;
+        }
     }
 
     FORCE_INLINE bool has_space_for_packet() const { return num_free_slots; }

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_datamover_channels.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_datamover_channels.hpp
@@ -215,7 +215,11 @@ public:
     }
 
     FORCE_INLINE uint32_t channel_base_address() const {
-        return static_cast<uint32_t>(this->buffer_addresses[0]);
+        if constexpr (NUM_BUFFERS == 0) {
+            return 0;
+        } else {
+            return static_cast<uint32_t>(this->buffer_addresses[0]);
+        }
     }
 
 private:

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
@@ -76,12 +76,39 @@ constexpr uint32_t ETH_RETRAIN_LINK_SYNC_STREAM_ID = NAMED_CT_ARG("ETH_RETRAIN_L
 // ============================================================================
 constexpr size_t MAX_NUM_SENDER_CHANNELS = NAMED_CT_ARG("MAX_NUM_SENDER_CHANNELS");
 constexpr size_t MAX_NUM_RECEIVER_CHANNELS = NAMED_CT_ARG("MAX_NUM_RECEIVER_CHANNELS");
+constexpr size_t MAX_NUM_VCS = NAMED_CT_ARG("MAX_NUM_VCS");
+
+// Per-VC actual sender channel counts
+constexpr size_t ACTUAL_VC0_SENDER_CHANNELS = NAMED_CT_ARG("ACTUAL_VC0_SENDER_CHANNELS");
+constexpr size_t ACTUAL_VC1_SENDER_CHANNELS = NAMED_CT_ARG("ACTUAL_VC1_SENDER_CHANNELS");
+
 // VC0 and VC1 channel counts depend on router type:
 // Z_ROUTER: 5 VC0 + 4 VC1 = 9 total
 // MESH: 4 VC0 + 4 VC1 = 8 total (with some unused)
-constexpr size_t MAX_NUM_SENDER_CHANNELS_VC0 = (MAX_NUM_SENDER_CHANNELS >= 9) ? 5 : 4;
-constexpr size_t MAX_NUM_SENDER_CHANNELS_VC1 = MAX_NUM_SENDER_CHANNELS - MAX_NUM_SENDER_CHANNELS_VC0;
-constexpr size_t VC1_SENDER_CHANNEL_START = MAX_NUM_SENDER_CHANNELS_VC0;
+constexpr size_t MAX_NUM_SENDER_CHANNELS_VC0 = ACTUAL_VC0_SENDER_CHANNELS;
+constexpr size_t MAX_NUM_SENDER_CHANNELS_VC1 = ACTUAL_VC1_SENDER_CHANNELS;
+constexpr size_t VC1_SENDER_CHANNEL_START = ACTUAL_VC0_SENDER_CHANNELS;
+
+static_assert(
+    MAX_NUM_VCS == 2, "MAX_NUM_VCS must be 2 for the current implementation. Additional VCs required code changes");
+// Per-VC arrays (for N-VC generalization)
+constexpr size_t ACTUAL_SENDER_CHANNELS_PER_VC[MAX_NUM_VCS] = {ACTUAL_VC0_SENDER_CHANNELS, ACTUAL_VC1_SENDER_CHANNELS};
+constexpr size_t VC_SENDER_CHANNEL_START[MAX_NUM_VCS] = {0, ACTUAL_VC0_SENDER_CHANNELS};
+
+// ============================================================================
+// Per-VC sender channel array slicing helper
+// Extracts a sub-array for a given VC from a flat MAX_NUM_SENDER_CHANNELS-sized array
+// ============================================================================
+template <size_t vc, typename T, size_t N>
+constexpr auto slice_sender_channels_for_vc(const std::array<T, N>& flat) {
+    constexpr size_t offset = VC_SENDER_CHANNEL_START[vc];
+    constexpr size_t count = ACTUAL_SENDER_CHANNELS_PER_VC[vc];
+    std::array<T, count> result{};
+    for (size_t i = 0; i < count; i++) {
+        result[i] = flat[offset + i];
+    }
+    return result;
+}
 
 // ============================================================================
 // Downstream tensix connections
@@ -96,11 +123,11 @@ constexpr size_t NUM_RECEIVER_CHANNELS = NAMED_CT_ARG("NUM_RECEIVER_CHANNELS");
 constexpr size_t NUM_DOWNSTREAM_CHANNELS = NAMED_CT_ARG("NUM_DOWNSTREAM_CHANNELS");
 constexpr size_t NUM_DOWNSTREAM_SENDERS_VC0 = NAMED_CT_ARG("NUM_DOWNSTREAM_SENDERS_VC0");
 constexpr size_t NUM_DOWNSTREAM_SENDERS_VC1 = NAMED_CT_ARG("NUM_DOWNSTREAM_SENDERS_VC1");
+constexpr size_t NUM_DOWNSTREAM_SENDERS_PER_VC[MAX_NUM_VCS] = {NUM_DOWNSTREAM_SENDERS_VC0, NUM_DOWNSTREAM_SENDERS_VC1};
 constexpr bool wait_for_host_signal = NAMED_CT_ARG("WAIT_FOR_HOST_SIGNAL");
 
-static_assert(
-    NUM_RECEIVER_CHANNELS <= NUM_SENDER_CHANNELS,
-    "NUM_RECEIVER_CHANNELS must be less than or equal to NUM_SENDER_CHANNELS");
+// NUM_RECEIVER_CHANNELS = MAX_NUM_VCS (one per VC, with 0-buffer placeholders for inactive VCs)
+// This can exceed NUM_SENDER_CHANNELS when VCs have receivers but no senders
 static_assert(
     NUM_RECEIVER_CHANNELS <= MAX_NUM_RECEIVER_CHANNELS,
     "NUM_RECEIVER_CHANNELS must be less than or equal to MAX_NUM_RECEIVER_CHANNELS");
@@ -123,6 +150,7 @@ constexpr size_t handshake_addr = NAMED_CT_ARG("HANDSHAKE_ADDR");
 
 static_assert(fuse_receiver_flush_and_completion_ptr == 1, "fuse_receiver_flush_and_completion_ptr must be 0");
 
+// Receiver channels are indexed directly by VC (no flat/compact indexing)
 constexpr size_t VC0_RECEIVER_CHANNEL = 0;
 constexpr size_t VC1_RECEIVER_CHANNEL = 1;
 
@@ -141,12 +169,12 @@ constexpr bool skip_src_ch_id_update = fabric_tensix_extension_mux_mode;
 
 constexpr bool ENABLE_FIRST_LEVEL_ACK_VC0 = NAMED_CT_ARG("ENABLE_FIRST_LEVEL_ACK_VC0");
 constexpr bool ENABLE_FIRST_LEVEL_ACK_VC1 = NAMED_CT_ARG("ENABLE_FIRST_LEVEL_ACK_VC1");
+constexpr bool ENABLE_FIRST_LEVEL_ACK_PER_VC[MAX_NUM_VCS] = {ENABLE_FIRST_LEVEL_ACK_VC0, ENABLE_FIRST_LEVEL_ACK_VC1};
 constexpr bool ENABLE_RISC_CPU_DATA_CACHE = NAMED_CT_ARG("ENABLE_RISC_CPU_DATA_CACHE");
 constexpr bool z_router_enabled = NAMED_CT_ARG("Z_ROUTER_ENABLED");
 constexpr size_t VC0_DOWNSTREAM_EDM_SIZE = NAMED_CT_ARG("VC0_DOWNSTREAM_EDM_SIZE");
 constexpr size_t VC1_DOWNSTREAM_EDM_SIZE = NAMED_CT_ARG("VC1_DOWNSTREAM_EDM_SIZE");
-constexpr size_t ACTUAL_VC0_SENDER_CHANNELS = NAMED_CT_ARG("ACTUAL_VC0_SENDER_CHANNELS");
-constexpr size_t ACTUAL_VC1_SENDER_CHANNELS = NAMED_CT_ARG("ACTUAL_VC1_SENDER_CHANNELS");
+constexpr size_t DOWNSTREAM_EDM_SIZE_PER_VC[MAX_NUM_VCS] = {VC0_DOWNSTREAM_EDM_SIZE, VC1_DOWNSTREAM_EDM_SIZE};
 
 // Remote channel info (always available; 0 when inactive)
 constexpr size_t remote_worker_sender_channel = NAMED_CT_ARG("REMOTE_WORKER_SENDER_CHANNEL");
@@ -163,6 +191,11 @@ constexpr size_t CHANNEL_ALLOCATIONS_IDX = 0;
 using channel_allocs = ChannelAllocations<CHANNEL_ALLOCATIONS_IDX, NUM_SENDER_CHANNELS, NUM_RECEIVER_CHANNELS>;
 
 constexpr std::array<size_t, NUM_SENDER_CHANNELS> SENDER_TO_ENTRY_IDX = channel_allocs::sender_channel_to_entry_index;
+// Per-VC sender entry indices (pad to MAX, then slice)
+static constexpr auto SENDER_TO_ENTRY_IDX_PADDED_ =
+    take_first_n_elements<MAX_NUM_SENDER_CHANNELS, NUM_SENDER_CHANNELS, size_t>(SENDER_TO_ENTRY_IDX);
+constexpr auto SENDER_TO_ENTRY_IDX_VC0 = slice_sender_channels_for_vc<0>(SENDER_TO_ENTRY_IDX_PADDED_);
+constexpr auto SENDER_TO_ENTRY_IDX_VC1 = slice_sender_channels_for_vc<1>(SENDER_TO_ENTRY_IDX_PADDED_);
 constexpr std::array<size_t, NUM_RECEIVER_CHANNELS> RECEIVER_TO_ENTRY_IDX =
     channel_allocs::receiver_channel_to_entry_index;
 
@@ -234,7 +267,8 @@ constexpr uint32_t notify_worker_of_read_counter_update_src_address =
 // ============================================================================
 // Channel servicing flags
 // ============================================================================
-constexpr std::array<bool, MAX_NUM_SENDER_CHANNELS> is_sender_channel_serviced = {
+// Flat array (kept for internal slicing only)
+static constexpr std::array<bool, MAX_NUM_SENDER_CHANNELS> is_sender_channel_serviced_flat_ = {
     static_cast<bool>(NAMED_CT_ARG("IS_SENDER_CHANNEL_0_SERVICED")),
     static_cast<bool>(NAMED_CT_ARG("IS_SENDER_CHANNEL_1_SERVICED")),
     static_cast<bool>(NAMED_CT_ARG("IS_SENDER_CHANNEL_2_SERVICED")),
@@ -245,10 +279,29 @@ constexpr std::array<bool, MAX_NUM_SENDER_CHANNELS> is_sender_channel_serviced =
     static_cast<bool>(NAMED_CT_ARG("IS_SENDER_CHANNEL_7_SERVICED")),
     static_cast<bool>(NAMED_CT_ARG("IS_SENDER_CHANNEL_8_SERVICED")),
 };
+// Per-VC sender channel servicing arrays
+constexpr auto is_sender_channel_serviced_vc0 = slice_sender_channels_for_vc<0>(is_sender_channel_serviced_flat_);
+constexpr auto is_sender_channel_serviced_vc1 = slice_sender_channels_for_vc<1>(is_sender_channel_serviced_flat_);
+
 constexpr std::array<bool, MAX_NUM_RECEIVER_CHANNELS> is_receiver_channel_serviced = {
     static_cast<bool>(NAMED_CT_ARG("IS_RECEIVER_CHANNEL_0_SERVICED")),
     static_cast<bool>(NAMED_CT_ARG("IS_RECEIVER_CHANNEL_1_SERVICED")),
 };
+
+// Per-VC servicing accessors (compile-time VC selection)
+template <size_t vc>
+constexpr auto& get_is_sender_channel_serviced() {
+    if constexpr (vc == 0) {
+        return is_sender_channel_serviced_vc0;
+    } else {
+        return is_sender_channel_serviced_vc1;
+    }
+}
+template <size_t vc, size_t ch>
+constexpr bool is_vc_sender_channel_serviced() {
+    return get_is_sender_channel_serviced<vc>()[ch];
+}
+constexpr bool is_vc_receiver_channel_serviced(size_t vc) { return is_receiver_channel_serviced[vc]; }
 
 // ============================================================================
 // RISC configuration
@@ -303,6 +356,8 @@ constexpr bool is_intramesh_router_on_edge = NAMED_CT_ARG("IS_INTRAMESH_ROUTER_O
 // ============================================================================
 // Sender channel per-channel arrays
 // Arrays are sized to NUM_SENDER_CHANNELS, built from MAX-sized intermediaries.
+// Per-VC arrays (preferred) are created below; flat aliases kept for backward compat
+// with functions not yet converted to per-VC (see per_vc_conversion_remaining_todos.md)
 // ============================================================================
 static constexpr std::array<bool, MAX_NUM_SENDER_CHANNELS> sender_ch_live_check_skip_all_ = {
     static_cast<bool>(NAMED_CT_ARG("SENDER_CH_0_LIVE_CHECK_SKIP")),
@@ -315,8 +370,16 @@ static constexpr std::array<bool, MAX_NUM_SENDER_CHANNELS> sender_ch_live_check_
     static_cast<bool>(NAMED_CT_ARG("SENDER_CH_7_LIVE_CHECK_SKIP")),
     static_cast<bool>(NAMED_CT_ARG("SENDER_CH_8_LIVE_CHECK_SKIP")),
 };
-constexpr std::array<bool, NUM_SENDER_CHANNELS> sender_ch_live_check_skip =
-    take_first_n_elements<NUM_SENDER_CHANNELS, MAX_NUM_SENDER_CHANNELS, bool>(sender_ch_live_check_skip_all_);
+constexpr auto sender_ch_live_check_skip_vc0 = slice_sender_channels_for_vc<0>(sender_ch_live_check_skip_all_);
+constexpr auto sender_ch_live_check_skip_vc1 = slice_sender_channels_for_vc<1>(sender_ch_live_check_skip_all_);
+template <size_t vc>
+constexpr auto& get_sender_ch_live_check_skip() {
+    if constexpr (vc == 0) {
+        return sender_ch_live_check_skip_vc0;
+    } else {
+        return sender_ch_live_check_skip_vc1;
+    }
+}
 
 // A channel is a "traffic injection channel" if it is a sender channel that is adding *new*
 // traffic to this dimension/ring. Examples include channels service worker traffic and
@@ -333,9 +396,18 @@ static constexpr std::array<bool, MAX_NUM_SENDER_CHANNELS> sender_channel_is_tra
     static_cast<bool>(NAMED_CT_ARG("SENDER_CH_7_IS_INJECTION")),
     static_cast<bool>(NAMED_CT_ARG("SENDER_CH_8_IS_INJECTION")),
 };
-constexpr std::array<bool, NUM_SENDER_CHANNELS> sender_channel_is_traffic_injection_channel =
-    take_first_n_elements<NUM_SENDER_CHANNELS, MAX_NUM_SENDER_CHANNELS, bool>(
-        sender_channel_is_traffic_injection_channel_all_);
+constexpr auto sender_channel_is_traffic_injection_vc0 =
+    slice_sender_channels_for_vc<0>(sender_channel_is_traffic_injection_channel_all_);
+constexpr auto sender_channel_is_traffic_injection_vc1 =
+    slice_sender_channels_for_vc<1>(sender_channel_is_traffic_injection_channel_all_);
+template <size_t vc>
+constexpr auto& get_sender_channel_is_traffic_injection() {
+    if constexpr (vc == 0) {
+        return sender_channel_is_traffic_injection_vc0;
+    } else {
+        return sender_channel_is_traffic_injection_vc1;
+    }
+}
 constexpr size_t BUBBLE_FLOW_CONTROL_INJECTION_SENDER_CHANNEL_MIN_FREE_SLOTS = 2;
 
 static constexpr std::array<size_t, MAX_NUM_SENDER_CHANNELS> sender_channel_ack_noc_ids_all_ = {
@@ -349,8 +421,16 @@ static constexpr std::array<size_t, MAX_NUM_SENDER_CHANNELS> sender_channel_ack_
     static_cast<size_t>(NAMED_CT_ARG("SENDER_CH_7_ACK_NOC_ID")),
     static_cast<size_t>(NAMED_CT_ARG("SENDER_CH_8_ACK_NOC_ID")),
 };
-constexpr std::array<size_t, NUM_SENDER_CHANNELS> sender_channel_ack_noc_ids =
-    take_first_n_elements<NUM_SENDER_CHANNELS, MAX_NUM_SENDER_CHANNELS, size_t>(sender_channel_ack_noc_ids_all_);
+constexpr auto sender_channel_ack_noc_ids_vc0 = slice_sender_channels_for_vc<0>(sender_channel_ack_noc_ids_all_);
+constexpr auto sender_channel_ack_noc_ids_vc1 = slice_sender_channels_for_vc<1>(sender_channel_ack_noc_ids_all_);
+template <size_t vc>
+constexpr auto& get_sender_channel_ack_noc_ids() {
+    if constexpr (vc == 0) {
+        return sender_channel_ack_noc_ids_vc0;
+    } else {
+        return sender_channel_ack_noc_ids_vc1;
+    }
+}
 
 static constexpr std::array<uint8_t, MAX_NUM_SENDER_CHANNELS> sender_channel_ack_cmd_buf_ids_all_ = {
     static_cast<uint8_t>(NAMED_CT_ARG("SENDER_CH_0_ACK_CMD_BUF_ID")),
@@ -363,8 +443,18 @@ static constexpr std::array<uint8_t, MAX_NUM_SENDER_CHANNELS> sender_channel_ack
     static_cast<uint8_t>(NAMED_CT_ARG("SENDER_CH_7_ACK_CMD_BUF_ID")),
     static_cast<uint8_t>(NAMED_CT_ARG("SENDER_CH_8_ACK_CMD_BUF_ID")),
 };
-constexpr std::array<uint8_t, NUM_SENDER_CHANNELS> sender_channel_ack_cmd_buf_ids =
-    take_first_n_elements<NUM_SENDER_CHANNELS, MAX_NUM_SENDER_CHANNELS, uint8_t>(sender_channel_ack_cmd_buf_ids_all_);
+constexpr auto sender_channel_ack_cmd_buf_ids_vc0 =
+    slice_sender_channels_for_vc<0>(sender_channel_ack_cmd_buf_ids_all_);
+constexpr auto sender_channel_ack_cmd_buf_ids_vc1 =
+    slice_sender_channels_for_vc<1>(sender_channel_ack_cmd_buf_ids_all_);
+template <size_t vc>
+constexpr auto& get_sender_channel_ack_cmd_buf_ids() {
+    if constexpr (vc == 0) {
+        return sender_channel_ack_cmd_buf_ids_vc0;
+    } else {
+        return sender_channel_ack_cmd_buf_ids_vc1;
+    }
+}
 
 // ============================================================================
 // Receiver channel per-channel arrays
@@ -612,6 +702,19 @@ constexpr std::array<size_t, NumChannels> build_remote_num_slots_array() {
 
 constexpr std::array<size_t, NUM_SENDER_CHANNELS> SENDER_NUM_BUFFERS_ARRAY =
     build_num_slots_array<channel_allocs, SENDER_TO_ENTRY_IDX, NUM_SENDER_CHANNELS>();
+// Per-VC sender buffer count arrays (pad to MAX first, then slice per VC)
+static constexpr auto SENDER_NUM_BUFFERS_PADDED_ =
+    take_first_n_elements<MAX_NUM_SENDER_CHANNELS, NUM_SENDER_CHANNELS, size_t>(SENDER_NUM_BUFFERS_ARRAY);
+constexpr auto SENDER_NUM_BUFFERS_VC0 = slice_sender_channels_for_vc<0>(SENDER_NUM_BUFFERS_PADDED_);
+constexpr auto SENDER_NUM_BUFFERS_VC1 = slice_sender_channels_for_vc<1>(SENDER_NUM_BUFFERS_PADDED_);
+template <size_t vc>
+constexpr auto& get_sender_num_buffers() {
+    if constexpr (vc == 0) {
+        return SENDER_NUM_BUFFERS_VC0;
+    } else {
+        return SENDER_NUM_BUFFERS_VC1;
+    }
+}
 
 constexpr std::array<size_t, NUM_RECEIVER_CHANNELS> RECEIVER_NUM_BUFFERS_ARRAY =
     build_num_slots_array<channel_allocs, RECEIVER_TO_ENTRY_IDX, NUM_RECEIVER_CHANNELS>();

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
@@ -269,7 +269,7 @@ constexpr uint32_t notify_worker_of_read_counter_update_src_address =
 // Channel servicing flags
 // ============================================================================
 // Flat array (kept for internal slicing only)
-static constexpr std::array<bool, MAX_NUM_SENDER_CHANNELS> is_sender_channel_serviced_flat_ = {
+constexpr std::array<bool, MAX_NUM_SENDER_CHANNELS> is_sender_channel_serviced_flat_ = {
     static_cast<bool>(NAMED_CT_ARG("IS_SENDER_CHANNEL_0_SERVICED")),
     static_cast<bool>(NAMED_CT_ARG("IS_SENDER_CHANNEL_1_SERVICED")),
     static_cast<bool>(NAMED_CT_ARG("IS_SENDER_CHANNEL_2_SERVICED")),
@@ -361,7 +361,7 @@ constexpr bool is_intramesh_router_on_edge = NAMED_CT_ARG("IS_INTRAMESH_ROUTER_O
 // Per-VC arrays (preferred) are created below; flat aliases kept for backward compat
 // with functions not yet converted to per-VC (see per_vc_conversion_remaining_todos.md)
 // ============================================================================
-static constexpr std::array<bool, MAX_NUM_SENDER_CHANNELS> sender_ch_live_check_skip_all_ = {
+constexpr std::array<bool, MAX_NUM_SENDER_CHANNELS> sender_ch_live_check_skip_all_ = {
     static_cast<bool>(NAMED_CT_ARG("SENDER_CH_0_LIVE_CHECK_SKIP")),
     static_cast<bool>(NAMED_CT_ARG("SENDER_CH_1_LIVE_CHECK_SKIP")),
     static_cast<bool>(NAMED_CT_ARG("SENDER_CH_2_LIVE_CHECK_SKIP")),
@@ -388,7 +388,7 @@ constexpr auto& get_sender_ch_live_check_skip() {
 // traffic to this dimension/ring. Examples include channels service worker traffic and
 // sender channels that receive traffic from a "turn" (e.g. an EAST channel receiving traffic from NORTH)
 // This attribute is necessary to support bubble flow control.
-static constexpr std::array<bool, MAX_NUM_SENDER_CHANNELS> sender_channel_is_traffic_injection_channel_all_ = {
+constexpr std::array<bool, MAX_NUM_SENDER_CHANNELS> sender_channel_is_traffic_injection_channel_all_ = {
     static_cast<bool>(NAMED_CT_ARG("SENDER_CH_0_IS_INJECTION")),
     static_cast<bool>(NAMED_CT_ARG("SENDER_CH_1_IS_INJECTION")),
     static_cast<bool>(NAMED_CT_ARG("SENDER_CH_2_IS_INJECTION")),
@@ -414,7 +414,7 @@ constexpr auto& get_sender_channel_is_traffic_injection() {
 }
 constexpr size_t BUBBLE_FLOW_CONTROL_INJECTION_SENDER_CHANNEL_MIN_FREE_SLOTS = 2;
 
-static constexpr std::array<size_t, MAX_NUM_SENDER_CHANNELS> sender_channel_ack_noc_ids_all_ = {
+constexpr std::array<size_t, MAX_NUM_SENDER_CHANNELS> sender_channel_ack_noc_ids_all_ = {
     static_cast<size_t>(NAMED_CT_ARG("SENDER_CH_0_ACK_NOC_ID")),
     static_cast<size_t>(NAMED_CT_ARG("SENDER_CH_1_ACK_NOC_ID")),
     static_cast<size_t>(NAMED_CT_ARG("SENDER_CH_2_ACK_NOC_ID")),
@@ -437,7 +437,7 @@ constexpr auto& get_sender_channel_ack_noc_ids() {
     }
 }
 
-static constexpr std::array<uint8_t, MAX_NUM_SENDER_CHANNELS> sender_channel_ack_cmd_buf_ids_all_ = {
+constexpr std::array<uint8_t, MAX_NUM_SENDER_CHANNELS> sender_channel_ack_cmd_buf_ids_all_ = {
     static_cast<uint8_t>(NAMED_CT_ARG("SENDER_CH_0_ACK_CMD_BUF_ID")),
     static_cast<uint8_t>(NAMED_CT_ARG("SENDER_CH_1_ACK_CMD_BUF_ID")),
     static_cast<uint8_t>(NAMED_CT_ARG("SENDER_CH_2_ACK_CMD_BUF_ID")),
@@ -708,7 +708,7 @@ constexpr std::array<size_t, NumChannels> build_remote_num_slots_array() {
 constexpr std::array<size_t, NUM_SENDER_CHANNELS> SENDER_NUM_BUFFERS_ARRAY =
     build_num_slots_array<channel_allocs, SENDER_TO_ENTRY_IDX, NUM_SENDER_CHANNELS>();
 // Per-VC sender buffer count arrays (pad to MAX first, then slice per VC)
-static constexpr auto SENDER_NUM_BUFFERS_PADDED_ =
+constexpr auto SENDER_NUM_BUFFERS_PADDED_ =
     take_first_n_elements<MAX_NUM_SENDER_CHANNELS, NUM_SENDER_CHANNELS, size_t>(SENDER_NUM_BUFFERS_ARRAY);
 constexpr auto SENDER_NUM_BUFFERS_VC0 = slice_sender_channels_for_vc<0>(SENDER_NUM_BUFFERS_PADDED_);
 constexpr auto SENDER_NUM_BUFFERS_VC1 = slice_sender_channels_for_vc<1>(SENDER_NUM_BUFFERS_PADDED_);

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
@@ -104,6 +104,7 @@ constexpr auto slice_sender_channels_for_vc(const std::array<T, N>& flat) {
     constexpr size_t offset = VC_SENDER_CHANNEL_START[vc];
     constexpr size_t count = ACTUAL_SENDER_CHANNELS_PER_VC[vc];
     std::array<T, count> result{};
+    static_assert(flat.size() > count, "trying to slice out of bounds of constexpr array");
     for (size_t i = 0; i < count; i++) {
         result[i] = flat[offset + i];
     }
@@ -289,17 +290,18 @@ constexpr std::array<bool, MAX_NUM_RECEIVER_CHANNELS> is_receiver_channel_servic
 };
 
 // Per-VC servicing accessors (compile-time VC selection)
-template <size_t vc>
+template <size_t vc, size_t ch>
 constexpr auto& get_is_sender_channel_serviced() {
+    static_assert(vc <= 1, "At most 2 VCs currently supported");
     if constexpr (vc == 0) {
-        return is_sender_channel_serviced_vc0;
+        return is_sender_channel_serviced_vc0[ch];
     } else {
-        return is_sender_channel_serviced_vc1;
+        return is_sender_channel_serviced_vc1[ch];
     }
 }
 template <size_t vc, size_t ch>
 constexpr bool is_vc_sender_channel_serviced() {
-    return get_is_sender_channel_serviced<vc>()[ch];
+    return get_is_sender_channel_serviced<vc, ch>();
 }
 constexpr bool is_vc_receiver_channel_serviced(size_t vc) { return is_receiver_channel_serviced[vc]; }
 
@@ -374,6 +376,7 @@ constexpr auto sender_ch_live_check_skip_vc0 = slice_sender_channels_for_vc<0>(s
 constexpr auto sender_ch_live_check_skip_vc1 = slice_sender_channels_for_vc<1>(sender_ch_live_check_skip_all_);
 template <size_t vc>
 constexpr auto& get_sender_ch_live_check_skip() {
+    static_assert(vc <= 1, "At most 2 VCs currently supported");
     if constexpr (vc == 0) {
         return sender_ch_live_check_skip_vc0;
     } else {
@@ -402,6 +405,7 @@ constexpr auto sender_channel_is_traffic_injection_vc1 =
     slice_sender_channels_for_vc<1>(sender_channel_is_traffic_injection_channel_all_);
 template <size_t vc>
 constexpr auto& get_sender_channel_is_traffic_injection() {
+    static_assert(vc <= 1, "At most 2 VCs currently supported");
     if constexpr (vc == 0) {
         return sender_channel_is_traffic_injection_vc0;
     } else {
@@ -425,6 +429,7 @@ constexpr auto sender_channel_ack_noc_ids_vc0 = slice_sender_channels_for_vc<0>(
 constexpr auto sender_channel_ack_noc_ids_vc1 = slice_sender_channels_for_vc<1>(sender_channel_ack_noc_ids_all_);
 template <size_t vc>
 constexpr auto& get_sender_channel_ack_noc_ids() {
+    static_assert(vc <= 1, "At most 2 VCs currently supported");
     if constexpr (vc == 0) {
         return sender_channel_ack_noc_ids_vc0;
     } else {
@@ -449,6 +454,7 @@ constexpr auto sender_channel_ack_cmd_buf_ids_vc1 =
     slice_sender_channels_for_vc<1>(sender_channel_ack_cmd_buf_ids_all_);
 template <size_t vc>
 constexpr auto& get_sender_channel_ack_cmd_buf_ids() {
+    static_assert(vc <= 1, "At most 2 VCs currently supported");
     if constexpr (vc == 0) {
         return sender_channel_ack_cmd_buf_ids_vc0;
     } else {
@@ -594,8 +600,6 @@ struct BufferSlot {
 
 using buffer_slot = BufferSlot<channel_buffer_size, sizeof(PACKET_HEADER_TYPE)>;
 
-constexpr size_t NUM_FORWARDED_SENDER_CHANNELS = NUM_SENDER_CHANNELS - 1;
-
 //////////////////////////////////////////////////////////////////////////////////////////
 ////                CT ARGS FETCHING DONE
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -615,6 +619,7 @@ constexpr std::array<uint32_t, MAX_NUM_RECEIVER_CHANNELS> to_receiver_packets_se
         std::array<uint32_t, MAX_NUM_RECEIVER_CHANNELS>{to_receiver_0_pkts_sent_id, to_receiver_1_pkts_sent_id});
 
 // not in symbol table - because not used
+constexpr INVALID_STREAM_ID = 33;
 constexpr std::array<uint32_t, MAX_NUM_SENDER_CHANNELS> to_sender_packets_acked_streams =
     take_first_n_elements<MAX_NUM_SENDER_CHANNELS, MAX_NUM_SENDER_CHANNELS, uint32_t>(
         std::array<uint32_t, MAX_NUM_SENDER_CHANNELS>{
@@ -624,10 +629,10 @@ constexpr std::array<uint32_t, MAX_NUM_SENDER_CHANNELS> to_sender_packets_acked_
             to_sender_2_pkts_acked_id,
             to_sender_3_pkts_acked_id,
             // VC1
-            0,  // Padding upto MAX_NUM_SENDER_CHANNELS. VC1 does not use first level acks.
-            0,
-            0,
-            0});
+            INVALID_STREAM_ID,  // Padding upto MAX_NUM_SENDER_CHANNELS. VC1 does not use first level acks.
+            INVALID_STREAM_ID,
+            INVALID_STREAM_ID,
+            INVALID_STREAM_ID});
 
 // data section
 constexpr std::array<uint32_t, MAX_NUM_SENDER_CHANNELS> to_sender_packets_completed_streams =
@@ -709,6 +714,7 @@ constexpr auto SENDER_NUM_BUFFERS_VC0 = slice_sender_channels_for_vc<0>(SENDER_N
 constexpr auto SENDER_NUM_BUFFERS_VC1 = slice_sender_channels_for_vc<1>(SENDER_NUM_BUFFERS_PADDED_);
 template <size_t vc>
 constexpr auto& get_sender_num_buffers() {
+    static_assert(vc <= 1, "At most 2 VCs currently supported");
     if constexpr (vc == 0) {
         return SENDER_NUM_BUFFERS_VC0;
     } else {

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
@@ -662,7 +662,7 @@ static constexpr uint8_t edm_to_downstream_noc = receiver_channel_forwarding_noc
 #ifdef ARCH_BLACKHOLE
 static constexpr uint8_t worker_handshake_noc = noc_index;
 #else
-static constexpr uint8_t worker_handshake_noc = sender_channel_ack_noc_ids[0];
+static constexpr uint8_t worker_handshake_noc = sender_channel_ack_noc_ids_vc0[0];
 #endif
 constexpr bool local_chip_noc_equals_downstream_noc =
     receiver_channel_forwarding_noc_ids[0] == receiver_channel_local_write_noc_ids[0];

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
@@ -104,7 +104,7 @@ constexpr auto slice_sender_channels_for_vc(const std::array<T, N>& flat) {
     constexpr size_t offset = VC_SENDER_CHANNEL_START[vc];
     constexpr size_t count = ACTUAL_SENDER_CHANNELS_PER_VC[vc];
     std::array<T, count> result{};
-    static_assert(flat.size() > offset + count, "trying to slice out of bounds of constexpr array");
+    static_assert(flat.size() >= offset + count, "trying to slice out of bounds of constexpr array");
     for (size_t i = 0; i < count; i++) {
         result[i] = flat[offset + i];
     }

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
@@ -104,7 +104,7 @@ constexpr auto slice_sender_channels_for_vc(const std::array<T, N>& flat) {
     constexpr size_t offset = VC_SENDER_CHANNEL_START[vc];
     constexpr size_t count = ACTUAL_SENDER_CHANNELS_PER_VC[vc];
     std::array<T, count> result{};
-    static_assert(flat.size() > count, "trying to slice out of bounds of constexpr array");
+    static_assert(flat.size() > offset + count, "trying to slice out of bounds of constexpr array");
     for (size_t i = 0; i < count; i++) {
         result[i] = flat[offset + i];
     }
@@ -619,7 +619,7 @@ constexpr std::array<uint32_t, MAX_NUM_RECEIVER_CHANNELS> to_receiver_packets_se
         std::array<uint32_t, MAX_NUM_RECEIVER_CHANNELS>{to_receiver_0_pkts_sent_id, to_receiver_1_pkts_sent_id});
 
 // not in symbol table - because not used
-constexpr INVALID_STREAM_ID = 33;
+constexpr size_t INVALID_STREAM_ID = 33;
 constexpr std::array<uint32_t, MAX_NUM_SENDER_CHANNELS> to_sender_packets_acked_streams =
     take_first_n_elements<MAX_NUM_SENDER_CHANNELS, MAX_NUM_SENDER_CHANNELS, uint32_t>(
         std::array<uint32_t, MAX_NUM_SENDER_CHANNELS>{

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -703,34 +703,34 @@ FORCE_INLINE __attribute__((optimize("jump-tables"))) bool can_forward_packet_co
     uint32_t hop_cmd,
     std::array<DownstreamSenderT, DOWNSTREAM_EDM_SIZE>& downstream_edm_interfaces,
     LocalRelayInterfaceT& local_relay_interface) {
-    bool ret_val = false;
+
 
     using eth_chan_directions::EAST;
     using eth_chan_directions::NORTH;
     using eth_chan_directions::SOUTH;
     using eth_chan_directions::WEST;
 
-#ifdef ARCH_WORMHOLE
+#if defined(ARCH_WORMHOLE) && defined(FABRIC_2D_VC1_ACTIVE)
     bool ret_val = true;
     if (hop_cmd & MeshRoutingFields::FORWARD_EAST) {
-        ret_val&& = downstreams_have_space<DownstreamSenderT, LocalRelayInterfaceT, DOWNSTREAM_EDM_SIZE, EAST>(
+        ret_val = ret_val && downstreams_have_space<DownstreamSenderT, LocalRelayInterfaceT, DOWNSTREAM_EDM_SIZE, EAST>(
             downstream_edm_interfaces, local_relay_interface);
     }
     if (hop_cmd & MeshRoutingFields::FORWARD_WEST) {
-        ret_val&& = downstreams_have_space<DownstreamSenderT, LocalRelayInterfaceT, DOWNSTREAM_EDM_SIZE, WEST>(
+        ret_val = ret_val && downstreams_have_space<DownstreamSenderT, LocalRelayInterfaceT, DOWNSTREAM_EDM_SIZE, WEST>(
             downstream_edm_interfaces, local_relay_interface);
     }
     if (hop_cmd & MeshRoutingFields::FORWARD_SOUTH) {
-        ret_val&& = downstreams_have_space<DownstreamSenderT, LocalRelayInterfaceT, DOWNSTREAM_EDM_SIZE, SOUTH>(
+        ret_val = ret_val && downstreams_have_space<DownstreamSenderT, LocalRelayInterfaceT, DOWNSTREAM_EDM_SIZE, SOUTH>(
             downstream_edm_interfaces, local_relay_interface);
     }
     if (hop_cmd & MeshRoutingFields::FORWARD_NORTH) {
-        ret_val&& = downstreams_have_space<DownstreamSenderT, LocalRelayInterfaceT, DOWNSTREAM_EDM_SIZE, NORTH>(
+        ret_val = ret_val && downstreams_have_space<DownstreamSenderT, LocalRelayInterfaceT, DOWNSTREAM_EDM_SIZE, NORTH>(
             downstream_edm_interfaces, local_relay_interface);
     }
     return ret_val;
 #else
-
+    bool ret_val = false;
     switch (hop_cmd) {
         case MeshRoutingFields::NOOP:
             if constexpr (z_router_enabled) {

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -324,6 +324,20 @@ static_assert(sender_channel_free_slots_stream_ids[5] == 27);
 static_assert(sender_channel_free_slots_stream_ids[6] == 28);
 static_assert(sender_channel_free_slots_stream_ids[7] == 29);
 
+// Per-VC sender channel free slots stream IDs
+static constexpr auto sender_channel_free_slots_stream_ids_vc0 =
+    slice_sender_channels_for_vc<0>(sender_channel_free_slots_stream_ids);
+static constexpr auto sender_channel_free_slots_stream_ids_vc1 =
+    slice_sender_channels_for_vc<1>(sender_channel_free_slots_stream_ids);
+template <size_t vc>
+constexpr auto& get_sender_channel_free_slots_stream_ids() {
+    if constexpr (vc == 0) {
+        return sender_channel_free_slots_stream_ids_vc0;
+    } else {
+        return sender_channel_free_slots_stream_ids_vc1;
+    }
+}
+
 // For 2D fabric: maps compact index to downstream direction for each my_direction
 // For 1D fabric: only 1 downstream direction per router (EAST forwards to WEST in 1D linear topology)
 constexpr uint32_t MAX_DOWNSTREAM_EDM_COUNT = 4;
@@ -1359,15 +1373,19 @@ FORCE_INLINE void establish_edm_connection(
     local_sender_channel_worker_interface.template cache_producer_noc_addr<ENABLE_RISC_CPU_DATA_CACHE, USE_DYNAMIC_CREDIT_ADDR>();
 }
 
-bool any_sender_channels_active(
-    const std::array<uint32_t, NUM_SENDER_CHANNELS>& local_sender_channel_free_slots_stream_ids) {
-    for (size_t i = 0; i < NUM_SENDER_CHANNELS; i++) {
-        if (get_ptr_val(local_sender_channel_free_slots_stream_ids[i]) !=
-            static_cast<int32_t>(SENDER_NUM_BUFFERS_ARRAY[i])) {
+template <size_t vc, size_t N>
+bool any_vc_sender_channels_active(const std::array<uint32_t, N>& free_slots_stream_ids) {
+    for (size_t ch = 0; ch < N; ch++) {
+        if (get_ptr_val(free_slots_stream_ids[ch]) != static_cast<int32_t>(get_sender_num_buffers<vc>()[ch])) {
             return true;
         }
     }
     return false;
+}
+template <size_t N0, size_t N1>
+bool any_sender_channels_active(
+    const std::array<uint32_t, N0>& free_slots_vc0, const std::array<uint32_t, N1>& free_slots_vc1) {
+    return any_vc_sender_channels_active<0>(free_slots_vc0) || any_vc_sender_channels_active<1>(free_slots_vc1);
 }
 
 /*
@@ -1461,9 +1479,10 @@ void run_coordinated_context_switch_to_base_firmware(
         }
     }
 }
-template <typename LocalTelemetryT>
+template <typename LocalTelemetryT, size_t N0, size_t N1>
 FORCE_INLINE void update_telemetry(
-    const std::array<uint32_t, NUM_SENDER_CHANNELS>& local_sender_channel_free_slots_stream_ids_ordered,
+    const std::array<uint32_t, N0>& free_slots_vc0,
+    const std::array<uint32_t, N1>& free_slots_vc1,
     bool tx_progress,
     bool rx_progress,
     LocalTelemetryT& local_fabric_telemetry,
@@ -1477,7 +1496,7 @@ FORCE_INLINE void update_telemetry(
     if constexpr (FABRIC_TELEMETRY_HEARTBEAT_TX) {
         bool sender_idle = false;
         if (!tx_progress) {
-            sender_idle = !any_sender_channels_active(local_sender_channel_free_slots_stream_ids_ordered);
+            sender_idle = !any_sender_channels_active(free_slots_vc0, free_slots_vc1);
         }
         if (tx_progress || sender_idle) {
             volatile RiscTimestampV2* tx_heartbeat_addr =
@@ -1588,7 +1607,8 @@ FORCE_INLINE void update_bw_cycles(
 ////////////////////////////////////
 ////////////////////////////////////
 template <
-    uint8_t sender_channel_index,
+    uint8_t vc,
+    uint8_t ch,
     uint8_t to_receiver_pkts_sent_id,
     bool SKIP_CONNECTION_LIVENESS_CHECK,
     bool enable_first_level_ack,
@@ -1611,14 +1631,11 @@ FORCE_INLINE
         SenderChannelFromReceiverCredits& sender_channel_from_receiver_credits,
         PerfTelemetryRecorder& perf_telemetry_recorder,
         LocalTelemetryT& local_fabric_telemetry) {
+    constexpr uint8_t sender_channel_index = VC_SENDER_CHANNEL_START[vc] + ch;  // flat index for perf recording
     bool progress = false;
-    // If the receiver has space, and we have one or more packets unsent from producer, then send one
-    // TODO: convert to loop to send multiple packets back to back (or support sending multiple packets in one shot)
-    //       when moving to stream regs to manage rd/wr ptrs
-    // TODO: update to be stream reg based. Initialize to space available and simply check for non-zero
 
     constexpr bool use_bubble_flow_control =
-        sender_channel_is_traffic_injection_channel[sender_channel_index] && enable_deadlock_avoidance;
+        get_sender_channel_is_traffic_injection<vc>()[ch] && enable_deadlock_avoidance;
     static_assert(
         !use_bubble_flow_control || enable_first_level_ack,
         "Bubble flow control and first level ack must be set to the same values");
@@ -1700,14 +1717,16 @@ FORCE_INLINE
 };
 
 template <
-    uint8_t VC_RECEIVER_CHANNEL,
-    uint8_t sender_channel_index,
+    uint8_t vc,
+    uint8_t ch,
     bool enable_first_level_ack,
     typename EthSenderChannels,
     typename EdmChannelWorkerIFs,
     typename RemoteEthReceiverChannels,
     typename ReceiverPointersT,
-    size_t NUM_SENDER_CHANNELS,
+    typename ChannelConnectionEstablishedT,
+    typename FreeSlotsStreamIdsT,
+    typename SenderFromReceiverCreditsT,
     typename LocalTelemetryT>
 #if !defined(FABRIC_2D_VC1_ACTIVE)
 FORCE_INLINE
@@ -1718,28 +1737,27 @@ FORCE_INLINE
         EdmChannelWorkerIFs& local_sender_channel_worker_interfaces,
         ReceiverPointersT& outbound_to_receiver_channel_pointers,
         RemoteEthReceiverChannels& remote_receiver_channels,
-        std::array<bool, NUM_SENDER_CHANNELS>& channel_connection_established,
-        std::array<uint32_t, NUM_SENDER_CHANNELS>& local_sender_channel_free_slots_stream_ids,
-        std::array<SenderChannelFromReceiverCredits, NUM_SENDER_CHANNELS>& sender_channel_from_receiver_credits,
+        ChannelConnectionEstablishedT& channel_connection_established,
+        FreeSlotsStreamIdsT& local_sender_channel_free_slots_stream_ids,
+        SenderFromReceiverCreditsT& sender_channel_from_receiver_credits,
         PerfTelemetryRecorder& perf_telemetry_recorder,
         LocalTelemetryT& local_fabric_telemetry) {
-    if constexpr (is_sender_channel_serviced[sender_channel_index]) {
-        // the cache is invalidated here because the channel will read some
-        // L1 locations to see if it can make progress
+    if constexpr (is_vc_sender_channel_serviced<vc, ch>()) {
         router_invalidate_l1_cache<ENABLE_RISC_CPU_DATA_CACHE>();
 
         return run_sender_channel_step_impl<
-            sender_channel_index,
-            to_receiver_packets_sent_streams[VC_RECEIVER_CHANNEL],
-            sender_ch_live_check_skip[sender_channel_index],
+            vc,
+            ch,
+            to_receiver_packets_sent_streams[vc],
+            get_sender_ch_live_check_skip<vc>()[ch],
             enable_first_level_ack>(
-            local_sender_channels.template get<sender_channel_index>(),
-            local_sender_channel_worker_interfaces.template get<sender_channel_index>(),
+            local_sender_channels.template get<ch>(),
+            local_sender_channel_worker_interfaces.template get<ch>(),
             outbound_to_receiver_channel_pointers,
-            remote_receiver_channels.template get<VC_RECEIVER_CHANNEL>(),
-            channel_connection_established[sender_channel_index],
-            local_sender_channel_free_slots_stream_ids[sender_channel_index],
-            sender_channel_from_receiver_credits[sender_channel_index],
+            remote_receiver_channels.template get<vc>(),
+            channel_connection_established[ch],
+            local_sender_channel_free_slots_stream_ids[ch],
+            sender_channel_from_receiver_credits[ch],
             perf_telemetry_recorder,
             local_fabric_telemetry);
     }
@@ -1968,7 +1986,8 @@ FORCE_INLINE bool run_receiver_channel_step(
     ReceiverChannelPointersT& receiver_channel_pointers,
     WriteTridTracker& receiver_channel_trid_tracker,
     std::array<uint8_t, num_eth_ports>& port_direction_table,
-    std::array<ReceiverChannelResponseCreditSender, NUM_RECEIVER_CHANNELS>& receiver_channel_response_credit_senders,
+    std::array<ReceiverChannelResponseCreditSender, MAX_NUM_RECEIVER_CHANNELS>&
+        receiver_channel_response_credit_senders,
     const tt::tt_fabric::routing_l1_info_t& routing_table,
     LocalTelemetryT& local_fabric_telemetry) {
     if constexpr (is_receiver_channel_serviced[receiver_channel]) {
@@ -2106,15 +2125,15 @@ FORCE_INLINE bool continue_running_main_run_loop(volatile tt::tt_fabric::Termina
  * channels every iteration unless it is unsafe/undesirable to do so (e.g. for performance reasons).
  */
 template <
-    size_t NUM_RECEIVER_CHANNELS,
     typename DownstreamSenderVC0T,
     typename DownstreamSenderVC1T,
     typename LocalRelayInterfaceT,
-    size_t NUM_SENDER_CHANNELS,
-    typename EthSenderChannels,
+    typename EthSenderChannelsVC0,
+    typename EthSenderChannelsVC1,
     typename EthReceiverChannels,
     typename RemoteEthReceiverChannels,
-    typename EdmChannelWorkerIFs,
+    typename EdmChannelWorkerIFsVC0,
+    typename EdmChannelWorkerIFsVC1,
     typename TransactionIdTrackerCH0
 #if defined(FABRIC_2D_VC1_ACTIVE)
     ,
@@ -2123,10 +2142,12 @@ template <
     >
 FORCE_INLINE void run_fabric_edm_main_loop(
     EthReceiverChannels& local_receiver_channels,
-    EthSenderChannels& local_sender_channels,
-    EdmChannelWorkerIFs& local_sender_channel_worker_interfaces,
-    std::array<DownstreamSenderVC0T, VC0_DOWNSTREAM_EDM_SIZE>& downstream_edm_noc_interfaces_vc0,
-    std::array<DownstreamSenderVC1T, VC1_DOWNSTREAM_EDM_SIZE>& downstream_edm_noc_interfaces_vc1,
+    EthSenderChannelsVC0& local_sender_channels_vc0,
+    EthSenderChannelsVC1& local_sender_channels_vc1,
+    EdmChannelWorkerIFsVC0& local_sender_channel_worker_interfaces_vc0,
+    EdmChannelWorkerIFsVC1& local_sender_channel_worker_interfaces_vc1,
+    std::array<DownstreamSenderVC0T, DOWNSTREAM_EDM_SIZE_PER_VC[0]>& downstream_edm_noc_interfaces_vc0,
+    std::array<DownstreamSenderVC1T, DOWNSTREAM_EDM_SIZE_PER_VC[1]>& downstream_edm_noc_interfaces_vc1,
     LocalRelayInterfaceT& local_relay_interface,
     RemoteEthReceiverChannels& remote_receiver_channels,
     volatile tt::tt_fabric::TerminationSignal* termination_signal_ptr,
@@ -2135,7 +2156,8 @@ FORCE_INLINE void run_fabric_edm_main_loop(
     TransactionIdTrackerCH1& receiver_channel_1_trid_tracker,
 #endif  // FABRIC_2D_VC1_ACTIVE
     std::array<uint8_t, num_eth_ports>& port_direction_table,
-    std::array<uint32_t, NUM_SENDER_CHANNELS>& local_sender_channel_free_slots_stream_ids) {
+    std::array<uint32_t, ACTUAL_SENDER_CHANNELS_PER_VC[0]>& local_sender_channel_free_slots_stream_ids_vc0_,
+    std::array<uint32_t, ACTUAL_SENDER_CHANNELS_PER_VC[1]>& local_sender_channel_free_slots_stream_ids_vc1_) {
     size_t did_nothing_count = 0;
     using FabricTelemetryT = FabricTelemetry;
     FabricTelemetryT local_fabric_telemetry{};
@@ -2157,8 +2179,7 @@ FORCE_INLINE void run_fabric_edm_main_loop(
     configure_outbound_to_receiver_channel_pointers(outbound_to_receiver_channel_pointers, remote_receiver_channels);
 
     // Workaround the perf regression in RingAsLinear test.
-    auto outbound_to_receiver_channel_pointer_ch0 =
-        outbound_to_receiver_channel_pointers.template get<VC0_RECEIVER_CHANNEL>();
+    auto outbound_to_receiver_channel_pointer_ch0 = outbound_to_receiver_channel_pointers.template get<0>();
 
     auto receiver_channel_pointers = ChannelPointersTuple<ReceiverChannelPointers, RECEIVER_NUM_BUFFERS_ARRAY>::make();
     // Workaround the perf regression in RingAsLinear test.
@@ -2167,8 +2188,7 @@ FORCE_INLINE void run_fabric_edm_main_loop(
 
 #if defined(FABRIC_2D_VC1_ACTIVE)
     // VC1 receiver channel pointer for inter-mesh routing
-    auto outbound_to_receiver_channel_pointer_ch1 =
-        outbound_to_receiver_channel_pointers.template get<VC1_RECEIVER_CHANNEL>();
+    auto outbound_to_receiver_channel_pointer_ch1 = outbound_to_receiver_channel_pointers.template get<1>();
 
     auto receiver_channel_pointers_ch1 = receiver_channel_pointers.template get<1>();
     receiver_channel_pointers_ch1.reset();
@@ -2178,17 +2198,29 @@ FORCE_INLINE void run_fabric_edm_main_loop(
         receiver_channel_pointers_ch0.set_src_chan_id(BufferIndex{0}, remote_worker_sender_channel);
     }
 
-    std::array<bool, NUM_SENDER_CHANNELS> channel_connection_established =
-        initialize_array<NUM_SENDER_CHANNELS, bool, false>();
+    // Per-VC sender runtime state
+    auto channel_connection_established_vc0 = initialize_array<ACTUAL_SENDER_CHANNELS_PER_VC[0], bool, false>();
+#if defined(FABRIC_2D_VC1_ACTIVE)
+    auto channel_connection_established_vc1 = initialize_array<ACTUAL_SENDER_CHANNELS_PER_VC[1], bool, false>();
+#else
+    [[maybe_unused]] auto channel_connection_established_vc1 = initialize_array<0, bool, false>();
+#endif
 
     PerfTelemetryRecorder inner_loop_perf_telemetry_collector = build_perf_telemetry_recorder<perf_telemetry_mode>();
     auto local_perf_telemetry_buffer =
         build_perf_telemetry_buffer(reinterpret_cast<uint32_t*>(perf_telemetry_buffer_addr));
 
     auto receiver_channel_response_credit_senders =
-        init_receiver_channel_response_credit_senders<NUM_RECEIVER_CHANNELS>();
-    auto sender_channel_from_receiver_credits =
-        init_sender_channel_from_receiver_credits_flow_controllers<NUM_SENDER_CHANNELS>();
+        init_receiver_channel_response_credit_senders<MAX_NUM_RECEIVER_CHANNELS>();
+    auto sender_channel_from_receiver_credits_vc0 =
+        init_sender_channel_from_receiver_credits_flow_controllers<ACTUAL_SENDER_CHANNELS_PER_VC[0]>();
+#if defined(FABRIC_2D_VC1_ACTIVE)
+    auto sender_channel_from_receiver_credits_vc1 =
+        init_sender_channel_from_receiver_credits_flow_controllers<ACTUAL_SENDER_CHANNELS_PER_VC[1]>();
+#else
+    [[maybe_unused]] auto sender_channel_from_receiver_credits_vc1 =
+        init_sender_channel_from_receiver_credits_flow_controllers<0>();
+#endif
 
     // This value defines the number of loop iterations we perform of the main control sequence before exiting
     // to check for termination and context switch. Removing the these checks from the inner loop can drastically
@@ -2210,7 +2242,7 @@ FORCE_INLINE void run_fabric_edm_main_loop(
             uint32_t tx_progress = 0;
             uint32_t rx_progress = 0;
 
-            if constexpr (is_sender_channel_serviced[0]) {
+            if constexpr (is_vc_sender_channel_serviced<0, 0>()) {
                 open_perf_recording_window(inner_loop_perf_telemetry_collector);
             }
 
@@ -2218,45 +2250,45 @@ FORCE_INLINE void run_fabric_edm_main_loop(
             if constexpr (FABRIC_TELEMETRY_BANDWIDTH) {
                 loop_start_cycles = get_timestamp();
             }
-            if constexpr (super_speedy_mode && is_sender_channel_serviced[0]) {
+            if constexpr (super_speedy_mode && is_vc_sender_channel_serviced<0, 0>()) {
                 auto check_connection_status =
-                    !channel_connection_established[0] ||
-                    local_sender_channel_worker_interfaces.template get<0>().has_worker_teardown_request();
+                    !channel_connection_established_vc0[0] ||
+                    local_sender_channel_worker_interfaces_vc0.template get<0>().has_worker_teardown_request();
                 if (check_connection_status) {
                     check_worker_connections<MY_ETH_CHANNEL, ENABLE_RISC_CPU_DATA_CACHE>(
-                        local_sender_channel_worker_interfaces.template get<0>(),
-                        channel_connection_established[0],
-                        local_sender_channel_free_slots_stream_ids[0]);
+                        local_sender_channel_worker_interfaces_vc0.template get<0>(),
+                        channel_connection_established_vc0[0],
+                        local_sender_channel_free_slots_stream_ids_vc0_[0]);
                 }
             }
             for (size_t i = 0; i < iterations_between_ctx_switch_and_teardown_checks; i++) {
                 if constexpr (super_speedy_mode) {
                     router_invalidate_l1_cache<ENABLE_RISC_CPU_DATA_CACHE>();
 
-                    if constexpr (is_sender_channel_serviced[0]) {
+                    if constexpr (is_vc_sender_channel_serviced<0, 0>()) {
                         tx_progress |= run_sender_channel_step_speedy<
                             0,
-                            to_receiver_packets_sent_streams[VC0_RECEIVER_CHANNEL],
-                            ENABLE_FIRST_LEVEL_ACK_VC0>(
-                            local_sender_channels.template get<0>(),
-                            local_sender_channel_worker_interfaces.template get<0>(),
+                            to_receiver_packets_sent_streams[0],
+                            ENABLE_FIRST_LEVEL_ACK_PER_VC[0]>(
+                            local_sender_channels_vc0.template get<0>(),
+                            local_sender_channel_worker_interfaces_vc0.template get<0>(),
                             outbound_to_receiver_channel_pointer_ch0,
-                            remote_receiver_channels.template get<VC0_RECEIVER_CHANNEL>(),
-                            channel_connection_established[0],
-                            local_sender_channel_free_slots_stream_ids[0],
-                            sender_channel_from_receiver_credits[0],
+                            remote_receiver_channels.template get<0>(),
+                            channel_connection_established_vc0[0],
+                            local_sender_channel_free_slots_stream_ids_vc0_[0],
+                            sender_channel_from_receiver_credits_vc0[0],
                             inner_loop_perf_telemetry_collector,
                             local_fabric_telemetry,
                             local_speedy_sender_state);
                     }
 
-                    if constexpr (is_receiver_channel_serviced[0]) {
+                    if constexpr (is_vc_receiver_channel_serviced(0)) {
 #if defined(FABRIC_2D_VC0_CROSSOVER_TO_VC1)
                         rx_progress |= run_receiver_channel_step_speedy<
                             0,
                             to_receiver_packets_sent_streams[0],
-                            ENABLE_FIRST_LEVEL_ACK_VC0,
-                            VC1_DOWNSTREAM_EDM_SIZE,
+                            ENABLE_FIRST_LEVEL_ACK_PER_VC[0],
+                            DOWNSTREAM_EDM_SIZE_PER_VC[1],
                             decltype(receiver_channel_0_trid_tracker)>(
                             local_receiver_channels.template get<0>(),
                             downstream_edm_noc_interfaces_vc1,
@@ -2270,10 +2302,10 @@ FORCE_INLINE void run_fabric_edm_main_loop(
                             local_speedy_receiver_state);
 #else
                         rx_progress |= run_receiver_channel_step_speedy<
-                            0,
-                            to_receiver_packets_sent_streams[0],
-                            ENABLE_FIRST_LEVEL_ACK_VC0,
-                            VC0_DOWNSTREAM_EDM_SIZE,
+                            VC0_RECEIVER_CHANNEL,
+                            to_receiver_packets_sent_streams[VC0_RECEIVER_CHANNEL],
+                            ENABLE_FIRST_LEVEL_ACK_PER_VC[0],
+                            DOWNSTREAM_EDM_SIZE_PER_VC[0],
                             decltype(receiver_channel_0_trid_tracker)>(
                             local_receiver_channels.template get<0>(),
                             downstream_edm_noc_interfaces_vc0,
@@ -2294,14 +2326,15 @@ FORCE_INLINE void run_fabric_edm_main_loop(
                     // There are some cases, mainly for performance, where we don't want to switch between sender
                     // channels so we interoduce this to provide finer grain control over when we disable the automatic
                     // switching
-                    tx_progress |= run_sender_channel_step<VC0_RECEIVER_CHANNEL, 0, ENABLE_FIRST_LEVEL_ACK_VC0>(
-                        local_sender_channels,
-                        local_sender_channel_worker_interfaces,
+                    // VC0 sender channel 0
+                    tx_progress |= run_sender_channel_step<0, 0, ENABLE_FIRST_LEVEL_ACK_PER_VC[0]>(
+                        local_sender_channels_vc0,
+                        local_sender_channel_worker_interfaces_vc0,
                         outbound_to_receiver_channel_pointer_ch0,
                         remote_receiver_channels,
-                        channel_connection_established,
-                        local_sender_channel_free_slots_stream_ids,
-                        sender_channel_from_receiver_credits,
+                        channel_connection_established_vc0,
+                        local_sender_channel_free_slots_stream_ids_vc0_,
+                        sender_channel_from_receiver_credits_vc0,
                         inner_loop_perf_telemetry_collector,
                         local_fabric_telemetry);
 #if defined(FABRIC_2D_VC0_CROSSOVER_TO_VC1)
@@ -2309,8 +2342,8 @@ FORCE_INLINE void run_fabric_edm_main_loop(
                     // This VC0 traffic needs to be forwarded over VC1 in the receiving mesh.
                     rx_progress |= run_receiver_channel_step<
                         0,
-                        ENABLE_FIRST_LEVEL_ACK_VC0,
-                        VC1_DOWNSTREAM_EDM_SIZE,  // Explicit size for VC1 downstream interfaces
+                        ENABLE_FIRST_LEVEL_ACK_PER_VC[0],
+                        DOWNSTREAM_EDM_SIZE_PER_VC[1],
                         DownstreamSenderVC1T,
                         decltype(local_relay_interface)>(
                         local_receiver_channels,
@@ -2325,8 +2358,8 @@ FORCE_INLINE void run_fabric_edm_main_loop(
 #else
                     rx_progress |= run_receiver_channel_step<
                         0,
-                        ENABLE_FIRST_LEVEL_ACK_VC0,
-                        VC0_DOWNSTREAM_EDM_SIZE,  // Explicit size for VC0 downstream interfaces
+                        ENABLE_FIRST_LEVEL_ACK_PER_VC[0],
+                        DOWNSTREAM_EDM_SIZE_PER_VC[0],
                         DownstreamSenderVC0T,
                         decltype(local_relay_interface)>(
                         local_receiver_channels,
@@ -2339,46 +2372,48 @@ FORCE_INLINE void run_fabric_edm_main_loop(
                         routing_table,
                         local_fabric_telemetry);
 #endif
-                    tx_progress |= run_sender_channel_step<VC0_RECEIVER_CHANNEL, 1, ENABLE_FIRST_LEVEL_ACK_VC0>(
-                        local_sender_channels,
-                        local_sender_channel_worker_interfaces,
+                    // VC0 sender channel 1
+                    tx_progress |= run_sender_channel_step<0, 1, ENABLE_FIRST_LEVEL_ACK_PER_VC[0]>(
+                        local_sender_channels_vc0,
+                        local_sender_channel_worker_interfaces_vc0,
                         outbound_to_receiver_channel_pointer_ch0,
                         remote_receiver_channels,
-                        channel_connection_established,
-                        local_sender_channel_free_slots_stream_ids,
-                        sender_channel_from_receiver_credits,
+                        channel_connection_established_vc0,
+                        local_sender_channel_free_slots_stream_ids_vc0_,
+                        sender_channel_from_receiver_credits_vc0,
                         inner_loop_perf_telemetry_collector,
                         local_fabric_telemetry);
                     if constexpr (is_2d_fabric) {
-                        tx_progress |= run_sender_channel_step<VC0_RECEIVER_CHANNEL, 2, ENABLE_FIRST_LEVEL_ACK_VC0>(
-                            local_sender_channels,
-                            local_sender_channel_worker_interfaces,
+                        // VC0 sender channels 2-4
+                        tx_progress |= run_sender_channel_step<0, 2, ENABLE_FIRST_LEVEL_ACK_PER_VC[0]>(
+                            local_sender_channels_vc0,
+                            local_sender_channel_worker_interfaces_vc0,
                             outbound_to_receiver_channel_pointer_ch0,
                             remote_receiver_channels,
-                            channel_connection_established,
-                            local_sender_channel_free_slots_stream_ids,
-                            sender_channel_from_receiver_credits,
+                            channel_connection_established_vc0,
+                            local_sender_channel_free_slots_stream_ids_vc0_,
+                            sender_channel_from_receiver_credits_vc0,
                             inner_loop_perf_telemetry_collector,
                             local_fabric_telemetry);
-                        tx_progress |= run_sender_channel_step<VC0_RECEIVER_CHANNEL, 3, ENABLE_FIRST_LEVEL_ACK_VC0>(
-                            local_sender_channels,
-                            local_sender_channel_worker_interfaces,
+                        tx_progress |= run_sender_channel_step<0, 3, ENABLE_FIRST_LEVEL_ACK_PER_VC[0]>(
+                            local_sender_channels_vc0,
+                            local_sender_channel_worker_interfaces_vc0,
                             outbound_to_receiver_channel_pointer_ch0,
                             remote_receiver_channels,
-                            channel_connection_established,
-                            local_sender_channel_free_slots_stream_ids,
-                            sender_channel_from_receiver_credits,
+                            channel_connection_established_vc0,
+                            local_sender_channel_free_slots_stream_ids_vc0_,
+                            sender_channel_from_receiver_credits_vc0,
                             inner_loop_perf_telemetry_collector,
                             local_fabric_telemetry);
-                        if constexpr (ACTUAL_VC0_SENDER_CHANNELS > 4) {
-                            tx_progress |= run_sender_channel_step<VC0_RECEIVER_CHANNEL, 4, ENABLE_FIRST_LEVEL_ACK_VC0>(
-                                local_sender_channels,
-                                local_sender_channel_worker_interfaces,
+                        if constexpr (ACTUAL_SENDER_CHANNELS_PER_VC[0] > 4) {
+                            tx_progress |= run_sender_channel_step<0, 4, ENABLE_FIRST_LEVEL_ACK_PER_VC[0]>(
+                                local_sender_channels_vc0,
+                                local_sender_channel_worker_interfaces_vc0,
                                 outbound_to_receiver_channel_pointer_ch0,
                                 remote_receiver_channels,
-                                channel_connection_established,
-                                local_sender_channel_free_slots_stream_ids,
-                                sender_channel_from_receiver_credits,
+                                channel_connection_established_vc0,
+                                local_sender_channel_free_slots_stream_ids_vc0_,
+                                sender_channel_from_receiver_credits_vc0,
                                 inner_loop_perf_telemetry_collector,
                                 local_fabric_telemetry);
                         }
@@ -2386,64 +2421,52 @@ FORCE_INLINE void run_fabric_edm_main_loop(
                 }  // end of if constexpr (super_speedy_mode) else block
                 if constexpr (is_2d_fabric) {
 #if defined(FABRIC_2D_VC1_SERVICED)
-                    tx_progress |= run_sender_channel_step<
-                        VC1_RECEIVER_CHANNEL,
-                        ACTUAL_VC0_SENDER_CHANNELS,
-                        ENABLE_FIRST_LEVEL_ACK_VC1>(
-                        local_sender_channels,
-                        local_sender_channel_worker_interfaces,
+                    tx_progress |= run_sender_channel_step<1, 0, ENABLE_FIRST_LEVEL_ACK_PER_VC[1]>(
+                        local_sender_channels_vc1,
+                        local_sender_channel_worker_interfaces_vc1,
                         outbound_to_receiver_channel_pointer_ch1,
                         remote_receiver_channels,
-                        channel_connection_established,
-                        local_sender_channel_free_slots_stream_ids,
-                        sender_channel_from_receiver_credits,
+                        channel_connection_established_vc1,
+                        local_sender_channel_free_slots_stream_ids_vc1_,
+                        sender_channel_from_receiver_credits_vc1,
                         inner_loop_perf_telemetry_collector,
                         local_fabric_telemetry);
-                    tx_progress |= run_sender_channel_step<
-                        VC1_RECEIVER_CHANNEL,
-                        ACTUAL_VC0_SENDER_CHANNELS + 1,
-                        ENABLE_FIRST_LEVEL_ACK_VC1>(
-                        local_sender_channels,
-                        local_sender_channel_worker_interfaces,
+                    tx_progress |= run_sender_channel_step<1, 1, ENABLE_FIRST_LEVEL_ACK_PER_VC[1]>(
+                        local_sender_channels_vc1,
+                        local_sender_channel_worker_interfaces_vc1,
                         outbound_to_receiver_channel_pointer_ch1,
                         remote_receiver_channels,
-                        channel_connection_established,
-                        local_sender_channel_free_slots_stream_ids,
-                        sender_channel_from_receiver_credits,
+                        channel_connection_established_vc1,
+                        local_sender_channel_free_slots_stream_ids_vc1_,
+                        sender_channel_from_receiver_credits_vc1,
                         inner_loop_perf_telemetry_collector,
                         local_fabric_telemetry);
-                    tx_progress |= run_sender_channel_step<
-                        VC1_RECEIVER_CHANNEL,
-                        ACTUAL_VC0_SENDER_CHANNELS + 2,
-                        ENABLE_FIRST_LEVEL_ACK_VC1>(
-                        local_sender_channels,
-                        local_sender_channel_worker_interfaces,
+                    tx_progress |= run_sender_channel_step<1, 2, ENABLE_FIRST_LEVEL_ACK_PER_VC[1]>(
+                        local_sender_channels_vc1,
+                        local_sender_channel_worker_interfaces_vc1,
                         outbound_to_receiver_channel_pointer_ch1,
                         remote_receiver_channels,
-                        channel_connection_established,
-                        local_sender_channel_free_slots_stream_ids,
-                        sender_channel_from_receiver_credits,
+                        channel_connection_established_vc1,
+                        local_sender_channel_free_slots_stream_ids_vc1_,
+                        sender_channel_from_receiver_credits_vc1,
                         inner_loop_perf_telemetry_collector,
                         local_fabric_telemetry);
-                    if constexpr (ACTUAL_VC1_SENDER_CHANNELS > 3) {
-                        tx_progress |= run_sender_channel_step<
-                            VC1_RECEIVER_CHANNEL,
-                            ACTUAL_VC0_SENDER_CHANNELS + 3,
-                            ENABLE_FIRST_LEVEL_ACK_VC1>(
-                            local_sender_channels,
-                            local_sender_channel_worker_interfaces,
+                    if constexpr (ACTUAL_SENDER_CHANNELS_PER_VC[1] > 3) {
+                        tx_progress |= run_sender_channel_step<1, 3, ENABLE_FIRST_LEVEL_ACK_PER_VC[1]>(
+                            local_sender_channels_vc1,
+                            local_sender_channel_worker_interfaces_vc1,
                             outbound_to_receiver_channel_pointer_ch1,
                             remote_receiver_channels,
-                            channel_connection_established,
-                            local_sender_channel_free_slots_stream_ids,
-                            sender_channel_from_receiver_credits,
+                            channel_connection_established_vc1,
+                            local_sender_channel_free_slots_stream_ids_vc1_,
+                            sender_channel_from_receiver_credits_vc1,
                             inner_loop_perf_telemetry_collector,
                             local_fabric_telemetry);
                     }
                     rx_progress |= run_receiver_channel_step<
                         1,
-                        ENABLE_FIRST_LEVEL_ACK_VC1,
-                        VC1_DOWNSTREAM_EDM_SIZE,  // Explicit size for VC1 downstream interfaces
+                        ENABLE_FIRST_LEVEL_ACK_PER_VC[1],
+                        DOWNSTREAM_EDM_SIZE_PER_VC[1],
                         DownstreamSenderVC1T,
                         decltype(local_relay_interface)>(
                         local_receiver_channels,
@@ -2467,7 +2490,8 @@ FORCE_INLINE void run_fabric_edm_main_loop(
             // Compute idle conditions and update heartbeats in one helper
             if constexpr (FABRIC_TELEMETRY_ANY_DYNAMIC_STAT) {
                 update_telemetry(
-                    local_sender_channel_free_slots_stream_ids,
+                    local_sender_channel_free_slots_stream_ids_vc0_,
+                    local_sender_channel_free_slots_stream_ids_vc1_,
                     tx_progress,
                     rx_progress,
                     local_fabric_telemetry,
@@ -2495,11 +2519,13 @@ FORCE_INLINE void run_fabric_edm_main_loop(
                 run_routing_without_noc_sync_coordinated_as_non_master(termination_signal_ptr);
             }
 
-            if constexpr (is_sender_channel_serviced[0]) {
+            if constexpr (is_vc_sender_channel_serviced<0, 0>()) {
                 close_perf_recording_window(inner_loop_perf_telemetry_collector);
                 if constexpr (perf_telemetry_mode != PerfTelemetryRecorderType::NONE) {
                     if (captured_an_event(inner_loop_perf_telemetry_collector) ||
-                        any_sender_channels_active(local_sender_channel_free_slots_stream_ids)) {
+                        any_sender_channels_active(
+                            local_sender_channel_free_slots_stream_ids_vc0_,
+                            local_sender_channel_free_slots_stream_ids_vc1_)) {
                         write_perf_recording_window_results(
                             inner_loop_perf_telemetry_collector, local_perf_telemetry_buffer);
                     }
@@ -2550,37 +2576,37 @@ FORCE_INLINE void run_fabric_edm_main_loop(
     }
 }
 
-template <typename EdmChannelWorkerIFs, size_t NUM_SENDER_CHANNELS>
+template <size_t vc, typename EdmChannelWorkerIFs, size_t N>
+void wait_for_vc_static_connections(
+    EdmChannelWorkerIFs& local_sender_channel_worker_interfaces, std::array<uint32_t, N>& free_slots_stream_ids) {
+    [&]<size_t... Chs>(std::index_sequence<Chs...>) {
+        (([&]<size_t ch>() {
+             if constexpr (is_vc_sender_channel_serviced<vc, ch>()) {
+                 if (get_sender_ch_live_check_skip<vc>()[ch]) {
+                     auto& interface = local_sender_channel_worker_interfaces.template get<ch>();
+                     while (!connect_is_requested(*interface.connection_live_semaphore)) {
+                         router_invalidate_l1_cache<ENABLE_RISC_CPU_DATA_CACHE>();
+                     }
+                     establish_edm_connection(interface, free_slots_stream_ids[ch]);
+                 }
+             }
+         }.template operator()<Chs>()),
+         ...);
+    }(std::make_index_sequence<N>{});
+}
+
+template <typename EdmChannelWorkerIFsVC0, typename EdmChannelWorkerIFsVC1, size_t N0, size_t N1>
 void
 #ifdef FABRIC_2D
     __attribute__((noinline))
 #endif
     wait_for_static_connection_to_ready(
-        EdmChannelWorkerIFs& local_sender_channel_worker_interfaces,
-        std::array<uint32_t, NUM_SENDER_CHANNELS>& local_sender_channel_free_slots_stream_ids) {
-    auto establish_static_connection_from_receiver_side = [&](auto& interface, size_t sender_channel_idx) {
-        if (!sender_ch_live_check_skip[sender_channel_idx]) {
-            return;
-        }
-        while (!connect_is_requested(*interface.connection_live_semaphore)) {
-            router_invalidate_l1_cache<ENABLE_RISC_CPU_DATA_CACHE>();
-        }
-        establish_edm_connection(interface, local_sender_channel_free_slots_stream_ids[sender_channel_idx]);
-    };
-    if constexpr (multi_txq_enabled) {
-        tuple_for_each_constexpr(
-            local_sender_channel_worker_interfaces.channel_worker_interfaces, [&](auto& interface, auto idx) {
-                if constexpr (is_sender_channel_serviced[idx]) {
-                    establish_static_connection_from_receiver_side(interface, idx);
-                }
-            });
-    } else {
-        // Very slight performance regression on WH if we commonize to the above path, so we preserve this path
-        // too
-        tuple_for_each(
-            local_sender_channel_worker_interfaces.channel_worker_interfaces,
-            [&](auto& interface, size_t idx) { establish_static_connection_from_receiver_side(interface, idx); });
-    }
+        EdmChannelWorkerIFsVC0& worker_interfaces_vc0,
+        EdmChannelWorkerIFsVC1& worker_interfaces_vc1,
+        std::array<uint32_t, N0>& free_slots_vc0,
+        std::array<uint32_t, N1>& free_slots_vc1) {
+    wait_for_vc_static_connections<0>(worker_interfaces_vc0, free_slots_vc0);
+    wait_for_vc_static_connections<1>(worker_interfaces_vc1, free_slots_vc1);
 }
 
 // Returns the number of starting credits for the specified sender channel `i`
@@ -2588,87 +2614,61 @@ void
 // except for channels which service transient/worker connections. Those
 // sender channels use counter based credit schemes so they are initialized
 // to 0.
-template <size_t i>
-constexpr size_t get_credits_init_val() {
-    return i == 0 ? 0 : SENDER_NUM_BUFFERS_ARRAY[i];
-};
-
-// SFINAE helper to initialize a single sender channel worker interface
-// Only enabled when I < NUM_SENDER_CHANNELS
-template <size_t I, size_t NUM_SENDER_CHANNELS, typename EdmChannelWorkerIFs>
-FORCE_INLINE typename std::enable_if<(I < NUM_SENDER_CHANNELS), void>::type init_sender_channel_worker_interface(
-    std::array<size_t, NUM_SENDER_CHANNELS>& local_sender_connection_live_semaphore_addresses,
-    std::array<size_t, NUM_SENDER_CHANNELS>& local_sender_connection_info_addresses,
+// Initialize a single sender channel worker interface using per-VC arrays
+template <size_t vc, size_t ch, typename EdmChannelWorkerIFs, size_t N>
+FORCE_INLINE void init_sender_channel_worker_interface_vc(
+    std::array<size_t, N>& semaphore_addrs,
+    std::array<size_t, N>& info_addrs,
     EdmChannelWorkerIFs& local_sender_channel_worker_interfaces) {
-    auto connection_live_semaphore_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t* const>(local_sender_connection_live_semaphore_addresses[I]);
-    auto connection_worker_info_ptr = reinterpret_cast<volatile tt::tt_fabric::EDMChannelWorkerLocationInfo*>(
-        local_sender_connection_info_addresses[I]);
-    new (&local_sender_channel_worker_interfaces.template get<I>()) tt::tt_fabric::
-        StaticSizedSenderChannelWorkerInterface<tt::tt_fabric::worker_handshake_noc, SENDER_NUM_BUFFERS_ARRAY[I]>(
+    // Channel 0 of VC0 is always the worker channel — init credits to 0 (counter-based)
+    // All other channels get full credit init
+    constexpr size_t credits_init = (vc == 0 && ch == 0) ? 0 : get_sender_num_buffers<vc>()[ch];
+    auto connection_live_semaphore_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t* const>(semaphore_addrs[ch]);
+    auto connection_worker_info_ptr =
+        reinterpret_cast<volatile tt::tt_fabric::EDMChannelWorkerLocationInfo*>(info_addrs[ch]);
+    new (&local_sender_channel_worker_interfaces.template get<ch>()) tt::tt_fabric::
+        StaticSizedSenderChannelWorkerInterface<tt::tt_fabric::worker_handshake_noc, get_sender_num_buffers<vc>()[ch]>(
             connection_worker_info_ptr,
-            0,  // Not used for credits.
+            0,
             reinterpret_cast<volatile tt_l1_ptr uint32_t* const>(connection_live_semaphore_ptr),
-            sender_channel_ack_cmd_buf_ids[I],
-            get_credits_init_val<I>(),
+            get_sender_channel_ack_cmd_buf_ids<vc>()[ch],
+            credits_init,
             notify_worker_of_read_counter_update_src_address);
 }
 
-// SFINAE overload - no-op when I >= NUM_SENDER_CHANNELS
-template <size_t I, size_t NUM_SENDER_CHANNELS, typename EdmChannelWorkerIFs>
-typename std::enable_if<(I >= NUM_SENDER_CHANNELS), void>::type init_sender_channel_worker_interface(
-    std::array<size_t, NUM_SENDER_CHANNELS>&, std::array<size_t, NUM_SENDER_CHANNELS>&, EdmChannelWorkerIFs&) {
-    // No-op when channel index is out of range
+template <size_t vc, typename EdmChannelWorkerIFs, size_t N>
+void init_vc_sender_channel_worker_interfaces(
+    std::array<size_t, N>& semaphore_addrs,
+    std::array<size_t, N>& info_addrs,
+    EdmChannelWorkerIFs& local_sender_channel_worker_interfaces) {
+    [&]<size_t... Chs>(std::index_sequence<Chs...>) {
+        ((init_sender_channel_worker_interface_vc<vc, Chs>(
+             semaphore_addrs, info_addrs, local_sender_channel_worker_interfaces)),
+         ...);
+    }(std::make_index_sequence<N>{});
 }
 
-template <size_t NUM_SENDER_CHANNELS, typename EdmChannelWorkerIFs>
+template <typename EdmChannelWorkerIFsVC0, typename EdmChannelWorkerIFsVC1, size_t N0, size_t N1>
 void
 #ifdef FABRIC_2D
     __attribute__((noinline))
 #endif
     init_local_sender_channel_worker_interfaces(
-        std::array<size_t, NUM_SENDER_CHANNELS>& local_sender_connection_live_semaphore_addresses,
-        std::array<size_t, NUM_SENDER_CHANNELS>& local_sender_connection_info_addresses,
-        EdmChannelWorkerIFs& local_sender_channel_worker_interfaces) {
-    // manual unrol because previously, going from having this in a loop to unrolling this would
-    // lead to a performance regression. Having these unrolled is needed to enable some performance optimizations
-    // because setup will differ in that each will be a different type. Keeping them unrolled here let's us
-    // stay safe from perf regression due to weirdness of codegen.
-    init_sender_channel_worker_interface<0, NUM_SENDER_CHANNELS>(
-        local_sender_connection_live_semaphore_addresses,
-        local_sender_connection_info_addresses,
-        local_sender_channel_worker_interfaces);
-    if constexpr (NUM_SENDER_CHANNELS > 1) {
-        init_sender_channel_worker_interface<1, NUM_SENDER_CHANNELS>(
-            local_sender_connection_live_semaphore_addresses,
-            local_sender_connection_info_addresses,
-            local_sender_channel_worker_interfaces);
-    }
-#ifdef FABRIC_2D
-    // Use compile-time loop to initialize remaining sender channels (2-6) for code size optimization
-    if constexpr (NUM_SENDER_CHANNELS > 2) {
-        [&]<size_t... Is>(std::index_sequence<Is...>) {
-            (([&]<size_t I>() {
-                 if constexpr (NUM_SENDER_CHANNELS > I) {
-                     init_sender_channel_worker_interface<I, NUM_SENDER_CHANNELS>(
-                         local_sender_connection_live_semaphore_addresses,
-                         local_sender_connection_info_addresses,
-                         local_sender_channel_worker_interfaces);
-                 }
-             }.template operator()<Is + 2>()),
-             ...);
-        }(std::make_index_sequence<7>{});  // Indices 0-6 map to channels 2-8
-    }
-#endif
+        std::array<size_t, N0>& semaphore_addrs_vc0,
+        std::array<size_t, N0>& info_addrs_vc0,
+        std::array<size_t, N1>& semaphore_addrs_vc1,
+        std::array<size_t, N1>& info_addrs_vc1,
+        EdmChannelWorkerIFsVC0& worker_interfaces_vc0,
+        EdmChannelWorkerIFsVC1& worker_interfaces_vc1) {
+    init_vc_sender_channel_worker_interfaces<0>(semaphore_addrs_vc0, info_addrs_vc0, worker_interfaces_vc0);
+    init_vc_sender_channel_worker_interfaces<1>(semaphore_addrs_vc1, info_addrs_vc1, worker_interfaces_vc1);
 }
 
-// copy the sender_channel_free_slots_stream_ids (in L1) to local memory for performance.
-template <size_t NUM_SENDER_CHANNELS>
-void populate_local_sender_channel_free_slots_stream_id_ordered_map(
-    uint32_t has_downstream_edm_vc0_buffer_connection,
-    std::array<uint32_t, NUM_SENDER_CHANNELS>& local_sender_channel_free_slots_stream_ids) {
-    for (size_t i = 0; i < NUM_SENDER_CHANNELS; i++) {
-        local_sender_channel_free_slots_stream_ids[i] = sender_channel_free_slots_stream_ids[i];
+// Copy the sender_channel_free_slots_stream_ids to per-VC local arrays
+template <size_t vc, size_t N>
+void populate_vc_sender_channel_free_slots_stream_ids(std::array<uint32_t, N>& out) {
+    for (size_t ch = 0; ch < N; ch++) {
+        out[ch] = get_sender_channel_free_slots_stream_ids<vc>()[ch];
     }
 }
 
@@ -2715,11 +2715,11 @@ FORCE_INLINE void teardown(
     if constexpr (NUM_ACTIVE_ERISCS > 1) {
         wait_for_other_local_erisc();
     }
-    if constexpr (is_receiver_channel_serviced[0]) {
+    if constexpr (is_vc_receiver_channel_serviced(0)) {
         receiver_channel_0_trid_tracker.all_buffer_slot_transactions_acked();
     }
 #if defined(FABRIC_2D_VC1_ACTIVE)
-    if constexpr (is_receiver_channel_serviced[1]) {
+    if constexpr (is_vc_receiver_channel_serviced(1)) {
         receiver_channel_1_trid_tracker.all_buffer_slot_transactions_acked();
     }
 #endif
@@ -2840,11 +2840,11 @@ void kernel_main() {
         receiver_txq_id == sender_txq_id || receiver_txq_id == 1,
         "For multi-txq mode, the only currently supported configuration is sender_txq_id=0 and receiver_txq_id=1");
     if constexpr (receiver_txq_id != sender_txq_id) {
-        constexpr bool is_erisc_that_sets_up_second_txq = is_receiver_channel_serviced[0];
+        constexpr bool is_erisc_that_sets_up_second_txq = is_vc_receiver_channel_serviced(0);
         if constexpr (is_erisc_that_sets_up_second_txq) {
             initialize_state_for_txq1_active_mode();
         }
-        if constexpr (is_sender_channel_serviced[0]) {
+        if constexpr (is_vc_sender_channel_serviced<0, 0>()) {
             initialize_state_for_txq1_active_mode_sender_side();
         }
     }
@@ -2864,8 +2864,11 @@ void kernel_main() {
     init_ptr_val<to_sender_packets_completed_streams[0]>(0);
     init_ptr_val<to_sender_packets_completed_streams[1]>(0);
     // The first sender channel in the array is always for the transient/worker connection
+    // VC0 sender stream reg init
     init_ptr_val<sender_channel_free_slots_stream_ids[0]>(SENDER_NUM_BUFFERS_ARRAY[0]);  // LOCAL WORKER
-    init_ptr_val<sender_channel_free_slots_stream_ids[1]>(SENDER_NUM_BUFFERS_ARRAY[1]);  // Compact index 0
+    if constexpr (ACTUAL_SENDER_CHANNELS_PER_VC[0] > 1) {
+        init_ptr_val<sender_channel_free_slots_stream_ids[1]>(SENDER_NUM_BUFFERS_ARRAY[1]);
+    }
 
     // Init retrain sync reg
     if (IS_RETRAIN_SYNC_MASTER()) {
@@ -2882,17 +2885,22 @@ void kernel_main() {
         init_ptr_val<to_sender_packets_acked_streams[2]>(0);
         init_ptr_val<to_sender_packets_acked_streams[3]>(0);
 
-        // Initialize completion streams and sender channel free slots for channels 2-7 using compile-time loop
-        // SENDER_NUM_BUFFERS_ARRAY[] is sized to NUM_SENDER_CHANNELS, which is the number of used sender channels.
+        // Initialize completion streams for flat sender channels 2-7
         [&]<size_t... Is>(std::index_sequence<Is...>) {
-            (([&]() {
-                 init_ptr_val<to_sender_packets_completed_streams[Is + 2]>(0);
-                 if constexpr (NUM_SENDER_CHANNELS > (Is + 2)) {
-                     init_ptr_val<sender_channel_free_slots_stream_ids[Is + 2]>(SENDER_NUM_BUFFERS_ARRAY[Is + 2]);
-                 }
-             }()),
-             ...);
+            ((init_ptr_val<to_sender_packets_completed_streams[Is + 2]>(0)), ...);
         }(std::make_index_sequence<6>{});
+
+        // Initialize sender channel free slots per VC (channels beyond 0,1 which are already init'd)
+        // VC0 channels 2+
+        [&]<size_t... Chs>(std::index_sequence<Chs...>) {
+            ((init_ptr_val<get_sender_channel_free_slots_stream_ids<0>()[Chs + 2]>(
+                 get_sender_num_buffers<0>()[Chs + 2])),
+             ...);
+        }(std::make_index_sequence<ACTUAL_SENDER_CHANNELS_PER_VC[0] >= 2 ? ACTUAL_SENDER_CHANNELS_PER_VC[0] - 2 : 0>{});
+        // VC1 all channels
+        [&]<size_t... Chs>(std::index_sequence<Chs...>) {
+            ((init_ptr_val<get_sender_channel_free_slots_stream_ids<1>()[Chs]>(get_sender_num_buffers<1>()[Chs])), ...);
+        }(std::make_index_sequence<ACTUAL_SENDER_CHANNELS_PER_VC[1]>{});
     }
 
 #if !defined(FABRIC_2D_VC1_ACTIVE)
@@ -2917,16 +2925,25 @@ void kernel_main() {
     ///////////////////////
     // Common runtime args:
     ///////////////////////
-    // Read sender channel connection semaphore addresses (9 channels: 8 base + 1 for Z routers)
-    std::array<size_t, MAX_NUM_SENDER_CHANNELS> local_sender_channel_connection_semaphore_addrs;
+    // Read sender channel connection semaphore addresses (MAX_NUM_SENDER_CHANNELS, unused = 0)
+    std::array<size_t, MAX_NUM_SENDER_CHANNELS> local_sender_channel_connection_semaphore_addrs_flat_;
     for (size_t i = 0; i < MAX_NUM_SENDER_CHANNELS; i++) {
-        local_sender_channel_connection_semaphore_addrs[i] = get_arg_val<uint32_t>(arg_idx++);
+        local_sender_channel_connection_semaphore_addrs_flat_[i] = get_arg_val<uint32_t>(arg_idx++);
     }
-    // Read sender channel connection buffer index IDs (9 channels: 8 base + 1 for Z routers)
-    std::array<size_t, MAX_NUM_SENDER_CHANNELS> local_sender_channel_connection_buffer_index_ids;
+    auto local_sender_channel_connection_semaphore_addrs_vc0 =
+        slice_sender_channels_for_vc<0>(local_sender_channel_connection_semaphore_addrs_flat_);
+    auto local_sender_channel_connection_semaphore_addrs_vc1 =
+        slice_sender_channels_for_vc<1>(local_sender_channel_connection_semaphore_addrs_flat_);
+
+    // Read sender channel connection buffer index IDs (MAX_NUM_SENDER_CHANNELS, unused = 0)
+    std::array<size_t, MAX_NUM_SENDER_CHANNELS> local_sender_channel_connection_buffer_index_ids_flat_;
     for (size_t i = 0; i < MAX_NUM_SENDER_CHANNELS; i++) {
-        local_sender_channel_connection_buffer_index_ids[i] = get_arg_val<uint32_t>(arg_idx++);
+        local_sender_channel_connection_buffer_index_ids_flat_[i] = get_arg_val<uint32_t>(arg_idx++);
     }
+    [[maybe_unused]] auto local_sender_channel_connection_buffer_index_ids_vc0 =
+        slice_sender_channels_for_vc<0>(local_sender_channel_connection_buffer_index_ids_flat_);
+    [[maybe_unused]] auto local_sender_channel_connection_buffer_index_ids_vc1 =
+        slice_sender_channels_for_vc<1>(local_sender_channel_connection_buffer_index_ids_flat_);
 
     // downstream EDM VC0 connection info
     const auto has_downstream_edm_vc0_buffer_connection = get_arg_val<uint32_t>(arg_idx++);
@@ -2934,8 +2951,8 @@ void kernel_main() {
     // For 2D: read 3 buffer base addresses, NOC coords, and registration addresses (one per compact index)
     // For 1D: reads as 1D and only uses first element
 #if defined(FABRIC_2D)
-    std::array<uint32_t, NUM_DOWNSTREAM_SENDERS_VC0> downstream_edm_vc0_buffer_base_addresses;
-    for (size_t i = 0; i < NUM_DOWNSTREAM_SENDERS_VC0; i++) {
+    std::array<uint32_t, NUM_DOWNSTREAM_SENDERS_PER_VC[0]> downstream_edm_vc0_buffer_base_addresses;
+    for (size_t i = 0; i < NUM_DOWNSTREAM_SENDERS_PER_VC[0]; i++) {
         downstream_edm_vc0_buffer_base_addresses[i] = get_arg_val<uint32_t>(arg_idx++);
     }
 #else
@@ -2946,16 +2963,16 @@ void kernel_main() {
     const auto downstream_edm_vc0_noc_y = get_arg_val<uint32_t>(arg_idx++);
 
 #if defined(FABRIC_2D)
-    std::array<uint32_t, NUM_DOWNSTREAM_SENDERS_VC0> downstream_edm_vc0_worker_registration_ids;
-    std::array<uint32_t, NUM_DOWNSTREAM_SENDERS_VC0> downstream_edm_vc0_worker_location_info_addresses;
-    std::array<uint32_t, NUM_DOWNSTREAM_SENDERS_VC0> downstream_edm_vc0_buffer_index_semaphore_addresses;
-    for (size_t i = 0; i < NUM_DOWNSTREAM_SENDERS_VC0; i++) {
+    std::array<uint32_t, NUM_DOWNSTREAM_SENDERS_PER_VC[0]> downstream_edm_vc0_worker_registration_ids;
+    std::array<uint32_t, NUM_DOWNSTREAM_SENDERS_PER_VC[0]> downstream_edm_vc0_worker_location_info_addresses;
+    std::array<uint32_t, NUM_DOWNSTREAM_SENDERS_PER_VC[0]> downstream_edm_vc0_buffer_index_semaphore_addresses;
+    for (size_t i = 0; i < NUM_DOWNSTREAM_SENDERS_PER_VC[0]; i++) {
         downstream_edm_vc0_worker_registration_ids[i] = get_arg_val<uint32_t>(arg_idx++);
     }
-    for (size_t i = 0; i < NUM_DOWNSTREAM_SENDERS_VC0; i++) {
+    for (size_t i = 0; i < NUM_DOWNSTREAM_SENDERS_PER_VC[0]; i++) {
         downstream_edm_vc0_worker_location_info_addresses[i] = get_arg_val<uint32_t>(arg_idx++);
     }
-    for (size_t i = 0; i < NUM_DOWNSTREAM_SENDERS_VC0; i++) {
+    for (size_t i = 0; i < NUM_DOWNSTREAM_SENDERS_PER_VC[0]; i++) {
         downstream_edm_vc0_buffer_index_semaphore_addresses[i] = get_arg_val<uint32_t>(arg_idx++);
     }
 #else
@@ -2966,24 +2983,24 @@ void kernel_main() {
 
 #if defined(FABRIC_2D_VC1_ACTIVE)
     const auto has_downstream_edm_vc1_buffer_connection = get_arg_val<uint32_t>(arg_idx++);
-    std::array<uint32_t, NUM_DOWNSTREAM_SENDERS_VC1> downstream_edm_vc1_buffer_base_addresses;
-    for (size_t i = 0; i < NUM_DOWNSTREAM_SENDERS_VC1; i++) {
+    std::array<uint32_t, NUM_DOWNSTREAM_SENDERS_PER_VC[1]> downstream_edm_vc1_buffer_base_addresses;
+    for (size_t i = 0; i < NUM_DOWNSTREAM_SENDERS_PER_VC[1]; i++) {
         downstream_edm_vc1_buffer_base_addresses[i] = get_arg_val<uint32_t>(arg_idx++);
     }
 
     const auto downstream_edm_vc1_noc_x = get_arg_val<uint32_t>(arg_idx++);
     const auto downstream_edm_vc1_noc_y = get_arg_val<uint32_t>(arg_idx++);
 
-    std::array<uint32_t, NUM_DOWNSTREAM_SENDERS_VC1> downstream_edm_vc1_worker_registration_ids;
-    std::array<uint32_t, NUM_DOWNSTREAM_SENDERS_VC1> downstream_edm_vc1_worker_location_info_addresses;
-    std::array<uint32_t, NUM_DOWNSTREAM_SENDERS_VC1> downstream_edm_vc1_buffer_index_semaphore_addresses;
-    for (size_t i = 0; i < NUM_DOWNSTREAM_SENDERS_VC1; i++) {
+    std::array<uint32_t, NUM_DOWNSTREAM_SENDERS_PER_VC[1]> downstream_edm_vc1_worker_registration_ids;
+    std::array<uint32_t, NUM_DOWNSTREAM_SENDERS_PER_VC[1]> downstream_edm_vc1_worker_location_info_addresses;
+    std::array<uint32_t, NUM_DOWNSTREAM_SENDERS_PER_VC[1]> downstream_edm_vc1_buffer_index_semaphore_addresses;
+    for (size_t i = 0; i < NUM_DOWNSTREAM_SENDERS_PER_VC[1]; i++) {
         downstream_edm_vc1_worker_registration_ids[i] = get_arg_val<uint32_t>(arg_idx++);
     }
-    for (size_t i = 0; i < NUM_DOWNSTREAM_SENDERS_VC1; i++) {
+    for (size_t i = 0; i < NUM_DOWNSTREAM_SENDERS_PER_VC[1]; i++) {
         downstream_edm_vc1_worker_location_info_addresses[i] = get_arg_val<uint32_t>(arg_idx++);
     }
-    for (size_t i = 0; i < NUM_DOWNSTREAM_SENDERS_VC1; i++) {
+    for (size_t i = 0; i < NUM_DOWNSTREAM_SENDERS_PER_VC[1]; i++) {
         downstream_edm_vc1_buffer_index_semaphore_addresses[i] = get_arg_val<uint32_t>(arg_idx++);
     }
 #endif  // FABRIC_2D_VC1_ACTIVE
@@ -2992,11 +3009,15 @@ void kernel_main() {
     const auto downstream_vc0_noc_interface_buffer_index_local_addr = 0;
     const auto downstream_vc1_noc_interface_buffer_index_local_addr = 0;
 
-    // Read teardown semaphores (MAX_NUM_SENDER_CHANNELS channels)
-    std::array<size_t, MAX_NUM_SENDER_CHANNELS> my_sem_for_teardown_from_edm;
+    // Read teardown semaphores (MAX_NUM_SENDER_CHANNELS, unused = 0)
+    std::array<size_t, MAX_NUM_SENDER_CHANNELS> my_sem_for_teardown_from_edm_flat_;
     for (size_t i = 0; i < MAX_NUM_SENDER_CHANNELS; i++) {
-        my_sem_for_teardown_from_edm[i] = get_arg_val<uint32_t>(arg_idx++);
+        my_sem_for_teardown_from_edm_flat_[i] = get_arg_val<uint32_t>(arg_idx++);
     }
+    [[maybe_unused]] auto my_sem_for_teardown_from_edm_vc0 =
+        slice_sender_channels_for_vc<0>(my_sem_for_teardown_from_edm_flat_);
+    [[maybe_unused]] auto my_sem_for_teardown_from_edm_vc1 =
+        slice_sender_channels_for_vc<1>(my_sem_for_teardown_from_edm_flat_);
     ///////////////////////////////////////////////
     // Local tensix (relay) connection runtime args
     // UDM mode only - packed at end of runtime args
@@ -3021,16 +3042,20 @@ void kernel_main() {
         }
     }
 
-    //  initialize the statically allocated "semaphores"
-    [&]<size_t... Is>(std::index_sequence<Is...>) {
-        (([&]<size_t I>() {
-             if constexpr (is_sender_channel_serviced[I]) {
-                 *reinterpret_cast<volatile uint32_t*>(local_sender_channel_connection_semaphore_addrs[I]) = 0;
-                 *reinterpret_cast<volatile uint32_t*>(local_sender_channel_connection_buffer_index_ids[I]) = 0;
+    //  initialize the statically allocated "semaphores" per VC
+    auto init_vc_semaphores = [&]<size_t vc, size_t... Is>(std::index_sequence<Is...>) {
+        (([&]<size_t ch>() {
+             if constexpr (get_is_sender_channel_serviced<vc>()[ch]) {
+                 *reinterpret_cast<volatile uint32_t*>(
+                     local_sender_channel_connection_semaphore_addrs_flat_[VC_SENDER_CHANNEL_START[vc] + ch]) = 0;
+                 *reinterpret_cast<volatile uint32_t*>(
+                     local_sender_channel_connection_buffer_index_ids_flat_[VC_SENDER_CHANNEL_START[vc] + ch]) = 0;
              }
          }.template operator()<Is>()),
          ...);
-    }(std::make_index_sequence<NUM_SENDER_CHANNELS>{});
+    };
+    init_vc_semaphores.template operator()<0>(std::make_index_sequence<ACTUAL_SENDER_CHANNELS_PER_VC[0]>{});
+    init_vc_semaphores.template operator()<1>(std::make_index_sequence<ACTUAL_SENDER_CHANNELS_PER_VC[1]>{});
     asm volatile("nop");
 
 #if !defined(FABRIC_2D_VC1_ACTIVE)
@@ -3049,12 +3074,15 @@ void kernel_main() {
     // Needed so `downstream_edm_noc_interfaces_vc0` can be initialized properly below
     // Issue #33360 TODO: Create a new array for downstream receiver stream IDs
     // so we can remove this hack.
-    std::array<uint32_t, NUM_SENDER_CHANNELS> local_sender_channel_free_slots_stream_ids;
-    // std::array<uint32_t, NUM_SENDER_CHANNELS == 1 ? 2 : NUM_SENDER_CHANNELS>
-    // local_sender_channel_free_slots_stream_ids;
+    // Per-VC local sender channel free slots stream IDs (populated later in populate helper)
+    auto local_sender_channel_free_slots_stream_ids_vc0 =
+        initialize_array<ACTUAL_SENDER_CHANNELS_PER_VC[0], uint32_t, 0>();
+    auto local_sender_channel_free_slots_stream_ids_vc1 =
+        initialize_array<ACTUAL_SENDER_CHANNELS_PER_VC[1], uint32_t, 0>();
 
     const auto& local_sem_for_teardown_from_downstream_edm =
-        take_first_n_elements<NUM_DOWNSTREAM_CHANNELS, MAX_NUM_SENDER_CHANNELS, size_t>(my_sem_for_teardown_from_edm);
+        take_first_n_elements<NUM_DOWNSTREAM_CHANNELS, MAX_NUM_SENDER_CHANNELS, size_t>(
+            my_sem_for_teardown_from_edm_flat_);
 
     auto remote_receiver_channels = tt::tt_fabric::ReceiverChannelBuffersFromAllocs<
         PACKET_HEADER_TYPE,
@@ -3064,48 +3092,67 @@ void kernel_main() {
     auto local_receiver_channels = tt::tt_fabric::
         ReceiverChannelBuffersFromAllocs<PACKET_HEADER_TYPE, channel_allocs, RECEIVER_TO_ENTRY_IDX>::make();
 
-    auto local_sender_channels =
-        tt::tt_fabric::SenderChannelBuffersFromAllocs<PACKET_HEADER_TYPE, channel_allocs, SENDER_TO_ENTRY_IDX>::make();
+    auto local_sender_channels_vc0 = tt::tt_fabric::
+        SenderChannelBuffersFromAllocs<PACKET_HEADER_TYPE, channel_allocs, SENDER_TO_ENTRY_IDX_VC0>::make();
+#if defined(FABRIC_2D_VC1_SERVICED)
+    auto local_sender_channels_vc1 = tt::tt_fabric::
+        SenderChannelBuffersFromAllocs<PACKET_HEADER_TYPE, channel_allocs, SENDER_TO_ENTRY_IDX_VC1>::make();
+#else
+    [[maybe_unused]] std::tuple<> local_sender_channels_vc1;
+#endif
 
-    std::array<size_t, NUM_SENDER_CHANNELS> local_sender_connection_live_semaphore_addresses =
-        take_first_n_elements<NUM_SENDER_CHANNELS, MAX_NUM_SENDER_CHANNELS, size_t>(
-            local_sender_channel_connection_semaphore_addrs);
-    std::array<size_t, NUM_SENDER_CHANNELS> local_sender_connection_info_addresses =
-        take_first_n_elements<NUM_SENDER_CHANNELS, MAX_NUM_SENDER_CHANNELS, size_t>(
-            std::array<size_t, MAX_NUM_SENDER_CHANNELS>{
-                local_sender_channel_0_connection_info_addr,
-                local_sender_channel_1_connection_info_addr,
-                local_sender_channel_2_connection_info_addr,
-                local_sender_channel_3_connection_info_addr,
-                local_sender_channel_4_connection_info_addr,
-                local_sender_channel_5_connection_info_addr,
-                local_sender_channel_6_connection_info_addr,
-                local_sender_channel_7_connection_info_addr,
-                local_sender_channel_8_connection_info_addr});
+    // Semaphore addresses used via local_sender_channel_connection_semaphore_addrs_vc0/vc1 directly
+    static constexpr std::array<size_t, MAX_NUM_SENDER_CHANNELS> local_sender_connection_info_addresses_flat_ = {
+        local_sender_channel_0_connection_info_addr,
+        local_sender_channel_1_connection_info_addr,
+        local_sender_channel_2_connection_info_addr,
+        local_sender_channel_3_connection_info_addr,
+        local_sender_channel_4_connection_info_addr,
+        local_sender_channel_5_connection_info_addr,
+        local_sender_channel_6_connection_info_addr,
+        local_sender_channel_7_connection_info_addr,
+        local_sender_channel_8_connection_info_addr};
+    constexpr auto local_sender_connection_info_addresses_vc0 =
+        slice_sender_channels_for_vc<0>(local_sender_connection_info_addresses_flat_);
+    constexpr auto local_sender_connection_info_addresses_vc1 =
+        slice_sender_channels_for_vc<1>(local_sender_connection_info_addresses_flat_);
 
-    for (size_t i = 0; i < NUM_SENDER_CHANNELS; i++) {
+    // Init edm_read_counter for all active sender channels per VC
+    for (size_t i = 0; i < ACTUAL_SENDER_CHANNELS_PER_VC[0]; i++) {
         auto connection_worker_info_ptr = reinterpret_cast<volatile tt::tt_fabric::EDMChannelWorkerLocationInfo*>(
-            local_sender_connection_info_addresses[i]);
+            local_sender_connection_info_addresses_vc0[i]);
         connection_worker_info_ptr->edm_read_counter = 0;
     }
-    // create the sender channel worker interfaces with input array of number of buffers
-    auto local_sender_channel_worker_interfaces =
-        tt::tt_fabric::EdmChannelWorkerInterfaces<tt::tt_fabric::worker_handshake_noc, SENDER_NUM_BUFFERS_ARRAY>::make(
-            std::make_index_sequence<NUM_SENDER_CHANNELS>{});
+    for (size_t i = 0; i < ACTUAL_SENDER_CHANNELS_PER_VC[1]; i++) {
+        auto connection_worker_info_ptr = reinterpret_cast<volatile tt::tt_fabric::EDMChannelWorkerLocationInfo*>(
+            local_sender_connection_info_addresses_vc1[i]);
+        connection_worker_info_ptr->edm_read_counter = 0;
+    }
+    // create per-VC sender channel worker interfaces
+    auto local_sender_channel_worker_interfaces_vc0 =
+        tt::tt_fabric::EdmChannelWorkerInterfaces<tt::tt_fabric::worker_handshake_noc, SENDER_NUM_BUFFERS_VC0>::make(
+            std::make_index_sequence<ACTUAL_SENDER_CHANNELS_PER_VC[0]>{});
+#if defined(FABRIC_2D_VC1_SERVICED)
+    auto local_sender_channel_worker_interfaces_vc1 =
+        tt::tt_fabric::EdmChannelWorkerInterfaces<tt::tt_fabric::worker_handshake_noc, SENDER_NUM_BUFFERS_VC1>::make(
+            std::make_index_sequence<ACTUAL_SENDER_CHANNELS_PER_VC[1]>{});
+#else
+    [[maybe_unused]] std::tuple<> local_sender_channel_worker_interfaces_vc1;
+#endif
 
 #if !defined(FABRIC_2D_VC1_ACTIVE)
     POSTCODE(tt::tt_fabric::EDMStatus::DOWNSTREAM_EDM_SETUP_STARTED);
 #endif
 
     // TODO: change to TMP.
-    std::array<RouterToRouterSender<DOWNSTREAM_SENDER_NUM_BUFFERS_VC0>, VC0_DOWNSTREAM_EDM_SIZE>
+    std::array<RouterToRouterSender<DOWNSTREAM_SENDER_NUM_BUFFERS_ARRAY[0]>, DOWNSTREAM_EDM_SIZE_PER_VC[0]>
         downstream_edm_noc_interfaces_vc0;
 
     // Ensure array size is at least 1 to avoid undefined behavior
-    static_assert(VC0_DOWNSTREAM_EDM_SIZE > 0, "VC0_DOWNSTREAM_EDM_SIZE must be at least 1");
+    static_assert(DOWNSTREAM_EDM_SIZE_PER_VC[0] > 0, "DOWNSTREAM_EDM_SIZE_PER_VC[0] must be at least 1");
 
-    populate_local_sender_channel_free_slots_stream_id_ordered_map(
-        has_downstream_edm_vc0_buffer_connection, local_sender_channel_free_slots_stream_ids);
+    populate_vc_sender_channel_free_slots_stream_ids<0>(local_sender_channel_free_slots_stream_ids_vc0);
+    populate_vc_sender_channel_free_slots_stream_ids<1>(local_sender_channel_free_slots_stream_ids_vc1);
 
     if (has_downstream_edm_vc0_buffer_connection) {
         // Only bit 0 is set for 1D
@@ -3124,7 +3171,7 @@ void kernel_main() {
                 auto receiver_channel_free_slots_stream_id = StreamId{vc_0_free_slots_stream_ids[0]};
 #endif
                 new (&downstream_edm_noc_interfaces_vc0[compact_index])
-                    RouterToRouterSender<DOWNSTREAM_SENDER_NUM_BUFFERS_VC0>(
+                    RouterToRouterSender<DOWNSTREAM_SENDER_NUM_BUFFERS_ARRAY[0]>(
                         // persistent_mode -> hardcode to false for 1D because for 1D, EDM -> EDM
                         // connections we must always use semaphore lookup
                         // For 2D, downstream_edm_vc0_semaphore_id is an address.
@@ -3136,7 +3183,7 @@ void kernel_main() {
 #else
                         downstream_edm_vc0_buffer_base_address,
 #endif
-                        DOWNSTREAM_SENDER_NUM_BUFFERS_VC0,
+                        DOWNSTREAM_SENDER_NUM_BUFFERS_ARRAY[0],
 #if defined(FABRIC_2D)
                         // connection handshake address on downstream edm
                         downstream_edm_vc0_worker_registration_ids[dense_index],
@@ -3190,11 +3237,11 @@ void kernel_main() {
         }
     }
 
-    std::array<RouterToRouterSender<DOWNSTREAM_SENDER_NUM_BUFFERS_VC1>, VC1_DOWNSTREAM_EDM_SIZE>
+    std::array<RouterToRouterSender<DOWNSTREAM_SENDER_NUM_BUFFERS_ARRAY[1]>, DOWNSTREAM_EDM_SIZE_PER_VC[1]>
         downstream_edm_noc_interfaces_vc1;
 #if defined(FABRIC_2D_VC1_ACTIVE)
     // Ensure array size is at least 1 to avoid undefined behavior
-    static_assert(VC1_DOWNSTREAM_EDM_SIZE > 0, "VC1_DOWNSTREAM_EDM_SIZE must be at least 1");
+    static_assert(DOWNSTREAM_EDM_SIZE_PER_VC[1] > 0, "DOWNSTREAM_EDM_SIZE_PER_VC[1] must be at least 1");
     if (has_downstream_edm_vc1_buffer_connection) {
         uint32_t has_downstream_edm = has_downstream_edm_vc1_buffer_connection & 0xF;  // 4-bit mask
         uint32_t compact_index = 0;
@@ -3202,18 +3249,18 @@ void kernel_main() {
         while (has_downstream_edm) {
             if (has_downstream_edm & 0x1) {
                 const auto teardown_sem_address =
-                    local_sem_for_teardown_from_downstream_edm[dense_index + NUM_DOWNSTREAM_SENDERS_VC0];
+                    local_sem_for_teardown_from_downstream_edm[dense_index + NUM_DOWNSTREAM_SENDERS_PER_VC[0]];
                 // reset the handshake addresses to 0 (this is for router -> router handshake for connections over
                 // noc)
                 *reinterpret_cast<volatile uint32_t* const>(teardown_sem_address) = 0;
                 auto receiver_channel_free_slots_stream_id = StreamId{vc_1_free_slots_stream_ids[compact_index]};
                 new (&downstream_edm_noc_interfaces_vc1[compact_index])
-                    RouterToRouterSender<DOWNSTREAM_SENDER_NUM_BUFFERS_VC1>(
+                    RouterToRouterSender<DOWNSTREAM_SENDER_NUM_BUFFERS_ARRAY[1]>(
                         is_persistent_fabric,
                         (downstream_edm_vc1_noc_x >> (dense_index * 8)) & 0xFF,
                         (downstream_edm_vc1_noc_y >> (dense_index * 8)) & 0xFF,
                         downstream_edm_vc1_buffer_base_addresses[dense_index],
-                        DOWNSTREAM_SENDER_NUM_BUFFERS_VC1,
+                        DOWNSTREAM_SENDER_NUM_BUFFERS_ARRAY[1],
                         downstream_edm_vc1_worker_registration_ids[dense_index],
                         downstream_edm_vc1_worker_location_info_addresses[dense_index],
                         channel_buffer_size,
@@ -3292,16 +3339,22 @@ void kernel_main() {
     remote_receiver_channels.init<eth_remote_channel_allocs>(channel_buffer_size, sizeof(PACKET_HEADER_TYPE));
 
     // initialize the local sender channel buffers
-    local_sender_channels.init<channel_allocs>(channel_buffer_size, sizeof(PACKET_HEADER_TYPE));
+    local_sender_channels_vc0.init<channel_allocs>(channel_buffer_size, sizeof(PACKET_HEADER_TYPE));
+#if defined(FABRIC_2D_VC1_SERVICED)
+    local_sender_channels_vc1.init<channel_allocs>(channel_buffer_size, sizeof(PACKET_HEADER_TYPE));
+#endif
 
-    // initialize the local sender channel worker interfaces
-    // Sender channel 0 is always for local worker in the new design
-    constexpr auto sender_channel = 0;
-    if constexpr (is_sender_channel_serviced[sender_channel]) {
+    // initialize the local sender channel worker interfaces per VC
+    if constexpr (is_vc_sender_channel_serviced<0, 0>()) {
+        auto info_addrs_vc0 = local_sender_connection_info_addresses_vc0;  // copy for mutability
+        auto info_addrs_vc1 = local_sender_connection_info_addresses_vc1;
         init_local_sender_channel_worker_interfaces(
-            local_sender_connection_live_semaphore_addresses,
-            local_sender_connection_info_addresses,
-            local_sender_channel_worker_interfaces);
+            local_sender_channel_connection_semaphore_addrs_vc0,
+            info_addrs_vc0,
+            local_sender_channel_connection_semaphore_addrs_vc1,
+            info_addrs_vc1,
+            local_sender_channel_worker_interfaces_vc0,
+            local_sender_channel_worker_interfaces_vc1);
     }
 
     WriteTransactionIdTracker<
@@ -3455,13 +3508,13 @@ void kernel_main() {
         }
     } else {
         // We can check just the first index because all receiver channels are serviced by the same core
-        if constexpr (is_receiver_channel_serviced[0]) {
+        if constexpr (is_vc_receiver_channel_serviced(0)) {
             if (has_downstream_edm_vc0_buffer_connection) {
                 downstream_edm_noc_interfaces_vc0[0]
                     .template open<false, use_posted_writes_for_connection_open, tt::tt_fabric::worker_handshake_noc>();
                 ASSERT(
                     get_ptr_val(downstream_edm_noc_interfaces_vc0[0].get_worker_credits_stream_id()) ==
-                    DOWNSTREAM_SENDER_NUM_BUFFERS_VC0);
+                    static_cast<int32_t>(DOWNSTREAM_SENDER_NUM_BUFFERS_ARRAY[0]));
             }
         }
     }
@@ -3472,7 +3525,7 @@ void kernel_main() {
 #if !defined(FABRIC_2D_VC1_ACTIVE)
     POSTCODE(tt::tt_fabric::EDMStatus::VCS_OPENED);
 #endif
-    if constexpr (is_receiver_channel_serviced[0] and NUM_ACTIVE_ERISCS > 1) {
+    if constexpr (is_vc_receiver_channel_serviced(0) and NUM_ACTIVE_ERISCS > 1) {
         // Two erisc mode requires us to reorder the cmd buf programming/state setting
         // because we need to reshuffle some of our cmd_buf/noc assignments around for
         // just the fabric bringup phase. These calls are also located earlier for the
@@ -3493,7 +3546,7 @@ void kernel_main() {
         }
     }
 #if defined(FABRIC_2D_VC1_ACTIVE)
-    if constexpr (is_receiver_channel_serviced[1] and NUM_ACTIVE_ERISCS > 1) {
+    if constexpr (is_vc_receiver_channel_serviced(1) and NUM_ACTIVE_ERISCS > 1) {
         // Two erisc mode requires us to reorder the cmd buf programming/state setting
         // because we need to reshuffle some of our cmd_buf/noc assignments around for
         // just the fabric bringup phase. These calls are also located earlier for the
@@ -3526,7 +3579,10 @@ void kernel_main() {
 
     WAYPOINT("FSCW");
     wait_for_static_connection_to_ready(
-        local_sender_channel_worker_interfaces, local_sender_channel_free_slots_stream_ids);
+        local_sender_channel_worker_interfaces_vc0,
+        local_sender_channel_worker_interfaces_vc1,
+        local_sender_channel_free_slots_stream_ids_vc0,
+        local_sender_channel_free_slots_stream_ids_vc1);
     WAYPOINT("FSCD");
 
     if constexpr (NUM_ACTIVE_ERISCS > 1) {
@@ -3549,13 +3605,14 @@ void kernel_main() {
     //////////////////////////////
     //////////////////////////////
     run_fabric_edm_main_loop<
-        NUM_RECEIVER_CHANNELS,
-        RouterToRouterSender<DOWNSTREAM_SENDER_NUM_BUFFERS_VC0>,
-        RouterToRouterSender<DOWNSTREAM_SENDER_NUM_BUFFERS_VC1>,
+        RouterToRouterSender<DOWNSTREAM_SENDER_NUM_BUFFERS_ARRAY[0]>,
+        RouterToRouterSender<DOWNSTREAM_SENDER_NUM_BUFFERS_ARRAY[1]>,
         RouterToRouterSender<LOCAL_RELAY_NUM_BUFFERS>>(
         local_receiver_channels,
-        local_sender_channels,
-        local_sender_channel_worker_interfaces,
+        local_sender_channels_vc0,
+        local_sender_channels_vc1,
+        local_sender_channel_worker_interfaces_vc0,
+        local_sender_channel_worker_interfaces_vc1,
         downstream_edm_noc_interfaces_vc0,
         downstream_edm_noc_interfaces_vc1,
         // pass in the relay adpator
@@ -3567,7 +3624,8 @@ void kernel_main() {
         receiver_channel_1_trid_tracker,
 #endif  // FABRIC_2D_VC1_ACTIVE
         port_direction_table,
-        local_sender_channel_free_slots_stream_ids);
+        local_sender_channel_free_slots_stream_ids_vc0,
+        local_sender_channel_free_slots_stream_ids_vc1);
     WAYPOINT("LPDN");
     // make sure all the noc transactions are acked before re-init the noc counters
     teardown(

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -325,9 +325,9 @@ static_assert(sender_channel_free_slots_stream_ids[6] == 28);
 static_assert(sender_channel_free_slots_stream_ids[7] == 29);
 
 // Per-VC sender channel free slots stream IDs
-static constexpr auto sender_channel_free_slots_stream_ids_vc0 =
+constexpr auto sender_channel_free_slots_stream_ids_vc0 =
     slice_sender_channels_for_vc<0>(sender_channel_free_slots_stream_ids);
-static constexpr auto sender_channel_free_slots_stream_ids_vc1 =
+constexpr auto sender_channel_free_slots_stream_ids_vc1 =
     slice_sender_channels_for_vc<1>(sender_channel_free_slots_stream_ids);
 template <size_t vc>
 constexpr auto& get_sender_channel_free_slots_stream_ids() {
@@ -1374,11 +1374,34 @@ FORCE_INLINE void establish_edm_connection(
     local_sender_channel_worker_interface.template cache_producer_noc_addr<ENABLE_RISC_CPU_DATA_CACHE, USE_DYNAMIC_CREDIT_ADDR>();
 }
 
+template <size_t vc>
+constexpr bool all_sender_num_buffers_entries_same() {
+    const auto& arr = get_sender_num_buffers<vc>();
+    if (arr.size() == 0) {
+        return true;
+    }
+    const auto first = arr[0];
+    for (size_t i = 1; i < std::size(arr); ++i) {
+        if (arr[i] != first) {
+            return false;
+        }
+    }
+    return true;
+}
+
 template <size_t vc, size_t N>
 bool any_vc_sender_channels_active(const std::array<uint32_t, N>& free_slots_stream_ids) {
-    for (size_t ch = 0; ch < N; ch++) {
-        if (get_ptr_val(free_slots_stream_ids[ch]) != static_cast<int32_t>(get_sender_num_buffers<vc>()[ch])) {
-            return true;
+    if constexpr (all_sender_num_buffers_entries_same<vc>()) {
+        for (size_t ch = 0; ch < N; ch++) {
+            if (get_ptr_val(free_slots_stream_ids[ch]) != static_cast<int32_t>(get_sender_num_buffers<vc>()[0])) {
+                return true;
+            }
+        }
+    } else {
+        for (size_t ch = 0; ch < N; ch++) {
+            if (get_ptr_val(free_slots_stream_ids[ch]) != static_cast<int32_t>(get_sender_num_buffers<vc>()[ch])) {
+                return true;
+            }
         }
     }
     return false;
@@ -2870,18 +2893,19 @@ void kernel_main() {
     //
 
     // Initialize stream register state for credit management across the Ethernet link.
-    // We make sure to do this before we handshake to guarantee that the registers are
-    // initialized before the other side has any possibility of modifying them.
-    init_ptr_val<to_receiver_packets_sent_streams[0]>(0);
-    init_ptr_val<to_sender_packets_acked_streams[0]>(0);
-    init_ptr_val<to_sender_packets_acked_streams[1]>(0);
-    init_ptr_val<to_sender_packets_completed_streams[0]>(0);
-    init_ptr_val<to_sender_packets_completed_streams[1]>(0);
-    // The first sender channel in the array is always for the transient/worker connection
-    // VC0 sender stream reg init
-    init_ptr_val<sender_channel_free_slots_stream_ids[0]>(SENDER_NUM_BUFFERS_ARRAY[0]);  // LOCAL WORKER
-    if constexpr (ACTUAL_SENDER_CHANNELS_PER_VC[0] > 1) {
-        init_ptr_val<sender_channel_free_slots_stream_ids[1]>(SENDER_NUM_BUFFERS_ARRAY[1]);
+    // Do this before handshaking to guarantee registers are set before the other side can modify them.
+    for (size_t i = 0; i < MAX_NUM_RECEIVER_CHANNELS; i++) {
+        init_ptr_val(to_receiver_packets_sent_streams[i], 0);
+    }
+    for (size_t i = 0; i < MAX_NUM_SENDER_CHANNELS; i++) {
+        init_ptr_val(to_sender_packets_acked_streams[i], 0);
+        init_ptr_val(to_sender_packets_completed_streams[i], 0);
+    }
+    for (size_t ch = 0; ch < ACTUAL_SENDER_CHANNELS_PER_VC[0]; ch++) {
+        init_ptr_val(get_sender_channel_free_slots_stream_ids<0>()[ch], get_sender_num_buffers<0>()[ch]);
+    }
+    for (size_t ch = 0; ch < ACTUAL_SENDER_CHANNELS_PER_VC[1]; ch++) {
+        init_ptr_val(get_sender_channel_free_slots_stream_ids<1>()[ch], get_sender_num_buffers<1>()[ch]);
     }
 
     // Init retrain sync reg
@@ -2892,29 +2916,6 @@ void kernel_main() {
 
     if constexpr (NUM_ACTIVE_ERISCS > 1) {
         wait_for_other_local_erisc();
-    }
-
-    if constexpr (is_2d_fabric) {
-        init_ptr_val<to_receiver_packets_sent_streams[1]>(0);
-        init_ptr_val<to_sender_packets_acked_streams[2]>(0);
-        init_ptr_val<to_sender_packets_acked_streams[3]>(0);
-
-        // Initialize completion streams for flat sender channels 2-7
-        [&]<size_t... Is>(std::index_sequence<Is...>) {
-            ((init_ptr_val<to_sender_packets_completed_streams[Is + 2]>(0)), ...);
-        }(std::make_index_sequence<6>{});
-
-        // Initialize sender channel free slots per VC (channels beyond 0,1 which are already init'd)
-        // VC0 channels 2+
-        [&]<size_t... Chs>(std::index_sequence<Chs...>) {
-            ((init_ptr_val<get_sender_channel_free_slots_stream_ids<0>()[Chs + 2]>(
-                 get_sender_num_buffers<0>()[Chs + 2])),
-             ...);
-        }(std::make_index_sequence<ACTUAL_SENDER_CHANNELS_PER_VC[0] >= 2 ? ACTUAL_SENDER_CHANNELS_PER_VC[0] - 2 : 0>{});
-        // VC1 all channels
-        [&]<size_t... Chs>(std::index_sequence<Chs...>) {
-            ((init_ptr_val<get_sender_channel_free_slots_stream_ids<1>()[Chs]>(get_sender_num_buffers<1>()[Chs])), ...);
-        }(std::make_index_sequence<ACTUAL_SENDER_CHANNELS_PER_VC[1]>{});
     }
 
 #if !defined(FABRIC_2D_VC1_ACTIVE)
@@ -3056,20 +3057,19 @@ void kernel_main() {
         }
     }
 
-    //  initialize the statically allocated "semaphores" per VC
-    auto init_vc_semaphores = [&]<size_t vc, size_t... Is>(std::index_sequence<Is...>) {
-        (([&]<size_t ch>() {
-             if constexpr (get_is_sender_channel_serviced<vc, ch>()) {
-                 *reinterpret_cast<volatile uint32_t*>(
-                     local_sender_channel_connection_semaphore_addrs_flat_[VC_SENDER_CHANNEL_START[vc] + ch]) = 0;
-                 *reinterpret_cast<volatile uint32_t*>(
-                     local_sender_channel_connection_buffer_index_ids_flat_[VC_SENDER_CHANNEL_START[vc] + ch]) = 0;
-             }
-         }.template operator()<Is>()),
-         ...);
-    };
-    init_vc_semaphores.template operator()<0>(std::make_index_sequence<ACTUAL_SENDER_CHANNELS_PER_VC[0]>{});
-    init_vc_semaphores.template operator()<1>(std::make_index_sequence<ACTUAL_SENDER_CHANNELS_PER_VC[1]>{});
+    // Initialize the statically allocated "semaphores" per VC
+    for (size_t ch = 0; ch < ACTUAL_SENDER_CHANNELS_PER_VC[0]; ch++) {
+        *reinterpret_cast<volatile uint32_t*>(
+            local_sender_channel_connection_semaphore_addrs_flat_[VC_SENDER_CHANNEL_START[0] + ch]) = 0;
+        *reinterpret_cast<volatile uint32_t*>(
+            local_sender_channel_connection_buffer_index_ids_flat_[VC_SENDER_CHANNEL_START[0] + ch]) = 0;
+    }
+    for (size_t ch = 0; ch < ACTUAL_SENDER_CHANNELS_PER_VC[1]; ch++) {
+        *reinterpret_cast<volatile uint32_t*>(
+            local_sender_channel_connection_semaphore_addrs_flat_[VC_SENDER_CHANNEL_START[1] + ch]) = 0;
+        *reinterpret_cast<volatile uint32_t*>(
+            local_sender_channel_connection_buffer_index_ids_flat_[VC_SENDER_CHANNEL_START[1] + ch]) = 0;
+    }
     asm volatile("nop");
 
 #if !defined(FABRIC_2D_VC1_ACTIVE)

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -331,6 +331,7 @@ static constexpr auto sender_channel_free_slots_stream_ids_vc1 =
     slice_sender_channels_for_vc<1>(sender_channel_free_slots_stream_ids);
 template <size_t vc>
 constexpr auto& get_sender_channel_free_slots_stream_ids() {
+    static_assert(vc <= 1, "At most 2 VCs currently supported");
     if constexpr (vc == 0) {
         return sender_channel_free_slots_stream_ids_vc0;
     } else {
@@ -2609,6 +2610,11 @@ void
     wait_for_vc_static_connections<1>(worker_interfaces_vc1, free_slots_vc1);
 }
 
+template <size_t vc, size_t ch>
+constexpr bool is_worker_sender_channel() {
+    return (vc == 0 && ch == 0);
+}
+
 // Returns the number of starting credits for the specified sender channel `i`
 // Generally, we will always start with `SENDER_NUM_BUFFERS` of credits,
 // except for channels which service transient/worker connections. Those
@@ -2617,12 +2623,14 @@ void
 // Initialize a single sender channel worker interface using per-VC arrays
 template <size_t vc, size_t ch, typename EdmChannelWorkerIFs, size_t N>
 FORCE_INLINE void init_sender_channel_worker_interface_vc(
-    std::array<size_t, N>& semaphore_addrs,
-    std::array<size_t, N>& info_addrs,
+    const std::array<size_t, N>& semaphore_addrs,
+    const std::array<size_t, N>& info_addrs,
     EdmChannelWorkerIFs& local_sender_channel_worker_interfaces) {
+    constexpr size_t WORKER_SENDER_CHANNEL_CREDIT_INIT = 0;
     // Channel 0 of VC0 is always the worker channel — init credits to 0 (counter-based)
     // All other channels get full credit init
-    constexpr size_t credits_init = (vc == 0 && ch == 0) ? 0 : get_sender_num_buffers<vc>()[ch];
+    constexpr size_t credits_init =
+        is_worker_sender_channel<vc, ch>() ? WORKER_SENDER_CHANNEL_CREDIT_INIT : get_sender_num_buffers<vc>()[ch];
     auto connection_live_semaphore_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t* const>(semaphore_addrs[ch]);
     auto connection_worker_info_ptr =
         reinterpret_cast<volatile tt::tt_fabric::EDMChannelWorkerLocationInfo*>(info_addrs[ch]);
@@ -2638,8 +2646,8 @@ FORCE_INLINE void init_sender_channel_worker_interface_vc(
 
 template <size_t vc, typename EdmChannelWorkerIFs, size_t N>
 void init_vc_sender_channel_worker_interfaces(
-    std::array<size_t, N>& semaphore_addrs,
-    std::array<size_t, N>& info_addrs,
+    const std::array<size_t, N>& semaphore_addrs,
+    const std::array<size_t, N>& info_addrs,
     EdmChannelWorkerIFs& local_sender_channel_worker_interfaces) {
     [&]<size_t... Chs>(std::index_sequence<Chs...>) {
         ((init_sender_channel_worker_interface_vc<vc, Chs>(
@@ -2654,10 +2662,10 @@ void
     __attribute__((noinline))
 #endif
     init_local_sender_channel_worker_interfaces(
-        std::array<size_t, N0>& semaphore_addrs_vc0,
-        std::array<size_t, N0>& info_addrs_vc0,
-        std::array<size_t, N1>& semaphore_addrs_vc1,
-        std::array<size_t, N1>& info_addrs_vc1,
+        const std::array<size_t, N0>& semaphore_addrs_vc0,
+        const std::array<size_t, N0>& info_addrs_vc0,
+        const std::array<size_t, N1>& semaphore_addrs_vc1,
+        const std::array<size_t, N1>& info_addrs_vc1,
         EdmChannelWorkerIFsVC0& worker_interfaces_vc0,
         EdmChannelWorkerIFsVC1& worker_interfaces_vc1) {
     init_vc_sender_channel_worker_interfaces<0>(semaphore_addrs_vc0, info_addrs_vc0, worker_interfaces_vc0);
@@ -3045,7 +3053,7 @@ void kernel_main() {
     //  initialize the statically allocated "semaphores" per VC
     auto init_vc_semaphores = [&]<size_t vc, size_t... Is>(std::index_sequence<Is...>) {
         (([&]<size_t ch>() {
-             if constexpr (get_is_sender_channel_serviced<vc>()[ch]) {
+             if constexpr (get_is_sender_channel_serviced<vc, ch>()) {
                  *reinterpret_cast<volatile uint32_t*>(
                      local_sender_channel_connection_semaphore_addrs_flat_[VC_SENDER_CHANNEL_START[vc] + ch]) = 0;
                  *reinterpret_cast<volatile uint32_t*>(
@@ -3346,13 +3354,13 @@ void kernel_main() {
 
     // initialize the local sender channel worker interfaces per VC
     if constexpr (is_vc_sender_channel_serviced<0, 0>()) {
-        auto info_addrs_vc0 = local_sender_connection_info_addresses_vc0;  // copy for mutability
-        auto info_addrs_vc1 = local_sender_connection_info_addresses_vc1;
+        // auto info_addrs_vc0 = local_sender_connection_info_addresses_vc0;  // copy for mutability
+        // auto info_addrs_vc1 = local_sender_connection_info_addresses_vc1;
         init_local_sender_channel_worker_interfaces(
             local_sender_channel_connection_semaphore_addrs_vc0,
-            info_addrs_vc0,
+            local_sender_connection_info_addresses_vc0,
             local_sender_channel_connection_semaphore_addrs_vc1,
-            info_addrs_vc1,
+            local_sender_connection_info_addresses_vc1,
             local_sender_channel_worker_interfaces_vc0,
             local_sender_channel_worker_interfaces_vc1);
     }

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -2189,7 +2189,8 @@ FORCE_INLINE void run_fabric_edm_main_loop(
 
 #if defined(FABRIC_2D_VC1_ACTIVE)
     // VC1 receiver channel pointer for inter-mesh routing
-    auto outbound_to_receiver_channel_pointer_ch1 = outbound_to_receiver_channel_pointers.template get<1>();
+    [[maybe_unused]] auto outbound_to_receiver_channel_pointer_ch1 =
+        outbound_to_receiver_channel_pointers.template get<1>();
 
     auto receiver_channel_pointers_ch1 = receiver_channel_pointers.template get<1>();
     receiver_channel_pointers_ch1.reset();
@@ -2202,7 +2203,8 @@ FORCE_INLINE void run_fabric_edm_main_loop(
     // Per-VC sender runtime state
     auto channel_connection_established_vc0 = initialize_array<ACTUAL_SENDER_CHANNELS_PER_VC[0], bool, false>();
 #if defined(FABRIC_2D_VC1_ACTIVE)
-    auto channel_connection_established_vc1 = initialize_array<ACTUAL_SENDER_CHANNELS_PER_VC[1], bool, false>();
+    [[maybe_unused]] auto channel_connection_established_vc1 =
+        initialize_array<ACTUAL_SENDER_CHANNELS_PER_VC[1], bool, false>();
 #else
     [[maybe_unused]] auto channel_connection_established_vc1 = initialize_array<0, bool, false>();
 #endif
@@ -2216,7 +2218,7 @@ FORCE_INLINE void run_fabric_edm_main_loop(
     auto sender_channel_from_receiver_credits_vc0 =
         init_sender_channel_from_receiver_credits_flow_controllers<ACTUAL_SENDER_CHANNELS_PER_VC[0]>();
 #if defined(FABRIC_2D_VC1_ACTIVE)
-    auto sender_channel_from_receiver_credits_vc1 =
+    [[maybe_unused]] auto sender_channel_from_receiver_credits_vc1 =
         init_sender_channel_from_receiver_credits_flow_controllers<ACTUAL_SENDER_CHANNELS_PER_VC[1]>();
 #else
     [[maybe_unused]] auto sender_channel_from_receiver_credits_vc1 =
@@ -2607,7 +2609,9 @@ void
         std::array<uint32_t, N0>& free_slots_vc0,
         std::array<uint32_t, N1>& free_slots_vc1) {
     wait_for_vc_static_connections<0>(worker_interfaces_vc0, free_slots_vc0);
+#if defined(FABRIC_2D_VC1_SERVICED)
     wait_for_vc_static_connections<1>(worker_interfaces_vc1, free_slots_vc1);
+#endif
 }
 
 template <size_t vc, size_t ch>
@@ -2669,7 +2673,9 @@ void
         EdmChannelWorkerIFsVC0& worker_interfaces_vc0,
         EdmChannelWorkerIFsVC1& worker_interfaces_vc1) {
     init_vc_sender_channel_worker_interfaces<0>(semaphore_addrs_vc0, info_addrs_vc0, worker_interfaces_vc0);
+#if defined(FABRIC_2D_VC1_SERVICED)
     init_vc_sender_channel_worker_interfaces<1>(semaphore_addrs_vc1, info_addrs_vc1, worker_interfaces_vc1);
+#endif
 }
 
 // Copy the sender_channel_free_slots_stream_ids to per-VC local arrays

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -710,6 +710,27 @@ FORCE_INLINE __attribute__((optimize("jump-tables"))) bool can_forward_packet_co
     using eth_chan_directions::SOUTH;
     using eth_chan_directions::WEST;
 
+#ifdef ARCH_WORMHOLE
+    bool ret_val = true;
+    if (hop_cmd & MeshRoutingFields::FORWARD_EAST) {
+        ret_val&& = downstreams_have_space<DownstreamSenderT, LocalRelayInterfaceT, DOWNSTREAM_EDM_SIZE, EAST>(
+            downstream_edm_interfaces, local_relay_interface);
+    }
+    if (hop_cmd & MeshRoutingFields::FORWARD_WEST) {
+        ret_val&& = downstreams_have_space<DownstreamSenderT, LocalRelayInterfaceT, DOWNSTREAM_EDM_SIZE, WEST>(
+            downstream_edm_interfaces, local_relay_interface);
+    }
+    if (hop_cmd & MeshRoutingFields::FORWARD_SOUTH) {
+        ret_val&& = downstreams_have_space<DownstreamSenderT, LocalRelayInterfaceT, DOWNSTREAM_EDM_SIZE, SOUTH>(
+            downstream_edm_interfaces, local_relay_interface);
+    }
+    if (hop_cmd & MeshRoutingFields::FORWARD_NORTH) {
+        ret_val&& = downstreams_have_space<DownstreamSenderT, LocalRelayInterfaceT, DOWNSTREAM_EDM_SIZE, NORTH>(
+            downstream_edm_interfaces, local_relay_interface);
+    }
+    return ret_val;
+#else
+
     switch (hop_cmd) {
         case MeshRoutingFields::NOOP:
             if constexpr (z_router_enabled) {
@@ -819,6 +840,7 @@ FORCE_INLINE __attribute__((optimize("jump-tables"))) bool can_forward_packet_co
         default: __builtin_unreachable();
     }
     return ret_val;
+#endif
 }
 
 #else


### PR DESCRIPTION

Emit per-VC receiver channel pool data and remove flat receiver indexing assumption. This change simplifies future work where we introduce additional VCs and with each VC being a potentially different sizes. Additionally, this simplifies the implementation and design in a few areas:
- general code in host and router code (always index by {vc, relative index})
- enable/disable logic for "fast VC" implementations
- future support for fabric "plugin" implementations
- it also enables "gaps" in VCs (e.g. VC0 + VC2), although this is not an important use case yet


### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=snijjar/remove-flat-receiver-indexing)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:snijjar/remove-flat-receiver-indexing)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snijjar/remove-flat-receiver-indexing)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snijjar/remove-flat-receiver-indexing) - same failure [on main](https://github.com/tenstorrent/tt-metal/actions/runs/22912504378)
- [ ] [![Fabric Tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tm-fabric-tests.yaml/badge.svg?branch=snijjar/remove-flat-receiver-indexing)](https://github.com/tenstorrent/tt-metal/actions/workflows/tm-fabric-tests.yaml?query=branch:snijjar/remove-flat-receiver-indexing)
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early

