### PR TITLE
[skip ci] Disable test_all_to_all_dispatch_no_trace_batch1 (UInt16/Short mismatch)

### DIFF
--- a/tests/nightly/t3000/ccl/test_all_to_all_dispatch.py
+++ b/tests/nightly/t3000/ccl/test_all_to_all_dispatch.py
@@ -1156,7 +1156,7 @@ def test_all_to_all_dispatch_skew(
     )
 
 
-@pytest.mark.skip(reason="UInt16/Short dtype mismatch - https://github.com/tenstorrent/tt-metal/issues/39633")
+@pytest.mark.xfail(reason="UInt16/Short dtype mismatch - https://github.com/tenstorrent/tt-metal/issues/39633")
 @pytest.mark.parametrize(
     "device_params",
     [

--- a/tests/nightly/t3000/ccl/test_all_to_all_dispatch.py
+++ b/tests/nightly/t3000/ccl/test_all_to_all_dispatch.py
@@ -1156,6 +1156,7 @@ def test_all_to_all_dispatch_skew(
     )
 
 
+@pytest.mark.skip(reason="UInt16/Short dtype mismatch - https://github.com/tenstorrent/tt-metal/issues/39633")
 @pytest.mark.parametrize(
     "device_params",
     [


### PR DESCRIPTION
Related to #39633

### Ticket
https://github.com/tenstorrent/tt-metal/issues/39633

### Problem description
The T3000 e2e `t3k_ccl_tests` job has been failing in 5+ consecutive runs on main. The failing test `test_all_to_all_dispatch_no_trace_batch1` raises `RuntimeError: UInt16 did not match Short`. Nobody was willing to pick up the ticket, so this PR disables the test to unblock CI.

### What's changed
- Added `@pytest.mark.skip` to `test_all_to_all_dispatch_no_trace_batch1` in `tests/nightly/t3000/ccl/test_all_to_all_dispatch.py`
- Skip reason references the GitHub issue for traceability

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=disable-t3k-ccl-test-all-to-all-dispatch-batch1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:disable-t3k-ccl-test-all-to-all-dispatch-batch1)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=disable-t3k-ccl-test-all-to-all-dispatch-batch1)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:disable-t3k-ccl-test-all-to-all-dispatch-batch1)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=disable-t3k-ccl-test-all-to-all-dispatch-batch1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:disable-t3k-ccl-test-all-to-all-dispatch-batch1)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=disable-t3k-ccl-test-all-to-all-dispatch-batch1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:disable-t3k-ccl-test-all-to-all-dispatch-batch1)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=disable-t3k-ccl-test-all-to-all-dispatch-batch1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:disable-t3k-ccl-test-all-to-all-dispatch-batch1)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=disable-t3k-ccl-test-all-to-all-dispatch-batch1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:disable-t3k-ccl-test-all-to-all-dispatch-batch1)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

Made with [Cursor](https://cursor.com)