### PR TITLE
Improve tracing and add tracing to Wan

### DIFF
--- a/models/tt_dit/encoders/t5/encoder_pair.py
+++ b/models/tt_dit/encoders/t5/encoder_pair.py
@@ -15,6 +15,7 @@ import ttnn
 from ...parallel.config import EncoderParallelConfig
 from ...parallel.manager import CCLManager
 from ...utils import cache
+from ...utils.tracing import Tracer
 from .model_t5 import T5Config, T5Encoder
 
 if TYPE_CHECKING:
@@ -52,6 +53,9 @@ class T5TokenizerEncoderPair:
         self._use_attention_mask = use_attention_mask
 
         self._encoder = self._load_encoder(checkpoint, use_torch=use_torch) if enabled else None
+        self._tracer = (
+            None if use_torch or not enabled else Tracer(self._encoder.forward, device=device, clone_prep_inputs=False)
+        )
 
     def load_torch_model(self, checkpoint: str) -> T5EncoderModel:
         return T5EncoderModel.from_pretrained(checkpoint)
@@ -93,12 +97,15 @@ class T5TokenizerEncoderPair:
 
         return model
 
-    def encode(self, prompts: Iterable[str], *, num_images_per_prompt: int) -> torch.Tensor:
+    def encode(
+        self, prompts: Iterable[str], *, num_images_per_prompt: int, enable_tracing: bool = False
+    ) -> torch.Tensor:
         return _get_t5_prompt_embeds(
             prompts=prompts,
             num_images_per_prompt=num_images_per_prompt,
             tokenizer=self._tokenizer,
             text_encoder=self._encoder,
+            tracer=self._tracer if enable_tracing else None,
             sequence_length=self._sequence_length,
             empty_sequence_length=self._empty_sequence_length,
             embedding_dim=self._embedding_dim,
@@ -113,6 +120,7 @@ def _get_t5_prompt_embeds(
     *,
     prompts: Iterable[str],
     text_encoder: T5Encoder | T5EncoderModel | None,
+    tracer: Tracer | None = None,
     tokenizer: PreTrainedTokenizerBase,
     sequence_length: int,
     empty_sequence_length: int,
@@ -169,7 +177,7 @@ def _get_t5_prompt_embeds(
             if attention_mask is not None
             else None
         )
-        tt_hidden_states = text_encoder(prompt=tt_tokens, attention_mask=tt_attention_mask)
+        tt_hidden_states = (tracer or text_encoder.forward)(prompt=tt_tokens, attention_mask=tt_attention_mask)
         tt_prompt_embeds = tt_hidden_states[-1]
 
         prompt_embeds = ttnn.to_torch(ttnn.get_device_tensors(tt_prompt_embeds)[0])

--- a/models/tt_dit/encoders/t5/model_t5.py
+++ b/models/tt_dit/encoders/t5/model_t5.py
@@ -15,6 +15,7 @@ from ...layers.normalization import RMSNorm
 from ...parallel.config import EncoderParallelConfig
 from ...parallel.manager import CCLManager
 from ...utils.substate import pop_substate, rename_substate
+from ...utils.tracing import Tracer
 
 
 # Make this a dataclass. Also consider using HF config directly.
@@ -518,6 +519,7 @@ class RelativePositionEmbeddings(Module):
                 relative_attention_max_distance=self.config.relative_attention_max_distance,
             )
             r = ttnn.embedding(position_ids, self.weight.data, layout=ttnn.TILE_LAYOUT)
+            Tracer.warn_if_live()
             self.relative_bias_cache = ttnn.unsqueeze(ttnn.permute(r, (2, 0, 1)), 0)
         return self.relative_bias_cache
 

--- a/models/tt_dit/encoders/t5/model_t5.py
+++ b/models/tt_dit/encoders/t5/model_t5.py
@@ -193,11 +193,7 @@ class T5RMSNorm(RMSNorm):
         )
 
     def forward(self, x: ttnn.Tensor) -> ttnn.Tensor:
-        return super().forward(
-            x,
-            compute_kernel_config=self.compute_kernel_config,
-            program_config=ttnn.LayerNormDefaultProgramConfig(legacy_reduction=True, legacy_rsqrt=True),
-        )
+        return super().forward(x, compute_kernel_config=self.compute_kernel_config)
 
     def reference(self, x: ttnn.Tensor) -> ttnn.Tensor:
         variance = ttnn.mean(ttnn.pow(x, 2), dim=-1, keepdim=True)
@@ -417,9 +413,7 @@ class T5Attention(Module):
         scores = ttnn.matmul(q, k)
 
         scores = scores + position_bias
-        attn_weights = ttnn.softmax(
-            scores, dim=-1, numeric_stable=False, compute_kernel_config=self.layer_norm.compute_kernel_config
-        )
+        attn_weights = ttnn.softmax(scores, dim=-1, compute_kernel_config=self.layer_norm.compute_kernel_config)
         attn_output = ttnn.matmul(attn_weights, v)
         attn_output = ttnn.transformer.concatenate_heads(attn_output)
 

--- a/models/tt_dit/encoders/t5/model_t5.py
+++ b/models/tt_dit/encoders/t5/model_t5.py
@@ -193,7 +193,11 @@ class T5RMSNorm(RMSNorm):
         )
 
     def forward(self, x: ttnn.Tensor) -> ttnn.Tensor:
-        return super().forward(x, compute_kernel_config=self.compute_kernel_config)
+        return super().forward(
+            x,
+            compute_kernel_config=self.compute_kernel_config,
+            program_config=ttnn.LayerNormDefaultProgramConfig(legacy_reduction=True, legacy_rsqrt=True),
+        )
 
     def reference(self, x: ttnn.Tensor) -> ttnn.Tensor:
         variance = ttnn.mean(ttnn.pow(x, 2), dim=-1, keepdim=True)
@@ -413,7 +417,9 @@ class T5Attention(Module):
         scores = ttnn.matmul(q, k)
 
         scores = scores + position_bias
-        attn_weights = ttnn.softmax(scores, dim=-1, compute_kernel_config=self.layer_norm.compute_kernel_config)
+        attn_weights = ttnn.softmax(
+            scores, dim=-1, numeric_stable=False, compute_kernel_config=self.layer_norm.compute_kernel_config
+        )
         attn_output = ttnn.matmul(attn_weights, v)
         attn_output = ttnn.transformer.concatenate_heads(attn_output)
 

--- a/models/tt_dit/layers/conv2d.py
+++ b/models/tt_dit/layers/conv2d.py
@@ -160,6 +160,9 @@ class Conv2d(Module):
             on_host=True,
         )
 
+        self._prepared_weight = None
+        self._prepared_bias = None
+
         self.in_channels = in_channels
         self.out_channels = out_channels
         self.kernel_size = kernel_size
@@ -258,10 +261,10 @@ class Conv2d(Module):
         )
 
         try:
-            x, [out_height, out_width] = ttnn.conv2d(
+            x, (out_height, out_width), (self._prepared_weight, self._prepared_bias) = ttnn.conv2d(
                 input_tensor=x,
-                weight_tensor=self.weight.data,
-                bias_tensor=self.bias.data if self.bias is not None else None,
+                weight_tensor=self._prepared_weight or self.weight.data,
+                bias_tensor=(self._prepared_bias or self.bias.data) if self.bias is not None else None,
                 in_channels=self.in_channels // self.in_mesh_axis_size,
                 out_channels=self.weight.data.shape[0],
                 device=self.mesh_device,
@@ -275,6 +278,7 @@ class Conv2d(Module):
                 compute_config=self.compute_config,
                 slice_config=slice_config,
                 return_output_dim=True,
+                return_weights_and_bias=True,
             )
         except RuntimeError as e:
             m = re.search(r"Out of Memory: (.*)", str(e))

--- a/models/tt_dit/layers/conv2d.py
+++ b/models/tt_dit/layers/conv2d.py
@@ -13,6 +13,7 @@ import ttnn
 
 from ..parallel.config import vae_all_gather
 from ..parallel.manager import CCLManager
+from ..utils.tracing import Tracer
 from .module import Module, Parameter
 
 if TYPE_CHECKING:
@@ -261,6 +262,9 @@ class Conv2d(Module):
         )
 
         try:
+            if self._prepared_weight is None:
+                Tracer.warn_if_live()
+
             x, (out_height, out_width), (self._prepared_weight, self._prepared_bias) = ttnn.conv2d(
                 input_tensor=x,
                 weight_tensor=self._prepared_weight or self.weight.data,

--- a/models/tt_dit/layers/normalization.py
+++ b/models/tt_dit/layers/normalization.py
@@ -42,19 +42,12 @@ class RMSNorm(Module):
             self.weight = None
             self.bias = None
 
-    def forward(
-        self,
-        x: ttnn.Tensor,
-        *,
-        compute_kernel_config=None,
-        program_config: ttnn.LayerNormDefaultProgramConfig | ttnn.LayerNormShardedMultiCoreProgramConfig | None = None,
-    ) -> ttnn.Tensor:
+    def forward(self, x: ttnn.Tensor, compute_kernel_config=None) -> ttnn.Tensor:
         return ttnn.rms_norm(
             x,
             weight=self.weight.data if self.weight is not None else None,
             bias=self.bias.data if self.bias is not None else None,
             epsilon=self.norm_eps,
-            program_config=program_config,
             compute_kernel_config=compute_kernel_config,
         )
 

--- a/models/tt_dit/layers/normalization.py
+++ b/models/tt_dit/layers/normalization.py
@@ -42,12 +42,19 @@ class RMSNorm(Module):
             self.weight = None
             self.bias = None
 
-    def forward(self, x: ttnn.Tensor, compute_kernel_config=None) -> ttnn.Tensor:
+    def forward(
+        self,
+        x: ttnn.Tensor,
+        *,
+        compute_kernel_config=None,
+        program_config: ttnn.LayerNormDefaultProgramConfig | ttnn.LayerNormShardedMultiCoreProgramConfig | None = None,
+    ) -> ttnn.Tensor:
         return ttnn.rms_norm(
             x,
             weight=self.weight.data if self.weight is not None else None,
             bias=self.bias.data if self.bias is not None else None,
             epsilon=self.norm_eps,
+            program_config=program_config,
             compute_kernel_config=compute_kernel_config,
         )
 

--- a/models/tt_dit/layers/normalization.py
+++ b/models/tt_dit/layers/normalization.py
@@ -11,6 +11,7 @@ import torch
 
 import ttnn
 
+from ..utils.tracing import Tracer
 from .module import Module, Parameter
 
 
@@ -295,6 +296,7 @@ class DistributedLayerNorm(Module):
             core_range_set = ttnn.CoreRangeSet(
                 {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid.x - 1, grid.y - 1))}
             )
+            Tracer.warn_if_live()
             self._recip_tensors[key] = ttnn.create_layer_norm_reciprocals(mesh_device, core_range_set, width_per_device)
 
         self.recip_tensor = self._recip_tensors[key]

--- a/models/tt_dit/models/transformers/wan2_2/transformer_wan.py
+++ b/models/tt_dit/models/transformers/wan2_2/transformer_wan.py
@@ -23,6 +23,7 @@ from ....utils.mochi import get_rot_transformation_mat
 from ....utils.padding import pad_vision_seq_parallel
 from ....utils.substate import pop_substate, rename_substate
 from ....utils.tensor import bf16_tensor, float32_tensor, from_torch, unflatten
+from ....utils.tracing import Tracer
 from .attention_wan import WanAttention
 
 
@@ -365,6 +366,7 @@ class WanTransformer3DModel(Module):
     def get_rope_features(self, hidden_states: torch.Tensor, *, on_host: bool = False):
         if tuple(hidden_states.shape) not in self.cached_rope_features:
             rope_features = self.prepare_rope_features(hidden_states)
+            Tracer.warn_if_live()
             self.cached_rope_features[(tuple(hidden_states.shape), on_host)] = rope_features
         return self.cached_rope_features[(tuple(hidden_states.shape), on_host)]
 

--- a/models/tt_dit/models/transformers/wan2_2/transformer_wan.py
+++ b/models/tt_dit/models/transformers/wan2_2/transformer_wan.py
@@ -362,13 +362,15 @@ class WanTransformer3DModel(Module):
         # Torch fallbacks
         self.rope.load_state_dict(pop_substate(state, "rope"))
 
-    def get_rope_features(self, hidden_states):
+    def get_rope_features(self, hidden_states: torch.Tensor, *, on_host: bool = False):
         if tuple(hidden_states.shape) not in self.cached_rope_features:
             rope_features = self.prepare_rope_features(hidden_states)
-            self.cached_rope_features[tuple(hidden_states.shape)] = rope_features
-        return self.cached_rope_features[tuple(hidden_states.shape)]
+            self.cached_rope_features[(tuple(hidden_states.shape), on_host)] = rope_features
+        return self.cached_rope_features[(tuple(hidden_states.shape), on_host)]
 
-    def prepare_rope_features(self, hidden_states):
+    def prepare_rope_features(
+        self, hidden_states: torch.Tensor, *, on_host: bool = False
+    ) -> tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor]:
         """
         Given video input, compute RoPE features.
         Return tensors on device.
@@ -395,14 +397,16 @@ class WanTransformer3DModel(Module):
             device=self.mesh_device,
             dtype=ttnn.float32,
             mesh_axes=[..., sp_axis, None],
+            on_host=on_host,
         )
         tt_rope_sin_1HND = from_torch(
             rope_sin_1HND,
             device=self.mesh_device,
             dtype=ttnn.float32,
             mesh_axes=[..., sp_axis, None],
+            on_host=on_host,
         )
-        tt_trans_mat = bf16_tensor(trans_mat, device=self.mesh_device)
+        tt_trans_mat = from_torch(trans_mat, device=self.mesh_device, on_host=on_host)
 
         logger.info(f"TT rope cos shape: {tt_rope_cos_1HND.shape}")
         logger.info(f"TT rope sin shape: {tt_rope_sin_1HND.shape}")
@@ -574,7 +578,9 @@ class WanTransformer3DModel(Module):
 
         return spatial_out
 
-    def inner_step(self, spatial_1BNI_torch, prompt_1BLP, rope_cos_1HND, rope_sin_1HND, trans_mat, N, timestep_torch):
+    def inner_step(
+        self, spatial_1BNI, prompt_1BLP, rope_cos_1HND, rope_sin_1HND, trans_mat, N, temb_11BD, timestep_proj_1BTD
+    ):
         """
         Reduced forward function which assumes outer loop has cached certain inputs that are step independent:
             - prompt_1BLP
@@ -583,19 +589,9 @@ class WanTransformer3DModel(Module):
             - trans_mat
             - N
 
-        Spatial input is a torch tensor with layout `1 B (patch_F patch_H patch_W) (pF pH pW C)`.
-        Spatial output is an fp32 ttnn.Tensor on device with same layout.
+        Spatial input is a TT-NN tensor with layout `1 B (patch_F patch_H patch_W) (pF pH pW C)`.
+        Spatial output is a TT-NN tensor with same layout.
         """
-
-        # Push spatial input to device
-        spatial_1BNI = bf16_tensor(
-            spatial_1BNI_torch,
-            device=self.mesh_device,
-            mesh_axis=self.parallel_config.sequence_parallel.mesh_axis,
-            shard_dim=-2,
-        )
-        temb_11BD, timestep_proj_1BTD = self.prepare_timestep_conditioning(timestep_torch)
-
         spatial_1BND = self.patch_embedding(spatial_1BNI)
 
         for idx, block in enumerate(self.blocks):

--- a/models/tt_dit/models/vae/vae_wan2_1.py
+++ b/models/tt_dit/models/vae/vae_wan2_1.py
@@ -17,14 +17,13 @@ from ...layers.module import Module, ModuleList, Parameter
 from ...layers.normalization import RMSNorm
 from ...parallel.config import VaeHWParallelConfig
 from ...parallel.manager import CCLManager
-from ...utils.conv3d import _ntuple, aligned_channels, count_convs, get_conv3d_config, prepare_conv3d_weights
+from ...utils import tensor
+from ...utils.conv3d import _ntuple, aligned_channels, get_conv3d_config, prepare_conv3d_weights
 from ...utils.substate import pop_substate, rename_substate
 from ...utils.tensor import typed_tensor
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
-
-CACHE_T = 2
 
 
 def conv3d_to_linear_weight(state):
@@ -215,11 +214,19 @@ class WanCausalConv3d(Module):
         kernel_size: Sequence[int] | int,
         stride: Sequence[int] | int = 1,
         padding: Sequence[int] | int = 0,
+        cache_key: str = "",
         mesh_device: ttnn.MeshDevice,
         parallel_config: VaeHWParallelConfig,
         ccl_manager: CCLManager,
         dtype: ttnn.DataType = ttnn.bfloat16,
     ) -> None:
+        """Causal 3D convolution with temporal caching for autoregressive VAE inference.
+
+        Unlike in the diffusers implementation padding[0] is applied to the front only once. The
+        diffusers implementation applies 2 * padding[0] making it impossible to have odd padding.
+        The diffusers implementation works around this by moving the padding logic out of the module
+        in the odd case.
+        """
         super().__init__()
 
         self.unpadded_in_channels = in_channels
@@ -243,7 +250,7 @@ class WanCausalConv3d(Module):
         external_padding = list(padding)
         internal_padding = list(padding)
         # t padding is handled explicitly and depends on the cache.
-        external_padding[0] = 2 * padding[0]
+        external_padding[0] = padding[0]
         internal_padding[0] = 0
         # HW padding may be handled by the halo CCL if the model is parallelized
         if self.parallel_config.height_parallel.factor > 1:
@@ -278,6 +285,7 @@ class WanCausalConv3d(Module):
         self.bias = Parameter(total_shape=[1, self.out_channels], device=mesh_device, pad_value=0, dtype=dtype)
 
         self.mask_cache = {}
+        self._cache_key = cache_key
 
     def _prepare_torch_state(self, state: dict[str, torch.Tensor]) -> None:
         def maybe_pad_out_channels(weight, bias):
@@ -315,7 +323,7 @@ class WanCausalConv3d(Module):
         self,
         x_BTHWC: ttnn.Tensor,
         logical_h: int,
-        cache_x_BTHWC: ttnn.Tensor | None = None,
+        feat_cache: dict[str, ttnn.Tensor] | None = None,
     ) -> ttnn.Tensor:
         """
         x_BTHWC: (B, T, H, W, C) fractured on H and W, ROW_MAJOR layout
@@ -326,16 +334,17 @@ class WanCausalConv3d(Module):
         assert x_BTHWC.layout == ttnn.ROW_MAJOR_LAYOUT, f"WanCausalConv3d expects ROW_MAJOR input, got {x_BTHWC.layout}"
         # NOTE: T padding is handled explicitly and depends on the cache
         t_front_padding = self.external_padding[0]
+        cache_x_BTHWC = (
+            update_cache_value(feat_cache, self._cache_key, x_BTHWC, length=t_front_padding)
+            if feat_cache is not None
+            else None
+        )
         if cache_x_BTHWC is not None and t_front_padding > 0:
             # concat on T
             x_BTHWC = ttnn.concat([cache_x_BTHWC, x_BTHWC], dim=1)
             t_front_padding -= cache_x_BTHWC.shape[1]
         if t_front_padding > 0:
-            # Padding only works on the lowest 3 dims. reshape input.
-            B, T, H, W, C = x_BTHWC.shape
-            x_BTNC = ttnn.reshape(x_BTHWC, (B, T, H * W, C))
-            x_BTNC = ttnn.pad(x_BTNC, [(0, 0), (t_front_padding, 0), (0, 0), (0, 0)], value=0.0)
-            x_BTHWC = ttnn.reshape(x_BTNC, (B, T + t_front_padding, H, W, C))
+            x_BTHWC = tensor.pad_single(x_BTHWC, dim=1, front=t_front_padding, value=0.0)
 
         # Use > (not !=) to only mask when there are EXCESS padding rows (decoder upsample
         # amplifies mesh_partition padding). The encoder's 1::2 downsampling creates a deficit
@@ -416,6 +425,7 @@ class WanResidualBlock(Module):
         *,
         in_dim: int,
         out_dim: int,
+        cache_key: str = "",
         mesh_device: ttnn.MeshDevice,
         parallel_config: VaeHWParallelConfig,
         ccl_manager: CCLManager,
@@ -439,7 +449,8 @@ class WanResidualBlock(Module):
             in_channels=in_dim,
             out_channels=out_dim,
             kernel_size=3,
-            padding=1,
+            padding=(2, 1, 1),
+            cache_key=f"{cache_key}.conv1",
             mesh_device=mesh_device,
             ccl_manager=ccl_manager,
             parallel_config=parallel_config,
@@ -457,7 +468,8 @@ class WanResidualBlock(Module):
             in_channels=out_dim,
             out_channels=out_dim,
             kernel_size=3,
-            padding=1,
+            padding=(2, 1, 1),
+            cache_key=f"{cache_key}.conv2",
             mesh_device=mesh_device,
             ccl_manager=ccl_manager,
             parallel_config=parallel_config,
@@ -513,8 +525,7 @@ class WanResidualBlock(Module):
         self,
         x_BTHWC: ttnn.Tensor,
         logical_h: int,
-        feat_cache: list[ttnn.Tensor] | None = None,
-        feat_idx: list[int] = [0],
+        feat_cache: dict[str, ttnn.Tensor] | None = None,
     ) -> ttnn.Tensor:
         assert x_BTHWC.layout == ttnn.TILE_LAYOUT, f"WanResidualBlock expects TILE input, got {x_BTHWC.layout}"
         h_tile_BTHWC = (
@@ -527,21 +538,7 @@ class WanResidualBlock(Module):
         x_BTHWC = ttnn.to_layout(x_silu_tile_BTHWC, ttnn.ROW_MAJOR_LAYOUT)
 
         # Cached conv
-        if feat_cache is not None:
-            # Prepare to cache the current activation for future use
-            idx = feat_idx[0]
-            t_start = x_BTHWC.shape[1] - CACHE_T
-            cache_x_BTHWC = x_BTHWC[:, t_start:, :, :, :]
-            if cache_x_BTHWC.shape[1] < 2 and feat_cache[idx] is not None:
-                # Current activation is too short, so append the cached activation as well
-                cache_x_BTHWC = ttnn.concat([feat_cache[idx][:, -1:, :, :, :], cache_x_BTHWC], dim=1)
-
-            x_conv_BTHWC = self.conv1(x_BTHWC, logical_h, feat_cache[idx])
-            # NOTE: Should deallocate feat_cache[idx] after it's reassigned
-            feat_cache[idx] = cache_x_BTHWC
-            feat_idx[0] += 1
-        else:
-            x_conv_BTHWC = self.conv1(x_BTHWC, logical_h)
+        x_conv_BTHWC = self.conv1(x_BTHWC, logical_h, feat_cache)
 
         x_tile_BTHWC = ttnn.to_layout(x_conv_BTHWC, ttnn.TILE_LAYOUT)
         x_norm_tile_BTHWC = self.norm2(x_tile_BTHWC, compute_kernel_config=self.norm_compute_kernel_config)
@@ -549,21 +546,7 @@ class WanResidualBlock(Module):
         x_BTHWC = ttnn.to_layout(x_silu_tile_BTHWC, ttnn.ROW_MAJOR_LAYOUT)
 
         # Cached conv
-        if feat_cache is not None:
-            # Prepare to cache the current activation for future use
-            idx = feat_idx[0]
-            t_start = x_BTHWC.shape[1] - CACHE_T
-            cache_x_BTHWC = x_BTHWC[:, t_start:, :, :, :]
-            if cache_x_BTHWC.shape[1] < 2 and feat_cache[idx] is not None:
-                # Current activation is too short, so append the cached activation as well
-                cache_x_BTHWC = ttnn.concat([feat_cache[idx][:, -1:, :, :, :], cache_x_BTHWC], dim=1)
-
-            x_conv_BTHWC = self.conv2(x_BTHWC, logical_h, feat_cache[idx])
-            # NOTE: Should deallocate feat_cache[idx] after it's reassigned
-            feat_cache[idx] = cache_x_BTHWC
-            feat_idx[0] += 1
-        else:
-            x_conv_BTHWC = self.conv2(x_BTHWC, logical_h)
+        x_conv_BTHWC = self.conv2(x_BTHWC, logical_h, feat_cache)
 
         # Add residual
         x_tile_BTHWC = ttnn.to_layout(x_conv_BTHWC, ttnn.TILE_LAYOUT)
@@ -577,6 +560,7 @@ class WanMidBlock(Module):
         *,
         dim: int,
         num_layers: int = 1,
+        cache_key: str = "",
         mesh_device: ttnn.MeshDevice,
         parallel_config: VaeHWParallelConfig,
         ccl_manager: CCLManager,
@@ -593,6 +577,7 @@ class WanMidBlock(Module):
             WanResidualBlock(
                 in_dim=dim,
                 out_dim=dim,
+                cache_key=f"{cache_key}.resnet0",
                 mesh_device=mesh_device,
                 ccl_manager=ccl_manager,
                 parallel_config=parallel_config,
@@ -600,7 +585,7 @@ class WanMidBlock(Module):
             )
         )
 
-        for _ in range(num_layers):
+        for i in range(num_layers):
             attentions.append(
                 WanAttentionBlock(
                     dim=dim,
@@ -614,6 +599,7 @@ class WanMidBlock(Module):
                 WanResidualBlock(
                     in_dim=dim,
                     out_dim=dim,
+                    cache_key=f"{cache_key}.resnet{i + 1}",
                     mesh_device=mesh_device,
                     ccl_manager=ccl_manager,
                     parallel_config=parallel_config,
@@ -628,15 +614,14 @@ class WanMidBlock(Module):
         self,
         x_BTHWC: ttnn.Tensor,
         logical_h: int,
-        feat_cache: list[ttnn.Tensor] | None = None,
-        feat_idx: list[int] = [0],
+        feat_cache: dict[str, ttnn.Tensor] | None = None,
     ) -> ttnn.Tensor:
         assert x_BTHWC.layout == ttnn.TILE_LAYOUT, f"WanMidBlock expects TILE input, got {x_BTHWC.layout}"
-        x_res_BTHWC = self.resnets[0](x_BTHWC, logical_h, feat_cache, feat_idx)
+        x_res_BTHWC = self.resnets[0](x_BTHWC, logical_h, feat_cache)
         x_BTHWC = x_res_BTHWC
         for i in range(len(self.attentions)):
             x_attn_BTHWC = self.attentions[i](x_BTHWC, logical_h)
-            x_BTHWC = self.resnets[i + 1](x_attn_BTHWC, logical_h, feat_cache, feat_idx)
+            x_BTHWC = self.resnets[i + 1](x_attn_BTHWC, logical_h, feat_cache)
         return x_BTHWC
 
 
@@ -823,6 +808,7 @@ class WanResample(Module):
         dim: int,
         mode: str,
         resample_out_dim: int | None = None,
+        cache_key: str = "",
         mesh_device: ttnn.MeshDevice,
         parallel_config: VaeHWParallelConfig,
         ccl_manager: CCLManager,
@@ -856,13 +842,16 @@ class WanResample(Module):
                 in_channels=dim,
                 out_channels=dim * 2 if self.is_upsample else dim,
                 kernel_size=(3, 1, 1),
-                padding=(1, 0, 0) if self.is_upsample else (0, 0, 0),
+                padding=(2, 0, 0) if self.is_upsample else (1, 0, 0),
                 stride=(1, 1, 1) if self.is_upsample else (2, 1, 1),
+                cache_key=cache_key,
                 mesh_device=mesh_device,
                 ccl_manager=ccl_manager,
                 parallel_config=parallel_config,
                 dtype=dtype,
             )
+
+        self._time_conv_cache_key = cache_key
 
     def _prepare_torch_state(self, state: dict[str, torch.Tensor]) -> None:
         rename_substate(state, "resample.1", "conv")
@@ -871,41 +860,17 @@ class WanResample(Module):
         self,
         x_BTHWC,
         logical_h,
-        feat_cache: list[ttnn.Tensor] | None = None,
-        feat_idx: list[int] = [0],
+        feat_cache: dict[str, ttnn.Tensor] | None = None,
     ) -> tuple[ttnn.Tensor, int]:
         assert x_BTHWC.layout == ttnn.ROW_MAJOR_LAYOUT, f"WanResample expects ROW_MAJOR input, got {x_BTHWC.layout}"
         B, T, H, W, C = x_BTHWC.shape
         if self.is_3d and self.is_upsample:  # upsample3d
             if feat_cache is not None:
-                idx = feat_idx[0]
-                if feat_cache[idx] is None:
-                    feat_cache[idx] = "Rep"
-                    feat_idx[0] += 1
+                if feat_cache.get(self._time_conv_cache_key) is None:
+                    update_cache_value(feat_cache, self._time_conv_cache_key, ttnn.fill(x_BTHWC, 0.0), length=2)
                 else:
-                    t_start = x_BTHWC.shape[1] - CACHE_T
-                    cache_x_BTHWC = x_BTHWC[:, t_start:, :, :, :]
-                    is_rep = isinstance(feat_cache[idx], str) and feat_cache[idx] == "Rep"
-                    assert not (
-                        isinstance(feat_cache[idx], str) and not is_rep
-                    ), "If feat_cache[idx] is a string, it must be 'Rep'"
-                    if cache_x_BTHWC.shape[1] < 2 and feat_cache[idx] is not None and not is_rep:
-                        cache_x_BTHWC = ttnn.concat([feat_cache[idx][:, -1:, :, :, :], cache_x_BTHWC], dim=1)
-
-                    if cache_x_BTHWC.shape[1] < 2 and feat_cache[idx] is not None and is_rep:
-                        # When feat_cache[idx] is "Rep", we need to pad the cache_x_BTHWC with zeros
-                        # Padding only works on the lowest 3 dims
-                        cache_x_B1NC = ttnn.reshape(cache_x_BTHWC, (B, 1, H * W, C))
-                        cache_x_BTNC = ttnn.pad(cache_x_B1NC, [(0, 0), (1, 0), (0, 0), (0, 0)], value=0.0)
-                        cache_x_BTHWC = ttnn.reshape(cache_x_BTNC, (B, 2, H, W, C))
-
-                    if is_rep:
-                        x_time_BTHWU = self.time_conv(x_BTHWC, logical_h)
-                    else:
-                        x_time_BTHWU = self.time_conv(x_BTHWC, logical_h, feat_cache[idx])
+                    x_time_BTHWU = self.time_conv(x_BTHWC, logical_h, feat_cache)
                     x_BTHWU = x_time_BTHWU
-                    feat_cache[idx] = cache_x_BTHWC
-                    feat_idx[0] += 1
 
                     T1 = x_BTHWU.shape[1]
                     x_BTHW2C = ttnn.reshape(x_BTHWU, (B, T1, H, W, 2, C))
@@ -932,17 +897,10 @@ class WanResample(Module):
         # Handle downsample3d
         if self.is_3d and not self.is_upsample:  # downsample3d
             if feat_cache is not None:
-                idx = feat_idx[0]
-                if feat_cache[idx] is None:
-                    feat_cache[idx] = ttnn.clone(x_conv_BTHWC)
-                    feat_idx[0] += 1
+                if feat_cache.get(self._time_conv_cache_key) is None:
+                    update_cache_value(feat_cache, self._time_conv_cache_key, x_conv_BTHWC, length=1)
                 else:
-                    cache_x_BTHWC = ttnn.clone(x_conv_BTHWC[:, -1:, :, :, :])
-                    x_conv_BTHWC = self.time_conv(
-                        ttnn.concat([feat_cache[idx][:, -1:, :, :, :], x_conv_BTHWC], dim=1), logical_h
-                    )
-                    feat_cache[idx] = cache_x_BTHWC
-                    feat_idx[0] += 1
+                    x_conv_BTHWC = self.time_conv.forward(x_conv_BTHWC, logical_h, feat_cache=feat_cache)
             else:
                 raise ValueError("feat_cache cannot be None")
         return x_conv_BTHWC, logical_h
@@ -956,6 +914,7 @@ class WanUpBlock(Module):
         out_dim: int,
         num_res_blocks: int,
         upsample_mode: str | None = None,
+        cache_key: str = "",
         mesh_device: ttnn.MeshDevice,
         parallel_config: VaeHWParallelConfig,
         ccl_manager: CCLManager,
@@ -975,11 +934,12 @@ class WanUpBlock(Module):
 
         resnets = ModuleList()
         current_dim = in_dim
-        for _ in range(num_res_blocks + 1):
+        for i in range(num_res_blocks + 1):
             resnets.append(
                 WanResidualBlock(
                     in_dim=current_dim,
                     out_dim=out_dim,
+                    cache_key=f"{cache_key}.resnet{i}",
                     mesh_device=mesh_device,
                     ccl_manager=ccl_manager,
                     parallel_config=parallel_config,
@@ -994,6 +954,7 @@ class WanUpBlock(Module):
             self.upsamplers = WanResample(
                 dim=out_dim,
                 mode=upsample_mode,
+                cache_key=f"{cache_key}.upsampler",
                 mesh_device=mesh_device,
                 ccl_manager=ccl_manager,
                 parallel_config=parallel_config,
@@ -1007,15 +968,14 @@ class WanUpBlock(Module):
         self,
         x_BTHWC: ttnn.Tensor,
         logical_h: int,
-        feat_cache: list[ttnn.Tensor] | None = None,
-        feat_idx: list[int] = [0],
+        feat_cache: dict[str, ttnn.Tensor] | None = None,
     ) -> tuple[ttnn.Tensor, int]:
         for resnet in self.resnets:
-            x_res_BTHWC = resnet(x_BTHWC, logical_h, feat_cache, feat_idx)
+            x_res_BTHWC = resnet(x_BTHWC, logical_h, feat_cache)
             x_BTHWC = x_res_BTHWC
         if self.upsamplers is not None:
             x_BTHWC = ttnn.to_layout(x_BTHWC, ttnn.ROW_MAJOR_LAYOUT)
-            x_upsampled_BTHWC, logical_h = self.upsamplers(x_BTHWC, logical_h, feat_cache, feat_idx)
+            x_upsampled_BTHWC, logical_h = self.upsamplers(x_BTHWC, logical_h, feat_cache)
             x_BTHWC = ttnn.to_layout(x_upsampled_BTHWC, ttnn.TILE_LAYOUT)
         return x_BTHWC, logical_h
 
@@ -1058,7 +1018,8 @@ class WanDecoder3d(Module):
             z_dim,
             dims[0],
             kernel_size=3,
-            padding=1,
+            padding=(2, 1, 1),
+            cache_key="conv_in",
             mesh_device=mesh_device,
             ccl_manager=ccl_manager,
             parallel_config=parallel_config,
@@ -1069,6 +1030,7 @@ class WanDecoder3d(Module):
         self.mid_block = WanMidBlock(
             dim=dims[0],
             num_layers=1,
+            cache_key="mid_block",
             mesh_device=mesh_device,
             ccl_manager=ccl_manager,
             parallel_config=parallel_config,
@@ -1098,6 +1060,7 @@ class WanDecoder3d(Module):
                 out_dim=out_dim,
                 num_res_blocks=num_res_blocks,
                 upsample_mode=upsample_mode,
+                cache_key=f"up_block{i}",
                 mesh_device=mesh_device,
                 ccl_manager=ccl_manager,
                 parallel_config=parallel_config,
@@ -1118,7 +1081,8 @@ class WanDecoder3d(Module):
             out_dim,
             out_channels,
             kernel_size=3,
-            padding=1,
+            padding=(2, 1, 1),
+            cache_key="conv_out",
             mesh_device=mesh_device,
             ccl_manager=ccl_manager,
             parallel_config=parallel_config,
@@ -1133,51 +1097,27 @@ class WanDecoder3d(Module):
         self,
         x_BTHWC: ttnn.Tensor,
         logical_h: int,
-        feat_cache: list[ttnn.Tensor] | None = None,
-        feat_idx: list[int] = [0],
-        first_chunk: bool = False,
+        feat_cache: dict[str, ttnn.Tensor] | None = None,
     ) -> tuple[ttnn.Tensor, int]:
-        # NOTE: first_chunk is not used. It would be needed for WanResidualUpBlock.
         ## conv1
-        if feat_cache is not None:
-            idx = feat_idx[0]
-            t_start = x_BTHWC.shape[1] - CACHE_T
-            cache_x_BTHWC = x_BTHWC[:, t_start:, :, :, :]
-            if cache_x_BTHWC.shape[1] < 2 and feat_cache[idx] is not None:
-                # Current activation is too short, so append the cached activation as well
-                cache_x_BTHWC = ttnn.concat([feat_cache[idx][:, -1:, :, :, :], cache_x_BTHWC], dim=1)
-            x_BTHWC = self.conv_in(x_BTHWC, logical_h, feat_cache[idx])
-            feat_cache[idx] = cache_x_BTHWC
-            feat_idx[0] += 1
-        else:
-            x_BTHWC = self.conv_in(x_BTHWC, logical_h)
+        x_BTHWC = self.conv_in(x_BTHWC, logical_h, feat_cache)
 
         x_BTHWC = ttnn.to_layout(x_BTHWC, ttnn.TILE_LAYOUT)
 
         ## middle
-        x_BTHWC = self.mid_block(x_BTHWC, logical_h, feat_cache, feat_idx)
+        x_BTHWC = self.mid_block(x_BTHWC, logical_h, feat_cache)
 
         ## upsamples
         for up_block in self.up_blocks:
-            x_BTHWC, logical_h = up_block(x_BTHWC, logical_h, feat_cache, feat_idx)
+            x_BTHWC, logical_h = up_block(x_BTHWC, logical_h, feat_cache)
 
         ## head
         x_norm_tile_BTHWC = self.norm_out(x_BTHWC)
         x_silu_tile_BTHWC = ttnn.silu(x_norm_tile_BTHWC)
         x_BTHWC = ttnn.to_layout(x_silu_tile_BTHWC, ttnn.ROW_MAJOR_LAYOUT)
 
-        if feat_cache is not None:
-            idx = feat_idx[0]
-            t_start = x_BTHWC.shape[1] - CACHE_T
-            cache_x_BTHWC = x_BTHWC[:, t_start:, :, :, :]
-            if cache_x_BTHWC.shape[1] < 2 and feat_cache[idx] is not None:
-                # Current activation is too short, so append the cached activation as well
-                cache_x_BTHWC = ttnn.concat([feat_cache[idx][:, -1:, :, :, :], cache_x_BTHWC], dim=1)
-            x_BTHWC = self.conv_out(x_BTHWC, logical_h, feat_cache[idx])
-            feat_cache[idx] = cache_x_BTHWC
-            feat_idx[0] += 1
-        else:
-            x_BTHWC = self.conv_out(x_BTHWC, logical_h)
+        x_BTHWC = self.conv_out(x_BTHWC, logical_h, feat_cache)
+
         return x_BTHWC, logical_h
 
 
@@ -1272,8 +1212,6 @@ class WanDecoder(Module):
             dtype=dtype,
         )
 
-        self.cached_conv_count = count_convs(self.decoder)
-
     def _prepare_torch_state(self, state: dict[str, torch.Tensor]) -> None:
         if "post_quant_conv.weight" in state and "post_quant_conv.bias" in state:
             state_sub = conv3d_to_linear_weight(pop_substate(state, "post_quant_conv"))
@@ -1283,14 +1221,11 @@ class WanDecoder(Module):
         pop_substate(state, "encoder")
         pop_substate(state, "quant_conv")
 
-    def clear_cache(self):
-        self._conv_idx = [0]
-        self._feat_cache = [None] * self.cached_conv_count
-
     def forward(self, z_BTHWC: ttnn.Tensor, logical_h: int) -> tuple[ttnn.Tensor, int]:
         B, T, H, W, C = z_BTHWC.shape
 
-        self.clear_cache()
+        feat_cache = {}
+
         z_tile_BTHWC = ttnn.to_layout(z_BTHWC, ttnn.TILE_LAYOUT)
         x_tile_BTHWC = self.post_quant_conv(z_tile_BTHWC)
         x_BTHWC = ttnn.to_layout(x_tile_BTHWC, ttnn.ROW_MAJOR_LAYOUT)
@@ -1298,10 +1233,7 @@ class WanDecoder(Module):
         output_BCTHW = None
         for i in range(T):
             # Process one frame at a time
-            self._conv_idx = [0]
-            out_BTHWC, new_logical_h = self.decoder(
-                x_BTHWC[:, i : i + 1, :, :, :], logical_h, feat_cache=self._feat_cache, feat_idx=self._conv_idx
-            )
+            out_BTHWC, new_logical_h = self.decoder(x_BTHWC[:, i : i + 1, :, :, :], logical_h, feat_cache=feat_cache)
             # Channels first
             out_BCTHW = ttnn.permute(out_BTHWC, (0, 4, 1, 2, 3))
             # Trim padding on output channels
@@ -1314,7 +1246,6 @@ class WanDecoder(Module):
         output_tile_BCTHW = ttnn.to_layout(output_BCTHW, ttnn.TILE_LAYOUT)
         output_BCTHW = ttnn.clamp(output_tile_BCTHW, min=-1.0, max=1.0)
         output_BCTHW = ttnn.to_layout(output_BCTHW, ttnn.ROW_MAJOR_LAYOUT)
-        self.clear_cache()
         return (output_BCTHW, new_logical_h)
 
 
@@ -1356,7 +1287,8 @@ class WanEncoder3D(Module):
             in_channels,
             dims[0],
             kernel_size=3,
-            padding=1,
+            padding=(2, 1, 1),
+            cache_key="conv_in",
             mesh_device=mesh_device,
             ccl_manager=ccl_manager,
             parallel_config=parallel_config,
@@ -1366,11 +1298,12 @@ class WanEncoder3D(Module):
         # downsample blocks.
         self.down_blocks = ModuleList()
         for i, (in_dim, out_dim) in enumerate(zip(dims[:-1], dims[1:])):
-            for _ in range(num_res_blocks):
+            for j in range(num_res_blocks):
                 self.down_blocks.append(
                     WanResidualBlock(
                         in_dim=in_dim,
                         out_dim=out_dim,
+                        cache_key=f"down{i}.resnet{j}",
                         mesh_device=mesh_device,
                         ccl_manager=ccl_manager,
                         parallel_config=parallel_config,
@@ -1396,6 +1329,7 @@ class WanEncoder3D(Module):
                     WanResample(
                         dim=out_dim,
                         mode=mode,
+                        cache_key=f"resample{i}",
                         mesh_device=mesh_device,
                         ccl_manager=ccl_manager,
                         parallel_config=parallel_config,
@@ -1408,6 +1342,7 @@ class WanEncoder3D(Module):
         self.mid_block = WanMidBlock(
             dim=out_dim,
             num_layers=1,
+            cache_key="mid_block",
             mesh_device=mesh_device,
             ccl_manager=ccl_manager,
             parallel_config=parallel_config,
@@ -1427,7 +1362,8 @@ class WanEncoder3D(Module):
             out_dim,
             z_dim,
             kernel_size=3,
-            padding=1,
+            padding=(2, 1, 1),
+            cache_key="conv_out",
             mesh_device=mesh_device,
             ccl_manager=ccl_manager,
             parallel_config=parallel_config,
@@ -1442,22 +1378,10 @@ class WanEncoder3D(Module):
         self,
         x_BTHWC: ttnn.Tensor,
         logical_h: int,
-        feat_cache: list[ttnn.Tensor] | None = None,
-        feat_idx: list[int] = [0],
+        feat_cache: dict[str, ttnn.Tensor] | None = None,
     ) -> tuple[ttnn.Tensor, int]:
         ## conv1
-        if feat_cache is not None:
-            idx = feat_idx[0]
-            t_start = x_BTHWC.shape[1] - CACHE_T
-            cache_x_BTHWC = x_BTHWC[:, t_start:, :, :, :]
-            if cache_x_BTHWC.shape[1] < 2 and feat_cache[idx] is not None:
-                # Current activation is too short, so append the cached activation as well
-                cache_x_BTHWC = ttnn.concat([feat_cache[idx][:, -1:, :, :, :], cache_x_BTHWC], dim=1)
-            x_BTHWC = self.conv_in(x_BTHWC, logical_h, feat_cache[idx])
-            feat_cache[idx] = cache_x_BTHWC
-            feat_idx[0] += 1
-        else:
-            x_BTHWC = self.conv_in(x_BTHWC, logical_h)
+        x_BTHWC = self.conv_in(x_BTHWC, logical_h, feat_cache)
 
         x_BTHWC = ttnn.to_layout(x_BTHWC, ttnn.TILE_LAYOUT)
 
@@ -1465,35 +1389,25 @@ class WanEncoder3D(Module):
         for down_block in self.down_blocks:
             if isinstance(down_block, WanResample):
                 x_BTHWC = ttnn.to_layout(x_BTHWC, ttnn.ROW_MAJOR_LAYOUT)
-                x_BTHWC, logical_h = down_block(x_BTHWC, logical_h, feat_cache, feat_idx)
+                x_BTHWC, logical_h = down_block(x_BTHWC, logical_h, feat_cache)
                 x_BTHWC = ttnn.to_layout(x_BTHWC, ttnn.TILE_LAYOUT)
             elif isinstance(down_block, WanResidualBlock):
-                x_BTHWC = down_block(x_BTHWC, logical_h, feat_cache, feat_idx)
+                x_BTHWC = down_block(x_BTHWC, logical_h, feat_cache)
             elif isinstance(down_block, WanAttentionBlock):
                 x_BTHWC = down_block(x_BTHWC, logical_h)
             else:
                 raise ValueError(f"Unsupported downblock type: {type(down_block)}")
 
         ## middle
-        x_BTHWC = self.mid_block(x_BTHWC, logical_h, feat_cache, feat_idx)
+        x_BTHWC = self.mid_block(x_BTHWC, logical_h, feat_cache)
 
         ## head
         x_norm_tile_BTHWC = self.norm_out(x_BTHWC)
         x_silu_tile_BTHWC = ttnn.silu(x_norm_tile_BTHWC)
         x_BTHWC = ttnn.to_layout(x_silu_tile_BTHWC, ttnn.ROW_MAJOR_LAYOUT)
 
-        if feat_cache is not None:
-            idx = feat_idx[0]
-            t_start = x_BTHWC.shape[1] - CACHE_T
-            cache_x_BTHWC = x_BTHWC[:, t_start:, :, :, :]
-            if cache_x_BTHWC.shape[1] < 2 and feat_cache[idx] is not None:
-                # Current activation is too short, so append the cached activation as well
-                cache_x_BTHWC = ttnn.concat([feat_cache[idx][:, -1:, :, :, :], cache_x_BTHWC], dim=1)
-            x_BTHWC = self.conv_out(x_BTHWC, logical_h, feat_cache[idx])
-            feat_cache[idx] = cache_x_BTHWC
-            feat_idx[0] += 1
-        else:
-            x_BTHWC = self.conv_out(x_BTHWC, logical_h)
+        x_BTHWC = self.conv_out(x_BTHWC, logical_h, feat_cache)
+
         return x_BTHWC, logical_h
 
 
@@ -1538,7 +1452,6 @@ class WanEncoder(Module):
             mesh_device=mesh_device,
             dtype=dtype,
         )
-        self.cached_conv_count = count_convs(self.encoder)
 
     def _prepare_torch_state(self, state: dict[str, torch.Tensor]) -> None:
         if "quant_conv.weight" in state and "quant_conv.bias" in state:
@@ -1549,28 +1462,21 @@ class WanEncoder(Module):
         pop_substate(state, "decoder")
         pop_substate(state, "post_quant_conv")
 
-    def clear_cache(self):
-        self._conv_idx = [0]
-        self._feat_cache = [None] * self.cached_conv_count
-
     def forward(self, x_BTHWC: ttnn.Tensor, logical_h: int) -> tuple[ttnn.Tensor, int]:
         B, T, H, W, C = x_BTHWC.shape
 
-        self.clear_cache()
+        feat_cache = {}
 
         output_BTHWC = None
         T_encoded = 1 + (T - 1) // 4
         for i in range(T_encoded):
             # Process one frame at a time
-            self._conv_idx = [0]
             if i == 0:
                 x_BTHWC_chunk = x_BTHWC[:, :1, :, :, :]
             else:
                 x_BTHWC_chunk = x_BTHWC[:, 1 + 4 * (i - 1) : 1 + 4 * i, :, :, :]
 
-            out_BTHWC, new_logical_h = self.encoder(
-                x_BTHWC_chunk, logical_h, feat_cache=self._feat_cache, feat_idx=self._conv_idx
-            )
+            out_BTHWC, new_logical_h = self.encoder(x_BTHWC_chunk, logical_h, feat_cache=feat_cache)
 
             if output_BTHWC is None:
                 output_BTHWC = out_BTHWC
@@ -1584,7 +1490,6 @@ class WanEncoder(Module):
         output_BCTHW = ttnn.permute(output_BTHWC, (0, 4, 1, 2, 3))
         # Trim padding on output channels
         output_BCTHW = output_BCTHW[:, : self.z_dim, :, :, :]  # Get the mean
-        self.clear_cache()
         return (output_BCTHW, new_logical_h)
 
 
@@ -1596,3 +1501,70 @@ def get_neighbor_pad_num_links(ccl_manager, input_tensor, dim):
     for i in range(dim):
         upper_dims *= input_tensor.shape[i]
     return min(upper_dims, ccl_manager.num_links)
+
+
+def update_cache_value(
+    feat_cache: dict[str, ttnn.Tensor], key: str, value: ttnn.Tensor, /, *, length: int
+) -> ttnn.Tensor | None:
+    """Update a cached activation and return the previous value.
+
+    Stores ``value`` under ``key``, trimming or front-padding along the temporal dimension (dim
+    1) so that the stored tensor has exactly ``length`` frames.  If the new value is shorter
+    than ``length`` and a cached tensor already exists, the tail of the old cache is prepended
+    to fill the gap.
+
+    Args:
+        feat_cache: Dictionary mapping slot names to cached tensors.
+        key: Cache slot identifier.
+        value: New activation tensor with shape ``(B, T, H, W, C)``.
+        length: Desired temporal length of the stored tensor.
+
+    Returns:
+        The previously cached tensor (cloned), or ``None`` if the slot was empty.
+    """
+    cached = feat_cache.get(key)
+    cached = ttnn.clone(cached) if cached is not None else None
+
+    if cached is not None and cached.shape[1] != length:
+        msg = f"existing cache for key {key} has temporal length {cached.shape[1]}, expected {length}"
+        raise ValueError(msg)
+
+    short = length - value.shape[1]
+    if short < 0:
+        value = value[:, -length:]
+    elif short > 0:
+        if cached is not None:
+            # Current activation is too short, so prepend the cached activation
+            prepend = min(cached.shape[1], short)
+            value = ttnn.concat([cached[:, -prepend:], value], dim=1)
+            short -= prepend
+
+        if short > 0:
+            value = tensor.pad_single(value, dim=1, front=short, value=0.0)
+
+    if key in feat_cache:
+        # preserve cached tensor address to support tracing
+        ttnn.copy(value, feat_cache[key])
+    else:
+        feat_cache[key] = value
+
+    return cached
+
+
+def defrag_cache(feat_cache: dict[str, ttnn.Tensor]) -> None:
+    """Defragment device memory by moving cached tensors to the host and back.
+
+    Args:
+        feat_cache: Dictionary mapping slot names to cached tensors.
+    """
+    device = None
+
+    for k, v in feat_cache.items():
+        if device is None:
+            device = v.device()
+
+        feat_cache[k] = v.cpu()
+        # tensors get deallocated by Python's reference counting mechanism
+
+    for k, v in feat_cache.items():
+        feat_cache[k] = ttnn.to_device(v, device)

--- a/models/tt_dit/models/vae/vae_wan2_1.py
+++ b/models/tt_dit/models/vae/vae_wan2_1.py
@@ -21,6 +21,7 @@ from ...utils import tensor
 from ...utils.conv3d import _ntuple, aligned_channels, get_conv3d_config, prepare_conv3d_weights
 from ...utils.substate import pop_substate, rename_substate
 from ...utils.tensor import typed_tensor
+from ...utils.tracing import Tracer
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -316,6 +317,7 @@ class WanCausalConv3d(Module):
                 shard_dim=2,
                 dtype=self.dtype,
             )
+            Tracer.warn_if_live()
             self.mask_cache[key] = mask
         return self.mask_cache[key]
 
@@ -722,6 +724,7 @@ class WanConv2d(Module):
                 shard_dim=2,
                 dtype=self.dtype,
             )
+            Tracer.warn_if_live()
             self.mask_cache[key] = mask
         return self.mask_cache[key]
 

--- a/models/tt_dit/parallel/manager.py
+++ b/models/tt_dit/parallel/manager.py
@@ -124,6 +124,8 @@ class CCLManager:
                 output_buffer = bf16_tensor(torch.empty(output_buffer_shape), device=self.mesh_device)
                 buffers.append([intermediate_buffer, output_buffer])
 
+            # It is okay for these buffers to be allocated after trace capture, as long as they hold
+            # only temporary values consumed before trace replay.
             self._ping_pong_buffer_cache[cache_key] = buffers
             self._ping_pong_buffer_indices[cache_key] = 0
             ttnn.synchronize_device(self.mesh_device)
@@ -168,6 +170,8 @@ class CCLManager:
                 )
                 buffers.append(output_buffer)
 
+            # It is okay for these buffers to be allocated after trace capture, as long as they hold
+            # only temporary values consumed before trace replay.
             self._ping_pong_buffer_cache[cache_key] = buffers
             self._ping_pong_buffer_indices[cache_key] = 0
             ttnn.synchronize_device(self.mesh_device)
@@ -269,6 +273,8 @@ class CCLManager:
                 )
                 buffers.append(output_buffer)
 
+            # It is okay for these buffers to be allocated after trace capture, as long as they hold
+            # only temporary values consumed before trace replay.
             self._ping_pong_buffer_cache[cache_key] = buffers
             self._ping_pong_buffer_indices[cache_key] = 0
             ttnn.synchronize_device(self.mesh_device)

--- a/models/tt_dit/parallel/manager.py
+++ b/models/tt_dit/parallel/manager.py
@@ -354,6 +354,11 @@ class CCLManager:
             for sem in self.ag_ping_pong_semaphores[axis]:
                 ttnn.reset_global_semaphore_value(sem, 0)
 
+    def clear_persistent_buffers(self):
+        """Free all cached ping-pong buffers from device memory."""
+        self._ping_pong_buffer_cache.clear()
+        self._ping_pong_buffer_indices.clear()
+
     def all_gather_persistent_buffer(
         self, tensor: ttnn.Tensor, /, *, dim: int, mesh_axis: int | None, use_hyperparams: bool = False
     ) -> ttnn.Tensor:

--- a/models/tt_dit/pipelines/wan/pipeline_wan.py
+++ b/models/tt_dit/pipelines/wan/pipeline_wan.py
@@ -288,18 +288,6 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
         self.vae_scale_factor_spatial = self.vae.config.scale_factor_spatial if getattr(self, "vae", None) else 8
         self.video_processor = VideoProcessor(vae_scale_factor=self.vae_scale_factor_spatial)
 
-        self._allocate_persistent_buffers()
-
-    def _allocate_persistent_buffers(self) -> None:
-        """Allocate persistent buffers by running a pipeline pass without tracing.
-
-        This is important so they do not get allocated after trace capture, which would lead to
-        them being overwritten during trace execution. The resolution must match the resolution
-        used for traced inference.
-        """
-        logger.info("Pipeline allocation run...")
-        self.run_single_prompt(prompt="", num_inference_steps=2, seed=0, traced=False, num_frames=1)
-
     @staticmethod
     def create_pipeline(
         mesh_device,
@@ -881,6 +869,9 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
                 max_sequence_length=max_sequence_length,
                 encoder_traced=encoder_traced,
             )
+        if self._encoder_tracer is not None:
+            self._encoder_tracer.release_trace()
+            self._encoder_tracer = None
 
         # 4. Prepare timesteps
         self.scheduler.set_timesteps(num_inference_steps, device=device)
@@ -1041,6 +1032,15 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             profiler.end("denoising", profiler_iteration)
 
         self._current_timestep = None
+        if self._transformer_1_tracer is not None:
+            self._transformer_1_tracer.release_trace()
+            self._transformer_1_tracer = None
+        if self._transformer_2_tracer is not None:
+            self._transformer_2_tracer.release_trace()
+            self._transformer_2_tracer = None
+        self.transformer_1.cached_rope_features.clear()
+        self.transformer_2.cached_rope_features.clear()
+        self.dit_ccl_manager.clear_persistent_buffers()
 
         # Postprocess spatial output
         latents = current_model.postprocess_spatial_output_host(
@@ -1080,11 +1080,17 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
                 vae_decode = self._vae_tracer if vae_traced else self.tt_vae.forward
                 tt_video_BCTHW, new_logical_h = vae_decode(tt_latents_BTHWC, logical_h)
 
+            if self._vae_tracer is not None:
+                self._vae_tracer.release_trace()
+                self._vae_tracer = None
+
             concat_dims = [None, None]
             concat_dims[self.vae_parallel_config.height_parallel.mesh_axis] = 3
             concat_dims[self.vae_parallel_config.width_parallel.mesh_axis] = 4
             video_torch = self.vae_ccl_manager.device_to_host(tt_video_BCTHW, concat_dims)
             video_torch = video_torch[:, :, :, :new_logical_h, :]
+
+            self.vae_ccl_manager.clear_persistent_buffers()
 
             video = self.video_processor.postprocess_video(video_torch, output_type=output_type)
         else:
@@ -1092,10 +1098,6 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
 
         # Offload all models
         # self.maybe_free_model_hooks()
-        self.transformer_1.cached_rope_features.clear()
-        self.transformer_2.cached_rope_features.clear()
-        self.dit_ccl_manager.clear_persistent_buffers()
-        self.vae_ccl_manager.clear_persistent_buffers()
 
         if not return_dict:
             return (video,)

--- a/models/tt_dit/pipelines/wan/pipeline_wan.py
+++ b/models/tt_dit/pipelines/wan/pipeline_wan.py
@@ -4,6 +4,7 @@
 
 # Adapted from https://github.com/huggingface/diffusers/blob/main/src/diffusers/pipelines/wan/pipeline_wan.py
 
+import functools
 import html
 import os
 from contextlib import nullcontext
@@ -202,7 +203,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             parallel_config=self.encoder_parallel_config,
         )
 
-        self.transformer = WanTransformer3DModel(
+        self.transformer_1 = WanTransformer3DModel(
             patch_size=self.torch_transformer.config.patch_size,
             num_heads=self.torch_transformer.config.num_attention_heads,
             dim=self.torch_transformer.config.num_attention_heads * self.torch_transformer.config.attention_head_dim,
@@ -261,19 +262,22 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             # The module loading utility will take care of the necessary unloading.
             self.tt_umt5_encoder.set_unload_set(self.transformer_2)
             if ttnn.device.is_blackhole():
-                self.transformer.set_unload_set(self.transformer_2)
-                self.transformer_2.set_unload_set(self.transformer, self.tt_umt5_encoder)
+                self.transformer_1.set_unload_set(self.transformer_2)
+                self.transformer_2.set_unload_set(self.transformer_1, self.tt_umt5_encoder)
             else:
                 # WH T3K has tighter DRAM — include VAE in the unload chain so
                 # transformers and VAE never coexist in DRAM across pipeline runs.
-                self.transformer.set_unload_set(self.transformer_2, self.tt_vae)
-                self.transformer_2.set_unload_set(self.transformer, self.tt_umt5_encoder, self.tt_vae)
-                self.tt_vae.set_unload_set(self.transformer, self.transformer_2)
+                self.transformer_1.set_unload_set(self.transformer_2, self.tt_vae)
+                self.transformer_2.set_unload_set(self.transformer_1, self.tt_umt5_encoder, self.tt_vae)
+                self.tt_vae.set_unload_set(self.transformer_1, self.transformer_2)
 
-        self._transformer_tracer = None
+        self._transformer_1_tracer = None
         self._transformer_2_tracer = None
         self._vae_tracer = None
         self._encoder_tracer = None
+
+        self._transformer_1_step = functools.partial(self._transformer_step, self.transformer_1)
+        self._transformer_2_step = functools.partial(self._transformer_step, self.transformer_2)
 
         # Cache warmup: Load in reverse order of use to ensure the earliest required models stay loaded before call.
         self._prepare_transformer2()
@@ -412,11 +416,11 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             )
 
     def _prepare_transformer1(self):
-        if self._transformer_tracer is not None:
-            self._transformer_tracer.release_trace()
-            self._transformer_tracer = None
+        if self._transformer_1_tracer is not None:
+            self._transformer_1_tracer.release_trace()
+            self._transformer_1_tracer = None
         cache.load_model(
-            self.transformer,
+            self.transformer_1,
             model_name=os.path.basename(self.checkpoint_name),
             subfolder="transformer",
             parallel_config=self.parallel_config,
@@ -424,8 +428,10 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             is_fsdp=self.is_fsdp,
             get_torch_state_dict=lambda: self.torch_transformer.state_dict(),
         )
-        if self._transformer_tracer is None:
-            self._transformer_tracer = Tracer(self._transformer_step, device=self.mesh_device, clone_prep_inputs=False)
+        if self._transformer_1_tracer is None:
+            self._transformer_1_tracer = Tracer(
+                self._transformer_1_step, device=self.mesh_device, clone_prep_inputs=False
+            )
 
     def _prepare_transformer2(self):
         if self._transformer_2_tracer is not None:
@@ -913,8 +919,8 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
 
         permuted_latent = None
         rope_args = None
-        prompt_embeds_map = {"transformer": None, "transformer_2": None}
-        negative_prompt_embeds_map = {"transformer": None, "transformer_2": None}
+        prompt_embeds_map = {"transformer_1": None, "transformer_2": None}
+        negative_prompt_embeds_map = {"transformer_1": None, "transformer_2": None}
         current_model_name = None
 
         latent_frames, latent_height, latent_width = latents.shape[2], latents.shape[3], latents.shape[4]
@@ -933,16 +939,16 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
                         self._transformer_2_tracer.release_trace()
                         self._transformer_2_tracer = None
                     # wan2.1 or high-noise stage in wan2.2
-                    current_model = self.transformer
-                    forward = self._transformer_tracer if traced else self._transformer_step
-                    current_model_name = "transformer"
+                    current_model = self.transformer_1
+                    forward = self._transformer_1_tracer if traced else self._transformer_1_step
+                    current_model_name = "transformer_1"
                     current_guidance_scale = guidance_scale
                 else:
                     # low-noise stage in wan2.2
                     self._prepare_transformer2()
-                    if self._transformer_tracer is not None:
-                        self._transformer_tracer.release_trace()
-                        self._transformer_tracer = None
+                    if self._transformer_1_tracer is not None:
+                        self._transformer_1_tracer.release_trace()
+                        self._transformer_1_tracer = None
                     current_model = self.transformer_2
                     forward = self._transformer_2_tracer if traced else self._transformer_2_step
                     current_model_name = "transformer_2"
@@ -1086,7 +1092,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
 
         # Offload all models
         # self.maybe_free_model_hooks()
-        self.transformer.cached_rope_features.clear()
+        self.transformer_1.cached_rope_features.clear()
         self.transformer_2.cached_rope_features.clear()
         self.dit_ccl_manager.clear_persistent_buffers()
         self.vae_ccl_manager.clear_persistent_buffers()
@@ -1104,6 +1110,8 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
 
     def _transformer_step(
         self,
+        transformer: WanTransformer3DModel,
+        *,
         do_classifier_free_guidance: bool,
         spatial_1BNI: ttnn.Tensor,
         prompt_1BLP: ttnn.Tensor,
@@ -1115,7 +1123,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
         rope_sin_1HND: ttnn.Tensor,
         trans_mat: ttnn.Tensor,
     ) -> tuple[ttnn.Tensor, ttnn.Tensor | None]:
-        cond = self.transformer.inner_step(
+        cond = transformer.inner_step(
             spatial_1BNI,
             prompt_1BLP,
             rope_cos_1HND,
@@ -1128,45 +1136,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
         if not do_classifier_free_guidance:
             return cond, None
 
-        uncond = self.transformer.inner_step(
-            spatial_1BNI,
-            negative_prompt_1BLP,
-            rope_cos_1HND,
-            rope_sin_1HND,
-            trans_mat,
-            N,
-            temb_11BD,
-            timestep_proj_1BTD,
-        )
-        return cond, uncond
-
-    def _transformer_2_step(
-        self,
-        do_classifier_free_guidance: bool,
-        spatial_1BNI: ttnn.Tensor,
-        prompt_1BLP: ttnn.Tensor,
-        negative_prompt_1BLP: ttnn.Tensor,
-        N: int,
-        temb_11BD: ttnn.Tensor,
-        timestep_proj_1BTD: ttnn.Tensor,
-        rope_cos_1HND: ttnn.Tensor,
-        rope_sin_1HND: ttnn.Tensor,
-        trans_mat: ttnn.Tensor,
-    ) -> tuple[ttnn.Tensor, ttnn.Tensor | None]:
-        cond = self.transformer_2.inner_step(
-            spatial_1BNI,
-            prompt_1BLP,
-            rope_cos_1HND,
-            rope_sin_1HND,
-            trans_mat,
-            N,
-            temb_11BD,
-            timestep_proj_1BTD,
-        )
-        if not do_classifier_free_guidance:
-            return cond, None
-
-        uncond = self.transformer_2.inner_step(
+        uncond = transformer.inner_step(
             spatial_1BNI,
             negative_prompt_1BLP,
             rope_cos_1HND,

--- a/models/tt_dit/pipelines/wan/pipeline_wan.py
+++ b/models/tt_dit/pipelines/wan/pipeline_wan.py
@@ -31,9 +31,10 @@ from ...models.transformers.wan2_2.transformer_wan import WanTransformer3DModel
 from ...models.vae.vae_wan2_1 import WanDecoder
 from ...parallel.config import DiTParallelConfig, EncoderParallelConfig, ParallelFactor, VaeHWParallelConfig
 from ...parallel.manager import CCLManager
-from ...utils import cache
+from ...utils import cache, tensor
 from ...utils.conv3d import conv_pad_height, conv_pad_in_channels
 from ...utils.tensor import typed_tensor_2dshard
+from ...utils.tracing import Tracer
 
 EXAMPLE_DOC_STRING = """
     Examples:
@@ -138,6 +139,8 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
         vae_dtype: ttnn.DataType = ttnn.bfloat16,
     ):
         super().__init__()
+        self.register_to_config(boundary_ratio=boundary_ratio)
+        self.register_to_config(expand_timesteps=expand_timesteps)
 
         self.checkpoint_name = checkpoint_name
         self.model_type = model_type
@@ -267,17 +270,31 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
                 self.transformer_2.set_unload_set(self.transformer, self.tt_umt5_encoder, self.tt_vae)
                 self.tt_vae.set_unload_set(self.transformer, self.transformer_2)
 
+        self._transformer_tracer = None
+        self._transformer_2_tracer = None
+        self._vae_tracer = None
+        self._encoder_tracer = None
+
         # Cache warmup: Load in reverse order of use to ensure the earliest required models stay loaded before call.
         self._prepare_transformer2()
         self._prepare_transformer1()
         self._prepare_text_encoder()
         self._prepare_vae()
-
-        self.register_to_config(boundary_ratio=boundary_ratio)
-        self.register_to_config(expand_timesteps=expand_timesteps)
         self.vae_scale_factor_temporal = self.vae.config.scale_factor_temporal if getattr(self, "vae", None) else 4
         self.vae_scale_factor_spatial = self.vae.config.scale_factor_spatial if getattr(self, "vae", None) else 8
         self.video_processor = VideoProcessor(vae_scale_factor=self.vae_scale_factor_spatial)
+
+        self._allocate_persistent_buffers()
+
+    def _allocate_persistent_buffers(self) -> None:
+        """Allocate persistent buffers by running a pipeline pass without tracing.
+
+        This is important so they do not get allocated after trace capture, which would lead to
+        them being overwritten during trace execution. The resolution must match the resolution
+        used for traced inference.
+        """
+        logger.info("Pipeline allocation run...")
+        self.run_single_prompt(prompt="", num_inference_steps=2, seed=0, traced=False, num_frames=1)
 
     @staticmethod
     def create_pipeline(
@@ -378,6 +395,9 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
         )
 
     def _prepare_text_encoder(self):
+        if self._encoder_tracer is not None:
+            self._encoder_tracer.release_trace()
+            self._encoder_tracer = None
         cache.load_model(
             self.tt_umt5_encoder,
             model_name=os.path.basename(self.checkpoint_name),
@@ -386,8 +406,15 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             mesh_shape=tuple(self.mesh_device.shape),
             get_torch_state_dict=lambda: self.text_encoder.state_dict(),
         )
+        if self._encoder_tracer is None:
+            self._encoder_tracer = Tracer(
+                self.tt_umt5_encoder.forward, device=self.mesh_device, clone_prep_inputs=False
+            )
 
     def _prepare_transformer1(self):
+        if self._transformer_tracer is not None:
+            self._transformer_tracer.release_trace()
+            self._transformer_tracer = None
         cache.load_model(
             self.transformer,
             model_name=os.path.basename(self.checkpoint_name),
@@ -397,8 +424,13 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             is_fsdp=self.is_fsdp,
             get_torch_state_dict=lambda: self.torch_transformer.state_dict(),
         )
+        if self._transformer_tracer is None:
+            self._transformer_tracer = Tracer(self._transformer_step, device=self.mesh_device, clone_prep_inputs=False)
 
     def _prepare_transformer2(self):
+        if self._transformer_2_tracer is not None:
+            self._transformer_2_tracer.release_trace()
+            self._transformer_2_tracer = None
         cache.load_model(
             self.transformer_2,
             model_name=os.path.basename(self.checkpoint_name),
@@ -408,8 +440,15 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             is_fsdp=self.is_fsdp,
             get_torch_state_dict=lambda: self.torch_transformer_2.state_dict(),
         )
+        if self._transformer_2_tracer is None:
+            self._transformer_2_tracer = Tracer(
+                self._transformer_2_step, device=self.mesh_device, clone_prep_inputs=False
+            )
 
     def _prepare_vae(self):
+        if self._vae_tracer is not None:
+            self._vae_tracer.release_trace()
+            self._vae_tracer = None
         cache.load_model(
             self.tt_vae,
             model_name=os.path.basename(self.checkpoint_name),
@@ -418,12 +457,15 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             mesh_shape=tuple(self.mesh_device.shape),
             get_torch_state_dict=lambda: self.vae.state_dict(),
         )
+        if self._vae_tracer is None:
+            self._vae_tracer = Tracer(self.tt_vae.forward, device=self.mesh_device, clone_prep_inputs=False)
 
     def _get_t5_prompt_embeds(
         self,
         prompt: Union[str, List[str]] = None,
         num_videos_per_prompt: int = 1,
         max_sequence_length: int = 512,
+        encoder_traced: bool = False,
     ):
         prompt = [prompt] if isinstance(prompt, str) else prompt
         prompt = [prompt_clean(u) for u in prompt]
@@ -451,7 +493,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
         tt_prompt = ttnn.from_torch(
             text_input_ids,
             layout=ttnn.TILE_LAYOUT,
-            device=self.mesh_device,
+            device=None if encoder_traced else self.mesh_device,
             mesh_mapper=mesh_mapper,
         )
 
@@ -459,11 +501,15 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             mask,
             dtype=ttnn.bfloat16,
             layout=ttnn.TILE_LAYOUT,
-            device=self.mesh_device,
+            device=None if encoder_traced else self.mesh_device,
             mesh_mapper=mesh_mapper,
         )
 
-        prompt_embeds = self.tt_umt5_encoder(tt_prompt, attention_mask=tt_mask)[-1]
+        encoder_forward = self._encoder_tracer if encoder_traced else self.tt_umt5_encoder
+        prompt_embeds = encoder_forward(tt_prompt, attention_mask=tt_mask)[-1]
+
+        if encoder_traced:
+            tt_mask = tt_mask.to(self.mesh_device)
 
         # use the mask to zero out the padding tokens.
         prompt_embeds = prompt_embeds * ttnn.unsqueeze(tt_mask, -1)
@@ -487,6 +533,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
         prompt_embeds: Optional[torch.Tensor] = None,
         negative_prompt_embeds: Optional[torch.Tensor] = None,
         max_sequence_length: int = 512,
+        encoder_traced: bool = False,
     ):
         r"""
         Batch encodes the prompt and negative prompt into text encoder hidden states..
@@ -554,6 +601,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             prompt=all_input_prompts,
             num_videos_per_prompt=num_videos_per_prompt,
             max_sequence_length=max_sequence_length,
+            encoder_traced=encoder_traced,
         )
 
         # When CFG is enabled, we should be able to leave the shards on device.
@@ -696,6 +744,8 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
         callback_on_step_end_tensor_inputs: List[str] = ["latents"],
         max_sequence_length: int = 512,
         traced: bool = False,
+        vae_traced: bool | None = None,
+        encoder_traced: bool | None = None,
         profiler: BenchmarkProfiler = None,
         profiler_iteration: int = 0,
     ):
@@ -767,6 +817,8 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
                 the first element is a list with the generated images and the second element is a list of `bool`s
                 indicating whether the corresponding generated image contains "not-safe-for-work" (nsfw) content.
         """
+        vae_traced = vae_traced if vae_traced is not None else traced
+        encoder_traced = encoder_traced if encoder_traced is not None else traced
 
         if isinstance(callback_on_step_end, (PipelineCallback, MultiPipelineCallbacks)):
             callback_on_step_end_tensor_inputs = callback_on_step_end.tensor_inputs
@@ -821,6 +873,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
                 prompt_embeds=prompt_embeds,
                 negative_prompt_embeds=negative_prompt_embeds,
                 max_sequence_length=max_sequence_length,
+                encoder_traced=encoder_traced,
             )
 
         # 4. Prepare timesteps
@@ -872,19 +925,32 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
                     continue
 
                 self._current_timestep = t
+                previous_model_name = current_model_name
 
                 if boundary_timestep is None or t >= boundary_timestep:
                     self._prepare_transformer1()
+                    if self._transformer_2_tracer is not None:
+                        self._transformer_2_tracer.release_trace()
+                        self._transformer_2_tracer = None
                     # wan2.1 or high-noise stage in wan2.2
                     current_model = self.transformer
+                    forward = self._transformer_tracer if traced else self._transformer_step
                     current_model_name = "transformer"
                     current_guidance_scale = guidance_scale
                 else:
                     # low-noise stage in wan2.2
                     self._prepare_transformer2()
+                    if self._transformer_tracer is not None:
+                        self._transformer_tracer.release_trace()
+                        self._transformer_tracer = None
                     current_model = self.transformer_2
+                    forward = self._transformer_2_tracer if traced else self._transformer_2_step
                     current_model_name = "transformer_2"
                     current_guidance_scale = guidance_scale_2
+
+                assert forward is not None
+                model_changed = current_model_name != previous_model_name
+                reuse_tensors = i > 0 and traced and not model_changed
 
                 if permuted_latent is None:
                     # First iteration, preprocess spatial input and prepare rope features
@@ -893,7 +959,8 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
                     if cond_latents is not None:
                         cond_latents, _ = current_model.preprocess_spatial_input_host(cond_latents)
 
-                    rope_cos_1HND, rope_sin_1HND, trans_mat = current_model.get_rope_features(latents)
+                    # Allocate on host when traced since device tensors may be overwritten by trace execution.
+                    rope_cos_1HND, rope_sin_1HND, trans_mat = current_model.get_rope_features(latents, on_host=traced)
                     rope_args = {
                         "rope_cos_1HND": rope_cos_1HND,
                         "rope_sin_1HND": rope_sin_1HND,
@@ -901,6 +968,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
                     }
 
                 # Cache text conditioning
+                # Allocate on host since device tensors may be overwritten by trace execution.
                 if prompt_embeds_map[current_model_name] is None:
                     prompt_embeds_map[current_model_name] = current_model.prepare_text_conditioning(prompt_embeds)
                 if self.do_classifier_free_guidance and negative_prompt_embeds_map[current_model_name] is None:
@@ -920,22 +988,25 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
 
                 permuted_model_input = self.get_model_input(permuted_latent, cond_latents)
 
-                permuted_noise_pred_tt = current_model.inner_step(
-                    spatial_1BNI_torch=permuted_model_input,
+                permuted_model_input_tt = tensor.from_torch(
+                    permuted_model_input,
+                    device=self.mesh_device,
+                    mesh_axes=[None, None, self.parallel_config.sequence_parallel.mesh_axis, None],
+                )
+                temb_11BD, timestep_proj_1BTD = current_model.prepare_timestep_conditioning(timestep)
+
+                permuted_noise_pred_tt, permuted_noise_uncond_tt = forward(
+                    do_classifier_free_guidance=self.do_classifier_free_guidance,
+                    spatial_1BNI=permuted_model_input_tt,
                     prompt_1BLP=prompt_embeds_map[current_model_name],
+                    negative_prompt_1BLP=negative_prompt_embeds_map[current_model_name],
                     N=patchified_seqlen,
-                    timestep_torch=timestep,
+                    temb_11BD=temb_11BD,
+                    timestep_proj_1BTD=timestep_proj_1BTD,
                     **rope_args,
                 )
 
                 if self.do_classifier_free_guidance:
-                    permuted_noise_uncond_tt = current_model.inner_step(
-                        spatial_1BNI_torch=permuted_model_input,
-                        prompt_1BLP=negative_prompt_embeds_map[current_model_name],
-                        N=patchified_seqlen,
-                        timestep_torch=timestep,
-                        **rope_args,
-                    )
                     # On-device CFG with high precision fp32 lerp: uncond + scale * (cond - uncond)
                     permuted_noise_pred_tt = ttnn.lerp(
                         permuted_noise_uncond_tt, permuted_noise_pred_tt, current_guidance_scale
@@ -1000,7 +1071,8 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             )
             with profiler("vae", profiler_iteration) if profiler else nullcontext():
                 self._prepare_vae()
-                tt_video_BCTHW, new_logical_h = self.tt_vae(tt_latents_BTHWC, logical_h)
+                vae_decode = self._vae_tracer if vae_traced else self.tt_vae.forward
+                tt_video_BCTHW, new_logical_h = vae_decode(tt_latents_BTHWC, logical_h)
 
             concat_dims = [None, None]
             concat_dims[self.vae_parallel_config.height_parallel.mesh_axis] = 3
@@ -1014,6 +1086,10 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
 
         # Offload all models
         # self.maybe_free_model_hooks()
+        self.transformer.cached_rope_features.clear()
+        self.transformer_2.cached_rope_features.clear()
+        self.dit_ccl_manager.clear_persistent_buffers()
+        self.vae_ccl_manager.clear_persistent_buffers()
 
         if not return_dict:
             return (video,)
@@ -1025,3 +1101,79 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
 
     def synchronize_devices(self):
         ttnn.synchronize_device(self.mesh_device)
+
+    def _transformer_step(
+        self,
+        do_classifier_free_guidance: bool,
+        spatial_1BNI: ttnn.Tensor,
+        prompt_1BLP: ttnn.Tensor,
+        negative_prompt_1BLP: ttnn.Tensor,
+        N: int,
+        temb_11BD: ttnn.Tensor,
+        timestep_proj_1BTD: ttnn.Tensor,
+        rope_cos_1HND: ttnn.Tensor,
+        rope_sin_1HND: ttnn.Tensor,
+        trans_mat: ttnn.Tensor,
+    ) -> tuple[ttnn.Tensor, ttnn.Tensor | None]:
+        cond = self.transformer.inner_step(
+            spatial_1BNI,
+            prompt_1BLP,
+            rope_cos_1HND,
+            rope_sin_1HND,
+            trans_mat,
+            N,
+            temb_11BD,
+            timestep_proj_1BTD,
+        )
+        if not do_classifier_free_guidance:
+            return cond, None
+
+        uncond = self.transformer.inner_step(
+            spatial_1BNI,
+            negative_prompt_1BLP,
+            rope_cos_1HND,
+            rope_sin_1HND,
+            trans_mat,
+            N,
+            temb_11BD,
+            timestep_proj_1BTD,
+        )
+        return cond, uncond
+
+    def _transformer_2_step(
+        self,
+        do_classifier_free_guidance: bool,
+        spatial_1BNI: ttnn.Tensor,
+        prompt_1BLP: ttnn.Tensor,
+        negative_prompt_1BLP: ttnn.Tensor,
+        N: int,
+        temb_11BD: ttnn.Tensor,
+        timestep_proj_1BTD: ttnn.Tensor,
+        rope_cos_1HND: ttnn.Tensor,
+        rope_sin_1HND: ttnn.Tensor,
+        trans_mat: ttnn.Tensor,
+    ) -> tuple[ttnn.Tensor, ttnn.Tensor | None]:
+        cond = self.transformer_2.inner_step(
+            spatial_1BNI,
+            prompt_1BLP,
+            rope_cos_1HND,
+            rope_sin_1HND,
+            trans_mat,
+            N,
+            temb_11BD,
+            timestep_proj_1BTD,
+        )
+        if not do_classifier_free_guidance:
+            return cond, None
+
+        uncond = self.transformer_2.inner_step(
+            spatial_1BNI,
+            negative_prompt_1BLP,
+            rope_cos_1HND,
+            rope_sin_1HND,
+            trans_mat,
+            N,
+            temb_11BD,
+            timestep_proj_1BTD,
+        )
+        return cond, uncond

--- a/models/tt_dit/tests/encoders/t5/test_t5_full.py
+++ b/models/tt_dit/tests/encoders/t5/test_t5_full.py
@@ -20,6 +20,7 @@ from models.tt_dit.encoders.t5.model_t5 import T5Config, T5Encoder
 from models.tt_dit.parallel.config import EncoderParallelConfig, ParallelFactor
 from models.tt_dit.parallel.manager import CCLManager
 from models.tt_dit.utils.check import assert_quality
+from models.tt_dit.utils.tracing import Tracer
 
 
 @pytest.mark.parametrize(
@@ -121,10 +122,11 @@ def test_t5_encoder(
 
     tt_encoder = T5Encoder(config, encoder_submesh, ccl_manager, parallel_config)
     tt_encoder.load_torch_state_dict(hf_model.state_dict())
+    tracer = Tracer(tt_encoder.forward, device=encoder_submesh, clone_prep_inputs=False)
 
     # time TT model inference only
     tt_start_time = time.time()
-    tt_output = tt_encoder(tt_prompt)
+    tt_output = tracer(tt_prompt)
 
     tt_end_time = time.time()
     tt_execution_time = tt_end_time - tt_start_time

--- a/models/tt_dit/tests/models/wan2_2/test_pipeline_wan.py
+++ b/models/tt_dit/tests/models/wan2_2/test_pipeline_wan.py
@@ -12,16 +12,18 @@ from models.tt_dit.pipelines.wan.pipeline_wan import WanPipeline
 
 from ....utils.test import line_params, ring_params
 
+DEVICE_PARAMS = {"trace_region_size": 90000000}
+
 
 @pytest.mark.parametrize(
     "mesh_device, mesh_shape, sp_axis, tp_axis, num_links, dynamic_load, device_params, topology, is_fsdp",
     [
-        [(2, 2), (2, 2), 0, 1, 2, False, line_params, ttnn.Topology.Linear, True],
-        [(2, 4), (2, 4), 0, 1, 1, True, line_params, ttnn.Topology.Linear, True],
+        ((2, 2), (2, 2), 0, 1, 2, False, {**DEVICE_PARAMS, **line_params}, ttnn.Topology.Linear, True),
+        ((2, 4), (2, 4), 0, 1, 1, True, {**DEVICE_PARAMS, **line_params}, ttnn.Topology.Linear, True),
         # WH (ring) on 4x8
-        [(4, 8), (4, 8), 1, 0, 4, False, ring_params, ttnn.Topology.Ring, True],
+        ((4, 8), (4, 8), 1, 0, 4, False, {**DEVICE_PARAMS, **ring_params}, ttnn.Topology.Ring, True),
         # BH (linear) on 4x8
-        [(4, 8), (4, 8), 1, 0, 2, False, line_params, ttnn.Topology.Linear, False],
+        ((4, 8), (4, 8), 1, 0, 2, False, {**DEVICE_PARAMS, **line_params}, ttnn.Topology.Linear, False),
     ],
     ids=[
         "2x2sp0tp1",
@@ -42,7 +44,15 @@ from ....utils.test import line_params, ring_params
         "resolution_720p",
     ],
 )
+@pytest.mark.parametrize(
+    "traced",
+    [
+        pytest.param(True, id="tracing_on"),
+        pytest.param(False, id="tracing_off"),
+    ],
+)
 def test_pipeline_inference(
+    *,
     mesh_device,
     mesh_shape,
     sp_axis,
@@ -53,6 +63,7 @@ def test_pipeline_inference(
     width,
     height,
     is_fsdp,
+    traced: bool,
 ):
     parent_mesh = mesh_device
     mesh_device = parent_mesh.create_submesh(ttnn.MeshShape(*mesh_shape))
@@ -86,6 +97,9 @@ def test_pipeline_inference(
             num_frames=num_frames,
             num_inference_steps=num_inference_steps,
             seed=seed,
+            traced=traced,
+            vae_traced=traced,
+            encoder_traced=traced,
             guidance_scale=4.0,
             guidance_scale_2=3.0,
         )
@@ -106,11 +120,16 @@ def test_pipeline_inference(
     elif isinstance(frames, torch.Tensor):
         print(f"  Video data range: [{frames.min().item():.3f}, {frames.max().item():.3f}]")
 
+    filename = "wan_output_video"
+    if traced:
+        filename += "_traced"
+    filename += ".mp4"
+
     # Save video using diffusers utility
     # Remove batch dimension
     frames = frames[0]
     try:
-        export_to_video(frames, "wan_output_video.mp4", fps=16)
-        print("✓ Saved video to: wan_output_video.mp4")
+        export_to_video(frames, filename, fps=16)
+        print(f"✓ Saved video to: {filename}")
     except AttributeError as e:
         print(f"AttributeError: {e}")

--- a/models/tt_dit/tests/models/wan2_2/test_pipeline_wan.py
+++ b/models/tt_dit/tests/models/wan2_2/test_pipeline_wan.py
@@ -97,7 +97,7 @@ def test_pipeline_inference(
             num_frames=num_frames,
             num_inference_steps=num_inference_steps,
             seed=seed,
-            traced=traced,
+            traced=not dynamic_load,
             vae_traced=traced,
             encoder_traced=traced,
             guidance_scale=4.0,

--- a/models/tt_dit/tests/models/wan2_2/test_transformer_wan.py
+++ b/models/tt_dit/tests/models/wan2_2/test_transformer_wan.py
@@ -380,14 +380,15 @@ def test_wan_transformer_inner_step(
 
     # Run TT inner_step (returns on-device tensor)
     logger.info(f"Running TT inner_step with spatial_host shape {spatial_host.shape}, N={N}")
+    spatial_1BNI = bf16_tensor(
+        spatial_host,
+        device=mesh_device,
+        mesh_axis=parallel_config.sequence_parallel.mesh_axis,
+        shard_dim=-2,
+    )
+    temb_11BD, timestep_proj_1BTD = tt_model.prepare_timestep_conditioning(timestep_input)
     tt_output_1BNI_tt = tt_model.inner_step(
-        spatial_1BNI_torch=spatial_host,
-        prompt_1BLP=prompt_1BLP,
-        rope_cos_1HND=rope_cos_1HND,
-        rope_sin_1HND=rope_sin_1HND,
-        trans_mat=trans_mat,
-        N=N,
-        timestep_torch=timestep_input,
+        spatial_1BNI, prompt_1BLP, rope_cos_1HND, rope_sin_1HND, trans_mat, N, temb_11BD, timestep_proj_1BTD
     )
     tt_output_1BNI = tt_model.device_to_host(tt_output_1BNI_tt)
     tt_output = tt_model.postprocess_spatial_output_host(tt_output_1BNI, T, H, W, N)

--- a/models/tt_dit/tests/models/wan2_2/test_vae_wan2_1.py
+++ b/models/tt_dit/tests/models/wan2_2/test_vae_wan2_1.py
@@ -2,8 +2,11 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import time
 from collections import defaultdict
+from typing import TYPE_CHECKING
 
 import pytest
 import torch
@@ -24,12 +27,19 @@ from ....models.vae.vae_wan2_1 import (
     WanResample,
     WanResidualBlock,
     WanUpBlock,
+    defrag_cache,
+    update_cache_value,
 )
 from ....parallel.config import ParallelFactor, VaeHWParallelConfig
 from ....parallel.manager import CCLManager
+from ....utils import tensor
 from ....utils.check import assert_quality
 from ....utils.conv3d import conv_pad_height, conv_pad_in_channels, conv_unpad_height, count_convs
 from ....utils.tensor import bf16_tensor_2dshard, typed_tensor_2dshard
+from ....utils.tracing import Tracer
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 def setup_hooks(model):
@@ -315,14 +325,7 @@ def test_wan_attention(mesh_device, B, C, T, H, W, mean, std, h_axis, w_axis, dt
     tt_output = tt_model(tt_input_tensor, logical_h=logical_h)
 
     tt_output = ttnn.to_layout(tt_output, ttnn.ROW_MAJOR_LAYOUT)
-    concat_dims = [None, None]
-    concat_dims[h_axis] = 2
-    concat_dims[w_axis] = 3
-
-    tt_output_torch = ttnn.to_torch(
-        tt_output,
-        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=concat_dims),
-    )
+    tt_output_torch = tensor.to_torch(tt_output, mesh_axes=[..., h_axis, w_axis, None])
 
     tt_output_torch = conv_unpad_height(tt_output_torch, logical_h)
     tt_output_torch = tt_output_torch.permute(0, 4, 1, 2, 3)
@@ -391,7 +394,11 @@ def test_wan_conv3d(
     tt_input_dtype = ttnn.bfloat16 if dtype == ttnn.DataType.BFLOAT16 else ttnn.float32
     torch_dtype = torch.float32
     torch_model = TorchWanCausalConv3d(
-        in_channels=C_in, out_channels=C_out, kernel_size=kernel_size, stride=stride, padding=padding
+        in_channels=C_in,
+        out_channels=C_out,
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=(-(-padding[0] // 2), *padding[1:]),
     )
     torch_model.eval()
 
@@ -441,20 +448,18 @@ def test_wan_conv3d(
             shard_mapping={h_axis: 2, w_axis: 3},
             dtype=tt_input_dtype,
         )
+
+        tt_cache = {}
+        update_cache_value(tt_cache, "", tt_cache_tensor, length=padding[0])
     else:
         torch_cache_tensor = tt_cache_tensor = None
+        tt_cache = None
 
     with torch.no_grad():
         torch_output = torch_model(torch_input_tensor, cache_x=torch_cache_tensor)
-    tt_output = tt_model(tt_input_tensor, cache_x_BTHWC=tt_cache_tensor, logical_h=logical_h)
+    tt_output = tt_model(tt_input_tensor, logical_h, tt_cache)
 
-    concat_dims = [None, None]
-    concat_dims[h_axis] = 2
-    concat_dims[w_axis] = 3
-    tt_output_torch = ttnn.to_torch(
-        tt_output,
-        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=concat_dims),
-    )
+    tt_output_torch = tensor.to_torch(tt_output, mesh_axes=[..., h_axis, w_axis, None])
     if logical_h != tt_output_torch.shape[2]:
         logger.info(f"Checking that output padded portion is zeros")
         padding = tt_output_torch[:, :, logical_h:, :, :]
@@ -560,6 +565,8 @@ def test_wan_residual_block(mesh_device, B, in_dim, out_dim, T, H, W, cache_len,
     logger.info(f"torch_input_tensor.shape: {torch_input_tensor.shape}")
     logger.info(f"tt_input_tensor.shape: {tt_input_tensor.shape}")
 
+    tt_feat_cache = {}
+
     if cache_len is not None:
         torch_cache_tensor_1 = torch.randn(B, in_dim, cache_len, H, W, dtype=torch_dtype) * std + mean
         torch_cache_tensor_2 = torch.randn(B, out_dim, cache_len, H, W, dtype=torch_dtype) * std + mean
@@ -584,13 +591,11 @@ def test_wan_residual_block(mesh_device, B, in_dim, out_dim, T, H, W, cache_len,
             shard_mapping={h_axis: 2, w_axis: 3},
             dtype=tt_input_dtype,
         )
-        tt_feat_cache = [tt_cache_tensor_1, tt_cache_tensor_2]
-        tt_feat_idx = [0]
+        update_cache_value(tt_feat_cache, ".conv1", tt_cache_tensor_1, length=2)
+        update_cache_value(tt_feat_cache, ".conv2", tt_cache_tensor_2, length=2)
     else:
         torch_feat_cache = [None, None]
         torch_feat_idx = [0]
-        tt_feat_cache = [None, None]
-        tt_feat_idx = [0]
 
     with torch.no_grad():
         torch_output = torch_model(
@@ -599,36 +604,25 @@ def test_wan_residual_block(mesh_device, B, in_dim, out_dim, T, H, W, cache_len,
             feat_idx=torch_feat_idx,
         )
 
-    tt_output = tt_model(
-        tt_input_tensor,
-        logical_h,
-        feat_cache=tt_feat_cache,
-        feat_idx=tt_feat_idx,
-    )
+    tt_output = tt_model(tt_input_tensor, logical_h, feat_cache=tt_feat_cache)
 
     tt_output = ttnn.to_layout(tt_output, ttnn.ROW_MAJOR_LAYOUT)
-    concat_dims = [None, None]
-    concat_dims[h_axis] = 2
-    concat_dims[w_axis] = 3
-    tt_output_torch = ttnn.to_torch(
-        tt_output,
-        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=concat_dims),
-    )
+    tt_output_torch = tensor.to_torch(tt_output, mesh_axes=[..., h_axis, w_axis, None])
     tt_output_torch = conv_unpad_height(tt_output_torch, logical_h)
     tt_output_torch = tt_output_torch.permute(0, 4, 1, 2, 3)
 
     logger.info(f"checking output")
     assert_quality(torch_output, tt_output_torch, pcc=0.999_900, relative_rmse=0.012)
 
-    for i in range(len(tt_feat_cache)):
-        tt_feat_cache[i] = ttnn.to_torch(
-            tt_feat_cache[i],
-            mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=concat_dims),
-        )
-        tt_feat_cache[i] = conv_unpad_height(tt_feat_cache[i], logical_h)
-        tt_feat_cache[i] = tt_feat_cache[i].permute(0, 4, 1, 2, 3)
-        logger.info(f"checking feat_cache {i}")
-        assert_quality(torch_feat_cache[i], tt_feat_cache[i], pcc=0.999_000, relative_rmse=0.04)
+    _check_feat_cache(
+        torch_feat_cache,
+        tt_feat_cache,
+        h_axis=h_axis,
+        w_axis=w_axis,
+        logical_h=logical_h,
+        pcc=0.999,
+        relative_rmse=0.04,
+    )
 
 
 @pytest.mark.parametrize(
@@ -720,9 +714,8 @@ def test_wan_mid_block(mesh_device, B, dim, T, H, W, cache_len, mean, std, h_axi
     tt_input_tensor = ttnn.to_layout(tt_input_tensor, ttnn.TILE_LAYOUT)
 
     torch_feat_cache = []
-    tt_feat_cache = []
     torch_feat_idx = [0]
-    tt_feat_idx = [0]
+    tt_feat_cache = {}
     for i in range(num_convs):
         torch.manual_seed(0)
         if cache_len is not None:
@@ -738,11 +731,10 @@ def test_wan_mid_block(mesh_device, B, dim, T, H, W, cache_len, mean, std, h_axi
                 shard_mapping={h_axis: 2, w_axis: 3},
                 dtype=tt_input_dtype,
             )
-            tt_feat_cache.append(tt_cache_tensor)
 
+            update_cache_value(tt_feat_cache, f".resnet{i // 2}.conv{i % 2 + 1}", tt_cache_tensor, length=2)
         else:
             torch_feat_cache.append(None)
-            tt_feat_cache.append(None)
 
     with torch.no_grad():
         torch_output = torch_model(
@@ -751,36 +743,25 @@ def test_wan_mid_block(mesh_device, B, dim, T, H, W, cache_len, mean, std, h_axi
             feat_idx=torch_feat_idx,
         )
 
-    tt_output = tt_model(
-        tt_input_tensor,
-        logical_h,
-        feat_cache=tt_feat_cache,
-        feat_idx=tt_feat_idx,
-    )
+    tt_output = tt_model(tt_input_tensor, logical_h, feat_cache=tt_feat_cache)
 
     tt_output = ttnn.to_layout(tt_output, ttnn.ROW_MAJOR_LAYOUT)
-    concat_dims = [None, None]
-    concat_dims[h_axis] = 2
-    concat_dims[w_axis] = 3
-    tt_output_torch = ttnn.to_torch(
-        tt_output,
-        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=concat_dims),
-    )
+    tt_output_torch = tensor.to_torch(tt_output, mesh_axes=[..., h_axis, w_axis, None])
     tt_output_torch = conv_unpad_height(tt_output_torch, logical_h)
     tt_output_torch = tt_output_torch.permute(0, 4, 1, 2, 3)
 
     logger.info(f"checking output")
     assert_quality(torch_output, tt_output_torch, pcc=MIN_PCC, relative_rmse=MAX_RMSE)
 
-    for i in range(len(tt_feat_cache)):
-        tt_feat_cache[i] = ttnn.to_torch(
-            tt_feat_cache[i],
-            mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=concat_dims),
-        )
-        tt_feat_cache[i] = conv_unpad_height(tt_feat_cache[i], logical_h)
-        tt_feat_cache[i] = tt_feat_cache[i].permute(0, 4, 1, 2, 3)
-        logger.info(f"checking feat_cache {i}")
-        assert_quality(torch_feat_cache[i], tt_feat_cache[i], pcc=0.999_000, relative_rmse=0.016)
+    _check_feat_cache(
+        torch_feat_cache,
+        tt_feat_cache,
+        h_axis=h_axis,
+        w_axis=w_axis,
+        logical_h=logical_h,
+        pcc=0.997,
+        relative_rmse=0.08,
+    )
 
 
 @pytest.mark.parametrize(
@@ -875,9 +856,8 @@ def test_wan_resample(mesh_device, B, dim, T, H, W, mode, resample_out_dim, cach
     )
 
     torch_feat_cache = []
-    tt_feat_cache = []
+    tt_feat_cache = {}
     torch_feat_idx = [0]
-    tt_feat_idx = [0]
     for i in range(num_convs):
         if cache_len is not None:
             torch_cache_tensor = (
@@ -890,11 +870,10 @@ def test_wan_resample(mesh_device, B, dim, T, H, W, mode, resample_out_dim, cach
             tt_cache_tensor = bf16_tensor_2dshard(
                 tt_cache_tensor, mesh_device, layout=ttnn.ROW_MAJOR_LAYOUT, shard_mapping={h_axis: 2, w_axis: 3}
             )
-            tt_feat_cache.append(tt_cache_tensor)
+            update_cache_value(tt_feat_cache, "", tt_cache_tensor, length=1 if "downsample" in mode else 2)
 
         else:
             torch_feat_cache.append(None)
-            tt_feat_cache.append(None)
 
     with torch.no_grad():
         torch_output = torch_model(
@@ -903,39 +882,16 @@ def test_wan_resample(mesh_device, B, dim, T, H, W, mode, resample_out_dim, cach
             feat_idx=torch_feat_idx,
         )
 
-    tt_output, new_logical_h = tt_model(
-        tt_input_tensor,
-        logical_h,
-        feat_cache=tt_feat_cache,
-        feat_idx=tt_feat_idx,
-    )
+    tt_output, new_logical_h = tt_model(tt_input_tensor, logical_h, feat_cache=tt_feat_cache)
 
-    concat_dims = [None, None]
-    concat_dims[h_axis] = 2
-    concat_dims[w_axis] = 3
-    tt_output_torch = ttnn.to_torch(
-        tt_output,
-        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=concat_dims),
-    )
+    tt_output_torch = tensor.to_torch(tt_output, mesh_axes=[..., h_axis, w_axis, None])
     tt_output_torch = conv_unpad_height(tt_output_torch, new_logical_h)
     tt_output_torch = tt_output_torch.permute(0, 4, 1, 2, 3)
 
     logger.info(f"checking output")
     assert_quality(torch_output, tt_output_torch, pcc=0.999_900, relative_rmse=0.008)
 
-    for i in range(len(tt_feat_cache)):
-        logger.info(f"checking feat_cache {i}")
-        if isinstance(tt_feat_cache[i], str) and tt_feat_cache[i] == "Rep":
-            logger.info(f"feat_cache {i} is Rep")
-            assert torch_feat_cache[i] == "Rep"
-            continue
-        tt_feat_cache[i] = ttnn.to_torch(
-            tt_feat_cache[i],
-            mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=concat_dims),
-        )
-        tt_feat_cache[i] = tt_feat_cache[i][:, :, : torch_feat_cache[i].shape[3], :, :]
-        tt_feat_cache[i] = tt_feat_cache[i].permute(0, 4, 1, 2, 3)
-        assert_quality(torch_feat_cache[i], tt_feat_cache[i], pcc=0.999_000, relative_rmse=0.016)
+    _check_feat_cache(torch_feat_cache, tt_feat_cache, h_axis=h_axis, w_axis=w_axis, pcc=0.999, relative_rmse=0.016)
 
 
 @pytest.mark.parametrize(
@@ -1015,12 +971,11 @@ def test_wan_upblock(mesh_device, B, in_dim, out_dim, T, H, W, mode, num_res_blo
     num_convs = count_convs(tt_model)
 
     torch_feat_cache = [None for _ in range(num_convs)]
-    tt_feat_cache = [None for _ in range(num_convs)]
+    tt_feat_cache = {}
 
     # Run 4 times to get models to create their own caches
     for i in range(4):
         torch_feat_idx = [0]
-        tt_feat_idx = [0]
         logger.info(f"running test iteration {i}")
 
         torch_input_tensor = torch.randn(B, in_dim, T, H, W, dtype=torch_dtype) * std + mean
@@ -1046,69 +1001,19 @@ def test_wan_upblock(mesh_device, B, in_dim, out_dim, T, H, W, mode, num_res_blo
             )
 
         logger.info(f"running tt model")
-        tt_output, new_logical_h = tt_model(
-            tt_input_tensor,
-            logical_h,
-            feat_cache=tt_feat_cache,
-            feat_idx=tt_feat_idx,
-        )
+        tt_output, new_logical_h = tt_model(tt_input_tensor, logical_h, feat_cache=tt_feat_cache)
 
         tt_output = ttnn.to_layout(tt_output, ttnn.ROW_MAJOR_LAYOUT)
-        concat_dims = [None, None]
-        concat_dims[h_axis] = 2
-        concat_dims[w_axis] = 3
-        tt_output_torch = ttnn.to_torch(
-            tt_output,
-            mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=concat_dims),
-        )
+        tt_output_torch = tensor.to_torch(tt_output, mesh_axes=[..., h_axis, w_axis, None])
         tt_output_torch = conv_unpad_height(tt_output_torch, new_logical_h)
         tt_output_torch = tt_output_torch.permute(0, 4, 1, 2, 3)
 
         logger.info(f"checking output")
         assert_quality(torch_output, tt_output_torch, pcc=0.999_000, relative_rmse=0.02)
 
-        for i in range(len(tt_feat_cache)):
-            logger.info(f"checking feat_cache {i}")
-            if isinstance(tt_feat_cache[i], str) and tt_feat_cache[i] == "Rep":
-                logger.info(f"feat_cache {i} is Rep")
-                assert torch_feat_cache[i] == "Rep"
-                continue
-            tt_feat_cache_back = ttnn.to_torch(
-                tt_feat_cache[i],
-                mesh_composer=ttnn.ConcatMesh2dToTensor(
-                    mesh_device, mesh_shape=tuple(mesh_device.shape), dims=concat_dims
-                ),
-            )
-            tt_feat_cache_back = tt_feat_cache_back[:, :, : torch_feat_cache[i].shape[3], :, :]
-            tt_feat_cache_back = tt_feat_cache_back.permute(0, 4, 1, 2, 3)
-            assert_quality(torch_feat_cache[i], tt_feat_cache_back, pcc=0.999_000, relative_rmse=0.03)
+        _check_feat_cache(torch_feat_cache, tt_feat_cache, h_axis=h_axis, w_axis=w_axis, pcc=0.999, relative_rmse=0.03)
 
-        # Defrag the cache
-        tt_feat_cache_host = []
-        for i in range(len(tt_feat_cache)):
-            if isinstance(tt_feat_cache[i], str) and tt_feat_cache[i] == "Rep":
-                tt_feat_cache_host.append(tt_feat_cache[i])
-            else:
-                tt_feat_cache_host.append(
-                    ttnn.to_torch(
-                        tt_feat_cache[i],
-                        mesh_composer=ttnn.ConcatMesh2dToTensor(
-                            mesh_device, mesh_shape=tuple(mesh_device.shape), dims=concat_dims
-                        ),
-                    )
-                )
-                ttnn.deallocate(tt_feat_cache[i])
-        for i in range(len(tt_feat_cache)):
-            if isinstance(tt_feat_cache[i], str) and tt_feat_cache[i] == "Rep":
-                tt_feat_cache[i] = tt_feat_cache_host[i]
-            else:
-                tt_feat_cache[i] = typed_tensor_2dshard(
-                    tt_feat_cache_host[i],
-                    mesh_device,
-                    layout=ttnn.ROW_MAJOR_LAYOUT,
-                    shard_mapping={h_axis: 2, w_axis: 3},
-                    dtype=tt_input_dtype,
-                )
+        defrag_cache(tt_feat_cache)
 
 
 @pytest.mark.parametrize(
@@ -1150,7 +1055,9 @@ def test_wan_upblock(mesh_device, B, in_dim, out_dim, T, H, W, mode, num_res_blo
     ],
     indirect=["mesh_device"],
 )
-@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
+@pytest.mark.parametrize(
+    "device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 3300000}], indirect=True
+)
 def test_wan_decoder3d(
     mesh_device, B, C, T, H, W, mean, std, h_axis, w_axis, num_links, check_cache, dtype, MIN_PCC, MAX_RMSE
 ):
@@ -1205,18 +1112,19 @@ def test_wan_decoder3d(
         dtype=dtype,
     )
     tt_model.load_torch_state_dict(torch_model.state_dict())
+    tracer = Tracer(tt_model.forward, device=mesh_device, clone_prep_inputs=False)
+    traced = True
 
     num_convs = count_convs(tt_model)
 
     torch_feat_cache = [None for _ in range(num_convs)]
-    tt_feat_cache = [None for _ in range(num_convs)]
+    tt_feat_cache = {}
 
     # Run 4 times to get models to create their own caches
     for i in range(3):
         torch.manual_seed(0)
 
         torch_feat_idx = [0]
-        tt_feat_idx = [0]
         logger.info(f"running test iteration {i}")
 
         torch_input_tensor = torch.randn(B, C, T, H, W, dtype=torch_dtype) * std + mean
@@ -1241,20 +1149,11 @@ def test_wan_decoder3d(
         logger.info(f"torch output shape: {torch_output.shape}")
 
         logger.info(f"running tt model")
-        tt_output, new_logical_h = tt_model(
-            tt_input_tensor,
-            logical_h,
-            feat_cache=tt_feat_cache,
-            feat_idx=tt_feat_idx,
+        tt_output, new_logical_h = (tracer if traced and i != 0 else tt_model)(
+            tt_input_tensor, logical_h, feat_cache=tt_feat_cache if i <= 1 else None
         )
 
-        concat_dims = [None, None]
-        concat_dims[h_axis] = 2
-        concat_dims[w_axis] = 3
-        tt_output_torch = ttnn.to_torch(
-            tt_output,
-            mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=concat_dims),
-        )
+        tt_output_torch = tensor.to_torch(tt_output, mesh_axes=[..., h_axis, w_axis, None])
         tt_output_torch = conv_unpad_height(tt_output_torch, new_logical_h)
         tt_output_torch = tt_output_torch.permute(0, 4, 1, 2, 3)
         # Trim padding on output channels
@@ -1266,63 +1165,11 @@ def test_wan_decoder3d(
         assert_quality(torch_output, tt_output_torch, pcc=MIN_PCC, relative_rmse=MAX_RMSE)
 
         if check_cache:
-            for cache_idx in range(len(tt_feat_cache)):
-                logger.info(f"checking feat_cache {cache_idx}")
-                if isinstance(tt_feat_cache[cache_idx], str) and tt_feat_cache[cache_idx] == "Rep":
-                    logger.info(f"feat_cache {cache_idx} is Rep")
-                    assert torch_feat_cache[cache_idx] == "Rep"
-                    continue
-                tt_feat_cache_back = ttnn.to_torch(
-                    tt_feat_cache[cache_idx],
-                    mesh_composer=ttnn.ConcatMesh2dToTensor(
-                        mesh_device, mesh_shape=tuple(mesh_device.shape), dims=concat_dims
-                    ),
-                )
-                tt_feat_cache_back = tt_feat_cache_back.permute(0, 4, 1, 2, 3)
-                if tt_feat_cache_back.shape[1] != torch_feat_cache[cache_idx].shape[1]:
-                    tt_feat_cache_back = tt_feat_cache_back[:, : torch_feat_cache[cache_idx].shape[1]]
-                    logger.warning(f"Trimmed tt_feat_cache_back to {tt_feat_cache_back.shape}")
-                if tt_feat_cache_back.shape[3] != torch_feat_cache[cache_idx].shape[3]:
-                    tt_feat_cache_back = tt_feat_cache_back[:, :, :, : torch_feat_cache[cache_idx].shape[3]]
-                    logger.warning(f"Trimmed tt_feat_cache_back to {tt_feat_cache_back.shape}")
-                logger.info(
-                    f"feat_cache {cache_idx} shape: {torch_feat_cache[cache_idx].shape}, {tt_feat_cache_back.shape}"
-                )
-                try:
-                    assert_quality(torch_feat_cache[cache_idx], tt_feat_cache_back, pcc=MIN_PCC, relative_rmse=MAX_RMSE)
-                except Exception as e:
-                    logger.error(
-                        f"Error checking feat_cache {cache_idx}: {e}. Known issue where when T=2 in cache, T=0 is corrupted after cache is updated."
-                    )
-                    # breakpoint()
-                    raise e
+            _check_feat_cache(
+                torch_feat_cache, tt_feat_cache, h_axis=h_axis, w_axis=w_axis, pcc=MIN_PCC, relative_rmse=MAX_RMSE
+            )
 
-        # Defrag the cache
-        tt_feat_cache_host = []
-        for j in range(len(tt_feat_cache)):
-            if isinstance(tt_feat_cache[j], str) and tt_feat_cache[j] == "Rep":
-                tt_feat_cache_host.append(tt_feat_cache[j])
-            else:
-                tt_feat_cache_host.append(
-                    ttnn.to_torch(
-                        tt_feat_cache[j],
-                        mesh_composer=ttnn.ConcatMesh2dToTensor(
-                            mesh_device, mesh_shape=tuple(mesh_device.shape), dims=concat_dims
-                        ),
-                    )
-                )
-                ttnn.deallocate(tt_feat_cache[j])
-        for j in range(len(tt_feat_cache)):
-            if isinstance(tt_feat_cache[j], str) and tt_feat_cache[j] == "Rep":
-                tt_feat_cache[j] = tt_feat_cache_host[j]
-            else:
-                tt_feat_cache[j] = typed_tensor_2dshard(
-                    tt_feat_cache_host[j],
-                    mesh_device,
-                    layout=ttnn.ROW_MAJOR_LAYOUT,
-                    shard_mapping={h_axis: 2, w_axis: 3},
-                    dtype=tt_input_dtype,
-                )
+        defrag_cache(tt_feat_cache)
 
 
 @pytest.mark.parametrize(
@@ -1429,6 +1276,7 @@ def test_wan_decoder(
         dtype=dtype,
     )
     tt_model.load_torch_state_dict(torch_model.state_dict())
+    tracer = Tracer(tt_model.forward, device=mesh_device)
 
     torch_input_tensor = torch.randn(B, C, T, H, W, dtype=torch_dtype) * std + mean
     tt_input_tensor = torch_input_tensor.permute(0, 2, 3, 4, 1)
@@ -1446,18 +1294,9 @@ def test_wan_decoder(
 
     logger.info(f"running tt model")
     start = time.time()
-    tt_output, new_logical_h = tt_model(
-        tt_input_tensor,
-        logical_h,
-    )
+    tt_output, new_logical_h = tracer(tt_input_tensor, logical_h)
 
-    concat_dims = [None, None]
-    concat_dims[h_axis] = 3
-    concat_dims[w_axis] = 4
-    tt_output_torch = ttnn.to_torch(
-        tt_output,
-        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=concat_dims),
-    )
+    tt_output_torch = tensor.to_torch(tt_output, mesh_axes=[..., h_axis, w_axis])
     logger.info(f"tt time taken: {time.time() - start}")
     logger.info(f"tt output shape: {tt_output_torch.shape}")
 
@@ -1564,16 +1403,17 @@ def test_wan_encoder3d(mesh_device, B, C, T, H, W, mean, std, h_axis, w_axis, nu
         dtype=ttnn.bfloat16,
     )
     tt_model.load_torch_state_dict(torch_model.state_dict())
+    tracer = Tracer(tt_model.forward, device=mesh_device)
+    traced = True
 
     num_convs = count_convs(tt_model)
 
     torch_feat_cache = [None for _ in range(num_convs)]
-    tt_feat_cache = [None for _ in range(num_convs)]
+    tt_feat_cache = {}
 
     # Run 4 times to get models to create their own caches
     for i in range(3):
         torch_feat_idx = [0]
-        tt_feat_idx = [0]
         logger.info(f"running test iteration {i}")
 
         torch_input_tensor = torch.randn(B, C, (1 if i == 0 else T), H, W, dtype=torch_dtype) * std + mean
@@ -1596,20 +1436,11 @@ def test_wan_encoder3d(mesh_device, B, C, T, H, W, mean, std, h_axis, w_axis, nu
         logger.info(f"torch output shape: {torch_output.shape}")
 
         logger.info(f"running tt model")
-        tt_output, new_logical_h = tt_model(
-            tt_input_tensor,
-            logical_h,
-            feat_cache=tt_feat_cache,
-            feat_idx=tt_feat_idx,
+        tt_output, new_logical_h = (tracer if traced and i != 0 else tt_model)(
+            tt_input_tensor, logical_h, feat_cache=tt_feat_cache if i <= 1 else None
         )
 
-        concat_dims = [None, None]
-        concat_dims[h_axis] = 2
-        concat_dims[w_axis] = 3
-        tt_output_torch = ttnn.to_torch(
-            tt_output,
-            mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=concat_dims),
-        )
+        tt_output_torch = tensor.to_torch(tt_output, mesh_axes=[..., h_axis, w_axis, None])
         tt_output_torch = conv_unpad_height(tt_output_torch, new_logical_h)
         tt_output_torch = tt_output_torch.permute(0, 4, 1, 2, 3)
 
@@ -1621,62 +1452,11 @@ def test_wan_encoder3d(mesh_device, B, C, T, H, W, mean, std, h_axis, w_axis, nu
         assert_quality(torch_output, tt_output_torch, pcc=MIN_PCC, relative_rmse=MAX_RMSE)
 
         if check_cache:
-            for cache_idx in range(len(tt_feat_cache)):
-                logger.info(f"checking feat_cache {cache_idx}")
-                if isinstance(tt_feat_cache[cache_idx], str) and tt_feat_cache[cache_idx] == "Rep":
-                    logger.info(f"feat_cache {cache_idx} is Rep")
-                    assert torch_feat_cache[cache_idx] == "Rep"
-                    continue
-                tt_feat_cache_back = ttnn.to_torch(
-                    tt_feat_cache[cache_idx],
-                    mesh_composer=ttnn.ConcatMesh2dToTensor(
-                        mesh_device, mesh_shape=tuple(mesh_device.shape), dims=concat_dims
-                    ),
-                )
-                tt_feat_cache_back = tt_feat_cache_back.permute(0, 4, 1, 2, 3)
-                if tt_feat_cache_back.shape[1] != torch_feat_cache[cache_idx].shape[1]:
-                    tt_feat_cache_back = tt_feat_cache_back[:, : torch_feat_cache[cache_idx].shape[1]]
-                    logger.warning(f"Trimmed tt_feat_cache_back to {tt_feat_cache_back.shape}")
-                if tt_feat_cache_back.shape[3] != torch_feat_cache[cache_idx].shape[3]:
-                    tt_feat_cache_back = tt_feat_cache_back[:, :, :, : torch_feat_cache[cache_idx].shape[3]]
-                    logger.warning(f"Trimmed tt_feat_cache_back to {tt_feat_cache_back.shape}")
-                logger.info(
-                    f"feat_cache {cache_idx} shape: {torch_feat_cache[cache_idx].shape}, {tt_feat_cache_back.shape}"
-                )
-                try:
-                    assert_quality(torch_feat_cache[cache_idx], tt_feat_cache_back, pcc=MIN_PCC, relative_rmse=MAX_RMSE)
-                except Exception as e:
-                    logger.error(
-                        f"Error checking feat_cache {cache_idx}: {e}. Known issue where when T=2 in cache, T=0 is corrupted after cache is updated."
-                    )
-                    # breakpoint()
-                    raise e
+            _check_feat_cache(
+                torch_feat_cache, tt_feat_cache, h_axis=h_axis, w_axis=w_axis, pcc=MIN_PCC, relative_rmse=MAX_RMSE
+            )
 
-        # Defrag the cache
-        tt_feat_cache_host = []
-        for j in range(len(tt_feat_cache)):
-            if isinstance(tt_feat_cache[j], str) and tt_feat_cache[j] == "Rep":
-                tt_feat_cache_host.append(tt_feat_cache[j])
-            else:
-                tt_feat_cache_host.append(
-                    ttnn.to_torch(
-                        tt_feat_cache[j],
-                        mesh_composer=ttnn.ConcatMesh2dToTensor(
-                            mesh_device, mesh_shape=tuple(mesh_device.shape), dims=concat_dims
-                        ),
-                    )
-                )
-                ttnn.deallocate(tt_feat_cache[j])
-        for j in range(len(tt_feat_cache)):
-            if isinstance(tt_feat_cache[j], str) and tt_feat_cache[j] == "Rep":
-                tt_feat_cache[j] = tt_feat_cache_host[j]
-            else:
-                tt_feat_cache[j] = bf16_tensor_2dshard(
-                    tt_feat_cache_host[j],
-                    mesh_device,
-                    layout=ttnn.ROW_MAJOR_LAYOUT,
-                    shard_mapping={h_axis: 2, w_axis: 3},
-                )
+        defrag_cache(tt_feat_cache)
 
 
 @pytest.mark.parametrize(
@@ -1771,6 +1551,7 @@ def test_wan_encoder(mesh_device, B, C, T, H, W, mean, std, h_axis, w_axis, num_
         dtype=ttnn.bfloat16,
     )
     tt_model.load_torch_state_dict(torch_model.state_dict())
+    tracer = Tracer(tt_model.forward, device=mesh_device)
 
     torch_input_tensor = torch.randn(B, C, T, H, W, dtype=torch_dtype) * std + mean
     tt_input_tensor = torch_input_tensor.permute(0, 2, 3, 4, 1)
@@ -1784,18 +1565,9 @@ def test_wan_encoder(mesh_device, B, C, T, H, W, mean, std, h_axis, w_axis, num_
 
     logger.info(f"running tt model")
     start = time.time()
-    tt_output, new_logical_h = tt_model(
-        tt_input_tensor,
-        logical_h,
-    )
+    tt_output, new_logical_h = tracer(tt_input_tensor, logical_h)
 
-    concat_dims = [None, None]
-    concat_dims[h_axis] = 3
-    concat_dims[w_axis] = 4
-    tt_output_torch = ttnn.to_torch(
-        tt_output,
-        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=concat_dims),
-    )
+    tt_output_torch = tensor.to_torch(tt_output, mesh_axes=[..., h_axis, w_axis])
     logger.info(f"tt time taken: {time.time() - start}")
     logger.info(f"tt output shape: {tt_output_torch.shape}")
 
@@ -1820,3 +1592,35 @@ def test_wan_encoder(mesh_device, B, C, T, H, W, mean, std, h_axis, w_axis, num_
         assert_quality(torch_output, tt_output_torch, pcc=0.995_000, relative_rmse=0.1)
     else:
         logger.warning("Skipping check")
+
+
+def _check_feat_cache(
+    torch_feat_cache: Sequence[torch.Tensor | str | None],
+    tt_feat_cache: dict[str, ttnn.Tensor],
+    *,
+    h_axis: int,
+    w_axis: int,
+    logical_h: int | None = None,
+    pcc: float,
+    relative_rmse: float,
+) -> None:
+    tt_features = tt_feat_cache.values()
+
+    for i, (tt_feat, torch_feat) in enumerate(zip(tt_features, torch_feat_cache, strict=True)):
+        logger.debug(f"checking feat_cache {i}")
+
+        if torch_feat == "Rep":
+            logger.debug(f"feat_cache {i} is Rep")
+            continue
+
+        assert isinstance(torch_feat, torch.Tensor)
+
+        tt_feat_torch = tensor.to_torch(tt_feat, mesh_axes=[..., h_axis, w_axis, None])
+        if logical_h is not None:
+            tt_feat_torch = conv_unpad_height(tt_feat_torch, logical_h)
+        tt_feat_torch = tt_feat_torch.permute(0, 4, 1, 2, 3)
+
+        tt_feat_torch = tt_feat_torch[:, : torch_feat.shape[1], -torch_feat.shape[2] :, : torch_feat.shape[3], :]
+        trimmed_torch_feat = torch_feat[:, :, -tt_feat_torch.shape[2] :, :, :]
+
+        assert_quality(trimmed_torch_feat, tt_feat_torch, pcc=pcc, relative_rmse=relative_rmse)

--- a/models/tt_dit/tests/unit/test_tensor_utils.py
+++ b/models/tt_dit/tests/unit/test_tensor_utils.py
@@ -1,0 +1,141 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+import ttnn
+
+from ...utils import tensor
+from ...utils.tracing import Tracer
+
+
+@pytest.mark.parametrize("mesh_device", [(1, 1)], indirect=True)
+def test_full(mesh_device: ttnn.MeshDevice) -> None:
+    shape = (32, 32)
+    dtype = ttnn.bfloat16
+    value = 10
+
+    full = Tracer(
+        lambda: tensor.full(shape, value, dtype=dtype, device=mesh_device),
+        device=mesh_device,
+    )
+
+    result = full()
+    ref = torch.full(shape, value, dtype=torch.bfloat16)
+
+    assert result.dtype == dtype
+    assert tuple(result.shape) == tuple(ref.shape)
+
+    result_torch = tensor.to_torch(result)
+    assert torch.allclose(result_torch, ref, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("mesh_device", [(1, 1)], indirect=True)
+def test_arange(mesh_device: ttnn.MeshDevice) -> None:
+    dtype = ttnn.bfloat16
+    start, end, step = 10, 20, 2
+
+    arange = Tracer(
+        lambda: tensor.arange(start, end, step, dtype=dtype, device=mesh_device),
+        device=mesh_device,
+    )
+
+    result = arange()
+    ref = torch.arange(start, end, step, dtype=torch.bfloat16)
+
+    assert result.dtype == dtype
+    assert tuple(result.shape) == tuple(ref.shape)
+
+    result_torch = tensor.to_torch(result)
+    assert torch.allclose(result_torch, ref, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize(
+    ("shape", "dim", "front", "back"),
+    [
+        # On device tile padding does not support front padding.
+        # rank <= 4: direct ttnn.pad path
+        ((2, 32, 64), 0, 0, 2),
+        ((2, 32, 64), 1, 0, 3),
+        # rank > 4, dim >= rank - 3: direct ttnn.pad path (last 3 dims)
+        ((2, 2, 2, 32, 64), 3, 0, 2),
+        ((2, 2, 2, 32, 64), -1, 0, 4),
+        # rank > 4, dim < rank - 3: reshape workaround path (early dims)
+        ((2, 2, 2, 32, 64), 0, 0, 2),
+        ((2, 2, 2, 32, 64), 1, 0, 3),
+    ],
+)
+@pytest.mark.parametrize("mesh_device", [(1, 1)], indirect=True)
+def test_pad_single(mesh_device: ttnn.MeshDevice, shape: tuple, dim: int, front: int, back: int) -> None:
+    dtype = ttnn.bfloat16
+
+    x_torch = torch.randn(shape, dtype=torch.bfloat16)
+    x_tt = tensor.from_torch(x_torch, device=mesh_device, dtype=dtype)
+
+    pad = Tracer(
+        lambda: tensor.pad_single(x_tt, dim=dim, front=front, back=back),
+        device=mesh_device,
+    )
+
+    result = pad()
+
+    pad_per_dim = [(front, back) if i == (dim % len(shape)) else (0, 0) for i in reversed(range(len(shape)))]
+    ref = torch.nn.functional.pad(x_torch, [v for pair in pad_per_dim for v in pair])
+
+    assert result.dtype == dtype
+    assert tuple(result.shape) == tuple(ref.shape)
+
+    result_torch = tensor.to_torch(result)
+    assert torch.allclose(result_torch, ref, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("diagonal", [0, 1, -1])
+@pytest.mark.parametrize("mesh_device", [(1, 1)], indirect=True)
+def test_tril(mesh_device: ttnn.MeshDevice, diagonal: int) -> None:
+    shape = (1, 1, 64, 64)
+    dtype = ttnn.bfloat16
+
+    x_torch = torch.ones(shape, dtype=torch.bfloat16)
+    x_tt = tensor.from_torch(x_torch, device=mesh_device, dtype=dtype)
+
+    tril = Tracer(
+        lambda: tensor.tril(x_tt, diagonal=diagonal),
+        device=mesh_device,
+    )
+
+    result = tril()
+    ref = torch.tril(x_torch, diagonal=diagonal)
+
+    assert result.dtype == dtype
+    assert tuple(result.shape) == tuple(ref.shape)
+
+    result_torch = tensor.to_torch(result)
+    assert torch.allclose(result_torch, ref, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("diagonal", [0, 1, -1])
+@pytest.mark.parametrize("mesh_device", [(1, 1)], indirect=True)
+def test_triu(mesh_device: ttnn.MeshDevice, diagonal: int) -> None:
+    shape = (1, 1, 64, 64)
+    dtype = ttnn.bfloat16
+
+    x_torch = torch.ones(shape, dtype=torch.bfloat16)
+    x_tt = tensor.from_torch(x_torch, device=mesh_device, dtype=dtype)
+
+    triu = Tracer(
+        lambda: tensor.triu(x_tt, diagonal=diagonal),
+        device=mesh_device,
+    )
+
+    result = triu()
+    ref = torch.triu(x_torch, diagonal=diagonal)
+
+    assert result.dtype == dtype
+    assert tuple(result.shape) == tuple(ref.shape)
+
+    result_torch = tensor.to_torch(result)
+    assert torch.allclose(result_torch, ref, atol=0, rtol=0)

--- a/models/tt_dit/utils/tensor.py
+++ b/models/tt_dit/utils/tensor.py
@@ -224,6 +224,45 @@ def _invert_placements(placements: Sequence[int | None], *, output_rank: int) ->
     return tuple(out)
 
 
+def pad_single(
+    x: ttnn.Tensor,
+    /,
+    *,
+    dim: int,
+    front: int = 0,
+    back: int = 0,
+    value: float = 0.0,
+) -> ttnn.Tensor:
+    """Pad a tensor along a single dimension, working around the `ttnn.pad` dimension restriction."""
+    shape = list(x.shape)
+    rank = len(shape)
+
+    if dim < 0:
+        dim += rank
+
+    if dim < 0 or dim >= rank:
+        msg = f"padding dimension {dim} is out of bounds for tensor with rank {rank}"
+        raise ValueError(msg)
+
+    # From ttnn: "ttnn::pad only supports padding on the lowest 3 dimensions for tensors with rank > 4."
+    # With the way we count, the last three dimensions are supported.
+    if rank <= 4 or dim >= rank - 3:
+        padding = [(0, 0)] * rank
+        padding[dim] = (front, back)
+        return ttnn.pad(x, padding, value=value)
+
+    # The reshapes should be fast, since they preserve the last two dimensions.
+
+    before = math.prod(shape[:dim])
+    x = ttnn.reshape(x, [before, -1, *shape[-2:]])  # reshape to 4d
+
+    v = math.prod(shape[dim + 1 : -2])
+    x = ttnn.pad(x, [(0, 0), (front * v, back * v), (0, 0), (0, 0)], value=value)
+
+    shape[dim] += front + back
+    return ttnn.reshape(x, shape)
+
+
 def upsample(
     x: ttnn.Tensor,
     /,
@@ -268,3 +307,104 @@ def unflatten(x: ttnn.Tensor, dim: int, sizes: Sequence[int]) -> ttnn.Tensor:
     else:
         new_shape[dim : dim + 1] = sizes
     return ttnn.reshape(x, new_shape)
+
+
+def full(
+    size: ttnn.Shape | Sequence[int],
+    fill_value: float,
+    *,
+    dtype: ttnn.DataType,
+    layout: ttnn.Layout = ttnn.TILE_LAYOUT,
+    device: ttnn.MeshDevice,
+    memory_config: ttnn.MemoryConfig | None = None,
+) -> ttnn.Tensor:
+    """Alternative to `ttnn.full` that supports tracing."""
+    if not isinstance(size, ttnn.Shape):
+        size = ttnn.Shape(size)
+
+    result = ttnn.allocate_tensor_on_device(size, dtype, layout, device, memory_config)
+    ttnn.fill(result, fill_value, output_tensor=result)
+    return result
+
+
+def arange(
+    start: float,
+    end: float,
+    step: float = 1.0,
+    *,
+    dtype: ttnn.DataType,
+    layout: ttnn.Layout = ttnn.TILE_LAYOUT,
+    device: ttnn.MeshDevice,
+    memory_config: ttnn.MemoryConfig | None = None,
+) -> ttnn.Tensor:
+    """Alternative to `ttnn.arange` that supports tracing."""
+    x = full(
+        [math.ceil((end - start) / step)],
+        fill_value=step,
+        dtype=dtype,
+        layout=layout,
+        device=device,
+        memory_config=memory_config,
+    )
+
+    return ttnn.cumsum(x, 0) + (start - step)
+
+
+_tril_cache: dict[tuple, ttnn.Tensor] = {}
+_triu_cache: dict[tuple, ttnn.Tensor] = {}
+
+
+def tril(
+    x: ttnn.Tensor,
+    /,
+    diagonal: int = 0,
+    *,
+    memory_config: ttnn.MemoryConfig | None = None,
+    output_tensor: ttnn.Tensor | None = None,
+) -> ttnn.Tensor:
+    """Alternative to `ttnn.tril` that supports tracing."""
+    device = x.device()
+
+    if device is None:
+        msg = "tril is not supported for host tensors"
+        raise ValueError(msg)
+
+    mask_shape = tuple(x.shape)[-2:]
+
+    cache_key = (mask_shape, device.id(), diagonal)
+    if cache_key in _tril_cache:
+        mask = _tril_cache[cache_key]
+    else:
+        mask = full(mask_shape, 1.0, dtype=ttnn.bfloat4_b, layout=ttnn.TILE_LAYOUT, device=device)
+        mask = ttnn.tril(mask, diagonal=diagonal)
+        _tril_cache[cache_key] = mask
+
+    return ttnn.mul(x, mask, memory_config=memory_config, output_tensor=output_tensor)
+
+
+def triu(
+    x: ttnn.Tensor,
+    /,
+    diagonal: int = 0,
+    *,
+    memory_config: ttnn.MemoryConfig | None = None,
+    output_tensor: ttnn.Tensor | None = None,
+) -> ttnn.Tensor:
+    """Alternative to `ttnn.triu` that supports tracing."""
+    device = x.device()
+
+    if device is None:
+        msg = "triu is not supported for host tensors"
+        raise ValueError(msg)
+
+    mask_shape = tuple(x.shape)[-2:]
+
+    cache_key = (mask_shape, device.id(), diagonal)
+    if cache_key in _triu_cache:
+        mask = _triu_cache[cache_key]
+    else:
+        mask = full(mask_shape, 1.0, dtype=ttnn.bfloat4_b, layout=ttnn.TILE_LAYOUT, device=device)
+        mask = ttnn.triu(mask, diagonal=diagonal)
+        _triu_cache[cache_key] = mask
+
+    return ttnn.mul(x, mask, memory_config=memory_config, output_tensor=output_tensor)

--- a/models/tt_dit/utils/tensor.py
+++ b/models/tt_dit/utils/tensor.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING
 
 import ttnn
 
+from .tracing import Tracer
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
     from types import EllipsisType
@@ -377,6 +379,7 @@ def tril(
     else:
         mask = full(mask_shape, 1.0, dtype=ttnn.bfloat4_b, layout=ttnn.TILE_LAYOUT, device=device)
         mask = ttnn.tril(mask, diagonal=diagonal)
+        Tracer.warn_if_live()
         _tril_cache[cache_key] = mask
 
     return ttnn.mul(x, mask, memory_config=memory_config, output_tensor=output_tensor)
@@ -405,6 +408,7 @@ def triu(
     else:
         mask = full(mask_shape, 1.0, dtype=ttnn.bfloat4_b, layout=ttnn.TILE_LAYOUT, device=device)
         mask = ttnn.triu(mask, diagonal=diagonal)
+        Tracer.warn_if_live()
         _triu_cache[cache_key] = mask
 
     return ttnn.mul(x, mask, memory_config=memory_config, output_tensor=output_tensor)

--- a/models/tt_dit/utils/tracing.py
+++ b/models/tt_dit/utils/tracing.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 from types import NoneType
 from typing import TYPE_CHECKING, Any
 
+from loguru import logger
+
 import ttnn
 
 if TYPE_CHECKING:
@@ -14,17 +16,47 @@ if TYPE_CHECKING:
 
 
 class Tracer:
-    """Wrapper for capturing and executing a trace of a given function."""
+    """Wrapper for capturing and executing a trace of a given function.
 
-    def __init__(self, function: Callable[..., Any], /, *, device: ttnn.MeshDevice) -> None:
+    All inputs and outputs of the traced function must be ``ttnn.Tensor`` instances or plain
+    Python scalars (``int``, ``float``, ``str``, ``bool``, ``None``), optionally nested in
+    tuples, lists, or dicts.
+
+    Important caveats:
+
+    1. Tensors allocated after trace capture may be overwritten during trace execution.
+       Host tensors are not affected. Input tensors are copied before trace execution, so
+       they can safely be allocated on device if their content is not needed after execution.
+
+    2. The tracer returns the same output tensor objects every time; a subsequent call
+       overwrites previous results in place.
+    """
+
+    def __init__(
+        self,
+        function: Callable[..., Any],
+        /,
+        *,
+        device: ttnn.MeshDevice,
+        prep_run: bool = True,
+        clone_prep_inputs: bool = True,
+    ) -> None:
         """Initialize the tracer.
+
+        If the function modifies its input tensors in place, set ``clone_prep_inputs`` to ``True``
+        so that preparation runs operate on cloned inputs, leaving the originals intact for trace
+        capture.
 
         Args:
             function: Function to be traced.
             device: Device on which to capture and execute the trace.
+            prep_run: Whether to run the function once before capturing the trace.
+            clone_prep_inputs: Whether to clone tensor inputs for the preparation run.
         """
         self._function = function
         self._device = device
+        self._prep_run = prep_run
+        self._clone_prep_inputs = clone_prep_inputs
         self._args: tuple[Any, ...] = ()
         self._kwargs: dict[str, Any] = {}
         self._outputs: Any = None
@@ -35,22 +67,26 @@ class Tracer:
         *args: Any,
         tracer_cq_id: int = 0,
         tracer_blocking_execution: bool = True,
+        tracer_execute_on_capture: bool = True,
         **kwargs: Any,
     ) -> Any:
         """Capture or execute trace.
 
-        On the first call, runs the wrapped function twice, once to compile, and once to capture the
-        trace. On subsequent calls, executes the captured trace.
+        On the first call, runs the wrapped function to capture the trace. On subsequent calls,
+        executes the captured trace. On the first call, inputs initialize the trace inputs. On
+        subsequent calls, they update the trace inputs. Only ``ttnn.Tensor`` inputs can be changed.
+        Aside from omitting positional inputs to reuse previous values, a value of ``None`` can be
+        passed to reuse the previous value for tensor inputs as well. Host tensor inputs will
+        automatically be moved to the tracer device.
 
         Args:
             tracer_cq_id: Command queue id.
-            tracer_blocking_execution: Whether `ttnn.execute_trace` should block.
-            *args: Positional inputs to pass to the wrapped function. On the first call, these are
-                   used to initialize the trace inputs. On subsequent calls, these are used to
-                   update the trace inputs. Only tensor inputs can be changed.
-            **kwargs: Named inputs to pass to the wrapped function. On the first call, these are
-                      used to initialize the trace inputs. On subsequent calls, these are optional
-                      and used to update the trace inputs. Only tensor inputs can be changed.
+            tracer_blocking_execution: Whether ``ttnn.execute_trace`` should block.
+            tracer_execute_on_capture: Whether to execute the trace immediately after capturing it
+                on the first call. If ``False``, only the trace is captured and outputs are not
+                computed.
+            *args: Positional inputs to pass to the wrapped function.
+            **kwargs: Named inputs to pass to the wrapped function. Optional on subsequent calls.
 
         Returns:
             The outputs of the wrapped function.
@@ -60,15 +96,28 @@ class Tracer:
             Any exception raised by the wrapped function during first invocation.
         """
         if self._trace_id is None:
+            if self._function is None:
+                msg = "tracer can not be reused after the trace was released"
+                raise RuntimeError(msg)
+
             args = _tree_map(_verify_value, args, path_label="args")
             kwargs = _tree_map(_verify_value, kwargs, path_label="kwargs")
-            self._args = _tree_map(self._move_to_device_if_tensor, args, path_label="args")
-            self._kwargs = _tree_map(self._move_to_device_if_tensor, kwargs, path_label="kwargs")
+            self._args = _tree_map(self._tensor_to_device, args, path_label="args")
+            self._kwargs = _tree_map(self._tensor_to_device, kwargs, path_label="kwargs")
 
-            # compile
-            self._function(*self._args, **self._kwargs)
+            if self._prep_run:
+                if self._clone_prep_inputs:
+                    prep_args = _tree_map(_clone_tensor, self._args, path_label="args")
+                    prep_kwargs = _tree_map(_clone_tensor, self._kwargs, path_label="kwargs")
+                else:
+                    prep_args = self._args
+                    prep_kwargs = self._kwargs
+
+                self._function(*prep_args, **prep_kwargs)
+                del prep_args, prep_kwargs
 
             # capture trace
+            logger.debug("capturing trace...")
             trace_id = ttnn.begin_trace_capture(self._device, cq_id=tracer_cq_id)
             try:
                 try:
@@ -81,24 +130,48 @@ class Tracer:
                 ttnn.release_trace(self._device, trace_id)
                 raise
 
+            if tracer_execute_on_capture:
+                # Trace capture records commands but does not execute them. Execute the trace to
+                # actually compute outputs.
+                ttnn.execute_trace(self._device, trace_id, cq_id=tracer_cq_id, blocking=tracer_blocking_execution)
+
+            # Allow resources referenced by the function to be freed, which might be used to offload
+            # weights.
+            self._function = None
+
             self._trace_id = trace_id
             self._outputs = outputs
         else:
+            if len(args) > len(self._args):
+                msg = f"expected at most {len(self._args)} positional args, got {len(args)}"
+                raise TypeError(msg)
+
+            # Pad with None to allow omitting trailing positional args.
+            args = args + (None,) * (len(self._args) - len(args))
             _tree_map(self._update_input, self._args, args, path_label="args")
 
+            # kwargs can be omitted entirely to reuse all previous values, but individual
+            # entries must be explicitly set to None to preserve them (unlike positional args,
+            # _tree_map requires dicts to have matching keys).
             for name, new in kwargs.items():
                 if name not in self._kwargs:
                     msg = f"input '{name}' was not in the initial inputs"
                     raise KeyError(msg)
-                prev = self._kwargs[name]
 
-                _tree_map(self._update_input, prev, new, path_label=f'kwargs["{name}"]')
+                # None means reuse the previous value entirely.
+                if new is not None:
+                    _tree_map(self._update_input, self._kwargs[name], new, path_label=f'kwargs["{name}"]')
 
             ttnn.execute_trace(self._device, self._trace_id, cq_id=tracer_cq_id, blocking=tracer_blocking_execution)
 
         return self._outputs
 
-    def release(self) -> None:
+    @property
+    def trace_captured(self) -> bool:
+        """Whether a trace has been captured and is ready for execution."""
+        return self._trace_id is not None
+
+    def release_trace(self) -> None:
         """Release the captured trace and clear inputs and outputs."""
         trace_id = self._trace_id
 
@@ -109,7 +182,7 @@ class Tracer:
             self._outputs = None
             ttnn.release_trace(self._device, trace_id)
 
-    def _move_to_device_if_tensor(self, value: Any, *, path_label: str) -> Any:
+    def _tensor_to_device(self, value: Any, *, path_label: str) -> Any:
         if not isinstance(value, ttnn.Tensor):
             return value
 
@@ -122,6 +195,9 @@ class Tracer:
         raise ValueError(msg)
 
     def _update_input(self, prev: Any, new: Any, *, path_label: str) -> None:
+        if new is None and isinstance(prev, ttnn.Tensor):
+            return
+
         if type(new) is not type(prev):
             msg = f"input '{path_label}' type {type(new)} does not match the initial type {type(prev)}"
             raise TypeError(msg)
@@ -137,7 +213,9 @@ class Tracer:
                 if new.device() != prev.device():
                     msg = f"input '{path_label}' tensor device does not match the initial device"
                     raise ValueError(msg)
-                ttnn.copy(new, prev)
+
+                if new.buffer_address() != prev.buffer_address():
+                    ttnn.copy(new, prev)
 
         elif new != prev:
             msg = f"input '{path_label}' does not match the initial value"
@@ -152,7 +230,12 @@ def _verify_value(value: Any, *, path_label: str) -> Any:
     return value
 
 
-def _tree_map(f: Callable, x: Any, /, *xs: Any, path_label: str) -> Any:
+def _clone_tensor(value: Any, *, path_label: str) -> Any:  # noqa: ARG001
+    """Clone a tensor, passing through non-tensor values unchanged."""
+    return ttnn.clone(value) if isinstance(value, ttnn.Tensor) else value
+
+
+def _tree_map(f: Callable[..., Any], x: Any, /, *xs: Any, path_label: str) -> Any:
     """Apply a function to leaves of nested data structures.
 
     Recursively traverses nested structures (tuples, lists, dicts) and applies
@@ -166,19 +249,20 @@ def _tree_map(f: Callable, x: Any, /, *xs: Any, path_label: str) -> Any:
         path_label: String representing the current traversal path (used for error messages).
 
     Returns:
-        A new nested structure with the same shape as the inputs, where each
-        leaf has been transformed by applying f to the corresponding leaves
-        from all input structures.
+        A new nested structure with the same shape as the inputs, where each leaf has been
+        transformed by applying f to the corresponding leaves from all input structures.
 
     Raises:
-        ValueError: If the input structures don't have matching types at
-            corresponding positions, or if dicts have different keys.
+        TypeError: If the input structures don't have matching types at corresponding positions.
+        ValueError: If tuples/lists have different lengths or dicts have different keys.
     """
-    tx = type(x)
+    if not isinstance(x, (tuple, list, dict)):
+        return f(x, *xs, path_label=path_label)
+
     for y in xs:
-        if type(y) is not tx:
-            msg = f"types of '{path_label}' should be the same: {tx} != {type(y)}"
-            raise ValueError(msg)
+        if not isinstance(y, type(x)):
+            msg = f"types of '{path_label}' should be the same: {type(x)} != {type(y)}"
+            raise TypeError(msg)
 
     if isinstance(x, tuple):
         for y in xs:
@@ -205,4 +289,4 @@ def _tree_map(f: Callable, x: Any, /, *xs: Any, path_label: str) -> Any:
                 raise ValueError(msg)
         return {key: _tree_map(f, *(d[key] for d in (x, *xs)), path_label=f'{path_label}["{key}"]') for key in x}
 
-    return f(x, *xs, path_label=path_label)
+    raise AssertionError  # unreachable

--- a/models/tt_dit/utils/tracing.py
+++ b/models/tt_dit/utils/tracing.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import inspect
 from types import NoneType
 from typing import TYPE_CHECKING, Any
 
@@ -31,6 +32,8 @@ class Tracer:
     2. The tracer returns the same output tensor objects every time; a subsequent call
        overwrites previous results in place.
     """
+
+    _traces_live: int = 0
 
     def __init__(
         self,
@@ -139,6 +142,7 @@ class Tracer:
             # weights.
             self._function = None
 
+            Tracer._traces_live += 1
             self._trace_id = trace_id
             self._outputs = outputs
         else:
@@ -180,7 +184,16 @@ class Tracer:
             self._args = ()
             self._kwargs = {}
             self._outputs = None
+            Tracer._traces_live -= 1
             ttnn.release_trace(self._device, trace_id)
+
+    @staticmethod
+    def warn_if_live() -> None:
+        """Log a warning if there are any live traces that have not been released."""
+        if Tracer._traces_live > 0:
+            frame = inspect.stack()[1]
+            location = f"{frame.filename}:{frame.lineno} in {frame.function}"
+            logger.warning(f"{Tracer._traces_live} live trace(s) at: {location}")
 
     def _tensor_to_device(self, value: Any, *, path_label: str) -> Any:
         if not isinstance(value, ttnn.Tensor):


### PR DESCRIPTION
### Ticket

https://github.com/tenstorrent/tt-metal/issues/36032

### What's new

This PR add support for tracing to the whole Wan pipeline (encoder, DiT, VAE). Moreover it adds several tracing improvements to tt_dit:

* Conv2d tracing support.
* Replacements for `ttnn.full`, `ttnn.arange`, `ttnn.tril`, and `ttnn.triu` that are compatible with tracing.
* The function `utils.tensor.pad_single` which transparently (and I think without performance loss) works around the fact that `ttnn.pad` does not allow padding of arbitrary tensor dimension.
* The `Tracer` class now has safer defaults that can all be overridden: clones input tensors for the compile run, executes trace after compile run.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=friedrich/tracing-wan)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:friedrich/tracing-wan)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=friedrich/tracing-wan)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:friedrich/tracing-wan)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=friedrich/tracing-wan)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:friedrich/tracing-wan)
- [x] New/Existing tests provide coverage for changes
- [x] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=friedrich/tracing-wan)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:friedrich/tracing-wan)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [x] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=friedrich/tracing-wan)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:friedrich/tracing-wan)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [x] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=friedrich/tracing-wan)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:friedrich/tracing-wan)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [x] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
