### PR TITLE
[Cleanup] Remove set_default_fabric_topology and set_custom_fabric_topology

### DIFF
--- a/tests/tt_metal/multihost/fabric_tests/mesh_socket_test_context.cpp
+++ b/tests/tt_metal/multihost/fabric_tests/mesh_socket_test_context.cpp
@@ -120,8 +120,8 @@ void MeshSocketTestContext::initialize_and_validate_custom_physical_config(
             }
         }
     }
-    tt::tt_metal::MetalContext::instance().set_custom_fabric_topology(
-        physical_mesh_config.mesh_descriptor_path, chip_to_eth_coord_mapping);
+    custom_mesh_graph_desc_path_ = physical_mesh_config.mesh_descriptor_path;
+    custom_logical_to_physical_mapping_ = std::move(chip_to_eth_coord_mapping);
 }
 
 void MeshSocketTestContext::run_test(const ParsedTestConfig& test) {
@@ -161,7 +161,16 @@ void MeshSocketTestContext::setup_fabric_configuration() {
         default: TT_THROW("Unsupported fabric topology, must be Mesh");
     }
 
-    tt::tt_fabric::SetFabricConfig(fabric_config);
+    tt::tt_fabric::SetFabricConfig(
+        fabric_config,
+        tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE,
+        std::nullopt,
+        tt::tt_fabric::FabricTensixConfig::DISABLED,
+        tt::tt_fabric::FabricUDMMode::DISABLED,
+        tt::tt_fabric::FabricManagerMode::DEFAULT,
+        tt::tt_fabric::FabricRouterConfig{},
+        custom_mesh_graph_desc_path_,
+        custom_logical_to_physical_mapping_);
 }
 
 void MeshSocketTestContext::expand_test_configurations() {

--- a/tests/tt_metal/multihost/fabric_tests/mesh_socket_test_context.hpp
+++ b/tests/tt_metal/multihost/fabric_tests/mesh_socket_test_context.hpp
@@ -70,6 +70,10 @@ private:
     MeshId local_mesh_id_;
     std::unordered_map<Rank, tt::tt_fabric::MeshId> rank_to_mesh_mapping_;
 
+    // Custom fabric topology (populated if physical_mesh_config is specified)
+    std::optional<std::string> custom_mesh_graph_desc_path_;
+    std::map<tt::tt_fabric::FabricNodeId, ChipId> custom_logical_to_physical_mapping_;
+
     // Random number generation
     std::mt19937 gen_;
 

--- a/tests/tt_metal/multihost/fabric_tests/multihost_fabric_fixtures.hpp
+++ b/tests/tt_metal/multihost/fabric_tests/multihost_fabric_fixtures.hpp
@@ -14,8 +14,13 @@
 
 namespace tt::tt_fabric::fabric_router_tests {
 
+struct CustomFabricTopology {
+    std::string mesh_graph_desc_path;
+    std::map<FabricNodeId, ChipId> logical_to_physical_mapping;
+};
+
 template <typename Fixture>
-void validate_and_setup_control_plane_config(Fixture* fixture) {
+CustomFabricTopology get_validated_control_plane_config(Fixture* fixture) {
     const char* mesh_id_str = std::getenv("TT_MESH_ID");
     TT_FATAL(mesh_id_str != nullptr, "TT_MESH_ID environment variable must be set for Multi-Host Fabric Tests.");
 
@@ -25,15 +30,18 @@ void validate_and_setup_control_plane_config(Fixture* fixture) {
         tt::tt_metal::MetalContext::instance().rtoptions().is_custom_fabric_mesh_graph_desc_path_specified();
     std::string custom_mesh_graph_path =
         tt::tt_metal::MetalContext::instance().rtoptions().get_custom_fabric_mesh_graph_desc_path();
-    tt::tt_metal::MetalContext::instance().set_custom_fabric_topology(
-        custom_mesh_graph_path_set ? custom_mesh_graph_path : fixture->get_path_to_mesh_graph_desc(),
-        chip_to_eth_coord_mapping);
+
     TT_FATAL(
         !tt::tt_metal::MetalContext::instance().get_cluster().get_ethernet_connections_to_remote_devices().empty(),
         "Multi-Host Routing tests require ethernet links to a remote host.");
     TT_FATAL(
         *(tt::tt_metal::MetalContext::instance().global_distributed_context().size()) > 1,
         "Multi-Host Routing tests require multiple hosts in the system");
+
+    return CustomFabricTopology{
+        .mesh_graph_desc_path =
+            custom_mesh_graph_path_set ? custom_mesh_graph_path : fixture->get_path_to_mesh_graph_desc(),
+        .logical_to_physical_mapping = std::move(chip_to_eth_coord_mapping)};
 }
 
 inline const std::vector<EthCoord>& get_eth_coords_for_2x4_t3k() {
@@ -101,8 +109,14 @@ public:
             GTEST_SKIP() << "Skipping since this is not a supported system.";
         }
 
-        validate_and_setup_control_plane_config(this);
-        this->DoSetUpTestSuite(tt::tt_fabric::FabricConfig::FABRIC_2D);
+        auto topology = get_validated_control_plane_config(this);
+        this->DoSetUpTestSuite(
+            tt::tt_fabric::FabricConfig::FABRIC_2D,
+            std::nullopt,
+            tt::tt_fabric::FabricTensixConfig::DISABLED,
+            tt::tt_fabric::FabricUDMMode::DISABLED,
+            std::move(topology.mesh_graph_desc_path),
+            topology.logical_to_physical_mapping);
     }
 
     void TearDown() override {
@@ -134,7 +148,9 @@ public:
         if (not system_supported()) {
             GTEST_SKIP() << "Skipping since this is not a supported system.";
         }
-        validate_and_setup_control_plane_config(this);
+        auto topology = get_validated_control_plane_config(this);
+        this->custom_mesh_graph_desc_path_ = std::move(topology.mesh_graph_desc_path);
+        this->custom_logical_to_physical_mapping_ = std::move(topology.logical_to_physical_mapping);
         tt::tt_metal::GenericMeshDeviceFabric2DFixture::SetUp();
     }
 

--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -79,7 +79,9 @@ public:
         tt_fabric::FabricConfig fabric_config,
         std::optional<uint8_t> num_routing_planes = std::nullopt,
         tt_fabric::FabricTensixConfig fabric_tensix_config = tt_fabric::FabricTensixConfig::DISABLED,
-        tt_fabric::FabricUDMMode fabric_udm_mode = tt_fabric::FabricUDMMode::DISABLED) {
+        tt_fabric::FabricUDMMode fabric_udm_mode = tt_fabric::FabricUDMMode::DISABLED,
+        std::optional<std::string> custom_mesh_graph_desc_path = std::nullopt,
+        const std::map<FabricNodeId, ChipId>& logical_mesh_chip_id_to_physical_chip_id_mapping = {}) {
         slow_dispatch_ = getenv("TT_METAL_SLOW_DISPATCH_MODE");
         if (slow_dispatch_) {
             log_info(tt::LogTest, "Running fabric api tests with slow dispatch");
@@ -108,7 +110,15 @@ public:
             ids.push_back(id);
         }
         tt::tt_fabric::SetFabricConfig(
-            fabric_config, reliability_mode, num_routing_planes, fabric_tensix_config, fabric_udm_mode);
+            fabric_config,
+            reliability_mode,
+            num_routing_planes,
+            fabric_tensix_config,
+            fabric_udm_mode,
+            tt::tt_fabric::FabricManagerMode::DEFAULT,
+            tt::tt_fabric::FabricRouterConfig{},
+            std::move(custom_mesh_graph_desc_path),
+            logical_mesh_chip_id_to_physical_chip_id_mapping);
         const auto& dispatch_core_config =
             tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_core_config();
         devices_map_ = tt::tt_metal::distributed::MeshDevice::create_unit_meshes(
@@ -310,9 +320,13 @@ public:
     void SetUp(
         const std::string& mesh_graph_desc_file,
         const std::map<FabricNodeId, ChipId>& logical_mesh_chip_id_to_physical_chip_id_mapping) {
-        tt::tt_metal::MetalContext::instance().set_custom_fabric_topology(
-            mesh_graph_desc_file, logical_mesh_chip_id_to_physical_chip_id_mapping);
-        BaseFabricFixture::DoSetUpTestSuite(tt::tt_fabric::FabricConfig::FABRIC_2D);
+        BaseFabricFixture::DoSetUpTestSuite(
+            tt::tt_fabric::FabricConfig::FABRIC_2D,
+            std::nullopt,
+            tt::tt_fabric::FabricTensixConfig::DISABLED,
+            tt::tt_fabric::FabricUDMMode::DISABLED,
+            mesh_graph_desc_file,
+            logical_mesh_chip_id_to_physical_chip_id_mapping);
     }
 
 private:
@@ -348,8 +362,12 @@ protected:
             "Galaxy1x32Fabric1DFixture requires mesh graph descriptor {} but it was not found",
             mesh_graph_desc_path.string());
 
-        tt::tt_metal::MetalContext::instance().set_custom_fabric_topology(mesh_graph_desc_path.string(), {});
-        BaseFabricFixture::DoSetUpTestSuite(tt::tt_fabric::FabricConfig::FABRIC_1D);
+        BaseFabricFixture::DoSetUpTestSuite(
+            tt::tt_fabric::FabricConfig::FABRIC_1D,
+            std::nullopt,
+            tt::tt_fabric::FabricTensixConfig::DISABLED,
+            tt::tt_fabric::FabricUDMMode::DISABLED,
+            mesh_graph_desc_path.string());
     }
 
     static void TearDownTestSuite() {

--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -320,7 +320,7 @@ private:
 
     void TearDown() override {
         BaseFabricFixture::DoTearDownTestSuite();
-        tt::tt_metal::MetalContext::instance().set_default_fabric_topology();
+        tt::tt_metal::detail::ReleaseOwnership();
     }
 };
 
@@ -357,7 +357,7 @@ protected:
             return;
         }
         BaseFabricFixture::DoTearDownTestSuite();
-        tt::tt_metal::MetalContext::instance().set_default_fabric_topology();
+        tt::tt_metal::detail::ReleaseOwnership();
     }
 
     void SetUp() override {

--- a/tests/tt_metal/tt_fabric/fabric_router/test_channel_trimming_capture.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_channel_trimming_capture.cpp
@@ -1970,9 +1970,13 @@ protected:
 
         // Use t3k_2x2 mesh descriptor (2 meshes, inter-mesh connectivity → VC1 enabled)
         const auto& [mesh_graph_desc_path, mesh_graph_eth_coords] = t3k_mesh_descriptor_chip_mappings[2];
-        tt::tt_metal::MetalContext::instance().set_custom_fabric_topology(
-            mesh_graph_desc_path, get_physical_chip_mapping_from_eth_coords_mapping(mesh_graph_eth_coords));
-        BaseFabricFixture::DoSetUpTestSuite(tt::tt_fabric::FabricConfig::FABRIC_2D);
+        BaseFabricFixture::DoSetUpTestSuite(
+            tt::tt_fabric::FabricConfig::FABRIC_2D,
+            std::nullopt,
+            tt::tt_fabric::FabricTensixConfig::DISABLED,
+            tt::tt_fabric::FabricUDMMode::DISABLED,
+            mesh_graph_desc_path,
+            get_physical_chip_mapping_from_eth_coords_mapping(mesh_graph_eth_coords));
     }
 
     void TearDown() override {

--- a/tests/tt_metal/tt_fabric/fabric_router/test_channel_trimming_capture.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_channel_trimming_capture.cpp
@@ -1980,9 +1980,7 @@ protected:
             return;
         }
         BaseFabricFixture::DoTearDownTestSuite();
-        tt::tt_metal::MetalContext::instance().set_default_fabric_topology();
-        auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
-        rtoptions.set_fabric_trimming_override_path("");
+        tt::tt_metal::detail::ReleaseOwnership();
         if (std::filesystem::exists(override_dir_)) {
             std::filesystem::remove_all(override_dir_);
         }

--- a/tests/tt_metal/tt_fabric/fabric_router/test_multi_host.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_multi_host.cpp
@@ -227,7 +227,7 @@ TEST(MultiHost, TestDual2x4ControlPlaneInit) {
 
 // Verifies that ControlPlane APIs return values derived from the post-solving mapping (MappedChipInfo in
 // fabric_node_id_to_mapping_), not from pre-solved mesh_graph, PSD, or local bindings. Uses discovery path
-// (no set_custom_fabric_topology). Run with:
+// (no custom_mesh_graph_desc_path). Run with:
 //   tt-run --mock-cluster-rank-binding
 //   tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/t3k_dual_host_cluster_desc_mapping.yaml
 //   --rank-binding tests/tt_metal/distributed/config/dual_t3k_rank_bindings.yaml --mpi-args "--allow-run-as-root"

--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
@@ -172,7 +172,7 @@ TEST(MeshGraphValidation, TestMGDConnections) {
 
 TEST_F(ControlPlaneFixture, TestControlPlaneInitNoMGD) {
     // Reset MetalContext's control plane to ensure a clean state
-    tt::tt_metal::MetalContext::instance().set_default_fabric_topology();
+    tt::tt_metal::detail::ReleaseOwnership();
 
     tt::tt_metal::MetalContext::instance().set_fabric_config(
         tt::tt_fabric::FabricConfig::FABRIC_2D, tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
@@ -224,7 +224,7 @@ TEST(MeshGraphValidation, TestT3kMeshGraphInit) {
 
 TEST_F(ControlPlaneFixture, TestT3kControlPlaneInit) {
     // Reset MetalContext's control plane to ensure it doesn't interfere with the test's custom control plane
-    tt::tt_metal::MetalContext::instance().set_default_fabric_topology();
+    tt::tt_metal::detail::ReleaseOwnership();
 
     // Delete any existing mapping file to ensure we check the one written by the test's ControlPlane
     const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
@@ -395,7 +395,7 @@ TEST_P(T3kCustomMeshGraphControlPlaneFixture, TestT3kControlPlaneInit) {
 
     // Reset MetalContext's control plane to ensure it doesn't interfere with the test's custom control plane
     // This prevents MetalContext from creating an auto-discovery control plane that writes a mapping file first
-    tt::tt_metal::MetalContext::instance().set_default_fabric_topology();
+    tt::tt_metal::detail::ReleaseOwnership();
 
     // Delete any existing mapping file to ensure we check the one written by the test's ControlPlane
     const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();

--- a/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
@@ -153,7 +153,11 @@ protected:
                 tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE,
                 std::nullopt,
                 config_.fabric_tensix_config,
-                config_.fabric_udm_mode);
+                config_.fabric_udm_mode,
+                tt_fabric::FabricManagerMode::DEFAULT,
+                tt_fabric::FabricRouterConfig{},
+                custom_mesh_graph_desc_path_,
+                custom_logical_to_physical_mapping_);
         }
         mesh_device_ = MeshDevice::create(
             MeshDeviceConfig(config_.mesh_shape.value_or(system_mesh_shape), config_.mesh_offset),
@@ -180,6 +184,11 @@ protected:
 
     std::shared_ptr<tt::tt_metal::distributed::MeshDevice> mesh_device_;
     uint32_t max_cbs_{};
+
+    // Optional custom fabric topology override. Set these before calling SetUp()
+    // to use a custom mesh graph descriptor instead of auto-discovery.
+    std::optional<std::string> custom_mesh_graph_desc_path_;
+    std::map<tt_fabric::FabricNodeId, ChipId> custom_logical_to_physical_mapping_;
 
 private:
     Config config_;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
@@ -1789,6 +1789,11 @@ private:
     mutable std::map<FabricNodeId, uint32_t> device_frequency_cache_;
     mutable bool frequency_validated_ = false;
 
+    // Custom fabric topology (populated if physical_mesh_config is specified)
+    std::optional<std::string> custom_mesh_graph_desc_path_;
+    std::map<FabricNodeId, ChipId> custom_logical_to_physical_mapping_;
+    std::optional<MeshId> expected_local_mesh_id_;
+
     void initialize_and_validate_custom_physical_config(const PhysicalMeshConfig& physical_mesh_config) {
         const char* mesh_id_str = std::getenv("TT_MESH_ID");
         TT_FATAL(mesh_id_str != nullptr, "TT_MESH_ID environment variable must be set");
@@ -1796,7 +1801,6 @@ private:
         const auto& eth_coord_mapping = physical_mesh_config.eth_coord_mapping;
         const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
 
-        // ethernet coordinate chip mapping, which should be migrated away from
         std::map<FabricNodeId, ChipId> chip_to_eth_coord_mapping;
         for (std::uint32_t mesh_id = 0; mesh_id < eth_coord_mapping.size(); mesh_id++) {
             if (mesh_id == *local_mesh_id) {
@@ -1808,19 +1812,9 @@ private:
                 }
             }
         }
-        tt::tt_metal::MetalContext::instance().set_custom_fabric_topology(
-            physical_mesh_config.mesh_descriptor_path, chip_to_eth_coord_mapping);
-
-        // ensure user specified matches what control plane sees
-        const auto user_mesh_id =
-            tt::tt_metal::MetalContext::instance().get_control_plane().get_user_physical_mesh_ids()[0];
-        TT_FATAL(
-            *user_mesh_id == *local_mesh_id,
-            "Local mesh id {} does not not match user mesh id {}",
-            *user_mesh_id,
-            *local_mesh_id);
-
-        local_host_rank_ = tt::tt_metal::MetalContext::instance().get_control_plane().get_local_host_rank_id_binding();
+        custom_mesh_graph_desc_path_ = physical_mesh_config.mesh_descriptor_path;
+        custom_logical_to_physical_mapping_ = std::move(chip_to_eth_coord_mapping);
+        expected_local_mesh_id_ = local_mesh_id;
     }
 
     void open_devices_internal(
@@ -1842,12 +1836,24 @@ private:
             fabric_tensix_config,
             tt::tt_fabric::FabricUDMMode::DISABLED,
             tt::tt_fabric::FabricManagerMode::DEFAULT,
-            router_config);
+            router_config,
+            custom_mesh_graph_desc_path_,
+            custom_logical_to_physical_mapping_);
 
         // Now it's safe to initialize control plane (will use correct mesh graph descriptor)
-        // first need to re-init contorl plane so that it checks out the latest fabric config.
+        // first need to re-init control plane so that it checks out the latest fabric config.
         tt::tt_metal::MetalContext::instance().initialize_control_plane();
         local_host_rank_ = tt::tt_metal::MetalContext::instance().get_control_plane().get_local_host_rank_id_binding();
+
+        if (expected_local_mesh_id_.has_value()) {
+            const auto user_mesh_id =
+                tt::tt_metal::MetalContext::instance().get_control_plane().get_user_physical_mesh_ids()[0];
+            TT_FATAL(
+                *user_mesh_id == *expected_local_mesh_id_.value(),
+                "Local mesh id {} does not not match user mesh id {}",
+                *user_mesh_id,
+                *expected_local_mesh_id_.value());
+        }
 
         // Initialize mesh and device info that was deferred from init()
         const auto user_meshes =

--- a/tt_metal/api/tt-metalium/experimental/fabric/fabric.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/fabric.hpp
@@ -12,6 +12,8 @@
 #include <tt-metalium/device_types.hpp>
 // UMD: re-exports CoreType (used in append_fabric_connection/FabricHandle default params).
 #include <umd/device/types/core_coordinates.hpp>
+#include <map>
+#include <string>
 #include <vector>
 #include <optional>
 #include <hostdevcommon/fabric_common.h>
@@ -144,6 +146,16 @@ tt::tt_metal::KernelHandle generate_erisc_datamover_kernel(const FabricEriscData
  * available routing planes, num_routing_planes can be left unspecified.
  * NOTE: This does not 'reserve' routing planes for any clients, but is rather a global setting.
  *
+ * Topology discovery:
+ * If custom_mesh_graph_desc_path is not specified, the fabric topology will be determined through
+ * automatic discovery based on the physical system descriptor. To override auto-discovery, provide a
+ * custom mesh graph descriptor path and an optional logical-to-physical chip ID mapping.
+ *
+ * NOTE: The TT_MESH_GRAPH_DESC_PATH environment variable, if set, will override the
+ * custom_mesh_graph_desc_path specified here.
+ *
+ * When specifying a custom topology, this must be called with no devices currently active.
+ *
  * Return value: void
  *
  * | Argument             | Description                      | Data type              | Required |
@@ -155,6 +167,8 @@ tt::tt_metal::KernelHandle generate_erisc_datamover_kernel(const FabricEriscData
  * | fabric_udm_mode     | Unified DataMovement mode        | FabricUDMMode          | No       |
  * | fabric_manager      | Fabric manager mode              | FabricManagerMode      | No       |
  * | router_config       | Router-level configuration       | FabricRouterConfig     | No       |
+ * | custom_mesh_graph_desc_path | Path to custom mesh graph descriptor | optional<string> | No |
+ * | logical_mesh_chip_id_to_physical_chip_id_mapping | Logical to physical chip mapping | map | No |
  */
 void SetFabricConfig(
     FabricConfig fabric_config,
@@ -163,7 +177,9 @@ void SetFabricConfig(
     FabricTensixConfig fabric_tensix_config = FabricTensixConfig::DISABLED,
     FabricUDMMode fabric_udm_mode = FabricUDMMode::DISABLED,
     FabricManagerMode fabric_manager = FabricManagerMode::DEFAULT,
-    FabricRouterConfig router_config = FabricRouterConfig{});
+    FabricRouterConfig router_config = FabricRouterConfig{},
+    std::optional<std::string> custom_mesh_graph_desc_path = std::nullopt,
+    const std::map<FabricNodeId, ChipId>& logical_mesh_chip_id_to_physical_chip_id_mapping = {});
 
 FabricConfig GetFabricConfig();
 

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -453,7 +453,9 @@ void SetFabricConfig(
     FabricTensixConfig fabric_tensix_config,
     FabricUDMMode fabric_udm_mode,
     FabricManagerMode fabric_manager,
-    FabricRouterConfig router_config) {
+    FabricRouterConfig router_config,
+    std::optional<std::string> custom_mesh_graph_desc_path,
+    const std::map<FabricNodeId, ChipId>& logical_mesh_chip_id_to_physical_chip_id_mapping) {
     tt::tt_metal::MetalContext::instance().set_fabric_config(
         fabric_config,
         reliability_mode,
@@ -461,7 +463,9 @@ void SetFabricConfig(
         fabric_tensix_config,
         fabric_udm_mode,
         fabric_manager,
-        router_config);
+        router_config,
+        std::move(custom_mesh_graph_desc_path),
+        logical_mesh_chip_id_to_physical_chip_id_mapping);
 }
 
 std::optional<eth_chan_directions> get_eth_forwarding_direction(

--- a/tt_metal/fabric/topology_mapper.cpp
+++ b/tt_metal/fabric/topology_mapper.cpp
@@ -418,7 +418,7 @@ void TopologyMapper::build_mapping(const Cluster& cluster) {
     TT_FATAL(
         local_mesh_binding_.mesh_ids.size() == 1,
         "Multi-mesh-per-host systems are not supported by this algorithm, please use custom fabric topology via "
-        "MetalContext::set_custom_fabric_topology");
+        "SetFabricConfig with a custom_mesh_graph_desc_path");
 
     generate_mapping_locally_ = (mesh_graph_.get_all_mesh_ids().size() == 1) &&
                                 (mesh_graph_.get_host_ranks(local_mesh_binding_.mesh_ids[0]).size() == 1);

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -558,25 +558,6 @@ void MetalContext::set_custom_fabric_topology(
     this->set_fabric_config(fabric_config_, tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
 }
 
-void MetalContext::set_default_fabric_topology() {
-    TT_FATAL(
-        !device_manager_->is_initialized() || device_manager_->get_all_active_devices().empty(),
-        "Modifying control plane requires no devices to be active");
-    // Reset the system mesh and control plane, since they were initialized with custom parameters.
-    system_mesh_.reset();
-    control_plane_.reset();
-    // Set the mesh graph descriptor file to the default value and clear the custom FabricNodeId to physical chip
-    // mapping.
-    this->logical_mesh_chip_id_to_physical_chip_id_mapping_.clear();
-
-    if (rtoptions().is_custom_fabric_mesh_graph_desc_path_specified()) {
-        custom_mesh_graph_desc_path_ = rtoptions().get_custom_fabric_mesh_graph_desc_path();
-    } else {
-        custom_mesh_graph_desc_path_ = std::nullopt;
-    }
-    this->set_fabric_config(fabric_config_, tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
-}
-
 void MetalContext::teardown_fabric_config() {
     this->fabric_config_ = tt_fabric::FabricConfig::DISABLED;
     this->get_cluster().configure_ethernet_cores_for_fabric_routers(this->fabric_config_);

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -546,18 +546,6 @@ distributed::SystemMesh& MetalContext::get_system_mesh() {
     return *system_mesh_;
 }
 
-void MetalContext::set_custom_fabric_topology(
-    const std::string& mesh_graph_desc_file,
-    const std::map<tt_fabric::FabricNodeId, ChipId>& logical_mesh_chip_id_to_physical_chip_id_mapping) {
-    TT_FATAL(
-        !device_manager_->is_initialized() || device_manager_->get_all_active_devices().empty(),
-        "Modifying control plane requires no devices to be active");
-    // Set the user specified mesh graph descriptor file and FabricNodeID to physical chip mapping.
-    this->logical_mesh_chip_id_to_physical_chip_id_mapping_ = logical_mesh_chip_id_to_physical_chip_id_mapping;
-    custom_mesh_graph_desc_path_ = mesh_graph_desc_file;
-    this->set_fabric_config(fabric_config_, tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
-}
-
 void MetalContext::teardown_fabric_config() {
     this->fabric_config_ = tt_fabric::FabricConfig::DISABLED;
     this->get_cluster().configure_ethernet_cores_for_fabric_routers(this->fabric_config_);
@@ -573,10 +561,28 @@ void MetalContext::set_fabric_config(
     tt_fabric::FabricTensixConfig fabric_tensix_config,
     tt_fabric::FabricUDMMode fabric_udm_mode,
     tt_fabric::FabricManagerMode fabric_manager,
-    tt_fabric::FabricRouterConfig router_config) {
+    tt_fabric::FabricRouterConfig router_config,
+    std::optional<std::string> custom_mesh_graph_desc_path,
+    const std::map<tt_fabric::FabricNodeId, ChipId>& logical_mesh_chip_id_to_physical_chip_id_mapping) {
     // Changes to fabric force a re-init. TODO: We should supply the fabric config in the same way as the dispatch
     // config, not through this function exposed in the detail API.
     force_reinit_ = true;
+
+    if (custom_mesh_graph_desc_path.has_value()) {
+        TT_FATAL(
+            !device_manager_->is_initialized() || device_manager_->get_all_active_devices().empty(),
+            "Setting custom fabric topology requires no devices to be active");
+        if (rtoptions().is_custom_fabric_mesh_graph_desc_path_specified()) {
+            log_warning(
+                tt::LogMetal,
+                "TT_MESH_GRAPH_DESC_PATH is set to '{}', overriding programmatic custom mesh graph descriptor '{}'",
+                rtoptions().get_custom_fabric_mesh_graph_desc_path(),
+                custom_mesh_graph_desc_path.value());
+        } else {
+            custom_mesh_graph_desc_path_ = std::move(custom_mesh_graph_desc_path);
+        }
+        logical_mesh_chip_id_to_physical_chip_id_mapping_ = logical_mesh_chip_id_to_physical_chip_id_mapping;
+    }
 
     // Export channel trimming capture data before fabric config changes.
     // Must happen while fabric_config_ is still active and fabric context is alive.

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -121,7 +121,6 @@ public:
     void set_custom_fabric_topology(
         const std::string& mesh_graph_desc_file,
         const std::map<tt_fabric::FabricNodeId, ChipId>& logical_mesh_chip_id_to_physical_chip_id_mapping);
-    void set_default_fabric_topology();
     void set_fabric_config(
         tt_fabric::FabricConfig fabric_config,
         tt_fabric::FabricReliabilityMode reliability_mode =

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -118,9 +118,6 @@ public:
 
     // System mesh accessor — lazily initialized, reset when control plane is reset.
     distributed::SystemMesh& get_system_mesh();
-    void set_custom_fabric_topology(
-        const std::string& mesh_graph_desc_file,
-        const std::map<tt_fabric::FabricNodeId, ChipId>& logical_mesh_chip_id_to_physical_chip_id_mapping);
     void set_fabric_config(
         tt_fabric::FabricConfig fabric_config,
         tt_fabric::FabricReliabilityMode reliability_mode =
@@ -129,7 +126,9 @@ public:
         tt_fabric::FabricTensixConfig fabric_tensix_config = tt_fabric::FabricTensixConfig::DISABLED,
         tt_fabric::FabricUDMMode fabric_udm_mode = tt_fabric::FabricUDMMode::DISABLED,
         tt_fabric::FabricManagerMode fabric_manager = tt_fabric::FabricManagerMode::DEFAULT,
-        tt_fabric::FabricRouterConfig router_config = tt_fabric::FabricRouterConfig{});
+        tt_fabric::FabricRouterConfig router_config = tt_fabric::FabricRouterConfig{},
+        std::optional<std::string> custom_mesh_graph_desc_path = std::nullopt,
+        const std::map<tt_fabric::FabricNodeId, ChipId>& logical_mesh_chip_id_to_physical_chip_id_mapping = {});
     void initialize_fabric_config();
     void initialize_fabric_tensix_datamover_config();
     tt_fabric::FabricConfig get_fabric_config() const;

--- a/ttnn/cpp/ttnn-nanobind/fabric.cpp
+++ b/ttnn/cpp/ttnn-nanobind/fabric.cpp
@@ -5,7 +5,9 @@
 #include "fabric.hpp"
 
 #include <nanobind/nanobind.h>
+#include <nanobind/stl/map.h>
 #include <nanobind/stl/optional.h>
+#include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
 
 #include <tt-metalium/core_coord.hpp>
@@ -127,7 +129,10 @@ void bind_fabric_api(nb::module_& mod) {
         nb::arg("fabric_tensix_config") = nb::cast(tt::tt_fabric::FabricTensixConfig::DISABLED),
         nb::arg("fabric_udm_mode") = nb::cast(tt::tt_fabric::FabricUDMMode::DISABLED),
         nb::arg("fabric_manager_mode") = nb::cast(tt::tt_fabric::FabricManagerMode::DEFAULT),
-        nb::arg("router_config") = nb::cast(tt::tt_fabric::FabricRouterConfig{}));
+        nb::arg("router_config") = nb::cast(tt::tt_fabric::FabricRouterConfig{}),
+        nb::arg("custom_mesh_graph_desc_path") = nb::none(),
+        nb::arg("logical_mesh_chip_id_to_physical_chip_id_mapping") =
+            nb::cast(std::map<tt::tt_fabric::FabricNodeId, tt::ChipId>{}));
 
     mod.def(
         "setup_fabric_connection",


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/39594

### Problem description
- Cleaning up MetalContext
- set_default_fabric_topology: Full reinit is required. To prevent leaving MetalContext in a partial state, it's safer to call `tt::tt_metal::detail::ReleaseOwnership` instead
- set_custom_fabric_topology: Hidden call order dependency between set_custom_fabric_topology and set_fabric_config. Prefer directly to pass in a custom topology with `SetFabricConfig` instead to prevent errors.

### What's changed
- Remove `set_custom_fabric_topology` and `set_default_fabric_topology`.
- Update unit tests
- Update the nanobind file for `SetFabricConfig`

### Checklist

BH Galaxy Quick
https://github.com/tenstorrent/tt-metal/actions/runs/22930448517

WH Galaxy Quick
https://github.com/tenstorrent/tt-metal/actions/runs/22930441425

Merge Gate
https://github.com/tenstorrent/tt-metal/actions/runs/22930480358

APC
https://github.com/tenstorrent/tt-metal/actions/runs/22930430608

BH
https://github.com/tenstorrent/tt-metal/actions/runs/22930432027

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=nhuang/remove-mc-funcs)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:nhuang/remove-mc-funcs)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nhuang/remove-mc-funcs)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nhuang/remove-mc-funcs)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nhuang/remove-mc-funcs)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nhuang/remove-mc-funcs)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nhuang/remove-mc-funcs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nhuang/remove-mc-funcs)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nhuang/remove-mc-funcs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nhuang/remove-mc-funcs)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nhuang/remove-mc-funcs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nhuang/remove-mc-funcs)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
