### PR TITLE
[skip ci] ci: bump ttsim default version v1.4.2 → v1.4.3

### DIFF
--- a/.github/workflows/ttsim.yaml
+++ b/.github/workflows/ttsim.yaml
@@ -21,7 +21,7 @@ on:
       ttsim-version:
         required: false
         type: string
-        default: "v1.4.2"
+        default: "v1.4.3"
       job-timeout:
         required: false
         type: number


### PR DESCRIPTION
Bumps the default `ttsim-version` in `.github/workflows/ttsim.yaml` from `v1.4.2` to `v1.4.3`.

Release: https://github.com/tenstorrent/ttsim/releases/tag/v1.4.3