### PR TITLE
Fix non-paged attn unit tests in TT-Transformers

### DIFF
--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -538,16 +538,11 @@ class Generator(WarmupForwardMixin):
                 f"Prefill seq len: {prefill_seq_len}, max_prefill_chunk_size: {self.model_args[0].max_prefill_chunk_size}, trace: {enable_trace_current_prompt}"
             )
 
-            # For batched prefill: pass full page_table (function handles slot placement)
-            # For non-batched prefill: pass sliced page_table for current user (like original code)
-            if use_batched_prefill:
-                page_table_for_user = page_table
-            elif page_table is not None:
-                page_table_for_user = page_table[idx : idx + 1]
-            else:
-                page_table_for_user = None
-            page_table_user = (
-                self._get_prefill_user_page_table(
+            if page_table is not None:
+                # For batched prefill: pass full page_table (function handles slot placement)
+                # For non-batched prefill: pass sliced page_table for current user (like original code)
+                page_table_for_user = page_table if use_batched_prefill else page_table[idx : idx + 1]
+                page_table_user = self._get_prefill_user_page_table(
                     page_table_for_user,
                     kv_cache[model_id],
                     seq_len,
@@ -556,9 +551,8 @@ class Generator(WarmupForwardMixin):
                     use_batched_prefill=use_batched_prefill,
                     user_id=batch_user_ids if use_batched_prefill else user_id,
                 )
-                if page_table is not None
-                else None
-            )
+            else:
+                page_table_user = None
             if page_table_user is not None and _deepseek_kvdbg_enabled():
                 sample = []
                 if page_table_user.numel():


### PR DESCRIPTION
Fix non-paged attn unit tests in TT-Transformers, by ensuring that no page table is manipulated if if doesn't exist

There was a collision with a different fix, but this ones makes it a bit cleaner.

## Issue
https://github.com/tenstorrent/tt-metal/issues/39372

### Problem description
The non-paged attn mixtral test was failing when trying to slice a `NoneDevice`, returning the error `TypeError: 'NoneType' object is not subscriptable`

```
pytest models/tt_transformers/tests/mixtral/test_mixtral_model_prefill.py::test_model_inference[wormhole_b0-device_params0-1layer-performance-max128k-4k-page_params0-default_attention-8] --timeout=720 ; fail+=$?
```

This bug was introduced with the batch prefill support.

### What's changed
Fix the if statement inside the generator.

### Checklist
- [ ] T3K unit test mixtral: https://github.com/tenstorrent/tt-metal/actions/runs/22917599762