### PR TITLE
sdxl convs resnetblock 

### DIFF
--- a/models/demos/stable_diffusion_xl_base/tests/pcc/test_module_tt_resnetblock2d.py
+++ b/models/demos/stable_diffusion_xl_base/tests/pcc/test_module_tt_resnetblock2d.py
@@ -20,86 +20,34 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 @pytest.mark.parametrize(
     "image_resolution, input_shape, temb_shape, down_block_id, resnet_id, conv_shortcut, block, pcc",
     [
-        # 1024x1024 image resolution # == RESHARD ARG ERROR
+        # fmt: off
+        # 1024x1024 image resolution; # == unique+common runtime args error (before 2x reshard)
         ((1024, 1024), (1, 320, 128, 128), (1, 1280), 0, 0, False, "down_blocks", 0.999),
-        (
-            (1024, 1024),
-            (1, 320, 64, 64),
-            (1, 1280),
-            1,
-            0,
-            True,
-            "down_blocks",
-            0.999,
-        ),  # used to fail with unique+common args reshard_reader_diff_width
-        (
-            (1024, 1024),
-            (1, 640, 64, 64),
-            (1, 1280),
-            1,
-            1,
-            False,
-            "down_blocks",
-            0.999,
-        ),  # used to fail with unique+common args reshard_reader_diff_width
+        ((1024, 1024), (1, 320, 64, 64), (1, 1280), 1, 0, True, "down_blocks", 0.999,),
+        ((1024, 1024), (1, 640, 64, 64), (1, 1280), 1, 1, False, "down_blocks", 0.999,),
         ((1024, 1024), (1, 640, 32, 32), (1, 1280), 2, 0, True, "down_blocks", 0.999),
         ((1024, 1024), (1, 1280, 32, 32), (1, 1280), 2, 1, False, "down_blocks", 0.999),
         ((1024, 1024), (1, 2560, 32, 32), (1, 1280), 0, 0, True, "up_blocks", 0.999),
         ((1024, 1024), (1, 1920, 32, 32), (1, 1280), 0, 2, True, "up_blocks", 0.999),
-        (
-            (1024, 1024),
-            (1, 1920, 64, 64),
-            (1, 1280),
-            1,
-            0,
-            True,
-            "up_blocks",
-            0.999,
-        ),  # used to fail with unique+common args reshard_reader_diff_width
-        (
-            (1024, 1024),
-            (1, 1280, 64, 64),
-            (1, 1280),
-            1,
-            1,
-            True,
-            "up_blocks",
-            0.999,
-        ),  # used to fail with unique+common args reshard_reader_diff_width
-        (
-            (1024, 1024),
-            (1, 960, 64, 64),
-            (1, 1280),
-            1,
-            2,
-            True,
-            "up_blocks",
-            0.999,
-        ),  # used to fail with unique+common args reshard_reader_diff_width
-        # ((1024, 1024), (1, 960, 128, 128), (1, 1280), 2, 0, True, "up_blocks", 0.998), # OOM GN
-        (
-            (1024, 1024),
-            (1, 640, 128, 128),
-            (1, 1280),
-            2,
-            1,
-            True,
-            "up_blocks",
-            0.998,
-        ),  # used to fail with unique+common args reshard_reader_diff_width
+        ((1024, 1024), (1, 1920, 64, 64), (1, 1280), 1, 0, True, "up_blocks", 0.999,),
+        ((1024, 1024), (1, 1280, 64, 64), (1, 1280), 1, 1, True, "up_blocks", 0.999,),
+        ((1024, 1024), (1, 960, 64, 64), (1, 1280), 1, 2, True, "up_blocks", 0.999,),
+        ((1024, 1024), (1, 960, 128, 128), (1, 1280), 2, 0, True, "up_blocks", 0.998),
+        ((1024, 1024), (1, 640, 128, 128), (1, 1280), 2, 1, True, "up_blocks", 0.998,),
         # 512x512 image resolution
-        # ((512, 512), (1, 320, 64, 64), (1, 1280), 0, 0, False, "down_blocks", 0.999),
-        # ((512, 512), (1, 320, 32, 32), (1, 1280), 1, 0, True, "down_blocks", 0.999),
-        # ((512, 512), (1, 640, 32, 32), (1, 1280), 1, 1, False, "down_blocks", 0.999),
-        # ((512, 512), (1, 640, 16, 16), (1, 1280), 2, 0, True, "down_blocks", 0.999),
-        # ((512, 512), (1, 1280, 16, 16), (1, 1280), 2, 1, False, "down_blocks", 0.999),
-        # ((512, 512), (1, 2560, 16, 16), (1, 1280), 0, 0, True, "up_blocks", 0.999),
-        # ((512, 512), (1, 1920, 16, 16), (1, 1280), 0, 2, True, "up_blocks", 0.999),
-        # ((512, 512), (1, 1920, 32, 32), (1, 1280), 1, 0, True, "up_blocks", 0.999),
-        # ((512, 512), (1, 1280, 32, 32), (1, 1280), 1, 1, True, "up_blocks", 0.999),
-        # ((512, 512), (1, 960, 32, 32), (1, 1280), 1, 2, True, "up_blocks", 0.999),
-        # ((512, 512), (1, 960, 64, 64), (1, 1280), 2, 0, True, "up_blocks", 0.999),
-        # ((512, 512), (1, 640, 64, 64), (1, 1280), 2, 1, True, "up_blocks", 0.999),
+        ((512, 512), (1, 320, 64, 64), (1, 1280), 0, 0, False, "down_blocks", 0.999),
+        ((512, 512), (1, 320, 32, 32), (1, 1280), 1, 0, True, "down_blocks", 0.999),
+        ((512, 512), (1, 640, 32, 32), (1, 1280), 1, 1, False, "down_blocks", 0.999),
+        ((512, 512), (1, 640, 16, 16), (1, 1280), 2, 0, True, "down_blocks", 0.999),
+        ((512, 512), (1, 1280, 16, 16), (1, 1280), 2, 1, False, "down_blocks", 0.999),
+        ((512, 512), (1, 2560, 16, 16), (1, 1280), 0, 0, True, "up_blocks", 0.999),
+        ((512, 512), (1, 1920, 16, 16), (1, 1280), 0, 2, True, "up_blocks", 0.999),
+        ((512, 512), (1, 1920, 32, 32), (1, 1280), 1, 0, True, "up_blocks", 0.999),
+        ((512, 512), (1, 1280, 32, 32), (1, 1280), 1, 1, True, "up_blocks", 0.999),
+        ((512, 512), (1, 960, 32, 32), (1, 1280), 1, 2, True, "up_blocks", 0.999),
+        ((512, 512), (1, 960, 64, 64), (1, 1280), 2, 0, True, "up_blocks", 0.999),
+        ((512, 512), (1, 640, 64, 64), (1, 1280), 2, 1, True, "up_blocks", 0.999),
+        # fmt: on
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)

--- a/models/demos/stable_diffusion_xl_base/tests/pcc/test_module_tt_resnetblock2d.py
+++ b/models/demos/stable_diffusion_xl_base/tests/pcc/test_module_tt_resnetblock2d.py
@@ -10,7 +10,7 @@ from diffusers import UNet2DConditionModel
 from loguru import logger
 
 import ttnn
-from models.common.utility_functions import torch_random, is_blackhole
+from models.common.utility_functions import is_blackhole, torch_random
 from models.demos.stable_diffusion_xl_base.tests.test_common import SDXL_L1_SMALL_SIZE
 from models.demos.stable_diffusion_xl_base.tt.model_configs import load_model_optimisations
 from models.demos.stable_diffusion_xl_base.tt.tt_resnetblock2d import TtResnetBlock2D
@@ -20,32 +20,86 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 @pytest.mark.parametrize(
     "image_resolution, input_shape, temb_shape, down_block_id, resnet_id, conv_shortcut, block, pcc",
     [
-        # 1024x1024 image resolution
+        # 1024x1024 image resolution # == RESHARD ARG ERROR
         ((1024, 1024), (1, 320, 128, 128), (1, 1280), 0, 0, False, "down_blocks", 0.999),
-        ((1024, 1024), (1, 320, 64, 64), (1, 1280), 1, 0, True, "down_blocks", 0.999),
-        ((1024, 1024), (1, 640, 64, 64), (1, 1280), 1, 1, False, "down_blocks", 0.999),
+        (
+            (1024, 1024),
+            (1, 320, 64, 64),
+            (1, 1280),
+            1,
+            0,
+            True,
+            "down_blocks",
+            0.999,
+        ),  # used to fail with unique+common args reshard_reader_diff_width
+        (
+            (1024, 1024),
+            (1, 640, 64, 64),
+            (1, 1280),
+            1,
+            1,
+            False,
+            "down_blocks",
+            0.999,
+        ),  # used to fail with unique+common args reshard_reader_diff_width
         ((1024, 1024), (1, 640, 32, 32), (1, 1280), 2, 0, True, "down_blocks", 0.999),
         ((1024, 1024), (1, 1280, 32, 32), (1, 1280), 2, 1, False, "down_blocks", 0.999),
         ((1024, 1024), (1, 2560, 32, 32), (1, 1280), 0, 0, True, "up_blocks", 0.999),
         ((1024, 1024), (1, 1920, 32, 32), (1, 1280), 0, 2, True, "up_blocks", 0.999),
-        ((1024, 1024), (1, 1920, 64, 64), (1, 1280), 1, 0, True, "up_blocks", 0.999),
-        ((1024, 1024), (1, 1280, 64, 64), (1, 1280), 1, 1, True, "up_blocks", 0.999),
-        ((1024, 1024), (1, 960, 64, 64), (1, 1280), 1, 2, True, "up_blocks", 0.999),
-        ((1024, 1024), (1, 960, 128, 128), (1, 1280), 2, 0, True, "up_blocks", 0.998),
-        ((1024, 1024), (1, 640, 128, 128), (1, 1280), 2, 1, True, "up_blocks", 0.998),
+        (
+            (1024, 1024),
+            (1, 1920, 64, 64),
+            (1, 1280),
+            1,
+            0,
+            True,
+            "up_blocks",
+            0.999,
+        ),  # used to fail with unique+common args reshard_reader_diff_width
+        (
+            (1024, 1024),
+            (1, 1280, 64, 64),
+            (1, 1280),
+            1,
+            1,
+            True,
+            "up_blocks",
+            0.999,
+        ),  # used to fail with unique+common args reshard_reader_diff_width
+        (
+            (1024, 1024),
+            (1, 960, 64, 64),
+            (1, 1280),
+            1,
+            2,
+            True,
+            "up_blocks",
+            0.999,
+        ),  # used to fail with unique+common args reshard_reader_diff_width
+        # ((1024, 1024), (1, 960, 128, 128), (1, 1280), 2, 0, True, "up_blocks", 0.998), # OOM GN
+        (
+            (1024, 1024),
+            (1, 640, 128, 128),
+            (1, 1280),
+            2,
+            1,
+            True,
+            "up_blocks",
+            0.998,
+        ),  # used to fail with unique+common args reshard_reader_diff_width
         # 512x512 image resolution
-        ((512, 512), (1, 320, 64, 64), (1, 1280), 0, 0, False, "down_blocks", 0.999),
-        ((512, 512), (1, 320, 32, 32), (1, 1280), 1, 0, True, "down_blocks", 0.999),
-        ((512, 512), (1, 640, 32, 32), (1, 1280), 1, 1, False, "down_blocks", 0.999),
-        ((512, 512), (1, 640, 16, 16), (1, 1280), 2, 0, True, "down_blocks", 0.999),
-        ((512, 512), (1, 1280, 16, 16), (1, 1280), 2, 1, False, "down_blocks", 0.999),
-        ((512, 512), (1, 2560, 16, 16), (1, 1280), 0, 0, True, "up_blocks", 0.999),
-        ((512, 512), (1, 1920, 16, 16), (1, 1280), 0, 2, True, "up_blocks", 0.999),
-        ((512, 512), (1, 1920, 32, 32), (1, 1280), 1, 0, True, "up_blocks", 0.999),
-        ((512, 512), (1, 1280, 32, 32), (1, 1280), 1, 1, True, "up_blocks", 0.999),
-        ((512, 512), (1, 960, 32, 32), (1, 1280), 1, 2, True, "up_blocks", 0.999),
-        ((512, 512), (1, 960, 64, 64), (1, 1280), 2, 0, True, "up_blocks", 0.999),
-        ((512, 512), (1, 640, 64, 64), (1, 1280), 2, 1, True, "up_blocks", 0.999),
+        # ((512, 512), (1, 320, 64, 64), (1, 1280), 0, 0, False, "down_blocks", 0.999),
+        # ((512, 512), (1, 320, 32, 32), (1, 1280), 1, 0, True, "down_blocks", 0.999),
+        # ((512, 512), (1, 640, 32, 32), (1, 1280), 1, 1, False, "down_blocks", 0.999),
+        # ((512, 512), (1, 640, 16, 16), (1, 1280), 2, 0, True, "down_blocks", 0.999),
+        # ((512, 512), (1, 1280, 16, 16), (1, 1280), 2, 1, False, "down_blocks", 0.999),
+        # ((512, 512), (1, 2560, 16, 16), (1, 1280), 0, 0, True, "up_blocks", 0.999),
+        # ((512, 512), (1, 1920, 16, 16), (1, 1280), 0, 2, True, "up_blocks", 0.999),
+        # ((512, 512), (1, 1920, 32, 32), (1, 1280), 1, 0, True, "up_blocks", 0.999),
+        # ((512, 512), (1, 1280, 32, 32), (1, 1280), 1, 1, True, "up_blocks", 0.999),
+        # ((512, 512), (1, 960, 32, 32), (1, 1280), 1, 2, True, "up_blocks", 0.999),
+        # ((512, 512), (1, 960, 64, 64), (1, 1280), 2, 0, True, "up_blocks", 0.999),
+        # ((512, 512), (1, 640, 64, 64), (1, 1280), 2, 1, True, "up_blocks", 0.999),
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)

--- a/models/demos/stable_diffusion_xl_base/tt/model_configs/model_configs_1024x1024BH.py
+++ b/models/demos/stable_diffusion_xl_base/tt/model_configs/model_configs_1024x1024BH.py
@@ -45,7 +45,7 @@ class ModelOptimisations1024x1024BH:
             act_block_w_div=1,
             act_block_h_override=1024,
         )
-        self.conv_configs["ABH_256_ADB_HS"] = ttnn.Conv2dConfig(
+        self.conv_configs["ABH_256_ADB_HS"] = ttnn.Conv2dConfig(  #
             weights_dtype=conv_w_dtype,
             shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
             deallocate_activation=True,
@@ -65,7 +65,7 @@ class ModelOptimisations1024x1024BH:
             act_block_w_div=1,
             act_block_h_override=256,
         )
-        self.conv_configs["ABH_128_NO_ADB_HS"] = ttnn.Conv2dConfig(
+        self.conv_configs["ABH_128_NO_ADB_HS"] = ttnn.Conv2dConfig(  #
             weights_dtype=conv_w_dtype,
             shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
             deallocate_activation=True,
@@ -120,19 +120,19 @@ class ModelOptimisations1024x1024BH:
         # endregion
 
         # region BLOCK SHARDED
-        override_output_sharding_config = not force_full_grid
-        override_output_core_grid = (
-            ttnn.CoreRangeSet(
-                {
-                    ttnn.CoreRange(
-                        ttnn.CoreCoord(0, 0),
-                        ttnn.CoreCoord(4, 7),
-                    ),
-                }
-            )
-            if override_output_sharding_config
-            else None
-        )
+        # override_output_sharding_config = not force_full_grid
+        # override_output_core_grid = (
+        #     ttnn.CoreRangeSet(
+        #         {
+        #             ttnn.CoreRange(
+        #                 ttnn.CoreCoord(0, 0),
+        #                 ttnn.CoreCoord(4, 7),
+        #             ),
+        #         }
+        #     )
+        #     if override_output_sharding_config
+        #     else None
+        # )
 
         self.conv_configs["ABH_0_ADB_WDB_BS"] = ttnn.Conv2dConfig(
             weights_dtype=self.conv_ws_dtype,
@@ -144,11 +144,11 @@ class ModelOptimisations1024x1024BH:
             reshard_if_not_optimal=True,
             act_block_w_div=1,
             act_block_h_override=0,
-            override_output_sharding_config=override_output_sharding_config,
-            core_grid=override_output_core_grid,
+            # override_output_sharding_config=override_output_sharding_config,
+            # core_grid=override_output_core_grid,
         )
 
-        self.conv_configs["ABH_0_ADB_WDB_NO_DEALLOC_BS"] = ttnn.Conv2dConfig(
+        self.conv_configs["ABH_0_ADB_WDB_NO_DEALLOC_BS"] = ttnn.Conv2dConfig(  #
             weights_dtype=self.conv_ws_dtype,
             shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
             deallocate_activation=False,
@@ -158,8 +158,8 @@ class ModelOptimisations1024x1024BH:
             reshard_if_not_optimal=True,
             act_block_w_div=1,
             act_block_h_override=0,
-            override_output_sharding_config=override_output_sharding_config,
-            core_grid=override_output_core_grid,
+            # override_output_sharding_config=override_output_sharding_config,
+            # core_grid=override_output_core_grid,
         )
         self.conv_configs["ABH_64_ADB_WDB_BS"] = ttnn.Conv2dConfig(
             weights_dtype=self.conv_ws_dtype,
@@ -171,8 +171,8 @@ class ModelOptimisations1024x1024BH:
             reshard_if_not_optimal=True,
             act_block_w_div=1,
             act_block_h_override=64,
-            override_output_sharding_config=override_output_sharding_config,
-            core_grid=override_output_core_grid,
+            # override_output_sharding_config=override_output_sharding_config,
+            # core_grid=override_output_core_grid,
         )
         self.conv_configs["ABH_128_ADB_WDB_BS"] = ttnn.Conv2dConfig(
             weights_dtype=self.conv_ws_dtype,
@@ -184,8 +184,8 @@ class ModelOptimisations1024x1024BH:
             reshard_if_not_optimal=True,
             act_block_w_div=1,
             act_block_h_override=128,
-            override_output_sharding_config=override_output_sharding_config,
-            core_grid=override_output_core_grid,
+            # override_output_sharding_config=override_output_sharding_config,
+            # core_grid=override_output_core_grid,
         )
         self.conv_configs["ABH_128_ADB_WDB_MOVE_BS"] = ttnn.Conv2dConfig(
             weights_dtype=self.conv_ws_dtype,
@@ -197,8 +197,8 @@ class ModelOptimisations1024x1024BH:
             reshard_if_not_optimal=True,
             act_block_w_div=1,
             act_block_h_override=128,
-            override_output_sharding_config=override_output_sharding_config,
-            core_grid=override_output_core_grid,
+            # override_output_sharding_config=override_output_sharding_config,
+            # core_grid=override_output_core_grid,
         )
         self.conv_configs["ABH_256_NO_ADB_BS"] = ttnn.Conv2dConfig(
             weights_dtype=self.conv_w_dtype,
@@ -233,8 +233,8 @@ class ModelOptimisations1024x1024BH:
             reshard_if_not_optimal=True,
             act_block_w_div=1,
             act_block_h_override=256,
-            override_output_sharding_config=override_output_sharding_config,
-            core_grid=override_output_core_grid,
+            # override_output_sharding_config=override_output_sharding_config,
+            # core_grid=override_output_core_grid,
         )
 
         self.conv_configs["ABH_512_NO_ADB_BS"] = ttnn.Conv2dConfig(
@@ -261,7 +261,7 @@ class ModelOptimisations1024x1024BH:
             act_block_h_override=512,
         )
 
-        self.conv_configs["ABH_512_ADB_WDB_NO_DEALLOC_BS"] = ttnn.Conv2dConfig(
+        self.conv_configs["ABH_512_ADB_WDB_NO_DEALLOC_BS"] = ttnn.Conv2dConfig(  #
             weights_dtype=self.conv_ws_dtype,
             shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
             deallocate_activation=False,
@@ -271,8 +271,8 @@ class ModelOptimisations1024x1024BH:
             reshard_if_not_optimal=True,
             act_block_w_div=1,
             act_block_h_override=512,
-            override_output_sharding_config=override_output_sharding_config,
-            core_grid=override_output_core_grid,
+            # override_output_sharding_config=override_output_sharding_config,
+            # core_grid=override_output_core_grid,
         )
 
         self.conv_configs["ABH_1024_NO_ADB_BS"] = ttnn.Conv2dConfig(
@@ -297,13 +297,13 @@ class ModelOptimisations1024x1024BH:
             reshard_if_not_optimal=True,
             act_block_w_div=1,
             act_block_h_override=1024,
-            override_output_sharding_config=override_output_sharding_config,
-            core_grid=override_output_core_grid,
+            # override_output_sharding_config=override_output_sharding_config,
+            # core_grid=override_output_core_grid,
         )
         # endregion
 
         # region DEFAULT CONF
-        self.conv_configs["DEFAULT"] = ttnn.Conv2dConfig(
+        self.conv_configs["DEFAULT"] = ttnn.Conv2dConfig(  #
             weights_dtype=conv_w_dtype,
             shard_layout=None,
             deallocate_activation=True,
@@ -1194,7 +1194,7 @@ class ModelOptimisations1024x1024BH:
         elif ("up_blocks.1.resnets" in conv_path) and ("conv2" in conv_path):
             return self.conv_configs["ABH_0_ADB_WDB_BS"]
         elif "up_blocks.1.upsamplers.0" == conv_path:
-            return self.conv_configs["ABH_128_ADB_WDB_BS"]
+            return self.conv_configs["ABH_128_ADB_WDB_BS"]  #
 
         # UP BLOCK 2
         elif "up_blocks.2.resnets.0.conv1" == conv_path:

--- a/models/demos/stable_diffusion_xl_base/tt/tt_resnetblock2d.py
+++ b/models/demos/stable_diffusion_xl_base/tt/tt_resnetblock2d.py
@@ -161,6 +161,18 @@ class TtResnetBlock2D(LightweightModule):
         hidden_states = ttnn.silu(hidden_states, output_tensor=hidden_states)
 
         hidden_states = ttnn.to_layout(hidden_states, ttnn.ROW_MAJOR_LAYOUT)
+
+        # reshard to 8x10
+        # this is done to avoid unique+common args reshard_reader_diff_width error
+        sharded_mem_config_ = ttnn.create_sharded_memory_config_(
+            shape=hidden_states.shape,
+            core_grid=ttnn.CoreGrid(y=8, x=10),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        )
+        hidden_states = ttnn.to_memory_config(hidden_states, sharded_mem_config_)
+        # conv2d has reshard_if_not_optimal=True so it will sometimes reshard again but it is cheap
+
         [hidden_states, [H, W], [tt_conv1_weights, tt_conv1_bias]] = ttnn.conv2d(
             input_tensor=hidden_states,
             weight_tensor=self.tt_conv1_weights,
@@ -227,6 +239,17 @@ class TtResnetBlock2D(LightweightModule):
         )
 
         ttnn.silu(hidden_states, output_tensor=hidden_states)
+
+        # reshard to 8x10
+        # this is done to avoid unique+common args reshard_reader_diff_width error
+        sharded_mem_config_ = ttnn.create_sharded_memory_config_(
+            shape=hidden_states.shape,
+            core_grid=ttnn.CoreGrid(y=8, x=10),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        )
+        hidden_states = ttnn.to_memory_config(hidden_states, sharded_mem_config_)
+        # conv2d has reshard_if_not_optimal=True so it will sometimes reshard again but it is cheap
 
         [hidden_states, [H, W], [tt_conv2_weights, tt_conv2_bias]] = ttnn.conv2d(
             input_tensor=hidden_states,

--- a/models/demos/stable_diffusion_xl_base/tt/tt_resnetblock2d.py
+++ b/models/demos/stable_diffusion_xl_base/tt/tt_resnetblock2d.py
@@ -4,6 +4,7 @@
 
 import ttnn
 from models.common.lightweightmodule import LightweightModule
+from models.common.utility_functions import is_blackhole
 from models.demos.stable_diffusion_xl_base.refiner.tt.model_configs import RefinerModelOptimisationsBase
 from models.demos.stable_diffusion_xl_base.tt.sdxl_utility import prepare_conv_params, prepare_linear_params
 
@@ -162,16 +163,17 @@ class TtResnetBlock2D(LightweightModule):
 
         hidden_states = ttnn.to_layout(hidden_states, ttnn.ROW_MAJOR_LAYOUT)
 
-        # reshard to 8x10
-        # this is done to avoid unique+common args reshard_reader_diff_width error
-        sharded_mem_config_ = ttnn.create_sharded_memory_config_(
-            shape=hidden_states.shape,
-            core_grid=ttnn.CoreGrid(y=8, x=10),
-            strategy=ttnn.ShardStrategy.BLOCK,
-            orientation=ttnn.ShardOrientation.ROW_MAJOR,
-        )
-        hidden_states = ttnn.to_memory_config(hidden_states, sharded_mem_config_)
-        # conv2d has reshard_if_not_optimal=True so it will sometimes reshard again but it is cheap
+        if is_blackhole():
+            # reshard to 8x10
+            # this is done to avoid unique+common args reshard_reader_diff_width error
+            sharded_mem_config_ = ttnn.create_sharded_memory_config_(
+                shape=hidden_states.shape,
+                core_grid=ttnn.CoreGrid(y=8, x=10),
+                strategy=ttnn.ShardStrategy.BLOCK,
+                orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            )
+            hidden_states = ttnn.to_memory_config(hidden_states, sharded_mem_config_)
+            # conv2d has reshard_if_not_optimal=True so it will sometimes reshard again but it is cheap
 
         [hidden_states, [H, W], [tt_conv1_weights, tt_conv1_bias]] = ttnn.conv2d(
             input_tensor=hidden_states,
@@ -240,16 +242,17 @@ class TtResnetBlock2D(LightweightModule):
 
         ttnn.silu(hidden_states, output_tensor=hidden_states)
 
-        # reshard to 8x10
-        # this is done to avoid unique+common args reshard_reader_diff_width error
-        sharded_mem_config_ = ttnn.create_sharded_memory_config_(
-            shape=hidden_states.shape,
-            core_grid=ttnn.CoreGrid(y=8, x=10),
-            strategy=ttnn.ShardStrategy.BLOCK,
-            orientation=ttnn.ShardOrientation.ROW_MAJOR,
-        )
-        hidden_states = ttnn.to_memory_config(hidden_states, sharded_mem_config_)
-        # conv2d has reshard_if_not_optimal=True so it will sometimes reshard again but it is cheap
+        if is_blackhole():
+            # reshard to 8x10
+            # this is done to avoid unique+common args reshard_reader_diff_width error
+            sharded_mem_config_ = ttnn.create_sharded_memory_config_(
+                shape=hidden_states.shape,
+                core_grid=ttnn.CoreGrid(y=8, x=10),
+                strategy=ttnn.ShardStrategy.BLOCK,
+                orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            )
+            hidden_states = ttnn.to_memory_config(hidden_states, sharded_mem_config_)
+            # conv2d has reshard_if_not_optimal=True so it will sometimes reshard again but it is cheap
 
         [hidden_states, [H, W], [tt_conv2_weights, tt_conv2_bias]] = ttnn.conv2d(
             input_tensor=hidden_states,


### PR DESCRIPTION
**This is experimental and will be refactored before merge to main**

### Problem description
Conv2d reshards in resnetblock and disabled grid override in model configs. Left those as commented just in case they need to be reused.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nmilicevic/sdxl-conv-resnetblock)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nmilicevic/sdxl-conv-resnetblock)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nmilicevic/sdxl-conv-resnetblock)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nmilicevic/sdxl-conv-resnetblock)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nmilicevic/sdxl-conv-resnetblock)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nmilicevic/sdxl-conv-resnetblock)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nmilicevic/sdxl-conv-resnetblock)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nmilicevic/sdxl-conv-resnetblock)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nmilicevic/sdxl-conv-resnetblock)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nmilicevic/sdxl-conv-resnetblock)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nmilicevic/sdxl-conv-resnetblock)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nmilicevic/sdxl-conv-resnetblock)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
