### PR TITLE
[deepseek] Set trace mode ON and sample on device ON by default

### DIFF
--- a/models/demos/deepseek_v3/demo/demo.py
+++ b/models/demos/deepseek_v3/demo/demo.py
@@ -107,10 +107,11 @@ def create_parser() -> argparse.ArgumentParser:
         help="Select generator implementation: default = bp (batch parallel).",
     )
     p.add_argument(
-        "--enable-trace",
-        action="store_true",
-        default=False,
-        help="Enable trace for decode forward pass",
+        "--disable-trace",
+        action="store_false",
+        dest="enable_trace",
+        default=True,
+        help="Disable trace for decode forward pass.",
     )
     p.add_argument(
         "--enable-mem-profile",
@@ -141,10 +142,11 @@ def create_parser() -> argparse.ArgumentParser:
         help="Profile decode performance: skip prefill (use random tokens), and run only first dense layer + first MoE layer during decode.",
     )
     p.add_argument(
-        "--sample-on-device",
-        action="store_true",
-        default=False,
-        help="Enable on-device sampling (default: host-side sampling).",
+        "--sample-on-host",
+        action="store_false",
+        dest="sample_on_device",
+        default=True,
+        help="Disable on-device sampling and use host-side sampling.",
     )
     p.add_argument(
         "--force-recalculate",
@@ -265,13 +267,13 @@ def run_demo(
     tf_prompt_len: int | None = None,
     early_print_first_user: bool = True,
     generator: str = "bp",
-    enable_trace: bool = False,
+    enable_trace: bool = True,
     enable_mem_profile: bool = False,
     repeat_batches: int = 1,
     signpost: bool = False,
     prefill_max_tokens: int = None,
     profile_decode: bool = False,
-    sample_on_device: bool = False,
+    sample_on_device: bool = True,
     force_recalculate: bool = False,
 ) -> dict:
     """Programmatic entrypoint for the DeepSeek-V3 demo.

--- a/models/demos/deepseek_v3/demo/test_demo.py
+++ b/models/demos/deepseek_v3/demo/test_demo.py
@@ -15,103 +15,132 @@ MODEL_PATH = Path(
 CACHE_DIR = Path(os.getenv("DEEPSEEK_V3_CACHE", "/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI"))
 
 
+def _demo_case(
+    *,
+    max_prompts: int,
+    repeat_batches: int,
+    max_new_tokens: int,
+    override_num_layers: int | None,
+    enable_trace: bool,
+    sample_on_device: bool,
+    artifact_name: str | None,
+    profile_decode: bool,
+    case_id: str,
+    marks=None,
+):
+    return pytest.param(
+        {
+            "max_prompts": max_prompts,
+            "repeat_batches": repeat_batches,
+            "max_new_tokens": max_new_tokens,
+            "override_num_layers": override_num_layers,
+            "enable_trace": enable_trace,
+            "sample_on_device": sample_on_device,
+            "artifact_name": artifact_name,
+            "profile_decode": profile_decode,
+        },
+        id=case_id,
+        marks=marks,
+    )
+
+
+# Test matrix:
+# +------------------+-------------+----------------+----------------+---------------------+--------------+------------------+--------------------------+----------------+
+# | id               | max_prompts | repeat_batches | max_new_tokens | override_num_layers | enable_trace | sample_on_device | artifact_name            | profile_decode |
+# +------------------+-------------+----------------+----------------+---------------------+--------------+------------------+--------------------------+----------------+
+# | tg_light_stress  | 56          | 2              | 128            | 5                   | True         | True             | None                     | False          |
+# | dual_full_demo   | 256         | 1              | 129            | None                | True         | True             | dual_demo_full_results   | False          |
+# | dual_stress_demo | 56          | 20             | 129            | None                | True         | True             | dual_demo_stress_results | False          |
+# | quad_full_demo   | 512         | 1              | 129            | None                | True         | True             | quad_demo_full_results   | False          |
+# | quad_stress_demo | 56          | 20             | 129            | None                | True         | True             | quad_demo_stress_results | False          |
+# | profile_decode   | 1           | 1              | 13             | 5                   | True         | True             | None                     | True           |
+# +------------------+-------------+----------------+----------------+---------------------+--------------+------------------+--------------------------+----------------+
+
+
 @pytest.mark.parametrize(
-    "max_prompts,repeat_batches,max_new_tokens,override_num_layers,enable_trace,artifact_name,profile_decode",
+    # update test matrix table above if new test cases are added
+    "case",
     [
-        pytest.param(
-            56,
-            2,
-            128,
-            5,
-            False,
-            None,
-            False,
-            id="tg_stress",
+        _demo_case(
+            max_prompts=56,
+            repeat_batches=2,
+            max_new_tokens=128,
+            override_num_layers=5,
+            enable_trace=True,
+            sample_on_device=True,
+            artifact_name=None,
+            profile_decode=False,
+            case_id="tg_light_stress",
             marks=pytest.mark.requires_device(["TG"]),
         ),
-        pytest.param(
-            256,
-            1,
-            129,
-            None,
-            True,
-            "dual_demo_full_results",
-            False,
-            id="dual_full_demo",
+        _demo_case(
+            max_prompts=256,
+            repeat_batches=1,
+            max_new_tokens=129,
+            override_num_layers=None,
+            enable_trace=True,
+            sample_on_device=True,
+            artifact_name="dual_demo_full_results",
+            profile_decode=False,
+            case_id="dual_full_demo",
             marks=[pytest.mark.requires_device(["DUAL"]), pytest.mark.timeout(2400)],
         ),
-        pytest.param(
-            56,
-            20,
-            129,
-            None,
-            True,
-            "dual_demo_stress_results",
-            False,
-            id="dual_stress_demo",
+        _demo_case(
+            max_prompts=56,
+            repeat_batches=20,
+            max_new_tokens=129,
+            override_num_layers=None,
+            enable_trace=True,
+            sample_on_device=True,
+            artifact_name="dual_demo_stress_results",
+            profile_decode=False,
+            case_id="dual_stress_demo",
             marks=[pytest.mark.requires_device(["DUAL"]), pytest.mark.timeout(5400)],
         ),
-        pytest.param(
-            512,
-            1,
-            129,
-            None,
-            True,
-            "quad_demo_full_results",
-            False,
-            id="quad_full_demo",
+        _demo_case(
+            max_prompts=512,
+            repeat_batches=1,
+            max_new_tokens=129,
+            override_num_layers=None,
+            enable_trace=True,
+            sample_on_device=True,
+            artifact_name="quad_demo_full_results",
+            profile_decode=False,
+            case_id="quad_full_demo",
             marks=[pytest.mark.requires_device(["QUAD"]), pytest.mark.timeout(3600)],
         ),
-        pytest.param(
-            56,
-            20,
-            129,
-            None,
-            True,
-            "quad_demo_stress_results",
-            False,
-            id="quad_stress_demo",
+        _demo_case(
+            max_prompts=56,
+            repeat_batches=20,
+            max_new_tokens=129,
+            override_num_layers=None,
+            enable_trace=True,
+            sample_on_device=True,
+            artifact_name="quad_demo_stress_results",
+            profile_decode=False,
+            case_id="quad_stress_demo",
             marks=[pytest.mark.requires_device(["QUAD"]), pytest.mark.timeout(5400)],
         ),
-        pytest.param(
-            1,
-            1,
-            13,
-            5,
-            True,
-            None,
-            True,
-            id="profile_decode",
+        _demo_case(
+            max_prompts=1,
+            repeat_batches=1,
+            max_new_tokens=13,
+            override_num_layers=5,
+            enable_trace=True,
+            sample_on_device=True,
+            artifact_name=None,
+            profile_decode=True,
+            case_id="profile_decode",
             marks=pytest.mark.timeout(1800),
         ),
     ],
 )
-def test_demo(
-    max_prompts: int,
-    repeat_batches: int,
-    max_new_tokens: int,
-    override_num_layers: int,
-    enable_trace: bool,
-    artifact_name: str,
-    profile_decode: bool,
-    force_recalculate_weight_config: bool,
-):
-    """
-    DeepSeek v3 demo test with prompts loaded from JSON file.
-
-    Test variants:
-    - tg_stress (TG): 56 prompts, 2 batches, 5 layers - stress test for CI
-    - dual_full_demo (DUAL): 256 prompts, 1 batch - tests full prompt capacity
-    - dual_stress_demo (DUAL): 56 prompts, 20 batches - tests stability under repeated execution
-    - quad_full_demo (QUAD): 512 prompts, 1 batch - tests full prompt capacity
-    - quad_stress_demo (QUAD): 56 prompts, 20 batches - tests stability under repeated execution
-    - profile_decode: Profile decode for non-moe and moe layers
-    """
+def test_demo(case: dict, force_recalculate_weight_config: bool):
     # Path to the external JSON file containing prompts
     json_path = "models/demos/deepseek_v3/demo/test_prompts.json"
 
     # Load prompts from JSON file
-    prompts = load_prompts_from_json(json_path, max_prompts=max_prompts)
+    prompts = load_prompts_from_json(json_path, max_prompts=case["max_prompts"])
 
     # Run demo
     run_kwargs = dict(
@@ -119,27 +148,27 @@ def test_demo(
         model_path=MODEL_PATH,
         cache_dir=CACHE_DIR,
         random_weights=False,
-        max_new_tokens=max_new_tokens,
-        repeat_batches=repeat_batches,
-        profile_decode=profile_decode,
+        max_new_tokens=case["max_new_tokens"],
+        repeat_batches=case["repeat_batches"],
+        enable_trace=case["enable_trace"],
+        sample_on_device=case["sample_on_device"],
+        profile_decode=case["profile_decode"],
         force_recalculate=force_recalculate_weight_config,
         signpost=True,
     )
-    if override_num_layers is not None:
-        run_kwargs["override_num_layers"] = override_num_layers
-    if enable_trace:
-        run_kwargs["enable_trace"] = True
+    if case["override_num_layers"] is not None:
+        run_kwargs["override_num_layers"] = case["override_num_layers"]
 
     results = run_demo(**run_kwargs)
 
     # Check output
-    assert len(results["generations"][0]["tokens"]) == max_new_tokens
+    assert len(results["generations"][0]["tokens"]) == case["max_new_tokens"]
 
     # Save results to JSON for artifact upload (QUAD tests only)
-    if artifact_name is not None:
+    if case["artifact_name"] is not None:
         artifact_dir = Path("generated/artifacts")
         artifact_dir.mkdir(parents=True, exist_ok=True)
-        output_file = artifact_dir / f"{artifact_name}.json"
+        output_file = artifact_dir / f"{case['artifact_name']}.json"
 
         output_data = {
             "prompts": prompts,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/35128

### What's changed
- Set trace mode ON and sample on device ON by default in deepseek demo.py
- refactor test_demo.py (test trace mode for tg_stress also and make params more readble)


### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pprajapati/demo_defaults)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pprajapati/demo_defaults)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pprajapati/demo_defaults)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pprajapati/demo_defaults)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pprajapati/demo_defaults)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pprajapati/demo_defaults)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pprajapati/demo_defaults)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pprajapati/demo_defaults)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pprajapati/demo_defaults)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pprajapati/demo_defaults)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pprajapati/demo_defaults)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pprajapati/demo_defaults)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
