### PR TITLE
[DM] Exclude noc estimator tests from L2 Nightly

### DIFF
--- a/.github/workflows/tm-data-movement-wrapper.yaml
+++ b/.github/workflows/tm-data-movement-wrapper.yaml
@@ -131,7 +131,7 @@ jobs:
         docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
         build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
         wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-        gtest_filter: "*-*NIGHTLY_*"
+        gtest_filter: "*-*NIGHTLY_*:*NocEstimator*"
   data-movement-perf-tests:
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.run-perf-tests != false || (github.event_name == 'workflow_call' || github.event_name == 'push') }}
     uses: ./.github/workflows/tm-data-movement-perf-impl.yaml

--- a/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/test_noc_estimator.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/test_noc_estimator.cpp
@@ -1374,77 +1374,77 @@ static void sweep_column_to_column(const shared_ptr<distributed::MeshDevice>& me
 // ============ TEST CASES ============
 
 // ---- L1 tests (800-809) ----
-TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorL1OneToOne) {
+TEST_F(GenericMeshDeviceFixture, NocEstimatorL1OneToOne) {
     unit_tests::dm::noc_estimator::sweep_one_to_one(get_mesh_device(), 800);
 }
 
-TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorL1OneFromOne) {
+TEST_F(GenericMeshDeviceFixture, NocEstimatorL1OneFromOne) {
     unit_tests::dm::noc_estimator::sweep_one_from_one(get_mesh_device(), 801);
 }
 
-TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorL1OneToAll) {
+TEST_F(GenericMeshDeviceFixture, NocEstimatorL1OneToAll) {
     unit_tests::dm::noc_estimator::sweep_one_to_all(get_mesh_device(), 802);
 }
 
-TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorL1OneFromAll) {
+TEST_F(GenericMeshDeviceFixture, NocEstimatorL1OneFromAll) {
     unit_tests::dm::noc_estimator::sweep_one_from_all(get_mesh_device(), 803);
 }
 
-TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorL1AllToAll) {
+TEST_F(GenericMeshDeviceFixture, NocEstimatorL1AllToAll) {
     unit_tests::dm::noc_estimator::sweep_all_to_all(get_mesh_device(), 804);
 }
 
-TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorL1AllFromAll) {
+TEST_F(GenericMeshDeviceFixture, NocEstimatorL1AllFromAll) {
     unit_tests::dm::noc_estimator::sweep_all_from_all(get_mesh_device(), 805);
 }
 
-TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorL1OneToRow) {
+TEST_F(GenericMeshDeviceFixture, NocEstimatorL1OneToRow) {
     unit_tests::dm::noc_estimator::sweep_one_to_row(get_mesh_device(), 806);
 }
 
-TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorL1RowToRow) {
+TEST_F(GenericMeshDeviceFixture, NocEstimatorL1RowToRow) {
     unit_tests::dm::noc_estimator::sweep_row_to_row(get_mesh_device(), 807);
 }
 
-TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorL1OneToColumn) {
+TEST_F(GenericMeshDeviceFixture, NocEstimatorL1OneToColumn) {
     unit_tests::dm::noc_estimator::sweep_one_to_column(get_mesh_device(), 808);
 }
 
-TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorL1ColumnToColumn) {
+TEST_F(GenericMeshDeviceFixture, NocEstimatorL1ColumnToColumn) {
     unit_tests::dm::noc_estimator::sweep_column_to_column(get_mesh_device(), 809);
 }
 
 // ---- DRAM Read tests (810-813) ----
-TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorDRAMShardedOneFromOne) {
+TEST_F(GenericMeshDeviceFixture, NocEstimatorDRAMShardedOneFromOne) {
     unit_tests::dm::noc_estimator::sweep_dram_sharded_one_from_one(get_mesh_device(), 810);
 }
 
-TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorDRAMShardedAllFromAll) {
+TEST_F(GenericMeshDeviceFixture, NocEstimatorDRAMShardedAllFromAll) {
     unit_tests::dm::noc_estimator::sweep_dram_sharded_all_from_all(get_mesh_device(), 811);
 }
 
-TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorDRAMInterleavedOneFromAll) {
+TEST_F(GenericMeshDeviceFixture, NocEstimatorDRAMInterleavedOneFromAll) {
     unit_tests::dm::noc_estimator::sweep_dram_interleaved_one_from_all(get_mesh_device(), 812);
 }
 
-TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorDRAMInterleavedAllFromAll) {
+TEST_F(GenericMeshDeviceFixture, NocEstimatorDRAMInterleavedAllFromAll) {
     unit_tests::dm::noc_estimator::sweep_dram_interleaved_all_from_all(get_mesh_device(), 813);
 }
 
 // ---- DRAM Write tests (814-817) ----
-TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorDRAMShardedOneToOne) {
+TEST_F(GenericMeshDeviceFixture, NocEstimatorDRAMShardedOneToOne) {
     unit_tests::dm::noc_estimator::sweep_dram_sharded_one_to_one(get_mesh_device(), 814);
 }
 
-TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorDRAMShardedAllToAll) {
+TEST_F(GenericMeshDeviceFixture, NocEstimatorDRAMShardedAllToAll) {
     unit_tests::dm::noc_estimator::sweep_dram_sharded_all_to_all(get_mesh_device(), 815);
 }
 
-TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorDRAMInterleavedOneToAll) {
+TEST_F(GenericMeshDeviceFixture, NocEstimatorDRAMInterleavedOneToAll) {
     unit_tests::dm::noc_estimator::sweep_dram_interleaved_one_to_all(get_mesh_device(), 816);
 }
 
-TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorDRAMInterleavedAllToAll) {
+TEST_F(GenericMeshDeviceFixture, NocEstimatorDRAMInterleavedAllToAll) {
     unit_tests::dm::noc_estimator::sweep_dram_interleaved_all_to_all(get_mesh_device(), 817);
 }
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/39869)

### Problem description
The current NoC estimator tests were timing out on [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml).

### What's changed
There's no need for these tests to be running in any workflow.
I removed the NIGHTLY_ filter and excluded them from the TM-DM workflow.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nstamatovic/noc_estimator_ci_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nstamatovic/noc_estimator_ci_fix)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nstamatovic/noc_estimator_ci_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nstamatovic/noc_estimator_ci_fix)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nstamatovic/noc_estimator_ci_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nstamatovic/noc_estimator_ci_fix)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nstamatovic/noc_estimator_ci_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nstamatovic/noc_estimator_ci_fix)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nstamatovic/noc_estimator_ci_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nstamatovic/noc_estimator_ci_fix)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nstamatovic/noc_estimator_ci_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nstamatovic/noc_estimator_ci_fix)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
