### PR TITLE
SDXL support accuracy for 512 resolution

### DIFF
--- a/models/demos/stable_diffusion_xl_base/demo/demo.py
+++ b/models/demos/stable_diffusion_xl_base/demo/demo.py
@@ -312,8 +312,9 @@ def test_demo(
     timesteps,
     sigmas,
 ):
-    if image_resolution == (512, 512) and is_blackhole():
-        pytest.skip("512x512 not supported on Blackhole")
+    if vae_on_device and is_blackhole():
+        pytest.skip("Device VAE not supported on Blackhole")
+
     prepare_device(mesh_device, use_cfg_parallel)
     return run_demo_inference(
         mesh_device,

--- a/models/demos/stable_diffusion_xl_base/demo/demo_base_and_refiner.py
+++ b/models/demos/stable_diffusion_xl_base/demo/demo_base_and_refiner.py
@@ -54,6 +54,9 @@ def run_demo_inference(
     timesteps=None,
     sigmas=None,
 ):
+    if vae_on_device and is_blackhole():
+        pytest.skip("Device VAE not supported on Blackhole")
+
     batch_size = determinate_min_batch_size(ttnn_device, use_cfg_parallel)
 
     start_from, _ = evaluation_range

--- a/models/demos/stable_diffusion_xl_base/demo/demo_img2img.py
+++ b/models/demos/stable_diffusion_xl_base/demo/demo_img2img.py
@@ -339,8 +339,9 @@ def test_demo(
     timesteps,
     sigmas,
 ):
-    if image_resolution == (512, 512) and is_blackhole():
-        pytest.skip("512x512 not supported on Blackhole")
+    if vae_on_device and is_blackhole():
+        pytest.skip("Device VAE not supported on Blackhole")
+
     if isinstance(images_or_path, str):
         images = [Image.open(images_or_path).convert("RGB")]
     else:

--- a/models/demos/stable_diffusion_xl_base/demo/demo_inpainting.py
+++ b/models/demos/stable_diffusion_xl_base/demo/demo_inpainting.py
@@ -389,8 +389,9 @@ def test_demo(
     input_images=None,
     input_masks=None,
 ):
-    if image_resolution == (512, 512) and is_blackhole():
-        pytest.skip("512x512 not supported on Blackhole")
+    if vae_on_device and is_blackhole():
+        pytest.skip("Device VAE not supported on Blackhole")
+
     prepare_device(mesh_device, use_cfg_parallel)
     return run_demo_inference(
         mesh_device,

--- a/models/demos/stable_diffusion_xl_base/demo/demo_lora.py
+++ b/models/demos/stable_diffusion_xl_base/demo/demo_lora.py
@@ -13,7 +13,7 @@ from transformers import CLIPTextModel, CLIPTextModelWithProjection
 
 import ttnn
 from conftest import is_galaxy
-from models.common.utility_functions import profiler, is_blackhole
+from models.common.utility_functions import is_blackhole, profiler
 from models.demos.stable_diffusion_xl_base.tests.test_common import (
     CONCATENATED_TEXT_EMBEDINGS_SIZE,
     MAX_SEQUENCE_LENGTH,
@@ -50,8 +50,8 @@ def run_demo_inference(
     sigmas=None,
     lora_path=None,
 ):
-    if image_resolution == (512, 512) and is_blackhole():
-        pytest.skip("512x512 not supported on Blackhole")
+    if vae_on_device and is_blackhole():
+        pytest.skip("Device VAE not supported on Blackhole")
 
     batch_size = determinate_min_batch_size(ttnn_device, use_cfg_parallel)
 

--- a/models/demos/stable_diffusion_xl_base/demo/demo_lora.py
+++ b/models/demos/stable_diffusion_xl_base/demo/demo_lora.py
@@ -13,7 +13,7 @@ from transformers import CLIPTextModel, CLIPTextModelWithProjection
 
 import ttnn
 from conftest import is_galaxy
-from models.common.utility_functions import profiler
+from models.common.utility_functions import profiler, is_blackhole
 from models.demos.stable_diffusion_xl_base.tests.test_common import (
     CONCATENATED_TEXT_EMBEDINGS_SIZE,
     MAX_SEQUENCE_LENGTH,
@@ -50,6 +50,9 @@ def run_demo_inference(
     sigmas=None,
     lora_path=None,
 ):
+    if image_resolution == (512, 512) and is_blackhole():
+        pytest.skip("512x512 not supported on Blackhole")
+
     batch_size = determinate_min_batch_size(ttnn_device, use_cfg_parallel)
 
     start_from, _ = evaluation_range

--- a/models/demos/stable_diffusion_xl_base/targets/targets.json
+++ b/models/demos/stable_diffusion_xl_base/targets/targets.json
@@ -1,5 +1,5 @@
 {
-  "sdxl": {
+  "sdxl-1024": {
     "perf": {
       "functional": 125,
       "complete":   25,
@@ -21,7 +21,30 @@
       "warning": 25
     }
   },
-  "sdxl-inpaint": {
+  "sdxl-512": {
+    "perf": {
+      "functional": 62.5,
+      "complete": 12.5,
+      "target": 6.25
+    },
+    "perf-tp": {
+      "functional": 31.25,
+      "complete": 6.25,
+      "target": 3.125
+    },
+    "accuracy": {
+      "_TODO": "Determine proper ranges for 512x512 resolution",
+      "fid_valid_range_full_dataset": [10.0, 50.0],
+      "clip_valid_range_full_dataset": [20.0, 40.0],
+      "clip_valid_range_100": [20.0, 40.0],
+      "fid_valid_range_100": [100.0, 300.0]
+    },
+    "clip_score_thresholds": {
+      "error": 19,
+      "warning": 25
+    }
+  },
+  "sdxl-inpaint-1024": {
     "perf": {
       "functional": 125,
       "complete":   25,
@@ -43,7 +66,30 @@
       "warning": 25
     }
   },
-  "sdxl-img2img": {
+  "sdxl-inpaint-512": {
+    "perf": {
+      "functional": 62.5,
+      "complete": 12.5,
+      "target": 6.25
+    },
+    "perf-tp": {
+      "functional": 31.25,
+      "complete": 6.25,
+      "target": 3.125
+    },
+    "accuracy": {
+      "_TODO": "Determine proper ranges for 512x512 resolution",
+      "fid_valid_range_full_dataset": [10.0, 50.0],
+      "clip_valid_range_full_dataset": [20.0, 40.0],
+      "clip_valid_range_100": [20.0, 40.0],
+      "fid_valid_range_100": [100.0, 300.0]
+    },
+    "clip_score_thresholds": {
+      "error": 19.5,
+      "warning": 25
+    }
+  },
+  "sdxl-img2img-1024": {
     "perf": {
       "functional": 125,
       "complete":   25,
@@ -59,7 +105,24 @@
       "clip_valid_range_100": [0.111, 0.1188]
     }
   },
-  "sdxl-base-refiner": {
+  "sdxl-img2img-512": {
+    "perf": {
+      "functional": 62.5,
+      "complete": 12.5,
+      "target": 6.25
+    },
+    "perf-tp": {
+      "functional": 31.25,
+      "complete": 6.25,
+      "target": 3.125
+    },
+    "accuracy": {
+      "_TODO": "Determine proper ranges for 512x512 resolution",
+      "clip_valid_range_full_dataset": [0.05, 0.2],
+      "clip_valid_range_100": [0.05, 0.2]
+    }
+  },
+  "sdxl-base-refiner-1024": {
     "perf": {
       "functional": 125,
       "complete":   25,
@@ -81,7 +144,30 @@
       "warning": 25
     }
   },
-  "sdxl-lora": {
+  "sdxl-base-refiner-512": {
+    "perf": {
+      "functional": 62.5,
+      "complete": 12.5,
+      "target": 6.25
+    },
+    "perf-tp": {
+      "functional": 31.25,
+      "complete": 6.25,
+      "target": 3.125
+    },
+    "accuracy": {
+      "_TODO": "Determine proper ranges for 512x512 resolution",
+      "fid_valid_range_full_dataset": [10.0, 50.0],
+      "clip_valid_range_full_dataset": [20.0, 40.0],
+      "clip_valid_range_100": [20.0, 40.0],
+      "fid_valid_range_100": [100.0, 300.0]
+    },
+    "clip_score_thresholds": {
+      "error": 19.5,
+      "warning": 25
+    }
+  },
+  "sdxl-lora-1024": {
     "perf": {
       "functional": 125,
       "complete":   25,
@@ -97,6 +183,29 @@
       "clip_valid_range_full_dataset": [34.4303, 35.2303],
       "clip_valid_range_100": [34.6343, 35.4343],
       "fid_valid_range_100": [264.3848, 280.3848]
+    },
+    "clip_score_thresholds": {
+      "error": 20,
+      "warning": 28
+    }
+  },
+  "sdxl-lora-512": {
+    "perf": {
+      "functional": 62.5,
+      "complete": 12.5,
+      "target": 6.25
+    },
+    "perf-tp": {
+      "functional": 31.25,
+      "complete": 6.25,
+      "target": 3.125
+    },
+    "accuracy": {
+      "_TODO": "Determine proper ranges for 512x512 resolution",
+      "fid_valid_range_full_dataset": [50.0, 200.0],
+      "clip_valid_range_full_dataset": [25.0, 45.0],
+      "clip_valid_range_100": [25.0, 45.0],
+      "fid_valid_range_100": [200.0, 400.0]
     },
     "clip_score_thresholds": {
       "error": 20,

--- a/models/demos/stable_diffusion_xl_base/targets/targets.json
+++ b/models/demos/stable_diffusion_xl_base/targets/targets.json
@@ -33,11 +33,10 @@
       "target": 3.125
     },
     "accuracy": {
-      "_TODO": "Determine proper ranges for 512x512 resolution",
-      "fid_valid_range_full_dataset": [10.0, 50.0],
-      "clip_valid_range_full_dataset": [20.0, 40.0],
-      "clip_valid_range_100": [20.0, 40.0],
-      "fid_valid_range_100": [100.0, 300.0]
+      "fid_valid_range_full_dataset": [49, 54],
+      "clip_valid_range_full_dataset": [29.38, 31],
+      "clip_valid_range_100": [28.5, 30.8],
+      "fid_valid_range_100": [195, 233]
     },
     "clip_score_thresholds": {
       "error": 19,
@@ -78,11 +77,10 @@
       "target": 3.125
     },
     "accuracy": {
-      "_TODO": "Determine proper ranges for 512x512 resolution",
-      "fid_valid_range_full_dataset": [10.0, 50.0],
-      "clip_valid_range_full_dataset": [20.0, 40.0],
-      "clip_valid_range_100": [20.0, 40.0],
-      "fid_valid_range_100": [100.0, 300.0]
+      "fid_valid_range_full_dataset": [40, 43],
+      "clip_valid_range_full_dataset": [30, 30.5],
+      "clip_valid_range_100": [29.8, 31.4],
+      "fid_valid_range_100": [190, 199]
     },
     "clip_score_thresholds": {
       "error": 19.5,
@@ -117,9 +115,8 @@
       "target": 3.125
     },
     "accuracy": {
-      "_TODO": "Determine proper ranges for 512x512 resolution",
-      "clip_valid_range_full_dataset": [0.05, 0.2],
-      "clip_valid_range_100": [0.05, 0.2]
+      "clip_valid_range_full_dataset": [0.112, 0.122],
+      "clip_valid_range_100": [0.12, 0.14]
     }
   },
   "sdxl-base-refiner-1024": {
@@ -156,11 +153,10 @@
       "target": 3.125
     },
     "accuracy": {
-      "_TODO": "Determine proper ranges for 512x512 resolution",
-      "fid_valid_range_full_dataset": [10.0, 50.0],
-      "clip_valid_range_full_dataset": [20.0, 40.0],
-      "clip_valid_range_100": [20.0, 40.0],
-      "fid_valid_range_100": [100.0, 300.0]
+      "fid_valid_range_full_dataset": [46, 52],
+      "clip_valid_range_full_dataset": [29.2, 30],
+      "clip_valid_range_100": [28.7, 30.5],
+      "fid_valid_range_100": [195, 226]
     },
     "clip_score_thresholds": {
       "error": 19.5,
@@ -201,11 +197,10 @@
       "target": 3.125
     },
     "accuracy": {
-      "_TODO": "Determine proper ranges for 512x512 resolution",
-      "fid_valid_range_full_dataset": [50.0, 200.0],
-      "clip_valid_range_full_dataset": [25.0, 45.0],
-      "clip_valid_range_100": [25.0, 45.0],
-      "fid_valid_range_100": [200.0, 400.0]
+      "fid_valid_range_full_dataset": [155, 165],
+      "clip_valid_range_full_dataset": [32.8, 33.3],
+      "clip_valid_range_100": [33, 34.5],
+      "fid_valid_range_100": [285, 296]
     },
     "clip_score_thresholds": {
       "error": 20,

--- a/models/demos/stable_diffusion_xl_base/tests/test_sdxl_accuracy.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_sdxl_accuracy.py
@@ -138,8 +138,8 @@ def test_accuracy_sdxl(
     refiner_aesthetic_score,
     refiner_negative_aesthetic_score,
 ):
-    if image_resolution == (512, 512) and is_blackhole():
-        pytest.skip("512x512 not supported on Blackhole")
+    if vae_on_device and is_blackhole():
+        pytest.skip("Device VAE not supported on Blackhole")
 
     start_from, num_prompts = evaluation_range
 

--- a/models/demos/stable_diffusion_xl_base/tests/test_sdxl_accuracy.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_sdxl_accuracy.py
@@ -189,6 +189,14 @@ def test_accuracy_sdxl(
 
     accuracy_metrics = calculate_accuracy_metrics(images, prompts, coco_statistics_path)
 
+    # Additional accuracy calculation on first 100 samples for CI testing
+    if num_prompts >= 100:
+        logger.info("Calculating accuracy metrics on first 100 samples for CI testing...")
+        accuracy_metrics_100 = calculate_accuracy_metrics(images[:100], prompts[:100], coco_statistics_path)
+        logger.info(
+            f"Accuracy metrics (100 samples): CLIP={accuracy_metrics_100['average_clip_score']:.4f}, FID={accuracy_metrics_100['fid_score']:.4f}"
+        )
+
     model_name = (
         ("sdxl-base-refiner" if use_refiner else "sdxl")
         + f"-{image_resolution[0]}"

--- a/models/demos/stable_diffusion_xl_base/tests/test_sdxl_accuracy.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_sdxl_accuracy.py
@@ -140,8 +140,6 @@ def test_accuracy_sdxl(
 ):
     if image_resolution == (512, 512) and is_blackhole():
         pytest.skip("512x512 not supported on Blackhole")
-    if image_resolution == (512, 512) and (vae_on_device or use_refiner):
-        pytest.skip("Accuracy test on 512x512 image resolution is only supported for UNet on device.")
 
     start_from, num_prompts = evaluation_range
 
@@ -191,7 +189,11 @@ def test_accuracy_sdxl(
 
     accuracy_metrics = calculate_accuracy_metrics(images, prompts, coco_statistics_path)
 
-    model_name = ("sdxl-base-refiner" if use_refiner else "sdxl") + ("-tp" if use_cfg_parallel else "")
+    model_name = (
+        ("sdxl-base-refiner" if use_refiner else "sdxl")
+        + f"-{image_resolution[0]}"
+        + ("-tp" if use_cfg_parallel else "")
+    )
     metadata = {
         "model_name": model_name,
         "device": get_device_name(),

--- a/models/demos/stable_diffusion_xl_base/tests/test_sdxl_accuracy.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_sdxl_accuracy.py
@@ -189,14 +189,6 @@ def test_accuracy_sdxl(
 
     accuracy_metrics = calculate_accuracy_metrics(images, prompts, coco_statistics_path)
 
-    # Additional accuracy calculation on first 100 samples for CI testing
-    if num_prompts >= 100:
-        logger.info("Calculating accuracy metrics on first 100 samples for CI testing...")
-        accuracy_metrics_100 = calculate_accuracy_metrics(images[:100], prompts[:100], coco_statistics_path)
-        logger.info(
-            f"Accuracy metrics (100 samples): CLIP={accuracy_metrics_100['average_clip_score']:.4f}, FID={accuracy_metrics_100['fid_score']:.4f}"
-        )
-
     model_name = (
         ("sdxl-base-refiner" if use_refiner else "sdxl")
         + f"-{image_resolution[0]}"

--- a/models/demos/stable_diffusion_xl_base/tests/test_sdxl_img2img_accuracy.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_sdxl_img2img_accuracy.py
@@ -12,6 +12,7 @@ from loguru import logger
 from transformers import CLIPImageProcessor, CLIPTextModelWithProjection, CLIPTokenizer, CLIPVisionModelWithProjection
 
 from models.demos.stable_diffusion_xl_base.conftest import get_device_name
+from models.common.utility_functions import is_blackhole
 from models.demos.stable_diffusion_xl_base.demo.demo_img2img import test_demo
 from models.demos.stable_diffusion_xl_base.tests.test_common import SDXL_FABRIC_CONFIG, SDXL_TRACE_REGION_SIZE
 from models.demos.stable_diffusion_xl_base.utils.accuracy_utils import (
@@ -128,8 +129,8 @@ def test_accuracy_sdxl_img2img(
     timesteps,
     sigmas,
 ):
-    if image_resolution == (512, 512):
-        pytest.skip("Accuracy test on 512x512 image resolution is not yet supported for img2img pipeline.")
+    if image_resolution == (512, 512) and is_blackhole():
+        pytest.skip("512x512 not supported on Blackhole")
 
     start_from, num_prompts = evaluation_range
 
@@ -184,7 +185,7 @@ def test_accuracy_sdxl_img2img(
     deviation_clip_score = statistics.stdev(scores)
     logger.info(f"Average directional similarity: {average_clip_score}")
 
-    model_name = "sdxl-img2img-tp" if use_cfg_parallel else "sdxl-img2img"
+    model_name = f"sdxl-img2img-{image_resolution[0]}" + ("-tp" if use_cfg_parallel else "")
     metadata = {
         "model_name": model_name,
         "device": get_device_name(),

--- a/models/demos/stable_diffusion_xl_base/tests/test_sdxl_img2img_accuracy.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_sdxl_img2img_accuracy.py
@@ -185,16 +185,6 @@ def test_accuracy_sdxl_img2img(
     deviation_clip_score = statistics.stdev(scores)
     logger.info(f"Average directional similarity: {average_clip_score}")
 
-    # Additional accuracy calculation on first 100 samples for CI testing
-    if num_prompts >= 100:
-        logger.info("Calculating directional similarity on first 100 samples for CI testing...")
-        scores_100 = scores[:100]
-        average_clip_score_100 = sum(scores_100) / len(scores_100)
-        deviation_clip_score_100 = statistics.stdev(scores_100) if len(scores_100) > 1 else 0
-        logger.info(
-            f"Directional similarity (100 samples): average={average_clip_score_100:.4f}, deviation={deviation_clip_score_100:.4f}"
-        )
-
     model_name = f"sdxl-img2img-{image_resolution[0]}" + ("-tp" if use_cfg_parallel else "")
     metadata = {
         "model_name": model_name,

--- a/models/demos/stable_diffusion_xl_base/tests/test_sdxl_img2img_accuracy.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_sdxl_img2img_accuracy.py
@@ -11,8 +11,8 @@ from datasets import load_dataset
 from loguru import logger
 from transformers import CLIPImageProcessor, CLIPTextModelWithProjection, CLIPTokenizer, CLIPVisionModelWithProjection
 
-from models.demos.stable_diffusion_xl_base.conftest import get_device_name
 from models.common.utility_functions import is_blackhole
+from models.demos.stable_diffusion_xl_base.conftest import get_device_name
 from models.demos.stable_diffusion_xl_base.demo.demo_img2img import test_demo
 from models.demos.stable_diffusion_xl_base.tests.test_common import SDXL_FABRIC_CONFIG, SDXL_TRACE_REGION_SIZE
 from models.demos.stable_diffusion_xl_base.utils.accuracy_utils import (
@@ -129,8 +129,8 @@ def test_accuracy_sdxl_img2img(
     timesteps,
     sigmas,
 ):
-    if image_resolution == (512, 512) and is_blackhole():
-        pytest.skip("512x512 not supported on Blackhole")
+    if vae_on_device and is_blackhole():
+        pytest.skip("Device VAE not supported on Blackhole")
 
     start_from, num_prompts = evaluation_range
 

--- a/models/demos/stable_diffusion_xl_base/tests/test_sdxl_img2img_accuracy.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_sdxl_img2img_accuracy.py
@@ -185,6 +185,16 @@ def test_accuracy_sdxl_img2img(
     deviation_clip_score = statistics.stdev(scores)
     logger.info(f"Average directional similarity: {average_clip_score}")
 
+    # Additional accuracy calculation on first 100 samples for CI testing
+    if num_prompts >= 100:
+        logger.info("Calculating directional similarity on first 100 samples for CI testing...")
+        scores_100 = scores[:100]
+        average_clip_score_100 = sum(scores_100) / len(scores_100)
+        deviation_clip_score_100 = statistics.stdev(scores_100) if len(scores_100) > 1 else 0
+        logger.info(
+            f"Directional similarity (100 samples): average={average_clip_score_100:.4f}, deviation={deviation_clip_score_100:.4f}"
+        )
+
     model_name = f"sdxl-img2img-{image_resolution[0]}" + ("-tp" if use_cfg_parallel else "")
     metadata = {
         "model_name": model_name,

--- a/models/demos/stable_diffusion_xl_base/tests/test_sdxl_inpaint_accuracy.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_sdxl_inpaint_accuracy.py
@@ -9,6 +9,7 @@ from datasets import load_dataset
 from loguru import logger
 
 from models.demos.stable_diffusion_xl_base.conftest import get_device_name
+from models.common.utility_functions import is_blackhole
 from models.demos.stable_diffusion_xl_base.demo.demo_inpainting import test_demo
 from models.demos.stable_diffusion_xl_base.tests.test_common import SDXL_FABRIC_CONFIG, SDXL_TRACE_REGION_SIZE
 from models.demos.stable_diffusion_xl_base.utils.accuracy_utils import (
@@ -110,8 +111,8 @@ def test_accuracy_sdxl_inpaint(
     use_cfg_parallel,
     strength,
 ):
-    if image_resolution == (512, 512):
-        pytest.skip("Accuracy test on 512x512 image resolution is not yet supported for inpainting pipeline.")
+    if image_resolution == (512, 512) and is_blackhole():
+        pytest.skip("512x512 not supported on Blackhole")
 
     start_from, num_prompts = evaluation_range
     input_images, input_masks, prompts = get_dataset_for_inpainting_accuracy(num_prompts)
@@ -148,7 +149,7 @@ def test_accuracy_sdxl_inpaint(
 
     accuracy_metrics = calculate_accuracy_metrics(images, prompts, coco_statistics_path)
 
-    model_name = "sdxl-inpaint-tp" if use_cfg_parallel else "sdxl-inpaint"
+    model_name = f"sdxl-inpaint-{image_resolution[0]}" + ("-tp" if use_cfg_parallel else "")
     metadata = {
         "model_name": model_name,
         "device": get_device_name(),

--- a/models/demos/stable_diffusion_xl_base/tests/test_sdxl_inpaint_accuracy.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_sdxl_inpaint_accuracy.py
@@ -149,6 +149,14 @@ def test_accuracy_sdxl_inpaint(
 
     accuracy_metrics = calculate_accuracy_metrics(images, prompts, coco_statistics_path)
 
+    # Additional accuracy calculation on first 100 samples for CI testing
+    if num_prompts >= 100:
+        logger.info("Calculating accuracy metrics on first 100 samples for CI testing...")
+        accuracy_metrics_100 = calculate_accuracy_metrics(images[:100], prompts[:100], coco_statistics_path)
+        logger.info(
+            f"Accuracy metrics (100 samples): CLIP={accuracy_metrics_100['average_clip_score']:.4f}, FID={accuracy_metrics_100['fid_score']:.4f}"
+        )
+
     model_name = f"sdxl-inpaint-{image_resolution[0]}" + ("-tp" if use_cfg_parallel else "")
     metadata = {
         "model_name": model_name,

--- a/models/demos/stable_diffusion_xl_base/tests/test_sdxl_inpaint_accuracy.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_sdxl_inpaint_accuracy.py
@@ -149,14 +149,6 @@ def test_accuracy_sdxl_inpaint(
 
     accuracy_metrics = calculate_accuracy_metrics(images, prompts, coco_statistics_path)
 
-    # Additional accuracy calculation on first 100 samples for CI testing
-    if num_prompts >= 100:
-        logger.info("Calculating accuracy metrics on first 100 samples for CI testing...")
-        accuracy_metrics_100 = calculate_accuracy_metrics(images[:100], prompts[:100], coco_statistics_path)
-        logger.info(
-            f"Accuracy metrics (100 samples): CLIP={accuracy_metrics_100['average_clip_score']:.4f}, FID={accuracy_metrics_100['fid_score']:.4f}"
-        )
-
     model_name = f"sdxl-inpaint-{image_resolution[0]}" + ("-tp" if use_cfg_parallel else "")
     metadata = {
         "model_name": model_name,

--- a/models/demos/stable_diffusion_xl_base/tests/test_sdxl_inpaint_accuracy.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_sdxl_inpaint_accuracy.py
@@ -8,8 +8,8 @@ import pytest
 from datasets import load_dataset
 from loguru import logger
 
-from models.demos.stable_diffusion_xl_base.conftest import get_device_name
 from models.common.utility_functions import is_blackhole
+from models.demos.stable_diffusion_xl_base.conftest import get_device_name
 from models.demos.stable_diffusion_xl_base.demo.demo_inpainting import test_demo
 from models.demos.stable_diffusion_xl_base.tests.test_common import SDXL_FABRIC_CONFIG, SDXL_TRACE_REGION_SIZE
 from models.demos.stable_diffusion_xl_base.utils.accuracy_utils import (
@@ -111,8 +111,8 @@ def test_accuracy_sdxl_inpaint(
     use_cfg_parallel,
     strength,
 ):
-    if image_resolution == (512, 512) and is_blackhole():
-        pytest.skip("512x512 not supported on Blackhole")
+    if vae_on_device and is_blackhole():
+        pytest.skip("Device VAE not supported on Blackhole")
 
     start_from, num_prompts = evaluation_range
     input_images, input_masks, prompts = get_dataset_for_inpainting_accuracy(num_prompts)

--- a/models/demos/stable_diffusion_xl_base/tests/test_sdxl_lora_accuracy.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_sdxl_lora_accuracy.py
@@ -172,6 +172,14 @@ def test_accuracy_sdxl_lora(
 
     accuracy_metrics = calculate_accuracy_metrics(images, prompts, coco_statistics_path)
 
+    # Additional accuracy calculation on first 100 samples for CI testing
+    if num_prompts >= 100:
+        logger.info("Calculating accuracy metrics on first 100 samples for CI testing...")
+        accuracy_metrics_100 = calculate_accuracy_metrics(images[:100], prompts[:100], coco_statistics_path)
+        logger.info(
+            f"Accuracy metrics (100 samples): CLIP={accuracy_metrics_100['average_clip_score']:.4f}, FID={accuracy_metrics_100['fid_score']:.4f}"
+        )
+
     model_name = f"sdxl-lora-{image_resolution[0]}" + ("-tp" if use_cfg_parallel else "")
     metadata = {
         "model_name": model_name,

--- a/models/demos/stable_diffusion_xl_base/tests/test_sdxl_lora_accuracy.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_sdxl_lora_accuracy.py
@@ -8,8 +8,8 @@ import os
 import pytest
 from loguru import logger
 
-from models.demos.stable_diffusion_xl_base.conftest import get_device_name
 from models.common.utility_functions import is_blackhole
+from models.demos.stable_diffusion_xl_base.conftest import get_device_name
 from models.demos.stable_diffusion_xl_base.demo.demo_lora import run_demo_inference
 from models.demos.stable_diffusion_xl_base.tests.test_common import (
     SDXL_FABRIC_CONFIG,
@@ -126,8 +126,8 @@ def test_accuracy_sdxl_lora(
     sigmas,
     lora_path,
 ):
-    if image_resolution == (512, 512) and is_blackhole():
-        pytest.skip("512x512 not supported on Blackhole")
+    if vae_on_device and is_blackhole():
+        pytest.skip("Device VAE not supported on Blackhole")
 
     start_from, num_prompts = evaluation_range
 

--- a/models/demos/stable_diffusion_xl_base/tests/test_sdxl_lora_accuracy.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_sdxl_lora_accuracy.py
@@ -172,14 +172,6 @@ def test_accuracy_sdxl_lora(
 
     accuracy_metrics = calculate_accuracy_metrics(images, prompts, coco_statistics_path)
 
-    # Additional accuracy calculation on first 100 samples for CI testing
-    if num_prompts >= 100:
-        logger.info("Calculating accuracy metrics on first 100 samples for CI testing...")
-        accuracy_metrics_100 = calculate_accuracy_metrics(images[:100], prompts[:100], coco_statistics_path)
-        logger.info(
-            f"Accuracy metrics (100 samples): CLIP={accuracy_metrics_100['average_clip_score']:.4f}, FID={accuracy_metrics_100['fid_score']:.4f}"
-        )
-
     model_name = f"sdxl-lora-{image_resolution[0]}" + ("-tp" if use_cfg_parallel else "")
     metadata = {
         "model_name": model_name,

--- a/models/demos/stable_diffusion_xl_base/tests/test_sdxl_lora_accuracy.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_sdxl_lora_accuracy.py
@@ -9,6 +9,7 @@ import pytest
 from loguru import logger
 
 from models.demos.stable_diffusion_xl_base.conftest import get_device_name
+from models.common.utility_functions import is_blackhole
 from models.demos.stable_diffusion_xl_base.demo.demo_lora import run_demo_inference
 from models.demos.stable_diffusion_xl_base.tests.test_common import (
     SDXL_FABRIC_CONFIG,
@@ -125,8 +126,8 @@ def test_accuracy_sdxl_lora(
     sigmas,
     lora_path,
 ):
-    if image_resolution == (512, 512):
-        pytest.skip("Accuracy target not available for 512x512 image resolution")
+    if image_resolution == (512, 512) and is_blackhole():
+        pytest.skip("512x512 not supported on Blackhole")
 
     start_from, num_prompts = evaluation_range
 
@@ -171,7 +172,7 @@ def test_accuracy_sdxl_lora(
 
     accuracy_metrics = calculate_accuracy_metrics(images, prompts, coco_statistics_path)
 
-    model_name = "sdxl-lora" + ("-tp" if use_cfg_parallel else "")
+    model_name = f"sdxl-lora-{image_resolution[0]}" + ("-tp" if use_cfg_parallel else "")
     metadata = {
         "model_name": model_name,
         "device": get_device_name(),

--- a/models/demos/stable_diffusion_xl_base/utils/clip_fid_ranges.py
+++ b/models/demos/stable_diffusion_xl_base/utils/clip_fid_ranges.py
@@ -24,18 +24,22 @@ get_approx = lambda range_tuple: (range_tuple[0] * 0.97, range_tuple[1] * 1.03)
 
 
 def using_full_dataset(model_name, num_prompts):
-    if model_name in {
-        "sdxl",
-        "sdxl-tp",
-        "sdxl-base-refiner",
-        "sdxl-base-refiner-tp",
-        "sdxl-img2img",
-        "sdxl-img2img-tp",
-        "sdxl-lora",
-        "sdxl-lora-tp",
+    base_name = model_name.removesuffix("-tp")
+    if base_name in {
+        "sdxl-1024",
+        "sdxl-512",
+        "sdxl-base-refiner-1024",
+        "sdxl-base-refiner-512",
+        "sdxl-img2img-1024",
+        "sdxl-img2img-512",
+        "sdxl-lora-1024",
+        "sdxl-lora-512",
     }:
         return num_prompts == SDXL_DATASET_SIZE
-    elif model_name in {"sdxl-inpaint", "sdxl-inpaint-tp"}:
+    elif base_name in {
+        "sdxl-inpaint-1024",
+        "sdxl-inpaint-512",
+    }:
         return num_prompts == SDXL_INPAINT_DATASET_SIZE
     assert False, f"Unknown model name {model_name}"
 


### PR DESCRIPTION
### Ticket
Improve SDXL accuracy tests: assertions, LoRA, 512 support #39705

### Problem description
512 accuracy was skipped (pyskiped)

### What's changed
512 targets added, 512 resulotion accuracy enabled

### Checklist
- [ ] [SDXL accuracy, 512x512, 1024x1024, refiner, base , 100 prompts](https://github.com/tenstorrent/tt-shield/actions/runs/23200908609)
- [ ] [lora accuracy, 512x512, 1024x1024, 100 prompts](https://github.com/tenstorrent/tt-shield/actions/runs/23202376630)
- [ ] [img2img, 512x512, 1024x1024, 100 prompts](https://github.com/tenstorrent/tt-shield/actions/runs/23202405753)
- [ ] [inpainting, 512x512, 1024x1024, 100 prompts](https://github.com/tenstorrent/tt-shield/actions/runs/23202433700)




