### PR TITLE
Fixing auto-rank bindings issue

### DIFF
--- a/tests/tt_metal/tt_fabric/fabric_router/test_topology_mapper_utils.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_topology_mapper_utils.cpp
@@ -120,7 +120,7 @@ protected:
     template <typename NodeType>
     static auto build_grid_adjacency(const std::vector<NodeType>& nodes, size_t rows, size_t cols) {
         std::map<NodeType, std::vector<NodeType>> adj;
-        auto idx = [cols](size_t r, size_t c) { return r * cols + c; };
+        auto idx = [cols](size_t r, size_t c) { return (r * cols) + c; };
 
         for (size_t r = 0; r < rows; ++r) {
             for (size_t c = 0; c < cols; ++c) {
@@ -148,7 +148,7 @@ protected:
     template <typename NodeType>
     static auto build_torus_adjacency(const std::vector<NodeType>& nodes, size_t rows, size_t cols) {
         std::map<NodeType, std::vector<NodeType>> adj;
-        auto idx = [cols](size_t r, size_t c) { return r * cols + c; };
+        auto idx = [cols](size_t r, size_t c) { return (r * cols) + c; };
 
         for (size_t r = 0; r < rows; ++r) {
             for (size_t c = 0; c < cols; ++c) {
@@ -2916,7 +2916,7 @@ TEST_F(TopologyMapperUtilsTest, MapMultiMeshToPhysical_FourNodesFourHosts_NoHost
             if (rank_it != fabric_node_id_to_mesh_rank[mesh0].end() && rank_it->second.get() == rank) {
                 // Find which host this ASIC belongs to
                 for (const auto& [hostname, host_asics] : config.hostname_to_asics) {
-                    if (host_asics.find(asic_id) != host_asics.end()) {
+                    if (host_asics.contains(asic_id)) {
                         hosts_for_rank.insert(hostname);
                         break;
                     }

--- a/tests/tt_metal/tt_fabric/fabric_router/test_topology_mapper_utils.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_topology_mapper_utils.cpp
@@ -142,6 +142,33 @@ protected:
         return adj;
     }
 
+    // Build a 2D torus: rows x cols with 4-connectivity and wrap-around connections
+    // X-direction wrap-around: column 0 connects to column (cols-1), and vice versa
+    // Y-direction wrap-around: row 0 connects to row (rows-1), and vice versa
+    template <typename NodeType>
+    static auto build_torus_adjacency(const std::vector<NodeType>& nodes, size_t rows, size_t cols) {
+        std::map<NodeType, std::vector<NodeType>> adj;
+        auto idx = [cols](size_t r, size_t c) { return r * cols + c; };
+
+        for (size_t r = 0; r < rows; ++r) {
+            for (size_t c = 0; c < cols; ++c) {
+                adj[nodes[idx(r, c)]] = {};
+                // Y-direction: wrap-around (row 0 connects to row rows-1, row rows-1 connects to row 0)
+                size_t r_up = (r == 0) ? (rows - 1) : (r - 1);
+                size_t r_down = (r == rows - 1) ? 0 : (r + 1);
+                adj[nodes[idx(r, c)]].push_back(nodes[idx(r_up, c)]);
+                adj[nodes[idx(r, c)]].push_back(nodes[idx(r_down, c)]);
+
+                // X-direction: wrap-around (column 0 connects to column cols-1, column cols-1 connects to column 0)
+                size_t c_left = (c == 0) ? (cols - 1) : (c - 1);
+                size_t c_right = (c == cols - 1) ? 0 : (c + 1);
+                adj[nodes[idx(r, c)]].push_back(nodes[idx(r, c_left)]);
+                adj[nodes[idx(r, c)]].push_back(nodes[idx(r, c_right)]);
+            }
+        }
+        return adj;
+    }
+
     // -------------------------------------------------------------------------
     // Rank map builders
     // -------------------------------------------------------------------------
@@ -2815,6 +2842,342 @@ TEST_F(TopologyMapperUtilsTest, MapMultiMeshToPhysical_FourNodesFourHosts_Partia
             << "Rank-1 fabric node (chip 1) must map to bound ASIC " << bound_asic_idx;
         verify_connectivity_preserved(result, logical_adj, physical_adj);
     }
+}
+
+TEST_F(TopologyMapperUtilsTest, MapMultiMeshToPhysical_FourNodesFourHosts_NoHostRankAssigned) {
+    // 8 nodes in a 2x4 torus (2 rows, 4 columns) with wrap-around connections in x and y directions.
+    // 4 hosts with 2 ASICs each. All ASIC ranks are UNSET (no host rank assigned).
+    // 4 ranks total, matching 4 hosts. Each rank maps to exactly one host, and each host maps to exactly one rank.
+    // fabric_node_id_to_mesh_rank: each host (1x2 = 2 ASICs) maps to one rank (4 ranks total).
+    using namespace ::tt::tt_fabric;
+
+    const MeshId mesh0{0};
+    constexpr size_t kRows = 2;
+    constexpr size_t kCols = 4;
+    constexpr size_t kNumNodes = kRows * kCols;
+    constexpr size_t kAsicsPerHost = 2;
+
+    std::vector<FabricNodeId> logical_nodes = make_nodes(kNumNodes);
+    auto logical_adj = build_torus_adjacency(logical_nodes, kRows, kCols);
+
+    LogicalMultiMeshGraph logical_multi_mesh_graph;
+    logical_multi_mesh_graph.mesh_adjacency_graphs_[mesh0] = AdjacencyGraph<FabricNodeId>(logical_adj);
+    AdjacencyGraph<MeshId>::AdjacencyMap logical_mesh_level_adj;
+    logical_mesh_level_adj[mesh0] = {};
+    logical_multi_mesh_graph.mesh_level_graph_ = AdjacencyGraph<MeshId>(logical_mesh_level_adj);
+    logical_multi_mesh_graph.mesh_exit_node_graphs_[mesh0] = AdjacencyGraph<LogicalExitNode>();
+
+    std::vector<tt::tt_metal::AsicID> physical_asics = make_asics(kNumNodes, 100);
+    auto physical_adj = build_torus_adjacency(physical_asics, kRows, kCols);
+
+    PhysicalMultiMeshGraph physical_multi_mesh_graph;
+    physical_multi_mesh_graph.mesh_adjacency_graphs_[mesh0] = AdjacencyGraph<tt::tt_metal::AsicID>(physical_adj);
+    AdjacencyGraph<MeshId>::AdjacencyMap physical_mesh_level_adj;
+    physical_mesh_level_adj[mesh0] = {};
+    physical_multi_mesh_graph.mesh_level_graph_ = AdjacencyGraph<MeshId>(physical_mesh_level_adj);
+    physical_multi_mesh_graph.mesh_exit_node_graphs_[mesh0] = AdjacencyGraph<PhysicalExitNode>();
+
+    // Fabric node ranks: each host (1x2 = 2 ASICs) maps to one rank
+    // Rank 0: nodes 0,1; Rank 1: nodes 2,3; Rank 2: nodes 4,5; Rank 3: nodes 6,7
+    std::map<MeshId, std::map<FabricNodeId, MeshHostRankId>> fabric_node_id_to_mesh_rank;
+    for (size_t i = 0; i < kNumNodes; ++i) {
+        fabric_node_id_to_mesh_rank[mesh0][logical_nodes[i]] = MeshHostRankId{i / kAsicsPerHost};
+    }
+
+    TopologyMappingConfig config;
+    config.strict_mode = true;
+    config.disable_rank_bindings = false;
+    // 4 hosts, 2 ASICs each. Rotated layout - solver picks assignment (same-host same-rank enforced).
+    config.hostname_to_asics["host0"] = {physical_asics[2], physical_asics[3]};
+    config.hostname_to_asics["host1"] = {physical_asics[6], physical_asics[7]};
+    config.hostname_to_asics["host2"] = {physical_asics[4], physical_asics[5]};
+    config.hostname_to_asics["host3"] = {physical_asics[0], physical_asics[1]};
+
+    // All ASIC ranks are UNSET (no host rank assigned)
+    std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>> asic_id_to_mesh_rank;
+    for (size_t i = 0; i < kNumNodes; ++i) {
+        asic_id_to_mesh_rank[mesh0][physical_asics[i]] = ::tt::tt_fabric::MESH_HOST_RANK_UNSET;
+    }
+
+    const auto result = map_multi_mesh_to_physical(
+        logical_multi_mesh_graph, physical_multi_mesh_graph, config, asic_id_to_mesh_rank, fabric_node_id_to_mesh_rank);
+
+    ASSERT_TRUE(result.success) << "Mapping with no host rank assigned should succeed: " << result.error_message;
+    verify_bidirectional_consistency(result);
+    EXPECT_EQ(result.fabric_node_to_asic.size(), kNumNodes);
+    verify_connectivity_preserved(result, logical_adj, physical_adj);
+
+    // Verify that each rank maps to exactly one host
+    constexpr size_t kNumRanks = 4;
+    for (size_t rank = 0; rank < kNumRanks; ++rank) {
+        std::set<std::string> hosts_for_rank;
+        for (const auto& [fabric_node, asic_id] : result.fabric_node_to_asic) {
+            auto rank_it = fabric_node_id_to_mesh_rank[mesh0].find(fabric_node);
+            if (rank_it != fabric_node_id_to_mesh_rank[mesh0].end() && rank_it->second.get() == rank) {
+                // Find which host this ASIC belongs to
+                for (const auto& [hostname, host_asics] : config.hostname_to_asics) {
+                    if (host_asics.find(asic_id) != host_asics.end()) {
+                        hosts_for_rank.insert(hostname);
+                        break;
+                    }
+                }
+            }
+        }
+        EXPECT_EQ(hosts_for_rank.size(), 1u)
+            << "Rank " << rank << " should map to exactly one host, but found " << hosts_for_rank.size() << " host(s)";
+    }
+
+    // Also verify same-host same-rank (each host maps to exactly one rank)
+    verify_same_host_same_rank(result, fabric_node_id_to_mesh_rank[mesh0], config.hostname_to_asics);
+}
+
+TEST_F(TopologyMapperUtilsTest, MapMultiMeshToPhysical_NoHostRankAssigned_2x2Torus) {
+    // 2x2 torus, 2 hosts with 2 ASICs each, all UNSET.
+    using namespace ::tt::tt_fabric;
+
+    const MeshId mesh0{0};
+    constexpr size_t kRows = 2;
+    constexpr size_t kCols = 2;
+    constexpr size_t kNumNodes = kRows * kCols;
+
+    std::vector<FabricNodeId> logical_nodes = make_nodes(kNumNodes);
+    auto logical_adj = build_torus_adjacency(logical_nodes, kRows, kCols);
+
+    LogicalMultiMeshGraph logical_multi_mesh_graph;
+    logical_multi_mesh_graph.mesh_adjacency_graphs_[mesh0] = AdjacencyGraph<FabricNodeId>(logical_adj);
+    AdjacencyGraph<MeshId>::AdjacencyMap logical_mesh_level_adj;
+    logical_mesh_level_adj[mesh0] = {};
+    logical_multi_mesh_graph.mesh_level_graph_ = AdjacencyGraph<MeshId>(logical_mesh_level_adj);
+    logical_multi_mesh_graph.mesh_exit_node_graphs_[mesh0] = AdjacencyGraph<LogicalExitNode>();
+
+    std::vector<tt::tt_metal::AsicID> physical_asics = make_asics(kNumNodes, 100);
+    auto physical_adj = build_torus_adjacency(physical_asics, kRows, kCols);
+
+    PhysicalMultiMeshGraph physical_multi_mesh_graph;
+    physical_multi_mesh_graph.mesh_adjacency_graphs_[mesh0] = AdjacencyGraph<tt::tt_metal::AsicID>(physical_adj);
+    AdjacencyGraph<MeshId>::AdjacencyMap physical_mesh_level_adj;
+    physical_mesh_level_adj[mesh0] = {};
+    physical_multi_mesh_graph.mesh_level_graph_ = AdjacencyGraph<MeshId>(physical_mesh_level_adj);
+    physical_multi_mesh_graph.mesh_exit_node_graphs_[mesh0] = AdjacencyGraph<PhysicalExitNode>();
+
+    std::map<MeshId, std::map<FabricNodeId, MeshHostRankId>> fabric_node_id_to_mesh_rank;
+    fabric_node_id_to_mesh_rank[mesh0][logical_nodes[0]] = MeshHostRankId{0};
+    fabric_node_id_to_mesh_rank[mesh0][logical_nodes[1]] = MeshHostRankId{0};
+    fabric_node_id_to_mesh_rank[mesh0][logical_nodes[2]] = MeshHostRankId{1};
+    fabric_node_id_to_mesh_rank[mesh0][logical_nodes[3]] = MeshHostRankId{1};
+
+    TopologyMappingConfig config;
+    config.strict_mode = true;
+    config.disable_rank_bindings = false;
+    config.hostname_to_asics["host0"] = {physical_asics[0], physical_asics[1]};
+    config.hostname_to_asics["host1"] = {physical_asics[2], physical_asics[3]};
+
+    std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>> asic_id_to_mesh_rank;
+    for (size_t i = 0; i < kNumNodes; ++i) {
+        asic_id_to_mesh_rank[mesh0][physical_asics[i]] = ::tt::tt_fabric::MESH_HOST_RANK_UNSET;
+    }
+
+    const auto result = map_multi_mesh_to_physical(
+        logical_multi_mesh_graph, physical_multi_mesh_graph, config, asic_id_to_mesh_rank, fabric_node_id_to_mesh_rank);
+
+    ASSERT_TRUE(result.success) << result.error_message;
+    verify_bidirectional_consistency(result);
+    EXPECT_EQ(result.fabric_node_to_asic.size(), kNumNodes);
+    verify_connectivity_preserved(result, logical_adj, physical_adj);
+    verify_same_host_same_rank(result, fabric_node_id_to_mesh_rank[mesh0], config.hostname_to_asics);
+}
+
+TEST_F(TopologyMapperUtilsTest, MapMultiMeshToPhysical_NoHostRankAssigned_1x1) {
+    // 1x1 (single node), 1 host with 1 ASIC, all UNSET.
+    using namespace ::tt::tt_fabric;
+
+    const MeshId mesh0{0};
+    constexpr size_t kRows = 1;
+    constexpr size_t kCols = 1;
+    constexpr size_t kNumNodes = 1;
+
+    std::vector<FabricNodeId> logical_nodes = make_nodes(kNumNodes);
+    auto logical_adj = build_torus_adjacency(logical_nodes, kRows, kCols);
+
+    LogicalMultiMeshGraph logical_multi_mesh_graph;
+    logical_multi_mesh_graph.mesh_adjacency_graphs_[mesh0] = AdjacencyGraph<FabricNodeId>(logical_adj);
+    AdjacencyGraph<MeshId>::AdjacencyMap logical_mesh_level_adj;
+    logical_mesh_level_adj[mesh0] = {};
+    logical_multi_mesh_graph.mesh_level_graph_ = AdjacencyGraph<MeshId>(logical_mesh_level_adj);
+    logical_multi_mesh_graph.mesh_exit_node_graphs_[mesh0] = AdjacencyGraph<LogicalExitNode>();
+
+    std::vector<tt::tt_metal::AsicID> physical_asics = make_asics(kNumNodes, 200);
+    auto physical_adj = build_torus_adjacency(physical_asics, kRows, kCols);
+
+    PhysicalMultiMeshGraph physical_multi_mesh_graph;
+    physical_multi_mesh_graph.mesh_adjacency_graphs_[mesh0] = AdjacencyGraph<tt::tt_metal::AsicID>(physical_adj);
+    AdjacencyGraph<MeshId>::AdjacencyMap physical_mesh_level_adj;
+    physical_mesh_level_adj[mesh0] = {};
+    physical_multi_mesh_graph.mesh_level_graph_ = AdjacencyGraph<MeshId>(physical_mesh_level_adj);
+    physical_multi_mesh_graph.mesh_exit_node_graphs_[mesh0] = AdjacencyGraph<PhysicalExitNode>();
+
+    std::map<MeshId, std::map<FabricNodeId, MeshHostRankId>> fabric_node_id_to_mesh_rank;
+    fabric_node_id_to_mesh_rank[mesh0][logical_nodes[0]] = MeshHostRankId{0};
+
+    TopologyMappingConfig config;
+    config.strict_mode = true;
+    config.disable_rank_bindings = false;
+    config.hostname_to_asics["host0"] = {physical_asics[0]};
+
+    std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>> asic_id_to_mesh_rank;
+    asic_id_to_mesh_rank[mesh0][physical_asics[0]] = ::tt::tt_fabric::MESH_HOST_RANK_UNSET;
+
+    const auto result = map_multi_mesh_to_physical(
+        logical_multi_mesh_graph, physical_multi_mesh_graph, config, asic_id_to_mesh_rank, fabric_node_id_to_mesh_rank);
+
+    ASSERT_TRUE(result.success) << result.error_message;
+    verify_bidirectional_consistency(result);
+    EXPECT_EQ(result.fabric_node_to_asic.size(), 1u);
+}
+
+TEST_F(TopologyMapperUtilsTest, MapMultiMeshToPhysical_NoHostRankAssigned_4x4TorusFourHosts) {
+    // 4x4 torus, 4 hosts with 4 ASICs each, all UNSET.
+    using namespace ::tt::tt_fabric;
+
+    const MeshId mesh0{0};
+    constexpr size_t kRows = 4;
+    constexpr size_t kCols = 4;
+    constexpr size_t kNumNodes = kRows * kCols;
+    constexpr size_t kAsicsPerHost = 4;
+
+    std::vector<FabricNodeId> logical_nodes = make_nodes(kNumNodes);
+    auto logical_adj = build_torus_adjacency(logical_nodes, kRows, kCols);
+
+    LogicalMultiMeshGraph logical_multi_mesh_graph;
+    logical_multi_mesh_graph.mesh_adjacency_graphs_[mesh0] = AdjacencyGraph<FabricNodeId>(logical_adj);
+    AdjacencyGraph<MeshId>::AdjacencyMap logical_mesh_level_adj;
+    logical_mesh_level_adj[mesh0] = {};
+    logical_multi_mesh_graph.mesh_level_graph_ = AdjacencyGraph<MeshId>(logical_mesh_level_adj);
+    logical_multi_mesh_graph.mesh_exit_node_graphs_[mesh0] = AdjacencyGraph<LogicalExitNode>();
+
+    std::vector<tt::tt_metal::AsicID> physical_asics = make_asics(kNumNodes, 300);
+    auto physical_adj = build_torus_adjacency(physical_asics, kRows, kCols);
+
+    PhysicalMultiMeshGraph physical_multi_mesh_graph;
+    physical_multi_mesh_graph.mesh_adjacency_graphs_[mesh0] = AdjacencyGraph<tt::tt_metal::AsicID>(physical_adj);
+    AdjacencyGraph<MeshId>::AdjacencyMap physical_mesh_level_adj;
+    physical_mesh_level_adj[mesh0] = {};
+    physical_multi_mesh_graph.mesh_level_graph_ = AdjacencyGraph<MeshId>(physical_mesh_level_adj);
+    physical_multi_mesh_graph.mesh_exit_node_graphs_[mesh0] = AdjacencyGraph<PhysicalExitNode>();
+
+    std::map<MeshId, std::map<FabricNodeId, MeshHostRankId>> fabric_node_id_to_mesh_rank;
+    for (size_t i = 0; i < kNumNodes; ++i) {
+        fabric_node_id_to_mesh_rank[mesh0][logical_nodes[i]] = MeshHostRankId{i / kAsicsPerHost};
+    }
+
+    TopologyMappingConfig config;
+    config.strict_mode = true;
+    config.disable_rank_bindings = false;
+    config.hostname_to_asics["host0"] = {physical_asics[4], physical_asics[5], physical_asics[6], physical_asics[7]};
+    config.hostname_to_asics["host1"] = {physical_asics[0], physical_asics[1], physical_asics[2], physical_asics[3]};
+    config.hostname_to_asics["host2"] = {physical_asics[8], physical_asics[9], physical_asics[10], physical_asics[11]};
+    config.hostname_to_asics["host3"] = {
+        physical_asics[12], physical_asics[13], physical_asics[14], physical_asics[15]};
+
+    std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>> asic_id_to_mesh_rank;
+    for (size_t i = 0; i < kNumNodes; ++i) {
+        asic_id_to_mesh_rank[mesh0][physical_asics[i]] = ::tt::tt_fabric::MESH_HOST_RANK_UNSET;
+    }
+
+    const auto result = map_multi_mesh_to_physical(
+        logical_multi_mesh_graph, physical_multi_mesh_graph, config, asic_id_to_mesh_rank, fabric_node_id_to_mesh_rank);
+
+    ASSERT_TRUE(result.success) << result.error_message;
+    verify_bidirectional_consistency(result);
+    EXPECT_EQ(result.fabric_node_to_asic.size(), kNumNodes);
+    verify_connectivity_preserved(result, logical_adj, physical_adj);
+    verify_same_host_same_rank(result, fabric_node_id_to_mesh_rank[mesh0], config.hostname_to_asics);
+}
+
+TEST_F(TopologyMapperUtilsTest, MapMultiMeshToPhysical_NoHostRankAssigned_4x6TorusSixHosts2x3) {
+    // 4x6 torus, 6 hosts in 2x3 layout (4 ASICs per host), all UNSET.
+    // Hosts as 2x2 blocks: host0=(0,1,6,7), host1=(2,3,8,9), host2=(4,5,10,11),
+    // host3=(12,13,18,19), host4=(14,15,20,21), host5=(16,17,22,23).
+    using namespace ::tt::tt_fabric;
+
+    const MeshId mesh0{0};
+    constexpr size_t kRows = 4;
+    constexpr size_t kCols = 6;
+    constexpr size_t kNumNodes = kRows * kCols;
+
+    std::vector<FabricNodeId> logical_nodes = make_nodes(kNumNodes);
+    auto logical_adj = build_torus_adjacency(logical_nodes, kRows, kCols);
+
+    LogicalMultiMeshGraph logical_multi_mesh_graph;
+    logical_multi_mesh_graph.mesh_adjacency_graphs_[mesh0] = AdjacencyGraph<FabricNodeId>(logical_adj);
+    AdjacencyGraph<MeshId>::AdjacencyMap logical_mesh_level_adj;
+    logical_mesh_level_adj[mesh0] = {};
+    logical_multi_mesh_graph.mesh_level_graph_ = AdjacencyGraph<MeshId>(logical_mesh_level_adj);
+    logical_multi_mesh_graph.mesh_exit_node_graphs_[mesh0] = AdjacencyGraph<LogicalExitNode>();
+
+    std::vector<tt::tt_metal::AsicID> physical_asics = make_asics(kNumNodes, 400);
+    auto physical_adj = build_torus_adjacency(physical_asics, kRows, kCols);
+
+    PhysicalMultiMeshGraph physical_multi_mesh_graph;
+    physical_multi_mesh_graph.mesh_adjacency_graphs_[mesh0] = AdjacencyGraph<tt::tt_metal::AsicID>(physical_adj);
+    AdjacencyGraph<MeshId>::AdjacencyMap physical_mesh_level_adj;
+    physical_mesh_level_adj[mesh0] = {};
+    physical_multi_mesh_graph.mesh_level_graph_ = AdjacencyGraph<MeshId>(physical_mesh_level_adj);
+    physical_multi_mesh_graph.mesh_exit_node_graphs_[mesh0] = AdjacencyGraph<PhysicalExitNode>();
+
+    // Ranks align with 2x3 host layout: rank i <- fabric nodes in host i's 2x2 block.
+    std::map<MeshId, std::map<FabricNodeId, MeshHostRankId>> fabric_node_id_to_mesh_rank;
+    fabric_node_id_to_mesh_rank[mesh0][logical_nodes[0]] = MeshHostRankId{0};
+    fabric_node_id_to_mesh_rank[mesh0][logical_nodes[1]] = MeshHostRankId{0};
+    fabric_node_id_to_mesh_rank[mesh0][logical_nodes[6]] = MeshHostRankId{0};
+    fabric_node_id_to_mesh_rank[mesh0][logical_nodes[7]] = MeshHostRankId{0};
+    fabric_node_id_to_mesh_rank[mesh0][logical_nodes[2]] = MeshHostRankId{1};
+    fabric_node_id_to_mesh_rank[mesh0][logical_nodes[3]] = MeshHostRankId{1};
+    fabric_node_id_to_mesh_rank[mesh0][logical_nodes[8]] = MeshHostRankId{1};
+    fabric_node_id_to_mesh_rank[mesh0][logical_nodes[9]] = MeshHostRankId{1};
+    fabric_node_id_to_mesh_rank[mesh0][logical_nodes[4]] = MeshHostRankId{2};
+    fabric_node_id_to_mesh_rank[mesh0][logical_nodes[5]] = MeshHostRankId{2};
+    fabric_node_id_to_mesh_rank[mesh0][logical_nodes[10]] = MeshHostRankId{2};
+    fabric_node_id_to_mesh_rank[mesh0][logical_nodes[11]] = MeshHostRankId{2};
+    fabric_node_id_to_mesh_rank[mesh0][logical_nodes[12]] = MeshHostRankId{3};
+    fabric_node_id_to_mesh_rank[mesh0][logical_nodes[13]] = MeshHostRankId{3};
+    fabric_node_id_to_mesh_rank[mesh0][logical_nodes[18]] = MeshHostRankId{3};
+    fabric_node_id_to_mesh_rank[mesh0][logical_nodes[19]] = MeshHostRankId{3};
+    fabric_node_id_to_mesh_rank[mesh0][logical_nodes[14]] = MeshHostRankId{4};
+    fabric_node_id_to_mesh_rank[mesh0][logical_nodes[15]] = MeshHostRankId{4};
+    fabric_node_id_to_mesh_rank[mesh0][logical_nodes[20]] = MeshHostRankId{4};
+    fabric_node_id_to_mesh_rank[mesh0][logical_nodes[21]] = MeshHostRankId{4};
+    fabric_node_id_to_mesh_rank[mesh0][logical_nodes[16]] = MeshHostRankId{5};
+    fabric_node_id_to_mesh_rank[mesh0][logical_nodes[17]] = MeshHostRankId{5};
+    fabric_node_id_to_mesh_rank[mesh0][logical_nodes[22]] = MeshHostRankId{5};
+    fabric_node_id_to_mesh_rank[mesh0][logical_nodes[23]] = MeshHostRankId{5};
+
+    TopologyMappingConfig config;
+    config.strict_mode = true;
+    config.disable_rank_bindings = false;
+    config.hostname_to_asics["host0"] = {physical_asics[2], physical_asics[3], physical_asics[8], physical_asics[9]};
+    config.hostname_to_asics["host1"] = {physical_asics[0], physical_asics[1], physical_asics[6], physical_asics[7]};
+    config.hostname_to_asics["host2"] = {physical_asics[4], physical_asics[5], physical_asics[10], physical_asics[11]};
+    config.hostname_to_asics["host3"] = {
+        physical_asics[12], physical_asics[13], physical_asics[18], physical_asics[19]};
+    config.hostname_to_asics["host4"] = {
+        physical_asics[14], physical_asics[15], physical_asics[20], physical_asics[21]};
+    config.hostname_to_asics["host5"] = {
+        physical_asics[16], physical_asics[17], physical_asics[22], physical_asics[23]};
+
+    std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>> asic_id_to_mesh_rank;
+    for (size_t i = 0; i < kNumNodes; ++i) {
+        asic_id_to_mesh_rank[mesh0][physical_asics[i]] = ::tt::tt_fabric::MESH_HOST_RANK_UNSET;
+    }
+
+    const auto result = map_multi_mesh_to_physical(
+        logical_multi_mesh_graph, physical_multi_mesh_graph, config, asic_id_to_mesh_rank, fabric_node_id_to_mesh_rank);
+
+    ASSERT_TRUE(result.success) << result.error_message;
+    verify_bidirectional_consistency(result);
+    EXPECT_EQ(result.fabric_node_to_asic.size(), kNumNodes);
+    verify_connectivity_preserved(result, logical_adj, physical_adj);
+    verify_same_host_same_rank(result, fabric_node_id_to_mesh_rank[mesh0], config.hostname_to_asics);
 }
 
 TEST_F(TopologyMapperUtilsTest, MapMultiMeshToPhysical_TwoHostsTwoAsicsEach_RotatedSplit_SameHostSameRank) {

--- a/tests/tt_metal/tt_fabric/fabric_router/test_topology_solver.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_topology_solver.cpp
@@ -2873,6 +2873,89 @@ TEST_F(TopologySolverTest, MappingConstraintsManyToMany) {
         constraints.is_valid_mapping(4, 10));  // Not in target_nodes set (but constraint still applies if queried)
 }
 
+// Same-group constraint: target groups map within global group boundaries (no splitting).
+// Multiple target groups may share one global group.
+TEST_F(TopologySolverTest, SolveTopologyMapping_SameGroupConstraint_Basic) {
+    // Chain 1-2-3-4; groups {1,2}, {3,4} -> globals {10,11}, {12,13}
+    AdjacencyGraph<TestTargetNode>::AdjacencyMap target_adj;
+    target_adj[1] = {2};
+    target_adj[2] = {1, 3};
+    target_adj[3] = {2, 4};
+    target_adj[4] = {3};
+    AdjacencyGraph<TestTargetNode> target_graph(target_adj);
+
+    AdjacencyGraph<TestGlobalNode>::AdjacencyMap global_adj;
+    global_adj[10] = {11};
+    global_adj[11] = {10, 12};
+    global_adj[12] = {11, 13};
+    global_adj[13] = {12};
+    AdjacencyGraph<TestGlobalNode> global_graph(global_adj);
+
+    MappingConstraints<TestTargetNode, TestGlobalNode> constraints;
+    constraints.set_same_rank_groups_constraint(
+        std::vector<std::set<TestTargetNode>>{{1, 2}, {3, 4}},
+        std::vector<std::set<TestGlobalNode>>{{10, 11}, {12, 13}});
+
+    auto result = solve_topology_mapping(target_graph, global_graph, constraints, ConnectionValidationMode::RELAXED);
+    ASSERT_TRUE(result.success) << result.error_message;
+
+    TestGlobalNode g1 = result.target_to_global.at(1), g2 = result.target_to_global.at(2);
+    TestGlobalNode g3 = result.target_to_global.at(3), g4 = result.target_to_global.at(4);
+    bool grp0_first = (g1 == 10 || g1 == 11) && (g2 == 10 || g2 == 11);
+    bool grp1_first = (g3 == 10 || g3 == 11) && (g4 == 10 || g4 == 11);
+    EXPECT_NE(grp0_first, grp1_first) << "Each target group stays within one global group";
+}
+
+TEST_F(TopologySolverTest, SolveTopologyMapping_SameGroupConstraint_SharedGlobalGroup) {
+    // {1} {2} map to {1,3,2}: multiple target groups may share one global group; no boundary breaking
+    AdjacencyGraph<TestTargetNode>::AdjacencyMap target_adj;
+    target_adj[1] = {2};
+    target_adj[2] = {1};
+    AdjacencyGraph<TestTargetNode> target_graph(target_adj);
+
+    AdjacencyGraph<TestGlobalNode>::AdjacencyMap global_adj;
+    global_adj[1] = {3};
+    global_adj[3] = {1, 2};
+    global_adj[2] = {3};
+    AdjacencyGraph<TestGlobalNode> global_graph(global_adj);
+
+    MappingConstraints<TestTargetNode, TestGlobalNode> constraints;
+    constraints.set_same_rank_groups_constraint(
+        std::vector<std::set<TestTargetNode>>{{1}, {2}}, std::vector<std::set<TestGlobalNode>>{{1, 3, 2}});
+
+    auto result = solve_topology_mapping(target_graph, global_graph, constraints, ConnectionValidationMode::RELAXED);
+    ASSERT_TRUE(result.success) << result.error_message;
+
+    // Both targets in same global group; chain 1-2 maps to path in 1-3-2
+    EXPECT_TRUE(
+        (result.target_to_global.at(1) == 1 && result.target_to_global.at(2) == 3) ||
+        (result.target_to_global.at(1) == 3 && result.target_to_global.at(2) == 1) ||
+        (result.target_to_global.at(1) == 3 && result.target_to_global.at(2) == 2) ||
+        (result.target_to_global.at(1) == 2 && result.target_to_global.at(2) == 3));
+}
+
+TEST_F(TopologySolverTest, SolveTopologyMapping_SameGroupConstraint_SplittingTargetGroupRejected) {
+    // [1,2,3] must stay together; globals {10},{11},{12} force splitting -> should fail
+    AdjacencyGraph<TestTargetNode>::AdjacencyMap target_adj;
+    target_adj[1] = {2};
+    target_adj[2] = {1, 3};
+    target_adj[3] = {2};
+    AdjacencyGraph<TestTargetNode> target_graph(target_adj);
+
+    AdjacencyGraph<TestGlobalNode>::AdjacencyMap global_adj;
+    global_adj[10] = {11};
+    global_adj[11] = {10, 12};
+    global_adj[12] = {11};
+    AdjacencyGraph<TestGlobalNode> global_graph(global_adj);
+
+    MappingConstraints<TestTargetNode, TestGlobalNode> constraints;
+    constraints.set_same_rank_groups_constraint(
+        std::vector<std::set<TestTargetNode>>{{1, 2, 3}}, std::vector<std::set<TestGlobalNode>>{{10}, {11}, {12}});
+
+    auto result = solve_topology_mapping(target_graph, global_graph, constraints, ConnectionValidationMode::RELAXED);
+    ASSERT_FALSE(result.success) << "Target group {1,2,3} cannot be split across global groups {10},{11},{12}";
+}
+
 TEST_F(TopologySolverTest, MappingConstraintsManyToManyIntersection) {
     // Test many-to-many constraint intersection with existing constraints
     MappingConstraints<TestTargetNode, TestGlobalNode> constraints;

--- a/tests/tt_metal/tt_fabric/golden_mapping_files/T3K2x2AssignZDirectionControlPlaneInit.yaml
+++ b/tests/tt_metal/tt_fabric/golden_mapping_files/T3K2x2AssignZDirectionControlPlaneInit.yaml
@@ -3,7 +3,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_0
       mesh:
         - mesh: 0
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 0
@@ -39,7 +39,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_1
       mesh:
         - mesh: 1
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 0

--- a/tests/tt_metal/tt_fabric/golden_mapping_files/Test32x4QuadGalaxyControlPlaneInit.yaml
+++ b/tests/tt_metal/tt_fabric/golden_mapping_files/Test32x4QuadGalaxyControlPlaneInit.yaml
@@ -10,7 +10,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 28
+                chip_id: 67
               asic_id: 10420692328979940533
             - umd_chip_id: 1
               asic_position:
@@ -18,7 +18,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 24
+                chip_id: 71
               asic_id: 16858847167973294033
             - umd_chip_id: 2
               asic_position:
@@ -26,7 +26,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 20
+                chip_id: 75
               asic_id: 11943907749601514269
             - umd_chip_id: 3
               asic_position:
@@ -34,7 +34,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 16
+                chip_id: 79
               asic_id: 2260407651912694205
             - umd_chip_id: 4
               asic_position:
@@ -42,7 +42,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 29
+                chip_id: 66
               asic_id: 3545058606368020308
             - umd_chip_id: 5
               asic_position:
@@ -50,7 +50,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 25
+                chip_id: 70
               asic_id: 7322821320465174274
             - umd_chip_id: 6
               asic_position:
@@ -58,7 +58,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 21
+                chip_id: 74
               asic_id: 15748125374049650739
             - umd_chip_id: 7
               asic_position:
@@ -66,7 +66,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 17
+                chip_id: 78
               asic_id: 14981437604426635727
             - umd_chip_id: 8
               asic_position:
@@ -74,7 +74,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 0
+                chip_id: 95
               asic_id: 9005846771902407868
             - umd_chip_id: 9
               asic_position:
@@ -82,7 +82,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 4
+                chip_id: 91
               asic_id: 13261964671183476486
             - umd_chip_id: 10
               asic_position:
@@ -90,7 +90,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 8
+                chip_id: 87
               asic_id: 654113421763867332
             - umd_chip_id: 11
               asic_position:
@@ -98,7 +98,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 12
+                chip_id: 83
               asic_id: 2903668744338173225
             - umd_chip_id: 12
               asic_position:
@@ -106,7 +106,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 1
+                chip_id: 94
               asic_id: 16662089296156389067
             - umd_chip_id: 13
               asic_position:
@@ -114,7 +114,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 5
+                chip_id: 90
               asic_id: 8459453417937019583
             - umd_chip_id: 14
               asic_position:
@@ -122,7 +122,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 9
+                chip_id: 86
               asic_id: 15320864729297851414
             - umd_chip_id: 15
               asic_position:
@@ -130,7 +130,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 13
+                chip_id: 82
               asic_id: 15126157745808670475
             - umd_chip_id: 16
               asic_position:
@@ -138,7 +138,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 3
+                chip_id: 92
               asic_id: 14128960817017869870
             - umd_chip_id: 17
               asic_position:
@@ -146,7 +146,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 7
+                chip_id: 88
               asic_id: 10278550171993314862
             - umd_chip_id: 18
               asic_position:
@@ -154,7 +154,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 11
+                chip_id: 84
               asic_id: 14806468339898619732
             - umd_chip_id: 19
               asic_position:
@@ -162,7 +162,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 15
+                chip_id: 80
               asic_id: 1604292789751472466
             - umd_chip_id: 20
               asic_position:
@@ -170,7 +170,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 2
+                chip_id: 93
               asic_id: 15083349085223658311
             - umd_chip_id: 21
               asic_position:
@@ -178,7 +178,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 6
+                chip_id: 89
               asic_id: 3575928811973860520
             - umd_chip_id: 22
               asic_position:
@@ -186,7 +186,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 10
+                chip_id: 85
               asic_id: 10160560557877890534
             - umd_chip_id: 23
               asic_position:
@@ -194,7 +194,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 14
+                chip_id: 81
               asic_id: 2075020600483094409
             - umd_chip_id: 24
               asic_position:
@@ -202,7 +202,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 31
+                chip_id: 64
               asic_id: 7133379751700409482
             - umd_chip_id: 25
               asic_position:
@@ -210,7 +210,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 27
+                chip_id: 68
               asic_id: 3610489619553281414
             - umd_chip_id: 26
               asic_position:
@@ -218,7 +218,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 23
+                chip_id: 72
               asic_id: 10589045247879180631
             - umd_chip_id: 27
               asic_position:
@@ -226,7 +226,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 19
+                chip_id: 76
               asic_id: 7667703486032200453
             - umd_chip_id: 28
               asic_position:
@@ -234,7 +234,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 30
+                chip_id: 65
               asic_id: 13050829983521971424
             - umd_chip_id: 29
               asic_position:
@@ -242,7 +242,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 26
+                chip_id: 69
               asic_id: 8272986739339197707
             - umd_chip_id: 30
               asic_position:
@@ -250,7 +250,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 22
+                chip_id: 73
               asic_id: 17731534091076460985
             - umd_chip_id: 31
               asic_position:
@@ -258,7 +258,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 18
+                chip_id: 77
               asic_id: 15747074476910224431
     - hostname: g14glx03_1
       mesh:
@@ -270,7 +270,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 60
+                chip_id: 35
               asic_id: 10226334474985596897
             - umd_chip_id: 1
               asic_position:
@@ -278,7 +278,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 56
+                chip_id: 39
               asic_id: 8280119897343582203
             - umd_chip_id: 2
               asic_position:
@@ -286,7 +286,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 52
+                chip_id: 43
               asic_id: 2082826764486319073
             - umd_chip_id: 3
               asic_position:
@@ -294,7 +294,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 48
+                chip_id: 47
               asic_id: 4079216823390969085
             - umd_chip_id: 4
               asic_position:
@@ -302,7 +302,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 61
+                chip_id: 34
               asic_id: 5154644496761410793
             - umd_chip_id: 5
               asic_position:
@@ -310,7 +310,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 57
+                chip_id: 38
               asic_id: 5834234138203129835
             - umd_chip_id: 6
               asic_position:
@@ -318,7 +318,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 53
+                chip_id: 42
               asic_id: 14043443525815778900
             - umd_chip_id: 7
               asic_position:
@@ -326,7 +326,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 49
+                chip_id: 46
               asic_id: 16812483142119243863
             - umd_chip_id: 8
               asic_position:
@@ -334,7 +334,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 32
+                chip_id: 63
               asic_id: 14149510633143332028
             - umd_chip_id: 9
               asic_position:
@@ -342,7 +342,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 36
+                chip_id: 59
               asic_id: 12000688019540304874
             - umd_chip_id: 10
               asic_position:
@@ -350,7 +350,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 40
+                chip_id: 55
               asic_id: 536931448715418808
             - umd_chip_id: 11
               asic_position:
@@ -358,7 +358,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 44
+                chip_id: 51
               asic_id: 1162803831390147914
             - umd_chip_id: 12
               asic_position:
@@ -366,7 +366,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 33
+                chip_id: 62
               asic_id: 10587034585156449563
             - umd_chip_id: 13
               asic_position:
@@ -374,7 +374,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 37
+                chip_id: 58
               asic_id: 11797047715904782499
             - umd_chip_id: 14
               asic_position:
@@ -382,7 +382,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 41
+                chip_id: 54
               asic_id: 15111953082946926376
             - umd_chip_id: 15
               asic_position:
@@ -390,7 +390,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 45
+                chip_id: 50
               asic_id: 708412231165941339
             - umd_chip_id: 16
               asic_position:
@@ -398,7 +398,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 35
+                chip_id: 60
               asic_id: 14003118019635688458
             - umd_chip_id: 17
               asic_position:
@@ -406,7 +406,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 39
+                chip_id: 56
               asic_id: 17303558093600380143
             - umd_chip_id: 18
               asic_position:
@@ -414,7 +414,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 43
+                chip_id: 52
               asic_id: 14434650995991072379
             - umd_chip_id: 19
               asic_position:
@@ -422,7 +422,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 47
+                chip_id: 48
               asic_id: 9216489861973315365
             - umd_chip_id: 20
               asic_position:
@@ -430,7 +430,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 34
+                chip_id: 61
               asic_id: 902531930634579519
             - umd_chip_id: 21
               asic_position:
@@ -438,7 +438,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 38
+                chip_id: 57
               asic_id: 6202194299593905867
             - umd_chip_id: 22
               asic_position:
@@ -446,7 +446,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 42
+                chip_id: 53
               asic_id: 15466617829308642389
             - umd_chip_id: 23
               asic_position:
@@ -454,7 +454,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 46
+                chip_id: 49
               asic_id: 10087648044157209356
             - umd_chip_id: 24
               asic_position:
@@ -462,7 +462,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 63
+                chip_id: 32
               asic_id: 3330083772412171638
             - umd_chip_id: 25
               asic_position:
@@ -470,7 +470,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 59
+                chip_id: 36
               asic_id: 14271819240522180615
             - umd_chip_id: 26
               asic_position:
@@ -478,7 +478,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 55
+                chip_id: 40
               asic_id: 10019806703049827097
             - umd_chip_id: 27
               asic_position:
@@ -486,7 +486,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 51
+                chip_id: 44
               asic_id: 9736256344625049232
             - umd_chip_id: 28
               asic_position:
@@ -494,7 +494,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 62
+                chip_id: 33
               asic_id: 4917613447345955392
             - umd_chip_id: 29
               asic_position:
@@ -502,7 +502,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 58
+                chip_id: 37
               asic_id: 8917364369942805032
             - umd_chip_id: 30
               asic_position:
@@ -510,7 +510,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 54
+                chip_id: 41
               asic_id: 8596703779022679612
             - umd_chip_id: 31
               asic_position:
@@ -518,7 +518,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 50
+                chip_id: 45
               asic_id: 15454480318232610300
     - hostname: g14glx03_2
       mesh:
@@ -530,7 +530,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 92
+                chip_id: 3
               asic_id: 15363116050363420586
             - umd_chip_id: 1
               asic_position:
@@ -538,7 +538,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 88
+                chip_id: 7
               asic_id: 11737583369229716954
             - umd_chip_id: 2
               asic_position:
@@ -546,7 +546,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 84
+                chip_id: 11
               asic_id: 14664827591026514529
             - umd_chip_id: 3
               asic_position:
@@ -554,7 +554,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 80
+                chip_id: 15
               asic_id: 82061751988408819
             - umd_chip_id: 4
               asic_position:
@@ -562,7 +562,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 93
+                chip_id: 2
               asic_id: 3684764184900680217
             - umd_chip_id: 5
               asic_position:
@@ -570,7 +570,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 89
+                chip_id: 6
               asic_id: 14693492012748402975
             - umd_chip_id: 6
               asic_position:
@@ -578,7 +578,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 85
+                chip_id: 10
               asic_id: 16049815133351541553
             - umd_chip_id: 7
               asic_position:
@@ -586,7 +586,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 81
+                chip_id: 14
               asic_id: 16908006572952434954
             - umd_chip_id: 8
               asic_position:
@@ -594,7 +594,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 64
+                chip_id: 31
               asic_id: 9000880225119913754
             - umd_chip_id: 9
               asic_position:
@@ -602,7 +602,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 68
+                chip_id: 27
               asic_id: 14156826200670352245
             - umd_chip_id: 10
               asic_position:
@@ -610,7 +610,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 72
+                chip_id: 23
               asic_id: 1121407419904759799
             - umd_chip_id: 11
               asic_position:
@@ -618,7 +618,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 76
+                chip_id: 19
               asic_id: 14971645544801764328
             - umd_chip_id: 12
               asic_position:
@@ -626,7 +626,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 65
+                chip_id: 30
               asic_id: 8498480550811023797
             - umd_chip_id: 13
               asic_position:
@@ -634,7 +634,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 69
+                chip_id: 26
               asic_id: 17540900401176088410
             - umd_chip_id: 14
               asic_position:
@@ -642,7 +642,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 73
+                chip_id: 22
               asic_id: 12438390489266616142
             - umd_chip_id: 15
               asic_position:
@@ -650,7 +650,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 77
+                chip_id: 18
               asic_id: 13529575077633816381
             - umd_chip_id: 16
               asic_position:
@@ -658,7 +658,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 67
+                chip_id: 28
               asic_id: 11983769814284083458
             - umd_chip_id: 17
               asic_position:
@@ -666,7 +666,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 71
+                chip_id: 24
               asic_id: 9992174381597509921
             - umd_chip_id: 18
               asic_position:
@@ -674,7 +674,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 75
+                chip_id: 20
               asic_id: 17070135835806860129
             - umd_chip_id: 19
               asic_position:
@@ -682,7 +682,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 79
+                chip_id: 16
               asic_id: 9975081979281732154
             - umd_chip_id: 20
               asic_position:
@@ -690,7 +690,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 66
+                chip_id: 29
               asic_id: 12875834591906946702
             - umd_chip_id: 21
               asic_position:
@@ -698,7 +698,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 70
+                chip_id: 25
               asic_id: 7949948826651947323
             - umd_chip_id: 22
               asic_position:
@@ -706,7 +706,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 74
+                chip_id: 21
               asic_id: 15757839794359872403
             - umd_chip_id: 23
               asic_position:
@@ -714,7 +714,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 78
+                chip_id: 17
               asic_id: 10315959617013009353
             - umd_chip_id: 24
               asic_position:
@@ -722,7 +722,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 95
+                chip_id: 0
               asic_id: 2515082257436398994
             - umd_chip_id: 25
               asic_position:
@@ -730,7 +730,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 91
+                chip_id: 4
               asic_id: 11706268941777103433
             - umd_chip_id: 26
               asic_position:
@@ -738,7 +738,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 87
+                chip_id: 8
               asic_id: 16189263530587828442
             - umd_chip_id: 27
               asic_position:
@@ -746,7 +746,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 83
+                chip_id: 12
               asic_id: 2565685239674212705
             - umd_chip_id: 28
               asic_position:
@@ -754,7 +754,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 94
+                chip_id: 1
               asic_id: 16267613932689807872
             - umd_chip_id: 29
               asic_position:
@@ -762,7 +762,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 90
+                chip_id: 5
               asic_id: 13290357433517321445
             - umd_chip_id: 30
               asic_position:
@@ -770,7 +770,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 86
+                chip_id: 9
               asic_id: 16708018001526599812
             - umd_chip_id: 31
               asic_position:
@@ -778,7 +778,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 82
+                chip_id: 13
               asic_id: 10173074869510732125
     - hostname: g14glx03_3
       mesh:
@@ -790,7 +790,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 124
+                chip_id: 99
               asic_id: 16897428286434427954
             - umd_chip_id: 1
               asic_position:
@@ -798,7 +798,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 120
+                chip_id: 103
               asic_id: 4852634695797572643
             - umd_chip_id: 2
               asic_position:
@@ -806,7 +806,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 116
+                chip_id: 107
               asic_id: 1637391396660754749
             - umd_chip_id: 3
               asic_position:
@@ -814,7 +814,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 112
+                chip_id: 111
               asic_id: 5910813795414918290
             - umd_chip_id: 4
               asic_position:
@@ -822,7 +822,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 125
+                chip_id: 98
               asic_id: 11894359302434260555
             - umd_chip_id: 5
               asic_position:
@@ -830,7 +830,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 121
+                chip_id: 102
               asic_id: 2102976113964704928
             - umd_chip_id: 6
               asic_position:
@@ -838,7 +838,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 117
+                chip_id: 106
               asic_id: 10878532645696201208
             - umd_chip_id: 7
               asic_position:
@@ -846,7 +846,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 113
+                chip_id: 110
               asic_id: 12308323375305491712
             - umd_chip_id: 8
               asic_position:
@@ -854,7 +854,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 96
+                chip_id: 127
               asic_id: 11623476740466885285
             - umd_chip_id: 9
               asic_position:
@@ -862,7 +862,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 100
+                chip_id: 123
               asic_id: 7126657058388660435
             - umd_chip_id: 10
               asic_position:
@@ -870,7 +870,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 104
+                chip_id: 119
               asic_id: 11060180391853616868
             - umd_chip_id: 11
               asic_position:
@@ -878,7 +878,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 108
+                chip_id: 115
               asic_id: 6576062449545301732
             - umd_chip_id: 12
               asic_position:
@@ -886,7 +886,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 97
+                chip_id: 126
               asic_id: 2148056954463447228
             - umd_chip_id: 13
               asic_position:
@@ -894,7 +894,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 101
+                chip_id: 122
               asic_id: 10797481097187450198
             - umd_chip_id: 14
               asic_position:
@@ -902,7 +902,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 105
+                chip_id: 118
               asic_id: 6696368501424518245
             - umd_chip_id: 15
               asic_position:
@@ -910,7 +910,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 109
+                chip_id: 114
               asic_id: 11679838140546874259
             - umd_chip_id: 16
               asic_position:
@@ -918,7 +918,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 99
+                chip_id: 124
               asic_id: 4727126700201877005
             - umd_chip_id: 17
               asic_position:
@@ -926,7 +926,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 103
+                chip_id: 120
               asic_id: 15891147556611507707
             - umd_chip_id: 18
               asic_position:
@@ -934,7 +934,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 107
+                chip_id: 116
               asic_id: 4748540699048813465
             - umd_chip_id: 19
               asic_position:
@@ -942,7 +942,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 111
+                chip_id: 112
               asic_id: 10841962151628824575
             - umd_chip_id: 20
               asic_position:
@@ -950,7 +950,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 98
+                chip_id: 125
               asic_id: 6665689513120234091
             - umd_chip_id: 21
               asic_position:
@@ -958,7 +958,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 102
+                chip_id: 121
               asic_id: 10137482696966351673
             - umd_chip_id: 22
               asic_position:
@@ -966,7 +966,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 106
+                chip_id: 117
               asic_id: 3958117681924467995
             - umd_chip_id: 23
               asic_position:
@@ -974,7 +974,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 110
+                chip_id: 113
               asic_id: 839538201186331506
             - umd_chip_id: 24
               asic_position:
@@ -982,7 +982,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 127
+                chip_id: 96
               asic_id: 14146789140720940991
             - umd_chip_id: 25
               asic_position:
@@ -990,7 +990,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 123
+                chip_id: 100
               asic_id: 10093816942286469935
             - umd_chip_id: 26
               asic_position:
@@ -998,7 +998,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 119
+                chip_id: 104
               asic_id: 4655730208925534597
             - umd_chip_id: 27
               asic_position:
@@ -1006,7 +1006,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 115
+                chip_id: 108
               asic_id: 16925692033872625686
             - umd_chip_id: 28
               asic_position:
@@ -1014,7 +1014,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 126
+                chip_id: 97
               asic_id: 17187122270725927983
             - umd_chip_id: 29
               asic_position:
@@ -1022,7 +1022,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 122
+                chip_id: 101
               asic_id: 11012993497719140567
             - umd_chip_id: 30
               asic_position:
@@ -1030,7 +1030,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 118
+                chip_id: 105
               asic_id: 6551685666095798433
             - umd_chip_id: 31
               asic_position:
@@ -1038,5 +1038,5 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 114
+                chip_id: 109
               asic_id: 1606694279306191890

--- a/tests/tt_metal/tt_fabric/golden_mapping_files/Test6uSplit4x4ControlPlaneInit.yaml
+++ b/tests/tt_metal/tt_fabric/golden_mapping_files/Test6uSplit4x4ControlPlaneInit.yaml
@@ -3,7 +3,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_0
       mesh:
         - mesh: 0
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 2
@@ -135,7 +135,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_1
       mesh:
         - mesh: 1
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 3

--- a/tests/tt_metal/tt_fabric/golden_mapping_files/Test6uSplit8x2ControlPlaneInit.yaml
+++ b/tests/tt_metal/tt_fabric/golden_mapping_files/Test6uSplit8x2ControlPlaneInit.yaml
@@ -3,7 +3,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_0
       mesh:
         - mesh: 0
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 3
@@ -135,7 +135,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_1
       mesh:
         - mesh: 1
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 2

--- a/tests/tt_metal/tt_fabric/golden_mapping_files/TestBHBlitzPipelineControlPlaneInit.yaml
+++ b/tests/tt_metal/tt_fabric/golden_mapping_files/TestBHBlitzPipelineControlPlaneInit.yaml
@@ -3,7 +3,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_0
       mesh:
         - mesh: 0
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 3
@@ -71,7 +71,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_1
       mesh:
         - mesh: 1
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 1
@@ -139,7 +139,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_10
       mesh:
         - mesh: 10
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 2
@@ -207,7 +207,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_11
       mesh:
         - mesh: 11
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 4
@@ -275,7 +275,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_12
       mesh:
         - mesh: 12
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 2
@@ -343,7 +343,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_13
       mesh:
         - mesh: 13
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 1
@@ -411,7 +411,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_14
       mesh:
         - mesh: 14
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 2
@@ -479,7 +479,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_15
       mesh:
         - mesh: 15
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 1
@@ -547,7 +547,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_16
       mesh:
         - mesh: 16
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 2
@@ -615,7 +615,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_17
       mesh:
         - mesh: 17
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 4
@@ -683,7 +683,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_18
       mesh:
         - mesh: 18
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 2
@@ -751,7 +751,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_19
       mesh:
         - mesh: 19
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 4
@@ -819,7 +819,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_2
       mesh:
         - mesh: 2
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 3
@@ -887,7 +887,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_20
       mesh:
         - mesh: 20
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 3
@@ -955,7 +955,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_21
       mesh:
         - mesh: 21
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 1
@@ -1023,7 +1023,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_22
       mesh:
         - mesh: 22
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 3
@@ -1091,7 +1091,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_23
       mesh:
         - mesh: 23
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 1
@@ -1159,7 +1159,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_24
       mesh:
         - mesh: 24
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 2
@@ -1227,7 +1227,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_25
       mesh:
         - mesh: 25
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 4
@@ -1295,7 +1295,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_26
       mesh:
         - mesh: 26
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 2
@@ -1363,7 +1363,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_27
       mesh:
         - mesh: 27
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 4
@@ -1431,7 +1431,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_28
       mesh:
         - mesh: 28
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 3
@@ -1499,7 +1499,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_29
       mesh:
         - mesh: 29
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 1
@@ -1567,7 +1567,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_3
       mesh:
         - mesh: 3
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 4
@@ -1635,7 +1635,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_30
       mesh:
         - mesh: 30
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 3
@@ -1703,7 +1703,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_31
       mesh:
         - mesh: 31
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 1
@@ -1771,7 +1771,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_32
       mesh:
         - mesh: 32
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 2
@@ -1839,7 +1839,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_33
       mesh:
         - mesh: 33
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 1
@@ -1907,7 +1907,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_34
       mesh:
         - mesh: 34
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 2
@@ -1975,7 +1975,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_35
       mesh:
         - mesh: 35
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 1
@@ -2043,7 +2043,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_36
       mesh:
         - mesh: 36
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 3
@@ -2111,7 +2111,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_37
       mesh:
         - mesh: 37
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 1
@@ -2179,7 +2179,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_38
       mesh:
         - mesh: 38
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 3
@@ -2247,7 +2247,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_39
       mesh:
         - mesh: 39
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 4
@@ -2315,7 +2315,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_4
       mesh:
         - mesh: 4
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 2
@@ -2383,7 +2383,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_40
       mesh:
         - mesh: 40
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 2
@@ -2451,7 +2451,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_41
       mesh:
         - mesh: 41
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 4
@@ -2519,7 +2519,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_42
       mesh:
         - mesh: 42
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 3
@@ -2587,7 +2587,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_43
       mesh:
         - mesh: 43
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 1
@@ -2655,7 +2655,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_44
       mesh:
         - mesh: 44
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 3
@@ -2723,7 +2723,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_45
       mesh:
         - mesh: 45
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 4
@@ -2791,7 +2791,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_46
       mesh:
         - mesh: 46
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 2
@@ -2859,7 +2859,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_47
       mesh:
         - mesh: 47
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 4
@@ -2927,7 +2927,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_5
       mesh:
         - mesh: 5
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 4
@@ -2995,7 +2995,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_6
       mesh:
         - mesh: 6
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 3
@@ -3063,7 +3063,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_7
       mesh:
         - mesh: 7
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 1
@@ -3131,7 +3131,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_8
       mesh:
         - mesh: 8
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 3
@@ -3199,7 +3199,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_9
       mesh:
         - mesh: 9
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 4

--- a/tests/tt_metal/tt_fabric/golden_mapping_files/TestBHQB4x4ControlPlaneInit.yaml
+++ b/tests/tt_metal/tt_fabric/golden_mapping_files/TestBHQB4x4ControlPlaneInit.yaml
@@ -46,7 +46,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 0
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 3
+                chip_id: 12
               asic_id: 143238000804096
             - umd_chip_id: 1
               asic_position:
@@ -54,7 +54,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 0
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 6
+                chip_id: 9
               asic_id: 143238001595264
             - umd_chip_id: 2
               asic_position:
@@ -62,7 +62,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 0
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 2
+                chip_id: 13
               asic_id: 143238001601888
             - umd_chip_id: 3
               asic_position:
@@ -70,7 +70,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 0
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 7
+                chip_id: 8
               asic_id: 143238001602656
     - hostname: g14glx03_2
       mesh:
@@ -82,7 +82,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 0
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 12
+                chip_id: 3
               asic_id: 143238000417728
             - umd_chip_id: 1
               asic_position:
@@ -90,7 +90,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 0
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 9
+                chip_id: 6
               asic_id: 143238000419456
             - umd_chip_id: 2
               asic_position:
@@ -98,7 +98,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 0
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 8
+                chip_id: 7
               asic_id: 143238000420960
             - umd_chip_id: 3
               asic_position:
@@ -106,7 +106,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 0
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 13
+                chip_id: 2
               asic_id: 143238000422752
     - hostname: g14glx03_3
       mesh:

--- a/tests/tt_metal/tt_fabric/golden_mapping_files/TestBHQB4x4RelaxedControlPlaneInit.yaml
+++ b/tests/tt_metal/tt_fabric/golden_mapping_files/TestBHQB4x4RelaxedControlPlaneInit.yaml
@@ -3,7 +3,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_0
       mesh:
         - mesh: 0
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 0
@@ -39,43 +39,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_1
       mesh:
         - mesh: 0
-          chips:
-            - umd_chip_id: 0
-              asic_position:
-                tray_id: 0
-                asic_location: 0
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 3
-              asic_id: 143238000804096
-            - umd_chip_id: 1
-              asic_position:
-                tray_id: 0
-                asic_location: 0
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 6
-              asic_id: 143238001595264
-            - umd_chip_id: 2
-              asic_position:
-                tray_id: 0
-                asic_location: 0
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 2
-              asic_id: 143238001601888
-            - umd_chip_id: 3
-              asic_position:
-                tray_id: 0
-                asic_location: 0
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 7
-              asic_id: 143238001602656
-    - hostname: g14glx03_2
-      mesh:
-        - mesh: 0
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 0
@@ -83,7 +47,7 @@ asic_to_fabric_node_mapping:
               fabric_node_id:
                 mesh_id: 0
                 chip_id: 12
-              asic_id: 143238000417728
+              asic_id: 143238000804096
             - umd_chip_id: 1
               asic_position:
                 tray_id: 0
@@ -91,6 +55,42 @@ asic_to_fabric_node_mapping:
               fabric_node_id:
                 mesh_id: 0
                 chip_id: 9
+              asic_id: 143238001595264
+            - umd_chip_id: 2
+              asic_position:
+                tray_id: 0
+                asic_location: 0
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 13
+              asic_id: 143238001601888
+            - umd_chip_id: 3
+              asic_position:
+                tray_id: 0
+                asic_location: 0
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 8
+              asic_id: 143238001602656
+    - hostname: g14glx03_2
+      mesh:
+        - mesh: 0
+        - chips:
+            - umd_chip_id: 0
+              asic_position:
+                tray_id: 0
+                asic_location: 0
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 3
+              asic_id: 143238000417728
+            - umd_chip_id: 1
+              asic_position:
+                tray_id: 0
+                asic_location: 0
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 6
               asic_id: 143238000419456
             - umd_chip_id: 2
               asic_position:
@@ -98,7 +98,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 0
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 8
+                chip_id: 7
               asic_id: 143238000420960
             - umd_chip_id: 3
               asic_position:
@@ -106,12 +106,12 @@ asic_to_fabric_node_mapping:
                 asic_location: 0
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 13
+                chip_id: 2
               asic_id: 143238000422752
     - hostname: g14glx03_3
       mesh:
         - mesh: 0
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 0

--- a/tests/tt_metal/tt_fabric/golden_mapping_files/TestDualGalaxyControlPlaneInit.yaml
+++ b/tests/tt_metal/tt_fabric/golden_mapping_files/TestDualGalaxyControlPlaneInit.yaml
@@ -10,7 +10,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 0
+                chip_id: 63
               asic_id: 87030958941810993
             - umd_chip_id: 1
               asic_position:
@@ -18,7 +18,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 56
+                chip_id: 7
               asic_id: 87030958941811251
             - umd_chip_id: 2
               asic_position:
@@ -26,7 +26,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 59
+                chip_id: 4
               asic_id: 87030958941811271
             - umd_chip_id: 3
               asic_position:
@@ -34,7 +34,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 3
+                chip_id: 60
               asic_id: 87030958941811289
             - umd_chip_id: 4
               asic_position:
@@ -42,7 +42,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 8
+                chip_id: 55
               asic_id: 159088552979738929
             - umd_chip_id: 5
               asic_position:
@@ -50,7 +50,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 48
+                chip_id: 15
               asic_id: 159088552979739187
             - umd_chip_id: 6
               asic_position:
@@ -58,7 +58,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 51
+                chip_id: 12
               asic_id: 159088552979739207
             - umd_chip_id: 7
               asic_position:
@@ -66,7 +66,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 11
+                chip_id: 52
               asic_id: 159088552979739225
             - umd_chip_id: 8
               asic_position:
@@ -74,7 +74,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 16
+                chip_id: 47
               asic_id: 231146147017666865
             - umd_chip_id: 9
               asic_position:
@@ -82,7 +82,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 40
+                chip_id: 23
               asic_id: 231146147017667123
             - umd_chip_id: 10
               asic_position:
@@ -90,7 +90,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 43
+                chip_id: 20
               asic_id: 231146147017667143
             - umd_chip_id: 11
               asic_position:
@@ -98,7 +98,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 19
+                chip_id: 44
               asic_id: 231146147017667161
             - umd_chip_id: 12
               asic_position:
@@ -106,7 +106,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 24
+                chip_id: 39
               asic_id: 303203741055594801
             - umd_chip_id: 13
               asic_position:
@@ -114,7 +114,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 32
+                chip_id: 31
               asic_id: 303203741055595059
             - umd_chip_id: 14
               asic_position:
@@ -122,7 +122,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 35
+                chip_id: 28
               asic_id: 303203741055595079
             - umd_chip_id: 15
               asic_position:
@@ -130,7 +130,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 27
+                chip_id: 36
               asic_id: 303203741055595097
             - umd_chip_id: 16
               asic_position:
@@ -138,7 +138,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 1
+                chip_id: 62
               asic_id: 375261335093522737
             - umd_chip_id: 17
               asic_position:
@@ -146,7 +146,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 57
+                chip_id: 6
               asic_id: 375261335093522995
             - umd_chip_id: 18
               asic_position:
@@ -154,7 +154,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 58
+                chip_id: 5
               asic_id: 375261335093523015
             - umd_chip_id: 19
               asic_position:
@@ -162,7 +162,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 2
+                chip_id: 61
               asic_id: 375261335093523033
             - umd_chip_id: 20
               asic_position:
@@ -170,7 +170,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 9
+                chip_id: 54
               asic_id: 447318929131450673
             - umd_chip_id: 21
               asic_position:
@@ -178,7 +178,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 49
+                chip_id: 14
               asic_id: 447318929131450931
             - umd_chip_id: 22
               asic_position:
@@ -186,7 +186,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 50
+                chip_id: 13
               asic_id: 447318929131450951
             - umd_chip_id: 23
               asic_position:
@@ -194,7 +194,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 10
+                chip_id: 53
               asic_id: 447318929131450969
             - umd_chip_id: 24
               asic_position:
@@ -202,7 +202,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 17
+                chip_id: 46
               asic_id: 519376523169378609
             - umd_chip_id: 25
               asic_position:
@@ -210,7 +210,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 41
+                chip_id: 22
               asic_id: 519376523169378867
             - umd_chip_id: 26
               asic_position:
@@ -218,7 +218,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 42
+                chip_id: 21
               asic_id: 519376523169378887
             - umd_chip_id: 27
               asic_position:
@@ -226,7 +226,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 18
+                chip_id: 45
               asic_id: 519376523169378905
             - umd_chip_id: 28
               asic_position:
@@ -234,7 +234,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 25
+                chip_id: 38
               asic_id: 591434117207306545
             - umd_chip_id: 29
               asic_position:
@@ -242,7 +242,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 33
+                chip_id: 30
               asic_id: 591434117207306803
             - umd_chip_id: 30
               asic_position:
@@ -250,7 +250,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 34
+                chip_id: 29
               asic_id: 591434117207306823
             - umd_chip_id: 31
               asic_position:
@@ -258,7 +258,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 26
+                chip_id: 37
               asic_id: 591434117207306841
     - hostname: g14glx03_1
       mesh:
@@ -270,7 +270,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 63
+                chip_id: 0
               asic_id: 87029889494954051
             - umd_chip_id: 1
               asic_position:
@@ -278,7 +278,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 7
+                chip_id: 56
               asic_id: 87029889494954065
             - umd_chip_id: 2
               asic_position:
@@ -286,7 +286,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 60
+                chip_id: 3
               asic_id: 87029889494954070
             - umd_chip_id: 3
               asic_position:
@@ -294,7 +294,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 4
+                chip_id: 59
               asic_id: 87030954646843723
             - umd_chip_id: 4
               asic_position:
@@ -302,7 +302,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 55
+                chip_id: 8
               asic_id: 159087483532881987
             - umd_chip_id: 5
               asic_position:
@@ -310,7 +310,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 15
+                chip_id: 48
               asic_id: 159087483532882001
             - umd_chip_id: 6
               asic_position:
@@ -318,7 +318,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 52
+                chip_id: 11
               asic_id: 159087483532882006
             - umd_chip_id: 7
               asic_position:
@@ -326,7 +326,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 12
+                chip_id: 51
               asic_id: 159088548684771659
             - umd_chip_id: 8
               asic_position:
@@ -334,7 +334,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 47
+                chip_id: 16
               asic_id: 231145077570809923
             - umd_chip_id: 9
               asic_position:
@@ -342,7 +342,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 23
+                chip_id: 40
               asic_id: 231145077570809937
             - umd_chip_id: 10
               asic_position:
@@ -350,7 +350,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 44
+                chip_id: 19
               asic_id: 231145077570809942
             - umd_chip_id: 11
               asic_position:
@@ -358,7 +358,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 20
+                chip_id: 43
               asic_id: 231146142722699595
             - umd_chip_id: 12
               asic_position:
@@ -366,7 +366,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 39
+                chip_id: 24
               asic_id: 303202671608737859
             - umd_chip_id: 13
               asic_position:
@@ -374,7 +374,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 31
+                chip_id: 32
               asic_id: 303202671608737873
             - umd_chip_id: 14
               asic_position:
@@ -382,7 +382,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 36
+                chip_id: 27
               asic_id: 303202671608737878
             - umd_chip_id: 15
               asic_position:
@@ -390,7 +390,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 28
+                chip_id: 35
               asic_id: 303203736760627531
             - umd_chip_id: 16
               asic_position:
@@ -398,7 +398,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 62
+                chip_id: 1
               asic_id: 375260265646665795
             - umd_chip_id: 17
               asic_position:
@@ -406,7 +406,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 6
+                chip_id: 57
               asic_id: 375260265646665809
             - umd_chip_id: 18
               asic_position:
@@ -414,7 +414,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 61
+                chip_id: 2
               asic_id: 375260265646665814
             - umd_chip_id: 19
               asic_position:
@@ -422,7 +422,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 5
+                chip_id: 58
               asic_id: 375261330798555467
             - umd_chip_id: 20
               asic_position:
@@ -430,7 +430,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 54
+                chip_id: 9
               asic_id: 447317859684593731
             - umd_chip_id: 21
               asic_position:
@@ -438,7 +438,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 14
+                chip_id: 49
               asic_id: 447317859684593745
             - umd_chip_id: 22
               asic_position:
@@ -446,7 +446,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 53
+                chip_id: 10
               asic_id: 447317859684593750
             - umd_chip_id: 23
               asic_position:
@@ -454,7 +454,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 13
+                chip_id: 50
               asic_id: 447318924836483403
             - umd_chip_id: 24
               asic_position:
@@ -462,7 +462,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 46
+                chip_id: 17
               asic_id: 519375453722521667
             - umd_chip_id: 25
               asic_position:
@@ -470,7 +470,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 22
+                chip_id: 41
               asic_id: 519375453722521681
             - umd_chip_id: 26
               asic_position:
@@ -478,7 +478,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 45
+                chip_id: 18
               asic_id: 519375453722521686
             - umd_chip_id: 27
               asic_position:
@@ -486,7 +486,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 21
+                chip_id: 42
               asic_id: 519376518874411339
             - umd_chip_id: 28
               asic_position:
@@ -494,7 +494,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 38
+                chip_id: 25
               asic_id: 591433047760449603
             - umd_chip_id: 29
               asic_position:
@@ -502,7 +502,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 30
+                chip_id: 33
               asic_id: 591433047760449617
             - umd_chip_id: 30
               asic_position:
@@ -510,7 +510,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 37
+                chip_id: 26
               asic_id: 591433047760449622
             - umd_chip_id: 31
               asic_position:
@@ -518,5 +518,5 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 29
+                chip_id: 34
               asic_id: 591434112912339275

--- a/tests/tt_metal/tt_fabric/golden_mapping_files/TestDualGalaxyControlPlaneInitFlipped.yaml
+++ b/tests/tt_metal/tt_fabric/golden_mapping_files/TestDualGalaxyControlPlaneInitFlipped.yaml
@@ -3,7 +3,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_0
       mesh:
         - mesh: 0
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 2
@@ -263,7 +263,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_1
       mesh:
         - mesh: 0
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 3

--- a/tests/tt_metal/tt_fabric/golden_mapping_files/TestQuadGalaxyControlPlaneInit.yaml
+++ b/tests/tt_metal/tt_fabric/golden_mapping_files/TestQuadGalaxyControlPlaneInit.yaml
@@ -10,7 +10,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 0
+                chip_id: 119
               asic_id: 87028777098424372
             - umd_chip_id: 1
               asic_position:
@@ -18,7 +18,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 112
+                chip_id: 7
               asic_id: 87028777098424392
             - umd_chip_id: 2
               asic_position:
@@ -26,7 +26,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 115
+                chip_id: 4
               asic_id: 87028777098424398
             - umd_chip_id: 3
               asic_position:
@@ -34,7 +34,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 3
+                chip_id: 116
               asic_id: 87028789983326288
             - umd_chip_id: 4
               asic_position:
@@ -42,7 +42,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 16
+                chip_id: 103
               asic_id: 159086371136352308
             - umd_chip_id: 5
               asic_position:
@@ -50,7 +50,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 96
+                chip_id: 23
               asic_id: 159086371136352328
             - umd_chip_id: 6
               asic_position:
@@ -58,7 +58,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 99
+                chip_id: 20
               asic_id: 159086371136352334
             - umd_chip_id: 7
               asic_position:
@@ -66,7 +66,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 19
+                chip_id: 100
               asic_id: 159086384021254224
             - umd_chip_id: 8
               asic_position:
@@ -74,7 +74,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 32
+                chip_id: 87
               asic_id: 231143965174280244
             - umd_chip_id: 9
               asic_position:
@@ -82,7 +82,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 80
+                chip_id: 39
               asic_id: 231143965174280264
             - umd_chip_id: 10
               asic_position:
@@ -90,7 +90,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 83
+                chip_id: 36
               asic_id: 231143965174280270
             - umd_chip_id: 11
               asic_position:
@@ -98,7 +98,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 35
+                chip_id: 84
               asic_id: 231143978059182160
             - umd_chip_id: 12
               asic_position:
@@ -106,7 +106,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 48
+                chip_id: 71
               asic_id: 303201559212208180
             - umd_chip_id: 13
               asic_position:
@@ -114,7 +114,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 64
+                chip_id: 55
               asic_id: 303201559212208200
             - umd_chip_id: 14
               asic_position:
@@ -122,7 +122,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 67
+                chip_id: 52
               asic_id: 303201559212208206
             - umd_chip_id: 15
               asic_position:
@@ -130,7 +130,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 51
+                chip_id: 68
               asic_id: 303201572097110096
             - umd_chip_id: 16
               asic_position:
@@ -138,7 +138,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 1
+                chip_id: 118
               asic_id: 375259153250136116
             - umd_chip_id: 17
               asic_position:
@@ -146,7 +146,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 113
+                chip_id: 6
               asic_id: 375259153250136136
             - umd_chip_id: 18
               asic_position:
@@ -154,7 +154,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 114
+                chip_id: 5
               asic_id: 375259153250136142
             - umd_chip_id: 19
               asic_position:
@@ -162,7 +162,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 2
+                chip_id: 117
               asic_id: 375259166135038032
             - umd_chip_id: 20
               asic_position:
@@ -170,7 +170,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 17
+                chip_id: 102
               asic_id: 447316747288064052
             - umd_chip_id: 21
               asic_position:
@@ -178,7 +178,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 97
+                chip_id: 22
               asic_id: 447316747288064072
             - umd_chip_id: 22
               asic_position:
@@ -186,7 +186,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 98
+                chip_id: 21
               asic_id: 447316747288064078
             - umd_chip_id: 23
               asic_position:
@@ -194,7 +194,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 18
+                chip_id: 101
               asic_id: 447316760172965968
             - umd_chip_id: 24
               asic_position:
@@ -202,7 +202,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 33
+                chip_id: 86
               asic_id: 519374341325991988
             - umd_chip_id: 25
               asic_position:
@@ -210,7 +210,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 81
+                chip_id: 38
               asic_id: 519374341325992008
             - umd_chip_id: 26
               asic_position:
@@ -218,7 +218,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 82
+                chip_id: 37
               asic_id: 519374341325992014
             - umd_chip_id: 27
               asic_position:
@@ -226,7 +226,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 34
+                chip_id: 85
               asic_id: 519374354210893904
             - umd_chip_id: 28
               asic_position:
@@ -234,7 +234,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 49
+                chip_id: 70
               asic_id: 591431935363919924
             - umd_chip_id: 29
               asic_position:
@@ -242,7 +242,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 65
+                chip_id: 54
               asic_id: 591431935363919944
             - umd_chip_id: 30
               asic_position:
@@ -250,7 +250,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 66
+                chip_id: 53
               asic_id: 591431935363919950
             - umd_chip_id: 31
               asic_position:
@@ -258,7 +258,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 50
+                chip_id: 69
               asic_id: 591431948248821840
     - hostname: g14glx03_1
       mesh:
@@ -270,7 +270,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 119
+                chip_id: 0
               asic_id: 87028755623587893
             - umd_chip_id: 1
               asic_position:
@@ -278,7 +278,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 4
+                chip_id: 115
               asic_id: 87028768508489781
             - umd_chip_id: 2
               asic_position:
@@ -286,7 +286,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 116
+                chip_id: 3
               asic_id: 87028768508489794
             - umd_chip_id: 3
               asic_position:
@@ -294,7 +294,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 7
+                chip_id: 112
               asic_id: 87028789983326265
             - umd_chip_id: 4
               asic_position:
@@ -302,7 +302,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 103
+                chip_id: 16
               asic_id: 159086349661515829
             - umd_chip_id: 5
               asic_position:
@@ -310,7 +310,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 20
+                chip_id: 99
               asic_id: 159086362546417717
             - umd_chip_id: 6
               asic_position:
@@ -318,7 +318,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 100
+                chip_id: 19
               asic_id: 159086362546417730
             - umd_chip_id: 7
               asic_position:
@@ -326,7 +326,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 23
+                chip_id: 96
               asic_id: 159086384021254201
             - umd_chip_id: 8
               asic_position:
@@ -334,7 +334,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 87
+                chip_id: 32
               asic_id: 231143943699443765
             - umd_chip_id: 9
               asic_position:
@@ -342,7 +342,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 36
+                chip_id: 83
               asic_id: 231143956584345653
             - umd_chip_id: 10
               asic_position:
@@ -350,7 +350,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 84
+                chip_id: 35
               asic_id: 231143956584345666
             - umd_chip_id: 11
               asic_position:
@@ -358,7 +358,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 39
+                chip_id: 80
               asic_id: 231143978059182137
             - umd_chip_id: 12
               asic_position:
@@ -366,7 +366,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 71
+                chip_id: 48
               asic_id: 303201537737371701
             - umd_chip_id: 13
               asic_position:
@@ -374,7 +374,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 52
+                chip_id: 67
               asic_id: 303201550622273589
             - umd_chip_id: 14
               asic_position:
@@ -382,7 +382,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 68
+                chip_id: 51
               asic_id: 303201550622273602
             - umd_chip_id: 15
               asic_position:
@@ -390,7 +390,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 55
+                chip_id: 64
               asic_id: 303201572097110073
             - umd_chip_id: 16
               asic_position:
@@ -398,7 +398,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 118
+                chip_id: 1
               asic_id: 375259131775299637
             - umd_chip_id: 17
               asic_position:
@@ -406,7 +406,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 5
+                chip_id: 114
               asic_id: 375259144660201525
             - umd_chip_id: 18
               asic_position:
@@ -414,7 +414,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 117
+                chip_id: 2
               asic_id: 375259144660201538
             - umd_chip_id: 19
               asic_position:
@@ -422,7 +422,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 6
+                chip_id: 113
               asic_id: 375259166135038009
             - umd_chip_id: 20
               asic_position:
@@ -430,7 +430,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 102
+                chip_id: 17
               asic_id: 447316725813227573
             - umd_chip_id: 21
               asic_position:
@@ -438,7 +438,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 21
+                chip_id: 98
               asic_id: 447316738698129461
             - umd_chip_id: 22
               asic_position:
@@ -446,7 +446,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 101
+                chip_id: 18
               asic_id: 447316738698129474
             - umd_chip_id: 23
               asic_position:
@@ -454,7 +454,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 22
+                chip_id: 97
               asic_id: 447316760172965945
             - umd_chip_id: 24
               asic_position:
@@ -462,7 +462,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 86
+                chip_id: 33
               asic_id: 519374319851155509
             - umd_chip_id: 25
               asic_position:
@@ -470,7 +470,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 37
+                chip_id: 82
               asic_id: 519374332736057397
             - umd_chip_id: 26
               asic_position:
@@ -478,7 +478,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 85
+                chip_id: 34
               asic_id: 519374332736057410
             - umd_chip_id: 27
               asic_position:
@@ -486,7 +486,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 38
+                chip_id: 81
               asic_id: 519374354210893881
             - umd_chip_id: 28
               asic_position:
@@ -494,7 +494,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 70
+                chip_id: 49
               asic_id: 591431913889083445
             - umd_chip_id: 29
               asic_position:
@@ -502,7 +502,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 53
+                chip_id: 66
               asic_id: 591431926773985333
             - umd_chip_id: 30
               asic_position:
@@ -510,7 +510,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 69
+                chip_id: 50
               asic_id: 591431926773985346
             - umd_chip_id: 31
               asic_position:
@@ -518,7 +518,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 54
+                chip_id: 65
               asic_id: 591431948248821817
     - hostname: g14glx03_2
       mesh:
@@ -530,7 +530,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 11
+                chip_id: 124
               asic_id: 87028789983326519
             - umd_chip_id: 1
               asic_position:
@@ -538,7 +538,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 8
+                chip_id: 127
               asic_id: 87028789983326529
             - umd_chip_id: 2
               asic_position:
@@ -546,7 +546,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 120
+                chip_id: 15
               asic_id: 87028789983326547
             - umd_chip_id: 3
               asic_position:
@@ -554,7 +554,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 123
+                chip_id: 12
               asic_id: 87028789983326550
             - umd_chip_id: 4
               asic_position:
@@ -562,7 +562,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 27
+                chip_id: 108
               asic_id: 159086384021254455
             - umd_chip_id: 5
               asic_position:
@@ -570,7 +570,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 24
+                chip_id: 111
               asic_id: 159086384021254465
             - umd_chip_id: 6
               asic_position:
@@ -578,7 +578,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 104
+                chip_id: 31
               asic_id: 159086384021254483
             - umd_chip_id: 7
               asic_position:
@@ -586,7 +586,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 107
+                chip_id: 28
               asic_id: 159086384021254486
             - umd_chip_id: 8
               asic_position:
@@ -594,7 +594,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 43
+                chip_id: 92
               asic_id: 231143978059182391
             - umd_chip_id: 9
               asic_position:
@@ -602,7 +602,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 40
+                chip_id: 95
               asic_id: 231143978059182401
             - umd_chip_id: 10
               asic_position:
@@ -610,7 +610,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 88
+                chip_id: 47
               asic_id: 231143978059182419
             - umd_chip_id: 11
               asic_position:
@@ -618,7 +618,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 91
+                chip_id: 44
               asic_id: 231143978059182422
             - umd_chip_id: 12
               asic_position:
@@ -626,7 +626,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 59
+                chip_id: 76
               asic_id: 303201572097110327
             - umd_chip_id: 13
               asic_position:
@@ -634,7 +634,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 56
+                chip_id: 79
               asic_id: 303201572097110337
             - umd_chip_id: 14
               asic_position:
@@ -642,7 +642,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 72
+                chip_id: 63
               asic_id: 303201572097110355
             - umd_chip_id: 15
               asic_position:
@@ -650,7 +650,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 75
+                chip_id: 60
               asic_id: 303201572097110358
             - umd_chip_id: 16
               asic_position:
@@ -658,7 +658,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 10
+                chip_id: 125
               asic_id: 375259166135038263
             - umd_chip_id: 17
               asic_position:
@@ -666,7 +666,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 9
+                chip_id: 126
               asic_id: 375259166135038273
             - umd_chip_id: 18
               asic_position:
@@ -674,7 +674,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 121
+                chip_id: 14
               asic_id: 375259166135038291
             - umd_chip_id: 19
               asic_position:
@@ -682,7 +682,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 122
+                chip_id: 13
               asic_id: 375259166135038294
             - umd_chip_id: 20
               asic_position:
@@ -690,7 +690,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 26
+                chip_id: 109
               asic_id: 447316760172966199
             - umd_chip_id: 21
               asic_position:
@@ -698,7 +698,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 25
+                chip_id: 110
               asic_id: 447316760172966209
             - umd_chip_id: 22
               asic_position:
@@ -706,7 +706,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 105
+                chip_id: 30
               asic_id: 447316760172966227
             - umd_chip_id: 23
               asic_position:
@@ -714,7 +714,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 106
+                chip_id: 29
               asic_id: 447316760172966230
             - umd_chip_id: 24
               asic_position:
@@ -722,7 +722,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 42
+                chip_id: 93
               asic_id: 519374354210894135
             - umd_chip_id: 25
               asic_position:
@@ -730,7 +730,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 41
+                chip_id: 94
               asic_id: 519374354210894145
             - umd_chip_id: 26
               asic_position:
@@ -738,7 +738,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 89
+                chip_id: 46
               asic_id: 519374354210894163
             - umd_chip_id: 27
               asic_position:
@@ -746,7 +746,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 90
+                chip_id: 45
               asic_id: 519374354210894166
             - umd_chip_id: 28
               asic_position:
@@ -754,7 +754,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 58
+                chip_id: 77
               asic_id: 591431948248822071
             - umd_chip_id: 29
               asic_position:
@@ -762,7 +762,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 57
+                chip_id: 78
               asic_id: 591431948248822081
             - umd_chip_id: 30
               asic_position:
@@ -770,7 +770,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 73
+                chip_id: 62
               asic_id: 591431948248822099
             - umd_chip_id: 31
               asic_position:
@@ -778,7 +778,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 74
+                chip_id: 61
               asic_id: 591431948248822102
     - hostname: g14glx03_3
       mesh:
@@ -790,7 +790,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 127
+                chip_id: 8
               asic_id: 87028789983326263
             - umd_chip_id: 1
               asic_position:
@@ -798,7 +798,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 124
+                chip_id: 11
               asic_id: 87028789983326292
             - umd_chip_id: 2
               asic_position:
@@ -806,7 +806,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 15
+                chip_id: 120
               asic_id: 87028789983326521
             - umd_chip_id: 3
               asic_position:
@@ -814,7 +814,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 12
+                chip_id: 123
               asic_id: 87028789983326768
             - umd_chip_id: 4
               asic_position:
@@ -822,7 +822,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 111
+                chip_id: 24
               asic_id: 159086384021254199
             - umd_chip_id: 5
               asic_position:
@@ -830,7 +830,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 108
+                chip_id: 27
               asic_id: 159086384021254228
             - umd_chip_id: 6
               asic_position:
@@ -838,7 +838,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 31
+                chip_id: 104
               asic_id: 159086384021254457
             - umd_chip_id: 7
               asic_position:
@@ -846,7 +846,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 28
+                chip_id: 107
               asic_id: 159086384021254704
             - umd_chip_id: 8
               asic_position:
@@ -854,7 +854,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 95
+                chip_id: 40
               asic_id: 231143978059182135
             - umd_chip_id: 9
               asic_position:
@@ -862,7 +862,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 92
+                chip_id: 43
               asic_id: 231143978059182164
             - umd_chip_id: 10
               asic_position:
@@ -870,7 +870,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 47
+                chip_id: 88
               asic_id: 231143978059182393
             - umd_chip_id: 11
               asic_position:
@@ -878,7 +878,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 44
+                chip_id: 91
               asic_id: 231143978059182640
             - umd_chip_id: 12
               asic_position:
@@ -886,7 +886,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 79
+                chip_id: 56
               asic_id: 303201572097110071
             - umd_chip_id: 13
               asic_position:
@@ -894,7 +894,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 76
+                chip_id: 59
               asic_id: 303201572097110100
             - umd_chip_id: 14
               asic_position:
@@ -902,7 +902,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 63
+                chip_id: 72
               asic_id: 303201572097110329
             - umd_chip_id: 15
               asic_position:
@@ -910,7 +910,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 60
+                chip_id: 75
               asic_id: 303201572097110576
             - umd_chip_id: 16
               asic_position:
@@ -918,7 +918,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 126
+                chip_id: 9
               asic_id: 375259166135038007
             - umd_chip_id: 17
               asic_position:
@@ -926,7 +926,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 125
+                chip_id: 10
               asic_id: 375259166135038036
             - umd_chip_id: 18
               asic_position:
@@ -934,7 +934,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 14
+                chip_id: 121
               asic_id: 375259166135038265
             - umd_chip_id: 19
               asic_position:
@@ -942,7 +942,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 13
+                chip_id: 122
               asic_id: 375259166135038512
             - umd_chip_id: 20
               asic_position:
@@ -950,7 +950,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 110
+                chip_id: 25
               asic_id: 447316760172965943
             - umd_chip_id: 21
               asic_position:
@@ -958,7 +958,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 109
+                chip_id: 26
               asic_id: 447316760172965972
             - umd_chip_id: 22
               asic_position:
@@ -966,7 +966,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 30
+                chip_id: 105
               asic_id: 447316760172966201
             - umd_chip_id: 23
               asic_position:
@@ -974,7 +974,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 29
+                chip_id: 106
               asic_id: 447316760172966448
             - umd_chip_id: 24
               asic_position:
@@ -982,7 +982,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 94
+                chip_id: 41
               asic_id: 519374354210893879
             - umd_chip_id: 25
               asic_position:
@@ -990,7 +990,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 93
+                chip_id: 42
               asic_id: 519374354210893908
             - umd_chip_id: 26
               asic_position:
@@ -998,7 +998,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 46
+                chip_id: 89
               asic_id: 519374354210894137
             - umd_chip_id: 27
               asic_position:
@@ -1006,7 +1006,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 45
+                chip_id: 90
               asic_id: 519374354210894384
             - umd_chip_id: 28
               asic_position:
@@ -1014,7 +1014,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 78
+                chip_id: 57
               asic_id: 591431948248821815
             - umd_chip_id: 29
               asic_position:
@@ -1022,7 +1022,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 77
+                chip_id: 58
               asic_id: 591431948248821844
             - umd_chip_id: 30
               asic_position:
@@ -1030,7 +1030,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 62
+                chip_id: 73
               asic_id: 591431948248822073
             - umd_chip_id: 31
               asic_position:
@@ -1038,5 +1038,5 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 61
+                chip_id: 74
               asic_id: 591431948248822320

--- a/tests/tt_metal/tt_fabric/golden_mapping_files/TestSplit2x2ControlPlaneInit.yaml
+++ b/tests/tt_metal/tt_fabric/golden_mapping_files/TestSplit2x2ControlPlaneInit.yaml
@@ -3,7 +3,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_0
       mesh:
         - mesh: 0
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 0
@@ -39,7 +39,7 @@ asic_to_fabric_node_mapping:
     - hostname: g14glx03_1
       mesh:
         - mesh: 1
-          chips:
+        - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 0

--- a/tests/tt_metal/tt_fabric/golden_mapping_files/TestTriplePod16x8QuadBHGalaxyControlPlaneInit.yaml
+++ b/tests/tt_metal/tt_fabric/golden_mapping_files/TestTriplePod16x8QuadBHGalaxyControlPlaneInit.yaml
@@ -1,6 +1,6 @@
 asic_to_fabric_node_mapping:
   hostnames:
-    - hostname: UF-MN-B3-GWH01_0
+    - hostname: g14glx03_0
       mesh:
         - mesh: 0
         - chips:
@@ -10,7 +10,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 27
+                chip_id: 96
               asic_id: 4015139053881686263
             - umd_chip_id: 1
               asic_position:
@@ -18,7 +18,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 33
+                chip_id: 90
               asic_id: 4293754642479271510
             - umd_chip_id: 2
               asic_position:
@@ -26,7 +26,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 1
+                chip_id: 122
               asic_id: 4297198497990999668
             - umd_chip_id: 3
               asic_position:
@@ -34,7 +34,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 35
+                chip_id: 88
               asic_id: 5152878922918480065
             - umd_chip_id: 4
               asic_position:
@@ -42,7 +42,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 51
+                chip_id: 72
               asic_id: 5725456556045297322
             - umd_chip_id: 5
               asic_position:
@@ -50,7 +50,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 32
+                chip_id: 91
               asic_id: 5951117041131159388
             - umd_chip_id: 6
               asic_position:
@@ -58,7 +58,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 10
+                chip_id: 113
               asic_id: 5999584508252761467
             - umd_chip_id: 7
               asic_position:
@@ -66,7 +66,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 50
+                chip_id: 73
               asic_id: 6380569581715101503
             - umd_chip_id: 8
               asic_position:
@@ -74,7 +74,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 41
+                chip_id: 82
               asic_id: 7669057571733667651
             - umd_chip_id: 9
               asic_position:
@@ -82,7 +82,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 11
+                chip_id: 112
               asic_id: 8130813488093937279
             - umd_chip_id: 10
               asic_position:
@@ -90,7 +90,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 49
+                chip_id: 74
               asic_id: 8520042005742043698
             - umd_chip_id: 11
               asic_position:
@@ -98,7 +98,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 25
+                chip_id: 98
               asic_id: 9759511604032291291
             - umd_chip_id: 12
               asic_position:
@@ -106,7 +106,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 0
+                chip_id: 123
               asic_id: 9871626897429866173
             - umd_chip_id: 13
               asic_position:
@@ -114,7 +114,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 57
+                chip_id: 66
               asic_id: 10042118635050604804
             - umd_chip_id: 14
               asic_position:
@@ -122,7 +122,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 8
+                chip_id: 115
               asic_id: 11344327765109952640
             - umd_chip_id: 15
               asic_position:
@@ -130,7 +130,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 3
+                chip_id: 120
               asic_id: 12896014417745305665
             - umd_chip_id: 16
               asic_position:
@@ -138,7 +138,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 56
+                chip_id: 67
               asic_id: 13603147099094158770
             - umd_chip_id: 17
               asic_position:
@@ -146,7 +146,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 48
+                chip_id: 75
               asic_id: 13773051510894320610
             - umd_chip_id: 18
               asic_position:
@@ -154,7 +154,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 42
+                chip_id: 81
               asic_id: 14049621424350934141
             - umd_chip_id: 19
               asic_position:
@@ -162,7 +162,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 24
+                chip_id: 99
               asic_id: 14952301210084974370
             - umd_chip_id: 20
               asic_position:
@@ -170,7 +170,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 16
+                chip_id: 107
               asic_id: 15239431485920572942
             - umd_chip_id: 21
               asic_position:
@@ -178,7 +178,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 26
+                chip_id: 97
               asic_id: 15385024325187731614
             - umd_chip_id: 22
               asic_position:
@@ -186,7 +186,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 34
+                chip_id: 89
               asic_id: 15470236399078210826
             - umd_chip_id: 23
               asic_position:
@@ -194,7 +194,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 18
+                chip_id: 105
               asic_id: 15761518385204273539
             - umd_chip_id: 24
               asic_position:
@@ -202,7 +202,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 58
+                chip_id: 65
               asic_id: 16261424787273519591
             - umd_chip_id: 25
               asic_position:
@@ -210,7 +210,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 59
+                chip_id: 64
               asic_id: 16522223436016007978
             - umd_chip_id: 26
               asic_position:
@@ -218,7 +218,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 43
+                chip_id: 80
               asic_id: 16779929275816062523
             - umd_chip_id: 27
               asic_position:
@@ -226,7 +226,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 9
+                chip_id: 114
               asic_id: 17273024576962915557
             - umd_chip_id: 28
               asic_position:
@@ -234,7 +234,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 40
+                chip_id: 83
               asic_id: 17612074373475594817
             - umd_chip_id: 29
               asic_position:
@@ -242,7 +242,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 2
+                chip_id: 121
               asic_id: 18138467941411947868
             - umd_chip_id: 30
               asic_position:
@@ -250,7 +250,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 17
+                chip_id: 106
               asic_id: 18270253674144463298
             - umd_chip_id: 31
               asic_position:
@@ -258,9 +258,9 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 19
+                chip_id: 104
               asic_id: 18273080800459561610
-    - hostname: UF-MN-B3-GWH01_1
+    - hostname: g14glx03_1
       mesh:
         - mesh: 0
         - chips:
@@ -270,7 +270,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 37
+                chip_id: 94
               asic_id: 650421544081505285
             - umd_chip_id: 1
               asic_position:
@@ -278,7 +278,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 62
+                chip_id: 69
               asic_id: 759674371012042681
             - umd_chip_id: 2
               asic_position:
@@ -286,7 +286,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 23
+                chip_id: 108
               asic_id: 1278618585946748323
             - umd_chip_id: 3
               asic_position:
@@ -294,7 +294,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 15
+                chip_id: 116
               asic_id: 1409910845107221465
             - umd_chip_id: 4
               asic_position:
@@ -302,7 +302,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 44
+                chip_id: 87
               asic_id: 2351850558927920447
             - umd_chip_id: 5
               asic_position:
@@ -310,7 +310,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 29
+                chip_id: 102
               asic_id: 3576129850696554714
             - umd_chip_id: 6
               asic_position:
@@ -318,7 +318,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 38
+                chip_id: 93
               asic_id: 4344505770102943653
             - umd_chip_id: 7
               asic_position:
@@ -326,7 +326,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 5
+                chip_id: 126
               asic_id: 4864024171382154771
             - umd_chip_id: 8
               asic_position:
@@ -334,7 +334,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 39
+                chip_id: 92
               asic_id: 5129755396355777844
             - umd_chip_id: 9
               asic_position:
@@ -342,7 +342,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 21
+                chip_id: 110
               asic_id: 5528852007837852788
             - umd_chip_id: 10
               asic_position:
@@ -350,7 +350,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 14
+                chip_id: 117
               asic_id: 6074070378446960422
             - umd_chip_id: 11
               asic_position:
@@ -358,7 +358,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 47
+                chip_id: 84
               asic_id: 6175938289485490640
             - umd_chip_id: 12
               asic_position:
@@ -366,7 +366,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 54
+                chip_id: 77
               asic_id: 6181842542226162421
             - umd_chip_id: 13
               asic_position:
@@ -374,7 +374,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 55
+                chip_id: 76
               asic_id: 6211188630195614173
             - umd_chip_id: 14
               asic_position:
@@ -382,7 +382,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 63
+                chip_id: 68
               asic_id: 6962610333654833890
             - umd_chip_id: 15
               asic_position:
@@ -390,7 +390,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 45
+                chip_id: 86
               asic_id: 8267573113037461913
             - umd_chip_id: 16
               asic_position:
@@ -398,7 +398,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 13
+                chip_id: 118
               asic_id: 8477064126247037115
             - umd_chip_id: 17
               asic_position:
@@ -406,7 +406,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 53
+                chip_id: 78
               asic_id: 8642605409265878512
             - umd_chip_id: 18
               asic_position:
@@ -414,7 +414,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 36
+                chip_id: 95
               asic_id: 8647625426668573486
             - umd_chip_id: 19
               asic_position:
@@ -422,7 +422,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 30
+                chip_id: 101
               asic_id: 9795820433025443632
             - umd_chip_id: 20
               asic_position:
@@ -430,7 +430,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 6
+                chip_id: 125
               asic_id: 10458279698815118660
             - umd_chip_id: 21
               asic_position:
@@ -438,7 +438,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 52
+                chip_id: 79
               asic_id: 10581738303983564604
             - umd_chip_id: 22
               asic_position:
@@ -446,7 +446,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 60
+                chip_id: 71
               asic_id: 10815534592467708593
             - umd_chip_id: 23
               asic_position:
@@ -454,7 +454,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 28
+                chip_id: 103
               asic_id: 13163416133340509915
             - umd_chip_id: 24
               asic_position:
@@ -462,7 +462,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 31
+                chip_id: 100
               asic_id: 13620522171604337071
             - umd_chip_id: 25
               asic_position:
@@ -470,7 +470,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 22
+                chip_id: 109
               asic_id: 13681428107587072560
             - umd_chip_id: 26
               asic_position:
@@ -478,7 +478,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 61
+                chip_id: 70
               asic_id: 13735393490658273438
             - umd_chip_id: 27
               asic_position:
@@ -486,7 +486,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 20
+                chip_id: 111
               asic_id: 15643852771242972941
             - umd_chip_id: 28
               asic_position:
@@ -494,7 +494,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 12
+                chip_id: 119
               asic_id: 15980092694121183966
             - umd_chip_id: 29
               asic_position:
@@ -502,7 +502,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 4
+                chip_id: 127
               asic_id: 16418791270080614156
             - umd_chip_id: 30
               asic_position:
@@ -510,7 +510,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 7
+                chip_id: 124
               asic_id: 17172097971703158368
             - umd_chip_id: 31
               asic_position:
@@ -518,9 +518,9 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 46
+                chip_id: 85
               asic_id: 17197675523627772381
-    - hostname: UF-MN-B3-GWH01_10
+    - hostname: g14glx03_10
       mesh:
         - mesh: 2
         - chips:
@@ -780,7 +780,7 @@ asic_to_fabric_node_mapping:
                 mesh_id: 2
                 chip_id: 56
               asic_id: 18341657909943303203
-    - hostname: UF-MN-B3-GWH01_11
+    - hostname: g14glx03_11
       mesh:
         - mesh: 2
         - chips:
@@ -1040,7 +1040,7 @@ asic_to_fabric_node_mapping:
                 mesh_id: 2
                 chip_id: 7
               asic_id: 17923607448576730733
-    - hostname: UF-MN-B3-GWH01_2
+    - hostname: g14glx03_2
       mesh:
         - mesh: 0
         - chips:
@@ -1050,7 +1050,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 66
+                chip_id: 57
               asic_id: 401337518907361871
             - umd_chip_id: 1
               asic_position:
@@ -1058,7 +1058,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 115
+                chip_id: 8
               asic_id: 430890185489928492
             - umd_chip_id: 2
               asic_position:
@@ -1066,7 +1066,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 104
+                chip_id: 19
               asic_id: 692690275524063637
             - umd_chip_id: 3
               asic_position:
@@ -1074,7 +1074,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 73
+                chip_id: 50
               asic_id: 1229998203186239511
             - umd_chip_id: 4
               asic_position:
@@ -1082,7 +1082,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 88
+                chip_id: 35
               asic_id: 1734830983127975496
             - umd_chip_id: 5
               asic_position:
@@ -1090,7 +1090,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 122
+                chip_id: 1
               asic_id: 1861863816036089619
             - umd_chip_id: 6
               asic_position:
@@ -1098,7 +1098,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 98
+                chip_id: 25
               asic_id: 2048868718786698021
             - umd_chip_id: 7
               asic_position:
@@ -1106,7 +1106,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 123
+                chip_id: 0
               asic_id: 2130883600670189900
             - umd_chip_id: 8
               asic_position:
@@ -1114,7 +1114,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 74
+                chip_id: 49
               asic_id: 2977020757321232977
             - umd_chip_id: 9
               asic_position:
@@ -1122,7 +1122,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 72
+                chip_id: 51
               asic_id: 4231210081009303848
             - umd_chip_id: 10
               asic_position:
@@ -1130,7 +1130,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 64
+                chip_id: 59
               asic_id: 4299649333528068871
             - umd_chip_id: 11
               asic_position:
@@ -1138,7 +1138,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 113
+                chip_id: 10
               asic_id: 5755846157507482580
             - umd_chip_id: 12
               asic_position:
@@ -1146,7 +1146,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 82
+                chip_id: 41
               asic_id: 5916400381259020946
             - umd_chip_id: 13
               asic_position:
@@ -1154,7 +1154,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 105
+                chip_id: 18
               asic_id: 6042747085481328621
             - umd_chip_id: 14
               asic_position:
@@ -1162,7 +1162,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 80
+                chip_id: 43
               asic_id: 6695964551700819526
             - umd_chip_id: 15
               asic_position:
@@ -1170,7 +1170,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 106
+                chip_id: 17
               asic_id: 9067060589648077241
             - umd_chip_id: 16
               asic_position:
@@ -1178,7 +1178,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 99
+                chip_id: 24
               asic_id: 9094166003275609369
             - umd_chip_id: 17
               asic_position:
@@ -1186,7 +1186,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 89
+                chip_id: 34
               asic_id: 9336878208705773747
             - umd_chip_id: 18
               asic_position:
@@ -1194,7 +1194,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 91
+                chip_id: 32
               asic_id: 9819222692007590233
             - umd_chip_id: 19
               asic_position:
@@ -1202,7 +1202,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 112
+                chip_id: 11
               asic_id: 9954665973819926719
             - umd_chip_id: 20
               asic_position:
@@ -1210,7 +1210,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 81
+                chip_id: 42
               asic_id: 11931033763845401760
             - umd_chip_id: 21
               asic_position:
@@ -1218,7 +1218,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 67
+                chip_id: 56
               asic_id: 14157380878147747328
             - umd_chip_id: 22
               asic_position:
@@ -1226,7 +1226,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 97
+                chip_id: 26
               asic_id: 14415420534742026726
             - umd_chip_id: 23
               asic_position:
@@ -1234,7 +1234,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 107
+                chip_id: 16
               asic_id: 14966567221657730258
             - umd_chip_id: 24
               asic_position:
@@ -1242,7 +1242,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 121
+                chip_id: 2
               asic_id: 14970797127470725332
             - umd_chip_id: 25
               asic_position:
@@ -1250,7 +1250,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 90
+                chip_id: 33
               asic_id: 15338193993411687817
             - umd_chip_id: 26
               asic_position:
@@ -1258,7 +1258,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 120
+                chip_id: 3
               asic_id: 15837661886381334628
             - umd_chip_id: 27
               asic_position:
@@ -1266,7 +1266,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 65
+                chip_id: 58
               asic_id: 16204851374915171406
             - umd_chip_id: 28
               asic_position:
@@ -1274,7 +1274,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 96
+                chip_id: 27
               asic_id: 16775659700169645334
             - umd_chip_id: 29
               asic_position:
@@ -1282,7 +1282,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 75
+                chip_id: 48
               asic_id: 16830661331005093014
             - umd_chip_id: 30
               asic_position:
@@ -1290,7 +1290,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 83
+                chip_id: 40
               asic_id: 17174932920519537227
             - umd_chip_id: 31
               asic_position:
@@ -1298,9 +1298,9 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 114
+                chip_id: 9
               asic_id: 17811904539885282606
-    - hostname: UF-MN-B3-GWH01_3
+    - hostname: g14glx03_3
       mesh:
         - mesh: 0
         - chips:
@@ -1310,7 +1310,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 101
+                chip_id: 30
               asic_id: 313650361076034623
             - umd_chip_id: 1
               asic_position:
@@ -1318,7 +1318,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 110
+                chip_id: 21
               asic_id: 1316772005928213923
             - umd_chip_id: 2
               asic_position:
@@ -1326,7 +1326,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 103
+                chip_id: 28
               asic_id: 1408778462404599637
             - umd_chip_id: 3
               asic_position:
@@ -1334,7 +1334,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 76
+                chip_id: 55
               asic_id: 1790268702040388330
             - umd_chip_id: 4
               asic_position:
@@ -1342,7 +1342,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 68
+                chip_id: 63
               asic_id: 3371414299746441410
             - umd_chip_id: 5
               asic_position:
@@ -1350,7 +1350,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 108
+                chip_id: 23
               asic_id: 3841612461917036993
             - umd_chip_id: 6
               asic_position:
@@ -1358,7 +1358,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 78
+                chip_id: 53
               asic_id: 4050361119573817869
             - umd_chip_id: 7
               asic_position:
@@ -1366,7 +1366,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 86
+                chip_id: 45
               asic_id: 4626142204601111602
             - umd_chip_id: 8
               asic_position:
@@ -1374,7 +1374,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 70
+                chip_id: 61
               asic_id: 4940957888807637657
             - umd_chip_id: 9
               asic_position:
@@ -1382,7 +1382,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 127
+                chip_id: 4
               asic_id: 4965058465883733834
             - umd_chip_id: 10
               asic_position:
@@ -1390,7 +1390,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 69
+                chip_id: 62
               asic_id: 5060645188502771228
             - umd_chip_id: 11
               asic_position:
@@ -1398,7 +1398,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 95
+                chip_id: 36
               asic_id: 5113304306981078376
             - umd_chip_id: 12
               asic_position:
@@ -1406,7 +1406,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 87
+                chip_id: 44
               asic_id: 5295793135446783947
             - umd_chip_id: 13
               asic_position:
@@ -1414,7 +1414,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 84
+                chip_id: 47
               asic_id: 6051024940858745138
             - umd_chip_id: 14
               asic_position:
@@ -1422,7 +1422,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 102
+                chip_id: 29
               asic_id: 7410929570732062722
             - umd_chip_id: 15
               asic_position:
@@ -1430,7 +1430,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 124
+                chip_id: 7
               asic_id: 7582399015508169023
             - umd_chip_id: 16
               asic_position:
@@ -1438,7 +1438,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 85
+                chip_id: 46
               asic_id: 7830623694002473925
             - umd_chip_id: 17
               asic_position:
@@ -1446,7 +1446,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 126
+                chip_id: 5
               asic_id: 8421753656434672484
             - umd_chip_id: 18
               asic_position:
@@ -1454,7 +1454,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 79
+                chip_id: 52
               asic_id: 9716929175281449440
             - umd_chip_id: 19
               asic_position:
@@ -1462,7 +1462,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 94
+                chip_id: 37
               asic_id: 9922117238191143716
             - umd_chip_id: 20
               asic_position:
@@ -1470,7 +1470,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 71
+                chip_id: 60
               asic_id: 10054623275765501911
             - umd_chip_id: 21
               asic_position:
@@ -1478,7 +1478,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 92
+                chip_id: 39
               asic_id: 10281072969541577240
             - umd_chip_id: 22
               asic_position:
@@ -1486,7 +1486,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 119
+                chip_id: 12
               asic_id: 12512186430164155614
             - umd_chip_id: 23
               asic_position:
@@ -1494,7 +1494,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 117
+                chip_id: 14
               asic_id: 12546837450656722284
             - umd_chip_id: 24
               asic_position:
@@ -1502,7 +1502,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 77
+                chip_id: 54
               asic_id: 13567352836474075276
             - umd_chip_id: 25
               asic_position:
@@ -1510,7 +1510,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 109
+                chip_id: 22
               asic_id: 14427583256616748711
             - umd_chip_id: 26
               asic_position:
@@ -1518,7 +1518,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 93
+                chip_id: 38
               asic_id: 14764770483778850194
             - umd_chip_id: 27
               asic_position:
@@ -1526,7 +1526,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 125
+                chip_id: 6
               asic_id: 15230295758484287666
             - umd_chip_id: 28
               asic_position:
@@ -1534,7 +1534,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 116
+                chip_id: 15
               asic_id: 17184132379278075247
             - umd_chip_id: 29
               asic_position:
@@ -1542,7 +1542,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 118
+                chip_id: 13
               asic_id: 17303878229876237513
             - umd_chip_id: 30
               asic_position:
@@ -1550,7 +1550,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 100
+                chip_id: 31
               asic_id: 17659935727681795003
             - umd_chip_id: 31
               asic_position:
@@ -1558,9 +1558,9 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 111
+                chip_id: 20
               asic_id: 18242298208287120962
-    - hostname: UF-MN-B3-GWH01_4
+    - hostname: g14glx03_4
       mesh:
         - mesh: 1
         - chips:
@@ -1820,7 +1820,7 @@ asic_to_fabric_node_mapping:
                 mesh_id: 1
                 chip_id: 41
               asic_id: 16986169942014796079
-    - hostname: UF-MN-B3-GWH01_5
+    - hostname: g14glx03_5
       mesh:
         - mesh: 1
         - chips:
@@ -2080,7 +2080,7 @@ asic_to_fabric_node_mapping:
                 mesh_id: 1
                 chip_id: 12
               asic_id: 17908134424639479912
-    - hostname: UF-MN-B3-GWH01_6
+    - hostname: g14glx03_6
       mesh:
         - mesh: 1
         - chips:
@@ -2340,7 +2340,7 @@ asic_to_fabric_node_mapping:
                 mesh_id: 1
                 chip_id: 122
               asic_id: 18391595455951996786
-    - hostname: UF-MN-B3-GWH01_7
+    - hostname: g14glx03_7
       mesh:
         - mesh: 1
         - chips:
@@ -2600,7 +2600,7 @@ asic_to_fabric_node_mapping:
                 mesh_id: 1
                 chip_id: 102
               asic_id: 18334331821271288478
-    - hostname: UF-MN-B3-GWH01_8
+    - hostname: g14glx03_8
       mesh:
         - mesh: 2
         - chips:
@@ -2860,7 +2860,7 @@ asic_to_fabric_node_mapping:
                 mesh_id: 2
                 chip_id: 66
               asic_id: 17937138559393544966
-    - hostname: UF-MN-B3-GWH01_9
+    - hostname: g14glx03_9
       mesh:
         - mesh: 2
         - chips:

--- a/tt_metal/api/tt-metalium/experimental/fabric/topology_solver.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/topology_solver.hpp
@@ -598,9 +598,9 @@ struct ConstraintIndexData {
     std::vector<std::pair<std::set<std::pair<size_t, size_t>>, size_t>> cardinality_constraints;
 
     // Same-group: target_idx/global_idx -> group_id (-1 or SIZE_MAX if not in any group)
-    std::vector<int> global_to_same_rank_group_;
-    std::vector<std::set<size_t>> same_rank_groups_;
-    std::vector<size_t> target_to_group_;
+    std::vector<int> global_to_same_rank_group;
+    std::vector<std::set<size_t>> same_rank_groups;
+    std::vector<size_t> target_to_group;
 
     /**
      * @brief Construct ConstraintIndexData from MappingConstraints and GraphIndexData
@@ -651,8 +651,9 @@ struct ConstraintIndexData {
     /**
      * @brief Check if assigning (target_idx, global_idx) satisfies same-rank groups constraint
      *
-     * For global in a same-rank group: all already-assigned globals in that group must
-     * be mapped to targets with the same trait as target_idx.
+     * Ensures no target-group boundary splitting: all other targets in target_idx's group
+     * that are already assigned must map to globals in the same global group as global_idx.
+     * Multiple target groups may share a global group.
      */
     bool check_same_rank_constraint(
         size_t target_idx, size_t global_idx, const std::vector<int>& mapping, const std::vector<bool>& used) const;

--- a/tt_metal/api/tt-metalium/experimental/fabric/topology_solver.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/topology_solver.hpp
@@ -356,6 +356,22 @@ public:
         const;
 
     /**
+     * @brief Set same-group constraint (for UNSET host rank binding)
+     *
+     * Ensures that targets in the same target group can only map to globals in one global group.
+     * The solver picks the assignment; no pre-assignment. Apply required constraints (e.g. rank
+     * must map to specific host) after this for explicit bindings.
+     *
+     * @param target_groups Vector of sets; each set is target nodes (e.g. fabric nodes per rank)
+     * @param global_groups Vector of sets; each set is global nodes (e.g. ASICs per host)
+     */
+    void set_same_rank_groups_constraint(
+        const std::vector<std::set<TargetNode>>& target_groups, const std::vector<std::set<GlobalNode>>& global_groups);
+
+    const std::vector<std::set<TargetNode>>& get_same_rank_target_groups() const { return same_rank_target_groups_; }
+    const std::vector<std::set<GlobalNode>>& get_same_rank_global_groups() const { return same_rank_global_groups_; }
+
+    /**
      * @brief Get forbidden (target, global) pairs that are invalid even when no required constraints exist
      *
      * Used when add_forbidden_constraint is called for a target with no valid_mappings_ entry.
@@ -387,6 +403,10 @@ private:
     // Cardinality constraints: vector of (mapping_pairs, min_count) tuples
     // Each constraint requires that at least min_count of the mapping_pairs must be satisfied
     std::vector<std::pair<std::set<std::pair<TargetNode, GlobalNode>>, size_t>> cardinality_constraints_;
+
+    // Same-group constraint: targets in a target group map to at most one global group
+    std::vector<std::set<TargetNode>> same_rank_target_groups_;
+    std::vector<std::set<GlobalNode>> same_rank_global_groups_;
 
     // Track which global nodes are exclusively reserved by many-to-many constraints
     // Maps global node -> set of target nodes that are allowed to map to it via many-to-many constraints
@@ -577,6 +597,11 @@ struct ConstraintIndexData {
     // Each constraint requires that at least min_count of the (target_idx, global_idx) pairs must be satisfied
     std::vector<std::pair<std::set<std::pair<size_t, size_t>>, size_t>> cardinality_constraints;
 
+    // Same-group: target_idx/global_idx -> group_id (-1 or SIZE_MAX if not in any group)
+    std::vector<int> global_to_same_rank_group_;
+    std::vector<std::set<size_t>> same_rank_groups_;
+    std::vector<size_t> target_to_group_;
+
     /**
      * @brief Construct ConstraintIndexData from MappingConstraints and GraphIndexData
      *
@@ -622,6 +647,15 @@ struct ConstraintIndexData {
 
     // Helper: check if mapping is valid
     bool is_valid_mapping(size_t target_idx, size_t global_idx) const;
+
+    /**
+     * @brief Check if assigning (target_idx, global_idx) satisfies same-rank groups constraint
+     *
+     * For global in a same-rank group: all already-assigned globals in that group must
+     * be mapped to targets with the same trait as target_idx.
+     */
+    bool check_same_rank_constraint(
+        size_t target_idx, size_t global_idx, const std::vector<int>& mapping, const std::vector<bool>& used) const;
 
     // Helper: get candidates for target node
     // Returns restricted candidates if available, otherwise returns empty vector (meaning all are valid)

--- a/tt_metal/api/tt-metalium/experimental/fabric/topology_solver.tpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/topology_solver.tpp
@@ -1299,13 +1299,13 @@ ConstraintIndexData<TargetNode, GlobalNode>::ConstraintIndexData(
     // Convert same-group constraint from node-based to index-based
     const auto& target_groups_node = constraints.get_same_rank_target_groups();
     const auto& global_groups_node = constraints.get_same_rank_global_groups();
-    target_to_group_.resize(graph_data.n_target, SIZE_MAX);
-    global_to_same_rank_group_.resize(graph_data.n_global, -1);
+    target_to_group.resize(graph_data.n_target, SIZE_MAX);
+    global_to_same_rank_group.resize(graph_data.n_global, -1);
     for (size_t group_id = 0; group_id < target_groups_node.size(); ++group_id) {
         for (const auto& target_node : target_groups_node[group_id]) {
             auto idx_it = graph_data.target_to_idx.find(target_node);
             if (idx_it != graph_data.target_to_idx.end()) {
-                target_to_group_[idx_it->second] = group_id;
+                target_to_group[idx_it->second] = group_id;
             }
         }
     }
@@ -1315,10 +1315,10 @@ ConstraintIndexData<TargetNode, GlobalNode>::ConstraintIndexData(
             auto idx_it = graph_data.global_to_idx.find(global_node);
             if (idx_it != graph_data.global_to_idx.end()) {
                 group_indices.insert(idx_it->second);
-                global_to_same_rank_group_[idx_it->second] = static_cast<int>(group_id);
+                global_to_same_rank_group[idx_it->second] = static_cast<int>(group_id);
             }
         }
-        same_rank_groups_.push_back(std::move(group_indices));
+        same_rank_groups.push_back(std::move(group_indices));
     }
 }
 
@@ -1329,15 +1329,19 @@ bool ConstraintIndexData<TargetNode, GlobalNode>::check_same_rank_constraint(
     // map to globals in the same global group. Multiple target groups may share a global group
     // (e.g. {1},{2} -> {1,3,2} is fine). Splitting a target group across global groups is invalid
     // (e.g. [1,2,3] mapping to globals spanning [3,4,5] when 3,4 and 5 are in different groups).
-    if (global_to_same_rank_group_.empty() || global_idx >= global_to_same_rank_group_.size()) {
+    bool no_same_rank_groups =
+        global_to_same_rank_group.empty() || global_idx >= global_to_same_rank_group.size();
+    if (no_same_rank_groups) {
         return true;
     }
-    int group_id = global_to_same_rank_group_[global_idx];
-    if (group_id < 0 || static_cast<size_t>(group_id) >= same_rank_groups_.size()) {
+    int group_id = global_to_same_rank_group[global_idx];
+    bool group_id_out_of_range = group_id < 0 || static_cast<size_t>(group_id) >= same_rank_groups.size();
+    if (group_id_out_of_range) {
         return true;
     }
-    size_t my_group = target_idx < target_to_group_.size() ? target_to_group_[target_idx] : SIZE_MAX;
-    if (my_group == SIZE_MAX) {
+    size_t my_group = target_idx < target_to_group.size() ? target_to_group[target_idx] : SIZE_MAX;
+    bool target_not_in_any_group = (my_group == SIZE_MAX);
+    if (target_not_in_any_group) {
         return true;
     }
     // Check: any other target in our group already assigned must be in the same global group
@@ -1345,14 +1349,14 @@ bool ConstraintIndexData<TargetNode, GlobalNode>::check_same_rank_constraint(
         if (t == target_idx || mapping[t] < 0) {
             continue;
         }
-        if (t >= target_to_group_.size() || target_to_group_[t] != my_group) {
+        if (t >= target_to_group.size() || target_to_group[t] != my_group) {
             continue;
         }
         size_t other_global_idx = static_cast<size_t>(mapping[t]);
-        if (other_global_idx >= global_to_same_rank_group_.size()) {
+        if (other_global_idx >= global_to_same_rank_group.size()) {
             continue;
         }
-        int other_global_group = global_to_same_rank_group_[other_global_idx];
+        int other_global_group = global_to_same_rank_group[other_global_idx];
         if (other_global_group != group_id) {
             return false;  // Would split our target group across global boundaries
         }
@@ -1879,7 +1883,9 @@ bool DFSSearchEngine<TargetNode, GlobalNode>::dfs_recursive(
         }
 
         // Check same-rank groups (UNSET host: all ASICs from a host must map to same rank)
-        if (!constraint_data.check_same_rank_constraint(target_idx, global_idx, state_.mapping, state_.used)) {
+        bool violates_same_host_same_rank =
+            !constraint_data.check_same_rank_constraint(target_idx, global_idx, state_.mapping, state_.used);
+        if (violates_same_host_same_rank) {
             continue;  // Would violate same-host same-rank
         }
 

--- a/tt_metal/api/tt-metalium/experimental/fabric/topology_solver.tpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/topology_solver.tpp
@@ -508,6 +508,14 @@ MappingConstraints<TargetNode, GlobalNode>::get_cardinality_constraints() const 
 }
 
 template <typename TargetNode, typename GlobalNode>
+void MappingConstraints<TargetNode, GlobalNode>::set_same_rank_groups_constraint(
+    const std::vector<std::set<TargetNode>>& target_groups,
+    const std::vector<std::set<GlobalNode>>& global_groups) {
+    same_rank_target_groups_ = target_groups;
+    same_rank_global_groups_ = global_groups;
+}
+
+template <typename TargetNode, typename GlobalNode>
 const std::set<std::pair<TargetNode, GlobalNode>>& MappingConstraints<TargetNode, GlobalNode>::get_forbidden_pairs()
     const {
     return forbidden_pairs_;
@@ -1287,6 +1295,69 @@ ConstraintIndexData<TargetNode, GlobalNode>::ConstraintIndexData(
                 indexed_pairs.size());
         }
     }
+
+    // Convert same-group constraint from node-based to index-based
+    const auto& target_groups_node = constraints.get_same_rank_target_groups();
+    const auto& global_groups_node = constraints.get_same_rank_global_groups();
+    target_to_group_.resize(graph_data.n_target, SIZE_MAX);
+    global_to_same_rank_group_.resize(graph_data.n_global, -1);
+    for (size_t group_id = 0; group_id < target_groups_node.size(); ++group_id) {
+        for (const auto& target_node : target_groups_node[group_id]) {
+            auto idx_it = graph_data.target_to_idx.find(target_node);
+            if (idx_it != graph_data.target_to_idx.end()) {
+                target_to_group_[idx_it->second] = group_id;
+            }
+        }
+    }
+    for (size_t group_id = 0; group_id < global_groups_node.size(); ++group_id) {
+        std::set<size_t> group_indices;
+        for (const auto& global_node : global_groups_node[group_id]) {
+            auto idx_it = graph_data.global_to_idx.find(global_node);
+            if (idx_it != graph_data.global_to_idx.end()) {
+                group_indices.insert(idx_it->second);
+                global_to_same_rank_group_[idx_it->second] = static_cast<int>(group_id);
+            }
+        }
+        same_rank_groups_.push_back(std::move(group_indices));
+    }
+}
+
+template <typename TargetNode, typename GlobalNode>
+bool ConstraintIndexData<TargetNode, GlobalNode>::check_same_rank_constraint(
+    size_t target_idx, size_t global_idx, const std::vector<int>& mapping, const std::vector<bool>& /*used*/) const {
+    // Constraint: don't break target-group boundaries. All targets in the same target group must
+    // map to globals in the same global group. Multiple target groups may share a global group
+    // (e.g. {1},{2} -> {1,3,2} is fine). Splitting a target group across global groups is invalid
+    // (e.g. [1,2,3] mapping to globals spanning [3,4,5] when 3,4 and 5 are in different groups).
+    if (global_to_same_rank_group_.empty() || global_idx >= global_to_same_rank_group_.size()) {
+        return true;
+    }
+    int group_id = global_to_same_rank_group_[global_idx];
+    if (group_id < 0 || static_cast<size_t>(group_id) >= same_rank_groups_.size()) {
+        return true;
+    }
+    size_t my_group = target_idx < target_to_group_.size() ? target_to_group_[target_idx] : SIZE_MAX;
+    if (my_group == SIZE_MAX) {
+        return true;
+    }
+    // Check: any other target in our group already assigned must be in the same global group
+    for (size_t t = 0; t < mapping.size(); ++t) {
+        if (t == target_idx || mapping[t] < 0) {
+            continue;
+        }
+        if (t >= target_to_group_.size() || target_to_group_[t] != my_group) {
+            continue;
+        }
+        size_t other_global_idx = static_cast<size_t>(mapping[t]);
+        if (other_global_idx >= global_to_same_rank_group_.size()) {
+            continue;
+        }
+        int other_global_group = global_to_same_rank_group_[other_global_idx];
+        if (other_global_group != group_id) {
+            return false;  // Would split our target group across global boundaries
+        }
+    }
+    return true;
 }
 
 // ============================================================================
@@ -1805,6 +1876,11 @@ bool DFSSearchEngine<TargetNode, GlobalNode>::dfs_recursive(
         if (!ConsistencyChecker::check_forward_consistency(
                 target_idx, global_idx, graph_data, constraint_data, state_.mapping, state_.used, validation_mode)) {
             continue;  // Skip candidate that leaves no options
+        }
+
+        // Check same-rank groups (UNSET host: all ASICs from a host must map to same rank)
+        if (!constraint_data.check_same_rank_constraint(target_idx, global_idx, state_.mapping, state_.used)) {
+            continue;  // Would violate same-host same-rank
         }
 
         // Assign candidate temporarily to check cardinality constraints

--- a/tt_metal/fabric/topology_mapper_utils.cpp
+++ b/tt_metal/fabric/topology_mapper_utils.cpp
@@ -745,6 +745,7 @@ void add_rank_binding_constraints(
         // Constraint: each host's ASICs must all map to fabric nodes of the same rank
         // (same-host same-rank). We add UNSET ASICs to all unclaimed ranks' pools and
         // set a same-rank-groups constraint so the solver rejects splits during DFS.
+        // If large meshes hit DFS limits, consider pruning (e.g., host↔rank matching).
         // -----------------------------------------------------------------------
         if (!unset_hosts.empty()) {
             std::vector<MeshHostRankId> unclaimed_ranks;
@@ -768,6 +769,7 @@ void add_rank_binding_constraints(
 
             // Same-group: target_groups = one set of fabric nodes per rank; global_groups = one set per UNSET host
             std::vector<std::set<FabricNodeId>> target_groups;
+            target_groups.reserve(rank_to_fabric_nodes.size());
             for (const auto& [rank, fabric_nodes] : rank_to_fabric_nodes) {
                 target_groups.push_back(fabric_nodes);
             }

--- a/tt_metal/fabric/topology_mapper_utils.cpp
+++ b/tt_metal/fabric/topology_mapper_utils.cpp
@@ -740,19 +740,11 @@ void add_rank_binding_constraints(
         }
 
         // -----------------------------------------------------------------------
-        // Device pool for UNSET hosts (hosts with no explicit rank binding)
+        // UNSET hosts: no pre-assignment of ranks. Solver picks assignment.
         // -----------------------------------------------------------------------
-        // UNSET hosts form a "device pool" that we assign to unclaimed ranks.
-        // Two strategies to preserve same-host same-rank:
-        //
-        // 1. Multi-ASIC hosts: Assign the entire host to one unclaimed rank.
-        //    All ASICs on that host go to the same rank's pool, so the solver
-        //    cannot split them across ranks.
-        //
-        // 2. Single-ASIC hosts: Add to a shared pool available to ALL unclaimed ranks.
-        //    The solver picks which rank gets each ASIC while satisfying connectivity.
-        //    Flexibility is needed when e.g. only rank 1 is explicitly bound and we
-        //    have 3 single-ASIC hosts for ranks 0, 2, 3.
+        // Constraint: each host's ASICs must all map to fabric nodes of the same rank
+        // (same-host same-rank). We add UNSET ASICs to all unclaimed ranks' pools and
+        // set a same-rank-groups constraint so the solver rejects splits during DFS.
         // -----------------------------------------------------------------------
         if (!unset_hosts.empty()) {
             std::vector<MeshHostRankId> unclaimed_ranks;
@@ -768,25 +760,19 @@ void add_rank_binding_constraints(
                     unset_hosts.size());
             }
 
-            std::set<tt::tt_metal::AsicID> single_asic_pool;  // Shared pool for single-ASIC UNSET hosts
-            size_t multi_idx = 0;
-            for (const auto& host_asics : unset_hosts) {
-                if (host_asics.size() > 1) {
-                    // Multi-ASIC: assign whole host to one unclaimed rank (round-robin).
-                    MeshHostRankId r = unclaimed_ranks[multi_idx++ % unclaimed_ranks.size()];
-                    for (const auto& asic_id : host_asics) {
-                        rank_to_asics[r].insert(asic_id);
-                    }
-                } else {
-                    // Single-ASIC: add to shared pool. Will be added to all unclaimed ranks below.
-                    single_asic_pool.insert(host_asics.begin(), host_asics.end());
-                }
-            }
             for (const auto& r : unclaimed_ranks) {
-                for (const auto& asic_id : single_asic_pool) {
-                    rank_to_asics[r].insert(asic_id);
+                for (const auto& host_asics : unset_hosts) {
+                    rank_to_asics[r].insert(host_asics.begin(), host_asics.end());
                 }
             }
+
+            // Same-group: target_groups = one set of fabric nodes per rank; global_groups = one set per UNSET host
+            std::vector<std::set<FabricNodeId>> target_groups;
+            for (const auto& [rank, fabric_nodes] : rank_to_fabric_nodes) {
+                target_groups.push_back(fabric_nodes);
+            }
+            std::vector<std::set<tt::tt_metal::AsicID>> global_groups(unset_hosts.begin(), unset_hosts.end());
+            intra_mesh_constraints.set_same_rank_groups_constraint(target_groups, global_groups);
         }
     }
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/39653

### Problem description
Auto-rank-bindings assignment is still broken in some cases, here's another fix along with unit tests to ensure its completely fixed

- [ ] [Multi-host test](https://github.com/tenstorrent/tt-metal/actions/runs/22978253288)

###
Confirmed fix with 
```
TT_METAL_SLOW_DISPATCH_MODE=1 /data/deepseek/scripts/ds-run  ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter=ControlPlaneFixture.TestControlPlaneInitNoMGD -k quad

[1,0]<stdout>:  (topology_solver.tpp:84)
[1,0]<stdout>: 2026-03-11 22:02:27.958 | info     |          Fabric | Starting multi-mesh mapping: 1 logical mesh(es) to 1 physical mesh(es) (topology_mapper_utils.cpp:1105)
[1,0]<stdout>: 2026-03-11 22:02:27.958 | info     |          Fabric | Multi-mesh mapping attempt 1/2: Trying inter-mesh mapping (topology_mapper_utils.cpp:1146)
[1,0]<stdout>: 2026-03-11 22:02:27.958 | info     |          Fabric | Attempt 1: Inter-mesh mapping succeeded, found 1 mesh pair(s) (topology_mapper_utils.cpp:1175)
[1,0]<stdout>: 2026-03-11 22:02:28.687 | info     |          Fabric | Multi-mesh mapping succeeded after 1 attempt(s): 1 mesh pair(s) mapped (topology_mapper_utils.cpp:1314)
[1,0]<stdout>: [       OK ] ControlPlaneFixture.TestControlPlaneInitNoMGD (6935 ms)
[1,0]<stdout>: [----------] 1 test from ControlPlaneFixture (6935 ms total)
[1,0]<stdout>: 
[1,0]<stdout>: [----------] Global test environment tear-down
[1,0]<stdout>: [==========] 1 test from 1 test suite ran. (6935 ms total)
[1,0]<stdout>: [  PASSED  ] 1 test.
[1,3]<stdout>: [       OK ] ControlPlaneFixture.TestControlPlaneInitNoMGD (6827 ms)
[1,3]<stdout>: [----------] 1 test from ControlPlaneFixture (6827 ms total)
[1,3]<stdout>: 
[1,3]<stdout>: [----------] Global test environment tear-down
[1,3]<stdout>: [==========] 1 test from 1 test suite ran. (6827 ms total)
[1,3]<stdout>: [  PASSED  ] 1 test.
[1,3]<stdout>: 2026-03-11 22:02:28.993 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:478)
[1,3]<stdout>: 2026-03-11 22:02:28.993 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)
[1,0]<stdout>: 2026-03-11 22:02:28.993 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:478)
[1,0]<stdout>: 2026-03-11 22:02:28.993 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)
[1,2]<stdout>: [       OK ] ControlPlaneFixture.TestControlPlaneInitNoMGD (6829 ms)
[1,2]<stdout>: [----------] 1 test from ControlPlaneFixture (6829 ms total)
[1,2]<stdout>: 
[1,2]<stdout>: [----------] Global test environment tear-down
[1,2]<stdout>: [==========] 1 test from 1 test suite ran. (6829 ms total)
[1,2]<stdout>: [  PASSED  ] 1 test.
[1,2]<stdout>: 2026-03-11 22:02:28.994 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:478)
[1,2]<stdout>: 2026-03-11 22:02:28.995 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)
[1,1]<stdout>: [       OK ] ControlPlaneFixture.TestControlPlaneInitNoMGD (6836 ms)
[1,1]<stdout>: [----------] 1 test from ControlPlaneFixture (6836 ms total)
[1,1]<stdout>: 
[1,1]<stdout>: [----------] Global test environment tear-down
[1,1]<stdout>: [==========] 1 test from 1 test suite ran. (6836 ms total)
[1,1]<stdout>: [  PASSED  ] 1 test.
[1,1]<stdout>: 2026-03-11 22:02:29.001 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:478)
[1,1]<stdout>: 2026-03-11 22:02:29.001 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)
```