### PR TITLE
[tt-train] Prefer runtime root in Python config loading

### DIFF
--- a/tt-train/sources/examples/gsm8k_finetune/gsm8k_finetune.py
+++ b/tt-train/sources/examples/gsm8k_finetune/gsm8k_finetune.py
@@ -344,12 +344,12 @@ def train():
     tokenizer = AutoTokenizer.from_pretrained("gpt2")
 
     yaml_config = load_config(
-        CONFIG, f"{get_tt_metal_home()}/tt-train/configs/training_configs"
+        CONFIG, f"{get_tt_metal_runtime_root()}/tt-train/configs/training_configs"
     )
     model_config = load_config(yaml_config["training_config"]["model_config"])
 
     override_config_path = (
-        f"{os.environ['TT_METAL_HOME']}/tt-train/configs/training_overrides.yaml"
+        f"{get_tt_metal_runtime_root()}/tt-train/configs/training_overrides.yaml"
     )
 
     if os.path.isfile(override_config_path):

--- a/tt-train/sources/examples/gsm8k_finetune/gsm8k_finetune.py
+++ b/tt-train/sources/examples/gsm8k_finetune/gsm8k_finetune.py
@@ -87,9 +87,7 @@ def gsm8k_collate_fn(
     input_ids_np = data_np.reshape(batch_size, 1, 1, max_sequence_length)
 
     # labels: shift left by 1 for next-token prediction
-    labels_np = np.full(
-        (batch_size, max_sequence_length), eos_token_id, dtype=np.uint32
-    )
+    labels_np = np.full((batch_size, max_sequence_length), eos_token_id, dtype=np.uint32)
     labels_np[:, :-1] = input_ids_np[:, 0, 0, 1:]
 
     # loss_mask: 0 for prompt tokens and padding, 1 elsewhere, then normalised
@@ -104,15 +102,9 @@ def gsm8k_collate_fn(
         loss_mask_np *= (batch_size * max_sequence_length) / total_weight
 
     return Batch(
-        input_ids=ttml.autograd.Tensor.from_numpy(
-            input_ids_np, ttnn.Layout.ROW_MAJOR, ttnn.DataType.UINT32
-        ),
-        labels=ttml.autograd.Tensor.from_numpy(
-            labels_np, ttnn.Layout.ROW_MAJOR, ttnn.DataType.UINT32
-        ),
-        loss_mask=ttml.autograd.Tensor.from_numpy(
-            loss_mask_np, ttnn.Layout.TILE, ttnn.DataType.BFLOAT16
-        ),
+        input_ids=ttml.autograd.Tensor.from_numpy(input_ids_np, ttnn.Layout.ROW_MAJOR, ttnn.DataType.UINT32),
+        labels=ttml.autograd.Tensor.from_numpy(labels_np, ttnn.Layout.ROW_MAJOR, ttnn.DataType.UINT32),
+        loss_mask=ttml.autograd.Tensor.from_numpy(loss_mask_np, ttnn.Layout.TILE, ttnn.DataType.BFLOAT16),
     )
 
 
@@ -157,9 +149,7 @@ def generate_text_tt(
     composer = ttml.core.distributed.concat_mesh_to_tensor_composer(device, 0)
 
     # Preallocate once
-    padded_prompt_tokens = np.full(
-        (1, 1, 1, max_sequence_length), pad_token_id, dtype=np.uint32
-    )
+    padded_prompt_tokens = np.full((1, 1, 1, max_sequence_length), pad_token_id, dtype=np.uint32)
 
     with no_grad():
         for _ in range(max_gen_tokens):
@@ -173,9 +163,7 @@ def generate_text_tt(
 
             # Refill buffer (fully) to avoid stale ids
             padded_prompt_tokens[...] = pad_token_id
-            padded_prompt_tokens[0, 0, 0, : len(window)] = np.asarray(
-                window, dtype=np.uint32
-            )
+            padded_prompt_tokens[0, 0, 0, : len(window)] = np.asarray(window, dtype=np.uint32)
 
             # [1,1,1,T] -> TT tensor
             padded_prompt_tensor = ttml.autograd.Tensor.from_numpy(
@@ -189,21 +177,11 @@ def generate_text_tt(
 
             # Sample: next tokens for all positions [1,1,T,1]
             # With temperature=0.0 this behaves like argmax/greedy.
-            next_token_tensor = ttml.ops.sample.sample_op(
-                logits, 0.0, np.random.randint(low=1e7), logits_mask_tensor
-            )
+            next_token_tensor = ttml.ops.sample.sample_op(logits, 0.0, np.random.randint(low=1e7), logits_mask_tensor)
 
             # Take the token at the last active position in the current window
-            next_token_idx = (
-                max_sequence_length - 1
-                if len(prompt_tokens) > max_sequence_length
-                else len(window) - 1
-            )
-            next_token = int(
-                next_token_tensor.to_numpy(composer=composer).reshape(-1, 1)[
-                    next_token_idx
-                ][0]
-            )
+            next_token_idx = max_sequence_length - 1 if len(prompt_tokens) > max_sequence_length else len(window) - 1
+            next_token = int(next_token_tensor.to_numpy(composer=composer).reshape(-1, 1)[next_token_idx][0])
 
             if next_token == tokenizer.eos_token_id:
                 break
@@ -212,9 +190,7 @@ def generate_text_tt(
             prompt_tokens.append(next_token)
 
         # Decode once at the end
-        out = tokenizer.decode(
-            prompt_tokens if return_with_prompt else generated_tokens
-        )
+        out = tokenizer.decode(prompt_tokens if return_with_prompt else generated_tokens)
 
     model.train()
 
@@ -289,9 +265,7 @@ def validate(
             val_file.write(f"Generated Answer: {gen_text}\n")
             val_file.write("\n====================================\n")
 
-        val_file.write(
-            f"Last validation loss: {float(np.mean(cur_val_losses)):.4f}\n\n\n"
-        )
+        val_file.write(f"Last validation loss: {float(np.mean(cur_val_losses)):.4f}\n\n\n")
 
     tt_model.train()
     return np.mean(cur_val_losses)
@@ -327,9 +301,7 @@ def tokenize_dataset(data, tokenizer: AutoTokenizer) -> TokenizedDataset:
     X = [sample["question"] for sample in data]
     y = [sample["answer"] for sample in data]
 
-    tok = lambda texts: tokenizer(texts, return_tensors="np", add_special_tokens=False)[
-        "input_ids"
-    ]
+    tok = lambda texts: tokenizer(texts, return_tensors="np", add_special_tokens=False)["input_ids"]
     return TokenizedDataset(tok(X), tok(y))
 
 
@@ -343,14 +315,10 @@ def train():
     # Disable tokenizer parallelism to avoid conflicts with DataLoader multiprocessing
     tokenizer = AutoTokenizer.from_pretrained("gpt2")
 
-    yaml_config = load_config(
-        CONFIG, f"{get_tt_metal_runtime_root()}/tt-train/configs/training_configs"
-    )
+    yaml_config = load_config(CONFIG, f"{get_tt_metal_runtime_root()}/tt-train/configs/training_configs")
     model_config = load_config(yaml_config["training_config"]["model_config"])
 
-    override_config_path = (
-        f"{get_tt_metal_runtime_root()}/tt-train/configs/training_overrides.yaml"
-    )
+    override_config_path = f"{get_tt_metal_runtime_root()}/tt-train/configs/training_overrides.yaml"
 
     if os.path.isfile(override_config_path):
         print("Applying training overrides...")
@@ -375,9 +343,7 @@ def train():
     # initialize device
     device_config = DeviceConfig(yaml_config)
     ttml.autograd.AutoContext.get_instance().initialize_parallelism_context(
-        ttml.autograd.DistributedConfig(
-            enable_ddp=device_config.enable_ddp, enable_tp=device_config.enable_tp
-        )
+        ttml.autograd.DistributedConfig(enable_ddp=device_config.enable_ddp, enable_tp=device_config.enable_tp)
     )
     # no need to initialize device if #devices=1
     if device_config.total_devices() > 1:
@@ -411,12 +377,8 @@ def train():
 
     # Load dataset
     print("Loading GSM8K dataset...")
-    training_data = datasets.load_dataset(
-        "gsm8k", "main", split="train", ignore_verifications=True
-    )
-    testing_data = datasets.load_dataset(
-        "gsm8k", "main", split="test", ignore_verifications=True
-    )
+    training_data = datasets.load_dataset("gsm8k", "main", split="train", ignore_verifications=True)
+    testing_data = datasets.load_dataset("gsm8k", "main", split="test", ignore_verifications=True)
 
     training_data = tokenize_dataset(training_data, tokenizer)
     testing_data = tokenize_dataset(testing_data, tokenizer)

--- a/tt-train/sources/examples/lora_llama/train_lora_llama.py
+++ b/tt-train/sources/examples/lora_llama/train_lora_llama.py
@@ -72,9 +72,7 @@ def validate_mesh_graph_descriptor(mesh_shape: list[int]) -> None:
     with open(mgd_path) as f:
         content = f.read()
 
-    dims_match = re.search(
-        r"device_topology\s*\{[^}]*dims\s*:\s*\[\s*([\d\s,]+)\]", content
-    )
+    dims_match = re.search(r"device_topology\s*\{[^}]*dims\s*:\s*\[\s*([\d\s,]+)\]", content)
     if not dims_match:
         print(f"WARNING: Could not parse dims from MGD file: {mgd_path}")
         return
@@ -88,9 +86,7 @@ def validate_mesh_graph_descriptor(mesh_shape: list[int]) -> None:
             f"Please ensure --ddp value matches the MGD file."
         )
 
-    types_match = re.search(
-        r"device_topology\s*\{[^}]*dim_types\s*:\s*\[\s*([A-Z_,\s]+)\]", content
-    )
+    types_match = re.search(r"device_topology\s*\{[^}]*dim_types\s*:\s*\[\s*([A-Z_,\s]+)\]", content)
     if types_match:
         dim_types = [t.strip() for t in types_match.group(1).split(",")]
         ddp_axis = 1
@@ -116,9 +112,7 @@ def llama_config_from_yaml(yaml_config: dict, vocab_size: int) -> LlamaConfig:
             scaling_factor=rs.get("scaling_factor", rope_scaling.scaling_factor),
             high_freq_factor=rs.get("high_freq_factor", rope_scaling.high_freq_factor),
             low_freq_factor=rs.get("low_freq_factor", rope_scaling.low_freq_factor),
-            original_context_length=rs.get(
-                "original_context_length", rope_scaling.original_context_length
-            ),
+            original_context_length=rs.get("original_context_length", rope_scaling.original_context_length),
         )
 
     runner_type = RunnerType.Default
@@ -172,9 +166,7 @@ def load_lora_checkpoint(model: LoraModel, filepath: str) -> None:
         if name not in parameters:
             skipped.append(name)
             continue
-        restored = ttml.autograd.Tensor.from_numpy(
-            arr.astype(ml_dtypes.bfloat16), layout=ttnn.Layout.TILE
-        )
+        restored = ttml.autograd.Tensor.from_numpy(arr.astype(ml_dtypes.bfloat16), layout=ttnn.Layout.TILE)
         parameters[name].assign(restored)
         loaded += 1
 
@@ -186,9 +178,7 @@ def load_lora_checkpoint(model: LoraModel, filepath: str) -> None:
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(
-        description="Llama LoRA fine-tuning on Shakespeare"
-    )
+    parser = argparse.ArgumentParser(description="Llama LoRA fine-tuning on Shakespeare")
     parser.add_argument(
         "-m",
         "--model_config",
@@ -283,9 +273,7 @@ def main():
         hf_tokenizer = AutoTokenizer.from_pretrained(src)
         vocab_size = (hf_tokenizer.vocab_size + 31) // 32 * 32
         ids = np.array(hf_tokenizer.encode(text), dtype=np.uint32)
-        print(
-            f"Using HF BPE tokenizer, vocab_size={hf_tokenizer.vocab_size} (padded to {vocab_size})"
-        )
+        print(f"Using HF BPE tokenizer, vocab_size={hf_tokenizer.vocab_size} (padded to {vocab_size})")
     else:
         tokenizer = CharTokenizer(text)
         vocab_size = (tokenizer.vocab_size + 31) // 32 * 32
@@ -301,18 +289,14 @@ def main():
 
     if use_ddp:
         if batch_size % num_devices != 0:
-            raise ValueError(
-                f"--batch ({batch_size}) must be divisible by --ddp ({num_devices})"
-            )
+            raise ValueError(f"--batch ({batch_size}) must be divisible by --ddp ({num_devices})")
         ttml.core.distributed.enable_fabric(num_devices)
         validate_mesh_graph_descriptor(mesh_shape)
 
     autograd_ctx = ttml.autograd.AutoContext.get_instance()
     if use_ddp:
         autograd_ctx.open_device(mesh_shape)
-        autograd_ctx.initialize_parallelism_context(
-            ttml.autograd.DistributedConfig(enable_ddp=True)
-        )
+        autograd_ctx.initialize_parallelism_context(ttml.autograd.DistributedConfig(enable_ddp=True))
         print(f"DDP enabled: {num_devices} devices, mesh_shape={mesh_shape}")
     else:
         autograd_ctx.open_device([1, 1], [0])
@@ -400,9 +384,7 @@ def main():
             ttnn.DataType.UINT32,
             mapper,
         )
-        tt_y = ttml.autograd.Tensor.from_numpy(
-            y_np, ttnn.Layout.ROW_MAJOR, ttnn.DataType.UINT32, mapper
-        )
+        tt_y = ttml.autograd.Tensor.from_numpy(y_np, ttnn.Layout.ROW_MAJOR, ttnn.DataType.UINT32, mapper)
 
         optimizer.zero_grad()
         logits = model(tt_x, None)
@@ -430,9 +412,7 @@ def main():
         step_ms = (time.perf_counter() - t0) * 1000
 
         if step % PRINT_INTERVAL == 0 or step == 1:
-            print(
-                f"step {step:>4}/{steps}  loss={loss_val:.4f}  step_time={step_ms:.1f}ms"
-            )
+            print(f"step {step:>4}/{steps}  loss={loss_val:.4f}  step_time={step_ms:.1f}ms")
 
         if args.track_memory and is_first_step:
             is_first_step = False

--- a/tt-train/sources/examples/lora_llama/train_lora_llama.py
+++ b/tt-train/sources/examples/lora_llama/train_lora_llama.py
@@ -319,7 +319,7 @@ def main():
 
     # ── Model ─────────────────────────────────────────────────────────────────
     if args.model_config is not None:
-        tt_train_root = f"{get_tt_metal_home()}/tt-train"
+        tt_train_root = f"{get_tt_metal_runtime_root()}/tt-train"
         print(f"Loading model config from: {args.model_config}")
         yaml_config = load_config(args.model_config, tt_train_root)
         llama_cfg = llama_config_from_yaml(yaml_config, vocab_size)

--- a/tt-train/sources/examples/nano_gpt/nanogpt_primitives_example.py
+++ b/tt-train/sources/examples/nano_gpt/nanogpt_primitives_example.py
@@ -866,9 +866,7 @@ def main():
         tt_metal_root = get_tt_metal_runtime_root()
         if tt_metal_root and os.path.exists(tt_metal_root):
             os.environ["TT_METAL_RUNTIME_ROOT"] = tt_metal_root
-            print(
-                f"Set TT_METAL_RUNTIME_ROOT={tt_metal_root} (from get_tt_metal_runtime_root)"
-            )
+            print(f"Set TT_METAL_RUNTIME_ROOT={tt_metal_root} (from get_tt_metal_runtime_root)")
         else:
             current_dir = os.getcwd()
             if os.path.exists(os.path.join(current_dir, "tt_metal")):

--- a/tt-train/sources/examples/nano_gpt/nanogpt_primitives_example.py
+++ b/tt-train/sources/examples/nano_gpt/nanogpt_primitives_example.py
@@ -863,10 +863,12 @@ def main():
     print()
 
     if "TT_METAL_RUNTIME_ROOT" not in os.environ:
-        tt_metal_home = get_tt_metal_home()
-        if tt_metal_home and os.path.exists(tt_metal_home):
-            os.environ["TT_METAL_RUNTIME_ROOT"] = tt_metal_home
-            print(f"Set TT_METAL_RUNTIME_ROOT={tt_metal_home} (from get_tt_metal_home)")
+        tt_metal_root = get_tt_metal_runtime_root()
+        if tt_metal_root and os.path.exists(tt_metal_root):
+            os.environ["TT_METAL_RUNTIME_ROOT"] = tt_metal_root
+            print(
+                f"Set TT_METAL_RUNTIME_ROOT={tt_metal_root} (from get_tt_metal_runtime_root)"
+            )
         else:
             current_dir = os.getcwd()
             if os.path.exists(os.path.join(current_dir, "tt_metal")):
@@ -885,7 +887,7 @@ def main():
         print(f"Using TT_METAL_RUNTIME_ROOT={os.environ.get('TT_METAL_RUNTIME_ROOT')}")
     print()
 
-    tt_train_root = f"{get_tt_metal_home()}/tt-train"
+    tt_train_root = f"{get_tt_metal_runtime_root()}/tt-train"
     configs_root = f"{tt_train_root}/configs"
     try:
         print(f"Loading training config from: {args.config}")

--- a/tt-train/sources/examples/nano_gpt/train_nanogpt.py
+++ b/tt-train/sources/examples/nano_gpt/train_nanogpt.py
@@ -1040,13 +1040,15 @@ def main():
     print("=" * 70)
     print()
 
-    # Set TT_METAL_RUNTIME_ROOT if not set and TT_METAL_HOME is available
+    # Set TT_METAL_RUNTIME_ROOT if not set and a valid runtime root is available
     # This is needed for the runtime to find kernel files like moreh_mean
     if "TT_METAL_RUNTIME_ROOT" not in os.environ:
-        tt_metal_home = get_tt_metal_home()
-        if tt_metal_home and os.path.exists(tt_metal_home):
-            os.environ["TT_METAL_RUNTIME_ROOT"] = tt_metal_home
-            print(f"Set TT_METAL_RUNTIME_ROOT={tt_metal_home} (from get_tt_metal_home)")
+        tt_metal_root = get_tt_metal_runtime_root()
+        if tt_metal_root and os.path.exists(tt_metal_root):
+            os.environ["TT_METAL_RUNTIME_ROOT"] = tt_metal_root
+            print(
+                f"Set TT_METAL_RUNTIME_ROOT={tt_metal_root} (from get_tt_metal_runtime_root)"
+            )
         else:
             # Try to auto-detect from current directory
             current_dir = os.getcwd()
@@ -1069,7 +1071,7 @@ def main():
     print()
 
     # Load configs using ttml.common.config utilities
-    tt_train_root = f"{get_tt_metal_home()}/tt-train"
+    tt_train_root = f"{get_tt_metal_runtime_root()}/tt-train"
     configs_root = f"{tt_train_root}/configs"
     try:
         print(f"Loading training config from: {args.config}")

--- a/tt-train/sources/examples/nano_gpt/train_nanogpt.py
+++ b/tt-train/sources/examples/nano_gpt/train_nanogpt.py
@@ -1046,9 +1046,7 @@ def main():
         tt_metal_root = get_tt_metal_runtime_root()
         if tt_metal_root and os.path.exists(tt_metal_root):
             os.environ["TT_METAL_RUNTIME_ROOT"] = tt_metal_root
-            print(
-                f"Set TT_METAL_RUNTIME_ROOT={tt_metal_root} (from get_tt_metal_runtime_root)"
-            )
+            print(f"Set TT_METAL_RUNTIME_ROOT={tt_metal_root} (from get_tt_metal_runtime_root)")
         else:
             # Try to auto-detect from current directory
             current_dir = os.getcwd()

--- a/tt-train/sources/ttml/ttml/common/config.py
+++ b/tt-train/sources/ttml/ttml/common/config.py
@@ -224,9 +224,7 @@ def get_training_config(
 ) -> TrainingConfig:
     """Load training configuration given its filename."""
     if configs_root is None:
-        configs_root = (
-            f"{get_tt_metal_runtime_root()}/tt-train/configs/training_configs"
-        )
+        configs_root = f"{get_tt_metal_runtime_root()}/tt-train/configs/training_configs"
 
     training_config = load_config(training_config_src, configs_root)
     training_config = TrainingConfig(training_config)
@@ -240,9 +238,7 @@ def get_device_config(
 ) -> DeviceConfig:
     """Load device configuration given its filename."""
     if configs_root is None:
-        configs_root = (
-            f"{get_tt_metal_runtime_root()}/tt-train/configs/training_configs/"
-        )
+        configs_root = f"{get_tt_metal_runtime_root()}/tt-train/configs/training_configs/"
 
     device_config = load_config(device_config_src, configs_root)
     device_config = DeviceConfig(device_config)
@@ -270,9 +266,7 @@ def get_multihost_config(
 ) -> MultiHostConfig:
     """Load multihost configuration given its filename."""
     if configs_root is None:
-        configs_root = (
-            f"{get_tt_metal_runtime_root()}/tt-train/configs/multihost_configs/"
-        )
+        configs_root = f"{get_tt_metal_runtime_root()}/tt-train/configs/multihost_configs/"
 
     multihost_config = load_config(multihost_config_src, configs_root)
     multihost_config = MultiHostConfig(multihost_config)

--- a/tt-train/sources/ttml/ttml/common/config.py
+++ b/tt-train/sources/ttml/ttml/common/config.py
@@ -6,7 +6,7 @@
 import os
 import yaml
 from typing import Union
-from ttml.common.utils import get_tt_metal_home
+from ttml.common.utils import get_tt_metal_runtime_root
 
 
 class DeviceConfig:
@@ -207,7 +207,7 @@ def load_config(path: str, configs_root: str = None) -> dict:
     """
 
     if configs_root is None:
-        configs_root = f"{get_tt_metal_home()}/tt-train/configs/"
+        configs_root = f"{get_tt_metal_runtime_root()}/tt-train/configs/"
 
     # if the path is relative, make it absolute
     if not (os.path.isabs(path)):
@@ -224,7 +224,9 @@ def get_training_config(
 ) -> TrainingConfig:
     """Load training configuration given its filename."""
     if configs_root is None:
-        configs_root = f"{get_tt_metal_home()}/tt-train/configs/training_configs"
+        configs_root = (
+            f"{get_tt_metal_runtime_root()}/tt-train/configs/training_configs"
+        )
 
     training_config = load_config(training_config_src, configs_root)
     training_config = TrainingConfig(training_config)
@@ -238,7 +240,9 @@ def get_device_config(
 ) -> DeviceConfig:
     """Load device configuration given its filename."""
     if configs_root is None:
-        configs_root = f"{get_tt_metal_home()}/tt-train/configs/training_configs/"
+        configs_root = (
+            f"{get_tt_metal_runtime_root()}/tt-train/configs/training_configs/"
+        )
 
     device_config = load_config(device_config_src, configs_root)
     device_config = DeviceConfig(device_config)
@@ -252,7 +256,7 @@ def get_model_config(
 ) -> TransformerConfig:
     """Load model configuration given its filename."""
     if configs_root is None:
-        configs_root = f"{get_tt_metal_home()}/tt-train/"
+        configs_root = f"{get_tt_metal_runtime_root()}/tt-train/"
 
     model_config = load_config(model_config_src, configs_root)
     model_config = TransformerConfig(model_config)
@@ -266,7 +270,9 @@ def get_multihost_config(
 ) -> MultiHostConfig:
     """Load multihost configuration given its filename."""
     if configs_root is None:
-        configs_root = f"{get_tt_metal_home()}/tt-train/configs/multihost_configs/"
+        configs_root = (
+            f"{get_tt_metal_runtime_root()}/tt-train/configs/multihost_configs/"
+        )
 
     multihost_config = load_config(multihost_config_src, configs_root)
     multihost_config = MultiHostConfig(multihost_config)

--- a/tt-train/sources/ttml/ttml/common/config.py
+++ b/tt-train/sources/ttml/ttml/common/config.py
@@ -220,9 +220,11 @@ def load_config(path: str, configs_root: str = None) -> dict:
 
 def get_training_config(
     training_config_src: str,
-    configs_root: str = f"{get_tt_metal_home()}/tt-train/configs/training_configs",
+    configs_root: str = None,
 ) -> TrainingConfig:
     """Load training configuration given its filename."""
+    if configs_root is None:
+        configs_root = f"{get_tt_metal_home()}/tt-train/configs/training_configs"
 
     training_config = load_config(training_config_src, configs_root)
     training_config = TrainingConfig(training_config)
@@ -232,9 +234,11 @@ def get_training_config(
 
 def get_device_config(
     device_config_src: str,
-    configs_root: str = f"{get_tt_metal_home()}/tt-train/configs/training_configs/",
+    configs_root: str = None,
 ) -> DeviceConfig:
     """Load device configuration given its filename."""
+    if configs_root is None:
+        configs_root = f"{get_tt_metal_home()}/tt-train/configs/training_configs/"
 
     device_config = load_config(device_config_src, configs_root)
     device_config = DeviceConfig(device_config)
@@ -244,9 +248,11 @@ def get_device_config(
 
 def get_model_config(
     model_config_src: str,
-    configs_root: str = f"{get_tt_metal_home()}/tt-train/",
+    configs_root: str = None,
 ) -> TransformerConfig:
     """Load model configuration given its filename."""
+    if configs_root is None:
+        configs_root = f"{get_tt_metal_home()}/tt-train/"
 
     model_config = load_config(model_config_src, configs_root)
     model_config = TransformerConfig(model_config)
@@ -256,9 +262,11 @@ def get_model_config(
 
 def get_multihost_config(
     multihost_config_src: str,
-    configs_root: str = f"{get_tt_metal_home()}/tt-train/configs/multihost_configs/",
+    configs_root: str = None,
 ) -> MultiHostConfig:
     """Load multihost configuration given its filename."""
+    if configs_root is None:
+        configs_root = f"{get_tt_metal_home()}/tt-train/configs/multihost_configs/"
 
     multihost_config = load_config(multihost_config_src, configs_root)
     multihost_config = MultiHostConfig(multihost_config)

--- a/tt-train/sources/ttml/ttml/common/utils.py
+++ b/tt-train/sources/ttml/ttml/common/utils.py
@@ -66,9 +66,7 @@ def initialize_device(yaml_config: dict):
     device_config = DeviceConfig(yaml_config)
     if device_config.total_devices() > 1:
         ttml.core.distributed.enable_fabric(device_config.total_devices())
-    ttml.autograd.AutoContext.get_instance().open_device(
-        device_config.mesh_shape, device_config.device_ids
-    )
+    ttml.autograd.AutoContext.get_instance().open_device(device_config.mesh_shape, device_config.device_ids)
 
 
 def create_optimizer(model, yaml_config: dict):
@@ -106,9 +104,7 @@ def get_loss_over_devices(loss):
 def build_logits_mask(vocab_size: int, padded_vocab_size: int) -> ttml.autograd.Tensor:
     logits_mask = np.zeros((1, 1, 1, padded_vocab_size), dtype=np.float32)
     logits_mask[:, :, :, vocab_size:] = 1e4
-    return ttml.autograd.Tensor.from_numpy(
-        logits_mask, ttnn.Layout.TILE, ttnn.DataType.BFLOAT16
-    )  # [1,1,1,T], bfloat16
+    return ttml.autograd.Tensor.from_numpy(logits_mask, ttnn.Layout.TILE, ttnn.DataType.BFLOAT16)  # [1,1,1,T], bfloat16
 
 
 class PerformanceMeter:
@@ -127,9 +123,7 @@ class PerformanceMeter:
         if time_window == 0:
             return 0, 0
 
-        samples = (
-            len(self.steps) * self.cfg.batch_size * self.cfg.gradient_accumulation_steps
-        )
+        samples = len(self.steps) * self.cfg.batch_size * self.cfg.gradient_accumulation_steps
         samples_per_second = samples / time_window
         tokens_per_second = samples * self.cfg.seq_len / time_window
         return samples_per_second, tokens_per_second
@@ -162,19 +156,9 @@ def summary(model) -> None:
     col_nparams = "# Params"
     col_train = "Trainable"
 
-    name_w = (
-        max(len(col_name), *(len(e[0]) for e in entries)) if entries else len(col_name)
-    )
-    shape_w = (
-        max(len(col_shape), *(len(str(e[1])) for e in entries))
-        if entries
-        else len(col_shape)
-    )
-    nparams_w = (
-        max(len(col_nparams), *(len(f"{e[2]:,}") for e in entries))
-        if entries
-        else len(col_nparams)
-    )
+    name_w = max(len(col_name), *(len(e[0]) for e in entries)) if entries else len(col_name)
+    shape_w = max(len(col_shape), *(len(str(e[1])) for e in entries)) if entries else len(col_shape)
+    nparams_w = max(len(col_nparams), *(len(f"{e[2]:,}") for e in entries)) if entries else len(col_nparams)
     train_w = len(col_train)
 
     total_w = name_w + shape_w + nparams_w + train_w + 9  # 3 separators + padding
@@ -182,10 +166,7 @@ def summary(model) -> None:
     sep = "=" * total_w
     thin_sep = "-" * total_w
 
-    header = (
-        f" {col_name:<{name_w}} | {col_shape:<{shape_w}} "
-        f"| {col_nparams:>{nparams_w}} | {col_train}"
-    )
+    header = f" {col_name:<{name_w}} | {col_shape:<{shape_w}} " f"| {col_nparams:>{nparams_w}} | {col_train}"
 
     lines = [sep, header, sep]
 
@@ -195,10 +176,7 @@ def summary(model) -> None:
             lines.append(thin_sep)
         prev_trainable = is_train
         mark = "Yes" if is_train else "No"
-        lines.append(
-            f" {name:<{name_w}} | {str(shape):<{shape_w}} "
-            f"| {n:>{nparams_w},} | {mark}"
-        )
+        lines.append(f" {name:<{name_w}} | {str(shape):<{shape_w}} " f"| {n:>{nparams_w},} | {mark}")
 
     total = sum(e[2] for e in entries)
     total_train = sum(e[2] for e in trainable)
@@ -232,11 +210,7 @@ class no_grad:
 
     def __enter__(self):
         self._ctx = ttml.autograd.AutoContext.get_instance()
-        self._prev = (
-            self._ctx.get_gradient_mode()
-            if hasattr(self._ctx, "get_gradient_mode")
-            else None
-        )
+        self._prev = self._ctx.get_gradient_mode() if hasattr(self._ctx, "get_gradient_mode") else None
         self._ctx.set_gradient_mode(ttml.autograd.GradMode.DISABLED)
         return self
 

--- a/tt-train/sources/ttml/ttml/common/utils.py
+++ b/tt-train/sources/ttml/ttml/common/utils.py
@@ -25,17 +25,18 @@ def set_seed(seed: int = 42):
 
 
 def get_tt_metal_home() -> str:
-    """Get the TT-Metal home directory.
+    """Get the TT-Metal root directory.
 
     Returns:
-        Path to TT-Metal home directory
+        Path to TT-Metal runtime root.
     """
-    tt_metal_home = (
-        os.environ["TT_METAL_HOME"]
-        if "TT_METAL_HOME" in os.environ
-        else os.path.expanduser("~/.tt-metal")
+    runtime_root = os.environ.get("TT_METAL_RUNTIME_ROOT")
+    if runtime_root:
+        return runtime_root
+    raise RuntimeError(
+        "TT_METAL_RUNTIME_ROOT is not set. Please export TT_METAL_RUNTIME_ROOT "
+        "to the tt-metal repository root before running training utilities."
     )
-    return tt_metal_home
 
 
 def round_up_to_tile(value: int, tile: int = 32) -> int:

--- a/tt-train/sources/ttml/ttml/common/utils.py
+++ b/tt-train/sources/ttml/ttml/common/utils.py
@@ -25,10 +25,13 @@ def set_seed(seed: int = 42):
 
 
 def get_tt_metal_home() -> str:
-    """Get the TT-Metal root directory.
+    """Return TT-Metal runtime root from the environment.
 
     Returns:
-        Path to TT-Metal runtime root.
+        Value of TT_METAL_RUNTIME_ROOT.
+
+    Raises:
+        RuntimeError: If TT_METAL_RUNTIME_ROOT is not set.
     """
     runtime_root = os.environ.get("TT_METAL_RUNTIME_ROOT")
     if runtime_root:

--- a/tt-train/sources/ttml/ttml/common/utils.py
+++ b/tt-train/sources/ttml/ttml/common/utils.py
@@ -24,7 +24,7 @@ def set_seed(seed: int = 42):
     ttml.autograd.AutoContext.get_instance().set_seed(seed)
 
 
-def get_tt_metal_home() -> str:
+def get_tt_metal_runtime_root() -> str:
     """Return TT-Metal runtime root from the environment.
 
     Returns:


### PR DESCRIPTION
### Ticket
N/A (Infrastructure fix)

### Problem description
TT-Train Python utilities used a helper named `get_tt_metal_home` while enforcing runtime-root behavior. This naming/usage mismatch created confusion, and strict runtime-root validation risked import-time failures when used in default argument expressions.

### What's changed
- **Renamed helper**
  - `get_tt_metal_home()` -> `get_tt_metal_runtime_root()`
  - Strict behavior remains:
    - returns `TT_METAL_RUNTIME_ROOT` when set
    - raises `RuntimeError` when unset
- **Updated call sites**
  - Migrated references in:
    - `ttml/common/config.py`
    - `sources/examples/nano_gpt/train_nanogpt.py`
    - `sources/examples/nano_gpt/nanogpt_primitives_example.py`
    - `sources/examples/gsm8k_finetune/gsm8k_finetune.py`
    - `sources/examples/lora_llama/train_lora_llama.py`
- **Import-time safety**
  - In `ttml/common/config.py`, config helper defaults remain `None` and resolve root inside function body to avoid import-time env evaluation failures.

### Testing
- [ ] `get_tt_metal_runtime_root()` returns `TT_METAL_RUNTIME_ROOT` when set
- [ ] `get_tt_metal_runtime_root()` raises `RuntimeError` when unset
- [ ] Importing `ttml.common.config` does not fail due to import-time default evaluation
- [ ] Updated example/config call sites resolve paths correctly when env is set

### Checklist
- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mdragula/runtime-root-load-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mdragula/runtime-root-load-config)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mdragula/runtime-root-load-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mdragula/runtime-root-load-config)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mdragula/runtime-root-load-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mdragula/runtime-root-load-config)
- [ ] New/Existing tests provide coverage for changes