### PR TITLE
[Bug Fix]: NOC_MAX_TRANSACTION_ID for Quasar since there are 32 txnIDs

### DIFF
--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/noc/noc_parameters.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/noc/noc_parameters.h
@@ -27,7 +27,7 @@
 #define NUM_NOCS 1
 #define NOC_ID_WIDTH 6
 
-#define NOC_MAX_TRANSACTION_ID 0xF
+#define NOC_MAX_TRANSACTION_ID 0x1F
 #define NOC_MAX_TRANSACTION_ID_COUNT 0xFFFF
 
 // FLEX Port defnes


### PR DESCRIPTION
### What's changed
32 transaction ids on Quasar 
Note: we probably need to specify for diff chiplets 
