### PR TITLE
#23644: TopK not correct when part of the input contains inf values

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_topk.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_topk.py
@@ -235,6 +235,84 @@ def test_topk_large_2d_shapes(N, C, H, W, dim, k, dtype, sorted, largest, device
     run_topk_test(N, C, H, W, k, dtype, dim, sorted, largest, device, sub_core_grids, pass_indices_tensor)
 
 
+def run_topk_bfloat8_inf_test(N, C, H, W, k, dim, sub_core_grids, device):
+    assert W % 32 == 0, "W must be a multiple of 32 to avoid the pad path"
+    assert H >= 2, "H must be >= 2 to have both finite and all-inf rows"
+
+    torch.manual_seed(2005)
+    shape = [N, C, H, W]
+    input_torch = torch.randn(shape, dtype=torch.bfloat16) * 0.9
+    # Set all rows except the first to +inf to trigger the shared-exponent bug
+    # on the intermediate transposed tiles.
+    input_torch[:, :, 1:, :] = float("inf")
+
+    pyt_values, _ = torch.topk(input_torch, k, dim=dim, largest=True, sorted=True)
+
+    ttnn_input = ttnn.from_torch(input_torch, ttnn.bfloat8_b, layout=ttnn.Layout.TILE, device=device)
+    ttnn_values, ttnn_indices = ttnn.topk(
+        ttnn_input, k, dim=dim, largest=True, sorted=True, sub_core_grids=sub_core_grids
+    )
+
+    desired_shape = list(shape)
+    desired_shape[dim] = k
+    assert list(ttnn_values.shape) == desired_shape
+    assert list(ttnn_indices.shape) == desired_shape
+
+    ttnn_values_torch = ttnn.to_torch(ttnn_values)
+    ttnn_indices_torch = ttnn.to_torch(ttnn_indices).to(torch.int64)
+
+    # Only compare the finite (H=0) rows; the all-inf rows are uninteresting and
+    # their exact ordering is undefined when all values are equal (+inf).
+    pyt_values_finite = pyt_values[:, :, :1, :]
+    ttnn_values_finite = ttnn_values_torch[:, :, :1, :]
+    ttnn_gather_finite = torch.gather(input_torch, dim, ttnn_indices_torch)[:, :, :1, :]
+
+    cosine = torch.nn.CosineSimilarity(dim=dim)
+    cosine_sim = torch.mean(cosine(pyt_values_finite, ttnn_gather_finite))
+    assert cosine_sim > 0.99, (
+        f"Cosine similarity between bfloat8_b topk values and gather-from-indices "
+        f"is {cosine_sim:.4f} (expected > 0.99).  "
+        f"This is the bfp8 shared-exponent/inf regression."
+    )
+
+    # bfloat8_b has limited precision; accept a small absolute difference.
+    # Cast to float32 first: pyt_values_finite is bfloat16, ttnn_values_finite is
+    # float32 (ttnn.to_torch upcasts bfloat8_b), and torch.allclose raises on
+    # dtype mismatch.
+    assert torch.allclose(pyt_values_finite.float(), ttnn_values_finite.float(), atol=0.5), (
+        f"bfloat8_b TopK values differ from PyTorch reference by more than 0.5:\n"
+        f"  PyTorch:  {pyt_values_finite}\n"
+        f"  TTNN:     {ttnn_values_finite}"
+    )
+
+
+@pytest.mark.parametrize(
+    "N, C, H, W, dim, k, sub_core_grids",
+    [
+        (1, 1, 32, 256, 3, 32, None),
+        (
+            1,
+            1,
+            32,
+            16 * 1024,
+            3,
+            32,
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 7)),
+                ]
+            ),
+        ),
+    ],
+    ids=["single_core_bfp8_inf", "multi_core_bfp8_inf"],
+)
+def test_topk_bfloat8_with_inf(N, C, H, W, dim, k, sub_core_grids, device):
+    """bfloat8_b TopK correctness when an entire H-row contains +inf values."""
+    if dim == 0 or dim == 1:
+        pytest.skip("dim=0/1 not supported for bfloat8_b (transpose path requires bfloat16 or float32)")
+    run_topk_bfloat8_inf_test(N, C, H, W, k, dim, sub_core_grids, device)
+
+
 @pytest.mark.parametrize(
     "torch_input_tensor_dtype, ttnn_input_tensor_dtype",
     [

--- a/tests/ttnn/unit_tests/operations/reduce/test_topk.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_topk.py
@@ -275,12 +275,16 @@ def run_topk_bfloat8_inf_test(N, C, H, W, k, dim, sub_core_grids, device):
         f"This is the bfp8 shared-exponent/inf regression."
     )
 
-    # bfloat8_b has limited precision; accept a small absolute difference.
-    # Cast to float32 first: pyt_values_finite is bfloat16, ttnn_values_finite is
-    # float32 (ttnn.to_torch upcasts bfloat8_b), and torch.allclose raises on
-    # dtype mismatch.
-    assert torch.allclose(pyt_values_finite.float(), ttnn_values_finite.float(), atol=0.5), (
-        f"bfloat8_b TopK values differ from PyTorch reference by more than 0.5:\n"
+    # bfloat8_b has 2 mantissa bits, so the maximum relative quantization error per
+    # value is 2^-2 = 25%.  Two quantization steps occur (input bf16→bfp8 and output
+    # bf16→bfp8), but they are correlated so the combined worst-case stays near 25%.
+    # rtol=0.1 is therefore stricter than the format's theoretical maximum, meaning it
+    # catches genuine corruption (e.g. values becoming 0 due to the inf/shared-exponent
+    # bug) while tolerating legitimate bfp8 rounding.
+    # Cast to float32 first: pyt_values_finite is bfloat16 while ttnn_values_finite is
+    # float32 (ttnn.to_torch upcasts bfloat8_b), and torch.allclose raises on dtype mismatch.
+    assert torch.allclose(pyt_values_finite.float(), ttnn_values_finite.float(), rtol=0.1, atol=0.1), (
+        f"bfloat8_b TopK values exceed 10 % relative error vs PyTorch reference:\n"
         f"  PyTorch:  {pyt_values_finite}\n"
         f"  TTNN:     {ttnn_values_finite}"
     )

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk.cpp
@@ -20,10 +20,12 @@
  */
 FORCE_INLINE void transpose_and_pack(
     const uint32_t input_cb_index, const uint32_t dest_cb_index, const uint32_t total_tiles) {
-    // Configure data formats for transpose operation
+    // Configure data formats for transpose operation.
+    // Pack using the DESTINATION CB format: input_cb may be bf16 (higher-precision
+    // intermediate) while dest_cb is the original bfp8/bfp4 output format.
     reconfig_data_format_srca(input_cb_index);
     transpose_wh_init_short(input_cb_index);
-    pack_reconfig_data_format(input_cb_index);
+    pack_reconfig_data_format(dest_cb_index);
 
     // Wait for all tiles to be available (double-buffered, hence 2 * total_tiles)
     cb_wait_front(input_cb_index, 2 * total_tiles);

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_common_funcs.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_common_funcs.hpp
@@ -272,7 +272,9 @@ void process_iteration(
 void transpose_and_pack(uint32_t transposed_cb_index, uint32_t dest_cb_index, uint32_t Kt, uint32_t Wt) {
     reconfig_data_format_srca(transposed_cb_index);
     transpose_wh_init_short(transposed_cb_index);
-    pack_reconfig_data_format(transposed_cb_index);
+    // Pack using the DESTINATION CB format: transposed_cb may be bf16 (higher-precision
+    // intermediate) while dest_cb is the original bfp8/bfp4 output format.
+    pack_reconfig_data_format(dest_cb_index);
 
     cb_wait_front(transposed_cb_index, Kt);
     for (uint32_t i = 0; i < Kt; ++i) {

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_local.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_local.cpp
@@ -175,10 +175,12 @@ void kernel_main() {
         // After bitonic merging, the top Kt tiles contain the locally optimal
         // TopK elements. Extract these and prepare for sending to the final core.
 
-        // Configure data formats for tile copying and prepare value tiles
+        // Configure data formats for tile copying and prepare value tiles.
+        // Pack using values_cb format: input_transposed_cb may be bf16 (higher-precision
+        // intermediate) while values_cb is the original bfp8/bfp4 output format.
         reconfig_data_format_srca(input_transposed_cb_index);
         copy_tile_to_dst_init_short_with_dt(index_transposed_cb_index, input_transposed_cb_index);
-        pack_reconfig_data_format(input_transposed_cb_index);
+        pack_reconfig_data_format(values_cb_index);
 
         // Extract local TopK values (first Kt tiles contain best values)
         cb_wait_front(input_transposed_cb_index, Kt);

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_device_operation.cpp
@@ -108,10 +108,8 @@ TopKDeviceOperation::program_factory_t TopKDeviceOperation::select_program_facto
 
     // Select program factory based on feasibility analysis
     if (multicore_supported) {
-        std::cout << "Using multi-core program factory" << std::endl;
         return TopKMultiCoreProgramFactory{};
     }
-    std::cout << "Using single-core program factory" << std::endl;
     return TopKSingleCoreProgramFactory{};
 }
 

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_device_operation.cpp
@@ -108,9 +108,10 @@ TopKDeviceOperation::program_factory_t TopKDeviceOperation::select_program_facto
 
     // Select program factory based on feasibility analysis
     if (multicore_supported) {
+        std::cout << "Using multi-core program factory" << std::endl;
         return TopKMultiCoreProgramFactory{};
     }
-
+    std::cout << "Using single-core program factory" << std::endl;
     return TopKSingleCoreProgramFactory{};
 }
 

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_multi_core_program_factory.cpp
@@ -76,6 +76,14 @@ TopKMultiCoreProgramFactory::cached_program_t TopKMultiCoreProgramFactory::creat
     const tt::DataFormat index_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(index_tensor.dtype());
     const bool is32_bit_data = index_cb_data_format == tt::DataFormat::UInt32;
 
+    // Use bf16 for compute intermediate buffers to avoid precision loss from bfp8/bfp4
+    // shared-exponent grouping during sort (e.g. a single inf in a block makes all other
+    // elements in that block encode to 0, corrupting the sort result).
+    const tt::DataFormat compute_cb_data_format =
+        (input_cb_data_format == tt::DataFormat::Bfp8_b || input_cb_data_format == tt::DataFormat::Bfp4_b)
+            ? tt::DataFormat::Float16_b
+            : input_cb_data_format;
+
     // Core grid and tile size calculations
     const auto first_core_range = args.sub_core_grids.ranges().at(0);
     const auto first_core_range_set = CoreRangeSet(first_core_range);
@@ -83,6 +91,7 @@ TopKMultiCoreProgramFactory::cached_program_t TopKMultiCoreProgramFactory::creat
     const uint32_t input_tile_size = tile_size(input_cb_data_format);
     const uint32_t value_tile_size = tile_size(value_cb_data_format);
     const uint32_t index_tile_size = tile_size(index_cb_data_format);
+    const uint32_t compute_tile_size = tile_size(compute_cb_data_format);
 
     // DRAM buffer pointers for kernel runtime arguments
     const auto* input_buffer = input_tensor.buffer();
@@ -162,13 +171,17 @@ TopKMultiCoreProgramFactory::cached_program_t TopKMultiCoreProgramFactory::creat
             .set_page_size(index_cb_index, index_tile_size);
     tt::tt_metal::CreateCircularBuffer(program, all_cores_range_set, index_input_intermed0_config);
 
-    // Gathered values (aggregation buffer for final core)
-    // Receives local TopK results from all worker cores (Wt_final = num_cores * Kt)
+    // Gathered values (aggregation buffer for final core).
+    // Uses compute_cb_data_format (bf16 when input is bfp8/bfp4): the local cores write
+    // tiles in transposed layout where each tile row mixes values from different H positions
+    // (e.g. [normal_H0, INF_H1, ..., INF_H31]). If stored as bfp8 the shared-exponent
+    // block is dominated by INF, zeroing out H=0's value. Keeping bf16 here and in
+    // values_cb_index (local) avoids that precision loss for the inter-core transfer.
     constexpr uint32_t gathered_values_cb_index = tt::CBIndex::c_4;
     const tt::tt_metal::CircularBufferConfig gathered_values_cb_config =
         tt::tt_metal::CircularBufferConfig(
-            Wt_final * value_tile_size, {{gathered_values_cb_index, value_cb_data_format}})
-            .set_page_size(gathered_values_cb_index, value_tile_size);
+            Wt_final * compute_tile_size, {{gathered_values_cb_index, compute_cb_data_format}})
+            .set_page_size(gathered_values_cb_index, compute_tile_size);
     tt::tt_metal::CreateCircularBuffer(program, all_cores_range_set, gathered_values_cb_config);
 
     // Gathered indices (aggregation buffer for final core)
@@ -179,13 +192,6 @@ TopKMultiCoreProgramFactory::cached_program_t TopKMultiCoreProgramFactory::creat
             .set_page_size(gathered_indices_cb_index, index_tile_size);
     tt::tt_metal::CreateCircularBuffer(program, all_cores_range_set, gathered_indices_cb_config);
 
-    // Local TopK values output (local cores → writer → final core)
-    constexpr uint32_t values_cb_index = tt::CBIndex::c_8;
-    const tt::tt_metal::CircularBufferConfig values_cb_config =
-        tt::tt_metal::CircularBufferConfig(num_cb_unit * value_tile_size, {{values_cb_index, value_cb_data_format}})
-            .set_page_size(values_cb_index, value_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores_range_set, values_cb_config);
-
     // Local TopK indices output (local cores → writer → final core)
     constexpr uint32_t output_ind_cb_index = tt::CBIndex::c_9;
     const tt::tt_metal::CircularBufferConfig output_ind_cb_config =
@@ -194,12 +200,14 @@ TopKMultiCoreProgramFactory::cached_program_t TopKMultiCoreProgramFactory::creat
     tt::tt_metal::CreateCircularBuffer(program, all_cores_range_set, output_ind_cb_config);
 
     // Transposed values (single-buffered for in-place bitonic operations)
-    // Holds all Wt_local tiles for complete width chunk processing
+    // Holds all Wt_local tiles for complete width chunk processing.
+    // Uses bf16 when input is bfp8/bfp4 to avoid precision loss from shared-exponent
+    // grouping during the sort (inf in one slot zeroes out its block-mates).
     constexpr uint32_t input_transposed_cb_index = tt::CBIndex::c_2;
     const tt::tt_metal::CircularBufferConfig input_transposed_cb_config =
         tt::tt_metal::CircularBufferConfig(
-            Wt_local * value_tile_size, {{input_transposed_cb_index, input_cb_data_format}})
-            .set_page_size(input_transposed_cb_index, input_tile_size);
+            Wt_local * compute_tile_size, {{input_transposed_cb_index, compute_cb_data_format}})
+            .set_page_size(input_transposed_cb_index, compute_tile_size);
     tt::tt_metal::CreateCircularBuffer(program, local_cores_range_set, input_transposed_cb_config);
 
     // Transposed indices (single-buffered for in-place bitonic operations)
@@ -210,11 +218,36 @@ TopKMultiCoreProgramFactory::cached_program_t TopKMultiCoreProgramFactory::creat
             .set_page_size(index_transposed_cb_index, index_tile_size);
     tt::tt_metal::CreateCircularBuffer(program, local_cores_range_set, index_transposed_cb_config);
 
-    // Final values (staging buffer for final compute output)
+    // Local TopK values output — split format between local and final cores.
+    //
+    // Local cores (bf16): the sorted Kt tile in transposed layout has rows of the form
+    // [normal_H0, INF_H1, ..., INF_H31]. Packing such a row to bfp8 makes the
+    // shared-exponent INF-dominated, reducing H=0's value to 0. Using bf16 here
+    // preserves all values through the NoC transfer to the final core's c_4 buffer
+    // (also bf16, same tile size, so the raw-byte NoC copy is format-consistent).
+    //
+    // Final core (bfp8): after the final merge and transpose-back, the tile rows are
+    // per-H-row (H=0 row has only normal values, no INF mixing), so bfp8 quantisation
+    // is safe. bfp8 also matches the output tensor dtype for the DRAM write.
+    constexpr uint32_t values_cb_index = tt::CBIndex::c_8;
+    const tt::tt_metal::CircularBufferConfig values_cb_config_local =
+        tt::tt_metal::CircularBufferConfig(num_cb_unit * compute_tile_size, {{values_cb_index, compute_cb_data_format}})
+            .set_page_size(values_cb_index, compute_tile_size);
+    tt::tt_metal::CreateCircularBuffer(program, local_cores_range_set, values_cb_config_local);
+
+    const tt::tt_metal::CircularBufferConfig values_cb_config_final =
+        tt::tt_metal::CircularBufferConfig(num_cb_unit * value_tile_size, {{values_cb_index, value_cb_data_format}})
+            .set_page_size(values_cb_index, value_tile_size);
+    tt::tt_metal::CreateCircularBuffer(program, final_cores_range_set, values_cb_config_final);
+
+    // Final values (staging buffer for final compute output).
+    // Uses bf16 when input is bfp8/bfp4 so that the final bitonic merge operates at
+    // higher precision (same rationale as input_transposed_cb_index above).
     constexpr uint32_t final_values_cb_index = tt::CBIndex::c_6;
     const tt::tt_metal::CircularBufferConfig final_values_cb_config =
-        tt::tt_metal::CircularBufferConfig(Wt_final * value_tile_size, {{final_values_cb_index, value_cb_data_format}})
-            .set_page_size(final_values_cb_index, value_tile_size);
+        tt::tt_metal::CircularBufferConfig(
+            Wt_final * compute_tile_size, {{final_values_cb_index, compute_cb_data_format}})
+            .set_page_size(final_values_cb_index, compute_tile_size);
     tt::tt_metal::CreateCircularBuffer(program, final_cores_range_set, final_values_cb_config);
 
     // Final indices (staging buffer for final compute output)

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_single_core_program_factory.cpp
@@ -35,10 +35,19 @@ TopKSingleCoreProgramFactory::cached_program_t TopKSingleCoreProgramFactory::cre
     const tt::DataFormat output_ind_cb_data_format =
         tt::tt_metal::datatype_to_dataformat_converter(index_tensor.dtype());
 
+    // Use bf16 for compute intermediate buffers to avoid precision loss from bfp8/bfp4
+    // shared-exponent grouping during sort (e.g. a single inf in a block makes all other
+    // elements in that block encode to 0, corrupting the sort result).
+    const tt::DataFormat compute_cb_data_format =
+        (input_cb_data_format == tt::DataFormat::Bfp8_b || input_cb_data_format == tt::DataFormat::Bfp4_b)
+            ? tt::DataFormat::Float16_b
+            : input_cb_data_format;
+
     // Calculate tile sizes for memory allocation
     const uint32_t input_tile_size = tile_size(input_cb_data_format);
     const uint32_t value_tile_size = tile_size(output_val_cb_data_format);
     const uint32_t index_tile_size = tile_size(output_ind_cb_data_format);
+    const uint32_t compute_tile_size = tile_size(compute_cb_data_format);
 
     // Device memory buffer pointers for kernel runtime arguments
     const auto* input_buffer = input_tensor.buffer();
@@ -92,11 +101,13 @@ TopKSingleCoreProgramFactory::cached_program_t TopKSingleCoreProgramFactory::cre
             .set_page_size(index_cb_index, index_tile_size);
     tt::tt_metal::CreateCircularBuffer(program, core_range, index_input_intermed0_config);
 
+    // Uses bf16 when input is bfp8/bfp4 so that the insertion sort operates at higher
+    // precision and avoids shared-exponent corruption of tiles adjacent to inf values.
     constexpr uint32_t transposed_val_cb_index = tt::CBIndex::c_2;
     const tt::tt_metal::CircularBufferConfig transposed_val_cb_config =
         tt::tt_metal::CircularBufferConfig(
-            transposed_cb_tile_count * input_tile_size, {{transposed_val_cb_index, input_cb_data_format}})
-            .set_page_size(transposed_val_cb_index, input_tile_size);
+            transposed_cb_tile_count * compute_tile_size, {{transposed_val_cb_index, compute_cb_data_format}})
+            .set_page_size(transposed_val_cb_index, compute_tile_size);
     tt::tt_metal::CreateCircularBuffer(program, core_range, transposed_val_cb_config);
 
     constexpr uint32_t transposed_ind_cb_index = tt::CBIndex::c_3;
@@ -106,11 +117,12 @@ TopKSingleCoreProgramFactory::cached_program_t TopKSingleCoreProgramFactory::cre
             .set_page_size(transposed_ind_cb_index, index_tile_size);
     tt::tt_metal::CreateCircularBuffer(program, core_range, transposed_ind_cb_config);
 
+    // Uses bf16 when input is bfp8/bfp4 (same rationale as transposed_val_cb_index).
     constexpr uint32_t result_prep_val_cb_index = tt::CBIndex::c_4;
     const tt::tt_metal::CircularBufferConfig result_prep_val_cb_config =
         tt::tt_metal::CircularBufferConfig(
-            result_prep_cb_tile_count * input_tile_size, {{result_prep_val_cb_index, input_cb_data_format}})
-            .set_page_size(result_prep_val_cb_index, input_tile_size);
+            result_prep_cb_tile_count * compute_tile_size, {{result_prep_val_cb_index, compute_cb_data_format}})
+            .set_page_size(result_prep_val_cb_index, compute_tile_size);
     tt::tt_metal::CreateCircularBuffer(program, core_range, result_prep_val_cb_config);
 
     constexpr uint32_t result_prep_ind_cb_index = tt::CBIndex::c_5;

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_utils.cpp
@@ -243,9 +243,9 @@ bool verify_single_core_cost(const ttnn::Tensor& input_tensor, uint32_t k, bool 
     // Total memory cost: input/output buffers use value_tile_size, intermediate compute
     // buffers (transposed + result_prep) use compute_tile_size (may be larger).
     const uint32_t memory_cost_local =
-        input_cb_tile_count * (value_tile_size + index_tile_size) +
-        (transposed_cb_tile_count + result_prep_cb_tile_count) * (compute_tile_size + index_tile_size) +
-        output_cb_tile_count * (value_tile_size + index_tile_size);
+        (input_cb_tile_count * (value_tile_size + index_tile_size)) +
+        ((transposed_cb_tile_count + result_prep_cb_tile_count) * (compute_tile_size + index_tile_size)) +
+        (output_cb_tile_count * (value_tile_size + index_tile_size));
 
     // Verify that total memory requirement fits within single core's L1 cache
     return memory_cost_local < device->l1_size_per_core();

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_utils.cpp
@@ -75,9 +75,10 @@ std::optional<TopKCoreConfig> find_topk_core_config(
     const uint32_t start_split_size =
         static_cast<uint32_t>(width / tile_width / largest_power_of_two(max_cores)) * tile_width;
 
-    // The transposed intermediate CB (c_2) uses bf16 when the input format is bfp8/bfp4 to
-    // avoid shared-exponent precision loss during sort.  Use the larger of the two tile sizes
-    // when estimating per-core local memory.
+    // The transposed intermediate CBs (c_2, c_4, c_6, and c_8 on local cores) all use bf16
+    // when the input format is bfp8/bfp4 to avoid shared-exponent precision loss during sort
+    // and inter-core transfer.  Use the larger of the two tile sizes for all value-holding
+    // CB cost estimates.
     const uint32_t bf16_tile_size = tt::tile_size(tt::DataFormat::Float16_b);
     const uint32_t transposed_tile_size = std::max(value_tile_size, bf16_tile_size);
 
@@ -89,8 +90,10 @@ std::optional<TopKCoreConfig> find_topk_core_config(
 
         // Gather cost: memory for collecting results from all cores.
         // Factor of 2 accounts for intermediate storage during gather phase.
-        // The gather (c_4/c_5) buffers use the original value_tile_size.
-        const uint32_t memory_cost_gather = 2 * num_cores * (value_tile_size + index_tile_size);
+        // c_4 (gathered values) is allocated with transposed_tile_size (bf16 when input is
+        // bfp8/bfp4) to avoid shared-exponent corruption on inter-core transfer; c_5
+        // (gathered indices) remains index_tile_size.
+        const uint32_t memory_cost_gather = 2 * num_cores * (transposed_tile_size + index_tile_size);
 
         // Local cost: memory each core needs for its width chunk.
         // Uses transposed_tile_size (bf16 when input is bfp8/bfp4) for the transposed CB.

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_utils.cpp
@@ -74,20 +74,27 @@ std::optional<TopKCoreConfig> find_topk_core_config(
     // This ensures we start with a split size that can utilize most available cores
     const uint32_t start_split_size =
         static_cast<uint32_t>(width / tile_width / largest_power_of_two(max_cores)) * tile_width;
+
+    // The transposed intermediate CB (c_2) uses bf16 when the input format is bfp8/bfp4 to
+    // avoid shared-exponent precision loss during sort.  Use the larger of the two tile sizes
+    // when estimating per-core local memory.
+    const uint32_t bf16_tile_size = tt::tile_size(tt::DataFormat::Float16_b);
+    const uint32_t transposed_tile_size = std::max(value_tile_size, bf16_tile_size);
+
     // Search for optimal split size by trying powers of 2 from conservative start to max_dim
     for (uint32_t split_size = start_split_size; split_size <= max_dim; split_size *= 2) {
         // Calculate work distribution for this split size
         const uint32_t rem = width % split_size;                      // Remainder after even division
         const uint32_t num_cores = (width / split_size) + (rem > 0);  // Cores needed (extra for remainder)
 
-        // Calculate memory costs for this configuration:
-        // Gather cost: Memory for collecting results from all cores (includes both value and index tiles)
-        // Factor of 2 accounts for intermediate storage during gather phase
+        // Gather cost: memory for collecting results from all cores.
+        // Factor of 2 accounts for intermediate storage during gather phase.
+        // The gather (c_4/c_5) buffers use the original value_tile_size.
         const uint32_t memory_cost_gather = 2 * num_cores * (value_tile_size + index_tile_size);
 
-        // Local cost: Memory each core needs for its portion of the work
-        // Proportional to split_size converted to tiles
-        const uint32_t memory_cost_local = (split_size / tile_width) * (value_tile_size + index_tile_size);
+        // Local cost: memory each core needs for its width chunk.
+        // Uses transposed_tile_size (bf16 when input is bfp8/bfp4) for the transposed CB.
+        const uint32_t memory_cost_local = (split_size / tile_width) * (transposed_tile_size + index_tile_size);
 
         // Extract core grid dimensions from the available range
         const uint32_t max_x = core_range.end_coord.x - core_range.start_coord.x;
@@ -223,10 +230,19 @@ bool verify_single_core_cost(const ttnn::Tensor& input_tensor, uint32_t k, bool 
     const uint32_t value_tile_size = tt::tile_size(value_cb_data_format);
     const uint32_t index_tile_size = tt::tile_size(index_cb_data_format);
 
-    // Total memory cost: sum of all circular buffers, each storing both values and indices
+    // Transposed (c_2) and result-prep (c_4) CBs use bf16 when input is bfp8/bfp4 to
+    // preserve precision during the sort.  Use the larger bf16 tile size for those buffers.
+    const uint32_t compute_tile_size =
+        (value_cb_data_format == tt::DataFormat::Bfp8_b || value_cb_data_format == tt::DataFormat::Bfp4_b)
+            ? tt::tile_size(tt::DataFormat::Float16_b)
+            : value_tile_size;
+
+    // Total memory cost: input/output buffers use value_tile_size, intermediate compute
+    // buffers (transposed + result_prep) use compute_tile_size (may be larger).
     const uint32_t memory_cost_local =
-        (input_cb_tile_count + transposed_cb_tile_count + result_prep_cb_tile_count + output_cb_tile_count) *
-        (value_tile_size + index_tile_size);
+        input_cb_tile_count * (value_tile_size + index_tile_size) +
+        (transposed_cb_tile_count + result_prep_cb_tile_count) * (compute_tile_size + index_tile_size) +
+        output_cb_tile_count * (value_tile_size + index_tile_size);
 
     // Verify that total memory requirement fits within single core's L1 cache
     return memory_cost_local < device->l1_size_per_core();


### PR DESCRIPTION
### Ticket

#23644

### Problem description

The `ttnn.topk` operation produces incorrect results when input tensors contain inf values in bfp8 format, because the transpose step causes bfp8's shared exponent (across 16 datums) to zero out non-inf values in the same block. This PR addresses the issue by using higher precision (bf16) during compute while maintaining bfp8 input/output compatibility.

### What's changed

- Changed reconfigured DST dtype only when input is `bfloat8_b` and `bfloat4_b`,
- Adjusted  compute core buffer-format/memory-model for larger data size for `bfloat8_b` and `bfloat4_b`.

### Comparison table

Program factory | Shape | dtype | Time - new implementation [ns] | Time - old implementation [ns] | Time - delta (old - new) [ns] | Time - delta [%]
-- | -- | -- | -- | -- | -- | --
Single core | (1, 1, 32, 32) | bfloat16 | 43981 | 43597 | -384 | -0.87%
Single core | (1, 1, 32, 32 * 2) | bfloat16 | 43873 | 43577 | -296 | -0.67%
Single core | (1, 1, 32, 32 * 4) | bfloat16 | 79517 | 79128 | -389 | -0.49%
Single core | (1, 1, 32, 32 * 8) | bfloat16 | 149978 | 150021 | 43 | 0.03%
Single core | (1, 1, 32, 32 * 16) | bfloat16 | 292548 | 292438 | -110 | -0.04%
Single core | (1, 1, 32, 32 * 32) | bfloat16 | 576131 | 576092 | -39 | -0.01%
Single core | (1, 1, 32, 32 * 64) | bfloat16 | 1148197 | 1148824 | 627 | 0.05%
Single core | (1, 1, 32, 32 * 128) | bfloat16 | 2288778 | 2289233 | 455 | 0.02%
Multi core | (1, 1, 32, 32 * 256) | bfloat16 | 369730 | 369731 | 1 | 0.00%
Multi core | (1, 1, 32, 32 * 512) | bfloat16 | 689836 | 689475 | -361 | -0.05%
Multi core | (1, 1, 32, 32 * 1024) | bfloat16 | 1333581 | 1333325 | -256 | -0.02%
Single core | (1, 1, 32, 32 * 2048) | bfloat16 | 17286938 | 17289286 | 2348 | 0.01%
Single core | (1, 1, 32, 32) | bfloat8_b | 43602 | 43611 | 9 | 0.02%
Single core | (1, 1, 32, 32 * 2) | bfloat8_b | 43562 | 43510 | -52 | -0.12%
Single core | (1, 1, 32, 32 * 4) | bfloat8_b | 79335 | 79241 | -94 | -0.12%
Single core | (1, 1, 32, 32 * 8) | bfloat8_b | 150045 | 150010 | -35 | -0.02%
Single core | (1, 1, 32, 32 * 16) | bfloat8_b | 291644 | 291397 | -247 | -0.08%
Single core | (1, 1, 32, 32 * 32) | bfloat8_b | 574714 | 574531 | -183 | -0.03%
Single core | (1, 1, 32, 32 * 64) | bfloat8_b | 1144610 | 1144542 | -68 | -0.01%
Single core | (1, 1, 32, 32 * 128) | bfloat8_b | 2279555 | 2280150 | 595 | 0.03%
Multi core | (1, 1, 32, 32 * 256) | bfloat8_b | 369210 | 366714 | -2496 | -0.68%
Multi core | (1, 1, 32, 32 * 512) | bfloat8_b | 687735 | 685929 | -1806 | -0.26%
Multi core | (1, 1, 32, 32 * 1024) | bfloat8_b | 1328945 | 1325784 | -3161 | -0.24%
Single core | (1, 1, 32, 32 * 2048) | bfloat8_b | 17255463 | 17262836 | 7373 | 0.04%

Performance change within margin of error +-0.1%.

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mgajewskiTT/23644-topk-not-correct-when-part-of-the-input-contains-inf-values)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mgajewskiTT/23644-topk-not-correct-when-part-of-the-input-contains-inf-values)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mgajewskiTT/23644-topk-not-correct-when-part-of-the-input-contains-inf-values)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mgajewskiTT/23644-topk-not-correct-when-part-of-the-input-contains-inf-values)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mgajewskiTT/23644-topk-not-correct-when-part-of-the-input-contains-inf-values)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mgajewskiTT/23644-topk-not-correct-when-part-of-the-input-contains-inf-values)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mgajewskiTT/23644-topk-not-correct-when-part-of-the-input-contains-inf-values)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mgajewskiTT/23644-topk-not-correct-when-part-of-the-input-contains-inf-values)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mgajewskiTT/23644-topk-not-correct-when-part-of-the-input-contains-inf-values)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mgajewskiTT/23644-topk-not-correct-when-part-of-the-input-contains-inf-values)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mgajewskiTT/23644-topk-not-correct-when-part-of-the-input-contains-inf-values)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mgajewskiTT/23644-topk-not-correct-when-part-of-the-input-contains-inf-values)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
