### PR TITLE
Add TT_METAL_DISABLE_PRECOMPILED_FW

### DIFF
--- a/tt_metal/jit_build/build_env_manager.cpp
+++ b/tt_metal/jit_build/build_env_manager.cpp
@@ -170,14 +170,18 @@ void BuildEnvManager::add_build_env_locked(
     uint64_t build_key = compute_build_key(dev_config, rtoptions);
     auto device_kernel_defines = initialize_device_kernel_defines(dev_config);
     dev_build_env.build_env.init(build_key, dev_config, rtoptions, device_kernel_defines);
-    auto precompiled_dir =
-        precompiled::find_precompiled_dir(rtoptions.get_root_dir(), dev_build_env.build_env.get_build_key());
-    if (precompiled_dir.has_value()) {
-        dev_build_env.build_env.set_firmware_binary_root(*precompiled_dir);
-        dev_build_env.firmware_precompiled = true;
-    } else {
+    if (rtoptions.get_disable_precompiled_fw()) {
         dev_build_env.firmware_precompiled = false;
-        log_debug(tt::LogBuildKernels, "No pre-compiled firmware found for build key: {}", build_key);
+    } else {
+        auto precompiled_dir =
+            precompiled::find_precompiled_dir(rtoptions.get_root_dir(), dev_build_env.build_env.get_build_key());
+        if (precompiled_dir.has_value()) {
+            dev_build_env.build_env.set_firmware_binary_root(*precompiled_dir);
+            dev_build_env.firmware_precompiled = true;
+        } else {
+            dev_build_env.firmware_precompiled = false;
+            log_debug(tt::LogBuildKernels, "No pre-compiled firmware found for build key: {}", build_key);
+        }
     }
     dev_build_env.firmware_build_states = create_build_state(dev_build_env.build_env, dev_config, true);
     dev_build_env.kernel_build_states = create_build_state(dev_build_env.build_env, dev_config, false);

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -202,7 +202,8 @@ enum class EnvVarID {
     // ========================================
     // JIT BUILD CONFIGURATION
     // ========================================
-    TT_METAL_BACKEND_DUMP_RUN_CMD,  // Dump JIT build commands to stdout
+    TT_METAL_DISABLE_PRECOMPILED_FW,  // Disable use of pre-compiled firmware
+    TT_METAL_BACKEND_DUMP_RUN_CMD,    // Dump JIT build commands to stdout
 };
 
 // Environment variable name for TT-Metal root directory
@@ -1344,6 +1345,12 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
         // Default: false
         // Usage: export TT_METAL_BACKEND_DUMP_RUN_CMD=1
         case EnvVarID::TT_METAL_BACKEND_DUMP_RUN_CMD: this->dump_build_commands = is_env_enabled(value); break;
+
+        // TT_METAL_DISABLE_PRECOMPILED_FW
+        // Disable use of pre-compiled firmware and force JIT compilation instead.
+        // Default: false
+        // Usage: export TT_METAL_DISABLE_PRECOMPILED_FW=1
+        case EnvVarID::TT_METAL_DISABLE_PRECOMPILED_FW: this->set_disable_precompiled_fw(is_env_enabled(value)); break;
     }
 }
 

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -321,6 +321,9 @@ class RunTimeOptions {
     // Dump JIT build commands to stdout for debugging
     bool dump_build_commands = false;
 
+    // Disable use of pre-compiled firmware and fall back to JIT compilation.
+    bool disable_precompiled_fw = false;
+
 public:
     RunTimeOptions();
     RunTimeOptions(const RunTimeOptions&) = delete;
@@ -719,6 +722,9 @@ public:
     bool get_disable_xip_dump() const { return disable_xip_dump; }
 
     bool get_dump_build_commands() const { return dump_build_commands; }
+
+    bool get_disable_precompiled_fw() const { return disable_precompiled_fw; }
+    void set_disable_precompiled_fw(bool disable) { disable_precompiled_fw = disable; }
 
     // Parse all feature-specific environment variables, after hal is initialized.
     // (Needed because syntax of some env vars is arch-dependent.)


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/38397

### Problem description
Need a mechanism to disable precompiled firmware loading.  Useful for firmware developers.

### What's changed
Added an env var TT_METAL_DISABLE_PRECOMPILED_FW to control that.

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ruizhang/offline-fw-build)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ruizhang/offline-fw-build)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ruizhang/offline-fw-build)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ruizhang/offline-fw-build)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ruizhang/offline-fw-build)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ruizhang/offline-fw-build)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ruizhang/offline-fw-build)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ruizhang/offline-fw-build)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ruizhang/offline-fw-build)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ruizhang/offline-fw-build)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ruizhang/offline-fw-build)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ruizhang/offline-fw-build)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
