### PR TITLE
[skip ci] Add BrAIn to merge-gate failure notifications

### DIFF
--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -429,7 +429,7 @@ jobs:
         uses: tenstorrent/tt-metal/.github/actions/slack-report-merge-gate@main
         with:
           slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_WEBHOOK_URL }}
-          owner: "U08GTDV8MDH,U0AK4BVCFM0"
+          owner: "U08GTDV8MDH"
       - if: (failure() && contains(join(needs.*.result, ','), 'failure') && github.ref == 'refs/heads/main')
         uses: tenstorrent/tt-metal/.github/actions/slack-report-merge-gate-main@main
         with:

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -429,9 +429,9 @@ jobs:
         uses: tenstorrent/tt-metal/.github/actions/slack-report-merge-gate@main
         with:
           slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_WEBHOOK_URL }}
-          owner: "U08GTDV8MDH"
+          owner: "U08GTDV8MDH,U0AK4BVCFM0"
       - if: (failure() && contains(join(needs.*.result, ','), 'failure') && github.ref == 'refs/heads/main')
         uses: tenstorrent/tt-metal/.github/actions/slack-report-merge-gate-main@main
         with:
           slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_WEBHOOK_URL }}
-          owner: "S0985AN7TC5"
+          owner: "S0985AN7TC5,U0AK4BVCFM0"


### PR DESCRIPTION
## Summary

Tags BrAIn on main merge-gate failures so it can automatically triage alerts.

Existing owners retained — metalinfra stays in the loop.