### PR TITLE
fix the residual add in moe/mlp

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/moe/moe_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe/moe_kernel.cpp
@@ -1127,10 +1127,21 @@ void kernel_main() {
         }
 
         // 11d. Shared: Residual Add — matmul_out + shard(residual) on 112 cores
+        //      When multi-device reduce is enabled, only the ROOT1 device performs
+        //      the actual add so the residual is counted exactly once after the
+        //      cross-device sum.  Non-root devices pass matmul output through.
         {
             DeviceZoneScopedN("SHARED_RESIDUAL_ADD");
+#ifdef ENABLE_REDUCE_TO_ONE
+            constexpr bool skip_residual_add =
+                get_named_compile_time_arg_val("reduce_device_role") != deepseek_b1_ops::MESH_ROOT1;
+            deepseek_b1_ops::ResidualAdd::
+                Op<Moe::Shared::ResidualAddCTArgs, Core::Shared::is_mcast_receiver_core, skip_residual_add>
+                    shared_residual_add;
+#else
             deepseek_b1_ops::ResidualAdd::Op<Moe::Shared::ResidualAddCTArgs, Core::Shared::is_mcast_receiver_core>
                 shared_residual_add;
+#endif
             shared_residual_add(moe.shared.residual_add_args);
         }
 

--- a/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
@@ -3007,6 +3007,7 @@ class MoeOp:
         use_hardcoded_expert_index=False,
         hardcoded_expert_index=0,
         explicit_expert_scale=None,
+        include_residual=True,
     ):
         """
         PyTorch reference for the full fused MoE (routed + shared expert + eltwise add).
@@ -3029,6 +3030,8 @@ class MoeOp:
             bias_tensor: [1, 8, 32] gate bias (routing only)
             eps, scaling_factor, use_hardcoded_expert_index, hardcoded_expert_index,
             explicit_expert_scale: routed expert gate params (routing only)
+            include_residual: If True, add residual (raw input) in shared expert.
+                Set to False for non-root devices in multi-device reduce.
 
         Returns:
             (top8_scores, top8_indices, final_output) — scores/indices are None when enable_routing=False
@@ -3042,13 +3045,14 @@ class MoeOp:
         variance = x.pow(2).mean(-1, keepdim=True)
         normalized_input = ((x * torch.rsqrt(variance + rmsnorm_epsilon)) * rmsnorm_gamma.float()).bfloat16().float()
 
-        # Shared expert: normalized input for compute, raw input for residual
+        # Shared expert: normalized input for compute, residual (raw input) added when include_residual=True
+        residual = input_tensor.float() if include_residual else torch.zeros_like(input_tensor.float())
         shared_output = SharedExpertOp.golden(
             normalized_input.float(),
             shared_gate_weights.float(),
             shared_up_weights.float(),
             shared_down_weights.float(),
-            input_tensor.float(),  # residual is the raw (pre-norm) input
+            residual,
         ).bfloat16()
 
         # Reshape to match routed golden's fused_add_tensor expectation [1,1,1,N]

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_mlp.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_mlp.py
@@ -1082,10 +1082,10 @@ def test_moe_fused_with_reduce(
     device_gate_indices = ttnn.to_torch(ttnn_result_indices, mesh_composer=ttnn.ConcatMeshToTensor(submesh, dim=0))
     device_gate_scores = ttnn.to_torch(ttnn_result_scores, mesh_composer=ttnn.ConcatMeshToTensor(submesh, dim=0))
 
-    # Compute expected output for each device, then sum
-    # Each device uses a different hardcoded expert index (chip_id)
-    # and a different TP shard of shared expert weights
+    # Compute expected output for each device, then sum.
+    # Residual is only added on ROOT1 device; non-root devices skip it.
     K_down = s.K_down
+    root_device_idx = root_coord[0] * submesh.shape[1] + root_coord[1]
     expected_final_outputs = []
     for device_idx in range(num_devices):
         chip_id = device_idx
@@ -1118,6 +1118,7 @@ def test_moe_fused_with_reduce(
             use_hardcoded_expert_index=True,
             hardcoded_expert_index=actual_expert_idx,
             explicit_expert_scale=actual_expert_scale,
+            include_residual=(device_idx == root_device_idx),
         )
         expected_final_outputs.append(torch_expected_final)
         logger.info(
@@ -1135,8 +1136,6 @@ def test_moe_fused_with_reduce(
         mesh_composer=ttnn.ConcatMeshToTensor(submesh, dim=0),
     )
 
-    # ROOT1 is at row 1, col 1 -> device_idx = 1*2 + 1 = 3
-    root_device_idx = root_coord[0] * submesh.shape[1] + root_coord[1]
     reduce_output_root = reduce_output_torch[root_device_idx]
 
     # Extract valid portion (remove per-core padding)
@@ -1178,10 +1177,11 @@ def test_moe_fused_with_reduce(
         with torch.no_grad():
             ref_moe_output = reference_moe(normed_input.unsqueeze(0)).squeeze(0)
 
+        # Residual is added once (on ROOT1 only), so reduce output directly
+        # matches: residual + moe_output
         ref_block_output = r.torch_input.float() + ref_moe_output.float()
-        adjusted_reduce = reduce_output_valid.float() - 7 * r.torch_input.float()
 
-        passing_ref, pcc_ref = comp_pcc(ref_block_output, adjusted_reduce, 0.95)
+        passing_ref, pcc_ref = comp_pcc(ref_block_output, reduce_output_valid.float(), 0.95)
         logger.info(f"Reference MoE comparison PCC: {pcc_ref}")
         assert passing_ref, f"Reference MoE comparison PCC failed: {pcc_ref}"
 
@@ -1532,9 +1532,10 @@ def test_mlp_with_reduce(
     logger.info(f"MoeOp no-routing with reduce: {num_iterations} iterations completed (reconfig={reconfig_moe_cbs})")
 
     # ── Verify results ──
-    # Compute per-device golden with per-device TP shards of shared expert weights
-    # For dense (use_mlp_weights): each device uses routed expert d; pass single-expert dict for that device.
+    # Compute per-device golden with per-device TP shards of shared expert weights.
+    # Residual is only added on ROOT1 device; non-root devices skip it.
     K_down = s.K_down
+    root_device_idx = root_coord[0] * submesh.shape[1] + root_coord[1]
     expected_final_outputs = []
     for device_idx in range(num_devices):
         shared_gate_shard = s.torch_gate_weights[:, device_idx * K_down : (device_idx + 1) * K_down]
@@ -1561,6 +1562,7 @@ def test_mlp_with_reduce(
             rmsnorm_gamma=r.torch_rmsnorm_gamma,
             rmsnorm_epsilon=1e-6,
             enable_routing=False,
+            include_residual=(device_idx == root_device_idx),
         )
         expected_final_outputs.append(device_expected)
 
@@ -1573,8 +1575,6 @@ def test_mlp_with_reduce(
         mesh_composer=ttnn.ConcatMeshToTensor(submesh, dim=0),
     )
 
-    # ROOT1 is at row 1, col 1 -> device_idx = 1*2 + 1 = 3
-    root_device_idx = root_coord[0] * submesh.shape[1] + root_coord[1]
     reduce_output_root = reduce_output_torch[root_device_idx]
 
     # Extract valid portion (remove per-core padding)
@@ -1600,13 +1600,13 @@ def test_mlp_with_reduce(
         with torch.no_grad():
             shared_output = shared_ref(normed_input.unsqueeze(0)).squeeze(0)
             routed_outputs = [routed_refs[d](normed_input.unsqueeze(0)).squeeze(0) for d in range(8)]
-        ref_reduce = sum(routed_outputs).float() + shared_output.float() + num_devices * r.torch_input.float()
-        # Also compare against single full MLP (reference block): reduce_output - 7*residual = block_output
+        # Residual is added once (on ROOT1 only)
+        ref_reduce = sum(routed_outputs).float() + shared_output.float() + r.torch_input.float()
+        # Also compare against single full MLP (reference block): reduce_output directly matches
         full_mlp_ref = create_reference_dense_full_mlp(state_dict, layer_idx)
         with torch.no_grad():
             ref_block_output = r.torch_input.float() + full_mlp_ref(normed_input.unsqueeze(0)).squeeze(0).float()
-        adjusted_reduce = reduce_output_valid.float() - 7 * r.torch_input.float()
-        passing_full, pcc_full = comp_pcc(ref_block_output.flatten(), adjusted_reduce.flatten(), 0.975)
+        passing_full, pcc_full = comp_pcc(ref_block_output.flatten(), reduce_output_valid.float().flatten(), 0.975)
         logger.info(f"Reference full MLP (block) comparison PCC: {pcc_full}")
         assert passing_full, f"Reference full MLP block comparison PCC failed: {pcc_full}"
     else:
@@ -1614,9 +1614,8 @@ def test_mlp_with_reduce(
         with torch.no_grad():
             expert_0_output = expert_ref(normed_input.unsqueeze(0)).squeeze(0)
             shared_full_output = shared_ref(normed_input.unsqueeze(0)).squeeze(0)
-        ref_reduce = (
-            num_devices * expert_0_output.float() + shared_full_output.float() + num_devices * r.torch_input.float()
-        )
+        # Residual is added once (on ROOT1 only)
+        ref_reduce = num_devices * expert_0_output.float() + shared_full_output.float() + r.torch_input.float()
 
     passing_ref, pcc_ref = comp_pcc(ref_reduce, reduce_output_valid, 0.975)
     logger.info(f"Reference MLP comparison PCC: {pcc_ref}")

--- a/models/demos/deepseek_v3_b1/unified_kernels/residual_add.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/residual_add.hpp
@@ -7,6 +7,7 @@
 
 #if defined(COMPILE_FOR_TRISC)
 #include "api/compute/eltwise_binary.h"
+#include "api/compute/tile_move_copy.h"
 #endif
 
 namespace deepseek_b1_ops {
@@ -46,7 +47,10 @@ struct ResidualAdd {
 
     using RTArgs = unified_kernels::SelectByRISCV<ReaderArgs, WriterArgs, ComputeArgs>;
 
-    template <typename CTArgs, bool IsActiveCore>
+    // SkipAdd: when true, copies in0→out and pops in1 without adding.
+    // Used on non-root devices in multi-device reduce so residual is only
+    // counted once after the cross-device sum.
+    template <typename CTArgs, bool IsActiveCore, bool SkipAdd = false>
     class Op {
     public:
         void operator()(const RTArgs& args) {
@@ -60,24 +64,44 @@ struct ResidualAdd {
 #if defined(COMPILE_FOR_TRISC)
             constexpr uint32_t out_w = CTArgs::out_w;
 
-            reconfig_data_format<false, true>(args.in0_cb, args.in1_cb);
-            pack_reconfig_data_format<true>(args.out_cb);
-
-            add_tiles_init(args.in0_cb, args.in1_cb);
-
             cb_wait_front(args.in0_cb, out_w);
             cb_wait_front(args.in1_cb, args.total_in1_tiles);
-            cb_reserve_back(args.out_cb, out_w);
-            tile_regs_acquire();
-            for (uint32_t j = 0; j < out_w; j++) {
-                add_tiles(args.in0_cb, args.in1_cb, j, args.core_idx * out_w + j, j);
+
+            if constexpr (SkipAdd) {
+                // Pass-through: copy in0 to out, discard in1
+                reconfig_data_format<false, true>(args.in0_cb, args.in0_cb);
+                pack_reconfig_data_format<true>(args.out_cb);
+                copy_tile_to_dst_init_short(args.in0_cb);
+                cb_reserve_back(args.out_cb, out_w);
+                tile_regs_acquire();
+                for (uint32_t j = 0; j < out_w; j++) {
+                    copy_tile(args.in0_cb, j, j);
+                }
+                tile_regs_commit();
+                tile_regs_wait();
+                for (uint32_t j = 0; j < out_w; j++) {
+                    pack_tile(j, args.out_cb, j);
+                }
+                tile_regs_release();
+            } else {
+                // Normal: matmul_out + shard(residual)
+                reconfig_data_format<false, true>(args.in0_cb, args.in1_cb);
+                pack_reconfig_data_format<true>(args.out_cb);
+
+                add_tiles_init(args.in0_cb, args.in1_cb);
+
+                cb_reserve_back(args.out_cb, out_w);
+                tile_regs_acquire();
+                for (uint32_t j = 0; j < out_w; j++) {
+                    add_tiles(args.in0_cb, args.in1_cb, j, args.core_idx * out_w + j, j);
+                }
+                tile_regs_commit();
+                tile_regs_wait();
+                for (uint32_t j = 0; j < out_w; j++) {
+                    pack_tile(j, args.out_cb, j);
+                }
+                tile_regs_release();
             }
-            tile_regs_commit();
-            tile_regs_wait();
-            for (uint32_t j = 0; j < out_w; j++) {
-                pack_tile(j, args.out_cb, j);
-            }
-            tile_regs_release();
 
             cb_pop_front(args.in0_cb, out_w);
             cb_pop_front(args.in1_cb, args.total_in1_tiles);


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=yugao/moe-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:yugao/moe-fix)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=yugao/moe-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:yugao/moe-fix)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=yugao/moe-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:yugao/moe-fix)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=yugao/moe-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:yugao/moe-fix)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=yugao/moe-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:yugao/moe-fix)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=yugao/moe-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:yugao/moe-fix)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
