### PR TITLE
#39553: fix cb size calculation for group_norm

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm.py
@@ -1,0 +1,51 @@
+import pytest
+import numpy as np
+import torch
+import ttnn
+
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+def test_group_norm_large_ex_external_cb(device):
+    torch.manual_seed(0)
+    shape = (1, 1, 1280 * 720, 256)  # [N, 1, H*W, C]
+    num_groups = 32
+    eps = 1e-5
+
+    input_tensor = torch.randn(shape, dtype=torch.bfloat16)
+    weight = torch.randn((shape[-1],), dtype=torch.bfloat16)
+    bias = torch.randn((shape[-1],), dtype=torch.bfloat16)
+    c = shape[-1]
+    weight_4d = weight.reshape(1, 1, c // 32, 32)
+    bias_4d = bias.reshape(1, 1, c // 32, 32)
+
+    # GroupNorm golden: convert [N,1,H*W,C] -> [N,C,1,H*W], apply GN, convert back.
+    input_tensor_nchw = input_tensor.permute(0, 3, 1, 2).float()
+    golden = torch.nn.functional.group_norm(
+        input_tensor_nchw, num_groups=num_groups, weight=weight.float(), bias=bias.float(), eps=eps
+    ).permute(0, 2, 3, 1)
+
+    input_tensor_tt = ttnn.from_torch(input_tensor, device=device, layout=ttnn.TILE_LAYOUT)
+    w_tt = ttnn.from_torch(weight_4d, device=device, layout=ttnn.ROW_MAJOR_LAYOUT)
+    b_tt = ttnn.from_torch(bias_4d, device=device, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+    sharded_mem_config, grid_size = ttnn.determine_expected_group_norm_sharded_config_and_grid_size(
+        device=device,
+        num_channels=c,
+        num_groups=num_groups,
+        input_nhw=1280 * 720,
+        is_height_sharded=False,
+        is_row_major=False,
+    )
+    output_tensor_tt = ttnn.group_norm(
+        input_tensor_tt,
+        num_groups=num_groups,
+        epsilon=eps,
+        weight=w_tt,
+        bias=b_tt,
+        core_grid=grid_size,
+        inplace=False,
+        num_out_blocks=-1,
+    )
+    output_tensor = ttnn.to_torch(output_tensor_tt)
+    assert_with_pcc(golden, output_tensor)

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import numpy as np
 import torch

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm.py
@@ -2,8 +2,6 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import pytest
-import numpy as np
 import torch
 import ttnn
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
@@ -729,15 +729,21 @@ GroupNormMcastProgramFactory::cached_program_t GroupNormMcastProgramFactory::cre
     // num_out_blocks_padded calculation to get the exact count.
     uint32_t ex_cb_external_index = tt::CBIndex::c_10;
     uint32_t num_out_blocks_padded = num_out_blocks;
-    {
+    if (!use_welford) {
+        // Legacy mcast sender/compute path: mirror kernel's num_out_blocks_padded calculation.
         uint32_t out_block_h_normal = block_ht_group_1 / num_out_blocks;
         if (block_ht_group_1 % num_out_blocks != 0) {
             uint32_t residual = block_ht_group_1 - (num_out_blocks * out_block_h_normal);
             num_out_blocks_padded += (residual / out_block_h_normal + 1);
         }
     }
-    uint32_t cb_ex_external_tiles =
-        (num_out_blocks_padded * num_cores_per_mcast_group * 16 + single_tile_size - 1) / single_tile_size;
+    uint32_t cb_ex_external_tiles = 1;
+    if (!use_welford) {
+        // Only the legacy kernels reference CBIndex::c_10; in Welford mode use a minimal size
+        // to preserve L1 headroom while keeping the CB index valid.
+        cb_ex_external_tiles =
+            (num_out_blocks_padded * num_cores_per_mcast_group * 16 + single_tile_size - 1) / single_tile_size;
+    }
     tt::tt_metal::CircularBufferConfig ex_cb_external_config =
         tt::tt_metal::CircularBufferConfig(
             cb_ex_external_tiles * single_tile_size, {{ex_cb_external_index, cb_data_format}})

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
@@ -720,10 +720,27 @@ GroupNormMcastProgramFactory::cached_program_t GroupNormMcastProgramFactory::cre
         tt::tt_metal::CreateCircularBuffer(program, all_cores, ex2_cb_partial_config);
     }
 
+    // cb_ex_external holds packed 16-byte partial-reduction scalars gathered from
+    // every core in the mcast group, for every out_block.  The reader kernel
+    // (reader_mcast_sender_unary_gn) and compute kernel (groupnorm) both
+    // reserve / wait-for cb_ex_external_tiles_required tiles at once, where
+    //   cb_ex_external_tiles_required = ceil(num_out_blocks_padded * num_mcast_cores * 16 / tile_size)
+    // so the CB must be at least that large.  Mirror the kernel's
+    // num_out_blocks_padded calculation to get the exact count.
     uint32_t ex_cb_external_index = tt::CBIndex::c_10;
+    uint32_t num_out_blocks_padded = num_out_blocks;
+    {
+        uint32_t out_block_h_normal = block_ht_group_1 / num_out_blocks;
+        if (block_ht_group_1 % num_out_blocks != 0) {
+            uint32_t residual = block_ht_group_1 - (num_out_blocks * out_block_h_normal);
+            num_out_blocks_padded += (residual / out_block_h_normal + 1);
+        }
+    }
+    uint32_t cb_ex_external_tiles =
+        (num_out_blocks_padded * num_cores_per_mcast_group * 16 + single_tile_size - 1) / single_tile_size;
     tt::tt_metal::CircularBufferConfig ex_cb_external_config =
         tt::tt_metal::CircularBufferConfig(
-            2 * single_tile_size * num_cores_per_mcast_group, {{ex_cb_external_index, cb_data_format}})
+            cb_ex_external_tiles * single_tile_size, {{ex_cb_external_index, cb_data_format}})
             .set_page_size(ex_cb_external_index, single_tile_size);
     tt::tt_metal::CreateCircularBuffer(program, all_cores, ex_cb_external_config);
 


### PR DESCRIPTION
### Ticket
Link to Github Issue #39553

### Problem description
A specific call to group norm was resulting in incorrect output. LLK/lightweight asserts were complaining about fifo_wr_ptr being greater than the fifo_limit.

### What's changed
- Setting the size of the CB related to the asserts in the program factory fixed the output.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-39553_gn_cb)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-39553_gn_cb)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-39553_gn_cb)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-39553_gn_cb)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-39553_gn_cb)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-39553_gn_cb)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-39553_gn_cb)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-39553_gn_cb)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-39553_gn_cb)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-39553_gn_cb)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-39553_gn_cb)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-39553_gn_cb)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
