### PR TITLE
Enable ISL=64k for GPT-OSS

### DIFF
--- a/models/demos/gpt_oss/demo/text_demo.py
+++ b/models/demos/gpt_oss/demo/text_demo.py
@@ -517,7 +517,7 @@ def test_gpt_oss_demo(
             f"Invalid input prompts: {input_prompts}. Expected a list of prompts or a string path to a json file."
         )
 
-    # Calculate ISL (Input Sequence Length) in tokens, not characters
+    # Calculate ISL in tokens
     max_isl = max(len(tokenizer.encode(p)) for p in real_prompts)
     logger.info(f"Max ISL (Input Sequence Length): {max_isl} tokens")
 

--- a/models/demos/gpt_oss/demo/text_demo.py
+++ b/models/demos/gpt_oss/demo/text_demo.py
@@ -516,20 +516,25 @@ def test_gpt_oss_demo(
         raise ValueError(
             f"Invalid input prompts: {input_prompts}. Expected a list of prompts or a string path to a json file."
         )
+
+    # Calculate ISL (Input Sequence Length) in tokens, not characters
+    max_isl = max(len(tokenizer.encode(p)) for p in real_prompts)
+    logger.info(f"Max ISL (Input Sequence Length): {max_isl} tokens")
+
     if model_args[0].model_name.split("-")[-1] == "120b" and mesh_device.shape[0] == 1:
-        if max([len(p) for p in real_prompts]) > 32 * 1024:
+        if max_isl > 32 * 1024:
             pytest.skip(
-                "120b model with mesh_shape (1, 8) and prefill > 32k is not supported. OOM error gh issue #38729"
+                f"120b model with mesh_shape (1, 8) and ISL {max_isl} > 32k tokens is not supported. OOM error gh issue #38729"
             )
     if model_args[0].model_name.split("-")[-1] == "120b" and mesh_device.shape[0] == 4:
-        if max([len(p) for p in real_prompts]) >= 32 * 1024:
+        if max_isl > 64 * 1024:
             pytest.skip(
-                "120b model with mesh_shape (4, 8) and prefill >= 32k is not supported. OOM error gh issue #38728"
+                f"120b model with mesh_shape (4, 8) and ISL {max_isl} > 64k tokens is not supported. OOM error gh issue #38728"
             )
     if model_args[0].model_name.split("-")[-1] == "20b" and mesh_device.shape[0] == 4:
-        if max([len(p) for p in real_prompts]) > 32 * 1024:
+        if max_isl > 32 * 1024:
             pytest.skip(
-                "20b model with mesh_shape (4, 8) and prefill > 32k is not supported. Determinstic hang gh issue #38751"
+                f"20b model with mesh_shape (4, 8) and ISL {max_isl} > 32k tokens is not supported. Deterministic hang gh issue #38751"
             )
 
     if long_context_mode:

--- a/models/demos/gpt_oss/tt/experts/prefill.py
+++ b/models/demos/gpt_oss/tt/experts/prefill.py
@@ -183,6 +183,8 @@ def _process_prefill_chunk(
 
         # Reduce across experts
         next_states_reduced = reduce_experts(next_states)
+        next_states.deallocate(True)
+
         if next_states_reduced_acc is None:
             next_states_reduced_acc = next_states_reduced
         else:


### PR DESCRIPTION
### Problem description
GPT-OSS-120B was going OOM in prefill for ISL=64k

### What's changed
Deallocated tensors to free up some space in DRAM.
Also fixed the text_demo logic to check number of tokens for ISL and not characters

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=atupe/gpt-oss-isl-64k-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:atupe/gpt-oss-isl-64k-fix)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=atupe/gpt-oss-isl-64k-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:atupe/gpt-oss-isl-64k-fix)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=atupe/gpt-oss-isl-64k-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:atupe/gpt-oss-isl-64k-fix)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=atupe/gpt-oss-isl-64k-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:atupe/gpt-oss-isl-64k-fix)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=atupe/gpt-oss-isl-64k-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:atupe/gpt-oss-isl-64k-fix)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=atupe/gpt-oss-isl-64k-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:atupe/gpt-oss-isl-64k-fix)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
