### PR TITLE
[wh-6u upstream] Modify pytest commands to include FAKE_DEVICE and timeout

### DIFF
--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -187,7 +187,7 @@ test_suite_wh_6u_llama_demo_tests() {
 
     verify_llama_dir_
 
-    pytest models/demos/llama3_70b_galaxy/demo/text_demo.py -k "repeat"
+    FAKE_DEVICE=TG pytest models/demos/llama3_70b_galaxy/demo/text_demo.py -k "repeat" --timeout 1000
     # Some AssertionError: Throughput is out of targets 49 - 53 t/s/u in 200 iterations
     # assert 200 <= 20
     # pytest models/demos/llama3_70b_galaxy/demo/demo_decode.py -k "full"
@@ -200,7 +200,7 @@ test_suite_wh_6u_llama_long_stress_tests() {
     verify_llama_dir_
 
     # This will take almost 3 hours. Ensure that the tensors are cached in the LLAMA_DIR.
-    pytest models/demos/llama3_70b_galaxy/demo/demo_decode.py -k "stress-test and not mini-stress-test"
+    FAKE_DEVICE=TG pytest models/demos/llama3_70b_galaxy/demo/demo_decode.py -k "stress-test and not mini-stress-test" --timeout 1000
 }
 
 test_suite_bh_ttnn_stress_tests() {


### PR DESCRIPTION
### Ticket
None

### Problem description
Llama demo test running in WH-galaxy upstream container does not match what's currently run in the galaxy demos pipeline.

### What's changed
To match calls in galaxy demos: https://github.com/tenstorrent/tt-metal/blob/main/tests/pipeline_reorg/galaxy_demo_tests.yaml

- Set `FAKE_DEVICE=TG`
- Set 1000s pytest testcase timeout

### Checklist

- [x] Upstream tests https://github.com/tenstorrent/tt-metal/actions/runs/22928219724/job/66575376818#step:4:3345
Demo test is [failing on main](https://github.com/tenstorrent/tt-metal/actions/runs/22930531410/job/66551467571#step:7:1884) as well but the error message now matches between pipelines. 
