### PR TITLE
Fix fast_tilize_init sentinel to track srcB operand

### DIFF
--- a/tt_metal/hw/inc/api/compute/tilize.h
+++ b/tt_metal/hw/inc/api/compute/tilize.h
@@ -241,7 +241,9 @@ ALWI void tilize_uninit_with_dt(uint32_t old_icb, uint32_t new_icb, uint32_t ocb
 }
 
 ALWI void fast_tilize_init(uint32_t icb, uint32_t full_dim, uint32_t ocb, uint32_t call_line = __builtin_LINE()) {
-    state_configure<Operand::SRCA, Operand::PACK>(icb, ocb, call_line);
+    // fast_tilize configures both UNP0 (srcA) and UNP1 (srcB) at the LLK level,
+    // so the sentinel must track all three operands (srcA, srcB, pack).
+    state_configure(icb, icb, ocb, call_line);
 #ifdef ARCH_BLACKHOLE
     // Blackhole fallback
     tilize_init(icb, full_dim, ocb, call_line);


### PR DESCRIPTION
## Summary

- `fast_tilize_init` internally configures both UNP0 (srcA) and UNP1 (srcB) at the LLK level (`_llk_unpack_fast_tilize_init_` writes to `THCON_SEC1_*` and `UNP1_*` registers), but `state_configure<Operand::SRCA, Operand::PACK>` only informed the sentinel about srcA and pack.
- This caused the sentinel to miss srcB reconfig injections when transitioning to/from fast_tilize, leaving srcB data format/configuration in a stale state from the previous operation.
- Fix: use the 3-argument `state_configure(icb, icb, ocb, call_line)` overload to track all three operands, consistent with other two-operand APIs (`tilizeA_B_reduce_init`, `matmul_init`, `add_tiles_init`).

## Root cause

Regular `tilize_init` only uses srcA, so `state_configure<Operand::SRCA, Operand::PACK>` is correct there. `fast_tilize_init` was modeled after it but the developer didn't account for fast tilize also configuring srcB.

## Test plan

- [ ] Existing fast tilize tests pass
- [ ] Verify sentinel correctly injects srcB reconfig when transitioning to/from fast_tilize

🤖 Generated with [Claude Code](https://claude.com/claude-code)