### PR TITLE
Ncvetkovic/high power usage workload

### DIFF
--- a/power_perf_tradeoff.md
+++ b/power_perf_tradeoff.md
@@ -1,0 +1,194 @@
+# Power vs. Performance Tradeoff on Tenstorrent Hardware
+
+## Context
+
+The researcher has already demonstrated that power consumption can be measured and graphed on
+Wormhole hardware using tt-sim and tt-telemetry. The power-vs-cores curve exists. What is missing
+is the **execution time axis** — a workload that runs on a Wormhole N300 quietbox, sweeps the number
+of active Tensix cores, and produces a matching latency-vs-cores curve.
+
+Once both curves exist on the same x-axis, the story tells itself:
+
+> *"For this workload, 24 cores delivers 92% of the performance of 48 cores at roughly half the power.
+> Everything to the right of that point is efficiency you are paying for but not getting."*
+
+---
+
+## Hardware
+
+- **Platform**: Wormhole B0 quietbox, N300 card
+- **N300**: two WH chips on a single card; for single-chip inference workloads the compute grid per
+  chip is **8 × 8 = 64 Tensix cores**
+- The sweep runs on one chip; the power reading from the researcher's telemetry covers the card as a
+  whole, which is fine — the active-chip contribution dominates and the relationship is consistent
+
+---
+
+## The Combined Graph
+
+```
+      time (ms)           power (W)
+          │\                  │             /
+          │ \                 │            /
+          │  \__              │           /
+          │      \____        │          /
+          │           \_____  │_________/
+          └────────────────── └──────────────
+                    ↑ cores ↑
+               sweet spot: time curve
+               has flattened, power
+               curve has not
+```
+
+The x-axis is number of active Tensix cores. The researcher overlays their power curve on top of
+the latency curve we produce. The knee — where latency stops improving but power keeps climbing —
+is the recommended operating point.
+
+---
+
+## What We Already Have
+
+Branch `ncvetkovic/high_power_usage_workload` contains a C++ programming example at
+`tt_metal/programming_examples/high_power_matmul/` that:
+
+- Runs a configurable HiFi4 matmul with fixed total FLOPs across a variable number of cores
+- Accepts `num_cores` as a CLI argument; total work is held constant so the latency change is
+  purely a function of how many cores share it
+- Reports per-iteration wall-clock latency
+
+A full WH N300 sweep (one chip, multiples of 8 for clean row alignment):
+
+```bash
+BIN=./build/programming_examples/metal_example_high_power_matmul
+for cores in 8 16 24 32 40 48 56 64; do
+    echo -n "cores=$cores  "
+    $BIN 4096 4096 4096 100 $cores 2>/dev/null | grep "Per-iteration"
+done
+```
+
+This infrastructure is the foundation for both approaches below.
+
+---
+
+## Approach A — Matmul Sweep with LLM-Representative Shapes
+
+### What it is
+
+The existing example, with matrix dimensions chosen to match the dominant ops in a real 7B-parameter
+LLM (Llama-7B / Falcon-7B weight projection layers). No model weights are needed. The argument to
+the researcher is: *"this is the op that accounts for ~90% of compute time in this model's inference."*
+
+### Two shapes, two stories
+
+| Mode | Shape | Character | Expected latency curve |
+|------|-------|-----------|------------------------|
+| **Decode** (1 token at a time) | `[32, 4096] × [4096, 4096]` | Memory-bandwidth-bound | Nearly flat — adding cores does almost nothing |
+| **Prefill** (seq=2048, prompt processing) | `[2048, 4096] × [4096, 4096]` | Compute-bound | Clearly sloping — each core reduces latency proportionally |
+
+Plotting both on the same chart makes a second, complementary point: **the power-efficiency case
+is strongest for decode**, which is exactly the hot path in interactive LLM serving.
+
+### How to run
+
+```bash
+BIN=./build/programming_examples/metal_example_high_power_matmul
+
+echo "=== Decode (memory-bound) ==="
+for cores in 8 16 24 32 40 48 56 64; do
+    printf "cores=%-3s  " $cores
+    $BIN 32 4096 4096 500 $cores 2>/dev/null | grep "Per-iteration"
+done
+
+echo ""
+echo "=== Prefill (compute-bound) ==="
+for cores in 8 16 24 32 40 48 56 64; do
+    printf "cores=%-3s  " $cores
+    $BIN 2048 4096 4096 100 $cores 2>/dev/null | grep "Per-iteration"
+done
+```
+
+Run these while the researcher's telemetry is recording. The decode sweep is the one to highlight —
+the latency curve will be nearly flat while the researcher's power curve will be linear, making the
+efficiency waste explicit.
+
+### Effort
+
+**None** — the binary already exists on this branch. Swap in the shapes above and run.
+
+---
+
+## Approach B — Full Model Sweep on SentenceBERT
+
+### What it is
+
+Run the full SentenceBERT model (12-layer BERT-base encoder) end-to-end at varying core counts,
+measuring inference latency per batch. SentenceBERT is already validated and has a performant
+traced runner on Wormhole B0:
+
+```
+models/demos/wormhole/sentence_bert/tests/perf/test_sentence_bert_e2e_performant.py
+```
+
+The headline the researcher can publish:
+
+> *"SentenceBERT, batch=8, seq=384, N300: reducing active cores from 48 → 24 costs ~8% latency,
+> saves ~40% power."*
+
+This is a complete, attributable finding on a named model with a known use case (sentence
+embeddings for semantic search / RAG pipelines), which gives it real-world weight.
+
+### Technical details
+
+All op configs in `models/demos/wormhole/sentence_bert/ttnn/common.py` hardcode
+`compute_with_storage_grid_size=(6, 8)` = 48 cores. The 2D multicast matmul tiling means
+both grid dimensions drive the blocking factors — you cannot change the grid without
+recomputing them.
+
+The QKV fused projection constrains `grid_x` to 6 (its output has 72 tiles, which 8 does not
+divide). So the sweep holds `grid_x = 6` and varies `grid_y`, giving four data points:
+
+| Config | Active cores | `per_core_M` | Status |
+|--------|-------------|--------------|--------|
+| `(6, 1)` | 6 | 96 tiles | Needs L1 fit verification |
+| `(6, 2)` | 12 | 48 tiles | |
+| `(6, 4)` | 24 | 24 tiles | |
+| `(6, 8)` | 48 | 12 tiles | Current baseline |
+
+With `grid_x` fixed, `per_core_N`, `in0_block_w`, and the weight-direction subblock sizes are
+unchanged across all configs. Only `per_core_M` and `out_subblock_h` need recalculating per
+grid size.
+
+### What needs to be built
+
+1. **Parameterise `common.py`**: replace the hardcoded `(6, 8)` in each of the 7 program configs
+   with a function that accepts `grid_y` and returns the correct config. The only value that
+   changes is `per_core_M = 96 // grid_y`; `out_subblock_h` needs to be the largest divisor of
+   `per_core_M` such that `out_subblock_h × out_subblock_w ≤ 8`.
+
+2. **Thread `grid_y` through the runner**: `SentenceBERTPerformantRunner` →
+   `SentenceBERTPerformanceRunnerInfra` → model construction. Each core count requires a
+   fresh trace capture (the trace is compiled against a specific grid).
+
+3. **Write the sweep script**: for each `grid_y` in `[1, 2, 4, 8]`, instantiate the model,
+   capture the trace, run 50 iterations, record average latency, release. Run while telemetry
+   is recording.
+
+### Effort
+
+**~4 hours** of engineering work. Requires the model weights (downloaded automatically on
+first run via HuggingFace).
+
+---
+
+## Recommendation
+
+Run **Approach A first**. The binary is ready today; the decode sweep with Llama-7B shapes will
+produce the latency curve in under an hour and can be overlaid with the researcher's existing
+power data immediately. This validates the joint graph and confirms the knee is visible in the data.
+
+**Approach B** is the stronger demo artefact — a named model with a quotable finding — and is
+worth the half-day of engineering once the methodology is confirmed with Approach A.
+
+The `(6, 4)` = 24-core config in Approach B is the one to highlight: it sits just past the likely
+knee, and the power saving relative to the 48-core baseline is the concrete number to put in any
+write-up.

--- a/tt_metal/programming_examples/CMakeLists.txt
+++ b/tt_metal/programming_examples/CMakeLists.txt
@@ -30,6 +30,7 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/NoC_tile_transfer)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/sfpu_eltwise_chain)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/custom_sfpi_add)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/custom_sfpi_smoothstep)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/high_power_matmul)
 
 add_custom_target(
     programming_examples

--- a/tt_metal/programming_examples/high_power_matmul/CMakeLists.txt
+++ b/tt_metal/programming_examples/high_power_matmul/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_executable(metal_example_high_power_matmul)
+target_sources(metal_example_high_power_matmul PRIVATE high_power_matmul.cpp)
+
+if(NOT TARGET TT::Metalium)
+    find_package(TT-Metalium REQUIRED)
+endif()
+
+target_link_libraries(metal_example_high_power_matmul PRIVATE TT::Metalium)
+
+if(TARGET TT::CommonPCH)
+    target_precompile_headers(metal_example_high_power_matmul REUSE_FROM TT::CommonPCH)
+endif()

--- a/tt_metal/programming_examples/high_power_matmul/README.md
+++ b/tt_metal/programming_examples/high_power_matmul/README.md
@@ -1,0 +1,55 @@
+# High Power Matmul Workload
+
+*Read this whole doc before running anything. It's quite small so it won't take much time!*
+
+Sustained HiFi4 matmul across all cores for power draw measurement.
+
+C++ Test: `tt_metal/programming_examples/high_power_matmul/high_power_matmul.cpp`
+Compute kernel: `tt_metal/programming_examples/high_power_matmul/kernels/compute/mm_power.cpp`
+Data Movement kernels: `tt_metal/programming_examples/high_power_matmul/kernels/dataflow`
+
+## Build
+
+```bash
+./build_metal.sh --build-programming-examples
+export TT_METAL_HOME=$(pwd) PYTHONPATH=$(pwd)
+```
+
+*Note*: You don't need to rebuild if you're changing the kernels, they're JIT compiled. You do need to recompile if you're changing the C++ test.
+
+You can put printing statements inside the kernels to debug/instrument the code, see example below. Please note that they add a small execution overhead, although since we're not debugging race conditions (yet), this might not matter. For more details ask Deepwiki or look at the tt-metal documentation.
+
+## Run
+
+To run the test with predefined values:
+```bash
+./build/programming_examples/metal_example_high_power_matmul
+```
+
+*Defaults*: 4096×4096×2048 (datums, not tiles), HiFi4, 500 iterations.
+
+## Custom parameters
+
+```bash
+./build/programming_examples/metal_example_high_power_matmul [M] [N] [K] [iterations]
+```
+
+Examples:
+```bash
+# Longer, more compute-bound run
+./build/programming_examples/metal_example_high_power_matmul 4096 4096 4096 1000
+
+# Quick sanity check
+./build/programming_examples/metal_example_high_power_matmul 2048 2048 2048 100
+
+# If you wish to print out the iteration progress:
+TT_METAL_DPRINT_CORES=0,0 ./build/programming_examples/metal_example_high_power_matmul 2048 2048 2048 500
+```
+
+All dimensions must be multiples of 32 (tile size)!
+
+## Tuning for more power
+
+- **Larger K** → more compute per output tile (more compute-bound)
+- **More iterations** → longer sustained power draw
+- **Larger M×N** → more output tiles across cores

--- a/tt_metal/programming_examples/high_power_matmul/README.md
+++ b/tt_metal/programming_examples/high_power_matmul/README.md
@@ -2,7 +2,8 @@
 
 *Read this whole doc before running anything. It's quite small so it won't take much time!*
 
-Sustained HiFi4 matmul across all cores for power draw measurement.
+Sustained HiFi4 matmul with configurable core count for power draw and performance measurement.
+Sweep `num_cores` to produce a cores-vs-execution-time curve that can be crossed with power graphs.
 
 C++ Test: `tt_metal/programming_examples/high_power_matmul/high_power_matmul.cpp`
 Compute kernel: `tt_metal/programming_examples/high_power_matmul/kernels/compute/mm_power.cpp`
@@ -26,27 +27,51 @@ To run the test with predefined values:
 ./build/programming_examples/metal_example_high_power_matmul
 ```
 
-*Defaults*: 4096×4096×2048 (datums, not tiles), HiFi4, 500 iterations.
+*Defaults*: 4096×4096×4096 (datums, not tiles), HiFi4, 500 iterations, all cores.
 
 ## Custom parameters
 
 ```bash
-./build/programming_examples/metal_example_high_power_matmul [M] [N] [K] [iterations]
+./build/programming_examples/metal_example_high_power_matmul [M] [N] [K] [iterations] [num_cores]
 ```
+
+`num_cores` is snapped down to the nearest whole number of rows in the compute grid (e.g. on
+Blackhole with an 8-wide grid: 15 → 8, 20 → 16). Omit or pass 0 to use all cores.
 
 Examples:
 ```bash
-# Longer, more compute-bound run
+# Longer, more compute-bound run on all cores
 ./build/programming_examples/metal_example_high_power_matmul 4096 4096 4096 1000
 
 # Quick sanity check
 ./build/programming_examples/metal_example_high_power_matmul 2048 2048 2048 100
+
+# Run on exactly 8 cores (one row on Blackhole)
+./build/programming_examples/metal_example_high_power_matmul 4096 4096 4096 500 8
 
 # If you wish to print out the iteration progress:
 TT_METAL_DPRINT_CORES=0,0 ./build/programming_examples/metal_example_high_power_matmul 2048 2048 2048 500
 ```
 
 All dimensions must be multiples of 32 (tile size)!
+
+## Cores-vs-time sweep (for crossing with power graphs)
+
+Keep M, N, K, and iterations fixed, sweep `num_cores`. Example for Blackhole (13×10 = 130 cores):
+
+```bash
+BIN=./build/programming_examples/metal_example_high_power_matmul
+for cores in 13 26 39 52 65 78 91 104 117 130; do
+    echo -n "cores=$cores  "
+    $BIN 4096 4096 4096 100 $cores 2>/dev/null | grep "Per-iteration"
+done
+```
+
+`num_cores` snaps down to whole rows, so pass multiples of the grid width (13 on Blackhole) to
+get exactly the requested count. The binary prints the actual grid used.
+
+This produces the execution-time axis. Cross it against your power readings (sampled at the same
+`num_cores` values) to find the efficiency knee.
 
 ## Tuning for more power
 

--- a/tt_metal/programming_examples/high_power_matmul/high_power_matmul.cpp
+++ b/tt_metal/programming_examples/high_power_matmul/high_power_matmul.cpp
@@ -1,0 +1,244 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//
+// High-power matmul workload for sustained power draw measurement.
+//
+// Runs a large HiFi4 matrix multiplication across all available cores for many
+// iterations, producing near-maximum compute utilization and power consumption.
+//
+// Usage:
+//   ./metal_example_high_power_matmul [M] [N] [K] [iterations]
+//
+// Defaults: M=4096 N=4096 K=2048 iterations=500
+// All dimensions must be multiples of 32 (tile size).
+//
+
+#include <chrono>
+#include <random>
+
+#include <fmt/core.h>
+#include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/tilize_utils.hpp>
+#include <tt-metalium/work_split.hpp>
+
+using namespace tt::constants;
+using namespace tt;
+using namespace tt::tt_metal;
+
+#ifndef OVERRIDE_KERNEL_PREFIX
+#define OVERRIDE_KERNEL_PREFIX ""
+#endif
+
+int main(int argc, char* argv[]) {
+    uint32_t M = 4096;
+    uint32_t N = 4096;
+    uint32_t K = 4096;
+    uint32_t num_iterations = 500;
+
+    if (argc >= 2) {
+        M = std::stoul(argv[1]);
+    }
+    if (argc >= 3) {
+        N = std::stoul(argv[2]);
+    }
+    if (argc >= 4) {
+        K = std::stoul(argv[3]);
+    }
+    if (argc >= 5) {
+        num_iterations = std::stoul(argv[4]);
+    }
+
+    TT_FATAL(M % TILE_HEIGHT == 0, "M ({}) must be divisible by TILE_HEIGHT ({})", M, TILE_HEIGHT);
+    TT_FATAL(N % TILE_WIDTH == 0, "N ({}) must be divisible by TILE_WIDTH ({})", N, TILE_WIDTH);
+    TT_FATAL(K % TILE_WIDTH == 0, "K ({}) must be divisible by TILE_WIDTH ({})", K, TILE_WIDTH);
+
+    const uint32_t Mt = M / TILE_HEIGHT;
+    const uint32_t Kt = K / TILE_WIDTH;
+    const uint32_t Nt = N / TILE_WIDTH;
+    const uint32_t total_output_tiles = Mt * Nt;
+
+    double flops_per_iter = 2.0 * M * N * K;
+    double total_flops = flops_per_iter * num_iterations;
+
+    fmt::print("=== High Power Matmul Workload ===\n");
+    fmt::print("Matrix: M={} N={} K={} (tiles: {}x{}x{})\n", M, N, K, Mt, Nt, Kt);
+    fmt::print("Output tiles: {}  |  Iterations: {}\n", total_output_tiles, num_iterations);
+    fmt::print("Math fidelity: HiFi4  |  Data format: Float16_b\n");
+    fmt::print("Expected FLOPs: {:.2e}\n\n", total_flops);
+
+    try {
+        constexpr int device_id = 0;
+        auto mesh_device = distributed::MeshDevice::create_unit_mesh(device_id);
+        auto& cq = mesh_device->mesh_command_queue();
+
+        auto core_grid = mesh_device->compute_with_storage_grid_size();
+        fmt::print("Compute grid: {}x{} ({} cores)\n", core_grid.x, core_grid.y, core_grid.x * core_grid.y);
+
+        auto [num_cores, all_cores, core_group_1, core_group_2, work_per_core1, work_per_core2] =
+            split_work_to_cores(core_grid, total_output_tiles);
+
+        fmt::print("Active cores: {}  |  Tiles/core: {}", num_cores, work_per_core1);
+        if (work_per_core2 > 0) {
+            fmt::print(" / {}", work_per_core2);
+        }
+        fmt::print("\n\n");
+
+        Program program{};
+        constexpr uint32_t single_tile_size = sizeof(bfloat16) * TILE_HEIGHT * TILE_WIDTH;
+
+        // DRAM buffers
+        distributed::DeviceLocalBufferConfig dram_config{
+            .page_size = single_tile_size, .buffer_type = BufferType::DRAM};
+
+        auto src0_dram = distributed::MeshBuffer::create(
+            distributed::ReplicatedBufferConfig{.size = single_tile_size * Mt * Kt}, dram_config, mesh_device.get());
+        auto src1_dram = distributed::MeshBuffer::create(
+            distributed::ReplicatedBufferConfig{.size = single_tile_size * Kt * Nt}, dram_config, mesh_device.get());
+        auto dst_dram = distributed::MeshBuffer::create(
+            distributed::ReplicatedBufferConfig{.size = single_tile_size * Mt * Nt}, dram_config, mesh_device.get());
+
+        // Circular buffers (double-buffered)
+        const auto cb_fmt = tt::DataFormat::Float16_b;
+        constexpr uint32_t num_cb_tiles = 2;
+
+        tt_metal::CreateCircularBuffer(
+            program,
+            all_cores,
+            CircularBufferConfig(num_cb_tiles * single_tile_size, {{CBIndex::c_0, cb_fmt}})
+                .set_page_size(CBIndex::c_0, single_tile_size));
+        tt_metal::CreateCircularBuffer(
+            program,
+            all_cores,
+            CircularBufferConfig(num_cb_tiles * single_tile_size, {{CBIndex::c_1, cb_fmt}})
+                .set_page_size(CBIndex::c_1, single_tile_size));
+        tt_metal::CreateCircularBuffer(
+            program,
+            all_cores,
+            CircularBufferConfig(num_cb_tiles * single_tile_size, {{CBIndex::c_16, cb_fmt}})
+                .set_page_size(CBIndex::c_16, single_tile_size));
+
+        // Reader kernel
+        std::vector<uint32_t> reader_ct_args;
+        TensorAccessorArgs(*src0_dram).append_to(reader_ct_args);
+        TensorAccessorArgs(*src1_dram).append_to(reader_ct_args);
+
+        auto reader_id = tt_metal::CreateKernel(
+            program,
+            OVERRIDE_KERNEL_PREFIX "high_power_matmul/kernels/dataflow/reader_power.cpp",
+            all_cores,
+            DataMovementConfig{
+                .processor = DataMovementProcessor::RISCV_1,
+                .noc = NOC::RISCV_1_default,
+                .compile_args = reader_ct_args});
+
+        // Writer kernel
+        std::vector<uint32_t> writer_ct_args;
+        TensorAccessorArgs(*dst_dram).append_to(writer_ct_args);
+
+        auto writer_id = tt_metal::CreateKernel(
+            program,
+            OVERRIDE_KERNEL_PREFIX "high_power_matmul/kernels/dataflow/writer_power.cpp",
+            all_cores,
+            DataMovementConfig{
+                .processor = DataMovementProcessor::RISCV_0,
+                .noc = NOC::RISCV_0_default,
+                .compile_args = writer_ct_args});
+
+        // Compute kernel (HiFi4)
+        auto compute_id = tt_metal::CreateKernel(
+            program,
+            OVERRIDE_KERNEL_PREFIX "high_power_matmul/kernels/compute/mm_power.cpp",
+            all_cores,
+            ComputeConfig{.math_fidelity = MathFidelity::HiFi4});
+
+        // Per-core runtime args
+        uint32_t work_offset = 0;
+        auto work_groups = {std::make_pair(core_group_1, work_per_core1), std::make_pair(core_group_2, work_per_core2)};
+
+        for (const auto& [ranges, work_per_core] : work_groups) {
+            for (const auto& range : ranges.ranges()) {
+                for (const auto& core : range) {
+                    tt_metal::SetRuntimeArgs(
+                        program,
+                        reader_id,
+                        core,
+                        {src0_dram->address(),
+                         src1_dram->address(),
+                         Mt,
+                         Kt,
+                         Nt,
+                         work_offset,
+                         work_per_core,
+                         num_iterations});
+
+                    tt_metal::SetRuntimeArgs(
+                        program, writer_id, core, {dst_dram->address(), work_per_core, work_offset, num_iterations});
+
+                    tt_metal::SetRuntimeArgs(program, compute_id, core, {work_per_core, Kt, num_iterations});
+
+                    work_offset += work_per_core;
+                }
+            }
+        }
+
+        // Fill input buffers with random data
+        fmt::print("Generating and uploading input data...\n");
+        std::mt19937 rng(42);
+        std::uniform_real_distribution<float> dist(-0.5f, 0.5f);
+
+        std::vector<bfloat16> src0_vec(M * K);
+        std::vector<bfloat16> src1_vec(K * N);
+        for (auto& v : src0_vec) {
+            v = bfloat16(dist(rng));
+        }
+        for (auto& v : src1_vec) {
+            v = bfloat16(dist(rng));
+        }
+
+        src0_vec = tilize_nfaces(src0_vec, M, K);
+        src1_vec = tilize_nfaces(src1_vec, K, N);
+
+        distributed::EnqueueWriteMeshBuffer(cq, src0_dram, src0_vec, false);
+        distributed::EnqueueWriteMeshBuffer(cq, src1_dram, src1_vec, false);
+
+        // Execute workload
+        fmt::print(
+            "Running {} iterations of {}x{}x{} HiFi4 matmul on {} cores...\n", num_iterations, M, N, K, num_cores);
+
+        distributed::MeshWorkload workload;
+        distributed::MeshCoordinateRange device_range(mesh_device->shape());
+        workload.add_program(device_range, std::move(program));
+
+        auto t_start = std::chrono::high_resolution_clock::now();
+        distributed::EnqueueMeshWorkload(cq, workload, false);
+
+        // Blocking read to wait for completion
+        std::vector<bfloat16> result_vec(Mt * Nt * TILE_HW);
+        distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_dram, true);
+        auto t_end = std::chrono::high_resolution_clock::now();
+
+        double elapsed_s = std::chrono::duration<double>(t_end - t_start).count();
+        double tflops = total_flops / elapsed_s / 1e12;
+
+        fmt::print("\n=== Results ===\n");
+        fmt::print("Total time:       {:.3f} s\n", elapsed_s);
+        fmt::print("Throughput:       {:.2f} TFLOPS\n", tflops);
+        fmt::print("Per-iteration:    {:.3f} ms\n", elapsed_s * 1000.0 / num_iterations);
+        fmt::print("Test Passed\n");
+
+        mesh_device->close();
+
+    } catch (const std::exception& e) {
+        fmt::print(stderr, "Test failed: {}\n", e.what());
+        throw;
+    }
+
+    return 0;
+}

--- a/tt_metal/programming_examples/high_power_matmul/high_power_matmul.cpp
+++ b/tt_metal/programming_examples/high_power_matmul/high_power_matmul.cpp
@@ -5,14 +5,16 @@
 //
 // High-power matmul workload for sustained power draw measurement.
 //
-// Runs a large HiFi4 matrix multiplication across all available cores for many
-// iterations, producing near-maximum compute utilization and power consumption.
+// Runs a large HiFi4 matrix multiplication across a configurable number of
+// cores for many iterations, producing near-maximum compute utilization.
+// Sweep num_cores to produce a cores-vs-execution-time curve.
 //
 // Usage:
-//   ./metal_example_high_power_matmul [M] [N] [K] [iterations]
+//   ./metal_example_high_power_matmul [M] [N] [K] [iterations] [num_cores]
 //
-// Defaults: M=4096 N=4096 K=2048 iterations=500
+// Defaults: M=4096 N=4096 K=4096 iterations=500 num_cores=all
 // All dimensions must be multiples of 32 (tile size).
+// num_cores is snapped down to whole rows of the compute grid.
 //
 
 #include <chrono>
@@ -41,6 +43,7 @@ int main(int argc, char* argv[]) {
     uint32_t N = 4096;
     uint32_t K = 4096;
     uint32_t num_iterations = 500;
+    uint32_t requested_cores = 0;  // 0 = use all available
 
     if (argc >= 2) {
         M = std::stoul(argv[1]);
@@ -53,6 +56,9 @@ int main(int argc, char* argv[]) {
     }
     if (argc >= 5) {
         num_iterations = std::stoul(argv[4]);
+    }
+    if (argc >= 6) {
+        requested_cores = std::stoul(argv[5]);
     }
 
     TT_FATAL(M % TILE_HEIGHT == 0, "M ({}) must be divisible by TILE_HEIGHT ({})", M, TILE_HEIGHT);
@@ -79,10 +85,27 @@ int main(int argc, char* argv[]) {
         auto& cq = mesh_device->mesh_command_queue();
 
         auto core_grid = mesh_device->compute_with_storage_grid_size();
-        fmt::print("Compute grid: {}x{} ({} cores)\n", core_grid.x, core_grid.y, core_grid.x * core_grid.y);
+        uint32_t total_available_cores = core_grid.x * core_grid.y;
+        fmt::print("Compute grid: {}x{} ({} cores)\n", core_grid.x, core_grid.y, total_available_cores);
+
+        // Build effective grid from requested_cores, snapping down to whole rows.
+        CoreCoord effective_grid = core_grid;
+        if (requested_cores > 0 && requested_cores < total_available_cores) {
+            if (requested_cores <= core_grid.x) {
+                effective_grid = {requested_cores, 1};
+            } else {
+                effective_grid = {core_grid.x, requested_cores / core_grid.x};
+            }
+            fmt::print(
+                "Requested cores: {}  →  using {}x{} = {} cores\n",
+                requested_cores,
+                effective_grid.x,
+                effective_grid.y,
+                effective_grid.x * effective_grid.y);
+        }
 
         auto [num_cores, all_cores, core_group_1, core_group_2, work_per_core1, work_per_core2] =
-            split_work_to_cores(core_grid, total_output_tiles);
+            split_work_to_cores(effective_grid, total_output_tiles);
 
         fmt::print("Active cores: {}  |  Tiles/core: {}", num_cores, work_per_core1);
         if (work_per_core2 > 0) {

--- a/tt_metal/programming_examples/high_power_matmul/kernels/compute/mm_power.cpp
+++ b/tt_metal/programming_examples/high_power_matmul/kernels/compute/mm_power.cpp
@@ -23,7 +23,7 @@ void kernel_main() {
     for (uint32_t iter = 0; iter < num_iterations; iter++) {
         if (iter % 10 == 0) {
             // Only print from TRISC0, otherwise we'll get three identical prints
-            UNPACKER(DPRINT << "Iteration " << iter << " of " << num_iterations << ENDL();)
+            UNPACK((DPRINT << "Iteration " << iter << " of " << num_iterations << ENDL()));
         }
         for (uint32_t i = 0; i < num_output_tiles; i++) {
             // TRISC1 Acquires the tile registers

--- a/tt_metal/programming_examples/high_power_matmul/kernels/compute/mm_power.cpp
+++ b/tt_metal/programming_examples/high_power_matmul/kernels/compute/mm_power.cpp
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "api/compute/matmul.h"
+#include "api/compute/tile_move_copy.h"
+
+using std::uint32_t;
+
+void kernel_main() {
+    uint32_t num_output_tiles = get_arg_val<uint32_t>(0);
+    uint32_t Kt = get_arg_val<uint32_t>(1);
+    uint32_t num_iterations = get_arg_val<uint32_t>(2);
+
+    constexpr tt::CBIndex cb_in0 = tt::CBIndex::c_0;
+    constexpr tt::CBIndex cb_in1 = tt::CBIndex::c_1;
+    constexpr tt::CBIndex cb_out = tt::CBIndex::c_16;
+
+    // Initialize the matmul operation
+    mm_init(cb_in0, cb_in1, cb_out);
+
+    for (uint32_t iter = 0; iter < num_iterations; iter++) {
+        if (iter % 10 == 0) {
+            // Only print from TRISC0, otherwise we'll get three identical prints
+            UNPACKER(DPRINT << "Iteration " << iter << " of " << num_iterations << ENDL();)
+        }
+        for (uint32_t i = 0; i < num_output_tiles; i++) {
+            // TRISC1 Acquires the tile registers
+            tile_regs_acquire();
+            for (uint32_t kt = 0; kt < Kt; kt++) {
+                // TRISC0 waits for the input tiles to be available in the input circular buffers in SRAM (reader kernel
+                // populates them)
+                cb_wait_front(cb_in0, 1);
+                cb_wait_front(cb_in1, 1);
+                // TRISC0 tells the FPU to performs the matrix multiplication
+                matmul_tiles(cb_in0, cb_in1, 0, 0, 0);
+                // TRISC1 marks the input tiles as used by popping them from the front of the circular buffers
+                cb_pop_front(cb_in0, 1);
+                cb_pop_front(cb_in1, 1);
+            }
+            // TRISC1 commits the results, transferring ownership of the tile registers to the packer (TRISC2)
+            tile_regs_commit();
+            // TRISC2 waits for the FPU (TRISC1) to be ready
+            tile_regs_wait();
+            // TRISC2 reserves space in the output circular buffer for the result tile
+            cb_reserve_back(cb_out, 1);
+            // TRISC2 tells the packer to pack the result tile into the output circular buffer
+            pack_tile(0, cb_out);
+            // TRISC2 marks the result tile as used by pushing it to the back of the output circular buffer (writer
+            // kernel can read them now)
+            cb_push_back(cb_out, 1);
+            // TRISC1 releases the tile registers, allowing TRISC0 to acquire them again for the next iteration
+            tile_regs_release();
+        }
+    }
+}

--- a/tt_metal/programming_examples/high_power_matmul/kernels/compute/mm_power.cpp
+++ b/tt_metal/programming_examples/high_power_matmul/kernels/compute/mm_power.cpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include "api/compute/matmul.h"
 #include "api/compute/tile_move_copy.h"
+#include "api/debug/dprint.h"
 
 using std::uint32_t;
 
@@ -22,8 +23,7 @@ void kernel_main() {
 
     for (uint32_t iter = 0; iter < num_iterations; iter++) {
         if (iter % 10 == 0) {
-            // Only print from TRISC0, otherwise we'll get three identical prints
-            UNPACK((DPRINT << "Iteration " << iter << " of " << num_iterations << ENDL()));
+            DPRINT_UNPACK(DPRINT << "Iteration " << iter << " of " << num_iterations << ENDL());
         }
         for (uint32_t i = 0; i < num_output_tiles; i++) {
             // TRISC1 Acquires the tile registers

--- a/tt_metal/programming_examples/high_power_matmul/kernels/dataflow/reader_power.cpp
+++ b/tt_metal/programming_examples/high_power_matmul/kernels/dataflow/reader_power.cpp
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+
+void kernel_main() {
+    uint32_t src0_addr = get_arg_val<uint32_t>(0);
+    uint32_t src1_addr = get_arg_val<uint32_t>(1);
+    uint32_t Mt = get_arg_val<uint32_t>(2);
+    uint32_t Kt = get_arg_val<uint32_t>(3);
+    uint32_t Nt = get_arg_val<uint32_t>(4);
+    uint32_t output_tile_start_id = get_arg_val<uint32_t>(5);
+    uint32_t num_output_tiles = get_arg_val<uint32_t>(6);
+    uint32_t num_iterations = get_arg_val<uint32_t>(7);
+
+    constexpr uint32_t cb_id_in0 = tt::CBIndex::c_0;
+    constexpr uint32_t cb_id_in1 = tt::CBIndex::c_1;
+
+    const uint32_t in0_tile_bytes = get_tile_size(cb_id_in0);
+    const uint32_t in1_tile_bytes = get_tile_size(cb_id_in1);
+
+    constexpr auto a_args = TensorAccessorArgs<0>();
+    const auto a = TensorAccessor(a_args, src0_addr, in0_tile_bytes);
+    constexpr auto b_args = TensorAccessorArgs<a_args.next_compile_time_args_offset()>();
+    const auto b = TensorAccessor(b_args, src1_addr, in1_tile_bytes);
+
+    for (uint32_t iter = 0; iter < num_iterations; iter++) {
+        for (uint32_t output_tile = 0; output_tile < num_output_tiles; output_tile++) {
+            uint32_t current_tile_id = output_tile_start_id + output_tile;
+            uint32_t out_row = current_tile_id / Nt;
+            uint32_t out_col = current_tile_id % Nt;
+
+            for (uint32_t k = 0; k < Kt; k++) {
+                {
+                    uint32_t tile_A = out_row * Kt + k;
+                    cb_reserve_back(cb_id_in0, 1);
+                    uint32_t l1_addr = get_write_ptr(cb_id_in0);
+                    noc_async_read_tile(tile_A, a, l1_addr);
+                    noc_async_read_barrier();
+                    cb_push_back(cb_id_in0, 1);
+                }
+                {
+                    uint32_t tile_B = k * Nt + out_col;
+                    cb_reserve_back(cb_id_in1, 1);
+                    uint32_t l1_addr = get_write_ptr(cb_id_in1);
+                    noc_async_read_tile(tile_B, b, l1_addr);
+                    noc_async_read_barrier();
+                    cb_push_back(cb_id_in1, 1);
+                }
+            }
+        }
+    }
+}

--- a/tt_metal/programming_examples/high_power_matmul/kernels/dataflow/writer_power.cpp
+++ b/tt_metal/programming_examples/high_power_matmul/kernels/dataflow/writer_power.cpp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/dataflow/dataflow_api.h"
+
+void kernel_main() {
+    uint32_t dst_addr = get_arg_val<uint32_t>(0);
+    uint32_t num_tiles = get_arg_val<uint32_t>(1);
+    uint32_t start_id = get_arg_val<uint32_t>(2);
+    uint32_t num_iterations = get_arg_val<uint32_t>(3);
+
+    constexpr uint32_t cb_id_out = tt::CBIndex::c_16;
+    const uint32_t tile_bytes = get_tile_size(cb_id_out);
+
+    constexpr auto c_args = TensorAccessorArgs<0>();
+    const auto c = TensorAccessor(c_args, dst_addr, tile_bytes);
+
+    uint32_t end_id = start_id + num_tiles;
+
+    for (uint32_t iter = 0; iter < num_iterations; iter++) {
+        for (uint32_t i = start_id; i < end_id; i++) {
+            cb_wait_front(cb_id_out, 1);
+            uint32_t l1_read_addr = get_read_ptr(cb_id_out);
+            noc_async_write_tile(i, c, l1_read_addr);
+            noc_async_write_barrier();
+            cb_pop_front(cb_id_out, 1);
+        }
+    }
+}


### PR DESCRIPTION
### Ticket
N/A

### Problem description
For a research collab.

### What's changed
Added a new programming example, nothing to see here 😊 

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ncvetkovic/high_power_usage_workload)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ncvetkovic/high_power_usage_workload)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ncvetkovic/high_power_usage_workload)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ncvetkovic/high_power_usage_workload)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ncvetkovic/high_power_usage_workload)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ncvetkovic/high_power_usage_workload)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ncvetkovic/high_power_usage_workload)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ncvetkovic/high_power_usage_workload)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ncvetkovic/high_power_usage_workload)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ncvetkovic/high_power_usage_workload)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ncvetkovic/high_power_usage_workload)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ncvetkovic/high_power_usage_workload)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ncvetkovic/high_power_usage_workload)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ncvetkovic/high_power_usage_workload)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ncvetkovic/high_power_usage_workload)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ncvetkovic/high_power_usage_workload)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ncvetkovic/high_power_usage_workload)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ncvetkovic/high_power_usage_workload)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ncvetkovic/high_power_usage_workload)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ncvetkovic/high_power_usage_workload)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ncvetkovic/high_power_usage_workload)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ncvetkovic/high_power_usage_workload)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ncvetkovic/high_power_usage_workload)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ncvetkovic/high_power_usage_workload)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ncvetkovic/high_power_usage_workload)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ncvetkovic/high_power_usage_workload)