### PR TITLE
Fix the falling feedforward tests in unet

### DIFF
--- a/models/demos/stable_diffusion_xl_base/tt/model_configs/__init__.py
+++ b/models/demos/stable_diffusion_xl_base/tt/model_configs/__init__.py
@@ -19,8 +19,8 @@ def get_image_resolution_from_model_config(model_config):
     Get the image resolution from a ModelOptimisations instance.
 
     Args:
-        model_config: A ModelOptimisations instance (either ModelOptimisations512x512 or
-            ModelOptimisations1024x1024).
+        model_config: A ModelOptimisations instance (either ModelOptimisations512x512,
+            ModelOptimisations1024x1024, or ModelOptimisations1024x1024BH).
 
     Returns:
         tuple: A tuple of (height, width) representing the image resolution.
@@ -37,10 +37,12 @@ def get_image_resolution_from_model_config(model_config):
         return (512, 512)
     elif isinstance(model_config, ModelOptimisations1024x1024):
         return (1024, 1024)
+    elif isinstance(model_config, ModelOptimisations1024x1024BH):
+        return (1024, 1024)
     else:
         raise ValueError(
             f"Unsupported model_config type: {type(model_config).__name__}. "
-            "Expected ModelOptimisations512x512 or ModelOptimisations1024x1024."
+            "Expected ModelOptimisations512x512, ModelOptimisations1024x1024, or ModelOptimisations1024x1024BH."
         )
 
 


### PR DESCRIPTION
### Problem description
PR that added Blackhole configs for Unet did not update `get_image_resolution_from_model_config` function which led to falling Feedforward unit tests.

### What's changed
This PR fixes that mistake by updating the `get_image_resolution_from_model_config` function. 

### Checklist
- [ ] [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/runs/22958754431)
- [ ] [(Single-card) Demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/22958793615)
- [ ] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/22958832498)
- [ ] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/22945146762)
- [ ] [TT-metal L2 nightly](https://github.com/tenstorrent/tt-metal/actions/runs/22958891719)