### PR TITLE
tt_metal/ttnn: add #pragma once to hpp files missing include guards

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -15,6 +15,10 @@
 #
 # === Evaluated ===
 #
+# modernize-use-pragma-once:
+#   Intentionally enabled. Enforces #pragma once in all header files instead
+#   of #ifndef/#define include guards. Requires clang-tidy >= 18 (project uses clang-20).
+#
 # bugprone-unchecked-optional-access:
 #   Attempted, no fixit, lots of violations. Extensive usage of std::optional in this codebase.
 #

--- a/tests/tests_common/sfpu_helper/sfpu_helper.hpp
+++ b/tests/tests_common/sfpu_helper/sfpu_helper.hpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 // Sfpu golden functions
 #include <cmath>
 #include <numbers>

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_write_worker_latency_ubench_common.hpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_write_worker_latency_ubench_common.hpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include <cstdint>
 #include <array>
 #include "eth_l1_address_map.h"

--- a/tt-train/sources/examples/nano_gpt/3tier/common.hpp
+++ b/tt-train/sources/examples/nano_gpt/3tier/common.hpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include <ttnn/distributed/create_socket.hpp>
 
 #include "core/distributed/distributed.hpp"

--- a/tt-train/sources/ttml/metal/ops/sdpa_bw/device/kernels/compute/sdpa_bw_compute_utils.hpp
+++ b/tt-train/sources/ttml/metal/ops/sdpa_bw/device/kernels/compute/sdpa_bw_compute_utils.hpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include <api/debug/dprint.h>
 #include <api/compute/reg_api.h>
 

--- a/tt-train/sources/ttml/metal/ops/sdpa_fw/device/kernels/compute/sdpa_compute_utils.hpp
+++ b/tt-train/sources/ttml/metal/ops/sdpa_fw/device/kernels/compute/sdpa_compute_utils.hpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include <cstdint>
 
 #include "api/compute/compute_kernel_api.h"

--- a/tt-train/sources/ttml/modules/distributed/multi_head_attention.hpp
+++ b/tt-train/sources/ttml/modules/distributed/multi_head_attention.hpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include <cstdint>
 
 #include "autograd/tensor.hpp"

--- a/tt-train/sources/ttml/nanobind/nb_export_enum.hpp
+++ b/tt-train/sources/ttml/nanobind/nb_export_enum.hpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include <nanobind/nanobind.h>
 
 #include <enchantum/enchantum.hpp>

--- a/tt-train/sources/ttml/ops/multi_head_utils.hpp
+++ b/tt-train/sources/ttml/ops/multi_head_utils.hpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include "autograd/tensor.hpp"
 
 namespace ttml::ops {

--- a/tt_metal/common/core_assignment.hpp
+++ b/tt_metal/common/core_assignment.hpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include <stdint.h>
 #include <umd/device/types/arch.hpp>  // tt::ARCH
 #include <vector>

--- a/tt_metal/detail/reports/report_utils.hpp
+++ b/tt_metal/detail/reports/report_utils.hpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include <string>
 #include "impl/context/metal_context.hpp"
 

--- a/tt_metal/distributed/mesh_workload_utils.hpp
+++ b/tt_metal/distributed/mesh_workload_utils.hpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include <host_api.hpp>
 #include <stdint.h>
 

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_edge_node_router.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_edge_node_router.hpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include "fabric/fabric_edm_packet_header.hpp"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp"
 

--- a/tt_metal/impl/dispatch/debug_tools.hpp
+++ b/tt_metal/impl/dispatch/debug_tools.hpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include <device.hpp>
 #include <host_api.hpp>
 #include <fstream>

--- a/tt_metal/jit_build/depend.hpp
+++ b/tt_metal/jit_build/depend.hpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include <string>
 #include <unordered_map>
 #include <vector>

--- a/ttnn/cpp/ttnn/operations/ccl/common/kernels/minimal_ccl_common.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/kernels/minimal_ccl_common.hpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include "api/dataflow/dataflow_api.h"
 #include <tt-metalium/buffer_types.hpp>
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"

--- a/ttnn/cpp/ttnn/operations/ccl/common/kernels/moe_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/kernels/moe_utils.hpp
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
+#pragma once
+
 #include <tuple>
 
 #include "tt_metal/fabric/hw/inc/tt_fabric_api.h"

--- a/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 // This file contains common kernel functions used in data movement device kernels
 // It's best to copy and paste the functions in rather than include the header as code size will likely explode
 // Best to separate in to cpp/hpp at some point to avoid the code size explosion but need to figure out the linking

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_common.hpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include "api/dataflow/dataflow_api.h"
 
 #include <cstdint>

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/common.hpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 // Takes in an id_per_dim and dims array, both of size ndims
 // Advances the id_per_dim by one, wrapping and carrying as needed
 static inline int advance_tensor_index(

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/compute/sort_common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/compute/sort_common.hpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 namespace NAMESPACE {
 
 /**

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/cross_core_data_exchange_common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/cross_core_data_exchange_common.hpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include "api/dataflow/dataflow_api.h"
 
 #include <cstdint>

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/sort_dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/sort_dataflow_common.hpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include "api/dataflow/dataflow_api.h"
 
 template <typename T = uint16_t>

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/strided_all_gather_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/strided_all_gather_common.hpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include "api/dataflow/dataflow_api.h"
 #include <tt-metalium/buffer_types.hpp>
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/matmul_dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/matmul_dataflow_common.hpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include <cstdint>
 #include <algorithm>
 #include <tuple>

--- a/ttnn/cpp/ttnn/operations/full/device/kernels/full_kernel_common.hpp
+++ b/ttnn/cpp/ttnn/operations/full/device/kernels/full_kernel_common.hpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 union value {
     float f;
     uint32_t u;

--- a/ttnn/cpp/ttnn/operations/point_to_point/device/kernels/common.hpp
+++ b/ttnn/cpp/ttnn/operations/point_to_point/device/kernels/common.hpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 ///
 
+#pragma once
+
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 
 namespace tt::point_to_point::common {

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/kernels/dataflow/utils.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/kernels/dataflow/utils.hpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include <stdint.h>
 
 #include "api/dataflow/dataflow_api.h"

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_common_funcs.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_common_funcs.hpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 namespace NAMESPACE {
 void process_and_sort_tiles(
     uint32_t input_cb_index,

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/topk_dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/topk_dataflow_common.hpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 /**
  * Generate index tiles for TopK multicore local processing phase.
  *

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk_nanobind.hpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include "ttnn-nanobind/nanobind_fwd.hpp"
 
 namespace ttnn::operations::reduction::detail {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include <cstdint>
 
 #define REDUCE_OP (PoolType::MAX)

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include <cstdint>
 #include <algorithm>
 #include "api/dataflow/dataflow_api.h"

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include <vector>

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/rt_args_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/rt_args_common.hpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include <tt-metalium/constants.hpp>
 #include <optional>
 #include <tuple>

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_windowed/device/kernels/array_view.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_windowed/device/kernels/array_view.hpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include "api/debug/assert.h"
 #include "api/debug/dprint_tile.h"
 #include "api/debug/dprint.h"


### PR DESCRIPTION
Scanned all 2045 `.hpp` files in the repo (excluding `third_party`) and found **35 files** missing both `#pragma once` and `#ifndef`/`#define` include guards.

Added `#pragma once` after the SPDX header block in each file. All pre-commit hooks pass including clang-format.

**Files fixed (35):**
- `tests/tests_common/sfpu_helper/sfpu_helper.hpp`
- `tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_write_worker_latency_ubench_common.hpp`
- `tt-train/sources/examples/nano_gpt/3tier/common.hpp`
- `tt-train/sources/ttml/metal/ops/sdpa_bw/device/kernels/compute/sdpa_bw_compute_utils.hpp`
- `tt-train/sources/ttml/metal/ops/sdpa_fw/device/kernels/compute/sdpa_compute_utils.hpp`
- `tt-train/sources/ttml/modules/distributed/multi_head_attention.hpp`
- `tt-train/sources/ttml/nanobind/nb_export_enum.hpp`
- `tt-train/sources/ttml/ops/multi_head_utils.hpp`
- `tt_metal/common/core_assignment.hpp`
- `tt_metal/detail/reports/report_utils.hpp`
- `tt_metal/distributed/mesh_workload_utils.hpp`
- `tt_metal/fabric/hw/inc/edm_fabric/fabric_edge_node_router.hpp`
- `tt_metal/impl/dispatch/debug_tools.hpp`
- `tt_metal/jit_build/depend.hpp`
- `ttnn/cpp/ttnn/operations/ccl/common/kernels/minimal_ccl_common.hpp`
- `ttnn/cpp/ttnn/operations/ccl/common/kernels/moe_utils.hpp`
- `ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp`
- `ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_common.hpp`
- `ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/common.hpp`
- `ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/compute/sort_common.hpp`
- `ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/cross_core_data_exchange_common.hpp`
- `ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/sort_dataflow_common.hpp`
- `ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/strided_all_gather_common.hpp`
- `ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/matmul_dataflow_common.hpp`
- `ttnn/cpp/ttnn/operations/full/device/kernels/full_kernel_common.hpp`
- `ttnn/cpp/ttnn/operations/point_to_point/device/kernels/common.hpp`
- `ttnn/cpp/ttnn/operations/reduction/prod/device/kernels/dataflow/utils.hpp`
- `ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_common_funcs.hpp`
- `ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/topk_dataflow_common.hpp`
- `ttnn/cpp/ttnn/operations/reduction/topk/topk_nanobind.hpp`
- `ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp`
- `ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp`
- `ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp`
- `ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/rt_args_common.hpp`
- `ttnn/cpp/ttnn/operations/transformer/sdpa_windowed/device/kernels/array_view.hpp`

Issue flagged by @nsextonTT