### PR TITLE
Adjust T3K tests to avoid timeout in integration tests

### DIFF
--- a/tests/scripts/t3000/run_t3000_integration_tests.sh
+++ b/tests/scripts/t3000/run_t3000_integration_tests.sh
@@ -43,7 +43,7 @@ run_t3000_llama3_tests() {
   for hf_model in "$llama8b"; do
     tt_cache=$TT_CACHE_HOME/$hf_model
     HF_MODEL=$hf_model TT_CACHE_PATH=$tt_cache pytest models/tt_transformers/tests/test_model.py -k full ; fail+=$?
-    HF_MODEL=$hf_model TT_CACHE_PATH=$tt_cache pytest models/tt_transformers/tests/test_model_prefill.py ; fail+=$?
+    HF_MODEL=$hf_model TT_CACHE_PATH=$tt_cache pytest models/tt_transformers/tests/test_model_prefill.py -k "performance and not accuracy" ; fail+=$?
     echo "LOG_METAL: Llama3 tests for $hf_model completed"
   done
 
@@ -71,7 +71,7 @@ run_t3000_llama3_70b_tests() {
   llama70b=meta-llama/Llama-3.1-70B-Instruct
   tt_cache_llama70b=$TT_CACHE_HOME/$llama70b
   HF_MODEL=$llama70b TT_CACHE_PATH=$tt_cache_llama70b pytest models/tt_transformers/tests/test_model.py -k full ; fail+=$?
-  HF_MODEL=$llama70b TT_CACHE_PATH=$tt_cache_llama70b pytest models/tt_transformers/tests/test_model_prefill.py ; fail+=$?
+  HF_MODEL=$llama70b TT_CACHE_PATH=$tt_cache_llama70b pytest models/tt_transformers/tests/test_model_prefill.py -k "performance and not accuracy" ; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)
@@ -251,7 +251,7 @@ run_t3000_mistral_tests() {
   hf_model=mistralai/Mistral-7B-Instruct-v0.3
   tt_cache_path=$TT_CACHE_HOME/$hf_model
   TT_CACHE_PATH=$tt_cache_path HF_MODEL=$hf_model pytest models/tt_transformers/tests/test_model.py -k full
-  TT_CACHE_PATH=$tt_cache_path HF_MODEL=$hf_model pytest models/tt_transformers/tests/test_model_prefill.py
+  TT_CACHE_PATH=$tt_cache_path HF_MODEL=$hf_model pytest models/tt_transformers/tests/test_model_prefill.py -k "performance and not accuracy"
 
 }
 


### PR DESCRIPTION
This was caused by a more thorough warmup in all our TT-Transformers models. In short, we now do prefill warmup up to the max seqlen specified, which for this model_prefill test was the max sequence length.

We plan on further adjusting these tests for our ongoing Tier Models CI refactor.
Issue that will track this problem is here: https://github.com/tenstorrent/tt-metal/issues/39641

- [x] T3K integration tests: https://github.com/tenstorrent/tt-metal/actions/runs/22958291620