### PR TITLE
Fix context descriptor size fields for large trace regions

### DIFF
--- a/tt_metal/impl/context/context_descriptor.hpp
+++ b/tt_metal/impl/context/context_descriptor.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <optional>
 #include <cstdint>
 #include <string>
@@ -31,9 +32,9 @@ class ContextDescriptor : public MetalEnvDescriptor {
 public:
     ContextDescriptor(
         int num_cqs = 1,
-        int l1_small_size = 0,
-        int trace_region_size = 0,
-        int worker_l1_size = 0,
+        size_t l1_small_size = 0,
+        size_t trace_region_size = 0,
+        size_t worker_l1_size = 0,
         const tt::tt_metal::DispatchCoreConfig& dispatch_core_config = {},
         tt::stl::Span<const std::uint32_t> l1_bank_remap = {},
         const std::string& mock_cluster_desc_path = "",
@@ -71,9 +72,9 @@ public:
         tt::tt_fabric::FabricManagerMode fabric_manager,
         tt::tt_fabric::FabricRouterConfig router_config = tt::tt_fabric::FabricRouterConfig{},
         int num_cqs = 1,
-        int l1_small_size = 0,
-        int trace_region_size = 0,
-        int worker_l1_size = 0,
+        size_t l1_small_size = 0,
+        size_t trace_region_size = 0,
+        size_t worker_l1_size = 0,
         const tt::tt_metal::DispatchCoreConfig& dispatch_core_config = {},
         tt::stl::Span<const std::uint32_t> l1_bank_remap = {},
         const std::string& mock_cluster_desc_path = "") :
@@ -103,9 +104,9 @@ public:
     const llrt::RunTimeOptions& rtoptions() const { return *rtoptions_; }
 
     int num_cqs() const { return num_cqs_; }
-    int l1_small_size() const { return l1_small_size_; }
-    int trace_region_size() const { return trace_region_size_; }
-    int worker_l1_size() const { return worker_l1_size_; }
+    size_t l1_small_size() const { return l1_small_size_; }
+    size_t trace_region_size() const { return trace_region_size_; }
+    size_t worker_l1_size() const { return worker_l1_size_; }
     const DispatchCoreConfig& dispatch_core_config() const { return dispatch_core_config_; }
     const tt::stl::Span<const std::uint32_t>& l1_bank_remap() const { return l1_bank_remap_; }
 
@@ -124,9 +125,9 @@ public:
 
     // Dispatch
     int num_cqs_ = 1;
-    int l1_small_size_ = 0;
-    int trace_region_size_ = 0;
-    int worker_l1_size_ = 0;
+    size_t l1_small_size_ = 0;
+    size_t trace_region_size_ = 0;
+    size_t worker_l1_size_ = 0;
     DispatchCoreConfig dispatch_core_config_;
     tt::stl::Span<const std::uint32_t> l1_bank_remap_;
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Blackhole traced `test_pgm_dispatch` benchmarks can request a trace region larger than `INT_MAX`. `ContextDescriptor` stored `l1_small_size`, `trace_region_size`, and `worker_l1_size` as `int`, which truncated large values before device initialization and corrupted allocator sizing.

### What's changed
Store the size-based `ContextDescriptor` fields and accessors as `size_t` instead of `int` so large trace-region values are preserved through the device-manager initialization path. This keeps allocator configuration consistent and prevents traced program binary buffer allocation from tripping the 32-bit buffer address assertion on Blackhole.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/fixcontextsizes)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/fixcontextsizes)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jbauman/fixcontextsizes)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/fixcontextsizes)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/fixcontextsizes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/fixcontextsizes)
- [x] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/fixcontextsizes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/fixcontextsizes)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/fixcontextsizes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/fixcontextsizes)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/fixcontextsizes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/fixcontextsizes)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
