### PR TITLE
[skip ci] Disable BH P150 DRAM ubench test

### DIFF
--- a/.github/workflows/metal-run-microbenchmarks-impl.yaml
+++ b/.github/workflows/metal-run-microbenchmarks-impl.yaml
@@ -45,7 +45,7 @@ jobs:
             name: "WH Data Movement Regressions",
             cmd: "pytest -svv tests/tt_metal/tt_metal/data_movement/python/test_data_movement.py --gtest-filter Directed --verbose-log",
           }, # Ata Tuzuner
-          # Disabled: CI regression on gh05/gh06 (~0.01 GB/s vs 500 GB/s locally). Suspected machine-specific issue. https://github.com/tenstorrent/tt-metal/issues/39545
+          # Disabled: CI regression on gh05/gh06 (~0.01 GB/s vs 500 GB/s locally). Suspected machine-specific issue. Tracking: https://github.com/tenstorrent/tt-metal/issues/39545. Re-enable this test when issue #39545 is resolved.
           # {
           #   arch: blackhole,
           #   runs-on: ["BH", "pipeline-perf", "P150", "in-service"],

--- a/.github/workflows/metal-run-microbenchmarks-impl.yaml
+++ b/.github/workflows/metal-run-microbenchmarks-impl.yaml
@@ -45,7 +45,7 @@ jobs:
             name: "WH Data Movement Regressions",
             cmd: "pytest -svv tests/tt_metal/tt_metal/data_movement/python/test_data_movement.py --gtest-filter Directed --verbose-log",
           }, # Ata Tuzuner
-          # Disabled: CI regression on gh05/gh06 (~0.01 GB/s vs 500 GB/s locally). Suspected machine-specific issue.
+          # Disabled: CI regression on gh05/gh06 (~0.01 GB/s vs 500 GB/s locally). Suspected machine-specific issue. https://github.com/tenstorrent/tt-metal/issues/39545
           # {
           #   arch: blackhole,
           #   runs-on: ["BH", "pipeline-perf", "P150", "in-service"],

--- a/.github/workflows/metal-run-microbenchmarks-impl.yaml
+++ b/.github/workflows/metal-run-microbenchmarks-impl.yaml
@@ -45,12 +45,13 @@ jobs:
             name: "WH Data Movement Regressions",
             cmd: "pytest -svv tests/tt_metal/tt_metal/data_movement/python/test_data_movement.py --gtest-filter Directed --verbose-log",
           }, # Ata Tuzuner
-          {
-            arch: blackhole,
-            runs-on: ["BH", "pipeline-perf", "P150", "in-service"],
-            name: "BH P150 DRAM ubench",
-            cmd: "./tests/scripts/run_moreh_microbenchmark.sh",
-          }, # Yu Gao
+          # Disabled: CI regression on gh05/gh06 (~0.01 GB/s vs 500 GB/s locally). Suspected machine-specific issue.
+          # {
+          #   arch: blackhole,
+          #   runs-on: ["BH", "pipeline-perf", "P150", "in-service"],
+          #   name: "BH P150 DRAM ubench",
+          #   cmd: "./tests/scripts/run_moreh_microbenchmark.sh",
+          # }, # Yu Gao
           {
             arch: blackhole,
             runs-on: ["BH", "pipeline-perf", "in-service"],


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/39545

### Problem description
The BH P150 DRAM ubench job has been failing in CI since ~Mar 8 (commit 669abf5):
- **CI (gh05/gh06):** ~0.01 GB/s (regression - below 350 GB/s lower bound)
- **Local (multiple devs):** ~500 GB/s (expected)

Firmware versions are identical across runs. Two developers confirmed 500 GB/s locally with the exact CI-equivalent command. Evidence points to a machine-specific issue on gh05/gh06 rather than a code regression.

### What's changed
- Commented out the BH P150 DRAM ubench job in `metal-run-microbenchmarks-impl.yaml`
- Added comment explaining the disable and linking to the suspected root cause

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=disable-bh-p150-dram-ubench)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:disable-bh-p150-dram-ubench)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=disable-bh-p150-dram-ubench)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:disable-bh-p150-dram-ubench)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=disable-bh-p150-dram-ubench)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:disable-bh-p150-dram-ubench)
- [x] New/Existing tests provide coverage for changes (N/A - disabling test)
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

Workflow-only change: no model code changes. Metal microbenchmarks workflow will run with one fewer job.

Made with [Cursor](https://cursor.com)