### PR TITLE
#0: Cleanup sdpa reduction ccl

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/kernels/attention_block_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/kernels/attention_block_kernel.cpp
@@ -739,7 +739,6 @@ void kernel_main() {
         get_named_compile_time_arg_val("sdpa_cb_local_ms"),
         get_named_compile_time_arg_val("sdpa_cb_r1_result_l"),
         get_named_compile_time_arg_val("sdpa_cb_r1_result_ms"),
-        get_named_compile_time_arg_val("sdpa_cb_packet_slot"),
         get_named_compile_time_arg_val("sdpa_l1_alignment"),
         get_named_compile_time_arg_val("sdpa_page_size_bytes"),
         get_named_compile_time_arg_val("sdpa_slot_size"),
@@ -1105,6 +1104,8 @@ void kernel_main() {
         sdpa_reduce_worker_args.r1_neighbor_device_idx = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
         sdpa_reduce_worker_args.r2_neighbor_device_idx = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
         sdpa_reduce_worker_args.r2_neighbor_r1_neighbor_idx = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        sdpa_reduce_worker_args.swap_r1_reduction_order = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        sdpa_reduce_worker_args.swap_r2_reduction_order = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
     }
 
     using SdpaReduceForwarderCTArgs = deepseek_b1_ops::SdpaReduceForwarder::CTArgs<0, 0, 0>;

--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
@@ -922,7 +922,6 @@ class AttentionBlock:
         sdpa_cb_r1_result_l = cb_id_context.get_cb_id(data_format, TD_SDPA)
         sdpa_cb_r1_result_ms = cb_id_context.get_cb_id(data_format, TD_SDPA)
         sdpa_cb_l_out = cb_id_context.get_cb_id(data_format, TD_SDPA)
-        sdpa_cb_packet_slot = cb_id_context.get_cb_id(ttnn.uint32, TD_32x32)
 
         matmul4_in0_cb = cb_id_context.get_cb_id(data_format, TD_1x32)  # Matmul4 input (kv_b2 grid)
         matmul4_in1_cb = cb_id_context.get_cb_id(  # Matmul4 weights (kv_b2 grid)
@@ -1789,7 +1788,6 @@ class AttentionBlock:
                 ("sdpa_cb_local_ms", sdpa_cb_local_ms),
                 ("sdpa_cb_r1_result_l", sdpa_cb_r1_result_l),
                 ("sdpa_cb_r1_result_ms", sdpa_cb_r1_result_ms),
-                ("sdpa_cb_packet_slot", sdpa_cb_packet_slot),
                 ("sdpa_cb_l_out", sdpa_cb_l_out),
                 # SDPA tile/chunk sizes
                 ("sdpa_ms_tile_size_bytes", sdpa_ms_tile_size),
@@ -2921,24 +2919,6 @@ class AttentionBlock:
         )
         post_sdpa_cb_list.append(sdpa_l_out_cb_descriptor)
 
-        # CB 21: SDPA packet slot (for fabric packet headers)
-        sdpa_packet_header_cb_size = 2 * ttnn.get_tt_fabric_packet_header_size_bytes()
-        sdpa_packet_slot_cb_format = ttnn.CBFormatDescriptor(
-            buffer_index=sdpa_cb_packet_slot,
-            data_format=ttnn.uint32,
-            page_size=sdpa_packet_header_cb_size,
-        )
-        sdpa_packet_slot_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
-            sdpa_cb_packet_slot,
-            ref_sdpa_forwarder_scratch,
-            address_offset=sdpa_forwarder_scratch_running_offset,
-            total_size=sdpa_packet_header_cb_size,
-            core_ranges=full_device_grid,
-        )
-        sdpa_packet_slot_cb_descriptor.format_descriptors = [sdpa_packet_slot_cb_format]
-        sdpa_forwarder_scratch_running_offset += sdpa_packet_slot_cb_descriptor.total_size
-        post_sdpa_cb_list.append(sdpa_packet_slot_cb_descriptor)
-
         # ========================================================================
         # Semaphore descriptors
         # ========================================================================
@@ -3817,6 +3797,14 @@ class AttentionBlock:
                             pos_r2_neighbor_idx - 1 + sdpa_num_ring_devices
                         ) % sdpa_num_ring_devices
 
+                    # Deterministic reduction order based on device indices so all devices produce identical results.
+                    # R1: swap so lower device index is always arg1 ("worker")
+                    swap_r1_reduction_order = 1 if sdpa_ring_idx < pos_r1_neighbor_idx else 0
+                    # R2: swap so the R1 pair with lower min device index is always arg1 ("worker")
+                    r1_pair_min = min(sdpa_ring_idx, pos_r1_neighbor_idx)
+                    r2_pair_min = min(pos_r2_neighbor_idx, pos_r2_neighbor_r1_idx)
+                    swap_r2_reduction_order = 1 if r1_pair_min < r2_pair_min else 0
+
                     # TRISC args: pos_addr, device_idx, r1_neighbor, r2_neighbor, r2_neighbor_r1_neighbor
                     sdpa_worker_trisc_rt_args[worker_core.x][worker_core.y] = [
                         sdpa_pos_addr,
@@ -3824,6 +3812,8 @@ class AttentionBlock:
                         pos_r1_neighbor_idx,
                         pos_r2_neighbor_idx,
                         pos_r2_neighbor_r1_idx,
+                        swap_r1_reduction_order,
+                        swap_r2_reduction_order,
                     ]
 
                     # Extend NCRISC args: pos_addr, r1_neighbor, r2_neighbor, r2_neighbor_r1_neighbor

--- a/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/kernels/post_sdpa_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/kernels/post_sdpa_kernel.cpp
@@ -349,7 +349,6 @@ void kernel_main() {
                 get_named_compile_time_arg_val("sdpa_cb_local_ms"),
                 get_named_compile_time_arg_val("sdpa_cb_r1_result_l"),
                 get_named_compile_time_arg_val("sdpa_cb_r1_result_ms"),
-                get_named_compile_time_arg_val("sdpa_cb_packet_slot"),
                 get_named_compile_time_arg_val("sdpa_l1_alignment"),
                 get_named_compile_time_arg_val("sdpa_page_size_bytes"),
                 get_named_compile_time_arg_val("sdpa_slot_size"),
@@ -421,6 +420,8 @@ void kernel_main() {
                 compute_args.r1_neighbor_device_idx = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
                 compute_args.r2_neighbor_device_idx = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
                 compute_args.r2_neighbor_r1_neighbor_idx = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+                compute_args.swap_r1_reduction_order = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+                compute_args.swap_r2_reduction_order = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
             }
             Worker::Op<ComputeCTArgs> sdpa_worker;
             sdpa_worker(compute_args);

--- a/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/op.py
@@ -342,7 +342,6 @@ class PostSDPA:
             sdpa_cb_r1_result_l = 18
             sdpa_cb_r1_result_ms = 19
             sdpa_cb_l_out = 20
-            sdpa_cb_packet_slot = 21
 
             # SDPA forwarder parameters (using Type A/B worker split like original op)
             sdpa_num_workers = 8
@@ -668,7 +667,6 @@ class PostSDPA:
                             ("sdpa_cb_local_ms", sdpa_cb_local_ms),
                             ("sdpa_cb_r1_result_l", sdpa_cb_r1_result_l),
                             ("sdpa_cb_r1_result_ms", sdpa_cb_r1_result_ms),
-                            ("sdpa_cb_packet_slot", sdpa_cb_packet_slot),
                             ("sdpa_cb_l_out", sdpa_cb_l_out),
                             # SDPA tile/chunk sizes
                             ("sdpa_ms_tile_size_bytes", sdpa_ms_tile_size),
@@ -1029,20 +1027,6 @@ class PostSDPA:
                         sdpa_cb_l_out, sdpa_output_l_device
                     )
                     cb_list.append(sdpa_l_out_cb_descriptor)
-
-                    # CB 21: SDPA packet slot (for fabric packet headers)
-                    sdpa_packet_header_cb_size = 2 * ttnn.get_tt_fabric_packet_header_size_bytes()
-                    sdpa_packet_slot_cb_format = ttnn.CBFormatDescriptor(
-                        buffer_index=sdpa_cb_packet_slot,
-                        data_format=ttnn.uint32,
-                        page_size=sdpa_packet_header_cb_size,
-                    )
-                    sdpa_packet_slot_cb_descriptor = ttnn.CBDescriptor(
-                        total_size=sdpa_packet_header_cb_size,
-                        core_ranges=sdpa_worker_grid,
-                        format_descriptors=[sdpa_packet_slot_cb_format],
-                    )
-                    cb_list.append(sdpa_packet_slot_cb_descriptor)
 
                 # ========================================================================
                 # Semaphore descriptors
@@ -1438,6 +1422,14 @@ class PostSDPA:
                                     pos_r2_neighbor_idx - 1 + sdpa_num_ring_devices
                                 ) % sdpa_num_ring_devices
 
+                            # Deterministic reduction order based on device indices so all devices produce identical results.
+                            # R1: swap so lower device index is always arg1 ("worker")
+                            swap_r1_reduction_order = 1 if sdpa_ring_idx < pos_r1_neighbor_idx else 0
+                            # R2: swap so the R1 pair with lower min device index is always arg1 ("worker")
+                            r1_pair_min = min(sdpa_ring_idx, pos_r1_neighbor_idx)
+                            r2_pair_min = min(pos_r2_neighbor_idx, pos_r2_neighbor_r1_idx)
+                            swap_r2_reduction_order = 1 if r1_pair_min < r2_pair_min else 0
+
                             # TRISC args: pos_addr, device_idx, r1_neighbor, r2_neighbor, r2_neighbor_r1_neighbor
                             sdpa_worker_trisc_rt_args[worker_core.x][worker_core.y] = [
                                 sdpa_pos_addr,
@@ -1445,6 +1437,8 @@ class PostSDPA:
                                 pos_r1_neighbor_idx,
                                 pos_r2_neighbor_idx,
                                 pos_r2_neighbor_r1_idx,
+                                swap_r1_reduction_order,
+                                swap_r2_reduction_order,
                             ]
 
                             # Extend NCRISC args: pos_addr, r1_neighbor, r2_neighbor, r2_neighbor_r1_neighbor

--- a/models/demos/deepseek_v3_b1/micro_ops/sdpa_reduce_to_all/kernels/sdpa_reduce_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/sdpa_reduce_to_all/kernels/sdpa_reduce_kernel.cpp
@@ -94,7 +94,6 @@ void kernel_main() {
             get_named_compile_time_arg_val("cb_local_ms"),
             get_named_compile_time_arg_val("cb_r1_result_l"),
             get_named_compile_time_arg_val("cb_r1_result_ms"),
-            get_named_compile_time_arg_val("cb_packet_slot"),
             get_named_compile_time_arg_val("l1_alignment"),
             get_named_compile_time_arg_val("page_size_bytes"),
             get_named_compile_time_arg_val("slot_size"),
@@ -191,6 +190,8 @@ void kernel_main() {
             compute_args.r1_neighbor_device_idx = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
             compute_args.r2_neighbor_device_idx = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
             compute_args.r2_neighbor_r1_neighbor_idx = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+            compute_args.swap_r1_reduction_order = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+            compute_args.swap_r2_reduction_order = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
         }
         Worker::Op<ComputeCTArgs> op;
         op(compute_args);

--- a/models/demos/deepseek_v3_b1/micro_ops/sdpa_reduce_to_all/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/sdpa_reduce_to_all/op.py
@@ -309,7 +309,6 @@ class SdpaReduceToAll:
                 cb_r1_result_l = 4
                 cb_r1_result_ms = 5
                 cb_l_out = 6
-                cb_packet_slot = 7
 
                 # Scatter compile-time parameters
                 if scatter_enabled:
@@ -350,7 +349,6 @@ class SdpaReduceToAll:
                     ("cb_local_ms", cb_local_ms),
                     ("cb_r1_result_l", cb_r1_result_l),
                     ("cb_r1_result_ms", cb_r1_result_ms),
-                    ("cb_packet_slot", cb_packet_slot),
                     ("l1_alignment", l1_alignment),
                     ("page_size_bytes", input_page_size_bytes),
                     ("slot_size", slot_size),
@@ -430,19 +428,6 @@ class SdpaReduceToAll:
                             buffer_index=cb_r1_result_ms,
                             data_format=input_dtype,
                             page_size=aligned_page_size,
-                            tile=tile_desc,
-                        )
-                    ],
-                )
-
-                cb_packet_slot_desc = ttnn.CBDescriptor(
-                    total_size=2 * header_cb_size,
-                    core_ranges=shard_grid,
-                    format_descriptors=[
-                        ttnn.CBFormatDescriptor(
-                            buffer_index=cb_packet_slot,
-                            data_format=ttnn.uint32,
-                            page_size=header_cb_size,
                             tile=tile_desc,
                         )
                     ],
@@ -585,6 +570,14 @@ class SdpaReduceToAll:
                             else:
                                 r2_neighbor_r1_neighbor_idx = (r2_neighbor_device_idx - 1 + num_devices) % num_devices
 
+                            # Deterministic reduction order based on device indices so all devices produce identical results.
+                            # R1: swap so lower device index is always arg1 ("worker")
+                            swap_r1_reduction_order = 1 if device_idx < r1_neighbor_device_idx else 0
+                            # R2: swap so the R1 pair with lower min device index is always arg1 ("worker")
+                            r1_pair_min = min(device_idx, r1_neighbor_device_idx)
+                            r2_pair_min = min(r2_neighbor_device_idx, r2_neighbor_r1_neighbor_idx)
+                            swap_r2_reduction_order = 1 if r1_pair_min < r2_pair_min else 0
+
                             trisc_core_args.append(
                                 (
                                     core,
@@ -594,6 +587,8 @@ class SdpaReduceToAll:
                                         r1_neighbor_device_idx,
                                         r2_neighbor_device_idx,
                                         r2_neighbor_r1_neighbor_idx,
+                                        swap_r1_reduction_order,
+                                        swap_r2_reduction_order,
                                     ],
                                 )
                             )
@@ -701,7 +696,6 @@ class SdpaReduceToAll:
                         cb_r1_result_l_desc,
                         cb_r1_result_ms_desc,
                         cb_l_out_desc,
-                        cb_packet_slot_desc,
                     ],
                 )
 

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_sdpa_reduce_to_all.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_sdpa_reduce_to_all.py
@@ -303,6 +303,11 @@ def test_sdpa_reduce_to_all(bh_2d_mesh_device, scatter_enabled, position_id):
     logger.info(f"L tensor match: {match}, max_diff: {max_diff:.4f}")
     assert match, f"L tensor mismatch! Max diff: {max_diff}"
 
+    # Reduction order should be deterministic so all devices produce identical results.
+    for i in range(1, num_devices):
+        dev_eq = torch.equal(output_l_torch[i], out_l_root)
+        assert dev_eq, f"L tensor mismatch on device {i}"
+
     # ========================================================================
     # Verify scatter output (only when scatter is enabled)
     # Each core (x=i, y=j) should have ref_l[j, i*l_width:(i+1)*l_width]

--- a/models/demos/deepseek_v3_b1/unified_kernels/sdpa_reduce_worker.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/sdpa_reduce_worker.hpp
@@ -82,6 +82,7 @@ struct SdpaRoundConfig {
     uint32_t fwd_slot_addr;
     uint32_t fwd_sem_addr;
     uint32_t base_slot_idx;
+    uint32_t header_addr;
 };
 
 /**
@@ -89,7 +90,6 @@ struct SdpaRoundConfig {
  * Template parameters encode size constants for zero-overhead abstraction.
  */
 template <
-    uint32_t cb_packet_slot,
     uint32_t l1_alignment,
     uint32_t slot_size,
     uint32_t ms_tile_size_bytes,
@@ -110,9 +110,6 @@ struct SdpaChunkSender {
     uint64_t sem_noc;      // Fabric destination semaphore
     uint64_t fwd_sem_noc;  // Forwarder semaphore
 
-    // Cached header address (set once per round, reused for all packets)
-    uint32_t header_addr;
-
     // Derived constants
     static constexpr uint32_t total_l_bytes = num_l_chunks * l_chunk_size_bytes;
     static constexpr size_t packet_header_size_bytes = sizeof(PACKET_HEADER_TYPE);
@@ -126,16 +123,8 @@ struct SdpaChunkSender {
         sem_noc = get_noc_addr(current_core_x, current_core_y, cfg.sem_addr);
         fwd_sem_noc = get_noc_addr(fwd_core_x, fwd_core_y, cfg.fwd_sem_addr);
 
-        cb_reserve_back(cb_packet_slot, 1);
-        header_addr = get_write_ptr(cb_packet_slot);
-
-        auto* header = reinterpret_cast<volatile PACKET_HEADER_TYPE*>(header_addr);
+        auto* header = reinterpret_cast<volatile PACKET_HEADER_TYPE*>(cfg.header_addr);
         (void)fabric_set_unicast_route(header, cfg.dst_chip_id, cfg.dst_mesh_id);
-    }
-
-    FORCE_INLINE void finish_round() {
-        cb_push_back(cb_packet_slot, 1);
-        cb_pop_front(cb_packet_slot, 1);
     }
 
     FORCE_INLINE SdpaFabricDest get_fabric_dest(uint32_t dst_addr) const {
@@ -161,7 +150,7 @@ struct SdpaChunkSender {
         const SdpaForwarderDest& fwd_dest,
         uint32_t src_addr,
         uint32_t payload_size) const {
-        auto* header = reinterpret_cast<volatile PACKET_HEADER_TYPE*>(header_addr);
+        auto* header = reinterpret_cast<volatile PACKET_HEADER_TYPE*>(cfg.header_addr);
         constexpr uint32_t ATOMIC_INC_VAL = 1;
         constexpr bool FLUSH_WRITES = false;
         header->to_noc_fused_unicast_write_atomic_inc(
@@ -169,7 +158,7 @@ struct SdpaChunkSender {
                 fabric_dest.dst_noc, fabric_dest.sem_noc, ATOMIC_INC_VAL, FLUSH_WRITES},
             align(payload_size, l1_alignment));
 
-        noc_async_write(header_addr, fwd_dest.slot_noc, packet_header_size_bytes);
+        noc_async_write(cfg.header_addr, fwd_dest.slot_noc, packet_header_size_bytes);
         uint64_t fwd_payload_noc = fwd_dest.slot_noc + packet_header_size_bytes;
         noc_async_write(src_addr, fwd_payload_noc, payload_size);
         noc_async_writes_flushed();
@@ -333,7 +322,8 @@ ALWI void sdpa_tail_streaming_conditional(
     uint32_t cb_l2,
     uint32_t cb_l_out,
     bool neighbor_valid,
-    bool local_valid) {
+    bool local_valid,
+    bool swap_reduction_order) {
     // Only local valid - copy local data to output
     if (!neighbor_valid && local_valid) {
         // TODO: Can be optimized to just division
@@ -349,6 +339,9 @@ ALWI void sdpa_tail_streaming_conditional(
         } else {
             sdpa_forward_data(cb_prev_max_sum, cb_cur_max_sum, num_l_chunks, cb_l2, cb_l_out, block_size);
         }
+        // Wait for remote data to arrive still since we need to properly pop the CBs
+        cb_wait_front(cb_worker_max_sum, 1);
+        cb_wait_front(cb_l1, num_l_chunks * block_size);
         return;
     }
 
@@ -367,18 +360,39 @@ ALWI void sdpa_tail_streaming_conditional(
         } else {
             sdpa_forward_data(cb_worker_max_sum, cb_cur_max_sum, num_l_chunks, cb_l1, cb_l_out, block_size);
         }
+        // We don't pop local data so no need to wait for it
         return;
     }
 
     // Just copy local data as fallback
     if (!neighbor_valid && !local_valid) {
         sdpa_forward_data(cb_prev_max_sum, cb_cur_max_sum, num_l_chunks, cb_l2, cb_l_out, block_size);
+        // Wait for remote data to arrive still since we need to properly pop the CBs
+        cb_wait_front(cb_worker_max_sum, 1);
+        cb_wait_front(cb_l1, num_l_chunks * block_size);
         return;
     }
 
     // Both valid - perform normal SDPA reduction
-    sdpa_tail_streaming<SDPA_EXP_APPROX_MODE, normalize, untilize, block_size, scale_fp32, num_l_chunks, vector_mode>(
-        cb_worker_max_sum, cb_prev_max_sum, cb_cur_max_sum, cb_l1, cb_l2, cb_l_out);
+    if (swap_reduction_order) {
+        sdpa_tail_streaming<
+            SDPA_EXP_APPROX_MODE,
+            normalize,
+            untilize,
+            block_size,
+            scale_fp32,
+            num_l_chunks,
+            vector_mode>(cb_prev_max_sum, cb_worker_max_sum, cb_cur_max_sum, cb_l2, cb_l1, cb_l_out);
+    } else {
+        sdpa_tail_streaming<
+            SDPA_EXP_APPROX_MODE,
+            normalize,
+            untilize,
+            block_size,
+            scale_fp32,
+            num_l_chunks,
+            vector_mode>(cb_worker_max_sum, cb_prev_max_sum, cb_cur_max_sum, cb_l1, cb_l2, cb_l_out);
+    }
 }
 
 #endif  // COMPILE_FOR_TRISC
@@ -432,7 +446,6 @@ struct SdpaReduceWorker {
         uint32_t cbLocalMs,
         uint32_t cbR1ResultL,
         uint32_t cbR1ResultMs,
-        uint32_t cbPacketSlot,
         uint32_t l1Alignment,
         uint32_t pageSizeBytes,
         uint32_t slotSize,
@@ -453,7 +466,6 @@ struct SdpaReduceWorker {
         static constexpr uint32_t cb_local_ms = cbLocalMs;
         static constexpr uint32_t cb_r1_result_l = cbR1ResultL;
         static constexpr uint32_t cb_r1_result_ms = cbR1ResultMs;
-        static constexpr uint32_t cb_packet_slot = cbPacketSlot;
         static constexpr uint32_t l1_alignment = l1Alignment;
         static constexpr uint32_t page_size_bytes = pageSizeBytes;
         static constexpr uint32_t slot_size = slotSize;
@@ -555,6 +567,8 @@ struct SdpaReduceWorker {
         uint32_t r1_neighbor_device_idx;
         uint32_t r2_neighbor_device_idx;
         uint32_t r2_neighbor_r1_neighbor_idx;
+        uint32_t swap_r1_reduction_order;
+        uint32_t swap_r2_reduction_order;
     };
 
     using RTArgs = unified_kernels::SelectByRISCV<ReaderArgs, WriterArgs, ComputeArgs>;
@@ -649,7 +663,6 @@ struct SdpaReduceWorker {
         // ==================================================================
         void writer_impl(const WriterArgs& args) {
             using Sender = SdpaChunkSender<
-                CTArgs::cb_packet_slot,
                 CTArgs::l1_alignment,
                 CTArgs::slot_size,
                 CTArgs::ms_tile_size_bytes,
@@ -659,6 +672,8 @@ struct SdpaReduceWorker {
 
             // Initialize sender with core coordinates
             Sender sender{args.current_core_x, args.current_core_y, args.fwd_core_x, args.fwd_core_y};
+            PacketHeaderPool::reset();
+            auto* header = PacketHeaderPool::allocate_header(1);
 
             // ROUND 1: Send local input to R1 neighbor
             sender.setup_round(
@@ -670,9 +685,9 @@ struct SdpaReduceWorker {
                  args.r1_neighbor_sem_addr,
                  args.r1_fwd_slot_addr,
                  args.r1_fwd_sem_addr,
-                 args.r1_base_slot_idx});
+                 args.r1_base_slot_idx,
+                 reinterpret_cast<uint32_t>(header)});
             sender.send_all();
-            sender.finish_round();
 
             // ROUND 2: Send R1 result to R2 neighbor (streaming)
             sender.setup_round(
@@ -684,13 +699,10 @@ struct SdpaReduceWorker {
                  args.r2_neighbor_sem_addr,
                  args.r2_fwd_slot_addr,
                  args.r2_fwd_sem_addr,
-                 args.r2_base_slot_idx});
+                 args.r2_base_slot_idx,
+                 reinterpret_cast<uint32_t>(header)});
             sender.send_streaming();
-            sender.finish_round();
 
-            // Release the single MS tile from R1 result after R2 streaming send to
-            // preserve BRISC/TRISC synchronization semantics from post_sdpa.
-            cb_pop_front(CTArgs::cb_r1_result_ms, 1);
             noc_async_full_barrier();
 
             // SCATTER PHASE: Distribute output rows to destination cores
@@ -746,6 +758,8 @@ struct SdpaReduceWorker {
             bool local_valid = true;
             bool r1_neighbor_valid = true;
             bool r2_neighbor_valid = true;
+            bool swap_r1_reduction_order = false;
+            bool swap_r2_reduction_order = false;
 
             [[maybe_unused]] uint32_t device_idx = 0;
             [[maybe_unused]] uint32_t r1_neighbor_device_idx = 0;
@@ -765,6 +779,8 @@ struct SdpaReduceWorker {
                 r1_neighbor_valid = (position_id >= r1_neighbor_device_idx * chunk);
                 r2_neighbor_valid = (position_id >= r2_neighbor_device_idx * chunk) ||
                                     (position_id >= args.r2_neighbor_r1_neighbor_idx * chunk);
+                swap_r1_reduction_order = args.swap_r1_reduction_order;
+                swap_r2_reduction_order = args.swap_r2_reduction_order;
             }
 
             uint32_t neighbor_cb_base_rd_ptr = 0;
@@ -795,7 +811,8 @@ struct SdpaReduceWorker {
                 CTArgs::cb_local_l,
                 CTArgs::cb_r1_result_l,
                 r1_neighbor_valid,
-                local_valid);
+                local_valid,
+                swap_r1_reduction_order);
 
             // Pop R1 input MS CBs — TRISC-owned, no BRISC race.
             // cb_r1_neighbor_ms: incoming from neighbor, consumed only by TRISC
@@ -835,7 +852,8 @@ struct SdpaReduceWorker {
                 CTArgs::cb_r1_result_l,
                 CTArgs::cb_l_out,
                 r2_neighbor_r1_valid,
-                local_r1_valid);
+                local_r1_valid,
+                swap_r2_reduction_order);
 
             // Pop R2 worker MS CB — incoming from neighbor, consumed only by TRISC.
             // Do NOT pop cb_r1_result_ms — BRISC owns that pop (writer_impl line 668)


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
SDPA reduction had a number of issues:
- non-deterministic reduction order across devices
- ND PCC due to race with popping the remote CB buffers
- Wasting a cb id and L1 for a packet header when we can get one from the pool

### What's changed
- Reorder reductions so that all devices produce the same output
- Wait for remote data even when it's invalid so that we pop the CB appropriately
- Remove packet header CB and get one from the packet header pool instead

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aho/sdpa-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aho/sdpa-reduction)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aho/sdpa-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/sdpa-reduction)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aho/sdpa-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/sdpa-reduction)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aho/sdpa-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/sdpa-reduction)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aho/sdpa-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/sdpa-reduction)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aho/sdpa-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/sdpa-reduction)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
