### PR TITLE
Clean up gather reduce

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/kernels/attention_block_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/kernels/attention_block_kernel.cpp
@@ -143,8 +143,8 @@ void kernel_main() {
         get_named_compile_time_arg_val("gather_reduce_grid_end_x"),
         get_named_compile_time_arg_val("gather_reduce_grid_end_y"),
         get_named_compile_time_arg_val("gather_reduce_half_num_cores"),
-        get_named_compile_time_arg_val("gather_reduce_half0_cb_id"),
-        get_named_compile_time_arg_val("gather_reduce_half1_cb_id"),
+        get_named_compile_time_arg_val("gather_reduce_dst_cb"),
+        get_named_compile_time_arg_val("gather_reduce_half_size_bytes"),
     };
 
     // RMSNorm2 reader args
@@ -517,8 +517,7 @@ void kernel_main() {
         get_named_compile_time_arg_val("gather_reduce_noc1_num_senders"),
         get_named_compile_time_arg_val("gather_reduce_noc0_receiver_semaphore_addr"),
         get_named_compile_time_arg_val("gather_reduce_noc1_receiver_semaphore_addr"),
-        get_named_compile_time_arg_val("gather_reduce_half0_dst_cb"),
-        get_named_compile_time_arg_val("gather_reduce_half1_dst_cb"),
+        get_named_compile_time_arg_val("gather_reduce_dst_cb"),
         get_named_compile_time_arg_val("gather_reduce_dst_num_tiles"),
     };
 
@@ -879,8 +878,8 @@ void kernel_main() {
 
     // Gather reduce compute args
     deepseek_b1_ops::GatherReduce::ComputeArgs gather_reduce_args{
-        get_named_compile_time_arg_val("gather_reduce_half0_dst_cb"),
-        get_named_compile_time_arg_val("gather_reduce_half1_dst_cb"),
+        get_named_compile_time_arg_val("gather_reduce_dst_cb"),
+        get_named_compile_time_arg_val("gather_reduce_out_cb"),
         get_named_compile_time_arg_val("gather_reduce_dst_num_tiles"),
     };
 
@@ -1227,28 +1226,30 @@ void kernel_main() {
         // work / owns the current KV-cache slot. The normalized (device-local)
         // local_cur_pos is used for kv cache update and flash mla.
         volatile tt_l1_ptr uint32_t* pos_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cur_pos_addr);
+        invalidate_l1_cache();
         uint32_t cur_pos = pos_ptr[0];
 
         const auto [skip_attention, skip_kv_cache_update, local_cur_pos] = get_device_mla_work_assignment(
             cur_pos, Core::kv_cache_sp_device_idx, Core::kv_cache_device_chunk_size, Core::kv_cache_num_sp_devices);
 
         using FlashMLAOp = deepseek_b1_ops::FlashMLADecode::Op<FlashMLACTArgs, Core::is_mla_core>;
+        // The first mcast is also used to synchronize downstream ccls, so must always run.
+        // Can revisit this later
+        // ====================================================================
+        // Input core: RMSNorm + Mcast send
+        // ====================================================================
+        {
+            DeviceZoneScopedN("RMSNORM");
+            deepseek_b1_ops::RMSNorm::Op<RMSNormCTArgs, Core::is_input_core, true> rmsnorm;
+            rmsnorm(rmsnorm_args);
+        }
+
+        {
+            DeviceZoneScopedN("MCAST");
+            mcast(mcast_args);
+        }
 
         if (!skip_attention) {
-            // ====================================================================
-            // Input core: RMSNorm + Mcast send
-            // ====================================================================
-            {
-                DeviceZoneScopedN("RMSNORM");
-                deepseek_b1_ops::RMSNorm::Op<RMSNormCTArgs, Core::is_input_core, true> rmsnorm;
-                rmsnorm(rmsnorm_args);
-            }
-
-            {
-                DeviceZoneScopedN("MCAST");
-                mcast(mcast_args);
-            }
-
             // ====================================================================
             // Matmul operation
             // ====================================================================

--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
@@ -851,9 +851,9 @@ class AttentionBlock:
             data_format, TD_16x32
         )  # Gamma for second RMSNorm (1536 elements = 3 tiles of 16x32)
         rmsnorm2_input_cb = cb_id_context.get_cb_id(data_format, TD_16x32)  # Input CB for RMSNorm2
-        gather_reduce_half1_scratch_cb = cb_id_context.get_cb_id(
+        gather_reduce_scratch_cb = cb_id_context.get_cb_id(
             data_format, TD_16x32
-        )  # Dedicated half1 scratch CB for gather_reduce
+        )  # Dedicated scratch CB for gather_reduce (stores both halves: 2 * dst_num_tiles of 16x32)
         rmsnorm2_output_cb = cb_id_context.get_cb_id(data_format, TD_16x32)  # Output CB for RMSNorm2
         # Matmul2 + Matmul3 + QRoPE/CreateQHeads path
         matmul2_input_cb = cb_id_context.get_cb_id(
@@ -981,6 +981,14 @@ class AttentionBlock:
         # KV Cache Branch parameters
         dkv_matmul_k_num_tiles = 7168 // 32
         dkv_matmul_input_page_size = TILE_1x32.get_tile_size(data_format)
+
+        # Create tile descriptor for proper tile dimensions
+        tile_descriptor = ttnn.TileDescriptor(interpreted_tile)
+
+        # RMSNorm2 uses separate CBs with exact sizes (16x32 tiles)
+        TILE_16x32 = ttnn.Tile((16, 32))
+        rmsnorm2_tile_descriptor = ttnn.TileDescriptor(TILE_16x32)
+        rmsnorm2_page_size = TILE_16x32.get_tile_size(data_format)
 
         # RMSNorm reader compile-time args (named args for NCRISC)
         rmsnorm_reader_named_compile_time_args = [
@@ -1280,8 +1288,8 @@ class AttentionBlock:
             ("gather_reduce_grid_end_x", matmul_bbox.end.x),
             ("gather_reduce_grid_end_y", matmul_bbox.end.y),
             ("gather_reduce_half_num_cores", matmul_half_num_cores),
-            ("gather_reduce_half0_cb_id", rmsnorm2_input_cb),
-            ("gather_reduce_half1_cb_id", gather_reduce_half1_scratch_cb),
+            ("gather_reduce_dst_cb", gather_reduce_scratch_cb),
+            ("gather_reduce_half_size_bytes", rmsnorm2_num_tiles * rmsnorm2_page_size),
         ]
 
         # Gather receiver compile-time args (named args for BRISC on rmsnorm core)
@@ -1293,14 +1301,13 @@ class AttentionBlock:
             ("gather_reduce_noc1_num_senders", gather_reduce_noc1_num_senders),
             ("gather_reduce_noc0_receiver_semaphore_addr", gather_reduce_noc0_receiver_semaphore_addr),
             ("gather_reduce_noc1_receiver_semaphore_addr", gather_reduce_noc1_receiver_semaphore_addr),
-            ("gather_reduce_half0_dst_cb", rmsnorm2_input_cb),
-            ("gather_reduce_half1_dst_cb", gather_reduce_half1_scratch_cb),
+            ("gather_reduce_dst_cb", gather_reduce_scratch_cb),
             ("gather_reduce_dst_num_tiles", rmsnorm2_num_tiles),
         ]
         # TRISC: compute-side gather-reduce destination CBs and tile count
         gather_reduce_trisc_named_compile_time_args = [
-            ("gather_reduce_half0_dst_cb", rmsnorm2_input_cb),
-            ("gather_reduce_half1_dst_cb", gather_reduce_half1_scratch_cb),
+            ("gather_reduce_dst_cb", gather_reduce_scratch_cb),
+            ("gather_reduce_out_cb", rmsnorm2_input_cb),
             ("gather_reduce_dst_num_tiles", rmsnorm2_num_tiles),
         ]
 
@@ -1853,14 +1860,6 @@ class AttentionBlock:
             ]
         )
 
-        # Create tile descriptor for proper tile dimensions
-        tile_descriptor = ttnn.TileDescriptor(interpreted_tile)
-
-        # RMSNorm2 uses separate CBs with exact sizes (16x32 tiles)
-        TILE_16x32 = ttnn.Tile((16, 32))
-        rmsnorm2_tile_descriptor = ttnn.TileDescriptor(TILE_16x32)
-        rmsnorm2_page_size = TILE_16x32.get_tile_size(data_format)
-
         # Reference tensors from device 0 for CB descriptor creation
         # (all devices have identical buffer addresses, sizes, and layouts)
         ref_input_tensor = input_tensors_per_device[0]
@@ -2039,24 +2038,23 @@ class AttentionBlock:
         # 1) RMSNorm2 writes normalized output here
         # 2) Mcast2 reads from CB9 and writes to matmul2 input CB
 
-        # CB 8: gather_reduce half1 scratch buffer (3 tiles) — overlap with sdpa_out_interm L1 buffer
-        # at offset 3136 B. This CB is consumed before SDPA runs.
-        gather_reduce_half1_scratch_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
-            gather_reduce_half1_scratch_cb,
+        gather_reduce_scratch_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+            gather_reduce_scratch_cb,
             ref_sdpa_kv_cache_buffer,
-            address_offset=sdpa_kv_cache_running_offset_mcast_core,  # 17472 B
-            total_size=rmsnorm2_num_tiles * rmsnorm2_page_size,
+            address_offset=sdpa_kv_cache_running_offset_mcast_core,
+            total_size=2 * rmsnorm2_num_tiles * rmsnorm2_page_size,
             core_ranges=full_device_grid,
         )
-        gather_reduce_half1_scratch_cb_descriptor.format_descriptors = [
+
+        gather_reduce_scratch_cb_descriptor.format_descriptors = [
             ttnn.CBFormatDescriptor(
-                buffer_index=gather_reduce_half1_scratch_cb,
+                buffer_index=gather_reduce_scratch_cb,
                 data_format=data_format,
                 page_size=rmsnorm2_page_size,
                 tile=rmsnorm2_tile_descriptor,
             )
         ]
-        sdpa_kv_cache_running_offset_mcast_core += gather_reduce_half1_scratch_cb_descriptor.total_size  # +3072 B
+        sdpa_kv_cache_running_offset_mcast_core += gather_reduce_scratch_cb_descriptor.total_size
 
         # CB: RMSNorm2 output buffer (3 tiles)
         rmsnorm2_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
@@ -3309,7 +3307,7 @@ class AttentionBlock:
             matmul_input_cb_descriptor,
             rmsnorm2_gamma_cb_descriptor,
             rmsnorm2_input_cb_descriptor,
-            gather_reduce_half1_scratch_cb_descriptor,
+            gather_reduce_scratch_cb_descriptor,
             rmsnorm2_output_cb_descriptor,
             matmul2_input_cb_descriptor,
             matmul2_output_cb_descriptor,

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
@@ -153,8 +153,8 @@ uint32_t per_core_rta_arg_idx = 0;
         get_named_compile_time_arg_val("gather_reduce_grid_end_x"),
         get_named_compile_time_arg_val("gather_reduce_grid_end_y"),
         get_named_compile_time_arg_val("gather_reduce_half_num_cores"),
-        get_named_compile_time_arg_val("gather_reduce_half0_cb_id"),
-        get_named_compile_time_arg_val("gather_reduce_half1_cb_id"),
+        get_named_compile_time_arg_val("gather_reduce_dst_cb"),
+        get_named_compile_time_arg_val("gather_reduce_half_size_bytes"),
     };
 
     // RMSNorm2 reader args
@@ -365,8 +365,7 @@ uint32_t per_core_rta_arg_idx = 0;
         get_named_compile_time_arg_val("gather_reduce_noc1_num_senders"),
         get_named_compile_time_arg_val("gather_reduce_noc0_receiver_semaphore_addr"),
         get_named_compile_time_arg_val("gather_reduce_noc1_receiver_semaphore_addr"),
-        get_named_compile_time_arg_val("gather_reduce_half0_dst_cb"),
-        get_named_compile_time_arg_val("gather_reduce_half1_dst_cb"),
+        get_named_compile_time_arg_val("gather_reduce_dst_cb"),
         get_named_compile_time_arg_val("gather_reduce_dst_num_tiles"),
     };
 
@@ -579,8 +578,8 @@ uint32_t per_core_rta_arg_idx = 0;
 
     // Gather reduce compute args
     deepseek_b1_ops::GatherReduce::ComputeArgs gather_reduce_args{
-        get_named_compile_time_arg_val("gather_reduce_half0_dst_cb"),
-        get_named_compile_time_arg_val("gather_reduce_half1_dst_cb"),
+        get_named_compile_time_arg_val("gather_reduce_dst_cb"),
+        get_named_compile_time_arg_val("gather_reduce_out_cb"),
         get_named_compile_time_arg_val("gather_reduce_dst_num_tiles"),
     };
 

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
@@ -556,7 +556,9 @@ class PreSDPA:
         matmul_input_cb = 5
         rmsnorm2_gamma_cb = 6  # Gamma for second RMSNorm (1536 elements = 3 tiles of 16x32)
         rmsnorm2_input_cb = 7  # Input CB for RMSNorm2
-        gather_reduce_half1_scratch_cb = 8  # Dedicated half1 scratch CB for gather_reduce
+        gather_reduce_scratch_cb = (
+            8  # Dedicated scratch CB for gather_reduce (stores both halves: 2 * dst_num_tiles of 16x32)
+        )
         rmsnorm2_output_cb = 9  # Output CB for RMSNorm2
         # Matmul2 + Matmul3 + QRoPE/CreateQHeads path
         matmul2_input_cb = 10  # Input CB for second matmul (1x1536 with 1x32 tiles)
@@ -635,6 +637,14 @@ class PreSDPA:
         # KV Cache Branch parameters
         dkv_matmul_k_num_tiles = 7168 // 32
         dkv_matmul_input_page_size = TILE_1x32.get_tile_size(data_format)
+
+        # Create tile descriptor for proper tile dimensions
+        tile_descriptor = ttnn.TileDescriptor(interpreted_tile)
+
+        # RMSNorm2 uses separate CBs with exact sizes (16x32 tiles)
+        TILE_16x32 = ttnn.Tile((16, 32))
+        rmsnorm2_tile_descriptor = ttnn.TileDescriptor(TILE_16x32)
+        rmsnorm2_page_size = TILE_16x32.get_tile_size(data_format)
 
         # RMSNorm reader compile-time args (named args for NCRISC)
         rmsnorm_reader_named_compile_time_args = [
@@ -934,8 +944,8 @@ class PreSDPA:
             ("gather_reduce_grid_end_x", matmul_bbox.end.x),
             ("gather_reduce_grid_end_y", matmul_bbox.end.y),
             ("gather_reduce_half_num_cores", matmul_half_num_cores),
-            ("gather_reduce_half0_cb_id", rmsnorm2_input_cb),
-            ("gather_reduce_half1_cb_id", gather_reduce_half1_scratch_cb),
+            ("gather_reduce_dst_cb", gather_reduce_scratch_cb),
+            ("gather_reduce_half_size_bytes", rmsnorm2_num_tiles * rmsnorm2_page_size),
         ]
 
         # Gather receiver compile-time args (named args for BRISC on rmsnorm core)
@@ -947,14 +957,13 @@ class PreSDPA:
             ("gather_reduce_noc1_num_senders", gather_reduce_noc1_num_senders),
             ("gather_reduce_noc0_receiver_semaphore_addr", gather_reduce_noc0_receiver_semaphore_addr),
             ("gather_reduce_noc1_receiver_semaphore_addr", gather_reduce_noc1_receiver_semaphore_addr),
-            ("gather_reduce_half0_dst_cb", rmsnorm2_input_cb),
-            ("gather_reduce_half1_dst_cb", gather_reduce_half1_scratch_cb),
+            ("gather_reduce_dst_cb", gather_reduce_scratch_cb),
             ("gather_reduce_dst_num_tiles", rmsnorm2_num_tiles),
         ]
         # TRISC: compute-side gather-reduce destination CBs and tile count
         gather_reduce_trisc_named_compile_time_args = [
-            ("gather_reduce_half0_dst_cb", rmsnorm2_input_cb),
-            ("gather_reduce_half1_dst_cb", gather_reduce_half1_scratch_cb),
+            ("gather_reduce_dst_cb", gather_reduce_scratch_cb),
+            ("gather_reduce_out_cb", rmsnorm2_input_cb),
             ("gather_reduce_dst_num_tiles", rmsnorm2_num_tiles),
         ]
 
@@ -1285,14 +1294,6 @@ class PreSDPA:
             ("mla_out_final_cb", mla_out_final_cb),
         ]
 
-        # Create tile descriptor for proper tile dimensions
-        tile_descriptor = ttnn.TileDescriptor(interpreted_tile)
-
-        # RMSNorm2 uses separate CBs with exact sizes (16x32 tiles)
-        TILE_16x32 = ttnn.Tile((16, 32))
-        rmsnorm2_tile_descriptor = ttnn.TileDescriptor(TILE_16x32)
-        rmsnorm2_page_size = TILE_16x32.get_tile_size(data_format)
-
         per_device_contexts = []
 
         # ========================================================================
@@ -1511,23 +1512,24 @@ class PreSDPA:
                 # 1) RMSNorm2 writes normalized output here
                 # 2) Mcast2 reads from CB9 and writes to matmul2 input CB
 
-                # CB 8: gather_reduce half1 scratch buffer (3 tiles) — overlap with sdpa_out_interm L1 buffer
-                # This CB is consumed before SDPA runs.
-                gather_reduce_half1_scratch_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
-                    gather_reduce_half1_scratch_cb,
+                gather_reduce_scratch_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+                    gather_reduce_scratch_cb,
                     sdpa_kv_cache_buffer_device,
                     address_offset=sdpa_kv_cache_running_offset_mcast_core,
-                    total_size=rmsnorm2_num_tiles * rmsnorm2_page_size,
+                    total_size=2 * rmsnorm2_num_tiles * rmsnorm2_page_size,
+                    core_ranges=full_device_grid,
                 )
-                gather_reduce_half1_scratch_cb_descriptor.format_descriptors = [
+
+                gather_reduce_scratch_cb_descriptor.format_descriptors = [
                     ttnn.CBFormatDescriptor(
-                        buffer_index=gather_reduce_half1_scratch_cb,
+                        buffer_index=gather_reduce_scratch_cb,
                         data_format=data_format,
                         page_size=rmsnorm2_page_size,
                         tile=rmsnorm2_tile_descriptor,
                     )
                 ]
-                sdpa_kv_cache_running_offset_mcast_core += gather_reduce_half1_scratch_cb_descriptor.total_size
+                sdpa_kv_cache_running_offset_mcast_core += gather_reduce_scratch_cb_descriptor.total_size
+
                 # CB: RMSNorm2 output buffer (3 tiles)
                 rmsnorm2_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     rmsnorm2_output_cb,
@@ -2385,7 +2387,7 @@ class PreSDPA:
                     matmul_input_cb_descriptor,
                     rmsnorm2_gamma_cb_descriptor,
                     rmsnorm2_input_cb_descriptor,
-                    gather_reduce_half1_scratch_cb_descriptor,
+                    gather_reduce_scratch_cb_descriptor,
                     rmsnorm2_output_cb_descriptor,
                     matmul2_input_cb_descriptor,
                     matmul2_weights_cb_descriptor,

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_attention_block.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_attention_block.py
@@ -1104,9 +1104,15 @@ def test_attention_block(
     # ========================================================================
     # Validate attention block output (full pipeline: SDPA -> kv_b2 -> o_proj -> all-reduce + residual)
     # ========================================================================
+    ref_device_idx = 0
+    ref_device_output = output_torch[ref_device_idx : ref_device_idx + 1, :]
     for device_idx in range(mesh_rows * mesh_cols):
         received = output_torch[device_idx : device_idx + 1, :]
-        passing, pcc = comp_pcc(torch_output_expected, received, 0.996)
+        if device_idx != ref_device_idx:
+            dev_eq = torch.equal(received, ref_device_output)
+            assert dev_eq, f"Device {device_idx} output mismatch"
+
+        passing, pcc = comp_pcc(torch_output_expected, received, 0.997)
         logger.info(f"Device {device_idx} Attention Block Output PCC: {pcc}")
         assert passing, f"Device {device_idx} Attention Block Output PCC check failed: {pcc}"
 

--- a/models/demos/deepseek_v3_b1/unified_kernels/gather_reduce.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/gather_reduce.hpp
@@ -28,16 +28,16 @@ namespace deepseek_b1_ops {
 // CB States:
 //   NCRISC (Sender):
 //     - Waits: src_cb (src_num_pages)
-//     - Remote writes: dst_cb_id chosen from {half0_cb_id, half1_cb_id}
+//     - Remote writes: dst_cb (dst_num_tiles)
 //     - Pops: src_cb (src_num_pages) if pop_src=true
 //   BRISC (Receiver):
-//     - Reserves: half0_dst_cb (dst_num_tiles), half1_dst_cb (dst_num_tiles)
-//     - Pushes: half0_dst_cb (dst_num_tiles), half1_dst_cb (dst_num_tiles)
+//     - Reserves: dst_cb (2 * dst_num_tiles)
+//     - Pushes: dst_cb (2 * dst_num_tiles)
 //   TRISC (Reducer):
-//     - Waits: in0_cb/in1_cb (num_tiles)
-//     - Computes: in0_cb += in1_cb
-//     - Pops: in0_cb and in1_cb (num_tiles)
-//     - Re-pushes: in0_cb (num_tiles)
+//     - Waits: in_cb (2 * num_tiles)
+//     - Computes: out_cb = in_cb first half + in_cb second half
+//     - Pops: in_cb (2 * num_tiles)
+//     - Re-pushes: out_cb (num_tiles)
 //
 // Semaphore states:
 //   Sender: increments receiver semaphore after NOC write completion
@@ -54,8 +54,7 @@ struct GatherReduce {
         uint32_t noc1_num_senders;
         uint32_t noc0_receiver_semaphore_addr;
         uint32_t noc1_receiver_semaphore_addr;
-        uint32_t half0_dst_cb;
-        uint32_t half1_dst_cb;
+        uint32_t dst_cb;
         uint32_t dst_num_tiles;
     };
 
@@ -71,13 +70,13 @@ struct GatherReduce {
         uint32_t gather_reduce_grid_end_x;
         uint32_t gather_reduce_grid_end_y;
         uint32_t gather_reduce_half_num_cores;
-        uint32_t half0_cb_id;
-        uint32_t half1_cb_id;
+        uint32_t dst_cb_id;
+        uint32_t half_size_bytes;
     };
 
     struct ComputeArgs {
-        uint32_t in0_cb;
-        uint32_t in1_cb;
+        uint32_t in_cb;
+        uint32_t out_cb;
         uint32_t num_tiles;
     };
 
@@ -85,35 +84,27 @@ struct GatherReduce {
     using RTArgs = unified_kernels::SelectByRISCV<SenderArgs, ReceiverArgs, ComputeArgs>;
 
 #if defined(COMPILE_FOR_TRISC)
-    // in0_cb += in1_cb over num_tiles tiles, in place
-    static inline void add_tiles_inplace(uint32_t in0_cb, uint32_t in1_cb, uint32_t num_tiles) {
-        reconfig_data_format<false, true>(in0_cb, in1_cb);
-        pack_reconfig_data_format<true>(in0_cb);
-        add_tiles_init(in0_cb, in1_cb);
-        cb_wait_front(in0_cb, num_tiles);
-        cb_wait_front(in1_cb, num_tiles);
-
-        uint32_t in0_cb_base_rd_ptr = 0;
-        UNPACK(({ in0_cb_base_rd_ptr = unified_kernels::get_local_cb_rd_ptr(in0_cb); }));
+    static inline void add_half_tiles(uint32_t in_cb, uint32_t out_cb, uint32_t num_tiles) {
+        reconfig_data_format<false, true>(in_cb, in_cb);
+        pack_reconfig_data_format<true>(out_cb);
+        add_tiles_init(in_cb, in_cb);
+        cb_wait_front(in_cb, 2 * num_tiles);
+        cb_reserve_back(out_cb, num_tiles);
 
         // Process tiles - element-wise add
         tile_regs_acquire();
         for (uint32_t i = 0; i < num_tiles; i++) {
-            add_tiles(in0_cb, in1_cb, i, i, i);
+            add_tiles(in_cb, in_cb, i, num_tiles + i, i);
         }
         tile_regs_commit();
         tile_regs_wait();
         for (uint32_t i = 0; i < num_tiles; i++) {
-            pack_tile(i, in0_cb);
+            pack_tile(i, out_cb);
         }
+        cb_push_back(out_cb, num_tiles);
         tile_regs_release();
 
-        // restore in0_cb read pointer to the beginning of the block so that the reduced tiles can be popped by the
-        // caller
-        UNPACK(({ unified_kernels::update_local_cb_rd_ptr(in0_cb, in0_cb_base_rd_ptr); }));
-
-        // pop cb1 after reduction since it's no longer needed
-        cb_pop_front(in1_cb, num_tiles);
+        cb_pop_front(in_cb, 2 * num_tiles);
     }
 #endif
 
@@ -143,9 +134,9 @@ struct GatherReduce {
                     args.gather_reduce_grid_end_x,
                     args.gather_reduce_grid_end_y,
                     args.gather_reduce_half_num_cores);
-                uint32_t dst_cb_id = half_info.is_half0 ? args.half0_cb_id : args.half1_cb_id;
-                uint32_t dst_base_addr = get_write_ptr(dst_cb_id);
-                uint32_t dst_offset = half_info.half_local_idx * args.data_size_bytes;
+                uint32_t dst_base_addr = get_write_ptr(args.dst_cb_id);
+                uint32_t dst_offset =
+                    (half_info.is_half0 ? 0 : args.half_size_bytes) + half_info.half_local_idx * args.data_size_bytes;
 
                 const uint64_t dst_noc_coord = get_noc_addr(args.dest_noc_x, args.dest_noc_y, 0);
                 uint64_t dst_data_noc_addr = dst_noc_coord | (uint64_t)(dst_base_addr + dst_offset);
@@ -177,8 +168,7 @@ struct GatherReduce {
                     (volatile tt_l1_ptr uint32_t*)args.noc0_receiver_semaphore_addr;
 
                 // Reserve space in destination CBs
-                cb_reserve_back(args.half0_dst_cb, args.dst_num_tiles);
-                cb_reserve_back(args.half1_dst_cb, args.dst_num_tiles);
+                cb_reserve_back(args.dst_cb, 2 * args.dst_num_tiles);
 
                 noc_semaphore_wait(noc0_receiver_semaphore_addr_ptr, args.noc0_num_senders);
                 noc_semaphore_set(noc0_receiver_semaphore_addr_ptr, 0);
@@ -191,15 +181,14 @@ struct GatherReduce {
                 }
 
                 // Push to destination CBs after data arrived
-                cb_push_back(args.half0_dst_cb, args.dst_num_tiles);
-                cb_push_back(args.half1_dst_cb, args.dst_num_tiles);
+                cb_push_back(args.dst_cb, 2 * args.dst_num_tiles);
             }
 #elif defined(COMPILE_FOR_TRISC)
             // ================================================================
             // TRISC - No-op (gather is dataflow only)
             // ================================================================
             if constexpr (IsReduceCore) {
-                add_tiles_inplace(args.in0_cb, args.in1_cb, args.num_tiles);
+                add_half_tiles(args.in_cb, args.out_cb, args.num_tiles);
             }
 #endif
         }

--- a/models/demos/deepseek_v3_b1/unified_kernels/kernel_utils.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/kernel_utils.hpp
@@ -91,6 +91,9 @@ FORCE_INLINE void semaphore_dec(volatile tt_l1_ptr uint32_t* sem_addr) {
 // Phase 1: BR/TR0/TR2 signal done → NC waits for all 3
 FORCE_INLINE void sync_riscs_enter(volatile uint32_t tt_l1_ptr* sem_addr) {
 #if defined(COMPILE_FOR_BRISC) || defined(UCK_CHLKC_UNPACK) || defined(UCK_CHLKC_PACK)
+#if defined(UCK_CHLKC_UNPACK) || defined(UCK_CHLKC_PACK)
+    tensix_sync();
+#endif
     __atomic_fetch_add(&sem_addr[0], 1, __ATOMIC_RELAXED);
 #elif defined(COMPILE_FOR_NCRISC)
     while (__atomic_load_n(&sem_addr[0], __ATOMIC_RELAXED) < 3) {
@@ -140,7 +143,7 @@ FORCE_INLINE void override_cb_rd_ptr(uint32_t cb_id, uint32_t byte_address) {
 //   NCRISC/BRISC:  read=true,  write=true
 //   TRISC0/unpack: read=true,  write=false
 //   TRISC2/pack:   read=false, write=true
-template <bool do_read, bool do_write, bool do_reset_stream_regs>
+template <bool do_read, bool do_write, bool do_write_tile_ptr, bool do_reset_stream_regs>
 FORCE_INLINE void reconfig_cbs_for_mask(uint32_t tt_l1_ptr* cb_config, uint32_t mask, uint32_t start_cb) {
     uint32_t cb = start_cb;
     while (mask) {
@@ -158,6 +161,9 @@ FORCE_INLINE void reconfig_cbs_for_mask(uint32_t tt_l1_ptr* cb_config, uint32_t 
             if constexpr (do_write) {
                 iface.fifo_wr_ptr = fifo_addr;
                 iface.fifo_num_pages = fifo_num_pages;
+            }
+            if constexpr (do_write_tile_ptr) {
+                iface.fifo_wr_tile_ptr = 0;
             }
             iface.fifo_size = fifo_size;
             iface.fifo_limit = fifo_addr + fifo_size;
@@ -179,26 +185,30 @@ FORCE_INLINE void reconfig_cb_interfaces(uint32_t tt_l1_ptr* cb_config) {
 #if defined(COMPILE_FOR_NCRISC)
     constexpr bool do_read = true;
     constexpr bool do_write = true;
+    constexpr bool do_write_tile_ptr = false;
     constexpr bool do_reset_stream_regs = true;
 #elif defined(COMPILE_FOR_BRISC)
     constexpr bool do_read = true;
     constexpr bool do_write = true;
+    constexpr bool do_write_tile_ptr = false;
     constexpr bool do_reset_stream_regs = false;
 #elif defined(UCK_CHLKC_UNPACK)
     constexpr bool do_read = true;
     constexpr bool do_write = false;
+    constexpr bool do_write_tile_ptr = false;
     constexpr bool do_reset_stream_regs = false;
 #elif defined(UCK_CHLKC_PACK)
     constexpr bool do_read = false;
     constexpr bool do_write = true;
+    constexpr bool do_write_tile_ptr = true;
     constexpr bool do_reset_stream_regs = false;
 #endif
 
     volatile uint32_t tt_l1_ptr* reconfig_sem = reinterpret_cast<volatile uint32_t tt_l1_ptr*>(&cb_config[258]);
     sync_riscs_enter(reconfig_sem);
 
-    reconfig_cbs_for_mask<do_read, do_write, do_reset_stream_regs>(cb_config, cb_config[256], 0);
-    reconfig_cbs_for_mask<do_read, do_write, do_reset_stream_regs>(cb_config, cb_config[257], 32);
+    reconfig_cbs_for_mask<do_read, do_write, do_write_tile_ptr, do_reset_stream_regs>(cb_config, cb_config[256], 0);
+    reconfig_cbs_for_mask<do_read, do_write, do_write_tile_ptr, do_reset_stream_regs>(cb_config, cb_config[257], 32);
 
     sync_riscs_exit(reconfig_sem);
 #else

--- a/models/demos/deepseek_v3_b1/unified_kernels/mcast.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/mcast.hpp
@@ -311,6 +311,7 @@ struct Mcast {
                         CTArgsT::is_part_of_receiver_grid,
                         linked,
                         posted>(mcast_flag_noc_addr, args.data_sender_semaphore_addr);
+                    noc_async_posted_writes_flushed();
                 }
                 noc_semaphore_set(data_sender_semaphore_addr_ptr, VALID);
             }


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Gather reduce had a race with 2nd RMSNorm since they were both using the same CB as input, and gather reduce was updating in place.

### What's changed
Use a separate CB for gather reduce input/output, to properly signal 2nd RMSNorm.
Move attention block mcast outside of skip attention conditional. This is used to signal downstream CCLs that broadcast is finished so should always run.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aho/gather-reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aho/gather-reduce)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aho/gather-reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/gather-reduce)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aho/gather-reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/gather-reduce)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aho/gather-reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/gather-reduce)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aho/gather-reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/gather-reduce)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aho/gather-reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/gather-reduce)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
