### PR TITLE
#38904: migrate [group_]attn_matmul and fast_reduce_nc to device 2.0

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/kernels/compute/transformer_attn_matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/kernels/compute/transformer_attn_matmul.cpp
@@ -7,6 +7,7 @@
 #include "api/compute/matmul.h"
 #include "api/compute/tilize.h"
 #include "api/compute/untilize.h"
+#include "experimental/circular_buffer.h"
 
 using std::uint32_t;
 
@@ -28,6 +29,13 @@ void kernel_main() {
     constexpr uint32_t cb_intermed2 = tt::CBIndex::c_4;
     constexpr uint32_t out_cb_id = tt::CBIndex::c_5;
 
+    experimental::CircularBuffer cb_in0_obj(cb_in0);
+    experimental::CircularBuffer cb_in1_obj(cb_in1);
+    experimental::CircularBuffer cb_intermed0_obj(cb_intermed0);
+    experimental::CircularBuffer cb_intermed1_obj(cb_intermed1);
+    experimental::CircularBuffer cb_intermed2_obj(cb_intermed2);
+    experimental::CircularBuffer cb_out_obj(out_cb_id);
+
     constexpr uint32_t num_rows_in_one_tile = 32;
 
     mm_init(cb_in0, cb_in1, cb_intermed0, transpose_hw);
@@ -40,49 +48,49 @@ void kernel_main() {
                     tile_regs_acquire();
                     for (uint32_t kt = 0; kt < Kt; ++kt) {
                         if (tile_row_id == 0) {
-                            cb_wait_front(cb_in0, kt + 1);
+                            cb_in0_obj.wait_front(kt + 1);
                         }
-                        cb_wait_front(cb_in1, onetile);
+                        cb_in1_obj.wait_front(onetile);
 
                         matmul_tiles(cb_in0, cb_in1, kt, 0, 0);
 
-                        cb_pop_front(cb_in1, onetile);
+                        cb_in1_obj.pop_front(onetile);
                     }
                     tile_regs_commit();
 
-                    cb_reserve_back(cb_intermed0, onetile);
+                    cb_intermed0_obj.reserve_back(onetile);
                     tile_regs_wait();
                     pack_tile(0, cb_intermed0);
                     tile_regs_release();
-                    cb_push_back(cb_intermed0, onetile);
+                    cb_intermed0_obj.push_back(onetile);
 
                     // untilize tile and write to CBIndex::c_25
                     reconfig_data_format_srca(cb_in1, cb_intermed0);
-                    cb_wait_front(cb_intermed0, onetile);
+                    cb_intermed0_obj.wait_front(onetile);
                     untilize_init(cb_intermed0);
-                    cb_reserve_back(cb_intermed1, onetile);
+                    cb_intermed1_obj.reserve_back(onetile);
                     untilize_block(cb_intermed0, onetile, cb_intermed1);
-                    cb_push_back(cb_intermed1, onetile);
+                    cb_intermed1_obj.push_back(onetile);
 
-                    cb_pop_front(cb_intermed0, onetile);
+                    cb_intermed0_obj.pop_front(onetile);
                     untilize_uninit(cb_intermed0);
 
                     reconfig_data_format_srca(cb_intermed0, cb_in1);
                     mm_init_short(cb_in0, cb_in1, transpose_hw);
                 }
-                cb_pop_front(cb_in0, Kt);
+                cb_in0_obj.pop_front(Kt);
 
                 // cb_intermed2 comes from reader; untilized row-major tile
                 pack_reconfig_data_format(cb_intermed1, out_cb_id);
-                cb_wait_front(cb_intermed2, onetile);
-                cb_reserve_back(out_cb_id, onetile);
+                cb_intermed2_obj.wait_front(onetile);
+                cb_out_obj.reserve_back(onetile);
 
                 // tilize CB::intermed2 and write to CBIndex::c_16
                 tilize_init_short_with_dt(cb_in1, cb_intermed2, onetile, out_cb_id);
                 tilize_block(cb_intermed2, onetile, out_cb_id);
-                cb_push_back(out_cb_id, onetile);
+                cb_out_obj.push_back(onetile);
 
-                cb_pop_front(cb_intermed2, onetile);
+                cb_intermed2_obj.pop_front(onetile);
                 tilize_uninit_with_dt(cb_intermed2, cb_in1, out_cb_id);
 
                 pack_reconfig_data_format(out_cb_id, cb_intermed0);

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/kernels/dataflow/reader_transformer_attn_matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/kernels/dataflow/reader_transformer_attn_matmul.cpp
@@ -4,6 +4,11 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
+#include "experimental/endpoints.h"
+#include "experimental/core_local_mem.h"
 
 void kernel_main() {
     // same arg indices as in reader_binary_diff_lengths for compat
@@ -28,6 +33,12 @@ void kernel_main() {
     constexpr uint32_t cb_id_intermed1 = tt::CBIndex::c_3;
     constexpr uint32_t cb_id_intermed2 = tt::CBIndex::c_4;
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_in0_obj(cb_id_in0);
+    experimental::CircularBuffer cb_in1_obj(cb_id_in1);
+    experimental::CircularBuffer cb_intermed1_obj(cb_id_intermed1);
+    experimental::CircularBuffer cb_intermed2_obj(cb_id_intermed2);
+
     constexpr uint32_t onetile = 1;
     const uint32_t in0_tile_bytes = get_tile_size(cb_id_in0);
     const uint32_t in1_tile_bytes = get_tile_size(cb_id_in1);
@@ -44,12 +55,16 @@ void kernel_main() {
     uint32_t itileA;
     uint32_t itileB;
 
-    uint32_t cb_intermed1_addr_initial = get_read_ptr(cb_id_intermed1);
-    uint32_t cb_intermed2_addr_initial = get_write_ptr(cb_id_intermed2);
+    uint32_t cb_intermed1_addr_initial = cb_intermed1_obj.get_read_ptr();
+    uint32_t cb_intermed2_addr_initial = cb_intermed2_obj.get_write_ptr();
     uint32_t cb_intermed1_addr;
     uint32_t cb_intermed2_addr;
     constexpr uint32_t bfloat16_row_bytes = fp32_acc_en ? 128 : 64;
     constexpr uint32_t num_rows_in_one_tile = 32;
+
+    uint32_t local_noc_x = my_x[noc.get_noc_id()];
+    uint32_t local_noc_y = my_y[noc.get_noc_id()];
+    experimental::UnicastEndpoint local_src;
 
     for (uint32_t b = 0; b < blocks; b++) {
         itileA_Mt = itileA_batch;
@@ -64,26 +79,24 @@ void kernel_main() {
                 itileA = itileA_Mt;
                 itileB = itileB_Nt;
 
-                cb_reserve_back(cb_id_in0, Kt);
+                cb_in0_obj.reserve_back(Kt);
                 for (uint32_t kt = 0; kt < Kt; kt++) {
                     // Read A's tile at (mt, kt)
-                    uint32_t l1_write_addr_in0 = get_write_ptr(cb_id_in0);
-                    noc_async_read_tile(itileA, s0, l1_write_addr_in0);
-                    noc_async_read_barrier();
-                    cb_push_back(cb_id_in0, onetile);
+                    noc.async_read(s0, cb_in0_obj, in0_tile_bytes, {.page_id = itileA}, {.offset_bytes = 0});
+                    noc.async_read_barrier();
+                    cb_in0_obj.push_back(onetile);
 
                     itileA++;  // A is MK
                 }
 
-                cb_reserve_back(cb_id_intermed2, 1);
+                cb_intermed2_obj.reserve_back(1);
                 for (uint32_t tile_row_id = 0; tile_row_id < num_rows_in_one_tile; tile_row_id++) {
                     for (uint32_t kt = 0; kt < Kt; kt++) {
                         // Read B's tile at (kt, nt)
-                        cb_reserve_back(cb_id_in1, onetile);
-                        uint32_t l1_write_addr_in1 = get_write_ptr(cb_id_in1);
-                        noc_async_read_tile(itileB, s1, l1_write_addr_in1);
-                        noc_async_read_barrier();
-                        cb_push_back(cb_id_in1, onetile);
+                        cb_in1_obj.reserve_back(onetile);
+                        noc.async_read(s1, cb_in1_obj, in1_tile_bytes, {.page_id = itileB}, {.offset_bytes = 0});
+                        noc.async_read_barrier();
+                        cb_in1_obj.push_back(onetile);
 
                         if constexpr (transpose_hw_bool) {
                             itileB++;  // Kt is in B[3], so it is contiguous in memory
@@ -93,16 +106,22 @@ void kernel_main() {
                     }  // Kt loop
 
                     // Read 32 untilized tiles and select correct rows to reconstruct single correct tile
-                    cb_wait_front(cb_id_intermed1, 1);
-                    noc_async_read(get_noc_addr(cb_intermed1_addr), cb_intermed2_addr, bfloat16_row_bytes);
-                    noc_async_read_barrier();
-                    cb_pop_front(cb_id_intermed1, 1);
+                    cb_intermed1_obj.wait_front(1);
+                    experimental::CoreLocalMem<uint32_t> local_dst(cb_intermed2_addr);
+                    noc.async_read(
+                        local_src,
+                        local_dst,
+                        bfloat16_row_bytes,
+                        {.noc_x = local_noc_x, .noc_y = local_noc_y, .addr = cb_intermed1_addr},
+                        {});
+                    noc.async_read_barrier();
+                    cb_intermed1_obj.pop_front(1);
                     cb_intermed1_addr += bfloat16_row_bytes;
                     cb_intermed2_addr += bfloat16_row_bytes;
 
                     itileB += in1_KtNt_skip;  // different depending on transpose_hw
                 }  // 32 tiles loop
-                cb_push_back(cb_id_intermed2, 1);
+                cb_intermed2_obj.push_back(1);
 
                 // Next tile in Nt
                 if constexpr (transpose_hw_bool) {

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/kernels/compute/transformer_group_attn_matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/kernels/compute/transformer_group_attn_matmul.cpp
@@ -7,6 +7,7 @@
 #include "api/compute/matmul.h"
 #include "api/compute/tilize.h"
 #include "api/compute/pack_untilize.h"
+#include "experimental/circular_buffer.h"
 
 using std::uint32_t;
 
@@ -49,6 +50,12 @@ void kernel_main() {
     constexpr uint32_t cb_intermed1 = tt::CBIndex::c_4;
     constexpr uint32_t out_cb_id = tt::CBIndex::c_5;
 
+    experimental::CircularBuffer cb_in0_obj(cb_in0);
+    experimental::CircularBuffer cb_in1_obj(cb_in1);
+    experimental::CircularBuffer cb_intermed0_obj(cb_intermed0);
+    experimental::CircularBuffer cb_intermed1_obj(cb_intermed1);
+    experimental::CircularBuffer cb_out_obj(out_cb_id);
+
     constexpr uint32_t onetile = 1;
     constexpr uint32_t num_rows_in_one_tile = 32;
     constexpr uint32_t in0_num_blocks_w = 1; // TODO: Generalize
@@ -66,13 +73,13 @@ void kernel_main() {
 
         for (uint32_t m = 0; m < Mt; m++) {  // TODO: Must be 1; generalize to support batch > 32 (ie. Mt > 1)
             for (uint32_t in0_block = 0; in0_block < in0_num_blocks_w; in0_block++) { // TODO: Must be 1; generalize to support inner dim blocking
-                cb_wait_front(cb_in0, in0_block_num_tiles);
+                cb_in0_obj.wait_front(in0_block_num_tiles);
 
                 for (uint32_t in1_block = 0; in1_block < in1_num_blocks; in1_block++) {
                     uint32_t in0_index_subblock_offset = 0;
                     for (uint32_t tile_row_id = 0; tile_row_id < num_rows_in_one_tile; tile_row_id++) {
-                        cb_wait_front(cb_in1, in1_block_num_tiles);
-                        cb_pop_front(cb_in1, num_kv_heads_skip);
+                        cb_in1_obj.wait_front(in1_block_num_tiles);
+                        cb_in1_obj.pop_front(num_kv_heads_skip);
 
 			// This init changes DEST mapping, hence needs to be called before MATH does any processing, so that it has correct DEST mapping.
                         pack_untilize_dest_init<intermediate_num_tiles>(cb_intermed0);
@@ -134,16 +141,16 @@ void kernel_main() {
 
                             in1_index_subblock_offset += out_subblock_w;
                         } // in1_num_subblocks loop
-                        cb_pop_front(cb_in1, num_kv_heads_remaining);
+                        cb_in1_obj.pop_front(num_kv_heads_remaining);
                         // TODO: Review inner dim blocking, untilizing, and in1_num_subblocks > 1 (with pack_untilize, can only untilize up to dst num tiles)
                         // This should normally be inside subblock loop and we pack out out_subblock_num_tiles
-                        cb_reserve_back(cb_intermed0, intermediate_num_tiles);
+                        cb_intermed0_obj.reserve_back(intermediate_num_tiles);
                         tile_regs_wait();
                         pack_untilize_dest<intermediate_num_tiles>(cb_intermed0);
                         pack_untilize_uninit(cb_intermed0);
 
                         tile_regs_release();
-                        cb_push_back(cb_intermed0, intermediate_num_tiles);
+                        cb_intermed0_obj.push_back(intermediate_num_tiles);
 
                     }  // 32 tiles loop
 
@@ -154,19 +161,19 @@ void kernel_main() {
             // cb_intermed1 comes from reader; untilized row-major tile
             reconfig_data_format_srca(cb_in1, cb_intermed1);
             pack_reconfig_data_format(cb_intermed0, out_cb_id);
-            cb_wait_front(cb_intermed1, out_num_tiles);
+            cb_intermed1_obj.wait_front(out_num_tiles);
 
-            cb_reserve_back(out_cb_id, out_num_tiles);
+            cb_out_obj.reserve_back(out_num_tiles);
 
             // tilize CB::intermed1 and write to CBIndex::c_16
             tilize_init_short_with_dt(cb_in1, cb_intermed1, out_num_tiles, out_cb_id);
             tilize_block(cb_intermed1, out_num_tiles, out_cb_id);
-            cb_push_back(out_cb_id, out_num_tiles);
+            cb_out_obj.push_back(out_num_tiles);
 
-            cb_pop_front(cb_intermed1, out_num_tiles);
+            cb_intermed1_obj.pop_front(out_num_tiles);
             tilize_uninit(cb_intermed1, out_cb_id);
 
-            cb_pop_front(cb_in0, in0_block_num_tiles);
+            cb_in0_obj.pop_front(in0_block_num_tiles);
         } // Mt loop
     }  // batch
 

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/kernels/dataflow/reader_mcast_transformer_group_attn_matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/kernels/dataflow/reader_mcast_transformer_group_attn_matmul.cpp
@@ -4,6 +4,12 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
+#include "experimental/noc_semaphore.h"
+#include "experimental/endpoints.h"
+#include "experimental/core_local_mem.h"
 
 void kernel_main() {
     uint32_t i = 0;
@@ -45,8 +51,8 @@ void kernel_main() {
     uint32_t in1_mcast_num_dests = get_arg_val<uint32_t>(i++);
     uint32_t in1_mcast_num_cores = get_arg_val<uint32_t>(i++);
     uint32_t in1_mcast_grid_size = get_arg_val<uint32_t>(i++);
-    uint32_t in1_mcast_sender_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(i++));
-    uint32_t in1_mcast_receiver_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(i++));
+    experimental::Semaphore<> sender_sem(get_arg_val<uint32_t>(i++));
+    experimental::Semaphore<> receiver_sem(get_arg_val<uint32_t>(i++));
 
     uint32_t in1_mcast_sender_size_bytes = get_arg_val<uint32_t>(i++);
     uint32_t in1_mcast_sender_id = get_arg_val<uint32_t>(i++);
@@ -64,6 +70,10 @@ void kernel_main() {
     constexpr uint32_t cb_id_in1 = 1;  // mcast receive all kv_heads; compute chooses which kv_heads to use for matmul
     constexpr uint32_t cb_id_in2 = 2;  // all interleaved or sharded KV heads for one user batch
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_in1_obj(cb_id_in1);
+    experimental::CircularBuffer cb_in2_obj(cb_id_in2);
+
     constexpr uint32_t num_rows_in_one_tile = 32;
     const uint32_t in1_tile_bytes = get_tile_size(cb_id_in1);
     constexpr uint32_t in0_num_blocks_w = 1;  // TODO: Must be 1; generalize to support inner dim blocking
@@ -74,21 +84,17 @@ void kernel_main() {
 #endif
 
     // Mcast setup
-    // Set ur local VALID value, to be mcasted to destinations flag address after the data has been mcasted
-    volatile tt_l1_ptr uint32_t* in1_mcast_receiver_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in1_mcast_receiver_semaphore_addr);
-    noc_semaphore_set(in1_mcast_receiver_semaphore_addr_ptr, VALID);
-    // local address that will be atomically incremented by mcast receivers, to know when all receivers are ready
-    // to receive the mcast
-    volatile tt_l1_ptr uint32_t* in1_mcast_sender_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in1_mcast_sender_semaphore_addr);
+    // Set our local VALID value, to be mcasted to destinations flag address after the data has been mcasted
+    receiver_sem.set(VALID);
 
-    uint64_t in1_mcast_sender_semaphore_noc_addr_vec[num_rows_in_one_tile];
+    // Pre-compute sender core coordinates for each tile_row_id (for receiver to increment sender semaphore)
+    uint32_t sender_sem_noc_x_vec[num_rows_in_one_tile];
+    uint32_t sender_sem_noc_y_vec[num_rows_in_one_tile];
     if constexpr (row_major) {
         uint32_t x = 0, y = 0;
         for (uint32_t i = 0; i < num_rows_in_one_tile; ++i) {
-            in1_mcast_sender_semaphore_noc_addr_vec[i] =
-                get_noc_addr(in1_mcast_sender_noc_x[x], in1_mcast_sender_noc_y[y], in1_mcast_sender_semaphore_addr);
+            sender_sem_noc_x_vec[i] = in1_mcast_sender_noc_x[x];
+            sender_sem_noc_y_vec[i] = in1_mcast_sender_noc_y[y];
             ++x;
             if (x == in1_mcast_sender_num_x) {
                 x = 0;
@@ -98,8 +104,8 @@ void kernel_main() {
     } else {
         uint32_t x = 0, y = 0;
         for (uint32_t i = 0; i < num_rows_in_one_tile; ++i) {
-            in1_mcast_sender_semaphore_noc_addr_vec[i] =
-                get_noc_addr(in1_mcast_sender_noc_x[x], in1_mcast_sender_noc_y[y], in1_mcast_sender_semaphore_addr);
+            sender_sem_noc_x_vec[i] = in1_mcast_sender_noc_x[x];
+            sender_sem_noc_y_vec[i] = in1_mcast_sender_noc_y[y];
             ++y;
             if (y == in1_mcast_sender_num_y) {
                 y = 0;
@@ -108,19 +114,17 @@ void kernel_main() {
         }
     }
 
-    uint64_t in1_multicast_noc_addr = get_noc_multicast_addr(
-        in1_mcast_dest_noc_start_x, in1_mcast_dest_noc_start_y, in1_mcast_dest_noc_end_x, in1_mcast_dest_noc_end_y, 0);
-
-    uint64_t in1_mcast_receiver_semaphore_noc_addr = in1_multicast_noc_addr | in1_mcast_receiver_semaphore_addr;
+    uint32_t local_noc_x = my_x[noc.get_noc_id()];
+    uint32_t local_noc_y = my_y[noc.get_noc_id()];
+    experimental::UnicastEndpoint local_src;
 
     const bool in1_sender_in_receiver_grid = in1_mcast_sender_id < in1_mcast_grid_size;
     bool mcast_in1_to_local_cb = false;
-    uint32_t in1_sharded_cb_addr = get_read_ptr(cb_id_in2);
+    uint32_t in1_sharded_cb_addr = cb_in2_obj.get_read_ptr();
 #ifdef IN1_SHARDED
     // Only used for sharded
     // Don't need to track batch because user batch must be 32 (ie. Mt must be 1)
-    uint64_t in1_sharded_cb_noc_addr_Nt = get_noc_addr(in1_sharded_cb_addr);
-    uint64_t in1_sharded_cb_noc_addr;
+    uint32_t in1_sharded_l1_addr_Nt = in1_sharded_cb_addr;
     uint32_t in1_block_w_tile_read_bytes = in1_block_w_tile_bytes;
     if (in1_num_blocks == 1) {
         mcast_in1_to_local_cb =
@@ -161,8 +165,8 @@ void kernel_main() {
                 for (uint32_t tile_row_id = 0; tile_row_id < num_rows_in_one_tile; tile_row_id++) {
                     for (uint32_t in0_block = 0; in0_block < in0_num_blocks_w;
                          in0_block++) {  // TODO: Must be 1; generalize to support inner dim blocking
-                        cb_reserve_back(cb_id_in1, in1_block_num_tiles);
-                        uint32_t l1_write_addr_in1 = get_write_ptr(cb_id_in1);
+                        cb_in1_obj.reserve_back(in1_block_num_tiles);
+                        uint32_t l1_write_addr_in1 = cb_in1_obj.get_write_ptr();
 
                         for (uint32_t in1_subblock = 0; in1_subblock < in1_num_subblocks;
                              in1_subblock++) {  // TODO: Must be 1; for generic padding, need full + partial subblocks
@@ -178,76 +182,104 @@ void kernel_main() {
                                     // work to writer)
 
                                     // Copy to cb_id_in1 to mcast
-                                    uint64_t in1_sharded_cb_noc_addr = in1_sharded_cb_noc_addr_Nt;
-                                    uint32_t in1_current_l1_write_addr = l1_write_addr_in1;
+                                    uint32_t in1_sharded_l1_addr = in1_sharded_l1_addr_Nt;
+                                    uint32_t write_offset = 0;
                                     for (uint32_t kv_heads_id = 0; kv_heads_id < num_kv_heads; kv_heads_id++) {
                                         for (uint32_t inner_dim = 0; inner_dim < in0_block_w; inner_dim++) {
-                                            noc_async_read(
-                                                in1_sharded_cb_noc_addr,
-                                                in1_current_l1_write_addr,
-                                                in1_block_w_tile_read_bytes);
-                                            in1_sharded_cb_noc_addr += Nt_bytes;  // Increment by Nt to get to next kt
-                                            in1_current_l1_write_addr += in1_block_w_tile_bytes;
+                                            noc.async_read(
+                                                local_src,
+                                                cb_in1_obj,
+                                                in1_block_w_tile_read_bytes,
+                                                {.noc_x = local_noc_x,
+                                                 .noc_y = local_noc_y,
+                                                 .addr = in1_sharded_l1_addr},
+                                                {.offset_bytes = write_offset});
+                                            in1_sharded_l1_addr += Nt_bytes;  // Increment by Nt to get to next kt
+                                            write_offset += in1_block_w_tile_bytes;
                                         }
                                         // Next head follows after finishing KtNt, so no need to increment
-                                        // in1_current_l1_write_addr
+                                        // write_offset
                                     }
                                     // These indices are local to each core, so don't modify when looping
                                     // num_rows_in_one_tile
-                                    noc_async_read_barrier();
+                                    noc.async_read_barrier();
                                 }
 #else
                                 uint32_t in1_tensor_id_along_Kt = in1_tensor_id;
-                                uint32_t in1_current_l1_write_addr = l1_write_addr_in1;
+                                uint32_t write_offset = 0;
                                 for (uint32_t kv_heads_id = 0; kv_heads_id < num_kv_heads; kv_heads_id++) {
                                     for (uint32_t inner_dim = 0; inner_dim < in0_block_w; inner_dim++) {
                                         uint32_t in1_tensor_current_id = in1_tensor_id_along_Kt;
                                         for (uint32_t w = 0; w < out_subblock_w_; w++) {
-                                            noc_async_read_tile(in1_tensor_current_id, s1, in1_current_l1_write_addr);
+                                            noc.async_read(
+                                                s1,
+                                                cb_in1_obj,
+                                                in1_tile_bytes,
+                                                {.page_id = in1_tensor_current_id},
+                                                {.offset_bytes = write_offset});
                                             in1_tensor_current_id++;  // Increment to get next Nt
-                                            in1_current_l1_write_addr += in1_tile_bytes;
+                                            write_offset += in1_tile_bytes;
                                         }
-                                        in1_current_l1_write_addr += in1_block_addr_skip;
+                                        write_offset += in1_block_addr_skip;
                                         in1_tensor_id_along_Kt += Nt;  // Increment by Nt to get next Kt
                                     }
                                     // Next head follows after finishing KtNt, so no need to increment
                                 }
-                                noc_async_read_barrier();
+                                noc.async_read_barrier();
 #endif
 
                                 // wait until all in1 mcast destinations have atomically incremented the in1
                                 // semaphore_addr (i.e. its value should be in1_mcast_num_dests), then reset the
                                 // semaphore_addr value back to zero for the next block
-                                noc_semaphore_wait(in1_mcast_sender_semaphore_addr_ptr, in1_mcast_num_dests);
-                                noc_semaphore_set(in1_mcast_sender_semaphore_addr_ptr, 0);
+                                sender_sem.wait(in1_mcast_num_dests);
+                                sender_sem.set(0);
 
                                 // Now we have the block in the CB address, we can mcast to dests!
-                                uint64_t in1_multicast_data_addr = in1_multicast_noc_addr | l1_write_addr_in1;
                                 if (mcast_in1_to_local_cb) {  // directly mcast data in in1 sharded cb
+                                    experimental::CoreLocalMem<uint32_t> mcast_src(in1_sharded_cb_addr);
                                     if (in1_sender_in_receiver_grid) {
                                         // if sender is in receiver grid, num_dests will include source, since we are
                                         // copying to a different local CB as well
-                                        noc_async_write_multicast_loopback_src(
-                                            in1_sharded_cb_addr,
-                                            in1_multicast_data_addr,
+                                        noc.async_write_multicast<experimental::Noc::McastMode::INCLUDE_SRC>(
+                                            mcast_src,
+                                            cb_in1_obj,
                                             in1_mcast_sender_size_bytes,
-                                            in1_mcast_num_cores + 1);
+                                            in1_mcast_num_cores + 1,
+                                            {},
+                                            {.noc_x_start = in1_mcast_dest_noc_start_x,
+                                             .noc_y_start = in1_mcast_dest_noc_start_y,
+                                             .noc_x_end = in1_mcast_dest_noc_end_x,
+                                             .noc_y_end = in1_mcast_dest_noc_end_y,
+                                             .offset_bytes = 0});
                                     } else {
                                         // if sender is not in receiver grid, do a regular multicast but from
                                         // in1_sharded_cb_addr
-                                        noc_async_write_multicast(
-                                            in1_sharded_cb_addr,
-                                            in1_multicast_data_addr,
+                                        noc.async_write_multicast<experimental::Noc::McastMode::EXCLUDE_SRC>(
+                                            mcast_src,
+                                            cb_in1_obj,
                                             in1_mcast_sender_size_bytes,
-                                            in1_mcast_num_cores);
+                                            in1_mcast_num_cores,
+                                            {},
+                                            {.noc_x_start = in1_mcast_dest_noc_start_x,
+                                             .noc_y_start = in1_mcast_dest_noc_start_y,
+                                             .noc_x_end = in1_mcast_dest_noc_end_x,
+                                             .noc_y_end = in1_mcast_dest_noc_end_y,
+                                             .offset_bytes = 0});
                                     }
                                 } else {  // mcast from l1_write_addr_in1 which is populated locally by copying from in1
                                           // sharded or interleaved
-                                    noc_async_write_multicast(
-                                        l1_write_addr_in1,
-                                        in1_multicast_data_addr,
+                                    experimental::CoreLocalMem<uint32_t> mcast_src(l1_write_addr_in1);
+                                    noc.async_write_multicast<experimental::Noc::McastMode::EXCLUDE_SRC>(
+                                        mcast_src,
+                                        cb_in1_obj,
                                         in1_mcast_sender_size_bytes,
-                                        in1_mcast_num_cores);
+                                        in1_mcast_num_cores,
+                                        {},
+                                        {.noc_x_start = in1_mcast_dest_noc_start_x,
+                                         .noc_y_start = in1_mcast_dest_noc_start_y,
+                                         .noc_x_end = in1_mcast_dest_noc_end_x,
+                                         .noc_y_end = in1_mcast_dest_noc_end_y,
+                                         .offset_bytes = 0});
                                 }
 
                                 // Note: no need for write barrier, since these two multicasts are done on the same noc
@@ -256,42 +288,44 @@ void kernel_main() {
 #ifdef ARCH_BLACKHOLE
                                 // On Blackhole the flush is needed because the commands go into separate cmd buffer
                                 // FIFOs and may not be sent in order they are issued
-                                noc_async_writes_flushed();
+                                noc.async_writes_flushed();
 #endif
 
                                 // We should also multicast VALID flag to destinations for receiver semaphore
-                                noc_semaphore_set_multicast(
-                                    in1_mcast_receiver_semaphore_addr,
-                                    in1_mcast_receiver_semaphore_noc_addr,
+                                receiver_sem.set_multicast(
+                                    noc,
+                                    in1_mcast_dest_noc_start_x,
+                                    in1_mcast_dest_noc_start_y,
+                                    in1_mcast_dest_noc_end_x,
+                                    in1_mcast_dest_noc_end_y,
                                     in1_mcast_num_cores);
 
                                 // Write barrier needed to make sure we finish sending mcast flag before we modify
                                 // locally
-                                noc_async_write_barrier();
+                                noc.async_write_barrier();
                             } else if (in1_sender_in_receiver_grid) {
                                 // MCAST RECEIVER: receive all kv_heads in one user batch
                                 // All cores in mcast grid needs to participate in receiving otherwise data corruption
                                 // since we mcast from and to the same CB
 
                                 // Set in1 semaphore value to INVALID
-                                noc_semaphore_set(in1_mcast_receiver_semaphore_addr_ptr, INVALID);
+                                receiver_sem.set(INVALID);
 
                                 // Atomic increment source core counter
-                                uint64_t in1_mcast_sender_semaphore_noc_addr =
-                                    in1_mcast_sender_semaphore_noc_addr_vec[tile_row_id];
-                                noc_semaphore_inc(in1_mcast_sender_semaphore_noc_addr, 1);
+                                sender_sem.up(
+                                    noc, sender_sem_noc_x_vec[tile_row_id], sender_sem_noc_y_vec[tile_row_id], 1);
 
                                 // wait on in1 semaphore value to become VALID (set by mcast sender after it multicasts
                                 // data)
-                                noc_semaphore_wait(in1_mcast_receiver_semaphore_addr_ptr, VALID);
+                                receiver_sem.wait(VALID);
                             }
                             if (has_work_for_q_heads_bool) {
-                                cb_push_back(cb_id_in1, in1_block_num_tiles);
+                                cb_in1_obj.push_back(in1_block_num_tiles);
                             } else {
                                 // Mcast is in lockstep; this makes write ptr addresses are synced properly for cores
                                 // that only send and have no compute / writer active
-                                cb_push_back(cb_id_in1, in1_block_num_tiles);
-                                cb_pop_front(cb_id_in1, in1_block_num_tiles);
+                                cb_in1_obj.push_back(in1_block_num_tiles);
+                                cb_in1_obj.pop_front(in1_block_num_tiles);
                             }
 
 #ifndef IN1_SHARDED
@@ -302,7 +336,7 @@ void kernel_main() {
                 }  // 32 tiles loop
 
 #ifdef IN1_SHARDED
-                in1_sharded_cb_noc_addr_Nt += in1_block_w_tile_bytes;
+                in1_sharded_l1_addr_Nt += in1_block_w_tile_bytes;
 #else
                 in1_tensor_id_along_Nt += out_block_w;
 #endif

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/kernels/dataflow/writer_transformer_group_attn_matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/kernels/dataflow/writer_transformer_group_attn_matmul.cpp
@@ -3,6 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
+#include "experimental/endpoints.h"
+#include "experimental/core_local_mem.h"
 
 void kernel_main() {
     uint32_t i = 0;
@@ -43,6 +48,12 @@ void kernel_main() {
     constexpr uint32_t cb_id_intermed0 = tt::CBIndex::c_3;
     constexpr uint32_t cb_id_intermed1 = tt::CBIndex::c_4;
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_in0_obj(cb_id_in0);
+    experimental::CircularBuffer cb_intermed0_obj(cb_id_intermed0);
+    experimental::CircularBuffer cb_intermed1_obj(cb_id_intermed1);
+    experimental::CircularBuffer cb_out_obj(cb_id_out);
+
     constexpr uint32_t onetile = 1;
     constexpr uint32_t num_rows_in_one_tile = 32;
     const uint32_t in1_tile_bytes = get_tile_size(cb_id_in1);
@@ -73,6 +84,10 @@ void kernel_main() {
 
     uint32_t bfloat16_row_bytes_read = bfloat16_row_bytes;
 
+    uint32_t local_noc_x = my_x[noc.get_noc_id()];
+    uint32_t local_noc_y = my_y[noc.get_noc_id()];
+    experimental::UnicastEndpoint local_src;
+
     for (uint32_t b = 0; b < blocks; b++) {  // TODO: Must be 1
 #ifndef IN0_SHARDED
         in0_Mt = in0_batch;
@@ -80,24 +95,25 @@ void kernel_main() {
 
         for (uint32_t m = 0; m < Mt; m++) {  // TODO: Must be 1; generalize to support batch > 32 (ie. Mt > 1)
             // TODO: Generalize to support inner dim blocking; in0 reads has to moved within num_rows_in_one_tile loop
-            cb_reserve_back(cb_id_in0, in0_block_w);
+            cb_in0_obj.reserve_back(in0_block_w);
 #ifndef IN0_SHARDED
             in0_tensor_id = in0_Mt;
-            uint32_t l1_write_addr_in0 = get_write_ptr(cb_id_in0);
+            uint32_t write_offset_in0 = 0;
             for (uint32_t inner_dim = 0; inner_dim < in0_block_w; inner_dim++) {
                 // Read in0 block
-                noc_async_read_tile(in0_tensor_id, s0, l1_write_addr_in0);
+                noc.async_read(
+                    s0, cb_in0_obj, in0_tile_bytes, {.page_id = in0_tensor_id}, {.offset_bytes = write_offset_in0});
 
-                l1_write_addr_in0 += in0_tile_bytes;
+                write_offset_in0 += in0_tile_bytes;
                 in0_tensor_id++;
             }
-            noc_async_read_barrier();
+            noc.async_read_barrier();
 #endif
 
-            cb_push_back(cb_id_in0, in0_block_w);
+            cb_in0_obj.push_back(in0_block_w);
 
-            cb_reserve_back(cb_id_intermed1, out_num_tiles);
-            uint32_t cb_intermed1_addr = get_write_ptr(cb_id_intermed1);
+            cb_intermed1_obj.reserve_back(out_num_tiles);
+            uint32_t cb_intermed1_addr = cb_intermed1_obj.get_write_ptr();
             for (uint32_t in1_block = 0; in1_block < in1_num_blocks; in1_block++) {
                 const bool last_out = in1_block == in1_num_blocks - 1;
                 if (last_out) {
@@ -112,13 +128,17 @@ void kernel_main() {
                          in1_subblock++) {  // TODO: Must be 1; to generalize, need to handle untilizing + reading for
                                             // subblocks
                         // Read 32 untilized tiles and select correct rows to reconstruct single correct tile
-                        cb_wait_front(cb_id_intermed0, intermediate_num_tiles);
-                        noc_async_read(
-                            get_noc_addr(get_read_ptr(cb_id_intermed0)) + row_offset_bytes,
-                            cb_intermed1_addr_curr_block,
-                            bfloat16_row_bytes_read);
-                        noc_async_read_barrier();
-                        cb_pop_front(cb_id_intermed0, intermediate_num_tiles);
+                        cb_intermed0_obj.wait_front(intermediate_num_tiles);
+                        uint32_t src_addr = cb_intermed0_obj.get_read_ptr() + row_offset_bytes;
+                        experimental::CoreLocalMem<uint32_t> local_dst(cb_intermed1_addr_curr_block);
+                        noc.async_read(
+                            local_src,
+                            local_dst,
+                            bfloat16_row_bytes_read,
+                            {.noc_x = local_noc_x, .noc_y = local_noc_y, .addr = src_addr},
+                            {});
+                        noc.async_read_barrier();
+                        cb_intermed0_obj.pop_front(intermediate_num_tiles);
                         row_offset_bytes += bfloat16_row_bytes;
                         cb_intermed1_addr_curr_block += bfloat16_Nt_bytes;
                     }  // in1_num_subblocks loop
@@ -130,19 +150,20 @@ void kernel_main() {
                 cb_intermed1_addr += bfloat16_row_bytes;
 
             }  // in1_num_blocks loop
-            cb_push_back(cb_id_intermed1, out_num_tiles);
+            cb_intermed1_obj.push_back(out_num_tiles);
 
 #ifndef OUT_SHARDED
-            cb_wait_front(cb_id_out, out_num_tiles);
-            uint32_t l1_read_addr_out = get_read_ptr(cb_id_out);
+            cb_out_obj.wait_front(out_num_tiles);
+            uint32_t read_offset_out = 0;
             for (uint32_t nt = 0; nt < Nt;
                  nt++) {  // TODO: Must be full MtNt; generalize to support Mt > 1 or blocks > 1
-                noc_async_write_tile(out_tensor_id, s, l1_read_addr_out);
-                l1_read_addr_out += out_tile_bytes;
+                noc.async_write(
+                    cb_out_obj, s, out_tile_bytes, {.offset_bytes = read_offset_out}, {.page_id = out_tensor_id});
+                read_offset_out += out_tile_bytes;
                 out_tensor_id++;
             }
-            noc_async_write_barrier();
-            cb_pop_front(cb_id_out, out_num_tiles);
+            noc.async_write_barrier();
+            cb_out_obj.pop_front(out_num_tiles);
 #endif
         }  // Mt loop
 
@@ -152,6 +173,6 @@ void kernel_main() {
     }  // B loop
 
 #ifdef OUT_SHARDED
-    cb_wait_front(cb_id_out, out_num_tiles);
+    cb_out_obj.wait_front(out_num_tiles);
 #endif
 }

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/kernels/reader_reduce_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/kernels/reader_reduce_nc.cpp
@@ -4,6 +4,9 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/kernel/dataflow/generate_reduce_scaler.hpp"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 
 inline uint32_t get_read_tile_id(uint32_t output_tile_id, uint32_t reduce_tile_size, uint32_t inner_tile_size) {
     return ((output_tile_id / inner_tile_size) * reduce_tile_size) + (output_tile_id % inner_tile_size);
@@ -31,13 +34,16 @@ void kernel_main() {
     constexpr uint32_t cb_id_in1 = 1;
     constexpr uint32_t scaler = 0;
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_in0_obj(cb_id_in0);
+
     generate_reduce_scaler(cb_id_in1, scaler);
 
-    uint32_t l1_write_addr_in0;
     constexpr uint32_t input_tile_bytes = get_tile_size(cb_id_in0);
 
     auto tensor_accessor = TensorAccessor(tensor_args, input_addr, input_tile_bytes);
     uint32_t input_granularity_index = 0;
+    uint32_t write_offset = 0;
 
     // For each shard, start at the index of the first shard to be reduced (same
     // index as output), then increment by the appropriate increment (based on
@@ -59,16 +65,21 @@ void kernel_main() {
             // 128+130, 128+260, and 128+390.
             for (uint32_t j = 0; j < num_input_tiles; ++j) {
                 if (input_granularity_index == 0) {
-                    cb_reserve_back(cb_id_in0, input_granularity);
-                    l1_write_addr_in0 = get_write_ptr(cb_id_in0);
+                    cb_in0_obj.reserve_back(input_granularity);
+                    write_offset = 0;
                 }
-                noc_async_read_page(read_tile_id, tensor_accessor, l1_write_addr_in0);
-                l1_write_addr_in0 += input_tile_bytes;
+                noc.async_read(
+                    tensor_accessor,
+                    cb_in0_obj,
+                    input_tile_bytes,
+                    {.page_id = read_tile_id},
+                    {.offset_bytes = write_offset});
+                write_offset += input_tile_bytes;
                 read_tile_id += inner_tile_size;
                 input_granularity_index++;
                 if (input_granularity_index == input_granularity) {
-                    noc_async_read_barrier();
-                    cb_push_back(cb_id_in0, input_granularity);
+                    noc.async_read_barrier();
+                    cb_in0_obj.push_back(input_granularity);
                     input_granularity_index = 0;
                 }
             }

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/kernels/reduce_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/kernels/reduce_nc.cpp
@@ -4,6 +4,7 @@
 
 #include "api/compute/common.h"
 #include "api/compute/eltwise_binary.h"
+#include "experimental/circular_buffer.h"
 
 void kernel_main() {
     // compile-time args
@@ -19,10 +20,14 @@ void kernel_main() {
     constexpr uint32_t dst1 = 1;
     constexpr uint32_t first_tile = 0;
 
+    experimental::CircularBuffer cb_in0_obj(cb_in0);
+    experimental::CircularBuffer cb_in1_obj(cb_in1);
+    experimental::CircularBuffer cb_out0_obj(cb_out0);
+
     constexpr uint32_t num_input_tiles_iter = num_input_tiles / input_granularity;
 
     binary_op_init_common(cb_in0, cb_in1, cb_out0);
-    cb_wait_front(cb_in1, onetile);
+    cb_in1_obj.wait_front(onetile);
 
     // For each assigned output tile, process the input tiles in a doubly nested
     // loop. The inner loop processes the number of tiles specified by
@@ -33,18 +38,18 @@ void kernel_main() {
         reconfig_data_format(cb_in0, cb_in1);
         tile_regs_acquire();
         for (uint32_t j = 0; j < num_input_tiles_iter; ++j) {
-            cb_wait_front(cb_in0, input_granularity);
+            cb_in0_obj.wait_front(input_granularity);
             for (uint32_t k = 0; k < input_granularity; k++) {
                 add_tiles(cb_in0, cb_in1, k, first_tile, dst0);
             }
-            cb_pop_front(cb_in0, input_granularity);
+            cb_in0_obj.pop_front(input_granularity);
         }
         tile_regs_commit();
-        cb_reserve_back(cb_out0, onetile);
+        cb_out0_obj.reserve_back(onetile);
         pack_reconfig_data_format(cb_out0);
         tile_regs_wait();
         pack_tile(dst0, cb_out0);
         tile_regs_release();
-        cb_push_back(cb_out0, onetile);
+        cb_out0_obj.push_back(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/kernels/writer_reduce_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/kernels/writer_reduce_nc.cpp
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 
 void kernel_main() {
     // compile-time args
@@ -19,6 +22,9 @@ void kernel_main() {
     constexpr uint32_t cb_id_out = 16;
     constexpr uint32_t onetile = 1;
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_out_obj(cb_id_out);
+
     uint32_t output_tile_bytes = get_tile_size(cb_id_out);
 
     auto tensor_accessor = TensorAccessor(tensor_args, output_addr, output_tile_bytes);
@@ -31,12 +37,11 @@ void kernel_main() {
         for (uint32_t id_offset = 0; id_offset < shard_factor; id_offset++) {
             uint32_t i = outer_id + id_offset;
             uint32_t write_tile_id = i;
-            cb_wait_front(cb_id_out, onetile);
-
-            uint32_t l1_read_addr = get_read_ptr(cb_id_out);
-            noc_async_write_page(write_tile_id, tensor_accessor, l1_read_addr);
-            noc_async_write_barrier();
-            cb_pop_front(cb_id_out, onetile);
+            cb_out_obj.wait_front(onetile);
+            noc.async_write(
+                cb_out_obj, tensor_accessor, output_tile_bytes, {.offset_bytes = 0}, {.page_id = write_tile_id});
+            noc.async_write_barrier();
+            cb_out_obj.pop_front(onetile);
         }
     }
 }


### PR DESCRIPTION
### Ticket
Link to Github Issue #38904

### Problem description
There is a new device 2.0 api

### What's changed
Move group_attn_matmul, attn_matmul, and fast_reduce_nc to the new api

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=bbradel-38904_attn_mm_red_nc_dm20)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:bbradel-38904_attn_mm_red_nc_dm20)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-38904_attn_mm_red_nc_dm20)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-38904_attn_mm_red_nc_dm20)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-38904_attn_mm_red_nc_dm20)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-38904_attn_mm_red_nc_dm20)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-38904_attn_mm_red_nc_dm20)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-38904_attn_mm_red_nc_dm20)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-38904_attn_mm_red_nc_dm20)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-38904_attn_mm_red_nc_dm20)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-38904_attn_mm_red_nc_dm20)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-38904_attn_mm_red_nc_dm20)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
