### PR TITLE
[skip ci] Update Falcon-40B T3K perf baselines (fixes #39442)

### DIFF
--- a/models/demos/t3000/falcon40b/tests/test_perf_falcon.py
+++ b/models/demos/t3000/falcon40b/tests/test_perf_falcon.py
@@ -306,13 +306,13 @@ def run_test_FalconCausalLM_end_to_end(
 @pytest.mark.parametrize(
     "llm_mode, batch, seq_len, kv_cache_len, expected_compile_time, expected_inference_time, num_layers, model_config_str",
     (
-        ("prefill", 1, 32, 0, 62, 0.37 + 0.04, 60, "BFLOAT8_B-DRAM"),
-        ("prefill", 1, 128, 0, 60, 0.39 + 0.04, 60, "BFLOAT8_B-DRAM"),
-        ("prefill", 1, 2048, 0, 60, 0.94 + 0.1, 60, "BFLOAT8_B-DRAM"),
-        ("prefill", 1, 32, 0, 60, 0.42 + 0.04, 60, "BFLOAT16-DRAM"),
-        ("prefill", 1, 128, 0, 60, 0.46 + 0.04, 60, "BFLOAT16-DRAM"),
-        ("prefill", 1, 2048, 0, 60, 1.18 + 0.1, 60, "BFLOAT16-DRAM"),
-        ("decode", 32, 1, 128, 60, 0.21 + 0.02, 60, "BFLOAT8_B-SHARDED"),
+        ("prefill", 1, 32, 0, 62, 0.11 + 0.02, 60, "BFLOAT8_B-DRAM"),
+        ("prefill", 1, 128, 0, 60, 0.12 + 0.03, 60, "BFLOAT8_B-DRAM"),
+        ("prefill", 1, 2048, 0, 60, 0.67 + 0.05, 60, "BFLOAT8_B-DRAM"),
+        ("prefill", 1, 32, 0, 60, 0.11 + 0.02, 60, "BFLOAT16-DRAM"),
+        ("prefill", 1, 128, 0, 60, 0.11 + 0.02, 60, "BFLOAT16-DRAM"),
+        ("prefill", 1, 2048, 0, 60, 0.95 + 0.07, 60, "BFLOAT16-DRAM"),
+        ("decode", 32, 1, 128, 60, 0.13 + 0.02, 60, "BFLOAT8_B-SHARDED"),
     ),
     ids=[
         "prefill_seq32_bfp8",

--- a/models/demos/t3000/falcon40b/tests/test_perf_falcon.py
+++ b/models/demos/t3000/falcon40b/tests/test_perf_falcon.py
@@ -307,7 +307,7 @@ def run_test_FalconCausalLM_end_to_end(
     "llm_mode, batch, seq_len, kv_cache_len, expected_compile_time, expected_inference_time, num_layers, model_config_str",
     (
         ("prefill", 1, 32, 0, 62, 0.11 + 0.02, 60, "BFLOAT8_B-DRAM"),
-        ("prefill", 1, 128, 0, 60, 0.12 + 0.03, 60, "BFLOAT8_B-DRAM"),
+        ("prefill", 1, 128, 0, 60, 0.11 + 0.03, 60, "BFLOAT8_B-DRAM"),
         ("prefill", 1, 2048, 0, 60, 0.67 + 0.05, 60, "BFLOAT8_B-DRAM"),
         ("prefill", 1, 32, 0, 60, 0.11 + 0.02, 60, "BFLOAT16-DRAM"),
         ("prefill", 1, 128, 0, 60, 0.11 + 0.02, 60, "BFLOAT16-DRAM"),


### PR DESCRIPTION
### Ticket
Fixes https://github.com/tenstorrent/tt-metal/issues/39442

### Problem description
The T3000 perf job `t3k_LLM_falcon40b_model_perf_tests` has been failing on main because Falcon-40B performance improved beyond the configured baselines. The perf pipeline fails when measured inference times are outside the allowed tolerance (80%–100% of expected); current runs show large improvements (e.g. 25–75%), so the checker reports "update baseline".

### What's changed
- Updated expected inference-time baselines in `models/demos/t3000/falcon40b/tests/test_perf_falcon.py` for all seven Falcon-40B perf configurations (prefill seq 32/128/2048 for BFLOAT8_B-DRAM and BFLOAT16-DRAM, and decode batch 32 for BFLOAT8_B-SHARDED) to match current improved performance.
- One additional small adjustment for the prefill seq128 BFLOAT8_B-DRAM case so measured values stay within the 80% tolerance window.

No functional or product changes; this only updates the expected values used by the perf check so CI can pass.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ebanerjee/39442-ci-t3k-t3000-perf-tests-t3k_llm_falcon40b_model_perf_tests-failing-perf-checks)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ebanerjee/39442-ci-t3k-t3000-perf-tests-t3k_llm_falcon40b_model_perf_tests-failing-perf-checks)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ebanerjee/39442-ci-t3k-t3000-perf-tests-t3k_llm_falcon40b_model_perf_tests-failing-perf-checks)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ebanerjee/39442-ci-t3k-t3000-perf-tests-t3k_llm_falcon40b_model_perf_tests-failing-perf-checks)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ebanerjee/39442-ci-t3k-t3000-perf-tests-t3k_llm_falcon40b_model_perf_tests-failing-perf-checks)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ebanerjee/39442-ci-t3k-t3000-perf-tests-t3k_llm_falcon40b_model_perf_tests-failing-perf-checks)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early

#### Model tests

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ebanerjee/39442-ci-t3k-t3000-perf-tests-t3k_llm_falcon40b_model_perf_tests-failing-perf-checks)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ebanerjee/39442-ci-t3k-t3000-perf-tests-t3k_llm_falcon40b_model_perf_tests-failing-perf-checks)
  - [x] `models-extended` preset (T3K Falcon-40B perf: run t3000 perf pipeline to validate updated baselines) https://github.com/tenstorrent/tt-metal/actions/runs/23158635178
