### PR TITLE
[DFB Feature]: Enable implicit sync method to post/ack credits from DMs

### DIFF
--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
@@ -33,6 +33,12 @@ namespace tt::tt_metal {
 
 enum class DFBPorCType : uint8_t { DM, TENSIX };
 
+class DFBImplicitSyncParamFixture : public MeshDeviceFixture, public ::testing::WithParamInterface<bool> {};
+
+static std::string ImplicitSyncParamName(const ::testing::TestParamInfo<bool>& info) {
+    return info.param ? "ImplicitSyncTrue" : "ImplicitSyncFalse";
+}
+
 void execute_program_and_verify(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     Program& program,
@@ -115,7 +121,7 @@ void run_single_dfb_program(
     CoreCoord logical_core = CoreCoord(0, 0);
 
     uint32_t num_entries_per_producer = dfb_config.num_entries / dfb_config.num_producers;
-    std::vector<uint32_t> producer_cta = {(uint32_t)in_buffer->address(), num_entries_per_producer};
+    std::vector<uint32_t> producer_cta = {(uint32_t)in_buffer->address(), num_entries_per_producer, (uint32_t)dfb_config.enable_implicit_sync};
     tt::tt_metal::TensorAccessorArgs(in_buffer).append_to(producer_cta);
 
     KernelHandle producer_kernel;
@@ -140,7 +146,8 @@ void run_single_dfb_program(
     std::vector<uint32_t> consumer_cta = {
         (uint32_t)out_buffer->address(),
         num_entries_per_consumer,
-        (uint32_t)dfb_config.cap == ::experimental::AccessPattern::BLOCKED};
+        (uint32_t)dfb_config.cap == ::experimental::AccessPattern::BLOCKED,
+        (uint32_t)dfb_config.enable_implicit_sync};
     tt::tt_metal::TensorAccessorArgs(out_buffer).append_to(consumer_cta);
 
     KernelHandle consumer_kernel;
@@ -256,7 +263,7 @@ void run_in_dfb_out_dfb_program(
     execute_program_and_verify(mesh_device, program, in_buffer, out_buffer, zero_coord, buffer_size);
 }
 
-TEST_F(MeshDeviceFixture, DMTest1xDFB1Sx1S) {
+TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB1Sx1S) {
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
@@ -267,12 +274,12 @@ TEST_F(MeshDeviceFixture, DMTest1xDFB1Sx1S) {
         .pap = ::experimental::AccessPattern::STRIDED,
         .num_consumers = 1,
         .cap = ::experimental::AccessPattern::STRIDED,
-        .enable_implicit_sync = false};
+        .enable_implicit_sync = GetParam()};
 
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM);
 }
 
-TEST_F(MeshDeviceFixture, DMTensixTest1xDFB1Sx1S) {
+TEST_P(DFBImplicitSyncParamFixture, DMTensixTest1xDFB1Sx1S) {
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
@@ -283,12 +290,12 @@ TEST_F(MeshDeviceFixture, DMTensixTest1xDFB1Sx1S) {
         .pap = ::experimental::AccessPattern::STRIDED,
         .num_consumers = 1,
         .cap = ::experimental::AccessPattern::STRIDED,
-        .enable_implicit_sync = false};
+        .enable_implicit_sync = GetParam()};
 
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::TENSIX);
 }
 
-TEST_F(MeshDeviceFixture, TensixDMTest1xDFB1Sx1S) {
+TEST_P(DFBImplicitSyncParamFixture, TensixDMTest1xDFB1Sx1S) {
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
@@ -299,7 +306,7 @@ TEST_F(MeshDeviceFixture, TensixDMTest1xDFB1Sx1S) {
         .pap = ::experimental::AccessPattern::STRIDED,
         .num_consumers = 1,
         .cap = ::experimental::AccessPattern::STRIDED,
-        .enable_implicit_sync = false};
+        .enable_implicit_sync = GetParam()};
 
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::TENSIX, DFBPorCType::DM);
 }
@@ -379,7 +386,7 @@ TEST_F(MeshDeviceFixture, DMTensixDMTest1xDFB4Sx1S1xDFB1Sx4S) {
     run_in_dfb_out_dfb_program(this->devices_.at(0), dm2tensix_config, tensix2dm_config);
 }
 
-TEST_F(MeshDeviceFixture, DMTest1xDFB1Sx4S) {
+TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB1Sx4S) {
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
@@ -390,12 +397,12 @@ TEST_F(MeshDeviceFixture, DMTest1xDFB1Sx4S) {
         .pap = ::experimental::AccessPattern::STRIDED,
         .num_consumers = 4,
         .cap = ::experimental::AccessPattern::STRIDED,
-        .enable_implicit_sync = false};
+        .enable_implicit_sync = GetParam()};
 
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM);
 }
 
-TEST_F(MeshDeviceFixture, DMTensixTest1xDFB1Sx4S) {
+TEST_P(DFBImplicitSyncParamFixture, DMTensixTest1xDFB1Sx4S) {
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
@@ -406,11 +413,11 @@ TEST_F(MeshDeviceFixture, DMTensixTest1xDFB1Sx4S) {
         .pap = ::experimental::AccessPattern::STRIDED,
         .num_consumers = 4,
         .cap = ::experimental::AccessPattern::STRIDED,
-        .enable_implicit_sync = false};
+        .enable_implicit_sync = GetParam()};
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::TENSIX);
 }
 
-TEST_F(MeshDeviceFixture, TensixDMTest1xDFB1Sx4S) {
+TEST_P(DFBImplicitSyncParamFixture, TensixDMTest1xDFB1Sx4S) {
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
@@ -421,11 +428,11 @@ TEST_F(MeshDeviceFixture, TensixDMTest1xDFB1Sx4S) {
         .pap = ::experimental::AccessPattern::STRIDED,
         .num_consumers = 4,
         .cap = ::experimental::AccessPattern::STRIDED,
-        .enable_implicit_sync = false};
+        .enable_implicit_sync = GetParam()};
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::TENSIX, DFBPorCType::DM);
 }
 
-TEST_F(MeshDeviceFixture, DMTest1xDFB4Sx1S) {
+TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB4Sx1S) {
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
@@ -436,12 +443,12 @@ TEST_F(MeshDeviceFixture, DMTest1xDFB4Sx1S) {
         .pap = ::experimental::AccessPattern::STRIDED,
         .num_consumers = 1,
         .cap = ::experimental::AccessPattern::STRIDED,
-        .enable_implicit_sync = false};
+        .enable_implicit_sync = GetParam()};
 
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM);
 }
 
-TEST_F(MeshDeviceFixture, DMTensixTest1xDFB4Sx1S) {
+TEST_P(DFBImplicitSyncParamFixture, DMTensixTest1xDFB4Sx1S) {
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
@@ -452,11 +459,11 @@ TEST_F(MeshDeviceFixture, DMTensixTest1xDFB4Sx1S) {
         .pap = ::experimental::AccessPattern::STRIDED,
         .num_consumers = 1,
         .cap = ::experimental::AccessPattern::STRIDED,
-        .enable_implicit_sync = false};
+        .enable_implicit_sync = GetParam()};
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::TENSIX);
 }
 
-TEST_F(MeshDeviceFixture, TensixDMTest1xDFB4Sx1S) {
+TEST_P(DFBImplicitSyncParamFixture, TensixDMTest1xDFB4Sx1S) {
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
@@ -467,11 +474,11 @@ TEST_F(MeshDeviceFixture, TensixDMTest1xDFB4Sx1S) {
         .pap = ::experimental::AccessPattern::STRIDED,
         .num_consumers = 1,
         .cap = ::experimental::AccessPattern::STRIDED,
-        .enable_implicit_sync = false};
+        .enable_implicit_sync = GetParam()};
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::TENSIX, DFBPorCType::DM);
 }
 
-TEST_F(MeshDeviceFixture, DMTest1xDFB4Sx4S) {
+TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB4Sx4S) {
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
@@ -482,12 +489,12 @@ TEST_F(MeshDeviceFixture, DMTest1xDFB4Sx4S) {
         .pap = ::experimental::AccessPattern::STRIDED,
         .num_consumers = 4,
         .cap = ::experimental::AccessPattern::STRIDED,
-        .enable_implicit_sync = false};
+        .enable_implicit_sync = GetParam()};
 
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM);
 }
 
-TEST_F(MeshDeviceFixture, DMTensixTest1xDFB4Sx4S) {
+TEST_P(DFBImplicitSyncParamFixture, DMTensixTest1xDFB4Sx4S) {
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
@@ -498,12 +505,12 @@ TEST_F(MeshDeviceFixture, DMTensixTest1xDFB4Sx4S) {
         .pap = ::experimental::AccessPattern::STRIDED,
         .num_consumers = 4,
         .cap = ::experimental::AccessPattern::STRIDED,
-        .enable_implicit_sync = false};
+        .enable_implicit_sync = GetParam()};
 
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::TENSIX);
 }
 
-TEST_F(MeshDeviceFixture, TensixDMTest1xDFB4Sx4S) {
+TEST_P(DFBImplicitSyncParamFixture, TensixDMTest1xDFB4Sx4S) {
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
@@ -514,11 +521,11 @@ TEST_F(MeshDeviceFixture, TensixDMTest1xDFB4Sx4S) {
         .pap = ::experimental::AccessPattern::STRIDED,
         .num_consumers = 4,
         .cap = ::experimental::AccessPattern::STRIDED,
-        .enable_implicit_sync = false};
+        .enable_implicit_sync = GetParam()};
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::TENSIX, DFBPorCType::DM);
 }
 
-TEST_F(MeshDeviceFixture, DMTest1xDFB2Sx4S) {
+TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB2Sx4S) {
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
@@ -529,12 +536,12 @@ TEST_F(MeshDeviceFixture, DMTest1xDFB2Sx4S) {
         .pap = ::experimental::AccessPattern::STRIDED,
         .num_consumers = 4,
         .cap = ::experimental::AccessPattern::STRIDED,
-        .enable_implicit_sync = false};
+        .enable_implicit_sync = GetParam()};
 
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM);
 }
 
-TEST_F(MeshDeviceFixture, DMTensixTest1xDFB2Sx4S) {
+TEST_P(DFBImplicitSyncParamFixture, DMTensixTest1xDFB2Sx4S) {
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
@@ -545,11 +552,11 @@ TEST_F(MeshDeviceFixture, DMTensixTest1xDFB2Sx4S) {
         .pap = ::experimental::AccessPattern::STRIDED,
         .num_consumers = 4,
         .cap = ::experimental::AccessPattern::STRIDED,
-        .enable_implicit_sync = false};
+        .enable_implicit_sync = GetParam()};
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::TENSIX);
 }
 
-TEST_F(MeshDeviceFixture, TensixDMTest1xDFB2Sx4S) {
+TEST_P(DFBImplicitSyncParamFixture, TensixDMTest1xDFB2Sx4S) {
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
@@ -560,11 +567,11 @@ TEST_F(MeshDeviceFixture, TensixDMTest1xDFB2Sx4S) {
         .pap = ::experimental::AccessPattern::STRIDED,
         .num_consumers = 4,
         .cap = ::experimental::AccessPattern::STRIDED,
-        .enable_implicit_sync = false};
+        .enable_implicit_sync = GetParam()};
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::TENSIX, DFBPorCType::DM);
 }
 
-TEST_F(MeshDeviceFixture, DMTest1xDFB4Sx2S) {
+TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB4Sx2S) {
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
@@ -575,12 +582,12 @@ TEST_F(MeshDeviceFixture, DMTest1xDFB4Sx2S) {
         .pap = ::experimental::AccessPattern::STRIDED,
         .num_consumers = 2,
         .cap = ::experimental::AccessPattern::STRIDED,
-        .enable_implicit_sync = false};
+        .enable_implicit_sync = GetParam()};
 
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM);
 }
 
-TEST_F(MeshDeviceFixture, DMTensixTest1xDFB4Sx2S) {
+TEST_P(DFBImplicitSyncParamFixture, DMTensixTest1xDFB4Sx2S) {
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
@@ -591,11 +598,11 @@ TEST_F(MeshDeviceFixture, DMTensixTest1xDFB4Sx2S) {
         .pap = ::experimental::AccessPattern::STRIDED,
         .num_consumers = 2,
         .cap = ::experimental::AccessPattern::STRIDED,
-        .enable_implicit_sync = false};
+        .enable_implicit_sync = GetParam()};
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::TENSIX);
 }
 
-TEST_F(MeshDeviceFixture, TensixDMTest1xDFB4Sx2S) {
+TEST_P(DFBImplicitSyncParamFixture, TensixDMTest1xDFB4Sx2S) {
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
@@ -606,13 +613,13 @@ TEST_F(MeshDeviceFixture, TensixDMTest1xDFB4Sx2S) {
         .pap = ::experimental::AccessPattern::STRIDED,
         .num_consumers = 2,
         .cap = ::experimental::AccessPattern::STRIDED,
-        .enable_implicit_sync = false};
+        .enable_implicit_sync = GetParam()};
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::TENSIX, DFBPorCType::DM);
 }
 
 // Blocked
 
-TEST_F(MeshDeviceFixture, DMTest1xDFB1Sx4B) {
+TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB1Sx4B) {
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
@@ -623,12 +630,12 @@ TEST_F(MeshDeviceFixture, DMTest1xDFB1Sx4B) {
         .pap = ::experimental::AccessPattern::STRIDED,
         .num_consumers = 4,
         .cap = ::experimental::AccessPattern::BLOCKED,
-        .enable_implicit_sync = false};
+        .enable_implicit_sync = GetParam()};
 
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM);
 }
 
-TEST_F(MeshDeviceFixture, DMTensixTest1xDFB1Sx4B) {
+TEST_P(DFBImplicitSyncParamFixture, DMTensixTest1xDFB1Sx4B) {
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
@@ -639,12 +646,12 @@ TEST_F(MeshDeviceFixture, DMTensixTest1xDFB1Sx4B) {
         .pap = ::experimental::AccessPattern::STRIDED,
         .num_consumers = 4,
         .cap = ::experimental::AccessPattern::BLOCKED,
-        .enable_implicit_sync = false};
+        .enable_implicit_sync = GetParam()};
 
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::TENSIX);
 }
 
-TEST_F(MeshDeviceFixture, TensixDMTest1xDFB1Sx4B) {
+TEST_P(DFBImplicitSyncParamFixture, TensixDMTest1xDFB1Sx4B) {
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
@@ -655,11 +662,11 @@ TEST_F(MeshDeviceFixture, TensixDMTest1xDFB1Sx4B) {
         .pap = ::experimental::AccessPattern::STRIDED,
         .num_consumers = 4,
         .cap = ::experimental::AccessPattern::BLOCKED,
-        .enable_implicit_sync = false};
+        .enable_implicit_sync = GetParam()};
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::TENSIX, DFBPorCType::DM);
 }
 
-TEST_F(MeshDeviceFixture, DMTest1xDFB4Sx1B) {
+TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB4Sx1B) { // mismatching
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
@@ -670,12 +677,12 @@ TEST_F(MeshDeviceFixture, DMTest1xDFB4Sx1B) {
         .pap = ::experimental::AccessPattern::STRIDED,
         .num_consumers = 1,
         .cap = ::experimental::AccessPattern::BLOCKED,
-        .enable_implicit_sync = false};
+        .enable_implicit_sync = GetParam()};
 
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM);
 }
 
-TEST_F(MeshDeviceFixture, DMTensixTest1xDFB4Sx1B) {
+TEST_P(DFBImplicitSyncParamFixture, DMTensixTest1xDFB4Sx1B) {
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
@@ -686,12 +693,12 @@ TEST_F(MeshDeviceFixture, DMTensixTest1xDFB4Sx1B) {
         .pap = ::experimental::AccessPattern::STRIDED,
         .num_consumers = 1,
         .cap = ::experimental::AccessPattern::BLOCKED,
-        .enable_implicit_sync = false};
+        .enable_implicit_sync = GetParam()};
 
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::TENSIX);
 }
 
-TEST_F(MeshDeviceFixture, TensixDMTest1xDFB4Sx1B) {
+TEST_P(DFBImplicitSyncParamFixture, TensixDMTest1xDFB4Sx1B) {
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
@@ -702,12 +709,12 @@ TEST_F(MeshDeviceFixture, TensixDMTest1xDFB4Sx1B) {
         .pap = ::experimental::AccessPattern::STRIDED,
         .num_consumers = 1,
         .cap = ::experimental::AccessPattern::BLOCKED,
-        .enable_implicit_sync = false};
+        .enable_implicit_sync = GetParam()};
 
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::TENSIX, DFBPorCType::DM);
 }
 
-TEST_F(MeshDeviceFixture, DMTest1xDFB4Sx4B) {
+TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB4Sx4B) { // mismatching
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
@@ -718,12 +725,12 @@ TEST_F(MeshDeviceFixture, DMTest1xDFB4Sx4B) {
         .pap = ::experimental::AccessPattern::STRIDED,
         .num_consumers = 4,
         .cap = ::experimental::AccessPattern::BLOCKED,
-        .enable_implicit_sync = false};
+        .enable_implicit_sync = GetParam()};
 
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM);
 }
 
-TEST_F(MeshDeviceFixture, DMTensixTest1xDFB4Sx4B) {
+TEST_P(DFBImplicitSyncParamFixture, DMTensixTest1xDFB4Sx4B) {
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
@@ -734,12 +741,12 @@ TEST_F(MeshDeviceFixture, DMTensixTest1xDFB4Sx4B) {
         .pap = ::experimental::AccessPattern::STRIDED,
         .num_consumers = 4,
         .cap = ::experimental::AccessPattern::BLOCKED,
-        .enable_implicit_sync = false};
+        .enable_implicit_sync = GetParam()};
 
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::TENSIX);
 }
 
-TEST_F(MeshDeviceFixture, TensixDMTest1xDFB4Sx4B) {
+TEST_P(DFBImplicitSyncParamFixture, TensixDMTest1xDFB4Sx4B) {
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
@@ -750,12 +757,12 @@ TEST_F(MeshDeviceFixture, TensixDMTest1xDFB4Sx4B) {
         .pap = ::experimental::AccessPattern::STRIDED,
         .num_consumers = 4,
         .cap = ::experimental::AccessPattern::BLOCKED,
-        .enable_implicit_sync = false};
+        .enable_implicit_sync = GetParam()};
 
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::TENSIX, DFBPorCType::DM);
 }
 
-TEST_F(MeshDeviceFixture, DMTest1xDFB4Sx2B) {
+TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB4Sx2B) {
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
@@ -766,12 +773,12 @@ TEST_F(MeshDeviceFixture, DMTest1xDFB4Sx2B) {
         .pap = ::experimental::AccessPattern::STRIDED,
         .num_consumers = 2,
         .cap = ::experimental::AccessPattern::BLOCKED,
-        .enable_implicit_sync = false};
+        .enable_implicit_sync = GetParam()};
 
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM);
 }
 
-TEST_F(MeshDeviceFixture, DMTensixTest1xDFB4Sx2B) {
+TEST_P(DFBImplicitSyncParamFixture, DMTensixTest1xDFB4Sx2B) {
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
@@ -782,11 +789,11 @@ TEST_F(MeshDeviceFixture, DMTensixTest1xDFB4Sx2B) {
         .pap = ::experimental::AccessPattern::STRIDED,
         .num_consumers = 2,
         .cap = ::experimental::AccessPattern::BLOCKED,
-        .enable_implicit_sync = false};
+        .enable_implicit_sync = GetParam()};
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::TENSIX);
 }
 
-TEST_F(MeshDeviceFixture, TensixDMTest1xDFB4Sx2B) {
+TEST_P(DFBImplicitSyncParamFixture, TensixDMTest1xDFB4Sx2B) {
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
@@ -797,11 +804,11 @@ TEST_F(MeshDeviceFixture, TensixDMTest1xDFB4Sx2B) {
         .pap = ::experimental::AccessPattern::STRIDED,
         .num_consumers = 2,
         .cap = ::experimental::AccessPattern::BLOCKED,
-        .enable_implicit_sync = false};
+        .enable_implicit_sync = GetParam()};
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::TENSIX, DFBPorCType::DM);
 }
 
-TEST_F(MeshDeviceFixture, DMTest1xDFB2Sx4B) {
+TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB2Sx4B) {
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
@@ -812,12 +819,12 @@ TEST_F(MeshDeviceFixture, DMTest1xDFB2Sx4B) {
         .pap = ::experimental::AccessPattern::STRIDED,
         .num_consumers = 4,
         .cap = ::experimental::AccessPattern::BLOCKED,
-        .enable_implicit_sync = false};
+        .enable_implicit_sync = GetParam()};
 
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM);
 }
 
-TEST_F(MeshDeviceFixture, DMTensixTest1xDFB2Sx4B) {
+TEST_P(DFBImplicitSyncParamFixture, DMTensixTest1xDFB2Sx4B) {
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
@@ -828,11 +835,11 @@ TEST_F(MeshDeviceFixture, DMTensixTest1xDFB2Sx4B) {
         .pap = ::experimental::AccessPattern::STRIDED,
         .num_consumers = 4,
         .cap = ::experimental::AccessPattern::BLOCKED,
-        .enable_implicit_sync = false};
+        .enable_implicit_sync = GetParam()};
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::TENSIX);
 }
 
-TEST_F(MeshDeviceFixture, TensixDMTest1xDFB2Sx4B) {
+TEST_P(DFBImplicitSyncParamFixture, TensixDMTest1xDFB2Sx4B) {
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
@@ -843,8 +850,14 @@ TEST_F(MeshDeviceFixture, TensixDMTest1xDFB2Sx4B) {
         .pap = ::experimental::AccessPattern::STRIDED,
         .num_consumers = 4,
         .cap = ::experimental::AccessPattern::BLOCKED,
-        .enable_implicit_sync = false};
+        .enable_implicit_sync = GetParam()};
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::TENSIX, DFBPorCType::DM);
 }
+
+INSTANTIATE_TEST_SUITE_P(
+    ImplicitSync,
+    DFBImplicitSyncParamFixture,
+    ::testing::Bool(),
+    ImplicitSyncParamName);
 
 }  // end namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_consumer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_consumer.cpp
@@ -11,7 +11,8 @@ void kernel_main() {
     const uint32_t dst_addr_base = get_compile_time_arg_val(0);
     const uint32_t num_entries_per_consumer = get_compile_time_arg_val(1);
     const uint32_t blocked_consumer = get_compile_time_arg_val(2);
-    constexpr auto dst_args = TensorAccessorArgs<3>();
+    constexpr uint32_t implicit_sync = get_compile_time_arg_val(3);
+    constexpr auto dst_args = TensorAccessorArgs<4>();
 
     uint32_t consumer_mask = get_arg_val<uint32_t>(0);
     uint32_t logical_dfb_id = get_arg_val<uint32_t>(1);
@@ -28,15 +29,10 @@ void kernel_main() {
     // DPRINT << "consumer_idx: " << consumer_idx << " num_entries_per_consumer: " << num_entries_per_consumer <<
     // ENDL();
 
-    // uint32_t dst_addr_base = get_arg_val<uint32_t>(0);
     uint32_t entry_size = dfb.get_entry_size();
     const auto tensor_accessor = TensorAccessor(dst_args, dst_addr_base, entry_size);
 
     for (uint32_t tile_id = 0; tile_id < num_entries_per_consumer; tile_id++) {
-        // DPRINT << "wfw" << ENDL();
-        dfb.wait_front(1);
-        // in blocked case maybe each consumer can modify the data so host knows that each have consumed it
-        // DPRINT << "wfd" << ENDL();
         uint32_t page_id = 0;
         if constexpr (blocked_consumer) {
             page_id = tile_id;
@@ -44,12 +40,14 @@ void kernel_main() {
             page_id = tile_id * num_consumers + consumer_idx;
         }
         DPRINT << "consumer tile id " << tile_id << " page id " << page_id << ENDL();
-        // for blocked consumer each consumer reads each tile .. user kernel shouldn't have to think about this (tensor
-        // accessor will abstract)
-        noc.async_write(dfb, tensor_accessor, entry_size, {}, {.page_id = page_id});
-        // DPRINT << "pfw" << ENDL();
-        dfb.pop_front(1);
-        // DPRINT << "pfd" << ENDL();
+        if constexpr (implicit_sync) {
+            dfb.write_out(noc, tensor_accessor, {.page_id = page_id});
+        } else {
+            dfb.wait_front(1);
+            noc.async_write(dfb, tensor_accessor, entry_size, {}, {.page_id = page_id});
+            noc.async_write_barrier();
+            dfb.pop_front(1);
+        }
     }
     DPRINT << "CBW" << ENDL();
     noc.async_write_barrier();

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp
@@ -10,7 +10,8 @@
 void kernel_main() {
     const uint32_t src_addr_base = get_compile_time_arg_val(0);
     const uint32_t num_entries_per_producer = get_compile_time_arg_val(1);
-    constexpr auto src_args = TensorAccessorArgs<2>();
+    constexpr uint32_t implicit_sync = get_compile_time_arg_val(2);
+    constexpr auto src_args = TensorAccessorArgs<3>();
 
     uint32_t producer_mask = get_arg_val<uint32_t>(0);
     const uint32_t num_producers = static_cast<uint32_t>(__builtin_popcount(producer_mask));
@@ -29,24 +30,16 @@ void kernel_main() {
     uint32_t entry_size = dfb.get_entry_size();
     const auto tensor_accessor = TensorAccessor(src_args, src_addr_base, entry_size);
 
-    // for (uint32_t tensix_id = 0; tensix_id < 4; tensix_id++) {
-    //     for (uint32_t tc_id = 0; tc_id < 16; tc_id++) {
-    //         DPRINT << "tensix_id: " << tensix_id << " tc_id: " << tc_id
-    //                << " capacity: " << static_cast<uint32_t>(llk_intf_get_capacity(tensix_id, tc_id)) << ENDL();
-    //     }
-    // }
-
     for (uint32_t tile_id = 0; tile_id < num_entries_per_producer; tile_id++) {
-        // DPRINT << "rbw" << ENDL();
-        dfb.reserve_back(1);
-        // DPRINT << "rbd" << ENDL();
-        // DPRINT << "rdi" << ENDL();
-        DPRINT << "producer tile id " << tile_id << " page id " << ((tile_id * num_producers) + producer_idx) << ENDL();
-        noc.async_read(tensor_accessor, dfb, entry_size, {.page_id = tile_id * num_producers + producer_idx}, {});
-        noc.async_read_barrier();
-        DPRINT << "rdd" << ENDL();
-        dfb.push_back(1);
-        // DPRINT << "pbd" << ENDL();
+        // DPRINT << "producer tile id " << tile_id << " page id " << ((tile_id * num_producers) + producer_idx) << ENDL();
+        if constexpr (implicit_sync) {
+            dfb.read_in(noc, tensor_accessor, {.page_id = tile_id * num_producers + producer_idx});
+        } else {
+            dfb.reserve_back(1);
+            noc.async_read(tensor_accessor, dfb, entry_size, {.page_id = tile_id * num_producers + producer_idx}, {});
+            noc.async_read_barrier();
+            dfb.push_back(1);
+        }
     }
     DPRINT << "PFW" << ENDL();
     dfb.finish();

--- a/tt_metal/hw/firmware/src/tt-2xx/dm.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dm.cc
@@ -104,9 +104,11 @@ void deassert_trisc() {
     subordinate_sync->allNeo3 = RUN_SYNC_MSG_ALL_INIT;
     deassert_trisc_reset();
 }
-// Definition of the global DFB interface array (declared extern in dataflow_buffer_init.h)
+
 thread_local ::experimental::LocalDFBInterface g_dfb_interface[experimental::NUM_DFBS] __attribute__((used));
 RemapperAPI g_remapper_configurator __attribute__((used));
+
+volatile experimental::TxnDFBDescriptor experimental::g_txn_dfb_descriptor[32] __attribute__((used));
 
 void device_setup() {
     // instn_buf

--- a/tt_metal/hw/inc/experimental/dataflow_buffer.h
+++ b/tt_metal/hw/inc/experimental/dataflow_buffer.h
@@ -43,12 +43,6 @@ public:
 #if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_PACK)
         llk_wait_for_free_tiles(logical_dfb_id_, num_entries);
         // DPRINT << "reserve_back: tc_id: " << static_cast<uint32_t>(tc_id) << " acked: " << static_cast<uint32_t>(tile_counters[tc_id].f.acked) << ENDL();
-        // PACK({
-        //     uint16_t entries_freed;
-        //     do {
-        //         entries_freed = tile_counters[tc_id].f.acked;
-        //     } while (entries_freed < num_entries);
-        // })
 #elif !defined(COMPILE_FOR_TRISC)
         if (__builtin_expect(local_dfb_interface_.broadcast_tc, 0)) {
             // DM-DM BLOCKED: wait until every consumer TC has free space (throttled by slowest consumer)
@@ -79,15 +73,6 @@ public:
 #if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_PACK)
         llk_push_tiles(logical_dfb_id_, num_entries);
         // DPRINT << "push_bak: tc_id: " << static_cast<uint32_t>(tc_id) << " posted: " << static_cast<uint32_t>(tile_counters[tc_id].f.posted) << ENDL();
-        // PACK({
-        //     tile_counters[tc_id].f.posted = num_entries;
-        //     local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr += (num_entries * local_dfb_interface_.stride_size);
-        //     if (local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr == local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].limit) {
-        //         local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].base_addr;
-        //     }
-
-        //     local_dfb_interface_.tc_idx = (local_dfb_interface_.tc_idx + 1) % local_dfb_interface_.num_tcs_to_rr;
-        // })
 #elif !defined(COMPILE_FOR_TRISC)
         if (__builtin_expect(local_dfb_interface_.broadcast_tc, 0)) {
             // DM-DM BLOCKED: post to all N TCs; wr_ptr tracked on slot 0
@@ -127,13 +112,6 @@ public:
             return;
         }
         llk_wait_tiles(logical_dfb_id_, num_entries);
-
-        // UNPACK({
-        //     uint16_t entries_received;
-        //     do {
-        //         entries_received = tile_counters[tc_id].f.posted;
-        //     } while (entries_received < num_entries);
-        // })
 #elif !defined(COMPILE_FOR_TRISC)
         uint8_t tensix_id = get_tensix_id(packed_tc);
         // DPRINT << "wait_front: tensix_id: " << static_cast<uint32_t>(tensix_id)
@@ -153,14 +131,6 @@ public:
             return;
         }
         llk_pop_tiles(logical_dfb_id_, num_entries);
-        // UNPACK({
-        //     tile_counters[tc_id].f.acked = num_entries;
-        //     local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr += (num_entries * local_dfb_interface_.stride_size);
-        //     if (local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr == local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].limit) {
-        //         local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].base_addr;
-        //     }
-        //     local_dfb_interface_.tc_idx = (local_dfb_interface_.tc_idx + 1) % local_dfb_interface_.num_tcs_to_rr;
-        // })
 #elif !defined(COMPILE_FOR_TRISC)
         uint8_t tensix_id = get_tensix_id(packed_tc);
         llk_intf_inc_acked(tensix_id, tc_id, num_entries);
@@ -175,10 +145,71 @@ public:
     // Explicit sync APIs end
 
     // Implicit sync APIs
-    void read_in() {}
+    // one tile at a time right now
+#ifndef COMPILE_FOR_TRISC
+    template <typename Src>
+    void read_in(const Noc& noc, const Src& src, const typename noc_traits_t<Src>::src_args_type& src_args) {
+        PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].packed_tile_counter;
+        uint8_t tensix_id = get_tensix_id(packed_tc);
+        uint8_t tc_id = get_counter_id(packed_tc);
 
-    void write_out() {}
+        // Wait for entries that were previously read across all transaction ids to be posted. Need to do this because HW doesn't track pending posts
+        // When this condition is met, we know previous reads were committed
+        while (fast_llk_intf_read_posted(tensix_id, tc_id) < (ptxn_id_loop_cnt_ * local_dfb_interface_.num_entries_per_txn_id_per_tc));
+
+        // Make sure there is space for the new tile
+        while (fast_llk_intf_get_free_space(tensix_id, tc_id) < 1);
+
+        noc.async_read<Noc::TxnIdMode::ENABLED>(src, *this, get_entry_size(), src_args, {}, NOC_UNICAST_WRITE_VC, local_dfb_interface_.txn_ids[ptxn_id_index_]);
+
+        local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr += (local_dfb_interface_.stride_size);
+        if (local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr == local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].limit) {
+            local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].base_addr;
+        }
+
+        ptiles_read_++;
+       // Move to next txn id when we have read in num tiles per DM producer.
+       // This is safe because we ensure previously read entries are posted before reading in more data
+        if (ptiles_read_ % local_dfb_interface_.num_entries_per_txn_id == 0) {
+            ptxn_id_index_ = (ptxn_id_index_ + 1) % local_dfb_interface_.num_txn_ids;
+            ptxn_id_loop_cnt_++;
+        }
+
+        local_dfb_interface_.tc_idx = (local_dfb_interface_.tc_idx + 1) % local_dfb_interface_.num_tcs_to_rr;
+    }
+
+    template <typename Dst>
+    void write_out(const Noc& noc, const Dst& dst, const typename noc_traits_t<Dst>::dst_args_type& dst_args) {
+        PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].packed_tile_counter;
+        uint8_t tensix_id = get_tensix_id(packed_tc);
+        uint8_t tc_id = get_counter_id(packed_tc);
+
+
+        // Wait for entries that were previously written across all transaction ids to be acked. Need to do this because HW doesn't track pending acks
+        // When this condition is met, we know previous writes were issued
+        while (fast_llk_intf_read_acked(tensix_id, tc_id) < (ctxn_id_loop_cnt_ * local_dfb_interface_.num_entries_per_txn_id_per_tc));
+
+        while (fast_llk_intf_get_occupancy(tensix_id, tc_id) < 1);
+
+        noc.async_write<Noc::TxnIdMode::ENABLED>(*this, dst, get_entry_size(), {}, dst_args, NOC_UNICAST_WRITE_VC, local_dfb_interface_.txn_ids[ctxn_id_index_]);
+
+        local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr += (local_dfb_interface_.stride_size);
+        if (local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr == local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].limit) {
+            local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].base_addr;
+        }
+
+        ctiles_written_++;
+        // Move to next txn id when the DM has written its threshold per transaction id.
+        // This is safe because we ensure previous writes are acked before trying to write more data
+        if (ctiles_written_ % local_dfb_interface_.num_entries_per_txn_id == 0) {
+            ctxn_id_index_ = (ctxn_id_index_ + 1) % local_dfb_interface_.num_txn_ids;
+            ctxn_id_loop_cnt_++;
+        }
+
+        local_dfb_interface_.tc_idx = (local_dfb_interface_.tc_idx + 1) % local_dfb_interface_.num_tcs_to_rr;
+    }
     // Implicit sync APIs end
+#endif
 
     // from pov of producer need to make sure all the entries get posted (check the raw posted per TC == raw acked per
     // TC)
@@ -207,12 +238,12 @@ public:
 
     uint32_t get_write_ptr() const {
         // return byte address (wr_ptr is 16B address on Gen1XX)
-        return local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr;
+        return local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr + MEM_L1_UNCACHED_BASE;
     }
 
     uint32_t get_read_ptr() const {
         // return byte address (rd_ptr is 16B address on Gen1XX)
-        return local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr;
+        return local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr + MEM_L1_UNCACHED_BASE;
     }
 
     [[nodiscard]] auto scoped_lock() {
@@ -228,9 +259,15 @@ private:
     LocalDFBInterface& local_dfb_interface_;
 
     uint16_t logical_dfb_id_;
-    uint32_t txn_id_loop_cnt_ = 0;  // try to remove this
-    // TODO: update txn id isr handling
-    uint8_t txn_id_index_ = 0;
+
+    // Metadata for implicit sync
+    uint16_t ptxn_id_loop_cnt_ = 0;
+    uint8_t ptxn_id_index_ = 0;
+    uint16_t ptiles_read_ = 0; // isn't the same as reading the tile counter because we don't have a way of tracking pending posts from HW
+
+    uint16_t ctxn_id_loop_cnt_ = 0;
+    uint8_t ctxn_id_index_ = 0;
+    uint16_t ctiles_written_ = 0; // isn't the same as reading the tile counter because we don't have a way of tracking pending acks from HW
 };
 
 #ifndef COMPILE_FOR_TRISC

--- a/tt_metal/hw/inc/internal/dataflow_buffer_init.h
+++ b/tt_metal/hw/inc/internal/dataflow_buffer_init.h
@@ -11,6 +11,7 @@
 #include "internal/tt-2xx/quasar/overlay/remapper_api.hpp"
 #ifndef COMPILE_FOR_TRISC
 #include "internal/tt-2xx/quasar/overlay/llk_intf_api.hpp"
+#include "internal/tt-2xx/quasar/overlay/dataflow_buffer_isr.h"
 #else
 #include "ckernel_trisc_common.h"
 #endif
@@ -25,6 +26,21 @@ extern RemapperAPI g_remapper_configurator;
 #endif
 
 namespace experimental {
+
+FORCE_INLINE void setup_isr_csrs() {
+#ifndef COMPILE_FOR_TRISC
+    // Setup mtvec
+    uint64_t csr_reg = (uint64_t)dfb_implicit_sync_handler;
+
+    asm volatile("csrw mtvec, %0" : : "r"(csr_reg));
+
+    // Enable ROCC interrupt in mie
+    asm volatile("csrrs zero, mie, %0" : : "r"(static_cast<uint64_t>(1 << 13)));
+
+    // Enable MIE in mstatus
+    asm volatile("csrrs zero, mstatus, %0" : : "r"(static_cast<uint64_t>(1 << 3)));
+#endif
+}
 
 FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base, uint32_t local_dfb_mask) {
     uint64_t hartid;
@@ -85,16 +101,27 @@ FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base
             dfb_interface.wr_entry_idx = 0;
             dfb_interface.wr_entry_ptr = 0;
 
-            dfb_interface.num_txn_ids = init_ptr->num_txn_ids;
-            for (uint8_t i = 0; i < init_ptr->num_txn_ids; i++) {
-                dfb_interface.txn_ids[i] = init_ptr->txn_ids[i];
-            }
-            dfb_interface.num_entries_per_txn_id = init_ptr->num_entries_per_txn_id;
-            dfb_interface.num_entries_per_txn_id_per_tc = init_ptr->num_entries_per_txn_id_per_tc;
-
             dfb_interface.tc_idx = 0;
             dfb_interface.tensix_trisc_mask = init_ptr->risc_mask_bits.tensix_trisc_mask;
             dfb_interface.broadcast_tc = per_risc_ptr->num_tcs_and_init.broadcast_tc;
+
+#ifndef COMPILE_FOR_TRISC
+            if (per_risc_ptr->flags.is_producer) {
+                dfb_interface.num_txn_ids = init_ptr->producer_txn_descriptor.num_txn_ids;
+                dfb_interface.num_entries_per_txn_id = init_ptr->producer_txn_descriptor.num_entries_per_txn_id;
+                dfb_interface.num_entries_per_txn_id_per_tc = init_ptr->producer_txn_descriptor.num_entries_per_txn_id_per_tc;
+                for (uint8_t i = 0; i < dfb_interface.num_txn_ids; i++) {
+                    dfb_interface.txn_ids[i] = init_ptr->producer_txn_descriptor.txn_ids[i];
+                }
+            } else {
+                dfb_interface.num_txn_ids = init_ptr->consumer_txn_descriptor.num_txn_ids;
+                dfb_interface.num_entries_per_txn_id = init_ptr->consumer_txn_descriptor.num_entries_per_txn_id;
+                dfb_interface.num_entries_per_txn_id_per_tc = init_ptr->consumer_txn_descriptor.num_entries_per_txn_id_per_tc;
+                for (uint8_t i = 0; i < dfb_interface.num_txn_ids; i++) {
+                    dfb_interface.txn_ids[i] = init_ptr->consumer_txn_descriptor.txn_ids[i];
+                }
+            }
+#endif
         }
 
         // Jump to next DFB: skip dfb_initializer_t + (num_riscs * dfb_initializer_per_risc_t)
@@ -106,6 +133,7 @@ FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base
     if (hartid == 0) {
         // Pass A: configure remapper for all DM producers across all DFBs, then enable
         bool enable_remapper = false;
+        bool enable_implicit_sync = false;
         base_ptr = reinterpret_cast<volatile uint8_t*>(dfb_config_base);
         for (uint32_t logical_dfb_id = 0; logical_dfb_id < num_dfbs; logical_dfb_id++) {
             volatile dfb_initializer_t* init_ptr = reinterpret_cast<volatile dfb_initializer_t*>(base_ptr);
@@ -115,40 +143,94 @@ FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base
             volatile dfb_initializer_per_risc_t* per_risc_base =
                 reinterpret_cast<volatile dfb_initializer_per_risc_t*>(base_ptr + sizeof(dfb_initializer_t));
 
-            // Configure remapper for all producers with remapper_en (DM and Tensix, e.g. Tensix producer + BLOCKED).
+            uint8_t num_producer_tcs = 0;
+            uint8_t producer_tcs[MAX_NUM_TILE_COUNTERS_TO_RR] = {};
+            uint8_t num_consumer_tcs = 0;
+            uint8_t consumer_tcs[MAX_NUM_TILE_COUNTERS_TO_RR] = {};
             for (uint8_t i = 0; i < num_riscs; i++) {
                 volatile dfb_initializer_per_risc_t* per_risc_ptr = per_risc_base + i;
-                if (per_risc_ptr->flags.is_producer && per_risc_ptr->flags.remapper_en) {
-                    enable_remapper = true;
-                    uint8_t remapper_consumer_ids_mask = per_risc_ptr->remapper_consumer_ids_mask;
-                    uint8_t producer_client_type = per_risc_ptr->producer_client_type;
-                    uint8_t num_clientRs = static_cast<uint8_t>(__builtin_popcount(remapper_consumer_ids_mask));
-                    uint8_t clientR_valid_mask = (1u << num_clientRs) - 1;
-                    g_remapper_configurator.set_pair_index(static_cast<uint32_t>(per_risc_ptr->flags.remapper_pair_index));
-                    // DPRINT << "Setting clientL fields clientL=" << static_cast<uint32_t>(producer_client_type)
-                    //        << " tc: " << static_cast<uint32_t>(get_counter_id(per_risc_ptr->packed_tile_counter[0]))
-                    //        << " mask: " << static_cast<uint32_t>(clientR_valid_mask) << ENDL();
-                    g_remapper_configurator.configure_clientL_all_fields(
-                        producer_client_type,
-                        get_counter_id(per_risc_ptr->packed_tile_counter[0]),
-                        clientR_valid_mask,
-                        1,  // is_producer
-                        1,  // group mode
-                        0   // distribute mode
-                    );
-                    uint8_t mask_remaining = remapper_consumer_ids_mask;
-                    for (uint8_t clientR_idx = 0; clientR_idx < num_clientRs; clientR_idx++) {
-                        uint8_t id_R = static_cast<uint8_t>(__builtin_ctz(mask_remaining));
-                        mask_remaining &= mask_remaining - 1;
-                        uint8_t tc_R = (per_risc_ptr->consumer_tcs >> (clientR_idx * 5)) & 0x1F;
-                        // DPRINT << "Setting clientR slot " << static_cast<uint32_t>(clientR_idx)
-                        //        << " id: " << static_cast<uint32_t>(id_R) << " tc: " << static_cast<uint32_t>(tc_R)
-                        //        << ENDL();
-                        g_remapper_configurator.set_clientR_slot(clientR_idx, id_R, tc_R);
+
+                if (per_risc_ptr->flags.is_producer) {
+                    if (per_risc_ptr->flags.remapper_en) { // Configure remapper for all producers with remapper_en (DM and Tensix)
+                        enable_remapper = true;
+                        uint8_t remapper_consumer_ids_mask = per_risc_ptr->remapper_consumer_ids_mask;
+                        uint8_t producer_client_type = per_risc_ptr->producer_client_type;
+                        uint8_t num_clientRs = static_cast<uint8_t>(__builtin_popcount(remapper_consumer_ids_mask));
+                        uint8_t clientR_valid_mask = (1u << num_clientRs) - 1;
+                        g_remapper_configurator.set_pair_index(static_cast<uint32_t>(per_risc_ptr->flags.remapper_pair_index));
+                        // DPRINT << "Setting clientL fields clientL=" << static_cast<uint32_t>(producer_client_type)
+                        //        << " tc: " << static_cast<uint32_t>(get_counter_id(per_risc_ptr->packed_tile_counter[0]))
+                        //        << " mask: " << static_cast<uint32_t>(clientR_valid_mask) << ENDL();
+                        g_remapper_configurator.configure_clientL_all_fields(
+                            producer_client_type,
+                            get_counter_id(per_risc_ptr->packed_tile_counter[0]),
+                            clientR_valid_mask,
+                            1,  // is_producer
+                            1,  // group mode
+                            0   // distribute mode
+                        );
+                        uint8_t mask_remaining = remapper_consumer_ids_mask;
+                        for (uint8_t clientR_idx = 0; clientR_idx < num_clientRs; clientR_idx++) {
+                            uint8_t id_R = static_cast<uint8_t>(__builtin_ctz(mask_remaining));
+                            mask_remaining &= mask_remaining - 1;
+                            uint8_t tc_R = (per_risc_ptr->consumer_tcs >> (clientR_idx * 5)) & 0x1F;
+                            // DPRINT << "Setting clientR slot " << static_cast<uint32_t>(clientR_idx)
+                            //        << " id: " << static_cast<uint32_t>(id_R) << " tc: " << static_cast<uint32_t>(tc_R)
+                            //        << ENDL();
+                            g_remapper_configurator.set_clientR_slot(clientR_idx, id_R, tc_R);
+                        }
+                        // DPRINT << "Writing all remapper configs" << ENDL();
+                        g_remapper_configurator.write_all_configs();
                     }
-                    // DPRINT << "Writing all remapper configs" << ENDL();
-                    g_remapper_configurator.write_all_configs();
+
+                    for (uint8_t i = 0; i < per_risc_ptr->num_tcs_and_init.num_tcs_to_rr; i++) {
+                        producer_tcs[num_producer_tcs++] = per_risc_ptr->packed_tile_counter[i];
+                    }
+                } else {
+                    for (uint8_t i = 0; i < per_risc_ptr->num_tcs_and_init.num_tcs_to_rr; i++) {
+                        consumer_tcs[num_consumer_tcs++] = per_risc_ptr->packed_tile_counter[i];
+                    }
                 }
+            }
+
+            // Got all info from producers and consumers, now set up the TxnDFBDescriptor for producer and consumer
+            uint32_t producer_txn_id_mask = 0;
+            uint32_t consumer_txn_id_mask = 0;
+            for (uint8_t i = 0; i < init_ptr->producer_txn_descriptor.num_txn_ids; i++) {
+                uint8_t txn_id = init_ptr->producer_txn_descriptor.txn_ids[i];
+                producer_txn_id_mask |= (1u << txn_id);
+                volatile TxnDFBDescriptor& dst = g_txn_dfb_descriptor[txn_id];
+                dst.num_counters = static_cast<uint8_t>(num_producer_tcs);
+                for (uint8_t j = 0; j < dst.num_counters; j++) {
+                    dst.tile_counters[j] = producer_tcs[j];
+                }
+                dst.tiles_to_post = init_ptr->producer_txn_descriptor.num_entries_per_txn_id_per_tc;
+                SET_TILES_TO_PROCESS_THRES_TR_ACK(txn_id, init_ptr->producer_txn_descriptor.num_entries_to_process_threshold);
+            }
+            for (uint8_t i = 0; i < init_ptr->consumer_txn_descriptor.num_txn_ids; i++) {
+                uint8_t txn_id = init_ptr->consumer_txn_descriptor.txn_ids[i];
+                consumer_txn_id_mask |= (1u << txn_id);
+                volatile TxnDFBDescriptor& dst = g_txn_dfb_descriptor[txn_id];
+                dst.num_counters = static_cast<uint8_t>(num_consumer_tcs);
+                for (uint8_t j = 0; j < dst.num_counters; j++) {
+                    dst.tile_counters[j] = consumer_tcs[j];
+                }
+                dst.tiles_to_ack = init_ptr->consumer_txn_descriptor.num_entries_per_txn_id_per_tc;
+                SET_TILES_TO_PROCESS_THRES_WR_SENT(txn_id, init_ptr->consumer_txn_descriptor.num_entries_to_process_threshold);
+            }
+            if (producer_txn_id_mask != 0) {
+                enable_implicit_sync = true;
+                // per_trid_tiles_to_process_set_interrupt_enable_cmdbuf_0(producer_txn_id_mask);
+                uint64_t reg_val = CMDBUF_RD_REG(0, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_PER_TR_ID_IE_1_REG_OFFSET);
+                reg_val = (reg_val & 0x00000000FFFFFFFFULL) | ((uint64_t)(producer_txn_id_mask & 0xFFFFFFFFULL) << 32);
+                CMDBUF_WR_REG(OVERLAY_RD_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_PER_TR_ID_IE_1_REG_OFFSET, reg_val);
+            }
+            if (consumer_txn_id_mask != 0) {
+                enable_implicit_sync = true;
+                // per_trid_wr_tiles_to_process_set_interrupt_enable_cmdbuf_0(consumer_txn_id_mask);
+                uint64_t reg_val = CMDBUF_RD_REG(0, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_PER_TR_ID_IE_2_REG_OFFSET);
+                reg_val = (reg_val & 0xFFFFFFFF00000000ULL) | (consumer_txn_id_mask & 0xFFFFFFFFULL);
+                CMDBUF_WR_REG(OVERLAY_WR_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_PER_TR_ID_IE_2_REG_OFFSET, reg_val);
             }
 
             base_ptr += sizeof(dfb_initializer_t) + (num_riscs * sizeof(dfb_initializer_per_risc_t));
@@ -157,6 +239,10 @@ FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base
         if (enable_remapper) {
             // DPRINT << "Enabling remapper" << ENDL();
             g_remapper_configurator.enable_remapper();
+        }
+
+        if (enable_implicit_sync) {
+            setup_isr_csrs();
         }
     }  // end if (hartid == 0)
 #endif
@@ -194,9 +280,6 @@ FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base
                     //         << " tc_id: " << static_cast<uint32_t>(tc_id) << ENDL();
                     llk_intf_reset(tensix_id, tc_id);
                     llk_intf_set_capacity(tensix_id, tc_id, init_ptr->capacity);
-                    // DPRINT << " capacity: "
-                    //         << static_cast<uint32_t>(llk_intf_get_capacity(tensix_id, tc_id))
-                    //         << " free space: " << static_cast<uint32_t>(llk_intf_get_free_space(tensix_id, tc_id)) << ENDL();
 #endif
                 }
                 // Single writer per per_risc entry; no atomic needed

--- a/tt_metal/hw/inc/internal/dataflow_buffer_interface.h
+++ b/tt_metal/hw/inc/internal/dataflow_buffer_interface.h
@@ -61,9 +61,17 @@ inline __attribute__((always_inline)) constexpr uint8_t get_counter_id(PackedTil
     | dfb_initializer_per_risc_t | risc 0
     | dfb_initializer_per_risc_t | risc 1
     ...
-    (24 + (44 * 12)) * 16 = 8320 bytes
+    (36 + (44 * 12)) * 16 = 8336 bytes
 */
-struct dfb_initializer_t {  // 24 bytes
+struct dfb_txn_id_descriptor_t {
+    uint8_t txn_ids[NUM_TXN_IDS];
+    uint8_t num_entries_to_process_threshold; // entries each txn ID tracks before posting/acking
+    uint8_t num_txn_ids;
+    uint8_t num_entries_per_txn_id;
+    uint8_t num_entries_per_txn_id_per_tc;
+} __attribute__((packed));
+
+struct dfb_initializer_t {  // 36 bytes
     uint32_t logical_id;
     uint32_t entry_size;
     uint32_t stride_in_entries;
@@ -73,11 +81,11 @@ struct dfb_initializer_t {  // 24 bytes
         uint16_t tensix_mask : 4;     // bits 8-11: Neo RISC mask
         uint16_t tensix_trisc_mask : 4;        // bits 12-15: indicates which triscs use the DFB (tensix producer uses trisc2 and tensix consumer can use trisc0 or trisc3)
     } risc_mask_bits;
+    // For DM-to-DM DFBs, producer and consumer would have different set of transaction ids
+    dfb_txn_id_descriptor_t producer_txn_descriptor;
+    dfb_txn_id_descriptor_t consumer_txn_descriptor;
     uint8_t num_producers;
-    uint8_t num_txn_ids;
-    uint8_t txn_ids[NUM_TXN_IDS];
-    uint8_t num_entries_per_txn_id;
-    uint8_t num_entries_per_txn_id_per_tc;
+    uint8_t padding[3];
 } __attribute__((packed));
 
 struct dfb_initializer_per_risc_t {  // 44 bytes
@@ -114,6 +122,9 @@ struct dfb_initializer_intra_tensix_t {  // 24 bytes
     uint8_t tensix_mask;
 } __attribute__((packed));
 
+
+// TODO: Put LocalDFBInterface into device only header so fields can be ifdef for trisc vs dm
+
 // Per–tile-counter slot
 struct DFBTCSlot {
     uint32_t rd_ptr;
@@ -148,8 +159,19 @@ struct LocalDFBInterface {
 
 } __attribute__((packed));
 
+// Holds metadata for transaction ID based ISR handling
+// It is used by the ISR to understand which tile counters need to update which credits (post/ack)
+struct TxnDFBDescriptor {
+    uint8_t num_counters;
+    PackedTileCounter tile_counters[MAX_NUM_TILE_COUNTERS_TO_RR];
+    union {
+        uint8_t tiles_to_post;
+        uint8_t tiles_to_ack;
+    } __attribute__((packed));
+};
+
 static_assert(sizeof(DFBTCSlot) == 17, "DFBTCSlot size is incorrect");
-static_assert(sizeof(dfb_initializer_t) == 24, "dfb_initializer_t size is incorrect");
+static_assert(sizeof(dfb_initializer_t) == 36, "dfb_initializer_t size is incorrect");
 static_assert(sizeof(dfb_initializer_per_risc_t) == 44, "dfb_initializer_per_risc_t size is incorrect");
 static_assert(sizeof(dfb_initializer_intra_tensix_t) == 24, "dfb_initializer_intra_tensix_t size is incorrect");
 static_assert(sizeof(LocalDFBInterface) == 103, "LocalDFBInterface size is incorrect");

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/overlay/dataflow_buffer_isr.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/overlay/dataflow_buffer_isr.h
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "internal/dataflow_buffer_interface.h"
+#include "internal/tt-2xx/quasar/overlay/llk_intf_api.hpp"
+
+namespace experimental {
+
+extern volatile TxnDFBDescriptor g_txn_dfb_descriptor[32];
+
+inline __attribute__((always_inline)) void dfb_tile_poster_irq_handler() {
+    uint64_t fired_trids = CMDBUF_RD_REG(OVERLAY_RD_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_PER_TR_ID_IP_1_REG_OFFSET);
+    uint64_t pending = (fired_trids >> 32) & 0xFFFFFFFFULL;
+    while (pending) {
+        uint64_t trid = __builtin_ctzll(pending);
+
+        volatile TxnDFBDescriptor& txn_dfb_descriptor = g_txn_dfb_descriptor[trid];
+        for (uint8_t i = 0; i < txn_dfb_descriptor.num_counters; i++) {
+            PackedTileCounter packed_tile_counter = txn_dfb_descriptor.tile_counters[i];
+            uint8_t tensix_id = get_tensix_id(packed_tile_counter);
+            uint8_t tc_id = get_counter_id(packed_tile_counter);
+            fast_llk_intf_inc_posted(tensix_id, tc_id, txn_dfb_descriptor.tiles_to_post);
+        }
+
+        CMDBUF_CLEAR_TILES_TO_PROCESS_TR_ACK(OVERLAY_RD_CMD_BUF, trid);
+        asm volatile("nop");  // must give time for the clear to propagate (hw bug, this is needed)
+
+        pending &= (pending - 1);
+    }
+    if ((fired_trids >> 32) != 0) {
+        uint64_t to_clear = (fired_trids >> 32) & 0xFFFFFFFFULL;
+        uint64_t clear_val = fired_trids & ~(to_clear << 32);
+        CMDBUF_WR_REG(OVERLAY_RD_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_PER_TR_ID_IP_1_REG_OFFSET, clear_val);
+    }
+}
+
+inline __attribute__((always_inline)) void dfb_tile_acker_irq_handler() {
+    uint64_t fired_trids = CMDBUF_RD_REG(OVERLAY_WR_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_PER_TR_ID_IP_2_REG_OFFSET);
+    uint64_t pending = fired_trids & 0xFFFFFFFFULL;
+    while (pending) {
+        uint64_t trid = __builtin_ctzll(pending);
+
+        volatile TxnDFBDescriptor& txn_dfb_descriptor = g_txn_dfb_descriptor[trid];
+        for (uint8_t i = 0; i < txn_dfb_descriptor.num_counters; i++) {
+            PackedTileCounter packed_tile_counter = txn_dfb_descriptor.tile_counters[i];
+            uint8_t tensix_id = get_tensix_id(packed_tile_counter);
+            uint8_t tc_id = get_counter_id(packed_tile_counter);
+            fast_llk_intf_inc_acked(tensix_id, tc_id, txn_dfb_descriptor.tiles_to_ack);
+        }
+
+        CMDBUF_CLEAR_TILES_TO_PROCESS_WR_SENT(OVERLAY_WR_CMD_BUF, trid);
+        asm volatile("nop");  // must give time for the clear to propagate (this is needed)
+
+        pending &= (pending - 1);
+    }
+    if ((fired_trids & 0xFFFFFFFFULL) != 0) {
+        uint64_t to_clear = fired_trids & 0xFFFFFFFFULL;
+        uint64_t clear_val = fired_trids & ~to_clear;
+        CMDBUF_WR_REG(OVERLAY_WR_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_PER_TR_ID_IP_2_REG_OFFSET, clear_val);
+    }
+}
+
+inline __attribute__((interrupt, hot)) void dfb_implicit_sync_handler() {
+    dfb_tile_poster_irq_handler();
+    dfb_tile_acker_irq_handler();
+}
+
+}  // namespace experimental

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
@@ -109,6 +109,20 @@ uint8_t RemapperIndexAllocator::allocate(const CoreCoord& core_coord) {
 
 void RemapperIndexAllocator::reset() { next_index_.clear(); }
 
+std::vector<uint8_t> TxnIdAllocator::allocate(uint8_t count) {
+    TT_FATAL(
+        next_id_ + count <= 32,
+        "TxnIdAllocator exhausted: requested {} IDs at next_id_={}, but only 32 are available",
+        count,
+        next_id_);
+    std::vector<uint8_t> ids;
+    ids.reserve(count);
+    for (uint8_t i = 0; i < count; i++) {
+        ids.push_back(next_id_++);
+    }
+    return ids;
+}
+
 uint8_t ClientTypeAllocator::allocate_for_consumer(uint8_t producer_client_type, uint8_t consumer_risc_id) {
     uint8_t client_type;
 
@@ -136,6 +150,56 @@ uint8_t ClientTypeAllocator::allocate_for_consumer(uint8_t producer_client_type,
     }
 
     return client_type;
+}
+
+// Computes dfb_txn_id_descriptor_t for either the producer or consumer side of a DFB.
+static ::experimental::dfb_txn_id_descriptor_t compute_txn_descriptor(
+    uint16_t capacity,
+    uint8_t num_producers,
+    uint8_t num_consumers,
+    bool is_producer,
+    const std::vector<uint8_t>& txn_ids,
+    uint8_t num_tcs_per_risc) {
+    uint8_t num_prods_or_cons = is_producer ? num_producers : num_consumers;
+    uint8_t num_txn_ids = static_cast<uint8_t>(txn_ids.size());
+
+    // threshold is the number of transactions that each txn ID needs to process before posting/acking
+    // for reads the transaction needs to be committed to dst, for writes the transaction needs to be sent out
+    uint8_t threshold;
+    if (num_producers == 1 && num_consumers == 1) {
+        TT_FATAL(
+            capacity % num_txn_ids == 0,
+            "DFB capacity {} must be divisible by num_txn_ids {} for implicit sync",
+            capacity,
+            num_txn_ids);
+        threshold = static_cast<uint8_t>(capacity / num_txn_ids);
+    } else {
+        threshold = num_prods_or_cons * num_tcs_per_risc;
+    }
+
+    TT_FATAL(
+        threshold % num_prods_or_cons == 0,
+        "num_entries_to_process_threshold {} must be divisible by num_prods_or_cons {}",
+        threshold,
+        num_prods_or_cons);
+    uint8_t per_txn = threshold / num_prods_or_cons;
+
+    TT_FATAL(
+        per_txn % num_tcs_per_risc == 0,
+        "num_entries_per_txn_id {} must be divisible by num_tcs_per_risc {}",
+        per_txn,
+        num_tcs_per_risc);
+    uint8_t per_txn_per_tc = per_txn / num_tcs_per_risc;
+
+    ::experimental::dfb_txn_id_descriptor_t desc = {};
+    desc.num_txn_ids = num_txn_ids;
+    desc.num_entries_to_process_threshold = threshold;
+    desc.num_entries_per_txn_id = per_txn; // number of transactions each DM producer/consumer contributes
+    desc.num_entries_per_txn_id_per_tc = per_txn_per_tc; // number of transactions each TC contributes
+    for (uint8_t i = 0; i < num_txn_ids; i++) {
+        desc.txn_ids[i] = txn_ids[i];
+    }
+    return desc;
 }
 
 bool has_dm_risc(uint16_t risc_mask) { return (risc_mask & 0xFF) != 0; }
@@ -230,12 +294,8 @@ std::vector<uint8_t> DataflowBufferImpl::serialize() const {
     init.risc_mask_bits.tensix_mask = (this->risc_mask >> 8) & 0x0F;
     init.risc_mask_bits.tensix_trisc_mask = this->tensix_trisc_mask & 0x0F;
     init.num_producers = this->config.num_producers;
-    init.num_txn_ids = this->num_txn_ids;
-    for (int i = 0; i < 4; i++) {
-        init.txn_ids[i] = this->txn_ids[i];
-    }
-    init.num_entries_per_txn_id = this->num_entries_per_txn_id;
-    init.num_entries_per_txn_id_per_tc = this->num_entries_per_txn_id_per_tc;
+    init.producer_txn_descriptor = this->producer_txn_descriptor;
+    init.consumer_txn_descriptor = this->consumer_txn_descriptor;
 
     log_info(
         tt::LogMetal,
@@ -250,12 +310,16 @@ std::vector<uint8_t> DataflowBufferImpl::serialize() const {
     log_info(tt::LogMetal, "Stride in entries: {}", this->stride_in_entries);
     log_info(tt::LogMetal, "Capacity: {}", this->capacity);
     log_info(tt::LogMetal, "Risc mask: 0x{:x}", this->risc_mask);
-    log_info(tt::LogMetal, "Num txn ids: {}", this->num_txn_ids);
-    for (int i = 0; i < ::experimental::NUM_TXN_IDS; i++) {
-        log_info(tt::LogMetal, "Txn id {}: {}", i, this->txn_ids[i]);
-    }
-    log_info(tt::LogMetal, "Num entries per txn id: {}", this->num_entries_per_txn_id);
-    log_info(tt::LogMetal, "Num entries per txn id per tc: {}", this->num_entries_per_txn_id_per_tc);
+    log_info(tt::LogMetal, "Producer txn descriptor: num_txn_ids={} threshold={} per_txn={} per_tc={}",
+        this->producer_txn_descriptor.num_txn_ids,
+        this->producer_txn_descriptor.num_entries_to_process_threshold,
+        this->producer_txn_descriptor.num_entries_per_txn_id,
+        this->producer_txn_descriptor.num_entries_per_txn_id_per_tc);
+    log_info(tt::LogMetal, "Consumer txn descriptor: num_txn_ids={} threshold={} per_txn={} per_tc={}",
+        this->consumer_txn_descriptor.num_txn_ids,
+        this->consumer_txn_descriptor.num_entries_to_process_threshold,
+        this->consumer_txn_descriptor.num_entries_per_txn_id,
+        this->consumer_txn_descriptor.num_entries_per_txn_id_per_tc);
 
     const auto* init_bytes = reinterpret_cast<const uint8_t*>(&init);
     data.insert(data.end(), init_bytes, init_bytes + sizeof(init));
@@ -390,7 +454,6 @@ uint32_t ProgramImpl::add_dataflow_buffer(const CoreRangeSet& core_range_set, co
 
     TT_FATAL(config.pap != ::experimental::AccessPattern::BLOCKED, "Blocked producer pattern not supported");
 
-    TT_FATAL(!config.enable_implicit_sync, "Implicit sync not supported yet");
     TT_FATAL(
         core_range_set.num_cores() == 1,
         "DFB only supports single core, but CoreRangeSet contains {} cores: {}",
@@ -534,9 +597,6 @@ void ProgramImpl::finalize_single_dfb_config(
         !(producer_is_tensix_only && consumer_is_tensix_only),
         "Both producer and consumer cannot be Tensix-only RISCs - at least one DM RISC is required to initialize tile "
         "counters");
-    // TT_FATAL(
-    //     !(producer_is_tensix_only && config.cap == ::experimental::AccessPattern::BLOCKED),
-    //     "Tensix producer with BLOCKED consumer pattern is not supported");
 
     dfb->risc_mask = config.producer_risc_mask | config.consumer_risc_mask;
 
@@ -845,6 +905,46 @@ void ProgramImpl::finalize_single_dfb_config(
         risc_config.config.num_tcs_to_rr = num_consumer_tcs;
 
         dfb->risc_configs.push_back(risc_config);
+    }
+
+    // Allocate transaction IDs and compute ISR descriptor fields when implicit sync is enabled.
+    // Two txn IDs per side for double buffering.
+    if (config.enable_implicit_sync) {
+        constexpr uint8_t TXN_IDS_PER_SIDE = 2;
+
+        auto producer_txn_ids = txn_id_allocator_.allocate(TXN_IDS_PER_SIDE);
+        dfb->producer_txn_descriptor = compute_txn_descriptor(
+            dfb->capacity,
+            config.num_producers,
+            config.num_consumers,
+            /*is_producer=*/true,
+            producer_txn_ids,
+            num_producer_tcs);
+
+        auto consumer_txn_ids = txn_id_allocator_.allocate(TXN_IDS_PER_SIDE);
+        dfb->consumer_txn_descriptor = compute_txn_descriptor(
+            dfb->capacity,
+            config.num_producers,
+            config.num_consumers,
+            /*is_producer=*/false,
+            consumer_txn_ids,
+            num_consumer_tcs);
+
+        log_info(
+            tt::LogMetal,
+            "DFB {} implicit sync: producer txn_ids=[{},{}] threshold={} per_txn={} per_tc={}; "
+            "consumer txn_ids=[{},{}] threshold={} per_txn={} per_tc={}",
+            dfb->id,
+            dfb->producer_txn_descriptor.txn_ids[0],
+            dfb->producer_txn_descriptor.txn_ids[1],
+            dfb->producer_txn_descriptor.num_entries_to_process_threshold,
+            dfb->producer_txn_descriptor.num_entries_per_txn_id,
+            dfb->producer_txn_descriptor.num_entries_per_txn_id_per_tc,
+            dfb->consumer_txn_descriptor.txn_ids[0],
+            dfb->consumer_txn_descriptor.txn_ids[1],
+            dfb->consumer_txn_descriptor.num_entries_to_process_threshold,
+            dfb->consumer_txn_descriptor.num_entries_per_txn_id,
+            dfb->consumer_txn_descriptor.num_entries_per_txn_id_per_tc);
     }
 
     dfb->configs_finalized = true;

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
@@ -534,9 +534,9 @@ void ProgramImpl::finalize_single_dfb_config(
         !(producer_is_tensix_only && consumer_is_tensix_only),
         "Both producer and consumer cannot be Tensix-only RISCs - at least one DM RISC is required to initialize tile "
         "counters");
-    TT_FATAL(
-        !(producer_is_tensix_only && config.cap == ::experimental::AccessPattern::BLOCKED),
-        "Tensix producer with BLOCKED consumer pattern is not supported");
+    // TT_FATAL(
+    //     !(producer_is_tensix_only && config.cap == ::experimental::AccessPattern::BLOCKED),
+    //     "Tensix producer with BLOCKED consumer pattern is not supported");
 
     dfb->risc_mask = config.producer_risc_mask | config.consumer_risc_mask;
 

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp
@@ -54,10 +54,8 @@ struct DataflowBufferImpl {
     // Shared config fields (written to dfb_initializer_t)
     uint32_t entry_size = 0;
     uint32_t stride_in_entries = 0;
-    std::array<uint8_t, 4> txn_ids = {0};
-    uint8_t num_entries_per_txn_id = 0;
-    uint8_t num_entries_per_txn_id_per_tc = 0;
-    uint8_t num_txn_ids = 0;
+    ::experimental::dfb_txn_id_descriptor_t producer_txn_descriptor = {};
+    ::experimental::dfb_txn_id_descriptor_t consumer_txn_descriptor = {};
 
     // Flag to track if TC/remapper allocation has been finalized
     bool configs_finalized = false;
@@ -87,6 +85,16 @@ public:
 
 private:
     std::unordered_map<CoreCoord, uint8_t> next_index_;
+};
+
+// Allocates hardware transaction IDs. Valid range: [0, 31]
+class TxnIdAllocator {
+public:
+    std::vector<uint8_t> allocate(uint8_t count);
+    void reset() { next_id_ = 0; }
+
+private:
+    uint8_t next_id_ = 0;
 };
 
 // Allocates Remapper clientTypes for BLOCKED consumer mode.

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -375,6 +375,7 @@ private:
         dataflow_buffer_by_id_;
     tt::tt_metal::experimental::dfb::detail::TileCounterAllocator tile_counter_allocator_;
     tt::tt_metal::experimental::dfb::detail::RemapperIndexAllocator remapper_index_allocator_;
+    tt::tt_metal::experimental::dfb::detail::TxnIdAllocator txn_id_allocator_;
     std::unordered_map<CoreCoord, uint8_t> per_core_num_dfbs_;
     std::vector<CircularBufferAllocator> dfb_allocators_;
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/36891

### What's changed
Quasar DMs can automatically post/ack tile counter credits using interrupts on transaction ids. This pr introduces that support. 
Added new "implicit sync" read/write api on dataflow buffer and dfb_txn_id_descriptor_t to set up transaction ids + isr. These allow caller to issue a noc read into/noc write out of the dfb's backing memory. When a specified threshold (num_entries_to_process_threshold) of reads land into the buffer/writes are sent for a particular transaction id, an ISR fires to post/ack credits to tile counters spanning that region of the dfb. 

Added a global array that tells isr  which tile counters need to be updated (and with how many credits) when a particular txn ID threshold is met.

Currently only use two transaction ids per DFB and only DM0 (capable of fast context switch) services the interrupts for all transactions.  In the future we can play around with distributing this handling per txnID or per DFB across DMs

Note: HW doesn't expose "pending tiles to post" so the dfb class tracks how many credits should have been posted. Details about this issue [here](https://docs.google.com/document/d/1L2DT0flwW8ENmOc5OvaZoua286Inoq3v8jexCdL6w0s/edit?tab=t.0#heading=h.os8orrgqzptp)

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=abhullar/dfb-is)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:abhullar/dfb-is)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=abhullar/dfb-is)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:abhullar/dfb-is)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=abhullar/dfb-is)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:abhullar/dfb-is)
- [x] New/Existing tests provide coverage for changes
- [x] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early

