### PR TITLE
Update Deepseek MLA to store and use Prefill-mode and height-sharded `sin`, `cos`, `trans_mat` to avoid transposes in RoPE

### DIFF
--- a/models/demos/deepseek_v3/tt/mla/mla1d.py
+++ b/models/demos/deepseek_v3/tt/mla/mla1d.py
@@ -1875,20 +1875,14 @@ class MLA1D(AbstractModule):
 
         # KV RoPE
         # 1,1,32,64 1x2 [32,32]
-        tt_kv_rope = ttnn.transpose(
-            tt_kv_rope, 1, 2, memory_config=cfg["kv_rope_reshard"]
-        )  # [1, bsz, 1, qk_rope_head_dim]        # 1,32,1,64 interleaved | should be: 4x8 [32,64]
         tt_kv_rope = ttnn.experimental.rotary_embedding_llama(
             tt_kv_rope,
-            rope_tensors["cos_matrix"],
-            rope_tensors["sin_matrix"],
-            rope_tensors["trans_matrix"],
-            is_decode_mode=True,
+            rope_tensors["cos_matrix_prefill_shape"],
+            rope_tensors["sin_matrix_prefill_shape"],
+            rope_tensors["trans_matrix_prefill_shape"],
+            is_decode_mode=False,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
         )
-        # 1,32,1,64 4x8 [32,64]
-        tt_kv_rope = ttnn.transpose(
-            tt_kv_rope, 1, 2, memory_config=ttnn.L1_MEMORY_CONFIG
-        )  # [1, 1, bsz, qk_rope_head_dim]
         # 1,1,32,64 L1 interleaved
         tt_kv_nope = ttnn.to_memory_config(tt_kv_nope, memory_config=ttnn.L1_MEMORY_CONFIG)
 

--- a/models/demos/deepseek_v3/tt/mla/mla1d.py
+++ b/models/demos/deepseek_v3/tt/mla/mla1d.py
@@ -1879,7 +1879,7 @@ class MLA1D(AbstractModule):
             tt_kv_rope,
             rope_tensors["cos_matrix_prefill_shape"],
             rope_tensors["sin_matrix_prefill_shape"],
-            rope_tensors["trans_matrix_prefill_shape"],
+            rope_tensors["trans_matrix"],
             is_decode_mode=False,
             memory_config=ttnn.L1_MEMORY_CONFIG,
         )

--- a/models/demos/deepseek_v3/tt/rope.py
+++ b/models/demos/deepseek_v3/tt/rope.py
@@ -249,7 +249,8 @@ class RotarySetup:
             use_height_and_width_as_shard_shape=True,
         )
 
-        # [1, 1, batch, dim] HEIGHT_SHARDED for rotary_embedding_llama with input_transpose=HC
+        # For using height-sharded prefill-mode in decode with batch reinterpreted as seq_len
+        # Possible because `rotary_embedding_llama` is (almost) an eltwise op.
         cos_matrix_prefill_shape = ttnn.to_memory_config(
             cos, memory_config=mem_config
         )  # ttnn.interleaved_to_sharded(cos, mem_config)
@@ -318,7 +319,8 @@ class RotarySetup:
             use_height_and_width_as_shard_shape=True,
         )
 
-        # [1, 1, batch, dim] HEIGHT_SHARDED for rotary_embedding_llama with input_transpose=HC
+        # For using height-sharded prefill-mode in decode with batch reinterpreted as seq_len
+        # Possible because `rotary_embedding_llama` is (almost) an eltwise op.
         cos_matrix_prefill_shape = ttnn.to_memory_config(
             cos, memory_config=mem_config
         )  # ttnn.interleaved_to_sharded(cos, mem_config)

--- a/models/demos/deepseek_v3/tt/rope.py
+++ b/models/demos/deepseek_v3/tt/rope.py
@@ -251,10 +251,10 @@ class RotarySetup:
 
         # [1, 1, batch, dim] HEIGHT_SHARDED for rotary_embedding_llama with input_transpose=HC
         cos_matrix_prefill_shape = ttnn.to_memory_config(
-            cos, memory_config=ttnn.DRAM_MEMORY_CONFIG
+            cos, memory_config=mem_config
         )  # ttnn.interleaved_to_sharded(cos, mem_config)
         sin_matrix_prefill_shape = ttnn.to_memory_config(
-            sin, memory_config=ttnn.DRAM_MEMORY_CONFIG
+            sin, memory_config=mem_config
         )  # ttnn.interleaved_to_sharded(sin, mem_config)
 
         cos = ttnn.transpose(cos, 1, 2)  # [1, batch, 1[32], dim]
@@ -320,10 +320,10 @@ class RotarySetup:
 
         # [1, 1, batch, dim] HEIGHT_SHARDED for rotary_embedding_llama with input_transpose=HC
         cos_matrix_prefill_shape = ttnn.to_memory_config(
-            cos, memory_config=ttnn.DRAM_MEMORY_CONFIG
+            cos, memory_config=mem_config
         )  # ttnn.interleaved_to_sharded(cos, mem_config)
         sin_matrix_prefill_shape = ttnn.to_memory_config(
-            sin, memory_config=ttnn.DRAM_MEMORY_CONFIG
+            sin, memory_config=mem_config
         )  # ttnn.interleaved_to_sharded(sin, mem_config)
 
         cos = ttnn.transpose(cos, 1, 2)  # [1, batch, 1[32], dim]

--- a/models/demos/deepseek_v3/tt/rope.py
+++ b/models/demos/deepseek_v3/tt/rope.py
@@ -217,7 +217,6 @@ class RotarySetup:
             A list containing the cos matrix, sin matrix, and transformation matrix.
             If return_rot_idxs is True, it will also return the rotary positional embedding indices.
         """
-
         device = self.device
 
         # If position_idxs is a torch tensor, get the TTNN version of it
@@ -238,12 +237,9 @@ class RotarySetup:
         cos = ttnn.unsqueeze_to_4D(cos)  # [1, 1, batch, dim]
         sin = ttnn.unsqueeze_to_4D(sin)  # [1, 1, batch, dim]
 
-        cos = ttnn.transpose(cos, 1, 2)  # [1, batch, 1[32], dim]
-        sin = ttnn.transpose(sin, 1, 2)  # [1, batch, 1[32], dim]
-
         if self.batch_size_per_row % ttnn.TILE_SIZE != 0:
-            cos = cos[:, : self.batch_size_per_row, :, :]
-            sin = sin[:, : self.batch_size_per_row, :, :]
+            cos = cos[:, :, : self.batch_size_per_row, :]
+            sin = sin[:, :, : self.batch_size_per_row, :]
 
         mem_config = ttnn.create_sharded_memory_config(
             shape=(ttnn.TILE_SIZE, self.dim),
@@ -253,12 +249,36 @@ class RotarySetup:
             use_height_and_width_as_shard_shape=True,
         )
 
+        # [1, 1, batch, dim] HEIGHT_SHARDED for rotary_embedding_llama with input_transpose=HC
+        cos_matrix_prefill_shape = ttnn.to_memory_config(
+            cos, memory_config=ttnn.DRAM_MEMORY_CONFIG
+        )  # ttnn.interleaved_to_sharded(cos, mem_config)
+        sin_matrix_prefill_shape = ttnn.to_memory_config(
+            sin, memory_config=ttnn.DRAM_MEMORY_CONFIG
+        )  # ttnn.interleaved_to_sharded(sin, mem_config)
+
+        cos = ttnn.transpose(cos, 1, 2)  # [1, batch, 1[32], dim]
+        sin = ttnn.transpose(sin, 1, 2)  # [1, batch, 1[32], dim]
         cos = ttnn.interleaved_to_sharded(cos, mem_config)  # [1, 1 (= batch / shard_num_cores), 1[32], self.dim]
         sin = ttnn.interleaved_to_sharded(sin, mem_config)  # [1, 1 (= batch / shard_num_cores), 1[32], self.dim]
 
         if return_rot_idxs:
-            return {"cos_matrix": cos, "sin_matrix": sin, "trans_matrix": self.transformation_mat}, rot_idxs
-        return {"cos_matrix": cos, "sin_matrix": sin, "trans_matrix": self.transformation_mat}
+            return {
+                "cos_matrix": cos,
+                "sin_matrix": sin,
+                "trans_matrix": self.transformation_mat,
+                "cos_matrix_prefill_shape": cos_matrix_prefill_shape,
+                "sin_matrix_prefill_shape": sin_matrix_prefill_shape,
+                "trans_matrix_prefill_shape": self.transformation_mat_prefill,
+            }, rot_idxs
+        return {
+            "cos_matrix": cos,
+            "sin_matrix": sin,
+            "trans_matrix": self.transformation_mat,
+            "cos_matrix_prefill_shape": cos_matrix_prefill_shape,
+            "sin_matrix_prefill_shape": sin_matrix_prefill_shape,
+            "trans_matrix_prefill_shape": self.transformation_mat_prefill,
+        }
 
     def get_rot_mats_from_rot_idxs(
         self, rot_idxs: ttnn.Tensor, return_rot_idxs: bool = False
@@ -277,6 +297,7 @@ class RotarySetup:
         """
         assert isinstance(rot_idxs, ttnn.Tensor), "rot_idxs must be a TTNN tensor"
         assert len(rot_idxs.shape) == 2 and rot_idxs.shape[0] == 1, "rot_idxs must be a [1, batch] tensor"
+
         # All operations below are pure ttnn ops (no from_torch/as_tensor)
         embedding_layout = ttnn.TILE_LAYOUT
         cos = ttnn.embedding(rot_idxs, self.cos_matrix, layout=embedding_layout)  # [1, batch, dim]
@@ -285,12 +306,9 @@ class RotarySetup:
         cos = ttnn.unsqueeze_to_4D(cos)  # [1, 1, batch, dim]
         sin = ttnn.unsqueeze_to_4D(sin)  # [1, 1, batch, dim]
 
-        cos = ttnn.transpose(cos, 1, 2)  # [1, batch, 1[32], dim]
-        sin = ttnn.transpose(sin, 1, 2)  # [1, batch, 1[32], dim]
-
         if self.batch_size_per_row % ttnn.TILE_SIZE != 0:
-            cos = cos[:, : self.batch_size_per_row, :, :]
-            sin = sin[:, : self.batch_size_per_row, :, :]
+            cos = cos[:, :, : self.batch_size_per_row, :]
+            sin = sin[:, :, : self.batch_size_per_row, :]
 
         mem_config = ttnn.create_sharded_memory_config(
             shape=(ttnn.TILE_SIZE, self.dim),
@@ -300,9 +318,33 @@ class RotarySetup:
             use_height_and_width_as_shard_shape=True,
         )
 
+        # [1, 1, batch, dim] HEIGHT_SHARDED for rotary_embedding_llama with input_transpose=HC
+        cos_matrix_prefill_shape = ttnn.to_memory_config(
+            cos, memory_config=ttnn.DRAM_MEMORY_CONFIG
+        )  # ttnn.interleaved_to_sharded(cos, mem_config)
+        sin_matrix_prefill_shape = ttnn.to_memory_config(
+            sin, memory_config=ttnn.DRAM_MEMORY_CONFIG
+        )  # ttnn.interleaved_to_sharded(sin, mem_config)
+
+        cos = ttnn.transpose(cos, 1, 2)  # [1, batch, 1[32], dim]
+        sin = ttnn.transpose(sin, 1, 2)  # [1, batch, 1[32], dim]
         cos = ttnn.interleaved_to_sharded(cos, mem_config)
         sin = ttnn.interleaved_to_sharded(sin, mem_config)
 
         if return_rot_idxs:
-            return {"cos_matrix": cos, "sin_matrix": sin, "trans_matrix": self.transformation_mat}, rot_idxs
-        return {"cos_matrix": cos, "sin_matrix": sin, "trans_matrix": self.transformation_mat}
+            return {
+                "cos_matrix": cos,
+                "sin_matrix": sin,
+                "trans_matrix": self.transformation_mat,
+                "cos_matrix_prefill_shape": cos_matrix_prefill_shape,
+                "sin_matrix_prefill_shape": sin_matrix_prefill_shape,
+                "trans_matrix_prefill_shape": self.transformation_mat_prefill,
+            }, rot_idxs
+        return {
+            "cos_matrix": cos,
+            "sin_matrix": sin,
+            "trans_matrix": self.transformation_mat,
+            "cos_matrix_prefill_shape": cos_matrix_prefill_shape,
+            "sin_matrix_prefill_shape": sin_matrix_prefill_shape,
+            "trans_matrix_prefill_shape": self.transformation_mat_prefill,
+        }


### PR DESCRIPTION
### Ticket
Closes #38104.

### Problem description
* Deepseek MLA had a KV RoPE call which performed `transpose`->height-sharding->`rotary_embedding_llama(..., is_decode_mode=True, ...)`->interleave->`transpose` call, which was previously reduced to be `transpose`->RoPE->`transpose`, but the timings of the block were still high at about ~12µs.

### What's changed
* #39572 added support for height-sharded `cos`/`sin` and `trans_mat` when calling `rotary_embedding_llama` API in prefill mode. This allows us to eliminate `ttnn.transpose()` and sharding/interleaving calls around one of the KV RoPE blocks in Deepseek MLA.
* Updates `rope.py` to store height-sharded `cos`/`sin`/`trans_mat` (with prefill shape) so the new prefill kernel is triggered
* The KV RoPE timing for the affected block after this PR is reduced to around ~3.9µs after this change.

### Checklist
* APC/BHPC etc. not applicable as the affected change only runs on a Galaxy (AFAIK).
- [x] Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [x] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=gchoudhary/38104-test-deepseek-mla-with-sharded-sin-cos-trans_mat-prefill-mode-rotary_embedding_llama-call)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:gchoudhary/38104-test-deepseek-mla-with-sharded-sin-cos-trans_mat-prefill-mode-rotary_embedding_llama-call)
  - [x] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [x] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)


#### DeepSeek workflow badges

- DeepSeek: [![(Galaxy) DeepSeek tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml/badge.svg?branch=gchoudhary/38104-test-deepseek-mla-with-sharded-sin-cos-trans_mat-prefill-mode-rotary_embedding_llama-call)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml?query=branch:gchoudhary/38104-test-deepseek-mla-with-sharded-sin-cos-trans_mat-prefill-mode-rotary_embedding_llama-call)
- DeepSeek demo: [![(Galaxy) demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml/badge.svg?branch=gchoudhary/38104-test-deepseek-mla-with-sharded-sin-cos-trans_mat-prefill-mode-rotary_embedding_llama-call)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml?query=branch:gchoudhary/38104-test-deepseek-mla-with-sharded-sin-cos-trans_mat-prefill-mode-rotary_embedding_llama-call)