### PR TITLE
MoE: selective comine fixes for GPT-OSS

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_device_operation.cpp
@@ -9,6 +9,8 @@
 #include "selective_reduce_combine_device_operation.hpp"
 #include "ttnn/device_operation.hpp"
 #include "cpp/ttnn/operations/data_movement/common/common.hpp"
+#include <tt-metalium/hal.hpp>
+#include <tt-metalium/tt_align.hpp>
 #include <tt-metalium/work_split.hpp>
 
 namespace ttnn::experimental::prim {
@@ -31,11 +33,11 @@ void SelectiveReduceCombineDeviceOperation::validate_on_program_cache_miss(
     const auto datum_size =
         tt::datum_size(tt::tt_metal::datatype_to_dataformat_converter(token_activations_tensor.dtype()));
 
-    const auto alignmnent = (token_activations_tensor.memory_config().buffer_type() == BufferType::L1)
-                                ? hal::get_l1_alignment()
-                                : hal::get_dram_alignment();
+    const auto alignment = (token_activations_tensor.memory_config().buffer_type() == BufferType::L1)
+                               ? tt::tt_metal::hal::get_l1_alignment()
+                               : tt::tt_metal::hal::get_dram_alignment();
     const uint32_t expected_activations_stride_elm =
-        tt::align((2 * experts_per_device + 1) * datum_size, alignmnent) / datum_size;
+        tt::align((2 * experts_per_device + 1) * datum_size, alignment) / datum_size;
 
     TT_FATAL(
         activations_stride_elm == expected_activations_stride_elm,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_device_operation.cpp
@@ -14,7 +14,33 @@
 namespace ttnn::experimental::prim {
 
 void SelectiveReduceCombineDeviceOperation::validate_on_program_cache_miss(
-    const operation_attributes_t& /*operation_attributes*/, const tensor_args_t& /*tensor_args*/) {}
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const auto& token_activations_tensor = tensor_args.dense_activations_tensor;
+
+    const auto num_devices = token_activations_tensor.device()->get_view().num_devices();
+
+    const auto experts = operation_attributes.experts;
+    const auto batch_size = operation_attributes.batch_size;
+    const auto seq_size = operation_attributes.seq_size;
+    const auto total_tokens = batch_size * seq_size;
+
+    const auto experts_per_device = experts / num_devices;
+
+    const uint32_t activations_stride_elm = token_activations_tensor.logical_shape()[-1] / total_tokens;
+
+    const auto datum_size =
+        tt::datum_size(tt::tt_metal::datatype_to_dataformat_converter(token_activations_tensor.dtype()));
+
+    const auto alignmnent = (token_activations_tensor.memory_config().buffer_type() == BufferType::L1)
+                                ? hal::get_l1_alignment()
+                                : hal::get_dram_alignment();
+    const uint32_t expected_activations_stride_elm =
+        tt::align((2 * experts_per_device + 1) * datum_size, alignmnent) / datum_size;
+
+    TT_FATAL(
+        activations_stride_elm == expected_activations_stride_elm,
+        "The token activations tensor is expected to have aligned 2 * experts_per_device + 1 elements per token");
+}
 
 SelectiveReduceCombineDeviceOperation::spec_return_value_t SelectiveReduceCombineDeviceOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.cpp
@@ -266,8 +266,6 @@ ttnn::device_operation::CachedProgram<UnifiedSelectReduce::shared_variables_t> U
     // page size: total tokens * (2 * experts_per_device + 1 + 3) * sizeof(uint32_t)
     const uint32_t activations_stride_elm = token_activations_tensor.logical_shape()[-1] / total_tokens;
 
-    TT_FATAL(activations_stride_elm == 8, "unexpected stride");
-
     const auto token_activations_page_size_bytes = token_activations_tensor.tensor_spec().compute_page_size_bytes();
     const auto aligned_token_activations_page_size_bytes = tt::align(token_activations_page_size_bytes, l1_alignment);
     constexpr auto token_activations_cb_id = tt::CBIndex::c_3;
@@ -284,7 +282,7 @@ ttnn::device_operation::CachedProgram<UnifiedSelectReduce::shared_variables_t> U
             .set_page_size(client_interface_cb_id, CLIENT_INTERFACE_SIZE);
 
     // create circular buffers
-    CreateCircularBuffer(program, needed_worker_core_range_set, cb_data_config);
+    const auto data_cb_handle = CreateCircularBuffer(program, needed_worker_core_range_set, cb_data_config);
     CreateCircularBuffer(program, needed_worker_core_range_set, cb_dense_token_maps_config);
     CreateCircularBuffer(program, needed_worker_core_range_set, cb_token_counts_config);
     CreateCircularBuffer(program, needed_worker_core_range_set, cb_token_activations_config);
@@ -484,6 +482,7 @@ ttnn::device_operation::CachedProgram<UnifiedSelectReduce::shared_variables_t> U
         std::move(program),
         {.reader_kernel_id = ternary_reader_kernel_id,
          .writer_kernel_id = unary_writer_kernel_id,
+         .data_cb_handle = data_cb_handle,
          .cores = sender_cores,
          .init_semaphore = init_semaphore,
          .cross_device_semaphore = cross_device_semaphore}};
@@ -505,7 +504,11 @@ void UnifiedSelectReduce::override_runtime_arguments(
         const auto& shared_variables = cached_workload.shared_variables.at(range);
         const auto& reader_kernel_id = shared_variables.reader_kernel_id;
         const auto& writer_kernel_id = shared_variables.writer_kernel_id;
+        const auto& data_cb_handle = shared_variables.data_cb_handle;
         const auto& cores = shared_variables.cores;
+
+        tt::tt_metal::UpdateDynamicCircularBufferAddress(
+            program, data_cb_handle, *tensor_args.dense_input_tensor.buffer());
 
         for (const auto& core : cores) {
             auto& reader_runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.hpp
@@ -20,6 +20,7 @@ struct UnifiedSelectReduce {
     struct shared_variables_t {
         tt::tt_metal::KernelHandle reader_kernel_id;
         tt::tt_metal::KernelHandle writer_kernel_id;
+        tt::tt_metal::CBHandle data_cb_handle;
         std::vector<CoreCoord> cores;
         const GlobalSemaphore init_semaphore;
         const GlobalSemaphore cross_device_semaphore;


### PR DESCRIPTION
### Ticket
NA

### Problem description
Bugs and inconsistencies with selective combine for GPT-OSS

### What's changed
- Make activations tensor validation more flexible
- Add missing global CB address override

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amorrison/selective-combine-gpt-oss-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amorrison/selective-combine-gpt-oss-fixes)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=amorrison/selective-combine-gpt-oss-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:amorrison/selective-combine-gpt-oss-fixes)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amorrison/selective-combine-gpt-oss-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amorrison/selective-combine-gpt-oss-fixes)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amorrison/selective-combine-gpt-oss-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amorrison/selective-combine-gpt-oss-fixes)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amorrison/selective-combine-gpt-oss-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amorrison/selective-combine-gpt-oss-fixes)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amorrison/selective-combine-gpt-oss-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amorrison/selective-combine-gpt-oss-fixes)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
