### PR TITLE
Switching lightweight asserts from ebreak to while(true)

### DIFF
--- a/tools/triage/dump_lightweight_asserts.py
+++ b/tools/triage/dump_lightweight_asserts.py
@@ -66,7 +66,7 @@ def extract_assert_code(file: str | None, line: int | None, column: int | None) 
         with open(file, "r") as f:
             lines = f.readlines()
             if not (0 <= line - 1 < len(lines)):
-                return "?wrong line number?"
+                return "?wrong line number? Check the first code line in the stack trace."
             code_line = lines[line - 1]
             start_index = -1
             while True:
@@ -75,13 +75,13 @@ def extract_assert_code(file: str | None, line: int | None, column: int | None) 
                     break
                 start_index = new_index
             if start_index == -1:
-                return "?ASSERT() not found?"
+                return "ASSERT() not found! Check the first code line in the stack trace."
             while start_index > 0 and (code_line[start_index - 1].isalnum() or code_line[start_index - 1] == "_"):
                 start_index -= 1
             # Find the matching closing parenthesis for ASSERT(
             open_paren_index = code_line.find("(", start_index)
             if open_paren_index == -1:
-                return "?ASSERT() not opened?"
+                return "ASSERT() not opened! Check the first code line in the stack trace."
             paren_count = 1
             i = open_paren_index + 1
             while i < len(code_line):
@@ -93,7 +93,7 @@ def extract_assert_code(file: str | None, line: int | None, column: int | None) 
                         break
                 i += 1
             if paren_count != 0:
-                return "?ASSERT() not closed?"
+                return "ASSERT() is multi line. Check the first code line in the stack trace."
             return code_line[start_index : i + 1].strip()
     except Exception:
         return "?"

--- a/tools/triage/dump_lightweight_asserts.py
+++ b/tools/triage/dump_lightweight_asserts.py
@@ -149,17 +149,17 @@ def dump_lightweight_asserts(
             if pc >= 4:
                 previous_instruction = read_word_from_device(location, pc - 4)
 
-        # Check if core hit ebreak
+        # Check if core hit ebreak or is spinning in a while(true) loop after an assert failure
         while_true_instruction = 0x0000006F
         ebreak_instruction = 0x00100073
-        rewind_pc = False
-        if previous_instruction == ebreak_instruction or previous_instruction == while_true_instruction:
-            rewind_pc = True
+        rewind_pc_for_ebreak = False
+        if previous_instruction == ebreak_instruction:
+            rewind_pc_for_ebreak = True
         elif current_instruction != ebreak_instruction and current_instruction != while_true_instruction:
             return None
 
         callstack_data = callstack_provider.get_cached_callstacks(
-            location, risc_name, rewind_pc, use_full_callstack=True
+            location, risc_name, rewind_pc_for_ebreak, use_full_callstack=True
         )
         arguments_and_locals = None
         assert_code = "?"

--- a/tools/triage/dump_lightweight_asserts.py
+++ b/tools/triage/dump_lightweight_asserts.py
@@ -150,15 +150,16 @@ def dump_lightweight_asserts(
                 previous_instruction = read_word_from_device(location, pc - 4)
 
         # Check if core hit ebreak
+        while_true_instruction = 0x0000006F
         ebreak_instruction = 0x00100073
-        rewind_pc_for_ebreak = False
-        if previous_instruction == ebreak_instruction:
-            rewind_pc_for_ebreak = True
-        elif current_instruction != ebreak_instruction:
+        rewind_pc = False
+        if previous_instruction == ebreak_instruction or previous_instruction == while_true_instruction:
+            rewind_pc = True
+        elif current_instruction != ebreak_instruction and current_instruction != while_true_instruction:
             return None
 
         callstack_data = callstack_provider.get_cached_callstacks(
-            location, risc_name, rewind_pc_for_ebreak, use_full_callstack=True
+            location, risc_name, rewind_pc, use_full_callstack=True
         )
         arguments_and_locals = None
         assert_code = "?"

--- a/tt_metal/hw/inc/api/debug/assert.h
+++ b/tt_metal/hw/inc/api/debug/assert.h
@@ -54,10 +54,10 @@ inline void assert_and_hang(uint32_t line_num, debug_assert_type_t assert_type =
 
 #if defined(LIGHTWEIGHT_KERNEL_ASSERTS)
 
-#define ASSERT(condition, ...)      \
-    do {                            \
-        if (!(condition))           \
-            asm volatile("ebreak"); \
+#define ASSERT(condition, ...) \
+    do {                       \
+        if (!(condition))      \
+            while (true);      \
     } while (0)
 
 #define ASSERT_ENABLED 1


### PR DESCRIPTION
We found a bug that won't trigger `ebreak` in some scenarios. Since asserts are not using feature of continuing halted core, we will switch to `while(true);` which works as expected.
Once we check with hardware folks for mitigation, we will be returning `ebreak` if it is possible. We cannot continue NCRISC anyways, but we might consider using `ebreak` and `continue` on Quasar and beyond.

Updating `dump_lightweight_asserts.py` to support both `ebreak` and `while(true);` instructions.