### PR TITLE
DeepSeek: apply numerical tuning for MLP, LM head, and RMSNorm

### DIFF
--- a/models/demos/deepseek_v3/tt/experts.py
+++ b/models/demos/deepseek_v3/tt/experts.py
@@ -13,6 +13,7 @@ import ttnn
 from models.demos.deepseek_v3.utils.abstract_module import AbstractModule
 from models.demos.deepseek_v3.utils.config_dataclass import FromWeightConfig, LinearConfig, MeshDeviceStub, MulConfig
 from models.demos.deepseek_v3.utils.config_helpers import (
+    COMPUTE_KERNEL_CONFIG_HIFI2,
     COMPUTE_KERNEL_CONFIG_LOFI,
     even_int_div,
     get_dequantized_tensor,
@@ -70,7 +71,7 @@ class Experts(AbstractModule):
                     _load_expert_weight(hf_name).unsqueeze(0).transpose(-1, -2),
                     shard_dims=(1, 1),
                     mesh_device=mesh_device,
-                    dtype=ttnn.bfloat8_b if hf_name == "up_proj" else ttnn.bfloat4_b,
+                    dtype=ttnn.bfloat8_b if hf_name == "down_proj" else ttnn.bfloat4_b,
                     memory_config=ttnn.DRAM_MEMORY_CONFIG,
                 )
             }
@@ -124,7 +125,7 @@ class Experts(AbstractModule):
             "w2_experts": LinearConfig(
                 input_tensor_b=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
                 memory_config=output_memory_config,
-                compute_kernel_config=COMPUTE_KERNEL_CONFIG_LOFI,
+                compute_kernel_config=COMPUTE_KERNEL_CONFIG_HIFI2,
             ),
             "w3_experts": LinearConfig(
                 input_tensor_b=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),

--- a/models/demos/deepseek_v3/tt/lm_head.py
+++ b/models/demos/deepseek_v3/tt/lm_head.py
@@ -21,7 +21,7 @@ from models.demos.deepseek_v3.utils.config_dataclass import (
     OpConfigBase,
 )
 from models.demos.deepseek_v3.utils.config_helpers import (
-    COMPUTE_KERNEL_CONFIG_LOFI,
+    COMPUTE_KERNEL_CONFIG_HIFI2,
     SEQ_LEN_CHUNK_SIZE,
     USERS_PER_ROW,
     dram_sharded_weight_config,
@@ -93,7 +93,7 @@ class LMHead(AbstractModule):
                     weight_tensor,
                     shard_dims=(-1, -1),
                     mesh_device=mesh_device,
-                    dtype=ttnn.bfloat4_b,
+                    dtype=ttnn.bfloat8_b,
                     layout=ttnn.TILE_LAYOUT,
                     memory_config=dram_sharded_weight_config(
                         hidden_dim,
@@ -186,7 +186,7 @@ class LMHead(AbstractModule):
                 program_config=get_dram_sharded_matmul_config(
                     USERS_PER_ROW, hidden_dim, even_int_div(vocab_size, num_devices), input_num_cores, output_num_cores
                 ),
-                compute_kernel_config=COMPUTE_KERNEL_CONFIG_LOFI,
+                compute_kernel_config=COMPUTE_KERNEL_CONFIG_HIFI2,
             ),
             "all_gather": AllGatherAsyncConfig(
                 mesh_device=mesh_device,
@@ -238,7 +238,7 @@ class LMHead(AbstractModule):
             "linear": LinearConfig(
                 input_tensor_b=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                compute_kernel_config=COMPUTE_KERNEL_CONFIG_LOFI,
+                compute_kernel_config=COMPUTE_KERNEL_CONFIG_HIFI2,
             ),
             "all_gather": AllGatherAsyncConfig(
                 mesh_device=mesh_device,

--- a/models/demos/deepseek_v3/tt/lm_head1d.py
+++ b/models/demos/deepseek_v3/tt/lm_head1d.py
@@ -17,7 +17,7 @@ from models.demos.deepseek_v3.utils.config_dataclass import (
     MeshDeviceStub,
 )
 from models.demos.deepseek_v3.utils.config_helpers import (
-    COMPUTE_KERNEL_CONFIG_LOFI,
+    COMPUTE_KERNEL_CONFIG_HIFI2,
     SEQ_LEN_CHUNK_SIZE,
     even_int_div,
     get_dequantized_tensor,
@@ -75,7 +75,7 @@ class LMHead1D(AbstractModule):
                     weight_tensor,
                     shard_dims=(None, -1),
                     mesh_device=mesh_device,
-                    dtype=ttnn.bfloat4_b,
+                    dtype=ttnn.bfloat8_b,
                     layout=ttnn.TILE_LAYOUT,
                     memory_config=ttnn.DRAM_MEMORY_CONFIG,
                 )
@@ -90,7 +90,7 @@ class LMHead1D(AbstractModule):
             "linear": LinearConfig(
                 input_tensor_b=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
                 memory_config=ttnn.L1_MEMORY_CONFIG,
-                compute_kernel_config=COMPUTE_KERNEL_CONFIG_LOFI,
+                compute_kernel_config=COMPUTE_KERNEL_CONFIG_HIFI2,
             ),
             "all_gather": AllGatherAsyncConfig(
                 mesh_device=mesh_device,
@@ -110,7 +110,7 @@ class LMHead1D(AbstractModule):
             "linear": LinearConfig(
                 input_tensor_b=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                compute_kernel_config=COMPUTE_KERNEL_CONFIG_LOFI,
+                compute_kernel_config=COMPUTE_KERNEL_CONFIG_HIFI2,
             ),
             "all_gather": AllGatherAsyncConfig(
                 mesh_device=mesh_device,

--- a/models/demos/deepseek_v3/tt/mlp/mlp.py
+++ b/models/demos/deepseek_v3/tt/mlp/mlp.py
@@ -22,7 +22,7 @@ from models.demos.deepseek_v3.utils.config_dataclass import (
     SavedWeight,
 )
 from models.demos.deepseek_v3.utils.config_helpers import (
-    COMPUTE_KERNEL_CONFIG_LOFI,
+    COMPUTE_KERNEL_CONFIG_HIFI2,
     SEQ_LEN_CHUNK_SIZE,
     USERS_PER_ROW,
     dram_sharded_weight_config,
@@ -51,7 +51,7 @@ class MLP(AbstractModule):
     """
 
     WEIGHT_TORCH_DTYPE = torch.bfloat16
-    WEIGHT_DTYPE = ttnn.bfloat4_b
+    WEIGHT_DTYPE = ttnn.bfloat8_b
 
     @dataclass
     class ProgramConfigData(OpConfigBase):
@@ -181,7 +181,7 @@ class MLP(AbstractModule):
         linear_op_config = LinearConfig(
             input_tensor_b=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            compute_kernel_config=COMPUTE_KERNEL_CONFIG_LOFI,
+            compute_kernel_config=COMPUTE_KERNEL_CONFIG_HIFI2,
         )
 
         # Construct the config
@@ -281,7 +281,7 @@ class MLP(AbstractModule):
                 program_config=get_dram_sharded_matmul_config(
                     USERS_PER_ROW, dim, even_int_div(hidden_dim, mesh_width), input_num_cores, inner_num_cores
                 ),
-                compute_kernel_config=COMPUTE_KERNEL_CONFIG_LOFI,
+                compute_kernel_config=COMPUTE_KERNEL_CONFIG_HIFI2,
             ),
             "w2": LinearConfig(
                 input_tensor_b=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
@@ -293,7 +293,7 @@ class MLP(AbstractModule):
                     inner_num_cores,
                     output_num_cores,
                 ),
-                compute_kernel_config=COMPUTE_KERNEL_CONFIG_LOFI,
+                compute_kernel_config=COMPUTE_KERNEL_CONFIG_HIFI2,
             ),
             "w3": LinearConfig(
                 input_tensor_b=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
@@ -301,7 +301,7 @@ class MLP(AbstractModule):
                 program_config=get_dram_sharded_matmul_config(
                     USERS_PER_ROW, dim, even_int_div(hidden_dim, mesh_width), input_num_cores, inner_num_cores
                 ),
-                compute_kernel_config=COMPUTE_KERNEL_CONFIG_LOFI,
+                compute_kernel_config=COMPUTE_KERNEL_CONFIG_HIFI2,
             ),
             "mul": MulConfig(
                 memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,

--- a/models/demos/deepseek_v3/tt/rms_norm/distributed_rms_norm.py
+++ b/models/demos/deepseek_v3/tt/rms_norm/distributed_rms_norm.py
@@ -19,7 +19,13 @@ from models.demos.deepseek_v3.utils.config_dataclass import (
     RMSNormPostAllGatherConfig,
     RMSNormPreAllGatherConfig,
 )
-from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, even_int_div, get_state_dicts, shard_and_save
+from models.demos.deepseek_v3.utils.config_helpers import (
+    COMPUTE_KERNEL_CONFIG_HIFI4,
+    USERS_PER_ROW,
+    even_int_div,
+    get_state_dicts,
+    shard_and_save,
+)
 from models.demos.deepseek_v3.utils.run_config import (
     MESH_DEVICE_STATE_DICT_KEY,
     ModelDecodeConfig,
@@ -130,6 +136,7 @@ class DistributedRMSNorm(RMSNormBase):
             "input_memory_config": memory_config,
             "rms_norm_pre_all_gather": RMSNormPreAllGatherConfig(
                 dtype=ttnn.bfloat16,
+                compute_kernel_config=COMPUTE_KERNEL_CONFIG_HIFI4,
             ),
             "all_gather": AllGatherAsyncConfig(
                 dim=3,
@@ -141,6 +148,7 @@ class DistributedRMSNorm(RMSNormBase):
                 epsilon=hf_config.rms_norm_eps,
                 weight=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
                 dtype=ttnn.bfloat16,
+                compute_kernel_config=COMPUTE_KERNEL_CONFIG_HIFI4,
             ),
         }
 

--- a/models/demos/deepseek_v3/tt/rms_norm/distributed_rms_norm.py
+++ b/models/demos/deepseek_v3/tt/rms_norm/distributed_rms_norm.py
@@ -20,7 +20,7 @@ from models.demos.deepseek_v3.utils.config_dataclass import (
     RMSNormPreAllGatherConfig,
 )
 from models.demos.deepseek_v3.utils.config_helpers import (
-    COMPUTE_KERNEL_CONFIG_HIFI4,
+    COMPUTE_KERNEL_CONFIG_HIFI4_NOFP32_ACC,
     USERS_PER_ROW,
     even_int_div,
     get_state_dicts,
@@ -136,7 +136,7 @@ class DistributedRMSNorm(RMSNormBase):
             "input_memory_config": memory_config,
             "rms_norm_pre_all_gather": RMSNormPreAllGatherConfig(
                 dtype=ttnn.bfloat16,
-                compute_kernel_config=COMPUTE_KERNEL_CONFIG_HIFI4,
+                compute_kernel_config=COMPUTE_KERNEL_CONFIG_HIFI4_NOFP32_ACC,
             ),
             "all_gather": AllGatherAsyncConfig(
                 dim=3,
@@ -148,7 +148,7 @@ class DistributedRMSNorm(RMSNormBase):
                 epsilon=hf_config.rms_norm_eps,
                 weight=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
                 dtype=ttnn.bfloat16,
-                compute_kernel_config=COMPUTE_KERNEL_CONFIG_HIFI4,
+                compute_kernel_config=COMPUTE_KERNEL_CONFIG_HIFI4_NOFP32_ACC,
             ),
         }
 

--- a/models/demos/deepseek_v3/tt/rms_norm/rms_norm.py
+++ b/models/demos/deepseek_v3/tt/rms_norm/rms_norm.py
@@ -11,7 +11,11 @@ from transformers.configuration_utils import PretrainedConfig
 import ttnn
 from models.demos.deepseek_v3.tt.rms_norm.rms_norm_base import RMSNormBase
 from models.demos.deepseek_v3.utils.config_dataclass import FromWeightConfig, MeshDeviceStub, RMSNormConfig
-from models.demos.deepseek_v3.utils.config_helpers import COMPUTE_KERNEL_CONFIG_HIFI4, get_state_dicts, shard_and_save
+from models.demos.deepseek_v3.utils.config_helpers import (
+    COMPUTE_KERNEL_CONFIG_HIFI4_NOFP32_ACC,
+    get_state_dicts,
+    shard_and_save,
+)
 from models.demos.deepseek_v3.utils.run_config import (
     ModelDecodeConfig,
     ModelPrefillConfig,
@@ -55,7 +59,7 @@ class RMSNorm(RMSNormBase):
         return RMSNormConfig(
             epsilon=hf_config.rms_norm_eps,
             weight=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
-            compute_kernel_config=COMPUTE_KERNEL_CONFIG_HIFI4,
+            compute_kernel_config=COMPUTE_KERNEL_CONFIG_HIFI4_NOFP32_ACC,
         )
 
     @classmethod
@@ -63,7 +67,7 @@ class RMSNorm(RMSNormBase):
         return RMSNormConfig(
             epsilon=hf_config.rms_norm_eps,
             weight=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
-            compute_kernel_config=COMPUTE_KERNEL_CONFIG_HIFI4,
+            compute_kernel_config=COMPUTE_KERNEL_CONFIG_HIFI4_NOFP32_ACC,
         )
 
     @staticmethod

--- a/models/demos/deepseek_v3/tt/rms_norm/rms_norm.py
+++ b/models/demos/deepseek_v3/tt/rms_norm/rms_norm.py
@@ -11,7 +11,7 @@ from transformers.configuration_utils import PretrainedConfig
 import ttnn
 from models.demos.deepseek_v3.tt.rms_norm.rms_norm_base import RMSNormBase
 from models.demos.deepseek_v3.utils.config_dataclass import FromWeightConfig, MeshDeviceStub, RMSNormConfig
-from models.demos.deepseek_v3.utils.config_helpers import COMPUTE_KERNEL_CONFIG_LOFI, get_state_dicts, shard_and_save
+from models.demos.deepseek_v3.utils.config_helpers import COMPUTE_KERNEL_CONFIG_HIFI4, get_state_dicts, shard_and_save
 from models.demos.deepseek_v3.utils.run_config import (
     ModelDecodeConfig,
     ModelPrefillConfig,
@@ -55,7 +55,7 @@ class RMSNorm(RMSNormBase):
         return RMSNormConfig(
             epsilon=hf_config.rms_norm_eps,
             weight=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
-            compute_kernel_config=COMPUTE_KERNEL_CONFIG_LOFI,
+            compute_kernel_config=COMPUTE_KERNEL_CONFIG_HIFI4,
         )
 
     @classmethod
@@ -63,7 +63,7 @@ class RMSNorm(RMSNormBase):
         return RMSNormConfig(
             epsilon=hf_config.rms_norm_eps,
             weight=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
-            compute_kernel_config=COMPUTE_KERNEL_CONFIG_LOFI,
+            compute_kernel_config=COMPUTE_KERNEL_CONFIG_HIFI4,
         )
 
     @staticmethod

--- a/models/demos/deepseek_v3/utils/config_helpers.py
+++ b/models/demos/deepseek_v3/utils/config_helpers.py
@@ -80,6 +80,13 @@ COMPUTE_KERNEL_CONFIG_HIFI4 = ttnn.WormholeComputeKernelConfig(
     packer_l1_acc=True,
 )
 
+COMPUTE_KERNEL_CONFIG_HIFI4_NOFP32_ACC = ttnn.WormholeComputeKernelConfig(
+    math_fidelity=ttnn.MathFidelity.HiFi4,
+    math_approx_mode=False,
+    fp32_dest_acc_en=False,
+    packer_l1_acc=True,
+)
+
 COMPUTE_KERNEL_CONFIG_HIFI2_NA = ttnn.WormholeComputeKernelConfig(
     math_fidelity=ttnn.MathFidelity.HiFi2,
     math_approx_mode=False,


### PR DESCRIPTION
## Summary
As part of trying to improve AIME24 scores for #38446 I made a range of reasonable-looking changes to the model. These are definitely not optimal and we will have to do a process of figuring out what we actually can run in LoFi etc anyway, but for now we should stick to the most known-good settings on main I think, so we have a solid base to iterate from.

## Changes
- Move the DeepSeek MLP and LM head weights and matmuls from lower-precision settings to BFP8 + HiFi2 where the debug branch showed better behavior.
- Move DeepSeek RMSNorm onto HiFi4 and then disable FP32 destination accumulation for those configs to match the final tuned runtime state.
- Keep the expert-side rollback from the debug branch so only `down_proj` stays BFP8 and only `w2_experts` stays on HiFi2, avoiding the broader expert precision change.

## Issue
Refs #38446

## Testing
- `python3 -m py_compile models/demos/deepseek_v3/tt/experts.py models/demos/deepseek_v3/tt/lm_head.py models/demos/deepseek_v3/tt/lm_head1d.py models/demos/deepseek_v3/tt/mlp/mlp.py models/demos/deepseek_v3/tt/rms_norm/distributed_rms_norm.py models/demos/deepseek_v3/tt/rms_norm/rms_norm.py models/demos/deepseek_v3/utils/config_helpers.py`
- `git diff --check origin/main...HEAD`
- `python3 -m pytest --collect-only models/demos/deepseek_v3/tests/test_rms_norm.py models/demos/deepseek_v3/tests/test_mlp.py models/demos/deepseek_v3/tests/test_lm_head.py -k "rms_norm or mlp or lm_head"` could not run in this shell (`No module named pytest`)
- Triggered `(Galaxy) DeepSeek tests`

## CI Badge
[![(Galaxy) DeepSeek tests (yieldthought/ds-numerical-tuning)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml/badge.svg?branch=yieldthought%2Fds-numerical-tuning)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml?query=branch%3Ayieldthought%2Fds-numerical-tuning)
