### PR TITLE
[tt-train] Capture forward_impl by reference instead of value

### DIFF
--- a/tt-train/sources/ttml/models/common/transformer_common.hpp
+++ b/tt-train/sources/ttml/models/common/transformer_common.hpp
@@ -51,7 +51,7 @@ autograd::TensorPtr memory_efficient_runner(
     }
 
     // define grad function and copy generator (in the state before forward pass)
-    autograd::GradFunction grad = [input, mask, out, forward_impl, generator]() mutable {
+    autograd::GradFunction grad = [input, mask, out, &forward_impl, generator]() mutable {
         // detach input from existing graph
         auto input_detached = autograd::create_tensor(input->get_value());
         // enable gradients for the detached input so the graph is built during recomputation


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Fix object slicing in memory_efficient_runner when blocks are stored as base class pointers

### What's changed
Capture `forward_impl` by reference instead of by value in the gradient checkpointing lambda to prevent object slicing when the caller passes a polymorphic ModuleBase&

Motif model requires storing ffn as ModuleBase, because it can have different types (dense or moe, depends on config)


### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=philei/capture_forward_impl_by_ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:philei/capture_forward_impl_by_ref)