### PR TITLE
[Deepseek] Add top-k, top-p and temperature sampling params support

### DIFF
--- a/models/demos/deepseek_v3/demo/demo.py
+++ b/models/demos/deepseek_v3/demo/demo.py
@@ -15,11 +15,11 @@ import ttnn
 from models.common.sampling.sampling_params import SamplingParams
 from models.demos.deepseek_v3.tt.generator import DeepseekGenerator as DeepseekGeneratorDP
 from models.demos.deepseek_v3.utils.config_helpers import (
-    get_fabric_config,
     DEFAULT_SAMPLING_TEMPERATURE,
     DEFAULT_SAMPLING_TOP_K,
     DEFAULT_SAMPLING_TOP_P,
     USERS_PER_ROW,
+    get_fabric_config,
 )
 from models.demos.deepseek_v3.utils.hf_model_utils import load_tokenizer
 from models.demos.deepseek_v3.utils.test_utils import system_name_to_mesh_shape

--- a/models/demos/deepseek_v3/demo/demo.py
+++ b/models/demos/deepseek_v3/demo/demo.py
@@ -14,7 +14,13 @@ from loguru import logger
 import ttnn
 from models.common.sampling.sampling_params import SamplingParams
 from models.demos.deepseek_v3.tt.generator import DeepseekGenerator as DeepseekGeneratorDP
-from models.demos.deepseek_v3.utils.config_helpers import get_fabric_config
+from models.demos.deepseek_v3.utils.config_helpers import (
+    get_fabric_config,
+    DEFAULT_SAMPLING_TEMPERATURE,
+    DEFAULT_SAMPLING_TOP_K,
+    DEFAULT_SAMPLING_TOP_P,
+    USERS_PER_ROW,
+)
 from models.demos.deepseek_v3.utils.hf_model_utils import load_tokenizer
 from models.demos.deepseek_v3.utils.test_utils import system_name_to_mesh_shape
 
@@ -85,6 +91,16 @@ def _print_performance_metrics(results: dict) -> None:
         logger.info(f"Full demo runtime: {statistics['Full demo runtime']:.2f}s")
 
 
+def _print_model_params(results: dict) -> None:
+    """Print model parameters from model_params."""
+    if "model_params" in results and results["model_params"]:
+        logger.info("=== Model Parameters ===")
+        model_params = results["model_params"]
+        for key in sorted(model_params):
+            logger.info(f"{key}: {model_params[key]}")
+        logger.info("=====================")
+
+
 def create_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser("DeepSeek-V3 Demo on TT-NN")
     # Prompt is required for full-model mode, optional/ignored for --random-weights
@@ -121,9 +137,24 @@ def create_parser() -> argparse.ArgumentParser:
         help="Path to local HF DeepSeek-V3 model (safetensors)",
     )
     p.add_argument("--max-new-tokens", type=int, default=32, help="Number of tokens to generate")
-    p.add_argument("--temperature", type=float, default=1.0, help="Sampling temperature.")
-    p.add_argument("--top-k", type=int, default=1, help="Top-k value for sampling.")
-    p.add_argument("--top-p", type=float, default=1.0, help="Top-p value for sampling.")
+    p.add_argument(
+        "--sampling-temperature",
+        type=float,
+        default=DEFAULT_SAMPLING_TEMPERATURE,
+        help=f"Sampling temperature (default: {DEFAULT_SAMPLING_TEMPERATURE}).",
+    )
+    p.add_argument(
+        "--sampling-top-k",
+        type=int,
+        default=DEFAULT_SAMPLING_TOP_K,
+        help=f"Top-k value for sampling (default: {DEFAULT_SAMPLING_TOP_K}).",
+    )
+    p.add_argument(
+        "--sampling-top-p",
+        type=float,
+        default=DEFAULT_SAMPLING_TOP_P,
+        help=f"Top-p value for sampling (default: {DEFAULT_SAMPLING_TOP_P}).",
+    )
     p.add_argument("--cache-dir", type=str, required=True)
     # Random-weights mode options (reuse Model1D pipeline; single dense layer only)
     p.add_argument(
@@ -354,9 +385,9 @@ def run_demo(
     stop_at_eos: bool = True,
     checkpoint_jsonl: str | Path | None = None,
     enable_mtp: bool = False,
-    temperature: float = 1.0,
-    top_k: int = 1,
-    top_p: float = 0.0,
+    sampling_temperature: float = DEFAULT_SAMPLING_TEMPERATURE,
+    sampling_top_k: int = DEFAULT_SAMPLING_TOP_K,
+    sampling_top_p: float = DEFAULT_SAMPLING_TOP_P,
 ) -> dict:
     """Programmatic entrypoint for the DeepSeek-V3 demo.
 
@@ -372,20 +403,12 @@ def run_demo(
         raise SystemExit("Missing cache directory. Provide --cache-dir.")
     cache_dir = Path(cache_dir)
 
-    if temperature <= 0:
-        raise SystemExit("--sampling-temperature must be > 0 when --sampling is enabled.")
-    if not (0.0 < top_p <= 1.0):
+    if sampling_temperature <= 0:
+        raise SystemExit("--sampling-temperature must be > 0.")
+    if not (0.0 < sampling_top_p <= 1.0):
         raise SystemExit("--sampling-top-p must be in the interval (0, 1].")
-    if top_k < 0:
+    if sampling_top_k < 0:
         raise SystemExit("--sampling-top-k must be >= 0.")
-
-    sampling_params = SamplingParams(
-        temperature=temperature,
-        top_p=top_p,
-        top_k=top_k,
-    )
-
-    logger.info(f"Sampling parameters: {sampling_params.temperature}, {sampling_params.top_p}, {sampling_params.top_k}")
 
     # Validate model directory per mode
     validate_model_path(
@@ -434,6 +457,17 @@ def run_demo(
                 "Failed to load tokenizer from model path. Ensure the directory contains tokenizer files (e.g., tokenizer.model or tokenizer.json)."
             )
             raise
+
+    batch_size_per_row = USERS_PER_ROW
+    batch_size = batch_size_per_row * mesh_device.shape[0]
+
+    # Configure sampling
+    # sampling values of all users are assumed to be the same when initialized with run_demo function.
+    sampling_params = SamplingParams(
+        temperature=[sampling_temperature] * batch_size,
+        top_p=[sampling_top_p] * batch_size,
+        top_k=[sampling_top_k] * batch_size,
+    )
 
     gen = None
     try:
@@ -558,7 +592,7 @@ def run_demo(
                         if pre_tokenized_prompts is not None
                         else None
                     )
-                    batch_generations, batch_stats = gen.generate(
+                    batch_generations, batch_stats, model_params= gen.generate(
                         batch_prompts,
                         max_new_tokens=max_new_tokens,
                         teacher_forcing=token_acc,
@@ -640,7 +674,7 @@ def run_demo(
                 checkpoint_fh.flush()
                 os.fsync(checkpoint_fh.fileno())
 
-            return {"generations": results, "statistics": statistics}
+            return {"generations": results, "statistics": statistics, "model_params": model_params}
         finally:
             if checkpoint_fh is not None:
                 checkpoint_fh.close()
@@ -699,9 +733,9 @@ def main() -> None:
         profile_decode=args.profile_decode,
         sample_on_device=args.sample_on_device,
         force_recalculate=bool(args.force_recalculate),
-        temperature=args.temperature,
-        top_k=args.top_k,
-        top_p=args.top_p,
+        sampling_temperature=args.sampling_temperature,
+        sampling_top_k=args.sampling_top_k,
+        sampling_top_p=args.sampling_top_p,
         stop_at_eos=bool(args.stop_at_eos),
         checkpoint_jsonl=args.checkpoint_jsonl,
         enable_mtp=(args.mtp == "on"),
@@ -716,6 +750,7 @@ def main() -> None:
             prompts=args.prompts,
             generations=results["generations"],
             statistics=results.get("statistics", {}),
+            model_params=results.get("model_params", {}),
             random_weights=bool(args.random_weights),
         )
         if int(os.getenv("TT_MESH_HOST_RANK", "0")) == 0:
@@ -742,6 +777,9 @@ def main() -> None:
 
     # Print performance metrics if available
     _print_performance_metrics(results)
+
+    # Print model parameters if available
+    _print_model_params(results)
 
 
 if __name__ == "__main__":

--- a/models/demos/deepseek_v3/demo/demo.py
+++ b/models/demos/deepseek_v3/demo/demo.py
@@ -37,12 +37,14 @@ def _build_output_data(
     prompts: list[str] | None,
     generations: list[dict],
     statistics: dict,
+    model_params: dict,
     random_weights: bool,
 ) -> dict:
     output_data = {
         "prompts": prompts if prompts else [],
         "generations": [],
         "statistics": statistics,
+        "model_params": model_params,
     }
     for i, gen_result in enumerate(generations):
         output_data["generations"].append(
@@ -621,7 +623,7 @@ def run_demo(
                         if pre_tokenized_prompts is not None
                         else None
                     )
-                    batch_generations, batch_stats, model_params= gen.generate(
+                    batch_generations, batch_stats, model_params = gen.generate(
                         batch_prompts,
                         max_new_tokens=max_new_tokens,
                         teacher_forcing=token_acc,
@@ -662,7 +664,7 @@ def run_demo(
                         if any(key in s for s in all_stats):
                             statistics[key] = sum(float(s.get(key, 0) or 0) for s in all_stats)
             else:
-                generations, statistics = gen.generate(
+                generations, statistics, model_params = gen.generate(
                     prompt_list,
                     max_new_tokens=max_new_tokens,
                     teacher_forcing=token_acc,

--- a/models/demos/deepseek_v3/demo/demo.py
+++ b/models/demos/deepseek_v3/demo/demo.py
@@ -91,11 +91,40 @@ def _print_performance_metrics(results: dict) -> None:
         logger.info(f"Full demo runtime: {statistics['Full demo runtime']:.2f}s")
 
 
-def _print_model_params(results: dict) -> None:
+def _format_model_params_for_reporting(model_params: dict, summarize_sampling: bool = True) -> dict:
+    """Summarize sampling arrays for concise reporting."""
+    if not summarize_sampling:
+        return model_params
+
+    sampling = model_params.get("sampling")
+    if not isinstance(sampling, dict):
+        return model_params
+
+    formatted_sampling = {}
+    for key, value in sampling.items():
+        if isinstance(value, (list, tuple)):
+            if value and all(v == value[0] for v in value):
+                formatted_sampling[key] = {"same_value_all_users": value[0], "count": len(value)}
+            else:
+                formatted_sampling[key] = {
+                    "same_value_all_users": False,
+                    "note": "all values are not same",
+                    "first_3_values": list(value[:3]),
+                    "count": len(value),
+                }
+        else:
+            formatted_sampling[key] = value
+
+    return {**model_params, "sampling": formatted_sampling}
+
+
+def _print_model_params(results: dict, summarize_sampling: bool = True) -> None:
     """Print model parameters from model_params."""
     if "model_params" in results and results["model_params"]:
         logger.info("=== Model Parameters ===")
-        model_params = results["model_params"]
+        model_params = _format_model_params_for_reporting(
+            results["model_params"], summarize_sampling=summarize_sampling
+        )
         for key in sorted(model_params):
             logger.info(f"{key}: {model_params[key]}")
         logger.info("=====================")
@@ -750,7 +779,9 @@ def main() -> None:
             prompts=args.prompts,
             generations=results["generations"],
             statistics=results.get("statistics", {}),
-            model_params=results.get("model_params", {}),
+            model_params=_format_model_params_for_reporting(
+                results.get("model_params", {}),
+            ),
             random_weights=bool(args.random_weights),
         )
         if int(os.getenv("TT_MESH_HOST_RANK", "0")) == 0:

--- a/models/demos/deepseek_v3/demo/demo.py
+++ b/models/demos/deepseek_v3/demo/demo.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from loguru import logger
 
 import ttnn
+from models.common.sampling.sampling_params import SamplingParams
 from models.demos.deepseek_v3.tt.generator import DeepseekGenerator as DeepseekGeneratorDP
 from models.demos.deepseek_v3.utils.config_helpers import get_fabric_config
 from models.demos.deepseek_v3.utils.hf_model_utils import load_tokenizer
@@ -120,6 +121,9 @@ def create_parser() -> argparse.ArgumentParser:
         help="Path to local HF DeepSeek-V3 model (safetensors)",
     )
     p.add_argument("--max-new-tokens", type=int, default=32, help="Number of tokens to generate")
+    p.add_argument("--temperature", type=float, default=1.0, help="Sampling temperature.")
+    p.add_argument("--top-k", type=int, default=1, help="Top-k value for sampling.")
+    p.add_argument("--top-p", type=float, default=1.0, help="Top-p value for sampling.")
     p.add_argument("--cache-dir", type=str, required=True)
     # Random-weights mode options (reuse Model1D pipeline; single dense layer only)
     p.add_argument(
@@ -350,6 +354,9 @@ def run_demo(
     stop_at_eos: bool = True,
     checkpoint_jsonl: str | Path | None = None,
     enable_mtp: bool = False,
+    temperature: float = 1.0,
+    top_k: int = 1,
+    top_p: float = 0.0,
 ) -> dict:
     """Programmatic entrypoint for the DeepSeek-V3 demo.
 
@@ -364,6 +371,21 @@ def run_demo(
     if cache_dir is None:
         raise SystemExit("Missing cache directory. Provide --cache-dir.")
     cache_dir = Path(cache_dir)
+
+    if temperature <= 0:
+        raise SystemExit("--sampling-temperature must be > 0 when --sampling is enabled.")
+    if not (0.0 < top_p <= 1.0):
+        raise SystemExit("--sampling-top-p must be in the interval (0, 1].")
+    if top_k < 0:
+        raise SystemExit("--sampling-top-k must be >= 0.")
+
+    sampling_params = SamplingParams(
+        temperature=temperature,
+        top_p=top_p,
+        top_k=top_k,
+    )
+
+    logger.info(f"Sampling parameters: {sampling_params.temperature}, {sampling_params.top_p}, {sampling_params.top_k}")
 
     # Validate model directory per mode
     validate_model_path(
@@ -454,6 +476,7 @@ def run_demo(
                 profile_decode=profile_decode,
                 sample_on_device=sample_on_device,
                 enable_mtp=enable_mtp,
+                sampling_params=sampling_params,
             )
         else:
             raise ValueError(f"Unsupported generator: {generator}")
@@ -676,6 +699,9 @@ def main() -> None:
         profile_decode=args.profile_decode,
         sample_on_device=args.sample_on_device,
         force_recalculate=bool(args.force_recalculate),
+        temperature=args.temperature,
+        top_k=args.top_k,
+        top_p=args.top_p,
         stop_at_eos=bool(args.stop_at_eos),
         checkpoint_jsonl=args.checkpoint_jsonl,
         enable_mtp=(args.mtp == "on"),

--- a/models/demos/deepseek_v3/demo/demo.py
+++ b/models/demos/deepseek_v3/demo/demo.py
@@ -435,11 +435,13 @@ def run_demo(
     cache_dir = Path(cache_dir)
 
     if sampling_temperature < 0:
-        raise SystemExit("--sampling-temperature must be > 0 (use 0 for greedy decoding).")
+        raise SystemExit("--sampling-temperature must be >= 0 (use 0 for greedy decoding).")
     if not (0.0 < sampling_top_p <= 1.0):
         raise SystemExit("--sampling-top-p must be in the interval (0, 1].")
     if sampling_top_k < 0:
-        raise SystemExit("--sampling-top-k must be >= 0.")
+        raise SystemExit(
+            "--sampling-top-k must be >= 0. For top-k=0, use --sample-on-host. See https://github.com/tenstorrent/tt-metal/issues/40236"
+        )
     if sampling_top_k == 0 and sample_on_device:
         raise SystemExit(
             "--sampling-top-k=0 is not supported when sampling on device. Use --sample-on-host. See https://github.com/tenstorrent/tt-metal/issues/40236"

--- a/models/demos/deepseek_v3/demo/demo.py
+++ b/models/demos/deepseek_v3/demo/demo.py
@@ -434,12 +434,16 @@ def run_demo(
         raise SystemExit("Missing cache directory. Provide --cache-dir.")
     cache_dir = Path(cache_dir)
 
-    if sampling_temperature <= 0:
-        raise SystemExit("--sampling-temperature must be > 0.")
+    if sampling_temperature < 0:
+        raise SystemExit("--sampling-temperature must be > 0 (use 0 for greedy decoding).")
     if not (0.0 < sampling_top_p <= 1.0):
         raise SystemExit("--sampling-top-p must be in the interval (0, 1].")
     if sampling_top_k < 0:
         raise SystemExit("--sampling-top-k must be >= 0.")
+    if sampling_top_k == 0 and sample_on_device:
+        raise SystemExit(
+            "--sampling-top-k=0 is not supported when sampling on device. Use --sample-on-host. See https://github.com/tenstorrent/tt-metal/issues/40236"
+        )
 
     # Validate model directory per mode
     validate_model_path(

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -215,6 +215,7 @@ class DeepseekGenerator(WarmupForwardMixin):
         self.batch_size = self.batch_size_per_row * self.mesh_device.shape[0]
 
         # Configure sampling
+        # sampling values of all users are assumed to be the same default values if not provided in constructor.
         self.sample_on_device = sample_on_device
         self.sampling_params = (
             sampling_params
@@ -238,9 +239,8 @@ class DeepseekGenerator(WarmupForwardMixin):
             self._reset_sampling_state(self.sampling_params, self.batch_size, self.batch_size_per_row)
 
         logger.info(f"Sampling mode: {'device' if self.sample_on_device else 'host'}")
-        # sampling values of all users are assumed to be the same when initialized with generator constructor.
         logger.info(
-            f"Sampling parameters: "
+            f"Sampling parameters for first user (other users may have different values): "
             + f"temperature={self.sampling_params.temperature[0]}, "
             + f"top_p={self.sampling_params.top_p[0]}, "
             + f"top_k={self.sampling_params.top_k[0]}"
@@ -1017,6 +1017,16 @@ class DeepseekGenerator(WarmupForwardMixin):
             logits = logits.squeeze(0)
         return torch.argmax(logits, dim=-1)  # [B]
 
+    @staticmethod
+    def _get_sampling_value(value, index: int):
+        if isinstance(value, list):
+            if not value:
+                return None
+            if index < len(value):
+                return value[index]
+            return value[-1]
+        return value
+    
     def _sample_greedy_on_host(self, logits: torch.Tensor) -> torch.Tensor:
         return self._sample_greedy(logits)
 
@@ -1509,53 +1519,61 @@ class DeepseekGenerator(WarmupForwardMixin):
         if self.sampling_params is None:
             return torch.argmax(logits, dim=-1)
 
-        if self.sampling_params.temperature <= 0:
-            return torch.argmax(logits, dim=-1)
-
-        scores = logits / self.sampling_params.temperature
-
-        if self.sampling_params.top_k > 0:
-            top_k = min(self.sampling_params.top_k, scores.shape[-1])
-            kth_values = torch.topk(scores, top_k, dim=-1).values[..., -1, None]
-            scores = scores.masked_fill(scores < kth_values, float("-inf"))
-
-        if 0.0 < self.sampling_params.top_p < 1.0:
-            sorted_scores, sorted_indices = torch.sort(scores, descending=True, dim=-1)
-            sorted_probs = torch.softmax(sorted_scores, dim=-1)
-            cumulative_probs = torch.cumsum(sorted_probs, dim=-1)
-            remove_mask = cumulative_probs > self.sampling_params.top_p
-            remove_mask[..., 1:] = remove_mask[..., :-1].clone()
-            remove_mask[..., 0] = False
-            sorted_scores = sorted_scores.masked_fill(remove_mask, float("-inf"))
-
-            filtered_scores = torch.full_like(scores, float("-inf"))
-            filtered_scores.scatter_(dim=-1, index=sorted_indices, src=sorted_scores)
-            scores = filtered_scores
-
-        probs = torch.softmax(scores, dim=-1)
-        row_sums = probs.sum(dim=-1)
-        valid_rows = torch.isfinite(probs).all(dim=-1) & torch.isfinite(row_sums) & (row_sums > 0)
-
-        # Honor sampling.seed (if provided) for deterministic host-side sampling.
-        generator: torch.Generator | None = None
-        if self.sampling_params.seed is not None:
-            generator = torch.Generator(device=probs.device).manual_seed(int(self.sampling_params.seed))
-
-        if valid_rows.all():
-            if generator is None:
-                return torch.multinomial(probs, num_samples=1).squeeze(-1)
-            return torch.multinomial(probs, num_samples=1, generator=generator).squeeze(-1)
+        if logits.ndim == 1:
+            logits = logits.unsqueeze(0)
 
         sampled_tokens = torch.argmax(logits, dim=-1)
-        if valid_rows.any():
+        batch_size = logits.shape[0]
+
+        for row_idx in range(batch_size):
+            user_idx = start_user_idx + row_idx
+            temperature = self._get_sampling_value(self.sampling_params.temperature, user_idx)
+            top_k = self._get_sampling_value(self.sampling_params.top_k, user_idx)
+            top_p = self._get_sampling_value(self.sampling_params.top_p, user_idx)
+            seed = self._get_sampling_value(getattr(self.sampling_params, "seed", None), user_idx)
+
+            temperature = float(temperature) if temperature is not None else 1.0
+            top_k = int(top_k) if top_k is not None else 0
+            top_p = float(top_p) if top_p is not None else 1.0
+
+            if temperature <= 0:
+                continue
+
+            scores = logits[row_idx : row_idx + 1] / temperature
+
+            if top_k > 0:
+                top_k = min(top_k, scores.shape[-1])
+                kth_values = torch.topk(scores, top_k, dim=-1).values[..., -1, None]
+                scores = scores.masked_fill(scores < kth_values, float("-inf"))
+
+            if 0.0 < top_p < 1.0:
+                sorted_scores, sorted_indices = torch.sort(scores, descending=True, dim=-1)
+                sorted_probs = torch.softmax(sorted_scores, dim=-1)
+                cumulative_probs = torch.cumsum(sorted_probs, dim=-1)
+                remove_mask = cumulative_probs > top_p
+                remove_mask[..., 1:] = remove_mask[..., :-1].clone()
+                remove_mask[..., 0] = False
+                sorted_scores = sorted_scores.masked_fill(remove_mask, float("-inf"))
+
+                filtered_scores = torch.full_like(scores, float("-inf"))
+                filtered_scores.scatter_(dim=-1, index=sorted_indices, src=sorted_scores)
+                scores = filtered_scores
+
+            probs = torch.softmax(scores, dim=-1)
+            row_sum = probs.sum(dim=-1)
+            valid_row = torch.isfinite(probs).all(dim=-1) & torch.isfinite(row_sum) & (row_sum > 0)
+            if not bool(valid_row.item()):
+                continue
+
+            generator: torch.Generator | None = None
+            if seed is not None:
+                generator = torch.Generator(device=probs.device).manual_seed(int(seed))
+
             if generator is None:
-                sampled_tokens[valid_rows] = torch.multinomial(probs[valid_rows], num_samples=1).squeeze(-1)
+                sampled_tokens[row_idx] = torch.multinomial(probs, num_samples=1).squeeze(-1)
             else:
-                sampled_tokens[valid_rows] = torch.multinomial(
-                    probs[valid_rows],
-                    num_samples=1,
-                    generator=generator,
-                ).squeeze(-1)
+                sampled_tokens[row_idx] = torch.multinomial(probs, num_samples=1, generator=generator).squeeze(-1)
+
         return sampled_tokens
     
     def generate(

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -250,6 +250,9 @@ class DeepseekGenerator(WarmupForwardMixin):
             + f"top_k={self._get_sampling_value(self.sampling_params.top_k, 0)}"
         )
 
+        if enable_mtp and sample_on_device:
+            raise SystemExit("MTP with sampling on device is not supported. Disable MTP or sample on host.")
+
         # Weight cache to avoid loading weights multiple times
         self._weight_ttnn_cache: dict[str, ttnn.Tensor] = {}
         # Paged attention setup

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -1612,6 +1612,8 @@ class DeepseekGenerator(WarmupForwardMixin):
 
         Returns: (list of generated token id lists for the provided prompts (order preserved), statistics dictionary)
         """
+        if teacher_forcing is not None and self.sample_on_device:
+            raise ValueError("teacher_forcing is not supported when sample_on_device is True")
         # Initialize profiler
         profiler = BenchmarkProfiler()
         profiler.start("run")

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -20,7 +20,14 @@ from models.demos.deepseek_v3.tt.mla.mla2d import MLA2D
 from models.demos.deepseek_v3.tt.model.row_batched_model import RowBatchedModel
 from models.demos.deepseek_v3.tt.rope import RotarySetup
 from models.demos.deepseek_v3.utils.config_dataclass import KvCacheConfig
-from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, even_int_div, make_deepseek_sampling_args
+from models.demos.deepseek_v3.utils.config_helpers import (
+    DEFAULT_SAMPLING_TEMPERATURE,
+    DEFAULT_SAMPLING_TOP_K,
+    DEFAULT_SAMPLING_TOP_P,
+    USERS_PER_ROW,
+    even_int_div,
+    make_deepseek_sampling_args,
+)
 from models.demos.deepseek_v3.utils.debug_utils import dump_ttnn_meminfo
 from models.demos.deepseek_v3.utils.run_config import create_run_config
 from models.demos.deepseek_v3.utils.weight_config import get_weight_config
@@ -158,13 +165,12 @@ class DeepseekGenerator(WarmupForwardMixin):
         profile_decode: bool = False,
         sample_on_device: bool = False,
         enable_mtp: bool = False,
-        sampling_params: SamplingParams = SamplingParams(temperature=1.0, top_p=0.0, top_k=1),
+        sampling_params: None = None,
     ) -> None:
         self.mesh_device = mesh_device
         self.model_path = str(model_path)
         self.cache_dir = cache_dir
-        self.sample_on_device = sample_on_device
-        self.sampling_params = sampling_params
+
         # Load HF config + tokenizer
         self.hf_config = (
             hf_config if hf_config is not None else AutoConfig.from_pretrained(self.model_path, trust_remote_code=True)
@@ -209,6 +215,16 @@ class DeepseekGenerator(WarmupForwardMixin):
         self.batch_size = self.batch_size_per_row * self.mesh_device.shape[0]
 
         # Configure sampling
+        self.sample_on_device = sample_on_device
+        self.sampling_params = (
+            sampling_params
+            if sampling_params is not None
+            else SamplingParams(
+                temperature=[DEFAULT_SAMPLING_TEMPERATURE] * self.batch_size,
+                top_p=[DEFAULT_SAMPLING_TOP_P] * self.batch_size,
+                top_k=[DEFAULT_SAMPLING_TOP_K] * self.batch_size,
+            )
+        )
         if self.sample_on_device:
             enable_internal_trace_sampling = enable_trace and self.sample_on_device
             self.sampling_args = make_deepseek_sampling_args(mesh_device, self.hf_config.vocab_size)
@@ -222,6 +238,14 @@ class DeepseekGenerator(WarmupForwardMixin):
             self._reset_sampling_state(self.sampling_params, self.batch_size, self.batch_size_per_row)
 
         logger.info(f"Sampling mode: {'device' if self.sample_on_device else 'host'}")
+        # sampling values of all users are assumed to be the same when initialized with generator constructor.
+        logger.info(
+            f"Sampling parameters: "
+            + f"temperature={self.sampling_params.temperature[0]}, "
+            + f"top_p={self.sampling_params.top_p[0]}, "
+            + f"top_k={self.sampling_params.top_k[0]}"
+        )
+
         # Weight cache to avoid loading weights multiple times
         self._weight_ttnn_cache: dict[str, ttnn.Tensor] = {}
         # Paged attention setup
@@ -1500,6 +1524,7 @@ class DeepseekGenerator(WarmupForwardMixin):
             sorted_probs = torch.softmax(sorted_scores, dim=-1)
             cumulative_probs = torch.cumsum(sorted_probs, dim=-1)
             remove_mask = cumulative_probs > self.sampling_params.top_p
+            remove_mask[..., 1:] = remove_mask[..., :-1].clone()
             remove_mask[..., 0] = False
             sorted_scores = sorted_scores.masked_fill(remove_mask, float("-inf"))
 
@@ -1537,7 +1562,6 @@ class DeepseekGenerator(WarmupForwardMixin):
         self,
         prompts: Iterable[str],
         max_new_tokens: int = 32,
-        sampling: SamplingParams | None = None,
         teacher_forcing=None,
         early_print_first_user: bool = True,
         repeat_batches: int = 1,
@@ -1620,6 +1644,14 @@ class DeepseekGenerator(WarmupForwardMixin):
         # Run one or more prefill+decode batches
         stop_token_ids = self._get_stop_token_ids() if stop_at_eos and teacher_forcing is None else set()
         for batch_idx in range(repeat_batches):
+            if self.sample_on_device:
+                # reset sampling state for each repeat batch, o/p tokens will be different for each repeat batch
+                assert self.sampling_params is not None, "sampling_params must be set when sampling on device"
+                self._reset_sampling_state(
+                    self.sampling_params,
+                    self.batch_size,
+                    self.batch_size_per_row,
+                )
             # Reset teacher-forcing state per batch.
             if teacher_forcing is not None:
                 teacher_forcing.reset()
@@ -1991,10 +2023,29 @@ class DeepseekGenerator(WarmupForwardMixin):
         if mtp_verifies is not None:
             statistics["mtp_verifies"] = mtp_verifies
 
+            
+        model_params = {
+            "mesh_device": f"{self.mesh_device.shape[0]}x{self.mesh_device.shape[1]}",
+            "model_path": str(self.model_path),
+            "cache_dir": str(self.cache_dir),
+            "batch_size": self.batch_size,
+            "repeat_batches": repeat_batches,
+            "enable_trace": self.enable_trace,
+            "sample_on_device": self.sample_on_device,
+            "num_hidden_layers": self.hf_config.num_hidden_layers,
+            "random_weights": self.random_weights,
+            "sampling": {
+                "temperature": self.sampling_params.temperature,
+                "top_k": self.sampling_params.top_k,
+                "top_p": self.sampling_params.top_p,
+            },
+        }
+        
         for page_tables in temp_decode_page_tables:
             self._release_page_table_tuple(page_tables)
 
-        return generations, statistics
+        return generations, statistics, model_params
+        
 
     def _encode_prompt(self, prompt: str) -> List[int]:
         # Use HF chat template if a tokenizer is provided; otherwise synthesize simple token ids

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -1026,7 +1026,7 @@ class DeepseekGenerator(WarmupForwardMixin):
                 return value[index]
             return value[-1]
         return value
-    
+
     def _sample_greedy_on_host(self, logits: torch.Tensor) -> torch.Tensor:
         return self._sample_greedy(logits)
 
@@ -1514,13 +1514,16 @@ class DeepseekGenerator(WarmupForwardMixin):
             decode_step_user_tokens=decode_step_user_tokens,
         )
 
-    def _sample_on_host(self, logits: torch.Tensor) -> torch.Tensor | int:
+    def _sample_on_host(self, logits: torch.Tensor, start_user_idx: int = 0) -> torch.Tensor | int:
         """Sample on host using top-k/top-p/temperature from sampling_params."""
         if self.sampling_params is None:
             return torch.argmax(logits, dim=-1)
 
         if logits.ndim == 1:
             logits = logits.unsqueeze(0)
+        elif logits.ndim > 2:
+            # Normalize to [batch, vocab] so each sampled row maps to one user lane.
+            logits = logits.reshape(-1, logits.shape[-1])
 
         sampled_tokens = torch.argmax(logits, dim=-1)
         batch_size = logits.shape[0]
@@ -1562,7 +1565,7 @@ class DeepseekGenerator(WarmupForwardMixin):
             probs = torch.softmax(scores, dim=-1)
             row_sum = probs.sum(dim=-1)
             valid_row = torch.isfinite(probs).all(dim=-1) & torch.isfinite(row_sum) & (row_sum > 0)
-            if not bool(valid_row.item()):
+            if not bool(valid_row.all().item()):
                 continue
 
             generator: torch.Generator | None = None
@@ -1575,7 +1578,7 @@ class DeepseekGenerator(WarmupForwardMixin):
                 sampled_tokens[row_idx] = torch.multinomial(probs, num_samples=1, generator=generator).squeeze(-1)
 
         return sampled_tokens
-    
+
     def generate(
         self,
         prompts: Iterable[str],
@@ -1753,7 +1756,9 @@ class DeepseekGenerator(WarmupForwardMixin):
                                 prefill_logits, torch.Tensor
                             ), "prefill_logits should be a torch.Tensor on host"
                             last_token_logits = prefill_logits[0, 0, max(prompt_len - 1, 0), :]
-                            pred_token = int(self._sample_on_host(last_token_logits.unsqueeze(0)).item())
+                            pred_token = int(
+                                self._sample_on_host(last_token_logits.unsqueeze(0), start_user_idx=user_id).item()
+                            )
                         prefill_tokens.append(torch.tensor(pred_token, dtype=torch.int64))
                     self.ccl.reset_sem_counters()
                 if use_mtp_path:
@@ -1890,7 +1895,7 @@ class DeepseekGenerator(WarmupForwardMixin):
                             break
                         logger.info(f"Decoding step {gen_idx} for {num_of_prompts} user(s)...")
                         profiler.start(f"decode_time_{gen_idx}")
-                        logits = self.decode_forward(
+                        decode_logits = self.decode_forward(
                             tokens=next_tokens,
                             start_pos=positions,
                             batch_size_per_row=self.batch_size_per_row,
@@ -1904,15 +1909,17 @@ class DeepseekGenerator(WarmupForwardMixin):
                         decode_forward_passes += 1
                         self.ccl.reset_sem_counters()
                         if self.sample_on_device:
-                            pred_tokens_device = self._sample_tokens_device(logits, enable_trace=self.enable_trace)
+                            pred_tokens_device = self._sample_tokens_device(
+                                decode_logits, enable_trace=self.enable_trace
+                            )
                             pred_tokens = self._tokens_from_device(
                                 pred_tokens_device, self.mesh_device, batch_size_per_row=self.batch_size_per_row
                             )
                             if not self.enable_trace:
-                                ttnn.deallocate(logits)
+                                ttnn.deallocate(decode_logits)
                                 ttnn.deallocate(pred_tokens_device)
                         else:
-                            pred_token = int(self._sample_on_host(last_token_logits.unsqueeze(0)).item())
+                            pred_tokens = self._sample_on_host(decode_logits)
                         if teacher_forcing is not None:
                             # Record user-0 prediction for accuracy, then force teacher token.
                             forced = teacher_forcing.collect_predicted_tokens(int(pred_tokens[0].item()))
@@ -2041,7 +2048,6 @@ class DeepseekGenerator(WarmupForwardMixin):
         if mtp_verifies is not None:
             statistics["mtp_verifies"] = mtp_verifies
 
-            
         model_params = {
             "mesh_device": f"{self.mesh_device.shape[0]}x{self.mesh_device.shape[1]}",
             "model_path": str(self.model_path),
@@ -2058,12 +2064,11 @@ class DeepseekGenerator(WarmupForwardMixin):
                 "top_p": self.sampling_params.top_p,
             },
         }
-        
+
         for page_tables in temp_decode_page_tables:
             self._release_page_table_tuple(page_tables)
 
         return generations, statistics, model_params
-        
 
     def _encode_prompt(self, prompt: str) -> List[int]:
         # Use HF chat template if a tokenizer is provided; otherwise synthesize simple token ids

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -158,12 +158,13 @@ class DeepseekGenerator(WarmupForwardMixin):
         profile_decode: bool = False,
         sample_on_device: bool = False,
         enable_mtp: bool = False,
+        sampling_params: SamplingParams = SamplingParams(temperature=1.0, top_p=0.0, top_k=1),
     ) -> None:
         self.mesh_device = mesh_device
         self.model_path = str(model_path)
         self.cache_dir = cache_dir
         self.sample_on_device = sample_on_device
-
+        self.sampling_params = sampling_params
         # Load HF config + tokenizer
         self.hf_config = (
             hf_config if hf_config is not None else AutoConfig.from_pretrained(self.model_path, trust_remote_code=True)
@@ -217,13 +218,7 @@ class DeepseekGenerator(WarmupForwardMixin):
                 tt_ccl=self.ccl,
                 enable_internal_trace=enable_internal_trace_sampling,
             )
-            # Use default sampling params (top-k=1, top-p=0.0, temperature=1.0) i.e. argmax sampling for device sampling
-            self.sampling_params = SamplingParams(
-                temperature=[1.0] * self.batch_size,
-                top_k=[1] * self.batch_size,
-                top_p=[0.0] * self.batch_size,
-                seed=[42] * self.batch_size,
-            )
+
             self._reset_sampling_state(self.sampling_params, self.batch_size, self.batch_size_per_row)
 
         logger.info(f"Sampling mode: {'device' if self.sample_on_device else 'host'}")
@@ -1485,6 +1480,59 @@ class DeepseekGenerator(WarmupForwardMixin):
             decode_step_user_tokens=decode_step_user_tokens,
         )
 
+    def _sample_on_host(self, logits: torch.Tensor) -> torch.Tensor | int:
+        """Sample on host using top-k/top-p/temperature from sampling_params."""
+        if self.sampling_params is None:
+            return torch.argmax(logits, dim=-1)
+
+        if self.sampling_params.temperature <= 0:
+            return torch.argmax(logits, dim=-1)
+
+        scores = logits / self.sampling_params.temperature
+
+        if self.sampling_params.top_k > 0:
+            top_k = min(self.sampling_params.top_k, scores.shape[-1])
+            kth_values = torch.topk(scores, top_k, dim=-1).values[..., -1, None]
+            scores = scores.masked_fill(scores < kth_values, float("-inf"))
+
+        if 0.0 < self.sampling_params.top_p < 1.0:
+            sorted_scores, sorted_indices = torch.sort(scores, descending=True, dim=-1)
+            sorted_probs = torch.softmax(sorted_scores, dim=-1)
+            cumulative_probs = torch.cumsum(sorted_probs, dim=-1)
+            remove_mask = cumulative_probs > self.sampling_params.top_p
+            remove_mask[..., 0] = False
+            sorted_scores = sorted_scores.masked_fill(remove_mask, float("-inf"))
+
+            filtered_scores = torch.full_like(scores, float("-inf"))
+            filtered_scores.scatter_(dim=-1, index=sorted_indices, src=sorted_scores)
+            scores = filtered_scores
+
+        probs = torch.softmax(scores, dim=-1)
+        row_sums = probs.sum(dim=-1)
+        valid_rows = torch.isfinite(probs).all(dim=-1) & torch.isfinite(row_sums) & (row_sums > 0)
+
+        # Honor sampling.seed (if provided) for deterministic host-side sampling.
+        generator: torch.Generator | None = None
+        if self.sampling_params.seed is not None:
+            generator = torch.Generator(device=probs.device).manual_seed(int(self.sampling_params.seed))
+
+        if valid_rows.all():
+            if generator is None:
+                return torch.multinomial(probs, num_samples=1).squeeze(-1)
+            return torch.multinomial(probs, num_samples=1, generator=generator).squeeze(-1)
+
+        sampled_tokens = torch.argmax(logits, dim=-1)
+        if valid_rows.any():
+            if generator is None:
+                sampled_tokens[valid_rows] = torch.multinomial(probs[valid_rows], num_samples=1).squeeze(-1)
+            else:
+                sampled_tokens[valid_rows] = torch.multinomial(
+                    probs[valid_rows],
+                    num_samples=1,
+                    generator=generator,
+                ).squeeze(-1)
+        return sampled_tokens
+    
     def generate(
         self,
         prompts: Iterable[str],
@@ -1655,7 +1703,7 @@ class DeepseekGenerator(WarmupForwardMixin):
                                 prefill_logits, torch.Tensor
                             ), "prefill_logits should be a torch.Tensor on host"
                             last_token_logits = prefill_logits[0, 0, max(prompt_len - 1, 0), :]
-                            pred_token = self._sample_greedy_on_host(last_token_logits)
+                            pred_token = int(self._sample_on_host(last_token_logits.unsqueeze(0)).item())
                         prefill_tokens.append(torch.tensor(pred_token, dtype=torch.int64))
                     self.ccl.reset_sem_counters()
                 if use_mtp_path:
@@ -1814,7 +1862,7 @@ class DeepseekGenerator(WarmupForwardMixin):
                                 ttnn.deallocate(logits)
                                 ttnn.deallocate(pred_tokens_device)
                         else:
-                            pred_tokens = self._sample_greedy_on_host(logits)
+                            pred_token = int(self._sample_on_host(last_token_logits.unsqueeze(0)).item())
                         if teacher_forcing is not None:
                             # Record user-0 prediction for accuracy, then force teacher token.
                             forced = teacher_forcing.collect_predicted_tokens(int(pred_tokens[0].item()))

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -165,7 +165,7 @@ class DeepseekGenerator(WarmupForwardMixin):
         profile_decode: bool = False,
         sample_on_device: bool = False,
         enable_mtp: bool = False,
-        sampling_params: None = None,
+        sampling_params: SamplingParams | None = None,
     ) -> None:
         self.mesh_device = mesh_device
         self.model_path = str(model_path)
@@ -226,6 +226,10 @@ class DeepseekGenerator(WarmupForwardMixin):
                 top_k=[DEFAULT_SAMPLING_TOP_K] * self.batch_size,
             )
         )
+        if self._get_sampling_value(self.sampling_params.top_k, 0) == 0 and self.sample_on_device:
+            raise SystemExit(
+                "top-k=0 is not supported when sampling on device. Sampling on host instead. See https://github.com/tenstorrent/tt-metal/issues/40236"
+            )
         if self.sample_on_device:
             enable_internal_trace_sampling = enable_trace and self.sample_on_device
             self.sampling_args = make_deepseek_sampling_args(mesh_device, self.hf_config.vocab_size)
@@ -241,9 +245,9 @@ class DeepseekGenerator(WarmupForwardMixin):
         logger.info(f"Sampling mode: {'device' if self.sample_on_device else 'host'}")
         logger.info(
             f"Sampling parameters for first user (other users may have different values): "
-            + f"temperature={self.sampling_params.temperature[0]}, "
-            + f"top_p={self.sampling_params.top_p[0]}, "
-            + f"top_k={self.sampling_params.top_k[0]}"
+            + f"temperature={self._get_sampling_value(self.sampling_params.temperature, 0)}, "
+            + f"top_p={self._get_sampling_value(self.sampling_params.top_p, 0)}, "
+            + f"top_k={self._get_sampling_value(self.sampling_params.top_k, 0)}"
         )
 
         # Weight cache to avoid loading weights multiple times
@@ -669,9 +673,8 @@ class DeepseekGenerator(WarmupForwardMixin):
         sampling_params = format_sampling_params(sampling_params, max_batch_size=batch_size)
         self.sampling_generator.reset_sampling_params(sampling_params)
         seed = getattr(sampling_params, "seed", None)
-        if seed is not None:
-            user_ids = list(range(batch_size))
-            self.sampling_generator.seed_manager.reset_seed(seed, user_ids)
+        user_ids = list(range(batch_size))
+        self.sampling_generator.seed_manager.reset_seed(seed, user_ids)
         self.sampling_generator.reset_prompt_tokens(torch.zeros((batch_size_per_row, 1), dtype=torch.int64))
         self.sampling_generator.reset_output_state(torch.zeros((batch_size_per_row, 1), dtype=torch.int64))
 

--- a/models/demos/deepseek_v3/utils/config_helpers.py
+++ b/models/demos/deepseek_v3/utils/config_helpers.py
@@ -26,7 +26,11 @@ MAX_TOP_K = 32
 # Default sampling parameters, huggingface recommended values
 DEFAULT_SAMPLING_TEMPERATURE = 0.6
 DEFAULT_SAMPLING_TOP_P = 0.95
-DEFAULT_SAMPLING_TOP_K = 0
+# huggingface recommended value for top-k sampling is zero for DeepSeek-V3 model, but TTNN Op
+# does not support top-k=0. see https://github.com/tenstorrent/tt-metal/issues/40236
+# So, using 32 as default value for top-k when sampling on device. If top-k = 0 is needed, then
+# do sampling on host.
+DEFAULT_SAMPLING_TOP_K = 32
 
 
 def get_fabric_config():

--- a/models/demos/deepseek_v3/utils/config_helpers.py
+++ b/models/demos/deepseek_v3/utils/config_helpers.py
@@ -23,6 +23,10 @@ USERS_PER_ROW = 32
 SEQ_LEN_CHUNK_SIZE = 1024  # NOTE: should be 512 for blackhole (in case of future bring-up)
 TOPK_MIN_WIDTH = 64  # Minimum width of the topk input tensor
 MAX_TOP_K = 32
+# Default sampling parameters, huggingface recommended values
+DEFAULT_SAMPLING_TEMPERATURE = 0.6
+DEFAULT_SAMPLING_TOP_P = 0.95
+DEFAULT_SAMPLING_TOP_K = 0
 
 
 def get_fabric_config():


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/40356

### What's changed
Added configurable DeepSeek sampling (temperature/top-k/top-p) across demo and generator, replaced hardcoded defaults with shared constants, and included model/sampling params in output metadata for easier run comparison.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pprajapati/sampling_params)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pprajapati/sampling_params)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pprajapati/sampling_params)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pprajapati/sampling_params)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pprajapati/sampling_params)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pprajapati/sampling_params)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pprajapati/sampling_params)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pprajapati/sampling_params)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pprajapati/sampling_params)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pprajapati/sampling_params)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pprajapati/sampling_params)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pprajapati/sampling_params)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
