### PR TITLE
[skip-ci] Add distinc exit codes to validation and fabric analysis scripts

### DIFF
--- a/tools/scaleout/exabox/README.md
+++ b/tools/scaleout/exabox/README.md
@@ -107,6 +107,24 @@ The script parses all `*.log` files in the specified directory and provides:
 - **Success Rate**: Percentage of healthy iterations (80%+ is typically a pass)
 - **Recommendations**: Actionable next steps based on detected failure patterns
 - **Cluster Info**: Detected hosts, chips per host, and traffic configuration
+- **Exit Codes**: Returns specific exit codes for automated workflows
+
+**Exit Codes Description**
+The script returns exit codes enabling automated troubleshooting (e.g., Ansible playbooks):
+- `0` - Cluster healthy (≥80% success rate)
+- `1` - Unhealthy links (repeated on same link)
+- `2` - Unhealthy links (scattered across different links)
+- `3` - DRAM training failures
+- `4` - Missing connections (found in FSD but not in discovered topology)
+- `5` - Extra connections (found in topology but not in FSD)
+- `6` - Missing global connection
+- `7` - FSD error
+- `8` - MGD error
+- `9` - Workload timeout
+- `10` - ARC timeout
+- `11` - AICLK timeout
+- `12` - Network errors (MPI/SSH)
+- `50` - Inconclusive (manual review required)
 
 ### Dispatch Tests
 
@@ -166,6 +184,17 @@ The script parses the test log and provides:
 - **Warnings & Failures**: Critical errors and runtime warnings detected during testing
 - **Recommendations**: Actionable next steps including escalation paths for persistent issues
 - **Final Test Result**: Clear pass/fail indication with appropriate exit code
+
+**Exit Codes for Automation:**
+The script returns specific exit codes for automated workflows:
+- `0` - All tests passed
+- `1` - MGD error (topology mismatch)
+- `2` - Firmware initialization failed
+- `3` - Fabric router sync timeout
+- `4` - Test hanging (incomplete log)
+- `5` - NOC address conflict
+- `6` - Ethernet core timeout
+- `50` - Inconclusive (manual review required)
 
 
 **Important: Host Ordering Matters for 4x32 Clusters**
@@ -257,8 +286,10 @@ A missing cable or bad port/connection will show up as a **consistently missing 
 | `run_validation.sh` | Full 50-loop validation |
 | `run_dispatch_tests.sh` | Chip stability stress tests |
 | `run_fabric_tests.sh` | Fabric connectivity tests |
-| `analyze_validation_results.py` | Parse validation logs || `analyze_dispatch_results.py` | Parse dispatch test logs |
-| `analyze_fabric_results.py` | Parse fabric test logs || `mpi-docker` | MPI+Docker wrapper (`--help` for usage) |
+| `analyze_validation_results.py` | Parse validation logs |
+| `analyze_dispatch_results.py` | Parse dispatch test logs |
+| `analyze_fabric_results.py` | Parse fabric test logs |
+| `mpi-docker` | MPI+Docker wrapper (`--help` for usage) |
 
 ## Config Files
 

--- a/tools/scaleout/exabox/README.md
+++ b/tools/scaleout/exabox/README.md
@@ -125,6 +125,7 @@ The script returns exit codes enabling automated troubleshooting (e.g., Ansible 
 - `11` - AICLK timeout
 - `12` - Network errors (MPI/SSH)
 - `50` - Inconclusive (manual review required)
+- `66` - Input error (file/directory not found)
 
 ### Dispatch Tests
 
@@ -195,6 +196,7 @@ The script returns specific exit codes for automated workflows:
 - `5` - NOC address conflict
 - `6` - Ethernet core timeout
 - `50` - Inconclusive (manual review required)
+- `66` - Input error (log file not found)
 
 
 **Important: Host Ordering Matters for 4x32 Clusters**

--- a/tools/scaleout/exabox/analyze_fabric_results.py
+++ b/tools/scaleout/exabox/analyze_fabric_results.py
@@ -28,6 +28,7 @@ EXIT_CODE_TEST_HANGING = 4
 EXIT_CODE_NOC_CONFLICT = 5
 EXIT_CODE_ETHERNET_CORE_TIMEOUT = 6
 EXIT_CODE_INCONCLUSIVE = 50
+EXIT_CODE_INPUT_ERROR = 66
 
 
 class Colors:
@@ -55,7 +56,7 @@ class LogAnalysis:
     all_passed: bool = False
     warnings: list[str] = field(default_factory=list)
     critical_errors: list[str] = field(default_factory=list)
-    error_category: str = ""
+    error_category: str = "inconclusive"
     exit_code: int = EXIT_CODE_INCONCLUSIVE
 
 
@@ -240,19 +241,6 @@ def print_recommendations(analysis: LogAnalysis) -> None:
     print("Recommendations")
     print("=" * 50 + "\n")
 
-    # Use registry pattern to generate recommendations
-    # Process categories in a consistent order
-    category_order = [
-        "passed",
-        "mgd_error",
-        "fw_init_failed",
-        "fabric_router_sync_timeout",
-        "noc_conflict",
-        "ethernet_core_timeout",
-        "test_hanging",
-        "inconclusive",
-    ]
-
     recs = []
     if analysis.error_category in RECOMMENDATION_GENERATORS:
         recs.extend(RECOMMENDATION_GENERATORS[analysis.error_category](analysis))
@@ -356,7 +344,7 @@ def main():
     log_file = Path(args.path)
     if not log_file.is_file():
         print(f"Error: Log file not found: {args.path}", file=sys.stderr)
-        sys.exit(1)
+        sys.exit(EXIT_CODE_INPUT_ERROR)
 
     # Analyze log file
     analysis = analyze_log_file(str(log_file))

--- a/tools/scaleout/exabox/analyze_fabric_results.py
+++ b/tools/scaleout/exabox/analyze_fabric_results.py
@@ -19,6 +19,16 @@ from pathlib import Path
 MAX_WARNINGS = 10
 MAX_ERRORS = 10
 
+# Exit codes for specific failure types
+EXIT_CODE_PASSED = 0
+EXIT_CODE_MGD_ERROR = 1
+EXIT_CODE_FW_INIT_FAILED = 2
+EXIT_CODE_FABRIC_ROUTER_SYNC_TIMEOUT = 3
+EXIT_CODE_TEST_HANGING = 4
+EXIT_CODE_NOC_CONFLICT = 5
+EXIT_CODE_ETHERNET_CORE_TIMEOUT = 6
+EXIT_CODE_INCONCLUSIVE = 50
+
 
 class Colors:
     GREEN = "\033[0;32m"
@@ -45,6 +55,8 @@ class LogAnalysis:
     all_passed: bool = False
     warnings: list[str] = field(default_factory=list)
     critical_errors: list[str] = field(default_factory=list)
+    error_category: str = ""
+    exit_code: int = EXIT_CODE_INCONCLUSIVE
 
 
 def analyze_log_file(filepath: str) -> LogAnalysis:
@@ -68,6 +80,42 @@ def analyze_log_file(filepath: str) -> LogAnalysis:
     success_count = result.content.count("All tests completed successfully")
     result.all_passed = success_count == expected_hosts and expected_hosts > 0
 
+    # Detect specific error categories
+    if result.all_passed:
+        result.exit_code = EXIT_CODE_PASSED
+        result.error_category = "passed"
+    else:
+        # Check for specific error patterns (priority order)
+        if re.search(
+            r"(Mesh Graph Descriptor|MGD).*(could not fit|cannot fit).*physical topology", result.content, re.IGNORECASE
+        ):
+            result.error_category = "mgd_error"
+            result.exit_code = EXIT_CODE_MGD_ERROR
+        elif re.search(r"failed to initialize FW|Timeout.*waiting for physical cores to finish", result.content):
+            result.error_category = "fw_init_failed"
+            result.exit_code = EXIT_CODE_FW_INIT_FAILED
+        elif re.search(r"Fabric Router Sync: Timeout", result.content):
+            result.error_category = "fabric_router_sync_timeout"
+            result.exit_code = EXIT_CODE_FABRIC_ROUTER_SYNC_TIMEOUT
+        elif re.search(r"Expected NOC address.*but got", result.content):
+            result.error_category = "noc_conflict"
+            result.exit_code = EXIT_CODE_NOC_CONFLICT
+        elif re.search(r"Timed out while waiting for active ethernet core", result.content):
+            result.error_category = "ethernet_core_timeout"
+            result.exit_code = EXIT_CODE_ETHERNET_CORE_TIMEOUT
+        else:
+            # Check if test is hanging - log ends with output format indicating test was still running
+            # Pattern: [1,X]<stdout>: or [1,X]<stderr>: followed by timestamp and log level (| info | etc)
+            lines = [line.strip() for line in result.content.split("\n") if line.strip()]
+            if lines and re.match(
+                r"^\[1,\d+\]<std(?:out|err)>:\s+\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2}\.\d+\s+\|", lines[-1]
+            ):
+                result.error_category = "test_hanging"
+                result.exit_code = EXIT_CODE_TEST_HANGING
+            else:
+                result.error_category = "inconclusive"
+                result.exit_code = EXIT_CODE_INCONCLUSIVE
+
     # Extract warnings (excluding FAILED markers)
     warning_pattern = re.compile(r"warning.*(timed out|failed)", re.IGNORECASE)
     failed_marker = re.compile(r"\[  FAILED  \]")
@@ -85,18 +133,138 @@ def analyze_log_file(filepath: str) -> LogAnalysis:
     return result
 
 
-def print_summary(analysis: LogAnalysis, input_path: str) -> None:
-    """Print analysis summary."""
+# Recommendation generator registry
+RECOMMENDATION_GENERATORS = {}
+
+
+def register_recommendation(category: str):
+    """Decorator to register a recommendation generator for a category."""
+
+    def decorator(func):
+        RECOMMENDATION_GENERATORS[category] = func
+        return func
+
+    return decorator
+
+
+@register_recommendation("passed")
+def _recommend_passed(analysis: LogAnalysis) -> list[str]:
+    """Generate recommendations for passed tests."""
+    return [f"{Colors.GREEN}✓ All fabric tests passed successfully. Cluster fabric is healthy.{Colors.NC}"]
+
+
+@register_recommendation("mgd_error")
+def _recommend_mgd_error(analysis: LogAnalysis) -> list[str]:
+    """Generate recommendations for MGD topology mismatch."""
+    return [
+        f"{Colors.RED}• MGD topology mismatch detected.{Colors.NC}",
+        "• Check host order in host variables against cabling descriptors.",
+        "• Verify MGD file matches the physical topology.",
+        "• If host ordering is correct, escalate missing connections issue.",
+    ]
+
+
+@register_recommendation("fw_init_failed")
+def _recommend_fw_init_failed(analysis: LogAnalysis) -> list[str]:
+    """Generate recommendations for firmware initialization failures."""
+    return [
+        f"{Colors.RED}• Firmware initialization failed.{Colors.NC}",
+        "• Reset boards with: tt-smi -r",
+        "• Wait 30 seconds and retry fabric test.",
+        "• If issue persists after reset, escalate to SYSENG.",
+    ]
+
+
+@register_recommendation("fabric_router_sync_timeout")
+def _recommend_fabric_router_sync_timeout(analysis: LogAnalysis) -> list[str]:
+    """Generate recommendations for fabric router sync timeout."""
+    return [
+        f"{Colors.RED}• Fabric Router Sync timeout detected.{Colors.NC}",
+        "• Check fabric connectivity and router status.",
+        "• Try reset with: tt-smi -r",
+        "• Escalate to SYSENG if issue persists.",
+    ]
+
+
+@register_recommendation("test_hanging")
+def _recommend_test_hanging(analysis: LogAnalysis) -> list[str]:
+    """Generate recommendations for hanging tests."""
+    return [
+        f"{Colors.YELLOW}• Test appears to be hanging (incomplete log).{Colors.NC}",
+        "• Log shows test was running but never completed.",
+        "• Test may have been killed or timed out.",
+        "• Check if test process is still running.",
+        "• Consider increasing timeout or investigating hang cause.",
+    ]
+
+
+@register_recommendation("noc_conflict")
+def _recommend_noc_conflict(analysis: LogAnalysis) -> list[str]:
+    """Generate recommendations for NOC address conflicts."""
+    return [
+        f"{Colors.RED}• NOC address conflict detected.{Colors.NC}",
+        "• UMD detected mismatch between expected and actual NOC addresses.",
+        "• This typically indicates memory mapping or firmware issue.",
+        "• Try resetting boards with: tt-smi -r",
+        "• If issue persists, escalate to SYSENG - may require firmware update.",
+    ]
+
+
+@register_recommendation("ethernet_core_timeout")
+def _recommend_ethernet_core_timeout(analysis: LogAnalysis) -> list[str]:
+    """Generate recommendations for ethernet core timeout."""
+    return [
+        f"{Colors.RED}• Ethernet core activation timeout detected.{Colors.NC}",
+        "• One or more ethernet cores failed to become active.",
+        "• This indicates a hardware or firmware issue with ethernet cores.",
+        "• Reset boards with: tt-smi -r",
+        "• Wait 30 seconds and retry fabric test.",
+        "• If issue persists, escalate to SYSENG - board may need replacement.",
+    ]
+
+
+@register_recommendation("inconclusive")
+def _recommend_inconclusive(analysis: LogAnalysis) -> list[str]:
+    """Generate recommendations for inconclusive results."""
+    return [
+        f"{Colors.YELLOW}• Fabric test failed with unrecognized error pattern.{Colors.NC}",
+        "• Review critical errors and warnings above.",
+        "• Check cable connections, port status, and fabric topology.",
+        "• Report to SYSENG and SCALEOUT teams with full logs.",
+    ]
+
+
+def print_recommendations(analysis: LogAnalysis) -> None:
+    """Print actionable recommendations."""
     print("=" * 50)
-    print("Fabric Test Log Analyzer")
-    print("=" * 50)
-    print(f"Log file: {input_path}")
-    print(f"Timestamp: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+    print("Recommendations")
     print("=" * 50 + "\n")
 
-    status_color = Colors.GREEN if analysis.all_passed else Colors.RED
-    status_text = "PASSED" if analysis.all_passed else "FAILED"
-    print(f"Test Status: {status_color}{status_text}{Colors.NC}\n")
+    # Use registry pattern to generate recommendations
+    # Process categories in a consistent order
+    category_order = [
+        "passed",
+        "mgd_error",
+        "fw_init_failed",
+        "fabric_router_sync_timeout",
+        "noc_conflict",
+        "ethernet_core_timeout",
+        "test_hanging",
+        "inconclusive",
+    ]
+
+    recs = []
+    if analysis.error_category in RECOMMENDATION_GENERATORS:
+        recs.extend(RECOMMENDATION_GENERATORS[analysis.error_category](analysis))
+
+    # Add critical errors notice if present and test failed
+    if analysis.critical_errors and analysis.error_category != "passed":
+        recs.append("")
+        recs.append(f"{Colors.RED}• Critical errors detected - check logs above for details.{Colors.NC}")
+
+    for r in recs:
+        print(r)
+    print()
 
 
 def print_warnings_and_errors(analysis: LogAnalysis) -> None:
@@ -121,34 +289,21 @@ def print_warnings_and_errors(analysis: LogAnalysis) -> None:
     print("=" * 50 + "\n")
 
 
-def print_recommendations(analysis: LogAnalysis) -> None:
-    """Print actionable recommendations."""
+def print_summary(analysis: LogAnalysis, input_path: str) -> None:
+    """Print analysis summary."""
     print("=" * 50)
-    print("Recommendations")
+    print("Fabric Test Log Analyzer")
+    print("=" * 50)
+    print(f"Log file: {input_path}")
+    print(f"Timestamp: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
     print("=" * 50 + "\n")
 
-    recs = []
-
+    status_color = Colors.GREEN if analysis.all_passed else Colors.RED
+    status_text = "PASSED" if analysis.all_passed else "FAILED"
+    print(f"Test Status: {status_color}{status_text}{Colors.NC}")
     if not analysis.all_passed:
-        recs.append("• Fabric test failed. Review logs for connectivity or hardware issues.")
-        recs.append("• Check cable connections, port status, and fabric topology.")
-        recs.append("• If issues persist, report to SYSENG and SCALEOUT teams.")
-
-    if analysis.critical_errors:
-        recs.append(
-            "• Critical errors detected (TT_FATAL, segmentation faults). "
-            "Check for driver issues or hardware failures."
-        )
-        recs.append("• Escalate to SYSENG team for hardware diagnostics.")
-
-    if analysis.warnings:
-        recs.append("• Runtime warnings detected. Review timeout or failed operation messages.")
-
-    if analysis.all_passed and not analysis.critical_errors:
-        recs.append(f"{Colors.GREEN}✓ All fabric tests passed successfully. Cluster fabric is healthy.{Colors.NC}")
-
-    for r in recs:
-        print(r)
+        print(f"Error Category: {analysis.error_category}")
+        print(f"Exit Code: {analysis.exit_code}")
     print()
 
 
@@ -158,6 +313,8 @@ def output_json(analysis: LogAnalysis, input_path: str):
         "timestamp": datetime.now().isoformat(),
         "log_file": input_path,
         "test_passed": analysis.all_passed,
+        "error_category": analysis.error_category,
+        "exit_code": analysis.exit_code,
         "warnings_count": len(analysis.warnings),
         "critical_errors_count": len(analysis.critical_errors),
     }
@@ -209,10 +366,9 @@ def main():
         output_json(analysis, args.path)
     else:
         output_text(analysis, args.path)
-    if analysis.all_passed:
-        exit(0)
-    else:
-        exit(1)
+
+    # Exit with specific code based on error category
+    sys.exit(analysis.exit_code)
 
 
 if __name__ == "__main__":

--- a/tools/scaleout/exabox/analyze_validation_results.py
+++ b/tools/scaleout/exabox/analyze_validation_results.py
@@ -39,6 +39,25 @@ MAX_LINE_PREVIEW = 200
 MAX_ERROR_PREVIEW = 100
 TIMELINE_ROW_SIZE = 25
 
+# Exit codes for specific failure types
+EXIT_CODE_HEALTHY = 0
+EXIT_CODE_UNHEALTHY_REPEATED = 1
+EXIT_CODE_UNHEALTHY_SCATTERED = 2
+EXIT_CODE_DRAM_FAILURE = 3
+EXIT_CODE_MISSING_CONNECTIONS = 4
+EXIT_CODE_EXTRA_CONNECTIONS = 5
+EXIT_CODE_MISSING_GLOBAL_CONNECTION = 6
+EXIT_CODE_FSD_ERROR = 7
+EXIT_CODE_MGD_ERROR = 8
+EXIT_CODE_WORKLOAD_TIMEOUT = 9
+EXIT_CODE_ARC_TIMEOUT = 10
+EXIT_CODE_AICLK_TIMEOUT = 11
+EXIT_CODE_NETWORK_ERROR = 12
+EXIT_CODE_INCONCLUSIVE = 50
+
+# Threshold for repeated link failures (> 50% = same link failing repeatedly)
+REPEATED_LINK_THRESHOLD = 0.5
+
 
 class Colors:
     GREEN = "\033[0;32m"
@@ -90,6 +109,11 @@ CATEGORIES = {
         "BLUE",
         "Recovered connections",
     ),
+    "missing_global_connection": (
+        r"Global Connection.*is not found in the host connectivity graph",
+        "BLUE",
+        "Missing global connection",
+    ),
     "extra_connections": (
         r"extra port/cable connections|extra channel connections",
         "YELLOW",
@@ -101,16 +125,31 @@ CATEGORIES = {
         "YELLOW",
         "Workload timeout",
     ),
-    "dram_failure": (r"DRAM training failed|gddr issue", "RED", "DRAM training failures", True),
     "arc_timeout": (r"ARC.*[Tt]imeout|ARC message timed out", "YELLOW", "ARC timeout"),
     "aiclk_timeout": (
-        r"Waiting for AICLK value to settle failed on timeout",
+        r"Waiting for AICLK value to settle failed on timeout|Timeout.*waiting for physical cores|No ASIC ID found at hostname",
         "RED",
         "AICLK timeout",
     ),
-    # Connectivity issues
-    "mpi_error": (r"PRTE has lost communication|MPI_ABORT", "RED", "MPI error"),
-    "ssh_error": (r"Permission denied \(publickey\)", "YELLOW", "SSH error"),
+    "dram_failure": (r"DRAM training failed|gddr issue", "RED", "DRAM training failures", True),
+    # Connectivity issues - only explicit network errors, not generic MPI crashes
+    "mpi_error": (
+        r"Unable to connect to the peer.*Network is unreachable|btl_tcp_endpoint.*Unable to connect",
+        "RED",
+        "MPI error",
+    ),
+    "ssh_error": (
+        r"Permission denied \(publickey\)|ssh.*Connection refused|ssh.*Connection timed out",
+        "YELLOW",
+        "SSH error",
+    ),
+    # Configuration errors (FSD/MGD) - treated as connections mismatch
+    "fsd_error": (r"Hostname not found in FSD", "RED", "FSD configuration error"),
+    "mgd_error": (
+        r"Graph specified in MGD could not fit in the discovered physical topology",
+        "RED",
+        "MGD topology mismatch",
+    ),
 }
 
 
@@ -526,6 +565,8 @@ def print_summary(analyses: list[LogAnalysis], metrics: dict, show_files: bool =
         "aiclk_timeout",
         "mpi_error",
         "ssh_error",
+        "fsd_error",
+        "mgd_error",
         "inconclusive",
     ]
     for cat in display_order:
@@ -777,7 +818,7 @@ def _recommend_extra_connections(cats: dict, total: int, analyses: list[LogAnaly
     if not cats.get("extra_connections"):
         return []
     return [
-        f"- {Colors.YELLOW}Extra connections:{Colors.NC} Unexpected links found. Verify correct FSD file for your topology."
+        f"- {Colors.YELLOW}Extra connections:{Colors.NC} Additional links found that don't match FSD. Verify correct FSD file for your topology."
     ]
 
 
@@ -799,14 +840,6 @@ def _recommend_workload_timeout(cats: dict, total: int, analyses: list[LogAnalys
     return [msg]
 
 
-@register_recommendation("dram_failure")
-def _recommend_dram_failure(cats: dict, total: int, analyses: list[LogAnalysis]) -> list[str]:
-    """Generate recommendations for DRAM failures."""
-    if not cats.get("dram_failure"):
-        return []
-    return [f"- {Colors.RED}DRAM training failures:{Colors.NC} Hardware issue. Report to Syseng."]
-
-
 @register_recommendation("arc_timeout")
 def _recommend_arc_timeout(cats: dict, total: int, analyses: list[LogAnalysis]) -> list[str]:
     """Generate recommendations for ARC timeout."""
@@ -825,6 +858,14 @@ def _recommend_aiclk_timeout(cats: dict, total: int, analyses: list[LogAnalysis]
         f"- {Colors.RED}AICLK timeout:{Colors.NC} AICLK failed to settle ({count} occurrence(s)). "
         f"Could indicate bad Firmware or Hardware state. Escalate to Systems Engineering."
     ]
+
+
+@register_recommendation("dram_failure")
+def _recommend_dram_failure(cats: dict, total: int, analyses: list[LogAnalysis]) -> list[str]:
+    """Generate recommendations for DRAM failures."""
+    if not cats.get("dram_failure"):
+        return []
+    return [f"- {Colors.RED}DRAM training failures:{Colors.NC} Hardware issue. Report to Syseng."]
 
 
 @register_recommendation("mpi_error")
@@ -959,6 +1000,10 @@ def print_timeline(analyses: list[LogAnalysis]) -> None:
             icons.append(("C", Colors.RED))
         elif "ssh_error" in a.categories:
             icons.append(("S", Colors.YELLOW))
+        elif "fsd_error" in a.categories:
+            icons.append(("F", Colors.RED))
+        elif "mgd_error" in a.categories:
+            icons.append(("G", Colors.RED))
         elif "missing_ports" in a.categories:
             icons.append(("○", Colors.BLUE))
         elif "missing_channels" in a.categories:
@@ -988,6 +1033,8 @@ def print_timeline(analyses: list[LogAnalysis]) -> None:
         f"{Colors.RED}C{Colors.NC}=aiclk "
         f"{Colors.RED}M{Colors.NC}=mpi "
         f"{Colors.YELLOW}S{Colors.NC}=ssh "
+        f"{Colors.RED}F{Colors.NC}=fsd "
+        f"{Colors.RED}G{Colors.NC}=mgd "
         f"{Colors.CYAN}?{Colors.NC}=inconclusive "
         f"{Colors.YELLOW}~{Colors.NC}=other\n"
     )
@@ -1190,44 +1237,194 @@ def generate_plots(analyses: list[LogAnalysis], output_dir: str) -> None:
     print()
 
 
-def validate_results(analyses: list[LogAnalysis], metrics: dict) -> tuple[str, int]:
-    """
-    Validate analysis results against expected thresholds.
+def analyze_unhealthy_link_pattern(analyses: list[LogAnalysis]) -> str | None:
+    """Analyze unhealthy link failure pattern to determine if repeated or scattered."""
+    link_stats, _ = aggregate_stats(analyses)
+    if not link_stats:
+        return None
 
-    Returns:
-        tuple of (exit_message, exit_code) where:
-            exit_message: Formatted string describing validation result
-            exit_code: 0 if cluster meets stability criteria, 1 otherwise
-    """
+    # Count how many runs had unhealthy links
+    unhealthy_runs = len([a for a in analyses if "unhealthy" in a.categories])
+    if unhealthy_runs == 0:
+        return None
+
+    # Find the link with the highest failure count
+    max_failure_count = max(stats["count"] for stats in link_stats.values())
+
+    # If any single link fails more than 50% of unhealthy runs, it's "repeated"
+    if max_failure_count / unhealthy_runs > REPEATED_LINK_THRESHOLD:
+        return "repeated"
+    else:
+        return "scattered"
+
+
+def count_validation_issues(analyses: list[LogAnalysis]) -> dict[str, dict]:
+    """Count frequency of each issue type across analyses."""
+    issue_counts = {}
+    total = len(analyses)
+
+    # Count DRAM failures
+    dram_count = len([a for a in analyses if "dram_failure" in a.categories])
+    if dram_count > 0:
+        issue_counts["dram_failure"] = {
+            "count": dram_count,
+            "exit_code": EXIT_CODE_DRAM_FAILURE,
+            "message": f"{Colors.RED}VALIDATION FAILED:{Colors.NC} DRAM TRAINING FAILURES detected in {dram_count}/{total} runs.",
+            "priority": 1,
+        }
+
+    # Count unhealthy links (differentiate repeated vs scattered)
+    unhealthy_count = len([a for a in analyses if "unhealthy" in a.categories])
+    if unhealthy_count > 0:
+        pattern = analyze_unhealthy_link_pattern(analyses)
+        if pattern == "repeated":
+            issue_counts["unhealthy_repeated"] = {
+                "count": unhealthy_count,
+                "exit_code": EXIT_CODE_UNHEALTHY_REPEATED,
+                "message": f"{Colors.RED}VALIDATION FAILED:{Colors.NC} UNHEALTHY LINKS (REPEATED) - same links failing repeatedly in {unhealthy_count}/{total} runs.",
+                "priority": 2,
+            }
+        else:  # scattered
+            issue_counts["unhealthy_scattered"] = {
+                "count": unhealthy_count,
+                "exit_code": EXIT_CODE_UNHEALTHY_SCATTERED,
+                "message": f"{Colors.RED}VALIDATION FAILED:{Colors.NC} UNHEALTHY LINKS (SCATTERED) - failures scattered across different links in {unhealthy_count}/{total} runs.",
+                "priority": 3,
+            }
+
+    # Count missing connections (missing ports/channels)
+    missing_connections_count = len(
+        [a for a in analyses if "missing_ports" in a.categories or "missing_channels" in a.categories]
+    )
+    if missing_connections_count > 0:
+        issue_counts["missing_connections"] = {
+            "count": missing_connections_count,
+            "exit_code": EXIT_CODE_MISSING_CONNECTIONS,
+            "message": f"{Colors.RED}VALIDATION FAILED:{Colors.NC} MISSING CONNECTIONS detected in {missing_connections_count}/{total} runs.",
+            "priority": 10,
+        }
+
+    # Count extra connections
+    extra_connections_count = len([a for a in analyses if "extra_connections" in a.categories])
+    if extra_connections_count > 0:
+        issue_counts["extra_connections"] = {
+            "count": extra_connections_count,
+            "exit_code": EXIT_CODE_EXTRA_CONNECTIONS,
+            "message": f"{Colors.RED}VALIDATION FAILED:{Colors.NC} EXTRA CONNECTIONS detected in {extra_connections_count}/{total} runs.",
+            "priority": 4,
+        }
+
+    # Count missing global connection
+    missing_global_count = len([a for a in analyses if "missing_global_connection" in a.categories])
+    if missing_global_count > 0:
+        issue_counts["missing_global_connection"] = {
+            "count": missing_global_count,
+            "exit_code": EXIT_CODE_MISSING_GLOBAL_CONNECTION,
+            "message": f"{Colors.RED}VALIDATION FAILED:{Colors.NC} MISSING GLOBAL CONNECTION detected in {missing_global_count}/{total} runs.",
+            "priority": 5,
+        }
+
+    # Count FSD errors
+    fsd_count = len([a for a in analyses if "fsd_error" in a.categories])
+    if fsd_count > 0:
+        issue_counts["fsd_error"] = {
+            "count": fsd_count,
+            "exit_code": EXIT_CODE_FSD_ERROR,
+            "message": f"{Colors.RED}VALIDATION FAILED:{Colors.NC} FSD CONFIGURATION ERROR detected in {fsd_count}/{total} runs.",
+            "priority": 6,
+        }
+
+    # Count MGD errors
+    mgd_count = len([a for a in analyses if "mgd_error" in a.categories])
+    if mgd_count > 0:
+        issue_counts["mgd_error"] = {
+            "count": mgd_count,
+            "exit_code": EXIT_CODE_MGD_ERROR,
+            "message": f"{Colors.RED}VALIDATION FAILED:{Colors.NC} MGD TOPOLOGY MISMATCH detected in {mgd_count}/{total} runs.",
+            "priority": 7,
+        }
+
+    # Count timeouts (split into separate codes for each timeout type)
+    workload_timeout_count = len([a for a in analyses if "workload_timeout" in a.categories])
+    if workload_timeout_count > 0:
+        issue_counts["workload_timeout"] = {
+            "count": workload_timeout_count,
+            "exit_code": EXIT_CODE_WORKLOAD_TIMEOUT,
+            "message": f"{Colors.RED}VALIDATION FAILED:{Colors.NC} WORKLOAD TIMEOUT detected in {workload_timeout_count}/{total} runs.",
+            "priority": 8,
+        }
+
+    arc_timeout_count = len([a for a in analyses if "arc_timeout" in a.categories])
+    if arc_timeout_count > 0:
+        issue_counts["arc_timeout"] = {
+            "count": arc_timeout_count,
+            "exit_code": EXIT_CODE_ARC_TIMEOUT,
+            "message": f"{Colors.RED}VALIDATION FAILED:{Colors.NC} ARC TIMEOUT detected in {arc_timeout_count}/{total} runs.",
+            "priority": 8,
+        }
+
+    aiclk_timeout_count = len([a for a in analyses if "aiclk_timeout" in a.categories])
+    if aiclk_timeout_count > 0:
+        issue_counts["aiclk_timeout"] = {
+            "count": aiclk_timeout_count,
+            "exit_code": EXIT_CODE_AICLK_TIMEOUT,
+            "message": f"{Colors.RED}VALIDATION FAILED:{Colors.NC} AICLK TIMEOUT detected in {aiclk_timeout_count}/{total} runs.",
+            "priority": 8,
+        }
+
+    # Count network errors (combined MPI and SSH)
+    mpi_count = len([a for a in analyses if "mpi_error" in a.categories])
+    ssh_count = len([a for a in analyses if "ssh_error" in a.categories])
+    network_count = mpi_count + ssh_count
+    if network_count > 0:
+        issue_counts["network_error"] = {
+            "count": network_count,
+            "exit_code": EXIT_CODE_NETWORK_ERROR,
+            "message": f"{Colors.RED}VALIDATION FAILED:{Colors.NC} NETWORK ERROR detected in {network_count}/{total} runs.",
+            "priority": 9,
+        }
+
+    # Count inconclusive
+    inconclusive_count = len([a for a in analyses if "inconclusive" in a.categories])
+    if inconclusive_count > 0:
+        issue_counts["inconclusive"] = {
+            "count": inconclusive_count,
+            "exit_code": EXIT_CODE_INCONCLUSIVE,
+            "message": f"{Colors.RED}VALIDATION FAILED:{Colors.NC} INCONCLUSIVE - unrecognized errors in {inconclusive_count}/{total} runs.",
+            "priority": 11,
+        }
+
+    return issue_counts
+
+
+def validate_results(analyses: list[LogAnalysis], metrics: dict) -> tuple[str, int]:
+    """Validate analysis results and return specific exit code based on detected issues."""
     if not analyses:
-        return (f"{Colors.RED}VALIDATION FAILED:{Colors.NC} No log files analyzed", 1)
+        return (f"{Colors.RED}VALIDATION FAILED:{Colors.NC} No log files analyzed", EXIT_CODE_INCONCLUSIVE)
 
     success_rate = metrics["success_rate"]
     timeout_rate = metrics["timeout_rate"]
 
-    # Determine exit code based on thresholds
-    exit_code = 0
-    messages = []
-
-    if success_rate < SUCCESS_RATE_STABLE:
-        messages.append(
-            f"{Colors.RED}VALIDATION FAILED:{Colors.NC} Success rate {success_rate:.1f}% is below threshold {SUCCESS_RATE_STABLE}%"
-        )
-        exit_code = 1
-
-    if timeout_rate >= TIMEOUT_ESCALATION_THRESHOLD:
-        messages.append(
-            f"{Colors.RED}VALIDATION FAILED:{Colors.NC} Timeout rate {timeout_rate:.1f}% exceeds threshold {TIMEOUT_ESCALATION_THRESHOLD}%"
-        )
-        exit_code = 1
-
-    if exit_code == 0:
+    # Check if validation passed according to original thresholds
+    if success_rate >= SUCCESS_RATE_STABLE and timeout_rate < TIMEOUT_ESCALATION_THRESHOLD:
         return (
-            f"{Colors.GREEN}VALIDATION PASSED:{Colors.NC} Cluster meets stability criteria (success: {success_rate:.1f}%, timeout: {timeout_rate:.1f}%)",
-            0,
+            f"{Colors.GREEN}VALIDATION PASSED:{Colors.NC} Cluster healthy with {success_rate:.1f}% success rate.",
+            EXIT_CODE_HEALTHY,
         )
 
-    return ("\n".join(messages), exit_code)
+    # Validation failed - count frequency of each issue type
+    issue_counts = count_validation_issues(analyses)
+
+    # Select the most frequent issue (use priority as tiebreaker)
+    if issue_counts:
+        most_frequent = max(issue_counts.values(), key=lambda x: (x["count"], -x["priority"]))
+        return (most_frequent["message"], most_frequent["exit_code"])
+
+    # Validation failed but no specific issue category detected
+    return (
+        f"{Colors.RED}VALIDATION FAILED:{Colors.NC} Success rate {success_rate:.1f}% below threshold {SUCCESS_RATE_STABLE}%.",
+        EXIT_CODE_INCONCLUSIVE,
+    )
 
 
 def main():

--- a/tools/scaleout/exabox/analyze_validation_results.py
+++ b/tools/scaleout/exabox/analyze_validation_results.py
@@ -54,6 +54,7 @@ EXIT_CODE_ARC_TIMEOUT = 10
 EXIT_CODE_AICLK_TIMEOUT = 11
 EXIT_CODE_NETWORK_ERROR = 12
 EXIT_CODE_INCONCLUSIVE = 50
+EXIT_CODE_INPUT_ERROR = 66
 
 # Threshold for repeated link failures (> 50% = same link failing repeatedly)
 REPEATED_LINK_THRESHOLD = 0.5
@@ -1448,12 +1449,12 @@ def main():
     log_dir = Path(args.directory)
     if not log_dir.is_dir():
         print(f"Error: {args.directory} not found", file=sys.stderr)
-        sys.exit(1)
+        sys.exit(EXIT_CODE_INPUT_ERROR)
 
     log_files = sorted(log_dir.glob("*.log"))
     if not log_files:
         print(f"No .log files in {args.directory}", file=sys.stderr)
-        sys.exit(1)
+        sys.exit(EXIT_CODE_INPUT_ERROR)
 
     analyses = [analyze_log_file(str(f)) for f in log_files]
     metrics = calculate_metrics(analyses)


### PR DESCRIPTION
### Ticket
[DCAMP-87](https://tenstorrent.atlassian.net/browse/DCAMP-87)

### Goal
Enable automated cluster troubleshooting by implementing specific exit codes in validation and fabric analysis scripts.

### What's changed

**Added analyze_validation_results.py Exit Codes:**
- `0` - Cluster healthy (≥80% success rate)
- `1` - Unhealthy links (repeated on same link)
- `2` - Unhealthy links (scattered across different links)
- `3` - DRAM training failures
- `4` - Missing connections (found in FSD but not in discovered topology)
- `5` - Extra connections (found in topology but not in FSD)
- `6` - Missing global connection
- `7` - FSD error
- `8` - MGD error
- `9` - Workload timeout
- `10` - ARC timeout
- `11` - AICLK timeout
- `12` - Network errors (MPI/SSH)
- `50` - Inconclusive (manual review required)
- `66` - Input Error

When multiple iteration logs show issues:
- Frequency-based selection: Exit code represents most common issue across analyzed logs
- Priority tiebreakers: When multiple issues occur with equal frequency, higher-priority issues take precedence

**Added analyze_fabric_results.py Exit Codes:**
- `0`: All tests passed
- `1`: MGD topology mismatch
- `2`: Firmware initialization failure
- `3`: Fabric router sync timeout
- `4`: Test hanging (incomplete logs)
- `5`: NOC address conflict
- `6`: Ethernet core timeout
- `50`: Inconclusive (manual review required)
- `66` - Input Error

**Updated tools/scaleout/README with new exit codes description**


- [x] Detection was verified on multiple validation/fabric test logs
