### PR TITLE
Clean up TP all reduce

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/kernels/attention_block_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/kernels/attention_block_kernel.cpp
@@ -442,7 +442,6 @@ void kernel_main() {
     // Note: skip_local_push=1 because gather3 already pushed to CB7 (gather3_dst_cb)
     using CCLReceiverReaderCTArgs = deepseek_b1_ops::AllReduceReceiver::ReaderCTArgs<
         get_named_compile_time_arg_val("ccl_receiver_cb_in1"),
-        get_named_compile_time_arg_val("ccl_receiver_l1_alignment"),
         get_named_compile_time_arg_val("ccl_receiver_cb_in2"),
         get_named_compile_time_arg_val("ccl_receiver_remote_sender_noc_x"),
         get_named_compile_time_arg_val("ccl_receiver_remote_sender_noc_y"),
@@ -451,10 +450,6 @@ void kernel_main() {
         get_named_compile_time_arg_val("ccl_receiver_has_residual"),
         get_named_compile_time_arg_val("ccl_receiver_skip_local_push")>;
 
-    // Dummy WriterCTArgs - not used by NCRISC but needed for Op template
-    using DummyWriterCTArgs = deepseek_b1_ops::AllReduceSender::WriterCTArgs<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>;
-    // Dummy ComputeCTArgs - not used by NCRISC but needed for Op template
-    using DummyComputeCTArgs = deepseek_b1_ops::AllReduceReceiver::ComputeCTArgs<0, 0, 0, 0, 0, 0, 0>;
     deepseek_b1_ops::AllReduceSender::RTArgs ccl_sender_args{};
     deepseek_b1_ops::AllReduceReceiver::RTArgs ccl_receiver_args{};
 
@@ -804,9 +799,7 @@ void kernel_main() {
 
     // CCL Sender BRISC CTArgs (sends via fabric)
     using CCLSenderWriterCTArgs = deepseek_b1_ops::AllReduceSender::WriterCTArgs<
-        get_named_compile_time_arg_val("ccl_sender_packet_header_cb_id"),
         get_named_compile_time_arg_val("ccl_sender_packet_cb_id"),
-        get_named_compile_time_arg_val("ccl_sender_l1_alignment"),
         get_named_compile_time_arg_val("ccl_sender_input_num_tiles"),
         get_named_compile_time_arg_val("ccl_sender_page_size_bytes"),
         get_named_compile_time_arg_val("ccl_sender_payload_size_bytes"),
@@ -817,8 +810,6 @@ void kernel_main() {
         get_named_compile_time_arg_val("ccl_sender_dst_num_hops"),
         get_named_compile_time_arg_val("ccl_sender_num_connections")>;
 
-    // Dummy ReaderCTArgs - not used by BRISC but needed for Op template
-    using DummyReaderCTArgs = deepseek_b1_ops::AllReduceSender::ReaderCTArgs<0, 0, 0, 0, 0>;
     deepseek_b1_ops::AllReduceSender::RTArgs ccl_sender_args{};
     if constexpr (Core::is_ccl_sender_core) {
         ccl_sender_args = {
@@ -1117,12 +1108,9 @@ void kernel_main() {
         get_named_compile_time_arg_val("ccl_receiver_cb_in1"),
         get_named_compile_time_arg_val("ccl_receiver_cb_out0"),
         get_named_compile_time_arg_val("ccl_receiver_cb_residual"),
-        get_named_compile_time_arg_val("ccl_receiver_cb_temp"),
         get_named_compile_time_arg_val("ccl_receiver_has_residual"),
         get_named_compile_time_arg_val("ccl_receiver_num_tiles")>;
 
-    using DummyReaderCTArgs = deepseek_b1_ops::AllReduceReceiver::ReaderCTArgs<0, 0, 0, 0, 0, 0, 0, 0, 0>;
-    // Dummy ReaderCTArgs - not used by TRISC but needed for Op template
     deepseek_b1_ops::AllReduceReceiver::RTArgs ccl_receiver_args{};
 
     deepseek_compute_kernel_init();
@@ -1570,14 +1558,14 @@ void kernel_main() {
             noc_semaphore_wait(gather3_completion_semaphore_addr, 1);
             noc_semaphore_set(gather3_completion_semaphore_addr, 0);
 
-            deepseek_b1_ops::AllReduceSender::Op<CCLSenderReaderCTArgs, DummyWriterCTArgs> ccl_sender_reader;
+            deepseek_b1_ops::AllReduceSender::Op<CCLSenderReaderCTArgs> ccl_sender_reader;
             ccl_sender_reader(ccl_sender_args);
 #elif defined(COMPILE_FOR_BRISC)
             volatile tt_l1_ptr uint32_t* sync_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
                 get_named_compile_time_arg_val("mcast_data_receiver_semaphore_addr"));
             noc_semaphore_wait(sync_sem, 2);
             noc_semaphore_set(sync_sem, 0);
-            deepseek_b1_ops::AllReduceSender::Op<DummyReaderCTArgs, CCLSenderWriterCTArgs> ccl_sender_writer;
+            deepseek_b1_ops::AllReduceSender::Op<CCLSenderWriterCTArgs> ccl_sender_writer;
             ccl_sender_writer(ccl_sender_args);
 #endif
         }
@@ -1587,10 +1575,10 @@ void kernel_main() {
 #if defined(COMPILE_FOR_NCRISC)
             // TODO: We're popping the RMSNorm input and then re-pushing it here as the residual
             // Should avoid this and not pop in RMSNorm
-            deepseek_b1_ops::AllReduceReceiver::Op<CCLReceiverReaderCTArgs, DummyComputeCTArgs> ccl_receiver_reader;
+            deepseek_b1_ops::AllReduceReceiver::Op<CCLReceiverReaderCTArgs> ccl_receiver_reader;
             ccl_receiver_reader(ccl_receiver_args);
 #elif defined(COMPILE_FOR_TRISC)
-            deepseek_b1_ops::AllReduceReceiver::Op<DummyReaderCTArgs, CCLReceiverComputeCTArgs> ccl_receiver_compute;
+            deepseek_b1_ops::AllReduceReceiver::Op<CCLReceiverComputeCTArgs> ccl_receiver_compute;
             ccl_receiver_compute(ccl_receiver_args);
 #endif
         }

--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
@@ -722,7 +722,6 @@ class AttentionBlock:
         ccl_num_pages = gather3_dst_num_pages  # 7 pages of 32x32
         ccl_payload_size_bytes = ccl_num_pages * ccl_page_size_bytes  # 7 * 2048 = 14336 bytes
         ccl_packet_header_size_bytes = ttnn.get_tt_fabric_packet_header_size_bytes()
-        l1_alignment = 16
 
         has_residual = 1
 
@@ -942,7 +941,6 @@ class AttentionBlock:
         )  # CCL sender reads gather3 output (sender core)
         ccl_remote_data_cb = cb_id_context.get_cb_id(data_format, TD_INTERP)  # CCL received remote data (receiver core)
         ccl_residual_cb = input_cb
-        ccl_temp_cb = cb_id_context.get_cb_id(data_format, TD_INTERP)  # CCL temp for compute (receiver core)
         ccl_output_cb = cb_id_context.get_cb_id(data_format, TD_INTERP)  # CCL output (receiver core)
         ccl_packet_header_cb = cb_id_context.get_cb_id(
             ttnn.uint32, TD_32x32
@@ -1699,7 +1697,6 @@ class AttentionBlock:
             ("ccl_sender_gather3_completion_semaphore_id", gather3_completion_semaphore_id),
             # CCL receiver (NCRISC waits for remote data)
             ("ccl_receiver_cb_in1", ccl_remote_data_cb),
-            ("ccl_receiver_l1_alignment", l1_alignment),
             ("ccl_receiver_cb_in2", gather3_dst_cb),  # Local data from gather3
             ("ccl_receiver_remote_sender_noc_x", ccl_sender_noc_core.x),
             ("ccl_receiver_remote_sender_noc_y", ccl_sender_noc_core.y),
@@ -1766,9 +1763,7 @@ class AttentionBlock:
             ("ccl_sender_noc_x", ccl_sender_noc_core.x),
             ("ccl_sender_noc_y", ccl_sender_noc_core.y),
             # CCL sender (BRISC sends via fabric)
-            ("ccl_sender_packet_header_cb_id", ccl_packet_header_cb),
             ("ccl_sender_packet_cb_id", ccl_sender_in_cb),
-            ("ccl_sender_l1_alignment", l1_alignment),
             ("ccl_sender_input_num_tiles", ccl_num_pages),
             ("ccl_sender_page_size_bytes", ccl_page_size_bytes),
             ("ccl_sender_payload_size_bytes", ccl_payload_size_bytes),
@@ -1794,7 +1789,7 @@ class AttentionBlock:
                 ("sdpa_l_chunk_size_bytes", sdpa_l_chunk_size_bytes),
                 ("sdpa_num_l_chunks", sdpa_num_l_chunks),
                 ("sdpa_tiles_per_l_chunk", sdpa_tiles_per_l_chunk),
-                ("sdpa_l1_alignment", l1_alignment),
+                ("sdpa_l1_alignment", sdpa_l1_alignment),
                 ("sdpa_page_size_bytes", sdpa_l_tile_size),
                 ("sdpa_slot_size", sdpa_fwd_slot_size),
                 # SDPA scatter params
@@ -1833,7 +1828,6 @@ class AttentionBlock:
             ("ccl_receiver_cb_in1", gather3_dst_cb),  # Local data
             ("ccl_receiver_cb_out0", ccl_output_cb),
             ("ccl_receiver_cb_residual", ccl_residual_cb),
-            ("ccl_receiver_cb_temp", ccl_temp_cb),
             ("ccl_receiver_has_residual", has_residual),
             ("ccl_receiver_num_tiles", ccl_num_tiles),
         ]
@@ -2801,24 +2795,6 @@ class AttentionBlock:
         sdpa_kv_cache_running_offset_mcast_core += ccl_remote_data_cb_descriptor.total_size
         post_sdpa_cb_list.append(ccl_remote_data_cb_descriptor)
         ccl_send_addr = ttnn.get_cb_address(ccl_remote_data_cb_descriptor)
-
-        # CB 11: CCL temp scratch buffer (not backed by tensor)
-        ccl_temp_cb_format = ttnn.CBFormatDescriptor(
-            buffer_index=ccl_temp_cb,
-            data_format=data_format,
-            page_size=cb_page_size,
-            tile=tile_descriptor,
-        )
-        ccl_temp_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
-            ccl_temp_cb,
-            ref_sdpa_kv_cache_buffer,
-            address_offset=sdpa_kv_cache_running_offset_mcast_core,
-            total_size=ccl_num_tiles * tile_size,
-            core_ranges=full_device_grid,
-        )
-        ccl_temp_cb_descriptor.format_descriptors = [ccl_temp_cb_format]
-        sdpa_kv_cache_running_offset_mcast_core += ccl_temp_cb_descriptor.total_size
-        post_sdpa_cb_list.append(ccl_temp_cb_descriptor)
 
         # CB 12: CCL output (from sharded tensor)
         attention_block_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(

--- a/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/kernels/post_sdpa_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/kernels/post_sdpa_kernel.cpp
@@ -156,7 +156,6 @@ void kernel_main() {
     // Note: skip_local_push=1 because gather3 already pushed to CB7 (gather3_dst_cb)
     using CCLReceiverReaderCTArgs = deepseek_b1_ops::AllReduceReceiver::ReaderCTArgs<
         get_named_compile_time_arg_val("ccl_receiver_cb_in1"),
-        get_named_compile_time_arg_val("ccl_receiver_l1_alignment"),
         get_named_compile_time_arg_val("ccl_receiver_cb_in2"),
         get_named_compile_time_arg_val("ccl_receiver_remote_sender_noc_x"),
         get_named_compile_time_arg_val("ccl_receiver_remote_sender_noc_y"),
@@ -224,9 +223,7 @@ void kernel_main() {
 #ifndef SKIP_CCL
     // CCL Sender BRISC CTArgs (sends via fabric)
     using CCLSenderWriterCTArgs = deepseek_b1_ops::AllReduceSender::WriterCTArgs<
-        get_named_compile_time_arg_val("ccl_sender_packet_header_cb_id"),
         get_named_compile_time_arg_val("ccl_sender_packet_cb_id"),
-        get_named_compile_time_arg_val("ccl_sender_l1_alignment"),
         get_named_compile_time_arg_val("ccl_sender_input_num_tiles"),
         get_named_compile_time_arg_val("ccl_sender_page_size_bytes"),
         get_named_compile_time_arg_val("ccl_sender_payload_size_bytes"),
@@ -281,7 +278,6 @@ void kernel_main() {
         get_named_compile_time_arg_val("ccl_receiver_cb_in1"),
         get_named_compile_time_arg_val("ccl_receiver_cb_out0"),
         get_named_compile_time_arg_val("ccl_receiver_cb_residual"),
-        get_named_compile_time_arg_val("ccl_receiver_cb_temp"),
         get_named_compile_time_arg_val("ccl_receiver_has_residual"),
         get_named_compile_time_arg_val("ccl_receiver_num_tiles")>;
 #endif
@@ -583,39 +579,32 @@ void kernel_main() {
         noc_semaphore_wait(gather3_completion_semaphore_addr, 1);
         noc_semaphore_set(gather3_completion_semaphore_addr, 0);
 
-        // Dummy WriterCTArgs - not used by NCRISC but needed for Op template
-        using DummyWriterCTArgs = deepseek_b1_ops::AllReduceSender::WriterCTArgs<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>;
-
         deepseek_b1_ops::AllReduceSender::RTArgs ccl_sender_args{};
         ccl_sender_args.tensor_address = get_common_arg_val<uint32_t>(0);
 
-        deepseek_b1_ops::AllReduceSender::Op<CCLSenderReaderCTArgs, DummyWriterCTArgs> ccl_sender_reader;
+        deepseek_b1_ops::AllReduceSender::Op<CCLSenderReaderCTArgs> ccl_sender_reader;
         ccl_sender_reader(ccl_sender_args);
     }
 
     if constexpr (Core::is_ccl_receiver_core) {
         DeviceZoneScopedN("CCL_RECEIVER_WAIT");
-        // Dummy ComputeCTArgs - not used by NCRISC but needed for Op template
-        using DummyComputeCTArgs = deepseek_b1_ops::AllReduceReceiver::ComputeCTArgs<0, 0, 0, 0, 0, 0, 0>;
 
         deepseek_b1_ops::AllReduceReceiver::RTArgs ccl_receiver_args{};
         ccl_receiver_args.sender_semaphore_addr = get_common_arg_val<uint32_t>(0);
 
-        deepseek_b1_ops::AllReduceReceiver::Op<CCLReceiverReaderCTArgs, DummyComputeCTArgs> ccl_receiver_reader;
+        deepseek_b1_ops::AllReduceReceiver::Op<CCLReceiverReaderCTArgs> ccl_receiver_reader;
         ccl_receiver_reader(ccl_receiver_args);
     }
 
 #elif defined(COMPILE_FOR_BRISC)
     if constexpr (Core::is_ccl_sender_core) {
         DeviceZoneScopedN("CCL_SENDER_SEND");
-        // Dummy ReaderCTArgs - not used by BRISC but needed for Op template
-        using DummyReaderCTArgs = deepseek_b1_ops::AllReduceSender::ReaderCTArgs<0, 0, 0, 0, 0>;
 
         deepseek_b1_ops::AllReduceSender::RTArgs ccl_sender_args{};
         ccl_sender_args.receiver_base_address = get_common_arg_val<uint32_t>(0);
         ccl_sender_args.receive_semaphore_addr = get_common_arg_val<uint32_t>(1);
 
-        deepseek_b1_ops::AllReduceSender::Op<DummyReaderCTArgs, CCLSenderWriterCTArgs> ccl_sender_writer;
+        deepseek_b1_ops::AllReduceSender::Op<CCLSenderWriterCTArgs> ccl_sender_writer;
         ccl_sender_writer(ccl_sender_args);
     }
     // CCL Receiver BRISC is no-op
@@ -623,12 +612,10 @@ void kernel_main() {
 #elif defined(COMPILE_FOR_TRISC)
     if constexpr (Core::is_ccl_receiver_core) {
         DeviceZoneScopedN("CCL_RECEIVER_COMPUTE");
-        // Dummy ReaderCTArgs - not used by TRISC but needed for Op template
-        using DummyReaderCTArgs = deepseek_b1_ops::AllReduceReceiver::ReaderCTArgs<0, 0, 0, 0, 0, 0, 0, 0, 0>;
 
         deepseek_b1_ops::AllReduceReceiver::RTArgs ccl_receiver_args{};
 
-        deepseek_b1_ops::AllReduceReceiver::Op<DummyReaderCTArgs, CCLReceiverComputeCTArgs> ccl_receiver_compute;
+        deepseek_b1_ops::AllReduceReceiver::Op<CCLReceiverComputeCTArgs> ccl_receiver_compute;
         ccl_receiver_compute(ccl_receiver_args);
     }
     // CCL Sender TRISC is no-op

--- a/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/op.py
@@ -32,9 +32,7 @@ CB Layout:
 - CB 8: ccl_sender_in (ccl sender core)
 - CB 9: ccl_remote_data (gather/receiver core - intermediate tensor)
 - CB 10: ccl_residual (gather/receiver core - optional)
-- CB 11: ccl_temp (gather/receiver core - for compute)
 - CB 12: ccl_output (gather/receiver core - final output)
-- CB 13: ccl_packet_header (sender + receiver cores)
 """
 
 
@@ -402,9 +400,7 @@ class PostSDPA:
         ccl_sender_in_cb = 52  # CCL sender reads gather3 output (sender core)
         ccl_remote_data_cb = 53  # CCL received remote data (receiver core)
         ccl_residual_cb = 54  # CCL residual (receiver core)
-        ccl_temp_cb = 55  # CCL temp for compute (receiver core)
         ccl_output_cb = 56  # CCL output (receiver core)
-        ccl_packet_header_cb = 57  # CCL packet headers (sender + receiver cores)
 
         # ========================================================================
         # Gather2 parameters: 64 cores -> [1, 8192]
@@ -427,21 +423,19 @@ class PostSDPA:
         # ========================================================================
         gather3_data_size_bytes = matmul5_out_w_per_core * tile_1x32_size
         gather3_src_num_pages = matmul5_out_w_per_core  # 2 pages per sender
-        gather3_dst_num_pages = num_matmul5_cores * matmul5_out_w_per_core  # 112 * 2 = 224 pages
+        gather3_dst_num_pages = num_matmul5_cores * matmul5_out_w_per_core // 32  # 112 * 2 / 32 = 7 pages
         gather3_noc0_num_senders = num_matmul5_cores
         gather3_noc1_num_senders = 0
 
         # ========================================================================
         # CCL parameters: [1, 7168] all-reduce
         # ========================================================================
-        # Using 1x32 tiles to match gather3 output format (for tile-compatible reduction)
-        # 7168 elements = 224 tiles of 1x32 (32 elements each)
-        ccl_num_tiles = gather3_dst_num_pages  # 224 tiles of 1x32
-        ccl_page_size_bytes = tile_1x32_size  # 1x32 tile size
-        ccl_num_pages = gather3_dst_num_pages  # 224 pages of 1x32
-        ccl_payload_size_bytes = ccl_num_pages * ccl_page_size_bytes  # 224 * 64 = 14336 bytes
-        ccl_packet_header_size_bytes = ttnn.get_tt_fabric_packet_header_size_bytes()
-        l1_alignment = 16
+        # Using 32x32 tiles to match gather3 output format (for tile-compatible reduction)
+        # 7168 elements = 7 tiles of 32x32 (1024 elements each)
+        ccl_num_tiles = gather3_dst_num_pages  # 7 tiles of 32x32
+        ccl_page_size_bytes = tile_32x32_size  # 32x32 tile size
+        ccl_num_pages = gather3_dst_num_pages  # 7 pages of 32x32
+        ccl_payload_size_bytes = ccl_num_pages * ccl_page_size_bytes  # 7 * 2048 = 14336 bytes
 
         has_residual = 1 if residual_tensor_mesh is not None else 0
 
@@ -569,7 +563,6 @@ class PostSDPA:
                     ("ccl_sender_gather3_completion_semaphore_id", gather3_completion_semaphore_id),
                     # CCL receiver (NCRISC waits for remote data)
                     ("ccl_receiver_cb_in1", ccl_remote_data_cb),
-                    ("ccl_receiver_l1_alignment", l1_alignment),
                     ("ccl_receiver_cb_in2", gather3_dst_cb),  # Local data from gather3
                     ("ccl_receiver_remote_sender_noc_x", ccl_sender_noc_core.x),
                     ("ccl_receiver_remote_sender_noc_y", ccl_sender_noc_core.y),
@@ -644,9 +637,7 @@ class PostSDPA:
                     ("ccl_sender_noc_x", ccl_sender_noc_core.x),
                     ("ccl_sender_noc_y", ccl_sender_noc_core.y),
                     # CCL sender (BRISC sends via fabric)
-                    ("ccl_sender_packet_header_cb_id", ccl_packet_header_cb),
                     ("ccl_sender_packet_cb_id", ccl_sender_in_cb),
-                    ("ccl_sender_l1_alignment", l1_alignment),
                     ("ccl_sender_input_num_tiles", ccl_num_pages),
                     ("ccl_sender_page_size_bytes", ccl_page_size_bytes),
                     ("ccl_sender_payload_size_bytes", ccl_payload_size_bytes),
@@ -673,7 +664,7 @@ class PostSDPA:
                             ("sdpa_l_chunk_size_bytes", sdpa_l_chunk_size_bytes),
                             ("sdpa_num_l_chunks", sdpa_num_l_chunks),
                             ("sdpa_tiles_per_l_chunk", sdpa_tiles_per_l_chunk),
-                            ("sdpa_l1_alignment", l1_alignment),
+                            ("sdpa_l1_alignment", sdpa_l1_alignment),
                             ("sdpa_page_size_bytes", sdpa_l_tile_size),
                             ("sdpa_slot_size", sdpa_fwd_slot_size),
                             # SDPA scatter params
@@ -712,7 +703,6 @@ class PostSDPA:
                     ("ccl_receiver_cb_in1", gather3_dst_cb),  # Local data
                     ("ccl_receiver_cb_out0", ccl_output_cb),
                     ("ccl_receiver_cb_residual", ccl_residual_cb),
-                    ("ccl_receiver_cb_temp", ccl_temp_cb),
                     ("ccl_receiver_has_residual", has_residual),
                     ("ccl_receiver_num_tiles", ccl_num_tiles),
                 ]
@@ -839,6 +829,14 @@ class PostSDPA:
                 gather3_dst_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     gather3_dst_cb, gather3_output_tensor_device
                 )
+                gather3_dst_cb_descriptor.format_descriptors = [
+                    ttnn.CBFormatDescriptor(
+                        buffer_index=gather3_dst_cb,
+                        data_format=data_format,
+                        page_size=tile_32x32_size,
+                        tile=ttnn.TileDescriptor(TILE_32x32),
+                    )
+                ]
 
                 cb_list = [
                     matmul4_in0_cb_descriptor,
@@ -857,21 +855,21 @@ class PostSDPA:
                     ccl_sender_in_cb_format = ttnn.CBFormatDescriptor(
                         buffer_index=ccl_sender_in_cb,
                         data_format=data_format,
-                        page_size=tile_1x32_size,
-                        tile=matmul4_out_tile_descriptor,
+                        page_size=ccl_page_size_bytes,
+                        tile=ttnn.TileDescriptor(TILE_32x32),
                     )
                     if sdpa_kv_cache_buffer_device is not None:
                         ccl_sender_in_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                             ccl_sender_in_cb,
                             sdpa_kv_cache_buffer_device,
                             address_offset=running_address_offset,
-                            total_size=ccl_num_pages * tile_1x32_size,
+                            total_size=ccl_num_pages * ccl_page_size_bytes,
                         )
                         ccl_sender_in_cb_descriptor.format_descriptors = [ccl_sender_in_cb_format]
                         running_address_offset += ccl_sender_in_cb_descriptor.total_size
                     else:
                         ccl_sender_in_cb_descriptor = ttnn.CBDescriptor(
-                            total_size=ccl_num_pages * tile_1x32_size,
+                            total_size=ccl_num_pages * ccl_page_size_bytes,
                             core_ranges=ccl_sender_core_grid,
                             format_descriptors=[ccl_sender_in_cb_format],
                         )
@@ -883,6 +881,15 @@ class PostSDPA:
                         ccl_remote_data_cb, intermediate_tensor_device
                     )
                     ccl_remote_data_cb_descriptor.core_ranges = gather_core_grid
+                    ccl_remote_data_cb_descriptor.total_size = ccl_num_pages * ccl_page_size_bytes
+                    ccl_remote_data_cb_descriptor.format_descriptors = [
+                        ttnn.CBFormatDescriptor(
+                            buffer_index=ccl_remote_data_cb,
+                            data_format=data_format,
+                            page_size=ccl_page_size_bytes,
+                            tile=ttnn.TileDescriptor(TILE_32x32),
+                        )
+                    ]
                     cb_list.append(ccl_remote_data_cb_descriptor)
 
                     # CB 10: CCL residual (optional, from sharded tensor)
@@ -891,70 +898,33 @@ class PostSDPA:
                             ccl_residual_cb, residual_tensors_per_device[device_idx]
                         )
                         ccl_residual_cb_descriptor.core_ranges = gather_core_grid
-                        ccl_residual_cb_descriptor.total_size = ccl_num_tiles * tile_1x32_size
+                        ccl_residual_cb_descriptor.total_size = ccl_num_tiles * ccl_page_size_bytes
                         ccl_residual_cb_descriptor.format_descriptors = [
                             ttnn.CBFormatDescriptor(
                                 buffer_index=ccl_residual_cb,
                                 data_format=data_format,
-                                page_size=tile_1x32_size,
-                                tile=matmul4_out_tile_descriptor,  # 1x32 tiles to match gather3
+                                page_size=ccl_page_size_bytes,
+                                tile=ttnn.TileDescriptor(TILE_32x32),
                             )
                         ]
                         cb_list.append(ccl_residual_cb_descriptor)
-
-                        # CB 11: CCL temp scratch buffer (not backed by tensor)
-                        ccl_temp_cb_format = ttnn.CBFormatDescriptor(
-                            buffer_index=ccl_temp_cb,
-                            data_format=data_format,
-                            page_size=tile_1x32_size,
-                            tile=matmul4_out_tile_descriptor,
-                        )
-                        if sdpa_kv_cache_buffer_device is not None:
-                            ccl_temp_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
-                                ccl_temp_cb,
-                                sdpa_kv_cache_buffer_device,
-                                address_offset=running_address_offset,
-                                total_size=ccl_num_tiles * tile_1x32_size,
-                            )
-                            ccl_temp_cb_descriptor.format_descriptors = [ccl_temp_cb_format]
-                            running_address_offset += ccl_temp_cb_descriptor.total_size
-                        else:
-                            ccl_temp_cb_descriptor = ttnn.CBDescriptor(
-                                total_size=ccl_num_tiles * tile_1x32_size,
-                                core_ranges=gather_core_grid,
-                                format_descriptors=[ccl_temp_cb_format],
-                            )
-                        cb_list.append(ccl_temp_cb_descriptor)
 
                     # CB 12: CCL output (from sharded tensor)
                     ccl_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                         ccl_output_cb, output_tensor_device
                     )
                     ccl_output_cb_descriptor.core_ranges = gather_core_grid
+                    ccl_output_cb_descriptor.total_size = ccl_num_pages * ccl_page_size_bytes
+                    ccl_output_cb_descriptor.format_descriptors = [
+                        ttnn.CBFormatDescriptor(
+                            buffer_index=ccl_output_cb,
+                            data_format=data_format,
+                            page_size=ccl_page_size_bytes,
+                            tile=ttnn.TileDescriptor(TILE_32x32),
+                        )
+                    ]
                     cb_list.append(ccl_output_cb_descriptor)
 
-                    # CB 13: CCL packet headers
-                    ccl_packet_header_cb_format = ttnn.CBFormatDescriptor(
-                        buffer_index=ccl_packet_header_cb,
-                        data_format=ttnn.uint32,
-                        page_size=ccl_packet_header_size_bytes,
-                    )
-                    if sdpa_kv_cache_buffer_device is not None:
-                        ccl_packet_header_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
-                            ccl_packet_header_cb,
-                            sdpa_kv_cache_buffer_device,
-                            address_offset=running_address_offset,
-                            total_size=2 * ccl_packet_header_size_bytes,
-                        )
-                        ccl_packet_header_cb_descriptor.format_descriptors = [ccl_packet_header_cb_format]
-                        running_address_offset += ccl_packet_header_cb_descriptor.total_size
-                    else:
-                        ccl_packet_header_cb_descriptor = ttnn.CBDescriptor(
-                            total_size=2 * ccl_packet_header_size_bytes,
-                            core_ranges=gather_core_grid.merge(ccl_sender_core_grid),
-                            format_descriptors=[ccl_packet_header_cb_format],
-                        )
-                    cb_list.append(ccl_packet_header_cb_descriptor)
                 # SDPA CBs (14-24): only when SDPA is enabled
                 if sdpa_enabled:
                     # Get per-device SDPA tensors

--- a/models/demos/deepseek_v3_b1/micro_ops/ccl_all_reduce/kernels/all_reduce_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/ccl_all_reduce/kernels/all_reduce_kernel.cpp
@@ -40,20 +40,16 @@ void kernel_main() {
             get_named_compile_time_arg_val("core_noc_x"),
             get_named_compile_time_arg_val("core_noc_y")>;
 
-        // Dummy WriterCTArgs - not used by NCRISC but needed for Op template
-        using WriterCTArgs = Sender::WriterCTArgs<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>;
-
         Sender::RTArgs args{};
         args.tensor_address = get_common_arg_val<uint32_t>(0);
 
-        Sender::Op<ReaderCTArgs, WriterCTArgs> op;
+        Sender::Op<ReaderCTArgs> op;
         op(args);
     } else {
         using Receiver = deepseek_b1_ops::AllReduceReceiver;
 
         using ReaderCTArgs = Receiver::ReaderCTArgs<
             get_named_compile_time_arg_val("cb_in1"),
-            get_named_compile_time_arg_val("l1_alignment"),
             get_named_compile_time_arg_val("cb_in2"),
             get_named_compile_time_arg_val("remote_sender_noc_x"),
             get_named_compile_time_arg_val("remote_sender_noc_y"),
@@ -61,13 +57,10 @@ void kernel_main() {
             get_named_compile_time_arg_val("cb_residual"),
             get_named_compile_time_arg_val("has_residual")>;
 
-        // Dummy ComputeCTArgs - not used by NCRISC but needed for Op template
-        using ComputeCTArgs = Receiver::ComputeCTArgs<0, 0, 0, 0, 0, 0, 0>;
-
         Receiver::RTArgs args{};
         args.sender_semaphore_addr = get_common_arg_val<uint32_t>(0);
 
-        Receiver::Op<ReaderCTArgs, ComputeCTArgs> op;
+        Receiver::Op<ReaderCTArgs> op;
         op(args);
     }
 
@@ -78,13 +71,8 @@ void kernel_main() {
     if constexpr (is_sender) {
         using Sender = deepseek_b1_ops::AllReduceSender;
 
-        // Dummy ReaderCTArgs - not used by BRISC but needed for Op template
-        using ReaderCTArgs = Sender::ReaderCTArgs<0, 0, 0, 0, 0>;
-
         using WriterCTArgs = Sender::WriterCTArgs<
-            get_named_compile_time_arg_val("packet_header_cb_id"),
             get_named_compile_time_arg_val("packet_cb_id"),
-            get_named_compile_time_arg_val("l1_alignment"),
             get_named_compile_time_arg_val("input_num_tiles"),
             get_named_compile_time_arg_val("page_size_bytes"),
             get_named_compile_time_arg_val("payload_size_bytes"),
@@ -99,7 +87,7 @@ void kernel_main() {
         args.receiver_base_address = get_common_arg_val<uint32_t>(0);
         args.receive_semaphore_addr = get_common_arg_val<uint32_t>(1);
 
-        Sender::Op<ReaderCTArgs, WriterCTArgs> op;
+        Sender::Op<WriterCTArgs> op;
         op(args);
     }
     // else: receiver BRISC is no-op
@@ -111,15 +99,11 @@ void kernel_main() {
     if constexpr (!is_sender) {
         using Receiver = deepseek_b1_ops::AllReduceReceiver;
 
-        // Dummy ReaderCTArgs - not used by TRISC but needed for Op template
-        using ReaderCTArgs = Receiver::ReaderCTArgs<0, 0, 0, 0, 0, 0, 0, 0, 0>;
-
         using ComputeCTArgs = Receiver::ComputeCTArgs<
             get_named_compile_time_arg_val("cb_in0"),
             get_named_compile_time_arg_val("cb_in1"),
             get_named_compile_time_arg_val("cb_out0"),
             get_named_compile_time_arg_val("cb_residual"),
-            get_named_compile_time_arg_val("cb_temp"),
             get_named_compile_time_arg_val("has_residual"),
             get_named_compile_time_arg_val("num_tiles")>;
 
@@ -127,7 +111,7 @@ void kernel_main() {
 
         Receiver::RTArgs args{};
 
-        Receiver::Op<ReaderCTArgs, ComputeCTArgs> op;
+        Receiver::Op<ComputeCTArgs> op;
         op(args);
     }
     // else: sender TRISC is no-op

--- a/models/demos/deepseek_v3_b1/micro_ops/ccl_all_reduce/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/ccl_all_reduce/op.py
@@ -129,7 +129,6 @@ class DeepseekMinimalAllReduce:
         num_standard_tiles = (input_num_pages + tiny_tiles_per_standard_tile - 1) // tiny_tiles_per_standard_tile
 
         # Packet and alignment info
-        l1_alignment = 16  # L1 alignment
         packet_size_bytes = input_num_pages * page_size_bytes
 
         # CB indices
@@ -137,10 +136,8 @@ class DeepseekMinimalAllReduce:
         compute_cb_in1 = 1  # For remote data (standard tiles, intermediate tensor)
         compute_cb_in2 = 2  # For local data (standard tiles, re-interpreted input)
         compute_cb_out = 3  # For output (standard tiles, re-interpreted output)
-        packet_header_cb_id = 4  # For fabric packet headers
         packet_cb_id = 5  # For fabric packets
         compute_cb_residual = 6  # For fused residual add
-        compute_cb_temp = 7
 
         # Packet header size
         packet_header_size_bytes = 32  # Size of one packet header
@@ -231,9 +228,7 @@ class DeepseekMinimalAllReduce:
                 ]
 
                 sender_brisc_ct_args = [
-                    ("packet_header_cb_id", packet_header_cb_id),
                     ("packet_cb_id", src0_cb_index),
-                    ("l1_alignment", l1_alignment),
                     ("input_num_tiles", input_num_pages),
                     ("page_size_bytes", page_size_bytes),
                     ("payload_size_bytes", packet_size_bytes),
@@ -248,7 +243,6 @@ class DeepseekMinimalAllReduce:
                 # Receiver kernel: NCRISC (reader) + TRISC (compute)
                 receiver_ncrisc_ct_args = [
                     ("cb_in1", compute_cb_in1),
-                    ("l1_alignment", l1_alignment),
                     ("cb_in2", compute_cb_in2),
                     ("remote_sender_noc_x", remote_sender_noc_x),
                     ("remote_sender_noc_y", remote_sender_noc_y),
@@ -262,7 +256,6 @@ class DeepseekMinimalAllReduce:
                     ("cb_in1", compute_cb_in2),
                     ("cb_out0", compute_cb_out),
                     ("cb_residual", compute_cb_residual),
-                    ("cb_temp", compute_cb_temp),
                     ("has_residual", has_residual),
                     ("num_tiles", num_standard_tiles),
                 ]
@@ -327,18 +320,6 @@ class DeepseekMinimalAllReduce:
                     )
                 ]
 
-                # CB4: Packet headers
-                cb4_format = ttnn.CBFormatDescriptor(
-                    buffer_index=packet_header_cb_id,
-                    data_format=ttnn.uint32,
-                    page_size=packet_header_size_bytes,
-                )
-                cb4_desc = ttnn.CBDescriptor(
-                    total_size=2 * packet_header_size_bytes,
-                    core_ranges=worker_core_set,
-                    format_descriptors=[cb4_format],
-                )
-
                 # CB5: Packet data for sender
                 cb5_format = ttnn.CBFormatDescriptor(
                     buffer_index=packet_cb_id,
@@ -350,7 +331,7 @@ class DeepseekMinimalAllReduce:
                     core_ranges=worker_core_set,
                     format_descriptors=[cb5_format],
                 )
-                cb_list = [cb0_desc, cb1_desc, cb2_desc, cb3_desc, cb4_desc, cb5_desc]
+                cb_list = [cb0_desc, cb1_desc, cb2_desc, cb3_desc, cb5_desc]
                 if residual_tensor_mesh is not None:
                     cb6_desc = ttnn.cb_descriptor_from_sharded_tensor(
                         compute_cb_residual, residual_tensors_per_device[device_idx]
@@ -366,20 +347,6 @@ class DeepseekMinimalAllReduce:
                         )
                     ]
                     cb_list.append(cb6_desc)
-                    # CB7: Temp scratch buffer (not backed by tensor)
-                    cb7_desc = ttnn.CBDescriptor(
-                        total_size=num_standard_tiles * standard_tile_size_bytes,
-                        core_ranges=receiver_core_set,
-                        format_descriptors=[
-                            ttnn.CBFormatDescriptor(
-                                buffer_index=compute_cb_temp,
-                                data_format=dtype,
-                                page_size=standard_tile_size_bytes,
-                                tile=ttnn.TileDescriptor(intermediate_tile_height, intermediate_tile_width),
-                            )
-                        ],
-                    )
-                    cb_list.append(cb7_desc)
 
                 # === KERNEL DESCRIPTORS using UnifiedKernelDescriptor ===
                 # Single unified kernel with is_sender compile-time arg to differentiate roles

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_ccl_all_reduce.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_ccl_all_reduce.py
@@ -44,7 +44,6 @@ def create_fabric_router_config(max_payload_size):
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("input_dtype", [ttnn.bfloat16])
 @pytest.mark.parametrize("cluster_axis", [0])
-@pytest.mark.parametrize("mesh_device", [(4, 2)], indirect=True)  # Open full mesh, create submesh
 @pytest.mark.parametrize("num_iter, num_warmup_iter", [(30, 15)])
 @pytest.mark.parametrize(
     "device_params",
@@ -59,7 +58,7 @@ def create_fabric_router_config(max_payload_size):
 )
 @pytest.mark.parametrize("fuse_residual_add", [True])
 def test_ccl_all_reduce(
-    mesh_device,
+    bh_2d_mesh_device,
     num_devices,
     output_shape,
     input_shard_shape,
@@ -72,11 +71,11 @@ def test_ccl_all_reduce(
     num_iter,
 ):
     # Validate mesh size
-    if mesh_device.shape[0] * mesh_device.shape[1] < num_devices:
+    if bh_2d_mesh_device.shape[0] * bh_2d_mesh_device.shape[1] < num_devices:
         pytest.skip("Test requires more devices than are available on this platform")
 
     # Create submesh - fabric requires opening full system mesh first
-    submesh = mesh_device.create_submesh(ttnn.MeshShape((num_devices, 1)))
+    submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((num_devices, 1)))
 
     # Set up sub-device
     compute_grid_size = submesh.compute_with_storage_grid_size()
@@ -255,10 +254,16 @@ def test_ccl_all_reduce(
     )
 
     all_passed = True
+    ref_device_idx = 0
+    ref_device_output = output_tensor_torch[ref_device_idx : ref_device_idx + 1, :]
     for device_idx in range(num_devices):
         received = output_tensor_torch[device_idx : device_idx + 1, :]
 
         assert received.shape == torch_expected.shape, f"Shape mismatch at device {device_idx}"
+
+        if device_idx != ref_device_idx:
+            dev_eq = torch.equal(received, ref_device_output)
+            assert dev_eq, f"Device {device_idx} output mismatch"
 
         if not torch.allclose(received, torch_expected, rtol=1e-2, atol=1e-2):
             logger.error(f"Output mismatch for device {device_idx}")

--- a/models/demos/deepseek_v3_b1/unified_kernels/all_reduce_receiver.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/all_reduce_receiver.hpp
@@ -21,6 +21,7 @@ using namespace tt::tt_fabric::linear::experimental;
 using namespace tt::tt_fabric::common::experimental;
 
 #elif defined(COMPILE_FOR_TRISC)
+#include "api/compute/tile_move_copy.h"
 #include "api/compute/eltwise_binary.h"
 #endif
 
@@ -42,7 +43,6 @@ struct AllReduceReceiver {
     // Reader CTArgs (NCRISC)
     template <
         uint32_t cbIn1,
-        uint32_t alignment,
         uint32_t cbIn2,
         uint32_t remoteSenderNocX,
         uint32_t remoteSenderNocY,
@@ -52,7 +52,6 @@ struct AllReduceReceiver {
         uint32_t skipLocalPush = 0>  // Skip cb_reserve/push on cb_in2 when fused with gather
     struct ReaderCTArgs {
         static constexpr uint32_t cb_in1 = cbIn1;
-        static constexpr uint32_t l1_alignment = alignment;
         static constexpr uint32_t cb_in2 = cbIn2;
         static constexpr uint32_t remote_sender_noc_x = remoteSenderNocX;
         static constexpr uint32_t remote_sender_noc_y = remoteSenderNocY;
@@ -68,7 +67,6 @@ struct AllReduceReceiver {
         uint32_t cbIn1,
         uint32_t cbOut0,
         uint32_t cbResidual,
-        uint32_t cbTemp,
         uint32_t hasResidual,
         uint32_t numTiles>
     struct ComputeCTArgs {
@@ -76,7 +74,6 @@ struct AllReduceReceiver {
         static constexpr uint32_t cb_in1 = cbIn1;
         static constexpr uint32_t cb_out0 = cbOut0;
         static constexpr uint32_t cb_residual = cbResidual;
-        static constexpr uint32_t cb_temp = cbTemp;
         static constexpr bool has_residual = hasResidual;
         static constexpr uint32_t num_tiles = numTiles;
     };
@@ -105,12 +102,61 @@ struct AllReduceReceiver {
     // ReaderCT: compile-time args for NCRISC reader
     // ComputeCT: compile-time args for TRISC compute
     // ========================================================================
-    template <typename ReaderCT, typename ComputeCT>
+    template <typename CTArgs>
     class Op {
     public:
         void operator()(const RTArgs& args) { impl(args); }
 
     private:
+#if defined(COMPILE_FOR_TRISC)
+        template <bool AcquireRegs>
+        static FORCE_INLINE void batched_add(uint32_t cb_a, uint32_t cb_b, uint32_t cb_out, uint32_t num_tiles) {
+            // constexpr uint32_t max_dst_tiles = 4;
+            // uint32_t num_batches = (num_tiles + max_dst_tiles - 1) / max_dst_tiles;
+
+            cb_wait_front(cb_a, num_tiles);
+            cb_wait_front(cb_b, num_tiles);
+            cb_reserve_back(cb_out, num_tiles);
+
+            // Original code for reference
+            // TODO: Restore the pack overlap with math for better performance
+            // for (uint32_t batch = 0; batch < num_batches; ++batch) {
+            //     uint32_t start_tile = batch * max_dst_tiles;
+            //     uint32_t batch_size = (start_tile + max_dst_tiles <= num_tiles)
+            //                               ? max_dst_tiles
+            //                               : (num_tiles - start_tile);
+
+            //     tile_regs_acquire();
+            //     for (uint32_t i = 0; i < batch_size; ++i) {
+            //         add_tiles(cb_a, cb_b, start_tile + i, start_tile + i, i);
+            //     }
+            //     tile_regs_commit();
+
+            //     tile_regs_wait();
+            //     for (uint32_t i = 0; i < batch_size; ++i) {
+            //         pack_tile(i, cb_out, start_tile + i);
+            //     }
+            //     tile_regs_release();
+            // }
+            if constexpr (AcquireRegs) {
+                tile_regs_acquire();
+            }
+            for (uint32_t i = 0; i < num_tiles; i++) {
+                add_tiles(cb_a, cb_b, i, i, i);
+            }
+            tile_regs_commit();
+            tile_regs_wait();
+            for (uint32_t i = 0; i < num_tiles; i++) {
+                pack_tile(i, cb_out, i);
+            }
+            tile_regs_release();
+
+            cb_pop_front(cb_a, num_tiles);
+            cb_pop_front(cb_b, num_tiles);
+            cb_push_back(cb_out, num_tiles);
+        }
+#endif
+
         void impl([[maybe_unused]] const RTArgs& args) {
 #if defined(COMPILE_FOR_NCRISC)
             // ================================================================
@@ -118,24 +164,22 @@ struct AllReduceReceiver {
             // ================================================================
             // Push local and residual tiles to compute immediately (they're ready)
             // Skip local push if data is already in CB (e.g., from preceding gather operation)
-            if constexpr (!ReaderCT::skip_local_push) {
-                cb_reserve_back(ReaderCT::cb_in2, ReaderCT::num_standard_tiles);
-                cb_push_back(ReaderCT::cb_in2, ReaderCT::num_standard_tiles);
+            if constexpr (CTArgs::has_residual) {
+                cb_reserve_back(CTArgs::cb_residual, CTArgs::num_standard_tiles);
+                cb_push_back(CTArgs::cb_residual, CTArgs::num_standard_tiles);
             }
-
-            if constexpr (ReaderCT::has_residual) {
-                cb_reserve_back(ReaderCT::cb_residual, ReaderCT::num_standard_tiles);
-                cb_push_back(ReaderCT::cb_residual, ReaderCT::num_standard_tiles);
+            if constexpr (!CTArgs::skip_local_push) {
+                cb_reserve_back(CTArgs::cb_in2, CTArgs::num_standard_tiles);
+                cb_push_back(CTArgs::cb_in2, CTArgs::num_standard_tiles);
             }
-
             // Wait for remote sender to signal data has been written to intermediate tensor
             auto local_semaphore_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.sender_semaphore_addr);
             noc_semaphore_wait(local_semaphore_ptr, 1);
             noc_semaphore_set(local_semaphore_ptr, 0);
 
             // Remote data is now ready, push to compute
-            cb_reserve_back(ReaderCT::cb_in1, ReaderCT::num_standard_tiles);
-            cb_push_back(ReaderCT::cb_in1, ReaderCT::num_standard_tiles);
+            cb_reserve_back(CTArgs::cb_in1, CTArgs::num_standard_tiles);
+            cb_push_back(CTArgs::cb_in1, CTArgs::num_standard_tiles);
 
 #elif defined(COMPILE_FOR_BRISC)
             // ================================================================
@@ -146,96 +190,24 @@ struct AllReduceReceiver {
             // ================================================================
             // TRISC (Compute) - performs reduction: local + remote → output
             // ================================================================
-            reconfig_data_format<false, true>(ComputeCT::cb_in0, ComputeCT::cb_in1);
-            pack_reconfig_data_format<true>(ComputeCT::cb_out0);
-            add_tiles_init(ComputeCT::cb_in0, ComputeCT::cb_in1);
+            reconfig_data_format<false, true>(CTArgs::cb_in0, CTArgs::cb_in1);
+            pack_reconfig_data_format<true>(CTArgs::cb_out0);
 
-            constexpr uint32_t max_dst_tiles = 4;
-            constexpr uint32_t num_batches = (ComputeCT::num_tiles + max_dst_tiles - 1) / max_dst_tiles;
+            // TODO: Fix this to account for actual dst size
+            static_assert(CTArgs::num_tiles <= 8, "num_tiles must be less than or equal to 8");
 
-            if constexpr (ComputeCT::has_residual) {
-                // Fused residual add: (local + residual) + remote → output
-                cb_wait_front(ComputeCT::cb_in1, ComputeCT::num_tiles);
-                cb_wait_front(ComputeCT::cb_residual, ComputeCT::num_tiles);
-                cb_reserve_back(ComputeCT::cb_temp, ComputeCT::num_tiles);
-
-                // First add: local + residual → temp
-                for (uint32_t batch = 0; batch < num_batches; ++batch) {
-                    uint32_t start_tile = batch * max_dst_tiles;
-                    uint32_t batch_size = (start_tile + max_dst_tiles <= ComputeCT::num_tiles)
-                                              ? max_dst_tiles
-                                              : (ComputeCT::num_tiles - start_tile);
-
-                    tile_regs_acquire();
-                    for (uint32_t i = 0; i < batch_size; ++i) {
-                        add_tiles(ComputeCT::cb_in1, ComputeCT::cb_residual, start_tile + i, start_tile + i, i);
-                    }
-                    tile_regs_commit();
-
-                    tile_regs_wait();
-                    for (uint32_t i = 0; i < batch_size; ++i) {
-                        pack_tile(i, ComputeCT::cb_temp, start_tile + i);
-                    }
-                    tile_regs_release();
+            if constexpr (CTArgs::has_residual) {
+                copy_tile_to_dst_init_short(CTArgs::cb_residual);
+                cb_wait_front(CTArgs::cb_residual, CTArgs::num_tiles);
+                tile_regs_acquire();
+                for (uint32_t i = 0; i < CTArgs::num_tiles; i++) {
+                    copy_tile(CTArgs::cb_residual, i, i);
                 }
-                cb_pop_front(ComputeCT::cb_in1, ComputeCT::num_tiles);
-                cb_pop_front(ComputeCT::cb_residual, ComputeCT::num_tiles);
-                cb_push_back(ComputeCT::cb_temp, ComputeCT::num_tiles);
-
-                // Second add: (local+residual) + remote → output
-                cb_wait_front(ComputeCT::cb_in0, ComputeCT::num_tiles);
-                cb_wait_front(ComputeCT::cb_temp, ComputeCT::num_tiles);
-                cb_reserve_back(ComputeCT::cb_out0, ComputeCT::num_tiles);
-
-                for (uint32_t batch = 0; batch < num_batches; ++batch) {
-                    uint32_t start_tile = batch * max_dst_tiles;
-                    uint32_t batch_size = (start_tile + max_dst_tiles <= ComputeCT::num_tiles)
-                                              ? max_dst_tiles
-                                              : (ComputeCT::num_tiles - start_tile);
-
-                    tile_regs_acquire();
-                    for (uint32_t i = 0; i < batch_size; ++i) {
-                        add_tiles(ComputeCT::cb_temp, ComputeCT::cb_in0, start_tile + i, start_tile + i, i);
-                    }
-                    tile_regs_commit();
-
-                    tile_regs_wait();
-                    for (uint32_t i = 0; i < batch_size; ++i) {
-                        pack_tile(i, ComputeCT::cb_out0, start_tile + i);
-                    }
-                    tile_regs_release();
-                }
-                cb_pop_front(ComputeCT::cb_in0, ComputeCT::num_tiles);
-                cb_pop_front(ComputeCT::cb_temp, ComputeCT::num_tiles);
-                cb_push_back(ComputeCT::cb_out0, ComputeCT::num_tiles);
-            } else {
-                // Simple all-reduce: local + remote → output
-                cb_wait_front(ComputeCT::cb_in0, ComputeCT::num_tiles);
-                cb_wait_front(ComputeCT::cb_in1, ComputeCT::num_tiles);
-                cb_reserve_back(ComputeCT::cb_out0, ComputeCT::num_tiles);
-
-                for (uint32_t batch = 0; batch < num_batches; ++batch) {
-                    uint32_t start_tile = batch * max_dst_tiles;
-                    uint32_t batch_size = (start_tile + max_dst_tiles <= ComputeCT::num_tiles)
-                                              ? max_dst_tiles
-                                              : (ComputeCT::num_tiles - start_tile);
-
-                    tile_regs_acquire();
-                    for (uint32_t i = 0; i < batch_size; ++i) {
-                        add_tiles(ComputeCT::cb_in0, ComputeCT::cb_in1, start_tile + i, start_tile + i, i);
-                    }
-                    tile_regs_commit();
-
-                    tile_regs_wait();
-                    for (uint32_t i = 0; i < batch_size; ++i) {
-                        pack_tile(i, ComputeCT::cb_out0, start_tile + i);
-                    }
-                    tile_regs_release();
-                }
-                cb_pop_front(ComputeCT::cb_in0, ComputeCT::num_tiles);
-                cb_pop_front(ComputeCT::cb_in1, ComputeCT::num_tiles);
-                cb_push_back(ComputeCT::cb_out0, ComputeCT::num_tiles);
+                cb_pop_front(CTArgs::cb_residual, CTArgs::num_tiles);
             }
+            constexpr bool acquire_regs = CTArgs::has_residual ? false : true;
+            add_tiles_init(CTArgs::cb_in0, CTArgs::cb_in1, CTArgs::has_residual);
+            batched_add<acquire_regs>(CTArgs::cb_in0, CTArgs::cb_in1, CTArgs::cb_out0, CTArgs::num_tiles);
 #endif
         }
     };

--- a/models/demos/deepseek_v3_b1/unified_kernels/all_reduce_sender.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/all_reduce_sender.hpp
@@ -52,9 +52,7 @@ struct AllReduceSender {
 
     // Writer CTArgs (BRISC)
     template <
-        uint32_t packetHeaderCbId,
         uint32_t packetCbId,
-        uint32_t alignment,
         uint32_t inputNumTiles,
         uint32_t pageSizeBytes,
         uint32_t payloadSizeBytes,
@@ -65,9 +63,7 @@ struct AllReduceSender {
         uint32_t dstNumHops,
         uint32_t numConnections>
     struct WriterCTArgs {
-        static constexpr uint32_t packet_header_cb_id = packetHeaderCbId;
         static constexpr uint32_t packet_cb_id = packetCbId;
-        static constexpr uint32_t l1_alignment = alignment;
         static constexpr uint32_t input_num_tiles = inputNumTiles;
         static constexpr uint32_t page_size_bytes = pageSizeBytes;
         static constexpr uint32_t payload_size_bytes = payloadSizeBytes;
@@ -107,7 +103,7 @@ struct AllReduceSender {
     // ReaderCT: compile-time args for NCRISC reader
     // WriterCT: compile-time args for BRISC writer
     // ========================================================================
-    template <typename ReaderCT, typename WriterCT>
+    template <typename CTArgs>
     class Op {
     public:
         void operator()(const RTArgs& args) { impl(args); }
@@ -118,53 +114,49 @@ struct AllReduceSender {
             // ================================================================
             // NCRISC (Reader) - reads local tensor data into CB
             // ================================================================
-            cb_reserve_back(ReaderCT::cb0_id, ReaderCT::num_tiles);
-            const uint32_t l1_write_addr = get_write_ptr(ReaderCT::cb0_id);
-            uint64_t base_src_addr = get_noc_addr(ReaderCT::core_noc_x, ReaderCT::core_noc_y, args.tensor_address);
-            noc_async_read(base_src_addr, l1_write_addr, ReaderCT::num_tiles * ReaderCT::tensor_page_size);
+            cb_reserve_back(CTArgs::cb0_id, CTArgs::num_tiles);
+            const uint32_t l1_write_addr = get_write_ptr(CTArgs::cb0_id);
+            uint64_t base_src_addr = get_noc_addr(CTArgs::core_noc_x, CTArgs::core_noc_y, args.tensor_address);
+            noc_async_read(base_src_addr, l1_write_addr, CTArgs::num_tiles * CTArgs::tensor_page_size);
             noc_async_read_barrier();
-            cb_push_back(ReaderCT::cb0_id, ReaderCT::num_tiles);
+            cb_push_back(CTArgs::cb0_id, CTArgs::num_tiles);
 
 #elif defined(COMPILE_FOR_BRISC)
             // ================================================================
             // BRISC (Writer) - sends data to remote device via fabric
             // ================================================================
-            constexpr size_t packet_header_size_bytes = sizeof(PACKET_HEADER_TYPE);
-
             tt::tt_fabric::RoutingPlaneConnectionManager fabric_connection;
 
             size_t fabric_args_start_index = size_t(args.fabric_args_start_index);
-            open_connections(fabric_connection, WriterCT::num_connections, fabric_args_start_index);
+            open_connections(fabric_connection, CTArgs::num_connections, fabric_args_start_index);
 
-            cb_reserve_back(WriterCT::packet_header_cb_id, 1);
-            uint32_t packet_header_addr = get_read_ptr(WriterCT::packet_header_cb_id);
-            cb_push_back(WriterCT::packet_header_cb_id, 1);
+            PacketHeaderPool::reset();
+            auto* packet_header_ptr = PacketHeaderPool::allocate_header(1);
 
-            auto* packet_header_ptr = reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_addr);
             fabric_set_unicast_route(fabric_connection, packet_header_ptr, 0);
-            packet_header_ptr->to_chip_unicast(WriterCT::dst_num_hops);
+            packet_header_ptr->to_chip_unicast(CTArgs::dst_num_hops);
 
-            cb_wait_front(WriterCT::packet_cb_id, WriterCT::input_num_tiles);
-            uint32_t packet_base_addr = get_read_ptr(WriterCT::packet_cb_id);
+            cb_wait_front(CTArgs::packet_cb_id, CTArgs::input_num_tiles);
+            uint32_t packet_base_addr = get_read_ptr(CTArgs::packet_cb_id);
 
             const uint64_t dst_noc_addr =
-                get_noc_addr(WriterCT::data_noc_x, WriterCT::data_noc_y, args.receiver_base_address);
-            const uint64_t receive_sem_noc_addr = get_noc_addr(
-                WriterCT::remote_receiver_noc_x, WriterCT::remote_receiver_noc_y, args.receive_semaphore_addr);
+                get_noc_addr(CTArgs::data_noc_x, CTArgs::data_noc_y, args.receiver_base_address);
+            const uint64_t receive_sem_noc_addr =
+                get_noc_addr(CTArgs::remote_receiver_noc_x, CTArgs::remote_receiver_noc_y, args.receive_semaphore_addr);
 
             // Use fused packet API to send data + semaphore increment in a single packet
             packet_header_ptr->to_noc_fused_unicast_write_atomic_inc(
                 tt::tt_fabric::NocUnicastAtomicIncFusedCommandHeader{dst_noc_addr, receive_sem_noc_addr, 1, true},
-                align(WriterCT::payload_size_bytes, WriterCT::l1_alignment));
+                align(CTArgs::payload_size_bytes, L1_ALIGNMENT));
 
             auto& connection = fabric_connection.get(0).sender;
             connection.wait_for_empty_write_slot();
             connection.send_payload_without_header_non_blocking_from_address(
-                packet_base_addr, WriterCT::payload_size_bytes);
+                packet_base_addr, CTArgs::payload_size_bytes);
             connection.send_payload_flush_blocking_from_address(
                 (uint32_t)packet_header_ptr, sizeof(PACKET_HEADER_TYPE));
 
-            cb_pop_front(WriterCT::packet_cb_id, WriterCT::input_num_tiles);
+            cb_pop_front(CTArgs::packet_cb_id, CTArgs::input_num_tiles);
 
             close_connections(fabric_connection);
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
TP all reduce produces different output per device due to reduction order.

### What's changed
Update all reduce to produce the same output per device.
This current change reduces perf a bit due to no longer overlapping pack with math after 4 tiles. This can be fixed/updated to restore the perf loss.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aho/all-reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aho/all-reduce)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aho/all-reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/all-reduce)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aho/all-reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/all-reduce)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aho/all-reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/all-reduce)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aho/all-reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/all-reduce)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aho/all-reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/all-reduce)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
