### PR TITLE
[skip ci][Galaxy Stress tests] Add timeouts to stress test commands

### DIFF
--- a/.github/workflows/galaxy-stress-tests-impl.yaml
+++ b/.github/workflows/galaxy-stress-tests-impl.yaml
@@ -64,7 +64,7 @@ jobs:
         run: |
           for i in {1..5}; do
             echo "🔁 Run #$i"
-            timeout --preserve-status 1200 pytest models/demos/llama3_70b_galaxy/demo/demo_decode.py -k "nd-hang-test"
+            timeout --preserve-status 1200 pytest models/demos/llama3_70b_galaxy/demo/demo_decode.py -k "nd-hang-test" --timeout=1200
           done
       - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
@@ -82,14 +82,14 @@ jobs:
           {
             name: "Galaxy Fabric Stability Tests",
             arch: wormhole_b0,
-            cmd: TT_METAL_CLEAR_L1=1 build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_stability_6U_galaxy.yaml,
+            cmd: TT_METAL_CLEAR_L1=1 build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_stability_6U_galaxy.yaml --timeout=6000,
             timeout: 100,
             owner_id: U08FXFFH7L0
           }, # Abhishek Agarwal
           {
             name: "Llama Galaxy Long Stress Test",
             arch: wormhole_b0,
-            cmd: "LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ FAKE_DEVICE=TG pytest models/demos/llama3_70b_galaxy/demo/demo_decode.py  -k 'stress-test and not mini-stress-test'",
+            cmd: "LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ FAKE_DEVICE=TG pytest models/demos/llama3_70b_galaxy/demo/demo_decode.py  -k 'stress-test and not mini-stress-test' --timeout=8400",
             timeout: 140,
             owner_id: U053W15B6JF
           } # Djordje Ivanovic


### PR DESCRIPTION
### Problem description
pytest.ini defines per pytest default timeout to 300s while stress tests last way longer than that.

### What's changed
Updated pytest commands to reflect relevant timelines as in CI job configurations. Timeouts can be updated once we have passing run based on execution time.

failing CI run due to timeout: https://github.com/tenstorrent/tt-metal/actions/runs/22791335439/job/66479374964

### Checklist

- [ ] [Galaxy Stress test](https://github.com/tenstorrent/tt-metal/actions/runs/22916389633)
