### PR TITLE
Updating llama embedding forward to use ttnn.to_layout rather than ttnn.tilize

### DIFF
--- a/models/tt_transformers/tt/multimodal/llama_class_embedding.py
+++ b/models/tt_transformers/tt/multimodal/llama_class_embedding.py
@@ -40,6 +40,6 @@ class TtLlamaClassEmbedding(LightweightModule):
         # Broadcast class embedding to match input batch size
         class_embedding = ttnn.concat([self.class_embedding] * bsz, dim=1)  # Broadcast batch size
         x = ttnn.concat([class_embedding, x], dim=2)  # Output ROW_MAJOR_LAYOUT
-        x = ttnn.tilize(x)  # Convert back to TILE_LAYOUT
+        x = ttnn.to_layout(x, layout=ttnn.TILE_LAYOUT)  # Convert back to TILE_LAYOUT
 
         return x


### PR DESCRIPTION
### Ticket
N/A
### Problem description
The Llama embedding forward method was erroneously using `ttnn.tilize`, which does not consider the tensor padding. The recent change in PR [Tilize ND sharding](https://github.com/tenstorrent/tt-metal/pull/38377) also fixed a bug in the validate function [#38875 ](https://github.com/tenstorrent/tt-metal/issues/38875) to reject tensors not divisible by the tile size (these are unsupported by `ttnn.tilize`). This caused some llama T3K tests to fail.
In such cases where the tensor requires padding to tilize,  `ttnn.tilize_with_val_padding` must be used. `ttnn.to_layout` will select the proper op for you, and thus, must be used instead of the more-restrictive `ttnn.tilize`.

Broken pipelines due to this:
[t3000-unit-tests / t3k_n300_mesh_llama3.2-11b-vision_tests](https://github.com/tenstorrent/tt-metal/actions/runs/22868271407/job/66344032637#logs)
[t3000-unit-tests / t3k_llama3.2-90b-vision_tests](https://github.com/tenstorrent/tt-metal/actions/runs/22868271407/job/66344032448#logs)
[t3000-unit-tests / t3k_llama3.2-11b-vision_tests](https://github.com/tenstorrent/tt-metal/actions/runs/22868271407/job/66344032519#logs)
[t3000-demo-tests / t3k_llama3_vision_tests](https://github.com/tenstorrent/tt-metal/actions/runs/22930543265/job/66551509288#logs)

### What's changed
Replaced the `ttnn.tilize(x)` call in the llama embedding forward function with `ttnn.to_layout(x, layout=ttnn.TILE_LAYOUT)`.

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=awliu/Tilize_ND_PR_Fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:awliu/Tilize_ND_PR_Fix)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=awliu/Tilize_ND_PR_Fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:awliu/Tilize_ND_PR_Fix)
- [x] [T3K Demo](https://github.com/tenstorrent/tt-metal/actions/runs/22990872848)
- [x] [T3K Unit Tests](https://github.com/tenstorrent/tt-metal/actions/runs/22990884020)
- [x] New/Existing tests provide coverage for changes
- [x] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/runs/22990923915) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=awliu/Tilize_ND_PR_Fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:awliu/Tilize_ND_PR_Fix)
  - [x] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/22991015785) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/22991035311))
  - [x] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/runs/22991047884) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/runs/22991068388)

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=awliu/Tilize_ND_PR_Fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:awliu/Tilize_ND_PR_Fix)
  - [x] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/22990884020)
  - [x] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/runs/22990872848) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/runs/22990996143) tests)

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=awliu/Tilize_ND_PR_Fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:awliu/Tilize_ND_PR_Fix)
  - [x] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/runs/22991142014))
