### PR TITLE
[Security] Fix CRITICAL: Pin PyPI publish action to commit SHA

### DIFF
--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -193,7 +193,7 @@ jobs:
 
       - name: Publish to PyPI (Trusted Publishing)
         if: ${{ !inputs.dry-run }}
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ed0c539abdc6b55ad89f3ea7b8e96860a5ddef80 # v1.13.0
 
 
 


### PR DESCRIPTION
## Security Vulnerability Fix

**Risk Level:** 🔴 CRITICAL

### Issue
The package-and-release.yaml workflow currently references a mutable branch:
```yaml
uses: pypa/gh-action-pypi-publish@release/v1
```

### Security Impact
- Branch references (even release branches) are mutable and can be updated with new commits
- While `pypa/gh-action-pypi-publish` is a trusted action, using branch references creates a supply chain security vulnerability
- If the `release/v1` branch is compromised or updated with vulnerable code, all workflows using it are affected

### Fix
Pinned to specific commit SHA from the release/v1 branch:
```yaml
uses: pypa/gh-action-pypi-publish@ed0c539abdc6b55ad89f3ea7b8e96860a5ddef80 # v1.13.0
```

### Details
- **Commit SHA:** `ed0c539abdc6b55ad89f3ea7b8e96860a5ddef80`
- **Version:** v1.13.0 (latest release as of 2026-03-09)
- **Source:** https://github.com/pypa/gh-action-pypi-publish/releases

### Benefits
✅ Commit SHAs are immutable and cannot be changed  
✅ Provides reproducible builds  
✅ Prevents potential supply chain attacks  
✅ Can be updated via Dependabot for security patches  

### Note
While `pypa/gh-action-pypi-publish` is from a trusted organization and `release/v1` is their official release branch, pinning to commit SHA is security best practice for **all** external actions.

### Source
Identified by: GitHub Actions Security Audit (2026-03-09)