### PR TITLE
Add 2D matmul sweep tests for interleaved in0 + sharded in1

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul.py
@@ -7,8 +7,7 @@ import torch
 import ttnn
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
-from tests.ttnn.unit_tests.operations.matmul.test_matmul import pad_to_dram_banks
-from tests.ttnn.unit_tests.operations.matmul.test_matmul_deepseek import pad_batch_to_dram_banks, pad_to_tile
+from tests.ttnn.unit_tests.operations.matmul.test_matmul_deepseek import _run_matmul_2d_interleaved_in0_sharded_in1
 
 
 @pytest.mark.parametrize(
@@ -191,261 +190,6 @@ def test_sdxl_matmul(
         assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.999)
 
 
-def _run_matmul_2d_interleaved_in0_sharded_in1(
-    device,
-    batch,
-    seq_len,
-    k,
-    n,
-    in0_dtype=ttnn.bfloat16,
-    in1_dtype=ttnn.bfloat8_b,
-    out_dtype=ttnn.bfloat16,
-    has_bias=False,
-    num_dram_banks=12,
-    expected_pcc=0.999,
-):
-    """
-    Run matmul with DRAM interleaved in0 and DRAM sharded in1 using
-    MatmulMultiCoreReuseMultiCastProgramConfig (2D multicast).
-
-    batch == 1: in1 WIDTH_SHARDED in DRAM, fuse_batch=True
-    batch > 1: in1 HEIGHT_SHARDED in DRAM, fuse_batch=False
-    """
-    torch.manual_seed(0)
-    tile_h = 32
-    tile_w = 32
-
-    # --- Hardware Validation ---
-    device_banks = device.dram_grid_size().x
-    if device_banks < num_dram_banks:
-        pytest.skip(f"Device has {device_banks} DRAM banks, need {num_dram_banks}")
-
-    bias_torch = None
-    bias_t = None
-
-    # ==========================================
-    # 1. TENSOR SETUP & MEMORY SHARDING
-    # ==========================================
-    if batch == 1:
-        # UNBATCHED PATH: Shard the weights (in1) across the N dimension (Width)
-        n_padded = pad_to_dram_banks(n, tile_w, tile_w * num_dram_banks)
-
-        in0_shape = [1, 1, seq_len, k]
-        in1_shape = [1, 1, k, n]
-
-        in0 = torch.randn(in0_shape, dtype=torch.bfloat16)
-        in1 = torch.randn(in1_shape, dtype=torch.bfloat16)
-
-        # in0 is always Standard DRAM Interleaved
-        in0_t = ttnn.from_torch(
-            in0,
-            dtype=in0_dtype,
-            layout=ttnn.TILE_LAYOUT,
-            device=device,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-        )
-
-        # in1 requires a specific Shard Specification defining how it breaks across cores
-        # Use tile-padded k because TILE_LAYOUT pads the tensor's K dim to next multiple of 32
-        in1_shard_shape = [pad_to_tile(k, tile_w), n_padded // num_dram_banks]
-        in1_shard_grid = ttnn.CoreRangeSet(
-            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_dram_banks - 1, 0))}
-        )
-        in1_shard_spec = ttnn.ShardSpec(in1_shard_grid, in1_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
-        in1_memory_config = ttnn.MemoryConfig(
-            ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, in1_shard_spec
-        )
-        in1_t = ttnn.from_torch(
-            in1,
-            dtype=in1_dtype,
-            layout=ttnn.TILE_LAYOUT,
-            device=device,
-            memory_config=in1_memory_config,
-        )
-
-        if has_bias:
-            bias_shape = [1, 1, tile_h, n]
-            bias_torch = torch.randn(bias_shape, dtype=torch.bfloat16)
-            bias_t = ttnn.from_torch(
-                bias_torch,
-                dtype=in1_dtype,
-                layout=ttnn.TILE_LAYOUT,
-                device=device,
-                memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            )
-    else:
-        # BATCHED PATH: Shard the weights (in1) across the Batch dimension (Height)
-        batch_padded = pad_batch_to_dram_banks(batch, num_dram_banks)
-        batches_per_bank = batch_padded // num_dram_banks
-        k_padded = pad_to_tile(k, tile_w)
-        n_padded = pad_to_tile(n, tile_w)
-
-        in0_orig = torch.randn([1, batch, seq_len, k], dtype=torch.bfloat16)
-        in1_orig = torch.randn([1, batch, k, n], dtype=torch.bfloat16)
-
-        in0_t = ttnn.from_torch(
-            in0_orig,
-            dtype=in0_dtype,
-            layout=ttnn.TILE_LAYOUT,
-            device=device,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-        )
-
-        dram_shard_grid = ttnn.CoreRangeSet(
-            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_dram_banks - 1, 0))}
-        )
-        in1_shard_shape = [batches_per_bank * k_padded, n_padded]
-        in1_shard_spec = ttnn.ShardSpec(dram_shard_grid, in1_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
-        in1_memory_config = ttnn.MemoryConfig(
-            ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.DRAM, in1_shard_spec
-        )
-        in1_t = ttnn.from_torch(
-            in1_orig,
-            dtype=in1_dtype,
-            layout=ttnn.TILE_LAYOUT,
-            device=device,
-            memory_config=in1_memory_config,
-        )
-
-    # ==========================================
-    # 2. HARDWARE GRID & CACHE MATH
-    # ==========================================
-    # Pad to tile boundaries to match what TILE_LAYOUT produces on device
-    seq_len_padded = pad_to_tile(seq_len, tile_h)
-    k_tiled = pad_to_tile(k, tile_w)
-    n_tiled = pad_to_tile(n, tile_w)
-
-    # Calculate how many 32x32 tiles make up the (padded) matrices
-    device_grid = device.compute_with_storage_grid_size()
-    M_tiles = seq_len_padded // tile_h
-    K_tiles = k_tiled // tile_w
-    N_tiles = n_tiled // tile_w
-
-    # Determine the compute grid shape (grid_x and grid_y) by finding the largest
-    # number of cores that evenly divide the Output Matrix dimensions (N and M).
-    grid_x = 1
-    for x in range(min(device_grid.x, N_tiles), 0, -1):
-        if N_tiles % x == 0:
-            grid_x = x
-            break
-
-    grid_y = 1
-    for y in range(min(device_grid.y, M_tiles), 0, -1):
-        if M_tiles % y == 0:
-            grid_y = y
-            break
-
-    # Calculate workload per core
-    in0_block_h = M_tiles // grid_y
-    out_block_w = N_tiles // grid_x
-    per_core_M = in0_block_h
-    per_core_N = out_block_w
-
-    # Calculate in0_block_w: Finds the largest chunk of the K dimension we can
-    # process at once without overflowing the Circular Buffers (CBs) on the chip.
-    max_cb_tiles = 256
-    in0_block_w = K_tiles
-    while in0_block_w > 1:
-        if K_tiles % in0_block_w == 0 and in0_block_w * out_block_w * 2 <= max_cb_tiles:
-            break
-        in0_block_w -= 1
-    while in0_block_w > 1 and in0_block_h * in0_block_w * 2 > max_cb_tiles:
-        in0_block_w = in0_block_w // 2
-        if K_tiles % in0_block_w != 0:
-            while in0_block_w > 1 and K_tiles % in0_block_w != 0:
-                in0_block_w -= 1
-
-    # Calculate out_block_h: Ensures the final output and intermediate fp32 math
-    # fits inside the ~1.2MB L1 cache limit of the cores.
-    max_l1_usage = 1200 * 1024
-    out_block_h = in0_block_h
-    for candidate_h in range(in0_block_h, 0, -1):
-        if in0_block_h % candidate_h != 0:
-            continue
-        in0_cb = candidate_h * in0_block_w * 2 * 2048
-        in1_cb = out_block_w * in0_block_w * 2 * 2048
-        interm0_cb = candidate_h * out_block_w * 4096
-        output_cb = candidate_h * out_block_w * 2048
-        total = in0_cb + in1_cb + interm0_cb + output_cb
-        if total <= max_l1_usage:
-            out_block_h = candidate_h
-            break
-
-    # Calculate subblock dimensions (Hardware limitation: h * w must be <= 4)
-    out_subblock_w = 1
-    for sw in range(min(out_block_w, 4), 0, -1):
-        if out_block_w % sw == 0:
-            out_subblock_w = sw
-            break
-    max_sh = 4 // out_subblock_w
-    out_subblock_h = 1
-    for sh in range(min(out_block_h, max_sh), 0, -1):
-        if out_block_h % sh == 0:
-            out_subblock_h = sh
-            break
-
-    # ==========================================
-    # 3. EXECUTION & VALIDATION
-    # ==========================================
-    program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
-        compute_with_storage_grid_size=(grid_x, grid_y),
-        in0_block_w=in0_block_w,
-        out_subblock_h=out_subblock_h,
-        out_subblock_w=out_subblock_w,
-        out_block_h=out_block_h,
-        out_block_w=out_block_w,
-        per_core_M=per_core_M,
-        per_core_N=per_core_N,
-        transpose_mcast=False,
-        fused_activation=None,
-        fuse_batch=(batch == 1),
-    )
-
-    compute_kernel_config = ttnn.init_device_compute_kernel_config(
-        device.arch(),
-        math_fidelity=ttnn.MathFidelity.LoFi,
-        math_approx_mode=True,
-        fp32_dest_acc_en=True,
-        packer_l1_acc=True,
-    )
-
-    if has_bias and batch == 1:
-        output_t = ttnn.linear(
-            in0_t,
-            in1_t,
-            bias=bias_t,
-            program_config=program_config,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            dtype=out_dtype,
-            compute_kernel_config=compute_kernel_config,
-        )
-    else:
-        output_t = ttnn.matmul(
-            in0_t,
-            in1_t,
-            program_config=program_config,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            dtype=out_dtype,
-            compute_kernel_config=compute_kernel_config,
-        )
-
-    output_tensor = ttnn.to_torch(output_t)
-    if batch == 1:
-        # Slice padded output back to original logical dimensions
-        output_tensor = output_tensor[:, :, :seq_len, :n]
-        pt_out = torch.matmul(in0, in1)
-        if has_bias:
-            num_bias_repeats = (seq_len + tile_h - 1) // tile_h
-            bias_repeated = torch.repeat_interleave(bias_torch, num_bias_repeats, dim=2)
-            bias_repeated = bias_repeated[:, :, :seq_len, :]  # match pt_out length (padded repeat can exceed)
-            pt_out = pt_out + bias_repeated
-    else:
-        output_tensor = output_tensor[:, :batch, :seq_len, :n]
-        pt_out = torch.matmul(in0_orig, in1_orig)
-
-    assert_with_pcc(pt_out, output_tensor, expected_pcc)
-
-
 @pytest.mark.parametrize("batch", [1, 25])
 @pytest.mark.parametrize("seq_len", [63, 5000])
 @pytest.mark.parametrize("k", [63, 32])
@@ -484,13 +228,14 @@ def test_matmul_2d_interleaved_sharded_dimension_sweep(device, batch, seq_len, k
 @pytest.mark.parametrize("in1_dtype", [ttnn.bfloat16, ttnn.bfloat8_b, ttnn.float32])
 @pytest.mark.parametrize("out_dtype", [ttnn.bfloat16, ttnn.bfloat8_b, ttnn.float32])
 @pytest.mark.parametrize("has_bias", [False, True])
+@pytest.mark.parametrize("bias_dtype", [ttnn.bfloat16, ttnn.bfloat8_b, ttnn.float32])
 @pytest.mark.timeout(120)
 def test_matmul_2d_interleaved_sharded_dtype_sweep(
-    device, batch, seq_len, k, n, num_dram_banks, in0_dtype, in1_dtype, out_dtype, has_bias
+    device, batch, seq_len, k, n, num_dram_banks, in0_dtype, in1_dtype, out_dtype, has_bias, bias_dtype
 ):
     """
     Sweep test for 2D matmul with DRAM interleaved in0 and DRAM sharded in1
-    across various data type combinations for inputs and outputs, with optional bias.
+    across various data type combinations for inputs, outputs, and bias.
     """
     expected_pcc = 0.99
     _run_matmul_2d_interleaved_in0_sharded_in1(
@@ -503,6 +248,7 @@ def test_matmul_2d_interleaved_sharded_dtype_sweep(
         in1_dtype=in1_dtype,
         out_dtype=out_dtype,
         has_bias=has_bias,
+        bias_dtype=bias_dtype if has_bias else None,
         num_dram_banks=num_dram_banks,
         expected_pcc=expected_pcc,
     )

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul.py
@@ -236,14 +236,33 @@ def test_matmul_2d_interleaved_sharded_dimension_sweep(device, batch, seq_len, k
     ],
 )
 @pytest.mark.timeout(120)
-def test_matmul_2d_interleaved_sharded_dtype_sweep(
+def test_matmul_2d_interleaved_sharded_dtype_bias_sweep(
     device, batch, seq_len, k, n, num_dram_banks, in0_dtype, in1_dtype, out_dtype, has_bias, bias_dtype
 ):
     """
     Sweep test for 2D matmul with DRAM interleaved in0 and DRAM sharded in1
-    across various data type combinations for inputs, outputs, and bias.
+    across various data type combinations for inputs, outputs, and bias,
+    restricted to batch == 1 so that ttnn.Linear() can be used with bias.
     """
     expected_pcc = 0.99
+
+    if has_bias and batch == 1:
+        # Low PCC (in0, in1, bias) dtype combos: ttnn.linear runs but gives very low PCC. See issue #40167.
+        skip_configs = {
+            (ttnn.bfloat8_b, ttnn.bfloat16, ttnn.float32),
+            (ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.float32),
+            (ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat16),
+            (ttnn.float32, ttnn.bfloat16, ttnn.float32),
+            (ttnn.float32, ttnn.bfloat8_b, ttnn.float32),
+            (ttnn.float32, ttnn.bfloat8_b, ttnn.bfloat16),
+            (ttnn.bfloat16, ttnn.bfloat8_b, ttnn.float32),
+        }
+        if (in0_dtype, in1_dtype, bias_dtype) in skip_configs:
+            pytest.skip(
+                f"Issue #40167: Low PCC dtype combination for ttnn.Linear "
+                f"(in0={in0_dtype}, in1={in1_dtype}, bias={bias_dtype})"
+            )
+
     _run_matmul_2d_interleaved_in0_sharded_in1(
         device=device,
         batch=batch,

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul.py
@@ -221,14 +221,20 @@ def test_matmul_2d_interleaved_sharded_dimension_sweep(device, batch, seq_len, k
     "batch, seq_len, k, n, num_dram_banks",
     [
         (1, 512, 128, 128, 12),
-        (150, 256, 512, 512, 9),
     ],
 )
 @pytest.mark.parametrize("in0_dtype", [ttnn.bfloat16, ttnn.bfloat8_b, ttnn.float32])
 @pytest.mark.parametrize("in1_dtype", [ttnn.bfloat16, ttnn.bfloat8_b, ttnn.float32])
 @pytest.mark.parametrize("out_dtype", [ttnn.bfloat16, ttnn.bfloat8_b, ttnn.float32])
-@pytest.mark.parametrize("has_bias", [False, True])
-@pytest.mark.parametrize("bias_dtype", [ttnn.bfloat16, ttnn.bfloat8_b, ttnn.float32])
+@pytest.mark.parametrize(
+    "has_bias, bias_dtype",
+    [
+        (False, None),
+        (True, ttnn.bfloat16),
+        (True, ttnn.bfloat8_b),
+        (True, ttnn.float32),
+    ],
+)
 @pytest.mark.timeout(120)
 def test_matmul_2d_interleaved_sharded_dtype_sweep(
     device, batch, seq_len, k, n, num_dram_banks, in0_dtype, in1_dtype, out_dtype, has_bias, bias_dtype

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul.py
@@ -2,13 +2,13 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-from loguru import logger
 import pytest
 import torch
-import math
 import ttnn
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.unit_tests.operations.matmul.test_matmul import pad_to_dram_banks
+from tests.ttnn.unit_tests.operations.matmul.test_matmul_deepseek import pad_batch_to_dram_banks, pad_to_tile
 
 
 @pytest.mark.parametrize(
@@ -189,3 +189,320 @@ def test_sdxl_matmul(
     if not perf_test_mode:
         output_tensor = ttnn.to_torch(output_tensor)
         assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.999)
+
+
+def _run_matmul_2d_interleaved_in0_sharded_in1(
+    device,
+    batch,
+    seq_len,
+    k,
+    n,
+    in0_dtype=ttnn.bfloat16,
+    in1_dtype=ttnn.bfloat8_b,
+    out_dtype=ttnn.bfloat16,
+    has_bias=False,
+    num_dram_banks=12,
+    expected_pcc=0.999,
+):
+    """
+    Run matmul with DRAM interleaved in0 and DRAM sharded in1 using
+    MatmulMultiCoreReuseMultiCastProgramConfig (2D multicast).
+
+    batch == 1: in1 WIDTH_SHARDED in DRAM, fuse_batch=True
+    batch > 1: in1 HEIGHT_SHARDED in DRAM, fuse_batch=False
+    """
+    torch.manual_seed(0)
+    tile_h = 32
+    tile_w = 32
+
+    # --- Hardware Validation ---
+    device_banks = device.dram_grid_size().x
+    if device_banks < num_dram_banks:
+        pytest.skip(f"Device has {device_banks} DRAM banks, need {num_dram_banks}")
+
+    bias_torch = None
+    bias_t = None
+
+    # ==========================================
+    # 1. TENSOR SETUP & MEMORY SHARDING
+    # ==========================================
+    if batch == 1:
+        # UNBATCHED PATH: Shard the weights (in1) across the N dimension (Width)
+        n_padded = pad_to_dram_banks(n, tile_w, tile_w * num_dram_banks)
+
+        in0_shape = [1, 1, seq_len, k]
+        in1_shape = [1, 1, k, n]
+
+        in0 = torch.randn(in0_shape, dtype=torch.bfloat16)
+        in1 = torch.randn(in1_shape, dtype=torch.bfloat16)
+
+        # in0 is always Standard DRAM Interleaved
+        in0_t = ttnn.from_torch(
+            in0,
+            dtype=in0_dtype,
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+        # in1 requires a specific Shard Specification defining how it breaks across cores
+        # Use tile-padded k because TILE_LAYOUT pads the tensor's K dim to next multiple of 32
+        in1_shard_shape = [pad_to_tile(k, tile_w), n_padded // num_dram_banks]
+        in1_shard_grid = ttnn.CoreRangeSet(
+            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_dram_banks - 1, 0))}
+        )
+        in1_shard_spec = ttnn.ShardSpec(in1_shard_grid, in1_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+        in1_memory_config = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, in1_shard_spec
+        )
+        in1_t = ttnn.from_torch(
+            in1,
+            dtype=in1_dtype,
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            memory_config=in1_memory_config,
+        )
+
+        if has_bias:
+            bias_shape = [1, 1, tile_h, n]
+            bias_torch = torch.randn(bias_shape, dtype=torch.bfloat16)
+            bias_t = ttnn.from_torch(
+                bias_torch,
+                dtype=in1_dtype,
+                layout=ttnn.TILE_LAYOUT,
+                device=device,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+    else:
+        # BATCHED PATH: Shard the weights (in1) across the Batch dimension (Height)
+        batch_padded = pad_batch_to_dram_banks(batch, num_dram_banks)
+        batches_per_bank = batch_padded // num_dram_banks
+        k_padded = pad_to_tile(k, tile_w)
+        n_padded = pad_to_tile(n, tile_w)
+
+        in0_orig = torch.randn([1, batch, seq_len, k], dtype=torch.bfloat16)
+        in1_orig = torch.randn([1, batch, k, n], dtype=torch.bfloat16)
+
+        in0_t = ttnn.from_torch(
+            in0_orig,
+            dtype=in0_dtype,
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+        dram_shard_grid = ttnn.CoreRangeSet(
+            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_dram_banks - 1, 0))}
+        )
+        in1_shard_shape = [batches_per_bank * k_padded, n_padded]
+        in1_shard_spec = ttnn.ShardSpec(dram_shard_grid, in1_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+        in1_memory_config = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.DRAM, in1_shard_spec
+        )
+        in1_t = ttnn.from_torch(
+            in1_orig,
+            dtype=in1_dtype,
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            memory_config=in1_memory_config,
+        )
+
+    # ==========================================
+    # 2. HARDWARE GRID & CACHE MATH
+    # ==========================================
+    # Pad to tile boundaries to match what TILE_LAYOUT produces on device
+    seq_len_padded = pad_to_tile(seq_len, tile_h)
+    k_tiled = pad_to_tile(k, tile_w)
+    n_tiled = pad_to_tile(n, tile_w)
+
+    # Calculate how many 32x32 tiles make up the (padded) matrices
+    device_grid = device.compute_with_storage_grid_size()
+    M_tiles = seq_len_padded // tile_h
+    K_tiles = k_tiled // tile_w
+    N_tiles = n_tiled // tile_w
+
+    # Determine the compute grid shape (grid_x and grid_y) by finding the largest
+    # number of cores that evenly divide the Output Matrix dimensions (N and M).
+    grid_x = 1
+    for x in range(min(device_grid.x, N_tiles), 0, -1):
+        if N_tiles % x == 0:
+            grid_x = x
+            break
+
+    grid_y = 1
+    for y in range(min(device_grid.y, M_tiles), 0, -1):
+        if M_tiles % y == 0:
+            grid_y = y
+            break
+
+    # Calculate workload per core
+    in0_block_h = M_tiles // grid_y
+    out_block_w = N_tiles // grid_x
+    per_core_M = in0_block_h
+    per_core_N = out_block_w
+
+    # Calculate in0_block_w: Finds the largest chunk of the K dimension we can
+    # process at once without overflowing the Circular Buffers (CBs) on the chip.
+    max_cb_tiles = 256
+    in0_block_w = K_tiles
+    while in0_block_w > 1:
+        if K_tiles % in0_block_w == 0 and in0_block_w * out_block_w * 2 <= max_cb_tiles:
+            break
+        in0_block_w -= 1
+    while in0_block_w > 1 and in0_block_h * in0_block_w * 2 > max_cb_tiles:
+        in0_block_w = in0_block_w // 2
+        if K_tiles % in0_block_w != 0:
+            while in0_block_w > 1 and K_tiles % in0_block_w != 0:
+                in0_block_w -= 1
+
+    # Calculate out_block_h: Ensures the final output and intermediate fp32 math
+    # fits inside the ~1.2MB L1 cache limit of the cores.
+    max_l1_usage = 1200 * 1024
+    out_block_h = in0_block_h
+    for candidate_h in range(in0_block_h, 0, -1):
+        if in0_block_h % candidate_h != 0:
+            continue
+        in0_cb = candidate_h * in0_block_w * 2 * 2048
+        in1_cb = out_block_w * in0_block_w * 2 * 2048
+        interm0_cb = candidate_h * out_block_w * 4096
+        output_cb = candidate_h * out_block_w * 2048
+        total = in0_cb + in1_cb + interm0_cb + output_cb
+        if total <= max_l1_usage:
+            out_block_h = candidate_h
+            break
+
+    # Calculate subblock dimensions (Hardware limitation: h * w must be <= 4)
+    out_subblock_w = 1
+    for sw in range(min(out_block_w, 4), 0, -1):
+        if out_block_w % sw == 0:
+            out_subblock_w = sw
+            break
+    max_sh = 4 // out_subblock_w
+    out_subblock_h = 1
+    for sh in range(min(out_block_h, max_sh), 0, -1):
+        if out_block_h % sh == 0:
+            out_subblock_h = sh
+            break
+
+    # ==========================================
+    # 3. EXECUTION & VALIDATION
+    # ==========================================
+    program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+        compute_with_storage_grid_size=(grid_x, grid_y),
+        in0_block_w=in0_block_w,
+        out_subblock_h=out_subblock_h,
+        out_subblock_w=out_subblock_w,
+        out_block_h=out_block_h,
+        out_block_w=out_block_w,
+        per_core_M=per_core_M,
+        per_core_N=per_core_N,
+        transpose_mcast=False,
+        fused_activation=None,
+        fuse_batch=(batch == 1),
+    )
+
+    compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.LoFi,
+        math_approx_mode=True,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=True,
+    )
+
+    if has_bias and batch == 1:
+        output_t = ttnn.linear(
+            in0_t,
+            in1_t,
+            bias=bias_t,
+            program_config=program_config,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            dtype=out_dtype,
+            compute_kernel_config=compute_kernel_config,
+        )
+    else:
+        output_t = ttnn.matmul(
+            in0_t,
+            in1_t,
+            program_config=program_config,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            dtype=out_dtype,
+            compute_kernel_config=compute_kernel_config,
+        )
+
+    output_tensor = ttnn.to_torch(output_t)
+    if batch == 1:
+        # Slice padded output back to original logical dimensions
+        output_tensor = output_tensor[:, :, :seq_len, :n]
+        pt_out = torch.matmul(in0, in1)
+        if has_bias:
+            num_bias_repeats = (seq_len + tile_h - 1) // tile_h
+            bias_repeated = torch.repeat_interleave(bias_torch, num_bias_repeats, dim=2)
+            bias_repeated = bias_repeated[:, :, :seq_len, :]  # match pt_out length (padded repeat can exceed)
+            pt_out = pt_out + bias_repeated
+    else:
+        output_tensor = output_tensor[:, :batch, :seq_len, :n]
+        pt_out = torch.matmul(in0_orig, in1_orig)
+
+    assert_with_pcc(pt_out, output_tensor, expected_pcc)
+
+
+@pytest.mark.parametrize("batch", [1, 25])
+@pytest.mark.parametrize("seq_len", [63, 5000])
+@pytest.mark.parametrize("k", [63, 32])
+@pytest.mark.parametrize("n", [63, 32])
+@pytest.mark.parametrize("num_dram_banks", [8, 9, 11, 12])
+@pytest.mark.timeout(120)
+def test_matmul_2d_interleaved_sharded_dimension_sweep(device, batch, seq_len, k, n, num_dram_banks):
+    """
+    Sweep test for 2D matmul with DRAM interleaved in0 and DRAM sharded in1
+    across various tensor dimension combinations and DRAM bank counts.
+    Exercises both batched (HEIGHT sharded) and unbatched (WIDTH sharded) paths.
+    """
+    _run_matmul_2d_interleaved_in0_sharded_in1(
+        device=device,
+        batch=batch,
+        seq_len=seq_len,
+        k=k,
+        n=n,
+        in0_dtype=ttnn.bfloat16,
+        in1_dtype=ttnn.bfloat8_b,
+        out_dtype=ttnn.bfloat16,
+        has_bias=False,
+        num_dram_banks=num_dram_banks,
+        expected_pcc=0.99,
+    )
+
+
+@pytest.mark.parametrize(
+    "batch, seq_len, k, n, num_dram_banks",
+    [
+        (1, 512, 128, 128, 12),
+        (150, 256, 512, 512, 9),
+    ],
+)
+@pytest.mark.parametrize("in0_dtype", [ttnn.bfloat16, ttnn.bfloat8_b, ttnn.float32])
+@pytest.mark.parametrize("in1_dtype", [ttnn.bfloat16, ttnn.bfloat8_b, ttnn.float32])
+@pytest.mark.parametrize("out_dtype", [ttnn.bfloat16, ttnn.bfloat8_b, ttnn.float32])
+@pytest.mark.parametrize("has_bias", [False, True])
+@pytest.mark.timeout(120)
+def test_matmul_2d_interleaved_sharded_dtype_sweep(
+    device, batch, seq_len, k, n, num_dram_banks, in0_dtype, in1_dtype, out_dtype, has_bias
+):
+    """
+    Sweep test for 2D matmul with DRAM interleaved in0 and DRAM sharded in1
+    across various data type combinations for inputs and outputs, with optional bias.
+    """
+    expected_pcc = 0.99
+    _run_matmul_2d_interleaved_in0_sharded_in1(
+        device=device,
+        batch=batch,
+        seq_len=seq_len,
+        k=k,
+        n=n,
+        in0_dtype=in0_dtype,
+        in1_dtype=in1_dtype,
+        out_dtype=out_dtype,
+        has_bias=has_bias,
+        num_dram_banks=num_dram_banks,
+        expected_pcc=expected_pcc,
+    )

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul_deepseek.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul_deepseek.py
@@ -30,6 +30,263 @@ def pad_to_tile(dim, tile_size):
     return ((dim + tile_size - 1) // tile_size) * tile_size
 
 
+def _run_matmul_2d_interleaved_in0_sharded_in1(
+    device,
+    batch,
+    seq_len,
+    k,
+    n,
+    in0_dtype=ttnn.bfloat16,
+    in1_dtype=ttnn.bfloat8_b,
+    out_dtype=ttnn.bfloat16,
+    has_bias=False,
+    bias_dtype=None,
+    num_dram_banks=12,
+    expected_pcc=0.999,
+):
+    """
+    Run matmul with DRAM interleaved in0 and DRAM sharded in1 using
+    MatmulMultiCoreReuseMultiCastProgramConfig (2D multicast).
+    batch == 1: in1 WIDTH_SHARDED in DRAM, fuse_batch=True
+    batch > 1: in1 HEIGHT_SHARDED in DRAM, fuse_batch=False
+    """
+    if bias_dtype is None:
+        bias_dtype = in1_dtype
+    torch.manual_seed(0)
+    tile_h = 32
+    tile_w = 32
+
+    # --- Hardware Validation ---
+    device_banks = device.dram_grid_size().x
+    if device_banks < num_dram_banks:
+        pytest.skip(f"Device has {device_banks} DRAM banks, need {num_dram_banks}")
+
+    bias_torch = None
+    bias_t = None
+
+    # ==========================================
+    # 1. TENSOR SETUP & MEMORY SHARDING
+    # ==========================================
+    if batch == 1:
+        # UNBATCHED PATH: Shard the weights (in1) across the N dimension (Width)
+        n_padded = pad_to_dram_banks(n, tile_w, tile_w * num_dram_banks)
+
+        in0_shape = [1, 1, seq_len, k]
+        in1_shape = [1, 1, k, n]
+
+        in0 = torch.randn(in0_shape, dtype=torch.bfloat16)
+        in1 = torch.randn(in1_shape, dtype=torch.bfloat16)
+
+        # in0 is always Standard DRAM Interleaved
+        in0_t = ttnn.from_torch(
+            in0,
+            dtype=in0_dtype,
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+        # in1 requires a specific Shard Specification defining how it breaks across cores
+        # Use tile-padded k because TILE_LAYOUT pads the tensor's K dim to next multiple of 32
+        in1_shard_shape = [pad_to_tile(k, tile_w), n_padded // num_dram_banks]
+        in1_shard_grid = ttnn.CoreRangeSet(
+            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_dram_banks - 1, 0))}
+        )
+        in1_shard_spec = ttnn.ShardSpec(in1_shard_grid, in1_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+        in1_memory_config = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, in1_shard_spec
+        )
+        in1_t = ttnn.from_torch(
+            in1,
+            dtype=in1_dtype,
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            memory_config=in1_memory_config,
+        )
+
+        if has_bias:
+            bias_shape = [1, 1, tile_h, n]
+            bias_torch = torch.randn(bias_shape, dtype=torch.bfloat16)
+            bias_t = ttnn.from_torch(
+                bias_torch,
+                dtype=bias_dtype,
+                layout=ttnn.TILE_LAYOUT,
+                device=device,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+    else:
+        # BATCHED PATH: Shard the weights (in1) across the Batch dimension (Height)
+        batch_padded = pad_batch_to_dram_banks(batch, num_dram_banks)
+        batches_per_bank = batch_padded // num_dram_banks
+        k_padded = pad_to_tile(k, tile_w)
+        n_padded = pad_to_tile(n, tile_w)
+
+        in0_orig = torch.randn([1, batch, seq_len, k], dtype=torch.bfloat16)
+        in1_orig = torch.randn([1, batch, k, n], dtype=torch.bfloat16)
+
+        in0_t = ttnn.from_torch(
+            in0_orig,
+            dtype=in0_dtype,
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+        dram_shard_grid = ttnn.CoreRangeSet(
+            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_dram_banks - 1, 0))}
+        )
+        in1_shard_shape = [batches_per_bank * k_padded, n_padded]
+        in1_shard_spec = ttnn.ShardSpec(dram_shard_grid, in1_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+        in1_memory_config = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.DRAM, in1_shard_spec
+        )
+        in1_t = ttnn.from_torch(
+            in1_orig,
+            dtype=in1_dtype,
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            memory_config=in1_memory_config,
+        )
+
+    # ==========================================
+    # 2. HARDWARE GRID & CACHE MATH
+    # ==========================================
+    # Pad to tile boundaries to match what TILE_LAYOUT produces on device
+    seq_len_padded = pad_to_tile(seq_len, tile_h)
+    k_tiled = pad_to_tile(k, tile_w)
+    n_tiled = pad_to_tile(n, tile_w)
+
+    # Calculate how many 32x32 tiles make up the (padded) matrices
+    device_grid = device.compute_with_storage_grid_size()
+    M_tiles = seq_len_padded // tile_h
+    K_tiles = k_tiled // tile_w
+    N_tiles = n_tiled // tile_w
+
+    # Determine the compute grid shape (grid_x and grid_y) by finding the largest
+    # number of cores that evenly divide the Output Matrix dimensions (N and M).
+    grid_x = 1
+    for x in range(min(device_grid.x, N_tiles), 0, -1):
+        if N_tiles % x == 0:
+            grid_x = x
+            break
+
+    grid_y = 1
+    for y in range(min(device_grid.y, M_tiles), 0, -1):
+        if M_tiles % y == 0:
+            grid_y = y
+            break
+
+    # Calculate workload per core
+    in0_block_h = M_tiles // grid_y
+    out_block_w = N_tiles // grid_x
+    per_core_M = in0_block_h
+    per_core_N = out_block_w
+
+    # Calculate in0_block_w: Finds the largest chunk of the K dimension we can
+    # process at once without overflowing the Circular Buffers (CBs) on the chip.
+    max_cb_tiles = 256
+    in0_block_w = K_tiles
+    while in0_block_w > 1:
+        if K_tiles % in0_block_w == 0 and in0_block_w * out_block_w * 2 <= max_cb_tiles:
+            break
+        in0_block_w -= 1
+    while in0_block_w > 1 and in0_block_h * in0_block_w * 2 > max_cb_tiles:
+        in0_block_w = in0_block_w // 2
+        if K_tiles % in0_block_w != 0:
+            while in0_block_w > 1 and K_tiles % in0_block_w != 0:
+                in0_block_w -= 1
+
+    # Calculate out_block_h: Ensures the final output and intermediate fp32 math
+    # fits inside the ~1.2MB L1 cache limit of the cores.
+    max_l1_usage = 1200 * 1024
+    out_block_h = in0_block_h
+    for candidate_h in range(in0_block_h, 0, -1):
+        if in0_block_h % candidate_h != 0:
+            continue
+        in0_cb = candidate_h * in0_block_w * 2 * 2048
+        in1_cb = out_block_w * in0_block_w * 2 * 2048
+        interm0_cb = candidate_h * out_block_w * 4096
+        output_cb = candidate_h * out_block_w * 2048
+        total = in0_cb + in1_cb + interm0_cb + output_cb
+        if total <= max_l1_usage:
+            out_block_h = candidate_h
+            break
+
+    # Calculate subblock dimensions (Hardware limitation: h * w must be <= 4)
+    out_subblock_w = 1
+    for sw in range(min(out_block_w, 4), 0, -1):
+        if out_block_w % sw == 0:
+            out_subblock_w = sw
+            break
+    max_sh = 4 // out_subblock_w
+    out_subblock_h = 1
+    for sh in range(min(out_block_h, max_sh), 0, -1):
+        if out_block_h % sh == 0:
+            out_subblock_h = sh
+            break
+
+    # ==========================================
+    # 3. EXECUTION & VALIDATION
+    # ==========================================
+    program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+        compute_with_storage_grid_size=(grid_x, grid_y),
+        in0_block_w=in0_block_w,
+        out_subblock_h=out_subblock_h,
+        out_subblock_w=out_subblock_w,
+        out_block_h=out_block_h,
+        out_block_w=out_block_w,
+        per_core_M=per_core_M,
+        per_core_N=per_core_N,
+        transpose_mcast=False,
+        fused_activation=None,
+        fuse_batch=(batch == 1),
+    )
+
+    compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.LoFi,
+        math_approx_mode=True,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=True,
+    )
+
+    if has_bias and batch == 1:
+        output_t = ttnn.linear(
+            in0_t,
+            in1_t,
+            bias=bias_t,
+            program_config=program_config,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            dtype=out_dtype,
+            compute_kernel_config=compute_kernel_config,
+        )
+    else:
+        output_t = ttnn.matmul(
+            in0_t,
+            in1_t,
+            program_config=program_config,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            dtype=out_dtype,
+            compute_kernel_config=compute_kernel_config,
+        )
+
+    output_tensor = ttnn.to_torch(output_t)
+    if batch == 1:
+        # Slice padded output back to original logical dimensions
+        output_tensor = output_tensor[:, :, :seq_len, :n]
+        pt_out = torch.matmul(in0, in1)
+        if has_bias:
+            num_bias_repeats = (seq_len + tile_h - 1) // tile_h
+            bias_repeated = torch.repeat_interleave(bias_torch, num_bias_repeats, dim=2)
+            bias_repeated = bias_repeated[:, :, :seq_len, :]  # match pt_out length (padded repeat can exceed)
+            pt_out = pt_out + bias_repeated
+    else:
+        output_tensor = output_tensor[:, :batch, :seq_len, :n]
+        pt_out = torch.matmul(in0_orig, in1_orig)
+
+    assert_with_pcc(pt_out, output_tensor, expected_pcc)
+
+
 @skip_for_blackhole("Deepseek tests target Wormhole")
 @pytest.mark.parametrize(
     "test_case",
@@ -823,205 +1080,16 @@ def test_prefill_mm_interleaved_sharded(device, test_case, seq_len):
     This exercises the prefill when forced to use the decode optimised weight sharding
     i.e. in1 is DRAM sharded - width for unbatched, and height (by batch) for batched matmuls
     """
-    torch.manual_seed(0)
-
-    batch = test_case["batch"]
-    k = test_case["k"]
-    n = test_case["n"]
-    in1_dtype = test_case["in1_dtype"]
-    expected_pcc = test_case["expected_pcc"]
-    tile_w = 32
-    tile_h = 32
-    num_dram_banks = test_case.get("num_dram_banks", 12)
-
-    device_banks = device.dram_grid_size().x
-
-    if device_banks < num_dram_banks:
-        pytest.skip("Device has less DRAM banks than required for test")
-
-    if batch == 1:
-        # --- Unbatched: in1 DRAM WIDTH sharded ---
-        n_padded = pad_to_dram_banks(n, tile_w, tile_w * num_dram_banks)
-
-        in0_shape = [1, 1, seq_len, k]
-        in1_shape = [1, 1, k, n]
-
-        in0 = torch.randn(in0_shape, dtype=torch.bfloat16)
-        in1 = torch.randn(in1_shape, dtype=torch.bfloat16)
-
-        in0_t = ttnn.from_torch(
-            in0,
-            dtype=ttnn.bfloat16,
-            layout=ttnn.TILE_LAYOUT,
-            device=device,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-        )
-
-        in1_shard_shape = [k, n_padded // num_dram_banks]
-        in1_shard_grid = ttnn.CoreRangeSet(
-            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_dram_banks - 1, 0))}
-        )
-        in1_shard_spec = ttnn.ShardSpec(in1_shard_grid, in1_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
-        in1_memory_config = ttnn.MemoryConfig(
-            ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, in1_shard_spec
-        )
-        in1_t = ttnn.from_torch(
-            in1,
-            dtype=in1_dtype,
-            layout=ttnn.TILE_LAYOUT,
-            device=device,
-            memory_config=in1_memory_config,
-        )
-    else:
-        # --- Batched: in1 DRAM HEIGHT sharded by batch (matching test_matmul_batched_dram_sharded) ---
-        batch_padded = pad_batch_to_dram_banks(batch, num_dram_banks)
-        batches_per_bank = batch_padded // num_dram_banks
-        k_padded = pad_to_tile(k, tile_w)
-        n_padded = pad_to_tile(n, tile_w)
-
-        in0_orig = torch.randn([1, batch, seq_len, k], dtype=torch.bfloat16)
-        in1_orig = torch.randn([1, batch, k, n], dtype=torch.bfloat16)
-
-        in0_t = ttnn.from_torch(
-            in0_orig,
-            dtype=ttnn.bfloat16,
-            layout=ttnn.TILE_LAYOUT,
-            device=device,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-        )
-
-        dram_shard_grid = ttnn.CoreRangeSet(
-            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_dram_banks - 1, 0))}
-        )
-        in1_shard_shape = [batches_per_bank * k_padded, n_padded]
-        in1_shard_spec = ttnn.ShardSpec(dram_shard_grid, in1_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
-        in1_memory_config = ttnn.MemoryConfig(
-            ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.DRAM, in1_shard_spec
-        )
-        in1_t = ttnn.from_torch(
-            in1_orig,
-            dtype=in1_dtype,
-            layout=ttnn.TILE_LAYOUT,
-            device=device,
-            memory_config=in1_memory_config,
-        )
-
-    # Compute 2D grid size
-    M_tiles = seq_len // tile_h
-    K_tiles = k // tile_w
-    N_tiles = n // tile_w
-
-    # grid_x splits N dimension; grid_y splits M dimension
-    # grid_x only needs to divide N_tiles (not K_tiles)
-    grid_x = 1
-    for x in range(min(8, N_tiles), 0, -1):
-        if N_tiles % x == 0:
-            grid_x = x
-            break
-
-    grid_y = 1
-    for y in range(min(8, M_tiles), 0, -1):
-        if M_tiles % y == 0:
-            grid_y = y
-            break
-
-    grid_size = (grid_x, grid_y)
-
-    in0_block_h = M_tiles // grid_y
-    out_block_h = in0_block_h
-    out_block_w = N_tiles // grid_x
-
-    # in0_block_w (inner dim block) must divide K_tiles.
-    # Target: keep in1 CB tiles (in0_block_w * out_block_w * 2) under ~256 tiles
-    # while maximizing in0_block_w to minimize inner loop iterations.
-    max_in1_cb_tiles = 256  # ~140 KB for bfloat8_b with double buffering
-    in0_block_w = K_tiles
-    while in0_block_w > 1:
-        if K_tiles % in0_block_w == 0 and in0_block_w * out_block_w * 2 <= max_in1_cb_tiles:
-            break
-        in0_block_w -= 1
-    # Ensure in0 CB is also reasonable
-    while in0_block_w > 1 and in0_block_h * in0_block_w * 2 > max_in1_cb_tiles:
-        in0_block_w = in0_block_w // 2
-        if K_tiles % in0_block_w != 0:
-            # Find next valid divisor
-            while in0_block_w > 1 and K_tiles % in0_block_w != 0:
-                in0_block_w -= 1
-
-    # Determine out_block_h to make sure the matmul will fit in L1.
-    # CBs that scale with out_block_h * out_block_w:
-    #   interm0 (fp32): out_block_h * out_block_w * 4096 bytes
-    #   output (bf16):  out_block_h * out_block_w * 2048 bytes
-    #   in0 (bf16):     out_block_h * in0_block_w * 2 * 2048 bytes (double-buffered)
-    # Target: total CB usage < ~1.2 MB (leaving headroom in 1.5 MB L1)
-    max_l1_usage = 1200 * 1024  # ~1.2 MB target
-    per_core_M = out_block_h
-    per_core_N = out_block_w
-    actual_out_block_h = out_block_h
-    for candidate_h in range(out_block_h, 0, -1):
-        if out_block_h % candidate_h != 0:
-            continue
-        # Estimate CB sizes
-        in0_cb = candidate_h * in0_block_w * 2 * 2048  # bf16 double-buffered
-        in1_cb = out_block_w * in0_block_w * 2 * 1088  # bf8b double-buffered
-        interm0_cb = candidate_h * out_block_w * 4096  # fp32
-        output_cb = candidate_h * out_block_w * 2048  # bf16
-        total = in0_cb + in1_cb + interm0_cb + output_cb
-        if total <= max_l1_usage:
-            actual_out_block_h = candidate_h
-            break
-
-    # Subblock calculation (h * w <= 4, hardware limit)
-    out_subblock_w = 1
-    for sw in range(min(out_block_w, 4), 0, -1):
-        if out_block_w % sw == 0:
-            out_subblock_w = sw
-            break
-    max_sh = 4 // out_subblock_w
-    out_subblock_h = 1
-    for sh in range(min(actual_out_block_h, max_sh), 0, -1):
-        if actual_out_block_h % sh == 0:
-            out_subblock_h = sh
-            break
-
-    program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
-        compute_with_storage_grid_size=grid_size,
-        in0_block_w=in0_block_w,
-        out_subblock_h=out_subblock_h,
-        out_subblock_w=out_subblock_w,
-        out_block_h=actual_out_block_h,
-        out_block_w=out_block_w,
-        per_core_M=per_core_M,
-        per_core_N=per_core_N,
-        transpose_mcast=False,
-        fused_activation=None,
-        fuse_batch=(batch == 1),
+    _run_matmul_2d_interleaved_in0_sharded_in1(
+        device=device,
+        batch=test_case["batch"],
+        seq_len=seq_len,
+        k=test_case["k"],
+        n=test_case["n"],
+        in0_dtype=ttnn.bfloat16,
+        in1_dtype=test_case["in1_dtype"],
+        out_dtype=ttnn.bfloat16,
+        has_bias=False,
+        num_dram_banks=test_case.get("num_dram_banks", 12),
+        expected_pcc=test_case["expected_pcc"],
     )
-
-    compute_kernel_config = ttnn.init_device_compute_kernel_config(
-        device.arch(),
-        math_fidelity=ttnn.MathFidelity.LoFi,
-        math_approx_mode=True,
-        fp32_dest_acc_en=True,
-        packer_l1_acc=True,
-    )
-
-    output_t = ttnn.matmul(
-        in0_t,
-        in1_t,
-        program_config=program_config,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-        dtype=ttnn.bfloat16,
-        compute_kernel_config=compute_kernel_config,
-    )
-
-    # Validate
-    output_tensor = ttnn.to_torch(output_t)
-    if batch == 1:
-        pt_out = torch.matmul(in0, in1)
-    else:
-        output_tensor = output_tensor[:, :batch, :seq_len, :n]
-        pt_out = torch.matmul(in0_orig, in1_orig)
-
-    pcc_passed, pcc_message = comp_pcc(pt_out, output_tensor, expected_pcc)
-    assert pcc_passed, f"PCC check failed: {pcc_message}"

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul_deepseek.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul_deepseek.py
@@ -288,7 +288,11 @@ def _run_matmul_2d_interleaved_in0_sharded_in1(
         packer_l1_acc=True,
     )
 
-    if has_bias and batch == 1:
+    assert not (
+        has_bias and batch != 1
+    ), "Batched matmul with bias not supported in _run_matmul_2d_interleaved_in0_sharded_in1; use batch == 1 or disable bias."
+
+    if has_bias:
         output_t = ttnn.linear(
             in0_t,
             in1_t,

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul_deepseek.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul_deepseek.py
@@ -30,6 +30,35 @@ def pad_to_tile(dim, tile_size):
     return ((dim + tile_size - 1) // tile_size) * tile_size
 
 
+def get_tile_size_bytes(dtype):
+    """
+    Return tile size in bytes for a given TTNN dtype.
+    The values are chosen to match hardware tile formats:
+      - bfloat16 tiles: 2048B
+      - float32 tiles: 4096B
+      - bfloat8_b tiles: 1088B
+    For unknown dtypes, fall back to 2048B, which is safe for bf16‑sized tiles
+    and conservative for smaller formats.
+    """
+    # Importing dtypes via ttnn keeps this helper local to the test.
+    if dtype in (
+        ttnn.bfloat16,
+        getattr(ttnn, "float16", None),
+    ):
+        return 2048
+    # Explicit handling for fp32 accumulation / tiles.
+    if dtype in (
+        getattr(ttnn, "float32", None),
+        getattr(ttnn, "bfloat32", None),
+    ):
+        return 4096
+    # Compressed / narrower tiles such as bfloat8_b.
+    if getattr(ttnn, "bfloat8_b", None) is not None and dtype == ttnn.bfloat8_b:
+        return 1088
+    # Fallback: assume bf16‑sized tiles.
+    return 2048
+
+
 def _run_matmul_2d_interleaved_in0_sharded_in1(
     device,
     batch,
@@ -200,13 +229,22 @@ def _run_matmul_2d_interleaved_in0_sharded_in1(
     # fits inside the ~1.2MB L1 cache limit of the cores.
     max_l1_usage = 1200 * 1024
     out_block_h = in0_block_h
+
+    # Compute per‑dtype tile sizes for more accurate CB and L1 usage estimates.
+    in0_tile_bytes = get_tile_size_bytes(in0_dtype)
+    in1_tile_bytes = get_tile_size_bytes(in1_dtype)
+    out_tile_bytes = get_tile_size_bytes(out_dtype)
+
     for candidate_h in range(in0_block_h, 0, -1):
         if in0_block_h % candidate_h != 0:
             continue
-        in0_cb = candidate_h * in0_block_w * 2 * 2048
-        in1_cb = out_block_w * in0_block_w * 2 * 2048
-        interm0_cb = candidate_h * out_block_w * 4096
-        output_cb = candidate_h * out_block_w * 2048
+        # in0_cb and in1_cb depend on the input dtypes.
+        in0_cb = candidate_h * in0_block_w * 2 * in0_tile_bytes
+        in1_cb = out_block_w * in0_block_w * 2 * in1_tile_bytes
+        # interm0_cb is fp32 accumulation; use the fp32 tile size from the helper.
+        interm0_cb = candidate_h * out_block_w * get_tile_size_bytes(getattr(ttnn, "float32", ttnn.bfloat16))
+        # Output CB usage depends on the output dtype.
+        output_cb = candidate_h * out_block_w * out_tile_bytes
         total = in0_cb + in1_cb + interm0_cb + output_cb
         if total <= max_l1_usage:
             out_block_h = candidate_h


### PR DESCRIPTION
### Ticket
- #37789

### Problem description
PR #37681 introduced support for 2D matmuls using DRAM_INTERLEAVED for in0 and DRAM_SHARDED for in1 (width-sharded for batch=1 and height-sharded for batch>1). However, the original implementation only included a few highly specific test cases tailored to DeepSeek models.  Issue #37789 asked for broader coverage.

### What's changed
In `tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul.py`:
- Helper: `_run_matmul_2d_interleaved_in0_sharded_in1` - runs the 2D matmul path (unbatched and batched) and checks against a PyTorch reference with PCC.
- `test_matmul_2d_interleaved_sharded_dimension_sweep` - parametrized over batch, seq_len, k, n, and DRAM bank count (64 tests).
- `test_matmul_2d_interleaved_sharded_dtype_sweep` - parametrized over in0/in1/out dtypes and optional bias (108 tests).

### Checklist

- [x] [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ign/sudha-matmul-tests)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ign/sudha-matmul-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ign/sudha-matmul-tests)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/sudha-matmul-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/sudha-matmul-tests)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/sudha-matmul-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/sudha-matmul-tests)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/sudha-matmul-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/sudha-matmul-tests)
  - [x] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/sudha-matmul-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/sudha-matmul-tests)
  - [x] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
