### PR TITLE
[Bug Fix] Fix enqueue_read_buffer for 1D MeshDevice

### DIFF
--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -2129,6 +2129,39 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, TestNonblockingReads) {
     }
 }
 
+TEST_F(UnitMeshCQSingleCardBufferFixture, EnqueueBufferVariousDims) {
+    // Release fixture devices to use different mesh device dimensions
+    devices_.clear();
+    reserved_devices_.clear();
+
+    for (const distributed::MeshShape& mesh_shape : {distributed::MeshShape(1, 1), distributed::MeshShape(1)}) {
+        auto mesh_device = distributed::MeshDevice::create(distributed::MeshDeviceConfig(mesh_shape));
+
+        for (const BufferType buftype : {BufferType::DRAM, BufferType::L1}) {
+            constexpr uint32_t page_size = 2048;
+            constexpr uint32_t num_pages = 8;
+            constexpr uint32_t buf_size = num_pages * page_size;
+
+            distributed::DeviceLocalBufferConfig local_config{
+                .page_size = page_size, .buffer_type = buftype, .bottom_up = false};
+            const distributed::ReplicatedBufferConfig buffer_config{.size = buf_size};
+
+            auto buf = distributed::MeshBuffer::create(buffer_config, local_config, mesh_device.get());
+            auto src = local_test_functions::generate_arange_vector(buf->size());
+
+            EXPECT_NO_THROW(distributed::EnqueueWriteMeshBuffer(mesh_device->mesh_command_queue(), buf, src, false));
+
+            std::vector<uint32_t> dst;
+            EXPECT_NO_THROW(distributed::EnqueueReadMeshBuffer(mesh_device->mesh_command_queue(), dst, buf, true));
+
+            EXPECT_EQ(src, dst);
+        }
+
+        mesh_device->close();
+        mesh_device.reset();
+    }
+}
+
 }  // end namespace basic_tests
 
 namespace stress_tests {

--- a/tt_metal/distributed/mesh_command_queue_base.cpp
+++ b/tt_metal/distributed/mesh_command_queue_base.cpp
@@ -215,7 +215,8 @@ void MeshCommandQueueBase::enqueue_read_mesh_buffer(
         this->read_sharded_buffer(*buffer, host_data);
     } else {
         std::vector<distributed::ShardDataTransfer> shard_data_transfers = {
-            distributed::ShardDataTransfer{MeshCoordinate(0, 0)}.host_data(host_data)};
+            distributed::ShardDataTransfer{MeshCoordinate::zero_coordinate(buffer->device()->shape().dims())}.host_data(
+                host_data)};
         // enqueue_read_shards will call lock_api_function_(), no need to call it here
         this->enqueue_read_shards(shard_data_transfers, buffer, blocking);
     }


### PR DESCRIPTION
### Ticket
N/A

### Problem description
EnqueueReadMeshBuffer was not working with a 1D MeshDevice because the ShardDataTransfer was hardcoded to 2 dimensions (0,0).

```
2026-03-13 18:34:34.220 | critical |          Always | TT_FATAL: Coordinate dimensions do not match: 2 != 1 (assert.hpp:104)
terminate called after throwing an instance of 'std::runtime_error'
  what():  TT_FATAL @ /localdev/nhuang/main/tt-metal/tt_metal/common/mesh_coord.cpp:290: coord.dims() == dims()
info:
Coordinate dimensions do not match: 2 != 1
backtrace:
```

### What's changed
- Get the dimensions from `buffer->device()->shape().dims()` instead
- Add unit test `UnitMeshCQSingleCardBufferFixture.EnqueueBufferVariousDims`

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nhuang/fix-1d)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nhuang/fix-1d)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nhuang/fix-1d)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nhuang/fix-1d)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nhuang/fix-1d)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nhuang/fix-1d)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nhuang/fix-1d)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nhuang/fix-1d)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nhuang/fix-1d)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nhuang/fix-1d)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nhuang/fix-1d)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nhuang/fix-1d)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
