### PR TITLE
Fix fmt formatter for std::vector<bool> proxy references

### DIFF
--- a/tt_stl/tests/test_fmt.cpp
+++ b/tt_stl/tests/test_fmt.cpp
@@ -42,6 +42,28 @@ TEST(FmtTest, VectorInt) {
     EXPECT_THAT(result, HasSubstr("3"));
 }
 
+// Test std::vector<bool> formatting (proxy reference edge case)
+// vector<bool> uses bit-packing; operator[] returns a proxy type, not a real bool.
+// This test guards against fmt 11's unformattable-type hard error regressing.
+TEST(FmtTest, VectorBool) {
+    // Mixed values
+    std::vector<bool> mixed = {true, false, true};
+    std::string result = fmt::format("{}", mixed);
+    EXPECT_THAT(result, HasSubstr("true"));
+    EXPECT_THAT(result, HasSubstr("false"));
+
+    // Empty vector
+    std::vector<bool> empty = {};
+    std::string empty_result = fmt::format("{}", empty);
+    EXPECT_EQ(empty_result, "{}");
+
+    // All-false
+    std::vector<bool> all_false = {false, false};
+    std::string all_false_result = fmt::format("{}", all_false);
+    EXPECT_THAT(all_false_result, HasSubstr("false"));
+    EXPECT_EQ(all_false_result.find("true"), std::string::npos);
+}
+
 // Test std::optional<T> formatting
 TEST(FmtTest, Optional) {
     std::optional<int> opt_val = 42;

--- a/tt_stl/tt_stl/fmt.hpp
+++ b/tt_stl/tt_stl/fmt.hpp
@@ -182,8 +182,8 @@ struct fmt::formatter<std::vector<T, Alloc>> {
     }
 };
 
-// std::vector<bool> — special case: operator[] returns a proxy __bit_const_reference, not a real bool.
-// fmt 11 cannot format proxy references directly; cast each element to bool explicitly.
+// std::vector<bool> — special case: operator[] returns a proxy reference type, not a real bool.
+// fmt 11 cannot format such proxy references directly; cast each element to bool explicitly.
 template <typename Alloc>
 struct fmt::formatter<std::vector<bool, Alloc>> {
     constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }

--- a/tt_stl/tt_stl/fmt.hpp
+++ b/tt_stl/tt_stl/fmt.hpp
@@ -182,6 +182,26 @@ struct fmt::formatter<std::vector<T, Alloc>> {
     }
 };
 
+// std::vector<bool> — special case: operator[] returns a proxy __bit_const_reference, not a real bool.
+// fmt 11 cannot format proxy references directly; cast each element to bool explicitly.
+template <typename Alloc>
+struct fmt::formatter<std::vector<bool, Alloc>> {
+    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
+
+    auto format(const std::vector<bool, Alloc>& vec, format_context& ctx) const -> format_context::iterator {
+        auto out = fmt::format_to(ctx.out(), "{{");
+        bool first = true;
+        for (bool val : vec) {
+            if (!first) {
+                out = fmt::format_to(out, ", ");
+            }
+            out = fmt::format_to(out, "{}", val);
+            first = false;
+        }
+        return fmt::format_to(out, "}}");
+    }
+};
+
 // std::array
 template <typename T, std::size_t N>
 struct fmt::formatter<std::array<T, N>> {


### PR DESCRIPTION
## Problem description

`std::vector<bool>` is a well-known C++ footgun: it uses bit-packing internally, so `operator[]` returns a `__bit_const_reference` proxy object instead of a real `bool`. fmt 11 cannot format proxy references, causing a hard compile error:

```
error: implicit instantiation of undefined template
  'fmt::detail::type_is_unformattable_for<
     std::__bit_const_reference<std::vector<bool>>, char>'
```

This broke `build-artifact-profiler` (Tracy-enabled build) in the `(Galaxy) perf tests` scheduled workflow — run [22897555647](https://github.com/tenstorrent/tt-metal/actions/runs/22897555647) — after PR #38941 replaced the old `reflection.hpp` catch-all stringstream formatter with the new stricter `tt_stl/fmt.hpp`.

The specific trigger: `moreh_group_norm`'s `operation_attributes_t` contains a `std::vector<bool> are_required_outputs` member. The device operation framework in `device_operation.hpp` automatically reflects and logs all fields of `operation_attributes_t` via `tt::stl::reflection::get_attributes()`. In Tracy builds, this logging path is active and hits the fmt error.

## What's changed

Added an explicit `fmt::formatter<std::vector<bool, Alloc>>` specialization to `tt_stl/fmt.hpp` that casts each proxy element to `bool` before formatting.

Output format: `{true, false, true}` — more readable than the old `{1, 0, 1}` from the stringstream path. No tests assert on log string content.

## Validation

- Compiled `ttnn_op_moreh` locally with `-DENABLE_TRACY=ON` — previously failing, now clean
- all-post-commit run: https://github.com/tenstorrent/tt-metal/actions/runs/22919675073 (in progress)

## Checklist

- [x] Non-functional change (no logic, only fmt output format changes from `0/1` to `true/false`)
- [x] Compiled locally with Tracy flags
- [x] All-post-commit triggered on branch
- [ ] Follow-up: sweep codebase to replace `std::vector<bool>` with `std::vector<uint8_t>` in `operation_attributes_t` structs (#TBD)