### PR TITLE
Replace deprecated loader.exec_module in sweep

### DIFF
--- a/tests/ttnn/sweep_tests/sweeps/__init__.py
+++ b/tests/ttnn/sweep_tests/sweeps/__init__.py
@@ -8,8 +8,7 @@ import pickle
 import sqlite3
 from types import ModuleType
 import zlib
-from importlib.machinery import SourceFileLoader
-from importlib.util import module_from_spec
+from importlib.util import spec_from_file_location, module_from_spec
 
 import enlighten
 import pandas as pd
@@ -21,19 +20,21 @@ SWEEP_RESULTS_DIR = SWEEPS_DIR / "results"
 DATABASE_FILE_NAME = SWEEP_RESULTS_DIR / "db.sqlite"
 
 
-class SweepFileLoader(SourceFileLoader):
-    def load_module(self) -> ModuleType:
-        spec = self.spec
-        module = module_from_spec(spec)
-        self.exec_module(module)
-
-        if not hasattr(module, "skip"):
-            setattr(module, "skip", lambda **kwargs: (False, None))
-
-        if not hasattr(module, "xfail"):
-            setattr(module, "xfail", lambda **kwargs: (False, None))
-
-        return module
+def _load_sweep_module(sweep_name: str, file_name: pathlib.Path | str) -> ModuleType:
+    module_path_parts = pathlib.PurePath(sweep_name).parts
+    module_name = f"sweep_module_{'.'.join(module_path_parts)}"
+    spec = spec_from_file_location(module_name, str(file_name))
+    if spec is None:
+        raise RuntimeError(f"Failed to load sweep module: spec_from_file_location returned None for {file_name!r}")
+    if spec.loader is None:
+        raise RuntimeError(f"Failed to load sweep module: spec has no loader for {file_name!r}")
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    if not hasattr(module, "skip"):
+        setattr(module, "skip", lambda **kwargs: (False, None))
+    if not hasattr(module, "xfail"):
+        setattr(module, "xfail", lambda **kwargs: (False, None))
+    return module
 
 
 if not SWEEP_RESULTS_DIR.exists():
@@ -125,7 +126,7 @@ def run_single_test(file_name, index, *, device):
     logger.info(f"Running {file_name}")
 
     sweep_name = get_sweep_name(file_name)
-    sweep_module = SweepFileLoader(f"sweep_module_{sweep_name}", str(file_name)).load_module()
+    sweep_module = _load_sweep_module(sweep_name, file_name)
     permutation = list(permutations(sweep_module.parameters))[index]
 
     pretty_printed_parameters = ",\n".join(
@@ -144,7 +145,7 @@ def run_single_test(file_name, index, *, device):
 def run_sweep(file_name, *, device):
     current_datetime = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
     sweep_name = get_sweep_name(file_name)
-    sweep_module = SweepFileLoader(f"sweep_module_{sweep_name}", str(file_name)).load_module()
+    sweep_module = _load_sweep_module(sweep_name, file_name)
 
     parameter_names = get_parameter_names(sweep_module.parameters)
     column_names = ["sweep_name", "timestamp", "status", "exception"] + parameter_names

--- a/tests/ttnn/sweep_tests/test_sweeps.py
+++ b/tests/ttnn/sweep_tests/test_sweeps.py
@@ -2,8 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-from importlib.machinery import SourceFileLoader
-from importlib.util import module_from_spec
+from importlib.util import spec_from_file_location, module_from_spec
 from .sweeps import (
     SWEEP_SOURCES_DIR,
     permutations,
@@ -32,10 +31,13 @@ for file_name in sorted(SWEEP_SOURCES_DIR.glob("**/*.py")):
 def create_test_function(file_name):
     base_name = os.path.basename(file_name)
     base_name = os.path.splitext(base_name)[0]
-    loader = SourceFileLoader(f"sweep_module_{base_name}", str(file_name))
-    spec = loader.spec
+    spec = spec_from_file_location(f"sweep_module_{base_name}", str(file_name))
+    if spec is None:
+        raise RuntimeError(f"Failed to load sweep module: spec_from_file_location returned None for {file_name!r}")
+    if spec.loader is None:
+        raise RuntimeError(f"Failed to load sweep module: spec has no loader for {file_name!r}")
     sweep_module = module_from_spec(spec)
-    loader.exec_module(sweep_module)
+    spec.loader.exec_module(sweep_module)
     base_name = base_name + ".csv"
     sweep_tests = []
     for sweep_test_index, parameter_list in enumerate(permutations(sweep_module.parameters)):


### PR DESCRIPTION
### Ticket
None

### Problem description

1. Current state is broken, command `pytest tests/ttnn/sweep_tests/test_sweeps.py` fails:

```
_________________________________________ ERROR collecting tests/ttnn/sweep_tests/test_sweeps.py __________________________________________
tests/ttnn/sweep_tests/test_sweeps.py:58: in <module>
    test_func = create_test_function(file_name)
tests/ttnn/sweep_tests/test_sweeps.py:36: in create_test_function
    spec = loader.spec
E   AttributeError: 'SourceFileLoader' object has no attribute 'spec'
```

2. `load_module` from `SourceFileLoader` is deprecated and will be removed in python 3.15
https://docs.python.org/3.12/library/importlib.html#importlib.machinery.SourceFileLoader

### What's changed
Replace `SourceFileLoader` by `spec_from_file_location`.

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vlad/no-deprecetad-funcs-in-sweep)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vlad/no-deprecetad-funcs-in-sweep)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vlad/no-deprecetad-funcs-in-sweep)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vlad/no-deprecetad-funcs-in-sweep)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vlad/no-deprecetad-funcs-in-sweep)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vlad/no-deprecetad-funcs-in-sweep)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vlad/no-deprecetad-funcs-in-sweep)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vlad/no-deprecetad-funcs-in-sweep)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vlad/no-deprecetad-funcs-in-sweep)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vlad/no-deprecetad-funcs-in-sweep)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vlad/no-deprecetad-funcs-in-sweep)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vlad/no-deprecetad-funcs-in-sweep)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
