### PR TITLE
Fix LLK_ASSERT hits for sdpa tests

### DIFF
--- a/tests/ttnn/unit_tests/operations/sdpa/test_mla_decode.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_mla_decode.py
@@ -6,10 +6,8 @@ import pytest
 import ttnn
 
 from tests.ttnn.unit_tests.operations.sdpa.mla_test_utils import run_flash_mla_decode_impl
-from models.common.utility_functions import skip_with_llk_assert
 
 
-@skip_with_llk_assert("Hits LLK assert check for are_unpacker_AB_configured_correctly.")
 @pytest.mark.parametrize(
     "batch, seq_len, nh, nkv, kv_lora_rank, d_rope, q_num_cores, q_mem_config",
     # batch, seq_len, num heads q, num heads kv, kv lora rank, dim rope, number of cores to shard q on

--- a/tests/ttnn/unit_tests/operations/sdpa/test_mla_prefill.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_mla_prefill.py
@@ -6,10 +6,8 @@ import pytest
 import ttnn
 
 from tests.ttnn.unit_tests.operations.sdpa.mla_test_utils import run_flash_mla_prefill_impl
-from models.common.utility_functions import skip_with_llk_assert
 
 
-@skip_with_llk_assert("Hits LLK assert check for L1 memory access.")
 @pytest.mark.parametrize(
     "batch, seq_len, nh, nkv, kv_lora_rank, d_rope",
     # batch, seq_len, num heads q, num heads kv, kv lora rank, dim rope

--- a/tests/ttnn/unit_tests/operations/sdpa/test_mla_prefill_v_embedding_space.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_mla_prefill_v_embedding_space.py
@@ -6,7 +6,6 @@ import torch
 import ttnn
 from loguru import logger
 import pytest
-from models.common.utility_functions import skip_with_llk_assert
 
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
     comp_pcc,
@@ -159,7 +158,6 @@ def run_flash_mla_prefill_impl(
     assert out_pass, f"Output mismatch: PCC {out_pcc} < 0.99"
 
 
-@skip_with_llk_assert("Hits LLK assert check for are_unpacker_AB_configured_correctly.")
 @pytest.mark.parametrize(
     "batch, seq_len_q, seq_len_kv, nh, nkv, kv_lora_rank, d_rope, v_head_dim, q_chunk_first, v_chunk_first, q_chunk_second, v_chunk_second",
     [

--- a/tests/ttnn/unit_tests/operations/sdpa/test_sdpa_decode.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_sdpa_decode.py
@@ -12,7 +12,6 @@ import torch
 import numpy as np
 import pytest
 import ttnn
-from models.common.utility_functions import skip_with_llk_assert
 
 from tests.ttnn.unit_tests.operations.sdpa.sdpa_test_utils import (
     num_to_corerange,
@@ -30,7 +29,6 @@ def reset_seeds():
     yield
 
 
-@skip_with_llk_assert("Hits LLK assert check for L1 memory access.")
 @pytest.mark.parametrize(
     "dtype, q_dtype",
     [
@@ -62,7 +60,6 @@ def test_sdpa_decode(device, b, nh, nkv, s, d, dtype, grid_size, q_dtype, single
         )
 
 
-@skip_with_llk_assert("Hits LLK assert check for L1 memory access.")
 @pytest.mark.parametrize(
     "dtype, q_dtype",
     [
@@ -91,7 +88,6 @@ def test_sdpa_decode_non_tile_aligned_heads(device, b, nh, nkv, s, d, dtype, gri
     )
 
 
-@skip_with_llk_assert("Hits LLK assert check for L1 memory access.")
 @pytest.mark.parametrize(
     "dtype, q_dtype",
     [
@@ -117,7 +113,6 @@ def test_sdpa_decode_non_causal(device, b, nh, nkv, s, d, dtype, grid_size, q_dt
     assert device.num_program_cache_entries() == 1
 
 
-@skip_with_llk_assert("Hits LLK assert check for L1 memory access.")
 @pytest.mark.parametrize(
     "dtype, q_dtype",
     [
@@ -152,7 +147,6 @@ def test_sdpa_decode_ignore_users(device, b, nh, nkv, s, d, dtype, grid_size, q_
     )
 
 
-@skip_with_llk_assert("Hits LLK assert check for L1 memory access.")
 @pytest.mark.parametrize(
     "kv_dtype, q_dtype",
     [
@@ -194,7 +188,6 @@ def test_sdpa_decode_paged_attention(
     assert device.num_program_cache_entries() == 4
 
 
-@skip_with_llk_assert("Hits LLK assert check for L1 memory access.")
 @pytest.mark.parametrize(
     "dtype, q_dtype",
     [
@@ -220,7 +213,6 @@ def test_sdpa_decode_sharded(device, b, nh, nkv, s, d, dtype, grid_size, q_dtype
     )
 
 
-@skip_with_llk_assert("Hits LLK assert check for L1 memory access.")
 @pytest.mark.parametrize(
     "dtype",
     [ttnn.bfloat8_b],
@@ -327,7 +319,6 @@ def test_sdpa_decode_program_cache(device, b, nh, nkv, s, d, dtype):
     assert device.num_program_cache_entries() == 4
 
 
-@skip_with_llk_assert("Hits LLK assert check for L1 memory access.")
 @pytest.mark.parametrize(
     "dtype, q_dtype",
     [

--- a/tests/ttnn/unit_tests/operations/sdpa/test_sdpa_prefill.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_sdpa_prefill.py
@@ -11,7 +11,6 @@ from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
 import ttnn
 from loguru import logger
 import pytest
-from models.common.utility_functions import skip_with_llk_assert
 
 
 def fa_rand(*shape):
@@ -629,7 +628,6 @@ def test_sdpa_tt_with_program_cache(device, b, nh, nkv, s, d, q_chunk_size, k_ch
     assert device.num_program_cache_entries() == 1
 
 
-@skip_with_llk_assert("Hits LLK assert check for are_unpacker_AB_configured_correctly.")
 @pytest.mark.parametrize("dtype", [ttnn.bfloat8_b], ids=["bfp8"])
 @pytest.mark.parametrize("q_chunk_size", [256], ids=["q256"])
 @pytest.mark.parametrize("k_chunk_size", [256], ids=["k256"])

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -1713,6 +1713,7 @@ void sdpa_inner_loop(
              *
              * matmul_blocks internally waits on both inputs
              */
+            reconfig_data_format(cb_k_in, cb_q_in);
             pack_reconfig_data_format(cb_qk_im);
             matmul_blocks(
                 cb_q_in,
@@ -1806,6 +1807,10 @@ void sdpa_inner_loop(
              */
             sub_exp_block_bcast_cols_inplace<cb_qk_im, Sq_chunk_t, scale_fp32, true>(
                 alias_cur_max, alias_cur_sum, Sk_chunk_t);
+
+            // Reconfigure unpackers: srcA (context 0) = cb_v_in, srcB (context 1) = cb_qk_im (operands are swapped in matmul)
+            reconfig_data_format(cb_v_in, cb_qk_im);
+            pack_reconfig_data_format(alias_mm2_cur_out);
 
             /* OUT_IM = QK @ V_CHUNK */
             matmul_blocks(

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -670,12 +670,6 @@ static void sdpa_inner_loop_step(
 
     exp_packthread_tile_init<true, true, scale_fp32, InputClamping::None>();
 
-    if constexpr (!uniform_pack_format) {
-        pack_reconfig_data_format(cb_qkt_im);
-    }
-    if constexpr (!uniform_unpack_format) {
-        reconfig_data_format(cb_kt_in, cb_q_in);
-    }
     // Use KT_stride for cb_qkt_im layout to keep CB pointers aligned across iterations
     cb_reserve_back(cb_qkt_im, Sq_chunk_t * KT_stride);
 
@@ -696,6 +690,13 @@ static void sdpa_inner_loop_step(
             cb_wait_front(cb_kt_in, DHt * KT_stride);
         }
         kt_index_offset = 0;
+
+        if constexpr (!uniform_pack_format) {
+            pack_reconfig_data_format(cb_qkt_im);
+        }
+        if constexpr (!uniform_unpack_format) {
+            reconfig_data_format(cb_kt_in, cb_q_in);
+        }
 #ifdef ARCH_BLACKHOLE
         mm_no_mop_init_short(cb_q_in, cb_kt_in, true, actual_sbw, subblock_h, in0_block_w);
 #else
@@ -716,6 +717,13 @@ static void sdpa_inner_loop_step(
                     kt_subblock * actual_sbw,
                     subblock_h,
                     actual_sbw);
+
+                if constexpr (!uniform_pack_format) {
+                    pack_reconfig_data_format(cb_qkt_im);
+                }
+                if constexpr (!uniform_unpack_format) {
+                    reconfig_data_format(cb_kt_in, cb_q_in);
+                }
 #ifdef ARCH_BLACKHOLE
                 mm_no_mop_reinit_short(cb_q_in, cb_kt_in, true, actual_sbw, subblock_h, in0_block_w);
 #else

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
@@ -323,7 +323,7 @@ void kernel_main() {
         // Loop through all K chunks
         for (uint32_t k_chunk = k_chunk_start; k_chunk < k_chunk_end; ++k_chunk) {
             // Reconfig register DF
-            reconfig_data_format(cb_q_in, cb_k_in);
+            reconfig_data_format(cb_k_in, cb_q_in);
             pack_reconfig_data_format(cb_qk_im);
 
             // OPTIMIZATION: Add the attention mask directly on top of DST if chunk sizes are dynamic
@@ -432,7 +432,7 @@ void kernel_main() {
                     cb_cur_sum, cb_cur_sum, Sk_chunk_t_dynamic, false);
 
                 /* OUT_IM = QK @ V_CHUNK */
-                reconfig_data_format(cb_qk_im, cb_v_in);  // DEBUG
+                reconfig_data_format(cb_v_in, cb_qk_im);  // DEBUG
                 pack_reconfig_data_format(cb_out_im);
                 matmul_blocks(
                     cb_qk_im,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/39199https://github.com/tenstorrent/tt-metal/issues/39199

### Problem description
This issue describes LLK_ASSERT hits during verifying UNPACK is configured correctly. It is configured during HW configure or later in reconfigure phase and then the same values are used during init or block execution. However, in case of a mismatch - one configuration is set, but a different configuration is provided to init/execution, the assert will be hit.

### What's changed
There are couple of fixes in kernels of 2 types:
1) Add missing reconfigure calls
2) Fix existing reconfigure calls by reordering operand ID-s to match the OP below

This PR is an example of how to address similar issues - where tests are skipped when LLK_ASSERTS are enabled due to unpacker configuration mismatch.

For this PR the relevant tests are ttnn sdpa group only. I have ran them with LLK_ASSERTS enabled (because that's the goal of PR) and here are the runs:
1. Sanity: https://github.com/tenstorrent/tt-metal/actions/runs/23194575399/job/67400482070
2. BHPC: https://github.com/tenstorrent/tt-metal/actions/runs/23172957024/job/67329448046
Due to the fact that at the moment of runs, not all tests were fixed for case when LLK_ASSERTS are enabled, there are some red groups. However, the important one is ttnn sdpa group, which is green in both cases.

Also run for Device perf tests: https://github.com/tenstorrent/tt-metal/actions/runs/23202124123

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/fix_sdpa_to_comply_with_llk_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/fix_sdpa_to_comply_with_llk_asserts)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ndivnic/fix_sdpa_to_comply_with_llk_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ndivnic/fix_sdpa_to_comply_with_llk_asserts)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/fix_sdpa_to_comply_with_llk_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/fix_sdpa_to_comply_with_llk_asserts)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/fix_sdpa_to_comply_with_llk_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/fix_sdpa_to_comply_with_llk_asserts)
  - [x] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/fix_sdpa_to_comply_with_llk_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/fix_sdpa_to_comply_with_llk_asserts)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/fix_sdpa_to_comply_with_llk_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/fix_sdpa_to_comply_with_llk_asserts)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
