### PR TITLE
Prevent fusion in case of Conv impacting LoRAs

### DIFF
--- a/models/demos/stable_diffusion_xl_base/lora/tt_lora_weights_manager.py
+++ b/models/demos/stable_diffusion_xl_base/lora/tt_lora_weights_manager.py
@@ -94,6 +94,7 @@ class TtLoRAWeightsManager:
         if self._affects_unsupported_ops():
             logger.warning("LoRA weights affect unsupported operations, skipping loading LoRA weights.")
             self._torch_pipeline.unload_lora_weights()
+            return
 
     def fuse_lora(self, lora_scale=1.0):
         if not self.has_lora_adapter():

--- a/models/demos/stable_diffusion_xl_base/lora/tt_lora_weights_manager.py
+++ b/models/demos/stable_diffusion_xl_base/lora/tt_lora_weights_manager.py
@@ -45,6 +45,9 @@ class TtLoRAWeightsManager:
     def has_lora_adapter(self):
         return any(self.get_lora_adapters().values())
 
+    def _get_supported_lora_affecting_ops(self):
+        return (".to_q", ".to_k", ".to_v", ".to_out.0", ".proj_in", ".proj_out", ".ff.net.2", ".ff.net.0.proj")
+
     def _uses_dora(self):
         adapters = self.get_lora_adapters()
         unet_adapters = adapters.get("unet", [])
@@ -65,6 +68,12 @@ class TtLoRAWeightsManager:
         adapters = self.get_lora_adapters()
         return any(component != "unet" and adapter_list for component, adapter_list in adapters.items())
 
+    def _affects_unsupported_ops(self):
+        for key in self._get_lora_params():
+            if not any(key.endswith(s) for s in self._get_supported_lora_affecting_ops()):
+                return True
+        return False
+
     def load_lora_weights(self, lora_path):
         if self.has_lora_adapter():
             logger.info("LoRA weights already loaded, skipping.")
@@ -73,14 +82,18 @@ class TtLoRAWeightsManager:
         self._torch_pipeline.load_lora_weights(lora_path)
 
         if self._affects_non_unet():
-            logger.warning("Only LoRA affecting the UNet is supported, skipping loading LoRA weights")
+            logger.warning("Only LoRA affecting the UNet is supported, skipping loading LoRA weights.")
             self._torch_pipeline.unload_lora_weights()
             return
 
         if self._uses_dora():
-            logger.warning("DoRA is not supported, skipping loading LoRA weights")
+            logger.warning("DoRA is not supported, skipping loading LoRA weights.")
             self._torch_pipeline.unload_lora_weights()
             return
+
+        if self._affects_unsupported_ops():
+            logger.warning("LoRA weights affect unsupported operations, skipping loading LoRA weights.")
+            self._torch_pipeline.unload_lora_weights()
 
     def fuse_lora(self, lora_scale=1.0):
         if not self.has_lora_adapter():


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/39894

### Problem description
Unsupported LoRA causes the SDXL model to crash in the LoRA fusion stage: https://huggingface.co/ostris/ikea-instructions-lora-sdxl. This LoRA affects Conv ops and embedding layers inside the Unet which are currently not supported.

### What's changed
Added guard that checks if LoRA only impacts supported ops in Unet. Now when `tt_pipeline.load_lora_weights()` is called, the following message is displayed in case of these LoRAs:
```
2026-03-14 15:21:10.939 | WARNING  | models.demos.stable_diffusion_xl_base.lora.tt_lora_weights_manager:load_lora_weights:95 - LoRA weights affect unsupported operations, skipping loading LoRA weights.
```
`tt_pipeline.fuse_lora()` has no effect as loading weights has to be successful.

This can be tested with: `pytest models/demos/stable_diffusion_xl_base/demo/demo_lora.py --lora-hf-repo ostris/ikea-instructions-lora-sdxl --lora-hf-filename ikea_instructions_xl_v1_5.safetensors -k "device_vae and device_encoders and no_trace and no_cfg_parallel and 1024x1024"`

### Checklist

- [x] [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/runs/23089124023) CI passes
- [x] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/23089130303) CI passes
- [x] [(Single-card) Demo tests (perf runs)](https://github.com/tenstorrent/tt-metal/actions/runs/23089139029) CI passes
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/23089145159) CI passes
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/23089150493) CI passes