### PR TITLE
Add deferred normalization to ring SDPA

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -259,6 +259,7 @@ tests/ttnn/unit_tests/operations/sdpa/ @tenstorrent/metallium-maintainers-llama-
 tests/ttnn/nightly/unit_tests/operations/sdpa/ @tenstorrent/metallium-maintainers-llama-models @tenstorrent/codeowner-bypass
 tests/ttnn/nightly/unit_tests/operations/eltwise/ @tenstorrent/metalium-developers-eltwise @tenstorrent/codeowner-bypass
 tests/nightly/t3000/ @tenstorrent/codeowner-bypass @tenstorrent/metalium-developers-ops-data-movement
+tests/nightly/t3000/ccl/test_ring_joint_attention.py @tenstorrent/metallium-maintainers-llama-models @tenstorrent/codeowner-bypass
 tests/nightly/tg/ @tenstorrent/codeowner-bypass @tenstorrent/metalium-developers-ops-data-movement
 tests/sweep_framework/sweeps @tenstorrent/codeowner-bypass @stevendae @cmaryanTT @ntarafdar @bbradelTT
 tests/sweep_framework/sweeps/eltwise/ @tenstorrent/metalium-developers-eltwise @tenstorrent/codeowner-bypass

--- a/models/tt_dit/tests/unit/test_ring_joint_attention.py
+++ b/models/tt_dit/tests/unit/test_ring_joint_attention.py
@@ -2,6 +2,8 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import math
+
 import pytest
 import torch
 import torch.nn.functional as F
@@ -59,6 +61,249 @@ def create_ring_joint_sdpa_submesh(mesh_device, rp_axis, rp_factor, up_axis, up_
     submesh_shape[up_axis] = up_factor
     submesh_device = mesh_device.create_submesh(ttnn.MeshShape(submesh_shape[0], submesh_shape[1]))
     return submesh_device
+
+
+def run_ring_joint_sdpa_model_config(
+    mesh_device,
+    *,
+    b,
+    nh,
+    base_seq_len,
+    joint_seq_len,
+    d,
+    q_chunk_size,
+    k_chunk_size,
+    rp_axis,
+    rp_factor,
+    up_axis,
+    up_factor,
+    num_links,
+    ccl_reserve_last_column,
+    use_column_major_ccl,
+    use_wormhole_compute_kernel_config,
+    pcc_threshold=0.999,
+):
+    """
+    Run ring_joint_scaled_dot_product_attention matching all model-specific
+    details: grid layout, CCL placement, compute kernel config, dtype, etc.
+    """
+    # Pad heads to be divisible by up_factor (tensor-parallel factor)
+    if nh % up_factor != 0:
+        nh = math.ceil(nh / up_factor) * up_factor
+
+    submesh = create_ring_joint_sdpa_submesh(mesh_device, rp_axis, rp_factor, up_axis, up_factor)
+    padded_seq_len = get_padded_vision_seq_len(base_seq_len, rp_factor)
+
+    full_grid = submesh.compute_with_storage_grid_size()
+
+    # --- Grid layout: match model's CCL core placement exactly ---
+    if ccl_reserve_last_column:
+        # Wan: reserve last column for CCL
+        sdpa_compute_grid = (full_grid.x - 1, full_grid.y)
+        ccl_core_grid_offset = (full_grid.x - 1, 0)
+    else:
+        # SD3.5 / Mochi: reserve last row for CCL
+        sdpa_compute_grid = (full_grid.x, full_grid.y - 1)
+        ccl_core_grid_offset = (0, full_grid.y - 1)
+
+    # --- Sub-device setup ---
+    ccl_sub_device_crs = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(full_grid.x - 1, full_grid.y - 1))}
+    )
+    worker_sub_device = ttnn.SubDevice([ccl_sub_device_crs])
+    worker_sub_device_id = ttnn.SubDeviceId(0)
+    sub_device_stall_group = [worker_sub_device_id]
+
+    sub_device_manager = submesh.create_sub_device_manager([worker_sub_device], 0)
+    submesh.load_sub_device_manager(sub_device_manager)
+    submesh.set_sub_device_stall_group(sub_device_stall_group)
+
+    # --- Global semaphores ---
+    ccl_semaphore_handles = [ttnn.create_global_semaphore(submesh, ccl_sub_device_crs, 0) for _ in range(2)]
+
+    # --- Persistent output buffers for all-gather K/V ---
+    kv_shard_dims = [None, None]
+    kv_shard_dims[up_axis] = 1  # Sharded on heads (dim 1)
+
+    ag_output_shape = (b, nh, padded_seq_len, d)
+    persistent_output_buffers = [
+        ttnn.from_torch(
+            torch.zeros(ag_output_shape),
+            device=submesh,
+            layout=ttnn.TILE_LAYOUT,
+            dtype=ttnn.bfloat16,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ShardTensor2dMesh(submesh, mesh_shape=tuple(submesh.shape), dims=kv_shard_dims),
+        )
+        for _ in range(2)  # K, V
+    ]
+
+    # --- Program config: exact grid from model ---
+    program_config = ttnn.SDPAProgramConfig(
+        compute_with_storage_grid_size=sdpa_compute_grid,
+        q_chunk_size=q_chunk_size,
+        k_chunk_size=k_chunk_size,
+        exp_approx_mode=False,
+    )
+
+    # --- Compute kernel config: match model exactly ---
+    if use_wormhole_compute_kernel_config:
+        # SD3.5 uses WormholeComputeKernelConfig directly
+        compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.HiFi2,
+            math_approx_mode=False,
+            fp32_dest_acc_en=False,
+        )
+    else:
+        # Wan / Mochi use init_device_compute_kernel_config
+        compute_kernel_config = ttnn.init_device_compute_kernel_config(
+            submesh.arch(),
+            math_fidelity=ttnn.MathFidelity.HiFi2,
+            math_approx_mode=False,
+            fp32_dest_acc_en=False,
+            packer_l1_acc=False,
+        )
+
+    # --- Create input tensors ---
+    Q = fa_rand(b, nh, base_seq_len, d)
+    K = fa_rand(b, nh, base_seq_len, d)
+    V = fa_rand(b, nh, base_seq_len, d)
+
+    padded_Q = torch.cat([Q, torch.zeros(b, nh, padded_seq_len - base_seq_len, d)], dim=2)
+    padded_K = torch.cat([K, torch.zeros(b, nh, padded_seq_len - base_seq_len, d)], dim=2)
+    padded_V = torch.cat([V, torch.zeros(b, nh, padded_seq_len - base_seq_len, d)], dim=2)
+
+    joint_Q = fa_rand(b, nh, joint_seq_len, d)
+    joint_K = fa_rand(b, nh, joint_seq_len, d)
+    joint_V = fa_rand(b, nh, joint_seq_len, d)
+
+    logger.debug(f"Q: {Q.shape}, padded_Q: {padded_Q.shape}, joint_Q: {joint_Q.shape}")
+
+    # Shard dims: RP on sequence (dim 2), UP on heads (dim 1)
+    sdpa_input_shard_dims = [None, None]
+    sdpa_input_shard_dims[rp_axis] = 2
+    sdpa_input_shard_dims[up_axis] = 1
+
+    # Joint only sharded on heads (replicated across RP axis)
+    sdpa_joint_shard_dims = [None, None]
+    sdpa_joint_shard_dims[up_axis] = 1
+
+    dtype = ttnn.bfloat16
+
+    tt_Q = ttnn.from_torch(
+        padded_Q,
+        dtype=dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=submesh,
+        mesh_mapper=ttnn.ShardTensor2dMesh(submesh, mesh_shape=tuple(submesh.shape), dims=sdpa_input_shard_dims),
+    )
+    tt_K = ttnn.from_torch(
+        padded_K,
+        dtype=dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=submesh,
+        mesh_mapper=ttnn.ShardTensor2dMesh(submesh, mesh_shape=tuple(submesh.shape), dims=sdpa_input_shard_dims),
+    )
+    tt_V = ttnn.from_torch(
+        padded_V,
+        dtype=dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=submesh,
+        mesh_mapper=ttnn.ShardTensor2dMesh(submesh, mesh_shape=tuple(submesh.shape), dims=sdpa_input_shard_dims),
+    )
+    tt_joint_Q = ttnn.from_torch(
+        joint_Q,
+        dtype=dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=submesh,
+        mesh_mapper=ttnn.ShardTensor2dMesh(submesh, mesh_shape=tuple(submesh.shape), dims=sdpa_joint_shard_dims),
+    )
+    tt_joint_K = ttnn.from_torch(
+        joint_K,
+        dtype=dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=submesh,
+        mesh_mapper=ttnn.ShardTensor2dMesh(submesh, mesh_shape=tuple(submesh.shape), dims=sdpa_joint_shard_dims),
+    )
+    tt_joint_V = ttnn.from_torch(
+        joint_V,
+        dtype=dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=submesh,
+        mesh_mapper=ttnn.ShardTensor2dMesh(submesh, mesh_shape=tuple(submesh.shape), dims=sdpa_joint_shard_dims),
+    )
+
+    logger.debug(f"tt_Q: {tt_Q.shape}, tt_joint_Q: {tt_joint_Q.shape}")
+    logger.debug(f"sdpa_compute_grid: {sdpa_compute_grid}, ccl_core_grid_offset: {ccl_core_grid_offset}")
+    logger.debug(f"use_column_major_ccl: {use_column_major_ccl}")
+
+    # --- Run the op ---
+    sdpa_kwargs = dict(
+        persistent_output_buffer_k=persistent_output_buffers[0],
+        persistent_output_buffer_v=persistent_output_buffers[1],
+        joint_strategy="rear",
+        logical_n=base_seq_len,
+        program_config=program_config,
+        compute_kernel_config=compute_kernel_config,
+        dim=2,
+        multi_device_global_semaphore=ccl_semaphore_handles,
+        num_links=num_links,
+        cluster_axis=rp_axis,
+        mesh_device=submesh,
+        topology=ttnn.Topology.Linear,
+        subdevice_id=worker_sub_device_id,
+        ccl_core_grid_offset=ccl_core_grid_offset,
+    )
+    if use_column_major_ccl:
+        sdpa_kwargs["use_column_major_ccl"] = True
+
+    tt_out, tt_joint_out, _ = ttnn.transformer.ring_joint_scaled_dot_product_attention(
+        tt_Q,
+        tt_K,
+        tt_V,
+        tt_joint_Q,
+        tt_joint_K,
+        tt_joint_V,
+        **sdpa_kwargs,
+    )
+
+    # --- Verify correctness ---
+    pt_Q = torch.cat([Q, joint_Q], dim=2)
+    pt_K = torch.cat([K, joint_K], dim=2)
+    pt_V = torch.cat([V, joint_V], dim=2)
+    gt = torch.nn.functional.scaled_dot_product_attention(pt_Q, pt_K, pt_V, is_causal=False)
+    gt_out = gt[:, :, :base_seq_len, :]
+    gt_joint_out = gt[:, :, base_seq_len:, :]
+
+    tt_out = ttnn.to_torch(
+        tt_out,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(submesh, mesh_shape=tuple(submesh.shape), dims=sdpa_input_shard_dims),
+    )
+    tt_out = tt_out[:, :, :base_seq_len, :]
+
+    passing = True
+    out_pass, out_pcc = comp_pcc(tt_out, gt_out, pcc_threshold)
+    mse = ((gt_out - tt_out) ** 2).mean()
+    logger.info(f"spatial PCC: {out_pcc}, MSE: {mse}")
+    passing = passing and out_pass
+
+    if joint_seq_len > 0:
+        joint_shard_dims = [None, None]
+        joint_shard_dims[up_axis] = 1
+        joint_shard_dims[rp_axis] = 0  # Concat replicas into batch
+        tt_joint_out = ttnn.to_torch(
+            tt_joint_out,
+            mesh_composer=ttnn.ConcatMesh2dToTensor(submesh, mesh_shape=tuple(submesh.shape), dims=joint_shard_dims),
+        )
+        tt_joint_out = tt_joint_out[:, :, :joint_seq_len, :]
+        for replica_id in range(tt_joint_out.shape[0]):
+            replica_out = tt_joint_out[replica_id, :, :, :]
+            jout_pass, jout_pcc = comp_pcc(replica_out, gt_joint_out, pcc_threshold)
+            jmse = ((gt_joint_out - replica_out) ** 2).mean()
+            logger.info(f"joint replica {replica_id} PCC: {jout_pcc}, MSE: {jmse}")
+            passing = passing and jout_pass
+
+    assert passing
 
 
 def run_ring_joint_sdpa(

--- a/tests/nightly/t3000/ccl/test_ring_joint_attention.py
+++ b/tests/nightly/t3000/ccl/test_ring_joint_attention.py
@@ -9,6 +9,7 @@ from loguru import logger
 import pytest
 from models.tt_dit.tests.unit.test_ring_joint_attention import (
     run_ring_joint_sdpa,
+    run_ring_joint_sdpa_model_config,
     run_test_ring_joint_sdpa,
     create_ring_joint_sdpa_submesh,
     wh_t3k_unit_test_params,
@@ -288,3 +289,94 @@ def test_ring_joint_sdpa_program_cache(
         )
 
     assert submesh.num_program_cache_entries() == 1
+
+
+# ===========================================================================
+# Model-config regression tests — reproduce code-size failures with exact
+# model shapes, chunk sizes, grid layouts, and default device_params.
+# ===========================================================================
+
+
+@pytest.mark.parametrize("mesh_device", [(2, 4)], ids=["2x4"], indirect=True)
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}],
+    indirect=True,
+)
+def test_ring_joint_sdpa_sd35_model_config(mesh_device, reset_seeds):
+    """SD3.5: heads=38, d=64, seq=4096, joint=333, sp4×tp2, chunks=(256,512)."""
+    run_ring_joint_sdpa_model_config(
+        mesh_device,
+        b=1,
+        nh=38,
+        base_seq_len=4096,
+        joint_seq_len=333,
+        d=64,
+        q_chunk_size=256,
+        k_chunk_size=512,
+        rp_axis=1,
+        rp_factor=4,
+        up_axis=0,
+        up_factor=2,
+        num_links=1,
+        ccl_reserve_last_column=False,
+        use_column_major_ccl=False,
+        use_wormhole_compute_kernel_config=True,
+    )
+
+
+@pytest.mark.parametrize("mesh_device", [(2, 4)], ids=["2x4"], indirect=True)
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}],
+    indirect=True,
+)
+def test_ring_joint_sdpa_wan_14b_720p_model_config(mesh_device, reset_seeds):
+    """Wan2.2 14B-720p: heads=40, d=128, seq=75600, joint=0, sp2×tp4, chunks=(256,256)."""
+    run_ring_joint_sdpa_model_config(
+        mesh_device,
+        b=1,
+        nh=40,
+        base_seq_len=75600,
+        joint_seq_len=0,
+        d=128,
+        q_chunk_size=256,
+        k_chunk_size=256,
+        rp_axis=0,
+        rp_factor=2,
+        up_axis=1,
+        up_factor=4,
+        num_links=1,
+        ccl_reserve_last_column=True,
+        use_column_major_ccl=True,
+        use_wormhole_compute_kernel_config=False,
+        pcc_threshold=0.9994,
+    )
+
+
+@pytest.mark.parametrize("mesh_device", [(2, 4)], ids=["2x4"], indirect=True)
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}],
+    indirect=True,
+)
+def test_ring_joint_sdpa_mochi_model_config(mesh_device, reset_seeds):
+    """Mochi: heads=24, d=128, seq=4000, joint=118, sp2×tp2, chunks=(256,256)."""
+    run_ring_joint_sdpa_model_config(
+        mesh_device,
+        b=1,
+        nh=24,
+        base_seq_len=4000,
+        joint_seq_len=118,
+        d=128,
+        q_chunk_size=256,
+        k_chunk_size=256,
+        rp_axis=0,
+        rp_factor=2,
+        up_axis=1,
+        up_factor=2,
+        num_links=1,
+        ccl_reserve_last_column=False,
+        use_column_major_ccl=False,
+        use_wormhole_compute_kernel_config=False,
+    )

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -53,6 +53,11 @@ ALWI void cb_push_back_hold_wr_ptr(uint32_t cb_id, uint32_t num_tiles) {
     }));
 }
 
+// Accumulator half: one side of the ping-pong buffer (sum, max, output CB indices).
+struct AccumulatorHalf {
+    uint32_t sum, max, out;
+};
+
 /**
  * Blocked subblock matmul with absolute offset packing.
  * Always uses pack_tile<true> at row-major positions in out_cb.
@@ -603,12 +608,8 @@ template <
     uint32_t cb_mask_in = 0,
     uint32_t KT_stride = Sk_chunk_t>
 static void sdpa_inner_loop_step(
-    const uint32_t prev_max,
-    const uint32_t cur_max,
-    const uint32_t prev_sum,
-    const uint32_t cur_sum,
-    const uint32_t prev_out,
-    const uint32_t cur_out,
+    AccumulatorHalf& prev,
+    AccumulatorHalf& cur,
     const bool is_last_iter,
     const bool is_first_iter,
     [[maybe_unused]] const bool apply_mask = false,
@@ -652,7 +653,7 @@ static void sdpa_inner_loop_step(
     // Use KT_stride for cb_qkt_im layout to keep CB pointers aligned across iterations
     cb_reserve_back(cb_qkt_im, Sq_chunk_t * KT_stride);
 
-    cb_reserve_back(cur_sum, Sq_chunk_t);
+    cb_reserve_back(cur.sum, Sq_chunk_t);
 
     // ========== PHASE 1: Q@KT directly into cb_qkt_im ==========
     // All matmul output goes to cb_qkt_im at absolute offsets via pack_tile<true>.
@@ -682,8 +683,8 @@ static void sdpa_inner_loop_step(
                 }
                 sub_exp_block_bcast_cols<PROFILING_ENABLED, scale_fp32, true, VectorMode::RC, true /*blocked_pack*/>(
                     cb_qkt_im,
-                    cur_max,
-                    cur_sum,
+                    cur.max,
+                    cur.sum,
                     KT_stride,
                     prev_q_subblock,
                     kt_subblock * qkt_subblock_w,
@@ -732,8 +733,8 @@ static void sdpa_inner_loop_step(
                         VectorMode::RC,
                         true /*blocked_pack*/>(
                         cb_qkt_im,
-                        cur_max,
-                        cur_sum,
+                        cur.max,
+                        cur.sum,
                         KT_stride,
                         prev_q_subblock,
                         kt_num_full_subblocks * qkt_subblock_w,
@@ -795,15 +796,15 @@ static void sdpa_inner_loop_step(
         // Max reduce: reads from cb_qkt_im at q_subblock position
         {
             MaybeDeviceZoneScopedN(PROFILING_ENABLED, "Reduce max");
-            cb_reserve_back(cur_max, sbh);
+            cb_reserve_back(cur.max, sbh);
 #ifdef ARCH_BLACKHOLE
-            PACK((llk_pack_mop_config<false, false, false>(cur_max, 1)));
+            PACK((llk_pack_mop_config<false, false, false>(cur.max, 1)));
 #endif
             reduce_c_row_group<PoolType::MAX, ReduceDim::REDUCE_ROW, cb_identity_scale_in, Sk_chunk_t, KT_stride>(
-                cb_qkt_im, cur_max, prev_max, q_subblock, !is_first_iter /*do_eltwise_max*/, sbh, active_Sk);
-            cb_push_back(cur_max, sbh);
+                cb_qkt_im, cur.max, prev.max, q_subblock, !is_first_iter /*do_eltwise_max*/, sbh, active_Sk);
+            cb_push_back(cur.max, sbh);
 #ifdef ARCH_BLACKHOLE
-            PACK((llk_pack_mop_config<false, false, false>(cur_max, qkt_subblock_w)));
+            PACK((llk_pack_mop_config<false, false, false>(cur.max, qkt_subblock_w)));
 #endif
         }
 
@@ -846,7 +847,7 @@ static void sdpa_inner_loop_step(
 
         // V wait deferred: don't block here. The sub_exp drain loop below
         // doesn't touch V, so the reader's V DMA can overlap with the drain.
-        cb_reserve_back(cur_out, qktv_output_num_tiles);
+        cb_reserve_back(cur.out, qktv_output_num_tiles);
 
         // q_subblock 0: drain last row's sub_exp in-place + first QKT@V matmul
 #ifdef ARCH_BLACKHOLE
@@ -862,8 +863,8 @@ static void sdpa_inner_loop_step(
                 for (uint32_t kt_sub = 0; kt_sub < kt_num_full_subblocks; ++kt_sub) {
                     sub_exp_block_bcast_cols<PROFILING_ENABLED, scale_fp32, true>(
                         cb_qkt_im,
-                        cur_max,
-                        cur_sum,
+                        cur.max,
+                        cur.sum,
                         KT_stride,
                         q_num_subblocks - 1,
                         kt_sub * qkt_subblock_w,
@@ -882,7 +883,7 @@ static void sdpa_inner_loop_step(
                         MaybeDeviceZoneScopedN(PROFILING_ENABLED, "QKT@V MM+Pack");
                         uint32_t v_index_offset = 0;
                         if constexpr (!uniform_unpack_format) {
-                            reconfig_data_format(cur_out, cb_v_in, cur_out, cb_qkt_im);
+                            reconfig_data_format(cur.out, cb_v_in, cur.out, cb_qkt_im);
                         }
 #ifdef ARCH_BLACKHOLE
                         mm_no_mop_init_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, qktv_subblock_h, matmul_inner);
@@ -893,7 +894,7 @@ static void sdpa_inner_loop_step(
                             blocked_matmul_and_pack<false, vDHt, vDHt>(
                                 cb_qkt_im,
                                 cb_v_in,
-                                cur_out,
+                                cur.out,
                                 qktv_in0_index_offset + kt_sub * matmul_inner,
                                 kt_sub * matmul_inner * vDHt + v_index_offset,
                                 0,
@@ -905,7 +906,7 @@ static void sdpa_inner_loop_step(
                             v_index_offset += qktv_subblock_w;
                         }
                         if constexpr (!uniform_unpack_format) {
-                            reconfig_data_format(cb_v_in, cur_out, cb_qkt_im, cur_out);
+                            reconfig_data_format(cb_v_in, cur.out, cb_qkt_im, cur.out);
                         }
                     }
 
@@ -918,8 +919,8 @@ static void sdpa_inner_loop_step(
                 for (uint32_t kt_sub = 0; kt_sub < kt_num_full_subblocks; ++kt_sub) {
                     sub_exp_block_bcast_cols<PROFILING_ENABLED, scale_fp32, true>(
                         cb_qkt_im,
-                        cur_max,
-                        cur_sum,
+                        cur.max,
+                        cur.sum,
                         KT_stride,
                         q_num_subblocks - 1,
                         kt_sub * qkt_subblock_w,
@@ -929,8 +930,8 @@ static void sdpa_inner_loop_step(
                 if (has_partial_subblock) {
                     sub_exp_block_bcast_cols<PROFILING_ENABLED, scale_fp32, true>(
                         cb_qkt_im,
-                        cur_max,
-                        cur_sum,
+                        cur.max,
+                        cur.sum,
                         KT_stride,
                         q_num_subblocks - 1,
                         kt_num_full_subblocks * qkt_subblock_w,
@@ -944,7 +945,7 @@ static void sdpa_inner_loop_step(
                     MaybeDeviceZoneScopedN(PROFILING_ENABLED, "QKT@V MM+Pack");
                     uint32_t v_index_offset = 0;
                     if constexpr (!uniform_unpack_format) {
-                        reconfig_data_format(cur_out, cb_v_in, cur_out, cb_qkt_im);
+                        reconfig_data_format(cur.out, cb_v_in, cur.out, cb_qkt_im);
                     }
 #ifdef ARCH_BLACKHOLE
                     mm_no_mop_reinit_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, qktv_subblock_h, v_matmul_dim);
@@ -955,7 +956,7 @@ static void sdpa_inner_loop_step(
                         blocked_matmul_and_pack<false, vDHt, vDHt>(
                             cb_qkt_im,
                             cb_v_in,
-                            cur_out,
+                            cur.out,
                             qktv_in0_index_offset,
                             v_index_offset,
                             0,
@@ -967,7 +968,7 @@ static void sdpa_inner_loop_step(
                         v_index_offset += qktv_subblock_w;
                     }
                     if constexpr (!uniform_unpack_format) {
-                        reconfig_data_format(cb_v_in, cur_out, cb_qkt_im, cur_out);
+                        reconfig_data_format(cb_v_in, cur.out, cb_qkt_im, cur.out);
                     }
                 }
             }
@@ -979,10 +980,10 @@ static void sdpa_inner_loop_step(
         [[maybe_unused]] auto normalize_row = [&](uint32_t w_salad, uint32_t& pushed) {
             if constexpr (!ring_mode) {
                 MaybeDeviceZoneScopedN(PROFILING_ENABLED, "ROW_NORM");
-                cb_push_back(cur_sum, sbh);
-                cb_push_back(cur_out, sbh * vDHt);
+                cb_push_back(cur.sum, sbh);
+                cb_push_back(cur.out, sbh * vDHt);
                 normalize_row_streaming<PROFILING_ENABLED, vDHt>(
-                    cur_sum, cur_out, cb_col_identity, cb_recip_scratch, cb_normalized_out, sbh);
+                    cur.sum, cur.out, cb_col_identity, cb_recip_scratch, cb_normalized_out, sbh);
                 pushed++;
             }
         };
@@ -992,11 +993,11 @@ static void sdpa_inner_loop_step(
             PACK((llk_pack_reconfig_l1_acc(1)));
             {
                 MaybeDeviceZoneScopedN(PROFILING_ENABLED, "S_SUM_CORR");
-                mul_bcast_cols_l1_acc(prev_sum, cb_exp_max_diff, cur_sum, salad_row, w_salad, sbh);
+                mul_bcast_cols_l1_acc(prev.sum, cb_exp_max_diff, cur.sum, salad_row, w_salad, sbh);
             }
             {
                 MaybeDeviceZoneScopedN(PROFILING_ENABLED, "S_OUT_CORR");
-                mul_block_bcast_cols_acc<vDHt>(prev_out, cb_exp_max_diff, cur_out, salad_row, w_salad, sbh);
+                mul_block_bcast_cols_acc<vDHt>(prev.out, cb_exp_max_diff, cur.out, salad_row, w_salad, sbh);
             }
             PACK((llk_pack_reconfig_l1_acc(0)));
             if (last_iter) {
@@ -1015,7 +1016,7 @@ static void sdpa_inner_loop_step(
             if (!is_first_iter) {
                 cb_reserve_back(cb_exp_max_diff, sbh);
                 sub_exp_first_col_blocks<PROFILING_ENABLED, scale_fp32>(
-                    prev_max, cur_max, cb_exp_max_diff, salad_row, sbh);
+                    prev.max, cur.max, cb_exp_max_diff, salad_row, sbh);
                 cb_push_back(cb_exp_max_diff, sbh);
             }
 
@@ -1025,7 +1026,7 @@ static void sdpa_inner_loop_step(
                 MaybeDeviceZoneScopedN(PROFILING_ENABLED, "QKT@V MM+Pack");
                 uint32_t v_index_offset = 0;
                 if constexpr (!uniform_unpack_format) {
-                    reconfig_data_format(cur_out, cb_v_in, cur_out, cb_qkt_im);
+                    reconfig_data_format(cur.out, cb_v_in, cur.out, cb_qkt_im);
                 }
 #ifdef ARCH_BLACKHOLE
                 mm_no_mop_init_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, qktv_subblock_h, v_matmul_dim);
@@ -1036,7 +1037,7 @@ static void sdpa_inner_loop_step(
                     blocked_matmul_and_pack<false, vDHt, vDHt>(
                         cb_qkt_im,
                         cb_v_in,
-                        cur_out,
+                        cur.out,
                         qktv_in0_index_offset,
                         v_index_offset,
                         w_q,
@@ -1048,7 +1049,7 @@ static void sdpa_inner_loop_step(
                     v_index_offset += qktv_subblock_w;
                 }
                 if constexpr (!uniform_unpack_format) {
-                    reconfig_data_format(cb_v_in, cur_out, cb_qkt_im, cur_out);
+                    reconfig_data_format(cb_v_in, cur.out, cb_qkt_im, cur.out);
                 }
             }
 
@@ -1071,17 +1072,17 @@ static void sdpa_inner_loop_step(
             if (!is_first_iter) {
                 cb_reserve_back(cb_exp_max_diff, sbh);
                 sub_exp_first_col_blocks<PROFILING_ENABLED, scale_fp32>(
-                    prev_max, cur_max, cb_exp_max_diff, salad_row, sbh);
+                    prev.max, cur.max, cb_exp_max_diff, salad_row, sbh);
                 cb_push_back(cb_exp_max_diff, sbh);
 
                 salad_correct_row(salad_row, w_salad, is_last_iter, pushed_rows);
             } else if constexpr (!ring_mode) {
                 if (is_last_iter) {
                     MaybeDeviceZoneScopedN(PROFILING_ENABLED, "ROW_NORM");
-                    cb_push_back(cur_sum, sbh);
-                    cb_push_back(cur_out, sbh * vDHt);
+                    cb_push_back(cur.sum, sbh);
+                    cb_push_back(cur.out, sbh * vDHt);
                     normalize_row_streaming<PROFILING_ENABLED, vDHt>(
-                        cur_sum, cur_out, cb_col_identity, cb_recip_scratch, cb_normalized_out, sbh);
+                        cur.sum, cur.out, cb_col_identity, cb_recip_scratch, cb_normalized_out, sbh);
                     pushed_rows++;
                 }
             }
@@ -1090,8 +1091,8 @@ static void sdpa_inner_loop_step(
         // Bulk push — skip on last iteration when rows are consumed by normalization.
         // In ring_mode, always bulk push — caller handles finalization.
         if (ring_mode || !is_last_iter) {
-            cb_push_back(cur_sum, Sq_chunk_t);
-            cb_push_back(cur_out, qktv_output_num_tiles);
+            cb_push_back(cur.sum, Sq_chunk_t);
+            cb_push_back(cur.out, qktv_output_num_tiles);
         }
 
         cb_pop_front(cb_v_in, KT_stride * vDHt);
@@ -1142,9 +1143,8 @@ void sdpa_standard_v2(
     constexpr uint32_t effective_Sk = Sk_chunk_t - padded_k_tiles_inner;
 
     for (uint32_t q = 0; q < q_chunks_per_core; q++) {
-        uint32_t alias_prev_sum = cb_sum_A, alias_cur_sum = cb_sum_B;
-        uint32_t alias_prev_max = cb_max_A, alias_cur_max = cb_max_B;
-        uint32_t alias_prev_out = cb_out_im_A, alias_cur_out = cb_out_im_B;
+        AccumulatorHalf prev = {cb_sum_A, cb_max_A, cb_out_im_A};
+        AccumulatorHalf cur = {cb_sum_B, cb_max_B, cb_out_im_B};
 
         auto call_step = [&](auto profiling_tag, bool is_last, bool is_first, uint32_t eff_Sk) {
             sdpa_inner_loop_step<
@@ -1170,12 +1170,8 @@ void sdpa_standard_v2(
                 cb_recip_scratch,
                 cb_normalized_out,
                 cb_mask_in>(
-                alias_prev_max,
-                alias_cur_max,
-                alias_prev_sum,
-                alias_cur_sum,
-                alias_prev_out,
-                alias_cur_out,
+                prev,
+                cur,
                 is_last,
                 is_first,
                 false,  // apply_mask
@@ -1195,17 +1191,15 @@ void sdpa_standard_v2(
             // Post-iteration cleanup
             if (!is_first) {
                 cb_pop_front(cb_exp_max_diff, Sq_chunk_t);
-                cb_pop_front(alias_prev_max, Sq_chunk_t);
-                cb_pop_front(alias_prev_sum, Sq_chunk_t);
-                cb_pop_front(alias_prev_out, Sq_chunk_t * vDHt);
+                cb_pop_front(prev.max, Sq_chunk_t);
+                cb_pop_front(prev.sum, Sq_chunk_t);
+                cb_pop_front(prev.out, Sq_chunk_t * vDHt);
             }
 
             if (is_last) {
-                cb_pop_front(alias_cur_max, Sq_chunk_t);
+                cb_pop_front(cur.max, Sq_chunk_t);
             } else {
-                std::swap(alias_prev_max, alias_cur_max);
-                std::swap(alias_prev_sum, alias_cur_sum);
-                std::swap(alias_prev_out, alias_cur_out);
+                std::swap(prev, cur);
             }
         }
         // Q already popped inside sdpa_inner_loop_step after Phase 1 of the last K chunk.
@@ -1258,21 +1252,16 @@ void sdpa_ring_v2(
     const uint32_t global_n_mask_chunk_id,
     const uint32_t local_n_mask_chunk_id,
     const uint32_t joint_n_mask_chunk_id,
-    const uint32_t cb_out_im_A,
-    const uint32_t cb_out_im_B,
-    const uint32_t cb_max_A,
-    const uint32_t cb_max_B,
-    const uint32_t cb_sum_A,
-    const uint32_t cb_sum_B,
+    AccumulatorHalf& prev,
+    AccumulatorHalf& cur,
     const LightweightMaskContext& lw_mask = {}) {
     constexpr bool uniform_format = uniform_dataformat;
 
     uint32_t KV_chunks_processed_in_iter = 0;
 
     for (uint32_t q = global_q_start; q < global_q_end; q++) {
-        uint32_t alias_prev_sum = cb_sum_A, alias_cur_sum = cb_sum_B;
-        uint32_t alias_prev_max = cb_max_A, alias_cur_max = cb_max_B;
-        uint32_t alias_prev_out = cb_out_im_A, alias_cur_out = cb_out_im_B;
+        // Reset ping-pong aliases each Q chunk (caller provides the CB pairs)
+        AccumulatorHalf q_prev = prev, q_cur = cur;
 
         uint32_t KV_chunks_processed = 0;
 
@@ -1341,12 +1330,8 @@ void sdpa_ring_v2(
                 cb_recip_scratch,
                 0,  // cb_normalized_out — unused in ring_mode (no per-row normalization)
                 cb_mask_in>(
-                alias_prev_max,
-                alias_cur_max,
-                alias_prev_sum,
-                alias_cur_sum,
-                alias_prev_out,
-                alias_cur_out,
+                q_prev,
+                q_cur,
                 false,  // is_last_iter
                 is_first,
                 apply_mask,
@@ -1356,40 +1341,38 @@ void sdpa_ring_v2(
             // Post-iteration cleanup: pop previous values and swap aliases
             if (!is_first) {
                 cb_pop_front(cb_exp_max_diff, Sq_chunk_t);
-                cb_pop_front(alias_prev_max, Sq_chunk_t);
-                cb_pop_front(alias_prev_sum, Sq_chunk_t);
-                cb_pop_front(alias_prev_out, Sq_chunk_t * vDHt);
+                cb_pop_front(q_prev.max, Sq_chunk_t);
+                cb_pop_front(q_prev.sum, Sq_chunk_t);
+                cb_pop_front(q_prev.out, Sq_chunk_t * vDHt);
             }
 
-            std::swap(alias_prev_max, alias_cur_max);
-            std::swap(alias_prev_sum, alias_cur_sum);
-            std::swap(alias_prev_out, alias_cur_out);
+            std::swap(q_prev, q_cur);
         }
 
         // Pop Q — not popped inside step since is_last_iter was always false
         cb_pop_front(cb_q_in, Sq_chunk_t * DHt);
 
         // ========== Ring Finalization ==========
-        // After all K chunks: alias_prev_sum = final sum, alias_prev_max = final max,
-        // alias_prev_out = final unnormalized output. alias_cur_* are empty.
+        // After all K chunks: q_prev.{sum,max,out} = final values. q_cur.* are empty.
         {
             constexpr uint32_t out_chunk_tiles = Sq_chunk_t * vDHt;
 
-            matmul_reduce<Sq_chunk_t>(cb_col_identity, alias_prev_sum);
-            log_block(alias_prev_sum, alias_cur_max, Sq_chunk_t);
-            mul_block_bcast_scalar_inplace<cb_scale_in, Sq_chunk_t>(alias_prev_max);
-            add_block_inplace(alias_prev_max, alias_cur_max, Sq_chunk_t);
-            recip_block_inplace(alias_prev_sum, Sq_chunk_t);
-            mul_block_bcast_cols_inplace<Sq_chunk_t, vDHt>(alias_prev_out, alias_prev_sum);
+            matmul_reduce<Sq_chunk_t>(cb_col_identity, q_prev.sum);
+            log_block(q_prev.sum, q_cur.max, Sq_chunk_t);
+            mul_block_bcast_scalar_inplace<cb_scale_in, Sq_chunk_t>(q_prev.max);
+            add_block_inplace(q_prev.max, q_cur.max, Sq_chunk_t);
+            recip_block_inplace(q_prev.sum, Sq_chunk_t);
+            mul_block_bcast_cols_inplace<Sq_chunk_t, vDHt>(q_prev.out, q_prev.sum);
 
             if (ring_iter > 0) {
                 cb_wait_front(cb_lse_in, Sq_chunk_t);
                 cb_wait_front(cb_prev_out, out_chunk_tiles);
 
-                uint32_t alias_cur_lse = alias_prev_max;
-                uint32_t alias_sig = alias_cur_max;
-                uint32_t alias_cur_out_r = alias_prev_out;
-                uint32_t alias_sub = alias_cur_out;
+                // Reuse accumulator CBs as temporaries for sigmoid merge
+                uint32_t alias_cur_lse = q_prev.max;
+                uint32_t alias_sig = q_cur.max;
+                uint32_t alias_cur_out_r = q_prev.out;
+                uint32_t alias_sub = q_cur.out;
 
                 sigmoid_sub(alias_cur_lse, cb_lse_in, alias_sig, Sq_chunk_t);
 
@@ -1423,11 +1406,11 @@ void sdpa_ring_v2(
                 if constexpr (!uniform_format) {
                     pack_reconfig_data_format(cb_out);
                 }
-                copy_block(alias_prev_out, cb_out, out_chunk_tiles);
+                copy_block(q_prev.out, cb_out, out_chunk_tiles);
                 if constexpr (!uniform_format) {
                     pack_reconfig_data_format(cb_lse_out);
                 }
-                copy_block(alias_prev_max, cb_lse_out, Sq_chunk_t);
+                copy_block(q_prev.max, cb_lse_out, Sq_chunk_t);
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -58,6 +58,12 @@ struct AccumulatorHalf {
     uint32_t sum, max, out;
 };
 
+// Persistent accumulator state for ring SDPA deferred normalization.
+// When each core processes exactly 1 Q chunk, this state carries across ring iterations.
+struct RingAccumulatorState {
+    AccumulatorHalf prev, cur;
+};
+
 /**
  * Blocked subblock matmul with absolute offset packing.
  * Always uses pack_tile<true> at row-major positions in out_cb.
@@ -595,6 +601,7 @@ template <
     bool use_padded_mask,
     bool ring_mode = false,
     bool use_ring_mask = false,
+
     bool uniform_dataformat = false,
     uint32_t cb_q_in = 0,
     uint32_t cb_kt_in = 0,
@@ -976,16 +983,14 @@ static void sdpa_inner_loop_step(
             qktv_in0_wait_tiles += qktv_in0_row_tiles;
         }
 
-        // Per-row normalization lambda — only compiled for non-ring mode
+        // Per-row normalization lambda — fires on last K chunk (standard or deferred norm)
         [[maybe_unused]] auto normalize_row = [&](uint32_t w_salad, uint32_t& pushed) {
-            if constexpr (!ring_mode) {
-                MaybeDeviceZoneScopedN(PROFILING_ENABLED, "ROW_NORM");
-                cb_push_back(cur.sum, sbh);
-                cb_push_back(cur.out, sbh * vDHt);
-                normalize_row_streaming<PROFILING_ENABLED, vDHt>(
-                    cur.sum, cur.out, cb_col_identity, cb_recip_scratch, cb_normalized_out, sbh);
-                pushed++;
-            }
+            MaybeDeviceZoneScopedN(PROFILING_ENABLED, "ROW_NORM");
+            cb_push_back(cur.sum, sbh);
+            cb_push_back(cur.out, sbh * vDHt);
+            normalize_row_streaming<PROFILING_ENABLED, vDHt>(
+                cur.sum, cur.out, cb_col_identity, cb_recip_scratch, cb_normalized_out, sbh);
+            pushed++;
         };
 
         // SALAD correction + optional normalization lambda
@@ -1076,7 +1081,7 @@ static void sdpa_inner_loop_step(
                 cb_push_back(cb_exp_max_diff, sbh);
 
                 salad_correct_row(salad_row, w_salad, is_last_iter, pushed_rows);
-            } else if constexpr (!ring_mode) {
+            } else {
                 if (is_last_iter) {
                     MaybeDeviceZoneScopedN(PROFILING_ENABLED, "ROW_NORM");
                     cb_push_back(cur.sum, sbh);
@@ -1089,8 +1094,7 @@ static void sdpa_inner_loop_step(
         }
 
         // Bulk push — skip on last iteration when rows are consumed by normalization.
-        // In ring_mode, always bulk push — caller handles finalization.
-        if (ring_mode || !is_last_iter) {
+        if (!is_last_iter) {
             cb_push_back(cur.sum, Sq_chunk_t);
             cb_push_back(cur.out, qktv_output_num_tiles);
         }
@@ -1101,8 +1105,23 @@ static void sdpa_inner_loop_step(
 }
 
 /**
- * Streaming SDPA wrapper (v2): Q-chunk / K-chunk outer loop with ping-pong buffer management.
+ * Streaming SDPA (v2): single-device, non-ring variant.
+ * Q-chunk / K-chunk outer loop with ping-pong buffer management.
  * No row buffers — uses cb_push_back_hold_wr_ptr for direct cb_qkt_im writes.
+ *
+ * @tparam Sq_chunk_t   Q chunk size in tiles (rows per attention block)
+ * @tparam Sk_chunk_t   K chunk size in tiles (columns per attention block)
+ * @tparam Skt          Total K sequence length in tiles (used for last-chunk padding detection)
+ * @tparam DHt          Head dimension in tiles
+ * @tparam vDHt         V head dimension in tiles (== DHt unless V has different width)
+ * @tparam scale_fp32   Attention scale factor as raw uint32_t bits (reinterpreted as float)
+ * @tparam subblock_h   Matmul subblock height (rows processed per DST acquire/release cycle)
+ *
+ * @param q_chunks_per_core  Number of Q chunks this core processes
+ * @param k_num_chunks       Total number of K chunks in the sequence
+ * @param cb_out_im_A/B      Ping-pong output accumulator CBs (hold un-normalized QK@V)
+ * @param cb_max_A/B          Ping-pong row-max CBs (for numerical stability)
+ * @param cb_sum_A/B          Ping-pong row-sum CBs (softmax denominator)
  */
 template <
     uint32_t Sq_chunk_t,
@@ -1159,6 +1178,7 @@ void sdpa_standard_v2(
                 use_padded_mask,
                 false,  // ring_mode
                 false,  // use_ring_mask
+
                 uniform_dataformat,
                 cb_q_in,
                 cb_kt_in,
@@ -1207,12 +1227,36 @@ void sdpa_standard_v2(
 }
 
 /**
- * Streaming Ring SDPA (v2): Ring-aware variant of sdpa_standard_v2.
- * Calls sdpa_inner_loop_step with ring_mode=true and use_ring_mask=true.
- * After K-chunk loop: performs ring finalization (log, LSE, recip, sigmoid blend).
+ * Streaming Ring SDPA (v2): Ring-aware variant of sdpa_standard_v2 with deferred normalization.
+ * Accumulates raw (un-normalized) softmax state across ring iterations; normalizes once on the
+ * last K chunk of the last ring iteration. Single Q-chunk: accumulators persist in L1 across
+ * ring iterations (no DRAM traffic). Multi Q-chunk: accumulators round-trip through DRAM.
  *
- * Per-Q-chunk outer loop with ping-pong buffer management.
- * Per ring iteration, processes all Q chunks over [global_q_start, global_q_end).
+ * @tparam Sq_chunk_t       Q chunk size in tiles
+ * @tparam Sk_chunk_t       K chunk size in tiles
+ * @tparam Skt              Not used for ring (pass 0)
+ * @tparam DHt              Head dimension in tiles
+ * @tparam vDHt             V head dimension in tiles (== DHt for ring)
+ * @tparam scale_fp32       Attention scale factor as raw uint32_t bits
+ * @tparam subblock_h       Matmul subblock height
+ * @tparam cb_max_in      CB for restoring row-max from DRAM (multi Q-chunk, c_6)
+ * @tparam cb_max_out     CB for saving row-max to DRAM (multi Q-chunk, c_17)
+ * @tparam cb_normalized_out CB for normalized output rows (written by normalize_row_streaming)
+ * @tparam cb_sum_out       CB for saving row-sum to DRAM (multi Q-chunk, c_10)
+ * @tparam cb_sum_in        CB for restoring row-sum from DRAM (multi Q-chunk, c_11)
+ *
+ * @param global_q_start     First global Q chunk index for this core
+ * @param global_q_end       One-past-last global Q chunk index for this core
+ * @param num_kv_chunks      Total K chunks this ring iter (local + joint if applicable)
+ * @param ring_iter          Current ring iteration (0..ring_size-1)
+ * @param ring_id            Device ID within the ring that owns this iter's KV shard
+ * @param num_local_k_chunks Number of K chunks from the local (non-joint) sequence
+ * @param local_padded_Nt    Per-device padded sequence length in tiles (N_local / TILE_H)
+ * @param logical_nt         Actual (unpadded) global sequence length in tiles
+ * @param acc_state          Persistent accumulator state (prev/cur CB halves for ping-pong)
+ * @param is_last_ring_iter  True on the final ring iteration — triggers normalization
+ * @param q_per_core         Number of Q chunks per core (1 = L1-only, >1 = DRAM round-trip)
+ * @param lw_mask            Lightweight mask context for partial-tile padding
  */
 template <
     uint32_t Sq_chunk_t,
@@ -1232,11 +1276,14 @@ template <
     uint32_t cb_recip_scratch,
     uint32_t cb_mask_in,
     uint32_t cb_scale_in,
-    uint32_t cb_lse_in,
-    uint32_t cb_lse_out,
+    uint32_t cb_max_in,
+    uint32_t cb_max_out,
     uint32_t cb_prev_out,
     uint32_t cb_out,
-    bool uniform_dataformat = false>
+    bool uniform_dataformat = false,
+    uint32_t cb_normalized_out = 0,
+    uint32_t cb_sum_out = 0,
+    uint32_t cb_sum_in = 0>
 void sdpa_ring_v2(
     const uint32_t global_q_start,
     const uint32_t global_q_end,
@@ -1252,16 +1299,40 @@ void sdpa_ring_v2(
     const uint32_t global_n_mask_chunk_id,
     const uint32_t local_n_mask_chunk_id,
     const uint32_t joint_n_mask_chunk_id,
-    AccumulatorHalf& prev,
-    AccumulatorHalf& cur,
+    RingAccumulatorState& acc_state,
+    const bool is_last_ring_iter = false,
+    const uint32_t q_per_core = 1,
     const LightweightMaskContext& lw_mask = {}) {
+    constexpr uint32_t out_chunk_tiles = Sq_chunk_t * vDHt;
     constexpr bool uniform_format = uniform_dataformat;
 
     uint32_t KV_chunks_processed_in_iter = 0;
 
+    // Pre-scan to count valid K chunks (needed to find last K chunk for normalization)
+    uint32_t total_valid_kv = 0;
+    for (uint32_t k = 0; k < num_kv_chunks; ++k) {
+        const bool is_joint = k >= num_local_k_chunks;
+        const uint32_t kv_start = local_padded_Nt * ring_id + k * Sk_chunk_t;
+        if (!is_joint && (kv_start >= logical_nt)) {
+            continue;
+        }
+        total_valid_kv++;
+    }
+
     for (uint32_t q = global_q_start; q < global_q_end; q++) {
-        // Reset ping-pong aliases each Q chunk (caller provides the CB pairs)
-        AccumulatorHalf q_prev = prev, q_cur = cur;
+        // Use persistent accumulator state from caller (single Q-chunk)
+        // or restore from DRAM (multi Q-chunk).
+        AccumulatorHalf q_prev = acc_state.prev, q_cur = acc_state.cur;
+
+        // First ring iteration starts fresh; subsequent ones have prior accumulated state.
+        const bool is_first_kv_for_this_q = (ring_iter == 0);
+
+        // Multi Q-chunk: restore accumulators from DRAM on non-first ring iterations.
+        if (q_per_core > 1 && ring_iter > 0) {
+            copy_block(cb_prev_out, q_prev.out, out_chunk_tiles);
+            copy_block(cb_max_in, q_prev.max, Sq_chunk_t);
+            copy_block(cb_sum_in, q_prev.sum, Sq_chunk_t);
+        }
 
         uint32_t KV_chunks_processed = 0;
 
@@ -1276,7 +1347,10 @@ void sdpa_ring_v2(
             KV_chunks_processed++;
             KV_chunks_processed_in_iter++;
 
-            bool is_first = (KV_chunks_processed == 1);
+            const bool is_first = is_first_kv_for_this_q && (KV_chunks_processed == 1);
+
+            // Last K chunk of last ring_iter triggers per-row normalization
+            const bool is_last = is_last_ring_iter && (KV_chunks_processed == total_valid_kv);
 
             // Determine if this K chunk needs masking (partial tile within a tile boundary)
             const bool is_global_n_mask_chunk = ring_iter_needs_global_n_mask && k_chunk == global_n_mask_chunk_id;
@@ -1319,6 +1393,7 @@ void sdpa_ring_v2(
                 false,  // use_padded_mask — ring uses ring mask instead
                 true,   // ring_mode
                 true,   // use_ring_mask
+
                 uniform_dataformat,
                 cb_q_in,
                 cb_kt_in,
@@ -1328,15 +1403,8 @@ void sdpa_ring_v2(
                 cb_exp_max_diff,
                 cb_col_identity,
                 cb_recip_scratch,
-                0,  // cb_normalized_out — unused in ring_mode (no per-row normalization)
-                cb_mask_in>(
-                q_prev,
-                q_cur,
-                false,  // is_last_iter
-                is_first,
-                apply_mask,
-                lw_partial_tile_idx,
-                effective_Sk_param);
+                cb_normalized_out,
+                cb_mask_in>(q_prev, q_cur, is_last, is_first, apply_mask, lw_partial_tile_idx, effective_Sk_param);
 
             // Post-iteration cleanup: pop previous values and swap aliases
             if (!is_first) {
@@ -1346,73 +1414,33 @@ void sdpa_ring_v2(
                 cb_pop_front(q_prev.out, Sq_chunk_t * vDHt);
             }
 
-            std::swap(q_prev, q_cur);
-        }
-
-        // Pop Q — not popped inside step since is_last_iter was always false
-        cb_pop_front(cb_q_in, Sq_chunk_t * DHt);
-
-        // ========== Ring Finalization ==========
-        // After all K chunks: q_prev.{sum,max,out} = final values. q_cur.* are empty.
-        {
-            constexpr uint32_t out_chunk_tiles = Sq_chunk_t * vDHt;
-
-            matmul_reduce<Sq_chunk_t>(cb_col_identity, q_prev.sum);
-            log_block(q_prev.sum, q_cur.max, Sq_chunk_t);
-            mul_block_bcast_scalar_inplace<cb_scale_in, Sq_chunk_t>(q_prev.max);
-            add_block_inplace(q_prev.max, q_cur.max, Sq_chunk_t);
-            recip_block_inplace(q_prev.sum, Sq_chunk_t);
-            mul_block_bcast_cols_inplace<Sq_chunk_t, vDHt>(q_prev.out, q_prev.sum);
-
-            if (ring_iter > 0) {
-                cb_wait_front(cb_lse_in, Sq_chunk_t);
-                cb_wait_front(cb_prev_out, out_chunk_tiles);
-
-                // Reuse accumulator CBs as temporaries for sigmoid merge
-                uint32_t alias_cur_lse = q_prev.max;
-                uint32_t alias_sig = q_cur.max;
-                uint32_t alias_cur_out_r = q_prev.out;
-                uint32_t alias_sub = q_cur.out;
-
-                sigmoid_sub(alias_cur_lse, cb_lse_in, alias_sig, Sq_chunk_t);
-
-                if constexpr (!uniform_format) {
-                    reconfig_data_format(cb_prev_out, alias_cur_out_r);
-                }
-                sub_block(cb_prev_out, alias_cur_out_r, alias_sub, out_chunk_tiles);
-                if constexpr (!uniform_format) {
-                    reconfig_data_format(alias_sub, alias_sig);
-                }
-                mul_block_bcast_cols_inplace<Sq_chunk_t, DHt>(alias_sub, alias_sig);
-                if constexpr (!uniform_format) {
-                    reconfig_data_format(cb_prev_out, alias_sub);
-                    pack_reconfig_data_format(cb_out);
-                }
-                sub_block(cb_prev_out, alias_sub, cb_out, out_chunk_tiles);
-                cb_pop_front(cb_prev_out, out_chunk_tiles);
-                cb_pop_front(alias_cur_out_r, out_chunk_tiles);
-                cb_pop_front(alias_sub, out_chunk_tiles);
-
-                if constexpr (!uniform_format) {
-                    pack_reconfig_data_format(alias_sig);
-                    reconfig_data_format(cb_lse_in, alias_cur_lse);
-                }
-                logsigmoid_sub(cb_lse_in, alias_cur_lse, alias_sig, Sq_chunk_t);
-                sub_block(cb_lse_in, alias_sig, cb_lse_out, Sq_chunk_t);
-                cb_pop_front(alias_sig, Sq_chunk_t);
-                cb_pop_front(alias_cur_lse, Sq_chunk_t);
-                cb_pop_front(cb_lse_in, Sq_chunk_t);
+            if (is_last) {
+                // Normalization consumed cur.sum and cur.out; pop cur.max.
+                cb_pop_front(q_cur.max, Sq_chunk_t);
             } else {
-                if constexpr (!uniform_format) {
-                    pack_reconfig_data_format(cb_out);
-                }
-                copy_block(q_prev.out, cb_out, out_chunk_tiles);
-                if constexpr (!uniform_format) {
-                    pack_reconfig_data_format(cb_lse_out);
-                }
-                copy_block(q_prev.max, cb_lse_out, Sq_chunk_t);
+                std::swap(q_prev, q_cur);
             }
         }
+
+        // Pop Q — not popped inside step since ring_mode gates the early Q pop
+        cb_pop_front(cb_q_in, Sq_chunk_t * DHt);
+
+        // Persist or save accumulators for next ring iteration
+        if (q_per_core == 1) {
+            // Single Q-chunk: persist in L1 (no DRAM round-trip)
+            acc_state.prev = q_prev;
+            acc_state.cur = q_cur;
+        } else if (!is_last_ring_iter) {
+            // Multi Q-chunk: save raw accumulators to DRAM via writer CBs.
+            // q_prev holds final accumulators after the last swap.
+            if constexpr (!uniform_format) {
+                pack_reconfig_data_format(cb_out);
+            }
+            copy_block(q_prev.out, cb_out, out_chunk_tiles);
+            copy_block(q_prev.max, cb_max_out, Sq_chunk_t);
+            copy_block(q_prev.sum, cb_sum_out, Sq_chunk_t);
+        }
+        // On last ring_iter: normalized output already in cb_out from normalize_row_streaming
     }
 
     // Dummy KV pop for double-buffer alignment (same as sdpa_inner_loop for RING)

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
@@ -118,6 +118,9 @@ void kernel_main() {
         (local_padded_Nt % Sk_chunk_t != 0) ? (Sk_chunk_t - (local_padded_Nt % Sk_chunk_t)) : 0;
     constexpr uint32_t joint_n_padded_tiles = (Lt % Sk_chunk_t != 0) ? (Sk_chunk_t - (Lt % Sk_chunk_t)) : 0;
 
+    AccumulatorHalf ring_prev = {cb_sum_A, cb_max_A, cb_out_im_A};
+    AccumulatorHalf ring_cur = {cb_sum_B, cb_max_B, cb_out_im_B};
+
     for (uint32_t ring_iter = 0; ring_iter < ring_size; ++ring_iter) {
         uint32_t ring_id = fused_op_indexer.get_next_ring_id_and_sync();
         const bool do_joint_kv = ring_id == ring_size - 1;
@@ -206,12 +209,8 @@ void kernel_main() {
                 global_n_mask_chunk_id,
                 local_n_mask_chunk_id,
                 joint_n_mask_chunk_id,
-                cb_out_im_A,
-                cb_out_im_B,
-                cb_max_A,
-                cb_max_B,
-                cb_sum_A,
-                cb_sum_B,
+                ring_prev,
+                ring_cur,
                 lw_mask);
         } else {
             sdpa_ring<cb_qk_im, cb_identity_scale_in, cb_scale_in, Sq_chunk_t, Sk_chunk_t, DHt, scale_fp32>(

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
@@ -51,6 +51,7 @@ void kernel_main() {
     constexpr uint32_t global_n_partial_col = get_compile_time_arg_val(32);
     constexpr uint32_t joint_l_partial_col = get_compile_time_arg_val(33);
     constexpr bool uniform_dataformat = get_compile_time_arg_val(34) == 1;
+    constexpr uint32_t q_per_core = get_compile_time_arg_val(35);
 
     // Lightweight mask: all mask tiles live in cb_mask_in (c_3).
     // Layout: [neginf(0)] [global_n_partial?(1)] [joint_l_partial?(1 or 2)]
@@ -84,7 +85,8 @@ void kernel_main() {
     constexpr uint32_t cb_scale_in = tt::CBIndex::c_4;
     constexpr uint32_t cb_identity_scale_in = tt::CBIndex::c_5;
     constexpr uint32_t cb_col_identity = tt::CBIndex::c_8;
-    constexpr uint32_t cb_lse_in = tt::CBIndex::c_6;
+    constexpr uint32_t cb_max_in = tt::CBIndex::c_6;  // deferred norm: running max
+    constexpr uint32_t cb_lse_in = tt::CBIndex::c_6;  // eager norm: LSE
     constexpr uint32_t cb_prev_out = tt::CBIndex::c_7;
     constexpr uint32_t cb_qk_im = tt::CBIndex::c_24;
     constexpr uint32_t cb_out_im_A = tt::CBIndex::c_25;
@@ -96,11 +98,16 @@ void kernel_main() {
     constexpr uint32_t cb_exp_max_diff = tt::CBIndex::c_31;
 
     constexpr uint32_t cb_out = tt::CBIndex::c_16;
-    constexpr uint32_t cb_lse_out = tt::CBIndex::c_17;
+    constexpr uint32_t cb_max_out = tt::CBIndex::c_17;  // deferred norm: running max
+    constexpr uint32_t cb_lse_out = tt::CBIndex::c_17;  // eager norm: LSE
 
     // Streaming compute uses c_9 as 1-tile recip scratch for normalize_row_streaming.
     // (c_4 is used by cb_scale_in in ring joint SDPA, unlike regular SDPA.)
     constexpr uint32_t cb_recip_scratch = tt::CBIndex::c_9;
+
+    // Deferred norm: sum save/restore CBs for multi Q-chunk DRAM round-trip.
+    constexpr uint32_t cb_sum_out = tt::CBIndex::c_10;
+    constexpr uint32_t cb_sum_in = tt::CBIndex::c_11;
 
     mm_init(cb_q_in, cb_k_in, cb_qk_im);
 
@@ -118,8 +125,10 @@ void kernel_main() {
         (local_padded_Nt % Sk_chunk_t != 0) ? (Sk_chunk_t - (local_padded_Nt % Sk_chunk_t)) : 0;
     constexpr uint32_t joint_n_padded_tiles = (Lt % Sk_chunk_t != 0) ? (Sk_chunk_t - (Lt % Sk_chunk_t)) : 0;
 
-    AccumulatorHalf ring_prev = {cb_sum_A, cb_max_A, cb_out_im_A};
-    AccumulatorHalf ring_cur = {cb_sum_B, cb_max_B, cb_out_im_B};
+    RingAccumulatorState acc_state = {
+        {cb_sum_A, cb_max_A, cb_out_im_A},  // prev
+        {cb_sum_B, cb_max_B, cb_out_im_B},  // cur
+    };
 
     for (uint32_t ring_iter = 0; ring_iter < ring_size; ++ring_iter) {
         uint32_t ring_id = fused_op_indexer.get_next_ring_id_and_sync();
@@ -172,6 +181,7 @@ void kernel_main() {
         }
 
         if constexpr (use_streaming_compute) {
+            const bool is_last_ring_iter = (ring_iter == ring_size - 1);
             sdpa_ring_v2<
                 Sq_chunk_t,
                 Sk_chunk_t,
@@ -190,11 +200,14 @@ void kernel_main() {
                 cb_recip_scratch,
                 cb_mask_in,
                 cb_scale_in,
-                cb_lse_in,
-                cb_lse_out,
+                cb_max_in,
+                cb_max_out,
                 cb_prev_out,
                 cb_out,
-                uniform_dataformat>(
+                uniform_dataformat,
+                cb_out,  // cb_normalized_out — output goes directly to cb_out
+                cb_sum_out,
+                cb_sum_in>(
                 global_q_start,
                 global_q_end,
                 num_kv_chunks,
@@ -209,8 +222,9 @@ void kernel_main() {
                 global_n_mask_chunk_id,
                 local_n_mask_chunk_id,
                 joint_n_mask_chunk_id,
-                ring_prev,
-                ring_cur,
+                acc_state,
+                is_last_ring_iter,
+                q_per_core,
                 lw_mask);
         } else {
             sdpa_ring<cb_qk_im, cb_identity_scale_in, cb_scale_in, Sq_chunk_t, Sk_chunk_t, DHt, scale_fp32>(

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
@@ -130,6 +130,9 @@ void kernel_main() {
         {cb_sum_B, cb_max_B, cb_out_im_B},  // cur
     };
 
+    const uint32_t last_active_ring_iter =
+        find_last_active_ring_iter(fused_op_indexer.seq, local_padded_Nt, logical_n / tt::constants::TILE_HEIGHT, L);
+
     for (uint32_t ring_iter = 0; ring_iter < ring_size; ++ring_iter) {
         uint32_t ring_id = fused_op_indexer.get_next_ring_id_and_sync();
         const bool do_joint_kv = ring_id == ring_size - 1;
@@ -181,7 +184,7 @@ void kernel_main() {
         }
 
         if constexpr (use_streaming_compute) {
-            const bool is_last_ring_iter = (ring_iter == ring_size - 1);
+            const bool is_last_ring_iter = (ring_iter == last_active_ring_iter);
             sdpa_ring_v2<
                 Sq_chunk_t,
                 Sk_chunk_t,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
@@ -51,7 +51,6 @@ void kernel_main() {
     constexpr uint32_t global_n_partial_col = get_compile_time_arg_val(32);
     constexpr uint32_t joint_l_partial_col = get_compile_time_arg_val(33);
     constexpr bool uniform_dataformat = get_compile_time_arg_val(34) == 1;
-    constexpr uint32_t q_per_core = get_compile_time_arg_val(35);
 
     // Lightweight mask: all mask tiles live in cb_mask_in (c_3).
     // Layout: [neginf(0)] [global_n_partial?(1)] [joint_l_partial?(1 or 2)]
@@ -70,6 +69,7 @@ void kernel_main() {
     uint32_t argidx = 0;
     const uint32_t global_q_start = get_arg_val<uint32_t>(argidx++);
     const uint32_t global_q_end = get_arg_val<uint32_t>(argidx++);
+    const uint32_t q_per_core = global_q_end - global_q_start;
 
     RingSDPAOpIndexer fused_op_indexer = RingSDPAOpIndexer(argidx);
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/fused_op_indexer.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/fused_op_indexer.hpp
@@ -6,83 +6,28 @@
 
 #include "api/compute/common.h"
 #include "api/debug/assert.h"
-#include <array>
+#include "ring_utils.hpp"
 
 struct RingSDPAOpIndexer {
-    constexpr static uint32_t num_directions = 2;
-
-    uint32_t ring_size = 0;
-    uint32_t ring_index = 0;
-
-    std::array<uint32_t, num_directions> received_inputs = {};
-    std::array<uint32_t, num_directions> expected_inputs = {};
-    uint32_t curr_dir = 1;
-    uint32_t curr_transfer_idx = 0;
-
+    RingIdSequencer seq;
     bool initialized = false;
 
     RingSDPAOpIndexer() {}
 
     RingSDPAOpIndexer(uint32_t& rt_args_idx) {
-        // Runtime args
-        this->ring_size = get_arg_val<uint32_t>(rt_args_idx++);
-        this->ring_index = get_arg_val<uint32_t>(rt_args_idx++);
+        uint32_t ring_size = get_arg_val<uint32_t>(rt_args_idx++);
+        uint32_t ring_index = get_arg_val<uint32_t>(rt_args_idx++);
         uint32_t forward_writes_expected = get_arg_val<uint32_t>(rt_args_idx++);
         uint32_t backward_writes_expected = get_arg_val<uint32_t>(rt_args_idx++);
 
         rt_args_idx += 2;  // Skip the semaphore addresses
 
-        this->expected_inputs[0] = backward_writes_expected;
-        this->expected_inputs[1] = forward_writes_expected;
-        this->received_inputs[0] = 0;
-        this->received_inputs[1] = 0;
-
-        /**
-         * 1: Data coming from backward_device -> this_device
-         * 0: Data coming from forward_device -> this_device
-         */
-        this->curr_dir = 0;  // Start backward
-        this->curr_transfer_idx = 0;
-
-        this->initialized = true;
+        seq = RingIdSequencer(ring_index, ring_size, backward_writes_expected, forward_writes_expected);
+        initialized = true;
     }
 
     uint32_t get_next_ring_id_and_sync() {
-        ASSERT(this->initialized);
-        // Behave differently for first iteration and subsequent iterations
-
-        uint32_t this_direction_inputs = this->received_inputs[this->curr_dir];
-        uint32_t sender_ring_id;
-        if (this->curr_transfer_idx == 0) {
-            // First iteration, waiting on local slice
-            sender_ring_id = this->ring_index;
-        } else {
-            this->received_inputs[this->curr_dir] += 1;
-            if (this->curr_dir == 1) {
-                // receiving from the forward direction. go backwards by that many targets
-                sender_ring_id =
-                    (this->ring_index - this->received_inputs[this->curr_dir] + this->ring_size) % this->ring_size;
-            } else {
-                // receiving from backward direction. go forward by that many targets
-                sender_ring_id = (this->ring_index + this->received_inputs[this->curr_dir]) % this->ring_size;
-            }
-        }
-
-        if (this->curr_transfer_idx == 0) {
-            if (this->expected_inputs[this->curr_dir] == 0) {
-                // On first transfer, only switch directions if there are no inputs in forward direction
-                this->curr_dir = 1 - this->curr_dir;
-            }
-        } else {
-            // Flip direction if we haven't received all inputs in that direction
-            uint32_t next_dir = 1 - this->curr_dir;
-            if (this->received_inputs[next_dir] < this->expected_inputs[next_dir]) {
-                this->curr_dir = next_dir;
-            }
-        }
-
-        this->curr_transfer_idx++;
-
-        return sender_ring_id;
+        ASSERT(initialized);
+        return seq.get_next_ring_id([](uint32_t, uint32_t) {});
     }
 };

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/fused_op_receiver.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/fused_op_receiver.hpp
@@ -6,102 +6,42 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/debug/assert.h"
+#include "ring_utils.hpp"
 #include <array>
 
 struct RingSDPAOpReceiver {
-    constexpr static uint32_t num_directions = 2;
-    bool wait_for_op_signal = 0;
-
-    uint32_t ring_size = 0;
-    uint32_t ring_index = 0;
-
-    std::array<volatile tt_l1_ptr uint32_t*, num_directions> signal_op_semaphore_addr_ptrs = {};
-    std::array<uint32_t, num_directions> received_inputs = {};
-    std::array<uint32_t, num_directions> expected_inputs = {};
-    uint32_t curr_dir = 1;
-    uint32_t curr_transfer_idx = 0;
-
+    RingIdSequencer seq;
+    bool wait_for_op_signal = false;
+    std::array<volatile tt_l1_ptr uint32_t*, 2> signal_op_semaphore_addr_ptrs = {};
     bool initialized = false;
 
     RingSDPAOpReceiver() {}
 
     RingSDPAOpReceiver(bool wait_for_op_signal, uint32_t& rt_args_idx) : wait_for_op_signal(wait_for_op_signal) {
-        // Runtime args
-        this->ring_size = get_arg_val<uint32_t>(rt_args_idx++);
-        this->ring_index = get_arg_val<uint32_t>(rt_args_idx++);
+        uint32_t ring_size = get_arg_val<uint32_t>(rt_args_idx++);
+        uint32_t ring_index = get_arg_val<uint32_t>(rt_args_idx++);
         uint32_t forward_writes_expected = get_arg_val<uint32_t>(rt_args_idx++);
         uint32_t backward_writes_expected = get_arg_val<uint32_t>(rt_args_idx++);
 
-        this->expected_inputs[0] = backward_writes_expected;
-        this->expected_inputs[1] = forward_writes_expected;
-        this->received_inputs[0] = 0;
-        this->received_inputs[1] = 0;
-
         if (this->wait_for_op_signal) {
             // First semaphore is AllGather's BWD semaphore. It belongs to direction 1.
-            this->signal_op_semaphore_addr_ptrs[1] =
+            signal_op_semaphore_addr_ptrs[1] =
                 reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(get_arg_val<uint32_t>(rt_args_idx++)));
             // Second is AllGather's FWD semaphore. It belongs to direction 0.
-            this->signal_op_semaphore_addr_ptrs[0] =
+            signal_op_semaphore_addr_ptrs[0] =
                 reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(get_arg_val<uint32_t>(rt_args_idx++)));
         }
 
-        /**
-         * 1: Data coming from backward_device -> this_device
-         * 0: Data coming from forward_device -> this_device
-         */
-        this->curr_dir = 0;  // Start backward
-        this->curr_transfer_idx = 0;
-
-        this->initialized = true;
+        seq = RingIdSequencer(ring_index, ring_size, backward_writes_expected, forward_writes_expected);
+        initialized = true;
     }
 
     uint32_t get_next_ring_id_and_sync() {
-        ASSERT(this->initialized);
-        // Behave differently for first iteration and subsequent iterations
-
-        uint32_t this_direction_inputs = this->received_inputs[this->curr_dir];
-        uint32_t sender_ring_id;
-        uint32_t sem_wait_val;
-        if (this->curr_transfer_idx == 0) {
-            // First iteration reads from local slice, so no synchronization is needed.
-            sender_ring_id = this->ring_index;
-            sem_wait_val = 0;
-        } else {
-            this->received_inputs[this->curr_dir] += 1;
-            if (this->curr_dir == 1) {
-                // receiving from the forward direction. go backwards by that many targets
-                sender_ring_id =
-                    (this->ring_index - this->received_inputs[this->curr_dir] + this->ring_size) % this->ring_size;
-                sem_wait_val = this->received_inputs[this->curr_dir];
-            } else {
-                // receiving from backward direction. go forward by that many targets
-                sender_ring_id = (this->ring_index + this->received_inputs[this->curr_dir]) % this->ring_size;
-                sem_wait_val = this->received_inputs[this->curr_dir] + 1;
+        ASSERT(initialized);
+        return seq.get_next_ring_id([&](uint32_t dir, uint32_t val) {
+            if (this->wait_for_op_signal) {
+                noc_semaphore_wait_min(this->signal_op_semaphore_addr_ptrs[dir], val);
             }
-        }
-
-        // Wait for a semaphore signal to start processing the tensor slice
-
-        if (this->wait_for_op_signal) {
-            noc_semaphore_wait_min(this->signal_op_semaphore_addr_ptrs[this->curr_dir], sem_wait_val);
-        }
-
-        if (this->curr_transfer_idx == 0) {
-            if (this->expected_inputs[this->curr_dir] == 0) {
-                // On first transfer, only switch directions if there are no inputs in forward direction
-                this->curr_dir = 1 - this->curr_dir;
-            }
-        } else {
-            // Flip direction if we haven't received all inputs in that direction
-            uint32_t next_dir = 1 - this->curr_dir;
-            if (this->received_inputs[next_dir] < this->expected_inputs[next_dir]) {
-                this->curr_dir = next_dir;
-            }
-        }
-
-        this->curr_transfer_idx++;
-
-        return sender_ring_id;
+        });
     }
 };

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
@@ -8,62 +8,274 @@
 #include "dataflow_common.hpp"
 #include "fused_op_receiver.hpp"
 
+// Eager-path reader: reads the previous ring iteration's normalized output and LSE from DRAM.
+// Used by the non-streaming (old sdpa_ring) path for sigmoid-based inter-iteration merging.
+// Pushes output tiles into cb_prev_out (c_7) and LSE tiles into cb_lse_in (c_6).
+//
+// @param cat_out_generator   Address generator for the output DRAM tensor (local or joint)
+// @param stats_writer        TensorAccessor for the stats DRAM tensor
+// @param stats_tile_logical  Tile shape of the stats tensor (for address computation)
+// @param nb                  Batch index
+// @param nq                  Head index
+// @param Sq_chunk_t          Q chunk size in tiles
+// @param out_slice           Row/col tile range in the output tensor for this Q chunk
+// @param end_seq_tile        Last valid sequence tile (for padding-aware reads)
+// @param stats_seq_start_tile  First tile row in the stats tensor for this Q chunk
+// @param stats_seq_end_tile    One-past-last tile row (clamped to avoid reading past padding)
+// @param cb_prev_out         CB to push previous output tiles into (c_7, read by compute)
+// @param cb_lse_in           CB to push previous LSE tiles into (c_6, read by compute)
+// @param tile_bytes          Output tile size in bytes
+// @param stats_tile_bytes    Stats tile size in bytes
 template <typename ReaderType, typename TensorAccessorType>
 void read_prev_output_and_lse(
     const PaddedAddrGenerator<ReaderType>& cat_out_generator,
-    const TensorAccessorType& lse_writer,
-    const TensorTileShape& lse_tile_logical,
+    const TensorAccessorType& stats_writer,
+    const TensorTileShape& stats_tile_logical,
     const uint32_t nb,
     const uint32_t nq,
     const uint32_t Sq_chunk_t,
     const Slice out_slice,
     const uint32_t end_seq_tile,
-    const uint32_t lse_seq_start_tile,
-    const uint32_t lse_seq_end_tile,
+    const uint32_t stats_seq_start_tile,
+    const uint32_t stats_seq_end_tile,
     const uint32_t cb_prev_out,
     const uint32_t cb_lse_in,
     const uint32_t tile_bytes,
-    const uint32_t lse_tile_bytes) {
+    const uint32_t stats_tile_bytes) {
     // Read previous output for this Q chunk
     read_block(cat_out_generator, out_slice, end_seq_tile, cb_prev_out, tile_bytes, false);
 
     // Read previous LSE for this Q chunk
     cb_reserve_back(cb_lse_in, Sq_chunk_t);
     uint32_t lse_addr = get_write_ptr(cb_lse_in);
-    for (uint32_t i = lse_seq_start_tile; i < lse_seq_end_tile; i++) {
-        noc_async_read_tile(lse_tile_logical.id_of(nb, nq, i, 0), lse_writer, lse_addr);
-        lse_addr += lse_tile_bytes;
+    for (uint32_t i = stats_seq_start_tile; i < stats_seq_end_tile; i++) {
+        noc_async_read_tile(stats_tile_logical.id_of(nb, nq, i, 0), stats_writer, lse_addr);
+        lse_addr += stats_tile_bytes;
     }
     noc_async_read_barrier();
     cb_push_back(cb_lse_in, Sq_chunk_t);
 }
 
+// Deferred-norm reader: restores raw (un-normalized) accumulators from DRAM for multi-Q-chunk.
+// Reads output, running max, and running sum — the full online-softmax state needed to continue
+// accumulation from a previous ring iteration.
+// Pushes into: cb_prev_out (c_7), cb_max_in (c_6), cb_sum_in (c_11).
+//
+// @param cat_out_generator   Address generator for the output DRAM tensor (local or joint)
+// @param stats_writer        TensorAccessor for the stats DRAM tensor
+// @param stats_tile_logical  Tile shape of the stats tensor
+// @param nb                  Batch index
+// @param nq                  Head index
+// @param Sq_chunk_t          Q chunk size in tiles
+// @param out_slice           Row/col tile range in the output tensor for this Q chunk
+// @param end_seq_tile        Last valid sequence tile (for padding-aware reads)
+// @param stats_seq_start_tile  First tile row in stats tensor for this Q chunk's max/sum
+// @param stats_seq_end_tile    One-past-last tile row (clamped to sequence bounds)
+// @param sum_offset          Row offset into stats tensor where sum tiles start (= local_padded_Nt + Lt)
+// @param cb_prev_out         CB for previous output tiles (c_7)
+// @param cb_max_in           CB for previous max tiles (c_6)
+// @param cb_sum_in           CB for previous sum tiles (c_11)
+// @param tile_bytes          Output tile size in bytes
+// @param stats_tile_bytes    Stats tile size in bytes
 template <typename ReaderType, typename TensorAccessorType>
-void write_output_and_lse(
+void read_prev_accumulators(
     const PaddedAddrGenerator<ReaderType>& cat_out_generator,
-    const TensorAccessorType& lse_writer,
-    const TensorTileShape& lse_tile_logical,
+    const TensorAccessorType& stats_writer,
+    const TensorTileShape& stats_tile_logical,
     const uint32_t nb,
     const uint32_t nq,
     const uint32_t Sq_chunk_t,
     const Slice out_slice,
     const uint32_t end_seq_tile,
-    const uint32_t lse_seq_start_tile,
-    const uint32_t lse_seq_end_tile,
+    const uint32_t stats_seq_start_tile,
+    const uint32_t stats_seq_end_tile,
+    const uint32_t sum_offset,
+    const uint32_t cb_prev_out,
+    const uint32_t cb_max_in,
+    const uint32_t cb_sum_in,
+    const uint32_t tile_bytes,
+    const uint32_t stats_tile_bytes) {
+    // Read previous output
+    read_block(cat_out_generator, out_slice, end_seq_tile, cb_prev_out, tile_bytes, false);
+
+    // Read max from stats DRAM (first half)
+    cb_reserve_back(cb_max_in, Sq_chunk_t);
+    uint32_t max_addr = get_write_ptr(cb_max_in);
+    for (uint32_t i = stats_seq_start_tile; i < stats_seq_end_tile; i++) {
+        noc_async_read_tile(stats_tile_logical.id_of(nb, nq, i, 0), stats_writer, max_addr);
+        max_addr += stats_tile_bytes;
+    }
+    noc_async_read_barrier();
+    cb_push_back(cb_max_in, Sq_chunk_t);
+
+    // Read sum from stats DRAM (second half, offset by sum_offset)
+    cb_reserve_back(cb_sum_in, Sq_chunk_t);
+    uint32_t sum_addr = get_write_ptr(cb_sum_in);
+    for (uint32_t i = stats_seq_start_tile; i < stats_seq_end_tile; i++) {
+        noc_async_read_tile(stats_tile_logical.id_of(nb, nq, sum_offset + i, 0), stats_writer, sum_addr);
+        sum_addr += stats_tile_bytes;
+    }
+    noc_async_read_barrier();
+    cb_push_back(cb_sum_in, Sq_chunk_t);
+}
+
+// Deferred-norm writer: saves raw accumulators to DRAM for multi-Q-chunk between ring iterations.
+// Drains output, running max, and running sum from compute CBs to the DRAM tensors.
+// Reads from: cb_out (c_16), cb_max_out (c_17), cb_sum_out (c_10).
+//
+// @param cat_out_generator   Address generator for the output DRAM tensor (local or joint)
+// @param stats_writer        TensorAccessor for the stats DRAM tensor
+// @param stats_tile_logical  Tile shape of the stats tensor
+// @param nb                  Batch index
+// @param nq                  Head index
+// @param Sq_chunk_t          Q chunk size in tiles
+// @param out_slice           Row/col tile range in the output tensor for this Q chunk
+// @param end_seq_tile        Last valid sequence tile
+// @param stats_seq_start_tile  First tile row in stats tensor for this Q chunk's max/sum
+// @param stats_seq_end_tile    One-past-last tile row (clamped to sequence bounds)
+// @param sum_offset          Row offset into stats tensor where sum tiles start (= local_padded_Nt + Lt)
+// @param cb_out              CB to drain output tiles from (c_16, pushed by compute)
+// @param cb_max_out          CB to drain max tiles from (c_17, pushed by compute)
+// @param cb_sum_out          CB to drain sum tiles from (c_10, pushed by compute)
+// @param tile_bytes          Output tile size in bytes
+// @param stats_tile_bytes    Stats tile size in bytes
+template <typename ReaderType, typename TensorAccessorType>
+void write_accumulators(
+    const PaddedAddrGenerator<ReaderType>& cat_out_generator,
+    const TensorAccessorType& stats_writer,
+    const TensorTileShape& stats_tile_logical,
+    const uint32_t nb,
+    const uint32_t nq,
+    const uint32_t Sq_chunk_t,
+    const Slice out_slice,
+    const uint32_t end_seq_tile,
+    const uint32_t stats_seq_start_tile,
+    const uint32_t stats_seq_end_tile,
+    const uint32_t sum_offset,
+    const uint32_t cb_out,
+    const uint32_t cb_max_out,
+    const uint32_t cb_sum_out,
+    const uint32_t tile_bytes,
+    const uint32_t stats_tile_bytes) {
+    // Write output
+    write_block(cat_out_generator, out_slice, end_seq_tile, cb_out, tile_bytes);
+
+    // Write max to stats DRAM (first half)
+    cb_wait_front(cb_max_out, Sq_chunk_t);
+    uint32_t max_write_addr = get_read_ptr(cb_max_out);
+    for (uint32_t i = stats_seq_start_tile; i < stats_seq_end_tile; i++) {
+        noc_async_write_tile(stats_tile_logical.id_of(nb, nq, i, 0), stats_writer, max_write_addr);
+        max_write_addr += stats_tile_bytes;
+    }
+    cb_pop_front(cb_max_out, Sq_chunk_t);
+
+    // Write sum to stats DRAM (second half, offset by sum_offset)
+    cb_wait_front(cb_sum_out, Sq_chunk_t);
+    uint32_t sum_write_addr = get_read_ptr(cb_sum_out);
+    for (uint32_t i = stats_seq_start_tile; i < stats_seq_end_tile; i++) {
+        noc_async_write_tile(stats_tile_logical.id_of(nb, nq, sum_offset + i, 0), stats_writer, sum_write_addr);
+        sum_write_addr += stats_tile_bytes;
+    }
+    cb_pop_front(cb_sum_out, Sq_chunk_t);
+}
+
+// Eager-path writer: writes normalized output and LSE to DRAM every ring iteration.
+// Used by the non-streaming (old sdpa_ring) path.
+// Reads from: cb_out (c_16), cb_lse_out (c_17).
+//
+// @param cat_out_generator   Address generator for the output DRAM tensor (local or joint)
+// @param stats_writer        TensorAccessor for the stats DRAM tensor
+// @param stats_tile_logical  Tile shape of the stats tensor
+// @param nb                  Batch index
+// @param nq                  Head index
+// @param Sq_chunk_t          Q chunk size in tiles
+// @param out_slice           Row/col tile range in the output tensor for this Q chunk
+// @param end_seq_tile        Last valid sequence tile
+// @param stats_seq_start_tile  First tile row in stats tensor for this Q chunk's LSE
+// @param stats_seq_end_tile    One-past-last tile row (clamped to sequence bounds)
+// @param cb_out              CB to drain output tiles from (c_16)
+// @param cb_lse_out          CB to drain LSE tiles from (c_17)
+// @param tile_bytes          Output tile size in bytes
+// @param stats_tile_bytes    Stats tile size in bytes
+template <typename ReaderType, typename TensorAccessorType>
+void write_output_and_lse(
+    const PaddedAddrGenerator<ReaderType>& cat_out_generator,
+    const TensorAccessorType& stats_writer,
+    const TensorTileShape& stats_tile_logical,
+    const uint32_t nb,
+    const uint32_t nq,
+    const uint32_t Sq_chunk_t,
+    const Slice out_slice,
+    const uint32_t end_seq_tile,
+    const uint32_t stats_seq_start_tile,
+    const uint32_t stats_seq_end_tile,
     const uint32_t cb_out,
     const uint32_t cb_lse_out,
     const uint32_t tile_bytes,
-    const uint32_t lse_tile_bytes) {
+    const uint32_t stats_tile_bytes) {
     write_block(cat_out_generator, out_slice, end_seq_tile, cb_out, tile_bytes);
 
     cb_wait_front(cb_lse_out, Sq_chunk_t);
     uint32_t lse_addr = get_read_ptr(cb_lse_out);
-    for (uint32_t i = lse_seq_start_tile; i < lse_seq_end_tile; i++) {
-        noc_async_write_tile(lse_tile_logical.id_of(nb, nq, i, 0), lse_writer, lse_addr);
-        lse_addr += lse_tile_bytes;
+    for (uint32_t i = stats_seq_start_tile; i < stats_seq_end_tile; i++) {
+        noc_async_write_tile(stats_tile_logical.id_of(nb, nq, i, 0), stats_writer, lse_addr);
+        lse_addr += stats_tile_bytes;
     }
     noc_async_writes_flushed();
     cb_pop_front(cb_lse_out, Sq_chunk_t);
+}
+
+struct QChunkInfo {
+    bool is_joint_q;
+    Slice out_slice;
+    uint32_t end_seq_tile;
+    uint32_t stats_seq_start_tile;
+    uint32_t stats_seq_end_tile;
+};
+
+// Compute output slice and stats tile range for one Q chunk.
+// is_joint_q distinguishes local-sequence Q chunks from joint-context Q chunks,
+// which write to different output tensors and have different causal extents.
+//
+// @param q_chunk             Q chunk index within [0, num_q_chunks) (local then joint)
+// @param nb                  Batch index
+// @param nq                  Head index
+// @param ring_id             Device ID that owns the current ring iteration's KV shard
+// @param num_local_q_chunks  Number of Q chunks from the local sequence (joint starts after)
+// @param Sq_chunk_t          Q chunk size in tiles
+// @param DHt                 Head dimension in tiles
+// @param Lt                  Joint (cross-attention context) sequence length in tiles
+// @param local_padded_Nt     Per-device padded local sequence length in tiles
+inline QChunkInfo get_q_chunk_info(
+    const uint32_t q_chunk,
+    const uint32_t nb,
+    const uint32_t nq,
+    const uint32_t ring_id,
+    const uint32_t num_local_q_chunks,
+    const uint32_t Sq_chunk_t,
+    const uint32_t DHt,
+    const uint32_t Lt,
+    const uint32_t local_padded_Nt) {
+    QChunkInfo info;
+    info.is_joint_q = q_chunk >= num_local_q_chunks;
+    if (info.is_joint_q) {
+        const uint32_t joint_out_row_start_tile = (q_chunk - num_local_q_chunks) * Sq_chunk_t;
+        info.out_slice = Slice(nb, nq, joint_out_row_start_tile, joint_out_row_start_tile + Sq_chunk_t, 0, DHt);
+        info.end_seq_tile = Lt;
+        info.stats_seq_start_tile = local_padded_Nt + (q_chunk - num_local_q_chunks) * Sq_chunk_t;
+        info.stats_seq_end_tile = info.stats_seq_start_tile + Sq_chunk_t;
+        info.stats_seq_start_tile = std::min(info.stats_seq_start_tile, local_padded_Nt + Lt);
+        info.stats_seq_end_tile = std::min(info.stats_seq_end_tile, local_padded_Nt + Lt);
+    } else {
+        const uint32_t out_row_start_tile = q_chunk * Sq_chunk_t;
+        info.out_slice = Slice(nb, nq, out_row_start_tile, out_row_start_tile + Sq_chunk_t, 0, DHt);
+        info.end_seq_tile = local_padded_Nt * (ring_id + 1);
+        info.stats_seq_start_tile = q_chunk * Sq_chunk_t;
+        info.stats_seq_end_tile = info.stats_seq_start_tile + Sq_chunk_t;
+        info.stats_seq_start_tile = std::min(info.stats_seq_start_tile, local_padded_Nt);
+        info.stats_seq_end_tile = std::min(info.stats_seq_end_tile, local_padded_Nt);
+    }
+    return info;
 }
 
 void kernel_main() {
@@ -89,15 +301,16 @@ void kernel_main() {
     constexpr uint32_t ring_size = get_compile_time_arg_val(19);
     constexpr uint32_t global_n_partial_col = get_compile_time_arg_val(20);
     constexpr uint32_t joint_l_partial_col = get_compile_time_arg_val(21);
+    constexpr bool use_streaming_compute = get_compile_time_arg_val(22) == 1;
 
-    constexpr auto out_args = TensorAccessorArgs<22>();
+    constexpr auto out_args = TensorAccessorArgs<23>();
     constexpr auto joint_out_args = TensorAccessorArgs<out_args.next_compile_time_args_offset()>();
-    constexpr auto lse_args = TensorAccessorArgs<joint_out_args.next_compile_time_args_offset()>();
+    constexpr auto stats_args = TensorAccessorArgs<joint_out_args.next_compile_time_args_offset()>();
 
     uint32_t argidx = 0;
     const uint32_t out_addr = get_arg_val<uint32_t>(argidx++);
     const uint32_t joint_out_addr = get_arg_val<uint32_t>(argidx++);
-    const uint32_t lse_addr = get_arg_val<uint32_t>(argidx++);
+    const uint32_t stats_addr = get_arg_val<uint32_t>(argidx++);
     const uint32_t global_q_start = get_arg_val<uint32_t>(argidx++);
     const uint32_t global_q_end = get_arg_val<uint32_t>(argidx++);
 
@@ -105,25 +318,33 @@ void kernel_main() {
         false, /* wait_for_op_signal */
         argidx);
 
-    constexpr uint32_t cb_lse_in = tt::CBIndex::c_6;
+    // c_6/c_17 carry softmax statistics between compute and writer for DRAM round-trips.
+    // Aliased by role: cb_max_* for deferred norm, cb_lse_* for eager norm.
+    constexpr uint32_t cb_max_in = tt::CBIndex::c_6;  // deferred norm: DRAM → compute (running max)
+    constexpr uint32_t cb_lse_in = tt::CBIndex::c_6;  // eager norm: DRAM → compute (LSE)
     constexpr uint32_t cb_prev_out = tt::CBIndex::c_7;
     constexpr uint32_t cb_out = tt::CBIndex::c_16;
-    constexpr uint32_t cb_lse_out = tt::CBIndex::c_17;
+    constexpr uint32_t cb_max_out = tt::CBIndex::c_17;  // deferred norm: compute → DRAM (running max)
+    constexpr uint32_t cb_lse_out = tt::CBIndex::c_17;  // eager norm: compute → DRAM (LSE)
     constexpr uint32_t cb_mask_in = tt::CBIndex::c_3;
+    constexpr uint32_t cb_sum_out = tt::CBIndex::c_10;
+    constexpr uint32_t cb_sum_in = tt::CBIndex::c_11;
     constexpr uint32_t tile_bytes = get_tile_size(cb_out);
-    constexpr uint32_t lse_tile_bytes = get_tile_size(cb_lse_in);
+    constexpr uint32_t stats_tile_bytes = get_tile_size(cb_max_in);
 
     const auto out_writer = TensorAccessor(out_args, out_addr, tile_bytes);
     const auto joint_out_writer = TensorAccessor(joint_out_args, joint_out_addr, tile_bytes);
-    const auto lse_writer = TensorAccessor(lse_args, lse_addr, lse_tile_bytes);
+    const auto stats_writer = TensorAccessor(stats_args, stats_addr, stats_tile_bytes);
 
     const auto output_tile_logical = TensorTileShape(B, NH, local_padded_Nt, DHt);
     const auto joint_tile_logical = TensorTileShape(B, NH, Lt, DHt);
-    const auto lse_tile_logical = TensorTileShape(B, NH, local_padded_Nt + Lt, 1);
+    // stats tensor is 2× the sequence length: first half stores max (used by both eager and
+    // deferred-norm paths), second half stores sum (deferred-norm only).
+    const auto stats_tile_logical = TensorTileShape(B, NH, (local_padded_Nt + Lt) * 2, 1);
 
     const auto out_generator = PaddedAddrGenerator(out_writer, output_tile_logical);
     const auto joint_out_generator = PaddedAddrGenerator(joint_out_writer, joint_tile_logical);
-    const auto lse_generator = PaddedAddrGenerator(lse_writer, lse_tile_logical);
+    const auto stats_generator = PaddedAddrGenerator(stats_writer, stats_tile_logical);
 
     constexpr uint32_t cb_scale_in = tt::CBIndex::c_4;
     constexpr uint32_t cb_col_identity = tt::CBIndex::c_8;
@@ -192,76 +413,120 @@ void kernel_main() {
         const bool joint_n_needs_masking = L % (Sk_chunk_t * tt::constants::TILE_HEIGHT) != 0;
         const bool ring_iter_needs_joint_n_mask = joint_n_needs_masking && do_joint_kv;
 
-        for (uint32_t global_q_chunk = global_q_start; global_q_chunk < global_q_end; ++global_q_chunk) {
-            // global_q_chunk is index into `B * NH * num_q_chunks`. Need to get nb, nq, q_chunk from this.
-            const uint32_t nb = global_q_chunk / (NH * num_q_chunks);
-            const uint32_t nq = (global_q_chunk % (NH * num_q_chunks)) / num_q_chunks;
-            const uint32_t q_chunk = global_q_chunk % num_q_chunks;
+        // Deferred normalization is always paired with streaming compute.
+        constexpr bool use_deferred_norm = use_streaming_compute;
+        if constexpr (use_deferred_norm) {
+            // Deferred norm: accumulates across ring iterations with exponential rescaling.
+            // Single Q-chunk: accumulators persist in L1, write final output on last ring_iter.
+            // Multi Q-chunk: raw accumulators round-trip through DRAM between ring iterations.
+            const bool is_last_ring_iter = (ring_iter == ring_size - 1);
+            const bool single_q_chunk = (global_q_end - global_q_start == 1);
 
-            const bool is_joint_q = q_chunk >= num_local_q_chunks;
-            Slice out_slice;
-            uint32_t end_seq_tile;
-            if (is_joint_q) {
-                const uint32_t joint_out_row_start_tile = (q_chunk - num_local_q_chunks) * Sq_chunk_t;
-                out_slice = Slice(nb, nq, joint_out_row_start_tile, joint_out_row_start_tile + Sq_chunk_t, 0, DHt);
-                end_seq_tile = Lt;
-            } else {
-                const uint32_t out_row_start_tile = q_chunk * Sq_chunk_t;
-                out_slice = Slice(nb, nq, out_row_start_tile, out_row_start_tile + Sq_chunk_t, 0, DHt);
-                end_seq_tile = local_padded_Nt * (ring_id + 1);
+            for (uint32_t global_q_chunk = global_q_start; global_q_chunk < global_q_end; ++global_q_chunk) {
+                const uint32_t nb = global_q_chunk / (NH * num_q_chunks);
+                const uint32_t nq = (global_q_chunk % (NH * num_q_chunks)) / num_q_chunks;
+                const uint32_t q_chunk = global_q_chunk % num_q_chunks;
+
+                const auto qi = get_q_chunk_info(
+                    q_chunk, nb, nq, ring_id, num_local_q_chunks, Sq_chunk_t, DHt, Lt, local_padded_Nt);
+
+                constexpr uint32_t sum_offset = local_padded_Nt + Lt;
+
+                if (!single_q_chunk && ring_iter > 0) {
+                    read_prev_accumulators(
+                        qi.is_joint_q ? joint_out_generator : out_generator,
+                        stats_writer,
+                        stats_tile_logical,
+                        nb,
+                        nq,
+                        Sq_chunk_t,
+                        qi.out_slice,
+                        qi.end_seq_tile,
+                        qi.stats_seq_start_tile,
+                        qi.stats_seq_end_tile,
+                        sum_offset,
+                        cb_prev_out,
+                        cb_max_in,
+                        cb_sum_in,
+                        tile_bytes,
+                        stats_tile_bytes);
+                }
+
+                if (is_last_ring_iter) {
+                    write_block(
+                        qi.is_joint_q ? joint_out_generator : out_generator,
+                        qi.out_slice,
+                        qi.end_seq_tile,
+                        cb_out,
+                        tile_bytes);
+                } else if (!single_q_chunk) {
+                    write_accumulators(
+                        qi.is_joint_q ? joint_out_generator : out_generator,
+                        stats_writer,
+                        stats_tile_logical,
+                        nb,
+                        nq,
+                        Sq_chunk_t,
+                        qi.out_slice,
+                        qi.end_seq_tile,
+                        qi.stats_seq_start_tile,
+                        qi.stats_seq_end_tile,
+                        sum_offset,
+                        cb_out,
+                        cb_max_out,
+                        cb_sum_out,
+                        tile_bytes,
+                        stats_tile_bytes);
+                }
             }
+            noc_async_write_barrier();
+        } else {
+            for (uint32_t global_q_chunk = global_q_start; global_q_chunk < global_q_end; ++global_q_chunk) {
+                // global_q_chunk is index into `B * NH * num_q_chunks`. Need to get nb, nq, q_chunk from this.
+                const uint32_t nb = global_q_chunk / (NH * num_q_chunks);
+                const uint32_t nq = (global_q_chunk % (NH * num_q_chunks)) / num_q_chunks;
+                const uint32_t q_chunk = global_q_chunk % num_q_chunks;
 
-            // If not on the first iteration, read LSE input and previous output chunk.
-            // No race condition because writer kernel writes previous output before reading it again
+                const auto qi = get_q_chunk_info(
+                    q_chunk, nb, nq, ring_id, num_local_q_chunks, Sq_chunk_t, DHt, Lt, local_padded_Nt);
 
-            uint32_t lse_seq_start_tile;
-            uint32_t lse_seq_end_tile;
-            if (is_joint_q) {
-                lse_seq_start_tile = local_padded_Nt + (q_chunk - num_local_q_chunks) * Sq_chunk_t;
-                lse_seq_end_tile = lse_seq_start_tile + Sq_chunk_t;
-                lse_seq_start_tile = std::min(lse_seq_start_tile, local_padded_Nt + Lt);
-                lse_seq_end_tile = std::min(lse_seq_end_tile, local_padded_Nt + Lt);
-            } else {
-                lse_seq_start_tile = q_chunk * Sq_chunk_t;
-                lse_seq_end_tile = lse_seq_start_tile + Sq_chunk_t;
-                lse_seq_start_tile = std::min(lse_seq_start_tile, local_padded_Nt);
-                lse_seq_end_tile = std::min(lse_seq_end_tile, local_padded_Nt);
-            }
+                // If not on the first iteration, read LSE and previous output chunk.
+                // No race condition because writer kernel writes previous output before reading it again
+                if (ring_iter > 0) {
+                    read_prev_output_and_lse(
+                        qi.is_joint_q ? joint_out_generator : out_generator,
+                        stats_writer,
+                        stats_tile_logical,
+                        nb,
+                        nq,
+                        Sq_chunk_t,
+                        qi.out_slice,
+                        qi.end_seq_tile,
+                        qi.stats_seq_start_tile,
+                        qi.stats_seq_end_tile,
+                        cb_prev_out,
+                        cb_lse_in,
+                        tile_bytes,
+                        stats_tile_bytes);
+                }
 
-            if (ring_iter > 0) {
-                read_prev_output_and_lse(
-                    is_joint_q ? joint_out_generator : out_generator,
-                    lse_writer,
-                    lse_tile_logical,
+                write_output_and_lse(
+                    qi.is_joint_q ? joint_out_generator : out_generator,
+                    stats_writer,
+                    stats_tile_logical,
                     nb,
                     nq,
                     Sq_chunk_t,
-                    out_slice,
-                    end_seq_tile,
-                    lse_seq_start_tile,
-                    lse_seq_end_tile,
-                    cb_prev_out,
-                    cb_lse_in,
+                    qi.out_slice,
+                    qi.end_seq_tile,
+                    qi.stats_seq_start_tile,
+                    qi.stats_seq_end_tile,
+                    cb_out,
+                    cb_lse_out,
                     tile_bytes,
-                    lse_tile_bytes);
+                    stats_tile_bytes);
             }
-
-            write_output_and_lse(
-                is_joint_q ? joint_out_generator : out_generator,
-                lse_writer,
-                lse_tile_logical,
-                nb,
-                nq,
-                Sq_chunk_t,
-                out_slice,
-                end_seq_tile,
-                lse_seq_start_tile,
-                lse_seq_end_tile,
-                cb_out,
-                cb_lse_out,
-                tile_bytes,
-                lse_tile_bytes);
+            noc_async_write_barrier();  // Ensure writes of output and LSE complete before next iteration
         }
-        noc_async_write_barrier();  // Ensure writes of output and LSE complete before next iteration
     }
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
@@ -167,6 +167,7 @@ void write_accumulators(
         noc_async_write_tile(stats_tile_logical.id_of(nb, nq, i, 0), stats_writer, max_write_addr);
         max_write_addr += stats_tile_bytes;
     }
+    noc_async_writes_flushed();
     cb_pop_front(cb_max_out, Sq_chunk_t);
 
     // Write sum to stats DRAM (second half, offset by sum_offset)
@@ -176,6 +177,7 @@ void write_accumulators(
         noc_async_write_tile(stats_tile_logical.id_of(nb, nq, sum_offset + i, 0), stats_writer, sum_write_addr);
         sum_write_addr += stats_tile_bytes;
     }
+    noc_async_writes_flushed();
     cb_pop_front(cb_sum_out, Sq_chunk_t);
 }
 
@@ -344,6 +346,7 @@ void kernel_main() {
 
     const auto out_generator = PaddedAddrGenerator(out_writer, output_tile_logical);
     const auto joint_out_generator = PaddedAddrGenerator(joint_out_writer, joint_tile_logical);
+
     constexpr uint32_t cb_scale_in = tt::CBIndex::c_4;
     constexpr uint32_t cb_col_identity = tt::CBIndex::c_8;
     constexpr uint32_t cb_identity_scale_in = tt::CBIndex::c_5;
@@ -361,6 +364,9 @@ void kernel_main() {
     if constexpr (needs_lightweight_mask) {
         generate_lightweight_mask_tiles<global_n_partial_col, joint_l_partial_col, cb_mask_in>();
     }
+
+    const uint32_t last_active_ring_iter =
+        find_last_active_ring_iter(fused_op_receiver.seq, local_padded_Nt, logical_n / tt::constants::TILE_HEIGHT, L);
 
     for (uint32_t ring_iter = 0; ring_iter < ring_size; ++ring_iter) {
         uint32_t ring_id = fused_op_receiver.get_next_ring_id_and_sync();
@@ -417,7 +423,7 @@ void kernel_main() {
             // Deferred norm: accumulates across ring iterations with exponential rescaling.
             // Single Q-chunk: accumulators persist in L1, write final output on last ring_iter.
             // Multi Q-chunk: raw accumulators round-trip through DRAM between ring iterations.
-            const bool is_last_ring_iter = (ring_iter == ring_size - 1);
+            const bool is_last_ring_iter = (ring_iter == last_active_ring_iter);
             const bool single_q_chunk = (global_q_end - global_q_start == 1);
 
             for (uint32_t global_q_chunk = global_q_start; global_q_chunk < global_q_end; ++global_q_chunk) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
@@ -344,8 +344,6 @@ void kernel_main() {
 
     const auto out_generator = PaddedAddrGenerator(out_writer, output_tile_logical);
     const auto joint_out_generator = PaddedAddrGenerator(joint_out_writer, joint_tile_logical);
-    const auto stats_generator = PaddedAddrGenerator(stats_writer, stats_tile_logical);
-
     constexpr uint32_t cb_scale_in = tt::CBIndex::c_4;
     constexpr uint32_t cb_col_identity = tt::CBIndex::c_8;
     constexpr uint32_t cb_identity_scale_in = tt::CBIndex::c_5;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_utils.hpp
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Ring SDPA topology helpers shared between compute and dataflow kernels.
+// Contains the single-source-of-truth ring_id assignment state machine
+// used by RingSDPAOpIndexer, RingSDPAOpReceiver, and pre-scan helpers.
+
+#pragma once
+
+#include <cstdint>
+
+/**
+ * Direction-alternating ring_id sequencer.
+ * Computes which device's KV shard to process at each ring iteration.
+ * Iteration 0 is always the local device (ring_index).
+ * Subsequent iterations alternate between backward and forward directions.
+ *
+ * The get_next_ring_id() method accepts a sync callback, allowing callers to
+ * inject hardware synchronization (e.g. semaphore waits) between the ring_id
+ * computation and the direction switch. This is the single implementation of
+ * the ring_id assignment logic — both RingSDPAOpIndexer and RingSDPAOpReceiver
+ * delegate to it.
+ */
+struct RingIdSequencer {
+    uint32_t ring_index = 0;
+    uint32_t ring_size = 0;
+    uint32_t received[2] = {0, 0};  // [backward, forward]
+    uint32_t expected[2] = {0, 0};  // [backward, forward]
+    uint32_t curr_dir = 0;          // 0 = backward, 1 = forward
+    uint32_t transfer_idx = 0;
+
+    RingIdSequencer() = default;
+
+    RingIdSequencer(uint32_t ring_index_, uint32_t ring_size_, uint32_t backward_expected, uint32_t forward_expected) :
+        ring_index(ring_index_),
+        ring_size(ring_size_),
+        received{0, 0},
+        expected{backward_expected, forward_expected},
+        curr_dir(0),
+        transfer_idx(0) {}
+
+    /**
+     * Compute the next ring_id and advance the state machine.
+     *
+     * @param sync_fn  Callback invoked between ring_id computation and direction switch.
+     *                 Signature: void(uint32_t dir, uint32_t wait_val)
+     *                 - dir: current direction index (for semaphore selection)
+     *                 - wait_val: semaphore threshold (0 on first iteration)
+     *                 Pass a no-op lambda for sync-free usage (compute kernel, pre-scan).
+     */
+    template <typename SyncFn>
+    uint32_t get_next_ring_id(SyncFn&& sync_fn) {
+        uint32_t sender_ring_id;
+        uint32_t sync_dir = curr_dir;
+        uint32_t sync_wait_val;
+
+        if (transfer_idx == 0) {
+            sender_ring_id = ring_index;
+            sync_wait_val = 0;
+        } else {
+            received[curr_dir] += 1;
+            if (curr_dir == 1) {
+                // Receiving from forward direction → go backwards
+                sender_ring_id = (ring_index - received[curr_dir] + ring_size) % ring_size;
+                sync_wait_val = received[curr_dir];
+            } else {
+                // Receiving from backward direction → go forwards
+                sender_ring_id = (ring_index + received[curr_dir]) % ring_size;
+                sync_wait_val = received[curr_dir] + 1;
+            }
+        }
+
+        sync_fn(sync_dir, sync_wait_val);
+
+        // Direction switch
+        if (transfer_idx == 0) {
+            if (expected[curr_dir] == 0) {
+                curr_dir = 1 - curr_dir;
+            }
+        } else {
+            uint32_t next_dir = 1 - curr_dir;
+            if (received[next_dir] < expected[next_dir]) {
+                curr_dir = next_dir;
+            }
+        }
+
+        transfer_idx++;
+        return sender_ring_id;
+    }
+};
+
+/**
+ * Find the last ring iteration that performs actual KV computation.
+ * Creates a copy of the sequencer and iterates it with no synchronization.
+ *
+ * @param seq               Sequencer state (copied — original is not modified)
+ * @param local_padded_Nt   Per-device padded sequence length in tiles
+ * @param global_n_tile_id  Logical (unpadded) sequence length in tiles (logical_n / TILE_HEIGHT)
+ * @param L                 Joint sequence length in elements (0 if no joint attention)
+ */
+inline uint32_t find_last_active_ring_iter(
+    RingIdSequencer seq, uint32_t local_padded_Nt, uint32_t global_n_tile_id, uint32_t L) {
+    uint32_t last_active = 0;
+    auto no_sync = [](uint32_t, uint32_t) {};
+
+    for (uint32_t t = 0; t < seq.ring_size; ++t) {
+        uint32_t ring_id = seq.get_next_ring_id(no_sync);
+        bool does_joint = (ring_id == seq.ring_size - 1);
+        uint32_t kv_start = ring_id * local_padded_Nt;
+        bool does_work = (kv_start <= global_n_tile_id) || (does_joint && L != 0);
+        if (does_work) {
+            last_active = t;
+        }
+    }
+
+    return last_active;
+}

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
@@ -225,9 +225,11 @@ RingJointSDPAResultSpec RingJointSDPADeviceOperation::compute_output_specs(
     const RingJointSDPAParams& args, const RingJointSDPAInputs& tensor_args) {
     const auto& input = tensor_args.input_q;
     const auto& joint_input = tensor_args.joint_q;
-    auto lse_shape = input.logical_shape();
-    lse_shape[3] = 1;
-    lse_shape[2] = input.padded_shape()[2] + joint_input.padded_shape()[2];
+    auto stats_shape = input.logical_shape();
+    stats_shape[3] = 1;
+    // 2× the sequence length: first half stores running max, second half stores running sum.
+    // Used as DRAM scratch for multi-Q-chunk deferred norm round-trips between ring iterations.
+    stats_shape[2] = (input.padded_shape()[2] + joint_input.padded_shape()[2]) * 2;
 
     return {
         .output = TensorSpec(
@@ -236,8 +238,8 @@ RingJointSDPAResultSpec RingJointSDPADeviceOperation::compute_output_specs(
         .joint_output = TensorSpec(
             joint_input.logical_shape(),
             TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), args.output_memory_config)),
-        .lse_output = TensorSpec(
-            lse_shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), args.output_memory_config))};
+        .stats_output = TensorSpec(
+            stats_shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), args.output_memory_config))};
 }
 
 RingJointSDPAResult RingJointSDPADeviceOperation::create_output_tensors(
@@ -246,7 +248,7 @@ RingJointSDPAResult RingJointSDPADeviceOperation::create_output_tensors(
     return {
         .output = create_device_tensor(output_specs.output, tensor_args.input_q.device()),
         .joint_output = create_device_tensor(output_specs.joint_output, tensor_args.joint_q.device()),
-        .lse_output = create_device_tensor(output_specs.lse_output, tensor_args.input_q.device()),
+        .stats_output = create_device_tensor(output_specs.stats_output, tensor_args.input_q.device()),
     };
 }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation_types.hpp
@@ -87,13 +87,13 @@ struct RingJointSDPAInputs {
 struct RingJointSDPAResult {
     Tensor output;
     Tensor joint_output;
-    Tensor lse_output;
+    Tensor stats_output;
 };
 
 struct RingJointSDPAResultSpec {
     TensorSpec output;
     TensorSpec joint_output;
-    TensorSpec lse_output;
+    TensorSpec stats_output;
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -101,7 +101,7 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
 
     auto& output_tensor = output_tensors.output;
     auto& joint_output_tensor = output_tensors.joint_output;
-    auto& lse_output_tensor = output_tensors.lse_output;
+    auto& stats_output_tensor = output_tensors.stats_output;
 
     std::size_t q_chunk_size = args.get_q_chunk_size();
     std::size_t k_chunk_size = args.get_k_chunk_size();
@@ -419,11 +419,12 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
         args.all_gather_operation_attributes.ring_size,
         global_n_partial_col,
         joint_l_partial_col,
+        (std::uint32_t)use_streaming_compute,
     };
 
     TensorAccessorArgs(output_tensor.buffer()).append_to(writer_compile_time_args);
     TensorAccessorArgs(joint_output_tensor.buffer()).append_to(writer_compile_time_args);
-    TensorAccessorArgs(lse_output_tensor.buffer()).append_to(writer_compile_time_args);
+    TensorAccessorArgs(stats_output_tensor.buffer()).append_to(writer_compile_time_args);
 
     // Early format check: when all data formats are identical, reconfig calls can be skipped.
     const tt::DataFormat q_df_early = tt::tt_metal::datatype_to_dataformat_converter(input_tensor_q.dtype());
@@ -472,6 +473,7 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
         global_n_partial_col,
         joint_l_partial_col,
         (std::uint32_t)uniform_dataformat,
+        q_per_core,
     };
 
     std::map<std::string, std::string> defines;
@@ -569,7 +571,7 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
                             .set_page_size(tt::CBIndex::c_5, scalar_tile_size);
     CreateCircularBuffer(program, core_grid, c_in5_config);
 
-    // lse input
+    // stats input
     auto c_in6_config = CircularBufferConfig(statistics_tiles * im_tile_size, {{tt::CBIndex::c_6, im_df}})
                             .set_page_size(tt::CBIndex::c_6, im_tile_size);
     CreateCircularBuffer(program, core_grid, c_in6_config);
@@ -629,7 +631,7 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
                              .set_page_size(tt::CBIndex::c_16, out_tile_size);
     CreateCircularBuffer(program, core_grid, c_out0_config);
 
-    // lse output
+    // stats output
     auto c_out1_config = CircularBufferConfig(statistics_tiles * im_tile_size, {{tt::CBIndex::c_17, im_df}})
                              .set_page_size(tt::CBIndex::c_17, im_tile_size);
     CreateCircularBuffer(program, core_grid, c_out1_config);
@@ -642,6 +644,20 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
         CreateCircularBuffer(program, core_grid, c_recip_scratch_config);
     }
 
+    // Deferred norm: sum save/restore CBs for multi Q-chunk DRAM round-trip.
+    // cb_sum_out (c_10) = compute pushes sum for writer to save to DRAM.
+    // cb_sum_in (c_11) = writer pushes restored sum from DRAM for compute to read.
+    if (use_streaming_compute) {
+        auto c_sum_out_config =
+            CircularBufferConfig(statistics_tiles * stats_tile_size, {{tt::CBIndex::c_10, stats_df}})
+                .set_page_size(tt::CBIndex::c_10, stats_tile_size);
+        CreateCircularBuffer(program, core_grid, c_sum_out_config);
+
+        auto c_sum_in_config = CircularBufferConfig(statistics_tiles * stats_tile_size, {{tt::CBIndex::c_11, stats_df}})
+                                   .set_page_size(tt::CBIndex::c_11, stats_tile_size);
+        CreateCircularBuffer(program, core_grid, c_sum_in_config);
+    }
+
     uint32_t q_addr = input_tensor_q.buffer()->address();
     uint32_t k_addr = input_tensor_k.buffer()->address();
     uint32_t v_addr = input_tensor_v.buffer()->address();
@@ -652,7 +668,7 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     uint32_t joint_v_addr = joint_tensor_v.buffer()->address();
     uint32_t out_addr = output_tensor.buffer()->address();
     uint32_t joint_out_addr = joint_output_tensor.buffer()->address();
-    uint32_t lse_addr = lse_output_tensor.buffer()->address();
+    uint32_t stats_addr = stats_output_tensor.buffer()->address();
 
     /**
      * Build chain selection for store-and-forward across cores per (batch, head).
@@ -881,7 +897,7 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
         std::vector<uint32_t> writer_args = {
             out_addr,
             joint_out_addr,
-            lse_addr,
+            stats_addr,
             global_q_start,
             global_q_end,
         };
@@ -964,7 +980,7 @@ void RingJointSDPAProgramFactory::override_runtime_arguments(
         // Get addresses for output tensors
         auto* out_buffer = output_tensors.output.buffer();
         auto* joint_out_buffer = output_tensors.joint_output.buffer();
-        auto* lse_buffer = output_tensors.lse_output.buffer();
+        auto* stats_buffer = output_tensors.stats_output.buffer();
 
         uint32_t q_addr = q_buffer->address();
         uint32_t k_addr = k_buffer->address();
@@ -976,7 +992,7 @@ void RingJointSDPAProgramFactory::override_runtime_arguments(
         uint32_t joint_v_addr = joint_v_buffer->address();
         uint32_t out_addr = out_buffer->address();
         uint32_t joint_out_addr = joint_out_buffer->address();
-        uint32_t lse_addr = lse_buffer->address();
+        uint32_t stats_addr = stats_buffer->address();
 
         auto& reader_args_by_core = GetRuntimeArgs(program, shared_vars.reader_kernels_id);
         auto& writer_args_by_core = GetRuntimeArgs(program, shared_vars.writer_kernels_id);
@@ -1000,7 +1016,7 @@ void RingJointSDPAProgramFactory::override_runtime_arguments(
             // Update writer args
             writer_args[0] = out_addr;
             writer_args[1] = joint_out_addr;
-            writer_args[2] = lse_addr;
+            writer_args[2] = stats_addr;
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -260,11 +260,11 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
      *
      */
     const uint32_t all_heads_num_q_chunks = B * NH * num_q_chunks;
-    const uint32_t q_per_core = tt::div_up(all_heads_num_q_chunks, num_cores);
+    const uint32_t max_q_per_core = tt::div_up(all_heads_num_q_chunks, num_cores);
 
-    const uint32_t q_buffer_factor = (q_per_core > 1) ? 2 : 1;
+    const uint32_t q_buffer_factor = (max_q_per_core > 1) ? 2 : 1;
 
-    log_debug(tt::LogOp, "q_per_core: {}", q_per_core);
+    log_debug(tt::LogOp, "max_q_per_core: {}", max_q_per_core);
 
     // These tile capacity counts for CBs need to match the number of tiles expected by the kernel (softmax.cpp)
     uint32_t q_tiles = Sq_chunk_t * DHt * q_buffer_factor;
@@ -473,7 +473,6 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
         global_n_partial_col,
         joint_l_partial_col,
         (std::uint32_t)uniform_dataformat,
-        q_per_core,
     };
 
     std::map<std::string, std::string> defines;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
@@ -195,7 +195,7 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> ExecuteRingJointAttention::
         scale,
         compute_kernel_config,
         core_allocation_strategy);
-    return {output_tensors.output, output_tensors.joint_output, output_tensors.lse_output};
+    return {output_tensors.output, output_tensors.joint_output, output_tensors.stats_output};
 }
 
 ttnn::Tensor ExecuteFlashMLAPrefill::invoke(


### PR DESCRIPTION
## Summary
- Fix code size issues that are currently being hit on CI for ring joint sdpa
- Replace per-ring-iteration sigmoid merge with deferred normalization: accumulate raw softmax state (output, max, sum) across all ring iterations and normalize once at the end
- Introduce `AccumulatorHalf` struct for ping-pong buffer management, replacing 6 separate alias variables
- Fix `q_per_core` mismatch between compute and writer kernels that caused deadlocks when Q chunks don't divide evenly across cores
- Compute code size: -40% (58.8KB → 35.1KB), perf: +2.2pp math util on small config, +1.0pp on large

## Test plan
- [ ] [![T3000 e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=pjosipovic/ring_joint_sdpa_deferred_normalisation)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:pjosipovic/ring_joint_sdpa_deferred_normalisation)
- [ ] [![T3000 integration tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-integration-tests.yaml/badge.svg?branch=pjosipovic/ring_joint_sdpa_deferred_normalisation)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-integration-tests.yaml?query=branch:pjosipovic/ring_joint_sdpa_deferred_normalisation)
- [ ] [![L2 nightly (SDPA)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/ring_joint_sdpa_deferred_normalisation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/ring_joint_sdpa_deferred_normalisation)
- [ ] [![Blackhole e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=pjosipovic/ring_joint_sdpa_deferred_normalisation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:pjosipovic/ring_joint_sdpa_deferred_normalisation)
- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=pjosipovic/ring_joint_sdpa_deferred_normalisation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:pjosipovic/ring_joint_sdpa_deferred_normalisation)
- [ ] [![Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/ring_joint_sdpa_deferred_normalisation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/ring_joint_sdpa_deferred_normalisation)
- [ ] [![(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-frequent-tests.yaml/badge.svg?branch=pjosipovic/ring_joint_sdpa_deferred_normalisation)](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-frequent-tests.yaml?query=branch:pjosipovic/ring_joint_sdpa_deferred_normalisation)
- [ ] [![(Galaxy) demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml/badge.svg?branch=pjosipovic/ring_joint_sdpa_deferred_normalisation)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml?query=branch:pjosipovic/ring_joint_sdpa_deferred_normalisation) (Wan 2.2, Mochi, SD 3.5)
- [x] 36/36 PCC tests pass (18 ring + 18 standard)
- [x] Model-config regression tests for SD3.5, Mochi, and Wan 14B

🤖 Generated with [Claude Code](https://claude.com/claude-code)