### PR TITLE
[tt-triage] Bump running ops to execute as soon as possible

### DIFF
--- a/tools/triage/dump_running_operations.py
+++ b/tools/triage/dump_running_operations.py
@@ -67,6 +67,7 @@ from ttexalens.umd_device import TimeoutDeviceRegisterError
 
 script_config = ScriptConfig(
     depends=["run_checks", "dispatcher_data", "operation_runtime_map"],
+    priority=ScriptPriority.HIGH,
 )
 
 # Core filtering

--- a/tools/triage/dump_running_operations.py
+++ b/tools/triage/dump_running_operations.py
@@ -59,6 +59,7 @@ from triage import (
     log_check_risc,
     triage_field,
     run_script,
+    ScriptPriority,
 )
 from ttexalens.context import Context
 from ttexalens.coordinate import OnChipCoordinate

--- a/tools/triage/operation_runtime_map.py
+++ b/tools/triage/operation_runtime_map.py
@@ -26,6 +26,7 @@ from inspector_data import run as get_inspector_data, InspectorData
 script_config = ScriptConfig(
     data_provider=True,
     depends=["inspector_data"],
+    priority=ScriptPriority.HIGH,
 )
 
 

--- a/tools/triage/operation_runtime_map.py
+++ b/tools/triage/operation_runtime_map.py
@@ -20,7 +20,7 @@ Owner:
 
 from __future__ import annotations
 
-from triage import ScriptConfig, triage_singleton, run_script, log_check
+from triage import ScriptConfig, triage_singleton, run_script, log_check, ScriptPriority
 from inspector_data import run as get_inspector_data, InspectorData
 
 script_config = ScriptConfig(

--- a/tools/triage/operation_runtime_map.py
+++ b/tools/triage/operation_runtime_map.py
@@ -20,13 +20,12 @@ Owner:
 
 from __future__ import annotations
 
-from triage import ScriptConfig, triage_singleton, run_script, log_check, ScriptPriority
+from triage import ScriptConfig, triage_singleton, run_script, log_check
 from inspector_data import run as get_inspector_data, InspectorData
 
 script_config = ScriptConfig(
     data_provider=True,
     depends=["inspector_data"],
-    priority=ScriptPriority.HIGH,
 )
 
 


### PR DESCRIPTION
`dump_running_operations.py` currently executes after scripts that do a bunch of NoC reads as well as halts - those operations can result in breaking the device in which case we cannot pull out info for running operations.

The idea behind this PR is to bump `dump_running_operations.py` to execute as soon as possible (after data provider scripts and scripts that don't do much traffic) so that we can reduce the chances of us losing the data that is currently most important for model hangs. 

This is a "mitigation" step before we solve the problem of triage "views" (different teams can specify different "views" of triage which will execute only a subset of scripts relevant to those teams).