### PR TITLE
DeepSeek: coordinate multihost weight cache publication

### DIFF
--- a/models/demos/deepseek_v3/conftest.py
+++ b/models/demos/deepseek_v3/conftest.py
@@ -15,6 +15,10 @@ from models.demos.deepseek_v3.utils.test_utils import get_valid_system_names, lo
 from tests.scripts.common import get_updated_device_params
 
 RESET_WEIGHT_CACHE_OPTION = "--recalculate-weights"
+RECALCULATE_WEIGHT_CACHE_DEMO_TIMEOUT_SECONDS = 6 * 60 * 60
+DEEPSEEK_DEMO_NODEID_PREFIX = "models/demos/deepseek_v3/demo/"
+DEEPSEEK_TESTS_NODEID_PREFIX = "models/demos/deepseek_v3/tests/"
+MULTIHOST_WEIGHT_CACHE_TEST_TIMEOUT_SECONDS = 30 * 60
 
 # Shared test parametrization constants
 # Prefill sequence lengths: powers of 2 from 128 to 128K
@@ -305,6 +309,79 @@ def pytest_configure(config):
     )
 
 
+def _get_timeout_override_marker(item, timeout_seconds: float) -> pytest.MarkDecorator:
+    timeout_marker = item.get_closest_marker("timeout")
+    if timeout_marker is None:
+        return pytest.mark.timeout(timeout_seconds)
+
+    args = list(timeout_marker.args)
+    kwargs = dict(timeout_marker.kwargs)
+    if args:
+        args[0] = timeout_seconds
+    elif "timeout" in kwargs:
+        kwargs["timeout"] = timeout_seconds
+    else:
+        args = [timeout_seconds]
+
+    return pytest.mark.timeout(*args, **kwargs)
+
+
+def _maybe_extend_demo_timeout_for_weight_recalculation(config: pytest.Config, item: pytest.Item) -> None:
+    if not config.getoption(RESET_WEIGHT_CACHE_OPTION):
+        return
+    if not item.nodeid.startswith(DEEPSEEK_DEMO_NODEID_PREFIX):
+        return
+    if "force_recalculate_weight_config" not in item.fixturenames:
+        return
+
+    timeout_marker = item.get_closest_marker("timeout")
+    current_timeout = None
+    if timeout_marker is not None:
+        current_timeout = timeout_marker.args[0] if timeout_marker.args else timeout_marker.kwargs.get("timeout")
+        try:
+            current_timeout = float(current_timeout)
+        except (TypeError, ValueError):
+            current_timeout = None
+
+    if current_timeout is not None and current_timeout >= RECALCULATE_WEIGHT_CACHE_DEMO_TIMEOUT_SECONDS:
+        return
+
+    # Cold-cache demo weight generation can take hours, so relax the timeout only
+    # when the user explicitly asks pytest to recalculate cached weights.
+    item.add_marker(
+        _get_timeout_override_marker(item, RECALCULATE_WEIGHT_CACHE_DEMO_TIMEOUT_SECONDS),
+        append=False,
+    )
+
+
+def _maybe_extend_test_timeout_for_multihost_weight_cache(current_device: str, item: pytest.Item) -> None:
+    if current_device not in {"TG", "DUAL", "QUAD"}:
+        return
+    if not item.nodeid.startswith(DEEPSEEK_TESTS_NODEID_PREFIX):
+        return
+    if "force_recalculate_weight_config" not in item.fixturenames:
+        return
+
+    timeout_marker = item.get_closest_marker("timeout")
+    current_timeout = None
+    if timeout_marker is not None:
+        current_timeout = timeout_marker.args[0] if timeout_marker.args else timeout_marker.kwargs.get("timeout")
+        try:
+            current_timeout = float(current_timeout)
+        except (TypeError, ValueError):
+            current_timeout = None
+
+    if current_timeout is not None and current_timeout >= MULTIHOST_WEIGHT_CACHE_TEST_TIMEOUT_SECONDS:
+        return
+
+    # Shared-cache publication/visibility for multihost DeepSeek tests regularly
+    # exceeds pytest's default 300s even when the code under test is healthy.
+    item.add_marker(
+        _get_timeout_override_marker(item, MULTIHOST_WEIGHT_CACHE_TEST_TIMEOUT_SECONDS),
+        append=False,
+    )
+
+
 def pytest_collection_modifyitems(config, items):
     """
     Check if tests have requires_device marker and skip them during collection if current device doesn't match.
@@ -316,6 +393,9 @@ def pytest_collection_modifyitems(config, items):
         pytest.exit(f"Could not determine device type during collection: {e}", returncode=1)
 
     for item in items:
+        _maybe_extend_demo_timeout_for_weight_recalculation(config, item)
+        _maybe_extend_test_timeout_for_multihost_weight_cache(current_device, item)
+
         marker = item.get_closest_marker("requires_device")
         if marker:
             # Get device_types from marker - can be single value or list

--- a/models/demos/deepseek_v3/conftest.py
+++ b/models/demos/deepseek_v3/conftest.py
@@ -15,10 +15,6 @@ from models.demos.deepseek_v3.utils.test_utils import get_valid_system_names, lo
 from tests.scripts.common import get_updated_device_params
 
 RESET_WEIGHT_CACHE_OPTION = "--recalculate-weights"
-RECALCULATE_WEIGHT_CACHE_DEMO_TIMEOUT_SECONDS = 6 * 60 * 60
-DEEPSEEK_DEMO_NODEID_PREFIX = "models/demos/deepseek_v3/demo/"
-DEEPSEEK_TESTS_NODEID_PREFIX = "models/demos/deepseek_v3/tests/"
-MULTIHOST_WEIGHT_CACHE_TEST_TIMEOUT_SECONDS = 30 * 60
 
 # Shared test parametrization constants
 # Prefill sequence lengths: powers of 2 from 128 to 128K
@@ -309,79 +305,6 @@ def pytest_configure(config):
     )
 
 
-def _get_timeout_override_marker(item, timeout_seconds: float) -> pytest.MarkDecorator:
-    timeout_marker = item.get_closest_marker("timeout")
-    if timeout_marker is None:
-        return pytest.mark.timeout(timeout_seconds)
-
-    args = list(timeout_marker.args)
-    kwargs = dict(timeout_marker.kwargs)
-    if args:
-        args[0] = timeout_seconds
-    elif "timeout" in kwargs:
-        kwargs["timeout"] = timeout_seconds
-    else:
-        args = [timeout_seconds]
-
-    return pytest.mark.timeout(*args, **kwargs)
-
-
-def _maybe_extend_demo_timeout_for_weight_recalculation(config: pytest.Config, item: pytest.Item) -> None:
-    if not config.getoption(RESET_WEIGHT_CACHE_OPTION):
-        return
-    if not item.nodeid.startswith(DEEPSEEK_DEMO_NODEID_PREFIX):
-        return
-    if "force_recalculate_weight_config" not in item.fixturenames:
-        return
-
-    timeout_marker = item.get_closest_marker("timeout")
-    current_timeout = None
-    if timeout_marker is not None:
-        current_timeout = timeout_marker.args[0] if timeout_marker.args else timeout_marker.kwargs.get("timeout")
-        try:
-            current_timeout = float(current_timeout)
-        except (TypeError, ValueError):
-            current_timeout = None
-
-    if current_timeout is not None and current_timeout >= RECALCULATE_WEIGHT_CACHE_DEMO_TIMEOUT_SECONDS:
-        return
-
-    # Cold-cache demo weight generation can take hours, so relax the timeout only
-    # when the user explicitly asks pytest to recalculate cached weights.
-    item.add_marker(
-        _get_timeout_override_marker(item, RECALCULATE_WEIGHT_CACHE_DEMO_TIMEOUT_SECONDS),
-        append=False,
-    )
-
-
-def _maybe_extend_test_timeout_for_multihost_weight_cache(current_device: str, item: pytest.Item) -> None:
-    if current_device not in {"TG", "DUAL", "QUAD"}:
-        return
-    if not item.nodeid.startswith(DEEPSEEK_TESTS_NODEID_PREFIX):
-        return
-    if "force_recalculate_weight_config" not in item.fixturenames:
-        return
-
-    timeout_marker = item.get_closest_marker("timeout")
-    current_timeout = None
-    if timeout_marker is not None:
-        current_timeout = timeout_marker.args[0] if timeout_marker.args else timeout_marker.kwargs.get("timeout")
-        try:
-            current_timeout = float(current_timeout)
-        except (TypeError, ValueError):
-            current_timeout = None
-
-    if current_timeout is not None and current_timeout >= MULTIHOST_WEIGHT_CACHE_TEST_TIMEOUT_SECONDS:
-        return
-
-    # Shared-cache publication/visibility for multihost DeepSeek tests regularly
-    # exceeds pytest's default 300s even when the code under test is healthy.
-    item.add_marker(
-        _get_timeout_override_marker(item, MULTIHOST_WEIGHT_CACHE_TEST_TIMEOUT_SECONDS),
-        append=False,
-    )
-
-
 def pytest_collection_modifyitems(config, items):
     """
     Check if tests have requires_device marker and skip them during collection if current device doesn't match.
@@ -393,9 +316,6 @@ def pytest_collection_modifyitems(config, items):
         pytest.exit(f"Could not determine device type during collection: {e}", returncode=1)
 
     for item in items:
-        _maybe_extend_demo_timeout_for_weight_recalculation(config, item)
-        _maybe_extend_test_timeout_for_multihost_weight_cache(current_device, item)
-
         marker = item.get_closest_marker("requires_device")
         if marker:
             # Get device_types from marker - can be single value or list

--- a/models/demos/deepseek_v3/tests/test_get_weight_config.py
+++ b/models/demos/deepseek_v3/tests/test_get_weight_config.py
@@ -13,6 +13,7 @@ import pytest
 import torch
 from transformers.configuration_utils import PretrainedConfig
 
+import models.demos.deepseek_v3.utils.weight_config as weight_config_module
 import ttnn
 from models.demos.deepseek_v3.utils.config_dataclass import SavedWeight
 from models.demos.deepseek_v3.utils.config_helpers import TENSOR_CACHE_EXTENSION
@@ -265,6 +266,73 @@ def test_get_weight_config_cache_invalidation_wrong_suffix(tmp_path: Path) -> No
     assert call_count["n"] == 2
 
 
+def test_get_weight_config_multihost_peer_uses_rank0_hit_decision(tmp_path: Path, monkeypatch) -> None:
+    """Peer ranks should follow rank 0's hit decision and skip local cache validation."""
+
+    class FakeModule:
+        @staticmethod
+        def convert_weights(hf_config, state_dicts, weight_cache_path: Path, mesh_device):
+            raise AssertionError("convert_weights should not run on a peer rank when rank 0 reported a cache hit")
+
+    sentinel = {"w": SavedWeight(path=tmp_path / "already-normalized.tensorbin", memory_config=ttnn.DRAM_MEMORY_CONFIG)}
+    monkeypatch.setattr(weight_config_module, "_is_multihost_distributed", lambda: True)
+    monkeypatch.setattr(weight_config_module, "_get_distributed_rank", lambda: 1)
+    monkeypatch.setattr(weight_config_module, "_distributed_barrier", lambda: None)
+    monkeypatch.setattr(weight_config_module, "_read_multihost_decision", lambda path: {"mode": "hit"})
+    monkeypatch.setattr(weight_config_module, "_load_cached_config_without_visibility_checks", lambda *_args: sentinel)
+
+    mesh_device = _FakeMeshDevice(shape=(2, 2))
+    hf_config = _make_hf_config(num_hidden_layers=2)
+    base_cache = tmp_path / "weight_cache"
+
+    cfg = get_weight_config(
+        ModuleClass=FakeModule,
+        hf_config=hf_config,
+        state_dicts=({"dummy": torch.empty(1)},),
+        weight_cache_path=base_cache,
+        mesh_device=mesh_device,
+        force_recalculate=False,
+    )
+
+    assert cfg is sentinel
+
+
+def test_get_weight_config_multihost_peer_miss_does_not_write_config(tmp_path: Path, monkeypatch) -> None:
+    """Peer ranks should participate in generation on miss, but leave config.json publication to rank 0."""
+
+    class FakeModule:
+        @staticmethod
+        def convert_weights(hf_config, state_dicts, weight_cache_path: Path, mesh_device):
+            (weight_cache_path / "weights").mkdir(parents=True, exist_ok=True)
+            rel_path = Path("weights") / f"w{TENSOR_CACHE_EXTENSION}"
+            (weight_cache_path / rel_path).write_bytes(b"unit-test")
+            return {"w": SavedWeight(path=rel_path, memory_config=ttnn.DRAM_MEMORY_CONFIG)}
+
+    monkeypatch.setattr(weight_config_module, "_is_multihost_distributed", lambda: True)
+    monkeypatch.setattr(weight_config_module, "_get_distributed_rank", lambda: 1)
+    monkeypatch.setattr(weight_config_module, "_distributed_barrier", lambda: None)
+    monkeypatch.setattr(weight_config_module, "_read_multihost_decision", lambda path: {"mode": "miss"})
+
+    mesh_device = _FakeMeshDevice(shape=(2, 2))
+    hf_config = _make_hf_config(num_hidden_layers=2)
+    base_cache = tmp_path / "weight_cache"
+
+    cfg = get_weight_config(
+        ModuleClass=FakeModule,
+        hf_config=hf_config,
+        state_dicts=({"dummy": torch.empty(1)},),
+        weight_cache_path=base_cache,
+        mesh_device=mesh_device,
+        force_recalculate=False,
+    )
+
+    weight_cache_path = (
+        base_cache / f"{hf_config.num_hidden_layers}_layers" / f"mesh_{mesh_device.shape[0]}x{mesh_device.shape[1]}"
+    )
+    assert cfg["w"].path.is_absolute()
+    assert not (weight_cache_path / "config.json").exists()
+
+
 def test_get_weight_config_path_construction(tmp_path: Path) -> None:
     """Test that weight_cache_path is correctly constructed with layers and mesh shape."""
 
@@ -380,6 +448,18 @@ def test_validate_weight_config_paths_missing_file(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="references missing file"):
         validate_weight_config_paths(root_path, weight_config)
+
+
+def test_validate_weight_config_paths_missing_file_allowed(tmp_path: Path) -> None:
+    """Test that file visibility checks can be skipped for peer ranks during first publication."""
+    root_path = tmp_path / "weights"
+    root_path.mkdir(parents=True)
+
+    weight_config = {
+        "layer1": SavedWeight(path=Path(f"missing{TENSOR_CACHE_EXTENSION}"), memory_config=ttnn.DRAM_MEMORY_CONFIG),
+    }
+
+    validate_weight_config_paths(root_path, weight_config, require_files_exist=False)
 
 
 def test_validate_weight_config_paths_wrong_suffix(tmp_path: Path) -> None:

--- a/models/demos/deepseek_v3/tests/test_get_weight_config.py
+++ b/models/demos/deepseek_v3/tests/test_get_weight_config.py
@@ -267,6 +267,7 @@ def test_get_weight_config_cache_invalidation_wrong_suffix(tmp_path: Path) -> No
 
 def test_get_weight_config_multihost_peer_uses_rank0_hit_decision(tmp_path: Path, monkeypatch) -> None:
     """Peer ranks should follow rank 0's hit decision and skip local cache validation."""
+    import models.demos.deepseek_v3.utils.weight_config as weight_config_module
 
     class FakeModule:
         @staticmethod
@@ -277,7 +278,7 @@ def test_get_weight_config_multihost_peer_uses_rank0_hit_decision(tmp_path: Path
     monkeypatch.setattr(weight_config_module, "_is_multihost_distributed", lambda: True)
     monkeypatch.setattr(weight_config_module, "_get_distributed_rank", lambda: 1)
     monkeypatch.setattr(weight_config_module, "_distributed_barrier", lambda: None)
-    monkeypatch.setattr(weight_config_module, "_read_multihost_decision", lambda path: {"mode": "hit"})
+    monkeypatch.setattr(weight_config_module, "_read_multihost_decision", lambda path: "hit")
     monkeypatch.setattr(weight_config_module, "_load_cached_config_without_visibility_checks", lambda *_args: sentinel)
 
     mesh_device = _FakeMeshDevice(shape=(2, 2))
@@ -298,6 +299,7 @@ def test_get_weight_config_multihost_peer_uses_rank0_hit_decision(tmp_path: Path
 
 def test_get_weight_config_multihost_peer_miss_does_not_write_config(tmp_path: Path, monkeypatch) -> None:
     """Peer ranks should participate in generation on miss, but leave config.json publication to rank 0."""
+    import models.demos.deepseek_v3.utils.weight_config as weight_config_module
 
     class FakeModule:
         @staticmethod
@@ -310,7 +312,7 @@ def test_get_weight_config_multihost_peer_miss_does_not_write_config(tmp_path: P
     monkeypatch.setattr(weight_config_module, "_is_multihost_distributed", lambda: True)
     monkeypatch.setattr(weight_config_module, "_get_distributed_rank", lambda: 1)
     monkeypatch.setattr(weight_config_module, "_distributed_barrier", lambda: None)
-    monkeypatch.setattr(weight_config_module, "_read_multihost_decision", lambda path: {"mode": "miss"})
+    monkeypatch.setattr(weight_config_module, "_read_multihost_decision", lambda path: "miss")
 
     mesh_device = _FakeMeshDevice(shape=(2, 2))
     hf_config = _make_hf_config(num_hidden_layers=2)

--- a/models/demos/deepseek_v3/tests/test_get_weight_config.py
+++ b/models/demos/deepseek_v3/tests/test_get_weight_config.py
@@ -13,7 +13,6 @@ import pytest
 import torch
 from transformers.configuration_utils import PretrainedConfig
 
-import models.demos.deepseek_v3.utils.weight_config as weight_config_module
 import ttnn
 from models.demos.deepseek_v3.utils.config_dataclass import SavedWeight
 from models.demos.deepseek_v3.utils.config_helpers import TENSOR_CACHE_EXTENSION

--- a/models/demos/deepseek_v3/tests/test_mlp.py
+++ b/models/demos/deepseek_v3/tests/test_mlp.py
@@ -3,6 +3,8 @@
 
 
 import os
+from pathlib import Path
+from uuid import uuid4
 
 import pytest
 import torch
@@ -26,41 +28,80 @@ from models.demos.deepseek_v3.utils.test_utils import (
     run_module_forward,
 )
 
+_SHARED_TEST_RUN_ID_ENV_VARS = (
+    "PMIX_NAMESPACE",
+    "PMI_NAMESPACE",
+    "PMI_JOBID",
+    "SLURM_STEP_ID",
+    "SLURM_JOB_ID",
+)
 
-# TODO: Doesn't work on multi-host - we should figure out why
+
+def _sanitize_cache_component(value: str) -> str:
+    sanitized = "".join(char if char.isalnum() or char in "._-" else "_" for char in value)
+    return sanitized.strip("._") or "unknown"
+
+
+def _is_multihost_distributed() -> bool:
+    if not ttnn.distributed_context_is_initialized():
+        return False
+    return int(ttnn.distributed_context_get_size()) > 1
+
+
+def _get_weight_conversion_run_id() -> str:
+    explicit_run_id = os.getenv("DEEPSEEK_TEST_RUN_ID")
+    if explicit_run_id:
+        return _sanitize_cache_component(explicit_run_id)
+
+    github_run_id = os.getenv("GITHUB_RUN_ID")
+    if github_run_id:
+        github_parts = [github_run_id, os.getenv("GITHUB_RUN_ATTEMPT"), os.getenv("GITHUB_JOB")]
+        return _sanitize_cache_component("-".join(part for part in github_parts if part))
+
+    for env_var in _SHARED_TEST_RUN_ID_ENV_VARS:
+        value = os.getenv(env_var)
+        if value:
+            return _sanitize_cache_component(value)
+
+    if _is_multihost_distributed():
+        raise RuntimeError(
+            "Multihost MLP weight conversion tests require a shared run identifier. "
+            "Set DEEPSEEK_TEST_RUN_ID or run under an environment that provides "
+            "GITHUB_RUN_ID, PMIX_NAMESPACE, PMI_NAMESPACE, PMI_JOBID, SLURM_STEP_ID, or SLURM_JOB_ID."
+        )
+
+    return f"local-{uuid4().hex}"
+
+
+def _get_weight_conversion_cache_root(cache_path: Path) -> Path:
+    return cache_path / "scratch_weight_conversion" / _get_weight_conversion_run_id()
+
+
 @pytest.mark.requires_device(["TG"])
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
-def test_convert_weights_for_non_dequantized_mlp(hf_config, tmp_path, mesh_device):
-    # Add a skip for mesh device shape 8x8 due to known issue https://github.com/tenstorrent/tt-metal/issues/35375
-    if tuple(mesh_device.shape) == (8, 8):
-        pytest.skip(
-            "Skipping test for mesh device shape 8x8 due to known issue https://github.com/tenstorrent/tt-metal/issues/35375"
-        )
+def test_convert_weights_for_non_dequantized_mlp(hf_config, cache_path, mesh_device):
     reference_model = DeepseekV3MLP(hf_config).eval()
     reference_state_dict = reference_model.to(torch.bfloat16).state_dict()
     run_weight_conversion_test(
         MLPClass=MLP,
         hf_config=hf_config,
         state_dict=reference_model.state_dict(),
-        tmp_path=tmp_path
-        / "mesh_8x8",  # TODO: dummy mesh shape required until convert_weights no longer relies on this for parsing the absolutem filepaths
+        weight_cache_root=_get_weight_conversion_cache_root(cache_path),
+        test_name="test_convert_weights_for_non_dequantized_mlp",
         mesh_device=mesh_device,
         reference_w1=reference_state_dict["gate_proj.weight"],
+        real_weights=False,
+        layer_id=None,
     )
 
 
-# TODO: Doesn't work on multi-host - we should figure out why
 @pytest.mark.requires_device(["TG"])
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
 @pytest.mark.parametrize(
     "MLPClass,module_path",
     [(NonExpert, "model.layers.0.mlp"), (SharedExpert, "model.layers.3.mlp.shared_experts")],
 )
-def test_convert_weights_for_dequantized_mlps(MLPClass, module_path, hf_config, tmp_path, mesh_device, state_dict):
-    if tuple(mesh_device.shape) == (8, 8):
-        pytest.skip(
-            "Skipping test for mesh device shape 8x8 due to known issue https://github.com/tenstorrent/tt-metal/issues/35375"
-        )
+def test_convert_weights_for_dequantized_mlps(MLPClass, module_path, hf_config, cache_path, mesh_device, state_dict):
     state_dict = sub_state_dict(state_dict, module_path + ".")
     reference_w1 = state_dict["gate_proj.weight"]
     assert (
@@ -70,23 +111,41 @@ def test_convert_weights_for_dequantized_mlps(MLPClass, module_path, hf_config, 
         MLPClass=MLPClass,
         hf_config=hf_config,
         state_dict=state_dict,
-        tmp_path=tmp_path
-        / "mesh_8x8",  # TODO: dummy mesh shape required until convert_weights no longer relies on this for parsing the absolutem filepaths
+        weight_cache_root=_get_weight_conversion_cache_root(cache_path),
+        test_name=f"test_convert_weights_for_dequantized_mlps_{MLPClass.__name__}",
         mesh_device=mesh_device,
         reference_w1=reference_w1,
+        real_weights=True,
+        layer_id=module_path,
     )
 
 
-def run_weight_conversion_test(MLPClass, hf_config, state_dict, tmp_path, reference_w1, mesh_device):
-    if tuple(mesh_device.shape) == (8, 8):
-        pytest.skip(
-            "Skipping test for mesh device shape 8x8 due to known issue https://github.com/tenstorrent/tt-metal/issues/35375"
-        )
+def run_weight_conversion_test(
+    MLPClass,
+    hf_config,
+    state_dict,
+    weight_cache_root,
+    test_name,
+    reference_w1,
+    mesh_device,
+    *,
+    real_weights,
+    layer_id,
+):
     num_module_layers, _ = mesh_device.shape
 
-    # Convert the weights
-    weight_config = MLPClass.convert_weights(
-        hf_config, [state_dict] + [None] * (num_module_layers - 1), tmp_path, mesh_device
+    # Use a per-run shared scratch namespace so multihost peers see the same cache files
+    # without touching the durable shared cache tree.
+    weight_config = get_test_weight_config(
+        MLPClass,
+        hf_config,
+        tuple([state_dict] + [None] * (num_module_layers - 1)),
+        weight_cache_root,
+        mesh_device,
+        True,
+        test_name=test_name,
+        real_weights=real_weights,
+        layer_id=layer_id,
     )
 
     # Verify weight_config structure
@@ -101,9 +160,6 @@ def run_weight_conversion_test(MLPClass, hf_config, state_dict, tmp_path, refere
     # assert Path(weight_config["w1"]["input_tensor_b"]).exists()
     # assert Path(weight_config["w2"]["input_tensor_b"]).exists()
     # assert Path(weight_config["w3"]["input_tensor_b"]).exists()
-
-    # Make the path absolute - this is required since load_weight expects an absolute path
-    weight_config["w1"]["input_tensor_b"].path = tmp_path / weight_config["w1"]["input_tensor_b"].path
 
     # Load and verify a weight
     w1_ttnn = load_weight(weight_config["w1"]["input_tensor_b"], device=mesh_device)

--- a/models/demos/deepseek_v3/utils/weight_config.py
+++ b/models/demos/deepseek_v3/utils/weight_config.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 
 import fcntl
 import json
+import os
+import socket
+import time
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
@@ -17,6 +20,13 @@ import ttnn
 from models.demos.deepseek_v3.utils.config_dataclass import SavedWeight
 from models.demos.deepseek_v3.utils.config_helpers import TENSOR_CACHE_EXTENSION
 from models.demos.deepseek_v3.utils.run_config import WeightConfig
+
+_MULTIHOST_CACHE_COORD_DIR = ".multihost_cache"
+_MULTIHOST_DECISION_FILE = "decision.json"
+_MULTIHOST_GENERATION_LOCK = "generation.lock"
+_MULTIHOST_POLL_INTERVAL_SECONDS = 0.1
+_MULTIHOST_WAIT_LOG_INTERVAL_SECONDS = 10 * 60
+_HOSTNAME = socket.gethostname().split(".", 1)[0]
 
 
 @contextmanager
@@ -105,6 +115,282 @@ def _try_load_cached_config(config_path: Path, weight_cache_path: Path, force_re
     return normalize_weight_config_paths(weight_cache_path, weight_config)
 
 
+def _load_cached_config_without_visibility_checks(config_path: Path, weight_cache_path: Path) -> WeightConfig:
+    _wait_for_path_exists(config_path, description="config.json")
+
+    with locked_file(config_path, "r", exclusive=False) as f:
+        weight_config = json.load(f, object_hook=try_decode_saved_weight)
+
+    validate_weight_config_paths(weight_cache_path, weight_config, require_files_exist=False)
+    _wait_for_weight_config_paths(weight_cache_path, weight_config, context="rank-0 cache hit")
+    logger.info(f"Using weights cached at {weight_cache_path}")
+    return normalize_weight_config_paths(weight_cache_path, weight_config)
+
+
+def _write_json_atomic(path: Path, payload: dict[str, Any], *, encoder: type[json.JSONEncoder] | None = None) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(f".{path.name}.tmp.{os.getpid()}")
+    with tmp_path.open("w") as f:
+        json.dump(payload, f, cls=encoder)
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(tmp_path, path)
+
+
+def _write_weight_config_json(config_path: Path, weight_config: WeightConfig) -> None:
+    _write_json_atomic(config_path, weight_config, encoder=WeightConfigEncoder)
+
+
+def _is_multihost_distributed() -> bool:
+    if not ttnn.distributed_context_is_initialized():
+        return False
+    try:
+        return int(ttnn.distributed_context_get_size()) > 1
+    except Exception:
+        return False
+
+
+def _get_distributed_rank() -> int:
+    if not _is_multihost_distributed():
+        return 0
+    return int(ttnn.distributed_context_get_rank())
+
+
+def _distributed_barrier() -> None:
+    if _is_multihost_distributed():
+        ttnn.distributed_context_barrier()
+
+
+def _get_multihost_coord_paths(weight_cache_path: Path) -> tuple[Path, Path]:
+    coord_dir = weight_cache_path / _MULTIHOST_CACHE_COORD_DIR
+    return coord_dir / _MULTIHOST_DECISION_FILE, coord_dir / _MULTIHOST_GENERATION_LOCK
+
+
+def _write_multihost_decision(decision_path: Path, *, mode: str) -> None:
+    _write_json_atomic(
+        decision_path,
+        {
+            "mode": mode,
+            "pid": os.getpid(),
+            "rank": _get_distributed_rank(),
+        },
+    )
+
+
+def _maybe_log_wait(last_log_time: float | None, message: str) -> float:
+    now = time.monotonic()
+    if last_log_time is None or now - last_log_time >= _MULTIHOST_WAIT_LOG_INTERVAL_SECONDS:
+        logger.info(message)
+        return now
+    return last_log_time
+
+
+def _find_first_missing_weight_file(root_path: Path, weight_config: WeightConfig) -> Path | None:
+    if isinstance(weight_config, dict):
+        entries = weight_config.values()
+    elif isinstance(weight_config, (list, tuple)):
+        entries = weight_config
+    else:
+        return None
+
+    for entry in entries:
+        if entry is None:
+            continue
+        if isinstance(entry, SavedWeight):
+            effective_path = entry.path if entry.path.is_absolute() else root_path / entry.path
+            if not effective_path.exists():
+                return effective_path
+        else:
+            missing_path = _find_first_missing_weight_file(root_path, entry)
+            if missing_path is not None:
+                return missing_path
+
+    return None
+
+
+def _read_multihost_decision(decision_path: Path) -> dict[str, Any]:
+    last_log_time = None
+    while True:
+        try:
+            with locked_file(decision_path, "r", exclusive=False) as f:
+                payload = json.load(f)
+            mode = payload.get("mode")
+            if mode not in {"hit", "miss"}:
+                raise RuntimeError(f"Invalid multihost cache decision payload in {decision_path}: {payload}")
+            return payload
+        except FileNotFoundError as e:
+            last_log_time = _maybe_log_wait(
+                last_log_time,
+                f"Still waiting for {decision_path.name} to become visible on host {_HOSTNAME}: {decision_path} ({e})",
+            )
+        except json.JSONDecodeError as e:
+            last_log_time = _maybe_log_wait(
+                last_log_time,
+                f"Still waiting for {decision_path.name} to become readable on host {_HOSTNAME}: {decision_path} ({e})",
+            )
+        time.sleep(_MULTIHOST_POLL_INTERVAL_SECONDS)
+
+
+def _wait_for_path_exists(path: Path, *, description: str) -> None:
+    last_log_time = None
+    while True:
+        if path.exists():
+            return
+        last_log_time = _maybe_log_wait(
+            last_log_time,
+            f"Still waiting for {path.name} to become visible on host {_HOSTNAME}: {path} ({description})",
+        )
+        time.sleep(_MULTIHOST_POLL_INTERVAL_SECONDS)
+
+
+def _wait_for_weight_config_paths(root_path: Path, weight_config: WeightConfig, *, context: str) -> None:
+    last_log_time = None
+    while True:
+        try:
+            validate_weight_config_paths(root_path, weight_config)
+            return
+        except ValueError as e:
+            if "references missing file" not in str(e):
+                raise
+            missing_path = _find_first_missing_weight_file(root_path, weight_config)
+            wait_target = str(missing_path) if missing_path is not None else str(root_path)
+            wait_name = missing_path.name if missing_path is not None else "<unknown>"
+            last_log_time = _maybe_log_wait(
+                last_log_time,
+                f"Still waiting for {wait_name} to become visible on host {_HOSTNAME}: {wait_target} during {context}",
+            )
+            time.sleep(_MULTIHOST_POLL_INTERVAL_SECONDS)
+
+
+def _prepare_state_dicts(
+    hf_config: PretrainedConfig,
+    state_dicts: tuple[dict[str, torch.Tensor] | None, ...] | None,
+    *,
+    random_weights: bool,
+    model_path: str | None,
+    single_layer: str | None,
+) -> tuple[dict[str, torch.Tensor] | None, ...]:
+    if state_dicts is not None:
+        return state_dicts
+
+    logger.info("State dict was not provided, preparing from random weights or model path")
+    from models.demos.deepseek_v3.utils.hf_model_utils import prepare_model_state_dict
+
+    model_state = prepare_model_state_dict(
+        hf_config=hf_config,
+        random_weights=random_weights,
+        model_path=model_path,
+        single_layer=single_layer,
+    )
+    return (model_state,)
+
+
+def _convert_and_cache_weight_config(
+    *,
+    ModuleClass: type["models.demos.deepseek_v3.utils.abstract_module.AbstractModule"],
+    hf_config: PretrainedConfig,
+    state_dicts: tuple[dict[str, torch.Tensor] | None, ...] | None,
+    weight_cache_path: Path,
+    config_path: Path,
+    mesh_device: ttnn.Device,
+    random_weights: bool,
+    model_path: str | None,
+    single_layer: str | None,
+    require_files_exist: bool,
+    write_config: bool,
+    wait_for_visibility: bool,
+) -> WeightConfig:
+    logger.info(f"Caching weights at {weight_cache_path}")
+    state_dicts = _prepare_state_dicts(
+        hf_config,
+        state_dicts,
+        random_weights=random_weights,
+        model_path=model_path,
+        single_layer=single_layer,
+    )
+
+    logger.info("Converting weights to TTNN SavedWeight format...")
+    weight_config = ModuleClass.convert_weights(hf_config, state_dicts, weight_cache_path, mesh_device)
+    validate_weight_config_paths(weight_cache_path, weight_config, require_files_exist=require_files_exist)
+    if write_config:
+        _write_weight_config_json(config_path, weight_config)
+    if wait_for_visibility:
+        _wait_for_weight_config_paths(
+            weight_cache_path, weight_config, context="first-time multihost cache publication"
+        )
+
+    normalized_config = normalize_weight_config_paths(weight_cache_path, weight_config)
+    logger.info("Done converting weights to TTNN SavedWeight format")
+    return normalized_config
+
+
+def _get_weight_config_multihost(
+    *,
+    ModuleClass: type["models.demos.deepseek_v3.utils.abstract_module.AbstractModule"],
+    hf_config: PretrainedConfig,
+    state_dicts: tuple[dict[str, torch.Tensor] | None, ...] | None,
+    weight_cache_path: Path,
+    config_path: Path,
+    mesh_device: ttnn.Device,
+    force_recalculate: bool,
+    random_weights: bool,
+    model_path: str | None,
+    single_layer: str | None,
+) -> WeightConfig:
+    decision_path, lock_path = _get_multihost_coord_paths(weight_cache_path)
+    rank = _get_distributed_rank()
+
+    if rank == 0:
+        with locked_file(lock_path, "a+", exclusive=True):
+            cached_config = _try_load_cached_config(config_path, weight_cache_path, force_recalculate)
+            decision_mode = "hit" if cached_config is not None else "miss"
+            _write_multihost_decision(decision_path, mode=decision_mode)
+            _distributed_barrier()
+            try:
+                if decision_mode == "hit":
+                    return cached_config
+                return _convert_and_cache_weight_config(
+                    ModuleClass=ModuleClass,
+                    hf_config=hf_config,
+                    state_dicts=state_dicts,
+                    weight_cache_path=weight_cache_path,
+                    config_path=config_path,
+                    mesh_device=mesh_device,
+                    random_weights=random_weights,
+                    model_path=model_path,
+                    single_layer=single_layer,
+                    require_files_exist=True,
+                    write_config=True,
+                    wait_for_visibility=False,
+                )
+            finally:
+                _distributed_barrier()
+                decision_path.unlink(missing_ok=True)
+
+    _distributed_barrier()
+    decision = _read_multihost_decision(decision_path)
+    try:
+        if decision["mode"] == "hit":
+            return _load_cached_config_without_visibility_checks(config_path, weight_cache_path)
+
+        return _convert_and_cache_weight_config(
+            ModuleClass=ModuleClass,
+            hf_config=hf_config,
+            state_dicts=state_dicts,
+            weight_cache_path=weight_cache_path,
+            config_path=config_path,
+            mesh_device=mesh_device,
+            random_weights=random_weights,
+            model_path=model_path,
+            single_layer=single_layer,
+            require_files_exist=False,
+            write_config=False,
+            wait_for_visibility=True,
+        )
+    finally:
+        _distributed_barrier()
+
+
 def get_weight_config(
     ModuleClass: type["models.demos.deepseek_v3.utils.abstract_module.AbstractModule"],
     hf_config: PretrainedConfig,
@@ -149,45 +435,44 @@ def get_weight_config(
     )
     config_path = weight_cache_path / "config.json"
 
+    if _is_multihost_distributed():
+        return _get_weight_config_multihost(
+            ModuleClass=ModuleClass,
+            hf_config=hf_config,
+            state_dicts=state_dicts,
+            weight_cache_path=weight_cache_path,
+            config_path=config_path,
+            mesh_device=mesh_device,
+            force_recalculate=force_recalculate,
+            random_weights=random_weights,
+            model_path=model_path,
+            single_layer=single_layer,
+        )
+
     # Try to load from cache
     cached_config = _try_load_cached_config(config_path, weight_cache_path, force_recalculate)
     if cached_config is not None:
         return cached_config
 
-    # Cache miss - need to convert weights
-    logger.info(f"Caching weights at {weight_cache_path}")
-    if state_dicts is None:
-        logger.info("State dict was not provided, preparing from random weights or model path")
-        from models.demos.deepseek_v3.utils.hf_model_utils import prepare_model_state_dict
-
-        model_state = prepare_model_state_dict(
-            hf_config=hf_config,
-            random_weights=random_weights,
-            model_path=model_path,
-            single_layer=single_layer,
-        )
-        state_dicts = (model_state,)
-
-    # Convert weights to TT tensors-on-disk and build weight_config
-    logger.info("Converting weights to TTNN SavedWeight format...")
-
-    weight_config = ModuleClass.convert_weights(hf_config, state_dicts, weight_cache_path, mesh_device)
-
-    # Validate the converted weight config
-    validate_weight_config_paths(weight_cache_path, weight_config)
-
-    # Save config with relative paths for portability
-    # Use exclusive lock to prevent concurrent writes and corruption
-    with locked_file(config_path, "w", exclusive=True) as f:
-        json.dump(weight_config, f, cls=WeightConfigEncoder)
-
-    # Return normalized config with absolute paths for runtime use
-    normalized_config = normalize_weight_config_paths(weight_cache_path, weight_config)
-    logger.info("Done converting weights to TTNN SavedWeight format")
-    return normalized_config
+    return _convert_and_cache_weight_config(
+        ModuleClass=ModuleClass,
+        hf_config=hf_config,
+        state_dicts=state_dicts,
+        weight_cache_path=weight_cache_path,
+        config_path=config_path,
+        mesh_device=mesh_device,
+        random_weights=random_weights,
+        model_path=model_path,
+        single_layer=single_layer,
+        require_files_exist=True,
+        write_config=True,
+        wait_for_visibility=False,
+    )
 
 
-def validate_weight_config_paths(root_path: Path, weight_config: WeightConfig, path_prefix: str = "") -> None:
+def validate_weight_config_paths(
+    root_path: Path, weight_config: WeightConfig, path_prefix: str = "", *, require_files_exist: bool = True
+) -> None:
     """
     Validate that all SavedWeight paths in the weight config exist and have the correct suffix.
 
@@ -195,6 +480,8 @@ def validate_weight_config_paths(root_path: Path, weight_config: WeightConfig, p
         root_path: Base path for resolving relative SavedWeight paths
         weight_config: Weight configuration (dict, list, tuple, or nested structures)
         path_prefix: Prefix for error messages to indicate location in nested structure
+        require_files_exist: If False, validate path structure and suffixes but do not require
+            the referenced files to be visible on the current host yet.
 
     Raises:
         ValueError: If any SavedWeight path is invalid (missing file, wrong suffix, etc.)
@@ -230,14 +517,14 @@ def validate_weight_config_paths(root_path: Path, weight_config: WeightConfig, p
                 )
 
             # Validate file exists
-            if not effective_path.exists():
+            if require_files_exist and not effective_path.exists():
                 raise ValueError(
                     f"SavedWeight at '{current_prefix}' references missing file. "
                     f"Resolved path: {effective_path} (original: {entry.path})"
                 )
         else:
             # Recursively validate nested structures
-            validate_weight_config_paths(root_path, entry, current_prefix)
+            validate_weight_config_paths(root_path, entry, current_prefix, require_files_exist=require_files_exist)
 
 
 def normalize_weight_config_paths(root_path: Path, weight_config: WeightConfig) -> WeightConfig:

--- a/models/demos/deepseek_v3/utils/weight_config.py
+++ b/models/demos/deepseek_v3/utils/weight_config.py
@@ -69,6 +69,10 @@ class WeightConfigEncoder(json.JSONEncoder):
         return obj
 
 
+class MissingWeightFileError(ValueError):
+    pass
+
+
 def try_decode_saved_weight(obj: dict[str, Any]) -> Any:
     path_str = obj.get("path", None)
     if not isinstance(path_str, str):
@@ -137,10 +141,6 @@ def _write_json_atomic(path: Path, payload: dict[str, Any], *, encoder: type[jso
     os.replace(tmp_path, path)
 
 
-def _write_weight_config_json(config_path: Path, weight_config: WeightConfig) -> None:
-    _write_json_atomic(config_path, weight_config, encoder=WeightConfigEncoder)
-
-
 def _is_multihost_distributed() -> bool:
     if not ttnn.distributed_context_is_initialized():
         return False
@@ -161,22 +161,6 @@ def _distributed_barrier() -> None:
         ttnn.distributed_context_barrier()
 
 
-def _get_multihost_coord_paths(weight_cache_path: Path) -> tuple[Path, Path]:
-    coord_dir = weight_cache_path / _MULTIHOST_CACHE_COORD_DIR
-    return coord_dir / _MULTIHOST_DECISION_FILE, coord_dir / _MULTIHOST_GENERATION_LOCK
-
-
-def _write_multihost_decision(decision_path: Path, *, mode: str) -> None:
-    _write_json_atomic(
-        decision_path,
-        {
-            "mode": mode,
-            "pid": os.getpid(),
-            "rank": _get_distributed_rank(),
-        },
-    )
-
-
 def _maybe_log_wait(last_log_time: float | None, message: str) -> float:
     now = time.monotonic()
     if last_log_time is None or now - last_log_time >= _MULTIHOST_WAIT_LOG_INTERVAL_SECONDS:
@@ -185,30 +169,7 @@ def _maybe_log_wait(last_log_time: float | None, message: str) -> float:
     return last_log_time
 
 
-def _find_first_missing_weight_file(root_path: Path, weight_config: WeightConfig) -> Path | None:
-    if isinstance(weight_config, dict):
-        entries = weight_config.values()
-    elif isinstance(weight_config, (list, tuple)):
-        entries = weight_config
-    else:
-        return None
-
-    for entry in entries:
-        if entry is None:
-            continue
-        if isinstance(entry, SavedWeight):
-            effective_path = entry.path if entry.path.is_absolute() else root_path / entry.path
-            if not effective_path.exists():
-                return effective_path
-        else:
-            missing_path = _find_first_missing_weight_file(root_path, entry)
-            if missing_path is not None:
-                return missing_path
-
-    return None
-
-
-def _read_multihost_decision(decision_path: Path) -> dict[str, Any]:
+def _read_multihost_decision(decision_path: Path) -> str:
     last_log_time = None
     while True:
         try:
@@ -217,7 +178,7 @@ def _read_multihost_decision(decision_path: Path) -> dict[str, Any]:
             mode = payload.get("mode")
             if mode not in {"hit", "miss"}:
                 raise RuntimeError(f"Invalid multihost cache decision payload in {decision_path}: {payload}")
-            return payload
+            return mode
         except FileNotFoundError as e:
             last_log_time = _maybe_log_wait(
                 last_log_time,
@@ -249,40 +210,13 @@ def _wait_for_weight_config_paths(root_path: Path, weight_config: WeightConfig, 
         try:
             validate_weight_config_paths(root_path, weight_config)
             return
-        except ValueError as e:
-            if "references missing file" not in str(e):
-                raise
-            missing_path = _find_first_missing_weight_file(root_path, weight_config)
-            wait_target = str(missing_path) if missing_path is not None else str(root_path)
-            wait_name = missing_path.name if missing_path is not None else "<unknown>"
+        except MissingWeightFileError as e:
             last_log_time = _maybe_log_wait(
                 last_log_time,
-                f"Still waiting for {wait_name} to become visible on host {_HOSTNAME}: {wait_target} during {context}",
+                f"Still waiting for cached weights to become visible on host {_HOSTNAME}: "
+                f"{root_path} during {context} ({e})",
             )
             time.sleep(_MULTIHOST_POLL_INTERVAL_SECONDS)
-
-
-def _prepare_state_dicts(
-    hf_config: PretrainedConfig,
-    state_dicts: tuple[dict[str, torch.Tensor] | None, ...] | None,
-    *,
-    random_weights: bool,
-    model_path: str | None,
-    single_layer: str | None,
-) -> tuple[dict[str, torch.Tensor] | None, ...]:
-    if state_dicts is not None:
-        return state_dicts
-
-    logger.info("State dict was not provided, preparing from random weights or model path")
-    from models.demos.deepseek_v3.utils.hf_model_utils import prepare_model_state_dict
-
-    model_state = prepare_model_state_dict(
-        hf_config=hf_config,
-        random_weights=random_weights,
-        model_path=model_path,
-        single_layer=single_layer,
-    )
-    return (model_state,)
 
 
 def _convert_and_cache_weight_config(
@@ -301,27 +235,30 @@ def _convert_and_cache_weight_config(
     wait_for_visibility: bool,
 ) -> WeightConfig:
     logger.info(f"Caching weights at {weight_cache_path}")
-    state_dicts = _prepare_state_dicts(
-        hf_config,
-        state_dicts,
-        random_weights=random_weights,
-        model_path=model_path,
-        single_layer=single_layer,
-    )
+    if state_dicts is None:
+        logger.info("State dict was not provided, preparing from random weights or model path")
+        from models.demos.deepseek_v3.utils.hf_model_utils import prepare_model_state_dict
+
+        model_state = prepare_model_state_dict(
+            hf_config=hf_config,
+            random_weights=random_weights,
+            model_path=model_path,
+            single_layer=single_layer,
+        )
+        state_dicts = (model_state,)
 
     logger.info("Converting weights to TTNN SavedWeight format...")
     weight_config = ModuleClass.convert_weights(hf_config, state_dicts, weight_cache_path, mesh_device)
     validate_weight_config_paths(weight_cache_path, weight_config, require_files_exist=require_files_exist)
     if write_config:
-        _write_weight_config_json(config_path, weight_config)
+        _write_json_atomic(config_path, weight_config, encoder=WeightConfigEncoder)
     if wait_for_visibility:
         _wait_for_weight_config_paths(
             weight_cache_path, weight_config, context="first-time multihost cache publication"
         )
 
-    normalized_config = normalize_weight_config_paths(weight_cache_path, weight_config)
     logger.info("Done converting weights to TTNN SavedWeight format")
-    return normalized_config
+    return normalize_weight_config_paths(weight_cache_path, weight_config)
 
 
 def _get_weight_config_multihost(
@@ -337,14 +274,16 @@ def _get_weight_config_multihost(
     model_path: str | None,
     single_layer: str | None,
 ) -> WeightConfig:
-    decision_path, lock_path = _get_multihost_coord_paths(weight_cache_path)
+    coord_dir = weight_cache_path / _MULTIHOST_CACHE_COORD_DIR
+    decision_path = coord_dir / _MULTIHOST_DECISION_FILE
+    lock_path = coord_dir / _MULTIHOST_GENERATION_LOCK
     rank = _get_distributed_rank()
 
     if rank == 0:
         with locked_file(lock_path, "a+", exclusive=True):
             cached_config = _try_load_cached_config(config_path, weight_cache_path, force_recalculate)
             decision_mode = "hit" if cached_config is not None else "miss"
-            _write_multihost_decision(decision_path, mode=decision_mode)
+            _write_json_atomic(decision_path, {"mode": decision_mode})
             _distributed_barrier()
             try:
                 if decision_mode == "hit":
@@ -368,9 +307,9 @@ def _get_weight_config_multihost(
                 decision_path.unlink(missing_ok=True)
 
     _distributed_barrier()
-    decision = _read_multihost_decision(decision_path)
+    decision_mode = _read_multihost_decision(decision_path)
     try:
-        if decision["mode"] == "hit":
+        if decision_mode == "hit":
             return _load_cached_config_without_visibility_checks(config_path, weight_cache_path)
 
         return _convert_and_cache_weight_config(
@@ -518,7 +457,7 @@ def validate_weight_config_paths(
 
             # Validate file exists
             if require_files_exist and not effective_path.exists():
-                raise ValueError(
+                raise MissingWeightFileError(
                     f"SavedWeight at '{current_prefix}' references missing file. "
                     f"Resolved path: {effective_path} (original: {entry.path})"
                 )


### PR DESCRIPTION
## Summary
When generating multihost weights I was still seeing hangs due to stale NFS file handles and what looked like straight-up logical errors in our weight generation code (e.g. not all ranks participating in the ttnn call, but the ttnn call containing a multi-host collective). These changes aim to alleviate that and to print clear messages when NFS issues such as a file that is present on one host not being visible on another cause a hang.

## Changes
- Coordinate DeepSeek weight-cache publication across multihost runs so rank 0 decides cache hit/miss and publishes `config.json`, while peer ranks follow the same decision and wait for file visibility instead of racing on NFS.
- Keep peer ranks participating in cache generation on misses so TTNN collectives do not hang, while allowing peers to validate path structure before the cache files become visible locally.
- Add targeted multihost unit coverage and extend DeepSeek test timeouts only when `--recalculate-weights` is used on demo or multihost test paths.

## Issue
Fixes #35375
Refs #38446

## Testing
- `python3 -m py_compile models/demos/deepseek_v3/utils/weight_config.py models/demos/deepseek_v3/conftest.py models/demos/deepseek_v3/tests/test_get_weight_config.py`
- Triggered `(Galaxy) DeepSeek tests` via `gh workflow run galaxy-deepseek-tests.yaml --ref yieldthought/ds-multihost-weight-cache`

## CI Badge
[![(Galaxy) DeepSeek tests (yieldthought/ds-multihost-weight-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml/badge.svg?branch=yieldthought%2Fds-multihost-weight-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml?query=branch%3Ayieldthought%2Fds-multihost-weight-cache)
