### PR TITLE
Adding real weight + real io test to Deepseek MoE module test

### DIFF
--- a/models/demos/deepseek_v3/tests/test_moe.py
+++ b/models/demos/deepseek_v3/tests/test_moe.py
@@ -15,7 +15,7 @@ from models.demos.deepseek_v3.reference.modeling_deepseek import DeepseekV3MoE
 from models.demos.deepseek_v3.tests.pytest_utils import DEFAULT_PREFILL_SEQ_LEN
 from models.demos.deepseek_v3.tt.model.row_batched_model import get_fabric_config
 from models.demos.deepseek_v3.tt.moe import MoE
-from models.demos.deepseek_v3.utils.config_helpers import dequantize, sub_state_dict
+from models.demos.deepseek_v3.utils.config_helpers import sub_state_dict
 from models.demos.deepseek_v3.utils.run_config import create_run_config
 from models.demos.deepseek_v3.utils.test_utils import (
     assert_hidden_dim_pcc,
@@ -25,6 +25,7 @@ from models.demos.deepseek_v3.utils.test_utils import (
     load_reference_io_tensors_for_module,
     run_module_forward,
 )
+
 
 @pytest.fixture
 def reference_model(hf_config):
@@ -37,24 +38,6 @@ def reference_model(hf_config):
 
 def _clone_state_dict(state_dict: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
     return {name: tensor.detach().clone() for name, tensor in state_dict.items()}
-
-
-def _dequantize_moe_state_dict(
-    state_dict: dict[str, torch.Tensor],
-    hf_config,
-) -> dict[str, torch.Tensor]:
-    dequantized_state_dict = {}
-    block_shape = hf_config.quantization_config["weight_block_size"]
-
-    for name in sorted(key for key in state_dict.keys() if not key.endswith("_scale_inv")):
-        tensor = state_dict[name]
-        scale_name = f"{name}_scale_inv"
-        if scale_name in state_dict:
-            dequantized_state_dict[name] = dequantize(tensor, state_dict[scale_name], block_shape).to(torch.bfloat16)
-        else:
-            dequantized_state_dict[name] = tensor.detach().clone()
-
-    return dequantized_state_dict
 
 
 def load_real_moe_input(mode: str, module_path: str, num_tokens: int) -> torch.Tensor:
@@ -104,7 +87,7 @@ def generate_reference_io(
         if not moe_state_dict:
             pytest.skip(f"Checkpoint does not contain routed MoE weights under '{module_path}'")
 
-        state_dict_out = _dequantize_moe_state_dict(moe_state_dict, hf_config)
+        state_dict_out = moe_state_dict
         reference_model.load_state_dict(state_dict_out)
         torch_input = load_real_moe_input(mode, module_path, num_tokens)
 
@@ -141,13 +124,7 @@ _prefill_seq_len = int(_max_seq_len_env) if _max_seq_len_env is not None else DE
         True,
     ],
 )
-@pytest.mark.parametrize(
-    "weight_type,module_path",
-    [
-        ("random", None),
-        ("real", REAL_MOE_MODULE_PATH),
-    ],
-)
+@pytest.mark.parametrize("weight_type", ["random", "real"])
 def test_forward_pass(
     device_params,
     mode,
@@ -161,11 +138,11 @@ def test_forward_pass(
     ccl,
     topk_fallback,
     weight_type,
-    module_path,
     force_recalculate_weight_config,
 ):
     """Test forward pass against reference model."""
 
+    module_path = "model.layers.3.mlp" if weight_type == "real" else None
     checkpoint_state_dict = request.getfixturevalue("state_dict") if weight_type == "real" else None
     state_dict, torch_input, reference_output = generate_reference_io(
         mode=mode,

--- a/models/demos/deepseek_v3/tests/test_moe.py
+++ b/models/demos/deepseek_v3/tests/test_moe.py
@@ -26,9 +26,6 @@ from models.demos.deepseek_v3.utils.test_utils import (
     run_module_forward,
 )
 
-REAL_MOE_MODULE_PATH = "model.layers.3.mlp"
-
-
 @pytest.fixture
 def reference_model(hf_config):
     """Build the routed-experts-only MoE reference used by the TT MoE test."""

--- a/models/demos/deepseek_v3/tests/test_moe.py
+++ b/models/demos/deepseek_v3/tests/test_moe.py
@@ -2,7 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+import math
 import os
+from copy import deepcopy
 
 import pytest
 import torch
@@ -13,52 +15,112 @@ from models.demos.deepseek_v3.reference.modeling_deepseek import DeepseekV3MoE
 from models.demos.deepseek_v3.tests.pytest_utils import DEFAULT_PREFILL_SEQ_LEN
 from models.demos.deepseek_v3.tt.model.row_batched_model import get_fabric_config
 from models.demos.deepseek_v3.tt.moe import MoE
-from models.demos.deepseek_v3.utils.config_helpers import sub_state_dict
+from models.demos.deepseek_v3.utils.config_helpers import dequantize, sub_state_dict
 from models.demos.deepseek_v3.utils.run_config import create_run_config
 from models.demos.deepseek_v3.utils.test_utils import (
     assert_hidden_dim_pcc,
     get_model_config,
     get_test_weight_config,
+    load_reference_io,
+    load_reference_io_tensors_for_module,
     run_module_forward,
 )
+
+REAL_MOE_MODULE_PATH = "model.layers.3.mlp"
 
 
 @pytest.fixture
 def reference_model(hf_config):
-    """Get the actual DeepSeek MLP model using local implementation."""
+    """Build the routed-experts-only MoE reference used by the TT MoE test."""
     torch.use_deterministic_algorithms(True)
-    # Note : Running Reference MoE without shared experts
-    hf_config.n_shared_experts = None
-    return DeepseekV3MoE(hf_config).eval()
+    moe_config = deepcopy(hf_config)
+    moe_config.n_shared_experts = None
+    return DeepseekV3MoE(moe_config).eval()
+
+
+def _clone_state_dict(state_dict: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+    return {name: tensor.detach().clone() for name, tensor in state_dict.items()}
+
+
+def _dequantize_moe_state_dict(
+    state_dict: dict[str, torch.Tensor],
+    hf_config,
+) -> dict[str, torch.Tensor]:
+    dequantized_state_dict = {}
+    block_shape = hf_config.quantization_config["weight_block_size"]
+
+    for name in sorted(key for key in state_dict.keys() if not key.endswith("_scale_inv")):
+        tensor = state_dict[name]
+        scale_name = f"{name}_scale_inv"
+        if scale_name in state_dict:
+            dequantized_state_dict[name] = dequantize(tensor, state_dict[scale_name], block_shape).to(torch.bfloat16)
+        else:
+            dequantized_state_dict[name] = tensor.detach().clone()
+
+    return dequantized_state_dict
+
+
+def load_real_moe_input(mode: str, module_path: str, num_tokens: int) -> torch.Tensor:
+    if mode == "prefill":
+        torch_input, _ = load_reference_io_tensors_for_module(mode, module_path, num_tokens, 1)
+        return torch_input.squeeze(0).to(torch.bfloat16)
+
+    reference_io = load_reference_io(mode, module_path)
+    assert all(len(logs) <= 1 for logs in reference_io), f"Expected a non-range module, got {module_path}"
+    assert all(len(logs) > 0 for logs in reference_io), f"Some logs for module {module_path} {mode} were not generated."
+
+    io_module_paths, torch_args, _, _ = zip(*[logs[0] for logs in reference_io])
+    (torch_inputs,) = zip(*torch_args)
+    assert set(io_module_paths) == {module_path}
+
+    torch_input = torch.concat(torch_inputs, dim=1).unsqueeze(0)
+
+    if torch_input.shape[2] < num_tokens:
+        repeats = math.ceil(num_tokens / torch_input.shape[2])
+        torch_input = torch_input.repeat(1, 1, repeats, 1)
+
+    return torch_input[:, :, :num_tokens, :].squeeze(0).to(torch.bfloat16)
+
+
+def generate_reference_io(
+    mode: str,
+    num_tokens: int,
+    reference_model: DeepseekV3MoE,
+    hf_config,
+    weight_type: str,
+    checkpoint_state_dict: dict[str, torch.Tensor] | None = None,
+    module_path: str | None = None,
+) -> tuple[dict[str, torch.Tensor], torch.Tensor, torch.Tensor]:
+    if weight_type == "random":
+        # Preserve random-init dtypes, especially the fp32 gate score-correction bias.
+        state_dict_out = _clone_state_dict(reference_model.state_dict())
+        torch_input = torch.randn(1, num_tokens, hf_config.hidden_size, dtype=torch.bfloat16)
+    else:
+        assert weight_type == "real"
+        assert checkpoint_state_dict is not None
+        assert module_path is not None
+        moe_state_dict = {
+            name: tensor
+            for name, tensor in sub_state_dict(checkpoint_state_dict, module_path + ".").items()
+            if not name.startswith("shared_experts.")
+        }
+        if not moe_state_dict:
+            pytest.skip(f"Checkpoint does not contain routed MoE weights under '{module_path}'")
+
+        state_dict_out = _dequantize_moe_state_dict(moe_state_dict, hf_config)
+        reference_model.load_state_dict(state_dict_out)
+        torch_input = load_real_moe_input(mode, module_path, num_tokens)
+
+    reference_model.eval()
+    reference_model.to(torch.bfloat16)
+    with torch.no_grad():
+        reference_output = reference_model(torch_input)
+
+    return state_dict_out, torch_input, reference_output
 
 
 _max_seq_len_env = os.getenv("DEEPSEEK_MAX_SEQ_LEN_OVERRIDE")
 _prefill_seq_len = int(_max_seq_len_env) if _max_seq_len_env is not None else DEFAULT_PREFILL_SEQ_LEN
-_moe_layer_path = "model.layers.3.mlp"
-
-
-def _get_test_state_dict(
-    reference_model: DeepseekV3MoE,
-    weight_type: str,
-    checkpoint_state_dict: dict[str, torch.Tensor] | None,
-) -> dict[str, torch.Tensor]:
-    if weight_type == "random":
-        # Keep the original random-init dtypes for the TT conversion path.
-        # In particular, the gate score-correction bias should remain fp32.
-        return {name: tensor.detach().clone() for name, tensor in reference_model.state_dict().items()}
-
-    assert weight_type == "real"
-    assert checkpoint_state_dict is not None
-    moe_state_dict = {
-        name: tensor
-        for name, tensor in sub_state_dict(checkpoint_state_dict, f"{_moe_layer_path}.").items()
-        if not name.startswith("shared_experts.")
-    }
-    if not moe_state_dict:
-        pytest.skip(f"Checkpoint does not contain routed MoE weights under '{_moe_layer_path}'")
-
-    reference_model.load_state_dict(moe_state_dict)
-    return moe_state_dict
 
 
 @pytest.mark.timeout(1200)
@@ -82,7 +144,13 @@ def _get_test_state_dict(
         True,
     ],
 )
-@pytest.mark.parametrize("weight_type", ["random"], ids=["random_weights"])
+@pytest.mark.parametrize(
+    "weight_type,module_path",
+    [
+        ("random", None),
+        ("real", REAL_MOE_MODULE_PATH),
+    ],
+)
 def test_forward_pass(
     device_params,
     mode,
@@ -96,22 +164,21 @@ def test_forward_pass(
     ccl,
     topk_fallback,
     weight_type,
+    module_path,
     force_recalculate_weight_config,
 ):
     """Test forward pass against reference model."""
 
-    # Load checkpoint only for real weights; random path needs no checkpoint.
     checkpoint_state_dict = request.getfixturevalue("state_dict") if weight_type == "real" else None
-    state_dict = _get_test_state_dict(reference_model, weight_type, checkpoint_state_dict)
-
-    # Create input tensor
-    torch_input = torch.randn(1, num_tokens, hf_config.hidden_size, dtype=torch.bfloat16)
-
-    # Reference forward pass
-    reference_model.eval()
-    reference_model.to(torch.bfloat16)
-    with torch.no_grad():
-        reference_output = reference_model(torch_input)
+    state_dict, torch_input, reference_output = generate_reference_io(
+        mode=mode,
+        num_tokens=num_tokens,
+        reference_model=reference_model,
+        hf_config=hf_config,
+        weight_type=weight_type,
+        checkpoint_state_dict=checkpoint_state_dict,
+        module_path=module_path,
+    )
 
     weight_config = get_test_weight_config(
         MoE,
@@ -122,24 +189,16 @@ def test_forward_pass(
         force_recalculate=force_recalculate_weight_config,
         test_name="test_moe",
         real_weights=weight_type == "real",
-        layer_id=_moe_layer_path,
+        layer_id=module_path,
     )
 
-    # Generate appropriate config using utility function
     model_config = get_model_config(
         MoE, mode, hf_config, mesh_device, device_params["fabric_config"], topk_fallback=topk_fallback
     )
-
-    # Create a new model state with CCL
     model_state = MoE.create_state(hf_config, mesh_device, ccl)
-
-    # Create a new model shared state
     model_shared_state = MoE.create_shared_state(hf_config, mesh_device)
-
-    # Create RunConfig using both weight_config and model_config
     run_config = create_run_config(model_config, weight_config, model_state, model_shared_state)
 
-    # Convert input to TTNN, DP=4 and Replicated
     tt_input = ttnn.from_torch(
         torch_input.unsqueeze(1),
         device=mesh_device,
@@ -149,31 +208,25 @@ def test_forward_pass(
         layout=ttnn.TILE_LAYOUT,
     )
 
-    # TTNN forward pass using utility function
     tt_input = ttnn.to_memory_config(tt_input, run_config["input_memory_config"])
-    # Pass handle_tensor_parallel=True to enable collective operations inside the forward functions
     tt_output = run_module_forward(MoE, mode, tt_input, run_config, handle_tensor_parallel=True)
 
-    # Verify output memory config matches expected
     expected_output_memory_config = run_config["output_memory_config"]
     actual_output_memory_config = tt_output.memory_config()
     assert (
         actual_output_memory_config == expected_output_memory_config
     ), f"MoE output memory config mismatch: expected {expected_output_memory_config}, got {actual_output_memory_config}"
 
-    # Convert output back to torch
     tt_output_torch = ttnn.to_torch(
         tt_output,
         mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(-2, -1), mesh_shape=tuple(mesh_device.shape)),
     )
 
-    # Cleanup
     ttnn.deallocate(tt_input)
     ttnn.deallocate(tt_output)
 
-    # Compare outputs using utility function
-    logger.info(f"Mode: {mode}, Num tokens: {num_tokens}")
-    assert_hidden_dim_pcc(tt_output_torch, reference_output.unsqueeze(0), pcc_required=0.98)
+    logger.info(f"Mode: {mode}, Num tokens: {num_tokens}, Weight type: {weight_type}")
+    assert_hidden_dim_pcc(tt_output_torch, reference_output.unsqueeze(0), pcc_required=0.97)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Ticket
#39604

### Problem description
test_moe appears to behave materially worse with real weights than with random weights, and the current explanation is unclear.

### What's changed
Adding real weights to test_moe, after investigation concluded that real inputs / hidden states are also needed to ensure PCC > 0.99. Deepseek MoE is dependent on the normalization of inputs, and fails if normalization is not as expected.

### Checklist

- [x] [![DeepSeek Tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml/badge.svg?branch=ds-moe-real)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml?query=branch:ds-moe-real)