### PR TITLE
#36408: adjust gn cbs for repack

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
@@ -451,9 +451,13 @@ def generate_sdxl_test_inputs():
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 0}], indirect=True)
 @pytest.mark.parametrize("input_shape", generate_sdxl_test_inputs())
 @pytest.mark.parametrize("use_welford", welford_flavors, ids=welford_ids)
-def test_sdxl_base_group_norm(device, input_shape, use_welford, perf_test_mode=False):
+@pytest.mark.parametrize("inplace", [True, False])
+def test_sdxl_base_group_norm(device, input_shape, use_welford, inplace, perf_test_mode=False):
     num_groups = 32  #  always 32 for SDXL Base
     N, C, H, W = input_shape
+    layout = ttnn.TILE_LAYOUT if C == 512 else ttnn.ROW_MAJOR_LAYOUT
+    if layout == ttnn.TILE_LAYOUT and inplace:
+        pytest.skip("Tile layout requires non-inplace tensors.")
     torch.manual_seed(0)
     if device.core_grid.y == 7:
         pytest.skip()
@@ -477,7 +481,7 @@ def test_sdxl_base_group_norm(device, input_shape, use_welford, perf_test_mode=F
     tt_input_tensor = ttnn.from_torch(
         tt_input_tensor,
         dtype=ttnn.DataType.BFLOAT16,
-        layout=ttnn.TILE_LAYOUT if C == 512 else ttnn.ROW_MAJOR_LAYOUT,
+        layout=layout,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
         device=device,
     )
@@ -503,7 +507,7 @@ def test_sdxl_base_group_norm(device, input_shape, use_welford, perf_test_mode=F
         input_mask=input_mask_tensor,
         memory_config=sharded_mem_config,
         core_grid=grid_size,
-        inplace=tt_input_tensor.layout != ttnn.TILE_LAYOUT,
+        inplace=inplace,
         use_welford=use_welford,
     )
     ttnn.synchronize_device(device)

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
@@ -437,8 +437,7 @@ def generate_sdxl_test_inputs():
     inputs.append((1, 640, 16, 16))
     inputs.append((1, 1280, 16, 16))
     inputs.append((1, 2560, 16, 16))
-    # This test is removed to test_group_norm_DRAM because of the Issue #36408. To be added back after the issue is resolved.
-    # inputs.append((1, 1920, 16, 16))
+    inputs.append((1, 1920, 16, 16))
     inputs.append((1, 1920, 32, 32))
     inputs.append((1, 1280, 32, 32))
     inputs.append((1, 960, 32, 32))

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
@@ -448,14 +448,8 @@ def generate_sdxl_test_inputs():
     return inputs
 
 
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 0}], indirect=True)
-@pytest.mark.parametrize("input_shape", generate_sdxl_test_inputs())
-@pytest.mark.parametrize("use_welford", welford_flavors, ids=welford_ids)
-@pytest.mark.parametrize("inplace", [True, False])
-def test_sdxl_base_group_norm(device, input_shape, use_welford, inplace, perf_test_mode=False):
+def run_sdxl_base_group_norm_test(device, N, C, H, W, use_welford, layout, inplace, perf_test_mode=False):
     num_groups = 32  #  always 32 for SDXL Base
-    N, C, H, W = input_shape
-    layout = ttnn.TILE_LAYOUT if C == 512 else ttnn.ROW_MAJOR_LAYOUT
     if layout == ttnn.TILE_LAYOUT and inplace:
         pytest.skip("Tile layout requires non-inplace tensors.")
     torch.manual_seed(0)
@@ -469,7 +463,7 @@ def test_sdxl_base_group_norm(device, input_shape, use_welford, inplace, perf_te
         grid_size = ttnn.CoreGrid(y=8, x=8)
 
     # Generate torch tensor
-    torch_input_tensor = torch.rand(input_shape, dtype=torch.bfloat16)
+    torch_input_tensor = torch.rand((N, C, H, W), dtype=torch.bfloat16)
 
     if not perf_test_mode:
         # Execute torch group_norm
@@ -517,6 +511,33 @@ def test_sdxl_base_group_norm(device, input_shape, use_welford, inplace, perf_te
         tt_output_tensor = ttnn.to_torch(tt_output_tensor)
 
         assert_with_pcc(torch_output_tensor, tt_output_tensor, 0.9996)
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 0}], indirect=True)
+@pytest.mark.parametrize("input_shape", generate_sdxl_test_inputs())
+@pytest.mark.parametrize("use_welford", welford_flavors, ids=welford_ids)
+# Paramemeters need to stay consistent with usage in
+# models/demos/stable_diffusion_xl_base/tests/test_sdxl_op_unit_test_perf.py::test_block_sharded_group_norm_sdxl_performance
+def test_sdxl_base_group_norm(device, input_shape, use_welford, perf_test_mode=False):
+    # Only one test case has C == 512, which has TILE_LAYOUT and inplace False
+    # ALL other inputs have ROW_MAJOR_LAYOUT and inplace True
+    N, C, H, W = input_shape
+    layout = ttnn.TILE_LAYOUT if C == 512 else ttnn.ROW_MAJOR_LAYOUT
+    inplace = C != 512
+    run_sdxl_base_group_norm_test(device, N, C, H, W, use_welford, layout, inplace, perf_test_mode)
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 0}], indirect=True)
+@pytest.mark.parametrize("input_shape", generate_sdxl_test_inputs())
+@pytest.mark.parametrize("use_welford", welford_flavors, ids=welford_ids)
+# Oppositive of previous test in terms of inplace, for full coverage purposes.
+def test_sdxl_group_norm_reverse_inplace(device, input_shape, use_welford, perf_test_mode=False):
+    # Only one test case has C == 512, which has TILE_LAYOUT and inplace True
+    # ALL other inputs have ROW_MAJOR_LAYOUT and inplace False
+    N, C, H, W = input_shape
+    layout = ttnn.TILE_LAYOUT if C == 512 else ttnn.ROW_MAJOR_LAYOUT
+    inplace = C == 512
+    run_sdxl_base_group_norm_test(device, N, C, H, W, use_welford, layout, inplace, perf_test_mode)
 
 
 def generate_sdxl_test_inputs_neg_mask():

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
@@ -723,12 +723,14 @@ GroupNormShardedProgramFactory::cached_program_t GroupNormShardedProgramFactory:
     } else {
         tt::tt_metal::CircularBufferConfig in0_cb_config =
             tt::tt_metal::CircularBufferConfig(in0_CB_size, {{in0_cb_index, in_data_format}})
-                .set_page_size(in0_cb_index, in_single_tile_size)
+                .set_page_size(in0_cb_index, in0_cb_page_size)
                 .set_globally_allocated_address(*a.buffer());
 
+        uint32_t out_cb_total_size = reader_repack_output ? output.buffer()->aligned_size_per_bank() : out_CB_size;
+        uint32_t out_cb_page_size = reader_repack_output ? output.buffer()->page_size() : out_single_tile_size;
         tt::tt_metal::CircularBufferConfig output_cb_config =
-            tt::tt_metal::CircularBufferConfig(out_CB_size, {{output_cb_index, out_data_format}})
-                .set_page_size(output_cb_index, out_single_tile_size)
+            tt::tt_metal::CircularBufferConfig(out_cb_total_size, {{output_cb_index, out_data_format}})
+                .set_page_size(output_cb_index, out_cb_page_size)
                 .set_globally_allocated_address(*output.buffer());
 
         cb_in0 = tt::tt_metal::CreateCircularBuffer(program, all_cores, in0_cb_config);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
@@ -708,13 +708,14 @@ GroupNormShardedProgramFactory::cached_program_t GroupNormShardedProgramFactory:
     uint32_t output_cb_index = tt::CBIndex::c_16;
     CBHandle cb_in0;
     CBHandle cb_output;
+    uint32_t in0_cb_page_size = reader_repack_output ? a.buffer()->page_size() : in_single_tile_size;
     if (inplace) {
         std::map<uint8_t, tt::DataFormat> in0_out0_cb_data_format_spec{
             {in0_cb_index, in_data_format}, {output_cb_index, in_data_format}};
         CircularBufferConfig in0_out0_cb_config =
             tt::tt_metal::CircularBufferConfig(in0_CB_size, in0_out0_cb_data_format_spec)
-                .set_page_size(in0_cb_index, in_single_tile_size)
-                .set_page_size(output_cb_index, in_single_tile_size)
+                .set_page_size(in0_cb_index, in0_cb_page_size)
+                .set_page_size(output_cb_index, in0_cb_page_size)
                 .set_globally_allocated_address(*a.buffer());
 
         cb_in0 = tt::tt_metal::CreateCircularBuffer(program, all_cores, in0_out0_cb_config);


### PR DESCRIPTION
### Ticket
Link to Github Issue #36408

### Problem description
An sdxl resulted in an error for group norm: "Failed allocation attempt on buffer index 0. Total circular buffer size 5120 B must be divisible by page size 2048 B"
The reason is that in0 is a single tile sized but in the specific input the input is not tiled.

### What's changed
- For the specific scenario where input is not tiled and is repacked, use stick size for page size.
- Adjust both input and output CBs where required.
- Adjust tests to maintain format for upstream dependencies while testing appropriate combinations.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-36408_gn_in0)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-36408_gn_in0)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-36408_gn_in0)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-36408_gn_in0)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-36408_gn_in0)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-36408_gn_in0)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-36408_gn_in0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-36408_gn_in0)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-36408_gn_in0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-36408_gn_in0)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-36408_gn_in0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-36408_gn_in0)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
