### PR TITLE
Implement ttnn normal (composite)

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/rand/test_normal.py
+++ b/tests/ttnn/nightly/unit_tests/operations/rand/test_normal.py
@@ -1,0 +1,169 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import ttnn
+import torch
+import math
+
+
+DEFAULT_SHAPE = (32, 32)
+# Use a large shape so statistical checks are meaningful
+STAT_SHAPE = (1024, 1024)
+
+
+def is_ttnn_float_type(tt_dtype) -> bool:
+    match tt_dtype:
+        case ttnn.bfloat16 | ttnn.float32 | ttnn.bfloat8_b | ttnn.bfloat4_b:
+            return True
+        case _:
+            return False
+
+
+def check_normal_distribution(data, expected_mean=0.0, expected_std=1.0, sigma_threshold=5.0, tolerance_pct=5.0):
+    """
+    Checks that sample mean and std are close to expected values.
+    Mean is checked via z-test (within sigma_threshold standard errors).
+    Std is checked via relative error (within tolerance_pct percent).
+    """
+    n = data.numel()
+    assert n >= 1000, f"Need at least 1000 samples for a meaningful check, got {n}"
+
+    flat = data.detach().cpu().float().flatten()
+    sample_mean = flat.mean().item()
+    sample_std = flat.std().item()
+
+    if expected_std == 0.0:
+        return (flat - expected_mean).abs().max().item() < 1e-3
+
+    # z-test: sample mean should be within sigma_threshold standard errors
+    se_mean = expected_std / math.sqrt(n)
+    mean_ok = abs(sample_mean - expected_mean) < sigma_threshold * se_mean
+    std_ok = abs(sample_std - expected_std) / expected_std * 100 < tolerance_pct
+
+    return mean_ok and std_ok
+
+
+# --- default behaviour ---
+
+
+def test_normal_defaults(device):
+    tensor = ttnn.normal(DEFAULT_SHAPE, device=device)
+
+    assert tensor.dtype == ttnn.bfloat16
+    assert tensor.layout == ttnn.TILE_LAYOUT
+    assert tensor.storage_type() == ttnn.StorageType.DEVICE
+    assert tensor.memory_config() == ttnn.DRAM_MEMORY_CONFIG
+    assert tuple(tensor.shape) == tuple(DEFAULT_SHAPE)
+
+
+# --- shape ---
+
+
+@pytest.mark.parametrize("shape", [tuple([32] * i) for i in range(1, 6)])
+def test_normal_shapes(device, shape):
+    tensor = ttnn.normal(shape, device=device)
+    assert tuple(tensor.shape) == tuple(shape)
+
+
+# --- dtype ---
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+def test_normal_dtype(device, dtype):
+    tensor = ttnn.normal(DEFAULT_SHAPE, device=device, dtype=dtype)
+    assert tensor.dtype == dtype
+    assert tuple(tensor.shape) == tuple(DEFAULT_SHAPE)
+
+
+# --- layout ---
+
+
+@pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
+def test_normal_layout(device, layout):
+    tensor = ttnn.normal(DEFAULT_SHAPE, device=device, layout=layout)
+    assert tensor.layout == layout
+
+
+# --- memory config ---
+
+
+@pytest.mark.parametrize("mem_config", [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG])
+def test_normal_memory_config(device, mem_config):
+    tensor = ttnn.normal(DEFAULT_SHAPE, device=device, memory_config=mem_config)
+    assert tensor.memory_config() == mem_config
+    assert tuple(tensor.shape) == tuple(DEFAULT_SHAPE)
+
+
+# --- distribution checks ---
+
+
+@pytest.mark.parametrize("mean,stddev", [(0.0, 1.0), (5.0, 2.0), (-3.0, 0.5)])
+def test_normal_distribution(device, mean, stddev):
+    tensor = ttnn.normal(STAT_SHAPE, device=device, dtype=ttnn.float32, mean=mean, std=stddev, seed=42)
+    torch_tensor = ttnn.to_torch(tensor)
+
+    assert not torch.isnan(torch_tensor).any(), "Tensor contains NaN values"
+    assert check_normal_distribution(
+        torch_tensor, expected_mean=mean, expected_std=stddev
+    ), f"Distribution check failed for mean={mean}, std={stddev}"
+
+
+def test_normal_std_zero(device):
+    """std=0 produces a constant tensor equal to mean."""
+    mean = 3.5
+    tensor = ttnn.normal(DEFAULT_SHAPE, device=device, dtype=ttnn.float32, mean=mean, std=0.0, seed=0)
+    torch_tensor = ttnn.to_torch(tensor).float()
+    assert torch.allclose(torch_tensor, torch.full(torch_tensor.shape, mean), atol=1e-2)
+
+
+def test_normal_no_nan(device):
+    tensor = ttnn.normal(STAT_SHAPE, device=device, dtype=ttnn.float32, seed=1)
+    torch_tensor = ttnn.to_torch(tensor)
+    assert not torch.isnan(torch_tensor).any()
+    assert not torch.isinf(torch_tensor).any()
+
+
+# --- seed reproducibility ---
+
+
+def test_normal_seed_reproducibility(device):
+    t1 = ttnn.normal(DEFAULT_SHAPE, device=device, dtype=ttnn.float32, seed=123)
+    t2 = ttnn.normal(DEFAULT_SHAPE, device=device, dtype=ttnn.float32, seed=123)
+    assert torch.equal(ttnn.to_torch(t1), ttnn.to_torch(t2)), "Same seed should produce identical tensors"
+
+
+def test_normal_different_seeds_differ(device):
+    t1 = ttnn.normal(DEFAULT_SHAPE, device=device, dtype=ttnn.float32, seed=1)
+    t2 = ttnn.normal(DEFAULT_SHAPE, device=device, dtype=ttnn.float32, seed=2)
+    assert not torch.equal(ttnn.to_torch(t1), ttnn.to_torch(t2)), "Different seeds should produce different tensors"
+
+
+# --- invalid args ---
+
+
+def test_normal_invalid_args(device):
+    with pytest.raises(TypeError):
+        # shape must be a list or tuple
+        ttnn.normal(5, device=device)
+
+    with pytest.raises(TypeError):
+        # layout must be ttnn.Layout
+        ttnn.normal(DEFAULT_SHAPE, device=device, layout="TILE")
+
+    with pytest.raises(TypeError):
+        # memory_config must be ttnn.MemoryConfig
+        ttnn.normal(DEFAULT_SHAPE, device=device, memory_config="DRAM")
+
+    with pytest.raises(TypeError):
+        # dtype must be ttnn.DataType
+        ttnn.normal(DEFAULT_SHAPE, device=device, dtype="bfloat16")
+
+    with pytest.raises(TypeError):
+        # device must be ttnn.Device / MeshDevice
+        ttnn.normal(DEFAULT_SHAPE, device="WORMHOLE")
+
+    with pytest.raises(Exception):
+        # negative std must be rejected
+        ttnn.normal(DEFAULT_SHAPE, device=device, std=-1.0)

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -399,6 +399,7 @@ set(TTNN_SRC_PYBIND
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/all_reduce_create_qkv_heads_nanobind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/where/where_nanobind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/rand/rand_nanobind.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/normal/normal_nanobind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/sort/sort_nanobind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/gather/gather_nanobind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/gather/tosa/gather_tosa_nanobind.cpp
@@ -705,6 +706,7 @@ target_link_libraries(
         TTNN::Ops::Pool
         TTNN::Ops::Normalization
         TTNN::Ops::Rand
+        TTNN::Ops::Normal
 )
 if(TT_INSTALL)
     install(
@@ -944,6 +946,7 @@ add_subdirectory(cpp/ttnn/operations/point_to_point)
 add_subdirectory(cpp/ttnn/operations/pool)
 add_subdirectory(cpp/ttnn/operations/prefetcher)
 add_subdirectory(cpp/ttnn/operations/rand)
+add_subdirectory(cpp/ttnn/operations/normal)
 add_subdirectory(cpp/ttnn/operations/reduction)
 add_subdirectory(cpp/ttnn/operations/sliding_window)
 add_subdirectory(cpp/ttnn/operations/transformer)

--- a/ttnn/cpp/ttnn-nanobind/__init__.cpp
+++ b/ttnn/cpp/ttnn-nanobind/__init__.cpp
@@ -72,6 +72,7 @@
 #include "ttnn/operations/transformer/transformer_nanobind.hpp"
 #include "ttnn/operations/uniform/uniform_nanobind.hpp"
 #include "ttnn/operations/rand/rand_nanobind.hpp"
+#include "ttnn/operations/normal/normal_nanobind.hpp"
 #include "ttnn/operations/experimental/test/hang_device/hang_device_operation_nanobind.hpp"
 
 namespace nb = nanobind;
@@ -204,6 +205,9 @@ void py_module(nb::module_& mod) {
 
     auto m_rand = mod.def_submodule("rand", "ttnn rand operation");
     rand::bind_rand_operation(m_rand);
+
+    auto m_normal = mod.def_submodule("normal", "ttnn normal operation");
+    normal::bind_normal_operation(m_normal);
 
     auto m_point_to_point = mod.def_submodule("point_to_point", "point_to_point operations");
     point_to_point::bind_point_to_point(m_point_to_point);

--- a/ttnn/cpp/ttnn/operations/normal/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/normal/CMakeLists.txt
@@ -1,0 +1,29 @@
+add_library(ttnn_op_normal ${LIB_TYPE})
+add_library(TTNN::Ops::Normal ALIAS ttnn_op_normal)
+
+target_precompile_headers(ttnn_op_normal REUSE_FROM TTNN::PCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_normal)
+
+# Verify only the api FILE_SET
+set_target_properties(
+    ttnn_op_normal
+    PROPERTIES
+        INTERFACE_HEADER_SETS_TO_VERIFY
+            api
+)
+
+target_sources(
+    ttnn_op_normal
+    PUBLIC
+        FILE_SET api
+        TYPE HEADERS
+        BASE_DIRS ${FixmeOpAPIDir}
+        FILES normal.hpp
+    PRIVATE
+        normal.cpp
+)
+
+target_include_directories(ttnn_op_normal PRIVATE ${FixmeOpIncDirs})
+target_link_libraries(ttnn_op_normal PUBLIC TTNN::Core PRIVATE TT::Metalium)
+
+install(TARGETS ttnn_op_normal FILE_SET api COMPONENT ttnn-dev LIBRARY COMPONENT tar)

--- a/ttnn/cpp/ttnn/operations/normal/normal.cpp
+++ b/ttnn/cpp/ttnn/operations/normal/normal.cpp
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "normal.hpp"
+
+#include <cmath>
+#include <random>
+
+#include "ttnn/operations/rand/rand.hpp"
+#include "ttnn/operations/eltwise/unary/unary.hpp"
+#include "ttnn/operations/eltwise/binary/binary.hpp"
+#include "ttnn/operations/copy/typecast/typecast.hpp"
+#include "ttnn/operations/core/core.hpp"
+
+namespace ttnn {
+
+Tensor normal(
+    const ttnn::Shape& shape,
+    MeshDevice& device,
+    const DataType dtype,
+    const Layout layout,
+    const MemoryConfig& memory_config,
+    float mean,
+    float stddev,
+    std::optional<uint32_t> seed) {
+    TT_FATAL(stddev >= 0.0f, "[ttnn::normal] stddev must be non-negative, got {}.", stddev);
+
+    // Box-Muller transform: z = sqrt(-2 * log(u1)) * cos(2 * pi * u2)
+    // u1 in (eps, 1] to avoid log(0); u2 in [0, 1)
+    const uint32_t effective_seed = seed.value_or(std::random_device{}());
+    auto u1 = ttnn::rand(shape, device, DataType::FLOAT32, Layout::TILE, memory_config, 1e-6f, 1.0f, effective_seed);
+    auto u2 = ttnn::rand(shape, device, DataType::FLOAT32, Layout::TILE, memory_config, 0.0f, 1.0f, effective_seed + 1);
+
+    auto log_u1 = ttnn::log(u1, memory_config);
+    auto neg2log = ttnn::multiply(log_u1, -2.0f, std::nullopt, memory_config);
+    auto r = ttnn::sqrt(neg2log, false, memory_config);
+
+    auto two_pi_u2 = ttnn::multiply(u2, static_cast<float>(2.0 * M_PI), std::nullopt, memory_config);
+    auto cos_u2 = ttnn::cos(two_pi_u2, memory_config);
+
+    auto z = ttnn::multiply(r, cos_u2, std::nullopt, memory_config);
+
+    if (stddev != 1.0f) {
+        z = ttnn::multiply(z, stddev, std::nullopt, memory_config);
+    }
+    if (mean != 0.0f) {
+        z = ttnn::add(z, mean, std::nullopt, memory_config);
+    }
+
+    if (dtype != DataType::FLOAT32) {
+        z = ttnn::typecast(z, dtype);
+    }
+    if (layout != Layout::TILE) {
+        z = ttnn::to_layout(z, layout);
+    }
+    return z;
+}
+
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/normal/normal.cpp
+++ b/ttnn/cpp/ttnn/operations/normal/normal.cpp
@@ -32,7 +32,7 @@ Tensor normal(
     auto u1 = ttnn::rand(shape, device, DataType::FLOAT32, Layout::TILE, memory_config, 1e-6f, 1.0f, effective_seed);
     auto u2 = ttnn::rand(shape, device, DataType::FLOAT32, Layout::TILE, memory_config, 0.0f, 1.0f, effective_seed + 1);
 
-    auto log_u1 = ttnn::log(u1, memory_config);
+    auto log_u1 = ttnn::log(u1, false, memory_config);
     auto neg2log = ttnn::multiply(log_u1, -2.0f, std::nullopt, memory_config);
     auto r = ttnn::sqrt(neg2log, false, memory_config);
 

--- a/ttnn/cpp/ttnn/operations/normal/normal.hpp
+++ b/ttnn/cpp/ttnn/operations/normal/normal.hpp
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+
+#include "ttnn/decorators.hpp"
+
+namespace ttnn {
+
+Tensor normal(
+    const ttnn::Shape& shape,
+    MeshDevice& device,
+    DataType dtype = DataType::BFLOAT16,
+    Layout layout = Layout::TILE,
+    const MemoryConfig& memory_config = types::DRAM_MEMORY_CONFIG,
+    float mean = 0.0f,
+    float stddev = 1.0f,
+    std::optional<uint32_t> seed = std::nullopt);
+
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/normal/normal_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/normal/normal_nanobind.cpp
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "normal_nanobind.hpp"
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/optional.h>
+
+#include "ttnn-nanobind/bind_function.hpp"
+#include "normal.hpp"
+
+namespace ttnn::operations::normal {
+void bind_normal_operation(nb::module_& mod) {
+    const auto* doc =
+        R"doc(
+        Generates a tensor with the given shape, filled with random values sampled
+        from a normal (Gaussian) distribution using the Box-Muller transform.
+
+        Args:
+            shape (list[int]): A list of integers defining the shape of the output tensor.
+            device (ttnn.Device | ttnn.MeshDevice): The device on which the tensor will be allocated.
+
+        Keyword args:
+            dtype (ttnn.DataType, optional): The data type of the tensor. Defaults to ``ttnn.bfloat16``.
+            layout (ttnn.Layout, optional): The layout of the tensor. Defaults to ``ttnn.TILE_LAYOUT``.
+            memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to ``ttnn.DRAM_MEMORY_CONFIG``.
+            mean (float, optional): Mean of the normal distribution. Defaults to 0.0.
+            std (float, optional): Standard deviation of the normal distribution. Must be non-negative. Defaults to 1.0.
+            seed (int, optional): Seed for reproducible results. If ``None``, a random seed is used.
+
+        Returns:
+            ttnn.Tensor: A tensor with the specified shape, dtype, and layout containing samples from N(mean, std^2).
+        )doc";
+
+    ttnn::bind_function<"normal">(
+        mod,
+        doc,
+        ttnn::overload_t(
+            &ttnn::normal,
+            nb::arg("shape"),
+            nb::arg("device"),
+            nb::kw_only(),
+            nb::arg("dtype") = nb::cast(DataType::BFLOAT16),
+            nb::arg("layout") = nb::cast(Layout::TILE),
+            nb::arg("memory_config") = nb::cast(ttnn::DRAM_MEMORY_CONFIG),
+            nb::arg("mean") = 0.0f,
+            nb::arg("std") = 1.0f,
+            nb::arg("seed") = nb::none()));
+}
+}  // namespace ttnn::operations::normal

--- a/ttnn/cpp/ttnn/operations/normal/normal_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/normal/normal_nanobind.hpp
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn-nanobind/nanobind_fwd.hpp"
+
+namespace ttnn::operations::normal {
+namespace nb = nanobind;
+void bind_normal_operation(nb::module_& mod);
+}  // namespace ttnn::operations::normal


### PR DESCRIPTION
### Problem description

Missing ttnn operation for generating normally distributed random values.

### What's changed

Implemented ttnn::normal with nanobind bindings and tests.

### Checklist

- [ ] APC (wip)
- [ ] BH APC (wip)