### PR TITLE
Add support for batched prefill for Qwen3-VL-32B

### DIFF
--- a/models/demos/qwen3_vl/demo/combined.py
+++ b/models/demos/qwen3_vl/demo/combined.py
@@ -16,132 +16,6 @@ import ttnn
 from models.demos.qwen3_vl.tt.model import DropInVisionTransformer
 from models.demos.qwen3_vl.tt.model_config import VisionModelArgs
 
-# @torch.no_grad()
-# @pytest.mark.parametrize(
-#     "mesh_device",
-#     [{"T3K": (1, 8), "TG": (8, 4)}.get(os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids()))],
-#     indirect=True,
-# )
-# @pytest.mark.parametrize(
-#     "image_input, text_input, expected_output",
-#     [
-#         (
-#             "file://models/sample_data/house_in_field_1080p.jpg",
-#             "Describe this image.",
-#             """This image is a vibrant, highly saturated landscape photograph that captures a serene and idyllic rural scene. The composition is symmetrical and balanced, with a striking reflection in the foreground.
-#             **Key Elements:**
-
-#             - **The House:** A charming, two-story brick house with a warm, terracotta-colored tiled roof sits on a lush green hill. The house features multiple white-framed windows, some arched, and a small balcony or overhang on the right side. Two chimneys are visible on the roof. The architecture suggests a European countryside style.
-
-#             - **The Landscape:** The house is nestled on a gently sloping,""",
-#         ),
-#         (
-#             "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen-VL/assets/demo.jpeg",
-#             "Describe this image.",
-#             """This is a heartwarming and serene photograph capturing a joyful moment between a woman and her dog on a beach at sunset.
-
-#             **Main Subjects:**
-#             - **The Woman:** She is sitting cross-legged on the sand, facing her dog. She has long, dark hair and is wearing a blue and white plaid shirt with rolled-up sleeves and dark pants. She is smiling warmly, looking at her dog, and holding a small treat in her hand. Her left wrist has a white watch or band.
-#             - **The Dog:** A golden-colored Labrador Retriever, likely a yellow lab, is sitting upright on the sand, facing the""",
-#         ),
-#         (
-#             "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png",
-#             "Transcribe the text in the image.",
-#             """Fractal Generative Models
-
-#             4.4. Relation to Long-Sequence Modeling
-#             Most previous work on pixel-by-pixel generation formulates the problem as long-sequence modeling and leverages methods from language modeling to address it (Child et al., 2019; Roy et al., 2021; Ren et al., 2021; Hawthorne et al., 2022; Yu et al., 2023). However, the intrinsic structures of many data types, including but not limited to images, are beyond one-dimensional sequences. Different from these methods, we treat such""",
-#         ),
-#     ],
-#     ids=["72dpi", "240dpi", "300dpi"],
-# )
-# @pytest.mark.parametrize(
-#     "use_tt_vision",
-#     [True],
-#     ids=["hf_vision"],
-# )
-# @pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
-# def test_qwen_vl_end_to_end(
-#     mesh_device,
-#     reset_seeds,
-#     ensure_gc,
-#     ensure_nltk,
-#     image_input,
-#     text_input,
-#     expected_output,
-#     use_tt_vision,
-#     is_ci_env,
-#     request,
-# ):
-#     test_id = request.node.callspec.id
-#     if is_ci_env and not "240dpi" in test_id:
-#         pytest.skip("CI only runs 240dpi image test for compromise of coverage and time limit")
-
-#     """Test end-to-end Qwen3-VL model with options to replace vision component."""
-#     batch_size = 1  # use batch size 1 for now to run the test in reasonable amount of time in CI
-#     max_new_tokens = 200
-
-#     # Load model and processor
-#     model_name = os.environ.get("HF_MODEL", "Qwen/Qwen3-VL-32B-Instruct")
-#     assert "Qwen3-VL-32B".lower() in model_name.lower(), "This test uses only Qwen3-VL-32B for fast accuracy checking"
-#     model = Qwen3VLForConditionalGeneration.from_pretrained(model_name, torch_dtype="auto", device_map="auto")
-#     processor = AutoProcessor.from_pretrained(model_name)
-
-#     # Sample image input to trigger vision model
-#     messages = [
-#         [
-#             {
-#                 "role": "user",
-#                 "content": [
-#                     {
-#                         "type": "image",
-#                         "image": image_input,
-#                     },
-#                     {"type": "text", "text": text_input},
-#                 ],
-#             }
-#         ]
-#     ] * batch_size
-
-#     # Process inputs
-#     text = processor.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
-#     image_inputs, video_inputs = process_vision_info(messages)
-#     inputs = processor(
-#         text=text,
-#         images=image_inputs,
-#         videos=video_inputs,
-#         padding=True,
-#         return_tensors="pt",
-#     ).to(model.device)
-
-#     # Optionally use TT vision model
-#     if use_tt_vision:
-#         # Create the TorchVisionTransformer wrapper using the original vision model as reference
-#         model_args = VisionModelArgs(mesh_device, max_batch_size=batch_size, max_seq_len=max_new_tokens)
-#         model.model.visual = DropInVisionTransformer(model.visual, model_args, debug=True)  # show PCC
-
-#     # Run inference
-#     logger.info("Running model generation...")
-#     generated_ids = model.generate(**inputs, max_new_tokens=max_new_tokens, do_sample=False)
-#     generated_ids_trimmed = [out_ids[len(in_ids) :] for in_ids, out_ids in zip(inputs.input_ids, generated_ids)]
-#     output_texts = processor.batch_decode(
-#         generated_ids_trimmed, skip_special_tokens=True, clean_up_tokenization_spaces=False
-#     )
-
-#     # Verify output
-#     # Token-level BLEU score (standard for text generation)
-#     for i, output_text in enumerate(output_texts):
-#         logger.info(f"Expected output: {expected_output}")
-#         logger.info(f"Generated output {i}: {output_text}")
-
-#         reference = [word_tokenize(expected_output.lower())]
-#         candidate = word_tokenize(output_text.lower())
-#         bleu_score = sentence_bleu(reference, candidate)
-#         logger.info(f"BLEU score of output {i}: {bleu_score:.3f}")
-#         assert bleu_score > 0.5
-
-#     logger.info(f"Test passed with {'TorchVisionTransformer' if use_tt_vision else 'original vision model'}")
-
 
 @torch.no_grad()
 @pytest.mark.parametrize(
@@ -188,7 +62,7 @@ def test_qwen_vl(
 ):
     os.environ["MAX_PREFILL_CHUNK_SIZE"] = "4"
     """Test end-to-end Qwen3-VL model with options to replace vision component."""
-    batch_size = 4  # use batch size 1 for now to run the test in reasonable amount of time in CI
+    batch_size = 4
     max_new_tokens = 200
 
     # Load model and processor
@@ -233,21 +107,3 @@ def test_qwen_vl(
     # Run inference
     logger.info("Running model generation...")
     generated_ids = model.generate(**inputs, max_new_tokens=max_new_tokens, do_sample=False)
-    # generated_ids_trimmed = [out_ids[len(in_ids) :] for in_ids, out_ids in zip(inputs.input_ids, generated_ids)]
-    # output_texts = processor.batch_decode(
-    #     generated_ids_trimmed, skip_special_tokens=True, clean_up_tokenization_spaces=False
-    # )
-
-    # # Verify output
-    # # Token-level BLEU score (standard for text generation)
-    # for i, output_text in enumerate(output_texts):
-    #     logger.info(f"Expected output: {expected_output}")
-    #     logger.info(f"Generated output {i}: {output_text}")
-
-    #     reference = [word_tokenize(expected_output.lower())]
-    #     candidate = word_tokenize(output_text.lower())
-    #     bleu_score = sentence_bleu(reference, candidate)
-    #     logger.info(f"BLEU score of output {i}: {bleu_score:.3f}")
-    #     assert bleu_score > 0.5
-
-    # logger.info(f"Test passed with {'TorchVisionTransformer' if use_tt_vision else 'original vision model'}")

--- a/models/demos/qwen3_vl/demo/combined.py
+++ b/models/demos/qwen3_vl/demo/combined.py
@@ -8,8 +8,6 @@ import os
 import pytest
 import torch
 from loguru import logger
-from nltk.tokenize import word_tokenize
-from nltk.translate.bleu_score import sentence_bleu
 from qwen_vl_utils import process_vision_info
 from transformers import AutoProcessor
 from transformers.models.qwen3_vl.modeling_qwen3_vl import Qwen3VLForConditionalGeneration
@@ -18,11 +16,141 @@ import ttnn
 from models.demos.qwen3_vl.tt.model import DropInVisionTransformer
 from models.demos.qwen3_vl.tt.model_config import VisionModelArgs
 
+# @torch.no_grad()
+# @pytest.mark.parametrize(
+#     "mesh_device",
+#     [{"T3K": (1, 8), "TG": (8, 4)}.get(os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids()))],
+#     indirect=True,
+# )
+# @pytest.mark.parametrize(
+#     "image_input, text_input, expected_output",
+#     [
+#         (
+#             "file://models/sample_data/house_in_field_1080p.jpg",
+#             "Describe this image.",
+#             """This image is a vibrant, highly saturated landscape photograph that captures a serene and idyllic rural scene. The composition is symmetrical and balanced, with a striking reflection in the foreground.
+#             **Key Elements:**
+
+#             - **The House:** A charming, two-story brick house with a warm, terracotta-colored tiled roof sits on a lush green hill. The house features multiple white-framed windows, some arched, and a small balcony or overhang on the right side. Two chimneys are visible on the roof. The architecture suggests a European countryside style.
+
+#             - **The Landscape:** The house is nestled on a gently sloping,""",
+#         ),
+#         (
+#             "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen-VL/assets/demo.jpeg",
+#             "Describe this image.",
+#             """This is a heartwarming and serene photograph capturing a joyful moment between a woman and her dog on a beach at sunset.
+
+#             **Main Subjects:**
+#             - **The Woman:** She is sitting cross-legged on the sand, facing her dog. She has long, dark hair and is wearing a blue and white plaid shirt with rolled-up sleeves and dark pants. She is smiling warmly, looking at her dog, and holding a small treat in her hand. Her left wrist has a white watch or band.
+#             - **The Dog:** A golden-colored Labrador Retriever, likely a yellow lab, is sitting upright on the sand, facing the""",
+#         ),
+#         (
+#             "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png",
+#             "Transcribe the text in the image.",
+#             """Fractal Generative Models
+
+#             4.4. Relation to Long-Sequence Modeling
+#             Most previous work on pixel-by-pixel generation formulates the problem as long-sequence modeling and leverages methods from language modeling to address it (Child et al., 2019; Roy et al., 2021; Ren et al., 2021; Hawthorne et al., 2022; Yu et al., 2023). However, the intrinsic structures of many data types, including but not limited to images, are beyond one-dimensional sequences. Different from these methods, we treat such""",
+#         ),
+#     ],
+#     ids=["72dpi", "240dpi", "300dpi"],
+# )
+# @pytest.mark.parametrize(
+#     "use_tt_vision",
+#     [True],
+#     ids=["hf_vision"],
+# )
+# @pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
+# def test_qwen_vl_end_to_end(
+#     mesh_device,
+#     reset_seeds,
+#     ensure_gc,
+#     ensure_nltk,
+#     image_input,
+#     text_input,
+#     expected_output,
+#     use_tt_vision,
+#     is_ci_env,
+#     request,
+# ):
+#     test_id = request.node.callspec.id
+#     if is_ci_env and not "240dpi" in test_id:
+#         pytest.skip("CI only runs 240dpi image test for compromise of coverage and time limit")
+
+#     """Test end-to-end Qwen3-VL model with options to replace vision component."""
+#     batch_size = 1  # use batch size 1 for now to run the test in reasonable amount of time in CI
+#     max_new_tokens = 200
+
+#     # Load model and processor
+#     model_name = os.environ.get("HF_MODEL", "Qwen/Qwen3-VL-32B-Instruct")
+#     assert "Qwen3-VL-32B".lower() in model_name.lower(), "This test uses only Qwen3-VL-32B for fast accuracy checking"
+#     model = Qwen3VLForConditionalGeneration.from_pretrained(model_name, torch_dtype="auto", device_map="auto")
+#     processor = AutoProcessor.from_pretrained(model_name)
+
+#     # Sample image input to trigger vision model
+#     messages = [
+#         [
+#             {
+#                 "role": "user",
+#                 "content": [
+#                     {
+#                         "type": "image",
+#                         "image": image_input,
+#                     },
+#                     {"type": "text", "text": text_input},
+#                 ],
+#             }
+#         ]
+#     ] * batch_size
+
+#     # Process inputs
+#     text = processor.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+#     image_inputs, video_inputs = process_vision_info(messages)
+#     inputs = processor(
+#         text=text,
+#         images=image_inputs,
+#         videos=video_inputs,
+#         padding=True,
+#         return_tensors="pt",
+#     ).to(model.device)
+
+#     # Optionally use TT vision model
+#     if use_tt_vision:
+#         # Create the TorchVisionTransformer wrapper using the original vision model as reference
+#         model_args = VisionModelArgs(mesh_device, max_batch_size=batch_size, max_seq_len=max_new_tokens)
+#         model.model.visual = DropInVisionTransformer(model.visual, model_args, debug=True)  # show PCC
+
+#     # Run inference
+#     logger.info("Running model generation...")
+#     generated_ids = model.generate(**inputs, max_new_tokens=max_new_tokens, do_sample=False)
+#     generated_ids_trimmed = [out_ids[len(in_ids) :] for in_ids, out_ids in zip(inputs.input_ids, generated_ids)]
+#     output_texts = processor.batch_decode(
+#         generated_ids_trimmed, skip_special_tokens=True, clean_up_tokenization_spaces=False
+#     )
+
+#     # Verify output
+#     # Token-level BLEU score (standard for text generation)
+#     for i, output_text in enumerate(output_texts):
+#         logger.info(f"Expected output: {expected_output}")
+#         logger.info(f"Generated output {i}: {output_text}")
+
+#         reference = [word_tokenize(expected_output.lower())]
+#         candidate = word_tokenize(output_text.lower())
+#         bleu_score = sentence_bleu(reference, candidate)
+#         logger.info(f"BLEU score of output {i}: {bleu_score:.3f}")
+#         assert bleu_score > 0.5
+
+#     logger.info(f"Test passed with {'TorchVisionTransformer' if use_tt_vision else 'original vision model'}")
+
 
 @torch.no_grad()
 @pytest.mark.parametrize(
     "mesh_device",
-    [{"N150": (1, 1), "N300": (1, 2)}.get(os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids()))],
+    [
+        {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
+            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
+        )
+    ],
     indirect=True,
 )
 @pytest.mark.parametrize(
@@ -38,33 +166,15 @@ from models.demos.qwen3_vl.tt.model_config import VisionModelArgs
 
             - **The Landscape:** The house is nestled on a gently sloping,""",
         ),
-        (
-            "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen-VL/assets/demo.jpeg",
-            "Describe this image.",
-            """This is a heartwarming and serene photograph capturing a joyful moment between a woman and her dog on a beach at sunset.
-
-            **Main Subjects:**
-            - **The Woman:** She is sitting cross-legged on the sand, facing her dog. She has long, dark hair and is wearing a blue and white plaid shirt with rolled-up sleeves and dark pants. She is smiling warmly, looking at her dog, and holding a small treat in her hand. Her left wrist has a white watch or band.
-            - **The Dog:** A golden-colored Labrador Retriever, likely a yellow lab, is sitting upright on the sand, facing the""",
-        ),
-        (
-            "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png",
-            "Transcribe the text in the image.",
-            """Fractal Generative Models
-
-            4.4. Relation to Long-Sequence Modeling
-            Most previous work on pixel-by-pixel generation formulates the problem as long-sequence modeling and leverages methods from language modeling to address it (Child et al., 2019; Roy et al., 2021; Ren et al., 2021; Hawthorne et al., 2022; Yu et al., 2023). However, the intrinsic structures of many data types, including but not limited to images, are beyond one-dimensional sequences. Different from these methods, we treat such""",
-        ),
     ],
-    ids=["72dpi", "240dpi", "300dpi"],
 )
 @pytest.mark.parametrize(
     "use_tt_vision",
-    [False],
+    [True],
     ids=["hf_vision"],
 )
 @pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
-def test_qwen_vl_end_to_end(
+def test_qwen_vl(
     mesh_device,
     reset_seeds,
     ensure_gc,
@@ -76,12 +186,9 @@ def test_qwen_vl_end_to_end(
     is_ci_env,
     request,
 ):
-    test_id = request.node.callspec.id
-    if is_ci_env and not "240dpi" in test_id:
-        pytest.skip("CI only runs 240dpi image test for compromise of coverage and time limit")
-
+    os.environ["MAX_PREFILL_CHUNK_SIZE"] = "4"
     """Test end-to-end Qwen3-VL model with options to replace vision component."""
-    batch_size = 1  # use batch size 1 for now to run the test in reasonable amount of time in CI
+    batch_size = 4  # use batch size 1 for now to run the test in reasonable amount of time in CI
     max_new_tokens = 200
 
     # Load model and processor
@@ -126,21 +233,21 @@ def test_qwen_vl_end_to_end(
     # Run inference
     logger.info("Running model generation...")
     generated_ids = model.generate(**inputs, max_new_tokens=max_new_tokens, do_sample=False)
-    generated_ids_trimmed = [out_ids[len(in_ids) :] for in_ids, out_ids in zip(inputs.input_ids, generated_ids)]
-    output_texts = processor.batch_decode(
-        generated_ids_trimmed, skip_special_tokens=True, clean_up_tokenization_spaces=False
-    )
+    # generated_ids_trimmed = [out_ids[len(in_ids) :] for in_ids, out_ids in zip(inputs.input_ids, generated_ids)]
+    # output_texts = processor.batch_decode(
+    #     generated_ids_trimmed, skip_special_tokens=True, clean_up_tokenization_spaces=False
+    # )
 
-    # Verify output
-    # Token-level BLEU score (standard for text generation)
-    for i, output_text in enumerate(output_texts):
-        logger.info(f"Expected output: {expected_output}")
-        logger.info(f"Generated output {i}: {output_text}")
+    # # Verify output
+    # # Token-level BLEU score (standard for text generation)
+    # for i, output_text in enumerate(output_texts):
+    #     logger.info(f"Expected output: {expected_output}")
+    #     logger.info(f"Generated output {i}: {output_text}")
 
-        reference = [word_tokenize(expected_output.lower())]
-        candidate = word_tokenize(output_text.lower())
-        bleu_score = sentence_bleu(reference, candidate)
-        logger.info(f"BLEU score of output {i}: {bleu_score:.3f}")
-        assert bleu_score > 0.5
+    #     reference = [word_tokenize(expected_output.lower())]
+    #     candidate = word_tokenize(output_text.lower())
+    #     bleu_score = sentence_bleu(reference, candidate)
+    #     logger.info(f"BLEU score of output {i}: {bleu_score:.3f}")
+    #     assert bleu_score > 0.5
 
-    logger.info(f"Test passed with {'TorchVisionTransformer' if use_tt_vision else 'original vision model'}")
+    # logger.info(f"Test passed with {'TorchVisionTransformer' if use_tt_vision else 'original vision model'}")

--- a/models/demos/qwen3_vl/demo/combined.py
+++ b/models/demos/qwen3_vl/demo/combined.py
@@ -8,6 +8,8 @@ import os
 import pytest
 import torch
 from loguru import logger
+from nltk.tokenize import word_tokenize
+from nltk.translate.bleu_score import sentence_bleu
 from qwen_vl_utils import process_vision_info
 from transformers import AutoProcessor
 from transformers.models.qwen3_vl.modeling_qwen3_vl import Qwen3VLForConditionalGeneration
@@ -40,15 +42,33 @@ from models.demos.qwen3_vl.tt.model_config import VisionModelArgs
 
             - **The Landscape:** The house is nestled on a gently sloping,""",
         ),
+        (
+            "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen-VL/assets/demo.jpeg",
+            "Describe this image.",
+            """This is a heartwarming and serene photograph capturing a joyful moment between a woman and her dog on a beach at sunset.
+
+            **Main Subjects:**
+            - **The Woman:** She is sitting cross-legged on the sand, facing her dog. She has long, dark hair and is wearing a blue and white plaid shirt with rolled-up sleeves and dark pants. She is smiling warmly, looking at her dog, and holding a small treat in her hand. Her left wrist has a white watch or band.
+            - **The Dog:** A golden-colored Labrador Retriever, likely a yellow lab, is sitting upright on the sand, facing the""",
+        ),
+        (
+            "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png",
+            "Transcribe the text in the image.",
+            """Fractal Generative Models
+
+            4.4. Relation to Long-Sequence Modeling
+            Most previous work on pixel-by-pixel generation formulates the problem as long-sequence modeling and leverages methods from language modeling to address it (Child et al., 2019; Roy et al., 2021; Ren et al., 2021; Hawthorne et al., 2022; Yu et al., 2023). However, the intrinsic structures of many data types, including but not limited to images, are beyond one-dimensional sequences. Different from these methods, we treat such""",
+        ),
     ],
+    ids=["72dpi", "240dpi", "300dpi"],
 )
 @pytest.mark.parametrize(
     "use_tt_vision",
     [True],
-    ids=["hf_vision"],
+    ids=["tt_vision"],
 )
 @pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
-def test_qwen_vl(
+def test_qwen_vl_end_to_end(
     mesh_device,
     reset_seeds,
     ensure_gc,
@@ -60,9 +80,12 @@ def test_qwen_vl(
     is_ci_env,
     request,
 ):
-    os.environ["MAX_PREFILL_CHUNK_SIZE"] = "4"
+    test_id = request.node.callspec.id
+    if is_ci_env and not "240dpi" in test_id:
+        pytest.skip("CI only runs 240dpi image test for compromise of coverage and time limit")
+
     """Test end-to-end Qwen3-VL model with options to replace vision component."""
-    batch_size = 4
+    batch_size = 1  # use batch size 1 for now to run the test in reasonable amount of time in CI
     max_new_tokens = 200
 
     # Load model and processor
@@ -107,3 +130,21 @@ def test_qwen_vl(
     # Run inference
     logger.info("Running model generation...")
     generated_ids = model.generate(**inputs, max_new_tokens=max_new_tokens, do_sample=False)
+    generated_ids_trimmed = [out_ids[len(in_ids) :] for in_ids, out_ids in zip(inputs.input_ids, generated_ids)]
+    output_texts = processor.batch_decode(
+        generated_ids_trimmed, skip_special_tokens=True, clean_up_tokenization_spaces=False
+    )
+
+    # Verify output
+    # Token-level BLEU score (standard for text generation)
+    for i, output_text in enumerate(output_texts):
+        logger.info(f"Expected output: {expected_output}")
+        logger.info(f"Generated output {i}: {output_text}")
+
+        reference = [word_tokenize(expected_output.lower())]
+        candidate = word_tokenize(output_text.lower())
+        bleu_score = sentence_bleu(reference, candidate)
+        logger.info(f"BLEU score of output {i}: {bleu_score:.3f}")
+        assert bleu_score > 0.5
+
+    logger.info(f"Test passed with {'TorchVisionTransformer' if use_tt_vision else 'original vision model'}")

--- a/models/demos/qwen3_vl/demo/demo.py
+++ b/models/demos/qwen3_vl/demo/demo.py
@@ -416,22 +416,19 @@ def test_demo(
             # text-only
             num_image_tokens.append([0] * batch_size)
 
-        # Vision prefill
         logger.info(f"Vision model prefill batch {batch_idx}")
-        if not vision_model_traced:
-            image_embeds, deepstack_visual_embeds = (
-                visual_model(inputs.pixel_values, grid_thw=inputs.image_grid_thw)
-                if "pixel_values" in inputs
-                else (torch.tensor([], dtype=torch.bfloat16), None)
-            )
-            vision_model_traced = True
-        profiler.start(f"vision_model_prefill", iteration=batch_idx)
-        image_embeds, deepstack_visual_embeds = (
-            visual_model(inputs.pixel_values, grid_thw=inputs.image_grid_thw)
-            if "pixel_values" in inputs
-            else (torch.tensor([], dtype=torch.bfloat16), None)
-        )
-        profiler.end(f"vision_model_prefill", iteration=batch_idx)
+        if "pixel_values" not in inputs:
+            image_embeds = torch.tensor([], dtype=torch.bfloat16)
+            deepstack_visual_embeds = None
+        else:
+            if not vision_model_traced:
+                _pv = inputs.pixel_values[: inputs.image_grid_thw[0].prod().item()]
+                _gw = inputs.image_grid_thw[:1]
+                visual_model(_pv, grid_thw=_gw)
+                vision_model_traced = True
+            profiler.start(f"vision_model_prefill", iteration=batch_idx)
+            image_embeds, deepstack_visual_embeds = visual_model(inputs.pixel_values, grid_thw=inputs.image_grid_thw)
+            profiler.end(f"vision_model_prefill", iteration=batch_idx)
 
         # Prepare text + vision inputs for decoder model
         logger.info(f"Prepare text + vision inputs for decoder model batch {batch_idx}")

--- a/models/demos/qwen3_vl/tt/generator.py
+++ b/models/demos/qwen3_vl/tt/generator.py
@@ -8,6 +8,7 @@ from loguru import logger
 import ttnn
 from models.common.warmup import WarmupForwardMixin
 from models.demos.qwen3_vl.tt.common import get_block_size, get_max_prefill_chunk_size, num_blocks_in_seq
+from models.tt_transformers.tt.generator import MAX_BATCHED_PREFILL_SEQ_LEN
 from models.tt_transformers.tt.generator import Generator as TTTGenerator
 
 
@@ -56,36 +57,148 @@ class Generator(WarmupForwardMixin):
         batch, batch_seq_len = tokens.shape[:2]
         output_logits = torch.zeros(batch, 1, self.model_args.vocab_size)
         prompt_lens = prompt_lens if prompt_lens is not None else torch.tensor([batch_seq_len] * batch)
+        if not isinstance(prompt_lens, list):
+            prompt_lens = prompt_lens.tolist()
 
         if page_table is not None:
             assert isinstance(
                 page_table, torch.Tensor
             ), "page_table must be a torch.Tensor when passing into prefill_forward"
 
-        for user_id in range(batch):
-            logger.info(f"Prefilling User {user_id + 1}")
-            seq_len = prompt_lens[user_id]
-            last_token_idx = seq_len - 1
+        prefill_seq_len = batch_seq_len
+        max_batch = getattr(self.model_args, "max_batched_prefill_size", 32)
+        use_batched_prefill = (
+            batch > 1
+            and prefill_seq_len * min(batch, max_batch) < MAX_BATCHED_PREFILL_SEQ_LEN
+            and self._ttt_generator.data_parallel == 1
+            and not getattr(self.model_args, "disable_batched_prefill", False)
+            and page_table is not None
+            and kv_cache is not None
+        )
 
-            if page_table is not None:
-                page_table_user = self._ttt_generator._get_prefill_user_page_table(page_table, kv_cache, seq_len)
+        if use_batched_prefill:
+            chunk_size = min(batch, max_batch)
+            for chunk_start in range(0, batch, chunk_size):
+                chunk_end = min(chunk_start + chunk_size, batch)
+                chunk_tokens = tokens[chunk_start:chunk_end]
+                chunk_prompt_lens = prompt_lens[chunk_start:chunk_end]
+                chunk_page_table = page_table[chunk_start:chunk_end]
+                chunk_rot_mats = (
+                    (rot_mats[0][chunk_start:chunk_end], rot_mats[1][chunk_start:chunk_end])
+                    if rot_mats is not None
+                    else rot_mats
+                )
+                chunk_deepstack = (
+                    deepstack_visual_embeds[chunk_start:chunk_end] if deepstack_visual_embeds is not None else None
+                )
+                chunk_logits = self.__prefill_forward_batched_text(
+                    tokens=chunk_tokens,
+                    rot_mats=chunk_rot_mats,
+                    page_table=chunk_page_table,
+                    kv_cache=kv_cache,
+                    prompt_lens=chunk_prompt_lens,
+                    prefill_seq_len=prefill_seq_len,
+                    deepstack_visual_embeds=chunk_deepstack,
+                    slot_offset=chunk_start,
+                )
+                output_logits[chunk_start:chunk_end] = chunk_logits
+        else:
+            for user_id in range(batch):
+                logger.info(f"Prefilling User {user_id + 1}")
+                seq_len = prompt_lens[user_id]
+                last_token_idx = seq_len - 1
 
-            logits = self.__prefill_forward_single_user_text(
-                tokens[user_id : user_id + 1],
-                page_table=page_table_user if page_table is not None else None,
-                user_id=user_id,
-                last_token_idx=last_token_idx,
-                rot_mats=rot_mats,
-                kv_cache=kv_cache,
-                deepstack_visual_embeds=deepstack_visual_embeds[user_id]
-                if deepstack_visual_embeds is not None
-                else None,
-            )
+                if page_table is not None:
+                    page_table_user = self._ttt_generator._get_prefill_user_page_table(page_table, kv_cache, seq_len)
 
-            # Since we give unpadded_seq_len, only the tile containing the last token is returned
-            output_logits[user_id] = logits
+                logits = self.__prefill_forward_single_user_text(
+                    tokens[user_id : user_id + 1],
+                    page_table=page_table_user if page_table is not None else None,
+                    user_id=user_id,
+                    last_token_idx=last_token_idx,
+                    rot_mats=rot_mats,
+                    kv_cache=kv_cache,
+                    deepstack_visual_embeds=deepstack_visual_embeds[user_id]
+                    if deepstack_visual_embeds is not None
+                    else None,
+                )
+
+                # Since we give unpadded_seq_len, only the tile containing the last token is returned
+                output_logits[user_id] = logits
 
         logger.info(f"Finished prefill for all users up to {batch_seq_len} tokens, Starting decode...")
+
+        return output_logits
+
+    def __prefill_forward_batched_text(
+        self,
+        tokens: torch.Tensor,
+        rot_mats,
+        page_table,
+        kv_cache,
+        prompt_lens,
+        prefill_seq_len,
+        deepstack_visual_embeds=None,
+        slot_offset=0,
+    ):
+        batch_size = tokens.shape[0]
+        last_token_idx = [pl - 1 for pl in prompt_lens]
+        batch_user_ids = list(range(slot_offset, slot_offset + batch_size))
+
+        page_table_user = self._ttt_generator._get_prefill_user_page_table(
+            page_table,
+            kv_cache,
+            prefill_seq_len,
+            trace_enabled=False,
+            prefill_seq_len=prefill_seq_len,
+            use_batched_prefill=True,
+            user_id=batch_user_ids,
+        )
+
+        deepstack_batched = None
+        if deepstack_visual_embeds is not None:
+            num_layers = len(deepstack_visual_embeds[0])
+            deepstack_batched = []
+            for layer_idx in range(num_layers):
+                layer_tensors = [deepstack_visual_embeds[user_idx][layer_idx] for user_idx in range(batch_size)]
+                deepstack_batched.append(torch.stack(layer_tensors))
+
+        prefill_input, rot_mats_prefill, page_table_tt, _, deepstack_prefill = self.model.prepare_inputs_prefill(
+            tokens,
+            rot_mats=rot_mats,
+            page_table=page_table_user,
+            deepstack_visual_embeds=deepstack_batched,
+            batch_size=batch_size,
+        )
+
+        tt_logits = self.model.ttnn_prefill_forward(
+            prefill_input,
+            rot_mats_global=rot_mats_prefill,
+            user_id=batch_user_ids,
+            page_table=page_table_tt,
+            get_last_token=-1,
+            kv_cache=kv_cache,
+            deepstack_visual_embeds=deepstack_prefill,
+            batch_size=batch_size,
+        )
+
+        hidden_dim = tt_logits.shape[-1]
+        logits = ttnn.reshape(tt_logits, [batch_size, 1, prefill_seq_len, hidden_dim])
+
+        user_hidden = self.model.extract_last_tokens_batched_prefill(
+            logits, last_token_idx, batch_size, prefill_seq_len
+        )
+        batched_logits = self.model._apply_norm_and_lm_head(user_hidden)
+
+        output_logits = torch.zeros(batch_size, 1, self.model_args.vocab_size)
+        batched_logits_cpu = ttnn.to_torch(
+            batched_logits, mesh_composer=ttnn.ConcatMeshToTensor(self._ttt_generator.mesh_device, dim=-1)
+        )
+        output_logits[:, 0, :] = batched_logits_cpu[0, 0, :batch_size, : self.model_args.vocab_size]
+
+        ttnn.deallocate(tt_logits)
+        ttnn.deallocate(prefill_input)
+        ttnn.deallocate(page_table_tt)
 
         return output_logits
 

--- a/models/demos/qwen3_vl/tt/model.py
+++ b/models/demos/qwen3_vl/tt/model.py
@@ -133,9 +133,6 @@ class VisionTransformer(LightweightModule):
         """
         if isinstance(unpadded_seq_len, (list, tuple)):
             chunks = []
-            # for b, s,in enumerate(unpadded_seq_len):
-            #     chunks.append(x[b, :,  :s, :])
-            # return ttnn.concat(chunks, dim=0)
             offset = 0
             for s, ps in zip(unpadded_seq_len, padded_seq_len_list):
                 chunks.append(x[:, :, offset : offset + s, :])
@@ -178,15 +175,12 @@ class VisionTransformer(LightweightModule):
             )
             if i in self.deepstack_visual_indices:
                 idx = self.deepstack_visual_indices.index(i)
-                # x_unpadded = ttnn.reshape(x, [batch_size, 1, x.shape[-2] // batch_size, -1])
                 x_unpadded = self._slice_unpadded(x, unpadded_seq_len, padded_seq_len_list)
                 deepstack_feature_list.append(self.deepstack_merger_list[idx](x_unpadded))
 
         # Merge patches - first remove any sequence length padding
-        # x = ttnn.reshape(x, [batch_size, 1, x.shape[-2] // batch_size, -1])
         x = self._slice_unpadded(x, unpadded_seq_len, padded_seq_len_list)
         x = self.patch_merger(x)
-        # x = ttnn.reshape(x, [1, 1, x.shape[-2] * batch_size, -1])
         return x, deepstack_feature_list
 
 
@@ -293,7 +287,6 @@ class DropInVisionTransformer(torch.nn.Module):
         Returns:
             torch.Tensor: Output tensor matching the reference model's output shape [total_seq_len, out_hidden_size].
         """
-        # import pdb; pdb.set_trace()
         # process pixel_values for each image/video separately
         all_pixel_values = pixel_values.clone()
         grid_thw_clone = grid_thw.clone()
@@ -321,8 +314,6 @@ class DropInVisionTransformer(torch.nn.Module):
                 current_pixel_values = pixel_values
                 seq_len = seq_len_list
                 padded_seq_len = padded_seq_len_list
-            # unpadded_seq_len = (grid_thw[:, 1] * grid_thw[:, 2]).sum().item()
-            # seq_len = ((unpadded_seq_len // 2048) + 1) * 2048
 
             # 3. Use reference model's patch embedding
             patch_input = self.reference_model.patch_embed(current_pixel_values)
@@ -339,7 +330,6 @@ class DropInVisionTransformer(torch.nn.Module):
                 dtype=ttnn.bfloat16,  # Use bfloat16 for RoPE
                 layout=ttnn.TILE_LAYOUT,
                 device=self.model_args.mesh_device,
-                # mesh_mapper=ttnn.ReplicateTensorToMesh(self.model_args.mesh_device),
                 # todo)) refactor this code to make the intent clear, which is data parallelism
                 mesh_mapper=ttnn.ShardTensorToMesh(self.model_args.mesh_device, dim=0),
             )
@@ -348,7 +338,6 @@ class DropInVisionTransformer(torch.nn.Module):
                 dtype=ttnn.bfloat16,  # Use bfloat16 for RoPE
                 layout=ttnn.TILE_LAYOUT,
                 device=self.model_args.mesh_device,
-                # mesh_mapper=ttnn.ReplicateTensorToMesh(self.model_args.mesh_device),
                 # todo)) refactor this code to make the intent clear, which is data parallelism
                 mesh_mapper=ttnn.ShardTensorToMesh(self.model_args.mesh_device, dim=0),
             )
@@ -425,8 +414,6 @@ class DropInVisionTransformer(torch.nn.Module):
         final_output_ttnn = torch.cat(final_outputs, dim=0)
         if self.debug:
             logger.info(f"DropInVisionTransformer: Debug enabled, running reference model...")
-            # reference_output, deepstack_ref = self.reference_model.forward(all_pixel_values, grid_thw_clone)
-            # torch.save(reference_output, "models/demos/qwen3_vl/tt/ref_out_visual.pt")
             reference_output = torch.load("models/demos/qwen3_vl/tt/ref_out_visual.pt")
             _, pcc = comp_pcc(reference_output, final_output_ttnn)
             logger.info(f"DropInVisionTransformer: PCC to reference model: {pcc}")
@@ -640,5 +627,4 @@ class Transformer(TTTransformer):
 
         if mode == Mode.PREFILL:
             x = ttnn.to_layout(x, layout=ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-            # x = ttnn.to_memory_config(x, memory_config=ttnn.DRAM_MEMORY_CONFIG)
         return x

--- a/models/demos/qwen3_vl/tt/model.py
+++ b/models/demos/qwen3_vl/tt/model.py
@@ -128,6 +128,8 @@ class VisionTransformer(LightweightModule):
         x,
         unpadded_seq_len,
         rot_mats,
+        batch_size=1,
+        user_id_tensor=None,
     ):
         """
         Forward pass through the Vision Transformer blocks.
@@ -147,6 +149,8 @@ class VisionTransformer(LightweightModule):
             x = block(
                 x,
                 rot_mats=rot_mats,
+                batch_size=batch_size,
+                user_id_tensor=user_id_tensor,
             )
             if i in self.deepstack_visual_indices:
                 idx = self.deepstack_visual_indices.index(i)
@@ -225,21 +229,40 @@ class DropInVisionTransformer(torch.nn.Module):
         Returns:
             torch.Tensor: Output tensor matching the reference model's output shape [total_seq_len, out_hidden_size].
         """
+        # import pdb; pdb.set_trace()
         # process pixel_values for each image/video separately
-        all_pixel_values = pixel_values
-        all_grid_thw = grid_thw
+        all_pixel_values = pixel_values.clone()
+        grid_thw_clone = grid_thw.clone()
         final_outputs = []
         deepstack_visual_embeds_list = [None] * len(self.deepstack_visual_indexes)
+        batch_size = grid_thw[0]
+        batched_prefill = True
+        all_grid_thw = grid_thw
+        if batched_prefill:
+            all_grid_thw = all_grid_thw.unsqueeze(0)
+        # print(f"{all_grid_thw.shape=}")
         # todo)) refactor this code to leverage tt-mesh's ttnn.ShardTensorToMesh(mesh_device, dim=batch_size_dim) for data parallelism
         for grid_thw in all_grid_thw:
             # --- pick out the pixel_values for this users' images (grid_thw.prod() pixels) ---
-            pixel_values = all_pixel_values[: grid_thw.prod(), :]
-            all_pixel_values = all_pixel_values[grid_thw.prod() :, :]
-            # --- Preprocessing ---
-            # 1. Calculate total unpadded sequence length
-            grid_thw = grid_thw.unsqueeze(0)
-            unpadded_seq_len = (grid_thw[:, 1] * grid_thw[:, 2]).sum().item()
+            # pixel_values = all_pixel_values[: grid_thw.prod(), :]
+            # all_pixel_values = all_pixel_values[grid_thw.prod() :, :]
+            # print(f"{grid_thw.shape=}")
+            # print(f"{pixel_values.shape=}")
+            # print(f"{all_pixel_values.shape=}")
+            # # --- Preprocessing ---
+            # # 1. Calculate total unpadded sequence length
+            # print(f"{seq_len=}")
+            # print(f"{unpadded_seq_len=}")
+
             # Calculate padded sequence length (divisible by 2048) required by models/tt_transformers/tt/attention.py::forward_prefill
+
+            if not batched_prefill:
+                current_pixel_values = pixel_values[: grid_thw.prod(), :]
+                pixel_values = pixel_values[grid_thw.prod() :, :]
+                grid_thw = grid_thw.unsqueeze(0)
+            else:
+                current_pixel_values = pixel_values
+            unpadded_seq_len = (grid_thw[:, 1] * grid_thw[:, 2]).sum().item()
             seq_len = ((unpadded_seq_len // 2048) + 1) * 2048
 
             # 2. Use preprocessing function from reference/functional to get indices and embeddings
@@ -251,7 +274,7 @@ class DropInVisionTransformer(torch.nn.Module):
             )
 
             # 3. Use reference model's patch embedding
-            patch_input = self.reference_model.patch_embed(pixel_values)
+            patch_input = self.reference_model.patch_embed(current_pixel_values)
             pos_embeds = self.reference_model.fast_pos_embed_interpolate(grid_thw)
             patch_input = patch_input + pos_embeds
 
@@ -298,6 +321,7 @@ class DropInVisionTransformer(torch.nn.Module):
                 tt_input,
                 unpadded_seq_len=unpadded_seq_len,
                 rot_mats=rot_mats,  # Use rot_mats generated in this forward pass
+                batch_size=batch_size,
             )
 
             # deallocate device tensors that are not needed by decode
@@ -334,12 +358,6 @@ class DropInVisionTransformer(torch.nn.Module):
                 for i in range(len(deepstack_visual_embeds_torch_list))
             ]
 
-            if self.debug:
-                logger.info(f"DropInVisionTransformer: Debug enabled, running reference model...")
-                reference_output, deepstack_ref = self.reference_model.forward(pixel_values, grid_thw)
-                _, pcc = comp_pcc(reference_output, final_output)
-                logger.info(f"DropInVisionTransformer: PCC to reference model: {pcc}")
-
             final_outputs.append(final_output)
             for i in range(len(deepstack_visual_embeds_list)):
                 if deepstack_visual_embeds_list[i] is None:
@@ -348,8 +366,21 @@ class DropInVisionTransformer(torch.nn.Module):
                     deepstack_visual_embeds_list[i] = torch.cat(
                         [deepstack_visual_embeds_list[i], deepstack_visual_embeds_torch[i]], dim=0
                     )
+
+        final_output_ttnn = torch.cat(final_outputs, dim=0)
+        if self.debug:
+            logger.info(f"DropInVisionTransformer: Debug enabled, running reference model...")
+            reference_output, deepstack_ref = self.reference_model.forward(all_pixel_values, grid_thw_clone)
+            torch.save(reference_output, "models/demos/qwen3_vl/tt/ref_out_visual.pt")
+            reference_output = torch.load("models/demos/qwen3_vl/tt/ref_out_visual.pt")
+            _, pcc = comp_pcc(reference_output, final_output_ttnn)
+            logger.info(f"DropInVisionTransformer: PCC to reference model: {pcc}")
+            import sys
+
+            sys.exit(pcc)
+
         # concatenate all the outputs
-        return torch.cat(final_outputs, dim=0), deepstack_visual_embeds_list
+        return final_output_ttnn, deepstack_visual_embeds_list
 
 
 class Transformer(TTTransformer):

--- a/models/demos/qwen3_vl/tt/model.py
+++ b/models/demos/qwen3_vl/tt/model.py
@@ -238,42 +238,6 @@ class DropInVisionTransformer(torch.nn.Module):
     def spatial_merge_size(self):
         return self.model_args.hf_config.vision_config.spatial_merge_size
 
-    def get_position_embeds(self, grid_thw: torch.Tensor):
-        cos_padded, sin_padded = [], []
-        for img in grid_thw:
-            seq_len = (img[1] * img[2]).item()
-            padded_seq_len = ((seq_len // 2048) + 1) * 2048
-            _, position_embeddings = qwen3_vision_transformer_preprocess(
-                seq_len=seq_len,
-                grid_thw=img.unsqueeze(0),
-                head_dim=self.model_args.head_dim,
-                spatial_merge_size=self.model_args.hf_config.vision_config.spatial_merge_size,
-            )
-
-            cos_orig, sin_orig = position_embeddings
-            cos_orig, sin_orig = convert_rope_style_hf_to_meta(cos_orig, sin_orig)
-            # pad sequence length with cos = 1, sin = 0 (identity rotation)
-            cos_padded.append(
-                torch.nn.functional.pad(cos_orig, (0, 0, 0, padded_seq_len - seq_len), value=1)
-                .unsqueeze(0)
-                .unsqueeze(0)
-            )
-            sin_padded.append(
-                torch.nn.functional.pad(sin_orig, (0, 0, 0, padded_seq_len - seq_len), value=0)
-                .unsqueeze(0)
-                .unsqueeze(0)
-            )
-        return cos_padded, sin_padded
-
-    def get_padded_seq(self, grid_thw: torch.Tensor, batched_prefill=False):
-        seq_len, padded_seq_len = [], []
-        for img in grid_thw:
-            seq_len.append((img[1] * img[2]).item())
-            padded_seq_len.append(((seq_len[-1] // 2048) + 1) * 2048)
-        if batched_prefill:
-            padded_seq_len = [max(padded_seq_len)] * len(padded_seq_len)
-        return seq_len, padded_seq_len
-
     def forward(self, pixel_values: torch.Tensor, grid_thw: torch.Tensor) -> torch.Tensor:
         """
         Forward pass mimicking the Qwen2_5_VisionTransformerPretrainedModel interface.
@@ -287,46 +251,53 @@ class DropInVisionTransformer(torch.nn.Module):
         Returns:
             torch.Tensor: Output tensor matching the reference model's output shape [total_seq_len, out_hidden_size].
         """
-        # process pixel_values for each image/video separately
-        all_pixel_values = pixel_values.clone()
-        grid_thw_clone = grid_thw.clone()
+        # process pixel_values for each image/video separately (sequential like main)
+        all_pixel_values = pixel_values
+        all_grid_thw = grid_thw
         final_outputs = []
         deepstack_visual_embeds_list = [None] * len(self.deepstack_visual_indexes)
-        batch_size = grid_thw.shape[0]
-        batched_prefill = True
-        all_grid_thw = grid_thw
-        if batched_prefill:
-            all_grid_thw = all_grid_thw.unsqueeze(0)
-
-        cos_padded, sin_padded = self.get_position_embeds(grid_thw)
-        seq_len_list, padded_seq_len_list = self.get_padded_seq(grid_thw, batched_prefill=batched_prefill)
-
         # todo)) refactor this code to leverage tt-mesh's ttnn.ShardTensorToMesh(mesh_device, dim=batch_size_dim) for data parallelism
-        for id, grid_thw in enumerate(all_grid_thw):
+        for grid_thw in all_grid_thw:
+            # --- pick out the pixel_values for this users' images (grid_thw.prod() pixels) ---
+            pixel_values = all_pixel_values[: grid_thw.prod(), :]
+            all_pixel_values = all_pixel_values[grid_thw.prod() :, :]
+            # --- Preprocessing ---
+            # 1. Calculate total unpadded sequence length
+            grid_thw = grid_thw.unsqueeze(0)
+            unpadded_seq_len = (grid_thw[:, 1] * grid_thw[:, 2]).sum().item()
             # Calculate padded sequence length (divisible by 2048) required by models/tt_transformers/tt/attention.py::forward_prefill
-            if not batched_prefill:
-                current_pixel_values = pixel_values[: grid_thw.prod(), :]
-                pixel_values = pixel_values[grid_thw.prod() :, :]
-                grid_thw = grid_thw.unsqueeze(0)
-                seq_len = seq_len_list[id]
-                padded_seq_len = padded_seq_len_list[id]
-            else:
-                current_pixel_values = pixel_values
-                seq_len = seq_len_list
-                padded_seq_len = padded_seq_len_list
+            seq_len = ((unpadded_seq_len // 2048) + 1) * 2048
+
+            # 2. Use preprocessing function from reference/functional to get indices and embeddings
+            cu_seqlens, position_embeddings = qwen3_vision_transformer_preprocess(
+                seq_len=unpadded_seq_len,
+                grid_thw=grid_thw,
+                head_dim=self.model_args.head_dim,
+                spatial_merge_size=self.model_args.hf_config.vision_config.spatial_merge_size,
+            )
 
             # 3. Use reference model's patch embedding
-            patch_input = self.reference_model.patch_embed(current_pixel_values)
+            patch_input = self.reference_model.patch_embed(pixel_values)
             pos_embeds = self.reference_model.fast_pos_embed_interpolate(grid_thw)
             patch_input = patch_input + pos_embeds
 
-            if batched_prefill:
-                cos_padded = [torch.cat(cos_padded, dim=2)]
-                sin_padded = [torch.cat(sin_padded, dim=2)]
-
+            # 4. Prepare rotational embeddings (cos, sin) -> pad -> convert to TT tensors
+            cos_orig, sin_orig = position_embeddings
+            cos_orig, sin_orig = convert_rope_style_hf_to_meta(cos_orig, sin_orig)
+            # pad sequence length with cos = 1, sin = 0 (identity rotation)
+            cos_padded = (
+                torch.nn.functional.pad(cos_orig, (0, 0, 0, seq_len - unpadded_seq_len), value=1)
+                .unsqueeze(0)
+                .unsqueeze(0)
+            )
+            sin_padded = (
+                torch.nn.functional.pad(sin_orig, (0, 0, 0, seq_len - unpadded_seq_len), value=0)
+                .unsqueeze(0)
+                .unsqueeze(0)
+            )
             # Convert to TT tensors on the mesh device
             cos = ttnn.from_torch(
-                cos_padded[id],
+                cos_padded,
                 dtype=ttnn.bfloat16,  # Use bfloat16 for RoPE
                 layout=ttnn.TILE_LAYOUT,
                 device=self.model_args.mesh_device,
@@ -334,7 +305,7 @@ class DropInVisionTransformer(torch.nn.Module):
                 mesh_mapper=ttnn.ShardTensorToMesh(self.model_args.mesh_device, dim=0),
             )
             sin = ttnn.from_torch(
-                sin_padded[id],
+                sin_padded,
                 dtype=ttnn.bfloat16,  # Use bfloat16 for RoPE
                 layout=ttnn.TILE_LAYOUT,
                 device=self.model_args.mesh_device,
@@ -344,28 +315,13 @@ class DropInVisionTransformer(torch.nn.Module):
             rot_mats = [cos, sin]
 
             # 5. Prepare input tensor for the TT model using window_index
-            if batched_prefill:
-                # For batched prefill, pad each image's patches individually to its padded_seq_len,
-                # then concatenate along dim 0 so the total shape is [sum(padded_seq_len_list), hidden_dim].
-                padded_chunks = []
-                offset = 0
-                for s, ps in zip(seq_len, padded_seq_len):
-                    chunk = patch_input[offset : offset + s, :]
-                    padded_chunks.append(torch.nn.functional.pad(chunk, (0, 0, 0, ps - s)))
-                    offset += s
-                patch_input = torch.cat(padded_chunks, dim=0)
-                total_padded_seq_len = sum(padded_seq_len)
-            else:
-                total_padded_seq_len = padded_seq_len
-            tt_input = self.tt_model.prepare_input(patch_input, total_padded_seq_len)
+            tt_input = self.tt_model.prepare_input(patch_input, seq_len)
 
             # --- TT Model Execution ---
             tt_out, deepstack_visual_embeds = self.tt_model(
                 tt_input,
-                unpadded_seq_len=seq_len,
+                unpadded_seq_len=unpadded_seq_len,
                 rot_mats=rot_mats,  # Use rot_mats generated in this forward pass
-                batch_size=batch_size,
-                padded_seq_len_list=padded_seq_len if batched_prefill else None,
             )
 
             # deallocate device tensors that are not needed by decode
@@ -474,14 +430,19 @@ class Transformer(TTTransformer):
         start_pos=0,
         page_table=None,
         chunk_page_table=None,
+        batch_size=1,
     ):
         assert isinstance(rot_mats[0], torch.Tensor)
         assert isinstance(rot_mats[1], torch.Tensor)
-        # tokens is actually embeddings
-        assert tokens.dim() == 3, "tokens should be a 3D tensor"  # [batch_size = 1, seq_len, head_dim]
-        S = tokens.shape[-2]
+        assert tokens.dim() == 3
+        B, S, H = tokens.shape
+        if batch_size > 1:
+            tokens = tokens.reshape(1, 1, B * S, H)
+        else:
+            tokens = tokens.unsqueeze(1)
+
         tokens_embd = ttnn.from_torch(
-            tokens.unsqueeze(1),
+            tokens,
             device=self.mesh_device,
             dtype=ttnn.bfloat16,
             layout=ttnn.TILE_LAYOUT,
@@ -493,7 +454,7 @@ class Transformer(TTTransformer):
         if deepstack_visual_embeds is not None:
             deepstack_visual_embeds = [
                 ttnn.from_torch(
-                    deepstack_visual_embeds[i].unsqueeze(0).unsqueeze(0),
+                    ds.unsqueeze(0).unsqueeze(0) if ds.dim() == 2 else ds.reshape(1, 1, -1, ds.shape[-1]),
                     device=self.mesh_device,
                     dtype=ttnn.bfloat16,
                     layout=ttnn.TILE_LAYOUT,
@@ -501,41 +462,40 @@ class Transformer(TTTransformer):
                         mesh_device=self.mesh_device, dims=(None, 3), mesh_shape=self.args.cluster_shape
                     ),
                 )
-                for i in range(len(deepstack_visual_embeds))
+                for ds in deepstack_visual_embeds
             ]
 
-        # Slice the rot mats to the prefill seqlen
         cos_matrix, sin_matrix = self._prepare_cos_sin(rot_mats=rot_mats)
-        assert (
-            cos_matrix.shape[2] >= start_pos + S
-        ), f"Padded prefill end idx {start_pos + S} exceeds max seq len {cos_matrix.shape[2]}"
-        tt_rot_mats_prefill = [
-            cos_matrix[:, :, start_pos : start_pos + S, :],
-            sin_matrix[:, :, start_pos : start_pos + S, :],
-        ]
+        assert cos_matrix.shape[2] >= start_pos + S
+        cos_slice = cos_matrix[:, :, start_pos : start_pos + S, :]
+        sin_slice = sin_matrix[:, :, start_pos : start_pos + S, :]
+        if batch_size > 1:
+            cos_slice = ttnn.reshape(cos_slice, [1, 1, B * S, cos_slice.shape[-1]])
+            sin_slice = ttnn.reshape(sin_slice, [1, 1, B * S, sin_slice.shape[-1]])
+        tt_rot_mats_prefill = [cos_slice, sin_slice]
 
-        if page_table is not None:
-            tt_page_table = ttnn.from_torch(
+        tt_page_table = (
+            ttnn.from_torch(
                 page_table,
                 device=self.mesh_device,
                 dtype=ttnn.int32,
                 layout=ttnn.ROW_MAJOR_LAYOUT,
                 mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
             )
-        else:
-            tt_page_table = None
-
-        if chunk_page_table is not None:
-            tt_chunk_page_table = ttnn.from_torch(
+            if page_table is not None
+            else None
+        )
+        tt_chunk_page_table = (
+            ttnn.from_torch(
                 chunk_page_table,
                 device=self.mesh_device,
                 dtype=ttnn.int32,
                 layout=ttnn.ROW_MAJOR_LAYOUT,
                 mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
             )
-        else:
-            tt_chunk_page_table = None
-
+            if chunk_page_table is not None
+            else None
+        )
         return tokens_embd, tt_rot_mats_prefill, tt_page_table, tt_chunk_page_table, deepstack_visual_embeds
 
     def deepstack_process(self, x, deepstack_visual_embeds):
@@ -554,6 +514,7 @@ class Transformer(TTTransformer):
         get_last_token=-1,
         kv_cache=None,
         deepstack_visual_embeds=None,
+        batch_size=1,
     ):
         return self.forward(
             x,
@@ -568,6 +529,7 @@ class Transformer(TTTransformer):
             get_last_token=get_last_token,
             kv_cache=kv_cache,
             deepstack_visual_embeds=deepstack_visual_embeds,
+            batch_size=batch_size,
         )
 
     def forward(
@@ -585,6 +547,7 @@ class Transformer(TTTransformer):
         kv_cache=None,
         visual_pos_masks=None,
         deepstack_visual_embeds=None,
+        batch_size=1,
     ):
         for i, layer in enumerate(self.layers):
             # No-op if callers already provide the right memory config
@@ -605,6 +568,7 @@ class Transformer(TTTransformer):
                 chunk_page_table=chunk_page_table,
                 chunk_start_idx=chunk_start_idx,
                 kv_cache=kv_cache[i] if kv_cache is not None else None,
+                batch_size=batch_size,
             )
             if deepstack_visual_embeds is not None and i in range(len(deepstack_visual_embeds)):
                 x = self.deepstack_process(x, deepstack_visual_embeds[i])

--- a/models/demos/qwen3_vl/tt/model.py
+++ b/models/demos/qwen3_vl/tt/model.py
@@ -123,6 +123,26 @@ class VisionTransformer(LightweightModule):
         )
         return x
 
+    def _slice_unpadded(self, x, unpadded_seq_len, padded_seq_len_list=None):
+        """Slice x along dim 2 to remove padding.
+
+        For a list of unpadded lengths (batched prefill), each image occupies
+        padded_seq_len_list[i] slots in dim 2; we extract the first
+        unpadded_seq_len[i] tokens from each and concatenate them.
+        For a scalar unpadded_seq_len, a simple prefix slice is performed.
+        """
+        if isinstance(unpadded_seq_len, (list, tuple)):
+            chunks = []
+            # for b, s,in enumerate(unpadded_seq_len):
+            #     chunks.append(x[b, :,  :s, :])
+            # return ttnn.concat(chunks, dim=0)
+            offset = 0
+            for s, ps in zip(unpadded_seq_len, padded_seq_len_list):
+                chunks.append(x[:, :, offset : offset + s, :])
+                offset += ps
+            return ttnn.concat(chunks, dim=2)
+        return x[:, :, :unpadded_seq_len, :]
+
     def forward(
         self,
         x,
@@ -130,14 +150,18 @@ class VisionTransformer(LightweightModule):
         rot_mats,
         batch_size=1,
         user_id_tensor=None,
+        padded_seq_len_list=None,
     ):
         """
         Forward pass through the Vision Transformer blocks.
 
         Args:
             x (ttnn.Tensor): Input tensor [batch_size, 1, seq_len, hidden_dim]
-            cu_seqlens (torch.Tensor): Cumulative sequence lengths
+            unpadded_seq_len (int | list[int]): Actual (unpadded) sequence length(s).
+                Pass a list for batched prefill; a scalar otherwise.
             rot_mats (list): Rotation matrices for positional embeddings
+            padded_seq_len_list (list[int] | None): Per-image padded slot counts,
+                required when unpadded_seq_len is a list.
 
         Returns:
             ttnn.Tensor: Output tensor
@@ -154,11 +178,15 @@ class VisionTransformer(LightweightModule):
             )
             if i in self.deepstack_visual_indices:
                 idx = self.deepstack_visual_indices.index(i)
-                deepstack_feature_list.append(self.deepstack_merger_list[idx](x[:, :, :unpadded_seq_len, :]))
+                # x_unpadded = ttnn.reshape(x, [batch_size, 1, x.shape[-2] // batch_size, -1])
+                x_unpadded = self._slice_unpadded(x, unpadded_seq_len, padded_seq_len_list)
+                deepstack_feature_list.append(self.deepstack_merger_list[idx](x_unpadded))
 
         # Merge patches - first remove any sequence length padding
-        x = x[:, :, :unpadded_seq_len, :]
+        # x = ttnn.reshape(x, [batch_size, 1, x.shape[-2] // batch_size, -1])
+        x = self._slice_unpadded(x, unpadded_seq_len, padded_seq_len_list)
         x = self.patch_merger(x)
+        # x = ttnn.reshape(x, [1, 1, x.shape[-2] * batch_size, -1])
         return x, deepstack_feature_list
 
 
@@ -216,6 +244,42 @@ class DropInVisionTransformer(torch.nn.Module):
     def spatial_merge_size(self):
         return self.model_args.hf_config.vision_config.spatial_merge_size
 
+    def get_position_embeds(self, grid_thw: torch.Tensor):
+        cos_padded, sin_padded = [], []
+        for img in grid_thw:
+            seq_len = (img[1] * img[2]).item()
+            padded_seq_len = ((seq_len // 2048) + 1) * 2048
+            _, position_embeddings = qwen3_vision_transformer_preprocess(
+                seq_len=seq_len,
+                grid_thw=img.unsqueeze(0),
+                head_dim=self.model_args.head_dim,
+                spatial_merge_size=self.model_args.hf_config.vision_config.spatial_merge_size,
+            )
+
+            cos_orig, sin_orig = position_embeddings
+            cos_orig, sin_orig = convert_rope_style_hf_to_meta(cos_orig, sin_orig)
+            # pad sequence length with cos = 1, sin = 0 (identity rotation)
+            cos_padded.append(
+                torch.nn.functional.pad(cos_orig, (0, 0, 0, padded_seq_len - seq_len), value=1)
+                .unsqueeze(0)
+                .unsqueeze(0)
+            )
+            sin_padded.append(
+                torch.nn.functional.pad(sin_orig, (0, 0, 0, padded_seq_len - seq_len), value=0)
+                .unsqueeze(0)
+                .unsqueeze(0)
+            )
+        return cos_padded, sin_padded
+
+    def get_padded_seq(self, grid_thw: torch.Tensor, batched_prefill=False):
+        seq_len, padded_seq_len = [], []
+        for img in grid_thw:
+            seq_len.append((img[1] * img[2]).item())
+            padded_seq_len.append(((seq_len[-1] // 2048) + 1) * 2048)
+        if batched_prefill:
+            padded_seq_len = [max(padded_seq_len)] * len(padded_seq_len)
+        return seq_len, padded_seq_len
+
     def forward(self, pixel_values: torch.Tensor, grid_thw: torch.Tensor) -> torch.Tensor:
         """
         Forward pass mimicking the Qwen2_5_VisionTransformerPretrainedModel interface.
@@ -235,66 +299,43 @@ class DropInVisionTransformer(torch.nn.Module):
         grid_thw_clone = grid_thw.clone()
         final_outputs = []
         deepstack_visual_embeds_list = [None] * len(self.deepstack_visual_indexes)
-        batch_size = grid_thw[0]
+        batch_size = grid_thw.shape[0]
         batched_prefill = True
         all_grid_thw = grid_thw
         if batched_prefill:
             all_grid_thw = all_grid_thw.unsqueeze(0)
-        # print(f"{all_grid_thw.shape=}")
+
+        cos_padded, sin_padded = self.get_position_embeds(grid_thw)
+        seq_len_list, padded_seq_len_list = self.get_padded_seq(grid_thw, batched_prefill=batched_prefill)
+
         # todo)) refactor this code to leverage tt-mesh's ttnn.ShardTensorToMesh(mesh_device, dim=batch_size_dim) for data parallelism
-        for grid_thw in all_grid_thw:
-            # --- pick out the pixel_values for this users' images (grid_thw.prod() pixels) ---
-            # pixel_values = all_pixel_values[: grid_thw.prod(), :]
-            # all_pixel_values = all_pixel_values[grid_thw.prod() :, :]
-            # print(f"{grid_thw.shape=}")
-            # print(f"{pixel_values.shape=}")
-            # print(f"{all_pixel_values.shape=}")
-            # # --- Preprocessing ---
-            # # 1. Calculate total unpadded sequence length
-            # print(f"{seq_len=}")
-            # print(f"{unpadded_seq_len=}")
-
+        for id, grid_thw in enumerate(all_grid_thw):
             # Calculate padded sequence length (divisible by 2048) required by models/tt_transformers/tt/attention.py::forward_prefill
-
             if not batched_prefill:
                 current_pixel_values = pixel_values[: grid_thw.prod(), :]
                 pixel_values = pixel_values[grid_thw.prod() :, :]
                 grid_thw = grid_thw.unsqueeze(0)
+                seq_len = seq_len_list[id]
+                padded_seq_len = padded_seq_len_list[id]
             else:
                 current_pixel_values = pixel_values
-            unpadded_seq_len = (grid_thw[:, 1] * grid_thw[:, 2]).sum().item()
-            seq_len = ((unpadded_seq_len // 2048) + 1) * 2048
-
-            # 2. Use preprocessing function from reference/functional to get indices and embeddings
-            cu_seqlens, position_embeddings = qwen3_vision_transformer_preprocess(
-                seq_len=unpadded_seq_len,
-                grid_thw=grid_thw,
-                head_dim=self.model_args.head_dim,
-                spatial_merge_size=self.model_args.hf_config.vision_config.spatial_merge_size,
-            )
+                seq_len = seq_len_list
+                padded_seq_len = padded_seq_len_list
+            # unpadded_seq_len = (grid_thw[:, 1] * grid_thw[:, 2]).sum().item()
+            # seq_len = ((unpadded_seq_len // 2048) + 1) * 2048
 
             # 3. Use reference model's patch embedding
             patch_input = self.reference_model.patch_embed(current_pixel_values)
             pos_embeds = self.reference_model.fast_pos_embed_interpolate(grid_thw)
             patch_input = patch_input + pos_embeds
 
-            # 4. Prepare rotational embeddings (cos, sin) -> pad -> convert to TT tensors
-            cos_orig, sin_orig = position_embeddings
-            cos_orig, sin_orig = convert_rope_style_hf_to_meta(cos_orig, sin_orig)
-            # pad sequence length with cos = 1, sin = 0 (identity rotation)
-            cos_padded = (
-                torch.nn.functional.pad(cos_orig, (0, 0, 0, seq_len - unpadded_seq_len), value=1)
-                .unsqueeze(0)
-                .unsqueeze(0)
-            )
-            sin_padded = (
-                torch.nn.functional.pad(sin_orig, (0, 0, 0, seq_len - unpadded_seq_len), value=0)
-                .unsqueeze(0)
-                .unsqueeze(0)
-            )
+            if batched_prefill:
+                cos_padded = [torch.cat(cos_padded, dim=2)]
+                sin_padded = [torch.cat(sin_padded, dim=2)]
+
             # Convert to TT tensors on the mesh device
             cos = ttnn.from_torch(
-                cos_padded,
+                cos_padded[id],
                 dtype=ttnn.bfloat16,  # Use bfloat16 for RoPE
                 layout=ttnn.TILE_LAYOUT,
                 device=self.model_args.mesh_device,
@@ -303,7 +344,7 @@ class DropInVisionTransformer(torch.nn.Module):
                 mesh_mapper=ttnn.ShardTensorToMesh(self.model_args.mesh_device, dim=0),
             )
             sin = ttnn.from_torch(
-                sin_padded,
+                sin_padded[id],
                 dtype=ttnn.bfloat16,  # Use bfloat16 for RoPE
                 layout=ttnn.TILE_LAYOUT,
                 device=self.model_args.mesh_device,
@@ -314,14 +355,28 @@ class DropInVisionTransformer(torch.nn.Module):
             rot_mats = [cos, sin]
 
             # 5. Prepare input tensor for the TT model using window_index
-            tt_input = self.tt_model.prepare_input(patch_input, seq_len)
+            if batched_prefill:
+                # For batched prefill, pad each image's patches individually to its padded_seq_len,
+                # then concatenate along dim 0 so the total shape is [sum(padded_seq_len_list), hidden_dim].
+                padded_chunks = []
+                offset = 0
+                for s, ps in zip(seq_len, padded_seq_len):
+                    chunk = patch_input[offset : offset + s, :]
+                    padded_chunks.append(torch.nn.functional.pad(chunk, (0, 0, 0, ps - s)))
+                    offset += s
+                patch_input = torch.cat(padded_chunks, dim=0)
+                total_padded_seq_len = sum(padded_seq_len)
+            else:
+                total_padded_seq_len = padded_seq_len
+            tt_input = self.tt_model.prepare_input(patch_input, total_padded_seq_len)
 
             # --- TT Model Execution ---
             tt_out, deepstack_visual_embeds = self.tt_model(
                 tt_input,
-                unpadded_seq_len=unpadded_seq_len,
+                unpadded_seq_len=seq_len,
                 rot_mats=rot_mats,  # Use rot_mats generated in this forward pass
                 batch_size=batch_size,
+                padded_seq_len_list=padded_seq_len if batched_prefill else None,
             )
 
             # deallocate device tensors that are not needed by decode
@@ -370,8 +425,8 @@ class DropInVisionTransformer(torch.nn.Module):
         final_output_ttnn = torch.cat(final_outputs, dim=0)
         if self.debug:
             logger.info(f"DropInVisionTransformer: Debug enabled, running reference model...")
-            reference_output, deepstack_ref = self.reference_model.forward(all_pixel_values, grid_thw_clone)
-            torch.save(reference_output, "models/demos/qwen3_vl/tt/ref_out_visual.pt")
+            # reference_output, deepstack_ref = self.reference_model.forward(all_pixel_values, grid_thw_clone)
+            # torch.save(reference_output, "models/demos/qwen3_vl/tt/ref_out_visual.pt")
             reference_output = torch.load("models/demos/qwen3_vl/tt/ref_out_visual.pt")
             _, pcc = comp_pcc(reference_output, final_output_ttnn)
             logger.info(f"DropInVisionTransformer: PCC to reference model: {pcc}")

--- a/models/demos/qwen3_vl/tt/vision_attention.py
+++ b/models/demos/qwen3_vl/tt/vision_attention.py
@@ -24,6 +24,8 @@ class VisionAttention(LightweightModule):
         page_table=None,
         chunk_page_table=None,
         chunk_start_idx=None,
+        batch_size=1,
+        user_id_tensor=None,
     ):
         return self.forward_prefill(
             x,
@@ -33,6 +35,8 @@ class VisionAttention(LightweightModule):
             chunk_page_table=chunk_page_table,
             chunk_start_idx=chunk_start_idx,
             kv_cache=None,
+            batch_size=1,
+            user_id_tensor=None,
         )
 
     def __init(
@@ -71,6 +75,7 @@ class VisionAttention(LightweightModule):
 
         self.n_local_heads = self.n_heads // self.num_devices_per_group
         self.n_local_kv_heads = self.n_kv_heads // self.num_devices_per_group
+        # self.padded_head_dim = self.head_dim
         self.padded_head_dim = math.ceil(self.head_dim / self.tile_size) * self.tile_size
 
         self.dtype = dtype
@@ -254,7 +259,7 @@ class VisionAttention(LightweightModule):
                 state_dict=self.state_dict,
                 state_dict_prefix=None,  # we already prefix q_norm_str
                 weight_cache_path=None if configuration.dummy_weights else weight_cache_path,
-                weight_dtype=ttnn.bfloat16,
+                weight_dtype=RMSNormttnn.bfloat16,
                 weight_key=q_norm_str,
                 is_distributed=False,
                 sharded_program_config=None,  # FIXME: add height-sharded support. self.model_config["SHARDED_NORM_ATTN_PRGM_CFG"],
@@ -359,7 +364,17 @@ class VisionAttention(LightweightModule):
         chunk_page_table=None,
         chunk_start_idx=None,
         kv_cache=None,
+        batch_size=1,
+        user_id_tensor=None,
     ):
+        # print(f"{x_11SH.shape=}")
+
+        # For batched prefill, x_11SH has shape [B, 1, S, H] where B is batch_size
+        # Following 70B Galaxy: concat before QKV matmul, then reshape back to batch after
+        if batch_size > 1:
+            # Concatenate batch dimension into sequence for matmul compatibility
+            x_11SH = ttnn.reshape(x_11SH, [1, 1, x_11SH.shape[-2] * x_11SH.shape[-3] * x_11SH.shape[-4], -1])
+
         seq_len = x_11SH.shape[-2]
         assert seq_len % 128 == 0 and seq_len > 0, "Seqlen must be divisible by 128"
         ###
@@ -388,6 +403,10 @@ class VisionAttention(LightweightModule):
         if seq_len > self.MAX_QKV_MM_SEQ_LEN:
             xqkv_fused = ttnn.reshape(xqkv_fused, [1, 1, seq_len, -1])
 
+        # For batched prefill, reshape back to [batch_size, 1, seq_len_per_user, dim]
+        if batch_size > 1:
+            xqkv_fused = ttnn.reshape(xqkv_fused, [batch_size, 1, seq_len // batch_size, -1])
+
         ttnn.deallocate(x_11SH)
 
         # split qkv into heads
@@ -405,8 +424,6 @@ class VisionAttention(LightweightModule):
 
         q_heads_1QSD_pre_rot = self.q_norm(q_heads_1QSD_pre_rot, mode=Mode.PREFILL)
         k_heads_1KSD_pre_rot = self.k_norm(k_heads_1KSD_pre_rot, mode=Mode.PREFILL)
-
-        # last_five_unpadded = lambda x, mesh_device: first_five(x, mesh_device, start=-(96 - 80) - 5, end=-(96 - 80))
 
         ttnn.deallocate(xqkv_fused)
 
@@ -472,6 +489,9 @@ class VisionAttention(LightweightModule):
                 ),
             )
         else:
+            # For batched prefill, the actual per-user seq_len is seq_len // batch_size
+            # since the tensors have shape [batch_size, n_heads, seq_len_per_user, head_dim]
+            sdpa_seq_len = seq_len // batch_size if batch_size > 1 else seq_len
             attn_output_84SD = ttnn.transformer.scaled_dot_product_attention(
                 q_heads_1QSD_8b,
                 k_heads_1KSD_8b,
@@ -479,7 +499,7 @@ class VisionAttention(LightweightModule):
                 is_causal=False,
                 scale=self.scale,
                 compute_kernel_config=self.sdpa_prefill_compute_kernel_cfg,
-                program_config=self.configuration.get_attn_sdpa_program_config(Mode.PREFILL, seq_len, None, None),
+                program_config=self.configuration.get_attn_sdpa_program_config(Mode.PREFILL, sdpa_seq_len, None, None),
             )
 
         # deallocate keys and values
@@ -487,7 +507,12 @@ class VisionAttention(LightweightModule):
         ttnn.deallocate(k_heads_1KSD_8b)
         ttnn.deallocate(v_heads_1VSD_8b)
 
-        attn_output_1QSD = ttnn.reshape(attn_output_84SD, [1, self.n_local_heads, -1, self.padded_head_dim])
+        # For single-user prefill, reshape to expected format for nlp_concat_heads
+        # For batched prefill (batch_size > 1), skip this reshape - nlp_concat_heads handles [B, H, S, D]
+        if batch_size == 1:
+            attn_output_1QSD = ttnn.reshape(attn_output_84SD, [1, self.n_local_heads, -1, self.padded_head_dim])
+        else:
+            attn_output_1QSD = attn_output_84SD
 
         ###
         # Output matmul
@@ -496,8 +521,14 @@ class VisionAttention(LightweightModule):
             attn_output_1QSD,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
         )
-
         ttnn.deallocate(attn_output_1QSD)
+
+        # For batched prefill, reshape to concatenate batch dimension into sequence
+        # This MUST happen AFTER nlp_concat_heads to preserve correct data layout
+        # nlp_concat_heads outputs [B, 1, S_per_user, H*D], reshape to [1, 1, B*S, H*D]
+        if batch_size > 1:
+            attn_output_11SH = ttnn.reshape(attn_output_11SH, [1, 1, seq_len, -1])
+
         # reshaping long sequence to matmul fit on device
         if seq_len > 1024:
             attn_output_11SH = ttnn.reshape(attn_output_11SH, [1, seq_len // 1024, 1024, -1])

--- a/models/demos/qwen3_vl/tt/vision_attention.py
+++ b/models/demos/qwen3_vl/tt/vision_attention.py
@@ -49,9 +49,7 @@ class VisionAttention(LightweightModule):
         transformation_mats,
         configuration,
         paged_attention_config=None,
-        # use_paged_kv_cache=False,
         causal_mask=True,
-        # use_kv_cache=True,
     ):
         super().__init__()
 
@@ -65,17 +63,15 @@ class VisionAttention(LightweightModule):
         self.n_kv_heads = configuration.n_kv_heads
         self.paged_attention_config = paged_attention_config
         self.causal_mask = causal_mask
-        # self.use_kv_cache = use_kv_cache
         self.min_kv_prefill_shard_seqlen = configuration.min_kv_prefill_shard_seqlen
         self.ccl_dtype = configuration.ccl_dtype
         self.MAX_QKV_MM_SEQ_LEN = configuration.MAX_QKV_MM_SEQ_LEN
         self.tile_size = configuration.tile_size
 
-        self.num_devices_per_group = 1  # [INFO] each device runs a copy of the vision model
+        self.num_devices_per_group = 1
 
         self.n_local_heads = self.n_heads // self.num_devices_per_group
         self.n_local_kv_heads = self.n_kv_heads // self.num_devices_per_group
-        # self.padded_head_dim = self.head_dim
         self.padded_head_dim = math.ceil(self.head_dim / self.tile_size) * self.tile_size
 
         self.dtype = dtype
@@ -229,7 +225,6 @@ class VisionAttention(LightweightModule):
             qkv_list.append(qkv)
 
         qkv_cat = torch.cat(qkv_list, dim=-1).unsqueeze(0).unsqueeze(0)
-        # qkv_cat.shape = [1, 1, 1280, 4608])
 
         self.wqkv = ttnn.as_tensor(
             qkv_cat,
@@ -367,8 +362,6 @@ class VisionAttention(LightweightModule):
         batch_size=1,
         user_id_tensor=None,
     ):
-        # print(f"{x_11SH.shape=}")
-
         # For batched prefill, x_11SH has shape [B, 1, S, H] where B is batch_size
         # Following 70B Galaxy: concat before QKV matmul, then reshape back to batch after
         if batch_size > 1:

--- a/models/demos/qwen3_vl/tt/vision_attention.py
+++ b/models/demos/qwen3_vl/tt/vision_attention.py
@@ -390,8 +390,11 @@ class VisionAttention(LightweightModule):
         )
 
         # FIXME: surely ttnn.linear bias should work?
+        # Use in-place add to avoid OOM from allocating a new tensor
         if self.wqkv_bias_prefill is not None:
-            xqkv_fused = xqkv_fused + self.wqkv_bias_prefill
+            xqkv_fused = ttnn.add(
+                xqkv_fused, self.wqkv_bias_prefill, output_tensor=xqkv_fused, memory_config=ttnn.DRAM_MEMORY_CONFIG
+            )
 
         if seq_len > self.MAX_QKV_MM_SEQ_LEN:
             xqkv_fused = ttnn.reshape(xqkv_fused, [1, 1, seq_len, -1])
@@ -535,8 +538,11 @@ class VisionAttention(LightweightModule):
             program_config=self.model_config["VISION_WO_PREFILL_PROGCFG"](seq_len),
         )
         # FIXME: surely ttnn.linear bias should work?
+        # Use in-place add to avoid OOM from allocating a new tensor
         if self.wo_bias_prefill is not None:
-            output_11SH = output_11SH + self.wo_bias_prefill
+            output_11SH = ttnn.add(
+                output_11SH, self.wo_bias_prefill, output_tensor=output_11SH, memory_config=ttnn.DRAM_MEMORY_CONFIG
+            )
 
         if seq_len > 1024:
             output_11SH = ttnn.reshape(output_11SH, [1, 1, seq_len, -1])

--- a/models/demos/qwen3_vl/tt/vision_attention.py
+++ b/models/demos/qwen3_vl/tt/vision_attention.py
@@ -362,10 +362,8 @@ class VisionAttention(LightweightModule):
         batch_size=1,
         user_id_tensor=None,
     ):
-        # For batched prefill, x_11SH has shape [B, 1, S, H] where B is batch_size
-        # Following 70B Galaxy: concat before QKV matmul, then reshape back to batch after
+        # For batched prefill, x_11SH has shape [B, 1, S, H]
         if batch_size > 1:
-            # Concatenate batch dimension into sequence for matmul compatibility
             x_11SH = ttnn.reshape(x_11SH, [1, 1, x_11SH.shape[-2] * x_11SH.shape[-3] * x_11SH.shape[-4], -1])
 
         seq_len = x_11SH.shape[-2]
@@ -504,7 +502,6 @@ class VisionAttention(LightweightModule):
         ttnn.deallocate(v_heads_1VSD_8b)
 
         # For single-user prefill, reshape to expected format for nlp_concat_heads
-        # For batched prefill (batch_size > 1), skip this reshape - nlp_concat_heads handles [B, H, S, D]
         if batch_size == 1:
             attn_output_1QSD = ttnn.reshape(attn_output_84SD, [1, self.n_local_heads, -1, self.padded_head_dim])
         else:
@@ -520,8 +517,6 @@ class VisionAttention(LightweightModule):
         ttnn.deallocate(attn_output_1QSD)
 
         # For batched prefill, reshape to concatenate batch dimension into sequence
-        # This MUST happen AFTER nlp_concat_heads to preserve correct data layout
-        # nlp_concat_heads outputs [B, 1, S_per_user, H*D], reshape to [1, 1, B*S, H*D]
         if batch_size > 1:
             attn_output_11SH = ttnn.reshape(attn_output_11SH, [1, 1, seq_len, -1])
 

--- a/models/demos/qwen3_vl/tt/vision_attention.py
+++ b/models/demos/qwen3_vl/tt/vision_attention.py
@@ -35,7 +35,7 @@ class VisionAttention(LightweightModule):
             chunk_page_table=chunk_page_table,
             chunk_start_idx=chunk_start_idx,
             kv_cache=None,
-            batch_size=1,
+            batch_size=batch_size,
             user_id_tensor=None,
         )
 

--- a/models/demos/qwen3_vl/tt/vision_block.py
+++ b/models/demos/qwen3_vl/tt/vision_block.py
@@ -77,7 +77,10 @@ class VisionBlock(LightweightModule):
         self,
         x: ttnn.Tensor,
         rot_mats,
+        batch_size=1,
+        user_id_tensor=None,
     ) -> ttnn.Tensor:
+        residual = x
         # x is fractured across devices and interleaved in DRAM (for prefill) and sharded in L1 (for decode)
         skip_mem_cfg = ttnn.DRAM_MEMORY_CONFIG
         assert (
@@ -88,12 +91,16 @@ class VisionBlock(LightweightModule):
         attn_in = self.attention_norm(x)
         # Attention takes replicated inputs and produces fractured outputs
         attn_out = self.attention.forward(
-            attn_in,
-            rot_mats=rot_mats,
+            attn_in, rot_mats=rot_mats, batch_size=batch_size, user_id_tensor=user_id_tensor
         )
+        # To match the batch-related reshape inside the attention module
+        # Use the batch_size parameter instead of inferring from shape[-3]
+        # because for [32, 1, S, H] tensors, shape[-3] is 1, not 32
+        # This reshape is only applicable in batched prefill
+        residual = ttnn.reshape(residual, [1, 1, residual.shape[-2] * residual.shape[-3] * residual.shape[0], -1])
 
         # Here x and attn_out are both fractured across devices
-        h = ttnn.add(x, attn_out, memory_config=skip_mem_cfg, dtype=None)
+        h = ttnn.add(residual, attn_out, memory_config=skip_mem_cfg, dtype=None)
         ttnn.deallocate(attn_out)
         ttnn.deallocate(x)
 

--- a/models/demos/qwen3_vl/tt/vision_block.py
+++ b/models/demos/qwen3_vl/tt/vision_block.py
@@ -93,10 +93,6 @@ class VisionBlock(LightweightModule):
         attn_out = self.attention.forward(
             attn_in, rot_mats=rot_mats, batch_size=batch_size, user_id_tensor=user_id_tensor
         )
-        # To match the batch-related reshape inside the attention module
-        # Use the batch_size parameter instead of inferring from shape[-3]
-        # because for [32, 1, S, H] tensors, shape[-3] is 1, not 32
-        # This reshape is only applicable in batched prefill
         residual = ttnn.reshape(residual, [1, 1, residual.shape[-2] * residual.shape[-3] * residual.shape[0], -1])
 
         # Here x and attn_out are both fractured across devices


### PR DESCRIPTION
### Problem description
This PR adds support for batched prefill in Qwen3-VL-32B text generator.

### What's changed
Added batched prefill path in Qwen3-VL text generator aligned with the tt-transformers batched prefill. To avoid OOM issue, smaller chunk size execution method is adapted.

### Results
#### batch-32
Prefill compile time: 2.67s (with batched prefill)
Prefill compile time: 2.73s (without batched prefill)
### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/qwen3_32b)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/qwen3_32b)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ign/qwen3_32b)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ign/qwen3_32b)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/qwen3_32b)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/qwen3_32b)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/qwen3_32b)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/qwen3_32b)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/qwen3_32b)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/qwen3_32b)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/qwen3_32b)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/qwen3_32b)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
