### PR TITLE
migrate some places from `tt::stl` to `ttsl`

### DIFF
--- a/tt_metal/api/tt-metalium/core_coord.hpp
+++ b/tt_metal/api/tt-metalium/core_coord.hpp
@@ -104,13 +104,13 @@ constexpr bool operator<(const CoreRange& left, const CoreRange& right) {
 
 class CoreRangeSet {
 public:
-    CoreRangeSet(tt::stl::Span<const CoreRange> core_ranges);
+    CoreRangeSet(ttsl::Span<const CoreRange> core_ranges);
 
     CoreRangeSet(const std::set<CoreRange>& core_ranges);
 
     CoreRangeSet(const CoreRange& core_range);
 
-    CoreRangeSet(tt::stl::Span<const CoreCoord> core_coords);
+    CoreRangeSet(ttsl::Span<const CoreCoord> core_coords);
 
     CoreRangeSet() = default;
 

--- a/tt_metal/api/tt-metalium/device.hpp
+++ b/tt_metal/api/tt-metalium/device.hpp
@@ -129,7 +129,7 @@ public:
 
     virtual std::optional<DeviceAddr> lowest_occupied_compute_l1_address() const = 0;
     virtual std::optional<DeviceAddr> lowest_occupied_compute_l1_address(
-        tt::stl::Span<const SubDeviceId> sub_device_ids) const = 0;
+        ttsl::Span<const SubDeviceId> sub_device_ids) const = 0;
 
     [[deprecated(
         "Storage-only cores do not exist. Cleanup code that calls this API.")]] virtual const std::set<CoreCoord>&
@@ -150,7 +150,7 @@ public:
         size_t l1_small_size,
         size_t trace_region_size,
         size_t worker_l1_size,
-        tt::stl::Span<const std::uint32_t> l1_bank_remap = {},
+        ttsl::Span<const std::uint32_t> l1_bank_remap = {},
         bool minimal = false) = 0;
     [[deprecated("This is an internal function. It will be removed.")]]
     virtual void init_command_queue_host() = 0;
@@ -188,7 +188,7 @@ public:
     virtual SubDeviceManagerId get_active_sub_device_manager_id() const = 0;
     virtual SubDeviceManagerId get_default_sub_device_manager_id() const = 0;
     virtual SubDeviceManagerId create_sub_device_manager(
-        tt::stl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size) = 0;
+        ttsl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size) = 0;
     virtual SubDeviceManagerId create_sub_device_manager(
         std::initializer_list<SubDevice> sub_devices, DeviceAddr local_l1_size) = 0;
     virtual void remove_sub_device_manager(SubDeviceManagerId sub_device_manager_id) = 0;
@@ -197,7 +197,7 @@ public:
     virtual CoreCoord virtual_program_dispatch_core(uint8_t cq_id) const = 0;
     virtual const std::vector<SubDeviceId>& get_sub_device_ids() const = 0;
     virtual const std::vector<SubDeviceId>& get_sub_device_stall_group() const = 0;
-    virtual void set_sub_device_stall_group(tt::stl::Span<const SubDeviceId> sub_device_ids) = 0;
+    virtual void set_sub_device_stall_group(ttsl::Span<const SubDeviceId> sub_device_ids) = 0;
     virtual void reset_sub_device_stall_group() = 0;
     virtual uint32_t num_sub_devices() const = 0;
     virtual uint32_t num_virtual_eth_cores(SubDeviceId sub_device_id) = 0;

--- a/tt_metal/api/tt-metalium/distributed.hpp
+++ b/tt_metal/api/tt-metalium/distributed.hpp
@@ -101,9 +101,9 @@ bool EventQuery(const MeshEvent& event);
 MeshTraceId BeginTraceCapture(MeshDevice* device, uint8_t cq_id);
 
 void Synchronize(
-    MeshDevice* device, std::optional<uint8_t> cq_id, tt::stl::Span<const SubDeviceId> sub_device_ids = {});
+    MeshDevice* device, std::optional<uint8_t> cq_id, ttsl::Span<const SubDeviceId> sub_device_ids = {});
 
-void Finish(MeshCommandQueue& mesh_cq, tt::stl::Span<const SubDeviceId> sub_device_ids = {});
+void Finish(MeshCommandQueue& mesh_cq, ttsl::Span<const SubDeviceId> sub_device_ids = {});
 
 // Returns true if the distributed environment is initialized and world_size > 1.
 bool UsingDistributedEnvironment();

--- a/tt_metal/api/tt-metalium/distributed_context.hpp
+++ b/tt_metal/api/tt-metalium/distributed_context.hpp
@@ -101,12 +101,12 @@ struct is_supported_dtype<T, std::void_t<decltype(dtype_of_v<T>)>> : std::true_t
 template <typename T>
 inline constexpr bool is_supported_dtype_v = is_supported_dtype<T>::value;
 
-using Rank = tt::stl::StrongType<int, struct RankTag>;
-using Tag = tt::stl::StrongType<int, struct TagTag>;
-using Color = tt::stl::StrongType<int, struct ColorTag>;
-using Key = tt::stl::StrongType<int, struct KeyTag>;
-using Size = tt::stl::StrongType<int, struct SizeTag>;
-using DistributedContextId = tt::stl::StrongType<int, struct DistributedContextIdTag>;
+using Rank = ttsl::StrongType<int, struct RankTag>;
+using Tag = ttsl::StrongType<int, struct TagTag>;
+using Color = ttsl::StrongType<int, struct ColorTag>;
+using Key = ttsl::StrongType<int, struct KeyTag>;
+using Size = ttsl::StrongType<int, struct SizeTag>;
+using DistributedContextId = ttsl::StrongType<int, struct DistributedContextIdTag>;
 
 class DistributedException : public std::exception {
 public:
@@ -169,73 +169,73 @@ public:
     virtual void barrier() const = 0;
 
     //--- Point-to-point (blocking) -----------------------------------------
-    virtual void send(tt::stl::Span<std::byte> buffer, Rank dest, Tag tag) const = 0;
+    virtual void send(ttsl::Span<std::byte> buffer, Rank dest, Tag tag) const = 0;
 
-    virtual void ssend(tt::stl::Span<std::byte> buffer, Rank dest, Tag tag) const = 0;
+    virtual void ssend(ttsl::Span<std::byte> buffer, Rank dest, Tag tag) const = 0;
 
-    virtual void recv(tt::stl::Span<std::byte> buffer, Rank source, Tag tag) const = 0;
+    virtual void recv(ttsl::Span<std::byte> buffer, Rank source, Tag tag) const = 0;
 
     //--- Point-to-point (non-blocking) -------------------------------------
-    [[nodiscard]] virtual RequestPtr isend(tt::stl::Span<std::byte> buffer, Rank dest, Tag tag) const = 0;
+    [[nodiscard]] virtual RequestPtr isend(ttsl::Span<std::byte> buffer, Rank dest, Tag tag) const = 0;
 
-    [[nodiscard]] virtual RequestPtr irecv(tt::stl::Span<std::byte> buffer, Rank source, Tag tag) const = 0;
+    [[nodiscard]] virtual RequestPtr irecv(ttsl::Span<std::byte> buffer, Rank source, Tag tag) const = 0;
 
     //--- Collective operations ---------------------------------------------
-    virtual void broadcast(tt::stl::Span<std::byte> buffer, Rank root) const = 0;
+    virtual void broadcast(ttsl::Span<std::byte> buffer, Rank root) const = 0;
 
-    virtual void gather(tt::stl::Span<std::byte> send_buf, tt::stl::Span<std::byte> recv_buf, Rank root) const = 0;
+    virtual void gather(ttsl::Span<std::byte> send_buf, ttsl::Span<std::byte> recv_buf, Rank root) const = 0;
 
-    virtual void scatter(tt::stl::Span<std::byte> send_buf, tt::stl::Span<std::byte> recv_buf, Rank root) const = 0;
+    virtual void scatter(ttsl::Span<std::byte> send_buf, ttsl::Span<std::byte> recv_buf, Rank root) const = 0;
 
-    virtual void all_gather(tt::stl::Span<std::byte> send_buf, tt::stl::Span<std::byte> recv_buf) const = 0;
+    virtual void all_gather(ttsl::Span<std::byte> send_buf, ttsl::Span<std::byte> recv_buf) const = 0;
 
-    virtual void all_to_all(tt::stl::Span<std::byte> send_buf, tt::stl::Span<std::byte> recv_buf) const = 0;
+    virtual void all_to_all(ttsl::Span<std::byte> send_buf, ttsl::Span<std::byte> recv_buf) const = 0;
 
     /// --- Reduce functions ------------------------------------------------
     virtual void all_reduce(
-        tt::stl::Span<std::byte> send_buf, tt::stl::Span<std::byte> recv_buf, ReduceOp op, DType dtype) const = 0;
+        ttsl::Span<std::byte> send_buf, ttsl::Span<std::byte> recv_buf, ReduceOp op, DType dtype) const = 0;
 
     virtual void reduce(
-        tt::stl::Span<std::byte> send_buf,
-        tt::stl::Span<std::byte> recv_buf,
+        ttsl::Span<std::byte> send_buf,
+        ttsl::Span<std::byte> recv_buf,
         ReduceOp op,
         DType dtype,
         Rank root) const = 0;
 
     virtual void reduce_scatter(
-        tt::stl::Span<std::byte> send_buf, tt::stl::Span<std::byte> recv_buf, ReduceOp op, DType dtype) const = 0;
+        ttsl::Span<std::byte> send_buf, ttsl::Span<std::byte> recv_buf, ReduceOp op, DType dtype) const = 0;
 
     virtual void scan(
-        tt::stl::Span<std::byte> send_buf, tt::stl::Span<std::byte> recv_buf, ReduceOp op, DType dtype) const = 0;
+        ttsl::Span<std::byte> send_buf, ttsl::Span<std::byte> recv_buf, ReduceOp op, DType dtype) const = 0;
 
     // --- Reduce functions with type deduction -------------------------------
     template <class T>
         requires is_supported_dtype_v<T>
-    void all_reduce(tt::stl::Span<T> send_buf, tt::stl::Span<T> recv_buf, ReduceOp op) const {
+    void all_reduce(ttsl::Span<T> send_buf, ttsl::Span<T> recv_buf, ReduceOp op) const {
         all_reduce(as_writable_bytes(send_buf), as_writable_bytes(recv_buf), op, dtype_of_v<T>);
     }
     template <class T>
         requires is_supported_dtype_v<T>
-    void reduce(tt::stl::Span<T> send_buf, tt::stl::Span<T> recv_buf, ReduceOp op, Rank root) const {
+    void reduce(ttsl::Span<T> send_buf, ttsl::Span<T> recv_buf, ReduceOp op, Rank root) const {
         reduce(as_writable_bytes(send_buf), as_writable_bytes(recv_buf), op, dtype_of_v<T>, root);
     }
     template <class T>
         requires is_supported_dtype_v<T>
-    void scan(tt::stl::Span<T> send_buf, tt::stl::Span<T> recv_buf, ReduceOp op) const {
+    void scan(ttsl::Span<T> send_buf, ttsl::Span<T> recv_buf, ReduceOp op) const {
         scan(as_writable_bytes(send_buf), as_writable_bytes(recv_buf), op, dtype_of_v<T>);
     }
     template <class T>
         requires is_supported_dtype_v<T>
-    void reduce_scatter(tt::stl::Span<T> send_buf, tt::stl::Span<T> recv_buf, ReduceOp op) const {
+    void reduce_scatter(ttsl::Span<T> send_buf, ttsl::Span<T> recv_buf, ReduceOp op) const {
         reduce_scatter(as_writable_bytes(send_buf), as_writable_bytes(recv_buf), op, dtype_of_v<T>);
     }
 
     //--- Communicator management -------------------------------------------
     [[nodiscard]] virtual ContextPtr duplicate() const = 0;
     [[nodiscard]] virtual ContextPtr split(Color color, Key key) const = 0;
-    [[nodiscard]] virtual ContextPtr create_sub_context(tt::stl::Span<int> ranks) const = 0;
+    [[nodiscard]] virtual ContextPtr create_sub_context(ttsl::Span<int> ranks) const = 0;
     virtual void translate_ranks_to_other_ctx(
-        tt::stl::Span<int> ranks, const ContextPtr& other_ctx, tt::stl::Span<int> translated_ranks) const = 0;
+        ttsl::Span<int> ranks, const ContextPtr& other_ctx, ttsl::Span<int> translated_ranks) const = 0;
     //--- Error handling -----------------------------------------------------
     virtual void abort(int error_code) const = 0;
 

--- a/tt_metal/api/tt-metalium/host_buffer.hpp
+++ b/tt_metal/api/tt-metalium/host_buffer.hpp
@@ -43,7 +43,7 @@ public:
 
     // Constructor for `HostBuffer` based on the borrowed data.
     template <typename T>
-    HostBuffer(tt::stl::Span<T> borrowed_data, MemoryPin pin);
+    HostBuffer(ttsl::Span<T> borrowed_data, MemoryPin pin);
 
     HostBuffer(const HostBuffer& other);
     HostBuffer& operator=(const HostBuffer& other);
@@ -51,22 +51,22 @@ public:
     HostBuffer& operator=(HostBuffer&& other) noexcept;
     void swap(HostBuffer& other) noexcept;
 
-    tt::stl::Span<std::byte> view_bytes() & noexcept;
-    tt::stl::Span<const std::byte> view_bytes() const& noexcept;
-    tt::stl::Span<std::byte> view_bytes() && noexcept = delete;
-    tt::stl::Span<const std::byte> view_bytes() const&& noexcept = delete;
+    ttsl::Span<std::byte> view_bytes() & noexcept;
+    ttsl::Span<const std::byte> view_bytes() const& noexcept;
+    ttsl::Span<std::byte> view_bytes() && noexcept = delete;
+    ttsl::Span<const std::byte> view_bytes() const&& noexcept = delete;
 
     template <typename T>
-    tt::stl::Span<T> view_as() &;
+    ttsl::Span<T> view_as() &;
 
     template <typename T>
-    tt::stl::Span<const T> view_as() const&;
+    ttsl::Span<const T> view_as() const&;
 
     template <typename T>
-    tt::stl::Span<T> view_as() && = delete;
+    ttsl::Span<T> view_as() && = delete;
 
     template <typename T>
-    tt::stl::Span<const T> view_as() const&& = delete;
+    ttsl::Span<const T> view_as() const&& = delete;
 
     // Returns the memory pin of the host buffer.
     MemoryPin pin() const { return pin_; }
@@ -74,7 +74,7 @@ public:
 private:
     friend class experimental::HostBufferPinnedMemoryHelper;
     MemoryPin pin_;
-    tt::stl::Span<std::byte> view_;
+    ttsl::Span<std::byte> view_;
     const std::type_info* type_info_ = nullptr;
     std::shared_ptr<experimental::PinnedMemory> pinned_memory_ = nullptr;
 };
@@ -82,7 +82,7 @@ private:
 template <typename T>
 HostBuffer::HostBuffer(const std::shared_ptr<std::vector<T>>& data) : type_info_(&typeid(T)) {
     const size_t size_bytes = data->size() * sizeof(T);
-    view_ = tt::stl::Span<std::byte>(reinterpret_cast<std::byte*>(data->data()), size_bytes);
+    view_ = ttsl::Span<std::byte>(reinterpret_cast<std::byte*>(data->data()), size_bytes);
     pin_ = MemoryPin(data);
 }
 
@@ -95,22 +95,22 @@ HostBuffer::HostBuffer(const std::vector<T>& data) :
     HostBuffer(std::shared_ptr<std::vector<T>>(std::make_shared<std::vector<T>>(data))) {}
 
 template <typename T>
-HostBuffer::HostBuffer(tt::stl::Span<T> borrowed_data, MemoryPin pin) :
+HostBuffer::HostBuffer(ttsl::Span<T> borrowed_data, MemoryPin pin) :
     pin_(std::move(pin)),
     view_(
-        tt::stl::Span<std::byte>(reinterpret_cast<std::byte*>(borrowed_data.data()), borrowed_data.size() * sizeof(T))),
+        ttsl::Span<std::byte>(reinterpret_cast<std::byte*>(borrowed_data.data()), borrowed_data.size() * sizeof(T))),
     type_info_(&typeid(T)) {}
 
 template <typename T>
-tt::stl::Span<T> HostBuffer::view_as() & {
+ttsl::Span<T> HostBuffer::view_as() & {
     TT_FATAL(*type_info_ == typeid(T), "Requested type T does not match the underlying buffer type.");
-    return tt::stl::Span<T>(reinterpret_cast<T*>(view_.data()), view_.size() / sizeof(T));
+    return ttsl::Span<T>(reinterpret_cast<T*>(view_.data()), view_.size() / sizeof(T));
 }
 
 template <typename T>
-tt::stl::Span<const T> HostBuffer::view_as() const& {
+ttsl::Span<const T> HostBuffer::view_as() const& {
     TT_FATAL(*type_info_ == typeid(T), "Requested type T does not match the underlying buffer type.");
-    return tt::stl::Span<const T>(reinterpret_cast<const T*>(view_.data()), view_.size() / sizeof(T));
+    return ttsl::Span<const T>(reinterpret_cast<const T*>(view_.data()), view_.size() / sizeof(T));
 }
 
 // Compares data buffers by their data.

--- a/tt_metal/api/tt-metalium/mesh_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/mesh_command_queue.hpp
@@ -138,13 +138,13 @@ public:
         bool blocking);
 
     virtual MeshEvent enqueue_record_event(
-        tt::stl::Span<const SubDeviceId> sub_device_ids = {},
+        ttsl::Span<const SubDeviceId> sub_device_ids = {},
         const std::optional<MeshCoordinateRange>& device_range = std::nullopt) = 0;
     virtual MeshEvent enqueue_record_event_to_host(
-        tt::stl::Span<const SubDeviceId> sub_device_ids = {},
+        ttsl::Span<const SubDeviceId> sub_device_ids = {},
         const std::optional<MeshCoordinateRange>& device_range = std::nullopt) = 0;
     virtual void enqueue_wait_for_event(const MeshEvent& sync_event) = 0;
-    virtual void finish(tt::stl::Span<const SubDeviceId> sub_device_ids = {}) = 0;
+    virtual void finish(ttsl::Span<const SubDeviceId> sub_device_ids = {}) = 0;
     virtual void reset_worker_state(
         bool reset_launch_msg_state,
         uint32_t num_sub_devices,

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -136,7 +136,7 @@ public:
     uint32_t dram_channel_from_virtual_core(const CoreCoord& virtual_core) const override;
     std::optional<DeviceAddr> lowest_occupied_compute_l1_address() const override;
     std::optional<DeviceAddr> lowest_occupied_compute_l1_address(
-        tt::stl::Span<const SubDeviceId> sub_device_ids) const override;
+        ttsl::Span<const SubDeviceId> sub_device_ids) const override;
     const std::set<CoreCoord>& ethernet_cores() const override;
     const std::set<CoreCoord>& storage_only_cores() const override;
     uint32_t get_noc_unicast_encoding(uint8_t noc_index, const CoreCoord& core) const override;
@@ -160,7 +160,7 @@ public:
         size_t l1_small_size,
         size_t trace_region_size,
         size_t worker_l1_size,
-        tt::stl::Span<const std::uint32_t> l1_bank_remap = {},
+        ttsl::Span<const std::uint32_t> l1_bank_remap = {},
         bool minimal = false) override;
     [[deprecated("This is an internal function. It will be removed.")]]
     void init_command_queue_host() override;
@@ -186,14 +186,14 @@ public:
     SubDeviceManagerId create_sub_device_manager(
         std::initializer_list<SubDevice> sub_devices, DeviceAddr local_l1_size) override;
     SubDeviceManagerId create_sub_device_manager(
-        tt::stl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size) override;
+        ttsl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size) override;
     void remove_sub_device_manager(SubDeviceManagerId sub_device_manager_id) override;
     void load_sub_device_manager(SubDeviceManagerId sub_device_manager_id) override;
     void clear_loaded_sub_device_manager() override;
     CoreCoord virtual_program_dispatch_core(uint8_t cq_id) const override;
     const std::vector<SubDeviceId>& get_sub_device_ids() const override;
     const std::vector<SubDeviceId>& get_sub_device_stall_group() const override;
-    void set_sub_device_stall_group(tt::stl::Span<const SubDeviceId> sub_device_ids) override;
+    void set_sub_device_stall_group(ttsl::Span<const SubDeviceId> sub_device_ids) override;
     void reset_sub_device_stall_group() override;
     uint32_t num_sub_devices() const override;
     bool is_mmio_capable() const override;
@@ -295,7 +295,7 @@ public:
         size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE,
         size_t num_command_queues = 1,
         const DispatchCoreConfig& dispatch_core_config = DispatchCoreConfig{},
-        tt::stl::Span<const std::uint32_t> l1_bank_remap = {},
+        ttsl::Span<const std::uint32_t> l1_bank_remap = {},
         size_t worker_l1_size = DEFAULT_WORKER_L1_SIZE);
     static std::shared_ptr<MeshDevice> create_unit_mesh(
         int device_id,
@@ -303,7 +303,7 @@ public:
         size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE,
         size_t num_command_queues = 1,
         const DispatchCoreConfig& dispatch_core_config = DispatchCoreConfig{},
-        tt::stl::Span<const std::uint32_t> l1_bank_remap = {},
+        ttsl::Span<const std::uint32_t> l1_bank_remap = {},
         size_t worker_l1_size = DEFAULT_WORKER_L1_SIZE);
     static std::map<int, std::shared_ptr<MeshDevice>> create_unit_meshes(
         const std::vector<int>& device_ids,
@@ -311,7 +311,7 @@ public:
         size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE,
         size_t num_command_queues = 1,
         const DispatchCoreConfig& dispatch_core_config = DispatchCoreConfig{},
-        tt::stl::Span<const std::uint32_t> l1_bank_remap = {},
+        ttsl::Span<const std::uint32_t> l1_bank_remap = {},
         size_t worker_l1_size = DEFAULT_WORKER_L1_SIZE);
 
     // Only for internal and testing purposes

--- a/tt_metal/api/tt-metalium/mesh_trace_id.hpp
+++ b/tt_metal/api/tt-metalium/mesh_trace_id.hpp
@@ -10,6 +10,6 @@
 namespace tt::tt_metal::distributed {
 
 // Identifier for a mesh trace.
-using MeshTraceId = tt::stl::StrongType<uint32_t, struct MeshTraceIdTag>;
+using MeshTraceId = ttsl::StrongType<uint32_t, struct MeshTraceIdTag>;
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/api/tt-metalium/shape.hpp
+++ b/tt_metal/api/tt-metalium/shape.hpp
@@ -58,7 +58,7 @@ public:
 
 std::ostream& operator<<(std::ostream& os, const tt::tt_metal::Shape& shape);
 
-tt::stl::SmallVector<size_t> compute_strides(const tt::tt_metal::Shape& shape);
+ttsl::SmallVector<size_t> compute_strides(const tt::tt_metal::Shape& shape);
 
 /**
  * @brief Computes a flat (linear) index from multi-dimensional indices and strides.
@@ -74,7 +74,7 @@ tt::stl::SmallVector<size_t> compute_strides(const tt::tt_metal::Shape& shape);
  *
  * @note The `indices` and `strides` spans must have the same length.
  */
-std::size_t compute_flat_indices(tt::stl::Span<const uint32_t> indices, tt::stl::Span<const size_t> strides);
+std::size_t compute_flat_indices(ttsl::Span<const uint32_t> indices, ttsl::Span<const size_t> strides);
 
 }  // namespace tt::tt_metal
 

--- a/tt_metal/api/tt-metalium/shape_base.hpp
+++ b/tt_metal/api/tt-metalium/shape_base.hpp
@@ -36,7 +36,7 @@ inline int32_t normalized_index(int32_t index, size_t original_size, size_t cont
 class ShapeBase {
 public:
     using coord_type = uint32_t;
-    using Container = tt::stl::SmallVector<uint32_t>;
+    using Container = ttsl::SmallVector<uint32_t>;
 
     ShapeBase() { init(); };
     explicit ShapeBase(const Container& shape) : value_(shape) { init(); }
@@ -46,7 +46,7 @@ public:
     explicit ShapeBase(const std::array<uint32_t, N>& arr) : value_(arr.begin(), arr.end()) {
         init();
     }
-    explicit ShapeBase(tt::stl::Span<const uint32_t> span) : value_(span.begin(), span.end()) { init(); }
+    explicit ShapeBase(ttsl::Span<const uint32_t> span) : value_(span.begin(), span.end()) { init(); }
 
     template <std::size_t N>
     bool operator==(const std::array<uint32_t, N>& other) const {
@@ -74,7 +74,7 @@ public:
     Container::const_iterator begin() const;
     Container::const_iterator end() const;
 
-    tt::stl::Span<const uint32_t> view() const;
+    ttsl::Span<const uint32_t> view() const;
 
     bool empty() const;
 

--- a/tt_metal/api/tt-metalium/sub_device_types.hpp
+++ b/tt_metal/api/tt-metalium/sub_device_types.hpp
@@ -10,7 +10,7 @@
 
 namespace tt::tt_metal {
 
-using SubDeviceId = tt::stl::StrongType<uint8_t, struct SubDeviceIdTag>;
-using SubDeviceManagerId = tt::stl::StrongType<uint64_t, struct SubDeviceManagerIdTag>;
+using SubDeviceId = ttsl::StrongType<uint8_t, struct SubDeviceIdTag>;
+using SubDeviceManagerId = ttsl::StrongType<uint64_t, struct SubDeviceManagerIdTag>;
 
 }  // namespace tt::tt_metal


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/38935)

### Problem description
1. as noted in the linked github issue, `tt::stl` was marked as deprecated in #23351 in favor of `ttsl`. a follow-up pr #38936 was created by copilot to handle the migration, but it has seen no progress for ~2 weeks
2. i created this pr to address the compilation warnings triggered by my kernels
4. ideally the remaining places that use `tt::stl` should be migrated as well but i decided to start with this as a small tangible improvement
3. if this pr gets merged, i am happy to help migrate all remaining places that use `tt::stl`

### What's changed
replaced `tt::stl` with `ttsl` in some places

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:{{branch_name}})
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early

#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
