### PR TITLE
[QSR]: Add Watcher NOC Sanitize Support

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
@@ -102,13 +102,14 @@ void RunTestOnCore(
     bool is_idle_eth_core = false) {
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();
     bool is_quasar = hal.get_arch() == tt::ARCH::QUASAR;
-    // It's not simple to check the watcher server status from the finish loop for slow dispatch, so just run these
-    // tests in FD.
+    // IDLE_ETH cores only support SD (FD not yet implemented)
+    // TENSIX/ACTIVE_ETH cores: SD only used for Quasar watcher tests (TODO: Remove once FD enabled on Quasar)
     if (fixture->IsSlowDispatch() && !is_idle_eth_core && !is_quasar) {
-        GTEST_SKIP();
+        GTEST_SKIP() << "Slow Dispatch tests only run on Quasar or IDLE_ETH cores";
     }
 
     const std::string kernel = "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord.cpp";
+    uint32_t dm_id = use_ncrisc ? 1 : 0;
 
     // Set up program
     distributed::MeshWorkload workload;
@@ -183,12 +184,13 @@ void RunTestOnCore(
     } else {
         if (is_quasar) {
             // On Quasar, kernel runs on all 8 DMs but only dm_id executes the test;
-            // others exit early. This lets us verify assert works on each DM individually
+            // others exit early. This lets us verify NOC sanitizations works on select DM individually
             dram_copy_kernel = tt::tt_metal::experimental::quasar::CreateKernel(
                 program_,
                 kernel,
                 core,
-                tt::tt_metal::experimental::quasar::QuasarDataMovementConfig{.num_threads_per_cluster = 1});
+                tt::tt_metal::experimental::quasar::QuasarDataMovementConfig{
+                    .num_threads_per_cluster = 8, .compile_args = {dm_id}});
         } else {
             tt_metal::DataMovementConfig config{
                 .processor =
@@ -239,8 +241,13 @@ void RunTestOnCore(
         case SanitizeEthSrcL1Overflow: eth_src_overflow_addr_words = 0xAAAAAAAA; break;
         case SanitizeEthDestL1Overflow: eth_dest_overflow_addr_words = 0xBBBBBBBB; break;
         case SanitizeNOCMulticastInvalidRange: {
+            // TODO: Enable this test once we have multi-cluster support enable for Quasar
+            if (is_quasar) {
+                GTEST_SKIP() << "Only single cluster runtime is enabled on quasar";
+            }
             // Use invalid multicast range with actual DRAM cores: start > end
             // Wrap-around is only allowed for Tensix cores, not DRAM
+            // Use actual Tensix worker cores with an invalid multicast range (start > end for NOC0).
             use_multicast_semaphore_inc = true;
 
             // Get actual DRAM NOC coordinates
@@ -304,11 +311,10 @@ void RunTestOnCore(
     std::string expected;
     CoreCoord input_core_virtual_coords = device->virtual_noc0_coordinate(noc, input_buf_noc_xy);
     CoreCoord output_core_virtual_coords = device->virtual_noc0_coordinate(noc, output_buf_noc_xy);
+    // TODO: replace ierisc and erisc with hal.get_processor_class_name() after
+    // unifying all tests + watcher_device_reader::get_riscv_name() with same method
     std::string risc_name = (is_eth_core) ? is_idle_eth_core ? "ierisc" : "erisc"
-                                          : hal.get_processor_class_name(HalProgrammableCoreType::TENSIX, 0, false);
-    if (use_ncrisc) {
-        risc_name = hal.get_processor_class_name(HalProgrammableCoreType::TENSIX, 1, false);
-    }
+                                          : hal.get_processor_class_name(HalProgrammableCoreType::TENSIX, dm_id, false);
     switch (feature) {
         case SanitizeNOCAddress:
             expected = fmt::format(
@@ -407,7 +413,7 @@ void RunTestOnCore(
                 "from local L1[{:#08x}] to DRAM core w/ virtual coords {} DRAM[addr=0x{:08x}] (inline dw writes do not "
                 "support DRAM destination addresses).",
                 device->id(),
-                (is_eth_core) ? "acteth" : "worker",
+                (is_eth_core) ? is_idle_eth_core ? "idleth" : "acteth" : "worker",
                 core.x,
                 core.y,
                 virtual_core.x,
@@ -536,7 +542,7 @@ void RunTestIEth(
         GTEST_SKIP();
     }
     CoreCoord core = *(device->get_inactive_ethernet_cores().begin());
-    RunTestOnCore(fixture, mesh_device, core, true, feature, false, true);
+    RunTestOnCore(fixture, mesh_device, core, true, feature, false /*use_ncrisc*/, true /*is_idle_eth_core*/);
 }
 
 // Run tests for host-side sanitization (uses functions that are from watcher_server.hpp).

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
@@ -126,9 +126,6 @@ void RunTestOnCore(
     auto& program_ = workload.get_programs().at(device_range);
     auto* device = mesh_device->get_devices()[0];
     auto& cq = mesh_device->mesh_command_queue();
-    uint32_t l1_unreserved_base = device->allocator()->get_base_allocator_addr(HalMemType::L1);
-    std::vector<uint32_t> init{0};
-    tt::tt_metal::detail::WriteToDeviceL1(device, core, l1_unreserved_base, init);
 
     CoreCoord virtual_core;
     if (is_eth_core) {
@@ -199,6 +196,9 @@ void RunTestOnCore(
             if (multi_dm_race) {
                 constexpr uint32_t multi_dm_base_addr = 0xFFFF0000;
                 constexpr uint32_t multi_dm_base_size = 0x1000;
+                uint32_t l1_unreserved_base = device->allocator()->get_base_allocator_addr(HalMemType::L1);
+                std::vector<uint32_t> init{0, 0};  // 8 bytes: Quasar barrier uses 64-bit atomics
+                tt::tt_metal::detail::WriteToDeviceL1(device, core, l1_unreserved_base, init);
                 config.compile_args = {num_dms, multi_dm_base_addr, multi_dm_base_size, l1_unreserved_base};
                 config.defines = {{"TEST_MULTI_DM_SANITIZE_RACE", "1"}};
             } else {
@@ -777,7 +777,7 @@ TEST_F(MeshWatcherFixture, TensixTestWatcherSanitizeMulticastSemaphoreInc) {
         this->devices_[0]);
 }
 
-// Quasar multi-DM race test: all 8 DMs sync then race to trigger sanitize error
+// Quasar multi-DM race test: all DMs sync then race to trigger sanitize error
 // Each DM uses unique identifiable data (addr/size). Verifies CAS ensures consistent error reporting
 TEST_F(MeshWatcherFixture, QuasarTestWatcherSanitizeMultiDMRace) {
     this->RunTestOnDevice(

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
@@ -313,8 +313,16 @@ void RunTestOnCore(
     CoreCoord output_core_virtual_coords = device->virtual_noc0_coordinate(noc, output_buf_noc_xy);
     // TODO: replace ierisc and erisc with hal.get_processor_class_name() after
     // unifying all tests + watcher_device_reader::get_riscv_name() with same method
-    std::string risc_name = (is_eth_core) ? is_idle_eth_core ? "ierisc" : "erisc"
-                                          : hal.get_processor_class_name(HalProgrammableCoreType::TENSIX, dm_id, false);
+    std::string risc_name;
+    if (is_eth_core) {
+        risc_name = is_idle_eth_core ? "ierisc" : "erisc";
+    } else {
+        risc_name = hal.get_processor_class_name(HalProgrammableCoreType::TENSIX, dm_id, false);
+    }
+    const char* core_name = "worker";
+    if (is_eth_core) {
+        core_name = is_idle_eth_core ? "idleth" : "acteth";
+    }
     switch (feature) {
         case SanitizeNOCAddress:
             expected = fmt::format(
@@ -322,7 +330,7 @@ void RunTestOnCore(
                 "bytes from local L1[{:#08x}] to Unknown core w/ virtual coords {} [addr=0x{:08x}] (NOC target "
                 "address did not map to any known Tensix/Ethernet/DRAM/PCIE core).",
                 device->id(),
-                (is_eth_core) ? is_idle_eth_core ? "idleth" : "acteth" : "worker",
+                core_name,
                 core.x,
                 core.y,
                 virtual_core.x,
@@ -340,7 +348,7 @@ void RunTestOnCore(
                 "bytes from local L1[{:#08x}] to Tensix core w/ virtual coords {} L1[addr=0x{:08x}] (invalid address "
                 "alignment in NOC transaction).",
                 device->id(),
-                (is_eth_core) ? "acteth" : "worker",
+                core_name,
                 core.x,
                 core.y,
                 virtual_core.x,
@@ -359,7 +367,7 @@ void RunTestOnCore(
                 "bytes to local L1[{:#08x}] from Tensix core w/ virtual coords {} L1[addr=0x{:08x}] (invalid address "
                 "alignment in NOC transaction).",
                 device->id(),
-                (is_eth_core) ? "acteth" : "worker",
+                core_name,
                 core.x,
                 core.y,
                 virtual_core.x,
@@ -377,7 +385,7 @@ void RunTestOnCore(
                 "bytes from local L1[{:#08x}] to Tensix core w/ virtual coords {} L1[addr=0x{:08x}] (NOC target "
                 "overwrites mailboxes).",
                 device->id(),
-                (is_eth_core) ? "acteth" : "worker",
+                core_name,
                 core.x,
                 core.y,
                 virtual_core.x,
@@ -395,7 +403,7 @@ void RunTestOnCore(
                 "bytes to local L1[{:#08x}] from Tensix core w/ virtual coords {} L1[addr=0x{:08x}] (Local L1 "
                 "overwrites mailboxes).",
                 device->id(),
-                (is_eth_core) ? "acteth" : "worker",
+                core_name,
                 core.x,
                 core.y,
                 virtual_core.x,
@@ -413,7 +421,7 @@ void RunTestOnCore(
                 "from local L1[{:#08x}] to DRAM core w/ virtual coords {} DRAM[addr=0x{:08x}] (inline dw writes do not "
                 "support DRAM destination addresses).",
                 device->id(),
-                (is_eth_core) ? is_idle_eth_core ? "idleth" : "acteth" : "worker",
+                core_name,
                 core.x,
                 core.y,
                 virtual_core.x,
@@ -429,7 +437,7 @@ void RunTestOnCore(
                 "bytes from local L1[{:#08x}] to Tensix core w/ virtual coords {} L1[addr=0x{:08x}] (submitting a "
                 "non-mcast transaction when there's a linked transaction).",
                 device->id(),
-                (is_eth_core) ? "acteth" : "worker",
+                core_name,
                 core.x,
                 core.y,
                 virtual_core.x,
@@ -446,7 +454,7 @@ void RunTestOnCore(
                 "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2}): {} core overflowed L1 with access to {:#x} "
                 "of length {} (read or write past the end of local memory).",
                 device->id(),
-                (is_eth_core) ? "acteth" : "worker",
+                core_name,
                 core.x,
                 core.y,
                 virtual_core.x,
@@ -485,7 +493,7 @@ void RunTestOnCore(
                 "bytes from local L1[{:#08x}] to DRAM core range w/ virtual coords (x={},y={})-(x={},y={}) "
                 "DRAM[addr=0x{:08x}] (multicast invalid range).",
                 device->id(),
-                (is_eth_core) ? "acteth" : "worker",
+                core_name,
                 core.x,
                 core.y,
                 virtual_core.x,

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
@@ -15,6 +15,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <regex>
 #include <stdexcept>
 #include <string>
 #include <unordered_set>
@@ -99,13 +100,18 @@ void RunTestOnCore(
     bool is_eth_core,
     watcher_features_t feature,
     bool use_ncrisc = false,
-    bool is_idle_eth_core = false) {
+    bool is_idle_eth_core = false,
+    bool multi_dm_race = false) {
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();
     bool is_quasar = hal.get_arch() == tt::ARCH::QUASAR;
+
     // IDLE_ETH cores only support SD (FD not yet implemented)
     // TENSIX/ACTIVE_ETH cores: SD only used for Quasar watcher tests (TODO: Remove once FD enabled on Quasar)
     if (fixture->IsSlowDispatch() && !is_idle_eth_core && !is_quasar) {
         GTEST_SKIP() << "Slow Dispatch tests only run on Quasar or IDLE_ETH cores";
+    }
+    if (multi_dm_race && !is_quasar) {
+        GTEST_SKIP() << "Multi-DM race test only runs on Quasar";
     }
 
     const std::string kernel = "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord.cpp";
@@ -120,6 +126,9 @@ void RunTestOnCore(
     auto& program_ = workload.get_programs().at(device_range);
     auto* device = mesh_device->get_devices()[0];
     auto& cq = mesh_device->mesh_command_queue();
+    uint32_t l1_unreserved_base = device->allocator()->get_base_allocator_addr(HalMemType::L1);
+    std::vector<uint32_t> init{0};
+    tt::tt_metal::detail::WriteToDeviceL1(device, core, l1_unreserved_base, init);
 
     CoreCoord virtual_core;
     if (is_eth_core) {
@@ -183,14 +192,19 @@ void RunTestOnCore(
         dram_copy_kernel = tt_metal::CreateKernel(program_, kernel, core, config);
     } else {
         if (is_quasar) {
-            // On Quasar, kernel runs on all 8 DMs but only dm_id executes the test;
-            // others exit early. This lets us verify NOC sanitizations works on select DM individually
-            dram_copy_kernel = tt::tt_metal::experimental::quasar::CreateKernel(
-                program_,
-                kernel,
-                core,
-                tt::tt_metal::experimental::quasar::QuasarDataMovementConfig{
-                    .num_threads_per_cluster = 8, .compile_args = {dm_id}});
+            // Quasar: all DMs run kernel; multi_dm_race syncs them to race, else only dm_id executes
+            uint32_t num_dms =
+                MetalContext::instance().hal().get_processor_types_count(HalProgrammableCoreType::TENSIX, 0);
+            tt::tt_metal::experimental::quasar::QuasarDataMovementConfig config{.num_threads_per_cluster = num_dms};
+            if (multi_dm_race) {
+                constexpr uint32_t multi_dm_base_addr = 0xFFFF0000;
+                constexpr uint32_t multi_dm_base_size = 0x1000;
+                config.compile_args = {num_dms, multi_dm_base_addr, multi_dm_base_size, l1_unreserved_base};
+                config.defines = {{"TEST_MULTI_DM_SANITIZE_RACE", "1"}};
+            } else {
+                config.compile_args = {dm_id};
+            }
+            dram_copy_kernel = tt::tt_metal::experimental::quasar::CreateKernel(program_, kernel, core, config);
         } else {
             tt_metal::DataMovementConfig config{
                 .processor =
@@ -241,13 +255,16 @@ void RunTestOnCore(
         case SanitizeEthSrcL1Overflow: eth_src_overflow_addr_words = 0xAAAAAAAA; break;
         case SanitizeEthDestL1Overflow: eth_dest_overflow_addr_words = 0xBBBBBBBB; break;
         case SanitizeNOCMulticastInvalidRange: {
-            // TODO: Enable this test once we have multi-cluster support enable for Quasar
-            if (is_quasar) {
-                GTEST_SKIP() << "Only single cluster runtime is enabled on quasar";
+            // This test requires at least 2 DRAM channels to create an invalid multicast range
+            if (device->num_dram_channels() < 2) {
+                log_info(
+                    LogTest,
+                    "Skipping SanitizeNOCMulticastInvalidRange: requires at least 2 DRAM channels, device has {}",
+                    device->num_dram_channels());
+                GTEST_SKIP();
             }
             // Use invalid multicast range with actual DRAM cores: start > end
             // Wrap-around is only allowed for Tensix cores, not DRAM
-            // Use actual Tensix worker cores with an invalid multicast range (start > end for NOC0).
             use_multicast_semaphore_inc = true;
 
             // Get actual DRAM NOC coordinates
@@ -323,6 +340,7 @@ void RunTestOnCore(
     if (is_eth_core) {
         core_name = is_idle_eth_core ? "idleth" : "acteth";
     }
+    // Note: for multi_dm_race, expected string is built but not used - verification uses regex instead
     switch (feature) {
         case SanitizeNOCAddress:
             expected = fmt::format(
@@ -513,13 +531,36 @@ void RunTestOnCore(
             break;
     }
 
-    log_info(LogTest, "Expected error: {}", expected);
+    if (!multi_dm_race) {
+        log_info(LogTest, "Expected error: {}", expected);
+    }
     std::string exception;
     do {
         exception = MetalContext::instance().watcher_server()->exception_message();
     } while (exception.empty());
     log_info(LogTest, "Reported error: {}", exception);
-    EXPECT_EQ(MetalContext::instance().watcher_server()->exception_message(), expected);
+
+    if (multi_dm_race) {
+        // Verify CAS atomicity: addr and size low bits must match (same DM wrote both)
+        std::regex addr_regex("addr=0x([0-9a-fA-F]+)");
+        std::regex size_regex("write ([0-9]+) bytes");
+        std::smatch addr_match, size_match;
+
+        ASSERT_TRUE(std::regex_search(exception, addr_match, addr_regex)) << "Could not find addr in error";
+        ASSERT_TRUE(std::regex_search(exception, size_match, size_regex)) << "Could not find size in error";
+
+        uint32_t reported_addr = std::stoul(addr_match[1].str(), nullptr, 16);
+        uint32_t reported_size = std::stoul(size_match[1].str());
+        uint32_t addr_dm_id = reported_addr & 0xF;
+        uint32_t size_dm_id = reported_size & 0xF;
+
+        EXPECT_EQ(addr_dm_id, size_dm_id)
+            << "CAS race corruption: addr dm_id=" << addr_dm_id << " but size dm_id=" << size_dm_id;
+        log_info(
+            LogTest, "Multi-DM race: DM{} won CAS with addr=0x{:x} size={}", addr_dm_id, reported_addr, reported_size);
+    } else {
+        EXPECT_EQ(exception, expected);
+    }
 }
 
 void RunTestEth(
@@ -732,6 +773,25 @@ TEST_F(MeshWatcherFixture, TensixTestWatcherSanitizeMulticastSemaphoreInc) {
         [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
             CoreCoord core{0, 0};
             RunTestOnCore(fixture, mesh_device, core, false, SanitizeNOCMulticastInvalidRange);
+        },
+        this->devices_[0]);
+}
+
+// Quasar multi-DM race test: all 8 DMs sync then race to trigger sanitize error
+// Each DM uses unique identifiable data (addr/size). Verifies CAS ensures consistent error reporting
+TEST_F(MeshWatcherFixture, QuasarTestWatcherSanitizeMultiDMRace) {
+    this->RunTestOnDevice(
+        [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
+            CoreCoord core{0, 0};
+            RunTestOnCore(
+                fixture,
+                mesh_device,
+                core,
+                false,
+                SanitizeNOCAddress,
+                false,
+                false /*is_idle_eth_core*/,
+                true /*multi_dm_race*/);
         },
         this->devices_[0]);
 }

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
@@ -38,6 +38,7 @@
 #include <tt-metalium/program.hpp>
 #include <tt_stl/span.hpp>
 #include <umd/device/types/xy_pair.hpp>
+#include <tt-metalium/experimental/host_api.hpp>
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // A test for checking watcher NOC sanitization.
@@ -97,12 +98,17 @@ void RunTestOnCore(
     CoreCoord& core,
     bool is_eth_core,
     watcher_features_t feature,
-    bool use_ncrisc = false) {
+    bool use_ncrisc = false,
+    bool is_idle_eth_core = false) {
+    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+    bool is_quasar = hal.get_arch() == tt::ARCH::QUASAR;
     // It's not simple to check the watcher server status from the finish loop for slow dispatch, so just run these
     // tests in FD.
-    if (fixture->IsSlowDispatch()) {
+    if (fixture->IsSlowDispatch() && !is_idle_eth_core && !is_quasar) {
         GTEST_SKIP();
     }
+
+    const std::string kernel = "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord.cpp";
 
     // Set up program
     distributed::MeshWorkload workload;
@@ -167,26 +173,30 @@ void RunTestOnCore(
     KernelHandle dram_copy_kernel;
     int noc = 0;
     if (is_eth_core) {
-        std::map<std::string, std::string> dram_copy_kernel_defines = {
-            {"SIGNAL_COMPLETION_TO_DISPATCHER", "1"},
-        };
-        tt_metal::EthernetConfig config = {.noc = tt_metal::NOC::NOC_0, .defines = dram_copy_kernel_defines};
+        tt_metal::EthernetConfig config = {.noc = tt_metal::NOC::NOC_0};
+        if (is_idle_eth_core) {
+            config.eth_mode = Eth::IDLE;
+        }
         eth_test_common::set_arch_specific_eth_config(config);
         noc = static_cast<int>(config.noc);
-        dram_copy_kernel = tt_metal::CreateKernel(
-            program_, "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord.cpp", core, config);
+        dram_copy_kernel = tt_metal::CreateKernel(program_, kernel, core, config);
     } else {
-        std::map<std::string, std::string> dram_copy_kernel_defines = {
-            {"SIGNAL_COMPLETION_TO_DISPATCHER", "1"},
-        };
-        tt_metal::DataMovementConfig config{
-            .processor =
-                (use_ncrisc) ? tt_metal::DataMovementProcessor::RISCV_1 : tt_metal::DataMovementProcessor::RISCV_0,
-            .noc = (use_ncrisc) ? tt_metal::NOC::RISCV_1_default : tt_metal::NOC::RISCV_0_default,
-            .defines = dram_copy_kernel_defines};
-        dram_copy_kernel = tt_metal::CreateKernel(
-            program_, "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord.cpp", core, config);
-        noc = static_cast<int>(config.noc);
+        if (is_quasar) {
+            // On Quasar, kernel runs on all 8 DMs but only dm_id executes the test;
+            // others exit early. This lets us verify assert works on each DM individually
+            dram_copy_kernel = tt::tt_metal::experimental::quasar::CreateKernel(
+                program_,
+                kernel,
+                core,
+                tt::tt_metal::experimental::quasar::QuasarDataMovementConfig{.num_threads_per_cluster = 1});
+        } else {
+            tt_metal::DataMovementConfig config{
+                .processor =
+                    (use_ncrisc) ? tt_metal::DataMovementProcessor::RISCV_1 : tt_metal::DataMovementProcessor::RISCV_0,
+                .noc = (use_ncrisc) ? tt_metal::NOC::RISCV_1_default : tt_metal::NOC::RISCV_0_default};
+            dram_copy_kernel = tt_metal::CreateKernel(program_, kernel, core, config);
+            noc = static_cast<int>(config.noc);
+        }
     }
 
     // Write to the input buffer
@@ -294,9 +304,10 @@ void RunTestOnCore(
     std::string expected;
     CoreCoord input_core_virtual_coords = device->virtual_noc0_coordinate(noc, input_buf_noc_xy);
     CoreCoord output_core_virtual_coords = device->virtual_noc0_coordinate(noc, output_buf_noc_xy);
-    std::string risc_name = (is_eth_core) ? "erisc" : "BRISC";
+    std::string risc_name = (is_eth_core) ? is_idle_eth_core ? "ierisc" : "erisc"
+                                          : hal.get_processor_class_name(HalProgrammableCoreType::TENSIX, 0, false);
     if (use_ncrisc) {
-        risc_name = "NCRISC";
+        risc_name = hal.get_processor_class_name(HalProgrammableCoreType::TENSIX, 1, false);
     }
     switch (feature) {
         case SanitizeNOCAddress:
@@ -305,7 +316,7 @@ void RunTestOnCore(
                 "bytes from local L1[{:#08x}] to Unknown core w/ virtual coords {} [addr=0x{:08x}] (NOC target "
                 "address did not map to any known Tensix/Ethernet/DRAM/PCIE core).",
                 device->id(),
-                (is_eth_core) ? "acteth" : "worker",
+                (is_eth_core) ? is_idle_eth_core ? "idleth" : "acteth" : "worker",
                 core.x,
                 core.y,
                 virtual_core.x,
@@ -519,16 +530,13 @@ void RunTestIEth(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     watcher_features_t feature) {
     auto* device = mesh_device->get_devices()[0];
-    if (fixture->IsSlowDispatch()) {
-        GTEST_SKIP();
-    }
     // Run on the first ethernet core (if there are any).
     if (device->get_inactive_ethernet_cores().empty()) {
         log_info(LogTest, "Skipping this test since device has no active ethernet cores.");
         GTEST_SKIP();
     }
     CoreCoord core = *(device->get_inactive_ethernet_cores().begin());
-    RunTestOnCore(fixture, mesh_device, core, true, feature);
+    RunTestOnCore(fixture, mesh_device, core, true, feature, false, true);
 }
 
 // Run tests for host-side sanitization (uses functions that are from watcher_server.hpp).

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
@@ -196,10 +196,15 @@ void RunTestOnCore(
             if (multi_dm_race) {
                 constexpr uint32_t multi_dm_base_addr = 0xFFFF0000;
                 constexpr uint32_t multi_dm_base_size = 0x1000;
-                uint32_t l1_unreserved_base = device->allocator()->get_base_allocator_addr(HalMemType::L1);
+                // Allocate dedicated L1 region for the DM barrier counter (avoid overlap with scratch buffer)
+                distributed::ReplicatedBufferConfig sync_cfg{.size = 32};
+                distributed::DeviceLocalBufferConfig sync_lcl{
+                    .page_size = 32, .buffer_type = tt::tt_metal::BufferType::L1};
+                auto sync_buf = distributed::MeshBuffer::create(sync_cfg, sync_lcl, mesh_device.get());
+                uint32_t l1_sync_addr = sync_buf->address();
                 std::vector<uint32_t> init{0, 0};  // 8 bytes: Quasar barrier uses 64-bit atomics
-                tt::tt_metal::detail::WriteToDeviceL1(device, core, l1_unreserved_base, init);
-                config.compile_args = {num_dms, multi_dm_base_addr, multi_dm_base_size, l1_unreserved_base};
+                tt::tt_metal::detail::WriteToDeviceL1(device, core, l1_sync_addr, init);
+                config.compile_args = {num_dms, multi_dm_base_addr, multi_dm_base_size, l1_sync_addr};
                 config.defines = {{"TEST_MULTI_DM_SANITIZE_RACE", "1"}};
             } else {
                 config.compile_args = {dm_id};

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord.cpp
@@ -19,13 +19,27 @@
  * */
 void kernel_main() {
 #if defined(COMPILE_FOR_DM)
-    constexpr uint32_t dm_id = get_compile_time_arg_val(0);
     uint64_t cpu_index = 0;
     asm volatile("csrr %0, mhartid" : "=r"(cpu_index));
-    // On Quasar since all 8 kernels are launched: execute only the processor matching dm_id ; skip others
+
+#if defined(TEST_MULTI_DM_SANITIZE_RACE)
+    // Having explicit sync barrier helps stress test CAS in sanitize.h since
+    // testing showed DM0 (which wakes other DMs) most likely wins without a barrier
+    constexpr uint32_t num_dms = get_compile_time_arg_val(0);
+    constexpr uint32_t multi_dm_base_addr = get_compile_time_arg_val(1);
+    constexpr uint32_t multi_dm_base_size = get_compile_time_arg_val(2);
+    constexpr uint32_t l1_sync_addr = get_compile_time_arg_val(3);
+    uint64_t* l1_ptr = reinterpret_cast<uint64_t*>(l1_sync_addr);
+    __atomic_add_fetch(l1_ptr, 1, __ATOMIC_RELAXED);
+    while (__atomic_load_n(l1_ptr, __ATOMIC_ACQUIRE) != num_dms) {
+    }
+#else
+    // Single DM test: only specified dm_id executes, others exit early
+    constexpr uint32_t dm_id = get_compile_time_arg_val(0);
     if (cpu_index != dm_id) {
         return;
     }
+#endif
 #endif
     std::uint32_t local_buffer_addr = get_arg_val<uint32_t>(0);
 
@@ -38,6 +52,11 @@ void kernel_main() {
     std::uint32_t dst_noc_y = get_arg_val<uint32_t>(6);
 
     std::uint32_t buffer_size = get_arg_val<uint32_t>(7);
+
+#if defined(COMPILE_FOR_DM) && defined(TEST_MULTI_DM_SANITIZE_RACE)
+    buffer_dst_addr = (multi_dm_base_addr | static_cast<uint32_t>(cpu_index));
+    buffer_size = (multi_dm_base_size | static_cast<uint32_t>(cpu_index));
+#endif
 
     bool use_inline_dw_write = static_cast<bool>(get_arg_val<uint32_t>(8));
     bool bad_linked_transaction = static_cast<bool>(get_arg_val<uint32_t>(9));

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord.cpp
@@ -19,8 +19,7 @@
  * */
 void kernel_main() {
 #if defined(COMPILE_FOR_DM)
-    uint64_t cpu_index = 0;
-    asm volatile("csrr %0, mhartid" : "=r"(cpu_index));
+    uint32_t cpu_index = get_my_thread_id();
 
 #if defined(TEST_MULTI_DM_SANITIZE_RACE)
     // Having explicit sync barrier helps stress test CAS in sanitize.h since

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord.cpp
@@ -23,7 +23,7 @@ void kernel_main() {
     uint64_t cpu_index = 0;
     asm volatile("csrr %0, mhartid" : "=r"(cpu_index));
     // On Quasar since all 8 kernels are launched: execute only the processor matching dm_id ; skip others
-    if (cpu_index == 0) {
+    if (cpu_index != dm_id) {
         return;
     }
 #endif

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord.cpp
@@ -6,7 +6,8 @@
 #include "api/dataflow/dataflow_api.h"
 #include "experimental/core_local_mem.h"
 #include "experimental/endpoints.h"
-#if defined(COMPILE_FOR_ERISC)
+#include "internal/firmware_common.h"
+#if defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_IDLE_ERISC)
 #include "internal/ethernet/tunneling.h"
 #endif
 
@@ -19,6 +20,7 @@ void kernel_main() {
     std::uint32_t local_buffer_addr = get_arg_val<uint32_t>(0);
 
     std::uint32_t buffer_src_addr = get_arg_val<uint32_t>(1);
+    DPRINT << HEX() << buffer_src_addr << ENDL();
     std::uint32_t src_noc_x = get_arg_val<uint32_t>(2);
     std::uint32_t src_noc_y = get_arg_val<uint32_t>(3);
 
@@ -37,31 +39,16 @@ void kernel_main() {
     std::uint32_t mcast_dst_end_x = get_arg_val<uint32_t>(14);
     std::uint32_t mcast_dst_end_y = get_arg_val<uint32_t>(15);
 
-#if defined(SIGNAL_COMPLETION_TO_DISPATCHER)
     // We will assert later. This kernel will hang.
     // Need to signal completion to dispatcher before hanging so that
     // Dispatcher Kernel is able to finish.
     // Device Close () requires fast dispatch kernels to finish.
-#if defined(COMPILE_FOR_ERISC)
-    tt_l1_ptr mailboxes_t* const mailboxes = (tt_l1_ptr mailboxes_t*)(eth_l1_mem::address_map::ERISC_MEM_MAILBOX_BASE);
+    volatile tt_l1_ptr go_msg_t* go_message_in = GET_MAILBOX_ADDRESS_DEV(go_messages[0]);
+#if defined(COMPILE_FOR_IDLE_ERISC) or defined(COMPILE_FOR_DM)
+    go_message_in->signal = RUN_MSG_DONE;
 #else
-    tt_l1_ptr mailboxes_t* const mailboxes = (tt_l1_ptr mailboxes_t*)(MEM_MAILBOX_BASE);
-#endif
-    uint64_t dispatch_addr = NOC_XY_ADDR(
-        NOC_X(mailboxes->go_messages[mailboxes->go_message_index].master_x),
-        NOC_Y(mailboxes->go_messages[mailboxes->go_message_index].master_y),
-        DISPATCH_MESSAGE_ADDR +
-            NOC_STREAM_REG_SPACE_SIZE * mailboxes->go_messages[mailboxes->go_message_index].dispatch_message_offset);
-    noc_fast_write_dw_inline<DM_DEDICATED_NOC>(
-        noc_index,
-        NCRISC_AT_CMD_BUF,
-        1 << REMOTE_DEST_BUF_WORDS_FREE_INC,
-        dispatch_addr,
-        0xF,  // byte-enable
-        NOC_UNICAST_WRITE_VC,
-        false,  // mcast
-        true    // posted
-    );
+    uint64_t dispatch_addr = calculate_dispatch_addr(go_message_in);
+    notify_dispatch_core_done(dispatch_addr, noc_index);
 #endif
 
     if (l1_overflow_addr) {
@@ -71,7 +58,7 @@ void kernel_main() {
 
     if (eth_src_overflow_addr || eth_dest_overflow_addr) {
         // Destructive if not caught properly
-#if defined(COMPILE_FOR_ERISC)
+#if defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_IDLE_ERISC)
         internal_::eth_send_packet(0, eth_src_overflow_addr, eth_dest_overflow_addr, 4);
 #endif
     }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord.cpp
@@ -7,6 +7,7 @@
 #include "experimental/core_local_mem.h"
 #include "experimental/endpoints.h"
 #include "internal/firmware_common.h"
+#include "api/compile_time_args.h"
 #if defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_IDLE_ERISC)
 #include "internal/ethernet/tunneling.h"
 #endif
@@ -17,10 +18,18 @@
  * APIs explicit flushes need to be used since the calls are non-blocking
  * */
 void kernel_main() {
+#if defined(COMPILE_FOR_DM)
+    constexpr uint32_t dm_id = get_compile_time_arg_val(0);
+    uint64_t cpu_index = 0;
+    asm volatile("csrr %0, mhartid" : "=r"(cpu_index));
+    // On Quasar since all 8 kernels are launched: execute only the processor matching dm_id ; skip others
+    if (cpu_index == 0) {
+        return;
+    }
+#endif
     std::uint32_t local_buffer_addr = get_arg_val<uint32_t>(0);
 
     std::uint32_t buffer_src_addr = get_arg_val<uint32_t>(1);
-    DPRINT << HEX() << buffer_src_addr << ENDL();
     std::uint32_t src_noc_x = get_arg_val<uint32_t>(2);
     std::uint32_t src_noc_y = get_arg_val<uint32_t>(3);
 
@@ -44,7 +53,10 @@ void kernel_main() {
     // Dispatcher Kernel is able to finish.
     // Device Close () requires fast dispatch kernels to finish.
     volatile tt_l1_ptr go_msg_t* go_message_in = GET_MAILBOX_ADDRESS_DEV(go_messages[0]);
-#if defined(COMPILE_FOR_IDLE_ERISC) or defined(COMPILE_FOR_DM)
+    // Signal completion to dispatcher before assert hangs the kernel
+    // SD signaling: IDLE_ERISC (all archs) and Quasar DM require RUN_MSG_DONE
+    // TODO: Remove COMPILE_FOR_DM once FD is enabled on Quasar
+#if defined(COMPILE_FOR_IDLE_ERISC) || defined(COMPILE_FOR_DM)
     go_message_in->signal = RUN_MSG_DONE;
 #else
     uint64_t dispatch_addr = calculate_dispatch_addr(go_message_in);

--- a/tt_metal/hw/firmware/src/tt-2xx/dm.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dm.cc
@@ -353,28 +353,6 @@ extern "C" uint32_t _start1() {
 
                 trigger_sync_register_init();
 
-                if constexpr (ASSERT_ENABLED) {
-                    if (noc_mode == DM_DYNAMIC_NOC) {
-                        WAYPOINT("NKFW");
-                        // Assert that no noc transactions are outstanding, to ensure that all reads and writes have
-                        // landed and the NOC interface is in a known idle state for the next kernel.
-                        for (int noc = 0; noc < NUM_NOCS; noc++) {
-                            ASSERT(ncrisc_dynamic_noc_reads_flushed(noc));
-                            ASSERT(ncrisc_dynamic_noc_nonposted_writes_sent(noc));
-                            ASSERT(ncrisc_dynamic_noc_nonposted_writes_flushed(noc));
-                            ASSERT(ncrisc_dynamic_noc_nonposted_atomics_flushed(noc));
-                            ASSERT(ncrisc_dynamic_noc_posted_writes_sent(noc));
-                        }
-                        WAYPOINT("NKFD");
-                    }
-                }
-
-#if defined(PROFILE_KERNEL)
-                if (noc_mode == DM_DYNAMIC_NOC) {
-                    // re-init for profiler to able to run barrier in dedicated noc mode
-                    noc_local_state_init(noc_index);
-                }
-#endif
                 // Need to ensure that Remapper state is cleared for next kernel launch
                 if (g_remapper_configurator.is_remapper_enabled()) {
                     g_remapper_configurator.clear_all_pairs();

--- a/tt_metal/hw/inc/api/dataflow/dataflow_api.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_api.h
@@ -580,8 +580,6 @@ inline void noc_async_read(
         Read requests - use static VC
         Read responses - assigned VCs dynamically
     */
-    DPRINT << "src_noc_addr     : 0x" << HEX() << src_noc_addr << ENDL();
-    DPRINT << "dst_local_l1_addr: 0x" << HEX() << dst_local_l1_addr << ENDL();
     if constexpr (enable_noc_tracing) {
         RECORD_NOC_EVENT_WITH_ADDR(NocEventType::READ, dst_local_l1_addr, src_noc_addr, size, -1, false, noc);
     }

--- a/tt_metal/hw/inc/api/dataflow/dataflow_api.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_api.h
@@ -580,6 +580,8 @@ inline void noc_async_read(
         Read requests - use static VC
         Read responses - assigned VCs dynamically
     */
+    DPRINT << "src_noc_addr     : 0x" << HEX() << src_noc_addr << ENDL();
+    DPRINT << "dst_local_l1_addr: 0x" << HEX() << dst_local_l1_addr << ENDL();
     if constexpr (enable_noc_tracing) {
         RECORD_NOC_EVENT_WITH_ADDR(NocEventType::READ, dst_local_l1_addr, src_noc_addr, size, -1, false, noc);
     }

--- a/tt_metal/hw/inc/hostdev/dev_msgs.h
+++ b/tt_metal/hw/inc/hostdev/dev_msgs.h
@@ -252,6 +252,9 @@ enum debug_sanitize_noc_return_code_enum {
     DebugSanitizeEthSrcL1AddrOverflow = 15,
     DebugSanitizeEthDestL1AddrOverflow = 16,
     DebugSanitizeCBOutOfBounds = 17,
+    // Applicable only on Quasar: multiple DMs share one NOC, so CAS is used to prevent race conditions
+    // This transient value indicates a DM is writing error metadata, host should ignore
+    DebugSanitizeWriteInProgress = 0xDEAD,
 };
 
 struct debug_assert_msg_t {

--- a/tt_metal/hw/inc/internal/debug/sanitize.h
+++ b/tt_metal/hw/inc/internal/debug/sanitize.h
@@ -393,14 +393,8 @@ uint32_t debug_sanitize_noc_addr(
                 // NoC torus architectures (WH/BH) support wrap-around multicasts where end < start.
                 // Non-torus architectures (Quasar) require start <= end.
 #ifdef ARCH_QUASAR
-                if (noc_id == 0) {
-                    if (x > x_end || y > y_end) {
-                        return_code = DebugSanitizeNocMulticastInvalidRange;
-                    }
-                } else {
-                    if (x_end > x || y_end > y) {
-                        return_code = DebugSanitizeNocMulticastInvalidRange;
-                    }
+                if (x > x_end || y > y_end) {
+                    return_code = DebugSanitizeNocMulticastInvalidRange;
                 }
 #endif
             } else {

--- a/tt_metal/hw/inc/internal/debug/sanitize.h
+++ b/tt_metal/hw/inc/internal/debug/sanitize.h
@@ -45,12 +45,6 @@ using debug_sanitize_noc_cast_t = bool;
 #define DEBUG_SANITIZE_NOC_LOCAL false
 using debug_sanitize_noc_which_core_t = bool;
 
-#ifdef ARCH_QUASAR
-#define VALID_L1_SIZE (MEM_L1_SIZE)
-#else
-#define VALID_L1_SIZE MEM_L1_SIZE
-#endif
-
 // Helper function to get the core type from noc coords.
 AddressableCoreType get_core_type(uint8_t noc_id, uint8_t x, uint8_t y, bool& is_virtual_coord) {
     core_info_msg_t tt_l1_ptr* core_info = GET_MAILBOX_ADDRESS_DEV(core_info);
@@ -169,9 +163,7 @@ inline uint16_t debug_valid_worker_addr(uint64_t addr, uint64_t len, bool write)
     if (addr < MEM_L1_BASE) {
         return DebugSanitizeNocAddrUnderflow;
     }
-    if (addr + len > MEM_L1_BASE + VALID_L1_SIZE) {
-        DPRINT << "debug_valid_worker_addr: 0x" << HEX() << VALID_L1_SIZE << ENDL();
-        DPRINT << "addr, len: " << HEX() << addr << ", " << len << ENDL();
+    if (addr + len > MEM_L1_BASE + MEM_L1_SIZE) {
         return DebugSanitizeNocAddrOverflow;
     }
 
@@ -193,7 +185,6 @@ inline uint16_t debug_valid_pcie_addr(uint64_t addr, uint64_t len) {
         return DebugSanitizeNocAddrUnderflow;
     }
     if (addr + len > core_info->noc_pcie_addr_end) {
-        DPRINT << "debug_valid_pcie_addr" << ENDL();
         return DebugSanitizeNocAddrOverflow;
     }
     return DebugSanitizeOK;
@@ -208,7 +199,6 @@ inline uint16_t debug_valid_dram_addr(uint64_t addr, uint64_t len) {
         return DebugSanitizeNocAddrUnderflow;
     }
     if (addr + len > core_info->noc_dram_addr_end) {
-        DPRINT << "debug_valid_dram_addr" << ENDL();
         return DebugSanitizeNocAddrOverflow;
     }
     return DebugSanitizeOK;
@@ -222,7 +212,6 @@ inline uint16_t debug_valid_eth_addr(uint64_t addr, uint64_t len, bool write) {
         return DebugSanitizeNocAddrUnderflow;
     }
     if (addr + len > MEM_ETH_BASE + MEM_ETH_SIZE) {
-        DPRINT << "debug_valid_eth_addr" << ENDL();
         return DebugSanitizeNocAddrOverflow;
     }
     constexpr uint64_t mem_mailbox_end = MEM_IERISC_MAILBOX_END < eth_l1_mem::address_map::ERISC_MEM_MAILBOX_END
@@ -269,7 +258,8 @@ inline uint16_t debug_valid_cb_addr(uint32_t l1_addr, uint32_t len) {
 
 // Note:
 //  - this isn't racy w/ the host so long as invalid is written last
-//  - this isn't racy between riscvs so long as each gets their own noc_index
+//  - this isn't racy between riscvs so long as each gets their own noc_index as is the case on WH/BH
+//  - for Quasar, we have a single noc_index across all DMs so the writes need to be atomic
 void __attribute__((noinline)) debug_sanitize_post_addr_and_hang(
     uint8_t noc_id,
     uint64_t noc_addr,
@@ -284,8 +274,15 @@ void __attribute__((noinline)) debug_sanitize_post_addr_and_hang(
     }
 
     debug_sanitize_addr_msg_t tt_l1_ptr* v = *GET_MAILBOX_ADDRESS_DEV(watcher.sanitize);
+    uint16_t expected = DebugSanitizeOK;
 
-    if (v[noc_id].return_code == DebugSanitizeOK) {
+#if defined(QUASAR)
+    uint16_t temp = 0xDEAD;
+    if (__atomic_compare_exchange_n(&v[noc_id].return_code, &expected, temp, false, __ATOMIC_ACQUIRE, __ATOMIC_RELAXED))
+#else
+    if (v[noc_id].return_code == DebugSanitizeOK)
+#endif
+    {
         v[noc_id].noc_addr = noc_addr;
         v[noc_id].l1_addr = l1_addr;
         v[noc_id].len = len;
@@ -293,7 +290,13 @@ void __attribute__((noinline)) debug_sanitize_post_addr_and_hang(
         v[noc_id].is_multicast = (multicast == DEBUG_SANITIZE_NOC_MULTICAST);
         v[noc_id].is_write = (dir == DEBUG_SANITIZE_NOC_WRITE);
         v[noc_id].is_target = (which_core == DEBUG_SANITIZE_NOC_TARGET);
+#if defined(QUASAR)
+        // __ATOMIC_RELEASE ensures all writes above are visible before this
+        // for host to read
+        __atomic_store_n(&v[noc_id].return_code, return_code, __ATOMIC_RELEASE)
+#else
         v[noc_id].return_code = return_code;
+#endif
     }
 
 #if defined(COMPILE_FOR_ERISC)
@@ -352,7 +355,6 @@ uint32_t debug_sanitize_noc_addr(
     debug_sanitize_noc_cast_t multicast,
     debug_sanitize_noc_dir_t dir,
     bool check_linked) {
-    DPRINT << "Inside debug_sanitize_noc_addr Here" << ENDL();
     // Different encoding of noc addr depending on multicast vs unitcast
     uint8_t x, y;
     if (multicast) {
@@ -576,7 +578,7 @@ void debug_sanitize_l1_access(uint64_t addr, uint32_t len) {
 #if defined(COMPILE_FOR_ERISC)
     constexpr uint64_t l1_overflow_addr = MEM_ETH_SIZE;
 #else
-    constexpr uint64_t l1_overflow_addr = VALID_L1_SIZE;
+    constexpr uint64_t l1_overflow_addr = MEM_L1_SIZE;
 #endif
     if (addr + len <= addr || addr + len > l1_overflow_addr) {
         debug_sanitize_post_addr_and_hang(
@@ -620,7 +622,7 @@ void debug_sanitize_eth(uint32_t src_addr, uint32_t dst_addr, uint32_t len) {
 #endif
 }
 
-#ifdef ARCH_QUASAR
+#if defined(ARCH_QUASAR) && !defined(NOC_AT_LEN_BE)
 #define NOC_AT_LEN_BE NOC_AT_LEN
 #endif
 

--- a/tt_metal/hw/inc/internal/debug/sanitize.h
+++ b/tt_metal/hw/inc/internal/debug/sanitize.h
@@ -18,10 +18,8 @@
 #include "api/debug/noc_logging.h"
 #include "api/debug/dprint.h"
 
-#if (                                                                                          \
-    defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_ERISC) || \
-    defined(COMPILE_FOR_IDLE_ERISC)) &&                                                        \
-    defined(WATCHER_ENABLED) && !defined(WATCHER_DISABLE_NOC_SANITIZE) && !defined(FORCE_WATCHER_OFF)
+#if !defined(COMPILE_FOR_TRISC) && defined(WATCHER_ENABLED) && !defined(WATCHER_DISABLE_NOC_SANITIZE) && \
+    !defined(FORCE_WATCHER_OFF)
 
 #include "watcher_common.h"
 #include "internal/hw_thread.h"
@@ -46,6 +44,12 @@ using debug_sanitize_noc_cast_t = bool;
 #define DEBUG_SANITIZE_NOC_TARGET true
 #define DEBUG_SANITIZE_NOC_LOCAL false
 using debug_sanitize_noc_which_core_t = bool;
+
+#ifdef ARCH_QUASAR
+#define VALID_L1_SIZE (MEM_L1_SIZE)
+#else
+#define VALID_L1_SIZE MEM_L1_SIZE
+#endif
 
 // Helper function to get the core type from noc coords.
 AddressableCoreType get_core_type(uint8_t noc_id, uint8_t x, uint8_t y, bool& is_virtual_coord) {
@@ -165,7 +169,9 @@ inline uint16_t debug_valid_worker_addr(uint64_t addr, uint64_t len, bool write)
     if (addr < MEM_L1_BASE) {
         return DebugSanitizeNocAddrUnderflow;
     }
-    if (addr + len > MEM_L1_BASE + MEM_L1_SIZE) {
+    if (addr + len > MEM_L1_BASE + VALID_L1_SIZE) {
+        DPRINT << "debug_valid_worker_addr: 0x" << HEX() << VALID_L1_SIZE << ENDL();
+        DPRINT << "addr, len: " << HEX() << addr << ", " << len << ENDL();
         return DebugSanitizeNocAddrOverflow;
     }
 
@@ -187,6 +193,7 @@ inline uint16_t debug_valid_pcie_addr(uint64_t addr, uint64_t len) {
         return DebugSanitizeNocAddrUnderflow;
     }
     if (addr + len > core_info->noc_pcie_addr_end) {
+        DPRINT << "debug_valid_pcie_addr" << ENDL();
         return DebugSanitizeNocAddrOverflow;
     }
     return DebugSanitizeOK;
@@ -201,6 +208,7 @@ inline uint16_t debug_valid_dram_addr(uint64_t addr, uint64_t len) {
         return DebugSanitizeNocAddrUnderflow;
     }
     if (addr + len > core_info->noc_dram_addr_end) {
+        DPRINT << "debug_valid_dram_addr" << ENDL();
         return DebugSanitizeNocAddrOverflow;
     }
     return DebugSanitizeOK;
@@ -214,6 +222,7 @@ inline uint16_t debug_valid_eth_addr(uint64_t addr, uint64_t len, bool write) {
         return DebugSanitizeNocAddrUnderflow;
     }
     if (addr + len > MEM_ETH_BASE + MEM_ETH_SIZE) {
+        DPRINT << "debug_valid_eth_addr" << ENDL();
         return DebugSanitizeNocAddrOverflow;
     }
     constexpr uint64_t mem_mailbox_end = MEM_IERISC_MAILBOX_END < eth_l1_mem::address_map::ERISC_MEM_MAILBOX_END
@@ -343,6 +352,7 @@ uint32_t debug_sanitize_noc_addr(
     debug_sanitize_noc_cast_t multicast,
     debug_sanitize_noc_dir_t dir,
     bool check_linked) {
+    DPRINT << "Inside debug_sanitize_noc_addr Here" << ENDL();
     // Different encoding of noc addr depending on multicast vs unitcast
     uint8_t x, y;
     if (multicast) {
@@ -566,7 +576,7 @@ void debug_sanitize_l1_access(uint64_t addr, uint32_t len) {
 #if defined(COMPILE_FOR_ERISC)
     constexpr uint64_t l1_overflow_addr = MEM_ETH_SIZE;
 #else
-    constexpr uint64_t l1_overflow_addr = MEM_L1_SIZE;
+    constexpr uint64_t l1_overflow_addr = VALID_L1_SIZE;
 #endif
     if (addr + len <= addr || addr + len > l1_overflow_addr) {
         debug_sanitize_post_addr_and_hang(
@@ -609,6 +619,10 @@ void debug_sanitize_eth(uint32_t src_addr, uint32_t dst_addr, uint32_t len) {
     }
 #endif
 }
+
+#ifdef ARCH_QUASAR
+#define NOC_AT_LEN_BE NOC_AT_LEN
+#endif
 
 // TODO: Clean these up with #7453
 #define DEBUG_SANITIZE_NOC_READ_TRANSACTION_FROM_STATE(noc_id, read_cmd_buf)                                       \

--- a/tt_metal/hw/inc/internal/debug/sanitize.h
+++ b/tt_metal/hw/inc/internal/debug/sanitize.h
@@ -263,7 +263,8 @@ inline uint16_t debug_valid_cb_addr(uint32_t l1_addr, uint32_t len) {
 // Note:
 //  - this isn't racy w/ the host so long as return_code is written last
 //  - this isn't racy between riscvs so long as each gets their own noc_index as is the case on WH/BH
-//  - for Quasar, multiple DMs share one NOC so CAS is used; writes go to cached view then flush
+//  - for Quasar, multiple DMs share one NOC so CAS is used; address is remapped from uncached to
+//    cached L1 (LR/SC requires cache coherence), then flushed to make writes visible to host
 void __attribute__((noinline)) debug_sanitize_post_addr_and_hang(
     uint8_t noc_id,
     uint64_t noc_addr,
@@ -302,7 +303,8 @@ void __attribute__((noinline)) debug_sanitize_post_addr_and_hang(
         san->is_target = (which_core == DEBUG_SANITIZE_NOC_TARGET);
         san->return_code = return_code;
 #if defined(ARCH_QUASAR)
-        // TODO: Replace with flush_l2_cache_line() once PR #38124 is merged
+        // Flush 64B cache line to L1 so host sees all fields via NOC; fence ensures completion
+        // TODO: Replace with flush_l2_cache_line() once available
         volatile uint64_t* flush_reg = reinterpret_cast<volatile uint64_t*>(L2_FLUSH_ADDR);
         *flush_reg = reinterpret_cast<uintptr_t>(san);
         asm volatile("fence" ::: "memory");
@@ -396,24 +398,13 @@ uint32_t debug_sanitize_noc_addr(
 
         // Only check wrap-around for Tensix-to-Tensix multicasts
         if (both_cores_tensix) {
-            if (is_virtual_coord && is_virtual_coord_end) {
-                // Virtual coordinates: noc0 and noc1 endpoints are identical in virtual space,
-                // but coordinate ordering differs between noc0 and noc1.
-                //
-                // NoC torus architectures (WH/BH) support wrap-around multicasts where end < start.
-                // Non-torus architectures (Quasar) require start <= end.
+            // NoC torus architectures (WH/BH) support wrap-around multicasts where end < start.
+            // Quasar is non-torus with 1 NOC, so start <= end is required regardless of coord type.
 #ifdef ARCH_QUASAR
-                if (x > x_end || y > y_end) {
-                    return_code = DebugSanitizeNocMulticastInvalidRange;
-                }
-#endif
-            } else {
-#ifdef ARCH_QUASAR
-                if (x > x_end || y > y_end) {
-                    return_code = DebugSanitizeNocMulticastInvalidRange;
-                }
-#endif
+            if (x > x_end || y > y_end) {
+                return_code = DebugSanitizeNocMulticastInvalidRange;
             }
+#endif
         } else {
             // For non-Tensix multicasts, enforce start <= end on all architectures
             if (is_virtual_coord && is_virtual_coord_end) {
@@ -625,10 +616,6 @@ void debug_sanitize_eth(uint32_t src_addr, uint32_t dst_addr, uint32_t len) {
     }
 #endif
 }
-
-#if defined(ARCH_QUASAR) && !defined(NOC_AT_LEN_BE)
-#define NOC_AT_LEN_BE NOC_AT_LEN
-#endif
 
 // TODO: Clean these up with #7453
 #define DEBUG_SANITIZE_NOC_READ_TRANSACTION_FROM_STATE(noc_id, read_cmd_buf)                                       \

--- a/tt_metal/hw/inc/internal/debug/sanitize.h
+++ b/tt_metal/hw/inc/internal/debug/sanitize.h
@@ -34,6 +34,10 @@
 #include "internal/circular_buffer_interface.h"
 #endif
 
+#if defined(ARCH_QUASAR)
+#include "internal/tt-2xx/quasar/overlay/overlay_addresses.h"
+#endif
+
 // A couple defines for specifying read/write and multi/unicast
 #define DEBUG_SANITIZE_NOC_READ true
 #define DEBUG_SANITIZE_NOC_WRITE false
@@ -257,9 +261,9 @@ inline uint16_t debug_valid_cb_addr(uint32_t l1_addr, uint32_t len) {
 #endif  // !WATCHER_DISABLE_CB_SANITIZE && !COMPILE_FOR_ERISC
 
 // Note:
-//  - this isn't racy w/ the host so long as invalid is written last
+//  - this isn't racy w/ the host so long as return_code is written last
 //  - this isn't racy between riscvs so long as each gets their own noc_index as is the case on WH/BH
-//  - for Quasar, we have a single noc_index across all DMs so the writes need to be atomic
+//  - for Quasar, multiple DMs share one NOC so CAS is used; writes go to cached view then flush
 void __attribute__((noinline)) debug_sanitize_post_addr_and_hang(
     uint8_t noc_id,
     uint64_t noc_addr,
@@ -274,28 +278,34 @@ void __attribute__((noinline)) debug_sanitize_post_addr_and_hang(
     }
 
     debug_sanitize_addr_msg_t tt_l1_ptr* v = *GET_MAILBOX_ADDRESS_DEV(watcher.sanitize);
-    uint16_t expected = DebugSanitizeOK;
+    volatile debug_sanitize_addr_msg_t* san = &v[noc_id];
 
-#if defined(QUASAR)
-    uint16_t temp = 0xDEAD;
-    if (__atomic_compare_exchange_n(&v[noc_id].return_code, &expected, temp, false, __ATOMIC_ACQUIRE, __ATOMIC_RELAXED))
+#if defined(ARCH_QUASAR)
+    // TODO: Remove this check once mailbox is accessed via cached memory (see dm.cc UNCACHED_MEM_MAILBOX_BASE)
+    uintptr_t addr = reinterpret_cast<uintptr_t>(san);
+    if (addr >= MEM_L1_UNCACHED_BASE) {
+        san = reinterpret_cast<volatile debug_sanitize_addr_msg_t*>(addr - MEM_L1_UNCACHED_BASE);
+    }
+    uint16_t expected = DebugSanitizeOK;
+    if (__atomic_compare_exchange_n(
+            &san->return_code, &expected, DebugSanitizeWriteInProgress, false, __ATOMIC_SEQ_CST, __ATOMIC_RELAXED))
 #else
-    if (v[noc_id].return_code == DebugSanitizeOK)
+    if (san->return_code == DebugSanitizeOK)
 #endif
     {
-        v[noc_id].noc_addr = noc_addr;
-        v[noc_id].l1_addr = l1_addr;
-        v[noc_id].len = len;
-        v[noc_id].which_risc = internal_::get_hw_thread_idx();
-        v[noc_id].is_multicast = (multicast == DEBUG_SANITIZE_NOC_MULTICAST);
-        v[noc_id].is_write = (dir == DEBUG_SANITIZE_NOC_WRITE);
-        v[noc_id].is_target = (which_core == DEBUG_SANITIZE_NOC_TARGET);
-#if defined(QUASAR)
-        // __ATOMIC_RELEASE ensures all writes above are visible before this
-        // for host to read
-        __atomic_store_n(&v[noc_id].return_code, return_code, __ATOMIC_RELEASE)
-#else
-        v[noc_id].return_code = return_code;
+        san->noc_addr = noc_addr;
+        san->l1_addr = l1_addr;
+        san->len = len;
+        san->which_risc = internal_::get_hw_thread_idx();
+        san->is_multicast = (multicast == DEBUG_SANITIZE_NOC_MULTICAST);
+        san->is_write = (dir == DEBUG_SANITIZE_NOC_WRITE);
+        san->is_target = (which_core == DEBUG_SANITIZE_NOC_TARGET);
+        san->return_code = return_code;
+#if defined(ARCH_QUASAR)
+        // TODO: Replace with flush_l2_cache_line() once PR #38124 is merged
+        volatile uint64_t* flush_reg = reinterpret_cast<volatile uint64_t*>(L2_FLUSH_ADDR);
+        *flush_reg = reinterpret_cast<uintptr_t>(san);
+        asm volatile("fence" ::: "memory");
 #endif
     }
 

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/dev_mem_map.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/dev_mem_map.h
@@ -31,6 +31,8 @@
 // RISC-V Address map definition (hardware)
 #define MEM_L1_BASE 0x0
 #define MEM_L1_SIZE (4 * 1024 * 1024)
+// Note: using RISC-V CAS (LR/SC + AMO) atomics don't work with uncached L1
+// The reservation mechanism requires cache coherence tracking
 #define MEM_L1_UNCACHED_BASE (MEM_L1_BASE + MEM_L1_SIZE)  // upper 4MBs bypass cache
 
 #define MEM_ETH_BASE 0x0

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/dev_mem_map.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/dev_mem_map.h
@@ -31,8 +31,8 @@
 // RISC-V Address map definition (hardware)
 #define MEM_L1_BASE 0x0
 #define MEM_L1_SIZE (4 * 1024 * 1024)
-// Note: using RISC-V CAS (LR/SC + AMO) atomics don't work with uncached L1
-// The reservation mechanism requires cache coherence tracking
+// Note: RISC-V LR/SC and AMO atomics don't work with uncached L1 (they hang).
+// Both require the cache coherence system. Only plain loads/stores with fences work uncached.
 #define MEM_L1_UNCACHED_BASE (MEM_L1_BASE + MEM_L1_SIZE)  // upper 4MBs bypass cache
 
 #define MEM_ETH_BASE 0x0

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/noc/noc_parameters.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/noc/noc_parameters.h
@@ -455,9 +455,17 @@
 #define NOC_XY_PCIE_ENCODING(x, y) \
     ((uint64_t(NOC_XY_ENCODING(x, y)) << (NOC_ADDR_LOCAL_BITS - NOC_COORD_REG_OFFSET)) | 0x1000000000000000)
 
-// Same as BH: uses 36-bit address encoding followed by coordinates, but PCIe transactions require bit 60 to
-// be set, so we mask out the xy-coordinate. When NOC_ADDR_LOCAL_BITS is 64 then NOC_LOCAL_ADDR_OFFSET can be used
-#define NOC_LOCAL_ADDR(addr) ((addr) & 0x1000000FFFFFFFFF)
+// Quasar firmware currently uses BH-style encoding (X,Y coords embedded at bits 36+).
+// NOC_LOCAL_ADDR extracts the local offset (bits 0-35) for memory bounds validation.
+//
+// Note: Unlike BH, Quasar doesn't need to preserve PCIe bit 60 here - PCIe TLBs
+// handle address translation before firmware sees the address.
+//
+// TODO: When software moves to ATT-based flat 64-bit addressing:
+//   1. Replace NOC_XY_ADDR() usage with global address construction
+//   2. Update sanitize.h to handle coordinate-less addresses
+//   3. Change this macro to identity: #define NOC_LOCAL_ADDR(addr) (addr)
+#define NOC_LOCAL_ADDR(addr) NOC_LOCAL_ADDR_OFFSET(addr)
 
 // TODO review these alignment restrictions
 // Alignment restrictions

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/noc/noc_parameters.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/noc/noc_parameters.h
@@ -63,6 +63,7 @@
 #define NOC_BRCST_LO (NOC_REGS_START_ADDR + 0x20)
 #define NOC_BRCST_HI (NOC_REGS_START_ADDR + 0x24)
 #define NOC_AT_LEN (NOC_REGS_START_ADDR + 0x28)
+#define NOC_AT_LEN_BE NOC_AT_LEN  // No separate byte-enable reg on Quasar; alias for WH/BH compat
 #define NOC_L1_ACC_AT_INSTRN (NOC_REGS_START_ADDR + 0x2C)
 #define NOC_SEC_CTRL (NOC_REGS_START_ADDR + 0x30)
 #define NOC_AT_DATA (NOC_REGS_START_ADDR + 0x34)
@@ -454,6 +455,8 @@
 #define NOC_XY_PCIE_ENCODING(x, y) \
     ((uint64_t(NOC_XY_ENCODING(x, y)) << (NOC_ADDR_LOCAL_BITS - NOC_COORD_REG_OFFSET)) | 0x1000000000000000)
 
+// Same as BH: uses 36-bit address encoding followed by coordinates, but PCIe transactions require bit 60 to
+// be set, so we mask out the xy-coordinate. When NOC_ADDR_LOCAL_BITS is 64 then NOC_LOCAL_ADDR_OFFSET can be used
 #define NOC_LOCAL_ADDR(addr) ((addr) & 0x1000000FFFFFFFFF)
 
 // TODO review these alignment restrictions

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/noc/noc_parameters.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/noc/noc_parameters.h
@@ -454,7 +454,7 @@
 #define NOC_XY_PCIE_ENCODING(x, y) \
     ((uint64_t(NOC_XY_ENCODING(x, y)) << (NOC_ADDR_LOCAL_BITS - NOC_COORD_REG_OFFSET)) | 0x1000000000000000)
 
-#define NOC_LOCAL_ADDR(addr) (addr)
+#define NOC_LOCAL_ADDR(addr) ((addr) & 0x1000000FFFFFFFFF)
 
 // TODO review these alignment restrictions
 // Alignment restrictions

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -732,6 +732,9 @@ void WatcherDeviceReader::Core::DumpNocSanitizeStatus(int noc) const {
             error_msg = get_noc_target_str(reader_.device_id, programmable_core_type_, noc, san);
             error_msg += " (NOC transaction overflows a circular buffer).";
             break;
+        case dev_msgs::DebugSanitizeWriteInProgress:
+            // Quasar: DM is atomically writing error metadata; ignore until complete
+            break;
         default:
             error_msg = fmt::format(
                 "Watcher unexpected data corruption, noc debug state on core {}, unknown failure code: {}",

--- a/tt_metal/llrt/sanitize_noc_host.hpp
+++ b/tt_metal/llrt/sanitize_noc_host.hpp
@@ -11,7 +11,7 @@
 namespace tt {
 
 // Host MMIO reads/writes don't have alignment restrictions, so no need to check alignment here.
-// TODO: For Quasar, consider expanding this range if we do NOC reads/writes to L1 by passing the cache.
+// TODO: For Quasar, consider expanding this range if we do NOC reads/writes to L1 by passing the cache from host.
 // Uncached region probably needs to baked into HAL for this
 #define DEBUG_VALID_L1_ADDR(a, l) (((a) >= HAL_MEM_L1_BASE) && ((a) + (l) <= HAL_MEM_L1_BASE + HAL_MEM_L1_SIZE))
 

--- a/tt_metal/llrt/sanitize_noc_host.hpp
+++ b/tt_metal/llrt/sanitize_noc_host.hpp
@@ -11,8 +11,8 @@
 namespace tt {
 
 // Host MMIO reads/writes don't have alignment restrictions, so no need to check alignment here.
-// TODO: For Quasar, consider expanding this range if we do NOC reads/writes to L1 by passing the cache from host.
-// Uncached region probably needs to baked into HAL for this
+// TODO: For Quasar, this range would need to be expanded if we need to write into uncached L1
+// (>= MEM_L1_UNCACHED_BASE) from host, probably by baking the existence of uncached memory into HAL.
 #define DEBUG_VALID_L1_ADDR(a, l) (((a) >= HAL_MEM_L1_BASE) && ((a) + (l) <= HAL_MEM_L1_BASE + HAL_MEM_L1_SIZE))
 
 #define DEBUG_VALID_REG_ADDR(a) tt::tt_metal::MetalContext::instance().hal().valid_reg_addr(a)

--- a/tt_metal/llrt/sanitize_noc_host.hpp
+++ b/tt_metal/llrt/sanitize_noc_host.hpp
@@ -11,6 +11,8 @@
 namespace tt {
 
 // Host MMIO reads/writes don't have alignment restrictions, so no need to check alignment here.
+// TODO: For Quasar, consider expanding this range if we do NOC reads/writes to L1 by passing the cache.
+// Uncached region probably needs to baked into HAL for this
 #define DEBUG_VALID_L1_ADDR(a, l) (((a) >= HAL_MEM_L1_BASE) && ((a) + (l) <= HAL_MEM_L1_BASE + HAL_MEM_L1_SIZE))
 
 #define DEBUG_VALID_REG_ADDR(a) tt::tt_metal::MetalContext::instance().hal().valid_reg_addr(a)


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/38105

### Problem description
Bring up NOC sanitize watcher on Quasar. Quasar has 8 DM cores sharing a single NOC, so the existing error reporting path can produce corrupted metadata reports when multiple DMs race to write the shared sanitize struct in L1 mailbox.

### What's changed

Host-Side changes:
- `watcher_device_reader.cpp`: Ignores transient `DebugSanitizeWriteInProgress` while DM is writing error metadata.
- dev_msgs.h: Added `DebugSanitizeWriteInProgress` sentinel enum value.

Test updates
- Extended `test_sanitize.cpp` for Quasar kernel
- Fixed `IDLE_ETH` tests that were previously skipped due to broad slow dispatch skip logic.
- Added `QuasarTestWatcherSanitizeMultiDMRace`: stress test where all DMs race to trigger a sanitize error, verifying CAS produces consistent error metadata.

Device-side changes:
- CAS based first come first report for NOC errors (`sanitize.h`). Uses `__atomic_compare_exchange_n` (LR/SC) to atomically claim the L1 mailbox sanitize slot with a `DebugSanitizeWriteInProgress` sentinel, then writes error metadata.
- For CAS to work, address is remapped from uncached to cached L1 before CAS since LR/SC requires cache coherence.
- Simplified multicast range validation for a single NOC on Quasar. (`sanitize.h`)
- Removed dynamic NOC path in `dm.cc` for a single NOC on Quasar.
- Extended `dram_copy_to_noc_coord.cpp` kernel for Quasar DM support.
  
NOC parameter (`noc_parameters.h`)
- `NOC_LOCAL_ADDR`: Changed from identity to mask that strips XY coordinates while preserving bit 60 (PCIe flag), matching BH encoding
- `NOC_AT_LEN_BE`: Added alias to NOC_AT_LEN (Quasar has no separate byte-enable register)







Sanitize Test | Tested | Comments
-- | -- | --
TensixTestWatcherSanitizeNOCAlignmentL1Write | Yes | Passes
TensixTestWatcherSanitizeNOCAlignmentL1Read | Yes | Passes
TensixTestWatcherSanitizeNOCAlignmentL1ReadNCrisc | Yes | Passes
TensixTestWatcherSanitizeNOCZeroL1Write | Yes | Passes
TensixTestWatcherSanitizeNOCMailboxWrite | Yes | Passes
TensixTestWatcherSanitizeNOCInlineWriteDram | Yes | Passes
TensixTestWatcherSanitizeL1Overflow | Yes | Passes
QuasarTestWatcherSanitizeMultiDMRace | Yes | New test (only applicable to quasar)
TensixTestWatcherSanitizeMulticastSemaphoreInc | No | Skipped: Needs more runtime software support (requires at least 2 DRAM channels)
ActiveEthTestWatcherSanitizeEth | No | Skipped: Needs runtime development - ethernet support
ActiveEthTestWatcherSanitizeNOCMailboxWrite | No | Skipped: Needs runtime development - ethernet support
ActiveEthTestWatcherSanitizeNOCInlineWriteDram | No | Skipped: Needs runtime development - ethernet support
ActiveEthTestWatcherSanitizeL1Overflow | No | Skipped: Needs runtime development - ethernet support
ActiveEthTestWatcherSanitizeEthSrcL1Overflow | No | Skipped: Needs runtime development - ethernet support
ActiveEthTestWatcherSanitizeEthDestL1Overflow | No | Skipped: Needs runtime development - ethernet support
IdleEthTestWatcherSanitizeIEth | No | Skipped: Needs runtime development - ethernet support
IdleEthTestWatcherSanitizeNOCInlineWriteDram | No | Skipped: Needs runtime development - ethernet support






### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snadkarni/quasar_noc_sanitize)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snadkarni/quasar_noc_sanitize)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snadkarni/quasar_noc_sanitize)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snadkarni/quasar_noc_sanitize)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadkarni/quasar_noc_sanitize)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadkarni/quasar_noc_sanitize)
- [x] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snadkarni/quasar_noc_sanitize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snadkarni/quasar_noc_sanitize)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snadkarni/quasar_noc_sanitize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snadkarni/quasar_noc_sanitize)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snadkarni/quasar_noc_sanitize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snadkarni/quasar_noc_sanitize)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
