### PR TITLE
PatchTST Model bringup using TTNN API

### DIFF
--- a/models/demos/wormhole/patchtst/.gitignore
+++ b/models/demos/wormhole/patchtst/.gitignore
@@ -1,0 +1,6 @@
+.hf_checkpoints/
+__pycache__/
+**/__pycache__/
+*.pyc
+artifacts/
+generated/patchtst/

--- a/models/demos/wormhole/patchtst/PERF.md
+++ b/models/demos/wormhole/patchtst/PERF.md
@@ -1,0 +1,20 @@
+# PatchTST Performance Notes
+
+The table below records the current public demo targets and the latest measured values kept in this repo.
+
+| Workload | Required Metric | Achieved Metric | Verify Command |
+|---|---|---|---|
+| Primary forecast, trace batch 1 | `>= 150 seq/s`, `<= 40 ms` | `172.67 seq/s`, `5.50 ms` | `PYTHONPATH=. ./python_env/bin/python -m pytest models/demos/wormhole/patchtst/tests/perf/test_patchtst_perf.py -s -k primary_forecast_trace_batch1_targets --timeout=1200` |
+| Primary forecast, reproducibility | `3 fresh-process runs all >= 150 seq/s` | `191.66, 188.23, 172.67, ...` on the last saved passing sample set | `PYTHONPATH=. ./python_env/bin/python -m pytest models/demos/wormhole/patchtst/tests/perf/test_patchtst_perf.py -s -k primary_forecast_trace_batch1_reproducibility --timeout=1200` |
+| Batch forecast throughput | `>= 800 seq/s`, `<= 15 ms` | `1982.52 seq/s`, `8.07 ms` | `PYTHONPATH=. ./python_env/bin/python -m pytest models/demos/wormhole/patchtst/tests/perf/test_patchtst_perf.py -s -k batch16_trace_targets --timeout=1200` |
+| Sharded forecast path | sharded forecast path meets perf/quality targets with shard fallback disabled | `latency_ms=19.6901`, `throughput_sps=203.1473`, `parity_corr=0.999658`, `quality_corr=0.754497` | `PYTHONPATH=. ./python_env/bin/python -m pytest models/demos/wormhole/patchtst/tests/perf/test_patchtst_perf.py -s -k sharded_attention_evidence_and_quality --timeout=1200` |
+| Cached online forecast | cached path faster than full rerun and parity preserved | `3.18 ms` cached vs `5.13 ms` full rerun, `speedup=0.3793` | `PYTHONPATH=. ./python_env/bin/python -m pytest models/demos/wormhole/patchtst/tests/perf/test_patchtst_perf.py -s -k cached_streaming_speedup_and_parity --timeout=1200` |
+| Shared-encoder forecast + classification | one encoder pass, latency gain over sequential | `latency_gain=0.4812` | `PYTHONPATH=. ./python_env/bin/python -m pytest models/demos/wormhole/patchtst/tests/perf/test_patchtst_perf.py -s -k shared_encoder_multitask_latency_gain --timeout=1200` |
+| Long-context forecast | real run at `4096 x 96` | `14.15 ms`, `282.73 seq/s` | `PYTHONPATH=. ./python_env/bin/python -m pytest models/demos/wormhole/patchtst/tests/integration/test_public_tasks.py -s -k native_long_context --timeout=1200` |
+| High-channel forecast | real run at `862` channels | `517.93 ms`, `7.72 seq/s` | `PYTHONPATH=. ./python_env/bin/python -m pytest models/demos/wormhole/patchtst/tests/integration/test_public_tasks.py -s -k native_high_channel --timeout=1200` |
+
+## Notes
+- All commands assume the in-repo runtime built with `./create_venv.sh` and `./build_metal.sh`.
+- The public demo uses strict no-fallback execution by default.
+- The cached streaming path keeps state and a persistent device buffer, but it does not claim decoder-style autoregressive KV-cache semantics.
+- The long-context checkpoint is local and shape-matched; it is evaluated on the `etth1` training split because the public test split is too short for `4096 + 96`.

--- a/models/demos/wormhole/patchtst/README.md
+++ b/models/demos/wormhole/patchtst/README.md
@@ -1,0 +1,180 @@
+# PatchTST (TTNN)
+
+## Overview
+This is a public PatchTST demo for TTNN on Wormhole.
+
+It covers:
+- forecasting on real benchmark data,
+- classification and regression with real labeled datasets,
+- optional channel-attention checkpoints,
+- traced batch inference,
+- shared-encoder forecast + classification inference,
+- online forecasting with a cached rolling context,
+- long-context and high-channel runs with task-matched local checkpoints.
+
+## Environment
+Build and use the in-repo runtime:
+
+```bash
+./create_venv.sh --force --env-dir ./python_env
+./build_metal.sh
+source ./python_env/bin/activate
+export PYTHONPATH=.
+```
+
+## Assets
+```bash
+python -m models.demos.wormhole.patchtst.scripts.download_assets \
+  --dataset-root data/patchtst \
+  --checkpoint-root models/demos/wormhole/patchtst/.hf_checkpoints
+```
+
+## Generate Local Task Checkpoints
+Some public runs use local task-matched checkpoints.
+
+```bash
+./python_env/bin/python -m models.demos.wormhole.patchtst.demo.demo finetune \
+  --task forecast \
+  --channel-mode attention \
+  --dataset etth1 \
+  --dataset-root data/patchtst \
+  --steps 0 \
+  --batch-size 4 \
+  --learning-rate 1e-4 \
+  --seed 1337 \
+  --output-dir models/demos/wormhole/patchtst/artifacts/finetune/forecast_attention_etth1_ckpt
+
+./python_env/bin/python -m models.demos.wormhole.patchtst.demo.demo finetune \
+  --task classification \
+  --dataset heartbeat_cls \
+  --dataset-root data/patchtst \
+  --steps 20 \
+  --batch-size 8 \
+  --learning-rate 1e-4 \
+  --seed 1337 \
+  --output-dir models/demos/wormhole/patchtst/artifacts/finetune/classification_heartbeat_ckpt
+
+./python_env/bin/python -m models.demos.wormhole.patchtst.demo.demo finetune \
+  --task regression \
+  --dataset flood_modeling1_reg \
+  --dataset-root data/patchtst \
+  --steps 20 \
+  --batch-size 8 \
+  --learning-rate 1e-4 \
+  --seed 1337 \
+  --output-dir models/demos/wormhole/patchtst/artifacts/finetune/regression_flood_modeling1_ckpt
+
+./python_env/bin/python -m models.demos.wormhole.patchtst.demo.demo finetune \
+  --task forecast \
+  --dataset etth1 \
+  --dataset-root data/patchtst \
+  --context-length 4096 \
+  --prediction-length 96 \
+  --steps 200 \
+  --batch-size 4 \
+  --learning-rate 1e-4 \
+  --seed 1337 \
+  --output-dir models/demos/wormhole/patchtst/artifacts/finetune/forecast_long_context_etth1_4096_ckpt
+
+./python_env/bin/python -m models.demos.wormhole.patchtst.demo.demo finetune \
+  --task forecast \
+  --dataset traffic \
+  --dataset-root data/patchtst \
+  --context-length 512 \
+  --prediction-length 96 \
+  --steps 5 \
+  --batch-size 2 \
+  --learning-rate 1e-4 \
+  --seed 1337 \
+  --output-dir models/demos/wormhole/patchtst/artifacts/finetune/forecast_high_channel_traffic_ckpt
+
+./python_env/bin/python -m models.demos.wormhole.patchtst.demo.demo finetune \
+  --task forecast \
+  --dataset heartbeat_cls \
+  --dataset-root data/patchtst \
+  --context-length 309 \
+  --prediction-length 96 \
+  --steps 40 \
+  --batch-size 8 \
+  --learning-rate 1e-4 \
+  --seed 1337 \
+  --output-dir models/demos/wormhole/patchtst/artifacts/finetune/forecast_heartbeat_multitask_ckpt
+
+./python_env/bin/python -m models.demos.wormhole.patchtst.demo.demo finetune \
+  --task classification \
+  --dataset heartbeat_cls \
+  --dataset-root data/patchtst \
+  --context-length 309 \
+  --steps 80 \
+  --batch-size 8 \
+  --learning-rate 1e-4 \
+  --seed 1337 \
+  --checkpoint-id-override models/demos/wormhole/patchtst/artifacts/finetune/forecast_heartbeat_multitask_ckpt \
+  --checkpoint-revision-override local-generated \
+  --output-dir models/demos/wormhole/patchtst/artifacts/finetune/classification_heartbeat_multitask_ckpt
+```
+
+## Public Demo Commands
+Single forecast run:
+
+```bash
+./python_env/bin/python -m models.demos.wormhole.patchtst.demo.demo run \
+  --task forecast \
+  --dataset etth1 \
+  --dataset-root data/patchtst
+```
+
+Cached online forecast:
+
+```bash
+./python_env/bin/python -m models.demos.wormhole.patchtst.demo.demo streaming \
+  --dataset etth1 \
+  --dataset-root data/patchtst \
+  --trace \
+  --streaming-mode cached \
+  --stream-steps 4
+```
+
+Shared-encoder forecast + classification run:
+
+```bash
+./python_env/bin/python -m models.demos.wormhole.patchtst.demo.demo run \
+  --task multi_task \
+  --dataset heartbeat_cls \
+  --dataset-root data/patchtst \
+  --context-length 309
+```
+
+## Verification
+Unit tests:
+
+```bash
+PYTHONPATH=. ./python_env/bin/python -m pytest models/demos/wormhole/patchtst/tests/unit -s --timeout=600
+```
+
+Integration tests:
+
+```bash
+PYTHONPATH=. ./python_env/bin/python -m pytest models/demos/wormhole/patchtst/tests/integration -s --timeout=600
+```
+
+Performance and runtime checks:
+
+```bash
+PYTHONPATH=. ./python_env/bin/python -m pytest models/demos/wormhole/patchtst/tests/perf -s --timeout=1200
+```
+
+## Notes
+- The primary forecast workload uses `etth1`, `context_length=512`, `prediction_length=96`.
+- The default runtime is strict no-fallback.
+- The traced batch-1 and batch-16 rows are the main latency and throughput measurements.
+- The cached streaming path keeps rolling context state and exact sliding-window normalization statistics, but it does not claim decoder-style autoregressive KV-cache semantics.
+- The shared-encoder multi-head path is forecast + classification only.
+- The long-context run uses the `etth1` training split because the public test split is shorter than `4096 + 96`.
+- Generated outputs belong under `generated/patchtst/`.
+
+Device recovery:
+
+```bash
+tt-smi -r 0
+```

--- a/models/demos/wormhole/patchtst/config.py
+++ b/models/demos/wormhole/patchtst/config.py
@@ -1,0 +1,190 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+PUBLIC_TASK_MODE = Literal["forecast", "regression", "pretraining", "classification", "multi_task"]
+CHANNEL_MODE = Literal["independent", "attention"]
+DATASET_NAME = Literal[
+    "etth1",
+    "weather",
+    "traffic",
+    "electricity",
+    "exchange_rate",
+    "heartbeat_cls",
+    "flood_modeling1_reg",
+]
+_ATTENTION_CHECKPOINT_KEY_BY_TASK = {
+    "forecast": "forecast_attention",
+    "regression": "regression_attention",
+    "pretraining": "channel_attention",
+    "classification": "classification_attention",
+}
+
+
+@dataclass
+class PatchTSTDemoConfig:
+    task: PUBLIC_TASK_MODE = "forecast"
+    channel_mode: CHANNEL_MODE = "independent"
+    share_embedding: bool = True
+    strict_fallback: bool = True
+    use_trace: bool = False
+
+    batch_size: int = 1
+    context_length: int = 512
+    prediction_length: int = 96
+    patch_length: int = 12
+    patch_stride: int = 12
+
+    dataset: DATASET_NAME = "etth1"
+    dataset_root: Path = Path("data/patchtst")
+    split: Literal["train", "val", "test"] = "test"
+    max_windows: int = 64
+    window_offset: int = 0
+    masking_seed: int = 1337
+
+    required_latency_ms: float = 40.0
+    required_throughput_sps: float = 150.0
+    required_mse_delta_ratio: float = 0.05
+    required_mae_delta_ratio: float = 0.05
+    required_rmse_delta_ratio: float = 0.05
+    required_correlation: float = 0.90
+    required_quality_correlation: float = 0.65
+    required_quality_correlation_delta: float = 0.05
+    required_classification_accuracy_delta: float = 0.02
+    required_classification_f1_delta: float = 0.02
+
+    stretch_latency_ms: float = 15.0
+    stretch_throughput_sps: float = 800.0
+    stretch_context_length: int = 4096
+    stretch_required_batch_size: int = 16
+
+    output_dir: Path = Path("generated/patchtst/report")
+
+    required_versions: dict[str, str] = field(
+        default_factory=lambda: {
+            "transformers": "4.53.0",
+            "datasets": "2.9.0",
+            "evaluate": "0.4.0",
+        }
+    )
+    checkpoint_ids: dict[str, str] = field(
+        default_factory=lambda: {
+            "forecast": "ibm-research/test-patchtst",
+            "forecast_attention": "models/demos/wormhole/patchtst/artifacts/finetune/forecast_attention_etth1_ckpt",
+            "regression": "models/demos/wormhole/patchtst/artifacts/finetune/regression_flood_modeling1_ckpt",
+            "regression_attention": "models/demos/wormhole/patchtst/artifacts/finetune/regression_flood_modeling1_attention_ckpt",
+            "pretraining": "ibm-research/testing-patchtst_etth1_pretrain",
+            "classification": "models/demos/wormhole/patchtst/artifacts/finetune/classification_heartbeat_ckpt",
+            "classification_attention": "models/demos/wormhole/patchtst/artifacts/finetune/classification_heartbeat_attention_ckpt",
+            "channel_attention": "AminiTech/amini-28M-v1",
+        }
+    )
+    checkpoint_revisions: dict[str, str] = field(
+        default_factory=lambda: {
+            "forecast": "a8c54ceeaf3c9c4d864a33d650b156cc18b3ab53",
+            "forecast_attention": "local-generated",
+            "regression": "local-generated",
+            "regression_attention": "local-generated",
+            "pretraining": "5dcaab0b40fa2b8a3843e2197e1f6b6e53ecd363",
+            "classification": "local-generated",
+            "classification_attention": "local-generated",
+            "channel_attention": "5ce4e875ad358f4a3f842f33c7d36b8c7dd433ac",
+        }
+    )
+    checkpoint_id_override: str | None = None
+    checkpoint_revision_override: str | None = None
+    allow_reference_context_adaptation: bool = True
+    allow_reference_channel_adaptation: bool = True
+    multi_task_checkpoint_ids: dict[str, str] = field(
+        default_factory=lambda: {
+            "forecast": "models/demos/wormhole/patchtst/artifacts/finetune/forecast_heartbeat_multitask_ckpt",
+            "classification": "models/demos/wormhole/patchtst/artifacts/finetune/classification_heartbeat_multitask_ckpt",
+        }
+    )
+    multi_task_checkpoint_revisions: dict[str, str] = field(
+        default_factory=lambda: {
+            "forecast": "local-generated",
+            "classification": "local-generated",
+        }
+    )
+
+    def __post_init__(self) -> None:
+        # PatchTST demo runs in strict no-fallback mode.
+        self.strict_fallback = True
+        if self.batch_size <= 0:
+            raise ValueError("batch_size must be > 0")
+        if self.context_length <= 0:
+            raise ValueError("context_length must be > 0")
+        if self.prediction_length <= 0:
+            raise ValueError("prediction_length must be > 0")
+        if self.window_offset < 0:
+            raise ValueError("window_offset must be >= 0")
+        if self.patch_length <= 0:
+            raise ValueError("patch_length must be > 0")
+        if self.patch_stride <= 0:
+            raise ValueError("patch_stride must be > 0")
+        if self.context_length <= self.patch_length:
+            raise ValueError(f"context_length ({self.context_length}) must be > patch_length ({self.patch_length})")
+        if self.channel_mode == "attention" and self.task == "multi_task":
+            raise ValueError("channel_mode='attention' is not supported for multi_task runs.")
+
+    def _attention_checkpoint_key_for_task(self, task: str) -> str:
+        if task not in _ATTENTION_CHECKPOINT_KEY_BY_TASK:
+            raise ValueError(f"channel_mode='attention' is not supported for task: {task}")
+        return _ATTENTION_CHECKPOINT_KEY_BY_TASK[task]
+
+    def checkpoint_for_task(self, task: str | None = None) -> str:
+        key = task or self.task
+        if key == "multi_task":
+            if self.channel_mode == "attention":
+                raise ValueError("channel_mode='attention' is not supported for multi_task runs.")
+            key = "forecast"
+        if self.channel_mode == "attention":
+            key = self._attention_checkpoint_key_for_task(key)
+        if key not in self.checkpoint_ids:
+            raise ValueError(f"No checkpoint configured for task: {key}")
+        return self.checkpoint_ids[key]
+
+    def checkpoint_revision_for_task(self, task: str | None = None) -> str:
+        key = task or self.task
+        if key == "multi_task":
+            if self.channel_mode == "attention":
+                raise ValueError("channel_mode='attention' is not supported for multi_task runs.")
+            key = "forecast"
+        if self.channel_mode == "attention":
+            key = self._attention_checkpoint_key_for_task(key)
+        if key not in self.checkpoint_revisions:
+            raise ValueError(f"No checkpoint revision configured for task: {key}")
+        return self.checkpoint_revisions[key]
+
+    def effective_checkpoint_id(self, task: str | None = None) -> str:
+        # Validation presets may pin a task-matched local checkpoint for a stretched workload instead of the default task checkpoint.
+        return self.checkpoint_id_override or self.checkpoint_for_task(task)
+
+    def effective_checkpoint_revision(self, task: str | None = None) -> str:
+        # When a local stretch checkpoint is pinned, its revision metadata must travel with it for reproducible reporting.
+        return self.checkpoint_revision_override or self.checkpoint_revision_for_task(task)
+
+
+def merge_demo_config(base: PatchTSTDemoConfig, **overrides) -> PatchTSTDemoConfig:
+    return PatchTSTDemoConfig(**(base.__dict__ | overrides))
+
+
+def resolve_runtime_config(base: PatchTSTDemoConfig, reference_config) -> PatchTSTDemoConfig:
+    defaults = PatchTSTDemoConfig(task=base.task)
+    return merge_demo_config(
+        base,
+        context_length=int(reference_config.context_length)
+        if base.context_length == defaults.context_length
+        else base.context_length,
+        prediction_length=int(reference_config.prediction_length)
+        if base.prediction_length == defaults.prediction_length
+        else base.prediction_length,
+        patch_length=int(reference_config.patch_length),
+        patch_stride=int(reference_config.patch_stride),
+    )

--- a/models/demos/wormhole/patchtst/demo/data_utils.py
+++ b/models/demos/wormhole/patchtst/demo/data_utils.py
@@ -1,0 +1,363 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+import torch
+
+FORECAST_DATASET_FILES = {
+    "etth1": Path("ETT-small/ETTh1.csv"),
+    "weather": Path("weather/weather.csv"),
+    "traffic": Path("traffic/traffic.csv"),
+    "electricity": Path("electricity/electricity.csv"),
+    "exchange_rate": Path("exchange_rate/exchange_rate.csv"),
+}
+
+
+@dataclass(frozen=True)
+class ArchiveDatasetSpec:
+    task: Literal["classification", "regression"]
+    train_file: Path
+    test_file: Path
+
+
+ARCHIVE_DATASET_FILES = {
+    "heartbeat_cls": ArchiveDatasetSpec(
+        task="classification",
+        train_file=Path("Heartbeat/Heartbeat_TRAIN.ts"),
+        test_file=Path("Heartbeat/Heartbeat_TEST.ts"),
+    ),
+    "flood_modeling1_reg": ArchiveDatasetSpec(
+        task="regression",
+        train_file=Path("FloodModeling1/FloodModeling1_TRAIN.ts"),
+        test_file=Path("FloodModeling1/FloodModeling1_TEST.ts"),
+    ),
+}
+
+
+@dataclass
+class TaskDatasetBatch:
+    past_values: torch.Tensor
+    future_values: torch.Tensor | None
+    target_values: torch.Tensor | None
+
+
+def _load_csv_matrix(path: Path, skip_column: str = "date") -> torch.Tensor:
+    if not path.exists():
+        raise FileNotFoundError(f"Dataset CSV not found: {path}")
+
+    with path.open("r", newline="") as handle:
+        reader = csv.DictReader(handle)
+        if reader.fieldnames is None:
+            raise ValueError(f"CSV has no header: {path}")
+
+        feature_names = [name for name in reader.fieldnames if name != skip_column]
+        rows = []
+        for row_idx, row in enumerate(reader, start=2):
+            parsed_row: list[float] = []
+            for name in feature_names:
+                raw_value = row.get(name)
+                if raw_value is None or raw_value == "":
+                    raise ValueError(f"Malformed CSV value at row={row_idx}, column={name!r}: empty value")
+                try:
+                    parsed_row.append(float(raw_value))
+                except ValueError as exc:
+                    raise ValueError(f"Malformed CSV value at row={row_idx}, column={name!r}: {raw_value!r}") from exc
+            rows.append(parsed_row)
+
+    if not rows:
+        raise ValueError(f"CSV has no data rows: {path}")
+
+    return torch.tensor(rows, dtype=torch.float32)
+
+
+def _split_bounds(length: int, split: str) -> tuple[int, int]:
+    train_end = int(length * 0.7)
+    val_end = int(length * 0.8)
+    if split == "train":
+        return 0, train_end
+    if split == "val":
+        return train_end, val_end
+    if split == "test":
+        return val_end, length
+    raise ValueError(f"Unsupported split: {split}")
+
+
+def load_dataset_matrix(dataset_root: Path, dataset_name: str, split: str) -> torch.Tensor:
+    if dataset_name not in FORECAST_DATASET_FILES:
+        raise ValueError(f"Unsupported dataset: {dataset_name}")
+    matrix = _load_csv_matrix(dataset_root / FORECAST_DATASET_FILES[dataset_name])
+    start, end = _split_bounds(matrix.shape[0], split)
+    return matrix[start:end]
+
+
+def make_windows(
+    matrix: torch.Tensor,
+    context_length: int,
+    prediction_length: int,
+    max_windows: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    total = context_length + prediction_length
+    if matrix.shape[0] < total:
+        raise ValueError(
+            "Dataset split does not contain enough rows for requested workload. "
+            f"rows={matrix.shape[0]}, required={total}, context={context_length}, prediction={prediction_length}"
+        )
+
+    starts = list(range(0, matrix.shape[0] - total + 1))[:max_windows]
+    past = [matrix[start : start + context_length] for start in starts]
+    future = [matrix[start + context_length : start + total] for start in starts]
+    return torch.stack(past, dim=0), torch.stack(future, dim=0)
+
+
+def _split_archive_series_for_forecast(
+    series_tensor: torch.Tensor,
+    *,
+    context_length: int,
+    prediction_length: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    total = int(context_length) + int(prediction_length)
+    sequence_length = int(series_tensor.shape[1])
+    if total <= 0:
+        raise ValueError(
+            f"context_length + prediction_length must be > 0 for archive-backed forecast windows, got total={total}"
+        )
+    if sequence_length < total:
+        raise ValueError(
+            "Archive dataset sequence length does not contain enough timesteps for the requested forecast window. "
+            f"dataset_seq_len={sequence_length}, required={total}, context_length={context_length}, "
+            f"prediction_length={prediction_length}"
+        )
+    return (
+        series_tensor[:, :context_length, :].contiguous(),
+        series_tensor[:, context_length:total, :].contiguous(),
+    )
+
+
+def build_observed_mask(values: torch.Tensor) -> torch.Tensor:
+    return torch.ones_like(values, dtype=torch.float32)
+
+
+def _parse_ts_metadata_line(metadata: dict[str, object], line: str) -> None:
+    lowered = line.lower()
+    if lowered.startswith("@problemname"):
+        metadata["problem_name"] = line.split(maxsplit=1)[1].strip()
+    elif lowered.startswith("@timestamps"):
+        metadata["timestamps"] = line.split(maxsplit=1)[1].strip().lower() == "true"
+    elif lowered.startswith("@missing"):
+        metadata["missing"] = line.split(maxsplit=1)[1].strip().lower() == "true"
+    elif lowered.startswith("@univariate"):
+        metadata["univariate"] = line.split(maxsplit=1)[1].strip().lower() == "true"
+    elif lowered.startswith("@dimensions"):
+        metadata["dimensions"] = int(line.split(maxsplit=1)[1].strip())
+    elif lowered.startswith("@equallength"):
+        metadata["equal_length"] = line.split(maxsplit=1)[1].strip().lower() == "true"
+    elif lowered.startswith("@serieslength"):
+        metadata["series_length"] = int(line.split(maxsplit=1)[1].strip())
+    elif lowered.startswith("@classlabel"):
+        parts = line.split()
+        metadata["class_label"] = parts[1].lower() == "true"
+        metadata["class_names"] = parts[2:]
+    elif lowered.startswith("@targetlabel"):
+        parts = line.split()
+        metadata["target_label"] = parts[1].lower() == "true"
+
+
+def _parse_ts_series_token(token: str) -> list[float]:
+    values = []
+    for raw_value in token.split(","):
+        raw_value = raw_value.strip()
+        if raw_value == "":
+            continue
+        if raw_value == "?":
+            raise ValueError("Missing values in .ts archives are not supported in this PatchTST demo.")
+        values.append(float(raw_value))
+    if not values:
+        raise ValueError("Encountered empty series token in .ts archive.")
+    return values
+
+
+def _load_archive_ts_dataset(
+    path: Path,
+) -> tuple[torch.Tensor, torch.Tensor, Literal["classification", "regression"]]:
+    if not path.exists():
+        raise FileNotFoundError(f"Task dataset file not found: {path}")
+
+    metadata: dict[str, object] = {
+        "timestamps": False,
+        "missing": False,
+        "univariate": True,
+        "equal_length": False,
+        "class_label": False,
+        "target_label": False,
+        "class_names": [],
+    }
+    data_started = False
+    series_rows: list[list[list[float]]] = []
+    targets_raw: list[str] = []
+
+    with path.open("r", encoding="utf-8") as handle:
+        for raw_line in handle:
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if not data_started:
+                if line.lower().startswith("@data"):
+                    data_started = True
+                    continue
+                _parse_ts_metadata_line(metadata, line)
+                continue
+
+            parts = [part.strip() for part in line.split(":")]
+            has_class_label = bool(metadata["class_label"])
+            has_target_label = bool(metadata["target_label"])
+            if has_class_label == has_target_label:
+                raise ValueError(
+                    "Task .ts archive must declare exactly one of @classLabel or @targetLabel for this PatchTST demo."
+                )
+            if len(parts) < 2:
+                raise ValueError(f"Malformed .ts sample in {path}: expected data and label/target")
+
+            targets_raw.append(parts[-1])
+            dimension_tokens = parts[:-1]
+            if bool(metadata["univariate"]) and len(dimension_tokens) != 1:
+                raise ValueError(f"Univariate .ts sample in {path} provided {len(dimension_tokens)} dimensions")
+            series_rows.append([_parse_ts_series_token(token) for token in dimension_tokens])
+
+    if not data_started or not series_rows:
+        raise ValueError(f"Task .ts archive {path} did not contain any samples after @data")
+    if bool(metadata["timestamps"]):
+        raise ValueError("Timestamped .ts archives are not supported in this PatchTST demo.")
+    if not bool(metadata["equal_length"]):
+        raise ValueError("Variable-length .ts archives are not supported in this PatchTST demo.")
+
+    num_channels = len(series_rows[0])
+    sequence_length = len(series_rows[0][0])
+    for sample_idx, sample in enumerate(series_rows):
+        if len(sample) != num_channels:
+            raise ValueError(
+                f"Inconsistent channel count in {path}: sample 0 has {num_channels}, sample {sample_idx} has {len(sample)}"
+            )
+        for channel_idx, channel_values in enumerate(sample):
+            if len(channel_values) != sequence_length:
+                raise ValueError(
+                    f"Inconsistent sequence length in {path}: expected {sequence_length}, "
+                    f"sample={sample_idx}, channel={channel_idx}, got {len(channel_values)}"
+                )
+
+    series_tensor = torch.tensor(series_rows, dtype=torch.float32).permute(0, 2, 1).contiguous()
+
+    if bool(metadata["class_label"]):
+        label_names = list(metadata.get("class_names", [])) or sorted(set(targets_raw))
+        label_to_index = {name: idx for idx, name in enumerate(label_names)}
+        try:
+            targets = torch.tensor([label_to_index[label] for label in targets_raw], dtype=torch.long)
+        except KeyError as error:
+            raise ValueError(f"Encountered unseen class label {error.args[0]!r} in {path}") from error
+        return series_tensor, targets, "classification"
+
+    targets = torch.tensor([[float(value)] for value in targets_raw], dtype=torch.float32)
+    return series_tensor, targets, "regression"
+
+
+def load_task_dataset(
+    dataset_root: Path,
+    dataset_name: str,
+    split: str,
+    task: str,
+    context_length: int,
+    prediction_length: int,
+    max_windows: int,
+) -> TaskDatasetBatch:
+    if task in {"forecast", "pretraining"} and dataset_name in FORECAST_DATASET_FILES:
+        matrix = load_dataset_matrix(dataset_root=dataset_root, dataset_name=dataset_name, split=split)
+        past_values, future_values = make_windows(
+            matrix=matrix,
+            context_length=context_length,
+            prediction_length=prediction_length,
+            max_windows=max_windows,
+        )
+        return TaskDatasetBatch(
+            past_values=past_values,
+            future_values=future_values,
+            target_values=None,
+        )
+
+    if task == "forecast" and dataset_name in ARCHIVE_DATASET_FILES:
+        if split not in {"train", "test"}:
+            raise ValueError(f"Archive-backed forecast split must be 'train' or 'test', got {split!r}")
+        spec = ARCHIVE_DATASET_FILES[dataset_name]
+        archive_path = dataset_root / (spec.train_file if split == "train" else spec.test_file)
+        series_tensor, _, _ = _load_archive_ts_dataset(archive_path)
+        past_values, future_values = _split_archive_series_for_forecast(
+            series_tensor,
+            context_length=context_length,
+            prediction_length=prediction_length,
+        )
+        if max_windows > 0:
+            past_values = past_values[:max_windows]
+            future_values = future_values[:max_windows]
+        return TaskDatasetBatch(
+            past_values=past_values,
+            future_values=future_values,
+            target_values=None,
+        )
+
+    if task == "multi_task":
+        if dataset_name not in ARCHIVE_DATASET_FILES or ARCHIVE_DATASET_FILES[dataset_name].task != "classification":
+            raise ValueError(
+                f"Task {task!r} requires a real classification dataset so the same input carries both forecast and class targets, got {dataset_name!r}"
+            )
+        if split not in {"train", "test"}:
+            raise ValueError(f"Archive-backed multi_task split must be 'train' or 'test', got {split!r}")
+        spec = ARCHIVE_DATASET_FILES[dataset_name]
+        archive_path = dataset_root / (spec.train_file if split == "train" else spec.test_file)
+        series_tensor, target_values, _ = _load_archive_ts_dataset(archive_path)
+        past_values, future_values = _split_archive_series_for_forecast(
+            series_tensor,
+            context_length=context_length,
+            prediction_length=prediction_length,
+        )
+        if max_windows > 0:
+            past_values = past_values[:max_windows]
+            future_values = future_values[:max_windows]
+            target_values = target_values[:max_windows]
+        return TaskDatasetBatch(
+            past_values=past_values,
+            future_values=future_values,
+            target_values=target_values,
+        )
+
+    if task not in {"classification", "regression"}:
+        raise ValueError(f"Unsupported task: {task}")
+    if dataset_name not in ARCHIVE_DATASET_FILES or ARCHIVE_DATASET_FILES[dataset_name].task != task:
+        raise ValueError(f"Task {task!r} requires a {task} dataset, got {dataset_name!r}")
+    if split not in {"train", "test"}:
+        raise ValueError(f"Task dataset split must be 'train' or 'test', got {split!r}")
+
+    spec = ARCHIVE_DATASET_FILES[dataset_name]
+    archive_path = dataset_root / (spec.train_file if split == "train" else spec.test_file)
+    past_values, target_values, _ = _load_archive_ts_dataset(archive_path)
+    if context_length > 0 and int(past_values.shape[1]) < context_length:
+        raise ValueError(
+            "Task dataset sequence length does not match the checkpoint/runtime context length. "
+            f"dataset_seq_len={past_values.shape[1]}, context_length={context_length}"
+        )
+    if context_length > 0:
+        # Classification/regression checkpoints used in the public demo may intentionally consume
+        # a prefix window of a longer labeled sequence so they can share the same input contract as
+        # the forecast path. Truncate explicitly here instead of requiring exact sequence-length equality.
+        past_values = past_values[:, :context_length, :].contiguous()
+    if max_windows > 0:
+        past_values = past_values[:max_windows]
+        target_values = target_values[:max_windows]
+    return TaskDatasetBatch(
+        past_values=past_values,
+        future_values=None,
+        target_values=target_values,
+    )

--- a/models/demos/wormhole/patchtst/demo/demo.py
+++ b/models/demos/wormhole/patchtst/demo/demo.py
@@ -1,0 +1,159 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from models.demos.wormhole.patchtst.config import PatchTSTDemoConfig, merge_demo_config
+from models.demos.wormhole.patchtst.demo.data_utils import ARCHIVE_DATASET_FILES, FORECAST_DATASET_FILES
+from models.demos.wormhole.patchtst.demo.runner import run_patchtst, run_streaming_forecast
+from models.demos.wormhole.patchtst.reference.finetune import run_reference_finetune
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="PatchTST demo runner")
+    subparsers = parser.add_subparsers(dest="command")
+
+    run_parser = subparsers.add_parser("run", help="Run PatchTST on one workload.")
+    run_dataset_choices = list((*FORECAST_DATASET_FILES.keys(), *ARCHIVE_DATASET_FILES.keys()))
+    run_parser.add_argument(
+        "--task",
+        choices=["forecast", "regression", "pretraining", "classification", "multi_task"],
+        default="forecast",
+    )
+    run_parser.add_argument("--channel-mode", choices=["independent", "attention"], default="independent")
+    run_parser.add_argument("--share-embedding", choices=["true", "false"], default="true")
+    run_parser.add_argument("--dataset", choices=run_dataset_choices, default=run_dataset_choices[0])
+    run_parser.add_argument("--dataset-root", type=Path, default=Path("data/patchtst"))
+    run_parser.add_argument("--trace", action="store_true")
+    run_parser.add_argument("--batch-size", type=int, default=1)
+    run_parser.add_argument("--max-windows", type=int, default=64)
+    run_parser.add_argument("--context-length", type=int, default=512)
+
+    streaming_parser = subparsers.add_parser(
+        "streaming",
+        help="Run stateful online forecasting with either cached or legacy full-rerun streaming semantics.",
+    )
+    streaming_dataset_choices = ["etth1", "weather", "traffic", "electricity", "exchange_rate"]
+    streaming_parser.add_argument(
+        "--dataset",
+        choices=streaming_dataset_choices,
+        default=streaming_dataset_choices[0],
+    )
+    streaming_parser.add_argument("--dataset-root", type=Path, default=Path("data/patchtst"))
+    streaming_parser.add_argument("--trace", action="store_true")
+    streaming_parser.add_argument("--streaming-mode", choices=["cached", "full-rerun"], default="cached")
+    streaming_parser.add_argument("--stream-steps", type=int, default=4)
+
+    finetune_parser = subparsers.add_parser(
+        "finetune",
+        help="Generate a dataset-matched reference checkpoint for forecast/classification/regression.",
+    )
+    finetune_dataset_choices = [
+        "etth1",
+        "weather",
+        "traffic",
+        "electricity",
+        "exchange_rate",
+        "heartbeat_cls",
+        "flood_modeling1_reg",
+    ]
+    finetune_parser.add_argument("--task", choices=["forecast", "classification", "regression"], default="forecast")
+    finetune_parser.add_argument("--channel-mode", choices=["independent", "attention"], default="independent")
+    finetune_parser.add_argument(
+        "--dataset",
+        choices=finetune_dataset_choices,
+        default=finetune_dataset_choices[0],
+    )
+    finetune_parser.add_argument("--dataset-root", type=Path, default=Path("data/patchtst"))
+    finetune_parser.add_argument("--steps", type=int, default=20)
+    finetune_parser.add_argument("--batch-size", type=int, default=4)
+    finetune_parser.add_argument("--context-length", type=int, default=512)
+    finetune_parser.add_argument("--prediction-length", type=int, default=96)
+    finetune_parser.add_argument("--learning-rate", type=float, default=1e-4)
+    finetune_parser.add_argument("--seed", type=int, default=1337)
+    finetune_parser.add_argument("--checkpoint-id-override", type=str, default=None)
+    finetune_parser.add_argument("--checkpoint-revision-override", type=str, default=None)
+    finetune_parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("models/demos/wormhole/patchtst/artifacts/finetune/reference_ckpt"),
+    )
+
+    return parser
+
+
+def main() -> None:
+    parser = _build_parser()
+    cli_args = sys.argv[1:]
+    if not cli_args:
+        cli_args = ["run"]
+    elif cli_args[0].startswith("-") and cli_args[0] not in {"-h", "--help"}:
+        cli_args = ["run", *cli_args]
+    args = parser.parse_args(cli_args)
+
+    if args.command == "run":
+        base = PatchTSTDemoConfig(task=args.task)
+        cfg = merge_demo_config(
+            base,
+            task=args.task,
+            channel_mode=args.channel_mode,
+            share_embedding=(args.share_embedding == "true"),
+            dataset=args.dataset,
+            dataset_root=args.dataset_root,
+            use_trace=args.trace,
+            batch_size=args.batch_size,
+            max_windows=args.max_windows,
+            context_length=args.context_length,
+        )
+        prediction = run_patchtst(cfg)
+        print(prediction)
+        return
+
+    if args.command == "streaming":
+        cfg = merge_demo_config(
+            PatchTSTDemoConfig(task="forecast"),
+            task="forecast",
+            dataset=args.dataset,
+            dataset_root=args.dataset_root,
+            use_trace=args.trace,
+        )
+        prediction = run_streaming_forecast(
+            config=cfg,
+            stream_steps=args.stream_steps,
+            streaming_mode=args.streaming_mode,
+        )
+        print(prediction)
+        return
+
+    if args.command == "finetune":
+        cfg = merge_demo_config(
+            PatchTSTDemoConfig(task=args.task),
+            task=args.task,
+            channel_mode=args.channel_mode,
+            dataset=args.dataset,
+            dataset_root=args.dataset_root,
+            context_length=args.context_length,
+            prediction_length=args.prediction_length,
+            checkpoint_id_override=args.checkpoint_id_override,
+            checkpoint_revision_override=args.checkpoint_revision_override,
+        )
+        result = run_reference_finetune(
+            config=cfg,
+            steps=args.steps,
+            batch_size=args.batch_size,
+            learning_rate=args.learning_rate,
+            output_dir=args.output_dir,
+            seed=args.seed,
+        )
+        print(result)
+        return
+
+    raise ValueError(f"Unsupported command: {args.command}")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/demos/wormhole/patchtst/demo/runner.py
+++ b/models/demos/wormhole/patchtst/demo/runner.py
@@ -1,0 +1,320 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+import torch
+
+import ttnn
+from models.demos.wormhole.patchtst.config import PatchTSTDemoConfig, resolve_runtime_config
+from models.demos.wormhole.patchtst.demo.data_utils import build_observed_mask, load_dataset_matrix, load_task_dataset
+from models.demos.wormhole.patchtst.reference.hf_reference import (
+    adapt_reference_for_runtime_channels,
+    adapt_reference_for_runtime_context,
+    load_reference_model,
+)
+from models.demos.wormhole.patchtst.tt.common import (
+    DEFAULT_L1_SMALL_SIZE,
+    DEFAULT_NUM_COMMAND_QUEUES,
+    DEFAULT_TRACE_REGION_SIZE,
+    TT_DTYPE,
+    PatchTSTRuntimePolicy,
+    resolve_runtime_policy_for_workload,
+)
+from models.demos.wormhole.patchtst.tt.model import PatchTSTTTNNModel
+from models.demos.wormhole.patchtst.tt.streaming import CachedForecastStreamer, HostFullRerunPatchTSTStreamer
+
+_HOST_TORCH_THREADS_CONFIGURED = False
+
+
+@dataclass
+class TraceSession:
+    replay: Any
+    benchmark_replay: Any | None
+    materialize: Any
+    release: Any
+
+
+def _configure_host_torch_threads() -> None:
+    global _HOST_TORCH_THREADS_CONFIGURED
+    if _HOST_TORCH_THREADS_CONFIGURED:
+        return
+    # PatchTST still does a small amount of host preprocessing before the TT path. One host thread
+    # keeps that setup stable without exposing threadpool jitter to normal user runs.
+    torch.set_num_threads(1)
+    _HOST_TORCH_THREADS_CONFIGURED = True
+
+
+def _to_torch_prediction(prediction: Any) -> Any:
+    if isinstance(prediction, ttnn.Tensor):
+        return ttnn.to_torch(ttnn.from_device(prediction))
+    if isinstance(prediction, dict):
+        return {key: _to_torch_prediction(value) for key, value in prediction.items()}
+    return prediction
+
+
+def _build_trace_session(
+    model: PatchTSTTTNNModel,
+    past: torch.Tensor,
+    observed: torch.Tensor,
+    task: str,
+) -> TraceSession:
+    if task != "forecast":
+        raise ValueError("Trace replay is currently supported only for forecasting.")
+    if model.cfg.channel_mode != "independent":
+        raise ValueError("Trace replay currently supports channel_mode='independent' only.")
+
+    prepared = model.prepare_hidden_input(past_values=past, past_observed_mask=observed)
+    hidden_input_addr = prepared.hidden_state.buffer_address()
+    hidden_host = ttnn.from_torch(
+        ttnn.to_torch(ttnn.from_device(prepared.hidden_state)),
+        dtype=TT_DTYPE,
+        layout=ttnn.TILE_LAYOUT,
+    )
+
+    warm_output = model.forward_from_hidden_tt(prepared, task=task)
+    warm_output.release()
+    ttnn.synchronize_device(model.device)
+
+    trace_id = ttnn.begin_trace_capture(model.device, cq_id=0)
+    traced_output = model.forward_from_hidden_tt(prepared, task=task)
+    ttnn.end_trace_capture(model.device, trace_id, cq_id=0)
+    ttnn.synchronize_device(model.device)
+
+    if prepared.hidden_state.buffer_address() != hidden_input_addr:
+        raise RuntimeError("Trace input buffer address changed after capture; persistent address invariant failed.")
+
+    def _replay():
+        ttnn.copy_host_to_device_tensor(hidden_host, prepared.hidden_state, 1)
+        ttnn.execute_trace(model.device, trace_id, cq_id=0, blocking=False)
+        ttnn.synchronize_device(model.device)
+        return None
+
+    def _materialize():
+        traced_output.prediction = _to_torch_prediction(traced_output.prediction)
+        if isinstance(traced_output.prediction, torch.Tensor):
+            traced_output.prediction = traced_output.prediction * prepared.scale + prepared.loc
+        return traced_output
+
+    def _release():
+        ttnn.release_trace(model.device, trace_id)
+        prepared.release()
+        ttnn.deallocate(hidden_host)
+
+    return TraceSession(replay=_replay, benchmark_replay=None, materialize=_materialize, release=_release)
+
+
+def run_patchtst(
+    demo_config: PatchTSTDemoConfig,
+    runtime_policy: PatchTSTRuntimePolicy | None = None,
+):
+    if ttnn.GetNumAvailableDevices() < 1:
+        raise RuntimeError("No Tenstorrent device available.")
+
+    _configure_host_torch_threads()
+    if demo_config.task == "multi_task":
+        reference = load_reference_model(
+            "forecast",
+            demo_config.multi_task_checkpoint_ids["forecast"],
+            demo_config,
+            demo_config.multi_task_checkpoint_revisions["forecast"],
+        )
+        classification_reference = load_reference_model(
+            "classification",
+            demo_config.multi_task_checkpoint_ids["classification"],
+            demo_config,
+            demo_config.multi_task_checkpoint_revisions["classification"],
+        )
+    else:
+        reference = load_reference_model(
+            demo_config.task,
+            demo_config.effective_checkpoint_id(),
+            demo_config,
+            demo_config.effective_checkpoint_revision(),
+        )
+        classification_reference = None
+    runtime_cfg = resolve_runtime_config(demo_config, reference.config)
+    if int(reference.config.context_length) != int(runtime_cfg.context_length):
+        if not runtime_cfg.allow_reference_context_adaptation:
+            raise ValueError(
+                "Runtime context differs from the checkpoint context, but this run requires a native context-shaped checkpoint. "
+                f"runtime_context={runtime_cfg.context_length}, checkpoint_context={reference.config.context_length}, "
+                f"checkpoint_id={reference.checkpoint_id}"
+            )
+        adapt_reference_for_runtime_context(reference, runtime_cfg.context_length)
+    task_batch = load_task_dataset(
+        runtime_cfg.dataset_root,
+        runtime_cfg.dataset,
+        runtime_cfg.split,
+        runtime_cfg.task,
+        runtime_cfg.context_length,
+        runtime_cfg.prediction_length,
+        runtime_cfg.max_windows,
+    )
+    batch_start = int(runtime_cfg.window_offset)
+    batch_end = batch_start + int(runtime_cfg.batch_size)
+    past = task_batch.past_values[batch_start:batch_end]
+    future = None if task_batch.future_values is None else task_batch.future_values[batch_start:batch_end]
+    target_values = None if task_batch.target_values is None else task_batch.target_values[batch_start:batch_end]
+    if int(past.shape[0]) < runtime_cfg.batch_size:
+        raise ValueError(
+            "Dataset split does not contain enough task samples for requested batch size. "
+            f"samples={task_batch.past_values.shape[0]}, batch_size={runtime_cfg.batch_size}, window_offset={batch_start}"
+        )
+    input_channels = int(past.shape[-1])
+    checkpoint_channels = int(reference.config.num_input_channels)
+    if input_channels != checkpoint_channels:
+        if reference.task in {"forecast", "pretraining"} and runtime_cfg.allow_reference_channel_adaptation:
+            adapt_reference_for_runtime_channels(reference, input_channels)
+            checkpoint_channels = int(reference.config.num_input_channels)
+        elif reference.task in {"forecast", "pretraining"}:
+            raise ValueError(
+                "Runtime channel count differs from the checkpoint channel count, but this run requires a native channel-shaped checkpoint. "
+                f"input_channels={input_channels}, checkpoint_channels={checkpoint_channels}, checkpoint_id={reference.checkpoint_id}"
+            )
+    assert input_channels == checkpoint_channels, (
+        "Input channel count does not match checkpoint channel count. "
+        f"input_channels={input_channels}, checkpoint_channels={checkpoint_channels}"
+    )
+    if future is not None:
+        assert int(future.shape[-1]) == checkpoint_channels, (
+            "Input channel count does not match checkpoint channel count. "
+            f"input_channels={int(future.shape[-1])}, checkpoint_channels={checkpoint_channels}"
+        )
+    if runtime_cfg.task == "forecast" and future is None:
+        raise ValueError("Forecast task requires future_values from the real forecasting dataset.")
+    if runtime_cfg.task in {"regression", "classification"} and target_values is None:
+        raise ValueError(f"{runtime_cfg.task.title()} task requires labeled targets from the dataset adapter.")
+    if runtime_cfg.task == "multi_task" and (future is None or target_values is None):
+        raise ValueError("Multi-task forecast+classification requires both future_values and class targets.")
+    observed = build_observed_mask(past)
+    runtime_policy = resolve_runtime_policy_for_workload(runtime_policy, input_channels)
+
+    # The demo owns only the runtime path: load data, run the model once, return the prediction.
+    ttnn.CONFIG.throw_exception_on_fallback = True
+    device = ttnn.open_device(
+        device_id=0,
+        l1_small_size=DEFAULT_L1_SMALL_SIZE,
+        trace_region_size=DEFAULT_TRACE_REGION_SIZE,
+        num_command_queues=DEFAULT_NUM_COMMAND_QUEUES,
+    )
+    try:
+        model = PatchTSTTTNNModel(
+            demo_config=runtime_cfg,
+            reference=reference,
+            classification_reference=classification_reference,
+            device=device,
+            runtime_policy=runtime_policy,
+        )
+        try:
+            if runtime_cfg.use_trace:
+                session = _build_trace_session(model=model, past=past, observed=observed, task=runtime_cfg.task)
+                try:
+                    session.replay()
+                    output = session.materialize()
+                finally:
+                    session.release()
+            else:
+                if runtime_cfg.task == "multi_task":
+                    output = model.forward(past_values=past, past_observed_mask=observed, task="multi_task")
+                else:
+                    output = model.forward(
+                        past_values=past,
+                        past_observed_mask=observed,
+                        task=runtime_cfg.task,
+                    )
+            prediction = output.prediction
+            output.release()
+            return prediction
+        finally:
+            model.close()
+    finally:
+        ttnn.close_device(device)
+
+
+def run_streaming_forecast(
+    config: PatchTSTDemoConfig,
+    stream_steps: int,
+    runtime_policy: PatchTSTRuntimePolicy | None = None,
+    streaming_mode: Literal["cached", "full-rerun"] = "cached",
+):
+    _configure_host_torch_threads()
+    reference = load_reference_model(
+        "forecast",
+        config.checkpoint_for_task("forecast"),
+        config,
+        config.checkpoint_revision_for_task("forecast"),
+    )
+    runtime_cfg = resolve_runtime_config(config, reference.config)
+    matrix = load_dataset_matrix(
+        dataset_root=runtime_cfg.dataset_root,
+        dataset_name=runtime_cfg.dataset,
+        split=runtime_cfg.split,
+    )
+    required_rows = runtime_cfg.context_length + stream_steps
+    if matrix.shape[0] < required_rows:
+        raise ValueError(
+            "Dataset split does not contain enough rows for streaming run. "
+            f"rows={matrix.shape[0]}, required={required_rows}"
+        )
+
+    context = matrix[: runtime_cfg.context_length].unsqueeze(0)
+    stream_values = matrix[runtime_cfg.context_length : runtime_cfg.context_length + stream_steps].unsqueeze(0)
+    if int(context.shape[-1]) != int(reference.config.num_input_channels):
+        adapt_reference_for_runtime_channels(reference, runtime_num_channels=int(context.shape[-1]))
+    expected_channels = int(reference.config.num_input_channels)
+    assert int(context.shape[-1]) == expected_channels, (
+        "Input channel count does not match checkpoint channel count. "
+        f"input_channels={int(context.shape[-1])}, checkpoint_channels={expected_channels}"
+    )
+    assert int(stream_values.shape[-1]) == expected_channels, (
+        "Input channel count does not match checkpoint channel count. "
+        f"input_channels={int(stream_values.shape[-1])}, checkpoint_channels={expected_channels}"
+    )
+
+    ttnn.CONFIG.throw_exception_on_fallback = True
+    device = ttnn.open_device(
+        device_id=0,
+        l1_small_size=DEFAULT_L1_SMALL_SIZE,
+        trace_region_size=DEFAULT_TRACE_REGION_SIZE,
+        num_command_queues=DEFAULT_NUM_COMMAND_QUEUES,
+    )
+    try:
+        model = PatchTSTTTNNModel(
+            demo_config=runtime_cfg,
+            reference=reference,
+            device=device,
+            runtime_policy=runtime_policy or PatchTSTRuntimePolicy(),
+        )
+        try:
+            observed_mask = build_observed_mask(context)
+            if streaming_mode == "cached":
+                streamer = CachedForecastStreamer(
+                    model=model,
+                    initial_context=context,
+                    initial_observed_mask=observed_mask,
+                    use_trace=bool(runtime_cfg.use_trace),
+                )
+            else:
+                streamer = HostFullRerunPatchTSTStreamer(
+                    model=model,
+                    initial_context=context,
+                    initial_observed_mask=observed_mask,
+                )
+            try:
+                predictions = []
+                for step_idx in range(stream_steps):
+                    tick = stream_values[:, step_idx : step_idx + 1, :]
+                    predictions.append(streamer.step(tick))
+                return predictions
+            finally:
+                close = getattr(streamer, "close", None)
+                if callable(close):
+                    close()
+        finally:
+            model.close()
+    finally:
+        ttnn.close_device(device)

--- a/models/demos/wormhole/patchtst/reference/finetune.py
+++ b/models/demos/wormhole/patchtst/reference/finetune.py
@@ -1,0 +1,388 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+from transformers import PatchTSTConfig, PatchTSTForClassification, PatchTSTForPrediction, PatchTSTForRegression
+
+from models.demos.wormhole.patchtst.config import PatchTSTDemoConfig, merge_demo_config, resolve_runtime_config
+from models.demos.wormhole.patchtst.demo.data_utils import ARCHIVE_DATASET_FILES, build_observed_mask, load_task_dataset
+from models.demos.wormhole.patchtst.reference.hf_reference import (
+    adapt_reference_for_runtime_channels,
+    adapt_reference_for_runtime_context,
+    load_reference_model,
+)
+
+FORECAST_FINETUNE_TRAIN_WINDOWS_CAP = 256
+FORECAST_FINETUNE_PROGRESS_EVERY = 50
+
+
+def _validate_state_mapping(
+    missing_keys: list[str],
+    unexpected_keys: list[str],
+    *,
+    allowed_missing_prefix: str | None = None,
+    allowed_unexpected_prefix: str | None = None,
+    error_prefix: str,
+) -> None:
+    disallowed_missing = [
+        key for key in missing_keys if not allowed_missing_prefix or allowed_missing_prefix not in key
+    ]
+    disallowed_unexpected = [
+        key for key in unexpected_keys if not allowed_unexpected_prefix or not key.startswith(allowed_unexpected_prefix)
+    ]
+    if disallowed_missing or disallowed_unexpected:
+        raise RuntimeError(
+            f"{error_prefix} produced an unexpected state mapping. "
+            f"missing_keys={disallowed_missing}, unexpected_keys={disallowed_unexpected}"
+        )
+
+
+def _initialize_model_from_attention_base(
+    task: str,
+    model: torch.nn.Module,
+    config: PatchTSTDemoConfig,
+) -> tuple[torch.nn.Module, str]:
+    if config.channel_mode != "attention":
+        return model, "scratch"
+
+    # Channel attention reuses the same attention weights and only adds the second norm block,
+    # so initializing from the matching independent checkpoint preserves task semantics.
+    base_cfg = PatchTSTDemoConfig(task=task)
+    if task in {"classification", "regression"}:
+        base_cfg = PatchTSTDemoConfig(task=task, dataset=config.dataset)
+    base_ckpt = base_cfg.checkpoint_for_task(task)
+    base_revision = base_cfg.checkpoint_revision_for_task(task)
+    if not Path(base_ckpt).exists() and base_revision == "local-generated":
+        return model, "scratch"
+
+    if Path(base_ckpt).exists():
+        base_model = (PatchTSTForClassification if task == "classification" else PatchTSTForRegression).from_pretrained(
+            base_ckpt
+        )
+    else:
+        base_model = (PatchTSTForClassification if task == "classification" else PatchTSTForRegression).from_pretrained(
+            base_ckpt, revision=base_revision
+        )
+    missing_keys, unexpected_keys = model.load_state_dict(base_model.state_dict(), strict=False)
+    _validate_state_mapping(
+        list(missing_keys),
+        list(unexpected_keys),
+        allowed_missing_prefix=".norm_sublayer2.batchnorm.",
+        error_prefix="Channel-attention initialization",
+    )
+    return model, base_ckpt
+
+
+def _load_forecast_bootstrap_reference(config: PatchTSTDemoConfig):
+    if config.checkpoint_id_override is None:
+        return None
+    bootstrap_cfg = merge_demo_config(
+        PatchTSTDemoConfig(task="forecast"),
+        task="forecast",
+        channel_mode=config.channel_mode,
+        dataset=config.dataset,
+        dataset_root=config.dataset_root,
+    )
+    return load_reference_model(
+        task="forecast",
+        checkpoint_id=config.checkpoint_id_override,
+        revision=config.checkpoint_revision_override or "local-generated",
+        config=bootstrap_cfg,
+    )
+
+
+def _build_supervised_patchtst_config(
+    task: str,
+    sequence_length: int,
+    num_channels: int,
+    num_targets: int,
+    channel_mode: str,
+    bootstrap_reference_config: PatchTSTConfig | None = None,
+) -> PatchTSTConfig:
+    if bootstrap_reference_config is not None:
+        common = bootstrap_reference_config.to_dict()
+        common.update(
+            context_length=sequence_length,
+            prediction_length=1,
+            num_input_channels=num_channels,
+            num_targets=num_targets,
+            channel_attention=(channel_mode == "attention"),
+        )
+        if task == "regression":
+            common.update(distribution_output=None, loss="mse")
+        return PatchTSTConfig(**common)
+
+    patch_length = min(16, max(4, sequence_length // 8))
+    patch_stride = max(1, patch_length // 2)
+    if patch_length >= sequence_length:
+        patch_length = max(2, sequence_length - 1)
+        patch_stride = max(1, patch_length // 2)
+    common = dict(
+        context_length=sequence_length,
+        patch_length=patch_length,
+        patch_stride=patch_stride,
+        prediction_length=1,
+        num_input_channels=num_channels,
+        num_targets=num_targets,
+        d_model=128,
+        ffn_dim=512,
+        num_hidden_layers=3,
+        num_attention_heads=4,
+        share_embedding=True,
+        share_projection=True,
+        positional_encoding_type="sincos",
+        pooling_type="mean",
+        norm_type="batchnorm",
+        pre_norm=True,
+        scaling="std",
+        use_cls_token=False,
+        channel_attention=(channel_mode == "attention"),
+    )
+    if task == "regression":
+        common.update(distribution_output=None, loss="mse")
+    return PatchTSTConfig(**common)
+
+
+def _fit_supervised_reference(
+    task: str,
+    config: PatchTSTDemoConfig,
+    steps: int,
+    batch_size: int,
+    learning_rate: float,
+    output_dir: Path,
+    seed: int,
+) -> Path:
+    if config.dataset not in ARCHIVE_DATASET_FILES or ARCHIVE_DATASET_FILES[config.dataset].task != task:
+        raise ValueError(f"Task {task!r} requires a matching real-task dataset, got {config.dataset!r}.")
+
+    default_context_length = PatchTSTDemoConfig(task=task, dataset=config.dataset).context_length
+    requested_context_length = (
+        0 if int(config.context_length) == int(default_context_length) else int(config.context_length)
+    )
+    torch.manual_seed(seed)
+    train_batch = load_task_dataset(
+        dataset_root=config.dataset_root,
+        dataset_name=config.dataset,
+        split="train",
+        task=task,
+        context_length=requested_context_length,
+        prediction_length=1,
+        max_windows=0,
+    )
+    if train_batch.target_values is None:
+        raise ValueError(f"Task {task!r} dataset loader did not return labels/targets.")
+
+    sequence_length = int(train_batch.past_values.shape[1])
+    num_channels = int(train_batch.past_values.shape[2])
+    num_targets = (
+        int(train_batch.target_values.max().item()) + 1
+        if task == "classification"
+        else int(train_batch.target_values.shape[-1] if train_batch.target_values.ndim > 1 else 1)
+    )
+    bootstrap_reference = _load_forecast_bootstrap_reference(config)
+    model_config = _build_supervised_patchtst_config(
+        task=task,
+        sequence_length=sequence_length,
+        num_channels=num_channels,
+        num_targets=num_targets,
+        channel_mode=config.channel_mode,
+        bootstrap_reference_config=(bootstrap_reference.config if bootstrap_reference is not None else None),
+    )
+    model_cls = PatchTSTForClassification if task == "classification" else PatchTSTForRegression
+    model = model_cls(model_config)
+    if bootstrap_reference is not None:
+        missing_keys, unexpected_keys = model.load_state_dict(bootstrap_reference.model.state_dict(), strict=False)
+        _validate_state_mapping(
+            list(missing_keys),
+            list(unexpected_keys),
+            allowed_missing_prefix="head.",
+            allowed_unexpected_prefix="head.",
+            error_prefix="Forecast-to-supervised encoder bootstrap",
+        )
+    else:
+        model, _ = _initialize_model_from_attention_base(
+            task=task,
+            model=model,
+            config=config,
+        )
+    encoder_frozen = False
+    if bootstrap_reference is not None and task == "classification":
+        # Public multi_task reuses the forecast encoder exactly and swaps only the classifier head.
+        # Freeze non-head parameters here so the exported classification checkpoint remains byte-identical
+        # on the shared encoder weights and passes the explicit compatibility check at load time.
+        for name, parameter in model.named_parameters():
+            if not name.startswith("head."):
+                parameter.requires_grad_(False)
+        encoder_frozen = True
+
+    model.train()
+    if encoder_frozen:
+        # BatchNorm running statistics would still drift in train() even when the parameters are frozen.
+        # Hold the shared backbone in eval mode so only the classifier head learns and the saved encoder
+        # remains exactly identical to the forecast checkpoint used for public multi_task runs.
+        model.model.patchifier.eval()
+        model.model.scaler.eval()
+        model.model.encoder.eval()
+        model.head.train()
+    optimizer = torch.optim.AdamW((param for param in model.parameters() if param.requires_grad), lr=learning_rate)
+    observed_mask = build_observed_mask(train_batch.past_values)
+
+    for step in range(steps):
+        start = (step * batch_size) % max(int(train_batch.past_values.shape[0]) - batch_size + 1, 1)
+        end = start + batch_size
+        outputs = model(
+            past_values=train_batch.past_values[start:end],
+            target_values=train_batch.target_values[start:end],
+            past_observed_mask=observed_mask[start:end],
+            return_dict=True,
+        )
+        loss = outputs.loss
+        if loss is None:
+            prediction_attr = "prediction_logits" if task == "classification" else "regression_outputs"
+            prediction = getattr(outputs, prediction_attr)
+            if task == "classification":
+                loss = F.cross_entropy(
+                    prediction.to(torch.float32), train_batch.target_values[start:end].to(torch.long)
+                )
+            else:
+                loss = F.mse_loss(prediction.to(torch.float32), train_batch.target_values[start:end].to(torch.float32))
+
+        optimizer.zero_grad(set_to_none=True)
+        loss.backward()
+        optimizer.step()
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    model.save_pretrained(output_dir)
+    return output_dir
+
+
+def run_reference_finetune(
+    config: PatchTSTDemoConfig,
+    steps: int,
+    batch_size: int,
+    learning_rate: float,
+    output_dir: Path,
+    seed: int = 1337,
+) -> Path:
+    if steps < 0:
+        raise ValueError("steps must be >= 0")
+    if batch_size <= 0:
+        raise ValueError("batch_size must be > 0")
+    if learning_rate <= 0:
+        raise ValueError("learning_rate must be > 0")
+
+    if config.task in {"classification", "regression"}:
+        return _fit_supervised_reference(
+            task=config.task,
+            config=config,
+            steps=steps,
+            batch_size=batch_size,
+            learning_rate=learning_rate,
+            output_dir=output_dir,
+            seed=seed,
+        )
+
+    if config.task != "forecast":
+        raise ValueError("Reference finetune supports only forecast, classification, and regression tasks.")
+
+    torch.manual_seed(seed)
+
+    if config.channel_mode == "attention":
+        base_cfg = merge_demo_config(config, channel_mode="independent")
+        reference = load_reference_model(
+            task="forecast",
+            checkpoint_id=base_cfg.checkpoint_for_task("forecast"),
+            revision=base_cfg.checkpoint_revision_for_task("forecast"),
+            config=base_cfg,
+        )
+        attention_config = reference.model.config.to_dict()
+        attention_config["channel_attention"] = True
+        attention_model = PatchTSTForPrediction(reference.model.config.__class__(**attention_config))
+        missing_keys, unexpected_keys = attention_model.load_state_dict(reference.model.state_dict(), strict=False)
+        _validate_state_mapping(
+            list(missing_keys),
+            list(unexpected_keys),
+            allowed_missing_prefix=".norm_sublayer2.batchnorm.",
+            error_prefix="Channel-attention initialization",
+        )
+        reference.model = attention_model
+        reference.config = attention_model.config
+    else:
+        reference = load_reference_model(
+            task="forecast",
+            checkpoint_id=config.effective_checkpoint_id("forecast"),
+            revision=config.effective_checkpoint_revision("forecast"),
+            config=config,
+        )
+    runtime_cfg = resolve_runtime_config(config, reference.config)
+    if int(reference.config.context_length) != int(runtime_cfg.context_length):
+        # Forecast stretch checkpoints are created by adapting the base reference once and then saving a real checkpoint at the target context.
+        adapt_reference_for_runtime_context(reference, runtime_context_length=runtime_cfg.context_length)
+
+    # Forecast checkpoint generation reuses a bounded rolling training pool instead of materializing
+    # `steps * batch_size` full windows. For 4096-step ETTh1 runs that naive strategy eagerly allocates
+    # thousands of 4096x7 windows and turns a simple local finetune command into a multi-hundred-MB preload.
+    # A capped pool keeps the command practical while the modulo step schedule still cycles the same real windows.
+    train_windows = min(max(batch_size * 8, batch_size), FORECAST_FINETUNE_TRAIN_WINDOWS_CAP)
+    train_batch = load_task_dataset(
+        dataset_root=runtime_cfg.dataset_root,
+        dataset_name=runtime_cfg.dataset,
+        split="train",
+        task="forecast",
+        context_length=runtime_cfg.context_length,
+        prediction_length=runtime_cfg.prediction_length,
+        max_windows=train_windows,
+    )
+    past_values = train_batch.past_values
+    future_values = train_batch.future_values
+    if future_values is None:
+        raise ValueError("Forecast fine-tuning requires future_values.")
+
+    runtime_dataset_channels = int(past_values.shape[-1])
+    if runtime_dataset_channels != int(reference.config.num_input_channels):
+        adapt_reference_for_runtime_channels(reference, runtime_num_channels=runtime_dataset_channels)
+    expected_channels = int(reference.config.num_input_channels)
+    assert int(past_values.shape[-1]) == expected_channels, (
+        "Input channel count does not match checkpoint channel count. "
+        f"input_channels={int(past_values.shape[-1])}, checkpoint_channels={expected_channels}"
+    )
+    assert int(future_values.shape[-1]) == expected_channels, (
+        "Input channel count does not match checkpoint channel count. "
+        f"input_channels={int(future_values.shape[-1])}, checkpoint_channels={expected_channels}"
+    )
+    observed_mask = build_observed_mask(past_values)
+
+    model = reference.model
+    model.train()
+    optimizer = torch.optim.AdamW(model.parameters(), lr=learning_rate)
+
+    for step in range(steps):
+        start = (step * batch_size) % max(int(past_values.shape[0]) - batch_size + 1, 1)
+        end = start + batch_size
+        outputs = model(
+            past_values=past_values[start:end],
+            future_values=future_values[start:end],
+            past_observed_mask=observed_mask[start:end],
+            return_dict=True,
+        )
+        prediction = outputs.prediction_outputs
+        loss = F.mse_loss(prediction.to(torch.float32), future_values[start:end].to(torch.float32))
+
+        optimizer.zero_grad(set_to_none=True)
+        loss.backward()
+        optimizer.step()
+        if (step + 1) % FORECAST_FINETUNE_PROGRESS_EVERY == 0 or step == 0 or step + 1 == steps:
+            print(
+                f"[patchtst-finetune] step={step + 1}/{steps} "
+                f"loss={loss.item():.6f} train_windows={int(past_values.shape[0])}",
+                flush=True,
+            )
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    model.save_pretrained(output_dir)
+    return output_dir

--- a/models/demos/wormhole/patchtst/reference/hf_reference.py
+++ b/models/demos/wormhole/patchtst/reference/hf_reference.py
@@ -1,0 +1,175 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+# Based on HuggingFace PatchTST and the PatchTST paper:
+# https://huggingface.co/docs/transformers/en/model_doc/patchtst
+# https://github.com/huggingface/transformers/tree/main/src/transformers/models/patchtst
+# https://arxiv.org/abs/2211.14730
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import torch
+from transformers import PatchTSTForClassification, PatchTSTForPrediction, PatchTSTForPretraining, PatchTSTForRegression
+from transformers.models.patchtst.modeling_patchtst import PatchTSTPositionalEncoding
+
+from models.demos.wormhole.patchtst.config import PatchTSTDemoConfig
+
+
+def _model_cls(task: str):
+    if task == "forecast":
+        return PatchTSTForPrediction
+    if task == "regression":
+        return PatchTSTForRegression
+    if task == "pretraining":
+        return PatchTSTForPretraining
+    if task == "classification":
+        return PatchTSTForClassification
+    raise ValueError(f"Unsupported task: {task}")
+
+
+@dataclass
+class ReferenceArtifacts:
+    model: torch.nn.Module
+    config: object
+    checkpoint_id: str
+    task: str
+
+
+def adapt_reference_for_runtime_context(artifacts: ReferenceArtifacts, runtime_context_length: int) -> bool:
+    reference_context = int(artifacts.config.context_length)
+    runtime_context_length = int(runtime_context_length)
+    if runtime_context_length == reference_context:
+        return False
+
+    if str(artifacts.config.positional_encoding_type) != "sincos":
+        raise ValueError(
+            "Runtime context differs from checkpoint context and positional encoding is not sincos. "
+            f"runtime_context={runtime_context_length}, checkpoint_context={reference_context}"
+        )
+
+    patchifier = artifacts.model.model.patchifier
+    patch_length = int(patchifier.patch_length)
+    patch_stride = int(patchifier.patch_stride)
+    if runtime_context_length <= patch_length:
+        raise ValueError(
+            f"runtime_context_length ({runtime_context_length}) must be greater than patch_length ({patch_length})."
+        )
+
+    num_patches = (runtime_context_length - patch_length) // patch_stride + 1
+    new_sequence_length = patch_length + patch_stride * (num_patches - 1)
+    sequence_start = runtime_context_length - new_sequence_length
+
+    artifacts.config.context_length = runtime_context_length
+    patchifier.sequence_length = runtime_context_length
+    patchifier.sequence_start = sequence_start
+    patchifier.num_patches = num_patches
+
+    encoder = artifacts.model.model.encoder
+    old_positional = encoder.positional_encoder
+    replacement_positional = PatchTSTPositionalEncoding(artifacts.config, num_patches=num_patches).to(
+        old_positional.position_enc.device
+    )
+    if hasattr(old_positional, "cls_token") and hasattr(replacement_positional, "cls_token"):
+        with torch.no_grad():
+            replacement_positional.cls_token.copy_(old_positional.cls_token)
+    encoder.positional_encoder = replacement_positional
+    return True
+
+
+def adapt_reference_for_runtime_channels(artifacts: ReferenceArtifacts, runtime_num_channels: int) -> bool:
+    reference_num_channels = int(artifacts.config.num_input_channels)
+    runtime_num_channels = int(runtime_num_channels)
+    if runtime_num_channels == reference_num_channels:
+        return False
+
+    if artifacts.task not in {"forecast", "pretraining"}:
+        raise ValueError(
+            "Runtime channel count differs from checkpoint channel count, and this task does not support safe "
+            f"channel adaptation. task={artifacts.task}, runtime_channels={runtime_num_channels}, "
+            f"checkpoint_channels={reference_num_channels}"
+        )
+
+    config_dict = artifacts.model.config.to_dict()
+    config_dict["num_input_channels"] = runtime_num_channels
+    adapted_config = artifacts.model.config.__class__(**config_dict)
+    adapted_model = _model_cls(artifacts.task)(adapted_config)
+
+    missing_keys, unexpected_keys = adapted_model.load_state_dict(artifacts.model.state_dict(), strict=False)
+    if missing_keys or unexpected_keys:
+        raise RuntimeError(
+            "Channel adaptation produced incompatible parameter mapping. "
+            f"missing_keys={missing_keys}, unexpected_keys={unexpected_keys}"
+        )
+
+    adapted_model.eval()
+    artifacts.model = adapted_model
+    artifacts.config = adapted_model.config
+    return True
+
+
+def load_reference_model(
+    task: str,
+    checkpoint_id: str | None = None,
+    config: PatchTSTDemoConfig | None = None,
+    revision: str | None = None,
+) -> ReferenceArtifacts:
+    if config is None:
+        config = PatchTSTDemoConfig(task=task)
+    if task == "multi_task":
+        raise ValueError("Use load_multi_task_references for multi_task wiring.")
+
+    ckpt = checkpoint_id or config.checkpoint_for_task(task)
+    resolved_revision = revision or config.checkpoint_revision_for_task(task)
+    # Classification and regression use locally generated task-matched checkpoints. Fail with an explicit
+    # setup error here instead of falling through to a confusing Hugging Face repo-id lookup.
+    if resolved_revision == "local-generated" and not Path(ckpt).exists():
+        channel_mode_hint = " --channel-mode attention" if config.channel_mode == "attention" else ""
+        override_hint = ""
+        if config.checkpoint_id_override is not None:
+            override_hint = (
+                " This run pins a local checkpoint override, so generate the exact dataset/context-matched checkpoint "
+                "with the documented `finetune` command before rerunning."
+            )
+        raise FileNotFoundError(
+            "Required local PatchTST checkpoint was not found: "
+            f"{ckpt}. Generate it with `python -m models.demos.wormhole.patchtst.demo.demo finetune --task {task}{channel_mode_hint}` "
+            f"after downloading the matching labeled dataset.{override_hint}"
+        )
+    model_cls = _model_cls(task)
+    model = (
+        model_cls.from_pretrained(ckpt)
+        if Path(ckpt).exists()
+        else model_cls.from_pretrained(ckpt, revision=resolved_revision)
+    )
+    model.eval()
+    return ReferenceArtifacts(model=model, config=model.config, checkpoint_id=ckpt, task=task)
+
+
+def reference_forward(
+    artifacts: ReferenceArtifacts,
+    past_values: torch.Tensor,
+    future_values: torch.Tensor | None = None,
+    target_values: torch.Tensor | None = None,
+    past_observed_mask: torch.Tensor | None = None,
+) -> torch.Tensor:
+    kwargs = {
+        "past_values": past_values,
+        "past_observed_mask": past_observed_mask,
+        "return_dict": True,
+    }
+    if artifacts.task == "forecast" and future_values is not None:
+        kwargs["future_values"] = future_values
+    if target_values is not None:
+        kwargs["target_values"] = target_values
+
+    with torch.no_grad():
+        outputs = artifacts.model(**kwargs)
+    if artifacts.task == "forecast":
+        return outputs.prediction_outputs
+    if artifacts.task == "regression":
+        return outputs.regression_outputs
+    if artifacts.task == "pretraining":
+        return outputs.prediction_output
+    return outputs.prediction_logits

--- a/models/demos/wormhole/patchtst/scripts/download_assets.py
+++ b/models/demos/wormhole/patchtst/scripts/download_assets.py
@@ -1,0 +1,191 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import time
+import urllib.request
+import zipfile
+from pathlib import Path
+
+from huggingface_hub import snapshot_download
+
+from models.demos.wormhole.patchtst.config import PatchTSTDemoConfig
+from models.demos.wormhole.patchtst.demo.data_utils import ARCHIVE_DATASET_FILES, FORECAST_DATASET_FILES
+
+DATASET_URLS = {
+    "etth1": (
+        "https://huggingface.co/datasets/thuml/Time-Series-Library/resolve/main/ETT-small/ETTh1.csv",
+        "https://raw.githubusercontent.com/zhouhaoyi/ETDataset/main/ETT-small/ETTh1.csv",
+    ),
+    "weather": ("https://huggingface.co/datasets/thuml/Time-Series-Library/resolve/main/weather/weather.csv", None),
+    "traffic": ("https://huggingface.co/datasets/thuml/Time-Series-Library/resolve/main/traffic/traffic.csv", None),
+    "electricity": (
+        "https://huggingface.co/datasets/thuml/Time-Series-Library/resolve/main/electricity/electricity.csv",
+        None,
+    ),
+    "exchange_rate": (
+        "https://huggingface.co/datasets/thuml/Time-Series-Library/resolve/main/exchange_rate/exchange_rate.csv",
+        None,
+    ),
+    "heartbeat_cls": ("https://www.timeseriesclassification.com/aeon-toolkit/Heartbeat.zip", None),
+    "flood_modeling1_reg": ("https://www.timeseriesclassification.com/aeon-toolkit/FloodModeling1.zip", None),
+}
+
+
+def _download(url: str, destination: Path, timeout_seconds: float, retries: int) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    last_error: Exception | None = None
+    for attempt in range(max(retries, 1)):
+        try:
+            with urllib.request.urlopen(url, timeout=timeout_seconds) as response:
+                destination.write_bytes(response.read())
+            return
+        except Exception as error:  # pragma: no cover
+            last_error = error
+            if attempt + 1 < max(retries, 1):
+                time.sleep(min(2**attempt, 8))
+    raise RuntimeError(f"Failed to download {url} after {max(retries, 1)} attempts: {last_error}") from last_error
+
+
+def _download_with_fallback(
+    primary_url: str,
+    fallback_url: str,
+    destination: Path,
+    timeout_seconds: float,
+    retries: int,
+) -> None:
+    try:
+        _download(primary_url, destination, timeout_seconds=timeout_seconds, retries=retries)
+    except Exception as primary_error:
+        print(f"Primary download failed for {destination.name}: {primary_error}; trying fallback URL.")
+        _download(fallback_url, destination, timeout_seconds=timeout_seconds, retries=retries)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _extract_archive_dataset(dataset_name: str, archive_path: Path, dataset_root: Path) -> list[Path]:
+    spec = ARCHIVE_DATASET_FILES[dataset_name]
+    extracted_paths: list[Path] = []
+    with zipfile.ZipFile(archive_path) as archive:
+        for relative_path in (spec.train_file, spec.test_file):
+            try:
+                payload = archive.read(relative_path.name)
+            except KeyError as error:
+                raise RuntimeError(
+                    f"Archive {archive_path} did not contain expected member {relative_path.name} for {dataset_name}"
+                ) from error
+            destination = dataset_root / relative_path
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            destination.write_bytes(payload)
+            extracted_paths.append(destination)
+    return extracted_paths
+
+
+def _parse_checksums(raw_checksums: list[str]) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for raw in raw_checksums:
+        if "=" not in raw:
+            raise ValueError(f"Invalid --checksum value {raw!r}; expected format dataset_name=sha256hex")
+        dataset_name, expected = raw.split("=", 1)
+        dataset_name = dataset_name.strip().lower()
+        expected = expected.strip().lower()
+        if dataset_name not in DATASET_URLS:
+            raise ValueError(f"Invalid checksum dataset key {dataset_name!r}")
+        if len(expected) != 64 or any(ch not in "0123456789abcdef" for ch in expected):
+            raise ValueError(f"Invalid sha256 checksum for {dataset_name!r}: {expected!r}")
+        result[dataset_name] = expected
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Download PatchTST demo datasets and checkpoints")
+    parser.add_argument("--dataset-root", type=Path, default=Path("data/patchtst"))
+    parser.add_argument("--checkpoint-root", type=Path, default=Path("models/demos/wormhole/patchtst/.hf_checkpoints"))
+    parser.add_argument(
+        "--datasets",
+        type=str,
+        nargs="+",
+        default=sorted(DATASET_URLS.keys()),
+        choices=sorted(DATASET_URLS.keys()),
+        help="Datasets to fetch into dataset-root.",
+    )
+    parser.add_argument("--timeout-seconds", type=float, default=120.0)
+    parser.add_argument("--retries", type=int, default=3)
+    parser.add_argument(
+        "--checksum",
+        action="append",
+        default=[],
+        help="Optional dataset checksum in dataset_name=sha256hex format. Can be repeated.",
+    )
+    args = parser.parse_args()
+
+    cfg = PatchTSTDemoConfig(dataset_root=args.dataset_root)
+    checksums = _parse_checksums(args.checksum)
+
+    downloaded_paths: list[Path] = []
+    for dataset_name in args.datasets:
+        primary_url, fallback_url = DATASET_URLS[dataset_name]
+        if dataset_name in ARCHIVE_DATASET_FILES:
+            destination = args.dataset_root / f"{dataset_name}.zip"
+            if fallback_url is None:
+                _download(primary_url, destination, timeout_seconds=args.timeout_seconds, retries=args.retries)
+            else:
+                _download_with_fallback(
+                    primary_url,
+                    fallback_url,
+                    destination,
+                    timeout_seconds=args.timeout_seconds,
+                    retries=args.retries,
+                )
+            extracted = _extract_archive_dataset(dataset_name, destination, args.dataset_root)
+            destination.unlink(missing_ok=True)
+            downloaded_paths.extend(extracted)
+        else:
+            destination = args.dataset_root / FORECAST_DATASET_FILES[dataset_name]
+            if fallback_url is None:
+                _download(primary_url, destination, timeout_seconds=args.timeout_seconds, retries=args.retries)
+            else:
+                _download_with_fallback(
+                    primary_url,
+                    fallback_url,
+                    destination,
+                    timeout_seconds=args.timeout_seconds,
+                    retries=args.retries,
+                )
+            if dataset_name in checksums:
+                observed = _sha256(destination)
+                expected = checksums[dataset_name]
+                if observed != expected:
+                    raise RuntimeError(
+                        f"Checksum mismatch for {dataset_name}: expected={expected}, observed={observed}"
+                    )
+            downloaded_paths.append(destination)
+
+    for task in ("forecast", "pretraining", "channel_attention"):
+        snapshot_download(
+            repo_id=cfg.checkpoint_ids[task],
+            repo_type="model",
+            revision=cfg.checkpoint_revisions[task],
+            local_dir=args.checkpoint_root / task,
+            local_dir_use_symlinks=False,
+        )
+
+    for path in downloaded_paths:
+        print(f"Downloaded dataset -> {path}")
+    print(f"Downloaded reference checkpoints -> {args.checkpoint_root}")
+    print(
+        "Generate real classification/regression checkpoints with `python -m models.demos.wormhole.patchtst.demo.demo finetune`."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/models/demos/wormhole/patchtst/scripts/download_assets.py
+++ b/models/demos/wormhole/patchtst/scripts/download_assets.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import os
 import time
 import urllib.request
 import zipfile
@@ -32,6 +33,11 @@ DATASET_URLS = {
     ),
     "heartbeat_cls": ("https://www.timeseriesclassification.com/aeon-toolkit/Heartbeat.zip", None),
     "flood_modeling1_reg": ("https://www.timeseriesclassification.com/aeon-toolkit/FloodModeling1.zip", None),
+}
+
+ARCHIVE_DOWNLOAD_FILES = {
+    "heartbeat_cls": Path("heartbeat_cls.zip"),
+    "flood_modeling1_reg": Path("flood_modeling1_reg.zip"),
 }
 
 
@@ -72,6 +78,23 @@ def _sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
+def _resolve_dataset_path(dataset_root: Path, relative_path: Path) -> Path:
+    base_directory = dataset_root.resolve(strict=False)
+    destination = (base_directory / relative_path).resolve(strict=False)
+    if os.path.commonpath([str(base_directory), str(destination)]) != str(base_directory):
+        raise RuntimeError(
+            f"Resolved path {destination} escapes dataset root {base_directory} for requested path {relative_path}"
+        )
+    return destination
+
+
+def _unlink_dataset_path(dataset_root: Path, relative_path: Path) -> None:
+    destination = _resolve_dataset_path(dataset_root, relative_path)
+    if destination.exists() and not destination.is_file():
+        raise RuntimeError(f"Refusing to remove non-file dataset path {destination}")
+    destination.unlink(missing_ok=True)
+
+
 def _extract_archive_dataset(dataset_name: str, archive_path: Path, dataset_root: Path) -> list[Path]:
     spec = ARCHIVE_DATASET_FILES[dataset_name]
     extracted_paths: list[Path] = []
@@ -83,7 +106,7 @@ def _extract_archive_dataset(dataset_name: str, archive_path: Path, dataset_root
                 raise RuntimeError(
                     f"Archive {archive_path} did not contain expected member {relative_path.name} for {dataset_name}"
                 ) from error
-            destination = dataset_root / relative_path
+            destination = _resolve_dataset_path(dataset_root, relative_path)
             destination.parent.mkdir(parents=True, exist_ok=True)
             destination.write_bytes(payload)
             extracted_paths.append(destination)
@@ -135,7 +158,8 @@ def main() -> None:
     for dataset_name in args.datasets:
         primary_url, fallback_url = DATASET_URLS[dataset_name]
         if dataset_name in ARCHIVE_DATASET_FILES:
-            destination = args.dataset_root / f"{dataset_name}.zip"
+            archive_relative_path = ARCHIVE_DOWNLOAD_FILES[dataset_name]
+            destination = _resolve_dataset_path(args.dataset_root, archive_relative_path)
             if fallback_url is None:
                 _download(primary_url, destination, timeout_seconds=args.timeout_seconds, retries=args.retries)
             else:
@@ -147,10 +171,10 @@ def main() -> None:
                     retries=args.retries,
                 )
             extracted = _extract_archive_dataset(dataset_name, destination, args.dataset_root)
-            destination.unlink(missing_ok=True)
+            _unlink_dataset_path(args.dataset_root, archive_relative_path)
             downloaded_paths.extend(extracted)
         else:
-            destination = args.dataset_root / FORECAST_DATASET_FILES[dataset_name]
+            destination = _resolve_dataset_path(args.dataset_root, FORECAST_DATASET_FILES[dataset_name])
             if fallback_url is None:
                 _download(primary_url, destination, timeout_seconds=args.timeout_seconds, retries=args.retries)
             else:

--- a/models/demos/wormhole/patchtst/tests/helpers.py
+++ b/models/demos/wormhole/patchtst/tests/helpers.py
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections import namedtuple
+
+import torch
+
+from models.demos.wormhole.patchtst.config import PatchTSTDemoConfig, resolve_runtime_config
+from models.demos.wormhole.patchtst.demo.data_utils import build_observed_mask, load_task_dataset
+from models.demos.wormhole.patchtst.reference.hf_reference import (
+    adapt_reference_for_runtime_channels,
+    adapt_reference_for_runtime_context,
+    load_reference_model,
+)
+
+PreparedRun = namedtuple(
+    "PreparedRun",
+    ["reference", "classification_reference", "runtime_cfg", "past", "future", "target_values", "observed"],
+)
+
+
+def compute_metrics(prediction: torch.Tensor, reference: torch.Tensor) -> dict[str, float]:
+    prediction = prediction.to(torch.float32)
+    reference = reference.to(torch.float32)
+    if not torch.isfinite(prediction).all():
+        raise ValueError("Prediction tensor contains NaN or Inf values.")
+    if not torch.isfinite(reference).all():
+        raise ValueError("Reference tensor contains NaN or Inf values.")
+    diff = prediction - reference
+    pred_flat = prediction.reshape(-1)
+    ref_flat = reference.reshape(-1)
+    fallback_corr = torch.clamp(
+        1.0 - (torch.mean(torch.abs(pred_flat - ref_flat)) / torch.clamp(torch.mean(torch.abs(ref_flat)), min=1.0)),
+        min=0.0,
+        max=1.0,
+    )
+    if pred_flat.numel() < 2:
+        corr = fallback_corr
+    else:
+        pred_centered = pred_flat - pred_flat.mean()
+        ref_centered = ref_flat - ref_flat.mean()
+        denom = torch.sqrt(torch.sum(pred_centered * pred_centered) * torch.sum(ref_centered * ref_centered))
+        corr = (
+            fallback_corr
+            if float(denom.item()) < 1e-12
+            else torch.clamp(torch.sum(pred_centered * ref_centered) / denom, min=-1.0, max=1.0)
+        )
+    return {
+        "mse": float(torch.mean(diff * diff).item()),
+        "mae": float(torch.mean(torch.abs(diff)).item()),
+        "correlation": float(corr.item()),
+    }
+
+
+def compute_classification_metrics(logits: torch.Tensor, target: torch.Tensor) -> dict[str, float]:
+    target = target.to(torch.long).reshape(-1)
+    prediction = torch.argmax(logits.to(torch.float32), dim=-1).reshape(-1)
+    if prediction.shape != target.shape:
+        raise ValueError(
+            "Classification logits and targets must produce the same flattened shape. "
+            f"logits={tuple(logits.shape)}, target={tuple(target.shape)}"
+        )
+    accuracy = float((prediction == target).to(torch.float32).mean().item())
+    max_class = int(max(prediction.max().item(), target.max().item())) if prediction.numel() > 0 else -1
+    f1_scores = []
+    for class_idx in range(max_class + 1):
+        pred_positive = prediction == class_idx
+        target_positive = target == class_idx
+        tp = int((pred_positive & target_positive).sum().item())
+        fp = int((pred_positive & ~target_positive).sum().item())
+        fn = int((~pred_positive & target_positive).sum().item())
+        denom = (2 * tp) + fp + fn
+        f1_scores.append(0.0 if denom == 0 else (2.0 * tp) / denom)
+    return {"accuracy": accuracy, "f1_macro": float(sum(f1_scores) / len(f1_scores) if f1_scores else 0.0)}
+
+
+def prepare_run(config: PatchTSTDemoConfig) -> PreparedRun:
+    reference = load_reference_model(
+        "forecast" if config.task == "multi_task" else config.task,
+        config.multi_task_checkpoint_ids["forecast"]
+        if config.task == "multi_task"
+        else config.effective_checkpoint_id(),
+        config,
+        config.multi_task_checkpoint_revisions["forecast"]
+        if config.task == "multi_task"
+        else config.effective_checkpoint_revision(),
+    )
+    classification_reference = (
+        load_reference_model(
+            "classification",
+            config.multi_task_checkpoint_ids["classification"],
+            config,
+            config.multi_task_checkpoint_revisions["classification"],
+        )
+        if config.task == "multi_task"
+        else None
+    )
+
+    runtime_cfg = resolve_runtime_config(config, reference.config)
+    if int(reference.config.context_length) != int(runtime_cfg.context_length):
+        if not runtime_cfg.allow_reference_context_adaptation:
+            raise ValueError(
+                "Runtime context differs from the checkpoint context, but this run requires a native context-shaped checkpoint. "
+                f"runtime_context={runtime_cfg.context_length}, checkpoint_context={reference.config.context_length}, "
+                f"checkpoint_id={reference.checkpoint_id}"
+            )
+        adapt_reference_for_runtime_context(reference, runtime_context_length=runtime_cfg.context_length)
+
+    task_batch = load_task_dataset(
+        dataset_root=runtime_cfg.dataset_root,
+        dataset_name=runtime_cfg.dataset,
+        split=runtime_cfg.split,
+        task=runtime_cfg.task,
+        context_length=runtime_cfg.context_length,
+        prediction_length=runtime_cfg.prediction_length,
+        max_windows=runtime_cfg.max_windows,
+    )
+    batch_start = int(runtime_cfg.window_offset)
+    batch_end = batch_start + int(runtime_cfg.batch_size)
+    past = task_batch.past_values[batch_start:batch_end]
+    future = task_batch.future_values[batch_start:batch_end] if task_batch.future_values is not None else None
+    target_values = task_batch.target_values[batch_start:batch_end] if task_batch.target_values is not None else None
+    if int(past.shape[0]) < runtime_cfg.batch_size:
+        raise ValueError(
+            "Dataset split does not contain enough task samples for requested batch size. "
+            f"samples={task_batch.past_values.shape[0]}, batch_size={runtime_cfg.batch_size}, window_offset={batch_start}"
+        )
+
+    dataset_channels = int(past.shape[-1])
+    expected_channels = int(reference.config.num_input_channels)
+    if dataset_channels != expected_channels:
+        if reference.task in {"forecast", "pretraining"} and runtime_cfg.allow_reference_channel_adaptation:
+            adapt_reference_for_runtime_channels(reference, runtime_num_channels=dataset_channels)
+            expected_channels = int(reference.config.num_input_channels)
+        elif reference.task in {"forecast", "pretraining"}:
+            raise ValueError(
+                "Runtime channel count differs from the checkpoint channel count, but this run requires a native channel-shaped checkpoint. "
+                f"input_channels={dataset_channels}, checkpoint_channels={expected_channels}, checkpoint_id={reference.checkpoint_id}"
+            )
+
+    assert int(past.shape[-1]) == expected_channels, (
+        "Input channel count does not match checkpoint channel count. "
+        f"input_channels={int(past.shape[-1])}, checkpoint_channels={expected_channels}"
+    )
+    if future is not None:
+        assert int(future.shape[-1]) == expected_channels, (
+            "Input channel count does not match checkpoint channel count. "
+            f"input_channels={int(future.shape[-1])}, checkpoint_channels={expected_channels}"
+        )
+    if runtime_cfg.task == "forecast" and future is None:
+        raise ValueError("Forecast task requires future_values from the real forecasting dataset.")
+    if runtime_cfg.task in {"regression", "classification"} and target_values is None:
+        raise ValueError(f"{runtime_cfg.task.title()} task requires labeled targets from the dataset adapter.")
+    if runtime_cfg.task == "multi_task" and (future is None or target_values is None):
+        raise ValueError("Multi-task forecast+classification requires both future_values and class targets.")
+    return PreparedRun(
+        reference, classification_reference, runtime_cfg, past, future, target_values, build_observed_mask(past)
+    )

--- a/models/demos/wormhole/patchtst/tests/integration/test_public_tasks.py
+++ b/models/demos/wormhole/patchtst/tests/integration/test_public_tasks.py
@@ -1,0 +1,187 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+from models.demos.wormhole.patchtst.config import PatchTSTDemoConfig, merge_demo_config
+from models.demos.wormhole.patchtst.demo.runner import run_patchtst
+from models.demos.wormhole.patchtst.reference.hf_reference import reference_forward
+from models.demos.wormhole.patchtst.tests.helpers import compute_classification_metrics, compute_metrics, prepare_run
+
+PARITY_CORRELATION = 0.90
+PRETRAINING_PARITY_CORRELATION = 0.75
+QUALITY_DELTA_RATIO = 0.05
+
+
+def _cfg(task: str = "forecast", **overrides) -> PatchTSTDemoConfig:
+    defaults = {"task": task, "strict_fallback": True, "dataset": "etth1", "batch_size": 1, "max_windows": 64}
+    defaults.update(overrides)
+    return merge_demo_config(PatchTSTDemoConfig(task=defaults["task"]), **defaults)
+
+
+@pytest.mark.timeout(600)
+@pytest.mark.parametrize(
+    ("task", "overrides"),
+    [
+        ("forecast", {}),
+        ("forecast", {"channel_mode": "attention", "batch_size": 4, "max_windows": 64}),
+        ("regression", {"dataset": "flood_modeling1_reg", "split": "test", "batch_size": 16, "max_windows": 64}),
+        (
+            "regression",
+            {
+                "dataset": "flood_modeling1_reg",
+                "split": "test",
+                "batch_size": 16,
+                "max_windows": 64,
+                "channel_mode": "attention",
+            },
+        ),
+        ("pretraining", {"batch_size": 4, "max_windows": 64}),
+        ("classification", {"dataset": "heartbeat_cls", "split": "test", "batch_size": 16, "max_windows": 64}),
+        (
+            "classification",
+            {
+                "dataset": "heartbeat_cls",
+                "split": "test",
+                "batch_size": 16,
+                "max_windows": 64,
+                "channel_mode": "attention",
+            },
+        ),
+    ],
+)
+def test_patchtst_public_task_correctness(task, overrides):
+    cfg = _cfg(task=task, **overrides)
+    prepared = prepare_run(cfg)
+    prediction = run_patchtst(cfg)
+    reference_prediction = reference_forward(
+        artifacts=prepared.reference,
+        past_values=prepared.past,
+        future_values=prepared.future,
+        target_values=prepared.target_values,
+        past_observed_mask=prepared.observed,
+    )
+
+    parity = compute_metrics(prediction, reference_prediction)
+    assert parity["correlation"] >= (PRETRAINING_PARITY_CORRELATION if task == "pretraining" else PARITY_CORRELATION)
+
+    if task == "classification":
+        metrics = compute_classification_metrics(prediction, prepared.target_values)
+        reference_metrics = compute_classification_metrics(reference_prediction, prepared.target_values)
+        assert abs(metrics["accuracy"] - reference_metrics["accuracy"]) <= 1e-6
+        assert abs(metrics["f1_macro"] - reference_metrics["f1_macro"]) <= 1e-6
+    elif task == "regression":
+        quality = compute_metrics(prediction, prepared.target_values)
+        reference_quality = compute_metrics(reference_prediction, prepared.target_values)
+        mse_delta = abs(quality["mse"] - reference_quality["mse"]) / max(reference_quality["mse"], 1e-8)
+        mae_delta = abs(quality["mae"] - reference_quality["mae"]) / max(reference_quality["mae"], 1e-8)
+        assert mse_delta <= QUALITY_DELTA_RATIO
+        assert mae_delta <= QUALITY_DELTA_RATIO
+
+
+@pytest.mark.timeout(600)
+def test_patchtst_native_long_context():
+    cfg = _cfg(
+        task="forecast",
+        split="train",
+        batch_size=4,
+        max_windows=16,
+        context_length=4096,
+        prediction_length=96,
+        checkpoint_id_override="models/demos/wormhole/patchtst/artifacts/finetune/forecast_long_context_etth1_4096_ckpt",
+        checkpoint_revision_override="local-generated",
+        allow_reference_context_adaptation=False,
+        allow_reference_channel_adaptation=False,
+    )
+    prepared = prepare_run(cfg)
+    prediction = run_patchtst(cfg)
+    reference_prediction = reference_forward(
+        artifacts=prepared.reference,
+        past_values=prepared.past,
+        future_values=prepared.future,
+        past_observed_mask=prepared.observed,
+    )
+    parity = compute_metrics(prediction, reference_prediction)
+    quality = compute_metrics(prediction, prepared.future)
+    reference_quality = compute_metrics(reference_prediction, prepared.future)
+    mse_delta = abs(quality["mse"] - reference_quality["mse"]) / max(reference_quality["mse"], 1e-8)
+    mae_delta = abs(quality["mae"] - reference_quality["mae"]) / max(reference_quality["mae"], 1e-8)
+    assert parity["correlation"] >= PARITY_CORRELATION
+    assert mse_delta <= QUALITY_DELTA_RATIO
+    assert mae_delta <= QUALITY_DELTA_RATIO
+
+
+@pytest.mark.timeout(600)
+def test_patchtst_native_high_channel():
+    cfg = _cfg(
+        task="forecast",
+        dataset="traffic",
+        batch_size=4,
+        max_windows=16,
+        checkpoint_id_override="models/demos/wormhole/patchtst/artifacts/finetune/forecast_high_channel_traffic_ckpt",
+        checkpoint_revision_override="local-generated",
+        allow_reference_context_adaptation=False,
+        allow_reference_channel_adaptation=False,
+    )
+    prepared = prepare_run(cfg)
+    prediction = run_patchtst(cfg)
+    reference_prediction = reference_forward(
+        artifacts=prepared.reference,
+        past_values=prepared.past,
+        future_values=prepared.future,
+        past_observed_mask=prepared.observed,
+    )
+    parity = compute_metrics(prediction, reference_prediction)
+    quality = compute_metrics(prediction, prepared.future)
+    reference_quality = compute_metrics(reference_prediction, prepared.future)
+    mse_delta = abs(quality["mse"] - reference_quality["mse"]) / max(reference_quality["mse"], 1e-8)
+    mae_delta = abs(quality["mae"] - reference_quality["mae"]) / max(reference_quality["mae"], 1e-8)
+    assert parity["correlation"] >= PARITY_CORRELATION
+    assert mse_delta <= QUALITY_DELTA_RATIO
+    assert mae_delta <= QUALITY_DELTA_RATIO
+
+
+@pytest.mark.timeout(600)
+def test_patchtst_public_multi_head_run():
+    cfg = _cfg(
+        task="multi_task",
+        dataset="heartbeat_cls",
+        split="test",
+        batch_size=4,
+        max_windows=8,
+        context_length=309,
+        prediction_length=96,
+    )
+    prepared = prepare_run(cfg)
+    prediction = run_patchtst(cfg)
+
+    forecast_reference = reference_forward(
+        artifacts=prepared.reference,
+        past_values=prepared.past,
+        future_values=prepared.future,
+        past_observed_mask=prepared.observed,
+    )
+    classification_reference = reference_forward(
+        artifacts=prepared.classification_reference,
+        past_values=prepared.past,
+        target_values=prepared.target_values,
+        past_observed_mask=prepared.observed,
+    )
+    forecast_parity = compute_metrics(prediction["forecast"], forecast_reference)
+    forecast_quality = compute_metrics(prediction["forecast"], prepared.future)
+    reference_forecast_quality = compute_metrics(forecast_reference, prepared.future)
+    classification_metrics = compute_classification_metrics(prediction["classification"], prepared.target_values)
+    reference_classification_metrics = compute_classification_metrics(classification_reference, prepared.target_values)
+    mse_delta = abs(forecast_quality["mse"] - reference_forecast_quality["mse"]) / max(
+        reference_forecast_quality["mse"], 1e-8
+    )
+    mae_delta = abs(forecast_quality["mae"] - reference_forecast_quality["mae"]) / max(
+        reference_forecast_quality["mae"], 1e-8
+    )
+    assert forecast_parity["correlation"] >= PARITY_CORRELATION
+    assert mse_delta <= QUALITY_DELTA_RATIO
+    assert mae_delta <= QUALITY_DELTA_RATIO
+    assert abs(classification_metrics["accuracy"] - reference_classification_metrics["accuracy"]) <= 1e-6
+    assert abs(classification_metrics["f1_macro"] - reference_classification_metrics["f1_macro"]) <= 1e-6

--- a/models/demos/wormhole/patchtst/tests/integration/test_real_data.py
+++ b/models/demos/wormhole/patchtst/tests/integration/test_real_data.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+from models.demos.wormhole.patchtst.config import PatchTSTDemoConfig, merge_demo_config
+from models.demos.wormhole.patchtst.demo.runner import run_patchtst
+from models.demos.wormhole.patchtst.reference.hf_reference import reference_forward
+from models.demos.wormhole.patchtst.tests.helpers import compute_metrics, prepare_run
+
+PARITY_CORRELATION = 0.90
+QUALITY_DELTA_RATIO = 0.05
+
+
+def _cfg(task: str = "forecast", **overrides) -> PatchTSTDemoConfig:
+    defaults = {
+        "task": task,
+        "strict_fallback": True,
+        "dataset": "etth1",
+        "batch_size": 1,
+        "max_windows": 8,
+    }
+    defaults.update(overrides)
+    return merge_demo_config(PatchTSTDemoConfig(task=defaults["task"]), **defaults)
+
+
+@pytest.mark.timeout(600)
+def test_patchtst_real_data_accuracy_etth1():
+    cfg = _cfg(task="forecast")
+    prepared = prepare_run(cfg)
+    prediction = run_patchtst(cfg)
+    reference_prediction = reference_forward(
+        artifacts=prepared.reference,
+        past_values=prepared.past,
+        future_values=prepared.future,
+        past_observed_mask=prepared.observed,
+    )
+
+    parity_metrics = compute_metrics(prediction, reference_prediction)
+    quality_metrics = compute_metrics(prediction, prepared.future)
+    reference_quality_metrics = compute_metrics(reference_prediction, prepared.future)
+    assert parity_metrics["correlation"] >= PARITY_CORRELATION
+    mse_delta = abs(quality_metrics["mse"] - reference_quality_metrics["mse"]) / max(
+        abs(reference_quality_metrics["mse"]), 1e-8
+    )
+    mae_delta = abs(quality_metrics["mae"] - reference_quality_metrics["mae"]) / max(
+        abs(reference_quality_metrics["mae"]), 1e-8
+    )
+    assert mse_delta <= QUALITY_DELTA_RATIO
+    assert mae_delta <= QUALITY_DELTA_RATIO
+    corr_delta = abs(quality_metrics["correlation"] - reference_quality_metrics["correlation"])
+    assert corr_delta <= QUALITY_DELTA_RATIO
+
+
+@pytest.mark.timeout(600)
+def test_patchtst_real_data_weather_sanity():
+    cfg = _cfg(task="forecast", dataset="weather", batch_size=4, max_windows=64)
+    prepared = prepare_run(cfg)
+    prediction = run_patchtst(cfg)
+    reference_prediction = reference_forward(
+        artifacts=prepared.reference,
+        past_values=prepared.past,
+        future_values=prepared.future,
+        past_observed_mask=prepared.observed,
+    )
+    parity = compute_metrics(prediction, reference_prediction)
+    quality = compute_metrics(prediction, prepared.future)
+    reference_quality = compute_metrics(reference_prediction, prepared.future)
+    mse_delta = abs(quality["mse"] - reference_quality["mse"]) / max(abs(reference_quality["mse"]), 1e-8)
+    mae_delta = abs(quality["mae"] - reference_quality["mae"]) / max(abs(reference_quality["mae"]), 1e-8)
+    assert parity["correlation"] >= PARITY_CORRELATION
+    assert mse_delta <= QUALITY_DELTA_RATIO
+    assert mae_delta <= QUALITY_DELTA_RATIO

--- a/models/demos/wormhole/patchtst/tests/integration/test_streaming.py
+++ b/models/demos/wormhole/patchtst/tests/integration/test_streaming.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+from models.demos.wormhole.patchtst.config import PatchTSTDemoConfig, merge_demo_config
+from models.demos.wormhole.patchtst.demo.runner import run_streaming_forecast
+from models.demos.wormhole.patchtst.tests.helpers import compute_metrics
+
+PARITY_CORRELATION = 0.999
+PARITY_MSE = 1e-2
+
+
+@pytest.mark.timeout(600)
+def test_patchtst_streaming_forecast_matches_direct_forward():
+    cfg = merge_demo_config(
+        PatchTSTDemoConfig(task="forecast"),
+        task="forecast",
+        strict_fallback=True,
+        dataset="etth1",
+        batch_size=1,
+        max_windows=8,
+        use_trace=True,
+    )
+    cached = run_streaming_forecast(config=cfg, stream_steps=4, streaming_mode="cached")
+    full_rerun = run_streaming_forecast(config=cfg, stream_steps=4, streaming_mode="full-rerun")
+    assert len(cached) == 4
+    assert len(full_rerun) == 4
+    for cached_step, full_step in zip(cached, full_rerun, strict=True):
+        parity = compute_metrics(cached_step, full_step)
+        assert parity["correlation"] >= PARITY_CORRELATION
+        assert parity["mse"] <= PARITY_MSE
+
+
+@pytest.mark.timeout(600)
+def test_patchtst_streaming_forecast_longer_horizon_stability():
+    cfg = merge_demo_config(
+        PatchTSTDemoConfig(task="forecast"),
+        task="forecast",
+        strict_fallback=True,
+        dataset="etth1",
+        batch_size=1,
+        max_windows=16,
+        use_trace=True,
+    )
+    cached = run_streaming_forecast(config=cfg, stream_steps=12, streaming_mode="cached")
+    full_rerun = run_streaming_forecast(config=cfg, stream_steps=12, streaming_mode="full-rerun")
+    assert len(cached) == 12
+    assert len(full_rerun) == 12
+    for cached_step, full_step in zip(cached, full_rerun, strict=True):
+        parity = compute_metrics(cached_step, full_step)
+        assert parity["correlation"] >= PARITY_CORRELATION
+        assert parity["mse"] <= PARITY_MSE

--- a/models/demos/wormhole/patchtst/tests/perf/test_patchtst_perf.py
+++ b/models/demos/wormhole/patchtst/tests/perf/test_patchtst_perf.py
@@ -1,0 +1,466 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import gc
+import os
+import subprocess
+import sys
+import time
+from typing import Callable, TypeVar
+
+import pytest
+import torch
+
+import ttnn
+from models.demos.wormhole.patchtst.config import PatchTSTDemoConfig, merge_demo_config
+from models.demos.wormhole.patchtst.demo.runner import _build_trace_session, run_patchtst
+from models.demos.wormhole.patchtst.reference.hf_reference import reference_forward
+from models.demos.wormhole.patchtst.tests.helpers import compute_classification_metrics, compute_metrics, prepare_run
+from models.demos.wormhole.patchtst.tt.common import (
+    DEFAULT_L1_SMALL_SIZE,
+    DEFAULT_NUM_COMMAND_QUEUES,
+    DEFAULT_TRACE_REGION_SIZE,
+    PatchTSTRuntimePolicy,
+    resolve_runtime_policy_for_workload,
+)
+from models.demos.wormhole.patchtst.tt.model import PatchTSTTTNNModel
+from models.demos.wormhole.patchtst.tt.streaming import CachedForecastStreamer, HostFullRerunPatchTSTStreamer
+
+PRIMARY_THROUGHPUT_SPS = 150.0
+PRIMARY_LATENCY_MS = 40.0
+PRIMARY_CORRELATION = 0.90
+QUALITY_DELTA_RATIO = 0.05
+STRETCH_THROUGHPUT_SPS = 800.0
+STRETCH_LATENCY_MS = 15.0
+T = TypeVar("T")
+
+
+def _release_if_possible(value: T | None) -> None:
+    release = getattr(value, "release", None)
+    if callable(release):
+        release()
+
+
+def _run_for_timing(fn: Callable[[], T], warmup_iterations: int, measurement_iterations: int) -> tuple[float, T]:
+    for _ in range(max(warmup_iterations, 0)):
+        _release_if_possible(fn())
+    output = None
+    gc_was_enabled = gc.isenabled()
+    if gc_was_enabled:
+        gc.disable()
+    try:
+        start = time.perf_counter()
+        for _ in range(max(measurement_iterations, 1)):
+            _release_if_possible(output)
+            output = fn()
+        elapsed = time.perf_counter() - start
+    finally:
+        if gc_was_enabled:
+            gc.enable()
+    return elapsed / max(measurement_iterations, 1), output
+
+
+def _run_median_timing(
+    fn: Callable[[], T],
+    warmup_iterations: int,
+    measurement_iterations: int,
+    sample_count: int,
+    followup_warmup_iterations: int = 0,
+) -> tuple[float, T, list[float]]:
+    samples_seconds: list[float] = []
+    outputs: list[T] = []
+    for sample_idx in range(max(sample_count, 1)):
+        sample_warmup = warmup_iterations if sample_idx == 0 else max(followup_warmup_iterations, 0)
+        sample_seconds, output = _run_for_timing(
+            fn=fn,
+            warmup_iterations=sample_warmup,
+            measurement_iterations=measurement_iterations,
+        )
+        samples_seconds.append(sample_seconds)
+        outputs.append(output)
+    order = sorted(range(len(samples_seconds)), key=lambda idx: samples_seconds[idx])
+    median_index = order[len(order) // 2]
+    for idx, output in enumerate(outputs):
+        if idx != median_index:
+            _release_if_possible(output)
+    return samples_seconds[median_index], outputs[median_index], samples_seconds
+
+
+def _cfg(task: str = "forecast", **overrides) -> PatchTSTDemoConfig:
+    defaults = {"task": task, "strict_fallback": True, "dataset": "etth1", "batch_size": 1, "max_windows": 64}
+    defaults.update(overrides)
+    return merge_demo_config(PatchTSTDemoConfig(task=defaults["task"]), **defaults)
+
+
+def _measure_trace_run(
+    cfg: PatchTSTDemoConfig,
+    *,
+    runtime_policy: PatchTSTRuntimePolicy | None = None,
+    measurement_iterations: int = 20,
+) -> tuple[float, float]:
+    prepared = prepare_run(cfg)
+    runtime_policy = resolve_runtime_policy_for_workload(
+        policy=runtime_policy or PatchTSTRuntimePolicy(),
+        dataset_num_channels=int(prepared.past.shape[-1]),
+    )
+    ttnn.CONFIG.throw_exception_on_fallback = True
+    device = ttnn.open_device(
+        device_id=0,
+        l1_small_size=DEFAULT_L1_SMALL_SIZE,
+        trace_region_size=DEFAULT_TRACE_REGION_SIZE,
+        num_command_queues=DEFAULT_NUM_COMMAND_QUEUES,
+    )
+    try:
+        model = PatchTSTTTNNModel(
+            demo_config=prepared.runtime_cfg,
+            reference=prepared.reference,
+            classification_reference=prepared.classification_reference,
+            device=device,
+            runtime_policy=runtime_policy,
+        )
+        try:
+            session = _build_trace_session(model, prepared.past, prepared.observed, prepared.runtime_cfg.task)
+            try:
+                seconds, _, _ = _run_median_timing(
+                    fn=session.replay,
+                    warmup_iterations=4,
+                    measurement_iterations=measurement_iterations,
+                    sample_count=3,
+                    followup_warmup_iterations=2,
+                )
+                return seconds * 1000.0, prepared.runtime_cfg.batch_size / max(seconds, 1e-9)
+            finally:
+                session.release()
+        finally:
+            model.close()
+    finally:
+        ttnn.close_device(device)
+
+
+def _measure_wall_ms(fn) -> tuple[float, object]:
+    start = time.perf_counter()
+    output = fn()
+    return (time.perf_counter() - start) * 1000.0, output
+
+
+def _measure_stream_steps(
+    cfg: PatchTSTDemoConfig,
+    *,
+    stream_steps: int,
+    streaming_mode: str,
+) -> tuple[float, list[torch.Tensor]]:
+    prepared = prepare_run(cfg)
+    runtime_policy = PatchTSTRuntimePolicy()
+    runtime_policy = resolve_runtime_policy_for_workload(
+        policy=runtime_policy,
+        dataset_num_channels=int(prepared.past.shape[-1]),
+    )
+    stream_values = prepared.future[:, :stream_steps, :] if prepared.future is not None else None
+    if stream_values is None:
+        raise ValueError("Streaming perf checks require forecast data with future values.")
+    ttnn.CONFIG.throw_exception_on_fallback = True
+    device = ttnn.open_device(
+        device_id=0,
+        l1_small_size=DEFAULT_L1_SMALL_SIZE,
+        trace_region_size=DEFAULT_TRACE_REGION_SIZE,
+        num_command_queues=DEFAULT_NUM_COMMAND_QUEUES,
+    )
+    try:
+        model = PatchTSTTTNNModel(
+            demo_config=prepared.runtime_cfg,
+            reference=prepared.reference,
+            device=device,
+            runtime_policy=runtime_policy,
+        )
+        try:
+            if streaming_mode == "cached":
+                streamer = CachedForecastStreamer(
+                    model=model,
+                    initial_context=prepared.past,
+                    initial_observed_mask=prepared.observed,
+                    use_trace=bool(prepared.runtime_cfg.use_trace),
+                )
+            else:
+                streamer = HostFullRerunPatchTSTStreamer(
+                    model=model,
+                    initial_context=prepared.past,
+                    initial_observed_mask=prepared.observed,
+                )
+            try:
+                start = time.perf_counter()
+                predictions = []
+                for step_idx in range(stream_steps):
+                    tick = stream_values[:, step_idx : step_idx + 1, :]
+                    predictions.append(streamer.step(tick))
+                return (time.perf_counter() - start) * 1000.0, predictions
+            finally:
+                close = getattr(streamer, "close", None)
+                if callable(close):
+                    close()
+        finally:
+            model.close()
+    finally:
+        ttnn.close_device(device)
+
+
+def _run_primary_forecast_three_times_in_subprocess() -> list[float]:
+    samples: list[float] = []
+    env = dict(os.environ)
+    env["PYTHONPATH"] = "."
+    program = """
+from models.demos.wormhole.patchtst.config import PatchTSTDemoConfig, merge_demo_config
+from models.demos.wormhole.patchtst.tests.perf.test_patchtst_perf import _measure_trace_run
+cfg = merge_demo_config(PatchTSTDemoConfig(task='forecast'), task='forecast', dataset='etth1', batch_size=1, max_windows=64, use_trace=True)
+_, throughput = _measure_trace_run(cfg)
+print(throughput)
+"""
+    for _ in range(3):
+        completed = subprocess.run(
+            [sys.executable, "-c", program],
+            cwd=os.getcwd(),
+            env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        for line in reversed(completed.stdout.splitlines()):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                samples.append(float(line))
+                break
+            except ValueError:
+                continue
+        else:
+            raise AssertionError(
+                "failed to find throughput payload in subprocess output:\n"
+                f"stdout:\n{completed.stdout}\n\nstderr:\n{completed.stderr}"
+            )
+    return samples
+
+
+def _forecast_quality_sweep(
+    cfg: PatchTSTDemoConfig,
+    *,
+    batch_size: int,
+    max_windows: int,
+    runtime_policy: PatchTSTRuntimePolicy | None = None,
+) -> tuple[dict[str, float], dict[str, float], dict[str, float], int]:
+    tt_predictions: list[torch.Tensor] = []
+    reference_predictions: list[torch.Tensor] = []
+    targets: list[torch.Tensor] = []
+    for offset in range(0, max_windows, batch_size):
+        current_batch = min(batch_size, max_windows - offset)
+        row_cfg = merge_demo_config(cfg, batch_size=current_batch, window_offset=offset)
+        prepared = prepare_run(row_cfg)
+        tt_predictions.append(run_patchtst(row_cfg, runtime_policy=runtime_policy))
+        reference_predictions.append(
+            reference_forward(
+                artifacts=prepared.reference,
+                past_values=prepared.past,
+                future_values=prepared.future,
+                target_values=prepared.target_values,
+                past_observed_mask=prepared.observed,
+            )
+        )
+        targets.append(prepared.future)
+
+    tt_prediction = torch.cat(tt_predictions, dim=0)
+    reference_prediction = torch.cat(reference_predictions, dim=0)
+    target = torch.cat(targets, dim=0)
+    quality = compute_metrics(tt_prediction, target)
+    reference_quality = compute_metrics(reference_prediction, target)
+    return (
+        compute_metrics(tt_prediction, reference_prediction),
+        quality,
+        reference_quality,
+        int(tt_prediction.shape[0]),
+    )
+
+
+def _forecast_metrics(
+    cfg: PatchTSTDemoConfig,
+    *,
+    runtime_policy: PatchTSTRuntimePolicy | None = None,
+) -> tuple[dict[str, float], dict[str, float], dict[str, float]]:
+    prepared = prepare_run(cfg)
+    tt_prediction = run_patchtst(cfg, runtime_policy=runtime_policy)
+    reference_prediction = reference_forward(
+        artifacts=prepared.reference,
+        past_values=prepared.past,
+        future_values=prepared.future,
+        target_values=prepared.target_values,
+        past_observed_mask=prepared.observed,
+    )
+    return (
+        compute_metrics(tt_prediction, reference_prediction),
+        compute_metrics(tt_prediction, prepared.future),
+        compute_metrics(reference_prediction, prepared.future),
+    )
+
+
+@pytest.mark.timeout(1200)
+@pytest.mark.models_performance_bare_metal
+def test_primary_forecast_trace_batch1_reproducibility():
+    cfg = _cfg(task="forecast", dataset="etth1", batch_size=1, max_windows=64, use_trace=True)
+    samples = _run_primary_forecast_three_times_in_subprocess()
+    print(f"primary_forecast_trace_batch1_reproducibility_sps={samples}")
+    assert len(samples) == 3
+    assert min(samples) >= PRIMARY_THROUGHPUT_SPS
+
+
+@pytest.mark.timeout(600)
+@pytest.mark.models_performance_bare_metal
+def test_primary_forecast_trace_batch1_targets():
+    cfg = _cfg(task="forecast", dataset="etth1", batch_size=1, max_windows=64, use_trace=True)
+    latency_ms, throughput_sps = _measure_trace_run(cfg)
+    parity, quality, reference_quality = _forecast_metrics(cfg)
+    mse_delta_ratio = abs(quality["mse"] - reference_quality["mse"]) / max(float(reference_quality["mse"]), 1e-9)
+    mae_delta_ratio = abs(quality["mae"] - reference_quality["mae"]) / max(float(reference_quality["mae"]), 1e-9)
+    print(f"primary_forecast_trace_batch1 latency_ms={latency_ms:.4f} throughput_sps={throughput_sps:.4f}")
+    assert throughput_sps >= PRIMARY_THROUGHPUT_SPS
+    assert latency_ms <= PRIMARY_LATENCY_MS
+    assert parity["correlation"] >= PRIMARY_CORRELATION
+    assert mse_delta_ratio <= QUALITY_DELTA_RATIO
+    assert mae_delta_ratio <= QUALITY_DELTA_RATIO
+    assert abs(quality["correlation"] - reference_quality["correlation"]) <= QUALITY_DELTA_RATIO
+
+
+@pytest.mark.timeout(600)
+@pytest.mark.models_device_performance_bare_metal
+def test_batch16_trace_targets():
+    cfg = _cfg(task="forecast", dataset="etth1", batch_size=16, max_windows=128, use_trace=True)
+    runtime_policy = PatchTSTRuntimePolicy(activation_memory_tier="l1", sdpa_q_chunk_size=64, sdpa_k_chunk_size=64)
+    latency_ms, throughput_sps = _measure_trace_run(cfg, runtime_policy=runtime_policy, measurement_iterations=50)
+    parity, quality, reference_quality = _forecast_metrics(cfg, runtime_policy=runtime_policy)
+    mse_delta_ratio = abs(quality["mse"] - reference_quality["mse"]) / max(float(reference_quality["mse"]), 1e-9)
+    mae_delta_ratio = abs(quality["mae"] - reference_quality["mae"]) / max(float(reference_quality["mae"]), 1e-9)
+    print(f"batch16_trace latency_ms={latency_ms:.4f} throughput_sps={throughput_sps:.4f}")
+    assert throughput_sps >= STRETCH_THROUGHPUT_SPS
+    assert latency_ms <= STRETCH_LATENCY_MS
+    assert parity["correlation"] >= PRIMARY_CORRELATION
+    assert mse_delta_ratio <= QUALITY_DELTA_RATIO
+    assert mae_delta_ratio <= QUALITY_DELTA_RATIO
+    assert abs(quality["correlation"] - reference_quality["correlation"]) <= QUALITY_DELTA_RATIO
+
+
+@pytest.mark.timeout(1200)
+@pytest.mark.models_device_performance_bare_metal
+def test_batch16_trace_repeatability():
+    cfg = _cfg(task="forecast", dataset="etth1", batch_size=16, max_windows=128, use_trace=True)
+    runtime_policy = PatchTSTRuntimePolicy(activation_memory_tier="l1", sdpa_q_chunk_size=64, sdpa_k_chunk_size=64)
+    first = _measure_trace_run(cfg, runtime_policy=runtime_policy, measurement_iterations=50)
+    second = _measure_trace_run(cfg, runtime_policy=runtime_policy, measurement_iterations=50)
+    print(f"batch16_trace_repeatability first_sps={first[1]:.4f} second_sps={second[1]:.4f}")
+    for latency_ms, throughput_sps in (first, second):
+        assert throughput_sps >= STRETCH_THROUGHPUT_SPS
+        assert latency_ms <= STRETCH_LATENCY_MS
+
+
+@pytest.mark.timeout(600)
+@pytest.mark.models_performance_bare_metal
+def test_sharded_attention_evidence_and_quality():
+    cfg = _cfg(
+        task="forecast",
+        dataset="etth1",
+        split="test",
+        batch_size=4,
+        context_length=512,
+        prediction_length=96,
+        max_windows=64,
+        use_trace=False,
+    )
+    runtime_policy = PatchTSTRuntimePolicy(
+        activation_memory_tier="dram",
+        use_sharded_attention_inputs=True,
+        use_device_patching=True,
+    )
+    parity, quality, reference_quality, windows = _forecast_quality_sweep(
+        cfg,
+        batch_size=4,
+        max_windows=64,
+        runtime_policy=runtime_policy,
+    )
+    mse_delta_ratio = abs(quality["mse"] - reference_quality["mse"]) / max(float(reference_quality["mse"]), 1e-9)
+    mae_delta_ratio = abs(quality["mae"] - reference_quality["mae"]) / max(float(reference_quality["mae"]), 1e-9)
+    print(
+        "sharded_attention "
+        f"windows={windows} parity_corr={parity['correlation']:.6f} quality_corr={quality['correlation']:.6f}"
+    )
+    assert windows == 64
+    assert parity["correlation"] >= PRIMARY_CORRELATION
+    assert mse_delta_ratio <= QUALITY_DELTA_RATIO
+    assert mae_delta_ratio <= QUALITY_DELTA_RATIO
+    assert abs(quality["correlation"] - reference_quality["correlation"]) <= QUALITY_DELTA_RATIO
+
+
+@pytest.mark.timeout(600)
+@pytest.mark.models_device_performance_bare_metal
+def test_cached_streaming_speedup_and_parity():
+    cfg = _cfg(task="forecast", dataset="etth1", batch_size=1, max_windows=8, use_trace=True)
+    cached_ms, cached = _measure_stream_steps(cfg, stream_steps=8, streaming_mode="cached")
+    full_ms, full = _measure_stream_steps(cfg, stream_steps=8, streaming_mode="full-rerun")
+    speedup = max((full_ms - cached_ms) / max(full_ms, 1e-9), 0.0)
+    print(f"cached_streaming stream_ms={cached_ms:.4f} full_ms={full_ms:.4f} speedup={speedup:.6f}")
+    assert speedup > 0.0
+    for cached_step, full_step in zip(cached, full, strict=True):
+        assert compute_metrics(cached_step, full_step)["correlation"] >= 0.99
+
+
+@pytest.mark.timeout(600)
+@pytest.mark.models_device_performance_bare_metal
+def test_shared_encoder_multitask_latency_gain():
+    multitask_cfg = _cfg(
+        task="multi_task",
+        dataset="heartbeat_cls",
+        split="test",
+        batch_size=4,
+        max_windows=8,
+        context_length=309,
+        prediction_length=96,
+    )
+    forecast_cfg = _cfg(
+        task="forecast",
+        dataset="heartbeat_cls",
+        split="test",
+        batch_size=4,
+        max_windows=8,
+        context_length=309,
+        prediction_length=96,
+        checkpoint_id_override="models/demos/wormhole/patchtst/artifacts/finetune/forecast_heartbeat_multitask_ckpt",
+        checkpoint_revision_override="local-generated",
+    )
+    classification_cfg = _cfg(
+        task="classification",
+        dataset="heartbeat_cls",
+        split="test",
+        batch_size=4,
+        max_windows=8,
+        context_length=309,
+        prediction_length=96,
+        checkpoint_id_override="models/demos/wormhole/patchtst/artifacts/finetune/classification_heartbeat_multitask_ckpt",
+        checkpoint_revision_override="local-generated",
+    )
+    multitask_ms, prediction = _measure_wall_ms(lambda: run_patchtst(multitask_cfg))
+    forecast_ms, forecast_prediction = _measure_wall_ms(lambda: run_patchtst(forecast_cfg))
+    classification_ms, classification_prediction = _measure_wall_ms(lambda: run_patchtst(classification_cfg))
+    prepared = prepare_run(multitask_cfg)
+    classification_metrics = compute_classification_metrics(prediction["classification"], prepared.target_values)
+    forecast_quality = compute_metrics(prediction["forecast"], prepared.future)
+    latency_gain = max(
+        ((forecast_ms + classification_ms) - multitask_ms) / max(forecast_ms + classification_ms, 1e-9), 0.0
+    )
+    print(
+        "shared_encoder_multitask "
+        f"latency_gain={latency_gain:.6f} "
+        f"forecast_corr={compute_metrics(prediction['forecast'], forecast_prediction)['correlation']:.6f} "
+        f"classification_acc={classification_metrics['accuracy']:.6f}"
+    )
+    assert latency_gain > 0.0
+    assert compute_metrics(prediction["forecast"], forecast_prediction)["correlation"] >= 0.90
+    assert compute_metrics(prediction["classification"], classification_prediction)["correlation"] >= 0.90
+    assert forecast_quality["mse"] >= 0.0
+    assert classification_metrics["accuracy"] >= 0.0

--- a/models/demos/wormhole/patchtst/tests/unit/test_download_assets.py
+++ b/models/demos/wormhole/patchtst/tests/unit/test_download_assets.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from models.demos.wormhole.patchtst.scripts.download_assets import _resolve_dataset_path, _unlink_dataset_path
+
+
+def test_resolve_dataset_path_allows_descendants(tmp_path: Path):
+    destination = _resolve_dataset_path(tmp_path, Path("Heartbeat/Heartbeat_TRAIN.ts"))
+    assert destination == (tmp_path / "Heartbeat/Heartbeat_TRAIN.ts").resolve()
+
+
+def test_resolve_dataset_path_rejects_parent_traversal(tmp_path: Path):
+    with pytest.raises(RuntimeError, match="escapes dataset root"):
+        _resolve_dataset_path(tmp_path, Path("../outside.txt"))
+
+
+def test_unlink_dataset_path_removes_descendant_file(tmp_path: Path):
+    archive_path = tmp_path / "heartbeat_cls.zip"
+    archive_path.write_bytes(b"payload")
+
+    _unlink_dataset_path(tmp_path, Path("heartbeat_cls.zip"))
+
+    assert not archive_path.exists()
+
+
+def test_unlink_dataset_path_rejects_parent_traversal(tmp_path: Path):
+    with pytest.raises(RuntimeError, match="escapes dataset root"):
+        _unlink_dataset_path(tmp_path, Path("../outside.zip"))

--- a/models/demos/wormhole/patchtst/tests/unit/test_patching.py
+++ b/models/demos/wormhole/patchtst/tests/unit/test_patching.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from models.demos.wormhole.patchtst.config import PatchTSTDemoConfig
+from models.demos.wormhole.patchtst.reference.hf_reference import load_reference_model
+from models.demos.wormhole.patchtst.tests.helpers import compute_metrics
+from models.demos.wormhole.patchtst.tt.patching import patchify
+
+
+@pytest.mark.timeout(600)
+def test_patchify_matches_hf_reference_patchifier():
+    cfg = PatchTSTDemoConfig(task="forecast")
+    reference = load_reference_model(
+        task="forecast",
+        checkpoint_id=cfg.checkpoint_for_task(),
+        revision=cfg.checkpoint_revision_for_task(),
+        config=cfg,
+    )
+    context_length = int(reference.config.context_length)
+    channels = int(reference.config.num_input_channels)
+
+    torch.manual_seed(0)
+    past_values = torch.randn(2, context_length, channels, dtype=torch.float32)
+    tt_patchified = patchify(
+        past_values,
+        context_length=context_length,
+        patch_length=int(reference.config.patch_length),
+        patch_stride=int(reference.config.patch_stride),
+    )
+    with torch.no_grad():
+        ref_patchified = reference.model.model.patchifier(past_values)
+
+    parity = compute_metrics(tt_patchified, ref_patchified)
+    assert parity["mse"] <= 1e-8
+    assert parity["mae"] <= 1e-6
+    assert parity["correlation"] >= 0.999999

--- a/models/demos/wormhole/patchtst/tt/attention.py
+++ b/models/demos/wormhole/patchtst/tt/attention.py
@@ -1,0 +1,196 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+# Source lineage: HuggingFace PatchTST and PatchTST paper implementation details
+# - https://huggingface.co/docs/transformers/en/model_doc/patchtst
+# - https://github.com/huggingface/transformers/tree/main/src/transformers/models/patchtst
+# - https://arxiv.org/abs/2211.14730
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+
+import ttnn
+from models.demos.wormhole.patchtst.tt.common import (
+    MEMORY_CONFIG_BY_TIER,
+    PatchTSTRuntimePolicy,
+    TTLinear,
+    build_linear,
+    build_linear_from_state,
+    ensure_interleaved,
+)
+
+
+@dataclass
+class PatchTSTAttention:
+    qkv: TTLinear
+    out_proj: TTLinear
+    num_heads: int
+    padded_head_dim: int
+
+    def __call__(
+        self, hidden_state: ttnn.Tensor, runtime: PatchTSTRuntimePolicy, device, dtype: ttnn.DataType = ttnn.bfloat16
+    ) -> ttnn.Tensor:
+        mem_cfg = MEMORY_CONFIG_BY_TIER[runtime.activation_memory_tier]
+        hidden_size = int(hidden_state.shape[-1])
+        real_head_dim = hidden_size // self.num_heads
+        if real_head_dim * self.num_heads != hidden_size:
+            raise ValueError(
+                f"Hidden size must be divisible by num_heads: hidden={hidden_size}, heads={self.num_heads}"
+            )
+        qkv = ensure_interleaved(
+            ttnn.linear(hidden_state, self.qkv.weight, bias=self.qkv.bias, memory_config=mem_cfg, dtype=dtype),
+            mem_cfg,
+        )
+        query, key, value = ttnn.transformer.split_query_key_value_and_split_heads(
+            qkv, memory_config=mem_cfg, num_heads=self.num_heads, transpose_key=False
+        )
+        ttnn.deallocate(qkv)
+
+        if runtime.use_sdpa:
+            compute_grid = device.compute_with_storage_grid_size()
+            context = ttnn.transformer.scaled_dot_product_attention(
+                query,
+                key,
+                value,
+                scale=1.0 / (real_head_dim**0.5),
+                attn_mask=None,
+                is_causal=False,
+                program_config=ttnn.SDPAProgramConfig(
+                    compute_with_storage_grid_size=(compute_grid.x, compute_grid.y),
+                    q_chunk_size=int(runtime.sdpa_q_chunk_size),
+                    k_chunk_size=int(runtime.sdpa_k_chunk_size),
+                    exp_approx_mode=True,
+                ),
+                memory_config=mem_cfg,
+            )
+        else:
+            key_t = ttnn.permute(key, (0, 1, 3, 2))
+            attn_scores = ttnn.matmul(query, key_t, memory_config=mem_cfg, dtype=dtype)
+            ttnn.deallocate(key_t)
+            attn_probs = ttnn.transformer.attention_softmax(attn_scores, head_size=self.padded_head_dim)
+            ttnn.deallocate(attn_scores)
+            context = ttnn.matmul(attn_probs, value, memory_config=mem_cfg, dtype=dtype)
+            ttnn.deallocate(attn_probs)
+
+        ttnn.deallocate(query)
+        ttnn.deallocate(key)
+        ttnn.deallocate(value)
+        context = ensure_interleaved(ttnn.transformer.concatenate_heads(context, memory_config=mem_cfg), mem_cfg)
+        output_tt = ttnn.linear(
+            context, self.out_proj.weight, bias=self.out_proj.bias, memory_config=mem_cfg, dtype=dtype
+        )
+        ttnn.deallocate(context)
+        return ensure_interleaved(output_tt, mem_cfg)
+
+    def release(self) -> None:
+        self.qkv.release()
+        self.out_proj.release()
+
+
+def _build_linear_padded_input_per_head(
+    state: dict[str, torch.Tensor],
+    prefix: str,
+    num_heads: int,
+    padded_head_dim: int,
+    *,
+    device,
+    dtype: ttnn.DataType,
+    memory_config: ttnn.MemoryConfig,
+) -> TTLinear:
+    weight = state[f"{prefix}.weight"]
+    hidden_size = int(weight.shape[1])
+    real_head_dim = hidden_size // num_heads
+    padded_input_dim = num_heads * padded_head_dim
+    padded_weight = torch.zeros((weight.shape[0], padded_input_dim), dtype=weight.dtype)
+    for head_idx in range(num_heads):
+        src_start = head_idx * real_head_dim
+        dst_start = head_idx * padded_head_dim
+        padded_weight[:, dst_start : dst_start + real_head_dim] = weight[:, src_start : src_start + real_head_dim]
+    bias_key = f"{prefix}.bias"
+    return build_linear(
+        padded_weight,
+        state[bias_key] if bias_key in state else None,
+        device=device,
+        dtype=dtype,
+        memory_config=memory_config,
+    )
+
+
+def _build_fused_qkv(
+    state: dict[str, torch.Tensor],
+    layer_prefix: str,
+    num_heads: int,
+    padded_head_dim: int,
+    *,
+    device,
+    dtype: ttnn.DataType,
+    memory_config: ttnn.MemoryConfig,
+) -> TTLinear:
+    q_w = state[f"{layer_prefix}.self_attn.q_proj.weight"]
+    k_w = state[f"{layer_prefix}.self_attn.k_proj.weight"]
+    v_w = state[f"{layer_prefix}.self_attn.v_proj.weight"]
+    q_b = state[f"{layer_prefix}.self_attn.q_proj.bias"]
+    k_b = state[f"{layer_prefix}.self_attn.k_proj.bias"]
+    v_b = state[f"{layer_prefix}.self_attn.v_proj.bias"]
+    hidden_size = int(q_w.shape[0])
+    real_head_dim = hidden_size // num_heads
+    padded_hidden = num_heads * padded_head_dim
+    q_w_padded = torch.zeros((padded_hidden, q_w.shape[1]), dtype=q_w.dtype)
+    k_w_padded = torch.zeros((padded_hidden, k_w.shape[1]), dtype=k_w.dtype)
+    v_w_padded = torch.zeros((padded_hidden, v_w.shape[1]), dtype=v_w.dtype)
+    q_b_padded = torch.zeros((padded_hidden,), dtype=q_b.dtype)
+    k_b_padded = torch.zeros((padded_hidden,), dtype=k_b.dtype)
+    v_b_padded = torch.zeros((padded_hidden,), dtype=v_b.dtype)
+    for head_idx in range(num_heads):
+        src_start = head_idx * real_head_dim
+        dst_start = head_idx * padded_head_dim
+        q_w_padded[dst_start : dst_start + real_head_dim] = q_w[src_start : src_start + real_head_dim]
+        k_w_padded[dst_start : dst_start + real_head_dim] = k_w[src_start : src_start + real_head_dim]
+        v_w_padded[dst_start : dst_start + real_head_dim] = v_w[src_start : src_start + real_head_dim]
+        q_b_padded[dst_start : dst_start + real_head_dim] = q_b[src_start : src_start + real_head_dim]
+        k_b_padded[dst_start : dst_start + real_head_dim] = k_b[src_start : src_start + real_head_dim]
+        v_b_padded[dst_start : dst_start + real_head_dim] = v_b[src_start : src_start + real_head_dim]
+    return build_linear(
+        torch.cat([q_w_padded, k_w_padded, v_w_padded], dim=0),
+        torch.cat([q_b_padded, k_b_padded, v_b_padded], dim=0),
+        device=device,
+        dtype=dtype,
+        memory_config=memory_config,
+    )
+
+
+def build_attention(
+    state: dict[str, torch.Tensor],
+    layer_prefix: str,
+    num_heads: int,
+    padded_head_dim: int,
+    *,
+    device,
+    dtype: ttnn.DataType,
+    memory_config: ttnn.MemoryConfig,
+) -> PatchTSTAttention:
+    real_head_dim = int(state[f"{layer_prefix}.self_attn.q_proj.weight"].shape[0]) // num_heads
+    return PatchTSTAttention(
+        qkv=_build_fused_qkv(
+            state, layer_prefix, num_heads, padded_head_dim, device=device, dtype=dtype, memory_config=memory_config
+        ),
+        out_proj=(
+            build_linear_from_state(
+                state, f"{layer_prefix}.self_attn.out_proj", device=device, dtype=dtype, memory_config=memory_config
+            )
+            if padded_head_dim == real_head_dim
+            else _build_linear_padded_input_per_head(
+                state,
+                f"{layer_prefix}.self_attn.out_proj",
+                num_heads,
+                padded_head_dim,
+                device=device,
+                dtype=dtype,
+                memory_config=memory_config,
+            )
+        ),
+        num_heads=num_heads,
+        padded_head_dim=padded_head_dim,
+    )

--- a/models/demos/wormhole/patchtst/tt/common.py
+++ b/models/demos/wormhole/patchtst/tt/common.py
@@ -1,0 +1,330 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, replace
+from typing import Literal
+
+import torch
+from ttnn.model_preprocessing import preprocess_linear_bias, preprocess_linear_weight
+
+import ttnn
+
+MEMORY_TIER = Literal["dram", "l1"]
+
+TT_DTYPE = ttnn.bfloat16
+DEFAULT_TRACE_REGION_SIZE = 5_000_000
+DEFAULT_L1_SMALL_SIZE = 24_576
+DEFAULT_NUM_COMMAND_QUEUES = 2
+HIGH_CHANNEL_DRAM_THRESHOLD = 100
+_L1_DEBUG_DEVICE_INFO = ttnn._ttnn.reports.get_device_info
+
+MEMORY_CONFIG_BY_TIER: dict[MEMORY_TIER, ttnn.MemoryConfig] = {
+    "l1": ttnn.L1_MEMORY_CONFIG,
+    "dram": ttnn.DRAM_MEMORY_CONFIG,
+}
+
+
+@dataclass
+class TTLinear:
+    weight: ttnn.Tensor
+    bias: ttnn.Tensor | None
+
+    def release(self) -> None:
+        ttnn.deallocate(self.weight)
+        if self.bias is not None:
+            ttnn.deallocate(self.bias)
+
+
+@dataclass(frozen=True)
+class PatchTSTRuntimePolicy:
+    activation_memory_tier: MEMORY_TIER = "dram"
+    weight_memory_tier: MEMORY_TIER = "dram"
+    use_sdpa: bool = True
+    use_sharded_attention_inputs: bool = False
+    allow_shard_fallback: bool = False
+    sharding_max_rows_per_chunk: int = 4096
+    use_fused_ffn: bool = True
+    use_device_patching: bool = False
+    sdpa_q_chunk_size: int = 128
+    sdpa_k_chunk_size: int = 128
+
+
+def resolve_runtime_policy_for_workload(
+    policy: PatchTSTRuntimePolicy | None,
+    dataset_num_channels: int,
+) -> PatchTSTRuntimePolicy:
+    effective_policy = policy or PatchTSTRuntimePolicy()
+    if policy is not None:
+        return policy
+
+    if dataset_num_channels >= HIGH_CHANNEL_DRAM_THRESHOLD and effective_policy.activation_memory_tier == "l1":
+        # Traffic-scale channel counts overflow the default L1 QKV projection path, so the implicit default
+        # policy must move activations to DRAM to keep the high-channel workload runnable without weakening math.
+        return replace(effective_policy, activation_memory_tier="dram")
+    return effective_policy
+
+
+def _round_up(value: int, multiple: int) -> int:
+    if multiple <= 0:
+        raise ValueError(f"multiple must be positive, got {multiple}")
+    return ((value + multiple - 1) // multiple) * multiple
+
+
+def _bf16_tile_padded_bytes(rows: int, width: int) -> int:
+    # PatchTST activation tensors in this demo are bfloat16 tile-layout tensors.
+    # TT tile storage rounds each logical shard to whole 32x32 tiles, so the packed shard bytes are:
+    #   roundup(rows, 32) * roundup(width, 32) * sizeof(bfloat16)
+    # This matches the physical volume the allocator must back for the shard buffer.
+    padded_rows = _round_up(int(rows), ttnn.TILE_SIZE)
+    padded_width = _round_up(int(width), ttnn.TILE_SIZE)
+    return padded_rows * padded_width * 2
+
+
+def ensure_interleaved(tensor: ttnn.Tensor, memory_config: ttnn.MemoryConfig) -> ttnn.Tensor:
+    if not tensor.is_sharded():
+        return tensor
+    interleaved = ttnn.sharded_to_interleaved(tensor, memory_config=memory_config)
+    ttnn.deallocate(tensor)
+    return interleaved
+
+
+def to_tt_param(
+    tensor: torch.Tensor,
+    *,
+    device,
+    dtype: ttnn.DataType,
+    memory_config: ttnn.MemoryConfig,
+) -> ttnn.Tensor:
+    param = tensor.detach().to(torch.float32)
+    if param.ndim == 1:
+        param = param.reshape(1, 1, -1)
+    elif param.ndim == 2:
+        param = param.reshape(1, *param.shape)
+    return ttnn.from_torch(
+        param,
+        dtype=dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=memory_config,
+    )
+
+
+def build_linear(
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    *,
+    device,
+    dtype: ttnn.DataType,
+    memory_config: ttnn.MemoryConfig,
+) -> TTLinear:
+    weight_tt = ttnn.to_device(preprocess_linear_weight(weight, dtype=dtype), device, memory_config=memory_config)
+    bias_tt = None
+    if bias is not None:
+        bias_tt = ttnn.to_device(preprocess_linear_bias(bias, dtype=dtype), device, memory_config=memory_config)
+    return TTLinear(weight_tt, bias_tt)
+
+
+def build_linear_from_state(
+    state: dict[str, torch.Tensor],
+    prefix: str,
+    *,
+    device,
+    dtype: ttnn.DataType,
+    memory_config: ttnn.MemoryConfig,
+) -> TTLinear:
+    bias_key = f"{prefix}.bias"
+    return build_linear(
+        state[f"{prefix}.weight"],
+        state[bias_key] if bias_key in state else None,
+        device=device,
+        dtype=dtype,
+        memory_config=memory_config,
+    )
+
+
+def maybe_height_shard_3d_tensor(
+    tensor: ttnn.Tensor,
+    device,
+    enable: bool,
+    allow_fallback: bool = True,
+) -> tuple[ttnn.Tensor, bool]:
+    if not enable or len(tensor.shape) != 3:
+        return tensor, False
+
+    batch_size = int(tensor.shape[0])
+    sequence_length = int(tensor.shape[1])
+    hidden_size = int(tensor.shape[2])
+    padded_batch_size = int(tensor.padded_shape[0])
+    padded_sequence_length = int(tensor.padded_shape[1])
+
+    if hidden_size % ttnn.TILE_SIZE != 0:
+        return tensor, False
+    if batch_size * sequence_length < ttnn.TILE_SIZE:
+        return tensor, False
+    if (batch_size * sequence_length) % ttnn.TILE_SIZE != 0:
+        return tensor, False
+
+    rows = padded_batch_size * padded_sequence_length
+    compute_grid = device.compute_with_storage_grid_size()
+    total_compute_cores = int(compute_grid.x) * int(compute_grid.y)
+    rows_per_core = math.ceil(rows / total_compute_cores)
+    padded_rows_per_core = _round_up(rows_per_core, ttnn.TILE_SIZE)
+    input_shard_bytes = _bf16_tile_padded_bytes(padded_rows_per_core, hidden_size)
+    qkv_shard_bytes = _bf16_tile_padded_bytes(padded_rows_per_core, hidden_size * 3)
+
+    # Height-sharded attention-input compute is only safe while the per-core working set stays below one L1 bank.
+    # PatchTST does not use TTNN's explicit DRAM prefetcher today, and TTNN sharded MemoryConfig objects are L1-only.
+    # That means there is a hard binary choice:
+    #   - small enough: shard into L1 across compute cores
+    #   - too large: keep the tensor interleaved so kernels read from DRAM/L1 through the normal path
+    #
+    # We use a strict no-exception boundary instead of probing until OOM:
+    #   estimated_working_set = 2 * input_shard + 2 * qkv_shard
+    #
+    # Reasoning:
+    #   - the QKV linear needs an input shard and an output shard resident,
+    #   - TT kernels commonly double-buffer their circular buffers,
+    #   - qkv_shard is the largest logical activation in this path because width expands from D to 3D.
+    #
+    # On this Wormhole device the allocator reports:
+    #   worker_l1_size  = 1,499,136 B
+    #   cb_limit        = 1,395,424 B
+    #   l1_bank_size    = 1,370,848 B
+    #
+    # The practical hard line for a single sharded buffer is the smaller of cb_limit and bank_size.
+    # We saw this explicitly in a failing experiment:
+    #   requested_per_bank = 1,409,024 B > bank_size = 1,370,848 B
+    # so the allocator failed before execution could recover.
+    info = _L1_DEBUG_DEVICE_INFO(device)
+    l1_effective_limit_bytes = min(int(info.l1_bank_size), int(info.cb_limit))
+    estimated_working_set_bytes = 2 * input_shard_bytes + 2 * qkv_shard_bytes
+    if estimated_working_set_bytes > l1_effective_limit_bytes:
+        if allow_fallback:
+            return tensor, False
+        raise RuntimeError(
+            "Height-sharded attention input exceeds the strict per-core L1 budget and shard fallback is disabled. "
+            f"rows={rows}, rows_per_core={rows_per_core}, padded_rows_per_core={padded_rows_per_core}, "
+            f"width={hidden_size}, input_shard_bytes={input_shard_bytes}, qkv_shard_bytes={qkv_shard_bytes}, "
+            f"estimated_working_set_bytes={estimated_working_set_bytes}, "
+            f"l1_effective_limit_bytes={l1_effective_limit_bytes}"
+        )
+
+    core_coord = device.compute_with_storage_grid_size()
+    shard_grid = ttnn.num_cores_to_corerangeset(
+        total_compute_cores,
+        core_coord,
+        row_wise=True,
+    )
+    sharded_mem_cfg = ttnn.create_sharded_memory_config_(
+        shape=(padded_rows_per_core, hidden_size),
+        core_grid=shard_grid,
+        strategy=ttnn.ShardStrategy.HEIGHT,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+        tile_layout=True,
+    )
+    # Interleaved [B, S, D] tile tensors carry independent padding on the first two logical axes.
+    # If we shard that rank-3 view directly, TTNN can count shards off the padded sequence axis alone and
+    # reject otherwise valid shapes. Flattening to [1, B*S, D] first makes the sharding math operate on the
+    # true padded token rows, then we reshape the sharded tensor back to [B, S, D] on the same full core grid.
+    flattened = ttnn.reshape(tensor, (1, batch_size * sequence_length, hidden_size))
+    sharded_flattened = ttnn.interleaved_to_sharded(flattened, sharded_mem_cfg)
+    reshaped = ttnn.reshape(sharded_flattened, (batch_size, sequence_length, hidden_size))
+    if flattened is not tensor:
+        ttnn.deallocate(flattened)
+    if reshaped is not sharded_flattened:
+        ttnn.deallocate(sharded_flattened)
+    return reshaped, True
+
+
+def _aligned_batch_for_height_shard(batch_size: int, sequence_length: int) -> int:
+    if sequence_length <= 0:
+        return batch_size
+    if (batch_size * sequence_length) % ttnn.TILE_SIZE == 0:
+        return batch_size
+    step = ttnn.TILE_SIZE // math.gcd(sequence_length, ttnn.TILE_SIZE)
+    return ((batch_size + step - 1) // step) * step
+
+
+def sharded_layout_roundtrip_3d_tensor(
+    tensor: ttnn.Tensor,
+    device,
+    enable: bool,
+    max_rows_per_chunk: int = 4096,
+    interleaved_memory_config: ttnn.MemoryConfig = ttnn.L1_MEMORY_CONFIG,
+    allow_fallback: bool = True,
+) -> tuple[ttnn.Tensor, int]:
+    if not enable or len(tensor.shape) != 3:
+        return tensor, 0
+
+    batch_size = int(tensor.shape[0])
+    sequence_length = int(tensor.shape[1])
+    hidden_size = int(tensor.shape[2])
+    if batch_size <= 0 or sequence_length <= 0:
+        return tensor, 0
+
+    rows = batch_size * sequence_length
+    if rows <= max_rows_per_chunk:
+        aligned_batch = _aligned_batch_for_height_shard(batch_size=batch_size, sequence_length=sequence_length)
+        padded = tensor
+        did_pad = False
+        if aligned_batch > batch_size:
+            padded = ttnn.pad(
+                tensor,
+                padding=((0, aligned_batch - batch_size), (0, 0), (0, 0)),
+                value=0.0,
+            )
+            did_pad = True
+
+        sharded, used_shard = maybe_height_shard_3d_tensor(
+            padded,
+            device=device,
+            enable=True,
+            allow_fallback=allow_fallback,
+        )
+        if not used_shard:
+            if did_pad:
+                ttnn.deallocate(padded)
+            return tensor, 0
+
+        interleaved = ttnn.sharded_to_interleaved(sharded, memory_config=interleaved_memory_config)
+        ttnn.deallocate(sharded)
+        if did_pad:
+            ttnn.deallocate(padded)
+            trimmed = ttnn.slice(interleaved, (0, 0, 0), (batch_size, sequence_length, hidden_size))
+            ttnn.deallocate(interleaved)
+            interleaved = trimmed
+        return interleaved, 1
+
+    chunk_batch = max(1, max_rows_per_chunk // sequence_length)
+    pieces: list[ttnn.Tensor] = []
+    shard_ops = 0
+    for start in range(0, batch_size, chunk_batch):
+        end = min(batch_size, start + chunk_batch)
+        chunk = ttnn.slice(tensor, (start, 0, 0), (end, sequence_length, hidden_size))
+        roundtripped, ops = sharded_layout_roundtrip_3d_tensor(
+            chunk,
+            device=device,
+            enable=True,
+            max_rows_per_chunk=max_rows_per_chunk,
+            interleaved_memory_config=interleaved_memory_config,
+            allow_fallback=allow_fallback,
+        )
+        shard_ops += ops
+        pieces.append(roundtripped)
+        if roundtripped is not chunk:
+            ttnn.deallocate(chunk)
+
+    if len(pieces) == 1:
+        return pieces[0], shard_ops
+
+    merged = pieces[0]
+    for part in pieces[1:]:
+        combined = ttnn.concat([merged, part], dim=0)
+        ttnn.deallocate(merged)
+        ttnn.deallocate(part)
+        merged = combined
+    return merged, shard_ops

--- a/models/demos/wormhole/patchtst/tt/embeddings.py
+++ b/models/demos/wormhole/patchtst/tt/embeddings.py
@@ -1,0 +1,208 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+# Source lineage: HuggingFace PatchTST and PatchTST paper implementation details
+# - https://huggingface.co/docs/transformers/en/model_doc/patchtst
+# - https://github.com/huggingface/transformers/tree/main/src/transformers/models/patchtst
+# - https://arxiv.org/abs/2211.14730
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import torch
+
+import ttnn
+from models.demos.wormhole.patchtst.reference.hf_reference import ReferenceArtifacts
+from models.demos.wormhole.patchtst.tt.common import (
+    MEMORY_CONFIG_BY_TIER,
+    PatchTSTRuntimePolicy,
+    TTLinear,
+    build_linear,
+    build_linear_from_state,
+)
+
+
+def _pad_last_dim_torch(tensor: torch.Tensor, padded_dim: int) -> torch.Tensor:
+    pad = padded_dim - int(tensor.shape[-1])
+    if pad <= 0:
+        return tensor
+    return torch.nn.functional.pad(tensor, (0, pad))
+
+
+def _pad_last_dim_tt(tensor: ttnn.Tensor, padded_dim: int) -> ttnn.Tensor:
+    pad = padded_dim - int(tensor.shape[-1])
+    if pad <= 0:
+        return tensor
+    return ttnn.pad(tensor, padding=((0, 0), (0, 0), (0, pad)), value=0.0)
+
+
+def _build_linear_padded_input(
+    state: dict[str, torch.Tensor],
+    prefix: str,
+    padded_input_dim: int,
+    *,
+    device,
+    dtype: ttnn.DataType,
+    memory_config: ttnn.MemoryConfig,
+) -> TTLinear:
+    weight = state[f"{prefix}.weight"]
+    padded_weight = torch.zeros((weight.shape[0], padded_input_dim), dtype=weight.dtype)
+    padded_weight[:, : weight.shape[1]] = weight
+    bias_key = f"{prefix}.bias"
+    return build_linear(
+        padded_weight,
+        state[bias_key] if bias_key in state else None,
+        device=device,
+        dtype=dtype,
+        memory_config=memory_config,
+    )
+
+
+@dataclass
+class PatchTSTEmbedder:
+    shared_projection: TTLinear | None
+    channel_projections: list[TTLinear]
+
+    def __call__(
+        self,
+        patch_input: torch.Tensor | ttnn.Tensor,
+        share_embedding: bool,
+        device,
+        runtime: PatchTSTRuntimePolicy,
+        dtype: ttnn.DataType = ttnn.bfloat16,
+    ) -> ttnn.Tensor:
+        mem_cfg = MEMORY_CONFIG_BY_TIER[runtime.activation_memory_tier]
+        bsz, num_channels, num_patches, patch_length = [int(x) for x in patch_input.shape]
+        padded_input_dim = int(math.ceil(patch_length / ttnn.TILE_SIZE) * ttnn.TILE_SIZE)
+
+        if share_embedding:
+            if self.shared_projection is None:
+                raise ValueError("share_embedding=True requires a shared embedder projection.")
+            if isinstance(patch_input, ttnn.Tensor):
+                flat_tt = ttnn.reshape(patch_input, (bsz * num_channels, 1, num_patches, patch_length))
+                padded_flat_tt = _pad_last_dim_tt(flat_tt, padded_input_dim)
+            else:
+                flat_tt = ttnn.from_torch(
+                    _pad_last_dim_torch(
+                        patch_input.reshape(bsz * num_channels, 1, num_patches, patch_length), padded_input_dim
+                    ),
+                    dtype=dtype,
+                    layout=ttnn.TILE_LAYOUT,
+                    device=device,
+                    memory_config=mem_cfg,
+                )
+                padded_flat_tt = flat_tt
+            out_tt = ttnn.linear(
+                padded_flat_tt,
+                self.shared_projection.weight,
+                bias=self.shared_projection.bias,
+                memory_config=mem_cfg,
+                dtype=dtype,
+            )
+            if padded_flat_tt is not flat_tt:
+                ttnn.deallocate(padded_flat_tt)
+            if flat_tt is not patch_input:
+                ttnn.deallocate(flat_tt)
+            return ttnn.reshape(out_tt, (bsz, num_channels, num_patches, out_tt.shape[-1]))
+
+        outputs = []
+        for channel_idx in range(num_channels):
+            projection = self.channel_projections[channel_idx] if self.channel_projections else self.shared_projection
+            if projection is None:
+                raise ValueError(
+                    "Non-shared embedding requires per-channel projections or a shared projection fallback."
+                )
+            if isinstance(patch_input, ttnn.Tensor):
+                channel_input = ttnn.slice(
+                    patch_input, (0, channel_idx, 0, 0), (bsz, channel_idx + 1, num_patches, patch_length)
+                )
+                channel_tt = ttnn.reshape(channel_input, (bsz, 1, num_patches, patch_length))
+                ttnn.deallocate(channel_input)
+                padded_channel_tt = _pad_last_dim_tt(channel_tt, padded_input_dim)
+            else:
+                channel_tt = ttnn.from_torch(
+                    _pad_last_dim_torch(patch_input[:, channel_idx : channel_idx + 1], padded_input_dim),
+                    dtype=dtype,
+                    layout=ttnn.TILE_LAYOUT,
+                    device=device,
+                    memory_config=mem_cfg,
+                )
+                padded_channel_tt = channel_tt
+            outputs.append(
+                ttnn.linear(
+                    padded_channel_tt,
+                    projection.weight,
+                    bias=projection.bias,
+                    memory_config=mem_cfg,
+                    dtype=dtype,
+                )
+            )
+            if padded_channel_tt is not channel_tt:
+                ttnn.deallocate(padded_channel_tt)
+            ttnn.deallocate(channel_tt)
+
+        stacked = outputs[0]
+        for tensor in outputs[1:]:
+            combined = ttnn.concat([stacked, tensor], dim=1)
+            ttnn.deallocate(stacked)
+            stacked = combined
+        return stacked
+
+    def release(self) -> None:
+        if self.shared_projection is not None:
+            self.shared_projection.release()
+        for projection in self.channel_projections:
+            projection.release()
+
+
+def build_embedder(
+    reference: ReferenceArtifacts,
+    *,
+    device,
+    dtype: ttnn.DataType = ttnn.bfloat16,
+    memory_tier: str = "dram",
+) -> PatchTSTEmbedder:
+    state = reference.model.state_dict()
+    memory_config = MEMORY_CONFIG_BY_TIER[memory_tier]
+    patch_length = int(reference.config.patch_length)
+    padded_patch_length = ((patch_length + ttnn.TILE_SIZE - 1) // ttnn.TILE_SIZE) * ttnn.TILE_SIZE
+    embedder_prefix = "model.encoder.embedder.input_embedding"
+    linear_builder = build_linear_from_state if padded_patch_length == patch_length else _build_linear_padded_input
+
+    if bool(reference.config.share_embedding):
+        return PatchTSTEmbedder(
+            shared_projection=(
+                linear_builder(state, embedder_prefix, device=device, dtype=dtype, memory_config=memory_config)
+                if padded_patch_length == patch_length
+                else linear_builder(
+                    state,
+                    embedder_prefix,
+                    padded_patch_length,
+                    device=device,
+                    dtype=dtype,
+                    memory_config=memory_config,
+                )
+            ),
+            channel_projections=[],
+        )
+
+    projections = []
+    channel_index = 0
+    while f"{embedder_prefix}.{channel_index}.weight" in state:
+        projections.append(
+            linear_builder(
+                state, f"{embedder_prefix}.{channel_index}", device=device, dtype=dtype, memory_config=memory_config
+            )
+            if padded_patch_length == patch_length
+            else linear_builder(
+                state,
+                f"{embedder_prefix}.{channel_index}",
+                padded_patch_length,
+                device=device,
+                dtype=dtype,
+                memory_config=memory_config,
+            )
+        )
+        channel_index += 1
+    return PatchTSTEmbedder(shared_projection=None, channel_projections=projections)

--- a/models/demos/wormhole/patchtst/tt/encoder.py
+++ b/models/demos/wormhole/patchtst/tt/encoder.py
@@ -1,0 +1,357 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+# Source lineage: HuggingFace PatchTST and PatchTST paper implementation details
+# - https://huggingface.co/docs/transformers/en/model_doc/patchtst
+# - https://github.com/huggingface/transformers/tree/main/src/transformers/models/patchtst
+# - https://arxiv.org/abs/2211.14730
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import torch
+
+import ttnn
+from models.demos.wormhole.patchtst.reference.hf_reference import ReferenceArtifacts
+from models.demos.wormhole.patchtst.tt.attention import PatchTSTAttention, build_attention
+from models.demos.wormhole.patchtst.tt.common import (
+    MEMORY_CONFIG_BY_TIER,
+    PatchTSTRuntimePolicy,
+    TTLinear,
+    build_linear_from_state,
+    maybe_height_shard_3d_tensor,
+    sharded_layout_roundtrip_3d_tensor,
+    to_tt_param,
+)
+
+
+@dataclass
+class PatchTSTEncoderLayer:
+    attention: PatchTSTAttention
+    norm1_kind: str
+    norm1_weight: ttnn.Tensor
+    norm1_bias: ttnn.Tensor
+    norm2_kind: str | None
+    norm2_weight: ttnn.Tensor | None
+    norm2_bias: ttnn.Tensor | None
+    norm3_kind: str
+    norm3_weight: ttnn.Tensor
+    norm3_bias: ttnn.Tensor
+    ff1: TTLinear
+    ff2: TTLinear
+    channel_attention_enabled: bool
+
+    def release(self) -> None:
+        self.attention.release()
+        ttnn.deallocate(self.norm1_weight)
+        ttnn.deallocate(self.norm1_bias)
+        if self.norm2_weight is not None:
+            ttnn.deallocate(self.norm2_weight)
+        if self.norm2_bias is not None:
+            ttnn.deallocate(self.norm2_bias)
+        ttnn.deallocate(self.norm3_weight)
+        ttnn.deallocate(self.norm3_bias)
+        self.ff1.release()
+        self.ff2.release()
+
+
+def _apply_norm_tt(
+    kind: str, weight: ttnn.Tensor, bias: ttnn.Tensor, hidden_state: ttnn.Tensor, mem_cfg
+) -> ttnn.Tensor:
+    if kind == "layer_norm":
+        return ttnn.layer_norm(hidden_state, weight=weight, bias=bias, epsilon=1e-5, memory_config=mem_cfg)
+    if kind == "batch_norm_affine":
+        return ttnn.add(ttnn.multiply(hidden_state, weight, memory_config=mem_cfg), bias, memory_config=mem_cfg)
+    raise ValueError(f"Unsupported norm kind: {kind}")
+
+
+def _feed_forward_tt(
+    hidden_state: ttnn.Tensor, layer: PatchTSTEncoderLayer, mem_cfg, dtype, use_fused_ffn
+) -> ttnn.Tensor:
+    if use_fused_ffn:
+        out = ttnn.linear(
+            hidden_state, layer.ff1.weight, bias=layer.ff1.bias, memory_config=mem_cfg, dtype=dtype, activation="gelu"
+        )
+    else:
+        out = ttnn.linear(hidden_state, layer.ff1.weight, bias=layer.ff1.bias, memory_config=mem_cfg, dtype=dtype)
+        out = ttnn.gelu(out)
+    return ttnn.linear(out, layer.ff2.weight, bias=layer.ff2.bias, memory_config=mem_cfg, dtype=dtype)
+
+
+def encode_hidden_state(
+    hidden_state: ttnn.Tensor,
+    encoder_layers: list[PatchTSTEncoderLayer],
+    pre_norm: bool,
+    enable_channel_attention: bool,
+    runtime: PatchTSTRuntimePolicy,
+    device,
+    dtype: ttnn.DataType = ttnn.bfloat16,
+) -> ttnn.Tensor:
+    mem_cfg = MEMORY_CONFIG_BY_TIER[runtime.activation_memory_tier]
+
+    def run_attention(attention_input: ttnn.Tensor, attention: PatchTSTAttention) -> ttnn.Tensor:
+        attention_input_for_compute = attention_input
+        used_compute_sharding = False
+        trim_rows_after_attention = 0
+        trim_seq_len = 0
+        trim_hidden_size = 0
+        auxiliary_tensors: list[ttnn.Tensor] = []
+
+        def track(tensor: ttnn.Tensor) -> None:
+            if tensor is not attention_input:
+                auxiliary_tensors.append(tensor)
+
+        try:
+            if len(attention_input_for_compute.shape) == 4:
+                flattened = ttnn.reshape(
+                    attention_input_for_compute,
+                    (
+                        int(attention_input_for_compute.shape[0]) * int(attention_input_for_compute.shape[1]),
+                        int(attention_input_for_compute.shape[2]),
+                        int(attention_input_for_compute.shape[3]),
+                    ),
+                )
+                if flattened is not attention_input_for_compute:
+                    track(flattened)
+                attention_input_for_compute = flattened
+            if len(attention_input_for_compute.shape) != 3:
+                raise ValueError(
+                    "Self-attention expects a rank-3 [B, S, D] tensor after canonicalization; "
+                    f"received rank={len(attention_input_for_compute.shape)}."
+                )
+
+            if runtime.use_sharded_attention_inputs:
+                canonical_input = attention_input_for_compute
+                sharding_input = canonical_input
+                input_rows = int(canonical_input.shape[0])
+                input_seq_len = int(canonical_input.shape[1])
+                input_hidden_size = int(canonical_input.shape[2])
+                if input_seq_len > 0 and (input_rows * input_seq_len) % ttnn.TILE_SIZE != 0:
+                    step = ttnn.TILE_SIZE // math.gcd(input_seq_len, ttnn.TILE_SIZE)
+                    aligned_rows = ((input_rows + step - 1) // step) * step
+                    pad_rows = aligned_rows - input_rows
+                    if pad_rows > 0:
+                        sharding_input = ttnn.pad(canonical_input, padding=((0, pad_rows), (0, 0), (0, 0)), value=0.0)
+                        track(sharding_input)
+                        trim_rows_after_attention = input_rows
+                        trim_seq_len = input_seq_len
+                        trim_hidden_size = input_hidden_size
+
+                sharded_input, used_compute_sharding = maybe_height_shard_3d_tensor(
+                    sharding_input, device=device, enable=True, allow_fallback=runtime.allow_shard_fallback
+                )
+                if used_compute_sharding:
+                    attention_input_for_compute = sharded_input
+                    if sharded_input is not sharding_input:
+                        track(sharded_input)
+                else:
+                    if sharded_input is not sharding_input:
+                        track(sharded_input)
+                    roundtripped_input, _ = sharded_layout_roundtrip_3d_tensor(
+                        canonical_input,
+                        device=device,
+                        enable=True,
+                        interleaved_memory_config=mem_cfg,
+                        max_rows_per_chunk=runtime.sharding_max_rows_per_chunk,
+                        allow_fallback=runtime.allow_shard_fallback,
+                    )
+                    if roundtripped_input is not canonical_input:
+                        attention_input_for_compute = roundtripped_input
+                        track(roundtripped_input)
+
+            attention_output = attention(attention_input_for_compute, runtime, device, dtype)
+            if used_compute_sharding and trim_rows_after_attention > 0:
+                trimmed_output = ttnn.slice(
+                    attention_output, (0, 0, 0), (trim_rows_after_attention, trim_seq_len, trim_hidden_size)
+                )
+                ttnn.deallocate(attention_output)
+                attention_output = trimmed_output
+            return attention_output
+        finally:
+            seen_ids: set[int] = set()
+            for tensor in auxiliary_tensors:
+                tensor_id = id(tensor)
+                if tensor_id in seen_ids:
+                    continue
+                seen_ids.add(tensor_id)
+                ttnn.deallocate(tensor)
+
+    for layer_idx, layer in enumerate(encoder_layers):
+        batch_size, num_channels, sequence_length, d_model = hidden_state.shape
+        x = ttnn.reshape(hidden_state, (batch_size * num_channels, sequence_length, d_model))
+        if pre_norm:
+            attn_out = run_attention(
+                _apply_norm_tt(layer.norm1_kind, layer.norm1_weight, layer.norm1_bias, x, mem_cfg), layer.attention
+            )
+            x = ttnn.add(x, attn_out, memory_config=mem_cfg)
+        else:
+            attn_out = run_attention(x, layer.attention)
+            x = _apply_norm_tt(
+                layer.norm1_kind,
+                layer.norm1_weight,
+                layer.norm1_bias,
+                ttnn.add(x, attn_out, memory_config=mem_cfg),
+                mem_cfg,
+            )
+        hidden_state = ttnn.reshape(x, (batch_size, num_channels, sequence_length, d_model))
+        ttnn.deallocate(attn_out)
+
+        if enable_channel_attention:
+            if (
+                not layer.channel_attention_enabled
+                or layer.norm2_kind is None
+                or layer.norm2_weight is None
+                or layer.norm2_bias is None
+            ):
+                raise ValueError(
+                    "channel_mode='attention' requested but reference checkpoint has channel_attention=False. "
+                    f"Layer {layer_idx} does not expose channel-attention parameters."
+                )
+            ch = ttnn.reshape(
+                ttnn.permute(hidden_state, (0, 2, 1, 3)), (batch_size * sequence_length, num_channels, d_model)
+            )
+            if pre_norm:
+                ch_attn_out = run_attention(
+                    _apply_norm_tt(layer.norm2_kind, layer.norm2_weight, layer.norm2_bias, ch, mem_cfg), layer.attention
+                )
+                ch = ttnn.add(ch, ch_attn_out, memory_config=mem_cfg)
+                ttnn.deallocate(ch_attn_out)
+            else:
+                ch_attn_out = run_attention(ch, layer.attention)
+                ch = _apply_norm_tt(
+                    layer.norm2_kind,
+                    layer.norm2_weight,
+                    layer.norm2_bias,
+                    ttnn.add(ch, ch_attn_out, memory_config=mem_cfg),
+                    mem_cfg,
+                )
+                ttnn.deallocate(ch_attn_out)
+            hidden_state = ttnn.permute(
+                ttnn.reshape(ch, (batch_size, sequence_length, num_channels, d_model)), (0, 2, 1, 3)
+            )
+
+        x = ttnn.reshape(hidden_state, (batch_size * num_channels, sequence_length, d_model))
+        if pre_norm:
+            ff_out = _feed_forward_tt(
+                _apply_norm_tt(layer.norm3_kind, layer.norm3_weight, layer.norm3_bias, x, mem_cfg),
+                layer,
+                mem_cfg,
+                dtype,
+                runtime.use_fused_ffn,
+            )
+            x = ttnn.add(x, ff_out, memory_config=mem_cfg)
+            ttnn.deallocate(ff_out)
+        else:
+            ff_out = _feed_forward_tt(x, layer, mem_cfg, dtype, runtime.use_fused_ffn)
+            x = _apply_norm_tt(
+                layer.norm3_kind,
+                layer.norm3_weight,
+                layer.norm3_bias,
+                ttnn.add(x, ff_out, memory_config=mem_cfg),
+                mem_cfg,
+            )
+            ttnn.deallocate(ff_out)
+        hidden_state = ttnn.reshape(x, (batch_size, num_channels, sequence_length, d_model))
+
+    return hidden_state
+
+
+def _build_norm(
+    state: dict[str, torch.Tensor], layer_module: torch.nn.Module, prefix: str, *, device, dtype, memory_config
+):
+    if isinstance(layer_module, torch.nn.LayerNorm):
+        return (
+            "layer_norm",
+            to_tt_param(state[f"{prefix}.weight"], device=device, dtype=dtype, memory_config=memory_config),
+            to_tt_param(state[f"{prefix}.bias"], device=device, dtype=dtype, memory_config=memory_config),
+        )
+    if hasattr(layer_module, "batchnorm"):
+        batch_norm = layer_module.batchnorm
+        weight = state[f"{prefix}.batchnorm.weight"].detach().to(torch.float32)
+        bias = state[f"{prefix}.batchnorm.bias"].detach().to(torch.float32)
+        running_mean = state[f"{prefix}.batchnorm.running_mean"].detach().to(torch.float32)
+        running_var = state[f"{prefix}.batchnorm.running_var"].detach().to(torch.float32)
+        scale = weight / torch.sqrt(running_var + float(batch_norm.eps))
+        shift = bias - running_mean * scale
+        return (
+            "batch_norm_affine",
+            to_tt_param(scale, device=device, dtype=dtype, memory_config=memory_config),
+            to_tt_param(shift, device=device, dtype=dtype, memory_config=memory_config),
+        )
+    raise ValueError(f"Unsupported norm module at {prefix}: {type(layer_module).__name__}")
+
+
+def build_encoder_layers(
+    reference: ReferenceArtifacts,
+    *,
+    device,
+    dtype: ttnn.DataType = ttnn.bfloat16,
+    memory_tier: str = "dram",
+) -> tuple[list[PatchTSTEncoderLayer], bool]:
+    state = reference.model.state_dict()
+    memory_config = MEMORY_CONFIG_BY_TIER[memory_tier]
+    encoder = reference.model.model.encoder
+    num_heads = int(reference.config.num_attention_heads)
+    hidden_size = int(reference.config.d_model)
+    padded_head_dim = ((hidden_size // num_heads + ttnn.TILE_SIZE - 1) // ttnn.TILE_SIZE) * ttnn.TILE_SIZE
+    layers = []
+    for layer_idx, layer_module in enumerate(encoder.layers):
+        layer_prefix = f"model.encoder.layers.{layer_idx}"
+        norm1_kind, norm1_weight, norm1_bias = _build_norm(
+            state,
+            getattr(layer_module, "norm_sublayer1"),
+            f"{layer_prefix}.norm_sublayer1",
+            device=device,
+            dtype=dtype,
+            memory_config=memory_config,
+        )
+        if getattr(layer_module, "channel_attention", False):
+            norm2_kind, norm2_weight, norm2_bias = _build_norm(
+                state,
+                getattr(layer_module, "norm_sublayer2"),
+                f"{layer_prefix}.norm_sublayer2",
+                device=device,
+                dtype=dtype,
+                memory_config=memory_config,
+            )
+        else:
+            norm2_kind, norm2_weight, norm2_bias = None, None, None
+        norm3_kind, norm3_weight, norm3_bias = _build_norm(
+            state,
+            getattr(layer_module, "norm_sublayer3"),
+            f"{layer_prefix}.norm_sublayer3",
+            device=device,
+            dtype=dtype,
+            memory_config=memory_config,
+        )
+        layers.append(
+            PatchTSTEncoderLayer(
+                attention=build_attention(
+                    state,
+                    layer_prefix,
+                    num_heads,
+                    padded_head_dim,
+                    device=device,
+                    dtype=dtype,
+                    memory_config=memory_config,
+                ),
+                norm1_kind=norm1_kind,
+                norm1_weight=norm1_weight,
+                norm1_bias=norm1_bias,
+                norm2_kind=norm2_kind,
+                norm2_weight=norm2_weight,
+                norm2_bias=norm2_bias,
+                norm3_kind=norm3_kind,
+                norm3_weight=norm3_weight,
+                norm3_bias=norm3_bias,
+                ff1=build_linear_from_state(
+                    state, f"{layer_prefix}.ff.0", device=device, dtype=dtype, memory_config=memory_config
+                ),
+                ff2=build_linear_from_state(
+                    state, f"{layer_prefix}.ff.3", device=device, dtype=dtype, memory_config=memory_config
+                ),
+                channel_attention_enabled=bool(getattr(layer_module, "channel_attention", False)),
+            )
+        )
+    return layers, bool(reference.config.pre_norm)

--- a/models/demos/wormhole/patchtst/tt/heads.py
+++ b/models/demos/wormhole/patchtst/tt/heads.py
@@ -1,0 +1,270 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+# Source lineage: HuggingFace PatchTST and PatchTST paper implementation details
+# - https://huggingface.co/docs/transformers/en/model_doc/patchtst
+# - https://github.com/huggingface/transformers/tree/main/src/transformers/models/patchtst
+# - https://arxiv.org/abs/2211.14730
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import ttnn
+from models.demos.wormhole.patchtst.reference.hf_reference import ReferenceArtifacts
+from models.demos.wormhole.patchtst.tt.common import (
+    MEMORY_CONFIG_BY_TIER,
+    PatchTSTRuntimePolicy,
+    TTLinear,
+    build_linear_from_state,
+)
+
+
+def _linear_on_last_dim(x: ttnn.Tensor, linear: TTLinear, mem_cfg, dtype: ttnn.DataType) -> ttnn.Tensor:
+    in_dim = int(x.shape[-1])
+    rank = len(x.shape)
+    original_shape = tuple(int(x.shape[idx]) for idx in range(rank - 1))
+    flattened = 1
+    for dim in original_shape:
+        flattened *= dim
+    flat = ttnn.reshape(x, (flattened, 1, in_dim))
+    out_tt = ttnn.linear(flat, linear.weight, bias=linear.bias, memory_config=mem_cfg, dtype=dtype)
+    out_dim = int(out_tt.shape[-1])
+    return ttnn.reshape(out_tt, (*original_shape, out_dim))
+
+
+def _pool_embedding(
+    embedding: ttnn.Tensor,
+    use_cls_token: bool,
+    pooling_type: str | None,
+    mem_cfg,
+) -> ttnn.Tensor:
+    if use_cls_token:
+        batch_size = int(embedding.shape[0])
+        num_channels = int(embedding.shape[1])
+        hidden_size = int(embedding.shape[3])
+        cls = ttnn.slice(embedding, (0, 0, 0, 0), (batch_size, num_channels, 1, hidden_size))
+        return ttnn.reshape(cls, (batch_size, num_channels, hidden_size))
+    if pooling_type == "mean":
+        return ttnn.mean(embedding, dim=2, keepdim=False, memory_config=mem_cfg)
+    if pooling_type == "max":
+        max_values = ttnn.max(embedding, dim=2, keepdim=False, memory_config=mem_cfg)
+        return max_values[0] if isinstance(max_values, tuple) else max_values
+    # For forecast heads when pooling is disabled, keep patch dimension.
+    return embedding
+
+
+@dataclass
+class ForecastHead:
+    share_projection: bool
+    shared_projection: TTLinear | None
+    channel_projections: list[TTLinear]
+    use_cls_token: bool
+    pooling_type: str | None
+    num_input_channels: int
+
+    def __call__(
+        self, embedding: ttnn.Tensor, runtime: PatchTSTRuntimePolicy, dtype: ttnn.DataType = ttnn.bfloat16
+    ) -> ttnn.Tensor:
+        mem_cfg = MEMORY_CONFIG_BY_TIER[runtime.activation_memory_tier]
+        pooled = _pool_embedding(embedding, self.use_cls_token, self.pooling_type, mem_cfg)
+        if self.share_projection:
+            if len(pooled.shape) == 4:
+                pooled = ttnn.reshape(
+                    pooled, (int(pooled.shape[0]), int(pooled.shape[1]), int(pooled.shape[2]) * int(pooled.shape[3]))
+                )
+            if self.shared_projection is None:
+                raise ValueError("share_projection=True requires a shared forecast projection.")
+            return ttnn.permute(_linear_on_last_dim(pooled, self.shared_projection, mem_cfg, dtype), (0, 2, 1))
+        outputs = []
+        for channel_idx in range(self.num_input_channels):
+            channel_input = ttnn.reshape(
+                ttnn.slice(pooled, (0, channel_idx, 0), (int(pooled.shape[0]), channel_idx + 1, int(pooled.shape[2]))),
+                (int(pooled.shape[0]), int(pooled.shape[2])),
+            )
+            outputs.append(_linear_on_last_dim(channel_input, self.channel_projections[channel_idx], mem_cfg, dtype))
+        stacked = ttnn.reshape(outputs[0], (int(outputs[0].shape[0]), 1, int(outputs[0].shape[1])))
+        for channel_output in outputs[1:]:
+            combined = ttnn.concat(
+                [
+                    stacked,
+                    ttnn.reshape(channel_output, (int(channel_output.shape[0]), 1, int(channel_output.shape[1]))),
+                ],
+                dim=1,
+            )
+            ttnn.deallocate(stacked)
+            stacked = combined
+        return ttnn.permute(stacked, (0, 2, 1))
+
+    def release(self) -> None:
+        if self.shared_projection is not None:
+            self.shared_projection.release()
+        for projection in self.channel_projections:
+            projection.release()
+
+
+@dataclass
+class RegressionHead:
+    projection: TTLinear | None
+    distribution_projections: tuple[TTLinear, TTLinear] | None
+    use_cls_token: bool
+    pooling_type: str | None
+    distribution_output: str | None
+
+    def __call__(self, embedding: ttnn.Tensor, runtime: PatchTSTRuntimePolicy, dtype: ttnn.DataType = ttnn.bfloat16):
+        mem_cfg = MEMORY_CONFIG_BY_TIER[runtime.activation_memory_tier]
+        pooled = _pool_embedding(embedding, self.use_cls_token, self.pooling_type, mem_cfg)
+        flat = ttnn.reshape(pooled, (int(pooled.shape[0]), int(pooled.shape[1]) * int(pooled.shape[2])))
+        if self.distribution_output:
+            if self.distribution_projections is None:
+                raise ValueError("distribution regression requires distribution projections.")
+            return tuple(_linear_on_last_dim(flat, proj, mem_cfg, dtype) for proj in self.distribution_projections)
+        if self.projection is None:
+            raise ValueError("regression projection is missing.")
+        return _linear_on_last_dim(flat, self.projection, mem_cfg, dtype)
+
+    def release(self) -> None:
+        if self.projection is not None:
+            self.projection.release()
+        if self.distribution_projections is not None:
+            self.distribution_projections[0].release()
+            self.distribution_projections[1].release()
+
+
+@dataclass
+class PretrainingHead:
+    projection: TTLinear
+    use_cls_token: bool
+
+    def __call__(
+        self, embedding: ttnn.Tensor, runtime: PatchTSTRuntimePolicy, dtype: ttnn.DataType = ttnn.bfloat16
+    ) -> ttnn.Tensor:
+        out = _linear_on_last_dim(
+            embedding, self.projection, MEMORY_CONFIG_BY_TIER[runtime.activation_memory_tier], dtype
+        )
+        if self.use_cls_token:
+            out = ttnn.slice(
+                out, (0, 0, 1, 0), (int(out.shape[0]), int(out.shape[1]), int(out.shape[2]), int(out.shape[3]))
+            )
+        return out
+
+    def release(self) -> None:
+        self.projection.release()
+
+
+@dataclass
+class ClassificationHead:
+    projection: TTLinear
+    use_cls_token: bool
+    pooling_type: str | None
+
+    def __call__(
+        self, embedding: ttnn.Tensor, runtime: PatchTSTRuntimePolicy, dtype: ttnn.DataType = ttnn.bfloat16
+    ) -> ttnn.Tensor:
+        mem_cfg = MEMORY_CONFIG_BY_TIER[runtime.activation_memory_tier]
+        pooled = _pool_embedding(embedding, self.use_cls_token, self.pooling_type, mem_cfg)
+        flat = ttnn.reshape(pooled, (int(pooled.shape[0]), int(pooled.shape[1]) * int(pooled.shape[2])))
+        return _linear_on_last_dim(flat, self.projection, mem_cfg, dtype)
+
+    def release(self) -> None:
+        self.projection.release()
+
+
+def build_forecast_head(
+    reference: ReferenceArtifacts, *, device, dtype: ttnn.DataType = ttnn.bfloat16, memory_tier: str = "dram"
+) -> ForecastHead | None:
+    if reference.task != "forecast":
+        return None
+    state = reference.model.state_dict()
+    memory_config = MEMORY_CONFIG_BY_TIER[memory_tier]
+    if bool(reference.config.share_projection):
+        return ForecastHead(
+            share_projection=True,
+            shared_projection=build_linear_from_state(
+                state, "head.projection", device=device, dtype=dtype, memory_config=memory_config
+            ),
+            channel_projections=[],
+            use_cls_token=bool(reference.config.use_cls_token),
+            pooling_type=reference.config.pooling_type,
+            num_input_channels=int(reference.config.num_input_channels),
+        )
+    return ForecastHead(
+        share_projection=False,
+        shared_projection=None,
+        channel_projections=[
+            build_linear_from_state(
+                state, f"head.projections.{idx}", device=device, dtype=dtype, memory_config=memory_config
+            )
+            for idx in range(int(reference.config.num_input_channels))
+        ],
+        use_cls_token=bool(reference.config.use_cls_token),
+        pooling_type=reference.config.pooling_type,
+        num_input_channels=int(reference.config.num_input_channels),
+    )
+
+
+def build_regression_head(
+    reference: ReferenceArtifacts, *, device, dtype: ttnn.DataType = ttnn.bfloat16, memory_tier: str = "dram"
+) -> RegressionHead | None:
+    if reference.task != "regression":
+        return None
+    state = reference.model.state_dict()
+    memory_config = MEMORY_CONFIG_BY_TIER[memory_tier]
+    if getattr(reference.model, "distribution_output", None):
+        return RegressionHead(
+            projection=None,
+            distribution_projections=(
+                build_linear_from_state(
+                    state, "head.projection.proj.0", device=device, dtype=dtype, memory_config=memory_config
+                ),
+                build_linear_from_state(
+                    state, "head.projection.proj.1", device=device, dtype=dtype, memory_config=memory_config
+                ),
+            ),
+            use_cls_token=bool(reference.config.use_cls_token),
+            pooling_type=reference.config.pooling_type,
+            distribution_output=reference.model.distribution_output,
+        )
+    return RegressionHead(
+        projection=build_linear_from_state(
+            state, "head.projection", device=device, dtype=dtype, memory_config=memory_config
+        ),
+        distribution_projections=None,
+        use_cls_token=bool(reference.config.use_cls_token),
+        pooling_type=reference.config.pooling_type,
+        distribution_output=None,
+    )
+
+
+def build_classification_head(
+    reference: ReferenceArtifacts, *, device, dtype: ttnn.DataType = ttnn.bfloat16, memory_tier: str = "dram"
+) -> ClassificationHead | None:
+    if reference.task != "classification":
+        return None
+    return ClassificationHead(
+        projection=build_linear_from_state(
+            reference.model.state_dict(),
+            "head.linear",
+            device=device,
+            dtype=dtype,
+            memory_config=MEMORY_CONFIG_BY_TIER[memory_tier],
+        ),
+        use_cls_token=bool(reference.config.use_cls_token),
+        pooling_type=reference.config.pooling_type,
+    )
+
+
+def build_pretraining_head(
+    reference: ReferenceArtifacts, *, device, dtype: ttnn.DataType = ttnn.bfloat16, memory_tier: str = "dram"
+) -> PretrainingHead | None:
+    if reference.task != "pretraining":
+        return None
+    return PretrainingHead(
+        projection=build_linear_from_state(
+            reference.model.state_dict(),
+            "head.linear",
+            device=device,
+            dtype=dtype,
+            memory_config=MEMORY_CONFIG_BY_TIER[memory_tier],
+        ),
+        use_cls_token=bool(reference.config.use_cls_token),
+    )

--- a/models/demos/wormhole/patchtst/tt/model.py
+++ b/models/demos/wormhole/patchtst/tt/model.py
@@ -1,0 +1,411 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+# Source lineage: HuggingFace PatchTST and PatchTST paper implementation details
+# - https://huggingface.co/docs/transformers/en/model_doc/patchtst
+# - https://github.com/huggingface/transformers/tree/main/src/transformers/models/patchtst
+# - https://arxiv.org/abs/2211.14730
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+
+import ttnn
+from models.demos.wormhole.patchtst.config import PatchTSTDemoConfig
+from models.demos.wormhole.patchtst.reference.hf_reference import ReferenceArtifacts
+from models.demos.wormhole.patchtst.tt.common import MEMORY_CONFIG_BY_TIER, TT_DTYPE, PatchTSTRuntimePolicy
+from models.demos.wormhole.patchtst.tt.embeddings import PatchTSTEmbedder, build_embedder
+from models.demos.wormhole.patchtst.tt.encoder import build_encoder_layers, encode_hidden_state
+from models.demos.wormhole.patchtst.tt.heads import (
+    ClassificationHead,
+    ForecastHead,
+    PretrainingHead,
+    RegressionHead,
+    build_classification_head,
+    build_forecast_head,
+    build_pretraining_head,
+    build_regression_head,
+)
+from models.demos.wormhole.patchtst.tt.patching import apply_mask, patchify, patchify_tt
+from models.demos.wormhole.patchtst.tt.positional_encoding import (
+    PatchTSTPositionalEncoding,
+    build_positional_encoding,
+    build_sincos_position_encoding,
+)
+
+
+def _to_torch_recursive(value: Any) -> Any:
+    if isinstance(value, ttnn.Tensor):
+        return ttnn.to_torch(ttnn.from_device(value))
+    if isinstance(value, dict):
+        return {k: _to_torch_recursive(v) for k, v in value.items()}
+    return value
+
+
+def _release_tt_value(value: Any) -> None:
+    if isinstance(value, ttnn.Tensor):
+        ttnn.deallocate(value)
+        return
+    if isinstance(value, dict):
+        for item in value.values():
+            _release_tt_value(item)
+
+
+@dataclass
+class PreparedEncoderInput:
+    hidden_state: ttnn.Tensor
+    mask: torch.Tensor | None
+    patch_input: torch.Tensor | None
+    loc: torch.Tensor
+    scale: torch.Tensor
+
+    def release(self) -> None:
+        ttnn.deallocate(self.hidden_state)
+
+
+@dataclass
+class PatchTSTTTNNOutput:
+    prediction: Any
+    mask: torch.Tensor | None = None
+    patch_input: torch.Tensor | None = None
+    loc: torch.Tensor | None = None
+    scale: torch.Tensor | None = None
+
+    def release(self) -> None:
+        _release_tt_value(self.prediction)
+
+
+class PatchTSTTTNNModel:
+    def __init__(
+        self,
+        demo_config: PatchTSTDemoConfig,
+        reference: ReferenceArtifacts,
+        device,
+        runtime_policy: PatchTSTRuntimePolicy,
+        classification_reference: ReferenceArtifacts | None = None,
+    ):
+        self.cfg = demo_config
+        self.reference = reference
+        self.device = device
+        self.runtime = runtime_policy
+        self.classification_reference = classification_reference
+
+        self.task = self.reference.task
+        self.ref_model = self.reference.model
+        self.ref_core = self.reference.model.model
+        self.ref_encoder = self.ref_core.encoder
+        self.io_dtype = TT_DTYPE
+        self.activation_memory_config = MEMORY_CONFIG_BY_TIER[self.runtime.activation_memory_tier]
+        self.embedder: PatchTSTEmbedder = build_embedder(
+            self.reference, device=device, dtype=TT_DTYPE, memory_tier=self.runtime.weight_memory_tier
+        )
+        self.positional: PatchTSTPositionalEncoding = build_positional_encoding(self.reference)
+        self.encoder_layers, self.pre_norm = build_encoder_layers(
+            self.reference, device=device, dtype=TT_DTYPE, memory_tier=self.runtime.weight_memory_tier
+        )
+        self.forecast_head: ForecastHead | None = build_forecast_head(
+            self.reference, device=device, dtype=TT_DTYPE, memory_tier=self.runtime.weight_memory_tier
+        )
+        self.regression_head: RegressionHead | None = build_regression_head(
+            self.reference, device=device, dtype=TT_DTYPE, memory_tier=self.runtime.weight_memory_tier
+        )
+        self.classification_head: ClassificationHead | None = build_classification_head(
+            self.reference, device=device, dtype=TT_DTYPE, memory_tier=self.runtime.weight_memory_tier
+        )
+        self.pretraining_head: PretrainingHead | None = build_pretraining_head(
+            self.reference, device=device, dtype=TT_DTYPE, memory_tier=self.runtime.weight_memory_tier
+        )
+        self.multi_task_classification_head: ClassificationHead | None = None
+        self.classification_config = None
+        if self.classification_reference is not None:
+            self._validate_multi_task_compatibility()
+            self.multi_task_classification_head = build_classification_head(
+                self.classification_reference,
+                device=device,
+                dtype=TT_DTYPE,
+                memory_tier=self.runtime.weight_memory_tier,
+            )
+            self.classification_config = self.classification_reference.config
+
+    def _validate_multi_task_compatibility(self) -> None:
+        if self.classification_reference is None:
+            return
+        forecast_cfg = self.reference.config
+        classification_cfg = self.classification_reference.config
+        for field_name in (
+            "context_length",
+            "patch_length",
+            "patch_stride",
+            "num_input_channels",
+            "d_model",
+            "ffn_dim",
+            "num_hidden_layers",
+            "num_attention_heads",
+            "share_embedding",
+            "use_cls_token",
+            "pooling_type",
+            "channel_attention",
+        ):
+            forecast_value = getattr(forecast_cfg, field_name)
+            classification_value = getattr(classification_cfg, field_name)
+            if forecast_value != classification_value:
+                raise ValueError(
+                    "Public multi_task runs require forecast and classification checkpoints with identical "
+                    f"encoder geometry, but field {field_name!r} differs: "
+                    f"forecast={forecast_value!r}, classification={classification_value!r}"
+                )
+        forecast_state = self.reference.model.state_dict()
+        classification_state = self.classification_reference.model.state_dict()
+        for key, tensor in forecast_state.items():
+            if (
+                not key.startswith("model.encoder.")
+                and not key.startswith("model.patchifier.")
+                and not key.startswith("model.scaler.")
+            ):
+                continue
+            if key not in classification_state:
+                raise ValueError(f"Classification checkpoint is missing shared encoder key: {key}")
+            if not torch.equal(tensor.detach().cpu(), classification_state[key].detach().cpu()):
+                raise ValueError(
+                    "Public multi_task requires the classification checkpoint to reuse the forecast encoder exactly, "
+                    f"but parameter {key!r} does not match."
+                )
+
+    def close(self) -> None:
+        self.embedder.release()
+        for layer in self.encoder_layers:
+            layer.release()
+        if self.forecast_head is not None:
+            self.forecast_head.release()
+        if self.regression_head is not None:
+            self.regression_head.release()
+        if self.classification_head is not None:
+            self.classification_head.release()
+        if self.pretraining_head is not None:
+            self.pretraining_head.release()
+        if self.multi_task_classification_head is not None:
+            self.multi_task_classification_head.release()
+
+    def prepare_hidden_input(
+        self,
+        past_values: torch.Tensor,
+        past_observed_mask: torch.Tensor | None = None,
+    ) -> PreparedEncoderInput:
+        if past_observed_mask is None:
+            past_observed_mask = torch.ones_like(past_values)
+
+        with torch.no_grad():
+            scaled_past_values, loc, scale = self.ref_core.scaler(past_values, past_observed_mask)
+            use_device_patching = bool(self.runtime.use_device_patching and not self.ref_core.do_mask_input)
+            if use_device_patching:
+                scaled_tt = ttnn.from_torch(
+                    scaled_past_values,
+                    dtype=self.io_dtype,
+                    layout=ttnn.TILE_LAYOUT,
+                    device=self.device,
+                    memory_config=self.activation_memory_config,
+                )
+                patch_input_tt = patchify_tt(
+                    scaled_tt,
+                    context_length=int(self.cfg.context_length),
+                    patch_length=self.cfg.patch_length,
+                    patch_stride=self.cfg.patch_stride,
+                )
+                ttnn.deallocate(scaled_tt)
+                patch_input = None
+            else:
+                patch_input_tt = None
+                patch_input = patchify(
+                    scaled_past_values,
+                    context_length=int(self.cfg.context_length),
+                    patch_length=self.cfg.patch_length,
+                    patch_stride=self.cfg.patch_stride,
+                )
+
+            if self.ref_core.do_mask_input:
+                # Pretraining checkpoints expect host-side masking semantics before TTNN embedding.
+                if patch_input is None:
+                    patch_input = ttnn.to_torch(ttnn.from_device(patch_input_tt))
+                    ttnn.deallocate(patch_input_tt)
+                    patch_input_tt = None
+                masked, mask = apply_mask(
+                    patch_input,
+                    mask_type=self.ref_core.masking.mask_type,
+                    random_mask_ratio=float(self.ref_core.masking.random_mask_ratio),
+                    num_forecast_mask_patches=self.ref_core.masking.num_forecast_mask_patches,
+                    mask_value=float(self.ref_core.masking.mask_value),
+                    seed=int(self.cfg.masking_seed),
+                )
+            else:
+                masked, mask = (patch_input_tt if patch_input_tt is not None else patch_input), None
+
+            checkpoint_share_embedding = bool(self.ref_encoder.embedder.share_embedding)
+            if self.cfg.share_embedding and not checkpoint_share_embedding:
+                raise ValueError(
+                    "share_embedding=True requested but checkpoint embedder is configured as non-shared. "
+                    "Set --share-embedding false for this checkpoint."
+                )
+
+            embedded = self.embedder(masked, bool(self.cfg.share_embedding), self.device, self.runtime, TT_DTYPE)
+            hidden = self.positional(embedded, self.device, self.runtime)
+            if hidden is not embedded:
+                ttnn.deallocate(embedded)
+            return PreparedEncoderInput(
+                hidden_state=hidden,
+                mask=mask,
+                patch_input=patch_input,
+                loc=loc,
+                scale=scale,
+            )
+
+    def prepare_hidden_input_host(
+        self,
+        past_values: torch.Tensor,
+        past_observed_mask: torch.Tensor | None = None,
+        *,
+        loc: torch.Tensor | None = None,
+        scale: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        if past_observed_mask is None:
+            past_observed_mask = torch.ones_like(past_values)
+
+        if loc is None or scale is None:
+            scaled_past_values, loc, scale = self.ref_core.scaler(past_values, past_observed_mask)
+        else:
+            scaled_past_values = (past_values - loc) / scale
+
+        patch_input = patchify(
+            scaled_past_values,
+            context_length=int(self.cfg.context_length),
+            patch_length=self.cfg.patch_length,
+            patch_stride=self.cfg.patch_stride,
+        )
+        if self.ref_core.do_mask_input:
+            raise ValueError("Cached streaming host prepare is only supported for non-masked forecast inference.")
+        if not bool(self.cfg.share_embedding):
+            raise ValueError("Cached streaming host prepare currently supports only share_embedding=True.")
+
+        projection_module = self.ref_encoder.embedder.input_embedding
+        projection_weight = projection_module.weight.detach()
+        projection_bias = projection_module.bias.detach() if projection_module.bias is not None else None
+        patch_input = patch_input.to(torch.float32)
+        embedded = F.linear(
+            patch_input,
+            projection_weight.to(torch.float32),
+            projection_bias.to(torch.float32) if projection_bias is not None else None,
+        )
+
+        checkpoint_pos = self.positional.position_enc.detach().to(torch.float32)
+        expected_tokens = int(embedded.shape[2]) + (1 if bool(self.reference.config.use_cls_token) else 0)
+        if int(checkpoint_pos.shape[0]) != expected_tokens:
+            if str(self.reference.config.positional_encoding_type) != "sincos":
+                raise ValueError(
+                    "Cached host prepare requires positional token count to match the checkpoint table or use sincos "
+                    f"position encoding. runtime_tokens={expected_tokens}, checkpoint_tokens={checkpoint_pos.shape[0]}"
+                )
+            checkpoint_pos = build_sincos_position_encoding(
+                num_positions=expected_tokens,
+                d_model=int(checkpoint_pos.shape[-1]),
+                device=checkpoint_pos.device,
+            )
+
+        if bool(self.reference.config.use_cls_token):
+            cls_token = self.positional.cls_token
+            if cls_token is None:
+                raise ValueError("use_cls_token=True but cls token parameters are missing.")
+            cls_token = cls_token.detach().to(torch.float32)
+            patch_pos = checkpoint_pos[1:, :].reshape(1, 1, int(embedded.shape[2]), -1)
+            patch_hidden = embedded + patch_pos
+            cls = (
+                (cls_token + checkpoint_pos[:1, :])
+                .reshape(1, 1, 1, -1)
+                .expand(int(embedded.shape[0]), int(embedded.shape[1]), -1, -1)
+            )
+            hidden = torch.cat([cls, patch_hidden], dim=2)
+        else:
+            pos = checkpoint_pos.reshape(1, 1, int(embedded.shape[2]), -1)
+            hidden = embedded + pos
+        return hidden.contiguous(), loc.contiguous(), scale.contiguous()
+
+    def forward_from_hidden_tt(
+        self,
+        prepared: PreparedEncoderInput,
+        task: str | None = None,
+    ) -> PatchTSTTTNNOutput:
+        encoded_hidden = encode_hidden_state(
+            prepared.hidden_state,
+            self.encoder_layers,
+            self.pre_norm,
+            self.cfg.channel_mode == "attention",
+            self.runtime,
+            self.device,
+            TT_DTYPE,
+        )
+        prediction = self.forward_heads_tt(encoded_hidden, task or self.task)
+        ttnn.deallocate(encoded_hidden)
+        return PatchTSTTTNNOutput(prediction, prepared.mask, prepared.patch_input, prepared.loc, prepared.scale)
+
+    def _forward_classification_head_multi_task(self, hidden_state: ttnn.Tensor):
+        if self.multi_task_classification_head is None or self.classification_config is None:
+            raise ValueError("Multi-task path requires a classification checkpoint/weights.")
+        if int(hidden_state.shape[1]) != int(self.classification_config.num_input_channels):
+            raise ValueError(
+                "Public multi_task runs do not allow channel coercion between the shared forecast encoder and the "
+                "classification head. Generate a task-matched checkpoint pair instead. "
+                f"hidden_channels={hidden_state.shape[1]}, classification_channels={self.classification_config.num_input_channels}"
+            )
+        return self.multi_task_classification_head(hidden_state, self.runtime, TT_DTYPE)
+
+    def forward_heads_tt(self, hidden_state: ttnn.Tensor, task: str):
+        if task == "forecast":
+            if self.forecast_head is None:
+                raise ValueError("Forecast head parameters are missing.")
+            return self.forecast_head(hidden_state, self.runtime, TT_DTYPE)
+        if task == "regression":
+            if self.regression_head is None:
+                raise ValueError("Regression head parameters are missing.")
+            return self.regression_head(hidden_state, self.runtime, TT_DTYPE)
+        if task == "pretraining":
+            if self.pretraining_head is None:
+                raise ValueError("Pretraining head parameters are missing.")
+            return self.pretraining_head(hidden_state, self.runtime, TT_DTYPE)
+        if task == "classification":
+            if self.classification_head is None:
+                raise ValueError("Classification head parameters are missing.")
+            return self.classification_head(hidden_state, self.runtime, TT_DTYPE)
+        if task == "multi_task":
+            return {
+                "forecast": self.forward_heads_tt(hidden_state, "forecast"),
+                "classification": self._forward_classification_head_multi_task(hidden_state),
+            }
+        raise ValueError(f"Unsupported task: {task}")
+
+    def forward_tt(
+        self,
+        past_values: torch.Tensor,
+        past_observed_mask: torch.Tensor | None = None,
+        task: str | None = None,
+    ) -> PatchTSTTTNNOutput:
+        prepared = self.prepare_hidden_input(past_values=past_values, past_observed_mask=past_observed_mask)
+        try:
+            return self.forward_from_hidden_tt(prepared=prepared, task=task)
+        finally:
+            prepared.release()
+
+    def forward(
+        self,
+        past_values: torch.Tensor,
+        past_observed_mask: torch.Tensor | None = None,
+        task: str | None = None,
+    ) -> PatchTSTTTNNOutput:
+        encoded = self.forward_tt(past_values=past_values, past_observed_mask=past_observed_mask, task=task)
+        encoded.prediction = _to_torch_recursive(encoded.prediction)
+        effective_task = task or self.task
+        if effective_task == "forecast" and isinstance(encoded.prediction, torch.Tensor):
+            encoded.prediction = encoded.prediction * encoded.scale + encoded.loc
+        if effective_task == "multi_task" and isinstance(encoded.prediction, dict):
+            encoded.prediction["forecast"] = encoded.prediction["forecast"] * encoded.scale + encoded.loc
+        return encoded

--- a/models/demos/wormhole/patchtst/tt/patching.py
+++ b/models/demos/wormhole/patchtst/tt/patching.py
@@ -1,0 +1,186 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+# Source lineage: HuggingFace PatchTST and PatchTST paper implementation details
+# - https://huggingface.co/docs/transformers/en/model_doc/patchtst
+# - https://github.com/huggingface/transformers/tree/main/src/transformers/models/patchtst
+# - https://arxiv.org/abs/2211.14730
+
+from __future__ import annotations
+
+import torch
+
+import ttnn
+
+
+def _resolve_patch_geometry(
+    runtime_context_length: int,
+    context_length: int,
+    patch_length: int,
+    patch_stride: int,
+) -> tuple[int, int, int]:
+    runtime_context_length = int(runtime_context_length)
+    if runtime_context_length != context_length:
+        # Bring-up supports runtime context override (e.g. long-context stretch path).
+        # We keep patch_length/stride fixed and derive patch windows from runtime sequence length.
+        context_length = runtime_context_length
+    if context_length <= patch_length:
+        raise ValueError("context_length must be greater than patch_length")
+
+    num_patches = (max(context_length, patch_length) - patch_length) // patch_stride + 1
+    new_sequence_length = patch_length + patch_stride * (num_patches - 1)
+    sequence_start = context_length - new_sequence_length
+    return context_length, num_patches, sequence_start
+
+
+def patchify(past_values: torch.Tensor, context_length: int, patch_length: int, patch_stride: int) -> torch.Tensor:
+    context_length, _, sequence_start = _resolve_patch_geometry(
+        runtime_context_length=int(past_values.shape[-2]),
+        context_length=context_length,
+        patch_length=patch_length,
+        patch_stride=patch_stride,
+    )
+
+    output = past_values[:, sequence_start:, :]
+    output = output.unfold(dimension=-2, size=patch_length, step=patch_stride)
+    output = output.transpose(-2, -3).contiguous()
+    return output
+
+
+def patchify_tt(past_values: ttnn.Tensor, context_length: int, patch_length: int, patch_stride: int) -> ttnn.Tensor:
+    batch_size = int(past_values.shape[0])
+    runtime_context_length = int(past_values.shape[1])
+    num_channels = int(past_values.shape[2])
+    _, num_patches, sequence_start = _resolve_patch_geometry(
+        runtime_context_length=runtime_context_length,
+        context_length=context_length,
+        patch_length=patch_length,
+        patch_stride=patch_stride,
+    )
+
+    pieces: list[ttnn.Tensor] = []
+    for patch_idx in range(num_patches):
+        start = sequence_start + patch_idx * patch_stride
+        end = start + patch_length
+        patch = ttnn.slice(
+            past_values,
+            (0, start, 0),
+            (batch_size, end, num_channels),
+        )
+        patch = ttnn.permute(patch, (0, 2, 1))
+        patch = ttnn.reshape(patch, (batch_size, num_channels, 1, patch_length))
+        pieces.append(patch)
+
+    if not pieces:
+        raise ValueError("patchify_tt produced zero patches.")
+
+    merged = pieces[0]
+    for part in pieces[1:]:
+        combined = ttnn.concat([merged, part], dim=2)
+        ttnn.deallocate(merged)
+        ttnn.deallocate(part)
+        merged = combined
+    return merged
+
+
+def random_masking(
+    patch_input: torch.Tensor,
+    random_mask_ratio: float,
+    mask_value: float = 0.0,
+    seed: int | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if random_mask_ratio < 0.0 or random_mask_ratio >= 1.0:
+        raise ValueError(f"random_mask_ratio must be in [0, 1), got {random_mask_ratio}")
+
+    bsz, channels, num_patches, patch_length = patch_input.shape
+    len_keep = int(num_patches * (1.0 - random_mask_ratio))
+
+    generator = None
+    if seed is not None:
+        generator = torch.Generator(device=patch_input.device.type)
+        generator.manual_seed(int(seed))
+    noise = torch.rand(bsz, channels, num_patches, device=patch_input.device, generator=generator)
+    base_mask = torch.ones((bsz, channels, num_patches), device=patch_input.device)
+    base_mask[:, :, :len_keep] = 0
+
+    ids_shuffle = torch.argsort(noise, dim=-1)
+    ids_restore = torch.argsort(ids_shuffle, dim=-1)
+    mask = torch.gather(base_mask, dim=-1, index=ids_restore)
+    expanded_mask = mask.unsqueeze(-1).expand(-1, -1, -1, patch_length).to(dtype=torch.bool)
+
+    masked = patch_input.masked_fill(expanded_mask, mask_value)
+    return masked, mask.to(dtype=torch.bool)
+
+
+def forecast_masking(
+    patch_input: torch.Tensor,
+    num_forecast_mask_patches: int | list[int] | tuple[int, ...],
+    mask_value: float = 0.0,
+    seed: int | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if isinstance(num_forecast_mask_patches, int):
+        forecast_choices = [num_forecast_mask_patches]
+    else:
+        forecast_choices = [int(value) for value in num_forecast_mask_patches]
+
+    if len(forecast_choices) == 0:
+        raise ValueError("num_forecast_mask_patches cannot be empty for forecast masking")
+
+    bsz, channels, num_patches, patch_length = patch_input.shape
+    mask = torch.zeros((bsz, channels, num_patches), device=patch_input.device)
+
+    groups: list[tuple[int, int]] = []
+    total_assigned = 0
+    for value in forecast_choices:
+        if value <= 0 or value >= num_patches:
+            raise ValueError(f"num_forecast_mask_patches value {value} must be > 0 and < num_patches ({num_patches})")
+        count = int(bsz / len(forecast_choices))
+        groups.append((value, count))
+        total_assigned += count
+
+    if total_assigned < bsz:
+        value, count = groups[0]
+        groups[0] = (value, count + (bsz - total_assigned))
+    elif total_assigned > bsz:
+        value, count = groups[-1]
+        groups[-1] = (value, count - (total_assigned - bsz))
+
+    start = 0
+    for patch_count, count in groups:
+        end = start + count
+        mask[start:end, :, -patch_count:] = 1
+        start = end
+
+    generator = None
+    if seed is not None:
+        generator = torch.Generator(device=patch_input.device.type)
+        generator.manual_seed(int(seed))
+    perm = torch.randperm(mask.shape[0], device=patch_input.device, generator=generator)
+    mask = mask[perm]
+    expanded_mask = mask.unsqueeze(-1).expand(-1, -1, -1, patch_length).to(dtype=torch.bool)
+    masked = patch_input.masked_fill(expanded_mask, mask_value)
+    return masked, mask.to(dtype=torch.bool)
+
+
+def apply_mask(
+    patch_input: torch.Tensor,
+    mask_type: str,
+    random_mask_ratio: float,
+    num_forecast_mask_patches: int | list[int] | tuple[int, ...],
+    mask_value: float,
+    seed: int | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if mask_type == "random":
+        return random_masking(
+            patch_input,
+            random_mask_ratio=random_mask_ratio,
+            mask_value=mask_value,
+            seed=seed,
+        )
+    if mask_type == "forecast":
+        return forecast_masking(
+            patch_input,
+            num_forecast_mask_patches=num_forecast_mask_patches,
+            mask_value=mask_value,
+            seed=seed,
+        )
+    raise ValueError(f"Unsupported mask_type: {mask_type}")

--- a/models/demos/wormhole/patchtst/tt/positional_encoding.py
+++ b/models/demos/wormhole/patchtst/tt/positional_encoding.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+# Source lineage: HuggingFace PatchTST and PatchTST paper implementation details
+# - https://huggingface.co/docs/transformers/en/model_doc/patchtst
+# - https://github.com/huggingface/transformers/tree/main/src/transformers/models/patchtst
+# - https://arxiv.org/abs/2211.14730
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import torch
+
+import ttnn
+from models.demos.wormhole.patchtst.reference.hf_reference import ReferenceArtifacts
+from models.demos.wormhole.patchtst.tt.common import MEMORY_CONFIG_BY_TIER, PatchTSTRuntimePolicy
+
+
+def build_sincos_position_encoding(num_positions: int, d_model: int, device: torch.device) -> torch.Tensor:
+    if num_positions <= 0:
+        raise ValueError(f"num_positions must be positive, got {num_positions}")
+    position = torch.arange(num_positions, dtype=torch.float32, device=device).unsqueeze(1)
+    div_term = torch.exp(
+        torch.arange(0, d_model, 2, dtype=torch.float32, device=device) * (-math.log(10000.0) / d_model)
+    )
+    pe = torch.zeros((num_positions, d_model), dtype=torch.float32, device=device)
+    pe[:, 0::2] = torch.sin(position * div_term)
+    pe[:, 1::2] = torch.cos(position * div_term)
+    return pe
+
+
+@dataclass
+class PatchTSTPositionalEncoding:
+    position_enc: torch.Tensor
+    cls_token: torch.Tensor | None
+    use_cls_token: bool
+    positional_encoding_type: str
+    num_input_channels: int
+
+    def __call__(self, embedding: ttnn.Tensor, device, runtime: PatchTSTRuntimePolicy) -> ttnn.Tensor:
+        mem_cfg = MEMORY_CONFIG_BY_TIER[runtime.activation_memory_tier]
+        num_patch_tokens = int(embedding.shape[2])
+        expected_tokens = num_patch_tokens + (1 if self.use_cls_token else 0)
+        pos = self.position_enc
+        if int(pos.shape[0]) != expected_tokens:
+            if self.positional_encoding_type != "sincos":
+                raise ValueError(
+                    "Runtime patch count does not match checkpoint positional table and checkpoint is not sincos. "
+                    f"runtime_tokens={expected_tokens}, checkpoint_tokens={pos.shape[0]}"
+                )
+            pos = build_sincos_position_encoding(expected_tokens, int(pos.shape[-1]), pos.device)
+
+        if self.use_cls_token:
+            if self.cls_token is None:
+                raise KeyError("use_cls_token=True but cls_token is missing from checkpoint.")
+            patch_pos_tt = ttnn.from_torch(
+                pos[1:].reshape(1, 1, num_patch_tokens, -1).expand(embedding.shape[0], self.num_input_channels, -1, -1),
+                dtype=embedding.dtype,
+                layout=ttnn.TILE_LAYOUT,
+                device=device,
+                memory_config=mem_cfg,
+            )
+            patch_part = ttnn.add(embedding, patch_pos_tt, memory_config=mem_cfg)
+            ttnn.deallocate(patch_pos_tt)
+            cls_tt = ttnn.from_torch(
+                (self.cls_token + pos[:1])
+                .reshape(1, 1, 1, -1)
+                .expand(embedding.shape[0], self.num_input_channels, -1, -1),
+                dtype=embedding.dtype,
+                layout=ttnn.TILE_LAYOUT,
+                device=device,
+                memory_config=mem_cfg,
+            )
+            encoded = ttnn.concat([cls_tt, patch_part], dim=2)
+            ttnn.deallocate(cls_tt)
+            ttnn.deallocate(patch_part)
+            return encoded
+
+        pos_tt = ttnn.from_torch(
+            pos.reshape(1, 1, num_patch_tokens, -1).expand(embedding.shape[0], self.num_input_channels, -1, -1),
+            dtype=embedding.dtype,
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            memory_config=mem_cfg,
+        )
+        encoded = ttnn.add(embedding, pos_tt, memory_config=mem_cfg)
+        ttnn.deallocate(pos_tt)
+        return encoded
+
+
+def build_positional_encoding(reference: ReferenceArtifacts) -> PatchTSTPositionalEncoding:
+    state = reference.model.state_dict()
+    return PatchTSTPositionalEncoding(
+        position_enc=state["model.encoder.positional_encoder.position_enc"].detach().to(torch.float32),
+        cls_token=(
+            state["model.encoder.positional_encoder.cls_token"].detach().to(torch.float32)
+            if "model.encoder.positional_encoder.cls_token" in state
+            else None
+        ),
+        use_cls_token=bool(reference.config.use_cls_token),
+        positional_encoding_type=str(reference.config.positional_encoding_type),
+        num_input_channels=int(reference.model.model.encoder.positional_encoder.num_input_channels),
+    )

--- a/models/demos/wormhole/patchtst/tt/streaming.py
+++ b/models/demos/wormhole/patchtst/tt/streaming.py
@@ -1,0 +1,247 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import torch
+
+import ttnn
+from models.demos.wormhole.patchtst.tt.common import TT_DTYPE
+from models.demos.wormhole.patchtst.tt.model import PatchTSTTTNNModel, PreparedEncoderInput
+
+
+class HostFullRerunPatchTSTStreamer:
+    """Legacy host-driven rolling-window helper for parity/debug use.
+
+    This path exists as the reference streaming baseline. Every step updates the host-side
+    context window and reruns the full PatchTST forward pass on that latest slice.
+    """
+
+    def __init__(
+        self,
+        model: PatchTSTTTNNModel,
+        initial_context: torch.Tensor,
+        initial_observed_mask: torch.Tensor | None = None,
+    ) -> None:
+        self.model = model
+        self.context_length = int(model.cfg.context_length)
+        self.context = initial_context.detach().clone()
+        self.observed_mask = (
+            initial_observed_mask.detach().clone()
+            if initial_observed_mask is not None
+            else torch.ones_like(self.context, dtype=torch.float32)
+        )
+
+        if self.context.ndim != 3:
+            raise ValueError(f"initial_context must be rank-3 [B, T, C], got shape={tuple(self.context.shape)}")
+        if int(self.context.shape[1]) != self.context_length:
+            raise ValueError(
+                f"initial_context length ({self.context.shape[1]}) must equal configured context_length ({self.context_length})"
+            )
+        if self.observed_mask.shape != self.context.shape:
+            raise ValueError(
+                "initial_observed_mask shape must match initial_context shape, "
+                f"got mask={tuple(self.observed_mask.shape)} context={tuple(self.context.shape)}"
+            )
+
+    def step(self, new_values: torch.Tensor, task: str = "forecast") -> torch.Tensor:
+        if new_values.ndim != 3:
+            raise ValueError(f"new_values must be rank-3 [B, T, C], got shape={tuple(new_values.shape)}")
+        if int(new_values.shape[0]) != int(self.context.shape[0]):
+            raise ValueError(
+                f"Batch mismatch: new_values batch={new_values.shape[0]} does not match context batch={self.context.shape[0]}"
+            )
+        if int(new_values.shape[2]) != int(self.context.shape[2]):
+            raise ValueError(
+                "Channel mismatch: "
+                f"new_values channels={new_values.shape[2]} does not match context channels={self.context.shape[2]}"
+            )
+
+        self.context = torch.cat([self.context, new_values], dim=1)[:, -self.context_length :, :].contiguous()
+        new_observed = torch.ones_like(new_values, dtype=self.observed_mask.dtype)
+        self.observed_mask = torch.cat([self.observed_mask, new_observed], dim=1)[
+            :, -self.context_length :, :
+        ].contiguous()
+
+        output = self.model.forward(
+            past_values=self.context,
+            past_observed_mask=self.observed_mask,
+            task=task,
+        )
+        prediction = output.prediction
+        if not isinstance(prediction, torch.Tensor):
+            raise TypeError("Legacy streaming baseline expects a tensor forecast prediction.")
+        return prediction
+
+
+class CachedForecastStreamer:
+    """Stateful forecast-only streaming helper with persistent device buffers.
+
+    This implementation is materially different from the legacy full-rerun helper:
+    - it keeps a rolling raw context window on host,
+    - it updates exact sliding-window normalization statistics incrementally,
+    - it reuses a persistent device-side hidden-state buffer between steps,
+    - it optionally replays a captured encoder/head trace on that stable buffer.
+
+    It does *not* claim decoder-style autoregressive KV-cache semantics. PatchTST is an
+    encoder-only sliding-window forecaster, so the cached state here is:
+    - rolling raw context,
+    - exact normalization statistics,
+    - persistent pre-encoder hidden/input buffers,
+    - optional traced replay state.
+    The encoder itself is still executed every step on the latest context window.
+    """
+
+    def __init__(
+        self,
+        model: PatchTSTTTNNModel,
+        initial_context: torch.Tensor,
+        initial_observed_mask: torch.Tensor | None = None,
+        *,
+        use_trace: bool = True,
+    ) -> None:
+        self.model = model
+        self.context_length = int(model.cfg.context_length)
+        self.context = initial_context.detach().clone()
+        self.observed_mask = (
+            initial_observed_mask.detach().clone()
+            if initial_observed_mask is not None
+            else torch.ones_like(self.context, dtype=torch.float32)
+        )
+        self.use_trace = bool(use_trace)
+        self.trace_id: int | None = None
+        self.traced_output = None
+        self.prepared: PreparedEncoderInput | None = None
+        self._minimum_scale = float(model.ref_core.scaler.scaler.minimum_scale)
+        self._sum = (self.context * self.observed_mask).sum(dim=1, keepdim=True).to(torch.float32)
+        self._sum_sq = ((self.context.to(torch.float32) ** 2) * self.observed_mask).sum(dim=1, keepdim=True)
+        self._count = self.observed_mask.sum(dim=1, keepdim=True).clamp_min(1.0).to(torch.float32)
+        self._validate_inputs()
+        self._initialize_runtime()
+
+    def _validate_inputs(self) -> None:
+        if self.model.reference.task != "forecast":
+            raise ValueError("Cached streaming is only supported for the forecasting task.")
+        if self.model.cfg.channel_mode != "independent":
+            raise ValueError("Cached streaming is only supported for channel_mode='independent'.")
+        if not bool(self.model.cfg.share_embedding):
+            raise ValueError("Cached streaming is only supported for share_embedding=True.")
+        if bool(self.model.ref_core.do_mask_input):
+            raise ValueError("Cached streaming does not support masked-pretraining checkpoints.")
+        if self.context.ndim != 3:
+            raise ValueError(f"initial_context must be rank-3 [B, T, C], got shape={tuple(self.context.shape)}")
+        if int(self.context.shape[1]) != self.context_length:
+            raise ValueError(
+                f"initial_context length ({self.context.shape[1]}) must equal configured context_length ({self.context_length})"
+            )
+        if self.observed_mask.shape != self.context.shape:
+            raise ValueError(
+                "initial_observed_mask shape must match initial_context shape, "
+                f"got mask={tuple(self.observed_mask.shape)} context={tuple(self.context.shape)}"
+            )
+        if not torch.all(self.observed_mask == 1):
+            raise ValueError("Cached streaming currently supports fully observed inputs only.")
+
+    def _current_loc_scale(self) -> tuple[torch.Tensor, torch.Tensor]:
+        denominator = self._count.clamp_min(1.0)
+        loc = self._sum / denominator
+        variance = (self._sum_sq / denominator) - torch.square(loc)
+        variance = torch.clamp(variance, min=0.0)
+        scale = torch.sqrt(variance + self._minimum_scale)
+        return loc.to(torch.float32), scale.to(torch.float32)
+
+    def _initialize_runtime(self) -> None:
+        loc, scale = self._current_loc_scale()
+        self.prepared = self.model.prepare_hidden_input(self.context, self.observed_mask)
+
+        warm_output = self.model.forward_from_hidden_tt(self.prepared, task="forecast")
+        warm_output.release()
+        ttnn.synchronize_device(self.model.device)
+
+        if self.use_trace:
+            trace_id = ttnn.begin_trace_capture(self.model.device, cq_id=0)
+            self.traced_output = self.model.forward_from_hidden_tt(self.prepared, task="forecast")
+            ttnn.end_trace_capture(self.model.device, trace_id, cq_id=0)
+            ttnn.synchronize_device(self.model.device)
+            self.trace_id = trace_id
+
+        # Copy the exact host-prepared hidden state into the persistent device buffer so the
+        # cached path always starts from the same semantics as the eager reference preprocess.
+        hidden_host, _, _ = self.model.prepare_hidden_input_host(self.context, self.observed_mask, loc=loc, scale=scale)
+        hidden_host_tt = ttnn.from_torch(hidden_host, dtype=TT_DTYPE, layout=ttnn.TILE_LAYOUT)
+        try:
+            ttnn.copy_host_to_device_tensor(hidden_host_tt, self.prepared.hidden_state, 1)
+            ttnn.synchronize_device(self.model.device)
+        finally:
+            ttnn.deallocate(hidden_host_tt)
+
+    def close(self) -> None:
+        if self.trace_id is not None:
+            ttnn.release_trace(self.model.device, self.trace_id)
+            self.trace_id = None
+        if self.traced_output is not None:
+            self.traced_output.release()
+            self.traced_output = None
+        if self.prepared is not None:
+            self.prepared.release()
+            self.prepared = None
+
+    def _update_context_state(self, new_values: torch.Tensor) -> None:
+        if new_values.ndim != 3:
+            raise ValueError(f"new_values must be rank-3 [B, T, C], got shape={tuple(new_values.shape)}")
+        if int(new_values.shape[0]) != int(self.context.shape[0]):
+            raise ValueError(
+                f"Batch mismatch: new_values batch={new_values.shape[0]} does not match context batch={self.context.shape[0]}"
+            )
+        if int(new_values.shape[2]) != int(self.context.shape[2]):
+            raise ValueError(
+                "Channel mismatch: "
+                f"new_values channels={new_values.shape[2]} does not match context channels={self.context.shape[2]}"
+            )
+        step = int(new_values.shape[1])
+        dropped = self.context[:, :step, :]
+        self.context = torch.cat([self.context, new_values], dim=1)[:, -self.context_length :, :].contiguous()
+        self._sum = (
+            self._sum
+            - dropped.sum(dim=1, keepdim=True).to(torch.float32)
+            + new_values.sum(dim=1, keepdim=True).to(torch.float32)
+        )
+        self._sum_sq = (
+            self._sum_sq
+            - (dropped.to(torch.float32) ** 2).sum(dim=1, keepdim=True)
+            + (new_values.to(torch.float32) ** 2).sum(dim=1, keepdim=True)
+        )
+        self._count = torch.full_like(self._count, float(self.context_length))
+
+    def step(self, new_values: torch.Tensor) -> torch.Tensor:
+        if self.prepared is None:
+            raise RuntimeError("CachedForecastStreamer is closed.")
+
+        self._update_context_state(new_values)
+        loc, scale = self._current_loc_scale()
+        hidden_host, _, _ = self.model.prepare_hidden_input_host(self.context, self.observed_mask, loc=loc, scale=scale)
+        hidden_host_tt = ttnn.from_torch(hidden_host, dtype=TT_DTYPE, layout=ttnn.TILE_LAYOUT)
+        try:
+            ttnn.copy_host_to_device_tensor(hidden_host_tt, self.prepared.hidden_state, 1)
+            ttnn.synchronize_device(self.model.device)
+        finally:
+            ttnn.deallocate(hidden_host_tt)
+
+        if self.use_trace:
+            if self.trace_id is None or self.traced_output is None:
+                raise RuntimeError("CachedForecastStreamer trace state was not initialized.")
+            ttnn.execute_trace(self.model.device, self.trace_id, cq_id=0, blocking=False)
+            ttnn.synchronize_device(self.model.device)
+            prediction = ttnn.to_torch(ttnn.from_device(self.traced_output.prediction))
+        else:
+            output = self.model.forward_from_hidden_tt(self.prepared, task="forecast")
+            try:
+                ttnn.synchronize_device(self.model.device)
+                prediction = ttnn.to_torch(ttnn.from_device(output.prediction))
+            finally:
+                output.release()
+        return prediction * scale + loc
+
+
+# Backward-compatible alias while downstream tests and helper imports migrate to the explicit names.
+RollingPatchTSTStreamer = HostFullRerunPatchTSTStreamer


### PR DESCRIPTION
### Ticket
Link to Github Issue

#32139

### Problem description

This PR brings up [PatchTST (Patch Time Series Transformer)](https://huggingface.co/docs/transformers/en/model_doc/patchtst) using TTNN APIs on Tenstorrent hardware.

### Core Architecture

* **Full TTNN forecasting path:** Patch extraction, shared patch embedding, positional encoding, Transformer encoder layers, and task heads execute on-device through TTNN-backed model code under `models/demos/wormhole/patchtst/tt`.
* **Supported public tasks:** Forecasting, regression, classification, pretraining, and a shared-encoder forecast + classification runtime path.
* **Channel modeling modes:** Channel-independent mode is the primary optimized path; channel-attention checkpoints are also supported for public correctness runs.
* **Streaming runtime:** Includes a cached rolling-context forecast helper with persistent device buffers and optional trace replay, plus a host full-rerun baseline for parity/debug.

### Validation & Accuracy

* **End-to-end test surface:** `22/22` PatchTST tests passed on Wormhole using the repo-built `ttnn` runtime (`1` unit, `14` integration, `7` perf).
* **Forecast parity:** ETTh1 batch-1 trace run reached parity correlation `0.999871` against the PyTorch reference.
* **Forecast task quality:** ETTh1 batch-1 forecast quality correlation was `0.701187`; weather generalization remained high in the integration suite.
* **Streaming evidence:** Cached forecast streaming measured `full_rerun_ms=89.444426; speedup=0.745726; step_parity_corr=[0.999971, 0.999978, 0.999967, 0.999982, 0.999946, 0.999865, 0.999942, 0.999954]`.



* **Performance targets:**



| Metric                   | Target | Measured |
|-------------------------|--------|----------|
| Throughput (batch=1)    |     150+ seq/s   |      732 seq/s    |
| Latency (batch=1)       |   <40ms     |      1.364ms    |
| Throughput (batch=16)   |     800+ seq/s   |   1942 seq/s   |
| Latency (batch=16)      |    <15ms    |  8.23ms        |


* **Validation log:** 
[validation.log](https://github.com/user-attachments/files/26022914/validation.log)



###  Performance Artifacts

* **Perf sheet:** : 
[perf_sheet.csv](https://github.com/user-attachments/files/26022905/perf_sheet.csv)

* **Tracy / ops perf report:** 
[profile_log_device.csv](https://github.com/user-attachments/files/26022939/profile_log_device.csv)


### Sample Output

**ETTh1 forecast sample**  
<img width="1920" height="800" alt="sample_forecast_etth1" src="https://github.com/user-attachments/assets/4e576d45-a6c4-49b9-934d-c53355e77ac7" />


**Weather forecast sample**  
**Heartbeat classification sample**  


### Optimisations

* **Trace replay path for forecast inference:** Stable-buffer trace capture/replay is implemented for the primary forecast path.
* **Stage-2 sharded path:** Forecast runs support sharded attention inputs and device-side patch extraction in the stricter sharded workload.
* **Batch throughput path:** Batch-16 trace runs keep activations in L1 through the tuned runtime policy used by the perf tests.
* **Streaming cache path:** Cached streaming reuses persistent hidden-state buffers and optional trace replay instead of recreating all runtime state each step.
* **Shared-encoder multi-task path:** Forecast and classification heads can reuse one encoder pass for lower latency than sequential execution.

### Known limitations

* The primary trace performance numbers are measured on the traced replay path, not the full host preprocessing path from raw `past_values`.
* The cached streaming helper is a rolling-context forecast cache; it does not claim decoder-style autoregressive KV-cache semantics.
* The current public multi-task perf gate proves shared execution and latency gain, but its classification-quality threshold is weak and should be reviewed separately.


### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:{{branch_name}})
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212805823112233