### PR TITLE
DeepSeek: add demo sampling controls

### DIFF
--- a/models/demos/deepseek_v3/demo/demo.py
+++ b/models/demos/deepseek_v3/demo/demo.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from loguru import logger
 
 import ttnn
+from models.common.sampling.generator import SamplingParams
 from models.demos.deepseek_v3.tt.generator import DeepseekGenerator as DeepseekGeneratorDP
 from models.demos.deepseek_v3.tt.model.row_batched_model import get_fabric_config
 from models.demos.deepseek_v3.utils.hf_model_utils import load_tokenizer
@@ -68,6 +69,27 @@ def create_parser() -> argparse.ArgumentParser:
     )
     p.add_argument("--max-new-tokens", type=int, default=32, help="Number of tokens to generate")
     p.add_argument("--cache-dir", type=str, required=True)
+    p.add_argument(
+        "--sampling",
+        action="store_true",
+        default=False,
+        help="Enable stochastic sampling. By default decode is greedy argmax.",
+    )
+    p.add_argument(
+        "--sampling-temperature",
+        type=float,
+        help="Sampling temperature. Default when --sampling is enabled: 0.6.",
+    )
+    p.add_argument(
+        "--sampling-top-p",
+        type=float,
+        help="Top-p (nucleus) threshold. Default when --sampling is enabled: 0.95.",
+    )
+    p.add_argument(
+        "--sampling-top-k",
+        type=int,
+        help="Top-k cutoff. Default when --sampling is enabled: 0 (disabled).",
+    )
     # Random-weights mode options (reuse Model1D pipeline; single dense layer only)
     p.add_argument(
         "--random-weights", action="store_true", help="Use randomly initialized weights instead of loading safetensors"
@@ -273,6 +295,10 @@ def run_demo(
     profile_decode: bool = False,
     sample_on_device: bool = False,
     force_recalculate: bool = False,
+    sampling: bool = False,
+    sampling_temperature: float | None = None,
+    sampling_top_p: float | None = None,
+    sampling_top_k: int | None = None,
 ) -> dict:
     """Programmatic entrypoint for the DeepSeek-V3 demo.
 
@@ -399,10 +425,38 @@ def run_demo(
                     raise SystemExit("A prompt is required unless --random-weights is used.")
                 prompt_list = prompts
 
+        sampling_params = None
+        if sampling:
+            effective_temperature = 0.6 if sampling_temperature is None else float(sampling_temperature)
+            effective_top_p = 0.95 if sampling_top_p is None else float(sampling_top_p)
+            effective_top_k = 0 if sampling_top_k is None else int(sampling_top_k)
+
+            if effective_temperature <= 0:
+                raise SystemExit("--sampling-temperature must be > 0 when --sampling is enabled.")
+            if not (0.0 < effective_top_p <= 1.0):
+                raise SystemExit("--sampling-top-p must be in the interval (0, 1].")
+            if effective_top_k < 0:
+                raise SystemExit("--sampling-top-k must be >= 0.")
+
+            sampling_params = SamplingParams(
+                temperature=effective_temperature,
+                top_p=effective_top_p,
+                top_k=effective_top_k,
+            )
+            logger.info(
+                "Sampling enabled "
+                f"(temperature={effective_temperature}, top_p={effective_top_p}, top_k={effective_top_k})"
+            )
+        else:
+            if sampling_temperature is not None or sampling_top_p is not None or sampling_top_k is not None:
+                logger.warning("Sampling parameters were provided without --sampling; using greedy argmax decode.")
+            logger.info("Sampling disabled; using greedy argmax decode.")
+
         # Multi-prompt generation
         generations, statistics = gen.generate(
             prompt_list,
             max_new_tokens=max_new_tokens,
+            sampling=sampling_params,
             teacher_forcing=token_acc,
             early_print_first_user=early_print_first_user,
             repeat_batches=repeat_batches,
@@ -482,6 +536,10 @@ def main() -> None:
         profile_decode=args.profile_decode,
         sample_on_device=args.sample_on_device,
         force_recalculate=bool(args.force_recalculate),
+        sampling=bool(args.sampling),
+        sampling_temperature=args.sampling_temperature,
+        sampling_top_p=args.sampling_top_p,
+        sampling_top_k=args.sampling_top_k,
     )
 
     # If prompts were loaded from a JSON file, save output to JSON file instead of printing

--- a/models/demos/deepseek_v3/tests/test_sampling.py
+++ b/models/demos/deepseek_v3/tests/test_sampling.py
@@ -8,6 +8,7 @@ import torch
 
 import ttnn
 from models.common.sampling import SamplingGenerator, SamplingParams, format_sampling_params
+from models.demos.deepseek_v3.tt.generator import DeepseekGenerator
 from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, make_deepseek_sampling_args
 
 
@@ -151,3 +152,31 @@ def test_deepseek_device_sampling_stochastic_behavior(mesh_device, ccl, hf_confi
         f"Only {len(sampled_set)} unique token(s) in {num_samples} samples; sampling may be stuck. "
         f"sampled_set={sorted(sampled_set)}"
     )
+
+
+def test_deepseek_host_sampling_argmax_fallback():
+    logits = torch.tensor([[1.0, 4.0, 2.0], [0.5, 0.1, 0.2]], dtype=torch.float32)
+
+    greedy = DeepseekGenerator._sample_next_token(logits, None)
+    zero_temp = DeepseekGenerator._sample_next_token(
+        logits,
+        SamplingParams(temperature=0.0, top_k=0, top_p=1.0),
+    )
+
+    expected = torch.tensor([1, 0], dtype=torch.int64)
+    assert torch.equal(greedy, expected)
+    assert torch.equal(zero_temp, expected)
+
+
+def test_deepseek_host_sampling_rejects_non_uniform_lists():
+    logits = torch.tensor([[1.0, 2.0, 3.0]], dtype=torch.float32)
+
+    with pytest.raises(ValueError, match="uniform temperature list"):
+        DeepseekGenerator._sample_next_token(
+            logits,
+            SamplingParams(
+                temperature=[1.0, 0.5],
+                top_k=0,
+                top_p=1.0,
+            ),
+        )

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -655,12 +655,28 @@ class DeepseekGenerator(WarmupForwardMixin):
         row_sums = probs.sum(dim=-1)
         valid_rows = torch.isfinite(probs).all(dim=-1) & torch.isfinite(row_sums) & (row_sums > 0)
 
+        # Honor sampling.seed (if provided) for deterministic host-side sampling.
+        generator: torch.Generator | None = None
+        if getattr(sampling, "seed", None) is not None:
+            seed_value = DeepseekGenerator._sampling_param_scalar(sampling.seed, "seed")
+            if seed_value is not None:
+                generator = torch.Generator(device=probs.device).manual_seed(int(seed_value))
+
         if valid_rows.all():
-            return torch.multinomial(probs, num_samples=1).squeeze(-1)
+            if generator is None:
+                return torch.multinomial(probs, num_samples=1).squeeze(-1)
+            return torch.multinomial(probs, num_samples=1, generator=generator).squeeze(-1)
 
         sampled_tokens = torch.argmax(logits, dim=-1)
         if valid_rows.any():
-            sampled_tokens[valid_rows] = torch.multinomial(probs[valid_rows], num_samples=1).squeeze(-1)
+            if generator is None:
+                sampled_tokens[valid_rows] = torch.multinomial(probs[valid_rows], num_samples=1).squeeze(-1)
+            else:
+                sampled_tokens[valid_rows] = torch.multinomial(
+                    probs[valid_rows],
+                    num_samples=1,
+                    generator=generator,
+                ).squeeze(-1)
         return sampled_tokens
 
     def _pad_batch(self, tokens_list: List[List[int]], batch_size: int) -> Tuple[torch.Tensor, torch.Tensor]:

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -606,6 +606,63 @@ class DeepseekGenerator(WarmupForwardMixin):
     def _sample_greedy_on_host(self, logits: torch.Tensor) -> torch.Tensor:
         return torch.argmax(logits, dim=-1)  # [B]
 
+    @staticmethod
+    def _sampling_param_scalar(value, name: str):
+        if isinstance(value, list):
+            if not value:
+                raise ValueError(f"{name} must not be an empty list")
+            first = value[0]
+            if any(v != first for v in value[1:]):
+                raise ValueError(f"Host-side sampling requires a scalar or uniform {name} list, got {value}")
+            return first
+        return value
+
+    @staticmethod
+    def _sample_next_token(logits: torch.Tensor, sampling: SamplingParams | None) -> torch.Tensor:
+        """Sample next tokens from host logits.
+
+        Falls back to greedy argmax when sampling is disabled or temperature <= 0.
+        """
+        if sampling is None:
+            return torch.argmax(logits, dim=-1)
+
+        temperature = float(DeepseekGenerator._sampling_param_scalar(sampling.temperature, "temperature"))
+        if temperature <= 0:
+            return torch.argmax(logits, dim=-1)
+
+        top_k = int(DeepseekGenerator._sampling_param_scalar(sampling.top_k, "top_k"))
+        top_p = float(DeepseekGenerator._sampling_param_scalar(sampling.top_p, "top_p"))
+        scores = logits / temperature
+
+        if top_k > 0:
+            top_k = min(top_k, scores.shape[-1])
+            kth_values = torch.topk(scores, top_k, dim=-1).values[..., -1, None]
+            scores = scores.masked_fill(scores < kth_values, float("-inf"))
+
+        if 0.0 < top_p < 1.0:
+            sorted_scores, sorted_indices = torch.sort(scores, descending=True, dim=-1)
+            sorted_probs = torch.softmax(sorted_scores, dim=-1)
+            cumulative_probs = torch.cumsum(sorted_probs, dim=-1)
+            remove_mask = cumulative_probs > top_p
+            remove_mask[..., 0] = False
+            sorted_scores = sorted_scores.masked_fill(remove_mask, float("-inf"))
+
+            filtered_scores = torch.full_like(scores, float("-inf"))
+            filtered_scores.scatter_(dim=-1, index=sorted_indices, src=sorted_scores)
+            scores = filtered_scores
+
+        probs = torch.softmax(scores, dim=-1)
+        row_sums = probs.sum(dim=-1)
+        valid_rows = torch.isfinite(probs).all(dim=-1) & torch.isfinite(row_sums) & (row_sums > 0)
+
+        if valid_rows.all():
+            return torch.multinomial(probs, num_samples=1).squeeze(-1)
+
+        sampled_tokens = torch.argmax(logits, dim=-1)
+        if valid_rows.any():
+            sampled_tokens[valid_rows] = torch.multinomial(probs[valid_rows], num_samples=1).squeeze(-1)
+        return sampled_tokens
+
     def _pad_batch(self, tokens_list: List[List[int]], batch_size: int) -> Tuple[torch.Tensor, torch.Tensor]:
         """Pad/pack a list of token id sequences to batch of size batch_size.
 
@@ -697,6 +754,13 @@ class DeepseekGenerator(WarmupForwardMixin):
 
         # Run one or more prefill+decode batches
         for _ in range(repeat_batches):
+            if self.sample_on_device:
+                self._reset_sampling_state(
+                    self.sampling_params if sampling is None else sampling,
+                    self.batch_size,
+                    self.batch_size_per_row,
+                )
+
             # Reset teacher-forcing state per batch.
             if teacher_forcing is not None:
                 teacher_forcing.reset()
@@ -747,7 +811,7 @@ class DeepseekGenerator(WarmupForwardMixin):
                         prefill_logits_sampled_host = self._tokens_from_device(
                             prefill_logits_sampled_device, self.mesh_device, batch_size_per_row=1
                         )
-                        pred_token = prefill_logits_sampled_host[0]
+                        pred_token = int(prefill_logits_sampled_host[0].item())
                         ttnn.deallocate(prefill_logits)
                         ttnn.deallocate(prefill_logits_sampled_device)
                     else:
@@ -757,7 +821,7 @@ class DeepseekGenerator(WarmupForwardMixin):
                         ), "prefill_logits should be a torch.Tensor on host"
                         # Sample only from the actual last prompt position for this user.
                         last_token_logits = prefill_logits[0, 0, max(prompt_len - 1, 0), :]
-                        pred_token = self._sample_greedy_on_host(last_token_logits)
+                        pred_token = int(self._sample_next_token(last_token_logits.unsqueeze(0), sampling).item())
                     prefill_tokens.append(torch.tensor(pred_token, dtype=torch.int64))
                     self.ccl.reset_sem_counters()
                 prefill_tokens = torch.stack(prefill_tokens)
@@ -834,7 +898,7 @@ class DeepseekGenerator(WarmupForwardMixin):
 
                     else:
                         assert isinstance(decode_logits, torch.Tensor), "decode_logits should be a torch.Tensor on host"
-                        pred_tokens = self._sample_greedy_on_host(decode_logits)
+                        pred_tokens = self._sample_next_token(decode_logits, sampling)
 
                     if teacher_forcing is not None:
                         # Record user-0 prediction for accuracy, then force teacher token.


### PR DESCRIPTION
## Summary
- add explicit sampling controls to the DeepSeek demo CLI and `run_demo()`
- make the generator honor `sampling=` for host and device sampling paths
- add lightweight host-side coverage for sampling fallback and validation

## Testing
- `python3 -m py_compile models/demos/deepseek_v3/demo/demo.py models/demos/deepseek_v3/tt/generator.py models/demos/deepseek_v3/tests/test_sampling.py`
- `git diff --check`
- local `pytest` unavailable in this shell (`No module named pytest`)

Refs #38446