### PR TITLE
Fix output head dim rounding for non tile aligned heads + batch assignment issue in SDPA decode

### DIFF
--- a/tests/ttnn/unit_tests/operations/sdpa/sdpa_test_utils.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/sdpa_test_utils.py
@@ -510,7 +510,7 @@ def run_test_sdpa_decode_single_iter(
     tt_back_shape = list(tt_back.shape)
     assert tt_back_shape[2] == nh, (
         f"SDPA decode output logical head dim should be {nh} (unpadded), got {tt_back_shape[2]}. "
-        f"TILE layout should not round up the logical shape."
+        f"SDPA decode should preserve the logical head dimension regardless of tensor layout."
     )
 
     tt_back = ttnn.to_torch(tt_back)

--- a/tests/ttnn/unit_tests/operations/sdpa/sdpa_test_utils.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/sdpa_test_utils.py
@@ -507,6 +507,12 @@ def run_test_sdpa_decode_single_iter(
             memory_config=height_sharded_memcfg if sharded_out else dram_memcfg,
         )
 
+    tt_back_shape = list(tt_back.shape)
+    assert tt_back_shape[2] == nh, (
+        f"SDPA decode output logical head dim should be {nh} (unpadded), got {tt_back_shape[2]}. "
+        f"TILE layout should not round up the logical shape."
+    )
+
     tt_back = ttnn.to_torch(tt_back)
     tt_back = tt_back[:, :, :nh, :]
 

--- a/tests/ttnn/unit_tests/operations/sdpa/test_sdpa_decode.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_sdpa_decode.py
@@ -73,6 +73,37 @@ def test_sdpa_decode(device, b, nh, nkv, s, d, dtype, grid_size, q_dtype, single
     ],
 )
 @pytest.mark.parametrize(
+    "b, nh, nkv, s, d, grid_size, single_iter, cur_pos_tensor",
+    ([1, 20, 20, 1024, 64, (8, 4), True, True],),  # Whisper-large (nh not multiple of 32)
+)
+@pytest.mark.timeout(120)
+def test_sdpa_decode_non_tile_aligned_heads(
+    device, b, nh, nkv, s, d, dtype, grid_size, q_dtype, single_iter, cur_pos_tensor
+):
+    """Regression test for models with num_heads not a multiple of 32 (e.g. Whisper-large with 20 heads).
+
+    The output logical shape must preserve the unpadded head count so that downstream
+    ops like nlp_concat_heads produce the correct hidden dimension.
+    """
+    if nkv > 1 and q_dtype != ttnn.bfloat16:
+        pytest.skip("nkv > 1 requires q_dtype to be bfloat16")
+
+    run_test_sdpa_decode_single_iter(
+        device, b, nh, nkv, s, d, dtype, grid_size, q_dtype, cur_pos_tensor, sharded_in=False, sharded_out=False
+    )
+
+
+@skip_with_llk_assert("Hits LLK assert check for L1 memory access.")
+@pytest.mark.parametrize(
+    "dtype, q_dtype",
+    [
+        [ttnn.bfloat8_b, ttnn.bfloat16],
+    ],
+    ids=[
+        "kv_bfp8",
+    ],
+)
+@pytest.mark.parametrize(
     "b, nh, nkv, s, d, grid_size",
     ([1, 64, 8, 2048, 128, (8, 8)],),  # num q heads greater than 32
 )

--- a/tests/ttnn/unit_tests/operations/sdpa/test_sdpa_decode.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_sdpa_decode.py
@@ -73,13 +73,11 @@ def test_sdpa_decode(device, b, nh, nkv, s, d, dtype, grid_size, q_dtype, single
     ],
 )
 @pytest.mark.parametrize(
-    "b, nh, nkv, s, d, grid_size, single_iter, cur_pos_tensor",
-    ([1, 20, 20, 1024, 64, (8, 4), True, True],),  # Whisper-large (nh not multiple of 32)
+    "b, nh, nkv, s, d, grid_size, cur_pos_tensor",
+    ([1, 20, 20, 1024, 64, (8, 4), True],),  # Whisper-large (nh not multiple of 32)
 )
 @pytest.mark.timeout(120)
-def test_sdpa_decode_non_tile_aligned_heads(
-    device, b, nh, nkv, s, d, dtype, grid_size, q_dtype, single_iter, cur_pos_tensor
-):
+def test_sdpa_decode_non_tile_aligned_heads(device, b, nh, nkv, s, d, dtype, grid_size, q_dtype, cur_pos_tensor):
     """Regression test for models with num_heads not a multiple of 32 (e.g. Whisper-large with 20 heads).
 
     The output logical shape must preserve the unpadded head count so that downstream

--- a/tests/ttnn/unit_tests/operations/sdpa/test_sdpa_decode.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_sdpa_decode.py
@@ -74,7 +74,7 @@ def test_sdpa_decode(device, b, nh, nkv, s, d, dtype, grid_size, q_dtype, single
 )
 @pytest.mark.parametrize(
     "b, nh, nkv, s, d, grid_size, cur_pos_tensor",
-    ([1, 20, 20, 1024, 64, (8, 4), True],),  # Whisper-large (nh not multiple of 32)
+    ([2, 20, 20, 512, 64, (8, 8), True],),  # Whisper-large (nh not multiple of 32; grid must give num_cores/b <= nkv)
 )
 @pytest.mark.timeout(120)
 def test_sdpa_decode_non_tile_aligned_heads(device, b, nh, nkv, s, d, dtype, grid_size, q_dtype, cur_pos_tensor):

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.cpp
@@ -387,7 +387,11 @@ TensorSpec SdpaDecodeDeviceOperation::compute_output_specs(
     ttnn::Shape output_shape = input.logical_shape();
     output_shape[1] = B;
     output_shape[2] = num_q_heads;
-    output_shape[3] = use_mla ? operation_attributes.head_dim_v.value() : q_shape[3];
+
+    // Preserve logical head_dim by default; only override in MLA mode.
+    if (use_mla) {
+        output_shape[3] = operation_attributes.head_dim_v.value();
+    }
     return TensorSpec(
         output_shape, TensorLayout(input.dtype(), PageConfig(output_layout), operation_attributes.output_mem_config));
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.cpp
@@ -372,33 +372,22 @@ TensorSpec SdpaDecodeDeviceOperation::compute_output_specs(
     }
     bool q_locally_available = false;
     uint32_t num_q_heads = q_shape_unpadded[2];
-
     if (input.is_sharded() && use_mla && operation_attributes.program_config.has_value()) {
         const uint32_t q_shard_height = input.memory_config().shard_spec()->shape[0];
         const uint32_t max_cores = operation_attributes.program_config->max_cores_per_head_batch;
         const uint32_t num_q_shards = input.memory_config().shard_spec()->grid.num_cores();
         const uint32_t num_groups = num_q_shards / max_cores;
         const uint32_t q_heads_parallel_factor = num_groups / B;
-
         q_locally_available = (q_shape[2] == B * q_shard_height * q_heads_parallel_factor * max_cores);
         if (q_locally_available) {
             num_q_heads = q_heads_parallel_factor * q_shard_height;
         }
     }
-
-    Layout output_layout = Layout::TILE;
+    Layout output_layout = input.layout() == Layout::ROW_MAJOR ? Layout::ROW_MAJOR : Layout::TILE;
     ttnn::Shape output_shape = input.logical_shape();
-    if (input.layout() == Layout::ROW_MAJOR) {
-        output_shape[2] = tt::round_up(num_q_heads, tt::constants::TILE_HEIGHT);
-        output_layout = Layout::ROW_MAJOR;
-    } else {
-        output_shape[1] = B;
-        output_shape[2] = tt::round_up(num_q_heads, tt::constants::TILE_HEIGHT);
-        output_layout = Layout::TILE;
-    }
-    if (use_mla) {
-        output_shape[3] = operation_attributes.head_dim_v.value();
-    }
+    output_shape[1] = B;
+    output_shape[2] = num_q_heads;
+    output_shape[3] = use_mla ? operation_attributes.head_dim_v.value() : q_shape[3];
     return TensorSpec(
         output_shape, TensorLayout(input.dtype(), PageConfig(output_layout), operation_attributes.output_mem_config));
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
@@ -163,9 +163,11 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
     const uint32_t max_cores_per_head =
         program_config.has_value() ? program_config->max_cores_per_head_batch : num_cores_available;
     const uint32_t max_num_cores_for_compute = max_cores_per_head * B * num_kv_heads;
-    const uint32_t num_cores_per_batch = std::min(num_cores_available, max_num_cores_for_compute) / B;
-    const uint32_t num_cores_per_head = std::max(1u, num_cores_per_batch / num_kv_heads);
-    const uint32_t num_heads_per_core = std::max(1u, (uint32_t)std::ceil((float)num_kv_heads / num_cores_per_batch));
+    const uint32_t num_cores_per_batch_uncapped = std::min(num_cores_available, max_num_cores_for_compute) / B;
+    const uint32_t num_cores_per_head = std::max(1u, num_cores_per_batch_uncapped / num_kv_heads);
+    const uint32_t num_heads_per_core =
+        std::max(1u, (uint32_t)std::ceil((float)num_kv_heads / num_cores_per_batch_uncapped));
+    const uint32_t num_cores_per_batch = num_cores_per_head * num_kv_heads / num_heads_per_core;
     const uint32_t num_reducer_cores = num_kv_heads * B / num_heads_per_core;
     const uint32_t num_output_cores = B;
     const uint32_t num_active_cores = num_cores_per_head * num_kv_heads * B / num_heads_per_core;


### PR DESCRIPTION
### Ticket
NA

### Problem description
In this [PR](https://github.com/tenstorrent/tt-metal/pull/36440), we unexpectedly round the number of q heads to tile sizes when layout is TILED, causing this failure on single card demo CI
```
E               The width of the first tensor must be equal to the height of the second tensor. Mismatch: width=2048 height=1280
```

Before: logical output shape [1, B, 20, 64] → after nlp_concat_heads → [B, 1, 1, 1280] (20×64) — matches out_proj.weight height of 1280
After: logical output shape [1, B, 32, 64] → after nlp_concat_heads → [B, 1, 1, 2048] (32×64) — mismatch with out_proj.weight height of 1280

There was also another issue when the KV heads parallel factor is less than the number of core per batch
for example in whisper for a grid size of (8,8) and kv head size of 20 we would assign `num_cores_per_batch = std::min(num_cores_available, max_num_cores_for_compute) / B;` which is `num_cores_per_batch = min(64, 64*2*20) / 2 = 32` and because we do batch assignment like so:
```
            cur_head = (i % num_cores_per_batch) / num_cores_per_head;
            cur_batch = i / num_cores_per_batch;
```
this will make the batch boundary at i=32 not align with the actual number of heads, the fix is to recompute num cores per batch based on the number of kv heads and num heads per core

### What's changed
- removed rounding on Q heads for both row major and tile layout, we should not be rounding to tile sizes since there are lots of models with q head dim not multiples of tile sizes
- added a regression test for non tile aligned q heads

### Checklist
- [x] [APC](https://github.com/tenstorrent/tt-metal/actions/runs/22907979278)
- [x] [Single card demo](https://github.com/tenstorrent/tt-metal/actions/runs/22915961446)
- [x] [Nightly L2 ](https://github.com/tenstorrent/tt-metal/actions/runs/22908195891)