### PR TITLE
Lower Fabric/ControlPlane/SystemMesh to MetalEnv

### DIFF
--- a/tests/tt_metal/tt_fabric/fabric_router/test_channel_trimming_capture.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_channel_trimming_capture.cpp
@@ -35,6 +35,7 @@
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/experimental/fabric/fabric.hpp>
 #include <tt-metalium/experimental/fabric/mesh_graph.hpp>
+#include "context/metal_env_accessor.hpp"
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/fabric/erisc_datamover_builder.hpp"
 #include "tt_metal/fabric/fabric_builder_context.hpp"
@@ -168,7 +169,8 @@ void verify_capture_roundtrip(const std::vector<EthCoreCaptureResult>& pre_expor
     }
 
     // Run the real exporter (writes to {logs_dir}/generated/reports/channel_trimming_capture.yaml)
-    export_channel_trimming_capture();
+    auto env = tt::tt_metal::MetalEnvAccessor(tt::tt_metal::MetalContext::instance().get_env());
+    tt::tt_fabric::export_channel_trimming_capture(env.impl());
 
     // Determine the output path
     const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
@@ -1296,7 +1298,8 @@ protected:
         BaseFabricFixture::DoSetUpTestSuite(tt::tt_fabric::FabricConfig::FABRIC_1D);
 
         // Export capture data (even if zero — that's a valid baseline)
-        export_channel_trimming_capture();
+        auto env = tt::tt_metal::MetalEnvAccessor(tt::tt_metal::MetalContext::instance().get_env());
+        tt::tt_fabric::export_channel_trimming_capture(env.impl());
         capture_yaml_path_ =
             std::filesystem::path(rtoptions.get_logs_dir()) / "generated" / "reports" / "channel_trimming_capture.yaml";
 

--- a/tests/tt_metal/tt_metal/context/test_metal_env_api.cpp
+++ b/tests/tt_metal/tt_metal/context/test_metal_env_api.cpp
@@ -6,6 +6,8 @@
 #include <sys/wait.h>
 #include <unistd.h>
 #include <tt-metalium/experimental/context/metal_env.hpp>
+#include <tt-metalium/experimental/fabric/control_plane.hpp>
+#include <tt-metalium/system_mesh.hpp>
 
 #include "impl/context/metal_env_accessor.hpp"
 #include "impl/device/mock_device_util.hpp"
@@ -33,8 +35,8 @@ TEST(MetalEnv, OnePhysicalMultipleMock) {
     auto mock_path_2 = experimental::get_mock_cluster_desc_name(tt::ARCH::WORMHOLE_B0, 2).value();
     MetalEnv env_mock_2{MetalEnvDescriptor(mock_path_2)};
 
-    EXPECT_EQ(MetalEnvAccessor(env_mock_1).get_cluster().arch(), tt::ARCH::BLACKHOLE);
-    EXPECT_EQ(MetalEnvAccessor(env_mock_2).get_cluster().arch(), tt::ARCH::WORMHOLE_B0);
+    EXPECT_EQ(MetalEnvAccessor(env_mock_1).impl().get_cluster().arch(), tt::ARCH::BLACKHOLE);
+    EXPECT_EQ(MetalEnvAccessor(env_mock_2).impl().get_cluster().arch(), tt::ARCH::WORMHOLE_B0);
 }
 
 TEST(MetalEnv, EnvQueries) {
@@ -106,7 +108,8 @@ TEST(MetalEnv, ForkSafetyMultipleEnvs) {
 
 TEST(MetalEnv, ForkSafetyActiveEnv) {
     MetalEnv env;
-    MetalEnvAccessor accessor(env);
+    MetalEnvImpl& accessor = MetalEnvAccessor(env).impl();
+
     accessor.acquire();
 
     pid_t pid = fork();
@@ -124,6 +127,148 @@ TEST(MetalEnv, ForkSafetyActiveEnv) {
     ASSERT_EQ(waitpid(pid, &status, 0), pid);
     EXPECT_TRUE(WIFEXITED(status));
     EXPECT_EQ(WEXITSTATUS(status), 1);
+}
+
+// --- FabricConfigDescriptor tests ---
+
+TEST(MetalEnv, FabricConfigDescriptorDefaults) {
+    FabricConfigDescriptor desc;
+    EXPECT_EQ(desc.fabric_config, tt_fabric::FabricConfig::DISABLED);
+    EXPECT_EQ(desc.reliability_mode, tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
+    EXPECT_FALSE(desc.num_routing_planes.has_value());
+    EXPECT_EQ(desc.fabric_tensix_config, tt_fabric::FabricTensixConfig::DISABLED);
+    EXPECT_EQ(desc.fabric_udm_mode, tt_fabric::FabricUDMMode::DISABLED);
+    EXPECT_EQ(desc.fabric_manager, tt_fabric::FabricManagerMode::DEFAULT);
+}
+
+TEST(MetalEnv, DescriptorWithFabricConfig) {
+    FabricConfigDescriptor fc;
+    fc.fabric_config = tt_fabric::FabricConfig::FABRIC_1D;
+    fc.reliability_mode = tt_fabric::FabricReliabilityMode::RELAXED_SYSTEM_HEALTH_SETUP_MODE;
+    fc.num_routing_planes = 4;
+    fc.fabric_tensix_config = tt_fabric::FabricTensixConfig::MUX;
+
+    auto mock_path = experimental::get_mock_cluster_desc_name(tt::ARCH::WORMHOLE_B0, 1);
+    MetalEnvDescriptor settings(mock_path, fc);
+
+    EXPECT_TRUE(settings.is_mock_device());
+    const auto& stored = settings.fabric_config_descriptor();
+    EXPECT_EQ(stored.fabric_config, tt_fabric::FabricConfig::FABRIC_1D);
+    EXPECT_EQ(stored.reliability_mode, tt_fabric::FabricReliabilityMode::RELAXED_SYSTEM_HEALTH_SETUP_MODE);
+    EXPECT_TRUE(stored.num_routing_planes.has_value());
+    EXPECT_EQ(stored.num_routing_planes.value(), 4);
+    EXPECT_EQ(stored.fabric_tensix_config, tt_fabric::FabricTensixConfig::MUX);
+}
+
+TEST(MetalEnv, DefaultDescriptorFabricConfigIsDisabled) {
+    MetalEnvDescriptor settings;
+    EXPECT_EQ(settings.fabric_config_descriptor().fabric_config, tt_fabric::FabricConfig::DISABLED);
+}
+
+TEST(MetalEnv, FabricConfigPreservedThroughEnv) {
+    FabricConfigDescriptor fc;
+    fc.fabric_config = tt_fabric::FabricConfig::FABRIC_2D;
+
+    auto mock_path = experimental::get_mock_cluster_desc_name(tt::ARCH::BLACKHOLE, 2);
+    MetalEnvDescriptor settings(mock_path, fc);
+    MetalEnv env(settings);
+
+    const auto& stored = env.get_descriptor().fabric_config_descriptor();
+    EXPECT_EQ(stored.fabric_config, tt_fabric::FabricConfig::FABRIC_2D);
+}
+
+TEST(MetalEnv, AccessorFabricConfigMatchesDescriptor) {
+    FabricConfigDescriptor fc;
+    fc.fabric_config = tt_fabric::FabricConfig::FABRIC_1D_RING;
+    fc.fabric_udm_mode = tt_fabric::FabricUDMMode::ENABLED;
+
+    auto mock_path = experimental::get_mock_cluster_desc_name(tt::ARCH::WORMHOLE_B0, 1);
+    MetalEnvDescriptor settings(mock_path, fc);
+    MetalEnv env(settings);
+
+    MetalEnvImpl& accessor = MetalEnvAccessor(env).impl();
+
+    EXPECT_EQ(accessor.get_fabric_config(), tt_fabric::FabricConfig::FABRIC_1D_RING);
+    EXPECT_EQ(accessor.get_fabric_udm_mode(), tt_fabric::FabricUDMMode::ENABLED);
+}
+
+// --- Control plane and system mesh tests ---
+
+TEST(MetalEnv, ControlPlaneAccessibleOnMock) {
+    auto mock_path = experimental::get_mock_cluster_desc_name(tt::ARCH::WORMHOLE_B0, 1);
+    MetalEnvDescriptor settings(mock_path);
+    MetalEnv env(settings);
+
+    auto& cp = env.get_control_plane();
+    EXPECT_EQ(cp.get_fabric_config(), tt_fabric::FabricConfig::DISABLED);
+}
+
+TEST(MetalEnv, SystemMeshAccessibleOnMock) {
+    auto mock_path = experimental::get_mock_cluster_desc_name(tt::ARCH::WORMHOLE_B0, 1);
+    MetalEnvDescriptor settings(mock_path);
+    MetalEnv env(settings);
+
+    auto& mesh = env.get_system_mesh();
+    EXPECT_GT(mesh.shape().mesh_size(), 0);
+}
+
+TEST(MetalEnv, ControlPlaneReflectsFabricConfig) {
+    FabricConfigDescriptor fc;
+    fc.fabric_config = tt_fabric::FabricConfig::FABRIC_1D;
+
+    auto mock_path = experimental::get_mock_cluster_desc_name(tt::ARCH::WORMHOLE_B0, 2);
+    MetalEnvDescriptor settings(mock_path, fc);
+    MetalEnv env(settings);
+
+    auto& cp = env.get_control_plane();
+    EXPECT_EQ(cp.get_fabric_config(), tt_fabric::FabricConfig::FABRIC_1D);
+}
+
+TEST(MetalEnv, ControlPlaneAndSystemMeshSameEnv) {
+    auto mock_path = experimental::get_mock_cluster_desc_name(tt::ARCH::BLACKHOLE, 2);
+    MetalEnvDescriptor settings(mock_path);
+    MetalEnv env(settings);
+
+    auto& cp1 = env.get_control_plane();
+    auto& cp2 = env.get_control_plane();
+    EXPECT_EQ(&cp1, &cp2);
+
+    auto& mesh1 = env.get_system_mesh();
+    auto& mesh2 = env.get_system_mesh();
+    EXPECT_EQ(&mesh1, &mesh2);
+}
+
+// The MetalEnv constructor are user settings.
+// If fabric not enabled by the user, but it turns out we need dispatch on fabric, then the
+// env needs to be reconfigured to enable fabric.
+TEST(MetalEnv, ReconfigureFabricForDispatch) {
+    auto mock_path = experimental::get_mock_cluster_desc_name(tt::ARCH::WORMHOLE_B0, 2);
+    MetalEnvDescriptor settings(mock_path);
+    MetalEnv env(settings);
+
+    // MetalEnv cannot be reconfigured after init so use the internal accessor
+    MetalEnvImpl& accessor = MetalEnvAccessor(env).impl();
+
+    EXPECT_EQ(accessor.get_fabric_config(), tt_fabric::FabricConfig::DISABLED);
+
+    auto& cp_before = env.get_control_plane();
+    EXPECT_EQ(cp_before.get_fabric_config(), tt_fabric::FabricConfig::DISABLED);
+
+    auto& mesh_before = env.get_system_mesh();
+    EXPECT_GT(mesh_before.shape().mesh_size(), 0);
+    const auto* cp_ptr_before = &cp_before;
+
+    accessor.set_fabric_config(
+        tt_fabric::FabricConfig::FABRIC_1D, tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE, 1);
+
+    EXPECT_EQ(accessor.get_fabric_config(), tt_fabric::FabricConfig::FABRIC_1D);
+
+    auto& cp_after = env.get_control_plane();
+    EXPECT_EQ(cp_after.get_fabric_config(), tt_fabric::FabricConfig::FABRIC_1D);
+    EXPECT_NE(cp_ptr_before, &cp_after);
+
+    auto& mesh_after = env.get_system_mesh();
+    EXPECT_GT(mesh_after.shape().mesh_size(), 0);
 }
 
 }  // namespace tt::tt_metal

--- a/tools/scaleout/validation/utils/ethernet_link_api.cpp
+++ b/tools/scaleout/validation/utils/ethernet_link_api.cpp
@@ -55,7 +55,7 @@ void reset_links_wh(const std::vector<ResetLink>& links_to_reset) {
 // ============================================================================
 
 struct BHEthMsg {
-    FWMailboxMsg msg_type;
+    tt_metal::FWMailboxMsg msg_type;
     std::vector<uint32_t> msg_args;
     std::string log_message;
 };
@@ -75,8 +75,8 @@ bool eth_mailbox_ready(ChipId chip_id, uint32_t channel, bool wait_for_ready = t
 
     // Check mailbox is empty/ready
     const auto mailbox_addr = hal.get_eth_fw_mailbox_address(0);
-    const auto status_mask = hal.get_eth_fw_mailbox_val(FWMailboxMsg::ETH_MSG_STATUS_MASK);
-    const auto done_message = hal.get_eth_fw_mailbox_val(FWMailboxMsg::ETH_MSG_DONE);
+    const auto status_mask = hal.get_eth_fw_mailbox_val(tt_metal::FWMailboxMsg::ETH_MSG_STATUS_MASK);
+    const auto done_message = hal.get_eth_fw_mailbox_val(tt_metal::FWMailboxMsg::ETH_MSG_DONE);
     uint32_t msg_status = 0;
     std::vector<uint32_t> msg_vec = {0};
     do {
@@ -94,7 +94,7 @@ bool eth_mailbox_ready(ChipId chip_id, uint32_t channel, bool wait_for_ready = t
 void send_eth_msg(
     ChipId chip_id,
     uint32_t channel,
-    FWMailboxMsg msg_type,
+    tt_metal::FWMailboxMsg msg_type,
     std::vector<uint32_t> args,
     bool wait_for_ready,
     bool wait_for_done) {
@@ -119,7 +119,7 @@ void send_eth_msg(
     // service_eth_msg picks up message call before args are fully populated
     const auto mailbox_addr = hal.get_eth_fw_mailbox_address(0);
     const auto first_arg_addr = hal.get_eth_fw_mailbox_arg_addr(0, 0);
-    const auto call = hal.get_eth_fw_mailbox_val(FWMailboxMsg::ETH_MSG_CALL);
+    const auto call = hal.get_eth_fw_mailbox_val(tt_metal::FWMailboxMsg::ETH_MSG_CALL);
     const auto msg_val = hal.get_eth_fw_mailbox_val(msg_type);
     std::vector<uint32_t> msg_vec = {call | msg_val};
 
@@ -161,10 +161,12 @@ void reset_links_bh(const std::vector<ResetLink>& links_to_reset) {
     const auto& distributed_context = tt::tt_metal::MetalContext::instance().global_distributed_context();
 
     const BHEthMsg ETH_MSG_PORT_DOWN = {
-        FWMailboxMsg::ETH_MSG_PORT_ACTION, {2, 0, 0}, "Sending ETH_MSG_PORT_ACTION to bring ports down on all links"};
+        tt_metal::FWMailboxMsg::ETH_MSG_PORT_ACTION,
+        {2, 0, 0},
+        "Sending ETH_MSG_PORT_ACTION to bring ports down on all links"};
 
     const BHEthMsg ETH_MSG_PORT_REINIT = {
-        FWMailboxMsg::ETH_MSG_PORT_REINIT_MACPCS,
+        tt_metal::FWMailboxMsg::ETH_MSG_PORT_REINIT_MACPCS,
         {1, 2, 0},
         "Sending ETH_MSG_PORT_REINIT_MACPCS to reinitialize MAC/PCS on all links"};
 

--- a/tools/scaleout/validation/utils/ethernet_link_api.hpp
+++ b/tools/scaleout/validation/utils/ethernet_link_api.hpp
@@ -9,7 +9,11 @@
 #include <string>
 #include <vector>
 
-#include "tt_metal/impl/context/metal_context.hpp"
+#include <tt-metalium/experimental/fabric/physical_system_descriptor.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <umd/device/types/cluster_descriptor_types.hpp>
+#include <umd/device/types/core_coordinates.hpp>
+#include "tt_metal/llrt/hal.hpp"
 
 namespace tt::scaleout_tools {
 

--- a/tt_metal/api/tt-metalium/experimental/context/metal_env.hpp
+++ b/tt_metal/api/tt-metalium/experimental/context/metal_env.hpp
@@ -7,8 +7,30 @@
 #include <memory>
 #include <optional>
 #include <umd/device/types/arch.hpp>
+#include <tt-metalium/experimental/fabric/fabric_types.hpp>
+
+namespace tt::tt_fabric {
+class ControlPlane;
+}  // namespace tt::tt_fabric
+
+namespace tt::tt_metal::distributed {
+class SystemMesh;
+}  // namespace tt::tt_metal::distributed
 
 namespace tt::tt_metal {
+
+// Describes the fabric topology and routing configuration for the devices in the environment.
+// These parameters determine how devices are interconnected and how data is routed between them.
+struct FabricConfigDescriptor {
+    tt_fabric::FabricConfig fabric_config = tt_fabric::FabricConfig::DISABLED;
+    tt_fabric::FabricReliabilityMode reliability_mode =
+        tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE;
+    std::optional<uint8_t> num_routing_planes = std::nullopt;
+    tt_fabric::FabricTensixConfig fabric_tensix_config = tt_fabric::FabricTensixConfig::DISABLED;
+    tt_fabric::FabricUDMMode fabric_udm_mode = tt_fabric::FabricUDMMode::DISABLED;
+    tt_fabric::FabricManagerMode fabric_manager = tt_fabric::FabricManagerMode::DEFAULT;
+    tt_fabric::FabricRouterConfig router_config = {};
+};
 
 // Configuration for a MetalEnv.
 //
@@ -24,15 +46,25 @@ public:
 
     explicit MetalEnvDescriptor(std::optional<std::string> mock_cluster_desc_path);
 
+    MetalEnvDescriptor(std::optional<std::string> mock_cluster_desc_path, FabricConfigDescriptor fabric_config_desc);
+
     bool is_mock_device() const { return mock_cluster_desc_path_.has_value(); }
     const std::string& mock_cluster_desc_path() const { return *mock_cluster_desc_path_; }
+    const FabricConfigDescriptor& fabric_config_descriptor() const { return fabric_config_desc_; }
 
 protected:
     std::optional<std::string> mock_cluster_desc_path_ = std::nullopt;
+    FabricConfigDescriptor fabric_config_desc_;
 };
+
+class MetalEnvImpl;
 
 // A MetalEnv provides an interface for the runtime environment to access a homogeneous cluster of Tenstorrent devices.
 // It exposes several query functions for the hardware capabilities and cluster configuration.
+//
+// The FabricConfigDescriptor in the MetalEnvDescriptor describes the topology of the devices — how they are
+// interconnected and how traffic is routed between them. From this topology the MetalEnv constructs the fabric
+// control plane and the system mesh, which virtualize and partition the physical hardware.
 //
 // Note, MetalEnv is a RAII object. As such, it must outlive every object that uses it (e.g. MeshDevice).
 // The MetalEnv should be destroyed before forking to avoid undefined behavior.
@@ -83,9 +115,18 @@ public:
     /// @return Representable SFPU Infinity value of this environment.
     float get_inf() const;
 
+    /// @return The fabric control plane, lazily initialized.
+    /// The control plane manages routing tables and fabric channels based on the device topology
+    /// described by the environment's FabricConfigDescriptor.
+    tt::tt_fabric::ControlPlane& get_control_plane();
+
+    /// @return The system mesh, lazily initialized.
+    /// The system mesh provides a virtualized coordinate system over the physical devices, allowing
+    /// MeshDevice instances to map logical coordinates to physical device IDs.
+    distributed::SystemMesh& get_system_mesh();
+
 private:
     friend class MetalEnvAccessor;
-    class MetalEnvImpl;
     std::unique_ptr<MetalEnvImpl> impl_;
 
     MetalEnvImpl& impl() { return *impl_; }

--- a/tt_metal/api/tt-metalium/system_mesh.hpp
+++ b/tt_metal/api/tt-metalium/system_mesh.hpp
@@ -18,6 +18,7 @@ class ControlPlane;
 
 namespace tt::tt_metal {
 class MetalContext;
+class MetalEnvImpl;
 }  // namespace tt::tt_metal
 
 namespace tt::tt_metal::distributed {
@@ -28,6 +29,7 @@ namespace tt::tt_metal::distributed {
 class SystemMesh {
 private:
     friend class tt::tt_metal::MetalContext;
+    friend class tt::tt_metal::MetalEnvImpl;
 
     class Impl;  // Forward declaration only
 

--- a/tt_metal/fabric/channel_trimming_export.cpp
+++ b/tt_metal/fabric/channel_trimming_export.cpp
@@ -39,6 +39,7 @@
 #include <tt-logger/tt-logger.hpp>
 #include <yaml-cpp/yaml.h>
 
+#include "context/metal_env_impl.hpp"
 #include "tt_metal/api/tt-metalium/experimental/fabric/control_plane.hpp"
 #include "tt_metal/fabric/builder/fabric_builder_config.hpp"
 #include "tt_metal/fabric/fabric_builder_context.hpp"
@@ -177,23 +178,20 @@ void emit_capture_channel_yaml(YAML::Emitter& emitter, const CaptureResults& cap
 
 }  // namespace
 
-void export_channel_trimming_capture() {
-    auto& metal_ctx = tt::tt_metal::MetalContext::instance();
-    const auto& rtoptions = metal_ctx.rtoptions();
+void export_channel_trimming_capture(tt::tt_metal::MetalEnvImpl& env) {
+    const auto& rtoptions = env.get_rtoptions();
+    const auto& cluster = env.get_cluster();
+    const auto& control_plane = env.get_control_plane();
 
     // Guard: capture must be enabled via runtime option
     if (!rtoptions.get_enable_channel_trimming_capture()) {
         return;
     }
 
-    auto& cluster = metal_ctx.get_cluster();
-
     // Guard: skip on Mock devices
     if (cluster.get_target_device_type() == tt::TargetDevice::Mock) {
         return;
     }
-
-    auto& control_plane = metal_ctx.get_control_plane();
 
     // Guard: capture buffer must be allocated
     const auto& builder_ctx = control_plane.get_fabric_context().get_builder_context();

--- a/tt_metal/fabric/channel_trimming_export.hpp
+++ b/tt_metal/fabric/channel_trimming_export.hpp
@@ -4,10 +4,12 @@
 
 #pragma once
 
+#include "context/metal_env_impl.hpp"
+
 namespace tt::tt_fabric {
 
 // Entry point: checks all guards internally (runtime option, Mock device, buffer enabled).
 // Safe to call unconditionally — returns immediately if capture is not active.
-void export_channel_trimming_capture();
+void export_channel_trimming_capture(tt::tt_metal::MetalEnvImpl& env);
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -23,12 +23,8 @@
 #include "core_coord.hpp"
 #include "device/firmware/risc_firmware_initializer.hpp"
 #include "dispatch/dispatch_settings.hpp"
-#include "firmware_capability.hpp"
-#include "hal.hpp"
 #include "hal_types.hpp"
-#include "fabric/channel_trimming_export.hpp"
 #include "fabric/fabric_host_utils.hpp"
-#include "allocator/l1_banking_allocator.hpp"
 #include "debug/dprint_server.hpp"
 #include "debug/inspector/inspector.hpp"
 
@@ -40,9 +36,6 @@
 #include "dispatch/topology.hpp"
 #include "dispatch/dispatch_core_common.hpp"
 #include "profiler/profiler_state_manager.hpp"
-#include "jit_build/build_env_manager.hpp"
-#include "llrt/get_platform_architecture.hpp"
-#include "llrt/llrt.hpp"
 #include <experimental/fabric/control_plane.hpp>
 #include <experimental/mock_device.hpp>
 #include "device/device_manager.hpp"
@@ -58,7 +51,6 @@
 #include <dispatch/dispatch_core_manager.hpp>
 #include <llrt/tt_cluster.hpp>
 #include <dispatch/dispatch_mem_map.hpp>
-#include "common/executor.hpp"
 
 namespace tt::tt_metal {
 
@@ -77,61 +69,6 @@ void validate_worker_l1_size(size_t& worker_l1_size, const Hal& hal) {
         worker_l1_size,
         max_worker_l1_size);
 }
-
-// Construct compute-only distributed context by filtering out switch meshes
-std::shared_ptr<distributed::multihost::DistributedContext> construct_compute_only_distributed_context(
-    MetalContext& metal_context) {
-    const auto& global_context = distributed::multihost::DistributedContext::get_current_world();
-    if (*global_context->size() == 1) {
-        return global_context;
-    }
-
-    // Get all compute mesh IDs (excludes switches) from control plane mesh graph
-    const auto& mesh_graph = metal_context.get_control_plane().get_mesh_graph();
-
-    // If there are no switch meshes, return the global context directly
-    if (mesh_graph.get_switch_ids().empty()) {
-        return global_context;
-    }
-
-    const auto& compute_mesh_ids = mesh_graph.get_mesh_ids();
-
-    // Get global logical bindings to map ranks to mesh IDs
-    const auto& global_logical_bindings = metal_context.get_control_plane().get_global_logical_bindings();
-
-    // Collect all MPI ranks for compute meshes only
-    std::unordered_set<int> compute_mpi_ranks;
-    for (const auto& [rank, mesh_binding] : global_logical_bindings) {
-        const auto& [mesh_id, _] = mesh_binding;
-        // Check if this mesh_id is a compute mesh (not a switch)
-        if (std::find(compute_mesh_ids.begin(), compute_mesh_ids.end(), mesh_id) != compute_mesh_ids.end()) {
-            compute_mpi_ranks.insert(rank.get());
-        }
-    }
-
-    // If no compute meshes found, fall back to host_local_context
-    if (compute_mpi_ranks.empty()) {
-        TT_THROW("No compute meshes found in mesh graph.");
-    }
-
-    // Convert to sorted vector for create_sub_context
-    std::vector<int> compute_ranks_vec(compute_mpi_ranks.begin(), compute_mpi_ranks.end());
-    std::sort(compute_ranks_vec.begin(), compute_ranks_vec.end());
-
-    // Check if current rank is in compute ranks
-    int current_rank = *global_context->rank();
-    bool is_current_rank_in_compute =
-        std::find(compute_ranks_vec.begin(), compute_ranks_vec.end(), current_rank) != compute_ranks_vec.end();
-
-    // If current rank is not in compute ranks (e.g., host only has switches), return host_local_context
-    if (!is_current_rank_in_compute) {
-        return metal_context.get_control_plane().get_host_local_context();
-    }
-
-    // Create sub-context with only compute mesh ranks
-    return global_context->create_sub_context(compute_ranks_vec);
-}
-
 }  // namespace
 
 void MetalContext::initialize_device_manager(
@@ -161,7 +98,11 @@ void MetalContext::initialize(
     if (rtoptions().get_force_context_reinit() or get_cluster().is_galaxy_cluster()) {
         force_reinit_ = true;
     }
-    // Settings that affect FW build can also trigger a re-initialization
+    // Fabric config changes (e.g. legacy DeviceManager enabling dispatch fabric) also force a re-init.
+    if (MetalEnvAccessor(*env_).impl().consume_force_reinit()) {
+        force_reinit_ = true;
+    }
+
     const size_t fw_compile_hash = std::hash<std::string>{}(rtoptions().get_compile_hash_string());
     validate_worker_l1_size(worker_l1_size, hal());
     if (initialized_) {
@@ -343,9 +284,6 @@ void MetalContext::teardown() {
     // Deinitialize inspector
     inspector_data_.reset();
 
-    system_mesh_.reset();
-    control_plane_.reset();
-
     noc_debug_state_.reset();
 }
 
@@ -400,11 +338,6 @@ void MetalContext::destroy_instance(bool check_device_count) {
 }
 
 void MetalContext::teardown_base_objects() {
-    // Teardown in backward order of dependencies to avoid dereferencing uninitialized objects
-    system_mesh_.reset();
-    control_plane_.reset();
-    distributed_context_.reset();
-    // Destroy inspector before cluster to prevent RPC handlers from accessing destroyed cluster
     inspector_data_.reset();
     if (env_owned_) {
         delete env_;
@@ -425,11 +358,6 @@ void MetalContext::teardown_dispatch_state() {
 }
 
 void MetalContext::initialize_base_objects() {
-    // TODO. This function is called automatically whenever MetalContext is invoked and not initialized.
-    // Ideally, this would be done by the user via an explicit context creation API.
-    // For now, just pull out the mock device descriptor from get_mock_cluster_desc() global state
-
-    // Check if mock mode was configured via API (before env vars take effect)
     MetalEnvDescriptor settings;
     if (auto mock_cluster_desc = experimental::get_mock_cluster_desc()) {
         log_info(tt::LogMetal, "Using programmatically configured mock mode: {}", *mock_cluster_desc);
@@ -437,42 +365,11 @@ void MetalContext::initialize_base_objects() {
     }
     env_ = new tt::tt_metal::MetalEnv(std::move(settings));
     env_owned_ = true;
-
-    distributed_context_ = distributed::multihost::DistributedContext::get_current_world();
 }
 
 MetalContext::MetalContext() {
     initialize_base_objects();
-
-    // If a custom fabric mesh graph descriptor is specified as an RT Option, use it by default
-    // to initialize the control plane.
-    if (rtoptions().is_custom_fabric_mesh_graph_desc_path_specified()) {
-        custom_mesh_graph_desc_path_ = rtoptions().get_custom_fabric_mesh_graph_desc_path();
-    }
-
     device_manager_ = std::make_unique<DeviceManager>();
-}
-
-const distributed::multihost::DistributedContext& MetalContext::full_world_distributed_context() const {
-    TT_FATAL(distributed_context_, "Distributed context not initialized.");
-    return *distributed_context_;
-}
-
-const distributed::multihost::DistributedContext& MetalContext::global_distributed_context() {
-    // If control plane is not initilazed, return the global distributed context
-    if (!control_plane_) {
-        return *distributed_context_;
-    }
-    // Lazy initilazation of compute only distributed context
-    if (!compute_only_distributed_context_) {
-        compute_only_distributed_context_ = construct_compute_only_distributed_context(*this);
-    }
-    return *compute_only_distributed_context_;
-}
-
-std::shared_ptr<distributed::multihost::DistributedContext> MetalContext::get_distributed_context_ptr() {
-    TT_FATAL(distributed_context_, "Distributed context not initialized.");
-    return distributed_context_;
 }
 
 MetalContext::~MetalContext() {
@@ -481,30 +378,39 @@ MetalContext::~MetalContext() {
     teardown_base_objects();
 }
 
+tt::tt_metal::MetalEnv& MetalContext::get_env() {
+    TT_ASSERT(env_ != nullptr, "Missing MetalEnv for this MetalContext");
+    return *env_;
+}
+
+// ─── Delegated accessors (Cluster / HAL / rtoptions) ─────────────────────────
+
 llrt::RunTimeOptions& MetalContext::rtoptions() {
-    TT_ASSERT(env_ != nullptr, "MetalEnv is not initialized");
-    return MetalEnvAccessor(*env_).get_rtoptions();
+    TT_ASSERT(env_ != nullptr, "Missing MetalEnv for this MetalContext");
+    return MetalEnvAccessor(*env_).impl().get_rtoptions();
 }
 
 Cluster& MetalContext::get_cluster() {
-    TT_ASSERT(env_ != nullptr, "MetalEnv is not initialized");
-    return MetalEnvAccessor(*env_).get_cluster();
+    TT_ASSERT(env_ != nullptr, "Missing MetalEnv for this MetalContext");
+    return MetalEnvAccessor(*env_).impl().get_cluster();
 }
 
 const llrt::RunTimeOptions& MetalContext::rtoptions() const {
-    TT_ASSERT(env_ != nullptr, "MetalEnv is not initialized");
-    return MetalEnvAccessor(*env_).get_rtoptions();
+    TT_ASSERT(env_ != nullptr, "Missing MetalEnv for this MetalContext");
+    return MetalEnvAccessor(*env_).impl().get_rtoptions();
 }
 
 const Cluster& MetalContext::get_cluster() const {
-    TT_ASSERT(env_ != nullptr, "MetalEnv is not initialized");
-    return MetalEnvAccessor(*env_).get_cluster();
+    TT_ASSERT(env_ != nullptr, "Missing MetalEnv for this MetalContext");
+    return MetalEnvAccessor(*env_).impl().get_cluster();
 }
 
 const Hal& MetalContext::hal() const {
-    TT_ASSERT(env_ != nullptr, "MetalEnv is not initialized");
-    return MetalEnvAccessor(*env_).get_hal();
+    TT_ASSERT(env_ != nullptr, "Missing MetalEnv for this MetalContext");
+    return MetalEnvAccessor(*env_).impl().get_hal();
 }
+
+// ─── Dispatch managers ────────────────────────────────────────────────────────
 
 dispatch_core_manager& MetalContext::get_dispatch_core_manager() {
     TT_FATAL(dispatch_core_manager_, "Trying to get dispatch_core_manager before initializing it.");
@@ -526,24 +432,21 @@ const DispatchMemMap& MetalContext::dispatch_mem_map(const CoreType& core_type) 
     return *mem_map;
 }
 
+// ─── Fabric / control plane / system mesh — delegated to MetalEnv ─────────────
+
 tt::tt_fabric::ControlPlane& MetalContext::get_control_plane() {
-    std::lock_guard<std::mutex> lock(control_plane_mutex_);
-    if (!control_plane_) {
-        // Initialize control plane (creates stub for mock devices)
-        this->initialize_control_plane_impl();
-    }
-    return *control_plane_;
+    TT_ASSERT(env_ != nullptr, "Missing MetalEnv for this MetalContext");
+    return MetalEnvAccessor(*env_).impl().get_control_plane();
+}
+
+void MetalContext::initialize_control_plane() {
+    TT_ASSERT(env_ != nullptr, "Missing MetalEnv for this MetalContext");
+    MetalEnvAccessor(*env_).impl().initialize_control_plane();
 }
 
 distributed::SystemMesh& MetalContext::get_system_mesh() {
-    std::lock_guard<std::mutex> lock(control_plane_mutex_);
-    if (!system_mesh_) {
-        if (!control_plane_) {
-            this->initialize_control_plane_impl();
-        }
-        system_mesh_ = std::unique_ptr<distributed::SystemMesh>(new distributed::SystemMesh(*control_plane_));
-    }
-    return *system_mesh_;
+    TT_ASSERT(env_ != nullptr, "Missing MetalEnv for this MetalContext");
+    return MetalEnvAccessor(*env_).impl().get_system_mesh();
 }
 
 void MetalContext::set_custom_fabric_topology(
@@ -552,197 +455,128 @@ void MetalContext::set_custom_fabric_topology(
     TT_FATAL(
         !device_manager_->is_initialized() || device_manager_->get_all_active_devices().empty(),
         "Modifying control plane requires no devices to be active");
-    // Set the user specified mesh graph descriptor file and FabricNodeID to physical chip mapping.
-    this->logical_mesh_chip_id_to_physical_chip_id_mapping_ = logical_mesh_chip_id_to_physical_chip_id_mapping;
-    custom_mesh_graph_desc_path_ = mesh_graph_desc_file;
-    this->set_fabric_config(fabric_config_, tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
+    TT_FATAL(env_ != nullptr, "Missing MetalEnv for this MetalContext");
+    MetalEnvAccessor(*env_).impl().set_custom_fabric_topology(
+        mesh_graph_desc_file, logical_mesh_chip_id_to_physical_chip_id_mapping);
 }
 
 void MetalContext::set_default_fabric_topology() {
     TT_FATAL(
         !device_manager_->is_initialized() || device_manager_->get_all_active_devices().empty(),
         "Modifying control plane requires no devices to be active");
-    // Reset the system mesh and control plane, since they were initialized with custom parameters.
-    system_mesh_.reset();
-    control_plane_.reset();
-    // Set the mesh graph descriptor file to the default value and clear the custom FabricNodeId to physical chip
-    // mapping.
-    this->logical_mesh_chip_id_to_physical_chip_id_mapping_.clear();
-
-    if (rtoptions().is_custom_fabric_mesh_graph_desc_path_specified()) {
-        custom_mesh_graph_desc_path_ = rtoptions().get_custom_fabric_mesh_graph_desc_path();
-    } else {
-        custom_mesh_graph_desc_path_ = std::nullopt;
-    }
-    this->set_fabric_config(fabric_config_, tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
-}
-
-void MetalContext::teardown_fabric_config() {
-    this->fabric_config_ = tt_fabric::FabricConfig::DISABLED;
-    this->get_cluster().configure_ethernet_cores_for_fabric_routers(this->fabric_config_);
-    this->num_fabric_active_routing_planes_ = 0;
-    // Stub control plane for mock devices will make this a no-op
-    this->get_control_plane().clear_fabric_context();
+    TT_FATAL(env_ != nullptr, "Missing MetalEnv for this MetalContext");
+    MetalEnvAccessor(*env_).impl().set_default_fabric_topology();
 }
 
 void MetalContext::set_fabric_config(
-    const tt_fabric::FabricConfig fabric_config,
+    tt_fabric::FabricConfig fabric_config,
     tt_fabric::FabricReliabilityMode reliability_mode,
     std::optional<uint8_t> num_routing_planes,
     tt_fabric::FabricTensixConfig fabric_tensix_config,
     tt_fabric::FabricUDMMode fabric_udm_mode,
     tt_fabric::FabricManagerMode fabric_manager,
     tt_fabric::FabricRouterConfig router_config) {
-    // Changes to fabric force a re-init. TODO: We should supply the fabric config in the same way as the dispatch
-    // config, not through this function exposed in the detail API.
-    force_reinit_ = true;
-
-    // Export channel trimming capture data before fabric config changes.
-    // Must happen while fabric_config_ is still active and fabric context is alive.
-    bool is_tearing_down_fabric = fabric_config == tt_fabric::FabricConfig::DISABLED &&
-        this->fabric_config_ != tt_fabric::FabricConfig::DISABLED;
-    if (is_tearing_down_fabric) {
-        tt::tt_fabric::export_channel_trimming_capture();
-    }
-
-    if (this->fabric_config_ == tt_fabric::FabricConfig::DISABLED ||
-        fabric_config == tt_fabric::FabricConfig::DISABLED) {
-        this->fabric_config_ = fabric_config;
-        this->fabric_reliability_mode_ = reliability_mode;
+    TT_FATAL(env_ != nullptr, "Missing MetalEnv for this MetalContext");
+    bool updated = MetalEnvAccessor(*env_).impl().set_fabric_config(
+        fabric_config,
+        reliability_mode,
+        num_routing_planes,
+        fabric_tensix_config,
+        fabric_udm_mode,
+        fabric_manager,
+        router_config);
+    if (updated) {
         // Update the risc firmware context descriptor with the new fabric settings
         // as well due to transient state between the descriptor creation and the fabric config update
         if (risc_fw_context_descriptor_) {
             risc_fw_context_descriptor_->fabric_config_ = fabric_config;
             risc_fw_context_descriptor_->reliability_mode_ = reliability_mode;
+            risc_fw_context_descriptor_->num_routing_planes_ = num_routing_planes;
+            risc_fw_context_descriptor_->fabric_tensix_config_ = fabric_tensix_config;
+            risc_fw_context_descriptor_->fabric_udm_mode_ = fabric_udm_mode;
+            risc_fw_context_descriptor_->fabric_manager_ = fabric_manager;
         }
-    } else {
-        TT_FATAL(
-            this->fabric_config_ == fabric_config,
-            "Tried to override previous value of fabric config: {}, with: {}",
-            this->fabric_config_,
-            fabric_config);
-    }
-
-    if (this->fabric_config_ == tt_fabric::FabricConfig::DISABLED) {
-        if (num_routing_planes.has_value()) {
-            log_warning(
-                tt::LogMetal,
-                "Got num_routing_planes while disabling fabric, ignoring it and disabling all active routing planes");
-        }
-
-        this->teardown_fabric_config();
-        return;
-    }
-
-    if (num_routing_planes.has_value() && num_routing_planes.value() < this->num_fabric_active_routing_planes_) {
-        log_warning(
-            tt::LogMetal,
-            "Got num_routing_planes: {}, which is less than current value: {}, ignoring the override",
-            num_routing_planes.value(),
-            this->num_fabric_active_routing_planes_);
-        return;
-    }
-
-    // if num_routing_planes is not specified, use max available number of routing planes
-    // ideally the highest value should be the maximum number of eth cores in a direction across all chips
-    const auto new_val = std::max(
-        this->num_fabric_active_routing_planes_, num_routing_planes.value_or(std::numeric_limits<uint8_t>::max()));
-    if (new_val != this->num_fabric_active_routing_planes_ && this->num_fabric_active_routing_planes_ > 0) {
-        log_info(
-            tt::LogMetal,
-            "Overriding the number of routing planes to activate from {} to {}",
-            this->num_fabric_active_routing_planes_,
-            new_val);
-    }
-    this->num_fabric_active_routing_planes_ = new_val;
-
-    // Set the fabric tensix config
-    this->set_fabric_tensix_config(fabric_tensix_config);
-    this->fabric_udm_mode_ = fabric_udm_mode;
-    this->fabric_manager_ = fabric_manager;
-    this->fabric_router_config_ = router_config;
-
-    // Update the risc firmware context descriptor with the new fabric settings
-    // as well due to transient state between the descriptor creation and the fabric config update
-    if (risc_fw_context_descriptor_) {
-        risc_fw_context_descriptor_->fabric_config_ = fabric_config;
-        risc_fw_context_descriptor_->reliability_mode_ = reliability_mode;
-        risc_fw_context_descriptor_->num_routing_planes_ = num_routing_planes;
-        risc_fw_context_descriptor_->fabric_tensix_config_ = fabric_tensix_config;
-        risc_fw_context_descriptor_->fabric_udm_mode_ = fabric_udm_mode;
-        risc_fw_context_descriptor_->fabric_manager_ = fabric_manager;
-    }
-
-    // Reinitialize control plane with updated fabric settings
-    if (control_plane_ != nullptr) {
-        log_info(
-            tt::LogMetal,
-            "Fabric config changed from {} to {}, reinitializing control plane",
-            this->get_control_plane().get_fabric_config(),
-            this->fabric_config_);
-        system_mesh_.reset();
-        this->initialize_control_plane_impl();
     }
 }
 
 void MetalContext::initialize_fabric_config() {
-    if (this->fabric_config_ == tt_fabric::FabricConfig::DISABLED) {
-        return;
-    }
-
-    this->get_cluster().configure_ethernet_cores_for_fabric_routers(
-        this->fabric_config_, this->num_fabric_active_routing_planes_);
-    auto& control_plane = this->get_control_plane();
-    control_plane.configure_routing_tables_for_fabric_ethernet_channels();
+    TT_FATAL(env_ != nullptr, "Missing MetalEnv for this MetalContext");
+    MetalEnvAccessor(*env_).impl().initialize_fabric_config();
 }
 
 void MetalContext::initialize_fabric_tensix_datamover_config() {
-    if (this->fabric_config_ == tt_fabric::FabricConfig::DISABLED) {
-        return;
-    }
-
-    if (get_cluster().get_target_device_type() == tt::TargetDevice::Mock) {
-        return;
-    }
-
-    // Initialize fabric tensix config after routing tables are configured and devices are available
-    if (tt::tt_fabric::is_tt_fabric_config(this->fabric_config_)) {
-        auto& control_plane = this->get_control_plane();
-        control_plane.initialize_fabric_tensix_datamover_config();
-    }
+    TT_FATAL(env_ != nullptr, "Missing MetalEnv for this MetalContext");
+    MetalEnvAccessor(*env_).impl().initialize_fabric_tensix_datamover_config();
 }
 
-tt_fabric::FabricConfig MetalContext::get_fabric_config() const { return fabric_config_; }
+tt_fabric::FabricConfig MetalContext::get_fabric_config() const {
+    TT_FATAL(env_ != nullptr, "Missing MetalEnv for this MetalContext");
+    return MetalEnvAccessor(*env_).impl().get_fabric_config();
+}
 
-tt_fabric::FabricReliabilityMode MetalContext::get_fabric_reliability_mode() const { return fabric_reliability_mode_; }
+tt_fabric::FabricReliabilityMode MetalContext::get_fabric_reliability_mode() const {
+    TT_FATAL(env_ != nullptr, "Missing MetalEnv for this MetalContext");
+    return MetalEnvAccessor(*env_).impl().get_fabric_reliability_mode();
+}
 
-const tt_fabric::FabricRouterConfig& MetalContext::get_fabric_router_config() const { return fabric_router_config_; }
+const tt_fabric::FabricRouterConfig& MetalContext::get_fabric_router_config() const {
+    TT_FATAL(env_ != nullptr, "Missing MetalEnv for this MetalContext");
+    return MetalEnvAccessor(*env_).impl().get_fabric_router_config();
+}
 
 void MetalContext::set_fabric_tensix_config(tt_fabric::FabricTensixConfig fabric_tensix_config) {
-    fabric_tensix_config_ = fabric_tensix_config;
+    TT_FATAL(env_ != nullptr, "Missing MetalEnv for this MetalContext");
+    MetalEnvAccessor(*env_).impl().set_fabric_tensix_config(fabric_tensix_config);
 }
 
-tt_fabric::FabricTensixConfig MetalContext::get_fabric_tensix_config() const { return fabric_tensix_config_; }
+tt_fabric::FabricTensixConfig MetalContext::get_fabric_tensix_config() const {
+    TT_FATAL(env_ != nullptr, "Missing MetalEnv for this MetalContext");
+    return MetalEnvAccessor(*env_).impl().get_fabric_tensix_config();
+}
 
-tt_fabric::FabricUDMMode MetalContext::get_fabric_udm_mode() const { return fabric_udm_mode_; }
+tt_fabric::FabricUDMMode MetalContext::get_fabric_udm_mode() const {
+    TT_FATAL(env_ != nullptr, "Missing MetalEnv for this MetalContext");
+    return MetalEnvAccessor(*env_).impl().get_fabric_udm_mode();
+}
 
-tt_fabric::FabricManagerMode MetalContext::get_fabric_manager() const { return fabric_manager_; }
+tt_fabric::FabricManagerMode MetalContext::get_fabric_manager() const {
+    TT_FATAL(env_ != nullptr, "Missing MetalEnv for this MetalContext");
+    return MetalEnvAccessor(*env_).impl().get_fabric_manager();
+}
+
+// ─── Distributed context — delegated to MetalEnv ─────────────────────────────
+
+const distributed::multihost::DistributedContext& MetalContext::full_world_distributed_context() const {
+    TT_FATAL(env_ != nullptr, "Missing MetalEnv for this MetalContext");
+    return MetalEnvAccessor(*env_).impl().full_world_distributed_context();
+}
+
+const distributed::multihost::DistributedContext& MetalContext::global_distributed_context() {
+    TT_FATAL(env_ != nullptr, "Missing MetalEnv for this MetalContext");
+    return MetalEnvAccessor(*env_).impl().global_distributed_context();
+}
+
+std::shared_ptr<distributed::multihost::DistributedContext> MetalContext::get_distributed_context_ptr() {
+    TT_FATAL(env_ != nullptr, "Missing MetalEnv for this MetalContext");
+    return MetalEnvAccessor(*env_).impl().get_distributed_context_ptr();
+}
 
 void MetalContext::init_context_descriptor(
     int num_hw_cqs, size_t l1_small_size, size_t trace_region_size, size_t worker_l1_size) {
-    TT_FATAL(env_ != nullptr, "MetalEnv is not initialized");
+    TT_FATAL(env_ != nullptr, "Missing MetalEnv for this MetalContext");
+    MetalEnvImpl& env_accessor = MetalEnvAccessor(*env_).impl();
     std::string mock_cluster_desc_path =
         env_->get_descriptor().is_mock_device() ? env_->get_descriptor().mock_cluster_desc_path() : "";
     context_descriptor_ = std::make_shared<ContextDescriptor>(
         hal(),
         get_cluster(),
         rtoptions(),
-        fabric_config_,
-        fabric_reliability_mode_,
-        fabric_tensix_config_,
-        fabric_udm_mode_,
-        fabric_manager_,
-        fabric_router_config_,
+        env_accessor.get_fabric_config(),
+        env_accessor.get_fabric_reliability_mode(),
+        env_accessor.get_fabric_tensix_config(),
+        env_accessor.get_fabric_udm_mode(),
+        env_accessor.get_fabric_manager(),
+        env_accessor.get_fabric_router_config(),
         num_hw_cqs,
         l1_small_size,
         trace_region_size,
@@ -753,18 +587,22 @@ void MetalContext::init_context_descriptor(
 }
 
 void MetalContext::init_risc_fw_context_descriptor(int num_hw_cqs, size_t worker_l1_size) {
+    // env_ is assigned in MetalContext constructor. It should never be null at this point
+    TT_FATAL(env_ != nullptr, "Missing MetalEnv for this MetalContext");
+
     // Fabric settings are used during risc init. In some cases, fabric is already running
     // and we don't want to reset the cores
+    MetalEnvImpl& env_accessor = MetalEnvAccessor(*env_).impl();
     risc_fw_context_descriptor_ = std::make_shared<ContextDescriptor>(
         hal(),
         get_cluster(),
         rtoptions(),
-        fabric_config_,
-        fabric_reliability_mode_,
-        fabric_tensix_config_,
-        fabric_udm_mode_,
-        fabric_manager_,
-        fabric_router_config_,
+        env_accessor.get_fabric_config(),
+        env_accessor.get_fabric_reliability_mode(),
+        env_accessor.get_fabric_tensix_config(),
+        env_accessor.get_fabric_udm_mode(),
+        env_accessor.get_fabric_manager(),
+        env_accessor.get_fabric_router_config(),
         num_hw_cqs,
         /*l1_small_size=*/0,
         /*trace_region_size=*/0,
@@ -774,105 +612,8 @@ void MetalContext::init_risc_fw_context_descriptor(int num_hw_cqs, size_t worker
         rtoptions().get_mock_cluster_desc_path());
 }
 
-void MetalContext::construct_control_plane(const std::filesystem::path& mesh_graph_desc_path) {
-    if (!logical_mesh_chip_id_to_physical_chip_id_mapping_.empty()) {
-        log_info(tt::LogDistributed, "Using custom Fabric Node Id to physical chip mapping.");
-        control_plane_ = std::make_unique<tt::tt_fabric::ControlPlane>(
-            get_cluster(),
-            rtoptions(),
-            hal(),
-            *distributed_context_,
-            mesh_graph_desc_path.string(),
-            logical_mesh_chip_id_to_physical_chip_id_mapping_,
-            this->fabric_config_,
-            this->fabric_reliability_mode_,
-            this->fabric_tensix_config_,
-            this->fabric_udm_mode_,
-            this->fabric_router_config_,
-            this->fabric_manager_);
-    } else {
-        control_plane_ = std::make_unique<tt::tt_fabric::ControlPlane>(
-            get_cluster(),
-            rtoptions(),
-            hal(),
-            *distributed_context_,
-            mesh_graph_desc_path.string(),
-            this->fabric_config_,
-            this->fabric_reliability_mode_,
-            this->fabric_tensix_config_,
-            this->fabric_udm_mode_,
-            this->fabric_router_config_,
-            this->fabric_manager_);
-    }
-}
+// ─── Command queue id stack ──────────────────────────────────────────────────
 
-void MetalContext::construct_control_plane() {
-    // Use auto-discovery to generate mesh graph from physical system descriptor
-    // This uses MeshGraph::generate_from_physical_system_descriptor which internally
-    // uses map_mesh_to_physical to find a valid mapping
-    if (!logical_mesh_chip_id_to_physical_chip_id_mapping_.empty()) {
-        log_warning(
-            tt::LogDistributed,
-            "Custom Fabric Node Id to physical chip mapping provided but no mesh graph descriptor path. "
-            "Mapping will be ignored. Please provide a custom mesh graph descriptor path for custom logical to "
-            "physical mapping.");
-    }
-    log_info(tt::LogDistributed, "Constructing control plane using auto-discovery (no mesh graph descriptor).");
-    control_plane_ = std::make_unique<tt::tt_fabric::ControlPlane>(
-        get_cluster(),
-        rtoptions(),
-        hal(),
-        *distributed_context_,
-        this->fabric_config_,
-        this->fabric_reliability_mode_,
-        this->fabric_tensix_config_,
-        this->fabric_udm_mode_,
-        this->fabric_router_config_,
-        this->fabric_manager_);
-}
-
-void MetalContext::initialize_control_plane() {
-    std::lock_guard<std::mutex> lock(control_plane_mutex_);
-    initialize_control_plane_impl();
-}
-
-void MetalContext::initialize_control_plane_impl() {
-    if (custom_mesh_graph_desc_path_.has_value()) {
-        log_debug(tt::LogDistributed, "Using custom mesh graph descriptor: {}", custom_mesh_graph_desc_path_.value());
-        std::filesystem::path mesh_graph_desc_path = std::filesystem::path(custom_mesh_graph_desc_path_.value());
-        TT_FATAL(
-            std::filesystem::exists(mesh_graph_desc_path),
-            "Custom mesh graph descriptor file not found: {}",
-            mesh_graph_desc_path.string());
-
-        log_info(tt::LogDistributed, "Using custom mesh graph descriptor: {}", mesh_graph_desc_path.string());
-        this->construct_control_plane(mesh_graph_desc_path);
-        return;
-    }
-    // If no custom mesh graph descriptor use auto discovery to generate mesh graph
-    log_info(tt::LogDistributed, "Using auto discovery to generate mesh graph.");
-
-    if (*distributed_context_->size() == 1) {
-        this->construct_control_plane();
-    } else {
-        const auto cluster_type = get_cluster().get_cluster_type();
-        auto fabric_type = tt::tt_fabric::get_fabric_type(this->fabric_config_, get_cluster().is_ubb_galaxy());
-        std::filesystem::path mesh_graph_desc_path =
-            tt::tt_fabric::MeshGraph::get_mesh_graph_descriptor_path_for_cluster_type(
-                cluster_type, rtoptions().get_root_dir(), fabric_type);
-
-        log_debug(tt::LogMetal, "Using mesh graph descriptor: {}", mesh_graph_desc_path);
-
-        TT_FATAL(!mesh_graph_desc_path.empty(), "No mesh graph descriptor found for cluster type");
-        TT_FATAL(
-            std::filesystem::exists(mesh_graph_desc_path),
-            "Mesh graph descriptor file not found: {}",
-            mesh_graph_desc_path.string());
-        this->construct_control_plane(mesh_graph_desc_path);
-    }
-}
-
-// Command queue id stack for thread
 thread_local MetalContext::CommandQueueIdStack MetalContext::command_queue_id_stack_for_thread_;
 
 MetalContext::CommandQueueIdStack& MetalContext::get_command_queue_id_stack_for_thread() {

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -10,8 +10,6 @@
 #include <impl/allocator/allocator_types.hpp>
 #include <tt-metalium/allocator.hpp>
 #include "impl/device/firmware/firmware_initializer.hpp"
-#include "experimental/fabric/routing_table_generator.hpp"
-#include "llrt/hal/generated/dev_msgs.hpp"
 #include <umd/device/types/cluster_descriptor_types.hpp>
 #include <tt-metalium/experimental/context/metal_env.hpp>
 #include "hostdevcommon/api/hostdevcommon/common_values.hpp"
@@ -19,10 +17,6 @@
 namespace tt::tt_fabric {
 class ControlPlane;
 }  // namespace tt::tt_fabric
-
-namespace tt::tt_metal::distributed {
-class SystemMesh;
-}  // namespace tt::tt_metal::distributed
 
 namespace tt {
 class Cluster;
@@ -67,11 +61,18 @@ public:
 
     static bool instance_exists();
 
-    Cluster& get_cluster();
-    llrt::RunTimeOptions& rtoptions();
-    const Cluster& get_cluster() const;
-    const llrt::RunTimeOptions& rtoptions() const;
-    const Hal& hal() const;
+    [[deprecated("Use MetalEnv instead")]] Cluster& get_cluster();
+    [[deprecated("Use MetalEnv instead")]] llrt::RunTimeOptions& rtoptions();
+    [[deprecated("Use MetalEnv instead")]] const Cluster& get_cluster() const;
+    [[deprecated("Use MetalEnv instead")]] const llrt::RunTimeOptions& rtoptions() const;
+    [[deprecated("Use MetalEnv instead")]] const Hal& hal() const;
+
+    // Returns the MetalEnv instance assigned to this context.
+    [[deprecated(
+        "Use MetalEnv directly instead. This is a temporary workaround until all code is migrated to use "
+        "MetalEnv.")]] tt::tt_metal::MetalEnv&
+    get_env();
+
     dispatch_core_manager& get_dispatch_core_manager();
     DispatchQueryManager& get_dispatch_query_manager();
     const DispatchMemMap& dispatch_mem_map() const;  // DispatchMemMap for the core type we're dispatching on.
@@ -112,12 +113,16 @@ public:
     // This ensures dispatch/compute core allocations stay in sync with the mode
     void set_fast_dispatch_mode(bool enable);
 
-    // Control plane accessors
+    // Delegates to MetalEnv assigned to this context
     void initialize_control_plane();
     tt::tt_fabric::ControlPlane& get_control_plane();
-
-    // System mesh accessor — lazily initialized, reset when control plane is reset.
     distributed::SystemMesh& get_system_mesh();
+
+    const distributed::multihost::DistributedContext& global_distributed_context();
+    const distributed::multihost::DistributedContext& full_world_distributed_context() const;
+    std::shared_ptr<distributed::multihost::DistributedContext> get_distributed_context_ptr();
+
+    // Fabric Settings
     void set_custom_fabric_topology(
         const std::string& mesh_graph_desc_file,
         const std::map<tt_fabric::FabricNodeId, ChipId>& logical_mesh_chip_id_to_physical_chip_id_mapping);
@@ -137,18 +142,11 @@ public:
     tt_fabric::FabricReliabilityMode get_fabric_reliability_mode() const;
     const tt_fabric::FabricRouterConfig& get_fabric_router_config() const;
 
-    const distributed::multihost::DistributedContext& global_distributed_context();
-    const distributed::multihost::DistributedContext& full_world_distributed_context() const;
-    std::shared_ptr<distributed::multihost::DistributedContext> get_distributed_context_ptr();
-
-    // Fabric tensix configuration
     void set_fabric_tensix_config(tt_fabric::FabricTensixConfig fabric_tensix_config);
     tt_fabric::FabricTensixConfig get_fabric_tensix_config() const;
 
-    // Fabric UDM mode configuration
     tt_fabric::FabricUDMMode get_fabric_udm_mode() const;
 
-    // Fabric manager mode configuration
     tt_fabric::FabricManagerMode get_fabric_manager() const;
 
     // This is used to track the current thread's command queue id stack
@@ -167,14 +165,7 @@ private:
     MetalContext();
     ~MetalContext();
 
-    void construct_control_plane(const std::filesystem::path& mesh_graph_desc_path);
-    void construct_control_plane();
-
-    // Reinitialize dispatch managers when transitioning dispatch modes (SD<->FD)
-    // This updates cached dispatch/compute core allocations to match current dispatch mode
     void reinitialize_dispatch_managers();
-    void initialize_control_plane_impl();  // Private implementation without mutex
-    void teardown_fabric_config();
     void teardown_base_objects();
     void teardown_dispatch_state();
     void initialize_base_objects();
@@ -199,8 +190,8 @@ private:
     std::mutex dispatch_timeout_detection_mutex_;
     bool dispatch_timeout_detection_processed_ = false;
 
-    // The MetalEnv is owned by the user
-    // For the legacy code, we will initialize it in the MetalContext constructor.
+    // The MetalEnv is owned by the user.
+    // For the legacy code, we initialize it in the MetalContext constructor.
     tt::tt_metal::MetalEnv* env_;
     bool env_owned_ = false;
 
@@ -222,29 +213,11 @@ private:
     std::unordered_set<InitializerKey> risc_fw_init_done_;
 
     std::array<std::unique_ptr<DispatchMemMap>, static_cast<size_t>(CoreType::COUNT)> dispatch_mem_map_;
-    std::unique_ptr<tt::tt_fabric::ControlPlane> control_plane_;
-    std::unique_ptr<distributed::SystemMesh> system_mesh_;
-    tt_fabric::FabricConfig fabric_config_ = tt_fabric::FabricConfig::DISABLED;
-    tt_fabric::FabricTensixConfig fabric_tensix_config_ = tt_fabric::FabricTensixConfig::DISABLED;
-    tt_fabric::FabricUDMMode fabric_udm_mode_ = tt_fabric::FabricUDMMode::DISABLED;
-    tt_fabric::FabricRouterConfig fabric_router_config_ = tt_fabric::FabricRouterConfig{};
-    std::shared_ptr<distributed::multihost::DistributedContext> distributed_context_;
-    std::shared_ptr<distributed::multihost::DistributedContext> compute_only_distributed_context_;
 
     // We are using a thread_local to allow each thread to have its own command queue id stack.
     // This not only allows consumers to set active command queue for a thread
     // but to also easily push/pop ids to temporarily change the current cq id.
     static thread_local CommandQueueIdStack command_queue_id_stack_for_thread_;
-
-    // Strict system health mode requires (expects) all links/devices to be live. When enabled, it
-    // is expected that any downed devices/links will result in some sort of error condition being
-    // reported. When set to false, the control plane is free to instantiate fewer routing planes
-    // according to which links are available.
-    tt_fabric::FabricReliabilityMode fabric_reliability_mode_ = tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE;
-    uint8_t num_fabric_active_routing_planes_ = 0;
-    std::map<tt_fabric::FabricNodeId, ChipId> logical_mesh_chip_id_to_physical_chip_id_mapping_;
-    std::optional<std::string> custom_mesh_graph_desc_path_ = std::nullopt;
-    tt_fabric::FabricManagerMode fabric_manager_ = tt_fabric::FabricManagerMode::DEFAULT;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/context/metal_env.cpp
+++ b/tt_metal/impl/context/metal_env.cpp
@@ -4,6 +4,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <pthread.h>
+#include <algorithm>
+#include <filesystem>
+#include <enchantum/enchantum.hpp>
+#include <tt_stl/fmt.hpp>
+#include <limits>
+#include <unordered_set>
 #include "metal_env_impl.hpp"
 #include "firmware_capability.hpp"
 #include "get_platform_architecture.hpp"
@@ -15,28 +21,62 @@
 #include <tt-logger/tt-logger.hpp>
 #include <utility>
 
+#include <experimental/fabric/control_plane.hpp>
+#include <experimental/fabric/mesh_graph.hpp>
+#include <distributed_context.hpp>
+#include <system_mesh.hpp>
+#include "fabric/fabric_host_utils.hpp"
+#include "fabric/channel_trimming_export.hpp"
+
 namespace tt::tt_metal {
 
-std::mutex MetalEnv::MetalEnvImpl::s_registry_mutex_;
-std::set<MetalEnv::MetalEnvImpl*> MetalEnv::MetalEnvImpl::s_registry_;
-std::once_flag MetalEnv::MetalEnvImpl::s_atfork_registered_;
+// ─── MetalEnvDescriptor ───────────────────────────────────────────────────────
+
+std::mutex MetalEnvImpl::s_registry_mutex_;
+std::set<MetalEnvImpl*> MetalEnvImpl::s_registry_;
+std::once_flag MetalEnvImpl::s_atfork_registered_;
 
 MetalEnvDescriptor::MetalEnvDescriptor(const std::string& mock_cluster_desc_path) :
     mock_cluster_desc_path_(
         mock_cluster_desc_path.empty() ? std::nullopt : std::optional<std::string>(mock_cluster_desc_path)) {}
 MetalEnvDescriptor::MetalEnvDescriptor(std::optional<std::string> mock_cluster_desc_path) :
     mock_cluster_desc_path_(std::move(mock_cluster_desc_path)) {}
+MetalEnvDescriptor::MetalEnvDescriptor(
+    std::optional<std::string> mock_cluster_desc_path, FabricConfigDescriptor fabric_config_desc) :
+    mock_cluster_desc_path_(std::move(mock_cluster_desc_path)), fabric_config_desc_(fabric_config_desc) {}
 
-void MetalEnv::MetalEnvImpl::prefork_check_all() {
+// ─── MetalEnvImpl core ───────────────────────────────────────────────────────
+
+void MetalEnvImpl::prefork_check_all() {
     std::lock_guard<std::mutex> lock(s_registry_mutex_);
     for (auto* impl : s_registry_) {
         impl->check_use_count_zero();
     }
 }
 
-MetalEnv::MetalEnvImpl::MetalEnvImpl(MetalEnvDescriptor descriptor) : descriptor_(std::move(descriptor)) {
+MetalEnvImpl::MetalEnvImpl(MetalEnvDescriptor descriptor) : descriptor_(std::move(descriptor)) {
     initialize_base_objects();
     verify_fw_capabilities();
+
+    // Apply fabric config from descriptor
+    const auto& fc = descriptor_.fabric_config_descriptor();
+    fabric_config_ = fc.fabric_config;
+    fabric_reliability_mode_ = fc.reliability_mode;
+    fabric_tensix_config_ = fc.fabric_tensix_config;
+    fabric_udm_mode_ = fc.fabric_udm_mode;
+    fabric_manager_ = fc.fabric_manager;
+    fabric_router_config_ = fc.router_config;
+    if (fc.num_routing_planes.has_value()) {
+        num_fabric_active_routing_planes_ = fc.num_routing_planes.value();
+    }
+
+    // Pick up any custom mesh graph descriptor from env/rtoptions
+    if (rtoptions_->is_custom_fabric_mesh_graph_desc_path_specified()) {
+        custom_mesh_graph_desc_path_ = rtoptions_->get_custom_fabric_mesh_graph_desc_path();
+    }
+
+    // Initialize distributed context
+    distributed_context_ = distributed::multihost::DistributedContext::get_current_world();
 
     std::call_once(s_atfork_registered_, []() { pthread_atfork(prefork_check_all, nullptr, nullptr); });
 
@@ -44,21 +84,22 @@ MetalEnv::MetalEnvImpl::MetalEnvImpl(MetalEnvDescriptor descriptor) : descriptor
     s_registry_.insert(this);
 }
 
-MetalEnv::MetalEnvImpl::~MetalEnvImpl() {
+MetalEnvImpl::~MetalEnvImpl() {
     {
         std::lock_guard<std::mutex> lock(s_registry_mutex_);
         s_registry_.erase(this);
     }
     check_use_count_zero();
+    teardown_fabric_objects();
     cluster_.reset();
     hal_.reset();
     rtoptions_.reset();
 }
 
-void MetalEnv::MetalEnvImpl::acquire() { use_count_.fetch_add(1, std::memory_order_acq_rel); }
-void MetalEnv::MetalEnvImpl::release() { use_count_.fetch_sub(1, std::memory_order_acq_rel); }
+void MetalEnvImpl::acquire() { use_count_.fetch_add(1, std::memory_order_acq_rel); }
+void MetalEnvImpl::release() { use_count_.fetch_sub(1, std::memory_order_acq_rel); }
 
-bool MetalEnv::MetalEnvImpl::check_use_count_zero() const {
+bool MetalEnvImpl::check_use_count_zero() const {
     const int use_count = use_count_.load(std::memory_order_acquire);
     if (use_count > 0) {
         log_error(
@@ -71,12 +112,12 @@ bool MetalEnv::MetalEnvImpl::check_use_count_zero() const {
     return true;
 }
 
-llrt::RunTimeOptions& MetalEnv::MetalEnvImpl::get_rtoptions() { return *rtoptions_; }
-const Hal& MetalEnv::MetalEnvImpl::get_hal() { return *hal_; }
-Cluster& MetalEnv::MetalEnvImpl::get_cluster() { return *cluster_; }
-const MetalEnvDescriptor& MetalEnv::MetalEnvImpl::get_descriptor() const { return descriptor_; }
+llrt::RunTimeOptions& MetalEnvImpl::get_rtoptions() { return *rtoptions_; }
+const Hal& MetalEnvImpl::get_hal() { return *hal_; }
+Cluster& MetalEnvImpl::get_cluster() { return *cluster_; }
+const MetalEnvDescriptor& MetalEnvImpl::get_descriptor() const { return descriptor_; }
 
-void MetalEnv::MetalEnvImpl::initialize_base_objects() {
+void MetalEnvImpl::initialize_base_objects() {
     this->rtoptions_ = std::make_unique<llrt::RunTimeOptions>();
 
     if (descriptor_.is_mock_device()) {
@@ -99,7 +140,7 @@ void MetalEnv::MetalEnvImpl::initialize_base_objects() {
     this->cluster_->set_hal(hal_.get());
 }
 
-void MetalEnv::MetalEnvImpl::verify_fw_capabilities() {
+void MetalEnvImpl::verify_fw_capabilities() {
     FirmwareCapabilityRequest req;
     req.enable_2_erisc_mode = this->rtoptions_->get_enable_2_erisc_mode();
 
@@ -110,8 +151,364 @@ void MetalEnv::MetalEnvImpl::verify_fw_capabilities() {
     }
 }
 
-MetalEnv::MetalEnv(MetalEnvDescriptor descriptor) :
-    impl_(std::make_unique<MetalEnv::MetalEnvImpl>(std::move(descriptor))) {}
+// ─── Fabric config ────────────────────────────────────────────────────────────
+
+tt_fabric::FabricConfig MetalEnvImpl::get_fabric_config() const { return fabric_config_; }
+
+tt_fabric::FabricReliabilityMode MetalEnvImpl::get_fabric_reliability_mode() const { return fabric_reliability_mode_; }
+
+const tt_fabric::FabricRouterConfig& MetalEnvImpl::get_fabric_router_config() const { return fabric_router_config_; }
+
+tt_fabric::FabricTensixConfig MetalEnvImpl::get_fabric_tensix_config() const { return fabric_tensix_config_; }
+
+tt_fabric::FabricUDMMode MetalEnvImpl::get_fabric_udm_mode() const { return fabric_udm_mode_; }
+
+tt_fabric::FabricManagerMode MetalEnvImpl::get_fabric_manager() const { return fabric_manager_; }
+
+uint8_t MetalEnvImpl::get_num_fabric_active_routing_planes() const { return num_fabric_active_routing_planes_; }
+
+void MetalEnvImpl::set_fabric_tensix_config(tt_fabric::FabricTensixConfig fabric_tensix_config) {
+    fabric_tensix_config_ = fabric_tensix_config;
+}
+
+// The fabric config is normally set once, from the FabricConfigDescriptor supplied at MetalEnv construction time.
+// However, for the legacy backward-compatibility path, the DeviceManager may call set_fabric_config a second time
+// to enable minimal fabric (FABRIC_1D) for dispatch when the user has not explicitly configured fabric.
+// See DeviceManager::initialize for that path.
+bool MetalEnvImpl::set_fabric_config(
+    tt_fabric::FabricConfig fabric_config,
+    tt_fabric::FabricReliabilityMode reliability_mode,
+    std::optional<uint8_t> num_routing_planes,
+    tt_fabric::FabricTensixConfig fabric_tensix_config,
+    tt_fabric::FabricUDMMode fabric_udm_mode,
+    tt_fabric::FabricManagerMode fabric_manager,
+    tt_fabric::FabricRouterConfig router_config) {
+    force_reinit_ = true;
+
+    // Export channel trimming capture data before fabric config changes.
+    // Must happen while fabric_config_ is still active and fabric context is alive.
+    bool is_tearing_down_fabric =
+        fabric_config == tt_fabric::FabricConfig::DISABLED && this->fabric_config_ != tt_fabric::FabricConfig::DISABLED;
+    if (is_tearing_down_fabric) {
+        tt::tt_fabric::export_channel_trimming_capture(*this);
+    }
+
+    if (this->fabric_config_ == tt_fabric::FabricConfig::DISABLED ||
+        fabric_config == tt_fabric::FabricConfig::DISABLED) {
+        this->fabric_config_ = fabric_config;
+        this->fabric_reliability_mode_ = reliability_mode;
+    } else {
+        TT_FATAL(
+            this->fabric_config_ == fabric_config,
+            "Tried to override previous value of fabric config: {}, with: {}",
+            enchantum::to_string(this->fabric_config_),
+            enchantum::to_string(fabric_config));
+    }
+
+    if (this->fabric_config_ == tt_fabric::FabricConfig::DISABLED) {
+        if (num_routing_planes.has_value()) {
+            log_warning(
+                tt::LogMetal,
+                "Got num_routing_planes while disabling fabric, ignoring it and disabling all active routing planes");
+        }
+
+        this->teardown_fabric_config();
+        return false;
+    }
+
+    if (num_routing_planes.has_value() && num_routing_planes.value() < this->num_fabric_active_routing_planes_) {
+        log_warning(
+            tt::LogMetal,
+            "Got num_routing_planes: {}, which is less than current value: {}, ignoring the override",
+            num_routing_planes.value(),
+            this->num_fabric_active_routing_planes_);
+        return false;
+    }
+
+    const auto new_val = std::max(
+        this->num_fabric_active_routing_planes_, num_routing_planes.value_or(std::numeric_limits<uint8_t>::max()));
+    if (new_val != this->num_fabric_active_routing_planes_ && this->num_fabric_active_routing_planes_ > 0) {
+        log_info(
+            tt::LogMetal,
+            "Overriding the number of routing planes to activate from {} to {}",
+            this->num_fabric_active_routing_planes_,
+            new_val);
+    }
+    this->num_fabric_active_routing_planes_ = new_val;
+
+    this->set_fabric_tensix_config(fabric_tensix_config);
+    this->fabric_udm_mode_ = fabric_udm_mode;
+    this->fabric_manager_ = fabric_manager;
+    this->fabric_router_config_ = router_config;
+
+    if (control_plane_ != nullptr) {
+        log_info(
+            tt::LogMetal,
+            "Fabric config changed from {} to {}, reinitializing control plane",
+            this->get_control_plane().get_fabric_config(),
+            this->fabric_config_);
+        system_mesh_.reset();
+        this->initialize_control_plane_impl();
+    }
+
+    return true;
+}
+
+void MetalEnvImpl::teardown_fabric_config() {
+    this->fabric_config_ = tt_fabric::FabricConfig::DISABLED;
+    this->get_cluster().configure_ethernet_cores_for_fabric_routers(this->fabric_config_);
+    this->num_fabric_active_routing_planes_ = 0;
+    this->get_control_plane().clear_fabric_context();
+}
+
+void MetalEnvImpl::initialize_fabric_config() {
+    if (this->fabric_config_ == tt_fabric::FabricConfig::DISABLED) {
+        return;
+    }
+
+    this->get_cluster().configure_ethernet_cores_for_fabric_routers(
+        this->fabric_config_, this->num_fabric_active_routing_planes_);
+    auto& cp = this->get_control_plane();
+    cp.configure_routing_tables_for_fabric_ethernet_channels();
+}
+
+void MetalEnvImpl::initialize_fabric_tensix_datamover_config() {
+    if (this->fabric_config_ == tt_fabric::FabricConfig::DISABLED) {
+        return;
+    }
+
+    if (get_cluster().get_target_device_type() == tt::TargetDevice::Mock) {
+        return;
+    }
+
+    if (tt::tt_fabric::is_tt_fabric_config(this->fabric_config_)) {
+        auto& cp = this->get_control_plane();
+        cp.initialize_fabric_tensix_datamover_config();
+    }
+}
+
+bool MetalEnvImpl::consume_force_reinit() {
+    bool val = force_reinit_;
+    force_reinit_ = false;
+    return val;
+}
+
+// ─── Control plane ────────────────────────────────────────────────────────────
+
+tt::tt_fabric::ControlPlane& MetalEnvImpl::get_control_plane() {
+    std::lock_guard<std::mutex> lock(control_plane_mutex_);
+    if (!control_plane_) {
+        this->initialize_control_plane_impl();
+    }
+    return *control_plane_;
+}
+
+void MetalEnvImpl::initialize_control_plane() {
+    std::lock_guard<std::mutex> lock(control_plane_mutex_);
+    initialize_control_plane_impl();
+}
+
+void MetalEnvImpl::initialize_control_plane_impl() {
+    if (custom_mesh_graph_desc_path_.has_value()) {
+        log_debug(tt::LogDistributed, "Using custom mesh graph descriptor: {}", custom_mesh_graph_desc_path_.value());
+        std::filesystem::path mesh_graph_desc_path = std::filesystem::path(custom_mesh_graph_desc_path_.value());
+        TT_FATAL(
+            std::filesystem::exists(mesh_graph_desc_path),
+            "Custom mesh graph descriptor file not found: {}",
+            mesh_graph_desc_path.string());
+
+        log_info(tt::LogDistributed, "Using custom mesh graph descriptor: {}", mesh_graph_desc_path.string());
+        this->construct_control_plane(mesh_graph_desc_path);
+        return;
+    }
+    log_info(tt::LogDistributed, "Using auto discovery to generate mesh graph.");
+
+    if (*distributed_context_->size() == 1) {
+        this->construct_control_plane();
+    } else {
+        const auto cluster_type = get_cluster().get_cluster_type();
+        auto fabric_type = tt::tt_fabric::get_fabric_type(this->fabric_config_, get_cluster().is_ubb_galaxy());
+        std::filesystem::path mesh_graph_desc_path =
+            tt::tt_fabric::MeshGraph::get_mesh_graph_descriptor_path_for_cluster_type(
+                cluster_type, rtoptions_->get_root_dir(), fabric_type);
+
+        log_debug(tt::LogMetal, "Using mesh graph descriptor: {}", mesh_graph_desc_path.string());
+
+        TT_FATAL(!mesh_graph_desc_path.empty(), "No mesh graph descriptor found for cluster type");
+        TT_FATAL(
+            std::filesystem::exists(mesh_graph_desc_path),
+            "Mesh graph descriptor file not found: {}",
+            mesh_graph_desc_path.string());
+        this->construct_control_plane(mesh_graph_desc_path);
+    }
+}
+
+void MetalEnvImpl::construct_control_plane(const std::filesystem::path& mesh_graph_desc_path) {
+    if (!logical_mesh_chip_id_to_physical_chip_id_mapping_.empty()) {
+        log_info(tt::LogDistributed, "Using custom Fabric Node Id to physical chip mapping.");
+        control_plane_ = std::make_unique<tt::tt_fabric::ControlPlane>(
+            get_cluster(),
+            *rtoptions_,
+            get_hal(),
+            *distributed_context_,
+            mesh_graph_desc_path.string(),
+            logical_mesh_chip_id_to_physical_chip_id_mapping_,
+            this->fabric_config_,
+            this->fabric_reliability_mode_,
+            this->fabric_tensix_config_,
+            this->fabric_udm_mode_,
+            this->fabric_router_config_,
+            this->fabric_manager_);
+    } else {
+        control_plane_ = std::make_unique<tt::tt_fabric::ControlPlane>(
+            get_cluster(),
+            *rtoptions_,
+            get_hal(),
+            *distributed_context_,
+            mesh_graph_desc_path.string(),
+            this->fabric_config_,
+            this->fabric_reliability_mode_,
+            this->fabric_tensix_config_,
+            this->fabric_udm_mode_,
+            this->fabric_router_config_,
+            this->fabric_manager_);
+    }
+}
+
+void MetalEnvImpl::construct_control_plane() {
+    if (!logical_mesh_chip_id_to_physical_chip_id_mapping_.empty()) {
+        log_warning(
+            tt::LogDistributed,
+            "Custom Fabric Node Id to physical chip mapping provided but no mesh graph descriptor path. "
+            "Mapping will be ignored. Please provide a custom mesh graph descriptor path for custom logical to "
+            "physical mapping.");
+    }
+    log_info(tt::LogDistributed, "Constructing control plane using auto-discovery (no mesh graph descriptor).");
+    control_plane_ = std::make_unique<tt::tt_fabric::ControlPlane>(
+        get_cluster(),
+        *rtoptions_,
+        get_hal(),
+        *distributed_context_,
+        this->fabric_config_,
+        this->fabric_reliability_mode_,
+        this->fabric_tensix_config_,
+        this->fabric_udm_mode_,
+        this->fabric_router_config_,
+        this->fabric_manager_);
+}
+
+// ─── System mesh ──────────────────────────────────────────────────────────────
+
+distributed::SystemMesh& MetalEnvImpl::get_system_mesh() {
+    std::lock_guard<std::mutex> lock(control_plane_mutex_);
+    if (!system_mesh_) {
+        if (!control_plane_) {
+            this->initialize_control_plane_impl();
+        }
+        system_mesh_ = std::unique_ptr<distributed::SystemMesh>(new distributed::SystemMesh(*control_plane_));
+    }
+    return *system_mesh_;
+}
+
+// ─── Custom topology ──────────────────────────────────────────────────────────
+
+void MetalEnvImpl::set_custom_fabric_topology(
+    const std::string& mesh_graph_desc_file,
+    const std::map<tt_fabric::FabricNodeId, ChipId>& logical_mesh_chip_id_to_physical_chip_id_mapping) {
+    this->logical_mesh_chip_id_to_physical_chip_id_mapping_ = logical_mesh_chip_id_to_physical_chip_id_mapping;
+    custom_mesh_graph_desc_path_ = mesh_graph_desc_file;
+    this->set_fabric_config(fabric_config_, tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
+}
+
+void MetalEnvImpl::set_default_fabric_topology() {
+    system_mesh_.reset();
+    control_plane_.reset();
+    this->logical_mesh_chip_id_to_physical_chip_id_mapping_.clear();
+
+    if (rtoptions_->is_custom_fabric_mesh_graph_desc_path_specified()) {
+        custom_mesh_graph_desc_path_ = rtoptions_->get_custom_fabric_mesh_graph_desc_path();
+    } else {
+        custom_mesh_graph_desc_path_ = std::nullopt;
+    }
+    this->set_fabric_config(fabric_config_, tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
+}
+
+// ─── Distributed context ──────────────────────────────────────────────────────
+
+namespace {
+std::shared_ptr<distributed::multihost::DistributedContext> construct_compute_only_distributed_context(
+    tt::tt_fabric::ControlPlane& control_plane) {
+    const auto& global_context = distributed::multihost::DistributedContext::get_current_world();
+    if (*global_context->size() == 1) {
+        return global_context;
+    }
+
+    const auto& mesh_graph = control_plane.get_mesh_graph();
+
+    if (mesh_graph.get_switch_ids().empty()) {
+        return global_context;
+    }
+
+    const auto& compute_mesh_ids = mesh_graph.get_mesh_ids();
+    const auto& global_logical_bindings = control_plane.get_global_logical_bindings();
+
+    std::unordered_set<int> compute_mpi_ranks;
+    for (const auto& [rank, mesh_binding] : global_logical_bindings) {
+        const auto& [mesh_id, _] = mesh_binding;
+        if (std::find(compute_mesh_ids.begin(), compute_mesh_ids.end(), mesh_id) != compute_mesh_ids.end()) {
+            compute_mpi_ranks.insert(rank.get());
+        }
+    }
+
+    if (compute_mpi_ranks.empty()) {
+        TT_THROW("No compute meshes found in mesh graph.");
+    }
+
+    std::vector<int> compute_ranks_vec(compute_mpi_ranks.begin(), compute_mpi_ranks.end());
+    std::sort(compute_ranks_vec.begin(), compute_ranks_vec.end());
+
+    int current_rank = *global_context->rank();
+    bool is_current_rank_in_compute =
+        std::find(compute_ranks_vec.begin(), compute_ranks_vec.end(), current_rank) != compute_ranks_vec.end();
+
+    if (!is_current_rank_in_compute) {
+        return control_plane.get_host_local_context();
+    }
+
+    return global_context->create_sub_context(compute_ranks_vec);
+}
+}  // namespace
+
+const distributed::multihost::DistributedContext& MetalEnvImpl::full_world_distributed_context() const {
+    TT_FATAL(distributed_context_, "Distributed context not initialized.");
+    return *distributed_context_;
+}
+
+const distributed::multihost::DistributedContext& MetalEnvImpl::global_distributed_context() {
+    if (!control_plane_) {
+        return *distributed_context_;
+    }
+    if (!compute_only_distributed_context_) {
+        compute_only_distributed_context_ = construct_compute_only_distributed_context(get_control_plane());
+    }
+    return *compute_only_distributed_context_;
+}
+
+std::shared_ptr<distributed::multihost::DistributedContext> MetalEnvImpl::get_distributed_context_ptr() {
+    TT_FATAL(distributed_context_, "Distributed context not initialized.");
+    return distributed_context_;
+}
+
+void MetalEnvImpl::teardown_fabric_objects() {
+    system_mesh_.reset();
+    control_plane_.reset();
+    distributed_context_.reset();
+    compute_only_distributed_context_.reset();
+}
+
+// ─── MetalEnv public forwarding ───────────────────────────────────────────────
+
+MetalEnv::MetalEnv(MetalEnvDescriptor descriptor) : impl_(std::make_unique<MetalEnvImpl>(std::move(descriptor))) {}
 
 MetalEnv::~MetalEnv() { this->impl_.reset(); }
 
@@ -134,5 +531,8 @@ uint32_t MetalEnv::get_max_worker_l1_unreserved_size() const {
 float MetalEnv::get_eps() const { return impl_->get_hal().get_eps(); }
 float MetalEnv::get_nan() const { return impl_->get_hal().get_nan(); }
 float MetalEnv::get_inf() const { return impl_->get_hal().get_inf(); }
+
+tt::tt_fabric::ControlPlane& MetalEnv::get_control_plane() { return impl_->get_control_plane(); }
+distributed::SystemMesh& MetalEnv::get_system_mesh() { return impl_->get_system_mesh(); }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/context/metal_env_accessor.hpp
+++ b/tt_metal/impl/context/metal_env_accessor.hpp
@@ -13,12 +13,8 @@ class MetalEnvAccessor {
 public:
     explicit MetalEnvAccessor(MetalEnv& env) noexcept : env_(env) {}
 
-    llrt::RunTimeOptions& get_rtoptions() { return env_.impl().get_rtoptions(); }
-    tt::Cluster& get_cluster() { return env_.impl().get_cluster(); }
-    const Hal& get_hal() const { return env_.impl().get_hal(); }
-    void acquire() { env_.impl().acquire(); }
-    void release() { env_.impl().release(); }
-    bool check_use_count_zero() const { return env_.impl().check_use_count_zero(); }
+    MetalEnvImpl& impl() { return env_.impl(); }
+    const MetalEnvImpl& impl() const { return env_.impl(); }
 
 private:
     MetalEnv& env_;

--- a/tt_metal/impl/context/metal_env_impl.hpp
+++ b/tt_metal/impl/context/metal_env_impl.hpp
@@ -4,17 +4,32 @@
 
 #pragma once
 
+#include <map>
 #include <mutex>
 #include <set>
 #include <atomic>
+#include <filesystem>
 #include <tt-metalium/experimental/context/metal_env.hpp>
+#include <tt-metalium/experimental/fabric/fabric_types.hpp>
 #include "tt_metal/llrt/hal.hpp"
 #include "tt_metal/llrt/tt_cluster.hpp"
 #include "tt_metal/llrt/rtoptions.hpp"
 
+namespace tt::tt_fabric {
+class ControlPlane;
+}  // namespace tt::tt_fabric
+
+namespace tt::tt_metal::distributed {
+class SystemMesh;
+}  // namespace tt::tt_metal::distributed
+
+namespace tt::tt_metal::distributed::multihost {
+class DistributedContext;
+}
+
 namespace tt::tt_metal {
 
-class MetalEnv::MetalEnvImpl {
+class MetalEnvImpl {
 public:
     explicit MetalEnvImpl(MetalEnvDescriptor descriptor);
     ~MetalEnvImpl();
@@ -29,6 +44,54 @@ public:
     void acquire();
     void release();
 
+    // --- Fabric config ---
+    tt_fabric::FabricConfig get_fabric_config() const;
+    tt_fabric::FabricReliabilityMode get_fabric_reliability_mode() const;
+    const tt_fabric::FabricRouterConfig& get_fabric_router_config() const;
+    tt_fabric::FabricTensixConfig get_fabric_tensix_config() const;
+    tt_fabric::FabricUDMMode get_fabric_udm_mode() const;
+    tt_fabric::FabricManagerMode get_fabric_manager() const;
+    uint8_t get_num_fabric_active_routing_planes() const;
+
+    // Returns true if updated
+    bool set_fabric_config(
+        tt_fabric::FabricConfig fabric_config,
+        tt_fabric::FabricReliabilityMode reliability_mode =
+            tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE,
+        std::optional<uint8_t> num_routing_planes = std::nullopt,
+        tt_fabric::FabricTensixConfig fabric_tensix_config = tt_fabric::FabricTensixConfig::DISABLED,
+        tt_fabric::FabricUDMMode fabric_udm_mode = tt_fabric::FabricUDMMode::DISABLED,
+        tt_fabric::FabricManagerMode fabric_manager = tt_fabric::FabricManagerMode::DEFAULT,
+        tt_fabric::FabricRouterConfig router_config = tt_fabric::FabricRouterConfig{});
+    void set_fabric_tensix_config(tt_fabric::FabricTensixConfig fabric_tensix_config);
+    void initialize_fabric_config();
+    void initialize_fabric_tensix_datamover_config();
+    void teardown_fabric_config();
+
+    // --- Control plane ---
+    tt::tt_fabric::ControlPlane& get_control_plane();
+    void initialize_control_plane();
+
+    // --- System mesh ---
+    distributed::SystemMesh& get_system_mesh();
+
+    // --- Custom topology ---
+    void set_custom_fabric_topology(
+        const std::string& mesh_graph_desc_file,
+        const std::map<tt_fabric::FabricNodeId, ChipId>& logical_mesh_chip_id_to_physical_chip_id_mapping);
+    void set_default_fabric_topology();
+
+    // --- Distributed context ---
+    const distributed::multihost::DistributedContext& full_world_distributed_context() const;
+    const distributed::multihost::DistributedContext& global_distributed_context();
+    std::shared_ptr<distributed::multihost::DistributedContext> get_distributed_context_ptr();
+
+    // Teardown fabric-layer objects (control plane, system mesh, distributed context).
+    void teardown_fabric_objects();
+
+    // Returns true if set_fabric_config changed state requiring a reinit.
+    bool consume_force_reinit();
+
 private:
     MetalEnvDescriptor descriptor_;
 
@@ -38,8 +101,35 @@ private:
 
     std::atomic<int> use_count_{0};
 
+    // --- Fabric config state ---
+    tt_fabric::FabricConfig fabric_config_ = tt_fabric::FabricConfig::DISABLED;
+    tt_fabric::FabricReliabilityMode fabric_reliability_mode_ =
+        tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE;
+    tt_fabric::FabricTensixConfig fabric_tensix_config_ = tt_fabric::FabricTensixConfig::DISABLED;
+    tt_fabric::FabricUDMMode fabric_udm_mode_ = tt_fabric::FabricUDMMode::DISABLED;
+    tt_fabric::FabricManagerMode fabric_manager_ = tt_fabric::FabricManagerMode::DEFAULT;
+    tt_fabric::FabricRouterConfig fabric_router_config_ = tt_fabric::FabricRouterConfig{};
+    uint8_t num_fabric_active_routing_planes_ = 0;
+    std::map<tt_fabric::FabricNodeId, ChipId> logical_mesh_chip_id_to_physical_chip_id_mapping_;
+    std::optional<std::string> custom_mesh_graph_desc_path_ = std::nullopt;
+
+    bool force_reinit_ = false;
+
+    // --- Control plane / system mesh ---
+    std::mutex control_plane_mutex_;
+    std::unique_ptr<tt::tt_fabric::ControlPlane> control_plane_;
+    std::unique_ptr<distributed::SystemMesh> system_mesh_;
+
+    // --- Distributed context ---
+    std::shared_ptr<distributed::multihost::DistributedContext> distributed_context_;
+    std::shared_ptr<distributed::multihost::DistributedContext> compute_only_distributed_context_;
+
     void initialize_base_objects();
     void verify_fw_capabilities();
+
+    void construct_control_plane(const std::filesystem::path& mesh_graph_desc_path);
+    void construct_control_plane();
+    void initialize_control_plane_impl();
 
     static std::mutex s_registry_mutex_;
     static std::set<MetalEnvImpl*> s_registry_;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/33849

### Problem description
- Fabric/ControlPlane/SystemMesh belong on a lower level than runtime/dispatch state. These objects set the physical topology of the cluster and also virtualize physical devices across the system. These settings are not runtime configuration like Num CQs, so it makes sense to have them on the MetalEnv level which is lower than MetalContext.
- With the new MetalEnv, we want to be able to query some physical info and then request a mesh device from it.

### What's changed
- Remove code from MetalContext and update it to maintain existing API
- When creating a MetalEnv, you can also specify the Fabric settings to configure the cluster with the desired topology.
- Add unit tests
- Add test for the edge case where Fabric was disabled/not set by the user, but we need it for Dispatching to remote devices

### Checklist
Sanity
https://github.com/tenstorrent/tt-metal/actions/runs/22963457533

Galaxy Quick
https://github.com/tenstorrent/tt-metal/actions/runs/22930502037

Multi Host Deployment -- Same result as main. stale file handle.
https://github.com/tenstorrent/tt-metal/actions/runs/22974124870

- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nhuang/lower-fabric)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nhuang/lower-fabric)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nhuang/lower-fabric)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nhuang/lower-fabric)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nhuang/lower-fabric)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nhuang/lower-fabric)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nhuang/lower-fabric)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nhuang/lower-fabric)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nhuang/lower-fabric)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nhuang/lower-fabric)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
