### PR TITLE
[Test]: Update datacopy test on Quasar to be multithreaded and use isr sync for dfbs

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_direct.cpp
+++ b/tests/tt_metal/tt_metal/api/test_direct.cpp
@@ -313,61 +313,68 @@ bool reader_datacopy_writer(
     auto output_dram_buffer = tt_metal::CreateBuffer(dram_config);
     uint32_t output_dram_byte_address = output_dram_buffer->address();
 
+    log_info(tt::LogTest, "Input DRAM byte address: {}", input_dram_byte_address);
+    log_info(tt::LogTest, "Output DRAM byte address: {}", output_dram_byte_address);
+
     KernelHandle reader_kernel;
     KernelHandle writer_kernel;
     KernelHandle compute_kernel;
-    uint32_t l1_input_dfb = 0;
-    uint32_t l1_output_dfb = 0;
+    uint32_t num_threads = 1;
     if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
+        if (test_config.num_tiles > 1) {
+            TT_FATAL(test_config.num_tiles % 4 == 0, "Number of tiles must be divisible by 4");
+        }
+        num_threads = test_config.num_tiles == 1 ? 1 : 4;
+
         tt_metal::experimental::dfb::DataflowBufferConfig l1_input_dfb_config = {
             .entry_size = test_config.tile_byte_size,
             .num_entries = test_config.num_tiles,
-            .producer_risc_mask = 0x1,
-            .num_producers = 1,
+            .num_producers = num_threads,
             .pap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
-            .consumer_risc_mask = 0x100,
-            .num_consumers = 1,
+            .num_consumers = num_threads,
             .cap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
-            .enable_implicit_sync = false,
+            .enable_implicit_sync = true,
             .data_format = test_config.l1_input_data_format
         };
 
         tt_metal::experimental::dfb::DataflowBufferConfig l1_output_dfb_config = {
             .entry_size = test_config.tile_byte_size,
             .num_entries = test_config.num_tiles,
-            .producer_risc_mask = 0x100,
-            .num_producers = 1,
+            .num_producers = num_threads,
             .pap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
-            .consumer_risc_mask = 0x2,
-            .num_consumers = 1,
+            .num_consumers = num_threads,
             .cap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
-            .enable_implicit_sync = false,
+            .enable_implicit_sync = true,
             .data_format = test_config.l1_output_data_format
         };
 
-        l1_input_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program_, test_config.core, l1_input_dfb_config);
-        l1_output_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program_, test_config.core, l1_output_dfb_config);
+        uint32_t l1_input_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program_, test_config.core, l1_input_dfb_config);
+        uint32_t l1_output_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program_, test_config.core, l1_output_dfb_config);
 
         reader_kernel = tt_metal::experimental::quasar::CreateKernel(
             program_,
             "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary.cpp",
             test_config.core,
             tt_metal::experimental::quasar::QuasarDataMovementConfig{
-                .num_threads_per_cluster = 1, .compile_args = {l1_input_dfb}});
+                .num_threads_per_cluster = num_threads, .compile_args = {l1_input_dfb}});
 
         writer_kernel = tt_metal::experimental::quasar::CreateKernel(
             program_,
             "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp",
             test_config.core,
             tt_metal::experimental::quasar::QuasarDataMovementConfig{
-                .num_threads_per_cluster = 1, .compile_args = {l1_output_dfb}});
+                .num_threads_per_cluster = num_threads, .compile_args = {l1_output_dfb}});
 
+        uint32_t per_core_tile_cnt = test_config.num_tiles / num_threads;
         compute_kernel = tt_metal::experimental::quasar::CreateKernel(
             program_,
             "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy.cpp",
             test_config.core,
             tt_metal::experimental::quasar::QuasarComputeConfig{
-                .num_threads_per_cluster = 1, .compile_args = {uint(test_config.num_tiles)}});
+                .num_threads_per_cluster = num_threads, .compile_args = {uint(per_core_tile_cnt)}});
+
+        tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(program_, l1_input_dfb, reader_kernel, compute_kernel);
+        tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(program_, l1_output_dfb, compute_kernel, writer_kernel);
     } else {
         const uint32_t input0_cb_index = 0;
         const uint32_t output_cb_index = 16;
@@ -407,11 +414,6 @@ bool reader_datacopy_writer(
             tt_metal::ComputeConfig{.compile_args = {uint(test_config.num_tiles)}});
     }
 
-    if (device->arch() == ARCH::QUASAR) {
-        tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(program_, l1_input_dfb, reader_kernel, compute_kernel);
-        tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(program_, l1_output_dfb, compute_kernel, writer_kernel);
-    }
-
     ////////////////////////////////////////////////////////////////////////////
     //                      Stimulus Generation
     ////////////////////////////////////////////////////////////////////////////
@@ -423,6 +425,8 @@ bool reader_datacopy_writer(
 
     tt_metal::detail::WriteToBuffer(input_dram_buffer, inputs);
 
+    uint32_t num_tiles_per_thread = test_config.num_tiles / num_threads;
+    log_info(tt::LogTest, "Num tiles per thread: {}", num_tiles_per_thread);
     tt_metal::SetRuntimeArgs(
         program_,
         reader_kernel,
@@ -430,7 +434,7 @@ bool reader_datacopy_writer(
         {
             (uint32_t)input_dram_byte_address,
             0,
-            (uint32_t)test_config.num_tiles,
+            num_tiles_per_thread
         });
     tt_metal::SetRuntimeArgs(
         program_,
@@ -439,7 +443,7 @@ bool reader_datacopy_writer(
         {
             (uint32_t)output_dram_byte_address,
             0,
-            (uint32_t)test_config.num_tiles,
+            num_tiles_per_thread
         });
 
     auto blocking = device->arch() == ARCH::QUASAR;
@@ -451,6 +455,7 @@ bool reader_datacopy_writer(
     std::vector<uint32_t> dest_buffer_data;
     tt_metal::detail::ReadFromBuffer(output_dram_buffer, dest_buffer_data);
     pass &= inputs == dest_buffer_data;
+
     return pass;
 }
 }  // namespace unit_tests::dram::direct
@@ -502,10 +507,12 @@ TEST_F(MeshDeviceFixture, TensixSingleCoreDirectDramReaderDatacopyWriter) {
         .l1_output_data_format = tt::DataFormat::Float16_b,
         .core = CoreCoord(0, 0)};
     for (unsigned int id = 0; id < num_devices_; id++) {
-        test_config.num_tiles = 1;
-        ASSERT_TRUE(unit_tests::dram::direct::reader_datacopy_writer(devices_.at(id), test_config));
-        test_config.num_tiles = 4;
-        ASSERT_TRUE(unit_tests::dram::direct::reader_datacopy_writer(devices_.at(id), test_config));
+        if (devices_.at(id)->arch() != ARCH::QUASAR) { // TODO (#38092): Remove when we can run back to back tests on Quasar
+            test_config.num_tiles = 1;
+            ASSERT_TRUE(unit_tests::dram::direct::reader_datacopy_writer(devices_.at(id), test_config));
+            test_config.num_tiles = 4;
+            ASSERT_TRUE(unit_tests::dram::direct::reader_datacopy_writer(devices_.at(id), test_config));
+        }
         test_config.num_tiles = 8;
         ASSERT_TRUE(unit_tests::dram::direct::reader_datacopy_writer(devices_.at(id), test_config));
     }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary.cpp
@@ -13,13 +13,15 @@
 
 void kernel_main() {
     const uint32_t cb_id = get_compile_time_arg_val(0);
-    uint32_t src_addr  = get_arg_val<uint32_t>(0);
-    uint32_t src_bank_id = get_arg_val<uint32_t>(1);
+    uint32_t src_addr  = get_arg_val<uint32_t>(0); // global base address
+    uint32_t src_bank_id = get_arg_val<uint32_t>(1); // data is in one bank
     uint32_t num_tiles = get_arg_val<uint32_t>(2);
 
     constexpr uint32_t ublock_size_tiles = 1;
 
 #ifdef ARCH_QUASAR
+    uint32_t producer_idx = get_my_thread_id();
+
     experimental::DataflowBuffer dfb(cb_id);
     constexpr experimental::AllocatorBankType bank_type = experimental::AllocatorBankType::DRAM;
     experimental::AllocatorBank<bank_type> src_dram;
@@ -27,12 +29,11 @@ void kernel_main() {
 
     uint32_t ublock_size_bytes = dfb.get_entry_size();
 
+    uint32_t tlocal_src_addr = src_addr + (producer_idx * ublock_size_bytes);
+
     for (uint32_t i = 0; i < num_tiles; i += ublock_size_tiles) {
-        dfb.reserve_back(ublock_size_tiles);
-        noc.async_read(src_dram, dfb, ublock_size_bytes, {.bank_id = src_bank_id, .addr = src_addr}, {});
-        noc.async_read_barrier();
-        dfb.push_back(ublock_size_tiles);
-        src_addr += ublock_size_bytes;
+        dfb.read_in(noc, src_dram, {.bank_id = src_bank_id, .addr = tlocal_src_addr});
+        tlocal_src_addr += dfb.get_stride_size();
     }
 
 #else

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp
@@ -11,13 +11,15 @@
 
 void kernel_main() {
     const uint32_t cb_id = get_compile_time_arg_val(0);
-    uint32_t dst_addr  = get_arg_val<uint32_t>(0);
-    uint32_t dst_bank_id = get_arg_val<uint32_t>(1);
+    uint32_t dst_addr  = get_arg_val<uint32_t>(0); // global base address
+    uint32_t dst_bank_id = get_arg_val<uint32_t>(1); // data is in one bank
     uint32_t num_tiles = get_arg_val<uint32_t>(2);
 
     uint32_t ublock_size_tiles = 1;
 
 #ifdef ARCH_QUASAR
+    uint32_t consumer_idx = get_my_thread_id();
+
     experimental::DataflowBuffer dfb(cb_id);
     constexpr experimental::AllocatorBankType bank_type = experimental::AllocatorBankType::DRAM;
     experimental::AllocatorBank<bank_type> dst_dram;
@@ -25,18 +27,17 @@ void kernel_main() {
 
     uint32_t ublock_size_bytes = dfb.get_entry_size();
 
-    volatile tt_l1_ptr uint32_t* debug_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(763520);
+    uint32_t tlocal_dst_addr = dst_addr + (consumer_idx * ublock_size_bytes);
 
     for (uint32_t i = 0; i < num_tiles; i += ublock_size_tiles) {
-        dfb.wait_front(ublock_size_tiles);
+        dfb.write_out(noc, dst_dram, {.bank_id = dst_bank_id, .addr = tlocal_dst_addr});
+        tlocal_dst_addr += dfb.get_stride_size();
+    }
 
-        DPRINT << "Debug pointer value: " << *debug_ptr << ENDL();
-
-        noc.async_write(dfb, dst_dram, ublock_size_bytes, {}, {.bank_id = dst_bank_id, .addr = dst_addr});
-        noc.async_write_barrier();
-
-        dfb.pop_front(ublock_size_tiles);
-        dst_addr += ublock_size_bytes;
+    // TODO: This will be replaced with some dfb.commit or noc.async_write_barrier call
+    experimental::LocalDFBInterface& local_dfb_interface = g_dfb_interface[cb_id];
+    for (uint32_t i = 0; i < local_dfb_interface.num_txn_ids; i++) {
+        noc.async_write_barrier<experimental::Noc::BarrierMode::TXN_ID>(local_dfb_interface.txn_ids[i]);
     }
 #else
     // single-tile ublocks

--- a/tt_metal/hw/inc/experimental/dataflow_buffer.h
+++ b/tt_metal/hw/inc/experimental/dataflow_buffer.h
@@ -35,6 +35,8 @@ public:
 
     uint32_t get_entry_size() const { return local_dfb_interface_.entry_size; }
 
+    uint32_t get_stride_size() const { return local_dfb_interface_.stride_size; }
+
     // Explicit sync APIs
     void reserve_back(uint16_t num_entries) {
         ASSERT(num_entries == 1);


### PR DESCRIPTION

### Ticket
N/A

### What's changed
Uplift datacopy quasar test to be multithreaded and use isr to post/ack credits 
Requires https://github.com/tenstorrent/tt-metal/pull/39920

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:{{branch_name}})
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [x] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early