### PR TITLE
fix(tt_metal): add PCIe BDF alias for bh-qb-10 quietbox

### DIFF
--- a/tt_metal/fabric/physical_system_discovery.cpp
+++ b/tt_metal/fabric/physical_system_discovery.cpp
@@ -48,6 +48,12 @@ TrayID get_tray_id_for_chip(
         {"H13DSG-O-CPU", {0x01, 0x21, 0x41, 0x61, 0x81, 0xa1, 0xc1, 0xe1}},
     };
 
+    // BDF aliases: some motherboard variants enumerate PCIe slots differently
+    // Map variant BDFs to their canonical equivalents for tray_id calculation
+    static const std::unordered_map<uint16_t, uint16_t> bus_id_aliases = {
+        {0x43, 0x42},  // bh-qb-10 (SIENAD8-2L2T variant) uses 0x43 for tray 4
+    };
+
     if (using_mock_cluster_desc) {
         return TrayID{0};
     }
@@ -65,6 +71,12 @@ TrayID get_tray_id_for_chip(
     const auto& ordered_bus_ids = mobo_to_bus_ids.at(mobo_name);
     auto bus_id = tt::tt_fabric::get_bus_id(cluster_desc, chip_id);
     auto bus_id_it = std::find(ordered_bus_ids.begin(), ordered_bus_ids.end(), bus_id);
+    // Apply alias if original bus_id not found and an alias exists
+    if (bus_id_it == ordered_bus_ids.end()) {
+        if (auto alias_it = bus_id_aliases.find(bus_id); alias_it != bus_id_aliases.end()) {
+            bus_id_it = std::find(ordered_bus_ids.begin(), ordered_bus_ids.end(), alias_it->second);
+        }
+    }
     TT_FATAL(bus_id_it != ordered_bus_ids.end(), "Bus ID {} not found.", bus_id);
     auto tray_id = std::distance(ordered_bus_ids.begin(), bus_id_it) + 1;
     return TrayID{static_cast<unsigned int>(tray_id)};


### PR DESCRIPTION
## Summary
- Add BDF alias map to handle PCIe slot enumeration differences on bh-qb-10
- bh-qb-10 uses BDF 0x43 for tray 4 instead of canonical 0x42
- Fixes "Bus ID 67 not found" error on device 2 and mesh device tests

## Test plan
- [x] Build: `./build_metal.sh -c`
- [x] Run: `build/test/tt_metal/tt_fabric/test_system_health` on bh-qb-10
- [x] All 3 tests pass (ReportIntermeshLinks, ReportSystemHealth, TestMeshFullConnectivity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


- [ ] [![Blackhole E2E](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=mbezulj/2603-bh-qb-10-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:mbezulj/2603-bh-qb-10-fix)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mbezulj/2603-bh-qb-10-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mbezulj/2603-bh-qb-10-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mbezulj/2603-bh-qb-10-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mbezulj/2603-bh-qb-10-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mbezulj/2603-bh-qb-10-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mbezulj/2603-bh-qb-10-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mbezulj/2603-bh-qb-10-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mbezulj/2603-bh-qb-10-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mbezulj/2603-bh-qb-10-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mbezulj/2603-bh-qb-10-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mbezulj/2603-bh-qb-10-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mbezulj/2603-bh-qb-10-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mbezulj/2603-bh-qb-10-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mbezulj/2603-bh-qb-10-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mbezulj/2603-bh-qb-10-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mbezulj/2603-bh-qb-10-fix)