### PR TITLE
Add overlay namespace for Quasar hardware intrinsics 

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_addrgen/kernels/addrgen_1d_example.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_addrgen/kernels/addrgen_1d_example.cpp
@@ -13,6 +13,8 @@
 #include "internal/tt-2xx/quasar/overlay/addrgen_api.hpp"
 #include <cstdint>
 
+using namespace overlay;
+
 constexpr uint32_t src_base = 0x10000;
 constexpr uint64_t src_stride = 4096;  // 2 tiles × 2048 B — skips 1 tile between each access
 

--- a/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_addrgen/kernels/addrgen_2d_example.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_addrgen/kernels/addrgen_2d_example.cpp
@@ -14,6 +14,8 @@
 #include "internal/tt-2xx/quasar/overlay/addrgen_api.hpp"
 #include <cstdint>
 
+using namespace overlay;
+
 // 4 cols x 4 rows
 constexpr uint32_t src_base = 0x30000;
 constexpr LoopConfig src_inner_cfg = {.stride = 128, .end_addr = 4 * 128};    // 4 cols, 128B apart

--- a/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_addrgen/kernels/addrgen_example.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_addrgen/kernels/addrgen_example.cpp
@@ -12,6 +12,8 @@
 #include "internal/tt-2xx/quasar/overlay/addrgen_api.hpp"
 #include <cstdint>
 
+using namespace overlay;
+
 // 1D source config
 constexpr uint32_t src_1d_base = 0x10000;
 constexpr uint64_t src_1d_stride = 2048;

--- a/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_addrgen/kernels/addrgen_face_example.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_addrgen/kernels/addrgen_face_example.cpp
@@ -27,6 +27,8 @@
 #include "internal/tt-2xx/quasar/overlay/addrgen_api.hpp"
 #include <cstdint>
 
+using namespace overlay;
+
 // 2 faces, each face: 4 cols x 4 rows
 constexpr uint32_t src_base = 0x10000;
 constexpr LoopConfig src_inner_cfg = {.stride = 128, .end_addr = 4 * 128};    // 4 cols, 128B apart

--- a/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_addrgen/kernels/addrgen_interleaved_example.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_addrgen/kernels/addrgen_interleaved_example.cpp
@@ -27,6 +27,8 @@
 #include "internal/tt-2xx/quasar/overlay/addrgen_api.hpp"
 #include <cstdint>
 
+using namespace overlay;
+
 constexpr uint32_t num_banks = 4;
 constexpr uint32_t first_bank = 20;   // use banks 20–23
 constexpr uint32_t bank_offset = 36;  // banks are 1MB (2^20 B) apart in address space

--- a/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_idma/kernels/idma_1d_strided_example.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_idma/kernels/idma_1d_strided_example.cpp
@@ -24,6 +24,8 @@
 #include "internal/tt-2xx/quasar/overlay/cmdbuff_api.hpp"
 #include <cstdint>
 
+using namespace overlay;
+
 constexpr uint32_t num_elements = 10;
 constexpr uint32_t elem_size = 8;
 constexpr uint32_t src_stride = 2 * elem_size;  // 16 — read every other element

--- a/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_idma/kernels/idma_basic_example.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_idma/kernels/idma_basic_example.cpp
@@ -17,6 +17,8 @@
 #include "internal/tt-2xx/quasar/overlay/cmdbuff_api.hpp"
 #include <cstdint>
 
+using namespace overlay;
+
 constexpr uint32_t num_elements = 16;
 constexpr uint32_t elem_size = 8;
 constexpr uint32_t total_bytes = num_elements * elem_size;  // 128

--- a/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_im2col/kernels/addrgen_im2col_dilation1_example.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_im2col/kernels/addrgen_im2col_dilation1_example.cpp
@@ -33,6 +33,8 @@
 #include "internal/tt-2xx/quasar/overlay/addrgen_api.hpp"
 #include <cstdint>
 
+using namespace overlay;
+
 constexpr uint32_t H = 4;
 constexpr uint32_t W = 5;
 constexpr uint32_t kH = 3;

--- a/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_im2col/kernels/addrgen_im2col_example.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_im2col/kernels/addrgen_im2col_example.cpp
@@ -31,6 +31,8 @@
 #include "internal/tt-2xx/quasar/overlay/addrgen_api.hpp"
 #include <cstdint>
 
+using namespace overlay;
+
 constexpr uint32_t H = 6;
 constexpr uint32_t W = 7;
 constexpr uint32_t k = 3;

--- a/tt_metal/hw/firmware/src/tt-2xx/dm.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dm.cc
@@ -102,7 +102,7 @@ void deassert_trisc() {
 }
 
 thread_local LocalDFBInterface g_dfb_interface[dfb::NUM_DFBS] __attribute__((used));
-RemapperAPI g_remapper_configurator __attribute__((used));
+overlay::RemapperAPI g_remapper_configurator __attribute__((used));
 volatile TxnDFBDescriptor g_txn_dfb_descriptor[32] __attribute__((used));
 volatile KernelBarrier g_kernel_barrier __attribute__((used));
 

--- a/tt_metal/hw/firmware/src/tt-2xx/dm.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dm.cc
@@ -101,7 +101,7 @@ void deassert_trisc() {
     deassert_trisc_reset();
 }
 
-thread_local experimental::LocalDFBInterface g_dfb_interface[experimental::NUM_DFBS] __attribute__((used));
+thread_local LocalDFBInterface g_dfb_interface[dfb::NUM_DFBS] __attribute__((used));
 RemapperAPI g_remapper_configurator __attribute__((used));
 volatile TxnDFBDescriptor g_txn_dfb_descriptor[32] __attribute__((used));
 volatile KernelBarrier g_kernel_barrier __attribute__((used));

--- a/tt_metal/hw/firmware/src/tt-2xx/dm.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dm.cc
@@ -101,7 +101,7 @@ void deassert_trisc() {
     deassert_trisc_reset();
 }
 
-thread_local ::experimental::LocalDFBInterface g_dfb_interface[experimental::NUM_DFBS] __attribute__((used));
+thread_local experimental::LocalDFBInterface g_dfb_interface[experimental::NUM_DFBS] __attribute__((used));
 RemapperAPI g_remapper_configurator __attribute__((used));
 volatile TxnDFBDescriptor g_txn_dfb_descriptor[32] __attribute__((used));
 volatile KernelBarrier g_kernel_barrier __attribute__((used));

--- a/tt_metal/hw/firmware/src/tt-2xx/dm.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dm.cc
@@ -101,7 +101,7 @@ void deassert_trisc() {
     deassert_trisc_reset();
 }
 
-thread_local LocalDFBInterface g_dfb_interface[dfb::NUM_DFBS] __attribute__((used));
+thread_local ::experimental::LocalDFBInterface g_dfb_interface[experimental::NUM_DFBS] __attribute__((used));
 RemapperAPI g_remapper_configurator __attribute__((used));
 volatile TxnDFBDescriptor g_txn_dfb_descriptor[32] __attribute__((used));
 volatile KernelBarrier g_kernel_barrier __attribute__((used));

--- a/tt_metal/hw/firmware/src/tt-2xx/quasar/fds_functions.cpp
+++ b/tt_metal/hw/firmware/src/tt-2xx/quasar/fds_functions.cpp
@@ -4,7 +4,7 @@
 
 #include "fds_functions.hpp"
 
-namespace FdsDispatch {
+namespace overlay::FdsDispatch {
 // Configure filter length: how many cycles a done signal from a NEO must be stable (through the deglitcher)
 void fds_config_filter_length(uint32_t threshold) {
     FDS_INTF_WRITE(TT_FDS_DISPATCH_FILTER_COUNT_THRESHOLD_REG_ADDR, threshold);
@@ -49,9 +49,9 @@ void fds_clear_neo_status(uint32_t neo_inst) {
 void fds_poll(uint32_t group_id, uint32_t count_threshold) {
     while (FDS_INTF_READ(TT_FDS_DISPATCH_GROUPID_COUNT_0__REG_ADDR + (group_id * sizeof(uint32_t))) < count_threshold);
 }
-}  // namespace FdsDispatch
+}  // namespace overlay::FdsDispatch
 
-namespace FdsNeo {
+namespace overlay::FdsNeo {
 // Configure filter length: how many cycles a go signal from a Dispatch must be stable (through the deglitcher)
 void fds_config_filter_length(uint32_t threshold) {
     FDS_INTF_WRITE(TT_FDS_TENSIXNEO_FILTER_COUNT_THRESHOLD_REG_OFFSET, threshold);
@@ -101,4 +101,4 @@ void fds_clear_de_status(uint32_t dispatch_inst) {
 
 // Configure interrupts for groupIDs: set bit for the groupIDs to generate interrupts
 void fds_config_interrupt_en(uint32_t mask) { FDS_INTF_WRITE(TT_FDS_TENSIXNEO_INTERRUPT_ENABLE_REG_OFFSET, mask); }
-}  // namespace FdsNeo
+}  // namespace overlay::FdsNeo

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer.inl
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer.inl
@@ -153,7 +153,7 @@ inline void DataflowBuffer::finish_impl() {
 #elif !defined(COMPILE_FOR_TRISC)
             uint8_t tensix_id = dfb::get_tensix_id(packed_tc);
             all_acked &=
-                (overlay::overlay::fast_llk_intf_read_acked(tensix_id, tc_id) == overlay::overlay::fast_llk_intf_read_posted(tensix_id, tc_id));
+                (overlay::fast_llk_intf_read_acked(tensix_id, tc_id) == overlay::fast_llk_intf_read_posted(tensix_id, tc_id));
 #endif
         }
     }

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer.inl
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer.inl
@@ -41,8 +41,8 @@ inline void DataflowBuffer::reserve_back_impl(uint16_t num_entries) {
             ready = true;
             for (uint8_t i = 0; i < local_dfb_interface_.num_tcs_to_rr; i++) {
                 dfb::PackedTileCounter ptc = local_dfb_interface_.tc_slots[i].packed_tile_counter;
-                ASSERT(llk_intf_get_capacity(dfb::get_tensix_id(ptc), dfb::get_counter_id(ptc)) >= num_entries);
-                if (llk_intf_get_free_space(dfb::get_tensix_id(ptc), dfb::get_counter_id(ptc)) < num_entries) {
+                ASSERT(overlay::llk_intf_get_capacity(dfb::get_tensix_id(ptc), dfb::get_counter_id(ptc)) >= num_entries);
+                if (overlay::llk_intf_get_free_space(dfb::get_tensix_id(ptc), dfb::get_counter_id(ptc)) < num_entries) {
                     ready = false;
                     break;
                 }
@@ -50,8 +50,8 @@ inline void DataflowBuffer::reserve_back_impl(uint16_t num_entries) {
         }
     } else {
         uint8_t tensix_id = dfb::get_tensix_id(packed_tc);
-        ASSERT(llk_intf_get_capacity(tensix_id, tc_id) >= num_entries);
-        while (llk_intf_get_free_space(tensix_id, tc_id) < num_entries);
+        ASSERT(overlay::llk_intf_get_capacity(tensix_id, tc_id) >= num_entries);
+        while (overlay::llk_intf_get_free_space(tensix_id, tc_id) < num_entries);
     }
 #endif
     WAYPOINT("RBD");
@@ -68,8 +68,8 @@ inline void DataflowBuffer::push_back_impl(uint16_t num_entries) {
         // DM-DM BLOCKED: post to all N TCs; wr_ptr tracked on slot 0
         for (uint8_t i = 0; i < local_dfb_interface_.num_tcs_to_rr; i++) {
             dfb::PackedTileCounter ptc = local_dfb_interface_.tc_slots[i].packed_tile_counter;
-            ASSERT(llk_intf_get_capacity(dfb::get_tensix_id(ptc), dfb::get_counter_id(ptc)) >= num_entries);
-            llk_intf_inc_posted(dfb::get_tensix_id(ptc), dfb::get_counter_id(ptc), num_entries);
+            ASSERT(overlay::llk_intf_get_capacity(dfb::get_tensix_id(ptc), dfb::get_counter_id(ptc)) >= num_entries);
+            overlay::llk_intf_inc_posted(dfb::get_tensix_id(ptc), dfb::get_counter_id(ptc), num_entries);
         }
         local_dfb_interface_.tc_slots[0].wr_ptr += (num_entries * local_dfb_interface_.stride_size);
         if (local_dfb_interface_.tc_slots[0].wr_ptr >= local_dfb_interface_.tc_slots[0].limit) {
@@ -78,8 +78,8 @@ inline void DataflowBuffer::push_back_impl(uint16_t num_entries) {
         // tc_idx deliberately not advanced
     } else {
         uint8_t tensix_id = dfb::get_tensix_id(packed_tc);
-        ASSERT(llk_intf_get_capacity(tensix_id, tc_id) >= num_entries);
-        llk_intf_inc_posted(tensix_id, tc_id, num_entries);
+        ASSERT(overlay::llk_intf_get_capacity(tensix_id, tc_id) >= num_entries);
+        overlay::llk_intf_inc_posted(tensix_id, tc_id, num_entries);
         local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr += (num_entries * local_dfb_interface_.stride_size);
         if (local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr >= local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].limit) {
             local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].base_addr;
@@ -102,8 +102,8 @@ inline void DataflowBuffer::wait_front_impl(uint16_t num_entries) {
     llk_wait_tiles(logical_dfb_id_, num_entries);
 #elif !defined(COMPILE_FOR_TRISC)
     uint8_t tensix_id = dfb::get_tensix_id(packed_tc);
-    ASSERT(llk_intf_get_capacity(tensix_id, tc_id) >= num_entries);
-    while (llk_intf_get_occupancy(tensix_id, tc_id) < num_entries);
+    ASSERT(overlay::llk_intf_get_capacity(tensix_id, tc_id) >= num_entries);
+    while (overlay::llk_intf_get_occupancy(tensix_id, tc_id) < num_entries);
 #endif
     WAYPOINT("WFD");
 }
@@ -119,8 +119,8 @@ inline void DataflowBuffer::pop_front_impl(uint16_t num_entries) {
     llk_pop_tiles(logical_dfb_id_, num_entries);
 #elif !defined(COMPILE_FOR_TRISC)
     uint8_t tensix_id = dfb::get_tensix_id(packed_tc);
-    ASSERT(llk_intf_get_capacity(tensix_id, tc_id) >= num_entries);
-    llk_intf_inc_acked(tensix_id, tc_id, num_entries);
+    ASSERT(overlay::llk_intf_get_capacity(tensix_id, tc_id) >= num_entries);
+    overlay::llk_intf_inc_acked(tensix_id, tc_id, num_entries);
     local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr += (num_entries * local_dfb_interface_.stride_size);
     if (local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr >= local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].limit) {
         local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].base_addr;
@@ -153,7 +153,7 @@ inline void DataflowBuffer::finish_impl() {
 #elif !defined(COMPILE_FOR_TRISC)
             uint8_t tensix_id = dfb::get_tensix_id(packed_tc);
             all_acked &=
-                (fast_llk_intf_read_acked(tensix_id, tc_id) == fast_llk_intf_read_posted(tensix_id, tc_id));
+                (overlay::overlay::fast_llk_intf_read_acked(tensix_id, tc_id) == overlay::overlay::fast_llk_intf_read_posted(tensix_id, tc_id));
 #endif
         }
     }
@@ -203,10 +203,10 @@ inline void DataflowBuffer::handle_final_credits(uint16_t transactions_issued, u
     auto read_actual_slot0 = [&]() -> uint16_t {
         if constexpr (is_producer) {
             return static_cast<uint16_t>(
-                fast_llk_intf_read_posted(dfb::get_tensix_id(ptc0), dfb::get_counter_id(ptc0)));
+                overlay::fast_llk_intf_read_posted(dfb::get_tensix_id(ptc0), dfb::get_counter_id(ptc0)));
         } else {
             return static_cast<uint16_t>(
-                fast_llk_intf_read_acked(dfb::get_tensix_id(ptc0), dfb::get_counter_id(ptc0)));
+                overlay::fast_llk_intf_read_acked(dfb::get_tensix_id(ptc0), dfb::get_counter_id(ptc0)));
         }
     };
 
@@ -270,14 +270,14 @@ inline void DataflowBuffer::handle_final_credits(uint16_t transactions_issued, u
             uint8_t tc_id     = dfb::get_counter_id(ptc);
             uint16_t expected = transactions_issued / N + (i < (transactions_issued % N) ? 1u : 0u);
             if constexpr (is_producer) {
-                uint16_t actual = static_cast<uint16_t>(fast_llk_intf_read_posted(tensix_id, tc_id));
+                uint16_t actual = static_cast<uint16_t>(overlay::fast_llk_intf_read_posted(tensix_id, tc_id));
                 if (actual < expected) {
-                    fast_llk_intf_inc_posted(tensix_id, tc_id, expected - actual);
+                    overlay::fast_llk_intf_inc_posted(tensix_id, tc_id, expected - actual);
                 }
             } else {
-                uint16_t actual = static_cast<uint16_t>(fast_llk_intf_read_acked(tensix_id, tc_id));
+                uint16_t actual = static_cast<uint16_t>(overlay::fast_llk_intf_read_acked(tensix_id, tc_id));
                 if (actual < expected) {
-                    fast_llk_intf_inc_acked(tensix_id, tc_id, expected - actual);
+                    overlay::fast_llk_intf_inc_acked(tensix_id, tc_id, expected - actual);
                 }
             }
         }
@@ -306,8 +306,8 @@ inline uint32_t DataflowBuffer::prepare_implicit_read() {
     uint8_t tc_id = dfb::get_counter_id(packed_tc);
     const uint32_t txn_id = local_dfb_interface_.txn_ids[ptxn_id_index_];
     WAYPOINT("PIRW");
-    while (fast_llk_intf_read_posted(tensix_id, tc_id) < (ptxn_id_loop_cnt_ * local_dfb_interface_.num_entries_per_txn_id_per_tc));
-    while (fast_llk_intf_get_free_space(tensix_id, tc_id) < 1);
+    while (overlay::fast_llk_intf_read_posted(tensix_id, tc_id) < (ptxn_id_loop_cnt_ * local_dfb_interface_.num_entries_per_txn_id_per_tc));
+    while (overlay::fast_llk_intf_get_free_space(tensix_id, tc_id) < 1);
     WAYPOINT("PIRD");
     return txn_id;
 }
@@ -336,8 +336,8 @@ inline uint32_t DataflowBuffer::prepare_implicit_write() {
     uint8_t tc_id = dfb::get_counter_id(packed_tc);
     const uint32_t txn_id = local_dfb_interface_.txn_ids[ctxn_id_index_];
     WAYPOINT("PIWW");
-    while (fast_llk_intf_read_acked(tensix_id, tc_id) < (ctxn_id_loop_cnt_ * local_dfb_interface_.num_entries_per_txn_id_per_tc));
-    while (fast_llk_intf_get_occupancy(tensix_id, tc_id) < 1);
+    while (overlay::fast_llk_intf_read_acked(tensix_id, tc_id) < (ctxn_id_loop_cnt_ * local_dfb_interface_.num_entries_per_txn_id_per_tc));
+    while (overlay::fast_llk_intf_get_occupancy(tensix_id, tc_id) < 1);
     WAYPOINT("PIWD");
     return txn_id;
 }

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_init.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_init.h
@@ -349,7 +349,7 @@ FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base
             volatile dfb_initializer_per_risc_t* per_risc_ptr = per_risc_base + risc_index;
 
             if (per_risc_ptr->flags.is_producer) {
-                while (per_risc_ptr->flags.remapper_en && !RemapperAPI::is_remapper_enabled());
+                while (per_risc_ptr->flags.remapper_en && !overlay::RemapperAPI::is_remapper_enabled());
 
                 // Note: resetting tile counters does not reset the buffer capacity to 0
                 for (uint8_t tc = 0; tc < per_risc_ptr->num_tcs_and_init.num_tcs_to_rr; tc++) {

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_init.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_init.h
@@ -368,8 +368,8 @@ FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base
                     //         << " tc_id: " << static_cast<uint32_t>(tc_id) << ENDL();
                     // DEVICE_PRINT("dfb {} initializing tc tensix_id: {} tc_id: {}\n", logical_dfb_id, tensix_id,
                     // tc_id);
-                    llk_intf_reset(tensix_id, tc_id);
-                    llk_intf_set_capacity(tensix_id, tc_id, init_ptr->capacity);
+                    overlay::llk_intf_reset(tensix_id, tc_id);
+                    overlay::llk_intf_set_capacity(tensix_id, tc_id, init_ptr->capacity);
 #endif
                 }
                 // Only the RISC that actually performed the TC hardware init sets tc_init_done.

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_interface.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_interface.h
@@ -24,7 +24,7 @@ extern thread_local LocalDFBInterface g_dfb_interface[dfb::NUM_DFBS];
 #ifndef COMPILE_FOR_TRISC
 // TODO: make this a constant when we clean up number of txn ids
 extern volatile TxnDFBDescriptor g_txn_dfb_descriptor[32];
-extern RemapperAPI g_remapper_configurator;
+extern overlay::RemapperAPI g_remapper_configurator;
 #endif
 
 #if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_PACK)

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_isr.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_isr.h
@@ -23,7 +23,7 @@ inline __attribute__((always_inline)) void dfb_tile_poster_irq_handler() {
             dfb::PackedTileCounter packed_tile_counter = txn_dfb_descriptor.tile_counters[i];
             uint8_t tensix_id = dfb::get_tensix_id(packed_tile_counter);
             uint8_t tc_id = dfb::get_counter_id(packed_tile_counter);
-            fast_llk_intf_inc_posted(tensix_id, tc_id, txn_dfb_descriptor.tiles_to_post);
+            overlay::fast_llk_intf_inc_posted(tensix_id, tc_id, txn_dfb_descriptor.tiles_to_post);
         }
 
         CMDBUF_CLEAR_TILES_TO_PROCESS_TR_ACK(OVERLAY_RD_CMD_BUF, trid);
@@ -52,7 +52,7 @@ inline __attribute__((always_inline)) void dfb_tile_acker_irq_handler() {
             dfb::PackedTileCounter packed_tile_counter = txn_dfb_descriptor.tile_counters[i];
             uint8_t tensix_id = dfb::get_tensix_id(packed_tile_counter);
             uint8_t tc_id = dfb::get_counter_id(packed_tile_counter);
-            fast_llk_intf_inc_acked(tensix_id, tc_id, txn_dfb_descriptor.tiles_to_ack);
+            overlay::fast_llk_intf_inc_acked(tensix_id, tc_id, txn_dfb_descriptor.tiles_to_ack);
         }
 
         CMDBUF_CLEAR_TILES_TO_PROCESS_WR_SENT(OVERLAY_WR_CMD_BUF, trid);

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api_v2.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api_v2.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <stdint.h>
 #include <cstdint>
 #include "internal/risc_attribs.h"
 #include "noc_parameters.h"
@@ -12,7 +11,6 @@
 #include "noc_overlay_parameters.h"
 #include "api/debug/assert.h"
 #include "internal/tt-2xx/quasar/overlay/rocc_instructions.hpp"
-#include "internal/tt-2xx/quasar/overlay/cmdbuff_api.hpp"
 
 #if !defined(COMPILE_FOR_DM)
 #error "NOC API V2 requires COMPILE_FOR_DM (uses RoCC custom instructions)"

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api_v2.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api_v2.h
@@ -12,6 +12,7 @@
 #include "noc_overlay_parameters.h"
 #include "api/debug/assert.h"
 #include "internal/tt-2xx/quasar/overlay/rocc_instructions.hpp"
+#include "internal/tt-2xx/quasar/overlay/cmdbuff_api.hpp"
 
 #if !defined(COMPILE_FOR_DM)
 #error "NOC API V2 requires COMPILE_FOR_DM (uses RoCC custom instructions)"
@@ -44,16 +45,16 @@ constexpr uint32_t NOC_PCIE_MASK = 0x1000000F;
 constexpr uint32_t WRITE_RESPONSE_STATIC_VC = 14;
 constexpr uint32_t READ_RESPONSE_STATIC_VC = 12;
 
-// Overlay command buffer VC assignments (matching cmdbuff_api.hpp)
-constexpr uint32_t CMDBUF_RD_REQ_VC = 1;
-constexpr uint32_t CMDBUF_RD_RESP_VC = 12;
-constexpr uint32_t CMDBUF_WR_REQ_VC = 2;
-constexpr uint32_t CMDBUF_WR_RESP_VC = 13;
-constexpr uint32_t CMDBUF_MCAST_REQ_VC = 8;
-constexpr uint32_t CMDBUF_MCAST_RESP_VC = 14;
+// NOC V2 command buffer VC assignments (same HW values as overlay::CMDBUF_*_VC)
+constexpr uint32_t NOC_V2_RD_REQ_VC = 1;
+constexpr uint32_t NOC_V2_RD_RESP_VC = 12;
+constexpr uint32_t NOC_V2_WR_REQ_VC = 2;
+constexpr uint32_t NOC_V2_WR_RESP_VC = 13;
+constexpr uint32_t NOC_V2_MCAST_REQ_VC = 8;
+constexpr uint32_t NOC_V2_MCAST_RESP_VC = 14;
 
 // Static transaction ID used for all command buffers
-constexpr uint32_t CMDBUF_TRID_STATIC = 0;
+constexpr uint32_t NOC_V2_TRID_STATIC = 0;
 
 // ============================================================================
 // CMD_BUF_MISC Register Bit Definitions (TT_ROCC_CMD_BUF_MISC_reg_t)
@@ -283,15 +284,15 @@ inline __attribute__((always_inline)) void noc_init(uint32_t atomic_ret_val) {
     __builtin_riscv_ttrocc_cmdbuf_wr_reg(
         OVERLAY_WR_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_SRC_COORD_REG_OFFSET / 8, my_xy);
     __builtin_riscv_ttrocc_cmdbuf_wr_reg(
-        OVERLAY_WR_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_REQ_VC_REG_OFFSET / 8, CMDBUF_WR_REQ_VC);
+        OVERLAY_WR_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_REQ_VC_REG_OFFSET / 8, NOC_V2_WR_REQ_VC);
     __builtin_riscv_ttrocc_cmdbuf_wr_reg(
-        OVERLAY_WR_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_RESP_VC_REG_OFFSET / 8, CMDBUF_WR_RESP_VC);
+        OVERLAY_WR_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_RESP_VC_REG_OFFSET / 8, NOC_V2_WR_RESP_VC);
     __builtin_riscv_ttrocc_cmdbuf_wr_reg(
-        OVERLAY_WR_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_WR_SENT_TR_ID_REG_OFFSET / 8, CMDBUF_TRID_STATIC);
+        OVERLAY_WR_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_WR_SENT_TR_ID_REG_OFFSET / 8, NOC_V2_TRID_STATIC);
     __builtin_riscv_ttrocc_cmdbuf_wr_reg(
-        OVERLAY_WR_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_TR_ACK_TR_ID_REG_OFFSET / 8, CMDBUF_TRID_STATIC);
+        OVERLAY_WR_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_TR_ACK_TR_ID_REG_OFFSET / 8, NOC_V2_TRID_STATIC);
     __builtin_riscv_ttrocc_cmdbuf_wr_reg(
-        OVERLAY_WR_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_TR_ID_REG_OFFSET / 8, CMDBUF_TRID_STATIC);
+        OVERLAY_WR_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_TR_ID_REG_OFFSET / 8, NOC_V2_TRID_STATIC);
 
     // Read command buffer (CMDBUF_1): remote src → local dest
     __builtin_riscv_ttrocc_cmdbuf_wr_reg(
@@ -299,15 +300,15 @@ inline __attribute__((always_inline)) void noc_init(uint32_t atomic_ret_val) {
     __builtin_riscv_ttrocc_cmdbuf_wr_reg(
         OVERLAY_RD_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_DEST_COORD_REG_OFFSET / 8, my_xy);
     __builtin_riscv_ttrocc_cmdbuf_wr_reg(
-        OVERLAY_RD_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_REQ_VC_REG_OFFSET / 8, CMDBUF_RD_REQ_VC);
+        OVERLAY_RD_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_REQ_VC_REG_OFFSET / 8, NOC_V2_RD_REQ_VC);
     __builtin_riscv_ttrocc_cmdbuf_wr_reg(
-        OVERLAY_RD_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_RESP_VC_REG_OFFSET / 8, CMDBUF_RD_RESP_VC);
+        OVERLAY_RD_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_RESP_VC_REG_OFFSET / 8, NOC_V2_RD_RESP_VC);
     __builtin_riscv_ttrocc_cmdbuf_wr_reg(
-        OVERLAY_RD_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_WR_SENT_TR_ID_REG_OFFSET / 8, CMDBUF_TRID_STATIC);
+        OVERLAY_RD_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_WR_SENT_TR_ID_REG_OFFSET / 8, NOC_V2_TRID_STATIC);
     __builtin_riscv_ttrocc_cmdbuf_wr_reg(
-        OVERLAY_RD_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_TR_ACK_TR_ID_REG_OFFSET / 8, CMDBUF_TRID_STATIC);
+        OVERLAY_RD_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_TR_ACK_TR_ID_REG_OFFSET / 8, NOC_V2_TRID_STATIC);
     __builtin_riscv_ttrocc_cmdbuf_wr_reg(
-        OVERLAY_RD_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_TR_ID_REG_OFFSET / 8, CMDBUF_TRID_STATIC);
+        OVERLAY_RD_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_TR_ID_REG_OFFSET / 8, NOC_V2_TRID_STATIC);
 
     // Atomic command buffer (SCMDBUF): simple buffer for atomics and inline writes
     __builtin_riscv_ttrocc_scmdbuf_wr_reg(
@@ -315,7 +316,7 @@ inline __attribute__((always_inline)) void noc_init(uint32_t atomic_ret_val) {
     __builtin_riscv_ttrocc_scmdbuf_wr_reg(TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_SRC_ADDR_REG_OFFSET / 8, atomic_ret_val);
     __builtin_riscv_ttrocc_scmdbuf_wr_reg(TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_SRC_COORD_REG_OFFSET / 8, my_xy);
     __builtin_riscv_ttrocc_scmdbuf_wr_reg(
-        TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_RESP_VC_REG_OFFSET / 8, CMDBUF_WR_RESP_VC);
+        TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_RESP_VC_REG_OFFSET / 8, NOC_V2_WR_RESP_VC);
 }
 
 // set noc local memory state for a single kernel from the global state
@@ -353,7 +354,7 @@ inline __attribute__((always_inline)) void ncrisc_noc_counters_init() {
 // Expects noc_init to have set on OVERLAY_RD_CMD_BUF:
 //   MISC      = CMD_BUF_MISC_READ
 //   DEST_COORD = my_xy (local core, read return destination)
-//   TR_ID / WR_SENT_TR_ID / TR_ACK_TR_ID = CMDBUF_TRID_STATIC
+//   TR_ID / WR_SENT_TR_ID / TR_ACK_TR_ID = NOC_V2_TRID_STATIC (0)
 template <uint8_t noc_mode = DM_DEDICATED_NOC>
 inline __attribute__((always_inline)) void ncrisc_noc_fast_read(
     uint32_t noc,
@@ -361,13 +362,13 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_read(
     uint64_t src_addr,
     uint32_t dest_addr,
     uint32_t len_bytes,
-    uint32_t read_req_vc = CMDBUF_RD_REQ_VC) {
+    uint32_t read_req_vc = NOC_V2_RD_REQ_VC) {
     static_assert(noc_mode != DM_DYNAMIC_NOC, "Quasar does not support DYNAMIC_NOC as it has only 1 NOC");
 
     __builtin_riscv_ttrocc_cmdbuf_wr_reg(
         cmd_buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_REQ_VC_REG_OFFSET / 8, read_req_vc);
     __builtin_riscv_ttrocc_cmdbuf_wr_reg(
-        cmd_buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_RESP_VC_REG_OFFSET / 8, CMDBUF_RD_RESP_VC);
+        cmd_buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_RESP_VC_REG_OFFSET / 8, NOC_V2_RD_RESP_VC);
     __builtin_riscv_ttrocc_cmdbuf_wr_reg(
         cmd_buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_SRC_ADDR_REG_OFFSET / 8, (uint32_t)src_addr);
     __builtin_riscv_ttrocc_cmdbuf_wr_reg(
@@ -423,7 +424,7 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_write(
     __builtin_riscv_ttrocc_cmdbuf_wr_reg(
         cmd_buf,
         TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_RESP_VC_REG_OFFSET / 8,
-        mcast ? CMDBUF_MCAST_RESP_VC : CMDBUF_WR_RESP_VC);
+        mcast ? NOC_V2_MCAST_RESP_VC : NOC_V2_WR_RESP_VC);
 
     if constexpr (use_trid) {
         __builtin_riscv_ttrocc_cmdbuf_wr_reg(cmd_buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_TR_ID_REG_OFFSET / 8, trid);
@@ -481,7 +482,7 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_write_loopback_src(
     __builtin_riscv_ttrocc_cmdbuf_wr_reg(
         cmd_buf,
         TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_RESP_VC_REG_OFFSET / 8,
-        mcast ? CMDBUF_MCAST_RESP_VC : CMDBUF_WR_RESP_VC);
+        mcast ? NOC_V2_MCAST_RESP_VC : NOC_V2_WR_RESP_VC);
 
     __builtin_riscv_ttrocc_cmdbuf_wr_reg(
         cmd_buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_SRC_ADDR_REG_OFFSET / 8, src_addr);
@@ -541,7 +542,7 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_read_any_len(
     uint64_t src_addr,
     uint32_t dest_addr,
     uint32_t len_bytes,
-    uint32_t read_req_vc = CMDBUF_RD_REQ_VC) {
+    uint32_t read_req_vc = NOC_V2_RD_REQ_VC) {
     static_assert(noc_mode != DM_DYNAMIC_NOC, "Quasar does not support DYNAMIC_NOC as it has only 1 NOC");
     // Overlay handles packetization via MAX_BYTES_IN_PACKET register; no software chunking needed.
     ncrisc_noc_fast_read<noc_mode>(noc, cmd_buf, src_addr, dest_addr, len_bytes, read_req_vc);
@@ -615,7 +616,7 @@ inline __attribute__((always_inline)) void noc_fast_write_dw_inline(
 
     __builtin_riscv_ttrocc_scmdbuf_wr_reg(TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_REQ_VC_REG_OFFSET / 8, static_vc);
     __builtin_riscv_ttrocc_scmdbuf_wr_reg(
-        TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_RESP_VC_REG_OFFSET / 8, mcast ? CMDBUF_MCAST_RESP_VC : CMDBUF_WR_RESP_VC);
+        TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_RESP_VC_REG_OFFSET / 8, mcast ? NOC_V2_MCAST_RESP_VC : NOC_V2_WR_RESP_VC);
 
     uint32_t be32 = be << (dest_addr & (NOC_WORD_BYTES - 1));
     __builtin_riscv_ttrocc_scmdbuf_wr_reg(TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_LEN_BYTES_REG_OFFSET / 8, be32);
@@ -698,7 +699,7 @@ inline __attribute__((always_inline)) void noc_fast_atomic_increment(
     __builtin_riscv_ttrocc_scmdbuf_wr_reg(TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_MISC_REG_OFFSET / 8, misc);
     __builtin_riscv_ttrocc_scmdbuf_wr_reg(TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_REQ_VC_REG_OFFSET / 8, vc);
     __builtin_riscv_ttrocc_scmdbuf_wr_reg(
-        TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_RESP_VC_REG_OFFSET / 8, CMDBUF_WR_RESP_VC);
+        TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_RESP_VC_REG_OFFSET / 8, NOC_V2_WR_RESP_VC);
     if constexpr (program_ret_addr) {
         __builtin_riscv_ttrocc_scmdbuf_wr_reg(
             TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_SRC_ADDR_REG_OFFSET / 8, atomic_ret_val);
@@ -739,7 +740,7 @@ inline __attribute__((always_inline)) void noc_fast_multicast_atomic_increment(
     __builtin_riscv_ttrocc_scmdbuf_wr_reg(TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_MISC_REG_OFFSET / 8, misc);
     __builtin_riscv_ttrocc_scmdbuf_wr_reg(TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_REQ_VC_REG_OFFSET / 8, vc);
     __builtin_riscv_ttrocc_scmdbuf_wr_reg(
-        TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_RESP_VC_REG_OFFSET / 8, CMDBUF_MCAST_RESP_VC);
+        TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_RESP_VC_REG_OFFSET / 8, NOC_V2_MCAST_RESP_VC);
     __builtin_riscv_ttrocc_scmdbuf_wr_reg(
         TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_DEST_ADDR_REG_OFFSET / 8, (uint32_t)(addr & 0xFFFFFFFF));
     __builtin_riscv_ttrocc_scmdbuf_wr_reg(
@@ -969,7 +970,7 @@ inline __attribute__((always_inline)) void ncrisc_noc_write_set_state(
     __builtin_riscv_ttrocc_cmdbuf_wr_reg(cmd_buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_MISC_REG_OFFSET / 8, misc);
     __builtin_riscv_ttrocc_cmdbuf_wr_reg(cmd_buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_REQ_VC_REG_OFFSET / 8, vc);
     __builtin_riscv_ttrocc_cmdbuf_wr_reg(
-        cmd_buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_RESP_VC_REG_OFFSET / 8, CMDBUF_WR_RESP_VC);
+        cmd_buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_RESP_VC_REG_OFFSET / 8, NOC_V2_WR_RESP_VC);
 
     // Set remote destination coordinate
     __builtin_riscv_ttrocc_cmdbuf_wr_reg(
@@ -1102,7 +1103,7 @@ inline __attribute__((always_inline)) void noc_fast_write_dw_inline_set_state(
     __builtin_riscv_ttrocc_scmdbuf_wr_reg(TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_MISC_REG_OFFSET / 8, misc);
     __builtin_riscv_ttrocc_scmdbuf_wr_reg(TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_REQ_VC_REG_OFFSET / 8, static_vc);
     __builtin_riscv_ttrocc_scmdbuf_wr_reg(
-        TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_RESP_VC_REG_OFFSET / 8, CMDBUF_WR_RESP_VC);
+        TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_RESP_VC_REG_OFFSET / 8, NOC_V2_WR_RESP_VC);
     __builtin_riscv_ttrocc_scmdbuf_wr_reg(
         TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_DEST_ADDR_REG_OFFSET / 8, (uint32_t)dest_addr);
     __builtin_riscv_ttrocc_scmdbuf_wr_reg(
@@ -1522,7 +1523,7 @@ inline __attribute__((always_inline)) void noc_write_init_state(uint32_t noc, ui
     __builtin_riscv_ttrocc_cmdbuf_wr_reg(
         cmd_buf,
         TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_RESP_VC_REG_OFFSET / 8,
-        (cmd_flags & CQ_NOC_CMD_FLAG_MCAST) ? CMDBUF_MCAST_RESP_VC : CMDBUF_WR_RESP_VC);
+        (cmd_flags & CQ_NOC_CMD_FLAG_MCAST) ? NOC_V2_MCAST_RESP_VC : NOC_V2_WR_RESP_VC);
 }
 
 // clang-format off

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api_v2.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api_v2.h
@@ -655,7 +655,7 @@ inline __attribute__((always_inline)) void noc_fast_write_dw_inline_multicast(
 
     __builtin_riscv_ttrocc_scmdbuf_wr_reg(TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_REQ_VC_REG_OFFSET / 8, static_vc);
     __builtin_riscv_ttrocc_scmdbuf_wr_reg(
-        TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_RESP_VC_REG_OFFSET / 8, mcast ? CMDBUF_MCAST_RESP_VC : CMDBUF_WR_RESP_VC);
+        TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_RESP_VC_REG_OFFSET / 8, mcast ? NOC_V2_MCAST_RESP_VC : NOC_V2_WR_RESP_VC);
 
     uint32_t be32 = be << (dest_addr & (NOC_WORD_BYTES - 1));
     __builtin_riscv_ttrocc_scmdbuf_wr_reg(TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_LEN_BYTES_REG_OFFSET / 8, be32);
@@ -1295,7 +1295,7 @@ inline __attribute__((always_inline)) void noc_inline_dw_write_init_state(uint32
         __builtin_riscv_ttrocc_scmdbuf_wr_reg(TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_REQ_VC_REG_OFFSET / 8, vc);
         __builtin_riscv_ttrocc_scmdbuf_wr_reg(
             TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_RESP_VC_REG_OFFSET / 8,
-            (cmd_flags & CQ_NOC_CMD_FLAG_MCAST) ? CMDBUF_MCAST_RESP_VC : CMDBUF_WR_RESP_VC);
+            (cmd_flags & CQ_NOC_CMD_FLAG_MCAST) ? NOC_V2_MCAST_RESP_VC : NOC_V2_WR_RESP_VC);
     } else {
         static_assert(cmd_buf <= 1, "normal cmdbuf operations are only valid for cmd_buf 0 or 1");
         __builtin_riscv_ttrocc_cmdbuf_wr_reg(cmd_buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_MISC_REG_OFFSET / 8, misc);
@@ -1303,7 +1303,7 @@ inline __attribute__((always_inline)) void noc_inline_dw_write_init_state(uint32
         __builtin_riscv_ttrocc_cmdbuf_wr_reg(
             cmd_buf,
             TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_RESP_VC_REG_OFFSET / 8,
-            (cmd_flags & CQ_NOC_CMD_FLAG_MCAST) ? CMDBUF_MCAST_RESP_VC : CMDBUF_WR_RESP_VC);
+            (cmd_flags & CQ_NOC_CMD_FLAG_MCAST) ? NOC_V2_MCAST_RESP_VC : NOC_V2_WR_RESP_VC);
     }
 }
 

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/overlay/addrgen_api.hpp
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/overlay/addrgen_api.hpp
@@ -57,6 +57,8 @@
 #define ADDRGEN_0 0
 #define ADDRGEN_1 1
 
+namespace overlay {
+
 enum bank_order_e { BANK_INNER = 0, BANK_MIDDLE, BANK_OUTER };
 
 /*
@@ -565,3 +567,5 @@ DEFINE_ADDR_GEN(addrgen_0, ADDRGEN_0)
 DEFINE_ADDR_GEN(addrgen_1, ADDRGEN_1)
 
 #undef DEFINE_ADDR_GEN
+
+}  // namespace overlay

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/overlay/cmdbuff_api.hpp
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/overlay/cmdbuff_api.hpp
@@ -33,6 +33,8 @@
 #define CMDBUF_0 0
 #define CMDBUF_1 1
 
+namespace overlay {
+
 /* Default transaction ID for both command buffers */
 constexpr uint32_t CMDBUF_DEF_TRID = 0;
 /* Static(starting) transaction ID for command buffer 0 */
@@ -1876,3 +1878,5 @@ inline __attribute__((always_inline)) bool noc_nonposted_writes_acked_reg_cmdbuf
     return SCMDBUF_TR_ACK_TRID(transaction_id) == 0;
 }
 inline __attribute__((always_inline)) bool noc_nonposted_writes_acked_reg_cmdbuf() { return SCMDBUF_TR_ACK() == 0; }
+
+}  // namespace overlay

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/overlay/fds_functions.hpp
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/overlay/fds_functions.hpp
@@ -14,6 +14,8 @@
 #define TRAP_INT_MASK 0x8000000000000000  // Mask to identify interrupt traps
 #define CORE_OFFSET 0x1000                // Offset between mhartid cores
 
+namespace overlay {
+
 namespace FdsDispatch {
 // Configure filter length: how many cycles a done signal from a NEO must be stable (through the deglitcher)
 void fds_config_filter_length(uint32_t threshold);
@@ -70,4 +72,7 @@ void fds_clear_de_status(uint32_t dispatch_inst);
 // Configure interrupts for groupIDs: set bit for the groupIDs to generate interrupts
 void fds_config_interrupt_en(uint32_t mask);
 }  // namespace FdsNeo
+
+}  // namespace overlay
+
 #endif

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/overlay/llk_intf_api.hpp
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/overlay/llk_intf_api.hpp
@@ -19,6 +19,8 @@
 #define LLK_REG_SIZE TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_REG_MAP_SIZE
 #define COUNTER_REG_SIZE TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_TILE_COUNTERS_0__REG_FILE_SIZE
 
+namespace overlay {
+
 /**
  * @enum llk_interface_e
  * @brief Enumeration of available LLK interfaces
@@ -219,3 +221,5 @@ inline __attribute__((always_inline)) uint16_t fast_llk_intf_read_error(uint64_t
         llk_if * LLK_REG_SIZE + counter * COUNTER_REG_SIZE +
         TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_TILE_COUNTERS_0__ERROR_STATUS_REG_ADDR);
 }
+
+}  // namespace overlay

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/overlay/overlay_interrupts.hpp
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/overlay/overlay_interrupts.hpp
@@ -9,6 +9,8 @@
 #include "overlay_hwtest.h"
 #include "metal/drivers/riscv_cpu.h"
 
+namespace overlay {
+
 uint64_t __ig_mcause_ovl(void);
 void __ig_metal_interrupt_external_enable_ovl(void);
 void __ig_metal_interrupt_global_enable_ovl(void);
@@ -16,5 +18,7 @@ void register_interrupt(size_t core, uint32_t irq, void (*custom_handler)());
 void disable_interrupt(size_t core, uint32_t irq);
 void claim_interrupt(uint32_t irq);
 void clear_interrupt(uint32_t irq);
+
+}  // namespace overlay
 
 #endif

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/overlay/remapper_api.hpp
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/overlay/remapper_api.hpp
@@ -38,6 +38,8 @@
 #include "remapper_common.hpp"
 #include "overlay_addresses.h"
 
+using namespace overlay;
+
 /**
  * @brief Generic API for Counter Remapper Configuration
  *

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/overlay/remapper_api.hpp
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/overlay/remapper_api.hpp
@@ -38,6 +38,8 @@
 #include "remapper_common.hpp"
 #include "overlay_addresses.h"
 
+namespace overlay {
+
 /**
  * @brief Generic API for Counter Remapper Configuration
  *
@@ -47,8 +49,8 @@
  */
 class RemapperAPI {
 private:
-    overlay::tClientR_Config_Reg_u clientR_configs[REMAP_NUM_PAIRS]{};
-    overlay::tClientL_Config_Reg_u clientL_configs[REMAP_NUM_PAIRS]{};
+    tClientR_Config_Reg_u clientR_configs[REMAP_NUM_PAIRS]{};
+    tClientL_Config_Reg_u clientL_configs[REMAP_NUM_PAIRS]{};
     uint32_t current_pair_idx;
 
 public:
@@ -164,7 +166,7 @@ public:
         for (uint32_t pair_idx = 0; pair_idx < REMAP_NUM_PAIRS; pair_idx++) {
             // Read ClientR configuration register from hardware
             uint32_t reg_val = READ_REG32(REMAP_CLIENT_R_CONFIG_REG_ADDR32(pair_idx));
-            overlay::tClientR_Config_Reg_u config;
+            tClientR_Config_Reg_u config;
             config.val = reg_val;
 
             // Check all 4 slots in this pair
@@ -321,7 +323,7 @@ public:
      *
      * @return Status register union
      */
-    overlay::tClientR_status_Reg_u read_clientR_status() { return read_clientR_status(current_pair_idx); }
+    tClientR_status_Reg_u read_clientR_status() { return read_clientR_status(current_pair_idx); }
 
     /**
      * @brief Read ClientR status register from hardware for a specific pair
@@ -329,8 +331,8 @@ public:
      * @param pair_idx Pair index (0-63)
      * @return Status register union
      */
-    overlay::tClientR_status_Reg_u read_clientR_status(uint32_t pair_idx) {
-        overlay::tClientR_status_Reg_u status;
+    tClientR_status_Reg_u read_clientR_status(uint32_t pair_idx) {
+        tClientR_status_Reg_u status;
         status.val = 0;
         if (pair_idx < REMAP_NUM_PAIRS) {
             status.val = READ_REG32(REMAP_CLIENT_R_STATUS_REG_ADDR32(pair_idx));
@@ -629,7 +631,7 @@ public:
      *
      * @return Status register union
      */
-    overlay::tClientL_status_Reg_u read_clientL_status() { return read_clientL_status(current_pair_idx); }
+    tClientL_status_Reg_u read_clientL_status() { return read_clientL_status(current_pair_idx); }
 
     /**
      * @brief Read ClientL status register from hardware for a specific pair
@@ -637,8 +639,8 @@ public:
      * @param pair_idx Pair index (0-63)
      * @return Status register union
      */
-    overlay::tClientL_status_Reg_u read_clientL_status(uint32_t pair_idx) {
-        overlay::tClientL_status_Reg_u status;
+    tClientL_status_Reg_u read_clientL_status(uint32_t pair_idx) {
+        tClientL_status_Reg_u status;
         status.val = 0;
         if (pair_idx < REMAP_NUM_PAIRS) {
             status.val = READ_REG32(REMAP_CLIENT_L_STATUS_REG_ADDR32(pair_idx));
@@ -746,7 +748,7 @@ public:
      * @param status ClientL status register
      * @return true if any error flags are set
      */
-    bool has_error(const overlay::tClientL_status_Reg_u& status) const {
+    bool has_error(const tClientL_status_Reg_u& status) const {
         return (status.f.err_inv_client_no != 0 || status.f.err_inv_client_id != 0 || status.f.err_inv_access != 0);
     }
 
@@ -764,7 +766,7 @@ public:
      * @return true if any error flags are set
      */
     bool check_clientL_errors(uint32_t pair_idx) {
-        overlay::tClientL_status_Reg_u status = read_clientL_status(pair_idx);
+        tClientL_status_Reg_u status = read_clientL_status(pair_idx);
         return has_error(status);
     }
 
@@ -777,7 +779,7 @@ public:
      * @param err_inv_access Output: Invalid access error
      */
     void get_error_details(
-        const overlay::tClientL_status_Reg_u& status,
+        const tClientL_status_Reg_u& status,
         bool& err_inv_client_no,
         bool& err_inv_client_id,
         bool& err_inv_access) const {
@@ -833,7 +835,7 @@ public:
      *
      * @return Reference to ClientR config union
      */
-    overlay::tClientR_Config_Reg_u& get_clientR_config_ref() { return get_clientR_config_ref(current_pair_idx); }
+    tClientR_Config_Reg_u& get_clientR_config_ref() { return get_clientR_config_ref(current_pair_idx); }
 
     /**
      * @brief Get direct reference to ClientR config register for a specific pair (for advanced use)
@@ -841,7 +843,7 @@ public:
      * @param pair_idx Pair index (0-63)
      * @return Reference to ClientR config union
      */
-    overlay::tClientR_Config_Reg_u& get_clientR_config_ref(uint32_t pair_idx) {
+    tClientR_Config_Reg_u& get_clientR_config_ref(uint32_t pair_idx) {
         if (pair_idx < REMAP_NUM_PAIRS) {
             return clientR_configs[pair_idx];
         }
@@ -854,7 +856,7 @@ public:
      *
      * @return Reference to ClientL config union
      */
-    overlay::tClientL_Config_Reg_u& get_clientL_config_ref() { return get_clientL_config_ref(current_pair_idx); }
+    tClientL_Config_Reg_u& get_clientL_config_ref() { return get_clientL_config_ref(current_pair_idx); }
 
     /**
      * @brief Get direct reference to ClientL config register for a specific pair (for advanced use)
@@ -862,7 +864,7 @@ public:
      * @param pair_idx Pair index (0-63)
      * @return Reference to ClientL config union
      */
-    overlay::tClientL_Config_Reg_u& get_clientL_config_ref(uint32_t pair_idx) {
+    tClientL_Config_Reg_u& get_clientL_config_ref(uint32_t pair_idx) {
         if (pair_idx < REMAP_NUM_PAIRS) {
             return clientL_configs[pair_idx];
         }
@@ -870,5 +872,7 @@ public:
         return clientL_configs[0];
     }
 };
+
+}  // namespace overlay
 
 #endif  // __DM__REMAPPER_API_HPP__

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/overlay/remapper_api.hpp
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/overlay/remapper_api.hpp
@@ -38,8 +38,6 @@
 #include "remapper_common.hpp"
 #include "overlay_addresses.h"
 
-using namespace overlay;
-
 /**
  * @brief Generic API for Counter Remapper Configuration
  *
@@ -49,8 +47,8 @@ using namespace overlay;
  */
 class RemapperAPI {
 private:
-    tClientR_Config_Reg_u clientR_configs[REMAP_NUM_PAIRS]{};
-    tClientL_Config_Reg_u clientL_configs[REMAP_NUM_PAIRS]{};
+    overlay::tClientR_Config_Reg_u clientR_configs[REMAP_NUM_PAIRS]{};
+    overlay::tClientL_Config_Reg_u clientL_configs[REMAP_NUM_PAIRS]{};
     uint32_t current_pair_idx;
 
 public:
@@ -166,7 +164,7 @@ public:
         for (uint32_t pair_idx = 0; pair_idx < REMAP_NUM_PAIRS; pair_idx++) {
             // Read ClientR configuration register from hardware
             uint32_t reg_val = READ_REG32(REMAP_CLIENT_R_CONFIG_REG_ADDR32(pair_idx));
-            tClientR_Config_Reg_u config;
+            overlay::tClientR_Config_Reg_u config;
             config.val = reg_val;
 
             // Check all 4 slots in this pair
@@ -323,7 +321,7 @@ public:
      *
      * @return Status register union
      */
-    tClientR_status_Reg_u read_clientR_status() { return read_clientR_status(current_pair_idx); }
+    overlay::tClientR_status_Reg_u read_clientR_status() { return read_clientR_status(current_pair_idx); }
 
     /**
      * @brief Read ClientR status register from hardware for a specific pair
@@ -331,8 +329,8 @@ public:
      * @param pair_idx Pair index (0-63)
      * @return Status register union
      */
-    tClientR_status_Reg_u read_clientR_status(uint32_t pair_idx) {
-        tClientR_status_Reg_u status;
+    overlay::tClientR_status_Reg_u read_clientR_status(uint32_t pair_idx) {
+        overlay::tClientR_status_Reg_u status;
         status.val = 0;
         if (pair_idx < REMAP_NUM_PAIRS) {
             status.val = READ_REG32(REMAP_CLIENT_R_STATUS_REG_ADDR32(pair_idx));
@@ -631,7 +629,7 @@ public:
      *
      * @return Status register union
      */
-    tClientL_status_Reg_u read_clientL_status() { return read_clientL_status(current_pair_idx); }
+    overlay::tClientL_status_Reg_u read_clientL_status() { return read_clientL_status(current_pair_idx); }
 
     /**
      * @brief Read ClientL status register from hardware for a specific pair
@@ -639,8 +637,8 @@ public:
      * @param pair_idx Pair index (0-63)
      * @return Status register union
      */
-    tClientL_status_Reg_u read_clientL_status(uint32_t pair_idx) {
-        tClientL_status_Reg_u status;
+    overlay::tClientL_status_Reg_u read_clientL_status(uint32_t pair_idx) {
+        overlay::tClientL_status_Reg_u status;
         status.val = 0;
         if (pair_idx < REMAP_NUM_PAIRS) {
             status.val = READ_REG32(REMAP_CLIENT_L_STATUS_REG_ADDR32(pair_idx));
@@ -748,7 +746,7 @@ public:
      * @param status ClientL status register
      * @return true if any error flags are set
      */
-    bool has_error(const tClientL_status_Reg_u& status) const {
+    bool has_error(const overlay::tClientL_status_Reg_u& status) const {
         return (status.f.err_inv_client_no != 0 || status.f.err_inv_client_id != 0 || status.f.err_inv_access != 0);
     }
 
@@ -766,7 +764,7 @@ public:
      * @return true if any error flags are set
      */
     bool check_clientL_errors(uint32_t pair_idx) {
-        tClientL_status_Reg_u status = read_clientL_status(pair_idx);
+        overlay::tClientL_status_Reg_u status = read_clientL_status(pair_idx);
         return has_error(status);
     }
 
@@ -779,7 +777,7 @@ public:
      * @param err_inv_access Output: Invalid access error
      */
     void get_error_details(
-        const tClientL_status_Reg_u& status,
+        const overlay::tClientL_status_Reg_u& status,
         bool& err_inv_client_no,
         bool& err_inv_client_id,
         bool& err_inv_access) const {
@@ -835,7 +833,7 @@ public:
      *
      * @return Reference to ClientR config union
      */
-    tClientR_Config_Reg_u& get_clientR_config_ref() { return get_clientR_config_ref(current_pair_idx); }
+    overlay::tClientR_Config_Reg_u& get_clientR_config_ref() { return get_clientR_config_ref(current_pair_idx); }
 
     /**
      * @brief Get direct reference to ClientR config register for a specific pair (for advanced use)
@@ -843,7 +841,7 @@ public:
      * @param pair_idx Pair index (0-63)
      * @return Reference to ClientR config union
      */
-    tClientR_Config_Reg_u& get_clientR_config_ref(uint32_t pair_idx) {
+    overlay::tClientR_Config_Reg_u& get_clientR_config_ref(uint32_t pair_idx) {
         if (pair_idx < REMAP_NUM_PAIRS) {
             return clientR_configs[pair_idx];
         }
@@ -856,7 +854,7 @@ public:
      *
      * @return Reference to ClientL config union
      */
-    tClientL_Config_Reg_u& get_clientL_config_ref() { return get_clientL_config_ref(current_pair_idx); }
+    overlay::tClientL_Config_Reg_u& get_clientL_config_ref() { return get_clientL_config_ref(current_pair_idx); }
 
     /**
      * @brief Get direct reference to ClientL config register for a specific pair (for advanced use)
@@ -864,7 +862,7 @@ public:
      * @param pair_idx Pair index (0-63)
      * @return Reference to ClientL config union
      */
-    tClientL_Config_Reg_u& get_clientL_config_ref(uint32_t pair_idx) {
+    overlay::tClientL_Config_Reg_u& get_clientL_config_ref(uint32_t pair_idx) {
         if (pair_idx < REMAP_NUM_PAIRS) {
             return clientL_configs[pair_idx];
         }

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/overlay/remapper_common.hpp
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/overlay/remapper_common.hpp
@@ -28,6 +28,8 @@
 #define REMAP_CLIENT_L_STATUS_REG_ADDR32(pair_idx) \
     (REMAP_CLIENT_L_STATUS_REG_BASE_ADDR32 + ((pair_idx) * REMAP_REG_PAIR_STRIDE))
 
+namespace overlay {
+
 typedef enum clientTypes { DM_0, DM_1, DM_2, DM_3, NEO_0, NEO_1, NEO_2, NEO_3 } tClientTypes;
 
 typedef struct {
@@ -121,5 +123,7 @@ typedef union {
 } tClientL_status_Reg_u;
 
 // Removed: Single register pointers replaced with pair-indexed access
+
+}  // namespace overlay
 
 #endif  // __DM__REMAPPER_COMMON_HPP__

--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -245,10 +245,10 @@ inline EnableSymbolsInfo get_enable_symbols_info(HalProgrammableCoreType core_ty
 // Format client name for tile counter output.
 // DM clients show paired DMs (e.g., DM0/DM4) because DM0-3 and DM4-7 share tile counter groups.
 inline void fprintClientName(FILE* f, uint32_t client_id) {
-    if (client_id < NEO_0) {
-        fprintf(f, "DM%u/DM%u", client_id, client_id + NEO_0);
+    if (client_id < overlay::NEO_0) {
+        fprintf(f, "DM%u/DM%u", client_id, client_id + overlay::NEO_0);
     } else {
-        fprintf(f, "NEO_%u", client_id - NEO_0);
+        fprintf(f, "NEO_%u", client_id - overlay::NEO_0);
     }
 }
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -1168,7 +1168,7 @@ void WatcherDeviceReader::Core::DumpTileCountersWithRemapper() const {
     uint32_t neo_tc_buffer_capacity_offset = hal.get_neo_tile_counters_buffer_capacity_offset();
 
     auto read_tiles_to_consume = [&](uint32_t client_id, uint32_t tc_id) -> std::pair<uint32_t, uint32_t> {
-        uint32_t neo_id = client_id % NEO_0;
+        uint32_t neo_id = client_id % overlay::NEO_0;
         uint32_t neo_tc_base = neo_tc_base_addr + (neo_id * neo_tc_stride) + (tc_id * neo_tc_size);
         auto capacity_data = reader_.env.get_cluster().read_core(
             reader_.device_id, virtual_coord_, neo_tc_base + neo_tc_buffer_capacity_offset, sizeof(uint32_t));
@@ -1188,8 +1188,8 @@ void WatcherDeviceReader::Core::DumpTileCountersWithRemapper() const {
         auto clientR_data =
             reader_.env.get_cluster().read_core(reader_.device_id, virtual_coord_, clientR_addr, sizeof(uint32_t));
 
-        tClientL_Config_Reg_u clientL;
-        tClientR_Config_Reg_u clientR;
+        overlay::tClientL_Config_Reg_u clientL;
+        overlay::tClientR_Config_Reg_u clientR;
         clientL.val = clientL_data[0];
         clientR.val = clientR_data[0];
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
There are multiple redefinitions from files which are from HW. This PR adds a new overlay namespace for all Qsr datamovement functions. 

### What's changed
New namespace.
Cmdbuf_api.hpp can now be included without compiler complaining. 
Renamed defines in noc_non_blocking_V2 In case there is a need to have it different to what is in the api files. 

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vvukomanovic/0326-qsr-overlay-minor-clean-up)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vvukomanovic/0326-qsr-overlay-minor-clean-up)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vvukomanovic/0326-qsr-overlay-minor-clean-up)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vvukomanovic/0326-qsr-overlay-minor-clean-up)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vvukomanovic/0326-qsr-overlay-minor-clean-up)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vvukomanovic/0326-qsr-overlay-minor-clean-up)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vvukomanovic/0326-qsr-overlay-minor-clean-up)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vvukomanovic/0326-qsr-overlay-minor-clean-up)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vvukomanovic/0326-qsr-overlay-minor-clean-up)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vvukomanovic/0326-qsr-overlay-minor-clean-up)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vvukomanovic/0326-qsr-overlay-minor-clean-up)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vvukomanovic/0326-qsr-overlay-minor-clean-up)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vvukomanovic/0326-qsr-overlay-minor-clean-up)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vvukomanovic/0326-qsr-overlay-minor-clean-up)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vvukomanovic/0326-qsr-overlay-minor-clean-up)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vvukomanovic/0326-qsr-overlay-minor-clean-up)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vvukomanovic/0326-qsr-overlay-minor-clean-up)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vvukomanovic/0326-qsr-overlay-minor-clean-up)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vvukomanovic/0326-qsr-overlay-minor-clean-up)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vvukomanovic/0326-qsr-overlay-minor-clean-up)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vvukomanovic/0326-qsr-overlay-minor-clean-up)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vvukomanovic/0326-qsr-overlay-minor-clean-up)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vvukomanovic/0326-qsr-overlay-minor-clean-up)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vvukomanovic/0326-qsr-overlay-minor-clean-up)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vvukomanovic/0326-qsr-overlay-minor-clean-up)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vvukomanovic/0326-qsr-overlay-minor-clean-up)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vvukomanovic/0326-qsr-overlay-minor-clean-up)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vvukomanovic/0326-qsr-overlay-minor-clean-up)