### PR TITLE
Fix the fabric config values the RISC FW initializer

### DIFF
--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -759,17 +759,18 @@ void MetalContext::init_context_descriptor(
 }
 
 void MetalContext::init_risc_fw_context_descriptor(int num_hw_cqs, size_t worker_l1_size) {
-    // Various settings are not known and not relevant for risc firmware
+    // Fabric settings are used during risc init. In some cases, fabric is already running
+    // and we don't want to reset the cores
     risc_fw_context_descriptor_ = std::make_shared<ContextDescriptor>(
         hal(),
         get_cluster(),
         rtoptions(),
-        tt::tt_fabric::FabricConfig::DISABLED,
-        tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE,
-        tt::tt_fabric::FabricTensixConfig::DISABLED,
-        tt::tt_fabric::FabricUDMMode::DISABLED,
-        tt::tt_fabric::FabricManagerMode::DEFAULT,
-        tt::tt_fabric::FabricRouterConfig{},
+        fabric_config_,
+        fabric_reliability_mode_,
+        fabric_tensix_config_,
+        fabric_udm_mode_,
+        fabric_manager_,
+        fabric_router_config_,
         num_hw_cqs,
         /*l1_small_size=*/0,
         /*trace_region_size=*/0,

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -611,6 +611,12 @@ void MetalContext::set_fabric_config(
         fabric_config == tt_fabric::FabricConfig::DISABLED) {
         this->fabric_config_ = fabric_config;
         this->fabric_reliability_mode_ = reliability_mode;
+        // Update the risc firmware context descriptor with the new fabric settings
+        // as well due to transient state between the descriptor creation and the fabric config update
+        if (risc_fw_context_descriptor_) {
+            risc_fw_context_descriptor_->fabric_config_ = fabric_config;
+            risc_fw_context_descriptor_->reliability_mode_ = reliability_mode;
+        }
     } else {
         TT_FATAL(
             this->fabric_config_ == fabric_config,
@@ -661,6 +667,17 @@ void MetalContext::set_fabric_config(
     this->fabric_udm_mode_ = fabric_udm_mode;
     this->fabric_manager_ = fabric_manager;
     this->fabric_router_config_ = router_config;
+
+    // Update the risc firmware context descriptor with the new fabric settings
+    // as well due to transient state between the descriptor creation and the fabric config update
+    if (risc_fw_context_descriptor_) {
+        risc_fw_context_descriptor_->fabric_config_ = fabric_config;
+        risc_fw_context_descriptor_->reliability_mode_ = reliability_mode;
+        risc_fw_context_descriptor_->num_routing_planes_ = num_routing_planes;
+        risc_fw_context_descriptor_->fabric_tensix_config_ = fabric_tensix_config;
+        risc_fw_context_descriptor_->fabric_udm_mode_ = fabric_udm_mode;
+        risc_fw_context_descriptor_->fabric_manager_ = fabric_manager;
+    }
 
     // Reinitialize control plane with updated fabric settings
     if (control_plane_ != nullptr) {


### PR DESCRIPTION
### Ticket
N/A

### Problem description
- There is a use case with RISC FW Init/Teardown where we already have Fabric running on the ethernet cores and we need to skip them but this broke because it was assumed that the fabric settings don't matter for risc fw.
- `test_all_to_all_combine_fabric_manager_8x4` started failing on Wormhole Galaxy

### What's changed
- Set the fabric settings at the start (before device init, SetFabricConfig is used but no descriptor exists yet)
- If the descriptor exists in SetFabricConfig (meaning the HAL,Cluster was created), update the fabric settings

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:{{branch_name}})
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early

Galaxy Quick
https://github.com/tenstorrent/tt-metal/actions/runs/22916384576/job/66503842469


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
