### PR TITLE
Optimized MoE Integration

### DIFF
--- a/models/demos/deepseek_v3/tests/test_decoder_block.py
+++ b/models/demos/deepseek_v3/tests/test_decoder_block.py
@@ -142,7 +142,7 @@ def run_test_forward_pass_decoder2d(
         ccl,
         mla_cache=paged_input_cache,
     )
-    model_shared_state = DecoderBlockClass.create_shared_state(hf_config_short, mesh_device)
+    model_shared_state = DecoderBlockClass.create_shared_state(hf_config_short, mesh_device, fabric_config)
     run_config = create_run_config(model_config, weight_config, model_state, model_shared_state)
 
     # Set up ttnn inputs

--- a/models/demos/deepseek_v3/tests/test_moe.py
+++ b/models/demos/deepseek_v3/tests/test_moe.py
@@ -134,7 +134,7 @@ def test_forward_pass(
     model_state = MoE.create_state(hf_config, mesh_device, ccl)
 
     # Create a new model shared state
-    model_shared_state = MoE.create_shared_state(hf_config, mesh_device)
+    model_shared_state = MoE.create_shared_state(hf_config, mesh_device, device_params["fabric_config"])
 
     # Create RunConfig using both weight_config and model_config
     run_config = create_run_config(model_config, weight_config, model_state, model_shared_state)

--- a/models/demos/deepseek_v3/tt/ccl.py
+++ b/models/demos/deepseek_v3/tt/ccl.py
@@ -42,6 +42,10 @@ class CCL:
                 )
                 self.barrier_sems[-1].append(ttnn.create_global_semaphore(self.mesh_device, self.core_range_set, 0))
 
+        # NOTE: these do not have to be double buffered, due to the synchronization between all_to_all_dispatch_metadata and selective_reduce_combine inside the MoE block
+        self.all_to_all_dispatch_metadata_sem = ttnn.create_global_semaphore(self.mesh_device, self.core_range_set, 0)
+        self.selective_reduce_combine_sem = ttnn.create_global_semaphore(self.mesh_device, self.core_range_set, 0)
+
         # Synchronize the device to ensure that the semaphores are created
         ttnn.synchronize_device(self.mesh_device)
 
@@ -177,6 +181,38 @@ class CCL:
 
         # Get runtime CCL parameters for reduce_scatter
         ccl_params = self.get_ccl_params_for_reduce_scatter(cluster_axis)
+
+        # Merge static config with runtime CCL parameters
+        return {**ccl_config, **ccl_params}
+
+    def populate_all_to_all_dispatch_metadata_args(self, ccl_config: dict) -> dict:
+        """Populate all_to_all_dispatch runtime arguments (semaphore) into the config.
+        Args:
+            ccl_config: Static CCL configuration dict
+        Returns:
+            Complete configuration dict with both static and runtime parameters
+        Example:
+            ttnn.experimental.all_to_all_dispatch_metadata(x, **ccl.populate_all_to_all_dispatch_metadata_args(cfg["all_to_all_dispatch_metadata"]))
+        """
+
+        # Get runtime CCL parameters for all_to_all_dispatch_metadata
+        ccl_params = {"cross_device_semaphore": self.all_to_all_dispatch_metadata_sem}
+
+        # Merge static config with runtime CCL parameters
+        return {**ccl_config, **ccl_params}
+
+    def populate_selective_reduce_combine_args(self, ccl_config: dict) -> dict:
+        """Populate selective_reduce_combine runtime arguments (semaphore) into the config.
+        Args:
+            ccl_config: Static CCL configuration dict
+        Returns:
+            Complete configuration dict with both static and runtime parameters
+        Example:
+            ttnn.experimental.selective_reduce_combine(x, **ccl.populate_selective_reduce_combine_args(cfg["selective_reduce_combine"]))
+        """
+
+        # Get runtime CCL parameters for selective_reduce_combine
+        ccl_params = {"optional_cross_device_semaphore": self.selective_reduce_combine_sem}
 
         # Merge static config with runtime CCL parameters
         return {**ccl_config, **ccl_params}

--- a/models/demos/deepseek_v3/tt/decoder_block/decoder_block_2d.py
+++ b/models/demos/deepseek_v3/tt/decoder_block/decoder_block_2d.py
@@ -63,6 +63,7 @@ class DecoderBlock2D(DecoderBlock2DBase):
         cls,
         hf_config: PretrainedConfig,
         mesh_device: ttnn.MeshDevice,
+        fabric_config: ttnn.FabricConfig,
     ) -> ModelState:
         return {}
 

--- a/models/demos/deepseek_v3/tt/decoder_block/decoder_block_base.py
+++ b/models/demos/deepseek_v3/tt/decoder_block/decoder_block_base.py
@@ -82,12 +82,14 @@ class DecoderBlockBase(SharedStateAddOn, AbstractModule):
         cls,
         hf_config: PretrainedConfig,
         mesh_device: ttnn.MeshDevice,
+        fabric_config: ttnn.FabricConfig,
     ) -> ModelState:
         return {
             MESH_DEVICE_STATE_DICT_KEY: mesh_device,
             "mlp": cls.create_mlp_shared_state(
                 hf_config,
                 mesh_device,
+                fabric_config,
             ),
         }
 
@@ -167,6 +169,7 @@ class DecoderBlockBase(SharedStateAddOn, AbstractModule):
         cls,
         hf_config: PretrainedConfig,
         mesh_device: ttnn.MeshDevice,
+        fabric_config: ttnn.FabricConfig,
     ) -> ModelState:
         """
         Create the shared state for the MLP component of the decoder layer.

--- a/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block_2d.py
+++ b/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block_2d.py
@@ -88,10 +88,11 @@ class MoEDecoderBlock2D(DecoderBlock2DBase):
         cls,
         hf_config: PretrainedConfig,
         mesh_device: ttnn.MeshDevice,
+        fabric_config: ttnn.FabricConfig,
     ) -> ModelState:
         return {
             "shared_expert": {},
-            "moe": MoE.create_shared_state(hf_config, mesh_device),
+            "moe": MoE.create_shared_state(hf_config, mesh_device, fabric_config),
         }
 
     @classmethod

--- a/models/demos/deepseek_v3/tt/model/row_batched_model.py
+++ b/models/demos/deepseek_v3/tt/model/row_batched_model.py
@@ -164,12 +164,14 @@ class RowBatchedModel(SharedStateAddOn, AbstractModule):
                 DecoderBlock2D.create_shared_state(
                     hf_config,
                     mesh_device,
+                    get_fabric_config(),
                 )
             ],
             "moe_decoder_block": [
                 MoEDecoderBlock2D.create_shared_state(
                     hf_config,
                     mesh_device,
+                    get_fabric_config(),
                 )
             ],
         }

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -403,7 +403,7 @@ class MoE(SharedStateAddOn, AbstractModule):
         for start in range(0, seq_len, chunk_size):
             end = min(start + chunk_size, seq_len)
             x_chunk = ttnn.slice(x, [0, 0, start, 0], [x.shape[0], x.shape[1], end, x.shape[3]])
-            output_chunks.append(cls._forward_impl(x_chunk, cfg))
+            output_chunks.append(cls._forward_prefill_impl(x_chunk, cfg))
             ttnn.deallocate(x_chunk)
 
         if len(output_chunks) == 1:

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -547,9 +547,7 @@ class MoE(SharedStateAddOn, AbstractModule):
                 **cfg["quad_ring_moe_compute"],
             )
 
-            ttnn.deallocate(dispatch_output_sparse_buffer)
-            ttnn.deallocate(dispatch_output_expert_indices)
-            ttnn.deallocate(dispatch_output_expert_scores)
+            # NOTE: can't deallocate dispatch output tensors as they are preallocated and reused across layers
 
             combine_output = ttnn.experimental.selective_reduce_combine(
                 compute_output,

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -143,7 +143,9 @@ class MoE(SharedStateAddOn, AbstractModule):
         """
 
         num_experts_per_device = MoEExperts._get_num_experts_per_device(hf_config, mesh_device)
-        expert_mapping_tensor = cls._create_expert_mapping_tensor(mesh_device, mode, num_experts_per_device)
+        expert_mapping_tensor = cls._create_expert_mapping_tensor(
+            mesh_device, fabric_config, mode, num_experts_per_device
+        )
 
         if mode == "decode":
             memory_config = ttnn.L1_MEMORY_CONFIG
@@ -214,7 +216,7 @@ class MoE(SharedStateAddOn, AbstractModule):
             }
 
             # optimized MoE ops only functional for quad torus
-            if ["fabric_config"] == ttnn.FabricConfig.FABRIC_1D_RING and mesh_device.shape[0] == 16:
+            if fabric_config == ttnn.FabricConfig.FABRIC_1D_RING and mesh_device.shape[0] == 16:
                 batch = USERS_PER_ROW * mesh_device.shape[0]
                 seq_len = 1
 
@@ -297,6 +299,7 @@ class MoE(SharedStateAddOn, AbstractModule):
     def _create_expert_mapping_tensor(
         cls,
         mesh_device: ttnn.Device,
+        fabric_config: ttnn.FabricConfig,
         mode: str,
         num_experts_per_device: int,
     ):
@@ -304,7 +307,7 @@ class MoE(SharedStateAddOn, AbstractModule):
         if mode == "decode":
             # optimized MoE ops only functional for quad torus
             num_dispatch_devices = mesh_device.shape[0]
-            if ["fabric_config"] == ttnn.FabricConfig.FABRIC_1D_RING and num_dispatch_devices == 16:
+            if fabric_config == ttnn.FabricConfig.FABRIC_1D_RING and num_dispatch_devices == 16:
                 num_experts = num_devices * num_experts_per_device
                 tp_size = mesh_device.shape[1]
                 num_experts_per_cluster = num_experts // tp_size

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -295,6 +295,7 @@ class MoE(SharedStateAddOn, AbstractModule):
 
     @classmethod
     def _create_expert_mapping_tensor(
+        cls,
         mesh_device: ttnn.Device,
         mode: str,
         num_experts_per_device: int,

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -71,6 +71,7 @@ class MoE(SharedStateAddOn, AbstractModule):
         cls,
         hf_config: PretrainedConfig,
         mesh_device: ttnn.Device,
+        fabric_config: ttnn.FabricConfig,
     ) -> ModelState:
         """Create shared model state containing tensors that are constant across all instances.
 
@@ -80,7 +81,37 @@ class MoE(SharedStateAddOn, AbstractModule):
         Returns:
             ModelState containing shared tensors
         """
+        num_devices = mesh_device.get_num_devices()
+        num_experts_per_device = MoEExperts._get_num_experts_per_device(hf_config, mesh_device)
         num_dispatch_device_rows = mesh_device.shape[0]
+
+        # optimized ops (exclusive to quad with ring fabric) use a different mapping format
+        if fabric_config == ttnn.FabricConfig.FABRIC_1D_RING and num_dispatch_device_rows == 16:
+            num_experts = num_devices * num_experts_per_device
+            tp_size = mesh_device.shape[1]
+            num_experts_per_cluster = num_experts // tp_size
+
+            e = torch.arange(num_experts, dtype=torch.int32)
+            torch_expert_mapping_tensor = (
+                (((e % num_experts_per_cluster) // num_experts_per_device) * tp_size + (e // num_experts_per_cluster))
+                .unsqueeze(0)
+                .repeat(num_devices, 1)
+            )
+        else:
+            torch_expert_mapping_tensor = (
+                torch.eye(num_devices, dtype=torch.int32)
+                .repeat_interleave(num_experts_per_device, dim=0)
+                .unsqueeze(0)
+                .unsqueeze(0)
+            )
+        expert_mapping_tensor = ttnn.from_torch(
+            torch_expert_mapping_tensor,
+            device=mesh_device,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+            dtype=ttnn.uint16,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+        )
 
         remap_topk_mask = ttnn.from_torch(
             torch.ones((1, num_dispatch_device_rows, 1, hf_config.n_routed_experts), dtype=torch.bfloat16),
@@ -91,10 +122,29 @@ class MoE(SharedStateAddOn, AbstractModule):
             layout=ttnn.ROW_MAJOR_LAYOUT,
         )
 
-        return {
+        config = {
+            "expert_mapping_tensor": expert_mapping_tensor,
             "remap_topk_mask": remap_topk_mask,
             MESH_DEVICE_STATE_DICT_KEY: mesh_device,
         }
+
+        # optimized ops (exclusive to quad with ring fabric) require preallocated tensors for all_to_all_dispatch_metadata
+        # TODO: (GR)
+        if fabric_config == ttnn.FabricConfig.FABRIC_1D_RING and num_dispatch_device_rows == 16:
+            batch = USERS_PER_ROW * mesh_device.shape[0]
+            preallocated_all_to_all_dispatch_metadata_tensors = (
+                AllToAllDispatchMetadataConfig.create_preallocated_dispatch_output_tensors(
+                    mesh_device,
+                    batch,
+                    hf_config.hidden_size,
+                    hf_config.num_experts_per_tok,
+                )
+            )
+            config[
+                "quad_ring_preallocated_all_to_all_dispatch_metadata_tensors"
+            ] = preallocated_all_to_all_dispatch_metadata_tensors
+
+        return config
 
     @classmethod
     def create_state(
@@ -143,9 +193,6 @@ class MoE(SharedStateAddOn, AbstractModule):
         """
 
         num_experts_per_device = MoEExperts._get_num_experts_per_device(hf_config, mesh_device)
-        expert_mapping_tensor = cls._create_expert_mapping_tensor(
-            mesh_device, fabric_config, mode, num_experts_per_device
-        )
 
         if mode == "decode":
             memory_config = ttnn.L1_MEMORY_CONFIG
@@ -167,7 +214,7 @@ class MoE(SharedStateAddOn, AbstractModule):
             )
 
             # Construct the config
-            decode_config = {
+            config = {
                 "mesh_device": MeshDeviceStub(mesh_device.shape),
                 "num_devices": mesh_device.get_num_devices(),
                 "fabric_config": fabric_config,
@@ -175,7 +222,6 @@ class MoE(SharedStateAddOn, AbstractModule):
                 "hidden_size": hf_config.hidden_size,
                 "num_experts_per_tok": hf_config.num_experts_per_tok,
                 "num_dispatch_devices": mesh_device.shape[0],
-                "expert_mapping_tensor": expert_mapping_tensor,
                 "moe_gate": MoEGate.model_config(hf_config, mesh_device, mode, topk_fallback=topk_fallback),
                 "all_to_all_dispatch_output_memory_config": memory_config,
                 "all_to_all_dispatch_metadata_memory_config": ttnn.DRAM_MEMORY_CONFIG,
@@ -214,54 +260,11 @@ class MoE(SharedStateAddOn, AbstractModule):
                     cluster_axis=1,
                 ),
             }
-
-            # optimized MoE ops only functional for quad torus
-            if fabric_config == ttnn.FabricConfig.FABRIC_1D_RING and mesh_device.shape[0] == 16:
-                batch = USERS_PER_ROW * mesh_device.shape[0]
-                seq_len = 1
-
-                decode_config["quad_ring_all_to_all_dispatch_metadata"] = AllToAllDispatchMetadataConfig(
-                    cluster_axis=0,
-                    worker_mode=ttnn.WorkerMode.DIRECT,
-                    dispatch_algorithm=ttnn.DispatchAlgorithm.SPARSE_MCAST_SHORTEST_PATH,
-                    output_tensors=AllToAllDispatchMetadataConfig.create_preallocated_dispatch_output_tensors(
-                        mesh_device,
-                        batch,
-                        HIDDEN_SIZE,
-                        hf_config.num_experts_per_tok,
-                    ),
-                )
-                decode_config["quad_ring_moreh_full"] = MorehFullConfig(
-                    shape=ttnn.Shape([hf_config.num_experts_per_tok, USERS_PER_ROW, hf_config.hidden_size]),
-                    fill_value=0,
-                    device=mesh_device,
-                    dtype=torch.bfloat16,
-                    layout=ttnn.ROW_MAJOR_LAYOUT,
-                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                )
-                decode_config["quad_ring_moe_compute"] = MoEComputeConfig(
-                    output_height_shard_dim=4,
-                    output_width_shard_dim=4,
-                    cluster_axis=0,
-                )
-                decode_config["quad_ring_selective_reduce_combine"] = SelectiveReduceCombineConfig(
-                    hidden_size=hf_config.hidden_size,
-                    batch=batch,
-                    seq=seq_len,
-                    select_experts_k=hf_config.num_experts_per_tok,
-                    experts=hf_config.n_routed_experts,
-                    axis=0,
-                    token_parallel_core_dim=4,
-                    data_parallel_core_dim=4,
-                    worker_cores=ttnn.experimental.get_moe_combine_cores(mesh_device),
-                    mux_core_range_set=ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(3, 0), ttnn.CoreCoord(4, 7))}),
-                )
-
-            return decode_config
         else:
             memory_config = ttnn.DRAM_MEMORY_CONFIG
+
             # Construct the config
-            return {
+            config = {
                 "mesh_device": MeshDeviceStub(mesh_device.shape),
                 "num_devices": mesh_device.get_num_devices(),
                 "fabric_config": fabric_config,
@@ -295,57 +298,43 @@ class MoE(SharedStateAddOn, AbstractModule):
                 ),
             }
 
-    @classmethod
-    def _create_expert_mapping_tensor(
-        cls,
-        mesh_device: ttnn.Device,
-        fabric_config: ttnn.FabricConfig,
-        mode: str,
-        num_experts_per_device: int,
-    ):
-        num_devices = mesh_device.get_num_devices()
-        if mode == "decode":
-            # optimized MoE ops only functional for quad torus
-            num_dispatch_devices = mesh_device.shape[0]
-            if fabric_config == ttnn.FabricConfig.FABRIC_1D_RING and num_dispatch_devices == 16:
-                num_experts = num_devices * num_experts_per_device
-                tp_size = mesh_device.shape[1]
-                num_experts_per_cluster = num_experts // tp_size
+        # configs for optimized ops (exclusive to quad with ring fabric)
+        if fabric_config == ttnn.FabricConfig.FABRIC_1D_RING and mesh_device.shape[0] == 16:
+            batch = USERS_PER_ROW * mesh_device.shape[0]
+            seq_len = 1
 
-                e = torch.arange(num_experts, dtype=torch.int32)
-                torch_expert_mapping_tensor = (
-                    (
-                        ((e % num_experts_per_cluster) // num_experts_per_device) * tp_size
-                        + (e // num_experts_per_cluster)
-                    )
-                    .unsqueeze(0)
-                    .repeat(num_devices, 1)
-                )
-            else:
-                torch_expert_mapping_tensor = (
-                    torch.eye(num_devices, dtype=torch.int32)
-                    .repeat_interleave(num_experts_per_device, dim=0)
-                    .unsqueeze(0)
-                    .unsqueeze(0)
-                )
-        else:
-            torch_expert_mapping_tensor = (
-                torch.eye(num_devices, dtype=torch.int32)
-                .repeat_interleave(num_experts_per_device, dim=0)
-                .unsqueeze(0)
-                .unsqueeze(0)
+            config["quad_ring_all_to_all_dispatch_metadata"] = AllToAllDispatchMetadataConfig(
+                cluster_axis=0,
+                worker_mode=ttnn.WorkerMode.DIRECT,
+                dispatch_algorithm=ttnn.DispatchAlgorithm.SPARSE_MCAST_SHORTEST_PATH,
+            )
+            config["quad_ring_moreh_full"] = MorehFullConfig(
+                shape=ttnn.Shape([hf_config.num_experts_per_tok, USERS_PER_ROW, hf_config.hidden_size]),
+                fill_value=0,
+                device=mesh_device,
+                dtype=torch.bfloat16,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+            config["quad_ring_moe_compute"] = MoEComputeConfig(
+                output_height_shard_dim=4,
+                output_width_shard_dim=4,
+                cluster_axis=0,
+            )
+            config["quad_ring_selective_reduce_combine"] = SelectiveReduceCombineConfig(
+                hidden_size=hf_config.hidden_size,
+                batch=batch,
+                seq=seq_len,
+                select_experts_k=hf_config.num_experts_per_tok,
+                experts=hf_config.n_routed_experts,
+                axis=0,
+                token_parallel_core_dim=4,
+                data_parallel_core_dim=4,
+                worker_cores=ttnn.experimental.get_moe_combine_cores(mesh_device),
+                mux_core_range_set=ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(3, 0), ttnn.CoreCoord(4, 7))}),
             )
 
-        expert_mapping_tensor = ttnn.from_torch(
-            torch_expert_mapping_tensor,
-            device=mesh_device,
-            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
-            dtype=ttnn.uint16,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            layout=ttnn.ROW_MAJOR_LAYOUT,
-        )
-
-        return expert_mapping_tensor
+        return config
 
     @classmethod
     def decode_model_config(
@@ -521,6 +510,7 @@ class MoE(SharedStateAddOn, AbstractModule):
                 topk_experts_indices,  # TODO: (GR) need to change shard spec of aho gate module output (once it's merged)
                 topk_experts_weights,  # TODO: (GR) need to change shard spec of aho gate module output (once it's merged)
                 cfg["expert_mapping_tensor"],
+                output_tensors=cfg["quad_ring_preallocated_all_to_all_dispatch_metadata_tensors"],
                 **ccl.populate_all_to_all_dispatch_metadata_args(cfg["quad_ring_all_to_all_dispatch_metadata"]),
             )
 

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -520,6 +520,9 @@ class MoE(SharedStateAddOn, AbstractModule):
                 topk_experts_weights, ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG
             )
 
+            ttnn.deallocate(topk_experts_indices)
+            ttnn.deallocate(topk_experts_weights)
+
             topk_experts_indices_rm = ttnn.permute(
                 topk_experts_indices_rm, (2, 0, 1, 3), memory_config=ttnn.L1_MEMORY_CONFIG
             )
@@ -566,8 +569,8 @@ class MoE(SharedStateAddOn, AbstractModule):
 
             # deallocation required in order to free up L1 space for moe_compute
             ttnn.deallocate(x_rm)
-            ttnn.deallocate(topk_experts_indices)
-            ttnn.deallocate(topk_experts_weights)
+            ttnn.deallocate(topk_experts_indices_rm_sharded)
+            ttnn.deallocate(topk_experts_weights_rm_sharded)
 
             # NOTE: we are actively working on fusing moe_compute and selective_reduce_combine
 
@@ -690,60 +693,78 @@ class MoE(SharedStateAddOn, AbstractModule):
         batch_size: int,
         seq_len: int,
     ) -> ttnn.Tensor:
-        # Repeat + Permute Expert weights
-        topk_experts_weights = cls._fwd_repeat_permute_expert_weights(topk_experts_weights, cfg)
-
         x_rm = ttnn.to_layout(x, ttnn.ROW_MAJOR_LAYOUT)
         x_rm = ttnn.reshape(
             x_rm,
             shape=(batch_size_per_device, 1, seq_len, cfg["hidden_size"]),
         )
 
-        topk_experts_indices_rm = ttnn.to_layout(topk_experts_indices, ttnn.ROW_MAJOR_LAYOUT)
-        topk_experts_indices_rm = ttnn.reshape(
-            topk_experts_indices_rm, shape=(batch_size_per_device, 1, seq_len, cfg["num_experts_per_tok"])
-        )
-
         # Chunk along local batch dimension to keep all_to_all_dispatch output small in prefill.
         chunk_size = min(batch_size_per_device, max(1, cfg.get("moe_chunk_size", batch_size_per_device)))
         output_chunks: list[ttnn.Tensor] = []
 
-        def _slice_topk_weights(batch_start: int, batch_end: int) -> ttnn.Tensor:
-            token_start = batch_start * seq_len
-            token_end = batch_end * seq_len
-            return ttnn.slice(
-                topk_experts_weights,
-                [0, 0, token_start, 0],
-                [cfg["num_experts_per_tok"], 1, token_end, cfg["hidden_size"]],
+        if cfg["fabric_config"] == ttnn.FabricConfig.FABRIC_1D_RING and cfg["num_dispatch_devices"] == 16:
+            ccl = cfg["ccl"]
+
+            topk_experts_indices_rm = ttnn.to_layout(
+                topk_experts_indices, ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG
+            )
+            topk_experts_weights_rm = ttnn.to_layout(
+                topk_experts_weights, ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG
             )
 
-        for batch_start in range(0, batch_size_per_device, chunk_size):
-            batch_end = min(batch_start + chunk_size, batch_size_per_device)
-            batch_chunk = batch_end - batch_start
-            batch_size_chunk = batch_chunk * cfg["num_dispatch_devices"]
+            ttnn.deallocate(topk_experts_indices)
+            ttnn.deallocate(topk_experts_weights)
 
-            x_chunk = ttnn.slice(
-                x_rm,
-                [batch_start, 0, 0, 0],
-                [batch_end, 1, seq_len, cfg["hidden_size"]],
+            topk_experts_indices_rm = ttnn.permute(
+                topk_experts_indices_rm, (2, 0, 1, 3), memory_config=ttnn.DRAM_MEMORY_CONFIG
             )
-            topk_indices_chunk = ttnn.slice(
-                topk_experts_indices_rm,
-                [batch_start, 0, 0, 0],
-                [batch_end, 1, seq_len, cfg["num_experts_per_tok"]],
+            topk_experts_weights_rm = ttnn.permute(
+                topk_experts_weights_rm, (2, 0, 1, 3), memory_config=ttnn.DRAM_MEMORY_CONFIG
             )
 
-            if cfg["fabric_config"] == ttnn.FabricConfig.FABRIC_1D_RING and cfg["num_dispatch_devices"] == 16:
-                ccl = cfg["ccl"]
+            for batch_start in range(0, batch_size_per_device, chunk_size):
+                batch_end = min(batch_start + chunk_size, batch_size_per_device)
 
-                # L1 sharded topk_experts_weights need to be deallocated before moe_compute
+                x_chunk = ttnn.slice(
+                    x_rm,
+                    [batch_start, 0, 0, 0],
+                    [batch_end, 1, seq_len, cfg["hidden_size"]],
+                )
+
+                topk_experts_indices_rm_chunk = ttnn.slice(
+                    topk_experts_indices_rm,
+                    [batch_start, 0, 0, 0],
+                    [batch_end, 1, seq_len, cfg["num_experts_per_tok"]],
+                )
+                topk_experts_indices_rm_chunk_sharded = ttnn.to_memory_config(
+                    topk_experts_indices_rm_chunk,
+                    memory_config=cfg["quad_ring_all_to_all_dispatch_metadata_sharded_memory_config"],
+                )
+
+                topk_experts_weights_rm_chunk = ttnn.slice(
+                    topk_experts_weights_rm,
+                    [batch_start, 0, 0, 0],
+                    [batch_end, 1, seq_len, cfg["num_experts_per_tok"]],
+                )
+                topk_expert_weights_rm_chunk_sharded = ttnn.to_memory_config(
+                    topk_experts_weights_rm_chunk,
+                    memory_config=cfg["quad_ring_all_to_all_dispatch_metadata_sharded_memory_config"],
+                )
+
+                # NOTE: L1 sharded topk_experts_weights need to be deallocated before moe_compute,
                 # configure weights for post combine scaling prior to that deallocation, and store in DRAM
-                permuted_topk_experts_weights = ttnn.permute(
-                    topk_experts_weights, (3, 1, 0, 2), memory_config=ttnn.L1_MEMORY_CONFIG
+                topk_experts_weights_for_scaling_chunk = ttnn.permute(
+                    topk_experts_weights_rm_chunk, (3, 1, 0, 2), memory_config=ttnn.L1_MEMORY_CONFIG
                 )
-                permuted_topk_experts_weights = ttnn.to_layout(
-                    permuted_topk_experts_weights, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG
+                topk_experts_weights_for_scaling_chunk = ttnn.to_layout(
+                    topk_experts_weights_for_scaling_chunk,
+                    layout=ttnn.TILE_LAYOUT,
+                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
                 )
+
+                ttnn.deallocate(topk_experts_indices_rm_chunk)
+                ttnn.deallocate(topk_experts_weights_rm_chunk)
 
                 # NOTE: needs to run prior to all_to_all_dispatch_metadata
                 preallocated_combine_output = ttnn.moreh_full(**cfg["quad_ring_moreh_full"])
@@ -753,18 +774,18 @@ class MoE(SharedStateAddOn, AbstractModule):
                     dispatch_output_expert_indices,
                     dispatch_output_expert_scores,
                 ) = ttnn.experimental.all_to_all_dispatch_metadata(
-                    x_rm,
-                    topk_experts_indices,  # TODO: (GR) need to change shard spec of aho gate module output (once it's merged)
-                    topk_experts_weights,  # TODO: (GR) need to change shard spec of aho gate module output (once it's merged)
+                    x_chunk,
+                    topk_experts_indices_rm_chunk_sharded,
+                    topk_expert_weights_rm_chunk_sharded,
                     cfg["expert_mapping_tensor"],
                     output_tensors=cfg["quad_ring_preallocated_all_to_all_dispatch_metadata_tensors"],
                     **ccl.populate_all_to_all_dispatch_metadata_args(cfg["quad_ring_all_to_all_dispatch_metadata"]),
                 )
 
                 # deallocation required in order to free up L1 space for moe_compute
-                ttnn.deallocate(x_rm)
-                ttnn.deallocate(topk_experts_indices)
-                ttnn.deallocate(topk_experts_weights)
+                ttnn.deallocate(x_chunk)
+                ttnn.deallocate(topk_experts_indices_rm_chunk_sharded)
+                ttnn.deallocate(topk_expert_weights_rm_chunk_sharded)
 
                 # NOTE: we are actively working on fusing moe_compute and selective_reduce_combine
 
@@ -812,9 +833,33 @@ class MoE(SharedStateAddOn, AbstractModule):
                 combine_output = ttnn.unsqueeze(combine_output, dim=1)
 
                 post_combine_output_tensor = ttnn.mul(
-                    combine_output, permuted_topk_experts_weights, **cfg["mul_experts_output_with_weights"]
+                    combine_output, topk_experts_weights_for_scaling_chunk, **cfg["mul_experts_output_with_weights"]
                 )
-            else:
+        else:
+            # Repeat + Permute Expert weights
+            topk_experts_weights = cls._fwd_repeat_permute_expert_weights(topk_experts_weights, cfg)
+
+            topk_experts_indices_rm = ttnn.to_layout(topk_experts_indices, ttnn.ROW_MAJOR_LAYOUT)
+            topk_experts_indices_rm = ttnn.reshape(
+                topk_experts_indices_rm, shape=(batch_size_per_device, 1, seq_len, cfg["num_experts_per_tok"])
+            )
+
+            for batch_start in range(0, batch_size_per_device, chunk_size):
+                batch_end = min(batch_start + chunk_size, batch_size_per_device)
+                batch_chunk = batch_end - batch_start
+                batch_size_chunk = batch_chunk * cfg["num_dispatch_devices"]
+
+                x_chunk = ttnn.slice(
+                    x_rm,
+                    [batch_start, 0, 0, 0],
+                    [batch_end, 1, seq_len, cfg["hidden_size"]],
+                )
+                topk_indices_chunk = ttnn.slice(
+                    topk_experts_indices_rm,
+                    [batch_start, 0, 0, 0],
+                    [batch_end, 1, seq_len, cfg["num_experts_per_tok"]],
+                )
+
                 all_to_all_dispatch_output_tensors, all_to_all_dispatch_metadata_tensors = ttnn.all_to_all_dispatch(
                     x_chunk,
                     topk_indices_chunk,
@@ -860,7 +905,11 @@ class MoE(SharedStateAddOn, AbstractModule):
                 )
                 post_combine_output_tensor = ttnn.to_layout(post_combine_output_tensor, ttnn.TILE_LAYOUT)
 
-                topk_weights_chunk = _slice_topk_weights(batch_start, batch_end)
+                topk_weights_chunk = ttnn.slice(
+                    topk_experts_weights,
+                    [0, 0, batch_start, 0],
+                    [cfg["num_experts_per_tok"], 1, batch_end, cfg["hidden_size"]],
+                )
                 post_combine_output_tensor = ttnn.mul(
                     post_combine_output_tensor, topk_weights_chunk, **cfg["mul_experts_output_with_weights"]
                 )

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -19,6 +19,7 @@ from models.demos.deepseek_v3.utils.config_dataclass import (
     DeepseekMoEReduceScatterConfig,
     MeshDeviceStub,
     MoEComputeConfig,
+    MorehFullConfig,
     MulConfig,
     ReduceScatterAsyncMinimalConfig,
     RepeatConfig,
@@ -223,12 +224,18 @@ class MoE(SharedStateAddOn, AbstractModule):
                     dispatch_algorithm=ttnn.DispatchAlgorithm.SPARSE_MCAST_SHORTEST_PATH,
                     output_tensors=AllToAllDispatchMetadataConfig.create_preallocated_dispatch_output_tensors(
                         mesh_device,
-                        mesh_device.shape,
-                        mesh_device.shape[0],
                         batch,
                         HIDDEN_SIZE,
                         hf_config.num_experts_per_tok,
                     ),
+                )
+                decode_config["quad_ring_moreh_full"] = MorehFullConfig(
+                    shape=ttnn.Shape([hf_config.num_experts_per_tok, USERS_PER_ROW, hf_config.hidden_size]),
+                    fill_value=0,
+                    device=mesh_device,
+                    dtype=torch.bfloat16,
+                    layout=ttnn.ROW_MAJOR_LAYOUT,
+                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
                 )
                 decode_config["quad_ring_moe_compute"] = MoEComputeConfig(
                     output_height_shard_dim=4,
@@ -440,9 +447,6 @@ class MoE(SharedStateAddOn, AbstractModule):
         # MoE Gate
         topk_experts_weights, topk_experts_indices = cls._fwd_moe_gate(x, cfg)
 
-        # Repeat + Permute Expert weights
-        topk_experts_weights = cls._fwd_repeat_permute_expert_weights(topk_experts_weights, cfg)
-
         # MOE
         post_combine_output_tensor = cls._fwd_prefill_moe(
             x,
@@ -492,14 +496,17 @@ class MoE(SharedStateAddOn, AbstractModule):
         if cfg["fabric_config"] == ttnn.FabricConfig.FABRIC_1D_RING and cfg["num_dispatch_devices"] == 16:
             ccl = cfg["ccl"]
 
-            preallocated_combine_output = ttnn.moreh_full(
-                shape=[cfg["num_experts_per_tok"], batch_size_per_device, cfg["hidden_size"]],
-                fill_value=0,
-                device=cfg["mesh_device"],
-                dtype=ttnn.bfloat16,
-                layout=ttnn.ROW_MAJOR_LAYOUT,
-                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            # L1 sharded topk_experts_weights need to be deallocated before moe_compute
+            # configure weights for post combine scaling prior to that deallocation, and store in DRAM
+            permuted_topk_experts_weights = ttnn.permute(
+                topk_experts_weights, (3, 1, 0, 2), memory_config=ttnn.L1_MEMORY_CONFIG
             )
+            permuted_topk_experts_weights = ttnn.to_layout(
+                permuted_topk_experts_weights, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG
+            )
+
+            # NOTE: needs to run prior to all_to_all_dispatch_metadata
+            preallocated_combine_output = ttnn.moreh_full(**cfg["quad_ring_moreh_full"])
 
             (
                 dispatch_output_sparse_buffer,
@@ -513,10 +520,14 @@ class MoE(SharedStateAddOn, AbstractModule):
                 **ccl.populate_all_to_all_dispatch_metadata_args(cfg["quad_ring_all_to_all_dispatch_metadata"]),
             )
 
-            # TODO: (GR)
-            w0_w1 = ()
-            w2 = ()
-            layer_id = 0
+            # deallocation required in order to free up L1 space for moe_compute
+            ttnn.deallocate(x_rm)
+            ttnn.deallocate(topk_experts_indices)
+            ttnn.deallocate(topk_experts_weights)
+
+            w0_w1 = ()  # TODO: (GR)
+            w2 = ()  # TODO: (GR)
+            layer_id = 0  # TODO: (GR)
             (
                 compute_output_token_counts,
                 compute_output_dense_expert_activation,
@@ -528,11 +539,15 @@ class MoE(SharedStateAddOn, AbstractModule):
                 dispatch_output_expert_indices,
                 dispatch_output_expert_scores,
                 cfg["expert_mapping_tensor"],
-                w0_w1,  # TODO: (GR)
-                w2,  # TODO: (GR)
-                layer_id=layer_id,  # TODO: (GR)
+                w0_w1,
+                w2,
+                layer_id=layer_id,
                 **cfg["quad_ring_moe_compute"],
             )
+
+            ttnn.deallocate(dispatch_output_sparse_buffer)
+            ttnn.deallocate(dispatch_output_expert_indices)
+            ttnn.deallocate(dispatch_output_expert_scores)
 
             combine_output = ttnn.experimental.selective_reduce_combine(
                 compute_output,
@@ -543,6 +558,11 @@ class MoE(SharedStateAddOn, AbstractModule):
                 **ccl.populate_selective_reduce_combine_args(cfg["quad_ring_selective_reduce_combine"]),
             )
 
+            ttnn.deallocate(compute_output)
+            ttnn.deallocate(compute_output_dense_expert_activation)
+            ttnn.deallocate(compute_ouput_dense_e_t)
+            ttnn.deallocate(compute_output_token_counts)
+
             combine_output = ttnn.to_layout(
                 combine_output,
                 layout=ttnn.TILE_LAYOUT,
@@ -550,15 +570,13 @@ class MoE(SharedStateAddOn, AbstractModule):
             )
             combine_output = ttnn.unsqueeze(combine_output, dim=1)
 
-            topk_experts_weights = ttnn.permute(topk_experts_weights, (3, 1, 0, 2), memory_config=ttnn.L1_MEMORY_CONFIG)
-            topk_experts_weights = ttnn.to_layout(
-                topk_experts_weights, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG
-            )
-
             post_combine_output_tensor = ttnn.mul(
-                combine_output, topk_experts_weights, memory_config=ttnn.L1_MEMORY_CONFIG
+                combine_output, permuted_topk_experts_weights, **cfg["mul_experts_output_with_weights"]
             )
         else:
+            # Repeat + Permute Expert weights
+            topk_experts_weights = cls._fwd_repeat_permute_expert_weights(topk_experts_weights, cfg)
+
             topk_experts_indices_rm = ttnn.to_layout(topk_experts_indices, ttnn.ROW_MAJOR_LAYOUT)
             topk_experts_indices_rm = ttnn.reshape(
                 topk_experts_indices_rm, shape=(batch_size_per_device, 1, seq_len, cfg["num_experts_per_tok"])
@@ -626,6 +644,9 @@ class MoE(SharedStateAddOn, AbstractModule):
         batch_size: int,
         seq_len: int,
     ) -> ttnn.Tensor:
+        # Repeat + Permute Expert weights
+        topk_experts_weights = cls._fwd_repeat_permute_expert_weights(topk_experts_weights, cfg)
+
         tokens = batch_size * seq_len
         x_rm = ttnn.to_layout(x, ttnn.ROW_MAJOR_LAYOUT)
         x_rm = ttnn.reshape(

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -358,6 +358,20 @@ class MoE(SharedStateAddOn, AbstractModule):
 
     @classmethod
     def forward_decode(cls, x: ttnn.Tensor, cfg: RunDecodeConfig | RunPrefillConfig) -> ttnn.Tensor:
+        # Validate input dimensions
+        hidden_size = cfg["hidden_size"]
+        mesh_device = cfg.get("mesh_device")
+        tp_size = mesh_device.shape[1] if mesh_device else 1
+
+        x_dim = x.shape[-1]
+        expected_dims = [hidden_size, hidden_size // tp_size] if tp_size > 1 else [hidden_size]
+
+        if x_dim not in expected_dims:
+            raise ValueError(
+                f"MoE: Unexpected input dimension {x_dim}. Expected one of {expected_dims}. "
+                f"(hidden_size={hidden_size}, tp_size={tp_size})"
+            )
+
         seq_len = 1  # a2a dispatch and combine require DP=num_dispatch_devices, hence in prefill for bs=1, we interchange the seq_len with batch_size dimensions
         batch_size_per_device = x.shape[
             -2

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -15,11 +15,14 @@ from models.demos.deepseek_v3.utils.config_dataclass import (
     AllGatherAsyncConfig,
     AllToAllCombineConfig,
     AllToAllDispatchConfig,
+    AllToAllDispatchMetadataConfig,
     DeepseekMoEReduceScatterConfig,
     MeshDeviceStub,
+    MoEComputeConfig,
     MulConfig,
     ReduceScatterAsyncMinimalConfig,
     RepeatConfig,
+    SelectiveReduceCombineConfig,
 )
 from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW
 from models.demos.deepseek_v3.utils.run_config import (
@@ -76,21 +79,7 @@ class MoE(SharedStateAddOn, AbstractModule):
         Returns:
             ModelState containing shared tensors
         """
-        num_devices = mesh_device.get_num_devices()
-        num_experts_per_device = MoEExperts._get_num_experts_per_device(hf_config, mesh_device)
         num_dispatch_device_rows = mesh_device.shape[0]
-
-        expert_mapping_tensors = ttnn.from_torch(
-            torch.eye(num_devices, dtype=torch.int32)
-            .repeat_interleave(num_experts_per_device, dim=0)
-            .unsqueeze(0)
-            .unsqueeze(0),
-            device=mesh_device,
-            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
-            dtype=ttnn.uint16,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            layout=ttnn.ROW_MAJOR_LAYOUT,
-        )
 
         remap_topk_mask = ttnn.from_torch(
             torch.ones((1, num_dispatch_device_rows, 1, hf_config.n_routed_experts), dtype=torch.bfloat16),
@@ -102,7 +91,6 @@ class MoE(SharedStateAddOn, AbstractModule):
         )
 
         return {
-            "expert_mapping_tensors": expert_mapping_tensors,
             "remap_topk_mask": remap_topk_mask,
             MESH_DEVICE_STATE_DICT_KEY: mesh_device,
         }
@@ -154,6 +142,7 @@ class MoE(SharedStateAddOn, AbstractModule):
         """
 
         num_experts_per_device = MoEExperts._get_num_experts_per_device(hf_config, mesh_device)
+        expert_mapping_tensor = cls._create_expert_mapping_tensor(mesh_device, mode, num_experts_per_device)
 
         if mode == "decode":
             memory_config = ttnn.L1_MEMORY_CONFIG
@@ -175,7 +164,7 @@ class MoE(SharedStateAddOn, AbstractModule):
             )
 
             # Construct the config
-            return {
+            decode_config = {
                 "mesh_device": MeshDeviceStub(mesh_device.shape),
                 "num_devices": mesh_device.get_num_devices(),
                 "fabric_config": fabric_config,
@@ -183,6 +172,7 @@ class MoE(SharedStateAddOn, AbstractModule):
                 "hidden_size": hf_config.hidden_size,
                 "num_experts_per_tok": hf_config.num_experts_per_tok,
                 "num_dispatch_devices": mesh_device.shape[0],
+                "expert_mapping_tensor": expert_mapping_tensor,
                 "moe_gate": MoEGate.model_config(hf_config, mesh_device, mode, topk_fallback=topk_fallback),
                 "all_to_all_dispatch_output_memory_config": memory_config,
                 "all_to_all_dispatch_metadata_memory_config": ttnn.DRAM_MEMORY_CONFIG,
@@ -221,6 +211,44 @@ class MoE(SharedStateAddOn, AbstractModule):
                     cluster_axis=1,
                 ),
             }
+
+            # optimized MoE ops only functional for quad torus
+            if ["fabric_config"] == ttnn.FabricConfig.FABRIC_1D_RING and mesh_device.shape[0] == 16:
+                batch = USERS_PER_ROW * mesh_device.shape[0]
+                seq_len = 1
+
+                decode_config["quad_ring_all_to_all_dispatch_metadata"] = AllToAllDispatchMetadataConfig(
+                    cluster_axis=0,
+                    worker_mode=ttnn.WorkerMode.DIRECT,
+                    dispatch_algorithm=ttnn.DispatchAlgorithm.SPARSE_MCAST_SHORTEST_PATH,
+                    output_tensors=AllToAllDispatchMetadataConfig.create_preallocated_dispatch_output_tensors(
+                        mesh_device,
+                        mesh_device.shape,
+                        mesh_device.shape[0],
+                        batch,
+                        HIDDEN_SIZE,
+                        hf_config.num_experts_per_tok,
+                    ),
+                )
+                decode_config["quad_ring_moe_compute"] = MoEComputeConfig(
+                    output_height_shard_dim=4,
+                    output_width_shard_dim=4,
+                    cluster_axis=0,
+                )
+                decode_config["quad_ring_selective_reduce_combine"] = SelectiveReduceCombineConfig(
+                    hidden_size=hf_config.hidden_size,
+                    batch=batch,
+                    seq=seq_len,
+                    select_experts_k=hf_config.num_experts_per_tok,
+                    experts=hf_config.n_routed_experts,
+                    axis=0,
+                    token_parallel_core_dim=4,
+                    data_parallel_core_dim=4,
+                    worker_cores=ttnn.experimental.get_moe_combine_cores(mesh_device),
+                    mux_core_range_set=ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(3, 0), ttnn.CoreCoord(4, 7))}),
+                )
+
+            return decode_config
         else:
             memory_config = ttnn.DRAM_MEMORY_CONFIG
             # Construct the config
@@ -259,6 +287,56 @@ class MoE(SharedStateAddOn, AbstractModule):
             }
 
     @classmethod
+    def _create_expert_mapping_tensor(
+        mesh_device: ttnn.Device,
+        mode: str,
+        num_experts_per_device: int,
+    ):
+        num_devices = mesh_device.get_num_devices()
+        if mode == "decode":
+            # optimized MoE ops only functional for quad torus
+            num_dispatch_devices = mesh_device.shape[0]
+            if ["fabric_config"] == ttnn.FabricConfig.FABRIC_1D_RING and num_dispatch_devices == 16:
+                num_experts = num_devices * num_experts_per_device
+                tp_size = mesh_device.shape[1]
+                num_experts_per_cluster = num_experts // tp_size
+
+                e = torch.arange(num_experts, dtype=torch.int32)
+                torch_expert_mapping_tensor = (
+                    (
+                        ((e % num_experts_per_cluster) // num_experts_per_device) * tp_size
+                        + (e // num_experts_per_cluster)
+                    )
+                    .unsqueeze(0)
+                    .repeat(num_devices, 1)
+                )
+            else:
+                torch_expert_mapping_tensor = (
+                    torch.eye(num_devices, dtype=torch.int32)
+                    .repeat_interleave(num_experts_per_device, dim=0)
+                    .unsqueeze(0)
+                    .unsqueeze(0)
+                )
+        else:
+            torch_expert_mapping_tensor = (
+                torch.eye(num_devices, dtype=torch.int32)
+                .repeat_interleave(num_experts_per_device, dim=0)
+                .unsqueeze(0)
+                .unsqueeze(0)
+            )
+
+        expert_mapping_tensor = ttnn.from_torch(
+            torch_expert_mapping_tensor,
+            device=mesh_device,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+            dtype=ttnn.uint16,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+        )
+
+        return expert_mapping_tensor
+
+    @classmethod
     def decode_model_config(
         cls,
         hf_config: PretrainedConfig,
@@ -279,7 +357,34 @@ class MoE(SharedStateAddOn, AbstractModule):
         return cls.model_config(hf_config, mesh_device, fabric_config, "prefill", topk_fallback=topk_fallback)
 
     @classmethod
-    def forward(cls, x: ttnn.Tensor, cfg: RunDecodeConfig | RunPrefillConfig) -> ttnn.Tensor:
+    def forward_decode(cls, x: ttnn.Tensor, cfg: RunDecodeConfig | RunPrefillConfig) -> ttnn.Tensor:
+        seq_len = 1  # a2a dispatch and combine require DP=num_dispatch_devices, hence in prefill for bs=1, we interchange the seq_len with batch_size dimensions
+        batch_size_per_device = x.shape[
+            -2
+        ]  # Input is expected to be DP. In prefill, this is equivalent to seq_len_per_device
+        batch_size = batch_size_per_device * cfg["num_dispatch_devices"]  # Global batch size
+
+        # Note: all_gather is handled by the caller (decoder block or test)
+
+        # MoE Gate
+        topk_experts_weights, topk_experts_indices = cls._fwd_moe_gate(x, cfg)
+
+        # MOE
+        post_combine_output_tensor = cls._fwd_decode_moe(
+            x,
+            topk_experts_indices,
+            topk_experts_weights,
+            cfg,
+            batch_size_per_device,
+            batch_size,
+            seq_len,
+        )
+
+        # Note: sum_experts and reduce_scatter is handled by the caller (decoder block or test)
+        return post_combine_output_tensor
+
+    @classmethod
+    def forward_prefill(cls, x: ttnn.Tensor, cfg: RunDecodeConfig | RunPrefillConfig) -> ttnn.Tensor:
         # Chunk the full MoE prefill path at 16K tokens to avoid OOM.
         # Use global token count (local seq_len * num_dispatch_devices) to decide.
         chunk_tokens = int(cfg.get("prefill_chunk_size", 16384))
@@ -288,7 +393,7 @@ class MoE(SharedStateAddOn, AbstractModule):
         if global_tokens > chunk_tokens:
             chunk_size = max(1, chunk_tokens // max(1, num_dispatch_devices))
             return cls._forward_chunked_prefill(x, cfg, chunk_size)
-        return cls._forward_impl(x, cfg)
+        return cls._forward_prefill_impl(x, cfg)
 
     @classmethod
     def _forward_chunked_prefill(cls, x: ttnn.Tensor, cfg: RunPrefillConfig, chunk_size: int) -> ttnn.Tensor:
@@ -309,7 +414,7 @@ class MoE(SharedStateAddOn, AbstractModule):
         return output
 
     @classmethod
-    def _forward_impl(cls, x: ttnn.Tensor, cfg: RunDecodeConfig | RunPrefillConfig) -> ttnn.Tensor:
+    def _forward_prefill_impl(cls, x: ttnn.Tensor, cfg: RunDecodeConfig | RunPrefillConfig) -> ttnn.Tensor:
         # Validate input dimensions
         hidden_size = cfg["hidden_size"]
         mesh_device = cfg.get("mesh_device")
@@ -324,8 +429,6 @@ class MoE(SharedStateAddOn, AbstractModule):
                 f"(hidden_size={hidden_size}, tp_size={tp_size})"
             )
 
-        # breakpoint()
-        ccl = cfg["ccl"]  # CCL runtime initialization in execution order
         seq_len = 1  # a2a dispatch and combine require DP=num_dispatch_devices, hence in prefill for bs=1, we interchange the seq_len with batch_size dimensions
         batch_size_per_device = x.shape[
             -2
@@ -338,12 +441,10 @@ class MoE(SharedStateAddOn, AbstractModule):
         topk_experts_weights, topk_experts_indices = cls._fwd_moe_gate(x, cfg)
 
         # Repeat + Permute Expert weights
-
         topk_experts_weights = cls._fwd_repeat_permute_expert_weights(topk_experts_weights, cfg)
 
         # MOE
-
-        post_combine_output_tensor = cls._fwd_moe(
+        post_combine_output_tensor = cls._fwd_prefill_moe(
             x,
             topk_experts_indices,
             topk_experts_weights,
@@ -354,7 +455,6 @@ class MoE(SharedStateAddOn, AbstractModule):
         )
 
         # Note: sum_experts and reduce_scatter is handled by the caller (decoder block or test)
-
         return post_combine_output_tensor
 
     @classmethod
@@ -373,7 +473,150 @@ class MoE(SharedStateAddOn, AbstractModule):
         return topk_experts_weights
 
     @classmethod
-    def _fwd_moe(
+    def _fwd_decode_moe(
+        cls,
+        x: ttnn.Tensor,
+        topk_experts_indices: ttnn.Tensor,
+        topk_experts_weights: ttnn.Tensor,
+        cfg: RunDecodeConfig | RunPrefillConfig,
+        batch_size_per_device: int,
+        batch_size: int,
+        seq_len: int,
+    ) -> ttnn.Tensor:
+        x_rm = ttnn.to_layout(x, ttnn.ROW_MAJOR_LAYOUT)
+        x_rm = ttnn.reshape(
+            x_rm,
+            shape=(batch_size_per_device, 1, seq_len, cfg["hidden_size"]),
+        )
+
+        if cfg["fabric_config"] == ttnn.FabricConfig.FABRIC_1D_RING and cfg["num_dispatch_devices"] == 16:
+            ccl = cfg["ccl"]
+
+            preallocated_combine_output = ttnn.moreh_full(
+                shape=[cfg["num_experts_per_tok"], batch_size_per_device, cfg["hidden_size"]],
+                fill_value=0,
+                device=cfg["mesh_device"],
+                dtype=ttnn.bfloat16,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+
+            (
+                dispatch_output_sparse_buffer,
+                dispatch_output_expert_indices,
+                dispatch_output_expert_scores,
+            ) = ttnn.experimental.all_to_all_dispatch_metadata(
+                x_rm,
+                topk_experts_indices,  # TODO: (GR) may need to change shard spec of aho gate output
+                topk_experts_weights,  # TODO: (GR) may need to change shard spec of aho gate output
+                cfg["expert_mapping_tensor"],
+                **ccl.populate_all_to_all_dispatch_metadata_args(cfg["quad_ring_all_to_all_dispatch_metadata"]),
+            )
+
+            # TODO: (GR)
+            w0_w1 = ()
+            w2 = ()
+            layer_id = 0
+            (
+                compute_output_token_counts,
+                compute_output_dense_expert_activation,
+                compute_ouput_dense_e_t,
+                _,  # tile layout output of selective tilize (same buffer as output)
+                compute_output,
+            ) = ttnn.experimental.moe_compute(
+                dispatch_output_sparse_buffer,
+                dispatch_output_expert_indices,
+                dispatch_output_expert_scores,
+                cfg["expert_mapping_tensor"],
+                w0_w1,  # TODO: (GR)
+                w2,  # TODO: (GR)
+                layer_id=layer_id,  # TODO: (GR)
+                **cfg["quad_ring_moe_compute"],
+            )
+
+            combine_output = ttnn.experimental.selective_reduce_combine(
+                compute_output,
+                compute_output_dense_expert_activation,
+                compute_ouput_dense_e_t,
+                compute_output_token_counts,
+                output_tensor=preallocated_combine_output,
+                **ccl.populate_selective_reduce_combine_args(cfg["quad_ring_selective_reduce_combine"]),
+            )
+
+            combine_output = ttnn.to_layout(
+                combine_output,
+                layout=ttnn.TILE_LAYOUT,
+                memory_config=ttnn.L1_MEMORY_CONFIG,
+            )
+            combine_output = ttnn.unsqueeze(combine_output, dim=1)
+
+            topk_experts_weights = ttnn.permute(topk_experts_weights, (3, 1, 0, 2), memory_config=ttnn.L1_MEMORY_CONFIG)
+            topk_experts_weights = ttnn.to_layout(
+                topk_experts_weights, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG
+            )
+
+            post_combine_output_tensor = ttnn.mul(
+                combine_output, topk_experts_weights, memory_config=ttnn.L1_MEMORY_CONFIG
+            )
+        else:
+            topk_experts_indices_rm = ttnn.to_layout(topk_experts_indices, ttnn.ROW_MAJOR_LAYOUT)
+            topk_experts_indices_rm = ttnn.reshape(
+                topk_experts_indices_rm, shape=(batch_size_per_device, 1, seq_len, cfg["num_experts_per_tok"])
+            )
+
+            all_to_all_dispatch_output_tensors, all_to_all_dispatch_metadata_tensors = ttnn.all_to_all_dispatch(
+                x_rm,
+                topk_experts_indices_rm,
+                cfg["expert_mapping_tensor"],
+                **cfg["all_to_all_dispatch"],
+            )
+
+            post_all_to_all_dispatch_output = ttnn.reshape(
+                all_to_all_dispatch_output_tensors, shape=(1, 1, batch_size * seq_len, cfg["hidden_size"])
+            )
+            post_all_to_all_dispatch_output = ttnn.to_layout(post_all_to_all_dispatch_output, ttnn.TILE_LAYOUT)
+            # repeat remap_topk_mask for the num_tokens known at runtime
+
+            remap_topk_mask = ttnn.repeat(
+                cfg["remap_topk_mask"], ttnn.Shape((1, batch_size_per_device, 1, 1))
+            )  # TODO: move to static path
+
+            _, sparsity_t = ttnn.moe_expert_token_remap(
+                remap_topk_mask,
+                cfg["expert_mapping_tensor"],
+                all_to_all_dispatch_metadata_tensors,
+                reduction_size=cfg["sparsity_block_size"],
+            )
+
+            experts_output = MoEExperts._forward(post_all_to_all_dispatch_output, sparsity_t, cfg["moe_experts"])
+            ttnn.deallocate(post_all_to_all_dispatch_output)
+
+            experts_output = ttnn.to_layout(experts_output, ttnn.ROW_MAJOR_LAYOUT)
+            experts_output = ttnn.reshape(
+                experts_output, shape=(cfg["num_experts_per_device"], batch_size, seq_len, cfg["hidden_size"])
+            )
+
+            all_to_all_combine_output_tensors = ttnn.all_to_all_combine(
+                experts_output,
+                all_to_all_dispatch_metadata_tensors,
+                cfg["expert_mapping_tensor"],
+                **cfg["all_to_all_combine"],
+            )
+
+            post_combine_output_tensor = ttnn.reshape(
+                all_to_all_combine_output_tensors,
+                shape=(cfg["num_experts_per_tok"], 1, batch_size_per_device * seq_len, cfg["hidden_size"]),
+            )
+            post_combine_output_tensor = ttnn.to_layout(post_combine_output_tensor, ttnn.TILE_LAYOUT)
+
+            post_combine_output_tensor = ttnn.mul(
+                post_combine_output_tensor, topk_experts_weights, **cfg["mul_experts_output_with_weights"]
+            )
+
+        return post_combine_output_tensor
+
+    @classmethod
+    def _fwd_prefill_moe(
         cls,
         x: ttnn.Tensor,
         topk_experts_indices: ttnn.Tensor,
@@ -515,32 +758,13 @@ class MoE(SharedStateAddOn, AbstractModule):
         return ttnn.reduce_scatter(post_combine_output_tensor, **rs_kwargs)
 
     @classmethod
-    def forward_prefill(
-        cls, x: ttnn.Tensor, cfg: RunPrefillConfig, handle_tensor_parallel: bool = False
-    ) -> ttnn.Tensor:
-        # Handle all_gather if tensor parallel is enabled
-        if handle_tensor_parallel:
-            x = cls._fwd_all_gather(x, cfg)
-
-        # Run the forward pass
-        output = cls.forward(x, cfg)
-
-        # Handle sum_experts and reduce_scatter if tensor parallel is enabled
-        if handle_tensor_parallel:
-            ccl = cfg["ccl"]
-            output = ttnn.sum(output, dim=0, keepdim=True, memory_config=cfg["sum_experts_output_memory_config"])
-            output = cls._fwd_reduce_scatter(output, cfg, ccl)
-
-        return output
-
-    @classmethod
     def forward_decode(cls, x: ttnn.Tensor, cfg: RunDecodeConfig, handle_tensor_parallel: bool = False) -> ttnn.Tensor:
         # Handle all_gather if tensor parallel is enabled
         if handle_tensor_parallel:
             x = cls._fwd_all_gather(x, cfg)
 
         # Run the forward pass
-        output = cls.forward(x, cfg)
+        output = cls.forward_decode(x, cfg)
 
         # Handle sum_experts and reduce_scatter if tensor parallel is enabled
         if handle_tensor_parallel:
@@ -560,5 +784,24 @@ class MoE(SharedStateAddOn, AbstractModule):
             else:
                 output = ttnn.sum(output, dim=0, keepdim=True, memory_config=cfg["sum_experts_output_memory_config"])
                 output = cls._fwd_reduce_scatter(output, cfg, ccl)
+
+        return output
+
+    @classmethod
+    def forward_prefill(
+        cls, x: ttnn.Tensor, cfg: RunPrefillConfig, handle_tensor_parallel: bool = False
+    ) -> ttnn.Tensor:
+        # Handle all_gather if tensor parallel is enabled
+        if handle_tensor_parallel:
+            x = cls._fwd_all_gather(x, cfg)
+
+        # Run the forward pass
+        output = cls.forward_prefill(x, cfg)
+
+        # Handle sum_experts and reduce_scatter if tensor parallel is enabled
+        if handle_tensor_parallel:
+            ccl = cfg["ccl"]
+            output = ttnn.sum(output, dim=0, keepdim=True, memory_config=cfg["sum_experts_output_memory_config"])
+            output = cls._fwd_reduce_scatter(output, cfg, ccl)
 
         return output

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -129,7 +129,6 @@ class MoE(SharedStateAddOn, AbstractModule):
         }
 
         # optimized ops (exclusive to quad with ring fabric) require preallocated tensors for all_to_all_dispatch_metadata
-        # TODO: (GR)
         if fabric_config == ttnn.FabricConfig.FABRIC_1D_RING and num_dispatch_device_rows == 16:
             batch = USERS_PER_ROW * mesh_device.shape[0]
             preallocated_all_to_all_dispatch_metadata_tensors = (
@@ -340,7 +339,6 @@ class MoE(SharedStateAddOn, AbstractModule):
             )
 
             # TODO: this is a temporary measure until we either a) uplift the optimized ops to support prefill shapes, or b) uplift prefill MMs to read from decode formatted weights
-            # set chunk size for prefill
             config["moe_chunk_size"] = USERS_PER_ROW
 
         return config
@@ -509,9 +507,8 @@ class MoE(SharedStateAddOn, AbstractModule):
             shape=(batch_size_per_device, 1, seq_len, cfg["hidden_size"]),
         )
 
+        # optimized ops are exclusive to quad with ring fabric
         if cfg["fabric_config"] == ttnn.FabricConfig.FABRIC_1D_RING and cfg["num_dispatch_devices"] == 16:
-            ccl = cfg["ccl"]
-
             # NOTE: can move towards removing these TMs once optimized moe_gate is integrated
             topk_experts_indices_rm = ttnn.to_layout(
                 topk_experts_indices, ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG
@@ -530,98 +527,12 @@ class MoE(SharedStateAddOn, AbstractModule):
                 topk_experts_weights_rm, (2, 0, 1, 3), memory_config=ttnn.L1_MEMORY_CONFIG
             )
 
-            topk_experts_indices_rm_sharded = ttnn.to_memory_config(
-                topk_experts_indices_rm,
-                memory_config=cfg["quad_ring_all_to_all_dispatch_metadata_sharded_memory_config"],
-            )
-            topk_experts_weights_rm_sharded = ttnn.to_memory_config(
-                topk_experts_weights_rm,
-                memory_config=cfg["quad_ring_all_to_all_dispatch_metadata_sharded_memory_config"],
-            )
-
-            # NOTE: L1 sharded topk_experts_weights need to be deallocated before moe_compute,
-            # configure weights for post combine scaling prior to that deallocation, and store in DRAM
-            topk_experts_weights_for_scaling = ttnn.permute(
-                topk_experts_weights_rm, (3, 1, 0, 2), memory_config=ttnn.L1_MEMORY_CONFIG
-            )
-            topk_experts_weights_for_scaling = ttnn.to_layout(
-                topk_experts_weights_for_scaling, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG
-            )
-
-            ttnn.deallocate(topk_experts_indices_rm)
-            ttnn.deallocate(topk_experts_weights_rm)
-
-            # NOTE: needs to run prior to all_to_all_dispatch_metadata
-            preallocated_combine_output = ttnn.moreh_full(**cfg["quad_ring_moreh_full"])
-
-            (
-                dispatch_output_sparse_buffer,
-                dispatch_output_expert_indices,
-                dispatch_output_expert_scores,
-            ) = ttnn.experimental.all_to_all_dispatch_metadata(
+            post_combine_output_tensor = cls._forward_moe_quad_ring_impl(
+                cfg,
                 x_rm,
-                topk_experts_indices_rm_sharded,
-                topk_experts_weights_rm_sharded,
-                cfg["expert_mapping_tensor"],
-                output_tensors=cfg["quad_ring_preallocated_all_to_all_dispatch_metadata_tensors"],
-                **ccl.populate_all_to_all_dispatch_metadata_args(cfg["quad_ring_all_to_all_dispatch_metadata"]),
+                topk_experts_indices_rm,
+                topk_experts_weights_rm,
             )
-
-            # deallocation required in order to free up L1 space for moe_compute
-            ttnn.deallocate(x_rm)
-            ttnn.deallocate(topk_experts_indices_rm_sharded)
-            ttnn.deallocate(topk_experts_weights_rm_sharded)
-
-            # NOTE: we are actively working on fusing moe_compute and selective_reduce_combine
-
-            w0_w1 = ()  # TODO: (GR)
-            w2 = ()  # TODO: (GR)
-            layer_id = 0  # TODO: (GR)
-            (
-                compute_output_token_counts,
-                compute_output_dense_expert_activation,
-                compute_ouput_dense_e_t,
-                _,  # tile layout output of selective tilize (same buffer as output)
-                compute_output,
-            ) = ttnn.experimental.moe_compute(
-                dispatch_output_sparse_buffer,
-                dispatch_output_expert_indices,
-                dispatch_output_expert_scores,
-                cfg["expert_mapping_tensor"],
-                w0_w1,
-                w2,
-                layer_id=layer_id,
-                **cfg["quad_ring_moe_compute"],
-            )
-
-            # NOTE: can't deallocate dispatch output tensors as they are preallocated and reused across layers
-
-            combine_output = ttnn.experimental.selective_reduce_combine(
-                compute_output,
-                compute_output_dense_expert_activation,
-                compute_ouput_dense_e_t,
-                compute_output_token_counts,
-                output_tensor=preallocated_combine_output,
-                **ccl.populate_selective_reduce_combine_args(cfg["quad_ring_selective_reduce_combine"]),
-            )
-
-            ttnn.deallocate(compute_output)
-            ttnn.deallocate(compute_output_dense_expert_activation)
-            ttnn.deallocate(compute_ouput_dense_e_t)
-            ttnn.deallocate(compute_output_token_counts)
-
-            combine_output = ttnn.to_layout(
-                combine_output,
-                layout=ttnn.TILE_LAYOUT,
-                memory_config=ttnn.L1_MEMORY_CONFIG,
-            )
-            combine_output = ttnn.unsqueeze(combine_output, dim=1)
-
-            post_combine_output_tensor = ttnn.mul(
-                combine_output, topk_experts_weights_for_scaling, **cfg["mul_experts_output_with_weights"]
-            )
-
-            ttnn.deallocate(combine_output)
         else:
             # Repeat + Permute Expert weights
             topk_experts_weights = cls._fwd_repeat_permute_expert_weights(topk_experts_weights, cfg)
@@ -703,9 +614,8 @@ class MoE(SharedStateAddOn, AbstractModule):
         chunk_size = min(batch_size_per_device, max(1, cfg.get("moe_chunk_size", batch_size_per_device)))
         output_chunks: list[ttnn.Tensor] = []
 
+        # optimized ops are exclusive to quad with ring fabric
         if cfg["fabric_config"] == ttnn.FabricConfig.FABRIC_1D_RING and cfg["num_dispatch_devices"] == 16:
-            ccl = cfg["ccl"]
-
             topk_experts_indices_rm = ttnn.to_layout(
                 topk_experts_indices, ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG
             )
@@ -716,6 +626,7 @@ class MoE(SharedStateAddOn, AbstractModule):
             ttnn.deallocate(topk_experts_indices)
             ttnn.deallocate(topk_experts_weights)
 
+            # NOTE: store in DRAM while chunking, as moe_compute requires just about all of L1
             topk_experts_indices_rm = ttnn.permute(
                 topk_experts_indices_rm, (2, 0, 1, 3), memory_config=ttnn.DRAM_MEMORY_CONFIG
             )
@@ -726,7 +637,7 @@ class MoE(SharedStateAddOn, AbstractModule):
             for batch_start in range(0, batch_size_per_device, chunk_size):
                 batch_end = min(batch_start + chunk_size, batch_size_per_device)
 
-                x_chunk = ttnn.slice(
+                x_rm_chunk = ttnn.slice(
                     x_rm,
                     [batch_start, 0, 0, 0],
                     [batch_end, 1, seq_len, cfg["hidden_size"]],
@@ -737,104 +648,20 @@ class MoE(SharedStateAddOn, AbstractModule):
                     [batch_start, 0, 0, 0],
                     [batch_end, 1, seq_len, cfg["num_experts_per_tok"]],
                 )
-                topk_experts_indices_rm_chunk_sharded = ttnn.to_memory_config(
-                    topk_experts_indices_rm_chunk,
-                    memory_config=cfg["quad_ring_all_to_all_dispatch_metadata_sharded_memory_config"],
-                )
 
                 topk_experts_weights_rm_chunk = ttnn.slice(
                     topk_experts_weights_rm,
                     [batch_start, 0, 0, 0],
                     [batch_end, 1, seq_len, cfg["num_experts_per_tok"]],
                 )
-                topk_expert_weights_rm_chunk_sharded = ttnn.to_memory_config(
+
+                post_combine_output_tensor = cls._forward_moe_quad_ring_impl(
+                    cfg,
+                    x_rm_chunk,
+                    topk_experts_indices_rm_chunk,
                     topk_experts_weights_rm_chunk,
-                    memory_config=cfg["quad_ring_all_to_all_dispatch_metadata_sharded_memory_config"],
                 )
-
-                # NOTE: L1 sharded topk_experts_weights need to be deallocated before moe_compute,
-                # configure weights for post combine scaling prior to that deallocation, and store in DRAM
-                topk_experts_weights_for_scaling_chunk = ttnn.permute(
-                    topk_experts_weights_rm_chunk, (3, 1, 0, 2), memory_config=ttnn.L1_MEMORY_CONFIG
-                )
-                topk_experts_weights_for_scaling_chunk = ttnn.to_layout(
-                    topk_experts_weights_for_scaling_chunk,
-                    layout=ttnn.TILE_LAYOUT,
-                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                )
-
-                ttnn.deallocate(topk_experts_indices_rm_chunk)
-                ttnn.deallocate(topk_experts_weights_rm_chunk)
-
-                # NOTE: needs to run prior to all_to_all_dispatch_metadata
-                preallocated_combine_output = ttnn.moreh_full(**cfg["quad_ring_moreh_full"])
-
-                (
-                    dispatch_output_sparse_buffer,
-                    dispatch_output_expert_indices,
-                    dispatch_output_expert_scores,
-                ) = ttnn.experimental.all_to_all_dispatch_metadata(
-                    x_chunk,
-                    topk_experts_indices_rm_chunk_sharded,
-                    topk_expert_weights_rm_chunk_sharded,
-                    cfg["expert_mapping_tensor"],
-                    output_tensors=cfg["quad_ring_preallocated_all_to_all_dispatch_metadata_tensors"],
-                    **ccl.populate_all_to_all_dispatch_metadata_args(cfg["quad_ring_all_to_all_dispatch_metadata"]),
-                )
-
-                # deallocation required in order to free up L1 space for moe_compute
-                ttnn.deallocate(x_chunk)
-                ttnn.deallocate(topk_experts_indices_rm_chunk_sharded)
-                ttnn.deallocate(topk_expert_weights_rm_chunk_sharded)
-
-                # NOTE: we are actively working on fusing moe_compute and selective_reduce_combine
-
-                w0_w1 = ()  # TODO: (GR)
-                w2 = ()  # TODO: (GR)
-                layer_id = 0  # TODO: (GR)
-                (
-                    compute_output_token_counts,
-                    compute_output_dense_expert_activation,
-                    compute_ouput_dense_e_t,
-                    _,  # tile layout output of selective tilize (same buffer as output)
-                    compute_output,
-                ) = ttnn.experimental.moe_compute(
-                    dispatch_output_sparse_buffer,
-                    dispatch_output_expert_indices,
-                    dispatch_output_expert_scores,
-                    cfg["expert_mapping_tensor"],
-                    w0_w1,
-                    w2,
-                    layer_id=layer_id,
-                    **cfg["quad_ring_moe_compute"],
-                )
-
-                # NOTE: can't deallocate dispatch output tensors as they are preallocated and reused across layers
-
-                combine_output = ttnn.experimental.selective_reduce_combine(
-                    compute_output,
-                    compute_output_dense_expert_activation,
-                    compute_ouput_dense_e_t,
-                    compute_output_token_counts,
-                    output_tensor=preallocated_combine_output,
-                    **ccl.populate_selective_reduce_combine_args(cfg["quad_ring_selective_reduce_combine"]),
-                )
-
-                ttnn.deallocate(compute_output)
-                ttnn.deallocate(compute_output_dense_expert_activation)
-                ttnn.deallocate(compute_ouput_dense_e_t)
-                ttnn.deallocate(compute_output_token_counts)
-
-                combine_output = ttnn.to_layout(
-                    combine_output,
-                    layout=ttnn.TILE_LAYOUT,
-                    memory_config=ttnn.L1_MEMORY_CONFIG,
-                )
-                combine_output = ttnn.unsqueeze(combine_output, dim=1)
-
-                post_combine_output_tensor = ttnn.mul(
-                    combine_output, topk_experts_weights_for_scaling_chunk, **cfg["mul_experts_output_with_weights"]
-                )
+                output_chunks.append(post_combine_output_tensor)
         else:
             # Repeat + Permute Expert weights
             topk_experts_weights = cls._fwd_repeat_permute_expert_weights(topk_experts_weights, cfg)
@@ -915,7 +742,7 @@ class MoE(SharedStateAddOn, AbstractModule):
                 )
                 ttnn.deallocate(topk_weights_chunk)
 
-            output_chunks.append(post_combine_output_tensor)
+                output_chunks.append(post_combine_output_tensor)
 
         if len(output_chunks) == 1:
             post_combine_output_tensor = output_chunks[0]
@@ -926,6 +753,110 @@ class MoE(SharedStateAddOn, AbstractModule):
 
         ttnn.deallocate(x_rm)
         ttnn.deallocate(topk_experts_indices_rm)
+        return post_combine_output_tensor
+
+    @classmethod
+    def _forward_moe_quad_ring_impl(
+        cls,
+        cfg: RunDecodeConfig | RunPrefillConfig,
+        x_rm: ttnn.Tensor,
+        topk_experts_indices_rm: ttnn.Tensor,
+        topk_experts_weights_rm: ttnn.Tensor,
+    ):
+        ccl = cfg["ccl"]
+
+        topk_experts_indices_rm_sharded = ttnn.to_memory_config(
+            topk_experts_indices_rm,
+            memory_config=cfg["quad_ring_all_to_all_dispatch_metadata_sharded_memory_config"],
+        )
+        topk_experts_weights_rm_sharded = ttnn.to_memory_config(
+            topk_experts_weights_rm,
+            memory_config=cfg["quad_ring_all_to_all_dispatch_metadata_sharded_memory_config"],
+        )
+
+        # NOTE: L1 sharded topk_experts_weights need to be deallocated before moe_compute,
+        # configure weights for post combine scaling prior to that deallocation, and store in DRAM
+        topk_experts_weights_for_scaling = ttnn.permute(
+            topk_experts_weights_rm, (3, 1, 0, 2), memory_config=ttnn.L1_MEMORY_CONFIG
+        )
+        topk_experts_weights_for_scaling = ttnn.to_layout(
+            topk_experts_weights_for_scaling, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG
+        )
+
+        ttnn.deallocate(topk_experts_indices_rm)
+        ttnn.deallocate(topk_experts_weights_rm)
+
+        # NOTE: needs to run prior to all_to_all_dispatch_metadata
+        preallocated_combine_output = ttnn.moreh_full(**cfg["quad_ring_moreh_full"])
+
+        (
+            dispatch_output_sparse_buffer,
+            dispatch_output_expert_indices,
+            dispatch_output_expert_scores,
+        ) = ttnn.experimental.all_to_all_dispatch_metadata(
+            x_rm,
+            topk_experts_indices_rm_sharded,
+            topk_experts_weights_rm_sharded,
+            cfg["expert_mapping_tensor"],
+            output_tensors=cfg["quad_ring_preallocated_all_to_all_dispatch_metadata_tensors"],
+            **ccl.populate_all_to_all_dispatch_metadata_args(cfg["quad_ring_all_to_all_dispatch_metadata"]),
+        )
+
+        # deallocation required in order to free up L1 space for moe_compute
+        ttnn.deallocate(x_rm)
+        ttnn.deallocate(topk_experts_indices_rm_sharded)
+        ttnn.deallocate(topk_experts_weights_rm_sharded)
+
+        # NOTE: we are actively working on fusing moe_compute and selective_reduce_combine
+
+        w0_w1 = ()  # TODO: (GR)
+        w2 = ()  # TODO: (GR)
+        layer_id = 0  # TODO: (GR)
+        (
+            compute_output_token_counts,
+            compute_output_dense_expert_activation,
+            compute_ouput_dense_e_t,
+            _,  # tile layout output of selective tilize (same buffer as output)
+            compute_output,
+        ) = ttnn.experimental.moe_compute(
+            dispatch_output_sparse_buffer,
+            dispatch_output_expert_indices,
+            dispatch_output_expert_scores,
+            cfg["expert_mapping_tensor"],
+            w0_w1,
+            w2,
+            layer_id=layer_id,
+            **cfg["quad_ring_moe_compute"],
+        )
+
+        # NOTE: can't deallocate dispatch output tensors as they are preallocated and reused across layers
+
+        combine_output = ttnn.experimental.selective_reduce_combine(
+            compute_output,
+            compute_output_dense_expert_activation,
+            compute_ouput_dense_e_t,
+            compute_output_token_counts,
+            output_tensor=preallocated_combine_output,
+            **ccl.populate_selective_reduce_combine_args(cfg["quad_ring_selective_reduce_combine"]),
+        )
+
+        ttnn.deallocate(compute_output)
+        ttnn.deallocate(compute_output_dense_expert_activation)
+        ttnn.deallocate(compute_ouput_dense_e_t)
+        ttnn.deallocate(compute_output_token_counts)
+
+        combine_output = ttnn.to_layout(
+            combine_output,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
+        )
+        combine_output = ttnn.unsqueeze(combine_output, dim=1)
+
+        post_combine_output_tensor = ttnn.mul(
+            combine_output, topk_experts_weights_for_scaling, **cfg["mul_experts_output_with_weights"]
+        )
+
+        ttnn.deallocate(combine_output)
         return post_combine_output_tensor
 
     @classmethod

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -308,6 +308,11 @@ class MoE(SharedStateAddOn, AbstractModule):
                 worker_mode=ttnn.WorkerMode.DIRECT,
                 dispatch_algorithm=ttnn.DispatchAlgorithm.SPARSE_MCAST_SHORTEST_PATH,
             )
+            config[
+                "quad_ring_all_to_all_dispatch_metadata_sharded_memory_config"
+            ] = AllToAllDispatchMetadataConfig.get_metadata_sharded_memory_config(
+                USERS_PER_ROW, hf_config.num_experts_per_tok
+            )
             config["quad_ring_moreh_full"] = MorehFullConfig(
                 shape=ttnn.Shape([hf_config.num_experts_per_tok, USERS_PER_ROW, hf_config.hidden_size]),
                 fill_value=0,
@@ -333,6 +338,10 @@ class MoE(SharedStateAddOn, AbstractModule):
                 worker_cores=ttnn.experimental.get_moe_combine_cores(mesh_device),
                 mux_core_range_set=ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(3, 0), ttnn.CoreCoord(4, 7))}),
             )
+
+            # TODO: this is a temporary measure until we either a) uplift the optimized ops to support prefill shapes, or b) uplift prefill MMs to read from decode formatted weights
+            # set chunk size for prefill
+            config["moe_chunk_size"] = USERS_PER_ROW
 
         return config
 
@@ -503,14 +512,41 @@ class MoE(SharedStateAddOn, AbstractModule):
         if cfg["fabric_config"] == ttnn.FabricConfig.FABRIC_1D_RING and cfg["num_dispatch_devices"] == 16:
             ccl = cfg["ccl"]
 
-            # L1 sharded topk_experts_weights need to be deallocated before moe_compute
+            # NOTE: can move towards removing these TMs once optimized moe_gate is integrated
+            topk_experts_indices_rm = ttnn.to_layout(
+                topk_experts_indices, ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG
+            )
+            topk_experts_weights_rm = ttnn.to_layout(
+                topk_experts_weights, ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG
+            )
+
+            topk_experts_indices_rm = ttnn.permute(
+                topk_experts_indices_rm, (2, 0, 1, 3), memory_config=ttnn.L1_MEMORY_CONFIG
+            )
+            topk_experts_weights_rm = ttnn.permute(
+                topk_experts_weights_rm, (2, 0, 1, 3), memory_config=ttnn.L1_MEMORY_CONFIG
+            )
+
+            topk_experts_indices_rm_sharded = ttnn.to_memory_config(
+                topk_experts_indices_rm,
+                memory_config=cfg["quad_ring_all_to_all_dispatch_metadata_sharded_memory_config"],
+            )
+            topk_experts_weights_rm_sharded = ttnn.to_memory_config(
+                topk_experts_weights_rm,
+                memory_config=cfg["quad_ring_all_to_all_dispatch_metadata_sharded_memory_config"],
+            )
+
+            # NOTE: L1 sharded topk_experts_weights need to be deallocated before moe_compute,
             # configure weights for post combine scaling prior to that deallocation, and store in DRAM
-            permuted_topk_experts_weights = ttnn.permute(
-                topk_experts_weights, (3, 1, 0, 2), memory_config=ttnn.L1_MEMORY_CONFIG
+            topk_experts_weights_for_scaling = ttnn.permute(
+                topk_experts_weights_rm, (3, 1, 0, 2), memory_config=ttnn.L1_MEMORY_CONFIG
             )
-            permuted_topk_experts_weights = ttnn.to_layout(
-                permuted_topk_experts_weights, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG
+            topk_experts_weights_for_scaling = ttnn.to_layout(
+                topk_experts_weights_for_scaling, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG
             )
+
+            ttnn.deallocate(topk_experts_indices_rm)
+            ttnn.deallocate(topk_experts_weights_rm)
 
             # NOTE: needs to run prior to all_to_all_dispatch_metadata
             preallocated_combine_output = ttnn.moreh_full(**cfg["quad_ring_moreh_full"])
@@ -521,8 +557,8 @@ class MoE(SharedStateAddOn, AbstractModule):
                 dispatch_output_expert_scores,
             ) = ttnn.experimental.all_to_all_dispatch_metadata(
                 x_rm,
-                topk_experts_indices,  # TODO: (GR) need to change shard spec of aho gate module output (once it's merged)
-                topk_experts_weights,  # TODO: (GR) need to change shard spec of aho gate module output (once it's merged)
+                topk_experts_indices_rm_sharded,
+                topk_experts_weights_rm_sharded,
                 cfg["expert_mapping_tensor"],
                 output_tensors=cfg["quad_ring_preallocated_all_to_all_dispatch_metadata_tensors"],
                 **ccl.populate_all_to_all_dispatch_metadata_args(cfg["quad_ring_all_to_all_dispatch_metadata"]),
@@ -579,8 +615,10 @@ class MoE(SharedStateAddOn, AbstractModule):
             combine_output = ttnn.unsqueeze(combine_output, dim=1)
 
             post_combine_output_tensor = ttnn.mul(
-                combine_output, permuted_topk_experts_weights, **cfg["mul_experts_output_with_weights"]
+                combine_output, topk_experts_weights_for_scaling, **cfg["mul_experts_output_with_weights"]
             )
+
+            ttnn.deallocate(combine_output)
         else:
             # Repeat + Permute Expert weights
             topk_experts_weights = cls._fwd_repeat_permute_expert_weights(topk_experts_weights, cfg)
@@ -655,7 +693,6 @@ class MoE(SharedStateAddOn, AbstractModule):
         # Repeat + Permute Expert weights
         topk_experts_weights = cls._fwd_repeat_permute_expert_weights(topk_experts_weights, cfg)
 
-        tokens = batch_size * seq_len
         x_rm = ttnn.to_layout(x, ttnn.ROW_MAJOR_LAYOUT)
         x_rm = ttnn.reshape(
             x_rm,
@@ -696,56 +733,138 @@ class MoE(SharedStateAddOn, AbstractModule):
                 [batch_end, 1, seq_len, cfg["num_experts_per_tok"]],
             )
 
-            all_to_all_dispatch_output_tensors, all_to_all_dispatch_metadata_tensors = ttnn.all_to_all_dispatch(
-                x_chunk,
-                topk_indices_chunk,
-                cfg["expert_mapping_tensors"],
-                **cfg["all_to_all_dispatch"],
-            )
-            ttnn.deallocate(x_chunk)
-            ttnn.deallocate(topk_indices_chunk)
+            if cfg["fabric_config"] == ttnn.FabricConfig.FABRIC_1D_RING and cfg["num_dispatch_devices"] == 16:
+                ccl = cfg["ccl"]
 
-            dispatch_chunk = ttnn.reshape(
-                all_to_all_dispatch_output_tensors,
-                shape=(1, 1, batch_size_chunk * seq_len, cfg["hidden_size"]),
-            )
-            dispatch_chunk = ttnn.repeat(dispatch_chunk, **cfg["activations_repeat"])
-            dispatch_chunk = ttnn.to_layout(dispatch_chunk, ttnn.TILE_LAYOUT)
-            ttnn.deallocate(all_to_all_dispatch_output_tensors)
+                # L1 sharded topk_experts_weights need to be deallocated before moe_compute
+                # configure weights for post combine scaling prior to that deallocation, and store in DRAM
+                permuted_topk_experts_weights = ttnn.permute(
+                    topk_experts_weights, (3, 1, 0, 2), memory_config=ttnn.L1_MEMORY_CONFIG
+                )
+                permuted_topk_experts_weights = ttnn.to_layout(
+                    permuted_topk_experts_weights, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG
+                )
 
-            experts_output = MoEExperts._forward(dispatch_chunk, cfg["moe_experts"])
-            ttnn.deallocate(dispatch_chunk)
+                # NOTE: needs to run prior to all_to_all_dispatch_metadata
+                preallocated_combine_output = ttnn.moreh_full(**cfg["quad_ring_moreh_full"])
 
-            experts_output = ttnn.to_layout(experts_output, ttnn.ROW_MAJOR_LAYOUT)
-            experts_output = ttnn.reshape(
-                experts_output, shape=(cfg["num_experts_per_device"], batch_size_chunk, seq_len, cfg["hidden_size"])
-            )
+                (
+                    dispatch_output_sparse_buffer,
+                    dispatch_output_expert_indices,
+                    dispatch_output_expert_scores,
+                ) = ttnn.experimental.all_to_all_dispatch_metadata(
+                    x_rm,
+                    topk_experts_indices,  # TODO: (GR) need to change shard spec of aho gate module output (once it's merged)
+                    topk_experts_weights,  # TODO: (GR) need to change shard spec of aho gate module output (once it's merged)
+                    cfg["expert_mapping_tensor"],
+                    output_tensors=cfg["quad_ring_preallocated_all_to_all_dispatch_metadata_tensors"],
+                    **ccl.populate_all_to_all_dispatch_metadata_args(cfg["quad_ring_all_to_all_dispatch_metadata"]),
+                )
 
-            all_to_all_dispatch_metadata_tensors = ttnn.reshape(
-                all_to_all_dispatch_metadata_tensors,
-                shape=(1, batch_size_chunk, seq_len, cfg["num_experts_per_tok"]),
-            )
+                # deallocation required in order to free up L1 space for moe_compute
+                ttnn.deallocate(x_rm)
+                ttnn.deallocate(topk_experts_indices)
+                ttnn.deallocate(topk_experts_weights)
 
-            all_to_all_combine_output_tensors = ttnn.all_to_all_combine(
-                experts_output,
-                all_to_all_dispatch_metadata_tensors,
-                cfg["expert_mapping_tensors"],
-                **cfg["all_to_all_combine"],
-            )
-            ttnn.deallocate(experts_output)
-            ttnn.deallocate(all_to_all_dispatch_metadata_tensors)
+                # NOTE: we are actively working on fusing moe_compute and selective_reduce_combine
 
-            post_combine_output_tensor = ttnn.reshape(
-                all_to_all_combine_output_tensors,
-                shape=(cfg["num_experts_per_tok"], 1, batch_chunk * seq_len, cfg["hidden_size"]),
-            )
-            post_combine_output_tensor = ttnn.to_layout(post_combine_output_tensor, ttnn.TILE_LAYOUT)
+                w0_w1 = ()  # TODO: (GR)
+                w2 = ()  # TODO: (GR)
+                layer_id = 0  # TODO: (GR)
+                (
+                    compute_output_token_counts,
+                    compute_output_dense_expert_activation,
+                    compute_ouput_dense_e_t,
+                    _,  # tile layout output of selective tilize (same buffer as output)
+                    compute_output,
+                ) = ttnn.experimental.moe_compute(
+                    dispatch_output_sparse_buffer,
+                    dispatch_output_expert_indices,
+                    dispatch_output_expert_scores,
+                    cfg["expert_mapping_tensor"],
+                    w0_w1,
+                    w2,
+                    layer_id=layer_id,
+                    **cfg["quad_ring_moe_compute"],
+                )
 
-            topk_weights_chunk = _slice_topk_weights(batch_start, batch_end)
-            post_combine_output_tensor = ttnn.mul(
-                post_combine_output_tensor, topk_weights_chunk, **cfg["mul_experts_output_with_weights"]
-            )
-            ttnn.deallocate(topk_weights_chunk)
+                # NOTE: can't deallocate dispatch output tensors as they are preallocated and reused across layers
+
+                combine_output = ttnn.experimental.selective_reduce_combine(
+                    compute_output,
+                    compute_output_dense_expert_activation,
+                    compute_ouput_dense_e_t,
+                    compute_output_token_counts,
+                    output_tensor=preallocated_combine_output,
+                    **ccl.populate_selective_reduce_combine_args(cfg["quad_ring_selective_reduce_combine"]),
+                )
+
+                ttnn.deallocate(compute_output)
+                ttnn.deallocate(compute_output_dense_expert_activation)
+                ttnn.deallocate(compute_ouput_dense_e_t)
+                ttnn.deallocate(compute_output_token_counts)
+
+                combine_output = ttnn.to_layout(
+                    combine_output,
+                    layout=ttnn.TILE_LAYOUT,
+                    memory_config=ttnn.L1_MEMORY_CONFIG,
+                )
+                combine_output = ttnn.unsqueeze(combine_output, dim=1)
+
+                post_combine_output_tensor = ttnn.mul(
+                    combine_output, permuted_topk_experts_weights, **cfg["mul_experts_output_with_weights"]
+                )
+            else:
+                all_to_all_dispatch_output_tensors, all_to_all_dispatch_metadata_tensors = ttnn.all_to_all_dispatch(
+                    x_chunk,
+                    topk_indices_chunk,
+                    cfg["expert_mapping_tensors"],
+                    **cfg["all_to_all_dispatch"],
+                )
+                ttnn.deallocate(x_chunk)
+                ttnn.deallocate(topk_indices_chunk)
+
+                dispatch_chunk = ttnn.reshape(
+                    all_to_all_dispatch_output_tensors,
+                    shape=(1, 1, batch_size_chunk * seq_len, cfg["hidden_size"]),
+                )
+                dispatch_chunk = ttnn.repeat(dispatch_chunk, **cfg["activations_repeat"])
+                dispatch_chunk = ttnn.to_layout(dispatch_chunk, ttnn.TILE_LAYOUT)
+                ttnn.deallocate(all_to_all_dispatch_output_tensors)
+
+                experts_output = MoEExperts._forward(dispatch_chunk, cfg["moe_experts"])
+                ttnn.deallocate(dispatch_chunk)
+
+                experts_output = ttnn.to_layout(experts_output, ttnn.ROW_MAJOR_LAYOUT)
+                experts_output = ttnn.reshape(
+                    experts_output, shape=(cfg["num_experts_per_device"], batch_size_chunk, seq_len, cfg["hidden_size"])
+                )
+
+                all_to_all_dispatch_metadata_tensors = ttnn.reshape(
+                    all_to_all_dispatch_metadata_tensors,
+                    shape=(1, batch_size_chunk, seq_len, cfg["num_experts_per_tok"]),
+                )
+
+                all_to_all_combine_output_tensors = ttnn.all_to_all_combine(
+                    experts_output,
+                    all_to_all_dispatch_metadata_tensors,
+                    cfg["expert_mapping_tensors"],
+                    **cfg["all_to_all_combine"],
+                )
+                ttnn.deallocate(experts_output)
+                ttnn.deallocate(all_to_all_dispatch_metadata_tensors)
+
+                post_combine_output_tensor = ttnn.reshape(
+                    all_to_all_combine_output_tensors,
+                    shape=(cfg["num_experts_per_tok"], 1, batch_chunk * seq_len, cfg["hidden_size"]),
+                )
+                post_combine_output_tensor = ttnn.to_layout(post_combine_output_tensor, ttnn.TILE_LAYOUT)
+
+                topk_weights_chunk = _slice_topk_weights(batch_start, batch_end)
+                post_combine_output_tensor = ttnn.mul(
+                    post_combine_output_tensor, topk_weights_chunk, **cfg["mul_experts_output_with_weights"]
+                )
+                ttnn.deallocate(topk_weights_chunk)
 
             output_chunks.append(post_combine_output_tensor)
 

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -514,8 +514,8 @@ class MoE(SharedStateAddOn, AbstractModule):
                 dispatch_output_expert_scores,
             ) = ttnn.experimental.all_to_all_dispatch_metadata(
                 x_rm,
-                topk_experts_indices,  # TODO: (GR) may need to change shard spec of aho gate output
-                topk_experts_weights,  # TODO: (GR) may need to change shard spec of aho gate output
+                topk_experts_indices,  # TODO: (GR) need to change shard spec of aho gate module output (once it's merged)
+                topk_experts_weights,  # TODO: (GR) need to change shard spec of aho gate module output (once it's merged)
                 cfg["expert_mapping_tensor"],
                 **ccl.populate_all_to_all_dispatch_metadata_args(cfg["quad_ring_all_to_all_dispatch_metadata"]),
             )
@@ -524,6 +524,8 @@ class MoE(SharedStateAddOn, AbstractModule):
             ttnn.deallocate(x_rm)
             ttnn.deallocate(topk_experts_indices)
             ttnn.deallocate(topk_experts_weights)
+
+            # NOTE: we are actively working on fusing moe_compute and selective_reduce_combine
 
             w0_w1 = ()  # TODO: (GR)
             w2 = ()  # TODO: (GR)

--- a/models/demos/deepseek_v3/utils/config_dataclass.py
+++ b/models/demos/deepseek_v3/utils/config_dataclass.py
@@ -458,6 +458,23 @@ class AllToAllDispatchMetadataConfig(OpConfigBase):
             preallocated_dispatch_output_expert_scores,
         )
 
+    @classmethod
+    def get_metadata_sharded_memory_config(cls, users_per_row: int, num_experts_per_tok: int):
+        num_cores_y = min(8, users_per_row)
+        num_cores_x = (users_per_row + num_cores_y - 1) // num_cores_y
+
+        return ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
+                ttnn.CoreRangeSet(
+                    {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_cores_x - 1, num_cores_y - 1))}
+                ),
+                [1, num_experts_per_tok],
+                ttnn.ShardOrientation.ROW_MAJOR,
+            ),
+        )
+
     cluster_axis: int | None = None
     num_links: int | None = 4
     worker_mode: ttnn.WorkerMode

--- a/models/demos/deepseek_v3/utils/config_dataclass.py
+++ b/models/demos/deepseek_v3/utils/config_dataclass.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass, fields
 from pathlib import Path
 from typing import Any, Union
 
+import torch
+
 import ttnn
 
 optimal_topology = ttnn.Topology.Ring if (os.getenv("USE_TORUS_MODE") is not None) else ttnn.Topology.Linear
@@ -394,6 +396,100 @@ class AllToAllCombineConfig(OpConfigBase):
     memory_config: ttnn.MemoryConfig
     num_links: int | None = None
     topology: ttnn.Topology = optimal_topology
+
+
+@dataclass
+class AllToAllDispatchMetadataConfig(OpConfigBase):
+    """Common parameters for a ttnn.all_to_all_dispatch_metadata op"""
+
+    @classmethod
+    def create_preallocated_dispatch_output_tensors(
+        mesh_device, mesh_shape, dispatch_devices, batch, hidden_size, num_experts_per_tok
+    ):
+        preallocated_dispatch_output_sparse_buffer = ttnn.from_torch(
+            torch.zeros([dispatch_devices, batch, hidden_size], dtype=torch.bfloat16),
+            device=mesh_device,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            dtype=ttnn.bfloat16,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(0, None), mesh_shape=mesh_shape),
+        )
+
+        preallocated_dispatch_output_expert_indices = ttnn.from_torch(
+            torch.zeros([dispatch_devices, batch, num_experts_per_tok], dtype=torch.uint16),
+            device=mesh_device,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            dtype=ttnn.uint16,
+            memory_config=ttnn.MemoryConfig(
+                ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+                ttnn.BufferType.L1,
+                ttnn.ShardSpec(
+                    ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(6, 9), ttnn.CoreCoord(6, 9))}),
+                    [batch, num_experts_per_tok],
+                    ttnn.ShardOrientation.ROW_MAJOR,
+                ),
+            ),
+            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(0, None), mesh_shape=mesh_shape),
+        )
+
+        preallocated_dispatch_output_expert_scores = ttnn.from_torch(
+            torch.zeros([dispatch_devices, batch, num_experts_per_tok], dtype=torch.bfloat16),
+            device=mesh_device,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            dtype=ttnn.bfloat16,
+            memory_config=ttnn.MemoryConfig(
+                ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+                ttnn.BufferType.L1,
+                ttnn.ShardSpec(
+                    ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(6, 9), ttnn.CoreCoord(6, 9))}),
+                    [batch, num_experts_per_tok],
+                    ttnn.ShardOrientation.ROW_MAJOR,
+                ),
+            ),
+            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(0, None), mesh_shape=mesh_shape),
+        )
+
+        return (
+            preallocated_dispatch_output_sparse_buffer,
+            preallocated_dispatch_output_expert_indices,
+            preallocated_dispatch_output_expert_scores,
+        )
+
+    cluster_axis: int | None = None
+    num_links: int | None = 4
+    worker_mode: ttnn.WorkerMode
+    dispatch_algorithm: ttnn.DispatchAlgorithm
+    output_tensors: list[ttnn.Tensor] | None = None
+    cross_device_semaphore: ttnn.global_semaphore.global_semaphore | None = None
+
+
+@dataclass
+class MoEComputeConfig(OpConfigBase):
+    """Common parameters for a ttnn.moe_compute op"""
+
+    output_height_shard_dim: int
+    output_width_shard_dim: int
+    cluster_axis: int | None = None
+
+
+@dataclass
+class SelectiveReduceCombineConfig(OpConfigBase):
+    """Common parameters for a ttnn.selective_reduce_combine op"""
+
+    hidden_size: int
+    batch: int
+    seq: int
+    select_experts_k: int
+    experts: int
+    axis: int | None = None
+    topology: ttnn.Topology = ttnn.Topology.Ring
+    num_links: int = 4
+    token_parallel_core_dim: int
+    data_parallel_core_dim: int
+    worker_cores: list[ttnn.CoreCoord]
+    mux_core_range_set: ttnn.CoreRangeset
+    output_tensor: ttnn.Tensor | None = None
+    optional_cross_device_semaphore: ttnn.global_semaphore.global_semaphore | None = None
 
 
 @dataclass

--- a/models/demos/deepseek_v3/utils/config_dataclass.py
+++ b/models/demos/deepseek_v3/utils/config_dataclass.py
@@ -403,7 +403,9 @@ class AllToAllDispatchMetadataConfig(OpConfigBase):
     """Common parameters for a ttnn.all_to_all_dispatch_metadata op"""
 
     @classmethod
-    def create_preallocated_dispatch_output_tensors(mesh_device, batch, hidden_size, num_experts_per_tok):
+    def create_preallocated_dispatch_output_tensors(
+        cls, mesh_device: ttnn.Device, batch: int, hidden_size: int, num_experts_per_tok: int
+    ):
         mesh_shape = mesh_device.shape
         dispatch_devices = mesh_shape[0]
 

--- a/models/demos/deepseek_v3/utils/config_dataclass.py
+++ b/models/demos/deepseek_v3/utils/config_dataclass.py
@@ -403,9 +403,10 @@ class AllToAllDispatchMetadataConfig(OpConfigBase):
     """Common parameters for a ttnn.all_to_all_dispatch_metadata op"""
 
     @classmethod
-    def create_preallocated_dispatch_output_tensors(
-        mesh_device, mesh_shape, dispatch_devices, batch, hidden_size, num_experts_per_tok
-    ):
+    def create_preallocated_dispatch_output_tensors(mesh_device, batch, hidden_size, num_experts_per_tok):
+        mesh_shape = mesh_device.shape
+        dispatch_devices = mesh_shape[0]
+
         preallocated_dispatch_output_sparse_buffer = ttnn.from_torch(
             torch.zeros([dispatch_devices, batch, hidden_size], dtype=torch.bfloat16),
             device=mesh_device,
@@ -461,6 +462,16 @@ class AllToAllDispatchMetadataConfig(OpConfigBase):
     dispatch_algorithm: ttnn.DispatchAlgorithm
     output_tensors: list[ttnn.Tensor] | None = None
     cross_device_semaphore: ttnn.global_semaphore.global_semaphore | None = None
+
+
+@dataclass
+class MorehFullConfig(OpConfigBase):
+    shape: ttnn.Shape
+    fill_value: int
+    device: ttnn.Device
+    dtype: ttnn.DataType
+    layout: ttnn.layout
+    memory_config: ttnn.MemoryConfig
 
 
 @dataclass

--- a/models/demos/deepseek_v3/utils/config_dataclass.py
+++ b/models/demos/deepseek_v3/utils/config_dataclass.py
@@ -462,7 +462,6 @@ class AllToAllDispatchMetadataConfig(OpConfigBase):
     num_links: int | None = 4
     worker_mode: ttnn.WorkerMode
     dispatch_algorithm: ttnn.DispatchAlgorithm
-    output_tensors: list[ttnn.Tensor] | None = None
     cross_device_semaphore: ttnn.global_semaphore.global_semaphore | None = None
 
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/38704)

### Problem description
- Integrates the optimized MoE ops into high batch deepseek
- Optimized ops are only functional for quad decode, and require ring fabric 


### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=grechsteiner/moe-integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:grechsteiner/moe-integration)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=grechsteiner/moe-integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:grechsteiner/moe-integration)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=grechsteiner/moe-integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:grechsteiner/moe-integration)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=grechsteiner/moe-integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:grechsteiner/moe-integration)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=grechsteiner/moe-integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:grechsteiner/moe-integration)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=grechsteiner/moe-integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:grechsteiner/moe-integration)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
