### PR TITLE
Conv3d: remove output channel padding and use C++ prepare_conv3d_weights with TILE layout

### DIFF
--- a/models/tt_dit/layers/conv3d.py
+++ b/models/tt_dit/layers/conv3d.py
@@ -124,31 +124,12 @@ class ContextParallelConv3d(Module):
         )
 
     def _prepare_torch_state(self, state: dict[str, torch.Tensor]) -> None:
-        alignment = 16
-
-        weight = state.get("weight")
-        if weight is not None:
-            c_in = weight.shape[1]
-            weight = weight.permute(2, 3, 4, 1, 0)  # kd, hk, kw, c, out_chan
-            align_pad = alignment - c_in % alignment
-            if c_in % alignment != 0:
-                weight = torch.nn.functional.pad(weight, (0, 0, 0, align_pad))
-
-            # Reshape weights so that num_c_in_blocks is the first dimension
-            kd, hk, kw, c_in_aligned, out_channels = weight.shape
-
-            c_in_block = self.conv_config.C_in_block
-            c_in_block = c_in_aligned if c_in_block == 0 else c_in_block
-            num_c_in_blocks = c_in_aligned // c_in_block
-            assert num_c_in_blocks * c_in_block == c_in_aligned
-
-            # Kernel expects num_c_in_blocks to be the first dimension to stride over it
-            weight = weight.reshape(kd, hk, kw, num_c_in_blocks, c_in_block, out_channels)
-            weight = weight.permute(3, 0, 1, 2, 4, 5)
-            weight = weight.reshape(-1, out_channels)
-
-            state["weight"] = weight
-
+        if "weight" in state:
+            weight_tt = ttnn.from_torch(state["weight"], dtype=ttnn.bfloat16, pad_value=0)
+            prepared = ttnn.experimental.prepare_conv3d_weights(
+                weight_tensor=weight_tt, C_in_block=self.conv_config.C_in_block, device=self.mesh_device
+            )
+            state["weight"] = ttnn.to_torch(ttnn.get_device_tensors(prepared)[0])
         if "bias" in state:
             state["bias"] = state["bias"].reshape(1, -1)
 
@@ -206,6 +187,7 @@ class ContextParallelConv3d(Module):
             input_tensor=x_pad_NTHWC,
             weight_tensor=self.weight.data,
             bias_tensor=self.bias.data if self.bias is not None else None,
+            device=self.mesh_device,
             config=self.conv_config,
             output_channels=self.out_channels,
             kernel_size=self.kernel_size,

--- a/models/tt_dit/models/vae/vae_wan2_1.py
+++ b/models/tt_dit/models/vae/vae_wan2_1.py
@@ -17,7 +17,7 @@ from ...layers.module import Module, ModuleList, Parameter
 from ...layers.normalization import RMSNorm
 from ...parallel.config import VaeHWParallelConfig
 from ...parallel.manager import CCLManager
-from ...utils.conv3d import _ntuple, aligned_channels, count_convs, get_conv3d_config, prepare_conv3d_weights
+from ...utils.conv3d import _ntuple, aligned_channels, count_convs, get_conv3d_config
 from ...utils.substate import pop_substate, rename_substate
 from ...utils.tensor import typed_tensor
 
@@ -243,14 +243,10 @@ class WanCausalConv3d(Module):
         super().__init__()
 
         self.unpadded_in_channels = in_channels
-        self.unpadded_out_channels = out_channels
-        self.TILE_WIDTH = 32
         self.in_channels = aligned_channels(in_channels)
         if self.in_channels != self.unpadded_in_channels:
             logger.warning(f"Padding in_channels from {self.unpadded_in_channels} to {self.in_channels}")
-        self.out_channels = self.TILE_WIDTH if out_channels < self.TILE_WIDTH else out_channels
-        if self.out_channels != self.unpadded_out_channels:
-            logger.warning(f"Padding out_channels from {self.unpadded_out_channels} to {self.out_channels}")
+        self.out_channels = out_channels
 
         self.kernel_size = _ntuple(kernel_size, 3)
         self.stride = _ntuple(stride, 3)
@@ -294,23 +290,25 @@ class WanCausalConv3d(Module):
         )
 
         d = self.kernel_size[0] * self.kernel_size[1] * self.kernel_size[2] * self.in_channels
-        self.weight = Parameter(total_shape=[d, self.out_channels], device=mesh_device, pad_value=0, dtype=dtype)
+        self.weight = Parameter(
+            total_shape=[d, self.out_channels],
+            device=mesh_device,
+            pad_value=0,
+            dtype=dtype,
+        )
         self.bias = Parameter(total_shape=[1, self.out_channels], device=mesh_device, pad_value=0, dtype=dtype)
 
         self.mask_cache = {}
 
     def _prepare_torch_state(self, state: dict[str, torch.Tensor]) -> None:
-        def maybe_pad_out_channels(weight, bias):
-            if self.out_channels != self.unpadded_out_channels:
-                weight = torch.nn.functional.pad(
-                    weight, (0, 0, 0, 0, 0, 0, 0, 0, 0, self.out_channels - self.unpadded_out_channels)
-                )
-                bias = torch.nn.functional.pad(bias, (0, self.out_channels - self.unpadded_out_channels))
-            return weight, bias
-
-        if "weight" in state and "bias" in state:
-            weight, bias = maybe_pad_out_channels(state["weight"], state["bias"])
-            state["weight"], state["bias"] = prepare_conv3d_weights(weight, bias, self.conv_config)
+        if "weight" in state:
+            weight_tt = ttnn.from_torch(state["weight"], dtype=self.dtype, pad_value=0)
+            prepared = ttnn.experimental.prepare_conv3d_weights(
+                weight_tensor=weight_tt, C_in_block=self.conv_config.C_in_block, device=self.mesh_device
+            )
+            state["weight"] = ttnn.to_torch(ttnn.get_device_tensors(prepared)[0])
+        if "bias" in state:
+            state["bias"] = state["bias"].reshape(1, -1)
 
     def get_cached_mask(self, x_BTHWC, logical_h):
         sharded_h = x_BTHWC.shape[2]
@@ -417,6 +415,7 @@ class WanCausalConv3d(Module):
             input_tensor=x_BTHWC,
             weight_tensor=self.weight.data,
             bias_tensor=self.bias.data,
+            device=self.mesh_device,
             config=self.conv_config,
             output_channels=self.out_channels,
             kernel_size=self.kernel_size,
@@ -679,11 +678,7 @@ class WanConv2d(Module):
         super().__init__()
 
         self.in_channels = in_channels
-        self.unpadded_out_channels = out_channels
-        self.TILE_WIDTH = 32
-        self.out_channels = self.TILE_WIDTH if out_channels < self.TILE_WIDTH else out_channels
-        if self.out_channels != self.unpadded_out_channels:
-            logger.warning(f"Padding out_channels from {self.unpadded_out_channels} to {self.out_channels}")
+        self.out_channels = out_channels
 
         self.kernel_size = _ntuple(kernel_size, 3)
         self.stride = _ntuple(stride, 3)
@@ -728,16 +723,30 @@ class WanConv2d(Module):
         )
 
         d = self.kernel_size[0] * self.kernel_size[1] * self.kernel_size[2] * self.in_channels
-        self.weight = Parameter(total_shape=[d, self.out_channels], device=mesh_device, pad_value=0, dtype=dtype)
-        self.bias = Parameter(total_shape=[1, self.out_channels], device=mesh_device, pad_value=0, dtype=dtype)
+        self.weight = Parameter(
+            total_shape=[d, self.out_channels],
+            device=mesh_device,
+            pad_value=0,
+            dtype=dtype,
+        )
+        self.bias = Parameter(
+            total_shape=[1, self.out_channels],
+            device=mesh_device,
+            pad_value=0,
+            dtype=dtype,
+        )
 
         self.mask_cache = {}
 
     def _prepare_torch_state(self, state: dict[str, torch.Tensor]) -> None:
-        if "weight" in state and "bias" in state:
-            state["weight"], state["bias"] = prepare_conv3d_weights(
-                state["weight"].unsqueeze(2), state["bias"], self.conv_config
+        if "weight" in state:
+            weight_tt = ttnn.from_torch(state["weight"].unsqueeze(2), dtype=self.dtype, pad_value=0)
+            prepared = ttnn.experimental.prepare_conv3d_weights(
+                weight_tensor=weight_tt, C_in_block=self.conv_config.C_in_block, device=self.mesh_device
             )
+            state["weight"] = ttnn.to_torch(ttnn.get_device_tensors(prepared)[0])
+        if "bias" in state:
+            state["bias"] = state["bias"].reshape(1, -1)
 
     def get_cached_mask(self, x_BTHWC, logical_h):
         sharded_h = x_BTHWC.shape[2]
@@ -821,6 +830,7 @@ class WanConv2d(Module):
             input_tensor=x_BTHWC,
             weight_tensor=self.weight.data,
             bias_tensor=self.bias.data,
+            device=self.mesh_device,
             config=self.conv_config,
             output_channels=self.out_channels,
             kernel_size=self.kernel_size,
@@ -1320,10 +1330,7 @@ class WanDecoder(Module):
             out_BTHWC, new_logical_h = self.decoder(
                 x_BTHWC[:, i : i + 1, :, :, :], logical_h, feat_cache=self._feat_cache, feat_idx=self._conv_idx
             )
-            # Channels first
             out_BCTHW = ttnn.permute(out_BTHWC, (0, 4, 1, 2, 3))
-            # Trim padding on output channels
-            out_BCTHW = out_BCTHW[:, : self.out_channels, :, :, :]
             if output_BCTHW is None:
                 output_BCTHW = out_BCTHW
             else:

--- a/models/tt_dit/tests/models/wan2_2/test_vae_wan2_1.py
+++ b/models/tt_dit/tests/models/wan2_2/test_vae_wan2_1.py
@@ -1277,10 +1277,6 @@ def test_wan_decoder3d(
         )
         tt_output_torch = conv_unpad_height(tt_output_torch, new_logical_h)
         tt_output_torch = tt_output_torch.permute(0, 4, 1, 2, 3)
-        # Trim padding on output channels
-        # DEBUG: REMOVING
-        logger.info(f"trimming output channels from {tt_output_torch.shape} to {out_channels}")
-        tt_output_torch = tt_output_torch[:, :out_channels]
 
         logger.info(f"checking output")
         assert_quality(torch_output, tt_output_torch, pcc=MIN_PCC, relative_rmse=MAX_RMSE)
@@ -1632,10 +1628,6 @@ def test_wan_encoder3d(mesh_device, B, C, T, H, W, mean, std, h_axis, w_axis, nu
         )
         tt_output_torch = conv_unpad_height(tt_output_torch, new_logical_h)
         tt_output_torch = tt_output_torch.permute(0, 4, 1, 2, 3)
-
-        # Trim padding on output channels
-        logger.info(f"trimming output channels from {tt_output_torch.shape} to {out_channels}")
-        tt_output_torch = tt_output_torch[:, :out_channels]
 
         logger.info(f"checking output")
         assert_quality(torch_output, tt_output_torch, pcc=MIN_PCC, relative_rmse=MAX_RMSE)

--- a/models/tt_dit/utils/conv3d.py
+++ b/models/tt_dit/utils/conv3d.py
@@ -29,6 +29,8 @@ def get_conv3d_config(in_channels, out_channels, kernel_size, weights_dtype, gri
     else:
         config_to_blocking = {
             # (in_channels, out_channels, kernel_size) -> (C_in_block, C_out_block, T_out_block, H_out_block, W_out_block)
+            # Keep the old padded conv_out tuning for the new unpadded C_out=3 path.
+            (96, 3, (3, 3, 3)): (96, 32, 1, 16, 8),
             (96, 32, (3, 3, 3)): (96, 32, 1, 16, 8),
             (192, 96, (1, 3, 3)): (192, 96, 1, 4, 8),
             (96, 96, (3, 3, 3)): (96, 96, 1, 8, 8),
@@ -116,29 +118,3 @@ def aligned_channels(channels):
     if channels % ALIGNMENT != 0:
         channels = channels + ALIGN_PAD
     return channels
-
-
-def prepare_conv3d_weights(weight, bias, conv_config):
-    """Prepare weights and bias for TTNN."""
-    C_in = weight.shape[1]
-    w = weight.permute(2, 3, 4, 1, 0)  # kD, kH, kW, C, out_chan
-    padded_C_in = aligned_channels(C_in)
-    if padded_C_in != C_in:
-        w = torch.nn.functional.pad(w, (0, 0, 0, padded_C_in - C_in))
-
-    # Reshape weights so that num_C_in_blocks is the first dimension
-    kD, kH, kW, C_in_aligned, out_channels = w.shape
-
-    C_in_block = conv_config.C_in_block
-    C_in_block = C_in_aligned if C_in_block == 0 else C_in_block
-    num_C_in_blocks = C_in_aligned // C_in_block
-    assert (
-        num_C_in_blocks * C_in_block == C_in_aligned
-    ), f"num_C_in_blocks * C_in_block == C_in_aligned, got {num_C_in_blocks} * {C_in_block} != {C_in_aligned}"
-
-    # Kernel expects num_C_in_blocks to be the first dimension to stride over it
-    w = w.reshape(kD, kH, kW, num_C_in_blocks, C_in_block, out_channels)
-    w = w.permute(3, 0, 1, 2, 4, 5)
-    w = w.reshape(-1, out_channels)
-
-    return w, bias.reshape(1, -1)


### PR DESCRIPTION
## Summary
- Remove output channel padding workaround (issue #38126) from `WanCausalConv3d` and `WanConv2d` — the C++ conv3d op now handles non-tile-aligned output channels internally
- Replace Python `prepare_conv3d_weights()` with C++ API (`ttnn.experimental.prepare_conv3d_weights`) in `_prepare_torch_state` for `WanCausalConv3d`, `WanConv2d`, and `ContextParallelConv3d` (issue #38324)
- Add `(96, 3, (3,3,3))` blocking config for decoder `conv_out` (no longer padded to 32)

## Test plan
- [ ] `pytest models/tt_dit/tests/models/wan2_2/test_vae_wan2_1.py::test_wan_conv3d`
- [ ] `pytest models/tt_dit/tests/models/wan2_2/test_vae_wan2_1.py::test_wan_decoder3d`
- [ ] T3K Wan2.2 pipeline e2e: `pytest models/tt_dit/tests/models/wan2_2/test_pipeline_wan.py -k "2x4sp0tp1 and resolution_480p"` ([run](https://github.com/tenstorrent/tt-metal/actions/runs/23006420426))
- [ ] T3K Mochi pipeline e2e (exercises `ContextParallelConv3d`): `pytest models/tt_dit/tests/models/mochi/test_pipeline_mochi.py -k "dit_2x4sp0tp1_vae_1x8sp0tp1"` ([run](https://github.com/tenstorrent/tt-metal/actions/runs/23006442701))
- [ ] Galaxy Wan2.2 pipeline e2e: `pytest models/tt_dit/tests/models/wan2_2/test_pipeline_wan.py -k "wh_4x8sp1tp0 and resolution_720p"` ([run](https://github.com/tenstorrent/tt-metal/actions/runs/23006470350))