### PR TITLE
fix op test ci  fails

### DIFF
--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/embedding/test_ds_embedding.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/embedding/test_ds_embedding.py
@@ -132,8 +132,16 @@ def _run_ds_embedding_test(
 
     # Log output shape for debugging
     logger.info(f"tt_output_torch shape after mesh concat: {tt_output_torch.shape}")
-    # Shape is [num_rows, seq_len, hidden_per_row] = [4, seq_len, 1792]
+    # Recent embedding API changes can produce either:
+    # - [num_rows, seq_len, hidden_per_row]
+    # - [num_rows, 1, seq_len, hidden_per_row]
+    if tt_output_torch.ndim == 4:
+        assert tt_output_torch.shape[1] == 1, f"Unexpected embedding output shape: {tt_output_torch.shape}"
+        tt_output_torch = tt_output_torch[:, 0, :, :]
+    elif tt_output_torch.ndim != 3:
+        raise ValueError(f"Unexpected embedding output shape: {tt_output_torch.shape}")
 
+    # Shape is now [num_rows, seq_len, hidden_per_row] = [4, seq_len, 1792]
     # Trim to original seq_len first
     tt_output_torch = tt_output_torch[:, :original_seq_len, :]
 

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_all_gather_preff1_3.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_all_gather_preff1_3.py
@@ -221,6 +221,7 @@ def _build_all_gather_inputs(
     force_recalculate_weight_config: bool,
     mode: str,
     seq_len: int,
+    fabric_config: ttnn.FabricConfig,
 ):
     from models.demos.deepseek_v3.tt.mlp.mlp import MLP
 
@@ -232,7 +233,7 @@ def _build_all_gather_inputs(
         mesh_device,
         force_recalculate_weight_config,
     )
-    model_config = get_model_config(MLP, mode, hf_config, mesh_device)
+    model_config = get_model_config(MLP, mode, hf_config, mesh_device, fabric_config)
     model_state = {
         "mesh_device": mesh_device,
         "mesh_shape": mesh_device.shape,
@@ -335,6 +336,7 @@ def test_ds_all_gather_preff1_3(
     expected_perf_us,
     program_cache_enabled,
     trace_mode,
+    device_params,
     hf_config,
     cache_path,
     mesh_device,
@@ -364,6 +366,7 @@ def test_ds_all_gather_preff1_3(
         force_recalculate_weight_config,
         mode,
         seq_len,
+        device_params["fabric_config"],
     )
     _run_ds_all_gather_preff1_3_test(
         mesh_device,

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_ff1_3.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_ff1_3.py
@@ -253,6 +253,7 @@ def _build_ff1_3_inputs(
     use_real_weights: bool,
     mode: str,
     seq_len: int,
+    fabric_config: ttnn.FabricConfig,
 ):
     weights = _build_ff1_3_weights(hf_config, use_real_weights)
 
@@ -272,7 +273,7 @@ def _build_ff1_3_inputs(
         mesh_device,
         force_recalculate_weight_config,
     )
-    model_config = get_model_config(MLP, mode, hf_config, mesh_device)
+    model_config = get_model_config(MLP, mode, hf_config, mesh_device, fabric_config)
     model_state = {
         "mesh_device": mesh_device,
         "mesh_shape": mesh_device.shape,
@@ -384,6 +385,7 @@ def test_ds_ff1_3(
     use_real_weights,
     program_cache_enabled,
     trace_mode,
+    device_params,
     hf_config,
     cache_path,
     mesh_device,
@@ -420,6 +422,7 @@ def test_ds_ff1_3(
         use_real_weights,
         mode,
         seq_len,
+        device_params["fabric_config"],
     )
     _run_ds_ff1_3_test(
         mesh_device,

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_ff2.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_ff2.py
@@ -289,6 +289,7 @@ def _build_ff2_inputs(
     use_real_weights: bool,
     mode: str,
     seq_len: int,
+    fabric_config: ttnn.FabricConfig,
 ):
     """
     Build inputs for FF2 test.
@@ -321,7 +322,7 @@ def _build_ff2_inputs(
         mesh_device,
         force_recalculate_weight_config,
     )
-    model_config = get_model_config(MLP, mode, hf_config, mesh_device)
+    model_config = get_model_config(MLP, mode, hf_config, mesh_device, fabric_config)
     model_state = {
         "mesh_device": mesh_device,
         "mesh_shape": mesh_device.shape,
@@ -489,6 +490,7 @@ def test_ds_ff2(
     use_real_weights,
     program_cache_enabled,
     trace_mode,
+    device_params,
     hf_config,
     cache_path,
     mesh_device,
@@ -518,6 +520,7 @@ def test_ds_ff2(
         use_real_weights,
         mode,
         seq_len,
+        device_params["fabric_config"],
     )
     _run_ds_ff2_test(
         mesh_device,

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_mul.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_mul.py
@@ -254,6 +254,7 @@ def _build_mul_inputs(
     force_recalculate_weight_config: bool,
     mode: str,
     seq_len: int,
+    fabric_config: ttnn.FabricConfig,
 ):
     from models.demos.deepseek_v3.tt.mlp.mlp import MLP
 
@@ -265,7 +266,7 @@ def _build_mul_inputs(
         mesh_device,
         force_recalculate_weight_config,
     )
-    model_config = get_model_config(MLP, mode, hf_config, mesh_device)
+    model_config = get_model_config(MLP, mode, hf_config, mesh_device, fabric_config)
     model_state = {
         "mesh_device": mesh_device,
         "mesh_shape": mesh_device.shape,
@@ -357,6 +358,7 @@ def test_ds_mul(
     expected_perf_us,
     program_cache_enabled,
     trace_mode,
+    device_params,
     hf_config,
     cache_path,
     mesh_device,
@@ -386,6 +388,7 @@ def test_ds_mul(
         force_recalculate_weight_config,
         mode,
         seq_len,
+        device_params["fabric_config"],
     )
     _run_ds_mul_test(
         mesh_device,
@@ -471,6 +474,7 @@ def test_ds_mul_single_device(
     expected_perf_us,
     program_cache_enabled,
     trace_mode,
+    device_params,
     hf_config,
     cache_path,
     mesh_device,
@@ -510,7 +514,7 @@ def test_ds_mul_single_device(
         mesh_device,
         force_recalculate_weight_config,
     )
-    model_config = get_model_config(MLP, mode, hf_config, mesh_device)
+    model_config = get_model_config(MLP, mode, hf_config, mesh_device, device_params["fabric_config"])
     model_state = {
         "mesh_device": mesh_device,
         "mesh_shape": mesh_device.shape,

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_reduce_scatter_post_ff2.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_reduce_scatter_post_ff2.py
@@ -308,6 +308,7 @@ def _build_reduce_scatter_inputs(
     force_recalculate_weight_config: bool,
     mode: str,
     seq_len: int,
+    fabric_config: ttnn.FabricConfig,
 ):
     """Build inputs for reduce_scatter_post_ff2 test.
 
@@ -330,7 +331,7 @@ def _build_reduce_scatter_inputs(
         mesh_device,
         force_recalculate_weight_config,
     )
-    model_config = get_model_config(MLP, mode, hf_config, mesh_device)
+    model_config = get_model_config(MLP, mode, hf_config, mesh_device, fabric_config)
     model_state = {
         "mesh_device": mesh_device,
         "mesh_shape": mesh_device.shape,
@@ -447,6 +448,7 @@ def test_ds_reduce_scatter_post_ff2(
     expected_perf_us,
     program_cache_enabled,
     trace_mode,
+    device_params,
     hf_config,
     cache_path,
     mesh_device,
@@ -475,6 +477,7 @@ def test_ds_reduce_scatter_post_ff2(
         force_recalculate_weight_config,
         mode,
         seq_len,
+        device_params["fabric_config"],
     )
     _run_ds_reduce_scatter_post_ff2_test(
         mesh_device,


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Deepseek Op Performance tests are failing on CI

### What's changed
- There were changes in fabric config and embedding op API behaviour, the unit tests are modified to support those changes.

#### Model tests
- [Deepseek Op Perf Tests](https://github.com/tenstorrent/tt-metal/actions/runs/23019705343/job/66853629691)
- [Deepseek Module Tests](https://github.com/tenstorrent/tt-metal/actions/runs/23019694744/job/66871274711)