### PR TITLE
[brain] Replace deprecated tt::stl:: with ttsl:: in ttnn/

### DIFF
--- a/ttnn/api/tools/profiler/op_profiler.hpp
+++ b/ttnn/api/tools/profiler/op_profiler.hpp
@@ -94,14 +94,14 @@ inline auto compute_program_hash(
                       const typename device_operation_t::tensor_args_t& tensor_args) {
                       {
                           device_operation_t::compute_program_hash(operation_attributes, tensor_args)
-                      } -> std::convertible_to<tt::stl::hash::hash_t>;
+                      } -> std::convertible_to<ttsl::hash::hash_t>;
                   }) {
         ZoneScopedN("Op profiler Compute custom program hash");
         return device_operation_t::compute_program_hash(operation_attributes, tensor_args);
     } else {
         ZoneScopedN("Op profiler Compute default program hash");
-        return tt::stl::hash::hash_objects_with_default_seed(
-            tt::stl::hash::type_hash<device_operation_t>, operation_attributes, tensor_args);
+        return ttsl::hash::hash_objects_with_default_seed(
+            ttsl::hash::type_hash<device_operation_t>, operation_attributes, tensor_args);
     }
 }
 
@@ -146,7 +146,7 @@ private:
 inline RuntimeIDToOpName runtime_id_to_opname_{};
 
 class ProgramHashToOpName {
-    using KeyType = std::pair<ChipId, tt::stl::hash::hash_t>;
+    using KeyType = std::pair<ChipId, ttsl::hash::hash_t>;
 
 public:
     std::string find_if_exists(const KeyType& key) {
@@ -412,7 +412,7 @@ inline json get_base_json(
     j["global_call_count"] = operation_id;
 
     auto as_string = [](std::string_view v) -> std::string { return {v.data(), v.size()}; };
-    std::string opName = as_string(tt::stl::get_type_name<device_operation_t>());
+    std::string opName = as_string(ttsl::get_type_name<device_operation_t>());
     if constexpr (requires { device_operation_t::get_type_name(operation_attributes); }) {
         opName = device_operation_t::get_type_name(operation_attributes);
     }
@@ -421,7 +421,7 @@ inline json get_base_json(
     j["op_code"] = opName;
 
     json attributesObj;
-    for (auto&& [name, value] : tt::stl::reflection::get_attributes(operation_attributes)) {
+    for (auto&& [name, value] : ttsl::reflection::get_attributes(operation_attributes)) {
         std::string nameStr;
         nameStr = fmt::format("{}", name);
         attributesObj[nameStr] = fmt::format("{}", value);
@@ -429,12 +429,12 @@ inline json get_base_json(
     j["attributes"] = attributesObj;
 
     std::vector<json> input_tensors;
-    tt::stl::reflection::visit_object_of_type<Tensor>(
+    ttsl::reflection::visit_object_of_type<Tensor>(
         [&input_tensors](auto&& tensor) { input_tensors.push_back(get_tensor_json(tensor)); }, tensor_args);
     j["input_tensors"] = input_tensors;
 
     std::vector<json> output_tensors;
-    tt::stl::reflection::visit_object_of_type<Tensor>(
+    ttsl::reflection::visit_object_of_type<Tensor>(
         [&output_tensors](auto&& tensor) { output_tensors.push_back(get_tensor_json(tensor)); }, tensor_return_value);
     j["output_tensors"] = output_tensors;
 

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -65,8 +65,8 @@ auto compute_program_hash(
         return device_operation_t::compute_program_hash(operation_attributes, tensor_args);
     } else {
         ZoneScopedN("Compute default program hash");
-        return tt::stl::hash::hash_objects_with_default_seed(
-            tt::stl::hash::type_hash<device_operation_t>, operation_attributes, tensor_args);
+        return ttsl::hash::hash_objects_with_default_seed(
+            ttsl::hash::type_hash<device_operation_t>, operation_attributes, tensor_args);
     }
 }
 
@@ -109,7 +109,7 @@ static auto create_mesh_workload_from_workload_factory(
         return cached_mesh_workload_t{std::move(mesh_workload), std::move(shared_variables)};
     } else {
         static_assert(
-            tt::stl::concepts::always_false_v<WorkloadFactory>,
+            ttsl::concepts::always_false_v<WorkloadFactory>,
             "WorkloadFactory must implement create_mesh_workload(operation_attributes, tensor_coords, tensor_args, "
             "tensor_return_value) or create_at(operation_attributes, mesh_coordinate, tensor_args, "
             "tensor_return_value, tensor_coords)");
@@ -133,7 +133,7 @@ auto get_operation_name(const typename device_operation_t::operation_attributes_
         // For MeshAdapter operations, we recurse to get the name of the underlying device operation
         return get_operation_name<typename device_operation_t::device_operation_t>(operation_attributes);
     } else {
-        return tt::stl::get_type_name<device_operation_t>();
+        return ttsl::get_type_name<device_operation_t>();
     }
 }
 
@@ -146,7 +146,7 @@ inline void log_operation(
     std::size_t /*device_id*/,
     const typename device_operation_t::operation_attributes_t& operation_attributes,
     const typename device_operation_t::tensor_args_t& tensor_args,
-    tt::stl::hash::hash_t program_hash,
+    ttsl::hash::hash_t program_hash,
     bool program_cache_hit) {
     log_debug(
         tt::LogOp, "Launching Device Operation: \"{}\"", get_operation_name<device_operation_t>(operation_attributes));
@@ -155,13 +155,13 @@ inline void log_operation(
     log_debug(tt::LogOp, "Program Cache Hit: {}", program_cache_hit);
 
     log_debug(tt::LogOp, "Attributes:");
-    for ([[maybe_unused]] const auto& [key, value] : tt::stl::reflection::get_attributes(operation_attributes)) {
+    for ([[maybe_unused]] const auto& [key, value] : ttsl::reflection::get_attributes(operation_attributes)) {
         log_debug(tt::LogOp, "\t{} = {}", key, value);
     }
 
     log_debug(tt::LogOp, "Tensors Args:");
     auto index = 0;
-    tt::stl::reflection::visit_object_of_type<Tensor>(
+    ttsl::reflection::visit_object_of_type<Tensor>(
         [&index](auto&& tensor) {
             log_debug(tt::LogOp, "\t{}: {}", index, tensor);
             index++;
@@ -178,7 +178,7 @@ inline void log_operation(
     std::size_t /*device_id*/,
     const typename device_operation_t::operation_attributes_t& /*operation_attributes*/,
     const typename device_operation_t::tensor_args_t& /*tensor_args*/,
-    tt::stl::hash::hash_t /*program_hash*/,
+    ttsl::hash::hash_t /*program_hash*/,
     bool /*program_cache_hit*/) {}
 
 #endif
@@ -212,7 +212,7 @@ void enqueue_mesh_workload(
 template <DeviceOperationWithMeshDeviceAdapter mesh_device_operation_t, typename ProgramFactory, typename Fn>
 void dispatch_to_mesh_workload_factory(const ProgramFactory& program_factory, const Fn& fn) {
     std::visit(
-        tt::stl::overloaded{
+        ttsl::overloaded{
             [&]<ProgramFactoryConcept T>(const T&) {
                 // Adapt ProgramFactory to MeshWorkloadFactory concept.
                 using AdaptedMeshWorkloadFactory = mesh_device_operation_t::template MeshWorkloadFactoryAdapter<T>;
@@ -231,7 +231,7 @@ void handle_mesh_adapter_cache_hit(
     typename mesh_device_operation_t::tensor_return_value_t& tensor_return_value,
     ttnn::MeshDevice* mesh_device,
     tt::tt_metal::program_cache::detail::ProgramCache& program_cache,
-    tt::stl::hash::hash_t program_hash) {
+    ttsl::hash::hash_t program_hash) {
     if constexpr (HasValidateOnProgramCacheHit<mesh_device_operation_t>) {
         mesh_device_operation_t::validate_on_program_cache_hit(operation_attributes, tensor_args);
     } else {
@@ -272,7 +272,7 @@ void emit_mesh_workload_annotation(
     if (tt::tt_metal::experimental::inspector::IsEnabled()) {
         auto operation_name = get_operation_name<mesh_device_operation_t>(operation_attributes);
         std::vector<std::reference_wrapper<const Tensor>> tensors;
-        tt::stl::reflection::visit_object_of_type<Tensor>(
+        ttsl::reflection::visit_object_of_type<Tensor>(
             [&tensors](const Tensor& t) { tensors.push_back(std::cref(t)); }, tensor_args);
         emit_mesh_workload_annotation_impl(workload, operation_name, tensors);
     }
@@ -286,7 +286,7 @@ void create_and_cache_mesh_workload(
     typename mesh_device_operation_t::tensor_return_value_t& tensor_return_value,
     ttnn::MeshDevice* mesh_device,
     tt::tt_metal::program_cache::detail::ProgramCache& program_cache,
-    tt::stl::hash::hash_t program_hash) {
+    ttsl::hash::hash_t program_hash) {
     mesh_device_operation_t::validate_on_program_cache_miss(operation_attributes, tensor_args);
 
     auto program_factory = mesh_device_operation_t::select_program_factory(operation_attributes, tensor_args);
@@ -385,7 +385,7 @@ void launch_operation_with_adapter(
     log_operation<mesh_device_operation_t>(
         mesh_device->id(), operation_attributes, tensor_args, program_hash, program_cache_hit);
 
-    tt::stl::reflection::visit_object_of_type<Tensor>(CheckDeviceBufferIsAllocated{}, tensor_args);
+    ttsl::reflection::visit_object_of_type<Tensor>(CheckDeviceBufferIsAllocated{}, tensor_args);
 
     if (program_cache_hit) {
         handle_mesh_adapter_cache_hit<mesh_device_operation_t>(
@@ -405,13 +405,13 @@ ttnn::MeshDevice* get_mesh_device(
     const typename device_operation_t::operation_attributes_t& operation_attributes,
     const typename device_operation_t::tensor_args_t& tensor_args) {
     ttnn::MeshDevice* mesh_device;
-    auto first_tensor = tt::stl::reflection::get_first_object_of_type<Tensor>(tensor_args);
+    auto first_tensor = ttsl::reflection::get_first_object_of_type<Tensor>(tensor_args);
     // Try to get the mesh device from the first tensor
     if (first_tensor.has_value()) [[likely]] {
         mesh_device = first_tensor.value().device();
     } else {
         // If no tensor is found, try to get the mesh device from the operation attributes
-        auto mesh_device_opt = tt::stl::reflection::get_first_object_of_type<ttnn::MeshDevice*>(operation_attributes);
+        auto mesh_device_opt = ttsl::reflection::get_first_object_of_type<ttnn::MeshDevice*>(operation_attributes);
         if (mesh_device_opt.has_value()) [[likely]] {
             mesh_device = mesh_device_opt.value();
         } else {
@@ -434,13 +434,13 @@ typename device_operation_t::tensor_return_value_t launch(
     const typename device_operation_t::operation_attributes_t& operation_attributes,
     const typename device_operation_t::tensor_args_t& tensor_args) {
     std::vector<std::reference_wrapper<const Tensor>> input_tensors;
-    tt::stl::reflection::visit_object_of_type<Tensor>(
+    ttsl::reflection::visit_object_of_type<Tensor>(
         [&input_tensors](const Tensor& t) { input_tensors.push_back(std::cref(t)); }, tensor_args);
 
     tt::tt_metal::GraphTracker::instance().track_function_start(
         detail::get_operation_name<device_operation_t>(operation_attributes), operation_attributes, input_tensors);
 
-    auto first_tensor = tt::stl::reflection::get_first_object_of_type<Tensor>(tensor_args);
+    auto first_tensor = ttsl::reflection::get_first_object_of_type<Tensor>(tensor_args);
     if (first_tensor.has_value()) [[likely]] {
         TT_FATAL(
             tt::tt_metal::is_device_tensor(first_tensor.value()),
@@ -477,7 +477,7 @@ typename device_operation_t::tensor_return_value_t launch(
 
         if (!custom_topologies.empty()) {
             // Use custom topologies provided by the op
-            tensor_return_value = tt::stl::reflection::transform_object_of_type<Tensor>(
+            tensor_return_value = ttsl::reflection::transform_object_of_type<Tensor>(
                 [&custom_topologies, topology_idx = size_t{0}](const Tensor& output_tensor) mutable {
                     TT_FATAL(
                         topology_idx < custom_topologies.size(),
@@ -491,7 +491,7 @@ typename device_operation_t::tensor_return_value_t launch(
             auto output_topology_result =
                 detail::compute_output_placements_and_shape(input_tensors, first_tensor.value());
 
-            tensor_return_value = tt::stl::reflection::transform_object_of_type<Tensor>(
+            tensor_return_value = ttsl::reflection::transform_object_of_type<Tensor>(
                 [&output_topology_result](const Tensor& output_tensor) {
                     auto topology = tt::tt_metal::TensorTopology(
                         output_topology_result.second,

--- a/ttnn/api/ttnn/device_operation_detail.hpp
+++ b/ttnn/api/ttnn/device_operation_detail.hpp
@@ -33,7 +33,7 @@ namespace ttnn::device_operation::detail {
  * Factored out of the template pipeline to reduce per-operation template instantiation cost.
  */
 std::pair<
-    tt::stl::SmallVector<tt::tt_metal::distributed::MeshMapperConfig::Placement>,
+    ttsl::SmallVector<tt::tt_metal::distributed::MeshMapperConfig::Placement>,
     tt::tt_metal::distributed::MeshShape>
 compute_output_placements_and_shape(
     const std::vector<std::reference_wrapper<const tt::tt_metal::Tensor>>& tensors,

--- a/ttnn/api/ttnn/distributed/distributed_tensor.hpp
+++ b/ttnn/api/ttnn/distributed/distributed_tensor.hpp
@@ -38,7 +38,7 @@ public:
     // materialized.
     template <typename T>
     Tensor operator()(
-        tt::stl::Span<T> buffer,
+        ttsl::Span<T> buffer,
         const ttnn::Shape& shape,
         const tt::tt_metal::MemoryPin& buffer_pin,
         const tt::tt_metal::TensorLayout& layout,
@@ -115,7 +115,7 @@ Tensor distribute_tensor(
 // `buffer_pin` as the RAII to retain reference count to the object.
 template <typename T>
 Tensor create_distributed_tensor(
-    tt::stl::Span<T> buffer,
+    ttsl::Span<T> buffer,
     const ttnn::Shape& global_shape,
     const tt::tt_metal::MemoryPin& buffer_pin,
     const tt::tt_metal::TensorLayout& shard_layout,
@@ -127,7 +127,7 @@ Tensor create_distributed_tensor(
 // Overload for unowned spans of data.
 template <typename T>
 Tensor create_distributed_tensor(
-    tt::stl::Span<const T> buffer,
+    ttsl::Span<const T> buffer,
     const ttnn::Shape& global_shape,
     const tt::tt_metal::TensorLayout& shard_layout,
     const TensorToMesh& mapper,

--- a/ttnn/api/ttnn/graph/graph_query_op_constraints.hpp
+++ b/ttnn/api/ttnn/graph/graph_query_op_constraints.hpp
@@ -62,7 +62,7 @@ auto invoke_op(Op&& op, Tuple& args) {
 template <typename T>
 inline std::vector<Tensor> extract_output_tensors(const T& result) {
     std::vector<Tensor> tensors;
-    tt::stl::reflection::visit_object_of_type<Tensor>([&tensors](auto&& tensor) { tensors.push_back(tensor); }, result);
+    ttsl::reflection::visit_object_of_type<Tensor>([&tensors](auto&& tensor) { tensors.push_back(tensor); }, result);
     return tensors;
 }
 
@@ -72,7 +72,7 @@ inline std::vector<Tensor> extract_output_tensors(const std::variant<Ts...>& res
     std::vector<Tensor> tensors;
     std::visit(
         [&tensors](auto&& value) {
-            tt::stl::reflection::visit_object_of_type<Tensor>(
+            ttsl::reflection::visit_object_of_type<Tensor>(
                 [&tensors](auto&& tensor) { tensors.push_back(tensor); }, value);
         },
         result);

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -70,7 +70,7 @@ struct MeshDeviceOperationAdapter {
     // Returns type name of the underlying device operation.
     // Used for logging and debugging; in particular, Tracy profiler uses this to identify operations.
     static std::string get_type_name(const operation_attributes_t& /* attribute */) {
-        return std::string(tt::stl::get_type_name<device_operation_t>());
+        return std::string(ttsl::get_type_name<device_operation_t>());
     }
 
     static void validate_on_program_cache_hit(const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
@@ -95,13 +95,13 @@ struct MeshDeviceOperationAdapter {
         return DeviceOperation::create_output_tensors(attrs, tensor_args);
     }
 
-    static tt::stl::hash::hash_t compute_program_hash(
+    static ttsl::hash::hash_t compute_program_hash(
         const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
         if constexpr (requires { DeviceOperation::compute_program_hash(attrs, tensor_args); }) {
             return DeviceOperation::compute_program_hash(attrs, tensor_args);
         } else {
-            return tt::stl::hash::hash_objects_with_default_seed(
-                tt::stl::hash::type_hash<DeviceOperation>, attrs, tensor_args);
+            return ttsl::hash::hash_objects_with_default_seed(
+                ttsl::hash::type_hash<DeviceOperation>, attrs, tensor_args);
         }
     }
 
@@ -152,7 +152,7 @@ struct MeshDeviceOperationAdapter {
         }
     };
 
-    static tt::stl::hash::hash_t compute_mesh_workload_hash(
+    static ttsl::hash::hash_t compute_mesh_workload_hash(
         tt::tt_metal::distributed::MeshDevice* mesh_device,
         const operation_attributes_t& attrs,
         const tensor_args_t& tensor_args) {

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -159,7 +159,7 @@ struct MeshDeviceOperationAdapter {
         // Hash the program hash and the tensor coordinates the workload is targeting.
         auto hash = compute_program_hash(attrs, tensor_args);
         for (const auto& coord : mesh_device_operation_utils::extract_tensor_coordinates(tensor_args, mesh_device)) {
-            ttsl::hash::hash_combine(hash, coord);
+            hash = ttsl::hash::hash_objects(hash, coord);
         }
         return hash;
     }

--- a/ttnn/api/ttnn/mesh_device_operation_utils.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_utils.hpp
@@ -29,7 +29,7 @@ using AdaptedCachedMeshWorkload = tt::tt_metal::program_cache::detail::AdaptedCa
 template <typename TensorArgs>
 bool all_tensors_have_uniform_storage(const TensorArgs& tensor_args) {
     bool uniform_storage = true;
-    tt::stl::reflection::visit_object_of_type<Tensor>(
+    ttsl::reflection::visit_object_of_type<Tensor>(
         [&](const Tensor& tensor) { uniform_storage &= tensor.device_storage().is_uniform_storage(); }, tensor_args);
     return uniform_storage;
 }
@@ -39,7 +39,7 @@ bool all_tensors_have_uniform_storage(const TensorArgs& tensor_args) {
 template <typename TensorReturnValue>
 TensorReturnValue filter_tensor_shards(
     const std::vector<ttnn::MeshCoordinate>& tensor_coordinates, const TensorReturnValue& tensor_return_value) {
-    return tt::stl::reflection::transform_object_of_type<Tensor>(
+    return ttsl::reflection::transform_object_of_type<Tensor>(
         [&](const Tensor& tensor) -> Tensor {
             const auto& old_storage = tensor.device_storage();
 
@@ -76,7 +76,7 @@ template <typename TensorArgs>
 std::vector<ttnn::MeshCoordinate> extract_tensor_coordinates(
     const TensorArgs& tensor_args, ttnn::MeshDevice* mesh_device = nullptr) {
     std::vector<std::reference_wrapper<const Tensor>> tensors;
-    tt::stl::reflection::visit_object_of_type<Tensor>(
+    ttsl::reflection::visit_object_of_type<Tensor>(
         [&tensors](const Tensor& t) { tensors.push_back(std::cref(t)); }, tensor_args);
     return ttnn::device_operation::detail::extract_tensor_coordinates_impl(tensors, mesh_device);
 }

--- a/ttnn/api/ttnn/operation.hpp
+++ b/ttnn/api/ttnn/operation.hpp
@@ -22,7 +22,7 @@ using Hash = ttsl::hash::hash_t;
 
 template <typename OperationType, typename... Types>
 static Hash hash_operation(const Types&... objects) {
-    return stl::hash::hash_objects_with_default_seed(ttsl::hash::type_hash<OperationType>, objects...);
+    return ttsl::hash::hash_objects_with_default_seed(ttsl::hash::type_hash<OperationType>, objects...);
 }
 
 using Tensors = std::vector<Tensor>;

--- a/ttnn/api/ttnn/operation.hpp
+++ b/ttnn/api/ttnn/operation.hpp
@@ -18,11 +18,11 @@
 
 namespace tt::tt_metal::operation {
 
-using Hash = tt::stl::hash::hash_t;
+using Hash = ttsl::hash::hash_t;
 
 template <typename OperationType, typename... Types>
 static Hash hash_operation(const Types&... objects) {
-    return stl::hash::hash_objects_with_default_seed(tt::stl::hash::type_hash<OperationType>, objects...);
+    return stl::hash::hash_objects_with_default_seed(ttsl::hash::type_hash<OperationType>, objects...);
 }
 
 using Tensors = std::vector<Tensor>;
@@ -165,10 +165,10 @@ public:
 struct ExternalOperation {
     using OutputTensors = Tensors;
     const std::string function_name_;
-    const tt::stl::reflection::Attributes attributes_;
+    const ttsl::reflection::Attributes attributes_;
 
     std::string get_type_name() const { return this->function_name_; }
-    tt::stl::reflection::Attributes attributes() const { return this->attributes_; }
+    ttsl::reflection::Attributes attributes() const { return this->attributes_; }
 };
 
 }  // namespace tt::tt_metal::operation

--- a/ttnn/api/ttnn/tensor/host_buffer/functions.hpp
+++ b/ttnn/api/ttnn/tensor/host_buffer/functions.hpp
@@ -38,24 +38,24 @@ void validate_datatype(const Tensor& tensor) {
 HostBuffer get_host_buffer(const Tensor& tensor);
 
 template <typename T>
-tt::stl::Span<const T> get_as(const HostBuffer& buffer) {
+ttsl::Span<const T> get_as(const HostBuffer& buffer) {
     return buffer.view_as<T>();
 }
 
 template <typename T>
-tt::stl::Span<T> get_as(HostBuffer& buffer) {
+ttsl::Span<T> get_as(HostBuffer& buffer) {
     return buffer.view_as<T>();
 }
 
 template <typename T>
-tt::stl::Span<const T> get_as(const Tensor& tensor) {
+ttsl::Span<const T> get_as(const Tensor& tensor) {
     validate_datatype<T>(tensor);
     HostBuffer buffer = get_host_buffer(tensor);
     return buffer.template view_as<T>();
 }
 
 template <typename T>
-tt::stl::Span<T> get_as(Tensor& tensor) {
+ttsl::Span<T> get_as(Tensor& tensor) {
     validate_datatype<T>(tensor);
     HostBuffer buffer = get_host_buffer(tensor);
     return buffer.template view_as<T>();

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -78,7 +78,7 @@ public:
     // The data in the buffer is copied into a tensor with host storage.
     template <typename T>
     [[nodiscard]] static Tensor from_span(
-        tt::stl::Span<const T> buffer,
+        ttsl::Span<const T> buffer,
         const TensorSpec& spec,
         distributed::MeshDevice* device = nullptr,
         std::optional<tt::tt_metal::QueueId> cq_id = std::nullopt,
@@ -98,11 +98,11 @@ public:
     // void* mmap_addr = mmap(...);
     // MemoryPin memory_pin(std::shared_ptr<void>(mmap_addr, [](void* addr) { munmap(addr, ...); }));
     // Tensor tensor = Tensor::from_borrowed_data(
-    //     tt::stl::Span<T>(reinterpret_cast<T*>(mmap_addr), buffer_size), shape, memory_pin);
+    //     ttsl::Span<T>(reinterpret_cast<T*>(mmap_addr), buffer_size), shape, memory_pin);
     //
     template <typename T>
     [[nodiscard]] static Tensor from_borrowed_data(
-        tt::stl::Span<T> buffer,
+        ttsl::Span<T> buffer,
         const tt::tt_metal::Shape& shape,
         tt::tt_metal::MemoryPin buffer_pin,
         const std::optional<Tile>& tile = std::nullopt);
@@ -110,7 +110,7 @@ public:
     // Overload that takes `on_creation_callback` and `on_destruction_callback` as separate arguments.
     template <typename T>
     [[nodiscard]] static Tensor from_borrowed_data(
-        tt::stl::Span<T> buffer,
+        ttsl::Span<T> buffer,
         const tt::tt_metal::Shape& shape,
         const std::function<void()>& on_creation_callback,
         const std::function<void()>& on_destruction_callback,
@@ -126,7 +126,7 @@ public:
         distributed::MeshDevice* device = nullptr,
         std::optional<tt::tt_metal::QueueId> cq_id = std::nullopt,
         T pad_value = 0) {
-        return from_span(tt::stl::Span<const T>(buffer), spec, device, cq_id, pad_value);
+        return from_span(ttsl::Span<const T>(buffer), spec, device, cq_id, pad_value);
     }
 
     // Same as `from_vector`, but takes in an rvalue. No copies will be made, if the target layout is row-major,

--- a/ttnn/api/ttnn/tensor/tensor_impl.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_impl.hpp
@@ -32,7 +32,7 @@ struct bfloat8_b {};
 
 template <typename T>
 std::vector<T> convert_layout_tile_to_row_major(
-    const Shape2D& shape, const Tile& tile, tt::stl::Span<const T> data_to_convert) {
+    const Shape2D& shape, const Tile& tile, ttsl::Span<const T> data_to_convert) {
     auto tile_shape = tile.get_tile_shape();
     auto face_shape = tile.get_face_shape();
     auto transpose_within_face = tile.get_transpose_within_face();
@@ -62,7 +62,7 @@ std::vector<T> convert_layout_tile_to_row_major(
 //     ** For the last shard, we only align to nearest page instead of full shard size for partial shards
 //   * After conversion, size of physical data will match 2D physical size indicated by tensor_spec.physical_shape()
 template <typename T>
-std::vector<T> encode_tensor_data(tt::stl::Span<const T> logical_data, const TensorSpec& tensor_spec, T pad_value = 0);
+std::vector<T> encode_tensor_data(ttsl::Span<const T> logical_data, const TensorSpec& tensor_spec, T pad_value = 0);
 
 // Converts physical data into logical data based on tensor spec (see encode_tensor_data for details)
 // - Physical data: Flat container of physical data corresponding to tensor spec
@@ -72,7 +72,7 @@ std::vector<T> encode_tensor_data(tt::stl::Span<const T> logical_data, const Ten
 //   * To get logical data, perform the exact inverse process of encode_tensor_data
 //   * Resulting data is safe to be converted to python tensors or general consumption with just a ND logical shape
 template <typename T>
-std::vector<T> decode_tensor_data(tt::stl::Span<const T> physical_data, const TensorSpec& tensor_spec);
+std::vector<T> decode_tensor_data(ttsl::Span<const T> physical_data, const TensorSpec& tensor_spec);
 
 // ===============================================================================================================================================
 //                                                              High Level APIs

--- a/ttnn/api/ttnn/tensor/xtensor/conversion_utils.hpp
+++ b/ttnn/api/ttnn/tensor/xtensor/conversion_utils.hpp
@@ -30,7 +30,7 @@ using AdaptedView = decltype(xt::adapt(
 // Returns `AdaptedView<T>` for a span of data.
 // Does not take ownership of the data.
 template <typename T>
-auto adapt(tt::stl::Span<T> data, const std::vector<size_t>& shape_vec) {
+auto adapt(ttsl::Span<T> data, const std::vector<size_t>& shape_vec) {
     return xt::adapt(data.data(), data.size(), xt::no_ownership(), std::move(shape_vec));
 }
 
@@ -40,18 +40,18 @@ template <typename T>
 class XtensorAdapter {
 public:
     XtensorAdapter(std::vector<T>&& data, const std::vector<size_t>& shape_vec) :
-        data_(std::move(data)), expr_(adapt(tt::stl::make_span(data_), std::move(shape_vec))) {}
+        data_(std::move(data)), expr_(adapt(ttsl::make_span(data_), std::move(shape_vec))) {}
 
     XtensorAdapter(const XtensorAdapter& other) :
-        data_(other.data_), expr_(adapt(tt::stl::make_span(data_), other.expr_.shape())) {}
+        data_(other.data_), expr_(adapt(ttsl::make_span(data_), other.expr_.shape())) {}
 
     XtensorAdapter(XtensorAdapter&& other) noexcept :
-        data_(std::move(other.data_)), expr_(adapt(tt::stl::make_span(data_), other.expr_.shape())) {}
+        data_(std::move(other.data_)), expr_(adapt(ttsl::make_span(data_), other.expr_.shape())) {}
 
     XtensorAdapter& operator=(const XtensorAdapter& other) {
         if (this != &other) {
             data_ = other.data_;
-            expr_ = adapt(tt::stl::make_span(data_), other.expr_.shape());
+            expr_ = adapt(ttsl::make_span(data_), other.expr_.shape());
         }
         return *this;
     }
@@ -59,7 +59,7 @@ public:
     XtensorAdapter& operator=(XtensorAdapter&& other) noexcept {
         if (this != &other) {
             data_ = std::move(other.data_);
-            expr_ = adapt(tt::stl::make_span(data_), other.expr_.shape());
+            expr_ = adapt(ttsl::make_span(data_), other.expr_.shape());
         }
         return *this;
     }
@@ -82,7 +82,7 @@ private:
 // Converts a span to an xtensor view.
 // IMPORTANT: the lifetime of the returned xtensor view is tied to the lifetime of the underlying buffer.
 template <typename T>
-xt::xarray<T> span_to_xtensor_view(tt::stl::Span<const T> buffer, const tt::tt_metal::Shape& shape) {
+xt::xarray<T> span_to_xtensor_view(ttsl::Span<const T> buffer, const tt::tt_metal::Shape& shape) {
     std::vector<size_t> shape_vec(shape.cbegin(), shape.cend());
     return xt::adapt(buffer.data(), buffer.size(), xt::no_ownership(), shape_vec);
 }
@@ -100,7 +100,7 @@ xt::xarray<T> span_to_xtensor_view(std::span<T> buffer, const tt::tt_metal::Shap
 template <typename T>
 auto xtensor_to_span(const xt::xarray<T>& xtensor) {
     auto adaptor = xt::adapt(xtensor.data(), xtensor.size(), xt::no_ownership());
-    return tt::stl::Span<const T>(adaptor.data(), adaptor.size());
+    return ttsl::Span<const T>(adaptor.data(), adaptor.size());
 }
 
 // Converts an xtensor to a Tensor.
@@ -119,7 +119,7 @@ template <typename T>
 xt::xarray<T> to_xtensor(const tt::tt_metal::Tensor& tensor) {
     auto vec = tensor.to_vector<T>();
     const auto& shape = tensor.logical_shape();
-    return xt::xarray<T>(span_to_xtensor_view(tt::stl::Span<T>(vec.data(), vec.size()), shape));
+    return xt::xarray<T>(span_to_xtensor_view(ttsl::Span<T>(vec.data(), vec.size()), shape));
 }
 
 }  // namespace tt::tt_metal::experimental::xtensor

--- a/ttnn/core/device_operation_detail.cpp
+++ b/ttnn/core/device_operation_detail.cpp
@@ -48,7 +48,7 @@ static bool is_fully_replicated(const tt::tt_metal::Tensor& tensor) {
 }
 
 std::pair<
-    tt::stl::SmallVector<tt::tt_metal::distributed::MeshMapperConfig::Placement>,
+    ttsl::SmallVector<tt::tt_metal::distributed::MeshMapperConfig::Placement>,
     tt::tt_metal::distributed::MeshShape>
 compute_output_placements_and_shape(
     const std::vector<std::reference_wrapper<const tt::tt_metal::Tensor>>& tensors,
@@ -77,8 +77,8 @@ compute_output_placements_and_shape(
         max_distribution_rank = first_tensor.tensor_topology().distribution_shape().dims();
     }
 
-    auto result_strides = tt::stl::SmallVector<uint32_t>(max_distribution_rank, 1);
-    auto result_placements = tt::stl::SmallVector<Placement>(max_distribution_rank, Replicate{});
+    auto result_strides = ttsl::SmallVector<uint32_t>(max_distribution_rank, 1);
+    auto result_placements = ttsl::SmallVector<Placement>(max_distribution_rank, Replicate{});
     std::unordered_map<int, int> shard_dim_to_distribution_dim;
     bool dim_mismatch = false;
 

--- a/ttnn/core/distributed/distributed_nanobind.cpp
+++ b/ttnn/core/distributed/distributed_nanobind.cpp
@@ -611,7 +611,7 @@ void py_module(nb::module_& mod) {
     py_mesh_mapper_config.def(
         "__init__",
         [](MeshMapperConfig* t,
-           tt::stl::SmallVector<MeshMapperConfig::Placement> placements,
+           ttsl::SmallVector<MeshMapperConfig::Placement> placements,
            const std::optional<MeshShape>& mesh_shape_override) {
             new (t) MeshMapperConfig{.placements = std::move(placements), .mesh_shape_override = mesh_shape_override};
         },
@@ -666,7 +666,7 @@ void py_module(nb::module_& mod) {
     auto py_mesh_composer_config = static_cast<nb::class_<MeshComposerConfig>>(mod.attr("MeshComposerConfig"));
     py_mesh_composer_config
         .def(
-            nb::init<tt::stl::SmallVector<int>, const std::optional<MeshShape>&>(),
+            nb::init<ttsl::SmallVector<int>, const std::optional<MeshShape>&>(),
             nb::arg("dims"),
             nb::arg("mesh_shape_override") = nb::none(),
             R"doc(

--- a/ttnn/core/distributed/distributed_tensor.cpp
+++ b/ttnn/core/distributed/distributed_tensor.cpp
@@ -48,7 +48,7 @@ auto get_remap_fn(DistributionMode distribution_mode, const MeshCoordinateRange*
 }
 
 // Increments `indices` in-place given `limits`, to support row-major order iteration.
-bool increment_indices(const tt::stl::SmallVector<int>& limits, tt::stl::SmallVector<int>& indices) {
+bool increment_indices(const ttsl::SmallVector<int>& limits, ttsl::SmallVector<int>& indices) {
     for (int i = static_cast<int>(indices.size()) - 1; i >= 0; --i) {
         if (++indices[i] < limits[i]) {
             return true;
@@ -87,7 +87,7 @@ TensorSpec compute_tensor_spec_for_shards(
 // - Otherwise, a copy of the data is created.
 template <typename T>
 tt::tt_metal::HostBuffer create_host_buffer_from_span(
-    tt::stl::Span<T> span, const tt::tt_metal::MemoryPin& buffer_pin, const TensorSpec& tensor_spec, T pad_value) {
+    ttsl::Span<T> span, const tt::tt_metal::MemoryPin& buffer_pin, const TensorSpec& tensor_spec, T pad_value) {
     if constexpr (!std::is_const_v<T>) {
         if (tensor_spec.layout() == tt::tt_metal::Layout::ROW_MAJOR &&
             tensor_spec.physical_shape() == tensor_spec.logical_2d_shape() &&
@@ -97,7 +97,7 @@ tt::tt_metal::HostBuffer create_host_buffer_from_span(
     }
 
     return tt::tt_metal::host_buffer::get_host_buffer(Tensor::from_span(
-        tt::stl::make_const_span(span),
+        ttsl::make_const_span(span),
         tensor_spec,
         /*device=*/nullptr,
         /*cq_id=*/std::nullopt,
@@ -148,7 +148,7 @@ public:
 
     template <typename T>
     Tensor operator()(
-        tt::stl::Span<T> span,
+        ttsl::Span<T> span,
         const Shape& shape,
         const tt::tt_metal::MemoryPin& buffer_pin,
         const tt::tt_metal::TensorLayout& layout,
@@ -158,10 +158,10 @@ public:
             span.size() == volume, "Current buffer size is {} different from shape volume {}", span.size(), volume);
 
         // Perform sharding, followed by replication.
-        tt::stl::SmallVector<size_t> shard_dims;
-        tt::stl::SmallVector<int> num_chunks_per_dim;
-        tt::stl::SmallVector<int> tensor_dims;
-        tt::stl::SmallVector<size_t> replicate_dims;
+        ttsl::SmallVector<size_t> shard_dims;
+        ttsl::SmallVector<int> num_chunks_per_dim;
+        ttsl::SmallVector<int> tensor_dims;
+        ttsl::SmallVector<size_t> replicate_dims;
         size_t sharded_mesh_size = 1;
         for (size_t mesh_dim_idx = 0; mesh_dim_idx < distribution_shape_.dims(); ++mesh_dim_idx) {
             const auto& placement = config_.placements[mesh_dim_idx];
@@ -214,9 +214,9 @@ public:
 
         // Distribute chunks to appropriate mesh coordinates.
         size_t chunk_idx = 0;
-        tt::stl::SmallVector<int> shard_indices(shard_dims.size(), 0);
+        ttsl::SmallVector<int> shard_indices(shard_dims.size(), 0);
         do {
-            tt::stl::SmallVector<uint32_t> mesh_coords(distribution_shape_.dims(), 0);
+            ttsl::SmallVector<uint32_t> mesh_coords(distribution_shape_.dims(), 0);
             for (size_t i = 0; i < shard_dims.size(); ++i) {
                 mesh_coords[shard_dims[i]] = shard_indices[i];
             }
@@ -227,7 +227,7 @@ public:
             chunk_idx++;
         } while (increment_indices(num_chunks_per_dim, shard_indices));
 
-        tt::stl::SmallVector<int> replicate_sizes;
+        ttsl::SmallVector<int> replicate_sizes;
         for (size_t replicate_mesh_dim : replicate_dims) {
             replicate_sizes.push_back(distribution_shape_[replicate_mesh_dim]);
         }
@@ -242,9 +242,9 @@ public:
                         return coord[replicate_mesh_dim] == 0;
                     });
                 if (xtensor_view.has_value() && replication_source) {
-                    tt::stl::SmallVector<int> replicate_indices(replicate_dims.size(), 0);
+                    ttsl::SmallVector<int> replicate_indices(replicate_dims.size(), 0);
                     do {
-                        tt::stl::SmallVector<uint32_t> mesh_coords(coord.coords().begin(), coord.coords().end());
+                        ttsl::SmallVector<uint32_t> mesh_coords(coord.coords().begin(), coord.coords().end());
                         for (size_t i = 0; i < replicate_dims.size(); ++i) {
                             mesh_coords[replicate_dims[i]] = replicate_indices[i];
                         }
@@ -264,7 +264,7 @@ private:
         const tt::tt_metal::TensorLayout& layout,
         T pad_value,
         const tt::tt_metal::MemoryPin& buffer_pin,
-        const tt::stl::SmallVector<int>& shard_dims) const {
+        const ttsl::SmallVector<int>& shard_dims) const {
         const TensorSpec shard_spec = compute_tensor_spec_for_shards(sharded_xtensor_views, layout);
 
         // Determine whether we can borrow directly from the source buffer instead of copying.
@@ -331,7 +331,7 @@ private:
                         auto& view = xtensor_view->get();
                         using U = std::remove_const_t<T>;
                         shard_tensor = Tensor::from_borrowed_data(
-                            tt::stl::Span<U>(const_cast<U*>(view.data() + view.data_offset()), view.size()),
+                            ttsl::Span<U>(const_cast<U*>(view.data() + view.data_offset()), view.size()),
                             shard_spec.logical_shape(),
                             buffer_pin);
                     } else {
@@ -420,7 +420,7 @@ public:
             xtensor_views.push_back(tt::tt_metal::experimental::xtensor::adapt(shard.view_as<const T>(), shard_shape));
         });
 
-        tt::stl::SmallVector<int> num_chunks;
+        ttsl::SmallVector<int> num_chunks;
         // Scalar (0-dim tensor)
         bool is_single_views = xtensor_views.size() == 1;
         if (!is_single_views) {
@@ -483,7 +483,7 @@ Tensor TensorToMesh::operator()(const Tensor& tensor) const { return (*impl_)(te
 
 template <typename T>
 Tensor TensorToMesh::operator()(
-    tt::stl::Span<T> buffer,
+    ttsl::Span<T> buffer,
     const ttnn::Shape& shape,
     const tt::tt_metal::MemoryPin& buffer_pin,
     const tt::tt_metal::TensorLayout& layout,
@@ -567,7 +567,7 @@ std::unique_ptr<TensorToMesh> shard_tensor_to_mesh_mapper(
         "Cluster axis {} is out of range for mesh device with {} dimensions",
         cluster_axis.value(),
         mesh_device.shape().dims());
-    tt::stl::SmallVector<MeshMapperConfig::Placement> placements(
+    ttsl::SmallVector<MeshMapperConfig::Placement> placements(
         mesh_device.shape().dims(), MeshMapperConfig::Replicate{});
     placements[cluster_axis.value()] = MeshMapperConfig::Shard{dim};
     return std::make_unique<TensorToMesh>(
@@ -605,7 +605,7 @@ Tensor distribute_tensor(
 
 template <typename T>
 Tensor create_distributed_tensor(
-    tt::stl::Span<T> buffer,
+    ttsl::Span<T> buffer,
     const ttnn::Shape& global_shape,
     const tt::tt_metal::MemoryPin& buffer_pin,
     const tt::tt_metal::TensorLayout& shard_layout,
@@ -622,7 +622,7 @@ Tensor create_distributed_tensor(
 
 template <typename T>
 Tensor create_distributed_tensor(
-    tt::stl::Span<const T> buffer,
+    ttsl::Span<const T> buffer,
     const ttnn::Shape& global_shape,
     const tt::tt_metal::TensorLayout& shard_layout,
     const TensorToMesh& mapper,
@@ -639,7 +639,7 @@ Tensor create_distributed_tensor(
 
 #define INSTANTIATE_CREATE_DISTRIBUTED_TENSOR(TYPE)                    \
     template Tensor create_distributed_tensor<TYPE>(                   \
-        tt::stl::Span<TYPE> buffer,                                    \
+        ttsl::Span<TYPE> buffer,                                    \
         const ttnn::Shape& global_shape,                               \
         const tt::tt_metal::MemoryPin& buffer_pin,                     \
         const tt::tt_metal::TensorLayout& shard_layout,                \
@@ -648,7 +648,7 @@ Tensor create_distributed_tensor(
         std::optional<ttnn::QueueId> cq_id,                            \
         TYPE pad_value);                                               \
     template Tensor create_distributed_tensor<TYPE>(                   \
-        tt::stl::Span<const TYPE> buffer,                              \
+        ttsl::Span<const TYPE> buffer,                              \
         const ttnn::Shape& global_shape,                               \
         const tt::tt_metal::TensorLayout& shard_layout,                \
         const TensorToMesh& mapper,                                    \

--- a/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
+++ b/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
@@ -55,33 +55,33 @@ tt::tt_metal::distributed::MeshShape from_flatbuffer(const flatbuffer::MeshShape
 tt::tt_metal::HostBuffer create_host_buffer_from_bytes(
     uint64_t size_bytes,
     const TensorSpec& spec,
-    tt::stl::Span<std::byte> data,
+    ttsl::Span<std::byte> data,
     const tt::tt_metal::MemoryPin& memory_pin) {
     switch (spec.data_type()) {
         case tt::tt_metal::DataType::UINT32:
         case tt::tt_metal::DataType::BFLOAT8_B:
         case tt::tt_metal::DataType::BFLOAT4_B: {
-            tt::stl::Span<uint32_t> typed_span(reinterpret_cast<uint32_t*>(data.data()), size_bytes / sizeof(uint32_t));
+            ttsl::Span<uint32_t> typed_span(reinterpret_cast<uint32_t*>(data.data()), size_bytes / sizeof(uint32_t));
             return tt::tt_metal::HostBuffer(typed_span, memory_pin);
         }
         case tt::tt_metal::DataType::INT32: {
-            tt::stl::Span<int32_t> typed_span(reinterpret_cast<int32_t*>(data.data()), size_bytes / sizeof(int32_t));
+            ttsl::Span<int32_t> typed_span(reinterpret_cast<int32_t*>(data.data()), size_bytes / sizeof(int32_t));
             return tt::tt_metal::HostBuffer(typed_span, memory_pin);
         }
         case tt::tt_metal::DataType::UINT8: {
-            tt::stl::Span<uint8_t> typed_span(reinterpret_cast<uint8_t*>(data.data()), size_bytes / sizeof(uint8_t));
+            ttsl::Span<uint8_t> typed_span(reinterpret_cast<uint8_t*>(data.data()), size_bytes / sizeof(uint8_t));
             return tt::tt_metal::HostBuffer(typed_span, memory_pin);
         }
         case tt::tt_metal::DataType::UINT16: {
-            tt::stl::Span<uint16_t> typed_span(reinterpret_cast<uint16_t*>(data.data()), size_bytes / sizeof(uint16_t));
+            ttsl::Span<uint16_t> typed_span(reinterpret_cast<uint16_t*>(data.data()), size_bytes / sizeof(uint16_t));
             return tt::tt_metal::HostBuffer(typed_span, memory_pin);
         }
         case tt::tt_metal::DataType::FLOAT32: {
-            tt::stl::Span<float> typed_span(reinterpret_cast<float*>(data.data()), size_bytes / sizeof(float));
+            ttsl::Span<float> typed_span(reinterpret_cast<float*>(data.data()), size_bytes / sizeof(float));
             return tt::tt_metal::HostBuffer(typed_span, memory_pin);
         }
         case tt::tt_metal::DataType::BFLOAT16: {
-            tt::stl::Span<bfloat16> typed_span(reinterpret_cast<bfloat16*>(data.data()), size_bytes / sizeof(bfloat16));
+            ttsl::Span<bfloat16> typed_span(reinterpret_cast<bfloat16*>(data.data()), size_bytes / sizeof(bfloat16));
             return tt::tt_metal::HostBuffer(typed_span, memory_pin);
         }
         case tt::tt_metal::DataType::INVALID: TT_THROW("Unsupported DataType");
@@ -212,7 +212,7 @@ flatbuffers::Offset<ttnn::flatbuffer::Tensor> to_flatbuffer(
 
 Tensor from_flatbuffer(
     const ttnn::flatbuffer::Tensor* fb_tensor,
-    tt::stl::Span<std::byte> tensor_data,
+    ttsl::Span<std::byte> tensor_data,
     const tt::tt_metal::MemoryPin& memory_pin) {
     auto spec = ttnn::from_flatbuffer(fb_tensor->tensor_spec());
 
@@ -231,7 +231,7 @@ Tensor from_flatbuffer(
         const uint64_t size = inline_storage->size();
 
         tt::tt_metal::HostBuffer host_buffer = create_host_buffer_from_bytes(
-            size, spec, tt::stl::Span<std::byte>(tensor_data.data() + offset, size), memory_pin);
+            size, spec, ttsl::Span<std::byte>(tensor_data.data() + offset, size), memory_pin);
 
         TT_FATAL(shard->mesh_coordinate() != nullptr, "Mesh coordinate is required for each shard");
         const auto coord = from_flatbuffer(shard->mesh_coordinate());

--- a/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.hpp
+++ b/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.hpp
@@ -20,7 +20,7 @@ namespace ttnn {
 // Only inline file storage (data stored in same file) is currently supported.
 Tensor from_flatbuffer(
     const ttnn::flatbuffer::Tensor* fb_tensor,
-    tt::stl::Span<std::byte> tensor_data,
+    ttsl::Span<std::byte> tensor_data,
     const tt::tt_metal::MemoryPin& memory_pin);
 
 // Converts Tensor object to FlatBuffer representation, writing the serialized flatbuffer object to `builder` and

--- a/ttnn/core/tensor/py_to_tt_tensor.cpp
+++ b/ttnn/core/tensor/py_to_tt_tensor.cpp
@@ -126,7 +126,7 @@ Tensor create_tt_tensor_from_host_data(
 
         TensorSpec tensor_spec(tensor_shape, dst_tensor_layout);
         return Tensor::from_span(
-            tt::stl::make_const_span(host_buffer.view_as<T>()),
+            ttsl::make_const_span(host_buffer.view_as<T>()),
             tensor_spec,
             nullptr,
             std::nullopt,
@@ -265,7 +265,7 @@ Tensor convert_python_tensor_to_tt_tensor(
         }
         new_dims.push_back(N);
         new_dims.push_back(K);
-        effective_shape = ttnn::Shape(tt::stl::Span<const uint32_t>(new_dims.data(), new_dims.size()));
+        effective_shape = ttnn::Shape(ttsl::Span<const uint32_t>(new_dims.data(), new_dims.size()));
     }
 
     Tensor output = create_tt_tensor_from_host_data(

--- a/ttnn/core/tensor/serialization.cpp
+++ b/ttnn/core/tensor/serialization.cpp
@@ -145,7 +145,7 @@ Tensor load_tensor_flatbuffer(const std::string& file_name, distributed::MeshDev
         (reinterpret_cast<uintptr_t>(data_region) & (kFlatbufferAlignment - 1)) == 0,
         "Tensor data pointer must be 8-byte aligned!");
 
-    Tensor tensor = ttnn::from_flatbuffer(fb_tensor, tt::stl::Span<std::byte>(data_region, data_size), memory_pin);
+    Tensor tensor = ttnn::from_flatbuffer(fb_tensor, ttsl::Span<std::byte>(data_region, data_size), memory_pin);
     if (device != nullptr) {
         tensor = tensor.to_device(device, tensor.tensor_spec().memory_config());
     }

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -131,7 +131,7 @@ void Tensor::deallocate_impl(bool force) {
     // GraphTracker::instance().track_function_start("Tensor::deallocate", *this, force);
     if (can_deallocate(tensor_attributes, force)) {
         std::visit(
-            tt::stl::overloaded{
+            ttsl::overloaded{
                 [](HostStorage&) {},
                 [this, force, &can_deallocate](DeviceStorage& storage) {
                     if (can_deallocate(storage.get_root_mesh_buffer(), force)) {
@@ -152,7 +152,7 @@ std::uint64_t Tensor::next_tensor_id() { return tensor_id_counter.fetch_add(1, s
 
 template <typename T>
 Tensor Tensor::from_span(
-    tt::stl::Span<const T> buffer,
+    ttsl::Span<const T> buffer,
     const TensorSpec& spec,
     distributed::MeshDevice* device,
     std::optional<tt::tt_metal::QueueId> cq_id,
@@ -162,7 +162,7 @@ Tensor Tensor::from_span(
 
 template <typename T>
 Tensor Tensor::from_borrowed_data(
-    tt::stl::Span<T> buffer,
+    ttsl::Span<T> buffer,
     const tt::tt_metal::Shape& shape,
     tt::tt_metal::MemoryPin buffer_pin,
     const std::optional<Tile>& tile) {
@@ -194,7 +194,7 @@ Tensor Tensor::from_vector(
     auto host_buffer =
         logical_matches_physical(buffer_spec)
             ? HostBuffer(std::move(buffer))
-            : HostBuffer(tensor_impl::encode_tensor_data(tt::stl::make_const_span(buffer), spec, pad_value));
+            : HostBuffer(tensor_impl::encode_tensor_data(ttsl::make_const_span(buffer), spec, pad_value));
     auto res = Tensor(std::move(host_buffer), buffer_spec);
     // Convert to datatype from original spec
     res = to_dtype(res, spec.data_type());
@@ -218,7 +218,7 @@ std::vector<float> Tensor::to_vector<float>(std::optional<tt::tt_metal::QueueId>
             if (logical_matches_physical(cpu_tensor.tensor_spec())) {
                 return physical_data;
             }
-            return tensor_impl::decode_tensor_data(tt::stl::make_const_span(physical_data), cpu_tensor.tensor_spec());
+            return tensor_impl::decode_tensor_data(ttsl::make_const_span(physical_data), cpu_tensor.tensor_spec());
         }
         case DataType::FLOAT32: {
             auto buffer = host_buffer::get_as<const float>(cpu_tensor);
@@ -232,7 +232,7 @@ std::vector<float> Tensor::to_vector<float>(std::optional<tt::tt_metal::QueueId>
                 cpu_tensor.tensor_spec().data_type() == DataType::BFLOAT8_B
                     ? unpack_bfp8_tiles_into_float_vec(buffer, /*row_major_output=*/false, /*is_exp_a=*/false, tile)
                     : unpack_bfp4_tiles_into_float_vec(buffer, /*row_major_output=*/false, /*is_exp_a=*/false, tile);
-            return tensor_impl::decode_tensor_data(tt::stl::make_const_span(unpacked_data), cpu_tensor.tensor_spec());
+            return tensor_impl::decode_tensor_data(ttsl::make_const_span(unpacked_data), cpu_tensor.tensor_spec());
         }
         default: {
             TT_THROW("Cannot convert tensor to vector for data type: {}", cpu_tensor.dtype());
@@ -257,68 +257,68 @@ std::vector<T> Tensor::to_vector(std::optional<tt::tt_metal::QueueId> cq_id) con
 
 // Instantiate explicitly for the supported types.
 template Tensor Tensor::from_span<bfloat16>(
-    tt::stl::Span<const bfloat16> buffer,
+    ttsl::Span<const bfloat16> buffer,
     const TensorSpec& spec,
     distributed::MeshDevice* device,
     std::optional<tt::tt_metal::QueueId> cq_id,
     bfloat16 pad_value);
 template Tensor Tensor::from_span<float>(
-    tt::stl::Span<const float> buffer,
+    ttsl::Span<const float> buffer,
     const TensorSpec& spec,
     distributed::MeshDevice* device,
     std::optional<tt::tt_metal::QueueId> cq_id,
     float pad_value);
 template Tensor Tensor::from_span<int32_t>(
-    tt::stl::Span<const int32_t> buffer,
+    ttsl::Span<const int32_t> buffer,
     const TensorSpec& spec,
     distributed::MeshDevice* device,
     std::optional<tt::tt_metal::QueueId> cq_id,
     int32_t pad_value);
 template Tensor Tensor::from_span<uint8_t>(
-    tt::stl::Span<const uint8_t> buffer,
+    ttsl::Span<const uint8_t> buffer,
     const TensorSpec& spec,
     distributed::MeshDevice* device,
     std::optional<tt::tt_metal::QueueId> cq_id,
     uint8_t pad_value);
 template Tensor Tensor::from_span<uint16_t>(
-    tt::stl::Span<const uint16_t> buffer,
+    ttsl::Span<const uint16_t> buffer,
     const TensorSpec& spec,
     distributed::MeshDevice* device,
     std::optional<tt::tt_metal::QueueId> cq_id,
     uint16_t pad_value);
 template Tensor Tensor::from_span<uint32_t>(
-    tt::stl::Span<const uint32_t> buffer,
+    ttsl::Span<const uint32_t> buffer,
     const TensorSpec& spec,
     distributed::MeshDevice* device,
     std::optional<tt::tt_metal::QueueId> cq_id,
     uint32_t pad_value);
 template Tensor Tensor::from_borrowed_data<float>(
-    tt::stl::Span<float> buffer,
+    ttsl::Span<float> buffer,
     const tt::tt_metal::Shape& shape,
     tt::tt_metal::MemoryPin buffer_pin,
     const std::optional<Tile>& tile);
 template Tensor Tensor::from_borrowed_data<bfloat16>(
-    tt::stl::Span<bfloat16> buffer,
+    ttsl::Span<bfloat16> buffer,
     const tt::tt_metal::Shape& shape,
     tt::tt_metal::MemoryPin buffer_pin,
     const std::optional<Tile>& tile);
 template Tensor Tensor::from_borrowed_data<int32_t>(
-    tt::stl::Span<int32_t> buffer,
+    ttsl::Span<int32_t> buffer,
     const tt::tt_metal::Shape& shape,
     tt::tt_metal::MemoryPin buffer_pin,
     const std::optional<Tile>& tile);
 template Tensor Tensor::from_borrowed_data<uint8_t>(
-    tt::stl::Span<uint8_t> buffer,
+    ttsl::Span<uint8_t> buffer,
     const tt::tt_metal::Shape& shape,
     tt::tt_metal::MemoryPin buffer_pin,
     const std::optional<Tile>& tile);
 template Tensor Tensor::from_borrowed_data<uint16_t>(
-    tt::stl::Span<uint16_t> buffer,
+    ttsl::Span<uint16_t> buffer,
     const tt::tt_metal::Shape& shape,
     tt::tt_metal::MemoryPin buffer_pin,
     const std::optional<Tile>& tile);
 template Tensor Tensor::from_borrowed_data<uint32_t>(
-    tt::stl::Span<uint32_t> buffer,
+    ttsl::Span<uint32_t> buffer,
     const tt::tt_metal::Shape& shape,
     tt::tt_metal::MemoryPin buffer_pin,
     const std::optional<Tile>& tile);
@@ -441,7 +441,7 @@ Tensor Tensor::with_tensor_topology(TensorTopology tensor_topology) const {
 
 bool Tensor::is_allocated() const {
     auto output = std::visit(
-        tt::stl::overloaded{
+        ttsl::overloaded{
             [](const DeviceStorage& storage) { return storage.is_allocated(); },
             [](const HostStorage&) { return true; },
         },
@@ -451,7 +451,7 @@ bool Tensor::is_allocated() const {
 
 StorageType Tensor::storage_type() const {
     return std::visit(
-        tt::stl::overloaded{
+        ttsl::overloaded{
             [](const HostStorage&) { return StorageType::HOST; },
             [](const DeviceStorage&) { return StorageType::DEVICE; },
         },
@@ -602,7 +602,7 @@ const std::optional<NdShardSpec>& Tensor::nd_shard_spec() const { return this->m
 const TensorTopology& Tensor::tensor_topology() const { return this->tensor_attributes->get_tensor_topology(); }
 
 std::ostream& operator<<(std::ostream& os, const tt::tt_metal::Tensor& tensor) {
-    tt::stl::reflection::operator<<(os, tensor);
+    ttsl::reflection::operator<<(os, tensor);
     return os;
 }
 

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -301,7 +301,7 @@ inline void print_datum(std::ostream& ss, uint8_t datum, bool use_scientific) {
 
 // Helper function to determine if scientific notation should be used
 template <typename T>
-bool should_use_scientific_notation(tt::stl::Span<const T> buffer) {
+bool should_use_scientific_notation(ttsl::Span<const T> buffer) {
     if (TTNN_PRINT_OPTIONS.sci_mode == SciMode::Enable) {
         return true;
     }
@@ -344,7 +344,7 @@ constexpr auto TENSOR_TYPE_STRING_PLUS_OPEN_PARENTHESIS_LENGTH = constexpr_strle
 template <typename T>
 void to_string_row_major(
     std::stringstream& ss,
-    tt::stl::Span<const T> buffer,
+    ttsl::Span<const T> buffer,
     const tt::tt_metal::Shape& shape,
     const tt::tt_metal::Strides& strides,
     std::size_t outer_index,
@@ -404,7 +404,7 @@ void to_string_row_major(
 template <typename T>
 void to_string(
     std::stringstream& ss,
-    tt::stl::Span<const T> buffer,
+    ttsl::Span<const T> buffer,
     const tt::tt_metal::Shape& shape,
     const tt::tt_metal::Strides& strides,
     DataType dtype,
@@ -842,7 +842,7 @@ std::vector<LogicalPhysicalMapping> compute_logical_to_physical_shards_mapping(
 // Converts a span of logical data to row major physical data.
 template <typename T>
 std::vector<T> convert_to_row_major_physical_data(
-    tt::stl::Span<const T> logical_data, const TensorSpec& tensor_spec, T pad_value) {
+    ttsl::Span<const T> logical_data, const TensorSpec& tensor_spec, T pad_value) {
     const auto& physical_shape = tensor_spec.physical_shape();
     const size_t physical_stride = physical_shape.width();
     auto [logical_shard_shape, physical_shard_shape] =
@@ -865,7 +865,7 @@ std::vector<T> convert_to_row_major_physical_data(
 
 // Converts a span of row major physical data to logical data.
 template <typename T>
-std::vector<T> convert_to_logical_data(tt::stl::Span<const T> row_major_physical_data, const TensorSpec& tensor_spec) {
+std::vector<T> convert_to_logical_data(ttsl::Span<const T> row_major_physical_data, const TensorSpec& tensor_spec) {
     const auto& logical_2d_shape = tensor_spec.logical_2d_shape();
     const size_t physical_stride = tensor_spec.physical_shape().width();
     auto [logical_shard_shape, physical_shard_shape] =
@@ -888,7 +888,7 @@ std::vector<T> convert_to_logical_data(tt::stl::Span<const T> row_major_physical
 
 template <typename T>
 std::vector<T> convert_layout_row_major_to_tile(
-    const Shape2D& shape, const Tile& tile, tt::stl::Span<const T> data_to_convert) {
+    const Shape2D& shape, const Tile& tile, ttsl::Span<const T> data_to_convert) {
     if (shape.width() * shape.height() == 0) {
         return std::vector<T>();
     }
@@ -920,7 +920,7 @@ std::vector<T> convert_layout_row_major_to_tile(
 }  // namespace
 
 template <typename T>
-std::vector<T> encode_tensor_data(tt::stl::Span<const T> logical_data, const TensorSpec& tensor_spec, T pad_value) {
+std::vector<T> encode_tensor_data(ttsl::Span<const T> logical_data, const TensorSpec& tensor_spec, T pad_value) {
     if (logical_data.size() == 0) {
         return {};
     }
@@ -938,11 +938,11 @@ std::vector<T> encode_tensor_data(tt::stl::Span<const T> logical_data, const Ten
     // `row_major_physical_data_span` stores span unconditionally (cheap), while `row_major_physical_data` stores the
     // converted vector only when needed (expensive).
     std::vector<T> row_major_physical_data;
-    tt::stl::Span<const T> row_major_physical_data_span;
+    ttsl::Span<const T> row_major_physical_data_span;
     if (tensor_spec.logical_2d_shape() != physical_shape) {
         row_major_physical_data =
             CMAKE_UNIQUE_NAMESPACE::convert_to_row_major_physical_data(logical_data, tensor_spec, pad_value);
-        row_major_physical_data_span = tt::stl::make_const_span(row_major_physical_data);
+        row_major_physical_data_span = ttsl::make_const_span(row_major_physical_data);
     } else {
         row_major_physical_data_span = logical_data;
     }
@@ -965,20 +965,20 @@ std::vector<T> encode_tensor_data(tt::stl::Span<const T> logical_data, const Ten
 }
 
 template std::vector<bfloat16> encode_tensor_data<bfloat16>(
-    tt::stl::Span<const bfloat16> logical_data, const TensorSpec& tensor_spec, bfloat16 pad_value);
+    ttsl::Span<const bfloat16> logical_data, const TensorSpec& tensor_spec, bfloat16 pad_value);
 template std::vector<float> encode_tensor_data<float>(
-    tt::stl::Span<const float> logical_data, const TensorSpec& tensor_spec, float pad_value);
+    ttsl::Span<const float> logical_data, const TensorSpec& tensor_spec, float pad_value);
 template std::vector<int32_t> encode_tensor_data<int32_t>(
-    tt::stl::Span<const int32_t> logical_data, const TensorSpec& tensor_spec, int32_t pad_value);
+    ttsl::Span<const int32_t> logical_data, const TensorSpec& tensor_spec, int32_t pad_value);
 template std::vector<uint32_t> encode_tensor_data<uint32_t>(
-    tt::stl::Span<const uint32_t> logical_data, const TensorSpec& tensor_spec, uint32_t pad_value);
+    ttsl::Span<const uint32_t> logical_data, const TensorSpec& tensor_spec, uint32_t pad_value);
 template std::vector<uint16_t> encode_tensor_data<uint16_t>(
-    tt::stl::Span<const uint16_t> logical_data, const TensorSpec& tensor_spec, uint16_t pad_value);
+    ttsl::Span<const uint16_t> logical_data, const TensorSpec& tensor_spec, uint16_t pad_value);
 template std::vector<uint8_t> encode_tensor_data<uint8_t>(
-    tt::stl::Span<const uint8_t> logical_data, const TensorSpec& tensor_spec, uint8_t pad_value);
+    ttsl::Span<const uint8_t> logical_data, const TensorSpec& tensor_spec, uint8_t pad_value);
 
 template <typename T>
-std::vector<T> decode_tensor_data(tt::stl::Span<const T> physical_data, const TensorSpec& tensor_spec) {
+std::vector<T> decode_tensor_data(ttsl::Span<const T> physical_data, const TensorSpec& tensor_spec) {
     if (physical_data.size() == 0) {
         return {};
     }
@@ -994,21 +994,21 @@ std::vector<T> decode_tensor_data(tt::stl::Span<const T> physical_data, const Te
     // `row_major_physical_data_span` stores span unconditionally (cheap), while `row_major_physical_data` stores the
     // converted vector only when needed (expensive).
     std::vector<T> row_major_physical_data;
-    tt::stl::Span<const T> row_major_physical_data_span;
+    ttsl::Span<const T> row_major_physical_data_span;
     if (tensor_spec.layout() == Layout::TILE) {
         row_major_physical_data =
             tensor_impl::convert_layout_tile_to_row_major(physical_shape, tensor_spec.tile(), physical_data);
-        row_major_physical_data_span = tt::stl::make_const_span(row_major_physical_data);
+        row_major_physical_data_span = ttsl::make_const_span(row_major_physical_data);
     } else {
         row_major_physical_data_span = physical_data;
     }
 
     // Same pattern as the above - `logical_data` is non empty only when the conversion to logical data was performed.
     std::vector<T> logical_data;
-    tt::stl::Span<const T> logical_data_span;
+    ttsl::Span<const T> logical_data_span;
     if (const auto& logical_2d_shape = tensor_spec.logical_2d_shape(); logical_2d_shape != physical_shape) {
         logical_data = CMAKE_UNIQUE_NAMESPACE::convert_to_logical_data(row_major_physical_data_span, tensor_spec);
-        logical_data_span = tt::stl::make_const_span(logical_data);
+        logical_data_span = ttsl::make_const_span(logical_data);
     } else {
         logical_data_span = row_major_physical_data_span;
     }
@@ -1031,17 +1031,17 @@ std::vector<T> decode_tensor_data(tt::stl::Span<const T> physical_data, const Te
 }
 
 template std::vector<bfloat16> decode_tensor_data<bfloat16>(
-    tt::stl::Span<const bfloat16> physical_data, const TensorSpec& tensor_spec);
+    ttsl::Span<const bfloat16> physical_data, const TensorSpec& tensor_spec);
 template std::vector<float> decode_tensor_data<float>(
-    tt::stl::Span<const float> physical_data, const TensorSpec& tensor_spec);
+    ttsl::Span<const float> physical_data, const TensorSpec& tensor_spec);
 template std::vector<int32_t> decode_tensor_data<int32_t>(
-    tt::stl::Span<const int32_t> physical_data, const TensorSpec& tensor_spec);
+    ttsl::Span<const int32_t> physical_data, const TensorSpec& tensor_spec);
 template std::vector<uint32_t> decode_tensor_data<uint32_t>(
-    tt::stl::Span<const uint32_t> physical_data, const TensorSpec& tensor_spec);
+    ttsl::Span<const uint32_t> physical_data, const TensorSpec& tensor_spec);
 template std::vector<uint16_t> decode_tensor_data<uint16_t>(
-    tt::stl::Span<const uint16_t> physical_data, const TensorSpec& tensor_spec);
+    ttsl::Span<const uint16_t> physical_data, const TensorSpec& tensor_spec);
 template std::vector<uint8_t> decode_tensor_data<uint8_t>(
-    tt::stl::Span<const uint8_t> physical_data, const TensorSpec& tensor_spec);
+    ttsl::Span<const uint8_t> physical_data, const TensorSpec& tensor_spec);
 
 // ======================================================================================
 //                                  .to_layout()
@@ -1369,14 +1369,14 @@ tt::tt_metal::HostStorage preprocess_storage(
 
     if (input_dtype == DataType::BFLOAT8_B) {
         return input_storage.transform([&](const tt::tt_metal::HostBuffer& buffer) {
-            tt::stl::Span<const uint32_t> uint32_data = buffer.view_as<const uint32_t>();
+            ttsl::Span<const uint32_t> uint32_data = buffer.view_as<const uint32_t>();
             auto float_unpacked_data = unpack_bfp8_tiles_into_float_vec(uint32_data, row_major_output, is_exp_a);
             return tt::tt_metal::HostBuffer(std::move(float_unpacked_data));
         });
     }
     if (input_dtype == DataType::BFLOAT4_B) {
         return input_storage.transform([&](const tt::tt_metal::HostBuffer& buffer) {
-            tt::stl::Span<const uint32_t> uint32_data = buffer.view_as<const uint32_t>();
+            ttsl::Span<const uint32_t> uint32_data = buffer.view_as<const uint32_t>();
             auto float_unpacked_data = unpack_bfp4_tiles_into_float_vec(uint32_data, row_major_output, is_exp_a);
             return tt::tt_metal::HostBuffer(std::move(float_unpacked_data));
         });

--- a/ttnn/cpp/ttnn-nanobind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/pytensor.cpp
@@ -162,7 +162,7 @@ PreprocessedPyTensor parse_py_tensor(nb::ndarray<nb::array_api> py_tensor, std::
 // `shape` and `data_type` information.
 struct RowMajorHostBuffer {
     static RowMajorHostBuffer create_padded(HostBuffer buffer, const ttnn::TensorSpec& tensor_spec) {
-        tt::stl::Span<const uint32_t> shape_view = tensor_spec.padded_shape().view();
+        ttsl::Span<const uint32_t> shape_view = tensor_spec.padded_shape().view();
         return RowMajorHostBuffer{
             .buffer = std::move(buffer),
             .shape = std::vector<uint32_t>(shape_view.begin(), shape_view.end()),
@@ -171,7 +171,7 @@ struct RowMajorHostBuffer {
     }
 
     static RowMajorHostBuffer create_logical(HostBuffer buffer, const ttnn::TensorSpec& tensor_spec) {
-        tt::stl::Span<const uint32_t> shape_view = tensor_spec.logical_shape().view();
+        ttsl::Span<const uint32_t> shape_view = tensor_spec.logical_shape().view();
         return RowMajorHostBuffer{
             .buffer = std::move(buffer),
             .shape = std::vector<uint32_t>(shape_view.begin(), shape_view.end()),
@@ -228,7 +228,7 @@ RowMajorHostBuffer convert_to_row_major_host_buffer(const Tensor& tt_tensor, con
             case DataType::BFLOAT8_B:
             case DataType::BFLOAT4_B: {
                 const auto& tile = tensor_spec.tile();
-                tt::stl::Span<const std::uint32_t> uint32_data = host_buffer::get_as<std::uint32_t>(buffer);
+                ttsl::Span<const std::uint32_t> uint32_data = host_buffer::get_as<std::uint32_t>(buffer);
                 auto float_unpacked_data = tt_dtype == DataType::BFLOAT8_B
                                                ? unpack_bfp8_tiles_into_float_vec(
                                                      uint32_data, /*row_major_output=*/false, /*is_exp_a=*/false, tile)
@@ -263,7 +263,7 @@ RowMajorHostBuffer convert_to_row_major_host_buffer(
     //
     auto dispatch_to_concrete = [&mesh_composer]<typename T>(const Tensor& tt_tensor) {
         auto [data, shape] = mesh_composer.compose<T>(tt_tensor);
-        tt::stl::Span<const uint32_t> shape_view = shape.view();
+        ttsl::Span<const uint32_t> shape_view = shape.view();
         return RowMajorHostBuffer{
             .buffer = HostBuffer(std::move(data)),
             .shape = std::vector<uint32_t>(shape_view.begin(), shape_view.end()),
@@ -331,7 +331,7 @@ auto parse_external_operation(
 
     // original impl had a bunch of no-ops. Reduce to minimum functionality.
     std::vector<Tensor> input_tensors;
-    tt::stl::reflection::Attributes attributes;
+    ttsl::reflection::Attributes attributes;
 
     auto operation = tt::tt_metal::operation::ExternalOperation{function_name, attributes};
     return std::make_tuple(operation, input_tensors);
@@ -346,7 +346,7 @@ HostBuffer convert_py_tensor_to_host_buffer(const nb::ndarray<nb::array_api>& py
         // while holding GIL.
         tt::tt_metal::MemoryPin pydata_pin(std::make_shared<nb::ndarray<nb::array_api>>(contiguous_py_tensor));
         T* typed_py_ptr = const_cast<T*>(static_cast<const T*>(contiguous_py_tensor.data()));
-        return HostBuffer(tt::stl::Span<T>(typed_py_ptr, contiguous_py_tensor.size()), pydata_pin);
+        return HostBuffer(ttsl::Span<T>(typed_py_ptr, contiguous_py_tensor.size()), pydata_pin);
     };
 
     auto to_host_buffer = [&to_host_buffer_impl,

--- a/ttnn/cpp/ttnn-nanobind/tensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/tensor.cpp
@@ -297,7 +297,7 @@ void tensor_mem_config_module(nb::module_& m_tensor) {
                const std::vector<int32_t>& dims,
                CoreRangeSet grid,
                ShardOrientation orientation) {
-                return self.sharded_across_dims(tt::stl::Span<const int32_t>(dims), std::move(grid), orientation);
+                return self.sharded_across_dims(ttsl::Span<const int32_t>(dims), std::move(grid), orientation);
             },
             nb::arg("dims"),
             nb::arg("grid"),
@@ -314,7 +314,7 @@ void tensor_mem_config_module(nb::module_& m_tensor) {
                CoreRangeSet grid,
                ShardOrientation orientation) {
                 return self.sharded_across_dims_except(
-                    tt::stl::Span<const int32_t>(dims), std::move(grid), orientation);
+                    ttsl::Span<const int32_t>(dims), std::move(grid), orientation);
             },
             nb::arg("dims"),
             nb::arg("grid"),
@@ -447,8 +447,8 @@ void tensor_mem_config_module(nb::module_& m_tensor) {
             )doc")
         .def(
             "__hash__",
-            [](const MemoryConfig& memory_config) -> tt::stl::hash::hash_t {
-                return tt::stl::hash::detail::hash_object(memory_config);
+            [](const MemoryConfig& memory_config) -> ttsl::hash::hash_t {
+                return ttsl::hash::detail::hash_object(memory_config);
             })
         .def("is_sharded", &MemoryConfig::is_sharded, "Whether tensor data is sharded across multiple cores in L1")
         .def(
@@ -501,7 +501,7 @@ void tensor_mem_config_module(nb::module_& m_tensor) {
         .def(
             "__init__",
             [](CoreRangeSet* t, const std::vector<CoreRange>& core_ranges) {
-                new (t) CoreRangeSet(tt::stl::Span<const CoreRange>(core_ranges));
+                new (t) CoreRangeSet(ttsl::Span<const CoreRange>(core_ranges));
             },
             nb::arg("core_ranges"))
         .def(

--- a/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_device_operation.cpp
@@ -61,11 +61,11 @@ BernoulliDeviceOperation::tensor_return_value_t BernoulliDeviceOperation::create
     return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
 }
 
-tt::stl::hash::hash_t BernoulliDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t BernoulliDeviceOperation::compute_program_hash(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     auto cached_operation_attributes = operation_attributes;
     cached_operation_attributes.seed = 0;
-    return tt::stl::hash::hash_objects_with_default_seed(cached_operation_attributes, tensor_args);
+    return ttsl::hash::hash_objects_with_default_seed(cached_operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::operations::bernoulli

--- a/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_device_operation.hpp
@@ -53,7 +53,7 @@ struct BernoulliDeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::operations::bernoulli

--- a/ttnn/cpp/ttnn/operations/ccl/all_broadcast/device/all_broadcast_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_broadcast/device/all_broadcast_device_operation.cpp
@@ -65,7 +65,7 @@ std::vector<Tensor> AllBroadcastDeviceOperation::create_output_tensors(
     return outputs;
 }
 
-tt::stl::hash::hash_t AllBroadcastDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t AllBroadcastDeviceOperation::compute_program_hash(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     log_trace(tt::LogOp, "AllBroadcastDeviceOperation::compute_program_hash is called");
 

--- a/ttnn/cpp/ttnn/operations/ccl/all_broadcast/device/all_broadcast_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_broadcast/device/all_broadcast_device_operation.hpp
@@ -30,7 +30,7 @@ struct AllBroadcastDeviceOperation {
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 std::vector<ttnn::Tensor> all_broadcast(

--- a/ttnn/cpp/ttnn/operations/ccl/broadcast/device/broadcast_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/broadcast/device/broadcast_device_operation.cpp
@@ -52,7 +52,7 @@ Tensor BroadcastDeviceOperation::create_output_tensors(
     return create_device_tensor(spec, tensor_args.input_tensor.device());
 }
 
-tt::stl::hash::hash_t BroadcastDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t BroadcastDeviceOperation::compute_program_hash(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     log_trace(tt::LogOp, "BroadcastDeviceOperation::compute_program_hash is called");
 

--- a/ttnn/cpp/ttnn/operations/ccl/broadcast/device/broadcast_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/broadcast/device/broadcast_device_operation.hpp
@@ -29,7 +29,7 @@ struct BroadcastDeviceOperation {
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 Tensor broadcast(

--- a/ttnn/cpp/ttnn/operations/ccl/broadcast/device/broadcast_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/broadcast/device/broadcast_device_operation_types.hpp
@@ -37,7 +37,7 @@ struct BroadcastParams {
 
     // Add attributes method for reflection
     auto attributes() const {
-        using tt::stl::reflection::Attribute;
+        using ttsl::reflection::Attribute;
         std::vector<std::tuple<std::string, Attribute>> attrs;
         attrs.emplace_back("sender_coord", sender_coord);
         attrs.emplace_back("num_links", num_links);

--- a/ttnn/cpp/ttnn/operations/ccl/common/host/ccl_worker_builder.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/host/ccl_worker_builder.cpp
@@ -897,7 +897,7 @@ static void log_command_stream(ttnn::ccl::cmd::CclHostLowLevelCommandSequence co
 
         auto get_addr_args_str = [](std::stringstream& ss, CclCommandAddrArgs const& args) {
             std::visit(
-                tt::stl::overloaded{
+                ttsl::overloaded{
                     [&ss](CclCommandAddrRelativeAddress const& a) {
                         ss << fmt::format("(relative_address:{})", a.relative_address);
                     },
@@ -915,7 +915,7 @@ static void log_command_stream(ttnn::ccl::cmd::CclHostLowLevelCommandSequence co
         };
         auto get_cmd_args_str = [](std::stringstream& ss, CclCommandArgs const& args) {
             std::visit(
-                tt::stl::overloaded{
+                ttsl::overloaded{
                     [&ss](CclCommandStreamTensorSlice const& a) {
                         ss << fmt::format(
                             "(shape: (w:{},z:{},y:{},x:{}), slice_shape: (w:{},z:{},y:{},x:{}), slice_offset: "
@@ -957,7 +957,7 @@ static void log_command_stream(ttnn::ccl::cmd::CclHostLowLevelCommandSequence co
 
         auto get_core_desc_args_str = [](std::stringstream& ss, CclCommandCoreDescriptorArgs const& args) {
             std::visit(
-                tt::stl::overloaded{
+                ttsl::overloaded{
                     [&ss](CclCommandCoreDescriptorTypeAddrgen const&  /*a*/) { ss << fmt::format("(addrgen)"); },
                     [&ss](CclCommandCoreDescriptorTypeLocal const&  /*a*/) { ss << fmt::format("(local_core)"); },
                     [&ss](CclCommandCoreDescriptorTypeNocXY const& a) { ss << fmt::format("(x:{}, y:{})", a.x, a.y); },
@@ -976,7 +976,7 @@ static void log_command_stream(ttnn::ccl::cmd::CclHostLowLevelCommandSequence co
 
         auto get_fabric_transfer_args_str = [](std::stringstream& ss, CclCommandDestArgs const& args) {
             std::visit(
-                tt::stl::overloaded{
+                ttsl::overloaded{
                     [&ss](UnicastCommandDestArgs const& a) {
                         ss << fmt::format(
                             "(distance_in_hops:{}, is_forward_direction:{})",

--- a/ttnn/cpp/ttnn/operations/ccl/common/uops/ccl_host_commands.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/uops/ccl_host_commands.cpp
@@ -74,7 +74,7 @@ CclHostLowLevelWorkerCommand fabric_write_cb_to_tensor_slice(
     size_t cb_id,
     std::variant<ttnn::ccl::cmd::UnicastCommandDestArgs, ttnn::ccl::cmd::MulticastCommandDestArgs> const& dest_args) {
     auto const dest_type = std::visit(
-        tt::stl::overloaded{
+        ttsl::overloaded{
             [](ttnn::ccl::cmd::UnicastCommandDestArgs const&) { return CclCommandDestType::CHIP_UNICAST; },
             [](ttnn::ccl::cmd::MulticastCommandDestArgs const&) { return CclCommandDestType::CHIP_MULTICAST; },
             [](auto&&) -> void {
@@ -85,7 +85,7 @@ CclHostLowLevelWorkerCommand fabric_write_cb_to_tensor_slice(
             }},
         dest_args);
     auto dest_args_variant = std::visit(
-        tt::stl::overloaded{
+        ttsl::overloaded{
             [](ttnn::ccl::cmd::UnicastCommandDestArgs const& arg) -> ttnn::ccl::cmd::CclCommandDestArgs {
                 return ttnn::ccl::cmd::UnicastCommandDestArgs(arg);
             },
@@ -120,7 +120,7 @@ CclHostLowLevelWorkerCommand fabric_write_cb_to_tensor_slice(
 
 static ttnn::ccl::cmd::CclCommandAddrType get_semaphore_addr_type(semaphore_id_t const& semaphore_id) {
     return std::visit(
-        tt::stl::overloaded{
+        ttsl::overloaded{
             [](uint32_t) { return ttnn::ccl::cmd::CclCommandAddrType::SEMAPHORE_ID; },
             [](tt::tt_metal::GlobalSemaphore const*) { return ttnn::ccl::cmd::CclCommandAddrType::ABSOLUTE_ADDRESS; },
             [](auto&&) -> void {
@@ -133,7 +133,7 @@ static ttnn::ccl::cmd::CclCommandAddrType get_semaphore_addr_type(semaphore_id_t
 static ttnn::ccl::cmd::CclCommandAddrArgs get_semaphore_addr_val(semaphore_id_t const& semaphore_id) {
     using ttnn::ccl::cmd::CclCommandAddrArgs;
     return std::visit(
-        tt::stl::overloaded{
+        ttsl::overloaded{
             [](uint32_t id) -> CclCommandAddrArgs { return ttnn::ccl::cmd::CclCommandAddrSemaphoreId{id}; },
             [](tt::tt_metal::GlobalSemaphore const* semaphore) -> CclCommandAddrArgs {
                 TT_FATAL(semaphore != nullptr, "Internal error: GlobalSemaphore pointer is null in call to get_semaphore_addr_val");
@@ -378,7 +378,7 @@ CclHostLowLevelWorkerCommand fabric_unicast_absolute_address_semaphore_inc(
 
 // Noc Read/Write commands
 // Densely packs as many transfers as possible into a single packet
-static std::vector<HostNocTransferBurstGrouping> densely_pack_noc_transfers(tt::stl::Span<noc_transfer_info> const& transfer_infos, size_t cb_size_bytes) {
+static std::vector<HostNocTransferBurstGrouping> densely_pack_noc_transfers(ttsl::Span<noc_transfer_info> const& transfer_infos, size_t cb_size_bytes) {
     std::vector<HostNocTransferBurstGrouping> transfer_burst_groupings;
 
     size_t group_size_bytes = 0;
@@ -406,7 +406,7 @@ static std::vector<HostNocTransferBurstGrouping> densely_pack_noc_transfers(tt::
 
 CclHostLowLevelWorkerCommand local_noc_read_burst_to_cb(
     CclCommandAddrAbsoluteAddress const& bank_base_address,
-    tt::stl::Span<noc_transfer_info> const& transfer_infos,
+    ttsl::Span<noc_transfer_info> const& transfer_infos,
     size_t cb_size_bytes,
     size_t cb_id
 ) {
@@ -424,7 +424,7 @@ CclHostLowLevelWorkerCommand local_noc_read_burst_to_cb(
 
 CclHostLowLevelWorkerCommand local_noc_write_burst_from_cb(
     CclCommandAddrAbsoluteAddress const& bank_base_address,
-    tt::stl::Span<noc_transfer_info> const& transfer_infos,
+    ttsl::Span<noc_transfer_info> const& transfer_infos,
     size_t cb_size_bytes,
     size_t cb_id
 ) {
@@ -442,7 +442,7 @@ CclHostLowLevelWorkerCommand local_noc_write_burst_from_cb(
 
 [[nodiscard]] CclHostLowLevelWorkerCommand fabric_unicast_noc_write_burst_from_cb(
     CclCommandAddrAbsoluteAddress const& bank_base_address,
-    tt::stl::Span<noc_transfer_info> const& transfer_infos,
+    ttsl::Span<noc_transfer_info> const& transfer_infos,
     size_t cb_size_bytes,
     size_t cb_id,
     UnicastCommandDestArgs const& unicast_args
@@ -465,7 +465,7 @@ CclHostLowLevelWorkerCommand local_noc_write_burst_from_cb(
 
 CclHostLowLevelWorkerCommand fabric_multicast_noc_write_burst_from_cb(
     CclCommandAddrAbsoluteAddress const& bank_base_address,
-    tt::stl::Span<noc_transfer_info> const& transfer_infos,
+    ttsl::Span<noc_transfer_info> const& transfer_infos,
     size_t cb_size_bytes,
     size_t cb_id,
     MulticastCommandDestArgs const& multicast_args

--- a/ttnn/cpp/ttnn/operations/ccl/common/uops/ccl_host_commands.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/uops/ccl_host_commands.hpp
@@ -88,21 +88,21 @@ using semaphore_id_t = std::variant<uint32_t, tt::tt_metal::GlobalSemaphore cons
 // Densely packs as many transfers as possible into a single packet
 [[nodiscard]] CclHostLowLevelWorkerCommand local_noc_read_burst_to_cb(
     CclCommandAddrAbsoluteAddress const& bank_base_address,
-    tt::stl::Span<noc_transfer_info> const& transfer_infos,
+    ttsl::Span<noc_transfer_info> const& transfer_infos,
     size_t cb_size_bytes,
     size_t cb_id
 );
 
 [[nodiscard]] CclHostLowLevelWorkerCommand local_noc_write_burst_from_cb(
     CclCommandAddrAbsoluteAddress const& bank_base_address,
-    tt::stl::Span<noc_transfer_info> const& transfer_infos,
+    ttsl::Span<noc_transfer_info> const& transfer_infos,
     size_t cb_size_bytes,
     size_t cb_id
 );
 
 [[nodiscard]] CclHostLowLevelWorkerCommand fabric_unicast_noc_write_burst_from_cb(
     CclCommandAddrAbsoluteAddress const& bank_base_address,
-    tt::stl::Span<noc_transfer_info> const& transfer_infos,
+    ttsl::Span<noc_transfer_info> const& transfer_infos,
     size_t cb_size_bytes,
     size_t cb_id,
     UnicastCommandDestArgs const& unicast_args
@@ -110,7 +110,7 @@ using semaphore_id_t = std::variant<uint32_t, tt::tt_metal::GlobalSemaphore cons
 
 [[nodiscard]] CclHostLowLevelWorkerCommand fabric_multicast_noc_write_burst_from_cb(
     CclCommandAddrAbsoluteAddress const& bank_base_address,
-    tt::stl::Span<noc_transfer_info> const& transfer_infos,
+    ttsl::Span<noc_transfer_info> const& transfer_infos,
     size_t cb_size_bytes,
     size_t cb_id,
     MulticastCommandDestArgs const& multicast_args

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -1439,7 +1439,7 @@ KernelStrideFoldingResult compute_kernel_stride_folding_params(
 }
 
 std::ostream& operator<<(std::ostream& os, const Conv2dConfig& config) {
-    tt::stl::reflection::operator<<(os, config);
+    ttsl::reflection::operator<<(os, config);
     return os;
 }
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation.cpp
@@ -136,7 +136,7 @@ void Conv2dDeviceOperation::validate_on_program_cache_miss(
     }
 }
 
-tt::stl::hash::hash_t Conv2dDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t Conv2dDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     hashable_operation_attributes_t hashable_args = {
         .sliding_window_config = args.sliding_window_config,
@@ -156,7 +156,7 @@ tt::stl::hash::hash_t Conv2dDeviceOperation::compute_program_hash(
         .config_tensors_in_dram = args.config_tensors_in_dram,
         .force_split_reader = args.force_split_reader,
     };
-    return tt::stl::hash::hash_objects_with_default_seed(hashable_args, tensor_args);
+    return ttsl::hash::hash_objects_with_default_seed(hashable_args, tensor_args);
 }
 
 tt::tt_metal::operation::OpPerformanceModelGeneral<Tensor> Conv2dDeviceOperation::create_op_performance_model(

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation.hpp
@@ -41,7 +41,7 @@ struct Conv2dDeviceOperation {
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& args, const tensor_args_t& tensor_args);
     static void validate_on_program_cache_miss(const operation_attributes_t& args, const tensor_args_t& tensor_args);
-    static tt::stl::hash::hash_t compute_program_hash(
+    static ttsl::hash::hash_t compute_program_hash(
         const operation_attributes_t& args, const tensor_args_t& tensor_args);
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensor);

--- a/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_device_op.cpp
+++ b/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_device_op.cpp
@@ -158,7 +158,7 @@ Tensor TypecastDeviceOperation::create_output_tensors(const TypecastParams& args
     return tt::tt_metal::create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.input.device());
 }
 
-tt::stl::hash::hash_t TypecastDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t TypecastDeviceOperation::compute_program_hash(
     const TypecastParams& args, const TypecastInputs& tensor_args) {
     const auto& input_tensor = tensor_args.input;
     const auto& input_shape = input_tensor.padded_shape();

--- a/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_device_op.hpp
+++ b/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_device_op.hpp
@@ -34,7 +34,7 @@ struct TypecastDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 
     static bool skip_launch(const operation_attributes_t&, const tensor_args_t&, const tensor_return_value_t&);
 };

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.cpp
@@ -225,7 +225,7 @@ Tensor BcastDeviceOperation::create_output_tensors(
     return create_device_tensor(spec, tensor_args.input_a.device());
 }
 
-tt::stl::hash::hash_t BcastDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t BcastDeviceOperation::compute_program_hash(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     log_trace(tt::LogOp, "BcastDeviceOperation::compute_program_hash is called");
 

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.hpp
@@ -39,7 +39,7 @@ struct BcastDeviceOperation {
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 
-    static tt::stl::hash::hash_t compute_program_hash(
+    static ttsl::hash::hash_t compute_program_hash(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(

--- a/ttnn/cpp/ttnn/operations/data_movement/expand/expand.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/expand/expand.cpp
@@ -31,7 +31,7 @@ ttnn::SmallVector<uint32_t> create_repetition_vector(const Tensor& tensor, std::
 
 ttnn::Tensor ExpandOperation::invoke(
     const ttnn::Tensor& tensor,
-    const tt::stl::Span<const int32_t> shape_vector,
+    const ttsl::Span<const int32_t> shape_vector,
     const std::optional<MemoryConfig>& memory_config) {
     return ttnn::repeat(tensor, create_repetition_vector(tensor, shape_vector), memory_config);
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/expand/expand.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/expand/expand.hpp
@@ -11,7 +11,7 @@ namespace ttnn::operations::expand {
 struct ExpandOperation {
     static Tensor invoke(
         const ttnn::Tensor& tensor,
-        tt::stl::Span<const int32_t> shape_vector,
+        ttsl::Span<const int32_t> shape_vector,
         const std::optional<MemoryConfig>& memory_config);
 };
 }  // namespace ttnn::operations::expand

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_op.cpp
@@ -81,7 +81,7 @@ ReshapeDeviceOperation::tensor_return_value_t ReshapeDeviceOperation::create_out
         compute_output_specs(operation_attributes, tensor_args), tensor_args.input_tensor.device());
 }
 
-tt::stl::hash::hash_t ReshapeDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t ReshapeDeviceOperation::compute_program_hash(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input_tensor;
     auto program_factory = select_program_factory(operation_attributes, tensor_args);

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_op.hpp
@@ -31,7 +31,7 @@ struct ReshapeDeviceOperation {
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 
-    static tt::stl::hash::hash_t compute_program_hash(
+    static ttsl::hash::hash_t compute_program_hash(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/reshape.cpp
@@ -99,7 +99,7 @@ ttnn::Tensor ReshapeOperation::invoke(
 
 ttnn::Tensor ReshapeOperation::invoke(
     const ttnn::Tensor& input_tensor,
-    tt::stl::Span<const int32_t> shape_vector,
+    ttsl::Span<const int32_t> shape_vector,
     const std::optional<MemoryConfig>& memory_config_arg) {
     return invoke(input_tensor, detail::infer_dims_for_reshape(input_tensor, shape_vector), memory_config_arg);
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/reshape.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/reshape.hpp
@@ -23,7 +23,7 @@ struct ReshapeOperation {
 
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input_tensor,
-        tt::stl::Span<const int32_t> shape_vector,
+        ttsl::Span<const int32_t> shape_vector,
         const std::optional<MemoryConfig>& memory_config_arg = std::nullopt);
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.cpp
@@ -45,7 +45,7 @@ tt::tt_metal::Tensor ReshapeViewDeviceOperation::create_output_tensors(
     return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
 }
 
-tt::stl::hash::hash_t ReshapeViewDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t ReshapeViewDeviceOperation::compute_program_hash(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     log_trace(tt::LogOp, "ReshapeViewDeviceOperation::compute_program_hash is called");
 

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.hpp
@@ -30,7 +30,7 @@ struct ReshapeViewDeviceOperation {
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 
-    static tt::stl::hash::hash_t compute_program_hash(
+    static ttsl::hash::hash_t compute_program_hash(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
@@ -429,7 +429,7 @@ ttnn::Tensor ReshapeViewOperation::invoke(
 
 ttnn::Tensor ReshapeViewOperation::invoke(
     const ttnn::Tensor& tensor,
-    tt::stl::Span<const int32_t> shape_vector,
+    ttsl::Span<const int32_t> shape_vector,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<PadValue>& pad_value,
     const TileReshapeMapMode reshape_map_mode,

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.hpp
@@ -47,7 +47,7 @@ struct ReshapeViewOperation {
         const std::optional<CoreRangeSet>& sub_core_grid = std::nullopt);
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input_tensor,
-        tt::stl::Span<const int32_t> shape_vector,
+        ttsl::Span<const int32_t> shape_vector,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<PadValue>& pad_value = std::nullopt,
         TileReshapeMapMode = TileReshapeMapMode::CACHE,

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.cpp
@@ -79,7 +79,7 @@ InterleavedToShardedDeviceOperation::tensor_return_value_t InterleavedToShardedD
     return create_device_tensor(spec, input_tensor.device());
 }
 
-tt::stl::hash::hash_t InterleavedToShardedDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t InterleavedToShardedDeviceOperation::compute_program_hash(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input_tensor;
     return tt::tt_metal::operation::hash_operation<InterleavedToShardedDeviceOperation>(

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.hpp
@@ -30,7 +30,7 @@ struct InterleavedToShardedDeviceOperation {
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 
-    static tt::stl::hash::hash_t compute_program_hash(
+    static ttsl::hash::hash_t compute_program_hash(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.cpp
@@ -71,7 +71,7 @@ Tensor InterleavedToShardedPartialDeviceOperation::create_output_tensors(
     return create_device_tensor(output_spec, input_tensor.device());
 }
 
-tt::stl::hash::hash_t InterleavedToShardedPartialDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t InterleavedToShardedPartialDeviceOperation::compute_program_hash(
     const operation_attributes_t& operation_attributes, const Tensor& input_tensor) {
     return tt::tt_metal::operation::hash_operation<InterleavedToShardedPartialDeviceOperation>(
         operation_attributes.grid_size,

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.hpp
@@ -25,7 +25,7 @@ struct InterleavedToShardedPartialDeviceOperation {
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const Tensor& input_tensor);
 
-    static tt::stl::hash::hash_t compute_program_hash(
+    static ttsl::hash::hash_t compute_program_hash(
         const operation_attributes_t& operation_attributes, const Tensor& input_tensor);
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
@@ -15,9 +15,9 @@ namespace ttnn::operations::data_movement {
 template <typename T>
 ttnn::Tensor SliceOperation::invoke(
     const ttnn::Tensor& input_tensor,
-    tt::stl::Span<const T> begins,
-    tt::stl::Span<const T> ends,
-    tt::stl::Span<const T> step,
+    ttsl::Span<const T> begins,
+    ttsl::Span<const T> ends,
+    ttsl::Span<const T> step,
     const std::optional<MemoryConfig>& memory_config_arg,
     const std::optional<Tensor>& optional_output_tensor,
     const std::optional<float>& pad_value,
@@ -189,9 +189,9 @@ ttnn::Tensor SliceOperation::invoke(
     const std::optional<Tensor>& optional_output_tensor,
     const std::optional<float>& pad_value,
     const std::optional<CoreRangeSet>& sub_core_grids) {
-    tt::stl::Span<const T> start(output_tensor_start.begin(), output_tensor_start.end());
-    tt::stl::Span<const T> end(output_tensor_end.begin(), output_tensor_end.end());
-    tt::stl::Span<const T> step_vec(step.begin(), step.end());
+    ttsl::Span<const T> start(output_tensor_start.begin(), output_tensor_start.end());
+    ttsl::Span<const T> end(output_tensor_end.begin(), output_tensor_end.end());
+    ttsl::Span<const T> step_vec(step.begin(), step.end());
     return SliceOperation::invoke<T>(
         input_tensor, start, end, step_vec, memory_config_arg, optional_output_tensor, pad_value, sub_core_grids);
 }
@@ -286,9 +286,9 @@ ttnn::Tensor SliceOperation::invoke(
     std::vector<T> output_tensor_end_vector = output_tensor_end.to_vector<T>();
 
     // convert the Vector to Span
-    tt::stl::Span<const T> output_tensor_start_span(
+    ttsl::Span<const T> output_tensor_start_span(
         output_tensor_start_vector.data(), output_tensor_start_vector.size());
-    tt::stl::Span<const T> output_tensor_end_span(output_tensor_end_vector.data(), output_tensor_end_vector.size());
+    ttsl::Span<const T> output_tensor_end_span(output_tensor_end_vector.data(), output_tensor_end_vector.size());
 
     // generate the step value if it is not provided
     ttnn::SmallVector<T> step_value = step.value_or(ttnn::SmallVector<T>(output_tensor_start_span.size(), 1));
@@ -297,7 +297,7 @@ ttnn::Tensor SliceOperation::invoke(
         input_tensor,
         output_tensor_start_span,
         output_tensor_end_span,
-        tt::stl::Span<const T>(step_value),
+        ttsl::Span<const T>(step_value),
         memory_config_arg,
         optional_output_tensor,
         pad_value,
@@ -307,9 +307,9 @@ ttnn::Tensor SliceOperation::invoke(
 // Template instantiations for SliceOperation::invoke
 template ttnn::Tensor SliceOperation::invoke<int32_t>(
     const ttnn::Tensor& input_tensor,
-    tt::stl::Span<const int32_t> begins,
-    tt::stl::Span<const int32_t> ends,
-    tt::stl::Span<const int32_t> step,
+    ttsl::Span<const int32_t> begins,
+    ttsl::Span<const int32_t> ends,
+    ttsl::Span<const int32_t> step,
     const std::optional<MemoryConfig>& memory_config_arg,
     const std::optional<Tensor>& optional_output_tensor,
     const std::optional<float>& pad_value,
@@ -317,9 +317,9 @@ template ttnn::Tensor SliceOperation::invoke<int32_t>(
 
 template ttnn::Tensor SliceOperation::invoke<uint32_t>(
     const ttnn::Tensor& input_tensor,
-    tt::stl::Span<const uint32_t> begins,
-    tt::stl::Span<const uint32_t> ends,
-    tt::stl::Span<const uint32_t> step,
+    ttsl::Span<const uint32_t> begins,
+    ttsl::Span<const uint32_t> ends,
+    ttsl::Span<const uint32_t> step,
     const std::optional<MemoryConfig>& memory_config_arg,
     const std::optional<Tensor>& optional_output_tensor,
     const std::optional<float>& pad_value,

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice.hpp
@@ -14,9 +14,9 @@ struct SliceOperation {
     template <typename T>
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input_tensor,
-        tt::stl::Span<const T> begins,
-        tt::stl::Span<const T> ends,
-        tt::stl::Span<const T> step,
+        ttsl::Span<const T> begins,
+        ttsl::Span<const T> ends,
+        ttsl::Span<const T> step,
         const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
         const std::optional<float>& pad_value = std::nullopt,
@@ -34,9 +34,9 @@ struct SliceOperation {
         const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt) {
         return invoke(
             input_tensor,
-            tt::stl::Span<const T>(begins),
-            tt::stl::Span<const T>(ends),
-            tt::stl::Span<const T>(step),
+            ttsl::Span<const T>(begins),
+            ttsl::Span<const T>(ends),
+            ttsl::Span<const T>(step),
             memory_config_arg,
             optional_output_tensor,
             pad_value,

--- a/ttnn/cpp/ttnn/operations/data_movement/split/split.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/split.cpp
@@ -63,7 +63,7 @@ std::vector<ttnn::Tensor> split_with_slice_impl(
 
     const ttnn::SmallVector<int32_t> steps(input_shape.rank(), 1);
     ttnn::SmallVector<int32_t> begins(input_shape.rank(), 0), ends(input_shape.cbegin(), input_shape.cend());
-    const tt::stl::Span<const int32_t> sbegins(begins), ssteps(steps), sends(ends);
+    const ttsl::Span<const int32_t> sbegins(begins), ssteps(steps), sends(ends);
 
     ends[dim] = 0;
     for (const auto& s : split_sizes) {

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_nd_shard_input_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_nd_shard_input_program_factory.cpp
@@ -60,7 +60,7 @@ UntilizeMultiCoreNDShardInputProgramFactory::cached_program_t UntilizeMultiCoreN
     const auto& groups = distribution_spec.core_groups();
     const auto& ordered_cores_with_data = distribution_spec.cores_with_data();
     uint32_t num_compute_cores = ordered_cores_with_data.size();
-    const auto& compute_core_range = CoreRangeSet(tt::stl::Span<const CoreCoord>(ordered_cores_with_data));
+    const auto& compute_core_range = CoreRangeSet(ttsl::Span<const CoreCoord>(ordered_cores_with_data));
 
     uint32_t num_tiles_per_input_block = input_shard_width / tile_width;
     uint32_t num_blocks_per_shard_plane =

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_program_factory.cpp
@@ -93,7 +93,7 @@ UntilizeMultiCoreProgramFactory::cached_program_t UntilizeMultiCoreProgramFactor
                            // cores have data on them and only activate those cores.
             ordered_cores_with_data = a.buffer()->buffer_distribution_spec().value().cores_with_data();
             has_ordered_cores_with_data = true;
-            compute_core_range = CoreRangeSet(tt::stl::Span<const CoreCoord>(ordered_cores_with_data));
+            compute_core_range = CoreRangeSet(ttsl::Span<const CoreCoord>(ordered_cores_with_data));
 
             full_compute_core_range = compute_core_range;
         } else {

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_nd_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_nd_sharded_program_factory.cpp
@@ -61,7 +61,7 @@ UntilizeWithUnpaddingMultiCoreNDShardedProgramFactory::create(
     const auto& groups = distribution_spec.core_groups();
     const auto& ordered_cores_with_data = distribution_spec.cores_with_data();
     uint32_t num_compute_cores = ordered_cores_with_data.size();
-    const auto& compute_core_range = CoreRangeSet(tt::stl::Span<const CoreCoord>(ordered_cores_with_data));
+    const auto& compute_core_range = CoreRangeSet(ttsl::Span<const CoreCoord>(ordered_cores_with_data));
 
     uint32_t num_tiles_per_input_block = input_shard_width / tile_width;
     uint32_t num_blocks_per_shard_plane =

--- a/ttnn/cpp/ttnn/operations/data_movement/view/view.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/view/view.cpp
@@ -44,7 +44,7 @@ ttnn::Tensor ViewOperation::invoke(const ttnn::Tensor& tensor, const ttnn::Shape
     return PerformView(tensor, shape, shape, tile_first_dim, tile_second_dim);
 }
 
-ttnn::Tensor ViewOperation::invoke(const ttnn::Tensor& tensor, tt::stl::Span<const int32_t> shape_vector) {
+ttnn::Tensor ViewOperation::invoke(const ttnn::Tensor& tensor, ttsl::Span<const int32_t> shape_vector) {
     return invoke(tensor, detail::infer_dims_for_reshape(tensor, shape_vector));
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/view/view.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/view/view.hpp
@@ -11,7 +11,7 @@ namespace operations::data_movement {
 
 struct ViewOperation {
     static ttnn::Tensor invoke(const ttnn::Tensor& input_tensor, const ttnn::Shape& logical_shape);
-    static ttnn::Tensor invoke(const ttnn::Tensor& input_tensor, tt::stl::Span<const int32_t> shape_vector);
+    static ttnn::Tensor invoke(const ttnn::Tensor& input_tensor, ttsl::Span<const int32_t> shape_vector);
 };
 
 }  // namespace operations::data_movement

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -242,8 +242,8 @@ bool is_legacy_only(
     const auto& rhs,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& output,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations) {
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations) {
     const auto& output_mem_cfg = memory_config.value_or(output ? output->memory_config() : MemoryConfig{});
 
     if (detail::any_sharded_block_format(lhs, rhs) or detail::any_subtile_broadcasted_block_format(lhs, rhs)) {
@@ -266,24 +266,24 @@ template bool is_legacy_only<Tensor>(
     const Tensor& rhs,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& output,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations);
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations);
 
 template bool is_legacy_only<float>(
     const Tensor& lhs,
     const float& rhs,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& output,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations);
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations);
 
 template bool is_legacy_only<int32_t>(
     const Tensor& lhs,
     const int32_t& rhs,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& output,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations);
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations);
 
 namespace detail {
 
@@ -294,9 +294,9 @@ inline auto invoke_binary_ng(
     const std::optional<const DataType>& dtype,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& output,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
     const std::optional<bool>& use_legacy,
     const std::optional<bool>& fast_and_approximate_mode,
     const std::optional<CoreRangeSet>& sub_core_grids) {
@@ -414,9 +414,9 @@ Tensor BinaryOperation<binary_op_type>::invoke(
     const std::optional<const DataType>& dtype,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& output,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
     const std::optional<bool>& use_legacy,
     const std::optional<CoreRangeSet>& sub_core_grids) {
     return detail::invoke_binary_ng(
@@ -441,9 +441,9 @@ Tensor BinaryOperation<binary_op_type>::invoke(
     const std::optional<const DataType>& dtype,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& output,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
     const std::optional<bool>& use_legacy,
     const std::optional<CoreRangeSet>& sub_core_grids) {
     return detail::invoke_binary_ng(
@@ -468,9 +468,9 @@ Tensor BinaryOperationWithFastApprox<binary_op_type>::invoke(
     const std::optional<const DataType>& dtype,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& output,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
     const std::optional<bool>& use_legacy,
     const std::optional<bool>& fast_and_approximate_mode,
     const std::optional<CoreRangeSet>& sub_core_grids) {
@@ -496,9 +496,9 @@ Tensor BinaryOperationWithFastApprox<binary_op_type>::invoke(
     const std::optional<const DataType>& dtype,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& output,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
     const std::optional<bool>& use_legacy,
     const std::optional<bool>& fast_and_approximate_mode,
     const std::optional<CoreRangeSet>& sub_core_grids) {
@@ -523,9 +523,9 @@ Tensor MulOperationWithFastApprox<binary_op_type>::invoke(
     const std::optional<const DataType>& dtype,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& output,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
     const std::optional<bool>& use_legacy,
     const std::optional<bool>& fast_and_approximate_mode,
     const std::optional<CoreRangeSet>& sub_core_grids) {
@@ -553,9 +553,9 @@ Tensor MulOperationWithFastApprox<binary_op_type>::invoke(
     const std::optional<const DataType>& dtype,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& output,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
     const std::optional<bool>& use_legacy,
     const std::optional<bool>& fast_and_approximate_mode,
     const std::optional<CoreRangeSet>& sub_core_grids) {
@@ -617,9 +617,9 @@ Tensor RelationalBinary<binary_op_type>::invoke(
     const std::optional<const DataType>& dtype,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& output,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
     const std::optional<bool>& use_legacy,
     const std::optional<CoreRangeSet>& sub_core_grids) {
     return detail::invoke_binary_ng(
@@ -644,9 +644,9 @@ Tensor RelationalBinary<binary_op_type>::invoke(
     const std::optional<const DataType>& dtype,
     const std::optional<ttnn::MemoryConfig>& memory_config,
     const std::optional<Tensor>& output,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
     const std::optional<bool>& use_legacy,
     const std::optional<CoreRangeSet>& sub_core_grids) {
     if (use_legacy ? *use_legacy
@@ -686,9 +686,9 @@ template <BinaryOpType binary_op_type>
 Tensor InplaceRelationalBinary<binary_op_type>::invoke(
     const Tensor& lhs,
     const Tensor& rhs,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy,
     const std::optional<CoreRangeSet>& sub_core_grids) {
     return RelationalBinary<binary_op_type>::invoke(
@@ -708,9 +708,9 @@ template <BinaryOpType binary_op_type>
 Tensor InplaceRelationalBinary<binary_op_type>::invoke(
     const ttnn::Tensor& lhs,
     const float rhs,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy,
     const std::optional<CoreRangeSet>& sub_core_grids) {
     return RelationalBinary<binary_op_type>::invoke(
@@ -730,9 +730,9 @@ template <BinaryOpType binary_op_type>
 Tensor InplaceLogicalBinary<binary_op_type>::invoke(
     const Tensor& lhs,
     const Tensor& rhs,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy,
     const std::optional<CoreRangeSet>& sub_core_grids) {
     return BinaryOperation<binary_op_type>::invoke(
@@ -752,9 +752,9 @@ template <BinaryOpType binary_op_type>
 Tensor InplaceBinaryOperation<binary_op_type>::invoke(
     const Tensor& lhs,
     const Tensor& rhs,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy,
     const std::optional<CoreRangeSet>& sub_core_grids) {
     return BinaryOperation<binary_op_type>::invoke(
@@ -774,9 +774,9 @@ template <BinaryOpType binary_op_type>
 Tensor InplaceBinaryOperation<binary_op_type>::invoke(
     const ttnn::Tensor& lhs,
     const float rhs,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy,
     const std::optional<CoreRangeSet>& sub_core_grids) {
     return BinaryOperation<binary_op_type>::invoke(
@@ -796,9 +796,9 @@ template <BinaryOpType binary_op_type>
 Tensor InplaceBinaryOperationWithFastApprox<binary_op_type>::invoke(
     const Tensor& lhs,
     const Tensor& rhs,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy,
     std::optional<bool> fast_and_approximate_mode,
     const std::optional<CoreRangeSet>& sub_core_grids) {
@@ -820,9 +820,9 @@ template <BinaryOpType binary_op_type>
 Tensor InplaceBinaryOperationWithFastApprox<binary_op_type>::invoke(
     const ttnn::Tensor& lhs,
     const float rhs,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy,
     std::optional<bool> fast_and_approximate_mode,
     const std::optional<CoreRangeSet>& sub_core_grids) {
@@ -844,9 +844,9 @@ template <BinaryOpType binary_op_type>
 Tensor InplaceMulOperationWithFastApprox<binary_op_type>::invoke(
     const Tensor& lhs,
     const Tensor& rhs,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy,
     std::optional<bool> fast_and_approximate_mode,
     const std::optional<CoreRangeSet>& sub_core_grids) {
@@ -870,9 +870,9 @@ template <BinaryOpType binary_op_type>
 Tensor InplaceMulOperationWithFastApprox<binary_op_type>::invoke(
     const ttnn::Tensor& lhs,
     const float rhs,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy,
     std::optional<bool> fast_and_approximate_mode,
     const std::optional<CoreRangeSet>& sub_core_grids) {
@@ -899,9 +899,9 @@ Tensor BinaryOperationSfpu<binary_op_type>::invoke(
     const std::optional<const DataType>& dtype,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& output,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     return detail::invoke_binary_ng(
         lhs,
@@ -971,7 +971,7 @@ Tensor WhereOperationWithScalar<binary_op_type>::invoke(
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
     const std::optional<CoreRangeSet>& sub_core_grids) {
-    constexpr tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> none{};
+    constexpr ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> none{};
     return ttnn::prim::binary_ng(
         condition,
         true_false_tensor,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.hpp
@@ -17,8 +17,8 @@ bool is_legacy_only(
     const auto& rhs,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& output,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations);
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations);
 
 template <BinaryOpType binary_op_type>
 struct BinaryOperation {
@@ -28,9 +28,9 @@ struct BinaryOperation {
         const std::optional<const DataType>& output_dtype = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& output = std::nullopt,
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
         const std::optional<bool>& use_legacy = std::nullopt,
         const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 
@@ -40,9 +40,9 @@ struct BinaryOperation {
         const std::optional<const DataType>& output_dtype = std::nullopt,
         const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& output = std::nullopt,
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
         const std::optional<bool>& use_legacy = std::nullopt,
         const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 };
@@ -55,9 +55,9 @@ struct BinaryOperationWithFastApprox {
         const std::optional<const DataType>& output_dtype = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& output = std::nullopt,
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
         const std::optional<bool>& use_legacy = std::nullopt,
         const std::optional<bool>& fast_and_approximate_mode = std::nullopt,
         const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
@@ -68,9 +68,9 @@ struct BinaryOperationWithFastApprox {
         const std::optional<const DataType>& output_dtype = std::nullopt,
         const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& output = std::nullopt,
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
         const std::optional<bool>& use_legacy = std::nullopt,
         const std::optional<bool>& fast_and_approximate_mode = std::nullopt,
         const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
@@ -84,9 +84,9 @@ struct MulOperationWithFastApprox {
         const std::optional<const DataType>& output_dtype = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& output = std::nullopt,
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
         const std::optional<bool>& use_legacy = std::nullopt,
         const std::optional<bool>& fast_and_approximate_mode = std::nullopt,
         const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
@@ -97,9 +97,9 @@ struct MulOperationWithFastApprox {
         const std::optional<const DataType>& output_dtype = std::nullopt,
         const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& output = std::nullopt,
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
         const std::optional<bool>& use_legacy = std::nullopt,
         const std::optional<bool>& fast_and_approximate_mode = std::nullopt,
         const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
@@ -118,9 +118,9 @@ struct RelationalBinary {
         const std::optional<const DataType>& output_dtype = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& output = std::nullopt,
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
         const std::optional<bool>& use_legacy = std::nullopt,
         const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 
@@ -130,9 +130,9 @@ struct RelationalBinary {
         const std::optional<const DataType>& dtype = std::nullopt,
         const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& output = std::nullopt,
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
         const std::optional<bool>& use_legacy = std::nullopt,
         const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 
@@ -150,18 +150,18 @@ struct InplaceRelationalBinary {
     static Tensor invoke(
         const Tensor& lhs,
         const Tensor& rhs,
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt,
         const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 
     static Tensor invoke(
         const Tensor& lhs,
         float rhs,
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt,
         const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 };
@@ -171,9 +171,9 @@ struct InplaceLogicalBinary {
     static Tensor invoke(
         const Tensor& lhs,
         const Tensor& rhs,
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt,
         const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 };
@@ -183,18 +183,18 @@ struct InplaceBinaryOperation {
     static Tensor invoke(
         const Tensor& lhs,
         const Tensor& rhs,
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt,
         const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 
     static Tensor invoke(
         const Tensor& lhs,
         float rhs,
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt,
         const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 };
@@ -204,9 +204,9 @@ struct InplaceBinaryOperationWithFastApprox {
     static Tensor invoke(
         const Tensor& lhs,
         const Tensor& rhs,
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt,
         std::optional<bool> fast_and_approximate_mode = std::nullopt,
         const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
@@ -214,9 +214,9 @@ struct InplaceBinaryOperationWithFastApprox {
     static Tensor invoke(
         const Tensor& lhs,
         float rhs,
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt,
         std::optional<bool> fast_and_approximate_mode = std::nullopt,
         const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
@@ -227,9 +227,9 @@ struct InplaceMulOperationWithFastApprox {
     static Tensor invoke(
         const Tensor& lhs,
         const Tensor& rhs,
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt,
         std::optional<bool> fast_and_approximate_mode = std::nullopt,
         const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
@@ -237,9 +237,9 @@ struct InplaceMulOperationWithFastApprox {
     static Tensor invoke(
         const Tensor& lhs,
         float rhs,
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt,
         std::optional<bool> fast_and_approximate_mode = std::nullopt,
         const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
@@ -253,9 +253,9 @@ struct BinaryOperationSfpu {
         const std::optional<const DataType>& output_dtype = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& output = std::nullopt,
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+        ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
 };
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -72,9 +72,9 @@ Tensor ExecuteMinimum::invoke(
     const std::optional<const DataType>& /*output_dtype*/,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     return BinaryOperationSfpu<operations::binary::BinaryOpType::MINIMUM>::invoke(
         input_tensor_a,
@@ -94,9 +94,9 @@ Tensor ExecuteMinimum::invoke(
     const std::optional<const DataType>& /*output_dtype*/,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> /*post_activations*/,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> /*lhs_activations*/,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> /*rhs_activations*/,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> /*post_activations*/,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> /*lhs_activations*/,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> /*rhs_activations*/,
     std::optional<bool> /*use_legacy*/) {
     return std::visit(
         [&](auto input_b) {
@@ -112,9 +112,9 @@ Tensor ExecuteMaximum::invoke(
     const std::optional<const DataType>& /*output_dtype*/,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     return BinaryOperationSfpu<operations::binary::BinaryOpType::MAXIMUM>::invoke(
         input_tensor_a,
@@ -134,9 +134,9 @@ Tensor ExecuteMaximum::invoke(
     const std::optional<const DataType>& /*output_dtype*/,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> /*post_activations*/,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> /*lhs_activations*/,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> /*rhs_activations*/,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> /*post_activations*/,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> /*lhs_activations*/,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> /*rhs_activations*/,
     std::optional<bool> /*use_legacy*/) {
     return std::visit(
         [&](auto input_b) {
@@ -196,9 +196,9 @@ Tensor ExecuteDiv::invoke(
     const std::optional<const DataType>& output_dtype,
     const std::optional<MemoryConfig>& output_mem_config,
     std::optional<Tensor> output_tensor,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
     const std::optional<bool>& use_legacy,
     const std::optional<CoreRangeSet>& sub_core_grids) {
     const auto has_legacy_only_args = rounding_mode.has_value();
@@ -324,9 +324,9 @@ Tensor ExecuteDiv::invoke(
     const std::optional<const DataType>& output_dtype,
     const std::optional<MemoryConfig>& output_mem_config,
     const std::optional<Tensor>& output_tensor,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
     const std::optional<bool>& use_legacy,
     const std::optional<CoreRangeSet>& sub_core_grids) {
     DataType input_dtype = input_a.dtype();
@@ -511,7 +511,7 @@ Tensor run_remainder(
     const Tensor& input_b,
     const std::optional<MemoryConfig>& output_mem_config,
     const std::optional<CoreRangeSet>& sub_core_grids) {
-    using FusedActivations = tt::stl::Span<const unary::EltwiseUnaryWithParam>;
+    using FusedActivations = ttsl::Span<const unary::EltwiseUnaryWithParam>;
     // explicitly using binary_ng to avoid fallback to legacy because of row broadcast
     Tensor result = ttnn::subtract(
         input_a,
@@ -759,9 +759,9 @@ Tensor ExecuteGCD::invoke(
     const std::optional<const DataType>& /*output_dtype*/,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     return BinaryOperationSfpu<operations::binary::BinaryOpType::GCD>::invoke(
         input_tensor_a,
@@ -781,9 +781,9 @@ Tensor ExecuteLCM::invoke(
     const std::optional<const DataType>& /*output_dtype*/,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     return BinaryOperationSfpu<operations::binary::BinaryOpType::LCM>::invoke(
         input_tensor_a,
@@ -835,9 +835,9 @@ Tensor ExecutePower::invoke(
     const std::optional<const DataType>& /*dtype*/,
     const std::optional<ttnn::MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     return BinaryOperationSfpu<operations::binary::BinaryOpType::POWER>::invoke(
         input,
@@ -858,9 +858,9 @@ Tensor ExecutePower::invoke(
     const std::optional<const DataType>& /*dtype*/,
     const std::optional<ttnn::MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     // As per binary infra, first input is always a tensor but this support needed for pytorch2 tracing
     // https://github.com/tenstorrent/pytorch2.0_ttnn/blob/main/docs/operations/aten.pow.Scalar.md
@@ -884,9 +884,9 @@ Tensor ExecuteRsub::invoke(
     const std::optional<const DataType>& output_dtype,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     return BinaryOperation<operations::binary::BinaryOpType::RSUB>::invoke(
         input_tensor_a,
@@ -906,9 +906,9 @@ Tensor ExecuteRsub::invoke(
     const std::optional<const DataType>& output_dtype,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     if (not(use_legacy ? *use_legacy
                        : binary::is_legacy_only(
@@ -940,9 +940,9 @@ Tensor ExecuteBitwiseAnd::invoke(
     const Tensor& input_tensor_b,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     if (not(use_legacy ? *use_legacy
                        : binary::is_legacy_only(
@@ -981,9 +981,9 @@ Tensor ExecuteBitwiseAnd::invoke(
     const int32_t input_b,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     if (not(use_legacy ? *use_legacy
                        : binary::is_legacy_only(
@@ -1016,9 +1016,9 @@ Tensor ExecuteBitwiseOr::invoke(
     const Tensor& input_tensor_b,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     if (not(use_legacy ? *use_legacy
                        : binary::is_legacy_only(
@@ -1049,9 +1049,9 @@ Tensor ExecuteBitwiseOr::invoke(
     const int32_t input_b,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     if (not(use_legacy ? *use_legacy
                        : binary::is_legacy_only(
@@ -1084,9 +1084,9 @@ Tensor ExecuteBitwiseXor::invoke(
     const Tensor& input_tensor_b,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     if (not(use_legacy ? *use_legacy
                        : binary::is_legacy_only(
@@ -1117,9 +1117,9 @@ Tensor ExecuteBitwiseXor::invoke(
     const int32_t input_b,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     if (not(use_legacy ? *use_legacy
                        : binary::is_legacy_only(
@@ -1152,9 +1152,9 @@ Tensor ExecuteBitwiseLeftShift::invoke(
     const Tensor& input_tensor_b,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     if (not(use_legacy ? *use_legacy
                        : binary::is_legacy_only(
@@ -1185,9 +1185,9 @@ Tensor ExecuteBitwiseLeftShift::invoke(
     const int32_t input_b,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     if (not(use_legacy ? *use_legacy
                        : binary::is_legacy_only(
@@ -1220,9 +1220,9 @@ Tensor ExecuteBitwiseRightShift::invoke(
     const Tensor& input_tensor_b,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     if (not(use_legacy ? *use_legacy
                        : binary::is_legacy_only(
@@ -1253,9 +1253,9 @@ Tensor ExecuteBitwiseRightShift::invoke(
     const int32_t input_b,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     if (not(use_legacy ? *use_legacy
                        : binary::is_legacy_only(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
@@ -328,7 +328,7 @@ BinaryDeviceOperation::tensor_return_value_t BinaryDeviceOperation::create_outpu
         compute_output_specs(operation_attributes, tensor_args), tensor_args.input_tensor_a.device());
 }
 
-tt::stl::hash::hash_t BinaryDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t BinaryDeviceOperation::compute_program_hash(
     const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
     const auto& input_tensor_a = tensor_args.input_tensor_a;
     const auto& input_tensor_b = tensor_args.input_tensor_b;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -223,10 +223,10 @@ SubtileBroadcastType get_subtile_broadcast_type(uint32_t a_h, uint32_t a_w, uint
     TT_THROW("Invalid subtile broadcast type");
 }
 
-tt::stl::hash::hash_t BinaryNgDeviceOperation::operation_attributes_t::to_hash() const {
+ttsl::hash::hash_t BinaryNgDeviceOperation::operation_attributes_t::to_hash() const {
     // TODO: a more generalized way to skip the hashing of an EltwiseUnaryWithParam?
     // Don't hash the quantization scale, otherwise we build the kernel for each different scale
-    return tt::stl::hash::hash_objects_with_default_seed(
+    return ttsl::hash::hash_objects_with_default_seed(
         binary_op_type,
         lhs_activations,
         rhs_activations,
@@ -454,7 +454,7 @@ BinaryNgDeviceOperation::tensor_return_value_t BinaryNgDeviceOperation::create_o
         compute_output_specs(operation_attributes, tensor_args), tensor_args.input_tensor_a.device());
 }
 
-tt::stl::hash::hash_t BinaryNgDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t BinaryNgDeviceOperation::compute_program_hash(
     const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
     const auto& input_tensor_a = tensor_args.input_tensor_a;
     const auto& input_tensor_b = tensor_args.input_tensor_b;
@@ -499,9 +499,9 @@ ttnn::operations::binary_ng::BinaryNgDeviceOperation::tensor_return_value_t bina
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& output_tensor,
     const std::optional<bool>& fast_and_approximate_mode,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
     std::optional<ttnn::operations::unary::ScalarVariant> scalar_value,
     const std::optional<CoreRangeSet>& sub_core_grids) {
     using OperationType = ttnn::operations::binary_ng::BinaryNgDeviceOperation;
@@ -619,9 +619,9 @@ ttnn::operations::binary_ng::BinaryNgDeviceOperation::tensor_return_value_t bina
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& output_tensor,
     const std::optional<bool>& fast_and_approximate_mode,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
     std::optional<ttnn::operations::unary::ScalarVariant> /*scalar_value*/,
     const std::optional<CoreRangeSet>& sub_core_grids) {
     using OperationType = ttnn::operations::binary_ng::BinaryNgDeviceOperation;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
@@ -46,7 +46,7 @@ struct BinaryNgDeviceOperation {
         bool is_quant_op = false;
         bool is_where_op = false;
 
-        tt::stl::hash::hash_t to_hash() const;
+        ttsl::hash::hash_t to_hash() const;
         DataType get_dtype() const;
     };
 
@@ -85,7 +85,7 @@ struct BinaryNgDeviceOperation {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
     static bool skip_launch(const operation_attributes_t&, const tensor_args_t&, const tensor_return_value_t&);
 };
 
@@ -101,9 +101,9 @@ ttnn::operations::binary_ng::BinaryNgDeviceOperation::tensor_return_value_t bina
     const std::optional<MemoryConfig>& memory_config = std::nullopt,
     const std::optional<Tensor>& optional_output_tensor = std::nullopt,
     const std::optional<bool>& fast_and_approximate_mode = std::nullopt,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
     std::optional<ttnn::operations::unary::ScalarVariant> scalar_value = std::nullopt,
     const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 
@@ -115,9 +115,9 @@ ttnn::operations::binary_ng::BinaryNgDeviceOperation::tensor_return_value_t bina
     const std::optional<MemoryConfig>& memory_config = std::nullopt,
     const std::optional<Tensor>& optional_output_tensor = std::nullopt,
     const std::optional<bool>& fast_and_approximate_mode = std::nullopt,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+    ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
     std::optional<ttnn::operations::unary::ScalarVariant> scalar_value = std::nullopt,
     const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -494,7 +494,7 @@ std::map<std::string, std::string> OpConfig::as_defines(DataType dtype) const {
 
 void add_activation_defines(
     std::map<std::string, std::string>& defines,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> activations,
     std::string_view operand,
     std::optional<DataType> dtype) {
     defines[fmt::format("PROCESS_{}_ACTIVATIONS(i)", operand)] = std::accumulate(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
@@ -92,7 +92,7 @@ struct OpConfig {
 
 void add_activation_defines(
     std::map<std::string, std::string>& defines,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> activations,
+    ttsl::Span<const unary::EltwiseUnaryWithParam> activations,
     std::string_view operand,
     std::optional<DataType> dtype = std::nullopt);
 

--- a/ttnn/cpp/ttnn/operations/eltwise/quantization/quantization.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/quantization/quantization.cpp
@@ -208,7 +208,7 @@ Tensor QuantOp::invoke(
         TT_FATAL(optional_output_tensor->dtype() == c_dtype, "Quantize only supports int32 outputs for now");
     }
 
-    constexpr tt::stl::Span<const unary::EltwiseUnaryWithParam> none{};
+    constexpr ttsl::Span<const unary::EltwiseUnaryWithParam> none{};
 
     const bool is_per_channel = axis.has_value();
     if (is_per_channel) {
@@ -239,7 +239,7 @@ Tensor QuantOp::invoke(
     }
 
     return std::visit(
-        tt::stl::overloaded{
+        ttsl::overloaded{
             [&](const float scale, const int32_t zero_point) {
                 const std::array post_activation{
                     unary::EltwiseUnaryWithParam{unary::UnaryOpType::ZERO_POINT, static_cast<float>(zero_point)}};
@@ -342,7 +342,7 @@ Tensor RequantOp::invoke(
         TT_FATAL(optional_output_tensor->dtype() == c_dtype, "Requantize only supports int32 outputs for now");
     }
 
-    constexpr tt::stl::Span<const unary::EltwiseUnaryWithParam> none{};
+    constexpr ttsl::Span<const unary::EltwiseUnaryWithParam> none{};
 
     const bool has_axis = axis.has_value();
 
@@ -439,7 +439,7 @@ Tensor RequantOp::invoke(
     }
 
     return std::visit(
-        tt::stl::overloaded{
+        ttsl::overloaded{
             // Enable fast path for all scalar scales & zero-points, fallback to composite ops otherwise.
             [&](const float in_scale,
                 const int32_t in_zero_point,
@@ -500,7 +500,7 @@ Tensor DequantOp::invoke(
         c_dtype == DataType::FLOAT32 || c_dtype == DataType::BFLOAT16,
         "Dequantize only supports bf16/f32 outputs for now");
 
-    constexpr tt::stl::Span<const unary::EltwiseUnaryWithParam> none{};
+    constexpr ttsl::Span<const unary::EltwiseUnaryWithParam> none{};
 
     const bool is_per_channel = axis.has_value();
     if (is_per_channel) {
@@ -540,7 +540,7 @@ Tensor DequantOp::invoke(
     }
 
     return std::visit(
-        tt::stl::overloaded{
+        ttsl::overloaded{
             [&](const float scale, const int32_t zero_point) {
                 // LLK dequant kernel does addition, so we need to negate zero_point
                 const std::array post_activation{

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_device_operation.cpp
@@ -250,8 +250,8 @@ static MemoryConfig resolve_mem_config_actual(
 
 DataType TernaryDeviceOperation::operation_attributes_t::get_dtype() const { return dtype.value_or(input_dtype); }
 
-tt::stl::hash::hash_t TernaryDeviceOperation::operation_attributes_t::to_hash() const {
-    return tt::stl::hash::hash_objects_with_default_seed(
+ttsl::hash::hash_t TernaryDeviceOperation::operation_attributes_t::to_hash() const {
+    return ttsl::hash::hash_objects_with_default_seed(
         ternary_op_type,
         ternary_variant,
         broadcast_type,
@@ -482,7 +482,7 @@ Tensor TernaryDeviceOperation::create_output_tensors(
     return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.input_tensor_a.device());
 }
 
-tt::stl::hash::hash_t TernaryDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t TernaryDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input_a = tensor_args.input_tensor_a;
     const auto& input_b = tensor_args.input_tensor_b;
@@ -491,7 +491,7 @@ tt::stl::hash::hash_t TernaryDeviceOperation::compute_program_hash(
     TernaryVariant variant = args.ternary_variant;
 
     TT_FATAL(is_device_tensor(input_a), "Unexpected Tensor type {}", input_a.storage_type());
-    tt::stl::hash::hash_t hash = tt::tt_metal::operation::hash_operation<TernaryDeviceOperation>(
+    ttsl::hash::hash_t hash = tt::tt_metal::operation::hash_operation<TernaryDeviceOperation>(
         args, input_a.dtype(), input_a.memory_config(), a_shape.volume());
 
     if (variant == TernaryVariant::TTT) {

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_device_operation.hpp
@@ -29,7 +29,7 @@ struct TernaryDeviceOperation {
         std::optional<ScalarVariant> scalar_input_a;
         std::optional<ScalarVariant> scalar_input_b;
 
-        tt::stl::hash::hash_t to_hash() const;
+        ttsl::hash::hash_t to_hash() const;
 
         DataType get_dtype() const;
     };
@@ -66,7 +66,7 @@ struct TernaryDeviceOperation {
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
     static bool skip_launch(const operation_attributes_t&, const tensor_args_t&, const tensor_return_value_t&);
 };
 

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_op_utils.cpp
@@ -719,7 +719,7 @@ ttnn::Shape compute_broadcasted_output_ternary(
     const int rank_c = c_shape.rank();
     const int largest_rank = std::max({rank_a, rank_b, rank_c});
 
-    tt::stl::SmallVector<uint32_t> output_shape(largest_rank, 1);
+    ttsl::SmallVector<uint32_t> output_shape(largest_rank, 1);
 
     for (int i = -1; i >= -largest_rank; --i) {
         auto dim_a = (i >= -rank_a) ? a_shape[i] : 1;

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary.cpp
@@ -28,7 +28,7 @@ Tensor where_impl(
     const MemoryConfig& memory_config,
     const std::optional<Tensor>& output) {
     log_debug(tt::LogOp, "Where Legacy");
-    using FusedActivations = tt::stl::Span<const unary::EltwiseUnaryWithParam>;
+    using FusedActivations = ttsl::Span<const unary::EltwiseUnaryWithParam>;
     constexpr auto dtype = std::nullopt;
     const auto get_multiplied = [&](const Tensor& condition, const auto& value) -> Tensor {
         return ttnn::multiply(

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
@@ -150,7 +150,7 @@ Tensor UnaryDeviceOperation::create_output_tensors(
     return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.input.device());
 }
 
-tt::stl::hash::hash_t UnaryDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t UnaryDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input;
     const auto& input_shape = input_tensor.padded_shape();

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.hpp
@@ -35,7 +35,7 @@ struct UnaryDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t& args, const tensor_args_t&);
 
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 
     static bool skip_launch(const operation_attributes_t&, const tensor_args_t&, const tensor_return_value_t&);
 };

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_device_operation.cpp
@@ -189,7 +189,7 @@ AllGatherAsyncDeviceOperation::tensor_return_value_t AllGatherAsyncDeviceOperati
     return create_device_tensor(output_spec, tensor_args.input_tensor.device());
 }
 
-tt::stl::hash::hash_t AllGatherAsyncDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t AllGatherAsyncDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     log_trace(tt::LogOp, "AllGatherAsyncDeviceOperation::compute_program_hash is called");
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_device_operation.hpp
@@ -30,7 +30,7 @@ struct AllGatherAsyncDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const Tensor& input_tensor,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_device_operation_types.hpp
@@ -78,7 +78,7 @@ struct AllGatherAsyncParams {
 
     // Add attributes method for reflection
     auto attributes() const {
-        using tt::stl::reflection::Attribute;
+        using ttsl::reflection::Attribute;
         std::vector<std::tuple<std::string, Attribute>> attrs;
 
         attrs.emplace_back("dim", dim);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_device_operation.cpp
@@ -78,7 +78,7 @@ AllGatherConcatDeviceOperation::tensor_return_value_t AllGatherConcatDeviceOpera
     return create_device_tensor(spec, tensor_args.input_tensor.device());
 }
 
-tt::stl::hash::hash_t AllGatherConcatDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t AllGatherConcatDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     log_trace(tt::LogOp, "AllGatherConcatDeviceOperation::compute_program_hash is called");
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_device_operation.hpp
@@ -30,7 +30,7 @@ struct AllGatherConcatDeviceOperation {
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t&);
 
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 Tensor all_gather_concat(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_device_operation_types.hpp
@@ -48,7 +48,7 @@ struct AllGatherConcatParams {
         cluster_axis(cluster_axis) {}
     // Add attributes method for reflection
     auto attributes() const {
-        using tt::stl::reflection::Attribute;
+        using ttsl::reflection::Attribute;
         std::vector<std::tuple<std::string, Attribute>> attrs;
 
         attrs.emplace_back("dim", dim);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul_async/device/all_gather_matmul_async_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul_async/device/all_gather_matmul_async_device_operation.cpp
@@ -107,7 +107,7 @@ AllGatherMatmulAsyncDeviceOperation::tensor_return_value_t AllGatherMatmulAsyncD
     return {all_gather_output_tensor, matmul_output_tensor};
 }
 
-tt::stl::hash::hash_t AllGatherMatmulAsyncDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t AllGatherMatmulAsyncDeviceOperation::compute_program_hash(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     log_trace(tt::LogOp, "AllGatherMatmulAsyncDeviceOperation::compute_program_hash is called");
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul_async/device/all_gather_matmul_async_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul_async/device/all_gather_matmul_async_device_operation.hpp
@@ -29,7 +29,7 @@ struct AllGatherMatmulAsyncDeviceOperation {
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t&);
 
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_device_operation.cpp
@@ -86,7 +86,7 @@ AllReduceAsyncDeviceOperation::tensor_return_value_t AllReduceAsyncDeviceOperati
     return create_device_tensor(output_spec, tensor_args.input_tensor.device());
 }
 
-tt::stl::hash::hash_t AllReduceAsyncDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t AllReduceAsyncDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     log_trace(tt::LogOp, "AllReduceAsyncDeviceOperation::compute_program_hash is called");
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_device_operation.hpp
@@ -25,7 +25,7 @@ struct AllReduceAsyncDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_device_operation_types.hpp
@@ -56,7 +56,7 @@ struct AllReduceAsyncParams {
 
     // Add attributes method for reflection
     auto attributes() const {
-        using tt::stl::reflection::Attribute;
+        using ttsl::reflection::Attribute;
         std::vector<std::tuple<std::string, Attribute>> attrs;
 
         attrs.emplace_back("num_links", num_links);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/all_to_all_async_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/all_to_all_async_device_operation.cpp
@@ -173,7 +173,7 @@ AllToAllAsyncDeviceOperation::tensor_return_value_t AllToAllAsyncDeviceOperation
     return tensor_args.persistent_output_buffer;
 }
 
-tt::stl::hash::hash_t AllToAllAsyncDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t AllToAllAsyncDeviceOperation::compute_program_hash(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     log_trace(tt::LogOp, "AllToAllAsyncDeviceOperation::compute_program_hash is called");
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/all_to_all_async_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/all_to_all_async_device_operation.hpp
@@ -31,7 +31,7 @@ struct AllToAllAsyncDeviceOperation {
 
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 Tensor all_to_all_async(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/all_to_all_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/all_to_all_async_device_operation_types.hpp
@@ -42,7 +42,7 @@ struct AllToAllAsyncParams {
         sub_device_id(sub_device_id) {}
 
     auto attributes() const {
-        using tt::stl::reflection::Attribute;
+        using ttsl::reflection::Attribute;
         std::vector<std::tuple<std::string, Attribute>> attrs;
         attrs.emplace_back("in_dim", in_dim);
         attrs.emplace_back("out_dim", out_dim);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_async_generic_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_async_generic_device_operation.cpp
@@ -127,7 +127,7 @@ AllToAllAsyncGenericDeviceOperation::tensor_return_value_t AllToAllAsyncGenericD
         compute_output_specs(operation_attributes, tensor_args), tensor_args.input_tensor.device());
 }
 
-tt::stl::hash::hash_t AllToAllAsyncGenericDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t AllToAllAsyncGenericDeviceOperation::compute_program_hash(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     log_trace(tt::LogOp, "AllToAllAsyncGenericDeviceOperation::compute_program_hash is called");
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_async_generic_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_async_generic_device_operation.hpp
@@ -32,7 +32,7 @@ struct AllToAllAsyncGenericDeviceOperation {
 
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/composite_common.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/composite_common.cpp
@@ -163,7 +163,7 @@ ttnn::Tensor composite_reduce_scatter(
     } else {
         const ttnn::SmallVector<int32_t> steps(output_shape.rank(), 1);
         ttnn::SmallVector<int32_t> begins(output_shape.rank(), 0), ends(output_shape.cbegin(), output_shape.cend());
-        const tt::stl::Span<const int32_t> sbegins(begins), ssteps(steps), sends(ends);
+        const ttsl::Span<const int32_t> sbegins(begins), ssteps(steps), sends(ends);
         rs_output_tensor =
             ttnn::slice(padded_native_rs_output_tensor, sbegins, sends, ssteps, native_rs_output_memory_config);
     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_moe_reduce_scatter/device/deepseek_moe_reduce_scatter_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_moe_reduce_scatter/device/deepseek_moe_reduce_scatter_device_operation.cpp
@@ -183,7 +183,7 @@ std::vector<ttnn::Tensor> DeepseekMoEReduceScatterDeviceOperation::create_output
     };
 }
 
-tt::stl::hash::hash_t DeepseekMoEReduceScatterDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t DeepseekMoEReduceScatterDeviceOperation::compute_program_hash(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     log_trace(tt::LogOp, "DeepseekMoEReduceScatterDeviceOperation::compute_program_hash is called");
     return tt::tt_metal::operation::hash_operation<DeepseekMoEReduceScatterDeviceOperation>(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_moe_reduce_scatter/device/deepseek_moe_reduce_scatter_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_moe_reduce_scatter/device/deepseek_moe_reduce_scatter_device_operation.hpp
@@ -31,7 +31,7 @@ struct DeepseekMoEReduceScatterDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_moe_reduce_scatter/device/deepseek_moe_reduce_scatter_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_moe_reduce_scatter/device/deepseek_moe_reduce_scatter_device_operation_types.hpp
@@ -32,7 +32,7 @@ struct DeepseekMoEReduceScatterParams {
     std::optional<uint32_t> cluster_axis;
 
     auto attributes() const {
-        using tt::stl::reflection::Attribute;
+        using ttsl::reflection::Attribute;
         std::vector<std::tuple<std::string, Attribute>> attrs;
         attrs.emplace_back("output_memory_config", output_memory_config);
         attrs.emplace_back("dim", dim);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_all_gather_matmul_async_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_all_gather_matmul_async_device_operation.cpp
@@ -88,7 +88,7 @@ LlamaAllGatherMatmulAsyncDeviceOperation::create_output_tensors(
     return LlamaAllGatherMatmulAsyncResult{.mm = matmul_output_tensor, .aggregated = aggregated_tensor};
 }
 
-tt::stl::hash::hash_t LlamaAllGatherMatmulAsyncDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t LlamaAllGatherMatmulAsyncDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input0 = tensor_args.input0;
     const auto& input1 = tensor_args.input1;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_all_gather_matmul_async_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_all_gather_matmul_async_device_operation.hpp
@@ -29,7 +29,7 @@ struct LlamaAllGatherMatmulAsyncDeviceOperation {
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_all_gather_matmul_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_all_gather_matmul_async_device_operation_types.hpp
@@ -56,7 +56,7 @@ struct LlamaAllGatherMatmulAsyncParams {
         cluster_axis(cluster_axis) {}
 
     auto attributes() const {
-        using tt::stl::reflection::Attribute;
+        using ttsl::reflection::Attribute;
         std::vector<std::tuple<std::string, Attribute>> attrs;
         attrs.emplace_back("devices", devices);
         attrs.emplace_back("dim", dim);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/device/rs_matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/device/rs_matmul_op.cpp
@@ -83,7 +83,7 @@ Matmul_RS::tensor_return_value_t Matmul_RS::create_output_tensors(
     return {matmul_output_tensor, rs_output_tensor};
 }
 
-tt::stl::hash::hash_t Matmul_RS::compute_program_hash(
+ttsl::hash::hash_t Matmul_RS::compute_program_hash(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     return tt::tt_metal::operation::hash_operation<Matmul_RS>(
         operation_attributes.rs_op.dim,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/device/rs_matmul_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/device/rs_matmul_op.hpp
@@ -77,7 +77,7 @@ struct Matmul_RS {
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/matmul_reduce_scatter_async/device/matmul_reduce_scatter_async_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/matmul_reduce_scatter_async/device/matmul_reduce_scatter_async_device_operation.cpp
@@ -79,7 +79,7 @@ MatmulReduceScatterAsyncDeviceOperation::create_output_tensors(
     return {.mm = matmul_output_tensor, .reduce_scatter = tensor_args.persistent_output};
 }
 
-tt::stl::hash::hash_t MatmulReduceScatterAsyncDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t MatmulReduceScatterAsyncDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     log_trace(tt::LogOp, "MatmulReduceScatterAsyncDeviceOperation::compute_program_hash is called");
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/matmul_reduce_scatter_async/device/matmul_reduce_scatter_async_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/matmul_reduce_scatter_async/device/matmul_reduce_scatter_async_device_operation.hpp
@@ -39,7 +39,7 @@ struct MatmulReduceScatterAsyncDeviceOperation {
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_device_operation_types.hpp
@@ -33,7 +33,7 @@ struct SelectiveReduceCombineParams {
     std::optional<GlobalSemaphore> optional_cross_device_semaphore;
 
     auto attributes() const {
-        using tt::stl::reflection::Attribute;
+        using ttsl::reflection::Attribute;
         std::vector<std::tuple<std::string, Attribute>> attrs;
         attrs.emplace_back("hidden_size", hidden_size);
         attrs.emplace_back("batch_size", batch_size);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation_types.hpp
@@ -21,7 +21,7 @@ struct MoEComputeParams {
     std::optional<uint32_t> cluster_axis;
 
     auto attributes() const {
-        using tt::stl::reflection::Attribute;
+        using ttsl::reflection::Attribute;
         std::vector<std::tuple<std::string, Attribute>> attrs;
         attrs.emplace_back("layer_id", layer_id);
         attrs.emplace_back("output_height_shard_dim", output_height_shard_dim);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/neighbor_pad_async_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/neighbor_pad_async_device_operation.cpp
@@ -153,7 +153,7 @@ Tensor NeighborPadAsyncDeviceOperation::create_output_tensors(
         compute_output_specs(operation_attributes, tensor_args), tensor_args.input_tensor.device());
 }
 
-tt::stl::hash::hash_t NeighborPadAsyncDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t NeighborPadAsyncDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     log_trace(tt::LogOp, "NeighborPadAsyncDeviceOperation::compute_program_hash is called");
     return operation::hash_operation<NeighborPadAsyncDeviceOperation>(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/neighbor_pad_async_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/neighbor_pad_async_device_operation.hpp
@@ -25,7 +25,7 @@ struct NeighborPadAsyncDeviceOperation {
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t&);
 
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/neighbor_pad_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/neighbor_pad_async_device_operation_types.hpp
@@ -83,7 +83,7 @@ struct NeighborPadAsyncParams {
         using_persistent_buffers(using_persistent_buffers) {}
 
     auto attributes() const {
-        using tt::stl::reflection::Attribute;
+        using ttsl::reflection::Attribute;
         std::vector<std::tuple<std::string, Attribute>> attrs;
         attrs.emplace_back("dim", dim);
         attrs.emplace_back("padding_left", padding_left);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op_device_operation.cpp
@@ -139,7 +139,7 @@ std::vector<Tensor> ReduceScatterMinimalAsyncDeviceOperation::create_output_tens
     return {intermediate_buffer, output_buffer};
 }
 
-tt::stl::hash::hash_t ReduceScatterMinimalAsyncDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t ReduceScatterMinimalAsyncDeviceOperation::compute_program_hash(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     log_trace(tt::LogOp, "ReduceScatterMinimalAsyncDeviceOperation::compute_program_hash is called");
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op_device_operation.hpp
@@ -30,7 +30,7 @@ struct ReduceScatterMinimalAsyncDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op_device_operation_types.hpp
@@ -49,7 +49,7 @@ struct ReduceScatterMinimalAsyncParams {
 
     // Add attributes method for reflection
     auto attributes() const {
-        using tt::stl::reflection::Attribute;
+        using ttsl::reflection::Attribute;
         std::vector<std::tuple<std::string, Attribute>> attrs;
         attrs.emplace_back("dim", dim);
         attrs.emplace_back("num_links", num_links);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_device_operation.cpp
@@ -145,7 +145,7 @@ RingAttentionAllGatherAsyncDeviceOperation::create_output_tensors(
     return output_tensors;
 }
 
-tt::stl::hash::hash_t RingAttentionAllGatherAsyncDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t RingAttentionAllGatherAsyncDeviceOperation::compute_program_hash(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     log_trace(tt::LogOp, "RingAttentionAllGatherAsyncDeviceOperation::compute_program_hash is called");
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_device_operation.hpp
@@ -32,7 +32,7 @@ struct RingAttentionAllGatherAsyncDeviceOperation {
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t&);
 
-    static tt::stl::hash::hash_t compute_program_hash(
+    static ttsl::hash::hash_t compute_program_hash(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_device_operation.cpp
@@ -215,7 +215,7 @@ Tensor RMSAllGatherDeviceOperation::create_output_tensors(
     return create_device_tensor(output_spec, tensor_args.input.device());
 }
 
-tt::stl::hash::hash_t RMSAllGatherDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t RMSAllGatherDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     log_trace(tt::LogOp, "RMSAllGatherDeviceOperation::compute_program_hash is called");
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_device_operation.hpp
@@ -28,7 +28,7 @@ struct RMSAllGatherDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t& args, const tensor_args_t&);
 
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_device_operation_types.hpp
@@ -67,7 +67,7 @@ struct RMSAllGatherParams {
         use_noc1_only(use_noc1_only) {}
 
     auto attributes() const {
-        using tt::stl::reflection::Attribute;
+        using ttsl::reflection::Attribute;
         std::vector<std::tuple<std::string, Attribute>> attrs;
         attrs.emplace_back("eps", eps);
         attrs.emplace_back("subblock_wt", subblock_wt);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async/device/recv_async_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async/device/recv_async_op_device_operation.cpp
@@ -31,7 +31,7 @@ RecvAsyncDeviceOperation::tensor_return_value_t RecvAsyncDeviceOperation::create
     return {tensor_args};
 }
 
-tt::stl::hash::hash_t RecvAsyncDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t RecvAsyncDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     log_trace(tt::LogOp, "RecvAsyncDeviceOperation::compute_program_hash is called");
     const ttnn::Tensor& output_tensor = tensor_args;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async/device/recv_async_op_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async/device/recv_async_op_device_operation.hpp
@@ -25,7 +25,7 @@ struct RecvAsyncDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async/device/recv_async_op_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async/device/recv_async_op_device_operation_types.hpp
@@ -17,7 +17,7 @@ struct RecvAsyncParams {
     RecvAsyncParams(const tt::tt_metal::distributed::MeshSocket& mesh_socket) : mesh_socket(mesh_socket) {}
     // Add attributes method for reflection
     auto attributes() const {
-        using tt::stl::reflection::Attribute;
+        using ttsl::reflection::Attribute;
         std::vector<std::tuple<std::string, Attribute>> attrs;
         attrs.emplace_back("mesh_socket", mesh_socket);
         return attrs;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async/device/send_async_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async/device/send_async_op_device_operation.cpp
@@ -33,7 +33,7 @@ SendAsyncDeviceOperation::tensor_return_value_t SendAsyncDeviceOperation::create
     return {};
 }
 
-tt::stl::hash::hash_t SendAsyncDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t SendAsyncDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     log_trace(tt::LogOp, "SendAsyncDeviceOperation::compute_program_hash is called");
     const ttnn::Tensor& input_tensor = tensor_args;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async/device/send_async_op_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async/device/send_async_op_device_operation.hpp
@@ -25,7 +25,7 @@ struct SendAsyncDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async/device/send_async_op_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async/device/send_async_op_device_operation_types.hpp
@@ -17,7 +17,7 @@ struct SendAsyncParams {
     SendAsyncParams(const tt::tt_metal::distributed::MeshSocket& mesh_socket) : mesh_socket(mesh_socket) {}
     // Add attributes method for reflection
     auto attributes() const {
-        using tt::stl::reflection::Attribute;
+        using ttsl::reflection::Attribute;
         std::vector<std::tuple<std::string, Attribute>> attrs;
         attrs.emplace_back("mesh_socket", mesh_socket);
         return attrs;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/slice_reshard_async_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/slice_reshard_async_device_operation.cpp
@@ -44,7 +44,7 @@ Tensor SliceReshardAsyncDeviceOperation::create_output_tensors(
     return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.device());
 }
 
-tt::stl::hash::hash_t SliceReshardAsyncDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t SliceReshardAsyncDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     log_trace(tt::LogOp, "SliceReshardAsyncDeviceOperation::compute_program_hash is called");
     return tt::tt_metal::operation::hash_operation<SliceReshardAsyncDeviceOperation>(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/slice_reshard_async_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/slice_reshard_async_device_operation.hpp
@@ -33,7 +33,7 @@ struct SliceReshardAsyncDeviceOperation {
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/slice_reshard_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/slice_reshard_async_device_operation_types.hpp
@@ -62,7 +62,7 @@ struct SliceReshardAsyncParams {
 
     // Add attributes method for reflection
     auto attributes() const {
-        using tt::stl::reflection::Attribute;
+        using ttsl::reflection::Attribute;
         std::vector<std::tuple<std::string, Attribute>> attrs;
 
         attrs.emplace_back("dim", dim);

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_device_operation.cpp
@@ -54,7 +54,7 @@ Tensor ConvertToCHWDeviceOperation::create_output_tensors(
     return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.device());
 }
 
-tt::stl::hash::hash_t ConvertToCHWDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t ConvertToCHWDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args;
     const auto& input_shape = input_tensor.padded_shape();

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_device_operation.hpp
@@ -26,7 +26,7 @@ struct ConvertToCHWDeviceOperation {
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_device_operation.cpp
@@ -56,10 +56,10 @@ Tensor ConvertToHWCDeviceOperation::create_output_tensors(
     return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
 }
 
-tt::stl::hash::hash_t ConvertToHWCDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t ConvertToHWCDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    return tt::stl::hash::hash_objects_with_default_seed(
-        tt::stl::hash::type_hash<ConvertToHWCDeviceOperation>, args, tensor_args);
+    return ttsl::hash::hash_objects_with_default_seed(
+        ttsl::hash::type_hash<ConvertToHWCDeviceOperation>, args, tensor_args);
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_device_operation.hpp
@@ -32,7 +32,7 @@ struct ConvertToHWCDeviceOperation {
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t&);
 
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.cpp
@@ -234,7 +234,7 @@ Tensor Conv3dDeviceOperation::create_output_tensors(
     return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.input_tensor.device());
 }
 
-tt::stl::hash::hash_t Conv3dDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t Conv3dDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input_tensor;
     const auto& input_shape = input_tensor.padded_shape();

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.hpp
@@ -30,7 +30,7 @@ struct Conv3dDeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.cpp
@@ -106,7 +106,7 @@ Tensor DropoutDeviceOperation::create_output_tensors(
     return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.input.device());
 }
 
-tt::stl::hash::hash_t DropoutDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t DropoutDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input;
     const auto& input_shape = input_tensor.padded_shape();

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.hpp
@@ -33,7 +33,7 @@ struct DropoutDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t& args, const tensor_args_t&);
 
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/isin/device/isin_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/isin/device/isin_device_operation.cpp
@@ -53,7 +53,7 @@ IsInDeviceOperation::tensor_return_value_t IsInDeviceOperation::create_output_te
     return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.elements_tensor.device());
 }
 
-tt::stl::hash::hash_t IsInDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t IsInDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input_memory_layout = tensor_args.elements_tensor.layout();
     const auto& input_dtype = tensor_args.elements_tensor.dtype();

--- a/ttnn/cpp/ttnn/operations/experimental/isin/device/isin_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/isin/device/isin_device_operation.hpp
@@ -21,7 +21,7 @@ struct IsInDeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 Tensor isin(

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_device_operation.cpp
@@ -103,7 +103,7 @@ AttnMatmulDeviceOperation::tensor_return_value_t AttnMatmulDeviceOperation::crea
     return create_device_tensor(output_spec, tensor_args.input_tensor_a.device());
 }
 
-tt::stl::hash::hash_t AttnMatmulDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t AttnMatmulDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     TT_FATAL(
         is_device_tensor(tensor_args.input_tensor_a),

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_device_operation.hpp
@@ -31,7 +31,7 @@ struct AttnMatmulDeviceOperation {
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t&);
 
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_device_operation.cpp
@@ -204,7 +204,7 @@ GroupAttnMatmulDeviceOperation::tensor_return_value_t GroupAttnMatmulDeviceOpera
         compute_output_specs(operation_attributes, tensor_args), tensor_args.input_tensor_a.device());
 }
 
-tt::stl::hash::hash_t GroupAttnMatmulDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t GroupAttnMatmulDeviceOperation::compute_program_hash(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     const auto& input_tensor_a = tensor_args.input_tensor_a;
     const auto& input_tensor_b = tensor_args.input_tensor_b;

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_device_operation.hpp
@@ -33,7 +33,7 @@ struct GroupAttnMatmulDeviceOperation {
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 
-    static tt::stl::hash::hash_t compute_program_hash(
+    static ttsl::hash::hash_t compute_program_hash(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_device_operation.cpp
@@ -105,7 +105,7 @@ Tensor PaddedSliceDeviceOperation::create_output_tensors(
     return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
 }
 
-tt::stl::hash::hash_t PaddedSliceDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t PaddedSliceDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     log_trace(tt::LogOp, "PaddedSliceDeviceOperation::compute_program_hash is called");
 

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_device_operation.hpp
@@ -34,7 +34,7 @@ struct PaddedSliceDeviceOperation {
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t&);
 
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/padded_slice.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/padded_slice.cpp
@@ -19,9 +19,9 @@ namespace ttnn::operations::experimental {
 template <typename T>
 ttnn::Tensor PaddedSliceOperation::invoke(
     const ttnn::Tensor& input_tensor,
-    tt::stl::Span<const T> begins,
-    tt::stl::Span<const T> ends,
-    tt::stl::Span<const T> step,
+    ttsl::Span<const T> begins,
+    ttsl::Span<const T> ends,
+    ttsl::Span<const T> step,
     const MemoryConfig& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
     const std::optional<float>& /*pad_value*/) {
@@ -152,18 +152,18 @@ ttnn::Tensor PaddedSliceOperation::invoke(
 
 template ttnn::Tensor PaddedSliceOperation::invoke<int>(
     const ttnn::Tensor& input_tensor,
-    tt::stl::Span<const int> begins,
-    tt::stl::Span<const int> ends,
-    tt::stl::Span<const int> step,
+    ttsl::Span<const int> begins,
+    ttsl::Span<const int> ends,
+    ttsl::Span<const int> step,
     const MemoryConfig& memory_config_arg,
     const std::optional<Tensor>& optional_output_tensor,
     const std::optional<float>& pad_value);
 
 template ttnn::Tensor PaddedSliceOperation::invoke<uint32_t>(
     const ttnn::Tensor& input_tensor,
-    tt::stl::Span<const uint32_t> begins,
-    tt::stl::Span<const uint32_t> ends,
-    tt::stl::Span<const uint32_t> step,
+    ttsl::Span<const uint32_t> begins,
+    ttsl::Span<const uint32_t> ends,
+    ttsl::Span<const uint32_t> step,
     const MemoryConfig& memory_config_arg,
     const std::optional<Tensor>& optional_output_tensor,
     const std::optional<float>& pad_value);

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/padded_slice.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/padded_slice.hpp
@@ -12,9 +12,9 @@ struct PaddedSliceOperation {
     template <typename T>
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input_tensor,
-        tt::stl::Span<const T> begins,
-        tt::stl::Span<const T> ends,
-        tt::stl::Span<const T> step,
+        ttsl::Span<const T> begins,
+        ttsl::Span<const T> ends,
+        ttsl::Span<const T> step,
         const MemoryConfig& memory_config_arg,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
         const std::optional<float>& pad_value = std::nullopt);
@@ -30,9 +30,9 @@ struct PaddedSliceOperation {
         const std::optional<float>& pad_value = std::nullopt) {
         return invoke(
             input_tensor,
-            tt::stl::Span<const T>(begins),
-            tt::stl::Span<const T>(ends),
-            tt::stl::Span<const T>(step),
+            ttsl::Span<const T>(begins),
+            ttsl::Span<const T>(ends),
+            ttsl::Span<const T>(step),
             memory_config_arg,
             optional_output_tensor,
             pad_value);

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation.cpp
@@ -68,7 +68,7 @@ Tensor PagedFillCacheDeviceOperation::create_output_tensors(
     return tensor_args.cache_tensor;
 }
 
-tt::stl::hash::hash_t PagedFillCacheDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t PagedFillCacheDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     auto program_factory = select_program_factory(args, tensor_args);
 

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation.hpp
@@ -34,7 +34,7 @@ struct PagedFillCacheDeviceOperation {
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t&);
 
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fused_update_cache/paged_fused_update_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fused_update_cache/paged_fused_update_cache_device_operation.cpp
@@ -243,7 +243,7 @@ PagedFusedUpdateCacheDeviceOperation::tensor_return_value_t PagedFusedUpdateCach
     return std::make_tuple(tensor_args.cache_tensor1, tensor_args.cache_tensor2);
 }
 
-tt::stl::hash::hash_t PagedFusedUpdateCacheDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t PagedFusedUpdateCacheDeviceOperation::compute_program_hash(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     auto program_factory = select_program_factory(operation_attributes, tensor_args);
 

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fused_update_cache/paged_fused_update_cache_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fused_update_cache/paged_fused_update_cache_device_operation.hpp
@@ -39,7 +39,7 @@ struct PagedFusedUpdateCacheDeviceOperation {
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 
-    static tt::stl::hash::hash_t compute_program_hash(
+    static ttsl::hash::hash_t compute_program_hash(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_device_operation.cpp
@@ -201,7 +201,7 @@ PagedUpdateCacheDeviceOperation::tensor_return_value_t PagedUpdateCacheDeviceOpe
     return tensor_args.cache_tensor;
 }
 
-tt::stl::hash::hash_t PagedUpdateCacheDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t PagedUpdateCacheDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     auto program_factory = select_program_factory(args, tensor_args);
 

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_device_operation.hpp
@@ -34,7 +34,7 @@ struct PagedUpdateCacheDeviceOperation {
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 
-    static tt::stl::hash::hash_t compute_program_hash(
+    static ttsl::hash::hash_t compute_program_hash(
         const operation_attributes_t& args, const tensor_args_t& tensor_args);
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_device_operation.cpp
@@ -23,7 +23,7 @@ PlusOneDeviceOperation::spec_return_value_t PlusOneDeviceOperation::compute_outp
     return input_tensor.tensor_spec();
 }
 
-tt::stl::hash::hash_t PlusOneDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t PlusOneDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& input_tensor) {
     const auto& input_shape = input_tensor.padded_shape();
     // Hash operation attributes (both sub_core_grids and skip_negative_entries affect program structure)

--- a/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_device_operation.hpp
@@ -27,7 +27,7 @@ struct PlusOneDeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t&);
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/fast_reduce_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/fast_reduce_nc.cpp
@@ -13,7 +13,7 @@ namespace ttnn::operations::experimental::reduction {
 
 ttnn::Tensor FastReduceNCOperation::invoke(
     const ttnn::Tensor& input,
-    tt::stl::Span<const int32_t> dims,
+    ttsl::Span<const int32_t> dims,
     const std::optional<const Tensor>& output,
     const ttnn::MemoryConfig& memory_config,
     std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config) {

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/fast_reduce_nc.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/fast_reduce_nc.hpp
@@ -13,7 +13,7 @@ namespace operations::experimental::reduction {
 struct FastReduceNCOperation {
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input,
-        tt::stl::Span<const int32_t> dims,
+        ttsl::Span<const int32_t> dims,
         const std::optional<const Tensor>& output,
         const ttnn::MemoryConfig& memory_config,
         std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config);

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/intimg_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/intimg_device_operation.hpp
@@ -23,7 +23,7 @@
 namespace ttnn::experimental::prim {
 
 using namespace tt::tt_metal;
-using namespace tt::stl;
+using namespace ttsl;
 
 struct IntImgDeviceOperation {
     using operation_attributes_t = IntImgParams;

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/intimg_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/intimg_program_factory.cpp
@@ -16,7 +16,7 @@
 namespace {
 
 using namespace tt::tt_metal;
-using namespace tt::stl;
+using namespace ttsl;
 
 enum class IntImgCB : uint32_t {
     START,

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/intimg_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/intimg_program_factory.hpp
@@ -21,7 +21,7 @@
 namespace ttnn::experimental::prim {
 
 using namespace tt::tt_metal;
-using namespace tt::stl;
+using namespace ttsl;
 
 struct IntImgProgramFactory {
     static constexpr std::array<const char*, 3> KERNEL_PATHS{

--- a/ttnn/cpp/ttnn/operations/experimental/reshape/view.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reshape/view.cpp
@@ -18,18 +18,18 @@ ttnn::Tensor view(const ttnn::Tensor& tensor, const ttnn::Shape& shape) {
     return tt::tt_metal::view(tensor, shape, shape);
 }
 
-ttnn::Tensor view(const ttnn::Tensor& tensor, tt::stl::Span<const int32_t> shape_vector) {
+ttnn::Tensor view(const ttnn::Tensor& tensor, ttsl::Span<const int32_t> shape_vector) {
     auto shape = ttnn::operations::data_movement::detail::infer_dims_for_reshape(tensor, shape_vector);
     return tt::tt_metal::view(tensor, shape, shape);
 }
 
 ttnn::Tensor view(const ttnn::Tensor& tensor, const ttnn::SmallVector<int32_t>& shape_vector) {
-    return ttnn::experimental::view(tensor, tt::stl::Span<const int32_t>(shape_vector.data(), shape_vector.size()));
+    return ttnn::experimental::view(tensor, ttsl::Span<const int32_t>(shape_vector.data(), shape_vector.size()));
 }
 
 ttnn::Tensor view(const ttnn::Tensor& tensor, int32_t N, int32_t C, int32_t H, int32_t W) {
     ttnn::SmallVector<int32_t> shape_vec{N, C, H, W};
-    return ttnn::experimental::view(tensor, tt::stl::Span<const int32_t>(shape_vec.data(), shape_vec.size()));
+    return ttnn::experimental::view(tensor, ttsl::Span<const int32_t>(shape_vec.data(), shape_vec.size()));
 }
 
 }  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/reshape/view.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reshape/view.hpp
@@ -10,7 +10,7 @@
 namespace ttnn::experimental {
 
 ttnn::Tensor view(const ttnn::Tensor& input_tensor, const ttnn::Shape& shape);
-ttnn::Tensor view(const ttnn::Tensor& input_tensor, tt::stl::Span<const int32_t> shape_vector);
+ttnn::Tensor view(const ttnn::Tensor& input_tensor, ttsl::Span<const int32_t> shape_vector);
 ttnn::Tensor view(
     const ttnn::Tensor& input_tensor, const ttnn::Shape& logical_shape, const ttnn::Shape& padded_shape);
 

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_device_operation.cpp
@@ -89,7 +89,7 @@ TensorSpec SliceWriteDeviceOperation::compute_output_specs(
     return tensor_args.output.tensor_spec();
 }
 
-tt::stl::hash::hash_t SliceWriteDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t SliceWriteDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     log_trace(tt::LogOp, "SliceWriteDeviceOperation::compute_program_hash is called");
 

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_device_operation.hpp
@@ -36,7 +36,7 @@ struct SliceWriteDeviceOperation {
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t&);
 
-    static tt::stl::hash::hash_t compute_program_hash(
+    static ttsl::hash::hash_t compute_program_hash(
         const operation_attributes_t& args, const tensor_args_t& tensor_args);
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/hc_sum_reduce_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/hc_sum_reduce_device_operation.cpp
@@ -59,7 +59,7 @@ Tensor HCSumReduceDeviceOperation::create_output_tensors(
     return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
 }
 
-tt::stl::hash::hash_t HCSumReduceDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t HCSumReduceDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input;
     const auto& input_shape = input_tensor.padded_shape();

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/hc_sum_reduce_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/hc_sum_reduce_device_operation.hpp
@@ -31,7 +31,7 @@ struct HCSumReduceDeviceOperation {
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t&);
 
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_device_operation.cpp
@@ -61,7 +61,7 @@ Tensor PrefixScanDeviceOperation::create_output_tensors(
     return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.a.device());
 }
 
-tt::stl::hash::hash_t PrefixScanDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t PrefixScanDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& a = tensor_args.a;
     const auto& a_shape = a.padded_shape();

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_device_operation.hpp
@@ -32,7 +32,7 @@ struct PrefixScanDeviceOperation {
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t&);
 
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_device_operation.cpp
@@ -110,7 +110,7 @@ Tensor RepeatAndInterleaveEltwiseMulDeviceOperation::create_output_tensors(
     return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.a.device());
 }
 
-tt::stl::hash::hash_t RepeatAndInterleaveEltwiseMulDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t RepeatAndInterleaveEltwiseMulDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input_tensor_a = tensor_args.a;
     const auto& input_tensor_b = tensor_args.b;

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_device_operation.hpp
@@ -30,7 +30,7 @@ struct RepeatAndInterleaveEltwiseMulDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t& args, const tensor_args_t&);
 
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/all_reduce_create_qkv_heads_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/all_reduce_create_qkv_heads_device_operation.cpp
@@ -272,7 +272,7 @@ AllReduceCreateQkvHeadsDeviceOperation::create_output_tensors(
         .v = create_device_tensor(output_specs.v, device)};
 }
 
-tt::stl::hash::hash_t AllReduceCreateQkvHeadsDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t AllReduceCreateQkvHeadsDeviceOperation::compute_program_hash(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input_tensor;
     auto input_shape = input_tensor.padded_shape();

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/all_reduce_create_qkv_heads_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/all_reduce_create_qkv_heads_device_operation.hpp
@@ -28,7 +28,7 @@ struct AllReduceCreateQkvHeadsDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/all_reduce_create_qkv_heads_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/all_reduce_create_qkv_heads_device_operation_types.hpp
@@ -65,7 +65,7 @@ struct AllReduceCreateQkvHeadsParams {
         cluster_axis(cluster_axis) {}
 
     auto attributes() const {
-        using tt::stl::reflection::Attribute;
+        using ttsl::reflection::Attribute;
         std::vector<std::tuple<std::string, Attribute>> attrs;
         attrs.emplace_back("num_links", num_links);
         attrs.emplace_back("ring_size", ring_size);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/concatenate_heads_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/concatenate_heads_device_operation.cpp
@@ -67,7 +67,7 @@ Tensor ConcatenateHeadsDeviceOperation::create_output_tensors(
     return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.input.device());
 }
 
-tt::stl::hash::hash_t ConcatenateHeadsDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t ConcatenateHeadsDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input;
     const auto& input_shape = input_tensor.padded_shape();

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/concatenate_heads_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/concatenate_heads_device_operation.hpp
@@ -30,7 +30,7 @@ struct ConcatenateHeadsDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t& args, const tensor_args_t&);
 
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads/device/create_qkv_heads_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads/device/create_qkv_heads_device_operation.cpp
@@ -124,7 +124,7 @@ CreateQKVHeadsResult CreateQKVHeadsDeviceOperation::create_output_tensors(
     };
 }
 
-tt::stl::hash::hash_t CreateQKVHeadsDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t CreateQKVHeadsDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input;
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads/device/create_qkv_heads_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads/device/create_qkv_heads_device_operation.hpp
@@ -29,7 +29,7 @@ struct CreateQKVHeadsDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t& args, const tensor_args_t&);
 
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads_from_separate_tensors/device/create_qkv_heads_from_separate_tensors_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads_from_separate_tensors/device/create_qkv_heads_from_separate_tensors_device_operation.cpp
@@ -216,7 +216,7 @@ CreateQKVHeadsSeparateTensorsDeviceOperation::create_output_tensors(
         create_device_tensor(std::get<1>(output_specs), tensor_args.input_tensor.device()),
         create_device_tensor(std::get<2>(output_specs), tensor_args.input_tensor.device()));
 }
-    tt::stl::hash::hash_t
+    ttsl::hash::hash_t
     CreateQKVHeadsSeparateTensorsDeviceOperation::compute_program_hash(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     return tt::tt_metal::operation::hash_operation<CreateQKVHeadsSeparateTensorsDeviceOperation>(

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads_from_separate_tensors/device/create_qkv_heads_from_separate_tensors_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads_from_separate_tensors/device/create_qkv_heads_from_separate_tensors_device_operation.hpp
@@ -28,7 +28,7 @@ struct CreateQKVHeadsSeparateTensorsDeviceOperation {
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t&);
 
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_device_operation.cpp
@@ -131,7 +131,7 @@ Tensor RotaryEmbeddingDeviceOperation::create_output_tensors(
     return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.input.device());
 }
 
-tt::stl::hash::hash_t RotaryEmbeddingDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t RotaryEmbeddingDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     tt::tt_metal::operation::Hash hash = tt::tt_metal::operation::hash_operation<RotaryEmbeddingDeviceOperation>(
         args.seq_len, args.output_mem_config, tensor_args.input, tensor_args.cos, tensor_args.sin);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_device_operation.hpp
@@ -24,7 +24,7 @@ struct RotaryEmbeddingDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t& args, const tensor_args_t&);
 
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_device_operation.cpp
@@ -174,7 +174,7 @@ RotaryEmbeddingLlamaDeviceOperation::tensor_return_value_t RotaryEmbeddingLlamaD
         compute_output_specs(operation_attributes, tensor_args)[0], tensor_args.input_tensor.device());
 }
 
-tt::stl::hash::hash_t RotaryEmbeddingLlamaDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t RotaryEmbeddingLlamaDeviceOperation::compute_program_hash(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     return tt::tt_metal::operation::hash_operation<RotaryEmbeddingLlamaDeviceOperation>(
         operation_attributes, tensor_args);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_device_operation.hpp
@@ -24,7 +24,7 @@ struct RotaryEmbeddingLlamaDeviceOperation {
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/device/gelu_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/device/gelu_backward_device_operation.cpp
@@ -100,7 +100,7 @@ Tensor GeluBackwardDeviceOperation::create_output_tensors(
     return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.input.device());
 }
 
-tt::stl::hash::hash_t GeluBackwardDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t GeluBackwardDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input;
     const auto& grad_output = tensor_args.grad_output;

--- a/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/device/gelu_backward_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/device/gelu_backward_device_operation.hpp
@@ -30,7 +30,7 @@ struct GeluBackwardDeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t& args, const tensor_args_t&);
 
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/full/device/full_program_factory_nd_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/full/device/full_program_factory_nd_sharded.cpp
@@ -53,7 +53,7 @@ FullNDShardedProgramFactory::cached_program_t FullNDShardedProgramFactory::creat
     } else {
         ordered_cores_with_data = distribution_spec.cores_with_data();
     }
-    const auto& compute_core_range = CoreRangeSet(tt::stl::Span<const CoreCoord>(ordered_cores_with_data));
+    const auto& compute_core_range = CoreRangeSet(ttsl::Span<const CoreCoord>(ordered_cores_with_data));
     const auto& aligned_page_size = output.buffer()->aligned_page_size();
     const auto& page_size = output.buffer()->page_size();
 

--- a/ttnn/cpp/ttnn/operations/full/device/full_program_factory_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/full/device/full_program_factory_sharded.cpp
@@ -62,14 +62,14 @@ FullShardedProgramFactory::cached_program_t FullShardedProgramFactory::create(
             runtime_cores.push_back(all_dram_workers[dram_channel]);  // Get the worker core for the DRAM bank and add
                                                                       // it to the vector of worker cores.
         }
-        compute_core_range = CoreRangeSet(tt::stl::Span<const CoreCoord>(runtime_cores));
+        compute_core_range = CoreRangeSet(ttsl::Span<const CoreCoord>(runtime_cores));
     } else {
         if (num_compute_cores >
             num_shards) {  // For L1 sharding, the user may specify a core grid larger than the number of shards. In
                            // this case, we need to determine which cores have data on them so that we are not running
                            // programs on cores with no data being processed.
             runtime_cores = output.buffer()->buffer_distribution_spec().value().cores_with_data();
-            compute_core_range = CoreRangeSet(tt::stl::Span<const CoreCoord>(runtime_cores));
+            compute_core_range = CoreRangeSet(ttsl::Span<const CoreCoord>(runtime_cores));
         } else {
             compute_core_range =
                 output_shard_spec.grid;  // If the user specified the same number of compute cores as the number of

--- a/ttnn/cpp/ttnn/operations/functions.hpp
+++ b/ttnn/cpp/ttnn/operations/functions.hpp
@@ -240,7 +240,7 @@ static Tensor fill_first_val_into_tensor(
     auto physical_volume = input_tensor.physical_volume();
     auto output_buffer = std::vector<T>(physical_volume);
     auto input_cpu_tensor = input_tensor.cpu();
-    tt::stl::Span<const T> host_buffer = tt::tt_metal::host_buffer::get_as<T>(input_cpu_tensor);
+    ttsl::Span<const T> host_buffer = tt::tt_metal::host_buffer::get_as<T>(input_cpu_tensor);
     const ttnn::Shape input_tensor_strides = input_tensor.strides();
     for (uint32_t i = 0; i < physical_volume; i++) {
         output_buffer[i] = host_buffer[0];
@@ -271,7 +271,7 @@ static Tensor prod_result_computation_WH_B0(
     const MemoryConfig& output_mem_config = MemoryConfig{}) {
     auto output_buffer = std::vector<T>(tt::constants::TILE_HW);
     auto input_cpu_tensor = input_tensor.cpu();
-    tt::stl::Span<const T> input_buffer = tt::tt_metal::host_buffer::get_as<T>(input_cpu_tensor);
+    ttsl::Span<const T> input_buffer = tt::tt_metal::host_buffer::get_as<T>(input_cpu_tensor);
     const ttnn::Shape input_tensor_strides = input_tensor.strides();
     T result = static_cast<T>(1.0f);
 
@@ -513,8 +513,8 @@ static bool allclose(const Tensor& tensor_a, const Tensor& tensor_b, Args... arg
         return false;
     }
 
-    tt::stl::Span<const DataType> tensor_a_buffer = tt::tt_metal::host_buffer::get_as<DataType>(tensor_a);
-    tt::stl::Span<const DataType> tensor_b_buffer = tt::tt_metal::host_buffer::get_as<DataType>(tensor_b);
+    ttsl::Span<const DataType> tensor_a_buffer = tt::tt_metal::host_buffer::get_as<DataType>(tensor_a);
+    ttsl::Span<const DataType> tensor_b_buffer = tt::tt_metal::host_buffer::get_as<DataType>(tensor_b);
 
     for (int index = 0; index < tensor_a_buffer.size(); index++) {
         using ::ttnn::detail::nearly_equal;

--- a/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.cpp
@@ -45,7 +45,7 @@ tensor_return_value_t GenericOpDeviceOperation::create_output_tensors(
     return tensor_args.output_tensor;
 }
 
-tt::stl::hash::hash_t compute_program_descriptor_hash(const tt::tt_metal::ProgramDescriptor& program_descriptor) {
+ttsl::hash::hash_t compute_program_descriptor_hash(const tt::tt_metal::ProgramDescriptor& program_descriptor) {
     if (program_descriptor.custom_program_hash) {
         return *program_descriptor.custom_program_hash;
     }
@@ -108,7 +108,7 @@ tt::stl::hash::hash_t compute_program_descriptor_hash(const tt::tt_metal::Progra
     return hash;
 }
 
-tt::stl::hash::hash_t GenericOpDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t GenericOpDeviceOperation::compute_program_hash(
     const operation_attributes_t& operation_attributes, const tensor_args_t& /*tensor_args*/) {
     size_t hash = 0;
     for (const auto& [mesh_coord_range, program_descriptor] : operation_attributes.mesh_programs) {

--- a/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.hpp
@@ -29,7 +29,7 @@ struct GenericOpDeviceOperation {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
 
     // Note: will either compute a program hash, or simply return user provided custom program hash
-    static tt::stl::hash::hash_t compute_program_hash(
+    static ttsl::hash::hash_t compute_program_hash(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 };  // struct GenericOpDeviceOperation
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -1299,7 +1299,7 @@ MatmulDeviceOperation::tensor_return_value_t MatmulDeviceOperation::create_outpu
     return output_tensors;
 }
 
-tt::stl::hash::hash_t MatmulDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t MatmulDeviceOperation::compute_program_hash(
     const operation_attributes_t& attributes, const tensor_args_t& args) {
     const auto& input_tensors = args.input_tensors;
     const auto& input_tensor_a = input_tensors.at(0);
@@ -1312,13 +1312,13 @@ tt::stl::hash::hash_t MatmulDeviceOperation::compute_program_hash(
 
     for (const auto& optional_input_tensor : args.optional_input_tensors) {
         if (optional_input_tensor.has_value()) {
-            hash = tt::stl::hash::hash_objects(hash, optional_input_tensor.value());
+            hash = ttsl::hash::hash_objects(hash, optional_input_tensor.value());
         }
     }
 
     for (const auto& optional_output_tensor : args.optional_output_tensors) {
         if (optional_output_tensor.has_value()) {
-            hash = tt::stl::hash::hash_objects(hash, optional_output_tensor.value());
+            hash = ttsl::hash::hash_objects(hash, optional_output_tensor.value());
         }
     }
     return hash;

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.hpp
@@ -41,7 +41,7 @@ struct MatmulDeviceOperation {
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 
-    static tt::stl::hash::hash_t compute_program_hash(
+    static ttsl::hash::hash_t compute_program_hash(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(

--- a/ttnn/cpp/ttnn/operations/matmul/device/sparse/sparse_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/sparse/sparse_matmul_device_operation.cpp
@@ -244,7 +244,7 @@ SparseMatmulDeviceOperation::tensor_return_value_t SparseMatmulDeviceOperation::
     return output_tensors;
 }
 
-// static tt::stl::hash::hash_t SparseMatmulDeviceOperation::compute_program_hash(
+// static ttsl::hash::hash_t SparseMatmulDeviceOperation::compute_program_hash(
 //     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 
 std::tuple<SparseMatmulDeviceOperation::operation_attributes_t, SparseMatmulDeviceOperation::tensor_args_t>

--- a/ttnn/cpp/ttnn/operations/matmul/device/sparse/sparse_matmul_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/sparse/sparse_matmul_device_operation.hpp
@@ -27,7 +27,7 @@ struct SparseMatmulDeviceOperation {
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 
-    // static tt::stl::hash::hash_t compute_program_hash(
+    // static ttsl::hash::hash_t compute_program_hash(
     //     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 
     // static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/moreh_adam_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/moreh_adam_device_operation.cpp
@@ -102,11 +102,11 @@ MorehAdamOperation::tensor_return_value_t MorehAdamOperation::create_output_tens
 
 auto MorehAdamOperation::compute_program_hash(
     const MorehAdamOperation::operation_attributes_t& operation_attributes,
-    const MorehAdamOperation::tensor_args_t& tensor_args) -> tt::stl::hash::hash_t {
+    const MorehAdamOperation::tensor_args_t& tensor_args) -> ttsl::hash::hash_t {
     auto operation_attributes_without_step_and_lr = operation_attributes;
     operation_attributes_without_step_and_lr.step = 0;
     operation_attributes_without_step_and_lr.lr = 0.0f;
-    return tt::stl::hash::hash_objects_with_default_seed(operation_attributes_without_step_and_lr, tensor_args);
+    return ttsl::hash::hash_objects_with_default_seed(operation_attributes_without_step_and_lr, tensor_args);
 }
 }  // namespace ttnn::operations::moreh::moreh_adam
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/moreh_adam_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/moreh_adam_device_operation.hpp
@@ -73,7 +73,7 @@ struct MorehAdamOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 }  // namespace ttnn::operations::moreh::moreh_adam
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/moreh_adamw_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/moreh_adamw_device_operation.cpp
@@ -131,12 +131,12 @@ MorehAdamWDeviceOperation::tensor_return_value_t MorehAdamWDeviceOperation::crea
     return result;
 }
 
-tt::stl::hash::hash_t MorehAdamWDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t MorehAdamWDeviceOperation::compute_program_hash(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     auto operation_attributes_without_step_and_lr = operation_attributes;
     operation_attributes_without_step_and_lr.step = 0;
     operation_attributes_without_step_and_lr.lr = 0.0f;
-    return tt::stl::hash::hash_objects_with_default_seed(operation_attributes_without_step_and_lr, tensor_args);
+    return ttsl::hash::hash_objects_with_default_seed(operation_attributes_without_step_and_lr, tensor_args);
 }
 }  // namespace ttnn::operations::moreh::moreh_adamw
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/moreh_adamw_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/moreh_adamw_device_operation.hpp
@@ -81,7 +81,7 @@ struct MorehAdamWDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 }  // namespace ttnn::operations::moreh::moreh_adamw
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm.cpp
@@ -19,7 +19,7 @@
 namespace {
 
 template <typename OutputDataType, typename InputDataType>
-std::vector<OutputDataType> cast_vec(tt::stl::Span<const InputDataType> data_to_convert) {
+std::vector<OutputDataType> cast_vec(ttsl::Span<const InputDataType> data_to_convert) {
     std::vector<OutputDataType> converted_data;
     for (auto datum : data_to_convert) {
         if constexpr (std::is_same_v<OutputDataType, float> and std::is_same_v<InputDataType, bfloat16>) {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/moreh_sum_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/moreh_sum_backward_device_operation.cpp
@@ -126,7 +126,7 @@ namespace ttnn::prim {
 ttnn::operations::moreh::moreh_sum_backward::MorehSumBackwardOperation::tensor_return_value_t moreh_sum_backward(
     const Tensor& output_grad,
     const std::optional<Tensor>& input,
-    tt::stl::Span<const int64_t> dims,
+    ttsl::Span<const int64_t> dims,
     bool keepdim,
     const std::optional<Tensor>& input_grad,
     const std::optional<MemoryConfig>& memory_config,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/moreh_sum_backward_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/moreh_sum_backward_device_operation.hpp
@@ -62,7 +62,7 @@ namespace ttnn::prim {
 ttnn::operations::moreh::moreh_sum_backward::MorehSumBackwardOperation::tensor_return_value_t moreh_sum_backward(
     const Tensor& output_grad,
     const std::optional<Tensor>& input,
-    tt::stl::Span<const int64_t> dims,
+    ttsl::Span<const int64_t> dims,
     bool keepdim,
     const std::optional<Tensor>& input_grad,
     const std::optional<MemoryConfig>& memory_config,

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.cpp
@@ -118,7 +118,7 @@ BatchNormOperation::tensor_return_value_t BatchNormOperation::create_output_tens
     return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
 }
 
-tt::stl::hash::hash_t BatchNormOperation::compute_program_hash(
+ttsl::hash::hash_t BatchNormOperation::compute_program_hash(
     const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
     const auto& [input, batch_mean, batch_var, weight, bias, output] = tensor_args;
 
@@ -153,8 +153,8 @@ tt::stl::hash::hash_t BatchNormOperation::compute_program_hash(
         std::move(args_tuple));
 }
 
-tt::stl::hash::hash_t BatchNormOperation::operation_attributes_t::to_hash() const {
-    return tt::stl::hash::hash_objects_with_default_seed(eps, memory_config, get_dtype(), compute_kernel_config);
+ttsl::hash::hash_t BatchNormOperation::operation_attributes_t::to_hash() const {
+    return ttsl::hash::hash_objects_with_default_seed(eps, memory_config, get_dtype(), compute_kernel_config);
 }
 
 }  // namespace ttnn::operations::normalization

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.hpp
@@ -17,7 +17,7 @@ struct BatchNormOperation {
 
         DataType input_dtype;
         std::optional<DataType> dtype;
-        tt::stl::hash::hash_t to_hash() const;
+        ttsl::hash::hash_t to_hash() const;
         DataType get_dtype() const;
     };
 
@@ -61,7 +61,7 @@ struct BatchNormOperation {
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 }  // namespace ttnn::operations::normalization
 

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
@@ -150,7 +150,7 @@ Pool2D::tensor_return_value_t Pool2D::create_output_tensors(
     return {create_device_tensor(output_spec_data, tensor.input_tensor_.device())};
 }
 
-tt::stl::hash::hash_t Pool2D::compute_program_hash(const operation_attributes_t& op_attr, const tensor_args_t& tensor) {
+ttsl::hash::hash_t Pool2D::compute_program_hash(const operation_attributes_t& op_attr, const tensor_args_t& tensor) {
     auto input_mem_config = tensor.input_tensor_.memory_config();
     auto in_dtype = tensor.input_tensor_.dtype();
     auto out_dtype = op_attr.output_dtype_;

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.hpp
@@ -89,7 +89,7 @@ struct Pool2D {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t&, const tensor_args_t&, const tensor_return_value_t&);
 };

--- a/ttnn/cpp/ttnn/operations/pool/rotate/device/rotate_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/rotate/device/rotate_device_operation.cpp
@@ -123,9 +123,9 @@ RotateDeviceOperation::tensor_return_value_t RotateDeviceOperation::create_outpu
     return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
 }
 
-tt::stl::hash::hash_t RotateDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t RotateDeviceOperation::compute_program_hash(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    return tt::stl::hash::hash_objects_with_default_seed(
+    return ttsl::hash::hash_objects_with_default_seed(
         operation_attributes.memory_config,
         operation_attributes.interpolation_mode,
         tensor_args.input.logical_shape(),

--- a/ttnn/cpp/ttnn/operations/pool/rotate/device/rotate_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/rotate/device/rotate_device_operation.hpp
@@ -96,7 +96,7 @@ struct RotateDeviceOperation {
         const std::string& interpolation_mode,
         const std::optional<MemoryConfig>& memory_config);
 
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::operations::rotate

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.cpp
@@ -41,7 +41,7 @@ RandDeviceOperation::tensor_return_value_t RandDeviceOperation::create_output_te
         operation_attributes.device);
 }
 
-tt::stl::hash::hash_t RandDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t RandDeviceOperation::compute_program_hash(
     const operation_attributes_t& operation_attributes, const tensor_args_t& /*tensor_args*/) {
     return tt::tt_metal::operation::hash_operation<RandDeviceOperation>(
         operation_attributes.shape,

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.hpp
@@ -51,7 +51,7 @@ struct RandDeviceOperation {
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::operations::rand

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_device_operation.hpp
@@ -21,7 +21,7 @@
 namespace ttnn::prim {
 
 using namespace tt::tt_metal;
-using namespace tt::stl;
+using namespace ttsl;
 
 struct AccumulationDeviceOperation {
     using operation_attributes_t = AccumulationParams;

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.hpp
@@ -21,7 +21,7 @@
 namespace ttnn::prim {
 
 using namespace tt::tt_metal;
-using namespace tt::stl;
+using namespace ttsl;
 
 struct AccumulationProgramFactory {
     enum class AccumulationCB : std::underlying_type_t<tt::CBIndex> {

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
@@ -84,7 +84,7 @@ ReduceDeviceOperation::tensor_return_value_t ReduceDeviceOperation::create_outpu
     return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.device());
 }
 
-tt::stl::hash::hash_t ReduceDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t ReduceDeviceOperation::compute_program_hash(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     auto program_factory = select_program_factory(operation_attributes, tensor_args);
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.hpp
@@ -37,7 +37,7 @@ struct ReduceDeviceOperation {
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 
-    static tt::stl::hash::hash_t compute_program_hash(
+    static ttsl::hash::hash_t compute_program_hash(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 };
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
@@ -253,7 +253,7 @@ RingJointSDPAResult RingJointSDPADeviceOperation::create_output_tensors(
     };
 }
 
-tt::stl::hash::hash_t RingJointSDPADeviceOperation::compute_program_hash(
+ttsl::hash::hash_t RingJointSDPADeviceOperation::compute_program_hash(
     const RingJointSDPAParams& args, const RingJointSDPAInputs& tensor_args) {
     const std::vector<Tensor> input_tensors = {
         tensor_args.input_q,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.hpp
@@ -24,7 +24,7 @@ struct RingJointSDPADeviceOperation {
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
     static tt::tt_metal::operation::OpPerformanceModelGeneral<Tensors> create_op_performance_model(
         const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensors);
 };

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation_types.hpp
@@ -51,7 +51,7 @@ struct RingJointSDPAParams {
         ccl_core_grid_offset(ccl_core_grid_offset) {}
 
     auto attributes() const {
-        using tt::stl::reflection::Attribute;
+        using ttsl::reflection::Attribute;
         std::vector<std::tuple<std::string, Attribute>> attrs;
         attrs.emplace_back("joint_strategy", joint_strategy);
         attrs.emplace_back("logical_n", logical_n);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_device_operation.cpp
@@ -371,7 +371,7 @@ SDPAOperation::tensor_return_value_t SDPAOperation::create_output_tensors(
     return create_device_tensor(compute_output_specs(attrs, tensors), tensors.q.device());
 }
 
-tt::stl::hash::hash_t SDPAOperation::compute_program_hash(const SDPAParams& attrs, const SDPAInputs& tensors) {
+ttsl::hash::hash_t SDPAOperation::compute_program_hash(const SDPAParams& attrs, const SDPAInputs& tensors) {
     bool is_chunked_prefill = attrs.chunk_start_idx.has_value() || attrs.chunk_start_idx_tensor.has_value();
     bool flexible_chunked = attrs.chunk_start_idx_tensor.has_value();
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_device_operation.hpp
@@ -28,7 +28,7 @@ struct SDPAOperation {
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t& attrs, const tensor_args_t&);
 
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensor);
 };

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.cpp
@@ -401,7 +401,7 @@ Tensor SdpaDecodeDeviceOperation::create_output_tensors(
     return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.q.device());
 }
 
-tt::stl::hash::hash_t SdpaDecodeDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t SdpaDecodeDeviceOperation::compute_program_hash(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     bool has_cur_pos = tensor_args.cur_pos_tensor.has_value();
     bool has_attn_mask = tensor_args.attn_mask.has_value();

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.hpp
@@ -34,7 +34,7 @@ struct SdpaDecodeDeviceOperation {
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 
-    static tt::stl::hash::hash_t compute_program_hash(
+    static ttsl::hash::hash_t compute_program_hash(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 };
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_windowed/device/sdpa_windowed_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_windowed/device/sdpa_windowed_device_operation.cpp
@@ -140,7 +140,7 @@ Tensor WindowedScaledDotProductAttentionDeviceOperation::create_output_tensors(
     return create_device_tensor(compute_output_specs(attrs, tensors), tensors.q.device());
 }
 
-tt::stl::hash::hash_t WindowedScaledDotProductAttentionDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t WindowedScaledDotProductAttentionDeviceOperation::compute_program_hash(
     const operation_attributes_t& attrs, const tensor_args_t& tensors) {
     operation::Hash hash = operation::hash_operation<WindowedScaledDotProductAttentionDeviceOperation>(
         attrs.scale,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_windowed/device/sdpa_windowed_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_windowed/device/sdpa_windowed_device_operation.hpp
@@ -36,7 +36,7 @@ struct WindowedScaledDotProductAttentionDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t&, const tensor_args_t&, tensor_return_value_t& output_tensor);
 };

--- a/ttnn/cpp/ttnn/operations/uniform/device/uniform_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/uniform/device/uniform_device_operation.cpp
@@ -34,10 +34,10 @@ UniformDeviceOperation::tensor_return_value_t UniformDeviceOperation::create_out
     return tensor_args.input;
 }
 
-tt::stl::hash::hash_t UniformDeviceOperation::compute_program_hash(const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+ttsl::hash::hash_t UniformDeviceOperation::compute_program_hash(const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     auto cached_operation_attributes = operation_attributes;
     cached_operation_attributes.seed = 0;
-    return tt::stl::hash::hash_objects_with_default_seed(cached_operation_attributes, tensor_args);
+    return ttsl::hash::hash_objects_with_default_seed(cached_operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::operations::uniform

--- a/ttnn/cpp/ttnn/operations/uniform/device/uniform_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/uniform/device/uniform_device_operation.hpp
@@ -52,7 +52,7 @@ struct UniformDeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::operations::uniform


### PR DESCRIPTION
The `tt::stl` namespace is marked `[[deprecated("Use ttsl namespace instead")]]`. This removes 245 instances across 221 files in `ttnn/`, eliminating the flood of `-Wdeprecated-declarations` warnings emitted when `tt-train` builds with `-Wdeprecated-declarations` re-enabled.

`ttsl` was introduced on **2025-06-16** in PR #23351 ("Set up TTSL namespace"). This PR is cleaning up `ttnn/` — the last major subsystem still using the deprecated alias, ~9 months later.

Replacements made:
- `tt::stl::Span`          → `ttsl::Span`
- `tt::stl::hash::`        → `ttsl::hash::`
- `tt::stl::reflection::`  → `ttsl::reflection::`
- `tt::stl::make_span`     → `ttsl::make_span`
- `tt::stl::get_type_name` → `ttsl::get_type_name`
- `tt::stl::overloaded`    → `ttsl::overloaded`
- `tt::stl::SmallVector`   → `ttsl::SmallVector`
- `using namespace tt::stl` → `using namespace ttsl`

No include changes needed — `ttsl` headers are already transitively included in all affected files.

### Checklist

- [ ] [\![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=brain/ttnn-ttsl-namespace-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:brain/ttnn-ttsl-namespace-migration)
- [ ] [\![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=brain/ttnn-ttsl-namespace-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:brain/ttnn-ttsl-namespace-migration)
- [ ] [\![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=brain/ttnn-ttsl-namespace-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:brain/ttnn-ttsl-namespace-migration)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early