### PR TITLE
Deduplicate replicated tensor shards during flatbuffer serialization

### DIFF
--- a/models/tt_dit/layers/module.py
+++ b/models/tt_dit/layers/module.py
@@ -100,7 +100,6 @@ class Module(ABC):
         module_key_prefix: str,
         missing_keys: MutableSequence[str],
         unexpected_keys: MutableSequence[str],
-        on_host: bool,
     ) -> None:
         state_dict = dict(state_dict)
         self._prepare_torch_state(state_dict)
@@ -114,7 +113,6 @@ class Module(ABC):
                     module_key_prefix=f"{module_key_prefix}{name}.",
                     missing_keys=missing_keys,
                     unexpected_keys=unexpected_keys,
-                    on_host=on_host,
                 )
             except LoadingError:
                 raise
@@ -125,7 +123,7 @@ class Module(ABC):
         for name, parameter in self.named_parameters():
             if name in state_dict:
                 try:
-                    parameter.load_torch_tensor(state_dict.pop(name), on_host=on_host)
+                    parameter.load_torch_tensor(state_dict.pop(name))
                 except LoadingError as err:
                     msg = f"while loading '{module_key_prefix}{name}': {err}"
                     raise LoadingError(msg) from err
@@ -135,17 +133,12 @@ class Module(ABC):
         for name in state_dict:
             unexpected_keys.append(f"{module_key_prefix}{name}")
 
-    def load_torch_state_dict(
-        self, state_dict: Mapping[str, torch.Tensor], *, strict: bool = True, on_host: bool = False
-    ) -> IncompatibleKeys:
+    def load_torch_state_dict(self, state_dict: Mapping[str, torch.Tensor], *, strict: bool = True) -> IncompatibleKeys:
         """Load PyTorch state dict into module parameters.
 
         Args:
             state_dict: Mapping of parameter names to PyTorch tensors.
             strict: If `True`, raises ValueError on missing or unexpected keys.
-            on_host: If `True`, keeps tensors in host memory. This is used when saving the module
-                to disk, since for device tensors, every shard is currently stored to disk, even
-                for replicated tensors, leading to redundant copies of data.
 
         Returns:
             `IncompatibleKeys` containing lists of missing and unexpected keys.
@@ -154,11 +147,7 @@ class Module(ABC):
         unexpected_keys = []
         self.evict_coresident_exclusions()
         self._load_torch_state_dict_inner(
-            state_dict,
-            module_key_prefix="",
-            missing_keys=missing_keys,
-            unexpected_keys=unexpected_keys,
-            on_host=on_host,
+            state_dict, module_key_prefix="", missing_keys=missing_keys, unexpected_keys=unexpected_keys
         )
 
         if strict and (missing_keys or unexpected_keys):
@@ -387,13 +376,13 @@ class Parameter:
         self.on_host = on_host
         self._data = None
 
-    def load_torch_tensor(self, torch_tensor: torch.Tensor, /, *, on_host: bool = False) -> None:
+    def load_torch_tensor(self, torch_tensor: torch.Tensor, /) -> None:
         shape = tuple(torch_tensor.shape)
         if shape != self.total_shape:
             msg = f"expected tensor shape {self.total_shape}, got {shape}"
             raise LoadingError(msg)
 
-        data = tensor.from_torch(
+        self.data = tensor.from_torch(
             torch_tensor,
             device=self.device,
             layout=self.layout,
@@ -401,9 +390,8 @@ class Parameter:
             memory_config=self.memory_config,
             pad_value=self.pad_value,
             mesh_axes=self.mesh_axes,
-            on_host=self.on_host or on_host,
+            on_host=self.on_host,
         )
-        self._set_data(data, allow_on_host=on_host)
 
     def save(self, path: str | Path, /) -> None:
         ttnn.dump_tensor(path, self.data)
@@ -425,7 +413,8 @@ class Parameter:
 
     @data.setter
     def data(self, value: ttnn.Tensor) -> None:
-        self._set_data(value)
+        self._check_data(value)
+        self._data = value
 
     def deallocate(self) -> None:
         """Deallocate the parameter's device memory."""
@@ -433,15 +422,14 @@ class Parameter:
             ttnn.deallocate(self._data)
             self._data = None
 
-    def _set_data(self, value: ttnn.Tensor, *, allow_on_host: bool = False) -> None:
+    def _check_data(self, value: ttnn.Tensor) -> None:
         if self.on_host:
             if value.device() is not None:
                 msg = "expected host tensor, got device tensor"
                 raise LoadingError(msg)
         elif value.device() is None:
-            if not allow_on_host:
-                msg = "expected device tensor, got host tensor"
-                raise LoadingError(msg)
+            msg = "expected device tensor, got host tensor"
+            raise LoadingError(msg)
         elif value.device() != self.device:
             msg = "device mismatch"
             raise LoadingError(msg)
@@ -461,5 +449,3 @@ class Parameter:
         if value.shape != self.local_shape:
             msg = f"shape mismatch: expected {self.local_shape}, got {tuple(value.shape)}"
             raise LoadingError(msg)
-
-        self._data = value

--- a/models/tt_dit/tests/models/mochi/test_transformer_mochi.py
+++ b/models/tt_dit/tests/models/mochi/test_transformer_mochi.py
@@ -495,7 +495,7 @@ def test_mochi_transformer_model_caching(
         is_fsdp=True,
     )
     start = time.time()
-    tt_model.load_torch_state_dict(torch_model.state_dict(), on_host=True)
+    tt_model.load_torch_state_dict(torch_model.state_dict())
     end = time.time()
     logger.info(f"Time taken to load state dict: {end - start} seconds")
 

--- a/models/tt_dit/tests/models/sd35/test_transformer_sd35.py
+++ b/models/tt_dit/tests/models/sd35/test_transformer_sd35.py
@@ -460,7 +460,7 @@ def test_sd35_transformer_model_caching(
         padding_config=padding_config,
     )
     start = time.time()
-    tt_model.load_torch_state_dict(torch_model.state_dict(), on_host=True)
+    tt_model.load_torch_state_dict(torch_model.state_dict())
     end = time.time()
     logger.info(f"Time taken to load state dict: {end - start} seconds")
 

--- a/models/tt_dit/tests/models/wan2_2/test_transformer_wan.py
+++ b/models/tt_dit/tests/models/wan2_2/test_transformer_wan.py
@@ -366,7 +366,7 @@ def test_wan_transformer_inner_step(
         num_layers=1,
     )
     start = time.time()
-    tt_model.load_torch_state_dict(torch_model.state_dict(), on_host=True)
+    tt_model.load_torch_state_dict(torch_model.state_dict())
     end = time.time()
     logger.info(f"Time taken to load state dict: {end - start} seconds")
 

--- a/models/tt_dit/utils/cache.py
+++ b/models/tt_dit/utils/cache.py
@@ -110,9 +110,7 @@ def load_model(
         raise MissingCacheError(cache_dir)
 
     logger.info("Cache does not exist. Loading PyTorch state dict.")
-    # Create host tensors when creating the cache to circumvent the issue that replicated device
-    # tensors lead to redundant copies when saved to disk.
-    tt_model.load_torch_state_dict(get_torch_state_dict(), on_host=create_cache)
+    tt_model.load_torch_state_dict(get_torch_state_dict())
 
     # If distributed, ensure that all processes have completed the check whether cache_dir exists,
     # before any rank might proceed to create that dir to save.
@@ -121,7 +119,6 @@ def load_model(
     if create_cache:
         logger.info(f"Writing cache to '{cache_dir}'.")
         tt_model.save(cache_dir)
-        tt_model.load(cache_dir)  # move to device
 
 
 def model_cache_dir(

--- a/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
+++ b/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
@@ -184,8 +184,12 @@ flatbuffers::Offset<ttnn::flatbuffer::Tensor> to_flatbuffer(
     std::unordered_map<const std::byte*, uint64_t> buffer_to_offset;
 
     uint64_t next_buffer_offset = 0;
-    for (const auto& coord : host_storage.buffer().shard_coords()) {
-        // Iterate over local populated shards.
+    // Iterate over distribution coordinates and map to physical coordinates via the topology.
+    const auto& topology_mesh_coords = tensor.tensor_topology().mesh_coords();
+    size_t dist_idx = 0;
+    for (const auto& dist_coord : tt::tt_metal::distributed::MeshCoordinateRange(mesh_shape)) {
+        const auto& coord = topology_mesh_coords[dist_idx++];
+
         if (const auto& buffer = host_storage.buffer().get_shard(coord); buffer.has_value()) {
             const auto* buffer_address = buffer->view_bytes().data();
             const std::size_t buffer_size = buffer->view_bytes().size();
@@ -195,7 +199,7 @@ flatbuffers::Offset<ttnn::flatbuffer::Tensor> to_flatbuffer(
             size_t key = 0;
             for (size_t dim = 0; dim < placements.size(); ++dim) {
                 if (std::holds_alternative<tt::tt_metal::distributed::MeshMapperConfig::Shard>(placements[dim])) {
-                    key = key * mesh_shape[dim] + coord[dim];
+                    key = key * mesh_shape[dim] + dist_coord[dim];
                 }
             }
 

--- a/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
+++ b/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
@@ -166,9 +166,23 @@ flatbuffers::Offset<ttnn::flatbuffer::Tensor> to_flatbuffer(
 
     const auto& host_storage = tensor.host_storage();
 
+    // Deduplicate replicated shards: two shards are duplicates if their coordinates differ only
+    // along Replicate dimensions. The deduplication key is built from coordinates at sharded
+    // dimensions only.
+    const auto& placements = tensor.tensor_topology().placements();
+    const auto& mesh_shape = tensor.tensor_topology().distribution_shape();
+    size_t unique_keys = 1;
+    for (size_t dim = 0; dim < placements.size(); ++dim) {
+        if (std::holds_alternative<tt::tt_metal::distributed::MeshMapperConfig::Shard>(placements[dim])) {
+            unique_keys *= mesh_shape[dim];
+        }
+    }
+    std::vector<uint64_t> dedup_key_to_offset(unique_keys, std::numeric_limits<uint64_t>::max());
+
     std::vector<flatbuffers::Offset<ttnn::flatbuffer::TensorShard>> shards_vector;
     // Used to deduplicate buffer addresses for replicated tensor data.
     std::unordered_map<const std::byte*, uint64_t> buffer_to_offset;
+
     uint64_t next_buffer_offset = 0;
     for (const auto& coord : host_storage.buffer().shard_coords()) {
         // Iterate over local populated shards.
@@ -177,14 +191,27 @@ flatbuffers::Offset<ttnn::flatbuffer::Tensor> to_flatbuffer(
             const std::size_t buffer_size = buffer->view_bytes().size();
 
             uint64_t shard_buffer_offset = next_buffer_offset;
-            if (auto [it, inserted] = buffer_to_offset.try_emplace(buffer_address, shard_buffer_offset); inserted) {
-                // Encountered a new buffer, add it to the buffers vector.
+
+            size_t key = 0;
+            for (size_t dim = 0; dim < placements.size(); ++dim) {
+                if (std::holds_alternative<tt::tt_metal::distributed::MeshMapperConfig::Shard>(placements[dim])) {
+                    key = key * mesh_shape[dim] + coord[dim];
+                }
+            }
+
+            if (dedup_key_to_offset.at(key) != std::numeric_limits<uint64_t>::max()) {
+                // Shards whose coordinates differ only along replicated dimensions are identical.
+                shard_buffer_offset = dedup_key_to_offset.at(key);
+            } else if (auto it = buffer_to_offset.find(buffer_address); it != buffer_to_offset.end()) {
+                // If two shards share the same buffer, they are identical.
+                shard_buffer_offset = it->second;
+            } else {
                 next_buffer_offset += buffer_size;
                 buffers.push_back(*buffer);
-            } else {
-                // Point to the existing buffer.
-                shard_buffer_offset = it->second;
             }
+
+            buffer_to_offset.emplace(buffer_address, shard_buffer_offset);
+            dedup_key_to_offset.at(key) = shard_buffer_offset;
 
             auto inline_storage = ttnn::flatbuffer::InlineFileStorage(shard_buffer_offset, buffer_size);
             auto mesh_coord_offset = to_flatbuffer(coord, builder);

--- a/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
+++ b/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
@@ -25,6 +25,7 @@
 #include <vector>
 #include <cstdint>
 #include <unordered_map>
+#include <limits>
 
 namespace ttnn {
 namespace {

--- a/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
+++ b/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
@@ -210,9 +210,9 @@ flatbuffers::Offset<ttnn::flatbuffer::Tensor> to_flatbuffer(
                 }
             }
 
-            if (dedup_key_to_offset.at(key) != std::numeric_limits<uint64_t>::max()) {
+            if (dedup_key_to_offset[key] != std::numeric_limits<uint64_t>::max()) {
                 // Shards whose coordinates differ only along replicated dimensions are identical.
-                shard_buffer_offset = dedup_key_to_offset.at(key);
+                shard_buffer_offset = dedup_key_to_offset[key];
             } else if (auto it = buffer_to_offset.find(buffer_address); it != buffer_to_offset.end()) {
                 // If two shards share the same buffer, they are identical.
                 shard_buffer_offset = it->second;
@@ -222,7 +222,7 @@ flatbuffers::Offset<ttnn::flatbuffer::Tensor> to_flatbuffer(
             }
 
             buffer_to_offset.emplace(buffer_address, shard_buffer_offset);
-            dedup_key_to_offset.at(key) = shard_buffer_offset;
+            dedup_key_to_offset[key] = shard_buffer_offset;
 
             auto inline_storage = ttnn::flatbuffer::InlineFileStorage(shard_buffer_offset, buffer_size);
             auto mesh_coord_offset = to_flatbuffer(coord, builder);

--- a/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
+++ b/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
@@ -183,9 +183,15 @@ flatbuffers::Offset<ttnn::flatbuffer::Tensor> to_flatbuffer(
     // Used to deduplicate buffer addresses for replicated tensor data.
     std::unordered_map<const std::byte*, uint64_t> buffer_to_offset;
 
-    uint64_t next_buffer_offset = 0;
-    // Iterate over distribution coordinates and map to physical coordinates via the topology.
     const auto& topology_mesh_coords = tensor.tensor_topology().mesh_coords();
+    TT_FATAL(
+        topology_mesh_coords.size() == mesh_shape.mesh_size(),
+        "Topology mesh coords size {} should match distribution shape size {}",
+        topology_mesh_coords.size(),
+        mesh_shape.mesh_size());
+
+    // Iterate over distribution coordinates and map to physical coordinates via the topology.
+    uint64_t next_buffer_offset = 0;
     size_t dist_idx = 0;
     for (const auto& dist_coord : tt::tt_metal::distributed::MeshCoordinateRange(mesh_shape)) {
         const auto& coord = topology_mesh_coords[dist_idx++];


### PR DESCRIPTION
This is a follow-up to https://github.com/tenstorrent/tt-metal/pull/38644, which was reverted due to a [failing test](https://github.com/tenstorrent/tt-metal/actions/runs/23017519847/job/66852535468). The [test now passes](https://github.com/tenstorrent/tt-metal/actions/runs/23647644033) as expected.

The previous PR used mesh coordinates for deduplication. This is incorrect if the tensor distribution shape is not the same as the physical mesh shape. The issue is fixed by iterating over distribution coordinates instead. The test now [succeeds](https://github.com/tenstorrent/tt-metal/actions/runs/23053241802).

### Problem description

When dumping tensors to disk using `ttnn.dump_tensor`, every replicated mesh shard is written, which leads to unnecessary disk usage. This is particularly problematic for multi-host setups, where the replication factor can be big.

### What's changed

  - Replicated tensor shards are now deduplicated at the C++ serialization layer (tensor_flatbuffer.cpp), so identical data along replicated mesh dimensions is stored only once on disk.
  - This removes the need for the `on_host` workaround in tt_dit's module.py and cache.py, where tensors were kept on host during cache creation to avoid redundant copies of replicated device shards. A workaround for the on single-host case only.

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=friedrich/caching-new)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:friedrich/caching-new)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=friedrich/caching-new)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:friedrich/caching-new) -Unrelated failure
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=friedrich/caching-new)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:friedrich/caching-new)
- [x] New/Existing tests provide coverage for changes
- [x] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early

#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [x] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=friedrich/caching-new)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:friedrich/caching-new) - failures unrelated (HF cache, tracy profiler regression)
  - [x] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [x] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=friedrich/caching-new)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:friedrich/caching-new) - failures unrelated (device/Ethernet timeouts in SetUp, mistral NameError, gpt-oss OOM)
  - [x] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [x] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=friedrich/caching-new)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:friedrich/caching-new) - failure unrelated (workflow bug)
  - [x] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:friedrich/caching-new) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=friedrich/caching-new)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:friedrich/caching-new) | [#2484](https://github.com/tenstorrent/tt-metal/actions/runs/24244162705) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:friedrich/caching-new) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=friedrich/caching-new)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:friedrich/caching-new) | [#17321](https://github.com/tenstorrent/tt-metal/actions/runs/24244171098) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:friedrich/caching-new) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=friedrich/caching-new)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:friedrich/caching-new) | [#5083](https://github.com/tenstorrent/tt-metal/actions/runs/24244176534) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:friedrich/caching-new) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=friedrich/caching-new)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:friedrich/caching-new) | [#844](https://github.com/tenstorrent/tt-metal/actions/runs/24244182095) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:friedrich/caching-new) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=friedrich/caching-new)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:friedrich/caching-new) | [#2875](https://github.com/tenstorrent/tt-metal/actions/runs/24244187584) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:friedrich/caching-new) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=friedrich/caching-new)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:friedrich/caching-new) | [#2257](https://github.com/tenstorrent/tt-metal/actions/runs/24244193628) |