### PR TITLE
[skip ci] Clarify GHA run names in multi host pipeline

### DIFF
--- a/.github/workflows/multi-host-physical.yaml
+++ b/.github/workflows/multi-host-physical.yaml
@@ -47,10 +47,10 @@ on:
 
 run-name: >
   ${{ github.event_name == 'schedule' &&
-      (github.event.schedule == '0 */3 * * *' && 'T3K/Dual Validation' ||
-       github.event.schedule == '0 2 * * *'  && 'Quad Nightly' ||
-       'Scheduled Run')
-      || 'Manual Run' }}
+      (github.event.schedule == '0 */3 * * *' && 'Multi host T3K/Dual Galaxy Validation' ||
+       github.event.schedule == '0 4 * * *'  && 'Multi host Quad Galaxy Nightly' ||
+       'Multi host Scheduled Run')
+      || 'Multi host Manual Run' }}
 
 jobs:
   build-artifact:


### PR DESCRIPTION
Multi host pipeline would sometimes run with name `Scheduled Run` and `Manual Run` which was confusing when pulling data wrt run names. Append `Multi host` to the front of run names and added `Galaxy` where applicable. Also fixes an issue where `Quad Nightly` run naming was not possible due to mismatch in `github.event.schedule` checking.

Behaviour previously:
- every 3 hours run `T3K/Dual Validation`
- every night run `Scheduled run`
- manual runs named `Manual run`
- if new cron was added, it would be named `Scheduled run`

Behaviour now:
- every 3 hours run `Multi host T3K/Dual Galaxy Validation`
- every night run `Multi host Quad Galaxy Nightly`
- manual runs named `Multi host Manual Run`
- if new cron was added, it would be named `Multi host Scheduled Run`

No actual testing behaviour is changed.