### PR TITLE
Cleanup Selu

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
@@ -356,35 +356,6 @@ Tensor ExecuteUnaryCompositeClamp::invoke(
         output_memory_config);
 }
 
-// Theano defines this differently...
-/**
- *
- *   alpha = 1.6732632423543772848170429916717
- *    scale = 1.0507009873554804934193349852946
- *    return scale * elu(x, alpha)
- *
- */
-// Function Selu - scaled exponential linear
-// use transformation y = scale *(max(0,x) + min(0,alpha * (exp(X)-1))) by broadcast
-// Ref: https://pytorch.org/docs/stable/generated/torch.nn.SELU.html
-Tensor _selu(
-    const Tensor& x, const float scale, const float alpha, const std::optional<MemoryConfig>& output_mem_config) {
-    // term 2
-    Tensor x_Exp_minus_1 = ttnn::expm1(x, output_mem_config);
-    Tensor result_t2_ = ttnn::multiply_(x_Exp_minus_1, alpha);
-    x_Exp_minus_1.deallocate();
-    Tensor result_term2 = ttnn::minimum(result_t2_, 0.0f, std::nullopt, output_mem_config);
-    result_t2_.deallocate();
-
-    // term 1
-    Tensor x_max = ttnn::maximum(x, 0.0f, std::nullopt, output_mem_config);
-    Tensor sum_max_term2 = ttnn::add_(x_max, result_term2);
-    x_max.deallocate();
-    Tensor result_selu = ttnn::multiply_(sum_max_term2, scale);
-
-    return result_selu;
-}
-
 std::vector<Tensor> split_tensor_for_glu(
     const Tensor& input_a, int32_t dim, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> t_split;


### PR DESCRIPTION
### Ticket
-

### Problem description
Selu was migrated as Device op as part of issue https://github.com/tenstorrent/tt-metal/issues/21830, but composite implementation was reverted as part of https://github.com/tenstorrent/tt-metal/pull/28477. 

### What's changed
Cleaned up selu op.

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=virdhatchani/selu_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:virdhatchani/selu_cleanup)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=virdhatchani/selu_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:virdhatchani/selu_cleanup)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=virdhatchani/selu_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:virdhatchani/selu_cleanup)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


