### PR TITLE
Change Merge Gate Smoke/Basic Tests To Regular P150b-Viommu Runner When Not Triggered By merge_gate

### DIFF
--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -181,11 +181,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [
-          "N300-viommu",
-          "in-service-dedicated-merge-gate", # run t3k tests on CIv1 for now in order to have dedicated machine
-          "p150b-viommu-prio",
-        ]
+        # run t3k tests on CIv1 for now in order to have dedicated machine
+        platform: ${{ github.event_name == 'merge_group'
+            && fromJSON('["N300-viommu","in-service-dedicated-merge-gate","p150b-viommu-prio"]')
+            || fromJSON('["N300-viommu","in-service-dedicated-merge-gate","p150b-viommu"]') }}
     uses: ./.github/workflows/smoke.yaml
     with:
       docker-image: ${{ needs.build-tsan.outputs.dev-docker-image }}
@@ -205,11 +204,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [
-          "N300-viommu",
-          "in-service-dedicated-merge-gate", # run t3k tests on CIv1 for now in order to have dedicated machine
-          "p150b-viommu-prio",
-        ]
+        # run t3k tests on CIv1 for now in order to have dedicated machine
+        platform: ${{ github.event_name == 'merge_group'
+            && fromJSON('["N300-viommu","in-service-dedicated-merge-gate","p150b-viommu-prio"]')
+            || fromJSON('["N300-viommu","in-service-dedicated-merge-gate","p150b-viommu"]') }}
     uses: ./.github/workflows/smoke.yaml
     with:
       docker-image: ${{ needs.build-tsan.outputs.dev-docker-image }}
@@ -253,10 +251,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [
-          "N150-viommu",
-          "p150b-viommu-prio",
-        ]
+        platform: ${{ github.event_name == 'merge_group'
+            && fromJSON('["N150-viommu","p150b-viommu-prio"]')
+            || fromJSON('["N150-viommu","p150b-viommu"]') }}
     uses: ./.github/workflows/basic.yaml
     with:
       docker-image: ${{ needs.build-asan.outputs.dev-docker-image }}
@@ -276,10 +273,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [
-          "N150-viommu",
-          "p150b-viommu-prio",
-        ]
+        platform: ${{ github.event_name == 'merge_group'
+            && fromJSON('["N150-viommu","p150b-viommu-prio"]')
+            || fromJSON('["N150-viommu","p150b-viommu"]') }}
     uses: ./.github/workflows/basic.yaml
     with:
       docker-image: ${{ needs.build-asan.outputs.dev-docker-image }}


### PR DESCRIPTION
### Problem description

The p150b-viommu-prio runner will soon be restricted to only the merge_group trigger. This means that only merge gate triggered in the merge queue will be able to use the priority runners, and non-priority triggers like workflow_dispatch will receive an error when attempting to use it.

### What's changed

Conditionally select the p150b-viommu-prio runner only when the merge gate is triggered via merge_group. For all other triggers, the regular p150b-viommu runner is used instead. This applies to all four test jobs, being metalium/ttnn smoke tests and metalium/ttnn basic tests.