### PR TITLE
[QSR/BH]: Add RISC-V Atomics Test

### DIFF
--- a/tests/tt_metal/tt_metal/sources.cmake
+++ b/tests/tt_metal/tt_metal/sources.cmake
@@ -31,4 +31,5 @@ set(UNIT_TESTS_LEGACY_SRC
     test_transpose_hc.cpp
     test_untilize_eltwise_binary.cpp
     test_unaligned_read_write_core.cpp
+    test_riscv_atomics.cpp
 )

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/riscv_atomics.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/riscv_atomics.cpp
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Kernel for testing RISCV atomics with L1 using gcc built-in Functions
+// Kernel is only launched archs that support atomics: Quasar and BH
+// While QSR supports both Zaamo and Zalrsc, BH only supports Zaamo
+// On BH, the RISCs always execute Zaamo aq/rl variants as if both bits were set
+// So relaxed/release/acquire/seq-cst collapse to the same hardware behavior,
+// though ELF disassembly shows the gcc built-ins generate stronger code for seq-cst
+// BH uses 32-bit atomics here; Quasar uses 64-bit atomics here
+
+#ifndef COMPILE_FOR_TRISC
+#include "api/dataflow/dataflow_api.h"
+#else
+#include "api/compute/common.h"
+#endif
+
+#include "api/debug/dprint.h"
+
+#if defined(ARCH_QUASAR)
+#include "internal/tt-2xx/quasar/overlay/overlay_addresses.h"
+
+typedef uint64_t atomic_type;
+
+// TODO: Remove this once cache invalidation functionality for Quasar is added
+inline __attribute__((always_inline)) void flush_l2_cache_line(atomic_type* addr) {
+    asm volatile("fence" ::: "memory");
+    volatile atomic_type* flush_reg = (volatile atomic_type*)L2_FLUSH_ADDR;
+    *flush_reg = (atomic_type)addr;
+    asm volatile("fence" ::: "memory");
+}
+#else
+typedef uint32_t atomic_type;
+#endif
+
+// Writer publishes the shared value, then sets the ready flag
+void writer(atomic_type* shared_value_ptr, atomic_type* ready_flag_ptr) {
+    *shared_value_ptr = SENTINEL;
+    __atomic_store_n(ready_flag_ptr, 1, __ATOMIC_SEQ_CST);
+}
+
+// Reader waits for the ready flag, then reads the published value
+void reader(atomic_type* shared_value_ptr, atomic_type* ready_flag_ptr, atomic_type* result_ptr) {
+    while (!__atomic_load_n(ready_flag_ptr, __ATOMIC_SEQ_CST)) {
+    }
+    *result_ptr = *shared_value_ptr;
+}
+
+void test_atomic_load_store(atomic_type* shared_value_ptr, atomic_type* ready_flag_ptr, atomic_type* result_ptr) {
+#ifdef ARCH_QUASAR
+    uint64_t thread_idx = 0;
+    asm volatile("csrr %0, mhartid" : "=r"(thread_idx));
+    // On Quasar, DM0 runs writer() and DM1-7 run reader()
+    // Each DM writes to its own result location for host to verify
+    if (thread_idx == 0) {
+        writer(shared_value_ptr, ready_flag_ptr);
+    } else {
+        // Each reader DM writes to a unique result slot so host verification is per thread
+        atomic_type* per_thread_result_ptr = result_ptr + (thread_idx - 1);
+        reader(shared_value_ptr, ready_flag_ptr, per_thread_result_ptr);
+        // Flush the cache so host readback sees the updated L1
+        flush_l2_cache_line(per_thread_result_ptr);
+    }
+#else
+    // ON BH, BRISC runs writer(), NCRISC runs reader()
+#ifdef COMPILE_FOR_BRISC
+    writer(shared_value_ptr, ready_flag_ptr);
+#else
+    reader(shared_value_ptr, ready_flag_ptr, result_ptr);
+#endif  // COMPILE_FOR_BRISC
+#endif  // ARCH_QUASAR
+}
+
+void test_atomic_add_fetch(atomic_type* l1_counter_ptr, const atomic_type increment_times) {
+    for (uint32_t i = 0; i < increment_times; i++) {
+        __atomic_add_fetch(l1_counter_ptr, 1, __ATOMIC_RELEASE);
+    }
+}
+
+void test_compare_and_swap_atomic(atomic_type* l1_counter_ptr, const uint32_t increment_times) {
+    for (uint32_t i = 0; i < increment_times; i++) {
+        atomic_type expected_read = __atomic_load_n(l1_counter_ptr, __ATOMIC_SEQ_CST);
+        while (!__atomic_compare_exchange_n(
+            l1_counter_ptr, &expected_read, expected_read + 1, false, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST)) {
+        }
+    }
+}
+
+void kernel_main() {
+    // shared L1 location between all DMs for atomic updates
+    atomic_type* l1_counter_ptr = reinterpret_cast<atomic_type*>(get_arg_val<uint32_t>(0));
+    const uint32_t increment_times = get_arg_val<uint32_t>(1);
+
+#if TEST_ATOMIC_LOAD_STORE
+    atomic_type* shared_value_ptr = l1_counter_ptr;
+    atomic_type* ready_flag_ptr = (l1_counter_ptr + 1);
+    atomic_type* result_ptr = (l1_counter_ptr + 2);
+    test_atomic_load_store(shared_value_ptr, ready_flag_ptr, result_ptr);
+#elif TEST_ATOMIC_ADD_FETCH
+    test_atomic_add_fetch(l1_counter_ptr, increment_times);
+#elif TEST_ATOMIC_CAS && defined(ARCH_QUASAR)
+    test_compare_and_swap_atomic(l1_counter_ptr, increment_times);
+#endif
+
+#if defined(ARCH_QUASAR)
+    // Flush the cache so host readback sees the updated L1
+    flush_l2_cache_line(l1_counter_ptr);
+#endif
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/riscv_atomics.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/riscv_atomics.cpp
@@ -3,12 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Kernel for testing RISCV atomics with L1 using gcc built-in Functions
-// Kernel is only launched archs that support atomics: Quasar and BH
+// Kernel is only launched on archs that support atomics: Quasar and BH
 // While QSR supports both Zaamo and Zalrsc, BH only supports Zaamo
 // On BH, the RISCs always execute Zaamo aq/rl variants as if both bits were set
 // So relaxed/release/acquire/seq-cst collapse to the same hardware behavior,
 // though ELF disassembly shows the gcc built-ins generate stronger code for seq-cst
-// BH uses 32-bit atomics here; Quasar uses 64-bit atomics here
+// BH uses 32-bit atomics; Quasar uses 64-bit atomics
 
 #ifndef COMPILE_FOR_TRISC
 #include "api/dataflow/dataflow_api.h"
@@ -16,13 +16,9 @@
 #include "api/compute/common.h"
 #endif
 
-#include "api/debug/dprint.h"
-
 #if defined(ARCH_QUASAR)
 #include "internal/tt-2xx/quasar/overlay/overlay_addresses.h"
-
 typedef uint64_t atomic_type;
-
 // TODO: Remove this once cache invalidation functionality for Quasar is added
 inline __attribute__((always_inline)) void flush_l2_cache_line(atomic_type* addr) {
     asm volatile("fence" ::: "memory");
@@ -34,50 +30,53 @@ inline __attribute__((always_inline)) void flush_l2_cache_line(atomic_type* addr
 typedef uint32_t atomic_type;
 #endif
 
-// Writer publishes the shared value, then sets the ready flag
-void writer(atomic_type* shared_value_ptr, atomic_type* ready_flag_ptr) {
-    *shared_value_ptr = SENTINEL;
-    __atomic_store_n(ready_flag_ptr, 1, __ATOMIC_SEQ_CST);
-}
+#if TEST_ATOMIC_LOAD_STORE
+// Writer atomically writes the sentinel value
+void writer(atomic_type* shared_value_ptr) { __atomic_store_n(shared_value_ptr, SENTINEL, __ATOMIC_SEQ_CST); }
 
-// Reader waits for the ready flag, then reads the published value
-void reader(atomic_type* shared_value_ptr, atomic_type* ready_flag_ptr, atomic_type* result_ptr) {
-    while (!__atomic_load_n(ready_flag_ptr, __ATOMIC_SEQ_CST)) {
+// Reader spins until atomic load sees SENTINEL, then writes the observed value for host verification
+void reader(atomic_type* shared_value_ptr, atomic_type* result_ptr) {
+    atomic_type val;
+    while ((val = __atomic_load_n(shared_value_ptr, __ATOMIC_SEQ_CST)) != SENTINEL) {
     }
-    *result_ptr = *shared_value_ptr;
+    *result_ptr = val;
 }
 
-void test_atomic_load_store(atomic_type* shared_value_ptr, atomic_type* ready_flag_ptr, atomic_type* result_ptr) {
+void test_atomic_load_store(atomic_type* shared_value_ptr, atomic_type* result_ptr) {
 #ifdef ARCH_QUASAR
     uint64_t thread_idx = 0;
     asm volatile("csrr %0, mhartid" : "=r"(thread_idx));
     // On Quasar, DM0 runs writer() and DM1-7 run reader()
     // Each DM writes to its own result location for host to verify
     if (thread_idx == 0) {
-        writer(shared_value_ptr, ready_flag_ptr);
+        writer(shared_value_ptr);
     } else {
         // Each reader DM writes to a unique result slot so host verification is per thread
         atomic_type* per_thread_result_ptr = result_ptr + (thread_idx - 1);
-        reader(shared_value_ptr, ready_flag_ptr, per_thread_result_ptr);
+        reader(shared_value_ptr, per_thread_result_ptr);
         // Flush the cache so host readback sees the updated L1
         flush_l2_cache_line(per_thread_result_ptr);
     }
 #else
     // ON BH, BRISC runs writer(), NCRISC runs reader()
 #ifdef COMPILE_FOR_BRISC
-    writer(shared_value_ptr, ready_flag_ptr);
+    writer(shared_value_ptr);
 #else
-    reader(shared_value_ptr, ready_flag_ptr, result_ptr);
+    reader(shared_value_ptr, result_ptr);
 #endif  // COMPILE_FOR_BRISC
 #endif  // ARCH_QUASAR
 }
+#endif  // TEST_ATOMIC_LOAD_STORE
 
-void test_atomic_add_fetch(atomic_type* l1_counter_ptr, const atomic_type increment_times) {
+#ifdef TEST_ATOMIC_ADD_FETCH
+void test_atomic_add_fetch(atomic_type* l1_counter_ptr, const uint32_t increment_times) {
     for (uint32_t i = 0; i < increment_times; i++) {
-        __atomic_add_fetch(l1_counter_ptr, 1, __ATOMIC_RELEASE);
+        __atomic_add_fetch(l1_counter_ptr, 1, __ATOMIC_SEQ_CST);
     }
 }
+#endif  // TEST_ATOMIC_ADD_FETCH
 
+#if defined(TEST_ATOMIC_CAS) && defined(ARCH_QUASAR)
 void test_compare_and_swap_atomic(atomic_type* l1_counter_ptr, const uint32_t increment_times) {
     for (uint32_t i = 0; i < increment_times; i++) {
         atomic_type expected_read = __atomic_load_n(l1_counter_ptr, __ATOMIC_SEQ_CST);
@@ -86,24 +85,24 @@ void test_compare_and_swap_atomic(atomic_type* l1_counter_ptr, const uint32_t in
         }
     }
 }
+#endif  // TEST_ATOMIC_CAS
 
 void kernel_main() {
-    // shared L1 location between all DMs for atomic updates
+    // Base L1 address shared by all DMs: used as a counter (add/CAS) or value + result slots (load/store)
     atomic_type* l1_counter_ptr = reinterpret_cast<atomic_type*>(get_arg_val<uint32_t>(0));
     const uint32_t increment_times = get_arg_val<uint32_t>(1);
 
 #if TEST_ATOMIC_LOAD_STORE
     atomic_type* shared_value_ptr = l1_counter_ptr;
-    atomic_type* ready_flag_ptr = (l1_counter_ptr + 1);
-    atomic_type* result_ptr = (l1_counter_ptr + 2);
-    test_atomic_load_store(shared_value_ptr, ready_flag_ptr, result_ptr);
+    atomic_type* result_ptr = (l1_counter_ptr + 1);
+    test_atomic_load_store(shared_value_ptr, result_ptr);
 #elif TEST_ATOMIC_ADD_FETCH
     test_atomic_add_fetch(l1_counter_ptr, increment_times);
 #elif TEST_ATOMIC_CAS && defined(ARCH_QUASAR)
     test_compare_and_swap_atomic(l1_counter_ptr, increment_times);
 #endif
 
-#if defined(ARCH_QUASAR)
+#if defined(ARCH_QUASAR) && (defined(TEST_ATOMIC_ADD_FETCH) || defined(TEST_ATOMIC_CAS))
     // Flush the cache so host readback sees the updated L1
     flush_l2_cache_line(l1_counter_ptr);
 #endif

--- a/tests/tt_metal/tt_metal/test_riscv_atomics.cpp
+++ b/tests/tt_metal/tt_metal/test_riscv_atomics.cpp
@@ -1,0 +1,200 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <vector>
+#include <gtest/gtest.h>
+
+#include <tt-metalium/tt_align.hpp>
+#include <tt-metalium/allocator.hpp>
+#include <tt_stl/assert.hpp>
+#include <tt-metalium/base_types.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/hal_types.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program.hpp>
+#include <tt-metalium/tt_metal.hpp>
+#include "impl/program/program_impl.hpp"
+#include "common/mesh_dispatch_fixture.hpp"
+#include <tt-metalium/experimental/host_api.hpp>
+
+namespace tt::tt_metal {
+
+// These Tests verify built in gcc atomics on Tensix RISCV processors
+// https://gcc.gnu.org/onlinedocs/gcc/_005f_005fatomic-Builtins.htmla
+
+class RISCVAtomicsFixture : public MeshDispatchFixture {
+protected:
+    static constexpr CoreCoord core = {0, 0};
+    static constexpr uint32_t SENTINEL{0xABABABAB};
+    static constexpr uint32_t iterations{2e3};
+    const std::string kernel_path = "tests/tt_metal/tt_metal/test_kernels/dataflow/riscv_atomics.cpp";
+    uint32_t l1_unreserved_base{0};
+    bool is_quasar{false};
+    std::shared_ptr<distributed::MeshDevice> mesh_device_;
+    IDevice* device_{nullptr};
+    uint32_t num_dms_{0};
+    std::vector<uint32_t> result;
+    std::vector<uint32_t> runtime_args;
+    uint32_t word_count_32b{0};
+
+    void SetUp() override {
+        MeshDispatchFixture::SetUp();
+        // No atomics support on WH
+        if (arch_ == tt::ARCH::WORMHOLE_B0) {
+            GTEST_SKIP() << "RISCV Atomics not supported on Wormhole";
+        }
+        mesh_device_ = devices_[0];
+        device_ = mesh_device_->get_devices()[0];
+        num_dms_ = MetalContext::instance().hal().get_processor_types_count(HalProgrammableCoreType::TENSIX, 0);
+        l1_unreserved_base = device_->allocator()->get_base_allocator_addr(HalMemType::L1);
+        is_quasar = arch_ == tt::ARCH::QUASAR;
+        // Quasar zero-inits in 64-bit slots; BH uses 32-bit slot
+        word_count_32b = is_quasar ? 2 : 1;
+        set_rtas();
+    }
+
+    void set_rtas() {
+        runtime_args.push_back(l1_unreserved_base);
+        runtime_args.push_back(iterations);
+    }
+
+    void run_riscv_atomics_test(const std::map<std::string, std::string>& dm_defines) {
+        distributed::MeshWorkload workload;
+        Program program;
+        distributed::MeshCoordinate zero_coord{0, 0};
+        distributed::MeshCoordinateRange device_range{zero_coord, zero_coord};
+
+        set_rtas();
+
+        // Same Kernel is launched on all DMs
+        if (arch_ == tt::ARCH::QUASAR) {
+            auto kernel = tt::tt_metal::experimental::quasar::CreateKernel(
+                program,
+                kernel_path,
+                core,
+                tt::tt_metal::experimental::quasar::QuasarDataMovementConfig{
+                    .num_threads_per_cluster = num_dms_, .defines = dm_defines});
+            SetRuntimeArgs(program, kernel, core, runtime_args);
+        } else {
+            // BH:
+            for (uint32_t dm_id = 0; dm_id < num_dms_; dm_id++) {
+                auto kernel = CreateKernel(
+                    program,
+                    kernel_path,
+                    core,
+                    DataMovementConfig{
+                        .processor = static_cast<tt_metal::DataMovementProcessor>(dm_id),
+                        .noc = (dm_id == 1 ? NOC::RISCV_1_default : NOC::RISCV_0_default),
+                        .defines = dm_defines});
+                SetRuntimeArgs(program, kernel, core, runtime_args);
+            }
+        }
+
+        workload.add_program(device_range, std::move(program));
+        RunProgram(mesh_device_, workload);
+    }
+};
+
+// Tests __atomic_load_n and __atomic_store_n on RISC. DM = 0 will write a value to L1
+// and atomically set a ready flag for other DM(s) to read that flag and read the value to L1
+// Expected to read back that value on Host
+TEST_F(RISCVAtomicsFixture, TestAtomicLoadStoreRISCV) {
+    std::map<std::string, std::string> dm_defines = {
+        {"TEST_ATOMIC_LOAD_STORE", "1"}, {"SENTINEL", std::to_string(SENTINEL)}};
+
+    // Number of slots used in L1:
+    // shared_value_ptr producer DM slot + ready_flag_ptr slot + one result slot per consumer DM x # of DMs
+    const uint32_t l1_slot_count = num_dms_ + 1;
+
+    // Zero-Init the L1 atomics scratch space
+    std::vector<uint32_t> initial_l1_words(l1_slot_count * word_count_32b, 0);
+    tt::tt_metal::detail::WriteToDeviceL1(device_, core, l1_unreserved_base, initial_l1_words);
+
+    // Run the test
+    run_riscv_atomics_test(dm_defines);
+
+    // Skip shared_value_ptr + ready_flag_ptr L1 address offset
+    // and read only consumer result slots on host
+    constexpr uint32_t l1_offset = 2;
+    const uint32_t read_addr = l1_unreserved_base + l1_offset * sizeof(uint32_t) * word_count_32b;
+    // Read back words written by all DMs to verify atomic load/store went through properly
+    const uint32_t read_size_bytes = sizeof(uint32_t) * (num_dms_ - 1) * word_count_32b;
+
+    tt::tt_metal::detail::ReadFromDeviceL1(device_, core, read_addr, read_size_bytes, result);
+
+    // Quasar publishes a 64-bit result, while BH reads back a 32-bit result
+    if (is_quasar) {
+        // Read from all DMs
+        for (uint32_t i = 0; i < result.size() - 1; i += word_count_32b) {
+            const uint64_t observed = static_cast<uint64_t>(result[i]) | (static_cast<uint64_t>(result[i + 1]) << 32);
+            log_info(LogTest, "Result: {} (expected: {})", observed, SENTINEL);
+            EXPECT_EQ(observed, SENTINEL) << "Kernel should have observed the producer value";
+        }
+    } else {
+        log_info(LogTest, "Result: {} (expected: {})", result[0], SENTINEL);
+        EXPECT_EQ(result[0], SENTINEL) << "Kernel should have observed the producer value";
+    }
+}
+
+// Tests __atomic_add_fetch on RISC. Each DM will atomically increment a counter 2e3 times.
+//  Expected to read back N x 2e3 back on host verifies atomic increments
+TEST_F(RISCVAtomicsFixture, TestAtomicAddFetchRISCV) {
+    std::map<std::string, std::string> dm_defines = {
+        {"TEST_ATOMIC_ADD_FETCH", "1"}, {"SENTINEL", std::to_string(SENTINEL)}};
+
+    // Zero-Init the L1 atomics scratch space
+    std::vector<uint32_t> initial_l1_words(word_count_32b, 0);
+    tt::tt_metal::detail::WriteToDeviceL1(device_, core, l1_unreserved_base, initial_l1_words);
+
+    // We launch the same kernel on all DMs. So each DM should've atomically incremented the counter 2e3 times
+    const uint32_t expected_result = num_dms_ * iterations;
+    const uint32_t read_size_bytes = sizeof(uint32_t) * word_count_32b;
+
+    // Run the test
+    run_riscv_atomics_test(dm_defines);
+
+    tt::tt_metal::detail::ReadFromDeviceL1(device_, core, l1_unreserved_base, read_size_bytes, result);
+
+    // Quasar publishes a 64-bit result, while BH reads back a 32-bit result
+    uint64_t observed = result[0];
+
+    if (is_quasar) {
+        observed |= static_cast<uint64_t>(result[1]) << 32;
+    }
+
+    log_info(LogTest, "Result: {} (expected: {})", observed, static_cast<uint64_t>(expected_result));
+    EXPECT_EQ(observed, static_cast<uint64_t>(expected_result))
+        << "Kernel should have performed " << expected_result << " atomic additions";
+}
+
+// Tests __atomic_compare_exchange_n on RISC. Each DM will CAS a value to L1 2e3 times.
+// Expected to read back N x 2e3 back on host verifies atomic CAS success
+TEST_F(RISCVAtomicsFixture, TestAtomicCASRISCV) {
+    if (!is_quasar) {
+        GTEST_SKIP() << "RISCV CAS Atomics only supported on Quasar";
+    }
+
+    std::map<std::string, std::string> dm_defines = {{"TEST_ATOMIC_CAS", "1"}, {"SENTINEL", std::to_string(SENTINEL)}};
+
+    // Zero-Init the L1 atomics scratch space
+    std::vector<uint32_t> initial_l1_words(word_count_32b, 0);
+    tt::tt_metal::detail::WriteToDeviceL1(device_, core, l1_unreserved_base, initial_l1_words);
+
+    // We launch the same kernel on all DMs. So each DM should've atomically CAS the counter 2e3 times
+    const uint64_t expected_result = num_dms_ * iterations;
+    const uint32_t read_size_bytes = sizeof(uint32_t) * word_count_32b;
+
+    // Run the test
+    run_riscv_atomics_test(dm_defines);
+
+    tt::tt_metal::detail::ReadFromDeviceL1(device_, core, l1_unreserved_base, read_size_bytes, result);
+
+    // Quasar publishes a 64-bit result
+    const uint64_t result64 = static_cast<uint64_t>(result[0]) | (static_cast<uint64_t>(result[1]) << 32);
+    log_info(LogTest, "Result: {} (expected: {})", result64, expected_result);
+    EXPECT_EQ(result64, expected_result) << "Kernel should have performed " << expected_result << " atomic additions";
+}
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/test_riscv_atomics.cpp
+++ b/tests/tt_metal/tt_metal/test_riscv_atomics.cpp
@@ -23,13 +23,13 @@
 namespace tt::tt_metal {
 
 // These Tests verify built in gcc atomics on Tensix RISCV processors
-// https://gcc.gnu.org/onlinedocs/gcc/_005f_005fatomic-Builtins.htmla
+// https://gcc.gnu.org/onlinedocs/gcc/_005f_005fatomic-Builtins.html
 
 class RISCVAtomicsFixture : public MeshDispatchFixture {
 protected:
     static constexpr CoreCoord core = {0, 0};
     static constexpr uint32_t SENTINEL{0xABABABAB};
-    static constexpr uint32_t iterations{2e3};
+    static constexpr uint32_t iterations{2000};
     const std::string kernel_path = "tests/tt_metal/tt_metal/test_kernels/dataflow/riscv_atomics.cpp";
     uint32_t l1_unreserved_base{0};
     bool is_quasar{false};
@@ -51,12 +51,14 @@ protected:
         num_dms_ = MetalContext::instance().hal().get_processor_types_count(HalProgrammableCoreType::TENSIX, 0);
         l1_unreserved_base = device_->allocator()->get_base_allocator_addr(HalMemType::L1);
         is_quasar = arch_ == tt::ARCH::QUASAR;
-        // Quasar zero-inits in 64-bit slots; BH uses 32-bit slot
+        // Number of uint32_t words per atomic_type: Quasar uses 64-bit atomics (2 words), BH uses 32-bit (1 word)
         word_count_32b = is_quasar ? 2 : 1;
-        set_rtas();
     }
 
     void set_rtas() {
+        if (!runtime_args.empty()) {
+            return;
+        }
         runtime_args.push_back(l1_unreserved_base);
         runtime_args.push_back(iterations);
     }
@@ -98,16 +100,15 @@ protected:
     }
 };
 
-// Tests __atomic_load_n and __atomic_store_n on RISC. DM = 0 will write a value to L1
-// and atomically set a ready flag for other DM(s) to read that flag and read the value to L1
-// Expected to read back that value on Host
+// DM0 (writer) atomically stores SENTINEL to L1, other DM(s) (reader) spin on atomic load until they see it.
+// Host reads back each reader's result slot and verifies SENTINEL was observed.
 TEST_F(RISCVAtomicsFixture, TestAtomicLoadStoreRISCV) {
     std::map<std::string, std::string> dm_defines = {
         {"TEST_ATOMIC_LOAD_STORE", "1"}, {"SENTINEL", std::to_string(SENTINEL)}};
 
     // Number of slots used in L1:
-    // shared_value_ptr producer DM slot + ready_flag_ptr slot + one result slot per consumer DM x # of DMs
-    const uint32_t l1_slot_count = num_dms_ + 1;
+    // 1 shared_value slot + (num_dms - 1) reader result slots
+    const uint32_t l1_slot_count = num_dms_;
 
     // Zero-Init the L1 atomics scratch space
     std::vector<uint32_t> initial_l1_words(l1_slot_count * word_count_32b, 0);
@@ -116,14 +117,14 @@ TEST_F(RISCVAtomicsFixture, TestAtomicLoadStoreRISCV) {
     // Run the test
     run_riscv_atomics_test(dm_defines);
 
-    // Skip shared_value_ptr + ready_flag_ptr L1 address offset
-    // and read only consumer result slots on host
-    constexpr uint32_t l1_offset = 2;
+    // Skip shared_value_ptr slot; read only consumer result slots
+    constexpr uint32_t l1_offset = 1;
     const uint32_t read_addr = l1_unreserved_base + l1_offset * sizeof(uint32_t) * word_count_32b;
     // Read back words written by all DMs to verify atomic load/store went through properly
     const uint32_t read_size_bytes = sizeof(uint32_t) * (num_dms_ - 1) * word_count_32b;
 
     tt::tt_metal::detail::ReadFromDeviceL1(device_, core, read_addr, read_size_bytes, result);
+    ASSERT_EQ(result.size(), (num_dms_ - 1) * word_count_32b);
 
     // Quasar publishes a 64-bit result, while BH reads back a 32-bit result
     if (is_quasar) {
@@ -139,17 +140,15 @@ TEST_F(RISCVAtomicsFixture, TestAtomicLoadStoreRISCV) {
     }
 }
 
-// Tests __atomic_add_fetch on RISC. Each DM will atomically increment a counter 2e3 times.
-//  Expected to read back N x 2e3 back on host verifies atomic increments
+// All DMs atomically increment a shared L1 counter 2000 times each.
+// Host verifies final count == num_dms * 2000 to confirm atomic increments
 TEST_F(RISCVAtomicsFixture, TestAtomicAddFetchRISCV) {
-    std::map<std::string, std::string> dm_defines = {
-        {"TEST_ATOMIC_ADD_FETCH", "1"}, {"SENTINEL", std::to_string(SENTINEL)}};
+    std::map<std::string, std::string> dm_defines = {{"TEST_ATOMIC_ADD_FETCH", "1"}};
 
     // Zero-Init the L1 atomics scratch space
     std::vector<uint32_t> initial_l1_words(word_count_32b, 0);
     tt::tt_metal::detail::WriteToDeviceL1(device_, core, l1_unreserved_base, initial_l1_words);
 
-    // We launch the same kernel on all DMs. So each DM should've atomically incremented the counter 2e3 times
     const uint32_t expected_result = num_dms_ * iterations;
     const uint32_t read_size_bytes = sizeof(uint32_t) * word_count_32b;
 
@@ -157,6 +156,7 @@ TEST_F(RISCVAtomicsFixture, TestAtomicAddFetchRISCV) {
     run_riscv_atomics_test(dm_defines);
 
     tt::tt_metal::detail::ReadFromDeviceL1(device_, core, l1_unreserved_base, read_size_bytes, result);
+    ASSERT_EQ(result.size(), word_count_32b);
 
     // Quasar publishes a 64-bit result, while BH reads back a 32-bit result
     uint64_t observed = result[0];
@@ -170,20 +170,19 @@ TEST_F(RISCVAtomicsFixture, TestAtomicAddFetchRISCV) {
         << "Kernel should have performed " << expected_result << " atomic additions";
 }
 
-// Tests __atomic_compare_exchange_n on RISC. Each DM will CAS a value to L1 2e3 times.
-// Expected to read back N x 2e3 back on host verifies atomic CAS success
+// All DMs CAS increment a shared L1 counter 2000 times each. Zalrsc extension only supported on Quasar.
+// Host verifies final count == num_dms * 2000 to confirm atomic CAS increments
 TEST_F(RISCVAtomicsFixture, TestAtomicCASRISCV) {
     if (!is_quasar) {
         GTEST_SKIP() << "RISCV CAS Atomics only supported on Quasar";
     }
 
-    std::map<std::string, std::string> dm_defines = {{"TEST_ATOMIC_CAS", "1"}, {"SENTINEL", std::to_string(SENTINEL)}};
+    std::map<std::string, std::string> dm_defines = {{"TEST_ATOMIC_CAS", "1"}};
 
     // Zero-Init the L1 atomics scratch space
     std::vector<uint32_t> initial_l1_words(word_count_32b, 0);
     tt::tt_metal::detail::WriteToDeviceL1(device_, core, l1_unreserved_base, initial_l1_words);
 
-    // We launch the same kernel on all DMs. So each DM should've atomically CAS the counter 2e3 times
     const uint64_t expected_result = num_dms_ * iterations;
     const uint32_t read_size_bytes = sizeof(uint32_t) * word_count_32b;
 
@@ -191,6 +190,7 @@ TEST_F(RISCVAtomicsFixture, TestAtomicCASRISCV) {
     run_riscv_atomics_test(dm_defines);
 
     tt::tt_metal::detail::ReadFromDeviceL1(device_, core, l1_unreserved_base, read_size_bytes, result);
+    ASSERT_EQ(result.size(), word_count_32b);
 
     // Quasar publishes a 64-bit result
     const uint64_t result64 = static_cast<uint64_t>(result[0]) | (static_cast<uint64_t>(result[1]) << 32);

--- a/tests/tt_metal/tt_metal/test_riscv_atomics.cpp
+++ b/tests/tt_metal/tt_metal/test_riscv_atomics.cpp
@@ -3,9 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <vector>
+#include <map>
+#include <memory>
+#include <string>
 #include <gtest/gtest.h>
+#include <tt-logger/tt-logger.hpp>
 
-#include <tt-metalium/tt_align.hpp>
 #include <tt-metalium/allocator.hpp>
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/base_types.hpp>
@@ -16,7 +19,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/tt_metal.hpp>
-#include "impl/program/program_impl.hpp"
+#include "impl/context/metal_context.hpp"
 #include "common/mesh_dispatch_fixture.hpp"
 #include <tt-metalium/experimental/host_api.hpp>
 
@@ -119,7 +122,7 @@ TEST_F(RISCVAtomicsFixture, TestAtomicLoadStoreRISCV) {
 
     // Skip shared_value_ptr slot; read only consumer result slots
     constexpr uint32_t l1_offset = 1;
-    const uint32_t read_addr = l1_unreserved_base + l1_offset * sizeof(uint32_t) * word_count_32b;
+    const uint32_t read_addr = l1_unreserved_base + (l1_offset * sizeof(uint32_t) * word_count_32b);
     // Read back words written by all DMs to verify atomic load/store went through properly
     const uint32_t read_size_bytes = sizeof(uint32_t) * (num_dms_ - 1) * word_count_32b;
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/38105

### Problem description
This test verifies gcc built-in atomics to L1 on Quasar and BH DM cores. We will soon use atomics on Quasar for watcher features (ring buffer, NOC sanitize reporting) to prevent races between DM error reporting, so it's important to verify they work correctly. 

### What's changed
Adds 3 tests:                                                                                                                                                                               
1. Load/Store: DM0 atomically stores a sentinel value; other DM(s) spin on atomic load until they see it. Host verifies each reader's result.
2. Add/Fetch: All DMs atomically increment a shared L1 counter 2000 times each. Host verifies final count == num_dms * 2000 (no lost updates).                                             
3. CAS (Quasar only): Same as add/fetch but uses compare-and-swap loop. Requires Zalrsc extension. 

Overall findings:

Arch | Atomic Extensions | Support type | Tested gcc in-built functions | Comments
-- | -- | -- | -- | --
WH | No Atomics supported
BH | Zaamo only | 32-bit | __atomic_add_fetch, __atomic_store_n, __atomic_load_n | No lr.w/sc.w support, so no CAS support. On hardware, aq/rl are always set from memory ordering perspective, so we always have the strictest memory ordering from hardware PoV, though ELF disassembly shows the compiler generates stronger code for __ATOMIC_SEQ_CST
QSR | Zaamo + Zalrsc | 32-bit, 64-bit | same as above + __atomic_compare_exchange_n | Compiler generates both lr.w/sc.w and lr.d/sc.d version


Also, C++ std::atomic generates identical assembly to gcc built-ins.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=snadkarni/test_riscv_atomics)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:snadkarni/test_riscv_atomics)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snadkarni/test_riscv_atomics)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snadkarni/test_riscv_atomics)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadkarni/test_riscv_atomics)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadkarni/test_riscv_atomics)
- [x] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early

Quasar emulator runs: https://gist.github.com/sidnadTT/481c70e8a390e925ef9fa36346617860

#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snadkarni/test_riscv_atomics)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snadkarni/test_riscv_atomics)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snadkarni/test_riscv_atomics)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snadkarni/test_riscv_atomics)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snadkarni/test_riscv_atomics)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snadkarni/test_riscv_atomics)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
