### PR TITLE
DeepSeek: fix batch-8 decode, long-prefill MLA, and users-per-row demo path

### DIFF
--- a/models/demos/deepseek_v3/demo/demo.py
+++ b/models/demos/deepseek_v3/demo/demo.py
@@ -14,9 +14,9 @@ from loguru import logger
 
 import ttnn
 from models.common.sampling.sampling_params import SamplingParams
-from models.demos.deepseek_v3.tt.generator import DEFAULT_MAX_SEQ_LEN
 from models.demos.deepseek_v3.tt.generator import DeepseekGenerator as DeepseekGeneratorDP
 from models.demos.deepseek_v3.utils.config_helpers import (
+    DEFAULT_MAX_SEQ_LEN,
     DEFAULT_SAMPLING_TEMPERATURE,
     DEFAULT_SAMPLING_TOP_K,
     DEFAULT_SAMPLING_TOP_P,

--- a/models/demos/deepseek_v3/demo/demo.py
+++ b/models/demos/deepseek_v3/demo/demo.py
@@ -531,7 +531,7 @@ def run_demo(
             )
             raise
 
-    batch_size_per_row = USERS_PER_ROW
+    batch_size_per_row = max_users_per_row
     batch_size = batch_size_per_row * mesh_device.shape[0]
 
     # Configure sampling

--- a/models/demos/deepseek_v3/demo/demo.py
+++ b/models/demos/deepseek_v3/demo/demo.py
@@ -304,6 +304,12 @@ def create_parser() -> argparse.ArgumentParser:
         help="Always record max-new-tokens even after EOS.",
     )
     p.set_defaults(stop_at_eos=True)
+    p.add_argument(
+        "--max-users-per-row",
+        type=int,
+        default=None,
+        help="Override the maximum number of active users per row for demo decode.",
+    )
     return p
 
 
@@ -406,6 +412,7 @@ def run_demo(
     *,
     model_path: str | Path | None = None,
     max_new_tokens: int = 32,
+    max_users_per_row: int | None = None,
     cache_dir: str | Path | None = None,
     random_weights: bool = False,
     single_layer: str | None = None,
@@ -568,6 +575,7 @@ def run_demo(
                 profile_decode=profile_decode,
                 sample_on_device=sample_on_device,
                 enable_mtp=enable_mtp,
+                batch_size_per_row=max_users_per_row,
                 sampling_params=sampling_params,
             )
         else:
@@ -792,6 +800,7 @@ def main() -> None:
         args.prompts,
         model_path=args.model_path,
         max_new_tokens=args.max_new_tokens,
+        max_users_per_row=args.max_users_per_row,
         cache_dir=args.cache_dir,
         random_weights=bool(args.random_weights),
         single_layer=args.single_layer,

--- a/models/demos/deepseek_v3/demo/demo.py
+++ b/models/demos/deepseek_v3/demo/demo.py
@@ -14,6 +14,7 @@ from loguru import logger
 
 import ttnn
 from models.common.sampling.sampling_params import SamplingParams
+from models.demos.deepseek_v3.tt.generator import DEFAULT_MAX_SEQ_LEN
 from models.demos.deepseek_v3.tt.generator import DeepseekGenerator as DeepseekGeneratorDP
 from models.demos.deepseek_v3.utils.config_helpers import (
     DEFAULT_SAMPLING_TEMPERATURE,
@@ -178,6 +179,12 @@ def create_parser() -> argparse.ArgumentParser:
         help="Path to local HF DeepSeek-V3 model (safetensors)",
     )
     p.add_argument("--max-new-tokens", type=int, default=32, help="Number of tokens to generate")
+    p.add_argument(
+        "--max-seq-len",
+        type=int,
+        default=DEFAULT_MAX_SEQ_LEN,
+        help=f"Maximum configured sequence length for the demo runtime (default: {DEFAULT_MAX_SEQ_LEN}).",
+    )
     p.add_argument(
         "--sampling-temperature",
         type=float,
@@ -412,6 +419,7 @@ def run_demo(
     *,
     model_path: str | Path | None = None,
     max_new_tokens: int = 32,
+    max_seq_len: int = DEFAULT_MAX_SEQ_LEN,
     max_users_per_row: int = USERS_PER_ROW,
     cache_dir: str | Path | None = None,
     random_weights: bool = False,
@@ -570,6 +578,7 @@ def run_demo(
                 enable_trace=enable_trace,
                 enable_mem_profile=enable_mem_profile,
                 signpost=signpost,
+                max_seq_len=max_seq_len,
                 prefill_max_tokens=prefill_max_tokens,
                 force_recalculate=force_recalculate,
                 profile_decode=profile_decode,
@@ -800,6 +809,7 @@ def main() -> None:
         args.prompts,
         model_path=args.model_path,
         max_new_tokens=args.max_new_tokens,
+        max_seq_len=args.max_seq_len,
         max_users_per_row=args.max_users_per_row,
         cache_dir=args.cache_dir,
         random_weights=bool(args.random_weights),

--- a/models/demos/deepseek_v3/demo/demo.py
+++ b/models/demos/deepseek_v3/demo/demo.py
@@ -307,8 +307,8 @@ def create_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "--max-users-per-row",
         type=int,
-        default=None,
-        help="Override the maximum number of active users per row for demo decode.",
+        default=USERS_PER_ROW,
+        help=f"Maximum number of active users per row for demo decode (default: {USERS_PER_ROW}).",
     )
     return p
 
@@ -412,7 +412,7 @@ def run_demo(
     *,
     model_path: str | Path | None = None,
     max_new_tokens: int = 32,
-    max_users_per_row: int | None = None,
+    max_users_per_row: int = USERS_PER_ROW,
     cache_dir: str | Path | None = None,
     random_weights: bool = False,
     single_layer: str | None = None,

--- a/models/demos/deepseek_v3/demo/test_demo.py
+++ b/models/demos/deepseek_v3/demo/test_demo.py
@@ -16,6 +16,7 @@ MODEL_PATH = Path(
 )
 CACHE_DIR = Path(os.getenv("DEEPSEEK_V3_CACHE", "/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI"))
 
+
 @lru_cache(maxsize=1)
 def get_total_model_layers(model_path: Path) -> int:
     with open(model_path / "config.json", "r", encoding="utf-8") as config_file:
@@ -43,7 +44,6 @@ def _assert_no_garbage_tokens(results: dict) -> None:
 
     if failures:
         pytest.fail("Garbage tokens detected during demo:\n" + "\n".join(failures))
-
 
 def _demo_case(
     *,
@@ -78,6 +78,7 @@ def _demo_case(
         id=case_id,
         marks=marks,
     )
+
 
 # Test matrix:
 # +------------------+-------------+-------------------+----------------+----------------+---------------------+--------------+------------------+--------------------------+----------------+-------------+--------------------+

--- a/models/demos/deepseek_v3/demo/test_demo.py
+++ b/models/demos/deepseek_v3/demo/test_demo.py
@@ -16,7 +16,6 @@ MODEL_PATH = Path(
 )
 CACHE_DIR = Path(os.getenv("DEEPSEEK_V3_CACHE", "/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI"))
 
-
 @lru_cache(maxsize=1)
 def get_total_model_layers(model_path: Path) -> int:
     with open(model_path / "config.json", "r", encoding="utf-8") as config_file:
@@ -78,14 +77,14 @@ def _demo_case(
         },
         id=case_id,
         marks=marks,
-)
-
+    )
 
 # Test matrix:
 # +------------------+-------------+-------------------+----------------+----------------+---------------------+--------------+------------------+--------------------------+----------------+-------------+--------------------+
 # | id               | max_prompts | max_users_per_row | repeat_batches | max_new_tokens | override_num_layers | enable_trace | sample_on_device | artifact_name            | profile_decode | stop_at_eos | expect_full_length |
 # +------------------+-------------+-------------------+----------------+----------------+---------------------+--------------+------------------+--------------------------+----------------+-------------+--------------------+
-# | tg_stress        | 32          | 8                 | 2              | 128            | 5                   | False        | True             | None                     | False          | False       | True               |
+# | tg_stress        | 56          | 32                | 2              | 128            | 5                   | False        | True             | None                     | False          | False       | True               |
+# | tg_upr8          | 32          | 8                 | 2              | 128            | 5                   | False        | True             | None                     | False          | False       | True               |
 # | dual_full_demo   | 256         | 32                | 1              | 129            | None                | True         | True             | dual_demo_full_results   | False          | None        | False              |
 # | dual_stress_demo | 56          | 32                | 20             | 129            | None                | True         | True             | dual_demo_stress_results | False          | False       | True               |
 # | quad_full_demo   | 512         | 32                | 1              | 129            | None                | True         | True             | quad_demo_full_results   | False          | None        | False              |
@@ -99,6 +98,21 @@ def _demo_case(
     "case",
     [
         _demo_case(
+            max_prompts=56,
+            max_users_per_row=32,
+            repeat_batches=2,
+            max_new_tokens=128,
+            override_num_layers=5,
+            enable_trace=False,
+            sample_on_device=True,
+            artifact_name=None,
+            profile_decode=False,
+            stop_at_eos=False,
+            expect_full_length=True,
+            case_id="tg_stress",
+            marks=pytest.mark.requires_device(["TG"]),
+        ),
+        _demo_case(
             max_prompts=32,
             max_users_per_row=8,
             repeat_batches=2,
@@ -110,7 +124,7 @@ def _demo_case(
             profile_decode=False,
             stop_at_eos=False,
             expect_full_length=True,
-            case_id="tg_stress",
+            case_id="tg_upr8",
             marks=pytest.mark.requires_device(["TG"]),
         ),
         _demo_case(

--- a/models/demos/deepseek_v3/demo/test_demo.py
+++ b/models/demos/deepseek_v3/demo/test_demo.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from models.demos.deepseek_v3.demo.demo import load_prompts_from_json, run_demo
+from models.demos.deepseek_v3.utils.test_utils import system_name_to_mesh_shape
 
 MODEL_PATH = Path(
     os.getenv("DEEPSEEK_V3_HF_MODEL", "/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-dequantized")
@@ -48,6 +49,7 @@ def _assert_no_garbage_tokens(results: dict) -> None:
 def _demo_case(
     *,
     max_prompts: int,
+    max_users_per_row: int,
     repeat_batches: int,
     max_new_tokens: int,
     override_num_layers: int | None,
@@ -63,6 +65,7 @@ def _demo_case(
     return pytest.param(
         {
             "max_prompts": max_prompts,
+            "max_users_per_row": max_users_per_row,
             "repeat_batches": repeat_batches,
             "max_new_tokens": max_new_tokens,
             "override_num_layers": override_num_layers,
@@ -75,20 +78,20 @@ def _demo_case(
         },
         id=case_id,
         marks=marks,
-    )
+)
 
 
 # Test matrix:
-# +------------------+-------------+----------------+----------------+---------------------+--------------+------------------+--------------------------+----------------+-------------+--------------------+
-# | id               | max_prompts | repeat_batches | max_new_tokens | override_num_layers | enable_trace | sample_on_device | artifact_name            | profile_decode | stop_at_eos | expect_full_length |
-# +------------------+-------------+----------------+----------------+---------------------+--------------+------------------+--------------------------+----------------+-------------+--------------------+
-# | tg_stress        | 56          | 2              | 128            | 5                   | False        | True             | None                     | False          | False       | True               |
-# | dual_full_demo   | 256         | 1              | 129            | None                | True         | True             | dual_demo_full_results   | False          | None        | False              |
-# | dual_stress_demo | 56          | 20             | 129            | None                | True         | True             | dual_demo_stress_results | False          | False       | True               |
-# | quad_full_demo   | 512         | 1              | 129            | None                | True         | True             | quad_demo_full_results   | False          | None        | False              |
-# | quad_stress_demo | 56          | 20             | 129            | None                | True         | True             | quad_demo_stress_results | False          | False       | True               |
-# | profile_decode   | 1           | 1              | 13             | 5                   | True         | True             | None                     | True           | False       | True               |
-# +------------------+-------------+----------------+----------------+---------------------+--------------+------------------+--------------------------+----------------+-------------+--------------------+
+# +------------------+-------------+-------------------+----------------+----------------+---------------------+--------------+------------------+--------------------------+----------------+-------------+--------------------+
+# | id               | max_prompts | max_users_per_row | repeat_batches | max_new_tokens | override_num_layers | enable_trace | sample_on_device | artifact_name            | profile_decode | stop_at_eos | expect_full_length |
+# +------------------+-------------+-------------------+----------------+----------------+---------------------+--------------+------------------+--------------------------+----------------+-------------+--------------------+
+# | tg_stress        | 32          | 8                 | 2              | 128            | 5                   | False        | True             | None                     | False          | False       | True               |
+# | dual_full_demo   | 256         | 32                | 1              | 129            | None                | True         | True             | dual_demo_full_results   | False          | None        | False              |
+# | dual_stress_demo | 56          | 32                | 20             | 129            | None                | True         | True             | dual_demo_stress_results | False          | False       | True               |
+# | quad_full_demo   | 512         | 32                | 1              | 129            | None                | True         | True             | quad_demo_full_results   | False          | None        | False              |
+# | quad_stress_demo | 56          | 32                | 20             | 129            | None                | True         | True             | quad_demo_stress_results | False          | False       | True               |
+# | profile_decode   | 1           | 32                | 1              | 13             | 5                   | True         | True             | None                     | True           | False       | True               |
+# +------------------+-------------+-------------------+----------------+----------------+---------------------+--------------+------------------+--------------------------+----------------+-------------+--------------------+
 
 
 @pytest.mark.parametrize(
@@ -96,7 +99,8 @@ def _demo_case(
     "case",
     [
         _demo_case(
-            max_prompts=56,
+            max_prompts=32,
+            max_users_per_row=8,
             repeat_batches=2,
             max_new_tokens=128,
             override_num_layers=5,
@@ -111,6 +115,7 @@ def _demo_case(
         ),
         _demo_case(
             max_prompts=256,
+            max_users_per_row=32,
             repeat_batches=1,
             max_new_tokens=129,
             override_num_layers=None,
@@ -125,6 +130,7 @@ def _demo_case(
         ),
         _demo_case(
             max_prompts=56,
+            max_users_per_row=32,
             repeat_batches=20,
             max_new_tokens=129,
             override_num_layers=None,
@@ -139,6 +145,7 @@ def _demo_case(
         ),
         _demo_case(
             max_prompts=512,
+            max_users_per_row=32,
             repeat_batches=1,
             max_new_tokens=129,
             override_num_layers=None,
@@ -153,6 +160,7 @@ def _demo_case(
         ),
         _demo_case(
             max_prompts=56,
+            max_users_per_row=32,
             repeat_batches=20,
             max_new_tokens=129,
             override_num_layers=None,
@@ -167,6 +175,7 @@ def _demo_case(
         ),
         _demo_case(
             max_prompts=1,
+            max_users_per_row=32,
             repeat_batches=1,
             max_new_tokens=13,
             override_num_layers=5,
@@ -195,6 +204,7 @@ def test_demo(case: dict, force_recalculate_weight_config: bool):
         cache_dir=CACHE_DIR,
         random_weights=False,
         max_new_tokens=case["max_new_tokens"],
+        max_users_per_row=case["max_users_per_row"],
         repeat_batches=case["repeat_batches"],
         enable_trace=case["enable_trace"],
         sample_on_device=case["sample_on_device"],
@@ -208,6 +218,13 @@ def test_demo(case: dict, force_recalculate_weight_config: bool):
         run_kwargs["stop_at_eos"] = case["stop_at_eos"]
 
     results = run_demo(**run_kwargs)
+
+    requested_system_name = os.getenv("MESH_DEVICE")
+    assert requested_system_name is not None, "MESH_DEVICE must be set for demo tests"
+    mesh_shape = system_name_to_mesh_shape(requested_system_name.upper())
+    expected_generations = min(len(prompts), case["max_users_per_row"] * int(mesh_shape[0]))
+
+    assert len(results["generations"]) == expected_generations
 
     # Full-demo cases can stop early on EOS; stress/profile cases disable EOS and
     # should always produce the requested token count.

--- a/models/demos/deepseek_v3/demo/test_demo.py
+++ b/models/demos/deepseek_v3/demo/test_demo.py
@@ -45,6 +45,7 @@ def _assert_no_garbage_tokens(results: dict) -> None:
     if failures:
         pytest.fail("Garbage tokens detected during demo:\n" + "\n".join(failures))
 
+
 def _demo_case(
     *,
     max_prompts: int,

--- a/models/demos/deepseek_v3/demo/test_demo_teacher_forced.py
+++ b/models/demos/deepseek_v3/demo/test_demo_teacher_forced.py
@@ -123,13 +123,14 @@ def test_demo_teacher_forcing_accuracy(
     tf_prompt_len = int(payload["tf_prompt_len"])
     saved_max_new_tokens = int(payload.get("max_new_tokens"))
 
-    max_supported_new_tokens = GENERATOR_MAX_SEQ_LEN - tf_prompt_len
+    configured_max_seq_len = GENERATOR_MAX_SEQ_LEN
+    max_supported_new_tokens = configured_max_seq_len - tf_prompt_len
     if max_supported_new_tokens <= 0:
-        pytest.skip(f"Prompt length {tf_prompt_len} exceeds max_seq_len {GENERATOR_MAX_SEQ_LEN}.")
+        pytest.skip(f"Prompt length {tf_prompt_len} exceeds max_seq_len {configured_max_seq_len}.")
     if max_new_tokens > max_supported_new_tokens:
         pytest.skip(
             f"Requested max_new_tokens={max_new_tokens} exceeds generator capacity: "
-            f"max_seq_len={GENERATOR_MAX_SEQ_LEN}, prompt_len={tf_prompt_len} -> max_new_tokens<={max_supported_new_tokens}."
+            f"max_seq_len={configured_max_seq_len}, prompt_len={tf_prompt_len} -> max_new_tokens<={max_supported_new_tokens}."
         )
 
     requested_system_name = os.getenv("MESH_DEVICE")
@@ -193,6 +194,7 @@ def test_demo_teacher_forcing_accuracy(
         cache_dir=CACHE_DIR,
         random_weights=False,
         max_new_tokens=max_new_tokens,
+        max_seq_len=configured_max_seq_len,
         repeat_batches=1,
         token_accuracy=True,
         reference_file=reference_file,

--- a/models/demos/deepseek_v3/demo/test_demo_teacher_forced.py
+++ b/models/demos/deepseek_v3/demo/test_demo_teacher_forced.py
@@ -8,6 +8,7 @@ import pytest
 import torch
 from loguru import logger
 
+import ttnn
 from models.demos.deepseek_v3.demo.demo import run_demo
 from models.demos.deepseek_v3.demo.token_accuracy import TokenAccuracy
 from models.demos.deepseek_v3.tt.generator import MAX_SEQ_LEN as GENERATOR_MAX_SEQ_LEN
@@ -67,6 +68,11 @@ def _assert_no_garbage_tokens(
         )
 
 
+def _tile_align(length: int) -> int:
+    tile_size = int(ttnn.TILE_SIZE)
+    return ((int(length) + tile_size - 1) // tile_size) * tile_size
+
+
 @pytest.mark.timeout(3600)
 @pytest.mark.parametrize("reference_file", [REFERENCE_FILE])
 @pytest.mark.parametrize("max_new_tokens", [128, 2048, 8192], ids=["128", "2048", "8192"])
@@ -123,16 +129,6 @@ def test_demo_teacher_forcing_accuracy(
     tf_prompt_len = int(payload["tf_prompt_len"])
     saved_max_new_tokens = int(payload.get("max_new_tokens"))
 
-    configured_max_seq_len = GENERATOR_MAX_SEQ_LEN
-    max_supported_new_tokens = configured_max_seq_len - tf_prompt_len
-    if max_supported_new_tokens <= 0:
-        pytest.skip(f"Prompt length {tf_prompt_len} exceeds max_seq_len {configured_max_seq_len}.")
-    if max_new_tokens > max_supported_new_tokens:
-        pytest.skip(
-            f"Requested max_new_tokens={max_new_tokens} exceeds generator capacity: "
-            f"max_seq_len={configured_max_seq_len}, prompt_len={tf_prompt_len} -> max_new_tokens<={max_supported_new_tokens}."
-        )
-
     requested_system_name = os.getenv("MESH_DEVICE")
     if requested_system_name is None:
         pytest.fail("Environment variable $MESH_DEVICE is not set. Please set it to DUAL, QUAD, TG, or T3K.")
@@ -182,10 +178,20 @@ def test_demo_teacher_forcing_accuracy(
             f"in {reference_file}. Regenerate the reference with a larger max_new_tokens."
         )
 
+    # Teacher forcing only needs enough configured context for the prompt plus the
+    # number of forced decode steps under test.
+    configured_max_seq_len = _tile_align(tf_prompt_len + max_new_tokens)
+    if configured_max_seq_len > GENERATOR_MAX_SEQ_LEN:
+        pytest.skip(
+            f"Requested teacher-forced context requires max_seq_len={configured_max_seq_len}, "
+            f"which exceeds generator capacity {GENERATOR_MAX_SEQ_LEN}."
+        )
+
     logger.info("=== Phase 2: Run teacher forcing ===")
     logger.info("Loaded reference from: {}", reference_file)
     logger.info("Total reference tokens: {}, prompt length: {}", total_ref_tokens, tf_prompt_len)
     logger.info("Using max_new_tokens={}", max_new_tokens)
+    logger.info("Using configured max_seq_len={}", configured_max_seq_len)
 
     # Run the demo with teacher forcing
     results = run_demo(

--- a/models/demos/deepseek_v3/demo/test_demo_teacher_forced.py
+++ b/models/demos/deepseek_v3/demo/test_demo_teacher_forced.py
@@ -11,8 +11,7 @@ from loguru import logger
 import ttnn
 from models.demos.deepseek_v3.demo.demo import run_demo
 from models.demos.deepseek_v3.demo.token_accuracy import TokenAccuracy
-from models.demos.deepseek_v3.tt.generator import MAX_SEQ_LEN as GENERATOR_MAX_SEQ_LEN
-from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW
+from models.demos.deepseek_v3.utils.config_helpers import DEFAULT_MAX_SEQ_LEN, USERS_PER_ROW
 from models.demos.deepseek_v3.utils.hf_model_utils import load_tokenizer
 from models.demos.deepseek_v3.utils.test_utils import system_name_to_mesh_shape
 
@@ -181,10 +180,10 @@ def test_demo_teacher_forcing_accuracy(
     # Teacher forcing only needs enough configured context for the prompt plus the
     # number of forced decode steps under test.
     configured_max_seq_len = _tile_align(tf_prompt_len + max_new_tokens)
-    if configured_max_seq_len > GENERATOR_MAX_SEQ_LEN:
+    if configured_max_seq_len > DEFAULT_MAX_SEQ_LEN:
         pytest.skip(
             f"Requested teacher-forced context requires max_seq_len={configured_max_seq_len}, "
-            f"which exceeds generator capacity {GENERATOR_MAX_SEQ_LEN}."
+            f"which exceeds the default demo max_seq_len {DEFAULT_MAX_SEQ_LEN}."
         )
 
     logger.info("=== Phase 2: Run teacher forcing ===")

--- a/models/demos/deepseek_v3/demo/test_eval_support.py
+++ b/models/demos/deepseek_v3/demo/test_eval_support.py
@@ -17,12 +17,16 @@ class _FakeTokenizer:
 
 
 class _FakeMeshDevice:
+    def __init__(self, shape=(1, 1)):
+        self.shape = shape
+
     def get_submeshes(self):
         return []
 
 
 class _FakeGenerator:
     def __init__(self, **kwargs):
+        self.init_kwargs = kwargs
         self.tokenizer = kwargs["tokenizer"]
         self.generate_kwargs = None
 
@@ -57,14 +61,14 @@ def test_stop_at_eos_signature_defaults():
     assert inspect.signature(demo_module.DeepseekGeneratorDP.generate).parameters["stop_at_eos"].default is True
 
 
-def _patch_demo_runtime(monkeypatch, fake_generator):
+def _patch_demo_runtime(monkeypatch, fake_generator, *, mesh_shape=(1, 1)):
     monkeypatch.setenv("MESH_DEVICE", "TG")
     monkeypatch.setattr(demo_module, "validate_model_path", lambda *args, **kwargs: None)
     monkeypatch.setattr(demo_module, "load_tokenizer", lambda *args, **kwargs: _FakeTokenizer())
-    monkeypatch.setattr(demo_module, "system_name_to_mesh_shape", lambda *args, **kwargs: (1, 1))
+    monkeypatch.setattr(demo_module, "system_name_to_mesh_shape", lambda *args, **kwargs: mesh_shape)
     monkeypatch.setattr(demo_module, "get_fabric_config", lambda: "fake-fabric")
     monkeypatch.setattr(demo_module.ttnn, "set_fabric_config", lambda *args, **kwargs: None)
-    monkeypatch.setattr(demo_module.ttnn, "open_mesh_device", lambda *args, **kwargs: _FakeMeshDevice())
+    monkeypatch.setattr(demo_module.ttnn, "open_mesh_device", lambda *args, **kwargs: _FakeMeshDevice(shape=mesh_shape))
     monkeypatch.setattr(demo_module.ttnn, "synchronize_device", lambda *args, **kwargs: None)
     monkeypatch.setattr(demo_module.ttnn, "close_mesh_device", lambda *args, **kwargs: None)
     monkeypatch.setattr(demo_module, "DeepseekGeneratorDP", lambda **kwargs: fake_generator)
@@ -109,6 +113,25 @@ def test_run_demo_defaults_to_stop_at_eos(monkeypatch, tmp_path):
     )
 
     assert fake_generator.generate_kwargs["stop_at_eos"] is True
+
+
+def test_run_demo_sizes_sampling_params_from_max_users_per_row(monkeypatch, tmp_path):
+    fake_generator = _FakeGenerator(tokenizer=_FakeTokenizer())
+
+    _patch_demo_runtime(monkeypatch, fake_generator, mesh_shape=(4, 8))
+
+    demo_module.run_demo(
+        prompts=["prompt-0"],
+        model_path=tmp_path / "model",
+        cache_dir=tmp_path / "cache",
+        max_users_per_row=8,
+    )
+
+    sampling_params = fake_generator.init_kwargs["sampling_params"]
+    expected_batch = 8 * 4
+    assert len(sampling_params.temperature) == expected_batch
+    assert len(sampling_params.top_p) == expected_batch
+    assert len(sampling_params.top_k) == expected_batch
 
 
 def test_lmeval_helpers():

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/embedding/test_ds_all_gather_embedding.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/embedding/test_ds_all_gather_embedding.py
@@ -451,9 +451,8 @@ def test_ds_all_gather_embedding_device_perf(mode, seq_len):
     step_name = f"ds_all_gather_embedding_device_perf_{mode}_seq{seq_len}"
     test_path = "models/demos/deepseek_v3/tests/fused_op_unit_tests/embedding/test_ds_all_gather_embedding.py"
     trace_filter = "trace" if mode == "decode" else "eager"
-    # Use substring matching in-k filter to select the right test variant
-    # This matches test IDs like: test_name[prefill-128-...-program_cache-eager]
-    command = f'pytest {test_path}::test_ds_all_gather_embedding -k "{mode}-{seq_len}"'
+    expr = f"program_cache and not no_program_cache and {trace_filter} and {mode} and {seq_len}"
+    command = f'pytest {test_path}::test_ds_all_gather_embedding -k "{expr}"'
 
     perf_profiler.start("run")
     perf_profiler.start(step_name)

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_all_gather_preff1_3.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_all_gather_preff1_3.py
@@ -233,7 +233,7 @@ def _build_all_gather_inputs(
         mesh_device,
         force_recalculate_weight_config,
     )
-    model_config = get_model_config(MLP, mode, hf_config, mesh_device, fabric_config)
+    model_config = get_model_config(MLP, mode, hf_config, mesh_device, fabric_config, batch_size_per_row=USERS_PER_ROW)
     model_state = {
         "mesh_device": mesh_device,
         "mesh_shape": mesh_device.shape,

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_ff1_3.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_ff1_3.py
@@ -273,7 +273,7 @@ def _build_ff1_3_inputs(
         mesh_device,
         force_recalculate_weight_config,
     )
-    model_config = get_model_config(MLP, mode, hf_config, mesh_device, fabric_config)
+    model_config = get_model_config(MLP, mode, hf_config, mesh_device, fabric_config, batch_size_per_row=USERS_PER_ROW)
     model_state = {
         "mesh_device": mesh_device,
         "mesh_shape": mesh_device.shape,

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_ff2.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_ff2.py
@@ -322,7 +322,7 @@ def _build_ff2_inputs(
         mesh_device,
         force_recalculate_weight_config,
     )
-    model_config = get_model_config(MLP, mode, hf_config, mesh_device, fabric_config)
+    model_config = get_model_config(MLP, mode, hf_config, mesh_device, fabric_config, batch_size_per_row=USERS_PER_ROW)
     model_state = {
         "mesh_device": mesh_device,
         "mesh_shape": mesh_device.shape,

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_mul.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_mul.py
@@ -262,7 +262,7 @@ def _build_mul_inputs(
         mesh_device,
         force_recalculate_weight_config,
     )
-    model_config = get_model_config(MLP, mode, hf_config, mesh_device, fabric_config)
+    model_config = get_model_config(MLP, mode, hf_config, mesh_device, fabric_config, batch_size_per_row=USERS_PER_ROW)
     model_state = {
         "mesh_device": mesh_device,
         "mesh_shape": mesh_device.shape,
@@ -520,7 +520,9 @@ def test_ds_mul_single_device(
         mesh_device,
         force_recalculate_weight_config,
     )
-    model_config = get_model_config(MLP, mode, hf_config, mesh_device, device_params["fabric_config"])
+    model_config = get_model_config(
+        MLP, mode, hf_config, mesh_device, device_params["fabric_config"], batch_size_per_row=USERS_PER_ROW
+    )
     model_state = {
         "mesh_device": mesh_device,
         "mesh_shape": mesh_device.shape,

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_mul.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_mul.py
@@ -298,7 +298,7 @@ def _build_mul_inputs(
         max_num_cores = mesh_device.core_grid.x * mesh_device.core_grid.y
         inner_num_cores = max(get_activation_sharding_core_counts_for_dram_matmul(hidden_dim_per_device, max_num_cores))
         input_memory_config = MLP._get_decode_activation_memory_config(
-            hidden_dim_per_device, inner_num_cores, mesh_device
+            hidden_dim_per_device, inner_num_cores, mesh_device, batch_size_per_row=USERS_PER_ROW
         )
     else:
         input_memory_config = ttnn.DRAM_MEMORY_CONFIG

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_reduce_scatter_post_ff2.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_reduce_scatter_post_ff2.py
@@ -335,7 +335,7 @@ def _build_reduce_scatter_inputs(
         mesh_device,
         force_recalculate_weight_config,
     )
-    model_config = get_model_config(MLP, mode, hf_config, mesh_device, fabric_config)
+    model_config = get_model_config(MLP, mode, hf_config, mesh_device, fabric_config, batch_size_per_row=USERS_PER_ROW)
     model_state = {
         "mesh_device": mesh_device,
         "mesh_shape": mesh_device.shape,

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_reduce_scatter_post_ff2.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_reduce_scatter_post_ff2.py
@@ -366,7 +366,9 @@ def _build_reduce_scatter_inputs(
         output_num_cores = max(
             get_activation_sharding_core_counts_for_dram_matmul(even_int_div(dim, mesh_width), max_num_cores)
         )
-        input_memory_config = MLP._get_decode_activation_memory_config(dim, output_num_cores, mesh_device)
+        input_memory_config = MLP._get_decode_activation_memory_config(
+            dim, output_num_cores, mesh_device, batch_size_per_row=USERS_PER_ROW
+        )
     else:
         input_memory_config = ttnn.DRAM_MEMORY_CONFIG
 

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/rms_norm/test_ds_distributed_norm.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/rms_norm/test_ds_distributed_norm.py
@@ -307,7 +307,7 @@ def _build_distributed_norm_inputs(
         mesh_device,
         force_recalculate_weight_config,
     )
-    model_config = get_model_config(DistributedRMSNorm, mode, hf_config, mesh_device)
+    model_config = get_model_config(DistributedRMSNorm, mode, hf_config, mesh_device, batch_size_per_row=USERS_PER_ROW)
     model_state = DistributedRMSNorm.create_state(hf_config, mesh_device, ccl)
     run_config = create_run_config(model_config, weight_config, model_state)
 

--- a/models/demos/deepseek_v3/tests/pytest_utils.py
+++ b/models/demos/deepseek_v3/tests/pytest_utils.py
@@ -149,7 +149,7 @@ def get_base_test_cases(users_per_row, prefill_seq_len, include_decode_random_po
           - when DEEPSEEK_MAX_SEQ_LEN_OVERRIDE is not set, includes one prefill case using
             prefill_seq_len: ("prefill", prefill_seq_len, users_per_row, None)
           - when DEEPSEEK_MAX_SEQ_LEN_OVERRIDE is set, replaces the prefill list with a single case:
-            ("prefill", max_seq_len, users_per_row, None)
+            ("prefill", max_seq_len // users_per_row, users_per_row, None)
 
     """
     base_cases = []
@@ -161,12 +161,15 @@ def get_base_test_cases(users_per_row, prefill_seq_len, include_decode_random_po
         # If DEEPSEEK_MAX_SEQ_LEN_OVERRIDE is not set, use the default prefill sequence length.
         base_cases += [("prefill", prefill_seq_len, users_per_row, None)]
     else:
-        # If DEEPSEEK_MAX_SEQ_LEN_OVERRIDE is set, use it to expand prefill and decode coverage.
+        # If DEEPSEEK_MAX_SEQ_LEN_OVERRIDE is set, use it to expand decode coverage.
+        # For prefill, scale the sequence length by users_per_row so the total token
+        # budget stays roughly aligned with the historical single-user-row workload.
         max_seq_len = int(max_seq_len_env)
+        prefill_max_seq_len = max(1, max_seq_len // max(1, users_per_row))
         base_cases += [
             ("decode", 1, users_per_row, 0),  # decode position_id 0
             ("decode", 1, users_per_row, max_seq_len - 1),  # decode position_id max_seq_len - 1
-            ("prefill", max_seq_len, users_per_row, None),  # prefill at max_seq_len
+            ("prefill", prefill_max_seq_len, users_per_row, None),  # prefill scaled for row-batched coverage
         ]
     return base_cases
 

--- a/models/demos/deepseek_v3/tests/pytest_utils.py
+++ b/models/demos/deepseek_v3/tests/pytest_utils.py
@@ -148,6 +148,8 @@ def get_base_test_cases(users_per_row, prefill_seq_len, include_decode_random_po
         - Prefill cases:
           - when DEEPSEEK_MAX_SEQ_LEN_OVERRIDE is not set, includes one prefill case using
             prefill_seq_len: ("prefill", prefill_seq_len, users_per_row, None)
+          - `users_per_row` here is the configured row width for the row-batched prefill
+            kernels under test, not the number of prompts driven by the outer generator loop
           - when DEEPSEEK_MAX_SEQ_LEN_OVERRIDE is set, replaces the prefill list with a single case:
             ("prefill", max_seq_len // users_per_row, users_per_row, None)
 
@@ -162,8 +164,9 @@ def get_base_test_cases(users_per_row, prefill_seq_len, include_decode_random_po
         base_cases += [("prefill", prefill_seq_len, users_per_row, None)]
     else:
         # If DEEPSEEK_MAX_SEQ_LEN_OVERRIDE is set, use it to expand decode coverage.
-        # For prefill, scale the sequence length by users_per_row so the total token
-        # budget stays roughly aligned with the historical single-user-row workload.
+        # For prefill, keep the configured row width fixed at users_per_row and scale
+        # the sequence length so the total token budget stays roughly aligned with the
+        # historical single-user-row workload.
         max_seq_len = int(max_seq_len_env)
         prefill_max_seq_len = max(1, max_seq_len // max(1, users_per_row))
         base_cases += [

--- a/models/demos/deepseek_v3/tests/pytest_utils.py
+++ b/models/demos/deepseek_v3/tests/pytest_utils.py
@@ -95,13 +95,13 @@ def build_expanded_test_ids(expanded_cases):
         >>> expanded_cases = [
         ...     ("decode", 1, 32, None),
         ...     ("decode", 1, 32, 1024),
-        ...     ("prefill", 128, 1, None),
+        ...     ("prefill", 128, 32, None),
         ... ]
         >>> build_expanded_test_ids(expanded_cases)
         [
             "mode_decode_seq_1_batch_32_pos_random",
             "mode_decode_seq_1_batch_32_pos_1024",
-            "mode_prefill_seq_128_batch_1",
+            "mode_prefill_seq_128_batch_32",
         ]
     """
     expanded_ids = []
@@ -147,9 +147,9 @@ def get_base_test_cases(users_per_row, prefill_seq_len, include_decode_random_po
             - position_id max_seq_len - 1
         - Prefill cases:
           - when DEEPSEEK_MAX_SEQ_LEN_OVERRIDE is not set, includes one prefill case using
-            prefill_seq_len: ("prefill", prefill_seq_len, 1, None)
+            prefill_seq_len: ("prefill", prefill_seq_len, users_per_row, None)
           - when DEEPSEEK_MAX_SEQ_LEN_OVERRIDE is set, replaces the prefill list with a single case:
-            ("prefill", max_seq_len, 1, None)
+            ("prefill", max_seq_len, users_per_row, None)
 
     """
     base_cases = []
@@ -159,14 +159,14 @@ def get_base_test_cases(users_per_row, prefill_seq_len, include_decode_random_po
     max_seq_len_env = os.getenv("DEEPSEEK_MAX_SEQ_LEN_OVERRIDE")
     if max_seq_len_env is None:
         # If DEEPSEEK_MAX_SEQ_LEN_OVERRIDE is not set, use the default prefill sequence length.
-        base_cases += [("prefill", prefill_seq_len, 1, None)]
+        base_cases += [("prefill", prefill_seq_len, users_per_row, None)]
     else:
         # If DEEPSEEK_MAX_SEQ_LEN_OVERRIDE is set, use it to expand prefill and decode coverage.
         max_seq_len = int(max_seq_len_env)
         base_cases += [
             ("decode", 1, users_per_row, 0),  # decode position_id 0
             ("decode", 1, users_per_row, max_seq_len - 1),  # decode position_id max_seq_len - 1
-            ("prefill", max_seq_len, 1, None),  # prefill at max_seq_len
+            ("prefill", max_seq_len, users_per_row, None),  # prefill at max_seq_len
         ]
     return base_cases
 

--- a/models/demos/deepseek_v3/tests/test_decoder_block.py
+++ b/models/demos/deepseek_v3/tests/test_decoder_block.py
@@ -95,7 +95,7 @@ def run_test_forward_pass_decoder2d(
 ):
     # Check params
     if mode == "prefill":
-        assert batch_size_per_row == 1, "Prefill only supports a batch size of 1"
+        assert batch_size_per_row == USERS_PER_ROW, f"Prefill expects a full row batch of {USERS_PER_ROW}"
         batch_size = batch_size_per_row
     else:
         assert mode == "decode" and seq_len == 1, "Decode only supports a sequence length of 1"

--- a/models/demos/deepseek_v3/tests/test_decoder_block.py
+++ b/models/demos/deepseek_v3/tests/test_decoder_block.py
@@ -129,7 +129,7 @@ def run_test_forward_pass_decoder2d(
         (state_dict,),
         cache_path,
         mesh_device,
-        force_recalculate_weight_config,
+        force_recalculate_weight_config or module_path is None,
         test_name="test_decoder_block",
         real_weights=is_real_weights,
         layer_id=module_path,

--- a/models/demos/deepseek_v3/tests/test_decoder_block.py
+++ b/models/demos/deepseek_v3/tests/test_decoder_block.py
@@ -202,9 +202,11 @@ def run_test_forward_pass_decoder2d(
     assert_hidden_dim_pcc(tt_output_torch, reference_output, pcc_required=required_pcc)
 
 
+ROW_BATCHED_PREFILL_SEQ_LEN = max(1, DEFAULT_PREFILL_SEQ_LEN // USERS_PER_ROW)
+
 TEST_CASES, TEST_IDS = build_test_cases_and_ids(
     USERS_PER_ROW,
-    DEFAULT_PREFILL_SEQ_LEN,  # default prefill sequence length to test
+    ROW_BATCHED_PREFILL_SEQ_LEN,  # keep total prefill token budget aligned with historical single-row coverage
     include_decode_random_pos_ids=True,  # include decode random position_ids case
 )
 

--- a/models/demos/deepseek_v3/tests/test_decoder_block.py
+++ b/models/demos/deepseek_v3/tests/test_decoder_block.py
@@ -134,7 +134,14 @@ def run_test_forward_pass_decoder2d(
         real_weights=is_real_weights,
         layer_id=module_path,
     )
-    model_config = get_model_config(DecoderBlockClass, mode, hf_config_short, mesh_device, fabric_config)
+    model_config = get_model_config(
+        DecoderBlockClass,
+        mode,
+        hf_config_short,
+        mesh_device,
+        fabric_config,
+        batch_size_per_row,
+    )
     model_state = DecoderBlockClass.create_state(
         hf_config_short,
         paged_config,

--- a/models/demos/deepseek_v3/tests/test_decoder_block.py
+++ b/models/demos/deepseek_v3/tests/test_decoder_block.py
@@ -93,13 +93,20 @@ def run_test_forward_pass_decoder2d(
     state_dict,
     decode_position_ids: int | None = None,
 ):
+    configured_row_width = batch_size_per_row
+
     # Check params
     if mode == "prefill":
-        assert batch_size_per_row == USERS_PER_ROW, f"Prefill expects a full row batch of {USERS_PER_ROW}"
-        batch_size = batch_size_per_row
+        # Like the MLA module test, this helper targets the row-batched prefill
+        # layout directly. The selected user_id picks which global row is updated,
+        # while the underlying prefill kernels operate on one full configured row.
+        assert (
+            configured_row_width == USERS_PER_ROW
+        ), f"Prefill coverage exercises a full row-wide layout of {USERS_PER_ROW} users"
+        reference_batch_size = configured_row_width
     else:
         assert mode == "decode" and seq_len == 1, "Decode only supports a sequence length of 1"
-        batch_size = batch_size_per_row * mesh_device.shape[0]
+        reference_batch_size = configured_row_width * mesh_device.shape[0]
 
     state_dict, position_ids, torch_input, reference_output, input_cache, _ = generate_reference_io(
         model_path,
@@ -107,7 +114,7 @@ def run_test_forward_pass_decoder2d(
         hf_config_short,
         reference_layer_idx,
         seq_len,
-        batch_size,
+        reference_batch_size,
         mode,
         state_dict,
         decode_position_ids,
@@ -115,7 +122,7 @@ def run_test_forward_pass_decoder2d(
 
     # Set up page config
     logger.info("Setting up model configs")
-    user_id = None if mode == "decode" else torch.randint(0, USERS_PER_ROW * mesh_device.shape[0], ()).item()
+    user_id = None if mode == "decode" else torch.randint(0, configured_row_width * mesh_device.shape[0], ()).item()
     paged_config = MLA1D.get_valid_paged_config(hf_config_short.max_seq_len, USERS_PER_ROW, mesh_device.shape[1])
     paged_input_cache, torch_page_table = paged_cache_from_torch(
         input_cache, tuple(mesh_device.shape), paged_config, user_id
@@ -140,7 +147,7 @@ def run_test_forward_pass_decoder2d(
         hf_config_short,
         mesh_device,
         fabric_config,
-        batch_size_per_row,
+        configured_row_width,
     )
     model_state = DecoderBlockClass.create_state(
         hf_config_short,
@@ -177,7 +184,7 @@ def run_test_forward_pass_decoder2d(
     tt_page_table = MLA2D.create_page_table(
         page_table=torch_page_table, paged_config=paged_config, mesh_device=mesh_device
     )
-    rope_tensors = get_rope_tensors(hf_config_short, batch_size_per_row, seq_len, position_ids, mesh_device)
+    rope_tensors = get_rope_tensors(hf_config_short, configured_row_width, seq_len, position_ids, mesh_device)
     paged_config = MLA2D.get_valid_paged_config(hf_config_short.max_seq_len, USERS_PER_ROW, mesh_device.shape[1])
 
     # Forward pass

--- a/models/demos/deepseek_v3/tests/test_decoder_block.py
+++ b/models/demos/deepseek_v3/tests/test_decoder_block.py
@@ -129,7 +129,7 @@ def run_test_forward_pass_decoder2d(
         (state_dict,),
         cache_path,
         mesh_device,
-        force_recalculate_weight_config or module_path is None,
+        force_recalculate_weight_config,
         test_name="test_decoder_block",
         real_weights=is_real_weights,
         layer_id=module_path,

--- a/models/demos/deepseek_v3/tests/test_decoder_block.py
+++ b/models/demos/deepseek_v3/tests/test_decoder_block.py
@@ -301,5 +301,63 @@ def test_forward_pass(
     )
 
 
+@pytest.mark.timeout(900)
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {"fabric_config": get_fabric_config()},
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "DecoderBlockClass, module_path, reference_layer_idx",
+    [
+        pytest.param(
+            DecoderBlock2D,
+            "model.layers.0",
+            0,
+            marks=pytest.mark.requires_device(["TG", "DUAL", "QUAD"]),
+        ),
+        pytest.param(
+            MoEDecoderBlock2D,
+            "model.layers.3",
+            3,
+            marks=pytest.mark.requires_device(["TG", "DUAL", "QUAD"]),
+        ),
+    ],
+)
+def test_mode_decode_forward_pass_batch_8_users_per_row(
+    DecoderBlockClass: type[DecoderBlock2DBase],
+    device_params,
+    module_path,
+    reference_layer_idx,
+    hf_config_short,
+    cache_path,
+    mesh_device,
+    model_path,
+    ccl,
+    force_recalculate_weight_config,
+    set_deterministic_env,
+    state_dict,
+):
+    run_test_forward_pass_decoder2d(
+        DecoderBlockClass,
+        device_params["fabric_config"],
+        module_path,
+        reference_layer_idx,
+        mode="decode",
+        seq_len=1,
+        batch_size_per_row=8,
+        hf_config_short=hf_config_short,
+        cache_path=cache_path,
+        mesh_device=mesh_device,
+        model_path=model_path,
+        ccl=ccl,
+        force_recalculate_weight_config=force_recalculate_weight_config,
+        state_dict=state_dict,
+        decode_position_ids=17,
+    )
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/models/demos/deepseek_v3/tests/test_decoder_block.py
+++ b/models/demos/deepseek_v3/tests/test_decoder_block.py
@@ -202,11 +202,14 @@ def run_test_forward_pass_decoder2d(
     assert_hidden_dim_pcc(tt_output_torch, reference_output, pcc_required=required_pcc)
 
 
-ROW_BATCHED_PREFILL_SEQ_LEN = max(1, DEFAULT_PREFILL_SEQ_LEN // USERS_PER_ROW)
+_SCALED_ROW_BATCHED_PREFILL_SEQ_LEN = max(1, DEFAULT_PREFILL_SEQ_LEN // USERS_PER_ROW)
+ROW_BATCHED_PREFILL_SEQ_LEN = (
+    (_SCALED_ROW_BATCHED_PREFILL_SEQ_LEN + ttnn.TILE_SIZE - 1) // ttnn.TILE_SIZE
+) * ttnn.TILE_SIZE
 
 TEST_CASES, TEST_IDS = build_test_cases_and_ids(
     USERS_PER_ROW,
-    ROW_BATCHED_PREFILL_SEQ_LEN,  # keep total prefill token budget aligned with historical single-row coverage
+    ROW_BATCHED_PREFILL_SEQ_LEN,  # keep total prefill token budget scaled while respecting tile-aligned prefill kernels
     include_decode_random_pos_ids=True,  # include decode random position_ids case
 )
 

--- a/models/demos/deepseek_v3/tests/test_get_weight_config.py
+++ b/models/demos/deepseek_v3/tests/test_get_weight_config.py
@@ -16,7 +16,6 @@ from transformers.configuration_utils import PretrainedConfig
 import ttnn
 from models.demos.deepseek_v3.utils.config_dataclass import SavedWeight
 from models.demos.deepseek_v3.utils.config_helpers import TENSOR_CACHE_EXTENSION
-from models.demos.deepseek_v3.utils.test_utils import get_test_weight_config
 from models.demos.deepseek_v3.utils.weight_config import (
     WeightConfigEncoder,
     get_weight_config,
@@ -37,67 +36,6 @@ def _make_hf_config(num_hidden_layers: int = 2) -> PretrainedConfig:
     hf_config = PretrainedConfig()
     hf_config.num_hidden_layers = num_hidden_layers
     return hf_config
-
-
-def test_get_test_weight_config_uses_shared_cache_for_real_weights(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    captured: dict[str, Path] = {}
-
-    class FakeModule:
-        pass
-
-    def fake_get_weight_config(ModuleClass, hf_config, state_dicts, weight_cache_path, mesh_device, force_recalculate):
-        captured["path"] = weight_cache_path
-        return {"ok": True}
-
-    monkeypatch.setattr("models.demos.deepseek_v3.utils.test_utils.get_weight_config", fake_get_weight_config)
-
-    result = get_test_weight_config(
-        FakeModule,
-        _make_hf_config(),
-        ({"dummy": torch.empty(1)},),
-        tmp_path,
-        _FakeMeshDevice(shape=(1, 1)),
-        False,
-        test_name="test_mla",
-        real_weights=True,
-        layer_id="model.layers.0.self_attn",
-    )
-
-    assert result == {"ok": True}
-    assert captured["path"] == tmp_path / "tests_cache" / "test_mla/FakeModule/real/model.layers.0.self_attn"
-
-
-def test_get_test_weight_config_uses_local_scratch_cache_for_random_weights(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    captured: dict[str, Path] = {}
-
-    class FakeModule:
-        pass
-
-    def fake_get_weight_config(ModuleClass, hf_config, state_dicts, weight_cache_path, mesh_device, force_recalculate):
-        captured["path"] = weight_cache_path
-        return {"ok": True}
-
-    monkeypatch.setattr("models.demos.deepseek_v3.utils.test_utils.get_weight_config", fake_get_weight_config)
-    monkeypatch.setenv("DEEPSEEK_V3_RANDOM_TEST_CACHE", str(tmp_path / "random-cache-root"))
-
-    result = get_test_weight_config(
-        FakeModule,
-        _make_hf_config(),
-        ({"dummy": torch.empty(1)},),
-        tmp_path,
-        _FakeMeshDevice(shape=(1, 1)),
-        False,
-        test_name="test_mla",
-        real_weights=False,
-        layer_id=None,
-    )
-
-    assert result == {"ok": True}
-    assert captured["path"] == tmp_path / "random-cache-root" / "tests_cache" / "test_mla/FakeModule/random"
 
 
 def test_get_weight_config_cache_hit_skips_convert(tmp_path: Path) -> None:

--- a/models/demos/deepseek_v3/tests/test_get_weight_config.py
+++ b/models/demos/deepseek_v3/tests/test_get_weight_config.py
@@ -16,6 +16,7 @@ from transformers.configuration_utils import PretrainedConfig
 import ttnn
 from models.demos.deepseek_v3.utils.config_dataclass import SavedWeight
 from models.demos.deepseek_v3.utils.config_helpers import TENSOR_CACHE_EXTENSION
+from models.demos.deepseek_v3.utils.test_utils import get_test_weight_config
 from models.demos.deepseek_v3.utils.weight_config import (
     WeightConfigEncoder,
     get_weight_config,
@@ -36,6 +37,67 @@ def _make_hf_config(num_hidden_layers: int = 2) -> PretrainedConfig:
     hf_config = PretrainedConfig()
     hf_config.num_hidden_layers = num_hidden_layers
     return hf_config
+
+
+def test_get_test_weight_config_uses_shared_cache_for_real_weights(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    captured: dict[str, Path] = {}
+
+    class FakeModule:
+        pass
+
+    def fake_get_weight_config(ModuleClass, hf_config, state_dicts, weight_cache_path, mesh_device, force_recalculate):
+        captured["path"] = weight_cache_path
+        return {"ok": True}
+
+    monkeypatch.setattr("models.demos.deepseek_v3.utils.test_utils.get_weight_config", fake_get_weight_config)
+
+    result = get_test_weight_config(
+        FakeModule,
+        _make_hf_config(),
+        ({"dummy": torch.empty(1)},),
+        tmp_path,
+        _FakeMeshDevice(shape=(1, 1)),
+        False,
+        test_name="test_mla",
+        real_weights=True,
+        layer_id="model.layers.0.self_attn",
+    )
+
+    assert result == {"ok": True}
+    assert captured["path"] == tmp_path / "tests_cache" / "test_mla/FakeModule/real/model.layers.0.self_attn"
+
+
+def test_get_test_weight_config_uses_local_scratch_cache_for_random_weights(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    captured: dict[str, Path] = {}
+
+    class FakeModule:
+        pass
+
+    def fake_get_weight_config(ModuleClass, hf_config, state_dicts, weight_cache_path, mesh_device, force_recalculate):
+        captured["path"] = weight_cache_path
+        return {"ok": True}
+
+    monkeypatch.setattr("models.demos.deepseek_v3.utils.test_utils.get_weight_config", fake_get_weight_config)
+    monkeypatch.setenv("DEEPSEEK_V3_RANDOM_TEST_CACHE", str(tmp_path / "random-cache-root"))
+
+    result = get_test_weight_config(
+        FakeModule,
+        _make_hf_config(),
+        ({"dummy": torch.empty(1)},),
+        tmp_path,
+        _FakeMeshDevice(shape=(1, 1)),
+        False,
+        test_name="test_mla",
+        real_weights=False,
+        layer_id=None,
+    )
+
+    assert result == {"ok": True}
+    assert captured["path"] == tmp_path / "random-cache-root" / "tests_cache" / "test_mla/FakeModule/random"
 
 
 def test_get_weight_config_cache_hit_skips_convert(tmp_path: Path) -> None:

--- a/models/demos/deepseek_v3/tests/test_lm_head1d.py
+++ b/models/demos/deepseek_v3/tests/test_lm_head1d.py
@@ -50,6 +50,7 @@ class DeepseekV3LMHead(nn.Module):
     "mode, batch_size_per_row",
     [
         ("decode", 32),
+        ("decode", 8),
         ("prefill", 1024),
     ],
 )

--- a/models/demos/deepseek_v3/tests/test_mla.py
+++ b/models/demos/deepseek_v3/tests/test_mla.py
@@ -238,24 +238,7 @@ def run_test_forward_pass_mla2d(
 
     # Set up ttnn inputs
     logger.info("Setting up model inputs")
-    # Create input memory config using the new pattern
-    if mode == "decode":
-        # Calculate per-device shape after ShardTensor2dMesh with dims=(-2, -1)
-        # For decode, torch_input.unsqueeze(0) has shape [1, seq_len, batch, hidden_size],
-        # so dims=(-2, -1) shards the (batch, hidden_size) dimensions across the mesh.
-        full_shape = torch_input.unsqueeze(0).shape  # [1, seq_len, batch, hidden_size]
-        per_device_shape = (
-            full_shape[0],
-            full_shape[1],
-            full_shape[2] // mesh_device.shape[0],  # batch (dim -2) sharded across mesh rows
-            full_shape[3] // mesh_device.shape[1],  # hidden_size (dim -1) sharded across mesh cols
-        )
-        input_memory_config = ttnn.create_sharded_memory_config(
-            per_device_shape,
-            **run_config["mla1d"]["wq_kv_a_in0_memory_config"],
-        )
-    else:
-        input_memory_config = run_config["input_memory_config"]
+    input_memory_config = run_config["input_memory_config"]
 
     tt_input = ttnn.from_torch(
         torch_input.unsqueeze(0),

--- a/models/demos/deepseek_v3/tests/test_mla.py
+++ b/models/demos/deepseek_v3/tests/test_mla.py
@@ -287,7 +287,7 @@ def run_test_forward_pass_mla2d(
 
         tt_output_torch = ttnn.to_torch(
             tt_output,
-            mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(-2, -1), mesh_shape=mesh_device.shape),
+            mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(0, -1), mesh_shape=mesh_device.shape),
         ).reshape(
             -1, seq_len, hf_config_short.hidden_size
         )  # Concatenate all batches together

--- a/models/demos/deepseek_v3/tests/test_mla.py
+++ b/models/demos/deepseek_v3/tests/test_mla.py
@@ -418,5 +418,44 @@ def test_forward_pass(
     )
 
 
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "fabric_config": get_fabric_config(),
+        }
+    ],
+    indirect=True,
+)
+@pytest.mark.requires_device(["TG", "DUAL", "QUAD"])
+def test_mode_decode_forward_pass_batch_8_users_per_row(
+    hf_config_short,
+    cache_path,
+    mesh_device,
+    ccl,
+    model_path,
+    force_recalculate_weight_config,
+    set_deterministic_env,
+    state_dict,
+):
+    # Keep this case out of the shared matrix so batch-8 decode coverage stays targeted.
+    run_test_forward_pass_mla2d(
+        layer_idx=0,
+        mode="decode",
+        seq_len=1,
+        batch_size_per_row=8,
+        hf_config_short=hf_config_short,
+        cache_path=cache_path,
+        mesh_device=mesh_device,
+        ccl=ccl,
+        model_path=model_path,
+        module_path="model.layers.0.self_attn",
+        force_recalculate_weight_config=force_recalculate_weight_config,
+        state_dict=state_dict,
+        decode_position_ids=17,
+        perf_mode=False,
+    )
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/models/demos/deepseek_v3/tests/test_mla.py
+++ b/models/demos/deepseek_v3/tests/test_mla.py
@@ -227,7 +227,7 @@ def run_test_forward_pass_mla2d(
         (state_dict,),
         cache_path,
         mesh_device,
-        force_recalculate_weight_config or module_path is None,
+        force_recalculate_weight_config,
         test_name="test_mla",
         real_weights=module_path is not None,
         layer_id=module_path,

--- a/models/demos/deepseek_v3/tests/test_mla.py
+++ b/models/demos/deepseek_v3/tests/test_mla.py
@@ -192,7 +192,7 @@ def run_test_forward_pass_mla2d(
 ):
     # Check params
     if mode == "prefill":
-        assert batch_size_per_row == 1, "Prefill only supports a batch size of 1"
+        assert batch_size_per_row == USERS_PER_ROW, f"Prefill expects a full row batch of {USERS_PER_ROW}"
         batch_size = batch_size_per_row
     else:
         assert mode == "decode" and seq_len == 1, "Decode only supports a sequence length of 1"

--- a/models/demos/deepseek_v3/tests/test_mla.py
+++ b/models/demos/deepseek_v3/tests/test_mla.py
@@ -298,18 +298,20 @@ def run_test_forward_pass_mla2d(
             mesh_device.get_num_devices(),
         )
         if mode == "prefill":
+            row_start = (user_id // batch_size_per_row) * batch_size_per_row
+            row_end = row_start + batch_size_per_row
             assert (
                 check_output_matches(tt_output_torch, reference_output, pcc_required=PCC_REQUIRED)
                 and check_cache_matches(
-                    tt_cache[user_id : user_id + 1, :, :seq_len],
+                    tt_cache[row_start:row_end, :, :seq_len],
                     output_cache,
                     hf_config_short.kv_lora_rank,
                     pcc_required=PCC_REQUIRED_KVPE,
                 )
                 and check_cache_unchanged(
-                    tt_cache, (slice(user_id, user_id + 1), slice(None), slice(None, seq_len), slice(None))
+                    tt_cache, (slice(row_start, row_end), slice(None), slice(None, seq_len), slice(None))
                 )
-            ), f"MLA output for prefill {seq_len=} {user_id=} does not meet PCC requirement {PCC_REQUIRED} or KVPE Cache PCC requirement {PCC_REQUIRED_KVPE} or has been modified outside user area"
+            ), f"MLA output for prefill {seq_len=} {user_id=} does not meet PCC requirement {PCC_REQUIRED} or KVPE Cache PCC requirement {PCC_REQUIRED_KVPE} or has been modified outside the selected row"
         else:
             assert check_output_matches(
                 tt_output_torch, reference_output, pcc_required=PCC_REQUIRED

--- a/models/demos/deepseek_v3/tests/test_mla.py
+++ b/models/demos/deepseek_v3/tests/test_mla.py
@@ -286,11 +286,12 @@ def run_test_forward_pass_mla2d(
         tt_output = ttnn.to_memory_config(tt_output, memory_config=ttnn.L1_MEMORY_CONFIG)
 
         if mode == "prefill":
-            # Isolated MLA prefill returns the selected user's output while still updating the full row cache.
+            # Row-batched MLA prefill now returns the full selected row so downstream residual adds operate on
+            # the correct per-user outputs instead of a broadcasted single-user result.
             tt_output_torch = ttnn.to_torch(
                 tt_output,
                 mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(-2, -1), mesh_shape=mesh_device.shape),
-            ).reshape(1, seq_len, hf_config_short.hidden_size)
+            ).reshape(-1, seq_len, hf_config_short.hidden_size)
         else:
             tt_output_torch = ttnn.to_torch(
                 tt_output,
@@ -306,15 +307,10 @@ def run_test_forward_pass_mla2d(
             mesh_device.get_num_devices(),
         )
         if mode == "prefill":
-            selected_user = user_id % batch_size_per_row
             row_start = (user_id // batch_size_per_row) * batch_size_per_row
             row_end = row_start + batch_size_per_row
             assert (
-                check_output_matches(
-                    tt_output_torch,
-                    reference_output[selected_user : selected_user + 1],
-                    pcc_required=PCC_REQUIRED,
-                )
+                check_output_matches(tt_output_torch, reference_output, pcc_required=PCC_REQUIRED)
                 and check_cache_matches(
                     tt_cache[row_start:row_end, :, :seq_len],
                     output_cache,

--- a/models/demos/deepseek_v3/tests/test_mla.py
+++ b/models/demos/deepseek_v3/tests/test_mla.py
@@ -214,8 +214,8 @@ def run_test_forward_pass_mla2d(
 
     # Set up page config
     logger.info("Setting up model configs")
-    user_id = None if mode == "decode" else torch.randint(0, USERS_PER_ROW * mesh_device.shape[0], ()).item()
-    paged_config = MLA2D.get_valid_paged_config(hf_config_short.max_seq_len, USERS_PER_ROW, mesh_device.shape[1])
+    user_id = None if mode == "decode" else torch.randint(0, batch_size_per_row * mesh_device.shape[0], ()).item()
+    paged_config = MLA2D.get_valid_paged_config(hf_config_short.max_seq_len, batch_size_per_row, mesh_device.shape[1])
     paged_input_cache, torch_page_table = paged_cache_from_torch(
         input_cache, tuple(mesh_device.shape), paged_config, user_id
     )
@@ -232,7 +232,7 @@ def run_test_forward_pass_mla2d(
         real_weights=module_path is not None,
         layer_id=module_path,
     )
-    model_config = get_model_config(MLA2D, mode, hf_config_short, mesh_device)
+    model_config = get_model_config(MLA2D, mode, hf_config_short, mesh_device, batch_size_per_row)
     model_state = MLA2D.create_state(hf_config_short, paged_config, mesh_device, ccl, paged_input_cache)
     run_config = create_run_config(model_config, weight_config, model_state)
 

--- a/models/demos/deepseek_v3/tests/test_mla.py
+++ b/models/demos/deepseek_v3/tests/test_mla.py
@@ -227,7 +227,7 @@ def run_test_forward_pass_mla2d(
         (state_dict,),
         cache_path,
         mesh_device,
-        force_recalculate_weight_config,
+        force_recalculate_weight_config or module_path is None,
         test_name="test_mla",
         real_weights=module_path is not None,
         layer_id=module_path,
@@ -285,12 +285,19 @@ def run_test_forward_pass_mla2d(
         # Convert to interleaved to match model behavior and avoid implicit conversion in to_torch
         tt_output = ttnn.to_memory_config(tt_output, memory_config=ttnn.L1_MEMORY_CONFIG)
 
-        tt_output_torch = ttnn.to_torch(
-            tt_output,
-            mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(0, -1), mesh_shape=mesh_device.shape),
-        ).reshape(
-            -1, seq_len, hf_config_short.hidden_size
-        )  # Concatenate all batches together
+        if mode == "prefill":
+            # Isolated MLA prefill returns the selected user's output while still updating the full row cache.
+            tt_output_torch = ttnn.to_torch(
+                tt_output,
+                mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(-2, -1), mesh_shape=mesh_device.shape),
+            ).reshape(1, seq_len, hf_config_short.hidden_size)
+        else:
+            tt_output_torch = ttnn.to_torch(
+                tt_output,
+                mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(0, -1), mesh_shape=mesh_device.shape),
+            ).reshape(
+                -1, seq_len, hf_config_short.hidden_size
+            )  # Concatenate all batches together
 
         # Check PCC
         tt_cache = torch_cache_from_paged(
@@ -299,10 +306,15 @@ def run_test_forward_pass_mla2d(
             mesh_device.get_num_devices(),
         )
         if mode == "prefill":
+            selected_user = user_id % batch_size_per_row
             row_start = (user_id // batch_size_per_row) * batch_size_per_row
             row_end = row_start + batch_size_per_row
             assert (
-                check_output_matches(tt_output_torch, reference_output, pcc_required=PCC_REQUIRED)
+                check_output_matches(
+                    tt_output_torch,
+                    reference_output[selected_user : selected_user + 1],
+                    pcc_required=PCC_REQUIRED,
+                )
                 and check_cache_matches(
                     tt_cache[row_start:row_end, :, :seq_len],
                     output_cache,

--- a/models/demos/deepseek_v3/tests/test_mla.py
+++ b/models/demos/deepseek_v3/tests/test_mla.py
@@ -190,13 +190,21 @@ def run_test_forward_pass_mla2d(
     perf_mode=False,
     num_iters=20,
 ):
+    configured_row_width = batch_size_per_row
+
     # Check params
     if mode == "prefill":
-        assert batch_size_per_row == USERS_PER_ROW, f"Prefill expects a full row batch of {USERS_PER_ROW}"
-        batch_size = batch_size_per_row
+        # These module tests exercise the row-batched prefill kernels directly. The
+        # outer generator still prefills one prompt at a time, but the MLA prefill
+        # path itself materializes and updates one full configured row of KV/cache
+        # state for the selected user row.
+        assert (
+            configured_row_width == USERS_PER_ROW
+        ), f"Prefill coverage exercises a full row-wide layout of {USERS_PER_ROW} users"
+        reference_batch_size = configured_row_width
     else:
         assert mode == "decode" and seq_len == 1, "Decode only supports a sequence length of 1"
-        batch_size = batch_size_per_row * mesh_device.shape[0]
+        reference_batch_size = configured_row_width * mesh_device.shape[0]
 
     # Get reference IO
     logger.info("Setting up reference IO")
@@ -206,7 +214,7 @@ def run_test_forward_pass_mla2d(
         hf_config_short,
         layer_idx,
         seq_len,
-        batch_size,
+        reference_batch_size,
         mode,
         state_dict,
         decode_position_ids,
@@ -214,8 +222,8 @@ def run_test_forward_pass_mla2d(
 
     # Set up page config
     logger.info("Setting up model configs")
-    user_id = None if mode == "decode" else torch.randint(0, batch_size_per_row * mesh_device.shape[0], ()).item()
-    paged_config = MLA2D.get_valid_paged_config(hf_config_short.max_seq_len, batch_size_per_row, mesh_device.shape[1])
+    user_id = None if mode == "decode" else torch.randint(0, configured_row_width * mesh_device.shape[0], ()).item()
+    paged_config = MLA2D.get_valid_paged_config(hf_config_short.max_seq_len, configured_row_width, mesh_device.shape[1])
     paged_input_cache, torch_page_table = paged_cache_from_torch(
         input_cache, tuple(mesh_device.shape), paged_config, user_id
     )
@@ -232,7 +240,7 @@ def run_test_forward_pass_mla2d(
         real_weights=module_path is not None,
         layer_id=module_path,
     )
-    model_config = get_model_config(MLA2D, mode, hf_config_short, mesh_device, batch_size_per_row)
+    model_config = get_model_config(MLA2D, mode, hf_config_short, mesh_device, configured_row_width)
     model_state = MLA2D.create_state(hf_config_short, paged_config, mesh_device, ccl, paged_input_cache)
     run_config = create_run_config(model_config, weight_config, model_state)
 
@@ -263,7 +271,7 @@ def run_test_forward_pass_mla2d(
     tt_page_table = MLA2D.create_page_table(
         page_table=torch_page_table, paged_config=paged_config, mesh_device=mesh_device
     )
-    tt_rope_tensors = get_rope_tensors(hf_config_short, batch_size_per_row, seq_len, position_ids, mesh_device)
+    tt_rope_tensors = get_rope_tensors(hf_config_short, configured_row_width, seq_len, position_ids, mesh_device)
 
     # Forward pass
     logger.info("Running TTNN forward pass")
@@ -307,8 +315,8 @@ def run_test_forward_pass_mla2d(
             mesh_device.get_num_devices(),
         )
         if mode == "prefill":
-            row_start = (user_id // batch_size_per_row) * batch_size_per_row
-            row_end = row_start + batch_size_per_row
+            row_start = (user_id // configured_row_width) * configured_row_width
+            row_end = row_start + configured_row_width
             assert (
                 check_output_matches(tt_output_torch, reference_output, pcc_required=PCC_REQUIRED)
                 and check_cache_matches(
@@ -325,11 +333,11 @@ def run_test_forward_pass_mla2d(
             assert check_output_matches(
                 tt_output_torch, reference_output, pcc_required=PCC_REQUIRED
             ) and check_cache_matches(
-                tt_cache[torch.arange(batch_size), :, position_ids, :].unsqueeze(2),
+                tt_cache[torch.arange(reference_batch_size), :, position_ids, :].unsqueeze(2),
                 output_cache[:, :, -1:, :],
                 hf_config_short.kv_lora_rank,
                 pcc_required=PCC_REQUIRED_KVPE,
-            ), f"MLA output for decode {batch_size=} {position_ids=} does not meet PCC requirement {PCC_REQUIRED} or KVPE Cache PCC requirement {PCC_REQUIRED_KVPE} or has been modified outside user area"
+            ), f"MLA output for decode {reference_batch_size=} {position_ids=} does not meet PCC requirement {PCC_REQUIRED} or KVPE Cache PCC requirement {PCC_REQUIRED_KVPE} or has been modified outside user area"
 
 
 _SCALED_ROW_BATCHED_PREFILL_SEQ_LEN = max(1, DEFAULT_PREFILL_SEQ_LEN // USERS_PER_ROW)

--- a/models/demos/deepseek_v3/tests/test_mla.py
+++ b/models/demos/deepseek_v3/tests/test_mla.py
@@ -286,7 +286,8 @@ def run_test_forward_pass_mla2d(
         tt_output = ttnn.to_memory_config(tt_output, memory_config=ttnn.L1_MEMORY_CONFIG)
 
         tt_output_torch = ttnn.to_torch(
-            tt_output, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(0, -1), mesh_shape=mesh_device.shape)
+            tt_output,
+            mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(-2, -1), mesh_shape=mesh_device.shape),
         ).reshape(
             -1, seq_len, hf_config_short.hidden_size
         )  # Concatenate all batches together

--- a/models/demos/deepseek_v3/tests/test_mla.py
+++ b/models/demos/deepseek_v3/tests/test_mla.py
@@ -323,11 +323,14 @@ def run_test_forward_pass_mla2d(
             ), f"MLA output for decode {batch_size=} {position_ids=} does not meet PCC requirement {PCC_REQUIRED} or KVPE Cache PCC requirement {PCC_REQUIRED_KVPE} or has been modified outside user area"
 
 
-ROW_BATCHED_PREFILL_SEQ_LEN = max(1, DEFAULT_PREFILL_SEQ_LEN // USERS_PER_ROW)
+_SCALED_ROW_BATCHED_PREFILL_SEQ_LEN = max(1, DEFAULT_PREFILL_SEQ_LEN // USERS_PER_ROW)
+ROW_BATCHED_PREFILL_SEQ_LEN = (
+    (_SCALED_ROW_BATCHED_PREFILL_SEQ_LEN + ttnn.TILE_SIZE - 1) // ttnn.TILE_SIZE
+) * ttnn.TILE_SIZE
 
 TEST_CASES, TEST_IDS = build_test_cases_and_ids(
     USERS_PER_ROW,
-    ROW_BATCHED_PREFILL_SEQ_LEN,  # keep total prefill token budget aligned with historical single-row coverage
+    ROW_BATCHED_PREFILL_SEQ_LEN,  # keep total prefill token budget scaled while respecting tile-aligned prefill kernels
     include_decode_random_pos_ids=True,  # include decode random position_ids case
 )
 

--- a/models/demos/deepseek_v3/tests/test_mla.py
+++ b/models/demos/deepseek_v3/tests/test_mla.py
@@ -227,7 +227,7 @@ def run_test_forward_pass_mla2d(
         (state_dict,),
         cache_path,
         mesh_device,
-        force_recalculate_weight_config,
+        force_recalculate_weight_config or module_path is None,
         test_name="test_mla",
         real_weights=module_path is not None,
         layer_id=module_path,

--- a/models/demos/deepseek_v3/tests/test_mla.py
+++ b/models/demos/deepseek_v3/tests/test_mla.py
@@ -323,9 +323,11 @@ def run_test_forward_pass_mla2d(
             ), f"MLA output for decode {batch_size=} {position_ids=} does not meet PCC requirement {PCC_REQUIRED} or KVPE Cache PCC requirement {PCC_REQUIRED_KVPE} or has been modified outside user area"
 
 
+ROW_BATCHED_PREFILL_SEQ_LEN = max(1, DEFAULT_PREFILL_SEQ_LEN // USERS_PER_ROW)
+
 TEST_CASES, TEST_IDS = build_test_cases_and_ids(
     USERS_PER_ROW,
-    DEFAULT_PREFILL_SEQ_LEN,  # default prefill sequence length to test
+    ROW_BATCHED_PREFILL_SEQ_LEN,  # keep total prefill token budget aligned with historical single-row coverage
     include_decode_random_pos_ids=True,  # include decode random position_ids case
 )
 

--- a/models/demos/deepseek_v3/tests/test_mlp.py
+++ b/models/demos/deepseek_v3/tests/test_mlp.py
@@ -16,7 +16,7 @@ from models.demos.deepseek_v3.tt.mlp.mlp import MLP
 from models.demos.deepseek_v3.tt.mlp.mlp_dequant import MLPDequant
 from models.demos.deepseek_v3.tt.mlp.non_expert import NonExpert
 from models.demos.deepseek_v3.tt.mlp.shared_expert import SharedExpert
-from models.demos.deepseek_v3.utils.config_helpers import get_fabric_config, sub_state_dict
+from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, get_fabric_config, sub_state_dict
 from models.demos.deepseek_v3.utils.run_config import create_run_config, load_weight
 from models.demos.deepseek_v3.utils.test_utils import (
     assert_hidden_dim_pcc,
@@ -194,7 +194,14 @@ def test_forward_pass(
         real_weights=module_path is not None,
         layer_id=module_path,
     )
-    model_config = get_model_config(MLPClass, mode, hf_config, mesh_device, device_params["fabric_config"])
+    model_config = get_model_config(
+        MLPClass,
+        mode,
+        hf_config,
+        mesh_device,
+        device_params["fabric_config"],
+        batch_size_per_row=USERS_PER_ROW,
+    )
     model_state = MLPClass.create_state(hf_config, mesh_device, ccl)
     run_config = create_run_config(model_config, weight_config, model_state)
 

--- a/models/demos/deepseek_v3/tests/test_mlp.py
+++ b/models/demos/deepseek_v3/tests/test_mlp.py
@@ -134,37 +134,20 @@ _max_seq_len_env = os.getenv("DEEPSEEK_MAX_SEQ_LEN_OVERRIDE")
 _prefill_seq_len = int(_max_seq_len_env) if _max_seq_len_env is not None else DEFAULT_PREFILL_SEQ_LEN
 
 
-@pytest.mark.parametrize("device_params", [{"fabric_config": get_fabric_config()}], indirect=True)
-@pytest.mark.parametrize(
-    "mode,seq_len",
-    [
-        ("decode", 32),
-        ("prefill", _prefill_seq_len),
-    ],
-)
-@pytest.mark.parametrize(
-    "MLPClass,module_path",
-    [
-        (MLP, None),
-        (NonExpert, "model.layers.0.mlp"),
-        (SharedExpert, "model.layers.3.mlp.shared_experts"),
-    ],
-)
-def test_forward_pass(
-    device_params,
+def run_test_forward_pass(
+    *,
     MLPClass,
     module_path,
     mode,
     seq_len,
+    batch_size_per_row,
     hf_config,
     mesh_device,
     ccl,
-    model_path,
-    tmp_path,
     cache_path,
     force_recalculate_weight_config,
-    set_deterministic_env,
     state_dict,
+    device_params,
 ):
     num_module_layers, _ = mesh_device.shape
 
@@ -200,7 +183,7 @@ def test_forward_pass(
         hf_config,
         mesh_device,
         device_params["fabric_config"],
-        batch_size_per_row=USERS_PER_ROW,
+        batch_size_per_row=batch_size_per_row,
     )
     model_state = MLPClass.create_state(hf_config, mesh_device, ccl)
     run_config = create_run_config(model_config, weight_config, model_state)
@@ -240,6 +223,90 @@ def test_forward_pass(
 
     # Check PCC
     assert_hidden_dim_pcc(tt_output_torch, reference_output, pcc_required=0.975)
+
+
+@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
+@pytest.mark.parametrize(
+    "mode,seq_len",
+    [
+        ("decode", 32),
+        ("prefill", _prefill_seq_len),
+    ],
+)
+@pytest.mark.parametrize(
+    "MLPClass,module_path",
+    [
+        (MLP, None),
+        (NonExpert, "model.layers.0.mlp"),
+        (SharedExpert, "model.layers.3.mlp.shared_experts"),
+    ],
+)
+def test_forward_pass(
+    device_params,
+    MLPClass,
+    module_path,
+    mode,
+    seq_len,
+    hf_config,
+    mesh_device,
+    ccl,
+    model_path,
+    tmp_path,
+    cache_path,
+    force_recalculate_weight_config,
+    set_deterministic_env,
+    state_dict,
+):
+    run_test_forward_pass(
+        MLPClass=MLPClass,
+        module_path=module_path,
+        mode=mode,
+        seq_len=seq_len,
+        batch_size_per_row=USERS_PER_ROW,
+        hf_config=hf_config,
+        mesh_device=mesh_device,
+        ccl=ccl,
+        cache_path=cache_path,
+        force_recalculate_weight_config=force_recalculate_weight_config,
+        state_dict=state_dict,
+        device_params=device_params,
+    )
+
+
+@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
+@pytest.mark.parametrize(
+    "MLPClass,module_path",
+    [
+        (NonExpert, "model.layers.0.mlp"),
+        (SharedExpert, "model.layers.3.mlp.shared_experts"),
+    ],
+)
+def test_mode_decode_forward_pass_batch_8_users_per_row(
+    device_params,
+    MLPClass,
+    module_path,
+    hf_config,
+    mesh_device,
+    ccl,
+    cache_path,
+    force_recalculate_weight_config,
+    set_deterministic_env,
+    state_dict,
+):
+    run_test_forward_pass(
+        MLPClass=MLPClass,
+        module_path=module_path,
+        mode="decode",
+        seq_len=8,
+        batch_size_per_row=8,
+        hf_config=hf_config,
+        mesh_device=mesh_device,
+        ccl=ccl,
+        cache_path=cache_path,
+        force_recalculate_weight_config=force_recalculate_weight_config,
+        state_dict=state_dict,
+        device_params=device_params,
+    )
 
 
 if __name__ == "__main__":

--- a/models/demos/deepseek_v3/tests/test_model.py
+++ b/models/demos/deepseek_v3/tests/test_model.py
@@ -305,7 +305,7 @@ def run_test_forward_pass_dpmodel(
     decode_position_ids: int | None = None,
 ):
     if mode == "prefill":
-        assert batch_size_per_row == 1, "Prefill only supports a batch size of 1"
+        assert batch_size_per_row == USERS_PER_ROW, f"Prefill expects a full row batch of {USERS_PER_ROW}"
         batch_size = batch_size_per_row
     else:
         assert mode == "decode" and seq_len == 1, "Decode only supports a sequence length of 1"
@@ -447,7 +447,13 @@ def run_test_forward_pass_dpmodel(
         test_name="test_model",
         real_weights=True,
     )
-    model_config = get_model_config(RowBatchedModel, mode, hf_config_short, mesh_device)
+    model_config = get_model_config(
+        RowBatchedModel,
+        mode,
+        hf_config_short,
+        mesh_device,
+        batch_size_per_row=batch_size_per_row,
+    )
     model_state = RowBatchedModel.create_state(hf_config_short, paged_config, mesh_device, ccl, paged_input_caches)
     model_shared_state = RowBatchedModel.create_shared_state(hf_config_short, mesh_device)
     run_config = create_run_config(model_config, weight_config, model_state, model_shared_state)

--- a/models/demos/deepseek_v3/tests/test_model.py
+++ b/models/demos/deepseek_v3/tests/test_model.py
@@ -479,12 +479,13 @@ def run_test_forward_pass_dpmodel(
         test_name="test_model",
         real_weights=True,
     )
+    config_batch_size_per_row = batch_size_per_row if mode == "decode" else USERS_PER_ROW
     model_config = get_model_config(
         RowBatchedModel,
         mode,
         hf_config_short,
         mesh_device,
-        batch_size_per_row=batch_size_per_row,
+        batch_size_per_row=config_batch_size_per_row,
     )
     model_state = RowBatchedModel.create_state(hf_config_short, paged_config, mesh_device, ccl, paged_input_caches)
     model_shared_state = RowBatchedModel.create_shared_state(hf_config_short, mesh_device)

--- a/models/demos/deepseek_v3/tests/test_model.py
+++ b/models/demos/deepseek_v3/tests/test_model.py
@@ -608,5 +608,38 @@ def test_forward_pass(
     )
 
 
+@pytest.mark.timeout(1200)
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {"fabric_config": get_fabric_config()},
+    ],
+    indirect=True,
+)
+def test_mode_decode_forward_pass_batch_8_users_per_row(
+    hf_config_short,
+    cache_path,
+    mesh_device,
+    ccl,
+    force_recalculate_weight_config,
+    set_deterministic_env,
+    state_dict,
+):
+    hf_config_short.num_hidden_layers = 5
+
+    run_test_forward_pass_dpmodel(
+        mode="decode",
+        seq_len=1,
+        batch_size_per_row=8,
+        hf_config_short=hf_config_short,
+        cache_path=cache_path,
+        mesh_device=mesh_device,
+        ccl=ccl,
+        force_recalculate_weight_config=force_recalculate_weight_config,
+        state_dict=state_dict,
+        decode_position_ids=17,
+    )
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/models/demos/deepseek_v3/tests/test_model.py
+++ b/models/demos/deepseek_v3/tests/test_model.py
@@ -479,13 +479,15 @@ def run_test_forward_pass_dpmodel(
         test_name="test_model",
         real_weights=True,
     )
-    config_batch_size_per_row = batch_size_per_row if mode == "decode" else USERS_PER_ROW
+    # The generator still drives prefill one prompt at a time, but the underlying
+    # row-batched prefill kernels/cache layout are configured for a full row.
+    configured_row_width = batch_size_per_row if mode == "decode" else USERS_PER_ROW
     model_config = get_model_config(
         RowBatchedModel,
         mode,
         hf_config_short,
         mesh_device,
-        config_batch_size_per_row,
+        configured_row_width,
     )
     model_state = RowBatchedModel.create_state(hf_config_short, paged_config, mesh_device, ccl, paged_input_caches)
     model_shared_state = RowBatchedModel.create_shared_state(hf_config_short, mesh_device)

--- a/models/demos/deepseek_v3/tests/test_model.py
+++ b/models/demos/deepseek_v3/tests/test_model.py
@@ -485,7 +485,7 @@ def run_test_forward_pass_dpmodel(
         mode,
         hf_config_short,
         mesh_device,
-        batch_size_per_row=config_batch_size_per_row,
+        config_batch_size_per_row,
     )
     model_state = RowBatchedModel.create_state(hf_config_short, paged_config, mesh_device, ccl, paged_input_caches)
     model_shared_state = RowBatchedModel.create_shared_state(hf_config_short, mesh_device)

--- a/models/demos/deepseek_v3/tests/test_model.py
+++ b/models/demos/deepseek_v3/tests/test_model.py
@@ -3,6 +3,7 @@
 
 import errno
 import hashlib
+import os
 import re
 import tempfile
 from pathlib import Path
@@ -14,7 +15,11 @@ from transformers.configuration_utils import PretrainedConfig
 
 import ttnn
 from models.demos.deepseek_v3.reference.modeling_deepseek import DeepseekV3ForCausalLM
-from models.demos.deepseek_v3.tests.pytest_utils import DEFAULT_PREFILL_SEQ_LEN, build_test_cases_and_ids
+from models.demos.deepseek_v3.tests.pytest_utils import (
+    DEFAULT_PREFILL_SEQ_LEN,
+    build_expanded_test_ids,
+    expand_test_cases_with_position_ids_ranges,
+)
 from models.demos.deepseek_v3.tt.mla.mla2d import MLA2D
 from models.demos.deepseek_v3.tt.model.row_batched_model import RowBatchedModel
 from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, get_fabric_config, sub_state_dict
@@ -39,6 +44,33 @@ REFERENCE_ENTRY_VERSION = 1
 
 def _default_reference_cache_dir(cache_path: Path) -> Path:
     return cache_path / "tests_cache"
+
+
+def _build_model_test_cases_and_ids(users_per_row: int, prefill_seq_len: int):
+    """
+    Keep model-level prefill coverage conservative.
+
+    RowBatchedModel prefill is still only exercised reliably with batch_size_per_row=1,
+    while the lower-level module tests cover the row-batched prefill paths.
+    """
+    base_cases = [("decode", 1, users_per_row, None)]
+
+    max_seq_len_env = os.getenv("DEEPSEEK_MAX_SEQ_LEN_OVERRIDE")
+    if max_seq_len_env is None:
+        base_cases.append(("prefill", prefill_seq_len, 1, None))
+    else:
+        max_seq_len = int(max_seq_len_env)
+        base_cases.extend(
+            [
+                ("decode", 1, users_per_row, 0),
+                ("decode", 1, users_per_row, max_seq_len - 1),
+                ("prefill", max_seq_len, 1, None),
+            ]
+        )
+
+    expanded_cases = expand_test_cases_with_position_ids_ranges(base_cases)
+    expanded_ids = build_expanded_test_ids(expanded_cases)
+    return expanded_cases, expanded_ids
 
 
 def _legacy_reference_cache_path(cache_path: Path) -> Path:
@@ -305,7 +337,7 @@ def run_test_forward_pass_dpmodel(
     decode_position_ids: int | None = None,
 ):
     if mode == "prefill":
-        assert batch_size_per_row == USERS_PER_ROW, f"Prefill expects a full row batch of {USERS_PER_ROW}"
+        assert batch_size_per_row == 1, "Model-level prefill only supports a batch size of 1"
         batch_size = batch_size_per_row
     else:
         assert mode == "decode" and seq_len == 1, "Decode only supports a sequence length of 1"
@@ -523,7 +555,7 @@ def run_test_forward_pass_dpmodel(
     ttnn.deallocate(tt_output)
 
 
-TEST_CASES, TEST_IDS = build_test_cases_and_ids(
+TEST_CASES, TEST_IDS = _build_model_test_cases_and_ids(
     USERS_PER_ROW,
     DEFAULT_PREFILL_SEQ_LEN,
 )

--- a/models/demos/deepseek_v3/tests/test_moe.py
+++ b/models/demos/deepseek_v3/tests/test_moe.py
@@ -168,7 +168,13 @@ def test_forward_pass(
     )
 
     model_config = get_model_config(
-        MoE, mode, hf_config, mesh_device, device_params["fabric_config"], topk_fallback=topk_fallback
+        MoE,
+        mode,
+        hf_config,
+        mesh_device,
+        device_params["fabric_config"],
+        batch_size_per_row=USERS_PER_ROW,
+        topk_fallback=topk_fallback,
     )
     model_state = MoE.create_state(hf_config, mesh_device, ccl)
     model_shared_state = MoE.create_shared_state(hf_config, mesh_device)

--- a/models/demos/deepseek_v3/tests/test_moe.py
+++ b/models/demos/deepseek_v3/tests/test_moe.py
@@ -102,6 +102,91 @@ _max_seq_len_env = os.getenv("DEEPSEEK_MAX_SEQ_LEN_OVERRIDE")
 _prefill_seq_len = int(_max_seq_len_env) if _max_seq_len_env is not None else DEFAULT_PREFILL_SEQ_LEN
 
 
+def run_test_forward_pass_moe(
+    *,
+    mode,
+    num_tokens,
+    batch_size_per_row,
+    reference_model,
+    hf_config,
+    request,
+    cache_path,
+    mesh_device,
+    ccl,
+    topk_fallback,
+    weight_type,
+    force_recalculate_weight_config,
+    device_params,
+):
+    """Test forward pass against reference model."""
+
+    module_path = "model.layers.3.mlp" if weight_type == "real" else None
+    checkpoint_state_dict = request.getfixturevalue("state_dict") if weight_type == "real" else None
+    state_dict, torch_input, reference_output = generate_reference_io(
+        mode=mode,
+        num_tokens=num_tokens,
+        reference_model=reference_model,
+        hf_config=hf_config,
+        weight_type=weight_type,
+        checkpoint_state_dict=checkpoint_state_dict,
+        module_path=module_path,
+    )
+
+    weight_config = get_test_weight_config(
+        MoE,
+        hf_config,
+        (state_dict,),
+        cache_path,
+        mesh_device,
+        force_recalculate=force_recalculate_weight_config,
+        test_name="test_moe",
+        real_weights=weight_type == "real",
+        layer_id=module_path,
+    )
+
+    model_config = get_model_config(
+        MoE,
+        mode,
+        hf_config,
+        mesh_device,
+        device_params["fabric_config"],
+        batch_size_per_row=batch_size_per_row,
+        topk_fallback=topk_fallback,
+    )
+    model_state = MoE.create_state(hf_config, mesh_device, ccl)
+    model_shared_state = MoE.create_shared_state(hf_config, mesh_device)
+    run_config = create_run_config(model_config, weight_config, model_state, model_shared_state)
+
+    tt_input = ttnn.from_torch(
+        torch_input.unsqueeze(1),
+        device=mesh_device,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(-2, -1), mesh_shape=tuple(mesh_device.shape)),
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        layout=ttnn.TILE_LAYOUT,
+    )
+
+    tt_input = ttnn.to_memory_config(tt_input, run_config["input_memory_config"])
+    tt_output = run_module_forward(MoE, mode, tt_input, run_config, handle_tensor_parallel=True)
+
+    expected_output_memory_config = run_config["output_memory_config"]
+    actual_output_memory_config = tt_output.memory_config()
+    assert (
+        actual_output_memory_config == expected_output_memory_config
+    ), f"MoE output memory config mismatch: expected {expected_output_memory_config}, got {actual_output_memory_config}"
+
+    tt_output_torch = ttnn.to_torch(
+        tt_output,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(-2, -1), mesh_shape=tuple(mesh_device.shape)),
+    )
+
+    ttnn.deallocate(tt_input)
+    ttnn.deallocate(tt_output)
+
+    logger.info(f"Mode: {mode}, Num tokens: {num_tokens}, Weight type: {weight_type}")
+    assert_hidden_dim_pcc(tt_output_torch, reference_output.unsqueeze(0), pcc_required=0.97)
+
+
 @pytest.mark.timeout(1200)
 @pytest.mark.parametrize(
     "device_params",
@@ -140,74 +225,57 @@ def test_forward_pass(
     weight_type,
     force_recalculate_weight_config,
 ):
-    """Test forward pass against reference model."""
-
-    module_path = "model.layers.3.mlp" if weight_type == "real" else None
-    checkpoint_state_dict = request.getfixturevalue("state_dict") if weight_type == "real" else None
-    num_tokens = batch_size_per_row * mesh_device.shape[0] if mode == "decode" else seq_len
-    state_dict, torch_input, reference_output = generate_reference_io(
+    run_test_forward_pass_moe(
         mode=mode,
-        num_tokens=num_tokens,
+        num_tokens=batch_size_per_row * mesh_device.shape[0] if mode == "decode" else seq_len,
+        batch_size_per_row=batch_size_per_row,
         reference_model=reference_model,
         hf_config=hf_config,
-        weight_type=weight_type,
-        checkpoint_state_dict=checkpoint_state_dict,
-        module_path=module_path,
-    )
-
-    weight_config = get_test_weight_config(
-        MoE,
-        hf_config,
-        (state_dict,),
-        cache_path,
-        mesh_device,
-        force_recalculate=force_recalculate_weight_config,
-        test_name="test_moe",
-        real_weights=weight_type == "real",
-        layer_id=module_path,
-    )
-
-    model_config = get_model_config(
-        MoE,
-        mode,
-        hf_config,
-        mesh_device,
-        device_params["fabric_config"],
-        batch_size_per_row=USERS_PER_ROW,
+        request=request,
+        cache_path=cache_path,
+        mesh_device=mesh_device,
+        ccl=ccl,
         topk_fallback=topk_fallback,
-    )
-    model_state = MoE.create_state(hf_config, mesh_device, ccl)
-    model_shared_state = MoE.create_shared_state(hf_config, mesh_device)
-    run_config = create_run_config(model_config, weight_config, model_state, model_shared_state)
-
-    tt_input = ttnn.from_torch(
-        torch_input.unsqueeze(1),
-        device=mesh_device,
-        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(-2, -1), mesh_shape=tuple(mesh_device.shape)),
-        dtype=ttnn.bfloat16,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-        layout=ttnn.TILE_LAYOUT,
+        weight_type=weight_type,
+        force_recalculate_weight_config=force_recalculate_weight_config,
+        device_params=device_params,
     )
 
-    tt_input = ttnn.to_memory_config(tt_input, run_config["input_memory_config"])
-    tt_output = run_module_forward(MoE, mode, tt_input, run_config, handle_tensor_parallel=True)
 
-    expected_output_memory_config = run_config["output_memory_config"]
-    actual_output_memory_config = tt_output.memory_config()
-    assert (
-        actual_output_memory_config == expected_output_memory_config
-    ), f"MoE output memory config mismatch: expected {expected_output_memory_config}, got {actual_output_memory_config}"
-
-    tt_output_torch = ttnn.to_torch(
-        tt_output,
-        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(-2, -1), mesh_shape=tuple(mesh_device.shape)),
+@pytest.mark.timeout(1200)
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {"fabric_config": get_fabric_config()},
+    ],
+    indirect=True,
+)
+def test_mode_decode_forward_pass_batch_8_users_per_row(
+    device_params,
+    set_deterministic_env,
+    reference_model,
+    hf_config,
+    request,
+    cache_path,
+    mesh_device,
+    ccl,
+    force_recalculate_weight_config,
+):
+    run_test_forward_pass_moe(
+        mode="decode",
+        num_tokens=8 * mesh_device.shape[0],
+        batch_size_per_row=8,
+        reference_model=reference_model,
+        hf_config=hf_config,
+        request=request,
+        cache_path=cache_path,
+        mesh_device=mesh_device,
+        ccl=ccl,
+        topk_fallback=True,
+        weight_type="real",
+        force_recalculate_weight_config=force_recalculate_weight_config,
+        device_params=device_params,
     )
-
-    ttnn.deallocate(tt_input)
-    ttnn.deallocate(tt_output)
-
-    logger.info(f"Mode: {mode}, Num tokens: {num_tokens}, Weight type: {weight_type}")
-    assert_hidden_dim_pcc(tt_output_torch, reference_output.unsqueeze(0), pcc_required=0.97)
 
 
 if __name__ == "__main__":

--- a/models/demos/deepseek_v3/tests/test_mtp.py
+++ b/models/demos/deepseek_v3/tests/test_mtp.py
@@ -571,6 +571,7 @@ class _MtpModuleRunner:
             hf_config=self.hf_config,
             mesh_device=self.mesh_device,
             fabric_config=get_fabric_config(),
+            batch_size_per_row=self.batch_size_per_row,
         )
         mtp_decode_run_config = create_run_config(
             self.model_decode_cfg,

--- a/models/demos/deepseek_v3/tests/test_mtp.py
+++ b/models/demos/deepseek_v3/tests/test_mtp.py
@@ -20,7 +20,11 @@ from models.demos.deepseek_v3.tt.ccl import CCL
 from models.demos.deepseek_v3.tt.decoder_block.decoder_block_2d import DecoderBlock2D
 from models.demos.deepseek_v3.tt.decoder_block.moe_decoder_block_2d import MoEDecoderBlock2D
 from models.demos.deepseek_v3.tt.embedding.embedding2d import Embedding2D
-from models.demos.deepseek_v3.tt.generator import MAX_SEQ_LEN, DeepseekGenerator, _build_verify_alias_page_table_host
+from models.demos.deepseek_v3.tt.generator import (
+    DEFAULT_MAX_SEQ_LEN,
+    DeepseekGenerator,
+    _build_verify_alias_page_table_host,
+)
 from models.demos.deepseek_v3.tt.lm_head1d import LMHead1D
 from models.demos.deepseek_v3.tt.mla.mla2d import MLA2D
 from models.demos.deepseek_v3.tt.model.row_batched_model import RowBatchedModel, get_fabric_config
@@ -506,7 +510,7 @@ class _MtpModuleRunner:
         self.enable_mtp = True
 
         self.hf_config = AutoConfig.from_pretrained(self.model_path, trust_remote_code=True)
-        self.hf_config.max_seq_len = MAX_SEQ_LEN
+        self.hf_config.max_seq_len = DEFAULT_MAX_SEQ_LEN
         if int(getattr(self.hf_config, "num_nextn_predict_layers", 0)) <= 0:
             raise RuntimeError("MTP module runner requires a model config with num_nextn_predict_layers > 0.")
 

--- a/models/demos/deepseek_v3/tests/test_mtp.py
+++ b/models/demos/deepseek_v3/tests/test_mtp.py
@@ -20,18 +20,14 @@ from models.demos.deepseek_v3.tt.ccl import CCL
 from models.demos.deepseek_v3.tt.decoder_block.decoder_block_2d import DecoderBlock2D
 from models.demos.deepseek_v3.tt.decoder_block.moe_decoder_block_2d import MoEDecoderBlock2D
 from models.demos.deepseek_v3.tt.embedding.embedding2d import Embedding2D
-from models.demos.deepseek_v3.tt.generator import (
-    DEFAULT_MAX_SEQ_LEN,
-    DeepseekGenerator,
-    _build_verify_alias_page_table_host,
-)
+from models.demos.deepseek_v3.tt.generator import DeepseekGenerator, _build_verify_alias_page_table_host
 from models.demos.deepseek_v3.tt.lm_head1d import LMHead1D
 from models.demos.deepseek_v3.tt.mla.mla2d import MLA2D
 from models.demos.deepseek_v3.tt.model.row_batched_model import RowBatchedModel, get_fabric_config
 from models.demos.deepseek_v3.tt.mtp import MTP2D
 from models.demos.deepseek_v3.tt.rms_norm.distributed_rms_norm import DistributedRMSNorm
 from models.demos.deepseek_v3.tt.rope import RotarySetup
-from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, even_int_div
+from models.demos.deepseek_v3.utils.config_helpers import DEFAULT_MAX_SEQ_LEN, USERS_PER_ROW, even_int_div
 from models.demos.deepseek_v3.utils.run_config import create_run_config
 from models.demos.deepseek_v3.utils.test_utils import load_state_dict
 from models.demos.deepseek_v3.utils.weight_config import _try_load_cached_config, get_weight_config

--- a/models/demos/deepseek_v3/tests/test_rms_norm.py
+++ b/models/demos/deepseek_v3/tests/test_rms_norm.py
@@ -109,7 +109,13 @@ def test_forward_pass(
         real_weights=reference_layernorm_path is not None,
         layer_id=reference_layernorm_path if reference_layernorm_path is not None else hf_config_size_attr,
     )
-    model_config = get_model_config(RMSNormClass, mode, hf_config, mesh_device)
+    model_config = get_model_config(
+        RMSNormClass,
+        mode,
+        hf_config,
+        mesh_device,
+        batch_size_per_row=USERS_PER_ROW,
+    )
     model_state = RMSNormClass.create_state(
         hf_config, mesh_device, *[ccl for _ in range(1) if RMSNormClass is DistributedRMSNorm]
     )

--- a/models/demos/deepseek_v3/tests/test_rms_norm.py
+++ b/models/demos/deepseek_v3/tests/test_rms_norm.py
@@ -27,6 +27,103 @@ _max_seq_len_env = os.getenv("DEEPSEEK_MAX_SEQ_LEN_OVERRIDE")
 _prefill_seq_len = int(_max_seq_len_env) if _max_seq_len_env is not None else DEFAULT_PREFILL_SEQ_LEN
 
 
+def run_test_forward_pass_rms_norm(
+    *,
+    RMSNormClass,
+    hf_config_size_attr,
+    mode,
+    seq_len,
+    batch_size_per_row,
+    reference_layernorm_path,
+    hf_config,
+    cache_path,
+    mesh_device,
+    ccl,
+    force_recalculate_weight_config,
+    state_dict,
+):
+    num_module_layers, _ = mesh_device.shape
+
+    # Get the hidden_size of the norm
+    hidden_size = getattr(hf_config, hf_config_size_attr)
+
+    # Get the reference inputs and outputs
+    reference_model = DeepseekV3RMSNorm(
+        hidden_size=hidden_size,
+        eps=hf_config.rms_norm_eps,
+    ).eval()
+
+    if reference_layernorm_path is not None:
+        # Use real weights from the model
+        state_dict = sub_state_dict(state_dict, reference_layernorm_path + ".")
+        reference_model.load_state_dict({k: v.to(torch.float32) for k, v in state_dict.items()})
+        state_dict = {k: v.to(torch.bfloat16) for k, v in state_dict.items()}
+    else:
+        state_dict = reference_model.to(torch.bfloat16).state_dict()
+
+    torch_input = torch.randn(num_module_layers, 1, seq_len, hidden_size)
+    reference_model = reference_model.to(torch.float32)
+    reference_output = reference_model(torch_input)
+
+    # Generate module configs and state
+    weight_config = get_test_weight_config(
+        RMSNormClass,
+        hf_config,
+        [state_dict] * num_module_layers,
+        cache_path,
+        mesh_device,
+        force_recalculate_weight_config,
+        test_name="test_rms_norm",
+        real_weights=reference_layernorm_path is not None,
+        layer_id=reference_layernorm_path if reference_layernorm_path is not None else hf_config_size_attr,
+    )
+    model_config = get_model_config(
+        RMSNormClass,
+        mode,
+        hf_config,
+        mesh_device,
+        batch_size_per_row=batch_size_per_row,
+    )
+    model_state = RMSNormClass.create_state(
+        hf_config, mesh_device, *[ccl for _ in range(1) if RMSNormClass is DistributedRMSNorm]
+    )
+    run_config = create_run_config(model_config, weight_config, model_state)
+
+    # Convert the input to TTNN tensor
+    if RMSNormClass is DistributedRMSNorm:
+        memory_config = run_config["input_memory_config"]
+    else:
+        memory_config = ttnn.L1_MEMORY_CONFIG
+    tt_input = ttnn.from_torch(
+        torch_input,
+        device=mesh_device,
+        mesh_mapper=ttnn.ShardTensor2dMesh(
+            mesh_device, mesh_device.shape, dims=(0, -1 if RMSNormClass is DistributedRMSNorm else None)
+        ),
+        dtype=ttnn.bfloat16,
+        memory_config=memory_config,
+        layout=ttnn.TILE_LAYOUT,
+    )
+
+    # Run TTNN forward pass
+    tt_output = run_module_forward(RMSNormClass, mode, tt_input, run_config)
+
+    # Convert output back to torch
+    tt_output_torch = ttnn.to_torch(
+        tt_output,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_device.shape, dims=(0, -1)),
+    )
+    if RMSNormClass is RMSNorm:
+        tt_output_torch = tt_output_torch[..., :hidden_size]
+
+    # Cleanup
+    ttnn.deallocate(tt_input)
+    ttnn.deallocate(tt_output)
+
+    # Check PCC
+    assert_hidden_dim_pcc(tt_output_torch, reference_output, pcc_required=0.98)
+
+
 @pytest.mark.parametrize(
     "device_params",
     [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL, "fabric_config": get_fabric_config()}],
@@ -74,86 +171,61 @@ def test_forward_pass(
     set_deterministic_env,
     state_dict: dict[str, torch.Tensor],
 ):
-    num_module_layers, _ = mesh_device.shape
-
-    # Get the hidden_size of the norm
-    hidden_size = getattr(hf_config, hf_config_size_attr)
-
-    # Get the reference inputs and outputs
-    reference_model = DeepseekV3RMSNorm(
-        hidden_size=hidden_size,
-        eps=hf_config.rms_norm_eps,
-    ).eval()
-
-    if reference_layernorm_path is not None:
-        # Use real weights from the model
-        state_dict = sub_state_dict(state_dict, reference_layernorm_path + ".")
-        reference_model.load_state_dict({k: v.to(torch.float32) for k, v in state_dict.items()})
-        state_dict = {k: v.to(torch.bfloat16) for k, v in state_dict.items()}
-    else:
-        state_dict = reference_model.to(torch.bfloat16).state_dict()
-
-    torch_input = torch.randn(num_module_layers, 1, seq_len, hidden_size)
-    reference_model = reference_model.to(torch.float32)
-    reference_output = reference_model(torch_input)
-
-    # Generate module configs and state
-    weight_config = get_test_weight_config(
-        RMSNormClass,
-        hf_config,
-        [state_dict] * num_module_layers,
-        cache_path,
-        mesh_device,
-        force_recalculate_weight_config,
-        test_name="test_rms_norm",
-        real_weights=reference_layernorm_path is not None,
-        layer_id=reference_layernorm_path if reference_layernorm_path is not None else hf_config_size_attr,
-    )
-    model_config = get_model_config(
-        RMSNormClass,
-        mode,
-        hf_config,
-        mesh_device,
+    run_test_forward_pass_rms_norm(
+        RMSNormClass=RMSNormClass,
+        hf_config_size_attr=hf_config_size_attr,
+        mode=mode,
+        seq_len=seq_len,
         batch_size_per_row=USERS_PER_ROW,
-    )
-    model_state = RMSNormClass.create_state(
-        hf_config, mesh_device, *[ccl for _ in range(1) if RMSNormClass is DistributedRMSNorm]
-    )
-    run_config = create_run_config(model_config, weight_config, model_state)
-
-    # Convert the input to TTNN tensor
-    if RMSNormClass is DistributedRMSNorm:
-        memory_config = run_config["input_memory_config"]
-    else:
-        memory_config = ttnn.L1_MEMORY_CONFIG
-    tt_input = ttnn.from_torch(
-        torch_input,
-        device=mesh_device,
-        mesh_mapper=ttnn.ShardTensor2dMesh(
-            mesh_device, mesh_device.shape, dims=(0, -1 if RMSNormClass is DistributedRMSNorm else None)
-        ),
-        dtype=ttnn.bfloat16,
-        memory_config=memory_config,
-        layout=ttnn.TILE_LAYOUT,
+        reference_layernorm_path=reference_layernorm_path,
+        hf_config=hf_config,
+        cache_path=cache_path,
+        mesh_device=mesh_device,
+        ccl=ccl,
+        force_recalculate_weight_config=force_recalculate_weight_config,
+        state_dict=state_dict,
     )
 
-    # Run TTNN forward pass
-    tt_output = run_module_forward(RMSNormClass, mode, tt_input, run_config)
 
-    # Convert output back to torch
-    tt_output_torch = ttnn.to_torch(
-        tt_output,
-        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_device.shape, dims=(0, -1)),
+@pytest.mark.parametrize(
+    "device_params",
+    [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL, "fabric_config": ttnn.FabricConfig.FABRIC_1D}],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "reference_layernorm_path, RMSNormClass, hf_config_size_attr",
+    [
+        ("model.layers.0.input_layernorm", DistributedRMSNorm, "hidden_size"),
+        ("model.layers.0.self_attn.kv_a_layernorm", RMSNorm, "kv_lora_rank"),
+    ],
+)
+def test_mode_decode_forward_pass_batch_8_users_per_row(
+    RMSNormClass,
+    hf_config_size_attr,
+    device_params,
+    reference_layernorm_path,
+    hf_config,
+    cache_path,
+    mesh_device,
+    ccl,
+    force_recalculate_weight_config,
+    set_deterministic_env,
+    state_dict: dict[str, torch.Tensor],
+):
+    run_test_forward_pass_rms_norm(
+        RMSNormClass=RMSNormClass,
+        hf_config_size_attr=hf_config_size_attr,
+        mode="decode",
+        seq_len=8,
+        batch_size_per_row=8,
+        reference_layernorm_path=reference_layernorm_path,
+        hf_config=hf_config,
+        cache_path=cache_path,
+        mesh_device=mesh_device,
+        ccl=ccl,
+        force_recalculate_weight_config=force_recalculate_weight_config,
+        state_dict=state_dict,
     )
-    if RMSNormClass is RMSNorm:
-        tt_output_torch = tt_output_torch[..., :hidden_size]
-
-    # Cleanup
-    ttnn.deallocate(tt_input)
-    ttnn.deallocate(tt_output)
-
-    # Check PCC
-    assert_hidden_dim_pcc(tt_output_torch, reference_output, pcc_required=0.98)
 
 
 if __name__ == "__main__":

--- a/models/demos/deepseek_v3/tt/decoder_block/decoder_block_2d.py
+++ b/models/demos/deepseek_v3/tt/decoder_block/decoder_block_2d.py
@@ -46,8 +46,14 @@ class DecoderBlock2D(DecoderBlock2DBase):
         hf_config: PretrainedConfig,
         mesh_device: ttnn.MeshDevice,
         fabric_config: ttnn.FabricConfig,
+        batch_size_per_row: int,
     ) -> ModelDecodeConfig:
-        return NonExpert.decode_model_config(hf_config, mesh_device, fabric_config)
+        return NonExpert.decode_model_config(
+            hf_config,
+            mesh_device,
+            fabric_config,
+            batch_size_per_row=batch_size_per_row,
+        )
 
     @classmethod
     def create_mlp_state(

--- a/models/demos/deepseek_v3/tt/decoder_block/decoder_block_2d.py
+++ b/models/demos/deepseek_v3/tt/decoder_block/decoder_block_2d.py
@@ -74,7 +74,14 @@ class DecoderBlock2D(DecoderBlock2DBase):
 
     @classmethod
     def forward_mlp_prefill(cls, x: ttnn.Tensor, cfg: RunPrefillConfig) -> ttnn.Tensor:
-        return NonExpert.forward_prefill(x, cfg)
+        if x.shape[1] == 1:
+            return NonExpert.forward_prefill(x, cfg)
+
+        batch_size = x.shape[1]
+        seq_len = x.shape[2]
+        x = ttnn.reshape(x, (x.shape[0], 1, batch_size * seq_len, x.shape[3]))
+        output = NonExpert.forward_prefill(x, cfg)
+        return ttnn.reshape(output, (output.shape[0], batch_size, seq_len, output.shape[3]))
 
     @classmethod
     def forward_mlp_decode(cls, x: ttnn.Tensor, cfg: RunDecodeConfig) -> ttnn.Tensor:

--- a/models/demos/deepseek_v3/tt/decoder_block/decoder_block_2d_base.py
+++ b/models/demos/deepseek_v3/tt/decoder_block/decoder_block_2d_base.py
@@ -168,8 +168,9 @@ class DecoderBlock2DBase(DecoderBlockBase):
         cls,
         hf_config: PretrainedConfig,
         mesh_device: ttnn.MeshDevice,
+        batch_size_per_row: int,
     ) -> ModelPrefillConfig:
-        return MLA2D.prefill_model_config(hf_config, mesh_device)
+        return MLA2D.prefill_model_config(hf_config, mesh_device, batch_size_per_row=batch_size_per_row)
 
     @classmethod
     @abstractmethod
@@ -177,12 +178,13 @@ class DecoderBlock2DBase(DecoderBlockBase):
         cls,
         hf_config: PretrainedConfig,
         mesh_device: ttnn.MeshDevice,
+        batch_size_per_row: int,
     ) -> ModelDecodeConfig:
         """
         Decode configuration for the MLA component of the decoder layer.
         This method should be implemented by subclasses to handle specific MLA configurations.
         """
-        return MLA2D.decode_model_config(hf_config, mesh_device)
+        return MLA2D.decode_model_config(hf_config, mesh_device, batch_size_per_row=batch_size_per_row)
 
     @classmethod
     @abstractmethod

--- a/models/demos/deepseek_v3/tt/decoder_block/decoder_block_2d_base.py
+++ b/models/demos/deepseek_v3/tt/decoder_block/decoder_block_2d_base.py
@@ -133,11 +133,7 @@ class DecoderBlock2DBase(DecoderBlockBase):
             ttnn.deallocate(mla_norm_in)
 
         # MLA
-        mla_reshard_memory_config = ttnn.create_sharded_memory_config(
-            mla_norm_out.shape,
-            **cfg["mla_reshard"],
-        )
-        mla_norm_out = ttnn.to_memory_config(mla_norm_out, memory_config=mla_reshard_memory_config)
+        mla_norm_out = ttnn.to_memory_config(mla_norm_out, **cfg["mla_reshard"])
         mla_out = MLA2D.forward_decode(mla_norm_out, position_idxs, cfg["mla"], rope_tensors, page_table)
         ttnn.deallocate(mla_norm_out)
 

--- a/models/demos/deepseek_v3/tt/decoder_block/decoder_block_base.py
+++ b/models/demos/deepseek_v3/tt/decoder_block/decoder_block_base.py
@@ -31,11 +31,12 @@ class DecoderBlockBase(SharedStateAddOn, AbstractModule):
         hf_config: PretrainedConfig,
         mesh_device: ttnn.MeshDevice,
         fabric_config: ttnn.FabricConfig,
+        batch_size_per_row: int,
     ) -> ModelPrefillConfig:
         mla_norm_config = DistributedRMSNorm.prefill_model_config(hf_config, mesh_device)
         mlp_norm_config = DistributedRMSNorm.prefill_model_config(hf_config, mesh_device)
 
-        mla_config = cls.prefill_mla_config(hf_config, mesh_device)
+        mla_config = cls.prefill_mla_config(hf_config, mesh_device, batch_size_per_row=batch_size_per_row)
 
         return {
             "mla_norm_reshard": ReshardConfig(memory_config=mla_norm_config["input_memory_config"]),
@@ -54,12 +55,26 @@ class DecoderBlockBase(SharedStateAddOn, AbstractModule):
         hf_config: PretrainedConfig,
         mesh_device: ttnn.MeshDevice,
         fabric_config: ttnn.FabricConfig,
+        batch_size_per_row: int,
     ) -> ModelDecodeConfig:
-        mla_norm_config = DistributedRMSNorm.decode_model_config(hf_config, mesh_device)
-        mlp_norm_config = DistributedRMSNorm.decode_model_config(hf_config, mesh_device)
+        mla_norm_config = DistributedRMSNorm.decode_model_config(
+            hf_config,
+            mesh_device,
+            batch_size_per_row=batch_size_per_row,
+        )
+        mlp_norm_config = DistributedRMSNorm.decode_model_config(
+            hf_config,
+            mesh_device,
+            batch_size_per_row=batch_size_per_row,
+        )
 
-        mla_config = cls.decode_mla_config(hf_config, mesh_device)
-        mlp_config = cls.decode_mlp_config(hf_config, mesh_device, fabric_config)
+        mla_config = cls.decode_mla_config(hf_config, mesh_device, batch_size_per_row=batch_size_per_row)
+        mlp_config = cls.decode_mlp_config(
+            hf_config,
+            mesh_device,
+            fabric_config,
+            batch_size_per_row=batch_size_per_row,
+        )
 
         # Get the input_memory_config for the mlp_reshard
         # For MoE blocks, input_memory_config is nested inside shared_expert
@@ -105,6 +120,7 @@ class DecoderBlockBase(SharedStateAddOn, AbstractModule):
         cls,
         hf_config: PretrainedConfig,
         mesh_device: ttnn.MeshDevice,
+        batch_size_per_row: int,
     ) -> ModelPrefillConfig:
         """
         Prefill configuration for the MLA component of the decoder layer.
@@ -132,6 +148,7 @@ class DecoderBlockBase(SharedStateAddOn, AbstractModule):
         cls,
         hf_config: PretrainedConfig,
         mesh_device: ttnn.MeshDevice,
+        batch_size_per_row: int,
     ) -> ModelDecodeConfig:
         """
         Decode configuration for the MLA component of the decoder layer.
@@ -146,6 +163,7 @@ class DecoderBlockBase(SharedStateAddOn, AbstractModule):
         hf_config: PretrainedConfig,
         mesh_device: ttnn.MeshDevice,
         fabric_config: ttnn.FabricConfig,
+        batch_size_per_row: int,
     ) -> ModelDecodeConfig:
         """
         Decode configuration for the MLP component of the decoder layer.

--- a/models/demos/deepseek_v3/tt/decoder_block/decoder_block_base.py
+++ b/models/demos/deepseek_v3/tt/decoder_block/decoder_block_base.py
@@ -86,7 +86,7 @@ class DecoderBlockBase(SharedStateAddOn, AbstractModule):
         return {
             "mla_norm_reshard": ReshardConfig(memory_config=mla_norm_config["input_memory_config"]),
             "mla_norm": mla_norm_config,
-            "mla_reshard": mla_config["mla1d"]["wq_kv_a_in0_memory_config"],
+            "mla_reshard": ReshardConfig(memory_config=mla_config["input_memory_config"]),
             "mla": mla_config,
             "mlp_norm_reshard": ReshardConfig(memory_config=mlp_norm_config["input_memory_config"]),
             "mlp_norm": mlp_norm_config,

--- a/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block_2d.py
+++ b/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block_2d.py
@@ -124,6 +124,11 @@ class MoEDecoderBlock2D(DecoderBlock2DBase):
             # Should always be TP-sharded at this point
             assert False, f"Expected TP-sharded input with dim {hidden_size // tp_size}, got dim {x_dim}"
 
+        batch_size = x_gathered.shape[1]
+        seq_len = x_gathered.shape[2]
+        if batch_size > 1:
+            x_gathered = ttnn.reshape(x_gathered, (x_gathered.shape[0], 1, batch_size * seq_len, x_gathered.shape[3]))
+
         # Run both MoE and SharedExpert with the same gathered input
         mlp_out = MoE.forward_prefill(x_gathered, cfg["moe"])
         # SharedExpert now always expects collective ops to be handled by caller
@@ -143,6 +148,8 @@ class MoEDecoderBlock2D(DecoderBlock2DBase):
                 **ccl_moe.populate_reduce_scatter_runtime_args(cfg["moe"]["final_output_reduce_scatter"]),
             )
             ttnn.deallocate(combined_out)
+            if batch_size > 1:
+                output = ttnn.reshape(output, (output.shape[0], batch_size, seq_len, output.shape[3]))
             # Cleanup gathered tensor
             if x_gathered is not x:
                 ttnn.deallocate(x_gathered)

--- a/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block_2d.py
+++ b/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block_2d.py
@@ -63,10 +63,21 @@ class MoEDecoderBlock2D(DecoderBlock2DBase):
         hf_config: PretrainedConfig,
         mesh_device: ttnn.MeshDevice,
         fabric_config: ttnn.FabricConfig,
+        batch_size_per_row: int,
     ) -> ModelDecodeConfig:
         return {
-            "shared_expert": SharedExpert.decode_model_config(hf_config, mesh_device, fabric_config),
-            "moe": MoE.decode_model_config(hf_config, mesh_device, fabric_config),
+            "shared_expert": SharedExpert.decode_model_config(
+                hf_config,
+                mesh_device,
+                fabric_config,
+                batch_size_per_row=batch_size_per_row,
+            ),
+            "moe": MoE.decode_model_config(
+                hf_config,
+                mesh_device,
+                fabric_config,
+                batch_size_per_row=batch_size_per_row,
+            ),
         }
 
     @classmethod

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -33,7 +33,7 @@ from models.demos.deepseek_v3.utils.run_config import create_run_config
 from models.demos.deepseek_v3.utils.weight_config import get_weight_config
 from models.perf.benchmarking_utils import BenchmarkProfiler
 
-MAX_SEQ_LEN = 32768
+DEFAULT_MAX_SEQ_LEN = 32768
 
 
 def _build_verify_alias_page_table_host(
@@ -176,7 +176,7 @@ class DeepseekGenerator(WarmupForwardMixin):
             hf_config if hf_config is not None else AutoConfig.from_pretrained(self.model_path, trust_remote_code=True)
         )
         model_max_seq_len = int(self.hf_config.max_position_embeddings)
-        requested_max_seq_len = MAX_SEQ_LEN if max_seq_len is None else int(max_seq_len)
+        requested_max_seq_len = DEFAULT_MAX_SEQ_LEN if max_seq_len is None else int(max_seq_len)
         if requested_max_seq_len <= 0:
             raise ValueError(f"max_seq_len must be > 0, got {requested_max_seq_len}")
         if requested_max_seq_len % ttnn.TILE_SIZE != 0:
@@ -185,11 +185,11 @@ class DeepseekGenerator(WarmupForwardMixin):
             raise ValueError(
                 f"max_seq_len {requested_max_seq_len} exceeds model-supported context length {model_max_seq_len}"
             )
-        if requested_max_seq_len != MAX_SEQ_LEN:
+        if requested_max_seq_len != DEFAULT_MAX_SEQ_LEN:
             logger.warning(
                 "Using overridden max_seq_len={} (default={}, model supports up to {}).",
                 requested_max_seq_len,
-                MAX_SEQ_LEN,
+                DEFAULT_MAX_SEQ_LEN,
                 model_max_seq_len,
             )
         self.hf_config.max_seq_len = requested_max_seq_len

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -228,8 +228,6 @@ class DeepseekGenerator(WarmupForwardMixin):
         batch_size_per_row = int(batch_size_per_row)
         if batch_size_per_row <= 0:
             raise ValueError(f"batch_size_per_row must be > 0, got {batch_size_per_row}")
-        if batch_size_per_row > USERS_PER_ROW:
-            raise ValueError(f"batch_size_per_row {batch_size_per_row} exceeds the supported maximum {USERS_PER_ROW}")
         if batch_size_per_row % self.dp_factor != 0:
             raise ValueError(f"batch_size_per_row {batch_size_per_row} must be divisible by dp_factor={self.dp_factor}")
         self.batch_size_per_row = batch_size_per_row

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -33,7 +33,7 @@ from models.demos.deepseek_v3.utils.run_config import create_run_config
 from models.demos.deepseek_v3.utils.weight_config import get_weight_config
 from models.perf.benchmarking_utils import BenchmarkProfiler
 
-DEFAULT_MAX_SEQ_LEN = 32768
+DEFAULT_MAX_SEQ_LEN = 2048
 
 
 def _build_verify_alias_page_table_host(

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -127,8 +127,8 @@ class DeepseekGenerator(WarmupForwardMixin):
     Notes:
     - Prefill at the model level is not fully implemented in RowBatchedModel; we emulate
       prefill by iterating decode steps over the prompt tokens (updates caches).
-    - Batch size in configs is tied to USERS_PER_ROW; for simplicity we decode
-      up to that many sequences. If fewer are provided, we pad/ignore extras.
+    - Decode runs are configured for up to a fixed number of users per row.
+      If fewer prompts are provided, we pad/ignore extras.
 
     Usage:
     - Context manager (recommended):
@@ -151,6 +151,7 @@ class DeepseekGenerator(WarmupForwardMixin):
         model_path: str | Path | None = None,
         cache_dir: str | Path | None = None,
         batch_size: int = USERS_PER_ROW,
+        batch_size_per_row: int | None = None,
         tokenizer=None,
         random_weights: bool = False,
         dense_layers: int | None = None,
@@ -225,7 +226,27 @@ class DeepseekGenerator(WarmupForwardMixin):
         self.ccl = CCL(mesh_device)
         mesh_shape = list(mesh_device.shape)
         self.dp_factor = mesh_shape[1]
-        self.batch_size_per_row = USERS_PER_ROW
+        legacy_batch_size_per_row = int(batch_size)
+        if batch_size_per_row is not None and legacy_batch_size_per_row != USERS_PER_ROW:
+            if int(batch_size_per_row) != legacy_batch_size_per_row:
+                raise ValueError(
+                    "Specify only one of batch_size and batch_size_per_row; "
+                    "batch_size is a deprecated alias for batch_size_per_row."
+                )
+        resolved_batch_size_per_row = (
+            int(batch_size_per_row) if batch_size_per_row is not None else legacy_batch_size_per_row
+        )
+        if resolved_batch_size_per_row <= 0:
+            raise ValueError(f"batch_size_per_row must be > 0, got {resolved_batch_size_per_row}")
+        if resolved_batch_size_per_row > USERS_PER_ROW:
+            raise ValueError(
+                f"batch_size_per_row {resolved_batch_size_per_row} exceeds the supported maximum {USERS_PER_ROW}"
+            )
+        if resolved_batch_size_per_row % self.dp_factor != 0:
+            raise ValueError(
+                f"batch_size_per_row {resolved_batch_size_per_row} must be divisible by dp_factor={self.dp_factor}"
+            )
+        self.batch_size_per_row = resolved_batch_size_per_row
         self.batch_size = self.batch_size_per_row * self.mesh_device.shape[0]
 
         # Configure sampling
@@ -333,7 +354,11 @@ class DeepseekGenerator(WarmupForwardMixin):
             )
         if sample_on_device:
             enable_internal_trace_sampling = enable_trace and self.sample_on_device
-            self.sampling_args = make_deepseek_sampling_args(self.mesh_device, self.hf_config.vocab_size)
+            self.sampling_args = make_deepseek_sampling_args(
+                self.mesh_device,
+                self.hf_config.vocab_size,
+                max_batch_size=self.batch_size_per_row,
+            )
             self.sampling_generator = SamplingGenerator(
                 args=self.sampling_args,
                 mesh_device=self.mesh_device,
@@ -486,7 +511,9 @@ class DeepseekGenerator(WarmupForwardMixin):
             logger.info("Creating model prefill config...")
             self._dump_meminfo("Before creating model prefill config...")
             self.model_prefill_cfg = RowBatchedModel.prefill_model_config(
-                hf_config=self.hf_config, mesh_device=self.mesh_device
+                hf_config=self.hf_config,
+                mesh_device=self.mesh_device,
+                batch_size_per_row=self.batch_size_per_row,
             )
             self._dump_meminfo("After creating model prefill config...")
             self._prepare_model_states(kv_cache_override=kv_cache_override)
@@ -512,7 +539,9 @@ class DeepseekGenerator(WarmupForwardMixin):
                 hasattr(self, "model_shared_state") and self.model_shared_state is not None
             ), "Model shared state must be prepared before creating decode run config. Run _prepare_run_configs('prefill') first."
             self.model_decode_cfg = RowBatchedModel.decode_model_config(
-                hf_config=self.hf_config, mesh_device=self.mesh_device
+                hf_config=self.hf_config,
+                mesh_device=self.mesh_device,
+                batch_size_per_row=self.batch_size_per_row,
             )
             self._dump_meminfo("Before creating model run config for decode...")
             self.model_run_config_decode = create_run_config(

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -150,8 +150,7 @@ class DeepseekGenerator(WarmupForwardMixin):
         mesh_device: ttnn.MeshDevice | None = None,
         model_path: str | Path | None = None,
         cache_dir: str | Path | None = None,
-        batch_size: int = USERS_PER_ROW,
-        batch_size_per_row: int | None = None,
+        batch_size_per_row: int = USERS_PER_ROW,
         tokenizer=None,
         random_weights: bool = False,
         dense_layers: int | None = None,
@@ -226,27 +225,14 @@ class DeepseekGenerator(WarmupForwardMixin):
         self.ccl = CCL(mesh_device)
         mesh_shape = list(mesh_device.shape)
         self.dp_factor = mesh_shape[1]
-        legacy_batch_size_per_row = int(batch_size)
-        if batch_size_per_row is not None and legacy_batch_size_per_row != USERS_PER_ROW:
-            if int(batch_size_per_row) != legacy_batch_size_per_row:
-                raise ValueError(
-                    "Specify only one of batch_size and batch_size_per_row; "
-                    "batch_size is a deprecated alias for batch_size_per_row."
-                )
-        resolved_batch_size_per_row = (
-            int(batch_size_per_row) if batch_size_per_row is not None else legacy_batch_size_per_row
-        )
-        if resolved_batch_size_per_row <= 0:
-            raise ValueError(f"batch_size_per_row must be > 0, got {resolved_batch_size_per_row}")
-        if resolved_batch_size_per_row > USERS_PER_ROW:
-            raise ValueError(
-                f"batch_size_per_row {resolved_batch_size_per_row} exceeds the supported maximum {USERS_PER_ROW}"
-            )
-        if resolved_batch_size_per_row % self.dp_factor != 0:
-            raise ValueError(
-                f"batch_size_per_row {resolved_batch_size_per_row} must be divisible by dp_factor={self.dp_factor}"
-            )
-        self.batch_size_per_row = resolved_batch_size_per_row
+        batch_size_per_row = int(batch_size_per_row)
+        if batch_size_per_row <= 0:
+            raise ValueError(f"batch_size_per_row must be > 0, got {batch_size_per_row}")
+        if batch_size_per_row > USERS_PER_ROW:
+            raise ValueError(f"batch_size_per_row {batch_size_per_row} exceeds the supported maximum {USERS_PER_ROW}")
+        if batch_size_per_row % self.dp_factor != 0:
+            raise ValueError(f"batch_size_per_row {batch_size_per_row} must be divisible by dp_factor={self.dp_factor}")
+        self.batch_size_per_row = batch_size_per_row
         self.batch_size = self.batch_size_per_row * self.mesh_device.shape[0]
 
         # Configure sampling
@@ -807,7 +793,7 @@ class DeepseekGenerator(WarmupForwardMixin):
 
         return tt_out
 
-    def _tokens_from_device(self, tt_out_tok, mesh_device, batch_size_per_row=USERS_PER_ROW) -> torch.Tensor:
+    def _tokens_from_device(self, tt_out_tok, mesh_device, batch_size_per_row: int) -> torch.Tensor:
         composed = ttnn.to_torch(
             tt_out_tok,
             mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(1, -1), mesh_shape=tuple(mesh_device.shape)),
@@ -2042,7 +2028,6 @@ class DeepseekGenerator(WarmupForwardMixin):
                         decode_logits = self.decode_forward(
                             tokens=next_tokens,
                             start_pos=positions,
-                            batch_size_per_row=self.batch_size_per_row,
                             profiler=profiler,
                             gen_idx=gen_idx,
                             enable_trace=self.enable_trace,
@@ -2689,7 +2674,6 @@ class DeepseekGenerator(WarmupForwardMixin):
         self,
         init_tokens: torch.Tensor,
         positions: torch.Tensor,
-        batch_size_per_row: int,
         page_tables: torch.Tensor | None = None,
     ) -> None:
         """Allocate persistent inputs, capture trace for one decode iteration, and store trace state."""
@@ -2750,7 +2734,6 @@ class DeepseekGenerator(WarmupForwardMixin):
         self,
         tokens: torch.Tensor,
         start_pos: torch.Tensor,
-        batch_size_per_row: int = USERS_PER_ROW,
         gen_idx: int = 0,
         profiler: BenchmarkProfiler | None = None,
         enable_trace: bool = False,
@@ -2767,7 +2750,7 @@ class DeepseekGenerator(WarmupForwardMixin):
         else:
             # Capture trace and return trace output
             if self._trace_id is None:
-                self._capture_decode_trace(tokens, start_pos, batch_size_per_row, page_table)
+                self._capture_decode_trace(tokens, start_pos, page_table)
                 # First call: return the captured run's output
                 assert self._trace_output is not None
 

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -175,8 +175,7 @@ class DeepseekGenerator(WarmupForwardMixin):
         self.hf_config = (
             hf_config if hf_config is not None else AutoConfig.from_pretrained(self.model_path, trust_remote_code=True)
         )
-        self._ensure_max_seq_len(self.hf_config)
-        model_max_seq_len = int(self.hf_config.max_seq_len)
+        model_max_seq_len = int(self.hf_config.max_position_embeddings)
         requested_max_seq_len = MAX_SEQ_LEN if max_seq_len is None else int(max_seq_len)
         if requested_max_seq_len <= 0:
             raise ValueError(f"max_seq_len must be > 0, got {requested_max_seq_len}")
@@ -404,32 +403,6 @@ class DeepseekGenerator(WarmupForwardMixin):
     def _dump_meminfo(self, header: str) -> None:
         if self.enable_mem_profile:
             dump_ttnn_meminfo(self.mesh_device, header=header)
-
-    @staticmethod
-    def _ensure_max_seq_len(hf_config) -> None:
-        if getattr(hf_config, "max_seq_len", None) is not None:
-            return
-        try:
-            max_pos = getattr(hf_config, "max_position_embeddings", None)
-            scaled = None
-            if getattr(hf_config, "rope_scaling", None):
-                factor = hf_config.rope_scaling.get("factor")
-                orig = hf_config.rope_scaling.get("original_max_position_embeddings")
-                if factor and orig:
-                    scaled = int(factor * orig)
-            if max_pos is not None and scaled is not None:
-                # Prefer the larger of the declared max_position_embeddings and the rope-scaled length.
-                hf_config.max_seq_len = int(max(max_pos, scaled))
-                return
-            if scaled is not None:
-                hf_config.max_seq_len = int(scaled)
-                return
-            if max_pos is not None:
-                hf_config.max_seq_len = int(max_pos)
-                return
-        except Exception:
-            pass
-        hf_config.max_seq_len = 4096
 
     def _prepare_weight_configs(self, cache_dir: str | Path | None) -> None:
         weight_cache_base = Path(cache_dir) if cache_dir is not None else Path("generated/deepseek_v3")

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -39,8 +39,6 @@ from models.demos.deepseek_v3.utils.weight_config import get_weight_config
 from models.perf.benchmarking_utils import BenchmarkProfiler
 
 DEFAULT_MAX_SEQ_LEN = 2048
-# Backward-compatible alias used by MTP tests and older call sites.
-MAX_SEQ_LEN = DEFAULT_MAX_SEQ_LEN
 
 
 def _build_verify_alias_page_table_host(

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -39,6 +39,8 @@ from models.demos.deepseek_v3.utils.weight_config import get_weight_config
 from models.perf.benchmarking_utils import BenchmarkProfiler
 
 DEFAULT_MAX_SEQ_LEN = 2048
+# Backward-compatible alias used by MTP tests and older call sites.
+MAX_SEQ_LEN = DEFAULT_MAX_SEQ_LEN
 
 
 def _build_verify_alias_page_table_host(

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -33,7 +33,7 @@ from models.demos.deepseek_v3.utils.run_config import create_run_config
 from models.demos.deepseek_v3.utils.weight_config import get_weight_config
 from models.perf.benchmarking_utils import BenchmarkProfiler
 
-MAX_SEQ_LEN = 2048
+MAX_SEQ_LEN = 32768
 
 
 def _build_verify_alias_page_table_host(
@@ -175,11 +175,25 @@ class DeepseekGenerator(WarmupForwardMixin):
         self.hf_config = (
             hf_config if hf_config is not None else AutoConfig.from_pretrained(self.model_path, trust_remote_code=True)
         )
-        # Hard-code the context length to keep KV cache + RoPE tables bounded.
-        # (Avoid env var overrides; long-context runs should change this constant in code.)
-        if max_seq_len is not None and int(max_seq_len) != MAX_SEQ_LEN:
-            logger.warning(f"Ignoring requested max_seq_len={max_seq_len}; using MAX_SEQ_LEN={MAX_SEQ_LEN}.")
-        self.hf_config.max_seq_len = MAX_SEQ_LEN
+        self._ensure_max_seq_len(self.hf_config)
+        model_max_seq_len = int(self.hf_config.max_seq_len)
+        requested_max_seq_len = MAX_SEQ_LEN if max_seq_len is None else int(max_seq_len)
+        if requested_max_seq_len <= 0:
+            raise ValueError(f"max_seq_len must be > 0, got {requested_max_seq_len}")
+        if requested_max_seq_len % ttnn.TILE_SIZE != 0:
+            raise ValueError(f"max_seq_len {requested_max_seq_len} must be divisible by TILE_SIZE={ttnn.TILE_SIZE}")
+        if requested_max_seq_len > model_max_seq_len:
+            raise ValueError(
+                f"max_seq_len {requested_max_seq_len} exceeds model-supported context length {model_max_seq_len}"
+            )
+        if requested_max_seq_len != MAX_SEQ_LEN:
+            logger.warning(
+                "Using overridden max_seq_len={} (default={}, model supports up to {}).",
+                requested_max_seq_len,
+                MAX_SEQ_LEN,
+                model_max_seq_len,
+            )
+        self.hf_config.max_seq_len = requested_max_seq_len
         # Optional overrides for layer counts before building states
         if override_num_layers is not None:
             try:
@@ -824,6 +838,27 @@ class DeepseekGenerator(WarmupForwardMixin):
             mesh_composer=ttnn.ConcatMesh2dToTensor(self.mesh_device, dims=(-2, -1), mesh_shape=self.mesh_device.shape),
         )
         return self._normalize_hidden_host_for_mtp(hidden)
+
+    def _tt_from_positions(self, positions: torch.Tensor) -> Tuple[dict, ttnn.Tensor]:
+        """Return rope tensors dict and TTNN positions shard for decode.
+
+        positions: [B] int tensor
+        returns: (rope_tensors, tt_positions)
+        """
+        rope_mats = self.rope_setup.get_rot_mats_table(seq_len=1)
+        rope_tensors = {
+            "cos_matrix": rope_mats["cos_matrix"],
+            "sin_matrix": rope_mats["sin_matrix"],
+            "trans_matrix": rope_mats["trans_matrix"],
+        }
+
+        tt_positions = ttnn.from_torch(
+            positions.to(torch.int32),
+            device=self.mesh_device,
+            mesh_mapper=ttnn.ShardTensorToMesh(self.mesh_device, dim=0),
+            dtype=ttnn.int32,
+        )
+        return rope_tensors, tt_positions
 
     def _iter_decode_mla_cfgs(self):
         for block_cfg in self.model_run_config_decode["mlp_decoder_block"]:

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -26,6 +26,7 @@ from models.demos.deepseek_v3.tt.model.row_batched_model import RowBatchedModel
 from models.demos.deepseek_v3.tt.rope import RotarySetup
 from models.demos.deepseek_v3.utils.config_dataclass import KvCacheConfig
 from models.demos.deepseek_v3.utils.config_helpers import (
+    DEFAULT_MAX_SEQ_LEN,
     DEFAULT_SAMPLING_TEMPERATURE,
     DEFAULT_SAMPLING_TOP_K,
     DEFAULT_SAMPLING_TOP_P,
@@ -37,8 +38,6 @@ from models.demos.deepseek_v3.utils.debug_utils import dump_ttnn_meminfo
 from models.demos.deepseek_v3.utils.run_config import create_run_config
 from models.demos.deepseek_v3.utils.weight_config import get_weight_config
 from models.perf.benchmarking_utils import BenchmarkProfiler
-
-DEFAULT_MAX_SEQ_LEN = 2048
 
 
 def _build_verify_alias_page_table_host(

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -865,27 +865,6 @@ class DeepseekGenerator(WarmupForwardMixin):
         )
         return self._normalize_hidden_host_for_mtp(hidden)
 
-    def _tt_from_positions(self, positions: torch.Tensor) -> Tuple[dict, ttnn.Tensor]:
-        """Return rope tensors dict and TTNN positions shard for decode.
-
-        positions: [B] int tensor
-        returns: (rope_tensors, tt_positions)
-        """
-        rope_mats = self.rope_setup.get_rot_mats_table(seq_len=1)
-        rope_tensors = {
-            "cos_matrix": rope_mats["cos_matrix"],
-            "sin_matrix": rope_mats["sin_matrix"],
-            "trans_matrix": rope_mats["trans_matrix"],
-        }
-
-        tt_positions = ttnn.from_torch(
-            positions.to(torch.int32),
-            device=self.mesh_device,
-            mesh_mapper=ttnn.ShardTensorToMesh(self.mesh_device, dim=0),
-            dtype=ttnn.int32,
-        )
-        return rope_tensors, tt_positions
-
     def _iter_decode_mla_cfgs(self):
         for block_cfg in self.model_run_config_decode["mlp_decoder_block"]:
             yield block_cfg["mla"]["mla1d"]

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -13,7 +13,12 @@ from tracy import signpost
 from transformers import AutoConfig
 
 import ttnn
-from models.common.sampling.generator import SamplingGenerator, SamplingParams, format_sampling_params
+from models.common.sampling.generator import (
+    SamplingGenerator,
+    SamplingParams,
+    chunk_sampling_params,
+    format_sampling_params,
+)
 from models.common.warmup import WarmupForwardMixin
 from models.demos.deepseek_v3.tt.ccl import CCL
 from models.demos.deepseek_v3.tt.mla.mla2d import MLA2D
@@ -227,6 +232,8 @@ class DeepseekGenerator(WarmupForwardMixin):
         batch_size_per_row = int(batch_size_per_row)
         if batch_size_per_row <= 0:
             raise ValueError(f"batch_size_per_row must be > 0, got {batch_size_per_row}")
+        if batch_size_per_row > USERS_PER_ROW:
+            raise ValueError(f"batch_size_per_row {batch_size_per_row} exceeds the supported maximum {USERS_PER_ROW}")
         if batch_size_per_row % self.dp_factor != 0:
             raise ValueError(f"batch_size_per_row {batch_size_per_row} must be divisible by dp_factor={self.dp_factor}")
         self.batch_size_per_row = batch_size_per_row
@@ -741,19 +748,52 @@ class DeepseekGenerator(WarmupForwardMixin):
     def _reset_sampling_state(self, sampling_params: SamplingParams, batch_size: int, batch_size_per_row: int) -> None:
         # TODO(vllm): Thread prompt/output token state into sampling resets for penalty correctness.
         sampling_params = format_sampling_params(sampling_params, max_batch_size=batch_size)
-        self.sampling_generator.reset_sampling_params(sampling_params)
+        sampling_dp = self.sampling_generator.tt_sampling._sampling_dp
+        sampling_param_chunks = chunk_sampling_params(sampling_params, sampling_dp)
         seed = getattr(sampling_params, "seed", None)
-        user_ids = list(range(batch_size))
-        self.sampling_generator.seed_manager.reset_seed(seed, user_ids)
-        self.sampling_generator.reset_prompt_tokens(torch.zeros((batch_size_per_row, 1), dtype=torch.int64))
-        self.sampling_generator.reset_output_state(torch.zeros((batch_size_per_row, 1), dtype=torch.int64))
+        if seed is not None:
+            user_ids = list(range(batch_size))
+            self.sampling_generator.seed_manager.reset_seed(seed, user_ids)
+        self.sampling_generator.apply_decode_state(
+            sampling_param_chunks,
+            reset_batch=True,
+            prompt_tokens=torch.zeros((batch_size_per_row, 1), dtype=torch.int64),
+            output_tokens=torch.zeros((batch_size_per_row, 1), dtype=torch.int64),
+        )
 
     def _sample_tokens_device(
         self, logits: ttnn.Tensor, enable_trace: bool = False, user_slots: list[int] | None = None
     ) -> ttnn.Tensor:
+        sampling_batch_size = self.sampling_generator.tt_sampling.max_batch_size
+        sampling_logits = logits
+        if logits.shape[2] != sampling_batch_size:
+            if enable_trace:
+                raise ValueError(
+                    f"Device sampling trace requires logits batch {sampling_batch_size}, got {logits.shape[2]}"
+                )
+            if logits.shape[2] <= 0 or logits.shape[2] > sampling_batch_size:
+                raise ValueError(
+                    f"Device sampling expects logits batch in [1, {sampling_batch_size}], got {logits.shape[2]}"
+                )
+            # Sampling kernels operate on the padded per-row batch size. Append filler rows so
+            # smaller decode/prefill batches can reuse the same device sampling path.
+            filler_row = ttnn.slice(
+                logits,
+                [0, 0, logits.shape[2] - 1, 0],
+                [1, 1, logits.shape[2], logits.shape[-1]],
+            )
+            filler = ttnn.repeat(filler_row, (1, 1, sampling_batch_size - logits.shape[2], 1))
+            ttnn.deallocate(filler_row)
+            sampling_logits = ttnn.concat([logits, filler], dim=2)
+            ttnn.deallocate(filler)
+
         self.sampling_generator.seed_manager.get_new_values(user_slots)
         self.sampling_generator.enable_internal_trace = enable_trace
-        tt_out = self.sampling_generator.sample(logits, enable_trace=enable_trace)
+        try:
+            tt_out = self.sampling_generator.sample(sampling_logits, enable_trace=enable_trace)
+        finally:
+            if sampling_logits is not logits:
+                ttnn.deallocate(sampling_logits)
 
         if isinstance(tt_out, tuple):
             tt_tokens, tt_log_probs = tt_out

--- a/models/demos/deepseek_v3/tt/generator_vllm.py
+++ b/models/demos/deepseek_v3/tt/generator_vllm.py
@@ -69,6 +69,7 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
             model_path=Path(model_path),
             cache_dir=Path(cache_dir),
             tokenizer=tokenizer,
+            max_seq_len=max_seq_len,
         )
 
         return model

--- a/models/demos/deepseek_v3/tt/generator_vllm.py
+++ b/models/demos/deepseek_v3/tt/generator_vllm.py
@@ -190,7 +190,6 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
         decode_step_output = super().decode_forward(
             tokens=tokens_step,
             start_pos=kwargs["start_pos"],
-            batch_size_per_row=USERS_PER_ROW,
             enable_trace=enable_trace,
             page_table=page_tables,
             sample_on_device=sample_on_device,

--- a/models/demos/deepseek_v3/tt/mla/mla1d.py
+++ b/models/demos/deepseek_v3/tt/mla/mla1d.py
@@ -1077,14 +1077,6 @@ class MLA1D(AbstractModule):
             out_dim=1,
         )
 
-        wq_a2a_reshard_out_mem_config = ttnn.create_sharded_memory_config(
-            shape=(batch_size_per_row, num_heads, kv_lora_rank + qk_rope_head_dim),
-            core_grid=ttnn.CoreGrid(y=8, x=8),
-            strategy=ttnn.ShardStrategy.HEIGHT,
-        )
-        wq_a2a_reshard_config = ReshardConfig(
-            memory_config=wq_a2a_reshard_out_mem_config,
-        )  # 1,4,128,576, height sharded 8x8 [32,576]
         # Slice configs for fused wq_kv_a output: [q_lora_rank | kv_lora_rank | qk_rope_head_dim]
         # Q and KV nope use non-overlapping core grids, but keep this decode path
         # on the pre-40275 merged-descriptor dispatch as a temporary workaround.

--- a/models/demos/deepseek_v3/tt/mla/mla1d.py
+++ b/models/demos/deepseek_v3/tt/mla/mla1d.py
@@ -30,6 +30,7 @@ from models.demos.deepseek_v3.utils.config_dataclass import (
     SavedWeight,
     SliceConfig,
 )
+from models.demos.deepseek_v3.utils.config_helpers import SEQ_LEN_CHUNK_SIZE as DEFAULT_SEQ_LEN_CHUNK_SIZE
 from models.demos.deepseek_v3.utils.config_helpers import (
     USERS_PER_ROW,
     even_int_div,
@@ -1751,28 +1752,84 @@ class MLA1D(AbstractModule):
         ttnn.deallocate(tt_q)
         ttnn.deallocate(tt_kvpe)
 
-        # DP wkv_b2 to match decode weights
-        v_out = ttnn.experimental.all_gather_async(
-            attn_out, **ccl.populate_all_gather_runtime_args(cfg["wkv_b2_ag_prefill"])
-        )  # [1, num_heads, seq_len, v_head_dim] # wkv_b2_ag_prefill
-
-        # wkv_b2 (interleaved in0 + DRAM HEIGHT sharded in1)
-        # Pad batch dimension to match DRAM sharded weight layout
+        # DP wkv_b2 to match decode weights.
+        # Chunk sequence for all_gather to avoid single giant output allocations at 8K+ prefill.
+        wkv_b2_ag_prefill_runtime_args = ccl.populate_all_gather_runtime_args(cfg["wkv_b2_ag_prefill"])
         num_heads_padded = pad_batch_to_dram_banks(num_heads)
 
-        wkv_b2_program_config = build_prefill_matmul_program_config(
-            seq_len,
-            k=kv_lora_rank,
-            n=v_head_dim,
-            batch=num_heads_padded,
-            mesh_device=cfg[MESH_DEVICE_STATE_DICT_KEY],
-        )
-        v_out = ttnn.linear(
-            v_out, **cfg["wkv_b2"], program_config=wkv_b2_program_config
-        )  # [1, num_heads_padded, seq_len, v_head_dim]
-        ttnn.deallocate(attn_out)
+        def _run_wkv_b2_prefill_matmul(v_out_chunk_ag: ttnn.Tensor, chunk_seq_len: int) -> ttnn.Tensor:
+            padded_chunk_seq_len = nearest_y(chunk_seq_len, ttnn.TILE_SIZE)
+            v_out_chunk_input = v_out_chunk_ag
+            if padded_chunk_seq_len != chunk_seq_len:
+                v_out_chunk_input = ttnn.pad(
+                    v_out_chunk_ag,
+                    padding=((0, 0), (0, 0), (0, padded_chunk_seq_len - chunk_seq_len), (0, 0)),
+                    value=0.0,
+                )
 
-        # Slice off batch padding from wkv_b2 output
+            wkv_b2_program_config = build_prefill_matmul_program_config(
+                padded_chunk_seq_len,
+                k=kv_lora_rank,
+                n=v_head_dim,
+                batch=num_heads_padded,
+                mesh_device=cfg[MESH_DEVICE_STATE_DICT_KEY],
+            )
+            v_out_chunk = ttnn.linear(v_out_chunk_input, **cfg["wkv_b2"], program_config=wkv_b2_program_config)
+
+            if v_out_chunk_input is not v_out_chunk_ag:
+                ttnn.deallocate(v_out_chunk_input)
+                trimmed_v_out_chunk = ttnn.slice(
+                    v_out_chunk,
+                    (0, 0, 0, 0),
+                    (1, v_out_chunk.shape[1], chunk_seq_len, v_head_dim),
+                )
+                ttnn.deallocate(v_out_chunk)
+                v_out_chunk = trimmed_v_out_chunk
+
+            return v_out_chunk
+
+        # This all-gather materializes [1, num_heads, chunk_seq_len, kv_lora_rank] in DRAM.
+        # Large prefills can OOM here, so keep the chunk size configurable and conservative.
+        WKV_B2_AG_SEQ_CHUNK_SIZE = int(os.getenv("DEEPSEEK_WKV_B2_AG_PREFILL_CHUNK_SIZE", "2048"))
+        if WKV_B2_AG_SEQ_CHUNK_SIZE <= 0:
+            WKV_B2_AG_SEQ_CHUNK_SIZE = 2048
+        if seq_len > WKV_B2_AG_SEQ_CHUNK_SIZE:
+            num_chunks = (seq_len + WKV_B2_AG_SEQ_CHUNK_SIZE - 1) // WKV_B2_AG_SEQ_CHUNK_SIZE
+            v_out_chunks = []
+            for chunk_idx in range(num_chunks):
+                start = chunk_idx * WKV_B2_AG_SEQ_CHUNK_SIZE
+                end = min(start + WKV_B2_AG_SEQ_CHUNK_SIZE, seq_len)
+                attn_out_chunk = ttnn.slice(
+                    attn_out,
+                    (0, 0, start, 0),
+                    (1, num_heads_local, end, kv_lora_rank),
+                )  # [1, num_heads_local, chunk_seq_len, kv_lora_rank]
+                v_out_chunk_ag = ttnn.experimental.all_gather_async(
+                    attn_out_chunk, **wkv_b2_ag_prefill_runtime_args
+                )  # [1, num_heads, chunk_seq_len, kv_lora_rank]
+                ttnn.deallocate(attn_out_chunk)
+
+                # wkv_b2
+                v_out_chunk = _run_wkv_b2_prefill_matmul(v_out_chunk_ag, end - start)
+                ttnn.deallocate(v_out_chunk_ag)
+                v_out_chunks.append(v_out_chunk)
+
+            ttnn.deallocate(attn_out)
+            if len(v_out_chunks) == 1:
+                v_out = v_out_chunks[0]
+            else:
+                v_out = ttnn.concat(v_out_chunks, dim=2)  # [1, num_heads, seq_len, v_head_dim]
+                for v_chunk in v_out_chunks:
+                    ttnn.deallocate(v_chunk)
+        else:
+            v_out_ag = ttnn.experimental.all_gather_async(
+                attn_out, **wkv_b2_ag_prefill_runtime_args
+            )  # [1, num_heads, seq_len, v_head_dim] # wkv_b2_ag_prefill
+
+            # wkv_b2
+            v_out = _run_wkv_b2_prefill_matmul(v_out_ag, seq_len)
+            ttnn.deallocate(v_out_ag)
+            ttnn.deallocate(attn_out)
 
         # Permute BEFORE all_gather to avoid large tensor permute at 32K+ seq_len
         v_out = ttnn.permute(v_out, (0, 2, 1, 3))  # [1, seq_len, num_heads_local, v_head_dim]
@@ -1783,46 +1840,53 @@ class MLA1D(AbstractModule):
         wo_k = num_heads * v_head_dim
         dim = x.shape[3]
 
-        SEQ_LEN_CHUNK_SIZE = 8192
-        if seq_len > SEQ_LEN_CHUNK_SIZE:
+        wo_prefill_seq_chunk_size = int(os.getenv("DEEPSEEK_WO_PREFILL_CHUNK_SIZE", str(DEFAULT_SEQ_LEN_CHUNK_SIZE)))
+        if wo_prefill_seq_chunk_size <= 0:
+            wo_prefill_seq_chunk_size = DEFAULT_SEQ_LEN_CHUNK_SIZE
+        if seq_len > wo_prefill_seq_chunk_size:
             num_heads = v_out.shape[2]
             v_head_dim = v_out.shape[3]
-            # Use ceiling division instead of even_int_div to handle non-multiples of 8192
-            num_chunks = (seq_len + SEQ_LEN_CHUNK_SIZE - 1) // SEQ_LEN_CHUNK_SIZE
-
-            # Pad seq_len to be a multiple of SEQ_LEN_CHUNK_SIZE if needed
-            padded_seq_len = num_chunks * SEQ_LEN_CHUNK_SIZE
-            if seq_len != padded_seq_len:
-                # Pad the sequence dimension (dim=1)
-                v_out = ttnn.pad(v_out, padding=((0, 0), (0, padded_seq_len - seq_len), (0, 0), (0, 0)), value=0.0)
-
-            wo_chunk_program_config = build_prefill_matmul_program_config(
-                SEQ_LEN_CHUNK_SIZE, k=wo_k, n=dim, mesh_device=cfg[MESH_DEVICE_STATE_DICT_KEY]
-            )
+            num_chunks = (seq_len + wo_prefill_seq_chunk_size - 1) // wo_prefill_seq_chunk_size
 
             output_chunks = []
             hidden_dim = num_heads * v_head_dim
             for chunk_idx in range(num_chunks):
-                start = chunk_idx * SEQ_LEN_CHUNK_SIZE
-                end = start + SEQ_LEN_CHUNK_SIZE
+                start = chunk_idx * wo_prefill_seq_chunk_size
+                end = min(start + wo_prefill_seq_chunk_size, seq_len)
                 v_chunk = ttnn.slice(v_out, (0, start, 0, 0), (1, end, num_heads, v_head_dim))
-                v_chunk = ttnn.reshape(v_chunk, (1, 1, SEQ_LEN_CHUNK_SIZE, hidden_dim))
+                chunk_seq_len = end - start
+                padded_chunk_seq_len = nearest_y(chunk_seq_len, ttnn.TILE_SIZE)
+                if padded_chunk_seq_len != chunk_seq_len:
+                    v_chunk = ttnn.pad(
+                        v_chunk,
+                        padding=((0, 0), (0, padded_chunk_seq_len - chunk_seq_len), (0, 0), (0, 0)),
+                        value=0.0,
+                    )
+                v_chunk = ttnn.reshape(v_chunk, (1, 1, padded_chunk_seq_len, hidden_dim))
+                wo_chunk_program_config = build_prefill_matmul_program_config(
+                    padded_chunk_seq_len,
+                    k=wo_k,
+                    n=dim,
+                    mesh_device=cfg[MESH_DEVICE_STATE_DICT_KEY],
+                )
                 out_chunk = ttnn.linear(
                     v_chunk, **cfg["wo"], program_config=wo_chunk_program_config
                 )  # [1, 1, chunk_size, dim]
-                output_chunks.append(out_chunk)
                 ttnn.deallocate(v_chunk)
+                if padded_chunk_seq_len != chunk_seq_len:
+                    trimmed_out_chunk = ttnn.slice(out_chunk, (0, 0, 0, 0), (1, 1, chunk_seq_len, dim))
+                    ttnn.deallocate(out_chunk)
+                    out_chunk = trimmed_out_chunk
+                output_chunks.append(out_chunk)
 
             ttnn.deallocate(v_out)
 
-            out = ttnn.concat(output_chunks, dim=2)
-            output_dim = out.shape[3]
-            for chunk in output_chunks:
-                ttnn.deallocate(chunk)
-
-            # Trim padding if we added any
-            if seq_len != padded_seq_len:
-                out = ttnn.slice(out, (0, 0, 0, 0), (1, 1, seq_len, output_dim))
+            if len(output_chunks) == 1:
+                out = output_chunks[0]
+            else:
+                out = ttnn.concat(output_chunks, dim=2)
+                for chunk in output_chunks:
+                    ttnn.deallocate(chunk)
         else:
             # For non-chunked case: [1, seq_len, num_heads, v_head_dim] -> [1, 1, seq_len, hidden_dim]
             v_out = ttnn.reshape(v_out, (1, 1, seq_len, num_heads * v_head_dim))
@@ -1846,6 +1910,13 @@ class MLA1D(AbstractModule):
         qk_rope_head_dim: int,
     ) -> tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor]:
         # Shard in0 to L1 WIDTH sharded for qkv_a matmul
+        x_shard_shape = list(x.shape)
+        x_shard_shape[-2] = ttnn.core.roundup(x_shard_shape[-2], ttnn.TILE_SIZE)
+        in0_memory_config = ttnn.create_sharded_memory_config(
+            x_shard_shape,
+            **cfg["wq_kv_a_in0_memory_config"],
+        )
+        x = ttnn.to_memory_config(x, memory_config=in0_memory_config)
 
         # Fused wq_kv_a matmul
         # 1,1,32,896, width sharded 7x4 [32,32]
@@ -2040,9 +2111,18 @@ class MLA1D(AbstractModule):
         qk_head_dim: int,
         qk_nope_head_dim: int,
     ) -> ttnn.Tensor:
+        pad_rows = 0
+        padded_bsz = bsz
+        if tt_q.shape[-2] < ttnn.TILE_SIZE:
+            pad_rows = ttnn.TILE_SIZE - tt_q.shape[-2]
+            padded_bsz = tt_q.shape[-2] + pad_rows
+            tt_q = ttnn.pad(tt_q, padding=((0, 0), (0, 0), (0, pad_rows), (0, 0)), value=0.0)
+
         # Shard in0 to L1 WIDTH sharded for wq_b matmul
+        tt_q_shard_shape = list(tt_q.shape)
+        tt_q_shard_shape[-2] = ttnn.core.roundup(tt_q_shard_shape[-2], ttnn.TILE_SIZE)
         wq_b_in0_memory_config = ttnn.create_sharded_memory_config(
-            tt_q.shape,
+            tt_q_shard_shape,
             **cfg["wq_b_in0_memory_config"],
         )
         tt_q = ttnn.to_memory_config(tt_q, memory_config=wq_b_in0_memory_config)
@@ -2062,7 +2142,7 @@ class MLA1D(AbstractModule):
                 ),
             ),
         )
-        tt_q = ttnn.experimental.view(tt_q, (1, bsz, num_heads_local, qk_head_dim))
+        tt_q = ttnn.experimental.view(tt_q, (1, padded_bsz, num_heads_local, qk_head_dim))
         tt_q = ttnn.to_memory_config(tt_q, memory_config=ttnn.L1_MEMORY_CONFIG)
         tt_q = ttnn.tilize_with_zero_padding(tt_q)
 
@@ -2101,6 +2181,8 @@ class MLA1D(AbstractModule):
         # Concat Q Nope and Q Rope
         # 1,32,16,512 L1 interleaved | # 1,32,16,64 L1 interleaved
         tt_q = ttnn.concat([tt_q_nope, tt_q_rope], **cfg["q_concat"])
+        if pad_rows:
+            tt_q = ttnn.slice(tt_q, [0, 0, 0, 0], [1, bsz, num_heads_local, tt_q.shape[-1]])
         # 1,32,16,576 L1 interleaved
         return tt_q
 
@@ -2175,19 +2257,24 @@ class MLA1D(AbstractModule):
         v_out = ttnn.untilize(v_out)
         v_out = ttnn.experimental.view(v_out, (1, 1, bsz // mesh_shape[1], num_heads * v_head_dim))
         # All_gather
-        wo_in0_memory_config = ttnn.create_sharded_memory_config(
-            (1, 1, bsz, num_heads * v_head_dim),
-            **cfg["wo_in0_memory_config"],
-        )
+        v_out = ttnn.to_memory_config(v_out, memory_config=ttnn.L1_MEMORY_CONFIG)
         v_out = ttnn.experimental.all_gather_async(v_out, **ccl.populate_all_gather_runtime_args(cfg["wo_ag_decode"]))
         v_out = ttnn.tilize(v_out)
-        v_out = ttnn.to_memory_config(v_out, memory_config=wo_in0_memory_config)
         # 1,1,32,16384 WIDTH sharded 2x8 [32,1024]
 
         return v_out
 
     @classmethod
     def _fwd_decode_wo(cls, v_out: ttnn.Tensor, cfg: RunDecodeConfig) -> ttnn.Tensor:
+        # 1,1,32,16384 L1 interleaved
+        # Shard in0 to L1 WIDTH sharded for wo matmul
+        v_out_shard_shape = list(v_out.shape)
+        v_out_shard_shape[-2] = ttnn.core.roundup(v_out_shard_shape[-2], ttnn.TILE_SIZE)
+        wo_in0_memory_config = ttnn.create_sharded_memory_config(
+            v_out_shard_shape,
+            **cfg["wo_in0_memory_config"],
+        )
+        v_out = ttnn.to_memory_config(v_out, memory_config=wo_in0_memory_config)
         out = ttnn.linear(v_out, **cfg["wo"])  # [1, 1, bsz, dim]
         # 1,1,32,896 WIDTH sharded 2x6 [32,96]
         return out

--- a/models/demos/deepseek_v3/tt/mla/mla1d.py
+++ b/models/demos/deepseek_v3/tt/mla/mla1d.py
@@ -2309,8 +2309,14 @@ class MLA1D(AbstractModule):
         # Fused wq_kv_a matmul (interleaved in0 + DRAM WIDTH sharded in1)
         dim = x.shape[3]
         qkv_a_n = q_lora_rank + kv_lora_rank + qk_rope_head_dim
+        # Row-batched prefill drives the fused Q/KV projection with batch on dim 1.
+        # The program config must account for that batch so fuse_batch stays disabled.
         wq_kv_a_program_config = build_prefill_matmul_program_config(
-            seq_len, k=dim, n=qkv_a_n, mesh_device=cfg[MESH_DEVICE_STATE_DICT_KEY]
+            seq_len,
+            k=dim,
+            n=qkv_a_n,
+            batch=x.shape[1],
+            mesh_device=cfg[MESH_DEVICE_STATE_DICT_KEY],
         )
         tt_q_kv = ttnn.linear(x, **cfg["wq_kv_a"], program_config=wq_kv_a_program_config)
 

--- a/models/demos/deepseek_v3/tt/mla/mla1d.py
+++ b/models/demos/deepseek_v3/tt/mla/mla1d.py
@@ -1804,8 +1804,9 @@ class MLA1D(AbstractModule):
         # This all-gather materializes [1, num_heads, chunk_seq_len, kv_lora_rank] in DRAM.
         # Large prefills can OOM here, so keep the chunk size configurable and conservative.
         WKV_B2_AG_SEQ_CHUNK_SIZE = int(os.getenv("DEEPSEEK_WKV_B2_AG_PREFILL_CHUNK_SIZE", "2048"))
-        if WKV_B2_AG_SEQ_CHUNK_SIZE <= 0:
-            WKV_B2_AG_SEQ_CHUNK_SIZE = 2048
+        assert WKV_B2_AG_SEQ_CHUNK_SIZE > 0, (
+            "DEEPSEEK_WKV_B2_AG_PREFILL_CHUNK_SIZE must be > 0, " f"got {WKV_B2_AG_SEQ_CHUNK_SIZE}"
+        )
         if seq_len > WKV_B2_AG_SEQ_CHUNK_SIZE:
             num_chunks = (seq_len + WKV_B2_AG_SEQ_CHUNK_SIZE - 1) // WKV_B2_AG_SEQ_CHUNK_SIZE
             v_out_chunks = []

--- a/models/demos/deepseek_v3/tt/mla/mla1d.py
+++ b/models/demos/deepseek_v3/tt/mla/mla1d.py
@@ -612,6 +612,7 @@ class MLA1D(AbstractModule):
         cls,
         hf_config: PretrainedConfig,
         mesh_device: ttnn.Device,
+        batch_size_per_row: int = USERS_PER_ROW,
     ) -> ModelDecodeConfig:
         """Generate decode operator configuration for this MLP layer.
 
@@ -642,7 +643,7 @@ class MLA1D(AbstractModule):
 
         input_memory_config = ttnn.create_sharded_memory_config(
             shape=(
-                ttnn.core.roundup(USERS_PER_ROW, ttnn.TILE_SIZE),
+                ttnn.core.roundup(batch_size_per_row, ttnn.TILE_SIZE),
                 hidden_size_per_device,
             ),
             core_grid=ttnn.CoreGrid(y=7, x=4),
@@ -676,7 +677,7 @@ class MLA1D(AbstractModule):
         qkv_a_num_in0_cores = qkv_a_in0_core_grid.x * qkv_a_in0_core_grid.y
         qkv_a_num_out_cores = qkv_a_out_core_grid.x * qkv_a_out_core_grid.y
         qkv_a_in0_block_w = even_int_div(hidden_size_per_device, qkv_a_num_in0_cores * tile_size)  # 896 // 7 // 32 = 4
-        qkv_a_per_core_M = math.ceil(USERS_PER_ROW / tile_size)  # ceil(32 / 32) = 1
+        qkv_a_per_core_M = math.ceil(batch_size_per_row / tile_size)
         qkv_a_per_core_N = even_int_div(qkv_a_n_padded, qkv_a_num_out_cores * tile_size)  # 2304 // 8 // 32 = 9
 
         qkv_a_program_config = ttnn.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig(
@@ -718,7 +719,7 @@ class MLA1D(AbstractModule):
         wq_b_num_in0_cores = wq_b_in0_core_grid.x * wq_b_in0_core_grid.y
         wq_b_num_out_cores = wq_b_out_core_grid.x * wq_b_out_core_grid.y
         wq_b_in0_block_w = even_int_div(q_lora_rank, wq_b_num_in0_cores * tile_size)  # 1536 // 16 // 32 = 3
-        wq_b_per_core_M = math.ceil(USERS_PER_ROW / tile_size)  # ceil(32 / 32) = 1
+        wq_b_per_core_M = math.ceil(batch_size_per_row / tile_size)
         wq_b_per_core_N = even_int_div(wq_b_n_padded, wq_b_num_out_cores * tile_size)  # 3072 // 16 // 32 = 6
 
         wq_b_program_config = ttnn.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig(
@@ -751,7 +752,7 @@ class MLA1D(AbstractModule):
         # =====================================================================
         wkv_b1_batch = num_heads_local  # 16
         wkv_b1_batch_padded = pad_batch_to_dram_banks(wkv_b1_batch)  # 24
-        wkv_b1_m = ttnn.core.roundup(USERS_PER_ROW, tile_size)  # roundup(32, 32) = 32
+        wkv_b1_m = ttnn.core.roundup(batch_size_per_row, tile_size)
         wkv_b1_k = qk_nope_head_dim  # 128
         wkv_b1_n = kv_lora_rank  # 512
 
@@ -880,7 +881,7 @@ class MLA1D(AbstractModule):
         wo_num_in0_cores = wo_in0_core_grid.x * wo_in0_core_grid.y
         wo_num_out_cores = wo_out_core_grid.x * wo_out_core_grid.y
         wo_in0_block_w = even_int_div(wo_k, wo_num_in0_cores * tile_size)  # 16384 // 16 // 32 = 32
-        wo_per_core_M = math.ceil(USERS_PER_ROW / tile_size)  # ceil(32 / 32) = 1
+        wo_per_core_M = math.ceil(batch_size_per_row / tile_size)
         wo_per_core_N = even_int_div(wo_n_padded, wo_num_out_cores * tile_size)  # 1152 // 12 // 32 = 3
 
         wo_program_config = ttnn.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig(
@@ -908,7 +909,7 @@ class MLA1D(AbstractModule):
         )
 
         # Resharding for q_rope
-        q_rope_shape = (1, USERS_PER_ROW, num_heads_local, qk_rope_head_dim)
+        q_rope_shape = (1, batch_size_per_row, num_heads_local, qk_rope_head_dim)
         q_rope_shard_height = nearest_y(q_rope_shape[2], ttnn.TILE_SIZE)
         q_rope_shard_width = q_rope_shape[3]
         q_rope_num_cores = q_rope_shape[1]
@@ -934,7 +935,7 @@ class MLA1D(AbstractModule):
         )
 
         # Resharding for kv_rope
-        kv_rope_shape = (1, USERS_PER_ROW, 1, qk_rope_head_dim)
+        kv_rope_shape = (1, batch_size_per_row, 1, qk_rope_head_dim)
         kv_rope_shard_height = nearest_y(kv_rope_shape[2], ttnn.TILE_SIZE)
         kv_rope_shard_width = kv_rope_shape[3]
         kv_rope_num_cores = kv_rope_shape[1]
@@ -961,7 +962,7 @@ class MLA1D(AbstractModule):
         )
 
         # Resharding for kvpe
-        kvpe_shape = (1, even_int_div(USERS_PER_ROW, mesh_shape[1]), 1, kv_lora_rank + qk_rope_head_dim)
+        kvpe_shape = (1, even_int_div(batch_size_per_row, mesh_shape[1]), 1, kv_lora_rank + qk_rope_head_dim)
         kvpe_shard_height = nearest_y(kvpe_shape[2], ttnn.TILE_SIZE)
         kvpe_shard_width = kvpe_shape[3]
         kvpe_num_cores = kvpe_shape[1]
@@ -995,9 +996,10 @@ class MLA1D(AbstractModule):
         )
 
         q_num_cores = num_cores
-        q_num_cores = min(even_int_div(USERS_PER_ROW, mesh_shape[1]) * num_heads, q_num_cores)
+        q_num_cores = min(even_int_div(batch_size_per_row, mesh_shape[1]) * num_heads, q_num_cores)
         block_height = nearest_y(
-            (even_int_div(USERS_PER_ROW, mesh_shape[1]) * num_heads) // q_num_cores, ttnn.TILE_SIZE
+            (even_int_div(batch_size_per_row, mesh_shape[1]) * num_heads) // q_num_cores,
+            ttnn.TILE_SIZE,
         )
         block_width = kv_lora_rank + qk_rope_head_dim
 
@@ -1073,12 +1075,20 @@ class MLA1D(AbstractModule):
             out_dim=1,
         )
 
+        wq_a2a_reshard_out_mem_config = ttnn.create_sharded_memory_config(
+            shape=(batch_size_per_row, num_heads, kv_lora_rank + qk_rope_head_dim),
+            core_grid=ttnn.CoreGrid(y=8, x=8),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+        )
+        wq_a2a_reshard_config = ReshardConfig(
+            memory_config=wq_a2a_reshard_out_mem_config,
+        )  # 1,4,128,576, height sharded 8x8 [32,576]
         # Slice configs for fused wq_kv_a output: [q_lora_rank | kv_lora_rank | qk_rope_head_dim]
         # Q and KV nope use non-overlapping core grids, but keep this decode path
         # on the pre-40275 merged-descriptor dispatch as a temporary workaround.
         num_q_cores = 16
         num_kv_nope_cores = 16
-        shard_height = ttnn.core.roundup(USERS_PER_ROW, ttnn.TILE_SIZE)
+        shard_height = ttnn.core.roundup(batch_size_per_row, ttnn.TILE_SIZE)
 
         # Q slice: WIDTH sharded on 4x4 grid (0,0)-(3,3) -> 16 cores, shard [32, 96]
         q_slice_mem_config = ttnn.MemoryConfig(
@@ -1720,7 +1730,7 @@ class MLA1D(AbstractModule):
         ttnn.deallocate(tt_kvpe_fp16)
 
         # Update KVPE Cache
-        batch_size_per_dp_shard = even_int_div(USERS_PER_ROW, sdpa_dp_factor)
+        batch_size_per_dp_shard = even_int_div(cfg.get("batch_size_per_row", USERS_PER_ROW), sdpa_dp_factor)
         local_batch_idx = batch_idx % batch_size_per_dp_shard  # Local batch index within the DP shard
         col_idx = batch_idx // batch_size_per_dp_shard  # Which DP shard the batch belongs to
         if _deepseek_kvdbg_enabled():

--- a/models/demos/deepseek_v3/tt/mla/mla1d.py
+++ b/models/demos/deepseek_v3/tt/mla/mla1d.py
@@ -1745,7 +1745,7 @@ class MLA1D(AbstractModule):
                 col_idx=col_idx,
                 block_size=kvpe_cache.shape[2],
                 max_blocks=kvpe_cache.shape[0],
-                mesh_device=cfg.get("mesh_device", None),
+                mesh_device=cfg["mesh_device"],
             )
 
         ttnn.experimental.paged_fill_cache(
@@ -1855,8 +1855,9 @@ class MLA1D(AbstractModule):
         dim = x.shape[3]
 
         wo_prefill_seq_chunk_size = int(os.getenv("DEEPSEEK_WO_PREFILL_CHUNK_SIZE", str(DEFAULT_SEQ_LEN_CHUNK_SIZE)))
-        if wo_prefill_seq_chunk_size <= 0:
-            wo_prefill_seq_chunk_size = DEFAULT_SEQ_LEN_CHUNK_SIZE
+        assert wo_prefill_seq_chunk_size > 0, (
+            "DEEPSEEK_WO_PREFILL_CHUNK_SIZE must be > 0, " f"got {wo_prefill_seq_chunk_size}"
+        )
         if seq_len > wo_prefill_seq_chunk_size:
             num_heads = v_out.shape[2]
             v_head_dim = v_out.shape[3]

--- a/models/demos/deepseek_v3/tt/mla/mla1d.py
+++ b/models/demos/deepseek_v3/tt/mla/mla1d.py
@@ -2274,7 +2274,8 @@ class MLA1D(AbstractModule):
         # All_gather
         v_out = ttnn.to_memory_config(v_out, memory_config=ttnn.L1_MEMORY_CONFIG)
         v_out = ttnn.experimental.all_gather_async(v_out, **ccl.populate_all_gather_runtime_args(cfg["wo_ag_decode"]))
-        v_out = ttnn.tilize(v_out)
+        # Decode batch sizes smaller than a tile still need a tiled tensor for `wo`.
+        v_out = ttnn.tilize_with_zero_padding(v_out)
         # 1,1,32,16384 WIDTH sharded 2x8 [32,1024]
 
         return v_out

--- a/models/demos/deepseek_v3/tt/mla/mla1d.py
+++ b/models/demos/deepseek_v3/tt/mla/mla1d.py
@@ -1618,6 +1618,203 @@ class MLA1D(AbstractModule):
             logger.warning("KVDBG deepseek prefill failed: {}", exc)
 
     @classmethod
+    def _fwd_prefill_output_from_q_and_kvpe(
+        cls,
+        tt_q: ttnn.Tensor,
+        tt_kvpe_fp16: ttnn.Tensor,
+        cfg: RunPrefillConfig,
+        rope_tensors: dict,
+        ccl: CCL,
+        seq_len: int,
+        dim: int,
+        num_heads: int,
+        num_heads_local: int,
+        q_lora_rank: int,
+        kv_lora_rank: int,
+        qk_nope_head_dim: int,
+        qk_rope_head_dim: int,
+        qk_head_dim: int,
+        v_head_dim: int,
+    ) -> ttnn.Tensor:
+        # Q path: norm + wq_b (interleaved in0 + DRAM WIDTH sharded in1)
+        tt_q = RMSNorm.forward_prefill(tt_q, cfg["q_norm"])
+        wq_b_program_config = build_prefill_matmul_program_config(
+            seq_len,
+            k=q_lora_rank,
+            n=num_heads_local * qk_head_dim,
+            mesh_device=cfg[MESH_DEVICE_STATE_DICT_KEY],
+        )
+        tt_q = ttnn.linear(tt_q, **cfg["wq_b"], program_config=wq_b_program_config)
+
+        tt_q = ttnn.reshape(tt_q, (1, seq_len, num_heads_local, qk_head_dim))
+        tt_q = ttnn.permute(tt_q, (0, 2, 1, 3))
+
+        tt_q_nope = ttnn.slice(tt_q, [0, 0, 0, 0], [1, num_heads_local, seq_len, qk_nope_head_dim])
+        tt_q_rope = ttnn.slice(tt_q, [0, 0, 0, qk_nope_head_dim], [1, num_heads_local, seq_len, qk_head_dim])
+        ttnn.deallocate(tt_q)
+
+        num_heads_local_padded = pad_batch_to_dram_banks(num_heads_local)
+        wkv_b1_program_config = build_prefill_matmul_program_config(
+            seq_len,
+            k=qk_nope_head_dim,
+            n=kv_lora_rank,
+            batch=num_heads_local_padded,
+            mesh_device=cfg[MESH_DEVICE_STATE_DICT_KEY],
+        )
+        tt_q_nope = ttnn.linear(
+            tt_q_nope, **cfg["wkv_b1"], program_config=wkv_b1_program_config
+        )  # [1, num_heads_local_padded, seq_len, kv_lora_rank]
+
+        tt_q_rope = ttnn.experimental.rotary_embedding_llama(
+            tt_q_rope,
+            rope_tensors["cos_matrix"],
+            rope_tensors["sin_matrix"],
+            rope_tensors["trans_matrix"],
+            is_decode_mode=False,
+        )
+
+        tt_q = ttnn.concat([tt_q_nope, tt_q_rope], dim=-1)
+
+        attn_out = ttnn.transformer.flash_mla_prefill(
+            tt_q,
+            tt_kvpe_fp16,
+            **cfg["flash_mla"],
+        )  # [1, num_heads_local, seq_len, kv_lora_rank]
+        ttnn.deallocate(tt_q)
+        ttnn.deallocate(tt_kvpe_fp16)
+
+        wkv_b2_ag_prefill_runtime_args = ccl.populate_all_gather_runtime_args(cfg["wkv_b2_ag_prefill"])
+        num_heads_padded = pad_batch_to_dram_banks(num_heads)
+
+        def _run_wkv_b2_prefill_matmul(v_out_chunk_ag: ttnn.Tensor, chunk_seq_len: int) -> ttnn.Tensor:
+            padded_chunk_seq_len = nearest_y(chunk_seq_len, ttnn.TILE_SIZE)
+            v_out_chunk_input = v_out_chunk_ag
+            if padded_chunk_seq_len != chunk_seq_len:
+                v_out_chunk_input = ttnn.pad(
+                    v_out_chunk_ag,
+                    padding=((0, 0), (0, 0), (0, padded_chunk_seq_len - chunk_seq_len), (0, 0)),
+                    value=0.0,
+                )
+
+            wkv_b2_program_config = build_prefill_matmul_program_config(
+                padded_chunk_seq_len,
+                k=kv_lora_rank,
+                n=v_head_dim,
+                batch=num_heads_padded,
+                mesh_device=cfg[MESH_DEVICE_STATE_DICT_KEY],
+            )
+            v_out_chunk = ttnn.linear(v_out_chunk_input, **cfg["wkv_b2"], program_config=wkv_b2_program_config)
+
+            if v_out_chunk_input is not v_out_chunk_ag:
+                ttnn.deallocate(v_out_chunk_input)
+                trimmed_v_out_chunk = ttnn.slice(
+                    v_out_chunk,
+                    (0, 0, 0, 0),
+                    (1, v_out_chunk.shape[1], chunk_seq_len, v_head_dim),
+                )
+                ttnn.deallocate(v_out_chunk)
+                v_out_chunk = trimmed_v_out_chunk
+
+            return v_out_chunk
+
+        WKV_B2_AG_SEQ_CHUNK_SIZE = int(os.getenv("DEEPSEEK_WKV_B2_AG_PREFILL_CHUNK_SIZE", "2048"))
+        assert WKV_B2_AG_SEQ_CHUNK_SIZE > 0, (
+            "DEEPSEEK_WKV_B2_AG_PREFILL_CHUNK_SIZE must be > 0, " f"got {WKV_B2_AG_SEQ_CHUNK_SIZE}"
+        )
+        if seq_len > WKV_B2_AG_SEQ_CHUNK_SIZE:
+            num_chunks = (seq_len + WKV_B2_AG_SEQ_CHUNK_SIZE - 1) // WKV_B2_AG_SEQ_CHUNK_SIZE
+            v_out_chunks = []
+            for chunk_idx in range(num_chunks):
+                start = chunk_idx * WKV_B2_AG_SEQ_CHUNK_SIZE
+                end = min(start + WKV_B2_AG_SEQ_CHUNK_SIZE, seq_len)
+                attn_out_chunk = ttnn.slice(
+                    attn_out,
+                    (0, 0, start, 0),
+                    (1, num_heads_local, end, kv_lora_rank),
+                )
+                v_out_chunk_ag = ttnn.experimental.all_gather_async(attn_out_chunk, **wkv_b2_ag_prefill_runtime_args)
+                ttnn.deallocate(attn_out_chunk)
+
+                v_out_chunk = _run_wkv_b2_prefill_matmul(v_out_chunk_ag, end - start)
+                ttnn.deallocate(v_out_chunk_ag)
+                v_out_chunks.append(v_out_chunk)
+
+            ttnn.deallocate(attn_out)
+            if len(v_out_chunks) == 1:
+                v_out = v_out_chunks[0]
+            else:
+                v_out = ttnn.concat(v_out_chunks, dim=2)
+                for v_chunk in v_out_chunks:
+                    ttnn.deallocate(v_chunk)
+        else:
+            v_out_ag = ttnn.experimental.all_gather_async(attn_out, **wkv_b2_ag_prefill_runtime_args)
+            v_out = _run_wkv_b2_prefill_matmul(v_out_ag, seq_len)
+            ttnn.deallocate(v_out_ag)
+            ttnn.deallocate(attn_out)
+
+        v_out = ttnn.permute(v_out, (0, 2, 1, 3))
+
+        wo_k = num_heads * v_head_dim
+        wo_prefill_seq_chunk_size = int(os.getenv("DEEPSEEK_WO_PREFILL_CHUNK_SIZE", str(DEFAULT_SEQ_LEN_CHUNK_SIZE)))
+        assert wo_prefill_seq_chunk_size > 0, (
+            "DEEPSEEK_WO_PREFILL_CHUNK_SIZE must be > 0, " f"got {wo_prefill_seq_chunk_size}"
+        )
+        if seq_len > wo_prefill_seq_chunk_size:
+            num_heads_v = v_out.shape[2]
+            v_head_dim_v = v_out.shape[3]
+            num_chunks = (seq_len + wo_prefill_seq_chunk_size - 1) // wo_prefill_seq_chunk_size
+
+            output_chunks = []
+            hidden_dim = num_heads_v * v_head_dim_v
+            for chunk_idx in range(num_chunks):
+                start = chunk_idx * wo_prefill_seq_chunk_size
+                end = min(start + wo_prefill_seq_chunk_size, seq_len)
+                v_chunk = ttnn.slice(v_out, (0, start, 0, 0), (1, end, num_heads_v, v_head_dim_v))
+                chunk_seq_len = end - start
+                padded_chunk_seq_len = nearest_y(chunk_seq_len, ttnn.TILE_SIZE)
+                if padded_chunk_seq_len != chunk_seq_len:
+                    v_chunk = ttnn.pad(
+                        v_chunk,
+                        padding=((0, 0), (0, padded_chunk_seq_len - chunk_seq_len), (0, 0), (0, 0)),
+                        value=0.0,
+                    )
+                v_chunk = ttnn.reshape(v_chunk, (1, 1, padded_chunk_seq_len, hidden_dim))
+                wo_chunk_program_config = build_prefill_matmul_program_config(
+                    padded_chunk_seq_len,
+                    k=wo_k,
+                    n=dim,
+                    mesh_device=cfg[MESH_DEVICE_STATE_DICT_KEY],
+                )
+                out_chunk = ttnn.linear(v_chunk, **cfg["wo"], program_config=wo_chunk_program_config)
+                ttnn.deallocate(v_chunk)
+                if padded_chunk_seq_len != chunk_seq_len:
+                    trimmed_out_chunk = ttnn.slice(out_chunk, (0, 0, 0, 0), (1, 1, chunk_seq_len, dim))
+                    ttnn.deallocate(out_chunk)
+                    out_chunk = trimmed_out_chunk
+                output_chunks.append(out_chunk)
+
+            ttnn.deallocate(v_out)
+
+            if len(output_chunks) == 1:
+                out = output_chunks[0]
+            else:
+                out = ttnn.concat(output_chunks, dim=2)
+                for chunk in output_chunks:
+                    ttnn.deallocate(chunk)
+        else:
+            v_out = ttnn.reshape(v_out, (1, 1, seq_len, num_heads * v_head_dim))
+            wo_program_config = build_prefill_matmul_program_config(
+                seq_len,
+                k=wo_k,
+                n=dim,
+                mesh_device=cfg[MESH_DEVICE_STATE_DICT_KEY],
+            )
+            out = ttnn.linear(v_out, **cfg["wo"], program_config=wo_program_config)
+            ttnn.deallocate(v_out)
+
+        return out
+
+    @classmethod
     def forward_prefill(
         cls,
         x: ttnn.Tensor,
@@ -1657,6 +1854,14 @@ class MLA1D(AbstractModule):
         ccl = cfg["ccl"]
 
         seq_len = x.shape[2]
+        batch_size = x.shape[1]
+        row_batched_prefill = batch_size > 1
+        if row_batched_prefill:
+            expected_batch_size = cfg["batch_size_per_row"]
+            assert (
+                batch_size == expected_batch_size
+            ), f"Row-batched MLA prefill expects a full row batch of {expected_batch_size}, got {batch_size}"
+            assert row_idx is not None, "Row-batched MLA prefill requires a concrete row_idx"
 
         # Fused Linear + AR: wq_kv_a (wq_a + wkv_a)
 
@@ -1669,47 +1874,6 @@ class MLA1D(AbstractModule):
             kv_lora_rank,
             qk_rope_head_dim,
         )
-
-        # Q path: norm + wq_b (interleaved in0 + DRAM WIDTH sharded in1)
-        tt_q = RMSNorm.forward_prefill(tt_q, cfg["q_norm"])
-        wq_b_program_config = build_prefill_matmul_program_config(
-            seq_len, k=q_lora_rank, n=num_heads_local * qk_head_dim, mesh_device=cfg[MESH_DEVICE_STATE_DICT_KEY]
-        )
-        tt_q = ttnn.linear(tt_q, **cfg["wq_b"], program_config=wq_b_program_config)
-
-        tt_q = ttnn.reshape(tt_q, (1, seq_len, num_heads_local, qk_head_dim))
-        tt_q = ttnn.permute(tt_q, (0, 2, 1, 3))  # [1, num_heads_local, seq_len, qk_head_dim]
-
-        tt_q_nope = ttnn.slice(tt_q, [0, 0, 0, 0], [1, num_heads_local, seq_len, qk_nope_head_dim])
-        tt_q_rope = ttnn.slice(tt_q, [0, 0, 0, qk_nope_head_dim], [1, num_heads_local, seq_len, qk_head_dim])
-        ttnn.deallocate(tt_q)
-
-        # wkv_b1 (interleaved in0 + DRAM HEIGHT sharded in1)
-        # Pad batch dimension to match DRAM sharded weight layout
-        num_heads_local_padded = pad_batch_to_dram_banks(num_heads_local)
-
-        wkv_b1_program_config = build_prefill_matmul_program_config(
-            seq_len,
-            k=qk_nope_head_dim,
-            n=kv_lora_rank,
-            batch=num_heads_local_padded,
-            mesh_device=cfg[MESH_DEVICE_STATE_DICT_KEY],
-        )
-        tt_q_nope = ttnn.linear(
-            tt_q_nope, **cfg["wkv_b1"], program_config=wkv_b1_program_config
-        )  # [1, num_heads_local_padded, seq_len, kv_lora_rank]
-
-        # Q RoPE
-        tt_q_rope = ttnn.experimental.rotary_embedding_llama(
-            tt_q_rope,
-            rope_tensors["cos_matrix"],
-            rope_tensors["sin_matrix"],
-            rope_tensors["trans_matrix"],
-            is_decode_mode=False,
-        )
-
-        # Q ready for FlashMLA
-        tt_q = ttnn.concat([tt_q_nope, tt_q_rope], dim=-1)
 
         # KV Norm
         tt_kv_nope = RMSNorm.forward_prefill(tt_kv_nope, cfg["kv_norm"])
@@ -1730,13 +1894,12 @@ class MLA1D(AbstractModule):
 
         tt_kvpe_fp16 = tt_kvpe
         tt_kvpe = ttnn.typecast(tt_kvpe_fp16, dtype=kvpe_cache.dtype)
-        ttnn.deallocate(tt_kvpe_fp16)
 
         # Update KVPE Cache
         batch_size_per_dp_shard = even_int_div(cfg["batch_size_per_row"], sdpa_dp_factor)
         local_batch_idx = batch_idx % batch_size_per_dp_shard  # Local batch index within the DP shard
         col_idx = batch_idx // batch_size_per_dp_shard  # Which DP shard the batch belongs to
-        if _deepseek_kvdbg_enabled():
+        if _deepseek_kvdbg_enabled() and not row_batched_prefill:
             cls._debug_prefill_page_table(
                 page_table=page_table,
                 local_batch_idx=local_batch_idx,
@@ -1748,170 +1911,94 @@ class MLA1D(AbstractModule):
                 mesh_device=cfg["mesh_device"],
             )
 
-        ttnn.experimental.paged_fill_cache(
-            kvpe_cache,
-            tt_kvpe,
-            page_table=page_table,
-            batch_idx=local_batch_idx,
-            mesh_coords=set(get_mesh_coords(mesh_shape, row_idx, col_idx)),
-        )
-
-        # FlashMLA
-        attn_out = ttnn.transformer.flash_mla_prefill(
-            tt_q,
-            tt_kvpe,
-            **cfg["flash_mla"],
-        )  # [1, num_heads_local, seq_len, kv_lora_rank]
-        ttnn.deallocate(tt_q)
+        if row_batched_prefill:
+            for dp_col_idx in range(sdpa_dp_factor):
+                batch_start = dp_col_idx * batch_size_per_dp_shard
+                mesh_coords = set(get_mesh_coords(mesh_shape, row_idx, dp_col_idx))
+                for local_user_idx in range(batch_size_per_dp_shard):
+                    user_batch_idx = batch_start + local_user_idx
+                    tt_kvpe_user = ttnn.slice(
+                        tt_kvpe,
+                        [0, user_batch_idx, 0, 0],
+                        [1, user_batch_idx + 1, seq_len, kv_lora_rank + qk_rope_head_dim],
+                    )
+                    ttnn.experimental.paged_fill_cache(
+                        kvpe_cache,
+                        tt_kvpe_user,
+                        page_table=page_table,
+                        batch_idx=local_user_idx,
+                        mesh_coords=mesh_coords,
+                    )
+                    ttnn.deallocate(tt_kvpe_user)
+        else:
+            ttnn.experimental.paged_fill_cache(
+                kvpe_cache,
+                tt_kvpe,
+                page_table=page_table,
+                batch_idx=local_batch_idx,
+                mesh_coords=set(get_mesh_coords(mesh_shape, row_idx, col_idx)),
+            )
         ttnn.deallocate(tt_kvpe)
 
-        # DP wkv_b2 to match decode weights.
-        # Chunk sequence for all_gather to avoid single giant output allocations at 8K+ prefill.
-        wkv_b2_ag_prefill_runtime_args = ccl.populate_all_gather_runtime_args(cfg["wkv_b2_ag_prefill"])
-        num_heads_padded = pad_batch_to_dram_banks(num_heads)
-
-        def _run_wkv_b2_prefill_matmul(v_out_chunk_ag: ttnn.Tensor, chunk_seq_len: int) -> ttnn.Tensor:
-            padded_chunk_seq_len = nearest_y(chunk_seq_len, ttnn.TILE_SIZE)
-            v_out_chunk_input = v_out_chunk_ag
-            if padded_chunk_seq_len != chunk_seq_len:
-                v_out_chunk_input = ttnn.pad(
-                    v_out_chunk_ag,
-                    padding=((0, 0), (0, 0), (0, padded_chunk_seq_len - chunk_seq_len), (0, 0)),
-                    value=0.0,
-                )
-
-            wkv_b2_program_config = build_prefill_matmul_program_config(
-                padded_chunk_seq_len,
-                k=kv_lora_rank,
-                n=v_head_dim,
-                batch=num_heads_padded,
-                mesh_device=cfg[MESH_DEVICE_STATE_DICT_KEY],
-            )
-            v_out_chunk = ttnn.linear(v_out_chunk_input, **cfg["wkv_b2"], program_config=wkv_b2_program_config)
-
-            if v_out_chunk_input is not v_out_chunk_ag:
-                ttnn.deallocate(v_out_chunk_input)
-                trimmed_v_out_chunk = ttnn.slice(
-                    v_out_chunk,
-                    (0, 0, 0, 0),
-                    (1, v_out_chunk.shape[1], chunk_seq_len, v_head_dim),
-                )
-                ttnn.deallocate(v_out_chunk)
-                v_out_chunk = trimmed_v_out_chunk
-
-            return v_out_chunk
-
-        # This all-gather materializes [1, num_heads, chunk_seq_len, kv_lora_rank] in DRAM.
-        # Large prefills can OOM here, so keep the chunk size configurable and conservative.
-        WKV_B2_AG_SEQ_CHUNK_SIZE = int(os.getenv("DEEPSEEK_WKV_B2_AG_PREFILL_CHUNK_SIZE", "2048"))
-        assert WKV_B2_AG_SEQ_CHUNK_SIZE > 0, (
-            "DEEPSEEK_WKV_B2_AG_PREFILL_CHUNK_SIZE must be > 0, " f"got {WKV_B2_AG_SEQ_CHUNK_SIZE}"
-        )
-        if seq_len > WKV_B2_AG_SEQ_CHUNK_SIZE:
-            num_chunks = (seq_len + WKV_B2_AG_SEQ_CHUNK_SIZE - 1) // WKV_B2_AG_SEQ_CHUNK_SIZE
-            v_out_chunks = []
-            for chunk_idx in range(num_chunks):
-                start = chunk_idx * WKV_B2_AG_SEQ_CHUNK_SIZE
-                end = min(start + WKV_B2_AG_SEQ_CHUNK_SIZE, seq_len)
-                attn_out_chunk = ttnn.slice(
-                    attn_out,
-                    (0, 0, start, 0),
-                    (1, num_heads_local, end, kv_lora_rank),
-                )  # [1, num_heads_local, chunk_seq_len, kv_lora_rank]
-                v_out_chunk_ag = ttnn.experimental.all_gather_async(
-                    attn_out_chunk, **wkv_b2_ag_prefill_runtime_args
-                )  # [1, num_heads, chunk_seq_len, kv_lora_rank]
-                ttnn.deallocate(attn_out_chunk)
-
-                # wkv_b2
-                v_out_chunk = _run_wkv_b2_prefill_matmul(v_out_chunk_ag, end - start)
-                ttnn.deallocate(v_out_chunk_ag)
-                v_out_chunks.append(v_out_chunk)
-
-            ttnn.deallocate(attn_out)
-            if len(v_out_chunks) == 1:
-                v_out = v_out_chunks[0]
-            else:
-                v_out = ttnn.concat(v_out_chunks, dim=2)  # [1, num_heads, seq_len, v_head_dim]
-                for v_chunk in v_out_chunks:
-                    ttnn.deallocate(v_chunk)
-        else:
-            v_out_ag = ttnn.experimental.all_gather_async(
-                attn_out, **wkv_b2_ag_prefill_runtime_args
-            )  # [1, num_heads, seq_len, v_head_dim] # wkv_b2_ag_prefill
-
-            # wkv_b2
-            v_out = _run_wkv_b2_prefill_matmul(v_out_ag, seq_len)
-            ttnn.deallocate(v_out_ag)
-            ttnn.deallocate(attn_out)
-
-        # Permute BEFORE all_gather to avoid large tensor permute at 32K+ seq_len
-        v_out = ttnn.permute(v_out, (0, 2, 1, 3))  # [1, seq_len, num_heads_local, v_head_dim]
-
-        # wo matmul (interleaved in0 + DRAM WIDTH sharded in1)
-        # Chunk the sequence dimension if needed to avoid OOM/hang in all_gather for large sequences
-        # Strategy: Process each chunk independently to keep all_gather buffers small
-        wo_k = num_heads * v_head_dim
         dim = x.shape[3]
-
-        wo_prefill_seq_chunk_size = int(os.getenv("DEEPSEEK_WO_PREFILL_CHUNK_SIZE", str(DEFAULT_SEQ_LEN_CHUNK_SIZE)))
-        assert wo_prefill_seq_chunk_size > 0, (
-            "DEEPSEEK_WO_PREFILL_CHUNK_SIZE must be > 0, " f"got {wo_prefill_seq_chunk_size}"
-        )
-        if seq_len > wo_prefill_seq_chunk_size:
-            num_heads = v_out.shape[2]
-            v_head_dim = v_out.shape[3]
-            num_chunks = (seq_len + wo_prefill_seq_chunk_size - 1) // wo_prefill_seq_chunk_size
-
-            output_chunks = []
-            hidden_dim = num_heads * v_head_dim
-            for chunk_idx in range(num_chunks):
-                start = chunk_idx * wo_prefill_seq_chunk_size
-                end = min(start + wo_prefill_seq_chunk_size, seq_len)
-                v_chunk = ttnn.slice(v_out, (0, start, 0, 0), (1, end, num_heads, v_head_dim))
-                chunk_seq_len = end - start
-                padded_chunk_seq_len = nearest_y(chunk_seq_len, ttnn.TILE_SIZE)
-                if padded_chunk_seq_len != chunk_seq_len:
-                    v_chunk = ttnn.pad(
-                        v_chunk,
-                        padding=((0, 0), (0, padded_chunk_seq_len - chunk_seq_len), (0, 0), (0, 0)),
-                        value=0.0,
-                    )
-                v_chunk = ttnn.reshape(v_chunk, (1, 1, padded_chunk_seq_len, hidden_dim))
-                wo_chunk_program_config = build_prefill_matmul_program_config(
-                    padded_chunk_seq_len,
-                    k=wo_k,
-                    n=dim,
-                    mesh_device=cfg[MESH_DEVICE_STATE_DICT_KEY],
+        if row_batched_prefill:
+            out_chunks = []
+            batch_size = tt_q.shape[1]
+            for user_batch_idx in range(batch_size):
+                tt_q_user = ttnn.slice(tt_q, [0, user_batch_idx, 0, 0], [1, user_batch_idx + 1, seq_len, q_lora_rank])
+                tt_kvpe_user = ttnn.slice(
+                    tt_kvpe_fp16,
+                    [0, user_batch_idx, 0, 0],
+                    [1, user_batch_idx + 1, seq_len, kv_lora_rank + qk_rope_head_dim],
                 )
-                out_chunk = ttnn.linear(
-                    v_chunk, **cfg["wo"], program_config=wo_chunk_program_config
-                )  # [1, 1, chunk_size, dim]
-                ttnn.deallocate(v_chunk)
-                if padded_chunk_seq_len != chunk_seq_len:
-                    trimmed_out_chunk = ttnn.slice(out_chunk, (0, 0, 0, 0), (1, 1, chunk_seq_len, dim))
-                    ttnn.deallocate(out_chunk)
-                    out_chunk = trimmed_out_chunk
-                output_chunks.append(out_chunk)
+                out_chunks.append(
+                    cls._fwd_prefill_output_from_q_and_kvpe(
+                        tt_q_user,
+                        tt_kvpe_user,
+                        cfg,
+                        rope_tensors,
+                        ccl,
+                        seq_len,
+                        dim,
+                        num_heads,
+                        num_heads_local,
+                        q_lora_rank,
+                        kv_lora_rank,
+                        qk_nope_head_dim,
+                        qk_rope_head_dim,
+                        qk_head_dim,
+                        v_head_dim,
+                    )
+                )
 
-            ttnn.deallocate(v_out)
+            ttnn.deallocate(tt_q)
+            ttnn.deallocate(tt_kvpe_fp16)
 
-            if len(output_chunks) == 1:
-                out = output_chunks[0]
-            else:
-                out = ttnn.concat(output_chunks, dim=2)
-                for chunk in output_chunks:
-                    ttnn.deallocate(chunk)
-        else:
-            # For non-chunked case: [1, seq_len, num_heads, v_head_dim] -> [1, 1, seq_len, hidden_dim]
-            v_out = ttnn.reshape(v_out, (1, 1, seq_len, num_heads * v_head_dim))
-            wo_program_config = build_prefill_matmul_program_config(
-                seq_len, k=wo_k, n=dim, mesh_device=cfg[MESH_DEVICE_STATE_DICT_KEY]
-            )
-            out = ttnn.linear(v_out, **cfg["wo"], program_config=wo_program_config)  # [1, 1, seq_len, dim]
-            ttnn.deallocate(v_out)
+            if len(out_chunks) == 1:
+                return out_chunks[0]
 
-        return out
+            out = ttnn.concat(out_chunks, dim=1)
+            for out_chunk in out_chunks:
+                ttnn.deallocate(out_chunk)
+            return out
+
+        return cls._fwd_prefill_output_from_q_and_kvpe(
+            tt_q,
+            tt_kvpe_fp16,
+            cfg,
+            rope_tensors,
+            ccl,
+            seq_len,
+            dim,
+            num_heads,
+            num_heads_local,
+            q_lora_rank,
+            kv_lora_rank,
+            qk_nope_head_dim,
+            qk_rope_head_dim,
+            qk_head_dim,
+            v_head_dim,
+        )
 
     @classmethod
     def _fwd_decode_wq_kv_a(
@@ -2308,6 +2395,7 @@ class MLA1D(AbstractModule):
     ) -> tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor]:
         # Fused wq_kv_a matmul (interleaved in0 + DRAM WIDTH sharded in1)
         dim = x.shape[3]
+        batch_size = x.shape[1]
         qkv_a_n = q_lora_rank + kv_lora_rank + qk_rope_head_dim
         # Row-batched prefill drives the fused Q/KV projection with batch on dim 1.
         # The program config must account for that batch so fuse_batch stays disabled.
@@ -2315,26 +2403,32 @@ class MLA1D(AbstractModule):
             seq_len,
             k=dim,
             n=qkv_a_n,
-            batch=x.shape[1],
+            batch=batch_size,
             mesh_device=cfg[MESH_DEVICE_STATE_DICT_KEY],
         )
         tt_q_kv = ttnn.linear(x, **cfg["wq_kv_a"], program_config=wq_kv_a_program_config)
 
         # AR using AG + local reduce (since sub-tile RS not supported for new shapes)
+        wq_kv_a_ag_args = ccl.populate_all_gather_runtime_args(cfg["wq_kv_a_ag_prefill"])
+        wq_kv_a_reduce_args = dict(cfg["wq_kv_a_r_prefill"])
+        if batch_size > 1:
+            # Keep the user batch intact during TP reduce by borrowing the singleton dim 0 as
+            # the gather/reduce axis; dim 1 already carries the real row batch.
+            wq_kv_a_ag_args = {**wq_kv_a_ag_args, "dim": 0}
+            wq_kv_a_reduce_args = {**wq_kv_a_reduce_args, "dims": [0]}
+
         tt_q_kv = ttnn.experimental.all_gather_async(
-            tt_q_kv, **ccl.populate_all_gather_runtime_args(cfg["wq_kv_a_ag_prefill"])
-        )  # [1, num_devices, seq_len, q_lora_rank + kv_lora_rank + qk_rope_head_dim]
-        tt_q_kv = ttnn.experimental.fast_reduce_nc(
-            tt_q_kv, **cfg["wq_kv_a_r_prefill"]
-        )  # [1, 1, seq_len, q_lora_rank + kv_lora_rank + qk_rope_head_dim]
+            tt_q_kv, **wq_kv_a_ag_args
+        )  # [1, batch, seq_len, q_lora_rank + kv_lora_rank + qk_rope_head_dim]
+        tt_q_kv = ttnn.experimental.fast_reduce_nc(tt_q_kv, **wq_kv_a_reduce_args)
 
         # Slice into three parts: tt_q, tt_kv_nope, tt_kv_rope
-        tt_q = ttnn.slice(tt_q_kv, [0, 0, 0, 0], [1, 1, seq_len, q_lora_rank])
-        tt_kv_nope = ttnn.slice(tt_q_kv, [0, 0, 0, q_lora_rank], [1, 1, seq_len, q_lora_rank + kv_lora_rank])
+        tt_q = ttnn.slice(tt_q_kv, [0, 0, 0, 0], [1, batch_size, seq_len, q_lora_rank])
+        tt_kv_nope = ttnn.slice(tt_q_kv, [0, 0, 0, q_lora_rank], [1, batch_size, seq_len, q_lora_rank + kv_lora_rank])
         tt_kv_rope = ttnn.slice(
             tt_q_kv,
             [0, 0, 0, q_lora_rank + kv_lora_rank],
-            [1, 1, seq_len, q_lora_rank + kv_lora_rank + qk_rope_head_dim],
+            [1, batch_size, seq_len, q_lora_rank + kv_lora_rank + qk_rope_head_dim],
         )
         ttnn.deallocate(tt_q_kv)
         return tt_q, tt_kv_nope, tt_kv_rope

--- a/models/demos/deepseek_v3/tt/mla/mla1d.py
+++ b/models/demos/deepseek_v3/tt/mla/mla1d.py
@@ -437,6 +437,7 @@ class MLA1D(AbstractModule):
         cls,
         hf_config: PretrainedConfig,
         mesh_device: ttnn.Device,
+        batch_size_per_row: int,
     ) -> ModelPrefillConfig:
         """Prefill model config for an MLP with 1D tensor parallelism.
 
@@ -583,6 +584,7 @@ class MLA1D(AbstractModule):
         )
 
         return {
+            "batch_size_per_row": batch_size_per_row,
             "num_heads": num_heads,
             "num_heads_local": num_heads_local,
             "q_lora_rank": q_lora_rank,
@@ -612,7 +614,7 @@ class MLA1D(AbstractModule):
         cls,
         hf_config: PretrainedConfig,
         mesh_device: ttnn.Device,
-        batch_size_per_row: int = USERS_PER_ROW,
+        batch_size_per_row: int,
     ) -> ModelDecodeConfig:
         """Generate decode operator configuration for this MLP layer.
 
@@ -1137,6 +1139,7 @@ class MLA1D(AbstractModule):
         )
 
         return {
+            "batch_size_per_row": batch_size_per_row,
             "num_heads": num_heads,
             "q_lora_rank": q_lora_rank,
             "kv_lora_rank": kv_lora_rank,
@@ -1730,7 +1733,7 @@ class MLA1D(AbstractModule):
         ttnn.deallocate(tt_kvpe_fp16)
 
         # Update KVPE Cache
-        batch_size_per_dp_shard = even_int_div(cfg.get("batch_size_per_row", USERS_PER_ROW), sdpa_dp_factor)
+        batch_size_per_dp_shard = even_int_div(cfg["batch_size_per_row"], sdpa_dp_factor)
         local_batch_idx = batch_idx % batch_size_per_dp_shard  # Local batch index within the DP shard
         col_idx = batch_idx // batch_size_per_dp_shard  # Which DP shard the batch belongs to
         if _deepseek_kvdbg_enabled():

--- a/models/demos/deepseek_v3/tt/mla/mla2d.py
+++ b/models/demos/deepseek_v3/tt/mla/mla2d.py
@@ -73,9 +73,11 @@ class MLA2D(MLA1D):
         cls,
         hf_config: PretrainedConfig,
         mesh_device: ttnn.Device,
+        batch_size_per_row: int = USERS_PER_ROW,
     ) -> ModelPrefillConfig:
         super_cfg = super().prefill_model_config(hf_config, mesh_device)
         input_memory_config = super_cfg.pop("input_memory_config")
+        super_cfg["batch_size_per_row"] = batch_size_per_row
         return {
             "mla1d": super_cfg,
             "input_memory_config": input_memory_config,
@@ -96,9 +98,11 @@ class MLA2D(MLA1D):
         cls,
         hf_config: PretrainedConfig,
         mesh_device: ttnn.Device,
+        batch_size_per_row: int = USERS_PER_ROW,
     ) -> ModelDecodeConfig:
-        super_cfg = super().decode_model_config(hf_config, mesh_device)
+        super_cfg = super().decode_model_config(hf_config, mesh_device, batch_size_per_row=batch_size_per_row)
         input_memory_config = super_cfg.pop("input_memory_config")
+        super_cfg["batch_size_per_row"] = batch_size_per_row
         return {
             "mla1d": super_cfg,
             "input_memory_config": input_memory_config,
@@ -184,10 +188,11 @@ class MLA2D(MLA1D):
         ccl = cfg["ccl"]
 
         x_next = ttnn.experimental.all_gather_async(x, **ccl.populate_all_gather_runtime_args(cfg["seq_ag_prefill"]))
+        batch_size_per_row = cfg["mla1d"].get("batch_size_per_row", USERS_PER_ROW)
         x_out = super().forward_prefill(
             x_next,
-            batch_idx=batch_idx % USERS_PER_ROW,
-            row_idx=batch_idx // USERS_PER_ROW,
+            batch_idx=batch_idx % batch_size_per_row,
+            row_idx=batch_idx // batch_size_per_row,
             cfg=cfg["mla1d"],
             rope_tensors=rope_tensors,
             page_table=page_table,

--- a/models/demos/deepseek_v3/tt/mla/mla2d.py
+++ b/models/demos/deepseek_v3/tt/mla/mla2d.py
@@ -18,7 +18,6 @@ from models.demos.deepseek_v3.utils.config_dataclass import (
     ReduceScatterAsyncMinimalConfig,
     SavedWeight,
 )
-from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW
 from models.demos.deepseek_v3.utils.run_config import (
     MESH_DEVICE_STATE_DICT_KEY,
     ModelDecodeConfig,
@@ -73,11 +72,10 @@ class MLA2D(MLA1D):
         cls,
         hf_config: PretrainedConfig,
         mesh_device: ttnn.Device,
-        batch_size_per_row: int = USERS_PER_ROW,
+        batch_size_per_row: int,
     ) -> ModelPrefillConfig:
-        super_cfg = super().prefill_model_config(hf_config, mesh_device)
+        super_cfg = super().prefill_model_config(hf_config, mesh_device, batch_size_per_row=batch_size_per_row)
         input_memory_config = super_cfg.pop("input_memory_config")
-        super_cfg["batch_size_per_row"] = batch_size_per_row
         return {
             "mla1d": super_cfg,
             "input_memory_config": input_memory_config,
@@ -98,11 +96,10 @@ class MLA2D(MLA1D):
         cls,
         hf_config: PretrainedConfig,
         mesh_device: ttnn.Device,
-        batch_size_per_row: int = USERS_PER_ROW,
+        batch_size_per_row: int,
     ) -> ModelDecodeConfig:
         super_cfg = super().decode_model_config(hf_config, mesh_device, batch_size_per_row=batch_size_per_row)
         input_memory_config = super_cfg.pop("input_memory_config")
-        super_cfg["batch_size_per_row"] = batch_size_per_row
         return {
             "mla1d": super_cfg,
             "input_memory_config": input_memory_config,
@@ -188,7 +185,7 @@ class MLA2D(MLA1D):
         ccl = cfg["ccl"]
 
         x_next = ttnn.experimental.all_gather_async(x, **ccl.populate_all_gather_runtime_args(cfg["seq_ag_prefill"]))
-        batch_size_per_row = cfg["mla1d"].get("batch_size_per_row", USERS_PER_ROW)
+        batch_size_per_row = cfg["mla1d"]["batch_size_per_row"]
         x_out = super().forward_prefill(
             x_next,
             batch_idx=batch_idx % batch_size_per_row,

--- a/models/demos/deepseek_v3/tt/mlp/mlp.py
+++ b/models/demos/deepseek_v3/tt/mlp/mlp.py
@@ -24,7 +24,6 @@ from models.demos.deepseek_v3.utils.config_dataclass import (
 from models.demos.deepseek_v3.utils.config_helpers import (
     COMPUTE_KERNEL_CONFIG_HIFI2,
     SEQ_LEN_CHUNK_SIZE,
-    USERS_PER_ROW,
     dram_sharded_weight_config,
     even_int_div,
     find_largest_divisor,
@@ -219,7 +218,7 @@ class MLP(AbstractModule):
         hf_config: PretrainedConfig,
         mesh_device: ttnn.Device,
         fabric_config: ttnn.FabricConfig,
-        batch_size_per_row: int = USERS_PER_ROW,
+        batch_size_per_row: int,
         input_num_cores: int | None = None,
         output_num_cores: int | None = None,
     ) -> ModelDecodeConfig:
@@ -356,7 +355,7 @@ class MLP(AbstractModule):
         per_device_width: int,
         activation_sharding_num_cores: int,
         mesh_device: ttnn.Device,
-        batch_size_per_row: int = USERS_PER_ROW,
+        batch_size_per_row: int,
     ) -> ttnn.MemoryConfig:
         """Get the memory config for an activation tensor in decode mode."""
         return ttnn.create_sharded_memory_config_(

--- a/models/demos/deepseek_v3/tt/mlp/mlp.py
+++ b/models/demos/deepseek_v3/tt/mlp/mlp.py
@@ -502,8 +502,8 @@ class MLP(AbstractModule):
 
             # De-chunk the output if needed (for SharedExpert usage)
             num_layers = x.shape[0]
-            _, num_chunks, _, output_dim = output.shape
-            if num_chunks > 1:
+            _, _, _, output_dim = output.shape
+            if original_seq_len > cfg["max_rows"]:
                 output = ttnn.reshape(output, [num_layers, 1, -1, output_dim])
                 if pad_rows > 0:
                     output = ttnn.slice(output, [0, 0, 0, 0], [num_layers, 1, original_seq_len, output_dim])
@@ -597,8 +597,8 @@ class MLP(AbstractModule):
         output = cls._fwd_reduce_scatter_post_ff2(output, cfg, ccl)
 
         # De-chunk the output if the input was chunked
-        _, num_chunks, _, output_dim = output.shape
-        if num_chunks > 1:
+        _, _, _, output_dim = output.shape
+        if original_seq_len > cfg["max_rows"]:
             output = ttnn.reshape(output, [num_layers, 1, -1, output_dim])
             if pad_rows > 0:
                 output = ttnn.slice(output, [0, 0, 0, 0], [num_layers, 1, original_seq_len, output_dim])

--- a/models/demos/deepseek_v3/tt/mlp/mlp.py
+++ b/models/demos/deepseek_v3/tt/mlp/mlp.py
@@ -219,6 +219,7 @@ class MLP(AbstractModule):
         hf_config: PretrainedConfig,
         mesh_device: ttnn.Device,
         fabric_config: ttnn.FabricConfig,
+        batch_size_per_row: int = USERS_PER_ROW,
         input_num_cores: int | None = None,
         output_num_cores: int | None = None,
     ) -> ModelDecodeConfig:
@@ -264,9 +265,17 @@ class MLP(AbstractModule):
 
         # Calculate input and output memory configurations
 
-        input_memory_config = cls._get_decode_activation_memory_config(dim, input_num_cores, mesh_device)
+        input_memory_config = cls._get_decode_activation_memory_config(
+            dim,
+            input_num_cores,
+            mesh_device,
+            batch_size_per_row=batch_size_per_row,
+        )
         output_memory_config = cls._get_decode_activation_memory_config(
-            even_int_div(dim, mesh_width), output_num_cores, mesh_device
+            even_int_div(dim, mesh_width),
+            output_num_cores,
+            mesh_device,
+            batch_size_per_row=batch_size_per_row,
         )
 
         # Construct the config
@@ -281,7 +290,11 @@ class MLP(AbstractModule):
                 input_tensor_b=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
                 memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
                 program_config=get_dram_sharded_matmul_config(
-                    USERS_PER_ROW, dim, even_int_div(hidden_dim, mesh_width), input_num_cores, inner_num_cores
+                    batch_size_per_row,
+                    dim,
+                    even_int_div(hidden_dim, mesh_width),
+                    input_num_cores,
+                    inner_num_cores,
                 ),
                 compute_kernel_config=COMPUTE_KERNEL_CONFIG_HIFI2,
             ),
@@ -289,7 +302,7 @@ class MLP(AbstractModule):
                 input_tensor_b=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
                 memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
                 program_config=get_dram_sharded_matmul_config(
-                    USERS_PER_ROW,
+                    batch_size_per_row,
                     even_int_div(hidden_dim, mesh_width),
                     dim,
                     inner_num_cores,
@@ -301,7 +314,11 @@ class MLP(AbstractModule):
                 input_tensor_b=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
                 memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
                 program_config=get_dram_sharded_matmul_config(
-                    USERS_PER_ROW, dim, even_int_div(hidden_dim, mesh_width), input_num_cores, inner_num_cores
+                    batch_size_per_row,
+                    dim,
+                    even_int_div(hidden_dim, mesh_width),
+                    input_num_cores,
+                    inner_num_cores,
                 ),
                 compute_kernel_config=COMPUTE_KERNEL_CONFIG_HIFI2,
             ),
@@ -335,12 +352,16 @@ class MLP(AbstractModule):
     @final
     @classmethod
     def _get_decode_activation_memory_config(
-        cls, per_device_width: int, activation_sharding_num_cores: int, mesh_device: ttnn.Device
+        cls,
+        per_device_width: int,
+        activation_sharding_num_cores: int,
+        mesh_device: ttnn.Device,
+        batch_size_per_row: int = USERS_PER_ROW,
     ) -> ttnn.MemoryConfig:
         """Get the memory config for an activation tensor in decode mode."""
         return ttnn.create_sharded_memory_config_(
             shape=(
-                ttnn.core.roundup(USERS_PER_ROW, ttnn.TILE_SIZE),
+                ttnn.core.roundup(batch_size_per_row, ttnn.TILE_SIZE),
                 ttnn.core.roundup(even_int_div(per_device_width, activation_sharding_num_cores), ttnn.TILE_SIZE),
             ),
             core_grid=ttnn.num_cores_to_corerangeset(

--- a/models/demos/deepseek_v3/tt/model/row_batched_model.py
+++ b/models/demos/deepseek_v3/tt/model/row_batched_model.py
@@ -108,6 +108,7 @@ class RowBatchedModel(SharedStateAddOn, AbstractModule):
         cls,
         hf_config: PretrainedConfig,
         mesh_device: ttnn.Device,
+        batch_size_per_row: int,
     ) -> ModelPrefillConfig:
         """Create the model configuration for prefill mode."""
         model_cfg = {
@@ -117,6 +118,7 @@ class RowBatchedModel(SharedStateAddOn, AbstractModule):
                     hf_config,
                     mesh_device,
                     get_fabric_config(),
+                    batch_size_per_row=batch_size_per_row,
                 )
             ],
             "moe_decoder_block": [
@@ -124,6 +126,7 @@ class RowBatchedModel(SharedStateAddOn, AbstractModule):
                     hf_config,
                     mesh_device,
                     get_fabric_config(),
+                    batch_size_per_row=batch_size_per_row,
                 )
             ],
             "norm": DistributedRMSNorm.prefill_model_config(hf_config, mesh_device),
@@ -138,9 +141,14 @@ class RowBatchedModel(SharedStateAddOn, AbstractModule):
         cls,
         hf_config: PretrainedConfig,
         mesh_device: ttnn.Device,
+        batch_size_per_row: int,
     ) -> ModelDecodeConfig:
         """Create the model configuration for decode mode."""
-        norm_config = DistributedRMSNorm.decode_model_config(hf_config, mesh_device)
+        norm_config = DistributedRMSNorm.decode_model_config(
+            hf_config,
+            mesh_device,
+            batch_size_per_row=batch_size_per_row,
+        )
         model_cfg = {
             "embedding": Embedding2D.decode_model_config(hf_config, mesh_device),
             "mlp_decoder_block": [
@@ -148,6 +156,7 @@ class RowBatchedModel(SharedStateAddOn, AbstractModule):
                     hf_config,
                     mesh_device,
                     get_fabric_config(),
+                    batch_size_per_row=batch_size_per_row,
                 )
             ],
             "moe_decoder_block": [
@@ -155,6 +164,7 @@ class RowBatchedModel(SharedStateAddOn, AbstractModule):
                     hf_config,
                     mesh_device,
                     get_fabric_config(),
+                    batch_size_per_row=batch_size_per_row,
                 )
             ],
             "norm_reshard": ReshardConfig(memory_config=norm_config["input_memory_config"]),

--- a/models/demos/deepseek_v3/tt/model/row_batched_model.py
+++ b/models/demos/deepseek_v3/tt/model/row_batched_model.py
@@ -172,7 +172,9 @@ class RowBatchedModel(SharedStateAddOn, AbstractModule):
             "lm_head": LMHead1D.decode_model_config(mesh_device),
         }
         if cls._has_mtp_layer(hf_config):
-            model_cfg["mtp"] = MTP2D.decode_model_config(hf_config, mesh_device, get_fabric_config())
+            model_cfg["mtp"] = MTP2D.decode_model_config(
+                hf_config, mesh_device, get_fabric_config(), batch_size_per_row=batch_size_per_row
+            )
         return model_cfg
 
     @classmethod

--- a/models/demos/deepseek_v3/tt/model/row_batched_model.py
+++ b/models/demos/deepseek_v3/tt/model/row_batched_model.py
@@ -133,7 +133,12 @@ class RowBatchedModel(SharedStateAddOn, AbstractModule):
             "lm_head": LMHead1D.prefill_model_config(mesh_device),
         }
         if cls._has_mtp_layer(hf_config):
-            model_cfg["mtp"] = MTP2D.prefill_model_config(hf_config, mesh_device, get_fabric_config())
+            model_cfg["mtp"] = MTP2D.prefill_model_config(
+                hf_config,
+                mesh_device,
+                get_fabric_config(),
+                batch_size_per_row=batch_size_per_row,
+            )
         return model_cfg
 
     @classmethod

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -156,7 +156,7 @@ class MoE(SharedStateAddOn, AbstractModule):
         mesh_device: ttnn.Device,
         fabric_config: ttnn.FabricConfig,
         mode: str,
-        batch_size_per_row: int = USERS_PER_ROW,
+        batch_size_per_row: int,
         topk_fallback: bool = False,
     ) -> ModelDecodeConfig | ModelPrefillConfig:
         """Generate decode configuration for this module.
@@ -281,7 +281,7 @@ class MoE(SharedStateAddOn, AbstractModule):
         hf_config: PretrainedConfig,
         mesh_device: ttnn.Device,
         fabric_config: ttnn.FabricConfig,
-        batch_size_per_row: int = USERS_PER_ROW,
+        batch_size_per_row: int,
         topk_fallback: bool = False,
     ) -> ModelDecodeConfig:
         return cls.model_config(
@@ -301,7 +301,14 @@ class MoE(SharedStateAddOn, AbstractModule):
         fabric_config: ttnn.FabricConfig,
         topk_fallback: bool = False,
     ) -> ModelPrefillConfig:
-        return cls.model_config(hf_config, mesh_device, fabric_config, "prefill", topk_fallback=topk_fallback)
+        return cls.model_config(
+            hf_config,
+            mesh_device,
+            fabric_config,
+            "prefill",
+            batch_size_per_row=USERS_PER_ROW,
+            topk_fallback=topk_fallback,
+        )
 
     @classmethod
     def forward(cls, x: ttnn.Tensor, cfg: RunDecodeConfig | RunPrefillConfig) -> ttnn.Tensor:

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -156,6 +156,7 @@ class MoE(SharedStateAddOn, AbstractModule):
         mesh_device: ttnn.Device,
         fabric_config: ttnn.FabricConfig,
         mode: str,
+        batch_size_per_row: int = USERS_PER_ROW,
         topk_fallback: bool = False,
     ) -> ModelDecodeConfig | ModelPrefillConfig:
         """Generate decode configuration for this module.
@@ -179,7 +180,7 @@ class MoE(SharedStateAddOn, AbstractModule):
             per_core_width = (HIDDEN_SIZE // TP_SIZE) // shard_core_grid.num_cores
             input_output_memory_config = ttnn.create_sharded_memory_config(
                 shape=(
-                    ttnn.core.roundup(USERS_PER_ROW, ttnn.TILE_SIZE),
+                    ttnn.core.roundup(batch_size_per_row, ttnn.TILE_SIZE),
                     ttnn.core.roundup(per_core_width, ttnn.TILE_SIZE),
                 ),
                 core_grid=shard_core_grid,
@@ -216,7 +217,9 @@ class MoE(SharedStateAddOn, AbstractModule):
                     memory_config=input_output_memory_config,
                 ),
                 "ring_sum_experts_output_memory_config": DeepseekMoEReduceScatterConfig.create_default_input_memory_config(
-                    USERS_PER_ROW, HIDDEN_SIZE, TP_SIZE
+                    batch_size_per_row,
+                    HIDDEN_SIZE,
+                    TP_SIZE,
                 ),
                 "ring_final_output_reduce_scatter": DeepseekMoEReduceScatterConfig(
                     cluster_axis=1,
@@ -278,9 +281,17 @@ class MoE(SharedStateAddOn, AbstractModule):
         hf_config: PretrainedConfig,
         mesh_device: ttnn.Device,
         fabric_config: ttnn.FabricConfig,
+        batch_size_per_row: int = USERS_PER_ROW,
         topk_fallback: bool = False,
     ) -> ModelDecodeConfig:
-        return cls.model_config(hf_config, mesh_device, fabric_config, "decode", topk_fallback=topk_fallback)
+        return cls.model_config(
+            hf_config,
+            mesh_device,
+            fabric_config,
+            "decode",
+            batch_size_per_row=batch_size_per_row,
+            topk_fallback=topk_fallback,
+        )
 
     @classmethod
     def prefill_model_config(

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -351,12 +351,7 @@ class MoE(SharedStateAddOn, AbstractModule):
         # MoE Gate
         topk_experts_weights, topk_experts_indices = cls._fwd_moe_gate(x, cfg)
 
-        # Repeat + Permute Expert weights
-
-        topk_experts_weights = cls._fwd_repeat_permute_expert_weights(topk_experts_weights, cfg)
-
         # MOE
-
         post_combine_output_tensor = cls._fwd_moe(
             x,
             topk_experts_indices,
@@ -366,6 +361,8 @@ class MoE(SharedStateAddOn, AbstractModule):
             batch_size,
             seq_len,
         )
+        ttnn.deallocate(topk_experts_weights)
+        ttnn.deallocate(topk_experts_indices)
 
         # Note: sum_experts and reduce_scatter is handled by the caller (decoder block or test)
 
@@ -409,18 +406,25 @@ class MoE(SharedStateAddOn, AbstractModule):
             topk_experts_indices_rm, shape=(batch_size_per_device, 1, seq_len, cfg["num_experts_per_tok"])
         )
 
-        # Chunk along local batch dimension to keep all_to_all_dispatch output small in prefill.
-        chunk_size = min(batch_size_per_device, max(1, cfg.get("moe_chunk_size", batch_size_per_device)))
+        # Chunk along local batch dimension to keep prefill intermediates (especially topk tilize) small.
+        chunk_size = min(batch_size_per_device, max(1, int(cfg.get("moe_chunk_size", min(batch_size_per_device, 256)))))
         output_chunks: list[ttnn.Tensor] = []
 
         def _slice_topk_weights(batch_start: int, batch_end: int) -> ttnn.Tensor:
             token_start = batch_start * seq_len
             token_end = batch_end * seq_len
-            return ttnn.slice(
+            topk_weights_chunk = ttnn.slice(
                 topk_experts_weights,
                 [0, 0, token_start, 0],
-                [cfg["num_experts_per_tok"], 1, token_end, cfg["hidden_size"]],
+                [1, 1, token_end, cfg["num_experts_per_tok"]],
             )
+            topk_weights_chunk_rm = ttnn.to_layout(topk_weights_chunk, ttnn.ROW_MAJOR_LAYOUT)
+            ttnn.deallocate(topk_weights_chunk)
+            topk_weights_chunk_rm = ttnn.repeat(topk_weights_chunk_rm, **cfg["topk_weights_repeat"])
+            topk_weights_chunk_rm = ttnn.permute(topk_weights_chunk_rm, (3, 1, 2, 0))
+            topk_weights_chunk = ttnn.to_layout(topk_weights_chunk_rm, ttnn.TILE_LAYOUT)
+            ttnn.deallocate(topk_weights_chunk_rm)
+            return topk_weights_chunk
 
         for batch_start in range(0, batch_size_per_device, chunk_size):
             batch_end = min(batch_start + chunk_size, batch_size_per_device)
@@ -452,7 +456,9 @@ class MoE(SharedStateAddOn, AbstractModule):
                 shape=(1, 1, batch_size_chunk * seq_len, cfg["hidden_size"]),
             )
             dispatch_chunk = ttnn.repeat(dispatch_chunk, **cfg["activations_repeat"])
-            dispatch_chunk = ttnn.to_layout(dispatch_chunk, ttnn.TILE_LAYOUT)
+            dispatch_chunk_rm = dispatch_chunk
+            dispatch_chunk = ttnn.to_layout(dispatch_chunk_rm, ttnn.TILE_LAYOUT)
+            ttnn.deallocate(dispatch_chunk_rm)
             ttnn.deallocate(all_to_all_dispatch_output_tensors)
 
             experts_output = MoEExperts._forward(dispatch_chunk, cfg["moe_experts"])
@@ -481,14 +487,19 @@ class MoE(SharedStateAddOn, AbstractModule):
                 all_to_all_combine_output_tensors,
                 shape=(cfg["num_experts_per_tok"], 1, batch_chunk * seq_len, cfg["hidden_size"]),
             )
-            post_combine_output_tensor = ttnn.to_layout(post_combine_output_tensor, ttnn.TILE_LAYOUT)
+            post_combine_output_tensor_rm = post_combine_output_tensor
+            post_combine_output_tensor = ttnn.to_layout(post_combine_output_tensor_rm, ttnn.TILE_LAYOUT)
+            ttnn.deallocate(all_to_all_combine_output_tensors)
 
             topk_weights_chunk = _slice_topk_weights(batch_start, batch_end)
-            post_combine_output_tensor = ttnn.mul(
+            post_combine_weighted_output_tensor = ttnn.mul(
                 post_combine_output_tensor, topk_weights_chunk, **cfg["mul_experts_output_with_weights"]
             )
+            ttnn.deallocate(post_combine_output_tensor)
             ttnn.deallocate(topk_weights_chunk)
 
+            post_combine_output_tensor = ttnn.sum(post_combine_weighted_output_tensor, dim=0, keepdim=True)
+            ttnn.deallocate(post_combine_weighted_output_tensor)
             output_chunks.append(post_combine_output_tensor)
 
         if len(output_chunks) == 1:

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -41,6 +41,9 @@ class MoE(SharedStateAddOn, AbstractModule):
     See the `AbstractModule` docstring for usage info.
     """
 
+    PREFILL_TOKEN_CHUNK_SIZE = 16384
+    PREFILL_BATCH_CHUNK_SIZE = 256
+
     @classmethod
     def convert_weights(
         cls,
@@ -314,8 +317,8 @@ class MoE(SharedStateAddOn, AbstractModule):
     def forward(cls, x: ttnn.Tensor, cfg: RunDecodeConfig | RunPrefillConfig) -> ttnn.Tensor:
         # Chunk the full MoE prefill path at 16K tokens to avoid OOM.
         # Use global token count (local seq_len * num_dispatch_devices) to decide.
-        chunk_tokens = int(cfg.get("prefill_chunk_size", 16384))
-        num_dispatch_devices = int(cfg.get("num_dispatch_devices", 1))
+        chunk_tokens = cls.PREFILL_TOKEN_CHUNK_SIZE
+        num_dispatch_devices = cfg["num_dispatch_devices"]
         global_tokens = x.shape[2] * num_dispatch_devices
         if global_tokens > chunk_tokens:
             chunk_size = max(1, chunk_tokens // max(1, num_dispatch_devices))
@@ -344,8 +347,8 @@ class MoE(SharedStateAddOn, AbstractModule):
     def _forward_impl(cls, x: ttnn.Tensor, cfg: RunDecodeConfig | RunPrefillConfig) -> ttnn.Tensor:
         # Validate input dimensions
         hidden_size = cfg["hidden_size"]
-        mesh_device = cfg.get("mesh_device")
-        tp_size = mesh_device.shape[1] if mesh_device else 1
+        mesh_device = cfg["mesh_device"]
+        tp_size = mesh_device.shape[1]
 
         x_dim = x.shape[-1]
         expected_dims = [hidden_size, hidden_size // tp_size] if tp_size > 1 else [hidden_size]
@@ -425,7 +428,7 @@ class MoE(SharedStateAddOn, AbstractModule):
         )
 
         # Chunk along local batch dimension to keep prefill intermediates (especially topk tilize) small.
-        chunk_size = min(batch_size_per_device, max(1, int(cfg.get("moe_chunk_size", min(batch_size_per_device, 256)))))
+        chunk_size = min(batch_size_per_device, cls.PREFILL_BATCH_CHUNK_SIZE)
         output_chunks: list[ttnn.Tensor] = []
 
         def _slice_topk_weights(batch_start: int, batch_end: int) -> ttnn.Tensor:

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -394,17 +394,6 @@ class MoE(SharedStateAddOn, AbstractModule):
         return MoEGate.forward(x, cfg["moe_gate"])
 
     @classmethod
-    def _fwd_repeat_permute_expert_weights(
-        cls, topk_experts_weights: ttnn.Tensor, cfg: RunDecodeConfig | RunPrefillConfig
-    ) -> ttnn.Tensor:
-        topk_experts_weights_rm = ttnn.to_layout(topk_experts_weights, ttnn.ROW_MAJOR_LAYOUT)
-        topk_experts_weights_rm = ttnn.repeat(topk_experts_weights_rm, **cfg["topk_weights_repeat"])
-        topk_experts_weights_rm = ttnn.permute(topk_experts_weights_rm, (3, 1, 2, 0))
-        topk_experts_weights = ttnn.to_layout(topk_experts_weights_rm, ttnn.TILE_LAYOUT)
-        ttnn.deallocate(topk_experts_weights_rm)
-        return topk_experts_weights
-
-    @classmethod
     def _fwd_moe(
         cls,
         x: ttnn.Tensor,

--- a/models/demos/deepseek_v3/tt/moe_gate.py
+++ b/models/demos/deepseek_v3/tt/moe_gate.py
@@ -305,6 +305,8 @@ class MoEGate(AbstractModule):
         # Sigmoid activation
         scores = ttnn.sigmoid(logits)
         ttnn.deallocate(logits)
+        token_count = scores.shape[1] * scores.shape[2]
+        scores_flat = scores if scores.shape[1] == 1 else ttnn.reshape(scores, (1, 1, token_count, scores.shape[3]))
         # Add score correction bias
         # Expand bias to match scores shape(dynamic shape)
         scores_correction_bias = cfg["add_score_correction_bias"]["input_tensor_b"]
@@ -316,8 +318,13 @@ class MoEGate(AbstractModule):
             memory_config=cfg["add_score_correction_bias"]["memory_config"],
             dtype=cfg["add_score_correction_bias"]["dtype"],
         )
+        scores_with_bias_flat = (
+            scores_with_bias
+            if scores_with_bias.shape[1] == 1
+            else ttnn.reshape(scores_with_bias, (1, 1, token_count, scores_with_bias.shape[3]))
+        )
         # Reshape scores to expert groups
-        expert_scores_grouped = ttnn.reshape(scores_with_bias, **cfg["reshape_scores"])
+        expert_scores_grouped = ttnn.reshape(scores_with_bias_flat, **cfg["reshape_scores"])
         num_experts_per_group = expert_scores_grouped.shape[3]
 
         # calculate top-2 scores with expert groups
@@ -364,11 +371,11 @@ class MoEGate(AbstractModule):
 
         # create full expert_groups_mask(dynamic shape)
         input_mask = cfg["scatter_top_expert_groups"]["input"]
-        input_mask = ttnn.repeat(input_mask, ttnn.Shape((1, 1, scores.shape[2], 1)))
+        input_mask = ttnn.repeat(input_mask, ttnn.Shape((1, 1, token_count, 1)))
 
         # create full src tensor of ones
         src_tensor = cfg["scatter_top_expert_groups"]["src"]
-        src_tensor = ttnn.repeat(src_tensor, ttnn.Shape((1, 1, scores.shape[2], 1)))
+        src_tensor = ttnn.repeat(src_tensor, ttnn.Shape((1, 1, token_count, 1)))
 
         # scatter top-k expert groups indices to full expert_groups_mask
         active_groups_mask = ttnn.scatter(
@@ -385,7 +392,7 @@ class MoEGate(AbstractModule):
         active_experts_mask = ttnn.repeat(active_groups_mask, ttnn.Shape((1, 1, 1, num_experts_per_group)))
         ttnn.deallocate(active_groups_mask)
         active_experts_mask = ttnn.reshape(active_experts_mask, **cfg["reshape_active_experts"])
-        active_experts_scores = ttnn.mul(scores_with_bias, active_experts_mask, **cfg["mul_scores_with_mask"])
+        active_experts_scores = ttnn.mul(scores_with_bias_flat, active_experts_mask, **cfg["mul_scores_with_mask"])
         ttnn.deallocate(scores_with_bias)
         ttnn.deallocate(active_experts_mask)
 
@@ -402,7 +409,7 @@ class MoEGate(AbstractModule):
         ttnn.deallocate(topk_experts_scores_with_bias)
 
         # gather original scores without bias
-        topk_experts_scores = ttnn.gather(scores, dim=3, index=topk_experts_indices)
+        topk_experts_scores = ttnn.gather(scores_flat, dim=3, index=topk_experts_indices)
         ttnn.deallocate(scores)
 
         # normalize scores

--- a/models/demos/deepseek_v3/tt/mtp.py
+++ b/models/demos/deepseek_v3/tt/mtp.py
@@ -179,11 +179,20 @@ class MTP2D(AbstractModule):
         hf_config: PretrainedConfig,
         mesh_device: ttnn.MeshDevice,
         fabric_config: ttnn.FabricConfig,
+        batch_size_per_row: int,
     ) -> ModelDecodeConfig:
-        hidden_norm_cfg = DistributedRMSNorm.decode_model_config(hf_config, mesh_device)
-        token_norm_cfg = DistributedRMSNorm.decode_model_config(hf_config, mesh_device)
-        decoder_block_cfg = MoEDecoderBlock2D.decode_model_config(hf_config, mesh_device, fabric_config)
-        head_norm_cfg = DistributedRMSNorm.decode_model_config(hf_config, mesh_device)
+        hidden_norm_cfg = DistributedRMSNorm.decode_model_config(
+            hf_config, mesh_device, batch_size_per_row=batch_size_per_row
+        )
+        token_norm_cfg = DistributedRMSNorm.decode_model_config(
+            hf_config, mesh_device, batch_size_per_row=batch_size_per_row
+        )
+        decoder_block_cfg = MoEDecoderBlock2D.decode_model_config(
+            hf_config, mesh_device, fabric_config, batch_size_per_row=batch_size_per_row
+        )
+        head_norm_cfg = DistributedRMSNorm.decode_model_config(
+            hf_config, mesh_device, batch_size_per_row=batch_size_per_row
+        )
         head_cfg = LMHead1D.decode_model_config(mesh_device)
         # Decode is single-token, so keep the MTP-specific intermediate tensors in L1.
         decode_memory_config = ttnn.L1_MEMORY_CONFIG

--- a/models/demos/deepseek_v3/tt/mtp.py
+++ b/models/demos/deepseek_v3/tt/mtp.py
@@ -132,10 +132,16 @@ class MTP2D(AbstractModule):
         hf_config: PretrainedConfig,
         mesh_device: ttnn.MeshDevice,
         fabric_config: ttnn.FabricConfig,
+        batch_size_per_row: int,
     ) -> ModelPrefillConfig:
         hidden_norm_cfg = DistributedRMSNorm.prefill_model_config(hf_config, mesh_device)
         token_norm_cfg = DistributedRMSNorm.prefill_model_config(hf_config, mesh_device)
-        decoder_block_cfg = MoEDecoderBlock2D.prefill_model_config(hf_config, mesh_device, fabric_config)
+        decoder_block_cfg = MoEDecoderBlock2D.prefill_model_config(
+            hf_config,
+            mesh_device,
+            fabric_config,
+            batch_size_per_row=batch_size_per_row,
+        )
         head_norm_cfg = DistributedRMSNorm.prefill_model_config(hf_config, mesh_device)
         head_cfg = LMHead1D.prefill_model_config(mesh_device)
         return {

--- a/models/demos/deepseek_v3/tt/rms_norm/distributed_rms_norm.py
+++ b/models/demos/deepseek_v3/tt/rms_norm/distributed_rms_norm.py
@@ -87,7 +87,12 @@ class DistributedRMSNorm(RMSNormBase):
         )  # type: ignore
 
     @classmethod
-    def decode_model_config(cls, hf_config: PretrainedConfig, mesh_device: ttnn.Device) -> ModelDecodeConfig:
+    def decode_model_config(
+        cls,
+        hf_config: PretrainedConfig,
+        mesh_device: ttnn.Device,
+        batch_size_per_row: int = USERS_PER_ROW,
+    ) -> ModelDecodeConfig:
         """Generate decode configuration for this module.
 
         Args:
@@ -100,7 +105,7 @@ class DistributedRMSNorm(RMSNormBase):
         shard_core_grid = ttnn.CoreGrid(x=4, y=7)
         memory_config = ttnn.create_sharded_memory_config(
             shape=(
-                ttnn.core.roundup(USERS_PER_ROW, ttnn.TILE_SIZE),
+                ttnn.core.roundup(batch_size_per_row, ttnn.TILE_SIZE),
                 ttnn.core.roundup(
                     even_int_div(hf_config.hidden_size, shard_core_grid.num_cores * mesh_device.shape[1]),
                     ttnn.TILE_SIZE,

--- a/models/demos/deepseek_v3/tt/rms_norm/distributed_rms_norm.py
+++ b/models/demos/deepseek_v3/tt/rms_norm/distributed_rms_norm.py
@@ -21,7 +21,6 @@ from models.demos.deepseek_v3.utils.config_dataclass import (
 )
 from models.demos.deepseek_v3.utils.config_helpers import (
     COMPUTE_KERNEL_CONFIG_HIFI4_NOFP32_ACC,
-    USERS_PER_ROW,
     even_int_div,
     get_state_dicts,
     shard_and_save,
@@ -91,7 +90,7 @@ class DistributedRMSNorm(RMSNormBase):
         cls,
         hf_config: PretrainedConfig,
         mesh_device: ttnn.Device,
-        batch_size_per_row: int = USERS_PER_ROW,
+        batch_size_per_row: int,
     ) -> ModelDecodeConfig:
         """Generate decode configuration for this module.
 

--- a/models/demos/deepseek_v3/tt/rms_norm/rms_norm.py
+++ b/models/demos/deepseek_v3/tt/rms_norm/rms_norm.py
@@ -62,7 +62,12 @@ class RMSNorm(RMSNormBase):
         )
 
     @classmethod
-    def decode_model_config(cls, hf_config: PretrainedConfig, mesh_device: ttnn.Device) -> ModelDecodeConfig:
+    def decode_model_config(
+        cls,
+        hf_config: PretrainedConfig,
+        mesh_device: ttnn.Device,
+        batch_size_per_row: int | None = None,
+    ) -> ModelDecodeConfig:
         return RMSNormConfig(
             epsilon=hf_config.rms_norm_eps,
             weight=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),

--- a/models/demos/deepseek_v3/tt/rope.py
+++ b/models/demos/deepseek_v3/tt/rope.py
@@ -162,7 +162,7 @@ class RotarySetup:
                 mesh_shape=self.device.shape,
             ),
             device=None if on_host else self.device,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            memory_config=None if on_host else ttnn.DRAM_MEMORY_CONFIG,
         )
 
     def get_position_idxs_tensor(self, position_idxs, on_host: bool = False):

--- a/models/demos/deepseek_v3/tt/rope.py
+++ b/models/demos/deepseek_v3/tt/rope.py
@@ -145,7 +145,7 @@ class RotarySetup:
             raise ValueError(
                 f"position idxs must be < max_seq_len ({self.hf_config.max_seq_len}); "
                 f"got max position {max_pos}. "
-                "Trim inputs or increase the configured max_seq_len (DeepseekGenerator MAX_SEQ_LEN)."
+                "Trim inputs or increase the configured max_seq_len."
             )
 
         # Add padding if needed

--- a/models/demos/deepseek_v3/tt/rope.py
+++ b/models/demos/deepseek_v3/tt/rope.py
@@ -124,14 +124,8 @@ class RotarySetup:
             mesh_mapper=ttnn.ReplicateTensorToMesh(device),
         )
 
-    def get_rot_idxs(self, position_idxs, on_host: bool = False):
-        """
-        Get the rotary positional embedding indices for the given position indices.
-        Args:
-            position_idxs: A tensor of shape [batch] containing the position indices.
-        Returns:
-            rot_idxs: A tensor of shape [1, batch] containing the rotary positional embedding indices.
-        """
+    def _position_idxs_to_tensor(self, position_idxs, *, dtype, on_host: bool = False):
+        """Map decode position ids to the row-sharded mesh layout used by DeepSeek decode."""
         assert isinstance(position_idxs, torch.Tensor), "Position ids must be a torch tensor"
         assert len(position_idxs.shape) == 1, "position idxs must be a [batch] tensor"
 
@@ -158,9 +152,9 @@ class RotarySetup:
         pad_size = ttnn.core.roundup(position_idxs.shape[1], ttnn.TILE_SIZE) - position_idxs.shape[1]
         position_idxs = torch.nn.functional.pad(position_idxs, (0, pad_size), "constant", 0)
 
-        rot_idxs = ttnn.as_tensor(
+        return ttnn.as_tensor(
             position_idxs,
-            dtype=ttnn.uint32,
+            dtype=dtype,
             layout=ttnn.ROW_MAJOR_LAYOUT,
             mesh_mapper=ttnn.ShardTensor2dMesh(
                 self.device,
@@ -171,7 +165,19 @@ class RotarySetup:
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
         )
 
-        return rot_idxs
+    def get_position_idxs_tensor(self, position_idxs, on_host: bool = False):
+        """Get decode position ids as an int32 tensor with row-sharded mesh layout."""
+        return self._position_idxs_to_tensor(position_idxs, dtype=ttnn.int32, on_host=on_host)
+
+    def get_rot_idxs(self, position_idxs, on_host: bool = False):
+        """
+        Get the rotary positional embedding indices for the given position indices.
+        Args:
+            position_idxs: A tensor of shape [batch] containing the position indices.
+        Returns:
+            rot_idxs: A tensor of shape [1, batch] containing the rotary positional embedding indices.
+        """
+        return self._position_idxs_to_tensor(position_idxs, dtype=ttnn.uint32, on_host=on_host)
 
     def get_rot_mats_table(self, seq_len: int | None = None):
         """

--- a/models/demos/deepseek_v3/utils/config_helpers.py
+++ b/models/demos/deepseek_v3/utils/config_helpers.py
@@ -20,6 +20,7 @@ from models.demos.deepseek_v3.utils.lazy_state_dict import LazyStateDict
 # Constants
 NORM_CATEGORIES = {"attention_norm", "mlp_norm", "q_norm", "k_norm"}
 USERS_PER_ROW = 32
+DEFAULT_MAX_SEQ_LEN = 2048
 SEQ_LEN_CHUNK_SIZE = 1024  # NOTE: should be 512 for blackhole (in case of future bring-up)
 TOPK_MIN_WIDTH = 64  # Minimum width of the topk input tensor
 MAX_TOP_K = 32

--- a/models/demos/deepseek_v3/utils/test_utils.py
+++ b/models/demos/deepseek_v3/utils/test_utils.py
@@ -215,7 +215,27 @@ def run_reference_with_attention(
     Intermediate tensors are explicitly freed between chunks using del.
     Attention weights are not stored by setting output_attentions=False, since they scale quadratically with sequence length.
     """
-    (batch_size,) = position_ids_or_seq_lens.shape
+    activation_batch_size = activation.shape[0]
+    if position_ids_or_seq_lens.ndim != 1:
+        raise ValueError(f"position_ids_or_seq_lens must be 1D, got shape {tuple(position_ids_or_seq_lens.shape)}")
+
+    if mode == "prefill":
+        if position_ids_or_seq_lens.numel() == 1 and activation_batch_size != 1:
+            # Older tests pass a scalar seq_len even when the activation batch is larger.
+            # Expand it here so reference-mask construction follows the true batch size.
+            position_ids_or_seq_lens = position_ids_or_seq_lens.expand(activation_batch_size)
+        elif position_ids_or_seq_lens.shape[0] != activation_batch_size:
+            raise ValueError(
+                "Prefill position_ids_or_seq_lens batch must match activation batch: "
+                f"{position_ids_or_seq_lens.shape[0]} != {activation_batch_size}"
+            )
+    elif position_ids_or_seq_lens.shape[0] != activation_batch_size:
+        raise ValueError(
+            "Decode position_ids_or_seq_lens batch must match activation batch: "
+            f"{position_ids_or_seq_lens.shape[0]} != {activation_batch_size}"
+        )
+
+    batch_size = activation_batch_size
     dim = hf_config.kv_lora_rank + hf_config.qk_rope_head_dim
     num_layers = hf_config.num_hidden_layers
     max_position_id_or_seq_len = position_ids_or_seq_lens.max().item()

--- a/models/demos/deepseek_v3/utils/test_utils.py
+++ b/models/demos/deepseek_v3/utils/test_utils.py
@@ -5,6 +5,7 @@
 import inspect
 import itertools
 import os
+import tempfile
 from copy import deepcopy
 from pathlib import Path
 from typing import Any, Literal
@@ -634,6 +635,11 @@ def get_test_weight_config(
     :func:`get_weight_config` in its internal sub-path, so they are not
     needed here either.
 
+    Random-weight conversions are cached under a local scratch root rather
+    than the shared DeepSeek cache mount. That keeps random-weight tests
+    independent from read-only CI cache mounts and from stale random caches
+    produced by older revisions on other hosts.
+
     When ``test_name`` is ``None`` the function falls back to
     ``PYTEST_CURRENT_TEST`` for backward compatibility.
 
@@ -654,7 +660,16 @@ def get_test_weight_config(
         weight_config_id = "/".join(parts)
     else:
         weight_config_id = os.environ.get("PYTEST_CURRENT_TEST", "unknown_test")
-    per_test_weight_cache_path = cache_path / "tests_cache" / weight_config_id
+    if real_weights:
+        per_test_weight_cache_path = cache_path / "tests_cache" / weight_config_id
+    else:
+        random_cache_root = os.getenv("DEEPSEEK_V3_RANDOM_TEST_CACHE")
+        if random_cache_root is None:
+            sha_tag = os.getenv("GITHUB_SHA", "local")[:12]
+            random_cache_root = Path(tempfile.gettempdir()) / "tt-metal-deepseek-v3-random-tests-cache" / sha_tag
+        else:
+            random_cache_root = Path(random_cache_root)
+        per_test_weight_cache_path = Path(random_cache_root) / "tests_cache" / weight_config_id
     return get_weight_config(
         ModuleClass, hf_config, state_dicts, per_test_weight_cache_path, mesh_device, force_recalculate
     )

--- a/models/demos/deepseek_v3/utils/test_utils.py
+++ b/models/demos/deepseek_v3/utils/test_utils.py
@@ -676,22 +676,6 @@ def get_rope_tensors(
     return rope_setup.get_rot_mats(position_ids)
 
 
-def get_position_ids_tensor(
-    hf_config: PretrainedConfig,
-    batch_size_per_row: int,
-    position_ids: torch.Tensor,
-    mesh_device: ttnn.MeshDevice,
-    *,
-    on_host: bool = False,
-) -> ttnn.Tensor:
-    rope_setup = RotarySetup(
-        device=mesh_device,
-        batch_size_per_row=batch_size_per_row,
-        hf_config=hf_config,
-    )
-    return rope_setup.get_position_idxs_tensor(position_ids, on_host=on_host)
-
-
 # Mapping of system names to their corresponding mesh shapes
 SYSTEM_NAME_TO_MESH_SHAPE: dict[str, tuple[int, int]] = {
     "TG": (4, 8),

--- a/models/demos/deepseek_v3/utils/test_utils.py
+++ b/models/demos/deepseek_v3/utils/test_utils.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import inspect
 import itertools
 import os
 from copy import deepcopy
@@ -475,14 +476,25 @@ def pad_or_trim_seq_len(tensor: torch.Tensor, mode: Literal["prefill", "decode"]
     return padded_tensor
 
 
-def get_model_config(ModuleClass: type[AbstractModule], mode: Literal["prefill", "decode"], *args, **kwargs) -> Any:
+def get_model_config(
+    ModuleClass: type[AbstractModule],
+    mode: Literal["prefill", "decode"],
+    *args,
+    batch_size_per_row: int | None = None,
+    **kwargs,
+) -> Any:
     """Get the module config for the given mode and kwargs."""
     if mode == "prefill":
-        return ModuleClass.prefill_model_config(*args, **kwargs)
+        config_fn = ModuleClass.prefill_model_config
     elif mode == "decode":
-        return ModuleClass.decode_model_config(*args, **kwargs)
+        config_fn = ModuleClass.decode_model_config
     else:
         raise ValueError(f"Unsupported mode: {mode}. Supported modes are 'prefill' and 'decode'.")
+
+    if batch_size_per_row is not None and "batch_size_per_row" in inspect.signature(config_fn).parameters:
+        kwargs.setdefault("batch_size_per_row", batch_size_per_row)
+
+    return config_fn(*args, **kwargs)
 
 
 def run_module_forward(ModuleClass: type[AbstractModule], mode: Literal["prefill", "decode"], *args, **kwargs) -> Any:

--- a/models/demos/deepseek_v3/utils/test_utils.py
+++ b/models/demos/deepseek_v3/utils/test_utils.py
@@ -538,16 +538,25 @@ def assert_hidden_dim_pcc(
 ) -> float:
     tt_output_torch = tt_output_torch.cpu().float()
 
+    tt_leading_shape = tt_output_torch.shape[:-2]
+    reference_leading_shape = reference_output.shape[:-2]
     assert (
         all(
             d1 == d2
-            for d1, d2 in itertools.zip_longest(tt_output_torch.shape[:-2], reference_output.shape[:-2], fillvalue=1)
+            for d1, d2 in itertools.zip_longest(
+                reversed(tt_leading_shape), reversed(reference_leading_shape), fillvalue=1
+            )
         )
         and tt_output_torch.shape[-1] == reference_output.shape[-1]
     ), (
         "Model and reference output shape must match on all dimensions except for the second to last one "
         f"(module leading singleton dimensions); got {tt_output_torch.shape=} and {reference_output.shape=} "
     )
+
+    while tt_output_torch.ndim < reference_output.ndim:
+        tt_output_torch = tt_output_torch.unsqueeze(0)
+    while reference_output.ndim < tt_output_torch.ndim:
+        reference_output = reference_output.unsqueeze(0)
 
     seq_len_or_batch_size = min(tt_output_torch.shape[-2], reference_output.shape[-2])
     tt_output_torch = tt_output_torch[..., :seq_len_or_batch_size, :]

--- a/models/demos/deepseek_v3/utils/test_utils.py
+++ b/models/demos/deepseek_v3/utils/test_utils.py
@@ -2,7 +2,6 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import inspect
 import itertools
 import os
 from copy import deepcopy
@@ -517,7 +516,7 @@ def get_model_config(
     else:
         raise ValueError(f"Unsupported mode: {mode}. Supported modes are 'prefill' and 'decode'.")
 
-    if batch_size_per_row is not None and "batch_size_per_row" in inspect.signature(config_fn).parameters:
+    if mode == "decode" and batch_size_per_row is not None:
         kwargs.setdefault("batch_size_per_row", batch_size_per_row)
 
     return config_fn(*args, **kwargs)

--- a/models/demos/deepseek_v3/utils/test_utils.py
+++ b/models/demos/deepseek_v3/utils/test_utils.py
@@ -630,6 +630,22 @@ def get_rope_tensors(
     return rope_setup.get_rot_mats(position_ids)
 
 
+def get_position_ids_tensor(
+    hf_config: PretrainedConfig,
+    batch_size_per_row: int,
+    position_ids: torch.Tensor,
+    mesh_device: ttnn.MeshDevice,
+    *,
+    on_host: bool = False,
+) -> ttnn.Tensor:
+    rope_setup = RotarySetup(
+        device=mesh_device,
+        batch_size_per_row=batch_size_per_row,
+        hf_config=hf_config,
+    )
+    return rope_setup.get_position_idxs_tensor(position_ids, on_host=on_host)
+
+
 # Mapping of system names to their corresponding mesh shapes
 SYSTEM_NAME_TO_MESH_SHAPE: dict[str, tuple[int, int]] = {
     "TG": (4, 8),

--- a/models/demos/deepseek_v3/utils/test_utils.py
+++ b/models/demos/deepseek_v3/utils/test_utils.py
@@ -19,7 +19,7 @@ from models.common.utility_functions import comp_pcc
 from models.demos.deepseek_v3.scripts.generate_test_inputs_outputs import __file__ as REFERENCE_IO_SCRIPT_NAME
 from models.demos.deepseek_v3.tt.rope import RotarySetup
 from models.demos.deepseek_v3.utils.abstract_module import AbstractModule
-from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, even_int_div
+from models.demos.deepseek_v3.utils.config_helpers import even_int_div
 from models.demos.deepseek_v3.utils.hf_model_utils import dequantize_state_dict as _dequantize_state_dict
 from models.demos.deepseek_v3.utils.weight_config import get_weight_config
 from models.tt_transformers.tt.common import PagedAttentionConfig
@@ -114,10 +114,16 @@ def paged_cache_from_torch(
     """
     if user_id is not None:
         torch_cache_line = torch_cache
+        batch_size_per_row = torch_cache_line.shape[0]
+        # Row-batched prefill helpers hand us one full row worth of cache lines.
+        # Expand back to the global user space and place that row at the row selected by `user_id`.
+        row_start = (user_id // batch_size_per_row) * batch_size_per_row
+        row_end = row_start + batch_size_per_row
         torch_cache = torch.zeros(
-            (mesh_shape[0] * USERS_PER_ROW, *torch_cache_line.shape[1:]), dtype=torch_cache_line.dtype
+            (mesh_shape[0] * batch_size_per_row, *torch_cache_line.shape[1:]),
+            dtype=torch_cache_line.dtype,
         )
-        torch_cache[user_id : user_id + 1] = torch_cache_line
+        torch_cache[row_start:row_end] = torch_cache_line
 
     batch_size, num_heads, seq_len, dim = torch_cache.shape
     batches_per_device = even_int_div(batch_size, mesh_shape[0] * mesh_shape[1])

--- a/models/demos/deepseek_v3/utils/test_utils.py
+++ b/models/demos/deepseek_v3/utils/test_utils.py
@@ -5,7 +5,6 @@
 import inspect
 import itertools
 import os
-import tempfile
 from copy import deepcopy
 from pathlib import Path
 from typing import Any, Literal
@@ -635,11 +634,6 @@ def get_test_weight_config(
     :func:`get_weight_config` in its internal sub-path, so they are not
     needed here either.
 
-    Random-weight conversions are cached under a local scratch root rather
-    than the shared DeepSeek cache mount. That keeps random-weight tests
-    independent from read-only CI cache mounts and from stale random caches
-    produced by older revisions on other hosts.
-
     When ``test_name`` is ``None`` the function falls back to
     ``PYTEST_CURRENT_TEST`` for backward compatibility.
 
@@ -660,16 +654,7 @@ def get_test_weight_config(
         weight_config_id = "/".join(parts)
     else:
         weight_config_id = os.environ.get("PYTEST_CURRENT_TEST", "unknown_test")
-    if real_weights:
-        per_test_weight_cache_path = cache_path / "tests_cache" / weight_config_id
-    else:
-        random_cache_root = os.getenv("DEEPSEEK_V3_RANDOM_TEST_CACHE")
-        if random_cache_root is None:
-            sha_tag = os.getenv("GITHUB_SHA", "local")[:12]
-            random_cache_root = Path(tempfile.gettempdir()) / "tt-metal-deepseek-v3-random-tests-cache" / sha_tag
-        else:
-            random_cache_root = Path(random_cache_root)
-        per_test_weight_cache_path = Path(random_cache_root) / "tests_cache" / weight_config_id
+    per_test_weight_cache_path = cache_path / "tests_cache" / weight_config_id
     return get_weight_config(
         ModuleClass, hf_config, state_dicts, per_test_weight_cache_path, mesh_device, force_recalculate
     )

--- a/models/demos/deepseek_v3/utils/test_utils.py
+++ b/models/demos/deepseek_v3/utils/test_utils.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import inspect
 import itertools
 import os
 from copy import deepcopy
@@ -516,7 +517,7 @@ def get_model_config(
     else:
         raise ValueError(f"Unsupported mode: {mode}. Supported modes are 'prefill' and 'decode'.")
 
-    if mode == "decode" and batch_size_per_row is not None:
+    if batch_size_per_row is not None and "batch_size_per_row" in inspect.signature(config_fn).parameters:
         kwargs.setdefault("batch_size_per_row", batch_size_per_row)
 
     return config_fn(*args, **kwargs)

--- a/tests/pipeline_reorg/galaxy_demo_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_demo_tests.yaml
@@ -130,7 +130,7 @@
 - name: Galaxy DeepSeek v3 demo tests
   cmd: |
     export DEEPSEEK_V3_HF_MODEL=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-dequantized DEEPSEEK_V3_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI MESH_DEVICE=TG
-    pytest models/demos/deepseek_v3/demo/test_demo.py -k "tg_stress" --timeout 900
+    pytest models/demos/deepseek_v3/demo/test_demo.py -k "tg_stress or tg_upr8" --timeout 900
   model: deepseek_v3
   skus:
     wh_galaxy_perf:


### PR DESCRIPTION
## Summary
- Chunk the DeepSeek MLA prefill `wkv_b2` all-gather/matmul path and WO prefill matmul path to avoid large 8K+ sequence allocations.
- Fix the batch-8 decode runtime path by rounding decode shard heights, padding/slicing the Q path where needed, and moving WO input sharding to after the decode all-gather.
- Add configurable `max_users_per_row` plumbing through the DeepSeek demo, generator, and decode/prefill model-config builders so reduced-row decode is exercised through the full demo path.
- Keep retained `32-users-per-row` coverage and add explicit `8-users-per-row` decode coverage across MLA, decoder block, model, MLP, MoE, RMSNorm, and LM head.
- Fix row-batched MLA prefill output handling and decoder-block MLA resharding so the reduced-row and long-seq paths execute correctly instead of relying on stale expectations or invalid shard shapes.

## Issue
Refs #38446

## Testing
- `MESH_DEVICE=TG pytest -svv models/demos/deepseek_v3/tests/test_mla.py --timeout 1800 -x`
- `MESH_DEVICE=TG pytest -svv models/demos/deepseek_v3/tests/test_decoder_block.py --timeout 1800 -x`
- `MESH_DEVICE=TG pytest -svv models/demos/deepseek_v3/tests/test_rms_norm.py --timeout 1800 -x`
- `MESH_DEVICE=TG pytest -svv models/demos/deepseek_v3/tests/test_mlp.py --timeout 1800 -x`
- `MESH_DEVICE=TG pytest -svv models/demos/deepseek_v3/tests/test_moe.py --timeout 1800 -x`
- `MESH_DEVICE=TG pytest -svv models/demos/deepseek_v3/tests/test_model.py::test_mode_decode_forward_pass_batch_8_users_per_row --timeout 1800 -x`
- `MESH_DEVICE=TG pytest -svv models/demos/deepseek_v3/tests/test_lm_head1d.py -k 'test_forward_pass and decode and 8' --timeout 1800 -x`
- Triggered `(Galaxy) DeepSeek tests` on `yieldthought/ds-batch8-prefill-mla` for `test-type=all`: https://github.com/tenstorrent/tt-metal/actions/runs/23620900592
- Triggered `(Galaxy) demo tests` on `yieldthought/ds-batch8-prefill-mla` for `model=deepseek_v3`: https://github.com/tenstorrent/tt-metal/actions/runs/23620900685
- Triggered `DeepSeek V3 Multi-Host Tests` on `yieldthought/ds-batch8-prefill-mla` for `setup=dual` and `teacher_forced=true`: https://github.com/tenstorrent/tt-metal/actions/runs/23620900740

## CI Badge
[![(Galaxy) DeepSeek tests (yieldthought/ds-batch8-prefill-mla)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml/badge.svg?branch=yieldthought%2Fds-batch8-prefill-mla)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml?query=branch%3Ayieldthought%2Fds-batch8-prefill-mla)
[![(Galaxy) demo tests (yieldthought/ds-batch8-prefill-mla)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml/badge.svg?branch=yieldthought%2Fds-batch8-prefill-mla)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml?query=branch%3Ayieldthought%2Fds-batch8-prefill-mla)
[![(DeepSeek V3 Multi-Host Tests) (yieldthought/ds-batch8-prefill-mla)](https://github.com/tenstorrent/tt-metal/actions/workflows/multi-host-deepseekv3.yaml/badge.svg?branch=yieldthought%2Fds-batch8-prefill-mla)](https://github.com/tenstorrent/tt-metal/actions/workflows/multi-host-deepseekv3.yaml?query=branch%3Ayieldthought%2Fds-batch8-prefill-mla)


