### PR TITLE
Refactor DeviceStorage

### DIFF
--- a/tests/ttnn/unit_tests/gtests/sources.cmake
+++ b/tests/ttnn/unit_tests/gtests/sources.cmake
@@ -61,6 +61,7 @@ set(UNIT_TESTS_TTNN_TENSOR_SOURCES
     tensor/test_create_tensor.cpp
     tensor/test_create_tensor_multi_device.cpp
     tensor/test_create_tensor_with_layout.cpp
+    tensor/test_device_storage_ownership.cpp
     tensor/test_distributed_tensor.cpp
     tensor/test_tensor_topology.cpp
     tensor/test_mesh_tensor.cpp

--- a/tests/ttnn/unit_tests/gtests/tensor/test_device_storage_ownership.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_device_storage_ownership.cpp
@@ -1,0 +1,178 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "tt_metal/tt_metal/common/multi_device_fixture.hpp"
+
+#include "ttnn/distributed/api.hpp"
+#include "ttnn/tensor/storage.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/tensor/tensor_ops.hpp"
+
+namespace ttnn::distributed::test {
+namespace {
+
+using ::testing::SizeIs;
+
+using tt::tt_metal::DataType;
+using tt::tt_metal::DeviceStorage;
+using tt::tt_metal::Layout;
+using tt::tt_metal::MemoryConfig;
+using tt::tt_metal::MeshDevice1x2Fixture;
+using tt::tt_metal::Tensor;
+using tt::tt_metal::TensorLayout;
+using tt::tt_metal::TensorSpec;
+
+using DeviceStorageOwnershipTest = MeshDevice1x2Fixture;
+
+TensorSpec make_test_tensor_spec() {
+    return TensorSpec(ttnn::Shape{1, 1, 32, 32}, TensorLayout(DataType::FLOAT32, Layout::ROW_MAJOR, MemoryConfig{}));
+}
+
+TEST_F(DeviceStorageOwnershipTest, SoleOwnerAfterCreation) {
+    Tensor tensor = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
+    const auto& storage = tensor.device_storage();
+
+    EXPECT_TRUE(storage.is_allocated());
+    EXPECT_TRUE(storage.is_sole_owner_of_device_memory());
+}
+
+TEST_F(DeviceStorageOwnershipTest, CopySharesOwnership) {
+    Tensor tensor1 = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
+    EXPECT_TRUE(tensor1.device_storage().is_sole_owner_of_device_memory());
+
+    // Copy constructor shares ownership
+    Tensor tensor2 = tensor1;
+    EXPECT_FALSE(tensor1.device_storage().is_sole_owner_of_device_memory());
+    EXPECT_FALSE(tensor2.device_storage().is_sole_owner_of_device_memory());
+
+    // Copy assignment also shares ownership
+    Tensor tensor3 = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
+    tensor3 = tensor1;
+    EXPECT_FALSE(tensor3.device_storage().is_sole_owner_of_device_memory());
+}
+
+TEST_F(DeviceStorageOwnershipTest, SoleOwnerRestoredAfterCopyDestroyed) {
+    Tensor tensor1 = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
+
+    {
+        Tensor tensor2 = tensor1;
+        EXPECT_FALSE(tensor1.device_storage().is_sole_owner_of_device_memory());
+    }
+
+    EXPECT_TRUE(tensor1.device_storage().is_sole_owner_of_device_memory());
+}
+
+TEST_F(DeviceStorageOwnershipTest, MoveTransfersOwnership) {
+    Tensor tensor1 = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
+
+    // Move constructor transfers ownership
+    Tensor tensor2 = std::move(tensor1);
+    EXPECT_TRUE(tensor2.device_storage().is_sole_owner_of_device_memory());
+
+    // Move assignment transfers ownership
+    Tensor tensor3 = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
+    tensor3 = std::move(tensor2);
+    EXPECT_TRUE(tensor3.device_storage().is_sole_owner_of_device_memory());
+}
+
+TEST_F(DeviceStorageOwnershipTest, DeallocateForce_AlwaysDeallocates) {
+    Tensor tensor1 = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
+    Tensor tensor2 = tensor1;
+
+    EXPECT_TRUE(tensor1.is_allocated());
+    EXPECT_TRUE(tensor2.is_allocated());
+
+    tensor1.deallocate(/*force=*/true);
+
+    EXPECT_FALSE(tensor1.is_allocated());
+    EXPECT_FALSE(tensor2.is_allocated());
+}
+
+TEST_F(DeviceStorageOwnershipTest, DeallocateNonForce_OnlyWhenSoleOwner) {
+    Tensor tensor1 = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
+    Tensor tensor2 = tensor1;
+
+    // Non-force deallocate is no-op when ownership is shared
+    tensor1.deallocate(/*force=*/false);
+    EXPECT_TRUE(tensor1.is_allocated());
+    EXPECT_TRUE(tensor2.is_allocated());
+
+    // After copy is gone, non-force deallocate works
+    tensor2 = Tensor{};
+    EXPECT_TRUE(tensor1.device_storage().is_sole_owner_of_device_memory());
+    tensor1.deallocate(/*force=*/false);
+    EXPECT_FALSE(tensor1.is_allocated());
+}
+
+TEST_F(DeviceStorageOwnershipTest, DeallocateIsIdempotent) {
+    Tensor tensor = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
+
+    tensor.deallocate(/*force=*/true);
+    EXPECT_FALSE(tensor.is_allocated());
+
+    EXPECT_NO_THROW(tensor.deallocate(/*force=*/true));
+    EXPECT_NO_THROW(tensor.deallocate(/*force=*/false));
+}
+
+TEST_F(DeviceStorageOwnershipTest, DefaultConstructedStorageState) {
+    DeviceStorage storage;
+
+    EXPECT_FALSE(storage.is_allocated());
+    EXPECT_TRUE(storage.is_uniform_storage());
+}
+
+TEST_F(DeviceStorageOwnershipTest, GettersThrowWhenDeallocated) {
+    Tensor tensor = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
+    tensor.deallocate(/*force=*/true);
+
+    EXPECT_THROW(tensor.device_storage().get_buffer(), std::exception);
+    EXPECT_THROW(tensor.device_storage().get_mesh_buffer(), std::exception);
+    EXPECT_THROW(tensor.device_storage().get_device(), std::exception);
+}
+
+TEST_F(DeviceStorageOwnershipTest, TensorShardsShareOwnership) {
+    Tensor tensor = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
+    auto shards = get_device_tensors(tensor);
+
+    ASSERT_THAT(shards, SizeIs(2));
+
+    // Original and all shards share ownership
+    EXPECT_FALSE(tensor.device_storage().is_sole_owner_of_device_memory());
+    for (const auto& shard : shards) {
+        EXPECT_TRUE(shard.device_storage().is_allocated());
+        EXPECT_FALSE(shard.device_storage().is_sole_owner_of_device_memory());
+    }
+
+    // Force deallocate through shard affects all
+    shards[0].deallocate(/*force=*/true);
+    EXPECT_FALSE(tensor.is_allocated());
+    EXPECT_FALSE(shards[1].is_allocated());
+}
+
+TEST_F(DeviceStorageOwnershipTest, DeviceStorageViewSharesOwnership) {
+    Tensor tensor = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
+    const auto& storage = tensor.device_storage();
+
+    auto coords = storage.get_coords();
+    ASSERT_THAT(coords, SizeIs(2));
+
+    // Create a view with subset of coords
+    std::vector<distributed::MeshCoordinate> subset_coords = {coords[0]};
+    DeviceStorage view_storage(storage, subset_coords);
+
+    EXPECT_TRUE(view_storage.is_allocated());
+    EXPECT_FALSE(storage.is_sole_owner_of_device_memory());
+    EXPECT_FALSE(view_storage.is_sole_owner_of_device_memory());
+    ASSERT_THAT(view_storage.get_coords(), SizeIs(1));
+
+    // Force deallocate through view affects original
+    view_storage.deallocate(/*force=*/true);
+    EXPECT_FALSE(storage.is_allocated());
+}
+
+}  // namespace
+}  // namespace ttnn::distributed::test

--- a/tests/ttnn/unit_tests/gtests/tensor/test_device_storage_ownership.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_device_storage_ownership.cpp
@@ -45,7 +45,7 @@ TEST_F(DeviceStorageOwnershipTest, CopySharesOwnership) {
     EXPECT_TRUE(tensor1.device_storage().is_sole_owner_of_device_memory());
 
     // Copy constructor shares ownership
-    Tensor tensor2 = tensor1;
+    Tensor tensor2 = tensor1;  // NOLINT(performance-unnecessary-copy-initialization)
     EXPECT_FALSE(tensor1.device_storage().is_sole_owner_of_device_memory());
     EXPECT_FALSE(tensor2.device_storage().is_sole_owner_of_device_memory());
 
@@ -59,7 +59,7 @@ TEST_F(DeviceStorageOwnershipTest, SoleOwnerRestoredAfterCopyDestroyed) {
     Tensor tensor1 = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
 
     {
-        Tensor tensor2 = tensor1;
+        Tensor tensor2 = tensor1;  // NOLINT(performance-unnecessary-copy-initialization)
         EXPECT_FALSE(tensor1.device_storage().is_sole_owner_of_device_memory());
     }
 
@@ -135,10 +135,15 @@ TEST_F(DeviceStorageOwnershipTest, GettersThrowWhenDeallocated) {
 }
 
 TEST_F(DeviceStorageOwnershipTest, TensorShardsShareOwnership) {
+    const auto num_devices = mesh_device_->num_devices();
+    if (num_devices < 2) {
+        GTEST_SKIP() << "Test requires at least 2 devices";
+    }
+
     Tensor tensor = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
     auto shards = get_device_tensors(tensor);
 
-    ASSERT_THAT(shards, SizeIs(2));
+    ASSERT_THAT(shards, SizeIs(num_devices));
 
     // Original and all shards share ownership
     EXPECT_FALSE(tensor.device_storage().is_sole_owner_of_device_memory());
@@ -150,7 +155,9 @@ TEST_F(DeviceStorageOwnershipTest, TensorShardsShareOwnership) {
     // Force deallocate through shard affects all
     shards[0].deallocate(/*force=*/true);
     EXPECT_FALSE(tensor.is_allocated());
-    EXPECT_FALSE(shards[1].is_allocated());
+    for (size_t i = 1; i < shards.size(); ++i) {
+        EXPECT_FALSE(shards[i].is_allocated());
+    }
 }
 
 TEST_F(DeviceStorageOwnershipTest, DeviceStorageViewSharesOwnership) {

--- a/tests/ttnn/unit_tests/gtests/tensor/test_device_storage_ownership.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_device_storage_ownership.cpp
@@ -32,7 +32,21 @@ TensorSpec make_test_tensor_spec() {
     return TensorSpec(ttnn::Shape{1, 1, 32, 32}, TensorLayout(DataType::FLOAT32, Layout::ROW_MAJOR, MemoryConfig{}));
 }
 
-TEST_F(DeviceStorageOwnershipTest, SoleOwnerAfterCreation) {
+// ======================================================================================
+// DeviceStorage Ownership Tests
+//
+// These tests verify the ownership semantics of DeviceStorage directly.
+// DeviceStorage tracks ownership via mesh_buffer shared_ptr use_count.
+// ======================================================================================
+
+TEST_F(DeviceStorageOwnershipTest, DeviceStorage_DefaultConstructedState) {
+    DeviceStorage storage;
+
+    EXPECT_FALSE(storage.is_allocated());
+    EXPECT_TRUE(storage.is_uniform_storage());
+}
+
+TEST_F(DeviceStorageOwnershipTest, DeviceStorage_SoleOwnerAfterCreation) {
     Tensor tensor = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
     const auto& storage = tensor.device_storage();
 
@@ -40,33 +54,95 @@ TEST_F(DeviceStorageOwnershipTest, SoleOwnerAfterCreation) {
     EXPECT_TRUE(storage.is_sole_owner_of_device_memory());
 }
 
-TEST_F(DeviceStorageOwnershipTest, CopySharesOwnership) {
-    Tensor tensor1 = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
-    EXPECT_TRUE(tensor1.device_storage().is_sole_owner_of_device_memory());
+TEST_F(DeviceStorageOwnershipTest, DeviceStorage_CopySharesOwnership) {
+    Tensor tensor = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
+    const auto& original_storage = tensor.device_storage();
 
-    // Copy constructor shares ownership
-    Tensor tensor2 = tensor1;  // NOLINT(performance-unnecessary-copy-initialization)
-    EXPECT_FALSE(tensor1.device_storage().is_sole_owner_of_device_memory());
-    EXPECT_FALSE(tensor2.device_storage().is_sole_owner_of_device_memory());
+    // Copying DeviceStorage shares the underlying mesh_buffer
+    DeviceStorage storage_copy = original_storage;  // NOLINT(performance-unnecessary-copy-initialization)
 
-    // Copy assignment also shares ownership
-    Tensor tensor3 = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
-    tensor3 = tensor1;
-    EXPECT_FALSE(tensor3.device_storage().is_sole_owner_of_device_memory());
+    // Both now share ownership (mesh_buffer.use_count() > 1)
+    EXPECT_FALSE(original_storage.is_sole_owner_of_device_memory());
+    EXPECT_FALSE(storage_copy.is_sole_owner_of_device_memory());
 }
 
-TEST_F(DeviceStorageOwnershipTest, SoleOwnerRestoredAfterCopyDestroyed) {
-    Tensor tensor1 = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
+TEST_F(DeviceStorageOwnershipTest, DeviceStorage_SoleOwnerRestoredAfterCopyDestroyed) {
+    Tensor tensor = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
+    const auto& original_storage = tensor.device_storage();
+    EXPECT_TRUE(original_storage.is_sole_owner_of_device_memory());
 
     {
-        Tensor tensor2 = tensor1;  // NOLINT(performance-unnecessary-copy-initialization)
-        EXPECT_FALSE(tensor1.device_storage().is_sole_owner_of_device_memory());
+        // Copying DeviceStorage shares ownership
+        DeviceStorage storage_copy = original_storage;  // NOLINT(performance-unnecessary-copy-initialization)
+        EXPECT_FALSE(original_storage.is_sole_owner_of_device_memory());
+        EXPECT_FALSE(storage_copy.is_sole_owner_of_device_memory());
     }
 
-    EXPECT_TRUE(tensor1.device_storage().is_sole_owner_of_device_memory());
+    // After copy is destroyed, sole ownership is restored
+    EXPECT_TRUE(original_storage.is_sole_owner_of_device_memory());
 }
 
-TEST_F(DeviceStorageOwnershipTest, MoveTransfersOwnership) {
+TEST_F(DeviceStorageOwnershipTest, DeviceStorage_ViewSharesOwnership) {
+    Tensor tensor = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
+    const auto& storage = tensor.device_storage();
+
+    auto coords = storage.get_coords();
+    ASSERT_THAT(coords, SizeIs(2));
+
+    // Create a view with subset of coords
+    std::vector<distributed::MeshCoordinate> subset_coords = {coords[0]};
+    DeviceStorage view_storage(storage, subset_coords);
+
+    EXPECT_TRUE(view_storage.is_allocated());
+    EXPECT_FALSE(storage.is_sole_owner_of_device_memory());
+    EXPECT_FALSE(view_storage.is_sole_owner_of_device_memory());
+    ASSERT_THAT(view_storage.get_coords(), SizeIs(1));
+}
+
+TEST_F(DeviceStorageOwnershipTest, DeviceStorage_ViewDeallocateAffectsOwner) {
+    Tensor tensor = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
+    const auto& storage = tensor.device_storage();
+
+    std::vector<distributed::MeshCoordinate> subset_coords = {storage.get_coords()[0]};
+    DeviceStorage view_storage(storage, subset_coords);
+
+    // Deallocate through view affects original
+    view_storage.deallocate();
+    EXPECT_FALSE(view_storage.is_allocated());
+    EXPECT_FALSE(storage.is_allocated());
+}
+
+TEST_F(DeviceStorageOwnershipTest, DeviceStorage_OwnerDeallocateAffectsView) {
+    Tensor tensor = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
+    DeviceStorage owner_storage = tensor.device_storage();
+
+    std::vector<distributed::MeshCoordinate> subset_coords = {owner_storage.get_coords()[0]};
+    DeviceStorage view_storage(owner_storage, subset_coords);
+
+    // Deallocate through owner affects view
+    owner_storage.deallocate();
+    EXPECT_FALSE(owner_storage.is_allocated());
+    EXPECT_FALSE(view_storage.is_allocated());
+}
+
+TEST_F(DeviceStorageOwnershipTest, DeviceStorage_GettersThrowWhenDeallocated) {
+    Tensor tensor = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
+    tensor.deallocate(/*force=*/true);
+
+    EXPECT_THROW(tensor.device_storage().get_buffer(), std::exception);
+    EXPECT_THROW(tensor.device_storage().get_mesh_buffer(), std::exception);
+    EXPECT_THROW(tensor.device_storage().get_device(), std::exception);
+}
+
+// ======================================================================================
+// Tensor Deallocation Tests
+//
+// These tests verify Tensor-level deallocation behavior.
+// Tensor tracks ownership via tensor_attributes shared_ptr, which is separate from
+// DeviceStorage's mesh_buffer ownership tracking.
+// ======================================================================================
+
+TEST_F(DeviceStorageOwnershipTest, Tensor_MoveTransfersOwnership) {
     Tensor tensor1 = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
 
     // Move constructor transfers ownership
@@ -79,9 +155,9 @@ TEST_F(DeviceStorageOwnershipTest, MoveTransfersOwnership) {
     EXPECT_TRUE(tensor3.device_storage().is_sole_owner_of_device_memory());
 }
 
-TEST_F(DeviceStorageOwnershipTest, DeallocateForce_AlwaysDeallocates) {
+TEST_F(DeviceStorageOwnershipTest, Tensor_DeallocateForceAlwaysDeallocates) {
     Tensor tensor1 = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
-    Tensor tensor2 = tensor1;
+    Tensor tensor2 = tensor1;  // NOLINT(performance-unnecessary-copy-initialization)
 
     EXPECT_TRUE(tensor1.is_allocated());
     EXPECT_TRUE(tensor2.is_allocated());
@@ -92,9 +168,9 @@ TEST_F(DeviceStorageOwnershipTest, DeallocateForce_AlwaysDeallocates) {
     EXPECT_FALSE(tensor2.is_allocated());
 }
 
-TEST_F(DeviceStorageOwnershipTest, DeallocateNonForce_OnlyWhenSoleOwner) {
+TEST_F(DeviceStorageOwnershipTest, Tensor_DeallocateNonForceOnlyWhenSoleOwner) {
     Tensor tensor1 = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
-    Tensor tensor2 = tensor1;
+    Tensor tensor2 = tensor1;  // NOLINT(performance-unnecessary-copy-initialization)
 
     // Non-force deallocate is no-op when ownership is shared
     tensor1.deallocate(/*force=*/false);
@@ -103,12 +179,11 @@ TEST_F(DeviceStorageOwnershipTest, DeallocateNonForce_OnlyWhenSoleOwner) {
 
     // After copy is gone, non-force deallocate works
     tensor2 = Tensor{};
-    EXPECT_TRUE(tensor1.device_storage().is_sole_owner_of_device_memory());
     tensor1.deallocate(/*force=*/false);
     EXPECT_FALSE(tensor1.is_allocated());
 }
 
-TEST_F(DeviceStorageOwnershipTest, DeallocateIsIdempotent) {
+TEST_F(DeviceStorageOwnershipTest, Tensor_DeallocateIsIdempotent) {
     Tensor tensor = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
 
     tensor.deallocate(/*force=*/true);
@@ -118,23 +193,7 @@ TEST_F(DeviceStorageOwnershipTest, DeallocateIsIdempotent) {
     EXPECT_NO_THROW(tensor.deallocate(/*force=*/false));
 }
 
-TEST_F(DeviceStorageOwnershipTest, DefaultConstructedStorageState) {
-    DeviceStorage storage;
-
-    EXPECT_FALSE(storage.is_allocated());
-    EXPECT_TRUE(storage.is_uniform_storage());
-}
-
-TEST_F(DeviceStorageOwnershipTest, GettersThrowWhenDeallocated) {
-    Tensor tensor = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
-    tensor.deallocate(/*force=*/true);
-
-    EXPECT_THROW(tensor.device_storage().get_buffer(), std::exception);
-    EXPECT_THROW(tensor.device_storage().get_mesh_buffer(), std::exception);
-    EXPECT_THROW(tensor.device_storage().get_device(), std::exception);
-}
-
-TEST_F(DeviceStorageOwnershipTest, TensorShardsShareOwnership) {
+TEST_F(DeviceStorageOwnershipTest, Tensor_ShardsShareDeviceStorageOwnership) {
     const auto num_devices = mesh_device_->num_devices();
     if (num_devices < 2) {
         GTEST_SKIP() << "Test requires at least 2 devices";
@@ -158,27 +217,6 @@ TEST_F(DeviceStorageOwnershipTest, TensorShardsShareOwnership) {
     for (size_t i = 1; i < shards.size(); ++i) {
         EXPECT_FALSE(shards[i].is_allocated());
     }
-}
-
-TEST_F(DeviceStorageOwnershipTest, DeviceStorageViewSharesOwnership) {
-    Tensor tensor = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
-    const auto& storage = tensor.device_storage();
-
-    auto coords = storage.get_coords();
-    ASSERT_THAT(coords, SizeIs(2));
-
-    // Create a view with subset of coords
-    std::vector<distributed::MeshCoordinate> subset_coords = {coords[0]};
-    DeviceStorage view_storage(storage, subset_coords);
-
-    EXPECT_TRUE(view_storage.is_allocated());
-    EXPECT_FALSE(storage.is_sole_owner_of_device_memory());
-    EXPECT_FALSE(view_storage.is_sole_owner_of_device_memory());
-    ASSERT_THAT(view_storage.get_coords(), SizeIs(1));
-
-    // Force deallocate through view affects original
-    view_storage.deallocate(/*force=*/true);
-    EXPECT_FALSE(storage.is_allocated());
 }
 
 }  // namespace

--- a/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
@@ -186,7 +186,7 @@ TEST_F(MeshTensorTest, ReplicateHostStorageTensor) {
 
     const auto& device_storage = device_tensor.device_storage();
     EXPECT_NO_THROW({ device_storage.get_mesh_buffer(); });
-    EXPECT_THAT(device_storage.coords, SizeIs(mesh_device_->num_devices()));
+    EXPECT_THAT(device_storage.get_coords(), SizeIs(mesh_device_->num_devices()));
 
     // Read the tensor back, and compare it with input data.
     Tensor output_host_tensor = cpu(device_tensor);
@@ -212,7 +212,8 @@ TEST_F(MeshTensorTest, GetDeviceTensors) {
     Tensor device_tensor = to_device(input_host_tensor, mesh_device_.get());
     const auto& device_storage = device_tensor.device_storage();
     EXPECT_NO_THROW({ device_storage.get_mesh_buffer(); });
-    EXPECT_THAT(device_storage.coords, SizeIs(mesh_device_->num_devices()));
+    EXPECT_TRUE(device_storage.is_allocated());
+    EXPECT_THAT(device_storage.get_coords(), SizeIs(mesh_device_->num_devices()));
 
     // Validate each tensor shard.
     std::vector<Tensor> device_tensors = get_device_tensors(device_tensor);
@@ -221,8 +222,9 @@ TEST_F(MeshTensorTest, GetDeviceTensors) {
     for (const auto& tensor_shard : device_tensors) {
         const auto& shard_storage = tensor_shard.device_storage();
         EXPECT_NO_THROW({ shard_storage.get_mesh_buffer(); });
-        EXPECT_THAT(shard_storage.coords, SizeIs(1));
-        device_shard_coords.push_back(shard_storage.coords.front());
+        EXPECT_TRUE(shard_storage.is_allocated());
+        EXPECT_THAT(shard_storage.get_coords(), SizeIs(1));
+        device_shard_coords.push_back(shard_storage.get_coords().front());
         EXPECT_THAT(tensor_shard.to_vector<float>(), Pointwise(FloatEq(), host_data));
     }
 
@@ -283,11 +285,11 @@ TEST_F(MeshTensorTest2x4, CombineDeviceTensors) {
         shard_dim);
 
     // Validate the shards are sorted, and are as expected.
-    ASSERT_THAT(partial_device_storage.coords, SizeIs(4));
-    EXPECT_EQ(partial_device_storage.coords[0], (distributed::MeshCoordinate{0, 0}));
-    EXPECT_EQ(partial_device_storage.coords[1], (distributed::MeshCoordinate{0, 2}));
-    EXPECT_EQ(partial_device_storage.coords[2], (distributed::MeshCoordinate{1, 0}));
-    EXPECT_EQ(partial_device_storage.coords[3], (distributed::MeshCoordinate{1, 2}));
+    ASSERT_THAT(partial_device_storage.get_coords(), SizeIs(4));
+    EXPECT_EQ(partial_device_storage.get_coords()[0], (distributed::MeshCoordinate{0, 0}));
+    EXPECT_EQ(partial_device_storage.get_coords()[1], (distributed::MeshCoordinate{0, 2}));
+    EXPECT_EQ(partial_device_storage.get_coords()[2], (distributed::MeshCoordinate{1, 0}));
+    EXPECT_EQ(partial_device_storage.get_coords()[3], (distributed::MeshCoordinate{1, 2}));
 }
 
 struct MeshTensorWriteTestParams {
@@ -342,7 +344,7 @@ TEST_P(MeshTensorWriteTest, WriteMultiDeviceHostTensor) {
     EXPECT_EQ(device_tensor.tensor_topology(), input_host_tensor_sharded.tensor_topology());
 
     const auto& device_storage = device_tensor.device_storage();
-    EXPECT_THAT(device_storage.coords, ElementsAreArray(coord_matchers));
+    EXPECT_THAT(device_storage.get_coords(), ElementsAreArray(coord_matchers));
 
     auto output_host_tensor = [&]() {
         if (GetParam().use_pre_allocated_tensor_api) {

--- a/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
@@ -138,7 +138,7 @@ TEST_F(LaunchOperation2x4Test, UniformTensor) {
 TEST_F(LaunchOperation2x4Test, UnevenTensor) {
     auto uneven_tensor = make_tensor_with_num_shards(2, mesh_device_.get());
 
-    EXPECT_THAT(uneven_tensor.device_storage().coords, SizeIs(2));
+    EXPECT_THAT(uneven_tensor.device_storage().get_coords(), SizeIs(2));
 
     EXPECT_FALSE(all_tensors_have_uniform_storage(uneven_tensor));
     EXPECT_THAT(

--- a/ttnn/api/ttnn/mesh_device_operation_utils.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_utils.hpp
@@ -59,8 +59,7 @@ TensorReturnValue filter_tensor_shards(
             }
 
             // Create new storage with filtered coords, sharing the mesh_buffer
-            tt::tt_metal::DeviceStorage new_storage(
-                old_storage.get_mesh_buffer_leak_ownership(), std::move(filtered_coords));
+            tt::tt_metal::DeviceStorage new_storage(old_storage, std::move(filtered_coords));
 
             // Return new tensor with new storage
             return Tensor(std::move(new_storage), tensor.tensor_spec(), tensor.tensor_topology());

--- a/ttnn/api/ttnn/mesh_device_operation_utils.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_utils.hpp
@@ -47,8 +47,8 @@ TensorReturnValue filter_tensor_shards(
             filtered_coords.reserve(tensor_coordinates.size());
 
             auto coord_it = tensor_coordinates.cbegin();
-            auto storage_it = old_storage.coords.cbegin();
-            while (coord_it != tensor_coordinates.end() && storage_it != old_storage.coords.end()) {
+            auto storage_it = old_storage.get_coords().begin();
+            while (coord_it != tensor_coordinates.end() && storage_it != old_storage.get_coords().end()) {
                 if (*storage_it == *coord_it) {
                     filtered_coords.push_back(*storage_it);
                     ++coord_it;

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -177,9 +177,9 @@ struct DeviceStorage {
 private:
     // Main internal constructor, performs all validation
     DeviceStorage(
-        std::shared_ptr<distributed::MeshBuffer> mesh_buffer_,
-        std::vector<distributed::MeshCoordinate> coords_,
-        std::shared_ptr<distributed::MeshBuffer> root_mesh_buffer_);
+        std::shared_ptr<distributed::MeshBuffer> mesh_buffer,
+        std::vector<distributed::MeshCoordinate> coords,
+        std::shared_ptr<distributed::MeshBuffer> root_mesh_buffer);
 
     std::vector<distributed::MeshCoordinate> coords_;
     std::shared_ptr<distributed::MeshBuffer> mesh_buffer;

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -66,6 +66,10 @@ private:
 
 public:
     DeviceStorage() = default;
+
+    // Constructs DeviceStorage with coords covering the full mesh device shape.
+    explicit DeviceStorage(std::shared_ptr<distributed::MeshBuffer> mesh_buffer_);
+
     DeviceStorage(
         std::shared_ptr<distributed::MeshBuffer> mesh_buffer_,
         std::vector<distributed::MeshCoordinate> coords_,

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <memory>
+#include <span>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/host_buffer.hpp>
 #include <tuple>
@@ -57,14 +58,6 @@ private:
 };
 
 struct DeviceStorage {
-    std::vector<distributed::MeshCoordinate> coords;
-
-private:
-    std::shared_ptr<distributed::MeshBuffer> mesh_buffer;
-    // Workaround for managing view MeshBuffer; expected to be refactored in #38093
-    std::shared_ptr<distributed::MeshBuffer> root_mesh_buffer;
-
-public:
     DeviceStorage() = default;
 
     // Constructs DeviceStorage with coords covering the full mesh device shape.
@@ -114,11 +107,20 @@ public:
     // Returns true if the tensor spans across all devices in a mesh.
     bool is_uniform_storage() const;
 
+    // Returns the coordinates the tensor spans across.
+    std::span<const distributed::MeshCoordinate> get_coords() const { return coords_; }
+
 private:
-    // Experimental features
+    std::vector<distributed::MeshCoordinate> coords_;
+    std::shared_ptr<distributed::MeshBuffer> mesh_buffer;
+
+    // Experimental features for viewing an existing DeviceStorage
     const std::shared_ptr<distributed::MeshBuffer>& get_root_mesh_buffer() const;
     void deallocate_root_mesh_buffer();
     void reset_root_mesh_buffer();
+
+    std::shared_ptr<distributed::MeshBuffer> root_mesh_buffer;
+    // End experimental features
 };
 
 using Storage = std::variant<HostStorage, DeviceStorage>;

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -4,11 +4,13 @@
 
 #pragma once
 
+#include <functional>
 #include <memory>
 #include <span>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/host_buffer.hpp>
 #include <tuple>
+#include <vector>
 
 #include "tt-metalium/distributed_host_buffer.hpp"
 #include "tt-metalium/experimental/tensor/host_tensor.hpp"
@@ -167,6 +169,14 @@ struct DeviceStorage {
     // They will be replaced with a new initiative as described in: #38093
     DeviceStorage(const DeviceStorage& owning_storage, std::shared_ptr<distributed::MeshBuffer> surface_buffer);
     // End internal functions.
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Aggregate DeviceStorages
+    //
+    // Combines a vector of DeviceStorages that shares the same device storage but spread across difference coordinates
+    // into a single DeviceStorage.
+    static DeviceStorage combine_device_storages(
+        const std::vector<std::reference_wrapper<const DeviceStorage>>& storages);
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Serialization

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -70,10 +70,9 @@ public:
     // Constructs DeviceStorage with coords covering the full mesh device shape.
     explicit DeviceStorage(std::shared_ptr<distributed::MeshBuffer> mesh_buffer_);
 
+    // Constructs DeviceStorage that is a view of the mesh_buffer_ at the given coords_
     DeviceStorage(
-        std::shared_ptr<distributed::MeshBuffer> mesh_buffer_,
-        std::vector<distributed::MeshCoordinate> coords_,
-        std::shared_ptr<distributed::MeshBuffer> root_buffer_ = nullptr);
+        std::shared_ptr<distributed::MeshBuffer> mesh_buffer_, std::vector<distributed::MeshCoordinate> coords_);
 
     Buffer* get_buffer() const;
     const distributed::MeshBuffer& get_mesh_buffer() const;
@@ -87,6 +86,8 @@ public:
     // These functions allows the use of the get_mesh_buffer as a view.
     // These are considered internal functions and are not part of the public API.
     // They will be replaced with a new initiative as described in: #38093
+    DeviceStorage(const DeviceStorage& owning_storage, std::shared_ptr<distributed::MeshBuffer> surface_buffer);
+
     const std::shared_ptr<distributed::MeshBuffer>& get_root_mesh_buffer() const;
     void deallocate_root_mesh_buffer();
     void reset_root_mesh_buffer();

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -57,6 +57,22 @@ private:
     HostTensor tensor;
 };
 
+// DeviceStorage manages a piece of device memory and that is valid for a vector of MeshCoordinates.
+//
+// DeviceStorage owns the lifetime of the underlying device memory.
+// Copying the DeviceStorage will share the ownership of the underlying device memory.
+// DeviceStorage currently allow "leaking" of the underlying device memory ownership via get_mesh_buffer(),
+// this will be addressed in #39064.
+//
+// DeviceStorage has two possible states:
+// - Allocated: the underlying device memory is allocated.
+//   - Can query device memory state/ coordinates/ device.
+//   - The MeshCoordinates obtained from get_coords will be within the boundaries of the underlying device memory.
+//   - Can be switched to the deallocated state by calling deallocate.
+// - Deallocated: the underlying device memory is released.
+//   - Query of device memory state/ coordinates/ device will throw.
+//   - is_uniform_storage will return true.
+//   - Calls to deallocate will have no effect.
 struct DeviceStorage {
     // Construct a DeviceStorage that is deallocated
     DeviceStorage() = default;
@@ -67,7 +83,8 @@ struct DeviceStorage {
     // Constructs DeviceStorage with coords covering the full mesh device shape.
     explicit DeviceStorage(std::shared_ptr<distributed::MeshBuffer> mesh_buffer_);
 
-    // Constructs DeviceStorage that is a view of the mesh_buffer_ at the given coords_
+    // Constructs DeviceStorage that is a view of the mesh_buffer_ at the given coords_.
+    // Throws if the coords_ are out of bounds for the mesh_buffer_ device shape.
     DeviceStorage(
         std::shared_ptr<distributed::MeshBuffer> mesh_buffer_, std::vector<distributed::MeshCoordinate> coords_);
 
@@ -82,18 +99,22 @@ struct DeviceStorage {
 
     // Creates a copy of the DeviceStorage that shares the underlying device memory,
     // but with a different set of coords.
+    // Throws if the coords_ are out of bounds for the mesh_buffer_ device shape.
     DeviceStorage(const DeviceStorage& other, std::vector<distributed::MeshCoordinate> coords);
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Device Memory getters
 
     // Get legacy single device buffer
+    // Throws if the DeviceStorage is not allocated.
     Buffer* get_buffer() const;
 
     // Get mesh buffer that represents the device memory
+    // Throws if the DeviceStorage is not allocated.
     const distributed::MeshBuffer& get_mesh_buffer() const;
 
     // Get the device the device memory is allocated on
+    // Throws if the DeviceStorage is not allocated.
     distributed::MeshDevice* get_device() const;
 
     // Returns the MeshDevice pointer if mesh_buffer exists, or nullptr otherwise.
@@ -113,10 +134,11 @@ struct DeviceStorage {
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // DeviceStorage as a view of the undelrying device memory at specific coordinates:
 
-    // Returns true if the tensor spans across all devices in a mesh.
+    // Returns true if the tensor spans across all devices in a mesh or if the DeviceStorage is not allocated.
     bool is_uniform_storage() const;
 
     // Returns the coordinates the tensor spans across.
+    // Throws if the DeviceStorage is not allocated.
     std::span<const distributed::MeshCoordinate> get_coords() const;
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -153,6 +175,12 @@ struct DeviceStorage {
     auto attribute_values() const { return std::forward_as_tuple(); }
 
 private:
+    // Main internal constructor, performs all validation
+    DeviceStorage(
+        std::shared_ptr<distributed::MeshBuffer> mesh_buffer_,
+        std::vector<distributed::MeshCoordinate> coords_,
+        std::shared_ptr<distributed::MeshBuffer> root_mesh_buffer_);
+
     std::vector<distributed::MeshCoordinate> coords_;
     std::shared_ptr<distributed::MeshBuffer> mesh_buffer;
 

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -146,11 +146,8 @@ struct DeviceStorage {
 
     // Deallocate the underlying device memory.
     // The underlying device memory could be shared by multiple instances of the DeviceStorage.
-    //
-    // If force is set, the underlying device memory will be deallocated irespective of the number of device storage
-    // owners. If force is not set, the underlying device memory will be deallocated only if "this" is the sole owner of
-    // the underlying device memory.
-    void deallocate(bool force);
+    // Deallocate will deallocate the device memory of among all shared instances.
+    void deallocate();
 
     // Returns true if no other DeviceStorage or third party has a shared reference to the device memory (MeshBuffer).
     bool is_sole_owner_of_device_memory() const;
@@ -194,9 +191,6 @@ private:
 
     // Experimental features for viewing an existing DeviceStorage
     const std::shared_ptr<distributed::MeshBuffer>& get_root_mesh_buffer() const;
-    void deallocate_root_mesh_buffer();
-    void reset_root_mesh_buffer();
-
     std::shared_ptr<distributed::MeshBuffer> root_mesh_buffer;
     // End experimental features
 };

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -70,8 +70,8 @@ private:
 //   - The MeshCoordinates obtained from get_coords will be within the boundaries of the underlying device memory.
 //   - Can be switched to the deallocated state by calling deallocate.
 // - Deallocated: the underlying device memory is released.
-//   - Query of device memory state/ coordinates/ device will throw.
-//   - is_uniform_storage will be undefined (currently returns true for backward compatibility).
+//   - Query of device memory state/ device will throw.
+//   - get_coords/ is_uniform_storage will be undefined (for transition, ideally they should all throw).
 //   - Calls to deallocate will have no effect.
 struct DeviceStorage {
     // Construct a DeviceStorage that is deallocated
@@ -115,7 +115,7 @@ struct DeviceStorage {
 
     // Get the device the device memory is allocated on
     // Throws if the DeviceStorage is not allocated.
-    distributed::MeshDevice* get_device() const;
+    distributed::MeshDevice& get_device() const;
 
     // Returns the MeshDevice pointer if mesh_buffer exists, or nullptr otherwise.
     // Unlike get_device(), this does NOT throw when the buffer is deallocated.
@@ -138,7 +138,6 @@ struct DeviceStorage {
     bool is_uniform_storage() const;
 
     // Returns the coordinates the tensor spans across.
-    // Throws if the DeviceStorage is not allocated.
     std::span<const distributed::MeshCoordinate> get_coords() const;
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -60,12 +60,28 @@ private:
 struct DeviceStorage {
     DeviceStorage() = default;
 
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Constructs a DeviceStorage from a device memory
+
     // Constructs DeviceStorage with coords covering the full mesh device shape.
     explicit DeviceStorage(std::shared_ptr<distributed::MeshBuffer> mesh_buffer_);
 
     // Constructs DeviceStorage that is a view of the mesh_buffer_ at the given coords_
     DeviceStorage(
         std::shared_ptr<distributed::MeshBuffer> mesh_buffer_, std::vector<distributed::MeshCoordinate> coords_);
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Copys an existing DeviceStorage and share it's underlying device memory.
+
+    // Creates a copy of the DeviceStorage that shares the underlying device memory
+    DeviceStorage(const DeviceStorage&) = default;
+    DeviceStorage(DeviceStorage&&) noexcept = default;
+    DeviceStorage& operator=(const DeviceStorage&) = default;
+    DeviceStorage& operator=(DeviceStorage&&) noexcept = default;
+
+    // Creates a copy of the DeviceStorage that shares the underlying device memory,
+    // but with a different set of coords.
+    DeviceStorage(const DeviceStorage& other, std::vector<distributed::MeshCoordinate> coords);
 
     Buffer* get_buffer() const;
     const distributed::MeshBuffer& get_mesh_buffer() const;

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -73,6 +73,9 @@ private:
 //   - Query of device memory state/ device will throw.
 //   - get_coords/ is_uniform_storage will be undefined (for transition, ideally they should all throw).
 //   - Calls to deallocate will have no effect.
+//
+// Right now the deallocated state is only restircted to have a nullptr to the mesh_buffer,
+// in the future we should restrict it to also cover have a non-null mesh_buffer that has a deallocated state.
 struct DeviceStorage {
     // Construct a DeviceStorage that is deallocated
     DeviceStorage() = default;

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -81,7 +81,7 @@ struct DeviceStorage {
     // Constructs a DeviceStorage from a device memory
 
     // Constructs DeviceStorage with coords covering the full mesh device shape.
-    explicit DeviceStorage(std::shared_ptr<distributed::MeshBuffer> mesh_buffer_);
+    explicit DeviceStorage(const std::shared_ptr<distributed::MeshBuffer>& mesh_buffer_);
 
     // Constructs DeviceStorage that is a view of the mesh_buffer_ at the given coords_.
     // Throws if the coords_ are out of bounds for the mesh_buffer_ device shape.

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -58,6 +58,7 @@ private:
 };
 
 struct DeviceStorage {
+    // Construct a DeviceStorage that is deallocated
     DeviceStorage() = default;
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -83,27 +84,17 @@ struct DeviceStorage {
     // but with a different set of coords.
     DeviceStorage(const DeviceStorage& other, std::vector<distributed::MeshCoordinate> coords);
 
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Device Memory getters
+
+    // Get legacy single device buffer
     Buffer* get_buffer() const;
+
+    // Get mesh buffer that represents the device memory
     const distributed::MeshBuffer& get_mesh_buffer() const;
 
-    // Returns true if no other DeviceStorage or third party has a shared reference to the device memory (MeshBuffer).
-    bool is_sole_owner_of_device_memory() const;
-
-    void deallocate(bool force);
-
-    // Begin internal functions:
-    std::shared_ptr<distributed::MeshBuffer> get_mesh_buffer_leak_ownership() const;
-    //
-    // These functions allows the use of the get_mesh_buffer as a view.
-    // These are considered internal functions and are not part of the public API.
-    // They will be replaced with a new initiative as described in: #38093
-    DeviceStorage(const DeviceStorage& owning_storage, std::shared_ptr<distributed::MeshBuffer> surface_buffer);
-    // End internal functions.
-
-    static constexpr auto attribute_names = std::forward_as_tuple();
-    auto attribute_values() const { return std::forward_as_tuple(); }
-
-    bool is_allocated() const;
+    // Get the device the device memory is allocated on
+    distributed::MeshDevice* get_device() const;
 
     // Returns the MeshDevice pointer if mesh_buffer exists, or nullptr otherwise.
     // Unlike get_device(), this does NOT throw when the buffer is deallocated.
@@ -118,13 +109,48 @@ struct DeviceStorage {
     // don't operate on deallocated tensors.
     distributed::MeshDevice* get_device_bypass_deallocate_check() const;
 
-    distributed::MeshDevice* get_device() const;
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // DeviceStorage as a view of the undelrying device memory at specific coordinates:
 
     // Returns true if the tensor spans across all devices in a mesh.
     bool is_uniform_storage() const;
 
     // Returns the coordinates the tensor spans across.
-    std::span<const distributed::MeshCoordinate> get_coords() const { return coords_; }
+    std::span<const distributed::MeshCoordinate> get_coords() const;
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Deallocation management
+
+    // Deallocate the underlying device memory.
+    // The underlying device memory could be shared by multiple instances of the DeviceStorage.
+    //
+    // If force is set, the underlying device memory will be deallocated irespective of the number of device storage
+    // owners. If force is not set, the underlying device memory will be deallocated only if "this" is the sole owner of
+    // the underlying device memory.
+    void deallocate(bool force);
+
+    // Returns true if no other DeviceStorage or third party has a shared reference to the device memory (MeshBuffer).
+    bool is_sole_owner_of_device_memory() const;
+
+    // Returns true if the underlying device memory is allocated.
+    bool is_allocated() const;
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Begin internal functions:
+    std::shared_ptr<distributed::MeshBuffer> get_mesh_buffer_leak_ownership() const;
+    //
+    // These functions allows the use of the get_mesh_buffer as a view.
+    // These are considered internal functions and are not part of the public API.
+    // They will be replaced with a new initiative as described in: #38093
+    DeviceStorage(const DeviceStorage& owning_storage, std::shared_ptr<distributed::MeshBuffer> surface_buffer);
+    // End internal functions.
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Serialization
+
+    static constexpr auto attribute_names = std::forward_as_tuple();
+    auto attribute_values() const { return std::forward_as_tuple(); }
 
 private:
     std::vector<distributed::MeshCoordinate> coords_;

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -80,6 +80,8 @@ public:
     // Returns true if no other DeviceStorage or third party has a shared reference to the device memory (MeshBuffer).
     bool is_sole_owner_of_device_memory() const;
 
+    void deallocate(bool force);
+
     // Begin internal functions:
     std::shared_ptr<distributed::MeshBuffer> get_mesh_buffer_leak_ownership() const;
     //
@@ -87,10 +89,6 @@ public:
     // These are considered internal functions and are not part of the public API.
     // They will be replaced with a new initiative as described in: #38093
     DeviceStorage(const DeviceStorage& owning_storage, std::shared_ptr<distributed::MeshBuffer> surface_buffer);
-
-    const std::shared_ptr<distributed::MeshBuffer>& get_root_mesh_buffer() const;
-    void deallocate_root_mesh_buffer();
-    void reset_root_mesh_buffer();
     // End internal functions.
 
     static constexpr auto attribute_names = std::forward_as_tuple();
@@ -115,6 +113,12 @@ public:
 
     // Returns true if the tensor spans across all devices in a mesh.
     bool is_uniform_storage() const;
+
+private:
+    // Experimental features
+    const std::shared_ptr<distributed::MeshBuffer>& get_root_mesh_buffer() const;
+    void deallocate_root_mesh_buffer();
+    void reset_root_mesh_buffer();
 };
 
 using Storage = std::variant<HostStorage, DeviceStorage>;

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -158,7 +158,11 @@ struct DeviceStorage {
     // Begin internal functions:
     std::shared_ptr<distributed::MeshBuffer> get_mesh_buffer_leak_ownership() const;
     //
-    // These functions allows the use of the get_mesh_buffer as a view.
+    // Creates a DeviceStorage representing a view of existing device memory.
+    // `surface_buffer` could provide a different buffer configuration (e.g., sharding parameters) from the
+    // configuration of the owning_storage. Ownership of the underlying device memory is shared amongs the new
+    // DeviceStorage and the owning_storage. Deallocation will affect both the new DeviceStorage and the owning_storage.
+    //
     // These are considered internal functions and are not part of the public API.
     // They will be replaced with a new initiative as described in: #38093
     DeviceStorage(const DeviceStorage& owning_storage, std::shared_ptr<distributed::MeshBuffer> surface_buffer);

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -63,8 +63,6 @@ private:
 //
 // DeviceStorage owns the lifetime of the underlying device memory.
 // Copying the DeviceStorage will share the ownership of the underlying device memory.
-// DeviceStorage currently allow "leaking" of the underlying device memory ownership via get_mesh_buffer(),
-// this will be addressed in #39064.
 //
 // DeviceStorage has two possible states:
 // - Allocated: the underlying device memory is allocated.
@@ -73,7 +71,7 @@ private:
 //   - Can be switched to the deallocated state by calling deallocate.
 // - Deallocated: the underlying device memory is released.
 //   - Query of device memory state/ coordinates/ device will throw.
-//   - is_uniform_storage will return true.
+//   - is_uniform_storage will be undefined (currently returns true for backward compatibility).
 //   - Calls to deallocate will have no effect.
 struct DeviceStorage {
     // Construct a DeviceStorage that is deallocated
@@ -136,7 +134,7 @@ struct DeviceStorage {
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // DeviceStorage as a view of the undelrying device memory at specific coordinates:
 
-    // Returns true if the tensor spans across all devices in a mesh or if the DeviceStorage is not allocated.
+    // Returns true if the tensor spans across all devices in a mesh.
     bool is_uniform_storage() const;
 
     // Returns the coordinates the tensor spans across.

--- a/ttnn/core/device_operation_detail.cpp
+++ b/ttnn/core/device_operation_detail.cpp
@@ -193,8 +193,8 @@ std::vector<MeshCoordinate> extract_tensor_coordinates_impl(
     const Tensor& first_tensor = tensors.front().get();
     std::vector<ttnn::MeshCoordinate> tensor_coordinates;
     std::transform(
-        first_tensor.device_storage().coords.begin(),
-        first_tensor.device_storage().coords.end(),
+        first_tensor.device_storage().get_coords().begin(),
+        first_tensor.device_storage().get_coords().end(),
         std::back_inserter(tensor_coordinates),
         [](const auto& coord) { return coord; });
 
@@ -202,11 +202,11 @@ std::vector<MeshCoordinate> extract_tensor_coordinates_impl(
     // that do not overlap.
     for (const auto& tensor_ref : tensors) {
         const Tensor& tensor = tensor_ref.get();
-        if (tensor.device_storage().coords.size() != tensor_coordinates.size()) {
+        if (tensor.device_storage().get_coords().size() != tensor_coordinates.size()) {
             std::vector<ttnn::MeshCoordinate> tensor_mesh_coords;
             std::transform(
-                tensor.device_storage().coords.begin(),
-                tensor.device_storage().coords.end(),
+                tensor.device_storage().get_coords().begin(),
+                tensor.device_storage().get_coords().end(),
                 std::back_inserter(tensor_mesh_coords),
                 [](const auto& coord) { return coord; });
             if (tensor_mesh_coords.size() < tensor_coordinates.size()) {

--- a/ttnn/core/distributed/api.cpp
+++ b/ttnn/core/distributed/api.cpp
@@ -73,7 +73,7 @@ std::vector<Tensor> get_device_tensors(const Tensor& tensor) {
             [&](const HostBuffer& buffer) { tensors.push_back(Tensor{buffer, tensor.tensor_spec()}); });
         return tensors;
     }
-    if (is_device_tensor(tensor)) {
+    if (is_device_tensor(tensor) && tensor.is_allocated()) {
         const auto& device_storage = tensor.device_storage();
         std::vector<ttnn::Tensor> tensors;
         tensors.reserve(device_storage.get_coords().size());

--- a/ttnn/core/distributed/api.cpp
+++ b/ttnn/core/distributed/api.cpp
@@ -81,7 +81,7 @@ std::vector<Tensor> get_device_tensors(const Tensor& tensor) {
             DeviceStorage shard_storage(device_storage, {coord});
             tensors.push_back(Tensor(std::move(shard_storage), tensor.tensor_spec(), tensor.tensor_topology()));
         }
-        return {tensor};
+        return tensors;
     }
     return {tensor};
 }

--- a/ttnn/core/distributed/api.cpp
+++ b/ttnn/core/distributed/api.cpp
@@ -75,14 +75,11 @@ std::vector<Tensor> get_device_tensors(const Tensor& tensor) {
     }
     if (is_device_tensor(tensor)) {
         const auto& device_storage = tensor.device_storage();
-        if (const auto& mesh_buffer = device_storage.get_mesh_buffer_leak_ownership(); mesh_buffer != nullptr) {
-            std::vector<ttnn::Tensor> tensors;
-            tensors.reserve(device_storage.coords.size());
-            for (const auto& coord : device_storage.coords) {
-                DeviceStorage shard_storage(mesh_buffer, {coord});
-                tensors.push_back(Tensor(std::move(shard_storage), tensor.tensor_spec(), tensor.tensor_topology()));
-            }
-            return tensors;
+        std::vector<ttnn::Tensor> tensors;
+        tensors.reserve(device_storage.get_coords().size());
+        for (const auto& coord : device_storage.get_coords()) {
+            DeviceStorage shard_storage(device_storage.get_mesh_buffer_leak_ownership(), {coord});
+            tensors.push_back(Tensor(std::move(shard_storage), tensor.tensor_spec(), tensor.tensor_topology()));
         }
         return {tensor};
     }
@@ -131,7 +128,7 @@ Tensor combine_device_tensors(const std::vector<Tensor>& tensor_shards, int shar
             shard_storage.get_mesh_buffer_leak_ownership() == mesh_buffer,
             "Error aggregating multichip tensors: tensor shards must be allocated on the same mesh buffer. "
             "Consider moving tensors to host, aggregating, and re-uploading on device storage.");
-        for (const auto& coord : shard_storage.coords) {
+        for (const auto& coord : shard_storage.get_coords()) {
             coords.push_back(coord);
         }
     }

--- a/ttnn/core/distributed/api.cpp
+++ b/ttnn/core/distributed/api.cpp
@@ -110,15 +110,8 @@ Tensor from_host_shards(const std::vector<Tensor>& tensor_shards, const MeshShap
 
 Tensor combine_device_tensors(const std::vector<Tensor>& tensor_shards, int shard_dim) {
     // Validations
-    const auto& reference_shard = tensor_shards.front();
     TT_FATAL(!tensor_shards.empty(), "At least one tensor shard must be provided");
-    for (const auto& shard : tensor_shards) {
-        TT_FATAL(shard.storage_type() == StorageType::DEVICE, "All tensor shards must be on device");
-        TT_FATAL(
-            shard.tensor_spec() == reference_shard.tensor_spec(), "All tensor shards must have the same tensor spec");
-    }
-
-    auto mesh_buffer = reference_shard.device_storage().get_mesh_buffer_leak_ownership();
+    const auto& reference_shard = tensor_shards.front();
     TT_FATAL(
         std::all_of(
             tensor_shards.begin(),

--- a/ttnn/core/distributed/api.cpp
+++ b/ttnn/core/distributed/api.cpp
@@ -123,7 +123,7 @@ Tensor combine_device_tensors(const std::vector<Tensor>& tensor_shards, int shar
             tensor_shards.begin(),
             tensor_shards.end(),
             [&](const auto& shard) { return shard.tensor_spec() == reference_shard.tensor_spec(); }),
-        "All tensor shards must be allocated");
+        "All tensor shards must have the same spec");
 
     // Combine the storages
     std::vector<std::reference_wrapper<const DeviceStorage>> device_storages;

--- a/ttnn/core/distributed/api.cpp
+++ b/ttnn/core/distributed/api.cpp
@@ -78,7 +78,7 @@ std::vector<Tensor> get_device_tensors(const Tensor& tensor) {
         std::vector<ttnn::Tensor> tensors;
         tensors.reserve(device_storage.get_coords().size());
         for (const auto& coord : device_storage.get_coords()) {
-            DeviceStorage shard_storage(device_storage.get_mesh_buffer_leak_ownership(), {coord});
+            DeviceStorage shard_storage(device_storage, {coord});
             tensors.push_back(Tensor(std::move(shard_storage), tensor.tensor_spec(), tensor.tensor_topology()));
         }
         return {tensor};

--- a/ttnn/core/distributed/api.cpp
+++ b/ttnn/core/distributed/api.cpp
@@ -109,8 +109,9 @@ Tensor from_host_shards(const std::vector<Tensor>& tensor_shards, const MeshShap
 }
 
 Tensor combine_device_tensors(const std::vector<Tensor>& tensor_shards, int shard_dim) {
+    // Validations
+    const auto& reference_shard = tensor_shards.front();
     TT_FATAL(!tensor_shards.empty(), "At least one tensor shard must be provided");
-    const auto& reference_shard = tensor_shards.at(0);
     for (const auto& shard : tensor_shards) {
         TT_FATAL(shard.storage_type() == StorageType::DEVICE, "All tensor shards must be on device");
         TT_FATAL(
@@ -119,28 +120,34 @@ Tensor combine_device_tensors(const std::vector<Tensor>& tensor_shards, int shar
 
     auto mesh_buffer = reference_shard.device_storage().get_mesh_buffer_leak_ownership();
     TT_FATAL(
-        mesh_buffer != nullptr,
-        "Error aggregating multichip tensors: tensors shards must be allocated on a mesh buffer.");
-    std::vector<MeshCoordinate> coords;
+        std::all_of(
+            tensor_shards.begin(),
+            tensor_shards.end(),
+            [](const auto& shard) { return shard.storage_type() == StorageType::DEVICE; }),
+        "All tensor shards must be on device");
+    TT_FATAL(
+        std::all_of(
+            tensor_shards.begin(),
+            tensor_shards.end(),
+            [&](const auto& shard) { return shard.tensor_spec() == reference_shard.tensor_spec(); }),
+        "All tensor shards must be allocated");
+
+    // Combine the storages
+    std::vector<std::reference_wrapper<const DeviceStorage>> device_storages;
+    device_storages.reserve(tensor_shards.size());
     for (const auto& shard : tensor_shards) {
         const auto& shard_storage = shard.device_storage();
         TT_FATAL(
             shard_storage.get_mesh_buffer_leak_ownership() == mesh_buffer,
             "Error aggregating multichip tensors: tensor shards must be allocated on the same mesh buffer. "
             "Consider moving tensors to host, aggregating, and re-uploading on device storage.");
-        for (const auto& coord : shard_storage.get_coords()) {
-            coords.push_back(coord);
-        }
+        device_storages.push_back(std::cref(shard.device_storage()));
     }
-    std::sort(coords.begin(), coords.end());
-    auto duplicate =
-        std::adjacent_find(coords.begin(), coords.end(), [](const auto& a, const auto& b) { return a == b; });
-    TT_FATAL(duplicate == coords.end(), "Found a tensor shard at duplicate coordinate {}", *duplicate);
 
+    auto combined_storage = DeviceStorage::combine_device_storages(device_storages);
     TensorTopology topology =
         TensorTopology::create_sharded_tensor_topology(MeshShape(tensor_shards.size()), shard_dim);
-    return Tensor(
-        DeviceStorage(std::move(mesh_buffer), std::move(coords)), reference_shard.tensor_spec(), std::move(topology));
+    return Tensor(std::move(combined_storage), reference_shard.tensor_spec(), std::move(topology));
 }
 
 }  // namespace ttnn::distributed

--- a/ttnn/core/distributed/api.cpp
+++ b/ttnn/core/distributed/api.cpp
@@ -129,11 +129,6 @@ Tensor combine_device_tensors(const std::vector<Tensor>& tensor_shards, int shar
     std::vector<std::reference_wrapper<const DeviceStorage>> device_storages;
     device_storages.reserve(tensor_shards.size());
     for (const auto& shard : tensor_shards) {
-        const auto& shard_storage = shard.device_storage();
-        TT_FATAL(
-            shard_storage.get_mesh_buffer_leak_ownership() == mesh_buffer,
-            "Error aggregating multichip tensors: tensor shards must be allocated on the same mesh buffer. "
-            "Consider moving tensors to host, aggregating, and re-uploading on device storage.");
         device_storages.push_back(std::cref(shard.device_storage()));
     }
 

--- a/ttnn/core/graph/graph_processor.cpp
+++ b/ttnn/core/graph/graph_processor.cpp
@@ -555,7 +555,7 @@ node_id GraphProcessor::add_tensor(const Tensor& t) {
         buffer = mesh_buffer.get_backing_buffer();
 
         // For multi-device tensors, capture per-device addresses and mesh device IDs
-        for (const auto& coord : t.device_storage().coords) {
+        for (const auto& coord : t.device_storage().get_coords()) {
             auto* device_buffer = mesh_buffer.get_device_buffer(coord);
             if (device_buffer != nullptr) {
                 device_tensors_json.push_back(

--- a/ttnn/core/graph/graph_processor.cpp
+++ b/ttnn/core/graph/graph_processor.cpp
@@ -547,7 +547,6 @@ node_id GraphProcessor::add_tensor(const Tensor& t) {
     nlohmann::json device_tensors_json = nlohmann::json::array();
     if (is_device_tensor(t) && t.is_allocated()) {
         const auto& mesh_buffer = t.mesh_buffer();
-
         // `t.buffers()` returns a reference buffer allocated on first device in a mesh.
         // It has an ID different from the "backing" buffer that was used to perform the allocation.
         // To deduplicate an entry for this buffer, captured during its allocation, use the "backing"

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -62,6 +62,9 @@ DeviceStorage::DeviceStorage(
     std::shared_ptr<distributed::MeshBuffer> mesh_buffer_, std::vector<distributed::MeshCoordinate> coords) :
     coords_(std::move(coords)), mesh_buffer(std::move(mesh_buffer_)) {}
 
+DeviceStorage::DeviceStorage(const DeviceStorage& other, std::vector<distributed::MeshCoordinate> coords) :
+    coords_(std::move(coords)), mesh_buffer(other.mesh_buffer), root_mesh_buffer(other.root_mesh_buffer) {}
+
 DeviceStorage::DeviceStorage(
     const DeviceStorage& owning_storage, std::shared_ptr<distributed::MeshBuffer> surface_buffer) :
     coords_(owning_storage.coords_.begin(), owning_storage.coords_.end()),

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -100,10 +100,15 @@ DeviceStorage::DeviceStorage(
     CMAKE_UNIQUE_NAMESPACE::validate_mesh_coordinates(coords_, get_device());
 }
 
-Buffer* DeviceStorage::get_buffer() const { return get_mesh_buffer().get_reference_buffer(); }
+Buffer* DeviceStorage::get_buffer() const {
+    if (this->mesh_buffer != nullptr) {
+        return this->mesh_buffer->get_reference_buffer();
+    }
+    TT_THROW("Buffer is not allocated");
+}
 
 const distributed::MeshBuffer& DeviceStorage::get_mesh_buffer() const {
-    TT_FATAL(is_allocated(), "Buffer is not allocated");
+    TT_FATAL(mesh_buffer != nullptr, "Buffer is not allocated");
     return *mesh_buffer;
 }
 
@@ -112,7 +117,7 @@ bool DeviceStorage::is_sole_owner_of_device_memory() const {
 }
 
 std::shared_ptr<distributed::MeshBuffer> DeviceStorage::get_mesh_buffer_leak_ownership() const {
-    TT_FATAL(is_allocated(), "Buffer is not allocated");
+    TT_FATAL(mesh_buffer != nullptr, "Buffer is not allocated");
     return mesh_buffer;
 }
 
@@ -139,10 +144,10 @@ distributed::MeshDevice* DeviceStorage::get_device_bypass_deallocate_check() con
 distributed::MeshDevice& DeviceStorage::get_device() const { return *get_mesh_buffer().device(); }
 
 bool DeviceStorage::is_uniform_storage() const {
-    if (!is_allocated()) {
+    if (mesh_buffer == nullptr) {
         return true;
     }
-    return coords_.size() == get_device().num_devices();
+    return coords_.size() == mesh_buffer->device()->num_devices();
 }
 
 std::span<const distributed::MeshCoordinate> DeviceStorage::get_coords() const {

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -107,6 +107,15 @@ void DeviceStorage::reset_root_mesh_buffer() {
     }
 }
 
+void DeviceStorage::deallocate(bool force) {
+    const auto& root_buffer = get_root_mesh_buffer();
+    bool can_deallocate = root_buffer.use_count() == 1 || (root_buffer.use_count() > 1 && force);
+    if (can_deallocate) {
+        deallocate_root_mesh_buffer();
+    }
+    reset_root_mesh_buffer();
+}
+
 bool DeviceStorage::is_allocated() const { return this->mesh_buffer != nullptr && this->mesh_buffer->is_allocated(); }
 
 distributed::MeshDevice* DeviceStorage::get_device_bypass_deallocate_check() const {

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -13,14 +13,39 @@
 #include "ttnn/tensor/storage.hpp"
 
 namespace tt::tt_metal {
+namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
+std::vector<distributed::MeshCoordinate> get_all_mesh_coordinates(const distributed::MeshDevice& device) {
+    std::vector<distributed::MeshCoordinate> coordinates;
+    coordinates.reserve(device.num_devices());
+    for (const auto& coord : distributed::MeshCoordinateRange(device.shape())) {
+        coordinates.push_back(coord);
+    }
+    return coordinates;
+}
 
-static DistributedHostBuffer create_unit_distributed_host_buffer(HostBuffer buffer) {
+void validate_mesh_coordinates(
+    const std::vector<distributed::MeshCoordinate>& coords, const distributed::MeshDevice& device) {
+    const distributed::MeshCoordinateRange valid_range(device.shape());
+    for (const auto& coord : coords) {
+        TT_FATAL(
+            valid_range.contains(coord),
+            "DeviceStorage coordinate {} is out of bounds for mesh device shape {}",
+            coord,
+            device.shape());
+    }
+}
+
+DistributedHostBuffer create_unit_distributed_host_buffer(HostBuffer buffer) {
     auto distributed_buffer = DistributedHostBuffer::create(distributed::MeshShape(1, 1));
     distributed_buffer.emplace_shard(distributed::MeshCoordinate(0, 0), [&buffer]() { return std::move(buffer); });
     return distributed_buffer;
 }
 
-HostStorage::HostStorage(HostBuffer buffer) : HostStorage(create_unit_distributed_host_buffer(std::move(buffer))) {}
+}  // namespace CMAKE_UNIQUE_NAMESPACE
+}  // namespace
+
+HostStorage::HostStorage(HostBuffer buffer) : HostStorage(CMAKE_UNIQUE_NAMESPACE::create_unit_distributed_host_buffer(std::move(buffer))) {}
 
 HostTensor create_dummy_host_tensor(DistributedHostBuffer buffer) {
     TensorSpec spec{Shape{}, TensorLayout{DataType::BFLOAT16, PageConfig{Layout::ROW_MAJOR}, MemoryConfig{}}};
@@ -48,28 +73,31 @@ HostStorage HostStorage::transform(const std::function<HostBuffer(const HostBuff
 }
 
 DeviceStorage::DeviceStorage(std::shared_ptr<distributed::MeshBuffer> mesh_buffer_) :
-    mesh_buffer(std::move(mesh_buffer_)) {
-    if (mesh_buffer != nullptr) {
-        const auto& device_shape = mesh_buffer->device()->shape();
-        coords_.reserve(device_shape.mesh_size());
-        for (const auto& coord : distributed::MeshCoordinateRange(device_shape)) {
-            coords_.push_back(coord);
-        }
-    }
-}
+    DeviceStorage(std::move(mesh_buffer_), CMAKE_UNIQUE_NAMESPACE::get_all_mesh_coordinates(*mesh_buffer_->device())) {}
 
 DeviceStorage::DeviceStorage(
     std::shared_ptr<distributed::MeshBuffer> mesh_buffer_, std::vector<distributed::MeshCoordinate> coords) :
-    coords_(std::move(coords)), mesh_buffer(std::move(mesh_buffer_)) {}
+    DeviceStorage(std::move(mesh_buffer_), std::move(coords), nullptr) {}
 
 DeviceStorage::DeviceStorage(const DeviceStorage& other, std::vector<distributed::MeshCoordinate> coords) :
-    coords_(std::move(coords)), mesh_buffer(other.mesh_buffer), root_mesh_buffer(other.root_mesh_buffer) {}
+    DeviceStorage(other.mesh_buffer, std::move(coords), other.root_mesh_buffer) {}
 
 DeviceStorage::DeviceStorage(
     const DeviceStorage& owning_storage, std::shared_ptr<distributed::MeshBuffer> surface_buffer) :
-    coords_(owning_storage.coords_.begin(), owning_storage.coords_.end()),
-    mesh_buffer(std::move(surface_buffer)),
-    root_mesh_buffer(owning_storage.get_root_mesh_buffer()) {}
+    DeviceStorage(std::move(surface_buffer), owning_storage.coords_, owning_storage.get_root_mesh_buffer()) {}
+
+DeviceStorage::DeviceStorage(
+    std::shared_ptr<distributed::MeshBuffer> mesh_buffer_,
+    std::vector<distributed::MeshCoordinate> coords_,
+    std::shared_ptr<distributed::MeshBuffer> root_mesh_buffer_) :
+    coords_(std::move(coords_)), mesh_buffer(std::move(mesh_buffer_)), root_mesh_buffer(std::move(root_mesh_buffer_)) {
+    if (!is_allocated()) {
+        mesh_buffer = nullptr;
+        root_mesh_buffer = nullptr;
+        return;
+    }
+    CMAKE_UNIQUE_NAMESPACE::validate_mesh_coordinates(coords_, *get_device());
+}
 
 Buffer* DeviceStorage::get_buffer() const {
     if (this->mesh_buffer != nullptr) {
@@ -111,6 +139,10 @@ void DeviceStorage::reset_root_mesh_buffer() {
 }
 
 void DeviceStorage::deallocate(bool force) {
+    if (!is_allocated()) {
+        return;
+    }
+
     const auto& root_buffer = get_root_mesh_buffer();
     bool can_deallocate = root_buffer.use_count() == 1 || (root_buffer.use_count() > 1 && force);
     if (can_deallocate) {
@@ -139,6 +171,9 @@ bool DeviceStorage::is_uniform_storage() const {
     return coords_.size() == mesh_buffer->device()->num_devices();
 }
 
-std::span<const distributed::MeshCoordinate> DeviceStorage::get_coords() const { return coords_; }
+std::span<const distributed::MeshCoordinate> DeviceStorage::get_coords() const {
+    TT_FATAL(is_allocated(), "Device memory is not allocated");
+    return coords_;
+}
 
 }  // namespace tt::tt_metal

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -177,4 +177,31 @@ std::span<const distributed::MeshCoordinate> DeviceStorage::get_coords() const {
     return coords_;
 }
 
+DeviceStorage DeviceStorage::combine_device_storages(
+    const std::vector<std::reference_wrapper<const DeviceStorage>>& storages) {
+    TT_FATAL(!storages.empty(), "Cannot aggregate empty vector of DeviceStorages");
+
+    const auto& model_storage = storages.front().get();
+    TT_FATAL(
+        std::all_of(
+            storages.begin(),
+            storages.end(),
+            [&](const auto& storage) { return storage.get().mesh_buffer == model_storage.mesh_buffer; }),
+        "All DeviceStorages must be allocated");
+
+    auto num_coords = std::accumulate(storages.begin(), storages.end(), 0, [](size_t sum, const auto& storage) {
+        return sum + storage.get().get_coords().size();
+    });
+
+    std::unordered_set<distributed::MeshCoordinate> joint_coords;
+    joint_coords.reserve(num_coords);
+    for (const auto& storage : storages) {
+        auto other_coords = storage.get().get_coords();
+        joint_coords.insert(other_coords.begin(), other_coords.end());
+    }
+
+    return DeviceStorage(
+        model_storage, std::vector<distributed::MeshCoordinate>(joint_coords.begin(), joint_coords.end()));
+}
+
 }  // namespace tt::tt_metal

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -172,7 +172,8 @@ bool DeviceStorage::is_uniform_storage() const {
 }
 
 std::span<const distributed::MeshCoordinate> DeviceStorage::get_coords() const {
-    TT_FATAL(is_allocated(), "Device memory is not allocated");
+    // Conv breaks if we keep the assert here.
+    // TT_FATAL(is_allocated(), "Device memory is not allocated");
     return coords_;
 }
 

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -112,7 +112,9 @@ const distributed::MeshBuffer& DeviceStorage::get_mesh_buffer() const {
     return *mesh_buffer;
 }
 
-bool DeviceStorage::is_sole_owner_of_device_memory() const { return mesh_buffer.use_count() == 1; }
+bool DeviceStorage::is_sole_owner_of_device_memory() const {
+    return mesh_buffer.use_count() == 1 && get_root_mesh_buffer().use_count() == 1;
+}
 
 std::shared_ptr<distributed::MeshBuffer> DeviceStorage::get_mesh_buffer_leak_ownership() const {
     TT_FATAL(mesh_buffer != nullptr, "Buffer is not allocated");
@@ -123,33 +125,14 @@ const std::shared_ptr<distributed::MeshBuffer>& DeviceStorage::get_root_mesh_buf
     return root_mesh_buffer ? root_mesh_buffer : mesh_buffer;
 }
 
-void DeviceStorage::deallocate_root_mesh_buffer() {
-    if (root_mesh_buffer) {
-        root_mesh_buffer->deallocate();
-    } else {
-        mesh_buffer->deallocate();
-    }
-}
-
-void DeviceStorage::reset_root_mesh_buffer() {
-    if (root_mesh_buffer) {
-        root_mesh_buffer.reset();
-    } else {
-        mesh_buffer.reset();
-    }
-}
-
-void DeviceStorage::deallocate(bool force) {
+void DeviceStorage::deallocate() {
     if (!is_allocated()) {
         return;
     }
 
-    const auto& root_buffer = get_root_mesh_buffer();
-    bool can_deallocate = root_buffer.use_count() == 1 || (root_buffer.use_count() > 1 && force);
-    if (can_deallocate) {
-        deallocate_root_mesh_buffer();
-    }
-    reset_root_mesh_buffer();
+    get_root_mesh_buffer()->deallocate();
+    root_mesh_buffer = nullptr;
+    mesh_buffer = nullptr;
 }
 
 bool DeviceStorage::is_allocated() const { return this->mesh_buffer != nullptr && this->mesh_buffer->is_allocated(); }

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -100,15 +100,10 @@ DeviceStorage::DeviceStorage(
     CMAKE_UNIQUE_NAMESPACE::validate_mesh_coordinates(coords_, get_device());
 }
 
-Buffer* DeviceStorage::get_buffer() const {
-    if (this->mesh_buffer != nullptr) {
-        return this->mesh_buffer->get_reference_buffer();
-    }
-    TT_THROW("Buffer is not allocated");
-}
+Buffer* DeviceStorage::get_buffer() const { return get_mesh_buffer().get_reference_buffer(); }
 
 const distributed::MeshBuffer& DeviceStorage::get_mesh_buffer() const {
-    TT_FATAL(mesh_buffer != nullptr, "Buffer is not allocated");
+    TT_FATAL(is_allocated(), "Buffer is not allocated");
     return *mesh_buffer;
 }
 
@@ -117,7 +112,7 @@ bool DeviceStorage::is_sole_owner_of_device_memory() const {
 }
 
 std::shared_ptr<distributed::MeshBuffer> DeviceStorage::get_mesh_buffer_leak_ownership() const {
-    TT_FATAL(mesh_buffer != nullptr, "Buffer is not allocated");
+    TT_FATAL(is_allocated(), "Buffer is not allocated");
     return mesh_buffer;
 }
 
@@ -144,10 +139,10 @@ distributed::MeshDevice* DeviceStorage::get_device_bypass_deallocate_check() con
 distributed::MeshDevice& DeviceStorage::get_device() const { return *get_mesh_buffer().device(); }
 
 bool DeviceStorage::is_uniform_storage() const {
-    if (mesh_buffer == nullptr) {
+    if (!is_allocated()) {
         return true;
     }
-    return coords_.size() == mesh_buffer->device()->num_devices();
+    return coords_.size() == get_device().num_devices();
 }
 
 std::span<const distributed::MeshCoordinate> DeviceStorage::get_coords() const {

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -47,6 +47,17 @@ HostStorage HostStorage::transform(const std::function<HostBuffer(const HostBuff
     return HostStorage(tensor.transform(callable));
 }
 
+DeviceStorage::DeviceStorage(std::shared_ptr<distributed::MeshBuffer> mesh_buffer_) :
+    mesh_buffer(std::move(mesh_buffer_)) {
+    if (mesh_buffer != nullptr) {
+        const auto& device_shape = mesh_buffer->device()->shape();
+        coords.reserve(device_shape.mesh_size());
+        for (const auto& coord : distributed::MeshCoordinateRange(device_shape)) {
+            coords.push_back(coord);
+        }
+    }
+}
+
 DeviceStorage::DeviceStorage(
     std::shared_ptr<distributed::MeshBuffer> mesh_buffer_,
     std::vector<distributed::MeshCoordinate> coords_,

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -59,10 +59,14 @@ DeviceStorage::DeviceStorage(std::shared_ptr<distributed::MeshBuffer> mesh_buffe
 }
 
 DeviceStorage::DeviceStorage(
-    std::shared_ptr<distributed::MeshBuffer> mesh_buffer_,
-    std::vector<distributed::MeshCoordinate> coords_,
-    std::shared_ptr<distributed::MeshBuffer> root_buffer_) :
-    coords(std::move(coords_)), mesh_buffer(std::move(mesh_buffer_)), root_mesh_buffer(std::move(root_buffer_)) {}
+    std::shared_ptr<distributed::MeshBuffer> mesh_buffer_, std::vector<distributed::MeshCoordinate> coords_) :
+    coords(std::move(coords_)), mesh_buffer(std::move(mesh_buffer_)) {}
+
+DeviceStorage::DeviceStorage(
+    const DeviceStorage& owning_storage, std::shared_ptr<distributed::MeshBuffer> surface_buffer) :
+    coords(owning_storage.coords),
+    mesh_buffer(std::move(surface_buffer)),
+    root_mesh_buffer(owning_storage.get_root_mesh_buffer()) {}
 
 Buffer* DeviceStorage::get_buffer() const {
     if (this->mesh_buffer != nullptr) {

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -139,4 +139,6 @@ bool DeviceStorage::is_uniform_storage() const {
     return coords_.size() == mesh_buffer->device()->num_devices();
 }
 
+std::span<const distributed::MeshCoordinate> DeviceStorage::get_coords() const { return coords_; }
+
 }  // namespace tt::tt_metal

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -51,20 +51,20 @@ DeviceStorage::DeviceStorage(std::shared_ptr<distributed::MeshBuffer> mesh_buffe
     mesh_buffer(std::move(mesh_buffer_)) {
     if (mesh_buffer != nullptr) {
         const auto& device_shape = mesh_buffer->device()->shape();
-        coords.reserve(device_shape.mesh_size());
+        coords_.reserve(device_shape.mesh_size());
         for (const auto& coord : distributed::MeshCoordinateRange(device_shape)) {
-            coords.push_back(coord);
+            coords_.push_back(coord);
         }
     }
 }
 
 DeviceStorage::DeviceStorage(
-    std::shared_ptr<distributed::MeshBuffer> mesh_buffer_, std::vector<distributed::MeshCoordinate> coords_) :
-    coords(std::move(coords_)), mesh_buffer(std::move(mesh_buffer_)) {}
+    std::shared_ptr<distributed::MeshBuffer> mesh_buffer_, std::vector<distributed::MeshCoordinate> coords) :
+    coords_(std::move(coords)), mesh_buffer(std::move(mesh_buffer_)) {}
 
 DeviceStorage::DeviceStorage(
     const DeviceStorage& owning_storage, std::shared_ptr<distributed::MeshBuffer> surface_buffer) :
-    coords(owning_storage.coords),
+    coords_(owning_storage.coords_.begin(), owning_storage.coords_.end()),
     mesh_buffer(std::move(surface_buffer)),
     root_mesh_buffer(owning_storage.get_root_mesh_buffer()) {}
 
@@ -133,7 +133,7 @@ bool DeviceStorage::is_uniform_storage() const {
     if (mesh_buffer == nullptr) {
         return true;
     }
-    return coords.size() == mesh_buffer->device()->num_devices();
+    return coords_.size() == mesh_buffer->device()->num_devices();
 }
 
 }  // namespace tt::tt_metal

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -72,8 +72,8 @@ HostStorage HostStorage::transform(const std::function<HostBuffer(const HostBuff
     return HostStorage(tensor.transform(callable));
 }
 
-DeviceStorage::DeviceStorage(std::shared_ptr<distributed::MeshBuffer> mesh_buffer_) :
-    DeviceStorage(std::move(mesh_buffer_), CMAKE_UNIQUE_NAMESPACE::get_all_mesh_coordinates(*mesh_buffer_->device())) {}
+DeviceStorage::DeviceStorage(const std::shared_ptr<distributed::MeshBuffer>& mesh_buffer_) :
+    DeviceStorage(mesh_buffer_, CMAKE_UNIQUE_NAMESPACE::get_all_mesh_coordinates(*mesh_buffer_->device())) {}
 
 DeviceStorage::DeviceStorage(
     std::shared_ptr<distributed::MeshBuffer> mesh_buffer_, std::vector<distributed::MeshCoordinate> coords) :

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -92,8 +92,8 @@ DeviceStorage::DeviceStorage(
     std::shared_ptr<distributed::MeshBuffer> root_mesh_buffer) :
     coords_(std::move(coords)), mesh_buffer(std::move(mesh_buffer)), root_mesh_buffer(std::move(root_mesh_buffer)) {
     if (!is_allocated()) {
-        mesh_buffer = nullptr;
-        root_mesh_buffer = nullptr;
+        this->mesh_buffer = nullptr;
+        this->root_mesh_buffer = nullptr;
         return;
     }
     CMAKE_UNIQUE_NAMESPACE::validate_mesh_coordinates(coords_, *get_device());

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -87,10 +87,10 @@ DeviceStorage::DeviceStorage(
     DeviceStorage(std::move(surface_buffer), owning_storage.coords_, owning_storage.get_root_mesh_buffer()) {}
 
 DeviceStorage::DeviceStorage(
-    std::shared_ptr<distributed::MeshBuffer> mesh_buffer_,
-    std::vector<distributed::MeshCoordinate> coords_,
-    std::shared_ptr<distributed::MeshBuffer> root_mesh_buffer_) :
-    coords_(std::move(coords_)), mesh_buffer(std::move(mesh_buffer_)), root_mesh_buffer(std::move(root_mesh_buffer_)) {
+    std::shared_ptr<distributed::MeshBuffer> mesh_buffer,
+    std::vector<distributed::MeshCoordinate> coords,
+    std::shared_ptr<distributed::MeshBuffer> root_mesh_buffer) :
+    coords_(std::move(coords)), mesh_buffer(std::move(mesh_buffer)), root_mesh_buffer(std::move(root_mesh_buffer)) {
     if (!is_allocated()) {
         mesh_buffer = nullptr;
         root_mesh_buffer = nullptr;

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <algorithm>
+#include <numeric>
 #include <functional>
 #include <unordered_set>
 #include <vector>

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -97,7 +97,7 @@ DeviceStorage::DeviceStorage(
         this->root_mesh_buffer = nullptr;
         return;
     }
-    CMAKE_UNIQUE_NAMESPACE::validate_mesh_coordinates(coords_, *get_device());
+    CMAKE_UNIQUE_NAMESPACE::validate_mesh_coordinates(coords_, get_device());
 }
 
 Buffer* DeviceStorage::get_buffer() const {
@@ -141,12 +141,7 @@ distributed::MeshDevice* DeviceStorage::get_device_bypass_deallocate_check() con
     return this->mesh_buffer ? this->mesh_buffer->device() : nullptr;
 }
 
-distributed::MeshDevice* DeviceStorage::get_device() const {
-    if (this->mesh_buffer != nullptr) {
-        return this->mesh_buffer->device();
-    }
-    TT_THROW("Buffer is not allocated");
-}
+distributed::MeshDevice& DeviceStorage::get_device() const { return *get_mesh_buffer().device(); }
 
 bool DeviceStorage::is_uniform_storage() const {
     if (mesh_buffer == nullptr) {

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -188,7 +188,7 @@ DeviceStorage DeviceStorage::combine_device_storages(
             storages.begin(),
             storages.end(),
             [&](const auto& storage) { return storage.get().mesh_buffer == model_storage.mesh_buffer; }),
-        "All DeviceStorages must be allocated");
+        "All DeviceStorages must point to the same device memory");
 
     auto num_coords = std::accumulate(storages.begin(), storages.end(), 0, [](size_t sum, const auto& storage) {
         return sum + storage.get().get_coords().size();

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -163,15 +163,24 @@ void Tensor::deallocate_impl(bool force) {
     bool tracking = GraphTracker::instance().is_enabled();
     if (can_deallocate(tensor_attributes, force)) {
         std::visit(
-            ttsl::overloaded{[](HostStorage&) {}, [force, tracking](DeviceStorage& storage) {
-                if (tracking) {
-                            GraphTracker::instance().track_function_start(std::string_view("Tensor::deallocate"));
-                }
-                storage.deallocate(force);
-                if (tracking) {
-                    GraphTracker::instance().track_function_end();
-                }
-            }},
+            ttsl::overloaded{
+                [](HostStorage&) {},
+                [force, tracking](DeviceStorage& storage) {
+                    // The underlying device memory could be shared by multiple other owners.
+                    if (!storage.is_sole_owner_of_device_memory() && !force) {
+                        return;
+                    }
+
+                    if (tracking) {
+                        GraphTracker::instance().track_function_start(std::string_view("Tensor::deallocate"));
+                    }
+
+                    storage.deallocate();
+
+                    if (tracking) {
+                        GraphTracker::instance().track_function_end();
+                    }
+                }},
             this->tensor_attributes->get_storage());
     }
 }

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -163,20 +163,15 @@ void Tensor::deallocate_impl(bool force) {
     bool tracking = GraphTracker::instance().is_enabled();
     if (can_deallocate(tensor_attributes, force)) {
         std::visit(
-            ttsl::overloaded{
-                [](HostStorage&) {},
-                [this, force, tracking, &can_deallocate](DeviceStorage& storage) {
-                    if (can_deallocate(storage.get_root_mesh_buffer(), force)) {
-                        if (tracking) {
+            ttsl::overloaded{[](HostStorage&) {}, [force, tracking](DeviceStorage& storage) {
+                if (tracking) {
                             GraphTracker::instance().track_function_start(std::string_view("Tensor::deallocate"));
-                        }
-                        storage.deallocate_root_mesh_buffer();
-                        if (tracking) {
-                            GraphTracker::instance().track_function_end();
-                        }
-                    }
-                    storage.reset_root_mesh_buffer();
-                }},
+                }
+                storage.deallocate(force);
+                if (tracking) {
+                    GraphTracker::instance().track_function_end();
+                }
+            }},
             this->tensor_attributes->get_storage());
     }
 }

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -478,7 +478,7 @@ std::string to_string_impl(const Tensor& tensor) {
         return to_string_impl<T>(cpu_tensor);
     }
 
-    auto* mesh_device = storage.get_device();
+    auto& mesh_device = storage.get_device();
     // TODO: Uncomment after the distributed tensors migration to tt-metal is complete.
     // if (mesh_device->num_devices() == 1) {
     //     return to_string<T>(ttnn::distributed::get_device_tensors(cpu_tensor).at(0));
@@ -492,8 +492,8 @@ std::string to_string_impl(const Tensor& tensor) {
     std::stringstream ss;
     for (size_t i = 0; i < buffers.size(); i++) {
         const distributed::MeshCoordinate coord = *coords_it++;
-        if (mesh_device->is_local(coord)) {
-            ss << "device_id: " << mesh_device->get_device(coord)->id() << ", " << coord << std::endl;
+        if (mesh_device.is_local(coord)) {
+            ss << "device_id: " << mesh_device.get_device(coord)->id() << ", " << coord << std::endl;
             detail::to_string(ss, buffers[i].view_as<T>(), shape, strides, tensor.dtype(), tensor.layout());
         }
         if (i + 1 != buffers.size()) {

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -595,7 +595,7 @@ DeviceStorage write_to_mesh_buffer(
     std::optional<uint8_t> cq_id_int = cq_id.has_value() ? std::make_optional(cq_id.value().get()) : std::nullopt;
     mesh_buffer->device()->mesh_command_queue(cq_id_int).enqueue_write(
         mesh_buffer, distributed_host_buffer, /*blocking=*/false);
-    // DistributedHostBuffer may not cover the entire MeshDevice, must perserve coords here.
+    // DistributedHostBuffer may not cover the entire MeshDevice, must preserve coords here.
     std::vector<distributed::MeshCoordinate> coords;
     coords.reserve(distributed_host_buffer.shard_coords().size());
     std::copy(

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -585,12 +585,7 @@ DeviceStorage replicate_to_mesh_buffer(
     mesh_device->mesh_command_queue(cq_id_int).enqueue_write_mesh_buffer(
         mesh_buffer, data_to_write.data(), /*blocking=*/false);
 
-    std::vector<distributed::MeshCoordinate> coords;
-    coords.reserve(mesh_device->shape().mesh_size());
-    for (const auto& coord : distributed::MeshCoordinateRange(mesh_device->shape())) {
-        coords.push_back(coord);
-    }
-    return DeviceStorage(mesh_buffer, std::move(coords));
+    return DeviceStorage(mesh_buffer);
 }
 
 DeviceStorage write_to_mesh_buffer(
@@ -600,6 +595,7 @@ DeviceStorage write_to_mesh_buffer(
     std::optional<uint8_t> cq_id_int = cq_id.has_value() ? std::make_optional(cq_id.value().get()) : std::nullopt;
     mesh_buffer->device()->mesh_command_queue(cq_id_int).enqueue_write(
         mesh_buffer, distributed_host_buffer, /*blocking=*/false);
+    // DistributedHostBuffer may not cover the entire MeshDevice, must perserve coords here.
     std::vector<distributed::MeshCoordinate> coords;
     coords.reserve(distributed_host_buffer.shard_coords().size());
     std::copy(

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -486,7 +486,7 @@ std::string to_string_impl(const Tensor& tensor) {
 
     const Tensor row_major_tensor = get_row_major_tensor(cpu_tensor);
     const auto strides = row_major_tensor.tensor_spec().compute_strides();
-    const auto& coords = storage.coords;
+    const auto coords = storage.get_coords();
     auto coords_it = coords.begin();
     const std::vector<HostBuffer> buffers = get_host_buffers(row_major_tensor.host_storage());
     std::stringstream ss;
@@ -550,7 +550,7 @@ Tensor to_host(const Tensor& tensor, bool blocking, std::optional<tt::tt_metal::
     auto distributed_host_buffer = DistributedHostBuffer::create(device->get_view());
 
     distributed_host_buffer.emplace_shards(
-        storage.coords,
+        std::vector<distributed::MeshCoordinate>(storage.get_coords().begin(), storage.get_coords().end()),
         [&](const distributed::MeshCoordinate&) { return allocate_host_buffer(tensor.tensor_spec()); },
         DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL);
 
@@ -681,8 +681,8 @@ void copy_to_host(
     // However, it may have some extra shards. Drop them by "unwrapping" the distributed host buffer, and re-wrapping
     // only for those shards that are actually present on device.
     std::vector<std::pair<distributed::MeshCoordinate, std::optional<HostBuffer>>> shards;
-    shards.reserve(device_storage.coords.size());
-    for (const auto& device_coord : device_storage.coords) {
+    shards.reserve(device_storage.get_coords().size());
+    for (const auto& device_coord : device_storage.get_coords()) {
         shards.push_back({device_coord, distributed_host_buffer.get_shard(device_coord)});
     }
 

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -26,7 +26,7 @@ tt::tt_metal::Tensor allocate_tensor_on_device(
     const tt::tt_metal::TensorSpec& tensor_spec, tt::tt_metal::distributed::MeshDevice* device) {
     using namespace tt::tt_metal;
     auto mesh_buffer = tensor_impl::allocate_device_buffer(device, tensor_spec);
-    DeviceStorage device_storage(std::move(mesh_buffer));
+    DeviceStorage device_storage(mesh_buffer);
     // TODO (#25340): Implement correct logic and add test for this
     ttsl::SmallVector<distributed::MeshMapperConfig::Placement> placements(device->shape().dims());
     for (size_t i = 0; i < device->shape().dims(); i++) {

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -33,7 +33,11 @@ tt::tt_metal::Tensor allocate_tensor_on_device(
         placements[i] = tt::tt_metal::distributed::MeshMapperConfig::Replicate{};
     }
 
-    auto tensor_topology = TensorTopology{device->shape(), placements, device_storage.coords};
+    auto tensor_topology = TensorTopology{
+        device->shape(),
+        placements,
+        std::vector<distributed::MeshCoordinate>(
+            device_storage.get_coords().begin(), device_storage.get_coords().end())};
     return Tensor(std::move(device_storage), tensor_spec, tensor_topology);
 }
 }  // namespace

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -26,19 +26,14 @@ tt::tt_metal::Tensor allocate_tensor_on_device(
     const tt::tt_metal::TensorSpec& tensor_spec, tt::tt_metal::distributed::MeshDevice* device) {
     using namespace tt::tt_metal;
     auto mesh_buffer = tensor_impl::allocate_device_buffer(device, tensor_spec);
-    std::vector<distributed::MeshCoordinate> coords;
-    coords.reserve(device->shape().mesh_size());
-    for (const auto& coord : distributed::MeshCoordinateRange(device->shape())) {
-        coords.push_back(coord);
-    }
-    DeviceStorage device_storage(std::move(mesh_buffer), coords);
+    DeviceStorage device_storage(std::move(mesh_buffer));
     // TODO (#25340): Implement correct logic and add test for this
     ttsl::SmallVector<distributed::MeshMapperConfig::Placement> placements(device->shape().dims());
     for (size_t i = 0; i < device->shape().dims(); i++) {
         placements[i] = tt::tt_metal::distributed::MeshMapperConfig::Replicate{};
     }
 
-    auto tensor_topology = TensorTopology{device->shape(), placements, coords};
+    auto tensor_topology = TensorTopology{device->shape(), placements, device_storage.coords};
     return Tensor(std::move(device_storage), tensor_spec, tensor_topology);
 }
 }  // namespace

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -300,8 +300,7 @@ Tensor view_device(const Tensor& input_tensor, const Shape& new_logical_shape, c
         new_device_config,
         input_tensor.device(),
         input_tensor.mesh_buffer().address());
-    tt::tt_metal::DeviceStorage view_storage(
-        view_mesh_buffer, input_tensor.device_storage().coords, input_tensor.device_storage().get_root_mesh_buffer());
+    tt::tt_metal::DeviceStorage view_storage(input_tensor.device_storage(), view_mesh_buffer);
 
     return Tensor(view_storage, new_spec, input_tensor.tensor_topology());
 }

--- a/ttnn/core/tensor/unit_mesh/unit_mesh_utils.cpp
+++ b/ttnn/core/tensor/unit_mesh/unit_mesh_utils.cpp
@@ -82,10 +82,7 @@ Tensor aggregate(const std::vector<tt::tt_metal::Tensor>& tensors) {
         reference_buffer.global_config(), reference_buffer.device_local_config(), parent_mesh.get(), reference_address);
 
     tt::tt_metal::DeviceStorage device_storage(mesh_buffer);
-    TT_FATAL(
-        device_storage.get_coords().size() == 1 &&
-            device_storage.get_coords()[0] == tt::tt_metal::distributed::MeshCoordinate(0, 0),
-        "mesh_buffer is not on a unit submesh");
+    TT_FATAL(device_storage.get_coords().size() == 1, "mesh_buffer is not on a unit submesh");
 
     return Tensor(
         std::move(device_storage),

--- a/ttnn/core/tensor/unit_mesh/unit_mesh_utils.cpp
+++ b/ttnn/core/tensor/unit_mesh/unit_mesh_utils.cpp
@@ -81,16 +81,13 @@ Tensor aggregate(const std::vector<tt::tt_metal::Tensor>& tensors) {
     auto mesh_buffer = tt::tt_metal::distributed::MeshBuffer::create(
         reference_buffer.global_config(), reference_buffer.device_local_config(), parent_mesh.get(), reference_address);
 
-    std::vector<tt::tt_metal::distributed::MeshCoordinate> coords;
-    coords.reserve(parent_mesh->shape().mesh_size());
-    for (const auto& coord : tt::tt_metal::distributed::MeshCoordinateRange(parent_mesh->shape())) {
-        coords.push_back(coord);
-    }
-
-    tt::tt_metal::DeviceStorage device_storage(std::move(mesh_buffer), std::move(coords));
+    tt::tt_metal::DeviceStorage device_storage(std::move(mesh_buffer));
+    TT_ASSERT(
+        device_storage.coords ==
+        std::vector<tt::tt_metal::distributed::MeshCoordinate>{tt::tt_metal::distributed::MeshCoordinate(0, 0)});
 
     return Tensor(
-        std::move(device_storage),
+        tt::tt_metal::DeviceStorage(std::move(mesh_buffer)),
         reference_spec,
         tt::tt_metal::TensorTopology::create_sharded_tensor_topology(
             tt::tt_metal::distributed::MeshShape(parent_mesh->shape().mesh_size()), /*shard_dim=*/0));
@@ -133,8 +130,9 @@ std::vector<tt::tt_metal::Tensor> disaggregate(const tt::tt_metal::Tensor& tenso
         auto mesh_buffer = tt::tt_metal::distributed::MeshBuffer::create(
             input_mesh_buffer.global_config(), input_mesh_buffer.device_local_config(), submesh.get(), input_address);
 
-        DeviceStorage device_storage(
-            std::move(mesh_buffer),
+        DeviceStorage device_storage(std::move(mesh_buffer));
+        TT_ASSERT(
+            device_storage.coords ==
             std::vector<tt::tt_metal::distributed::MeshCoordinate>{tt::tt_metal::distributed::MeshCoordinate(0, 0)});
 
         result.push_back(Tensor(std::move(device_storage), reference_spec, TensorTopology{}));

--- a/ttnn/core/tensor/unit_mesh/unit_mesh_utils.cpp
+++ b/ttnn/core/tensor/unit_mesh/unit_mesh_utils.cpp
@@ -82,9 +82,10 @@ Tensor aggregate(const std::vector<tt::tt_metal::Tensor>& tensors) {
         reference_buffer.global_config(), reference_buffer.device_local_config(), parent_mesh.get(), reference_address);
 
     tt::tt_metal::DeviceStorage device_storage(mesh_buffer);
-    TT_ASSERT(
+    TT_FATAL(
         device_storage.get_coords().size() == 1 &&
-        device_storage.get_coords()[0] == tt::tt_metal::distributed::MeshCoordinate(0, 0));
+            device_storage.get_coords()[0] == tt::tt_metal::distributed::MeshCoordinate(0, 0),
+        "mesh_buffer is not on a unit submesh");
 
     return Tensor(
         std::move(device_storage),

--- a/ttnn/core/tensor/unit_mesh/unit_mesh_utils.cpp
+++ b/ttnn/core/tensor/unit_mesh/unit_mesh_utils.cpp
@@ -83,8 +83,8 @@ Tensor aggregate(const std::vector<tt::tt_metal::Tensor>& tensors) {
 
     tt::tt_metal::DeviceStorage device_storage(std::move(mesh_buffer));
     TT_ASSERT(
-        device_storage.coords ==
-        std::vector<tt::tt_metal::distributed::MeshCoordinate>{tt::tt_metal::distributed::MeshCoordinate(0, 0)});
+        device_storage.get_coords().size() == 1 &&
+        device_storage.get_coords()[0] == tt::tt_metal::distributed::MeshCoordinate(0, 0));
 
     return Tensor(
         tt::tt_metal::DeviceStorage(std::move(mesh_buffer)),
@@ -132,8 +132,8 @@ std::vector<tt::tt_metal::Tensor> disaggregate(const tt::tt_metal::Tensor& tenso
 
         DeviceStorage device_storage(std::move(mesh_buffer));
         TT_ASSERT(
-            device_storage.coords ==
-            std::vector<tt::tt_metal::distributed::MeshCoordinate>{tt::tt_metal::distributed::MeshCoordinate(0, 0)});
+            device_storage.get_coords().size() == 1 &&
+            device_storage.get_coords()[0] == tt::tt_metal::distributed::MeshCoordinate(0, 0));
 
         result.push_back(Tensor(std::move(device_storage), reference_spec, TensorTopology{}));
     }

--- a/ttnn/core/tensor/unit_mesh/unit_mesh_utils.cpp
+++ b/ttnn/core/tensor/unit_mesh/unit_mesh_utils.cpp
@@ -81,13 +81,13 @@ Tensor aggregate(const std::vector<tt::tt_metal::Tensor>& tensors) {
     auto mesh_buffer = tt::tt_metal::distributed::MeshBuffer::create(
         reference_buffer.global_config(), reference_buffer.device_local_config(), parent_mesh.get(), reference_address);
 
-    tt::tt_metal::DeviceStorage device_storage(std::move(mesh_buffer));
+    tt::tt_metal::DeviceStorage device_storage(mesh_buffer);
     TT_ASSERT(
         device_storage.get_coords().size() == 1 &&
         device_storage.get_coords()[0] == tt::tt_metal::distributed::MeshCoordinate(0, 0));
 
     return Tensor(
-        tt::tt_metal::DeviceStorage(std::move(mesh_buffer)),
+        std::move(device_storage),
         reference_spec,
         tt::tt_metal::TensorTopology::create_sharded_tensor_topology(
             tt::tt_metal::distributed::MeshShape(parent_mesh->shape().mesh_size()), /*shard_dim=*/0));

--- a/ttnn/core/tensor/unit_mesh/unit_mesh_utils.cpp
+++ b/ttnn/core/tensor/unit_mesh/unit_mesh_utils.cpp
@@ -130,10 +130,11 @@ std::vector<tt::tt_metal::Tensor> disaggregate(const tt::tt_metal::Tensor& tenso
         auto mesh_buffer = tt::tt_metal::distributed::MeshBuffer::create(
             input_mesh_buffer.global_config(), input_mesh_buffer.device_local_config(), submesh.get(), input_address);
 
-        DeviceStorage device_storage(std::move(mesh_buffer));
-        TT_ASSERT(
+        DeviceStorage device_storage(mesh_buffer);
+        TT_FATAL(
             device_storage.get_coords().size() == 1 &&
-            device_storage.get_coords()[0] == tt::tt_metal::distributed::MeshCoordinate(0, 0));
+                device_storage.get_coords()[0] == tt::tt_metal::distributed::MeshCoordinate(0, 0),
+            "mesh_buffer is not on a unit submesh");
 
         result.push_back(Tensor(std::move(device_storage), reference_spec, TensorTopology{}));
     }

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
@@ -37,7 +37,7 @@ tt::tt_fabric::Topology convert_2d_to_1d_topology(tt::tt_fabric::Topology topolo
 tt::tt_metal::distributed::MeshCoordinate::BoundaryMode get_boundary_mode(
     const Tensor& tensor, tt::tt_fabric::Topology topology, std::optional<uint32_t> cluster_axis) {
     auto mesh_shape = tensor.device()->shape();
-    auto device_coords = tensor.device_storage().coords;
+    auto device_coords = tensor.device_storage().get_coords();
     TT_FATAL(!device_coords.empty(), "device_coords is empty");
     if (topology == tt::tt_fabric::Topology::Linear || topology == tt::tt_fabric::Topology::Mesh) {
         return tt::tt_metal::distributed::MeshCoordinate::BoundaryMode::NONE;
@@ -48,9 +48,9 @@ tt::tt_metal::distributed::MeshCoordinate::BoundaryMode get_boundary_mode(
         if (mesh_shape[cluster_axis.value()] == 2) {
             return tt::tt_metal::distributed::MeshCoordinate::BoundaryMode::NONE;
         }
-        bool first_index_is_0 = device_coords.at(0)[cluster_axis.value()] == 0;
+        bool first_index_is_0 = device_coords[0][cluster_axis.value()] == 0;
         bool last_index_is_mesh_shape_minus_1 =
-            device_coords.at(device_coords.size() - 1)[cluster_axis.value()] == mesh_shape[cluster_axis.value()] - 1;
+            device_coords[device_coords.size() - 1][cluster_axis.value()] == mesh_shape[cluster_axis.value()] - 1;
         if (first_index_is_0 && last_index_is_mesh_shape_minus_1) {
             return tt::tt_metal::distributed::MeshCoordinate::BoundaryMode::WRAP;
         }
@@ -93,16 +93,16 @@ tt::tt_fabric::Topology get_usable_topology(
 }
 
 uint32_t get_topological_dimension(const Tensor& tensor, const std::optional<uint32_t>& cluster_axis) {
-    const auto& device_coords = tensor.device_storage().coords;
+    const auto device_coords = tensor.device_storage().get_coords();
     TT_FATAL(!device_coords.empty(), "device_coords is empty");
     if (cluster_axis.has_value()) {
         log_debug(tt::LogOp, "Cluster axis has value {}", cluster_axis.value());
         TT_FATAL(!device_coords.empty(), "device_coords is empty");
         TT_FATAL(
-            device_coords.at(0).dims() > cluster_axis.value(),
+            device_coords[0].dims() > cluster_axis.value(),
             "cluster axis {} is out of range for device coords rank {} ",
             cluster_axis.value(),
-            device_coords.at(0).dims());
+            device_coords[0].dims());
         uint32_t ring_size = 0;
         for (const auto& device_coord : device_coords) {
             ring_size = std::max(ring_size, device_coord[cluster_axis.value()] + 1);
@@ -117,7 +117,7 @@ uint32_t get_topological_dimension(const Tensor& tensor, const std::optional<uin
 
 uint32_t get_linearized_index_from_physical_coord(
     const Tensor& tensor, const MeshCoordinate& physical_coord, const std::optional<uint32_t>& cluster_axis) {
-    const auto& device_coords = tensor.device_storage().coords;
+    const auto device_coords = tensor.device_storage().get_coords();
     TT_FATAL(!device_coords.empty(), "device_coords is empty");
     if (cluster_axis.has_value()) {
         log_debug(tt::LogOp, "Cluster axis has value {}", cluster_axis.value());
@@ -160,16 +160,16 @@ std::optional<MeshCoordinate> get_physical_neighbor_from_physical_coord(
     int offset,
     ttnn::ccl::Topology topology,
     const std::optional<uint32_t>& cluster_axis) {
-    const auto& device_coords = tensor.device_storage().coords;
+    const auto device_coords = tensor.device_storage().get_coords();
     TT_FATAL(!device_coords.empty(), "device_coords is empty");
     auto boundary_mode = get_boundary_mode(tensor, topology, cluster_axis);
     if (cluster_axis.has_value()) {
         TT_FATAL(
-            device_coords.at(0)[cluster_axis.value()] == 0,
+            device_coords[0][cluster_axis.value()] == 0,
             "Currently, we only support CCLs with physical coordinates starting from 0 along the cluster axis {}, we "
             "got {}",
             cluster_axis.value(),
-            device_coords.at(0)[cluster_axis.value()]);
+            device_coords[0][cluster_axis.value()]);
         TT_FATAL(
             physical_coord.dims() > cluster_axis.value(),
             "cluster axis {} is out of range for physical coord rank {} ",
@@ -207,7 +207,7 @@ std::optional<MeshCoordinate> get_physical_neighbor_from_physical_coord(
         return std::nullopt;
     }
     log_debug(tt::LogOp, "Potential neighbor idx {} is found in device_coords", potential_neighbor_idx);
-    return device_coords.at(potential_neighbor_idx);
+    return device_coords[potential_neighbor_idx];
 }
 
 void SyncModeSpec::add_signal(uint32_t sem_id, uint32_t wait_count) {
@@ -310,8 +310,8 @@ SenderReceiverConfig get_device_sender_receiver_config_in_ring(
 std::vector<IDevice*> get_active_physical_devices(const Tensor& tensor) {
     auto* mesh_device = tensor.device();
     std::vector<IDevice*> devices = {};
-    devices.reserve(tensor.device_storage().coords.size());
-    for (const auto& coord : tensor.device_storage().coords) {
+    devices.reserve(tensor.device_storage().get_coords().size());
+    for (const auto& coord : tensor.device_storage().get_coords()) {
         devices.push_back(mesh_device->get_device(coord));
     }
     return devices;

--- a/ttnn/cpp/ttnn/operations/data_movement/narrow/narrow.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/narrow/narrow.cpp
@@ -126,7 +126,7 @@ ttnn::Tensor narrow(
             storage.get_mesh_buffer().device(),
             storage.get_mesh_buffer().address() + offset_bytes);
 
-        tt::tt_metal::DeviceStorage subtensor_storage(subtensor_mesh, storage.coords, storage.get_root_mesh_buffer());
+        tt::tt_metal::DeviceStorage subtensor_storage(storage, subtensor_mesh);
         TensorSpec subtensor_spec = TensorSpec(
             output_tensor_shape,
             tt::tt_metal::TensorLayout(
@@ -282,7 +282,7 @@ ttnn::Tensor narrow(
             storage.get_mesh_buffer().device(),
             storage.get_mesh_buffer().address() + (page_offset * buffer->aligned_page_size()));
 
-        tt::tt_metal::DeviceStorage subtensor_storage(subtensor_mesh, storage.coords, storage.get_root_mesh_buffer());
+        tt::tt_metal::DeviceStorage subtensor_storage(storage, subtensor_mesh);
 
         auto narrowed_memory_config =
             MemoryConfig(input_tensor.memory_config().memory_layout(), BufferType::L1, narrowed_shard_spec);


### PR DESCRIPTION
### Ticket

### PR Kind
Refactor

### Problem description
Runtime is lowering TTNN::Tensor into Runtime as Host and MeshTensor.
MeshTensor has a unique ownership with a disabled copy-constructor, which requires extra wrapping around to fit the shared-ownership copyable ttnn::Tensor.
DeviceStorage is the perfect container to encapsulate this ownership and copy-ability, however, it is currently designed as a pod-like open struct.

### What's changed
Refactored DeviceStorage to:
1. expose it's member variables as getter.
2. allow express sharing ownership of device memory through copying the DeviceStorage itself.

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/refactor-device-storage)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/refactor-device-storage)
  - ND
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu/refactor-device-storage)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/refactor-device-storage)
  - Not related to this PR. See: https://tenstorrent.slack.com/archives/C08SJ7MGESY/p1774993469955909?thread_ts=1774991397.104899&cid=C08SJ7MGESY
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/refactor-device-storage)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/refactor-device-storage)
  - Reference: https://github.com/tenstorrent/tt-metal/actions/runs/23784421696
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/refactor-device-storage)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/refactor-device-storage)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/refactor-device-storage)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/refactor-device-storage)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/refactor-device-storage)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/refactor-device-storage)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
