### PR TITLE
[skip ci] Enable Tracy profiler builds in build-wrapper workflow

### DIFF
--- a/.github/workflows/build-wrapper.yaml
+++ b/.github/workflows/build-wrapper.yaml
@@ -102,7 +102,7 @@ jobs:
       publish-artifact: false
       publish-package: false
       skip-tt-train: true
-      tracy: false
+      tracy: true
       ref: ${{ inputs.ref }}
 
   # build job runs the matrix - either when called from merge-gate with pre-built tags,
@@ -142,7 +142,7 @@ jobs:
       publish-artifact: false
       publish-package: false
       skip-tt-train: true
-      tracy: false
+      tracy: true
       ref: ${{ inputs.ref }}
       # Pass pre-built docker image tags based on platform
       ci-build-docker-image: ${{


### PR DESCRIPTION
### Ticket
N/A

### Problem description
The `build-wrapper.yaml` workflow was previously building with `tracy: false`, meaning changes to Tracy profiler-related code were never compiled and exercised during standard CI builds. This created a blind spot where profiler code regressions could silently land undetected.

### What's changed
Set `tracy: true` in both the `build-dispatch` and `build` matrix jobs within `.github/workflows/build-wrapper.yaml`.

This ensures that Tracy profiler code is compiled and verified on every CI run — both for direct `workflow_dispatch` single-platform builds and for the full multi-platform matrix. Any future change that breaks profiler-related compilation will now be caught immediately in the standard build gate.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ci/enable-tracy-build-wrapper)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ci/enable-tracy-build-wrapper)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ci/enable-tracy-build-wrapper)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ci/enable-tracy-build-wrapper)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ci/enable-tracy-build-wrapper)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ci/enable-tracy-build-wrapper)
- [x] New/Existing tests provide coverage for changes — the build itself now validates Tracy compilation