### PR TITLE
[Feature] Allow Creating a MeshDevice using a MetalEnv

### DIFF
--- a/tests/tt_metal/distributed/benchmark_thread_pool.cpp
+++ b/tests/tt_metal/distributed/benchmark_thread_pool.cpp
@@ -6,6 +6,7 @@
 #include "tt_metal/common/env_lib.hpp"
 #include "tt_metal/common/thread_pool.hpp"
 #include "tt_metal/llrt/tt_cluster.hpp"
+#include "impl/context/context_types.hpp"
 
 template <typename ThreadPoolCreator>
 static void BM_ThreadPool(benchmark::State& state, ThreadPoolCreator create_thread_pool) {
@@ -45,8 +46,9 @@ static void BM_ThreadPool(benchmark::State& state, ThreadPoolCreator create_thre
 }
 
 static void BM_DeviceBoundThreadPool(benchmark::State& state) {
-    BM_ThreadPool(
-        state, [](uint32_t num_threads) { return tt::tt_metal::create_device_bound_thread_pool(num_threads); });
+    BM_ThreadPool(state, [](uint32_t num_threads) {
+        return tt::tt_metal::create_device_bound_thread_pool(tt::tt_metal::DEFAULT_CONTEXT_ID, num_threads);
+    });
 }
 
 BENCHMARK(BM_DeviceBoundThreadPool)->RangeMultiplier(2)->Range(1, 1 << 18)->Complexity(benchmark::oN)->UseRealTime();

--- a/tests/tt_metal/distributed/test_thread_pool.cpp
+++ b/tests/tt_metal/distributed/test_thread_pool.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 #include "tt_metal/common/thread_pool.hpp"
 #include "impl/context/metal_context.hpp"
+#include "impl/context/context_types.hpp"
 #include <llrt/tt_cluster.hpp>
 
 namespace tt::tt_metal::distributed::test {
@@ -15,7 +16,8 @@ TEST(ThreadPoolTest, StressDeviceBound) {
     // Enqueue enough tasks to saturate the thread pool.
     uint64_t NUM_ITERS = 1 << 18;
     uint32_t num_threads = MetalContext::instance().get_cluster().number_of_user_devices();
-    auto thread_pool = create_device_bound_thread_pool(MetalContext::instance().get_cluster().number_of_user_devices());
+    auto thread_pool = create_device_bound_thread_pool(
+        DEFAULT_CONTEXT_ID, MetalContext::instance(DEFAULT_CONTEXT_ID).get_cluster().number_of_user_devices());
     // Increment this once for each task in the thread pool.
     // Use this to verify that tasks actually executed.
     std::atomic<uint64_t> counter = 0;
@@ -43,7 +45,8 @@ TEST(ThreadPoolTest, StressDeviceBound) {
 
 // Test that an exception generated in the thread pool is propagated to the main thread
 TEST(ThreadPoolTest, Exception) {
-    auto thread_pool = create_device_bound_thread_pool(MetalContext::instance().get_cluster().number_of_user_devices());
+    auto thread_pool = create_device_bound_thread_pool(
+        DEFAULT_CONTEXT_ID, MetalContext::instance(DEFAULT_CONTEXT_ID).get_cluster().number_of_user_devices());
     auto exception_fn = []() { TT_THROW("Failed"); };
     thread_pool->enqueue(exception_fn);
     EXPECT_THROW(thread_pool->wait(), std::exception);

--- a/tests/tt_metal/tt_metal/api/allocator/test_overlapped_bank_manager.cpp
+++ b/tests/tt_metal/tt_metal/api/allocator/test_overlapped_bank_manager.cpp
@@ -25,6 +25,10 @@ struct AllocatorDependenciesParam {
     tt::tt_metal::BankManager::AllocatorDependencies::AdjacencyList expected_dependencies;
 };
 
+uint32_t get_dram_alignment_from_hal() {
+    return tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::DRAM);
+}
+
 tt::tt_metal::BankManager get_bank_manager_with_allocator_dependencies(
     const uint64_t size,
     const uint32_t alignment,
@@ -32,7 +36,14 @@ tt::tt_metal::BankManager get_bank_manager_with_allocator_dependencies(
     std::vector<int64_t> bank_desc = {0};
     const uint64_t unreserved_base = 0;
     return tt::tt_metal::BankManager(
-        tt::tt_metal::BufferType::DRAM, bank_desc, size, alignment, unreserved_base, false, allocator_dependencies);
+        tt::tt_metal::BufferType::DRAM,
+        bank_desc,
+        size,
+        alignment,
+        get_dram_alignment_from_hal(),
+        unreserved_base,
+        false,
+        allocator_dependencies);
 }
 
 }  // namespace overlapped_bank_manager_tests
@@ -1002,6 +1013,7 @@ TEST(OverlappedAllocators, NonzeroAddressLimit) {
         total_size,
         address_limit,  // interleaved_address_limit
         alignment,
+        get_dram_alignment_from_hal(),
         0,      // alloc_offset
         false,  // disable_interleaved
         deps);
@@ -1128,6 +1140,7 @@ TEST(OverlappedAllocators, NonzeroAllocOffset) {
         allocatable_l1_size,
         interleaved_address_limit,
         l1_alignment,
+        get_dram_alignment_from_hal(),
         l1_unreserved_base,
         disable_interleaved,
         deps);

--- a/tests/tt_metal/tt_metal/api/test_kernel_creation.cpp
+++ b/tests/tt_metal/tt_metal/api/test_kernel_creation.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt-metalium/core_coord.hpp>
+#include "context/metal_env_accessor.hpp"
+#include "distributed/mesh_device_impl.hpp"
 #include "llrt/core_descriptor.hpp"
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
@@ -66,8 +68,10 @@ TEST_F(MeshDispatchFixture, DISABLED_TensixIdleEthCreateKernelsOnDispatchCores) 
 
         const auto& dispatch_core_config = get_dispatch_core_config();
         CoreType dispatch_core_type = get_core_type_from_config(dispatch_core_config);
+        MetalEnvImpl& env_impl =
+            MetalEnvAccessor(MetalContext::instance(mesh_device->impl().get_context_id()).get_env()).impl();
         std::vector<CoreCoord> dispatch_cores =
-            tt::get_logical_dispatch_cores(device->id(), device->num_hw_cqs(), dispatch_core_config);
+            tt::get_logical_dispatch_cores(env_impl, device->id(), device->num_hw_cqs(), dispatch_core_config);
         std::set<CoreRange> dispatch_core_ranges;
         for (CoreCoord core : dispatch_cores) {
             dispatch_core_ranges.emplace(core);

--- a/tests/tt_metal/tt_metal/context/sources.cmake
+++ b/tests/tt_metal/tt_metal/context/sources.cmake
@@ -4,4 +4,5 @@
 set(UNIT_TESTS_CONTEXT_SMOKE_SOURCES
     test_metal_env_api.cpp
     test_metal_context_api.cpp
+    test_integration.cpp
 )

--- a/tests/tt_metal/tt_metal/context/test_integration.cpp
+++ b/tests/tt_metal/tt_metal/context/test_integration.cpp
@@ -246,20 +246,6 @@ TEST(MetalContextIntegrationTest, MockDeviceOnly) {
     ASSERT_FALSE(MetalContext::instance_exists(context_id));
 }
 
-TEST(MetalContextIntegrationTest, MockDeviceCommandQueueOnly) {
-    // This will try to run some actions on the mock device's command queue and then check
-    // it didn't implicitly create the physical metal context
-    {
-        MetalEnv mock_env_bh_1{MetalEnvDescriptor(experimental::get_mock_cluster_desc_name(tt::ARCH::BLACKHOLE, 1))};
-
-        auto mesh_config_mock = distributed::MeshDeviceConfig(distributed::MeshShape(1));
-        auto mock_device = mock_env_bh_1.create_mesh_device(mesh_config_mock);
-    }
-
-    // Assert that we didn't implicitly create the physical metal context
-    ASSERT_FALSE(MetalContext::instance_exists(DEFAULT_CONTEXT_ID));
-}
-
 TEST(MetalContextIntegrationTest, CoexistingSiliconAndMockDevice) {
     // Create mock mesh device with 1 blackhole chip
     MetalEnv mock_env_bh_1{MetalEnvDescriptor(experimental::get_mock_cluster_desc_name(tt::ARCH::BLACKHOLE, 1))};

--- a/tests/tt_metal/tt_metal/context/test_integration.cpp
+++ b/tests/tt_metal/tt_metal/context/test_integration.cpp
@@ -211,7 +211,11 @@ TEST(MetalContextIntegrationTest, MockDeviceOnly) {
         ASSERT_FALSE(buffer->is_allocated());
 
         // Test command queue operations
-        // auto& cq = mock_device->mesh_command_queue();
+        auto& cq = mock_device->mesh_command_queue();
+        std::vector<uint32_t> write_data(16);
+        std::iota(write_data.begin(), write_data.end(), 0xDEADBEEF);
+
+        distributed::EnqueueWriteMeshBuffer(cq, buffer, write_data, true);
     }
 
     // Assert that we didn't implicitly create the physical metal context

--- a/tests/tt_metal/tt_metal/context/test_integration.cpp
+++ b/tests/tt_metal/tt_metal/context/test_integration.cpp
@@ -198,6 +198,20 @@ TEST(MetalContextIntegrationTest, MockDeviceOnly) {
         auto mesh_config_mock = distributed::MeshDeviceConfig(distributed::MeshShape(1));
         auto mock_device = mock_env_bh_1.create_mesh_device(mesh_config_mock);
         context_id = mock_device->impl().get_context_id();
+
+        // Test buffer allocation and deallocation
+        constexpr size_t page_size = 4096;
+        constexpr size_t buffer_size = page_size * 12;
+        distributed::DeviceLocalBufferConfig local_config{.page_size = buffer_size, .buffer_type = BufferType::L1};
+        distributed::ReplicatedBufferConfig buffer_config{.size = buffer_size};
+        auto buffer = distributed::MeshBuffer::create(buffer_config, local_config, mock_device.get());
+        log_info(tt::LogTest, "Buffer address: {}", buffer->address());
+        ASSERT_TRUE(buffer->is_allocated());
+        buffer->deallocate();
+        ASSERT_FALSE(buffer->is_allocated());
+
+        // Test command queue operations
+        // auto& cq = mock_device->mesh_command_queue();
     }
 
     // Assert that we didn't implicitly create the physical metal context

--- a/tests/tt_metal/tt_metal/context/test_integration.cpp
+++ b/tests/tt_metal/tt_metal/context/test_integration.cpp
@@ -1,0 +1,427 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <cstdlib>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <numeric>
+#include <cstring>
+
+// Prefer to use API rather than internals in this
+// test as we are testing end to end functionality
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/experimental/context/metal_env.hpp>
+#include <tt-metalium/mesh_config.hpp>
+#include <tt-metalium/mesh_coord.hpp>
+#include <tt-metalium/mesh_device.hpp>
+#include <tt-metalium/system_mesh.hpp>
+#include <tt-metalium/mesh_buffer.hpp>
+#include <tt-metalium/mesh_workload.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/host_api.hpp>
+
+#include <umd/device/types/arch.hpp>
+
+// Internal access
+#include "impl/context/context_types.hpp"
+#include "distributed/mesh_device_impl.hpp"
+#include "context/metal_env_accessor.hpp"
+#include "device/mock_device_util.hpp"
+#include "impl/context/metal_context.hpp"
+
+namespace tt::tt_metal {
+
+namespace {
+
+constexpr int kExitBadNumDevices = 2;
+constexpr int kExitBadMeshSize = 3;
+constexpr int kExitWorkFailed = 5;
+constexpr int kExitBufferVerificationFailed = 10;
+
+// Helper function to perform buffer operations and kernel launch on a MeshDevice.
+// Uses a sharded MeshBuffer so this works on both single- and multi-device meshes.
+void PerformDeviceWork(
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    uint32_t data_pattern,
+    const std::string& process_name,
+    const std::string& kernel_identifier) {
+    constexpr uint32_t kElementsPerShard = 1024;
+    constexpr uint32_t kShardSize = kElementsPerShard * sizeof(uint32_t);
+
+    const size_t num_rows = mesh_device->num_rows();
+    const size_t num_cols = mesh_device->num_cols();
+    const size_t num_devices = mesh_device->num_devices();
+
+    distributed::ShardedBufferConfig buffer_config{
+        .global_size = kShardSize * num_devices,
+        .global_buffer_shape = {kElementsPerShard * num_rows, num_cols},
+        .shard_shape = {kElementsPerShard, 1},
+        .shard_orientation = ShardOrientation::ROW_MAJOR,
+    };
+    distributed::DeviceLocalBufferConfig local_config{
+        .page_size = kShardSize,
+        .buffer_type = BufferType::DRAM,
+    };
+    auto mesh_buffer = distributed::MeshBuffer::create(buffer_config, local_config, mesh_device.get());
+
+    std::vector<uint32_t> write_data(kElementsPerShard * num_devices);
+    std::iota(write_data.begin(), write_data.end(), data_pattern);
+
+    auto& mesh_cq = mesh_device->mesh_command_queue();
+    distributed::EnqueueWriteMeshBuffer(mesh_cq, mesh_buffer, write_data, false);
+
+    std::vector<uint32_t> read_data;
+    distributed::EnqueueReadMeshBuffer(mesh_cq, read_data, mesh_buffer, true);
+
+    if (read_data != write_data) {
+        throw std::runtime_error("Buffer read/write verification failed");
+    }
+
+    auto program = CreateProgram();
+    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
+    auto core_grid = mesh_device->compute_with_storage_grid_size();
+    auto core_range = CoreRange({0, 0}, {core_grid.x - 1, core_grid.y - 1});
+
+    std::string kernel_src = "void kernel_main() {\n    // " + kernel_identifier + "\n}";
+
+    CreateKernelFromString(
+        program,
+        kernel_src,
+        core_range,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
+
+    distributed::MeshWorkload workload;
+    workload.add_program(device_range, std::move(program));
+    distributed::EnqueueMeshWorkload(mesh_cq, workload, true);
+
+    log_info(tt::LogTest, "{}: Successfully completed buffer ops and kernel launch", process_name);
+}
+
+[[noreturn]] void RunChildWithVisibleDevices(
+    const std::string& visible_devices,
+    size_t expected_num_chips,
+    uint32_t data_pattern,
+    const std::string& child_name) {
+    setenv("TT_VISIBLE_DEVICES", visible_devices.c_str(), 1);
+
+    MetalEnv child_env;
+
+    auto child_num_devices = child_env.get_num_pcie_devices();
+    log_info(tt::LogTest, "{}: TT_VISIBLE_DEVICES={}, num_devices={}", child_name, visible_devices, child_num_devices);
+    if (child_num_devices != expected_num_chips) {
+        _exit(kExitBadNumDevices);
+    }
+
+    auto child_mesh_shape = child_env.get_system_mesh().shape();
+    auto child_mesh_device = child_env.create_mesh_device(distributed::MeshDeviceConfig(child_mesh_shape));
+    if (child_mesh_device->num_devices() != expected_num_chips) {
+        _exit(kExitBadMeshSize);
+    }
+    log_info(tt::LogTest, "{}: opened MeshDevice with {} device(s)", child_name, child_mesh_device->num_devices());
+
+    try {
+        PerformDeviceWork(child_mesh_device, data_pattern, child_name, child_name + " kernel");
+    } catch (const std::exception& e) {
+        log_error(tt::LogTest, "{}: Work failed: {}", child_name, e.what());
+        if (std::string(e.what()).find("Buffer read/write verification failed") != std::string::npos) {
+            _exit(kExitBufferVerificationFailed);
+        }
+        _exit(kExitWorkFailed);
+    }
+
+    _exit(0);
+}
+
+}  // namespace
+
+TEST(MetalContextIntegrationTest, Legacy) {
+    auto mesh_shape = tt_metal::distributed::SystemMesh::instance().shape();
+    auto mesh_device_config = distributed::MeshDeviceConfig(mesh_shape);
+    std::shared_ptr<distributed::MeshDevice> mesh_device = distributed::MeshDevice::create(mesh_device_config);
+    EXPECT_EQ(mesh_device->num_devices(), mesh_shape.mesh_size());
+    // Required for this unit test because legacy behaviour of MetalContext is not to close the cluster until atexit
+    // Close it right now so remaining tests can proceed
+    mesh_device->close();
+
+    // It was found that during ~MeshDevice, some calls to MetalContext::instance() were made which caused
+    // MetalContext to implicitly reinitialize thus undoing the effects of DestroyAllContexts().
+    // Subsequent tests will hang if that happens.
+    tt::tt_metal::detail::ReleaseOwnership();
+}
+
+TEST(MetalContextIntegrationTest, HelloWorld) {
+    MetalEnv env;
+
+    auto mesh_shape = env.get_system_mesh().shape();
+    auto mesh_device_config = distributed::MeshDeviceConfig(mesh_shape);
+    auto mesh_device = env.create_mesh_device(mesh_device_config);
+
+    mesh_device->close();
+}
+
+TEST(MetalContextIntegrationTest, HelloWorldQueryThenCreate) {
+    ContextId context_id;
+    {
+        MetalEnv env;
+
+        size_t l1_size = env.get_l1_size();
+        size_t trace_region_size = l1_size * 0.3;
+        size_t l1_small_region_size = l1_size * 0.05;
+
+        auto mesh_shape = env.get_system_mesh().shape();
+        auto mesh_device_config = distributed::MeshDeviceConfig(mesh_shape);
+        auto mesh_device = env.create_mesh_device(mesh_device_config, trace_region_size, l1_small_region_size);
+        context_id = mesh_device->impl().get_context_id();
+    }
+
+    // We only support 1 MetalEnv <-> 1 MetalContext instance for the physical cluster right now
+    ASSERT_EQ(context_id, DEFAULT_CONTEXT_ID);
+
+    // Assert that the MetalContext instance was cleaned up after MeshDevice close
+    ASSERT_FALSE(MetalContext::instance_exists(context_id));
+
+    // Check if can create another env
+    // If this hangs, it means there is a dangling cluster open somewhere
+    {
+        MetalEnv env;
+        ASSERT_NO_THROW(env.get_num_pcie_devices());
+    }
+}
+
+TEST(MetalContextIntegrationTest, MockDeviceOnly) {
+    ContextId context_id;
+    {
+        MetalEnv mock_env_bh_1{MetalEnvDescriptor(experimental::get_mock_cluster_desc_name(tt::ARCH::BLACKHOLE, 1))};
+
+        auto mesh_config_mock = distributed::MeshDeviceConfig(distributed::MeshShape(1));
+        auto mock_device = mock_env_bh_1.create_mesh_device(mesh_config_mock);
+        context_id = mock_device->impl().get_context_id();
+    }
+
+    // Assert that we didn't implicitly create the physical metal context
+    ASSERT_FALSE(MetalContext::instance_exists(DEFAULT_CONTEXT_ID));
+
+    // Assert that the MetalContext instance was cleaned up after MeshDevice close
+    ASSERT_FALSE(MetalContext::instance_exists(context_id));
+}
+
+TEST(MetalContextIntegrationTest, MockDeviceCommandQueueOnly) {
+    // This will try to run some actions on the mock device's command queue and then check
+    // it didn't implicitly create the physical metal context
+    {
+        MetalEnv mock_env_bh_1{MetalEnvDescriptor(experimental::get_mock_cluster_desc_name(tt::ARCH::BLACKHOLE, 1))};
+
+        auto mesh_config_mock = distributed::MeshDeviceConfig(distributed::MeshShape(1));
+        auto mock_device = mock_env_bh_1.create_mesh_device(mesh_config_mock);
+    }
+
+    // Assert that we didn't implicitly create the physical metal context
+    ASSERT_FALSE(MetalContext::instance_exists(DEFAULT_CONTEXT_ID));
+}
+
+TEST(MetalContextIntegrationTest, CoexistingSiliconAndMockDevice) {
+    // Create mock mesh device with 1 blackhole chip
+    MetalEnv mock_env_bh_1{MetalEnvDescriptor(experimental::get_mock_cluster_desc_name(tt::ARCH::BLACKHOLE, 1))};
+    auto mock_mesh_shape_bh_1 = mock_env_bh_1.get_system_mesh().shape();
+    auto mock_mesh_device_config_bh_1 = distributed::MeshDeviceConfig(mock_mesh_shape_bh_1);
+    std::shared_ptr<distributed::MeshDevice> mock_mesh_device_bh_1 =
+        mock_env_bh_1.create_mesh_device(mock_mesh_device_config_bh_1);
+    log_info(tt::LogTest, "Created mock mesh device with shape {}", mock_mesh_device_bh_1->shape().dims());
+
+    // Create mock mesh device with 2 blackhole chips
+    MetalEnv mock_env_bh_2{MetalEnvDescriptor(experimental::get_mock_cluster_desc_name(tt::ARCH::BLACKHOLE, 2))};
+    auto mock_mesh_shape_bh_2 = mock_env_bh_2.get_system_mesh().shape();
+    auto mock_mesh_device_config_bh_2 = distributed::MeshDeviceConfig(mock_mesh_shape_bh_2);
+    auto mock_mesh_device_bh_2 = mock_env_bh_2.create_mesh_device(mock_mesh_device_config_bh_2);
+    log_info(tt::LogTest, "Created mock mesh device with shape {}", mock_mesh_device_bh_2->shape().dims());
+
+    // Create silicon mesh
+    MetalEnv env;
+    auto mesh_shape = env.get_system_mesh().shape();
+    auto mesh_device_config = distributed::MeshDeviceConfig(mesh_shape);
+    std::shared_ptr<distributed::MeshDevice> mesh_device = env.create_mesh_device(mesh_device_config);
+    log_info(tt::LogTest, "Created silicon mesh device with shape {}", mesh_device->shape().dims());
+
+    ASSERT_EQ(mock_mesh_device_bh_1->get_devices().size(), 1);
+    ASSERT_EQ(mock_mesh_device_bh_2->get_devices().size(), 2);
+}
+
+// Same test as above but reverse the order to ensure no hangs due to unexpected internal objects created for the
+// incorrect context id
+TEST(MetalContextIntegrationTest, CoexistingMockAndSiliconDevice) {
+    // Create silicon mesh
+    MetalEnv silicon_env;
+
+    auto mesh_shape = silicon_env.get_system_mesh().shape();
+    auto mesh_device_config = distributed::MeshDeviceConfig(mesh_shape);
+    std::shared_ptr<distributed::MeshDevice> mesh_device = silicon_env.create_mesh_device(mesh_device_config);
+    log_info(tt::LogTest, "Created silicon mesh device with shape {}", mesh_device->shape().dims());
+
+    // Create mock mesh device with 1 blackhole chip
+    MetalEnv mock_env_bh_1{MetalEnvDescriptor(experimental::get_mock_cluster_desc_name(tt::ARCH::BLACKHOLE, 1))};
+    auto mock_mesh_shape_bh_1 = mock_env_bh_1.get_system_mesh().shape();
+    auto mock_mesh_device_config_bh_1 = distributed::MeshDeviceConfig(mock_mesh_shape_bh_1);
+    auto mock_mesh_device_bh_1 = mock_env_bh_1.create_mesh_device(mock_mesh_device_config_bh_1);
+    log_info(tt::LogTest, "Created mock mesh device with shape {}", mock_mesh_device_bh_1->shape().dims());
+
+    // Create mock mesh device with 2 blackhole chips
+    MetalEnv mock_env_bh_2{MetalEnvDescriptor(experimental::get_mock_cluster_desc_name(tt::ARCH::BLACKHOLE, 2))};
+
+    auto mock_mesh_shape_bh_2 = mock_env_bh_2.get_system_mesh().shape();
+    auto mock_mesh_device_config_bh_2 = distributed::MeshDeviceConfig(mock_mesh_shape_bh_2);
+    auto mock_mesh_device_bh_2 = mock_env_bh_2.create_mesh_device(mock_mesh_device_config_bh_2);
+    log_info(tt::LogTest, "Created mock mesh device with shape {}", mock_mesh_device_bh_2->shape().dims());
+
+    ASSERT_EQ(mock_mesh_device_bh_1->get_devices().size(), 1);
+    ASSERT_EQ(mock_mesh_device_bh_2->get_devices().size(), 2);
+}
+
+TEST(MetalContextIntegrationTest, ForkMockAndRealDevice) {
+    // Query hardware state before forking
+    {
+        MetalEnv env;
+
+        auto arch = env.get_arch();
+        auto l1_size = env.get_l1_size();
+        auto num_devices = env.get_num_available_devices();
+        log_info(tt::LogTest, "Pre-fork: arch={}, L1 size={}, num_devices={}", arch, l1_size, num_devices);
+        EXPECT_GT(l1_size, 0u);
+        EXPECT_GT(num_devices, 0u);
+    }
+
+    int pipe_fd[2];
+    ASSERT_EQ(pipe(pipe_fd), 0) << "pipe() failed";
+
+    pid_t pid = fork();
+    if (pid == -1) {
+        close(pipe_fd[0]);
+        close(pipe_fd[1]);
+        FAIL() << "Failed to fork";
+    }
+
+    if (pid == 0) {
+        close(pipe_fd[1]);
+
+        MetalEnv mock_env{MetalEnvDescriptor(experimental::get_mock_cluster_desc_name(tt::ARCH::BLACKHOLE, 2).value())};
+
+        if (!MetalEnvAccessor(mock_env).impl().get_rtoptions().get_mock_enabled()) {
+            _exit(1);
+        }
+
+        if (mock_env.get_arch() != tt::ARCH::BLACKHOLE) {
+            _exit(2);
+        }
+
+        auto mock_mesh_shape = mock_env.get_system_mesh().shape();
+        auto mock_mesh_device = mock_env.create_mesh_device(distributed::MeshDeviceConfig(mock_mesh_shape));
+        if (mock_mesh_device->get_devices().size() != 2) {
+            _exit(3);
+        }
+
+        char byte = 0;
+        if (read(pipe_fd[0], &byte, 1) != 1) {
+            _exit(4);
+        }
+        close(pipe_fd[0]);
+
+        _exit(0);
+    }
+
+    // Parent: real device work
+    close(pipe_fd[0]);
+
+    MetalEnv env;
+
+    auto real_arch = env.get_arch();
+    auto real_l1_size = env.get_l1_size();
+    log_info(tt::LogTest, "Parent (real): arch={}, L1 size={}", real_arch, real_l1_size);
+    EXPECT_GT(real_l1_size, 0u);
+
+    auto mesh_shape = env.get_system_mesh().shape();
+    auto silicon_mesh_device = env.create_mesh_device(distributed::MeshDeviceConfig(mesh_shape));
+    EXPECT_GT(silicon_mesh_device->num_devices(), 0u);
+    log_info(tt::LogTest, "Parent: created silicon mesh device with shape {}", silicon_mesh_device->shape().dims());
+
+    // Signal child to exit
+    char byte = 1;
+    ASSERT_EQ(write(pipe_fd[1], &byte, 1), 1) << "write(pipe) failed";
+    close(pipe_fd[1]);
+
+    int status = 0;
+    ASSERT_EQ(waitpid(pid, &status, 0), pid);
+    ASSERT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(WEXITSTATUS(status), 0);
+
+    silicon_mesh_device.reset();
+}
+
+TEST(MetalContextIntegrationTest, ForkWithDisjointDevices) {
+    size_t num_mmio_devices = 0;
+    size_t num_available_devices = 0;
+    {
+        MetalEnv env;
+        num_mmio_devices = env.get_num_pcie_devices();
+        num_available_devices = env.get_num_available_devices();
+        log_info(tt::LogTest, "System has {} PCIe devices, {} total chips", num_mmio_devices, num_available_devices);
+    }
+
+    if (num_mmio_devices < 2) {
+        GTEST_SKIP() << "ForkWithDisjointDevices requires at least 2 MMIO devices, found " << num_mmio_devices;
+    }
+
+    // Split PCIe devices into two halves
+    size_t half = num_mmio_devices / 2;
+    std::string first_half_devices;
+    std::string second_half_devices;
+    for (size_t i = 0; i < num_mmio_devices; i++) {
+        auto& target = (i < half) ? first_half_devices : second_half_devices;
+        if (!target.empty()) {
+            target += ",";
+        }
+        target += std::to_string(i);
+    }
+    size_t chips_per_pcie_device = num_available_devices / num_mmio_devices;
+    size_t expected_chips_first_half = half * chips_per_pcie_device;
+    size_t expected_chips_second_half = (num_mmio_devices - half) * chips_per_pcie_device;
+    log_info(
+        tt::LogTest,
+        "Splitting: child 1 gets PCIe devices [{}] ({} chips), child 2 gets [{}] ({} chips)",
+        first_half_devices,
+        expected_chips_first_half,
+        second_half_devices,
+        expected_chips_second_half);
+
+    pid_t pid1 = fork();
+    if (pid1 == -1) {
+        FAIL() << "Failed to fork first child";
+    }
+    if (pid1 == 0) {
+        RunChildWithVisibleDevices(first_half_devices, expected_chips_first_half, 0x12340000, "Child 1");
+    }
+
+    pid_t pid2 = fork();
+    if (pid2 == -1) {
+        FAIL() << "Failed to fork second child";
+    }
+    if (pid2 == 0) {
+        RunChildWithVisibleDevices(second_half_devices, expected_chips_second_half, 0x56780000, "Child 2");
+    }
+
+    auto wait_for_child = [](pid_t pid, const std::string& name) {
+        int status = 0;
+        ASSERT_EQ(waitpid(pid, &status, 0), pid);
+        ASSERT_TRUE(WIFEXITED(status));
+        EXPECT_EQ(WEXITSTATUS(status), 0)
+            << name << " exited with code " << WEXITSTATUS(status) << "(" << kExitBadNumDevices << "=num_devices"
+            << ", " << kExitBadMeshSize << "=mesh_size"
+            << ", " << kExitWorkFailed << "=work_failed"
+            << ", " << kExitBufferVerificationFailed << "=buffer_verification)";
+    };
+
+    wait_for_child(pid1, "Child 1");
+    wait_for_child(pid2, "Child 2");
+}
+
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/context/test_integration.cpp
+++ b/tests/tt_metal/tt_metal/context/test_integration.cpp
@@ -205,17 +205,38 @@ TEST(MetalContextIntegrationTest, MockDeviceOnly) {
         distributed::DeviceLocalBufferConfig local_config{.page_size = buffer_size, .buffer_type = BufferType::L1};
         distributed::ReplicatedBufferConfig buffer_config{.size = buffer_size};
         auto buffer = distributed::MeshBuffer::create(buffer_config, local_config, mock_device.get());
-        log_info(tt::LogTest, "Buffer address: {}", buffer->address());
+        ASSERT_GT(buffer->address(), 0);
         ASSERT_TRUE(buffer->is_allocated());
         buffer->deallocate();
         ASSERT_FALSE(buffer->is_allocated());
 
         // Test command queue operations
         auto& cq = mock_device->mesh_command_queue();
-        std::vector<uint32_t> write_data(16);
+        constexpr size_t num_elements = 16;
+        std::vector<uint32_t> write_data(num_elements);
         std::iota(write_data.begin(), write_data.end(), 0xDEADBEEF);
 
         distributed::EnqueueWriteMeshBuffer(cq, buffer, write_data, true);
+
+        std::vector<uint32_t> read_data;
+        distributed::EnqueueReadMeshBuffer(cq, read_data, buffer, true);
+
+        // TODO: Uncomment this once CreateProgram and CreateKernel stop implicitly creating the physical metal context
+        // https://github.com/tenstorrent/tt-metal/issues/39849
+        // auto program = CreateProgram();
+        // distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mock_device->shape());
+        // auto core_grid = mock_device->compute_with_storage_grid_size();
+        // auto core_range = CoreRange({0, 0}, {core_grid.x - 1, core_grid.y - 1});
+
+        // CreateKernelFromString(
+        //     program,
+        //     "void kernel_main() {}",
+        //     core_range,
+        //     DataMovementConfig{});
+
+        // distributed::MeshWorkload workload;
+        // workload.add_program(device_range, std::move(program));
+        // distributed::EnqueueMeshWorkload(cq, workload, true);
     }
 
     // Assert that we didn't implicitly create the physical metal context

--- a/tests/tt_metal/tt_metal/context/test_integration.cpp
+++ b/tests/tt_metal/tt_metal/context/test_integration.cpp
@@ -116,10 +116,17 @@ void PerformDeviceWork(
 
     auto child_mesh_shape = child_env.get_system_mesh().shape();
     auto child_mesh_device = child_env.create_mesh_device(distributed::MeshDeviceConfig(child_mesh_shape));
-    if (child_mesh_device->num_devices() != expected_num_chips) {
+    // The system mesh shape may be smaller than expected_num_chips when chips are not fabric-connected
+    // (e.g. standalone PCIe cards without direct chip-to-chip links). Verify at least one device opened.
+    if (child_mesh_device->num_devices() == 0) {
         _exit(kExitBadMeshSize);
     }
-    log_info(tt::LogTest, "{}: opened MeshDevice with {} device(s)", child_name, child_mesh_device->num_devices());
+    log_info(
+        tt::LogTest,
+        "{}: opened MeshDevice with {} device(s) (expected up to {})",
+        child_name,
+        child_mesh_device->num_devices(),
+        expected_num_chips);
 
     try {
         PerformDeviceWork(child_mesh_device, data_pattern, child_name, child_name + " kernel");

--- a/tt_metal/api/tt-metalium/experimental/context/metal_env.hpp
+++ b/tt_metal/api/tt-metalium/experimental/context/metal_env.hpp
@@ -9,6 +9,7 @@
 #include <umd/device/types/arch.hpp>
 #include <tt-metalium/experimental/fabric/fabric_types.hpp>
 #include <tt-metalium/mesh_device.hpp>
+#include <tt-metalium/sub_device.hpp>
 #include <tt-metalium/system_mesh.hpp>
 
 namespace tt::tt_fabric {
@@ -130,7 +131,7 @@ public:
     /// MeshDevice instances to map logical coordinates to physical device IDs.
     distributed::SystemMesh& get_system_mesh();
 
-    // Create a MeshDevice which will operate on this MetalEnv
+    // Create a MeshDevice which will use this MetalEnv
     std::shared_ptr<distributed::MeshDevice> create_mesh_device(
         const distributed::MeshDeviceConfig& config,
         size_t l1_small_size = DEFAULT_L1_SMALL_SIZE,
@@ -140,7 +141,7 @@ public:
         tt::stl::Span<const std::uint32_t> l1_bank_remap = {},
         size_t worker_l1_size = DEFAULT_WORKER_L1_SIZE);
 
-    // Create a unit mesh for the physical device ID which will operate on this MetalEnv
+    // Create a unit mesh for the physical device ID which will use this MetalEnv
     std::shared_ptr<distributed::MeshDevice> create_unit_mesh_device(
         int device_id,
         size_t l1_small_size = DEFAULT_L1_SMALL_SIZE,
@@ -150,7 +151,7 @@ public:
         tt::stl::Span<const std::uint32_t> l1_bank_remap = {},
         size_t worker_l1_size = DEFAULT_WORKER_L1_SIZE);
 
-    // Create a unit mesh for each physical device ID in the list which will operate on this MetalEnv
+    // Create a unit mesh for each physical device ID in the list which will use this MetalEnv
     std::map<int, std::shared_ptr<distributed::MeshDevice>> create_unit_meshes(
         const std::vector<int>& device_ids,
         size_t l1_small_size = DEFAULT_L1_SMALL_SIZE,
@@ -159,6 +160,9 @@ public:
         const DispatchCoreConfig& dispatch_core_config = DispatchCoreConfig{},
         tt::stl::Span<const std::uint32_t> l1_bank_remap = {},
         size_t worker_l1_size = DEFAULT_WORKER_L1_SIZE);
+
+    // Create a SubDevice that uses this MetalEnv
+    SubDevice create_sub_device(tt::stl::Span<const CoreRangeSet> cores);
 
 private:
     friend class MetalEnvAccessor;

--- a/tt_metal/api/tt-metalium/experimental/context/metal_env.hpp
+++ b/tt_metal/api/tt-metalium/experimental/context/metal_env.hpp
@@ -8,6 +8,8 @@
 #include <optional>
 #include <umd/device/types/arch.hpp>
 #include <tt-metalium/experimental/fabric/fabric_types.hpp>
+#include <tt-metalium/mesh_device.hpp>
+#include <tt-metalium/system_mesh.hpp>
 
 namespace tt::tt_fabric {
 class ControlPlane;
@@ -91,6 +93,9 @@ public:
     /// @return Total number of PCIe devices in this environment.
     uint32_t get_num_pcie_devices() const;
 
+    /// @return Number of available devices in this environment.
+    uint32_t get_num_available_devices() const;
+
     /// @return Size in bytes of each Tensix core's L1 SRAM of this environment.
     uint32_t get_l1_size() const;
 
@@ -124,6 +129,36 @@ public:
     /// The system mesh provides a virtualized coordinate system over the physical devices, allowing
     /// MeshDevice instances to map logical coordinates to physical device IDs.
     distributed::SystemMesh& get_system_mesh();
+
+    // Create a MeshDevice which will operate on this MetalEnv
+    std::shared_ptr<distributed::MeshDevice> create_mesh_device(
+        const distributed::MeshDeviceConfig& config,
+        size_t l1_small_size = DEFAULT_L1_SMALL_SIZE,
+        size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE,
+        size_t num_command_queues = 1,
+        const DispatchCoreConfig& dispatch_core_config = DispatchCoreConfig{},
+        tt::stl::Span<const std::uint32_t> l1_bank_remap = {},
+        size_t worker_l1_size = DEFAULT_WORKER_L1_SIZE);
+
+    // Create a unit mesh for the physical device ID which will operate on this MetalEnv
+    std::shared_ptr<distributed::MeshDevice> create_unit_mesh_device(
+        int device_id,
+        size_t l1_small_size = DEFAULT_L1_SMALL_SIZE,
+        size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE,
+        size_t num_command_queues = 1,
+        const DispatchCoreConfig& dispatch_core_config = DispatchCoreConfig{},
+        tt::stl::Span<const std::uint32_t> l1_bank_remap = {},
+        size_t worker_l1_size = DEFAULT_WORKER_L1_SIZE);
+
+    // Create a unit mesh for each physical device ID in the list which will operate on this MetalEnv
+    std::map<int, std::shared_ptr<distributed::MeshDevice>> create_unit_meshes(
+        const std::vector<int>& device_ids,
+        size_t l1_small_size = DEFAULT_L1_SMALL_SIZE,
+        size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE,
+        size_t num_command_queues = 1,
+        const DispatchCoreConfig& dispatch_core_config = DispatchCoreConfig{},
+        tt::stl::Span<const std::uint32_t> l1_bank_remap = {},
+        size_t worker_l1_size = DEFAULT_WORKER_L1_SIZE);
 
 private:
     friend class MetalEnvAccessor;

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -39,6 +39,7 @@
 
 namespace tt::tt_metal {
 class Allocator;
+class MetalEnv;
 class SubDevice;
 class SystemMemoryManager;
 
@@ -73,9 +74,12 @@ using DeviceIds = std::vector<int>;
 
 class MeshDevice : public IDevice, public std::enable_shared_from_this<MeshDevice> {
     friend class MeshDeviceImpl;
+    friend class tt::tt_metal::MetalEnv;
 
 private:
     MeshDevice() = default;
+    // [[Experimental]] Creates a MeshDevice that operates on a specific MetalEnv instance.
+    explicit MeshDevice(MetalEnv& metal_env);
 
     std::unique_ptr<MeshDeviceImpl> pimpl_;
 

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -78,7 +78,8 @@ class MeshDevice : public IDevice, public std::enable_shared_from_this<MeshDevic
 
 private:
     MeshDevice() = default;
-    // [[Experimental]] Creates a MeshDevice that operates on a specific MetalEnv instance.
+    // [[Experimental]] Creates a MeshDevice that uses the given MetalEnv instance.
+    // This is used by MetalEnv::create_mesh_device and MetalEnv::create_unit_mesh_device.
     explicit MeshDevice(MetalEnv& metal_env);
 
     std::unique_ptr<MeshDeviceImpl> pimpl_;

--- a/tt_metal/api/tt-metalium/sub_device.hpp
+++ b/tt_metal/api/tt-metalium/sub_device.hpp
@@ -11,6 +11,7 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/hal_types.hpp>
 #include <tt_stl/span.hpp>
+#include <tt-metalium/experimental/context/metal_env.hpp>
 
 namespace tt::tt_metal {
 
@@ -22,6 +23,9 @@ class SubDeviceImpl;
 class SubDevice {
 public:
     explicit SubDevice(tt::stl::Span<const CoreRangeSet> cores);
+    // Experimental API for creating a SubDevice which will use the given MetalEnv. May be removed or changed in the
+    // future.
+    explicit SubDevice(tt::tt_metal::MetalEnv& env, tt::stl::Span<const CoreRangeSet> cores);
     // Internal constructor (internal use only)
     SubDevice(SubDeviceImpl&& impl);
 

--- a/tt_metal/api/tt-metalium/sub_device.hpp
+++ b/tt_metal/api/tt-metalium/sub_device.hpp
@@ -23,7 +23,7 @@ class MetalEnv;
 class SubDevice {
 public:
     explicit SubDevice(tt::stl::Span<const CoreRangeSet> cores);
-    // [[Experimental]] Creates a SubDevice which will use the given MetalEnv
+    // [[Experimental]] Creates a SubDevice that uses the given MetalEnv instance.
     explicit SubDevice(tt::tt_metal::MetalEnv& env, tt::stl::Span<const CoreRangeSet> cores);
     // Internal constructor (internal use only)
     SubDevice(SubDeviceImpl&& impl);

--- a/tt_metal/api/tt-metalium/sub_device.hpp
+++ b/tt_metal/api/tt-metalium/sub_device.hpp
@@ -16,15 +16,12 @@ namespace tt::tt_metal {
 
 // Forward declaration
 class SubDeviceImpl;
-class MetalEnv;
 
 // TODO(river): Revisit this class and either remove it or bring sub-device APIs over
 
 class SubDevice {
 public:
     explicit SubDevice(tt::stl::Span<const CoreRangeSet> cores);
-    // [[Experimental]] Creates a SubDevice that uses the given MetalEnv instance.
-    explicit SubDevice(tt::tt_metal::MetalEnv& env, tt::stl::Span<const CoreRangeSet> cores);
     // Internal constructor (internal use only)
     SubDevice(SubDeviceImpl&& impl);
 

--- a/tt_metal/api/tt-metalium/sub_device.hpp
+++ b/tt_metal/api/tt-metalium/sub_device.hpp
@@ -11,20 +11,19 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/hal_types.hpp>
 #include <tt_stl/span.hpp>
-#include <tt-metalium/experimental/context/metal_env.hpp>
 
 namespace tt::tt_metal {
 
 // Forward declaration
 class SubDeviceImpl;
+class MetalEnv;
 
 // TODO(river): Revisit this class and either remove it or bring sub-device APIs over
 
 class SubDevice {
 public:
     explicit SubDevice(tt::stl::Span<const CoreRangeSet> cores);
-    // Experimental API for creating a SubDevice which will use the given MetalEnv. May be removed or changed in the
-    // future.
+    // [[Experimental]] Creates a SubDevice which will use the given MetalEnv
     explicit SubDevice(tt::tt_metal::MetalEnv& env, tt::stl::Span<const CoreRangeSet> cores);
     // Internal constructor (internal use only)
     SubDevice(SubDeviceImpl&& impl);

--- a/tt_metal/common/thread_pool.cpp
+++ b/tt_metal/common/thread_pool.cpp
@@ -13,6 +13,7 @@
 #include <numa.h>
 #include <tt-metalium/device.hpp>
 #include "impl/context/metal_context.hpp"
+#include "impl/context/context_types.hpp"
 #include "tt_metal/common/thread_pool.hpp"
 #include "tt_metal/llrt/tt_cluster.hpp"
 
@@ -31,12 +32,13 @@ std::unordered_map<int, std::vector<uint32_t>> get_cpu_cores_per_numa_node() {
     return cpu_cores_per_numa_node;
 }
 
-bool balanced_physical_device_numa() {
+bool balanced_physical_device_numa(ContextId context_id) {
     if (numa_available() != -1) {
         int num_nodes = numa_max_node() + 1;
         std::unordered_set<int> numa_nodes_for_cluster = {};
-        for (auto device_id : MetalContext::instance().get_cluster().user_exposed_chip_ids()) {
-            auto numa_node_for_device = MetalContext::instance().get_cluster().get_numa_node_for_device(device_id);
+        for (auto device_id : MetalContext::instance(context_id).get_cluster().user_exposed_chip_ids()) {
+            auto numa_node_for_device =
+                MetalContext::instance(context_id).get_cluster().get_numa_node_for_device(device_id);
             numa_nodes_for_cluster.insert(numa_node_for_device);
         }
         return numa_nodes_for_cluster.size() == num_nodes;
@@ -44,20 +46,28 @@ bool balanced_physical_device_numa() {
     return false;
 }
 
-uint32_t get_cpu_core_for_physical_device(uint32_t physical_device_id) {
+uint32_t get_cpu_core_for_physical_device(ContextId context_id, uint32_t physical_device_id) {
     static std::unordered_map<int, std::vector<uint32_t>> cpu_cores_per_numa_node = get_cpu_cores_per_numa_node();
     static std::unordered_map<int, int> logical_cpu_id_per_numa_node = {};
     // Initialize to an invalid value. Determine the NUMA Node based on the physical device id.
     // If a NUMA Node is not found, use a round robin policy.
     int numa_node = -1;
-    if (physical_device_id < MetalContext::instance().get_cluster().number_of_devices() &&
-        !tt::tt_metal::MetalContext::instance().rtoptions().get_simulator_enabled()) {
+    if (physical_device_id < MetalContext::instance(context_id).get_cluster().number_of_devices() &&
+        !tt::tt_metal::MetalContext::instance(context_id).rtoptions().get_simulator_enabled()) {
         // If the cluster uses all NUMA nodes, assign worker threads to CPU cores based
         // on the NUMA layout. If not, balance the worker threads across all NUMA Nodes/
         // CPU cores to minimize resource contention.
-        static bool devices_balanced_across_numa_nodes = balanced_physical_device_numa();
-        numa_node = devices_balanced_across_numa_nodes
-                        ? MetalContext::instance().get_cluster().get_numa_node_for_device(physical_device_id)
+        static std::unordered_map<uint64_t, bool> balanced_cache;
+        auto& cluster = MetalContext::instance(context_id).get_cluster();
+        uint64_t cache_key = static_cast<uint64_t>(cluster.arch()) |
+                             (static_cast<uint64_t>(cluster.get_target_device_type()) << 8) |
+                             (static_cast<uint64_t>(cluster.number_of_devices()) << 16);
+        auto [it, inserted] = balanced_cache.try_emplace(cache_key, false);
+        if (inserted) {
+            it->second = balanced_physical_device_numa(context_id);
+        }
+        numa_node = it->second
+                        ? MetalContext::instance(context_id).get_cluster().get_numa_node_for_device(physical_device_id)
                         : physical_device_id % 2;
     }
     if (cpu_cores_per_numa_node.contains(numa_node)) {
@@ -174,7 +184,7 @@ private:
 // across threads.
 class NumaAwareExecutor {
 public:
-    NumaAwareExecutor(uint32_t physical_device_id) {
+    NumaAwareExecutor(ContextId context_id, uint32_t physical_device_id) {
         // Set the priority for this process to 0 (niceness value in linux)
         thread_binding::set_process_priority(0);
         worker = std::thread([this]() {
@@ -215,7 +225,7 @@ public:
             }
         });
 
-        auto cpu_core_for_worker = thread_binding::get_cpu_core_for_physical_device(physical_device_id);
+        auto cpu_core_for_worker = thread_binding::get_cpu_core_for_physical_device(context_id, physical_device_id);
         thread_binding::set_worker_affinity(worker, cpu_core_for_worker);
     }
 
@@ -281,21 +291,22 @@ class DeviceBoundThreadPool : public ThreadPool {
 public:
     // Constructor accepting the physical device IDs this pool is bound to. Each thread will be tied to a device, and is
     // guaranteed to be bound to a CPU core on a NUMA Node "closest" to that device.
-    DeviceBoundThreadPool(const std::vector<tt::tt_metal::IDevice*>& physical_devices) :
+    // All physical devices must belong to the same context ID.
+    DeviceBoundThreadPool(ContextId context_id, const std::vector<tt::tt_metal::IDevice*>& physical_devices) :
         num_workers_(physical_devices.size()) {
         workers_.reserve(num_workers_);
         for (uint32_t i = 0; i < num_workers_; i++) {
-            workers_.emplace_back(std::make_unique<NumaAwareExecutor>(physical_devices[i]->id()));
+            workers_.emplace_back(std::make_unique<NumaAwareExecutor>(context_id, physical_devices[i]->id()));
             phys_device_to_thread_id_[physical_devices[i]->id()] = i;
         }
     }
     // Constructor accepting the number of threads to spawn. The threads in this pool will be bound to a specific CPU
     // core but they are not guaranteed to be "close" to any physical device.
-    DeviceBoundThreadPool(uint32_t thread_count) : num_workers_(thread_count) {
+    DeviceBoundThreadPool(ContextId context_id, uint32_t thread_count) : num_workers_(thread_count) {
         workers_.reserve(thread_count);
 
         for (uint32_t i = 0; i < thread_count; i++) {
-            workers_.emplace_back(std::make_unique<NumaAwareExecutor>(i));
+            workers_.emplace_back(std::make_unique<NumaAwareExecutor>(context_id, i));
             phys_device_to_thread_id_[i] = i;
         }
     }
@@ -349,16 +360,16 @@ public:
 
 }  // namespace thread_pool_impls
 
-std::shared_ptr<ThreadPool> create_device_bound_thread_pool(int num_threads) {
-    return std::make_shared<thread_pool_impls::DeviceBoundThreadPool>(num_threads);
+std::shared_ptr<ThreadPool> create_device_bound_thread_pool(ContextId context_id, int num_threads) {
+    return std::make_shared<thread_pool_impls::DeviceBoundThreadPool>(context_id, num_threads);
 }
 
 std::shared_ptr<ThreadPool> create_device_bound_thread_pool(
-    const std::vector<tt::tt_metal::IDevice*>& physical_devices) {
-    return std::make_shared<thread_pool_impls::DeviceBoundThreadPool>(physical_devices);
+    ContextId context_id, const std::vector<tt::tt_metal::IDevice*>& physical_devices) {
+    return std::make_shared<thread_pool_impls::DeviceBoundThreadPool>(context_id, physical_devices);
 }
 
-std::shared_ptr<ThreadPool> create_passthrough_thread_pool() {
+std::shared_ptr<ThreadPool> create_passthrough_thread_pool(ContextId /*context_id*/) {
     return std::make_shared<thread_pool_impls::PassThroughThreadPool>();
 }
 

--- a/tt_metal/common/thread_pool.hpp
+++ b/tt_metal/common/thread_pool.hpp
@@ -9,6 +9,9 @@
 #include <optional>
 #include <thread>
 #include <vector>
+
+#include "impl/context/context_types.hpp"
+
 namespace tt::tt_metal {
 
 class IDevice;
@@ -27,10 +30,11 @@ public:
 
 // API accespting the number of threads to spawn in the pool. Will bind each thread to a CPU core, but the
 // binding strategy will not be NUMA aware. Used for testing and benchmarking host-code.
-std::shared_ptr<ThreadPool> create_device_bound_thread_pool(int num_threads);
+std::shared_ptr<ThreadPool> create_device_bound_thread_pool(ContextId context_id, int num_threads);
 // API accepting the physical devices the pool will be bound to. The threads will be bound to CPU cores in a
 // NUMA aware manner (will be "closest" to the device it serves). Used for production data-paths.
+// All physical devices must belong to the same context ID.
 std::shared_ptr<ThreadPool> create_device_bound_thread_pool(
-    const std::vector<tt::tt_metal::IDevice*>& physical_devices);
-std::shared_ptr<ThreadPool> create_passthrough_thread_pool();
+    ContextId context_id, const std::vector<tt::tt_metal::IDevice*>& physical_devices);
+std::shared_ptr<ThreadPool> create_passthrough_thread_pool(ContextId context_id);
 }  // namespace tt::tt_metal

--- a/tt_metal/distributed/dispatch_context.cpp
+++ b/tt_metal/distributed/dispatch_context.cpp
@@ -6,6 +6,7 @@
 #include <tt-metalium/experimental/dispatch_context.hpp>
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/distributed_context.hpp>
+#include "impl/context/context_types.hpp"
 #include "mesh_device_impl.hpp"
 #include "mesh_command_queue.hpp"
 #include "fd_mesh_command_queue.hpp"
@@ -37,8 +38,9 @@ void DispatchContext::initialize_fast_dispatch(distributed::MeshDevice* mesh_dev
         return;
     }
 
-    fast_dispatch_enabled_ = MetalContext::instance().rtoptions().get_fast_dispatch();
-    const auto& cluster = MetalContext::instance().get_cluster();
+    ContextId context_id = extract_context_id(mesh_device);
+    fast_dispatch_enabled_ = MetalContext::instance(context_id).rtoptions().get_fast_dispatch();
+    const auto& cluster = MetalContext::instance(context_id).get_cluster();
     TT_FATAL(
         !fast_dispatch_enabled_,
         "Fast Dispatch can only be manually enabled when running the workload with Slow Dispatch mode.");
@@ -47,13 +49,13 @@ void DispatchContext::initialize_fast_dispatch(distributed::MeshDevice* mesh_dev
         cluster.is_ubb_galaxy() || cluster.arch() == tt::ARCH::BLACKHOLE,
         "Manually setting up and tearing down Fast Dispatch is only supported on Galaxy and Blackhole clusters.");
 
-    const auto& device_manager = MetalContext::instance().device_manager();
+    const auto& device_manager = MetalContext::instance(context_id).device_manager();
     const auto& active_devices = device_manager->get_all_active_devices();
 
     uint8_t num_hw_cqs = active_devices[0]->num_hw_cqs();
 
     // Enable Fast Dispatch and reinitialize dispatch managers to pick up FD core descriptor before allocating cores
-    MetalContext::instance().set_fast_dispatch_mode(true);
+    MetalContext::instance(context_id).set_fast_dispatch_mode(true);
 
     for (const auto& dev : active_devices) {
         TT_FATAL(dev->num_hw_cqs() == num_hw_cqs, "All devices must have the same number of command queues.");
@@ -92,7 +94,8 @@ void DispatchContext::terminate_fast_dispatch(distributed::MeshDevice* mesh_devi
     TT_FATAL(fast_dispatch_enabled_, "Can only manually terminate fast dispatch after initializing it.");
     TT_FATAL(num_fd_inits_ == 1, "Fast Dispatch can only be manually terminated and torn down once.");
 
-    const auto& device_manager = MetalContext::instance().device_manager();
+    ContextId context_id = extract_context_id(mesh_device);
+    const auto& device_manager = MetalContext::instance(context_id).device_manager();
     const auto& active_devices = device_manager->get_all_active_devices();
 
     uint8_t num_hw_cqs = active_devices[0]->num_hw_cqs();
@@ -121,7 +124,7 @@ void DispatchContext::terminate_fast_dispatch(distributed::MeshDevice* mesh_devi
     fast_dispatch_enabled_ = false;
 
     // Disable Fast Dispatch and reinitialize dispatch managers to pick up SD core descriptor
-    MetalContext::instance().set_fast_dispatch_mode(false);
+    MetalContext::instance(context_id).set_fast_dispatch_mode(false);
 }
 
 void DispatchContext::enable_asynchronous_slow_dispatch(distributed::MeshDevice* mesh_device) {

--- a/tt_metal/distributed/dummy_mesh_command_queue.cpp
+++ b/tt_metal/distributed/dummy_mesh_command_queue.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "dummy_mesh_command_queue.hpp"
+#include <distributed/mesh_device_impl.hpp>
 #include "tt_metal/common/thread_pool.hpp"
 #include <mesh_device.hpp>
 #include <mesh_event.hpp>
@@ -12,7 +13,11 @@ namespace tt::tt_metal::distributed {
 
 DummyMeshCommandQueue::DummyMeshCommandQueue(
     MeshDevice* mesh_device, uint32_t id, std::function<std::lock_guard<std::mutex>()> lock_api_function) :
-    MeshCommandQueueBase(mesh_device, id, create_passthrough_thread_pool(), std::move(lock_api_function)) {}
+    MeshCommandQueueBase(
+        mesh_device,
+        id,
+        create_passthrough_thread_pool(mesh_device->impl().get_context_id()),
+        std::move(lock_api_function)) {}
 
 std::optional<MeshTraceId> DummyMeshCommandQueue::trace_id() const { return std::nullopt; }
 

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -110,10 +110,15 @@ FDMeshCommandQueue::FDMeshCommandQueue(
     std::shared_ptr<distributed::multihost::DistributedContext> distributed_context) :
     MeshCommandQueueBase(mesh_device, id, dispatch_thread_pool, std::move(lock_api_function)),
     cq_shared_state_(cq_shared_state),
-    dispatch_core_type_(MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type()),
+    dispatch_core_type_(MetalContext::instance(mesh_device->impl().get_context_id())
+                            .get_dispatch_core_manager()
+                            .get_dispatch_core_type()),
     reader_thread_pool_(reader_thread_pool),
-    prefetcher_dram_aligned_block_size_(MetalContext::instance().hal().get_alignment(HalMemType::DRAM)),
-    prefetcher_cache_sizeB_(MetalContext::instance().dispatch_mem_map(this->dispatch_core_type_).ringbuffer_size()),
+    prefetcher_dram_aligned_block_size_(
+        MetalContext::instance(mesh_device->impl().get_context_id()).hal().get_alignment(HalMemType::DRAM)),
+    prefetcher_cache_sizeB_(MetalContext::instance(mesh_device->impl().get_context_id())
+                                .dispatch_mem_map(this->dispatch_core_type_)
+                                .ringbuffer_size()),
     prefetcher_dram_aligned_num_blocks_(prefetcher_cache_sizeB_ / prefetcher_dram_aligned_block_size_),
     prefetcher_cache_manager_size_(
         1 << (std::bit_width(std::min(1024u, std::max(2u, prefetcher_dram_aligned_num_blocks_ >> 4))) - 1)),
@@ -123,6 +128,7 @@ FDMeshCommandQueue::FDMeshCommandQueue(
         prefetcher_dram_aligned_block_size_, prefetcher_dram_aligned_num_blocks_, prefetcher_cache_manager_size_)),
     active_distributed_context_(std::move(distributed_context)) {
     program_dispatch::reset_config_buf_mgrs_and_expected_workers(
+        MetalContext::instance(mesh_device_->impl().get_context_id()).hal(),
         config_buffer_mgr_,
         expected_num_workers_completed_,
         DispatchSettings::DISPATCH_MESSAGE_ENTRIES,
@@ -134,8 +140,7 @@ FDMeshCommandQueue::FDMeshCommandQueue(
 
 FDMeshCommandQueue::~FDMeshCommandQueue() {
     // Mock devices don't have actual completion queues, skip validation
-    bool is_mock =
-        tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock;
+    bool is_mock = this->get_target_device_type() == tt::TargetDevice::Mock;
 
     if (in_use_ && !thread_exception_state_.load(std::memory_order_acquire)) {
         // If the FDMeshCommandQueue is being used, have it clear worker state
@@ -195,7 +200,7 @@ void FDMeshCommandQueue::populate_read_descriptor_queue() {
 }
 
 void FDMeshCommandQueue::populate_virtual_program_dispatch_core() {
-    if (tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock) {
+    if (this->get_target_device_type() == tt::TargetDevice::Mock) {
         this->dispatch_core_ = CoreCoord{0, 0};
         return;
     }
@@ -218,7 +223,7 @@ CoreCoord FDMeshCommandQueue::virtual_program_dispatch_core() const { return thi
 CoreType FDMeshCommandQueue::dispatch_core_type() const { return this->dispatch_core_type_; }
 
 void FDMeshCommandQueue::clear_expected_num_workers_completed() {
-    if (tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock) {
+    if (this->get_target_device_type() == tt::TargetDevice::Mock) {
         return;
     }
 
@@ -264,7 +269,9 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
     SubDeviceId sub_device_id = *(sub_device_ids.begin());
     auto mesh_device_id = mesh_device_->id();
     auto& sysmem_manager = this->reference_sysmem_manager();
-    auto dispatch_core_config = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
+    auto dispatch_core_config = MetalContext::instance(this->device()->impl().get_context_id())
+                                    .get_dispatch_core_manager()
+                                    .get_dispatch_core_config();
     CoreType dispatch_core_type = get_core_type_from_config(dispatch_core_config);
     if (!sysmem_manager.get_bypass_mode()) {
         auto& sub_device_cq_owner = cq_shared_state_->sub_device_cq_owner;
@@ -497,7 +504,7 @@ void FDMeshCommandQueue::enqueue_read_shard_from_core(
     ZoneScoped;
     auto lock = lock_api_function_();
 
-    if (tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock) {
+    if (this->get_target_device_type() == tt::TargetDevice::Mock) {
         return;
     }
 
@@ -536,7 +543,7 @@ void FDMeshCommandQueue::enqueue_read_shard_from_core(
 void FDMeshCommandQueue::finish_nolock(tt::stl::Span<const SubDeviceId> sub_device_ids) {
     ZoneScopedN("FDMeshCommandQueue::finish_nolock");
 
-    if (tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock) {
+    if (this->get_target_device_type() == tt::TargetDevice::Mock) {
         return;
     }
 
@@ -578,7 +585,7 @@ bool FDMeshCommandQueue::write_shard_to_device(
     const std::optional<BufferRegion>& region,
     tt::stl::Span<const SubDeviceId> sub_device_ids,
     std::shared_ptr<experimental::PinnedMemory> pinned_memory) {
-    if (tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock) {
+    if (this->get_target_device_type() == tt::TargetDevice::Mock) {
         return false;
     }
     if (!mesh_device_->impl().is_local(device_coord)) {
@@ -709,7 +716,7 @@ MeshEvent FDMeshCommandQueue::enqueue_record_event_helper(
     tt::stl::Span<const SubDeviceId> sub_device_ids,
     bool notify_host,
     const std::optional<MeshCoordinateRange>& device_range) {
-    if (tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock) {
+    if (this->get_target_device_type() == tt::TargetDevice::Mock) {
         // Return a dummy event for mock devices
         return MeshEvent(0, mesh_device_, id_, device_range.value_or(MeshCoordinateRange(mesh_device_->shape())));
     }
@@ -794,7 +801,7 @@ void FDMeshCommandQueue::enqueue_wait_for_event(const MeshEvent& sync_event) {
 }
 
 void FDMeshCommandQueue::read_completion_queue() {
-    if (tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock) {
+    if (this->get_target_device_type() == tt::TargetDevice::Mock) {
         return;
     }
 
@@ -859,10 +866,11 @@ MultiProducerSingleConsumerQueue<CompletionReaderVariant>& FDMeshCommandQueue::g
 void FDMeshCommandQueue::copy_buffer_data_to_user_space(MeshBufferReadDescriptor& read_buffer_descriptor) {
     auto reader_lambda = [this](IDevice* device, uint32_t num_reads) {
         auto& read_descriptor_queue = this->get_read_descriptor_queue(device);
+        const auto cid = this->mesh_device_->impl().get_context_id();
         ChipId mmio_device_id =
-            tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device->id());
+            tt::tt_metal::MetalContext::instance(cid).get_cluster().get_associated_mmio_device(device->id());
         uint16_t channel =
-            tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device->id());
+            tt::tt_metal::MetalContext::instance(cid).get_cluster().get_assigned_channel_for_device(device->id());
 
         for (int i = 0; i < num_reads; i++) {
             buffer_dispatch::copy_completion_queue_data_into_user_space(
@@ -899,10 +907,12 @@ void FDMeshCommandQueue::read_completion_queue_event(MeshReadEventDescriptor& re
     auto& device_range = read_event_descriptor.device_range;
     for_each_local(mesh_device_, device_range, [&](const auto& coord) {
         auto device = mesh_device_->impl().get_device(coord);
-        ChipId mmio_device_id =
-            tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device->id());
-        uint16_t channel =
-            tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device->id());
+        ChipId mmio_device_id = tt::tt_metal::MetalContext::instance(mesh_device_->impl().get_context_id())
+                                    .get_cluster()
+                                    .get_associated_mmio_device(device->id());
+        uint16_t channel = tt::tt_metal::MetalContext::instance(mesh_device_->impl().get_context_id())
+                               .get_cluster()
+                               .get_assigned_channel_for_device(device->id());
         device->sysmem_manager().completion_queue_wait_front(id_, exit_condition_);
 
         event_dispatch::read_events_from_completion_queue(
@@ -920,10 +930,11 @@ void FDMeshCommandQueue::read_l1_data_from_completion_queue(MeshCoreDataReadDesc
         return;
     }
     IDevice* device = mesh_device_->impl().get_device(read_l1_data_descriptor.device_coord);
+    const auto cid = mesh_device_->impl().get_context_id();
     const ChipId mmio_device_id =
-        tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device->id());
+        tt::tt_metal::MetalContext::instance(cid).get_cluster().get_associated_mmio_device(device->id());
     const uint16_t channel =
-        tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device->id());
+        tt::tt_metal::MetalContext::instance(cid).get_cluster().get_assigned_channel_for_device(device->id());
     device_dispatch::read_core_data_from_completion_queue(
         read_l1_data_descriptor.single_core_descriptor,
         mmio_device_id,
@@ -961,6 +972,7 @@ void FDMeshCommandQueue::reset_worker_state(
         }
     }
     program_dispatch::reset_config_buf_mgrs_and_expected_workers(
+        MetalContext::instance(mesh_device_->impl().get_context_id()).hal(),
         config_buffer_mgr_,
         expected_num_workers_completed_,
         mesh_device_->num_sub_devices(),
@@ -980,7 +992,9 @@ void FDMeshCommandQueue::write_program_cmds_to_subgrid(
     bool stall_before_program,
     std::unordered_set<uint32_t>& chip_ids_in_workload,
     uint32_t program_runtime_id) {
-    auto dispatch_core_config = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
+    auto dispatch_core_config = MetalContext::instance(mesh_device_->impl().get_context_id())
+                                    .get_dispatch_core_manager()
+                                    .get_dispatch_core_config();
     CoreType dispatch_core_type = get_core_type_from_config(dispatch_core_config);
     for_each_local(mesh_device_, sub_grid, [&](const auto& coord) {
         auto device = mesh_device_->impl().get_device(coord);
@@ -1020,10 +1034,14 @@ void FDMeshCommandQueue::capture_program_trace_on_subgrid(
     bool stall_first,
     bool stall_before_program,
     uint32_t program_runtime_id) {
-    auto dispatch_core_config = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
+    auto dispatch_core_config = MetalContext::instance(mesh_device_->impl().get_context_id())
+                                    .get_dispatch_core_manager()
+                                    .get_dispatch_core_config();
     CoreType dispatch_core_type = get_core_type_from_config(dispatch_core_config);
 
-    if (tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_enabled()) {
+    if (tt::tt_metal::MetalContext::instance(mesh_device_->impl().get_context_id())
+            .rtoptions()
+            .get_profiler_enabled()) {
         // Host Memory Intensive Path (when profiler is enabled): The launch messages across devices are unique, since
         // the host_assigned_field in the launch_msg contains the physical device id (required by the performance
         // profiler). Hence the trace per device must be uniquely captured.
@@ -1202,7 +1220,9 @@ SystemMemoryManager& FDMeshCommandQueue::reference_sysmem_manager() {
 
 void FDMeshCommandQueue::update_launch_messages_for_device_profiler(
     ProgramCommandSequence& program_cmd_seq, uint32_t program_runtime_id, IDevice* device) {
-    if (tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_enabled()) {
+    if (tt::tt_metal::MetalContext::instance(mesh_device_->impl().get_context_id())
+            .rtoptions()
+            .get_profiler_enabled()) {
         for (auto& [is_multicast, original_launch_msg, launch_msg] : program_cmd_seq.launch_messages) {
             launch_msg.kernel_config().host_assigned_id() =
                 tt_metal::detail::EncodePerDeviceProgramID(program_runtime_id, device->id());
@@ -1270,6 +1290,7 @@ void FDMeshCommandQueue::wait_for_completion(bool reset_launch_msg_state) {
                 reset_launch_msg_state);
         }
         program_dispatch::reset_config_buf_mgrs_and_expected_workers(
+            MetalContext::instance(mesh_device_->impl().get_context_id()).hal(),
             config_buffer_mgr_,
             expected_num_workers_completed_,
             mesh_device_->num_sub_devices(),

--- a/tt_metal/distributed/mesh_command_queue_base.cpp
+++ b/tt_metal/distributed/mesh_command_queue_base.cpp
@@ -24,6 +24,12 @@
 
 namespace tt::tt_metal::distributed {
 
+tt::TargetDevice MeshCommandQueueBase::get_target_device_type() const {
+    return tt::tt_metal::MetalContext::instance(this->device()->impl().get_context_id())
+        .get_cluster()
+        .get_target_device_type();
+}
+
 void MeshCommandQueueBase::write_sharded_buffer(const MeshBuffer& buffer, const void* src) {
     auto global_buffer_shape = buffer.global_shard_spec().global_buffer_shape;
 

--- a/tt_metal/distributed/mesh_command_queue_base.hpp
+++ b/tt_metal/distributed/mesh_command_queue_base.hpp
@@ -7,6 +7,7 @@
 #include "mesh_command_queue.hpp"
 
 #include "tt_metal/common/thread_pool.hpp"
+#include "tt_target_device.hpp"
 
 #include <mutex>
 #include <functional>
@@ -42,6 +43,8 @@ protected:
     virtual MeshEvent enqueue_record_event_to_host_nolock(
         tt::stl::Span<const SubDeviceId> sub_device_ids = {},
         const std::optional<MeshCoordinateRange>& device_range = std::nullopt) = 0;
+
+    tt::TargetDevice get_target_device_type() const;
 
 private:
     // Helper functions for read and write entire Sharded-MeshBuffers

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -55,11 +55,13 @@
 #include "sub_device/sub_device_manager_tracker.hpp"
 #include <umd/device/types/xy_pair.hpp>
 #include "context/metal_context.hpp"
+#include <experimental/context/metal_env.hpp>
 #include "dispatch/system_memory_manager.hpp"
 #include <llrt/tt_cluster.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 #include "mesh_device_view_impl.hpp"
 #include "dummy_mesh_command_queue.hpp"
+#include "impl/context/metal_env_accessor.hpp"
 
 namespace tt::tt_metal {
 class SystemMemoryManager;
@@ -67,6 +69,20 @@ class SystemMemoryManager;
 namespace program_cache::detail {
 struct ProgramCache;
 }  // namespace program_cache::detail
+
+namespace experimental {
+std::map<ChipId, IDevice*> CreateDevices(
+    ContextId context_id,
+    const std::vector<ChipId>& device_ids,
+    uint8_t num_hw_cqs,
+    size_t l1_small_size,
+    size_t trace_region_size,
+    const DispatchCoreConfig& dispatch_core_config,
+    const std::vector<uint32_t>& l1_bank_remap,
+    size_t worker_l1_size,
+    bool init_profiler,
+    bool initialize_fabric_and_dispatch_fw);
+}  // namespace experimental
 
 }  // namespace tt::tt_metal
 
@@ -78,12 +94,14 @@ int generate_unique_mesh_id() {
     return next_id++;
 }
 
-std::shared_ptr<ThreadPool> create_default_thread_pool(const std::vector<IDevice*>& physical_devices) {
+// All physical devices must belong to the same context ID.
+std::shared_ptr<ThreadPool> create_default_thread_pool(
+    ContextId context_id, const std::vector<IDevice*>& physical_devices) {
     // Bind the thread-pool to the physical devices being used.
     if (tt::parse_env("TT_MESH_PASS_THROUGH_THREAD_POOL", false) || physical_devices.size() == 1) {
-        return create_passthrough_thread_pool();
+        return create_passthrough_thread_pool(context_id);
     }
-    return create_device_bound_thread_pool(physical_devices);
+    return create_device_bound_thread_pool(context_id, physical_devices);
 }
 
 // Helper function to verify all devices in the MeshDevice have the same value
@@ -139,9 +157,12 @@ MeshDeviceImpl::ScopedDevices::ScopedDevices(
     size_t trace_region_size,
     size_t num_command_queues,
     size_t worker_l1_size,
-    const DispatchCoreConfig& dispatch_core_config) {
+    const DispatchCoreConfig& dispatch_core_config,
+    ContextId context_id) :
+    context_id_(context_id) {
     auto local_devices = extract_locals(all_device_ids);
-    opened_local_devices_ = tt_metal::detail::CreateDevices(
+    opened_local_devices_ = tt_metal::experimental::CreateDevices(
+        context_id,
         local_devices,
         num_command_queues,
         l1_small_size,
@@ -150,7 +171,6 @@ MeshDeviceImpl::ScopedDevices::ScopedDevices(
         {},
         worker_l1_size,
         /* init_profiler */ false,
-        /* ignored */ true,
         /* initialize_fabric_and_dispatch_fw */ false);
 
     for (auto device_id : active_device_ids) {
@@ -173,8 +193,9 @@ MeshDeviceImpl::ScopedDevices::~ScopedDevices() {
         // Catch any exceptions during device close - destructors must not throw.
         // This can happen when a device is hung and times out during close.
         try {
-            tt_metal::MetalContext::instance().device_manager()->close_devices(
-                devices_to_close, /*skip_synchronize=*/true);
+            tt_metal::MetalContext::instance(context_id_)
+                .device_manager()
+                ->close_devices(devices_to_close, /*skip_synchronize=*/true);
         } catch (const std::exception& e) {
             log_warning(
                 LogMetal,
@@ -237,17 +258,19 @@ void MeshDeviceImpl::mark_allocations_safe() { this->allocator_impl()->mark_allo
 MeshDeviceImpl::MeshDeviceImpl(
     std::shared_ptr<ScopedDevices> mesh_handle,
     std::unique_ptr<MeshDeviceView> mesh_device_view,
-    std::shared_ptr<MeshDevice> parent_mesh) :
+    std::shared_ptr<MeshDevice> parent_mesh,
+    ContextId context_id) :
+    context_id_(context_id),
     scoped_devices_(std::move(mesh_handle)),
     mesh_id_(generate_unique_mesh_id()),
     view_(std::move(mesh_device_view)),
     parent_mesh_(std::move(parent_mesh)),
-    dispatch_thread_pool_(create_default_thread_pool(extract_locals(scoped_devices_->root_devices()))),
-    reader_thread_pool_(create_default_thread_pool(extract_locals(scoped_devices_->root_devices()))),
+    dispatch_thread_pool_(create_default_thread_pool(context_id_, extract_locals(scoped_devices_->root_devices()))),
+    reader_thread_pool_(create_default_thread_pool(context_id_, extract_locals(scoped_devices_->root_devices()))),
     program_cache_(std::make_unique<program_cache::detail::ProgramCache>()) {
     Inspector::mesh_device_created(this, parent_mesh_ ? std::make_optional(parent_mesh_->id()) : std::nullopt);
     const auto& mpi_context =
-        tt::tt_metal::MetalContext::instance().get_control_plane().get_distributed_context(view_->mesh_id());
+        tt::tt_metal::MetalContext::instance(context_id_).get_control_plane().get_distributed_context(view_->mesh_id());
     distributed_context_ =
         mpi_context->split(distributed::multihost::Color(id()), distributed::multihost::Key(*mpi_context->rank()));
 }
@@ -278,12 +301,32 @@ std::shared_ptr<MeshDevice> MeshDeviceImpl::create(
     const DispatchCoreConfig& dispatch_core_config,
     tt::stl::Span<const std::uint32_t> l1_bank_remap,
     size_t worker_l1_size) {
-    const auto& mesh_graph = MetalContext::instance().get_control_plane().get_mesh_graph();
+    return create(
+        DEFAULT_CONTEXT_ID,
+        config,
+        l1_small_size,
+        trace_region_size,
+        num_command_queues,
+        dispatch_core_config,
+        l1_bank_remap,
+        worker_l1_size);
+}
+
+std::shared_ptr<MeshDevice> MeshDeviceImpl::create(
+    ContextId context_id,
+    const MeshDeviceConfig& config,
+    size_t l1_small_size,
+    size_t trace_region_size,
+    size_t num_command_queues,
+    const DispatchCoreConfig& dispatch_core_config,
+    tt::stl::Span<const std::uint32_t> l1_bank_remap,
+    size_t worker_l1_size) {
+    auto& ctx = MetalContext::instance(context_id);
+    const auto& mesh_graph = ctx.get_control_plane().get_mesh_graph();
     auto [scoped_devices, fabric_node_ids, mesh_shape] =
         [&]() -> std::tuple<std::shared_ptr<ScopedDevices>, std::vector<tt::tt_fabric::FabricNodeId>, MeshShape> {
         if (config.physical_device_ids().empty()) {
-            auto mapped_devices =
-                MetalContext::instance().get_system_mesh().get_mapped_devices(config.mesh_shape(), config.offset());
+            auto mapped_devices = ctx.get_system_mesh().get_mapped_devices(config.mesh_shape(), config.offset());
             // Validate that none of the fabric node IDs are on switch meshes
             for (const auto& fabric_node_id : mapped_devices.fabric_node_ids) {
                 TT_FATAL(
@@ -294,8 +337,8 @@ std::shared_ptr<MeshDevice> MeshDeviceImpl::create(
                     *fabric_node_id.mesh_id);
             }
             auto mapped_devices_full_system_device_ids =
-                (*MetalContext::instance().global_distributed_context().size() > 1)
-                    ? MetalContext::instance().get_system_mesh().get_mapped_devices(std::nullopt).device_ids
+                (*ctx.global_distributed_context().size() > 1)
+                    ? ctx.get_system_mesh().get_mapped_devices(std::nullopt).device_ids
                     : mapped_devices.device_ids;
             return std::make_tuple(
                 std::make_shared<MeshDeviceImpl::ScopedDevices>(
@@ -305,7 +348,8 @@ std::shared_ptr<MeshDevice> MeshDeviceImpl::create(
                     trace_region_size,
                     num_command_queues,
                     worker_l1_size,
-                    dispatch_core_config),
+                    dispatch_core_config,
+                    context_id),
                 mapped_devices.fabric_node_ids,
                 mapped_devices.mesh_shape);
         }  // Initialize fabric node ids manually.
@@ -314,8 +358,7 @@ std::shared_ptr<MeshDevice> MeshDeviceImpl::create(
         TT_FATAL(config.mesh_shape().has_value(), "Mesh shape must be provided when physical device ids are supplied");
         const auto& supplied_ids = config.physical_device_ids();
         for (int supplied_id : supplied_ids) {
-            auto fabric_node_id =
-                MetalContext::instance().get_control_plane().get_fabric_node_id_from_physical_chip_id(supplied_id);
+            auto fabric_node_id = ctx.get_control_plane().get_fabric_node_id_from_physical_chip_id(supplied_id);
             TT_FATAL(
                 !mesh_graph.is_switch_mesh(fabric_node_id.mesh_id),
                 "Cannot create devices on tt-switch meshes. Device {} maps to mesh_id {} which is a switch. "
@@ -325,8 +368,8 @@ std::shared_ptr<MeshDevice> MeshDeviceImpl::create(
             fabric_node_ids.push_back(fabric_node_id);
         }
         auto mapped_devices_full_system_device_ids =
-            (*MetalContext::instance().global_distributed_context().size() > 1)
-                ? MetalContext::instance().get_system_mesh().get_mapped_devices(std::nullopt).device_ids
+            (*ctx.global_distributed_context().size() > 1)
+                ? ctx.get_system_mesh().get_mapped_devices(std::nullopt).device_ids
                 : wrap_to_maybe_remote(supplied_ids);
         return std::make_tuple(
             std::make_shared<ScopedDevices>(
@@ -336,19 +379,20 @@ std::shared_ptr<MeshDevice> MeshDeviceImpl::create(
                 trace_region_size,
                 num_command_queues,
                 worker_l1_size,
-                dispatch_core_config),
+                dispatch_core_config,
+                context_id),
             fabric_node_ids,
             config.mesh_shape().value());
     }();
 
-    // Make a copy because we std::move the scoped_devices when creating MeshDeviceImpl
     const auto root_devices = scoped_devices->root_devices();
 
     auto mesh_device = std::shared_ptr<MeshDevice>(new MeshDevice());
     mesh_device->pimpl_ = std::make_unique<MeshDeviceImpl>(
         std::move(scoped_devices),
         std::make_unique<MeshDeviceView>(mesh_shape, root_devices, fabric_node_ids),
-        std::shared_ptr<MeshDevice>());
+        std::shared_ptr<MeshDevice>(),
+        context_id);
 
     mesh_device->initialize(num_command_queues, l1_small_size, trace_region_size, worker_l1_size, l1_bank_remap);
 
@@ -357,11 +401,10 @@ std::shared_ptr<MeshDevice> MeshDeviceImpl::create(
         dynamic_cast<Device*>(device)->set_mesh_device(mesh_device);
     }
 
-    // Wait for all ranks to finish initializing the mesh device before proceeding.
     mesh_device->pimpl_->distributed_context_->barrier();
 
-    tt_metal::MetalContext::instance().device_manager()->initialize_profiler();
-    tt_metal::MetalContext::instance().device_manager()->initialize_fabric_and_dispatch_fw();
+    ctx.device_manager()->initialize_profiler();
+    ctx.device_manager()->initialize_fabric_and_dispatch_fw();
     return mesh_device;
 }
 
@@ -393,18 +436,37 @@ std::map<int, std::shared_ptr<MeshDevice>> MeshDeviceImpl::create_unit_meshes(
     size_t trace_region_size,
     size_t num_command_queues,
     const DispatchCoreConfig& dispatch_core_config,
+    tt::stl::Span<const std::uint32_t> l1_bank_remap,
+    size_t worker_l1_size) {
+    return create_unit_meshes(
+        DEFAULT_CONTEXT_ID,
+        device_ids,
+        l1_small_size,
+        trace_region_size,
+        num_command_queues,
+        dispatch_core_config,
+        l1_bank_remap,
+        worker_l1_size);
+}
+
+std::map<int, std::shared_ptr<MeshDevice>> MeshDeviceImpl::create_unit_meshes(
+    ContextId context_id,
+    const std::vector<int>& device_ids,
+    size_t l1_small_size,
+    size_t trace_region_size,
+    size_t num_command_queues,
+    const DispatchCoreConfig& dispatch_core_config,
     tt::stl::Span<const std::uint32_t> /*l1_bank_remap*/,
     size_t worker_l1_size) {
     TT_FATAL(
         !device_ids.empty(), "Cannot create unit meshes with empty device_ids. At least one device ID is required.");
 
-    // Validate all devices are on compute meshes (not switches) before creating any resources
-    const auto& mesh_graph = MetalContext::instance().get_control_plane().get_mesh_graph();
+    auto& ctx = MetalContext::instance(context_id);
+    const auto& mesh_graph = ctx.get_control_plane().get_mesh_graph();
     std::vector<tt::tt_fabric::FabricNodeId> fabric_node_ids;
     fabric_node_ids.reserve(device_ids.size());
     for (const auto& device_id : device_ids) {
-        auto fabric_node_id =
-            MetalContext::instance().get_control_plane().get_fabric_node_id_from_physical_chip_id(device_id);
+        auto fabric_node_id = ctx.get_control_plane().get_fabric_node_id_from_physical_chip_id(device_id);
         TT_FATAL(
             !mesh_graph.is_switch_mesh(fabric_node_id.mesh_id),
             "Cannot create devices on tt-switch meshes. Device {} maps to mesh_id {} which is a switch. "
@@ -414,11 +476,9 @@ std::map<int, std::shared_ptr<MeshDevice>> MeshDeviceImpl::create_unit_meshes(
         fabric_node_ids.push_back(fabric_node_id);
     }
 
-    // Now create ScopedDevices after validation passes
-    auto mapped_devices_full_system_device_ids =
-        (*MetalContext::instance().global_distributed_context().size() > 1)
-            ? MetalContext::instance().get_system_mesh().get_mapped_devices(std::nullopt).device_ids
-            : wrap_to_maybe_remote(device_ids);
+    auto mapped_devices_full_system_device_ids = (*ctx.global_distributed_context().size() > 1)
+                                                     ? ctx.get_system_mesh().get_mapped_devices(std::nullopt).device_ids
+                                                     : wrap_to_maybe_remote(device_ids);
     auto scoped_devices = std::make_shared<MeshDeviceImpl::ScopedDevices>(
         mapped_devices_full_system_device_ids,
         wrap_to_maybe_remote(device_ids),
@@ -426,16 +486,17 @@ std::map<int, std::shared_ptr<MeshDevice>> MeshDeviceImpl::create_unit_meshes(
         trace_region_size,
         num_command_queues,
         worker_l1_size,
-        dispatch_core_config);
+        dispatch_core_config,
+        context_id);
 
-    // Make a copy because we std::move the scoped_devices when creating MeshDeviceImpl
     const auto root_devices = scoped_devices->root_devices();
 
     auto mesh_device = std::shared_ptr<MeshDevice>(new MeshDevice());
     mesh_device->pimpl_ = std::make_unique<MeshDeviceImpl>(
         std::move(scoped_devices),
         std::make_unique<MeshDeviceView>(MeshShape(1, device_ids.size()), root_devices, fabric_node_ids),
-        std::shared_ptr<MeshDevice>());
+        std::shared_ptr<MeshDevice>(),
+        context_id);
 
     auto submeshes = mesh_device->create_submeshes(MeshShape(1, 1));
     TT_FATAL(
@@ -448,11 +509,10 @@ std::map<int, std::shared_ptr<MeshDevice>> MeshDeviceImpl::create_unit_meshes(
         result[device_ids[i]] = submeshes[i];
     }
 
-    // Wait for all ranks to finish initializing the mesh device before proceeding.
     mesh_device->pimpl_->distributed_context_->barrier();
 
-    tt_metal::MetalContext::instance().device_manager()->initialize_profiler();
-    tt_metal::MetalContext::instance().device_manager()->initialize_fabric_and_dispatch_fw();
+    ctx.device_manager()->initialize_profiler();
+    ctx.device_manager()->initialize_fabric_and_dispatch_fw();
     return result;
 }
 
@@ -482,7 +542,28 @@ std::shared_ptr<MeshDevice> MeshDeviceImpl::create_unit_mesh(
     const DispatchCoreConfig& dispatch_core_config,
     tt::stl::Span<const std::uint32_t> l1_bank_remap,
     size_t worker_l1_size) {
+    return create_unit_mesh(
+        DEFAULT_CONTEXT_ID,
+        device_id,
+        l1_small_size,
+        trace_region_size,
+        num_command_queues,
+        dispatch_core_config,
+        l1_bank_remap,
+        worker_l1_size);
+}
+
+std::shared_ptr<MeshDevice> MeshDeviceImpl::create_unit_mesh(
+    ContextId context_id,
+    int device_id,
+    size_t l1_small_size,
+    size_t trace_region_size,
+    size_t num_command_queues,
+    const DispatchCoreConfig& dispatch_core_config,
+    tt::stl::Span<const std::uint32_t> l1_bank_remap,
+    size_t worker_l1_size) {
     return create_unit_meshes(
+               context_id,
                {device_id},
                l1_small_size,
                trace_region_size,
@@ -746,60 +827,70 @@ bool MeshDeviceImpl::close_impl(MeshDevice* pimpl_wrapper) {
     ZoneScoped;
 
     log_trace(tt::LogMetal, "Closing mesh device {}", this->id());
-    if (not is_initialized()) {
-        return true;
-    }
+    if (is_initialized()) {
+        if (MetalContext::instance(this->get_context_id()).get_cluster().get_target_device_type() !=
+            tt::TargetDevice::Mock) {
+            ReadMeshDeviceProfilerResults(*pimpl_wrapper, ProfilerReadState::LAST_FD_READ);
+        }
 
-    ReadMeshDeviceProfilerResults(*pimpl_wrapper, ProfilerReadState::LAST_FD_READ);
+        if (distributed_context_) {
+            // Wait for all ranks to be ready to close the mesh device before proceeding.
+            distributed_context_->barrier();
+        }
 
-    if (distributed_context_) {
-        // Wait for all ranks to be ready to close the mesh device before proceeding.
-        distributed_context_->barrier();
-    }
+        // TODO #20966: Remove these calls
+        for (auto* device : view_->get_devices()) {
+            dynamic_cast<Device*>(device)->set_mesh_device(parent_mesh_);
+        }
 
-    // TODO #20966: Remove these calls
-    for (auto* device : view_->get_devices()) {
-        dynamic_cast<Device*>(device)->set_mesh_device(parent_mesh_);
-    }
-
-    // Only one mesh device can use a CQ on a physical device at a time, or else teardown or some other operation will
-    // hang. Validate this.
-    for (uint32_t cq_id = 0; cq_id < mesh_command_queues_.size(); cq_id++) {
-        if (mesh_command_queues_[cq_id]->in_use()) {
-            auto parent_mesh = get_parent_mesh();
-            if (parent_mesh) {
-                auto parent_mesh_id = parent_mesh->impl().get_parent_mesh_id_with_in_use_cq(cq_id);
-                if (parent_mesh_id) {
-                    TT_THROW(
-                        "MeshDevice cq ID {} is in use by parent mesh ID {} during close of mesh ID {}",
-                        cq_id,
-                        *parent_mesh_id,
-                        id());
-                }
-            }
-
-            for (const auto& submesh : submeshes_) {
-                if (auto submesh_ptr = submesh.lock()) {
-                    auto child_mesh_id = submesh_ptr->impl().get_child_mesh_id_with_in_use_cq(cq_id);
-                    if (child_mesh_id) {
+        // Only one mesh device can use a CQ on a physical device at a time, or else teardown or some other operation
+        // will hang. Validate this.
+        for (uint32_t cq_id = 0; cq_id < mesh_command_queues_.size(); cq_id++) {
+            if (mesh_command_queues_[cq_id]->in_use()) {
+                auto parent_mesh = get_parent_mesh();
+                if (parent_mesh) {
+                    auto parent_mesh_id = parent_mesh->impl().get_parent_mesh_id_with_in_use_cq(cq_id);
+                    if (parent_mesh_id) {
                         TT_THROW(
-                            "MeshDevice cq ID {} is in use by child submesh ID {} during close of mesh ID {}",
+                            "MeshDevice cq ID {} is in use by parent mesh ID {} during close of mesh ID {}",
                             cq_id,
-                            *child_mesh_id,
+                            *parent_mesh_id,
                             id());
+                    }
+                }
+
+                for (const auto& submesh : submeshes_) {
+                    if (auto submesh_ptr = submesh.lock()) {
+                        auto child_mesh_id = submesh_ptr->impl().get_child_mesh_id_with_in_use_cq(cq_id);
+                        if (child_mesh_id) {
+                            TT_THROW(
+                                "MeshDevice cq ID {} is in use by child submesh ID {} during close of mesh ID {}",
+                                cq_id,
+                                *child_mesh_id,
+                                id());
+                        }
                     }
                 }
             }
         }
+
+        mesh_command_queues_.clear();
+        sub_device_manager_tracker_.reset();
+        scoped_devices_.reset();
+        parent_mesh_.reset();
+        is_internal_state_initialized = false;
+        if (distributed_context_) {
+            distributed_context_.reset();
+        }
     }
 
-    mesh_command_queues_.clear();
-    sub_device_manager_tracker_.reset();
-    scoped_devices_.reset();
-    parent_mesh_.reset();
-    is_internal_state_initialized = false;
-    if (distributed_context_) {
-        distributed_context_.reset();
+    // TODO: This assumes only one MeshDevice per MetalEnv.
+    // To support multiple MeshDevice from the same system mesh this cleanup needs to be
+    // uplifted to the MetalEnv level.
+    // https://github.com/tenstorrent/tt-metal/issues/21500
+    if (destroy_metal_context_instance_on_close_) {
+        MetalContext::destroy_instance(false, context_id_);
+        destroy_metal_context_instance_on_close_ = false;
     }
 
     return true;
@@ -1181,8 +1272,10 @@ bool MeshDeviceImpl::initialize_impl(
 
     // For MeshDevice, we support uniform sub-devices across all devices and we do not support ethernet subdevices.
     const auto& compute_grid_size = this->compute_with_storage_grid_size();
-    auto sub_devices = {
-        SubDevice(std::array{CoreRangeSet(CoreRange({0, 0}, {compute_grid_size.x - 1, compute_grid_size.y - 1}))})};
+    // By this point the env would have been registered with the MetalContext
+    auto sub_devices = {SubDevice(
+        MetalContext::instance(context_id_).get_env(),
+        std::array{CoreRangeSet(CoreRange({0, 0}, {compute_grid_size.x - 1, compute_grid_size.y - 1}))})};
 
     // Resource shared across mesh command queues.
     auto cq_shared_state = std::make_shared<CQSharedState>();
@@ -1195,9 +1288,9 @@ bool MeshDeviceImpl::initialize_impl(
     // Issue #19729: Store the maximum number of active ethernet cores across opened physical devices in the Mesh
     // as the number of virtual ethernet cores seen by the MeshDevice
     num_virtual_eth_cores_ =
-        tt_metal::MetalContext::instance().device_manager()->get_max_num_eth_cores_across_all_devices();
+        tt_metal::MetalContext::instance(context_id_).device_manager()->get_max_num_eth_cores_across_all_devices();
     mesh_command_queues_.reserve(this->num_hw_cqs());
-    if (MetalContext::instance().rtoptions().get_fast_dispatch()) {
+    if (MetalContext::instance(context_id_).rtoptions().get_fast_dispatch()) {
         for (std::size_t cq_id = 0; cq_id < this->num_hw_cqs(); cq_id++) {
             mesh_command_queues_.push_back(std::make_unique<FDMeshCommandQueue>(
                 pimpl_wrapper,
@@ -1351,6 +1444,8 @@ std::shared_ptr<distributed::MeshDevice> MeshDeviceImpl::get_mesh_device() {
     TT_THROW("get_mesh_device() should not be called on MeshDeviceImpl directly");
     return nullptr;
 }
+
+MeshDevice::MeshDevice(MetalEnv& /*metal_env*/) {}
 
 MeshDevice::~MeshDevice() {
     Inspector::mesh_device_destroyed(this->pimpl_.get());

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -1272,10 +1272,9 @@ bool MeshDeviceImpl::initialize_impl(
 
     // For MeshDevice, we support uniform sub-devices across all devices and we do not support ethernet subdevices.
     const auto& compute_grid_size = this->compute_with_storage_grid_size();
-    // By this point the env would have been registered with the MetalContext
-    auto sub_devices = {SubDevice(
-        MetalContext::instance(context_id_).get_env(),
-        std::array{CoreRangeSet(CoreRange({0, 0}, {compute_grid_size.x - 1, compute_grid_size.y - 1}))})};
+    auto& env_impl = MetalEnvAccessor(MetalContext::instance(context_id_).get_env()).impl();
+    auto sub_devices = {SubDevice(SubDeviceImpl(
+        &env_impl, std::array{CoreRangeSet(CoreRange({0, 0}, {compute_grid_size.x - 1, compute_grid_size.y - 1}))}))};
 
     // Resource shared across mesh command queues.
     auto cq_shared_state = std::make_shared<CQSharedState>();

--- a/tt_metal/distributed/mesh_device_impl.hpp
+++ b/tt_metal/distributed/mesh_device_impl.hpp
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include <hostdevcommon/common_values.hpp>
+#include "context/context_types.hpp"
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/dispatch_core_common.hpp>
@@ -38,6 +39,7 @@
 namespace tt::tt_metal {
 class Allocator;
 class HWCommandQueue;
+class MetalEnv;
 class SubDevice;
 class SystemMemoryManager;
 
@@ -81,6 +83,7 @@ private:
     private:
         std::vector<MaybeRemote<IDevice*>> devices_;
         std::map<ChipId, IDevice*> opened_local_devices_;
+        ContextId context_id_ = DEFAULT_CONTEXT_ID;
 
     public:
         // Constructor acquires physical resources
@@ -90,7 +93,8 @@ private:
             size_t num_command_queues,
             size_t worker_l1_size,
             const DispatchCoreConfig& dispatch_core_config,
-            const MeshDeviceConfig& config);
+            const MeshDeviceConfig& config,
+            ContextId context_id = DEFAULT_CONTEXT_ID);
         ScopedDevices(
             const std::vector<MaybeRemote<int>>& all_device_ids,
             const std::vector<MaybeRemote<int>>& active_device_ids,
@@ -98,7 +102,8 @@ private:
             size_t trace_region_size,
             size_t num_command_queues,
             size_t worker_l1_size,
-            const DispatchCoreConfig& dispatch_core_config);
+            const DispatchCoreConfig& dispatch_core_config,
+            ContextId context_id = DEFAULT_CONTEXT_ID);
 
         // Destructor releases physical resources
         ~ScopedDevices();
@@ -119,6 +124,14 @@ private:
     // on the device may not be thread safe.
     std::mutex api_mutex_;
     bool is_internal_state_initialized = false;
+    // Which MetalContext instance this MeshDevice uses
+    // To be removed in favor of directly passing around the MetalContext reference.
+    ContextId context_id_ = DEFAULT_CONTEXT_ID;
+    // Legacy path (MeshDevice::create): the MetalContext instance is managed externally and is
+    // not destroyed when the MeshDevice closes.
+    // New path (MetalEnv::create_mesh_device): a MetalContext instance is created for the
+    // MeshDevice, and when the MeshDevice closes it also destroys the associated MetalContext.
+    bool destroy_metal_context_instance_on_close_ = false;
     std::shared_ptr<ScopedDevices> scoped_devices_;
     int mesh_id_;
     std::unique_ptr<MeshDeviceView> view_;
@@ -166,7 +179,8 @@ public:
     MeshDeviceImpl(
         std::shared_ptr<ScopedDevices> mesh_handle,
         std::unique_ptr<MeshDeviceView> mesh_device_view,
-        std::shared_ptr<MeshDevice> parent_mesh = {});
+        std::shared_ptr<MeshDevice> parent_mesh = {},
+        ContextId context_id = DEFAULT_CONTEXT_ID);
     ~MeshDeviceImpl() override;
 
     MeshDeviceImpl(const MeshDeviceImpl&) = delete;
@@ -174,6 +188,11 @@ public:
 
     MeshDeviceImpl(MeshDeviceImpl&&) = delete;
     MeshDeviceImpl& operator=(MeshDeviceImpl&&) = delete;
+
+    ContextId get_context_id() const { return context_id_; }
+    void set_destroy_metal_context_instance_on_close(bool destroy) {
+        destroy_metal_context_instance_on_close_ = destroy;
+    }
 
     // IDevice interface implementation
     tt::ARCH arch() const override;
@@ -387,6 +406,37 @@ public:
         const DispatchCoreConfig& dispatch_core_config = DispatchCoreConfig{},
         tt::stl::Span<const std::uint32_t> l1_bank_remap = {},
         size_t worker_l1_size = DEFAULT_WORKER_L1_SIZE);
+
+    // Create Mesh Devices which refer to a specific MetalContext instance.
+    // When owns_context is true, the MeshDevice will destroy the MetalContext on close.
+    // TODO: This will be updated in favor of directly passing around the MetalContext and/or MetalEnv reference.
+    static std::shared_ptr<MeshDevice> create(
+        ContextId context_id,
+        const MeshDeviceConfig& config,
+        size_t l1_small_size,
+        size_t trace_region_size,
+        size_t num_command_queues,
+        const DispatchCoreConfig& dispatch_core_config,
+        tt::stl::Span<const std::uint32_t> l1_bank_remap,
+        size_t worker_l1_size);
+    static std::shared_ptr<MeshDevice> create_unit_mesh(
+        ContextId context_id,
+        int device_id,
+        size_t l1_small_size,
+        size_t trace_region_size,
+        size_t num_command_queues,
+        const DispatchCoreConfig& dispatch_core_config,
+        tt::stl::Span<const std::uint32_t> l1_bank_remap,
+        size_t worker_l1_size);
+    static std::map<int, std::shared_ptr<MeshDevice>> create_unit_meshes(
+        ContextId context_id,
+        const std::vector<int>& device_ids,
+        size_t l1_small_size,
+        size_t trace_region_size,
+        size_t num_command_queues,
+        const DispatchCoreConfig& dispatch_core_config,
+        tt::stl::Span<const std::uint32_t> l1_bank_remap,
+        size_t worker_l1_size);
 };
 
 std::ostream& operator<<(std::ostream& os, const MeshDeviceImpl& mesh_device);

--- a/tt_metal/distributed/mesh_device_impl.hpp
+++ b/tt_metal/distributed/mesh_device_impl.hpp
@@ -190,6 +190,9 @@ public:
     MeshDeviceImpl& operator=(MeshDeviceImpl&&) = delete;
 
     ContextId get_context_id() const { return context_id_; }
+    // The MeshDevice will call MetalContext::destroy_instance on close when this is set to true.
+    // This was added to cleanup the MetalContext after MeshDevice closes.
+    // It needs to be removed to enable https://github.com/tenstorrent/tt-metal/issues/21500.
     void set_destroy_metal_context_instance_on_close(bool destroy) {
         destroy_metal_context_instance_on_close_ = destroy;
     }

--- a/tt_metal/distributed/mesh_workload.cpp
+++ b/tt_metal/distributed/mesh_workload.cpp
@@ -8,6 +8,7 @@
 #include <mesh_workload.hpp>
 #include <cstdint>
 #include <tt_metal/impl/program/program_command_sequence.hpp>
+#include "distributed/mesh_device_impl.hpp"
 #include "tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp"
 #include <algorithm>
 #include <cstddef>
@@ -419,7 +420,12 @@ void MeshWorkloadImpl::finalize_offsets(MeshDevice* mesh_device) {
     tt::stl::Span<tt::tt_metal::detail::ProgramImpl*> programs(program_impls.data(), program_impls.size());
 
     this->max_program_kernels_sizeB_ = tt::tt_metal::detail::ProgramImpl::finalize_program_offsets(
-        mesh_device, kernels_getter, kernel_groups_getter, semaphores_getter, programs);
+        extract_context_id(mesh_device),
+        mesh_device,
+        kernels_getter,
+        kernel_groups_getter,
+        semaphores_getter,
+        programs);
 
     set_finalized();
 }

--- a/tt_metal/distributed/sd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.cpp
@@ -53,7 +53,11 @@ SDMeshCommandQueue::SDMeshCommandQueue(
     uint32_t id,
     std::function<std::lock_guard<std::mutex>()> lock_api_function,
     std::shared_ptr<distributed::multihost::DistributedContext> distributed_context) :
-    MeshCommandQueueBase(mesh_device, id, create_passthrough_thread_pool(), std::move(lock_api_function)),
+    MeshCommandQueueBase(
+        mesh_device,
+        id,
+        create_passthrough_thread_pool(mesh_device->impl().get_context_id()),
+        std::move(lock_api_function)),
     active_distributed_context_(std::move(distributed_context)) {}
 
 std::optional<MeshTraceId> SDMeshCommandQueue::trace_id() const {
@@ -68,7 +72,7 @@ bool SDMeshCommandQueue::write_shard_to_device(
     const std::optional<BufferRegion>& region,
     tt::stl::Span<const SubDeviceId> sub_device_ids,
     std::shared_ptr<experimental::PinnedMemory> /* pinned_memory */) {
-    if (tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock) {
+    if (this->get_target_device_type() == tt::TargetDevice::Mock) {
         return false;  // Skip hardware write for mock devices
     }
     // Wait for idle here to ensure that a previous program potentially using this address space
@@ -98,7 +102,7 @@ void SDMeshCommandQueue::read_shard_from_device(
     const std::optional<BufferRegion>& region,
     std::unordered_map<IDevice*, uint32_t>&,
     tt::stl::Span<const SubDeviceId> sub_device_ids) {
-    if (tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock) {
+    if (this->get_target_device_type() == tt::TargetDevice::Mock) {
         return;  // Skip hardware read for mock devices
     }
     // Wait for idle here to ensure that programs emitting this data are complete.
@@ -130,7 +134,7 @@ void SDMeshCommandQueue::wait_for_cores_idle() {
 }
 
 void SDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool blocking) {
-    if (tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock) {
+    if (this->get_target_device_type() == tt::TargetDevice::Mock) {
         return;  // Skip workload execution for mock devices
     }
 
@@ -180,7 +184,8 @@ void SDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
                         // Device had active cores before this program was launched
                         // Merge the active cores from the previous program with the active cores from the current
                         // program
-                        const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+                        const auto& hal =
+                            tt::tt_metal::MetalContext::instance(mesh_device_->impl().get_context_id()).hal();
                         auto program_cores = program.impl().logical_cores();
                         for (uint32_t core_type_index = 0; core_type_index < hal.get_programmable_core_type_count();
                              core_type_index++) {
@@ -219,14 +224,18 @@ void SDMeshCommandQueue::enqueue_wait_for_event(const MeshEvent&) {
 }
 
 void SDMeshCommandQueue::finish(tt::stl::Span<const SubDeviceId>) {
-    if (tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock) {
+    if (this->get_target_device_type() == tt::TargetDevice::Mock) {
         return;
     }
     auto lock = lock_api_function_();
     wait_for_cores_idle();
     for (const auto& device : mesh_device_->get_devices()) {
-        tt::tt_metal::MetalContext::instance().get_cluster().dram_barrier(device->id());
-        tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(device->id());
+        tt::tt_metal::MetalContext::instance(mesh_device_->impl().get_context_id())
+            .get_cluster()
+            .dram_barrier(device->id());
+        tt::tt_metal::MetalContext::instance(mesh_device_->impl().get_context_id())
+            .get_cluster()
+            .l1_barrier(device->id());
     }
 
     // Barrier across all active hosts of the mesh

--- a/tt_metal/fabric/fabric_tensix_builder.cpp
+++ b/tt_metal/fabric/fabric_tensix_builder.cpp
@@ -11,6 +11,7 @@
 #include <tt-logger/tt-logger.hpp>
 
 #include "impl/context/metal_context.hpp"
+#include "impl/context/context_types.hpp"
 #include "llrt/core_descriptor.hpp"
 #include "impl/device/device_manager.hpp"
 #include "fabric_context.hpp"
@@ -302,9 +303,11 @@ bool FabricTensixDatamoverConfig::initialize_channel_mappings() {
     auto num_hw_cqs = tt_metal::MetalContext::instance().get_dispatch_core_manager().get_num_hw_cqs();
     tt_metal::DispatchCoreConfig dispatch_core_config =
         tt_metal::MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
-    logical_fabric_mux_cores_ = tt::get_logical_fabric_mux_cores(device_id, num_hw_cqs, dispatch_core_config);
+
+    tt_metal::MetalEnvImpl& env_impl = tt_metal::MetalEnvAccessor(tt_metal::MetalContext::instance().get_env()).impl();
+    logical_fabric_mux_cores_ = tt::get_logical_fabric_mux_cores(env_impl, device_id, num_hw_cqs, dispatch_core_config);
     // TODO: once we merge the mux cores from dispatch to fabric, we can remove this.
-    logical_dispatch_mux_cores_ = tt::get_logical_dispatch_cores(device_id, num_hw_cqs, dispatch_core_config);
+    logical_dispatch_mux_cores_ = tt::get_logical_dispatch_cores(env_impl, device_id, num_hw_cqs, dispatch_core_config);
 
     TT_FATAL(!logical_fabric_mux_cores_.empty(), "No logical fabric mux cores found for device {}", device_id);
 

--- a/tt_metal/impl/allocator/allocator.cpp
+++ b/tt_metal/impl/allocator/allocator.cpp
@@ -44,6 +44,7 @@ void AllocatorImpl::init_one_bank_per_channel() {
         bank_offsets,
         dram_bank_size,
         config_->dram_alignment,
+        config_->dram_alignment,
         config_->dram_unreserved_base,
         config_->disable_interleaved);
     for (uint32_t bank_id = 0; bank_id < config_->num_dram_channels; bank_id++) {
@@ -58,6 +59,7 @@ void AllocatorImpl::init_one_bank_per_channel() {
         BufferType::TRACE,
         bank_offsets,
         config_->trace_region_size,
+        config_->dram_alignment,
         config_->dram_alignment,
         dram_bank_size + config_->dram_unreserved_base,
         config_->disable_interleaved);
@@ -80,6 +82,7 @@ void AllocatorImpl::init_one_bank_per_l1() {
         bank_offsets,
         l1_bank_size,
         config_->l1_alignment,
+        config_->dram_alignment,
         config_->l1_unreserved_base,
         config_->disable_interleaved);
 

--- a/tt_metal/impl/allocator/bank_manager.cpp
+++ b/tt_metal/impl/allocator/bank_manager.cpp
@@ -138,6 +138,7 @@ BankManager::BankManager(
     const std::vector<int64_t>& bank_offsets,
     DeviceAddr size_bytes,
     uint32_t alignment_bytes,
+    uint32_t dram_alignment_bytes,
     DeviceAddr alloc_offset,
     bool disable_interleaved,
     const AllocatorDependencies& dependencies) :
@@ -154,7 +155,9 @@ BankManager::BankManager(
     validate_num_banks(bank_id_to_bank_offset_.size(), buffer_type_, disable_interleaved);
 
     // Initialize all allocators; sets up allocator-dependent members
-    this->init_allocators(size_bytes, alignment_bytes, alloc_offset);
+    // Expect the alignment provided to by compatible with the DRAM alignment
+    TT_ASSERT(dram_alignment_bytes % alignment_bytes == 0);
+    this->init_allocators(size_bytes, dram_alignment_bytes, alloc_offset);
 }
 
 BankManager::BankManager(
@@ -163,6 +166,7 @@ BankManager::BankManager(
     DeviceAddr size_bytes,
     DeviceAddr interleaved_address_limit,
     uint32_t alignment_bytes,
+    uint32_t dram_alignment_bytes,
     DeviceAddr alloc_offset,
     bool disable_interleaved,
     const AllocatorDependencies& dependencies) :
@@ -174,7 +178,9 @@ BankManager::BankManager(
     validate_num_banks(bank_id_to_bank_offset_.size(), buffer_type_, disable_interleaved);
 
     // Initialize all allocators; sets up allocator-dependent members
-    this->init_allocators(size_bytes, alignment_bytes, alloc_offset);
+    // Expect the alignment provided to by compatible with the DRAM alignment
+    TT_ASSERT(dram_alignment_bytes % alignment_bytes == 0);
+    this->init_allocators(size_bytes, dram_alignment_bytes, alloc_offset);
 }
 
 uint32_t BankManager::num_banks() const { return bank_id_to_bank_offset_.size(); }
@@ -403,7 +409,8 @@ uint64_t BankManager::allocate_buffer(
             num_compute_banks);
         num_banks = num_shards.value();
     }
-    DeviceAddr size_per_bank = tt::tt_metal::detail::calculate_bank_size_spread(size, page_size, num_banks, alignment_bytes_);
+    DeviceAddr size_per_bank =
+        tt::tt_metal::detail::calculate_bank_size_spread(size, page_size, num_banks, alignment_bytes_);
     DeviceAddr address_limit = 0;
     if (!is_sharded and buffer_type_ == BufferType::L1) {
         address_limit = interleaved_address_limit_;

--- a/tt_metal/impl/allocator/bank_manager.cpp
+++ b/tt_metal/impl/allocator/bank_manager.cpp
@@ -155,8 +155,7 @@ BankManager::BankManager(
     validate_num_banks(bank_id_to_bank_offset_.size(), buffer_type_, disable_interleaved);
 
     // Initialize all allocators; sets up allocator-dependent members
-    // Expect the alignment provided to be compatible with the DRAM alignment for L1<->DRAM data transfers
-    TT_ASSERT(dram_alignment_bytes % alignment_bytes == 0);
+    // Pass in the DRAM alignment to ensure L1<->DRAM or DRAM<->DRAM data transfers are aligned
     this->init_allocators(size_bytes, dram_alignment_bytes, alloc_offset);
 }
 
@@ -178,8 +177,7 @@ BankManager::BankManager(
     validate_num_banks(bank_id_to_bank_offset_.size(), buffer_type_, disable_interleaved);
 
     // Initialize all allocators; sets up allocator-dependent members
-    // Expect the alignment provided to be compatible with the DRAM alignment for L1<->DRAM data transfers
-    TT_ASSERT(dram_alignment_bytes % alignment_bytes == 0);
+    // Pass in the DRAM alignment to ensure L1<->DRAM or DRAM<->DRAM data transfers are aligned
     this->init_allocators(size_bytes, dram_alignment_bytes, alloc_offset);
 }
 

--- a/tt_metal/impl/allocator/bank_manager.cpp
+++ b/tt_metal/impl/allocator/bank_manager.cpp
@@ -155,7 +155,7 @@ BankManager::BankManager(
     validate_num_banks(bank_id_to_bank_offset_.size(), buffer_type_, disable_interleaved);
 
     // Initialize all allocators; sets up allocator-dependent members
-    // Expect the alignment provided to by compatible with the DRAM alignment
+    // Expect the alignment provided to be compatible with the DRAM alignment for L1<->DRAM data transfers
     TT_ASSERT(dram_alignment_bytes % alignment_bytes == 0);
     this->init_allocators(size_bytes, dram_alignment_bytes, alloc_offset);
 }
@@ -178,7 +178,7 @@ BankManager::BankManager(
     validate_num_banks(bank_id_to_bank_offset_.size(), buffer_type_, disable_interleaved);
 
     // Initialize all allocators; sets up allocator-dependent members
-    // Expect the alignment provided to by compatible with the DRAM alignment
+    // Expect the alignment provided to be compatible with the DRAM alignment for L1<->DRAM data transfers
     TT_ASSERT(dram_alignment_bytes % alignment_bytes == 0);
     this->init_allocators(size_bytes, dram_alignment_bytes, alloc_offset);
 }

--- a/tt_metal/impl/allocator/bank_manager.cpp
+++ b/tt_metal/impl/allocator/bank_manager.cpp
@@ -154,7 +154,7 @@ BankManager::BankManager(
     validate_num_banks(bank_id_to_bank_offset_.size(), buffer_type_, disable_interleaved);
 
     // Initialize all allocators; sets up allocator-dependent members
-    this->init_allocators(size_bytes, MetalContext::instance().hal().get_alignment(HalMemType::DRAM), alloc_offset);
+    this->init_allocators(size_bytes, alignment_bytes, alloc_offset);
 }
 
 BankManager::BankManager(
@@ -174,7 +174,7 @@ BankManager::BankManager(
     validate_num_banks(bank_id_to_bank_offset_.size(), buffer_type_, disable_interleaved);
 
     // Initialize all allocators; sets up allocator-dependent members
-    this->init_allocators(size_bytes, MetalContext::instance().hal().get_alignment(HalMemType::DRAM), alloc_offset);
+    this->init_allocators(size_bytes, alignment_bytes, alloc_offset);
 }
 
 uint32_t BankManager::num_banks() const { return bank_id_to_bank_offset_.size(); }

--- a/tt_metal/impl/allocator/bank_manager.hpp
+++ b/tt_metal/impl/allocator/bank_manager.hpp
@@ -66,11 +66,14 @@ public:
         bool operator!=(const AllocatorDependencies& other) const noexcept { return !(*this == other); }
     };
 
+    // The DRAM alignment bytes is used to initialize the allocator. The alignment_bytes needs to be compatible with the
+    // DRAM alignment.
     BankManager(
         const BufferType& buffer_type,
         const std::vector<int64_t>& bank_offsets,
         DeviceAddr size_bytes,
         uint32_t alignment_bytes,
+        uint32_t dram_alignment_bytes,
         DeviceAddr alloc_offset = 0,
         bool disable_interleaved = false,
         const AllocatorDependencies& dependencies = AllocatorDependencies());
@@ -80,6 +83,7 @@ public:
         DeviceAddr size_bytes,
         DeviceAddr interleaved_address_limit,
         uint32_t alignment_bytes,
+        uint32_t dram_alignment_bytes,
         DeviceAddr alloc_offset = 0,
         bool disable_interleaved = false,
         const AllocatorDependencies& dependencies = AllocatorDependencies());

--- a/tt_metal/impl/allocator/l1_banking_allocator.cpp
+++ b/tt_metal/impl/allocator/l1_banking_allocator.cpp
@@ -125,17 +125,19 @@ void AllocatorImpl::init_compute_and_storage_l1_bank_manager() {
         allocatable_l1_size,
         interleaved_address_limit,
         config_->l1_alignment,
+        config_->dram_alignment,
         config_->l1_unreserved_base,
         config_->disable_interleaved);
     log_debug(
         tt::LogMetal,
         "Configured partition params: worker_l1_size:0x{:X}, "
-        "l1_unreserved_base:0x{:X}, l1_small_size:0x{:X}, disable_interleaved:{}, l1_alignment:{}",
+        "l1_unreserved_base:0x{:X}, l1_small_size:0x{:X}, disable_interleaved:{}, l1_alignment:{}, dram_alignment:{}",
         config_->worker_l1_size,
         config_->l1_unreserved_base,
         config_->l1_small_size,
         config_->disable_interleaved,
-        config_->l1_alignment);
+        config_->l1_alignment,
+        config_->dram_alignment);
 
     uint64_t small_interleaved_address_limit = config_->worker_l1_size - config_->l1_small_size;
     uint64_t small_alloc_offset = config_->l1_unreserved_base + allocatable_l1_size;
@@ -158,6 +160,7 @@ void AllocatorImpl::init_compute_and_storage_l1_bank_manager() {
         config_->l1_small_size,
         small_interleaved_address_limit,
         config_->l1_alignment,
+        config_->dram_alignment,
         small_alloc_offset,
         config_->disable_interleaved);
 }

--- a/tt_metal/impl/allocator/l1_banking_allocator.cpp
+++ b/tt_metal/impl/allocator/l1_banking_allocator.cpp
@@ -169,16 +169,18 @@ L1BankingAllocator::L1BankingAllocator(const AllocatorConfig& alloc_config) : Al
 }
 
 AllocatorConfig L1BankingAllocator::generate_config(
+    dispatch_core_manager& dispatch_core_manager,
+    MetalEnvImpl& env,
     ChipId device_id,
     uint8_t num_hw_cqs,
     size_t l1_small_size,
     size_t trace_region_size,
     size_t worker_l1_unreserved_start,
     BankMapping l1_bank_remap) {
-    const auto& cluster = MetalContext::instance().get_cluster();
-    const auto& hal = MetalContext::instance().hal();
+    const auto& cluster = env.get_cluster();
+    const auto& hal = env.get_hal();
     const metal_SocDescriptor& soc_desc = cluster.get_soc_desc(device_id);
-    const auto& dispatch_core_config = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
+    const auto& dispatch_core_config = dispatch_core_manager.get_dispatch_core_config();
     CoreType dispatch_core_type = get_core_type_from_config(dispatch_core_config);
     // Construct allocator config from soc_desc
     // Take max alignment to satisfy NoC rd/wr constraints
@@ -186,7 +188,7 @@ AllocatorConfig L1BankingAllocator::generate_config(
     // PCIe/DRAM -> Tensix/Eth src and dst addrs must be DRAM_ALIGNMENT aligned
     // Tensix/Eth <-> Tensix/Eth src and dst addrs must be L1_ALIGNMENT aligned
     const auto& logical_size = soc_desc.get_grid_size(CoreType::TENSIX);
-    const auto& compute_size = tt::get_compute_grid_size(device_id, num_hw_cqs, dispatch_core_config);
+    const auto& compute_size = tt::get_compute_grid_size(env, device_id, num_hw_cqs, dispatch_core_config);
     AllocatorConfig config(
         {.num_dram_channels = static_cast<size_t>(soc_desc.get_num_dram_views()),
          .dram_bank_size = soc_desc.dram_view_size,
@@ -229,12 +231,12 @@ AllocatorConfig L1BankingAllocator::generate_config(
              AllocCoreType::Invalid});
     }
 
-    for (const CoreCoord& core : tt::get_logical_compute_cores(device_id, num_hw_cqs, dispatch_core_config)) {
+    for (const CoreCoord& core : tt::get_logical_compute_cores(env, device_id, num_hw_cqs, dispatch_core_config)) {
         const auto noc_coord =
             cluster.get_virtual_coordinate_from_logical_coordinates(device_id, core, CoreType::WORKER);
         config.core_type_from_noc_coord_table[noc_coord] = AllocCoreType::ComputeAndStore;
     }
-    for (const CoreCoord& core : tt::get_logical_dispatch_cores(device_id, num_hw_cqs, dispatch_core_config)) {
+    for (const CoreCoord& core : tt::get_logical_dispatch_cores(env, device_id, num_hw_cqs, dispatch_core_config)) {
         const auto noc_coord =
             cluster.get_virtual_coordinate_from_logical_coordinates(device_id, core, dispatch_core_type);
         config.core_type_from_noc_coord_table[noc_coord] = AllocCoreType::Dispatch;

--- a/tt_metal/impl/allocator/l1_banking_allocator.hpp
+++ b/tt_metal/impl/allocator/l1_banking_allocator.hpp
@@ -5,11 +5,14 @@
 #pragma once
 
 #include <tt-metalium/allocator.hpp>
+#include "dispatch/dispatch_core_manager.hpp"
 #include "llrt/core_descriptor.hpp"
 #include <cstdint>
 
 #include "impl/allocator/allocator_types.hpp"
 #include "impl/allocator/allocator.hpp"
+#include "impl/context/context_types.hpp"
+#include "impl/context/metal_env_impl.hpp"
 
 namespace tt::tt_metal {
 
@@ -19,6 +22,8 @@ class L1BankingAllocator : public AllocatorImpl {
 public:
     explicit L1BankingAllocator(const AllocatorConfig& alloc_config);
     static AllocatorConfig generate_config(
+        dispatch_core_manager& dispatch_core_manager,
+        MetalEnvImpl& env,
         ChipId device_id,
         uint8_t num_hw_cqs,
         size_t l1_small_size,

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -21,6 +21,7 @@
 #include <string>
 #include <string_view>
 #include <utility>
+#include "context/context_types.hpp"
 #include "fmt/base.h"
 #include "lightmetal/host_api_capture_helpers.hpp"
 #include <tt_stl/strong_type.hpp>
@@ -425,7 +426,9 @@ void Buffer::allocate_impl() {
         TT_ASSERT(address_ <= std::numeric_limits<uint32_t>::max());
 
 #if defined(TRACY_ENABLE)
-        if (tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_buffer_usage_enabled()) {
+        if (tt::tt_metal::MetalContext::instance(extract_context_id(device_))
+                .rtoptions()
+                .get_profiler_buffer_usage_enabled()) {
             TracyAllocN(
                 reinterpret_cast<const void*>(address_), size_, get_buffer_location_name(buffer_type_, device_->id()));
         }
@@ -457,7 +460,9 @@ void Buffer::deallocate_impl() {
         GraphTracker::instance().track_deallocate(this);
         if (!GraphTracker::instance().hook_deallocate(this) && !hooked_allocation_) {
 #if defined(TRACY_ENABLE)
-            if (tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_buffer_usage_enabled()) {
+            if (tt::tt_metal::MetalContext::instance(extract_context_id(device_))
+                    .rtoptions()
+                    .get_profiler_buffer_usage_enabled()) {
                 TracyFreeN(
                     reinterpret_cast<const void*>(address()), get_buffer_location_name(buffer_type_, device_->id()));
             }

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -14,6 +14,7 @@
 #include <tt_stl/assert.hpp>
 #include "buffer_types.hpp"
 #include "dispatch.hpp"
+#include "distributed/mesh_device_impl.hpp"
 #include "impl/context/metal_context.hpp"
 #include "dispatch/kernels/cq_commands.hpp"
 #include "dispatch/dispatch_settings.hpp"
@@ -1383,14 +1384,16 @@ void issue_read_buffer_dispatch_command_sequence(
         return;
     }
 
-    // Mock devices don't have real hardware to read from, skip actual dispatch
-    if (tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock) {
-        return;
-    }
-
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();
 
     SystemMemoryManager& sysmem_manager = dispatch_params.device->sysmem_manager();
+
+    // Mock devices don't have real hardware to read from, skip actual dispatch
+    if (tt::tt_metal::MetalContext::instance(sysmem_manager.get_context_id()).get_cluster().get_target_device_type() ==
+        tt::TargetDevice::Mock) {
+        return;
+    }
+
     uint32_t num_worker_counters = sub_device_ids.size();
 
     // Precompute whether pinned direct write is feasible, and derive dst noc params

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -682,7 +682,8 @@ void issue_sharded_buffer_pinned_dispatch_command_sequence(
     const CoreCoord& core,
     tt::stl::Span<const SubDeviceId> sub_device_ids) {
     ZoneScoped;
-    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+    ContextId context_id = tt::tt_metal::extract_context_id(buffer.device());
+    const auto& hal = tt::tt_metal::MetalContext::instance(context_id).hal();
     const uint32_t pcie_alignment = hal.get_alignment(HalMemType::HOST);
     const uint32_t l1_alignment = hal.get_alignment(HalMemType::L1);
 
@@ -1128,7 +1129,8 @@ bool write_to_device_buffer(
     tt::stl::Span<const SubDeviceId> sub_device_ids,
     const std::shared_ptr<experimental::PinnedMemory>& pinned_memory) {
     SystemMemoryManager& sysmem_manager = buffer.device()->sysmem_manager();
-    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+    ContextId context_id = tt::tt_metal::extract_context_id(buffer.device());
+    const auto& hal = tt::tt_metal::MetalContext::instance(context_id).hal();
 
     if (tt::tt_metal::GraphTracker::instance().hook_write_to_device(&buffer)) {
         return false;
@@ -1384,7 +1386,8 @@ void issue_read_buffer_dispatch_command_sequence(
         return;
     }
 
-    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+    ContextId context_id = tt::tt_metal::extract_context_id(buffer.device());
+    const auto& hal = tt::tt_metal::MetalContext::instance(context_id).hal();
 
     SystemMemoryManager& sysmem_manager = dispatch_params.device->sysmem_manager();
 
@@ -1450,14 +1453,14 @@ void issue_read_buffer_dispatch_command_sequence(
         command_sequence.add_dispatch_wait(
             CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM,
             0,
-            MetalContext::instance().dispatch_mem_map().get_dispatch_stream_index(offset_index),
+            MetalContext::instance(context_id).dispatch_mem_map().get_dispatch_stream_index(offset_index),
             dispatch_params.expected_num_workers_completed[offset_index]);
     }
     auto offset_index = *sub_device_ids[last_index];
     command_sequence.add_dispatch_wait_with_prefetch_stall(
         CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM | CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER,
         0,
-        MetalContext::instance().dispatch_mem_map().get_dispatch_stream_index(offset_index),
+        MetalContext::instance(context_id).dispatch_mem_map().get_dispatch_stream_index(offset_index),
         dispatch_params.expected_num_workers_completed[offset_index]);
 
     // Select write op once, then unify relay
@@ -1632,12 +1635,14 @@ void copy_completion_queue_data_into_user_space(
             void* contiguous_dst = (void*)(uint64_t(dst) + contig_dst_offset);
             if (page_size == padded_page_size) {
                 uint32_t data_bytes_xfered = bytes_xfered - offset_in_completion_q_data;
-                tt::tt_metal::MetalContext::instance().get_cluster().read_sysmem(
-                    contiguous_dst,
-                    data_bytes_xfered,
-                    completion_q_read_ptr + offset_in_completion_q_data,
-                    mmio_device_id,
-                    channel);
+                tt::tt_metal::MetalContext::instance(sysmem_manager.get_context_id())
+                    .get_cluster()
+                    .read_sysmem(
+                        contiguous_dst,
+                        data_bytes_xfered,
+                        completion_q_read_ptr + offset_in_completion_q_data,
+                        mmio_device_id,
+                        channel);
                 contig_dst_offset += data_bytes_xfered;
                 offset_in_completion_q_data = 0;
             } else {
@@ -1681,12 +1686,14 @@ void copy_completion_queue_data_into_user_space(
                         num_bytes_to_copy = page_size;
                     }
 
-                    tt::tt_metal::MetalContext::instance().get_cluster().read_sysmem(
-                        (char*)(uint64_t(contiguous_dst) + dst_offset_bytes),
-                        num_bytes_to_copy,
-                        completion_q_read_ptr + src_offset_bytes,
-                        mmio_device_id,
-                        channel);
+                    tt::tt_metal::MetalContext::instance(sysmem_manager.get_context_id())
+                        .get_cluster()
+                        .read_sysmem(
+                            (char*)(uint64_t(contiguous_dst) + dst_offset_bytes),
+                            num_bytes_to_copy,
+                            completion_q_read_ptr + src_offset_bytes,
+                            mmio_device_id,
+                            channel);
 
                     src_offset_bytes += src_offset_increment;
                     dst_offset_bytes += num_bytes_to_copy;
@@ -1754,12 +1761,14 @@ void copy_completion_queue_data_into_user_space(
                     }
                 }
 
-                tt::tt_metal::MetalContext::instance().get_cluster().read_sysmem(
-                    (char*)(uint64_t(dst) + dst_offset_bytes),
-                    num_bytes_to_copy,
-                    completion_q_read_ptr + src_offset_bytes,
-                    mmio_device_id,
-                    channel);
+                tt::tt_metal::MetalContext::instance(sysmem_manager.get_context_id())
+                    .get_cluster()
+                    .read_sysmem(
+                        (char*)(uint64_t(dst) + dst_offset_bytes),
+                        num_bytes_to_copy,
+                        completion_q_read_ptr + src_offset_bytes,
+                        mmio_device_id,
+                        channel);
 
                 src_offset_bytes += src_offset_increment;
             }

--- a/tt_metal/impl/context/context_descriptor.hpp
+++ b/tt_metal/impl/context/context_descriptor.hpp
@@ -12,6 +12,9 @@
 #include <tt-metalium/dispatch_core_common.hpp>
 #include <tt-metalium/experimental/fabric/fabric_types.hpp>
 #include <tt-metalium/experimental/context/metal_env.hpp>
+#include "context/metal_env_accessor.hpp"
+#include "context/metal_env_impl.hpp"
+#include "context_types.hpp"
 
 namespace tt {
 class Cluster;
@@ -28,49 +31,15 @@ class MetalContext;
 class DeviceManager;
 
 // Used internally to share runtime configuration
+// Provides both lower level (MetalEnv) and runtime configuration (MetalContext)
 class ContextDescriptor : public MetalEnvDescriptor {
 public:
+    // MetalEnv is provided for access to the cluster, hal, and rtoptions
+    // It's settings may or may not match the settings (e.g. fabric config) in this descriptor yet
+    // as this contextdescriptor is passed around during initialization
     ContextDescriptor(
-        int num_cqs = 1,
-        size_t l1_small_size = 0,
-        size_t trace_region_size = 0,
-        size_t worker_l1_size = 0,
-        const tt::tt_metal::DispatchCoreConfig& dispatch_core_config = {},
-        tt::stl::Span<const std::uint32_t> l1_bank_remap = {},
-        const std::string& mock_cluster_desc_path = "",
-        tt::tt_fabric::FabricConfig fabric_config = tt::tt_fabric::FabricConfig::DISABLED,
-        tt::tt_fabric::FabricReliabilityMode reliability_mode =
-            tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE,
-        tt::tt_fabric::FabricTensixConfig fabric_tensix_config = tt::tt_fabric::FabricTensixConfig::DISABLED,
-        tt::tt_fabric::FabricUDMMode fabric_udm_mode = tt::tt_fabric::FabricUDMMode::DISABLED,
-        tt::tt_fabric::FabricManagerMode fabric_manager = tt::tt_fabric::FabricManagerMode::DEFAULT,
-        tt::tt_fabric::FabricRouterConfig router_config = tt::tt_fabric::FabricRouterConfig{}) :
-        MetalEnvDescriptor(
-            mock_cluster_desc_path.empty() ? std::optional<std::string>(std::nullopt)
-                                           : std::optional<std::string>(mock_cluster_desc_path)),
-        num_cqs_(num_cqs),
-        l1_small_size_(l1_small_size),
-        trace_region_size_(trace_region_size),
-        worker_l1_size_(worker_l1_size),
-        dispatch_core_config_(dispatch_core_config),
-        l1_bank_remap_(l1_bank_remap),
-        fabric_config_(fabric_config),
-        reliability_mode_(reliability_mode),
-        fabric_tensix_config_(fabric_tensix_config),
-        fabric_udm_mode_(fabric_udm_mode),
-        fabric_manager_(fabric_manager),
-        router_config_(router_config) {}
-
-    ContextDescriptor(
-        const Hal& hal,
-        Cluster& cluster,
-        const llrt::RunTimeOptions& rtoptions,
-        tt::tt_fabric::FabricConfig fabric_config,
-        tt::tt_fabric::FabricReliabilityMode reliability_mode,
-        tt::tt_fabric::FabricTensixConfig fabric_tensix_config,
-        tt::tt_fabric::FabricUDMMode fabric_udm_mode,
-        tt::tt_fabric::FabricManagerMode fabric_manager,
-        tt::tt_fabric::FabricRouterConfig router_config = tt::tt_fabric::FabricRouterConfig{},
+        MetalEnv* env,
+        MetalContext* metal_context,
         int num_cqs = 1,
         size_t l1_small_size = 0,
         size_t trace_region_size = 0,
@@ -81,27 +50,29 @@ public:
         MetalEnvDescriptor(
             mock_cluster_desc_path.empty() ? std::optional<std::string>(std::nullopt)
                                            : std::optional<std::string>(mock_cluster_desc_path)),
-        hal_(&hal),
-        cluster_(&cluster),
-        rtoptions_(&rtoptions),
+        env_(env),
+        metal_context_(metal_context),
         num_cqs_(num_cqs),
         l1_small_size_(l1_small_size),
         trace_region_size_(trace_region_size),
         worker_l1_size_(worker_l1_size),
         dispatch_core_config_(dispatch_core_config),
-        l1_bank_remap_(l1_bank_remap),
-        fabric_config_(fabric_config),
-        reliability_mode_(reliability_mode),
-        fabric_tensix_config_(fabric_tensix_config),
-        fabric_udm_mode_(fabric_udm_mode),
-        fabric_manager_(fabric_manager),
-        router_config_(router_config) {}
+        l1_bank_remap_(l1_bank_remap) {}
 
     ContextDescriptor() = default;
 
-    const Hal& hal() const { return *hal_; }
-    Cluster& cluster() const { return *cluster_; }
-    const llrt::RunTimeOptions& rtoptions() const { return *rtoptions_; }
+    MetalEnvImpl& env_impl() const {
+        TT_FATAL(env_ != nullptr, "Missing MetalEnv for this ContextDescriptor");
+        return MetalEnvAccessor(*env_).impl();
+    }
+    MetalEnv& env() const {
+        TT_FATAL(env_ != nullptr, "Missing MetalEnv for this ContextDescriptor");
+        return *env_;
+    }
+    MetalContext& metal_context() const {
+        TT_FATAL(metal_context_ != nullptr, "Missing MetalContext for this ContextDescriptor");
+        return *metal_context_;
+    }
 
     int num_cqs() const { return num_cqs_; }
     size_t l1_small_size() const { return l1_small_size_; }
@@ -110,18 +81,24 @@ public:
     const DispatchCoreConfig& dispatch_core_config() const { return dispatch_core_config_; }
     const tt::stl::Span<const std::uint32_t>& l1_bank_remap() const { return l1_bank_remap_; }
 
-    tt::tt_fabric::FabricConfig fabric_config() const { return fabric_config_; }
-    tt::tt_fabric::FabricReliabilityMode reliability_mode() const { return reliability_mode_; }
-    std::optional<uint8_t> num_routing_planes() const { return num_routing_planes_; }
-    tt::tt_fabric::FabricTensixConfig fabric_tensix_config() const { return fabric_tensix_config_; }
-    tt::tt_fabric::FabricUDMMode fabric_udm_mode() const { return fabric_udm_mode_; }
-    tt::tt_fabric::FabricManagerMode fabric_manager() const { return fabric_manager_; }
-    const tt::tt_fabric::FabricRouterConfig& router_config() const { return router_config_; }
+    const Hal& hal() const { return env_impl().get_hal(); }
+    Cluster& cluster() const { return env_impl().get_cluster(); }
+    const llrt::RunTimeOptions& rtoptions() const { return env_impl().get_rtoptions(); }
+
+    tt_fabric::FabricConfig fabric_config() const { return env_impl().get_fabric_config(); }
+    tt_fabric::FabricReliabilityMode fabric_reliability_mode() const {
+        return env_impl().get_fabric_reliability_mode();
+    }
+    tt_fabric::FabricTensixConfig fabric_tensix_config() const { return env_impl().get_fabric_tensix_config(); }
+    tt_fabric::FabricUDMMode fabric_udm_mode() const { return env_impl().get_fabric_udm_mode(); }
+    tt_fabric::FabricManagerMode fabric_manager() const { return env_impl().get_fabric_manager(); }
+    const tt::tt_fabric::FabricRouterConfig& fabric_router_config() const {
+        return env_impl().get_fabric_router_config();
+    }
 
     // Dependencies
-    const Hal* hal_ = nullptr;
-    Cluster* cluster_ = nullptr;
-    const llrt::RunTimeOptions* rtoptions_ = nullptr;
+    MetalEnv* env_ = nullptr;
+    MetalContext* metal_context_ = nullptr;
 
     // Dispatch
     int num_cqs_ = 1;
@@ -130,16 +107,6 @@ public:
     size_t worker_l1_size_ = 0;
     DispatchCoreConfig dispatch_core_config_;
     tt::stl::Span<const std::uint32_t> l1_bank_remap_;
-
-    // Fabric
-    tt::tt_fabric::FabricConfig fabric_config_ = tt::tt_fabric::FabricConfig::DISABLED;
-    tt::tt_fabric::FabricReliabilityMode reliability_mode_ =
-        tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE;
-    std::optional<uint8_t> num_routing_planes_;
-    tt::tt_fabric::FabricTensixConfig fabric_tensix_config_ = tt::tt_fabric::FabricTensixConfig::DISABLED;
-    tt::tt_fabric::FabricUDMMode fabric_udm_mode_ = tt::tt_fabric::FabricUDMMode::DISABLED;
-    tt::tt_fabric::FabricManagerMode fabric_manager_ = tt::tt_fabric::FabricManagerMode::DEFAULT;
-    tt::tt_fabric::FabricRouterConfig router_config_;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/context/context_types.hpp
+++ b/tt_metal/impl/context/context_types.hpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <tt_stl/strong_type.hpp>
 #include <tt-metalium/device.hpp>
+#include <tt-metalium/mesh_device.hpp>
 
 namespace tt::tt_metal {
 
@@ -24,6 +25,8 @@ constexpr size_t MAX_CONTEXT_COUNT = 32;
 
 // Helper function to extract the context ID from the public API device type by casting it to the concrete type
 // The IDevice does not have a get_context_id() method because Context ID is an internal concept.
-ContextId extract_context_id(IDevice* device);
+ContextId extract_context_id(const IDevice* device);
+
+ContextId extract_context_id(const distributed::MeshDevice* mesh_device);
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/context/context_types.hpp
+++ b/tt_metal/impl/context/context_types.hpp
@@ -23,10 +23,18 @@ constexpr ContextId DEFAULT_CONTEXT_ID = ContextId{0};
 // Limit the number of context IDs so they can be stored in an array
 constexpr size_t MAX_CONTEXT_COUNT = 32;
 
-// Helper function to extract the context ID from the public API device type by casting it to the concrete type
-// The IDevice does not have a get_context_id() method because Context ID is an internal concept.
+// Helper function to extract the context ID from the public API device type by casting it to the impl type.
+// This function may perform a dynamic cast on the IDevice so should not be used in performance critical paths.
+// TODO: Remove these extract_context_id functions once all child objects have MetalEnv and MetalContext references
+// passed in
 ContextId extract_context_id(const IDevice* device);
 
 ContextId extract_context_id(const distributed::MeshDevice* mesh_device);
+
+// Extract context ID from MeshDevice or Device, using whichever one is not nullptr
+// This is used specifically by the profiler as some functions accept both a MeshDevice xor a IDevice pointer
+// TOOD: Remove this and make profiler aware of which MetalEnv the device is on
+// https://github.com/tenstorrent/tt-metal/issues/39741
+ContextId extract_context_id(const distributed::MeshDevice* mesh_device, const IDevice* device);
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -20,6 +20,7 @@
 #include "context_types.hpp"
 #include "context/metal_env_accessor.hpp"
 #include <tt-metalium/experimental/context/metal_env.hpp>
+#include "dispatch_core_common.hpp"
 #include "distributed/mesh_device_impl.hpp"
 #include "metal_env_impl.hpp"
 #include "context_descriptor.hpp"
@@ -190,10 +191,12 @@ void MetalContext::initialize(
     // Resolve the dispatch core axis for this context's architecture.
     // The default DispatchCoreConfig leaves axis_ unset, causing get_dispatch_core_axis()
     // to call get_default_axis() which only checks the DEFAULT context. For non-default
-    // contexts (e.g. mock BLACKHOLE), this returns the wrong axis. Resolve it eagerly here.
-    dispatch_core_config_ = dispatch_core_config;
-    dispatch_core_config_.set_dispatch_core_axis(
-        resolve_dispatch_core_axis(get_cluster().arch(), get_fabric_tensix_config()));
+    // contexts (e.g. mock BLACKHOLE), this returns the wrong axis. Resolve it eagerly here,
+    // but only when the caller hasn't explicitly set an axis.
+    // TODO: https://github.com/tenstorrent/tt-metal/issues/39974
+    DispatchCoreAxis axis =
+        resolve_dispatch_core_axis(dispatch_core_config, get_cluster().arch(), get_fabric_tensix_config());
+    dispatch_core_config_.set_dispatch_core_axis(axis);
 
     num_hw_cqs_ = num_hw_cqs;
     worker_l1_size_ = worker_l1_size;

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -119,6 +119,18 @@ ContextId extract_context_id(const distributed::MeshDevice* mesh_device) {
     return mesh_device->impl().get_context_id();
 }
 
+ContextId extract_context_id(distributed::MeshDevice* mesh_device, IDevice* device) {
+    ContextId context_id = DEFAULT_CONTEXT_ID;
+    if (mesh_device != nullptr) {
+        context_id = extract_context_id(static_cast<const distributed::MeshDevice*>(mesh_device));
+    } else if (device != nullptr) {
+        context_id = extract_context_id(static_cast<const IDevice*>(device));
+    } else {
+        TT_FATAL(false, "Both MeshDevice and Device are nullptr");
+    }
+    return context_id;
+}
+
 void MetalContext::initialize_device_manager(
     const std::vector<ChipId>& device_ids,
     uint8_t num_hw_cqs,

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -194,6 +194,7 @@ void MetalContext::initialize(
     // contexts (e.g. mock BLACKHOLE), this returns the wrong axis. Resolve it eagerly here,
     // but only when the caller hasn't explicitly set an axis.
     // TODO: https://github.com/tenstorrent/tt-metal/issues/39974
+    dispatch_core_config_ = dispatch_core_config;
     DispatchCoreAxis axis =
         resolve_dispatch_core_axis(dispatch_core_config, get_cluster().arch(), get_fabric_tensix_config());
     dispatch_core_config_.set_dispatch_core_axis(axis);

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -17,8 +17,11 @@
 #include <tracy/Tracy.hpp>
 
 #include "metal_context.hpp"
+#include "context_types.hpp"
 #include "context/metal_env_accessor.hpp"
 #include <tt-metalium/experimental/context/metal_env.hpp>
+#include "distributed/mesh_device_impl.hpp"
+#include "metal_env_impl.hpp"
 #include "context_descriptor.hpp"
 #include "core_coord.hpp"
 #include "device/firmware/risc_firmware_initializer.hpp"
@@ -44,6 +47,7 @@
 #include <system_mesh.hpp>
 
 #include <tt_metal.hpp>
+#include <umd/device/types/arch.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>
 #include "dispatch/data_collector.hpp"
 
@@ -52,7 +56,7 @@
 #include <llrt/tt_cluster.hpp>
 #include <dispatch/dispatch_mem_map.hpp>
 
-namespace tt::tt_metal {
+                    namespace tt::tt_metal {
 
 // MetalContext destructor is private, so we can't use a unique_ptr to manage the instance.
 std::array<std::atomic<MetalContext*>, MAX_CONTEXT_COUNT> g_instances{};
@@ -97,6 +101,23 @@ void validate_worker_l1_size(size_t& worker_l1_size, const Hal& hal) {
         max_worker_l1_size);
 }
 }  // namespace
+
+ContextId extract_context_id(const IDevice* device) {
+    // get_mesh_device is not const
+    if (const_cast<IDevice*>(device)->get_mesh_device() != nullptr) {
+        const auto& mesh_device = const_cast<IDevice*>(device)->get_mesh_device();
+        return mesh_device->impl().get_context_id();
+    }
+    // Must be a Device if not MeshDevice
+    const auto* device_concrete = dynamic_cast<const Device*>(device);
+    TT_ASSERT(device_concrete != nullptr, "Device is not a Device");
+    return device_concrete->get_context_id();
+}
+
+ContextId extract_context_id(const distributed::MeshDevice* mesh_device) {
+    TT_ASSERT(mesh_device != nullptr, "MeshDevice is nullptr");
+    return mesh_device->impl().get_context_id();
+}
 
 void MetalContext::initialize_device_manager(
     const std::vector<ChipId>& device_ids,
@@ -153,7 +174,15 @@ void MetalContext::initialize(
     }
 
     initialized_ = true;
+
+    // Resolve the dispatch core axis for this context's architecture.
+    // The default DispatchCoreConfig leaves axis_ unset, causing get_dispatch_core_axis()
+    // to call get_default_axis() which only checks the DEFAULT context. For non-default
+    // contexts (e.g. mock BLACKHOLE), this returns the wrong axis. Resolve it eagerly here.
     dispatch_core_config_ = dispatch_core_config;
+    dispatch_core_config_.set_dispatch_core_axis(
+        resolve_dispatch_core_axis(get_cluster().arch(), get_fabric_tensix_config()));
+
     num_hw_cqs_ = num_hw_cqs;
     worker_l1_size_ = worker_l1_size;
     l1_bank_remap_ = l1_bank_remap;
@@ -165,17 +194,20 @@ void MetalContext::initialize(
         max_alignment);
 
     // Initialize inspector
-    inspector_data_ = Inspector::initialize();
-    // Set fw_compile_hash for Inspector RPC build environment info
-    Inspector::set_build_env_fw_compile_hash(fw_compile_hash);
-
+    if (this->get_cluster().get_target_device_type() != tt::TargetDevice::Mock) {
+        inspector_data_ = Inspector::initialize();
+        // Set fw_compile_hash for Inspector RPC build environment info
+        Inspector::set_build_env_fw_compile_hash(fw_compile_hash);
+    }
     // Reset timeout detection state
     dispatch_timeout_detection_processed_ = false;
 
     // Initialize dispatch state
     bool is_galaxy_cluster = get_cluster().is_galaxy_cluster();
-    dispatch_core_manager_ = std::make_unique<dispatch_core_manager>(dispatch_core_config, num_hw_cqs);
-    dispatch_query_manager_ = std::make_unique<DispatchQueryManager>(num_hw_cqs);
+    dispatch_core_manager_ = std::make_unique<dispatch_core_manager>(
+        dispatch_core_config_, num_hw_cqs, MetalEnvAccessor(*this->env_).impl());
+    dispatch_query_manager_ =
+        std::make_unique<DispatchQueryManager>(*this->env_, *dispatch_core_manager_, dispatch_core_config_, num_hw_cqs);
     dispatch_mem_map_[enchantum::to_underlying(CoreType::WORKER)] =
         std::make_unique<DispatchMemMap>(CoreType::WORKER, num_hw_cqs, hal(), is_galaxy_cluster);
     dispatch_mem_map_[enchantum::to_underlying(CoreType::ETH)] =
@@ -186,10 +218,10 @@ void MetalContext::initialize(
     if (rtoptions().get_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint)) {
         TT_FATAL(!rtoptions().get_profiler_enabled(), "Both DPRINT and Profiler cannot be enabled at the same time.");
         rtoptions().set_disable_dma_ops(true);  // DMA is not thread-safe
-        dprint_server_ = std::make_unique<DPrintServer>(rtoptions());
+        dprint_server_ = std::make_unique<DPrintServer>(*this->env_, num_hw_cqs, dispatch_core_config_);
     }
-    watcher_server_ =
-        std::make_unique<WatcherServer>();  // Watcher server always created, since we use it to register kernels
+    // Watcher server always created, since we use it to register kernels
+    watcher_server_ = std::make_unique<WatcherServer>(*this->env_);
     noc_debug_state_ = std::make_unique<NOCDebugState>();
 
     if (rtoptions().get_experimental_noc_debug_dump_enabled()) {
@@ -223,7 +255,7 @@ void MetalContext::initialize(
     risc_firmware_initializer_->run_async_build_phase(device_ids);
 
     // Set internal routing for active ethernet cores, this is required for our FW to run
-    if (has_flag(MetalContext::instance().get_fabric_manager(), tt_fabric::FabricManagerMode::INIT_FABRIC) &&
+    if (has_flag(get_fabric_manager(), tt_fabric::FabricManagerMode::INIT_FABRIC) &&
         get_cluster().get_target_device_type() != tt::TargetDevice::Mock) {
         get_cluster().set_internal_routing_info_for_ethernet_cores(this->get_control_plane(), true);
     }
@@ -246,8 +278,10 @@ void MetalContext::initialize(
 void MetalContext::reinitialize_dispatch_managers() {
     // Reinitialize dispatch core manager and query manager to pick up current dispatch mode
     // This refreshes cached dispatch/compute core allocations when transitioning SD<->FD
-    dispatch_core_manager_ = std::make_unique<dispatch_core_manager>(dispatch_core_config_, num_hw_cqs_);
-    dispatch_query_manager_ = std::make_unique<DispatchQueryManager>(num_hw_cqs_);
+    dispatch_core_manager_ = std::make_unique<dispatch_core_manager>(
+        dispatch_core_config_, num_hw_cqs_, MetalEnvAccessor(*this->env_).impl());
+    dispatch_query_manager_ = std::make_unique<DispatchQueryManager>(
+        *this->env_, *dispatch_core_manager_, dispatch_core_config_, num_hw_cqs_);
 }
 
 void MetalContext::set_fast_dispatch_mode(bool enable) {
@@ -421,7 +455,7 @@ void MetalContext::teardown_dispatch_state() {
 MetalContext::MetalContext(ContextId context_id, tt::tt_metal::MetalEnv& metal_env) :
     env_(&metal_env), context_id_(context_id) {
     check_context_id(context_id);
-    device_manager_ = std::make_unique<DeviceManager>();
+    device_manager_ = std::make_unique<DeviceManager>(metal_env, *this);
 }
 
 MetalContext::~MetalContext() {
@@ -532,7 +566,9 @@ void MetalContext::set_fabric_config(
     tt_fabric::FabricManagerMode fabric_manager,
     tt_fabric::FabricRouterConfig router_config) {
     TT_FATAL(env_ != nullptr, "Missing MetalEnv for this MetalContext");
-    bool updated = MetalEnvAccessor(*env_).impl().set_fabric_config(
+    // This env pointer was provided to both descriptors so they
+    // will see the updated config as well
+    MetalEnvAccessor(*env_).impl().set_fabric_config(
         fabric_config,
         reliability_mode,
         num_routing_planes,
@@ -540,18 +576,6 @@ void MetalContext::set_fabric_config(
         fabric_udm_mode,
         fabric_manager,
         router_config);
-    if (updated) {
-        // Update the risc firmware context descriptor with the new fabric settings
-        // as well due to transient state between the descriptor creation and the fabric config update
-        if (risc_fw_context_descriptor_) {
-            risc_fw_context_descriptor_->fabric_config_ = fabric_config;
-            risc_fw_context_descriptor_->reliability_mode_ = reliability_mode;
-            risc_fw_context_descriptor_->num_routing_planes_ = num_routing_planes;
-            risc_fw_context_descriptor_->fabric_tensix_config_ = fabric_tensix_config;
-            risc_fw_context_descriptor_->fabric_udm_mode_ = fabric_udm_mode;
-            risc_fw_context_descriptor_->fabric_manager_ = fabric_manager;
-        }
-    }
 }
 
 void MetalContext::initialize_fabric_config() {
@@ -619,19 +643,11 @@ std::shared_ptr<distributed::multihost::DistributedContext> MetalContext::get_di
 void MetalContext::init_context_descriptor(
     int num_hw_cqs, size_t l1_small_size, size_t trace_region_size, size_t worker_l1_size) {
     TT_FATAL(env_ != nullptr, "Missing MetalEnv for this MetalContext");
-    MetalEnvImpl& env_accessor = MetalEnvAccessor(*env_).impl();
     std::string mock_cluster_desc_path =
         env_->get_descriptor().is_mock_device() ? env_->get_descriptor().mock_cluster_desc_path() : "";
     context_descriptor_ = std::make_shared<ContextDescriptor>(
-        hal(),
-        get_cluster(),
-        rtoptions(),
-        env_accessor.get_fabric_config(),
-        env_accessor.get_fabric_reliability_mode(),
-        env_accessor.get_fabric_tensix_config(),
-        env_accessor.get_fabric_udm_mode(),
-        env_accessor.get_fabric_manager(),
-        env_accessor.get_fabric_router_config(),
+        env_,
+        this,
         num_hw_cqs,
         l1_small_size,
         trace_region_size,
@@ -647,17 +663,9 @@ void MetalContext::init_risc_fw_context_descriptor(int num_hw_cqs, size_t worker
 
     // Fabric settings are used during risc init. In some cases, fabric is already running
     // and we don't want to reset the cores
-    MetalEnvImpl& env_accessor = MetalEnvAccessor(*env_).impl();
     risc_fw_context_descriptor_ = std::make_shared<ContextDescriptor>(
-        hal(),
-        get_cluster(),
-        rtoptions(),
-        env_accessor.get_fabric_config(),
-        env_accessor.get_fabric_reliability_mode(),
-        env_accessor.get_fabric_tensix_config(),
-        env_accessor.get_fabric_udm_mode(),
-        env_accessor.get_fabric_manager(),
-        env_accessor.get_fabric_router_config(),
+        env_,
+        this,
         num_hw_cqs,
         /*l1_small_size=*/0,
         /*trace_region_size=*/0,

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -56,7 +56,7 @@
 #include <llrt/tt_cluster.hpp>
 #include <dispatch/dispatch_mem_map.hpp>
 
-                    namespace tt::tt_metal {
+namespace tt::tt_metal {
 
 // MetalContext destructor is private, so we can't use a unique_ptr to manage the instance.
 std::array<std::atomic<MetalContext*>, MAX_CONTEXT_COUNT> g_instances{};

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -119,12 +119,12 @@ ContextId extract_context_id(const distributed::MeshDevice* mesh_device) {
     return mesh_device->impl().get_context_id();
 }
 
-ContextId extract_context_id(distributed::MeshDevice* mesh_device, IDevice* device) {
+ContextId extract_context_id(const distributed::MeshDevice* mesh_device, const IDevice* device) {
     ContextId context_id = DEFAULT_CONTEXT_ID;
     if (mesh_device != nullptr) {
-        context_id = extract_context_id(static_cast<const distributed::MeshDevice*>(mesh_device));
+        context_id = extract_context_id(mesh_device);
     } else if (device != nullptr) {
-        context_id = extract_context_id(static_cast<const IDevice*>(device));
+        context_id = extract_context_id(device);
     } else {
         TT_FATAL(false, "Both MeshDevice and Device are nullptr");
     }

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -15,7 +15,6 @@
 #include "context_types.hpp"
 #include <tt-metalium/experimental/context/metal_env.hpp>
 #include "hostdevcommon/api/hostdevcommon/common_values.hpp"
-#include "context_types.hpp"
 
 namespace tt::tt_fabric {
 class ControlPlane;

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -12,6 +12,7 @@
 #include <tt-metalium/allocator.hpp>
 #include "impl/device/firmware/firmware_initializer.hpp"
 #include <umd/device/types/cluster_descriptor_types.hpp>
+#include "context_types.hpp"
 #include <tt-metalium/experimental/context/metal_env.hpp>
 #include "hostdevcommon/api/hostdevcommon/common_values.hpp"
 #include "context_types.hpp"
@@ -73,6 +74,10 @@ public:
 
     // Check if a MetalContext for a given context id exists.
     static bool instance_exists(ContextId context_id = DEFAULT_CONTEXT_ID);
+
+    // Returns the id of this instance. The ID cannot be used to uniquely identify the context.
+    // IDs are recycled after instances are destroyed.
+    ContextId get_context_id() const { return context_id_; }
 
     [[deprecated("Use MetalEnv instead")]] Cluster& get_cluster();
     [[deprecated("Use MetalEnv instead")]] llrt::RunTimeOptions& rtoptions();

--- a/tt_metal/impl/context/metal_env.cpp
+++ b/tt_metal/impl/context/metal_env.cpp
@@ -11,6 +11,8 @@
 #include <limits>
 #include <unordered_set>
 #include "metal_env_impl.hpp"
+#include "metal_context.hpp"
+#include "distributed/mesh_device_impl.hpp"
 #include "firmware_capability.hpp"
 #include "get_platform_architecture.hpp"
 #include "profiler_state_manager.hpp"
@@ -518,6 +520,7 @@ const MetalEnvDescriptor& MetalEnv::get_descriptor() const { return impl_->get_d
 tt::ARCH MetalEnv::get_arch() const { return impl_->get_cluster().arch(); }
 std::string MetalEnv::get_arch_name() const { return tt::get_string_lowercase(get_arch()); }
 uint32_t MetalEnv::get_num_pcie_devices() const { return impl_->get_cluster().number_of_pci_devices(); }
+uint32_t MetalEnv::get_num_available_devices() const { return impl_->get_cluster().number_of_user_devices(); }
 uint32_t MetalEnv::get_l1_size() const {
     return impl_->get_hal().get_dev_size(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::BASE);
 }
@@ -535,5 +538,77 @@ float MetalEnv::get_inf() const { return impl_->get_hal().get_inf(); }
 
 tt::tt_fabric::ControlPlane& MetalEnv::get_control_plane() { return impl_->get_control_plane(); }
 distributed::SystemMesh& MetalEnv::get_system_mesh() { return impl_->get_system_mesh(); }
+std::shared_ptr<distributed::MeshDevice> MetalEnv::create_mesh_device(
+    const distributed::MeshDeviceConfig& config,
+    size_t l1_small_size,
+    size_t trace_region_size,
+    size_t num_command_queues,
+    const DispatchCoreConfig& dispatch_core_config,
+    tt::stl::Span<const std::uint32_t> l1_bank_remap,
+    size_t worker_l1_size) {
+    // Associate a context ID for the mesh device's dependencies to easily access the MetalContext::instance(contextId)
+    // TODO: Remove this and directly pass in the MetalEnv reference
+    ContextId context_id = MetalContext::create_instance(*this);
+    auto mesh_device = distributed::MeshDeviceImpl::create(
+        context_id,
+        config,
+        l1_small_size,
+        trace_region_size,
+        num_command_queues,
+        dispatch_core_config,
+        l1_bank_remap,
+        worker_l1_size);
+    mesh_device->impl().set_destroy_metal_context_instance_on_close(true);
+    return mesh_device;
+}
+
+std::shared_ptr<distributed::MeshDevice> MetalEnv::create_unit_mesh_device(
+    int device_id,
+    size_t l1_small_size,
+    size_t trace_region_size,
+    size_t num_command_queues,
+    const DispatchCoreConfig& dispatch_core_config,
+    tt::stl::Span<const std::uint32_t> l1_bank_remap,
+    size_t worker_l1_size) {
+    ContextId context_id = MetalContext::create_instance(*this);
+    auto mesh_device = distributed::MeshDeviceImpl::create_unit_mesh(
+        context_id,
+        device_id,
+        l1_small_size,
+        trace_region_size,
+        num_command_queues,
+        dispatch_core_config,
+        l1_bank_remap,
+        worker_l1_size);
+    mesh_device->impl().set_destroy_metal_context_instance_on_close(true);
+    return mesh_device;
+}
+
+std::map<int, std::shared_ptr<distributed::MeshDevice>> MetalEnv::create_unit_meshes(
+    const std::vector<int>& device_ids,
+    size_t l1_small_size,
+    size_t trace_region_size,
+    size_t num_command_queues,
+    const DispatchCoreConfig& dispatch_core_config,
+    tt::stl::Span<const std::uint32_t> l1_bank_remap,
+    size_t worker_l1_size) {
+    ContextId context_id = MetalContext::create_instance(*this);
+    auto result = distributed::MeshDeviceImpl::create_unit_meshes(
+        context_id,
+        device_ids,
+        l1_small_size,
+        trace_region_size,
+        num_command_queues,
+        dispatch_core_config,
+        l1_bank_remap,
+        worker_l1_size);
+    if (!result.empty()) {
+        const auto& parent = result.begin()->second->get_parent_mesh();
+        if (parent) {
+            parent->impl().set_destroy_metal_context_instance_on_close(true);
+        }
+    }
+    return result;
+}
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/context/metal_env.cpp
+++ b/tt_metal/impl/context/metal_env.cpp
@@ -11,8 +11,10 @@
 #include <limits>
 #include <unordered_set>
 #include "metal_env_impl.hpp"
+#include "metal_env_accessor.hpp"
 #include "metal_context.hpp"
 #include "distributed/mesh_device_impl.hpp"
+#include "impl/sub_device/sub_device_impl.hpp"
 #include "firmware_capability.hpp"
 #include "get_platform_architecture.hpp"
 #include "profiler_state_manager.hpp"
@@ -609,6 +611,11 @@ std::map<int, std::shared_ptr<distributed::MeshDevice>> MetalEnv::create_unit_me
         }
     }
     return result;
+}
+
+SubDevice MetalEnv::create_sub_device(tt::stl::Span<const CoreRangeSet> cores) {
+    // Use SubDevice constructor marked as internal
+    return SubDevice(SubDeviceImpl(&MetalEnvAccessor(*this).impl(), cores));
 }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/context/metal_env_impl.hpp
+++ b/tt_metal/impl/context/metal_env_impl.hpp
@@ -37,6 +37,7 @@ public:
     llrt::RunTimeOptions& get_rtoptions();
     const Hal& get_hal();
     Cluster& get_cluster();
+    distributed::SystemMesh& get_system_mesh();
     const MetalEnvDescriptor& get_descriptor() const;
 
     bool check_use_count_zero() const;
@@ -72,10 +73,10 @@ public:
     tt::tt_fabric::ControlPlane& get_control_plane();
     void initialize_control_plane();
 
-    // --- System mesh ---
-    distributed::SystemMesh& get_system_mesh();
-
     // --- Custom topology ---
+    // Need to call set_fabric_config to reinit the control plane after calling this
+    // TODO: Remove these two functions in favor of a unified set fabric config where you can
+    // pass in a custom topology.
     void set_custom_fabric_topology(
         const std::string& mesh_graph_desc_file,
         const std::map<tt_fabric::FabricNodeId, ChipId>& logical_mesh_chip_id_to_physical_chip_id_mapping);
@@ -93,6 +94,10 @@ public:
     bool consume_force_reinit();
 
 private:
+    // During init we need to bypass set_fabric_config to avoid reinitialization of the control plane
+    // by directly setting the fabric config state.
+    friend class DeviceManager;
+
     MetalEnvDescriptor descriptor_;
 
     std::unique_ptr<llrt::RunTimeOptions> rtoptions_;

--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -13,6 +13,7 @@
 
 #include <fmt/format.h>
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
+#include "context/metal_env_accessor.hpp"
 #include "llrt/core_descriptor.hpp"
 #include "hostdevcommon/dprint_common.h"
 #include "impl/context/metal_context.hpp"
@@ -36,22 +37,20 @@ struct CoreDescriptorComparator {
 using CoreDescriptorSet = std::set<umd::CoreDescriptor, CoreDescriptorComparator>;
 
 // Helper function to get CoreDescriptors for all debug-relevant cores on device.
-inline static CoreDescriptorSet GetAllCores(ChipId device_id) {
+inline static CoreDescriptorSet GetAllCores(
+    tt::Cluster& cluster, tt::tt_fabric::ControlPlane& control_plane, ChipId device_id) {
     CoreDescriptorSet all_cores;
     // The set of all printable cores is Tensix + Eth cores
-    CoreCoord logical_grid_size =
-        tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device_id).get_grid_size(CoreType::TENSIX);
+    CoreCoord logical_grid_size = cluster.get_soc_desc(device_id).get_grid_size(CoreType::TENSIX);
     for (uint32_t x = 0; x < logical_grid_size.x; x++) {
         for (uint32_t y = 0; y < logical_grid_size.y; y++) {
             all_cores.insert({{x, y}, CoreType::WORKER});
         }
     }
-    for (const auto& logical_core :
-         tt::tt_metal::MetalContext::instance().get_control_plane().get_active_ethernet_cores(device_id)) {
+    for (const auto& logical_core : control_plane.get_active_ethernet_cores(device_id)) {
         all_cores.insert({logical_core, CoreType::ETH});
     }
-    for (const auto& logical_core :
-         tt::tt_metal::MetalContext::instance().get_control_plane().get_inactive_ethernet_cores(device_id)) {
+    for (const auto& logical_core : control_plane.get_inactive_ethernet_cores(device_id)) {
         all_cores.insert({logical_core, CoreType::ETH});
     }
 
@@ -60,14 +59,12 @@ inline static CoreDescriptorSet GetAllCores(ChipId device_id) {
 
 // Helper function to get CoreDescriptors for all cores that are used for dispatch. Should be a subset of
 // GetAllCores().
-[[maybe_unused]] static CoreDescriptorSet GetDispatchCores(ChipId device_id) {
+[[maybe_unused]] static CoreDescriptorSet GetDispatchCores(
+    MetalEnvImpl& env, ChipId device_id, uint8_t num_hw_cqs, const DispatchCoreConfig& dispatch_core_config) {
     CoreDescriptorSet dispatch_cores;
-    unsigned num_cqs = tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().get_num_hw_cqs();
-    const auto& dispatch_core_config =
-        tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
     CoreType dispatch_core_type = get_core_type_from_config(dispatch_core_config);
     log_debug(tt::LogAlways, "Dispatch Core Type = {}", dispatch_core_type);
-    for (auto logical_core : tt::get_logical_dispatch_cores(device_id, num_cqs, dispatch_core_config)) {
+    for (auto logical_core : tt::get_logical_dispatch_cores(env, device_id, num_hw_cqs, dispatch_core_config)) {
         dispatch_cores.insert({logical_core, dispatch_core_type});
     }
     return dispatch_cores;

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -31,6 +31,7 @@
 
 #include <enchantum/enchantum.hpp>
 #include <tt-logger/tt-logger.hpp>
+#include "context/metal_env_accessor.hpp"
 #include "impl/data_format/blockfloat_common.hpp"
 #include <tt_stl/assert.hpp>
 #include <tt_stl/fmt.hpp>
@@ -50,6 +51,7 @@
 #include "hostdevcommon/kernel_structs.h"
 #include "llrt.hpp"
 #include "impl/context/metal_context.hpp"
+#include "impl/context/metal_env_impl.hpp"
 #include "tt_backend_api_types.hpp"
 #include <llrt/tt_cluster.hpp>
 #include "impl/debug/inspector/inspector.hpp"
@@ -102,18 +104,22 @@ namespace {
 
 string logfile_path = "generated/dprint/";
 
-string GetRiscName(ChipId device_id, const umd::CoreDescriptor& logical_core, int risc_id, bool abbreviated = false) {
+string GetRiscName(
+    const tt::Cluster& cluster,
+    const tt_metal::Hal& hal,
+    ChipId device_id,
+    const umd::CoreDescriptor& logical_core,
+    int risc_id,
+    bool abbreviated = false) {
     CoreCoord virtual_core =
-        tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
-            device_id, logical_core.coord, logical_core.type);
+        cluster.get_virtual_coordinate_from_logical_coordinates(device_id, logical_core.coord, logical_core.type);
     auto programmable_core_type = llrt::get_core_type(device_id, virtual_core);
-    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
     return hal.get_processor_class_name(programmable_core_type, risc_id, abbreviated);
 }
 
-inline bool RiscEnabled(tt_metal::HalProgrammableCoreType core_type, int risc_index) {
-    const auto& processors =
-        tt::tt_metal::MetalContext::instance().rtoptions().get_feature_processors(tt::llrt::RunTimeDebugFeatureDprint);
+inline bool RiscEnabled(
+    const llrt::RunTimeOptions& rtoptions, tt_metal::HalProgrammableCoreType core_type, int risc_index) {
+    const auto& processors = rtoptions.get_feature_processors(tt::llrt::RunTimeDebugFeatureDprint);
     return processors.contains(core_type, risc_index);
 }
 
@@ -128,6 +134,7 @@ std::ostream null_stream(&null_buffer);
 // Writes a magic value at wpos ptr address for dprint buffer at the given address.
 // Used for debug print server startup sequence.
 void WriteInitMagic(
+    tt::Cluster& cluster,
     ChipId device_id,
     const CoreCoord& virtual_core,
     uint64_t base_addr,
@@ -137,7 +144,7 @@ void WriteInitMagic(
     // Force wait for first kernel launch by first writing a non-zero and waiting for a zero.
     std::vector<uint32_t> initbuf = std::vector<uint32_t>(buffer_size / sizeof(uint32_t), 0);
     initbuf[0] = uint32_t(enabled ? DEBUG_PRINT_SERVER_STARTING_MAGIC : DEBUG_PRINT_SERVER_DISABLED_MAGIC);
-    tt::tt_metal::MetalContext::instance().get_cluster().write_core(device_id, virtual_core, initbuf, base_addr);
+    cluster.write_core(device_id, virtual_core, initbuf, base_addr);
 
     // Prevent race conditions during runtime by waiting until the init value is actually written
     // DPrint is only used for debug purposes so this delay should not be a big issue.
@@ -147,8 +154,7 @@ void WriteInitMagic(
     // 4. now we will access wpos at the starting magic which is incorrect
     uint32_t num_tries = 100000;
     while (num_tries-- > 0) {
-        auto result =
-            tt::tt_metal::MetalContext::instance().get_cluster().read_core(device_id, virtual_core, base_addr, 4);
+        auto result = cluster.read_core(device_id, virtual_core, base_addr, 4);
         if ((result[0] == DEBUG_PRINT_SERVER_STARTING_MAGIC && enabled) ||
             (result[0] == DEBUG_PRINT_SERVER_DISABLED_MAGIC && !enabled)) {
             return;
@@ -161,8 +167,8 @@ void WriteInitMagic(
 // The assumption is that if our magic number was cleared,
 // it means there is a write in the queue and wpos/rpos are now valid
 // Note that this is not a bulletproof way to bootstrap the print server (TODO(AP))
-bool CheckInitMagicCleared(ChipId device_id, const CoreCoord& virtual_core, uint64_t base_addr) {
-    auto result = tt::tt_metal::MetalContext::instance().get_cluster().read_core(device_id, virtual_core, base_addr, 4);
+bool CheckInitMagicCleared(tt::Cluster& cluster, ChipId device_id, const CoreCoord& virtual_core, uint64_t base_addr) {
+    auto result = cluster.read_core(device_id, virtual_core, base_addr, 4);
     return (result[0] != DEBUG_PRINT_SERVER_STARTING_MAGIC && result[0] != DEBUG_PRINT_SERVER_DISABLED_MAGIC);
 }  // CheckInitMagicCleared
 
@@ -174,7 +180,7 @@ namespace tt::tt_metal {
 // Contains all common state and logic; subclasses only override peek_one_risc_non_blocking.
 class DPrintServer::Impl {
 public:
-    Impl(llrt::RunTimeOptions& rtoptions);
+    Impl(MetalEnv& env, uint8_t num_hw_cqs, const DispatchCoreConfig& dispatch_core_config);
     Impl() = delete;
     Impl(const Impl&) = delete;
     Impl& operator=(const Impl&) = delete;
@@ -250,6 +256,10 @@ protected:
     std::map<ChipId, bool> device_intermediate_streams_force_flush_;
     std::mutex device_intermediate_streams_force_flush_lock_;
 
+    MetalEnvImpl& env_;
+    uint8_t num_hw_cqs_;
+    DispatchCoreConfig dispatch_core_config_;
+
     // Polls specified cores/riscs on all attached devices and prints any new print data. This
     // function is the main loop for the print server thread.
     void poll_print_data();
@@ -270,7 +280,8 @@ protected:
 // Original DPRINT implementation: reads DPRINT buffers written by device kernels.
 class DPrintImpl : public DPrintServer::Impl {
 public:
-    DPrintImpl(llrt::RunTimeOptions& rtoptions) : DPrintServer::Impl(rtoptions) {}
+    DPrintImpl(MetalEnv& env, uint8_t num_hw_cqs, const DispatchCoreConfig& dispatch_core_config) :
+        DPrintServer::Impl(env, num_hw_cqs, dispatch_core_config) {}
 
 protected:
     bool poll_one_core(ChipId device_id, const umd::CoreDescriptor& logical_core, bool new_data_this_iter) override;
@@ -293,7 +304,8 @@ static_assert(sizeof(DevicePrintHeader) == sizeof(uint32_t));
 
 class DevicePrintImpl : public DPrintServer::Impl {
 public:
-    DevicePrintImpl(llrt::RunTimeOptions& rtoptions) : DPrintServer::Impl(rtoptions) {}
+    DevicePrintImpl(MetalEnv& env, uint8_t num_hw_cqs, const DispatchCoreConfig& dispatch_core_config) :
+        DPrintServer::Impl(env, num_hw_cqs, dispatch_core_config) {}
 
 protected:
     bool poll_one_core(ChipId device_id, const umd::CoreDescriptor& logical_core, bool new_data_this_iter) override;
@@ -323,36 +335,41 @@ private:
 
 void DPrintImpl::init_print_buffers_for_core(
     ChipId device_id, const CoreCoord& virtual_core, HalProgrammableCoreType core_type) {
-    uint32_t num_processors = MetalContext::instance().hal().get_num_risc_processors(core_type);
+    auto& cluster = env_.get_cluster();
+    uint32_t num_processors = env_.get_hal().get_num_risc_processors(core_type);
     for (int risc_index = 0; risc_index < num_processors; risc_index++) {
-        WriteInitMagic(device_id, virtual_core, GetDprintBufAddr(device_id, virtual_core, risc_index), false);
+        WriteInitMagic(cluster, device_id, virtual_core, GetDprintBufAddr(device_id, virtual_core, risc_index), false);
     }
 }
 
 void DPrintImpl::enable_print_buffers_for_core(
     ChipId device_id, const CoreCoord& virtual_core, HalProgrammableCoreType core_type) {
-    uint32_t num_processors = MetalContext::instance().hal().get_num_risc_processors(core_type);
+    const auto& rtoptions = env_.get_rtoptions();
+    auto& cluster = env_.get_cluster();
+    uint32_t num_processors = env_.get_hal().get_num_risc_processors(core_type);
     for (int risc_index = 0; risc_index < num_processors; risc_index++) {
-        if (RiscEnabled(core_type, risc_index)) {
-            WriteInitMagic(device_id, virtual_core, GetDprintBufAddr(device_id, virtual_core, risc_index), true);
+        if (RiscEnabled(rtoptions, core_type, risc_index)) {
+            WriteInitMagic(cluster, device_id, virtual_core, GetDprintBufAddr(device_id, virtual_core, risc_index), true);
         }
     }
 }
 
 bool DPrintImpl::core_has_outstanding_prints(
     ChipId device_id, const CoreCoord& virtual_core, HalProgrammableCoreType core_type) {
-    uint32_t num_processors = MetalContext::instance().hal().get_num_risc_processors(core_type);
+    const auto& rtoptions = env_.get_rtoptions();
+    auto& cluster = env_.get_cluster();
+    uint32_t num_processors = env_.get_hal().get_num_risc_processors(core_type);
     for (int risc_id = 0; risc_id < num_processors; risc_id++) {
-        if (!RiscEnabled(core_type, risc_id)) {
+        if (!RiscEnabled(rtoptions, core_type, risc_id)) {
             continue;
         }
         uint64_t base_addr = GetDprintBufAddr(device_id, virtual_core, risc_id);
-        if (!CheckInitMagicCleared(device_id, virtual_core, base_addr)) {
+        if (!CheckInitMagicCleared(cluster, device_id, virtual_core, base_addr)) {
             continue;
         }
         constexpr int eightbytes = 8;
         auto from_dev =
-            MetalContext::instance().get_cluster().read_core(device_id, virtual_core, base_addr, eightbytes);
+            cluster.read_core(device_id, virtual_core, base_addr, eightbytes);
         uint32_t wpos = from_dev[0], rpos = from_dev[1];
         if (rpos < wpos) {
             return true;
@@ -366,12 +383,13 @@ bool DPrintImpl::core_has_outstanding_prints(
 void DevicePrintImpl::print_buffer_data(
     ChipId device_id, const umd::CoreDescriptor& logical_core, const std::vector<uint32_t>& data) {
     std::size_t word_index = 0;
-    auto virtual_core = MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
-        device_id, logical_core.coord, logical_core.type);
+    auto& cluster = env_.get_cluster();
+    const auto& hal = env_.get_hal();
+    auto virtual_core =
+        cluster.get_virtual_coordinate_from_logical_coordinates(device_id, logical_core.coord, logical_core.type);
     auto programmable_core_type = llrt::get_core_type(device_id, virtual_core);
-    uint32_t risc_count = MetalContext::instance().hal().get_num_risc_processors(programmable_core_type);
-    uint32_t programmable_core_type_idx =
-        MetalContext::instance().hal().get_programmable_core_type_index(programmable_core_type);
+    uint32_t risc_count = env_.get_hal().get_num_risc_processors(programmable_core_type);
+    uint32_t programmable_core_type_idx = hal.get_programmable_core_type_index(programmable_core_type);
     DevicePrintParser::FormatMessageBuffer format_message_buffer;
 
     while (word_index < data.size()) {
@@ -413,7 +431,7 @@ void DevicePrintImpl::print_buffer_data(
 
             // Find elf path from inspector using kernel id
             auto kernel_path = Inspector::get_kernel_path_from_watcher_kernel_id(header->info_id);
-            auto risc_name = GetRiscName(device_id, logical_core, header->risc_id);
+            auto risc_name = GetRiscName(cluster, hal, device_id, logical_core, header->risc_id);
             std::transform(
                 risc_name.begin(), risc_name.end(), risc_name.begin(), [](auto c) { return std::tolower(c); });
             auto elf_path = std::filesystem::path(kernel_path) / risc_name / (risc_name + ".elf");
@@ -454,8 +472,7 @@ void DevicePrintImpl::print_buffer_data(
                 if (risc_data.firmware_elf_parser == nullptr) {
                     // Find firmware elf path from BuildEnvManager.
                     auto [processor_class, processor_type_idx] =
-                        MetalContext::instance().hal().get_processor_class_and_type_from_index(
-                            programmable_core_type, header->risc_id);
+                        hal.get_processor_class_and_type_from_index(programmable_core_type, header->risc_id);
                     auto firmware_elf_path = BuildEnvManager::get_instance().get_firmware_binary_path(
                         device_id,
                         programmable_core_type_idx,
@@ -507,12 +524,13 @@ void DevicePrintImpl::print_buffer_data(
                         if (!risc_data.line_prefix.has_value()) {
                             // Compute line prefix based on RTOptions
                             const bool prepend_device_core_risc =
-                                tt::tt_metal::MetalContext::instance().rtoptions().get_feature_prepend_device_core_risc(
+                                env_.get_rtoptions().get_feature_prepend_device_core_risc(
                                     tt::llrt::RunTimeDebugFeatureDprint);
                             if (prepend_device_core_risc) {
                                 const string& device_id_str = to_string(device_id);
                                 const string& core_coord_str = logical_core.coord.str();
-                                const string& risc_name = GetRiscName(device_id, logical_core, header->risc_id, true);
+                                const string& risc_name =
+                                    GetRiscName(cluster, hal, device_id, logical_core, header->risc_id, true);
                                 line_prefix = fmt::format("{}:{}:{}: ", device_id_str, core_coord_str, risc_name);
                             }
                             risc_data.line_prefix = line_prefix;
@@ -557,10 +575,11 @@ void DevicePrintImpl::print_buffer_data(
 
 bool DevicePrintImpl::poll_one_core(
     ChipId device_id, const umd::CoreDescriptor& logical_core, bool /*new_data_this_iter*/) {
-    auto virtual_core = MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
-        device_id, logical_core.coord, logical_core.type);
+    auto& cluster = env_.get_cluster();
+    auto virtual_core =
+        cluster.get_virtual_coordinate_from_logical_coordinates(device_id, logical_core.coord, logical_core.type);
     auto programmable_core_type = llrt::get_core_type(device_id, virtual_core);
-    uint32_t num_processors = MetalContext::instance().hal().get_num_risc_processors(programmable_core_type);
+    uint32_t num_processors = env_.get_hal().get_num_risc_processors(programmable_core_type);
 
     // Memory layout:
     // uint32_t wpos;
@@ -573,8 +592,7 @@ bool DevicePrintImpl::poll_one_core(
     uint32_t buffer_size = DPRINT_BUFFER_SIZE * num_processors;
     constexpr uint32_t eightbytes = 8;
     uint32_t risc_state_bytes = ((num_processors + 3) / 4) * 4;  // Round up to nearest word
-    auto from_dev =
-        MetalContext::instance().get_cluster().read_core(device_id, virtual_core, buffer_address, eightbytes);
+    auto from_dev = cluster.read_core(device_id, virtual_core, buffer_address, eightbytes);
     uint32_t wpos = from_dev[0], rpos = from_dev[1];
     uint32_t print_buffer_address =
         buffer_address + eightbytes + risc_state_bytes + sizeof(uint32_t);  // Skip wpos, rpos, risc state, and lock
@@ -586,8 +604,7 @@ bool DevicePrintImpl::poll_one_core(
 
     if (rpos > wpos) {
         // Read until end of buffer and then from beginning until wpos
-        auto data = MetalContext::instance().get_cluster().read_core(
-            device_id, virtual_core, print_buffer_address + rpos, print_buffer_size - rpos);
+        auto data = cluster.read_core(device_id, virtual_core, print_buffer_address + rpos, print_buffer_size - rpos);
 
         // Process buffer data
         print_buffer_data(device_id, logical_core, data);
@@ -597,8 +614,7 @@ bool DevicePrintImpl::poll_one_core(
     }
     if (rpos < wpos) {
         // Read until wpos
-        auto data = MetalContext::instance().get_cluster().read_core(
-            device_id, virtual_core, print_buffer_address + rpos, wpos - rpos);
+        auto data = cluster.read_core(device_id, virtual_core, print_buffer_address + rpos, wpos - rpos);
 
         // Process buffer data
         print_buffer_data(device_id, logical_core, data);
@@ -606,27 +622,30 @@ bool DevicePrintImpl::poll_one_core(
         // Update rpos, so that device knows it can use rest of the buffer
         rpos = wpos;
     }
-    MetalContext::instance().get_cluster().write_core(
-        device_id, virtual_core, std::vector<uint32_t>{rpos}, buffer_address + 4);
+    cluster.write_core(device_id, virtual_core, std::vector<uint32_t>{rpos}, buffer_address + 4);
     return true;
 }
 
 void DevicePrintImpl::init_print_buffers_for_core(
     ChipId device_id, const CoreCoord& virtual_core, HalProgrammableCoreType core_type) {
-    uint32_t num_processors = MetalContext::instance().hal().get_num_risc_processors(core_type);
+    const auto& hal = env_.get_hal();
+    auto& cluster = env_.get_cluster();
+    uint32_t num_processors = hal.get_num_risc_processors(core_type);
     uint32_t buffer_size = DPRINT_BUFFER_SIZE * num_processors;
-    WriteInitMagic(device_id, virtual_core, GetDevicePrintBufAddr(device_id, virtual_core), true, buffer_size);
+    WriteInitMagic(cluster, device_id, virtual_core, GetDevicePrintBufAddr(device_id, virtual_core), true, buffer_size);
 }
 
 void DevicePrintImpl::enable_print_buffers_for_core(
     ChipId device_id, const CoreCoord& virtual_core, HalProgrammableCoreType core_type) {
-    uint32_t num_processors = MetalContext::instance().hal().get_num_risc_processors(core_type);
+    auto& cluster = env_.get_cluster();
+    const auto& hal = env_.get_hal();
+    uint32_t num_processors = hal.get_num_risc_processors(core_type);
     uint64_t device_print_buffer_address = GetDevicePrintBufAddr(device_id, virtual_core);
     uint64_t risc_flags_address = device_print_buffer_address + 8;  // sizeof(wpos) + sizeof(rpos)
     std::vector<uint8_t> risc_flags(
         (num_processors + 3) / 4 * 4, static_cast<uint8_t>(DevicePrintRiscCoreState::KernelNotPrinted));
     for (int risc_index = 0; risc_index < num_processors; risc_index++) {
-        if (!RiscEnabled(core_type, risc_index)) {
+        if (!RiscEnabled(env_.get_rtoptions(), core_type, risc_index)) {
             risc_flags[risc_index] = static_cast<uint8_t>(DevicePrintRiscCoreState::PrintingDisabled);
         }
     }
@@ -635,8 +654,7 @@ void DevicePrintImpl::enable_print_buffers_for_core(
     // address. It is OK to do this write any time to update flags. Flags carry info about if kernel already sent kernel
     // loaded structure and if printing is enabled. If we overwrite flags while kernel is running, all we can do is make
     // kernel print more data (repeat kernel loaded structure). We will handle this on server side.
-    tt::tt_metal::MetalContext::instance().get_cluster().write_core(
-        device_id, virtual_core, risc_flags, risc_flags_address);
+    cluster.write_core(device_id, virtual_core, risc_flags, risc_flags_address);
 }
 
 bool DevicePrintImpl::core_has_outstanding_prints(
@@ -645,11 +663,13 @@ bool DevicePrintImpl::core_has_outstanding_prints(
     return false;
 }
 
-DPrintServer::Impl::Impl(llrt::RunTimeOptions& rtoptions) {
+DPrintServer::Impl::Impl(MetalEnv& env, uint8_t num_hw_cqs, const DispatchCoreConfig& dispatch_core_config) :
+    env_(MetalEnvAccessor(env).impl()), num_hw_cqs_(num_hw_cqs), dispatch_core_config_(dispatch_core_config) {
     // Read risc mask + log file from rtoptions
-    string file_name = rtoptions.get_feature_file_name(tt::llrt::RunTimeDebugFeatureDprint);
-    bool one_file_per_risc = rtoptions.get_feature_one_file_per_risc(tt::llrt::RunTimeDebugFeatureDprint);
-    bool prepend_device_core_risc = rtoptions.get_feature_prepend_device_core_risc(tt::llrt::RunTimeDebugFeatureDprint);
+    string file_name = env_.get_rtoptions().get_feature_file_name(tt::llrt::RunTimeDebugFeatureDprint);
+    bool one_file_per_risc = env_.get_rtoptions().get_feature_one_file_per_risc(tt::llrt::RunTimeDebugFeatureDprint);
+    bool prepend_device_core_risc =
+        env_.get_rtoptions().get_feature_prepend_device_core_risc(tt::llrt::RunTimeDebugFeatureDprint);
 
     // One file per risc auto-generates the output files and ignores the env var for it. Print a warning if both are
     // specified just in case.
@@ -665,11 +685,11 @@ DPrintServer::Impl::Impl(llrt::RunTimeOptions& rtoptions) {
             tt::LogMetal,
             "Both TT_METAL_DPRINT_PREPEND_DEVICE_CORE_RISC and TT_METAL_DPRINT_ONE_FILE_PER_RISC are specified. "
             "TT_METAL_DPRINT_PREPEND_DEVICE_CORE_RISC will be disabled.");
-        rtoptions.set_feature_prepend_device_core_risc(tt::llrt::RunTimeDebugFeatureDprint, false);
+        env_.get_rtoptions().set_feature_prepend_device_core_risc(tt::llrt::RunTimeDebugFeatureDprint, false);
     }
 
     // Set the output stream according to RTOptions, either a file name or stdout if none specified.
-    std::filesystem::path output_dir(rtoptions.get_logs_dir() + logfile_path);
+    std::filesystem::path output_dir(env_.get_rtoptions().get_logs_dir() + logfile_path);
     std::filesystem::create_directories(output_dir);
     if (!file_name.empty() && !one_file_per_risc) {
         outfile_ = new ofstream(file_name);
@@ -729,7 +749,9 @@ void DPrintServer::Impl::await() {
 }  // await
 
 void DPrintServer::Impl::init_device(ChipId device_id) {
-    tt::tt_metal::CoreDescriptorSet all_cores = tt::tt_metal::GetAllCores(device_id);
+    auto& cluster = env_.get_cluster();
+    auto& control_plane = env_.get_control_plane();
+    CoreDescriptorSet all_cores = GetAllCores(cluster, control_plane, device_id);
     // Initialize all print buffers on all cores on the device to have print disabled magic. We
     // will then write print enabled magic for only the cores the user has specified to monitor.
     // This way in the kernel code (dprint.h) we can detect whether the magic value is present and
@@ -737,14 +759,14 @@ void DPrintServer::Impl::init_device(ChipId device_id) {
     // flushed from the host.
     for (const auto& logical_core : all_cores) {
         CoreCoord virtual_core =
-            tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
+            cluster.get_virtual_coordinate_from_logical_coordinates(
                 device_id, logical_core.coord, logical_core.type);
         init_print_buffers_for_core(device_id, virtual_core, llrt::get_core_type(device_id, virtual_core));
     }
 }
 
 void DPrintServer::Impl::attach_devices() {
-    auto all_devices = MetalContext::instance().get_cluster().all_chip_ids();
+    auto all_devices = env_.get_cluster().all_chip_ids();
 
     // Always init all chips, to disable prints by default.
     for (ChipId device_id : all_devices) {
@@ -752,13 +774,12 @@ void DPrintServer::Impl::attach_devices() {
     }
 
     // If RTOptions enables all chips, then attach all chips. Otherwise only attach specified devices.
-    if (MetalContext::instance().rtoptions().get_feature_all_chips(tt::llrt::RunTimeDebugFeatureDprint)) {
+    if (env_.get_rtoptions().get_feature_all_chips(tt::llrt::RunTimeDebugFeatureDprint)) {
         for (ChipId device_id : all_devices) {
             attach_device(device_id);
         }
     } else {
-        for (ChipId device_id :
-             MetalContext::instance().rtoptions().get_feature_chip_ids(tt::llrt::RunTimeDebugFeatureDprint)) {
+        for (ChipId device_id : env_.get_rtoptions().get_feature_chip_ids(tt::llrt::RunTimeDebugFeatureDprint)) {
             attach_device(device_id);
         }
     }
@@ -767,12 +788,15 @@ void DPrintServer::Impl::attach_devices() {
 void DPrintServer::Impl::attach_device(ChipId device_id) {
     // A set of all valid printable cores, used for checking the user input. Note that the coords
     // here are virtual.
-    tt::tt_metal::CoreDescriptorSet all_cores = tt::tt_metal::GetAllCores(device_id);
-    tt::tt_metal::CoreDescriptorSet dispatch_cores = tt::tt_metal::GetDispatchCores(device_id);
+    auto& cluster = env_.get_cluster();
+    auto& control_plane = env_.get_control_plane();
+    tt::tt_metal::CoreDescriptorSet all_cores = tt::tt_metal::GetAllCores(cluster, control_plane, device_id);
+    tt::tt_metal::CoreDescriptorSet dispatch_cores =
+        tt::tt_metal::GetDispatchCores(env_, device_id, num_hw_cqs_, dispatch_core_config_);
 
     // If RTOptions doesn't enable DPRINT on this device, return here and don't actually attach it
     // to the server.
-    const auto& rtoptions = tt_metal::MetalContext::instance().rtoptions();
+    const auto& rtoptions = env_.get_rtoptions();
     std::vector<ChipId> chip_ids = rtoptions.get_feature_chip_ids(tt::llrt::RunTimeDebugFeatureDprint);
     if (!rtoptions.get_feature_all_chips(tt::llrt::RunTimeDebugFeatureDprint)) {
         if (std::find(chip_ids.begin(), chip_ids.end(), device_id) == chip_ids.end()) {
@@ -837,10 +861,8 @@ void DPrintServer::Impl::attach_device(ChipId device_id) {
                 CoreCoord virtual_core;
                 bool valid_logical_core = true;
                 try {
-                    virtual_core =
-                        tt::tt_metal::MetalContext::instance()
-                            .get_cluster()
-                            .get_virtual_coordinate_from_logical_coordinates(device_id, logical_core, core_type);
+                    virtual_core = env_.get_cluster().get_virtual_coordinate_from_logical_coordinates(
+                        device_id, logical_core, core_type);
                 } catch (std::runtime_error& error) {
                     valid_logical_core = false;
                 }
@@ -870,8 +892,7 @@ void DPrintServer::Impl::attach_device(ChipId device_id) {
     // Write print enable magic for the cores the user specified.
     for (auto& logical_core : print_cores_sanitized) {
         CoreCoord virtual_core =
-            tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
-                device_id, logical_core.coord, logical_core.type);
+            cluster.get_virtual_coordinate_from_logical_coordinates(device_id, logical_core.coord, logical_core.type);
         auto programmable_core_type = llrt::get_core_type(device_id, virtual_core);
         enable_print_buffers_for_core(device_id, virtual_core, programmable_core_type);
         if (dispatch_cores.contains(logical_core)) {
@@ -909,6 +930,8 @@ void DPrintServer::Impl::detach_devices() {
 }
 
 void DPrintServer::Impl::detach_device(ChipId device_id) {
+    auto& cluster = env_.get_cluster();
+    auto& control_plane = env_.get_control_plane();
     // When we detach a device, we should poll to make sure there's no outstanding prints.
     bool outstanding_prints = true;
     while (outstanding_prints && !server_killed_due_to_hang_) {
@@ -918,9 +941,8 @@ void DPrintServer::Impl::detach_device(ChipId device_id) {
         // Check all dprint-enabled cores on this device for outstanding prints.
         outstanding_prints = false;
         for (auto& logical_core : device_to_core_range_.at(device_id)) {
-            CoreCoord virtual_core =
-                MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
-                    device_id, logical_core.coord, logical_core.type);
+            CoreCoord virtual_core = cluster.get_virtual_coordinate_from_logical_coordinates(
+                device_id, logical_core.coord, logical_core.type);
             auto programmable_core_type = llrt::get_core_type(device_id, virtual_core);
             if (core_has_outstanding_prints(device_id, virtual_core, programmable_core_type)) {
                 outstanding_prints = true;
@@ -963,10 +985,10 @@ void DPrintServer::Impl::detach_device(ChipId device_id) {
     log_info(LogMetal, "DPRINT Server detached device {}", device_id);
 
     // When detaching a device, disable prints on it.
-    CoreDescriptorSet all_cores = GetAllCores(device_id);
+    tt::tt_metal::CoreDescriptorSet all_cores = tt::tt_metal::GetAllCores(cluster, control_plane, device_id);
     for (const auto& logical_core : all_cores) {
-        CoreCoord virtual_core = MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
-            device_id, logical_core.coord, logical_core.type);
+        CoreCoord virtual_core =
+            cluster.get_virtual_coordinate_from_logical_coordinates(device_id, logical_core.coord, logical_core.type);
         init_print_buffers_for_core(device_id, virtual_core, llrt::get_core_type(device_id, virtual_core));
     }
     device_to_core_range_lock_.unlock();
@@ -974,25 +996,26 @@ void DPrintServer::Impl::detach_device(ChipId device_id) {
 
 void DPrintServer::Impl::clear_log_file() {
     if (outfile_) {
+        auto& rtoptions = env_.get_rtoptions();
         // Just close the file and re-open it (without append) to clear it.
         outfile_->close();
         delete outfile_;
 
-        string file_name = tt::tt_metal::MetalContext::instance().rtoptions().get_feature_file_name(
-            tt::llrt::RunTimeDebugFeatureDprint);
+        string file_name = rtoptions.get_feature_file_name(tt::llrt::RunTimeDebugFeatureDprint);
         outfile_ = new ofstream(file_name);
         stream_ = outfile_ ? outfile_ : &std::cout;
     }
 }  // clear_log_file
 
 bool DPrintImpl::poll_one_core(ChipId device_id, const umd::CoreDescriptor& logical_core, bool new_data_this_iter) {
-    auto virtual_core = MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
-        device_id, logical_core.coord, logical_core.type);
+    auto& cluster = env_.get_cluster();
+    auto virtual_core =
+        cluster.get_virtual_coordinate_from_logical_coordinates(device_id, logical_core.coord, logical_core.type);
     auto programmable_core_type = llrt::get_core_type(device_id, virtual_core);
-    uint32_t risc_count = MetalContext::instance().hal().get_num_risc_processors(programmable_core_type);
+    uint32_t risc_count = env_.get_hal().get_num_risc_processors(programmable_core_type);
     bool new_data = false;
     for (int risc_index = 0; risc_index < risc_count; risc_index++) {
-        if (RiscEnabled(programmable_core_type, risc_index)) {
+        if (RiscEnabled(env_.get_rtoptions(), programmable_core_type, risc_index)) {
             new_data |= peek_one_risc_non_blocking(device_id, logical_core, risc_index, new_data_this_iter || new_data);
         }
     }
@@ -1002,10 +1025,11 @@ bool DPrintImpl::poll_one_core(ChipId device_id, const umd::CoreDescriptor& logi
 bool DPrintImpl::peek_one_risc_non_blocking(
     ChipId device_id, const umd::CoreDescriptor& logical_core, int risc_id, bool /*new_data_this_iter*/) {
     // If init magic isn't cleared for this risc, then dprint isn't enabled on it, don't read it.
+    auto& cluster = env_.get_cluster();
+    const auto& hal = env_.get_hal();
     CoreCoord virtual_core =
-        tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
-            device_id, logical_core.coord, logical_core.type);
-    if (!CheckInitMagicCleared(device_id, virtual_core, GetDprintBufAddr(device_id, virtual_core, risc_id))) {
+        cluster.get_virtual_coordinate_from_logical_coordinates(device_id, logical_core.coord, logical_core.type);
+    if (!CheckInitMagicCleared(cluster, device_id, virtual_core, GetDprintBufAddr(device_id, virtual_core, risc_id))) {
         return false;
     }
 
@@ -1019,12 +1043,11 @@ bool DPrintImpl::peek_one_risc_non_blocking(
         // Compute line prefix based on RTOptions
         std::string line_prefix;
         const bool prepend_device_core_risc =
-            tt::tt_metal::MetalContext::instance().rtoptions().get_feature_prepend_device_core_risc(
-                tt::llrt::RunTimeDebugFeatureDprint);
+            env_.get_rtoptions().get_feature_prepend_device_core_risc(tt::llrt::RunTimeDebugFeatureDprint);
         if (prepend_device_core_risc) {
             const string& device_id_str = to_string(device_id);
             const string& core_coord_str = logical_core.coord.str();
-            const string& risc_name = GetRiscName(device_id, logical_core, risc_id, true);
+            const string& risc_name = GetRiscName(cluster, hal, device_id, logical_core, risc_id, true);
             line_prefix = fmt::format("{}:{}:{}: ", device_id_str, core_coord_str, risc_name);
         }
         risc_to_parser_[risc_key] = std::make_unique<DPrintParser>(line_prefix);
@@ -1034,8 +1057,7 @@ bool DPrintImpl::peek_one_risc_non_blocking(
     // Device is incrementing wpos
     // Host is reading wpos and incrementing local rpos up to wpos
     // Device is filling the buffer and in the end waits on host to write rpos
-    auto from_dev = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
-        chip_id, virtual_core, base_addr, DPRINT_BUFFER_SIZE);
+    auto from_dev = env_.get_cluster().read_core(chip_id, virtual_core, base_addr, DPRINT_BUFFER_SIZE);
     DebugPrintMemLayout* l = reinterpret_cast<DebugPrintMemLayout*>(from_dev.data());
     uint32_t rpos = l->aux.rpos;
     uint32_t wpos = l->aux.wpos;
@@ -1068,8 +1090,7 @@ bool DPrintImpl::peek_one_risc_non_blocking(
         std::vector<uint32_t> rposbuf;
         rposbuf.push_back(rpos);
         uint32_t offs = DebugPrintMemLayout::rpos_offs();
-        tt::tt_metal::MetalContext::instance().get_cluster().write_core(
-            chip_id, virtual_core, rposbuf, base_addr + offs);
+        env_.get_cluster().write_core(chip_id, virtual_core, rposbuf, base_addr + offs);
 
         // Return true to signal that some print data was read
         return true;
@@ -1085,7 +1106,7 @@ void DPrintServer::Impl::poll_print_data() {
 
     // Main print loop, go through all chips/cores/riscs on the device and poll for any print data
     // written.
-    const auto& rtoptions = tt_metal::MetalContext::instance().rtoptions();
+    const auto& rtoptions = env_.get_rtoptions();
     while (true) {
         if (stop_print_server_ && !new_data_last_iter_) {
             // If the stop signal was received, exit the print server thread after all new data has been processed.
@@ -1155,7 +1176,9 @@ void DPrintServer::Impl::transfer_all_streams_to_output(ChipId device_id) {
 
 ostream* DPrintServer::Impl::get_output_stream(const RiscKey& risc_key) {
     ostream* output_stream = stream_;
-    const auto& rtoptions = tt_metal::MetalContext::instance().rtoptions();
+    auto& cluster = env_.get_cluster();
+    const auto& hal = env_.get_hal();
+    const auto& rtoptions = env_.get_rtoptions();
     if (rtoptions.get_feature_one_file_per_risc(tt::llrt::RunTimeDebugFeatureDprint)) {
         if (!risc_to_file_stream_[risc_key]) {
             const ChipId chip_id = get<0>(risc_key);
@@ -1168,7 +1191,7 @@ ostream* DPrintServer::Impl::get_output_stream(const RiscKey& risc_key) {
                 tt::tt_metal::get_core_type_name(logical_core.type),
                 logical_core.coord.x,
                 logical_core.coord.y,
-                GetRiscName(chip_id, logical_core, risc_id));
+                GetRiscName(cluster, hal, chip_id, logical_core, risc_id));
             risc_to_file_stream_[risc_key] = new ofstream(filename);
         }
         output_stream = risc_to_file_stream_[risc_key];
@@ -1182,9 +1205,9 @@ ostream* DPrintServer::Impl::get_output_stream(const RiscKey& risc_key) {
 }  // get_output_stream
 
 // Wrapper class functions
-DPrintServer::DPrintServer(llrt::RunTimeOptions& rtoptions) {
-    if (rtoptions.get_use_device_print()) {
-        impl_ = std::make_unique<DevicePrintImpl>(rtoptions);
+DPrintServer::DPrintServer(MetalEnv& env, uint8_t num_hw_cqs, const DispatchCoreConfig& dispatch_core_config) {
+    if (MetalEnvAccessor(env).impl().get_rtoptions().get_use_device_print()) {
+        impl_ = std::make_unique<DevicePrintImpl>(env, num_hw_cqs, dispatch_core_config);
     } else {
         // TODO: Enable this warning once DPRINT is fully deprecated and removed from the codebase.
         // log_warning(
@@ -1192,7 +1215,7 @@ DPrintServer::DPrintServer(llrt::RunTimeOptions& rtoptions) {
         //     "DPRINT is deprecated and will be removed in a future release. "
         //     "Please migrate to DEVICE_PRINT by setting TT_METAL_DEVICE_PRINT=1"
         //     " and using DEVICE_PRINT() macro when writing kernels.");
-        impl_ = std::make_unique<DPrintImpl>(rtoptions);
+        impl_ = std::make_unique<DPrintImpl>(env, num_hw_cqs, dispatch_core_config);
     }
 }
 DPrintServer::~DPrintServer() = default;

--- a/tt_metal/impl/debug/dprint_server.hpp
+++ b/tt_metal/impl/debug/dprint_server.hpp
@@ -11,13 +11,15 @@
 #include <umd/device/types/cluster_descriptor_types.hpp>
 #include <llrt/rtoptions.hpp>
 #include <memory>
+#include "impl/context/context_types.hpp"
+#include <tt-metalium/experimental/context/metal_env.hpp>
 
 namespace tt::tt_metal {
 
 class DPrintServer {
 public:
     // Constructor/destructor, reads dprint options from RTOptions.
-    DPrintServer(llrt::RunTimeOptions& rtoptions);
+    DPrintServer(MetalEnv& env, uint8_t num_hw_cqs, const DispatchCoreConfig& dispatch_core_config);
     ~DPrintServer();
 
     // Sets whether the print server is muted. Calling this function while a kernel is running may

--- a/tt_metal/impl/debug/inspector/inspector.cpp
+++ b/tt_metal/impl/debug/inspector/inspector.cpp
@@ -4,6 +4,7 @@
 
 #include <tt_stl/fmt.hpp>
 #include "inspector.hpp"
+#include "context/context_types.hpp"
 #include "impl/context/metal_context.hpp"
 #include "impl/debug/inspector/data.hpp"
 #include "impl/debug/inspector/rpc_server_generated.hpp"
@@ -19,10 +20,23 @@
 namespace tt::tt_metal {
 
 namespace {
-inspector::Data* get_inspector_data() { return tt::tt_metal::MetalContext::instance().get_inspector_data(); }
+inspector::Data* get_inspector_data() {
+    // TODO: we assume inspector only works on the silicon context
+    // https://github.com/tenstorrent/tt-metal/issues/39745
+    if (tt::tt_metal::MetalContext::instance_exists(DEFAULT_CONTEXT_ID)) {
+        return tt::tt_metal::MetalContext::instance(DEFAULT_CONTEXT_ID).get_inspector_data();
+    }
+    return nullptr;
+}
 }  // namespace
 
-bool Inspector::is_enabled() { return tt::tt_metal::MetalContext::instance().rtoptions().get_inspector_enabled(); }
+// Inspector is not used on mock devices
+bool Inspector::is_enabled() {
+    if (tt::tt_metal::MetalContext::instance_exists(DEFAULT_CONTEXT_ID)) {
+        return tt::tt_metal::MetalContext::instance(DEFAULT_CONTEXT_ID).rtoptions().get_inspector_enabled();
+    }
+    return false;
+}
 
 std::unique_ptr<inspector::Data> Inspector::initialize() {
     if (!is_enabled()) {
@@ -541,9 +555,7 @@ std::string Inspector::get_kernel_path_from_watcher_kernel_id(int watcher_kernel
 
 namespace experimental::inspector {
 
-bool IsEnabled() {
-    return Inspector::is_enabled();
-}
+bool IsEnabled() { return Inspector::is_enabled(); }
 
 void EmitMeshWorkloadAnnotation(
     tt::tt_metal::distributed::MeshWorkload& workload,

--- a/tt_metal/impl/debug/inspector/inspector.hpp
+++ b/tt_metal/impl/debug/inspector/inspector.hpp
@@ -6,6 +6,7 @@
 
 #include <memory>
 #include <string>
+#include "impl/context/context_types.hpp"
 #include "impl/program/program_impl.hpp"
 #include "impl/dispatch/dispatch_core_common.hpp"
 #include "mesh_coord.hpp"

--- a/tt_metal/impl/debug/inspector/inspector.hpp
+++ b/tt_metal/impl/debug/inspector/inspector.hpp
@@ -6,7 +6,6 @@
 
 #include <memory>
 #include <string>
-#include "impl/context/context_types.hpp"
 #include "impl/program/program_impl.hpp"
 #include "impl/dispatch/dispatch_core_common.hpp"
 #include "mesh_coord.hpp"

--- a/tt_metal/impl/debug/noc_logging.cpp
+++ b/tt_metal/impl/debug/noc_logging.cpp
@@ -12,6 +12,7 @@
 
 #include <tt_stl/assert.hpp>
 #include <tt_stl/fmt.hpp>
+#include "context/context_types.hpp"
 #include "core_coord.hpp"
 #include "debug_helpers.hpp"
 #include "hostdevcommon/dprint_common.h"
@@ -31,8 +32,8 @@ using noc_data_t = std::array<uint64_t, NOC_DATA_SIZE>;
 namespace tt {
 
 constexpr auto logfile_path = "generated/noc_data/";
-void PrintNocData(noc_data_t noc_data, const std::string& file_name) {
-    const auto& rtoptions = tt_metal::MetalContext::instance().rtoptions();
+void PrintNocData(MetalEnvImpl& env, noc_data_t noc_data, const std::string& file_name) {
+    const auto& rtoptions = env.get_rtoptions();
     std::filesystem::path output_dir(rtoptions.get_logs_dir() + logfile_path);
     std::filesystem::create_directories(output_dir);
     std::string filename = rtoptions.get_logs_dir() + logfile_path + file_name;
@@ -47,17 +48,15 @@ void PrintNocData(noc_data_t noc_data, const std::string& file_name) {
     outfile.close();
 }
 
-void DumpCoreNocData(ChipId device_id, const umd::CoreDescriptor& logical_core, noc_data_t& noc_data) {
-    CoreCoord virtual_core =
-        tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
-            device_id, logical_core.coord, logical_core.type);
-    uint32_t num_processors =
-        tt_metal::MetalContext::instance().hal().get_num_risc_processors(llrt::get_core_type(device_id, virtual_core));
+void DumpCoreNocData(
+    MetalEnvImpl& env, ChipId device_id, const umd::CoreDescriptor& logical_core, noc_data_t& noc_data) {
+    CoreCoord virtual_core = env.get_cluster().get_virtual_coordinate_from_logical_coordinates(
+        device_id, logical_core.coord, logical_core.type);
+    uint32_t num_processors = env.get_hal().get_num_risc_processors(llrt::get_core_type(device_id, virtual_core));
     for (int risc_id = 0; risc_id < num_processors; risc_id++) {
         // Read out the DPRINT buffer, we stored our data in the "data field"
         uint64_t addr = GetDprintBufAddr(device_id, virtual_core, risc_id);
-        auto from_dev = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
-            device_id, virtual_core, addr, DPRINT_BUFFER_SIZE);
+        auto from_dev = env.get_cluster().read_core(device_id, virtual_core, addr, DPRINT_BUFFER_SIZE);
         DebugPrintMemLayout* l = reinterpret_cast<DebugPrintMemLayout*>(from_dev.data());
         uint32_t* data = reinterpret_cast<uint32_t*>(l->data);
 
@@ -68,60 +67,71 @@ void DumpCoreNocData(ChipId device_id, const umd::CoreDescriptor& logical_core, 
     }
 }
 
-void DumpDeviceNocData(ChipId device_id, noc_data_t& noc_data, noc_data_t& dispatch_noc_data) {
+void DumpDeviceNocData(
+    tt_metal::MetalEnvImpl& env,
+    ChipId device_id,
+    noc_data_t& noc_data,
+    noc_data_t& dispatch_noc_data,
+    uint8_t num_hw_cqs,
+    const DispatchCoreConfig& dispatch_core_config) {
     // Need to treat dispatch cores and normal cores separately, so keep track of which cores are dispatch.
-    CoreDescriptorSet dispatch_cores = GetDispatchCores(device_id);
+    auto& cluster = env.get_cluster();
+    auto& control_plane = env.get_control_plane();
+    CoreDescriptorSet dispatch_cores = GetDispatchCores(env, device_id, num_hw_cqs, dispatch_core_config);
 
     // Now go through all cores on the device, and dump noc data for them.
-    CoreDescriptorSet all_cores = GetAllCores(device_id);
+    CoreDescriptorSet all_cores = GetAllCores(cluster, control_plane, device_id);
     for (const umd::CoreDescriptor& logical_core : all_cores) {
         if (dispatch_cores.contains(logical_core)) {
-            DumpCoreNocData(device_id, logical_core, dispatch_noc_data);
+            DumpCoreNocData(env, device_id, logical_core, dispatch_noc_data);
         } else {
-            DumpCoreNocData(device_id, logical_core, noc_data);
+            DumpCoreNocData(env, device_id, logical_core, noc_data);
         }
     }
 }
 
-void DumpNocData(const std::vector<ChipId>& devices) {
+void DumpNocData(
+    tt_metal::MetalEnvImpl& env,
+    const std::vector<ChipId>& devices,
+    uint8_t num_hw_cqs,
+    const DispatchCoreConfig& dispatch_core_config) {
     // Skip if feature is not enabled
-    if (!tt::tt_metal::MetalContext::instance().rtoptions().get_record_noc_transfers()) {
+    if (!env.get_rtoptions().get_record_noc_transfers()) {
         return;
     }
 
     noc_data_t noc_data = {}, dispatch_noc_data = {};
     for (ChipId device_id : devices) {
         log_info(tt::LogMetal, "Dumping noc data for Device {}...", device_id);
-        DumpDeviceNocData(device_id, noc_data, dispatch_noc_data);
+        DumpDeviceNocData(env, device_id, noc_data, dispatch_noc_data, num_hw_cqs, dispatch_core_config);
     }
 
-    PrintNocData(noc_data, "noc_data.txt");
-    PrintNocData(dispatch_noc_data, "dispatch_noc_data.txt");
+    PrintNocData(env, noc_data, "noc_data.txt");
+    PrintNocData(env, dispatch_noc_data, "dispatch_noc_data.txt");
 }
 
-void ClearNocData(ChipId device_id) {
+void ClearNocData(MetalEnvImpl& env, ChipId device_id) {
     // Skip if feature is not enabled
-    if (!tt::tt_metal::MetalContext::instance().rtoptions().get_record_noc_transfers()) {
+    if (!env.get_rtoptions().get_record_noc_transfers()) {
         return;
     }
 
     // This feature is incomatible with dprint since they share memory space
     TT_FATAL(
-        tt::tt_metal::MetalContext::instance().rtoptions().get_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint) ==
-            false,
+        env.get_rtoptions().get_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint) == false,
         "NOC transfer recording is incompatible with DPRINT");
 
-    CoreDescriptorSet all_cores = GetAllCores(device_id);
+    auto& cluster = env.get_cluster();
+    auto& control_plane = env.get_control_plane();
+    CoreDescriptorSet all_cores = GetAllCores(cluster, control_plane, device_id);
     for (const umd::CoreDescriptor& logical_core : all_cores) {
         CoreCoord virtual_core =
-            tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
-                device_id, logical_core.coord, logical_core.type);
-        uint32_t num_processors = tt_metal::MetalContext::instance().hal().get_num_risc_processors(
-            llrt::get_core_type(device_id, virtual_core));
+            cluster.get_virtual_coordinate_from_logical_coordinates(device_id, logical_core.coord, logical_core.type);
+        uint32_t num_processors = env.get_hal().get_num_risc_processors(llrt::get_core_type(device_id, virtual_core));
         for (int risc_id = 0; risc_id < num_processors; risc_id++) {
             uint64_t addr = GetDprintBufAddr(device_id, virtual_core, risc_id);
             std::vector<uint32_t> initbuf = std::vector<uint32_t>(DPRINT_BUFFER_SIZE / sizeof(uint32_t), 0);
-            tt::tt_metal::MetalContext::instance().get_cluster().write_core(device_id, virtual_core, initbuf, addr);
+            cluster.write_core(device_id, virtual_core, initbuf, addr);
         }
     }
 }

--- a/tt_metal/impl/debug/noc_logging.hpp
+++ b/tt_metal/impl/debug/noc_logging.hpp
@@ -4,11 +4,19 @@
 
 #pragma once
 
-#include <host_api.hpp>
-#include <tt-metalium/device_types.hpp>
+#include <cstdint>
 #include <vector>
 
+#include <host_api.hpp>
+#include <tt-metalium/device_types.hpp>
+#include <tt-metalium/dispatch_core_common.hpp>
+#include "impl/context/metal_env_impl.hpp"
+
 namespace tt {
-void ClearNocData(ChipId device_id);
-void DumpNocData(const std::vector<ChipId>& devices);
+void ClearNocData(tt_metal::MetalEnvImpl& env, ChipId device_id);
+void DumpNocData(
+    tt_metal::MetalEnvImpl& env,
+    const std::vector<ChipId>& devices,
+    uint8_t num_hw_cqs,
+    const tt_metal::DispatchCoreConfig& dispatch_core_config);
 }  // namespace tt

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -59,10 +59,9 @@ namespace {  // Helper functions
 // Helper function to get string rep of riscv type
 // TODO: Remove this and switch to HAL's generic names (such as TENSIX_DM_0),
 // or move it to HAL and make it arch-dependent.
-const char* get_riscv_name(HalProgrammableCoreType core_type, uint32_t processor_index) {
+const char* get_riscv_name(const Hal& hal, HalProgrammableCoreType core_type, uint32_t processor_index) {
     switch (core_type) {
         case HalProgrammableCoreType::TENSIX: {
-            const auto& hal = tt::tt_metal::MetalContext::instance().hal();
             auto num_processors = hal.get_num_risc_processors(core_type);
             TT_FATAL(
                 processor_index < num_processors,
@@ -142,6 +141,7 @@ CoreCoord virtual_noc_coordinate(tt::ChipId device_id, uint8_t noc_index, CoreCo
 
 // Helper function to get string rep of noc target.
 string get_noc_target_str(
+    const Hal& hal,
     tt::ChipId device_id,
     HalProgrammableCoreType programmable_core_type,
     int noc,
@@ -166,7 +166,7 @@ string get_noc_target_str(
     };
     string out = fmt::format(
         "{} using noc{} tried to {} {} {} bytes {} local L1[{:#08x}] {} ",
-        get_riscv_name(programmable_core_type, san.which_risc()),
+        get_riscv_name(hal, programmable_core_type, san.which_risc()),
         noc,
         san.is_multicast() ? "multicast" : "unicast",
         san.is_write() ? "write" : "read",
@@ -199,10 +199,12 @@ string get_noc_target_str(
 }
 
 string get_l1_target_str(
-    HalProgrammableCoreType programmable_core_type, dev_msgs::debug_sanitize_addr_msg_t::ConstView san) {
+    const Hal& hal,
+    HalProgrammableCoreType programmable_core_type,
+    dev_msgs::debug_sanitize_addr_msg_t::ConstView san) {
     string out = fmt::format(
         "{} core overflowed L1 with access to {:#x} of length {}",
-        get_riscv_name(programmable_core_type, san.which_risc()),
+        get_riscv_name(hal, programmable_core_type, san.which_risc()),
         san.l1_addr(),
         san.len());
     return out;
@@ -302,28 +304,29 @@ public:
     void Dump() const;
 };
 
-WatcherDeviceReader::WatcherDeviceReader(FILE* f, ChipId device_id, const std::vector<string>& kernel_names) :
-    f(f), device_id(device_id), kernel_names(kernel_names) {
+WatcherDeviceReader::WatcherDeviceReader(
+    FILE* f,
+    ChipId device_id,
+    const std::vector<string>& kernel_names,
+    tt::tt_metal::MetalEnvImpl& env,
+    WatcherServer& watcher_server) :
+    f(f), device_id(device_id), env(env), watcher_server(watcher_server), kernel_names(kernel_names) {
     // On init, read out eth link retraining register so that we can see if retraining has occurred. WH only for now.
-    if (tt::tt_metal::MetalContext::instance().get_cluster().arch() == ARCH::WORMHOLE_B0 &&
-        tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_enabled()) {
+    if (env.get_cluster().arch() == ARCH::WORMHOLE_B0 && env.get_rtoptions().get_watcher_enabled()) {
         std::vector<uint32_t> read_data;
-        for (const CoreCoord& eth_core :
-             tt::tt_metal::MetalContext::instance().get_control_plane().get_active_ethernet_cores(device_id)) {
+        for (const CoreCoord& eth_core : env.get_control_plane().get_active_ethernet_cores(device_id)) {
             CoreCoord virtual_core =
-                tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
-                    device_id, eth_core, CoreType::ETH);
-            read_data = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
+                env.get_cluster().get_virtual_coordinate_from_logical_coordinates(device_id, eth_core, CoreType::ETH);
+            read_data = env.get_cluster().read_core(
                 device_id,
                 virtual_core,
-                MetalContext::instance().hal().get_dev_addr(
-                    HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::RETRAIN_COUNT),
+                env.get_hal().get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::RETRAIN_COUNT),
                 sizeof(uint32_t));
             logical_core_to_eth_link_retraining_count[eth_core] = read_data[0];
         }
     }
 
-    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+    const auto& hal = env.get_hal();
     uint32_t core_count = hal.get_programmable_core_type_count();
     for (uint32_t i = 0; i < core_count; i++) {
         auto core_type = hal.get_programmable_core_type(i);
@@ -333,19 +336,15 @@ WatcherDeviceReader::WatcherDeviceReader(FILE* f, ChipId device_id, const std::v
 
 WatcherDeviceReader::~WatcherDeviceReader() {
     // On close, read out eth link retraining register so that we can see if retraining has occurred.
-    if (tt::tt_metal::MetalContext::instance().get_cluster().arch() == ARCH::WORMHOLE_B0 &&
-        tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_enabled()) {
+    if (env.get_cluster().arch() == ARCH::WORMHOLE_B0 && env.get_rtoptions().get_watcher_enabled()) {
         std::vector<uint32_t> read_data;
-        for (const CoreCoord& eth_core :
-             tt::tt_metal::MetalContext::instance().get_control_plane().get_active_ethernet_cores(device_id)) {
+        for (const CoreCoord& eth_core : env.get_control_plane().get_active_ethernet_cores(device_id)) {
             CoreCoord virtual_core =
-                tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
-                    device_id, eth_core, CoreType::ETH);
-            read_data = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
+                env.get_cluster().get_virtual_coordinate_from_logical_coordinates(device_id, eth_core, CoreType::ETH);
+            read_data = env.get_cluster().read_core(
                 device_id,
                 virtual_core,
-                MetalContext::instance().hal().get_dev_addr(
-                    HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::RETRAIN_COUNT),
+                env.get_hal().get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::RETRAIN_COUNT),
                 sizeof(uint32_t));
             uint32_t num_events = read_data[0] - logical_core_to_eth_link_retraining_count[eth_core];
             if (num_events > 0) {
@@ -384,8 +383,7 @@ void WatcherDeviceReader::Dump(FILE* file) {
     DumpData dump_data;
 
     // Dump worker cores
-    CoreCoord grid_size =
-        tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device_id).get_grid_size(CoreType::TENSIX);
+    CoreCoord grid_size = env.get_cluster().get_soc_desc(device_id).get_grid_size(CoreType::TENSIX);
     for (uint32_t y = 0; y < grid_size.y; y++) {
         for (uint32_t x = 0; x < grid_size.x; x++) {
             CoreCoord coord = {x, y};
@@ -394,12 +392,10 @@ void WatcherDeviceReader::Dump(FILE* file) {
     }
 
     // Dump eth cores
-    for (const CoreCoord& eth_core :
-         tt::tt_metal::MetalContext::instance().get_control_plane().get_active_ethernet_cores(device_id)) {
+    for (const CoreCoord& eth_core : env.get_control_plane().get_active_ethernet_cores(device_id)) {
         Core::Create(eth_core, HalProgrammableCoreType::ACTIVE_ETH, *this, dump_data).Dump();
     }
-    for (const CoreCoord& eth_core :
-         tt::tt_metal::MetalContext::instance().get_control_plane().get_inactive_ethernet_cores(device_id)) {
+    for (const CoreCoord& eth_core : env.get_control_plane().get_inactive_ethernet_cores(device_id)) {
         Core::Create(eth_core, HalProgrammableCoreType::IDLE_ETH, *this, dump_data).Dump();
     }
 
@@ -407,12 +403,13 @@ void WatcherDeviceReader::Dump(FILE* file) {
         fprintf(f, "k_id[%3d]: %s\n", k_id.first, kernel_names[k_id.first].c_str());
     }
 
-    const auto& hal = MetalContext::instance().hal();
+    const auto& hal = env.get_hal();
     // Print stack usage report for this device/dump
     if (!dump_data.highest_stack_usage.empty()) {
         fprintf(f, "Stack usage summary:");
         for (auto& [processor, info] : dump_data.highest_stack_usage) {
             const auto* processor_name = get_riscv_name(
+                hal,
                 processor.core_type,
                 hal.get_processor_index(processor.core_type, processor.processor_class, processor.processor_type));
             // Threshold of free space for warning.
@@ -460,12 +457,12 @@ void WatcherDeviceReader::Dump(FILE* file) {
             paused_cores_str += fmt::format(
                 "{}:{}, ",
                 virtual_core.str(),
-                get_riscv_name(llrt::get_core_type(device_id, virtual_core), processor_index));
+                get_riscv_name(hal, llrt::get_core_type(device_id, virtual_core), processor_index));
         }
         paused_cores_str += "\n";
         fprintf(f, "%s", paused_cores_str.c_str());
         log_info(tt::LogMetal, "{}Press ENTER to unpause core(s) and continue...", paused_cores_str);
-        if (!tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_auto_unpause()) {
+        if (!env.get_rtoptions().get_watcher_auto_unpause()) {
             while (std::cin.get() != '\n') {
                 ;
             }
@@ -481,10 +478,10 @@ void WatcherDeviceReader::Dump(FILE* file) {
                 dev_msgs_factory.offset_of<dev_msgs::watcher_msg_t>(dev_msgs::watcher_msg_t::Field::pause_status);
 
             // Clear only the one flag that we saved, in case another one was raised on device
-            tt::tt_metal::MetalContext::instance().get_cluster().read_core(
+            env.get_cluster().read_core(
                 pause_data.data(), pause_data.size(), {static_cast<size_t>(device_id), virtual_core}, addr);
             pause_data.view().flags()[processor_index] = 0;
-            tt::tt_metal::MetalContext::instance().get_cluster().write_core(
+            env.get_cluster().write_core(
                 pause_data.data(), pause_data.size(), {static_cast<size_t>(device_id), virtual_core}, addr);
         }
     }
@@ -496,12 +493,11 @@ WatcherDeviceReader::Core WatcherDeviceReader::Core::Create(
     HalProgrammableCoreType programmable_core_type,
     const WatcherDeviceReader& reader,
     DumpData& dump_data) {
-    const auto& rtoptions = tt_metal::MetalContext::instance().rtoptions();
-    const auto& hal = MetalContext::instance().hal();
+    const auto& rtoptions = reader.env.get_rtoptions();
+    const auto& hal = reader.env.get_hal();
     CoreType core_type = hal.get_core_type(hal.get_programmable_core_type_index(programmable_core_type));
-    auto virtual_coord =
-        tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
-            reader.device_id, logical_coord, core_type);
+    auto virtual_coord = reader.env.get_cluster().get_virtual_coordinate_from_logical_coordinates(
+        reader.device_id, logical_coord, core_type);
 
     // Print device id, core coords (logical)
     string core_type_str;
@@ -519,16 +515,14 @@ WatcherDeviceReader::Core WatcherDeviceReader::Core::Create(
         virtual_coord.x,
         virtual_coord.y);
     if (rtoptions.get_watcher_phys_coords()) {
-        CoreCoord phys_core =
-            tt::tt_metal::MetalContext::instance().get_cluster().get_physical_coordinate_from_logical_coordinates(
-                reader.device_id, logical_coord, core_type, true);
+        CoreCoord phys_core = reader.env.get_cluster().get_physical_coordinate_from_logical_coordinates(
+            reader.device_id, logical_coord, core_type, true);
         core_coord_str += fmt::format(" phys(x={:2},y={:2})", phys_core.x, phys_core.y);
     }
     auto core_str = fmt::format("Device {} {} {}", reader.device_id, core_type_str, core_coord_str);
     fprintf(reader.f, "%s: ", core_str.c_str());
 
-    uint64_t mailbox_addr =
-        MetalContext::instance().hal().get_dev_addr(programmable_core_type, HalL1MemAddrType::MAILBOX);
+    uint64_t mailbox_addr = reader.env.get_hal().get_dev_addr(programmable_core_type, HalL1MemAddrType::MAILBOX);
 
     auto dev_msgs_factory = hal.get_dev_msgs_factory(programmable_core_type);
     uint32_t mailbox_read_size =
@@ -537,7 +531,7 @@ WatcherDeviceReader::Core WatcherDeviceReader::Core::Create(
     // Watcher only reads the mailbox up to the end of the watcher struct.
     // Should be ok if we never access past that.
     std::vector<std::byte> l1_read_buf(mailbox_read_size);
-    tt::tt_metal::MetalContext::instance().get_cluster().read_core(
+    reader.env.get_cluster().read_core(
         l1_read_buf.data(), l1_read_buf.size(), {static_cast<size_t>(reader.device_id), virtual_coord}, mailbox_addr);
     return Core(
         virtual_coord,
@@ -550,7 +544,7 @@ WatcherDeviceReader::Core WatcherDeviceReader::Core::Create(
 }
 
 void WatcherDeviceReader::Core::Dump() const {
-    const auto& rtoptions = tt_metal::MetalContext::instance().rtoptions();
+    const auto& rtoptions = reader_.env.get_rtoptions();
     bool is_eth_core =
         (programmable_core_type_ == HalProgrammableCoreType::ACTIVE_ETH ||
          programmable_core_type_ == HalProgrammableCoreType::IDLE_ETH);
@@ -580,7 +574,7 @@ void WatcherDeviceReader::Core::Dump() const {
             DumpL1Status();
         }
         if (!rtoptions.watcher_noc_sanitize_disabled()) {
-            const auto NUM_NOCS_ = tt::tt_metal::MetalContext::instance().hal().get_num_nocs();
+            const auto NUM_NOCS_ = reader_.env.get_hal().get_num_nocs();
             for (uint32_t noc = 0; noc < NUM_NOCS_; noc++) {
                 DumpNocSanitizeStatus(noc);
             }
@@ -608,7 +602,7 @@ void WatcherDeviceReader::Core::Dump() const {
 
     auto kernel_config = launch_msg_.kernel_config();
     fprintf(reader_.f, "k_ids:");
-    auto num_processors = MetalContext::instance().hal().get_num_risc_processors(programmable_core_type_);
+    auto num_processors = reader_.env.get_hal().get_num_risc_processors(programmable_core_type_);
     for (size_t i = 0; i < num_processors; i++) {
         const char* separator = (i > 0) ? "|" : "";
         fprintf(reader_.f, "%s%3d", separator, kernel_config.watcher_kernel_ids()[i]);
@@ -640,13 +634,10 @@ void WatcherDeviceReader::Core::Dump() const {
 void WatcherDeviceReader::Core::DumpL1Status() const {
     // Read L1 address 0, looking for memory corruption
     std::vector<uint32_t> data;
-    data = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
-        reader_.device_id, virtual_coord_, HAL_MEM_L1_BASE, sizeof(uint32_t));
+    data = reader_.env.get_cluster().read_core(reader_.device_id, virtual_coord_, HAL_MEM_L1_BASE, sizeof(uint32_t));
     TT_ASSERT(programmable_core_type_ == HalProgrammableCoreType::TENSIX);
-    uint32_t core_type_idx =
-        MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
-    auto fw_launch_value =
-        MetalContext::instance().hal().get_jit_build_config(core_type_idx, 0, 0).fw_launch_addr_value;
+    uint32_t core_type_idx = reader_.env.get_hal().get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
+    auto fw_launch_value = reader_.env.get_hal().get_jit_build_config(core_type_idx, 0, 0).fw_launch_addr_value;
     if (data[0] != fw_launch_value) {
         LogRunningKernels();
         TT_THROW("Watcher found corruption at L1[0] on core {}: read {}", virtual_coord_.str(), data[0]);
@@ -673,63 +664,63 @@ void WatcherDeviceReader::Core::DumpNocSanitizeStatus(int noc) const {
             }
             break;
         case dev_msgs::DebugSanitizeNocAddrUnderflow:
-            error_msg = get_noc_target_str(reader_.device_id, programmable_core_type_, noc, san);
+            error_msg = get_noc_target_str(reader_.env.get_hal(), reader_.device_id, programmable_core_type_, noc, san);
             error_msg += string(san.is_target() ? " (NOC target" : " (Local L1") + " address underflow).";
             break;
         case dev_msgs::DebugSanitizeNocAddrOverflow:
-            error_msg = get_noc_target_str(reader_.device_id, programmable_core_type_, noc, san);
+            error_msg = get_noc_target_str(reader_.env.get_hal(), reader_.device_id, programmable_core_type_, noc, san);
             error_msg += string(san.is_target() ? " (NOC target" : " (Local L1") + " address overflow).";
             break;
         case dev_msgs::DebugSanitizeNocAddrZeroLength:
-            error_msg = get_noc_target_str(reader_.device_id, programmable_core_type_, noc, san);
+            error_msg = get_noc_target_str(reader_.env.get_hal(), reader_.device_id, programmable_core_type_, noc, san);
             error_msg += " (zero length transaction).";
             break;
         case dev_msgs::DebugSanitizeNocTargetInvalidXY:
-            error_msg = get_noc_target_str(reader_.device_id, programmable_core_type_, noc, san);
+            error_msg = get_noc_target_str(reader_.env.get_hal(), reader_.device_id, programmable_core_type_, noc, san);
             error_msg += " (NOC target address did not map to any known Tensix/Ethernet/DRAM/PCIE core).";
             break;
         case dev_msgs::DebugSanitizeNocMulticastNonWorker:
-            error_msg = get_noc_target_str(reader_.device_id, programmable_core_type_, noc, san);
+            error_msg = get_noc_target_str(reader_.env.get_hal(), reader_.device_id, programmable_core_type_, noc, san);
             error_msg += " (multicast to non-worker core).";
             break;
         case dev_msgs::DebugSanitizeNocMulticastInvalidRange:
-            error_msg = get_noc_target_str(reader_.device_id, programmable_core_type_, noc, san);
+            error_msg = get_noc_target_str(reader_.env.get_hal(), reader_.device_id, programmable_core_type_, noc, san);
             error_msg += " (multicast invalid range).";
             break;
         case dev_msgs::DebugSanitizeNocAlignment:
-            error_msg = get_noc_target_str(reader_.device_id, programmable_core_type_, noc, san);
+            error_msg = get_noc_target_str(reader_.env.get_hal(), reader_.device_id, programmable_core_type_, noc, san);
             error_msg += " (invalid address alignment in NOC transaction).";
             break;
         case dev_msgs::DebugSanitizeNocMixedVirtualandPhysical:
-            error_msg = get_noc_target_str(reader_.device_id, programmable_core_type_, noc, san);
+            error_msg = get_noc_target_str(reader_.env.get_hal(), reader_.device_id, programmable_core_type_, noc, san);
             error_msg += " (mixing virtual and virtual coordinates in Mcast).";
             break;
         case dev_msgs::DebugSanitizeInlineWriteDramUnsupported:
-            error_msg = get_noc_target_str(reader_.device_id, programmable_core_type_, noc, san);
+            error_msg = get_noc_target_str(reader_.env.get_hal(), reader_.device_id, programmable_core_type_, noc, san);
             error_msg += " (inline dw writes do not support DRAM destination addresses).";
             break;
         case dev_msgs::DebugSanitizeNocAddrMailbox:
-            error_msg = get_noc_target_str(reader_.device_id, programmable_core_type_, noc, san);
+            error_msg = get_noc_target_str(reader_.env.get_hal(), reader_.device_id, programmable_core_type_, noc, san);
             error_msg += string(san.is_target() ? " (NOC target" : " (Local L1") + " overwrites mailboxes).";
             break;
         case dev_msgs::DebugSanitizeNocLinkedTransactionViolation:
-            error_msg = get_noc_target_str(reader_.device_id, programmable_core_type_, noc, san);
+            error_msg = get_noc_target_str(reader_.env.get_hal(), reader_.device_id, programmable_core_type_, noc, san);
             error_msg += fmt::format(" (submitting a non-mcast transaction when there's a linked transaction).");
             break;
         case dev_msgs::DebugSanitizeL1AddrOverflow:
-            error_msg = get_l1_target_str(programmable_core_type_, san);
+            error_msg = get_l1_target_str(reader_.env.get_hal(), programmable_core_type_, san);
             error_msg += " (read or write past the end of local memory).";
             break;
         case dev_msgs::DebugSanitizeEthDestL1AddrOverflow:
-            error_msg = get_l1_target_str(programmable_core_type_, san);
+            error_msg = get_l1_target_str(reader_.env.get_hal(), programmable_core_type_, san);
             error_msg += " (ethernet send to core with L1 destination overflow).";
             break;
         case dev_msgs::DebugSanitizeEthSrcL1AddrOverflow:
-            error_msg = get_l1_target_str(programmable_core_type_, san);
+            error_msg = get_l1_target_str(reader_.env.get_hal(), programmable_core_type_, san);
             error_msg += " (ethernet send with L1 source overflow).";
             break;
         case dev_msgs::DebugSanitizeCBOutOfBounds:
-            error_msg = get_noc_target_str(reader_.device_id, programmable_core_type_, noc, san);
+            error_msg = get_noc_target_str(reader_.env.get_hal(), reader_.device_id, programmable_core_type_, noc, san);
             error_msg += " (NOC transaction overflows a circular buffer).";
             break;
         case dev_msgs::DebugSanitizeWriteInProgress:
@@ -751,7 +742,7 @@ void WatcherDeviceReader::Core::DumpNocSanitizeStatus(int noc) const {
         DumpRingBuffer(true);
         LogRunningKernels();
         // Save the error string for checking later in unit tests.
-        MetalContext::instance().watcher_server()->set_exception_message(fmt::format("{}: {}", core_str_, error_msg));
+        reader_.watcher_server.set_exception_message(fmt::format("{}: {}", core_str_, error_msg));
         TT_THROW("{}: {}", core_str_, error_msg);
     }
 }
@@ -769,8 +760,8 @@ void WatcherDeviceReader::Core::DumpAssertStatus() const {
         }
         return;  // no assert tripped, nothing to do
     }
-    std::string error_msg =
-        fmt::format("{}: {} ", core_str_, get_riscv_name(programmable_core_type_, assert_status.which()));
+    std::string error_msg = fmt::format(
+        "{}: {} ", core_str_, get_riscv_name(reader_.env.get_hal(), programmable_core_type_, assert_status.which()));
     std::string assert_msg = get_debug_assert_message(
         static_cast<dev_msgs::debug_assert_type_t>(assert_status.tripped()), assert_status.line_num());
     if (assert_msg.empty()) {
@@ -793,7 +784,7 @@ void WatcherDeviceReader::Core::DumpAssertStatus() const {
 
 void WatcherDeviceReader::Core::DumpPauseStatus() const {
     auto pause_status = mbox_data_.watcher().pause_status();
-    const auto& hal = MetalContext::instance().hal();
+    const auto& hal = reader_.env.get_hal();
     // Just record which cores are paused, printing handled at the end.
     auto num_processors = hal.get_num_risc_processors(programmable_core_type_);
     for (uint32_t processor_index = 0; processor_index < num_processors; processor_index++) {
@@ -808,8 +799,7 @@ void WatcherDeviceReader::Core::DumpPauseStatus() const {
             DumpRingBuffer(true);
             LogRunningKernels();
             // Save the error string for checking later in unit tests.
-            MetalContext::instance().watcher_server()->set_exception_message(
-                fmt::format("{}: {}", core_str_, error_reason));
+            reader_.watcher_server.set_exception_message(fmt::format("{}: {}", core_str_, error_reason));
             TT_THROW("{}", error_reason);
         }
     }
@@ -820,8 +810,7 @@ void WatcherDeviceReader::Core::DumpEthLinkStatus() const {
     if (eth_link_status.link_down() == 0) {
         return;
     }
-    auto noc0_core = tt::tt_metal::MetalContext::instance()
-                         .get_cluster()
+    auto noc0_core = reader_.env.get_cluster()
                          .get_soc_desc(reader_.device_id)
                          .translate_coord_to(virtual_coord_, CoordSystem::TRANSLATED, CoordSystem::NOC0);
     string error_msg = fmt::format(
@@ -832,7 +821,7 @@ void WatcherDeviceReader::Core::DumpEthLinkStatus() const {
     DumpWaypoints();
     DumpRingBuffer();
     LogRunningKernels();
-    MetalContext::instance().watcher_server()->set_exception_message(fmt::format("{}: {}", core_str_, error_msg));
+    reader_.watcher_server.set_exception_message(fmt::format("{}: {}", core_str_, error_msg));
     TT_THROW("{}: {}", core_str_, error_msg);
 }
 
@@ -909,7 +898,7 @@ void WatcherDeviceReader::Core::DumpRunState(uint32_t state) const {
 }
 
 void WatcherDeviceReader::Core::SetEnableFlags(uint32_t enables) const {
-    const auto& hal = MetalContext::instance().hal();
+    const auto& hal = reader_.env.get_hal();
     // Get enable flags symbols for watcher log
     const auto& symbols = reader_.get_cached_enable_symbols(programmable_core_type_);
     TT_ASSERT(!symbols.empty(), "No enable symbols found for core type {}", static_cast<int>(programmable_core_type_));
@@ -955,7 +944,7 @@ void WatcherDeviceReader::Core::SetEnableFlags(uint32_t enables) const {
 
 void WatcherDeviceReader::Core::DumpLaunchMessage() const {
     auto subordinate_sync = mbox_data_.subordinate_sync();
-    const auto& hal = MetalContext::instance().hal();
+    const auto& hal = reader_.env.get_hal();
     fprintf(reader_.f, "rmsg:");
     if (launch_msg_.kernel_config().mode() == dev_msgs::DISPATCH_MODE_DEV) {
         fprintf(reader_.f, "D");
@@ -1058,7 +1047,7 @@ void WatcherDeviceReader::Core::DumpWaypoints(bool to_stdout) const {
 }
 
 void WatcherDeviceReader::Core::DumpSyncRegs() const {
-    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+    const auto& hal = reader_.env.get_hal();
 
     if (!hal.has_stream_registers()) {
         return;
@@ -1073,13 +1062,11 @@ void WatcherDeviceReader::Core::DumpSyncRegs() const {
         uint32_t base = NOC_OVERLAY_START_ADDR + ((operand_start_stream + operand) * NOC_STREAM_REG_SPACE_SIZE);
 
         uint32_t rcvd_addr = base + (STREAM_REMOTE_DEST_BUF_SIZE_REG_INDEX * sizeof(uint32_t));
-        data = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
-            reader_.device_id, virtual_coord_, rcvd_addr, sizeof(uint32_t));
+        data = reader_.env.get_cluster().read_core(reader_.device_id, virtual_coord_, rcvd_addr, sizeof(uint32_t));
         uint32_t rcvd = data[0];
 
         uint32_t ackd_addr = base + (STREAM_REMOTE_DEST_BUF_START_REG_INDEX * sizeof(uint32_t));
-        data = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
-            reader_.device_id, virtual_coord_, ackd_addr, sizeof(uint32_t));
+        data = reader_.env.get_cluster().read_core(reader_.device_id, virtual_coord_, ackd_addr, sizeof(uint32_t));
         uint32_t ackd = data[0];
 
         if (rcvd != ackd) {
@@ -1090,7 +1077,7 @@ void WatcherDeviceReader::Core::DumpSyncRegs() const {
 
 void WatcherDeviceReader::Core::DumpStackUsage() const {
     auto stack_usage_mbox = mbox_data_.watcher().stack_usage();
-    const auto& hal = MetalContext::instance().hal();
+    const auto& hal = reader_.env.get_hal();
     auto num_processors = hal.get_num_risc_processors(programmable_core_type_);
     for (uint32_t processor_index = 0; processor_index < num_processors; processor_index++) {
         const auto& usage = stack_usage_mbox.cpu()[processor_index];
@@ -1108,14 +1095,14 @@ void WatcherDeviceReader::Core::DumpStackUsage() const {
 }
 
 void WatcherDeviceReader::Core::ValidateKernelIDs() const {
-    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+    const auto& hal = reader_.env.get_hal();
     auto num_processors = hal.get_num_risc_processors(programmable_core_type_);
     for (size_t i = 0; i < num_processors; i++) {
         uint16_t watcher_kernel_id = launch_msg_.kernel_config().watcher_kernel_ids()[i];
         if (watcher_kernel_id >= reader_.kernel_names.size()) {
             TT_THROW(
                 "Watcher data corruption, unexpected {} kernel id on Device {} core {}: {} (last valid {})",
-                get_riscv_name(programmable_core_type_, i),
+                get_riscv_name(hal, programmable_core_type_, i),
                 reader_.device_id,
                 virtual_coord_.str(),
                 watcher_kernel_id,
@@ -1126,11 +1113,11 @@ void WatcherDeviceReader::Core::ValidateKernelIDs() const {
 }
 
 void WatcherDeviceReader::Core::LogRunningKernels() const {
-    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+    const auto& hal = reader_.env.get_hal();
     auto num_processors = hal.get_num_risc_processors(programmable_core_type_);
     log_info(tt::LogMetal, "While running kernels:");
     for (size_t i = 0; i < num_processors; i++) {
-        log_info(tt::LogMetal, " {}: {}", get_riscv_name(programmable_core_type_, i), GetKernelName(i));
+        log_info(tt::LogMetal, " {}: {}", get_riscv_name(hal, programmable_core_type_, i), GetKernelName(i));
     }
 }
 

--- a/tt_metal/impl/debug/watcher_device_reader.hpp
+++ b/tt_metal/impl/debug/watcher_device_reader.hpp
@@ -14,6 +14,7 @@
 #include <umd/device/soc_descriptor.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>
 #include "debug_helpers.hpp"
+#include "impl/context/metal_env_impl.hpp"
 
 namespace tt::tt_metal {
 
@@ -24,7 +25,12 @@ constexpr uint8_t DEBUG_SANITIZE_SENTINEL_OK_8 = 0xda;
 
 class WatcherDeviceReader {
 public:
-    WatcherDeviceReader(FILE* f, ChipId device_id, const std::vector<std::string>& kernel_names);
+    WatcherDeviceReader(
+        FILE* f,
+        ChipId device_id,
+        const std::vector<std::string>& kernel_names,
+        tt::tt_metal::MetalEnvImpl& env,
+        WatcherServer& watcher_server);
     ~WatcherDeviceReader();
     void Dump(FILE* file = nullptr);
     const std::vector<std::string>& get_cached_enable_symbols(HalProgrammableCoreType core_type) const {
@@ -40,6 +46,8 @@ private:
     struct DumpData;
     FILE* f;
     ChipId device_id;
+    tt::tt_metal::MetalEnvImpl& env;
+    WatcherServer& watcher_server;  // Reference to the parent object
     const std::vector<std::string>& kernel_names;
     std::map<CoreCoord, uint32_t> logical_core_to_eth_link_retraining_count;
     std::map<HalProgrammableCoreType, EnableSymbolsInfo> symbols_info_cache_;

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -23,6 +23,7 @@
 
 #include <tt_stl/assert.hpp>
 #include <tt_stl/fmt.hpp>
+#include "context/metal_env_impl.hpp"
 #include "core_coord.hpp"
 #include "api/debug/ring_buffer.h"
 #include "debug_helpers.hpp"
@@ -31,6 +32,7 @@
 #include <tt-logger/tt-logger.hpp>
 #include "llrt/metal_soc_descriptor.hpp"
 #include <tt_stl/span.hpp>
+#include "impl/context/metal_env_accessor.hpp"
 #include "impl/context/metal_context.hpp"
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>
@@ -43,6 +45,8 @@ using namespace tt::tt_metal;
 namespace tt::tt_metal {
 class WatcherServer::Impl {
 public:
+    Impl(MetalEnv& env, WatcherServer& watcher_server);
+
     // Implementation of WatcherServer public functions
     void init_devices();
     void attach_devices();
@@ -93,21 +97,27 @@ private:
     std::string exception_message_;
     std::mutex exception_message_mutex_;
 
+    MetalEnvImpl& env_;
+    WatcherServer& watcher_server_;  // Reference back to the parent
+
     inline static const std::string LOG_FILE_PATH = "generated/watcher/";
     inline static const std::string LOG_FILE_NAME = "watcher.log";
     inline static const std::string KERNEL_FILE_NAME = "kernel_names.txt";
     inline static const std::string KERNEL_ELF_FILE_NAME = "kernel_elf_paths.txt";
 };
 
+WatcherServer::Impl::Impl(MetalEnv& env, WatcherServer& watcher_server) :
+    env_(MetalEnvAccessor(env).impl()), watcher_server_(watcher_server) {}
+
 void WatcherServer::Impl::init_devices() {
-    auto all_devices = MetalContext::instance().get_cluster().all_chip_ids();
+    auto all_devices = env_.get_cluster().all_chip_ids();
     for (ChipId device_id : all_devices) {
         init_device(device_id);
     }
 }
 
 void WatcherServer::Impl::attach_devices() {
-    auto& rtoptions = tt_metal::MetalContext::instance().rtoptions();
+    auto& rtoptions = env_.get_rtoptions();
     if (!rtoptions.get_watcher_enabled()) {
         return;
     }
@@ -116,9 +126,9 @@ void WatcherServer::Impl::attach_devices() {
         const std::lock_guard<std::mutex> lock(watch_mutex_);
         create_log_file();
         create_kernel_file();
-        auto all_devices = MetalContext::instance().get_cluster().all_chip_ids();
+        auto all_devices = env_.get_cluster().all_chip_ids();
         for (ChipId device_id : all_devices) {
-            device_id_to_reader_.try_emplace(device_id, logfile_, device_id, kernel_names_);
+            device_id_to_reader_.try_emplace(device_id, logfile_, device_id, kernel_names_, env_, watcher_server_);
             log_info(LogLLRuntime, "Watcher attached device {}", device_id);
             fprintf(logfile_, "At %.3lfs attach device %d\n\n", get_elapsed_secs(), device_id);
             fflush(logfile_);  // Ensure attach message is committed before watcher server thread writes
@@ -164,7 +174,7 @@ void WatcherServer::Impl::detach_devices() {
     // Detach all devices
     {
         const std::lock_guard<std::mutex> lock(watch_mutex_);
-        auto all_devices = MetalContext::instance().get_cluster().all_chip_ids();
+        auto all_devices = env_.get_cluster().all_chip_ids();
         for (ChipId device_id : all_devices) {
             TT_ASSERT(device_id_to_reader_.contains(device_id));
             device_id_to_reader_.erase(device_id);
@@ -173,7 +183,7 @@ void WatcherServer::Impl::detach_devices() {
         }
 
         // Watcher server closed, can use dma library again.
-        MetalContext::instance().rtoptions().set_disable_dma_ops(false);
+        env_.get_rtoptions().set_disable_dma_ops(false);
         close_file(logfile_);
         close_file(kernel_file_);
         close_file(kernel_elf_file_);
@@ -191,7 +201,7 @@ void WatcherServer::Impl::isolated_dump(std::vector<ChipId>& device_ids) {
     clear_log();
     read_kernel_ids_from_file();
     for (ChipId device_id : device_ids) {
-        device_id_to_reader_.try_emplace(device_id, logfile_, device_id, kernel_names_);
+        device_id_to_reader_.try_emplace(device_id, logfile_, device_id, kernel_names_, env_, watcher_server_);
         log_info(LogLLRuntime, "Watcher attached device {}", device_id);
         fprintf(logfile_, "At %.3lfs attach device %d\n", get_elapsed_secs(), device_id);
     }
@@ -200,7 +210,7 @@ void WatcherServer::Impl::isolated_dump(std::vector<ChipId>& device_ids) {
 }
 
 std::string WatcherServer::Impl::log_file_name() {
-    return tt::tt_metal::MetalContext::instance().rtoptions().get_logs_dir() + LOG_FILE_PATH + LOG_FILE_NAME;
+    return env_.get_rtoptions().get_logs_dir() + LOG_FILE_PATH + LOG_FILE_NAME;
 }
 
 int WatcherServer::Impl::register_kernel(const std::string& name) {
@@ -231,7 +241,7 @@ void WatcherServer::Impl::register_kernel_elf_paths(int id, std::vector<std::str
 }
 
 void WatcherServer::Impl::read_kernel_ids_from_file() {
-    std::filesystem::path output_dir(tt::tt_metal::MetalContext::instance().rtoptions().get_logs_dir() + LOG_FILE_PATH);
+    std::filesystem::path output_dir(env_.get_rtoptions().get_logs_dir() + LOG_FILE_PATH);
     std::string fname = output_dir.string() + KERNEL_FILE_NAME;
     std::ifstream f(fname);
     if (!f) {
@@ -261,7 +271,7 @@ double WatcherServer::Impl::get_elapsed_secs() {
 }
 
 void WatcherServer::Impl::create_log_file() {
-    const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
+    const auto& rtoptions = env_.get_rtoptions();
     const char* fmode = rtoptions.get_watcher_append() ? "a" : "w";
     std::filesystem::path output_dir(rtoptions.get_logs_dir() + LOG_FILE_PATH);
     std::filesystem::create_directories(output_dir);
@@ -310,7 +320,7 @@ void WatcherServer::Impl::create_log_file() {
 }
 
 void WatcherServer::Impl::create_kernel_file() {
-    const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
+    const auto& rtoptions = env_.get_rtoptions();
     const char* fmode = rtoptions.get_watcher_append() ? "a" : "w";
     std::filesystem::path output_dir(rtoptions.get_logs_dir() + LOG_FILE_PATH);
     std::filesystem::create_directories(output_dir);
@@ -328,7 +338,7 @@ void WatcherServer::Impl::create_kernel_file() {
 }
 
 void WatcherServer::Impl::create_kernel_elf_file() {
-    const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
+    const auto& rtoptions = env_.get_rtoptions();
     std::filesystem::path output_dir(rtoptions.get_logs_dir() + LOG_FILE_PATH);
     std::filesystem::create_directories(output_dir);
     std::string fname = output_dir.string() + KERNEL_ELF_FILE_NAME;
@@ -343,9 +353,9 @@ void WatcherServer::Impl::create_kernel_elf_file() {
 
 void WatcherServer::Impl::init_device(ChipId device_id) {
     const std::lock_guard<std::mutex> lock(watch_mutex_);
-    const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
-    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
-    const auto& hal = MetalContext::instance().hal();
+    const auto& rtoptions = env_.get_rtoptions();
+    const auto& cluster = env_.get_cluster();
+    const auto& hal = env_.get_hal();
     std::vector<dev_msgs::watcher_msg_t> watcher_init_val;
     watcher_init_val.reserve(NumHalProgrammableCoreTypes);
 
@@ -490,12 +500,10 @@ void WatcherServer::Impl::init_device(ChipId device_id) {
     }
 
     // Initialize ethernet cores debug values
-    for (const CoreCoord& active_eth_core :
-         tt::tt_metal::MetalContext::instance().get_control_plane().get_active_ethernet_cores(device_id)) {
+    for (const CoreCoord& active_eth_core : env_.get_control_plane().get_active_ethernet_cores(device_id)) {
         write_watcher_init_val(active_eth_core, HalProgrammableCoreType::ACTIVE_ETH);
     }
-    for (const CoreCoord& inactive_eth_core :
-         tt::tt_metal::MetalContext::instance().get_control_plane().get_inactive_ethernet_cores(device_id)) {
+    for (const CoreCoord& inactive_eth_core : env_.get_control_plane().get_inactive_ethernet_cores(device_id)) {
         write_watcher_init_val(inactive_eth_core, HalProgrammableCoreType::IDLE_ETH);
     }
 
@@ -506,7 +514,7 @@ void WatcherServer::Impl::poll_watcher_data() {
     TT_ASSERT(server_running_ == false);
     server_running_ = true;
     dump_count_ = 1;
-    const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
+    const auto& rtoptions = env_.get_rtoptions();
     auto sleep_duration = std::chrono::milliseconds(rtoptions.get_watcher_interval());
 
     // Print to the user which features are disabled via env vars.
@@ -569,7 +577,7 @@ void WatcherServer::Impl::poll_watcher_data() {
 }
 
 // Wrapper class functions
-WatcherServer::WatcherServer() : impl_(std::make_unique<Impl>()) {};
+WatcherServer::WatcherServer(MetalEnv& env) : impl_(std::make_unique<Impl>(env, *this)) {};
 WatcherServer::~WatcherServer() = default;
 void WatcherServer::init_devices() { impl_->init_devices(); }
 void WatcherServer::attach_devices() { impl_->attach_devices(); }

--- a/tt_metal/impl/debug/watcher_server.hpp
+++ b/tt_metal/impl/debug/watcher_server.hpp
@@ -8,13 +8,15 @@
 #include <stdint.h>
 #include <umd/device/types/cluster_descriptor_types.hpp>
 #include <string>
+#include "impl/context/context_types.hpp"
+#include <tt-metalium/experimental/context/metal_env.hpp>
 
 struct metal_SocDescriptor;
 
 namespace tt::tt_metal {
 class WatcherServer {
 public:
-    WatcherServer();
+    WatcherServer(MetalEnv& env);
     ~WatcherServer();
 
     void init_devices();    // Always runs, puts watcher mailboxes in a default state

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt_stl/fmt.hpp>
+#include "context/context_types.hpp"
+#include "context/metal_env_accessor.hpp"
 #include "device_impl.hpp"
 
 #include <core_descriptor.hpp>
@@ -61,11 +63,19 @@
 namespace tt::tt_metal {
 
 uint64_t IDevice::get_dev_addr(CoreCoord virtual_core, HalL1MemAddrType addr_type) const {
-    return MetalContext::instance().hal().get_dev_addr(this->get_programmable_core_type(virtual_core), addr_type);
+    // TODO: Remove this function
+    // https://github.com/tenstorrent/tt-metal/issues/39814
+    return MetalContext::instance(extract_context_id(this))
+        .hal()
+        .get_dev_addr(this->get_programmable_core_type(virtual_core), addr_type);
 }
 
 uint64_t IDevice::get_dev_size(CoreCoord virtual_core, HalL1MemAddrType addr_type) const {
-    return MetalContext::instance().hal().get_dev_size(this->get_programmable_core_type(virtual_core), addr_type);
+    // TODO: Remove this function
+    // https://github.com/tenstorrent/tt-metal/issues/39814
+    return MetalContext::instance(extract_context_id(this))
+        .hal()
+        .get_dev_size(this->get_programmable_core_type(virtual_core), addr_type);
 }
 
 void IDevice::set_program_cache_misses_allowed(bool allowed) {
@@ -76,6 +86,8 @@ Device::Device(Device&& other) noexcept = default;
 Device& Device::operator=(Device&& other) noexcept = default;
 
 Device::Device(
+    MetalEnv* env,
+    MetalContext* context,
     ChipId device_id,
     const uint8_t num_hw_cqs,
     size_t l1_small_size,
@@ -85,13 +97,15 @@ Device::Device(
     uint32_t /*worker_thread_core*/,
     uint32_t /*completion_queue_reader_core*/,
     size_t worker_l1_size) :
-    id_(device_id) {
+    context_(context), env_(env), id_(device_id) {
     ZoneScoped;
+    TT_FATAL(env != nullptr, "env is nullptr");
+    TT_FATAL(context != nullptr, "context is nullptr");
     this->initialize(num_hw_cqs, l1_small_size, trace_region_size, worker_l1_size, l1_bank_remap, minimal);
 }
 
 std::unordered_set<CoreCoord> Device::get_active_ethernet_cores(bool skip_reserved_tunnel_cores) const {
-    return tt::tt_metal::MetalContext::instance().get_control_plane().get_active_ethernet_cores(
+    return MetalEnvAccessor(*env_).impl().get_control_plane().get_active_ethernet_cores(
         this->id_, skip_reserved_tunnel_cores);
 }
 
@@ -101,12 +115,12 @@ bool Device::is_active_ethernet_core(CoreCoord logical_core, bool skip_reserved_
 }
 
 std::unordered_set<CoreCoord> Device::get_inactive_ethernet_cores() const {
-    return tt::tt_metal::MetalContext::instance().get_control_plane().get_inactive_ethernet_cores(this->id_);
+    return MetalEnvAccessor(*env_).impl().get_control_plane().get_inactive_ethernet_cores(this->id_);
 }
 
 bool Device::is_inactive_ethernet_core(CoreCoord logical_core) const {
     auto inactive_ethernet_cores =
-        tt::tt_metal::MetalContext::instance().get_control_plane().get_inactive_ethernet_cores(this->id_);
+        MetalEnvAccessor(*env_).impl().get_control_plane().get_inactive_ethernet_cores(this->id_);
     return inactive_ethernet_cores.contains(logical_core);
 }
 
@@ -115,16 +129,16 @@ uint32_t Device::num_virtual_eth_cores(SubDeviceId sub_device_id) {
 }
 
 std::tuple<ChipId, CoreCoord> Device::get_connected_ethernet_core(CoreCoord eth_core) const {
-    return tt::tt_metal::MetalContext::instance().get_cluster().get_connected_ethernet_core(
+    return MetalEnvAccessor(*env_).impl().get_cluster().get_connected_ethernet_core(
         std::make_tuple(this->id_, eth_core));
 }
 
 std::vector<CoreCoord> Device::get_ethernet_sockets(ChipId connected_chip_id) const {
-    return tt::tt_metal::MetalContext::instance().get_cluster().get_ethernet_sockets(this->id_, connected_chip_id);
+    return MetalEnvAccessor(*env_).impl().get_cluster().get_ethernet_sockets(this->id_, connected_chip_id);
 }
 
 bool Device::is_mmio_capable() const {
-    return tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(this->id_) == this->id_;
+    return MetalEnvAccessor(*env_).impl().get_cluster().get_associated_mmio_device(this->id_) == this->id_;
 }
 
 CoreRangeSet Device::worker_cores(HalProgrammableCoreType /*core_type*/, SubDeviceId /*sub_device_id*/) const {
@@ -143,8 +157,11 @@ std::unique_ptr<AllocatorImpl> Device::initialize_allocator(
     size_t worker_l1_unreserved_start,
     tt::stl::Span<const std::uint32_t> l1_bank_remap) {
     ZoneScoped;
-    const metal_SocDescriptor& soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(this->id_);
+    const metal_SocDescriptor& soc_desc = MetalEnvAccessor(*env_).impl().get_cluster().get_soc_desc(this->id_);
+    auto& dispatch_core_manager = context_->get_dispatch_core_manager();
     auto config = L1BankingAllocator::generate_config(
+        dispatch_core_manager,
+        MetalEnvAccessor(*env_).impl(),
         this->id(),
         this->num_hw_cqs(),
         l1_small_size,
@@ -165,7 +182,7 @@ std::unique_ptr<AllocatorImpl> Device::initialize_allocator(
 // cores
 void Device::configure_command_queue_programs(DispatchTopology* dispatch_topology) {
     ChipId device_id = this->id();
-    ChipId mmio_device_id = tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device_id);
+    ChipId mmio_device_id = MetalEnvAccessor(*env_).impl().get_cluster().get_associated_mmio_device(device_id);
 
     std::vector<uint32_t> zero = {0x0};  // Reset state in case L1 Clear is disabled.
     std::vector<uint32_t> pointers;
@@ -178,19 +195,19 @@ void Device::configure_command_queue_programs(DispatchTopology* dispatch_topolog
     // Reset host-side command queue pointers for all channels controlled by this mmio device
     if (this->is_mmio_capable()) {
         for (ChipId serviced_device_id :
-             tt::tt_metal::MetalContext::instance().get_cluster().get_devices_controlled_by_mmio_device(device_id)) {
-            uint16_t channel = tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(
-                serviced_device_id);
-            uint32_t host_issue_q_rd_ptr = MetalContext::instance().dispatch_mem_map().get_host_command_queue_addr(
-                CommandQueueHostAddrType::ISSUE_Q_RD);
-            uint32_t host_issue_q_wr_ptr = MetalContext::instance().dispatch_mem_map().get_host_command_queue_addr(
-                CommandQueueHostAddrType::ISSUE_Q_WR);
-            uint32_t host_completion_q_wr_ptr = MetalContext::instance().dispatch_mem_map().get_host_command_queue_addr(
-                CommandQueueHostAddrType::COMPLETION_Q_WR);
-            uint32_t host_completion_q_rd_ptr = MetalContext::instance().dispatch_mem_map().get_host_command_queue_addr(
-                CommandQueueHostAddrType::COMPLETION_Q_RD);
-            uint32_t cq_start = MetalContext::instance().dispatch_mem_map().get_host_command_queue_addr(
-                CommandQueueHostAddrType::UNRESERVED);
+             MetalEnvAccessor(*env_).impl().get_cluster().get_devices_controlled_by_mmio_device(device_id)) {
+            uint16_t channel =
+                MetalEnvAccessor(*env_).impl().get_cluster().get_assigned_channel_for_device(serviced_device_id);
+            uint32_t host_issue_q_rd_ptr =
+                context_->dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::ISSUE_Q_RD);
+            uint32_t host_issue_q_wr_ptr =
+                context_->dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::ISSUE_Q_WR);
+            uint32_t host_completion_q_wr_ptr =
+                context_->dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::COMPLETION_Q_WR);
+            uint32_t host_completion_q_rd_ptr =
+                context_->dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::COMPLETION_Q_RD);
+            uint32_t cq_start =
+                context_->dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
             pointers.resize(cq_start / sizeof(uint32_t));
             for (uint8_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
                 // Reset the host manager's pointer for this command queue
@@ -209,7 +226,7 @@ void Device::configure_command_queue_programs(DispatchTopology* dispatch_topolog
                      get_absolute_cq_offset(channel, cq_id, cq_size)) >>
                     4;
 
-                tt::tt_metal::MetalContext::instance().get_cluster().write_sysmem(
+                MetalEnvAccessor(*env_).impl().get_cluster().write_sysmem(
                     pointers.data(),
                     pointers.size() * sizeof(uint32_t),
                     get_absolute_cq_offset(channel, cq_id, cq_size),
@@ -228,15 +245,15 @@ void Device::configure_command_queue_programs(DispatchTopology* dispatch_topolog
     // Run the cq program
     command_queue_program.impl().finalize_offsets(this);
     detail::ConfigureDeviceWithProgram(this, command_queue_program, true);
-    tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(this->id());
+    MetalEnvAccessor(*env_).impl().get_cluster().l1_barrier(this->id());
 }
 
 void Device::init_command_queue_host() {
     // SystemMemoryManager now has internal stubs for mock devices
-    sysmem_manager_ = std::make_unique<SystemMemoryManager>(this->id_, this->num_hw_cqs());
+    sysmem_manager_ = std::make_unique<SystemMemoryManager>(context_->get_context_id(), this->id_, this->num_hw_cqs());
 
     // For mock devices, skip HWCommandQueue creation (they don't need real command queues)
-    if (tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock) {
+    if (MetalEnvAccessor(*env_).impl().get_cluster().get_target_device_type() == tt::TargetDevice::Mock) {
         return;
     }
 
@@ -252,37 +269,33 @@ void Device::init_command_queue_device_with_topology(DispatchTopology* topo) {
     TT_ASSERT(this->command_queue_programs_.size() == 1);
     this->configure_command_queue_programs(topo);
     Program& command_queue_program = *this->command_queue_programs_[0];
+    MetalEnvImpl& env_impl = MetalEnvAccessor(*env_).impl();
+    auto& cluster = env_impl.get_cluster();
+    const auto& hal = env_impl.get_hal();
 
     // Write 0 to all workers launch message read pointer. Need to do this since dispatch cores are written new on each
     // Device init. TODO: remove this once dispatch init moves to one-shot.
     auto reset_launch_message_rd_ptr = [&](const CoreCoord& logical_core, const CoreType& core_type) {
-        CoreCoord virtual_core = MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
-            id_, logical_core, core_type);
+        CoreCoord virtual_core = cluster.get_virtual_coordinate_from_logical_coordinates(id_, logical_core, core_type);
         auto programmable_core_type = get_programmable_core_type(virtual_core);
-        uint64_t launch_msg_buffer_read_ptr_addr = MetalContext::instance().hal().get_dev_addr(
-            programmable_core_type, HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR);
+        uint64_t launch_msg_buffer_read_ptr_addr =
+            hal.get_dev_addr(programmable_core_type, HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR);
         uint32_t zero = 0;
-        MetalContext::instance().get_cluster().write_core(
-            &zero, sizeof(uint32_t), tt_cxy_pair(id_, virtual_core), launch_msg_buffer_read_ptr_addr);
+        cluster.write_core(&zero, sizeof(uint32_t), tt_cxy_pair(id_, virtual_core), launch_msg_buffer_read_ptr_addr);
     };
     auto reset_go_message_index = [&](const CoreCoord& logical_core, const CoreType& core_type) {
-        CoreCoord virtual_core = MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
-            id_, logical_core, core_type);
+        CoreCoord virtual_core = cluster.get_virtual_coordinate_from_logical_coordinates(id_, logical_core, core_type);
         auto programmable_core_type = get_programmable_core_type(virtual_core);
-        uint32_t go_message_addr =
-            MetalContext::instance().hal().get_dev_addr(programmable_core_type, HalL1MemAddrType::GO_MSG);
+        uint32_t go_message_addr = hal.get_dev_addr(programmable_core_type, HalL1MemAddrType::GO_MSG);
         uint32_t zero = 0;
-        MetalContext::instance().get_cluster().write_core(
-            &zero, sizeof(uint32_t), tt_cxy_pair(id_, virtual_core), go_message_addr);
-        tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(id_);
-        uint32_t go_message_index_addr =
-            MetalContext::instance().hal().get_dev_addr(programmable_core_type, HalL1MemAddrType::GO_MSG_INDEX);
-        MetalContext::instance().get_cluster().write_core(
-            &zero, sizeof(uint32_t), tt_cxy_pair(id_, virtual_core), go_message_index_addr);
+        cluster.write_core(&zero, sizeof(uint32_t), tt_cxy_pair(id_, virtual_core), go_message_addr);
+        cluster.l1_barrier(id_);
+        uint32_t go_message_index_addr = hal.get_dev_addr(programmable_core_type, HalL1MemAddrType::GO_MSG_INDEX);
+        cluster.write_core(&zero, sizeof(uint32_t), tt_cxy_pair(id_, virtual_core), go_message_index_addr);
     };
     std::optional<std::unique_lock<std::mutex>> watcher_lock;
-    if (tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_enabled()) {
-        watcher_lock = MetalContext::instance().watcher_server()->get_lock();
+    if (MetalEnvAccessor(*env_).impl().get_rtoptions().get_watcher_enabled()) {
+        watcher_lock = context_->watcher_server()->get_lock();
     }
     for (uint32_t y = 0; y < logical_grid_size().y; y++) {
         for (uint32_t x = 0; x < logical_grid_size().x; x++) {
@@ -292,13 +305,13 @@ void Device::init_command_queue_device_with_topology(DispatchTopology* topo) {
         }
     }
     for (const auto& logical_core : this->get_active_ethernet_cores()) {
-        if (!has_flag(MetalContext::instance().get_fabric_manager(), tt_fabric::FabricManagerMode::INIT_FABRIC)) {
+        if (!has_flag(env_impl.get_fabric_manager(), tt_fabric::FabricManagerMode::INIT_FABRIC)) {
             continue;
         }
         reset_launch_message_rd_ptr(logical_core, CoreType::ETH);
     }
     for (const auto& logical_core : this->get_inactive_ethernet_cores()) {
-        if (!has_flag(MetalContext::instance().get_fabric_manager(), tt_fabric::FabricManagerMode::INIT_FABRIC)) {
+        if (!has_flag(env_impl.get_fabric_manager(), tt_fabric::FabricManagerMode::INIT_FABRIC)) {
             continue;
         }
         reset_launch_message_rd_ptr(logical_core, CoreType::ETH);
@@ -308,7 +321,6 @@ void Device::init_command_queue_device_with_topology(DispatchTopology* topo) {
     }
 
     std::vector<std::vector<CoreCoord>> logical_cores = command_queue_program.impl().logical_cores();
-    const auto& hal = MetalContext::instance().hal();
     for (uint32_t index = 0; index < hal.get_programmable_core_type_count(); index++) {
         const auto& logical_dispatch_cores = logical_cores[index];
         CoreType core_type = hal.get_core_type(index);
@@ -322,7 +334,7 @@ void Device::init_command_queue_device_with_topology(DispatchTopology* topo) {
                 virtual_core,
                 msg.view(),
                 go_msg,
-                this->get_dev_addr(virtual_core, HalL1MemAddrType::LAUNCH));
+                hal.get_dev_addr(this->get_programmable_core_type(virtual_core), HalL1MemAddrType::LAUNCH));
         }
     }
 
@@ -334,7 +346,7 @@ void Device::init_command_queue_device_with_topology(DispatchTopology* topo) {
         active_eth_core_ranges.emplace_back(core, core);
     }
 
-    const NOC noc_index = MetalContext::instance().get_dispatch_query_manager().go_signal_noc();
+    const NOC noc_index = context_->get_dispatch_query_manager().go_signal_noc();
     uint32_t idx = 0U;
     vector_aligned<uint32_t> noc_mcast_unicast_data;
     for (uint32_t i = 0U; i < num_sub_devices(); ++i) {
@@ -374,9 +386,10 @@ void Device::configure_fabric() {
 
     // Note: the l1_barrier below is needed to be sure writes to cores that
     // don't get the GO mailbox have all landed
-    tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(this->id());
+    MetalEnvImpl& env_impl = MetalEnvAccessor(*env_).impl();
+    env_impl.get_cluster().l1_barrier(this->id());
     std::vector<std::vector<CoreCoord>> logical_cores_used_in_program = fabric_program_->impl().logical_cores();
-    const auto& hal = MetalContext::instance().hal();
+    const auto& hal = env_impl.get_hal();
     for (uint32_t programmable_core_type_index = 0; programmable_core_type_index < logical_cores_used_in_program.size();
          programmable_core_type_index++) {
         CoreType core_type = hal.get_core_type(programmable_core_type_index);
@@ -388,7 +401,11 @@ void Device::configure_fabric() {
 
             auto physical_core = this->virtual_core_from_logical_core(logical_core, core_type);
             tt::llrt::write_launch_msg_to_core(
-                this->id(), physical_core, msg, go_msg, this->get_dev_addr(physical_core, HalL1MemAddrType::LAUNCH));
+                this->id(),
+                physical_core,
+                msg,
+                go_msg,
+                hal.get_dev_addr(this->get_programmable_core_type(physical_core), HalL1MemAddrType::LAUNCH));
         }
     }
     log_info(tt::LogMetal, "Fabric initialized on Device {}", this->id_);
@@ -414,9 +431,10 @@ bool Device::initialize(
         num_hw_cqs > 0 and num_hw_cqs <= dispatch_core_manager::MAX_NUM_HW_CQS,
         "num_hw_cqs can be between 1 and {}",
         dispatch_core_manager::MAX_NUM_HW_CQS);
-    using_fast_dispatch_ = MetalContext::instance().rtoptions().get_fast_dispatch();
+    MetalEnvImpl& env_impl = MetalEnvAccessor(*env_).impl();
+    using_fast_dispatch_ = env_impl.get_rtoptions().get_fast_dispatch();
     num_hw_cqs_ = num_hw_cqs;
-    const auto& hal = MetalContext::instance().hal();
+    const auto& hal = env_impl.get_hal();
     if (worker_l1_size == 0) {
         worker_l1_size = hal.get_dev_size(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
     }
@@ -477,38 +495,34 @@ Device::~Device() {
     }
 }
 
-tt::ARCH Device::arch() const { return tt::tt_metal::MetalContext::instance().get_cluster().arch(); }
+tt::ARCH Device::arch() const { return MetalEnvAccessor(*env_).impl().get_cluster().arch(); }
 
 int Device::num_dram_channels() const {
-    return tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(id_).get_num_dram_views();
+    return MetalEnvAccessor(*env_).impl().get_cluster().get_soc_desc(id_).get_num_dram_views();
 }
 
 uint32_t Device::l1_size_per_core() const {
-    return tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(id_).worker_l1_size;
+    return MetalEnvAccessor(*env_).impl().get_cluster().get_soc_desc(id_).worker_l1_size;
 }
 uint32_t Device::dram_size_per_channel() const {
-    return tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(id_).dram_view_size;
+    return MetalEnvAccessor(*env_).impl().get_cluster().get_soc_desc(id_).dram_view_size;
 }
 
-int Device::get_clock_rate_mhz() const {
-    return tt::tt_metal::MetalContext::instance().get_cluster().get_device_aiclk(id_);
-}
+int Device::get_clock_rate_mhz() const { return MetalEnvAccessor(*env_).impl().get_cluster().get_device_aiclk(id_); }
 
-CoreCoord Device::grid_size() const {
-    return tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(id_).grid_size;
-}
+CoreCoord Device::grid_size() const { return MetalEnvAccessor(*env_).impl().get_cluster().get_soc_desc(id_).grid_size; }
 
 CoreCoord Device::logical_grid_size() const {
-    return tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(id_).get_grid_size(CoreType::TENSIX);
+    return MetalEnvAccessor(*env_).impl().get_cluster().get_soc_desc(id_).get_grid_size(CoreType::TENSIX);
 }
 
 CoreCoord Device::dram_grid_size() const {
-    return tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(id_).get_dram_grid_size();
+    return MetalEnvAccessor(*env_).impl().get_cluster().get_soc_desc(id_).get_dram_grid_size();
 }
 
 CoreCoord Device::compute_with_storage_grid_size() const {
-    const auto& dispatch_core_config = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
-    return tt::get_compute_grid_size(id_, num_hw_cqs_, dispatch_core_config);
+    const auto& dispatch_core_config = context_->get_dispatch_core_manager().get_dispatch_core_config();
+    return tt::get_compute_grid_size(MetalEnvAccessor(*env_).impl(), id_, num_hw_cqs_, dispatch_core_config);
 }
 
 CoreCoord Device::virtual_noc0_coordinate(uint8_t noc_index, CoreCoord coord) const {
@@ -520,14 +534,14 @@ CoreCoord Device::virtual_noc0_coordinate(uint8_t noc_index, CoreCoord coord) co
     // Coordinate in Physical NOC0 Space. Convert to Virtual.
     coord = this->virtual_core_from_physical_core(coord);
     // Derive virtual coord in noc_index space.
+    const Hal& hal = MetalEnvAccessor(*env_).impl().get_hal();
     CoreCoord virtual_coord = {
-        MetalContext::instance().hal().noc_coordinate(noc_index, grid_size.x, coord.x),
-        MetalContext::instance().hal().noc_coordinate(noc_index, grid_size.y, coord.y)};
+        hal.noc_coordinate(noc_index, grid_size.x, coord.x), hal.noc_coordinate(noc_index, grid_size.y, coord.y)};
     return virtual_coord;
 }
 
 CoreCoord Device::physical_worker_core_from_logical_core(const CoreCoord& logical_core) const {
-    const metal_SocDescriptor& soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(this->id_);
+    const metal_SocDescriptor& soc_desc = MetalEnvAccessor(*env_).impl().get_cluster().get_soc_desc(this->id_);
     return soc_desc.get_physical_tensix_core_from_logical(logical_core);
 }
 
@@ -549,12 +563,12 @@ std::vector<CoreCoord> Device::ethernet_cores_from_logical_cores(const std::vect
 }
 
 CoreCoord Device::virtual_core_from_logical_core(const CoreCoord& logical_coord, const CoreType& core_type) const {
-    return tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
+    return MetalEnvAccessor(*env_).impl().get_cluster().get_virtual_coordinate_from_logical_coordinates(
         this->id_, logical_coord, core_type);
 }
 
 CoreCoord Device::virtual_core_from_physical_core(const CoreCoord& physical_coord) const {
-    return tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_physical_coordinates(
+    return MetalEnvAccessor(*env_).impl().get_cluster().get_virtual_coordinate_from_physical_coordinates(
         this->id_, physical_coord);
 }
 
@@ -567,26 +581,25 @@ CoreCoord Device::ethernet_core_from_logical_core(const CoreCoord& logical_core)
 }
 
 CoreCoord Device::logical_core_from_ethernet_core(const CoreCoord& ethernet_core) const {
-    return tt::tt_metal::MetalContext::instance().get_cluster().get_logical_ethernet_core_from_virtual(
+    return MetalEnvAccessor(*env_).impl().get_cluster().get_logical_ethernet_core_from_virtual(
         this->id(), ethernet_core);
 }
 
 uint32_t Device::get_noc_unicast_encoding(uint8_t noc_index, const CoreCoord& core) const {
     auto virtual_noc_coord = this->virtual_noc0_coordinate(noc_index, core);
-    return tt::tt_metal::MetalContext::instance().hal().noc_xy_encoding(virtual_noc_coord.x, virtual_noc_coord.y);
+    return MetalEnvAccessor(*env_).impl().get_hal().noc_xy_encoding(virtual_noc_coord.x, virtual_noc_coord.y);
 }
 
 uint32_t Device::get_noc_multicast_encoding(uint8_t noc_index, const CoreRange& cores) const {
     auto virtual_noc_start = this->virtual_noc0_coordinate(noc_index, cores.start_coord);
     auto virtual_noc_end = this->virtual_noc0_coordinate(noc_index, cores.end_coord);
-
+    const auto& hal = MetalEnvAccessor(*env_).impl().get_hal();
     // NOC 1 mcasts from bottom left to top right, so we need to reverse the coords
     if (noc_index == 0) {
-        return tt::tt_metal::MetalContext::instance().hal().noc_multicast_encoding(
+        return hal.noc_multicast_encoding(
             virtual_noc_start.x, virtual_noc_start.y, virtual_noc_end.x, virtual_noc_end.y);
     }
-    return tt::tt_metal::MetalContext::instance().hal().noc_multicast_encoding(
-        virtual_noc_end.x, virtual_noc_end.y, virtual_noc_start.x, virtual_noc_start.y);
+    return hal.noc_multicast_encoding(virtual_noc_end.x, virtual_noc_end.y, virtual_noc_start.x, virtual_noc_start.y);
 }
 
 const std::unique_ptr<AllocatorImpl>& Device::allocator_impl() const { return default_allocator_; }
@@ -608,25 +621,22 @@ const std::unique_ptr<Allocator>& Device::allocator(SubDeviceId sub_device_id) c
 uint32_t Device::num_sub_devices() const { return 1U; }
 
 CoreCoord Device::dram_core_from_dram_channel(uint32_t dram_channel, NOC noc) const {
-    return tt::tt_metal::MetalContext::instance()
-        .get_cluster()
-        .get_soc_desc(id_)
-        .get_preferred_worker_core_for_dram_view(dram_channel, noc);
+    return MetalEnvAccessor(*env_).impl().get_cluster().get_soc_desc(id_).get_preferred_worker_core_for_dram_view(
+        dram_channel, noc);
 }
 
 CoreCoord Device::logical_core_from_dram_channel(uint32_t dram_channel) const {
-    return tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(id_).get_logical_core_for_dram_view(
-        dram_channel);
+    return MetalEnvAccessor(*env_).impl().get_cluster().get_soc_desc(id_).get_logical_core_for_dram_view(dram_channel);
 }
 
 uint32_t Device::dram_channel_from_logical_core(const CoreCoord& logical_core) const {
-    return tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(id_).get_dram_channel_from_logical_core(
+    return MetalEnvAccessor(*env_).impl().get_cluster().get_soc_desc(id_).get_dram_channel_from_logical_core(
         logical_core);
 }
 
 uint32_t Device::dram_channel_from_virtual_core(const CoreCoord& virtual_core) const {
-    const metal_SocDescriptor& soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(this->id_);
-    uint32_t num_nocs = MetalContext::instance().hal().get_num_nocs();
+    const metal_SocDescriptor& soc_desc = MetalEnvAccessor(*env_).impl().get_cluster().get_soc_desc(this->id_);
+    uint32_t num_nocs = MetalEnvAccessor(*env_).impl().get_hal().get_num_nocs();
     for (uint32_t noc = 0; noc < num_nocs; noc++) {
         for (uint32_t channel = 0; channel < this->num_dram_channels(); ++channel) {
             if (soc_desc.get_preferred_worker_core_for_dram_view(channel, noc) == virtual_core) {
@@ -659,7 +669,7 @@ SystemMemoryManager& Device::sysmem_manager() {
     // SystemMemoryManager handles mock devices internally with stubs
     // For mock devices, ensure lazy initialization if not already done
     if (!sysmem_manager_) {
-        sysmem_manager_ = std::make_unique<SystemMemoryManager>(this->id_, 1);
+        sysmem_manager_ = std::make_unique<SystemMemoryManager>(context_->get_context_id(), this->id_, 1);
     }
     return *sysmem_manager_;
 }
@@ -776,19 +786,16 @@ std::vector<CoreCoord> Device::get_optimal_dram_bank_to_logical_worker_assignmen
         // Get physical coordinates of DRAM Controller NOC end-points
         uint32_t num_dram_banks = this->num_dram_channels();
 
-        const auto& hal = MetalContext::instance().hal();
+        const auto& hal = MetalEnvAccessor(*env_).impl().get_hal();
         bool noc_translation_enabled = true;
-        if (tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() != tt::TargetDevice::Mock) {
-            noc_translation_enabled = tt::tt_metal::MetalContext::instance()
-                                          .get_cluster()
-                                          .get_cluster_desc()
-                                          ->get_noc_translation_table_en()
-                                          .at(this->id());
+        if (MetalEnvAccessor(*env_).impl().get_cluster().get_target_device_type() != tt::TargetDevice::Mock) {
+            noc_translation_enabled =
+                MetalEnvAccessor(*env_).impl().get_cluster().get_cluster_desc()->get_noc_translation_table_en().at(
+                    this->id());
         }
         bool dram_is_virtualized =
             noc_translation_enabled && (hal.get_virtualized_core_types().contains(dev_msgs::AddressableCoreType::DRAM));
-        const metal_SocDescriptor& soc_d =
-            tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(this->id());
+        const metal_SocDescriptor& soc_d = MetalEnvAccessor(*env_).impl().get_cluster().get_soc_desc(this->id());
         std::vector<CoreCoord> dram_phy_coords;
         for (int i = 0; i < num_dram_banks; ++i) {
             auto dram_core = this->dram_core_from_dram_channel(i, noc);
@@ -821,8 +828,7 @@ std::vector<CoreCoord> Device::get_optimal_dram_bank_to_logical_worker_assignmen
         auto physical_worker_cores = get_optimal_dram_to_physical_worker_assignment(
             this->arch(), dram_phy_coords, full_grid_size_x, full_grid_size_y, worker_phy_x, worker_phy_y);
 
-        const metal_SocDescriptor& soc_desc =
-            tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(this->id_);
+        const metal_SocDescriptor& soc_desc = MetalEnvAccessor(*env_).impl().get_cluster().get_soc_desc(this->id_);
         // Convert to physical worker coordinates to logical. This gets returned to the user.
         for (auto physical_worker_core : physical_worker_cores) {
             tt::umd::CoreCoord logical_coord_translated =
@@ -840,7 +846,7 @@ std::vector<CoreCoord> Device::get_optimal_dram_bank_to_logical_worker_assignmen
 }
 
 HalProgrammableCoreType Device::get_programmable_core_type(CoreCoord virtual_core) const {
-    if (!tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_core(virtual_core, this->id_)) {
+    if (!MetalEnvAccessor(*env_).impl().get_cluster().is_ethernet_core(virtual_core, this->id_)) {
         return HalProgrammableCoreType::TENSIX;
     }
 
@@ -854,8 +860,8 @@ HalProgrammableCoreType Device::get_programmable_core_type(CoreCoord virtual_cor
 }
 
 HalMemType Device::get_mem_type_of_core(CoreCoord virtual_core) const {
-    if (!tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_core(virtual_core, this->id_) &&
-        !tt::tt_metal::MetalContext::instance().get_cluster().is_worker_core(virtual_core, this->id_)) {
+    if (!MetalEnvAccessor(*env_).impl().get_cluster().is_ethernet_core(virtual_core, this->id_) &&
+        !MetalEnvAccessor(*env_).impl().get_cluster().is_worker_core(virtual_core, this->id_)) {
         return HalMemType::DRAM;
     }
     return HalMemType::L1;

--- a/tt_metal/impl/device/device_impl.hpp
+++ b/tt_metal/impl/device/device_impl.hpp
@@ -10,6 +10,8 @@
 #include <hostdevcommon/common_values.hpp>
 #include <hostdevcommon/kernel_structs.h>  // Leaked up to ttnn level from here
 #include <tt-metalium/hal_types.hpp>
+#include "context/metal_context.hpp"
+#include "impl/context/context_types.hpp"
 #include "impl/dispatch/hardware_command_queue.hpp"
 #include <tt-metalium/sub_device_types.hpp>
 #include <tt-metalium/sub_device.hpp>
@@ -32,6 +34,8 @@ class Device : public IDevice {
 public:
     Device() = delete;
     Device(
+        MetalEnv* env,
+        MetalContext* context,
         ChipId device_id,
         uint8_t num_hw_cqs,
         std::size_t l1_small_size,
@@ -50,6 +54,8 @@ public:
 
     Device(Device&& other) noexcept;
     Device& operator=(Device&& other) noexcept;
+
+    ContextId get_context_id() const { return context_->get_context_id(); }
 
     tt::ARCH arch() const override;
 
@@ -207,6 +213,9 @@ private:
     CoreCoord dram_core_from_dram_channel(uint32_t dram_channel, NOC noc = NOC::NOC_0) const;
     CoreCoord virtual_core_from_physical_core(const CoreCoord& physical_coord) const;
 
+    // TODO: Remove this member in favor of passing in dependencies directly
+    MetalContext* context_ = nullptr;  // Runtime state
+    MetalEnv* env_;                    // Lower level state
     ChipId id_;
     std::vector<std::vector<ChipId>> tunnels_from_mmio_;
 

--- a/tt_metal/impl/device/device_manager.cpp
+++ b/tt_metal/impl/device/device_manager.cpp
@@ -12,6 +12,7 @@
 #include <tt_stl/assert.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include <tt_metal.hpp>
+#include "context/metal_env_accessor.hpp"
 #include "dispatch/dispatch_query_manager.hpp"
 #include "dprint_server.hpp"
 #include "fabric/fabric_host_utils.hpp"
@@ -61,6 +62,7 @@ std::unordered_map<int, std::vector<uint32_t>> get_cpu_cores_per_numa_node(std::
 }
 
 std::pair<int, int> get_cpu_cores_for_dispatch_threads(
+    ContextId context_id,
     int mmio_controlled_device_id,
     const std::unordered_map<int, std::vector<uint32_t>>& cpu_cores_per_numa_node,
     std::unordered_set<uint32_t>& free_cores,
@@ -70,8 +72,9 @@ std::pair<int, int> get_cpu_cores_for_dispatch_threads(
     int core_assigned_to_device_completion_queue_reader = 0;
     uint32_t num_online_processors = sysconf(_SC_NPROCESSORS_ONLN);
     // Get NUMA node that the current device is mapped to through UMD
-    int numa_node_for_device =
-        tt::tt_metal::MetalContext::instance().get_cluster().get_numa_node_for_device(mmio_controlled_device_id);
+    int numa_node_for_device = tt::tt_metal::MetalContext::instance(context_id)
+                                   .get_cluster()
+                                   .get_numa_node_for_device(mmio_controlled_device_id);
 
     if (numa_available() != -1 and cpu_cores_per_numa_node.contains(numa_node_for_device)) {
         // NUMA node reported by UMD exists on host. Choose a core on this numa-node using round robin policy
@@ -126,13 +129,15 @@ void bind_current_thread_to_free_cores(const std::unordered_set<uint32_t>& free_
 }
 
 std::unordered_map<uint32_t, uint32_t> get_device_id_to_core_map(
-    const uint8_t num_hw_cqs, std::unordered_map<uint32_t, uint32_t>& completion_queue_reader_to_cpu_core_map) {
+    ContextId context_id,
+    const uint8_t num_hw_cqs,
+    std::unordered_map<uint32_t, uint32_t>& completion_queue_reader_to_cpu_core_map) {
     std::vector<ChipId> device_ids;
-    for (ChipId device_id : tt::tt_metal::MetalContext::instance().get_cluster().all_chip_ids()) {
+    for (ChipId device_id : tt::tt_metal::MetalContext::instance(context_id).get_cluster().all_chip_ids()) {
         device_ids.emplace_back(device_id);
     }
     bool use_numa_node_based_thread_binding =
-        tt::tt_metal::MetalContext::instance().rtoptions().get_numa_based_affinity();
+        tt::tt_metal::MetalContext::instance(context_id).rtoptions().get_numa_based_affinity();
     std::unordered_set<uint32_t> free_cores = {};
     uint32_t num_online_processors = sysconf(_SC_NPROCESSORS_ONLN);
     constexpr uint32_t max_num_procs_per_device = 2;
@@ -146,6 +151,7 @@ std::unordered_map<uint32_t, uint32_t> get_device_id_to_core_map(
         for (const auto& device_id : device_ids) {
             auto [worker_thread_core, completion_queue_reader_core] =
                 device_cpu_allocator::get_cpu_cores_for_dispatch_threads(
+                    context_id,
                     device_id,
                     cpu_cores_per_numa_node,
                     free_cores,
@@ -192,12 +198,12 @@ void DeviceManager::initialize(
     l1_small_size_ = descriptor_->l1_small_size();
     trace_region_size_ = descriptor_->trace_region_size();
     worker_l1_size_ = descriptor_->worker_l1_size();
-    using_fast_dispatch_ = MetalContext::instance().rtoptions().get_fast_dispatch();
+    using_fast_dispatch_ = MetalEnvAccessor(env_).impl().get_rtoptions().get_fast_dispatch();
     init_profiler_ = init_profiler;
     initialize_fabric_and_dispatch_fw_ = initialize_fabric_and_dispatch_fw;
 
-    worker_thread_to_cpu_core_map_ =
-        device_cpu_allocator::get_device_id_to_core_map(num_hw_cqs_, completion_queue_reader_to_cpu_core_map_);
+    worker_thread_to_cpu_core_map_ = device_cpu_allocator::get_device_id_to_core_map(
+        this->ctx_.get_context_id(), num_hw_cqs_, completion_queue_reader_to_cpu_core_map_);
 
     l1_bank_remap_.assign(descriptor_->l1_bank_remap().begin(), descriptor_->l1_bank_remap().end());
 
@@ -208,7 +214,7 @@ void DeviceManager::initialize(
 void DeviceManager::open_devices(const std::vector<ChipId>& device_ids) {
     std::vector<ChipId> device_ids_to_open = device_ids;
     // Never skip for TG Cluster
-    bool is_galaxy = tt::tt_metal::MetalContext::instance().get_cluster().is_galaxy_cluster();
+    bool is_galaxy = ctx_.get_cluster().is_galaxy_cluster();
     bool skip = !is_galaxy;
     bool any_remote_devices = false;
 
@@ -218,8 +224,7 @@ void DeviceManager::open_devices(const std::vector<ChipId>& device_ids) {
         // Check if fabric needs to be enabled (any remote devices).
         // Note, all devices must be open to use fabric. This check will happen in add_devices_to_pool.
         for (auto dev_id : device_ids_to_open) {
-            any_remote_devices =
-                tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(dev_id) != dev_id;
+            any_remote_devices = ctx_.get_cluster().get_associated_mmio_device(dev_id) != dev_id;
             if (any_remote_devices) {
                 break;
             }
@@ -230,7 +235,7 @@ void DeviceManager::open_devices(const std::vector<ChipId>& device_ids) {
         // Must open all devices in cluster to use fabric
         if (any_remote_devices) {
             device_ids_to_open.clear();
-            for (int id = 0; id < tt::tt_metal::MetalContext::instance().get_cluster().number_of_devices(); ++id) {
+            for (int id = 0; id < env_impl_.get_cluster().number_of_devices(); ++id) {
                 device_ids_to_open.push_back(id);
             }
         }
@@ -239,18 +244,17 @@ void DeviceManager::open_devices(const std::vector<ChipId>& device_ids) {
     std::vector<ChipId> target_mmio_ids;
     for (const auto& device_id : device_ids_to_open) {
         TT_FATAL(
-            tt::tt_metal::MetalContext::instance().get_cluster().all_chip_ids().contains(device_id),
+            ctx_.get_cluster().all_chip_ids().contains(device_id),
             "Device index {} out of range. There are {} devices available.",
             device_id,
-            tt::tt_metal::MetalContext::instance().get_cluster().number_of_devices());
-        const auto& mmio_device_id =
-            tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device_id);
+            ctx_.get_cluster().number_of_devices());
+        const auto& mmio_device_id = ctx_.get_cluster().get_associated_mmio_device(device_id);
         if (std::find(target_mmio_ids.begin(), target_mmio_ids.end(), mmio_device_id) == target_mmio_ids.end()) {
             target_mmio_ids.push_back(mmio_device_id);
         }
         skip &= (device_id == mmio_device_id);
     }
-    if (target_mmio_ids.size() != tt::tt_metal::MetalContext::instance().get_cluster().number_of_pci_devices()) {
+    if (target_mmio_ids.size() != ctx_.get_cluster().number_of_pci_devices()) {
         log_warning(
             tt::LogMetal,
             "Opening subset of mmio devices slows down UMD read/write to remote chips. If opening more devices, "
@@ -261,21 +265,22 @@ void DeviceManager::open_devices(const std::vector<ChipId>& device_ids) {
     // while initializing default sub device state.
     // This call will be a no-op if fabric is disabled.
     // May be called again below
-    tt::tt_metal::MetalContext::instance().initialize_fabric_config();
+    env_impl_.initialize_fabric_config();
 
     // Mock devices don't support fabric operations
-    bool is_mock =
-        tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock;
+    bool is_mock = env_impl_.get_cluster().get_target_device_type() == tt::TargetDevice::Mock;
     if (any_remote_devices && !is_mock) {
-        auto fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
+        auto fabric_config = ctx_.get_fabric_config();
         if (fabric_config == tt::tt_fabric::FabricConfig::DISABLED) {
             fabric_config = tt::tt_fabric::FabricConfig::FABRIC_1D;
-            tt::tt_fabric::SetFabricConfig(
+            // TODO: This is using an internal API.
+            // Externally, we should decide how/where to have SetFabricConfig on the correct MetalEnv
+            ctx_.set_fabric_config(
                 fabric_config, tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE, 1);
             // Update the fabric config in the descriptor
-            descriptor_->fabric_config_ = fabric_config;
+            MetalEnvAccessor(descriptor_->env()).impl().fabric_config_ = fabric_config;
             // Call initialize again because previously it was a no-op
-            tt::tt_metal::MetalContext::instance().initialize_fabric_config();
+            ctx_.initialize_fabric_config();
             log_info(
                 tt::LogMetal,
                 "Enabling {} only for dispatch. If your workload requires fabric, please set the fabric config "
@@ -283,10 +288,11 @@ void DeviceManager::open_devices(const std::vector<ChipId>& device_ids) {
                 fabric_config);
         } else {
             // Use the same mode
-            tt::tt_fabric::SetFabricConfig(
+            ctx_.set_fabric_config(
                 fabric_config, tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE, 1);
         }
-        descriptor_->reliability_mode_ = tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE;
+        MetalEnvAccessor(descriptor_->env()).impl().fabric_reliability_mode_ =
+            tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE;
         log_info(tt::LogMetal, "Dispatch on {} with {} Command Queues\n", fabric_config, num_hw_cqs_);
     }
 
@@ -294,17 +300,17 @@ void DeviceManager::open_devices(const std::vector<ChipId>& device_ids) {
     add_devices_to_pool(device_ids_to_open);
 
     // Initialize fabric tensix datamover config after devices are added to the pool
-    tt::tt_metal::MetalContext::instance().initialize_fabric_tensix_datamover_config();
+    ctx_.initialize_fabric_tensix_datamover_config();
 
     init_firmware_on_active_devices();
 }
 
 void DeviceManager::activate_device(ChipId id) {
     TT_FATAL(
-        tt::tt_metal::MetalContext::instance().get_cluster().all_chip_ids().contains(id),
+        env_impl_.get_cluster().all_chip_ids().contains(id),
         "Device index {} out of range. There are {} devices available.",
         id,
-        tt::tt_metal::MetalContext::instance().get_cluster().number_of_devices());
+        env_impl_.get_cluster().number_of_devices());
     const std::lock_guard<std::mutex> lock(lock_);
     if (this->devices_.size() < id + 1) {
         this->devices_.reserve(id + 1);
@@ -319,6 +325,8 @@ void DeviceManager::activate_device(ChipId id) {
                                                ? this->completion_queue_reader_to_cpu_core_map_.at(id)
                                                : -1;
         device = new Device(
+            &this->env_,
+            &this->ctx_,
             id,
             this->num_hw_cqs_,
             this->l1_small_size_,
@@ -374,10 +382,7 @@ std::size_t DeviceManager::get_max_num_eth_cores_across_all_devices() const {
     std::size_t max_eth_core_count = 0;
     for (const auto& device : this->devices_) {
         max_eth_core_count = std::max(
-            MetalContext::instance()
-                .get_control_plane()
-                .get_active_ethernet_cores(device->id(), /*skip_reserved_cores*/ true)
-                .size(),
+            env_impl_.get_control_plane().get_active_ethernet_cores(device->id(), /*skip_reserved_cores*/ true).size(),
             max_eth_core_count);
     }
     return max_eth_core_count;
@@ -388,19 +393,16 @@ void DeviceManager::add_devices_to_pool(const std::vector<ChipId>& device_ids) {
 
     if (this->skip_remote_devices_) {
         for (const auto& device_id : device_ids) {
-            const auto& mmio_device_id =
-                tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device_id);
+            const auto& mmio_device_id = env_impl_.get_cluster().get_associated_mmio_device(device_id);
             TT_ASSERT(device_id == mmio_device_id, "Skipping remote devices is only available for mmio devices");
             devices_to_activate.insert(device_id);
         }
     } else {
         for (const auto& device_id : device_ids) {
             // Get list of all devices in the cluster connected to the passed in device_ids
-            const auto& mmio_device_id =
-                tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device_id);
+            const auto& mmio_device_id = env_impl_.get_cluster().get_associated_mmio_device(device_id);
             for (const auto& mmio_controlled_device_id :
-                 tt::tt_metal::MetalContext::instance().get_cluster().get_devices_controlled_by_mmio_device(
-                     mmio_device_id)) {
+                 env_impl_.get_cluster().get_devices_controlled_by_mmio_device(mmio_device_id)) {
                 devices_to_activate.insert(mmio_controlled_device_id);
             }
         }
@@ -415,11 +417,10 @@ void DeviceManager::add_devices_to_pool(const std::vector<ChipId>& device_ids) {
     }
 
     // Only can launch Fabric if all devices are active
-    tt_fabric::FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
+    tt_fabric::FabricConfig fabric_config = ctx_.get_fabric_config();
     if (tt_fabric::is_tt_fabric_config(fabric_config) and
-        (tt::tt_metal::MetalContext::instance().get_cluster().mmio_chip_ids().size() !=
-         tt::tt_metal::MetalContext::instance().get_cluster().all_chip_ids().size())) {
-        for (int i = 0; i < tt::tt_metal::MetalContext::instance().get_cluster().number_of_devices(); i++) {
+        (env_impl_.get_cluster().mmio_chip_ids().size() != env_impl_.get_cluster().all_chip_ids().size())) {
+        for (int i = 0; i < env_impl_.get_cluster().number_of_devices(); i++) {
             // Fabric currently requires all devices to be active
             TT_FATAL(
                 this->is_device_active(i),
@@ -440,15 +441,13 @@ void DeviceManager::add_devices_to_pool(const std::vector<ChipId>& device_ids) {
     // It allocates dispatch cores to dispatch_core_manager.
     auto dispatch_kernel_initializer = std::make_unique<DispatchKernelInitializer>(
         descriptor_,
-        MetalContext::instance().get_dispatch_core_manager(),
+        ctx_.get_dispatch_core_manager(),
         this,
-        []() -> tt::tt_fabric::ControlPlane& { return MetalContext::instance().get_control_plane(); },
-        []() -> const tt::tt_metal::DispatchQueryManager& {
-            return MetalContext::instance().get_dispatch_query_manager();
-        },
+        [this]() -> tt::tt_fabric::ControlPlane& { return env_impl_.get_control_plane(); },
+        [this]() -> const tt::tt_metal::DispatchQueryManager& { return ctx_.get_dispatch_query_manager(); },
         [this]() { return static_cast<uint32_t>(this->get_max_num_eth_cores_across_all_devices()); },
-        [](ChipId id) {
-            auto& s = MetalContext::instance().dprint_server();
+        [this](ChipId id) {
+            auto& s = ctx_.dprint_server();
             return s && s.get() && s->reads_dispatch_cores(id);
         });
     if (!activated_devices.empty()) {
@@ -458,19 +457,16 @@ void DeviceManager::add_devices_to_pool(const std::vector<ChipId>& device_ids) {
 }
 
 void DeviceManager::initialize_profiler() {
-    auto& ctx = tt::tt_metal::MetalContext::instance();
     auto active_devices = this->get_all_active_devices_impl();
     initializers_[ProfilerInitializer::key] =
-        std::make_unique<ProfilerInitializer>(descriptor_, skip_remote_devices_, ctx.profiler_state_manager().get());
+        std::make_unique<ProfilerInitializer>(descriptor_, skip_remote_devices_, ctx_.profiler_state_manager().get());
     initializers_[ProfilerInitializer::key]->init(active_devices, init_done_);
     init_done_.insert(ProfilerInitializer::key);
     initializers_[ProfilerInitializer::key]->configure();
 }
 
 void DeviceManager::initialize_fabric_and_dispatch_fw() {
-    auto& ctx = tt::tt_metal::MetalContext::instance();
-
-    if (using_fast_dispatch_ && ctx.get_cluster().is_galaxy_cluster()) {
+    if (using_fast_dispatch_ && env_impl_.get_cluster().is_galaxy_cluster()) {
         log_info(
             tt::LogMetal, "Initializing Fabric and Dispatch Firmware for Galaxy cluster (this may take a few minutes)");
     }
@@ -478,7 +474,7 @@ void DeviceManager::initialize_fabric_and_dispatch_fw() {
     auto active_devices = this->get_all_active_devices_impl();
 
     initializers_[FabricFirmwareInitializer::key] =
-        std::make_unique<FabricFirmwareInitializer>(descriptor_, ctx.get_control_plane());
+        std::make_unique<FabricFirmwareInitializer>(descriptor_, env_impl_.get_control_plane());
     initializers_[FabricFirmwareInitializer::key]->init(active_devices, init_done_);
     init_done_.insert(FabricFirmwareInitializer::key);
 
@@ -507,15 +503,13 @@ void DeviceManager::initialize_dispatch_firmware(bool force_recreate_topology) {
         // Or recreate the initializer after reset (it was erased so that topology can be recreated for FD).
         auto dispatch_kernel_initializer = std::make_unique<DispatchKernelInitializer>(
             descriptor_,
-            MetalContext::instance().get_dispatch_core_manager(),
+            ctx_.get_dispatch_core_manager(),
             this,
-            []() -> tt::tt_fabric::ControlPlane& { return MetalContext::instance().get_control_plane(); },
-            []() -> const tt::tt_metal::DispatchQueryManager& {
-                return MetalContext::instance().get_dispatch_query_manager();
-            },
+            [this]() -> tt::tt_fabric::ControlPlane& { return env_impl_.get_control_plane(); },
+            [this]() -> const tt::tt_metal::DispatchQueryManager& { return ctx_.get_dispatch_query_manager(); },
             [this]() { return static_cast<uint32_t>(this->get_max_num_eth_cores_across_all_devices()); },
-            [](ChipId id) {
-                auto& s = MetalContext::instance().dprint_server();
+            [this](ChipId id) {
+                auto& s = ctx_.dprint_server();
                 return s && s.get() && s->reads_dispatch_cores(id);
             });
         if (!active_devices.empty()) {
@@ -570,7 +564,8 @@ void DeviceManager::init_firmware_on_active_devices() {
     }
 }
 
-DeviceManager::DeviceManager() {
+DeviceManager::DeviceManager(MetalEnv& env, MetalContext& ctx) :
+    env_(env), env_impl_(MetalEnvAccessor(env).impl()), ctx_(ctx) {
     ZoneScoped;
     log_debug(tt::LogMetal, "DeviceManager constructor");
 }
@@ -649,11 +644,10 @@ bool DeviceManager::close_device(ChipId device_id) {
     // Currently can only call this on mmio chips, once we split dispatch kernel shutdown
     // from device close, we can call this on remote devices too
     ZoneScoped;
-    const auto& mmio_device_id =
-        tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device_id);
+    const auto& mmio_device_id = env_impl_.get_cluster().get_associated_mmio_device(device_id);
     std::vector<IDevice*> devices_to_close;
     for (const auto& mmio_controlled_device_id :
-         tt::tt_metal::MetalContext::instance().get_cluster().get_devices_controlled_by_mmio_device(mmio_device_id)) {
+         env_impl_.get_cluster().get_devices_controlled_by_mmio_device(mmio_device_id)) {
         auto* device = this->get_device(mmio_controlled_device_id);
         if (device && device->is_initialized()) {
             devices_to_close.push_back(device);
@@ -672,13 +666,11 @@ bool DeviceManager::close_devices(const std::vector<IDevice*>& devices, bool /*s
     // For Galaxy if an mmio device's tunnels are being closed, close the mmio device as well
     std::unordered_set<ChipId> mmio_devices_to_close;
     for (const auto& dev : devices) {
-        const auto& mmio_device_id =
-            tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(dev->id());
+        const auto& mmio_device_id = env_impl_.get_cluster().get_associated_mmio_device(dev->id());
         if (mmio_devices_to_close.contains(mmio_device_id)) {
             continue;
         }
-        auto tunnels_from_mmio =
-            tt::tt_metal::MetalContext::instance().get_cluster().get_tunnels_from_mmio_device(mmio_device_id);
+        auto tunnels_from_mmio = env_impl_.get_cluster().get_tunnels_from_mmio_device(mmio_device_id);
         // iterate over all tunnels origination from this mmio device
         for (auto t : tunnels_from_mmio) {
             // iterate over all tunneled devices (tunnel stops) in this tunnel

--- a/tt_metal/impl/device/device_manager.hpp
+++ b/tt_metal/impl/device/device_manager.hpp
@@ -12,6 +12,8 @@
 #include <hostdevcommon/common_values.hpp>
 #include "umd/device/types/cluster_descriptor_types.hpp"
 #include "device_impl.hpp"
+#include "impl/context/context_types.hpp"
+#include "impl/context/metal_env_impl.hpp"
 
 namespace tt::tt_metal {
 
@@ -28,7 +30,7 @@ enum class InitializerKey;
 class DeviceManager {
 public:
     ~DeviceManager();
-    DeviceManager();
+    DeviceManager(MetalEnv& env, MetalContext& ctx);
 
     bool is_initialized() const { return is_initialized_; }
 
@@ -60,6 +62,9 @@ public:
     const std::unordered_set<CoreCoord>& get_virtual_dispatch_routing_cores(ChipId dev_id) const;
 
 private:
+    MetalEnv& env_;
+    MetalEnvImpl& env_impl_;
+    MetalContext& ctx_;
     uint8_t num_hw_cqs_{};
     size_t l1_small_size_{};
     size_t trace_region_size_{};

--- a/tt_metal/impl/device/firmware/fabric_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/fabric_firmware_initializer.cpp
@@ -67,6 +67,11 @@ void FabricFirmwareInitializer::teardown(std::unordered_set<InitializerKey>& ini
     TT_FATAL(
         !init_done.contains(InitializerKey::Dispatch),
         "FabricFirmwareInitializer must be torn down after DispatchKernelInitializer");
+    if (descriptor_->is_mock_device()) {
+        log_info(tt::LogMetal, "Skipping fabric teardown for mock devices");
+        init_done.erase(key);
+        return;
+    }
     if (!has_flag(descriptor_->fabric_manager(), tt_fabric::FabricManagerMode::TERMINATE_FABRIC)) {
         devices_.clear();
         initialized_ = false;
@@ -134,7 +139,7 @@ void FabricFirmwareInitializer::teardown(std::unordered_set<InitializerKey>& ini
 
 void FabricFirmwareInitializer::post_teardown() {
     // Reset fabric config
-    tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::DISABLED);
+    descriptor_->metal_context().set_fabric_config(tt::tt_fabric::FabricConfig::DISABLED);
 }
 
 bool FabricFirmwareInitializer::is_initialized() const { return initialized_; }

--- a/tt_metal/impl/device/firmware/profiler_initializer.cpp
+++ b/tt_metal/impl/device/firmware/profiler_initializer.cpp
@@ -87,6 +87,7 @@ void ProfilerInitializer::teardown(std::unordered_set<InitializerKey>& init_done
     if (getDeviceProfilerState(descriptor_->metal_context().get_context_id())) {
         // Read profiler results from dispatch cores
         for (auto* dev : devices_) {
+            TT_ASSERT(dev != nullptr, "Device is nullptr");
             detail::ReadDeviceProfilerResults(static_cast<IDevice*>(dev), ProfilerReadState::ONLY_DISPATCH_CORES);
         }
 

--- a/tt_metal/impl/device/firmware/profiler_initializer.cpp
+++ b/tt_metal/impl/device/firmware/profiler_initializer.cpp
@@ -8,6 +8,7 @@
 #include <tt-logger/tt-logger.hpp>
 #include <llrt/tt_cluster.hpp>
 #include <device.hpp>
+#include "context/context_types.hpp"
 #include "device/device_impl.hpp"
 #include "impl/context/context_descriptor.hpp"
 
@@ -31,38 +32,43 @@ void ProfilerInitializer::init(
 #if defined(TRACY_ENABLE)
     devices_ = devices;
 
-    if (!getDeviceProfilerState()) {
-        return;
+    for (auto* dev : devices) {
+        TT_ASSERT(
+            dev->get_context_id() == descriptor_->metal_context().get_context_id(),
+            "All devices must belong to the same MetalEnv / context ID");
     }
 
-    for (auto* dev : devices_) {
-        // For Galaxy init, we only need to loop over mmio devices
-        if (cluster_.get_associated_mmio_device(dev->id()) != dev->id()) {
-            continue;
-        }
-        auto tunnels_from_mmio = cluster_.get_tunnels_from_mmio_device(dev->id());
-        detail::InitDeviceProfiler(dev);
-        log_info(tt::LogMetal, "Profiler started on device {}", dev->id());
-        if (!skip_remote_devices_) {
-            for (const auto& tunnel : tunnels_from_mmio) {
-                // Need to create devices from farthest to the closest.
-                for (uint32_t ts = tunnel.size() - 1; ts > 0; ts--) {
-                    uint32_t mmio_controlled_device_id = tunnel[ts];
-                    auto it = std::find_if(devices_.begin(), devices_.end(), [&](Device* d) {
-                        return d->id() == mmio_controlled_device_id;
-                    });
-                    if (it != devices_.end()) {
-                        detail::InitDeviceProfiler(*it);
-                        log_info(tt::LogMetal, "Profiler started on remote device {}", (*it)->id());
+    if (getDeviceProfilerState(descriptor_->metal_context().get_context_id())) {
+        for (auto* dev : devices_) {
+            // For Galaxy init, we only need to loop over mmio devices
+            if (cluster_.get_associated_mmio_device(dev->id()) != dev->id()) {
+                continue;
+            }
+            auto tunnels_from_mmio = cluster_.get_tunnels_from_mmio_device(dev->id());
+            detail::InitDeviceProfiler(dev);
+            log_info(tt::LogMetal, "Profiler started on device {}", dev->id());
+            if (!skip_remote_devices_) {
+                for (const auto& tunnel : tunnels_from_mmio) {
+                    // Need to create devices from farthest to the closest.
+                    for (uint32_t ts = tunnel.size() - 1; ts > 0; ts--) {
+                        uint32_t mmio_controlled_device_id = tunnel[ts];
+                        auto it = std::find_if(devices_.begin(), devices_.end(), [&](Device* d) {
+                            return d->id() == mmio_controlled_device_id;
+                        });
+                        if (it != devices_.end()) {
+                            detail::InitDeviceProfiler(*it);
+                            log_info(tt::LogMetal, "Profiler started on remote device {}", (*it)->id());
+                        }
                     }
                 }
             }
         }
-    }
-    detail::ProfilerSync(ProfilerSyncState::INIT);
+        detail::ProfilerSync(ProfilerSyncState::INIT);
 
-    if (profiler_state_manager_ && rtoptions_.get_experimental_noc_debug_dump_enabled()) {
-        tt::tt_metal::LaunchIntervalBasedProfilerReadThread(std::vector<IDevice*>(devices_.begin(), devices_.end()));
+        if (profiler_state_manager_ && rtoptions_.get_experimental_noc_debug_dump_enabled()) {
+            tt::tt_metal::LaunchIntervalBasedProfilerReadThread(
+                std::vector<IDevice*>(devices_.begin(), devices_.end()));
+        }
     }
 #endif
 
@@ -78,11 +84,14 @@ void ProfilerInitializer::teardown(std::unordered_set<InitializerKey>& init_done
     TT_FATAL(
         !init_done.contains(InitializerKey::Fabric),
         "ProfilerInitializer must be torn down after FabricFirmwareInitializer");
-    // Read profiler results from dispatch cores
-    for (auto* dev : devices_) {
-        detail::ReadDeviceProfilerResults(static_cast<IDevice*>(dev), ProfilerReadState::ONLY_DISPATCH_CORES);
+    if (getDeviceProfilerState(descriptor_->metal_context().get_context_id())) {
+        // Read profiler results from dispatch cores
+        for (auto* dev : devices_) {
+            detail::ReadDeviceProfilerResults(static_cast<IDevice*>(dev), ProfilerReadState::ONLY_DISPATCH_CORES);
+        }
+
+        detail::ProfilerSync(ProfilerSyncState::CLOSE_DEVICE);
     }
-    detail::ProfilerSync(ProfilerSyncState::CLOSE_DEVICE);
 
     devices_.clear();
     initialized_ = false;
@@ -90,7 +99,7 @@ void ProfilerInitializer::teardown(std::unordered_set<InitializerKey>& init_done
 }
 
 void ProfilerInitializer::post_teardown() {
-    if (getDeviceProfilerState()) {
+    if (getDeviceProfilerState(descriptor_->metal_context().get_context_id())) {
         // Device profiling data is dumped here instead of MetalContext::teardown() because MetalContext::teardown() is
         // called as a std::atexit() function, and ProfilerStateManager::cleanup_device_profilers() cannot be safely
         // called from a std::atexit() function because it creates new threads, which is unsafe during program

--- a/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
@@ -13,6 +13,7 @@
 #include <tt-logger/tt-logger.hpp>
 #include <tt_stl/assert.hpp>
 
+#include "context/metal_context.hpp"
 #include "impl/context/context_descriptor.hpp"
 #include "core_coord.hpp"
 #include "hal.hpp"
@@ -155,9 +156,9 @@ void RiscFirmwareInitializer::run_launch_phase(const std::set<tt::ChipId>& devic
     // Launch FW on each device sequentially, since a multithreaded launch leads to initialization hangs.
     // See https://github.com/tenstorrent/tt-metal/issues/35701
     ZoneScopedN("Resets and FW Launch");
-    for (tt::ChipId device_id : device_ids) {
-        if (cluster_.get_target_device_type() != tt::TargetDevice::Mock) {
-            ClearNocData(device_id);
+    if (cluster_.get_target_device_type() != tt::TargetDevice::Mock) {
+        for (tt::ChipId device_id : device_ids) {
+            ClearNocData(descriptor_->env_impl(), device_id);
             reset_cores(device_id);
             initialize_and_launch_firmware(device_id);
         }
@@ -395,6 +396,8 @@ void RiscFirmwareInitializer::generate_device_bank_to_noc_tables(
     std::vector<uint16_t>& l1_bank_to_noc_xy) {
     BankMapping l1_bank_remap(descriptor_->l1_bank_remap().begin(), descriptor_->l1_bank_remap().end());
     auto config = L1BankingAllocator::generate_config(
+        descriptor_->metal_context().get_dispatch_core_manager(),
+        descriptor_->env_impl(),
         device_id,
         num_hw_cqs_,
         DEFAULT_L1_SMALL_SIZE,      // Not required for noc table gen

--- a/tt_metal/impl/dispatch/dispatch_core_common.cpp
+++ b/tt_metal/impl/dispatch/dispatch_core_common.cpp
@@ -4,6 +4,7 @@
 
 #include "impl/dispatch/dispatch_core_common.hpp"
 #include <tt_stl/reflection.hpp>
+#include "dispatch_core_common.hpp"
 #include "impl/context/metal_context.hpp"
 #include <umd/device/types/arch.hpp>
 #include <umd/device/types/core_coordinates.hpp>
@@ -13,13 +14,11 @@
 namespace tt::tt_metal {
 
 DispatchCoreAxis DispatchCoreConfig::get_default_axis() {
-    // Deprecated fallback: only checks the DEFAULT context, so it fails for non-default
-    // contexts (e.g. mock devices).  All internal callers should use
-    // resolve_dispatch_core_axis(arch, fabric_tensix_config) instead.
-    // This remains for legacy external callers that go through get_dispatch_core_axis().
-    // TODO: remove this once the header API can be updated.
-    // https://github.com/tenstorrent/tt-metal/issues/39974
-    // We first check if the instance exists to avoid implicit creation of the default context with MetalEnv
+    // All internal callers should use resolve_dispatch_core_axis(arch, fabric_tensix_config) instead.
+
+    // Check if the instance exists to prevent implicit init of a second cluster
+    // if we already have one in MetalEnv
+    // TOOD: https://github.com/tenstorrent/tt-metal/issues/39974
     if (MetalContext::instance_exists(DEFAULT_CONTEXT_ID)) {
         if (MetalContext::instance().get_cluster().arch() == tt::ARCH::BLACKHOLE) {
             if (MetalContext::instance().get_fabric_tensix_config() == tt_fabric::FabricTensixConfig::DISABLED) {
@@ -30,7 +29,12 @@ DispatchCoreAxis DispatchCoreConfig::get_default_axis() {
     return DispatchCoreAxis::ROW;
 }
 
-DispatchCoreAxis resolve_dispatch_core_axis(tt::ARCH arch, tt_fabric::FabricTensixConfig fabric_tensix_config) {
+DispatchCoreAxis resolve_dispatch_core_axis(
+    const DispatchCoreConfig& config, tt::ARCH arch, tt_fabric::FabricTensixConfig fabric_tensix_config) {
+    const auto& axis = std::get<1>(config.attribute_values());
+    if (axis.has_value()) {
+        return axis.value();
+    }
     if (arch == tt::ARCH::BLACKHOLE && fabric_tensix_config == tt_fabric::FabricTensixConfig::DISABLED) {
         return DispatchCoreAxis::COL;
     }
@@ -46,6 +50,9 @@ CoreType get_core_type_from_config(const DispatchCoreConfig& config) {
 }
 
 DispatchCoreConfig get_dispatch_core_config() {
+    // Check if the instance exists to prevent implicit init of a second cluster
+    // if we already have one in MetalEnv
+    // TODO: https://github.com/tenstorrent/tt-metal/issues/39974
     if (MetalContext::instance_exists(DEFAULT_CONTEXT_ID)) {
         return MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
     }

--- a/tt_metal/impl/dispatch/dispatch_core_common.cpp
+++ b/tt_metal/impl/dispatch/dispatch_core_common.cpp
@@ -18,6 +18,7 @@ DispatchCoreAxis DispatchCoreConfig::get_default_axis() {
     // resolve_dispatch_core_axis(arch, fabric_tensix_config) instead.
     // This remains for legacy external callers that go through get_dispatch_core_axis().
     // TODO: remove this once the header API can be updated.
+    // https://github.com/tenstorrent/tt-metal/issues/39974
     // We first check if the instance exists to avoid implicit creation of the default context with MetalEnv
     if (MetalContext::instance_exists(DEFAULT_CONTEXT_ID)) {
         if (MetalContext::instance().get_cluster().arch() == tt::ARCH::BLACKHOLE) {

--- a/tt_metal/impl/dispatch/dispatch_core_common.cpp
+++ b/tt_metal/impl/dispatch/dispatch_core_common.cpp
@@ -13,10 +13,25 @@
 namespace tt::tt_metal {
 
 DispatchCoreAxis DispatchCoreConfig::get_default_axis() {
-    if (MetalContext::instance().get_cluster().arch() == tt::ARCH::BLACKHOLE) {
-        if (MetalContext::instance().get_fabric_tensix_config() == tt_fabric::FabricTensixConfig::DISABLED) {
-            return DispatchCoreAxis::COL;
+    // Deprecated fallback: only checks the DEFAULT context, so it fails for non-default
+    // contexts (e.g. mock devices).  All internal callers should use
+    // resolve_dispatch_core_axis(arch, fabric_tensix_config) instead.
+    // This remains for legacy external callers that go through get_dispatch_core_axis().
+    // TODO: remove this once the header API can be updated.
+    // We first check if the instance exists to avoid implicit creation of the default context with MetalEnv
+    if (MetalContext::instance_exists(DEFAULT_CONTEXT_ID)) {
+        if (MetalContext::instance().get_cluster().arch() == tt::ARCH::BLACKHOLE) {
+            if (MetalContext::instance().get_fabric_tensix_config() == tt_fabric::FabricTensixConfig::DISABLED) {
+                return DispatchCoreAxis::COL;
+            }
         }
+    }
+    return DispatchCoreAxis::ROW;
+}
+
+DispatchCoreAxis resolve_dispatch_core_axis(tt::ARCH arch, tt_fabric::FabricTensixConfig fabric_tensix_config) {
+    if (arch == tt::ARCH::BLACKHOLE && fabric_tensix_config == tt_fabric::FabricTensixConfig::DISABLED) {
+        return DispatchCoreAxis::COL;
     }
     return DispatchCoreAxis::ROW;
 }
@@ -30,7 +45,10 @@ CoreType get_core_type_from_config(const DispatchCoreConfig& config) {
 }
 
 DispatchCoreConfig get_dispatch_core_config() {
-    return MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
+    if (MetalContext::instance_exists(DEFAULT_CONTEXT_ID)) {
+        return MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
+    }
+    return DispatchCoreConfig();
 }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/dispatch_core_common.hpp
+++ b/tt_metal/impl/dispatch/dispatch_core_common.hpp
@@ -35,6 +35,7 @@ CoreType get_core_type_from_config(const DispatchCoreConfig& config);
 // Prefer this over DispatchCoreConfig::get_dispatch_core_axis() when the config's
 // axis_ may not be set, since the fallback get_default_axis() only checks the
 // DEFAULT context and fails for non-default contexts (e.g. mock devices).
+// TODO: https://github.com/tenstorrent/tt-metal/issues/39974
 DispatchCoreAxis resolve_dispatch_core_axis(tt::ARCH arch, tt_fabric::FabricTensixConfig fabric_tensix_config);
 
 // Helper functions to get the dispatch core config/type

--- a/tt_metal/impl/dispatch/dispatch_core_common.hpp
+++ b/tt_metal/impl/dispatch/dispatch_core_common.hpp
@@ -30,13 +30,11 @@ enum DispatchWorkerType : uint32_t {
 
 CoreType get_core_type_from_config(const DispatchCoreConfig& config);
 
-// Resolve the dispatch core axis for a given architecture and fabric config.
-// BLACKHOLE without fabric tensix uses COL; everything else uses ROW.
-// Prefer this over DispatchCoreConfig::get_dispatch_core_axis() when the config's
-// axis_ may not be set, since the fallback get_default_axis() only checks the
-// DEFAULT context and fails for non-default contexts (e.g. mock devices).
+// Resolve the dispatch core axis from a DispatchCoreConfig without depending on MetalContext.
+// Uses the config's explicit axis if set; otherwise falls back to arch-based resolution.
 // TODO: https://github.com/tenstorrent/tt-metal/issues/39974
-DispatchCoreAxis resolve_dispatch_core_axis(tt::ARCH arch, tt_fabric::FabricTensixConfig fabric_tensix_config);
+DispatchCoreAxis resolve_dispatch_core_axis(
+    const DispatchCoreConfig& config, tt::ARCH arch, tt_fabric::FabricTensixConfig fabric_tensix_config);
 
 // Helper functions to get the dispatch core config/type
 DispatchCoreConfig get_dispatch_core_config();

--- a/tt_metal/impl/dispatch/dispatch_core_common.hpp
+++ b/tt_metal/impl/dispatch/dispatch_core_common.hpp
@@ -7,7 +7,9 @@
 #include <cstdint>
 
 #include <tt-metalium/dispatch_core_common.hpp>
+#include <umd/device/types/arch.hpp>
 #include <umd/device/types/core_coordinates.hpp>  // CoreType
+#include <tt-metalium/experimental/fabric/fabric_types.hpp>
 
 namespace tt::tt_metal {
 
@@ -27,6 +29,13 @@ enum DispatchWorkerType : uint32_t {
 };
 
 CoreType get_core_type_from_config(const DispatchCoreConfig& config);
+
+// Resolve the dispatch core axis for a given architecture and fabric config.
+// BLACKHOLE without fabric tensix uses COL; everything else uses ROW.
+// Prefer this over DispatchCoreConfig::get_dispatch_core_axis() when the config's
+// axis_ may not be set, since the fallback get_default_axis() only checks the
+// DEFAULT context and fails for non-default contexts (e.g. mock devices).
+DispatchCoreAxis resolve_dispatch_core_axis(tt::ARCH arch, tt_fabric::FabricTensixConfig fabric_tensix_config);
 
 // Helper functions to get the dispatch core config/type
 DispatchCoreConfig get_dispatch_core_config();

--- a/tt_metal/impl/dispatch/dispatch_core_manager.cpp
+++ b/tt_metal/impl/dispatch/dispatch_core_manager.cpp
@@ -10,6 +10,7 @@
 #include <unordered_set>
 
 #include <tt_stl/assert.hpp>
+#include "context/metal_env_accessor.hpp"
 #include "core_coord.hpp"
 #include "core_descriptor.hpp"
 #include "impl/dispatch/dispatch_core_common.hpp"
@@ -28,7 +29,7 @@ const tt_cxy_pair& dispatch_core_manager::prefetcher_core(ChipId device_id, uint
         return assignment.prefetcher.value();
     }
     // Issue queue interface is on the MMIO device
-    ChipId mmio_device_id = tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device_id);
+    ChipId mmio_device_id = env_.get_cluster().get_associated_mmio_device(device_id);
     CoreCoord issue_queue_coord = this->get_next_available_dispatch_core(mmio_device_id);
     assignment.prefetcher = tt_cxy_pair(mmio_device_id, issue_queue_coord.x, issue_queue_coord.y);
     log_dispatch_assignment("Prefetcher", assignment.prefetcher.value(), device_id, channel, cq_id);
@@ -67,7 +68,7 @@ const tt_cxy_pair& dispatch_core_manager::completion_queue_writer_core(
         return assignment.completion_queue_writer.value();
     }
     // Completion queue interface is on the MMIO device
-    ChipId mmio_device_id = tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device_id);
+    ChipId mmio_device_id = env_.get_cluster().get_associated_mmio_device(device_id);
     CoreCoord completion_queue_coord = this->get_next_available_dispatch_core(mmio_device_id);
     assignment.completion_queue_writer =
         tt_cxy_pair(mmio_device_id, completion_queue_coord.x, completion_queue_coord.y);
@@ -99,7 +100,7 @@ const tt_cxy_pair& dispatch_core_manager::dispatcher_core_locked(ChipId device_i
     if (assignment.dispatcher.has_value()) {
         return assignment.dispatcher.value();
     }
-    ChipId mmio_device_id = tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device_id);
+    ChipId mmio_device_id = env_.get_cluster().get_associated_mmio_device(device_id);
     CoreCoord dispatcher_coord = this->get_next_available_dispatch_core(mmio_device_id);
     assignment.dispatcher = tt_cxy_pair(mmio_device_id, dispatcher_coord.x, dispatcher_coord.y);
     TT_ASSERT(
@@ -172,8 +173,7 @@ const tt_cxy_pair& dispatch_core_manager::dispatcher_s_core(ChipId device_id, ui
     }
     CoreCoord dispatcher_s_coord;
     if (this->get_dispatch_core_type() == CoreType::WORKER) {
-        ChipId mmio_device_id =
-            tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device_id);
+        ChipId mmio_device_id = env_.get_cluster().get_associated_mmio_device(device_id);
         if (mmio_device_id == device_id) {
             // dispatch_s is on the same tensix core as dispatch_hd
             dispatcher_s_coord = this->dispatcher_core_locked(device_id, channel, cq_id);
@@ -209,25 +209,27 @@ void dispatch_core_manager::add_dispatch_core_to_device_locked(ChipId device_id,
 }
 
 std::vector<CoreCoord> dispatch_core_manager::get_all_logical_dispatch_cores(ChipId device_id) {
-    return tt::get_logical_dispatch_cores(device_id, MAX_NUM_HW_CQS, this->dispatch_core_config_);
+    return tt::get_logical_dispatch_cores(this->env_, device_id, MAX_NUM_HW_CQS, this->dispatch_core_config_);
 }
 
 // private methods
 
-dispatch_core_manager::dispatch_core_manager(const DispatchCoreConfig& dispatch_core_config, uint8_t num_hw_cqs) {
-    this->reset_dispatch_core_manager(dispatch_core_config, num_hw_cqs);
+dispatch_core_manager::dispatch_core_manager(
+    const DispatchCoreConfig& dispatch_core_config, uint8_t num_hw_cqs, MetalEnvImpl& env) :
+    env_(env) {
+    this->reset_dispatch_core_manager(dispatch_core_config, num_hw_cqs, env);
 }
 
 void dispatch_core_manager::reset_dispatch_core_manager(
-    const DispatchCoreConfig& dispatch_core_config, uint8_t num_hw_cqs) {
+    const DispatchCoreConfig& dispatch_core_config, uint8_t num_hw_cqs, MetalEnvImpl& env) {
     std::lock_guard<std::mutex> lock(this->dispatch_core_assignments_mutex);
     this->dispatch_core_assignments.clear();
     this->available_dispatch_cores_by_device.clear();
     this->dispatch_core_config_ = dispatch_core_config;
-    for (ChipId device_id : tt::tt_metal::MetalContext::instance().get_cluster().all_chip_ids()) {
+    for (ChipId device_id : env.get_cluster().all_chip_ids()) {
         std::list<CoreCoord>& logical_dispatch_cores = this->available_dispatch_cores_by_device[device_id];
         for (const CoreCoord& logical_dispatch_core :
-             tt::get_logical_dispatch_cores(device_id, MAX_NUM_HW_CQS, dispatch_core_config)) {
+             tt::get_logical_dispatch_cores(env, device_id, MAX_NUM_HW_CQS, dispatch_core_config)) {
             logical_dispatch_cores.push_back(logical_dispatch_core);
         }
 
@@ -237,8 +239,7 @@ void dispatch_core_manager::reset_dispatch_core_manager(
         // the core descriptor (ex: 2 CQs on N300 need 10 dispatch cores and the core descriptor only allocates 6).
         // Infer the remaining dispatch cores from the idle eth core list (this is device dependent).
         if (get_core_type_from_config(dispatch_core_config) == CoreType::ETH) {
-            for (const auto& idle_eth_core :
-                 tt::tt_metal::MetalContext::instance().get_control_plane().get_inactive_ethernet_cores(device_id)) {
+            for (const auto& idle_eth_core : env_.get_control_plane().get_inactive_ethernet_cores(device_id)) {
                 add_dispatch_core_to_device_locked(device_id, idle_eth_core);
             }
         }
@@ -272,8 +273,7 @@ void dispatch_core_manager::log_dispatch_assignment(
         "Allocated {} Core: {}({}) for Device {} Channel {} CQ ID {}",
         name,
         cxy.str(),
-        tt::tt_metal::MetalContext::instance()
-            .get_cluster()
+        env_.get_cluster()
             .get_virtual_coordinate_from_logical_coordinates(
                 cxy, force_ethernet ? CoreType::ETH : get_dispatch_core_type())
             .str(),

--- a/tt_metal/impl/dispatch/dispatch_core_manager.hpp
+++ b/tt_metal/impl/dispatch/dispatch_core_manager.hpp
@@ -12,11 +12,14 @@
 #include <vector>
 
 #include <tt-metalium/core_coord.hpp>
+#include "context/context_types.hpp"
+#include "context/metal_env_impl.hpp"
 #include "llrt/core_descriptor.hpp"
 #include <tt-metalium/dispatch_core_common.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/xy_pair.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>
+#include <tt-metalium/experimental/context/metal_env.hpp>
 
 namespace tt::tt_metal {
 
@@ -62,7 +65,7 @@ public:
     ///         This list contains dispatch cores that have not been assigned to a particular dispatch function
     /// @param num_hw_cqs is used to get the correct collection of dispatch cores for a particular device
     /// @param dispatch_core_config specifies the core type that is designated for dispatch functionality
-    dispatch_core_manager(const DispatchCoreConfig& dispatch_core_config, uint8_t num_hw_cqs);
+    dispatch_core_manager(const DispatchCoreConfig& dispatch_core_config, uint8_t num_hw_cqs, MetalEnvImpl& env);
 
     static constexpr uint8_t MAX_NUM_HW_CQS = 2;
 
@@ -153,7 +156,8 @@ public:
 private:
     /// @brief reset_dispatch_core_manager initializes vector of cores per device for dispatch kernels
     /// @param dispatch_core_config specifies the core type for dispatch kernels
-    void reset_dispatch_core_manager(const DispatchCoreConfig& dispatch_core_config, uint8_t num_hw_cqs);
+    void reset_dispatch_core_manager(
+        const DispatchCoreConfig& dispatch_core_config, uint8_t num_hw_cqs, MetalEnvImpl& env);
 
     /// @brief getting any available dispatch core for a device
     /// @param device_id
@@ -192,6 +196,7 @@ private:
     std::unordered_map<ChipId, std::list<CoreCoord>> available_dispatch_cores_by_device;
     DispatchCoreConfig dispatch_core_config_;
     uint8_t num_hw_cqs{};
+    MetalEnvImpl& env_;
     static dispatch_core_manager* _inst;
 };
 

--- a/tt_metal/impl/dispatch/dispatch_query_manager.cpp
+++ b/tt_metal/impl/dispatch/dispatch_query_manager.cpp
@@ -11,7 +11,9 @@
 #include <utility>
 
 #include <tt_stl/assert.hpp>
+#include "context/metal_env_accessor.hpp"
 #include "core_descriptor.hpp"
+#include "dispatch/dispatch_core_manager.hpp"
 #include "impl/context/metal_context.hpp"
 #include <umd/device/types/cluster_descriptor_types.hpp>
 #include <umd/device/types/xy_pair.hpp>
@@ -19,37 +21,30 @@
 
 namespace {
 
-tt::tt_metal::DispatchCoreConfig dispatch_core_config() {
-    return tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
-}
-
-tt_cxy_pair dispatch_core(uint8_t cq_id) {
+tt_cxy_pair dispatch_core(
+    tt::tt_metal::MetalEnv& env, tt::tt_metal::dispatch_core_manager& core_manager, uint8_t cq_id) {
     tt_cxy_pair dispatch_core = tt_cxy_pair(0, 0, 0);
     std::optional<tt_cxy_pair> first_dispatch_core = std::nullopt;
-    for (tt::ChipId device_id : tt::tt_metal::MetalContext::instance().get_cluster().all_chip_ids()) {
-        uint16_t channel =
-            tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device_id);
-        if (tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device_id) == device_id) {
+    auto& cluster = tt::tt_metal::MetalEnvAccessor(env).impl().get_cluster();
+    for (tt::ChipId device_id : cluster.all_chip_ids()) {
+        uint16_t channel = cluster.get_assigned_channel_for_device(device_id);
+        if (cluster.get_associated_mmio_device(device_id) == device_id) {
             // Dispatch core is not allocated on this MMIO device or this is a TG system, skip it
             // On TG, local dispatch cores are allocated on MMIO devices, but are not used
             // since programs are not run on these devices. The placement of these cores is
             // irrelevant for the runtime layer, since these are not used. Hence, these are
             // skipped.
-            if (not tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().is_dispatcher_core_allocated(
-                    device_id, channel, cq_id) or
-                tt::tt_metal::MetalContext::instance().get_cluster().is_galaxy_cluster()) {
+            if (not core_manager.is_dispatcher_core_allocated(device_id, channel, cq_id) or
+                cluster.is_galaxy_cluster()) {
                 continue;
             }
-            dispatch_core = tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().dispatcher_core(
-                device_id, channel, cq_id);
+            dispatch_core = core_manager.dispatcher_core(device_id, channel, cq_id);
         } else {
             // Dispatch core is not allocated on this Non-MMIO device, skip it
-            if (not tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().is_dispatcher_d_core_allocated(
-                    device_id, channel, cq_id)) {
+            if (not core_manager.is_dispatcher_d_core_allocated(device_id, channel, cq_id)) {
                 continue;
             }
-            dispatch_core = tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().dispatcher_d_core(
-                device_id, channel, cq_id);
+            dispatch_core = core_manager.dispatcher_d_core(device_id, channel, cq_id);
         }
         if (not first_dispatch_core.has_value()) {
             first_dispatch_core = dispatch_core;
@@ -63,18 +58,15 @@ tt_cxy_pair dispatch_core(uint8_t cq_id) {
     return dispatch_core;
 }
 
-template <typename F>
 std::vector<CoreCoord> get_consistent_logical_cores(
-    uint8_t num_hw_cqs, const tt::tt_metal::DispatchCoreConfig& dispatch_core_config, F&& func) {
-    auto user_chips = tt::tt_metal::MetalContext::instance().get_cluster().user_exposed_chip_ids();
+    tt::tt_metal::MetalEnv& env, uint8_t num_hw_cqs, const tt::tt_metal::DispatchCoreConfig& dispatch_core_config) {
+    auto user_chips = tt::tt_metal::MetalEnvAccessor(env).impl().get_cluster().user_exposed_chip_ids();
     std::vector<CoreCoord> first_core_set;
     std::vector<CoreCoord> current_cores;
 
-    // Forward the callable once to preserve its value category.
-    auto&& callable = std::forward<F>(func);
-
     for (auto chip : user_chips) {
-        current_cores = callable(chip, num_hw_cqs, dispatch_core_config);
+        current_cores = tt::get_logical_dispatch_cores(
+            tt::tt_metal::MetalEnvAccessor(env).impl(), chip, num_hw_cqs, dispatch_core_config);
         if (!first_core_set.empty()) {
             TT_FATAL(first_core_set == current_cores, "Expected logical cores to match across user exposed devices");
         } else {
@@ -85,8 +77,8 @@ std::vector<CoreCoord> get_consistent_logical_cores(
 }
 
 std::vector<CoreCoord> populate_all_logical_dispatch_cores(
-    uint8_t num_hw_cqs, const tt::tt_metal::DispatchCoreConfig& dispatch_core_config) {
-    return get_consistent_logical_cores(num_hw_cqs, dispatch_core_config, tt::get_logical_dispatch_cores);
+    tt::tt_metal::MetalEnv& env, uint8_t num_hw_cqs, const tt::tt_metal::DispatchCoreConfig& dispatch_core_config) {
+    return get_consistent_logical_cores(env, num_hw_cqs, dispatch_core_config);
 }
 
 }  // namespace
@@ -99,22 +91,23 @@ bool DispatchQueryManager::distributed_dispatcher() const { return distributed_d
 
 NOC DispatchQueryManager::go_signal_noc() const { return go_signal_noc_; }
 
-void DispatchQueryManager::reset(uint8_t num_hw_cqs) {
+void DispatchQueryManager::reset(DispatchCoreConfig& dispatch_core_config, uint8_t num_hw_cqs) {
     num_hw_cqs_ = num_hw_cqs;
-    dispatch_core_config_ = dispatch_core_config();
+    dispatch_core_config_ = dispatch_core_config;
     dispatch_s_enabled_ =
-        (num_hw_cqs == 1 or dispatch_core_config().get_dispatch_core_type() == DispatchCoreType::WORKER);
+        (num_hw_cqs == 1 or dispatch_core_config_.get_dispatch_core_type() == DispatchCoreType::WORKER);
     distributed_dispatcher_ =
-        (num_hw_cqs == 1 and dispatch_core_config().get_dispatch_core_type() == DispatchCoreType::ETH);
+        (num_hw_cqs == 1 and dispatch_core_config_.get_dispatch_core_type() == DispatchCoreType::ETH);
     go_signal_noc_ = dispatch_s_enabled_ ? NOC::NOC_1 : NOC::NOC_0;
     // Reset the dispatch cores reported by the manager. Will be re-populated when the associated query is made
     dispatch_cores_ = {};
     // Populate dispatch
-    logical_dispatch_cores_on_user_chips_ = populate_all_logical_dispatch_cores(num_hw_cqs_, dispatch_core_config());
+    logical_dispatch_cores_on_user_chips_ =
+        populate_all_logical_dispatch_cores(env_, num_hw_cqs_, dispatch_core_config_);
 }
 
 const std::vector<CoreCoord>& DispatchQueryManager::get_logical_dispatch_cores(uint32_t device_id) const {
-    return tt::get_logical_dispatch_cores(device_id, num_hw_cqs_, dispatch_core_config());
+    return tt::get_logical_dispatch_cores(MetalEnvAccessor(env_).impl(), device_id, num_hw_cqs_, dispatch_core_config_);
 }
 
 const std::vector<CoreCoord>& DispatchQueryManager::get_logical_dispatch_cores_on_user_chips() const {
@@ -129,12 +122,16 @@ tt_cxy_pair DispatchQueryManager::get_dispatch_core(uint8_t cq_id) const {
             // the start of the process causes the dispatch core
             // order to change, which leads to lower performance
             // with ethernet dispatch.
-            dispatch_cores_.push_back(dispatch_core(cq));
+            dispatch_cores_.push_back(dispatch_core(env_, core_manager_, cq));
         }
     }
     return dispatch_cores_[cq_id];
 }
 
-DispatchQueryManager::DispatchQueryManager(uint8_t num_hw_cqs) { this->reset(num_hw_cqs); }
+DispatchQueryManager::DispatchQueryManager(
+    MetalEnv& env, dispatch_core_manager& core_manager, DispatchCoreConfig& dispatch_core_config, uint8_t num_hw_cqs) :
+    env_(env), core_manager_(core_manager) {
+    this->reset(dispatch_core_config, num_hw_cqs);
+}
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/dispatch_query_manager.hpp
+++ b/tt_metal/impl/dispatch/dispatch_query_manager.hpp
@@ -10,6 +10,7 @@
 
 #include "core_coord.hpp"
 #include <tt-metalium/kernel_types.hpp>
+#include <tt-metalium/experimental/context/metal_env.hpp>
 #include "dispatch_core_common.hpp"
 #include "dispatch_core_manager.hpp"
 #include <umd/device/types/xy_pair.hpp>
@@ -30,7 +31,11 @@ public:
     DispatchQueryManager& operator=(DispatchQueryManager&& other) noexcept = delete;
     DispatchQueryManager(const DispatchQueryManager&) = delete;
     DispatchQueryManager(DispatchQueryManager&& other) noexcept = delete;
-    DispatchQueryManager(uint8_t num_hw_cqs);
+    DispatchQueryManager(
+        MetalEnv& env,
+        dispatch_core_manager& core_manager,
+        DispatchCoreConfig& dispatch_core_config,
+        uint8_t num_hw_cqs);
 
     // dispatch_s related queries
     bool dispatch_s_enabled() const;
@@ -42,8 +47,10 @@ public:
     tt_cxy_pair get_dispatch_core(uint8_t cq_id) const;
 
 private:
-    void reset(uint8_t num_hw_cqs);
+    void reset(DispatchCoreConfig& dispatch_core_config, uint8_t num_hw_cqs);
 
+    MetalEnv& env_;
+    dispatch_core_manager& core_manager_;
     bool dispatch_s_enabled_ = false;
     bool distributed_dispatcher_ = false;
     NOC go_signal_noc_ = NOC::NOC_0;

--- a/tt_metal/impl/dispatch/hardware_command_queue.cpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.cpp
@@ -17,6 +17,7 @@
 #include "llrt/tt_cluster.hpp"
 #include "dispatch_query_manager.hpp"
 #include "device_command.hpp"
+#include "impl/device/device_impl.hpp"
 
 namespace tt::tt_metal {
 enum NOC : uint8_t;
@@ -24,7 +25,7 @@ enum NOC : uint8_t;
 
 namespace tt::tt_metal {
 
-HWCommandQueue::HWCommandQueue(IDevice* device, uint32_t id, NOC /*noc_index*/) :
+HWCommandQueue::HWCommandQueue(Device* device, uint32_t id, NOC /*noc_index*/) :
     id_(id), manager_(device->sysmem_manager()), device_(device) {
     ZoneScopedN("CommandQueue_constructor");
 
@@ -60,7 +61,7 @@ void HWCommandQueue::set_go_signal_noc_data_and_dispatch_sems(
     program_dispatch::set_go_signal_noc_data_on_dispatch(device_, noc_mcast_unicast_data, this->manager_, id_);
 }
 
-IDevice* HWCommandQueue::device() { return this->device_; }
+Device* HWCommandQueue::device() { return this->device_; }
 
 const CoreCoord& HWCommandQueue::virtual_enqueue_program_dispatch_core() const {
     return this->virtual_enqueue_program_dispatch_core_;
@@ -72,7 +73,8 @@ void HWCommandQueue::terminate() {
     log_debug(tt::LogDispatch, "Terminating dispatch kernels for command queue {}", this->id_);
     // CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_TERMINATE
     // CQ_PREFETCH_CMD_TERMINATE
-    uint32_t cmd_sequence_sizeB = MetalContext::instance().hal().get_alignment(HalMemType::HOST);
+    uint32_t cmd_sequence_sizeB =
+        MetalContext::instance(this->device_->get_context_id()).hal().get_alignment(HalMemType::HOST);
 
     // dispatch and prefetch terminate commands each needs to be a separate fetch queue entry
     void* cmd_region = this->manager_.issue_queue_reserve(cmd_sequence_sizeB, this->id_);

--- a/tt_metal/impl/dispatch/hardware_command_queue.hpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.hpp
@@ -20,16 +20,16 @@
 #include "worker_config_buffer.hpp"
 
 namespace tt::tt_metal {
-class IDevice;
 class SystemMemoryManager;
 enum NOC : uint8_t;
+class Device;
 }  // namespace tt::tt_metal
 
 namespace tt::tt_metal {
 
 class HWCommandQueue {
 public:
-    HWCommandQueue(IDevice* device, uint32_t id, NOC noc_index);
+    HWCommandQueue(Device* device, uint32_t id, NOC noc_index);
 
     ~HWCommandQueue() = default;
 
@@ -42,7 +42,7 @@ public:
 
     SystemMemoryManager& sysmem_manager();
 
-    IDevice* device();
+    Device* device();
 
     // needed interface items
     void terminate();
@@ -51,7 +51,7 @@ private:
     uint32_t id_;
     SystemMemoryManager& manager_;
 
-    IDevice* device_;
+    Device* device_;
 
     CoreCoord virtual_enqueue_program_dispatch_core_;
 };

--- a/tt_metal/impl/dispatch/system_memory_cq_interface.cpp
+++ b/tt_metal/impl/dispatch/system_memory_cq_interface.cpp
@@ -6,12 +6,12 @@
 
 #include <tt_stl/assert.hpp>
 #include "command_queue_common.hpp"
-#include "impl/context/metal_context.hpp"
 #include "dispatch_settings.hpp"
 
 namespace tt::tt_metal {
 
-SystemMemoryCQInterface::SystemMemoryCQInterface(uint16_t channel, uint8_t cq_id, uint32_t cq_size, uint32_t cq_start) :
+SystemMemoryCQInterface::SystemMemoryCQInterface(
+    uint16_t channel, uint8_t cq_id, uint32_t cq_size, uint32_t cq_start, uint32_t host_alignment) :
     cq_start(cq_start),
     command_completion_region_size(
         (((cq_size - cq_start) / DispatchSettings::TRANSFER_PAGE_SIZE) / 4) * DispatchSettings::TRANSFER_PAGE_SIZE),
@@ -24,10 +24,10 @@ SystemMemoryCQInterface::SystemMemoryCQInterface(uint16_t channel, uint8_t cq_id
     completion_fifo_size(command_completion_region_size >> 4),
     completion_fifo_limit(issue_fifo_limit + completion_fifo_size) {
     TT_ASSERT(
-        this->command_completion_region_size % MetalContext::instance().hal().get_alignment(HalMemType::HOST) == 0 and
-            this->command_issue_region_size % MetalContext::instance().hal().get_alignment(HalMemType::HOST) == 0,
+        this->command_completion_region_size % host_alignment == 0 and
+            this->command_issue_region_size % host_alignment == 0,
         "Issue queue and completion queue need to be {}B aligned!",
-        MetalContext::instance().hal().get_alignment(HalMemType::HOST));
+        host_alignment);
     TT_ASSERT(this->issue_fifo_limit != 0, "Cannot have a 0 fifo limit");
     // Currently read / write pointers on host and device assumes contiguous ranges for each channel
     // Device needs absolute offset of a hugepage to access the region of sysmem that holds a particular command

--- a/tt_metal/impl/dispatch/system_memory_cq_interface.hpp
+++ b/tt_metal/impl/dispatch/system_memory_cq_interface.hpp
@@ -14,7 +14,8 @@ struct SystemMemoryCQInterface {
     // Device signals completion and writes data for D2H transfers in the completion region, host reads from the
     // completion region Equation for issue fifo size is | issue_fifo_wr_ptr + command size B - issue_fifo_rd_ptr |
     // Space available would just be issue_fifo_limit - issue_fifo_size
-    SystemMemoryCQInterface(uint16_t channel, uint8_t cq_id, uint32_t cq_size, uint32_t cq_start);
+    SystemMemoryCQInterface(
+        uint16_t channel, uint8_t cq_id, uint32_t cq_size, uint32_t cq_start, uint32_t host_alignment);
 
     // Percentage of the command queue that is dedicated for issuing commands. Issue queue size is rounded to be 32B
     // aligned and remaining space is dedicated for completion queue Smaller issue queues can lead to more stalls for

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -41,11 +41,6 @@ void on_dispatch_timeout_detected();
 
 namespace {
 
-// Helper to check if running on mock device
-inline bool is_mock_device() {
-    return tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock;
-}
-
 bool wrap_ge(uint32_t a, uint32_t b) {
     // Signed Diff uses 2's Complement to handle wrap
     // Works as long as a and b are 2^31 apart
@@ -110,7 +105,8 @@ void loop_and_wait_with_timeout(
 }
 }  // namespace
 
-SystemMemoryManager::SystemMemoryManager(ChipId device_id, uint8_t num_hw_cqs) :
+SystemMemoryManager::SystemMemoryManager(ContextId context_id, ChipId device_id, uint8_t num_hw_cqs) :
+    context_id(context_id),
     device_id(device_id),
     completion_byte_addrs(num_hw_cqs),
     cq_to_event_locks(num_hw_cqs),
@@ -120,6 +116,7 @@ SystemMemoryManager::SystemMemoryManager(ChipId device_id, uint8_t num_hw_cqs) :
     this->prefetch_q_writers.reserve(num_hw_cqs);
     this->completion_q_writers.reserve(num_hw_cqs);
 
+    uint32_t alignment = MetalContext::instance(context_id).hal().get_alignment(HalMemType::HOST);
     if (is_mock_device()) {
         this->cq_size = 65536;
         this->cq_sysmem_start = nullptr;
@@ -127,17 +124,17 @@ SystemMemoryManager::SystemMemoryManager(ChipId device_id, uint8_t num_hw_cqs) :
         this->cq_to_event.resize(num_hw_cqs, 0);
         this->cq_to_last_completed_event.resize(num_hw_cqs, 0);
         for (uint8_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
-            this->cq_interfaces.emplace_back(0, cq_id, this->cq_size, 0);
+            this->cq_interfaces.emplace_back(0, cq_id, this->cq_size, 0, alignment);
         }
         log_debug(tt::LogMetal, "SystemMemoryManager: Initialized with stubs for mock device");
         return;
     }
 
     // Real hardware initialization below
-    ChipId mmio_device_id = tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device_id);
-    uint16_t channel = tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device_id);
-    char* hugepage_start = static_cast<char*>(
-        tt::tt_metal::MetalContext::instance().get_cluster().host_dma_address(0, mmio_device_id, channel));
+    auto& ctx = tt::tt_metal::MetalContext::instance(context_id);
+    ChipId mmio_device_id = ctx.get_cluster().get_associated_mmio_device(device_id);
+    uint16_t channel = ctx.get_cluster().get_assigned_channel_for_device(device_id);
+    char* hugepage_start = static_cast<char*>(ctx.get_cluster().host_dma_address(0, mmio_device_id, channel));
     hugepage_start += (channel >> 2) * DispatchSettings::MAX_DEV_CHANNEL_SIZE;
     this->cq_sysmem_start = hugepage_start;
 
@@ -147,10 +144,8 @@ SystemMemoryManager::SystemMemoryManager(ChipId device_id, uint8_t num_hw_cqs) :
         uint32_t cq_size_override = std::stoi(std::string(cq_size_override_env));
         this->cq_size = cq_size_override;
     } else {
-        this->cq_size =
-            tt::tt_metal::MetalContext::instance().get_cluster().get_host_channel_size(mmio_device_id, channel) /
-            num_hw_cqs;
-        if (tt::tt_metal::MetalContext::instance().get_cluster().is_galaxy_cluster()) {
+        this->cq_size = ctx.get_cluster().get_host_channel_size(mmio_device_id, channel) / num_hw_cqs;
+        if (ctx.get_cluster().is_galaxy_cluster()) {
             // We put 4 galaxy devices per huge page since number of hugepages available is less than number of
             // devices.
             this->cq_size = this->cq_size / DispatchSettings::DEVICES_PER_UMD_CHANNEL;
@@ -159,35 +154,27 @@ SystemMemoryManager::SystemMemoryManager(ChipId device_id, uint8_t num_hw_cqs) :
     this->channel_offset = DispatchSettings::MAX_HUGEPAGE_SIZE * get_umd_channel(channel) +
                            (channel >> 2) * DispatchSettings::MAX_DEV_CHANNEL_SIZE;
 
-    CoreType core_type = tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
-    uint32_t completion_q_rd_ptr = MetalContext::instance().dispatch_mem_map().get_device_command_queue_addr(
-        CommandQueueDeviceAddrType::COMPLETION_Q_RD);
-    uint32_t prefetch_q_base = MetalContext::instance().dispatch_mem_map().get_device_command_queue_addr(
-        CommandQueueDeviceAddrType::UNRESERVED);
-    uint32_t cq_start =
-        MetalContext::instance().dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
+    CoreType core_type = ctx.get_dispatch_core_manager().get_dispatch_core_type();
+    uint32_t completion_q_rd_ptr =
+        ctx.dispatch_mem_map().get_device_command_queue_addr(CommandQueueDeviceAddrType::COMPLETION_Q_RD);
+    uint32_t prefetch_q_base =
+        ctx.dispatch_mem_map().get_device_command_queue_addr(CommandQueueDeviceAddrType::UNRESERVED);
+    uint32_t cq_start = ctx.dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
     for (uint8_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
-        tt_cxy_pair prefetcher_core =
-            tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().prefetcher_core(
-                device_id, channel, cq_id);
-        auto prefetcher_virtual =
-            tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
-                prefetcher_core.chip, CoreCoord(prefetcher_core.x, prefetcher_core.y), core_type);
+        tt_cxy_pair prefetcher_core = ctx.get_dispatch_core_manager().prefetcher_core(device_id, channel, cq_id);
+        auto prefetcher_virtual = ctx.get_cluster().get_virtual_coordinate_from_logical_coordinates(
+            prefetcher_core.chip, CoreCoord(prefetcher_core.x, prefetcher_core.y), core_type);
         this->prefetcher_cores[cq_id] = tt_cxy_pair(prefetcher_core.chip, prefetcher_virtual.x, prefetcher_virtual.y);
-        this->prefetch_q_writers.emplace_back(
-            tt::tt_metal::MetalContext::instance().get_cluster().get_static_tlb_writer(this->prefetcher_cores[cq_id]));
+        this->prefetch_q_writers.emplace_back(ctx.get_cluster().get_static_tlb_writer(this->prefetcher_cores[cq_id]));
 
         tt_cxy_pair completion_queue_writer_core =
-            tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().completion_queue_writer_core(
-                device_id, channel, cq_id);
-        auto completion_queue_writer_virtual =
-            tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
-                completion_queue_writer_core.chip,
-                CoreCoord(completion_queue_writer_core.x, completion_queue_writer_core.y),
-                core_type);
+            ctx.get_dispatch_core_manager().completion_queue_writer_core(device_id, channel, cq_id);
+        auto completion_queue_writer_virtual = ctx.get_cluster().get_virtual_coordinate_from_logical_coordinates(
+            completion_queue_writer_core.chip,
+            CoreCoord(completion_queue_writer_core.x, completion_queue_writer_core.y),
+            core_type);
 
-        const std::tuple<uint32_t, uint32_t> completion_interface_tlb_data = tt::tt_metal::MetalContext::instance()
-                                                                                 .get_cluster()
+        const std::tuple<uint32_t, uint32_t> completion_interface_tlb_data = ctx.get_cluster()
                                                                                  .get_tlb_data(tt_cxy_pair(
                                                                                      completion_queue_writer_core.chip,
                                                                                      completion_queue_writer_virtual.x,
@@ -196,20 +183,17 @@ SystemMemoryManager::SystemMemoryManager(ChipId device_id, uint8_t num_hw_cqs) :
         auto [completion_tlb_offset, completion_tlb_size] = completion_interface_tlb_data;
 
         this->completion_byte_addrs[cq_id] = completion_q_rd_ptr % completion_tlb_size;
-        this->completion_q_writers.emplace_back(
-            tt::tt_metal::MetalContext::instance().get_cluster().get_static_tlb_writer(tt_cxy_pair(
-                completion_queue_writer_core.chip,
-                completion_queue_writer_virtual.x,
-                completion_queue_writer_virtual.y)));
+        this->completion_q_writers.emplace_back(ctx.get_cluster().get_static_tlb_writer(tt_cxy_pair(
+            completion_queue_writer_core.chip, completion_queue_writer_virtual.x, completion_queue_writer_virtual.y)));
 
-        this->cq_interfaces.push_back(SystemMemoryCQInterface(channel, cq_id, this->cq_size, cq_start));
+        this->cq_interfaces.push_back(SystemMemoryCQInterface(channel, cq_id, this->cq_size, cq_start, alignment));
         // Prefetch queue acts as the sync mechanism to ensure that issue queue has space to write, so issue queue
         // must be as large as the max amount of space the prefetch queue can specify Plus 1 to handle wrapping plus
         // PREFETCH_MAX_OUTSTANDING_PCIE_READS to allow us to start writing to issue queue
         // before we reserve space in the prefetch queue
         TT_FATAL(
-            MetalContext::instance().dispatch_mem_map().max_prefetch_command_size() *
-                    (MetalContext::instance().dispatch_mem_map().prefetch_q_entries() + 1U +
+            ctx.dispatch_mem_map().max_prefetch_command_size() *
+                    (ctx.dispatch_mem_map().prefetch_q_entries() + 1U +
                      PrefetchConstants::PREFETCH_MAX_OUTSTANDING_PCIE_READS) <=
                 this->get_issue_queue_size(cq_id),
             "Issue queue for cq_id {} has size of {} which is too small",
@@ -218,10 +202,14 @@ SystemMemoryManager::SystemMemoryManager(ChipId device_id, uint8_t num_hw_cqs) :
         this->cq_to_event.push_back(0);
         this->cq_to_last_completed_event.push_back(0);
         this->prefetch_q_dev_ptrs[cq_id] = prefetch_q_base;
-        this->prefetch_q_dev_fences[cq_id] =
-            prefetch_q_base + MetalContext::instance().dispatch_mem_map().prefetch_q_entries() *
-                                  sizeof(DispatchSettings::prefetch_q_entry_type);
+        this->prefetch_q_dev_fences[cq_id] = prefetch_q_base + ctx.dispatch_mem_map().prefetch_q_entries() *
+                                                                   sizeof(DispatchSettings::prefetch_q_entry_type);
     }
+}
+
+bool SystemMemoryManager::is_mock_device() const {
+    return tt::tt_metal::MetalContext::instance(this->context_id).get_cluster().get_target_device_type() ==
+           tt::TargetDevice::Mock;
 }
 
 uint32_t SystemMemoryManager::get_next_event(const uint8_t cq_id) {
@@ -408,6 +396,8 @@ uint32_t SystemMemoryManager::get_cq_size() const {
 
 ChipId SystemMemoryManager::get_device_id() const { return this->device_id; }
 
+ContextId SystemMemoryManager::get_context_id() const { return this->context_id; }
+
 std::vector<SystemMemoryCQInterface>& SystemMemoryManager::get_cq_interfaces() { return this->cq_interfaces; }
 
 void* SystemMemoryManager::issue_queue_reserve(uint32_t cmd_size_B, const uint8_t cq_id) {
@@ -426,10 +416,11 @@ void* SystemMemoryManager::issue_queue_reserve(uint32_t cmd_size_B, const uint8_
     uint32_t issue_q_write_ptr = this->get_issue_queue_write_ptr(cq_id);
 
     const uint32_t command_issue_limit = this->get_issue_queue_limit(cq_id);
-    if (issue_q_write_ptr +
-            align(
-                cmd_size_B,
-                tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::HOST)) >
+    if (issue_q_write_ptr + align(
+                                cmd_size_B,
+                                tt::tt_metal::MetalContext::instance(this->context_id)
+                                    .hal()
+                                    .get_alignment(tt::tt_metal::HalMemType::HOST)) >
         command_issue_limit) {
         this->wrap_issue_queue_wr_ptr(cq_id);
         issue_q_write_ptr = this->get_issue_queue_write_ptr(cq_id);
@@ -483,15 +474,12 @@ void SystemMemoryManager::issue_queue_push_back(uint32_t push_size_B, const uint
         return;
     }
 
+    auto& ctx = tt::tt_metal::MetalContext::instance(context_id);
     // All data needs to be PCIE_ALIGNMENT aligned
-    uint32_t push_size_16B =
-        align(
-            push_size_B, tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::HOST)) >>
-        4;
+    uint32_t push_size_16B = align(push_size_B, ctx.hal().get_alignment(tt::tt_metal::HalMemType::HOST)) >> 4;
 
     SystemMemoryCQInterface& cq_interface = this->cq_interfaces[cq_id];
-    uint32_t issue_q_wr_ptr =
-        MetalContext::instance().dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::ISSUE_Q_WR);
+    uint32_t issue_q_wr_ptr = ctx.dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::ISSUE_Q_WR);
 
     if (cq_interface.issue_fifo_wr_ptr + push_size_16B >= cq_interface.issue_fifo_limit) {
         cq_interface.issue_fifo_wr_ptr = (cq_interface.cq_start + cq_interface.offset) >> 4;  // In 16B words
@@ -501,11 +489,9 @@ void SystemMemoryManager::issue_queue_push_back(uint32_t push_size_B, const uint
     }
 
     // Also store this data in hugepages, so if a hang happens we can see what was written by host.
-    ChipId mmio_device_id =
-        tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(this->device_id);
-    uint16_t channel =
-        tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(this->device_id);
-    tt::tt_metal::MetalContext::instance().get_cluster().write_sysmem(
+    ChipId mmio_device_id = ctx.get_cluster().get_associated_mmio_device(this->device_id);
+    uint16_t channel = ctx.get_cluster().get_assigned_channel_for_device(this->device_id);
+    ctx.get_cluster().write_sysmem(
         &cq_interface.issue_fifo_wr_ptr,
         sizeof(uint32_t),
         issue_q_wr_ptr + get_relative_cq_offset(cq_id, this->cq_size),
@@ -524,13 +510,12 @@ void SystemMemoryManager::send_completion_queue_read_ptr(const uint8_t cq_id) co
     this->completion_q_writers[cq_id].write(this->completion_byte_addrs[cq_id], read_ptr_and_toggle);
 
     // Also store this data in hugepages in case we hang and can't get it from the device.
-    ChipId mmio_device_id =
-        tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(this->device_id);
-    uint16_t channel =
-        tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(this->device_id);
-    uint32_t completion_q_rd_ptr = MetalContext::instance().dispatch_mem_map().get_host_command_queue_addr(
-        CommandQueueHostAddrType::COMPLETION_Q_RD);
-    tt::tt_metal::MetalContext::instance().get_cluster().write_sysmem(
+    auto& ctx = tt::tt_metal::MetalContext::instance(context_id);
+    ChipId mmio_device_id = ctx.get_cluster().get_associated_mmio_device(this->device_id);
+    uint16_t channel = ctx.get_cluster().get_assigned_channel_for_device(this->device_id);
+    uint32_t completion_q_rd_ptr =
+        ctx.dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::COMPLETION_Q_RD);
+    ctx.get_cluster().write_sysmem(
         &read_ptr_and_toggle,
         sizeof(uint32_t),
         completion_q_rd_ptr + get_relative_cq_offset(cq_id, this->cq_size),
@@ -547,8 +532,9 @@ void SystemMemoryManager::fetch_queue_reserve_back(const uint8_t cq_id) {
         return;
     }
 
-    const uint32_t prefetch_q_rd_ptr = MetalContext::instance().dispatch_mem_map().get_device_command_queue_addr(
-        CommandQueueDeviceAddrType::PREFETCH_Q_RD);
+    auto& ctx = tt::tt_metal::MetalContext::instance(context_id);
+    const uint32_t prefetch_q_rd_ptr =
+        ctx.dispatch_mem_map().get_device_command_queue_addr(CommandQueueDeviceAddrType::PREFETCH_Q_RD);
 
     // Helper to wait for fetch queue space, if needed
     uint32_t fence;
@@ -560,8 +546,7 @@ void SystemMemoryManager::fetch_queue_reserve_back(const uint8_t cq_id) {
 
         // Body of the operation
         auto fetch_operation_body = [&]() {
-            tt::tt_metal::MetalContext::instance().get_cluster().read_core(
-                &fence, sizeof(uint32_t), this->prefetcher_cores[cq_id], prefetch_q_rd_ptr);
+            ctx.get_cluster().read_core(&fence, sizeof(uint32_t), this->prefetcher_cores[cq_id], prefetch_q_rd_ptr);
             this->prefetch_q_dev_fences[cq_id] = fence;
         };
 
@@ -571,16 +556,15 @@ void SystemMemoryManager::fetch_queue_reserve_back(const uint8_t cq_id) {
         };
 
         // Handler for timeout
-        auto fetch_on_timeout = []() {
-            MetalContext::instance().on_dispatch_timeout_detected();
+        auto fetch_on_timeout = [this]() {
+            tt::tt_metal::MetalContext::instance(this->context_id).on_dispatch_timeout_detected();
             TT_THROW("TIMEOUT: device timeout in fetch queue wait, potential hang detected");
         };
 
         // Get dispatch progress for timeout detection
         auto get_dispatch_progress = [&]() -> uint32_t { return get_cq_dispatch_progress(this->device_id, cq_id); };
 
-        auto timeout_duration =
-            tt::tt_metal::MetalContext::instance().rtoptions().get_timeout_duration_for_operations();
+        auto timeout_duration = ctx.rtoptions().get_timeout_duration_for_operations();
 
         loop_and_wait_with_timeout(
             fetch_operation_body, fetch_wait_condition, fetch_on_timeout, timeout_duration, get_dispatch_progress);
@@ -588,9 +572,9 @@ void SystemMemoryManager::fetch_queue_reserve_back(const uint8_t cq_id) {
 
     wait_for_fetch_q_space();
     // Wrap FetchQ if possible
-    uint32_t prefetch_q_base = MetalContext::instance().dispatch_mem_map().get_device_command_queue_addr(
-        CommandQueueDeviceAddrType::UNRESERVED);
-    uint32_t prefetch_q_limit = prefetch_q_base + (MetalContext::instance().dispatch_mem_map().prefetch_q_entries() *
+    uint32_t prefetch_q_base =
+        ctx.dispatch_mem_map().get_device_command_queue_addr(CommandQueueDeviceAddrType::UNRESERVED);
+    uint32_t prefetch_q_limit = prefetch_q_base + (ctx.dispatch_mem_map().prefetch_q_entries() *
                                                    sizeof(DispatchSettings::prefetch_q_entry_type));
     if (this->prefetch_q_dev_ptrs[cq_id] == prefetch_q_limit) {
         this->prefetch_q_dev_ptrs[cq_id] = prefetch_q_base;
@@ -623,10 +607,10 @@ uint32_t SystemMemoryManager::completion_queue_wait_front(
     };
 
     // Handler for the timeout
-    auto on_timeout = [&exit_condition]() {
+    auto on_timeout = [this, &exit_condition]() {
         exit_condition.store(true);
 
-        MetalContext::instance().on_dispatch_timeout_detected();
+        tt::tt_metal::MetalContext::instance(this->context_id).on_dispatch_timeout_detected();
 
         TT_THROW("TIMEOUT: device timeout, potential hang detected, the device is unrecoverable");
     };

--- a/tt_metal/impl/dispatch/system_memory_manager.hpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.hpp
@@ -14,6 +14,7 @@
 #include <functional>
 #include <mutex>
 #include <vector>
+#include "impl/context/context_types.hpp"
 
 using ChipId = int;
 
@@ -21,7 +22,9 @@ namespace tt::tt_metal {
 
 class SystemMemoryManager {
 public:
-    SystemMemoryManager(ChipId device_id, uint8_t num_hw_cqs);
+    // Create a SystemMemoryManager for accessing system memory accessible by the given device
+    // TODO: context_id will be removed in favor of directly passing around the MetalContext and MetalEnv reference.
+    SystemMemoryManager(ContextId context_id, ChipId device_id, uint8_t num_hw_cqs);
 
     uint32_t get_next_event(uint8_t cq_id);
 
@@ -65,6 +68,8 @@ public:
 
     ChipId get_device_id() const;
 
+    ContextId get_context_id() const;
+
     std::vector<SystemMemoryCQInterface>& get_cq_interfaces();
 
     void* issue_queue_reserve(uint32_t cmd_size_B, uint8_t cq_id);
@@ -95,6 +100,9 @@ public:
         uint8_t cq_id, uint32_t current_event_id, uint32_t last_completed_event_id);
 
 private:
+    bool is_mock_device() const;
+
+    ContextId context_id;
     ChipId device_id = 0;
     std::vector<uint32_t> completion_byte_addrs;
     char* cq_sysmem_start = nullptr;

--- a/tt_metal/impl/event/dispatch.cpp
+++ b/tt_metal/impl/event/dispatch.cpp
@@ -177,7 +177,8 @@ void read_events_from_completion_queue(
     SystemMemoryManager& sysmem_manager) {
     // For mock devices, the sysmem_manager is a stubbed singleton
     // Mock cluster.read_sysmem returns zeros, so validate that and handle gracefully
-    if (tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock) {
+    if (tt::tt_metal::MetalContext::instance(sysmem_manager.get_context_id()).get_cluster().get_target_device_type() ==
+        tt::TargetDevice::Mock) {
         sysmem_manager.set_last_completed_event(cq_id, event_descriptor.get_global_event_id());
         return;
     }

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt_stl/fmt.hpp>
+#include "context/metal_env_accessor.hpp"
 #include "core_coord.hpp"
 #include <common/TracyTTDeviceData.hpp>
 #include <device.hpp>
@@ -42,6 +43,7 @@
 #include "profiler_types.hpp"
 #include "common/tt_backend_api_types.hpp"
 #include "context/metal_context.hpp"
+#include "context/context_types.hpp"
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/arch.hpp>
 #include <umd/device/types/xy_pair.hpp>
@@ -422,8 +424,9 @@ std::set<experimental::ProgramAnalysisData> translateProgramsPerfResults(
 
 bool doAllDispatchCoresComeAfterNonDispatchCores(const IDevice* device, const std::vector<CoreCoord>& virtual_cores) {
     const auto& dispatch_core_config = get_dispatch_core_config();
+    auto& env = MetalEnvAccessor(tt::tt_metal::MetalContext::instance(extract_context_id(device)).get_env()).impl();
     const std::vector<CoreCoord> logical_dispatch_cores =
-        get_logical_dispatch_cores(device->id(), device->num_hw_cqs(), dispatch_core_config);
+        get_logical_dispatch_cores(env, device->id(), device->num_hw_cqs(), dispatch_core_config);
 
     std::vector<CoreCoord> virtual_dispatch_cores;
     for (const CoreCoord& core : logical_dispatch_cores) {
@@ -2098,14 +2101,17 @@ DeviceAddr DeviceProfiler::getProfilerDramBufferAddress(uint8_t active_dram_buff
 
 bool DeviceProfiler::isLastFDReadDone() const { return this->is_last_fd_read_done; }
 
+bool DeviceProfiler::profiler_enabled() const { return getDeviceProfilerState(extract_context_id(this->device)); }
+
 DeviceProfiler::DeviceProfiler(const IDevice* device, const bool new_logs [[maybe_unused]]) :
     device_arch(device->arch()),
     device_id(device->id()),
+    device(device),
     device_core_frequency(MetalContext::instance().get_cluster().get_device_aiclk(this->device_id)),
     max_compute_cores(device->logical_grid_size().x * device->logical_grid_size().y) {
 #if defined(TRACY_ENABLE)
     ZoneScopedC(tracy::Color::Green);
-    if (!getDeviceProfilerState()) {
+    if (!profiler_enabled()) {
         return;
     }
 
@@ -2161,20 +2167,22 @@ void DeviceProfiler::generateAnalysesForDeviceMarkers(
 void DeviceProfiler::dumpDeviceResults(bool is_mid_run_dump) {
 #if defined(TRACY_ENABLE)
     ZoneScoped;
-    if (!getDeviceProfilerState()) {
+    if (!profiler_enabled()) {
         return;
     }
 
+    auto context_id = extract_context_id(this->device);
     if (!this->thread_pool) {
-        this->thread_pool =
-            create_device_bound_thread_pool(MetalContext::instance()
-                                                .profiler_state_manager()
-                                                ->calculate_optimal_num_threads_for_device_profiler_thread_pool());
+        this->thread_pool = create_device_bound_thread_pool(
+            context_id,
+            MetalContext::instance(context_id)
+                .profiler_state_manager()
+                ->calculate_optimal_num_threads_for_device_profiler_thread_pool());
     }
 
     this->initializeMissingTracyContexts(/*blocking=*/is_mid_run_dump);
 
-    if (getDeviceDebugDumpEnabled()) {
+    if (getDeviceDebugDumpEnabled(context_id)) {
         // This was not called before so call it now for the final dump
         hash_to_zone_src_locations = generateZoneSourceLocationsHashes();
     }
@@ -2210,7 +2218,7 @@ void DeviceProfiler::dumpDeviceResults(bool is_mid_run_dump) {
 
 void DeviceProfiler::freshDeviceLog() {
 #if defined(TRACY_ENABLE)
-    if (!getDeviceProfilerState()) {
+    if (!profiler_enabled()) {
         return;
     }
     std::filesystem::path log_path = device_logs_output_dir / DEVICE_SIDE_LOG;
@@ -2223,7 +2231,7 @@ void DeviceProfiler::freshDeviceLog() {
 
 void DeviceProfiler::setOutputDir(const std::string& new_output_dir) {
 #if defined(TRACY_ENABLE)
-    if (!getDeviceProfilerState()) {
+    if (!profiler_enabled()) {
         return;
     }
     std::filesystem::create_directories(new_output_dir);
@@ -2240,7 +2248,7 @@ void DeviceProfiler::readResults(
     const std::optional<ProfilerOptionalMetadata>& /*metadata*/) {
 #if defined(TRACY_ENABLE)
     ZoneScoped;
-    if (!getDeviceProfilerState()) {
+    if (!profiler_enabled()) {
         return;
     }
 
@@ -2290,7 +2298,7 @@ void DeviceProfiler::processResults(
     const std::optional<std::map<CoreCoord, std::set<tracy::RiscType>>>& riscs_to_include) {
 #if defined(TRACY_ENABLE)
     ZoneScoped;
-    if (!getDeviceProfilerState()) {
+    if (!profiler_enabled()) {
         return;
     }
 
@@ -2340,7 +2348,7 @@ bool isSyncInfoNewer(const SyncInfo& old_info, const SyncInfo& new_info) {
 void DeviceProfiler::writeDeviceResultsToFiles() const {
 #if defined(TRACY_ENABLE)
     ZoneScoped;
-    if (!getDeviceProfilerState() || MetalContext::instance().rtoptions().get_profiler_disable_dump_to_files() ||
+    if (!profiler_enabled() || MetalContext::instance().rtoptions().get_profiler_disable_dump_to_files() ||
         MetalContext::instance().rtoptions().get_experimental_noc_debug_dump_enabled()) {
         return;
     }
@@ -2370,7 +2378,7 @@ void DeviceProfiler::pushTracyDeviceResults(
     std::vector<std::reference_wrapper<const tracy::TTDeviceMarker>>& device_markers_vec) {
 #if defined(TRACY_ENABLE)
     ZoneScoped;
-    if (!getDeviceProfilerState() || MetalContext::instance().rtoptions().get_profiler_disable_push_to_tracy()) {
+    if (!profiler_enabled() || MetalContext::instance().rtoptions().get_profiler_disable_push_to_tracy()) {
         return;
     }
 
@@ -2427,7 +2435,7 @@ void DeviceProfiler::setSyncInfo(const SyncInfo& sync_info) { device_sync_info =
 
 void DeviceProfiler::initializeMissingTracyContexts(bool blocking) {
 #if defined(TRACY_ENABLE)
-    if (!getDeviceProfilerState()) {
+    if (!profiler_enabled()) {
         return;
     }
     TT_ASSERT(this->thread_pool != nullptr);
@@ -2448,7 +2456,7 @@ void DeviceProfiler::initializeMissingTracyContexts(bool blocking) {
 void DeviceProfiler::updateTracyContexts(
     const std::vector<std::reference_wrapper<const tracy::TTDeviceMarker>>& device_markers_vec) {
 #if defined(TRACY_ENABLE)
-    if (!getDeviceProfilerState()) {
+    if (!profiler_enabled()) {
         return;
     }
     std::unordered_set<std::pair<ChipId, CoreCoord>, pair_hash<ChipId, CoreCoord>> device_cores_to_update;
@@ -2478,7 +2486,7 @@ void DeviceProfiler::updateTracyContexts(
 
 void DeviceProfiler::updateTracyContext(const std::pair<ChipId, CoreCoord>& device_core) {
 #if defined(TRACY_ENABLE)
-    if (!getDeviceProfilerState()) {
+    if (!profiler_enabled()) {
         return;
     }
     const ChipId device_id = device_core.first;
@@ -2549,7 +2557,7 @@ void DeviceProfiler::updateTracyContext(const std::pair<ChipId, CoreCoord>& devi
 
 void DeviceProfiler::destroyTracyContexts() {
 #if defined(TRACY_ENABLE)
-    if (!getDeviceProfilerState()) {
+    if (!profiler_enabled()) {
         return;
     }
     TT_ASSERT(this->thread_pool != nullptr);
@@ -2567,7 +2575,7 @@ void DeviceProfiler::pollDebugDumpResults(
     IDevice* device, const std::vector<CoreCoord>& virtual_cores, bool is_final_poll) {
 #if defined(TRACY_ENABLE)
     ZoneScoped;
-    if (!getDeviceProfilerState()) {
+    if (!profiler_enabled()) {
         return;
     }
 
@@ -2767,10 +2775,12 @@ void DeviceProfiler::pollDebugDumpResults(
 #endif
 }
 
-bool getDeviceProfilerState() { return MetalContext::instance().rtoptions().get_profiler_enabled(); }
+bool getDeviceProfilerState(ContextId context_id) {
+    return MetalContext::instance(context_id).rtoptions().get_profiler_enabled();
+}
 
-bool getDeviceDebugDumpEnabled() {
-    return MetalContext::instance().rtoptions().get_experimental_noc_debug_dump_enabled();
+bool getDeviceDebugDumpEnabled(ContextId context_id) {
+    return MetalContext::instance(context_id).rtoptions().get_experimental_noc_debug_dump_enabled();
 }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -176,8 +176,9 @@ int get_processor_id(tracy::RiscType risc_type) {
     }
 }
 
-DeviceAddr getControlVectorAddress(IDevice* device, const CoreCoord& virtual_core) {
-    const auto& hal = MetalContext::instance().hal();
+DeviceAddr getControlVectorAddress(IDevice* device, const CoreCoord& virtual_core, ContextId context_id) {
+    TT_ASSERT(context_id == extract_context_id(device));
+    const auto& hal = MetalContext::instance(context_id).hal();
     const HalProgrammableCoreType core_type = tt::llrt::get_core_type(device->id(), virtual_core);
     DeviceAddr profiler_msg_addr = hal.get_dev_addr(core_type, HalL1MemAddrType::PROFILER);
     DeviceAddr control_vector_addr =
@@ -422,9 +423,11 @@ std::set<experimental::ProgramAnalysisData> translateProgramsPerfResults(
     return programs_analyses_data;
 }
 
-bool doAllDispatchCoresComeAfterNonDispatchCores(const IDevice* device, const std::vector<CoreCoord>& virtual_cores) {
+bool doAllDispatchCoresComeAfterNonDispatchCores(
+    const IDevice* device, const std::vector<CoreCoord>& virtual_cores, ContextId context_id) {
+    TT_ASSERT(context_id == extract_context_id(device));
     const auto& dispatch_core_config = get_dispatch_core_config();
-    auto& env = MetalEnvAccessor(tt::tt_metal::MetalContext::instance(extract_context_id(device)).get_env()).impl();
+    auto& env = MetalEnvAccessor(tt::tt_metal::MetalContext::instance(context_id).get_env()).impl();
     const std::vector<CoreCoord> logical_dispatch_cores =
         get_logical_dispatch_cores(env, device->id(), device->num_hw_cqs(), dispatch_core_config);
 
@@ -1143,11 +1146,14 @@ bool isGalaxyMMIODevice(distributed::MeshDevice* mesh_device, IDevice* device) {
     if (mesh_device) {
         return false;
     }
-    return MetalContext::instance().get_cluster().is_galaxy_cluster() && device->is_mmio_capable();
+    return MetalContext::instance(extract_context_id(device)).get_cluster().is_galaxy_cluster() &&
+           device->is_mmio_capable();
 }
 
 bool useFastDispatch(distributed::MeshDevice* mesh_device, IDevice* device) {
-    return MetalContext::instance().device_manager()->is_dispatch_firmware_active() &&
+    return MetalContext::instance(extract_context_id(mesh_device, device))
+               .device_manager()
+               ->is_dispatch_firmware_active() &&
            !isGalaxyMMIODevice(mesh_device, device);
 }
 
@@ -1156,10 +1162,12 @@ void writeToCoreControlBuffer(
     IDevice* device,
     const CoreCoord& virtual_core,
     const std::vector<uint32_t>& data,
-    bool force_slow_dispatch) {
+    bool force_slow_dispatch,
+    ContextId context_id) {
     ZoneScoped;
 
-    const auto& hal = MetalContext::instance().hal();
+    TT_ASSERT(context_id == extract_context_id(mesh_device, device));
+    const auto& hal = MetalContext::instance(context_id).hal();
     const HalProgrammableCoreType core_type = tt::llrt::get_core_type(device->id(), virtual_core);
     DeviceAddr profiler_msg_addr = hal.get_dev_addr(core_type, HalL1MemAddrType::PROFILER);
     DeviceAddr control_vector_addr =
@@ -1177,14 +1185,16 @@ void writeToCoreControlBuffer(
             TT_FATAL(false, "Fast dispatch write to control buffer requires mesh device support");
         }
     } else {
-        MetalContext::instance().get_cluster().write_core(device->id(), virtual_core, data, control_vector_addr);
+        MetalContext::instance(context_id)
+            .get_cluster()
+            .write_core(device->id(), virtual_core, data, control_vector_addr);
     }
 }
 
 void DeviceProfiler::issueFastDispatchReadFromProfilerBuffer(
     distributed::MeshDevice* mesh_device, IDevice* device, uint8_t active_dram_buffer_index) {
     ZoneScoped;
-    TT_ASSERT(MetalContext::instance().device_manager()->is_dispatch_firmware_active());
+    TT_ASSERT(MetalContext::instance(context_id).device_manager()->is_dispatch_firmware_active());
     const DeviceAddr profiler_addr = getProfilerDramBufferAddress(active_dram_buffer_index);
     uint32_t profile_buffer_idx = 0;
 
@@ -1216,7 +1226,7 @@ void DeviceProfiler::issueSlowDispatchReadFromProfilerBuffer(IDevice* device, ui
     uint32_t profile_buffer_idx = 0;
 
     const int num_dram_channels = device->num_dram_channels();
-    const auto& cluster = MetalContext::instance().get_cluster();
+    const auto& cluster = MetalContext::instance(context_id).get_cluster();
     for (int dram_channel = 0; dram_channel < num_dram_channels; ++dram_channel) {
         cluster.read_dram_vec(
             &(profile_buffer[profile_buffer_idx]), bank_size_bytes, device_id, dram_channel, profiler_addr);
@@ -1229,9 +1239,9 @@ void DeviceProfiler::issueFastDispatchReadFromL1DataBuffer(
     distributed::MeshDevice* mesh_device, const CoreCoord& worker_core, std::vector<uint32_t>& core_l1_data_buffer) {
     ZoneScoped;
 
-    TT_ASSERT(MetalContext::instance().device_manager()->is_dispatch_firmware_active());
+    TT_ASSERT(MetalContext::instance(context_id).device_manager()->is_dispatch_firmware_active());
 
-    const Hal& hal = MetalContext::instance().hal();
+    const Hal& hal = MetalContext::instance(context_id).hal();
     const HalProgrammableCoreType core_type = tt::llrt::get_core_type(device_id, worker_core);
     DeviceAddr profiler_msg_addr = hal.get_dev_addr(core_type, HalL1MemAddrType::PROFILER);
     DeviceAddr buffer_addr =
@@ -1257,17 +1267,19 @@ void DeviceProfiler::issueSlowDispatchReadFromL1DataBuffer(
     IDevice* /*device*/, const CoreCoord& worker_core, std::vector<uint32_t>& core_l1_data_buffer) {
     ZoneScoped;
 
-    const Hal& hal = MetalContext::instance().hal();
+    const Hal& hal = MetalContext::instance(context_id).hal();
     const HalProgrammableCoreType core_type = tt::llrt::get_core_type(device_id, worker_core);
     DeviceAddr profiler_msg_addr = hal.get_dev_addr(core_type, HalL1MemAddrType::PROFILER);
     DeviceAddr buffer_addr =
         profiler_msg_addr + hal.get_dev_msgs_factory(core_type).offset_of<dev_msgs::profiler_msg_t>(
                                 dev_msgs::profiler_msg_t::Field::buffer);
-    core_l1_data_buffer = MetalContext::instance().get_cluster().read_core(
-        device_id,
-        worker_core,
-        buffer_addr,
-        kernel_profiler::PROFILER_L1_BUFFER_SIZE * hal.get_num_risc_processors(core_type));
+    core_l1_data_buffer = MetalContext::instance(context_id)
+                              .get_cluster()
+                              .read_core(
+                                  device_id,
+                                  worker_core,
+                                  buffer_addr,
+                                  kernel_profiler::PROFILER_L1_BUFFER_SIZE * hal.get_num_risc_processors(core_type));
 }
 
 void DeviceProfiler::readL1DataBufferForCore(
@@ -1300,7 +1312,7 @@ void DeviceProfiler::readL1DataBuffers(
 void DeviceProfiler::readControlBufferForCore(
     distributed::MeshDevice* mesh_device, IDevice* device, const CoreCoord& virtual_core, bool force_slow_dispatch) {
     ZoneScoped;
-    const auto& hal = MetalContext::instance().hal();
+    const auto& hal = MetalContext::instance(context_id).hal();
     const HalProgrammableCoreType core_type = tt::llrt::get_core_type(device_id, virtual_core);
     DeviceAddr profiler_msg = hal.get_dev_addr(core_type, HalL1MemAddrType::PROFILER);
     DeviceAddr control_vector_addr =
@@ -1322,8 +1334,11 @@ void DeviceProfiler::readControlBufferForCore(
             TT_FATAL(false, "Fast dispatch read from control buffer requires mesh device support");
         }
     } else {
-        core_control_buffers[virtual_core] = MetalContext::instance().get_cluster().read_core(
-            device_id, virtual_core, control_vector_addr, kernel_profiler::PROFILER_L1_CONTROL_BUFFER_SIZE);
+        core_control_buffers[virtual_core] =
+            MetalContext::instance(context_id)
+                .get_cluster()
+                .read_core(
+                    device_id, virtual_core, control_vector_addr, kernel_profiler::PROFILER_L1_CONTROL_BUFFER_SIZE);
     }
 }
 
@@ -1365,7 +1380,8 @@ void DeviceProfiler::resetControlBuffers(
     }
 
     for (const auto& [virtual_core, control_buffer_reset] : core_control_buffer_resets) {
-        writeToCoreControlBuffer(mesh_device, device, virtual_core, control_buffer_reset, force_slow_dispatch);
+        writeToCoreControlBuffer(
+            mesh_device, device, virtual_core, control_buffer_reset, force_slow_dispatch, context_id);
     }
 
     this->resetActiveDramBufferIndices();
@@ -1417,7 +1433,7 @@ void DeviceProfiler::readRiscProfilerResults(
     const std::vector<uint32_t>& data_buffer =
         (data_source == ProfilerDataBufferSource::DRAM) ? profile_buffer : core_l1_data_buffers.at(worker_core);
 
-    const auto& rtoptions = MetalContext::instance().rtoptions();
+    const auto& rtoptions = MetalContext::instance(context_id).rtoptions();
 
     if (!rtoptions.get_profiler_trace_only()) {
         if ((control_buffer[kernel_profiler::HOST_BUFFER_END_INDEX_BR_ER] == 0) &&
@@ -1429,13 +1445,15 @@ void DeviceProfiler::readRiscProfilerResults(
     const uint32_t profiler_dram_bank_size_per_risc_bytes = get_profiler_dram_bank_size_per_risc_bytes();
     const uint32_t profiler_dram_bank_vector_size_per_risc = profiler_dram_bank_size_per_risc_bytes / sizeof(uint32_t);
 
-    const uint32_t coreFlatID =
-        MetalContext::instance().get_cluster().get_virtual_routing_to_profiler_flat_id(device_id).at(worker_core);
-    const uint32_t startIndex = coreFlatID * MetalContext::instance().hal().get_max_processors_per_core() *
+    const uint32_t coreFlatID = MetalContext::instance(context_id)
+                                    .get_cluster()
+                                    .get_virtual_routing_to_profiler_flat_id(device_id)
+                                    .at(worker_core);
+    const uint32_t startIndex = coreFlatID * MetalContext::instance(context_id).hal().get_max_processors_per_core() *
                                 profiler_dram_bank_vector_size_per_risc;
 
     // translate worker core virtual coord to phys coordinates
-    const metal_SocDescriptor& soc_desc = MetalContext::instance().get_cluster().get_soc_desc(device_id);
+    const metal_SocDescriptor& soc_desc = MetalContext::instance(context_id).get_cluster().get_soc_desc(device_id);
     // disable linting here; slicing is __intended__
     // NOLINTBEGIN
     const CoreCoord phys_coord = soc_desc.translate_coord_to(worker_core, CoordSystem::TRANSLATED, CoordSystem::NOC0);
@@ -1782,9 +1800,10 @@ void DeviceProfiler::readDeviceMarkerData(
 
 #if defined(TRACY_ENABLE)
     if ((timer_id & 0xFFFF) == kernel_profiler::NOC_DEBUGGING_STATIC_ID) {
-        NOCDebugState* noc_debug_state = MetalContext::instance().noc_debug_state().get();
+        NOCDebugState* noc_debug_state = MetalContext::instance(context_id).noc_debug_state().get();
         if (noc_debug_state) {
-            const metal_SocDescriptor& soc_desc = MetalContext::instance().get_cluster().get_soc_desc(device_id);
+            const metal_SocDescriptor& soc_desc =
+                MetalContext::instance(context_id).get_cluster().get_soc_desc(device_id);
             // disable linting here; slicing is __intended__
             // NOLINTBEGIN
             const CoreCoord virtual_core =
@@ -1872,10 +1891,10 @@ void DeviceProfiler::readTsData16BMarkerData(
         return;
     }
 
-    auto& noc_debug_state = MetalContext::instance().noc_debug_state();
+    auto& noc_debug_state = MetalContext::instance(context_id).noc_debug_state();
     if (noc_debug_state) {
         EMD::LocalNocEvent local_noc_event = std::get<EMD::LocalNocEvent>(event_contents);
-        const metal_SocDescriptor& soc_desc = MetalContext::instance().get_cluster().get_soc_desc(device_id);
+        const metal_SocDescriptor& soc_desc = MetalContext::instance(context_id).get_cluster().get_soc_desc(device_id);
         // disable linting here; slicing is __intended__
         // NOLINTBEGIN
         const CoreCoord virtual_core =
@@ -1927,7 +1946,7 @@ void DeviceProfiler::processDeviceMarkerData(std::set<tracy::TTDeviceMarker>& de
         auto next_device_marker_it = std::next(device_marker_it);
 
         if (isMarkerAZoneEndpoint(marker)) {
-            if (MetalContext::instance().rtoptions().get_profiler_trace_only() &&
+            if (MetalContext::instance(context_id).rtoptions().get_profiler_trace_only() &&
                 marker.risc == tracy::RiscType::TENSIX_RISC_AGG) {
                 if (marker_details.marker_name_keyword_flags[static_cast<uint16_t>(
                         tracy::MarkerDetails::MarkerNameKeyword::_FW)]) {
@@ -1958,7 +1977,7 @@ void DeviceProfiler::processDeviceMarkerData(std::set<tracy::TTDeviceMarker>& de
 
                 const auto& start_marker_it = start_marker_stack.top();
 
-                if (!MetalContext::instance().rtoptions().get_profiler_trace_only()) {
+                if (!MetalContext::instance(context_id).rtoptions().get_profiler_trace_only()) {
                     TT_FATAL(
                         start_marker_it->marker_id == marker.marker_id,
                         "Start and end marker IDs do not match.\nStart marker: {}\nEnd marker: {}",
@@ -2094,24 +2113,22 @@ void DeviceProfiler::resetActiveDramBufferIndices() {
 }
 
 DeviceAddr DeviceProfiler::getProfilerDramBufferAddress(uint8_t active_dram_buffer_index) const {
-    const auto base_address = MetalContext::instance().hal().get_dev_addr(HalDramMemAddrType::PROFILER);
+    const auto base_address = MetalContext::instance(context_id).hal().get_dev_addr(HalDramMemAddrType::PROFILER);
     const auto offset = getProfileBufferBankSizeBytes() * active_dram_buffer_index;
     return base_address + offset;
 }
 
 bool DeviceProfiler::isLastFDReadDone() const { return this->is_last_fd_read_done; }
 
-bool DeviceProfiler::profiler_enabled() const { return getDeviceProfilerState(extract_context_id(this->device)); }
-
 DeviceProfiler::DeviceProfiler(const IDevice* device, const bool new_logs [[maybe_unused]]) :
     device_arch(device->arch()),
     device_id(device->id()),
-    device(device),
-    device_core_frequency(MetalContext::instance().get_cluster().get_device_aiclk(this->device_id)),
+    context_id(extract_context_id(device)),
+    device_core_frequency(MetalContext::instance(context_id).get_cluster().get_device_aiclk(this->device_id)),
     max_compute_cores(device->logical_grid_size().x * device->logical_grid_size().y) {
 #if defined(TRACY_ENABLE)
     ZoneScopedC(tracy::Color::Green);
-    if (!profiler_enabled()) {
+    if (!getDeviceProfilerState(context_id)) {
         return;
     }
 
@@ -2126,10 +2143,11 @@ DeviceProfiler::DeviceProfiler(const IDevice* device, const bool new_logs [[mayb
         std::filesystem::remove(device_perf_report_path);
     }
 
-    MetalContext::instance().profiler_state_manager()->device_programs_perf_analyses_map[this->device_id] = {};
+    MetalContext::instance(context_id).profiler_state_manager()->device_programs_perf_analyses_map[this->device_id] =
+        {};
 
     const std::string noc_events_report_path =
-        MetalContext::instance().rtoptions().get_profiler_noc_events_report_path();
+        MetalContext::instance(context_id).rtoptions().get_profiler_noc_events_report_path();
     if (!noc_events_report_path.empty()) {
         this->noc_trace_data_output_dir = std::filesystem::path(noc_events_report_path);
     } else {
@@ -2148,7 +2166,7 @@ void DeviceProfiler::generateAnalysesForDeviceMarkers(
     ZoneScoped;
 
     const std::filesystem::path analysis_configs_path =
-        std::filesystem::path(MetalContext::instance().rtoptions().get_root_dir()) /
+        std::filesystem::path(MetalContext::instance(context_id).rtoptions().get_root_dir()) /
         "tt_metal/tools/profiler/cpp_device_analyses.json";
     const std::vector<AnalysisConfig> analysis_configs = loadAnalysisConfigsFromJSON(analysis_configs_path);
 
@@ -2156,7 +2174,9 @@ void DeviceProfiler::generateAnalysesForDeviceMarkers(
         generatePerfResultsForPrograms(analysis_configs, device_markers, *this->thread_pool);
 
     std::vector<std::set<experimental::ProgramAnalysisData>>& device_programs_perf_analyses =
-        MetalContext::instance().profiler_state_manager()->device_programs_perf_analyses_map.at(this->device_id);
+        MetalContext::instance(context_id)
+            .profiler_state_manager()
+            ->device_programs_perf_analyses_map.at(this->device_id);
     device_programs_perf_analyses.push_back(translateProgramsPerfResults(programs_perf_results));
 
     writeProgramsPerfResultsToCSV(
@@ -2167,11 +2187,10 @@ void DeviceProfiler::generateAnalysesForDeviceMarkers(
 void DeviceProfiler::dumpDeviceResults(bool is_mid_run_dump) {
 #if defined(TRACY_ENABLE)
     ZoneScoped;
-    if (!profiler_enabled()) {
+    if (!getDeviceProfilerState(context_id)) {
         return;
     }
 
-    auto context_id = extract_context_id(this->device);
     if (!this->thread_pool) {
         this->thread_pool = create_device_bound_thread_pool(
             context_id,
@@ -2202,7 +2221,7 @@ void DeviceProfiler::dumpDeviceResults(bool is_mid_run_dump) {
     std::vector<std::reference_wrapper<const tracy::TTDeviceMarker>> device_markers_vec =
         getSortedDeviceMarkersVector(this->device_markers_per_core_risc_map, *this->thread_pool);
 
-    if (MetalContext::instance().rtoptions().get_profiler_cpp_post_process()) {
+    if (MetalContext::instance(context_id).rtoptions().get_profiler_cpp_post_process()) {
         this->generateAnalysesForDeviceMarkers(device_markers_vec);
     }
 
@@ -2218,7 +2237,7 @@ void DeviceProfiler::dumpDeviceResults(bool is_mid_run_dump) {
 
 void DeviceProfiler::freshDeviceLog() {
 #if defined(TRACY_ENABLE)
-    if (!profiler_enabled()) {
+    if (!getDeviceProfilerState(context_id)) {
         return;
     }
     std::filesystem::path log_path = device_logs_output_dir / DEVICE_SIDE_LOG;
@@ -2231,7 +2250,7 @@ void DeviceProfiler::freshDeviceLog() {
 
 void DeviceProfiler::setOutputDir(const std::string& new_output_dir) {
 #if defined(TRACY_ENABLE)
-    if (!profiler_enabled()) {
+    if (!getDeviceProfilerState(context_id)) {
         return;
     }
     std::filesystem::create_directories(new_output_dir);
@@ -2248,7 +2267,7 @@ void DeviceProfiler::readResults(
     const std::optional<ProfilerOptionalMetadata>& /*metadata*/) {
 #if defined(TRACY_ENABLE)
     ZoneScoped;
-    if (!profiler_enabled()) {
+    if (!getDeviceProfilerState(context_id)) {
         return;
     }
 
@@ -2258,9 +2277,9 @@ void DeviceProfiler::readResults(
 
     hash_to_zone_src_locations = generateZoneSourceLocationsHashes();
 
-    TT_ASSERT(doAllDispatchCoresComeAfterNonDispatchCores(device, virtual_cores));
+    TT_ASSERT(doAllDispatchCoresComeAfterNonDispatchCores(device, virtual_cores, context_id));
 
-    bool force_slow_dispatch = MetalContext::instance().rtoptions().get_experimental_noc_debug_dump_enabled();
+    bool force_slow_dispatch = MetalContext::instance(context_id).rtoptions().get_experimental_noc_debug_dump_enabled();
 
     constexpr uint8_t default_dram_buffer_index = 0;
 
@@ -2298,7 +2317,7 @@ void DeviceProfiler::processResults(
     const std::optional<std::map<CoreCoord, std::set<tracy::RiscType>>>& riscs_to_include) {
 #if defined(TRACY_ENABLE)
     ZoneScoped;
-    if (!profiler_enabled()) {
+    if (!getDeviceProfilerState(context_id)) {
         return;
     }
 
@@ -2348,18 +2367,19 @@ bool isSyncInfoNewer(const SyncInfo& old_info, const SyncInfo& new_info) {
 void DeviceProfiler::writeDeviceResultsToFiles() const {
 #if defined(TRACY_ENABLE)
     ZoneScoped;
-    if (!profiler_enabled() || MetalContext::instance().rtoptions().get_profiler_disable_dump_to_files() ||
-        MetalContext::instance().rtoptions().get_experimental_noc_debug_dump_enabled()) {
+    if (!getDeviceProfilerState(context_id) ||
+        MetalContext::instance(context_id).rtoptions().get_profiler_disable_dump_to_files() ||
+        MetalContext::instance(context_id).rtoptions().get_experimental_noc_debug_dump_enabled()) {
         return;
     }
 
-    std::scoped_lock lock(MetalContext::instance().profiler_state_manager()->log_file_write_mutex);
+    std::scoped_lock lock(MetalContext::instance(context_id).profiler_state_manager()->log_file_write_mutex);
 
     const std::filesystem::path log_path = device_logs_output_dir / DEVICE_SIDE_LOG;
     dumpDeviceResultsToCSV(
         device_markers_per_core_risc_map, device_arch, device_core_frequency, max_compute_cores, log_path);
 
-    if (MetalContext::instance().rtoptions().get_profiler_noc_events_enabled()) {
+    if (MetalContext::instance(context_id).rtoptions().get_profiler_noc_events_enabled()) {
         log_warning(
             tt::LogAlways, "Profiler NoC events are enabled; this can add 1-15% cycle overhead to typical operations!");
         FabricRoutingLookup routing_lookup;
@@ -2378,7 +2398,8 @@ void DeviceProfiler::pushTracyDeviceResults(
     std::vector<std::reference_wrapper<const tracy::TTDeviceMarker>>& device_markers_vec) {
 #if defined(TRACY_ENABLE)
     ZoneScoped;
-    if (!profiler_enabled() || MetalContext::instance().rtoptions().get_profiler_disable_push_to_tracy()) {
+    if (!getDeviceProfilerState(context_id) ||
+        MetalContext::instance(context_id).rtoptions().get_profiler_disable_push_to_tracy()) {
         return;
     }
 
@@ -2435,7 +2456,7 @@ void DeviceProfiler::setSyncInfo(const SyncInfo& sync_info) { device_sync_info =
 
 void DeviceProfiler::initializeMissingTracyContexts(bool blocking) {
 #if defined(TRACY_ENABLE)
-    if (!profiler_enabled()) {
+    if (!getDeviceProfilerState(context_id)) {
         return;
     }
     TT_ASSERT(this->thread_pool != nullptr);
@@ -2456,7 +2477,7 @@ void DeviceProfiler::initializeMissingTracyContexts(bool blocking) {
 void DeviceProfiler::updateTracyContexts(
     const std::vector<std::reference_wrapper<const tracy::TTDeviceMarker>>& device_markers_vec) {
 #if defined(TRACY_ENABLE)
-    if (!profiler_enabled()) {
+    if (!getDeviceProfilerState(context_id)) {
         return;
     }
     std::unordered_set<std::pair<ChipId, CoreCoord>, pair_hash<ChipId, CoreCoord>> device_cores_to_update;
@@ -2486,7 +2507,7 @@ void DeviceProfiler::updateTracyContexts(
 
 void DeviceProfiler::updateTracyContext(const std::pair<ChipId, CoreCoord>& device_core) {
 #if defined(TRACY_ENABLE)
-    if (!profiler_enabled()) {
+    if (!getDeviceProfilerState(context_id)) {
         return;
     }
     const ChipId device_id = device_core.first;
@@ -2557,7 +2578,7 @@ void DeviceProfiler::updateTracyContext(const std::pair<ChipId, CoreCoord>& devi
 
 void DeviceProfiler::destroyTracyContexts() {
 #if defined(TRACY_ENABLE)
-    if (!profiler_enabled()) {
+    if (!getDeviceProfilerState(context_id)) {
         return;
     }
     TT_ASSERT(this->thread_pool != nullptr);
@@ -2575,7 +2596,7 @@ void DeviceProfiler::pollDebugDumpResults(
     IDevice* device, const std::vector<CoreCoord>& virtual_cores, bool is_final_poll) {
 #if defined(TRACY_ENABLE)
     ZoneScoped;
-    if (!profiler_enabled()) {
+    if (!getDeviceProfilerState(context_id)) {
         return;
     }
 
@@ -2601,7 +2622,7 @@ void DeviceProfiler::pollDebugDumpResults(
     {
         ZoneScopedN("pollDebugDumpResults-FindStalledCores");
         for (const auto& virtual_core : virtual_cores) {
-            const auto& cluster = MetalContext::instance().get_cluster();
+            const auto& cluster = MetalContext::instance(context_id).get_cluster();
             bool is_eth = cluster.is_ethernet_core(virtual_core, device->id());
             const std::vector<uint32_t>& control_buffer = core_control_buffers.at(virtual_core);
             auto& active_risc_map = this->active_dram_buffer_per_core_risc_map[virtual_core];
@@ -2638,7 +2659,7 @@ void DeviceProfiler::pollDebugDumpResults(
                     // Note: Do not use the writeToCoreControlBuffer function as it will overwrite the entire control
                     // buffer. We only want to update the fields for the stalled riscs.
                     const auto dram_profiler_address_offset = control_buffer_dram_addr_index;
-                    const DeviceAddr addr = getControlVectorAddress(device, virtual_core) +
+                    const DeviceAddr addr = getControlVectorAddress(device, virtual_core, context_id) +
                                             (dram_profiler_address_offset * sizeof(uint32_t));
                     // Need to use write_reg to guarantee a single write to the control buffer
                     // Host index will be updated by the risc once it receives the new dram address
@@ -2724,7 +2745,7 @@ void DeviceProfiler::pollDebugDumpResults(
         std::map<CoreCoord, std::set<tracy::RiscType>> riscs_with_l1_data;
 
         for (const auto& virtual_core : virtual_cores) {
-            bool is_eth = MetalContext::instance().get_cluster().is_ethernet_core(virtual_core, device->id());
+            bool is_eth = MetalContext::instance(context_id).get_cluster().is_ethernet_core(virtual_core, device->id());
             bool core_has_l1_data = false;
 
             for (tracy::RiscType risc_type : enchantum::values_generator<tracy::RiscType>) {

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -1150,10 +1150,8 @@ bool isGalaxyMMIODevice(distributed::MeshDevice* mesh_device, IDevice* device) {
            device->is_mmio_capable();
 }
 
-bool useFastDispatch(distributed::MeshDevice* mesh_device, IDevice* device) {
-    return MetalContext::instance(extract_context_id(mesh_device, device))
-               .device_manager()
-               ->is_dispatch_firmware_active() &&
+bool useFastDispatch(distributed::MeshDevice* mesh_device, IDevice* device, ContextId context_id) {
+    return MetalContext::instance(context_id).device_manager()->is_dispatch_firmware_active() &&
            !isGalaxyMMIODevice(mesh_device, device);
 }
 
@@ -1173,7 +1171,7 @@ void writeToCoreControlBuffer(
     DeviceAddr control_vector_addr =
         profiler_msg_addr + hal.get_dev_msgs_factory(core_type).offset_of<dev_msgs::profiler_msg_t>(
                                 dev_msgs::profiler_msg_t::Field::control_vector);
-    if (useFastDispatch(mesh_device, device) && !force_slow_dispatch) {
+    if (useFastDispatch(mesh_device, device, context_id) && !force_slow_dispatch) {
         if (mesh_device) {
             distributed::FDMeshCommandQueue& mesh_cq =
                 dynamic_cast<distributed::FDMeshCommandQueue&>(mesh_device->mesh_command_queue());
@@ -1289,7 +1287,7 @@ void DeviceProfiler::readL1DataBufferForCore(
     std::vector<uint32_t>& core_l1_data_buffer,
     bool force_slow_dispatch) {
     ZoneScoped;
-    if (useFastDispatch(mesh_device, device) && !force_slow_dispatch) {
+    if (useFastDispatch(mesh_device, device, context_id) && !force_slow_dispatch) {
         issueFastDispatchReadFromL1DataBuffer(mesh_device, virtual_core, core_l1_data_buffer);
     } else {
         issueSlowDispatchReadFromL1DataBuffer(device, virtual_core, core_l1_data_buffer);
@@ -1318,7 +1316,7 @@ void DeviceProfiler::readControlBufferForCore(
     DeviceAddr control_vector_addr =
         profiler_msg + hal.get_dev_msgs_factory(core_type).offset_of<dev_msgs::profiler_msg_t>(
                            dev_msgs::profiler_msg_t::Field::control_vector);
-    if (useFastDispatch(mesh_device, device) && !force_slow_dispatch) {
+    if (useFastDispatch(mesh_device, device, context_id) && !force_slow_dispatch) {
         if (mesh_device) {
             distributed::FDMeshCommandQueue& mesh_cq =
                 dynamic_cast<distributed::FDMeshCommandQueue&>(mesh_device->mesh_command_queue());
@@ -1390,7 +1388,7 @@ void DeviceProfiler::resetControlBuffers(
 void DeviceProfiler::readProfilerBuffer(
     distributed::MeshDevice* mesh_device, IDevice* device, uint8_t active_dram_buffer_index, bool force_slow_dispatch) {
     ZoneScoped;
-    if (useFastDispatch(mesh_device, device) && !force_slow_dispatch) {
+    if (useFastDispatch(mesh_device, device, context_id) && !force_slow_dispatch) {
         issueFastDispatchReadFromProfilerBuffer(mesh_device, device, active_dram_buffer_index);
     } else {
         issueSlowDispatchReadFromProfilerBuffer(device, active_dram_buffer_index);

--- a/tt_metal/impl/profiler/profiler.hpp
+++ b/tt_metal/impl/profiler/profiler.hpp
@@ -71,6 +71,9 @@ private:
     // Device ID
     ChipId device_id{};
 
+    // Device
+    const IDevice* device;
+
     // Device frequency
     int device_core_frequency{};
 
@@ -252,6 +255,9 @@ private:
 
     // Get the trace id and trace id count
     std::pair<uint64_t, uint64_t> getTraceIdAndCount(uint32_t run_host_id, uint32_t device_trace_counter) const;
+
+    // Check the device context to seeif the profiler is enabled for this device
+    bool profiler_enabled() const;
 
 public:
     DeviceProfiler(const IDevice* device, bool new_logs);

--- a/tt_metal/impl/profiler/profiler.hpp
+++ b/tt_metal/impl/profiler/profiler.hpp
@@ -18,6 +18,7 @@
 
 #include "buffer.hpp"
 #include "common/TracyTTDeviceData.hpp"
+#include "context/context_types.hpp"
 #include "core_coord.hpp"
 #include "mesh_device.hpp"
 #include "profiler_optional_metadata.hpp"
@@ -71,8 +72,8 @@ private:
     // Device ID
     ChipId device_id{};
 
-    // Device
-    const IDevice* device;
+    // ContextID extracted from the device
+    ContextId context_id;
 
     // Device frequency
     int device_core_frequency{};
@@ -256,9 +257,6 @@ private:
     // Get the trace id and trace id count
     std::pair<uint64_t, uint64_t> getTraceIdAndCount(uint32_t run_host_id, uint32_t device_trace_counter) const;
 
-    // Check the device context to seeif the profiler is enabled for this device
-    bool profiler_enabled() const;
-
 public:
     DeviceProfiler(const IDevice* device, bool new_logs);
 
@@ -361,13 +359,14 @@ public:
     void pollDebugDumpResults(IDevice* device, const std::vector<CoreCoord>& virtual_cores, bool is_final_poll);
 };
 
-bool useFastDispatch(distributed::MeshDevice* mesh_device, IDevice* device);
+bool useFastDispatch(distributed::MeshDevice* mesh_device, IDevice* device, ContextId context_id);
 
 void writeToCoreControlBuffer(
     distributed::MeshDevice* mesh_device,
     IDevice* device,
     const CoreCoord& virtual_core,
     const std::vector<uint32_t>& data,
-    bool force_slow_dispatch);
+    bool force_slow_dispatch,
+    ContextId context_id);
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/profiler/profiler_analysis.cpp
+++ b/tt_metal/impl/profiler/profiler_analysis.cpp
@@ -14,6 +14,7 @@
 #include <tt-metalium/experimental/profiler.hpp>
 #include <fstream>
 
+#include "context/metal_env_accessor.hpp"
 #include "core_coord.hpp"
 #include "impl/context/metal_context.hpp"
 #include "profiler_analysis.hpp"
@@ -289,6 +290,9 @@ getMetaDataForPrograms(const std::vector<std::reference_wrapper<const tracy::TTD
     std::map<experimental::ProgramExecutionUID, ProgramsPerfResults::SingleProgramPerfResults::ProgramMetaData>
         program_execution_uid_to_meta_data;
 
+    // Use the default MetalEnv
+    MetalEnv& env = MetalContext::instance().get_env();
+
     std::unordered_map<experimental::ProgramExecutionUID, std::unordered_set<CoreCoord>>
         fw_cores_per_program_execution_uid;
     for (const auto& marker_ref : markers) {
@@ -304,8 +308,8 @@ getMetaDataForPrograms(const std::vector<std::reference_wrapper<const tracy::TTD
                 tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().get_num_hw_cqs();
             const DispatchCoreConfig& dispatch_core_config =
                 tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
-            const CoreCoord compute_grid_size =
-                tt::get_compute_grid_size(marker.chip_id, num_hw_cqs, dispatch_core_config);
+            const CoreCoord compute_grid_size = tt::get_compute_grid_size(
+                MetalEnvAccessor(env).impl(), marker.chip_id, num_hw_cqs, dispatch_core_config);
             const uint32_t num_available_worker_cores = compute_grid_size.x * compute_grid_size.y;
 
             program_execution_uid_to_meta_data[program_execution_uid] = {

--- a/tt_metal/impl/profiler/profiler_state.hpp
+++ b/tt_metal/impl/profiler/profiler_state.hpp
@@ -4,12 +4,14 @@
 
 #pragma once
 
+#include "impl/context/context_types.hpp"
+
 namespace tt::tt_metal {
 
 // Get global device profiling state based on build flag and environment variables
-bool getDeviceProfilerState();
+bool getDeviceProfilerState(ContextId context_id = DEFAULT_CONTEXT_ID);
 
 // Get if the device debug dump is enabled
-bool getDeviceDebugDumpEnabled();
+bool getDeviceDebugDumpEnabled(ContextId context_id = DEFAULT_CONTEXT_ID);
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -3,8 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 #include <core_descriptor.hpp>
 #include <device.hpp>
-#include "context/context_types.hpp"
-#include "context/metal_env_accessor.hpp"
 #include "distributed/mesh_device_impl.hpp"
 #include "impl/dispatch/dispatch_core_common.hpp"
 #include <host_api.hpp>
@@ -39,7 +37,9 @@
 #include "core_coord.hpp"
 #include "hal_types.hpp"
 #include "hostdevcommon/profiler_common.h"
+#include "context/context_types.hpp"
 #include "context/metal_context.hpp"
+#include "context/metal_env_accessor.hpp"
 #include "kernel_types.hpp"
 #include "llrt.hpp"
 #include "llrt/hal.hpp"
@@ -101,7 +101,7 @@ void setControlBuffer(
 
 void syncDeviceHost(distributed::MeshDevice* mesh_device, IDevice* device, CoreCoord logical_core, bool doHeader) {
     ZoneScopedC(tracy::Color::Tomato3);
-    ContextId context_id = extract_context_id(mesh_device, nullptr);
+    ContextId context_id = extract_context_id(mesh_device, device);
     if (!MetalContext::instance(context_id).rtoptions().get_profiler_sync_enabled()) {
         return;
     }
@@ -682,6 +682,7 @@ void ProfilerSync(ProfilerSyncState state) {
             } catch (const std::exception&) {
                 log_info(
                     tt::LogMetal, "Device {} is not managed by MeshDevice. Skipping host-device sync.", root_device_id);
+                continue;
             }
             syncDeviceHost(mesh_device, root_device, ProfilerStateManager::SYNC_CORE, true);
             if (num_devices > 1) {
@@ -699,6 +700,7 @@ void ProfilerSync(ProfilerSyncState state) {
             } catch (const std::exception&) {
                 log_info(
                     tt::LogMetal, "Device {} is not managed by MeshDevice. Skipping host-device sync.", root_device_id);
+                continue;
             }
             syncDeviceHost(mesh_device, root_device, ProfilerStateManager::SYNC_CORE, false);
             if (num_devices > 1) {

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -94,7 +94,7 @@ void setControlBuffer(
 
         control_buffer[kernel_profiler::FLAT_ID] = core.second;
 
-        writeToCoreControlBuffer(mesh_device, device, curr_core, control_buffer, force_slow_dispatch);
+        writeToCoreControlBuffer(mesh_device, device, curr_core, control_buffer, force_slow_dispatch, context_id);
     }
 #endif
 }
@@ -1028,20 +1028,21 @@ void ReadDeviceProfilerResults(
 #if defined(TRACY_ENABLE)
     ZoneScoped;
 
-    if (!getDeviceProfilerState(extract_context_id(device))) {
+    ContextId context_id = extract_context_id(device);
+    if (!getDeviceProfilerState(context_id)) {
         return;
     }
 
     // Manual reading of device profiler results is not supported when there is already another thread reading the
     // results
-    if (getDeviceDebugDumpEnabled(extract_context_id(device))) {
+    if (getDeviceDebugDumpEnabled(context_id)) {
         return;
     }
 
     TT_ASSERT(device->is_initialized());
 
     const std::unique_ptr<ProfilerStateManager>& profiler_state_manager =
-        MetalContext::instance(extract_context_id(device)).profiler_state_manager();
+        MetalContext::instance(context_id).profiler_state_manager();
     auto profiler_it = profiler_state_manager->device_profiler_map.find(device->id());
     TT_ASSERT(profiler_it != profiler_state_manager->device_profiler_map.end());
     DeviceProfiler& profiler = profiler_it->second;
@@ -1052,7 +1053,7 @@ void ReadDeviceProfilerResults(
     } catch (const std::exception&) {
         log_info(tt::LogMetal, "Device {} is not managed by MeshDevice", device->id());
     }
-    if (useFastDispatch(mesh_device, device)) {
+    if (useFastDispatch(mesh_device, device, context_id)) {
         if (profiler.isLastFDReadDone() && state == ProfilerReadState::LAST_FD_READ) {
             ZoneScopedN("Skipping! Last FD dispatch is done");
             return;
@@ -1139,7 +1140,7 @@ void ReadMeshDeviceProfilerResults(
     const std::unique_ptr<ProfilerStateManager>& profiler_state_manager =
         MetalContext::instance(context_id).profiler_state_manager();
 
-    if (useFastDispatch(&mesh_device, &mesh_device)) {
+    if (useFastDispatch(&mesh_device, &mesh_device, context_id)) {
         for (IDevice* device : mesh_device.get_devices()) {
             auto profiler_it = profiler_state_manager->device_profiler_map.find(device->id());
             TT_ASSERT(profiler_it != profiler_state_manager->device_profiler_map.end());
@@ -1166,7 +1167,7 @@ void ReadMeshDeviceProfilerResults(
         if (auto& profiler_state_manager = MetalContext::instance(context_id).profiler_state_manager()) {
             profiler_state_manager->signal_debug_dump_read();
         }
-        if (auto& noc_debug_state = MetalContext::instance().noc_debug_state()) {
+        if (auto& noc_debug_state = MetalContext::instance(context_id).noc_debug_state()) {
             noc_debug_state->process_accumulated_events_all_chips();
             noc_debug_state->finish_cores();
             // Only print when called by the user (state == normal) to avoid duplicate printing
@@ -1273,7 +1274,7 @@ std::map<ChipId, std::set<ProgramAnalysisData>> GetLatestProgramsPerfData() {
 #if defined(TRACY_ENABLE)
     ZoneScoped;
 
-    if (!getDeviceProfilerState(DEFAULT_CONTEXT_ID) || !detail::getProgramsPerfDataMidRun()) {
+    if (!getDeviceProfilerState() || !detail::getProgramsPerfDataMidRun()) {
         return {};
     }
 

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 #include <core_descriptor.hpp>
 #include <device.hpp>
+#include "context/context_types.hpp"
+#include "context/metal_env_accessor.hpp"
+#include "distributed/mesh_device_impl.hpp"
 #include "impl/dispatch/dispatch_core_common.hpp"
 #include <host_api.hpp>
 #include <profiler.hpp>
@@ -70,21 +73,35 @@ namespace tt::tt_metal {
 
 namespace detail {
 
+ContextId getContextIdSafe(distributed::MeshDevice* mesh_device, IDevice* device) {
+    ContextId context_id = DEFAULT_CONTEXT_ID;
+    if (mesh_device != nullptr) {
+        context_id = extract_context_id(mesh_device);
+    } else if (device != nullptr) {
+        context_id = extract_context_id(device);
+    } else {
+        TT_FATAL(false, "Both MeshDevice and Device are nullptr");
+    }
+    return context_id;
+}
+
 void setControlBuffer(
     distributed::MeshDevice* mesh_device,
     IDevice* device,
     std::vector<uint32_t>& control_buffer,
     bool force_slow_dispatch = false) {
 #if defined(TRACY_ENABLE)
-    if (!getDeviceProfilerState()) {
+    ContextId context_id = getContextIdSafe(mesh_device, device);
+    if (!getDeviceProfilerState(context_id)) {
         return;
     }
 
     const ChipId device_id = device->id();
-    const metal_SocDescriptor& soc_d = MetalContext::instance().get_cluster().get_soc_desc(device_id);
+    const metal_SocDescriptor& soc_d = MetalContext::instance(context_id).get_cluster().get_soc_desc(device_id);
 
     control_buffer[kernel_profiler::CORE_COUNT_PER_DRAM] = soc_d.profiler_ceiled_core_count_perf_dram_bank;
-    for (auto core : MetalContext::instance().get_cluster().get_virtual_routing_to_profiler_flat_id(device_id)) {
+    for (auto core :
+         MetalContext::instance(context_id).get_cluster().get_virtual_routing_to_profiler_flat_id(device_id)) {
         const CoreCoord curr_core = core.first;
 
         control_buffer[kernel_profiler::FLAT_ID] = core.second;
@@ -96,17 +113,18 @@ void setControlBuffer(
 
 void syncDeviceHost(distributed::MeshDevice* mesh_device, IDevice* device, CoreCoord logical_core, bool doHeader) {
     ZoneScopedC(tracy::Color::Tomato3);
-    if (!MetalContext::instance().rtoptions().get_profiler_sync_enabled()) {
+    ContextId context_id = getContextIdSafe(mesh_device, nullptr);
+    if (!MetalContext::instance(context_id).rtoptions().get_profiler_sync_enabled()) {
         return;
     }
     auto device_id = device->id();
     auto core = device->worker_core_from_logical_core(logical_core);
 
-    const metal_SocDescriptor& soc_desc = MetalContext::instance().get_cluster().get_soc_desc(device_id);
+    const metal_SocDescriptor& soc_desc = MetalContext::instance(context_id).get_cluster().get_soc_desc(device_id);
     auto phys_core = soc_desc.translate_coord_to(core, CoordSystem::TRANSLATED, CoordSystem::NOC0);
 
     const std::unique_ptr<ProfilerStateManager>& profiler_state_manager =
-        MetalContext::instance().profiler_state_manager();
+        MetalContext::instance(context_id).profiler_state_manager();
 
     profiler_state_manager->device_host_time_pair.emplace(device_id, (std::vector<std::pair<uint64_t, uint64_t>>){});
     profiler_state_manager->smallest_host_time.emplace(device_id, 0);
@@ -144,7 +162,7 @@ void syncDeviceHost(distributed::MeshDevice* mesh_device, IDevice* device, CoreC
     const int64_t hostStartTime = TracyGetCpuTime();
     std::vector<int64_t> writeTimes(sampleCount);
 
-    const auto& hal = MetalContext::instance().hal();
+    const auto& hal = MetalContext::instance(context_id).hal();
     HalProgrammableCoreType core_type = device->get_programmable_core_type(core);
     auto dev_msgs_factory = hal.get_dev_msgs_factory(core_type);
     DeviceAddr profiler_msg_addr = hal.get_dev_addr(core_type, HalL1MemAddrType::PROFILER);
@@ -594,7 +612,7 @@ void ProfilerSync(ProfilerSyncState state) {
     if (!MetalContext::instance().rtoptions().get_profiler_sync_enabled()) {
         return;
     }
-    if (!getDeviceProfilerState()) {
+    if (!getDeviceProfilerState(DEFAULT_CONTEXT_ID)) {
         return;
     }
 
@@ -603,7 +621,7 @@ void ProfilerSync(ProfilerSyncState state) {
         "Profiler sync is not supported with fast dispatch enabled!");
 
     const std::unique_ptr<ProfilerStateManager>& profiler_state_manager =
-        MetalContext::instance().profiler_state_manager();
+        MetalContext::instance(DEFAULT_CONTEXT_ID).profiler_state_manager();
     // Create a mapping of all connected devices to determine how to sync
     static std::unordered_map<ChipId, int> num_connected_devices;
     if (state == ProfilerSyncState::INIT) {
@@ -713,7 +731,7 @@ void ClearProfilerControlBuffer(IDevice* device) {
 void InitDeviceProfiler(IDevice* device) {
 #if defined(TRACY_ENABLE)
     ZoneScoped;
-    if (!getDeviceProfilerState()) {
+    if (!getDeviceProfilerState(extract_context_id(device))) {
         return;
     }
 
@@ -776,7 +794,11 @@ bool areAllCoresDispatchCores(IDevice* device, const std::vector<CoreCoord>& vir
     const uint8_t device_num_hw_cqs = device->num_hw_cqs();
     const auto& dispatch_core_config = get_dispatch_core_config();
     std::vector<CoreCoord> dispatch_cores;
-    for (const CoreCoord& core : tt::get_logical_dispatch_cores(device_id, device_num_hw_cqs, dispatch_core_config)) {
+    for (const CoreCoord& core : tt::get_logical_dispatch_cores(
+             MetalEnvAccessor(tt::tt_metal::MetalContext::instance(extract_context_id(device)).get_env()).impl(),
+             device_id,
+             device_num_hw_cqs,
+             dispatch_core_config)) {
         const CoreCoord virtual_dispatch_core =
             device->virtual_core_from_logical_core(core, get_core_type_from_config(dispatch_core_config));
         dispatch_cores.push_back(virtual_dispatch_core);
@@ -809,12 +831,17 @@ static void ReadDeviceProfilerResultsImpl(
     ProfilerReadState state,
     const std::optional<ProfilerOptionalMetadata>& metadata) {
     ZoneScoped;
-    if (!getDeviceProfilerState()) {
+    ContextId context_id = getContextIdSafe(mesh_device, device);
+    if (!getDeviceProfilerState(context_id)) {
+        return;
+    }
+
+    if (device != nullptr && !getDeviceProfilerState(extract_context_id(device))) {
         return;
     }
 
     const std::unique_ptr<ProfilerStateManager>& profiler_state_manager =
-        MetalContext::instance().profiler_state_manager();
+        MetalContext::instance(context_id).profiler_state_manager();
     auto profiler_it = profiler_state_manager->device_profiler_map.find(device->id());
     TT_ASSERT(profiler_it != profiler_state_manager->device_profiler_map.end());
     DeviceProfiler& profiler = profiler_it->second;
@@ -876,7 +903,7 @@ void ReadDeviceProfilerResults(
     ProfilerReadState state,
     const std::optional<ProfilerOptionalMetadata>& metadata) {
 #if defined(TRACY_ENABLE)
-    if (getDeviceDebugDumpEnabled()) {
+    if (getDeviceDebugDumpEnabled(extract_context_id(mesh_device))) {
         return;
     }
 
@@ -894,12 +921,12 @@ void ReadDeviceProfilerResultsInternal(
     // Note: This function bypasses the getDeviceDebugDumpEnabled() check
     // It is intended only for use by ProfilerStateManager during cleanup
 #if defined(TRACY_ENABLE)
-    if (!getDeviceProfilerState()) {
+    if (!getDeviceProfilerState(extract_context_id(mesh_device))) {
         return;
     }
 
     const std::unique_ptr<ProfilerStateManager>& profiler_state_manager =
-        MetalContext::instance().profiler_state_manager();
+        MetalContext::instance(extract_context_id(mesh_device)).profiler_state_manager();
     auto profiler_it = profiler_state_manager->device_profiler_map.find(device->id());
     TT_ASSERT(profiler_it != profiler_state_manager->device_profiler_map.end());
     DeviceProfiler& profiler = profiler_it->second;
@@ -947,7 +974,7 @@ void ProcessDeviceProfilerResults(
 #if defined(TRACY_ENABLE)
     ZoneScoped;
 
-    if (!getDeviceProfilerState()) {
+    if (!getDeviceProfilerState(extract_context_id(device))) {
         return;
     }
 
@@ -981,9 +1008,11 @@ std::vector<CoreCoord> getVirtualCoresForProfiling(const IDevice* device, const 
     const uint8_t device_num_hw_cqs = device->num_hw_cqs();
     const auto& dispatch_core_config = get_dispatch_core_config();
 
+    auto& env = MetalEnvAccessor(tt::tt_metal::MetalContext::instance(extract_context_id(device)).get_env()).impl();
+
     if (!onlyProfileDispatchCores(state)) {
         for (const CoreCoord& core :
-             tt::get_logical_compute_cores(device_id, device_num_hw_cqs, dispatch_core_config)) {
+             tt::get_logical_compute_cores(env, device_id, device_num_hw_cqs, dispatch_core_config)) {
             const CoreCoord curr_core = device->worker_core_from_logical_core(core);
             virtual_cores.push_back(curr_core);
         }
@@ -993,9 +1022,9 @@ std::vector<CoreCoord> getVirtualCoresForProfiling(const IDevice* device, const 
         }
     }
 
-    if (MetalContext::instance().rtoptions().get_profiler_do_dispatch_cores()) {
+    if (env.get_rtoptions().get_profiler_do_dispatch_cores()) {
         for (const CoreCoord& core :
-             tt::get_logical_dispatch_cores(device_id, device_num_hw_cqs, dispatch_core_config)) {
+             tt::get_logical_dispatch_cores(env, device_id, device_num_hw_cqs, dispatch_core_config)) {
             const CoreCoord curr_core =
                 device->virtual_core_from_logical_core(core, get_core_type_from_config(dispatch_core_config));
             virtual_cores.push_back(curr_core);
@@ -1010,20 +1039,20 @@ void ReadDeviceProfilerResults(
 #if defined(TRACY_ENABLE)
     ZoneScoped;
 
-    if (!getDeviceProfilerState()) {
+    if (!getDeviceProfilerState(extract_context_id(device))) {
         return;
     }
 
     // Manual reading of device profiler results is not supported when there is already another thread reading the
     // results
-    if (getDeviceDebugDumpEnabled()) {
+    if (getDeviceDebugDumpEnabled(extract_context_id(device))) {
         return;
     }
 
     TT_ASSERT(device->is_initialized());
 
     const std::unique_ptr<ProfilerStateManager>& profiler_state_manager =
-        MetalContext::instance().profiler_state_manager();
+        MetalContext::instance(extract_context_id(device)).profiler_state_manager();
     auto profiler_it = profiler_state_manager->device_profiler_map.find(device->id());
     TT_ASSERT(profiler_it != profiler_state_manager->device_profiler_map.end());
     DeviceProfiler& profiler = profiler_it->second;
@@ -1052,7 +1081,7 @@ void ReadDeviceProfilerResults(
 
 void SetDeviceProfilerDir(const std::string& output_dir) {
 #if defined(TRACY_ENABLE)
-    if (!getDeviceProfilerState()) {
+    if (!getDeviceProfilerState(DEFAULT_CONTEXT_ID)) {
         return;
     }
 
@@ -1068,7 +1097,7 @@ void SetDeviceProfilerDir(const std::string& output_dir) {
 
 void FreshProfilerDeviceLog() {
 #if defined(TRACY_ENABLE)
-    if (!getDeviceProfilerState()) {
+    if (!getDeviceProfilerState(DEFAULT_CONTEXT_ID)) {
         return;
     }
 
@@ -1111,15 +1140,15 @@ void ReadMeshDeviceProfilerResults(
     const std::optional<ProfilerOptionalMetadata>& metadata) {
 #if defined(TRACY_ENABLE)
     ZoneScoped;
-
-    if (!getDeviceProfilerState()) {
+    ContextId context_id = extract_context_id(&mesh_device);
+    if (!getDeviceProfilerState(context_id)) {
         return;
     }
 
     TT_ASSERT(mesh_device.is_initialized());
 
     const std::unique_ptr<ProfilerStateManager>& profiler_state_manager =
-        MetalContext::instance().profiler_state_manager();
+        MetalContext::instance(context_id).profiler_state_manager();
 
     if (useFastDispatch(&mesh_device, &mesh_device)) {
         for (IDevice* device : mesh_device.get_devices()) {
@@ -1144,8 +1173,8 @@ void ReadMeshDeviceProfilerResults(
     // At this point the kernels are done executing
     // Manual reading of device profiler results is not supported when there is already another thread reading the
     // results. Signal the debug dump thread to do a read instead.
-    if (getDeviceDebugDumpEnabled()) {
-        if (auto& profiler_state_manager = MetalContext::instance().profiler_state_manager()) {
+    if (getDeviceDebugDumpEnabled(context_id)) {
+        if (auto& profiler_state_manager = MetalContext::instance(context_id).profiler_state_manager()) {
             profiler_state_manager->signal_debug_dump_read();
         }
         if (auto& noc_debug_state = MetalContext::instance().noc_debug_state()) {
@@ -1255,7 +1284,7 @@ std::map<ChipId, std::set<ProgramAnalysisData>> GetLatestProgramsPerfData() {
 #if defined(TRACY_ENABLE)
     ZoneScoped;
 
-    if (!getDeviceProfilerState() || !detail::getProgramsPerfDataMidRun()) {
+    if (!getDeviceProfilerState(DEFAULT_CONTEXT_ID) || !detail::getProgramsPerfDataMidRun()) {
         return {};
     }
 
@@ -1287,7 +1316,7 @@ std::map<ChipId, std::set<ProgramAnalysisData>> GetAllProgramsPerfData() {
 #if defined(TRACY_ENABLE)
     ZoneScoped;
 
-    if (!getDeviceProfilerState() || !detail::getProgramsPerfDataMidRun()) {
+    if (!getDeviceProfilerState(DEFAULT_CONTEXT_ID) || !detail::getProgramsPerfDataMidRun()) {
         return {};
     }
 

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -73,25 +73,13 @@ namespace tt::tt_metal {
 
 namespace detail {
 
-ContextId getContextIdSafe(distributed::MeshDevice* mesh_device, IDevice* device) {
-    ContextId context_id = DEFAULT_CONTEXT_ID;
-    if (mesh_device != nullptr) {
-        context_id = extract_context_id(mesh_device);
-    } else if (device != nullptr) {
-        context_id = extract_context_id(device);
-    } else {
-        TT_FATAL(false, "Both MeshDevice and Device are nullptr");
-    }
-    return context_id;
-}
-
 void setControlBuffer(
     distributed::MeshDevice* mesh_device,
     IDevice* device,
     std::vector<uint32_t>& control_buffer,
     bool force_slow_dispatch = false) {
 #if defined(TRACY_ENABLE)
-    ContextId context_id = getContextIdSafe(mesh_device, device);
+    ContextId context_id = extract_context_id(mesh_device, device);
     if (!getDeviceProfilerState(context_id)) {
         return;
     }
@@ -113,7 +101,7 @@ void setControlBuffer(
 
 void syncDeviceHost(distributed::MeshDevice* mesh_device, IDevice* device, CoreCoord logical_core, bool doHeader) {
     ZoneScopedC(tracy::Color::Tomato3);
-    ContextId context_id = getContextIdSafe(mesh_device, nullptr);
+    ContextId context_id = extract_context_id(mesh_device, nullptr);
     if (!MetalContext::instance(context_id).rtoptions().get_profiler_sync_enabled()) {
         return;
     }
@@ -831,12 +819,8 @@ static void ReadDeviceProfilerResultsImpl(
     ProfilerReadState state,
     const std::optional<ProfilerOptionalMetadata>& metadata) {
     ZoneScoped;
-    ContextId context_id = getContextIdSafe(mesh_device, device);
+    ContextId context_id = extract_context_id(mesh_device, device);
     if (!getDeviceProfilerState(context_id)) {
-        return;
-    }
-
-    if (device != nullptr && !getDeviceProfilerState(extract_context_id(device))) {
         return;
     }
 
@@ -903,7 +887,8 @@ void ReadDeviceProfilerResults(
     ProfilerReadState state,
     const std::optional<ProfilerOptionalMetadata>& metadata) {
 #if defined(TRACY_ENABLE)
-    if (getDeviceDebugDumpEnabled(extract_context_id(mesh_device))) {
+    ContextId context_id = extract_context_id(mesh_device, device);
+    if (getDeviceDebugDumpEnabled(context_id)) {
         return;
     }
 
@@ -921,20 +906,22 @@ void ReadDeviceProfilerResultsInternal(
     // Note: This function bypasses the getDeviceDebugDumpEnabled() check
     // It is intended only for use by ProfilerStateManager during cleanup
 #if defined(TRACY_ENABLE)
-    if (!getDeviceProfilerState(extract_context_id(mesh_device))) {
+    ContextId context_id = extract_context_id(mesh_device, device);
+    if (!getDeviceProfilerState(context_id)) {
         return;
     }
 
     const std::unique_ptr<ProfilerStateManager>& profiler_state_manager =
-        MetalContext::instance(extract_context_id(mesh_device)).profiler_state_manager();
+        MetalContext::instance(context_id).profiler_state_manager();
     auto profiler_it = profiler_state_manager->device_profiler_map.find(device->id());
     TT_ASSERT(profiler_it != profiler_state_manager->device_profiler_map.end());
     DeviceProfiler& profiler = profiler_it->second;
 
     TT_FATAL(
-        !MetalContext::instance().dprint_server(), "Debug print server is running, cannot read device profiler data");
+        !MetalContext::instance(context_id).dprint_server(),
+        "Debug print server is running, cannot read device profiler data");
 
-    if (include_l1 || MetalContext::instance().rtoptions().get_profiler_trace_only()) {
+    if (include_l1 || MetalContext::instance(context_id).rtoptions().get_profiler_trace_only()) {
         profiler.readResults(
             mesh_device, device, virtual_cores, state, ProfilerDataBufferSource::DRAM_AND_L1, metadata);
     } else {

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -339,7 +339,8 @@ uint32_t finalize_kernel_bins(
     uint32_t& kernel_text_offset,
     uint32_t& kernel_text_size) {
     // Mock devices don't have real binaries, skip finalization
-    if (tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock) {
+    if (tt::tt_metal::MetalContext::instance(extract_context_id(device)).get_cluster().get_target_device_type() ==
+        tt::TargetDevice::Mock) {
         kernel_text_offset = base_offset;
         kernel_text_size = 0;
         return base_offset;
@@ -2035,8 +2036,8 @@ void assemble_device_commands(
     }
 }
 
-void initialize_worker_config_buf_mgr(WorkerConfigBufferMgr& config_buffer_mgr, uint32_t worker_l1_unreserved_start) {
-    const auto& hal = MetalContext::instance().hal();
+void initialize_worker_config_buf_mgr(
+    const Hal& hal, WorkerConfigBufferMgr& config_buffer_mgr, uint32_t worker_l1_unreserved_start) {
     for (uint32_t index = 0; index < hal.get_programmable_core_type_count(); index++) {
         uint32_t ringbuffer_size;
         if (hal.get_programmable_core_type(index) == tt::tt_metal::HalProgrammableCoreType::TENSIX) {
@@ -2682,13 +2683,14 @@ uint32_t program_base_addr_on_core(
 }
 
 void reset_config_buf_mgrs_and_expected_workers(
+    const Hal& hal,
     DispatchArray<WorkerConfigBufferMgr>& config_buffer_mgrs,
     DispatchArray<uint32_t>& expected_num_workers_completed,
     uint32_t num_entries_to_reset,
     uint32_t worker_l1_unreserved_start) {
     for (uint32_t i = 0; i < num_entries_to_reset; ++i) {
         config_buffer_mgrs[i] = WorkerConfigBufferMgr();
-        initialize_worker_config_buf_mgr(config_buffer_mgrs[i], worker_l1_unreserved_start);
+        initialize_worker_config_buf_mgr(hal, config_buffer_mgrs[i], worker_l1_unreserved_start);
     }
     std::fill(expected_num_workers_completed.begin(), expected_num_workers_completed.begin() + num_entries_to_reset, 0);
 }

--- a/tt_metal/impl/program/dispatch.hpp
+++ b/tt_metal/impl/program/dispatch.hpp
@@ -110,7 +110,8 @@ void insert_empty_program_dispatch_preamble_cmd(ProgramCommandSequence& program_
 
 void insert_stall_cmds(ProgramCommandSequence& program_command_sequence, SubDeviceId sub_device_id, IDevice* device);
 
-void initialize_worker_config_buf_mgr(WorkerConfigBufferMgr& config_buffer_mgr);
+void initialize_worker_config_buf_mgr(
+    const Hal& hal, WorkerConfigBufferMgr& config_buffer_mgr, uint32_t worker_l1_unreserved_start);
 
 void reserve_space_in_kernel_config_buffer(
     WorkerConfigBufferMgr& config_buffer_mgr,
@@ -159,6 +160,7 @@ void write_program_command_sequence(
 KernelHandle get_device_local_kernel_handle(KernelHandle kernel_handle);
 
 void reset_config_buf_mgrs_and_expected_workers(
+    const Hal& hal,
     DispatchArray<WorkerConfigBufferMgr>& config_buffer_mgrs,
     DispatchArray<uint32_t>& expected_num_workers_completed,
     uint32_t num_entries_to_reset,

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -45,6 +45,7 @@
 #include "core_coord.hpp"
 #include "common/stable_hash.hpp"
 #include "impl/context/metal_context.hpp"
+#include "impl/context/context_types.hpp"
 #include "jit_build/hlk_desc.hpp"
 #include "hal_types.hpp"
 #include "jit_build/build.hpp"
@@ -1171,7 +1172,8 @@ void detail::ProgramImpl::set_cb_tile_dims(const std::vector<CoreRange>& crs, Ji
 
 void detail::ProgramImpl::populate_dispatch_data(IDevice* device) {
     // Mock devices don't dispatch to hardware, skip dispatch data population
-    if (tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock) {
+    if (tt::tt_metal::MetalContext::instance(extract_context_id(device)).get_cluster().get_target_device_type() ==
+        tt::TargetDevice::Mock) {
         return;
     }
 
@@ -1505,6 +1507,7 @@ void ProgramImpl::generate_trace_dispatch_commands(IDevice* device, bool use_pre
 void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
     // ZoneScoped;
     const auto& build_env = BuildEnvManager::get_instance().get_device_build_env(device->build_id());
+    ContextId context_id = extract_context_id(device);
 
     if (compiled_.contains(build_env.build_key())) {
         Inspector::program_compile_already_exists(this, device, build_env.build_key());
@@ -1526,11 +1529,14 @@ void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
 
     std::vector<std::shared_future<void>> events;
 
+    bool is_mock = tt::tt_metal::MetalContext::instance(context_id).get_cluster().get_target_device_type() ==
+                   tt::TargetDevice::Mock;
+
     for (auto& kernels : kernels_) {
         for (auto& [id, kernel] : kernels) {
             validate_kernel_placement(force_slow_dispatch, kernel);
             launch_build_step(
-                [kernel, device, this, &build_env] {
+                [kernel, device, this, &build_env, is_mock] {
                     JitBuildOptions build_options(build_env.build_env);
                     kernel->set_build_options(build_options);
                     if (this->compiled_.empty()) {
@@ -1547,13 +1553,9 @@ void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
                     kernel->set_full_name(kernel_path_suffix);
                     build_options.set_name(kernel_path_suffix);
 
-                    if (tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() !=
-                        tt::TargetDevice::Mock) {
+                    if (!is_mock) {
                         kernel->register_kernel_elf_paths_with_watcher(*device);
                     }
-
-                    bool is_mock = tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() ==
-                                   tt::TargetDevice::Mock;
 
                     jit_build_once(kernel_hash, [&] {
                         if (!is_mock) {
@@ -1573,8 +1575,6 @@ void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
     sync_build_steps(events);
 
     // Mock devices don't have binaries to read
-    bool is_mock =
-        tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock;
     if (!is_mock) {
         for (const auto& kernels : kernels_) {
             for (const auto& pair : kernels) {
@@ -1788,7 +1788,7 @@ void detail::ProgramImpl::finalize_offsets(IDevice* device) {
     tt::stl::Span<ProgramImpl*> programs(programs_array);
 
     (void)ProgramImpl::finalize_program_offsets(
-        device, kernels_getter, kernel_groups_getter, semaphores_getter, programs);
+        extract_context_id(device), device, kernels_getter, kernel_groups_getter, semaphores_getter, programs);
 
     set_finalized();
 }
@@ -1796,6 +1796,7 @@ void detail::ProgramImpl::finalize_offsets(IDevice* device) {
 // Compute relative offsets (wrt the start of the kernel config ring buffer) and sizes of all
 // program data structures in L1. Will be used when assembling dispatch commands for this program
 uint32_t detail::ProgramImpl::finalize_program_offsets(
+    ContextId context_id,
     IDevice* device,
     const KernelsGetter& kernels_getter,
     const KernelGroupsGetter& kernel_groups_getter,
@@ -1803,7 +1804,7 @@ uint32_t detail::ProgramImpl::finalize_program_offsets(
     tt::stl::Span<ProgramImpl*> programs) {
     ProgramOffsetsState state;
 
-    const auto& hal = MetalContext::instance().hal();
+    const auto& hal = MetalContext::instance(context_id).hal();
 
     // Collect dataflow buffers from all programs
     std::vector<std::shared_ptr<tt::tt_metal::experimental::dfb::detail::DataflowBufferImpl>> dataflow_buffers;

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -256,7 +256,9 @@ public:
     // Helper function to finalize program offsets with custom getters. Returns the maximum kernel binaries size among
     // all the programs, to determine whether the mesh workload can fit in the prefetcher cache all of the programs in
     // it.
+    // context_id is which context the program and device belong to
     static uint32_t finalize_program_offsets(
+        ContextId context_id,
         IDevice* device,
         const KernelsGetter& kernels_getter,
         const KernelGroupsGetter& kernel_groups_getter,

--- a/tt_metal/impl/sub_device/sub_device.cpp
+++ b/tt_metal/impl/sub_device/sub_device.cpp
@@ -80,9 +80,6 @@ const CoreRangeSet& SubDeviceImpl::cores(HalProgrammableCoreType core_type) cons
 SubDevice::SubDevice(tt::stl::Span<const CoreRangeSet> cores) :
     pimpl_(std::make_unique<SubDeviceImpl>(nullptr, cores)) {}
 
-SubDevice::SubDevice(tt::tt_metal::MetalEnv& env, tt::stl::Span<const CoreRangeSet> cores) :
-    pimpl_(std::make_unique<SubDeviceImpl>(&MetalEnvAccessor(env).impl(), cores)) {}
-
 SubDevice::SubDevice(SubDeviceImpl&& impl) : pimpl_(std::make_unique<SubDeviceImpl>(std::move(impl))) {}
 
 SubDevice::SubDevice(const SubDevice& other) :

--- a/tt_metal/impl/sub_device/sub_device.cpp
+++ b/tt_metal/impl/sub_device/sub_device.cpp
@@ -14,28 +14,42 @@
 
 #include "hal_types.hpp"
 #include "impl/context/metal_context.hpp"
+#include "impl/context/metal_env_accessor.hpp"
 #include "impl/sub_device/sub_device_impl.hpp"
 
 namespace tt::tt_metal {
 
 // SubDeviceImpl implementation
 
-SubDeviceImpl::SubDeviceImpl(const std::array<CoreRangeSet, NumHalProgrammableCoreTypes>& cores) : cores_(cores) {
+tt::tt_metal::MetalEnvImpl* get_env_or_default(tt::tt_metal::MetalEnvImpl* env) {
+    if (env == nullptr) {
+        return &MetalEnvAccessor(MetalContext::instance(DEFAULT_CONTEXT_ID).get_env()).impl();
+    }
+    return env;
+}
+
+SubDeviceImpl::SubDeviceImpl(
+    tt::tt_metal::MetalEnvImpl* env, const std::array<CoreRangeSet, NumHalProgrammableCoreTypes>& cores) :
+    cores_(cores), env_(get_env_or_default(env)) {
     this->validate();
 }
 
-SubDeviceImpl::SubDeviceImpl(tt::stl::Span<const CoreRangeSet> cores) {
+SubDeviceImpl::SubDeviceImpl(tt::tt_metal::MetalEnvImpl* env, tt::stl::Span<const CoreRangeSet> cores) :
+    env_(get_env_or_default(env)) {
     TT_FATAL(cores.size() <= this->cores_.size(), "Too many core types for SubDevice");
     std::copy(cores.begin(), cores.end(), this->cores_.begin());
     this->validate();
 }
 
-SubDeviceImpl::SubDeviceImpl(std::array<CoreRangeSet, NumHalProgrammableCoreTypes>&& cores) : cores_(std::move(cores)) {
-    validate();
+SubDeviceImpl::SubDeviceImpl(
+    tt::tt_metal::MetalEnvImpl* env, std::array<CoreRangeSet, NumHalProgrammableCoreTypes>&& cores) :
+    cores_(std::move(cores)), env_(get_env_or_default(env)) {
+    this->validate();
 }
 
 void SubDeviceImpl::validate() const {
-    auto num_core_types = MetalContext::instance().hal().get_programmable_core_type_count();
+    TT_ASSERT(env_ != nullptr, "Missing MetalEnv for this SubDevice");
+    auto num_core_types = env_->get_hal().get_programmable_core_type_count();
     for (uint32_t i = num_core_types; i < NumHalProgrammableCoreTypes; ++i) {
         TT_FATAL(
             this->cores_[i].empty(),
@@ -63,7 +77,11 @@ const CoreRangeSet& SubDeviceImpl::cores(HalProgrammableCoreType core_type) cons
 
 // SubDevice implementation
 
-SubDevice::SubDevice(tt::stl::Span<const CoreRangeSet> cores) : pimpl_(std::make_unique<SubDeviceImpl>(cores)) {}
+SubDevice::SubDevice(tt::stl::Span<const CoreRangeSet> cores) :
+    pimpl_(std::make_unique<SubDeviceImpl>(nullptr, cores)) {}
+
+SubDevice::SubDevice(tt::tt_metal::MetalEnv& env, tt::stl::Span<const CoreRangeSet> cores) :
+    pimpl_(std::make_unique<SubDeviceImpl>(&MetalEnvAccessor(env).impl(), cores)) {}
 
 SubDevice::SubDevice(SubDeviceImpl&& impl) : pimpl_(std::make_unique<SubDeviceImpl>(std::move(impl))) {}
 

--- a/tt_metal/impl/sub_device/sub_device_impl.hpp
+++ b/tt_metal/impl/sub_device/sub_device_impl.hpp
@@ -10,15 +10,18 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/hal_types.hpp>
 #include <tt_stl/span.hpp>
+#include "context/metal_env_impl.hpp"
 
 namespace tt::tt_metal {
 
 class SubDeviceImpl {
 public:
     // Constructors for internal tt_metal/ use
-    explicit SubDeviceImpl(const std::array<CoreRangeSet, NumHalProgrammableCoreTypes>& cores);
-    explicit SubDeviceImpl(std::array<CoreRangeSet, NumHalProgrammableCoreTypes>&& cores);
-    explicit SubDeviceImpl(tt::stl::Span<const CoreRangeSet> cores);
+    explicit SubDeviceImpl(
+        tt::tt_metal::MetalEnvImpl* env, const std::array<CoreRangeSet, NumHalProgrammableCoreTypes>& cores);
+    explicit SubDeviceImpl(
+        tt::tt_metal::MetalEnvImpl* env, std::array<CoreRangeSet, NumHalProgrammableCoreTypes>&& cores);
+    explicit SubDeviceImpl(tt::tt_metal::MetalEnvImpl* env, tt::stl::Span<const CoreRangeSet> cores);
 
     // Copy/move semantics
     SubDeviceImpl(const SubDeviceImpl&) = default;
@@ -36,6 +39,7 @@ private:
     void validate() const;
 
     std::array<CoreRangeSet, NumHalProgrammableCoreTypes> cores_;
+    tt::tt_metal::MetalEnvImpl* env_;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/sub_device/sub_device_manager.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager.cpp
@@ -48,11 +48,11 @@ std::atomic<uint64_t> SubDeviceManager::next_sub_device_manager_id_ = 0;
 
 SubDeviceManager::SubDeviceManager(
     tt::stl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size, IDevice* device) :
-    id_(next_sub_device_manager_id_++),
-    sub_devices_(sub_devices.begin(), sub_devices.end()),
-    device_(device),
-    local_l1_size_(tt::align(local_l1_size, MetalContext::instance().hal().get_alignment(HalMemType::L1))) {
+    id_(next_sub_device_manager_id_++), sub_devices_(sub_devices.begin(), sub_devices.end()), device_(device) {
     TT_ASSERT(device != nullptr, "Device must not be null");
+    context_id_ = extract_context_id(device);
+    this->local_l1_size_ =
+        tt::align(local_l1_size, MetalContext::instance(context_id_).hal().get_alignment(HalMemType::L1));
     this->validate_sub_devices();
     this->populate_sub_device_ids();
     this->populate_num_cores();
@@ -68,6 +68,7 @@ SubDeviceManager::SubDeviceManager(
     local_l1_size_(0) {
     TT_ASSERT(device != nullptr, "Device must not be null");
 
+    context_id_ = extract_context_id(device);
     this->populate_sub_device_ids();
     // No need to validate sub-devices since this constructs a sub-device of the entire grid
     this->populate_num_cores();
@@ -208,8 +209,9 @@ void SubDeviceManager::validate_sub_devices() const {
         if (sub_device.impl()->has_core_type(HalProgrammableCoreType::ACTIVE_ETH)) {
             const auto& eth_cores = sub_device.cores(HalProgrammableCoreType::ACTIVE_ETH);
             uint32_t num_eth_cores = 0;
-            const auto& device_eth_cores =
-                tt::tt_metal::MetalContext::instance().get_control_plane().get_active_ethernet_cores(device_->id());
+            const auto& device_eth_cores = tt::tt_metal::MetalContext::instance(context_id_)
+                                               .get_control_plane()
+                                               .get_active_ethernet_cores(device_->id());
             for (const auto& dev_eth_core : device_eth_cores) {
                 if (eth_cores.contains(dev_eth_core)) {
                     num_eth_cores++;
@@ -320,7 +322,7 @@ void SubDeviceManager::populate_noc_data() {
     num_noc_unicast_txns_.resize(num_sub_devices);
     noc_unicast_data_start_index_.resize(num_sub_devices);
 
-    NOC noc_index = MetalContext::instance().get_dispatch_query_manager().go_signal_noc();
+    NOC noc_index = MetalContext::instance(context_id_).get_dispatch_query_manager().go_signal_noc();
     uint32_t idx = 0;
     for (uint32_t i = 0; i < num_sub_devices; ++i) {
         const auto& eth_cores = sub_devices_[i].cores(HalProgrammableCoreType::ACTIVE_ETH);

--- a/tt_metal/impl/sub_device/sub_device_manager.hpp
+++ b/tt_metal/impl/sub_device/sub_device_manager.hpp
@@ -19,6 +19,7 @@
 #include "hal_types.hpp"
 #include "sub_device.hpp"
 #include "sub_device_types.hpp"
+#include <impl/context/context_types.hpp>
 #include <tt-metalium/mesh_trace_id.hpp>
 
 namespace tt::tt_metal::distributed {
@@ -88,6 +89,7 @@ private:
     std::vector<SubDeviceId> sub_device_ids_;
     std::vector<SubDeviceId> sub_device_stall_group_;
     IDevice* device_;
+    tt::tt_metal::ContextId context_id_;
 
     DeviceAddr local_l1_size_;
     std::vector<std::unique_ptr<AllocatorImpl>> sub_device_allocators_;

--- a/tt_metal/jit_build/jit_device_config.cpp
+++ b/tt_metal/jit_build/jit_device_config.cpp
@@ -4,6 +4,7 @@
 
 #include "jit_device_config.hpp"
 
+#include "context/metal_env_accessor.hpp"
 #include "core_descriptor.hpp"
 #include "dispatch_core_common.hpp"
 #include "impl/context/metal_context.hpp"
@@ -18,16 +19,18 @@
 namespace tt::tt_metal {
 
 JitDeviceConfig create_jit_device_config(ChipId device_id, uint8_t num_hw_cqs) {
+    // Need both runtime state and hardware query
     auto& ctx = MetalContext::instance();
-    const auto& hal = ctx.hal();
-    const auto& cluster = ctx.get_cluster();
+    auto& env = MetalEnvAccessor(ctx.get_env()).impl();
+    const auto& hal = env.get_hal();
+    const auto& cluster = env.get_cluster();
     const auto& dispatch_core_config = ctx.get_dispatch_core_manager().get_dispatch_core_config();
     const metal_SocDescriptor& soc_d = cluster.get_soc_desc(device_id);
 
     const size_t num_dram_banks = static_cast<size_t>(soc_d.get_num_dram_views());
     // # of L1 banks needs to match allocator. For L1BankingAllocator this is the # of storage cores. TODO: when
     // allocator is pulled out of device, use it to get that info here.
-    const size_t num_l1_banks = get_logical_compute_cores(device_id, num_hw_cqs, dispatch_core_config).size();
+    const size_t num_l1_banks = get_logical_compute_cores(env, device_id, num_hw_cqs, dispatch_core_config).size();
 
     auto pcie_cores = soc_d.get_cores(CoreType::PCIE, CoordSystem::TRANSLATED);
     CoreCoord pcie_core = pcie_cores.empty() ? soc_d.grid_size : pcie_cores[0];

--- a/tt_metal/llrt/core_descriptor.cpp
+++ b/tt_metal/llrt/core_descriptor.cpp
@@ -42,18 +42,20 @@ inline YAML::Node string_to_yaml_node(const std::string& input) {
 }
 
 inline std::string get_core_descriptor_file(
-    const tt::ARCH& arch, const tt::tt_metal::DispatchCoreConfig& dispatch_core_config) {
+    tt::tt_metal::MetalEnvImpl& env,
+    const tt::ARCH& arch,
+    const tt::tt_metal::DispatchCoreConfig& dispatch_core_config) {
     // Ability to skip this runtime opt, since trimmed SOC desc limits which DRAM channels are available.
-    std::string core_desc_dir = tt_metal::MetalContext::instance().rtoptions().get_root_dir();
+    std::string core_desc_dir = env.get_rtoptions().get_root_dir();
     if (core_desc_dir.back() != '/') {
         core_desc_dir += "/";
     }
     core_desc_dir += "tt_metal/core_descriptors/";
 
     bool use_small_core_desc_yaml = false; // override to a different core descriptor for small RTL sims
-    if (tt_metal::MetalContext::instance().rtoptions().get_simulator_enabled()) {
+    if (env.get_rtoptions().get_simulator_enabled()) {
         auto soc_desc = tt::umd::SimulationChip::get_soc_descriptor_path_from_simulator_path(
-            tt_metal::MetalContext::instance().rtoptions().get_simulator_path());
+            env.get_rtoptions().get_simulator_path());
         tt_xy_pair grid_size = tt::umd::SocDescriptor::get_grid_size_from_soc_descriptor_path(soc_desc);
         if (grid_size.y <= 2 || grid_size.x <= 2) {  // these SOC descriptors declare a 2x2 grid
             use_small_core_desc_yaml = true;
@@ -70,8 +72,7 @@ inline std::string get_core_descriptor_file(
         };
     } else {
         // Check if fabric tensix is enabled based on fabric tensix config
-        tt_fabric::FabricTensixConfig fabric_tensix_config =
-            tt::tt_metal::MetalContext::instance().get_fabric_tensix_config();
+        tt_fabric::FabricTensixConfig fabric_tensix_config = env.get_fabric_tensix_config();
         bool use_fabric_tensix = (fabric_tensix_config != tt_fabric::FabricTensixConfig::DISABLED);
 
         auto core_type = get_core_type_from_config(dispatch_core_config);
@@ -102,7 +103,10 @@ inline std::string get_core_descriptor_file(
 }
 
 const core_descriptor_t& get_core_descriptor_config(
-    ChipId device_id, const uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig& dispatch_core_config) {
+    tt::tt_metal::MetalEnvImpl& env,
+    ChipId device_id,
+    const uint8_t num_hw_cqs,
+    const tt_metal::DispatchCoreConfig& dispatch_core_config) {
     // {arch : {product : {dispatch core axis: {fabric tensix config: {num_hw_cqs : {fast_dispatch : config}}}}}}
     static std::unordered_map<
         ARCH,
@@ -115,8 +119,8 @@ const core_descriptor_t& get_core_descriptor_config(
                     std::unordered_map<uint8_t, std::unordered_map<bool, core_descriptor_t>>>>>>
         config_by_arch;
 
-    ARCH arch = tt::tt_metal::MetalContext::instance().get_cluster().arch();
-    uint32_t harvesting_mask = tt::tt_metal::MetalContext::instance().get_cluster().get_harvesting_mask(device_id);
+    ARCH arch = env.get_cluster().arch();
+    uint32_t harvesting_mask = env.get_cluster().get_harvesting_mask(device_id);
     std::bitset<32> mask_bitset(harvesting_mask);
     uint32_t num_harvested_on_axis = mask_bitset.count();
 
@@ -126,37 +130,37 @@ const core_descriptor_t& get_core_descriptor_config(
     }
 
     std::string product_name = get_product_name(arch, num_harvested_on_axis);
-    if (tt::tt_metal::MetalContext::instance().get_cluster().is_galaxy_cluster()) {
-        if (tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(device_id) == BoardType::N150) {
+    if (env.get_cluster().is_galaxy_cluster()) {
+        if (env.get_cluster().get_board_type(device_id) == BoardType::N150) {
             // some Galaxy machines are setup with N150s that have 0 harvested rows.
             // get_product_name ( ) returns those chips as galaxy. Override that to nebula_x1.
             product_name = "nebula_x1";
         } else {
             TT_ASSERT(
-                tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(device_id) == BoardType::GALAXY,
+                env.get_cluster().get_board_type(device_id) == BoardType::GALAXY,
                 "Invalid Board Type in Galaxy Cluster. Only GALAXY and N150 are supported.");
         }
     }
 
-    tt_fabric::FabricTensixConfig fabric_tensix_config =
-        tt::tt_metal::MetalContext::instance().get_fabric_tensix_config();
-    bool fast_dispatch = tt_metal::MetalContext::instance().rtoptions().get_fast_dispatch();
+    tt_fabric::FabricTensixConfig fabric_tensix_config = env.get_fabric_tensix_config();
+    bool fast_dispatch = env.get_rtoptions().get_fast_dispatch();
+
+    tt_metal::DispatchCoreAxis resolved_axis = tt_metal::resolve_dispatch_core_axis(arch, fabric_tensix_config);
+
     std::unordered_map<uint8_t, std::unordered_map<bool, core_descriptor_t>>& config_by_num_cqs =
         config_by_arch[arch][product_name][dispatch_core_config][fabric_tensix_config];
     if (config_by_num_cqs[num_hw_cqs].contains(fast_dispatch)) {
         return config_by_num_cqs[num_hw_cqs].at(fast_dispatch);
     }
 
-    YAML::Node core_descriptor_yaml = YAML::LoadFile(get_core_descriptor_file(arch, dispatch_core_config));
+    YAML::Node core_descriptor_yaml = YAML::LoadFile(get_core_descriptor_file(env, arch, dispatch_core_config));
     YAML::Node desc_yaml =
-        core_descriptor_yaml[product_name]
-                            [(dispatch_core_config.get_dispatch_core_axis() == tt_metal::DispatchCoreAxis::ROW) ? "row"
-                                                                                                                : "col"]
+        core_descriptor_yaml[product_name][(resolved_axis == tt_metal::DispatchCoreAxis::ROW) ? "row" : "col"]
                             [std::to_string(num_hw_cqs)];
 
     auto compute_with_storage_start = desc_yaml["compute_with_storage_grid_range"]["start"];
     auto compute_with_storage_end = desc_yaml["compute_with_storage_grid_range"]["end"];
-    if (tt::tt_metal::MetalContext::instance().get_cluster().is_galaxy_cluster() and product_name == "nebula_x1") {
+    if (env.get_cluster().is_galaxy_cluster() and product_name == "nebula_x1") {
         compute_with_storage_start = desc_yaml["tg_compute_with_storage_grid_range"]["start"];
         compute_with_storage_end = desc_yaml["tg_compute_with_storage_grid_range"]["end"];
     }
@@ -164,9 +168,9 @@ const core_descriptor_t& get_core_descriptor_config(
     TT_ASSERT(compute_with_storage_end[0].as<size_t>() >= compute_with_storage_start[0].as<size_t>());
     TT_ASSERT(compute_with_storage_end[1].as<size_t>() >= compute_with_storage_start[1].as<size_t>());
     // // Adjusts the core grid configuration based on the value of the environment variable
-    if (tt_metal::MetalContext::instance().rtoptions().is_core_grid_override_todeprecate()) {
+    if (env.get_rtoptions().is_core_grid_override_todeprecate()) {
         auto compute_with_storage_end_override =
-            string_to_yaml_node(tt_metal::MetalContext::instance().rtoptions().get_core_grid_override_todeprecate());
+            string_to_yaml_node(env.get_rtoptions().get_core_grid_override_todeprecate());
         TT_FATAL(
             compute_with_storage_end_override.IsSequence(),
             "compute_with_storage_end_override must be a YAML sequence");
@@ -204,10 +208,8 @@ const core_descriptor_t& get_core_descriptor_config(
 
     CoreCoord compute_grid_size;
     // When slow dispatch is on, use full logical grid (no dispatch cores to reserve)
-    if (!fast_dispatch && !tt::tt_metal::MetalContext::instance().rtoptions().get_simulator_enabled()) {
-        compute_grid_size =
-            tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device_id).get_grid_size(
-                CoreType::TENSIX);
+    if (!fast_dispatch && !env.get_rtoptions().get_simulator_enabled()) {
+        compute_grid_size = env.get_cluster().get_soc_desc(device_id).get_grid_size(CoreType::TENSIX);
         log_info(
             tt::LogDevice,
             "Slow dispatch mode: Using full logical grid ({}, {})",
@@ -227,17 +229,15 @@ const core_descriptor_t& get_core_descriptor_config(
 
     std::vector<RelativeCoreCoord> dispatch_cores;
     const auto* dispatch_cores_string = "dispatch_cores";
-    if (tt::tt_metal::MetalContext::instance().get_cluster().is_galaxy_cluster() and product_name == "nebula_x1") {
+    if (env.get_cluster().is_galaxy_cluster() and product_name == "nebula_x1") {
         dispatch_cores_string = "tg_dispatch_cores";
     }
 
-    CoreCoord grid_size =
-        tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device_id).get_grid_size(CoreType::TENSIX);
+    CoreCoord grid_size = env.get_cluster().get_soc_desc(device_id).get_grid_size(CoreType::TENSIX);
     // For mock devices, control plane doesn't exist, use empty set
     std::unordered_set<CoreCoord> logical_active_eth_cores;
-    if (tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() != tt::TargetDevice::Mock) {
-        logical_active_eth_cores =
-            tt::tt_metal::MetalContext::instance().get_control_plane().get_active_ethernet_cores(device_id);
+    if (env.get_cluster().get_target_device_type() != tt::TargetDevice::Mock) {
+        logical_active_eth_cores = env.get_control_plane().get_active_ethernet_cores(device_id);
     }
 
     for (const auto& core_node : desc_yaml[dispatch_cores_string]) {
@@ -257,8 +257,7 @@ const core_descriptor_t& get_core_descriptor_config(
         dispatch_cores.push_back(coord);
     }
     TT_ASSERT(
-        !dispatch_cores.empty() || tt_metal::MetalContext::instance().rtoptions().get_simulator_enabled(),
-        "Dispatch cores size must be positive");
+        !dispatch_cores.empty() || env.get_rtoptions().get_simulator_enabled(), "Dispatch cores size must be positive");
 
     // Parse fabric_mux_cores
     std::vector<RelativeCoreCoord> fabric_mux_cores;
@@ -316,20 +315,25 @@ const core_descriptor_t& get_core_descriptor_config(
 }
 
 const std::tuple<uint32_t, CoreRange>& get_physical_worker_grid_config(
-    ChipId device_id, uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig& dispatch_core_config) {
-    // Get logical compute grid dimensions and num workers
-    static std::unordered_map<uint32_t, std::tuple<uint32_t, CoreRange>> physical_grid_config_cache = {};
-    // Unique hash generated based on the config that's being queried
-    uint32_t config_hash = ((uint8_t)(get_core_type_from_config(dispatch_core_config))) |
-                           ((uint8_t)(dispatch_core_config.get_dispatch_core_axis()) << 4) | (num_hw_cqs << 8) |
-                           (device_id << 16);
+    tt::tt_metal::MetalEnvImpl& env,
+    ChipId device_id,
+    uint8_t num_hw_cqs,
+    const tt_metal::DispatchCoreConfig& dispatch_core_config) {
+    static std::unordered_map<uint64_t, std::tuple<uint32_t, CoreRange>> physical_grid_config_cache = {};
+    tt_fabric::FabricTensixConfig fabric_tensix_config_phys = env.get_fabric_tensix_config();
+    tt_metal::DispatchCoreAxis resolved_axis_phys =
+        tt_metal::resolve_dispatch_core_axis(env.get_cluster().arch(), fabric_tensix_config_phys);
+
+    uint64_t config_hash = ((uint8_t)(get_core_type_from_config(dispatch_core_config))) |
+                           ((uint64_t)(resolved_axis_phys) << 4) | ((uint64_t)num_hw_cqs << 8) |
+                           ((uint64_t)device_id << 16) | ((uint64_t)env.get_cluster().arch() << 32) |
+                           ((uint64_t)env.get_cluster().get_target_device_type() << 40);
     if (!physical_grid_config_cache.contains(config_hash)) {
-        auto worker_grid = tt::get_compute_grid_size(device_id, num_hw_cqs, dispatch_core_config);
+        auto worker_grid = tt::get_compute_grid_size(env, device_id, num_hw_cqs, dispatch_core_config);
         std::size_t tensix_num_worker_cols = worker_grid.x;
         std::size_t tensix_num_worker_rows = worker_grid.y;
         uint32_t tensix_num_worker_cores = tensix_num_worker_cols * tensix_num_worker_rows;
-        const metal_SocDescriptor& soc_desc =
-            tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device_id);
+        const metal_SocDescriptor& soc_desc = env.get_cluster().get_soc_desc(device_id);
         // Get physical compute grid range based on SOC Desc and Logical Coords
         // Logical Worker Coords start at 0,0
         CoreCoord tensix_worker_start_phys = soc_desc.get_physical_tensix_core_from_logical(CoreCoord(0, 0));

--- a/tt_metal/llrt/core_descriptor.cpp
+++ b/tt_metal/llrt/core_descriptor.cpp
@@ -145,7 +145,8 @@ const core_descriptor_t& get_core_descriptor_config(
     tt_fabric::FabricTensixConfig fabric_tensix_config = env.get_fabric_tensix_config();
     bool fast_dispatch = env.get_rtoptions().get_fast_dispatch();
 
-    tt_metal::DispatchCoreAxis resolved_axis = tt_metal::resolve_dispatch_core_axis(arch, fabric_tensix_config);
+    tt_metal::DispatchCoreAxis resolved_axis =
+        tt_metal::resolve_dispatch_core_axis(dispatch_core_config, arch, fabric_tensix_config);
 
     std::unordered_map<uint8_t, std::unordered_map<bool, core_descriptor_t>>& config_by_num_cqs =
         config_by_arch[arch][product_name][dispatch_core_config][fabric_tensix_config];
@@ -322,7 +323,7 @@ const std::tuple<uint32_t, CoreRange>& get_physical_worker_grid_config(
     static std::unordered_map<uint64_t, std::tuple<uint32_t, CoreRange>> physical_grid_config_cache = {};
     tt_fabric::FabricTensixConfig fabric_tensix_config_phys = env.get_fabric_tensix_config();
     tt_metal::DispatchCoreAxis resolved_axis_phys =
-        tt_metal::resolve_dispatch_core_axis(env.get_cluster().arch(), fabric_tensix_config_phys);
+        tt_metal::resolve_dispatch_core_axis(dispatch_core_config, env.get_cluster().arch(), fabric_tensix_config_phys);
 
     uint64_t config_hash = ((uint8_t)(get_core_type_from_config(dispatch_core_config))) |
                            ((uint64_t)(resolved_axis_phys) << 4) | ((uint64_t)num_hw_cqs << 8) |

--- a/tt_metal/llrt/core_descriptor.hpp
+++ b/tt_metal/llrt/core_descriptor.hpp
@@ -17,6 +17,8 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/dispatch_core_common.hpp>
 #include "common/core_coord.hpp"
+#include "impl/context/context_types.hpp"
+#include "impl/context/metal_env_impl.hpp"
 
 namespace tt {
 
@@ -41,32 +43,50 @@ inline const std::string& get_product_name(tt::ARCH arch, uint32_t num_harvested
 }
 
 const core_descriptor_t& get_core_descriptor_config(
-    ChipId device_id, uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig& dispatch_core_config);
+    tt::tt_metal::MetalEnvImpl& env,
+    ChipId device_id,
+    uint8_t num_hw_cqs,
+    const tt_metal::DispatchCoreConfig& dispatch_core_config);
 
 const std::tuple<uint32_t, CoreRange>& get_physical_worker_grid_config(
-    ChipId device_id, uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig& dispatch_core_config);
+    tt::tt_metal::MetalEnvImpl& env,
+    ChipId device_id,
+    uint8_t num_hw_cqs,
+    const tt_metal::DispatchCoreConfig& dispatch_core_config);
 
 inline const CoreCoord& get_compute_grid_size(
-    ChipId device_id, const uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig& dispatch_core_config) {
-    const core_descriptor_t& core_desc = get_core_descriptor_config(device_id, num_hw_cqs, dispatch_core_config);
+    tt::tt_metal::MetalEnvImpl& env,
+    ChipId device_id,
+    const uint8_t num_hw_cqs,
+    const tt_metal::DispatchCoreConfig& dispatch_core_config) {
+    const core_descriptor_t& core_desc = get_core_descriptor_config(env, device_id, num_hw_cqs, dispatch_core_config);
     return core_desc.compute_grid_size;
 }
 
 inline const std::vector<CoreCoord>& get_logical_compute_cores(
-    ChipId device_id, const uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig& dispatch_core_config) {
-    const core_descriptor_t& core_desc = get_core_descriptor_config(device_id, num_hw_cqs, dispatch_core_config);
+    tt::tt_metal::MetalEnvImpl& env,
+    ChipId device_id,
+    const uint8_t num_hw_cqs,
+    const tt_metal::DispatchCoreConfig& dispatch_core_config) {
+    const core_descriptor_t& core_desc = get_core_descriptor_config(env, device_id, num_hw_cqs, dispatch_core_config);
     return core_desc.logical_compute_cores;
 }
 
 inline const std::vector<CoreCoord>& get_logical_dispatch_cores(
-    ChipId device_id, const uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig& dispatch_core_config) {
-    const core_descriptor_t& core_desc = get_core_descriptor_config(device_id, num_hw_cqs, dispatch_core_config);
+    tt::tt_metal::MetalEnvImpl& env,
+    ChipId device_id,
+    const uint8_t num_hw_cqs,
+    const tt_metal::DispatchCoreConfig& dispatch_core_config) {
+    const core_descriptor_t& core_desc = get_core_descriptor_config(env, device_id, num_hw_cqs, dispatch_core_config);
     return core_desc.logical_dispatch_cores;
 }
 
 inline const std::vector<CoreCoord>& get_logical_fabric_mux_cores(
-    ChipId device_id, const uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig& dispatch_core_config) {
-    const core_descriptor_t& core_desc = get_core_descriptor_config(device_id, num_hw_cqs, dispatch_core_config);
+    tt::tt_metal::MetalEnvImpl& env,
+    ChipId device_id,
+    const uint8_t num_hw_cqs,
+    const tt_metal::DispatchCoreConfig& dispatch_core_config) {
+    const core_descriptor_t& core_desc = get_core_descriptor_config(env, device_id, num_hw_cqs, dispatch_core_config);
     return core_desc.logical_fabric_mux_cores;
 }
 

--- a/tt_metal/sources.cmake
+++ b/tt_metal/sources.cmake
@@ -109,6 +109,7 @@ set(TT_METAL_PUBLIC_API
     api/tt-metalium/experimental/udm/mesh_semaphore.hpp
     api/tt-metalium/experimental/udm/mesh_tensor_builder.hpp
     api/tt-metalium/experimental/udm/mesh_utils.hpp
+    api/tt-metalium/experimental/context/metal_env.hpp
 )
 
 set(TT_METAL_SOURCES

--- a/tt_metal/tools/watcher_dump/watcher_dump.cpp
+++ b/tt_metal/tools/watcher_dump/watcher_dump.cpp
@@ -30,7 +30,6 @@ string logfile_name = "cq_dump.txt";
 
 void dump_data(
     MetalEnv& env,
-    WatcherServer& watcher_server,
     vector<ChipId>& device_ids,
     bool dump_watcher,
     bool dump_cqs,
@@ -71,8 +70,10 @@ void dump_data(
 
     // Watcher doesn't have kernel ids since we didn't create them here, need to read from file.
     if (dump_watcher) {
-        cout << "Dumping Watcher Log into: " << watcher_server.log_file_name() << endl;
-        watcher_server.isolated_dump(device_ids);
+        WatcherServer* watcher_server = MetalContext::instance().watcher_server().get();
+        TT_FATAL(watcher_server != nullptr, "Watcher server is null after device initialization");
+        cout << "Dumping Watcher Log into: " << watcher_server->log_file_name() << endl;
+        watcher_server->isolated_dump(device_ids);
     }
 
     // Dump noc data if requested
@@ -105,8 +106,6 @@ int main(int argc, char* argv[]) {
     // Default devices is all of them.
     vector<ChipId> device_ids;
     MetalEnv& env = MetalContext::instance().get_env();
-    WatcherServer* watcher_server = MetalContext::instance().watcher_server().get();
-    TT_FATAL(watcher_server != nullptr, "Watcher server is null");
     auto num_devices = tt::tt_metal::GetNumAvailableDevices();
     device_ids.reserve(num_devices);
     for (ChipId id = 0; id < num_devices; id++) {
@@ -167,15 +166,6 @@ int main(int argc, char* argv[]) {
     }
 
     // Call dump function with user config.
-    dump_data(
-        env,
-        *watcher_server,
-        device_ids,
-        dump_watcher,
-        dump_cqs,
-        dump_cqs_raw_data,
-        dump_noc_xfers,
-        eth_dispatch,
-        num_hw_cqs);
+    dump_data(env, device_ids, dump_watcher, dump_cqs, dump_cqs_raw_data, dump_noc_xfers, eth_dispatch, num_hw_cqs);
     std::cout << "Watcher dump tool finished." << std::endl;
 }

--- a/tt_metal/tools/watcher_dump/watcher_dump.cpp
+++ b/tt_metal/tools/watcher_dump/watcher_dump.cpp
@@ -8,9 +8,12 @@
 #include <string>
 #include <vector>
 
+#include "impl/context/context_types.hpp"
 #include "device.hpp"
 #include "dispatch_core_common.hpp"
 #include "impl/context/metal_context.hpp"
+#include "impl/context/metal_env_accessor.hpp"
+#include "impl/context/metal_env_impl.hpp"
 #include "impl/debug/noc_logging.hpp"
 #include "impl/dispatch/debug_tools.hpp"
 #include "impl/dispatch/system_memory_manager.hpp"
@@ -26,6 +29,8 @@ string output_dir_name = "generated/watcher/";
 string logfile_name = "cq_dump.txt";
 
 void dump_data(
+    MetalEnv& env,
+    WatcherServer& watcher_server,
     vector<ChipId>& device_ids,
     bool dump_watcher,
     bool dump_cqs,
@@ -33,15 +38,15 @@ void dump_data(
     bool dump_noc_xfers,
     bool eth_dispatch,
     int num_hw_cqs) {
+    MetalEnvImpl& env_impl = MetalEnvAccessor(env).impl();
     // Don't clear L1, this way we can dump the state.
-    tt_metal::MetalContext::instance().rtoptions().set_clear_l1(false);
+    env_impl.get_rtoptions().set_clear_l1(false);
 
     // Watcher should be disabled for this, so we don't (1) overwrite the kernel_names.txt and (2) do any other dumping
     // than the one we want.
-    tt_metal::MetalContext::instance().rtoptions().set_watcher_enabled(false);
+    env_impl.get_rtoptions().set_watcher_enabled(false);
 
-    std::filesystem::path parent_dir(
-        tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir() + output_dir_name);
+    std::filesystem::path parent_dir(env_impl.get_rtoptions().get_root_dir() + output_dir_name);
     std::filesystem::path cq_dir(parent_dir.string() + "command_queue_dump/");
     std::filesystem::create_directories(cq_dir);
 
@@ -58,20 +63,22 @@ void dump_data(
         devices.push_back(std::unique_ptr<IDevice>(device));
         if (dump_cqs) {
             cout << "Dumping Command Queues into: " << cq_dir.string() << endl;
-            std::unique_ptr<SystemMemoryManager> sysmem_manager = std::make_unique<SystemMemoryManager>(id, num_hw_cqs);
+            std::unique_ptr<SystemMemoryManager> sysmem_manager =
+                std::make_unique<SystemMemoryManager>(DEFAULT_CONTEXT_ID, id, num_hw_cqs);
             internal::dump_cqs(cq_file, iq_file, *sysmem_manager, dump_cqs_raw_data);
         }
     }
 
     // Watcher doesn't have kernel ids since we didn't create them here, need to read from file.
     if (dump_watcher) {
-        cout << "Dumping Watcher Log into: " << MetalContext::instance().watcher_server()->log_file_name() << endl;
-        MetalContext::instance().watcher_server()->isolated_dump(device_ids);
+        cout << "Dumping Watcher Log into: " << watcher_server.log_file_name() << endl;
+        watcher_server.isolated_dump(device_ids);
     }
 
     // Dump noc data if requested
     if (dump_noc_xfers) {
-        DumpNocData(device_ids);
+        DispatchCoreConfig dispatch_core_config{eth_dispatch ? DispatchCoreType::ETH : DispatchCoreType::WORKER};
+        DumpNocData(env_impl, device_ids, num_hw_cqs, dispatch_core_config);
     }
 }
 
@@ -97,6 +104,9 @@ int main(int argc, char* argv[]) {
     cout << "Running watcher dump tool..." << endl;
     // Default devices is all of them.
     vector<ChipId> device_ids;
+    MetalEnv& env = MetalContext::instance().get_env();
+    WatcherServer* watcher_server = MetalContext::instance().watcher_server().get();
+    TT_FATAL(watcher_server != nullptr, "Watcher server is null");
     auto num_devices = tt::tt_metal::GetNumAvailableDevices();
     device_ids.reserve(num_devices);
     for (ChipId id = 0; id < num_devices; id++) {
@@ -145,7 +155,7 @@ int main(int argc, char* argv[]) {
             cout << "CQ raw data dumping currently disabled" << endl;
             // dump_cqs_raw_data = true;
         } else if (s == "--dump-noc-transfer-data") {
-            tt::tt_metal::MetalContext::instance().rtoptions().set_record_noc_transfers(true);
+            MetalEnvAccessor(env).impl().get_rtoptions().set_record_noc_transfers(true);
             dump_noc_xfers = true;
         } else if (s == "--eth-dispatch") {
             eth_dispatch = true;
@@ -157,6 +167,15 @@ int main(int argc, char* argv[]) {
     }
 
     // Call dump function with user config.
-    dump_data(device_ids, dump_watcher, dump_cqs, dump_cqs_raw_data, dump_noc_xfers, eth_dispatch, num_hw_cqs);
+    dump_data(
+        env,
+        *watcher_server,
+        device_ids,
+        dump_watcher,
+        dump_cqs,
+        dump_cqs_raw_data,
+        dump_noc_xfers,
+        eth_dispatch,
+        num_hw_cqs);
     std::cout << "Watcher dump tool finished." << std::endl;
 }

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -8,6 +8,7 @@
 #include <enchantum/entries.hpp>
 #include <tt_stl/assert.hpp>
 #include <cstdint>
+#include "context/context_types.hpp"
 #include "context/metal_env_accessor.hpp"
 #include "device/device_manager.hpp"
 #include <global_circular_buffer.hpp>
@@ -1628,6 +1629,11 @@ uint8_t PopCurrentCommandQueueIdForThread() {
 }
 
 uint8_t GetCurrentCommandQueueIdForThread() {
+    // TODO: Make GetCurrentCommandQueueIdForThread work for non-default contexts
+    // https://github.com/tenstorrent/tt-metal/issues/39819
+    if (!MetalContext::instance_exists(DEFAULT_CONTEXT_ID)) {
+        return 0;
+    }
     const auto& cq_stack = MetalContext::instance().get_command_queue_id_stack_for_thread();
     if (cq_stack.empty()) {
         return 0;

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -8,6 +8,7 @@
 #include <enchantum/entries.hpp>
 #include <tt_stl/assert.hpp>
 #include <cstdint>
+#include "context/metal_env_accessor.hpp"
 #include "device/device_manager.hpp"
 #include <global_circular_buffer.hpp>
 #include <global_semaphore.hpp>
@@ -403,6 +404,51 @@ std::map<ChipId, IDevice*> CreateDevices(
     return ret_devices;
 }
 
+}  // namespace detail
+
+namespace experimental {
+
+std::map<ChipId, IDevice*> CreateDevices(
+    ContextId context_id,
+    const std::vector<ChipId>& device_ids,
+    uint8_t num_hw_cqs,
+    size_t l1_small_size,
+    size_t trace_region_size,
+    const DispatchCoreConfig& dispatch_core_config,
+    const std::vector<uint32_t>& /*l1_bank_remap*/,
+    size_t worker_l1_size,
+    bool init_profiler,
+    bool initialize_fabric_and_dispatch_fw) {
+    ZoneScoped;
+    auto& ctx = MetalContext::instance(context_id);
+    bool is_galaxy = ctx.get_cluster().is_galaxy_cluster();
+    ctx.initialize_device_manager(
+        device_ids,
+        num_hw_cqs,
+        l1_small_size,
+        trace_region_size,
+        dispatch_core_config,
+        {},
+        worker_l1_size,
+        init_profiler,
+        initialize_fabric_and_dispatch_fw);
+
+    const auto devices = ctx.device_manager()->get_all_active_devices();
+    std::map<ChipId, IDevice*> ret_devices;
+    for (IDevice* dev : devices) {
+        if (is_galaxy and dev->is_mmio_capable()) {
+            continue;
+        }
+        ret_devices.insert({dev->id(), dev});
+    }
+
+    return ret_devices;
+}
+
+}  // namespace experimental
+
+namespace detail {
+
 void CloseDevices(const std::map<ChipId, IDevice*>& devices) {
     std::vector<IDevice*> devices_to_close;
     devices_to_close.reserve(devices.size());
@@ -414,7 +460,7 @@ void CloseDevices(const std::map<ChipId, IDevice*>& devices) {
 
 void ReleaseOwnership() {
     experimental::DispatchContext::get().reset();
-    MetalContext::destroy_instance();
+    MetalContext::destroy_all_instances();
 }
 
 void print_page(
@@ -1050,10 +1096,13 @@ IDevice* CreateDevice(
 IDevice* CreateDeviceMinimal(
     ChipId device_id, const uint8_t num_hw_cqs, const DispatchCoreConfig& dispatch_core_config) {
     ZoneScoped;
-    MetalContext::instance().initialize(dispatch_core_config, num_hw_cqs, {}, DEFAULT_L1_SMALL_SIZE, true);
-    auto* dev = new Device(device_id, num_hw_cqs, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, {}, true);
-    auto& control_plane = MetalContext::instance().get_control_plane();
-    MetalContext::instance().get_cluster().set_internal_routing_info_for_ethernet_cores(control_plane, true);
+    auto& ctx = MetalContext::instance();  // runtime state
+    auto& env = ctx.get_env();             // default low level state
+    ctx.initialize(dispatch_core_config, num_hw_cqs, {}, DEFAULT_L1_SMALL_SIZE, true);
+    auto* dev =
+        new Device(&env, &ctx, device_id, num_hw_cqs, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, {}, true);
+    auto& control_plane = MetalEnvAccessor(env).impl().get_control_plane();
+    MetalEnvAccessor(env).impl().get_cluster().set_internal_routing_info_for_ethernet_cores(control_plane, true);
     return dev;
 }
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/38445

### Problem description
Cannot open both mock devices at the same time as silicon device.
We now have a experimental `MetalEnv` object which would allows users to open multiple cluster instances.
Update the codebase to refer to the correct `MetalEnv` and `MetalContext` instance.

### What's changed
- Add experimental APIs to `MetalEnv` to allow the user to create a mesh device using the given env. This allows creating MeshDevice on a silicon cluster at the same time as one or more mock clusters.
  - A private constructor was added to mesh_device.hpp. Only accessible by the MetalEnv.

- Add `MetalContextIntegrationTest` unit tests. These unit tests verify one or many mock devices can coexist at the same time as a silicon device and assert that we don't implicitly init the legacy MetalContext when performing various CQ operations.

- When opening a MeshDevice, the MetalEnv will register a MetalContext instance and pass that instance handle to the MeshDevice. The MeshDevice will propagate this handle to it's child objects, such as the CQ, so that they reference the correct MetalContext instance and do not implicitly init the MetalContext which is the legacy path.

- When the MeshDevice created from the MetalEnv closes, it will destroy the MetalContext instance that it created. Note, multiple MeshDevices from the same MetalEnv/SystemMesh are not supported right now (see https://github.com/tenstorrent/tt-metal/issues/21500). We will have to uplift the teardown to MetalEnv to check all MeshDevices are closed.

- Most LOC changed are for plumbing the MetalContext and MetalEnv instance to the child objects. In some cases the MetalContext/MetalEnv are not available because the object was not created in the initialization. When this happens, we use the ContextID from the MeshDevice/DeviceImpl and the MetalEnv can be obtained from calling `MetalContext::instance(context_id).get_env()`

**Workarounds in place to prevent implicit instantiation of the default / silicon cluster MetalContext** -> Created TODO tickets.
1. if the MeshDevice or IDevice is available, the `extract_context_id` helper function can be used to get the ContextID, and then query MetalContext by calling `MetalContext::instance(cid)`. Note, when an IDevice is given to`extract_context_id` is will do a dynamic_cast to the impl so it shouldn't be used on any hot paths.
2. Otherwise, check if the MetalContext exists with `MetalContext::instance(DEFAULT_CONTEXT_ID)`. If it doesn't exist, then return some default value.

Follow up work to further plumb the MetalEnv and MetalContext references are documented in https://github.com/tenstorrent/tt-metal/milestone/49

### Checklist

BH E2E Multi Card: Tests passed. One of them had a network error uploading results
https://github.com/tenstorrent/tt-metal/actions/runs/23208769731

BH Galaxy Quick
https://github.com/tenstorrent/tt-metal/actions/runs/23164997170

WH Galaxy Quick
https://github.com/tenstorrent/tt-metal/actions/runs/23164990586

Profiler CI
https://github.com/tenstorrent/tt-metal/actions/runs/23164299357

metal - Run Microbenchmarks: Same failure as main on BH uBench 
https://github.com/tenstorrent/tt-metal/actions/runs/23165699175

Galaxy Deepseek Tests
https://github.com/tenstorrent/tt-metal/actions/runs/23165007231

Deepseek Multi-Host Demo Test
https://github.com/tenstorrent/tt-metal/actions/runs/23212253712

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nhuang/metal-object-6)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch%3Anhuang%2Fmetal-object-6)
- [ ] [![Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nhuang%2Fmetal-object-6)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch%3Anhuang%2Fmetal-object-6)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nhuang/metal-object-6)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=metal-object-6)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
