### PR TITLE
T dimension partitioning in VAE SDPA

### DIFF
--- a/models/tt_dit/models/vae/vae_wan2_1.py
+++ b/models/tt_dit/models/vae/vae_wan2_1.py
@@ -156,16 +156,16 @@ class WanAttentionBlock(Module):
         B, T, H, W, C = x_BTHWC.shape
         x_TNC = ttnn.reshape(x_BTHWC, (B * T, H * W, C))
 
-        # Split T (batch) across axis-1 devices to reduce redundant SDPA compute.
+        # Split T (batch) across all devices to reduce redundant SDPA compute.
         # SDPA batch elements are independent, so they can be trivially partitioned.
-        axis1_factor = tuple(self.mesh_device.shape)[1]
+        total_devices = self.mesh_device.num_devices()
         BT = B * T
-        split_t = axis1_factor > 1 and T > 1
+        split_t = total_devices > 1 and T > 1
         if split_t:
-            padded_BT = ((BT + axis1_factor - 1) // axis1_factor) * axis1_factor
+            padded_BT = ((BT + total_devices - 1) // total_devices) * total_devices
             if padded_BT > BT:
                 x_TNC = ttnn.pad(x_TNC, [(0, padded_BT - BT), (0, 0), (0, 0)], value=0.0)
-            x_TNC = ttnn.mesh_partition(x_TNC, dim=0, cluster_axis=1)
+            x_TNC = ttnn.mesh_partition(x_TNC, dim=0)
 
         x_TNC = ttnn.to_layout(x_TNC, ttnn.TILE_LAYOUT)
         x_TNC = self.norm(x_TNC, compute_kernel_config=self.hifi4_compute_kernel_config)
@@ -193,6 +193,7 @@ class WanAttentionBlock(Module):
         # Gather T back before layout conversion (all-gather requires TILE)
         if split_t:
             out_TND = self.ccl_manager.all_gather_persistent_buffer(out_TND, dim=0, mesh_axis=1)
+            out_TND = self.ccl_manager.all_gather_persistent_buffer(out_TND, dim=0, mesh_axis=0)
             if padded_BT > BT:
                 out_TND = out_TND[:BT, :, :]
 

--- a/models/tt_dit/models/vae/vae_wan2_1.py
+++ b/models/tt_dit/models/vae/vae_wan2_1.py
@@ -155,6 +155,18 @@ class WanAttentionBlock(Module):
             x_BTHWC = x_BTHWC[:, :, :logical_h, :, :]
         B, T, H, W, C = x_BTHWC.shape
         x_TNC = ttnn.reshape(x_BTHWC, (B * T, H * W, C))
+
+        # Split T (batch) across axis-1 devices to reduce redundant SDPA compute.
+        # SDPA batch elements are independent, so they can be trivially partitioned.
+        axis1_factor = tuple(self.mesh_device.shape)[1]
+        BT = B * T
+        split_t = axis1_factor > 1 and T > 1
+        if split_t:
+            padded_BT = ((BT + axis1_factor - 1) // axis1_factor) * axis1_factor
+            if padded_BT > BT:
+                x_TNC = ttnn.pad(x_TNC, [(0, padded_BT - BT), (0, 0), (0, 0)], value=0.0)
+            x_TNC = ttnn.mesh_partition(x_TNC, dim=0, cluster_axis=1)
+
         x_TNC = ttnn.to_layout(x_TNC, ttnn.TILE_LAYOUT)
         x_TNC = self.norm(x_TNC, compute_kernel_config=self.hifi4_compute_kernel_config)
         default_block_size = (2, 2, 2) if x_TNC.dtype == ttnn.float32 else (8, 8, 8)
@@ -177,6 +189,13 @@ class WanAttentionBlock(Module):
         out_TND = self.proj(
             out_TNC, compute_kernel_config=self.mm_compute_kernel_config, default_block_size=default_block_size
         )
+
+        # Gather T back before layout conversion (all-gather requires TILE)
+        if split_t:
+            out_TND = self.ccl_manager.all_gather_persistent_buffer(out_TND, dim=0, mesh_axis=1)
+            if padded_BT > BT:
+                out_TND = out_TND[:BT, :, :]
+
         out_TND = ttnn.to_layout(out_TND, ttnn.ROW_MAJOR_LAYOUT)
 
         if padded_h > logical_h:

--- a/models/tt_dit/models/vae/vae_wan2_1.py
+++ b/models/tt_dit/models/vae/vae_wan2_1.py
@@ -158,7 +158,7 @@ class WanAttentionBlock(Module):
 
         # Split T (batch) across all devices to reduce redundant SDPA compute.
         # SDPA batch elements are independent, so they can be trivially partitioned.
-        total_devices = self.mesh_device.num_devices()
+        total_devices = self.mesh_device.get_num_devices()
         BT = B * T
         split_t = total_devices > 1 and T > 1
         if split_t:

--- a/models/tt_dit/tests/models/wan2_2/test_vae_wan2_1.py
+++ b/models/tt_dit/tests/models/wan2_2/test_vae_wan2_1.py
@@ -238,11 +238,19 @@ def test_wan_rmsnorm(device, B, C, T, H, W, images, mean, std):
     ("B, C, T, H, W"),
     [
         (1, 384, 1, 90, 160),  # decoder.mid_block.resnets.0.norm1
+        (1, 384, 3, 90, 160),
+        (1, 384, 8, 90, 160),
         (1, 384, 1, 60, 104),  # decoder.mid_block.resnets.0.norm1
+        (1, 384, 3, 60, 104),
+        (1, 384, 8, 60, 104),
     ],
     ids=[
-        "720p",
-        "480p",
+        "Tdim1-720p",
+        "Tdim3-720p",
+        "Tdim8-720p",
+        "Tdim1-480p",
+        "Tdim3-480p",
+        "Tdim8-480p",
     ],
 )
 @pytest.mark.parametrize("mean, std", [(0, 1)])


### PR DESCRIPTION
### Ticket
[34079](https://github.com/tenstorrent/tt-metal/issues/34079)

### Problem description
In the VAE when the T dimension > 1 the SDPA call can be optimized by partitioning the T dimension across the mesh grid. If T < grid size the dimension is padded.

### What's changed
Updates the Attention block in the VAE and adds a test configuration in the attention test to generate tensors with T > 1.

- [T3K Wan demo test](https://github.com/tenstorrent/tt-metal/actions/runs/23077827828)