### PR TITLE
Add support for semaphores in Quasar

### DIFF
--- a/tests/tt_metal/tt_metal/sources.cmake
+++ b/tests/tt_metal/tt_metal/sources.cmake
@@ -25,6 +25,7 @@ set(UNIT_TESTS_LEGACY_SRC
     test_multi_dm_add_two_ints.cpp
     test_multiple_programs.cpp
     test_quasar_compute_kernels.cpp
+    test_quasar_semaphores.cpp
     test_sdpa_reduce_c.cpp
     test_single_dm_l1_write.cpp
     test_stress_noc_mcast.cpp

--- a/tests/tt_metal/tt_metal/test_dm_loopback.cpp
+++ b/tests/tt_metal/tt_metal/test_dm_loopback.cpp
@@ -40,13 +40,13 @@ TEST_F(MeshDeviceSingleCardFixture, DmLoopback) {
     constexpr CoreCoord core = {0, 0};
 
     // These addresses have been randomly chosen
-    uint32_t signal_address = 999 * 1024;
+    // uint32_t signal_address = 999 * 1024;
     uint32_t l1_address = 1000 * 1024;
     uint32_t dram_address = 30000 * 1024;
     std::vector<uint32_t> value = {0x12345678};
 
-    std::vector<uint32_t> signal = {0};
-    tt_metal::detail::WriteToDeviceL1(dev, core, signal_address, signal);
+    // std::vector<uint32_t> signal = {0};
+    // tt_metal::detail::WriteToDeviceL1(dev, core, signal_address, signal);
     tt_metal::detail::WriteToDeviceDRAMChannel(dev, 0, dram_address, value);
     MetalContext::instance().get_cluster().dram_barrier(dev->id());
 
@@ -55,6 +55,8 @@ TEST_F(MeshDeviceSingleCardFixture, DmLoopback) {
     distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
     Program program = CreateProgram();
 
+    KernelHandle kernel_handle = tt_metal::CreateSemaphore(program, core, 0);
+
     std::vector<KernelHandle> dm_dram_to_l1_kernels;
     dm_dram_to_l1_kernels.reserve(4);
     for (uint32_t i = 0; i < 4; i++) {
@@ -62,7 +64,8 @@ TEST_F(MeshDeviceSingleCardFixture, DmLoopback) {
             program,
             OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_to_l1.cpp",
             core,
-            experimental::quasar::QuasarDataMovementConfig{.num_threads_per_cluster = 1}));
+            experimental::quasar::QuasarDataMovementConfig{
+                .num_threads_per_cluster = 1, .compile_args = {kernel_handle}}));
     }
 
     std::vector<KernelHandle> dm_l1_to_dram_kernels;
@@ -72,29 +75,25 @@ TEST_F(MeshDeviceSingleCardFixture, DmLoopback) {
             program,
             OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/l1_to_dram.cpp",
             core,
-            experimental::quasar::QuasarDataMovementConfig{.num_threads_per_cluster = 1}));
+            experimental::quasar::QuasarDataMovementConfig{
+                .num_threads_per_cluster = 1, .compile_args = {kernel_handle}}));
     }
 
+    uint32_t signal_value = 0;
     for (uint32_t i = 0; i < 4; i++) {
-        SetRuntimeArgs(
-            program,
-            dm_dram_to_l1_kernels[i],
-            core,
-            {dram_address, l1_address, MEM_L1_UNCACHED_BASE + signal_address, 4, 0, signal[0]});
-        signal[0]++;
+        SetRuntimeArgs(program, dm_dram_to_l1_kernels[i], core, {dram_address, l1_address, 4, 0, signal_value});
         dram_address += 1024;
+        signal_value++;
 
-        SetRuntimeArgs(
-            program,
-            dm_l1_to_dram_kernels[i],
-            core,
-            {dram_address, l1_address, MEM_L1_UNCACHED_BASE + signal_address, 4, 0, signal[0]});
-        signal[0]++;
+        SetRuntimeArgs(program, dm_l1_to_dram_kernels[i], core, {dram_address, l1_address, 4, 0, signal_value});
         l1_address += sizeof(uint32_t);
+        signal_value++;
     }
 
     workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, true);
+
+    log_info(LogTest, "Reading from DRAM");
 
     std::vector<uint32_t> outputs{0};
     tt_metal::detail::ReadFromDeviceDRAMChannel(dev, 0, dram_address, sizeof(uint32_t), outputs);

--- a/tests/tt_metal/tt_metal/test_dm_loopback.cpp
+++ b/tests/tt_metal/tt_metal/test_dm_loopback.cpp
@@ -9,7 +9,6 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/experimental/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
-#include "hw/inc/internal/tt-2xx/quasar/dev_mem_map.h"
 #include "impl/context/metal_context.hpp"
 #include "llrt/tt_cluster.hpp"
 
@@ -41,7 +40,9 @@ TEST_F(MeshDeviceSingleCardFixture, DmLoopback) {
 
     // These addresses have been randomly chosen
     uint32_t l1_address = 1000 * 1024;
-    uint32_t dram_address = 30000 * 1024;
+    uint32_t dram_bank_size = MetalContext::instance().hal().get_dev_size(HalDramMemAddrType::UNRESERVED);
+    std::cout << "DRAM bank size: " << dram_bank_size << std::endl;
+    uint32_t dram_address = dram_bank_size + 1024;
     std::vector<uint32_t> value = {0x12345678};
 
     tt_metal::detail::WriteToDeviceDRAMChannel(dev, 0, dram_address, value);
@@ -56,7 +57,7 @@ TEST_F(MeshDeviceSingleCardFixture, DmLoopback) {
 
     std::vector<KernelHandle> dm_dram_to_l1_kernels;
     dm_dram_to_l1_kernels.reserve(4);
-    for (uint32_t i = 0; i < 4; i++) {
+    for (uint32_t i = 0; i < 1; i++) {
         dm_dram_to_l1_kernels.push_back(experimental::quasar::CreateKernel(
             program,
             OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_to_l1.cpp",
@@ -66,7 +67,7 @@ TEST_F(MeshDeviceSingleCardFixture, DmLoopback) {
 
     std::vector<KernelHandle> dm_l1_to_dram_kernels;
     dm_l1_to_dram_kernels.reserve(4);
-    for (uint32_t i = 0; i < 4; i++) {
+    for (uint32_t i = 0; i < 1; i++) {
         dm_l1_to_dram_kernels.push_back(experimental::quasar::CreateKernel(
             program,
             OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/l1_to_dram.cpp",
@@ -74,8 +75,9 @@ TEST_F(MeshDeviceSingleCardFixture, DmLoopback) {
             experimental::quasar::QuasarDataMovementConfig{.num_threads_per_cluster = 1, .compile_args = {sem_id}}));
     }
 
+    dram_address = 1024;
     uint32_t signal_value = 0;
-    for (uint32_t i = 0; i < 4; i++) {
+    for (uint32_t i = 0; i < 1; i++) {
         SetRuntimeArgs(program, dm_dram_to_l1_kernels[i], core, {dram_address, l1_address, 4, 0, signal_value});
         dram_address += 1024;
         signal_value++;
@@ -91,7 +93,7 @@ TEST_F(MeshDeviceSingleCardFixture, DmLoopback) {
     log_info(LogTest, "Reading from DRAM");
 
     std::vector<uint32_t> outputs{0};
-    tt_metal::detail::ReadFromDeviceDRAMChannel(dev, 0, dram_address, sizeof(uint32_t), outputs);
+    tt_metal::detail::ReadFromDeviceDRAMChannel(dev, 0, dram_bank_size + 1024, sizeof(uint32_t), outputs);
 
     ASSERT_EQ(outputs[0], value[0]) << "Got the value " << std::hex << outputs[0] << " instead of " << value[0];
 }

--- a/tests/tt_metal/tt_metal/test_dm_loopback.cpp
+++ b/tests/tt_metal/tt_metal/test_dm_loopback.cpp
@@ -40,13 +40,10 @@ TEST_F(MeshDeviceSingleCardFixture, DmLoopback) {
     constexpr CoreCoord core = {0, 0};
 
     // These addresses have been randomly chosen
-    // uint32_t signal_address = 999 * 1024;
     uint32_t l1_address = 1000 * 1024;
     uint32_t dram_address = 30000 * 1024;
     std::vector<uint32_t> value = {0x12345678};
 
-    // std::vector<uint32_t> signal = {0};
-    // tt_metal::detail::WriteToDeviceL1(dev, core, signal_address, signal);
     tt_metal::detail::WriteToDeviceDRAMChannel(dev, 0, dram_address, value);
     MetalContext::instance().get_cluster().dram_barrier(dev->id());
 
@@ -55,7 +52,7 @@ TEST_F(MeshDeviceSingleCardFixture, DmLoopback) {
     distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
     Program program = CreateProgram();
 
-    KernelHandle kernel_handle = tt_metal::CreateSemaphore(program, core, 0);
+    const uint32_t sem_id = tt_metal::CreateSemaphore(program, core, 0);
 
     std::vector<KernelHandle> dm_dram_to_l1_kernels;
     dm_dram_to_l1_kernels.reserve(4);
@@ -64,8 +61,7 @@ TEST_F(MeshDeviceSingleCardFixture, DmLoopback) {
             program,
             OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_to_l1.cpp",
             core,
-            experimental::quasar::QuasarDataMovementConfig{
-                .num_threads_per_cluster = 1, .compile_args = {kernel_handle}}));
+            experimental::quasar::QuasarDataMovementConfig{.num_threads_per_cluster = 1, .compile_args = {sem_id}}));
     }
 
     std::vector<KernelHandle> dm_l1_to_dram_kernels;
@@ -75,8 +71,7 @@ TEST_F(MeshDeviceSingleCardFixture, DmLoopback) {
             program,
             OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/l1_to_dram.cpp",
             core,
-            experimental::quasar::QuasarDataMovementConfig{
-                .num_threads_per_cluster = 1, .compile_args = {kernel_handle}}));
+            experimental::quasar::QuasarDataMovementConfig{.num_threads_per_cluster = 1, .compile_args = {sem_id}}));
     }
 
     uint32_t signal_value = 0;

--- a/tests/tt_metal/tt_metal/test_dm_loopback.cpp
+++ b/tests/tt_metal/tt_metal/test_dm_loopback.cpp
@@ -40,9 +40,7 @@ TEST_F(MeshDeviceSingleCardFixture, DmLoopback) {
 
     // These addresses have been randomly chosen
     uint32_t l1_address = 1000 * 1024;
-    uint32_t dram_bank_size = MetalContext::instance().hal().get_dev_size(HalDramMemAddrType::UNRESERVED);
-    std::cout << "DRAM bank size: " << dram_bank_size << std::endl;
-    uint32_t dram_address = dram_bank_size + 1024;
+    uint32_t dram_address = 30000 * 1024;
     std::vector<uint32_t> value = {0x12345678};
 
     tt_metal::detail::WriteToDeviceDRAMChannel(dev, 0, dram_address, value);
@@ -57,7 +55,7 @@ TEST_F(MeshDeviceSingleCardFixture, DmLoopback) {
 
     std::vector<KernelHandle> dm_dram_to_l1_kernels;
     dm_dram_to_l1_kernels.reserve(4);
-    for (uint32_t i = 0; i < 1; i++) {
+    for (uint32_t i = 0; i < 4; i++) {
         dm_dram_to_l1_kernels.push_back(experimental::quasar::CreateKernel(
             program,
             OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_to_l1.cpp",
@@ -67,7 +65,7 @@ TEST_F(MeshDeviceSingleCardFixture, DmLoopback) {
 
     std::vector<KernelHandle> dm_l1_to_dram_kernels;
     dm_l1_to_dram_kernels.reserve(4);
-    for (uint32_t i = 0; i < 1; i++) {
+    for (uint32_t i = 0; i < 4; i++) {
         dm_l1_to_dram_kernels.push_back(experimental::quasar::CreateKernel(
             program,
             OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/l1_to_dram.cpp",
@@ -75,9 +73,8 @@ TEST_F(MeshDeviceSingleCardFixture, DmLoopback) {
             experimental::quasar::QuasarDataMovementConfig{.num_threads_per_cluster = 1, .compile_args = {sem_id}}));
     }
 
-    dram_address = 1024;
     uint32_t signal_value = 0;
-    for (uint32_t i = 0; i < 1; i++) {
+    for (uint32_t i = 0; i < 4; i++) {
         SetRuntimeArgs(program, dm_dram_to_l1_kernels[i], core, {dram_address, l1_address, 4, 0, signal_value});
         dram_address += 1024;
         signal_value++;
@@ -90,10 +87,8 @@ TEST_F(MeshDeviceSingleCardFixture, DmLoopback) {
     workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, true);
 
-    log_info(LogTest, "Reading from DRAM");
-
     std::vector<uint32_t> outputs{0};
-    tt_metal::detail::ReadFromDeviceDRAMChannel(dev, 0, dram_bank_size + 1024, sizeof(uint32_t), outputs);
+    tt_metal::detail::ReadFromDeviceDRAMChannel(dev, 0, dram_address, sizeof(uint32_t), outputs);
 
     ASSERT_EQ(outputs[0], value[0]) << "Got the value " << std::hex << outputs[0] << " instead of " << value[0];
 }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/risc_l1_read_write.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/risc_l1_read_write.cpp
@@ -15,8 +15,6 @@ void kernel_main() {
     const uint32_t base_src_l1_address = get_arg_val<uint32_t>(0);
     const uint32_t base_dst_l1_address = get_arg_val<uint32_t>(1);
 
-    // DPRINT << "Neo ID: " << neo_id << ENDL();
-
     ckernel::Semaphore semaphore(get_compile_time_arg_val(0));
     const uint32_t base_semaphore_value = get_compile_time_arg_val(1);
     semaphore.wait(base_semaphore_value + neo_id);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/risc_l1_read_write.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/risc_l1_read_write.cpp
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/debug/dprint.h"
+#include "api/compute/common.h"
+#include "api/compute/experimental/semaphore.h"
+#include "dev_mem_map.h"
+#include "ckernel.h"
+
+void kernel_main() {
+#ifdef TRISC_MATH
+    const uint32_t neo_id = ckernel::csr_read<ckernel::CSR::NEO_ID>();
+
+    const uint32_t base_src_l1_address = get_arg_val<uint32_t>(0);
+    const uint32_t base_dst_l1_address = get_arg_val<uint32_t>(1);
+
+    // DPRINT << "Neo ID: " << neo_id << ENDL();
+
+    ckernel::Semaphore semaphore(get_compile_time_arg_val(0));
+    const uint32_t base_semaphore_value = get_compile_time_arg_val(1);
+    semaphore.wait(base_semaphore_value + neo_id);
+
+    const uint32_t l1_src_address = base_src_l1_address + neo_id * sizeof(uint32_t);
+    const uint32_t l1_dst_address = base_dst_l1_address + neo_id * sizeof(uint32_t);
+
+    DPRINT << "Reading from " << l1_src_address << " and writing to " << l1_dst_address << ENDL();
+
+    *((uint32_t*)(l1_dst_address + MEM_L1_UNCACHED_BASE)) = *((uint32_t*)(l1_src_address + MEM_L1_UNCACHED_BASE));
+
+    semaphore.up(1);
+#endif
+}

--- a/tests/tt_metal/tt_metal/test_kernels/compute/transform_pipeline.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/transform_pipeline.cpp
@@ -1,0 +1,32 @@
+#include "api/debug/dprint.h"
+#include "api/compute/common.h"
+#include "api/compute/experimental/semaphore.h"
+#include "dev_mem_map.h"
+#include "ckernel.h"
+
+void kernel_main() {
+#ifdef TRISC_MATH
+    ckernel::Semaphore sem_in(get_compile_time_arg_val(0));
+    ckernel::Semaphore sem_out(get_compile_time_arg_val(1));
+    const uint32_t num_elements = get_compile_time_arg_val(2);
+
+    const uint32_t buf_a = get_arg_val<uint32_t>(0);
+    const uint32_t buf_b = get_arg_val<uint32_t>(1);
+
+    for (uint32_t i = 0; i < num_elements; i++) {
+        sem_in.down(1);
+
+        const uint32_t offset = i * static_cast<uint32_t>(sizeof(uint32_t));
+        const uint32_t buf_a_addr = buf_a + MEM_L1_UNCACHED_BASE + offset;
+        const uint32_t buf_b_addr = buf_b + MEM_L1_UNCACHED_BASE + offset;
+        const uint32_t val = *((volatile uint32_t*)(buf_a_addr));
+        const uint32_t new_val = val + 1;
+        *((volatile uint32_t*)(buf_b_addr)) = new_val;
+
+        DPRINT << "Read the value " << val << " from L1 address " << buf_a_addr << " and wrote the value " << new_val
+               << " to L1 address " << buf_b_addr << ENDL();
+
+        sem_out.up(1);
+    }
+#endif
+}

--- a/tests/tt_metal/tt_metal/test_kernels/compute/transform_pipeline.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/transform_pipeline.cpp
@@ -6,15 +6,23 @@
 
 void kernel_main() {
 #ifdef TRISC_MATH
-    ckernel::Semaphore sem_in(get_compile_time_arg_val(0));
+    const uint32_t num_elements = get_compile_time_arg_val(0);
+#if defined(INCOMING_SEM) && defined(OUTGOING_SEM)
+    ckernel::Semaphore sem_in(get_compile_time_arg_val(1));
+    ckernel::Semaphore sem_out(get_compile_time_arg_val(2));
+#elif defined(INCOMING_SEM)
+    ckernel::Semaphore sem_in(get_compile_time_arg_val(1));
+#elif defined(OUTGOING_SEM)
     ckernel::Semaphore sem_out(get_compile_time_arg_val(1));
-    const uint32_t num_elements = get_compile_time_arg_val(2);
+#endif
 
     const uint32_t buf_a = get_arg_val<uint32_t>(0);
     const uint32_t buf_b = get_arg_val<uint32_t>(1);
 
     for (uint32_t i = 0; i < num_elements; i++) {
+#if defined(INCOMING_SEM)
         sem_in.down(1);
+#endif
 
         const uint32_t offset = i * static_cast<uint32_t>(sizeof(uint32_t));
         const uint32_t buf_a_addr = buf_a + MEM_L1_UNCACHED_BASE + offset;
@@ -26,7 +34,9 @@ void kernel_main() {
         DPRINT << "Read the value " << val << " from L1 address " << buf_a_addr << " and wrote the value " << new_val
                << " to L1 address " << buf_b_addr << ENDL();
 
+#if defined(OUTGOING_SEM)
         sem_out.up(1);
+#endif
     }
 #endif
 }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/transform_pipeline.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/transform_pipeline.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
 #include "api/debug/dprint.h"
 #include "api/compute/common.h"
 #include "api/compute/experimental/semaphore.h"

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_to_l1.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_to_l1.cpp
@@ -23,15 +23,11 @@ void kernel_main() {
 
     semaphore.wait(signal_value);
 
-    // volatile tt_l1_ptr std::uint32_t* signal_addr = (tt_l1_ptr uint32_t*)((uintptr_t)signal_address);
-    // while (*signal_addr != signal_value);
-
     DPRINT << "Reading " << dram_buffer_size << " bytes from DRAM address " << dram_src_address << " in bank "
            << dram_src_bank_id << " and writing it to L1 address " << l1_dst_address << ENDL();
 
     noc.async_read(src_dram, l1_buffer, dram_buffer_size, {.bank_id = dram_src_bank_id, .addr = dram_src_address}, {});
     noc.async_read_barrier();
 
-    // *signal_addr = signal_value + 1;
     semaphore.up(1);
 }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_to_l1.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_to_l1.cpp
@@ -7,21 +7,24 @@
 #include "experimental/noc.h"
 #include "experimental/core_local_mem.h"
 #include "experimental/endpoints.h"
+#include "experimental/noc_semaphore.h"
 
 void kernel_main() {
     const uint32_t dram_src_address = get_arg_val<uint32_t>(0);
     const uint32_t l1_dst_address = get_arg_val<uint32_t>(1);
-    const uint32_t signal_address = get_arg_val<uint32_t>(2);
-    const uint32_t dram_buffer_size = get_arg_val<uint32_t>(3);
-    const uint32_t dram_src_bank_id = get_arg_val<uint32_t>(4);
-    const uint32_t signal_value = get_arg_val<uint32_t>(5);
+    const uint32_t dram_buffer_size = get_arg_val<uint32_t>(2);
+    const uint32_t dram_src_bank_id = get_arg_val<uint32_t>(3);
+    const uint32_t signal_value = get_arg_val<uint32_t>(4);
 
     experimental::Noc noc;
     experimental::CoreLocalMem<std::uint32_t> l1_buffer(l1_dst_address);
     experimental::AllocatorBank<experimental::AllocatorBankType::DRAM> src_dram;
+    experimental::quasar::Semaphore semaphore(get_compile_time_arg_val(0));
 
-    volatile tt_l1_ptr std::uint32_t* signal_addr = (tt_l1_ptr uint32_t*)((uintptr_t)signal_address);
-    while (*signal_addr != signal_value);
+    semaphore.wait(signal_value);
+
+    // volatile tt_l1_ptr std::uint32_t* signal_addr = (tt_l1_ptr uint32_t*)((uintptr_t)signal_address);
+    // while (*signal_addr != signal_value);
 
     DPRINT << "Reading " << dram_buffer_size << " bytes from DRAM address " << dram_src_address << " in bank "
            << dram_src_bank_id << " and writing it to L1 address " << l1_dst_address << ENDL();
@@ -29,5 +32,6 @@ void kernel_main() {
     noc.async_read(src_dram, l1_buffer, dram_buffer_size, {.bank_id = dram_src_bank_id, .addr = dram_src_address}, {});
     noc.async_read_barrier();
 
-    *signal_addr = signal_value + 1;
+    // *signal_addr = signal_value + 1;
+    semaphore.up(1);
 }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_to_l1.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_to_l1.cpp
@@ -19,7 +19,7 @@ void kernel_main() {
     experimental::Noc noc;
     experimental::CoreLocalMem<std::uint32_t> l1_buffer(l1_dst_address);
     experimental::AllocatorBank<experimental::AllocatorBankType::DRAM> src_dram;
-    experimental::quasar::Semaphore semaphore(get_compile_time_arg_val(0));
+    experimental::Semaphore semaphore(get_compile_time_arg_val(0));
 
     semaphore.wait(signal_value);
 

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_to_l1_pipeline.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_to_l1_pipeline.cpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "api/debug/dprint.h"
+#include "experimental/noc.h"
+#include "experimental/core_local_mem.h"
+#include "experimental/endpoints.h"
+#include "experimental/noc_semaphore.h"
+
+void kernel_main() {
+    const uint32_t dram_src_address = get_arg_val<uint32_t>(0);
+    const uint32_t l1_dst_address = get_arg_val<uint32_t>(1);
+    const uint32_t num_elements = get_arg_val<uint32_t>(2);
+    const uint32_t dram_src_bank_id = get_arg_val<uint32_t>(3);
+
+    experimental::Noc noc;
+    experimental::AllocatorBank<experimental::AllocatorBankType::DRAM> src_dram;
+    experimental::Semaphore sem(get_compile_time_arg_val(0));
+#ifdef WAIT_FOR_REMOTE_SEM
+    experimental::Semaphore remote_sem(get_compile_time_arg_val(1));
+#endif
+
+    for (uint32_t i = 0; i < num_elements; i++) {
+#ifdef WAIT_FOR_REMOTE_SEM
+        remote_sem.down(1);
+#endif
+
+        const uint32_t offset = i * static_cast<uint32_t>(sizeof(uint32_t));
+        DPRINT << "Reading " << sizeof(uint32_t) << " bytes from DRAM address " << dram_src_address + offset
+               << " in bank " << dram_src_bank_id << " and writing it to L1 address " << l1_dst_address + offset
+               << ENDL();
+        experimental::CoreLocalMem<uint32_t> l1_buf(l1_dst_address + offset);
+        noc.async_read(
+            src_dram, l1_buf, sizeof(uint32_t), {.bank_id = dram_src_bank_id, .addr = dram_src_address + offset}, {});
+        noc.async_read_barrier();
+
+        sem.up(1);
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/l1_to_dram.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/l1_to_dram.cpp
@@ -19,7 +19,7 @@ void kernel_main() {
     experimental::Noc noc;
     experimental::CoreLocalMem<std::uint32_t> l1_buffer(l1_src_address);
     experimental::AllocatorBank<experimental::AllocatorBankType::DRAM> dst_dram;
-    experimental::quasar::Semaphore semaphore(get_compile_time_arg_val(0));
+    experimental::Semaphore semaphore(get_compile_time_arg_val(0));
 
     semaphore.wait(signal_value);
 

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/l1_to_dram.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/l1_to_dram.cpp
@@ -7,21 +7,21 @@
 #include "experimental/noc.h"
 #include "experimental/core_local_mem.h"
 #include "experimental/endpoints.h"
+#include "experimental/noc_semaphore.h"
 
 void kernel_main() {
     const uint32_t dram_dst_address = get_arg_val<uint32_t>(0);
     const uint32_t l1_src_address = get_arg_val<uint32_t>(1);
-    const uint32_t signal_address = get_arg_val<uint32_t>(2);
-    const uint32_t dram_buffer_size = get_arg_val<uint32_t>(3);
-    const uint32_t dram_dst_bank_id = get_arg_val<uint32_t>(4);
-    const uint32_t signal_value = get_arg_val<uint32_t>(5);
+    const uint32_t dram_buffer_size = get_arg_val<uint32_t>(2);
+    const uint32_t dram_dst_bank_id = get_arg_val<uint32_t>(3);
+    const uint32_t signal_value = get_arg_val<uint32_t>(4);
 
     experimental::Noc noc;
     experimental::CoreLocalMem<std::uint32_t> l1_buffer(l1_src_address);
     experimental::AllocatorBank<experimental::AllocatorBankType::DRAM> dst_dram;
+    experimental::quasar::Semaphore semaphore(get_compile_time_arg_val(0));
 
-    volatile tt_l1_ptr std::uint32_t* signal_addr = (tt_l1_ptr uint32_t*)((uintptr_t)signal_address);
-    while (*signal_addr != signal_value);
+    semaphore.wait(signal_value);
 
     DPRINT << "Reading " << dram_buffer_size << " bytes from L1 address " << l1_src_address
            << " and writing it to DRAM address " << dram_dst_address << " in bank " << dram_dst_bank_id << ENDL();
@@ -29,5 +29,5 @@ void kernel_main() {
     noc.async_write(l1_buffer, dst_dram, dram_buffer_size, {}, {.bank_id = dram_dst_bank_id, .addr = dram_dst_address});
     noc.async_write_barrier();
 
-    *signal_addr = signal_value + 1;
+    semaphore.up(1);
 }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/l1_to_dram_pipeline.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/l1_to_dram_pipeline.cpp
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "api/debug/dprint.h"
+#include "experimental/noc.h"
+#include "experimental/core_local_mem.h"
+#include "experimental/endpoints.h"
+#include "experimental/noc_semaphore.h"
+
+void kernel_main() {
+    const uint32_t dram_dst_address = get_arg_val<uint32_t>(0);
+    const uint32_t l1_src_address = get_arg_val<uint32_t>(1);
+    const uint32_t num_elements = get_arg_val<uint32_t>(2);
+    const uint32_t dram_dst_bank_id = get_arg_val<uint32_t>(3);
+
+    experimental::Noc noc;
+    experimental::AllocatorBank<experimental::AllocatorBankType::DRAM> dst_dram;
+    experimental::Semaphore sem(get_compile_time_arg_val(0));
+#ifdef INCREMENT_REMOTE_SEM
+    experimental::Semaphore remote_sem(get_compile_time_arg_val(1));
+    const uint32_t remote_noc_x = get_arg_val<uint32_t>(4);
+    const uint32_t remote_noc_y = get_arg_val<uint32_t>(5);
+#endif
+
+    for (uint32_t i = 0; i < num_elements; i++) {
+        sem.down(1);
+
+        const uint32_t offset = i * static_cast<uint32_t>(sizeof(uint32_t));
+        DPRINT << "Reading " << sizeof(uint32_t) << " bytes from L1 address " << l1_src_address + offset
+               << " and writing it to DRAM address " << dram_dst_address + offset << " in bank " << dram_dst_bank_id
+               << ENDL();
+        experimental::CoreLocalMem<uint32_t> l1_buf(l1_src_address + offset);
+        noc.async_write(
+            l1_buf, dst_dram, sizeof(uint32_t), {}, {.bank_id = dram_dst_bank_id, .addr = dram_dst_address + offset});
+        noc.async_write_barrier();
+
+#ifdef INCREMENT_REMOTE_SEM
+        remote_sem.up(noc, remote_noc_x, remote_noc_y, 1);
+#endif
+    }
+}

--- a/tests/tt_metal/tt_metal/test_quasar_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_semaphores.cpp
@@ -247,13 +247,14 @@ TEST_F(MeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePipeline
 
     const uint32_t sem_core_0 = CreateSemaphore(program, core_0, 0);
     const uint32_t sem_cross = CreateSemaphore(program, CoreRange(core_0, core_1), 0);
-    const uint32_t sem_core_1 = CreateSemaphore(program, core_1, 0);
+    const uint32_t sem0_core_1 = CreateSemaphore(program, core_1, 0);
+    const uint32_t sem1_core_1 = CreateSemaphore(program, core_1, 0);
 
-    // const uint32_t dram_bank_size = MetalContext::instance().hal().get_dev_size(HalDramMemAddrType::UNRESERVED);
     constexpr uint32_t num_elements = 10;
     constexpr uint32_t buf_a_addr = 1000 * 1024;
     constexpr uint32_t buf_b_addr = buf_a_addr + num_elements * sizeof(uint32_t);
     const uint32_t dram_mid_addr = 31000 * 1024;
+    const uint32_t dram_dst_addr = 32000 * 1024;
 
     std::vector<uint32_t> initial_data(num_elements, 0);
     for (uint32_t i = 0; i < num_elements; i++) {
@@ -284,14 +285,13 @@ TEST_F(MeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePipeline
     SetRuntimeArgs(
         program, dm_writer_0, core_0, {dram_mid_addr, buf_b_addr, num_elements, 0, core_1_virtual.x, core_1_virtual.y});
 
-    // --- Core(1,0) kernels: wait for cross-core signal, DRAM -> L1 -> transform -> DRAM ---
     auto dm_reader_1 = experimental::quasar::CreateKernel(
         program,
         OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_to_l1_pipeline.cpp",
         core_1,
         experimental::quasar::QuasarDataMovementConfig{
             .num_threads_per_cluster = 1,
-            .compile_args = {sem_core_1, sem_cross},
+            .compile_args = {sem0_core_1, sem_cross},
             .defines = {{"WAIT_FOR_REMOTE_SEM", "1"}}});
     SetRuntimeArgs(program, dm_reader_1, core_1, {dram_mid_addr, buf_a_addr, num_elements, 0});
 
@@ -301,16 +301,23 @@ TEST_F(MeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePipeline
         core_1,
         experimental::quasar::QuasarComputeConfig{
             .num_threads_per_cluster = 1,
-            .compile_args = {num_elements, sem_core_1},
-            .defines = {{"INCOMING_SEM", "1"}}});
+            .compile_args = {num_elements, sem0_core_1, sem1_core_1},
+            .defines = {{"INCOMING_SEM", "1"}, {"OUTGOING_SEM", "1"}}});
     SetRuntimeArgs(program, compute_1, core_1, {buf_a_addr, buf_b_addr});
+
+    auto dm_writer_1 = experimental::quasar::CreateKernel(
+        program,
+        OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/l1_to_dram_pipeline.cpp",
+        core_1,
+        experimental::quasar::QuasarDataMovementConfig{.num_threads_per_cluster = 1, .compile_args = {sem1_core_1}});
+    SetRuntimeArgs(program, dm_writer_1, core_1, {dram_dst_addr, buf_b_addr, num_elements, 0});
 
     workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, true);
 
     std::vector<uint32_t> actual_data(num_elements, 0);
-    tt_metal::detail::ReadFromDeviceL1(
-        mesh_device->get_devices()[0], core_1, buf_b_addr, num_elements * sizeof(uint32_t), actual_data);
+    tt_metal::detail::ReadFromDeviceDRAMChannel(
+        mesh_device->get_devices()[0], 0, dram_dst_addr, num_elements * sizeof(uint32_t), actual_data);
 
     const std::vector<uint32_t> expected_data = {2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
 

--- a/tests/tt_metal/tt_metal/test_quasar_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_semaphores.cpp
@@ -1,0 +1,170 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "common/device_fixture.hpp"
+
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/experimental/host_api.hpp>
+#include <tt-metalium/tt_metal.hpp>
+#include "llrt/rtoptions.hpp"
+
+#ifndef OVERRIDE_KERNEL_PREFIX
+#define OVERRIDE_KERNEL_PREFIX ""
+#endif
+
+using namespace tt;
+using namespace tt::tt_metal;
+
+// This test requires simulator environment
+TEST_F(MeshDeviceSingleCardFixture, QuasarComputeKernelSemaphores) {
+    // Skip if simulator is not available
+    if (!MetalContext::instance().rtoptions().get_simulator_enabled()) {
+        GTEST_SKIP() << "This test can only be run using a simulator. Set TT_METAL_SIMULATOR environment variable.";
+    }
+
+    auto mesh_device = devices_[0];
+
+    if (!MetalContext::instance().rtoptions().get_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint)) {
+        std::cerr << "WARNING: Please set the environment variable TT_METAL_DPRINT_CORES to 0,0 to see the output of "
+                     "the Compute kernels."
+                  << std::endl;
+        std::cerr << "WARNING: For example, export TT_METAL_DPRINT_CORES=0,0" << std::endl;
+    }
+
+    // We are going to use the first device (0) and the first core (0, 0) on the device.
+    constexpr CoreCoord core = {0, 0};
+    // Command queue lets us submit work (execute programs and read/write buffers) to the device.
+    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
+    // Prepare a workload and a device coordinate range that spans the mesh.
+    distributed::MeshWorkload workload;
+    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
+    Program program = CreateProgram();
+
+    constexpr uint32_t base_src_l1_address = 1000 * 1024;
+    constexpr uint32_t base_dst_l1_address = 1025 * 1024;
+    std::vector<uint32_t> expected_values{0x0123, 0x4567, 0x89AB, 0xCDEF};
+    tt_metal::detail::WriteToDeviceL1(mesh_device->get_devices()[0], core, base_src_l1_address, expected_values);
+
+    uint32_t sem_id = CreateSemaphore(program, core, 0);
+
+    const KernelHandle kernel_handle = experimental::quasar::CreateKernel(
+        program,
+        OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/compute/risc_l1_read_write.cpp",
+        core,
+        experimental::quasar::QuasarComputeConfig{.num_threads_per_cluster = 4, .compile_args = {sem_id, 0}});
+    SetRuntimeArgs(program, kernel_handle, core, {base_src_l1_address, base_dst_l1_address});
+
+    workload.add_program(device_range, std::move(program));
+    distributed::EnqueueMeshWorkload(cq, workload, true);
+
+    std::vector<uint32_t> actual_values(4, 0);
+    tt_metal::detail::ReadFromDeviceL1(
+        mesh_device->get_devices()[0], core, base_dst_l1_address, 4 * sizeof(uint32_t), actual_values);
+
+    ASSERT_EQ(actual_values, expected_values);
+}
+
+// // This test requires simulator environment
+TEST_F(MeshDeviceSingleCardFixture, QuasarDmAndComputeKernelSemaphores) {
+    // Skip if simulator is not available
+    if (!MetalContext::instance().rtoptions().get_simulator_enabled()) {
+        GTEST_SKIP() << "This test can only be run using a simulator. Set TT_METAL_SIMULATOR environment variable.";
+    }
+
+    auto mesh_device = devices_[0];
+
+    if (!MetalContext::instance().rtoptions().get_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint)) {
+        std::cerr << "WARNING: Please set the environment variable TT_METAL_DPRINT_CORES to 0,0 to see the output of "
+                     "the Compute kernels."
+                  << std::endl;
+        std::cerr << "WARNING: For example, export TT_METAL_DPRINT_CORES=0,0" << std::endl;
+    }
+
+    // We are going to use the first device (0) and the first core (0, 0) on the device.
+    constexpr CoreCoord core = {0, 0};
+    // Command queue lets us submit work (execute programs and read/write buffers) to the device.
+    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
+    // Prepare a workload and a device coordinate range that spans the mesh.
+    distributed::MeshWorkload workload;
+    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
+    Program program = CreateProgram();
+
+    const uint32_t sem_id = CreateSemaphore(program, core, 0);
+
+    uint32_t l1_address = 1000 * 1024;
+    std::vector<uint32_t> expected_values{0x0123, 0x4567, 0x89AB, 0xCDEF};
+    uint32_t dram_address = 30000 * 1024;
+    tt_metal::detail::WriteToDeviceDRAMChannel(mesh_device->get_devices()[0], 0, dram_address, expected_values);
+
+    std::vector<KernelHandle> dm_dram_to_l1_kernels;
+    std::vector<KernelHandle> dm_l1_to_dram_kernels;
+    dm_dram_to_l1_kernels.reserve(2);
+    dm_l1_to_dram_kernels.reserve(2);
+    for (uint32_t i = 0; i < 2; i++) {
+        dm_dram_to_l1_kernels.push_back(experimental::quasar::CreateKernel(
+            program,
+            OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_to_l1.cpp",
+            core,
+            experimental::quasar::QuasarDataMovementConfig{.num_threads_per_cluster = 1, .compile_args = {sem_id}}));
+
+        dm_l1_to_dram_kernels.push_back(experimental::quasar::CreateKernel(
+            program,
+            OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/l1_to_dram.cpp",
+            core,
+            experimental::quasar::QuasarDataMovementConfig{.num_threads_per_cluster = 1, .compile_args = {sem_id}}));
+    }
+
+    SetRuntimeArgs(program, dm_dram_to_l1_kernels[0], core, {dram_address, l1_address, 4 * sizeof(uint32_t), 0, 0});
+    SetRuntimeArgs(program, dm_l1_to_dram_kernels[0], core, {dram_address, l1_address, 4 * sizeof(uint32_t), 0, 1});
+    l1_address += 4 * sizeof(uint32_t);
+    SetRuntimeArgs(program, dm_dram_to_l1_kernels[1], core, {dram_address, l1_address, 4 * sizeof(uint32_t), 0, 2});
+
+    const KernelHandle kernel_handle = experimental::quasar::CreateKernel(
+        program,
+        OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/compute/risc_l1_read_write.cpp",
+        core,
+        experimental::quasar::QuasarComputeConfig{.num_threads_per_cluster = 4, .compile_args = {sem_id, 3}});
+    const uint32_t base_src_l1_address = l1_address;
+    const uint32_t base_dst_l1_address = l1_address + 4 * sizeof(uint32_t);
+    SetRuntimeArgs(program, kernel_handle, core, {base_src_l1_address, base_dst_l1_address});
+
+    l1_address += 4 * sizeof(uint32_t);
+    SetRuntimeArgs(program, dm_l1_to_dram_kernels[1], core, {dram_address, l1_address, 4 * sizeof(uint32_t), 0, 7});
+
+    workload.add_program(device_range, std::move(program));
+    distributed::EnqueueMeshWorkload(cq, workload, true);
+
+    std::vector<uint32_t> actual_values(4, 0);
+    tt_metal::detail::ReadFromDeviceL1(
+        mesh_device->get_devices()[0], core, l1_address, 4 * sizeof(uint32_t), actual_values);
+
+    ASSERT_EQ(actual_values, expected_values);
+}
+
+// // This test requires simulator environment
+// TEST_F(MeshDeviceSingleCardFixture, QuasarCreateMultipleComputeKernelsSingleCluster) {
+//     // Skip if simulator is not available
+//     if (!MetalContext::instance().rtoptions().get_simulator_enabled()) {
+//         GTEST_SKIP() << "This test can only be run using a simulator. Set TT_METAL_SIMULATOR environment variable.";
+//     }
+
+//     constexpr CoreCoord core = {0, 0};
+//     Program program = CreateProgram();
+
+//     experimental::quasar::CreateKernel(
+//         program,
+//         OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/compute/risc_math.cpp",
+//         core,
+//         experimental::quasar::QuasarComputeConfig{.num_threads_per_cluster = 1});
+
+//     ASSERT_THROW(
+//         experimental::quasar::CreateKernel(
+//             program,
+//             OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/compute/risc_math.cpp",
+//             core,
+//             experimental::quasar::QuasarComputeConfig{.num_threads_per_cluster = 2}),
+//         std::runtime_error);
+// }

--- a/tests/tt_metal/tt_metal/test_quasar_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_semaphores.cpp
@@ -196,7 +196,9 @@ TEST_F(MeshDeviceSingleCardFixture, QuasarMultiSemaphorePipeline) {
         OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/compute/transform_pipeline.cpp",
         core,
         experimental::quasar::QuasarComputeConfig{
-            .num_threads_per_cluster = 1, .compile_args = {sem0, sem1, num_elements}});
+            .num_threads_per_cluster = 1,
+            .compile_args = {num_elements, sem0, sem1},
+            .defines = {{"OUTGOING_SEM", "1"}, {"INCOMING_SEM", "1"}}});
     SetRuntimeArgs(program, compute, core, {buf_a_addr, buf_b_addr});
 
     auto dm_writer = experimental::quasar::CreateKernel(
@@ -218,16 +220,7 @@ TEST_F(MeshDeviceSingleCardFixture, QuasarMultiSemaphorePipeline) {
     ASSERT_EQ(actual_data, expected_data);
 }
 
-// Cross-core pipeline test:
-//   Host -> DRAM(src) -> Core(0,0) L1 -> Compute(0,0) -> DRAM(mid)
-//     -> Core(1,0) L1 -> Compute(1,0) -> DRAM(dst) -> Host verifies
-//
-// Semaphores:
-//   sem0 on core_0: DM reader(0,0) -> Compute(0,0)
-//   sem1 on core_0: Compute(0,0) -> DM writer(0,0)
-//   sem_cross on both cores: DM writer(0,0) remotely signals DM reader(1,0)
-//   sem2 on core_1: DM reader(1,0) -> Compute(1,0)
-//   sem3 on core_1: Compute(1,0) -> DM writer(1,0)
+// This test requires simulator environment
 TEST_F(MeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePipeline) {
     // Skip if simulator is not available
     if (!MetalContext::instance().rtoptions().get_simulator_enabled()) {
@@ -252,45 +245,32 @@ TEST_F(MeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePipeline
     distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
     Program program = CreateProgram();
 
-    const uint32_t sem0 = CreateSemaphore(program, core_0, 0);
-    const uint32_t sem1 = CreateSemaphore(program, core_0, 0);
+    const uint32_t sem_core_0 = CreateSemaphore(program, core_0, 0);
     const uint32_t sem_cross = CreateSemaphore(program, CoreRange(core_0, core_1), 0);
-    const uint32_t sem2 = CreateSemaphore(program, core_1, 0);
-    const uint32_t sem3 = CreateSemaphore(program, core_1, 0);
+    const uint32_t sem_core_1 = CreateSemaphore(program, core_1, 0);
 
-    constexpr uint32_t num_elements = 1;
+    // const uint32_t dram_bank_size = MetalContext::instance().hal().get_dev_size(HalDramMemAddrType::UNRESERVED);
+    constexpr uint32_t num_elements = 10;
     constexpr uint32_t buf_a_addr = 1000 * 1024;
     constexpr uint32_t buf_b_addr = buf_a_addr + num_elements * sizeof(uint32_t);
-    constexpr uint32_t dram_src_addr = 29000 * 1024;
-    constexpr uint32_t dram_mid_addr = 30000 * 1024;
-    constexpr uint32_t dram_dst_addr = 31000 * 1024;
+    const uint32_t dram_mid_addr = 31000 * 1024;
 
     std::vector<uint32_t> initial_data(num_elements, 0);
     for (uint32_t i = 0; i < num_elements; i++) {
-        initial_data[i] = i + 5;
+        initial_data[i] = i;
     }
-    tt_metal::detail::WriteToDeviceDRAMChannel(
-        mesh_device->get_devices()[0],
-        0,
-        dram_src_addr + MetalContext::instance().hal().get_dev_size(HalDramMemAddrType::UNRESERVED),
-        initial_data);
+    tt_metal::detail::WriteToDeviceL1(mesh_device->get_devices()[0], core_0, buf_a_addr, initial_data);
 
     const CoreCoord core_1_virtual = mesh_device->worker_core_from_logical_core(core_1);
-
-    // --- Core(0,0) kernels: DRAM -> L1 -> transform -> DRAM, then remote signal core(1,0) ---
-    auto dm_reader_0 = experimental::quasar::CreateKernel(
-        program,
-        OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_to_l1_pipeline.cpp",
-        core_0,
-        experimental::quasar::QuasarDataMovementConfig{.num_threads_per_cluster = 1, .compile_args = {sem0}});
-    SetRuntimeArgs(program, dm_reader_0, core_0, {dram_src_addr, buf_a_addr, num_elements, 0});
 
     auto compute_0 = experimental::quasar::CreateKernel(
         program,
         OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/compute/transform_pipeline.cpp",
         core_0,
         experimental::quasar::QuasarComputeConfig{
-            .num_threads_per_cluster = 1, .compile_args = {sem0, sem1, num_elements}});
+            .num_threads_per_cluster = 1,
+            .compile_args = {num_elements, sem_core_0},
+            .defines = {{"OUTGOING_SEM", "1"}}});
     SetRuntimeArgs(program, compute_0, core_0, {buf_a_addr, buf_b_addr});
 
     auto dm_writer_0 = experimental::quasar::CreateKernel(
@@ -299,7 +279,7 @@ TEST_F(MeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePipeline
         core_0,
         experimental::quasar::QuasarDataMovementConfig{
             .num_threads_per_cluster = 1,
-            .compile_args = {sem1, sem_cross},
+            .compile_args = {sem_core_0, sem_cross},
             .defines = {{"INCREMENT_REMOTE_SEM", "1"}}});
     SetRuntimeArgs(
         program, dm_writer_0, core_0, {dram_mid_addr, buf_b_addr, num_elements, 0, core_1_virtual.x, core_1_virtual.y});
@@ -311,7 +291,7 @@ TEST_F(MeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePipeline
         core_1,
         experimental::quasar::QuasarDataMovementConfig{
             .num_threads_per_cluster = 1,
-            .compile_args = {sem2, sem_cross},
+            .compile_args = {sem_core_1, sem_cross},
             .defines = {{"WAIT_FOR_REMOTE_SEM", "1"}}});
     SetRuntimeArgs(program, dm_reader_1, core_1, {dram_mid_addr, buf_a_addr, num_elements, 0});
 
@@ -320,23 +300,17 @@ TEST_F(MeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePipeline
         OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/compute/transform_pipeline.cpp",
         core_1,
         experimental::quasar::QuasarComputeConfig{
-            .num_threads_per_cluster = 1, .compile_args = {sem2, sem3, num_elements}});
+            .num_threads_per_cluster = 1,
+            .compile_args = {num_elements, sem_core_1},
+            .defines = {{"INCOMING_SEM", "1"}}});
     SetRuntimeArgs(program, compute_1, core_1, {buf_a_addr, buf_b_addr});
-
-    auto dm_writer_1 = experimental::quasar::CreateKernel(
-        program,
-        OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/l1_to_dram_pipeline.cpp",
-        core_1,
-        experimental::quasar::QuasarDataMovementConfig{.num_threads_per_cluster = 1, .compile_args = {sem3}});
-    SetRuntimeArgs(program, dm_writer_1, core_1, {dram_dst_addr, buf_b_addr, num_elements, 0});
 
     workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, true);
 
-    // Each transform does val + 1, two transforms total: initial + 2
     std::vector<uint32_t> actual_data(num_elements, 0);
-    tt_metal::detail::ReadFromDeviceDRAMChannel(
-        mesh_device->get_devices()[0], 0, dram_dst_addr, num_elements * sizeof(uint32_t), actual_data);
+    tt_metal::detail::ReadFromDeviceL1(
+        mesh_device->get_devices()[0], core_1, buf_b_addr, num_elements * sizeof(uint32_t), actual_data);
 
     const std::vector<uint32_t> expected_data = {2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
 

--- a/tests/tt_metal/tt_metal/test_quasar_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_semaphores.cpp
@@ -29,7 +29,7 @@ TEST_F(MeshDeviceSingleCardFixture, QuasarComputeKernelSemaphores) {
 
     if (!MetalContext::instance().rtoptions().get_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint)) {
         std::cerr << "WARNING: Please set the environment variable TT_METAL_DPRINT_CORES to 0,0 to see the output of "
-                     "the Compute kernels."
+                     "the kernels."
                   << std::endl;
         std::cerr << "WARNING: For example, export TT_METAL_DPRINT_CORES=0,0" << std::endl;
     }
@@ -67,7 +67,7 @@ TEST_F(MeshDeviceSingleCardFixture, QuasarComputeKernelSemaphores) {
     ASSERT_EQ(actual_values, expected_values);
 }
 
-// // This test requires simulator environment
+// This test requires simulator environment
 TEST_F(MeshDeviceSingleCardFixture, QuasarDmAndComputeKernelSemaphores) {
     // Skip if simulator is not available
     if (!MetalContext::instance().rtoptions().get_simulator_enabled()) {
@@ -78,7 +78,7 @@ TEST_F(MeshDeviceSingleCardFixture, QuasarDmAndComputeKernelSemaphores) {
 
     if (!MetalContext::instance().rtoptions().get_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint)) {
         std::cerr << "WARNING: Please set the environment variable TT_METAL_DPRINT_CORES to 0,0 to see the output of "
-                     "the Compute kernels."
+                     "the kernels."
                   << std::endl;
         std::cerr << "WARNING: For example, export TT_METAL_DPRINT_CORES=0,0" << std::endl;
     }
@@ -144,27 +144,201 @@ TEST_F(MeshDeviceSingleCardFixture, QuasarDmAndComputeKernelSemaphores) {
     ASSERT_EQ(actual_values, expected_values);
 }
 
-// // This test requires simulator environment
-// TEST_F(MeshDeviceSingleCardFixture, QuasarCreateMultipleComputeKernelsSingleCluster) {
-//     // Skip if simulator is not available
-//     if (!MetalContext::instance().rtoptions().get_simulator_enabled()) {
-//         GTEST_SKIP() << "This test can only be run using a simulator. Set TT_METAL_SIMULATOR environment variable.";
-//     }
+// This test requires simulator environment
+TEST_F(MeshDeviceSingleCardFixture, QuasarMultiSemaphorePipeline) {
+    // Skip if simulator is not available
+    if (!MetalContext::instance().rtoptions().get_simulator_enabled()) {
+        GTEST_SKIP() << "This test can only be run using a simulator. Set TT_METAL_SIMULATOR environment variable.";
+    }
 
-//     constexpr CoreCoord core = {0, 0};
-//     Program program = CreateProgram();
+    auto mesh_device = devices_[0];
 
-//     experimental::quasar::CreateKernel(
-//         program,
-//         OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/compute/risc_math.cpp",
-//         core,
-//         experimental::quasar::QuasarComputeConfig{.num_threads_per_cluster = 1});
+    if (!MetalContext::instance().rtoptions().get_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint)) {
+        std::cerr << "WARNING: Please set the environment variable TT_METAL_DPRINT_CORES to 0,0 to see the output of "
+                     "the kernels."
+                  << std::endl;
+        std::cerr << "WARNING: For example, export TT_METAL_DPRINT_CORES=0,0" << std::endl;
+    }
 
-//     ASSERT_THROW(
-//         experimental::quasar::CreateKernel(
-//             program,
-//             OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/compute/risc_math.cpp",
-//             core,
-//             experimental::quasar::QuasarComputeConfig{.num_threads_per_cluster = 2}),
-//         std::runtime_error);
-// }
+    // We are going to use the first device (0) and the first core (0, 0) on the device.
+    constexpr CoreCoord core = {0, 0};
+    // Command queue lets us submit work (execute programs and read/write buffers) to the device.
+    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
+    // Prepare a workload and a device coordinate range that spans the mesh.
+    distributed::MeshWorkload workload;
+    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
+    Program program = CreateProgram();
+
+    const uint32_t sem0 = CreateSemaphore(program, core, 0);
+    const uint32_t sem1 = CreateSemaphore(program, core, 0);
+
+    constexpr uint32_t num_elements = 10;
+    constexpr uint32_t buf_a_addr = 1000 * 1024;
+    constexpr uint32_t buf_b_addr = buf_a_addr + num_elements * sizeof(uint32_t);
+    constexpr uint32_t dram_src_addr = 29000 * 1024;
+    constexpr uint32_t dram_dst_addr = 30000 * 1024;
+
+    std::vector<uint32_t> initial_data(num_elements, 0);
+    for (uint32_t i = 0; i < num_elements; i++) {
+        initial_data[i] = i;
+    }
+    tt_metal::detail::WriteToDeviceDRAMChannel(mesh_device->get_devices()[0], 0, dram_src_addr, initial_data);
+
+    auto dm_reader = experimental::quasar::CreateKernel(
+        program,
+        OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_to_l1_pipeline.cpp",
+        core,
+        experimental::quasar::QuasarDataMovementConfig{.num_threads_per_cluster = 1, .compile_args = {sem0}});
+    SetRuntimeArgs(program, dm_reader, core, {dram_src_addr, buf_a_addr, num_elements, 0});
+
+    auto compute = experimental::quasar::CreateKernel(
+        program,
+        OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/compute/transform_pipeline.cpp",
+        core,
+        experimental::quasar::QuasarComputeConfig{
+            .num_threads_per_cluster = 1, .compile_args = {sem0, sem1, num_elements}});
+    SetRuntimeArgs(program, compute, core, {buf_a_addr, buf_b_addr});
+
+    auto dm_writer = experimental::quasar::CreateKernel(
+        program,
+        OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/l1_to_dram_pipeline.cpp",
+        core,
+        experimental::quasar::QuasarDataMovementConfig{.num_threads_per_cluster = 1, .compile_args = {sem1}});
+    SetRuntimeArgs(program, dm_writer, core, {dram_dst_addr, buf_b_addr, num_elements, 0});
+
+    workload.add_program(device_range, std::move(program));
+    distributed::EnqueueMeshWorkload(cq, workload, true);
+
+    std::vector<uint32_t> actual_data(num_elements, 0);
+    tt_metal::detail::ReadFromDeviceDRAMChannel(
+        mesh_device->get_devices()[0], 0, dram_dst_addr, num_elements * sizeof(uint32_t), actual_data);
+
+    const std::vector<uint32_t> expected_data = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+
+    ASSERT_EQ(actual_data, expected_data);
+}
+
+// Cross-core pipeline test:
+//   Host -> DRAM(src) -> Core(0,0) L1 -> Compute(0,0) -> DRAM(mid)
+//     -> Core(1,0) L1 -> Compute(1,0) -> DRAM(dst) -> Host verifies
+//
+// Semaphores:
+//   sem0 on core_0: DM reader(0,0) -> Compute(0,0)
+//   sem1 on core_0: Compute(0,0) -> DM writer(0,0)
+//   sem_cross on both cores: DM writer(0,0) remotely signals DM reader(1,0)
+//   sem2 on core_1: DM reader(1,0) -> Compute(1,0)
+//   sem3 on core_1: Compute(1,0) -> DM writer(1,0)
+TEST_F(MeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePipeline) {
+    // Skip if simulator is not available
+    if (!MetalContext::instance().rtoptions().get_simulator_enabled()) {
+        GTEST_SKIP() << "This test can only be run using a simulator. Set TT_METAL_SIMULATOR environment variable.";
+    }
+
+    auto mesh_device = devices_[0];
+
+    if (!MetalContext::instance().rtoptions().get_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint)) {
+        std::cerr << "WARNING: Please set the environment variable TT_METAL_DPRINT_CORES to (0,0),(1,0) to see the "
+                     "output of the kernels."
+                  << std::endl;
+        std::cerr << "WARNING: For example, export TT_METAL_DPRINT_CORES=(0,0),(1,0)" << std::endl;
+    }
+
+    constexpr CoreCoord core_0 = {0, 0};
+    constexpr CoreCoord core_1 = {1, 0};
+
+    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
+
+    distributed::MeshWorkload workload;
+    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
+    Program program = CreateProgram();
+
+    const uint32_t sem0 = CreateSemaphore(program, core_0, 0);
+    const uint32_t sem1 = CreateSemaphore(program, core_0, 0);
+    const uint32_t sem_cross = CreateSemaphore(program, CoreRange(core_0, core_1), 0);
+    const uint32_t sem2 = CreateSemaphore(program, core_1, 0);
+    const uint32_t sem3 = CreateSemaphore(program, core_1, 0);
+
+    constexpr uint32_t num_elements = 1;
+    constexpr uint32_t buf_a_addr = 1000 * 1024;
+    constexpr uint32_t buf_b_addr = buf_a_addr + num_elements * sizeof(uint32_t);
+    constexpr uint32_t dram_src_addr = 29000 * 1024;
+    constexpr uint32_t dram_mid_addr = 30000 * 1024;
+    constexpr uint32_t dram_dst_addr = 31000 * 1024;
+
+    std::vector<uint32_t> initial_data(num_elements, 0);
+    for (uint32_t i = 0; i < num_elements; i++) {
+        initial_data[i] = i + 5;
+    }
+    tt_metal::detail::WriteToDeviceDRAMChannel(
+        mesh_device->get_devices()[0],
+        0,
+        dram_src_addr + MetalContext::instance().hal().get_dev_size(HalDramMemAddrType::UNRESERVED),
+        initial_data);
+
+    const CoreCoord core_1_virtual = mesh_device->worker_core_from_logical_core(core_1);
+
+    // --- Core(0,0) kernels: DRAM -> L1 -> transform -> DRAM, then remote signal core(1,0) ---
+    auto dm_reader_0 = experimental::quasar::CreateKernel(
+        program,
+        OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_to_l1_pipeline.cpp",
+        core_0,
+        experimental::quasar::QuasarDataMovementConfig{.num_threads_per_cluster = 1, .compile_args = {sem0}});
+    SetRuntimeArgs(program, dm_reader_0, core_0, {dram_src_addr, buf_a_addr, num_elements, 0});
+
+    auto compute_0 = experimental::quasar::CreateKernel(
+        program,
+        OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/compute/transform_pipeline.cpp",
+        core_0,
+        experimental::quasar::QuasarComputeConfig{
+            .num_threads_per_cluster = 1, .compile_args = {sem0, sem1, num_elements}});
+    SetRuntimeArgs(program, compute_0, core_0, {buf_a_addr, buf_b_addr});
+
+    auto dm_writer_0 = experimental::quasar::CreateKernel(
+        program,
+        OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/l1_to_dram_pipeline.cpp",
+        core_0,
+        experimental::quasar::QuasarDataMovementConfig{
+            .num_threads_per_cluster = 1,
+            .compile_args = {sem1, sem_cross},
+            .defines = {{"INCREMENT_REMOTE_SEM", "1"}}});
+    SetRuntimeArgs(
+        program, dm_writer_0, core_0, {dram_mid_addr, buf_b_addr, num_elements, 0, core_1_virtual.x, core_1_virtual.y});
+
+    // --- Core(1,0) kernels: wait for cross-core signal, DRAM -> L1 -> transform -> DRAM ---
+    auto dm_reader_1 = experimental::quasar::CreateKernel(
+        program,
+        OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_to_l1_pipeline.cpp",
+        core_1,
+        experimental::quasar::QuasarDataMovementConfig{
+            .num_threads_per_cluster = 1,
+            .compile_args = {sem2, sem_cross},
+            .defines = {{"WAIT_FOR_REMOTE_SEM", "1"}}});
+    SetRuntimeArgs(program, dm_reader_1, core_1, {dram_mid_addr, buf_a_addr, num_elements, 0});
+
+    auto compute_1 = experimental::quasar::CreateKernel(
+        program,
+        OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/compute/transform_pipeline.cpp",
+        core_1,
+        experimental::quasar::QuasarComputeConfig{
+            .num_threads_per_cluster = 1, .compile_args = {sem2, sem3, num_elements}});
+    SetRuntimeArgs(program, compute_1, core_1, {buf_a_addr, buf_b_addr});
+
+    auto dm_writer_1 = experimental::quasar::CreateKernel(
+        program,
+        OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/l1_to_dram_pipeline.cpp",
+        core_1,
+        experimental::quasar::QuasarDataMovementConfig{.num_threads_per_cluster = 1, .compile_args = {sem3}});
+    SetRuntimeArgs(program, dm_writer_1, core_1, {dram_dst_addr, buf_b_addr, num_elements, 0});
+
+    workload.add_program(device_range, std::move(program));
+    distributed::EnqueueMeshWorkload(cq, workload, true);
+
+    // Each transform does val + 1, two transforms total: initial + 2
+    std::vector<uint32_t> actual_data(num_elements, 0);
+    tt_metal::detail::ReadFromDeviceDRAMChannel(
+        mesh_device->get_devices()[0], 0, dram_dst_addr, num_elements * sizeof(uint32_t), actual_data);
+
+    const std::vector<uint32_t> expected_data = {2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+
+    ASSERT_EQ(actual_data, expected_data);
+}

--- a/tests/tt_metal/tt_metal/test_quasar_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_semaphores.cpp
@@ -27,13 +27,6 @@ TEST_F(MeshDeviceSingleCardFixture, QuasarComputeKernelSemaphores) {
 
     auto mesh_device = devices_[0];
 
-    if (!MetalContext::instance().rtoptions().get_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint)) {
-        std::cerr << "WARNING: Please set the environment variable TT_METAL_DPRINT_CORES to 0,0 to see the output of "
-                     "the kernels."
-                  << std::endl;
-        std::cerr << "WARNING: For example, export TT_METAL_DPRINT_CORES=0,0" << std::endl;
-    }
-
     // We are going to use the first device (0) and the first core (0, 0) on the device.
     constexpr CoreCoord core = {0, 0};
     // Command queue lets us submit work (execute programs and read/write buffers) to the device.
@@ -75,13 +68,6 @@ TEST_F(MeshDeviceSingleCardFixture, QuasarDmAndComputeKernelSemaphores) {
     }
 
     auto mesh_device = devices_[0];
-
-    if (!MetalContext::instance().rtoptions().get_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint)) {
-        std::cerr << "WARNING: Please set the environment variable TT_METAL_DPRINT_CORES to 0,0 to see the output of "
-                     "the kernels."
-                  << std::endl;
-        std::cerr << "WARNING: For example, export TT_METAL_DPRINT_CORES=0,0" << std::endl;
-    }
 
     // We are going to use the first device (0) and the first core (0, 0) on the device.
     constexpr CoreCoord core = {0, 0};
@@ -153,13 +139,6 @@ TEST_F(MeshDeviceSingleCardFixture, QuasarMultiSemaphorePipeline) {
 
     auto mesh_device = devices_[0];
 
-    if (!MetalContext::instance().rtoptions().get_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint)) {
-        std::cerr << "WARNING: Please set the environment variable TT_METAL_DPRINT_CORES to 0,0 to see the output of "
-                     "the kernels."
-                  << std::endl;
-        std::cerr << "WARNING: For example, export TT_METAL_DPRINT_CORES=0,0" << std::endl;
-    }
-
     // We are going to use the first device (0) and the first core (0, 0) on the device.
     constexpr CoreCoord core = {0, 0};
     // Command queue lets us submit work (execute programs and read/write buffers) to the device.
@@ -228,13 +207,6 @@ TEST_F(MeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePipeline
     }
 
     auto mesh_device = devices_[0];
-
-    if (!MetalContext::instance().rtoptions().get_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint)) {
-        std::cerr << "WARNING: Please set the environment variable TT_METAL_DPRINT_CORES to (0,0),(1,0) to see the "
-                     "output of the kernels."
-                  << std::endl;
-        std::cerr << "WARNING: For example, export TT_METAL_DPRINT_CORES=(0,0),(1,0)" << std::endl;
-    }
 
     constexpr CoreCoord core_0 = {0, 0};
     constexpr CoreCoord core_1 = {1, 0};

--- a/tt_metal/hw/firmware/src/tt-2xx/dm.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dm.cc
@@ -45,7 +45,7 @@ thread_local CBInterface cb_interface[NUM_CIRCULAR_BUFFERS] __attribute__((used)
 
 thread_local uint32_t tt_l1_ptr* rta_l1_base __attribute__((used));
 thread_local uint32_t tt_l1_ptr* crta_l1_base __attribute__((used));
-uint32_t tt_l1_ptr* sem_l1_base[ProgrammableCoreType::COUNT] __attribute__((used));
+thread_local uint32_t tt_l1_ptr* sem_l1_base[ProgrammableCoreType::COUNT] __attribute__((used));
 
 #if defined(WATCHER_ENABLED) && !defined(WATCHER_DISABLE_ASSERT)
 thread_local uint32_t rta_count __attribute__((used));

--- a/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
@@ -35,6 +35,9 @@ uint32_t sumIDs[SUM_COUNT] __attribute__((used));
 
 thread_local uint32_t tt_l1_ptr* rta_l1_base __attribute__((used));
 thread_local uint32_t tt_l1_ptr* crta_l1_base __attribute__((used));
+#if defined(ARCH_QUASAR)
+uint32_t tt_l1_ptr* sem_l1_base[ProgrammableCoreType::COUNT] __attribute__((used));
+#endif
 
 uint8_t my_logical_x_ __attribute__((used));
 uint8_t my_logical_y_ __attribute__((used));
@@ -148,6 +151,11 @@ extern "C" uint32_t _start1() {
             (uint32_t tt_l1_ptr*)(kernel_config_base + launch_msg->kernel_config.rta_offset[hartid].rta_offset);
         crta_l1_base =
             (uint32_t tt_l1_ptr*)(kernel_config_base + launch_msg->kernel_config.rta_offset[hartid].crta_offset);
+#if defined(ARCH_QUASAR)
+        sem_l1_base[ProgrammableCoreType::TENSIX] =
+            (uint32_t tt_l1_ptr*)(kernel_config_base +
+                                  launch_msg->kernel_config.sem_offset[ProgrammableCoreType::TENSIX]);
+#endif
         my_relative_x_ = my_logical_x_ - launch_msg->kernel_config.sub_device_origin_x;
         my_relative_y_ = my_logical_y_ - launch_msg->kernel_config.sub_device_origin_y;
 

--- a/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
@@ -35,9 +35,7 @@ uint32_t sumIDs[SUM_COUNT] __attribute__((used));
 
 thread_local uint32_t tt_l1_ptr* rta_l1_base __attribute__((used));
 thread_local uint32_t tt_l1_ptr* crta_l1_base __attribute__((used));
-#if defined(ARCH_QUASAR)
-uint32_t tt_l1_ptr* sem_l1_base[ProgrammableCoreType::COUNT] __attribute__((used));
-#endif
+thread_local uint32_t tt_l1_ptr* sem_l1_base[ProgrammableCoreType::COUNT] __attribute__((used));
 
 uint8_t my_logical_x_ __attribute__((used));
 uint8_t my_logical_y_ __attribute__((used));
@@ -151,11 +149,10 @@ extern "C" uint32_t _start1() {
             (uint32_t tt_l1_ptr*)(kernel_config_base + launch_msg->kernel_config.rta_offset[hartid].rta_offset);
         crta_l1_base =
             (uint32_t tt_l1_ptr*)(kernel_config_base + launch_msg->kernel_config.rta_offset[hartid].crta_offset);
-#if defined(ARCH_QUASAR)
         sem_l1_base[ProgrammableCoreType::TENSIX] =
             (uint32_t tt_l1_ptr*)(kernel_config_base +
                                   launch_msg->kernel_config.sem_offset[ProgrammableCoreType::TENSIX]);
-#endif
+
         my_relative_x_ = my_logical_x_ - launch_msg->kernel_config.sub_device_origin_x;
         my_relative_y_ = my_logical_y_ - launch_msg->kernel_config.sub_device_origin_y;
 

--- a/tt_metal/hw/inc/api/compute/common.h
+++ b/tt_metal/hw/inc/api/compute/common.h
@@ -16,6 +16,7 @@
 #ifdef ARCH_QUASAR
 extern thread_local uint32_t tt_l1_ptr* rta_l1_base;
 extern thread_local uint32_t tt_l1_ptr* crta_l1_base;
+extern uint32_t tt_l1_ptr* sem_l1_base;
 #else
 extern uint32_t tt_l1_ptr* rta_l1_base;
 extern uint32_t tt_l1_ptr* crta_l1_base;

--- a/tt_metal/hw/inc/api/compute/common.h
+++ b/tt_metal/hw/inc/api/compute/common.h
@@ -16,10 +16,11 @@
 #ifdef ARCH_QUASAR
 extern thread_local uint32_t tt_l1_ptr* rta_l1_base;
 extern thread_local uint32_t tt_l1_ptr* crta_l1_base;
-extern uint32_t tt_l1_ptr* sem_l1_base;
+extern thread_local uint32_t tt_l1_ptr* sem_l1_base[];
 #else
 extern uint32_t tt_l1_ptr* rta_l1_base;
 extern uint32_t tt_l1_ptr* crta_l1_base;
+extern uint32_t tt_l1_ptr* sem_l1_base[];
 #endif
 #if defined(WATCHER_ENABLED) && !defined(WATCHER_DISABLE_ASSERT)
 #ifdef ARCH_QUASAR

--- a/tt_metal/hw/inc/api/compute/experimental/semaphore.h
+++ b/tt_metal/hw/inc/api/compute/experimental/semaphore.h
@@ -13,14 +13,13 @@
 namespace ckernel {
 #ifdef ARCH_QUASAR
 /**
- * @brief Experimental semaphore synchronization primitive for programmable cores.
+ * @brief Experimental semaphore synchronization primitive for Tensix engines.
  *
  * @note This API is experimental and subject to change.
  *
  * The Semaphore class provides a simple interface for semaphore-based synchronization
- * between programmable cores. It allows incrementing and decrementing the semaphore value,
- * as well as waiting for the semaphore to reach a desired value. The semaphore can be
- * manipulated locally or remotely via the NoC.
+ * between Tensix engines. It allows incrementing and decrementing the semaphore value,
+ * as well as waiting for the semaphore to reach a desired value.
  *
  * Usage:
  *   - Construct a Semaphore with a given semaphore ID.
@@ -28,22 +27,19 @@ namespace ckernel {
  *
  * Methods:
  *  - up(value): Increment the semaphore by the specified value locally.
- *  - up(value, noc_x, noc_y, noc, vc): Atomically increment the semaphore by the specified value on a remote core.
  *  - down(value): Decrement the semaphore by the specified value, blocking until the semaphore is sufficient.
  *
  * The following methods (non-standard semantics) are also available, for parity with existing API:
  *  - wait(value): Block until the semaphore is set to the specified value.  Does not decrement the semaphore.
  *  - wait_min(value): Block until the semaphore is at least the specified value.  Does not decrement the semaphore.
  *  - set(value): Set the semaphore to the specified value.
- *  - set_multicast(...): Set the semaphore value on multiple cores.
- *  - set_multicast_loopback_src(...): Set the semaphore value on multiple cores including the source.
  */
 class Semaphore {
 public:
     explicit Semaphore(uint32_t semaphore_id) :
         local_l1_addr_(
             MEM_L1_UNCACHED_BASE +
-            (uintptr_t)(sem_l1_base[static_cast<int>(ProgrammableCoreType::TENSIX)] + semaphore_id * L1_ALIGNMENT)) {
+            ((uintptr_t)sem_l1_base[static_cast<int>(ProgrammableCoreType::TENSIX)] + semaphore_id * L1_ALIGNMENT)) {
         DPRINT << "Semaphore ID: " << semaphore_id << ENDL();
         DPRINT << "Semaphore base address: " << sem_l1_base[static_cast<int>(ProgrammableCoreType::TENSIX)] << ENDL();
         DPRINT << "L1 alignment: " << L1_ALIGNMENT << ENDL();
@@ -58,9 +54,9 @@ public:
      */
     void up(uint32_t value) {
         auto* sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(local_l1_addr_);
-        DPRINT << "Incrementing semaphore by " << value << ENDL();
+        DPRINT << "Incrementing semaphore " << local_l1_addr_ << " by " << value << ENDL();
         *sem_addr += value;
-        DPRINT << "Semaphore incremented to " << *sem_addr << ENDL();
+        DPRINT << "Semaphore " << local_l1_addr_ << " incremented to " << *sem_addr << ENDL();
     }
 
     /**
@@ -72,11 +68,11 @@ public:
     void down(uint32_t value) {
         auto* sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(local_l1_addr_);
         WAYPOINT("TSDW");
-        do {
-            // invalidate_l1_cache();
-        } while ((*sem_addr) < value);
+        while ((*sem_addr) < value);
         WAYPOINT("TSDD");
+        DPRINT << "Decrementing semaphore " << local_l1_addr_ << " by " << value << ENDL();
         *sem_addr -= value;
+        DPRINT << "Semaphore " << local_l1_addr_ << " decremented to " << *sem_addr << ENDL();
     }
 
     // The following methods provide parity with existing semaphore API, but have non-standard semantics.
@@ -87,14 +83,12 @@ public:
      * @param value The value to wait for.
      */
     void wait(uint32_t value) {
-        WAYPOINT("TSWW");
         auto* sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(local_l1_addr_);
         DPRINT << "Waiting for semaphore to be set to " << value << ENDL();
-        while ((*sem_addr) != value) {
-            DPRINT << "Current semaphore value: " << *sem_addr << ENDL();
-        }
-        DPRINT << "Semaphore set to " << *sem_addr << ENDL();
+        WAYPOINT("TSWW");
+        while ((*sem_addr) != value);
         WAYPOINT("TSWD");
+        DPRINT << "Semaphore set to " << *sem_addr << ENDL();
     }
 
     /**
@@ -103,12 +97,10 @@ public:
      * @param value The minimum value to wait for.
      */
     void wait_min(uint32_t value) {
-        WAYPOINT("TSMWW");
         auto* sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(local_l1_addr_);
-        do {
-            // invalidate_l1_cache();
-        } while ((*sem_addr) < value);
-        WAYPOINT("TSMWD");
+        WAYPOINT("TSWMW");
+        while ((*sem_addr) < value);
+        WAYPOINT("TSWMD");
     }
 
     /**

--- a/tt_metal/hw/inc/api/compute/experimental/semaphore.h
+++ b/tt_metal/hw/inc/api/compute/experimental/semaphore.h
@@ -8,6 +8,7 @@
 #include "api/compute/common.h"
 #include "core_config.h"
 #include "noc/noc_parameters.h"
+#include "api/debug/dprint.h"
 
 namespace ckernel {
 #ifdef ARCH_QUASAR

--- a/tt_metal/hw/inc/api/compute/experimental/semaphore.h
+++ b/tt_metal/hw/inc/api/compute/experimental/semaphore.h
@@ -6,7 +6,6 @@
 
 #include "dev_mem_map.h"
 #include "api/compute/common.h"
-#include "api/debug/dprint.h"
 #include "core_config.h"
 #include "noc/noc_parameters.h"
 
@@ -39,12 +38,7 @@ public:
     explicit Semaphore(uint32_t semaphore_id) :
         local_l1_addr_(
             MEM_L1_UNCACHED_BASE +
-            ((uintptr_t)sem_l1_base[static_cast<int>(ProgrammableCoreType::TENSIX)] + semaphore_id * L1_ALIGNMENT)) {
-        DPRINT << "Semaphore ID: " << semaphore_id << ENDL();
-        DPRINT << "Semaphore base address: " << sem_l1_base[static_cast<int>(ProgrammableCoreType::TENSIX)] << ENDL();
-        DPRINT << "L1 alignment: " << L1_ALIGNMENT << ENDL();
-        DPRINT << "Semaphore address: " << local_l1_addr_ << ENDL();
-    }
+            ((uintptr_t)sem_l1_base[static_cast<int>(ProgrammableCoreType::TENSIX)] + semaphore_id * L1_ALIGNMENT)) {}
 
     /**
      * @brief Increment the semaphore by the specified value.
@@ -54,9 +48,7 @@ public:
      */
     void up(uint32_t value) {
         auto* sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(local_l1_addr_);
-        DPRINT << "Incrementing semaphore " << local_l1_addr_ << " by " << value << ENDL();
         *sem_addr += value;
-        DPRINT << "Semaphore " << local_l1_addr_ << " incremented to " << *sem_addr << ENDL();
     }
 
     /**
@@ -70,9 +62,7 @@ public:
         WAYPOINT("TSDW");
         while ((*sem_addr) < value);
         WAYPOINT("TSDD");
-        DPRINT << "Decrementing semaphore " << local_l1_addr_ << " by " << value << ENDL();
         *sem_addr -= value;
-        DPRINT << "Semaphore " << local_l1_addr_ << " decremented to " << *sem_addr << ENDL();
     }
 
     // The following methods provide parity with existing semaphore API, but have non-standard semantics.
@@ -84,11 +74,9 @@ public:
      */
     void wait(uint32_t value) {
         auto* sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(local_l1_addr_);
-        DPRINT << "Waiting for semaphore to be set to " << value << ENDL();
         WAYPOINT("TSWW");
         while ((*sem_addr) != value);
         WAYPOINT("TSWD");
-        DPRINT << "Semaphore set to " << *sem_addr << ENDL();
     }
 
     /**

--- a/tt_metal/hw/inc/api/compute/experimental/semaphore.h
+++ b/tt_metal/hw/inc/api/compute/experimental/semaphore.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include "dev_mem_map.h"
 #include "api/compute/common.h"
 #include "core_config.h"
 #include "noc/noc_parameters.h"
@@ -38,8 +37,7 @@ class Semaphore {
 public:
     explicit Semaphore(uint32_t semaphore_id) :
         local_l1_addr_(
-            MEM_L1_UNCACHED_BASE +
-            ((uintptr_t)sem_l1_base[static_cast<int>(ProgrammableCoreType::TENSIX)] + semaphore_id * L1_ALIGNMENT)) {}
+            (uintptr_t)(sem_l1_base[static_cast<int>(ProgrammableCoreType::TENSIX)]) + semaphore_id * L1_ALIGNMENT) {}
 
     /**
      * @brief Increment the semaphore by the specified value.
@@ -103,7 +101,7 @@ public:
     }
 
 private:
-    uint32_t local_l1_addr_;
+    uintptr_t local_l1_addr_;
 };
 #endif
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/experimental/semaphore.h
+++ b/tt_metal/hw/inc/api/compute/experimental/semaphore.h
@@ -6,6 +6,7 @@
 
 #include "dev_mem_map.h"
 #include "api/compute/common.h"
+#include "api/debug/dprint.h"
 #include "core_config.h"
 #include "noc/noc_parameters.h"
 
@@ -41,8 +42,13 @@ class Semaphore {
 public:
     explicit Semaphore(uint32_t semaphore_id) :
         local_l1_addr_(
-            MEM_L1_UNCACHED_BASE + sem_l1_base[static_cast<int>(ProgrammableCoreType::TENSIX)] +
-            semaphore_id * L1_ALIGNMENT) {}
+            MEM_L1_UNCACHED_BASE +
+            (uintptr_t)(sem_l1_base[static_cast<int>(ProgrammableCoreType::TENSIX)] + semaphore_id * L1_ALIGNMENT)) {
+        DPRINT << "Semaphore ID: " << semaphore_id << ENDL();
+        DPRINT << "Semaphore base address: " << sem_l1_base[static_cast<int>(ProgrammableCoreType::TENSIX)] << ENDL();
+        DPRINT << "L1 alignment: " << L1_ALIGNMENT << ENDL();
+        DPRINT << "Semaphore address: " << local_l1_addr_ << ENDL();
+    }
 
     /**
      * @brief Increment the semaphore by the specified value.
@@ -52,7 +58,9 @@ public:
      */
     void up(uint32_t value) {
         auto* sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(local_l1_addr_);
+        DPRINT << "Incrementing semaphore by " << value << ENDL();
         *sem_addr += value;
+        DPRINT << "Semaphore incremented to " << *sem_addr << ENDL();
     }
 
     /**
@@ -81,9 +89,11 @@ public:
     void wait(uint32_t value) {
         WAYPOINT("TSWW");
         auto* sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(local_l1_addr_);
-        do {
-            // invalidate_l1_cache();
-        } while ((*sem_addr) != value);
+        DPRINT << "Waiting for semaphore to be set to " << value << ENDL();
+        while ((*sem_addr) != value) {
+            DPRINT << "Current semaphore value: " << *sem_addr << ENDL();
+        }
+        DPRINT << "Semaphore set to " << *sem_addr << ENDL();
         WAYPOINT("TSWD");
     }
 

--- a/tt_metal/hw/inc/api/compute/experimental/semaphore.h
+++ b/tt_metal/hw/inc/api/compute/experimental/semaphore.h
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "dev_mem_map.h"
+#include "api/compute/common.h"
+#include "core_config.h"
+#include "noc/noc_parameters.h"
+
+namespace ckernel {
+#ifdef ARCH_QUASAR
+/**
+ * @brief Experimental semaphore synchronization primitive for programmable cores.
+ *
+ * @note This API is experimental and subject to change.
+ *
+ * The Semaphore class provides a simple interface for semaphore-based synchronization
+ * between programmable cores. It allows incrementing and decrementing the semaphore value,
+ * as well as waiting for the semaphore to reach a desired value. The semaphore can be
+ * manipulated locally or remotely via the NoC.
+ *
+ * Usage:
+ *   - Construct a Semaphore with a given semaphore ID.
+ *   - Use up(), down(), and other methods to perform synchronization.
+ *
+ * Methods:
+ *  - up(value): Increment the semaphore by the specified value locally.
+ *  - up(value, noc_x, noc_y, noc, vc): Atomically increment the semaphore by the specified value on a remote core.
+ *  - down(value): Decrement the semaphore by the specified value, blocking until the semaphore is sufficient.
+ *
+ * The following methods (non-standard semantics) are also available, for parity with existing API:
+ *  - wait(value): Block until the semaphore is set to the specified value.  Does not decrement the semaphore.
+ *  - wait_min(value): Block until the semaphore is at least the specified value.  Does not decrement the semaphore.
+ *  - set(value): Set the semaphore to the specified value.
+ *  - set_multicast(...): Set the semaphore value on multiple cores.
+ *  - set_multicast_loopback_src(...): Set the semaphore value on multiple cores including the source.
+ */
+class Semaphore {
+public:
+    explicit Semaphore(uint32_t semaphore_id) :
+        local_l1_addr_(
+            MEM_L1_UNCACHED_BASE + sem_l1_base[static_cast<int>(ProgrammableCoreType::TENSIX)] +
+            semaphore_id * L1_ALIGNMENT) {}
+
+    /**
+     * @brief Increment the semaphore by the specified value.
+     * @note Currently atomicity is not guaranteed, multiple cores incrementing simultaneously may lead to lost updates.
+     *
+     * @param value The value to increment the semaphore by.
+     */
+    void up(uint32_t value) {
+        auto* sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(local_l1_addr_);
+        *sem_addr += value;
+    }
+
+    /**
+     * @brief Decrement the semaphore by the specified value, blocking until the semaphore is sufficient.
+     * @note Currently atomicity is not guaranteed, multiple cores decrementing simultaneously may lead to lost updates.
+     *
+     * @param value The value to decrement the semaphore by.
+     */
+    void down(uint32_t value) {
+        auto* sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(local_l1_addr_);
+        WAYPOINT("TSDW");
+        do {
+            // invalidate_l1_cache();
+        } while ((*sem_addr) < value);
+        WAYPOINT("TSDD");
+        *sem_addr -= value;
+    }
+
+    // The following methods provide parity with existing semaphore API, but have non-standard semantics.
+
+    /**
+     * @brief Block until the semaphore is set to the specified value.
+     *
+     * @param value The value to wait for.
+     */
+    void wait(uint32_t value) {
+        WAYPOINT("TSWW");
+        auto* sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(local_l1_addr_);
+        do {
+            // invalidate_l1_cache();
+        } while ((*sem_addr) != value);
+        WAYPOINT("TSWD");
+    }
+
+    /**
+     * @brief Block until the semaphore is at least the specified value.
+     *
+     * @param value The minimum value to wait for.
+     */
+    void wait_min(uint32_t value) {
+        WAYPOINT("TSMWW");
+        auto* sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(local_l1_addr_);
+        do {
+            // invalidate_l1_cache();
+        } while ((*sem_addr) < value);
+        WAYPOINT("TSMWD");
+    }
+
+    /**
+     * @brief Set the semaphore to the specified value.
+     *
+     * @param value The value to set the semaphore to.
+     */
+    void set(uint32_t value) {
+        auto* sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(local_l1_addr_);
+        *sem_addr = value;
+    }
+
+private:
+    uint32_t local_l1_addr_;
+};
+#endif
+}  // namespace ckernel

--- a/tt_metal/hw/inc/api/dataflow/dataflow_api.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_api.h
@@ -1502,7 +1502,7 @@ FORCE_INLINE void noc_async_write_shard(
 /**
  * Returns the local address of the semaphore with the given id.
  *
- * Return value: Local address of the semaphore (uint32_t)
+ * Return value: Local address of the semaphore (uintptr_t)
  *
  * | Argument                  | Description                | Type                     | Valid Range              | Required |
  * |---------------------------|----------------------------|--------------------------|--------------------------|----------|

--- a/tt_metal/hw/inc/api/dataflow/dataflow_api.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_api.h
@@ -1511,8 +1511,8 @@ FORCE_INLINE void noc_async_write_shard(
  */
 // clang-format on
 template <ProgrammableCoreType type = ProgrammableCoreType::TENSIX>
-FORCE_INLINE uint32_t get_semaphore(uint32_t semaphore_id) {
-    return (uint32_t)sem_l1_base[static_cast<int>(type)] + semaphore_id * L1_ALIGNMENT;
+FORCE_INLINE uintptr_t get_semaphore(uint32_t semaphore_id) {
+    return (uintptr_t)sem_l1_base[static_cast<int>(type)] + semaphore_id * L1_ALIGNMENT;
 }
 
 // clang-format off

--- a/tt_metal/hw/inc/experimental/noc_semaphore.h
+++ b/tt_metal/hw/inc/experimental/noc_semaphore.h
@@ -6,6 +6,7 @@
 
 #include "dev_mem_map.h"
 #include "experimental/noc.h"
+#include "api/debug/dprint.h"
 
 namespace experimental {
 
@@ -42,6 +43,10 @@ public:
 #ifdef ARCH_QUASAR
         local_l1_addr_ += MEM_L1_UNCACHED_BASE;
 #endif
+        DPRINT << "Semaphore ID: " << semaphore_id << ENDL();
+        DPRINT << "Semaphore base address: " << (uint32_t)(uintptr_t)sem_l1_base[static_cast<int>(core_type)] << ENDL();
+        DPRINT << "L1 alignment: " << L1_ALIGNMENT << ENDL();
+        DPRINT << "Semaphore address: " << local_l1_addr_ << ENDL();
     }
 
     /**
@@ -52,7 +57,9 @@ public:
      */
     void up(uint32_t value) {
         auto* sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(local_l1_addr_);
+        DPRINT << "Incrementing semaphore " << local_l1_addr_ << " by " << value << ENDL();
         *sem_addr += value;
+        DPRINT << "Semaphore " << local_l1_addr_ << " incremented to " << *sem_addr << ENDL();
     }
 
     /**
@@ -82,7 +89,9 @@ public:
             invalidate_l1_cache();
         } while ((*sem_addr) < value);
         WAYPOINT("NSDD");
+        DPRINT << "Decrementing semaphore " << local_l1_addr_ << " by " << value << ENDL();
         *sem_addr -= value;
+        DPRINT << "Semaphore " << local_l1_addr_ << " decremented to " << *sem_addr << ENDL();
     }
 
     // The following methods provide parity with existing semaphore API, but have non-standard semantics.

--- a/tt_metal/hw/inc/experimental/noc_semaphore.h
+++ b/tt_metal/hw/inc/experimental/noc_semaphore.h
@@ -65,11 +65,7 @@ public:
      * @param vc The virtual channel to use for the transaction (default is NOC_UNICAST_WRITE_VC).
      */
     void up(const Noc& noc, uint32_t noc_x, uint32_t noc_y, uint32_t value, uint8_t vc = NOC_UNICAST_WRITE_VC) {
-#ifdef ARCH_QUASAR
-        const uint64_t dest_noc_addr = get_noc_addr(noc_x, noc_y, local_l1_addr_ - MEM_L1_UNCACHED_BASE);
-#else
-        const uint64_t dest_noc_addr = get_noc_addr(noc_x, noc_y, local_l1_addr_);
-#endif
+        const uintptr_t dest_noc_addr = get_noc_addr(noc_x, noc_y);
         noc_semaphore_inc(dest_noc_addr, value, noc.get_noc_id(), vc);
     }
 
@@ -140,13 +136,13 @@ public:
         uint32_t noc_y_end,
         uint32_t num_dests,
         bool linked = false) {
+        const uintptr_t multicast_addr =
+            get_noc_multicast_addr(noc_x_start, noc_y_start, noc_x_end, noc_y_end, noc.get_noc_id());
 #ifdef ARCH_QUASAR
         const uintptr_t local_l1_addr = local_l1_addr_ - MEM_L1_UNCACHED_BASE;
 #else
         const uintptr_t local_l1_addr = local_l1_addr_;
 #endif
-        const uint64_t multicast_addr =
-            get_noc_multicast_addr(noc_x_start, noc_y_start, noc_x_end, noc_y_end, local_l1_addr, noc.get_noc_id());
         if constexpr (mcast_mode == Noc::McastMode::INCLUDE_SRC) {
             noc_semaphore_set_multicast_loopback_src(
                 local_l1_addr, multicast_addr, num_dests, linked, noc.get_noc_id());
@@ -175,18 +171,31 @@ public:
         uint32_t noc_y_end,
         uint32_t value,
         uint32_t num_dests) {
-#ifdef ARCH_QUASAR
-        const uint64_t multicast_addr = get_noc_multicast_addr(
-            noc_x_start, noc_y_start, noc_x_end, noc_y_end, local_l1_addr_ - MEM_L1_UNCACHED_BASE, noc.get_noc_id());
-#else
-        const uint64_t multicast_addr =
-            get_noc_multicast_addr(noc_x_start, noc_y_start, noc_x_end, noc_y_end, local_l1_addr_, noc.get_noc_id());
-#endif
+        const uintptr_t multicast_addr =
+            get_noc_multicast_addr(noc_x_start, noc_y_start, noc_x_end, noc_y_end, noc.get_noc_id());
         noc_semaphore_inc_multicast(multicast_addr, value, num_dests, noc.get_noc_id());
     }
 
 private:
     uintptr_t local_l1_addr_;
+
+    uintptr_t get_noc_multicast_addr(
+        uint32_t noc_x_start, uint32_t noc_y_start, uint32_t noc_x_end, uint32_t noc_y_end, uint8_t noc) const {
+#ifdef ARCH_QUASAR
+        return ::get_noc_multicast_addr(
+            noc_x_start, noc_y_start, noc_x_end, noc_y_end, local_l1_addr_ - MEM_L1_UNCACHED_BASE, noc);
+#else
+        return ::get_noc_multicast_addr(noc_x_start, noc_y_start, noc_x_end, noc_y_end, local_l1_addr_, noc);
+#endif
+    }
+
+    uintptr_t get_noc_addr(uint32_t noc_x, uint32_t noc_y) const {
+#ifdef ARCH_QUASAR
+        return ::get_noc_addr(noc_x, noc_y, local_l1_addr_ - MEM_L1_UNCACHED_BASE);
+#else
+        return ::get_noc_addr(noc_x, noc_y, local_l1_addr_);
+#endif
+    }
 };
 
 }  // namespace experimental

--- a/tt_metal/hw/inc/experimental/noc_semaphore.h
+++ b/tt_metal/hw/inc/experimental/noc_semaphore.h
@@ -6,7 +6,6 @@
 
 #include "dev_mem_map.h"
 #include "experimental/noc.h"
-#include "api/debug/dprint.h"
 
 namespace experimental {
 
@@ -43,10 +42,6 @@ public:
 #ifdef ARCH_QUASAR
         local_l1_addr_ += MEM_L1_UNCACHED_BASE;
 #endif
-        DPRINT << "Semaphore ID: " << semaphore_id << ENDL();
-        DPRINT << "Semaphore base address: " << (uint32_t)(uintptr_t)sem_l1_base[static_cast<int>(core_type)] << ENDL();
-        DPRINT << "L1 alignment: " << L1_ALIGNMENT << ENDL();
-        DPRINT << "Semaphore address: " << local_l1_addr_ << ENDL();
     }
 
     /**
@@ -57,9 +52,7 @@ public:
      */
     void up(uint32_t value) {
         auto* sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(local_l1_addr_);
-        DPRINT << "Incrementing semaphore " << local_l1_addr_ << " by " << value << ENDL();
         *sem_addr += value;
-        DPRINT << "Semaphore " << local_l1_addr_ << " incremented to " << *sem_addr << ENDL();
     }
 
     /**
@@ -89,9 +82,7 @@ public:
             invalidate_l1_cache();
         } while ((*sem_addr) < value);
         WAYPOINT("NSDD");
-        DPRINT << "Decrementing semaphore " << local_l1_addr_ << " by " << value << ENDL();
         *sem_addr -= value;
-        DPRINT << "Semaphore " << local_l1_addr_ << " decremented to " << *sem_addr << ENDL();
     }
 
     // The following methods provide parity with existing semaphore API, but have non-standard semantics.
@@ -183,62 +174,5 @@ public:
 private:
     uint32_t local_l1_addr_;
 };
-
-// namespace quasar {
-// class Semaphore {
-// public:
-//     explicit Semaphore(uint32_t semaphore_id) {
-//         this->reg_addr_ = TENSIX_GLOBAL_REGS_SEMAPHORE_REGS_REG_FILE_BASE_ADDR + (semaphore_id * 0x40);
-//     }
-
-//     void up(uint32_t value) {
-//         // const uint32_t current_value = READ_REG(this->reg_addr_);
-//         DPRINT << "Upping semaphore " << this->reg_addr_ << " by " << value << ENDL();
-//         READ_REG(this->reg_addr_ + 4 * (value + 8));
-//         DPRINT << "Semaphore value: " << READ_REG(this->reg_addr_) << ENDL();
-//     }
-
-//     void down(uint32_t value) {
-//         auto* sem_addr = reinterpret_cast<volatile tt_reg_ptr uint32_t*>(this->reg_addr_);
-//         do {
-//             invalidate_l1_cache();
-//         } while ((*sem_addr) < value);
-//         DPRINT << "Downing semaphore " << this->reg_addr_ << " by " << value << ENDL();
-//         READ_REG(this->reg_addr_ + (4 * value));
-//         DPRINT << "Semaphore value: " << READ_REG(this->reg_addr_) << ENDL();
-//     }
-
-//     void wait(uint32_t value) {
-//         auto* sem_addr = reinterpret_cast<volatile tt_reg_ptr uint32_t*>(this->reg_addr_);
-//         DPRINT << "Waiting for semaphore " << this->reg_addr_ << " to be " << value << ENDL();
-//         do {
-//             invalidate_l1_cache();
-//             // DPRINT << "Semaphore value: " << READ_REG(this->reg_addr_) << ENDL();
-//         } while ((*sem_addr) != value);
-//     }
-
-//     /**
-//      * @brief Block until the semaphore is at least the specified value.
-//      *
-//      * @param value The minimum value to wait for.
-//      */
-//     void wait_min(uint32_t value) {
-//         auto* sem_addr = reinterpret_cast<volatile tt_reg_ptr uint32_t*>(this->reg_addr_);
-//         do {
-//             invalidate_l1_cache();
-//         } while ((*sem_addr) < value);
-//     }
-
-//     /**
-//      * @brief Set the semaphore to the specified value.
-//      *
-//      * @param value The value to set the semaphore to.
-//      */
-//     void set(uint32_t value) { WRITE_REG(this->reg_addr_, value); }
-
-// private:
-//     uint32_t reg_addr_;
-// };
-// }  // namespace quasar
 
 }  // namespace experimental

--- a/tt_metal/hw/inc/experimental/noc_semaphore.h
+++ b/tt_metal/hw/inc/experimental/noc_semaphore.h
@@ -170,4 +170,61 @@ private:
     uint32_t local_l1_addr_;
 };
 
+namespace quasar {
+class Semaphore {
+public:
+    explicit Semaphore(uint32_t semaphore_id) {
+        this->reg_addr_ = TENSIX_GLOBAL_REGS_SEMAPHORE_REGS_REG_FILE_BASE_ADDR + (semaphore_id * 0x40);
+    }
+
+    void up(uint32_t value) {
+        // const uint32_t current_value = READ_REG(this->reg_addr_);
+        DPRINT << "Upping semaphore " << this->reg_addr_ << " by " << value << ENDL();
+        READ_REG(this->reg_addr_ + 4 * (value + 8));
+        DPRINT << "Semaphore value: " << READ_REG(this->reg_addr_) << ENDL();
+    }
+
+    void down(uint32_t value) {
+        auto* sem_addr = reinterpret_cast<volatile tt_reg_ptr uint32_t*>(this->reg_addr_);
+        do {
+            invalidate_l1_cache();
+        } while ((*sem_addr) < value);
+        DPRINT << "Downing semaphore " << this->reg_addr_ << " by " << value << ENDL();
+        READ_REG(this->reg_addr_ + (4 * value));
+        DPRINT << "Semaphore value: " << READ_REG(this->reg_addr_) << ENDL();
+    }
+
+    void wait(uint32_t value) {
+        auto* sem_addr = reinterpret_cast<volatile tt_reg_ptr uint32_t*>(this->reg_addr_);
+        DPRINT << "Waiting for semaphore " << this->reg_addr_ << " to be " << value << ENDL();
+        do {
+            invalidate_l1_cache();
+            // DPRINT << "Semaphore value: " << READ_REG(this->reg_addr_) << ENDL();
+        } while ((*sem_addr) != value);
+    }
+
+    /**
+     * @brief Block until the semaphore is at least the specified value.
+     *
+     * @param value The minimum value to wait for.
+     */
+    void wait_min(uint32_t value) {
+        auto* sem_addr = reinterpret_cast<volatile tt_reg_ptr uint32_t*>(this->reg_addr_);
+        do {
+            invalidate_l1_cache();
+        } while ((*sem_addr) < value);
+    }
+
+    /**
+     * @brief Set the semaphore to the specified value.
+     *
+     * @param value The value to set the semaphore to.
+     */
+    void set(uint32_t value) { WRITE_REG(this->reg_addr_, value); }
+
+private:
+    uint32_t reg_addr_;
+};
+}  // namespace quasar
+
 }  // namespace experimental

--- a/tt_metal/hw/inc/experimental/noc_semaphore.h
+++ b/tt_metal/hw/inc/experimental/noc_semaphore.h
@@ -175,61 +175,61 @@ private:
     uint32_t local_l1_addr_;
 };
 
-namespace quasar {
-class Semaphore {
-public:
-    explicit Semaphore(uint32_t semaphore_id) {
-        this->reg_addr_ = TENSIX_GLOBAL_REGS_SEMAPHORE_REGS_REG_FILE_BASE_ADDR + (semaphore_id * 0x40);
-    }
+// namespace quasar {
+// class Semaphore {
+// public:
+//     explicit Semaphore(uint32_t semaphore_id) {
+//         this->reg_addr_ = TENSIX_GLOBAL_REGS_SEMAPHORE_REGS_REG_FILE_BASE_ADDR + (semaphore_id * 0x40);
+//     }
 
-    void up(uint32_t value) {
-        // const uint32_t current_value = READ_REG(this->reg_addr_);
-        DPRINT << "Upping semaphore " << this->reg_addr_ << " by " << value << ENDL();
-        READ_REG(this->reg_addr_ + 4 * (value + 8));
-        DPRINT << "Semaphore value: " << READ_REG(this->reg_addr_) << ENDL();
-    }
+//     void up(uint32_t value) {
+//         // const uint32_t current_value = READ_REG(this->reg_addr_);
+//         DPRINT << "Upping semaphore " << this->reg_addr_ << " by " << value << ENDL();
+//         READ_REG(this->reg_addr_ + 4 * (value + 8));
+//         DPRINT << "Semaphore value: " << READ_REG(this->reg_addr_) << ENDL();
+//     }
 
-    void down(uint32_t value) {
-        auto* sem_addr = reinterpret_cast<volatile tt_reg_ptr uint32_t*>(this->reg_addr_);
-        do {
-            invalidate_l1_cache();
-        } while ((*sem_addr) < value);
-        DPRINT << "Downing semaphore " << this->reg_addr_ << " by " << value << ENDL();
-        READ_REG(this->reg_addr_ + (4 * value));
-        DPRINT << "Semaphore value: " << READ_REG(this->reg_addr_) << ENDL();
-    }
+//     void down(uint32_t value) {
+//         auto* sem_addr = reinterpret_cast<volatile tt_reg_ptr uint32_t*>(this->reg_addr_);
+//         do {
+//             invalidate_l1_cache();
+//         } while ((*sem_addr) < value);
+//         DPRINT << "Downing semaphore " << this->reg_addr_ << " by " << value << ENDL();
+//         READ_REG(this->reg_addr_ + (4 * value));
+//         DPRINT << "Semaphore value: " << READ_REG(this->reg_addr_) << ENDL();
+//     }
 
-    void wait(uint32_t value) {
-        auto* sem_addr = reinterpret_cast<volatile tt_reg_ptr uint32_t*>(this->reg_addr_);
-        DPRINT << "Waiting for semaphore " << this->reg_addr_ << " to be " << value << ENDL();
-        do {
-            invalidate_l1_cache();
-            // DPRINT << "Semaphore value: " << READ_REG(this->reg_addr_) << ENDL();
-        } while ((*sem_addr) != value);
-    }
+//     void wait(uint32_t value) {
+//         auto* sem_addr = reinterpret_cast<volatile tt_reg_ptr uint32_t*>(this->reg_addr_);
+//         DPRINT << "Waiting for semaphore " << this->reg_addr_ << " to be " << value << ENDL();
+//         do {
+//             invalidate_l1_cache();
+//             // DPRINT << "Semaphore value: " << READ_REG(this->reg_addr_) << ENDL();
+//         } while ((*sem_addr) != value);
+//     }
 
-    /**
-     * @brief Block until the semaphore is at least the specified value.
-     *
-     * @param value The minimum value to wait for.
-     */
-    void wait_min(uint32_t value) {
-        auto* sem_addr = reinterpret_cast<volatile tt_reg_ptr uint32_t*>(this->reg_addr_);
-        do {
-            invalidate_l1_cache();
-        } while ((*sem_addr) < value);
-    }
+//     /**
+//      * @brief Block until the semaphore is at least the specified value.
+//      *
+//      * @param value The minimum value to wait for.
+//      */
+//     void wait_min(uint32_t value) {
+//         auto* sem_addr = reinterpret_cast<volatile tt_reg_ptr uint32_t*>(this->reg_addr_);
+//         do {
+//             invalidate_l1_cache();
+//         } while ((*sem_addr) < value);
+//     }
 
-    /**
-     * @brief Set the semaphore to the specified value.
-     *
-     * @param value The value to set the semaphore to.
-     */
-    void set(uint32_t value) { WRITE_REG(this->reg_addr_, value); }
+//     /**
+//      * @brief Set the semaphore to the specified value.
+//      *
+//      * @param value The value to set the semaphore to.
+//      */
+//     void set(uint32_t value) { WRITE_REG(this->reg_addr_, value); }
 
-private:
-    uint32_t reg_addr_;
-};
-}  // namespace quasar
+// private:
+//     uint32_t reg_addr_;
+// };
+// }  // namespace quasar
 
 }  // namespace experimental

--- a/tt_metal/hw/inc/experimental/noc_semaphore.h
+++ b/tt_metal/hw/inc/experimental/noc_semaphore.h
@@ -65,7 +65,11 @@ public:
      * @param vc The virtual channel to use for the transaction (default is NOC_UNICAST_WRITE_VC).
      */
     void up(const Noc& noc, uint32_t noc_x, uint32_t noc_y, uint32_t value, uint8_t vc = NOC_UNICAST_WRITE_VC) {
-        uint64_t dest_noc_addr = get_noc_addr(noc_x, noc_y, local_l1_addr_);
+#ifdef ARCH_QUASAR
+        const uint64_t dest_noc_addr = get_noc_addr(noc_x, noc_y, local_l1_addr_ - MEM_L1_UNCACHED_BASE);
+#else
+        const uint64_t dest_noc_addr = get_noc_addr(noc_x, noc_y, local_l1_addr_);
+#endif
         noc_semaphore_inc(dest_noc_addr, value, noc.get_noc_id(), vc);
     }
 
@@ -136,13 +140,18 @@ public:
         uint32_t noc_y_end,
         uint32_t num_dests,
         bool linked = false) {
-        uint64_t multicast_addr =
-            get_noc_multicast_addr(noc_x_start, noc_y_start, noc_x_end, noc_y_end, local_l1_addr_, noc.get_noc_id());
+#ifdef ARCH_QUASAR
+        const uintptr_t local_l1_addr = local_l1_addr_ - MEM_L1_UNCACHED_BASE;
+#else
+        const uintptr_t local_l1_addr = local_l1_addr_;
+#endif
+        const uint64_t multicast_addr =
+            get_noc_multicast_addr(noc_x_start, noc_y_start, noc_x_end, noc_y_end, local_l1_addr, noc.get_noc_id());
         if constexpr (mcast_mode == Noc::McastMode::INCLUDE_SRC) {
             noc_semaphore_set_multicast_loopback_src(
-                local_l1_addr_, multicast_addr, num_dests, linked, noc.get_noc_id());
+                local_l1_addr, multicast_addr, num_dests, linked, noc.get_noc_id());
         } else if constexpr (mcast_mode == Noc::McastMode::EXCLUDE_SRC) {
-            noc_semaphore_set_multicast(local_l1_addr_, multicast_addr, num_dests, linked, noc.get_noc_id());
+            noc_semaphore_set_multicast(local_l1_addr, multicast_addr, num_dests, linked, noc.get_noc_id());
         }
     }
 
@@ -166,13 +175,18 @@ public:
         uint32_t noc_y_end,
         uint32_t value,
         uint32_t num_dests) {
-        uint64_t multicast_addr =
+#ifdef ARCH_QUASAR
+        const uint64_t multicast_addr = get_noc_multicast_addr(
+            noc_x_start, noc_y_start, noc_x_end, noc_y_end, local_l1_addr_ - MEM_L1_UNCACHED_BASE, noc.get_noc_id());
+#else
+        const uint64_t multicast_addr =
             get_noc_multicast_addr(noc_x_start, noc_y_start, noc_x_end, noc_y_end, local_l1_addr_, noc.get_noc_id());
+#endif
         noc_semaphore_inc_multicast(multicast_addr, value, num_dests, noc.get_noc_id());
     }
 
 private:
-    uint32_t local_l1_addr_;
+    uintptr_t local_l1_addr_;
 };
 
 }  // namespace experimental

--- a/tt_metal/hw/inc/experimental/noc_semaphore.h
+++ b/tt_metal/hw/inc/experimental/noc_semaphore.h
@@ -65,7 +65,7 @@ public:
      * @param vc The virtual channel to use for the transaction (default is NOC_UNICAST_WRITE_VC).
      */
     void up(const Noc& noc, uint32_t noc_x, uint32_t noc_y, uint32_t value, uint8_t vc = NOC_UNICAST_WRITE_VC) {
-        const uintptr_t dest_noc_addr = get_noc_addr(noc_x, noc_y);
+        const uint64_t dest_noc_addr = get_noc_addr(noc_x, noc_y);
         noc_semaphore_inc(dest_noc_addr, value, noc.get_noc_id(), vc);
     }
 
@@ -136,7 +136,7 @@ public:
         uint32_t noc_y_end,
         uint32_t num_dests,
         bool linked = false) {
-        const uintptr_t multicast_addr =
+        const uint64_t multicast_addr =
             get_noc_multicast_addr(noc_x_start, noc_y_start, noc_x_end, noc_y_end, noc.get_noc_id());
 #ifdef ARCH_QUASAR
         const uintptr_t local_l1_addr = local_l1_addr_ - MEM_L1_UNCACHED_BASE;
@@ -171,7 +171,7 @@ public:
         uint32_t noc_y_end,
         uint32_t value,
         uint32_t num_dests) {
-        const uintptr_t multicast_addr =
+        const uint64_t multicast_addr =
             get_noc_multicast_addr(noc_x_start, noc_y_start, noc_x_end, noc_y_end, noc.get_noc_id());
         noc_semaphore_inc_multicast(multicast_addr, value, num_dests, noc.get_noc_id());
     }
@@ -179,7 +179,7 @@ public:
 private:
     uintptr_t local_l1_addr_;
 
-    uintptr_t get_noc_multicast_addr(
+    uint64_t get_noc_multicast_addr(
         uint32_t noc_x_start, uint32_t noc_y_start, uint32_t noc_x_end, uint32_t noc_y_end, uint8_t noc) const {
 #ifdef ARCH_QUASAR
         return ::get_noc_multicast_addr(
@@ -189,7 +189,7 @@ private:
 #endif
     }
 
-    uintptr_t get_noc_addr(uint32_t noc_x, uint32_t noc_y) const {
+    uint64_t get_noc_addr(uint32_t noc_x, uint32_t noc_y) const {
 #ifdef ARCH_QUASAR
         return ::get_noc_addr(noc_x, noc_y, local_l1_addr_ - MEM_L1_UNCACHED_BASE);
 #else

--- a/tt_metal/hw/inc/experimental/noc_semaphore.h
+++ b/tt_metal/hw/inc/experimental/noc_semaphore.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "dev_mem_map.h"
 #include "experimental/noc.h"
 
 namespace experimental {
@@ -37,7 +38,11 @@ namespace experimental {
 template <ProgrammableCoreType core_type = ProgrammableCoreType::TENSIX>
 class Semaphore {
 public:
-    explicit Semaphore(uint32_t semaphore_id) : local_l1_addr_(get_semaphore<core_type>(semaphore_id)) {}
+    explicit Semaphore(uint32_t semaphore_id) : local_l1_addr_(get_semaphore<core_type>(semaphore_id)) {
+#ifdef ARCH_QUASAR
+        local_l1_addr_ += MEM_L1_UNCACHED_BASE;
+#endif
+    }
 
     /**
      * @brief Increment the semaphore by the specified value.

--- a/tt_metal/hw/inc/internal/dataflow/dataflow_api_common.h
+++ b/tt_metal/hw/inc/internal/dataflow/dataflow_api_common.h
@@ -22,9 +22,11 @@ extern int32_t bank_to_l1_offset[NUM_L1_BANKS];
 #ifdef ARCH_QUASAR
 extern thread_local uint32_t tt_l1_ptr* rta_l1_base;
 extern thread_local uint32_t tt_l1_ptr* crta_l1_base;
+extern thread_local uint32_t tt_l1_ptr* sem_l1_base[];
 #else
 extern uint32_t tt_l1_ptr* rta_l1_base;
 extern uint32_t tt_l1_ptr* crta_l1_base;
+extern uint32_t tt_l1_ptr* sem_l1_base[];
 #endif
 #if defined(WATCHER_ENABLED) && !defined(WATCHER_DISABLE_ASSERT)
 #ifdef ARCH_QUASAR
@@ -35,7 +37,6 @@ extern uint32_t rta_count;
 extern uint32_t crta_count;
 #endif
 #endif
-extern uint32_t tt_l1_ptr* sem_l1_base[];
 
 /** @file */
 

--- a/tt_metal/hw/inc/internal/firmware_common.h
+++ b/tt_metal/hw/inc/internal/firmware_common.h
@@ -112,11 +112,12 @@ uint32_t firmware_config_init(
 #ifdef ARCH_QUASAR
     extern thread_local uint32_t tt_l1_ptr* rta_l1_base;
     extern thread_local uint32_t tt_l1_ptr* crta_l1_base;
+    extern thread_local uint32_t tt_l1_ptr* sem_l1_base[ProgrammableCoreType::COUNT];
 #else
     extern uint32_t tt_l1_ptr* rta_l1_base;
     extern uint32_t tt_l1_ptr* crta_l1_base;
-#endif
     extern uint32_t tt_l1_ptr* sem_l1_base[ProgrammableCoreType::COUNT];
+#endif
 
     // TODO: check the asm for this loop to be sure loads are scheduled ok
     uintptr_t kernel_config_base[ProgrammableCoreType::COUNT];

--- a/tt_metal/hw/sources.cmake
+++ b/tt_metal/hw/sources.cmake
@@ -95,6 +95,7 @@ set(HW_JIT_API_HEADERS
     inc/api/compute/eltwise_unary/where.h
     inc/api/compute/ema.h
     inc/api/compute/experimental/mul_reduce_scalar.h
+    inc/api/compute/experimental/semaphore.h
     inc/api/compute/binary_fmod.h
     inc/api/compute/gcd.h
     inc/api/compute/layernorm.h

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1020,18 +1020,18 @@ void detail::ProgramImpl::validate_circular_buffer_core_ranges(const IDevice* de
 
 void detail::ProgramImpl::init_semaphores(
     const IDevice& device, const CoreCoord& logical_core, uint32_t programmable_core_type_index) const {
-    // const auto& hal = MetalContext::instance().hal();
-    // uint64_t kernel_config_base =
-    //     hal.get_dev_addr(hal.get_programmable_core_type(programmable_core_type_index),
-    //     HalL1MemAddrType::KERNEL_CONFIG);
-    // uint64_t addr = kernel_config_base + this->program_configs_[programmable_core_type_index].sem_offset;
+    const auto& hal = MetalContext::instance().hal();
+    uint64_t kernel_config_base =
+        hal.get_dev_addr(hal.get_programmable_core_type(programmable_core_type_index), HalL1MemAddrType::KERNEL_CONFIG);
+    uint64_t addr = kernel_config_base + this->program_configs_[programmable_core_type_index].sem_offset;
     CoreType core_type = MetalContext::instance().hal().get_core_type(programmable_core_type_index);
     auto semaphores_on_core = this->semaphores_on_core(logical_core, core_type);
     for (auto semaphore : semaphores_on_core) {
-        tt::tt_metal::MetalContext::instance().get_cluster().write_reg(
-            std::vector{semaphore.get().initial_value()}.data(),
-            tt_cxy_pair(device.id(), device.virtual_core_from_logical_core(logical_core, core_type)),
-            0x01840000);
+        tt::tt_metal::MetalContext::instance().get_cluster().write_core(
+            device.id(),
+            device.virtual_core_from_logical_core(logical_core, core_type),
+            std::vector{semaphore.get().initial_value()},
+            addr + semaphore.get().offset());
     }
 }
 

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1020,18 +1020,18 @@ void detail::ProgramImpl::validate_circular_buffer_core_ranges(const IDevice* de
 
 void detail::ProgramImpl::init_semaphores(
     const IDevice& device, const CoreCoord& logical_core, uint32_t programmable_core_type_index) const {
-    const auto& hal = MetalContext::instance().hal();
-    uint64_t kernel_config_base =
-        hal.get_dev_addr(hal.get_programmable_core_type(programmable_core_type_index), HalL1MemAddrType::KERNEL_CONFIG);
-    uint64_t addr = kernel_config_base + this->program_configs_[programmable_core_type_index].sem_offset;
+    // const auto& hal = MetalContext::instance().hal();
+    // uint64_t kernel_config_base =
+    //     hal.get_dev_addr(hal.get_programmable_core_type(programmable_core_type_index),
+    //     HalL1MemAddrType::KERNEL_CONFIG);
+    // uint64_t addr = kernel_config_base + this->program_configs_[programmable_core_type_index].sem_offset;
     CoreType core_type = MetalContext::instance().hal().get_core_type(programmable_core_type_index);
     auto semaphores_on_core = this->semaphores_on_core(logical_core, core_type);
     for (auto semaphore : semaphores_on_core) {
-        tt::tt_metal::MetalContext::instance().get_cluster().write_core(
-            device.id(),
-            device.virtual_core_from_logical_core(logical_core, core_type),
-            std::vector{semaphore.get().initial_value()},
-            addr + semaphore.get().offset());
+        tt::tt_metal::MetalContext::instance().get_cluster().write_reg(
+            std::vector{semaphore.get().initial_value()}.data(),
+            tt_cxy_pair(device.id(), device.virtual_core_from_logical_core(logical_core, core_type)),
+            0x01840000);
     }
 }
 


### PR DESCRIPTION
This PR adds support for semaphores in Quasar. 

These semaphores are meant to be used for:
- DM core <-> DM core communication within a cluster
- Tensix engine <-> DM core communication within a cluster
- Tensix engine <-> Tensix engine communication within a cluster
- DM core <-> DM core communication across clusters

The semaphores are allocated in L1 similar to how they're allocated in Wormhole and Blackhole.

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sagarwal/qsr_semaphores)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sagarwal/qsr_semaphores)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sagarwal/qsr_semaphores)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sagarwal/qsr_semaphores)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sagarwal/qsr_semaphores)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sagarwal/qsr_semaphores)
- [x] New/Existing tests provide coverage for changes
- [x] Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early
