### PR TITLE
Fixing Galaxy Multiprocess Test missing symbol error

### DIFF
--- a/.github/actions/run-multi-process-tests/action.yml
+++ b/.github/actions/run-multi-process-tests/action.yml
@@ -5,6 +5,9 @@ runs:
   steps:
     - name: Run Multi-Process tests
       shell: bash
+      env:
+        LD_LIBRARY_PATH: /work/build/lib
+        TT_METAL_HOME: /work
       run: |
         python3 tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py
         tt-run --mpi-args "--allow-run-as-root" --rank-binding 4x4_multi_big_mesh_rank_binding.yaml ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_dual_big_mesh_fabric_2d_sanity.yaml

--- a/tests/tt_metal/tt_fabric/CMakeLists.txt
+++ b/tests/tt_metal/tt_fabric/CMakeLists.txt
@@ -35,6 +35,7 @@ target_link_libraries(
         tt_metal
         test_common_libs
         yaml-cpp::yaml-cpp
+        spdlog::spdlog
 )
 
 target_include_directories(


### PR DESCRIPTION
Fixing this error:
```
2026-03-13 16:43:40.771 | INFO     | __main__:generate_tray_to_pcie_device_mapping:26 - Running: build/test/tt_metal/tt_fabric/test_physical_discovery --gtest_filter=*GenerateTrayToPCIeDeviceMapping*
build/test/tt_metal/tt_fabric/test_physical_discovery: symbol lookup error: build/test/tt_metal/tt_fabric/test_physical_discovery: undefined symbol: _ZN6spdlog5sinks9base_sinkINSt3__15mutexEE11set_patternERKNS2_12basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEE
2026-03-13 16:43:40.780 | ERROR    | __main__:generate_tray_to_pcie_device_mapping:31 - ['build/test/tt_metal/tt_fabric/test_physical_discovery', '--gtest_filter=*GenerateTrayToPCIeDeviceMapping*'] Failed to generate tray to pcie device mapping
```

https://github.com/tenstorrent/tt-metal/actions/runs/23059947631/job/66984891118

- [x] [Galaxy unit](https://github.com/tenstorrent/tt-metal/actions/runs/23063558236)