### PR TITLE
Torch reference implementations and decoder model tests for Blaze project

### DIFF
--- a/models/demos/deepseek_v3_b1/tests/block_tests/gqa.py
+++ b/models/demos/deepseek_v3_b1/tests/block_tests/gqa.py
@@ -4,7 +4,6 @@
 
 """GQA (Grouped Query Attention) — reference implementation."""
 
-import math
 import torch
 import torch.nn.functional as F
 
@@ -37,7 +36,7 @@ def gqa_attention_torch(
     wo: [hidden, num_q_heads * head_dim]
     position_embeddings: None or (cos, sin) each [b, seq, rope_dim]
     rope_variant: "standard" (Llama/Qwen) or "glm4" (interleaved, partial)
-    attention_mask: None, bool [b,1,q,kv] (True=keep), or additive [b,1,q,kv]
+    attention_mask: None or additive [b,1,q,kv]
     past_key_value: None or (past_k, past_v) each [b, kv_heads, past_seq, hd]
 
     Returns (attn_out [b, seq, hidden], present_kv or None)
@@ -67,16 +66,12 @@ def gqa_attention_torch(
     k_exp = repeat_kv(k, n_rep)
     v_exp = repeat_kv(v, n_rep)
 
-    scale = 1.0 / math.sqrt(head_dim)
-    attn_weights = torch.matmul(q, k_exp.transpose(-2, -1)) * scale
+    scores = torch.matmul(q, k_exp.transpose(-2, -1)) * (head_dim ** -0.5)
 
     if attention_mask is not None:
-        if attention_mask.dtype == torch.bool:
-            attn_weights = attn_weights.masked_fill(~attention_mask, float("-inf"))
-        else:
-            attn_weights = attn_weights + attention_mask
+        scores = scores + attention_mask
 
-    attn_weights = F.softmax(attn_weights, dim=-1)
+    attn_weights = F.softmax(scores, dim=-1, dtype=torch.float32).type_as(hidden_states)
     attn_out = torch.matmul(attn_weights, v_exp)
     attn_out = attn_out.transpose(1, 2).contiguous().view(b, q_seq, num_q_heads * head_dim)
     attn_out = F.linear(attn_out, wo)

--- a/models/demos/deepseek_v3_b1/tests/block_tests/gqa.py
+++ b/models/demos/deepseek_v3_b1/tests/block_tests/gqa.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
 """GQA (Grouped Query Attention) — reference implementation."""
 
 import math

--- a/models/demos/deepseek_v3_b1/tests/block_tests/gqa.py
+++ b/models/demos/deepseek_v3_b1/tests/block_tests/gqa.py
@@ -1,0 +1,71 @@
+"""GQA (Grouped Query Attention) — reference implementation."""
+
+import math
+import torch
+import torch.nn.functional as F
+
+from helpers import repeat_kv
+
+
+# ---------------------------------------------------------------------------
+# GQA — reference implementation
+# ---------------------------------------------------------------------------
+
+def gqa_attention_torch(
+    hidden_states,
+    *,
+    wq, wk, wv, wo,
+    num_q_heads,
+    num_kv_heads,
+    attention_mask=None,
+    past_key_value=None,
+    use_cache=False,
+):
+    """
+    Grouped Query Attention.
+
+    hidden_states: [b, seq, hidden]
+    wq: [num_q_heads * head_dim, hidden]
+    wk: [num_kv_heads * head_dim, hidden]
+    wv: [num_kv_heads * head_dim, hidden]
+    wo: [hidden, num_q_heads * head_dim]
+    attention_mask: None, bool [b,1,q,kv] (True=keep), or additive [b,1,q,kv]
+    past_key_value: None or (past_k, past_v) each [b, kv_heads, past_seq, hd]
+
+    Returns (attn_out [b, seq, hidden], present_kv or None)
+    """
+    b, q_seq, h = hidden_states.shape
+    head_dim = wq.shape[0] // num_q_heads
+
+    q = F.linear(hidden_states, wq).view(b, q_seq, num_q_heads, head_dim).transpose(1, 2)
+    k = F.linear(hidden_states, wk).view(b, q_seq, num_kv_heads, head_dim).transpose(1, 2)
+    v = F.linear(hidden_states, wv).view(b, q_seq, num_kv_heads, head_dim).transpose(1, 2)
+
+    if past_key_value is not None:
+        past_k, past_v = past_key_value
+        k = torch.cat([past_k, k], dim=2)
+        v = torch.cat([past_v, v], dim=2)
+
+    present_kv = (k, v) if use_cache else None
+
+    n_rep = num_q_heads // num_kv_heads
+    k_exp = repeat_kv(k, n_rep)
+    v_exp = repeat_kv(v, n_rep)
+
+    scale = 1.0 / math.sqrt(head_dim)
+    attn_weights = torch.matmul(q, k_exp.transpose(-2, -1)) * scale
+
+    if attention_mask is not None:
+        if attention_mask.dtype == torch.bool:
+            attn_weights = attn_weights.masked_fill(~attention_mask, float("-inf"))
+        else:
+            attn_weights = attn_weights + attention_mask
+
+    attn_weights = F.softmax(attn_weights, dim=-1)
+    attn_out = torch.matmul(attn_weights, v_exp)
+    attn_out = attn_out.transpose(1, 2).contiguous().view(b, q_seq, num_q_heads * head_dim)
+    attn_out = F.linear(attn_out, wo)
+    return attn_out, present_kv
+
+
+gqa_attention_tt = gqa_attention_torch

--- a/models/demos/deepseek_v3_b1/tests/block_tests/gqa.py
+++ b/models/demos/deepseek_v3_b1/tests/block_tests/gqa.py
@@ -4,7 +4,7 @@ import math
 import torch
 import torch.nn.functional as F
 
-from helpers import repeat_kv
+from helpers import repeat_kv, apply_rotary_pos_emb, apply_rotary_pos_emb_glm4
 
 
 # ---------------------------------------------------------------------------
@@ -17,6 +17,8 @@ def gqa_attention_torch(
     wq, wk, wv, wo,
     num_q_heads,
     num_kv_heads,
+    position_embeddings=None,
+    rope_variant="standard",
     attention_mask=None,
     past_key_value=None,
     use_cache=False,
@@ -29,6 +31,8 @@ def gqa_attention_torch(
     wk: [num_kv_heads * head_dim, hidden]
     wv: [num_kv_heads * head_dim, hidden]
     wo: [hidden, num_q_heads * head_dim]
+    position_embeddings: None or (cos, sin) each [b, seq, rope_dim]
+    rope_variant: "standard" (Llama/Qwen) or "glm4" (interleaved, partial)
     attention_mask: None, bool [b,1,q,kv] (True=keep), or additive [b,1,q,kv]
     past_key_value: None or (past_k, past_v) each [b, kv_heads, past_seq, hd]
 
@@ -40,6 +44,13 @@ def gqa_attention_torch(
     q = F.linear(hidden_states, wq).view(b, q_seq, num_q_heads, head_dim).transpose(1, 2)
     k = F.linear(hidden_states, wk).view(b, q_seq, num_kv_heads, head_dim).transpose(1, 2)
     v = F.linear(hidden_states, wv).view(b, q_seq, num_kv_heads, head_dim).transpose(1, 2)
+
+    if position_embeddings is not None:
+        cos, sin = position_embeddings
+        if rope_variant == "glm4":
+            q, k = apply_rotary_pos_emb_glm4(q, k, cos, sin)
+        else:
+            q, k = apply_rotary_pos_emb(q, k, cos, sin)
 
     if past_key_value is not None:
         past_k, past_v = past_key_value

--- a/models/demos/deepseek_v3_b1/tests/block_tests/helpers.py
+++ b/models/demos/deepseek_v3_b1/tests/block_tests/helpers.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
 """Shared helpers for attention/MoE reference implementations and tests."""
 
 import random

--- a/models/demos/deepseek_v3_b1/tests/block_tests/helpers.py
+++ b/models/demos/deepseek_v3_b1/tests/block_tests/helpers.py
@@ -19,6 +19,75 @@ def assert_close(a, b, **kw):
     torch.testing.assert_close(a, b, **kw)
 
 
+def _rotate_half(x):
+    """Rotate half the hidden dims: [x1, x2] → [-x2, x1]."""
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def _rotate_half_interleaved(x):
+    """Interleaved rotation: pairs (even, odd) → (-odd, even)."""
+    x1 = x[..., 0::2]
+    x2 = x[..., 1::2]
+    return torch.stack((-x2, x1), dim=-1).flatten(-2)
+
+
+def apply_rotary_pos_emb(q, k, cos, sin):
+    """
+    Standard RoPE (Llama/Qwen/Mixtral pattern).
+
+    q, k: [b, heads, seq, head_dim]
+    cos, sin: [b, seq, head_dim]  (from RotaryEmbedding)
+
+    Applies rotation to ALL head_dim dimensions.
+    """
+    cos = cos.unsqueeze(1)  # [b, 1, seq, head_dim]
+    sin = sin.unsqueeze(1)
+    q_embed = (q * cos) + (_rotate_half(q) * sin)
+    k_embed = (k * cos) + (_rotate_half(k) * sin)
+    return q_embed, k_embed
+
+
+def apply_rotary_pos_emb_interleaved(q, k, cos, sin):
+    """
+    Interleaved RoPE (DeepSeek V3 pattern with rope_interleave=True).
+
+    Rearranges q/k dims from interleaved to paired layout before applying
+    standard rotate_half, matching HF's apply_rotary_pos_emb_interleave.
+    """
+    cos = cos.unsqueeze(1)
+    sin = sin.unsqueeze(1)
+    # Rearrange: [a, b, c, d] → [a, c, b, d] (deinterleave pairs)
+    b, h, s, d = q.shape
+    q = q.view(b, h, s, d // 2, 2).transpose(4, 3).reshape(b, h, s, d)
+    b, h, s, d = k.shape
+    k = k.view(b, h, s, d // 2, 2).transpose(4, 3).reshape(b, h, s, d)
+    q_embed = (q * cos) + (_rotate_half(q) * sin)
+    k_embed = (k * cos) + (_rotate_half(k) * sin)
+    return q_embed, k_embed
+
+
+def apply_rotary_pos_emb_glm4(q, k, cos, sin):
+    """
+    GLM-4 RoPE: interleaved rotation with partial rotary support.
+
+    cos/sin may be smaller than head_dim (partial_rotary_factor).
+    Unrotated dims are passed through unchanged.
+    """
+    cos = cos.unsqueeze(1)
+    sin = sin.unsqueeze(1)
+    # GLM4 uses interleaved cos/sin — take first half and repeat_interleave
+    cos = cos[..., : cos.shape[-1] // 2].repeat_interleave(2, dim=-1)
+    sin = sin[..., : sin.shape[-1] // 2].repeat_interleave(2, dim=-1)
+    rotary_dim = cos.shape[-1]
+    q_rot, q_pass = q[..., :rotary_dim], q[..., rotary_dim:]
+    k_rot, k_pass = k[..., :rotary_dim], k[..., rotary_dim:]
+    q_embed = (q_rot * cos) + (_rotate_half_interleaved(q_rot) * sin)
+    k_embed = (k_rot * cos) + (_rotate_half_interleaved(k_rot) * sin)
+    return torch.cat([q_embed, q_pass], dim=-1), torch.cat([k_embed, k_pass], dim=-1)
+
+
 def repeat_kv(x, n_rep):
     """Repeat KV heads to match Q heads. x: [b, kv_heads, seq, hd]"""
     if n_rep == 1:

--- a/models/demos/deepseek_v3_b1/tests/block_tests/helpers.py
+++ b/models/demos/deepseek_v3_b1/tests/block_tests/helpers.py
@@ -1,0 +1,73 @@
+"""Shared helpers for attention/MoE reference implementations and tests."""
+
+import random
+import torch
+
+
+def seed_all(seed: int = 42):
+    random.seed(seed)
+    torch.manual_seed(seed)
+
+
+def assert_close(a, b, **kw):
+    diff = (a - b).abs()
+    flat_a = a.flatten()[:5]
+    flat_b = b.flatten()[:5]
+    print(f"  max_diff={diff.max().item():.2e}  mean_diff={diff.mean().item():.2e}")
+    print(f"  expected[:5]={flat_b.tolist()}")
+    print(f"  got[:5]     ={flat_a.tolist()}")
+    torch.testing.assert_close(a, b, **kw)
+
+
+def repeat_kv(x, n_rep):
+    """Repeat KV heads to match Q heads. x: [b, kv_heads, seq, hd]"""
+    if n_rep == 1:
+        return x
+    b, kv_heads, seq, hd = x.shape
+    x = x[:, :, None, :, :].expand(b, kv_heads, n_rep, seq, hd)
+    return x.reshape(b, kv_heads * n_rep, seq, hd)
+
+
+def rms_norm(x, weight, eps=1e-6):
+    """RMSNorm matching HuggingFace implementation."""
+    input_dtype = x.dtype
+    x = x.to(torch.float32)
+    variance = x.pow(2).mean(-1, keepdim=True)
+    x = x * torch.rsqrt(variance + eps)
+    return (weight * x).to(input_dtype)
+
+
+def make_profiles(size="tiny"):
+    """Return toy profiles that preserve structural constraints per family."""
+    if size == "tiny":
+        return {
+            "deepseek_v3": dict(
+                hidden_size=64, num_q_heads=8, num_kv_heads=2, head_dim=8,
+                top_k=2, num_experts=4, moe_intermediate=128,
+                kv_latent_dim=32, max_context=256_000,
+                use_mla=True, use_moe=True,
+                ffn_intermediate=128,
+            ),
+            "kimi_k25": dict(
+                hidden_size=64, num_q_heads=8, num_kv_heads=2, head_dim=8,
+                top_k=2, num_experts=4, moe_intermediate=128,
+                kv_latent_dim=32, max_context=256_000,
+                use_mla=True, use_moe=True,
+                ffn_intermediate=128,
+            ),
+            "glm4_355b": dict(
+                hidden_size=64, num_q_heads=8, num_kv_heads=4, head_dim=8,
+                top_k=1, num_experts=1, moe_intermediate=128,
+                kv_latent_dim=None, max_context=200_000,
+                use_mla=False, use_moe=False,
+                ffn_intermediate=128,
+            ),
+            "gpt_oss_120b": dict(
+                hidden_size=64, num_q_heads=8, num_kv_heads=2, head_dim=8,
+                top_k=2, num_experts=4, moe_intermediate=128,
+                kv_latent_dim=None, max_context=128_000,
+                use_mla=False, use_moe=True,
+                ffn_intermediate=128,
+            ),
+        }
+    raise ValueError(f"Unknown size: {size}")

--- a/models/demos/deepseek_v3_b1/tests/block_tests/helpers.py
+++ b/models/demos/deepseek_v3_b1/tests/block_tests/helpers.py
@@ -117,14 +117,14 @@ def make_profiles(size="tiny"):
             "deepseek_v3": dict(
                 hidden_size=64, num_q_heads=8, num_kv_heads=2, head_dim=8,
                 top_k=2, num_experts=4, moe_intermediate=128,
-                kv_latent_dim=32, max_context=256_000,
+                kv_latent_dim=32, qk_rope_head_dim=4, max_context=256_000,
                 use_mla=True, use_moe=True,
                 ffn_intermediate=128,
             ),
             "kimi_k25": dict(
                 hidden_size=64, num_q_heads=8, num_kv_heads=2, head_dim=8,
                 top_k=2, num_experts=4, moe_intermediate=128,
-                kv_latent_dim=32, max_context=256_000,
+                kv_latent_dim=32, qk_rope_head_dim=4, max_context=256_000,
                 use_mla=True, use_moe=True,
                 ffn_intermediate=128,
             ),

--- a/models/demos/deepseek_v3_b1/tests/block_tests/mla.py
+++ b/models/demos/deepseek_v3_b1/tests/block_tests/mla.py
@@ -1,0 +1,73 @@
+"""MLA (Multi-Head Latent Attention) — reference implementation."""
+
+import math
+import torch
+import torch.nn.functional as F
+
+from helpers import repeat_kv
+
+
+# ---------------------------------------------------------------------------
+# MLA — reference implementation
+# ---------------------------------------------------------------------------
+
+def mla_attention_torch(
+    hidden_states,
+    *,
+    wq, w_kv_down, w_k_up, w_v_up, wo,
+    num_q_heads,
+    num_kv_heads,
+    kv_latent_dim,
+    attention_mask=None,
+    past_key_value=None,
+    use_cache=False,
+):
+    """
+    MLA with explicit latent KV path.
+
+    hidden_states: [b, seq, hidden]
+    wq: [num_q_heads * head_dim, hidden]
+    w_kv_down: [kv_latent_dim, hidden]
+    w_k_up: [num_kv_heads * head_dim, kv_latent_dim]
+    w_v_up: [num_kv_heads * head_dim, kv_latent_dim]
+    wo: [hidden, num_q_heads * head_dim]
+    """
+    b, q_seq, h = hidden_states.shape
+    head_dim = wq.shape[0] // num_q_heads
+
+    # Q projection
+    q = F.linear(hidden_states, wq).view(b, q_seq, num_q_heads, head_dim).transpose(1, 2)
+
+    # Latent KV path
+    z = F.linear(hidden_states, w_kv_down)  # [b, seq, kv_latent_dim]
+    k = F.linear(z, w_k_up).view(b, q_seq, num_kv_heads, head_dim).transpose(1, 2)
+    v = F.linear(z, w_v_up).view(b, q_seq, num_kv_heads, head_dim).transpose(1, 2)
+
+    if past_key_value is not None:
+        past_k, past_v = past_key_value
+        k = torch.cat([past_k, k], dim=2)
+        v = torch.cat([past_v, v], dim=2)
+
+    present_kv = (k, v) if use_cache else None
+
+    n_rep = num_q_heads // num_kv_heads
+    k_exp = repeat_kv(k, n_rep)
+    v_exp = repeat_kv(v, n_rep)
+
+    scale = 1.0 / math.sqrt(head_dim)
+    attn_weights = torch.matmul(q, k_exp.transpose(-2, -1)) * scale
+
+    if attention_mask is not None:
+        if attention_mask.dtype == torch.bool:
+            attn_weights = attn_weights.masked_fill(~attention_mask, float("-inf"))
+        else:
+            attn_weights = attn_weights + attention_mask
+
+    attn_weights = F.softmax(attn_weights, dim=-1)
+    attn_out = torch.matmul(attn_weights, v_exp)
+    attn_out = attn_out.transpose(1, 2).contiguous().view(b, q_seq, num_q_heads * head_dim)
+    attn_out = F.linear(attn_out, wo)
+    return attn_out, present_kv
+
+
+mla_attention_tt = mla_attention_torch

--- a/models/demos/deepseek_v3_b1/tests/block_tests/mla.py
+++ b/models/demos/deepseek_v3_b1/tests/block_tests/mla.py
@@ -4,7 +4,7 @@ import math
 import torch
 import torch.nn.functional as F
 
-from helpers import repeat_kv
+from helpers import repeat_kv, apply_rotary_pos_emb, apply_rotary_pos_emb_interleaved
 
 
 # ---------------------------------------------------------------------------
@@ -18,30 +18,64 @@ def mla_attention_torch(
     num_q_heads,
     num_kv_heads,
     kv_latent_dim,
+    position_embeddings=None,
+    qk_rope_head_dim=0,
+    rope_interleave=False,
     attention_mask=None,
     past_key_value=None,
     use_cache=False,
 ):
     """
-    MLA with explicit latent KV path.
+    MLA with explicit latent KV path and optional RoPE.
 
     hidden_states: [b, seq, hidden]
-    wq: [num_q_heads * head_dim, hidden]
-    w_kv_down: [kv_latent_dim, hidden]
-    w_k_up: [num_kv_heads * head_dim, kv_latent_dim]
-    w_v_up: [num_kv_heads * head_dim, kv_latent_dim]
-    wo: [hidden, num_q_heads * head_dim]
+    wq: [num_q_heads * (nope_dim + rope_dim), hidden]
+    w_kv_down: [kv_latent_dim + rope_dim, hidden]  (latent + rope dims)
+    w_k_up: [num_kv_heads * nope_dim, kv_latent_dim]
+    w_v_up: [num_kv_heads * v_head_dim, kv_latent_dim]
+    wo: [hidden, num_q_heads * (nope_dim + rope_dim)]  (or nope_dim + v_head_dim output)
+    position_embeddings: None or (cos, sin) each [b, seq, rope_dim]
+    qk_rope_head_dim: number of RoPE dims per head (0 = no RoPE)
+    rope_interleave: use interleaved RoPE (DeepSeek V3 default)
     """
     b, q_seq, h = hidden_states.shape
-    head_dim = wq.shape[0] // num_q_heads
 
-    # Q projection
-    q = F.linear(hidden_states, wq).view(b, q_seq, num_q_heads, head_dim).transpose(1, 2)
+    if qk_rope_head_dim > 0 and position_embeddings is not None:
+        # MLA with RoPE: Q has nope+rope parts, KV compressed has latent+rope parts
+        nope_dim = wq.shape[0] // num_q_heads - qk_rope_head_dim
+        qk_head_dim = nope_dim + qk_rope_head_dim
 
-    # Latent KV path
-    z = F.linear(hidden_states, w_kv_down)  # [b, seq, kv_latent_dim]
-    k = F.linear(z, w_k_up).view(b, q_seq, num_kv_heads, head_dim).transpose(1, 2)
-    v = F.linear(z, w_v_up).view(b, q_seq, num_kv_heads, head_dim).transpose(1, 2)
+        # Q: project and split into nope + rope
+        q = F.linear(hidden_states, wq).view(b, q_seq, num_q_heads, qk_head_dim).transpose(1, 2)
+        q_nope, q_rope = q.split([nope_dim, qk_rope_head_dim], dim=-1)
+
+        # KV: compressed_kv contains [latent, rope_k]
+        compressed_kv = F.linear(hidden_states, w_kv_down)  # [b, seq, kv_latent_dim + rope_dim]
+        kv_latent, k_rope = compressed_kv.split([kv_latent_dim, qk_rope_head_dim], dim=-1)
+
+        # Up-project latent → K_nope and V
+        v_head_dim = w_v_up.shape[0] // num_kv_heads
+        k_nope = F.linear(kv_latent, w_k_up).view(b, q_seq, num_kv_heads, nope_dim).transpose(1, 2)
+        v = F.linear(kv_latent, w_v_up).view(b, q_seq, num_kv_heads, v_head_dim).transpose(1, 2)
+
+        # Apply RoPE to rope parts
+        k_rope = k_rope.view(b, 1, q_seq, qk_rope_head_dim)
+        cos, sin = position_embeddings
+        rope_fn = apply_rotary_pos_emb_interleaved if rope_interleave else apply_rotary_pos_emb
+        q_rope, k_rope = rope_fn(q_rope, k_rope, cos, sin)
+        k_rope = k_rope.expand(b, num_kv_heads, q_seq, qk_rope_head_dim)
+
+        # Concat nope + rope
+        q = torch.cat([q_nope, q_rope], dim=-1)
+        k = torch.cat([k_nope, k_rope], dim=-1)
+        head_dim = qk_head_dim
+    else:
+        # Original path: no RoPE
+        head_dim = wq.shape[0] // num_q_heads
+        q = F.linear(hidden_states, wq).view(b, q_seq, num_q_heads, head_dim).transpose(1, 2)
+        z = F.linear(hidden_states, w_kv_down)  # [b, seq, kv_latent_dim]
+        k = F.linear(z, w_k_up).view(b, q_seq, num_kv_heads, head_dim).transpose(1, 2)
+        v = F.linear(z, w_v_up).view(b, q_seq, num_kv_heads, head_dim).transpose(1, 2)
 
     if past_key_value is not None:
         past_k, past_v = past_key_value
@@ -64,8 +98,9 @@ def mla_attention_torch(
             attn_weights = attn_weights + attention_mask
 
     attn_weights = F.softmax(attn_weights, dim=-1)
-    attn_out = torch.matmul(attn_weights, v_exp)
-    attn_out = attn_out.transpose(1, 2).contiguous().view(b, q_seq, num_q_heads * head_dim)
+    attn_out = torch.matmul(attn_weights, v_exp)  # [b, heads, seq, v_dim]
+    v_dim = v_exp.shape[-1]
+    attn_out = attn_out.transpose(1, 2).contiguous().view(b, q_seq, num_q_heads * v_dim)
     attn_out = F.linear(attn_out, wo)
     return attn_out, present_kv
 

--- a/models/demos/deepseek_v3_b1/tests/block_tests/mla.py
+++ b/models/demos/deepseek_v3_b1/tests/block_tests/mla.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
 """MLA (Multi-Head Latent Attention) — reference implementation."""
 
 import math

--- a/models/demos/deepseek_v3_b1/tests/block_tests/mla.py
+++ b/models/demos/deepseek_v3_b1/tests/block_tests/mla.py
@@ -4,11 +4,10 @@
 
 """MLA (Multi-Head Latent Attention) — reference implementation."""
 
-import math
 import torch
 import torch.nn.functional as F
 
-from helpers import repeat_kv, apply_rotary_pos_emb, apply_rotary_pos_emb_interleaved
+from helpers import repeat_kv, rms_norm, apply_rotary_pos_emb_interleaved
 
 
 # ---------------------------------------------------------------------------
@@ -18,68 +17,92 @@ from helpers import repeat_kv, apply_rotary_pos_emb, apply_rotary_pos_emb_interl
 def mla_attention_torch(
     hidden_states,
     *,
-    wq, w_kv_down, w_k_up, w_v_up, wo,
+    wq, w_kv_a, w_kv_b, wo,
     num_q_heads,
     num_kv_heads,
     kv_latent_dim,
-    position_embeddings=None,
-    qk_rope_head_dim=0,
-    rope_interleave=False,
+    kv_a_layernorm_weight,
+    qk_rope_head_dim,
+    position_embeddings,
+    # Q LoRA (optional): q_a_proj → q_a_layernorm → q_b_proj
+    w_q_a=None,
+    q_a_layernorm_weight=None,
+    q_a_layernorm_eps=1e-6,
+    # KV layernorm
+    kv_a_layernorm_eps=1e-6,
+    # Scaling
+    mscale=1.0,
+    # Attention mode
+    # Mask / cache
     attention_mask=None,
     past_key_value=None,
     use_cache=False,
 ):
     """
-    MLA with explicit latent KV path and optional RoPE.
+    MLA with latent KV path, Q LoRA, KV layernorm, and RoPE.
+    Matches the official DeepSeek V3 MLA implementation.
+
+    Q path (two modes):
+      - Direct: wq projects hidden → Q  (when w_q_a is None)
+      - LoRA:   w_q_a → q_a_layernorm → wq (q_b_proj)  (when w_q_a is provided)
+
+    KV path:
+      - w_kv_a → kv_a_layernorm → w_kv_b → [k_nope, v] split
 
     hidden_states: [b, seq, hidden]
-    wq: [num_q_heads * (nope_dim + rope_dim), hidden]
-    w_kv_down: [kv_latent_dim + rope_dim, hidden]  (latent + rope dims)
-    w_k_up: [num_kv_heads * nope_dim, kv_latent_dim]
-    w_v_up: [num_kv_heads * v_head_dim, kv_latent_dim]
-    wo: [hidden, num_q_heads * (nope_dim + rope_dim)]  (or nope_dim + v_head_dim output)
-    position_embeddings: None or (cos, sin) each [b, seq, rope_dim]
-    qk_rope_head_dim: number of RoPE dims per head (0 = no RoPE)
-    rope_interleave: use interleaved RoPE (DeepSeek V3 default)
+    wq: [num_q_heads * qk_head_dim, hidden_or_q_lora_rank]
+    w_q_a: [q_lora_rank, hidden]  (optional Q LoRA down-projection)
+    q_a_layernorm_weight: [q_lora_rank]  (required when w_q_a is provided)
+    w_kv_a: [kv_latent_dim + rope_dim, hidden]
+    kv_a_layernorm_weight: [kv_latent_dim]
+    w_kv_b: [num_kv_heads * (nope_dim + v_head_dim), kv_latent_dim]
+    wo: [hidden, num_q_heads * v_head_dim]
+    qk_rope_head_dim: number of RoPE dims per head
+    position_embeddings: (cos, sin) each [b, seq, rope_dim]
+    mscale: attention scale multiplier for extended context (YaRN)
     """
     b, q_seq, h = hidden_states.shape
 
-    if qk_rope_head_dim > 0 and position_embeddings is not None:
-        # MLA with RoPE: Q has nope+rope parts, KV compressed has latent+rope parts
-        nope_dim = wq.shape[0] // num_q_heads - qk_rope_head_dim
-        qk_head_dim = nope_dim + qk_rope_head_dim
+    # Derive dimensions from weight shapes
+    qk_head_dim = wq.shape[0] // num_q_heads
+    nope_dim = qk_head_dim - qk_rope_head_dim
+    kv_b_per_head = w_kv_b.shape[0] // num_kv_heads
+    v_head_dim = kv_b_per_head - nope_dim
 
-        # Q: project and split into nope + rope
-        q = F.linear(hidden_states, wq).view(b, q_seq, num_q_heads, qk_head_dim).transpose(1, 2)
-        q_nope, q_rope = q.split([nope_dim, qk_rope_head_dim], dim=-1)
+    # Softmax scale with mscale (YaRN extended context)
+    scale = (qk_head_dim ** -0.5) * mscale * mscale
 
-        # KV: compressed_kv contains [latent, rope_k]
-        compressed_kv = F.linear(hidden_states, w_kv_down)  # [b, seq, kv_latent_dim + rope_dim]
-        kv_latent, k_rope = compressed_kv.split([kv_latent_dim, qk_rope_head_dim], dim=-1)
-
-        # Up-project latent → K_nope and V
-        v_head_dim = w_v_up.shape[0] // num_kv_heads
-        k_nope = F.linear(kv_latent, w_k_up).view(b, q_seq, num_kv_heads, nope_dim).transpose(1, 2)
-        v = F.linear(kv_latent, w_v_up).view(b, q_seq, num_kv_heads, v_head_dim).transpose(1, 2)
-
-        # Apply RoPE to rope parts
-        k_rope = k_rope.view(b, 1, q_seq, qk_rope_head_dim)
-        cos, sin = position_embeddings
-        rope_fn = apply_rotary_pos_emb_interleaved if rope_interleave else apply_rotary_pos_emb
-        q_rope, k_rope = rope_fn(q_rope, k_rope, cos, sin)
-        k_rope = k_rope.expand(b, num_kv_heads, q_seq, qk_rope_head_dim)
-
-        # Concat nope + rope
-        q = torch.cat([q_nope, q_rope], dim=-1)
-        k = torch.cat([k_nope, k_rope], dim=-1)
-        head_dim = qk_head_dim
+    # --- Q path ---
+    if w_q_a is not None:
+        q_latent = F.linear(hidden_states, w_q_a)
+        q_latent = rms_norm(q_latent, q_a_layernorm_weight, q_a_layernorm_eps)
+        q = F.linear(q_latent, wq)
     else:
-        # Original path: no RoPE
-        head_dim = wq.shape[0] // num_q_heads
-        q = F.linear(hidden_states, wq).view(b, q_seq, num_q_heads, head_dim).transpose(1, 2)
-        z = F.linear(hidden_states, w_kv_down)  # [b, seq, kv_latent_dim]
-        k = F.linear(z, w_k_up).view(b, q_seq, num_kv_heads, head_dim).transpose(1, 2)
-        v = F.linear(z, w_v_up).view(b, q_seq, num_kv_heads, head_dim).transpose(1, 2)
+        q = F.linear(hidden_states, wq)
+    q = q.view(b, q_seq, num_q_heads, qk_head_dim).transpose(1, 2)
+
+    # --- KV compressed path ---
+    compressed_kv = F.linear(hidden_states, w_kv_a)
+    kv_latent, k_pe = compressed_kv.split([kv_latent_dim, qk_rope_head_dim], dim=-1)
+
+    # KV layernorm (applied to latent part only)
+    kv_latent = rms_norm(kv_latent, kv_a_layernorm_weight, kv_a_layernorm_eps)
+
+    # --- RoPE on rope parts ---
+    q_nope, q_pe = q.split([nope_dim, qk_rope_head_dim], dim=-1)
+    k_pe_4d = k_pe.unsqueeze(1)  # [b, 1, seq, rope_dim]
+    cos, sin = position_embeddings
+    q_pe, k_pe_4d = apply_rotary_pos_emb_interleaved(q_pe, k_pe_4d, cos, sin)
+    k_pe = k_pe_4d.squeeze(1)  # [b, seq, rope_dim]
+
+    # --- Expand KV, standard attention ---
+    kv = F.linear(kv_latent, w_kv_b)
+    kv = kv.view(b, -1, num_kv_heads, kv_b_per_head).transpose(1, 2)
+    k_nope, v = kv.split([nope_dim, v_head_dim], dim=-1)
+
+    k_pe_expanded = k_pe.unsqueeze(1).expand(-1, num_kv_heads, -1, -1)
+    k = torch.cat([k_nope, k_pe_expanded], dim=-1)
+    q = torch.cat([q_nope, q_pe], dim=-1)
 
     if past_key_value is not None:
         past_k, past_v = past_key_value
@@ -92,21 +115,57 @@ def mla_attention_torch(
     k_exp = repeat_kv(k, n_rep)
     v_exp = repeat_kv(v, n_rep)
 
-    scale = 1.0 / math.sqrt(head_dim)
-    attn_weights = torch.matmul(q, k_exp.transpose(-2, -1)) * scale
+    scores = torch.matmul(q, k_exp.transpose(-2, -1)) * scale
 
     if attention_mask is not None:
-        if attention_mask.dtype == torch.bool:
-            attn_weights = attn_weights.masked_fill(~attention_mask, float("-inf"))
-        else:
-            attn_weights = attn_weights + attention_mask
+        scores = scores + attention_mask
 
-    attn_weights = F.softmax(attn_weights, dim=-1)
-    attn_out = torch.matmul(attn_weights, v_exp)  # [b, heads, seq, v_dim]
-    v_dim = v_exp.shape[-1]
-    attn_out = attn_out.transpose(1, 2).contiguous().view(b, q_seq, num_q_heads * v_dim)
+    attn_weights = F.softmax(scores, dim=-1, dtype=torch.float32).type_as(hidden_states)
+    attn_out = torch.matmul(attn_weights, v_exp)
+
+    attn_out = attn_out.transpose(1, 2).contiguous().view(b, q_seq, num_q_heads * v_head_dim)
     attn_out = F.linear(attn_out, wo)
     return attn_out, present_kv
 
 
 mla_attention_tt = mla_attention_torch
+
+
+# ---------------------------------------------------------------------------
+# Absorbed attention (optimization example)
+# ---------------------------------------------------------------------------
+# Instead of expanding KV via w_kv_b, absorbed attention works in latent space:
+# - Absorb w_kv_b[:k_nope] into Q:  q_absorbed = q_nope @ w_k_nope
+# - Cache (kv_latent, k_pe) instead of (K, V) — smaller KV cache
+# - Compute scores:  q_absorbed @ kv_latent^T + q_pe @ k_pe^T
+# - After softmax, apply w_kv_b[v:] to recover output in head space
+#
+# This produces identical results to the naive path above.
+#
+#     n_rep = num_q_heads // num_kv_heads
+#     w_kv_b_3d = w_kv_b.view(num_kv_heads, kv_b_per_head, kv_latent_dim)
+#     w_kv_b_3d = w_kv_b_3d.repeat_interleave(n_rep, dim=0)
+#
+#     # Absorb w_k into Q: q_nope @ w_k → q in latent space
+#     q_absorbed = torch.einsum("bhsd,hdc->bhsc", q_nope, w_kv_b_3d[:, :nope_dim, :])
+#
+#     # Cache compressed latent + PE
+#     if past_key_value is not None:
+#         past_kv, past_pe = past_key_value
+#         kv_latent = torch.cat([past_kv, kv_latent], dim=1)
+#         k_pe = torch.cat([past_pe, k_pe], dim=1)
+#
+#     present_kv = (kv_latent, k_pe) if use_cache else None
+#
+#     # Scores in latent space
+#     scores = (torch.einsum("bhsc,btc->bhst", q_absorbed, kv_latent)
+#               + torch.einsum("bhsr,btr->bhst", q_pe, k_pe)) * scale
+#
+#     if attention_mask is not None:
+#         scores = scores + attention_mask
+#
+#     attn_weights = F.softmax(scores, dim=-1, dtype=torch.float32).type_as(hidden_states)
+#
+#     # Output in latent space, then apply w_v
+#     attn_out = torch.einsum("bhst,btc->bhsc", attn_weights, kv_latent)
+#     attn_out = torch.einsum("bhsc,hdc->bhsd", attn_out, w_kv_b_3d[:, -v_head_dim:, :])

--- a/models/demos/deepseek_v3_b1/tests/block_tests/mlp.py
+++ b/models/demos/deepseek_v3_b1/tests/block_tests/mlp.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
 """MLP (SwiGLU) — reference implementation."""
 
 import torch.nn.functional as F

--- a/models/demos/deepseek_v3_b1/tests/block_tests/mlp.py
+++ b/models/demos/deepseek_v3_b1/tests/block_tests/mlp.py
@@ -1,0 +1,26 @@
+"""MLP (SwiGLU) — reference implementation."""
+
+import torch.nn.functional as F
+
+
+def mlp_torch(
+    hidden_states,
+    *,
+    w_gate,
+    w_up,
+    w_down,
+):
+    """
+    SwiGLU MLP applied to all tokens.
+
+    hidden_states: [b, s, h]
+    w_gate: [intermediate, h]
+    w_up:   [intermediate, h]
+    w_down: [h, intermediate]
+    """
+    gate = F.silu(F.linear(hidden_states, w_gate))
+    up = F.linear(hidden_states, w_up)
+    return F.linear(gate * up, w_down)
+
+
+mlp_tt = mlp_torch

--- a/models/demos/deepseek_v3_b1/tests/block_tests/moe.py
+++ b/models/demos/deepseek_v3_b1/tests/block_tests/moe.py
@@ -7,6 +7,83 @@
 import torch
 import torch.nn.functional as F
 
+from mlp import mlp_torch
+
+
+# ---------------------------------------------------------------------------
+# Gate — top-k routing
+# ---------------------------------------------------------------------------
+
+def gate_torch(
+    hidden_states,
+    *,
+    w_router,
+    top_k,
+    score_func="softmax",
+    n_group=1,
+    topk_group=1,
+    e_score_correction_bias=None,
+    routed_scaling_factor=1.0,
+    norm_topk_prob=True,
+):
+    """
+    Top-k routing gate with configurable scoring function.
+    Matches the official DeepSeek V3 Gate implementation.
+
+    hidden_states: [b, s, h]
+    w_router: [num_experts, h]
+    top_k: int — number of experts per token
+    score_func: "softmax" (Mixtral/OLMoE/Qwen3-MoE) or "sigmoid" (DeepSeek V3/Kimi K2.5)
+    n_group: number of expert groups (applies to both score_func modes)
+    topk_group: number of groups to keep
+    e_score_correction_bias: optional [num_experts] bias added before group selection
+    routed_scaling_factor: scale applied to final weights
+    norm_topk_prob: normalize top-k weights before scaling
+
+    Returns (topk_indices, topk_weights) each [b*s, top_k].
+    """
+    num_experts = w_router.shape[0]
+    x = hidden_states.reshape(-1, hidden_states.shape[-1])
+    router_logits = F.linear(x.float(), w_router.float())
+
+    # 1) Score function
+    if score_func == "softmax":
+        scores = F.softmax(router_logits, dim=-1, dtype=torch.float)
+    else:
+        scores = router_logits.sigmoid()
+    original_scores = scores
+
+    # 2) Optional bias (e.g. e_score_correction_bias in DeepSeek V3)
+    scores_for_choice = scores
+    if e_score_correction_bias is not None:
+        scores_for_choice = scores + e_score_correction_bias.unsqueeze(0)
+
+    # 3) Group-based selection (applies to both softmax and sigmoid)
+    if n_group > 1:
+        scores_for_choice = scores_for_choice.view(-1, n_group, num_experts // n_group)
+        if e_score_correction_bias is None:
+            group_scores = scores_for_choice.amax(dim=-1)
+        else:
+            group_scores = scores_for_choice.topk(2, dim=-1)[0].sum(dim=-1)
+        group_idx = torch.topk(group_scores, k=topk_group, dim=-1, sorted=False)[1]
+        group_mask = scores_for_choice.new_ones(x.size(0), n_group, dtype=torch.bool)
+        group_mask.scatter_(1, group_idx, False)
+        scores_for_choice = scores_for_choice.masked_fill(group_mask.unsqueeze(-1), float("-inf"))
+        scores_for_choice = scores_for_choice.flatten(1)
+
+    topk_indices = torch.topk(scores_for_choice, k=top_k, dim=-1)[1]
+    topk_weights = original_scores.gather(1, topk_indices)
+
+    # 4) Weight normalization and scaling
+    if score_func == "sigmoid" or norm_topk_prob:
+        topk_weights = topk_weights / (topk_weights.sum(dim=-1, keepdim=True) + 1e-20)
+    topk_weights = topk_weights * routed_scaling_factor
+
+    return topk_indices, topk_weights.type_as(x)
+
+
+gate_tt = gate_torch
+
 
 # ---------------------------------------------------------------------------
 # MoE — reference implementation
@@ -18,44 +95,42 @@ def moe_torch(
     w_router,
     w1,
     w2,
+    w3,
     top_k,
-    w3=None,
-    activation="silu",
-    normalize_topk=True,
+    gate_kwargs=None,
     precomputed_routing=None,
+    shared_mlp_kwargs=None,
     scale_input=False,
 ):
     """
-    Top-k routing MoE FFN.
+    Top-k routing MoE FFN. Each expert is a SwiGLU MLP.
 
     hidden_states: [b, s, h]
     w_router: [num_experts, h]
-    w1: [num_experts, moe_intermediate, h]  (gate_proj for SwiGLU)
-    w2: [num_experts, h, moe_intermediate]  (down_proj for SwiGLU)
-    w3: [num_experts, moe_intermediate, h]  (up_proj for SwiGLU, optional)
+    w1: [num_experts, moe_intermediate, h]  (gate_proj)
+    w2: [num_experts, h, moe_intermediate]  (down_proj)
+    w3: [num_experts, moe_intermediate, h]  (up_proj)
     top_k: int
-    precomputed_routing: optional (topk_idx, routing_weights) to bypass internal routing
+    gate_kwargs: optional dict of extra kwargs forwarded to gate_torch
+    precomputed_routing: optional (topk_idx, routing_weights) — bypasses gate_torch entirely
+    shared_mlp_kwargs: optional dict(w_gate, w_up, w_down) for shared experts
     scale_input: if True, scale input before expert (Llama4); else scale output (default)
     """
-    act_fn = F.silu if activation == "silu" else F.relu
     b, s, h = hidden_states.shape
-    num_experts = w_router.shape[0]
 
     x = hidden_states.reshape(b * s, h)
 
     if precomputed_routing is not None:
         topk_idx, routing_weights = precomputed_routing
     else:
-        logits = x @ w_router.T  # [b*s, num_experts]
-        topk_vals, topk_idx = torch.topk(logits, k=top_k, dim=-1)  # [b*s, top_k]
-        if normalize_topk:
-            routing_weights = F.softmax(topk_vals, dim=-1)
-        else:
-            routing_weights = F.softmax(logits, dim=-1).gather(-1, topk_idx)
+        topk_idx, routing_weights = gate_torch(
+            hidden_states, w_router=w_router, top_k=top_k,
+            **(gate_kwargs or {}),
+        )
 
     out = torch.zeros_like(x)
 
-    for e in range(num_experts):
+    for e in range(w_router.shape[0]):
         # Find which (token, slot) pairs selected this expert
         mask = topk_idx == e  # [b*s, top_k]
         token_mask = mask.any(dim=-1)  # [b*s]
@@ -71,112 +146,17 @@ def moe_torch(
         if scale_input:
             x_e = x_e * weights_e
 
-        # Expert MLP: SwiGLU when w3 provided, else standard 2-layer
-        gate_e = act_fn(F.linear(x_e, w1[e]))  # [n_tokens, intermediate]
-        if w3 is not None:
-            up_e = F.linear(x_e, w3[e])
-            o_e = F.linear(gate_e * up_e, w2[e])
-        else:
-            o_e = F.linear(gate_e, w2[e])  # [n_tokens, h]
+        o_e = mlp_torch(x_e, w_gate=w1[e], w_up=w3[e], w_down=w2[e])
 
         if scale_input:
             out[token_ids] += o_e
         else:
             out[token_ids] += o_e * weights_e
 
+    if shared_mlp_kwargs is not None:
+        out = out + mlp_torch(x, **shared_mlp_kwargs)
+
     return out.reshape(b, s, h)
 
 
 moe_tt = moe_torch
-
-
-# ---------------------------------------------------------------------------
-# Shared experts — reference implementation
-# ---------------------------------------------------------------------------
-
-def moe_shared_experts_torch(
-    hidden_states,
-    *,
-    w_gate,
-    w_up,
-    w_down,
-    activation="silu",
-):
-    """
-    Shared-expert SwiGLU MLP applied to all tokens.
-
-    hidden_states: [b, s, h]
-    w_gate: [intermediate, h]
-    w_up:   [intermediate, h]
-    w_down: [h, intermediate]
-    """
-    act_fn = F.silu if activation == "silu" else F.relu
-    gate = act_fn(F.linear(hidden_states, w_gate))
-    up = F.linear(hidden_states, w_up)
-    return F.linear(gate * up, w_down)
-
-
-moe_shared_experts_tt = moe_shared_experts_torch
-
-
-# ---------------------------------------------------------------------------
-# Routing — sigmoid top-k (DeepSeek V3 / Kimi K2.5)
-# ---------------------------------------------------------------------------
-
-def sigmoid_topk_routing(
-    hidden_states,
-    *,
-    w_router,
-    top_k,
-    n_group,
-    topk_group,
-    e_score_correction_bias=None,
-    routed_scaling_factor=1.0,
-    norm_topk_prob=False,
-):
-    """
-    Sigmoid routing with group-based top-k selection (DeepSeek V3 pattern).
-
-    hidden_states: [b, s, h]
-    w_router: [num_experts, h]
-    top_k: int — number of experts per token
-    n_group: int — number of expert groups
-    topk_group: int — number of groups to keep
-    e_score_correction_bias: optional [num_experts] bias added before group selection
-    routed_scaling_factor: float — scale applied to final weights
-    norm_topk_prob: bool — normalize top-k weights before scaling
-
-    Returns (topk_indices, topk_weights) each [b*s, top_k].
-    """
-    num_experts = w_router.shape[0]
-    x = hidden_states.reshape(-1, hidden_states.shape[-1]).float()
-    router_logits = F.linear(x, w_router.float())
-    scores = router_logits.sigmoid()
-
-    # Group-based top-k selection
-    scores_for_choice = scores.clone()
-    if e_score_correction_bias is not None:
-        scores_for_choice = scores_for_choice + e_score_correction_bias.unsqueeze(0)
-
-    group_scores = (
-        scores_for_choice.view(-1, n_group, num_experts // n_group)
-        .topk(2, dim=-1)[0]
-        .sum(dim=-1)
-    )
-    group_idx = torch.topk(group_scores, k=topk_group, dim=-1, sorted=False)[1]
-    group_mask = torch.zeros_like(group_scores)
-    group_mask.scatter_(1, group_idx, 1)
-    score_mask = (
-        group_mask.unsqueeze(-1)
-        .expand(-1, n_group, num_experts // n_group)
-        .reshape(-1, num_experts)
-    )
-    scores_for_choice = scores_for_choice.masked_fill(~score_mask.bool(), 0.0)
-    topk_indices = torch.topk(scores_for_choice, k=top_k, dim=-1, sorted=False)[1]
-
-    topk_weights = scores.gather(1, topk_indices)
-    if norm_topk_prob:
-        topk_weights = topk_weights / (topk_weights.sum(dim=-1, keepdim=True) + 1e-20)
-    topk_weights = topk_weights * routed_scaling_factor
-
-    return topk_indices, topk_weights

--- a/models/demos/deepseek_v3_b1/tests/block_tests/moe.py
+++ b/models/demos/deepseek_v3_b1/tests/block_tests/moe.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
 """MoE (Mixture of Experts) FFN — reference functions."""
 
 import torch

--- a/models/demos/deepseek_v3_b1/tests/block_tests/moe.py
+++ b/models/demos/deepseek_v3_b1/tests/block_tests/moe.py
@@ -1,0 +1,178 @@
+"""MoE (Mixture of Experts) FFN — reference functions."""
+
+import torch
+import torch.nn.functional as F
+
+
+# ---------------------------------------------------------------------------
+# MoE — reference implementation
+# ---------------------------------------------------------------------------
+
+def moe_torch(
+    hidden_states,
+    *,
+    w_router,
+    w1,
+    w2,
+    top_k,
+    w3=None,
+    activation="silu",
+    normalize_topk=True,
+    precomputed_routing=None,
+    scale_input=False,
+):
+    """
+    Top-k routing MoE FFN.
+
+    hidden_states: [b, s, h]
+    w_router: [num_experts, h]
+    w1: [num_experts, moe_intermediate, h]  (gate_proj for SwiGLU)
+    w2: [num_experts, h, moe_intermediate]  (down_proj for SwiGLU)
+    w3: [num_experts, moe_intermediate, h]  (up_proj for SwiGLU, optional)
+    top_k: int
+    precomputed_routing: optional (topk_idx, routing_weights) to bypass internal routing
+    scale_input: if True, scale input before expert (Llama4); else scale output (default)
+    """
+    act_fn = F.silu if activation == "silu" else F.relu
+    b, s, h = hidden_states.shape
+    num_experts = w_router.shape[0]
+
+    x = hidden_states.reshape(b * s, h)
+
+    if precomputed_routing is not None:
+        topk_idx, routing_weights = precomputed_routing
+    else:
+        logits = x @ w_router.T  # [b*s, num_experts]
+        topk_vals, topk_idx = torch.topk(logits, k=top_k, dim=-1)  # [b*s, top_k]
+        if normalize_topk:
+            routing_weights = F.softmax(topk_vals, dim=-1)
+        else:
+            routing_weights = F.softmax(logits, dim=-1).gather(-1, topk_idx)
+
+    out = torch.zeros_like(x)
+
+    for e in range(num_experts):
+        # Find which (token, slot) pairs selected this expert
+        mask = topk_idx == e  # [b*s, top_k]
+        token_mask = mask.any(dim=-1)  # [b*s]
+        if not token_mask.any():
+            continue
+
+        token_ids = token_mask.nonzero(as_tuple=True)[0]
+        x_e = x[token_ids]  # [n_tokens, h]
+
+        # Gather routing weights for this expert across top_k slots
+        weights_e = (mask[token_ids] * routing_weights[token_ids]).sum(dim=-1, keepdim=True)
+
+        if scale_input:
+            x_e = x_e * weights_e
+
+        # Expert MLP: SwiGLU when w3 provided, else standard 2-layer
+        gate_e = act_fn(F.linear(x_e, w1[e]))  # [n_tokens, intermediate]
+        if w3 is not None:
+            up_e = F.linear(x_e, w3[e])
+            o_e = F.linear(gate_e * up_e, w2[e])
+        else:
+            o_e = F.linear(gate_e, w2[e])  # [n_tokens, h]
+
+        if scale_input:
+            out[token_ids] += o_e
+        else:
+            out[token_ids] += o_e * weights_e
+
+    return out.reshape(b, s, h)
+
+
+moe_tt = moe_torch
+
+
+# ---------------------------------------------------------------------------
+# Shared experts — reference implementation
+# ---------------------------------------------------------------------------
+
+def moe_shared_experts_torch(
+    hidden_states,
+    *,
+    w_gate,
+    w_up,
+    w_down,
+    activation="silu",
+):
+    """
+    Shared-expert SwiGLU MLP applied to all tokens.
+
+    hidden_states: [b, s, h]
+    w_gate: [intermediate, h]
+    w_up:   [intermediate, h]
+    w_down: [h, intermediate]
+    """
+    act_fn = F.silu if activation == "silu" else F.relu
+    gate = act_fn(F.linear(hidden_states, w_gate))
+    up = F.linear(hidden_states, w_up)
+    return F.linear(gate * up, w_down)
+
+
+moe_shared_experts_tt = moe_shared_experts_torch
+
+
+# ---------------------------------------------------------------------------
+# Routing — sigmoid top-k (DeepSeek V3 / Kimi K2.5)
+# ---------------------------------------------------------------------------
+
+def sigmoid_topk_routing(
+    hidden_states,
+    *,
+    w_router,
+    top_k,
+    n_group,
+    topk_group,
+    e_score_correction_bias=None,
+    routed_scaling_factor=1.0,
+    norm_topk_prob=False,
+):
+    """
+    Sigmoid routing with group-based top-k selection (DeepSeek V3 pattern).
+
+    hidden_states: [b, s, h]
+    w_router: [num_experts, h]
+    top_k: int — number of experts per token
+    n_group: int — number of expert groups
+    topk_group: int — number of groups to keep
+    e_score_correction_bias: optional [num_experts] bias added before group selection
+    routed_scaling_factor: float — scale applied to final weights
+    norm_topk_prob: bool — normalize top-k weights before scaling
+
+    Returns (topk_indices, topk_weights) each [b*s, top_k].
+    """
+    num_experts = w_router.shape[0]
+    x = hidden_states.reshape(-1, hidden_states.shape[-1]).float()
+    router_logits = F.linear(x, w_router.float())
+    scores = router_logits.sigmoid()
+
+    # Group-based top-k selection
+    scores_for_choice = scores.clone()
+    if e_score_correction_bias is not None:
+        scores_for_choice = scores_for_choice + e_score_correction_bias.unsqueeze(0)
+
+    group_scores = (
+        scores_for_choice.view(-1, n_group, num_experts // n_group)
+        .topk(2, dim=-1)[0]
+        .sum(dim=-1)
+    )
+    group_idx = torch.topk(group_scores, k=topk_group, dim=-1, sorted=False)[1]
+    group_mask = torch.zeros_like(group_scores)
+    group_mask.scatter_(1, group_idx, 1)
+    score_mask = (
+        group_mask.unsqueeze(-1)
+        .expand(-1, n_group, num_experts // n_group)
+        .reshape(-1, num_experts)
+    )
+    scores_for_choice = scores_for_choice.masked_fill(~score_mask.bool(), 0.0)
+    topk_indices = torch.topk(scores_for_choice, k=top_k, dim=-1, sorted=False)[1]
+
+    topk_weights = scores.gather(1, topk_indices)
+    if norm_topk_prob:
+        topk_weights = topk_weights / (topk_weights.sum(dim=-1, keepdim=True) + 1e-20)
+    topk_weights = topk_weights * routed_scaling_factor
+
+    return topk_indices, topk_weights

--- a/models/demos/deepseek_v3_b1/tests/block_tests/test_decoders.py
+++ b/models/demos/deepseek_v3_b1/tests/block_tests/test_decoders.py
@@ -219,15 +219,14 @@ def _compose_deepseek_v3_forward(x, params, variant):
 
     # Input RMSNorm → MLA attention → residual
     normed = rms_norm(h, params["ln1_weight"], params["eps"])
-    attn_out, _ = mla_fn(
-        normed,
-        wq=params["wq"], w_kv_down=params["w_kv_down"],
-        w_k_up=params["w_k_up"], w_v_up=params["w_v_up"],
-        wo=params["wo"],
-        num_q_heads=params["num_q_heads"],
-        num_kv_heads=params["num_kv_heads"],
-        kv_latent_dim=params["kv_latent_dim"],
-    )
+    mla_kwargs = {k: params[k] for k in (
+        "wq", "w_kv_down", "w_k_up", "w_v_up", "wo",
+        "num_q_heads", "num_kv_heads", "kv_latent_dim",
+    )}
+    for k in ("position_embeddings", "qk_rope_head_dim", "rope_interleave"):
+        if k in params:
+            mla_kwargs[k] = params[k]
+    attn_out, _ = mla_fn(normed, **mla_kwargs)
     h = h + attn_out
 
     # Post-attention RMSNorm → FFN → residual
@@ -280,18 +279,21 @@ def test_deepseek_v3_decoder_from_primitives(variant):
     from transformers import DeepseekV3Config
     from transformers.models.deepseek_v3.modeling_deepseek_v3 import (
         DeepseekV3DecoderLayer,
+        DeepseekV3RotaryEmbedding,
     )
 
-    head_dim = 8
+    nope_dim = 8
+    rope_dim = 4
+    v_head_dim = 8
     config = DeepseekV3Config(
         hidden_size=64,
         num_attention_heads=4,
         num_key_value_heads=4,
         q_lora_rank=None,
         kv_lora_rank=16,
-        qk_rope_head_dim=0,
-        qk_nope_head_dim=head_dim,
-        v_head_dim=head_dim,
+        qk_rope_head_dim=rope_dim,
+        qk_nope_head_dim=nope_dim,
+        v_head_dim=v_head_dim,
         intermediate_size=128,
         moe_intermediate_size=32,
         n_routed_experts=4,
@@ -304,6 +306,7 @@ def test_deepseek_v3_decoder_from_primitives(variant):
         attention_bias=False,
         rms_norm_eps=1e-6,
         max_position_embeddings=256,
+        rope_theta=10000.0,
         attn_implementation="eager",
     )
 
@@ -311,8 +314,9 @@ def test_deepseek_v3_decoder_from_primitives(variant):
     b, seq_len = 1, 4
     x = torch.randn(b, seq_len, config.hidden_size)
     num_heads = config.num_attention_heads
-    cos = torch.empty(b, seq_len, 0)
-    sin = torch.empty(b, seq_len, 0)
+    rotary = DeepseekV3RotaryEmbedding(config)
+    position_ids = torch.arange(seq_len, dtype=torch.long).unsqueeze(0)
+    cos, sin = rotary(x, position_ids)
     label = variant
 
     for layer_idx in [0, 1]:
@@ -326,9 +330,9 @@ def test_deepseek_v3_decoder_from_primitives(variant):
         # 2) Collect params/weights
         attn = layer.self_attn
         kv_b_w = attn.kv_b_proj.weight.data
-        kv_b_reshaped = kv_b_w.view(num_heads, head_dim + head_dim, config.kv_lora_rank)
-        w_k_up = kv_b_reshaped[:, :head_dim, :].reshape(num_heads * head_dim, config.kv_lora_rank)
-        w_v_up = kv_b_reshaped[:, head_dim:, :].reshape(num_heads * head_dim, config.kv_lora_rank)
+        kv_b_reshaped = kv_b_w.view(num_heads, nope_dim + v_head_dim, config.kv_lora_rank)
+        w_k_up = kv_b_reshaped[:, :nope_dim, :].reshape(num_heads * nope_dim, config.kv_lora_rank)
+        w_v_up = kv_b_reshaped[:, nope_dim:, :].reshape(num_heads * v_head_dim, config.kv_lora_rank)
 
         is_dense = layer_idx < config.first_k_dense_replace
         params = dict(
@@ -342,6 +346,9 @@ def test_deepseek_v3_decoder_from_primitives(variant):
             num_q_heads=num_heads,
             num_kv_heads=config.num_key_value_heads,
             kv_latent_dim=config.kv_lora_rank,
+            position_embeddings=(cos, sin),
+            qk_rope_head_dim=rope_dim,
+            rope_interleave=True,
             is_dense=is_dense,
         )
 
@@ -375,7 +382,7 @@ def test_deepseek_v3_decoder_from_primitives(variant):
         h = _compose_deepseek_v3_forward(x, params, variant)
 
         # 4) Compare
-        assert_close(hf_out, h, atol=1e-4, rtol=1e-4), (
+        assert_close(hf_out, h, atol=1e-5, rtol=1e-5), (
             f"DeepSeek V3 ({label}): composed vs real HF "
             f"layer_idx={layer_idx} mismatch"
         )
@@ -393,13 +400,16 @@ def test_kimi_k25_decoder_from_primitives(variant):
     from transformers import DeepseekV3Config
     from transformers.models.deepseek_v3.modeling_deepseek_v3 import (
         DeepseekV3DecoderLayer,
+        DeepseekV3RotaryEmbedding,
     )
 
-    head_dim = 8
+    nope_dim = 8
+    rope_dim = 4
+    v_head_dim = 8
     config = DeepseekV3Config(
         hidden_size=64, num_attention_heads=4, num_key_value_heads=4,
-        q_lora_rank=None, kv_lora_rank=16, qk_rope_head_dim=0,
-        qk_nope_head_dim=head_dim, v_head_dim=head_dim,
+        q_lora_rank=None, kv_lora_rank=16, qk_rope_head_dim=rope_dim,
+        qk_nope_head_dim=nope_dim, v_head_dim=v_head_dim,
         intermediate_size=128, moe_intermediate_size=32,
         n_routed_experts=4, num_experts_per_tok=2,
         n_group=1, topk_group=1, routed_scaling_factor=2.827,
@@ -413,8 +423,9 @@ def test_kimi_k25_decoder_from_primitives(variant):
     b, seq_len = 1, 4
     x = torch.randn(b, seq_len, config.hidden_size)
     num_heads = config.num_attention_heads
-    cos = torch.empty(b, seq_len, 0)
-    sin = torch.empty(b, seq_len, 0)
+    rotary = DeepseekV3RotaryEmbedding(config)
+    position_ids = torch.arange(seq_len, dtype=torch.long).unsqueeze(0)
+    cos, sin = rotary(x, position_ids)
     label = variant
 
     for layer_idx in [0, 1]:
@@ -428,9 +439,9 @@ def test_kimi_k25_decoder_from_primitives(variant):
         # 2) Collect params
         attn = layer.self_attn
         kv_b_w = attn.kv_b_proj.weight.data
-        kv_b_reshaped = kv_b_w.view(num_heads, head_dim + head_dim, config.kv_lora_rank)
-        w_k_up = kv_b_reshaped[:, :head_dim, :].reshape(num_heads * head_dim, config.kv_lora_rank)
-        w_v_up = kv_b_reshaped[:, head_dim:, :].reshape(num_heads * head_dim, config.kv_lora_rank)
+        kv_b_reshaped = kv_b_w.view(num_heads, nope_dim + v_head_dim, config.kv_lora_rank)
+        w_k_up = kv_b_reshaped[:, :nope_dim, :].reshape(num_heads * nope_dim, config.kv_lora_rank)
+        w_v_up = kv_b_reshaped[:, nope_dim:, :].reshape(num_heads * v_head_dim, config.kv_lora_rank)
 
         is_dense = layer_idx < config.first_k_dense_replace
         params = dict(
@@ -444,6 +455,9 @@ def test_kimi_k25_decoder_from_primitives(variant):
             num_q_heads=num_heads,
             num_kv_heads=config.num_key_value_heads,
             kv_latent_dim=config.kv_lora_rank,
+            position_embeddings=(cos, sin),
+            qk_rope_head_dim=rope_dim,
+            rope_interleave=True,
             is_dense=is_dense,
         )
 
@@ -528,7 +542,7 @@ def test_glm4_decoder_from_primitives(variant):
     layer.eval()
 
     rotary = Glm4RotaryEmbedding(config)
-    position_ids = torch.zeros(b, seq_len, dtype=torch.long)
+    position_ids = torch.arange(seq_len, dtype=torch.long).unsqueeze(0)
     cos, sin = rotary(x, position_ids)
 
     # 1) HF reference
@@ -550,6 +564,8 @@ def test_glm4_decoder_from_primitives(variant):
             wv=attn.v_proj.weight.data, wo=attn.o_proj.weight.data,
             num_q_heads=config.num_attention_heads,
             num_kv_heads=config.num_key_value_heads,
+            position_embeddings=(cos, sin),
+            rope_variant="glm4",
         ),
         dense_gate=gate_up_w[:intermediate, :],
         dense_up=gate_up_w[intermediate:, :],
@@ -598,7 +614,7 @@ def test_gpt_oss_decoder_from_primitives(variant):
     layer.eval()
 
     rotary = MixtralRotaryEmbedding(config)
-    position_ids = torch.zeros(b, seq_len, dtype=torch.long)
+    position_ids = torch.arange(seq_len, dtype=torch.long).unsqueeze(0)
     cos, sin = rotary(x, position_ids)
 
     # 1) HF reference
@@ -618,6 +634,7 @@ def test_gpt_oss_decoder_from_primitives(variant):
             wv=attn.v_proj.weight.data, wo=attn.o_proj.weight.data,
             num_q_heads=config.num_attention_heads,
             num_kv_heads=config.num_key_value_heads,
+            position_embeddings=(cos, sin),
         ),
         moe_router=moe_mod.gate.weight.data,
         moe_w1=w1, moe_w2=w2, moe_w3=w3,
@@ -665,20 +682,24 @@ def _extract_mixtral_expert_weights(experts, ne):
     return w1, w2, w3
 
 
-def _collect_gqa_dense_params(layer, config):
+def _collect_gqa_dense_params(layer, config, position_embeddings=None, rope_variant="standard"):
     """Extract params dict from a Llama/Qwen-style GQA + dense SwiGLU layer."""
     attn = layer.self_attn
     mlp = layer.mlp
+    gqa_kwargs = dict(
+        wq=attn.q_proj.weight.data, wk=attn.k_proj.weight.data,
+        wv=attn.v_proj.weight.data, wo=attn.o_proj.weight.data,
+        num_q_heads=config.num_attention_heads,
+        num_kv_heads=config.num_key_value_heads,
+    )
+    if position_embeddings is not None:
+        gqa_kwargs["position_embeddings"] = position_embeddings
+        gqa_kwargs["rope_variant"] = rope_variant
     return dict(
         eps=config.rms_norm_eps,
         ln1_weight=layer.input_layernorm.weight.data,
         ln2_weight=layer.post_attention_layernorm.weight.data,
-        gqa_kwargs=dict(
-            wq=attn.q_proj.weight.data, wk=attn.k_proj.weight.data,
-            wv=attn.v_proj.weight.data, wo=attn.o_proj.weight.data,
-            num_q_heads=config.num_attention_heads,
-            num_kv_heads=config.num_key_value_heads,
-        ),
+        gqa_kwargs=gqa_kwargs,
         dense_gate=mlp.gate_proj.weight.data,
         dense_up=mlp.up_proj.weight.data,
         dense_down=mlp.down_proj.weight.data,
@@ -838,14 +859,14 @@ def test_llama_decoder_from_primitives(variant, model_name, config_overrides, se
     layer.eval()
 
     rotary = LlamaRotaryEmbedding(config)
-    position_ids = torch.zeros(b, seq_len, dtype=torch.long)
+    position_ids = torch.arange(seq_len, dtype=torch.long).unsqueeze(0)
     cos, sin = rotary(x, position_ids)
 
     # 1) HF reference
     hf_out = layer(x, position_embeddings=(cos, sin))
 
     # 2) Collect params
-    params = _collect_gqa_dense_params(layer, config)
+    params = _collect_gqa_dense_params(layer, config, position_embeddings=(cos, sin))
 
     # 3) Run composed forward
     h = _compose_gqa_dense_forward(x, params, variant)
@@ -882,7 +903,7 @@ def test_grok2_decoder_from_primitives(variant):
     layer.eval()
 
     rotary = MixtralRotaryEmbedding(config)
-    position_ids = torch.zeros(b, seq_len, dtype=torch.long)
+    position_ids = torch.arange(seq_len, dtype=torch.long).unsqueeze(0)
     cos, sin = rotary(x, position_ids)
 
     # 1) HF reference
@@ -901,6 +922,7 @@ def test_grok2_decoder_from_primitives(variant):
             wv=attn.v_proj.weight.data, wo=attn.o_proj.weight.data,
             num_q_heads=config.num_attention_heads,
             num_kv_heads=config.num_key_value_heads,
+            position_embeddings=(cos, sin),
         ),
         moe_router=moe_mod.gate.weight.data,
         moe_w1=w1, moe_w2=w2, moe_w3=w3,
@@ -1028,7 +1050,7 @@ def test_minimax_m25_decoder_from_primitives(variant):
     layer.eval()
 
     rotary = MiniMaxRotaryEmbedding(config)
-    position_ids = torch.zeros(b, seq_len, dtype=torch.long)
+    position_ids = torch.arange(seq_len, dtype=torch.long).unsqueeze(0)
     cos, sin = rotary(x, position_ids)
 
     # 1) HF reference
@@ -1047,6 +1069,7 @@ def test_minimax_m25_decoder_from_primitives(variant):
             wv=attn.v_proj.weight.data, wo=attn.o_proj.weight.data,
             num_q_heads=config.num_attention_heads,
             num_kv_heads=config.num_key_value_heads,
+            position_embeddings=(cos, sin),
         ),
         moe_router=moe_mod.gate.weight.data,
         moe_w1=w1, moe_w2=w2, moe_w3=w3,
@@ -1100,7 +1123,7 @@ def test_olmoe_decoder_from_primitives(variant):
     layer.self_attn.k_norm = nn.Identity()
 
     rotary = OlmoeRotaryEmbedding(config)
-    position_ids = torch.zeros(b, seq_len, dtype=torch.long)
+    position_ids = torch.arange(seq_len, dtype=torch.long).unsqueeze(0)
     cos, sin = rotary(x, position_ids)
 
     # 1) HF reference
@@ -1119,6 +1142,7 @@ def test_olmoe_decoder_from_primitives(variant):
             wv=attn.v_proj.weight.data, wo=attn.o_proj.weight.data,
             num_q_heads=config.num_attention_heads,
             num_kv_heads=config.num_key_value_heads,
+            position_embeddings=(cos, sin),
         ),
         moe_router=moe_mod.gate.weight.data,
         moe_w1=w1, moe_w2=w2, moe_w3=w3,
@@ -1148,7 +1172,6 @@ def test_qwen2_5_decoder_from_primitives(variant):
     Adaptations:
     - Qwen2 has hardcoded attention bias=True. Zero out all biases so
       F.linear(x, w, 0) == F.linear(x, w), matching our bias-free gqa functions.
-    - position_ids=0 → identity RoPE
     """
     from transformers import Qwen2Config
     from transformers.models.qwen2.modeling_qwen2 import (
@@ -1177,14 +1200,14 @@ def test_qwen2_5_decoder_from_primitives(variant):
     layer.self_attn.v_proj.bias.data.zero_()
 
     rotary = Qwen2RotaryEmbedding(config)
-    position_ids = torch.zeros(b, seq_len, dtype=torch.long)
+    position_ids = torch.arange(seq_len, dtype=torch.long).unsqueeze(0)
     cos, sin = rotary(x, position_ids)
 
     # 1) HF reference
     hf_out = layer(x, position_embeddings=(cos, sin))
 
     # 2) Collect params
-    params = _collect_gqa_dense_params(layer, config)
+    params = _collect_gqa_dense_params(layer, config, position_embeddings=(cos, sin))
 
     # 3) Run composed forward
     h = _compose_gqa_dense_forward(x, params, variant)
@@ -1238,7 +1261,7 @@ def test_qwen3moe_decoder_from_primitives(variant, model_name, config_overrides,
     layer.self_attn.k_norm = nn.Identity()
 
     rotary = Qwen3MoeRotaryEmbedding(config)
-    position_ids = torch.zeros(b, seq_len, dtype=torch.long)
+    position_ids = torch.arange(seq_len, dtype=torch.long).unsqueeze(0)
     cos, sin = rotary(x, position_ids)
 
     # 1) HF reference
@@ -1257,6 +1280,7 @@ def test_qwen3moe_decoder_from_primitives(variant, model_name, config_overrides,
             wv=attn.v_proj.weight.data, wo=attn.o_proj.weight.data,
             num_q_heads=config.num_attention_heads,
             num_kv_heads=config.num_key_value_heads,
+            position_embeddings=(cos, sin),
         ),
         moe_router=moe_mod.gate.weight.data,
         moe_w1=w1, moe_w2=w2, moe_w3=w3,
@@ -1285,7 +1309,6 @@ def test_qwen3_32b_decoder_from_primitives(variant):
 
     Adaptations:
     - QK norm monkey-patched to nn.Identity
-    - position_ids=0 → identity RoPE
     """
     import torch.nn as nn
     from transformers import Qwen3Config
@@ -1313,14 +1336,14 @@ def test_qwen3_32b_decoder_from_primitives(variant):
     layer.self_attn.k_norm = nn.Identity()
 
     rotary = Qwen3RotaryEmbedding(config)
-    position_ids = torch.zeros(b, seq_len, dtype=torch.long)
+    position_ids = torch.arange(seq_len, dtype=torch.long).unsqueeze(0)
     cos, sin = rotary(x, position_ids)
 
     # 1) HF reference
     hf_out = layer(x, position_embeddings=(cos, sin))
 
     # 2) Collect params
-    params = _collect_gqa_dense_params(layer, config)
+    params = _collect_gqa_dense_params(layer, config, position_embeddings=(cos, sin))
 
     # 3) Run composed forward
     h = _compose_gqa_dense_forward(x, params, variant)

--- a/models/demos/deepseek_v3_b1/tests/block_tests/test_decoders.py
+++ b/models/demos/deepseek_v3_b1/tests/block_tests/test_decoders.py
@@ -11,7 +11,8 @@ import pytest
 from helpers import seed_all, assert_close, make_profiles, rms_norm
 from gqa import gqa_attention_torch, gqa_attention_tt
 from mla import mla_attention_torch, mla_attention_tt
-from moe import moe_torch, moe_tt, moe_shared_experts_torch, moe_shared_experts_tt, sigmoid_topk_routing
+from moe import moe_torch, moe_tt
+from mlp import mlp_torch, mlp_tt
 
 # ---------------------------------------------------------------------------
 # Dispatch: variant string → function implementations
@@ -22,21 +23,21 @@ IMPL = {
         gqa=gqa_attention_torch,
         mla=mla_attention_torch,
         moe=moe_torch,
-        shared=moe_shared_experts_torch,
+        mlp=mlp_torch,
     ),
     "tt": dict(
         gqa=gqa_attention_tt,
         mla=mla_attention_tt,
         moe=moe_tt,
-        shared=moe_shared_experts_tt,
+        mlp=mlp_tt,
     ),
 }
 
 
 def fns(variant):
-    """Return (gqa_fn, mla_fn, moe_fn, shared_fn) for the given variant."""
+    """Return (gqa_fn, mla_fn, moe_fn, mlp_fn) for the given variant."""
     d = IMPL[variant]
-    return d["gqa"], d["mla"], d["moe"], d["shared"]
+    return d["gqa"], d["mla"], d["moe"], d["mlp"]
 
 
 # ---------------------------------------------------------------------------
@@ -61,12 +62,15 @@ def _make_decoder_weights(prof, dtype=torch.float32):
     # Attention weights
     if prof["use_mla"]:
         lat = prof["kv_latent_dim"]
+        rope_dim = prof["qk_rope_head_dim"]
+        nope_dim = hd - rope_dim
         w["attn"] = dict(
             wq=torch.randn(nq * hd, h, dtype=dtype),
-            w_kv_down=torch.randn(lat, h, dtype=dtype),
-            w_k_up=torch.randn(nkv * hd, lat, dtype=dtype),
-            w_v_up=torch.randn(nkv * hd, lat, dtype=dtype),
+            w_kv_a=torch.randn(lat + rope_dim, h, dtype=dtype),
+            kv_a_layernorm_weight=torch.ones(lat, dtype=dtype),
+            w_kv_b=torch.randn(nkv * (nope_dim + hd), lat, dtype=dtype),
             wo=torch.randn(h, nq * hd, dtype=dtype),
+            qk_rope_head_dim=rope_dim,
         )
     else:
         w["attn"] = dict(
@@ -84,6 +88,7 @@ def _make_decoder_weights(prof, dtype=torch.float32):
             w_router=torch.randn(ne, h, dtype=dtype),
             w1=torch.randn(ne, mi, h, dtype=dtype),
             w2=torch.randn(ne, h, mi, dtype=dtype),
+            w3=torch.randn(ne, mi, h, dtype=dtype),
         )
     else:
         w["ffn"] = dict(
@@ -119,9 +124,14 @@ def decoder_forward(hidden_states, profile, weights, variant="torch",
     )
 
     if profile["use_mla"]:
+        b, q_seq, _ = normed.shape
+        rope_dim = profile["qk_rope_head_dim"]
+        cos = torch.ones(b, q_seq, rope_dim, device=normed.device)
+        sin = torch.zeros(b, q_seq, rope_dim, device=normed.device)
         attn_out, present_kv = mla_fn(
             normed, **weights["attn"],
             kv_latent_dim=profile["kv_latent_dim"],
+            position_embeddings=(cos, sin),
             **attn_kwargs,
         )
     else:
@@ -173,13 +183,17 @@ def test_decoder_cache_chunking_equivalence_per_family():
         x = torch.randn(b, seq, h)
         weights = _make_decoder_weights(prof)
 
-        # Full forward with causal mask
-        causal_full = torch.tril(torch.ones(seq, seq, dtype=torch.bool)).unsqueeze(0).unsqueeze(0)
+        # Full forward with causal mask (additive: 0 = keep, -inf = mask)
+        causal_full = torch.where(
+            torch.tril(torch.ones(seq, seq)).bool(), 0.0, float("-inf"),
+        ).unsqueeze(0).unsqueeze(0)
         out_full, _ = decoder_forward(x, prof, weights, attention_mask=causal_full)
 
         # Chunk 1
         x1 = x[:, :split, :]
-        causal1 = torch.tril(torch.ones(split, split, dtype=torch.bool)).unsqueeze(0).unsqueeze(0)
+        causal1 = torch.where(
+            torch.tril(torch.ones(split, split)).bool(), 0.0, float("-inf"),
+        ).unsqueeze(0).unsqueeze(0)
         out1, cache = decoder_forward(
             x1, prof, weights, attention_mask=causal1, use_cache=True,
         )
@@ -187,10 +201,10 @@ def test_decoder_cache_chunking_equivalence_per_family():
         # Chunk 2
         x2 = x[:, split:, :]
         kv_len = seq
-        causal2 = torch.ones(seq - split, kv_len, dtype=torch.bool)
+        causal2_bool = torch.ones(seq - split, kv_len, dtype=torch.bool)
         for i in range(seq - split):
-            causal2[i, split + i + 1:] = False
-        causal2 = causal2.unsqueeze(0).unsqueeze(0)
+            causal2_bool[i, split + i + 1:] = False
+        causal2 = torch.where(causal2_bool, 0.0, float("-inf")).unsqueeze(0).unsqueeze(0)
         out2, _ = decoder_forward(
             x2, prof, weights, attention_mask=causal2,
             past_key_value=cache, use_cache=True,
@@ -217,17 +231,19 @@ def _compose_deepseek_v3_forward(x, params, variant):
     Compose a DeepSeek V3 decoder layer from primitives (MLA + MoE/dense FFN).
     params: dict with all weights/config needed for the forward pass.
     """
-    _, mla_fn, moe_fn, shared_fn = fns(variant)
+    _, mla_fn, moe_fn, mlp_fn = fns(variant)
 
     h = x
 
     # Input RMSNorm → MLA attention → residual
     normed = rms_norm(h, params["ln1_weight"], params["eps"])
     mla_kwargs = {k: params[k] for k in (
-        "wq", "w_kv_down", "w_k_up", "w_v_up", "wo",
+        "wq", "w_kv_a", "w_kv_b", "wo",
         "num_q_heads", "num_kv_heads", "kv_latent_dim",
+        "kv_a_layernorm_weight", "qk_rope_head_dim", "position_embeddings",
     )}
-    for k in ("position_embeddings", "qk_rope_head_dim", "rope_interleave"):
+    for k in ("w_q_a", "q_a_layernorm_weight", "q_a_layernorm_eps",
+              "kv_a_layernorm_eps"):
         if k in params:
             mla_kwargs[k] = params[k]
     attn_out, _ = mla_fn(normed, **mla_kwargs)
@@ -237,33 +253,22 @@ def _compose_deepseek_v3_forward(x, params, variant):
     normed2 = rms_norm(h, params["ln2_weight"], params["eps"])
 
     if params["is_dense"]:
-        ffn_out = shared_fn(
-            normed2,
-            w_gate=params["dense_gate"], w_up=params["dense_up"],
-            w_down=params["dense_down"],
-        )
+        ffn_out = mlp_fn(normed2, **params["mlp_kwargs"])
     else:
-        topk_indices, topk_weights = sigmoid_topk_routing(
-            normed2,
-            w_router=params["moe_router"],
-            top_k=params["top_k"],
-            n_group=params["n_group"],
-            topk_group=params["topk_group"],
-            e_score_correction_bias=params.get("e_score_correction_bias"),
-            routed_scaling_factor=params.get("routed_scaling_factor", 1.0),
-            norm_topk_prob=params.get("norm_topk_prob", False),
-        )
         ffn_out = moe_fn(
             normed2,
             w_router=params["moe_router"], w1=params["moe_w1"],
             w2=params["moe_w2"], w3=params["moe_w3"],
             top_k=params["top_k"],
-            precomputed_routing=(topk_indices, topk_weights),
-        )
-        ffn_out = ffn_out + shared_fn(
-            normed2,
-            w_gate=params["shared_gate"], w_up=params["shared_up"],
-            w_down=params["shared_down"],
+            gate_kwargs=dict(
+                score_func="sigmoid",
+                n_group=params["n_group"],
+                topk_group=params["topk_group"],
+                e_score_correction_bias=params.get("e_score_correction_bias"),
+                routed_scaling_factor=params.get("routed_scaling_factor", 1.0),
+                norm_topk_prob=params.get("norm_topk_prob", False),
+            ),
+            shared_mlp_kwargs=params["shared_mlp_kwargs"],
         )
 
     return h + ffn_out
@@ -279,7 +284,6 @@ def test_deepseek_v3_decoder_from_primitives(variant):
 
     Tests both dense (layer 0) and MoE (layer 1) decoder layers.
     """
-    import torch.nn as nn
     from transformers import DeepseekV3Config
     from transformers.models.deepseek_v3.modeling_deepseek_v3 import (
         DeepseekV3DecoderLayer,
@@ -289,11 +293,12 @@ def test_deepseek_v3_decoder_from_primitives(variant):
     nope_dim = 8
     rope_dim = 4
     v_head_dim = 8
+    q_lora_rank = 16
     config = DeepseekV3Config(
         hidden_size=64,
         num_attention_heads=4,
         num_key_value_heads=4,
-        q_lora_rank=None,
+        q_lora_rank=q_lora_rank,
         kv_lora_rank=16,
         qk_rope_head_dim=rope_dim,
         qk_nope_head_dim=nope_dim,
@@ -326,42 +331,41 @@ def test_deepseek_v3_decoder_from_primitives(variant):
     for layer_idx in [0, 1]:
         layer = DeepseekV3DecoderLayer(config, layer_idx=layer_idx)
         layer.eval()
-        layer.self_attn.kv_a_layernorm = nn.Identity()
 
         # 1) HF reference
         hf_out = layer(x, position_embeddings=(cos, sin))
 
         # 2) Collect params/weights
         attn = layer.self_attn
-        kv_b_w = attn.kv_b_proj.weight.data
-        kv_b_reshaped = kv_b_w.view(num_heads, nope_dim + v_head_dim, config.kv_lora_rank)
-        w_k_up = kv_b_reshaped[:, :nope_dim, :].reshape(num_heads * nope_dim, config.kv_lora_rank)
-        w_v_up = kv_b_reshaped[:, nope_dim:, :].reshape(num_heads * v_head_dim, config.kv_lora_rank)
-
         is_dense = layer_idx < config.first_k_dense_replace
         params = dict(
             eps=config.rms_norm_eps,
             ln1_weight=layer.input_layernorm.weight.data,
             ln2_weight=layer.post_attention_layernorm.weight.data,
-            wq=attn.q_proj.weight.data,
-            w_kv_down=attn.kv_a_proj_with_mqa.weight.data,
-            w_k_up=w_k_up, w_v_up=w_v_up,
+            # Q LoRA: q_a_proj → q_a_layernorm → q_b_proj
+            w_q_a=attn.q_a_proj.weight.data,
+            q_a_layernorm_weight=attn.q_a_layernorm.weight.data,
+            wq=attn.q_b_proj.weight.data,
+            # KV path with layernorm
+            w_kv_a=attn.kv_a_proj_with_mqa.weight.data,
+            kv_a_layernorm_weight=attn.kv_a_layernorm.weight.data,
+            w_kv_b=attn.kv_b_proj.weight.data,
             wo=attn.o_proj.weight.data,
             num_q_heads=num_heads,
             num_kv_heads=config.num_key_value_heads,
             kv_latent_dim=config.kv_lora_rank,
             position_embeddings=(cos, sin),
             qk_rope_head_dim=rope_dim,
-            rope_interleave=True,
+
             is_dense=is_dense,
         )
 
         if is_dense:
             mlp = layer.mlp
-            params.update(
-                dense_gate=mlp.gate_proj.weight.data,
-                dense_up=mlp.up_proj.weight.data,
-                dense_down=mlp.down_proj.weight.data,
+            params["mlp_kwargs"] = dict(
+                w_gate=mlp.gate_proj.weight.data,
+                w_up=mlp.up_proj.weight.data,
+                w_down=mlp.down_proj.weight.data,
             )
         else:
             moe_mod = layer.mlp
@@ -377,9 +381,11 @@ def test_deepseek_v3_decoder_from_primitives(variant):
                 e_score_correction_bias=moe_mod.gate.e_score_correction_bias,
                 routed_scaling_factor=config.routed_scaling_factor,
                 norm_topk_prob=config.norm_topk_prob,
-                shared_gate=moe_mod.shared_experts.gate_proj.weight.data,
-                shared_up=moe_mod.shared_experts.up_proj.weight.data,
-                shared_down=moe_mod.shared_experts.down_proj.weight.data,
+                shared_mlp_kwargs=dict(
+                    w_gate=moe_mod.shared_experts.gate_proj.weight.data,
+                    w_up=moe_mod.shared_experts.up_proj.weight.data,
+                    w_down=moe_mod.shared_experts.down_proj.weight.data,
+                ),
             )
 
         # 3) Run composed forward
@@ -400,7 +406,6 @@ def test_deepseek_v3_decoder_from_primitives(variant):
 @pytest.mark.parametrize("variant", IMPL.keys())
 def test_kimi_k25_decoder_from_primitives(variant):
     """Compose Kimi K2.5 decoder (DeepSeek V3 architecture with different params)."""
-    import torch.nn as nn
     from transformers import DeepseekV3Config
     from transformers.models.deepseek_v3.modeling_deepseek_v3 import (
         DeepseekV3DecoderLayer,
@@ -410,9 +415,10 @@ def test_kimi_k25_decoder_from_primitives(variant):
     nope_dim = 8
     rope_dim = 4
     v_head_dim = 8
+    q_lora_rank = 16
     config = DeepseekV3Config(
         hidden_size=64, num_attention_heads=4, num_key_value_heads=4,
-        q_lora_rank=None, kv_lora_rank=16, qk_rope_head_dim=rope_dim,
+        q_lora_rank=q_lora_rank, kv_lora_rank=16, qk_rope_head_dim=rope_dim,
         qk_nope_head_dim=nope_dim, v_head_dim=v_head_dim,
         intermediate_size=128, moe_intermediate_size=32,
         n_routed_experts=4, num_experts_per_tok=2,
@@ -435,42 +441,41 @@ def test_kimi_k25_decoder_from_primitives(variant):
     for layer_idx in [0, 1]:
         layer = DeepseekV3DecoderLayer(config, layer_idx=layer_idx)
         layer.eval()
-        layer.self_attn.kv_a_layernorm = nn.Identity()
 
         # 1) HF reference
         hf_out = layer(x, position_embeddings=(cos, sin))
 
         # 2) Collect params
         attn = layer.self_attn
-        kv_b_w = attn.kv_b_proj.weight.data
-        kv_b_reshaped = kv_b_w.view(num_heads, nope_dim + v_head_dim, config.kv_lora_rank)
-        w_k_up = kv_b_reshaped[:, :nope_dim, :].reshape(num_heads * nope_dim, config.kv_lora_rank)
-        w_v_up = kv_b_reshaped[:, nope_dim:, :].reshape(num_heads * v_head_dim, config.kv_lora_rank)
-
         is_dense = layer_idx < config.first_k_dense_replace
         params = dict(
             eps=config.rms_norm_eps,
             ln1_weight=layer.input_layernorm.weight.data,
             ln2_weight=layer.post_attention_layernorm.weight.data,
-            wq=attn.q_proj.weight.data,
-            w_kv_down=attn.kv_a_proj_with_mqa.weight.data,
-            w_k_up=w_k_up, w_v_up=w_v_up,
+            # Q LoRA: q_a_proj → q_a_layernorm → q_b_proj
+            w_q_a=attn.q_a_proj.weight.data,
+            q_a_layernorm_weight=attn.q_a_layernorm.weight.data,
+            wq=attn.q_b_proj.weight.data,
+            # KV path with layernorm
+            w_kv_a=attn.kv_a_proj_with_mqa.weight.data,
+            kv_a_layernorm_weight=attn.kv_a_layernorm.weight.data,
+            w_kv_b=attn.kv_b_proj.weight.data,
             wo=attn.o_proj.weight.data,
             num_q_heads=num_heads,
             num_kv_heads=config.num_key_value_heads,
             kv_latent_dim=config.kv_lora_rank,
             position_embeddings=(cos, sin),
             qk_rope_head_dim=rope_dim,
-            rope_interleave=True,
+
             is_dense=is_dense,
         )
 
         if is_dense:
             mlp = layer.mlp
-            params.update(
-                dense_gate=mlp.gate_proj.weight.data,
-                dense_up=mlp.up_proj.weight.data,
-                dense_down=mlp.down_proj.weight.data,
+            params["mlp_kwargs"] = dict(
+                w_gate=mlp.gate_proj.weight.data,
+                w_up=mlp.up_proj.weight.data,
+                w_down=mlp.down_proj.weight.data,
             )
         else:
             moe_mod = layer.mlp
@@ -486,9 +491,11 @@ def test_kimi_k25_decoder_from_primitives(variant):
                 e_score_correction_bias=moe_mod.gate.e_score_correction_bias,
                 routed_scaling_factor=config.routed_scaling_factor,
                 norm_topk_prob=config.norm_topk_prob,
-                shared_gate=moe_mod.shared_experts.gate_proj.weight.data,
-                shared_up=moe_mod.shared_experts.up_proj.weight.data,
-                shared_down=moe_mod.shared_experts.down_proj.weight.data,
+                shared_mlp_kwargs=dict(
+                    w_gate=moe_mod.shared_experts.gate_proj.weight.data,
+                    w_up=moe_mod.shared_experts.up_proj.weight.data,
+                    w_down=moe_mod.shared_experts.down_proj.weight.data,
+                ),
             )
 
         # 3) Run composed forward
@@ -571,9 +578,11 @@ def test_glm4_decoder_from_primitives(variant):
             position_embeddings=(cos, sin),
             rope_variant="glm4",
         ),
-        dense_gate=gate_up_w[:intermediate, :],
-        dense_up=gate_up_w[intermediate:, :],
-        dense_down=mlp.down_proj.weight.data,
+        mlp_kwargs=dict(
+            w_gate=gate_up_w[:intermediate, :],
+            w_up=gate_up_w[intermediate:, :],
+            w_down=mlp.down_proj.weight.data,
+        ),
     )
 
     # 3) Run composed forward
@@ -658,16 +667,6 @@ def test_gpt_oss_decoder_from_primitives(variant):
 # Helpers for composed decoder tests
 # ===========================================================================
 
-def _softmax_topk_routing(normed, gate_weight, top_k, normalize=True):
-    """Extract softmax→topk→renormalize routing (Mixtral/Qwen3Moe/OLMoE pattern)."""
-    flat = normed.reshape(-1, normed.shape[-1])
-    router_logits = F.linear(flat, gate_weight)
-    routing_weights = F.softmax(router_logits, dim=1, dtype=torch.float)
-    routing_weights, topk_indices = torch.topk(routing_weights, top_k, dim=-1)
-    if normalize:
-        routing_weights /= routing_weights.sum(dim=-1, keepdim=True)
-    routing_weights = routing_weights.to(flat.dtype)
-    return topk_indices, routing_weights
 
 
 def _extract_swiglu_expert_weights(experts, ne, attr_gate="gate_proj", attr_up="up_proj", attr_down="down_proj"):
@@ -704,15 +703,17 @@ def _collect_gqa_dense_params(layer, config, position_embeddings=None, rope_vari
         ln1_weight=layer.input_layernorm.weight.data,
         ln2_weight=layer.post_attention_layernorm.weight.data,
         gqa_kwargs=gqa_kwargs,
-        dense_gate=mlp.gate_proj.weight.data,
-        dense_up=mlp.up_proj.weight.data,
-        dense_down=mlp.down_proj.weight.data,
+        mlp_kwargs=dict(
+            w_gate=mlp.gate_proj.weight.data,
+            w_up=mlp.up_proj.weight.data,
+            w_down=mlp.down_proj.weight.data,
+        ),
     )
 
 
 def _compose_gqa_dense_forward(x, params, variant):
     """Compose GQA + dense SwiGLU decoder (Llama/Qwen2 pattern, 2 RMSNorms)."""
-    gqa_fn, _, _, shared_fn = fns(variant)
+    gqa_fn, _, _, mlp_fn = fns(variant)
 
     h = x
     normed = rms_norm(h, params["ln1_weight"], params["eps"])
@@ -720,17 +721,13 @@ def _compose_gqa_dense_forward(x, params, variant):
     h = h + attn_out
 
     normed2 = rms_norm(h, params["ln2_weight"], params["eps"])
-    ffn_out = shared_fn(
-        normed2,
-        w_gate=params["dense_gate"], w_up=params["dense_up"],
-        w_down=params["dense_down"],
-    )
+    ffn_out = mlp_fn(normed2, **params["mlp_kwargs"])
     return h + ffn_out
 
 
 def _compose_glm4_forward(x, params, variant):
     """Compose GLM-4 decoder (GQA + dense SwiGLU, 4 RMSNorms with post-attn/post-mlp norms)."""
-    gqa_fn, _, _, shared_fn = fns(variant)
+    gqa_fn, _, _, mlp_fn = fns(variant)
 
     h = x
     normed = rms_norm(h, params["ln1_weight"], params["eps"])
@@ -739,11 +736,7 @@ def _compose_glm4_forward(x, params, variant):
     h = h + attn_out
 
     normed2 = rms_norm(h, params["ln2_weight"], params["eps"])
-    mlp_out = shared_fn(
-        normed2,
-        w_gate=params["dense_gate"], w_up=params["dense_up"],
-        w_down=params["dense_down"],
-    )
+    mlp_out = mlp_fn(normed2, **params["mlp_kwargs"])
     mlp_out = rms_norm(mlp_out, params["ln_post_mlp"], params["eps"])
     return h + mlp_out
 
@@ -758,15 +751,13 @@ def _compose_gqa_moe_forward(x, params, variant):
     h = h + attn_out
 
     normed2 = rms_norm(h, params["ln2_weight"], params["eps"])
-    topk_idx, rw = _softmax_topk_routing(
-        normed2, params["moe_router"], params["top_k"],
-        normalize=params.get("normalize_routing", True),
-    )
     ffn_out = moe_fn(
         normed2, w_router=params["moe_router"],
         w1=params["moe_w1"], w2=params["moe_w2"], w3=params["moe_w3"],
         top_k=params["top_k"],
-        precomputed_routing=(topk_idx, rw),
+        gate_kwargs=dict(
+            norm_topk_prob=params.get("normalize_routing", True),
+        ),
     )
     return h + ffn_out
 
@@ -780,20 +771,17 @@ def _compose_minimax_forward(x, params, variant):
     h = normed * params["alpha_attn"] + attn_out * params["beta_attn"]
 
     normed2 = rms_norm(h, params["ln2_weight"], params["eps"])
-    topk_idx, rw = _softmax_topk_routing(
-        normed2, params["moe_router"], params["top_k"])
     moe_out = moe_fn(
         normed2, w_router=params["moe_router"],
         w1=params["moe_w1"], w2=params["moe_w2"], w3=params["moe_w3"],
         top_k=params["top_k"],
-        precomputed_routing=(topk_idx, rw),
     )
     return normed2 * params["alpha_mlp"] + moe_out * params["beta_mlp"]
 
 
 def _compose_llama4_forward(x, params, variant):
     """Compose Llama4 decoder (GQA + sigmoid MoE with shared expert, scale_input)."""
-    gqa_fn, _, moe_fn, shared_fn = fns(variant)
+    gqa_fn, _, moe_fn, _ = fns(variant)
 
     h = x
     normed = rms_norm(h, params["ln1_weight"], params["eps"])
@@ -814,12 +802,8 @@ def _compose_llama4_forward(x, params, variant):
         w1=params["moe_w1"], w2=params["moe_w2"], w3=params["moe_w3"],
         top_k=params["top_k"],
         precomputed_routing=(topk_indices, routing_weights),
+        shared_mlp_kwargs=params["shared_mlp_kwargs"],
         scale_input=True,
-    )
-    ffn_out = ffn_out + shared_fn(
-        normed2,
-        w_gate=params["shared_gate"], w_up=params["shared_up"],
-        w_down=params["shared_down"],
     )
     return h + ffn_out
 
@@ -1007,9 +991,11 @@ def test_llama4_decoder_from_primitives(variant, model_name, config_overrides, s
         moe_w3=moe_mod.experts.gate_up_proj.data[:, :, mi:].permute(0, 2, 1),
         moe_w2=moe_mod.experts.down_proj.data.permute(0, 2, 1),
         top_k=config.num_experts_per_tok,
-        shared_gate=shared.gate_proj.weight.data,
-        shared_up=shared.up_proj.weight.data,
-        shared_down=shared.down_proj.weight.data,
+        shared_mlp_kwargs=dict(
+            w_gate=shared.gate_proj.weight.data,
+            w_up=shared.up_proj.weight.data,
+            w_down=shared.down_proj.weight.data,
+        ),
     )
 
     # 3) Run composed forward

--- a/models/demos/deepseek_v3_b1/tests/block_tests/test_decoders.py
+++ b/models/demos/deepseek_v3_b1/tests/block_tests/test_decoders.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
 """Full decoder tests: per-family forward comparison + compose-from-primitives vs HF reference."""
 
 import torch
@@ -197,7 +201,7 @@ def test_decoder_cache_chunking_equivalence_per_family():
 
 
 # ===========================================================================
-# Real HF model comparison tests
+# HF model comparison tests
 # ===========================================================================
 
 # --- Helpers for manual forward replication ---
@@ -271,7 +275,7 @@ def test_deepseek_v3_decoder_from_primitives(variant):
     """
     Compose a full DeepSeek V3 decoder layer from our primitive functions
     (mla_attention_torch/hf from mla.py, moe_torch/hf + moe_shared_experts
-    from moe.py) and compare against the real HF DeepseekV3DecoderLayer.
+    from moe.py) and compare against the HF DeepseekV3DecoderLayer.
 
     Tests both dense (layer 0) and MoE (layer 1) decoder layers.
     """
@@ -383,7 +387,7 @@ def test_deepseek_v3_decoder_from_primitives(variant):
 
         # 4) Compare
         assert_close(hf_out, h, atol=1e-5, rtol=1e-5), (
-            f"DeepSeek V3 ({label}): composed vs real HF "
+            f"DeepSeek V3 ({label}): composed vs HF "
             f"layer_idx={layer_idx} mismatch"
         )
 
@@ -492,7 +496,7 @@ def test_kimi_k25_decoder_from_primitives(variant):
 
         # 4) Compare
         assert_close(hf_out, h, atol=1e-4, rtol=1e-4), (
-            f"Kimi K2.5 ({label}): composed vs real HF "
+            f"Kimi K2.5 ({label}): composed vs HF "
             f"layer_idx={layer_idx} mismatch"
         )
 
@@ -578,12 +582,12 @@ def test_glm4_decoder_from_primitives(variant):
     # 4) Compare
     label = variant
     assert_close(hf_out, h, atol=1e-4, rtol=1e-4), \
-        f"GLM-4 ({label}): composed vs real HF GLM-4 mismatch"
+        f"GLM-4 ({label}): composed vs HF GLM-4 mismatch"
 
 
 # ---------------------------------------------------------------------------
 # Full GPT-OSS 120B decoder layer composed from gqa.py + moe.py functions
-#   (using Mixtral as real HF reference — same GQA + MoE architecture)
+#   (using Mixtral as HF reference — same GQA + MoE architecture)
 # ---------------------------------------------------------------------------
 
 @torch.no_grad()
@@ -647,7 +651,7 @@ def test_gpt_oss_decoder_from_primitives(variant):
     # 4) Compare
     label = variant
     assert_close(hf_out, h, atol=1e-4, rtol=1e-4), \
-        f"GPT-OSS 120B ({label}): composed vs real HF Mixtral proxy mismatch"
+        f"GPT-OSS 120B ({label}): composed vs HF Mixtral proxy mismatch"
 
 
 # ===========================================================================
@@ -874,7 +878,7 @@ def test_llama_decoder_from_primitives(variant, model_name, config_overrides, se
     # 4) Compare
     label = variant
     assert_close(hf_out, h, atol=1e-4, rtol=1e-4), \
-        f"{model_name} ({label}): composed vs real HF Llama mismatch"
+        f"{model_name} ({label}): composed vs HF Llama mismatch"
 
 
 @torch.no_grad()
@@ -935,7 +939,7 @@ def test_grok2_decoder_from_primitives(variant):
     # 4) Compare
     label = variant
     assert_close(hf_out, h, atol=1e-4, rtol=1e-4), \
-        f"Grok 2 ({label}): composed vs real HF Mixtral proxy mismatch"
+        f"Grok 2 ({label}): composed vs HF Mixtral proxy mismatch"
 
 
 # ---------------------------------------------------------------------------
@@ -1014,7 +1018,7 @@ def test_llama4_decoder_from_primitives(variant, model_name, config_overrides, s
     # 4) Compare
     label = variant
     assert_close(hf_out, h, atol=1e-4, rtol=1e-4), \
-        f"{model_name} ({label}): composed vs real HF Llama4 mismatch"
+        f"{model_name} ({label}): composed vs HF Llama4 mismatch"
 
 
 # ---------------------------------------------------------------------------
@@ -1086,7 +1090,7 @@ def test_minimax_m25_decoder_from_primitives(variant):
     # 4) Compare
     label = variant
     assert_close(hf_out, h, atol=1e-4, rtol=1e-4), \
-        f"MiniMax M25 ({label}): composed vs real HF MiniMax mismatch"
+        f"MiniMax M25 ({label}): composed vs HF MiniMax mismatch"
 
 
 # ---------------------------------------------------------------------------
@@ -1156,7 +1160,7 @@ def test_olmoe_decoder_from_primitives(variant):
     # 4) Compare
     label = variant
     assert_close(hf_out, h, atol=1e-4, rtol=1e-4), \
-        f"OLMoE ({label}): composed vs real HF OLMoE mismatch"
+        f"OLMoE ({label}): composed vs HF OLMoE mismatch"
 
 
 # ---------------------------------------------------------------------------
@@ -1215,7 +1219,7 @@ def test_qwen2_5_decoder_from_primitives(variant):
     # 4) Compare
     label = variant
     assert_close(hf_out, h, atol=1e-4, rtol=1e-4), \
-        f"Qwen2.5 ({label}): composed vs real HF Qwen2 mismatch"
+        f"Qwen2.5 ({label}): composed vs HF Qwen2 mismatch"
 
 
 # ---------------------------------------------------------------------------
@@ -1294,7 +1298,7 @@ def test_qwen3moe_decoder_from_primitives(variant, model_name, config_overrides,
     # 4) Compare
     label = variant
     assert_close(hf_out, h, atol=1e-4, rtol=1e-4), \
-        f"{model_name} ({label}): composed vs real HF Qwen3Moe mismatch"
+        f"{model_name} ({label}): composed vs HF Qwen3Moe mismatch"
 
 
 # ---------------------------------------------------------------------------
@@ -1351,4 +1355,4 @@ def test_qwen3_32b_decoder_from_primitives(variant):
     # 4) Compare
     label = variant
     assert_close(hf_out, h, atol=1e-4, rtol=1e-4), \
-        f"Qwen3-32B ({label}): composed vs real HF Qwen3 mismatch"
+        f"Qwen3-32B ({label}): composed vs HF Qwen3 mismatch"

--- a/models/demos/deepseek_v3_b1/tests/block_tests/test_decoders.py
+++ b/models/demos/deepseek_v3_b1/tests/block_tests/test_decoders.py
@@ -1,0 +1,1331 @@
+"""Full decoder tests: per-family forward comparison + compose-from-primitives vs HF reference."""
+
+import torch
+import torch.nn.functional as F
+import pytest
+
+from helpers import seed_all, assert_close, make_profiles, rms_norm
+from gqa import gqa_attention_torch, gqa_attention_tt
+from mla import mla_attention_torch, mla_attention_tt
+from moe import moe_torch, moe_tt, moe_shared_experts_torch, moe_shared_experts_tt, sigmoid_topk_routing
+
+# ---------------------------------------------------------------------------
+# Dispatch: variant string → function implementations
+# ---------------------------------------------------------------------------
+
+IMPL = {
+    "torch": dict(
+        gqa=gqa_attention_torch,
+        mla=mla_attention_torch,
+        moe=moe_torch,
+        shared=moe_shared_experts_torch,
+    ),
+    "tt": dict(
+        gqa=gqa_attention_tt,
+        mla=mla_attention_tt,
+        moe=moe_tt,
+        shared=moe_shared_experts_tt,
+    ),
+}
+
+
+def fns(variant):
+    """Return (gqa_fn, mla_fn, moe_fn, shared_fn) for the given variant."""
+    d = IMPL[variant]
+    return d["gqa"], d["mla"], d["moe"], d["shared"]
+
+
+# ---------------------------------------------------------------------------
+# Weight construction
+# ---------------------------------------------------------------------------
+
+def _make_decoder_weights(prof, dtype=torch.float32):
+    h = prof["hidden_size"]
+    nq = prof["num_q_heads"]
+    nkv = prof["num_kv_heads"]
+    hd = prof["head_dim"]
+    ffn_i = prof["ffn_intermediate"]
+
+    w = {}
+
+    # Layer norms
+    w["ln1_weight"] = torch.ones(h, dtype=dtype)
+    w["ln1_bias"] = torch.zeros(h, dtype=dtype)
+    w["ln2_weight"] = torch.ones(h, dtype=dtype)
+    w["ln2_bias"] = torch.zeros(h, dtype=dtype)
+
+    # Attention weights
+    if prof["use_mla"]:
+        lat = prof["kv_latent_dim"]
+        w["attn"] = dict(
+            wq=torch.randn(nq * hd, h, dtype=dtype),
+            w_kv_down=torch.randn(lat, h, dtype=dtype),
+            w_k_up=torch.randn(nkv * hd, lat, dtype=dtype),
+            w_v_up=torch.randn(nkv * hd, lat, dtype=dtype),
+            wo=torch.randn(h, nq * hd, dtype=dtype),
+        )
+    else:
+        w["attn"] = dict(
+            wq=torch.randn(nq * hd, h, dtype=dtype),
+            wk=torch.randn(nkv * hd, h, dtype=dtype),
+            wv=torch.randn(nkv * hd, h, dtype=dtype),
+            wo=torch.randn(h, nq * hd, dtype=dtype),
+        )
+
+    # FFN weights
+    if prof["use_moe"]:
+        ne = prof["num_experts"]
+        mi = prof["moe_intermediate"]
+        w["ffn"] = dict(
+            w_router=torch.randn(ne, h, dtype=dtype),
+            w1=torch.randn(ne, mi, h, dtype=dtype),
+            w2=torch.randn(ne, h, mi, dtype=dtype),
+        )
+    else:
+        w["ffn"] = dict(
+            w1=torch.randn(ffn_i, h, dtype=dtype),
+            w2=torch.randn(h, ffn_i, dtype=dtype),
+        )
+
+    return w
+
+
+# ---------------------------------------------------------------------------
+# Decoder forward
+# ---------------------------------------------------------------------------
+
+def decoder_forward(hidden_states, profile, weights, variant="torch",
+                    attention_mask=None, past_key_value=None, use_cache=False):
+    """
+    Minimal decoder block: pre-norm -> attention -> residual -> pre-norm -> FFN -> residual.
+    """
+    gqa_fn, mla_fn, moe_fn, _ = fns(variant)
+    h = hidden_states
+
+    # Pre-norm + attention
+    normed = F.layer_norm(h, [profile["hidden_size"]],
+                          weight=weights["ln1_weight"], bias=weights["ln1_bias"])
+
+    attn_kwargs = dict(
+        num_q_heads=profile["num_q_heads"],
+        num_kv_heads=profile["num_kv_heads"],
+        attention_mask=attention_mask,
+        past_key_value=past_key_value,
+        use_cache=use_cache,
+    )
+
+    if profile["use_mla"]:
+        attn_out, present_kv = mla_fn(
+            normed, **weights["attn"],
+            kv_latent_dim=profile["kv_latent_dim"],
+            **attn_kwargs,
+        )
+    else:
+        attn_out, present_kv = gqa_fn(normed, **weights["attn"], **attn_kwargs)
+
+    h = h + attn_out
+
+    # Pre-norm + FFN
+    normed = F.layer_norm(h, [profile["hidden_size"]],
+                          weight=weights["ln2_weight"], bias=weights["ln2_bias"])
+
+    if profile["use_moe"]:
+        ffn_out = moe_fn(normed, **weights["ffn"], top_k=profile["top_k"])
+    else:
+        # Dense 2-linear MLP
+        ffn_out = F.silu(F.linear(normed, weights["ffn"]["w1"]))
+        ffn_out = F.linear(ffn_out, weights["ffn"]["w2"])
+
+    h = h + ffn_out
+    return h, present_kv
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_decoder_matches_hf_per_family():
+    seed_all(42)
+    profiles = make_profiles("tiny")
+    b, seq = 2, 6
+    for name, prof in profiles.items():
+        h = prof["hidden_size"]
+        x = torch.randn(b, seq, h)
+        weights = _make_decoder_weights(prof)
+
+        out_torch, _ = decoder_forward(x, prof, weights, variant="torch")
+        out_tt, _ = decoder_forward(x, prof, weights, variant="tt")
+        assert_close(out_torch, out_tt, atol=1e-5, rtol=1e-5), f"Failed for {name}"
+
+
+def test_decoder_cache_chunking_equivalence_per_family():
+    seed_all(123)
+    profiles = make_profiles("tiny")
+    b, seq = 1, 8
+    split = 4
+
+    for name, prof in profiles.items():
+        h = prof["hidden_size"]
+        x = torch.randn(b, seq, h)
+        weights = _make_decoder_weights(prof)
+
+        # Full forward with causal mask
+        causal_full = torch.tril(torch.ones(seq, seq, dtype=torch.bool)).unsqueeze(0).unsqueeze(0)
+        out_full, _ = decoder_forward(x, prof, weights, attention_mask=causal_full)
+
+        # Chunk 1
+        x1 = x[:, :split, :]
+        causal1 = torch.tril(torch.ones(split, split, dtype=torch.bool)).unsqueeze(0).unsqueeze(0)
+        out1, cache = decoder_forward(
+            x1, prof, weights, attention_mask=causal1, use_cache=True,
+        )
+
+        # Chunk 2
+        x2 = x[:, split:, :]
+        kv_len = seq
+        causal2 = torch.ones(seq - split, kv_len, dtype=torch.bool)
+        for i in range(seq - split):
+            causal2[i, split + i + 1:] = False
+        causal2 = causal2.unsqueeze(0).unsqueeze(0)
+        out2, _ = decoder_forward(
+            x2, prof, weights, attention_mask=causal2,
+            past_key_value=cache, use_cache=True,
+        )
+
+        out_chunked = torch.cat([out1, out2], dim=1)
+        assert_close(out_full, out_chunked, atol=1e-2, rtol=1e-2), f"Cache chunking failed for {name}"
+
+
+# ===========================================================================
+# Real HF model comparison tests
+# ===========================================================================
+
+# --- Helpers for manual forward replication ---
+
+
+
+# ---------------------------------------------------------------------------
+# Full DeepSeek V3 decoder layer composed from mla.py + moe.py functions
+# ---------------------------------------------------------------------------
+
+def _compose_deepseek_v3_forward(x, params, variant):
+    """
+    Compose a DeepSeek V3 decoder layer from primitives (MLA + MoE/dense FFN).
+    params: dict with all weights/config needed for the forward pass.
+    """
+    _, mla_fn, moe_fn, shared_fn = fns(variant)
+
+    h = x
+
+    # Input RMSNorm → MLA attention → residual
+    normed = rms_norm(h, params["ln1_weight"], params["eps"])
+    attn_out, _ = mla_fn(
+        normed,
+        wq=params["wq"], w_kv_down=params["w_kv_down"],
+        w_k_up=params["w_k_up"], w_v_up=params["w_v_up"],
+        wo=params["wo"],
+        num_q_heads=params["num_q_heads"],
+        num_kv_heads=params["num_kv_heads"],
+        kv_latent_dim=params["kv_latent_dim"],
+    )
+    h = h + attn_out
+
+    # Post-attention RMSNorm → FFN → residual
+    normed2 = rms_norm(h, params["ln2_weight"], params["eps"])
+
+    if params["is_dense"]:
+        ffn_out = shared_fn(
+            normed2,
+            w_gate=params["dense_gate"], w_up=params["dense_up"],
+            w_down=params["dense_down"],
+        )
+    else:
+        topk_indices, topk_weights = sigmoid_topk_routing(
+            normed2,
+            w_router=params["moe_router"],
+            top_k=params["top_k"],
+            n_group=params["n_group"],
+            topk_group=params["topk_group"],
+            e_score_correction_bias=params.get("e_score_correction_bias"),
+            routed_scaling_factor=params.get("routed_scaling_factor", 1.0),
+            norm_topk_prob=params.get("norm_topk_prob", False),
+        )
+        ffn_out = moe_fn(
+            normed2,
+            w_router=params["moe_router"], w1=params["moe_w1"],
+            w2=params["moe_w2"], w3=params["moe_w3"],
+            top_k=params["top_k"],
+            precomputed_routing=(topk_indices, topk_weights),
+        )
+        ffn_out = ffn_out + shared_fn(
+            normed2,
+            w_gate=params["shared_gate"], w_up=params["shared_up"],
+            w_down=params["shared_down"],
+        )
+
+    return h + ffn_out
+
+
+@torch.no_grad()
+@pytest.mark.parametrize("variant", IMPL.keys())
+def test_deepseek_v3_decoder_from_primitives(variant):
+    """
+    Compose a full DeepSeek V3 decoder layer from our primitive functions
+    (mla_attention_torch/hf from mla.py, moe_torch/hf + moe_shared_experts
+    from moe.py) and compare against the real HF DeepseekV3DecoderLayer.
+
+    Tests both dense (layer 0) and MoE (layer 1) decoder layers.
+    """
+    import torch.nn as nn
+    from transformers import DeepseekV3Config
+    from transformers.models.deepseek_v3.modeling_deepseek_v3 import (
+        DeepseekV3DecoderLayer,
+    )
+
+    head_dim = 8
+    config = DeepseekV3Config(
+        hidden_size=64,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        q_lora_rank=None,
+        kv_lora_rank=16,
+        qk_rope_head_dim=0,
+        qk_nope_head_dim=head_dim,
+        v_head_dim=head_dim,
+        intermediate_size=128,
+        moe_intermediate_size=32,
+        n_routed_experts=4,
+        num_experts_per_tok=2,
+        n_group=2,
+        topk_group=1,
+        first_k_dense_replace=1,  # layer 0 = dense, layer 1 = MoE
+        n_shared_experts=1,
+        num_hidden_layers=2,
+        attention_bias=False,
+        rms_norm_eps=1e-6,
+        max_position_embeddings=256,
+        attn_implementation="eager",
+    )
+
+    seed_all(42)
+    b, seq_len = 1, 4
+    x = torch.randn(b, seq_len, config.hidden_size)
+    num_heads = config.num_attention_heads
+    cos = torch.empty(b, seq_len, 0)
+    sin = torch.empty(b, seq_len, 0)
+    label = variant
+
+    for layer_idx in [0, 1]:
+        layer = DeepseekV3DecoderLayer(config, layer_idx=layer_idx)
+        layer.eval()
+        layer.self_attn.kv_a_layernorm = nn.Identity()
+
+        # 1) HF reference
+        hf_out = layer(x, position_embeddings=(cos, sin))
+
+        # 2) Collect params/weights
+        attn = layer.self_attn
+        kv_b_w = attn.kv_b_proj.weight.data
+        kv_b_reshaped = kv_b_w.view(num_heads, head_dim + head_dim, config.kv_lora_rank)
+        w_k_up = kv_b_reshaped[:, :head_dim, :].reshape(num_heads * head_dim, config.kv_lora_rank)
+        w_v_up = kv_b_reshaped[:, head_dim:, :].reshape(num_heads * head_dim, config.kv_lora_rank)
+
+        is_dense = layer_idx < config.first_k_dense_replace
+        params = dict(
+            eps=config.rms_norm_eps,
+            ln1_weight=layer.input_layernorm.weight.data,
+            ln2_weight=layer.post_attention_layernorm.weight.data,
+            wq=attn.q_proj.weight.data,
+            w_kv_down=attn.kv_a_proj_with_mqa.weight.data,
+            w_k_up=w_k_up, w_v_up=w_v_up,
+            wo=attn.o_proj.weight.data,
+            num_q_heads=num_heads,
+            num_kv_heads=config.num_key_value_heads,
+            kv_latent_dim=config.kv_lora_rank,
+            is_dense=is_dense,
+        )
+
+        if is_dense:
+            mlp = layer.mlp
+            params.update(
+                dense_gate=mlp.gate_proj.weight.data,
+                dense_up=mlp.up_proj.weight.data,
+                dense_down=mlp.down_proj.weight.data,
+            )
+        else:
+            moe_mod = layer.mlp
+            ne = config.n_routed_experts
+            params.update(
+                moe_router=moe_mod.gate.weight.data,
+                moe_w1=torch.stack([moe_mod.experts[e].gate_proj.weight.data for e in range(ne)]),
+                moe_w3=torch.stack([moe_mod.experts[e].up_proj.weight.data for e in range(ne)]),
+                moe_w2=torch.stack([moe_mod.experts[e].down_proj.weight.data for e in range(ne)]),
+                top_k=config.num_experts_per_tok,
+                n_group=config.n_group,
+                topk_group=config.topk_group,
+                e_score_correction_bias=moe_mod.gate.e_score_correction_bias,
+                routed_scaling_factor=config.routed_scaling_factor,
+                norm_topk_prob=config.norm_topk_prob,
+                shared_gate=moe_mod.shared_experts.gate_proj.weight.data,
+                shared_up=moe_mod.shared_experts.up_proj.weight.data,
+                shared_down=moe_mod.shared_experts.down_proj.weight.data,
+            )
+
+        # 3) Run composed forward
+        h = _compose_deepseek_v3_forward(x, params, variant)
+
+        # 4) Compare
+        assert_close(hf_out, h, atol=1e-4, rtol=1e-4), (
+            f"DeepSeek V3 ({label}): composed vs real HF "
+            f"layer_idx={layer_idx} mismatch"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Full Kimi K2.5 decoder layer composed from mla.py + moe.py functions
+# ---------------------------------------------------------------------------
+
+@torch.no_grad()
+@pytest.mark.parametrize("variant", IMPL.keys())
+def test_kimi_k25_decoder_from_primitives(variant):
+    """Compose Kimi K2.5 decoder (DeepSeek V3 architecture with different params)."""
+    import torch.nn as nn
+    from transformers import DeepseekV3Config
+    from transformers.models.deepseek_v3.modeling_deepseek_v3 import (
+        DeepseekV3DecoderLayer,
+    )
+
+    head_dim = 8
+    config = DeepseekV3Config(
+        hidden_size=64, num_attention_heads=4, num_key_value_heads=4,
+        q_lora_rank=None, kv_lora_rank=16, qk_rope_head_dim=0,
+        qk_nope_head_dim=head_dim, v_head_dim=head_dim,
+        intermediate_size=128, moe_intermediate_size=32,
+        n_routed_experts=4, num_experts_per_tok=2,
+        n_group=1, topk_group=1, routed_scaling_factor=2.827,
+        first_k_dense_replace=1, n_shared_experts=1,
+        num_hidden_layers=2, attention_bias=False,
+        rms_norm_eps=1e-5, rope_theta=50000.0,
+        max_position_embeddings=256, attn_implementation="eager",
+    )
+
+    seed_all(77)
+    b, seq_len = 1, 4
+    x = torch.randn(b, seq_len, config.hidden_size)
+    num_heads = config.num_attention_heads
+    cos = torch.empty(b, seq_len, 0)
+    sin = torch.empty(b, seq_len, 0)
+    label = variant
+
+    for layer_idx in [0, 1]:
+        layer = DeepseekV3DecoderLayer(config, layer_idx=layer_idx)
+        layer.eval()
+        layer.self_attn.kv_a_layernorm = nn.Identity()
+
+        # 1) HF reference
+        hf_out = layer(x, position_embeddings=(cos, sin))
+
+        # 2) Collect params
+        attn = layer.self_attn
+        kv_b_w = attn.kv_b_proj.weight.data
+        kv_b_reshaped = kv_b_w.view(num_heads, head_dim + head_dim, config.kv_lora_rank)
+        w_k_up = kv_b_reshaped[:, :head_dim, :].reshape(num_heads * head_dim, config.kv_lora_rank)
+        w_v_up = kv_b_reshaped[:, head_dim:, :].reshape(num_heads * head_dim, config.kv_lora_rank)
+
+        is_dense = layer_idx < config.first_k_dense_replace
+        params = dict(
+            eps=config.rms_norm_eps,
+            ln1_weight=layer.input_layernorm.weight.data,
+            ln2_weight=layer.post_attention_layernorm.weight.data,
+            wq=attn.q_proj.weight.data,
+            w_kv_down=attn.kv_a_proj_with_mqa.weight.data,
+            w_k_up=w_k_up, w_v_up=w_v_up,
+            wo=attn.o_proj.weight.data,
+            num_q_heads=num_heads,
+            num_kv_heads=config.num_key_value_heads,
+            kv_latent_dim=config.kv_lora_rank,
+            is_dense=is_dense,
+        )
+
+        if is_dense:
+            mlp = layer.mlp
+            params.update(
+                dense_gate=mlp.gate_proj.weight.data,
+                dense_up=mlp.up_proj.weight.data,
+                dense_down=mlp.down_proj.weight.data,
+            )
+        else:
+            moe_mod = layer.mlp
+            ne = config.n_routed_experts
+            params.update(
+                moe_router=moe_mod.gate.weight.data,
+                moe_w1=torch.stack([moe_mod.experts[e].gate_proj.weight.data for e in range(ne)]),
+                moe_w3=torch.stack([moe_mod.experts[e].up_proj.weight.data for e in range(ne)]),
+                moe_w2=torch.stack([moe_mod.experts[e].down_proj.weight.data for e in range(ne)]),
+                top_k=config.num_experts_per_tok,
+                n_group=config.n_group,
+                topk_group=config.topk_group,
+                e_score_correction_bias=moe_mod.gate.e_score_correction_bias,
+                routed_scaling_factor=config.routed_scaling_factor,
+                norm_topk_prob=config.norm_topk_prob,
+                shared_gate=moe_mod.shared_experts.gate_proj.weight.data,
+                shared_up=moe_mod.shared_experts.up_proj.weight.data,
+                shared_down=moe_mod.shared_experts.down_proj.weight.data,
+            )
+
+        # 3) Run composed forward
+        h = _compose_deepseek_v3_forward(x, params, variant)
+
+        # 4) Compare
+        assert_close(hf_out, h, atol=1e-4, rtol=1e-4), (
+            f"Kimi K2.5 ({label}): composed vs real HF "
+            f"layer_idx={layer_idx} mismatch"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Full GLM-4 decoder layer composed from gqa.py + moe.py functions
+# ---------------------------------------------------------------------------
+
+@torch.no_grad()
+@pytest.mark.parametrize("variant", IMPL.keys())
+def test_glm4_decoder_from_primitives(variant):
+    """
+    Compose a full GLM-4 decoder layer from our primitive functions.
+
+    GLM-4 structure (4x RMSNorm):
+    1) input_layernorm → attention
+    2) post_self_attn_layernorm(attn_out) → residual
+    3) post_attention_layernorm → SwiGLU MLP
+    4) post_mlp_layernorm(mlp_out) → residual
+    """
+    from transformers import Glm4Config
+    from transformers.models.glm4.modeling_glm4 import (
+        Glm4DecoderLayer,
+        Glm4RotaryEmbedding,
+    )
+
+    config = Glm4Config(
+        hidden_size=64,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        intermediate_size=128,
+        partial_rotary_factor=0.5,
+        attention_bias=False,
+        rms_norm_eps=1e-6,
+        max_position_embeddings=256,
+        rope_theta=10000.0,
+        num_hidden_layers=2,
+        attn_implementation="eager",
+    )
+
+    seed_all(42)
+    b, seq_len = 1, 4
+    x = torch.randn(b, seq_len, config.hidden_size)
+
+    layer = Glm4DecoderLayer(config, layer_idx=0)
+    layer.eval()
+
+    rotary = Glm4RotaryEmbedding(config)
+    position_ids = torch.zeros(b, seq_len, dtype=torch.long)
+    cos, sin = rotary(x, position_ids)
+
+    # 1) HF reference
+    hf_out = layer(x, position_embeddings=(cos, sin))
+
+    # 2) Collect params (GLM-4 has fused gate_up_proj and 4 RMSNorms)
+    attn = layer.self_attn
+    mlp = layer.mlp
+    intermediate = config.intermediate_size
+    gate_up_w = mlp.gate_up_proj.weight.data
+    params = dict(
+        eps=config.rms_norm_eps,
+        ln1_weight=layer.input_layernorm.weight.data,
+        ln_post_attn=layer.post_self_attn_layernorm.weight.data,
+        ln2_weight=layer.post_attention_layernorm.weight.data,
+        ln_post_mlp=layer.post_mlp_layernorm.weight.data,
+        gqa_kwargs=dict(
+            wq=attn.q_proj.weight.data, wk=attn.k_proj.weight.data,
+            wv=attn.v_proj.weight.data, wo=attn.o_proj.weight.data,
+            num_q_heads=config.num_attention_heads,
+            num_kv_heads=config.num_key_value_heads,
+        ),
+        dense_gate=gate_up_w[:intermediate, :],
+        dense_up=gate_up_w[intermediate:, :],
+        dense_down=mlp.down_proj.weight.data,
+    )
+
+    # 3) Run composed forward
+    h = _compose_glm4_forward(x, params, variant)
+
+    # 4) Compare
+    label = variant
+    assert_close(hf_out, h, atol=1e-4, rtol=1e-4), \
+        f"GLM-4 ({label}): composed vs real HF GLM-4 mismatch"
+
+
+# ---------------------------------------------------------------------------
+# Full GPT-OSS 120B decoder layer composed from gqa.py + moe.py functions
+#   (using Mixtral as real HF reference — same GQA + MoE architecture)
+# ---------------------------------------------------------------------------
+
+@torch.no_grad()
+@pytest.mark.parametrize("variant", IMPL.keys())
+def test_gpt_oss_decoder_from_primitives(variant):
+    """
+    GPT-OSS 120B uses GQA + MoE (Mixtral as HF proxy).
+    """
+    from transformers import MixtralConfig
+    from transformers.models.mixtral.modeling_mixtral import (
+        MixtralDecoderLayer,
+        MixtralRotaryEmbedding,
+    )
+
+    config = MixtralConfig(
+        hidden_size=64, num_attention_heads=4, num_key_value_heads=2,
+        head_dim=16, intermediate_size=128, num_local_experts=4,
+        num_experts_per_tok=2, rms_norm_eps=1e-6, max_position_embeddings=256,
+        rope_theta=10000.0, num_hidden_layers=2, router_jitter_noise=0.0,
+        attn_implementation="eager",
+    )
+
+    seed_all(42)
+    b, seq_len = 1, 4
+    x = torch.randn(b, seq_len, config.hidden_size)
+
+    layer = MixtralDecoderLayer(config, layer_idx=0)
+    layer.eval()
+
+    rotary = MixtralRotaryEmbedding(config)
+    position_ids = torch.zeros(b, seq_len, dtype=torch.long)
+    cos, sin = rotary(x, position_ids)
+
+    # 1) HF reference
+    hf_out = layer(x, position_embeddings=(cos, sin))
+
+    # 2) Collect params
+    attn = layer.self_attn
+    moe_mod = layer.block_sparse_moe
+    ne = config.num_local_experts
+    w1, w2, w3 = _extract_mixtral_expert_weights(moe_mod.experts, ne)
+    params = dict(
+        eps=config.rms_norm_eps,
+        ln1_weight=layer.input_layernorm.weight.data,
+        ln2_weight=layer.post_attention_layernorm.weight.data,
+        gqa_kwargs=dict(
+            wq=attn.q_proj.weight.data, wk=attn.k_proj.weight.data,
+            wv=attn.v_proj.weight.data, wo=attn.o_proj.weight.data,
+            num_q_heads=config.num_attention_heads,
+            num_kv_heads=config.num_key_value_heads,
+        ),
+        moe_router=moe_mod.gate.weight.data,
+        moe_w1=w1, moe_w2=w2, moe_w3=w3,
+        top_k=config.num_experts_per_tok,
+    )
+
+    # 3) Run composed forward
+    h = _compose_gqa_moe_forward(x, params, variant)
+
+    # 4) Compare
+    label = variant
+    assert_close(hf_out, h, atol=1e-4, rtol=1e-4), \
+        f"GPT-OSS 120B ({label}): composed vs real HF Mixtral proxy mismatch"
+
+
+# ===========================================================================
+# Helpers for composed decoder tests
+# ===========================================================================
+
+def _softmax_topk_routing(normed, gate_weight, top_k, normalize=True):
+    """Extract softmax→topk→renormalize routing (Mixtral/Qwen3Moe/OLMoE pattern)."""
+    flat = normed.reshape(-1, normed.shape[-1])
+    router_logits = F.linear(flat, gate_weight)
+    routing_weights = F.softmax(router_logits, dim=1, dtype=torch.float)
+    routing_weights, topk_indices = torch.topk(routing_weights, top_k, dim=-1)
+    if normalize:
+        routing_weights /= routing_weights.sum(dim=-1, keepdim=True)
+    routing_weights = routing_weights.to(flat.dtype)
+    return topk_indices, routing_weights
+
+
+def _extract_swiglu_expert_weights(experts, ne, attr_gate="gate_proj", attr_up="up_proj", attr_down="down_proj"):
+    """Extract SwiGLU weights from HF expert modules (gate/up/down naming)."""
+    w1 = torch.stack([getattr(experts[e], attr_gate).weight.data for e in range(ne)])
+    w3 = torch.stack([getattr(experts[e], attr_up).weight.data for e in range(ne)])
+    w2 = torch.stack([getattr(experts[e], attr_down).weight.data for e in range(ne)])
+    return w1, w2, w3
+
+
+def _extract_mixtral_expert_weights(experts, ne):
+    """Extract SwiGLU weights from Mixtral-style experts (w1/w3/w2 naming)."""
+    w1 = torch.stack([experts[e].w1.weight.data for e in range(ne)])
+    w3 = torch.stack([experts[e].w3.weight.data for e in range(ne)])
+    w2 = torch.stack([experts[e].w2.weight.data for e in range(ne)])
+    return w1, w2, w3
+
+
+def _collect_gqa_dense_params(layer, config):
+    """Extract params dict from a Llama/Qwen-style GQA + dense SwiGLU layer."""
+    attn = layer.self_attn
+    mlp = layer.mlp
+    return dict(
+        eps=config.rms_norm_eps,
+        ln1_weight=layer.input_layernorm.weight.data,
+        ln2_weight=layer.post_attention_layernorm.weight.data,
+        gqa_kwargs=dict(
+            wq=attn.q_proj.weight.data, wk=attn.k_proj.weight.data,
+            wv=attn.v_proj.weight.data, wo=attn.o_proj.weight.data,
+            num_q_heads=config.num_attention_heads,
+            num_kv_heads=config.num_key_value_heads,
+        ),
+        dense_gate=mlp.gate_proj.weight.data,
+        dense_up=mlp.up_proj.weight.data,
+        dense_down=mlp.down_proj.weight.data,
+    )
+
+
+def _compose_gqa_dense_forward(x, params, variant):
+    """Compose GQA + dense SwiGLU decoder (Llama/Qwen2 pattern, 2 RMSNorms)."""
+    gqa_fn, _, _, shared_fn = fns(variant)
+
+    h = x
+    normed = rms_norm(h, params["ln1_weight"], params["eps"])
+    attn_out, _ = gqa_fn(normed, **params["gqa_kwargs"])
+    h = h + attn_out
+
+    normed2 = rms_norm(h, params["ln2_weight"], params["eps"])
+    ffn_out = shared_fn(
+        normed2,
+        w_gate=params["dense_gate"], w_up=params["dense_up"],
+        w_down=params["dense_down"],
+    )
+    return h + ffn_out
+
+
+def _compose_glm4_forward(x, params, variant):
+    """Compose GLM-4 decoder (GQA + dense SwiGLU, 4 RMSNorms with post-attn/post-mlp norms)."""
+    gqa_fn, _, _, shared_fn = fns(variant)
+
+    h = x
+    normed = rms_norm(h, params["ln1_weight"], params["eps"])
+    attn_out, _ = gqa_fn(normed, **params["gqa_kwargs"])
+    attn_out = rms_norm(attn_out, params["ln_post_attn"], params["eps"])
+    h = h + attn_out
+
+    normed2 = rms_norm(h, params["ln2_weight"], params["eps"])
+    mlp_out = shared_fn(
+        normed2,
+        w_gate=params["dense_gate"], w_up=params["dense_up"],
+        w_down=params["dense_down"],
+    )
+    mlp_out = rms_norm(mlp_out, params["ln_post_mlp"], params["eps"])
+    return h + mlp_out
+
+
+def _compose_gqa_moe_forward(x, params, variant):
+    """Compose GQA + softmax MoE decoder (Mixtral/OLMoE/Qwen3Moe pattern, 2 RMSNorms)."""
+    gqa_fn, _, moe_fn, _ = fns(variant)
+
+    h = x
+    normed = rms_norm(h, params["ln1_weight"], params["eps"])
+    attn_out, _ = gqa_fn(normed, **params["gqa_kwargs"])
+    h = h + attn_out
+
+    normed2 = rms_norm(h, params["ln2_weight"], params["eps"])
+    topk_idx, rw = _softmax_topk_routing(
+        normed2, params["moe_router"], params["top_k"],
+        normalize=params.get("normalize_routing", True),
+    )
+    ffn_out = moe_fn(
+        normed2, w_router=params["moe_router"],
+        w1=params["moe_w1"], w2=params["moe_w2"], w3=params["moe_w3"],
+        top_k=params["top_k"],
+        precomputed_routing=(topk_idx, rw),
+    )
+    return h + ffn_out
+
+
+def _compose_minimax_forward(x, params, variant):
+    """Compose MiniMax decoder (GQA + MoE with weighted residual)."""
+    gqa_fn, _, moe_fn, _ = fns(variant)
+
+    normed = rms_norm(x, params["ln1_weight"], params["eps"])
+    attn_out, _ = gqa_fn(normed, **params["gqa_kwargs"])
+    h = normed * params["alpha_attn"] + attn_out * params["beta_attn"]
+
+    normed2 = rms_norm(h, params["ln2_weight"], params["eps"])
+    topk_idx, rw = _softmax_topk_routing(
+        normed2, params["moe_router"], params["top_k"])
+    moe_out = moe_fn(
+        normed2, w_router=params["moe_router"],
+        w1=params["moe_w1"], w2=params["moe_w2"], w3=params["moe_w3"],
+        top_k=params["top_k"],
+        precomputed_routing=(topk_idx, rw),
+    )
+    return normed2 * params["alpha_mlp"] + moe_out * params["beta_mlp"]
+
+
+def _compose_llama4_forward(x, params, variant):
+    """Compose Llama4 decoder (GQA + sigmoid MoE with shared expert, scale_input)."""
+    gqa_fn, _, moe_fn, shared_fn = fns(variant)
+
+    h = x
+    normed = rms_norm(h, params["ln1_weight"], params["eps"])
+    attn_out, _ = gqa_fn(normed, **params["gqa_kwargs"])
+    h = h + attn_out
+
+    normed2 = rms_norm(h, params["ln2_weight"], params["eps"])
+
+    # Llama4 sigmoid routing: topk → sigmoid
+    flat = normed2.reshape(-1, normed2.shape[-1])
+    router_logits = F.linear(flat, params["moe_router"])
+    router_top_value, topk_indices = torch.topk(
+        router_logits, params["top_k"], dim=1)
+    routing_weights = torch.sigmoid(router_top_value.float()).to(flat.dtype)
+
+    ffn_out = moe_fn(
+        normed2, w_router=params["moe_router"],
+        w1=params["moe_w1"], w2=params["moe_w2"], w3=params["moe_w3"],
+        top_k=params["top_k"],
+        precomputed_routing=(topk_indices, routing_weights),
+        scale_input=True,
+    )
+    ffn_out = ffn_out + shared_fn(
+        normed2,
+        w_gate=params["shared_gate"], w_up=params["shared_up"],
+        w_down=params["shared_down"],
+    )
+    return h + ffn_out
+
+
+# ===========================================================================
+# Llama-architecture decoders (GQA + dense SwiGLU, 2 RMSNorms)
+#   GPT-OSS 20B, GPT-OSS Safeguard 20B, Llama Guard 4, Llama 3.1, Llama 3.3
+# ===========================================================================
+
+@torch.no_grad()
+@pytest.mark.parametrize("variant", IMPL.keys())
+@pytest.mark.parametrize("model_name,config_overrides,seed", [
+    ("GPT-OSS 20B", None, 42),
+    ("GPT-OSS Safeguard 20B", dict(rope_theta=500000.0), 43),
+    ("Llama Guard 4 12B", dict(rope_theta=500000.0), 44),
+    ("Llama 3.1 8B", dict(rope_theta=500000.0), 45),
+    ("Llama 3.3 70B", dict(num_key_value_heads=4, rope_theta=500000.0), 46),
+], ids=["gpt_oss_20b", "gpt_oss_safeguard_20b", "llama_guard4", "llama3_1_8b", "llama3_3_70b"])
+def test_llama_decoder_from_primitives(variant, model_name, config_overrides, seed):
+    from transformers import LlamaConfig
+    from transformers.models.llama.modeling_llama import (
+        LlamaDecoderLayer,
+        LlamaRotaryEmbedding,
+    )
+
+    base_kwargs = dict(
+        hidden_size=64, num_attention_heads=4, num_key_value_heads=2,
+        head_dim=16, intermediate_size=128, rms_norm_eps=1e-6,
+        max_position_embeddings=256, rope_theta=10000.0,
+        num_hidden_layers=2, attn_implementation="eager",
+    )
+    if config_overrides:
+        base_kwargs.update(config_overrides)
+
+    config = LlamaConfig(**base_kwargs)
+    seed_all(seed)
+    b, seq_len = 1, 4
+    x = torch.randn(b, seq_len, config.hidden_size)
+
+    layer = LlamaDecoderLayer(config, layer_idx=0)
+    layer.eval()
+
+    rotary = LlamaRotaryEmbedding(config)
+    position_ids = torch.zeros(b, seq_len, dtype=torch.long)
+    cos, sin = rotary(x, position_ids)
+
+    # 1) HF reference
+    hf_out = layer(x, position_embeddings=(cos, sin))
+
+    # 2) Collect params
+    params = _collect_gqa_dense_params(layer, config)
+
+    # 3) Run composed forward
+    h = _compose_gqa_dense_forward(x, params, variant)
+
+    # 4) Compare
+    label = variant
+    assert_close(hf_out, h, atol=1e-4, rtol=1e-4), \
+        f"{model_name} ({label}): composed vs real HF Llama mismatch"
+
+
+@torch.no_grad()
+@pytest.mark.parametrize("variant", IMPL.keys())
+def test_grok2_decoder_from_primitives(variant):
+    """Grok 2 270B uses GQA + MoE (Mixtral as HF proxy)."""
+    from transformers import MixtralConfig
+    from transformers.models.mixtral.modeling_mixtral import (
+        MixtralDecoderLayer,
+        MixtralRotaryEmbedding,
+    )
+
+    config = MixtralConfig(
+        hidden_size=64, num_attention_heads=4, num_key_value_heads=2,
+        head_dim=16, intermediate_size=128, num_local_experts=8,
+        num_experts_per_tok=2, rms_norm_eps=1e-6, max_position_embeddings=256,
+        rope_theta=10000.0, num_hidden_layers=2, router_jitter_noise=0.0,
+        attn_implementation="eager",
+    )
+
+    seed_all(55)
+    b, seq_len = 1, 4
+    x = torch.randn(b, seq_len, config.hidden_size)
+
+    layer = MixtralDecoderLayer(config, layer_idx=0)
+    layer.eval()
+
+    rotary = MixtralRotaryEmbedding(config)
+    position_ids = torch.zeros(b, seq_len, dtype=torch.long)
+    cos, sin = rotary(x, position_ids)
+
+    # 1) HF reference
+    hf_out = layer(x, position_embeddings=(cos, sin))
+
+    # 2) Collect params
+    attn = layer.self_attn
+    moe_mod = layer.block_sparse_moe
+    w1, w2, w3 = _extract_mixtral_expert_weights(moe_mod.experts, config.num_local_experts)
+    params = dict(
+        eps=config.rms_norm_eps,
+        ln1_weight=layer.input_layernorm.weight.data,
+        ln2_weight=layer.post_attention_layernorm.weight.data,
+        gqa_kwargs=dict(
+            wq=attn.q_proj.weight.data, wk=attn.k_proj.weight.data,
+            wv=attn.v_proj.weight.data, wo=attn.o_proj.weight.data,
+            num_q_heads=config.num_attention_heads,
+            num_kv_heads=config.num_key_value_heads,
+        ),
+        moe_router=moe_mod.gate.weight.data,
+        moe_w1=w1, moe_w2=w2, moe_w3=w3,
+        top_k=config.num_experts_per_tok,
+    )
+
+    # 3) Run composed forward
+    h = _compose_gqa_moe_forward(x, params, variant)
+
+    # 4) Compare
+    label = variant
+    assert_close(hf_out, h, atol=1e-4, rtol=1e-4), \
+        f"Grok 2 ({label}): composed vs real HF Mixtral proxy mismatch"
+
+
+# ---------------------------------------------------------------------------
+# Llama4 Maverick / Scout — GQA + MoE (sigmoid routing, shared expert)
+# ---------------------------------------------------------------------------
+
+@torch.no_grad()
+@pytest.mark.parametrize("variant", IMPL.keys())
+@pytest.mark.parametrize("model_name,config_overrides,seed", [
+    ("Llama4 Maverick 17Bx128E", dict(num_local_experts=4), 50),
+    ("Llama4 Scout 17Bx16E", dict(num_local_experts=4), 51),
+], ids=["maverick", "scout"])
+def test_llama4_decoder_from_primitives(variant, model_name, config_overrides, seed):
+    """Compose Llama4 decoder (GQA + sigmoid MoE + shared expert, scale_input)."""
+    from transformers.models.llama4.configuration_llama4 import Llama4TextConfig
+    from transformers.models.llama4.modeling_llama4 import (
+        Llama4TextDecoderLayer,
+    )
+
+    base_kwargs = dict(
+        hidden_size=64, num_attention_heads=4, num_key_value_heads=2,
+        head_dim=16, intermediate_size=64, intermediate_size_mlp=128,
+        num_hidden_layers=2, num_local_experts=4, num_experts_per_tok=1,
+        moe_layers=[0, 1], layer_types=["full_attention", "full_attention"],
+        no_rope_layers=[0, 0],
+        use_qk_norm=False, attn_temperature_tuning=False,
+        rms_norm_eps=1e-6, max_position_embeddings=256,
+        rope_theta=500000.0, router_jitter_noise=0.0,
+        attn_implementation="eager",
+    )
+    if config_overrides:
+        base_kwargs.update(config_overrides)
+
+    config = Llama4TextConfig(**base_kwargs)
+    seed_all(seed)
+    b, seq_len = 1, 4
+    x = torch.randn(b, seq_len, config.hidden_size)
+
+    layer = Llama4TextDecoderLayer(config, layer_idx=0)
+    with torch.no_grad():
+        layer.feed_forward.experts.gate_up_proj.data.normal_()
+        layer.feed_forward.experts.down_proj.data.normal_()
+    layer.eval()
+
+    # 1) HF reference
+    hf_out = layer(x, position_embeddings=None)
+
+    # 2) Collect params
+    attn = layer.self_attn
+    moe_mod = layer.feed_forward
+    mi = config.intermediate_size
+    shared = moe_mod.shared_expert
+    params = dict(
+        eps=config.rms_norm_eps,
+        ln1_weight=layer.input_layernorm.weight.data,
+        ln2_weight=layer.post_attention_layernorm.weight.data,
+        gqa_kwargs=dict(
+            wq=attn.q_proj.weight.data, wk=attn.k_proj.weight.data,
+            wv=attn.v_proj.weight.data, wo=attn.o_proj.weight.data,
+            num_q_heads=config.num_attention_heads,
+            num_kv_heads=config.num_key_value_heads,
+        ),
+        moe_router=moe_mod.router.weight.data,
+        moe_w1=moe_mod.experts.gate_up_proj.data[:, :, :mi].permute(0, 2, 1),
+        moe_w3=moe_mod.experts.gate_up_proj.data[:, :, mi:].permute(0, 2, 1),
+        moe_w2=moe_mod.experts.down_proj.data.permute(0, 2, 1),
+        top_k=config.num_experts_per_tok,
+        shared_gate=shared.gate_proj.weight.data,
+        shared_up=shared.up_proj.weight.data,
+        shared_down=shared.down_proj.weight.data,
+    )
+
+    # 3) Run composed forward
+    h = _compose_llama4_forward(x, params, variant)
+
+    # 4) Compare
+    label = variant
+    assert_close(hf_out, h, atol=1e-4, rtol=1e-4), \
+        f"{model_name} ({label}): composed vs real HF Llama4 mismatch"
+
+
+# ---------------------------------------------------------------------------
+# MiniMax M25 — GQA + MoE (weighted residual, full_attention mode)
+# ---------------------------------------------------------------------------
+
+@torch.no_grad()
+@pytest.mark.parametrize("variant", IMPL.keys())
+def test_minimax_m25_decoder_from_primitives(variant):
+    """Compose MiniMax M25 decoder (GQA + MoE with weighted residual)."""
+    from transformers import MiniMaxConfig
+    from transformers.models.minimax.modeling_minimax import (
+        MiniMaxDecoderLayer,
+        MiniMaxRotaryEmbedding,
+    )
+
+    config = MiniMaxConfig(
+        hidden_size=64, num_attention_heads=4, num_key_value_heads=2,
+        intermediate_size=128, num_local_experts=4, num_experts_per_tok=2,
+        rms_norm_eps=1e-6, max_position_embeddings=256, rope_theta=10000.0,
+        num_hidden_layers=2, router_jitter_noise=0.0,
+        layer_types=["full_attention", "full_attention"],
+        full_attn_alpha_factor=1, full_attn_beta_factor=1,
+        mlp_alpha_factor=1, mlp_beta_factor=1,
+        attn_implementation="eager",
+    )
+
+    seed_all(60)
+    b, seq_len = 1, 4
+    x = torch.randn(b, seq_len, config.hidden_size)
+
+    layer = MiniMaxDecoderLayer(config, layer_idx=0)
+    layer.eval()
+
+    rotary = MiniMaxRotaryEmbedding(config)
+    position_ids = torch.zeros(b, seq_len, dtype=torch.long)
+    cos, sin = rotary(x, position_ids)
+
+    # 1) HF reference
+    hf_out = layer(x, position_embeddings=(cos, sin))
+
+    # 2) Collect params
+    attn = layer.self_attn
+    moe_mod = layer.block_sparse_moe
+    w1, w2, w3 = _extract_mixtral_expert_weights(moe_mod.experts, config.num_local_experts)
+    params = dict(
+        eps=config.rms_norm_eps,
+        ln1_weight=layer.input_layernorm.weight.data,
+        ln2_weight=layer.post_attention_layernorm.weight.data,
+        gqa_kwargs=dict(
+            wq=attn.q_proj.weight.data, wk=attn.k_proj.weight.data,
+            wv=attn.v_proj.weight.data, wo=attn.o_proj.weight.data,
+            num_q_heads=config.num_attention_heads,
+            num_kv_heads=config.num_key_value_heads,
+        ),
+        moe_router=moe_mod.gate.weight.data,
+        moe_w1=w1, moe_w2=w2, moe_w3=w3,
+        top_k=config.num_experts_per_tok,
+        alpha_attn=layer.attn_alpha_factor,
+        beta_attn=layer.attn_beta_factor,
+        alpha_mlp=layer.mlp_alpha_factor,
+        beta_mlp=layer.mlp_beta_factor,
+    )
+
+    # 3) Run composed forward
+    h = _compose_minimax_forward(x, params, variant)
+
+    # 4) Compare
+    label = variant
+    assert_close(hf_out, h, atol=1e-4, rtol=1e-4), \
+        f"MiniMax M25 ({label}): composed vs real HF MiniMax mismatch"
+
+
+# ---------------------------------------------------------------------------
+# OLMoE 1B-7B — GQA (QK norm→Identity) + MoE (softmax routing)
+# ---------------------------------------------------------------------------
+
+@torch.no_grad()
+@pytest.mark.parametrize("variant", IMPL.keys())
+def test_olmoe_decoder_from_primitives(variant):
+    """Compose OLMoE decoder (GQA with QK norm→Identity + softmax MoE)."""
+    import torch.nn as nn
+    from transformers import OlmoeConfig
+    from transformers.models.olmoe.modeling_olmoe import (
+        OlmoeDecoderLayer,
+        OlmoeRotaryEmbedding,
+    )
+
+    config = OlmoeConfig(
+        hidden_size=64, num_attention_heads=4, num_key_value_heads=2,
+        head_dim=16, intermediate_size=128, num_experts=4,
+        num_experts_per_tok=2, norm_topk_prob=True,
+        attention_bias=False, rms_norm_eps=1e-6,
+        max_position_embeddings=256, rope_theta=10000.0,
+        num_hidden_layers=2, attn_implementation="eager",
+    )
+
+    seed_all(65)
+    b, seq_len = 1, 4
+    x = torch.randn(b, seq_len, config.hidden_size)
+
+    layer = OlmoeDecoderLayer(config, layer_idx=0)
+    layer.eval()
+    layer.self_attn.q_norm = nn.Identity()
+    layer.self_attn.k_norm = nn.Identity()
+
+    rotary = OlmoeRotaryEmbedding(config)
+    position_ids = torch.zeros(b, seq_len, dtype=torch.long)
+    cos, sin = rotary(x, position_ids)
+
+    # 1) HF reference
+    hf_out = layer(x, position_embeddings=(cos, sin))[0]
+
+    # 2) Collect params
+    attn = layer.self_attn
+    moe_mod = layer.mlp
+    w1, w2, w3 = _extract_swiglu_expert_weights(moe_mod.experts, config.num_experts)
+    params = dict(
+        eps=config.rms_norm_eps,
+        ln1_weight=layer.input_layernorm.weight.data,
+        ln2_weight=layer.post_attention_layernorm.weight.data,
+        gqa_kwargs=dict(
+            wq=attn.q_proj.weight.data, wk=attn.k_proj.weight.data,
+            wv=attn.v_proj.weight.data, wo=attn.o_proj.weight.data,
+            num_q_heads=config.num_attention_heads,
+            num_kv_heads=config.num_key_value_heads,
+        ),
+        moe_router=moe_mod.gate.weight.data,
+        moe_w1=w1, moe_w2=w2, moe_w3=w3,
+        top_k=config.num_experts_per_tok,
+        normalize_routing=config.norm_topk_prob,
+    )
+
+    # 3) Run composed forward
+    h = _compose_gqa_moe_forward(x, params, variant)
+
+    # 4) Compare
+    label = variant
+    assert_close(hf_out, h, atol=1e-4, rtol=1e-4), \
+        f"OLMoE ({label}): composed vs real HF OLMoE mismatch"
+
+
+# ---------------------------------------------------------------------------
+# Qwen2.5-0.5B — GQA (attention bias→zeroed) + dense SwiGLU
+# ---------------------------------------------------------------------------
+
+@torch.no_grad()
+@pytest.mark.parametrize("variant", IMPL.keys())
+def test_qwen2_5_decoder_from_primitives(variant):
+    """
+    Compose Qwen2.5 decoder from primitives.
+
+    Adaptations:
+    - Qwen2 has hardcoded attention bias=True. Zero out all biases so
+      F.linear(x, w, 0) == F.linear(x, w), matching our bias-free gqa functions.
+    - position_ids=0 → identity RoPE
+    """
+    from transformers import Qwen2Config
+    from transformers.models.qwen2.modeling_qwen2 import (
+        Qwen2DecoderLayer,
+        Qwen2RotaryEmbedding,
+    )
+
+    config = Qwen2Config(
+        hidden_size=64, num_attention_heads=4, num_key_value_heads=2,
+        head_dim=16, intermediate_size=128,
+        rms_norm_eps=1e-6, max_position_embeddings=256,
+        rope_theta=10000.0, num_hidden_layers=2,
+        attn_implementation="eager",
+    )
+
+    seed_all(70)
+    b, seq_len = 1, 4
+    x = torch.randn(b, seq_len, config.hidden_size)
+
+    layer = Qwen2DecoderLayer(config, layer_idx=0)
+    layer.eval()
+
+    # Zero out attention biases so they don't affect comparison
+    layer.self_attn.q_proj.bias.data.zero_()
+    layer.self_attn.k_proj.bias.data.zero_()
+    layer.self_attn.v_proj.bias.data.zero_()
+
+    rotary = Qwen2RotaryEmbedding(config)
+    position_ids = torch.zeros(b, seq_len, dtype=torch.long)
+    cos, sin = rotary(x, position_ids)
+
+    # 1) HF reference
+    hf_out = layer(x, position_embeddings=(cos, sin))
+
+    # 2) Collect params
+    params = _collect_gqa_dense_params(layer, config)
+
+    # 3) Run composed forward
+    h = _compose_gqa_dense_forward(x, params, variant)
+
+    # 4) Compare
+    label = variant
+    assert_close(hf_out, h, atol=1e-4, rtol=1e-4), \
+        f"Qwen2.5 ({label}): composed vs real HF Qwen2 mismatch"
+
+
+# ---------------------------------------------------------------------------
+# Qwen3-235B-A22B / Qwen3-Coder-480B-A35B / Qwen3-Next-80B-A3B
+#   — GQA (QK norm→Identity) + MoE (softmax routing)
+# ---------------------------------------------------------------------------
+
+@torch.no_grad()
+@pytest.mark.parametrize("variant", IMPL.keys())
+@pytest.mark.parametrize("model_name,config_overrides,seed", [
+    ("Qwen3-235B-A22B", None, 80),
+    ("Qwen3-Coder-480B-A35B", None, 81),
+    ("Qwen3-Next-80B-A3B", dict(num_experts=8, num_experts_per_tok=2), 82),
+], ids=["qwen3_235b", "qwen3_coder_480b", "qwen3_next_80b"])
+def test_qwen3moe_decoder_from_primitives(variant, model_name, config_overrides, seed):
+    """Compose Qwen3Moe decoder (QK norm→Identity + softmax MoE)."""
+    import torch.nn as nn
+    from transformers import Qwen3MoeConfig
+    from transformers.models.qwen3_moe.modeling_qwen3_moe import (
+        Qwen3MoeDecoderLayer,
+        Qwen3MoeRotaryEmbedding,
+    )
+
+    base_kwargs = dict(
+        hidden_size=64, num_attention_heads=4, num_key_value_heads=2,
+        head_dim=16, intermediate_size=128, moe_intermediate_size=64,
+        num_experts=4, num_experts_per_tok=2, norm_topk_prob=False,
+        attention_bias=False, rms_norm_eps=1e-6,
+        max_position_embeddings=256, rope_theta=10000.0,
+        num_hidden_layers=2, attn_implementation="eager",
+    )
+    if config_overrides:
+        base_kwargs.update(config_overrides)
+
+    config = Qwen3MoeConfig(**base_kwargs)
+    seed_all(seed)
+    b, seq_len = 1, 4
+    x = torch.randn(b, seq_len, config.hidden_size)
+
+    layer = Qwen3MoeDecoderLayer(config, layer_idx=0)
+    layer.eval()
+    layer.self_attn.q_norm = nn.Identity()
+    layer.self_attn.k_norm = nn.Identity()
+
+    rotary = Qwen3MoeRotaryEmbedding(config)
+    position_ids = torch.zeros(b, seq_len, dtype=torch.long)
+    cos, sin = rotary(x, position_ids)
+
+    # 1) HF reference
+    hf_out = layer(x, position_embeddings=(cos, sin))
+
+    # 2) Collect params
+    attn = layer.self_attn
+    moe_mod = layer.mlp
+    w1, w2, w3 = _extract_swiglu_expert_weights(moe_mod.experts, config.num_experts)
+    params = dict(
+        eps=config.rms_norm_eps,
+        ln1_weight=layer.input_layernorm.weight.data,
+        ln2_weight=layer.post_attention_layernorm.weight.data,
+        gqa_kwargs=dict(
+            wq=attn.q_proj.weight.data, wk=attn.k_proj.weight.data,
+            wv=attn.v_proj.weight.data, wo=attn.o_proj.weight.data,
+            num_q_heads=config.num_attention_heads,
+            num_kv_heads=config.num_key_value_heads,
+        ),
+        moe_router=moe_mod.gate.weight.data,
+        moe_w1=w1, moe_w2=w2, moe_w3=w3,
+        top_k=config.num_experts_per_tok,
+        normalize_routing=config.norm_topk_prob,
+    )
+
+    # 3) Run composed forward
+    h = _compose_gqa_moe_forward(x, params, variant)
+
+    # 4) Compare
+    label = variant
+    assert_close(hf_out, h, atol=1e-4, rtol=1e-4), \
+        f"{model_name} ({label}): composed vs real HF Qwen3Moe mismatch"
+
+
+# ---------------------------------------------------------------------------
+# Qwen3-32B — GQA (QK norm→Identity) + dense SwiGLU
+# ---------------------------------------------------------------------------
+
+@torch.no_grad()
+@pytest.mark.parametrize("variant", IMPL.keys())
+def test_qwen3_32b_decoder_from_primitives(variant):
+    """
+    Compose Qwen3-32B decoder from primitives.
+
+    Adaptations:
+    - QK norm monkey-patched to nn.Identity
+    - position_ids=0 → identity RoPE
+    """
+    import torch.nn as nn
+    from transformers import Qwen3Config
+    from transformers.models.qwen3.modeling_qwen3 import (
+        Qwen3DecoderLayer,
+        Qwen3RotaryEmbedding,
+    )
+
+    config = Qwen3Config(
+        hidden_size=64, num_attention_heads=4, num_key_value_heads=2,
+        head_dim=16, intermediate_size=128, attention_bias=False,
+        rms_norm_eps=1e-6, max_position_embeddings=256,
+        rope_theta=10000.0, num_hidden_layers=2,
+        attn_implementation="eager",
+    )
+
+    seed_all(85)
+    b, seq_len = 1, 4
+    x = torch.randn(b, seq_len, config.hidden_size)
+
+    layer = Qwen3DecoderLayer(config, layer_idx=0)
+    layer.eval()
+
+    layer.self_attn.q_norm = nn.Identity()
+    layer.self_attn.k_norm = nn.Identity()
+
+    rotary = Qwen3RotaryEmbedding(config)
+    position_ids = torch.zeros(b, seq_len, dtype=torch.long)
+    cos, sin = rotary(x, position_ids)
+
+    # 1) HF reference
+    hf_out = layer(x, position_embeddings=(cos, sin))
+
+    # 2) Collect params
+    params = _collect_gqa_dense_params(layer, config)
+
+    # 3) Run composed forward
+    h = _compose_gqa_dense_forward(x, params, variant)
+
+    # 4) Compare
+    label = variant
+    assert_close(hf_out, h, atol=1e-4, rtol=1e-4), \
+        f"Qwen3-32B ({label}): composed vs real HF Qwen3 mismatch"

--- a/models/demos/deepseek_v3_b1/tests/block_tests/test_gqa.py
+++ b/models/demos/deepseek_v3_b1/tests/block_tests/test_gqa.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
 """GQA unit tests + comparison vs HF attention."""
 
 import torch
@@ -77,7 +81,7 @@ def test_gqa_cache_chunking_equivalence():
 def test_gqa_glm4():
     """
     Compare gqa_attention_torch and gqa_attention_tt from gqa.py against the
-    real HF Glm4Attention module with real RoPE (GLM4 interleaved, partial).
+    HF Glm4Attention module with RoPE (GLM4 interleaved, partial).
     """
     from transformers import Glm4Config
     from transformers.models.glm4.modeling_glm4 import (
@@ -141,8 +145,8 @@ def test_gqa_glm4():
 @torch.no_grad()
 def test_gqa_llama():
     """
-    Compare gqa_attention_torch against real HF LlamaAttention
-    with standard RoPE and real position_ids.
+    Compare gqa_attention_torch against HF LlamaAttention
+    with standard RoPE and position_ids.
     """
     from transformers import LlamaConfig
     from transformers.models.llama.modeling_llama import (

--- a/models/demos/deepseek_v3_b1/tests/block_tests/test_gqa.py
+++ b/models/demos/deepseek_v3_b1/tests/block_tests/test_gqa.py
@@ -54,21 +54,25 @@ def test_gqa_cache_chunking_equivalence():
         num_kv_heads=prof["num_kv_heads"],
     )
 
-    causal_full = torch.tril(torch.ones(seq, seq, dtype=torch.bool)).unsqueeze(0).unsqueeze(0)
+    causal_full = torch.where(
+        torch.tril(torch.ones(seq, seq)).bool(), 0.0, float("-inf"),
+    ).unsqueeze(0).unsqueeze(0)
     out_full, _ = gqa_attention_torch(x, **weights, **common, attention_mask=causal_full)
 
     x1 = x[:, :split, :]
-    causal1 = torch.tril(torch.ones(split, split, dtype=torch.bool)).unsqueeze(0).unsqueeze(0)
+    causal1 = torch.where(
+        torch.tril(torch.ones(split, split)).bool(), 0.0, float("-inf"),
+    ).unsqueeze(0).unsqueeze(0)
     out1, cache = gqa_attention_torch(
         x1, **weights, **common, attention_mask=causal1, use_cache=True,
     )
 
     x2 = x[:, split:, :]
     kv_len = split + (seq - split)
-    causal2 = torch.ones(seq - split, kv_len, dtype=torch.bool)
+    causal2_bool = torch.ones(seq - split, kv_len, dtype=torch.bool)
     for i in range(seq - split):
-        causal2[i, split + i + 1:] = False
-    causal2 = causal2.unsqueeze(0).unsqueeze(0)
+        causal2_bool[i, split + i + 1:] = False
+    causal2 = torch.where(causal2_bool, 0.0, float("-inf")).unsqueeze(0).unsqueeze(0)
     out2, _ = gqa_attention_torch(
         x2, **weights, **common, attention_mask=causal2, past_key_value=cache, use_cache=True,
     )

--- a/models/demos/deepseek_v3_b1/tests/block_tests/test_gqa.py
+++ b/models/demos/deepseek_v3_b1/tests/block_tests/test_gqa.py
@@ -1,0 +1,140 @@
+"""GQA unit tests + comparison vs HF attention."""
+
+import torch
+
+from helpers import seed_all, assert_close, make_profiles, rms_norm
+from gqa import gqa_attention_torch, gqa_attention_tt
+
+
+def _make_gqa_weights(profile, dtype=torch.float32):
+    h = profile["hidden_size"]
+    nq = profile["num_q_heads"]
+    nkv = profile["num_kv_heads"]
+    hd = profile["head_dim"]
+    return dict(
+        wq=torch.randn(nq * hd, h, dtype=dtype),
+        wk=torch.randn(nkv * hd, h, dtype=dtype),
+        wv=torch.randn(nkv * hd, h, dtype=dtype),
+        wo=torch.randn(h, nq * hd, dtype=dtype),
+    )
+
+
+def test_gqa_matches_hf_per_profile_cpu_fp32():
+    seed_all(42)
+    profiles = make_profiles("tiny")
+    b, seq = 2, 6
+    for name, prof in profiles.items():
+        h = prof["hidden_size"]
+        x = torch.randn(b, seq, h)
+        weights = _make_gqa_weights(prof)
+        common = dict(
+            num_q_heads=prof["num_q_heads"],
+            num_kv_heads=prof["num_kv_heads"],
+        )
+        out_torch, _ = gqa_attention_torch(x, **weights, **common)
+        out_tt, _ = gqa_attention_tt(x, **weights, **common)
+        assert_close(out_torch, out_tt, atol=1e-5, rtol=1e-5)
+
+
+def test_gqa_cache_chunking_equivalence():
+    """Full-seq vs chunk1+chunk2 with cache must give same final output."""
+    seed_all(123)
+    prof = make_profiles("tiny")["glm4_355b"]
+    h = prof["hidden_size"]
+    b, seq = 1, 8
+    split = 4
+    x = torch.randn(b, seq, h)
+    weights = _make_gqa_weights(prof)
+    common = dict(
+        num_q_heads=prof["num_q_heads"],
+        num_kv_heads=prof["num_kv_heads"],
+    )
+
+    causal_full = torch.tril(torch.ones(seq, seq, dtype=torch.bool)).unsqueeze(0).unsqueeze(0)
+    out_full, _ = gqa_attention_torch(x, **weights, **common, attention_mask=causal_full)
+
+    x1 = x[:, :split, :]
+    causal1 = torch.tril(torch.ones(split, split, dtype=torch.bool)).unsqueeze(0).unsqueeze(0)
+    out1, cache = gqa_attention_torch(
+        x1, **weights, **common, attention_mask=causal1, use_cache=True,
+    )
+
+    x2 = x[:, split:, :]
+    kv_len = split + (seq - split)
+    causal2 = torch.ones(seq - split, kv_len, dtype=torch.bool)
+    for i in range(seq - split):
+        causal2[i, split + i + 1:] = False
+    causal2 = causal2.unsqueeze(0).unsqueeze(0)
+    out2, _ = gqa_attention_torch(
+        x2, **weights, **common, attention_mask=causal2, past_key_value=cache, use_cache=True,
+    )
+
+    out_chunked = torch.cat([out1, out2], dim=1)
+    assert_close(out_full, out_chunked, atol=1e-3, rtol=1e-3)
+
+
+@torch.no_grad()
+def test_gqa_glm4():
+    """
+    Compare gqa_attention_torch and gqa_attention_tt from gqa.py against the
+    HF Glm4Attention module.
+
+    Adaptations:
+    - attention_bias=False (our functions don't support bias)
+    - position_ids=0 for all tokens → RoPE becomes identity (cos=1, sin=0)
+    """
+    from transformers import Glm4Config
+    from transformers.models.glm4.modeling_glm4 import (
+        Glm4DecoderLayer,
+        Glm4RotaryEmbedding,
+    )
+
+    config = Glm4Config(
+        hidden_size=64,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        intermediate_size=128,
+        partial_rotary_factor=0.5,
+        attention_bias=False,
+        rms_norm_eps=1e-6,
+        max_position_embeddings=256,
+        rope_theta=10000.0,
+        num_hidden_layers=2,
+        attn_implementation="eager",
+    )
+
+    seed_all(42)
+    b, seq_len = 1, 4
+    x = torch.randn(b, seq_len, config.hidden_size)
+
+    layer = Glm4DecoderLayer(config, layer_idx=0)
+    layer.eval()
+
+    rotary = Glm4RotaryEmbedding(config)
+    position_ids = torch.zeros(b, seq_len, dtype=torch.long)
+    cos, sin = rotary(x, position_ids)
+
+    normed = rms_norm(x, layer.input_layernorm.weight.data, config.rms_norm_eps)
+
+    hf_attn_out, _ = layer.self_attn(
+        normed, position_embeddings=(cos, sin), attention_mask=None,
+    )
+
+    attn = layer.self_attn
+    gqa_kwargs = dict(
+        wq=attn.q_proj.weight.data,
+        wk=attn.k_proj.weight.data,
+        wv=attn.v_proj.weight.data,
+        wo=attn.o_proj.weight.data,
+        num_q_heads=config.num_attention_heads,
+        num_kv_heads=config.num_key_value_heads,
+    )
+
+    our_torch_out, _ = gqa_attention_torch(normed, **gqa_kwargs)
+    our_tt_out, _ = gqa_attention_tt(normed, **gqa_kwargs)
+
+    assert_close(hf_attn_out, our_torch_out, atol=1e-5, rtol=1e-5), \
+        "gqa_attention_torch vs HF GLM-4 attention mismatch"
+    assert_close(hf_attn_out, our_tt_out, atol=1e-5, rtol=1e-5), \
+        "gqa_attention_tt vs HF GLM-4 attention mismatch"

--- a/models/demos/deepseek_v3_b1/tests/block_tests/test_gqa.py
+++ b/models/demos/deepseek_v3_b1/tests/block_tests/test_gqa.py
@@ -77,11 +77,7 @@ def test_gqa_cache_chunking_equivalence():
 def test_gqa_glm4():
     """
     Compare gqa_attention_torch and gqa_attention_tt from gqa.py against the
-    HF Glm4Attention module.
-
-    Adaptations:
-    - attention_bias=False (our functions don't support bias)
-    - position_ids=0 for all tokens → RoPE becomes identity (cos=1, sin=0)
+    real HF Glm4Attention module with real RoPE (GLM4 interleaved, partial).
     """
     from transformers import Glm4Config
     from transformers.models.glm4.modeling_glm4 import (
@@ -112,7 +108,7 @@ def test_gqa_glm4():
     layer.eval()
 
     rotary = Glm4RotaryEmbedding(config)
-    position_ids = torch.zeros(b, seq_len, dtype=torch.long)
+    position_ids = torch.arange(seq_len, dtype=torch.long).unsqueeze(0)
     cos, sin = rotary(x, position_ids)
 
     normed = rms_norm(x, layer.input_layernorm.weight.data, config.rms_norm_eps)
@@ -129,6 +125,8 @@ def test_gqa_glm4():
         wo=attn.o_proj.weight.data,
         num_q_heads=config.num_attention_heads,
         num_kv_heads=config.num_key_value_heads,
+        position_embeddings=(cos, sin),
+        rope_variant="glm4",
     )
 
     our_torch_out, _ = gqa_attention_torch(normed, **gqa_kwargs)
@@ -138,3 +136,65 @@ def test_gqa_glm4():
         "gqa_attention_torch vs HF GLM-4 attention mismatch"
     assert_close(hf_attn_out, our_tt_out, atol=1e-5, rtol=1e-5), \
         "gqa_attention_tt vs HF GLM-4 attention mismatch"
+
+
+@torch.no_grad()
+def test_gqa_llama():
+    """
+    Compare gqa_attention_torch against real HF LlamaAttention
+    with standard RoPE and real position_ids.
+    """
+    from transformers import LlamaConfig
+    from transformers.models.llama.modeling_llama import (
+        LlamaDecoderLayer,
+        LlamaRotaryEmbedding,
+    )
+
+    config = LlamaConfig(
+        hidden_size=64,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        intermediate_size=128,
+        rms_norm_eps=1e-6,
+        max_position_embeddings=256,
+        rope_theta=10000.0,
+        num_hidden_layers=2,
+        attn_implementation="eager",
+    )
+
+    seed_all(42)
+    b, seq_len = 1, 4
+    x = torch.randn(b, seq_len, config.hidden_size)
+
+    layer = LlamaDecoderLayer(config, layer_idx=0)
+    layer.eval()
+
+    rotary = LlamaRotaryEmbedding(config)
+    position_ids = torch.arange(seq_len, dtype=torch.long).unsqueeze(0)
+    cos, sin = rotary(x, position_ids)
+
+    normed = rms_norm(x, layer.input_layernorm.weight.data, config.rms_norm_eps)
+
+    hf_attn_out, _ = layer.self_attn(
+        normed, position_embeddings=(cos, sin), attention_mask=None,
+    )
+
+    attn = layer.self_attn
+    gqa_kwargs = dict(
+        wq=attn.q_proj.weight.data,
+        wk=attn.k_proj.weight.data,
+        wv=attn.v_proj.weight.data,
+        wo=attn.o_proj.weight.data,
+        num_q_heads=config.num_attention_heads,
+        num_kv_heads=config.num_key_value_heads,
+        position_embeddings=(cos, sin),
+    )
+
+    our_torch_out, _ = gqa_attention_torch(normed, **gqa_kwargs)
+    our_tt_out, _ = gqa_attention_tt(normed, **gqa_kwargs)
+
+    assert_close(hf_attn_out, our_torch_out, atol=1e-5, rtol=1e-5), \
+        "gqa_attention_torch vs HF Llama attention mismatch"
+    assert_close(hf_attn_out, our_tt_out, atol=1e-5, rtol=1e-5), \
+        "gqa_attention_tt vs HF Llama attention mismatch"

--- a/models/demos/deepseek_v3_b1/tests/block_tests/test_mla.py
+++ b/models/demos/deepseek_v3_b1/tests/block_tests/test_mla.py
@@ -10,19 +10,31 @@ from helpers import seed_all, assert_close, make_profiles, rms_norm
 from mla import mla_attention_torch, mla_attention_tt
 
 
+ROPE_DIM = 4
+
+
 def _make_mla_weights(profile, dtype=torch.float32):
     h = profile["hidden_size"]
     nq = profile["num_q_heads"]
     nkv = profile["num_kv_heads"]
     hd = profile["head_dim"]
     lat = profile["kv_latent_dim"]
+    nope_dim = hd - ROPE_DIM
+    v_head_dim = hd  # use same as head_dim for basic tests
     return dict(
         wq=torch.randn(nq * hd, h, dtype=dtype),
-        w_kv_down=torch.randn(lat, h, dtype=dtype),
-        w_k_up=torch.randn(nkv * hd, lat, dtype=dtype),
-        w_v_up=torch.randn(nkv * hd, lat, dtype=dtype),
-        wo=torch.randn(h, nq * hd, dtype=dtype),
+        w_kv_a=torch.randn(lat + ROPE_DIM, h, dtype=dtype),
+        kv_a_layernorm_weight=torch.ones(lat, dtype=dtype),
+        w_kv_b=torch.randn(nkv * (nope_dim + v_head_dim), lat, dtype=dtype),
+        wo=torch.randn(h, nq * v_head_dim, dtype=dtype),
     )
+
+
+def _make_rope(b, seq, rope_dim=ROPE_DIM):
+    """Create simple cos/sin position embeddings for testing."""
+    cos = torch.ones(b, seq, rope_dim)
+    sin = torch.zeros(b, seq, rope_dim)
+    return cos, sin
 
 
 def test_mla_matches_hf_per_profile_cpu_fp32():
@@ -39,6 +51,8 @@ def test_mla_matches_hf_per_profile_cpu_fp32():
             num_q_heads=prof["num_q_heads"],
             num_kv_heads=prof["num_kv_heads"],
             kv_latent_dim=prof["kv_latent_dim"],
+            qk_rope_head_dim=ROPE_DIM,
+            position_embeddings=_make_rope(b, seq),
         )
         out_torch, _ = mla_attention_torch(x, **weights, **common)
         out_tt, _ = mla_attention_tt(x, **weights, **common)
@@ -57,25 +71,38 @@ def test_mla_cache_chunking_equivalence():
         num_q_heads=prof["num_q_heads"],
         num_kv_heads=prof["num_kv_heads"],
         kv_latent_dim=prof["kv_latent_dim"],
+        qk_rope_head_dim=ROPE_DIM,
     )
 
-    causal_full = torch.tril(torch.ones(seq, seq, dtype=torch.bool)).unsqueeze(0).unsqueeze(0)
-    out_full, _ = mla_attention_torch(x, **weights, **common, attention_mask=causal_full)
+    # Full pass with causal mask (additive)
+    causal_full = torch.zeros(1, 1, seq, seq)
+    causal_full.masked_fill_(~torch.tril(torch.ones(seq, seq, dtype=torch.bool)), float("-inf"))
+    out_full, _ = mla_attention_torch(
+        x, **weights, **common,
+        position_embeddings=_make_rope(b, seq),
+        attention_mask=causal_full,
+    )
 
+    # Chunk 1
     x1 = x[:, :split, :]
-    causal1 = torch.tril(torch.ones(split, split, dtype=torch.bool)).unsqueeze(0).unsqueeze(0)
+    causal1 = torch.zeros(1, 1, split, split)
+    causal1.masked_fill_(~torch.tril(torch.ones(split, split, dtype=torch.bool)), float("-inf"))
     out1, cache = mla_attention_torch(
-        x1, **weights, **common, attention_mask=causal1, use_cache=True,
+        x1, **weights, **common,
+        position_embeddings=_make_rope(b, split),
+        attention_mask=causal1, use_cache=True,
     )
 
+    # Chunk 2
     x2 = x[:, split:, :]
-    kv_len = split + (seq - split)
-    causal2 = torch.ones(seq - split, kv_len, dtype=torch.bool)
+    kv_len = seq
+    causal2 = torch.zeros(1, 1, seq - split, kv_len)
     for i in range(seq - split):
-        causal2[i, split + i + 1:] = False
-    causal2 = causal2.unsqueeze(0).unsqueeze(0)
+        causal2[0, 0, i, split + i + 1:] = float("-inf")
     out2, _ = mla_attention_torch(
-        x2, **weights, **common, attention_mask=causal2, past_key_value=cache, use_cache=True,
+        x2, **weights, **common,
+        position_embeddings=_make_rope(b, seq - split),
+        attention_mask=causal2, past_key_value=cache, use_cache=True,
     )
 
     out_chunked = torch.cat([out1, out2], dim=1)
@@ -90,10 +117,7 @@ def test_mla_deepseek_v3():
 
     Adaptations:
     - q_lora_rank=None → direct Q projection (no LoRA), matches our wq
-    - kv_a_layernorm replaced with nn.Identity → no norm in KV latent path
-    - kv_b_proj weight split into separate w_k_up and w_v_up
     """
-    import torch.nn as nn
     from transformers import DeepseekV3Config
     from transformers.models.deepseek_v3.modeling_deepseek_v3 import (
         DeepseekV3DecoderLayer,
@@ -128,7 +152,6 @@ def test_mla_deepseek_v3():
 
     layer = DeepseekV3DecoderLayer(config, layer_idx=0)
     layer.eval()
-    layer.self_attn.kv_a_layernorm = nn.Identity()
 
     rotary = DeepseekV3RotaryEmbedding(config)
     position_ids = torch.arange(seq_len, dtype=torch.long).unsqueeze(0)
@@ -141,24 +164,18 @@ def test_mla_deepseek_v3():
     )
 
     attn = layer.self_attn
-    kv_b_w = attn.kv_b_proj.weight.data
-    num_heads = config.num_attention_heads
-    kv_b_reshaped = kv_b_w.view(num_heads, nope_dim + v_head_dim, config.kv_lora_rank)
-    w_k_up = kv_b_reshaped[:, :nope_dim, :].reshape(num_heads * nope_dim, config.kv_lora_rank)
-    w_v_up = kv_b_reshaped[:, nope_dim:, :].reshape(num_heads * v_head_dim, config.kv_lora_rank)
 
     mla_kwargs = dict(
         wq=attn.q_proj.weight.data,
-        w_kv_down=attn.kv_a_proj_with_mqa.weight.data,
-        w_k_up=w_k_up,
-        w_v_up=w_v_up,
+        w_kv_a=attn.kv_a_proj_with_mqa.weight.data,
+        kv_a_layernorm_weight=attn.kv_a_layernorm.weight.data,
+        w_kv_b=attn.kv_b_proj.weight.data,
         wo=attn.o_proj.weight.data,
         num_q_heads=config.num_attention_heads,
         num_kv_heads=config.num_key_value_heads,
         kv_latent_dim=config.kv_lora_rank,
         position_embeddings=(cos, sin),
         qk_rope_head_dim=rope_dim,
-        rope_interleave=True,
     )
 
     our_torch_out, _ = mla_attention_torch(normed, **mla_kwargs)
@@ -171,12 +188,97 @@ def test_mla_deepseek_v3():
 
 
 @torch.no_grad()
+def test_mla_deepseek_v3_full():
+    """
+    Full DeepSeek V3 MLA: Q LoRA (q_a_proj → q_a_layernorm → q_b_proj) +
+    KV layernorm (kv_a_layernorm) — no monkey-patching.
+    """
+    from transformers import DeepseekV3Config
+    from transformers.models.deepseek_v3.modeling_deepseek_v3 import (
+        DeepseekV3DecoderLayer,
+        DeepseekV3RotaryEmbedding,
+    )
+
+    nope_dim = 8
+    rope_dim = 4
+    v_head_dim = 8
+    q_lora_rank = 16
+    config = DeepseekV3Config(
+        hidden_size=64,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        q_lora_rank=q_lora_rank,
+        kv_lora_rank=16,
+        qk_rope_head_dim=rope_dim,
+        qk_nope_head_dim=nope_dim,
+        v_head_dim=v_head_dim,
+        intermediate_size=128,
+        num_hidden_layers=2,
+        first_k_dense_replace=2,
+        attention_bias=False,
+        rms_norm_eps=1e-6,
+        max_position_embeddings=256,
+        rope_theta=10000.0,
+        attn_implementation="eager",
+    )
+
+    seed_all(42)
+    b, seq_len = 1, 4
+    x = torch.randn(b, seq_len, config.hidden_size)
+
+    layer = DeepseekV3DecoderLayer(config, layer_idx=0)
+    layer.eval()
+
+    rotary = DeepseekV3RotaryEmbedding(config)
+    position_ids = torch.arange(seq_len, dtype=torch.long).unsqueeze(0)
+    cos, sin = rotary(x, position_ids)
+
+    normed = rms_norm(x, layer.input_layernorm.weight.data, config.rms_norm_eps)
+
+    hf_attn_out, _ = layer.self_attn(
+        normed, position_embeddings=(cos, sin), attention_mask=None,
+    )
+
+    attn = layer.self_attn
+
+    mla_kwargs = dict(
+        # Q LoRA: q_a_proj → q_a_layernorm → q_b_proj
+        w_q_a=attn.q_a_proj.weight.data,
+        q_a_layernorm_weight=attn.q_a_layernorm.weight.data,
+        q_a_layernorm_eps=config.rms_norm_eps,
+        wq=attn.q_b_proj.weight.data,
+        # KV path with layernorm
+        w_kv_a=attn.kv_a_proj_with_mqa.weight.data,
+        kv_a_layernorm_weight=attn.kv_a_layernorm.weight.data,
+        kv_a_layernorm_eps=config.rms_norm_eps,
+        w_kv_b=attn.kv_b_proj.weight.data,
+        wo=attn.o_proj.weight.data,
+        num_q_heads=config.num_attention_heads,
+        num_kv_heads=config.num_key_value_heads,
+        kv_latent_dim=config.kv_lora_rank,
+        position_embeddings=(cos, sin),
+        qk_rope_head_dim=rope_dim,
+    )
+
+    our_torch_out, _ = mla_attention_torch(normed, **mla_kwargs)
+    our_tt_out, _ = mla_attention_tt(normed, **mla_kwargs)
+
+    assert_close(hf_attn_out, our_torch_out, atol=1e-5, rtol=1e-5), \
+        "mla_attention_torch vs HF DeepSeek V3 full MLA mismatch"
+    assert_close(hf_attn_out, our_tt_out, atol=1e-5, rtol=1e-5), \
+        "mla_attention_tt vs HF DeepSeek V3 full MLA mismatch"
+
+
+# NOTE: absorbed attention test removed — absorbed path is now a commented-out
+# optimization example in mla.py.  See mla.py for the implementation.
+
+
+@torch.no_grad()
 def test_mla_kimi_k25():
     """
     Same as test_mla_deepseek_v3 but with Kimi K2.5 structural
     parameters (different rms_norm_eps, rope_theta).
     """
-    import torch.nn as nn
     from transformers import DeepseekV3Config
     from transformers.models.deepseek_v3.modeling_deepseek_v3 import (
         DeepseekV3DecoderLayer,
@@ -211,7 +313,6 @@ def test_mla_kimi_k25():
 
     layer = DeepseekV3DecoderLayer(config, layer_idx=0)
     layer.eval()
-    layer.self_attn.kv_a_layernorm = nn.Identity()
 
     rotary = DeepseekV3RotaryEmbedding(config)
     position_ids = torch.arange(seq_len, dtype=torch.long).unsqueeze(0)
@@ -223,24 +324,18 @@ def test_mla_kimi_k25():
     )
 
     attn = layer.self_attn
-    kv_b_w = attn.kv_b_proj.weight.data
-    num_heads = config.num_attention_heads
-    kv_b_reshaped = kv_b_w.view(num_heads, nope_dim + v_head_dim, config.kv_lora_rank)
-    w_k_up = kv_b_reshaped[:, :nope_dim, :].reshape(num_heads * nope_dim, config.kv_lora_rank)
-    w_v_up = kv_b_reshaped[:, nope_dim:, :].reshape(num_heads * v_head_dim, config.kv_lora_rank)
 
     mla_kwargs = dict(
         wq=attn.q_proj.weight.data,
-        w_kv_down=attn.kv_a_proj_with_mqa.weight.data,
-        w_k_up=w_k_up,
-        w_v_up=w_v_up,
+        w_kv_a=attn.kv_a_proj_with_mqa.weight.data,
+        kv_a_layernorm_weight=attn.kv_a_layernorm.weight.data,
+        w_kv_b=attn.kv_b_proj.weight.data,
         wo=attn.o_proj.weight.data,
         num_q_heads=config.num_attention_heads,
         num_kv_heads=config.num_key_value_heads,
         kv_latent_dim=config.kv_lora_rank,
         position_embeddings=(cos, sin),
         qk_rope_head_dim=rope_dim,
-        rope_interleave=True,
     )
 
     our_torch_out, _ = mla_attention_torch(normed, **mla_kwargs)

--- a/models/demos/deepseek_v3_b1/tests/block_tests/test_mla.py
+++ b/models/demos/deepseek_v3_b1/tests/block_tests/test_mla.py
@@ -1,0 +1,235 @@
+"""MLA unit tests + comparison vs HF attention."""
+
+import torch
+
+from helpers import seed_all, assert_close, make_profiles, rms_norm
+from mla import mla_attention_torch, mla_attention_tt
+
+
+def _make_mla_weights(profile, dtype=torch.float32):
+    h = profile["hidden_size"]
+    nq = profile["num_q_heads"]
+    nkv = profile["num_kv_heads"]
+    hd = profile["head_dim"]
+    lat = profile["kv_latent_dim"]
+    return dict(
+        wq=torch.randn(nq * hd, h, dtype=dtype),
+        w_kv_down=torch.randn(lat, h, dtype=dtype),
+        w_k_up=torch.randn(nkv * hd, lat, dtype=dtype),
+        w_v_up=torch.randn(nkv * hd, lat, dtype=dtype),
+        wo=torch.randn(h, nq * hd, dtype=dtype),
+    )
+
+
+def test_mla_matches_hf_per_profile_cpu_fp32():
+    seed_all(42)
+    profiles = make_profiles("tiny")
+    b, seq = 2, 6
+    for name, prof in profiles.items():
+        if not prof["use_mla"]:
+            continue
+        h = prof["hidden_size"]
+        x = torch.randn(b, seq, h)
+        weights = _make_mla_weights(prof)
+        common = dict(
+            num_q_heads=prof["num_q_heads"],
+            num_kv_heads=prof["num_kv_heads"],
+            kv_latent_dim=prof["kv_latent_dim"],
+        )
+        out_torch, _ = mla_attention_torch(x, **weights, **common)
+        out_tt, _ = mla_attention_tt(x, **weights, **common)
+        assert_close(out_torch, out_tt, atol=1e-5, rtol=1e-5)
+
+
+def test_mla_cache_chunking_equivalence():
+    seed_all(123)
+    prof = make_profiles("tiny")["deepseek_v3"]
+    h = prof["hidden_size"]
+    b, seq = 1, 8
+    split = 4
+    x = torch.randn(b, seq, h)
+    weights = _make_mla_weights(prof)
+    common = dict(
+        num_q_heads=prof["num_q_heads"],
+        num_kv_heads=prof["num_kv_heads"],
+        kv_latent_dim=prof["kv_latent_dim"],
+    )
+
+    causal_full = torch.tril(torch.ones(seq, seq, dtype=torch.bool)).unsqueeze(0).unsqueeze(0)
+    out_full, _ = mla_attention_torch(x, **weights, **common, attention_mask=causal_full)
+
+    x1 = x[:, :split, :]
+    causal1 = torch.tril(torch.ones(split, split, dtype=torch.bool)).unsqueeze(0).unsqueeze(0)
+    out1, cache = mla_attention_torch(
+        x1, **weights, **common, attention_mask=causal1, use_cache=True,
+    )
+
+    x2 = x[:, split:, :]
+    kv_len = split + (seq - split)
+    causal2 = torch.ones(seq - split, kv_len, dtype=torch.bool)
+    for i in range(seq - split):
+        causal2[i, split + i + 1:] = False
+    causal2 = causal2.unsqueeze(0).unsqueeze(0)
+    out2, _ = mla_attention_torch(
+        x2, **weights, **common, attention_mask=causal2, past_key_value=cache, use_cache=True,
+    )
+
+    out_chunked = torch.cat([out1, out2], dim=1)
+    assert_close(out_full, out_chunked, atol=1e-3, rtol=1e-3)
+
+
+@torch.no_grad()
+def test_mla_deepseek_v3():
+    """
+    Compare mla_attention_torch and mla_attention_tt from mla.py against the
+    HF DeepseekV3Attention module.
+
+    Adaptations to make architectures compatible:
+    - q_lora_rank=None → direct Q projection (no LoRA), matches our wq
+    - qk_rope_head_dim=0 → no RoPE dims, Q/K only have nope component
+    - qk_nope_head_dim = v_head_dim → uniform head_dim for K and V
+    - kv_a_layernorm replaced with nn.Identity → no norm in KV latent path
+    - kv_b_proj weight split into separate w_k_up and w_v_up
+    """
+    import torch.nn as nn
+    from transformers import DeepseekV3Config
+    from transformers.models.deepseek_v3.modeling_deepseek_v3 import (
+        DeepseekV3DecoderLayer,
+    )
+
+    head_dim = 8
+    config = DeepseekV3Config(
+        hidden_size=64,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        q_lora_rank=None,
+        kv_lora_rank=16,
+        qk_rope_head_dim=0,
+        qk_nope_head_dim=head_dim,
+        v_head_dim=head_dim,
+        intermediate_size=128,
+        num_hidden_layers=2,
+        first_k_dense_replace=2,
+        attention_bias=False,
+        rms_norm_eps=1e-6,
+        max_position_embeddings=256,
+        attn_implementation="eager",
+    )
+
+    seed_all(42)
+    b, seq_len = 1, 4
+    x = torch.randn(b, seq_len, config.hidden_size)
+
+    layer = DeepseekV3DecoderLayer(config, layer_idx=0)
+    layer.eval()
+    layer.self_attn.kv_a_layernorm = nn.Identity()
+
+    cos = torch.empty(b, seq_len, 0)
+    sin = torch.empty(b, seq_len, 0)
+
+    normed = rms_norm(x, layer.input_layernorm.weight.data, config.rms_norm_eps)
+
+    hf_attn_out, _ = layer.self_attn(
+        normed, position_embeddings=(cos, sin), attention_mask=None,
+    )
+
+    attn = layer.self_attn
+    kv_b_w = attn.kv_b_proj.weight.data
+    num_heads = config.num_attention_heads
+    kv_b_reshaped = kv_b_w.view(num_heads, head_dim + head_dim, config.kv_lora_rank)
+    w_k_up = kv_b_reshaped[:, :head_dim, :].reshape(num_heads * head_dim, config.kv_lora_rank)
+    w_v_up = kv_b_reshaped[:, head_dim:, :].reshape(num_heads * head_dim, config.kv_lora_rank)
+
+    mla_kwargs = dict(
+        wq=attn.q_proj.weight.data,
+        w_kv_down=attn.kv_a_proj_with_mqa.weight.data,
+        w_k_up=w_k_up,
+        w_v_up=w_v_up,
+        wo=attn.o_proj.weight.data,
+        num_q_heads=config.num_attention_heads,
+        num_kv_heads=config.num_key_value_heads,
+        kv_latent_dim=config.kv_lora_rank,
+    )
+
+    our_torch_out, _ = mla_attention_torch(normed, **mla_kwargs)
+    our_tt_out, _ = mla_attention_tt(normed, **mla_kwargs)
+
+    assert_close(hf_attn_out, our_torch_out, atol=1e-5, rtol=1e-5), \
+        "mla_attention_torch vs HF DeepSeek V3 attention mismatch"
+    assert_close(hf_attn_out, our_tt_out, atol=1e-5, rtol=1e-5), \
+        "mla_attention_tt vs HF DeepSeek V3 attention mismatch"
+
+
+@torch.no_grad()
+def test_mla_kimi_k25():
+    """
+    Same as test_mla_deepseek_v3 but with Kimi K2.5 structural
+    parameters (different rms_norm_eps, rope_theta).
+    """
+    import torch.nn as nn
+    from transformers import DeepseekV3Config
+    from transformers.models.deepseek_v3.modeling_deepseek_v3 import (
+        DeepseekV3DecoderLayer,
+    )
+
+    head_dim = 8
+    config = DeepseekV3Config(
+        hidden_size=64,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        q_lora_rank=None,
+        kv_lora_rank=16,
+        qk_rope_head_dim=0,
+        qk_nope_head_dim=head_dim,
+        v_head_dim=head_dim,
+        intermediate_size=128,
+        num_hidden_layers=2,
+        first_k_dense_replace=2,
+        attention_bias=False,
+        rms_norm_eps=1e-5,
+        rope_theta=50000.0,
+        max_position_embeddings=256,
+        attn_implementation="eager",
+    )
+
+    seed_all(77)
+    b, seq_len = 1, 4
+    x = torch.randn(b, seq_len, config.hidden_size)
+
+    layer = DeepseekV3DecoderLayer(config, layer_idx=0)
+    layer.eval()
+    layer.self_attn.kv_a_layernorm = nn.Identity()
+
+    cos = torch.empty(b, seq_len, 0)
+    sin = torch.empty(b, seq_len, 0)
+
+    normed = rms_norm(x, layer.input_layernorm.weight.data, config.rms_norm_eps)
+    hf_attn_out, _ = layer.self_attn(
+        normed, position_embeddings=(cos, sin), attention_mask=None,
+    )
+
+    attn = layer.self_attn
+    kv_b_w = attn.kv_b_proj.weight.data
+    num_heads = config.num_attention_heads
+    kv_b_reshaped = kv_b_w.view(num_heads, head_dim + head_dim, config.kv_lora_rank)
+    w_k_up = kv_b_reshaped[:, :head_dim, :].reshape(num_heads * head_dim, config.kv_lora_rank)
+    w_v_up = kv_b_reshaped[:, head_dim:, :].reshape(num_heads * head_dim, config.kv_lora_rank)
+
+    mla_kwargs = dict(
+        wq=attn.q_proj.weight.data,
+        w_kv_down=attn.kv_a_proj_with_mqa.weight.data,
+        w_k_up=w_k_up,
+        w_v_up=w_v_up,
+        wo=attn.o_proj.weight.data,
+        num_q_heads=config.num_attention_heads,
+        num_kv_heads=config.num_key_value_heads,
+        kv_latent_dim=config.kv_lora_rank,
+    )
+
+    our_torch_out, _ = mla_attention_torch(normed, **mla_kwargs)
+    our_tt_out, _ = mla_attention_tt(normed, **mla_kwargs)
+
+    assert_close(hf_attn_out, our_torch_out, atol=1e-5, rtol=1e-5), \
+        "mla_attention_torch vs HF Kimi K2.5 attention mismatch"
+    assert_close(hf_attn_out, our_tt_out, atol=1e-5, rtol=1e-5), \
+        "mla_attention_tt vs HF Kimi K2.5 attention mismatch"

--- a/models/demos/deepseek_v3_b1/tests/block_tests/test_mla.py
+++ b/models/demos/deepseek_v3_b1/tests/block_tests/test_mla.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
 """MLA unit tests + comparison vs HF attention."""
 
 import torch
@@ -81,8 +85,8 @@ def test_mla_cache_chunking_equivalence():
 @torch.no_grad()
 def test_mla_deepseek_v3():
     """
-    Compare mla_attention_torch against real HF DeepseekV3Attention
-    with real RoPE (nope+rope split) and real position_ids.
+    Compare mla_attention_torch against HF DeepseekV3Attention
+    with RoPE (nope+rope split) and position_ids.
 
     Adaptations:
     - q_lora_rank=None → direct Q projection (no LoRA), matches our wq

--- a/models/demos/deepseek_v3_b1/tests/block_tests/test_mla.py
+++ b/models/demos/deepseek_v3_b1/tests/block_tests/test_mla.py
@@ -81,13 +81,11 @@ def test_mla_cache_chunking_equivalence():
 @torch.no_grad()
 def test_mla_deepseek_v3():
     """
-    Compare mla_attention_torch and mla_attention_tt from mla.py against the
-    HF DeepseekV3Attention module.
+    Compare mla_attention_torch against real HF DeepseekV3Attention
+    with real RoPE (nope+rope split) and real position_ids.
 
-    Adaptations to make architectures compatible:
+    Adaptations:
     - q_lora_rank=None → direct Q projection (no LoRA), matches our wq
-    - qk_rope_head_dim=0 → no RoPE dims, Q/K only have nope component
-    - qk_nope_head_dim = v_head_dim → uniform head_dim for K and V
     - kv_a_layernorm replaced with nn.Identity → no norm in KV latent path
     - kv_b_proj weight split into separate w_k_up and w_v_up
     """
@@ -95,24 +93,28 @@ def test_mla_deepseek_v3():
     from transformers import DeepseekV3Config
     from transformers.models.deepseek_v3.modeling_deepseek_v3 import (
         DeepseekV3DecoderLayer,
+        DeepseekV3RotaryEmbedding,
     )
 
-    head_dim = 8
+    nope_dim = 8
+    rope_dim = 4
+    v_head_dim = 8
     config = DeepseekV3Config(
         hidden_size=64,
         num_attention_heads=4,
         num_key_value_heads=4,
         q_lora_rank=None,
         kv_lora_rank=16,
-        qk_rope_head_dim=0,
-        qk_nope_head_dim=head_dim,
-        v_head_dim=head_dim,
+        qk_rope_head_dim=rope_dim,
+        qk_nope_head_dim=nope_dim,
+        v_head_dim=v_head_dim,
         intermediate_size=128,
         num_hidden_layers=2,
         first_k_dense_replace=2,
         attention_bias=False,
         rms_norm_eps=1e-6,
         max_position_embeddings=256,
+        rope_theta=10000.0,
         attn_implementation="eager",
     )
 
@@ -124,8 +126,9 @@ def test_mla_deepseek_v3():
     layer.eval()
     layer.self_attn.kv_a_layernorm = nn.Identity()
 
-    cos = torch.empty(b, seq_len, 0)
-    sin = torch.empty(b, seq_len, 0)
+    rotary = DeepseekV3RotaryEmbedding(config)
+    position_ids = torch.arange(seq_len, dtype=torch.long).unsqueeze(0)
+    cos, sin = rotary(x, position_ids)
 
     normed = rms_norm(x, layer.input_layernorm.weight.data, config.rms_norm_eps)
 
@@ -136,9 +139,9 @@ def test_mla_deepseek_v3():
     attn = layer.self_attn
     kv_b_w = attn.kv_b_proj.weight.data
     num_heads = config.num_attention_heads
-    kv_b_reshaped = kv_b_w.view(num_heads, head_dim + head_dim, config.kv_lora_rank)
-    w_k_up = kv_b_reshaped[:, :head_dim, :].reshape(num_heads * head_dim, config.kv_lora_rank)
-    w_v_up = kv_b_reshaped[:, head_dim:, :].reshape(num_heads * head_dim, config.kv_lora_rank)
+    kv_b_reshaped = kv_b_w.view(num_heads, nope_dim + v_head_dim, config.kv_lora_rank)
+    w_k_up = kv_b_reshaped[:, :nope_dim, :].reshape(num_heads * nope_dim, config.kv_lora_rank)
+    w_v_up = kv_b_reshaped[:, nope_dim:, :].reshape(num_heads * v_head_dim, config.kv_lora_rank)
 
     mla_kwargs = dict(
         wq=attn.q_proj.weight.data,
@@ -149,6 +152,9 @@ def test_mla_deepseek_v3():
         num_q_heads=config.num_attention_heads,
         num_kv_heads=config.num_key_value_heads,
         kv_latent_dim=config.kv_lora_rank,
+        position_embeddings=(cos, sin),
+        qk_rope_head_dim=rope_dim,
+        rope_interleave=True,
     )
 
     our_torch_out, _ = mla_attention_torch(normed, **mla_kwargs)
@@ -170,18 +176,21 @@ def test_mla_kimi_k25():
     from transformers import DeepseekV3Config
     from transformers.models.deepseek_v3.modeling_deepseek_v3 import (
         DeepseekV3DecoderLayer,
+        DeepseekV3RotaryEmbedding,
     )
 
-    head_dim = 8
+    nope_dim = 8
+    rope_dim = 4
+    v_head_dim = 8
     config = DeepseekV3Config(
         hidden_size=64,
         num_attention_heads=4,
         num_key_value_heads=4,
         q_lora_rank=None,
         kv_lora_rank=16,
-        qk_rope_head_dim=0,
-        qk_nope_head_dim=head_dim,
-        v_head_dim=head_dim,
+        qk_rope_head_dim=rope_dim,
+        qk_nope_head_dim=nope_dim,
+        v_head_dim=v_head_dim,
         intermediate_size=128,
         num_hidden_layers=2,
         first_k_dense_replace=2,
@@ -200,8 +209,9 @@ def test_mla_kimi_k25():
     layer.eval()
     layer.self_attn.kv_a_layernorm = nn.Identity()
 
-    cos = torch.empty(b, seq_len, 0)
-    sin = torch.empty(b, seq_len, 0)
+    rotary = DeepseekV3RotaryEmbedding(config)
+    position_ids = torch.arange(seq_len, dtype=torch.long).unsqueeze(0)
+    cos, sin = rotary(x, position_ids)
 
     normed = rms_norm(x, layer.input_layernorm.weight.data, config.rms_norm_eps)
     hf_attn_out, _ = layer.self_attn(
@@ -211,9 +221,9 @@ def test_mla_kimi_k25():
     attn = layer.self_attn
     kv_b_w = attn.kv_b_proj.weight.data
     num_heads = config.num_attention_heads
-    kv_b_reshaped = kv_b_w.view(num_heads, head_dim + head_dim, config.kv_lora_rank)
-    w_k_up = kv_b_reshaped[:, :head_dim, :].reshape(num_heads * head_dim, config.kv_lora_rank)
-    w_v_up = kv_b_reshaped[:, head_dim:, :].reshape(num_heads * head_dim, config.kv_lora_rank)
+    kv_b_reshaped = kv_b_w.view(num_heads, nope_dim + v_head_dim, config.kv_lora_rank)
+    w_k_up = kv_b_reshaped[:, :nope_dim, :].reshape(num_heads * nope_dim, config.kv_lora_rank)
+    w_v_up = kv_b_reshaped[:, nope_dim:, :].reshape(num_heads * v_head_dim, config.kv_lora_rank)
 
     mla_kwargs = dict(
         wq=attn.q_proj.weight.data,
@@ -224,6 +234,9 @@ def test_mla_kimi_k25():
         num_q_heads=config.num_attention_heads,
         num_kv_heads=config.num_key_value_heads,
         kv_latent_dim=config.kv_lora_rank,
+        position_embeddings=(cos, sin),
+        qk_rope_head_dim=rope_dim,
+        rope_interleave=True,
     )
 
     our_torch_out, _ = mla_attention_torch(normed, **mla_kwargs)

--- a/models/demos/deepseek_v3_b1/tests/block_tests/test_mlp.py
+++ b/models/demos/deepseek_v3_b1/tests/block_tests/test_mlp.py
@@ -1,0 +1,157 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""MLP unit tests + comparison vs HF MLP module."""
+
+import torch
+
+from helpers import seed_all, assert_close, make_profiles, rms_norm
+from mlp import mlp_torch, mlp_tt
+
+
+def _make_mlp_weights(profile, dtype=torch.float32):
+    h = profile["hidden_size"]
+    mi = profile["ffn_intermediate"]
+    return dict(
+        w_gate=torch.randn(mi, h, dtype=dtype),
+        w_up=torch.randn(mi, h, dtype=dtype),
+        w_down=torch.randn(h, mi, dtype=dtype),
+    )
+
+
+def test_mlp_matches_per_profile_cpu_fp32():
+    seed_all(42)
+    profiles = make_profiles("tiny")
+    b, seq = 2, 6
+    for name, prof in profiles.items():
+        h = prof["hidden_size"]
+        x = torch.randn(b, seq, h)
+        weights = _make_mlp_weights(prof)
+        out_torch = mlp_torch(x, **weights)
+        out_tt = mlp_tt(x, **weights)
+        assert_close(out_torch, out_tt, atol=1e-5, rtol=1e-5)
+
+
+def test_mlp_batch1_seq1():
+    seed_all(77)
+    prof = make_profiles("tiny")["deepseek_v3"]
+    h = prof["hidden_size"]
+    x = torch.randn(1, 1, h)
+    weights = _make_mlp_weights(prof)
+    out_torch = mlp_torch(x, **weights)
+    out_tt = mlp_tt(x, **weights)
+    assert_close(out_torch, out_tt, atol=1e-5, rtol=1e-5)
+
+
+def test_mlp_odd_seq():
+    seed_all(55)
+    prof = make_profiles("tiny")["glm4_355b"]
+    h = prof["hidden_size"]
+    x = torch.randn(2, 7, h)
+    weights = _make_mlp_weights(prof)
+    out_torch = mlp_torch(x, **weights)
+    out_tt = mlp_tt(x, **weights)
+    assert_close(out_torch, out_tt, atol=1e-5, rtol=1e-5)
+
+
+@torch.no_grad()
+def test_mlp_llama():
+    """
+    Compare mlp_torch against real HF LlamaMLP (SwiGLU).
+    """
+    from transformers import LlamaConfig
+    from transformers.models.llama.modeling_llama import LlamaDecoderLayer
+
+    config = LlamaConfig(
+        hidden_size=64,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        intermediate_size=128,
+        rms_norm_eps=1e-6,
+        max_position_embeddings=256,
+        num_hidden_layers=2,
+        attn_implementation="eager",
+    )
+
+    seed_all(42)
+    b, seq_len = 1, 4
+    x = torch.randn(b, seq_len, config.hidden_size)
+
+    layer = LlamaDecoderLayer(config, layer_idx=0)
+    layer.eval()
+
+    normed = rms_norm(x, layer.post_attention_layernorm.weight.data, config.rms_norm_eps)
+
+    hf_mlp_out = layer.mlp(normed)
+
+    mlp = layer.mlp
+    our_torch_out = mlp_torch(
+        normed,
+        w_gate=mlp.gate_proj.weight.data,
+        w_up=mlp.up_proj.weight.data,
+        w_down=mlp.down_proj.weight.data,
+    )
+    our_tt_out = mlp_tt(
+        normed,
+        w_gate=mlp.gate_proj.weight.data,
+        w_up=mlp.up_proj.weight.data,
+        w_down=mlp.down_proj.weight.data,
+    )
+
+    assert_close(hf_mlp_out, our_torch_out, atol=1e-5, rtol=1e-5), \
+        "mlp_torch vs HF Llama MLP mismatch"
+    assert_close(hf_mlp_out, our_tt_out, atol=1e-5, rtol=1e-5), \
+        "mlp_tt vs HF Llama MLP mismatch"
+
+
+@torch.no_grad()
+def test_mlp_qwen2():
+    """
+    Compare mlp_torch against real HF Qwen2MLP (SwiGLU).
+    """
+    from transformers import Qwen2Config
+    from transformers.models.qwen2.modeling_qwen2 import Qwen2DecoderLayer
+
+    config = Qwen2Config(
+        hidden_size=64,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        intermediate_size=128,
+        rms_norm_eps=1e-6,
+        max_position_embeddings=256,
+        num_hidden_layers=2,
+        attn_implementation="eager",
+    )
+
+    seed_all(70)
+    b, seq_len = 1, 4
+    x = torch.randn(b, seq_len, config.hidden_size)
+
+    layer = Qwen2DecoderLayer(config, layer_idx=0)
+    layer.eval()
+
+    normed = rms_norm(x, layer.post_attention_layernorm.weight.data, config.rms_norm_eps)
+
+    hf_mlp_out = layer.mlp(normed)
+
+    mlp = layer.mlp
+    our_torch_out = mlp_torch(
+        normed,
+        w_gate=mlp.gate_proj.weight.data,
+        w_up=mlp.up_proj.weight.data,
+        w_down=mlp.down_proj.weight.data,
+    )
+    our_tt_out = mlp_tt(
+        normed,
+        w_gate=mlp.gate_proj.weight.data,
+        w_up=mlp.up_proj.weight.data,
+        w_down=mlp.down_proj.weight.data,
+    )
+
+    assert_close(hf_mlp_out, our_torch_out, atol=1e-5, rtol=1e-5), \
+        "mlp_torch vs HF Qwen2 MLP mismatch"
+    assert_close(hf_mlp_out, our_tt_out, atol=1e-5, rtol=1e-5), \
+        "mlp_tt vs HF Qwen2 MLP mismatch"

--- a/models/demos/deepseek_v3_b1/tests/block_tests/test_moe.py
+++ b/models/demos/deepseek_v3_b1/tests/block_tests/test_moe.py
@@ -1,0 +1,156 @@
+"""MoE unit tests + comparison vs HF MoE module."""
+
+import torch
+
+from helpers import seed_all, assert_close, make_profiles
+from moe import moe_torch, moe_tt, moe_shared_experts_torch, sigmoid_topk_routing
+
+
+def _make_moe_weights(profile, dtype=torch.float32):
+    h = profile["hidden_size"]
+    ne = profile["num_experts"]
+    mi = profile["moe_intermediate"]
+    return dict(
+        w_router=torch.randn(ne, h, dtype=dtype),
+        w1=torch.randn(ne, mi, h, dtype=dtype),
+        w2=torch.randn(ne, h, mi, dtype=dtype),
+    )
+
+
+def test_moe_matches_hf_per_profile_cpu_fp32():
+    seed_all(42)
+    profiles = make_profiles("tiny")
+    b, seq = 2, 6
+    for name, prof in profiles.items():
+        if not prof["use_moe"]:
+            continue
+        h = prof["hidden_size"]
+        x = torch.randn(b, seq, h)
+        weights = _make_moe_weights(prof)
+        out_torch = moe_torch(x, **weights, top_k=prof["top_k"])
+        out_tt = moe_tt(x, **weights, top_k=prof["top_k"])
+        assert_close(out_torch, out_tt, atol=1e-5, rtol=1e-5)
+
+
+def test_moe_topk1():
+    seed_all(99)
+    prof = make_profiles("tiny")["glm4_355b"]
+    prof = {**prof, "num_experts": 4, "top_k": 1, "use_moe": True}
+    h = prof["hidden_size"]
+    x = torch.randn(1, 1, h)
+    weights = _make_moe_weights(prof)
+    out_torch = moe_torch(x, **weights, top_k=1)
+    out_tt = moe_tt(x, **weights, top_k=1)
+    assert_close(out_torch, out_tt, atol=1e-5, rtol=1e-5)
+
+
+def test_moe_batch1_seq1():
+    seed_all(77)
+    prof = make_profiles("tiny")["deepseek_v3"]
+    h = prof["hidden_size"]
+    x = torch.randn(1, 1, h)
+    weights = _make_moe_weights(prof)
+    out_torch = moe_torch(x, **weights, top_k=prof["top_k"])
+    out_tt = moe_tt(x, **weights, top_k=prof["top_k"])
+    assert_close(out_torch, out_tt, atol=1e-5, rtol=1e-5)
+
+
+def test_moe_odd_seq():
+    seed_all(55)
+    prof = make_profiles("tiny")["gpt_oss_120b"]
+    h = prof["hidden_size"]
+    x = torch.randn(2, 7, h)  # odd seq length
+    weights = _make_moe_weights(prof)
+    out_torch = moe_torch(x, **weights, top_k=prof["top_k"])
+    out_tt = moe_tt(x, **weights, top_k=prof["top_k"])
+    assert_close(out_torch, out_tt, atol=1e-5, rtol=1e-5)
+
+
+def _extract_swiglu_expert_weights(experts, ne):
+    """Extract SwiGLU weights from HF expert modules → (w1, w2, w3)."""
+    w1 = torch.stack([experts[e].gate_proj.weight.data for e in range(ne)])
+    w3 = torch.stack([experts[e].up_proj.weight.data for e in range(ne)])
+    w2 = torch.stack([experts[e].down_proj.weight.data for e in range(ne)])
+    return w1, w2, w3
+
+
+def _extract_shared_expert_weights(shared):
+    """Extract shared expert SwiGLU weights from HF module."""
+    return dict(
+        w_gate=shared.gate_proj.weight.data,
+        w_up=shared.up_proj.weight.data,
+        w_down=shared.down_proj.weight.data,
+    )
+
+
+@torch.no_grad()
+def test_moe_deepseek_v3():
+    """
+    Compose DeepSeek V3 MoE from building blocks (sigmoid_topk_routing +
+    moe_forward + moe_shared_experts) and compare against HF module.
+    """
+    from transformers import DeepseekV3Config
+    from transformers.models.deepseek_v3.modeling_deepseek_v3 import (
+        DeepseekV3DecoderLayer,
+    )
+
+    config = DeepseekV3Config(
+        hidden_size=64,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        q_lora_rank=16,
+        kv_lora_rank=16,
+        qk_rope_head_dim=4,
+        qk_nope_head_dim=8,
+        v_head_dim=8,
+        intermediate_size=128,
+        moe_intermediate_size=32,
+        n_routed_experts=4,
+        num_experts_per_tok=2,
+        n_group=2,
+        topk_group=1,
+        first_k_dense_replace=0,
+        n_shared_experts=1,
+        num_hidden_layers=2,
+        rms_norm_eps=1e-6,
+        attn_implementation="eager",
+    )
+
+    seed_all(42)
+    b, seq_len = 1, 4
+    x = torch.randn(b, seq_len, config.hidden_size)
+
+    layer = DeepseekV3DecoderLayer(config, layer_idx=0)
+    layer.eval()
+
+    # 1) HF reference
+    moe_mod = layer.mlp
+    hf_out = moe_mod(x)
+
+    # 2) Extract weights
+    ne = config.n_routed_experts
+    w1, w2, w3 = _extract_swiglu_expert_weights(moe_mod.experts, ne)
+    shared_kwargs = _extract_shared_expert_weights(moe_mod.shared_experts)
+
+    # 3) Compose from building blocks: routing → routed experts → shared experts
+    topk_indices, topk_weights = sigmoid_topk_routing(
+        x,
+        w_router=moe_mod.gate.weight.data,
+        top_k=config.num_experts_per_tok,
+        n_group=config.n_group,
+        topk_group=config.topk_group,
+        e_score_correction_bias=moe_mod.gate.e_score_correction_bias,
+        routed_scaling_factor=config.routed_scaling_factor,
+        norm_topk_prob=config.norm_topk_prob,
+    )
+
+    our_out = moe_torch(
+        x, w_router=moe_mod.gate.weight.data, w1=w1, w2=w2, w3=w3,
+        top_k=config.num_experts_per_tok,
+        precomputed_routing=(topk_indices, topk_weights),
+    )
+    our_out = our_out + moe_shared_experts_torch(x, **shared_kwargs)
+
+    # 4) Compare
+    assert_close(hf_out, our_out, atol=1e-5, rtol=1e-5), \
+        "moe building blocks vs HF DeepSeek V3 MoE mismatch"

--- a/models/demos/deepseek_v3_b1/tests/block_tests/test_moe.py
+++ b/models/demos/deepseek_v3_b1/tests/block_tests/test_moe.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
 """MoE unit tests + comparison vs HF MoE module."""
 
 import torch

--- a/models/demos/deepseek_v3_b1/tests/block_tests/test_moe.py
+++ b/models/demos/deepseek_v3_b1/tests/block_tests/test_moe.py
@@ -7,7 +7,7 @@
 import torch
 
 from helpers import seed_all, assert_close, make_profiles
-from moe import moe_torch, moe_tt, moe_shared_experts_torch, sigmoid_topk_routing
+from moe import moe_torch, moe_tt
 
 
 def _make_moe_weights(profile, dtype=torch.float32):
@@ -18,6 +18,7 @@ def _make_moe_weights(profile, dtype=torch.float32):
         w_router=torch.randn(ne, h, dtype=dtype),
         w1=torch.randn(ne, mi, h, dtype=dtype),
         w2=torch.randn(ne, h, mi, dtype=dtype),
+        w3=torch.randn(ne, mi, h, dtype=dtype),
     )
 
 
@@ -137,23 +138,19 @@ def test_moe_deepseek_v3():
     shared_kwargs = _extract_shared_expert_weights(moe_mod.shared_experts)
 
     # 3) Compose from building blocks: routing → routed experts → shared experts
-    topk_indices, topk_weights = sigmoid_topk_routing(
-        x,
-        w_router=moe_mod.gate.weight.data,
-        top_k=config.num_experts_per_tok,
-        n_group=config.n_group,
-        topk_group=config.topk_group,
-        e_score_correction_bias=moe_mod.gate.e_score_correction_bias,
-        routed_scaling_factor=config.routed_scaling_factor,
-        norm_topk_prob=config.norm_topk_prob,
-    )
-
     our_out = moe_torch(
         x, w_router=moe_mod.gate.weight.data, w1=w1, w2=w2, w3=w3,
         top_k=config.num_experts_per_tok,
-        precomputed_routing=(topk_indices, topk_weights),
+        gate_kwargs=dict(
+            score_func="sigmoid",
+            n_group=config.n_group,
+            topk_group=config.topk_group,
+            e_score_correction_bias=moe_mod.gate.e_score_correction_bias,
+            routed_scaling_factor=config.routed_scaling_factor,
+            norm_topk_prob=config.norm_topk_prob,
+        ),
+        shared_mlp_kwargs=shared_kwargs,
     )
-    our_out = our_out + moe_shared_experts_torch(x, **shared_kwargs)
 
     # 4) Compare
     assert_close(hf_out, our_out, atol=1e-5, rtol=1e-5), \


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=az_it_lg/blaze_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:az_it_lg/blaze_tests)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=az_it_lg/blaze_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:az_it_lg/blaze_tests)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=az_it_lg/blaze_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:az_it_lg/blaze_tests)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=az_it_lg/blaze_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:az_it_lg/blaze_tests)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=az_it_lg/blaze_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:az_it_lg/blaze_tests)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=az_it_lg/blaze_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:az_it_lg/blaze_tests)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
