### PR TITLE
MeshTensor integration for dropout & matmul

### DIFF
--- a/migration.md
+++ b/migration.md
@@ -1,0 +1,309 @@
+# MeshTensor Migration Guide for Program Factories
+
+This guide explains how to migrate program factory implementations from using raw `Tensor` and `Buffer*` APIs to the new `MeshTensor` API.
+
+## Overview
+
+The migration involves changing program factories to work with `MeshTensor` instead of directly accessing `Buffer*` pointers from `Tensor` objects. This provides a more uniform interface for multi-device tensor operations.
+
+## Key API Changes
+
+| Old API | New API |
+|---------|---------|
+| `tensor_args.input.buffer()` | `tensor_args.input.mesh_tensor()` |
+| `tensor.device()` (returns `MeshDevice*`) | `mesh_tensor.device()` (returns `const MeshDevice&`) |
+| `tensor.buffer()->address()` | `mesh_tensor.address()` |
+| `TensorAccessorArgs(*buffer)` | `TensorAccessorArgs(mesh_tensor)` |
+| `tensor.shard_spec()` | `mesh_tensor.legacy_shard_spec()` |
+| `tensor.is_sharded()` | `mesh_tensor.is_sharded()` |
+| `buffer != nullptr` | `mesh_tensor.is_allocated()` |
+
+## Migration Steps
+
+### Step 1: Update Tensor Access in `create()` Function
+
+**Before:**
+```cpp
+const auto& input = tensor_args.input;
+const auto& output = tensor_return_value;
+tt::tt_metal::IDevice* device = input.device();
+```
+
+**After:**
+```cpp
+const auto& input = tensor_args.input.mesh_tensor();
+const auto& output = tensor_return_value.mesh_tensor();
+const auto& device = input.device();  // Now returns reference, not pointer
+```
+
+### Step 2: Update Device Access
+
+Since `device` is now a reference instead of a pointer, change all `device->` to `device.`:
+
+**Before:**
+```cpp
+device->arch()
+device->compute_with_storage_grid_size()
+device->worker_core_from_logical_core(core)
+```
+
+**After:**
+```cpp
+device.arch()
+device.compute_with_storage_grid_size()
+device.worker_core_from_logical_core(core)
+```
+
+### Step 3: Remove Buffer Variables, Use MeshTensor Directly
+
+Delete all `Buffer*` variables. Replace buffer methods with MeshTensor methods:
+
+| Old (using Buffer*) | New (using MeshTensor) |
+|---------------------|------------------------|
+| `buffer->address()` | `mesh_tensor.address()` |
+| `buffer != nullptr` | `mesh_tensor.is_allocated()` |
+| `TensorAccessorArgs(*buffer)` | `TensorAccessorArgs(mesh_tensor)` |
+
+### Step 4: Update Runtime Args (SetRuntimeArgs)
+
+**Before:**
+```cpp
+SetRuntimeArgs(program, kernel, core, {src_buffer->address(), ...});
+```
+
+**After:**
+```cpp
+SetRuntimeArgs(program, kernel, core, {input.address(), ...});
+```
+
+### Step 7: Update `override_runtime_arguments()` Function
+
+Apply the same changes to `override_runtime_arguments()`:
+
+**Before:**
+```cpp
+void MyProgramFactory::override_runtime_arguments(...) {
+    const auto& input = tensor_args.input;
+    auto* src_buffer = input.buffer();
+    // Use src_buffer->address() in SetRuntimeArgs
+}
+```
+
+**After:**
+```cpp
+void MyProgramFactory::override_runtime_arguments(...) {
+    const auto& input = tensor_args.input.mesh_tensor();
+    // Use input.address() in SetRuntimeArgs
+}
+```
+
+## Handling Sharded Tensors
+
+For operations that use sharded tensors with dynamic circular buffers, additional changes are required.
+
+### Shard Spec Access
+
+**Before:**
+```cpp
+auto num_tiles = tensor.shard_spec()
+```
+
+**After:**
+```cpp
+auto num_tiles = mesh_tensor.legacy_shard_spec()
+```
+
+## Helper Function Migration
+
+If your program factory has helper functions that take `const Tensor&` parameters, update them to take `const tt::tt_metal::MeshTensor&`:
+
+**Before:**
+```cpp
+void set_runtime_args(
+    Program& program,
+    const Tensor& input,
+    const Tensor& output,
+    ...) {
+    auto* src_buffer = input.buffer();
+    ...
+}
+```
+
+**After:**
+```cpp
+void set_runtime_args(
+    Program& program,
+    const tt::tt_metal::MeshTensor& input,
+    const tt::tt_metal::MeshTensor& output,
+    ...) {
+    // Use input.address() directly
+    ...
+}
+```
+
+Then update the callers to pass `.mesh_tensor()`:
+
+```cpp
+set_runtime_args(program,
+    tensor_args.input.mesh_tensor(),
+    tensor_return_value.mesh_tensor(),
+    ...);
+```
+
+## Complete Example
+
+See the following migrated files for reference:
+- `ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_program_factory.cpp`
+- `ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_program_factory.cpp`
+- `ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.cpp`
+
+## Build and Test Workflow
+
+### Step 0: Find the Appropriate Tests
+
+**Start every migration by finding the relevant tests.** Tests may exist as:
+
+- **Python tests:** `tests/ttnn/**/test_*.py`
+- **C++ tests:** `tests/ttnn/unit_tests/gtests/**/*.cpp`
+
+Search for tests related to your operation:
+
+```bash
+# Find Python tests
+find tests -name "*.py" | xargs grep -l "operation_name"
+
+# Find C++ tests
+find tests -name "*.cpp" | xargs grep -l "operation_name"
+```
+
+For example, for `attn_matmul`:
+- Python: `tests/ttnn/nightly/unit_tests/operations/matmul/test_attn_matmul.py`
+
+### Environment Setup
+
+Activate the Python virtual environment before running tests:
+
+```bash
+source ./python_env/bin/activate
+```
+
+### Build Command
+
+```bash
+./build_metal.sh -b RelWithDebInfo --build-tests -e
+```
+
+### Testing Workflow
+
+**IMPORTANT: Always run the relevant tests BEFORE and AFTER refactoring.**
+
+1. **Find tests** for the operation you're migrating (see Step 0)
+2. **Before refactoring:** Run tests to establish a baseline and ensure they pass
+3. **After refactoring:** Run the same tests to verify the migration didn't break anything
+
+```bash
+# Python tests
+source ./python_env/bin/activate
+pytest "path/to/test_file.py::test_function_name" --no-header -q
+
+# C++ tests (after building with --build-tests)
+./build_RelWithDebInfo/tests/ttnn/unit_tests/gtests/test_binary_name
+```
+
+If tests fail after refactoring, the issue is likely:
+- Missing `.mesh_tensor()` call
+- Using `->` instead of `.` for device access
+- Forgetting to update `override_runtime_arguments()`
+
+## Checklist
+
+- [ ] **Find tests** for the operation (Python and/or C++)
+- [ ] **Run tests BEFORE refactoring** (establish baseline)
+- [ ] Replace `tensor_args.xxx` with `tensor_args.xxx.mesh_tensor()`
+- [ ] Replace `tensor_return_value` with `tensor_return_value.mesh_tensor()`
+- [ ] Change device access from `->` to `.`
+- [ ] Remove buffer pointer variables
+- [ ] Update `TensorAccessorArgs` to use MeshTensor
+- [ ] Update address access to use `mesh_tensor.address()`
+- [ ] Update shard_spec access to use `legacy_shard_spec()`
+- [ ] Update circular buffer APIs to use MeshTensor overloads
+- [ ] Update `override_runtime_arguments()` similarly
+- [ ] **While refactoring:** Note any patterns requiring `mesh_buffer()` or `get_reference_buffer()` (see below)
+- [ ] Rebuild: `./build_metal.sh -b RelWithDebInfo --build-tests -e`
+- [ ] **Run tests AFTER refactoring** (verify migration)
+- [ ] **Report API improvements** (see "Identifying API Improvement Opportunities" below)
+
+---
+
+## Identifying API Improvement Opportunities
+
+**This is a required part of every migration.** While refactoring, look for patterns that indicate the need for API improvements. Document and report any issues you find.
+
+### What to Look For
+
+**1. Any pattern requiring `mesh_buffer()` access**
+
+If you encounter code that needs to call `mesh_tensor.mesh_buffer()`, this is a red flag. Report it.
+
+```cpp
+// RED FLAG - report this pattern
+mesh_tensor.mesh_buffer()->some_method()
+```
+
+**2. Any pattern requiring `get_reference_buffer()` access**
+
+This is an even stronger signal that an API overload is missing. Report it immediately.
+
+```cpp
+// RED FLAG - report this pattern
+*mesh_tensor.mesh_buffer()->get_reference_buffer()
+```
+
+**3. Functions that accept `Buffer&` but should accept `MeshTensor`**
+
+Look for tt_metal APIs that accept `const Buffer&` where you need to pass tensor data. These are candidates for MeshTensor overloads.
+
+### What NOT to Propose
+
+1. **Do not propose renaming `legacy_shard_spec()`** - The naming is intentional.
+2. **Do not propose changes unrelated to MeshTensor** - Keep proposals scoped.
+
+### Scope of Valid Proposals
+
+Proposals must be strictly limited to:
+
+- New methods on the `MeshTensor` class itself
+- New overloads of existing functions to accept `MeshTensor` as a parameter
+- Functions that currently require extracting `mesh_buffer()` or `get_reference_buffer()`
+
+### How to Report
+
+When you identify an improvement opportunity, document:
+
+1. **The verbose pattern** you encountered
+2. **The API that needs a MeshTensor overload**
+3. **The simplified usage** after the overload would be added
+
+**Example report format:**
+
+```
+Pattern found: *mesh_tensor.mesh_buffer()->get_reference_buffer()
+Location: SomeFunction() in some_file.cpp
+API needing overload: void SomeFunction(const Buffer&, ...)
+Suggested overload: void SomeFunction(const MeshTensor&, ...)
+```
+
+---
+
+## Migration Summary
+
+A complete migration includes:
+
+1. **Find tests** - Locate Python and/or C++ tests for the operation
+2. **Run baseline tests** - Ensure tests pass before changes
+3. **Refactor code** - Apply the MeshTensor migration steps
+4. **Note improvement opportunities** - Document any `mesh_buffer()` or `get_reference_buffer()` patterns
+5. **Rebuild and test** - Verify migration didn't break functionality
+6. **Report improvements** - Submit any API improvement opportunities found
+
+**The migration is not complete until improvement opportunities are documented and reported.**

--- a/tt_metal/api/tt-metalium/circular_buffer_config.hpp
+++ b/tt_metal/api/tt-metalium/circular_buffer_config.hpp
@@ -16,6 +16,7 @@
 #include <tt-metalium/tile.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
 
 namespace tt {
 enum class DataFormat : uint8_t;
@@ -61,6 +62,9 @@ public:
     CircularBufferConfig& set_total_size(uint32_t total_size);
 
     CircularBufferConfig& set_globally_allocated_address(const Buffer& buffer);
+    CircularBufferConfig& set_globally_allocated_address(const MeshTensor& tensor) {
+        return set_globally_allocated_address(*tensor.mesh_buffer()->get_reference_buffer());
+    }
 
     CircularBufferConfig& set_globally_allocated_address_and_total_size(const Buffer& buffer, uint32_t total_size);
 

--- a/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
@@ -179,6 +179,10 @@ public:
         return std::nullopt;
     }
 
+    const distributed::MeshDevice& device() const { return get_device().value(); }
+
+    DeviceAddr address() const { return mesh_buffer()->address(); }
+
     // Getters:
 
     const TensorSpec& tensor_spec() const {

--- a/tt_metal/api/tt-metalium/host_api.hpp
+++ b/tt_metal/api/tt-metalium/host_api.hpp
@@ -275,6 +275,10 @@ void UpdateCircularBufferPageSize(Program& program, CBHandle cb_handle, uint8_t 
 // clang-format on
 void UpdateDynamicCircularBufferAddress(Program& program, CBHandle cb_handle, const Buffer& buffer);
 
+inline void UpdateDynamicCircularBufferAddress(Program& program, CBHandle cb_handle, const MeshTensor& tensor) {
+    UpdateDynamicCircularBufferAddress(program, cb_handle, *tensor.mesh_buffer()->get_reference_buffer());
+}
+
 // clang-format off
 /**
  * Update the address and total size of a dynamic circular buffer. Dynamic circular buffers share the same address space as L1 buffers.

--- a/tt_metal/api/tt-metalium/host_api.hpp
+++ b/tt_metal/api/tt-metalium/host_api.hpp
@@ -292,6 +292,12 @@ void UpdateDynamicCircularBufferAddress(Program& program, CBHandle cb_handle, co
 void UpdateDynamicCircularBufferAddressAndTotalSize(
     Program& program, CBHandle cb_handle, const Buffer& buffer, uint32_t total_size);
 
+inline void UpdateDynamicCircularBufferAddressAndTotalSize(
+    Program& program, CBHandle cb_handle, const MeshTensor& tensor, uint32_t total_size) {
+    UpdateDynamicCircularBufferAddressAndTotalSize(
+        program, cb_handle, *tensor.mesh_buffer()->get_reference_buffer(), total_size);
+}
+
 [[deprecated(
     "tt::tt_metal::CreateSemaphore(Program& program, const std::variant<CoreRange, CoreRangeSet>& core_spec, uint32_t "
     "initial_value, CoreType core_type) is deprecated. Use tt::tt_metal::CreateSemaphore(Program& program, const "

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul_async/device/all_gather_matmul_async_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul_async/device/all_gather_matmul_async_program_factory.cpp
@@ -94,12 +94,13 @@ AllGatherMatmulAsyncMeshWorkloadFactory::cached_program_t AllGatherMatmulAsyncMe
                 matmul_shared_variables = std::move(cached_program.shared_variables);
             },
             [&](const operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig& config) {
+                const tt::tt_metal::MeshTensor* bias_ptr = bias.has_value() ? &bias.value().mesh_tensor() : nullptr;
                 auto cached_program = ttnn::prim::matmul_multi_core_reuse_mcast_1d_optimized_helper(
                     program,
-                    all_gather_output_tensor,
-                    {weight_tensor},
-                    bias,
-                    {matmul_output_tensor},
+                    all_gather_output_tensor.mesh_tensor(),
+                    {std::cref(weight_tensor.mesh_tensor())},
+                    bias_ptr,
+                    {std::cref(matmul_output_tensor.mesh_tensor())},
                     bcast_batch,
                     compute_kernel_config,
                     config,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/device/rs_matmul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/device/rs_matmul_program_factory.cpp
@@ -54,10 +54,11 @@ ttnn::device_operation::CachedProgram<Matmul_RS::Matmul_RS_PF::shared_variables_
             fused_op_signaler);
         auto matmul_sv = ttnn::prim::matmul_multi_core_reuse_mcast_1d_optimized_helper(
             program,
-            tensor_args.matmul.input_tensor,
-            {tensor_args.matmul.weight_tensor, tensor_args.second_weight_tensor.value()},
-            std::nullopt /*bias*/,
-            {tensor_return_value.at(0), tensor_return_value.at(1)},
+            tensor_args.matmul.input_tensor.mesh_tensor(),
+            {std::cref(tensor_args.matmul.weight_tensor.mesh_tensor()),
+             std::cref(tensor_args.second_weight_tensor.value().mesh_tensor())},
+            nullptr /*bias*/,
+            {std::cref(tensor_return_value.at(0).mesh_tensor()), std::cref(tensor_return_value.at(1).mesh_tensor())},
             operation_attributes.matmul.bcast_batch.value(),
             operation_attributes.matmul.compute_kernel_config.value(),
             operation_attributes.matmul.program_config.value(),
@@ -79,10 +80,10 @@ ttnn::device_operation::CachedProgram<Matmul_RS::Matmul_RS_PF::shared_variables_
         fused_op_signaler);
     auto matmul_sv = ttnn::prim::matmul_multi_core_reuse_mcast_1d_optimized_helper(
         program,
-        tensor_args.matmul.input_tensor,
-        {tensor_args.matmul.weight_tensor},
-        std::nullopt /*bias*/,
-        {tensor_return_value.at(0)},
+        tensor_args.matmul.input_tensor.mesh_tensor(),
+        {std::cref(tensor_args.matmul.weight_tensor.mesh_tensor())},
+        nullptr /*bias*/,
+        {std::cref(tensor_return_value.at(0).mesh_tensor())},
         operation_attributes.matmul.bcast_batch.value(),
         operation_attributes.matmul.compute_kernel_config.value(),
         operation_attributes.matmul.program_config.value(),

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.cpp
@@ -129,8 +129,8 @@ inline tt::tt_metal::KernelHandle create_compute_kernel(
 inline void assign_per_core_runtime_args(
     tt::tt_metal::Program& program,
     const DropoutKernels& kernels,
-    const tt::tt_metal::Buffer* src_buffer,
-    const tt::tt_metal::Buffer* dst_buffer,
+    const tt::tt_metal::MeshTensor& input_tensor,
+    const tt::tt_metal::MeshTensor& output_tensor,
     uint32_t num_cores,
     uint32_t num_cores_y,
     uint32_t num_tiles_per_core_group_1,
@@ -161,15 +161,16 @@ inline void assign_per_core_runtime_args(
             TT_THROW("Core not in specified core ranges.");
         }
         // Reader kernel: (src_addr, number_of_tiles, offset_in_tiles)
-        SetRuntimeArgs(program, kernels.reader, core, {src_buffer->address(), num_tiles_per_core, num_tiles_written});
+        SetRuntimeArgs(program, kernels.reader, core, {input_tensor.address(), num_tiles_per_core, num_tiles_written});
 
         // Writer kernel: (dst_addr, number_of_tiles, offset_in_tiles)
-        SetRuntimeArgs(program, kernels.writer, core, {dst_buffer->address(), num_tiles_per_core, num_tiles_written});
+        SetRuntimeArgs(program, kernels.writer, core, {output_tensor.address(), num_tiles_per_core, num_tiles_written});
 
         num_tiles_written += num_tiles_per_core;
     }
 }
 
+// Oppounity: output could be a MeshTensor?
 DropoutProgramFactory::cached_program_t DropoutProgramFactory::create(
     const DropoutParams& args, const DropoutInputs& tensor_args, Tensor& output) {
     using namespace tt;
@@ -178,8 +179,8 @@ DropoutProgramFactory::cached_program_t DropoutProgramFactory::create(
     // -------------------------------------------------------------------------
     // 1) Setup device, data formats, tile sizes, and compute split
     // -------------------------------------------------------------------------
-    const auto& input = tensor_args.input;
-    auto* device = input.device();
+    const auto& input = tensor_args.input.mesh_tensor();
+    const auto& device = input.device();
 
     tt::tt_metal::Program program{};
 
@@ -191,7 +192,7 @@ DropoutProgramFactory::cached_program_t DropoutProgramFactory::create(
 
     uint32_t num_tiles = input.physical_volume() / tt::constants::TILE_HW;
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = device.compute_with_storage_grid_size();
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
 
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
@@ -208,13 +209,12 @@ DropoutProgramFactory::cached_program_t DropoutProgramFactory::create(
     // -------------------------------------------------------------------------
     // 3) Create reader/writer kernels
     // -------------------------------------------------------------------------
-    auto* src_buffer = input.buffer();
     std::vector<uint32_t> reader_compile_args = {static_cast<uint32_t>(kSrc0CbIndex)};
-    tt::tt_metal::TensorAccessorArgs(src_buffer).append_to(reader_compile_args);
+    tt::tt_metal::TensorAccessorArgs(input).append_to(reader_compile_args);
 
-    auto* dst_buffer = output.buffer();
+    const auto& dst_tensor = output.mesh_tensor();
     std::vector<uint32_t> writer_compile_args = {static_cast<uint32_t>(kOutputCbIndex)};
-    tt::tt_metal::TensorAccessorArgs(dst_buffer).append_to(writer_compile_args);
+    tt::tt_metal::TensorAccessorArgs(dst_tensor).append_to(writer_compile_args);
 
     DropoutKernels kernels{};
     kernels.reader = create_reader_kernel(program, all_cores, reader_compile_args, kReaderKernelPath);
@@ -261,8 +261,8 @@ DropoutProgramFactory::cached_program_t DropoutProgramFactory::create(
     assign_per_core_runtime_args(
         program,
         kernels,
-        src_buffer,
-        dst_buffer,
+        input,
+        dst_tensor,
         num_cores,
         num_cores_y,
         num_tiles_per_core_group_1,
@@ -305,9 +305,8 @@ void DropoutProgramFactory::override_runtime_arguments(
     uint32_t num_cores = shared_vars.num_cores;
     uint32_t num_cores_y = shared_vars.num_cores_y;
 
-    const auto& input = tensor_args.input;
-    auto* src_buffer = input.buffer();
-    auto* dst_buffer = output.buffer();
+    const auto& input = tensor_args.input.mesh_tensor();
+    const auto& dst_tensor = output.mesh_tensor();
 
     // Only seed/address arguments need updating here; tile counts remain the same as in create().
     auto& reader_runtime_args = GetRuntimeArgs(program, dropout_reader_kernel);
@@ -323,12 +322,12 @@ void DropoutProgramFactory::override_runtime_arguments(
         // Update the source address for the reader kernel
         {
             auto& runtime_args = reader_runtime_args[core.x][core.y];
-            runtime_args[kSrcBufferIdx] = src_buffer->address();
+            runtime_args[kSrcBufferIdx] = input.address();
         }
         // Update the destination address for the writer kernel
         {
             auto& runtime_args = writer_runtime_args[core.x][core.y];
-            runtime_args[kDstBufferIdx] = dst_buffer->address();
+            runtime_args[kDstBufferIdx] = dst_tensor.address();
         }
         // Update the seed for the compute kernels
         if (core_group_1.contains(core)) {

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_program_factory.cpp
@@ -19,18 +19,18 @@ AttnMatmulProgramFactory::cached_program_t AttnMatmulProgramFactory::create(
     const AttnMatmulParams& operation_attributes, const AttnMatmulInputs& tensor_args, Tensor& tensor_return_value) {
     tt::tt_metal::Program program{};
 
-    const auto& a = tensor_args.input_tensor_a;
-    const auto& b = tensor_args.input_tensor_b;
-    auto& output = tensor_return_value;
+    const auto& a = tensor_args.input_tensor_a.mesh_tensor();
+    const auto& b = tensor_args.input_tensor_b.mesh_tensor();
+    const auto& output = tensor_return_value.mesh_tensor();
 
     const auto& ashape = a.padded_shape();
     const auto& bshape = b.padded_shape();
 
     // This should allocate a DRAM buffer on the device
-    tt::tt_metal::IDevice* device = a.device();
+    const auto& device = a.device();
 
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
-        get_compute_kernel_config_args(device->arch(), operation_attributes.compute_kernel_config);
+        get_compute_kernel_config_args(device.arch(), operation_attributes.compute_kernel_config);
 
     tt::DataFormat in0_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
     tt::DataFormat in1_data_format = tt::tt_metal::datatype_to_dataformat_converter(b.dtype());
@@ -57,9 +57,6 @@ AttnMatmulProgramFactory::cached_program_t AttnMatmulProgramFactory::create(
     log_debug(tt::LogOp, "interm_data_format: {}", interm_data_format);
     log_debug(tt::LogOp, "output_data_format: {}", output_data_format);
 
-    tt::tt_metal::Buffer* src0_buffer = a.buffer();
-    tt::tt_metal::Buffer* src1_buffer = b.buffer();
-
     // A block of work is one MtNt
     uint32_t num_cores_y = operation_attributes.compute_with_storage_grid_size.y;
     auto num_output_blocks_total = ashape[1];  // ashape[1] is Q num_heads; only parallelize on this
@@ -74,13 +71,10 @@ AttnMatmulProgramFactory::cached_program_t AttnMatmulProgramFactory::create(
                 operation_attributes.compute_with_storage_grid_size, num_output_blocks_total);
 
     auto all_device_cores = CoreRange(
-        {0, 0},
-        {a.device()->compute_with_storage_grid_size().x - 1, a.device()->compute_with_storage_grid_size().y - 1});
-    auto total_num_cores =
-        a.device()->compute_with_storage_grid_size().x * a.device()->compute_with_storage_grid_size().y;
+        {0, 0}, {device.compute_with_storage_grid_size().x - 1, device.compute_with_storage_grid_size().y - 1});
+    auto total_num_cores = device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y;
 
-    tt::tt_metal::Buffer* dst_buffer = output.buffer();
-    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+    TT_ASSERT(output.is_allocated(), "Output buffer should be allocated on device!");
 
     // C = torch.matmul(A.transpose(0, 2) * B).transpose(0, 2)
     // MN = MK*KN
@@ -104,9 +98,9 @@ AttnMatmulProgramFactory::cached_program_t AttnMatmulProgramFactory::create(
     uint32_t in1_KtNt_stride = transpose_hw_bool ? bshape[2] / TILE_HEIGHT * in1_Kt : in1_Kt * Nt;
     uint32_t in1_KtNt_skip = transpose_hw_bool ? (bshape[2] / TILE_HEIGHT - 1) * in1_Kt : (in1_Kt - Kt) * Nt;
 
-    uint32_t src0_addr = src0_buffer->address();
-    uint32_t src1_addr = src1_buffer->address();
-    uint32_t dst_addr = dst_buffer->address();
+    uint32_t src0_addr = a.address();
+    uint32_t src1_addr = b.address();
+    uint32_t dst_addr = output.address();
 
     uint32_t src0_cb_index = tt::CBIndex::c_0;
     uint32_t cb0_num_input_tiles = Kt * 2;
@@ -152,11 +146,11 @@ AttnMatmulProgramFactory::cached_program_t AttnMatmulProgramFactory::create(
 
     std::vector<uint32_t> reader_compile_time_args = {
         (uint32_t)transpose_hw_bool, (uint32_t)(fp32_dest_acc_en and in0_data_format == tt::DataFormat::Float32)};
-    tt::tt_metal::TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(*src1_buffer).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(a).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(b).append_to(reader_compile_time_args);
 
     std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index};
-    tt::tt_metal::TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(output).append_to(writer_compile_time_args);
 
     auto reader_id = tt::tt_metal::CreateKernel(
         program,
@@ -261,13 +255,9 @@ void AttnMatmulProgramFactory::override_runtime_arguments(
     auto& program = cached_program.program;
     const auto& shared_vars = cached_program.shared_variables;
 
-    const auto& a = tensor_args.input_tensor_a;
-    const auto& b = tensor_args.input_tensor_b;
-    auto& output = tensor_return_value;
-
-    auto* src_dram_buffer_a = a.buffer();
-    auto* src_dram_buffer_b = b.buffer();
-    auto* dst_dram_buffer = output.buffer();
+    const auto& a = tensor_args.input_tensor_a.mesh_tensor();
+    const auto& b = tensor_args.input_tensor_b.mesh_tensor();
+    const auto& output = tensor_return_value.mesh_tensor();
 
     auto ashape = a.padded_shape();
     auto bshape = b.padded_shape();
@@ -329,8 +319,8 @@ void AttnMatmulProgramFactory::override_runtime_arguments(
             shared_vars.reader_id,
             core,
             {
-                src_dram_buffer_a->address(),
-                src_dram_buffer_b->address(),
+                a.address(),
+                b.address(),
                 Mt,
                 Kt,
                 Nt,
@@ -359,7 +349,7 @@ void AttnMatmulProgramFactory::override_runtime_arguments(
             shared_vars.writer_id,
             core,
             {
-                dst_dram_buffer->address(),
+                output.address(),
                 num_output_blocks_per_core * MtNt,
                 num_blocks_written * MtNt,
             });

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_program_factory.cpp
@@ -19,19 +19,15 @@ namespace {
 
 void set_runtime_args(
     Program& program,
-    const Tensor& a,
-    const Tensor& b,
-    const Tensor& output,
+    const tt::tt_metal::MeshTensor& a,
+    const tt::tt_metal::MeshTensor& b,
+    const tt::tt_metal::MeshTensor& output,
     const GroupAttnMatmulParams& operation_attributes,
     const GroupAttnMatmulSharedVariables& shared_vars) {
-    tt::tt_metal::Buffer* src0_buffer = a.buffer();
-    tt::tt_metal::Buffer* src1_buffer = b.buffer();
-    tt::tt_metal::Buffer* dst_buffer = output.buffer();
-
     const auto& ashape = a.padded_shape();
     const auto& bshape = b.padded_shape();
 
-    tt::tt_metal::IDevice* device = a.device();
+    const auto& device = a.device();
 
     // A block of work is one MtNt
     uint32_t Q_HEADS =
@@ -114,14 +110,14 @@ void set_runtime_args(
     uint32_t mcast_num_cores = mcast_receiver_cores_bounding_box.size();
     CoreCoord top_left_core = mcast_receiver_cores_bounding_box.start_coord;
     CoreCoord bottom_right_core = mcast_receiver_cores_bounding_box.end_coord;
-    CoreCoord top_left_core_physical = device->worker_core_from_logical_core(top_left_core);
-    CoreCoord bottom_right_core_physical = device->worker_core_from_logical_core(bottom_right_core);
+    CoreCoord top_left_core_physical = device.worker_core_from_logical_core(top_left_core);
+    CoreCoord bottom_right_core_physical = device.worker_core_from_logical_core(bottom_right_core);
 
     // Default reader runtime args
     std::vector<uint32_t> reader_runtime_args = {
         0,  // 0: has_work_for_mcast_kv_heads
         0,  // 1: has_work_for_q_heads
-        src1_buffer->address(),
+        b.address(),
         Mt,
         Nt,
         KV_HEADS,
@@ -177,8 +173,8 @@ void set_runtime_args(
     // Default writer runtime args
     std::vector<uint32_t> writer_runtime_args = {
         0,  // 0: has_work_for_q_heads
-        src0_buffer->address(),
-        dst_buffer->address(),
+        a.address(),
+        output.address(),
         Mt,
         Kt,
         Nt,
@@ -280,9 +276,12 @@ void set_runtime_args(
     // Update dynamic CBs (which is most of them)
     if (shared_vars.in0_is_sharded) {
         uint32_t cb0_num_input_tiles =
-            a.shard_spec().value().numel() / TILE_HW;  // Should be full MtKt and C should be 1
+            a.legacy_shard_spec().value().numel() / TILE_HW;  // Should be full MtKt and C should be 1
         UpdateDynamicCircularBufferAddressAndTotalSize(
-            program, shared_vars.cb_src0, *src0_buffer, cb0_num_input_tiles * shared_vars.in0_single_tile_size);
+            program,
+            shared_vars.cb_src0,
+            *a.mesh_buffer()->get_reference_buffer(),
+            cb0_num_input_tiles * shared_vars.in0_single_tile_size);
     } else {
         uint32_t cb0_num_input_tiles =
             in0_block_w;  // TODO: Generalize; double buffer and add blocking along ineer dim if we have Mt > 1
@@ -295,18 +294,24 @@ void set_runtime_args(
 
     if (shared_vars.in1_is_sharded) {
         uint32_t cb2_num_input_tiles =
-            b.shard_spec().value().numel() / TILE_HW;  // Should be full CKtNt and batch must be 32
+            b.legacy_shard_spec().value().numel() / TILE_HW;  // Should be full CKtNt and batch must be 32
         UpdateDynamicCircularBufferAddressAndTotalSize(
-            program, shared_vars.cb_src2, *src1_buffer, cb2_num_input_tiles * shared_vars.in1_single_tile_size);
+            program,
+            shared_vars.cb_src2,
+            *b.mesh_buffer()->get_reference_buffer(),
+            cb2_num_input_tiles * shared_vars.in1_single_tile_size);
     }
 
     UpdateCircularBufferTotalSize(program, shared_vars.cb_interm1, MtNt * shared_vars.interm_single_tile_size);
 
     if (shared_vars.output_is_sharded) {
         uint32_t num_output_tiles =
-            output.shard_spec().value().numel() / TILE_HW;  // Should be full MtNt and C should be 1
+            output.legacy_shard_spec().value().numel() / TILE_HW;  // Should be full MtNt and C should be 1
         UpdateDynamicCircularBufferAddressAndTotalSize(
-            program, shared_vars.cb_output, *dst_buffer, num_output_tiles * shared_vars.output_single_tile_size);
+            program,
+            shared_vars.cb_output,
+            *output.mesh_buffer()->get_reference_buffer(),
+            num_output_tiles * shared_vars.output_single_tile_size);
     } else {
         uint32_t num_output_tiles =
             MtNt;  // TODO: Should be MtNt if Mt > 1? Or, produce one Nt at a time and double buffer?
@@ -323,18 +328,18 @@ GroupAttnMatmulProgramFactory::cached_program_t GroupAttnMatmulProgramFactory::c
     Tensor& tensor_return_value) {
     tt::tt_metal::Program program{};
 
-    const auto& a = tensor_args.input_tensor_a;
-    const auto& b = tensor_args.input_tensor_b;
-    const auto& output = tensor_return_value;
+    const auto& a = tensor_args.input_tensor_a.mesh_tensor();
+    const auto& b = tensor_args.input_tensor_b.mesh_tensor();
+    const auto& output = tensor_return_value.mesh_tensor();
 
     const auto& ashape = a.padded_shape();
     const auto& bshape = b.padded_shape();
 
     // This should allocate a DRAM buffer on the device
-    tt::tt_metal::IDevice* device = a.device();
+    const auto& device = a.device();
 
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
-        get_compute_kernel_config_args(device->arch(), operation_attributes.compute_kernel_config);
+        get_compute_kernel_config_args(device.arch(), operation_attributes.compute_kernel_config);
 
     tt::DataFormat in0_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
     tt::DataFormat in1_data_format = tt::tt_metal::datatype_to_dataformat_converter(b.dtype());
@@ -352,13 +357,10 @@ GroupAttnMatmulProgramFactory::cached_program_t GroupAttnMatmulProgramFactory::c
         TT_ASSERT(fp32_dest_acc_en == true, "when inputs/output are in fp32 format, fp32_dest_acc_en must be set");
     }
 
-    tt::tt_metal::Buffer* src0_buffer = a.buffer();
-    tt::tt_metal::Buffer* src1_buffer = b.buffer();
-    tt::tt_metal::Buffer* dst_buffer = output.buffer();
-    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+    TT_ASSERT(output.is_allocated(), "Output buffer should be allocated on device!");
 
     // Load kernels on all device cores, because we use cached program for input shapes with changing shapes
-    CoreCoord device_compute_with_storage_grid = device->compute_with_storage_grid_size();
+    CoreCoord device_compute_with_storage_grid = device.compute_with_storage_grid_size();
     auto all_device_cores =
         CoreRange({0, 0}, {device_compute_with_storage_grid.x - 1, device_compute_with_storage_grid.y - 1});
 
@@ -417,10 +419,10 @@ GroupAttnMatmulProgramFactory::cached_program_t GroupAttnMatmulProgramFactory::c
     std::vector<uint32_t> in1_mcast_sender_noc_x(mcast_sender_grid.x);
     std::vector<uint32_t> in1_mcast_sender_noc_y(mcast_sender_grid.y);
     for (uint32_t core_idx_x = 0; core_idx_x < mcast_sender_grid.x; ++core_idx_x) {
-        in1_mcast_sender_noc_x[core_idx_x] = device->worker_core_from_logical_core({core_idx_x, 0}).x;
+        in1_mcast_sender_noc_x[core_idx_x] = device.worker_core_from_logical_core({core_idx_x, 0}).x;
     }
     for (uint32_t core_idx_y = 0; core_idx_y < mcast_sender_grid.y; ++core_idx_y) {
-        in1_mcast_sender_noc_y[core_idx_y] = device->worker_core_from_logical_core({0, core_idx_y}).y;
+        in1_mcast_sender_noc_y[core_idx_y] = device.worker_core_from_logical_core({0, core_idx_y}).y;
     }
 
     // Set up CBs
@@ -433,12 +435,12 @@ GroupAttnMatmulProgramFactory::cached_program_t GroupAttnMatmulProgramFactory::c
     CBHandle cb_src0;
     if (in0_is_sharded) {
         uint32_t cb0_num_input_tiles =
-            a.shard_spec().value().numel() / TILE_HW;  // Should be full MtKt and C should be 1
+            a.legacy_shard_spec().value().numel() / TILE_HW;  // Should be full MtKt and C should be 1
         tt::tt_metal::CircularBufferConfig src0_cb_config =
             tt::tt_metal::CircularBufferConfig(
                 cb0_num_input_tiles * in0_single_tile_size, {{src0_cb_index, in0_data_format}})
                 .set_page_size(src0_cb_index, in0_single_tile_size)
-                .set_globally_allocated_address(*src0_buffer);
+                .set_globally_allocated_address(*a.mesh_buffer()->get_reference_buffer());
         cb_src0 = tt::tt_metal::CreateCircularBuffer(program, all_device_cores, src0_cb_config);
     } else {
         uint32_t cb0_num_input_tiles =
@@ -465,12 +467,12 @@ GroupAttnMatmulProgramFactory::cached_program_t GroupAttnMatmulProgramFactory::c
     if (in1_is_sharded) {
         uint32_t src2_cb_index = tt::CBIndex::c_2;
         uint32_t cb2_num_input_tiles =
-            b.shard_spec().value().numel() / TILE_HW;  // Should be full CKtNt and batch must be 32
+            b.legacy_shard_spec().value().numel() / TILE_HW;  // Should be full CKtNt and batch must be 32
         tt::tt_metal::CircularBufferConfig cb_src2_config =
             tt::tt_metal::CircularBufferConfig(
                 cb2_num_input_tiles * in1_single_tile_size, {{src2_cb_index, in1_data_format}})
                 .set_page_size(src2_cb_index, in1_single_tile_size)
-                .set_globally_allocated_address(*src1_buffer);
+                .set_globally_allocated_address(*b.mesh_buffer()->get_reference_buffer());
         cb_src2 = tt::tt_metal::CreateCircularBuffer(program, all_device_cores, cb_src2_config);
     }
 
@@ -495,12 +497,12 @@ GroupAttnMatmulProgramFactory::cached_program_t GroupAttnMatmulProgramFactory::c
     CBHandle cb_output;
     if (output_is_sharded) {
         uint32_t num_output_tiles =
-            output.shard_spec().value().numel() / TILE_HW;  // Should be full MtNt and C should be 1
+            output.legacy_shard_spec().value().numel() / TILE_HW;  // Should be full MtNt and C should be 1
         tt::tt_metal::CircularBufferConfig cb_output_config =
             tt::tt_metal::CircularBufferConfig(
                 num_output_tiles * output_single_tile_size, {{output_cb_index, output_data_format}})
                 .set_page_size(output_cb_index, output_single_tile_size)
-                .set_globally_allocated_address(*dst_buffer);
+                .set_globally_allocated_address(*output.mesh_buffer()->get_reference_buffer());
         cb_output = tt::tt_metal::CreateCircularBuffer(program, all_device_cores, cb_output_config);
     } else {
         uint32_t num_output_tiles =
@@ -517,15 +519,15 @@ GroupAttnMatmulProgramFactory::cached_program_t GroupAttnMatmulProgramFactory::c
         (uint32_t)operation_attributes.row_major,
         operation_attributes.out_subblock_w,
     };
-    tt::tt_metal::TensorAccessorArgs(*src1_buffer).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(b).append_to(reader_compile_time_args);
 
     std::vector<uint32_t> writer_compile_time_args = {
         (uint32_t)output_cb_index,
         operation_attributes.out_subblock_w,
         intermediate_num_tiles,
     };
-    tt::tt_metal::TensorAccessorArgs(*src0_buffer).append_to(writer_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(a).append_to(writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(output).append_to(writer_compile_time_args);
 
     std::map<std::string, std::string> reader_kernel_defines;
     std::map<std::string, std::string> writer_kernel_defines;
@@ -540,7 +542,7 @@ GroupAttnMatmulProgramFactory::cached_program_t GroupAttnMatmulProgramFactory::c
     }
 
     tt::tt_metal::NOC reader_noc =
-        tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());  // Default is NOC_1
+        tt::tt_metal::detail::preferred_noc_for_dram_read(device.arch());  // Default is NOC_1
     const bool reader_noc_is_NOC_0 = reader_noc == tt::tt_metal::NOC::NOC_0;
     tt::tt_metal::NOC writer_noc = reader_noc_is_NOC_0 ? tt::tt_metal::NOC::NOC_1 : tt::tt_metal::NOC::NOC_0;
     auto reader_id = tt::tt_metal::CreateKernel(
@@ -629,9 +631,9 @@ void GroupAttnMatmulProgramFactory::override_runtime_arguments(
     Tensor& tensor_return_value) {
     set_runtime_args(
         cached_program.program,
-        tensor_args.input_tensor_a,
-        tensor_args.input_tensor_b,
-        tensor_return_value,
+        tensor_args.input_tensor_a.mesh_tensor(),
+        tensor_args.input_tensor_b.mesh_tensor(),
+        tensor_return_value.mesh_tensor(),
         operation_attributes,
         cached_program.shared_variables);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_program_factory.cpp
@@ -278,10 +278,7 @@ void set_runtime_args(
         uint32_t cb0_num_input_tiles =
             a.legacy_shard_spec().value().numel() / TILE_HW;  // Should be full MtKt and C should be 1
         UpdateDynamicCircularBufferAddressAndTotalSize(
-            program,
-            shared_vars.cb_src0,
-            *a.mesh_buffer()->get_reference_buffer(),
-            cb0_num_input_tiles * shared_vars.in0_single_tile_size);
+            program, shared_vars.cb_src0, a, cb0_num_input_tiles * shared_vars.in0_single_tile_size);
     } else {
         uint32_t cb0_num_input_tiles =
             in0_block_w;  // TODO: Generalize; double buffer and add blocking along ineer dim if we have Mt > 1
@@ -296,10 +293,7 @@ void set_runtime_args(
         uint32_t cb2_num_input_tiles =
             b.legacy_shard_spec().value().numel() / TILE_HW;  // Should be full CKtNt and batch must be 32
         UpdateDynamicCircularBufferAddressAndTotalSize(
-            program,
-            shared_vars.cb_src2,
-            *b.mesh_buffer()->get_reference_buffer(),
-            cb2_num_input_tiles * shared_vars.in1_single_tile_size);
+            program, shared_vars.cb_src2, b, cb2_num_input_tiles * shared_vars.in1_single_tile_size);
     }
 
     UpdateCircularBufferTotalSize(program, shared_vars.cb_interm1, MtNt * shared_vars.interm_single_tile_size);
@@ -308,10 +302,7 @@ void set_runtime_args(
         uint32_t num_output_tiles =
             output.legacy_shard_spec().value().numel() / TILE_HW;  // Should be full MtNt and C should be 1
         UpdateDynamicCircularBufferAddressAndTotalSize(
-            program,
-            shared_vars.cb_output,
-            *output.mesh_buffer()->get_reference_buffer(),
-            num_output_tiles * shared_vars.output_single_tile_size);
+            program, shared_vars.cb_output, output, num_output_tiles * shared_vars.output_single_tile_size);
     } else {
         uint32_t num_output_tiles =
             MtNt;  // TODO: Should be MtNt if Mt > 1? Or, produce one Nt at a time and double buffer?
@@ -440,7 +431,7 @@ GroupAttnMatmulProgramFactory::cached_program_t GroupAttnMatmulProgramFactory::c
             tt::tt_metal::CircularBufferConfig(
                 cb0_num_input_tiles * in0_single_tile_size, {{src0_cb_index, in0_data_format}})
                 .set_page_size(src0_cb_index, in0_single_tile_size)
-                .set_globally_allocated_address(*a.mesh_buffer()->get_reference_buffer());
+                .set_globally_allocated_address(a);
         cb_src0 = tt::tt_metal::CreateCircularBuffer(program, all_device_cores, src0_cb_config);
     } else {
         uint32_t cb0_num_input_tiles =
@@ -472,7 +463,7 @@ GroupAttnMatmulProgramFactory::cached_program_t GroupAttnMatmulProgramFactory::c
             tt::tt_metal::CircularBufferConfig(
                 cb2_num_input_tiles * in1_single_tile_size, {{src2_cb_index, in1_data_format}})
                 .set_page_size(src2_cb_index, in1_single_tile_size)
-                .set_globally_allocated_address(*b.mesh_buffer()->get_reference_buffer());
+                .set_globally_allocated_address(b);
         cb_src2 = tt::tt_metal::CreateCircularBuffer(program, all_device_cores, cb_src2_config);
     }
 
@@ -502,7 +493,7 @@ GroupAttnMatmulProgramFactory::cached_program_t GroupAttnMatmulProgramFactory::c
             tt::tt_metal::CircularBufferConfig(
                 num_output_tiles * output_single_tile_size, {{output_cb_index, output_data_format}})
                 .set_page_size(output_cb_index, output_single_tile_size)
-                .set_globally_allocated_address(*output.mesh_buffer()->get_reference_buffer());
+                .set_globally_allocated_address(output);
         cb_output = tt::tt_metal::CreateCircularBuffer(program, all_device_cores, cb_output_config);
     } else {
         uint32_t num_output_tiles =

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_program_factory.cpp
@@ -21,9 +21,9 @@ MatmulMultiCoreProgramFactory::cached_program_t MatmulMultiCoreProgramFactory::c
         TT_FATAL(!tensor_args.optional_input_tensors[0].has_value(), "Bias is not supported for matmul multi core");
     }
 
-    const auto& a = tensor_args.input_tensors.at(0);
-    const auto& b = tensor_args.input_tensors.at(1);
-    auto& output = tensor_return_value.at(0);
+    const auto& a = tensor_args.input_tensors.at(0).mesh_tensor();
+    const auto& b = tensor_args.input_tensors.at(1).mesh_tensor();
+    const auto& output = tensor_return_value.at(0).mesh_tensor();
 
     TT_FATAL(operation_attributes.bcast_batch.has_value(), "Error: bcast_batch field should have been populated");
     bool bcast_batch = operation_attributes.bcast_batch.value();
@@ -41,14 +41,11 @@ MatmulMultiCoreProgramFactory::cached_program_t MatmulMultiCoreProgramFactory::c
     uint32_t output_single_tile_size = tt::tile_size(output_data_format);
     MathFidelity math_fidelity = MathFidelity::HiFi4;
 
-    tt_metal::Buffer* src0_buffer = a.buffer();
-    tt_metal::Buffer* src1_buffer = b.buffer();
-
     // This should allocate a DRAM buffer on the device
-    tt::tt_metal::IDevice* device = a.device();
+    const auto& device = a.device();
     const auto& cshape = output.padded_shape();  // C=A*B, N1MK*11KN->N1MN
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = device.compute_with_storage_grid_size();
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     uint32_t c_batch_size = get_batch_size(cshape);
     auto num_output_tiles_total = c_batch_size * cshape[-2] * cshape[-1] / TILE_HW;
@@ -61,8 +58,7 @@ MatmulMultiCoreProgramFactory::cached_program_t MatmulMultiCoreProgramFactory::c
          num_output_tiles_per_core_group_2] =
             tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_output_tiles_total);
 
-    tt_metal::Buffer* dst_buffer = output.buffer();
-    TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+    TT_FATAL(output.is_allocated(), "Output buffer should be allocated on device!");
 
     // C = A*B*...
     // MN = MK*KN
@@ -74,9 +70,9 @@ MatmulMultiCoreProgramFactory::cached_program_t MatmulMultiCoreProgramFactory::c
     uint32_t MtKt = Mt * Kt;
     uint32_t MtNt = Mt * Nt;
 
-    uint32_t src0_addr = src0_buffer->address();
-    uint32_t src1_addr = src1_buffer->address();
-    uint32_t dst_addr = dst_buffer->address();
+    uint32_t src0_addr = a.address();
+    uint32_t src1_addr = b.address();
+    uint32_t dst_addr = output.address();
 
     uint32_t src0_cb_index = 0;
     uint32_t num_input_tiles = 2;
@@ -99,13 +95,13 @@ MatmulMultiCoreProgramFactory::cached_program_t MatmulMultiCoreProgramFactory::c
             .set_page_size(output_cb_index, output_single_tile_size);
     tt_metal::CreateCircularBuffer(program, all_cores, output_cb_config);
 
-    uint32_t last_ktile_w = a.logical_shape()[-1] % TILE_WIDTH;
+    uint32_t last_ktile_w = tensor_args.input_tensors.at(0).logical_shape()[-1] % TILE_WIDTH;
     std::vector<uint32_t> reader_compile_time_args = {(uint32_t)last_ktile_w};
-    tt::tt_metal::TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(*src1_buffer).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(a).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(b).append_to(reader_compile_time_args);
 
     std::vector<uint32_t> writer_compile_time_args = {};
-    tt::tt_metal::TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(output).append_to(writer_compile_time_args);
 
     auto reader_id = tt_metal::CreateKernel(
         program,
@@ -206,20 +202,20 @@ void MatmulMultiCoreProgramFactory::override_runtime_arguments(
     auto num_cores = shared_variables.num_cores;
     auto num_cores_y = shared_variables.num_cores_y;
 
-    auto* src_dram_buffer_a = tensor_args.input_tensors.at(0).buffer();
-    auto* src_dram_buffer_b = tensor_args.input_tensors.at(1).buffer();
-    auto* dst_dram_buffer = tensor_return_value.at(0).buffer();
+    const auto& a = tensor_args.input_tensors.at(0).mesh_tensor();
+    const auto& b = tensor_args.input_tensors.at(1).mesh_tensor();
+    const auto& output = tensor_return_value.at(0).mesh_tensor();
 
     for (uint32_t i = 0; i < num_cores; i++) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
         {
             auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-            runtime_args[0] = src_dram_buffer_a->address();
-            runtime_args[1] = src_dram_buffer_b->address();
+            runtime_args[0] = a.address();
+            runtime_args[1] = b.address();
         }
         {
             auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-            runtime_args[0] = dst_dram_buffer->address();
+            runtime_args[0] = output.address();
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.cpp
@@ -15,6 +15,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/work_split.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/eltwise/unary/common/unary_op_utils.hpp"
 #include "ttnn/tensor/shape/shape.hpp"
 
@@ -50,10 +51,10 @@ create_program_batch_sharded(
     uint32_t per_core_M,   // M tiles per core (should equal M for batch sharding)
     uint32_t per_core_N,   // N tiles per core (should equal N for batch sharding)
     std::optional<UnaryWithParam> fused_activation,
-    tt_metal::Buffer* in0_buffer,
-    tt_metal::Buffer* in1_buffer,
-    tt_metal::Buffer* bias_buffer,
-    tt_metal::Buffer* out_buffer,
+    const tt::tt_metal::MeshTensor& in0,
+    const tt::tt_metal::MeshTensor& in1,
+    const std::optional<std::reference_wrapper<const tt::tt_metal::MeshTensor>>& bias,
+    const tt::tt_metal::MeshTensor& out,
     const tt::tt_metal::Tile& in0_tile,
     const tt::tt_metal::Tile& in1_tile,
     const tt::tt_metal::Tile& bias_tile,
@@ -264,8 +265,8 @@ create_program_batch_sharded(
     uint32_t interm0_CB_size = out_block_tiles * interm0_single_tile_size;
 
     // Sharded input buffer (in0 in L1)
-    uint32_t in0_shard_tiles = in0_buffer->shard_spec().shape()[0] / in0_tile.get_tile_shape()[0] *
-                               in0_buffer->shard_spec().shape()[1] / in0_tile.get_tile_shape()[1];
+    uint32_t in0_shard_tiles = in0.legacy_shard_spec().value().shape[0] / in0_tile.get_tile_shape()[0] *
+                               in0.legacy_shard_spec().value().shape[1] / in0_tile.get_tile_shape()[1];
     uint32_t in2_CB_size = in0_shard_tiles * in0_single_tile_size;
 
     // Bias CB
@@ -273,8 +274,8 @@ create_program_batch_sharded(
     uint32_t in3_CB_size = in3_block_tiles * bias_single_tile_size;
 
     // Output reshard buffer
-    uint32_t out_shard_tiles = out_buffer->shard_spec().shape()[0] / output_tile.get_tile_shape()[0] *
-                               out_buffer->shard_spec().shape()[1] / output_tile.get_tile_shape()[1];
+    uint32_t out_shard_tiles = out.legacy_shard_spec().value().shape[0] / output_tile.get_tile_shape()[0] *
+                               out.legacy_shard_spec().value().shape[1] / output_tile.get_tile_shape()[1];
     uint32_t out_reshard_CB_size = out_shard_tiles * output_single_tile_size;
 
     // Page sizes for DRAM reads
@@ -321,17 +322,17 @@ create_program_batch_sharded(
             .set_tile_dims(src1_cb_index, in1_tile);
     tt_metal::CreateCircularBuffer(program, all_cores_in_rect_grid, src1_cb_config);
 
-    // CB 2: sharded in0 buffer - on INPUT storage cores, backed by in0_buffer
+    // CB 2: sharded in0 buffer - on INPUT storage cores, backed by in0
     uint32_t src2_cb_index = tt::CBIndex::c_2;
     tt_metal::CircularBufferConfig src2_cb_config =
         tt_metal::CircularBufferConfig(in2_CB_size, {{src2_cb_index, in0_data_format}})
             .set_page_size(src2_cb_index, in0_single_tile_size)
             .set_tile_dims(src2_cb_index, in0_tile)
-            .set_globally_allocated_address(*in0_buffer);
+            .set_globally_allocated_address(in0);
     auto cb_src2 = tt_metal::CreateCircularBuffer(program, input_all_storage_cores, src2_cb_config);
 
     // CB 3: bias (if fused) - on all cores in bounding box
-    if (bias_buffer != nullptr) {
+    if (bias.has_value()) {
         uint32_t src3_cb_index = tt::CBIndex::c_3;
         tt_metal::CircularBufferConfig cb_src3_config =
             tt_metal::CircularBufferConfig(in3_CB_size, {{src3_cb_index, bias_data_format}})
@@ -370,13 +371,13 @@ create_program_batch_sharded(
         tt_metal::CreateCircularBuffer(program, all_worker_cores, output_cb_config);
     }
 
-    // CB 6: output reshard buffer - on OUTPUT storage cores, backed by out_buffer
+    // CB 6: output reshard buffer - on OUTPUT storage cores, backed by out
     uint32_t output_reshard_cb_index = tt::CBIndex::c_6;
     tt_metal::CircularBufferConfig output_reshard_cb_config =
         tt_metal::CircularBufferConfig(out_reshard_CB_size, {{output_reshard_cb_index, output_data_format}})
             .set_page_size(output_reshard_cb_index, output_single_tile_size)
             .set_tile_dims(output_reshard_cb_index, output_tile)
-            .set_globally_allocated_address(*out_buffer);
+            .set_globally_allocated_address(out);
     auto cb_output_reshard =
         tt_metal::CreateCircularBuffer(program, output_all_storage_cores, output_reshard_cb_config);
 
@@ -385,7 +386,7 @@ create_program_batch_sharded(
     std::map<std::string, std::string> reader_defines;
     std::map<std::string, std::string> writer_defines;
 
-    if (bias_buffer != nullptr) {
+    if (bias.has_value()) {
         mm_kernel_defines["FUSE_BIAS"] = "1";
         writer_defines["FUSE_BIAS"] = "1";
     }
@@ -443,7 +444,7 @@ create_program_batch_sharded(
         (uint32_t)out_batch_stride_bytes,  // out_tensor_stride_batch_bytes (for NOC write)
         (uint32_t)out_reshard_CB_size,     // out_shard_size_bytes (full shard)
     };
-    if (bias_buffer != nullptr) {
+    if (bias.has_value()) {
         in1_writer_compile_args.push_back(bias_buffer_page_size);
         in1_writer_compile_args.push_back(bias_buffer_num_pages);
         in1_writer_compile_args.push_back(in3_block_tiles);
@@ -597,7 +598,7 @@ create_program_batch_sharded(
             1u,                               // worker_core_type (1 = active worker)
             input_storage_noc_x[worker_idx],  // input storage core NOC x
             input_storage_noc_y[worker_idx],  // input storage core NOC y
-            in0_buffer->address(),            // L1 address of in0 shard on storage core
+            in0.address(),                    // L1 address of in0 shard on storage core
         };
         tt_metal::SetRuntimeArgs(program, mm_kernel_in0_reader_id, core, in0_reader_runtime_args);
         reader_kernel_ids.push_back(mm_kernel_in0_reader_id);
@@ -605,13 +606,13 @@ create_program_batch_sharded(
         // in1 writer runtime args
         std::vector<uint32_t> in1_writer_runtime_args = {
             1u,  // is_worker_core
-            in1_buffer->address(),
-            bias_buffer != nullptr ? bias_buffer->address() : 0u,
+            in1.address(),
+            bias.has_value() ? bias->get().address() : 0u,
             bank_id,
             vc,
             output_storage_noc_x[worker_idx],  // output storage core NOC x
             output_storage_noc_y[worker_idx],  // output storage core NOC y
-            out_buffer->address(),             // L1 address of output shard on storage core
+            out.address(),                     // L1 address of output shard on storage core
         };
         tt_metal::SetRuntimeArgs(program, mm_kernel_in1_writer_id, core, in1_writer_runtime_args);
         writer_kernel_ids.push_back(mm_kernel_in1_writer_id);
@@ -637,14 +638,11 @@ matmul_multi_core_reuse_batched_hs_dram_sharded_optimized_(
     const ttnn::prim::MatmulInputs& tensor_args,
     std::vector<ttnn::Tensor>& tensor_return_value,
     const ttnn::prim::MatmulParams& operation_attributes) {
-    const auto& input_tensors = tensor_args.input_tensors;
-    const auto& optional_input_tensors = tensor_args.optional_input_tensors;
-    const auto& output_tensors = tensor_return_value;
-
-    const auto& a = input_tensors.at(0);
-    const auto& b = input_tensors.at(1);
-    const auto& bias = optional_input_tensors.at(0);
-    const auto& output = output_tensors.at(0);
+    // Get MeshTensor references for the migration
+    const auto& a = tensor_args.input_tensors.at(0).mesh_tensor();
+    const auto& b = tensor_args.input_tensors.at(1).mesh_tensor();
+    const auto& bias_opt = tensor_args.optional_input_tensors.at(0);
+    const auto& output = tensor_return_value.at(0).mesh_tensor();
     const auto& ashape = a.padded_shape();
     const auto& bshape = b.padded_shape();
     auto in0_tile = a.tensor_spec().tile();
@@ -658,44 +656,38 @@ matmul_multi_core_reuse_batched_hs_dram_sharded_optimized_(
     tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(b.dtype());
     tt::DataFormat output_data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());
 
-    tt_metal::Buffer* bias_buffer = nullptr;
+    std::optional<std::reference_wrapper<const tt::tt_metal::MeshTensor>> bias_mesh_tensor = std::nullopt;
     tt::DataFormat bias_data_format = tt::DataFormat::Bfp8_b;
-    if (bias.has_value()) {
-        const auto& c = bias.value();
-        TT_FATAL(c.storage_type() == StorageType::DEVICE, "Bias tensor must be on device");
-        TT_FATAL(a.device() == c.device(), "Operands to matmul need to be on the same device!");
-        TT_FATAL(c.buffer() != nullptr, "Operands to matmul need to be allocated in buffers on device!");
-        bias_buffer = c.buffer();
+    if (bias_opt.has_value()) {
+        const auto& c = bias_opt.value().mesh_tensor();
+        TT_FATAL(c.is_allocated(), "Operands to matmul need to be allocated in buffers on device!");
+
+        bias_mesh_tensor = c;
         bias_data_format = tt_metal::datatype_to_dataformat_converter(c.dtype());
     }
 
     tt::tt_metal::IDevice* device =
         reuse_batched_hs_dram_sharded_optimized_helpers::get_device_for_dram_banks(a, mesh_coord);
 
-    TT_FATAL(
-        a.shard_spec().has_value() && output.shard_spec().has_value(), "Both input A and output must have shard specs");
-    CoreRangeSet input_all_cores_storage = a.shard_spec().value().grid;
-    CoreRangeSet output_all_cores_storage = output.shard_spec().value().grid;
+    TT_FATAL(a.is_sharded() && output.is_sharded(), "Both input A and output must have shard specs");
+    CoreRangeSet input_all_cores_storage = a.legacy_shard_spec().value().grid;
+    CoreRangeSet output_all_cores_storage = output.legacy_shard_spec().value().grid;
 
-    tt_metal::Buffer* in0_buffer = a.buffer();
-    tt_metal::Buffer* in1_buffer = b.buffer();
-    tt_metal::Buffer* out_buffer = output.buffer();
-
-    uint32_t in0_single_tile_size = in0_tile.get_tile_size(tt_metal::datatype_to_dataformat_converter(a.dtype()));
-    uint32_t in1_single_tile_size = in1_tile.get_tile_size(tt_metal::datatype_to_dataformat_converter(b.dtype()));
+    uint32_t in0_single_tile_size = in0_tile.get_tile_size(in0_data_format);
+    uint32_t in1_single_tile_size = in1_tile.get_tile_size(in1_data_format);
 
     // Buffer size validation
     TT_FATAL(
-        in0_buffer->size() % in0_single_tile_size == 0,
+        a.tensor_spec().compute_packed_buffer_size_bytes() % in0_single_tile_size == 0,
         "Input A buffer size ({}) must be divisible by single tile size ({})",
-        in0_buffer->size(),
+        a.tensor_spec().compute_packed_buffer_size_bytes(),
         in0_single_tile_size);
     TT_FATAL(
-        in1_buffer->size() % in1_single_tile_size == 0,
+        b.tensor_spec().compute_packed_buffer_size_bytes() % in1_single_tile_size == 0,
         "Input B buffer size ({}) must be divisible by single tile size ({})",
-        in1_buffer->size(),
+        b.tensor_spec().compute_packed_buffer_size_bytes(),
         in1_single_tile_size);
-    TT_FATAL(out_buffer != nullptr, "Output buffer should be allocated on device!");
+    TT_FATAL(output.is_allocated(), "Output buffer should be allocated on device!");
 
     // Shape compatibility checks
     TT_FATAL(
@@ -775,13 +767,13 @@ matmul_multi_core_reuse_batched_hs_dram_sharded_optimized_(
         per_core_M,
         per_core_N,
         fused_activation,
-        in0_buffer,
-        in1_buffer,
-        bias_buffer,
-        out_buffer,
+        a,
+        b,
+        bias_mesh_tensor,
+        output,
         in0_tile,
         in1_tile,
-        bias.has_value() ? bias->tensor_spec().tile() : output_tile,
+        bias_mesh_tensor.has_value() ? bias_mesh_tensor->get().tensor_spec().tile() : output_tile,
         output_tile,
         in0_data_format,
         in1_data_format,
@@ -817,19 +809,17 @@ void MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory::override_runtime_ar
     const ttnn::prim::MatmulParams& /*operation_attributes*/,
     const ttnn::prim::MatmulInputs& tensor_args,
     std::vector<ttnn::Tensor>& tensor_return_value) {
-    const auto& input_tensors = tensor_args.input_tensors;
-    const auto& optional_input_tensors = tensor_args.optional_input_tensors;
-    const auto& output_tensors = tensor_return_value;
+    const auto& a = tensor_args.input_tensors.at(0).mesh_tensor();
+    const auto& b = tensor_args.input_tensors.at(1).mesh_tensor();
+    const auto& bias_opt = tensor_args.optional_input_tensors.at(0);
+    const auto& output = tensor_return_value.at(0).mesh_tensor();
 
     for (auto& [mesh_coord_range, program] : cached_workload.workload.get_programs()) {
-        auto* src_buffer_a = input_tensors.at(0).buffer();
-        auto* src_buffer_b = input_tensors.at(1).buffer();
-        const auto& bias_tensor = optional_input_tensors.at(0);
-        auto* dst_buffer = output_tensors.at(0).buffer();
         auto shared_variables = cached_workload.shared_variables.at(mesh_coord_range);
 
-        UpdateDynamicCircularBufferAddress(program, shared_variables.cb_src2, *src_buffer_a);
-        UpdateDynamicCircularBufferAddress(program, shared_variables.cb_output_reshard, *dst_buffer);
+        // API improvement opportunity: UpdateDynamicCircularBufferAddress requires get_reference_buffer()
+        UpdateDynamicCircularBufferAddress(program, shared_variables.cb_src2, a);
+        UpdateDynamicCircularBufferAddress(program, shared_variables.cb_output_reshard, output);
 
         const auto& all_worker_cores_ordered = shared_variables.all_worker_cores_ordered;
         const auto& reader_kernel_ids = shared_variables.reader_kernel_ids;
@@ -841,18 +831,18 @@ void MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory::override_runtime_ar
             // Update reader kernel runtime args - arg[3] is the L1 address of in0 shard
             auto reader_kernel_id = reader_kernel_ids[i];
             auto& reader_runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-            reader_runtime_args[3] = src_buffer_a->address();
+            reader_runtime_args[3] = a.address();
 
             // Update writer kernel runtime args
             auto writer_kernel_id = writer_kernel_ids[i];
             auto& writer_runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-            writer_runtime_args[1] = src_buffer_b->address();
-            if (bias_tensor.has_value()) {
-                writer_runtime_args[2] = bias_tensor.value().buffer()->address();
+            writer_runtime_args[1] = b.address();
+            if (bias_opt.has_value()) {
+                writer_runtime_args[2] = bias_opt.value().mesh_tensor().address();
             } else {
                 writer_runtime_args[2] = 0;
             }
-            writer_runtime_args[7] = dst_buffer->address();  // L1 address of output shard on storage core
+            writer_runtime_args[7] = output.address();  // L1 address of output shard on storage core
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -65,7 +65,7 @@ uint32_t get_preferred_noc(
 
 MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_program_and_create_override_variables(
     tt_metal::Program& program,
-    const tt::tt_metal::Tensor& a,
+    const tt::tt_metal::MeshTensor& a,
     tt_metal::IDevice* device,
     MathFidelity math_fidelity,
     bool fp32_dest_acc_en,
@@ -88,10 +88,10 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
     uint32_t per_core_M,
     uint32_t per_core_N,
     std::optional<UnaryWithParam> fused_activation,
-    tt_metal::Buffer* in0_buffer,
-    tt_metal::Buffer* in1_buffer,
-    tt_metal::Buffer* bias_buffer,
-    tt_metal::Buffer* out_buffer,
+    const tt::tt_metal::MeshTensor& in0,
+    const tt::tt_metal::MeshTensor& in1,
+    const tt::tt_metal::MeshTensor* bias,
+    const tt::tt_metal::MeshTensor& out,
     const tt::tt_metal::Tile& in0_tile,
     const tt::tt_metal::Tile& in1_tile,
     const tt::tt_metal::Tile& bias_tile,
@@ -151,8 +151,8 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
     uint32_t in0_shard_width_in_tiles = 0;
     uint32_t in0_shard_height_in_tiles = 0;
     if (in0_is_sharded) {
-        in0_shard_width_in_tiles = in0_buffer->shard_spec().shape()[1] / in0_tile.get_width();
-        in0_shard_height_in_tiles = in0_buffer->shard_spec().shape()[0] / in0_tile.get_height();
+        in0_shard_width_in_tiles = in0.legacy_shard_spec()->shape[1] / in0_tile.get_width();
+        in0_shard_height_in_tiles = in0.legacy_shard_spec()->shape[0] / in0_tile.get_height();
         in2_block_tiles = per_core_M * in0_shard_width_in_tiles;
     }
     uint32_t in2_CB_tiles = in2_block_tiles;
@@ -164,7 +164,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
         in1_CB_tiles *= operations::matmul::utilities::MCAST_INPUT_BUFFERING_DEPTH;
     }
     if (in1_is_sharded) {
-        uint32_t in1_shard_height_in_tiles = in1_buffer->shard_spec().shape()[0] / in1_tile.get_height();
+        uint32_t in1_shard_height_in_tiles = in1.legacy_shard_spec()->shape[0] / in1_tile.get_height();
         in1_CB_tiles = per_core_N * in1_shard_height_in_tiles;
     }
 
@@ -194,7 +194,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
     uint32_t num_blocks_total = num_blocks_y * num_blocks_x;
     uint32_t num_cores_with_work = num_blocks_total;
 
-    uint32_t in0_sender_num_cores = in0_is_sharded ? a.shard_spec().value().grid.num_cores() : 1;
+    uint32_t in0_sender_num_cores = in0_is_sharded ? a.legacy_shard_spec().value().grid.num_cores() : 1;
     uint32_t num_cores = in0_is_sharded ? std::max(num_cores_with_work, in0_sender_num_cores) : num_cores_with_work;
 
     constexpr bool row_major = true;
@@ -280,7 +280,10 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
 
     uint32_t in0_num_subblocks = (out_block_h / out_subblock_h);
     uint32_t in0_block_num_tiles = out_subblock_h * in0_block_w * in0_num_subblocks;
-    const auto& a_shape_logical = operations::matmul::utilities::get_matmul_tensor_logical_shape(a, transpose_a);
+    auto a_shape_logical = a.logical_shape();
+    if (transpose_a) {
+        std::swap(a_shape_logical[-2], a_shape_logical[-1]);
+    }
     const auto in0_last_ktile_w = a_shape_logical[-1] % in0_tile.get_width();
 
     const auto in0_tensor_stride_w = transpose_a ? M : 1;
@@ -360,7 +363,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
         };
     }
     in0_sender_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_all_gather()));
-    tt::tt_metal::TensorAccessorArgs(*in0_buffer).append_to(in0_sender_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(in0).append_to(in0_sender_compile_time_args);
     tt::tt_metal::TensorAccessorArgs().append_to(in0_sender_compile_time_args);  // placeholder for sparsity
 
     std::vector<uint32_t> in1_sender_writer_compile_time_args = {
@@ -406,7 +409,8 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
         // batch args
         (std::uint32_t)M * N  // MtNt
     };
-    if (bias_buffer != nullptr) {
+    bool has_bias = bias != nullptr && bias->is_allocated();
+    if (has_bias) {
         in1_sender_writer_compile_time_args.push_back((std::uint32_t)1);  // in3_tensor_stride_w
     } else {
         in1_sender_writer_compile_time_args.push_back(0);  // Placeholder; not used
@@ -416,11 +420,11 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
     in1_sender_writer_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_reduce_scatter()));
 
     // Append TensorAccessorArgs
-    tt::tt_metal::TensorAccessorArgs(*in1_buffer).append_to(in1_sender_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(in1).append_to(in1_sender_writer_compile_time_args);
     tt::tt_metal::TensorAccessorArgs().append_to(in1_sender_writer_compile_time_args);  // placeholder for sparsity
-    tt::tt_metal::TensorAccessorArgs(*out_buffer).append_to(in1_sender_writer_compile_time_args);
-    if (bias_buffer != nullptr) {
-        tt::tt_metal::TensorAccessorArgs(*bias_buffer).append_to(in1_sender_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(out).append_to(in1_sender_writer_compile_time_args);
+    if (has_bias) {
+        tt::tt_metal::TensorAccessorArgs(*bias).append_to(in1_sender_writer_compile_time_args);
     }
 
     std::vector<uint32_t> in0_receiver_compile_time_args = {
@@ -441,7 +445,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
     std::map<std::string, std::string> mm_kernel_defines;
     std::map<std::string, std::string> mm_kernel_in0_sender_writer_defines;
     std::map<std::string, std::string> mm_kernel_in1_sender_writer_defines;
-    if (bias_buffer != nullptr) {
+    if (has_bias) {
         mm_kernel_defines["FUSE_BIAS"] = "1";
         mm_kernel_in1_sender_writer_defines["FUSE_BIAS"] = "1";
     }
@@ -719,7 +723,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
             .set_tile_dims(src1_cb_index, in1_tile);
 
     if (in1_is_sharded) {
-        src1_cb_config = src1_cb_config.set_globally_allocated_address(*in1_buffer);
+        src1_cb_config = src1_cb_config.set_globally_allocated_address(in1);
     }
 
     auto cb_src1 = tt_metal::CreateCircularBuffer(program, all_cores, src1_cb_config);
@@ -737,7 +741,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
         tt_metal::CircularBufferConfig src2_cb_config =
             tt_metal::CircularBufferConfig(in2_CB_size, {{src2_cb_index, in0_data_format}})
                 .set_page_size(src2_cb_index, in0_single_tile_size)
-                .set_globally_allocated_address(*in0_buffer)
+                .set_globally_allocated_address(in0)
                 .set_tile_dims(src2_cb_index, in0_tile);
         cb_src2 = tt_metal::CreateCircularBuffer(program, all_cores, src2_cb_config);
         log_debug(
@@ -800,7 +804,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
     }
 
     if (output_is_sharded) {
-        output_cb_config = output_cb_config.set_globally_allocated_address(*out_buffer);
+        output_cb_config = output_cb_config.set_globally_allocated_address(out);
     }
     auto cb_output = tt_metal::CreateCircularBuffer(program, all_cores, output_cb_config);
     log_debug(
@@ -812,7 +816,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
         out_CB_size);
 
     tt_metal::CBHandle cb_src3 = 0;
-    if (bias_buffer != nullptr) {
+    if (bias != nullptr && bias->is_allocated()) {
         uint32_t src3_cb_index = tt::CBIndex::c_3;
         tt_metal::CircularBufferConfig cb_src3_config =
             tt_metal::CircularBufferConfig(in3_CB_size, {{src3_cb_index, bias_data_format}})
@@ -820,7 +824,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
                 .set_tile_dims(src3_cb_index, bias_tile);
 
         if (bias_is_sharded) {
-            cb_src3_config = cb_src3_config.set_globally_allocated_address(*bias_buffer);
+            cb_src3_config = cb_src3_config.set_globally_allocated_address(*bias);
         }
 
         cb_src3 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src3_config);
@@ -924,7 +928,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
         else if (core == start_core) {
             std::vector<uint32_t> mm_in0_sender_args = {
                 // in0 tensor args
-                (std::uint32_t)in0_buffer->address(),
+                (std::uint32_t)in0.address(),
                 (std::uint32_t)in0_tensor_start_tile_id_stride * output_idx_y,  // in0_tensor_start_tile_id
                 // in0 mcast args
                 (std::uint32_t)start_core_noc.x,  // in0_mcast_dest_noc_start_x
@@ -963,7 +967,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
             std::vector<uint32_t> mm_in1_sender_writer_args = {
                 // READER
                 // in1 tensor args
-                (std::uint32_t)in1_buffer->address(),
+                (std::uint32_t)in1.address(),
                 (std::uint32_t)in1_tensor_start_tile_id_stride * output_idx_x,  // in1_tensor_start_tile_id
                 // in1 mcast args
                 (std::uint32_t)0,  // in1_mcast_dest_noc_start_x
@@ -976,7 +980,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
 
                 // WRITER
                 // out tensor args
-                (std::uint32_t)out_buffer->address(),
+                (std::uint32_t)out.address(),
                 ((std::uint32_t)output_idx_x * per_core_N) +
                     (output_idx_y * per_core_M * N)  // out_tensor_start_tile_id
             };
@@ -1009,9 +1013,9 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
                 mm_in1_sender_writer_args.push_back(0);
             }
 
-            mm_in1_sender_writer_args.push_back(bias_buffer ? (std::uint32_t)bias_buffer->address() : 0);
+            mm_in1_sender_writer_args.push_back(has_bias ? (std::uint32_t)bias->address() : 0);
             mm_in1_sender_writer_args.push_back(
-                bias_buffer ? (std::uint32_t)per_core_N * output_idx_x : 0);  // in3_tensor_start_tile_id
+                has_bias ? (std::uint32_t)per_core_N * output_idx_x : 0);  // in3_tensor_start_tile_id
             if (!output_is_sharded) {
                 if (output_idx_x == num_blocks_x - 1) {
                     mm_in1_sender_writer_args.push_back(last_out_num_blocks_w);
@@ -1041,7 +1045,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
 
 MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_program_and_create_override_variables(
     tt_metal::Program& program,
-    const tt::tt_metal::Tensor& a,
+    const tt::tt_metal::MeshTensor& a,
     tt_metal::IDevice* device,
     MathFidelity math_fidelity,
     bool fp32_dest_acc_en,
@@ -1064,10 +1068,10 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
     uint32_t per_core_M,
     uint32_t per_core_N,
     std::optional<UnaryWithParam> fused_activation,
-    tt_metal::Buffer* in0_buffer,
-    tt_metal::Buffer* in1_buffer,
-    tt_metal::Buffer* bias_buffer,
-    tt_metal::Buffer* out_buffer,
+    const tt::tt_metal::MeshTensor& in0,
+    const tt::tt_metal::MeshTensor& in1,
+    const tt::tt_metal::MeshTensor* bias,
+    const tt::tt_metal::MeshTensor& out,
     const tt::tt_metal::Tile& in0_tile,
     const tt::tt_metal::Tile& in1_tile,
     const tt::tt_metal::Tile& bias_tile,
@@ -1091,7 +1095,8 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
     // unnecessary overhead for reconfigs are added. Last iteration of l1 accumulation
     // does a spill and reload, so need more than 2 blocks to use l1 acc for packer
     // For bias, last iteration of l1 acc remains in intermediate buffer, does not spill and reload
-    bool packer_l1_acc_en = packer_l1_acc && (((bias_buffer != nullptr) && num_blocks > 1) || (num_blocks > 2));
+    bool has_bias = bias != nullptr && bias->is_allocated();
+    bool packer_l1_acc_en = packer_l1_acc && ((has_bias && num_blocks > 1) || (num_blocks > 2));
 
     // if fp32 enabled then we pack fp32 in l1, if not, then we pack fp16 in l1
     tt::DataFormat interm0_data_format = packer_l1_acc_en
@@ -1122,15 +1127,18 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
     }
     uint32_t in0_CB_size = in0_CB_tiles * in0_single_tile_size;
 
-    const auto& a_shape_logical = operations::matmul::utilities::get_matmul_tensor_logical_shape(a, transpose_a);
+    auto a_shape_logical = a.logical_shape();
+    if (transpose_a) {
+        std::swap(a_shape_logical[-2], a_shape_logical[-1]);
+    }
     const auto in0_last_ktile_w = a_shape_logical[-1] % in0_tile.get_width();
 
     bool extract_shard_sub_blocks = false;
     uint32_t in0_shard_height_in_tiles = 0;
     uint32_t in0_shard_width_in_tiles = 0;
     if (in0_is_sharded) {
-        in0_shard_height_in_tiles = in0_buffer->shard_spec().shape()[0] / in0_tile.get_height();
-        in0_shard_width_in_tiles = in0_buffer->shard_spec().shape()[1] / in0_tile.get_width();
+        in0_shard_height_in_tiles = in0.legacy_shard_spec()->shape[0] / in0_tile.get_height();
+        in0_shard_width_in_tiles = in0.legacy_shard_spec()->shape[1] / in0_tile.get_width();
         // NOTE: Criteria for extract_shard_sub_blocks is different from mcast in0
         // In the reader kernel, always need to copy to cb0 even for height=1 shards since we may not always do mcast
         // In mcast in0 sharded reader kernel, this is handled by mcast with loopback src
@@ -1243,7 +1251,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
         (std::uint32_t)false  // get_batch_from_reader
     };
     in0_sender_compile_time_args.push_back((std::uint32_t)fuse_op);
-    tt::tt_metal::TensorAccessorArgs(*in0_buffer).append_to(in0_sender_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(in0).append_to(in0_sender_compile_time_args);
     tt::tt_metal::TensorAccessorArgs().append_to(in0_sender_compile_time_args);  // placeholder for sparsity
 
     std::vector<uint32_t> in1_sender_writer_compile_time_args = {
@@ -1289,7 +1297,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
         // batch args
         (std::uint32_t)M * N  // MtNt
     };
-    if (bias_buffer != nullptr) {
+    if (has_bias) {
         in1_sender_writer_compile_time_args.push_back((std::uint32_t)1);  // in3_tensor_stride_w
     } else {
         in1_sender_writer_compile_time_args.push_back(0);  // Placeholder; not used
@@ -1299,11 +1307,11 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
     in1_sender_writer_compile_time_args.push_back((std::uint32_t)fuse_op);
 
     // Append TensorAccessorArgs
-    tt::tt_metal::TensorAccessorArgs(*in1_buffer).append_to(in1_sender_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(in1).append_to(in1_sender_writer_compile_time_args);
     tt::tt_metal::TensorAccessorArgs().append_to(in1_sender_writer_compile_time_args);  // placeholder for sparsity
-    tt::tt_metal::TensorAccessorArgs(*out_buffer).append_to(in1_sender_writer_compile_time_args);
-    if (bias_buffer != nullptr) {
-        tt::tt_metal::TensorAccessorArgs(*bias_buffer).append_to(in1_sender_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(out).append_to(in1_sender_writer_compile_time_args);
+    if (has_bias) {
+        tt::tt_metal::TensorAccessorArgs(*bias).append_to(in1_sender_writer_compile_time_args);
     }
 
     std::vector<uint32_t> in1_receiver_writer_compile_time_args = {
@@ -1336,19 +1344,19 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
         (std::uint32_t)M * N  // MtNt
     };
 
-    if (bias_buffer != nullptr) {
+    if (has_bias) {
         in1_receiver_writer_compile_time_args.push_back((std::uint32_t)in1_block_w);
     } else {
         in1_receiver_writer_compile_time_args.push_back(0);  // Placeholder; not used
     }
     in1_receiver_writer_compile_time_args.push_back((std::uint32_t)fuse_op);
-    tt::tt_metal::TensorAccessorArgs(*out_buffer).append_to(in1_receiver_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(out).append_to(in1_receiver_writer_compile_time_args);
 
     std::map<std::string, std::string> mm_kernel_defines;
     std::map<std::string, std::string> mm_kernel_in0_sender_defines;
     std::map<std::string, std::string> mm_kernel_in1_sender_writer_defines;
     std::map<std::string, std::string> mm_kernel_in1_receiver_writer_defines;
-    if (bias_buffer != nullptr) {
+    if (has_bias) {
         mm_kernel_defines["FUSE_BIAS"] = "1";
         mm_kernel_in1_sender_writer_defines["FUSE_BIAS"] = "1";
         mm_kernel_in1_receiver_writer_defines["FUSE_BIAS"] = "1";
@@ -1551,7 +1559,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
             .set_page_size(src0_cb_index, in0_single_tile_size)
             .set_tile_dims(src0_cb_index, in0_tile);
     if (in0_is_sharded and not extract_shard_sub_blocks) {
-        src0_cb_config = src0_cb_config.set_globally_allocated_address(*in0_buffer);
+        src0_cb_config = src0_cb_config.set_globally_allocated_address(in0);
     }
     auto cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores, src0_cb_config);
     log_debug(
@@ -1568,7 +1576,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
         tt_metal::CircularBufferConfig src2_cb_config =
             tt_metal::CircularBufferConfig(in2_CB_size, {{src2_cb_index, in0_data_format}})
                 .set_page_size(src2_cb_index, in0_single_tile_size)
-                .set_globally_allocated_address(*in0_buffer)
+                .set_globally_allocated_address(in0)
                 .set_tile_dims(src2_cb_index, in0_tile);
         cb_src2 = tt_metal::CreateCircularBuffer(program, all_cores, src2_cb_config);
         log_debug(
@@ -1638,7 +1646,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
     }
 
     if (output_is_sharded) {
-        output_cb_config = output_cb_config.set_globally_allocated_address(*out_buffer);
+        output_cb_config = output_cb_config.set_globally_allocated_address(out);
     }
     auto cb_output = tt_metal::CreateCircularBuffer(program, all_cores, output_cb_config);
     log_debug(
@@ -1649,7 +1657,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
         out_CB_size / output_single_tile_size,
         out_CB_size);
 
-    if (bias_buffer != nullptr) {
+    if (has_bias) {
         uint32_t src3_cb_index = tt::CBIndex::c_3;
         tt_metal::CircularBufferConfig cb_src3_config =
             tt_metal::CircularBufferConfig(in3_CB_size, {{src3_cb_index, bias_data_format}})
@@ -1719,7 +1727,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
             std::vector<uint32_t> mm_in1_sender_writer_args = {
                 // READER
                 // in1 tensor args
-                (std::uint32_t)in1_buffer->address(),
+                (std::uint32_t)in1.address(),
                 (std::uint32_t)in1_tensor_start_tile_id_stride * output_idx_x,  // in1_tensor_start_tile_id
                 // in1 mcast args
                 (std::uint32_t)start_core_noc.x,  // in1_mcast_dest_noc_start_x
@@ -1732,7 +1740,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
 
                 // WRITER
                 // out tensor args
-                (std::uint32_t)out_buffer->address(),
+                (std::uint32_t)out.address(),
                 ((std::uint32_t)output_idx_x * per_core_N) +
                     (output_idx_y * per_core_M * N),  // out_tensor_start_tile_id
 
@@ -1748,8 +1756,8 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
                 (std::uint32_t)0,
                 (std::uint32_t)0};
 
-            if (bias_buffer != nullptr) {
-                mm_in1_sender_writer_args.push_back((std::uint32_t)bias_buffer->address());
+            if (has_bias) {
+                mm_in1_sender_writer_args.push_back((std::uint32_t)bias->address());
                 mm_in1_sender_writer_args.push_back(
                     (std::uint32_t)per_core_N * output_idx_x);  // in3_tensor_start_tile_id
             } else {
@@ -1773,7 +1781,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
 
                 // WRITER
                 // out tensor args
-                (std::uint32_t)out_buffer->address(),  // out_tensor_addr
+                (std::uint32_t)out.address(),  // out_tensor_addr
                 ((std::uint32_t)output_idx_x * per_core_N) +
                     (output_idx_y * per_core_M * N)  // out_tensor_start_tile_id
             };
@@ -1819,7 +1827,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
         }
         std::vector<uint32_t> mm_in0_sender_args = {
             // in0 tensor args
-            (std::uint32_t)in0_buffer->address(),
+            (std::uint32_t)in0.address(),
             (std::uint32_t)in0_tensor_start_tile_id_stride * output_idx_y,  // in0_tensor_start_tile_id
             // in0 mcast args
             (std::uint32_t)0,  // in0_mcast_dest_noc_start_x
@@ -1849,8 +1857,8 @@ enum class CORE_TYPE : uint32_t { IDLE_CORE = 0, WORKER_CORE = 1, HOP_CORE = 2 }
 
 MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0_program_and_create_override_variables(
     tt_metal::Program& program,
-    const tt::tt_metal::Tensor& a,
-    const std::vector<tt::tt_metal::Tensor>& b_tensors,
+    const tt::tt_metal::MeshTensor& a,
+    const std::vector<std::reference_wrapper<const tt::tt_metal::MeshTensor>>& b_tensors,
     tt_metal::IDevice* device,
     MathFidelity math_fidelity,
     bool fp32_dest_acc_en,
@@ -1872,9 +1880,9 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
     uint32_t per_core_N,
     std::optional<UnaryWithParam> fused_activation,
     const CoreRangeSet& hop_cores,
-    tt_metal::Buffer* in0_buffer,
-    tt_metal::Buffer* in1_buffer,
-    std::vector<tt_metal::Buffer*> out_buffers,
+    const tt::tt_metal::MeshTensor& in0,
+    const tt::tt_metal::MeshTensor& in1,
+    const std::vector<std::reference_wrapper<const tt::tt_metal::MeshTensor>>& out_tensors,
     const tt::tt_metal::Tile& in0_tile,
     const tt::tt_metal::Tile& in1_tile,
     const tt::tt_metal::Tile& output_tile,
@@ -1887,16 +1895,16 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
     const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
     std::optional<CoreRangeSet> restricted_cores,
     std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>& fused_op_signaler) {
-    const auto& b = b_tensors[0];
-    const auto num_output_cb = out_buffers.size();
+    const auto& b = b_tensors[0].get();
+    const auto num_output_cb = out_tensors.size();
     const auto batch = b_tensors.size();
-    const bool in1_is_dram_interleaved = in1_buffer->is_dram() && !b.is_sharded();
+    const bool in1_is_dram_interleaved = in1.memory_config().is_dram() && !b.is_sharded();
     const bool in1_is_dram_sharded =
-        in1_buffer->is_dram() && b.is_sharded() && !global_cb.has_value();  // read from DRAM directly
+        in1.memory_config().is_dram() && b.is_sharded() && !global_cb.has_value();  // read from DRAM directly
 
     /* Core setup */
     constexpr bool row_major = true;
-    CoreRangeSet all_worker_cores = a.shard_spec().value().grid;
+    CoreRangeSet all_worker_cores = a.legacy_shard_spec().value().grid;
     CoreRangeSet non_idle_cores = all_worker_cores.merge(hop_cores);
     CoreRangeSet all_cores = non_idle_cores;
     std::vector<CoreRange> non_idle_cores_vec;
@@ -1925,7 +1933,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
     bool use_hop_cores = num_hop_cores > 0;
 
     /* Inner dim padding */
-    const uint32_t Kt_pad = in0_buffer->shard_spec().shape()[1] / in0_tile.get_width() * num_cores;
+    const uint32_t Kt_pad = in0.legacy_shard_spec()->shape[1] / in0_tile.get_width() * num_cores;
     in0_block_w = Kt_pad / num_cores;
 
     uint32_t num_blocks = Kt_pad / in0_block_w;
@@ -1946,7 +1954,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
     uint32_t interm0_single_tile_size = output_tile.get_tile_size(interm0_data_format);
 
     /* in0 */
-    uint32_t in0_shard_width_in_tiles = in0_buffer->shard_spec().shape()[1] / in0_tile.get_width();
+    uint32_t in0_shard_width_in_tiles = in0.legacy_shard_spec()->shape[1] / in0_tile.get_width();
     uint32_t in0_CB_tiles = per_core_M * in0_shard_width_in_tiles;
     uint32_t in0_CB_size = in0_CB_tiles * in0_single_tile_size;
 
@@ -1955,14 +1963,14 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
     uint32_t in1_shard_width_in_tiles = 0;
     uint32_t in1_CB_tiles = 0;
 
-    const auto& bshape = operations::matmul::utilities::get_matmul_tensor_padded_shape(b, /*transpose=*/false);
+    const auto& bshape = b.padded_shape();
     uint32_t in1_tensor_width_in_tiles = bshape[-1] / in1_tile.get_width();
 
     if (in1_is_dram_sharded || in1_is_dram_interleaved) {
         in1_CB_tiles = 2 * in0_shard_width_in_tiles * per_core_N;  // Double buffered
     } else {
-        in1_shard_height_in_tiles = in1_buffer->shard_spec().shape()[0] / in1_tile.get_height();
-        in1_shard_width_in_tiles = in1_buffer->shard_spec().shape()[1] / in1_tile.get_width() / num_global_cb_receivers;
+        in1_shard_height_in_tiles = in1.legacy_shard_spec()->shape[0] / in1_tile.get_height();
+        in1_shard_width_in_tiles = in1.legacy_shard_spec()->shape[1] / in1_tile.get_width() / num_global_cb_receivers;
         in1_CB_tiles = in1_shard_height_in_tiles * in1_shard_width_in_tiles;
     }
     uint32_t in1_CB_size = in1_CB_tiles * in1_single_tile_size;
@@ -1976,7 +1984,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
     uint32_t in1_block_width_num_pages = (per_core_N_size_bytes + in1_block_page_size - 1) / in1_block_page_size;
     uint32_t in1_shard_width_in_dram = 0;
     if (in1_is_dram_sharded) {
-        in1_shard_width_in_dram = in1_buffer->shard_spec().shape()[1] / in1_tile.get_width();
+        in1_shard_width_in_dram = in1.legacy_shard_spec()->shape[1] / in1_tile.get_width();
     }
 
     /* in2 */
@@ -2017,7 +2025,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
         tt_metal::CircularBufferConfig(in0_CB_size, {{src0_cb_index, in0_data_format}})
             .set_page_size(src0_cb_index, in0_single_tile_size)
             .set_tile_dims(src0_cb_index, in0_tile)
-            .set_globally_allocated_address(*in0_buffer);
+            .set_globally_allocated_address(in0);
     auto cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores, src0_cb_config);
 
     uint32_t src1_cb_index = base_cb_index + 1;
@@ -2038,7 +2046,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
                 .set_page_size(src1_cb_index, in1_single_tile_size)
                 .set_tile_dims(src1_cb_index, in1_tile);
         if (!in1_is_dram_interleaved && !in1_is_dram_sharded) {
-            src1_cb_config = src1_cb_config.set_globally_allocated_address(*in1_buffer);
+            src1_cb_config = src1_cb_config.set_globally_allocated_address(in1);
         }
         cb_src1 = tt_metal::CreateCircularBuffer(program, all_cores, src1_cb_config);
     }
@@ -2085,8 +2093,8 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
 
         tt_metal::CreateCircularBuffer(program, all_cores, interm0_cb_config);
 
-        for (uint32_t i = 0; i < out_buffers.size(); ++i) {
-            const auto& out_buffer = out_buffers[i];
+        for (uint32_t i = 0; i < out_tensors.size(); ++i) {
+            const auto& out_tensor = out_tensors[i].get();
             output_cb_index += i * 2;  // 5, 7, 9...
             TT_FATAL(
                 output_cb_index <= tt::CBIndex::c_31,
@@ -2100,15 +2108,15 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
             output_cb_config = tt_metal::CircularBufferConfig(out_CB_size, output_cb_data_format_spec)
                                    .set_page_size(output_cb_index, output_single_tile_size)
                                    .set_tile_dims(output_cb_index, output_tile)
-                                   .set_globally_allocated_address(*out_buffer);
+                                   .set_globally_allocated_address(out_tensor);
             auto cb_output = tt_metal::CreateCircularBuffer(program, all_cores, output_cb_config);
             cb_outputs.push_back(cb_output);
             output_cb_indices.push_back(output_cb_index);
             interm_cb_indices.push_back(interm0_cb_index);
         }
     } else {
-        for (uint32_t i = 0; i < out_buffers.size(); ++i) {
-            const auto& out_buffer = out_buffers[i];
+        for (uint32_t i = 0; i < out_tensors.size(); ++i) {
+            const auto& out_tensor = out_tensors[i].get();
             output_cb_index += i * 2;   // 5, 7, 9...
             interm0_cb_index += i * 2;  // 6, 8, 10...
             TT_FATAL(
@@ -2129,7 +2137,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
                                    .set_page_size(interm0_cb_index, interm0_single_tile_size)
                                    .set_tile_dims(output_cb_index, output_tile)
                                    .set_tile_dims(interm0_cb_index, output_tile)
-                                   .set_globally_allocated_address(*out_buffer);
+                                   .set_globally_allocated_address(out_tensor);
             auto cb_output = tt_metal::CreateCircularBuffer(program, all_cores, output_cb_config);
             cb_outputs.push_back(cb_output);
             output_cb_indices.push_back(output_cb_index);
@@ -2160,7 +2168,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
         (std::uint32_t)in1_shard_width_in_dram,
         (std::uint32_t)fused_op_signaler.has_value(),
     };
-    tt::tt_metal::TensorAccessorArgs(*in1_buffer).append_to(in1_sender_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(in1).append_to(in1_sender_writer_compile_time_args);
 
     /* compute kernel args */
     const uint32_t out_block_num_subblocks = out_block_tiles / out_subblock_num_tiles;
@@ -2335,7 +2343,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
     uint32_t first_col_max_x = device->arch() == tt::ARCH::WORMHOLE_B0 ? 3 : 7;
     uint32_t num_receiver_cores_per_dram = 2;  // default to 2 for wormhole b0 and blackhole
     if (in1_is_dram_sharded) {
-        num_receiver_cores_per_dram = ring_size / in1_buffer->shard_spec().grid().num_cores();
+        num_receiver_cores_per_dram = ring_size / in1.legacy_shard_spec()->grid.num_cores();
         if (device->arch() == tt::ARCH::WORMHOLE_B0) {
             worker_y_to_dram_bank_first_col[0] = 1;
             worker_y_to_dram_bank_first_col[4] = 2;
@@ -2439,8 +2447,8 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
         /* in1 */
         std::vector<uint32_t> mm_in1_args = {
             (std::uint32_t)core_type,
-            in1_buffer->address(),  // in1_tensor_addr
-            i,                      // ring_idx
+            in1.address(),  // in1_tensor_addr
+            i,              // ring_idx
         };
         if (in1_is_dram_sharded) {
             // Look up bank_id based on core.y and which column group core.x belongs to
@@ -2589,19 +2597,19 @@ inline void override_mcast_in1_program_parameters(
     TT_FATAL(
         output_tensors.size() == 1, "matmul mcast in1 requires 1 output tensor, {} provided", output_tensors.size());
 
-    auto* src_buffer_a = input_tensors.at(0).buffer();
-    auto* src_buffer_b = input_tensors.at(1).buffer();
+    const auto& src_a = input_tensors.at(0).mesh_tensor();
+    const auto& src_b = input_tensors.at(1).mesh_tensor();
     const auto& bias_tensor = optional_input_tensors.at(0);
 
-    std::optional<tt::tt_metal::Buffer*> bias_buffer;
+    const tt::tt_metal::MeshTensor* bias = nullptr;
     if (bias_tensor.has_value()) {
-        bias_buffer = bias_tensor.value().buffer();
+        bias = &bias_tensor.value().mesh_tensor();
     }
 
-    auto* dst_buffer = output_tensors.at(0).buffer();
+    const auto& dst = output_tensors.at(0).mesh_tensor();
 
-    bool src0_sharded = input_tensors[0].is_sharded();
-    bool out_sharded = output_tensors[0].is_sharded();
+    bool src0_sharded = src_a.is_sharded();
+    bool out_sharded = dst.is_sharded();
 
     auto& reader_runtime_args_by_core = GetRuntimeArgs(program, override_variables.kernels.at(0));
 
@@ -2610,15 +2618,15 @@ inline void override_mcast_in1_program_parameters(
         // in0 sender
         auto& reader_runtime_args =
             reader_runtime_args_by_core[override_variables.start_core.x][override_variables.start_core.y];
-        reader_runtime_args[0] = src_buffer_a->address();
+        reader_runtime_args[0] = src_a.address();
 
         // in1 sender
         auto& sender_writer_runtime_args =
             GetRuntimeArgs(program, override_variables.kernels.at(1), override_variables.start_core);
-        sender_writer_runtime_args[0] = src_buffer_b->address();
-        sender_writer_runtime_args[7] = dst_buffer->address();
-        if (bias_tensor.has_value()) {
-            sender_writer_runtime_args[18] = (*bias_buffer)->address();
+        sender_writer_runtime_args[0] = src_b.address();
+        sender_writer_runtime_args[7] = dst.address();
+        if (bias != nullptr) {
+            sender_writer_runtime_args[18] = bias->address();
         }
     }
 
@@ -2632,21 +2640,21 @@ inline void override_mcast_in1_program_parameters(
         auto& writer_runtime_args = receiver_writer_runtime_args_by_core[core.x][core.y];
 
         // in0 sender
-        reader_runtime_args[0] = src_buffer_a->address();
+        reader_runtime_args[0] = src_a.address();
         // in1 receiver
-        writer_runtime_args[2] = dst_buffer->address();
+        writer_runtime_args[2] = dst.address();
     }
 
     if (src0_sharded) {
         if (override_variables.extract_shard_sub_blocks) {
-            UpdateDynamicCircularBufferAddress(program, override_variables.cbs.at(1), *src_buffer_a);
+            UpdateDynamicCircularBufferAddress(program, override_variables.cbs.at(1), src_a);
         } else {
-            UpdateDynamicCircularBufferAddress(program, override_variables.cbs.at(0), *src_buffer_a);
+            UpdateDynamicCircularBufferAddress(program, override_variables.cbs.at(0), src_a);
         }
     }
 
     if (out_sharded) {
-        UpdateDynamicCircularBufferAddress(program, override_variables.cbs.at(2), *dst_buffer);
+        UpdateDynamicCircularBufferAddress(program, override_variables.cbs.at(2), dst);
     }
 }
 
@@ -2667,37 +2675,37 @@ static void override_mcast_in0_program_parameters(
     TT_FATAL(
         output_tensors.size() == 1, "matmul mcast in0 requires 1 output tensor, {} provided", output_tensors.size());
 
-    auto* src_buffer_a = input_tensors.at(0).buffer();
-    auto* src_buffer_b = input_tensors.at(1).buffer();
+    const auto& src_a = input_tensors.at(0).mesh_tensor();
+    const auto& src_b = input_tensors.at(1).mesh_tensor();
     const auto& bias_tensor = optional_input_tensors.at(0);
 
-    std::optional<tt::tt_metal::Buffer*> bias_buffer;
+    const tt::tt_metal::MeshTensor* bias = nullptr;
     if (bias_tensor.has_value()) {
-        bias_buffer = bias_tensor.value().buffer();
+        bias = &bias_tensor.value().mesh_tensor();
     }
 
-    auto* dst_buffer = output_tensors.at(0).buffer();
+    const auto& dst = output_tensors.at(0).mesh_tensor();
 
-    bool src0_sharded = input_tensors[0].is_sharded();
-    bool src1_sharded = input_tensors[1].is_sharded();
-    bool out_sharded = output_tensors[0].is_sharded();
+    bool src0_sharded = src_a.is_sharded();
+    bool src1_sharded = src_b.is_sharded();
+    bool out_sharded = dst.is_sharded();
 
     // Manually unroll sender core
     if (src0_sharded) {
-        UpdateDynamicCircularBufferAddress(program, override_variables.cbs.at(1), *src_buffer_a);
+        UpdateDynamicCircularBufferAddress(program, override_variables.cbs.at(1), src_a);
     } else {
         // in0 sender
         auto& reader_sender_runtime_args =
             GetRuntimeArgs(program, override_variables.kernels.at(0), override_variables.start_core);
-        reader_sender_runtime_args[0] = src_buffer_a->address();
+        reader_sender_runtime_args[0] = src_a.address();
     }
 
     if (src1_sharded) {
-        UpdateDynamicCircularBufferAddress(program, override_variables.cbs.at(0), *src_buffer_b);
+        UpdateDynamicCircularBufferAddress(program, override_variables.cbs.at(0), src_b);
     }
 
-    if (bias_tensor.has_value() && bias_tensor.value().is_sharded()) {
-        UpdateDynamicCircularBufferAddress(program, override_variables.cbs.at(2), *bias_buffer.value());
+    if (bias != nullptr && bias->is_sharded()) {
+        UpdateDynamicCircularBufferAddress(program, override_variables.cbs.at(2), *bias);
     }
 
     auto& writer_runtime_args_by_core = GetRuntimeArgs(program, override_variables.kernels.at(1));
@@ -2708,15 +2716,15 @@ static void override_mcast_in0_program_parameters(
         auto& writer_runtime_args = writer_runtime_args_by_core[core.x][core.y];
 
         // in1 sender
-        writer_runtime_args[0] = src_buffer_b->address();
-        writer_runtime_args[7] = dst_buffer->address();
-        if (bias_tensor.has_value()) {
-            writer_runtime_args[18] = (*bias_buffer)->address();
+        writer_runtime_args[0] = src_b.address();
+        writer_runtime_args[7] = dst.address();
+        if (bias != nullptr) {
+            writer_runtime_args[18] = bias->address();
         }
     }
 
     if (out_sharded) {
-        UpdateDynamicCircularBufferAddress(program, override_variables.cbs.at(3), *dst_buffer);
+        UpdateDynamicCircularBufferAddress(program, override_variables.cbs.at(3), dst);
     }
 }
 
@@ -2728,20 +2736,20 @@ inline void override_gather_in0_program_parameters(
     const std::vector<ttnn::Tensor>& output_tensors) {
     const auto& input_tensors = tensor_args.input_tensors;
 
-    auto* src_buffer_a = input_tensors[0].buffer();
-    auto* src_buffer_b = input_tensors[1].buffer();
+    const auto& src_a = input_tensors[0].mesh_tensor();
+    const auto& src_b = input_tensors[1].mesh_tensor();
 
-    bool src0_sharded = input_tensors[0].is_sharded();
-    bool src1_sharded = input_tensors[1].is_sharded();
-    bool out_sharded = output_tensors[0].is_sharded();
+    bool src0_sharded = src_a.is_sharded();
+    bool src1_sharded = src_b.is_sharded();
+    bool out_sharded = output_tensors[0].mesh_tensor().is_sharded();
 
     // Manually unroll sender core
     if (src0_sharded) {
-        UpdateDynamicCircularBufferAddress(program, override_variables.cbs[0], *src_buffer_a);
+        UpdateDynamicCircularBufferAddress(program, override_variables.cbs[0], src_a);
     }
     if (src1_sharded) {
-        if (!global_cb.has_value() && !src_buffer_b->is_dram()) {
-            UpdateDynamicCircularBufferAddress(program, override_variables.cbs[1], *src_buffer_b);
+        if (!global_cb.has_value() && !src_b.memory_config().is_dram()) {
+            UpdateDynamicCircularBufferAddress(program, override_variables.cbs[1], src_b);
         }
     }
     if (out_sharded) {
@@ -2749,8 +2757,8 @@ inline void override_gather_in0_program_parameters(
             // cbs 0 and 1 contain cb_src0 and cb_src1
             // the rest contains the actual output cbs
             const auto& cb_output = override_variables.cbs[i + 2];
-            const auto& out_buffer = output_tensors[i].buffer();
-            UpdateDynamicCircularBufferAddress(program, cb_output, *out_buffer);
+            const auto& out = output_tensors[i].mesh_tensor();
+            UpdateDynamicCircularBufferAddress(program, cb_output, out);
         }
     }
 
@@ -2762,7 +2770,7 @@ inline void override_gather_in0_program_parameters(
         auto& writer_runtime_args = writer_runtime_args_by_core[core.x][core.y];
 
         /* in1 */
-        writer_runtime_args[1] = src_buffer_b->address();
+        writer_runtime_args[1] = src_b.address();
     }
 }
 
@@ -2791,10 +2799,10 @@ void override_program_parameters(
 
 MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t matmul_multi_core_reuse_mcast_1d_optimized_(
     tt_metal::Program& program,
-    const Tensor& a,
-    const std::vector<Tensor>& b_tensors,
-    const std::optional<const Tensor>& bias,
-    const std::vector<Tensor>& output_tensors,
+    const tt::tt_metal::MeshTensor& a,
+    const std::vector<std::reference_wrapper<const tt::tt_metal::MeshTensor>>& b_tensors,
+    const tt::tt_metal::MeshTensor* bias,
+    const std::vector<std::reference_wrapper<const tt::tt_metal::MeshTensor>>& output_tensors,
     bool bcast_batch,
     bool transpose_a,
     bool transpose_b,
@@ -2820,15 +2828,15 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t matmul_multi_core_
     const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
     uint32_t start_cb_index,
     std::optional<CoreRangeSet> restricted_cores) {
-    const auto& b = b_tensors[0];
-    const auto& output = output_tensors[0];
+    const auto& b = b_tensors[0].get();
+    const auto& output = output_tensors[0].get();
 
     TT_FATAL(output_tensors.size() == b_tensors.size(), "number of outputs must match number of inputs b");
 
-    const auto& ashape = operations::matmul::utilities::get_matmul_tensor_padded_shape(a, transpose_a);
-    const auto& bshape = operations::matmul::utilities::get_matmul_tensor_padded_shape(b, transpose_b);
-    auto in0_tile = operations::matmul::utilities::get_matmul_tile(a, transpose_a);
-    auto in1_tile = operations::matmul::utilities::get_matmul_tile(b, transpose_b);
+    const auto& ashape = operations::matmul::utilities::get_matmul_mesh_tensor_padded_shape(a, transpose_a);
+    const auto& bshape = operations::matmul::utilities::get_matmul_mesh_tensor_padded_shape(b, transpose_b);
+    auto in0_tile = operations::matmul::utilities::get_matmul_mesh_tensor_tile(a, transpose_a);
+    auto in1_tile = operations::matmul::utilities::get_matmul_mesh_tensor_tile(b, transpose_b);
     // cannot use the output tensor tile directly as that might be changed by user override
     auto output_tile = tt::tt_metal::Tile({in0_tile.get_height(), in1_tile.get_width()});
 
@@ -2837,37 +2845,26 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t matmul_multi_core_
     tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(b.dtype());          // in1
     tt::DataFormat output_data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());  // output
 
-    tt_metal::Buffer* bias_buffer = nullptr;
-    tt::DataFormat bias_data_format = tt::DataFormat::Bfp8_b;  // bias; doesn't matter if bias=nullptr
-    if (bias.has_value()) {
-        const auto& c = bias.value();
-        TT_FATAL(
-            c.storage_type() == StorageType::DEVICE,
-            "Bias tensor must be on device, got storage type: {}",
-            c.storage_type());
-        TT_FATAL(a.device() == c.device(), "Operands to matmul need to be on the same device!");
-        TT_FATAL(c.buffer() != nullptr, "Operands to matmul need to be allocated in buffers on device!");
-
-        bias_buffer = c.buffer();
-
-        bias_data_format = tt_metal::datatype_to_dataformat_converter(c.dtype());
+    const tt::tt_metal::MeshTensor* bias_tensor = nullptr;
+    tt::DataFormat bias_data_format = tt::DataFormat::Bfp8_b;  // bias; doesn't matter if bias is not allocated
+    if (bias != nullptr && bias->is_allocated()) {
+        bias_tensor = bias;
+        bias_data_format = tt_metal::datatype_to_dataformat_converter(bias->dtype());
     }
 
-    tt_metal::IDevice* device = a.device();
+    tt_metal::IDevice* device = const_cast<tt_metal::distributed::MeshDevice*>(&a.device());
 
     uint32_t in0_single_tile_size = in0_tile.get_tile_size(in0_data_format);
     uint32_t in1_single_tile_size = in1_tile.get_tile_size(in1_data_format);
-    tt_metal::Buffer* in0_buffer = a.buffer();
-    tt_metal::Buffer* in1_buffer = b.buffer();
     TT_FATAL(
-        in0_buffer->size() % in0_single_tile_size == 0,
+        a.mesh_buffer()->size() % in0_single_tile_size == 0,
         "Input A buffer size ({}) must be divisible by single tile size ({})",
-        in0_buffer->size(),
+        a.mesh_buffer()->size(),
         in0_single_tile_size);
     TT_FATAL(
-        in1_buffer->size() % in1_single_tile_size == 0,
+        b.mesh_buffer()->size() % in1_single_tile_size == 0,
         "Input B buffer size ({}) must be divisible by single tile size ({})",
-        in1_buffer->size(),
+        b.mesh_buffer()->size(),
         in1_single_tile_size);
 
     TT_FATAL(
@@ -2934,8 +2931,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t matmul_multi_core_
     ////////////////////////////////////////////////////////////////////////////
     //                      Grayskull Device Setup
     ////////////////////////////////////////////////////////////////////////////
-    tt_metal::Buffer* out_buffer = output.buffer();
-    TT_FATAL(out_buffer != nullptr, "Output buffer should be allocated on device!");
+    TT_FATAL(output.is_allocated(), "Output buffer should be allocated on device!");
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Application Setup
@@ -2950,11 +2946,6 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t matmul_multi_core_
             !transpose_b,
             "Transpose B is ({}) not supported for gather_in0, please use a different program configuration",
             transpose_b);
-        std::vector<tt_metal::Buffer*> out_buffers;
-        out_buffers.reserve(output_tensors.size());
-        for (const auto& output_tensor : output_tensors) {
-            out_buffers.push_back(output_tensor.buffer());
-        }
         return reuse_mcast_1d_optimized_helpers::process_gather_in0_program_and_create_override_variables(
             program,
             a,
@@ -2980,9 +2971,9 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t matmul_multi_core_
             per_core_N,
             fused_activation,
             hop_cores,
-            in0_buffer,
-            in1_buffer,
-            out_buffers,
+            a,
+            b,
+            output_tensors,
             in0_tile,
             in1_tile,
             output_tile,
@@ -3035,22 +3026,22 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t matmul_multi_core_
             per_core_M,
             per_core_N,
             fused_activation,
-            in0_buffer,
-            in1_buffer,
-            bias_buffer,
-            out_buffer,
+            a,
+            b,
+            bias,
+            output,
             in0_tile,
             in1_tile,
-            bias.has_value() ? bias->tensor_spec().tile() : output_tile,
+            bias_tensor != nullptr ? bias_tensor->tensor_spec().tile() : output_tile,
             output_tile,
             in0_data_format,
             in1_data_format,
             bias_data_format,
             output_data_format,
-            a.memory_config().is_sharded(),
-            b.memory_config().is_sharded(),
-            bias.has_value() ? bias->memory_config().is_sharded() : false,
-            output.memory_config().is_sharded(),
+            a.is_sharded(),
+            b.is_sharded(),
+            bias_tensor != nullptr ? bias_tensor->is_sharded() : false,
+            output.is_sharded(),
             untilize_out,
             fused_op_signaler,
             sub_device_start_core);
@@ -3080,20 +3071,20 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t matmul_multi_core_
         per_core_M,
         per_core_N,
         fused_activation,
-        in0_buffer,
-        in1_buffer,
-        bias_buffer,
-        out_buffer,
+        a,
+        b,
+        bias,
+        output,
         in0_tile,
         in1_tile,
-        bias.has_value() ? bias->tensor_spec().tile() : output_tile,
+        bias_tensor != nullptr ? bias_tensor->tensor_spec().tile() : output_tile,
         output_tile,
         in0_data_format,
         in1_data_format,
         bias_data_format,
         output_data_format,
-        a.memory_config().is_sharded(),
-        output.memory_config().is_sharded(),
+        a.is_sharded(),
+        output.is_sharded(),
         untilize_out,
         sub_device_start_core);
 }
@@ -3109,13 +3100,28 @@ MatmulMultiCoreReuseMcast1DProgramFactory::cached_program_t MatmulMultiCoreReuse
     tt_metal::Program program{};
     std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler> empty_fused_op_signaler = std::nullopt;
 
-    auto b_tensors = std::vector<Tensor>{tensor_args.input_tensors.begin() + 1, tensor_args.input_tensors.end()};
+    const auto& a = tensor_args.input_tensors.at(0).mesh_tensor();
+    std::vector<std::reference_wrapper<const tt::tt_metal::MeshTensor>> b_tensors;
+    b_tensors.reserve(tensor_args.input_tensors.size() - 1);
+    for (size_t i = 1; i < tensor_args.input_tensors.size(); ++i) {
+        b_tensors.emplace_back(tensor_args.input_tensors.at(i).mesh_tensor());
+    }
+    const tt::tt_metal::MeshTensor* bias = nullptr;
+    if (tensor_args.optional_input_tensors.at(0).has_value()) {
+        bias = &tensor_args.optional_input_tensors.at(0)->mesh_tensor();
+    }
+    std::vector<std::reference_wrapper<const tt::tt_metal::MeshTensor>> output_tensors;
+    output_tensors.reserve(tensor_return_value.size());
+    for (auto& t : tensor_return_value) {
+        output_tensors.emplace_back(t.mesh_tensor());
+    }
+
     auto shared_vars = matmul_multi_core_reuse_mcast_1d_optimized_(
         program,
-        tensor_args.input_tensors.at(0),
+        a,
         b_tensors,
-        tensor_args.optional_input_tensors.at(0),
-        tensor_return_value,
+        bias,
+        output_tensors,
         operation_attributes.bcast_batch.value_or(false),
         operation_attributes.transpose_a,
         operation_attributes.transpose_b,
@@ -3170,10 +3176,10 @@ void MatmulMultiCoreReuseMcast1DProgramFactory::override_runtime_arguments(
 
 MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t matmul_multi_core_reuse_mcast_1d_optimized_helper(
     tt_metal::Program& program,
-    const Tensor& a,
-    const std::vector<Tensor>& b_tensors,
-    const std::optional<const Tensor>& bias,
-    const std::vector<Tensor>& output_tensors,
+    const tt::tt_metal::MeshTensor& a,
+    const std::vector<std::reference_wrapper<const tt::tt_metal::MeshTensor>>& b_tensors,
+    const tt::tt_metal::MeshTensor* bias,
+    const std::vector<std::reference_wrapper<const tt::tt_metal::MeshTensor>>& output_tensors,
     bool broadcast_batch,
     DeviceComputeKernelConfig compute_kernel_config,
     const operations::matmul::MatmulProgramConfig& program_config,
@@ -3254,10 +3260,10 @@ void MatmulMeshWorkloadMultiCoreReuseMcast1DProgramFactory::override_runtime_arg
 
 MatmulMultiCoreReuseMcast1DProgramFactory::cached_program_t matmul_multi_core_reuse_mcast_1d_optimized_helper(
     tt_metal::Program& program,
-    const Tensor& a,
-    const std::vector<Tensor>& b_tensors,
-    const std::optional<const Tensor>& bias,
-    const std::vector<Tensor>& output_tensors,
+    const tt::tt_metal::MeshTensor& a,
+    const std::vector<std::reference_wrapper<const tt::tt_metal::MeshTensor>>& b_tensors,
+    const tt::tt_metal::MeshTensor* bias,
+    const std::vector<std::reference_wrapper<const tt::tt_metal::MeshTensor>>& output_tensors,
     bool broadcast_batch,
     DeviceComputeKernelConfig compute_kernel_config,
     const operations::matmul::MatmulProgramConfig& program_config,

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <functional>
+
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/matmul/device/matmul_device_operation_types.hpp"
 #include "ttnn/operations/ccl/ccl_op_fusion.hpp"
@@ -64,10 +66,10 @@ struct MatmulMeshWorkloadMultiCoreReuseMcast1DProgramFactory {
 
 MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t matmul_multi_core_reuse_mcast_1d_optimized_helper(
     tt::tt_metal::Program& program,
-    const Tensor& a,
-    const std::vector<Tensor>& b_tensors,
-    const std::optional<const Tensor>& bias,
-    const std::vector<Tensor>& output_tensors,
+    const tt::tt_metal::MeshTensor& a,
+    const std::vector<std::reference_wrapper<const tt::tt_metal::MeshTensor>>& b_tensors,
+    const tt::tt_metal::MeshTensor* bias,
+    const std::vector<std::reference_wrapper<const tt::tt_metal::MeshTensor>>& output_tensors,
     bool broadcast_batch,
     DeviceComputeKernelConfig compute_kernel_config,
     const operations::matmul::MatmulProgramConfig& program_config,
@@ -80,10 +82,10 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t matmul_multi_core_
 
 MatmulMultiCoreReuseMcast1DProgramFactory::cached_program_t matmul_multi_core_reuse_mcast_1d_optimized_helper(
     tt::tt_metal::Program& program,
-    const Tensor& a,
-    const std::vector<Tensor>& b_tensors,
-    const std::optional<const Tensor>& bias,
-    const std::vector<Tensor>& output_tensors,
+    const tt::tt_metal::MeshTensor& a,
+    const std::vector<std::reference_wrapper<const tt::tt_metal::MeshTensor>>& b_tensors,
+    const tt::tt_metal::MeshTensor* bias,
+    const std::vector<std::reference_wrapper<const tt::tt_metal::MeshTensor>>& output_tensors,
     bool broadcast_batch,
     DeviceComputeKernelConfig compute_kernel_config,
     const operations::matmul::MatmulProgramConfig& program_config,

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
@@ -28,7 +28,7 @@ namespace reuse_mcast_optimized_helpers {
 
 MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t create_program_mcast_in0_in1(
     tt::tt_metal::Program& program,
-    tt::tt_metal::IDevice* device,
+    const tt::tt_metal::distributed::MeshDevice& device,
     MathFidelity math_fidelity,
     bool fp32_dest_acc_en,
     bool math_approx_mode,
@@ -51,10 +51,10 @@ MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t create_program_mcast
     uint32_t per_core_N,
     bool transpose_mcast,
     std::optional<UnaryWithParam> fused_activation,
-    tt::tt_metal::Buffer* in0_buffer,
-    tt::tt_metal::Buffer* in1_buffer,
-    tt::tt_metal::Buffer* bias_buffer,
-    tt::tt_metal::Buffer* out_buffer,
+    const tt::tt_metal::MeshTensor& in0_mesh_tensor,
+    const tt::tt_metal::MeshTensor& in1_mesh_tensor,
+    std::optional<std::reference_wrapper<const tt::tt_metal::MeshTensor>> bias_mesh_tensor,
+    const tt::tt_metal::MeshTensor& out_mesh_tensor,
     const tt::tt_metal::Tile& in0_tile,
     const tt::tt_metal::Tile& in1_tile,
     const tt::tt_metal::Tile& bias_tile,
@@ -75,7 +75,7 @@ MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t create_program_mcast
 
     bool fuse_op = fused_op_signaler.has_value();
 
-    TensorMemoryLayout in0_memory_layout = in0_buffer->buffer_layout();
+    TensorMemoryLayout in0_memory_layout = in0_mesh_tensor.memory_config().memory_layout();
 
     uint32_t num_blocks = K / in0_block_w;
 
@@ -83,7 +83,7 @@ MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t create_program_mcast
     // unnecessary overhead for reconfigs are added. Last iteration of l1 accumulation
     // does a spill and reload, so need more than 2 blocks to use l1 acc for packer
     // For bias, last iteration of l1 acc remains in intermediate buffer, does not spill and reload
-    bool packer_l1_acc_en = packer_l1_acc && (((bias_buffer != nullptr) && num_blocks > 1) || (num_blocks > 2));
+    bool packer_l1_acc_en = packer_l1_acc && ((bias_mesh_tensor.has_value() && num_blocks > 1) || (num_blocks > 2));
 
     // if fp32 enabled then we pack fp32 in l1, if not, then we pack fp16 in l1
     tt::DataFormat interm0_data_format = packer_l1_acc_en
@@ -99,10 +99,12 @@ MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t create_program_mcast
     const bool in0_block_sharded = in0_memory_layout == TensorMemoryLayout::BLOCK_SHARDED;
     const bool in0_height_sharded = in0_memory_layout == TensorMemoryLayout::HEIGHT_SHARDED;
     const bool in0_is_sharded = in0_block_sharded || in0_height_sharded;
-    const bool in1_is_width_sharded = in1_buffer->buffer_layout() == TensorMemoryLayout::WIDTH_SHARDED;
-    const bool in1_is_height_sharded = in1_buffer->buffer_layout() == TensorMemoryLayout::HEIGHT_SHARDED;
+    const bool in1_is_width_sharded =
+        in1_mesh_tensor.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED;
+    const bool in1_is_height_sharded =
+        in1_mesh_tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED;
     const bool in1_is_sharded = in1_is_width_sharded || in1_is_height_sharded;
-    const bool output_is_sharded = out_buffer->buffer_layout() == TensorMemoryLayout::BLOCK_SHARDED;
+    const bool output_is_sharded = out_mesh_tensor.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED;
 
     bool do_not_inplace_interm0_out_CB = output_is_sharded && (per_core_M != out_block_h);
 
@@ -140,8 +142,8 @@ MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t create_program_mcast
     uint32_t in0_shard_width_in_tiles = 0;
     uint32_t in0_shard_height_in_tiles = 0;
     if (in0_is_sharded) {
-        in0_shard_width_in_tiles = in0_buffer->shard_spec().shape()[1] / in0_tile.get_width();
-        in0_shard_height_in_tiles = in0_buffer->shard_spec().shape()[0] / in0_tile.get_height();
+        in0_shard_width_in_tiles = in0_mesh_tensor.legacy_shard_spec().value().shape[1] / in0_tile.get_width();
+        in0_shard_height_in_tiles = in0_mesh_tensor.legacy_shard_spec().value().shape[0] / in0_tile.get_height();
         in2_block_tiles = per_core_M * in0_shard_width_in_tiles;
     }
 
@@ -181,7 +183,7 @@ MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t create_program_mcast
     // Only used for in0 block sharded
     std::optional<CoreRange> in0_mcast_cores_without_work_and_not_in_receiver_grid;
     if (in0_block_sharded) {
-        CoreCoord in0_shard_grid = in0_buffer->shard_spec().grid().bounding_box().grid_size();
+        CoreCoord in0_shard_grid = in0_mesh_tensor.legacy_shard_spec().value().grid.bounding_box().grid_size();
         // in0 shard grid already accounts for transpose_mcast
         // ie. If transpose_mcast, in0 width is along y
         in0_sender_num_cores_along_width = transpose_mcast ? in0_shard_grid.y : in0_shard_grid.x;
@@ -199,23 +201,23 @@ MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t create_program_mcast
 
         if (transpose_mcast) {
             in0_mcast_receiver_grid_diff_coord_start =
-                device->worker_core_from_logical_core({start_core_x, start_core_y}).y;
+                device.worker_core_from_logical_core({start_core_x, start_core_y}).y;
             in0_mcast_receiver_grid_diff_coord_end =
-                device->worker_core_from_logical_core({start_core_x, start_core_y + num_blocks_x - 1}).y;
+                device.worker_core_from_logical_core({start_core_x, start_core_y + num_blocks_x - 1}).y;
             in0_mcast_noc_y.reserve(in0_sender_num_cores_along_width);
             for (uint32_t core_idx_y = 0; core_idx_y < in0_sender_num_cores_along_width; ++core_idx_y) {
                 in0_mcast_noc_y.push_back(
-                    device->worker_core_from_logical_core({start_core_x, start_core_y + core_idx_y}).y);
+                    device.worker_core_from_logical_core({start_core_x, start_core_y + core_idx_y}).y);
             }
         } else {
             in0_mcast_receiver_grid_diff_coord_start =
-                device->worker_core_from_logical_core({start_core_x, start_core_y}).x;
+                device.worker_core_from_logical_core({start_core_x, start_core_y}).x;
             in0_mcast_receiver_grid_diff_coord_end =
-                device->worker_core_from_logical_core({start_core_x + num_blocks_x - 1, start_core_y}).x;
+                device.worker_core_from_logical_core({start_core_x + num_blocks_x - 1, start_core_y}).x;
             in0_mcast_noc_x.reserve(in0_sender_num_cores_along_width);
             for (uint32_t core_idx_x = 0; core_idx_x < in0_sender_num_cores_along_width; ++core_idx_x) {
                 in0_mcast_noc_x.push_back(
-                    device->worker_core_from_logical_core({start_core_x + core_idx_x, start_core_y}).x);
+                    device.worker_core_from_logical_core({start_core_x + core_idx_x, start_core_y}).x);
             }
         }
 
@@ -310,7 +312,7 @@ MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t create_program_mcast
     auto in1_mcast_sender_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
     auto in1_mcast_receiver_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
 
-    bool in1_is_dram = in1_buffer->buffer_type() == tt_metal::BufferType::DRAM;
+    bool in1_is_dram = in1_mesh_tensor.memory_config().buffer_type() == tt_metal::BufferType::DRAM;
 
     uint32_t in0_num_subblocks = (out_block_h / out_subblock_h);
     uint32_t in0_block_num_tiles = out_subblock_h * in0_block_w * in0_num_subblocks;
@@ -328,12 +330,13 @@ MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t create_program_mcast
     uint32_t per_core_N_storage = 0;
     uint32_t batches_per_bank = 0;
     if (in1_is_sharded and in1_is_dram) {
-        num_dram_banks = device->num_dram_channels();
+        num_dram_banks = device.num_dram_channels();
         if (in1_is_width_sharded) {
             per_core_N_storage = (N + num_dram_banks - 1) / num_dram_banks;
         } else {
             // Height sharded: batches are distributed across DRAM banks
-            uint32_t in1_shard_height_in_tiles = in1_buffer->shard_spec().shape()[0] / in1_tile.get_height();
+            uint32_t in1_shard_height_in_tiles =
+                in1_mesh_tensor.legacy_shard_spec().value().shape[0] / in1_tile.get_height();
             batches_per_bank = in1_shard_height_in_tiles / K;
         }
     }
@@ -421,7 +424,7 @@ MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t create_program_mcast
         };
     }
     in0_sender_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_all_gather()));
-    tt::tt_metal::TensorAccessorArgs(*in0_buffer).append_to(in0_sender_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(in0_mesh_tensor).append_to(in0_sender_compile_time_args);
     tt::tt_metal::TensorAccessorArgs().append_to(in0_sender_compile_time_args);  // placeholder for sparsity
 
     std::vector<uint32_t> in1_sender_writer_compile_time_args = {
@@ -467,7 +470,7 @@ MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t create_program_mcast
         // batch args
         (std::uint32_t)M * N  // MtNt
     };
-    if (bias_buffer != nullptr) {
+    if (bias_mesh_tensor.has_value()) {
         in1_sender_writer_compile_time_args.push_back((std::uint32_t)1);  // in3_tensor_stride_w
     } else {
         in1_sender_writer_compile_time_args.push_back(0);  // Placeholder; not used
@@ -477,11 +480,11 @@ MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t create_program_mcast
     in1_sender_writer_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_reduce_scatter()));
 
     // Append TensorAccessorArgs
-    tt::tt_metal::TensorAccessorArgs(*in1_buffer).append_to(in1_sender_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(in1_mesh_tensor).append_to(in1_sender_writer_compile_time_args);
     tt::tt_metal::TensorAccessorArgs().append_to(in1_sender_writer_compile_time_args);  // placeholder for sparsity
-    tt::tt_metal::TensorAccessorArgs(*out_buffer).append_to(in1_sender_writer_compile_time_args);
-    if (bias_buffer != nullptr) {
-        tt::tt_metal::TensorAccessorArgs(*bias_buffer).append_to(in1_sender_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(out_mesh_tensor).append_to(in1_sender_writer_compile_time_args);
+    if (bias_mesh_tensor.has_value()) {
+        tt::tt_metal::TensorAccessorArgs(bias_mesh_tensor.value().get()).append_to(in1_sender_writer_compile_time_args);
     }
 
     if (in1_is_sharded and in1_is_dram) {
@@ -537,13 +540,13 @@ MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t create_program_mcast
         // batch args
         (std::uint32_t)M * N  // MtNt
     };
-    if (bias_buffer != nullptr) {
+    if (bias_mesh_tensor.has_value()) {
         in1_receiver_writer_compile_time_args.push_back((std::uint32_t)in1_block_w);
     } else {
         in1_receiver_writer_compile_time_args.push_back(0);  // Placeholder; not used
     }
     in1_receiver_writer_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_reduce_scatter()));
-    tt::tt_metal::TensorAccessorArgs(*out_buffer).append_to(in1_receiver_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(out_mesh_tensor).append_to(in1_receiver_writer_compile_time_args);
 
     std::map<std::string, std::string> mm_kernel_defines;
     std::map<std::string, std::string> mm_kernel_in0_sender_sharded_defines;
@@ -551,7 +554,7 @@ MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t create_program_mcast
     std::map<std::string, std::string> mm_kernel_in1_sender_writer_defines;
     std::map<std::string, std::string> mm_kernel_in1_receiver_writer_defines;
     std::map<std::string, std::string> mm_kernel_in1_receiver_writer_other_noc_setup_defines;
-    if (bias_buffer != nullptr) {
+    if (bias_mesh_tensor.has_value()) {
         mm_kernel_defines["FUSE_BIAS"] = "1";
         mm_kernel_in1_sender_writer_defines["FUSE_BIAS"] = "1";
         mm_kernel_in1_receiver_writer_defines["FUSE_BIAS"] = "1";
@@ -581,9 +584,9 @@ MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t create_program_mcast
     }
 
     ttnn::operations::compute_throttle_utils::add_stagger_defines_if_needed(
-        device->arch(), cores.size(), mm_kernel_defines);
+        device.arch(), cores.size(), mm_kernel_defines);
     ttnn::operations::compute_throttle_utils::throttle_mm_perf(
-        device->arch(), cores.size(), mm_kernel_defines, throttle_level);
+        device.arch(), cores.size(), mm_kernel_defines, throttle_level);
 
     if (in0_receiver_interleaved.num_cores() == 0) {
         mm_kernel_in0_sender_interleaved_defines["SKIP_MCAST"] = "1";
@@ -637,7 +640,7 @@ MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t create_program_mcast
     */
     bool in0_needs_intermediate_cb_read = false;
     bool in1_needs_intermediate_cb_read = false;
-    if (device->arch() == tt::ARCH::BLACKHOLE) {
+    if (device.arch() == tt::ARCH::BLACKHOLE) {
         in0_needs_intermediate_cb_read = ((in0_single_tile_size % 64) != 0);
         if (in0_needs_intermediate_cb_read) {
             mm_kernel_in0_sender_interleaved_defines["INTERMEDIATE_CB_READ"] = "1";
@@ -649,10 +652,10 @@ MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t create_program_mcast
     }
 
     // in1 is the reader of weights/output writer, and we choose to make it use the optimized reader noc
-    tt_metal::NOC in0_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(device->arch());
-    tt_metal::NOC in1_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
-    tt_metal::NOC in0_split_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
-    tt_metal::NOC in1_split_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(device->arch());
+    tt_metal::NOC in0_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(device.arch());
+    tt_metal::NOC in1_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device.arch());
+    tt_metal::NOC in0_split_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device.arch());
+    tt_metal::NOC in1_split_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(device.arch());
 
     tt::tt_metal::KernelHandle mm_kernel_in0_sender_id = 0;
     tt::tt_metal::KernelHandle mm_kernel_in0_mcast_cores_without_work_and_not_in_receiver_grid_id = 0;
@@ -695,9 +698,9 @@ MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t create_program_mcast
         if (fuse_op) {
             if (fused_op_signaler->is_all_gather()) {
                 // Create semaphores
-                fused_op_signaler->init_fused_op(program, device, in0_sender_interleaved);
+                fused_op_signaler->init_fused_op(program, &device, in0_sender_interleaved);
             } else if (fused_op_signaler->is_reduce_scatter()) {
-                fused_op_signaler->init_fused_op(program, device, all_cores, cores);
+                fused_op_signaler->init_fused_op(program, &device, all_cores, cores);
             } else {
                 TT_FATAL(false, "Fused operation must be either all_gather or reduce_scatter.");
             }
@@ -873,7 +876,7 @@ MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t create_program_mcast
             .set_page_size(src0_cb_index, in0_single_tile_size)
             .set_tile_dims(src0_cb_index, in0_tile);
     if (in0_height_sharded) {
-        src0_cb_config.set_globally_allocated_address(*in0_buffer);
+        src0_cb_config.set_globally_allocated_address(in0_mesh_tensor);
     }
     tt_metal::CreateCircularBuffer(program, all_cores, src0_cb_config);
     log_debug(
@@ -890,7 +893,7 @@ MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t create_program_mcast
             .set_page_size(src1_cb_index, in1_single_tile_size)
             .set_tile_dims(src1_cb_index, in1_tile);
     if (in1_is_sharded and not in1_is_dram) {
-        src1_cb_config.set_globally_allocated_address(*in1_buffer);
+        src1_cb_config.set_globally_allocated_address(in1_mesh_tensor);
     }
     tt_metal::CreateCircularBuffer(program, all_cores, src1_cb_config);
     log_debug(
@@ -907,7 +910,7 @@ MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t create_program_mcast
         tt_metal::CircularBufferConfig src2_cb_config =
             tt_metal::CircularBufferConfig(in2_CB_size, {{src2_cb_index, in0_data_format}})
                 .set_page_size(src2_cb_index, in0_single_tile_size)
-                .set_globally_allocated_address(*in0_buffer)
+                .set_globally_allocated_address(in0_mesh_tensor)
                 .set_tile_dims(src2_cb_index, in0_tile);
         cb_src2 = tt_metal::CreateCircularBuffer(program, all_cores, src2_cb_config);
         log_debug(
@@ -970,7 +973,7 @@ MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t create_program_mcast
     }
 
     if (output_is_sharded) {
-        output_cb_config = output_cb_config.set_globally_allocated_address(*out_buffer);
+        output_cb_config = output_cb_config.set_globally_allocated_address(out_mesh_tensor);
     }
     auto cb_output = tt_metal::CreateCircularBuffer(program, CoreRangeSet({all_cores}), output_cb_config);
     log_debug(
@@ -982,7 +985,7 @@ MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t create_program_mcast
         out_CB_size);
 
     // CB for bias
-    if (bias_buffer != nullptr) {
+    if (bias_mesh_tensor.has_value()) {
         uint32_t src3_cb_index = tt::CBIndex::c_3;
         tt_metal::CircularBufferConfig cb_src3_config =
             tt_metal::CircularBufferConfig(in3_CB_size, {{src3_cb_index, bias_data_format}})
@@ -1079,12 +1082,12 @@ MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t create_program_mcast
         CoreCoord top_core_plus_one = {(std::size_t)core.x, (std::size_t)start_core_y + 1};
         CoreCoord bottom_core = {(std::size_t)core.x, (std::size_t)start_core_y + num_cores_with_work_r - 1};
 
-        auto left_core_physical = device->worker_core_from_logical_core(left_core);
-        auto left_core_plus_one_physical = device->worker_core_from_logical_core(left_core_plus_one);
-        auto right_core_physical = device->worker_core_from_logical_core(right_core);
-        auto top_core_physical = device->worker_core_from_logical_core(top_core);
-        auto top_core_plus_one_physical = device->worker_core_from_logical_core(top_core_plus_one);
-        auto bottom_core_physical = device->worker_core_from_logical_core(bottom_core);
+        auto left_core_physical = device.worker_core_from_logical_core(left_core);
+        auto left_core_plus_one_physical = device.worker_core_from_logical_core(left_core_plus_one);
+        auto right_core_physical = device.worker_core_from_logical_core(right_core);
+        auto top_core_physical = device.worker_core_from_logical_core(top_core);
+        auto top_core_plus_one_physical = device.worker_core_from_logical_core(top_core_plus_one);
+        auto bottom_core_physical = device.worker_core_from_logical_core(bottom_core);
         uint32_t in0_idx = core.y - start_core_y;
         uint32_t in1_idx = core.x - start_core_x;
 
@@ -1117,7 +1120,7 @@ MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t create_program_mcast
             uint32_t in0_mcast_receiver_grid_same_coord;
             std::vector<uint32_t> mm_in0_sender_args;
             if (transpose_mcast) {
-                in0_mcast_receiver_grid_same_coord = device->worker_core_from_logical_core(core).x;
+                in0_mcast_receiver_grid_same_coord = device.worker_core_from_logical_core(core).x;
                 mm_in0_sender_args.push_back(core.y);
                 mm_in0_sender_args.push_back(in0_mcast_receiver_grid_same_coord);
                 mm_in0_sender_args.push_back(in0_mcast_receiver_grid_diff_coord_start);
@@ -1126,7 +1129,7 @@ MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t create_program_mcast
                 mm_in0_sender_args.push_back(in0_mcast_receiver_grid_same_coord);
                 mm_in0_sender_args.insert(mm_in0_sender_args.end(), in0_mcast_noc_y.begin(), in0_mcast_noc_y.end());
             } else {
-                in0_mcast_receiver_grid_same_coord = device->worker_core_from_logical_core(core).y;
+                in0_mcast_receiver_grid_same_coord = device.worker_core_from_logical_core(core).y;
                 mm_in0_sender_args.push_back(core.x);
                 mm_in0_sender_args.push_back(in0_mcast_receiver_grid_diff_coord_start);
                 mm_in0_sender_args.push_back(in0_mcast_receiver_grid_same_coord);
@@ -1148,7 +1151,7 @@ MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t create_program_mcast
         } else if (in1_idx == 0) {
             std::vector<uint32_t> mm_in0_sender_args = {
                 // in0 tensor args
-                (std::uint32_t)in0_buffer->address(),
+                (std::uint32_t)in0_mesh_tensor.address(),
                 (std::uint32_t)in0_tensor_start_tile_id_stride * in0_idx,  // in0_tensor_start_tile_id
                 // in0 mcast args
                 (std::uint32_t)in0_mcast_start.x,  // in0_mcast_dest_noc_start_x
@@ -1196,7 +1199,7 @@ MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t create_program_mcast
                 std::vector<uint32_t> mm_in1_sender_writer_args = {
                     // READER
                     // in1 tensor args
-                    (std::uint32_t)in1_buffer->address(),
+                    (std::uint32_t)in1_mesh_tensor.address(),
                     (std::uint32_t)in1_tensor_start_tile_id_stride * in1_idx,  // in1_tensor_start_tile_id
                     // in1 mcast args
                     (std::uint32_t)in1_mcast_start.x,  // in1_mcast_dest_noc_start_x
@@ -1209,7 +1212,7 @@ MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t create_program_mcast
 
                     // WRITER
                     // out tensor args
-                    (std::uint32_t)out_buffer->address(),
+                    (std::uint32_t)out_mesh_tensor.address(),
                     ((std::uint32_t)in1_idx * per_core_N) + (in0_idx * per_core_M * N)  // out_tensor_start_tile_id
                 };
 
@@ -1241,9 +1244,11 @@ MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t create_program_mcast
                     mm_in1_sender_writer_args.push_back(0);
                 }
 
-                mm_in1_sender_writer_args.push_back(bias_buffer ? (std::uint32_t)bias_buffer->address() : 0);
                 mm_in1_sender_writer_args.push_back(
-                    bias_buffer ? (std::uint32_t)per_core_N * in1_idx : 0);  // in1_tensor_start_tile_id
+                    bias_mesh_tensor.has_value() ? (std::uint32_t)bias_mesh_tensor.value().get().address() : 0);
+                mm_in1_sender_writer_args.push_back(
+                    bias_mesh_tensor.has_value() ? (std::uint32_t)per_core_N * in1_idx
+                                                 : 0);  // in1_tensor_start_tile_id
                 if (!output_is_sharded) {
                     if (in1_idx == in1_end_idx) {  // right cores when no transpose_mcast
                         mm_in1_sender_writer_args.push_back(last_out_num_blocks_w);
@@ -1341,7 +1346,7 @@ MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t create_program_mcast
 
                     // WRITER
                     // out tensor args
-                    (std::uint32_t)out_buffer->address(),                               // out_tensor_addr
+                    (std::uint32_t)out_mesh_tensor.address(),                           // out_tensor_addr
                     ((std::uint32_t)in1_idx * per_core_N) + (in0_idx * per_core_M * N)  // out_tensor_start_tile_id
                 };
 
@@ -1474,28 +1479,24 @@ void override_runtime_arguments_impl(
         input_tensors.size() + optional_input_tensors.size());
     TT_FATAL(output_tensors.size() == 1, "Number of output tensors must be 1, but got {}", output_tensors.size());
 
-    auto* src_buffer_a = input_tensors.at(0).buffer();
-    auto* src_buffer_b = input_tensors.at(1).buffer();
+    const auto& src_a = input_tensors.at(0).mesh_tensor();
+    const auto& src_b = input_tensors.at(1).mesh_tensor();
     const auto& bias_tensor = optional_input_tensors.at(0);
 
-    auto* dst_buffer = output_tensors.at(0).buffer();
+    const auto& dst = output_tensors.at(0).mesh_tensor();
 
-    bool src0_sharded = input_tensors[0].memory_config().is_sharded();
-    bool out_sharded = output_tensors[0].memory_config().is_sharded();
-
-    std::optional<tt::tt_metal::Buffer*> bias_buffer;
-    if (bias_tensor.has_value()) {
-        bias_buffer = bias_tensor.value().buffer();
-    }
+    bool src0_sharded = src_a.is_sharded();
+    bool out_sharded = dst.is_sharded();
 
     // in0 sender
     if (src0_sharded) {
-        UpdateDynamicCircularBufferAddress(program, cb_src2, *src_buffer_a);
+        // API improvement opportunity: UpdateDynamicCircularBufferAddress requires get_reference_buffer()
+        UpdateDynamicCircularBufferAddress(program, cb_src2, src_a);
     } else {
         auto& reader_sender_runtime_args_by_core = GetRuntimeArgs(program, mm_kernel_in0_sender_id);
         for (const auto& core : in0_sender_interleaved_cores) {
             auto& reader_runtime_args = reader_sender_runtime_args_by_core[core.x][core.y];
-            reader_runtime_args[0] = src_buffer_a->address();
+            reader_runtime_args[0] = src_a.address();
         }
     }
 
@@ -1503,10 +1504,10 @@ void override_runtime_arguments_impl(
     auto& sender_writer_runtime_args_by_core = GetRuntimeArgs(program, mm_kernel_in1_sender_writer_id);
     for (const auto& core : in1_sender_cores) {
         auto& writer_runtime_args = sender_writer_runtime_args_by_core[core.x][core.y];
-        writer_runtime_args[0] = src_buffer_b->address();
-        writer_runtime_args[7] = dst_buffer->address();
+        writer_runtime_args[0] = src_b.address();
+        writer_runtime_args[7] = dst.address();
         if (bias_tensor.has_value()) {
-            writer_runtime_args[18] = (*bias_buffer)->address();
+            writer_runtime_args[18] = bias_tensor.value().mesh_tensor().address();
         }
     }
 
@@ -1514,19 +1515,20 @@ void override_runtime_arguments_impl(
     auto& receiver_writer_runtime_args_by_core = GetRuntimeArgs(program, mm_kernel_in1_receiver_writer_id);
     for (const auto& core : in1_receiver_cores) {
         auto& writer_runtime_args = receiver_writer_runtime_args_by_core[core.x][core.y];
-        writer_runtime_args[2] = dst_buffer->address();
+        writer_runtime_args[2] = dst.address();
     }
     if (mm_kernel_in1_receiver_writer_id != mm_kernel_in1_receiver_writer_other_noc_setup_id) {
         auto& receiver_writer_runtime_args_by_core =
             GetRuntimeArgs(program, mm_kernel_in1_receiver_writer_other_noc_setup_id);
         for (const auto& core : in1_receiver_other_cores) {
             auto& writer_runtime_args = receiver_writer_runtime_args_by_core[core.x][core.y];
-            writer_runtime_args[2] = dst_buffer->address();
+            writer_runtime_args[2] = dst.address();
         }
     }
 
     if (out_sharded) {
-        UpdateDynamicCircularBufferAddress(program, cb_output, *dst_buffer);
+        // API improvement opportunity: UpdateDynamicCircularBufferAddress requires get_reference_buffer()
+        UpdateDynamicCircularBufferAddress(program, cb_output, dst);
     }
 }
 }  // namespace reuse_mcast_optimized_helpers
@@ -1540,10 +1542,10 @@ static MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t matmul_multi_
     using namespace tt;
     using namespace operations::matmul::utilities;
 
-    const auto& a = tensor_args.input_tensors.at(0);
-    const auto& b = tensor_args.input_tensors.at(1);
-    const auto& bias = tensor_args.optional_input_tensors.at(0);
-    const auto& output = tensor_return_value.at(0);
+    const auto& a = tensor_args.input_tensors.at(0).mesh_tensor();
+    const auto& b = tensor_args.input_tensors.at(1).mesh_tensor();
+    const auto& bias_tensor = tensor_args.optional_input_tensors.at(0);
+    const auto& output = tensor_return_value.at(0).mesh_tensor();
 
     TT_FATAL(operation_attributes.bcast_batch.has_value(), "Error: bcast_batch field should have been populated");
     TT_FATAL(operation_attributes.program_config.has_value(), "Error: program_config field should have been populated");
@@ -1572,10 +1574,10 @@ static MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t matmul_multi_
     auto untilize_out = operation_attributes.untilize_out;
     // auto fused_op_signaler = std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>();
 
-    const auto& a_shape_padded = get_matmul_tensor_padded_shape(a, transpose_a);
-    const auto& b_shape_padded = get_matmul_tensor_padded_shape(b, transpose_b);
-    const auto in0_tile = get_matmul_tile(a, transpose_a);
-    const auto in1_tile = get_matmul_tile(b, transpose_b);
+    const auto& a_shape_padded = get_matmul_mesh_tensor_padded_shape(a, transpose_a);
+    const auto& b_shape_padded = get_matmul_mesh_tensor_padded_shape(b, transpose_b);
+    const auto in0_tile = get_matmul_mesh_tensor_tile(a, transpose_a);
+    const auto in1_tile = get_matmul_mesh_tensor_tile(b, transpose_b);
 
     // cannot use the output tensor tile directly as that might be changed by user override
     const auto output_tile = tt::tt_metal::Tile({in0_tile.get_height(), in1_tile.get_width()});
@@ -1585,40 +1587,33 @@ static MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t matmul_multi_
     tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(b.dtype());          // in1
     tt::DataFormat output_data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());  // output
 
-    const auto& a_shape_logical = get_matmul_tensor_logical_shape(a, transpose_a);
+    const auto& a_shape_logical = get_matmul_mesh_tensor_logical_shape(a, transpose_a);
     const auto in0_last_ktile_w = a_shape_logical[-1] % in0_tile.get_width();
 
-    tt_metal::Buffer* bias_buffer = nullptr;
+    std::optional<std::reference_wrapper<const tt::tt_metal::MeshTensor>> bias_mesh_tensor = std::nullopt;
     tt::DataFormat bias_data_format = tt::DataFormat::Bfp8_b;  // bias; doesn't matter if bias=nullptr
-    if (bias.has_value()) {
-        const auto& c = bias.value();
-        TT_FATAL(
-            c.storage_type() == StorageType::DEVICE,
-            "Bias tensor must be on device, got storage type: {}",
-            c.storage_type());
-        TT_FATAL(a.device() == c.device(), "Operands to matmul need to be on the same device!");
-        TT_FATAL(c.buffer() != nullptr, "Operands to matmul need to be allocated in buffers on device!");
+    if (bias_tensor.has_value()) {
+        const auto& c = bias_tensor.value().mesh_tensor();
+        TT_FATAL(c.is_allocated(), "Operands to matmul need to be allocated in buffers on device!");
 
-        bias_buffer = c.buffer();
+        bias_mesh_tensor = c;
 
         bias_data_format = tt_metal::datatype_to_dataformat_converter(c.dtype());
     }
 
-    tt_metal::IDevice* device = a.device();
+    const auto& device = a.device();
 
     uint32_t in0_single_tile_size = in0_tile.get_tile_size(in0_data_format);
     uint32_t in1_single_tile_size = in1_tile.get_tile_size(in1_data_format);
-    tt_metal::Buffer* in0_buffer = a.buffer();
-    tt_metal::Buffer* in1_buffer = b.buffer();
     TT_FATAL(
-        in0_buffer->size() % in0_single_tile_size == 0,
+        a.mesh_buffer()->size() % in0_single_tile_size == 0,
         "Input A buffer size ({}) must be divisible by single tile size ({})",
-        in0_buffer->size(),
+        a.mesh_buffer()->size(),
         in0_single_tile_size);
     TT_FATAL(
-        in1_buffer->size() % in1_single_tile_size == 0,
+        b.mesh_buffer()->size() % in1_single_tile_size == 0,
         "Input B buffer size ({}) must be divisible by single tile size ({})",
-        in1_buffer->size(),
+        b.mesh_buffer()->size(),
         in1_single_tile_size);
 
     TT_FATAL(
@@ -1648,7 +1643,7 @@ static MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t matmul_multi_
         in1_tile.get_width());
 
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
-        get_compute_kernel_config_args(device->arch(), compute_kernel_config);
+        get_compute_kernel_config_args(device.arch(), compute_kernel_config);
     ////////////////////////////////////////////////////////////////////////////
     //                      Matmul Parameters Setup
     ////////////////////////////////////////////////////////////////////////////
@@ -1688,15 +1683,14 @@ static MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t matmul_multi_
     ////////////////////////////////////////////////////////////////////////////
     //                      Grayskull Device Setup
     ////////////////////////////////////////////////////////////////////////////
-    tt_metal::Buffer* out_buffer = output.buffer();
-    TT_FATAL(out_buffer != nullptr, "Output buffer should be allocated on device!");
+    TT_FATAL(output.is_allocated(), "Output buffer should be allocated on device!");
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Sub-device start core
     ////////////////////////////////////////////////////////////////////////////
     CoreCoord sub_device_start_core = {0, 0};
     if (operation_attributes.sub_device_id.has_value()) {
-        auto sub_device_cores = device->worker_cores(
+        auto sub_device_cores = device.worker_cores(
             tt::tt_metal::HalProgrammableCoreType::TENSIX, operation_attributes.sub_device_id.value());
         auto bbox = sub_device_cores.bounding_box();
         sub_device_start_core = bbox.start_coord;
@@ -1730,13 +1724,13 @@ static MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t matmul_multi_
         per_core_N,
         transpose_mcast,
         program_config.fused_activation,
-        in0_buffer,
-        in1_buffer,
-        bias_buffer,
-        out_buffer,
+        a,
+        b,
+        bias_mesh_tensor,
+        output,
         in0_tile,
         in1_tile,
-        bias.has_value() ? bias->tensor_spec().tile() : output_tile,
+        bias_tensor.has_value() ? bias_tensor->tensor_spec().tile() : output_tile,
         output_tile,
         in0_data_format,
         in1_data_format,

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
@@ -13,6 +13,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/work_split.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/eltwise/unary/common/unary_op_utils.hpp"
 #include "ttnn/tensor/shape/shape.hpp"
 
@@ -47,10 +48,10 @@ create_program_dram_sharded(
     uint32_t per_core_M,
     uint32_t per_core_N_storage,
     std::optional<UnaryWithParam> fused_activation,
-    tt_metal::Buffer* in0_buffer,
-    tt_metal::Buffer* in1_buffer,
-    tt_metal::Buffer* bias_buffer,
-    tt_metal::Buffer* out_buffer,
+    const tt::tt_metal::MeshTensor& in0,
+    const tt::tt_metal::MeshTensor& in1,
+    const std::optional<std::reference_wrapper<const tt::tt_metal::MeshTensor>>& bias,
+    const tt::tt_metal::MeshTensor& out,
     const tt::tt_metal::Tile& in0_tile,
     const tt::tt_metal::Tile& in1_tile,
     const tt::tt_metal::Tile& bias_tile,
@@ -73,7 +74,8 @@ create_program_dram_sharded(
     // currently only support transpose of the full tile
     bool in1_transpose_tile = in1_tile.get_transpose_of_faces() && in1_tile.get_transpose_within_face();
     TT_FATAL(
-        in1_buffer->shard_spec().orientation() == ShardOrientation::ROW_MAJOR, "Only ROW_MAJOR sharding is supported");
+        in1.legacy_shard_spec().value().orientation == ShardOrientation::ROW_MAJOR,
+        "Only ROW_MAJOR sharding is supported");
 
     tt_metal::Program program{};
 
@@ -114,7 +116,7 @@ create_program_dram_sharded(
     }
 
     // Remove cores assigned to padding-only DRAM banks from the workers category
-    uint32_t in1_shard_width_tiles = in1_buffer->shard_spec().shape()[1] / in1_tile.get_tile_shape()[1];
+    uint32_t in1_shard_width_tiles = in1.legacy_shard_spec().value().shape[1] / in1_tile.get_tile_shape()[1];
     uint32_t in1_tensor_padded_width_tiles = in1_shard_width_tiles * num_dram_banks;
 
     if (in1_tensor_padded_width_tiles > N) {
@@ -215,7 +217,7 @@ create_program_dram_sharded(
     uint32_t out_reshard_CB_tiles = out_reshard_block_tiles;  // No double buffer
     uint32_t out_reshard_CB_size = out_reshard_CB_tiles * output_single_tile_size;
 
-    uint32_t in0_shard_width_in_tiles = in0_buffer->shard_spec().shape()[1] / in0_tile.get_tile_shape()[1];
+    uint32_t in0_shard_width_in_tiles = in0.legacy_shard_spec().value().shape[1] / in0_tile.get_tile_shape()[1];
     uint32_t in2_block_tiles = per_core_M * in0_shard_width_in_tiles;
     uint32_t in2_CB_tiles = in2_block_tiles;
     uint32_t in2_CB_size = in2_CB_tiles * in0_single_tile_size;
@@ -340,7 +342,7 @@ create_program_dram_sharded(
         (std::uint32_t)per_core_N_compute * output_single_tile_size,  // out_tensor_stride_w_bytes
         (std::uint32_t)per_core_N_storage * output_single_tile_size,  // out_reshard_tensor_stride_w_bytes
         (std::uint32_t)per_core_M};
-    if (bias_buffer != nullptr) {
+    if (bias.has_value()) {
         in1_sender_writer_compile_time_args.push_back(bias_buffer_page_size);
         in1_sender_writer_compile_time_args.push_back(bias_buffer_num_pages);
         in1_sender_writer_compile_time_args.push_back((std::uint32_t)1);
@@ -349,7 +351,7 @@ create_program_dram_sharded(
     std::map<std::string, std::string> mm_kernel_defines;
     std::map<std::string, std::string> mm_kernel_in0_sender_define;
     std::map<std::string, std::string> mm_kernel_in1_sender_writer_defines;
-    if (bias_buffer != nullptr) {
+    if (bias.has_value()) {
         mm_kernel_defines["FUSE_BIAS"] = "1";
         mm_kernel_in1_sender_writer_defines["FUSE_BIAS"] = "1";
     }
@@ -510,7 +512,7 @@ create_program_dram_sharded(
         tt_metal::CircularBufferConfig(in2_CB_size, {{src2_cb_index, in0_data_format}})
             .set_page_size(src2_cb_index, in0_single_tile_size)
             .set_tile_dims(src2_cb_index, in0_tile)
-            .set_globally_allocated_address(*in0_buffer);
+            .set_globally_allocated_address(in0);
     auto cb_src2 = tt_metal::CreateCircularBuffer(program, all_cores_in_rect_grid, src2_cb_config);
     log_debug(
         LogOp,
@@ -580,10 +582,10 @@ create_program_dram_sharded(
         tt_metal::CircularBufferConfig(out_reshard_CB_size, output_reshard_cb_data_format_spec)
             .set_page_size(output_reshard_cb_index, output_single_tile_size)
             .set_tile_dims(output_reshard_cb_index, output_tile);
-    output_reshard_cb_config = output_reshard_cb_config.set_globally_allocated_address(*out_buffer);
+    output_reshard_cb_config = output_reshard_cb_config.set_globally_allocated_address(out);
     auto cb_output_reshard = tt_metal::CreateCircularBuffer(program, all_cores_in_rect_grid, output_reshard_cb_config);
 
-    if (bias_buffer != nullptr) {
+    if (bias.has_value()) {
         uint32_t src3_cb_index = tt::CBIndex::c_3;
         tt_metal::CircularBufferConfig cb_src3_config =
             tt_metal::CircularBufferConfig(in3_CB_size, {{src3_cb_index, bias_data_format}})
@@ -739,9 +741,9 @@ create_program_dram_sharded(
         bool is_worker_core = true;
         std::vector<uint32_t> mm_in1_sender_writer_args;
         mm_in1_sender_writer_args.push_back((std::uint32_t)is_worker_core);
-        mm_in1_sender_writer_args.push_back(in1_buffer->address());
-        if (bias_buffer != nullptr) {
-            mm_in1_sender_writer_args.push_back(bias_buffer->address());
+        mm_in1_sender_writer_args.push_back(in1.address());
+        if (bias.has_value()) {
+            mm_in1_sender_writer_args.push_back(bias->get().address());
         } else {
             mm_in1_sender_writer_args.push_back(0);
         }
@@ -908,14 +910,11 @@ matmul_multi_core_reuse_dram_sharded_optimized_(
     const ttnn::prim::MatmulInputs& tensor_args,
     std::vector<ttnn::Tensor>& tensor_return_value,
     const ttnn::prim::MatmulParams& operation_attributes) {
-    const auto& input_tensors = tensor_args.input_tensors;
-    const auto& optional_input_tensors = tensor_args.optional_input_tensors;
-    const auto& output_tensors = tensor_return_value;
-
-    const auto& a = input_tensors.at(0);
-    const auto& b = input_tensors.at(1);
-    const auto& bias = optional_input_tensors.at(0);
-    const auto& output = output_tensors.at(0);
+    // Get MeshTensor references for the migration
+    const auto& a = tensor_args.input_tensors.at(0).mesh_tensor();
+    const auto& b = tensor_args.input_tensors.at(1).mesh_tensor();
+    const auto& bias_opt = tensor_args.optional_input_tensors.at(0);
+    const auto& output = tensor_return_value.at(0).mesh_tensor();
     const auto& ashape = a.padded_shape();
     const auto& bshape = b.padded_shape();
     auto in0_tile = a.tensor_spec().tile();
@@ -930,42 +929,31 @@ matmul_multi_core_reuse_dram_sharded_optimized_(
     tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(b.dtype());          // in1
     tt::DataFormat output_data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());  // output
 
-    tt_metal::Buffer* bias_buffer = nullptr;
+    std::optional<std::reference_wrapper<const tt::tt_metal::MeshTensor>> bias_mesh_tensor = std::nullopt;
     tt::DataFormat bias_data_format = tt::DataFormat::Bfp8_b;  // bias; doesn't matter if bias=nullptr
-    if (bias.has_value()) {
-        const auto& c = bias.value();
-        TT_FATAL(
-            c.storage_type() == StorageType::DEVICE,
-            "Bias tensor must be on device, got storage type: {}",
-            c.storage_type());
-        TT_FATAL(a.device() == c.device(), "Operands to matmul need to be on the same device!");
-        TT_FATAL(c.buffer() != nullptr, "Operands to matmul need to be allocated in buffers on device!");
+    if (bias_opt.has_value()) {
+        const auto& c = bias_opt.value().mesh_tensor();
+        TT_FATAL(c.is_allocated(), "Operands to matmul need to be allocated in buffers on device!");
 
-        bias_buffer = c.buffer();
-
+        bias_mesh_tensor = c;
         bias_data_format = tt_metal::datatype_to_dataformat_converter(c.dtype());
     }
 
-    tt::tt_metal::IDevice* device = reuse_dram_sharded_optimized_helpers::get_device_for_dram_banks(a, mesh_coord);
-
-    TT_FATAL(
-        a.shard_spec().has_value() && output.shard_spec().has_value(), "Both input A and output must have shard specs");
-    CoreRangeSet input_all_cores_storage = a.shard_spec().value().grid;
-    CoreRangeSet output_all_cores_storage = output.shard_spec().value().grid;
+    TT_FATAL(a.is_sharded() && output.is_sharded(), "Both input A and output must have shard specs");
+    CoreRangeSet input_all_cores_storage = a.legacy_shard_spec().value().grid;
+    CoreRangeSet output_all_cores_storage = output.legacy_shard_spec().value().grid;
 
     uint32_t in0_single_tile_size = in0_tile.get_tile_size(in0_data_format);
     uint32_t in1_single_tile_size = in1_tile.get_tile_size(in1_data_format);
-    tt_metal::Buffer* in0_buffer = a.buffer();
-    tt_metal::Buffer* in1_buffer = b.buffer();
     TT_FATAL(
-        in0_buffer->size() % in0_single_tile_size == 0,
+        a.tensor_spec().compute_packed_buffer_size_bytes() % in0_single_tile_size == 0,
         "Input A buffer size ({}) must be divisible by single tile size ({})",
-        in0_buffer->size(),
+        a.tensor_spec().compute_packed_buffer_size_bytes(),
         in0_single_tile_size);
     TT_FATAL(
-        in1_buffer->size() % in1_single_tile_size == 0,
+        b.tensor_spec().compute_packed_buffer_size_bytes() % in1_single_tile_size == 0,
         "Input B buffer size ({}) must be divisible by single tile size ({})",
-        in1_buffer->size(),
+        b.tensor_spec().compute_packed_buffer_size_bytes(),
         in1_single_tile_size);
 
     TT_FATAL(
@@ -994,6 +982,7 @@ matmul_multi_core_reuse_dram_sharded_optimized_(
         bshape[-1],
         in1_tile_shape[1]);
 
+    tt::tt_metal::IDevice* device = reuse_dram_sharded_optimized_helpers::get_device_for_dram_banks(a, mesh_coord);
     const auto& compute_kernel_config = operation_attributes.compute_kernel_config.value();
     const auto& program_config = std::get<operations::matmul::MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig>(
         operation_attributes.program_config.value());
@@ -1026,8 +1015,7 @@ matmul_multi_core_reuse_dram_sharded_optimized_(
     ////////////////////////////////////////////////////////////////////////////
     //                      Grayskull Device Setup
     ////////////////////////////////////////////////////////////////////////////
-    tt_metal::Buffer* out_buffer = output.buffer();
-    TT_FATAL(out_buffer != nullptr, "Output buffer should be allocated on device!");
+    TT_FATAL(output.is_allocated(), "Output buffer should be allocated on device!");
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Application Setup
@@ -1049,13 +1037,13 @@ matmul_multi_core_reuse_dram_sharded_optimized_(
         per_core_M,
         per_core_N,
         fused_activation,
-        in0_buffer,
-        in1_buffer,
-        bias_buffer,
-        out_buffer,
+        a,
+        b,
+        bias_mesh_tensor,
+        output,
         in0_tile,
         in1_tile,
-        bias.has_value() ? bias->tensor_spec().tile() : output_tile,
+        bias_mesh_tensor.has_value() ? bias_mesh_tensor->get().tensor_spec().tile() : output_tile,
         output_tile,
         in0_data_format,
         in1_data_format,
@@ -1092,28 +1080,28 @@ void MatmulMultiCoreReuseMultiCastDRAMShardedProgramFactory::override_runtime_ar
     const ttnn::prim::MatmulParams& /*operation_attributes*/,
     const ttnn::prim::MatmulInputs& tensor_args,
     std::vector<ttnn::Tensor>& tensor_return_value) {
-    const auto& input_tensors = tensor_args.input_tensors;
-    const auto& optional_input_tensors = tensor_args.optional_input_tensors;
-    const auto& output_tensors = tensor_return_value;
+    const auto& a = tensor_args.input_tensors.at(0).mesh_tensor();
+    const auto& b = tensor_args.input_tensors.at(1).mesh_tensor();
+    const auto& bias_opt = tensor_args.optional_input_tensors.at(0);
+    const auto& output = tensor_return_value.at(0).mesh_tensor();
 
     for (auto& [mesh_coord_range, program] : cached_workload.workload.get_programs()) {
         TT_FATAL(
-            input_tensors.size() + optional_input_tensors.size() == 3,
+            tensor_args.input_tensors.size() + tensor_args.optional_input_tensors.size() == 3,
             "Total number of input tensors (required + optional) must be 3, but got {} + {} = {}",
-            input_tensors.size(),
-            optional_input_tensors.size(),
-            input_tensors.size() + optional_input_tensors.size());
-        TT_FATAL(output_tensors.size() == 1, "Number of output tensors must be 1, but got {}", output_tensors.size());
+            tensor_args.input_tensors.size(),
+            tensor_args.optional_input_tensors.size(),
+            tensor_args.input_tensors.size() + tensor_args.optional_input_tensors.size());
+        TT_FATAL(
+            tensor_return_value.size() == 1,
+            "Number of output tensors must be 1, but got {}",
+            tensor_return_value.size());
 
-        auto* src_buffer_a = input_tensors.at(0).buffer();
-        auto* src_buffer_b = input_tensors.at(1).buffer();
-        const auto& bias_tensor = optional_input_tensors.at(0);
-
-        auto* dst_buffer = output_tensors.at(0).buffer();
         auto shared_variables = cached_workload.shared_variables.at(mesh_coord_range);
 
-        UpdateDynamicCircularBufferAddress(program, shared_variables.cb_src2, *src_buffer_a);
-        UpdateDynamicCircularBufferAddress(program, shared_variables.cb_output_reshard, *dst_buffer);
+        // API improvement opportunity: UpdateDynamicCircularBufferAddress requires get_reference_buffer()
+        UpdateDynamicCircularBufferAddress(program, shared_variables.cb_src2, a);
+        UpdateDynamicCircularBufferAddress(program, shared_variables.cb_output_reshard, output);
 
         const auto& all_worker_cores_ordered = shared_variables.all_worker_cores_ordered;
         const auto& writer_kernel_ids = shared_variables.writer_kernel_ids;
@@ -1122,9 +1110,9 @@ void MatmulMultiCoreReuseMultiCastDRAMShardedProgramFactory::override_runtime_ar
             auto core = all_worker_cores_ordered[i];
             auto writer_kernel_id = writer_kernel_ids[i];
             auto& writer_runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-            writer_runtime_args[1] = src_buffer_b->address();
-            if (bias_tensor.has_value()) {
-                writer_runtime_args[2] = bias_tensor.value().buffer()->address();
+            writer_runtime_args[1] = b.address();
+            if (bias_opt.has_value()) {
+                writer_runtime_args[2] = bias_opt.value().mesh_tensor().address();
             } else {
                 writer_runtime_args[2] = 0;
             }

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.cpp
@@ -13,13 +13,11 @@
 #include "ttnn/tensor/shape/shape.hpp"
 
 using namespace tt;
-using tt::tt_metal::Tensor;
 
 namespace ttnn::prim {
 namespace reuse_optimized_helpers {
 
 MatmulMultiCoreReuseOptimizedProgramFactory::cached_program_t create_program(
-    tt_metal::IDevice* device,
     MathFidelity math_fidelity,
     bool fp32_dest_acc_en,
     bool math_approx_mode,
@@ -39,9 +37,9 @@ MatmulMultiCoreReuseOptimizedProgramFactory::cached_program_t create_program(
     uint32_t out_subblock_w,
     uint32_t per_core_M,
     uint32_t per_core_N,
-    const Tensor& in0,
-    const Tensor& in1,
-    const Tensor& output,
+    const tt::tt_metal::MeshTensor& in0,
+    const tt::tt_metal::MeshTensor& in1,
+    const tt::tt_metal::MeshTensor& output,
     const tt::tt_metal::Tile& in0_tile,
     const tt::tt_metal::Tile& in1_tile,
     tt::DataFormat in0_data_format,
@@ -49,6 +47,8 @@ MatmulMultiCoreReuseOptimizedProgramFactory::cached_program_t create_program(
     tt::DataFormat output_data_format,
     bool untilize_out) {
     tt_metal::Program program{};
+
+    const auto& device = in0.device();
 
     // TODO: We can generalize this into some special form of fuse batch, where we have B /= batch_scale_factor and M *=
     // batch_scale_factor
@@ -78,9 +78,6 @@ MatmulMultiCoreReuseOptimizedProgramFactory::cached_program_t create_program(
     uint32_t output_single_tile_size = output_tile.get_tile_size(output_data_format);
     uint32_t interm0_single_tile_size = output_tile.get_tile_size(interm0_data_format);
 
-    tt_metal::Buffer* in0_buffer = in0.buffer();
-    tt_metal::Buffer* in1_buffer = in1.buffer();
-    tt_metal::Buffer* out_buffer = output.buffer();
     bool in0_is_sharded = in0.is_sharded();
     bool in1_is_sharded = in1.is_sharded();
     bool output_is_sharded = output.is_sharded();
@@ -121,11 +118,11 @@ MatmulMultiCoreReuseOptimizedProgramFactory::cached_program_t create_program(
     uint32_t num_output_blocks_total = (B * M / per_core_M) * (N / per_core_N);
     std::optional<tt::tt_metal::ShardSpec> shard_spec = std::nullopt;
     if (in0_is_sharded) {
-        shard_spec = in0.shard_spec().value();
+        shard_spec = in0.legacy_shard_spec().value();
     } else if (in1_is_sharded) {
-        shard_spec = in1.shard_spec().value();
+        shard_spec = in1.legacy_shard_spec().value();
     } else if (output_is_sharded) {
-        shard_spec = output.shard_spec().value();
+        shard_spec = output.legacy_shard_spec().value();
     }
 
     uint32_t num_cores = 0, num_blocks_per_core_group_1 = 0, num_blocks_per_core_group_2 = 0;
@@ -175,7 +172,7 @@ MatmulMultiCoreReuseOptimizedProgramFactory::cached_program_t create_program(
         (std::uint32_t)bcast_batch,
         (std::uint32_t)M * K,  // MtKt
     };
-    tt::tt_metal::TensorAccessorArgs(*in0_buffer).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(in0).append_to(reader_compile_time_args);
 
     std::vector<uint32_t> reader_writer_compile_time_args = {
         (std::uint32_t)in1_tensor_stride_w,
@@ -199,8 +196,8 @@ MatmulMultiCoreReuseOptimizedProgramFactory::cached_program_t create_program(
         (std::uint32_t)out_num_subblocks_h,                // out_num_subblocks_h
         (std::uint32_t)M * N,                              // MtNt
     };
-    tt::tt_metal::TensorAccessorArgs(*in1_buffer).append_to(reader_writer_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(*out_buffer).append_to(reader_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(in1).append_to(reader_writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(output).append_to(reader_writer_compile_time_args);
     std::map<std::string, std::string> mm_kernel_in0_reader_defines;
     std::map<std::string, std::string> mm_kernel_in1_reader_writer_defines;
     if (in0_is_sharded) {
@@ -232,7 +229,7 @@ MatmulMultiCoreReuseOptimizedProgramFactory::cached_program_t create_program(
     */
     bool in0_needs_intermediate_cb_read = false;
     bool in1_needs_intermediate_cb_read = false;
-    if (device->arch() == tt::ARCH::BLACKHOLE) {
+    if (device.arch() == tt::ARCH::BLACKHOLE) {
         in0_needs_intermediate_cb_read = ((in0_single_tile_size % 64) != 0);
         if (in0_needs_intermediate_cb_read) {
             mm_kernel_in0_reader_defines["INTERMEDIATE_CB_READ"] = "1";
@@ -309,9 +306,9 @@ MatmulMultiCoreReuseOptimizedProgramFactory::cached_program_t create_program(
     }
 
     ttnn::operations::compute_throttle_utils::add_stagger_defines_if_needed(
-        device->arch(), num_cores, mm_kernel_defines);
+        device.arch(), num_cores, mm_kernel_defines);
     ttnn::operations::compute_throttle_utils::throttle_mm_perf(
-        device->arch(), num_cores, mm_kernel_defines, throttle_level);
+        device.arch(), num_cores, mm_kernel_defines, throttle_level);
 
     // Named compile args for compute kernels (CB indices)
     std::unordered_map<std::string, uint32_t> compute_named_compile_args = {
@@ -381,7 +378,7 @@ MatmulMultiCoreReuseOptimizedProgramFactory::cached_program_t create_program(
             .set_page_size(src0_cb_index, in0_single_tile_size)
             .set_tile_dims(src0_cb_index, in0_tile);
     if (in0_is_sharded) {
-        cb_src0_config = cb_src0_config.set_globally_allocated_address(*in0_buffer);
+        cb_src0_config = cb_src0_config.set_globally_allocated_address(in0);
     }
     auto cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
 
@@ -391,7 +388,7 @@ MatmulMultiCoreReuseOptimizedProgramFactory::cached_program_t create_program(
             .set_page_size(src1_cb_index, in1_single_tile_size)
             .set_tile_dims(src1_cb_index, in1_tile);
     if (in1_is_sharded) {
-        cb_src1_config = cb_src1_config.set_globally_allocated_address(*in1_buffer);
+        cb_src1_config = cb_src1_config.set_globally_allocated_address(in1);
     }
     auto cb_src1 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src1_config);
 
@@ -437,7 +434,7 @@ MatmulMultiCoreReuseOptimizedProgramFactory::cached_program_t create_program(
     // output_cb_data_format_spec) 	.set_page_size(output_cb_index, output_single_tile_size)
     //     .set_page_size(interm0_cb_index, output_single_tile_size);
     if (output_is_sharded) {
-        output_cb_config = output_cb_config.set_globally_allocated_address(*out_buffer);
+        output_cb_config = output_cb_config.set_globally_allocated_address(output);
     }
     auto cb_output = tt_metal::CreateCircularBuffer(program, CoreRangeSet({all_cores}), output_cb_config);
 
@@ -470,17 +467,17 @@ MatmulMultiCoreReuseOptimizedProgramFactory::cached_program_t create_program(
 
     // Write runtime args to device
     std::vector<uint32_t> mm_reader_args = {
-        (std::uint32_t)in0_buffer->address(),  // in0_tensor_addr
-        (std::uint32_t)0,                      // in0_tensor_start_tile_id placeholder
-        (std::uint32_t)0,                      // batch placeholder
+        (std::uint32_t)in0.address(),  // in0_tensor_addr
+        (std::uint32_t)0,              // in0_tensor_start_tile_id placeholder
+        (std::uint32_t)0,              // batch placeholder
     };
 
     std::vector<uint32_t> mm_writer_args = {
-        (std::uint32_t)in1_buffer->address(),  // in1_tensor_addr
-        (std::uint32_t)0,                      // in1_tensor_start_tile_id placeholder
-        (std::uint32_t)0,                      // batch placeholder
-        (std::uint32_t)out_buffer->address(),  // out_tensor_addr
-        (std::uint32_t)0,                      // out_tensor_start_tile_id placeholder
+        (std::uint32_t)in1.address(),     // in1_tensor_addr
+        (std::uint32_t)0,                 // in1_tensor_start_tile_id placeholder
+        (std::uint32_t)0,                 // batch placeholder
+        (std::uint32_t)output.address(),  // out_tensor_addr
+        (std::uint32_t)0,                 // out_tensor_start_tile_id placeholder
     };
     bool row_major = false;
     if (shard_spec.has_value()) {
@@ -544,9 +541,9 @@ MatmulMultiCoreReuseOptimizedProgramFactory::cached_program_t create_program(
 }  // namespace reuse_optimized_helpers
 
 MatmulMultiCoreReuseOptimizedProgramFactory::cached_program_t matmul_multi_core_reuse_optimized_(
-    const Tensor& a,
-    const Tensor& b,
-    Tensor& output,
+    const tt::tt_metal::MeshTensor& a,
+    const tt::tt_metal::MeshTensor& b,
+    const tt::tt_metal::MeshTensor& output,
     bool bcast_batch,
     bool transpose_a,
     bool transpose_b,
@@ -560,10 +557,10 @@ MatmulMultiCoreReuseOptimizedProgramFactory::cached_program_t matmul_multi_core_
     uint32_t per_core_N,
     bool fuse_batch,
     bool untilize_out) {
-    const auto& ashape = operations::matmul::utilities::get_matmul_tensor_padded_shape(a, transpose_a);
-    const auto& bshape = operations::matmul::utilities::get_matmul_tensor_padded_shape(b, transpose_b);
-    auto in0_tile = operations::matmul::utilities::get_matmul_tile(a, transpose_a);
-    auto in1_tile = operations::matmul::utilities::get_matmul_tile(b, transpose_b);
+    const auto& ashape = operations::matmul::utilities::get_matmul_mesh_tensor_padded_shape(a, transpose_a);
+    const auto& bshape = operations::matmul::utilities::get_matmul_mesh_tensor_padded_shape(b, transpose_b);
+    auto in0_tile = operations::matmul::utilities::get_matmul_mesh_tensor_tile(a, transpose_a);
+    auto in1_tile = operations::matmul::utilities::get_matmul_mesh_tensor_tile(b, transpose_b);
 
     TT_FATAL(
         (bcast_batch == false) or (ashape[0] == 1) or (ashape.rank() == 2),
@@ -574,10 +571,10 @@ MatmulMultiCoreReuseOptimizedProgramFactory::cached_program_t matmul_multi_core_
     tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(b.dtype());        // in1
     tt::DataFormat output_data_format = tt_metal::datatype_to_dataformat_converter(output_dtype);  // output
 
-    tt_metal::IDevice* device = a.device();
+    const auto& device = a.device();
 
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
-        get_compute_kernel_config_args(device->arch(), compute_kernel_config);
+        get_compute_kernel_config_args(device.arch(), compute_kernel_config);
 
     if (fp32_dest_acc_en) {
         TT_FATAL(
@@ -595,7 +592,7 @@ MatmulMultiCoreReuseOptimizedProgramFactory::cached_program_t matmul_multi_core_
     uint32_t Kt = operations::matmul::utilities::get_K_dim(ashape, in0_tile);
     uint32_t Nt = operations::matmul::utilities::get_N_dim(bshape, in1_tile);
 
-    const auto ashape_logical = operations::matmul::utilities::get_matmul_tensor_logical_shape(a, transpose_a);
+    const auto ashape_logical = operations::matmul::utilities::get_matmul_mesh_tensor_logical_shape(a, transpose_a);
     const auto in0_last_ktile_w = ashape_logical[-1] % in0_tile.get_width();
 
     // TODO: Generalize
@@ -609,14 +606,12 @@ MatmulMultiCoreReuseOptimizedProgramFactory::cached_program_t matmul_multi_core_
     //                      Grayskull Device Setup
     ////////////////////////////////////////////////////////////////////////////
     // Pass in cshape instead
-    tt_metal::Buffer* out_buffer = output.buffer();
-    TT_FATAL(out_buffer != nullptr, "Output buffer should be allocated on device!");
+    TT_FATAL(output.is_allocated(), "Output buffer should be allocated on device!");
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Application Setup
     ////////////////////////////////////////////////////////////////////////////
     return reuse_optimized_helpers::create_program(
-        device,
         math_fidelity,
         fp32_dest_acc_en,
         math_approx_mode,
@@ -669,9 +664,9 @@ MatmulMultiCoreReuseOptimizedProgramFactory::cached_program_t MatmulMultiCoreReu
     TT_FATAL(operation_attributes.bcast_batch.has_value(), "Bcast batch should have been provided");
 
     return matmul_multi_core_reuse_optimized_(
-        tensor_args.input_tensors.at(0),
-        tensor_args.input_tensors.at(1),
-        tensor_return_value.at(0),
+        tensor_args.input_tensors.at(0).mesh_tensor(),
+        tensor_args.input_tensors.at(1).mesh_tensor(),
+        tensor_return_value.at(0).mesh_tensor(),
         operation_attributes.bcast_batch.value(),
         operation_attributes.transpose_a,
         operation_attributes.transpose_b,
@@ -701,17 +696,13 @@ void MatmulMultiCoreReuseOptimizedProgramFactory::override_runtime_arguments(
     auto cb_output = shared_variables.cb_output;
     auto cores = shared_variables.cores;
 
-    const auto& input_tensors = tensor_args.input_tensors;
-    const auto& output_tensors = tensor_return_value;
+    const auto& in0 = tensor_args.input_tensors.at(0).mesh_tensor();
+    const auto& in1 = tensor_args.input_tensors.at(1).mesh_tensor();
+    const auto& output = tensor_return_value.at(0).mesh_tensor();
 
-    auto* src_buffer_a = input_tensors.at(0).buffer();
-    auto* src_buffer_b = input_tensors.at(1).buffer();
-
-    auto* dst_buffer = output_tensors.at(0).buffer();
-
-    const bool src0_sharded = input_tensors[0].memory_config().is_sharded();
-    const bool src1_sharded = input_tensors[1].memory_config().is_sharded();
-    const bool out_sharded = output_tensors[0].memory_config().is_sharded();
+    const bool src0_sharded = in0.is_sharded();
+    const bool src1_sharded = in1.is_sharded();
+    const bool out_sharded = output.is_sharded();
 
     const bool update_reader_args = !src0_sharded;
 
@@ -725,26 +716,26 @@ void MatmulMultiCoreReuseOptimizedProgramFactory::override_runtime_arguments(
         for (const auto& core : cores) {
             if (update_reader_args) {
                 auto& runtime_args = reader_runtime_args_by_core[core.x][core.y];
-                runtime_args[0] = src_buffer_a->address();  // in0_tensor_addr
+                runtime_args[0] = in0.address();  // in0_tensor_addr
             }
 
             if (update_writer_args) {
                 auto& runtime_args = writer_runtime_args_by_core[core.x][core.y];
-                runtime_args[0] = src_buffer_b->address();  // in1_tensor_addr
-                runtime_args[3] = dst_buffer->address();    // out_tensor_addr
+                runtime_args[0] = in1.address();     // in1_tensor_addr
+                runtime_args[3] = output.address();  // out_tensor_addr
             }
         }
     }
     if (src0_sharded) {
-        UpdateDynamicCircularBufferAddress(program, cb_src0, *src_buffer_a);
+        UpdateDynamicCircularBufferAddress(program, cb_src0, in0);
     }
 
     if (src1_sharded) {
-        UpdateDynamicCircularBufferAddress(program, cb_src1, *src_buffer_b);
+        UpdateDynamicCircularBufferAddress(program, cb_src1, in1);
     }
 
     if (out_sharded) {
-        UpdateDynamicCircularBufferAddress(program, cb_output, *dst_buffer);
+        UpdateDynamicCircularBufferAddress(program, cb_output, output);
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_program_factory.cpp
@@ -16,7 +16,6 @@ using namespace tt;
 namespace ttnn::prim {
 
 static MatmulMultiCoreReuseProgramFactory::cached_program_t create_program(
-    tt_metal::IDevice* device,
     tt::DataFormat in0_cb_data_format,
     tt::DataFormat in1_cb_data_format,
     tt::DataFormat out_cb_data_format,
@@ -32,10 +31,12 @@ static MatmulMultiCoreReuseProgramFactory::cached_program_t create_program(
     uint32_t out_subblock_w,
     uint32_t per_core_M,
     uint32_t per_core_N,
-    tt_metal::Buffer* in0_buffer,
-    tt_metal::Buffer* in1_buffer,
-    tt_metal::Buffer* out_buffer) {
+    const tt::tt_metal::MeshTensor& in0,
+    const tt::tt_metal::MeshTensor& in1,
+    const tt::tt_metal::MeshTensor& out) {
     tt_metal::Program program{};
+
+    const auto& device = in0.device();
 
     uint32_t in0_single_tile_size = tt::tile_size(in0_cb_data_format);
     uint32_t in1_single_tile_size = tt::tile_size(in1_cb_data_format);
@@ -87,7 +88,7 @@ static MatmulMultiCoreReuseProgramFactory::cached_program_t create_program(
     uint32_t num_blocks_x = N / per_core_N;
 
     CoreRangeSet all_cores(tt::tt_metal::num_cores_to_corerangeset(
-        num_blocks_x * num_blocks_y, device->compute_with_storage_grid_size(), true));
+        num_blocks_x * num_blocks_y, device.compute_with_storage_grid_size(), true));
 
     // Create circular buffers
     uint32_t src0_cb_index = 0;
@@ -113,11 +114,11 @@ static MatmulMultiCoreReuseProgramFactory::cached_program_t create_program(
     tt_metal::CreateCircularBuffer(program, all_cores, output_cb_config);
 
     std::vector<uint32_t> reader_compile_time_args = {};
-    tt::tt_metal::TensorAccessorArgs(*in0_buffer).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(*in1_buffer).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(in0).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(in1).append_to(reader_compile_time_args);
 
     std::vector<uint32_t> writer_compile_time_args = {};
-    tt::tt_metal::TensorAccessorArgs(*out_buffer).append_to(writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(out).append_to(writer_compile_time_args);
 
     // Create reader and writer kernels per core
     auto mm_reader_kernel_id = tt_metal::CreateKernel(
@@ -155,7 +156,7 @@ static MatmulMultiCoreReuseProgramFactory::cached_program_t create_program(
 
             // Write runtime args to device
             std::vector<uint32_t> mm_reader_args = {
-                (std::uint32_t)in0_buffer->address(),          // in0_tensor_addr
+                (std::uint32_t)in0.address(),                  // in0_tensor_addr
                 (std::uint32_t)K * per_core_M * output_idx_y,  // in0_tensor_start_tile_id
                 (std::uint32_t)1,                              // in0_tensor_stride_w
                 (std::uint32_t)K,                              // in0_tensor_stride_h
@@ -165,7 +166,7 @@ static MatmulMultiCoreReuseProgramFactory::cached_program_t create_program(
                 (std::uint32_t)per_core_M,                // in0_block_h
                 (std::uint32_t)in0_block_w * per_core_M,  // in0_block_num_tiles
 
-                (std::uint32_t)in1_buffer->address(),      // in1_tensor_addr
+                (std::uint32_t)in1.address(),              // in1_tensor_addr
                 (std::uint32_t)per_core_N * output_idx_x,  // in1_tensor_start_tile_id
                 (std::uint32_t)1,                          // in1_tensor_stride_w
                 (std::uint32_t)N,                          // in1_tensor_stride_h
@@ -184,7 +185,7 @@ static MatmulMultiCoreReuseProgramFactory::cached_program_t create_program(
             };
 
             std::vector<uint32_t> writer_args = {
-                (std::uint32_t)out_buffer->address(),  // out_tensor_addr
+                (std::uint32_t)out.address(),  // out_tensor_addr
                 ((std::uint32_t)output_idx_x * per_core_N) +
                     (output_idx_y * per_core_M * N),  // out_tensor_start_tile_id
                 (std::uint32_t)1,                     // out_tensor_stride_w
@@ -220,11 +221,12 @@ void MatmulMultiCoreReuseProgramFactory::override_runtime_arguments(
     constexpr uint32_t per_core_M = 16;
     constexpr uint32_t per_core_N = 16;
 
-    const auto& input_tensors = tensor_args.input_tensors;
-    const auto& output_tensors = tensor_return_value;
+    const auto& a = tensor_args.input_tensors.at(0).mesh_tensor();
+    const auto& b = tensor_args.input_tensors.at(1).mesh_tensor();
+    const auto& output = tensor_return_value.at(0).mesh_tensor();
 
-    const auto& ashape = input_tensors.at(0).padded_shape();
-    const auto& bshape = input_tensors.at(1).padded_shape();
+    const auto& ashape = a.padded_shape();
+    const auto& bshape = b.padded_shape();
     uint32_t M = ashape[-2] / TILE_HEIGHT;
     uint32_t N = bshape[-1] / TILE_WIDTH;
 
@@ -232,11 +234,6 @@ void MatmulMultiCoreReuseProgramFactory::override_runtime_arguments(
 
     uint32_t num_blocks_y = M / per_core_M;
     uint32_t num_blocks_x = N / per_core_N;
-
-    auto* src_dram_buffer_a = input_tensors.at(0).buffer();
-    auto* src_dram_buffer_b = input_tensors.at(1).buffer();
-
-    auto* dst_dram_buffer = output_tensors.at(0).buffer();
 
     auto& program = cached_program.program;
     auto& reader_kernel_id = cached_program.shared_variables.reader_kernel_id;
@@ -251,13 +248,13 @@ void MatmulMultiCoreReuseProgramFactory::override_runtime_arguments(
 
             {
                 auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-                runtime_args[0] = src_dram_buffer_a->address();
-                runtime_args[8] = src_dram_buffer_b->address();
+                runtime_args[0] = a.address();
+                runtime_args[8] = b.address();
             }
 
             {
                 auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-                runtime_args[0] = dst_dram_buffer->address();
+                runtime_args[0] = output.address();
             }
             num_blocks_read++;
         }
@@ -271,9 +268,9 @@ MatmulMultiCoreReuseProgramFactory::cached_program_t MatmulMultiCoreReuseProgram
     TT_FATAL(operation_attributes.bcast_batch.has_value(), "Error: bcast_batch field should have been populated");
     bool bcast_batch = operation_attributes.bcast_batch.value();
 
-    const auto& a = tensor_args.input_tensors.at(0);
-    const auto& b = tensor_args.input_tensors.at(1);
-    const auto& output = tensor_return_value.at(0);
+    const auto& a = tensor_args.input_tensors.at(0).mesh_tensor();
+    const auto& b = tensor_args.input_tensors.at(1).mesh_tensor();
+    const auto& output = tensor_return_value.at(0).mesh_tensor();
     const auto& ashape = a.padded_shape();
     const auto& bshape = b.padded_shape();
 
@@ -281,9 +278,6 @@ MatmulMultiCoreReuseProgramFactory::cached_program_t MatmulMultiCoreReuseProgram
     tt::DataFormat in1_cb_data_format = tt_metal::datatype_to_dataformat_converter(b.dtype());
     tt::DataFormat out_cb_data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());
     MathFidelity math_fidelity = MathFidelity::HiFi4;
-
-    tt_metal::Buffer* in0_buffer = a.buffer();
-    tt_metal::Buffer* in1_buffer = b.buffer();
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Matmul Parameters Setup
@@ -305,8 +299,8 @@ MatmulMultiCoreReuseProgramFactory::cached_program_t MatmulMultiCoreReuseProgram
     TT_FATAL(Kt % in0_block_w == 0, "Kt ({}) must be divisible by in0_block_w ({})", Kt, in0_block_w);
 
     // This should allocate a DRAM buffer on the device
-    tt_metal::IDevice* device = a.device();
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    const auto& device = a.device();
+    auto compute_with_storage_grid_size = device.compute_with_storage_grid_size();
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
 
@@ -320,15 +314,13 @@ MatmulMultiCoreReuseProgramFactory::cached_program_t MatmulMultiCoreReuseProgram
     ////////////////////////////////////////////////////////////////////////////
     //                      Grayskull Device Setup
     ////////////////////////////////////////////////////////////////////////////
-    tt_metal::Buffer* out_buffer = output.buffer();
-    TT_FATAL(out_buffer != nullptr, "Output buffer should be allocated on device!");
+    TT_FATAL(output.is_allocated(), "Output buffer should be allocated on device!");
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Application Setup
     ////////////////////////////////////////////////////////////////////////////
 
     return create_program(
-        device,
         in0_cb_data_format,
         in1_cb_data_format,
         out_cb_data_format,
@@ -344,9 +336,9 @@ MatmulMultiCoreReuseProgramFactory::cached_program_t MatmulMultiCoreReuseProgram
         out_subblock_w,
         per_core_M,
         per_core_N,
-        in0_buffer,
-        in1_buffer,
-        out_buffer);
+        a,
+        b,
+        output);
 }
 
 ////////////////////////////////////////////////////////////////////////////

--- a/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.cpp
@@ -236,13 +236,13 @@ tt::tt_metal::Tile get_matmul_tile(const Tensor& input_tensor, bool transpose) {
 
 namespace ttnn::prim::dram_sharded_helpers {
 
-tt::tt_metal::IDevice* get_device_for_dram_banks(const ttnn::Tensor& a, const ttnn::MeshCoordinate& coord) {
-    ttnn::distributed::MeshDevice* device = a.device();
-    const ttnn::distributed::MeshDeviceView& view = device->get_view();
+tt::tt_metal::IDevice* get_device_for_dram_banks(const tt::tt_metal::MeshTensor& a, const ttnn::MeshCoordinate& coord) {
+    const tt::tt_metal::distributed::MeshDevice& device = a.device();
+    const ttnn::distributed::MeshDeviceView& view = device.get_view();
     if (!view.contains(coord) || !view.is_local(coord)) {
-        return device;
+        return const_cast<tt::tt_metal::distributed::MeshDevice*>(&device);
     }
-    return a.device()->get_device(coord);
+    return device.get_device(coord);
 }
 
 void get_max_page_size_and_num_pages(

--- a/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.hpp
@@ -8,6 +8,7 @@
 
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/distributed/types.hpp"
+#include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
 
@@ -153,6 +154,68 @@ inline ttnn::Shape get_matmul_tensor_logical_shape(const Tensor& input_tensor, b
     return shape;
 }
 
+/**
+ * @brief Get the padded shape of a MeshTensor, with optional transpose.
+ *
+ * Returns the padded shape of the tensor. If transpose is true, the padded shape dimensions are swapped.
+ *
+ * @param input_tensor The MeshTensor whose padded shape is queried.
+ * @param transpose Whether to return the padded shape after transposing (swap height and width).
+ * @return ttnn::Shape The padded shape of the tensor, possibly transposed.
+ */
+inline ttnn::Shape get_matmul_mesh_tensor_padded_shape(const tt::tt_metal::MeshTensor& input_tensor, bool transpose) {
+    auto padded_shape = input_tensor.padded_shape();
+    if (transpose) {
+        std::swap(padded_shape[-2], padded_shape[-1]);
+    }
+    return padded_shape;
+}
+
+/**
+ * @brief Get the tile shape of a MeshTensor, with optional transpose.
+ *
+ * Returns a tile representing the height and width of the tensor's tile. If transpose is true,
+ * the tile shape dimensions are swapped.
+ *
+ * @param input_tensor The MeshTensor whose tile shape is queried.
+ * @param transpose Whether to return the tile shape after transposing (swap height and width).
+ * @return tt::tt_metal::Tile The tile shape of the tensor, possibly transposed.
+ */
+inline tt::tt_metal::Tile get_matmul_mesh_tensor_tile(const tt::tt_metal::MeshTensor& input_tensor, bool transpose) {
+    auto curr_tile = input_tensor.tensor_spec().tile();
+    if (!transpose) {
+        return curr_tile;
+    }
+
+    // If the tile is already transposed and we are asked to transpose it again,
+    // the result should be the original orientation (double-transpose cancels out).
+    // Therefore, we negate the transpose flag.
+    const auto transpose_was_set = curr_tile.get_transpose_of_faces();
+    TT_FATAL(
+        (!transpose_was_set) || curr_tile.get_transpose_within_face(),
+        "The tile spec must have both transpose_within_face {} and transpose_of_faces {} set or neither set",
+        curr_tile.get_transpose_within_face(),
+        curr_tile.get_transpose_of_faces());
+    return tt::tt_metal::Tile({curr_tile.get_width(), curr_tile.get_height()}, !transpose_was_set);
+}
+
+/**
+ * @brief Get the shape of a MeshTensor, with optional transpose.
+ *
+ * Returns the logical shape of the tensor. If transpose is true, the shape dimensions are swapped.
+ *
+ * @param input_tensor The MeshTensor whose shape is queried.
+ * @param transpose Whether to return the shape after transposing (swap height and width).
+ * @return ttnn::Shape The shape of the tensor, possibly transposed.
+ */
+inline ttnn::Shape get_matmul_mesh_tensor_logical_shape(const tt::tt_metal::MeshTensor& input_tensor, bool transpose) {
+    auto shape = input_tensor.logical_shape();
+    if (transpose) {
+        std::swap(shape[-2], shape[-1]);
+    }
+    return shape;
+}
+
 }  // namespace ttnn::operations::matmul::utilities
 
 namespace ttnn::prim::dram_sharded_helpers {
@@ -160,7 +223,7 @@ namespace ttnn::prim::dram_sharded_helpers {
 // Treat it as a one off patch to restore functionality that
 // was adjusted to fix one P0 causing another P0.
 // TODO: Proper fix will be implemented in Issue #32205
-tt::tt_metal::IDevice* get_device_for_dram_banks(const ttnn::Tensor& a, const ttnn::MeshCoordinate& coord);
+tt::tt_metal::IDevice* get_device_for_dram_banks(const tt::tt_metal::MeshTensor& a, const ttnn::MeshCoordinate& coord);
 
 void get_max_page_size_and_num_pages(
     tt::tt_metal::IDevice* device, uint32_t num_tiles, uint32_t tile_size, uint32_t& page_size, uint32_t& num_pages);


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/runtime-tensor-dropout)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/runtime-tensor-dropout)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu/runtime-tensor-dropout)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/runtime-tensor-dropout)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/runtime-tensor-dropout)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/runtime-tensor-dropout)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/runtime-tensor-dropout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/runtime-tensor-dropout)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/runtime-tensor-dropout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/runtime-tensor-dropout)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/runtime-tensor-dropout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/runtime-tensor-dropout)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
