### PR TITLE
Remove deprecated namespaces

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
@@ -6,6 +6,8 @@
 
 #include <optional>
 
+#include <tt_stl/span.hpp>
+
 #include "ttnn/decorators.hpp"
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/eltwise/binary/device/binary_composite_op.hpp"
@@ -45,9 +47,9 @@ struct ExecutePower {
         const std::optional<const DataType>& dtype = std::nullopt,
         const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
 
     static Tensor invoke(
@@ -56,9 +58,9 @@ struct ExecutePower {
         const std::optional<const DataType>& dtype = std::nullopt,
         const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
 };
 
@@ -109,9 +111,9 @@ struct ExecuteDiv {
         const std::optional<const DataType>& output_dtype = std::nullopt,
         const std::optional<MemoryConfig>& output_mem_config = std::nullopt,
         const std::optional<Tensor>& output_tensor = std::nullopt,
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
         const std::optional<bool>& use_legacy = std::nullopt,
         const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 
@@ -123,9 +125,9 @@ struct ExecuteDiv {
         const std::optional<const DataType>& output_dtype = std::nullopt,
         const std::optional<MemoryConfig>& output_mem_config = std::nullopt,
         std::optional<Tensor> output = std::nullopt,
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
         const std::optional<bool>& use_legacy = std::nullopt,
         const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 };
@@ -138,9 +140,9 @@ struct ExecuteBiasGelu {
         const std::optional<const DataType>& output_dtype = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt,
         const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt) {
         return BinaryOperation<binary_op_type>::invoke(
@@ -162,9 +164,9 @@ struct ExecuteBiasGelu {
         const std::optional<const DataType>& /*dtype*/ = std::nullopt,
         const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> /*post_activations*/ = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> /*lhs_activations*/ = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> /*rhs_activations*/ = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> /*post_activations*/ = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> /*lhs_activations*/ = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> /*rhs_activations*/ = {},
         std::optional<bool> /*use_legacy*/ = std::nullopt,
         const std::optional<CoreRangeSet>& /*sub_core_grids*/ = std::nullopt) {
         return ttnn::gelu(
@@ -180,9 +182,9 @@ struct ExecuteBiasGelu {
         const std::optional<const DataType>& output_dtype = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& output = std::nullopt,
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
         const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt) {
         return BinaryOperation<binary_op_type>::invoke(
             input_tensor_a,
@@ -202,9 +204,9 @@ struct ExecuteBiasGelu {
         const std::optional<const DataType>& output_dtype = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& output = std::nullopt,
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {}) {
+        ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations = {}) {
         return BinaryOperation<binary_op_type>::invoke(
             input_tensor_a,
             scalar,
@@ -262,9 +264,9 @@ struct ExecuteLCM {
         const std::optional<const DataType>& output_dtype = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
 };
 
@@ -275,9 +277,9 @@ struct ExecuteGCD {
         const std::optional<const DataType>& output_dtype = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
 };
 
@@ -288,9 +290,9 @@ struct ExecuteMaximum {
         const std::optional<const DataType>& output_dtype = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
 
     static Tensor invoke(
@@ -299,9 +301,9 @@ struct ExecuteMaximum {
         const std::optional<const DataType>& output_dtype = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
 };
 
@@ -312,9 +314,9 @@ struct ExecuteMinimum {
         const std::optional<const DataType>& output_dtype = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
 
     static Tensor invoke(
@@ -323,9 +325,9 @@ struct ExecuteMinimum {
         const std::optional<const DataType>& output_dtype = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
 };
 
@@ -351,9 +353,9 @@ struct ExecuteRsub {
         const std::optional<const DataType>& output_dtype = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
 
     static Tensor invoke(
@@ -362,9 +364,9 @@ struct ExecuteRsub {
         const std::optional<const DataType>& output_dtype = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
 };
 
@@ -374,9 +376,9 @@ struct ExecuteBitwiseAnd {
         const Tensor& input_tensor_b_arg,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
 
     static Tensor invoke(
@@ -384,9 +386,9 @@ struct ExecuteBitwiseAnd {
         int32_t input_b,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
 };
 
@@ -396,9 +398,9 @@ struct ExecuteBitwiseOr {
         const Tensor& input_tensor_b_arg,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
 
     static Tensor invoke(
@@ -406,9 +408,9 @@ struct ExecuteBitwiseOr {
         int32_t input_b,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
 };
 
@@ -418,9 +420,9 @@ struct ExecuteBitwiseXor {
         const Tensor& input_tensor_b_arg,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
 
     static Tensor invoke(
@@ -428,9 +430,9 @@ struct ExecuteBitwiseXor {
         int32_t input_b,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
 };
 
@@ -440,9 +442,9 @@ struct ExecuteBitwiseLeftShift {
         const Tensor& input_tensor_b_arg,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
 
     static Tensor invoke(
@@ -450,9 +452,9 @@ struct ExecuteBitwiseLeftShift {
         int32_t input_b,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
 };
 
@@ -462,9 +464,9 @@ struct ExecuteBitwiseRightShift {
         const Tensor& input_tensor_b_arg,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
 
     static Tensor invoke(
@@ -472,9 +474,9 @@ struct ExecuteBitwiseRightShift {
         int32_t input_b,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
+        ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
 };
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.hpp
@@ -33,9 +33,9 @@ struct BinaryDeviceOperation {
         const CoreRangeSet worker_grid;
         std::optional<DeviceComputeKernelConfig> compute_kernel_config;
 
-        tt::stl::hash::hash_t to_hash() const {
+        ttsl::hash::hash_t to_hash() const {
             // hash has to exclude the scalar value
-            return tt::stl::hash::hash_objects_with_default_seed(
+            return ttsl::hash::hash_objects_with_default_seed(
                 binary_op_type, activations, input_tensor_a_activation, memory_config, dtype, compute_kernel_config);
         }
     };
@@ -232,7 +232,7 @@ struct BinaryDeviceOperation {
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t&);
 
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t& attributes,


### PR DESCRIPTION
### Ticket
None

### Problem description
Warnings spamming a terminal.
```
/proj_sw/user_dev/vtsilytskyi/tt-metal/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.hpp:36:16: warning: 'stl' is deprecated: Use ttsl namespace instead [-Wdeprecated-declarations]
   36 |         tt::stl::hash::hash_t to_hash() const {
      |                ^
/proj_sw/user_dev/vtsilytskyi/tt-metal/tt_stl/tt_stl/reflection.hpp:1553:13: note: 'stl' has been explicitly marked deprecated here
 1553 | namespace [[deprecated("Use ttsl namespace instead")]] stl {
      |             ^
```

### What's changed
Replace `tt::stl::` by `ttsl::`.

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vlad/change-namespaces)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vlad/change-namespaces)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vlad/change-namespaces)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vlad/change-namespaces)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vlad/change-namespaces)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vlad/change-namespaces)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vlad/change-namespaces)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vlad/change-namespaces)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vlad/change-namespaces)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vlad/change-namespaces)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vlad/change-namespaces)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vlad/change-namespaces)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
