### PR TITLE
Temporary: disable flaky test_tt_decoder_forward[1link-load_dit-small_latent] in t3k_mochi_tests

### DIFF
--- a/models/tt_dit/tests/models/mochi/test_vae_mochi.py
+++ b/models/tt_dit/tests/models/mochi/test_vae_mochi.py
@@ -740,6 +740,9 @@ def load_dit(
 )
 @vae_device_config
 def test_tt_decoder_forward(mesh_device, config, reset_seeds, load_dit_weights, num_links):
+    # TODO(#39806): re-enable once root cause is fixed (groupnorm TT_THROW on 1link + load_dit + small_latent)
+    if num_links == 1 and load_dit_weights and config["name"] == "small_latent":
+        pytest.skip("Temporarily disabled - see https://github.com/tenstorrent/tt-metal/issues/39806")
     input_shape = config["input_shape"]
     N, C, T, H, W = input_shape
 


### PR DESCRIPTION
## Why this test is temporarily disabled

The **(T3K) T3000 integration tests** job **t3k_mochi_tests** has been failing in 3 consecutive runs on main due to a deterministic failure in one parametrization of `test_tt_decoder_forward`: the case `1link` + `load_dit` + `small_latent` fails with:

`RuntimeError: TT_THROW @ /project/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp:49: tt::exception`

## Issue

- **Issue:** https://github.com/tenstorrent/tt-metal/issues/39806

## Exact test(s) disabled

- `models/tt_dit/tests/models/mochi/test_vae_mochi.py::test_tt_decoder_forward` — only the parametrization `[wormhole_b0-mesh_device0-device_params0-1link-load_dit-small_latent]` is skipped via a runtime `pytest.skip()` when `num_links == 1 and load_dit_weights and config["name"] == "small_latent"`.

## Re-enable intent

This is a temporary mitigation. The test should be re-enabled once the root cause (groupnorm TT_THROW in this configuration) is fixed. The code includes `TODO(#39806): re-enable once root cause is fixed` and the skip reason links to the issue.
