### PR TITLE
[skip ci] Fix Mistral-7B N150 performance-ci-32 perf targets (Closes #39581)

### DIFF
--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -1511,7 +1511,7 @@ def test_demo_text(
                 "N150_Llama-3.2-1B": 25,
                 "N150_Llama-3.2-3B": 62,
                 "N150_Llama-3.1-8B": 120,
-                "N150_Mistral-7B": 106,
+                "N150_Mistral-7B": 40,  # Updated from 106; observed ~37.5ms in CI (issue #39581)
                 # N300 targets
                 # Faster-than-expected TTFT observed in CI; lower target and widen tolerance to avoid false failures.
                 "N300_Qwen2.5-7B": (90, 1.25),  # (value, high_tolerance_ratio)


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-metal/issues/39581

### Problem description
The `test_demo_text[performance-ci-32]` test for Mistral-7B on N150 has been repeatedly failing in CI. The run is actually **faster** than the stored targets, but `verify_perf` treats the large positive delta as a failure ("much lower than expected" for TTFT).

Observed metrics:
- `prefill_time_to_token`: ~37.5ms (target was 106ms)
- `decode_t/s/u`: 22.3–23.2 tok/s/user (target 22)
- `decode_t/s`: ~712–742 tok/s (target 704)

The hard-coded perf expectations were stale for current kernels/hardware.

### What's changed
- Updated `N150_Mistral-7B` TTFT target in `ci_target_ttft` from 106ms to 40ms
- Targets are based on observed values across 5 recent failing CI runs (37.49–37.65ms TTFT)
- 40ms provides ~6% buffer for normal variance while passing the verify_perf tolerance check

Note: The segfault during fixture teardown (mentioned in the issue) is a separate follow-up; this PR only addresses the perf assertion failure.

Made with [Cursor](https://cursor.com)