### PR TITLE
[Fix]: Don't assign txn ids for tensix dfb endpoints

### DIFF
--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
@@ -912,39 +912,46 @@ void ProgramImpl::finalize_single_dfb_config(
     if (config.enable_implicit_sync) {
         constexpr uint8_t TXN_IDS_PER_SIDE = 2;
 
-        auto producer_txn_ids = txn_id_allocator_.allocate(TXN_IDS_PER_SIDE);
-        dfb->producer_txn_descriptor = compute_txn_descriptor(
-            dfb->capacity,
-            config.num_producers,
-            config.num_consumers,
-            /*is_producer=*/true,
-            producer_txn_ids,
-            num_producer_tcs);
+        if (!producer_is_tensix_only) {
+            auto producer_txn_ids = txn_id_allocator_.allocate(TXN_IDS_PER_SIDE);
+            dfb->producer_txn_descriptor = compute_txn_descriptor(
+                dfb->capacity,
+                config.num_producers,
+                config.num_consumers,
+                /*is_producer=*/true,
+                producer_txn_ids,
+                num_producer_tcs);
+            log_info(
+                tt::LogMetal,
+                "DFB {} implicit sync: producer txn_ids=[{},{}] threshold={} per_txn={} per_tc={}",
+                dfb->id,
+                dfb->producer_txn_descriptor.txn_ids[0],
+                dfb->producer_txn_descriptor.txn_ids[1],
+                dfb->producer_txn_descriptor.num_entries_to_process_threshold,
+                dfb->producer_txn_descriptor.num_entries_per_txn_id,
+                dfb->producer_txn_descriptor.num_entries_per_txn_id_per_tc);
+        }
 
-        auto consumer_txn_ids = txn_id_allocator_.allocate(TXN_IDS_PER_SIDE);
-        dfb->consumer_txn_descriptor = compute_txn_descriptor(
-            dfb->capacity,
-            config.num_producers,
-            config.num_consumers,
-            /*is_producer=*/false,
-            consumer_txn_ids,
-            num_consumer_tcs);
-
-        log_info(
-            tt::LogMetal,
-            "DFB {} implicit sync: producer txn_ids=[{},{}] threshold={} per_txn={} per_tc={}; "
-            "consumer txn_ids=[{},{}] threshold={} per_txn={} per_tc={}",
-            dfb->id,
-            dfb->producer_txn_descriptor.txn_ids[0],
-            dfb->producer_txn_descriptor.txn_ids[1],
-            dfb->producer_txn_descriptor.num_entries_to_process_threshold,
-            dfb->producer_txn_descriptor.num_entries_per_txn_id,
-            dfb->producer_txn_descriptor.num_entries_per_txn_id_per_tc,
-            dfb->consumer_txn_descriptor.txn_ids[0],
-            dfb->consumer_txn_descriptor.txn_ids[1],
-            dfb->consumer_txn_descriptor.num_entries_to_process_threshold,
-            dfb->consumer_txn_descriptor.num_entries_per_txn_id,
-            dfb->consumer_txn_descriptor.num_entries_per_txn_id_per_tc);
+        if (!consumer_is_tensix_only) {
+            auto consumer_txn_ids = txn_id_allocator_.allocate(TXN_IDS_PER_SIDE);
+            dfb->consumer_txn_descriptor = compute_txn_descriptor(
+                dfb->capacity,
+                config.num_producers,
+                config.num_consumers,
+                /*is_producer=*/false,
+                consumer_txn_ids,
+                num_consumer_tcs);
+            log_info(
+                tt::LogMetal,
+                "DFB {} implicit sync: "
+                "consumer txn_ids=[{},{}] threshold={} per_txn={} per_tc={}",
+                dfb->id,
+                dfb->consumer_txn_descriptor.txn_ids[0],
+                dfb->consumer_txn_descriptor.txn_ids[1],
+                dfb->consumer_txn_descriptor.num_entries_to_process_threshold,
+                dfb->consumer_txn_descriptor.num_entries_per_txn_id,
+                dfb->consumer_txn_descriptor.num_entries_per_txn_id_per_tc);
+        }
     }
 
     dfb->configs_finalized = true;


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Was assigning txn ids for DFB endpoints even if they were tensix neos. Only DM producers/consumers issue noc transactions and use txn ids 

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=abhullar/txn-id-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:abhullar/txn-id-fix)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=abhullar/txn-id-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:abhullar/txn-id-fix)
- [x] New/Existing tests provide coverage for changes (in https://github.com/tenstorrent/tt-metal/pull/39921)
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early
