### PR TITLE
[cleanup]: refactor some builder and router code to index channels by VC rather than by flat index

### DIFF
--- a/tests/tt_metal/tt_fabric/fabric_router/test_channel_trimming_capture.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_channel_trimming_capture.cpp
@@ -1911,12 +1911,12 @@ TEST_F(Fabric2DChannelTrimmingOverrideVC0S0S1VC1AllFixture, ChannelCountsConsist
     const auto& builder_ctx = control_plane.get_fabric_context().get_builder_context();
 
     const auto& max_sender = builder_ctx.get_max_sender_channels_per_vc();
-    const auto& max_receiver = builder_ctx.get_max_receiver_channels_per_vc();
+    const auto& is_receiver_channel_active = builder_ctx.get_is_receiver_channel_active_per_vc();
 
     // 2D mesh: VC0 should have >= 4 sender channels (Worker + N/E/S/W directions)
     EXPECT_GE(max_sender[0], 4u);
     // VC0 should have at least 1 receiver
-    EXPECT_GE(max_receiver[0], 1u);
+    EXPECT_TRUE(is_receiver_channel_active[0]);
 }
 
 // Test: Override-only mode (no capture profile) creates a fully-enabled baseline.
@@ -2031,16 +2031,15 @@ TEST_F(T3kIntermeshChannelTrimmingOverrideVC0S0S1VC1AllFixture, IntermeshVC1Chan
     const auto& builder_ctx = control_plane.get_fabric_context().get_builder_context();
 
     const auto& max_sender = builder_ctx.get_max_sender_channels_per_vc();
-    const auto& max_receiver = builder_ctx.get_max_receiver_channels_per_vc();
+    const auto& is_receiver_channel_active = builder_ctx.get_is_receiver_channel_active_per_vc();
 
     // VC0: should have >= 4 sender channels (Worker + mesh directions)
     EXPECT_GE(max_sender[0], 4u);
-    EXPECT_GE(max_receiver[0], 1u);
+    EXPECT_TRUE(is_receiver_channel_active[0]);
 
     // VC1: intermesh topology should have non-zero VC1 channels
     EXPECT_GT(max_sender[1], 0u) << "Intermesh topology should have VC1 sender channels";
     EXPECT_GE(max_sender[1], 3u) << "Intermesh VC1 should have >= 3 sender channels (one per mesh direction)";
-    EXPECT_GE(max_receiver[1], 1u) << "Intermesh VC1 should have >= 1 receiver channel";
 }
 
 // Test: Override-only mode has no per-router profile, but global overrides are active

--- a/tt_metal/fabric/builder/fabric_builder_config.hpp
+++ b/tt_metal/fabric/builder/fabric_builder_config.hpp
@@ -43,6 +43,11 @@ namespace builder_config {
 // Number of Virtual Channels supported (VC0 and VC1)
 static constexpr std::size_t MAX_NUM_VCS = 2;
 
+// Maximum number of ERISC RISC-V cores per ethernet channel (1 on WH, up to 2 on BH)
+// NOTE: MAX_RISC_CORES_PER_ETH_CHAN == MAX_NUM_VCS by coincidence on current hardware.
+// Use MAX_RISC_CORES_PER_ETH_CHAN for arrays indexed by risc_id, MAX_NUM_VCS for VC logic.
+static constexpr std::size_t MAX_RISC_CORES_PER_ETH_CHAN = 2;
+
 // linear/mesh/ring/torus: for fabric with tensix extension, only one sender channel will be present on fabric router
 static constexpr std::size_t num_sender_channels_with_tensix_config = 1;
 
@@ -96,35 +101,5 @@ uint32_t get_vc0_downstream_edm_count(bool is_2D_routing);
 uint32_t get_vc1_downstream_edm_count(bool is_2D_routing);
 
 }  // namespace builder_config
-
-/**
- * Structure to hold all parameters needed for allocator construction.
- * This simplifies passing multiple parameters to allocator constructors.
- */
-struct AllocatorConstructionParams {
-    Topology topology;
-    FabricEriscDatamoverOptions options;
-    size_t num_used_sender_channels;
-    size_t num_used_receiver_channels;
-    size_t channel_buffer_size_bytes;
-    size_t available_channel_buffering_space;
-    std::vector<MemoryRegion> memory_regions;
-
-    AllocatorConstructionParams(
-        Topology topology,
-        const FabricEriscDatamoverOptions& options,
-        size_t num_used_sender_channels,
-        size_t num_used_receiver_channels,
-        size_t channel_buffer_size_bytes,
-        size_t available_channel_buffering_space,
-        const std::vector<MemoryRegion>& memory_regions) :
-        topology(topology),
-        options(options),
-        num_used_sender_channels(num_used_sender_channels),
-        num_used_receiver_channels(num_used_receiver_channels),
-        channel_buffer_size_bytes(channel_buffer_size_bytes),
-        available_channel_buffering_space(available_channel_buffering_space),
-        memory_regions(memory_regions) {}
-};
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/fabric/builder/fabric_remote_channels_allocator.cpp
+++ b/tt_metal/fabric/builder/fabric_remote_channels_allocator.cpp
@@ -14,63 +14,39 @@ FabricRemoteChannelsAllocator::FabricRemoteChannelsAllocator(
     FabricChannelAllocator(static_allocator.topology_, static_allocator.options_, static_allocator.memory_regions_) {
     // Extract remote receiver channel information from the static allocator for all VCs
     for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
-        this->num_used_receiver_channels_per_vc_[vc] = static_allocator.num_used_receiver_channels_per_vc[vc];
-        for (size_t i = 0; i < static_allocator.num_used_receiver_channels_per_vc[vc]; i++) {
-            this->remote_receiver_channels_base_address_[vc][i] =
-                static_allocator.remote_receiver_channels_base_address[vc][i];
-            this->remote_receiver_channels_num_buffers_[vc][i] =
-                static_allocator.remote_receiver_channels_num_buffers[vc][i];
+        this->is_receiver_channel_active_per_vc_[vc] = static_allocator.is_receiver_channel_active_per_vc[vc];
+        if (static_allocator.is_receiver_channel_active_per_vc[vc]) {
+            this->remote_receiver_channel_base_address_[vc] = static_allocator.remote_receiver_channel_base_address[vc];
+            this->remote_receiver_channel_num_buffers_[vc] = static_allocator.remote_receiver_channel_num_buffers[vc];
         }
     }
 }
 
 void FabricRemoteChannelsAllocator::emit_ct_args(std::vector<uint32_t>& ct_args) const {
     // Emit per-entry data in ChannelBufferEntry format for all VCs sequentially (VC0 first, then VC1)
-    // Format: for each receiver channel per VC: (base_address, num_buffers, remote_address, remote_num_buffers)
+    // Format: for the active receiver channel per VC: (base_address, num_buffers, remote_address, remote_num_buffers)
     for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
-        for (size_t i = 0; i < this->num_used_receiver_channels_per_vc_[vc]; ++i) {
-            ct_args.push_back(static_cast<uint32_t>(this->remote_receiver_channels_base_address_[vc][i]));
-            ct_args.push_back(static_cast<uint32_t>(this->remote_receiver_channels_num_buffers_[vc][i]));
+        if (this->is_receiver_channel_active_per_vc_[vc]) {
+            ct_args.push_back(static_cast<uint32_t>(this->remote_receiver_channel_base_address_[vc]));
+            ct_args.push_back(static_cast<uint32_t>(this->remote_receiver_channel_num_buffers_[vc]));
             ct_args.push_back(0);  // remote_address (unused for remote pools)
             ct_args.push_back(0);  // remote_num_buffers (unused for remote pools)
         }
     }
 }
 
-size_t FabricRemoteChannelsAllocator::get_remote_receiver_channel_base_address(size_t vc_id, size_t channel_id) const {
+size_t FabricRemoteChannelsAllocator::get_remote_receiver_channel_base_address(size_t vc_id) const {
     TT_FATAL(
         vc_id < builder_config::MAX_NUM_VCS, "VC ID {} out of bounds (max {})", vc_id, builder_config::MAX_NUM_VCS);
-    TT_FATAL(
-        channel_id < builder_config::num_max_receiver_channels,
-        "Channel ID {} out of bounds for VC{} (max {})",
-        channel_id,
-        vc_id,
-        builder_config::num_max_receiver_channels - 1);
-    TT_FATAL(
-        channel_id < this->num_used_receiver_channels_per_vc_[vc_id],
-        "Channel ID {} is not used in VC{} (only {} channels used)",
-        channel_id,
-        vc_id,
-        this->num_used_receiver_channels_per_vc_[vc_id]);
-    return this->remote_receiver_channels_base_address_[vc_id][channel_id];
+    TT_FATAL(this->is_receiver_channel_active_per_vc_[vc_id], "VC{} has no active receiver channel", vc_id);
+    return this->remote_receiver_channel_base_address_[vc_id];
 }
 
-size_t FabricRemoteChannelsAllocator::get_remote_receiver_channel_num_buffers(size_t vc_id, size_t channel_id) const {
+size_t FabricRemoteChannelsAllocator::get_remote_receiver_channel_num_buffers(size_t vc_id) const {
     TT_FATAL(
         vc_id < builder_config::MAX_NUM_VCS, "VC ID {} out of bounds (max {})", vc_id, builder_config::MAX_NUM_VCS);
-    TT_FATAL(
-        channel_id < builder_config::num_max_receiver_channels,
-        "Channel ID {} out of bounds for VC{} (max {})",
-        channel_id,
-        vc_id,
-        builder_config::num_max_receiver_channels - 1);
-    TT_FATAL(
-        channel_id < this->num_used_receiver_channels_per_vc_[vc_id],
-        "Channel ID {} is not used in VC{} (only {} channels used)",
-        channel_id,
-        vc_id,
-        this->num_used_receiver_channels_per_vc_[vc_id]);
-    return this->remote_receiver_channels_num_buffers_[vc_id][channel_id];
+    TT_FATAL(this->is_receiver_channel_active_per_vc_[vc_id], "VC{} has no active receiver channel", vc_id);
+    return this->remote_receiver_channel_num_buffers_[vc_id];
 }
 
 void FabricRemoteChannelsAllocator::emit_channel_allocations_ct_args(

--- a/tt_metal/fabric/builder/fabric_remote_channels_allocator.cpp
+++ b/tt_metal/fabric/builder/fabric_remote_channels_allocator.cpp
@@ -50,7 +50,8 @@ size_t FabricRemoteChannelsAllocator::get_remote_receiver_channel_num_buffers(si
 }
 
 void FabricRemoteChannelsAllocator::emit_channel_allocations_ct_args(
-    std::vector<uint32_t>& ct_args, size_t num_used_receiver_channels) const {
+    std::vector<uint32_t>& ct_args,
+    const std::array<bool, builder_config::MAX_NUM_VCS>& is_receiver_channel_active_per_vc) const {
     // Tag
     ct_args.push_back(0xabcd1234);
 
@@ -62,9 +63,13 @@ void FabricRemoteChannelsAllocator::emit_channel_allocations_ct_args(
     emit_ct_args(ct_args);
 
     // No sender channels for remote allocator (0 sender entries)
-    // Receiver channel-to-entry index (identity mapping)
-    for (size_t i = 0; i < num_used_receiver_channels; ++i) {
-        ct_args.push_back(static_cast<uint32_t>(i));
+    // Receiver channel-to-entry index: emit sequential indices only for active VCs
+    size_t entry_index = 0;
+    for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
+        if (is_receiver_channel_active_per_vc[vc]) {
+            ct_args.push_back(static_cast<uint32_t>(entry_index));
+            ++entry_index;
+        }
     }
 }
 

--- a/tt_metal/fabric/builder/fabric_remote_channels_allocator.hpp
+++ b/tt_metal/fabric/builder/fabric_remote_channels_allocator.hpp
@@ -55,8 +55,13 @@ public:
     /**
      * Emit the complete ChannelAllocations CT arg block for remote receiver channels.
      * Format: [tag] [num_entries] [per-entry data...] [receiver_to_entry_idx...]
+     *
+     * @param ct_args Vector to append compile-time arguments to
+     * @param is_receiver_channel_active_per_vc Whether the receiver channel is active per VC
      */
-    void emit_channel_allocations_ct_args(std::vector<uint32_t>& ct_args, size_t num_used_receiver_channels) const;
+    void emit_channel_allocations_ct_args(
+        std::vector<uint32_t>& ct_args,
+        const std::array<bool, builder_config::MAX_NUM_VCS>& is_receiver_channel_active_per_vc) const;
 
     /**
      * Get the base address for the remote receiver channel in a specific VC.

--- a/tt_metal/fabric/builder/fabric_remote_channels_allocator.hpp
+++ b/tt_metal/fabric/builder/fabric_remote_channels_allocator.hpp
@@ -59,56 +59,39 @@ public:
     void emit_channel_allocations_ct_args(std::vector<uint32_t>& ct_args, size_t num_used_receiver_channels) const;
 
     /**
-     * Get the base address for a specific remote receiver channel in a specific VC.
+     * Get the base address for the remote receiver channel in a specific VC.
+     * Each VC has at most one remote receiver channel.
      * @param vc_id Virtual Channel ID (0 for VC0, 1 for VC1)
-     * @param channel_id Channel ID within the VC
      * @return Base address
      */
-    size_t get_remote_receiver_channel_base_address(size_t vc_id, size_t channel_id) const;
+    size_t get_remote_receiver_channel_base_address(size_t vc_id) const;
 
     /**
-     * Get the number of buffers for a specific remote receiver channel in a specific VC.
+     * Get the number of buffers for the remote receiver channel in a specific VC.
+     * Each VC has at most one remote receiver channel.
      * @param vc_id Virtual Channel ID (0 for VC0, 1 for VC1)
-     * @param channel_id Channel ID within the VC
      * @return Number of buffers
      */
-    size_t get_remote_receiver_channel_num_buffers(size_t vc_id, size_t channel_id) const;
+    size_t get_remote_receiver_channel_num_buffers(size_t vc_id) const;
 
     /**
-     * Legacy getter for VC0 only (for backward compatibility).
-     * @param channel_id Channel ID
-     * @return Base address
-     */
-    size_t get_remote_receiver_channel_base_address(size_t channel_id) const {
-        return get_remote_receiver_channel_base_address(0, channel_id);
-    }
-
-    /**
-     * Legacy getter for VC0 only (for backward compatibility).
-     * @param channel_id Channel ID
-     * @return Number of buffers
-     */
-    size_t get_remote_receiver_channel_num_buffers(size_t channel_id) const {
-        return get_remote_receiver_channel_num_buffers(0, channel_id);
-    }
-
-    /**
-     * Get the number of used receiver channels for a specific VC.
+     * Get whether a specific VC has an active receiver channel.
      * @param vc_id Virtual Channel ID (0 for VC0, 1 for VC1)
-     * @return Number of used receiver channels
+     * @return true if the VC has an active receiver channel
      */
-    size_t get_num_receiver_channels(size_t vc_id) const {
+    bool is_receiver_channel_active(size_t vc_id) const {
         TT_FATAL(
             vc_id < builder_config::MAX_NUM_VCS, "VC ID {} out of bounds (max {})", vc_id, builder_config::MAX_NUM_VCS);
-        return num_used_receiver_channels_per_vc_[vc_id];
+        return is_receiver_channel_active_per_vc_[vc_id];
     }
 
     /**
-     * Legacy getter: Get total number of used receiver channels across all VCs.
-     * @return Total number of used receiver channels
+     * Get total number of active receiver channels across all VCs.
+     * @return Total number of active receiver channels (0, 1, or 2)
      */
     size_t get_num_receiver_channels() const {
-        return num_used_receiver_channels_per_vc_[0] + num_used_receiver_channels_per_vc_[1];
+        return static_cast<size_t>(is_receiver_channel_active_per_vc_[0]) +
+               static_cast<size_t>(is_receiver_channel_active_per_vc_[1]);
     }
 
     /**
@@ -117,26 +100,20 @@ public:
     void print(std::ostream& os) const override;
 
 private:
-    // Per-VC remote receiver channel data (VC × channel)
-    std::array<std::array<size_t, builder_config::num_max_receiver_channels>, builder_config::MAX_NUM_VCS>
-        remote_receiver_channels_base_address_ = {};
-    std::array<std::array<size_t, builder_config::num_max_receiver_channels>, builder_config::MAX_NUM_VCS>
-        remote_receiver_channels_num_buffers_ = {};
-    std::array<size_t, builder_config::MAX_NUM_VCS> num_used_receiver_channels_per_vc_ = {0, 0};
+    // Per-VC remote receiver channel data (one channel per VC)
+    std::array<size_t, builder_config::MAX_NUM_VCS> remote_receiver_channel_base_address_ = {};
+    std::array<size_t, builder_config::MAX_NUM_VCS> remote_receiver_channel_num_buffers_ = {};
+    std::array<bool, builder_config::MAX_NUM_VCS> is_receiver_channel_active_per_vc_ = {false, false};
 };
 
 inline void FabricRemoteChannelsAllocator::print(std::ostream& os) const {
     os << "FabricRemoteChannelsAllocator {\n";
     for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
-        os << "  VC" << vc << " num_used_receiver_channels: " << num_used_receiver_channels_per_vc_[vc] << "\n";
-        if (num_used_receiver_channels_per_vc_[vc] > 0) {
-            os << "  VC" << vc << " Remote Receiver Channels:\n";
-            for (size_t i = 0; i < num_used_receiver_channels_per_vc_[vc]; ++i) {
-                os << "    VC" << vc << " Channel " << i << ":\n";
-                os << "      base_address: 0x" << std::hex << remote_receiver_channels_base_address_[vc][i] << std::dec
-                   << "\n";
-                os << "      num_buffers: " << remote_receiver_channels_num_buffers_[vc][i] << "\n";
-            }
+        os << "  VC" << vc << " is_receiver_channel_active: " << is_receiver_channel_active_per_vc_[vc] << "\n";
+        if (is_receiver_channel_active_per_vc_[vc]) {
+            os << "  VC" << vc << " Remote Receiver Channel:\n";
+            os << "      base_address: 0x" << std::hex << remote_receiver_channel_base_address_[vc] << std::dec << "\n";
+            os << "      num_buffers: " << remote_receiver_channel_num_buffers_[vc] << "\n";
         }
     }
     os << "}";

--- a/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
+++ b/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
@@ -542,9 +542,12 @@ void FabricStaticSizedChannelsAllocator::emit_ct_args(std::vector<uint32_t>& ct_
 
 void FabricStaticSizedChannelsAllocator::emit_channel_allocations_ct_args(
     std::vector<uint32_t>& ct_args,
-    size_t num_used_vc0_sender_channels,
-    size_t num_used_vc1_sender_channels,
-    size_t num_used_receiver_channels) const {
+    const std::array<size_t, builder_config::MAX_NUM_VCS>& num_used_sender_channels_per_vc,
+    const std::array<bool, builder_config::MAX_NUM_VCS>& is_receiver_channel_active_per_vc) const {
+    size_t num_used_vc0_sender_channels = num_used_sender_channels_per_vc[0];
+    size_t num_used_vc1_sender_channels = num_used_sender_channels_per_vc[1];
+    size_t num_used_receiver_channels = static_cast<size_t>(is_receiver_channel_active_per_vc[0]) +
+                                        static_cast<size_t>(is_receiver_channel_active_per_vc[1]);
     // Tag
     ct_args.push_back(0xabcd1234);
 

--- a/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
+++ b/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
@@ -39,39 +39,31 @@ size_t FabricStaticSizedChannelsAllocator::get_sender_channel_number_of_slots(si
     return sender_channels_num_buffers[vc_id][channel_id];
 }
 
-size_t FabricStaticSizedChannelsAllocator::get_receiver_channel_number_of_slots(size_t vc_id, size_t channel_id) const {
+size_t FabricStaticSizedChannelsAllocator::get_receiver_channel_number_of_slots(size_t vc_id) const {
     TT_FATAL(
         vc_id < builder_config::MAX_NUM_VCS, "VC ID {} out of bounds (max {})", vc_id, builder_config::MAX_NUM_VCS);
-    TT_FATAL(
-        channel_id < receiver_channels_num_buffers[vc_id].size(),
-        "Receiver channel ID {} out of bounds for VC{}",
-        channel_id,
-        vc_id);
-    return receiver_channels_num_buffers[vc_id][channel_id];
+    TT_FATAL(is_receiver_channel_active_per_vc[vc_id], "VC{} has no active receiver channel", vc_id);
+    return receiver_channel_num_buffers[vc_id];
 }
 
-size_t FabricStaticSizedChannelsAllocator::get_receiver_channel_base_address(size_t vc_id, size_t channel_id) const {
+size_t FabricStaticSizedChannelsAllocator::get_receiver_channel_base_address(size_t vc_id) const {
     TT_FATAL(
         vc_id < builder_config::MAX_NUM_VCS, "VC ID {} out of bounds (max {})", vc_id, builder_config::MAX_NUM_VCS);
-    TT_FATAL(
-        channel_id < receiver_channels_base_address[vc_id].size(),
-        "Receiver channel ID {} out of bounds for VC{}",
-        channel_id,
-        vc_id);
-    return receiver_channels_base_address[vc_id][channel_id];
+    TT_FATAL(is_receiver_channel_active_per_vc[vc_id], "VC{} has no active receiver channel", vc_id);
+    return receiver_channel_base_address[vc_id];
 }
 
 FabricStaticSizedChannelsAllocator::FabricStaticSizedChannelsAllocator(
     tt::tt_fabric::Topology topology,
     const FabricEriscDatamoverOptions& options,
     const std::array<size_t, builder_config::MAX_NUM_VCS>& num_used_sender_channels_per_vc,
-    const std::array<size_t, builder_config::MAX_NUM_VCS>& num_used_receiver_channels_per_vc,
+    const std::array<bool, builder_config::MAX_NUM_VCS>& is_receiver_channel_active_per_vc,
     size_t channel_buffer_size_bytes,
     size_t available_channel_buffering_space,
     const std::vector<MemoryRegion>& memory_regions) :
     FabricChannelAllocator(topology, options, memory_regions),
     num_used_sender_channels_per_vc(num_used_sender_channels_per_vc),
-    num_used_receiver_channels_per_vc(num_used_receiver_channels_per_vc),
+    is_receiver_channel_active_per_vc(is_receiver_channel_active_per_vc),
     channel_buffer_size_bytes(channel_buffer_size_bytes),
     available_channel_buffering_space(available_channel_buffering_space) {
     // Compute buffer region start from memory regions
@@ -111,10 +103,7 @@ FabricStaticSizedChannelsAllocator::FabricStaticSizedChannelsAllocator(
             num_sender_buffer_slots_per_vc[vc].begin(),
             num_sender_buffer_slots_per_vc[vc].begin() + num_used_sender_channels_per_vc[vc],
             size_t{0});
-        size_t vc_receiver_slots = std::accumulate(
-            num_receiver_buffer_slots_per_vc[vc].begin(),
-            num_receiver_buffer_slots_per_vc[vc].begin() + num_used_receiver_channels_per_vc[vc],
-            size_t{0});
+        size_t vc_receiver_slots = is_receiver_channel_active_per_vc[vc] ? num_receiver_buffer_slots_per_vc[vc][0] : 0;
         total_slot_count += vc_sender_slots + vc_receiver_slots;
 
         log_trace(tt::LogFabric, "VC{} num_sender_buffer_slots: {}", vc, num_sender_buffer_slots_per_vc[vc]);
@@ -148,17 +137,16 @@ FabricStaticSizedChannelsAllocator::FabricStaticSizedChannelsAllocator(
                 channel_buffer_size_bytes * num_remote_sender_buffer_slots_per_vc[vc][i];
             this->remote_sender_channels_num_buffers[vc][i] = num_remote_sender_buffer_slots_per_vc[vc][i];
         }
-        // set the local receiver channel sizes and num buffers
-        for (uint32_t i = 0; i < num_used_receiver_channels_per_vc[vc]; i++) {
-            this->receiver_channels_size_bytes[vc][i] =
-                channel_buffer_size_bytes * num_receiver_buffer_slots_per_vc[vc][i];
-            this->receiver_channels_num_buffers[vc][i] = num_receiver_buffer_slots_per_vc[vc][i];
+        // set the local receiver channel size and num buffers (one per VC)
+        if (is_receiver_channel_active_per_vc[vc]) {
+            this->receiver_channel_size_bytes[vc] = channel_buffer_size_bytes * num_receiver_buffer_slots_per_vc[vc][0];
+            this->receiver_channel_num_buffers[vc] = num_receiver_buffer_slots_per_vc[vc][0];
         }
-        // set the remote receiver channel sizes and num buffers
-        for (uint32_t i = 0; i < num_used_receiver_channels_per_vc[vc]; i++) {
-            this->remote_receiver_channels_size_bytes[vc][i] =
-                channel_buffer_size_bytes * num_remote_receiver_buffer_slots_per_vc[vc][i];
-            this->remote_receiver_channels_num_buffers[vc][i] = num_remote_receiver_buffer_slots_per_vc[vc][i];
+        // set the remote receiver channel size and num buffers (one per VC)
+        if (is_receiver_channel_active_per_vc[vc]) {
+            this->remote_receiver_channel_size_bytes[vc] =
+                channel_buffer_size_bytes * num_remote_receiver_buffer_slots_per_vc[vc][0];
+            this->remote_receiver_channel_num_buffers[vc] = num_remote_receiver_buffer_slots_per_vc[vc][0];
         }
     }
 
@@ -175,15 +163,10 @@ FabricStaticSizedChannelsAllocator::FabricStaticSizedChannelsAllocator(
 
     uint32_t receiver_buffer_addr = sender_buffer_addr;
     for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
-        for (uint32_t i = 0; i < num_used_receiver_channels_per_vc[vc]; i++) {
-            this->receiver_channels_base_address[vc][i] = receiver_buffer_addr;
-            receiver_buffer_addr += this->receiver_channels_size_bytes[vc][i];
-            log_trace(
-                tt::LogFabric,
-                "VC{} Receiver {} channel_start: {}",
-                vc,
-                i,
-                this->receiver_channels_base_address[vc][i]);
+        if (is_receiver_channel_active_per_vc[vc]) {
+            this->receiver_channel_base_address[vc] = receiver_buffer_addr;
+            receiver_buffer_addr += this->receiver_channel_size_bytes[vc];
+            log_trace(tt::LogFabric, "VC{} Receiver channel_start: {}", vc, this->receiver_channel_base_address[vc]);
         }
     }
     uint32_t buffer_addr_end = receiver_buffer_addr;
@@ -205,15 +188,14 @@ FabricStaticSizedChannelsAllocator::FabricStaticSizedChannelsAllocator(
 
     uint32_t remote_receiver_buffer_addr = remote_sender_buffer_addr;
     for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
-        for (uint32_t i = 0; i < num_used_receiver_channels_per_vc[vc]; i++) {
-            this->remote_receiver_channels_base_address[vc][i] = remote_receiver_buffer_addr;
-            remote_receiver_buffer_addr += this->remote_receiver_channels_size_bytes[vc][i];
+        if (is_receiver_channel_active_per_vc[vc]) {
+            this->remote_receiver_channel_base_address[vc] = remote_receiver_buffer_addr;
+            remote_receiver_buffer_addr += this->remote_receiver_channel_size_bytes[vc];
             log_trace(
                 tt::LogFabric,
-                "VC{} Remote Receiver {} channel_start: {}",
+                "VC{} Remote Receiver channel_start: {}",
                 vc,
-                i,
-                this->remote_receiver_channels_base_address[vc][i]);
+                this->remote_receiver_channel_base_address[vc]);
         }
     }
 
@@ -241,13 +223,11 @@ FabricStaticSizedChannelsAllocator::FabricStaticSizedChannelsAllocator(
 
     // Validate receiver channels per VC
     for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
-        for (uint32_t i = 0; i < num_used_receiver_channels_per_vc[vc]; i++) {
+        if (is_receiver_channel_active_per_vc[vc]) {
             TT_FATAL(
-                this->receiver_channels_size_bytes[vc][i] > 0,
-                "Internal error when computing `receiver_channels_size_bytes[VC{}][{}]` which was computed to be size "
-                "0",
-                vc,
-                i);
+                this->receiver_channel_size_bytes[vc] > 0,
+                "Internal error when computing `receiver_channel_size_bytes[VC{}]` which was computed to be size 0",
+                vc);
         }
     }
 
@@ -258,10 +238,9 @@ FabricStaticSizedChannelsAllocator::FabricStaticSizedChannelsAllocator(
             this->sender_channels_size_bytes[vc].begin(),
             this->sender_channels_size_bytes[vc].begin() + num_used_sender_channels_per_vc[vc],
             0ul);
-        total_size += std::accumulate(
-            this->receiver_channels_size_bytes[vc].begin(),
-            this->receiver_channels_size_bytes[vc].begin() + num_used_receiver_channels_per_vc[vc],
-            0ul);
+        if (is_receiver_channel_active_per_vc[vc]) {
+            total_size += this->receiver_channel_size_bytes[vc];
+        }
     }
 
     TT_FATAL(
@@ -489,9 +468,9 @@ void FabricStaticSizedChannelsAllocator::configure_buffer_slots_helper(
             get_optimal_num_slots_per_vc(
                 default_with_tensix_buffer_slot_options[arch_index],
                 num_used_sender_channels_per_vc[0],
-                num_used_receiver_channels_per_vc[0],
+                static_cast<size_t>(is_receiver_channel_active_per_vc[0]),
                 num_used_sender_channels_per_vc[1],
-                num_used_receiver_channels_per_vc[1],
+                static_cast<size_t>(is_receiver_channel_active_per_vc[1]),
                 vc0_sender_buffer_slots,
                 vc0_receiver_buffer_slots,
                 vc1_sender_buffer_slots,
@@ -519,9 +498,9 @@ void FabricStaticSizedChannelsAllocator::configure_buffer_slots_helper(
     get_optimal_num_slots_per_vc(
         get_num_buffer_slots(topology, arch_index),
         num_used_sender_channels_per_vc[0],
-        num_used_receiver_channels_per_vc[0],
+        static_cast<size_t>(is_receiver_channel_active_per_vc[0]),
         num_used_sender_channels_per_vc[1],
-        num_used_receiver_channels_per_vc[1],
+        static_cast<size_t>(is_receiver_channel_active_per_vc[1]),
         vc0_sender_buffer_slots,
         vc0_receiver_buffer_slots,
         vc1_sender_buffer_slots,
@@ -550,13 +529,13 @@ void FabricStaticSizedChannelsAllocator::emit_ct_args(std::vector<uint32_t>& ct_
         }
     }
 
-    // Emit receiver channel args for all VCs
+    // Emit receiver channel args for all VCs (one channel per VC)
     for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
-        for (size_t i = 0; i < this->num_used_receiver_channels_per_vc[vc]; ++i) {
-            ct_args.push_back(static_cast<uint32_t>(this->receiver_channels_base_address[vc][i]));
-            ct_args.push_back(this->receiver_channels_num_buffers[vc][i]);
-            ct_args.push_back(static_cast<uint32_t>(this->remote_receiver_channels_base_address[vc][i]));
-            ct_args.push_back(this->remote_receiver_channels_num_buffers[vc][i]);
+        if (this->is_receiver_channel_active_per_vc[vc]) {
+            ct_args.push_back(static_cast<uint32_t>(this->receiver_channel_base_address[vc]));
+            ct_args.push_back(this->receiver_channel_num_buffers[vc]);
+            ct_args.push_back(static_cast<uint32_t>(this->remote_receiver_channel_base_address[vc]));
+            ct_args.push_back(this->remote_receiver_channel_num_buffers[vc]);
         }
     }
 }

--- a/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.hpp
+++ b/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.hpp
@@ -42,12 +42,15 @@ public:
     /**
      * Emit the complete ChannelAllocations CT arg block including tag, num_entries,
      * per-channel data, and channel-to-entry index mappings.
+     *
+     * @param ct_args Vector to append compile-time arguments to
+     * @param num_used_sender_channels_per_vc Number of active sender channels per VC
+     * @param is_receiver_channel_active_per_vc Whether the receiver channel is active per VC
      */
     void emit_channel_allocations_ct_args(
         std::vector<uint32_t>& ct_args,
-        size_t num_used_vc0_sender_channels,
-        size_t num_used_vc1_sender_channels,
-        size_t num_used_receiver_channels) const;
+        const std::array<size_t, builder_config::MAX_NUM_VCS>& num_used_sender_channels_per_vc,
+        const std::array<bool, builder_config::MAX_NUM_VCS>& is_receiver_channel_active_per_vc) const;
 
     /**
      * Get the number of slots for a specific sender channel in a VC.

--- a/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.hpp
+++ b/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.hpp
@@ -32,7 +32,7 @@ public:
         tt::tt_fabric::Topology topology,
         const FabricEriscDatamoverOptions& options,
         const std::array<size_t, builder_config::MAX_NUM_VCS>& num_used_sender_channels_per_vc,
-        const std::array<size_t, builder_config::MAX_NUM_VCS>& num_used_receiver_channels_per_vc,
+        const std::array<bool, builder_config::MAX_NUM_VCS>& is_receiver_channel_active_per_vc,
         size_t channel_buffer_size_bytes,
         size_t available_channel_buffering_space,
         const std::vector<MemoryRegion>& memory_regions);
@@ -66,30 +66,30 @@ public:
     size_t get_sender_channel_base_address(size_t vc_id, size_t channel_id) const;
 
     /**
-     * Get the number of slots for a specific receiver channel in a VC.
+     * Get the number of slots for the receiver channel in a VC.
+     * Each VC has at most one receiver channel.
      * @param vc_id Virtual Channel ID (0 or 1)
-     * @param channel_id Channel ID within the VC
-     * @return Number of slots
+     * @return Number of slots, or 0 if the VC has no active receiver channel
      */
-    size_t get_receiver_channel_number_of_slots(size_t vc_id, size_t channel_id) const;
+    size_t get_receiver_channel_number_of_slots(size_t vc_id) const;
 
     /**
-     * Get the base address for a specific receiver channel in a VC.
+     * Get the base address for the receiver channel in a VC.
+     * Each VC has at most one receiver channel.
      * @param vc_id Virtual Channel ID (0 or 1)
-     * @param channel_id Channel ID within the VC
      * @return Base address
      */
-    size_t get_receiver_channel_base_address(size_t vc_id, size_t channel_id) const;
+    size_t get_receiver_channel_base_address(size_t vc_id) const;
 
     size_t get_num_sender_channels(size_t vc_id) const {
         TT_FATAL(
             vc_id < builder_config::MAX_NUM_VCS, "VC ID {} out of bounds (max {})", vc_id, builder_config::MAX_NUM_VCS);
         return num_used_sender_channels_per_vc[vc_id];
     }
-    size_t get_num_receiver_channels(size_t vc_id) const {
+    bool is_receiver_channel_active(size_t vc_id) const {
         TT_FATAL(
             vc_id < builder_config::MAX_NUM_VCS, "VC ID {} out of bounds (max {})", vc_id, builder_config::MAX_NUM_VCS);
-        return num_used_receiver_channels_per_vc[vc_id];
+        return is_receiver_channel_active_per_vc[vc_id];
     }
 
     // Legacy getters (assume VC0 for backward compatibility)
@@ -99,18 +99,13 @@ public:
     size_t get_sender_channel_base_address(size_t channel_id) const {
         return get_sender_channel_base_address(0, channel_id);
     }
-    size_t get_receiver_channel_number_of_slots(size_t channel_id) const {
-        return get_receiver_channel_number_of_slots(0, channel_id);
-    }
-    size_t get_receiver_channel_base_address(size_t channel_id) const {
-        return get_receiver_channel_base_address(0, channel_id);
-    }
     // For total counts: return sum across all VCs
     size_t get_num_sender_channels() const {
         return num_used_sender_channels_per_vc[0] + num_used_sender_channels_per_vc[1];
     }
     size_t get_num_receiver_channels() const {
-        return num_used_receiver_channels_per_vc[0] + num_used_receiver_channels_per_vc[1];
+        return static_cast<size_t>(is_receiver_channel_active_per_vc[0]) +
+               static_cast<size_t>(is_receiver_channel_active_per_vc[1]);
     }
 
     // Override virtual print method from base class
@@ -139,7 +134,7 @@ private:
 
     // Configuration parameters
     std::array<size_t, builder_config::MAX_NUM_VCS> num_used_sender_channels_per_vc = {0, 0};
-    std::array<size_t, builder_config::MAX_NUM_VCS> num_used_receiver_channels_per_vc = {0, 0};
+    std::array<bool, builder_config::MAX_NUM_VCS> is_receiver_channel_active_per_vc = {false, false};
     size_t channel_buffer_size_bytes = 0;
     size_t available_channel_buffering_space = 0;
     size_t max_l1_loading_size = 0;
@@ -152,34 +147,29 @@ private:
     // Channel size and buffer information per VC (VC × channel)
     std::array<std::array<std::size_t, builder_config::num_max_sender_channels>, builder_config::MAX_NUM_VCS>
         sender_channels_size_bytes = {};
-    std::array<std::array<std::size_t, builder_config::num_max_receiver_channels>, builder_config::MAX_NUM_VCS>
-        receiver_channels_size_bytes = {};
+    // Each VC has at most one receiver channel — stored as per-VC scalar.
+    std::array<std::size_t, builder_config::MAX_NUM_VCS> receiver_channel_size_bytes = {};
     std::array<std::array<size_t, builder_config::num_max_sender_channels>, builder_config::MAX_NUM_VCS>
         sender_channels_num_buffers = {};
-    std::array<std::array<size_t, builder_config::num_max_receiver_channels>, builder_config::MAX_NUM_VCS>
-        receiver_channels_num_buffers = {};
+    std::array<size_t, builder_config::MAX_NUM_VCS> receiver_channel_num_buffers = {};
 
     // Remote channels sizes, used to calculate the remote buffer addresses.
     std::array<std::array<std::size_t, builder_config::num_max_sender_channels>, builder_config::MAX_NUM_VCS>
         remote_sender_channels_size_bytes = {};
-    std::array<std::array<std::size_t, builder_config::num_max_receiver_channels>, builder_config::MAX_NUM_VCS>
-        remote_receiver_channels_size_bytes = {};
+    std::array<std::size_t, builder_config::MAX_NUM_VCS> remote_receiver_channel_size_bytes = {};
     // Remote recv channels number of buffers, use by the local sender channel to check free slots.
     std::array<std::array<std::size_t, builder_config::num_max_sender_channels>, builder_config::MAX_NUM_VCS>
         remote_sender_channels_num_buffers = {};
-    std::array<std::array<size_t, builder_config::num_max_receiver_channels>, builder_config::MAX_NUM_VCS>
-        remote_receiver_channels_num_buffers = {};
+    std::array<size_t, builder_config::MAX_NUM_VCS> remote_receiver_channel_num_buffers = {};
 
     // Base addresses per VC
     std::array<std::array<size_t, builder_config::num_max_sender_channels>, builder_config::MAX_NUM_VCS>
         sender_channels_base_address = {};
-    std::array<std::array<size_t, builder_config::num_max_receiver_channels>, builder_config::MAX_NUM_VCS>
-        receiver_channels_base_address = {};
+    std::array<size_t, builder_config::MAX_NUM_VCS> receiver_channel_base_address = {};
     // the base addr per remote channel, used by local channels.
     std::array<std::array<size_t, builder_config::num_max_sender_channels>, builder_config::MAX_NUM_VCS>
         remote_sender_channels_base_address = {};
-    std::array<std::array<size_t, builder_config::num_max_receiver_channels>, builder_config::MAX_NUM_VCS>
-        remote_receiver_channels_base_address = {};
+    std::array<size_t, builder_config::MAX_NUM_VCS> remote_receiver_channel_base_address = {};
 };
 
 // Implementation of virtual print method
@@ -190,8 +180,8 @@ inline void FabricStaticSizedChannelsAllocator::print(std::ostream& os) const {
     os << "  Configuration:\n";
     os << "    num_used_sender_channels_per_vc: [" << num_used_sender_channels_per_vc[0] << ", "
        << num_used_sender_channels_per_vc[1] << "]\n";
-    os << "    num_used_receiver_channels_per_vc: [" << num_used_receiver_channels_per_vc[0] << ", "
-       << num_used_receiver_channels_per_vc[1] << "]\n";
+    os << "    is_receiver_channel_active_per_vc: [" << is_receiver_channel_active_per_vc[0] << ", "
+       << is_receiver_channel_active_per_vc[1] << "]\n";
     os << "    channel_buffer_size_bytes: " << channel_buffer_size_bytes << " B\n";
     os << "    available_channel_buffering_space: " << available_channel_buffering_space << " B\n";
     os << "    buffer_region_start: 0x" << std::hex << buffer_region_start << std::dec << "\n";
@@ -218,20 +208,17 @@ inline void FabricStaticSizedChannelsAllocator::print(std::ostream& os) const {
             }
         }
 
-        // Receiver channels for this VC
-        if (num_used_receiver_channels_per_vc[vc] > 0) {
-            os << "    Receiver Channels:\n";
-            for (size_t i = 0; i < num_used_receiver_channels_per_vc[vc]; ++i) {
-                os << "      Channel " << i << ":\n";
-                os << "        base_address: 0x" << std::hex << receiver_channels_base_address[vc][i] << std::dec << "\n";
-                os << "        num_buffers: " << receiver_channels_num_buffers[vc][i] << "\n";
-                os << "        size_bytes: " << receiver_channels_size_bytes[vc][i] << " B\n";
-                if (remote_receiver_channels_num_buffers[vc][i] > 0) {
-                    os << "        remote_base_address: 0x" << std::hex << remote_receiver_channels_base_address[vc][i]
-                       << std::dec << "\n";
-                    os << "        remote_num_buffers: " << remote_receiver_channels_num_buffers[vc][i] << "\n";
-                    os << "        remote_size_bytes: " << remote_receiver_channels_size_bytes[vc][i] << " B\n";
-                }
+        // Receiver channel for this VC (at most one per VC)
+        if (is_receiver_channel_active_per_vc[vc]) {
+            os << "    Receiver Channel:\n";
+            os << "        base_address: 0x" << std::hex << receiver_channel_base_address[vc] << std::dec << "\n";
+            os << "        num_buffers: " << receiver_channel_num_buffers[vc] << "\n";
+            os << "        size_bytes: " << receiver_channel_size_bytes[vc] << " B\n";
+            if (remote_receiver_channel_num_buffers[vc] > 0) {
+                os << "        remote_base_address: 0x" << std::hex << remote_receiver_channel_base_address[vc]
+                   << std::dec << "\n";
+                os << "        remote_num_buffers: " << remote_receiver_channel_num_buffers[vc] << "\n";
+                os << "        remote_size_bytes: " << remote_receiver_channel_size_bytes[vc] << " B\n";
             }
         }
     }

--- a/tt_metal/fabric/compute_mesh_router_builder.cpp
+++ b/tt_metal/fabric/compute_mesh_router_builder.cpp
@@ -256,7 +256,9 @@ std::unique_ptr<ComputeMeshRouterBuilder> ComputeMeshRouterBuilder::build(
 
     // Build reverse channel maps and compute injection flags for each builder variant
     // Get ERISC's channel count from config
-    size_t erisc_num_channels = edm_config.num_used_sender_channels;
+    // Derive from per-VC counts — consistent with num_used_sender_channels_per_vc as canonical source
+    size_t erisc_num_channels =
+        edm_config.num_used_sender_channels_per_vc[0] + edm_config.num_used_sender_channels_per_vc[1];
     auto erisc_to_router_channel_map =
         get_variant_to_router_channel_map(channel_mapping, BuilderType::ERISC, erisc_num_channels);
     auto erisc_injection_flags =

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -1255,13 +1255,16 @@ FabricEriscDatamoverBuilder::CompileTimeArgs FabricEriscDatamoverBuilder::get_co
     // Emit local channel allocations
     auto* static_alloc_ptr = dynamic_cast<FabricStaticSizedChannelsAllocator*>(config.channel_allocator.get());
     TT_FATAL(static_alloc_ptr != nullptr, "Channel allocator must be a FabricStaticSizedChannelsAllocator");
+    const std::array<size_t, builder_config::MAX_NUM_VCS> actual_sender_channels_per_vc = {
+        actual_sender_channels_vc0, actual_sender_channels_vc1};
     static_alloc_ptr->emit_channel_allocations_ct_args(
-        ct_args, actual_sender_channels_vc0, actual_sender_channels_vc1, num_receiver_channels);
+        ct_args, actual_sender_channels_per_vc, config.is_receiver_channel_active_per_vc);
 
     // Emit remote channel allocations
     ct_args.push_back(0xabaddad6);
     TT_FATAL(config.remote_channels_allocator != nullptr, "Remote channels allocator must be non-null");
-    config.remote_channels_allocator->emit_channel_allocations_ct_args(ct_args, num_receiver_channels);
+    config.remote_channels_allocator->emit_channel_allocations_ct_args(
+        ct_args, config.is_receiver_channel_active_per_vc);
 
     // Downstream sender data
     ct_args.push_back(0xabaddad7);

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -381,27 +381,27 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(
     Topology topology,
     FabricEriscDatamoverOptions options,
     const std::array<std::size_t, builder_config::MAX_NUM_VCS>& sender_channels_per_vc,
-    const std::array<std::size_t, builder_config::MAX_NUM_VCS>& receiver_channels_per_vc) :
+    const std::array<bool, builder_config::MAX_NUM_VCS>& is_receiver_channel_active_per_vc) :
     FabricEriscDatamoverConfig(topology) {
     this->channel_buffer_size_bytes = channel_buffer_size_bytes;
 
     // Set channel counts from parameters
     for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
         this->num_used_sender_channels_per_vc[vc] = sender_channels_per_vc[vc];
-        this->num_used_receiver_channels_per_vc[vc] = receiver_channels_per_vc[vc];
+        this->is_receiver_channel_active_per_vc[vc] = is_receiver_channel_active_per_vc[vc];
         log_debug(
             tt::LogFabric,
-            "  VC{}: {} senders, {} receivers",
+            "  VC{}: {} senders, receiver_active={}",
             vc,
             this->num_used_sender_channels_per_vc[vc],
-            this->num_used_receiver_channels_per_vc[vc]);
+            this->is_receiver_channel_active_per_vc[vc]);
     }
 
     // Set total counts for backward compatibility
     this->num_used_sender_channels = std::accumulate(
         this->num_used_sender_channels_per_vc.begin(), this->num_used_sender_channels_per_vc.end(), size_t{0});
-    this->num_used_receiver_channels = std::accumulate(
-        this->num_used_receiver_channels_per_vc.begin(), this->num_used_receiver_channels_per_vc.end(), size_t{0});
+    this->num_used_receiver_channels = static_cast<size_t>(this->is_receiver_channel_active_per_vc[0]) +
+                                       static_cast<size_t>(this->is_receiver_channel_active_per_vc[1]);
 
     // num_fwd_paths = total sender channels - 1 (worker channel)
     this->num_fwd_paths = this->num_used_sender_channels - 1;
@@ -460,7 +460,7 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(
         topology,
         options,
         this->num_used_sender_channels_per_vc,
-        this->num_used_receiver_channels_per_vc,
+        this->is_receiver_channel_active_per_vc,
         this->channel_buffer_size_bytes,
         available_channel_buffering_space,
         this->available_buffer_memory_regions);
@@ -711,8 +711,10 @@ FabricEriscDatamoverBuilder::FabricEriscDatamoverBuilder(
 
     // Initialize per-RISC channel servicing flags
     const auto& sender_counts = actual_sender_channels_per_vc.value_or(this->config.num_used_sender_channels_per_vc);
-    const auto& receiver_counts =
-        actual_receiver_channels_per_vc.value_or(this->config.num_used_receiver_channels_per_vc);
+    std::array<size_t, builder_config::MAX_NUM_VCS> config_receiver_counts = {
+        static_cast<size_t>(this->config.is_receiver_channel_active_per_vc[0]),
+        static_cast<size_t>(this->config.is_receiver_channel_active_per_vc[1])};
+    const auto& receiver_counts = actual_receiver_channels_per_vc.value_or(config_receiver_counts);
 
     bool is_mux_mode = has_tensix_extension && (tt::tt_metal::MetalContext::instance().get_fabric_tensix_config() ==
                                                 tt::tt_fabric::FabricTensixConfig::MUX);
@@ -972,7 +974,7 @@ FabricEriscDatamoverBuilder::CompileTimeArgs FabricEriscDatamoverBuilder::get_co
     // Get actual downstream EDM counts from the adapter (actual connections made)
     uint32_t num_vc0_downstream_edms = this->receiver_channel_to_downstream_adapter->get_downstream_edm_count_for_vc(0);
 
-    bool needs_vc1 = config.num_used_receiver_channels_per_vc[1] > 0;
+    bool needs_vc1 = config.is_receiver_channel_active_per_vc[1];
     // Get actual VC1 downstream EDM count from adapter (only relevant for multi-mesh 2D routing)
     uint32_t num_vc1_downstream_edms =
         needs_vc1 ? this->receiver_channel_to_downstream_adapter->get_downstream_edm_count_for_vc(1) : 0;
@@ -1321,7 +1323,7 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_runtime_args() const {
 
     // Pack VC1 runtime args if VC1 is configured
     // Both inter-mesh and intra-mesh routers have VC1 in multi-mesh topologies
-    bool needs_vc1 = config.num_used_receiver_channels_per_vc[1] > 0;
+    bool needs_vc1 = config.is_receiver_channel_active_per_vc[1];
     if (needs_vc1) {
         receiver_channel_to_downstream_adapter->pack_inbound_channel_rt_args(1, rt_args);
     }
@@ -1555,8 +1557,7 @@ void FabricEriscDatamoverBuilder::setup_downstream_vc_connection(
     // Validate upstream VC1 usage
     if (upstream_vc_idx == 1) {
         TT_FATAL(
-            config.num_used_receiver_channels_per_vc[1] > 0,
-            "VC1 receiver channels not configured on upstream router.");
+            config.is_receiver_channel_active_per_vc[1], "VC1 receiver channels not configured on upstream router.");
     }
 
     const auto ds_noc_x = downstream_builder->get_noc_x();
@@ -1599,7 +1600,7 @@ tt::tt_metal::KernelBuildOptLevel FabricEriscDatamoverBuilder::get_kernel_opt_le
     }
     // Use Os (optimize for size) when VC1 is active to fit in code space
     // Use O3 (optimize for performance) otherwise
-    bool vc1_active = this->config.num_used_receiver_channels_per_vc[1] > 0;
+    bool vc1_active = this->config.is_receiver_channel_active_per_vc[1];
     return vc1_active ? tt::tt_metal::KernelBuildOptLevel::Os : tt::tt_metal::KernelBuildOptLevel::O3;
 }
 

--- a/tt_metal/fabric/erisc_datamover_builder.hpp
+++ b/tt_metal/fabric/erisc_datamover_builder.hpp
@@ -316,7 +316,8 @@ struct FabricEriscDatamoverConfig {
 
     std::size_t channel_buffer_size_bytes = 0;
 
-    std::size_t num_used_sender_channels = 0;    // Total across all VCs (duplicate in allocator... don't modify)
+    std::size_t num_used_sender_channels = 0;    // Derived total: sum(num_used_sender_channels_per_vc). Use
+                                                 // num_used_sender_channels_per_vc for per-VC logic.
     std::size_t num_used_receiver_channels = 0;  // Total across all VCs (duplicate in allocator... don't modify)
     std::array<std::size_t, builder_config::MAX_NUM_VCS> num_used_sender_channels_per_vc = {
         0, 0};  // Per-VC sender channel counts
@@ -616,8 +617,11 @@ public:
 
 private:
     // Per-RISC channel servicing flags [risc_id][channel_id]
-    std::array<std::array<bool, builder_config::num_max_sender_channels>, builder_config::MAX_NUM_VCS> is_sender_channel_serviced_{};
-    std::array<std::array<bool, builder_config::num_max_receiver_channels>, builder_config::MAX_NUM_VCS> is_receiver_channel_serviced_{};
+    // Outer dim is MAX_RISC_CORES_PER_ETH_CHAN (not MAX_NUM_VCS — they are equal by coincidence on current HW)
+    std::array<std::array<bool, builder_config::num_max_sender_channels>, builder_config::MAX_RISC_CORES_PER_ETH_CHAN>
+        is_sender_channel_serviced_{};
+    std::array<std::array<bool, builder_config::num_max_receiver_channels>, builder_config::MAX_RISC_CORES_PER_ETH_CHAN>
+        is_receiver_channel_serviced_{};
 
     // Apply channel trimming overrides: disables unused sender/receiver channels
     // and stores overrides for compile-time arg generation (RX forwarding disable flags).

--- a/tt_metal/fabric/erisc_datamover_builder.hpp
+++ b/tt_metal/fabric/erisc_datamover_builder.hpp
@@ -312,14 +312,16 @@ struct FabricEriscDatamoverConfig {
         Topology topology,
         FabricEriscDatamoverOptions options,
         const std::array<std::size_t, builder_config::MAX_NUM_VCS>& sender_channels_per_vc,
-        const std::array<std::size_t, builder_config::MAX_NUM_VCS>& receiver_channels_per_vc);
+        const std::array<bool, builder_config::MAX_NUM_VCS>& is_receiver_channel_active_per_vc);
 
     std::size_t channel_buffer_size_bytes = 0;
 
     std::size_t num_used_sender_channels = 0;    // Total across all VCs (duplicate in allocator... don't modify)
     std::size_t num_used_receiver_channels = 0;  // Total across all VCs (duplicate in allocator... don't modify)
-    std::array<std::size_t, builder_config::MAX_NUM_VCS> num_used_sender_channels_per_vc = {0, 0};    // Per-VC sender channel counts
-    std::array<std::size_t, builder_config::MAX_NUM_VCS> num_used_receiver_channels_per_vc = {0, 0};  // Per-VC receiver channel counts
+    std::array<std::size_t, builder_config::MAX_NUM_VCS> num_used_sender_channels_per_vc = {
+        0, 0};  // Per-VC sender channel counts
+    std::array<bool, builder_config::MAX_NUM_VCS> is_receiver_channel_active_per_vc = {
+        false, false};  // Whether each VC has an active receiver channel
     std::size_t num_fwd_paths = 0;
     std::size_t sender_txq_id = 0;
     std::size_t receiver_txq_id = 0;
@@ -571,11 +573,6 @@ public:
     std::shared_ptr<tt::tt_fabric::ChannelConnectionWriterAdapter> receiver_channel_to_downstream_adapter;
     std::array<std::shared_ptr<tt::tt_fabric::FabricChannelAllocator>, builder_config::max_downstream_edms>
         downstream_allocators = {};
-
-    std::array<size_t, builder_config::num_max_receiver_channels> receiver_channels_num_buffers = {};
-    std::array<size_t, builder_config::num_max_receiver_channels> remote_receiver_channels_num_buffers = {};
-    std::array<size_t, builder_config::num_max_receiver_channels> local_receiver_channels_buffer_address = {};
-    std::array<size_t, builder_config::num_max_receiver_channels> remote_receiver_channels_base_address = {};
 
     std::array<size_t, builder_config::num_max_sender_channels> local_sender_channels_connection_info_addr = {};
 

--- a/tt_metal/fabric/fabric_builder_context.cpp
+++ b/tt_metal/fabric/fabric_builder_context.cpp
@@ -42,7 +42,7 @@ void FabricBuilderContext::compute_max_channel_counts() {
 
     // Compute max channel counts across all router types in this fabric
     max_sender_channels_per_vc_.fill(0);
-    max_receiver_channels_per_vc_.fill(0);
+    is_receiver_channel_active_per_vc_.fill(false);
 
     for (const auto& mapping : possible_mappings) {
         uint32_t num_vcs = mapping.get_num_virtual_channels();
@@ -50,9 +50,7 @@ void FabricBuilderContext::compute_max_channel_counts() {
             max_sender_channels_per_vc_[vc] = std::max(
                 max_sender_channels_per_vc_[vc],
                 static_cast<std::size_t>(mapping.get_num_sender_channels_for_vc(vc)));
-            max_receiver_channels_per_vc_[vc] = std::max(
-                max_receiver_channels_per_vc_[vc],
-                static_cast<std::size_t>(1u));  // Always 1 receiver per VC
+            is_receiver_channel_active_per_vc_[vc] = true;  // Always 1 receiver per VC (when VC is active)
         }
     }
 }
@@ -124,8 +122,8 @@ std::unique_ptr<FabricEriscDatamoverConfig> FabricBuilderContext::create_edm_con
         fabric_context_.get_fabric_channel_buffer_size_bytes(),
         fabric_context_.get_fabric_topology(),
         edm_options,
-        max_sender_channels_per_vc_,      // Max for this fabric instance
-        max_receiver_channels_per_vc_);   // Max for this fabric instance
+        max_sender_channels_per_vc_,          // Max for this fabric instance
+        is_receiver_channel_active_per_vc_);  // Max for this fabric instance
 }
 
 FabricEriscDatamoverConfig& FabricBuilderContext::get_fabric_router_config(

--- a/tt_metal/fabric/fabric_builder_context.hpp
+++ b/tt_metal/fabric/fabric_builder_context.hpp
@@ -133,8 +133,8 @@ public:
     const std::array<std::size_t, builder_config::MAX_NUM_VCS>& get_max_sender_channels_per_vc() const {
         return max_sender_channels_per_vc_;
     }
-    const std::array<std::size_t, builder_config::MAX_NUM_VCS>& get_max_receiver_channels_per_vc() const {
-        return max_receiver_channels_per_vc_;
+    const std::array<bool, builder_config::MAX_NUM_VCS>& get_is_receiver_channel_active_per_vc() const {
+        return is_receiver_channel_active_per_vc_;
     }
 
     // ============ Tensix Config ============
@@ -195,7 +195,7 @@ private:
 
     // Computed max channel counts based on actual router types in this fabric
     std::array<std::size_t, builder_config::MAX_NUM_VCS> max_sender_channels_per_vc_{};
-    std::array<std::size_t, builder_config::MAX_NUM_VCS> max_receiver_channels_per_vc_{};
+    std::array<bool, builder_config::MAX_NUM_VCS> is_receiver_channel_active_per_vc_{};
 
     // Pre-built EDM config templates
     std::unique_ptr<FabricEriscDatamoverConfig> router_config_;

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
@@ -125,6 +125,8 @@ static_assert(fuse_receiver_flush_and_completion_ptr == 1, "fuse_receiver_flush_
 
 constexpr size_t VC0_RECEIVER_CHANNEL = 0;
 constexpr size_t VC1_RECEIVER_CHANNEL = 1;
+// Note: VC1_SENDER_CHANNEL_START is defined above as MAX_NUM_SENDER_CHANNELS_VC0
+constexpr size_t VC0_SENDER_CHANNEL_START = 0;
 
 // Doesn't REALLY matter but for consistency I picked the next available ID
 constexpr size_t worker_info_offset_past_connection_semaphore = 32;

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -688,6 +688,28 @@ FORCE_INLINE __attribute__((optimize("jump-tables"))) bool can_forward_packet_co
     uint32_t hop_cmd,
     std::array<DownstreamSenderT, DOWNSTREAM_EDM_SIZE>& downstream_edm_interfaces,
     LocalRelayInterfaceT& local_relay_interface) {
+#if defined(ARCH_WORMHOLE) && defined(FABRIC_2D_VC1_ACTIVE)
+    bool ret_val = true;
+    if (hop_cmd & MeshRoutingFields::FORWARD_EAST) {
+        ret_val = ret_val && downstreams_have_space<DownstreamSenderT, LocalRelayInterfaceT, DOWNSTREAM_EDM_SIZE, EAST>(
+                                 downstream_edm_interfaces, local_relay_interface);
+    }
+    if (hop_cmd & MeshRoutingFields::FORWARD_WEST) {
+        ret_val = ret_val && downstreams_have_space<DownstreamSenderT, LocalRelayInterfaceT, DOWNSTREAM_EDM_SIZE, WEST>(
+                                 downstream_edm_interfaces, local_relay_interface);
+    }
+    if (hop_cmd & MeshRoutingFields::FORWARD_SOUTH) {
+        ret_val =
+            ret_val && downstreams_have_space<DownstreamSenderT, LocalRelayInterfaceT, DOWNSTREAM_EDM_SIZE, SOUTH>(
+                           downstream_edm_interfaces, local_relay_interface);
+    }
+    if (hop_cmd & MeshRoutingFields::FORWARD_NORTH) {
+        ret_val =
+            ret_val && downstreams_have_space<DownstreamSenderT, LocalRelayInterfaceT, DOWNSTREAM_EDM_SIZE, NORTH>(
+                           downstream_edm_interfaces, local_relay_interface);
+    }
+    return ret_val;
+#else
     bool ret_val = false;
 
     using eth_chan_directions::EAST;
@@ -804,6 +826,7 @@ FORCE_INLINE __attribute__((optimize("jump-tables"))) bool can_forward_packet_co
         default: __builtin_unreachable();
     }
     return ret_val;
+#endif
 }
 
 #else

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -1512,7 +1512,7 @@ FORCE_INLINE void update_telemetry(
     if constexpr (FABRIC_TELEMETRY_HEARTBEAT_RX) {
         bool receiver_idle = false;
         if (!rx_progress) {
-            receiver_idle = (get_ptr_val<to_receiver_packets_sent_streams[0]>() == 0);
+            receiver_idle = (get_ptr_val<to_receiver_packets_sent_streams[VC0_RECEIVER_CHANNEL]>() == 0);
         }
         if (rx_progress || receiver_idle) {
             volatile RiscTimestampV2* rx_heartbeat_addr =
@@ -2185,7 +2185,7 @@ FORCE_INLINE void run_fabric_edm_main_loop(
 
     auto receiver_channel_pointers = ChannelPointersTuple<ReceiverChannelPointers, RECEIVER_NUM_BUFFERS_ARRAY>::make();
     // Workaround the perf regression in RingAsLinear test.
-    auto receiver_channel_pointers_ch0 = receiver_channel_pointers.template get<0>();
+    auto receiver_channel_pointers_ch0 = receiver_channel_pointers.template get<VC0_RECEIVER_CHANNEL>();
     receiver_channel_pointers_ch0.reset();
 
 #if defined(FABRIC_2D_VC1_ACTIVE)
@@ -2193,7 +2193,7 @@ FORCE_INLINE void run_fabric_edm_main_loop(
     auto outbound_to_receiver_channel_pointer_ch1 =
         outbound_to_receiver_channel_pointers.template get<VC1_RECEIVER_CHANNEL>();
 
-    auto receiver_channel_pointers_ch1 = receiver_channel_pointers.template get<1>();
+    auto receiver_channel_pointers_ch1 = receiver_channel_pointers.template get<VC1_RECEIVER_CHANNEL>();
     receiver_channel_pointers_ch1.reset();
 #endif  // FABRIC_2D_VC1_ACTIVE
 
@@ -2273,38 +2273,38 @@ FORCE_INLINE void run_fabric_edm_main_loop(
                             local_speedy_sender_state);
                     }
 
-                    if constexpr (is_receiver_channel_serviced[0]) {
+                    if constexpr (is_receiver_channel_serviced[VC0_RECEIVER_CHANNEL]) {
 #if defined(FABRIC_2D_VC0_CROSSOVER_TO_VC1)
                         rx_progress |= run_receiver_channel_step_speedy<
-                            0,
-                            to_receiver_packets_sent_streams[0],
+                            VC0_RECEIVER_CHANNEL,
+                            to_receiver_packets_sent_streams[VC0_RECEIVER_CHANNEL],
                             ENABLE_FIRST_LEVEL_ACK_VC0,
                             VC1_DOWNSTREAM_EDM_SIZE,
                             decltype(receiver_channel_0_trid_tracker)>(
-                            local_receiver_channels.template get<0>(),
+                            local_receiver_channels.template get<VC0_RECEIVER_CHANNEL>(),
                             downstream_edm_noc_interfaces_vc1,
                             local_relay_interface,
                             receiver_channel_pointers_ch0,
                             receiver_channel_0_trid_tracker,
                             port_direction_table,
-                            receiver_channel_response_credit_senders[0],
+                            receiver_channel_response_credit_senders[VC0_RECEIVER_CHANNEL],
                             routing_table,
                             local_fabric_telemetry,
                             local_speedy_receiver_state);
 #else
                         rx_progress |= run_receiver_channel_step_speedy<
-                            0,
-                            to_receiver_packets_sent_streams[0],
+                            VC0_RECEIVER_CHANNEL,
+                            to_receiver_packets_sent_streams[VC0_RECEIVER_CHANNEL],
                             ENABLE_FIRST_LEVEL_ACK_VC0,
                             VC0_DOWNSTREAM_EDM_SIZE,
                             decltype(receiver_channel_0_trid_tracker)>(
-                            local_receiver_channels.template get<0>(),
+                            local_receiver_channels.template get<VC0_RECEIVER_CHANNEL>(),
                             downstream_edm_noc_interfaces_vc0,
                             local_relay_interface,
                             receiver_channel_pointers_ch0,
                             receiver_channel_0_trid_tracker,
                             port_direction_table,
-                            receiver_channel_response_credit_senders[0],
+                            receiver_channel_response_credit_senders[VC0_RECEIVER_CHANNEL],
                             routing_table,
                             local_fabric_telemetry,
                             local_speedy_receiver_state);
@@ -2331,7 +2331,7 @@ FORCE_INLINE void run_fabric_edm_main_loop(
                     // Inter-mesh routers receive neighbor mesh's locally generated traffic on VC0.
                     // This VC0 traffic needs to be forwarded over VC1 in the receiving mesh.
                     rx_progress |= run_receiver_channel_step<
-                        0,
+                        VC0_RECEIVER_CHANNEL,
                         ENABLE_FIRST_LEVEL_ACK_VC0,
                         VC1_DOWNSTREAM_EDM_SIZE,  // Explicit size for VC1 downstream interfaces
                         DownstreamSenderVC1T,
@@ -2347,7 +2347,7 @@ FORCE_INLINE void run_fabric_edm_main_loop(
                         local_fabric_telemetry);
 #else
                     rx_progress |= run_receiver_channel_step<
-                        0,
+                        VC0_RECEIVER_CHANNEL,
                         ENABLE_FIRST_LEVEL_ACK_VC0,
                         VC0_DOWNSTREAM_EDM_SIZE,  // Explicit size for VC0 downstream interfaces
                         DownstreamSenderVC0T,
@@ -2464,7 +2464,7 @@ FORCE_INLINE void run_fabric_edm_main_loop(
                             local_fabric_telemetry);
                     }
                     rx_progress |= run_receiver_channel_step<
-                        1,
+                        VC1_RECEIVER_CHANNEL,
                         ENABLE_FIRST_LEVEL_ACK_VC1,
                         VC1_DOWNSTREAM_EDM_SIZE,  // Explicit size for VC1 downstream interfaces
                         DownstreamSenderVC1T,
@@ -2738,11 +2738,11 @@ FORCE_INLINE void teardown(
     if constexpr (NUM_ACTIVE_ERISCS > 1) {
         wait_for_other_local_erisc();
     }
-    if constexpr (is_receiver_channel_serviced[0]) {
+    if constexpr (is_receiver_channel_serviced[VC0_RECEIVER_CHANNEL]) {
         receiver_channel_0_trid_tracker.all_buffer_slot_transactions_acked();
     }
 #if defined(FABRIC_2D_VC1_ACTIVE)
-    if constexpr (is_receiver_channel_serviced[1]) {
+    if constexpr (is_receiver_channel_serviced[VC1_RECEIVER_CHANNEL]) {
         receiver_channel_1_trid_tracker.all_buffer_slot_transactions_acked();
     }
 #endif
@@ -2863,7 +2863,7 @@ void kernel_main() {
         receiver_txq_id == sender_txq_id || receiver_txq_id == 1,
         "For multi-txq mode, the only currently supported configuration is sender_txq_id=0 and receiver_txq_id=1");
     if constexpr (receiver_txq_id != sender_txq_id) {
-        constexpr bool is_erisc_that_sets_up_second_txq = is_receiver_channel_serviced[0];
+        constexpr bool is_erisc_that_sets_up_second_txq = is_receiver_channel_serviced[VC0_RECEIVER_CHANNEL];
         if constexpr (is_erisc_that_sets_up_second_txq) {
             initialize_state_for_txq1_active_mode();
         }
@@ -2881,7 +2881,7 @@ void kernel_main() {
     // Initialize stream register state for credit management across the Ethernet link.
     // We make sure to do this before we handshake to guarantee that the registers are
     // initialized before the other side has any possibility of modifying them.
-    init_ptr_val<to_receiver_packets_sent_streams[0]>(0);
+    init_ptr_val<to_receiver_packets_sent_streams[VC0_RECEIVER_CHANNEL]>(0);
     init_ptr_val<to_sender_packets_acked_streams[0]>(0);
     init_ptr_val<to_sender_packets_acked_streams[1]>(0);
     init_ptr_val<to_sender_packets_completed_streams[0]>(0);
@@ -2901,7 +2901,7 @@ void kernel_main() {
     }
 
     if constexpr (is_2d_fabric) {
-        init_ptr_val<to_receiver_packets_sent_streams[1]>(0);
+        init_ptr_val<to_receiver_packets_sent_streams[VC1_RECEIVER_CHANNEL]>(0);
         init_ptr_val<to_sender_packets_acked_streams[2]>(0);
         init_ptr_val<to_sender_packets_acked_streams[3]>(0);
 
@@ -3197,8 +3197,8 @@ void kernel_main() {
                         // This is our local stream register for the copy of the downstream router's
                         // free slots
                         receiver_channel_free_slots_stream_id,
-                        receiver_channel_forwarding_data_cmd_buf_ids[0],
-                        receiver_channel_forwarding_sync_cmd_buf_ids[0]);
+                        receiver_channel_forwarding_data_cmd_buf_ids[VC0_RECEIVER_CHANNEL],
+                        receiver_channel_forwarding_sync_cmd_buf_ids[VC0_RECEIVER_CHANNEL]);
                 // Only receiver channel servicing cores should be setting up the noc cmd buf.
                 if constexpr (NUM_ACTIVE_ERISCS == 1 && !FORCE_ALL_PATHS_TO_USE_SAME_NOC) {
                     downstream_edm_noc_interfaces_vc0[compact_index]
@@ -3246,8 +3246,8 @@ void kernel_main() {
                         downstream_vc1_noc_interface_buffer_index_local_addr,
                         get_vc1_downstream_sender_channel_free_slots_stream_id(compact_index),
                         receiver_channel_free_slots_stream_id,
-                        receiver_channel_forwarding_data_cmd_buf_ids[1],
-                        receiver_channel_forwarding_sync_cmd_buf_ids[1]);
+                        receiver_channel_forwarding_data_cmd_buf_ids[VC1_RECEIVER_CHANNEL],
+                        receiver_channel_forwarding_sync_cmd_buf_ids[VC1_RECEIVER_CHANNEL]);
                 // Only receiver channel servicing cores should be setting up the noc cmd buf.
                 if constexpr (NUM_ACTIVE_ERISCS == 1 && !FORCE_ALL_PATHS_TO_USE_SAME_NOC) {
                     downstream_edm_noc_interfaces_vc1[compact_index]
@@ -3292,8 +3292,8 @@ void kernel_main() {
                 StreamId{local_tensix_relay_free_slots_stream_id},
                 // Local stream: our copy of relay's free slots - dedicated stream ID for relay
                 StreamId{tensix_relay_local_free_slots_stream_id},
-                receiver_channel_forwarding_data_cmd_buf_ids[0],
-                receiver_channel_forwarding_sync_cmd_buf_ids[0]);
+                receiver_channel_forwarding_data_cmd_buf_ids[VC0_RECEIVER_CHANNEL],
+                receiver_channel_forwarding_sync_cmd_buf_ids[VC0_RECEIVER_CHANNEL]);
 
             // Setup NOC command buffer for relay interface
             if constexpr (NUM_ACTIVE_ERISCS == 1 && !FORCE_ALL_PATHS_TO_USE_SAME_NOC) {
@@ -3478,7 +3478,7 @@ void kernel_main() {
         }
     } else {
         // We can check just the first index because all receiver channels are serviced by the same core
-        if constexpr (is_receiver_channel_serviced[0]) {
+        if constexpr (is_receiver_channel_serviced[VC0_RECEIVER_CHANNEL]) {
             if (has_downstream_edm_vc0_buffer_connection) {
                 downstream_edm_noc_interfaces_vc0[0]
                     .template open<false, use_posted_writes_for_connection_open, tt::tt_fabric::worker_handshake_noc>();
@@ -3495,7 +3495,7 @@ void kernel_main() {
 #if !defined(FABRIC_2D_VC1_ACTIVE)
     POSTCODE(tt::tt_fabric::EDMStatus::VCS_OPENED);
 #endif
-    if constexpr (is_receiver_channel_serviced[0] and NUM_ACTIVE_ERISCS > 1) {
+    if constexpr (is_receiver_channel_serviced[VC0_RECEIVER_CHANNEL] and NUM_ACTIVE_ERISCS > 1) {
         // Two erisc mode requires us to reorder the cmd buf programming/state setting
         // because we need to reshuffle some of our cmd_buf/noc assignments around for
         // just the fabric bringup phase. These calls are also located earlier for the
@@ -3516,7 +3516,7 @@ void kernel_main() {
         }
     }
 #if defined(FABRIC_2D_VC1_ACTIVE)
-    if constexpr (is_receiver_channel_serviced[1] and NUM_ACTIVE_ERISCS > 1) {
+    if constexpr (is_receiver_channel_serviced[VC1_RECEIVER_CHANNEL] and NUM_ACTIVE_ERISCS > 1) {
         // Two erisc mode requires us to reorder the cmd buf programming/state setting
         // because we need to reshuffle some of our cmd_buf/noc assignments around for
         // just the fabric bringup phase. These calls are also located earlier for the

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -2233,7 +2233,7 @@ FORCE_INLINE void run_fabric_edm_main_loop(
             uint32_t tx_progress = 0;
             uint32_t rx_progress = 0;
 
-            if constexpr (is_sender_channel_serviced[0]) {
+            if constexpr (is_sender_channel_serviced[VC0_SENDER_CHANNEL_START]) {
                 open_perf_recording_window(inner_loop_perf_telemetry_collector);
             }
 
@@ -2241,7 +2241,7 @@ FORCE_INLINE void run_fabric_edm_main_loop(
             if constexpr (FABRIC_TELEMETRY_BANDWIDTH) {
                 loop_start_cycles = get_timestamp();
             }
-            if constexpr (super_speedy_mode && is_sender_channel_serviced[0]) {
+            if constexpr (super_speedy_mode && is_sender_channel_serviced[VC0_SENDER_CHANNEL_START]) {
                 auto check_connection_status =
                     !channel_connection_established[0] ||
                     local_sender_channel_worker_interfaces.template get<0>().has_worker_teardown_request();
@@ -2256,7 +2256,7 @@ FORCE_INLINE void run_fabric_edm_main_loop(
                 if constexpr (super_speedy_mode) {
                     router_invalidate_l1_cache<ENABLE_RISC_CPU_DATA_CACHE>();
 
-                    if constexpr (is_sender_channel_serviced[0]) {
+                    if constexpr (is_sender_channel_serviced[VC0_SENDER_CHANNEL_START]) {
                         tx_progress |= run_sender_channel_step_speedy<
                             0,
                             to_receiver_packets_sent_streams[VC0_RECEIVER_CHANNEL],
@@ -2518,7 +2518,7 @@ FORCE_INLINE void run_fabric_edm_main_loop(
                 run_routing_without_noc_sync_coordinated_as_non_master(termination_signal_ptr);
             }
 
-            if constexpr (is_sender_channel_serviced[0]) {
+            if constexpr (is_sender_channel_serviced[VC0_SENDER_CHANNEL_START]) {
                 close_perf_recording_window(inner_loop_perf_telemetry_collector);
                 if constexpr (perf_telemetry_mode != PerfTelemetryRecorderType::NONE) {
                     if (captured_an_event(inner_loop_perf_telemetry_collector) ||
@@ -2867,7 +2867,7 @@ void kernel_main() {
         if constexpr (is_erisc_that_sets_up_second_txq) {
             initialize_state_for_txq1_active_mode();
         }
-        if constexpr (is_sender_channel_serviced[0]) {
+        if constexpr (is_sender_channel_serviced[VC0_SENDER_CHANNEL_START]) {
             initialize_state_for_txq1_active_mode_sender_side();
         }
     }


### PR DESCRIPTION
This is an incremental change to cleanup VC indexing. A handful of datastructures on host and device are updated to be per-vc.

Emit per-VC receiver channel pool data and remove flat receiver indexing assumption. This change simplifies future work where we introduce additional VCs and with each VC being a potentially different sizes. Additionally, this simplifies the implementation and design in a few areas:

general code in host and router code (always index by {vc, relative index})
enable/disable logic for "fast VC" implementations
future support for fabric "plugin" implementations
it also enables "gaps" in VCs (e.g. VC0 + VC2), although this is not an important use case yet

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snijjar/convert-flat-to-per-vc-indexing-receiver-channels-pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snijjar/convert-flat-to-per-vc-indexing-receiver-channels-pr)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snijjar/convert-flat-to-per-vc-indexing-receiver-channels-pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snijjar/convert-flat-to-per-vc-indexing-receiver-channels-pr)
- [ ] [![tm-fabric-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tm-fabric-tests.yaml/badge.svg?branch=snijjar/convert-flat-to-per-vc-indexing-receiver-channels-pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/tm-fabric-tests.yaml?query=branch:snijjar/convert-flat-to-per-vc-indexing-receiver-channels-pr)
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early

