### PR TITLE
Optimized MoE Model Integration - High Batch Deepseek

### DIFF
--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/moe/test_optimized_moe_decode_block.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/moe/test_optimized_moe_decode_block.py
@@ -932,7 +932,18 @@ def test_optimized_moe_decode_block(
     ############################################
     # set post combine memory configs
     ############################################
-    tilized_combine_output_memory_config = ttnn.L1_MEMORY_CONFIG
+    post_combine_tilize_output_memory_config = ttnn.MemoryConfig(
+        buffer_type=ttnn.BufferType.L1,
+        nd_shard_spec=ttnn.NdShardSpec(
+            shard_shape=[32, 1024],
+            grid=ttnn.CoreRangeSet(
+                {
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(6, 7)),
+                }
+            ),
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        ),
+    )
 
     scaled_output_memory_config = ttnn.L1_MEMORY_CONFIG
 
@@ -1067,13 +1078,14 @@ def test_optimized_moe_decode_block(
             optional_cross_device_semaphore=combine_global_semaphore,
         )
 
-        tt_tilized_compute_output = ttnn.to_layout(
-            tt_combine_output, layout=ttnn.TILE_LAYOUT, memory_config=tilized_combine_output_memory_config
-        )
-
         # unsqueeze
         # [select_experts_k, tokens_per_device, hidden_size] -> [select_experts_k, 1, tokens_per_device, hidden_size]
-        tt_unsqueezed_output = ttnn.unsqueeze(tt_tilized_compute_output, dim=1)
+        tt_unsqueezed_output = ttnn.unsqueeze(tt_combine_output, dim=1)
+
+        tt_tilized_compute_output = ttnn.experimental.deepseek_moe_post_combine_tilize(
+            tt_unsqueezed_output,
+            output_memory_config=post_combine_tilize_output_memory_config,
+        )
 
         # scale with scores
         # [tokens_per_device, 1, seq, select_experts_k] -> [select_experts_k, 1, tokens_per_device, seq]
@@ -1084,7 +1096,7 @@ def test_optimized_moe_decode_block(
             topk_experts_weights, layout=ttnn.TILE_LAYOUT, memory_config=scaled_output_memory_config
         )
         tt_scaled_output = ttnn.mul(
-            tt_unsqueezed_output, topk_experts_weights, memory_config=scaled_output_memory_config
+            tt_tilized_compute_output, topk_experts_weights, memory_config=scaled_output_memory_config
         )
 
         tt_fast_reduce_output_tensors = ttnn.experimental.deepseek_moe_fast_reduce_nc(

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/moe/test_optimized_moe_decode_block.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/moe/test_optimized_moe_decode_block.py
@@ -541,6 +541,7 @@ def verify_output(iteration, mesh_device, mesh_shape, tt_output_tensor, output_r
 @pytest.mark.parametrize("shard_dim", [0])
 @pytest.mark.parametrize("experts", [256])
 @pytest.mark.parametrize("select_experts_k", [8])
+@pytest.mark.parametrize("dispatch_persistent_buffers", [False, True])
 @pytest.mark.parametrize("seq", [1])
 @pytest.mark.parametrize("hidden_size", [7168])
 @pytest.mark.parametrize("matmul_N", [2048])
@@ -623,7 +624,9 @@ def test_optimized_moe_decode_block(
     # NOTE: these don't have to be double buffered
     # - there is a global sync in combine after reading all dispatch output (can't loop around on dispatch semaphore)
     # - there is a global sync at the end of dispatch (can't loop around on combine semaphore)
-    dispatch_global_semaphore = ttnn.create_global_semaphore(mesh_device, worker_cores, 0)
+    dispatch_global_semaphore = (
+        ttnn.create_global_semaphore(mesh_device, worker_cores, 0) if dispatch_persistent_buffers else None
+    )
     combine_global_semaphore = ttnn.create_global_semaphore(mesh_device, worker_cores, 0)
 
     ############################################
@@ -922,9 +925,13 @@ def test_optimized_moe_decode_block(
 
     # NOTE: these don't have to be double buffered, as there is a global sync in combine after reading all dispatch output
     tt_dispatch_preallocated_output_tensors = (
-        tt_preallocated_dispatch_output_sparse_buffer,
-        tt_preallocated_dispatch_output_expert_indices,
-        tt_preallocated_dispatch_output_expert_scores,
+        (
+            tt_preallocated_dispatch_output_sparse_buffer,
+            tt_preallocated_dispatch_output_expert_indices,
+            tt_preallocated_dispatch_output_expert_scores,
+        )
+        if dispatch_persistent_buffers
+        else None
     )
 
     logger.info(f"Done creating persistent dispatch output tensors")
@@ -1024,7 +1031,9 @@ def test_optimized_moe_decode_block(
             tt_expert_mapping,
             cluster_axis=cluster_axis,
             num_links=4,
-            drain_sync_tilizer_core=None,
+            drain_sync_tilizer_core=None
+            if dispatch_persistent_buffers
+            else (compute_tilize_drain_core.x, compute_tilize_drain_core.y),
             worker_mode=ttnn.WorkerMode.DIRECT,
             dispatch_algorithm=ttnn.DispatchAlgorithm.SPARSE_MCAST_SHORTEST_PATH,
             output_tensors=tt_dispatch_preallocated_output_tensors,

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/moe/test_optimized_moe_decode_block.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/moe/test_optimized_moe_decode_block.py
@@ -358,12 +358,12 @@ def device_mesh_iterator(mesh_shape):
             yield m0, m1, device
 
 
-def get_batch_cluster_idxr(cluster_axis, batch, batch_per_device):
+def get_batch_cluster_idxr(cluster_axis, batch, batches_per_device):
     def _idxr(m0, m1, b):
         if cluster_axis == 0:
-            return m1 * batch + m0 * batch_per_device + b
+            return m1 * batch + m0 * batches_per_device + b
         elif cluster_axis == 1:
-            return m0 * batch + m1 * batch_per_device + b
+            return m0 * batch + m1 * batches_per_device + b
         else:
             return b
 
@@ -450,6 +450,8 @@ def verify_combine(iteration, mesh_device, mesh_shape, cluster_axis, tt_combine_
     logger.info(f"Combine Output - Iteration: {iteration} - AllClose: {allclose_output}")
     if not allclose_passed:
         logger.warning(f"FAILED Combine Output - Iteration: {iteration} - AllClose: {allclose_output}")
+        mask = (torch_combine_output - torch_combine_golden).abs() > ATOL_THRESHOLD
+        logger.warning(f"AllClose variation result: {torch_combine_output[mask]}, ref: {torch_combine_golden[mask]}")
 
     return pcc_passed and allclose_passed
 
@@ -537,9 +539,9 @@ def verify_output(iteration, mesh_device, mesh_shape, tt_output_tensor, output_r
 )
 @pytest.mark.parametrize("cluster_axis", [0])
 @pytest.mark.parametrize("layer_id, num_layers", [(0, 1)])
-@pytest.mark.parametrize("batches_per_device", [32])
+@pytest.mark.parametrize("batches_per_device", [3, 8, 16, 32])
 @pytest.mark.parametrize("shard_dim", [0])
-@pytest.mark.parametrize("experts", [256])
+@pytest.mark.parametrize("experts_per_device", [2])
 @pytest.mark.parametrize("select_experts_k", [8])
 @pytest.mark.parametrize("dispatch_persistent_buffers", [False, True])
 @pytest.mark.parametrize("seq", [1])
@@ -573,7 +575,7 @@ def test_optimized_moe_decode_block(
     num_layers,
     batches_per_device,
     shard_dim,
-    experts,
+    experts_per_device,
     select_experts_k,
     seq,
     hidden_size,
@@ -586,6 +588,7 @@ def test_optimized_moe_decode_block(
     combine_data_parallel_core_dim,
     enable_trace,
     num_iterations,
+    dispatch_persistent_buffers,
 ):
     ############################################
     # initial setup
@@ -600,7 +603,8 @@ def test_optimized_moe_decode_block(
     batch = batches_per_device * num_dispatch_devices
     total_tokens = batch * seq
     tokens_per_device = batch // num_dispatch_devices
-    experts_per_device = experts // num_devices
+
+    experts = experts_per_device * num_devices
     experts_per_cluster = experts // num_replicated_devices
 
     if cluster_axis == 1:
@@ -1091,10 +1095,21 @@ def test_optimized_moe_decode_block(
         # [select_experts_k, tokens_per_device, hidden_size] -> [select_experts_k, 1, tokens_per_device, hidden_size]
         tt_unsqueezed_output = ttnn.unsqueeze(tt_combine_output, dim=1)
 
-        tt_tilized_compute_output = ttnn.experimental.deepseek_moe_post_combine_tilize(
-            tt_unsqueezed_output,
-            output_memory_config=post_combine_tilize_output_memory_config,
-        )
+        if batches_per_device == ttnn.TILE_SIZE:
+            tt_tilized_compute_output = ttnn.experimental.deepseek_moe_post_combine_tilize(
+                tt_unsqueezed_output,
+                output_memory_config=post_combine_tilize_output_memory_config,
+            )
+
+        else:
+            output_tensor_shape = list(tt_unsqueezed_output.shape)
+            output_tensor_shape[2] = ((output_tensor_shape[2] + ttnn.TILE_SIZE - 1) // ttnn.TILE_SIZE) * ttnn.TILE_SIZE
+            tt_tilized_compute_output = ttnn.tilize_with_val_padding(
+                tt_unsqueezed_output,
+                output_tensor_shape=output_tensor_shape,
+                pad_value=0.0,
+                memory_config=post_combine_tilize_output_memory_config,
+            )
 
         # scale with scores
         # [tokens_per_device, 1, seq, select_experts_k] -> [select_experts_k, 1, tokens_per_device, seq]
@@ -1116,14 +1131,19 @@ def test_optimized_moe_decode_block(
         )
 
         # [select_experts_k, tokens_per_device, hidden_size // num_replicated_devices] final per device shape
-        tt_final_output = ttnn.experimental.deepseek_moe_reduce_scatter(
-            tt_fast_reduce_output_tensors,
-            output_memory_config=rs_output_memory_config,
-            dim=-1,
-            num_links=4,
-            topology=ttnn.Topology.Ring,
-            cluster_axis=1,
-        )
+        if mesh_shape[1 - cluster_axis] == 8:
+            tt_final_output = ttnn.experimental.deepseek_moe_reduce_scatter(
+                tt_fast_reduce_output_tensors,
+                output_memory_config=rs_output_memory_config,
+                dim=-1,
+                num_links=4,
+                topology=ttnn.Topology.Ring,
+                cluster_axis=1,
+            )
+        elif mesh_shape[1 - cluster_axis] == 1:
+            tt_final_output = tt_fast_reduce_output_tensors[0]
+        else:
+            raise RuntimeError("Bad test config")
 
         return tt_combine_output, tt_final_output
 

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/test_decode_reduce_scatter.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/test_decode_reduce_scatter.py
@@ -2,13 +2,13 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import os
 
 import pytest
 import torch
 from loguru import logger
 
 import ttnn
+from models.demos.deepseek_v3.utils.config_helpers import get_fabric_config, is_ring_fabric
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
 
 
@@ -146,7 +146,7 @@ def run_decode_reduce_scatter_deepseek_impl(
 
 @pytest.mark.requires_device(["TG"])
 @pytest.mark.skipif(
-    (os.getenv("USE_TORUS_MODE") is None),
+    (not is_ring_fabric(get_fabric_config())),
     reason=f"Requires ring fabric",
 )
 @pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)

--- a/models/demos/deepseek_v3/tests/test_decoder_block.py
+++ b/models/demos/deepseek_v3/tests/test_decoder_block.py
@@ -142,7 +142,7 @@ def run_test_forward_pass_decoder2d(
         ccl,
         mla_cache=paged_input_cache,
     )
-    model_shared_state = DecoderBlockClass.create_shared_state(hf_config_short, mesh_device)
+    model_shared_state = DecoderBlockClass.create_shared_state(hf_config_short, mesh_device, fabric_config)
     run_config = create_run_config(model_config, weight_config, model_state, model_shared_state)
 
     # Set up ttnn inputs

--- a/models/demos/deepseek_v3/tests/test_moe.py
+++ b/models/demos/deepseek_v3/tests/test_moe.py
@@ -106,7 +106,7 @@ _prefill_seq_len = int(_max_seq_len_env) if _max_seq_len_env is not None else DE
 @pytest.mark.parametrize(
     "device_params",
     [
-        {"fabric_config": get_fabric_config()},
+        {"dispatch_core_axis": ttnn.DispatchCoreAxis.COL, "fabric_config": get_fabric_config()},
     ],
     indirect=True,
 )

--- a/models/demos/deepseek_v3/tests/test_moe.py
+++ b/models/demos/deepseek_v3/tests/test_moe.py
@@ -171,7 +171,7 @@ def test_forward_pass(
         MoE, mode, hf_config, mesh_device, device_params["fabric_config"], topk_fallback=topk_fallback
     )
     model_state = MoE.create_state(hf_config, mesh_device, ccl)
-    model_shared_state = MoE.create_shared_state(hf_config, mesh_device)
+    model_shared_state = MoE.create_shared_state(hf_config, mesh_device, device_params["fabric_config"])
     run_config = create_run_config(model_config, weight_config, model_state, model_shared_state)
 
     tt_input = ttnn.from_torch(

--- a/models/demos/deepseek_v3/tests/test_moe_experts.py
+++ b/models/demos/deepseek_v3/tests/test_moe_experts.py
@@ -16,7 +16,14 @@ import ttnn
 from models.demos.deepseek_v3.reference.modeling_deepseek import DeepseekV3MLP as ReferenceExpert
 from models.demos.deepseek_v3.tests.pytest_utils import DEFAULT_PREFILL_SEQ_LEN
 from models.demos.deepseek_v3.tt.experts import Experts as TTExperts
-from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, even_int_div, sub_state_dict
+from models.demos.deepseek_v3.utils.config_helpers import (
+    USERS_PER_ROW,
+    even_int_div,
+    get_fabric_config,
+    is_quad_mesh,
+    is_ring_fabric,
+    sub_state_dict,
+)
 from models.demos.deepseek_v3.utils.run_config import create_run_config
 from models.demos.deepseek_v3.utils.test_utils import get_model_config, get_test_weight_config, run_module_forward
 
@@ -68,6 +75,10 @@ _max_seq_len_env = os.getenv("DEEPSEEK_MAX_SEQ_LEN_OVERRIDE")
 _prefill_seq_len = int(_max_seq_len_env) if _max_seq_len_env is not None else DEFAULT_PREFILL_SEQ_LEN
 
 
+@pytest.mark.skipif(
+    (is_ring_fabric(get_fabric_config()) and is_quad_mesh()),
+    reason=f"Optimized quad ring MoE implementation embeds expert matmuls inside fused CCL ops",
+)
 @pytest.mark.parametrize(
     "mode, batch_size_per_row, seq_len",
     [

--- a/models/demos/deepseek_v3/tests/test_mtp.py
+++ b/models/demos/deepseek_v3/tests/test_mtp.py
@@ -23,11 +23,11 @@ from models.demos.deepseek_v3.tt.embedding.embedding2d import Embedding2D
 from models.demos.deepseek_v3.tt.generator import MAX_SEQ_LEN, DeepseekGenerator, _build_verify_alias_page_table_host
 from models.demos.deepseek_v3.tt.lm_head1d import LMHead1D
 from models.demos.deepseek_v3.tt.mla.mla2d import MLA2D
-from models.demos.deepseek_v3.tt.model.row_batched_model import RowBatchedModel, get_fabric_config
+from models.demos.deepseek_v3.tt.model.row_batched_model import RowBatchedModel
 from models.demos.deepseek_v3.tt.mtp import MTP2D
 from models.demos.deepseek_v3.tt.rms_norm.distributed_rms_norm import DistributedRMSNorm
 from models.demos.deepseek_v3.tt.rope import RotarySetup
-from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, even_int_div
+from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, even_int_div, get_fabric_config
 from models.demos.deepseek_v3.utils.run_config import create_run_config
 from models.demos.deepseek_v3.utils.test_utils import load_state_dict
 from models.demos.deepseek_v3.utils.weight_config import _try_load_cached_config, get_weight_config
@@ -495,11 +495,13 @@ class _MtpModuleRunner:
     def __init__(
         self,
         mesh_device: ttnn.MeshDevice,
+        fabric_config: ttnn.FabricConfig,
         model_path: Path,
         cache_path: Path,
         force_recalculate: bool,
     ) -> None:
         self.mesh_device = mesh_device
+        self.fabric_config = fabric_config
         self.model_path = Path(model_path)
         self.cache_path = Path(cache_path)
         self.force_recalculate = force_recalculate
@@ -562,11 +564,12 @@ class _MtpModuleRunner:
         self.model_shared_state = MTP2D.create_shared_state(
             hf_config=self.hf_config,
             mesh_device=self.mesh_device,
+            fabric_config=self.fabric_config,
         )
         self.model_decode_cfg = MTP2D.decode_model_config(
             hf_config=self.hf_config,
             mesh_device=self.mesh_device,
-            fabric_config=get_fabric_config(),
+            fabric_config=self.fabric_config,
         )
         mtp_decode_run_config = create_run_config(
             self.model_decode_cfg,
@@ -627,12 +630,14 @@ class _MtpModuleRunner:
 
 def _prepare_mtp_module_runner(
     mesh_device: ttnn.MeshDevice,
+    fabric_config: ttnn.FabricConfig,
     model_path: Path,
     cache_path: Path,
     force_recalculate: bool,
 ) -> _MtpModuleRunner:
     return _MtpModuleRunner(
         mesh_device=mesh_device,
+        fabric_config=fabric_config,
         model_path=model_path,
         cache_path=cache_path,
         force_recalculate=force_recalculate,
@@ -1200,7 +1205,7 @@ def test_generate_mtp_reference_io(
     "device_params",
     [
         {
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "fabric_config": get_fabric_config(),
             "trace_region_size": TRACE_REGION_SIZE,
         }
     ],
@@ -1215,6 +1220,7 @@ def test_generate_mtp_reference_io(
     ],
 )
 def test_mtp_accept_rate_and_perf(
+    device_params,
     min_accept_rate,
     enable_trace,
     mesh_device,
@@ -1229,6 +1235,7 @@ def test_mtp_accept_rate_and_perf(
 
     with _prepare_mtp_module_runner(
         mesh_device=mesh,
+        fabric_config=device_params["fabric_config"],
         model_path=model_path,
         cache_path=cache_path,
         force_recalculate=force_recalculate_weight_config,

--- a/models/demos/deepseek_v3/tt/ccl.py
+++ b/models/demos/deepseek_v3/tt/ccl.py
@@ -43,6 +43,10 @@ class CCL:
                 )
                 self.barrier_sems[-1].append(ttnn.create_global_semaphore(self.mesh_device, self.core_range_set, 0))
 
+        # NOTE: these do not have to be double buffered, due to the synchronization between all_to_all_dispatch_metadata and selective_reduce_combine inside the MoE block
+        self.all_to_all_dispatch_metadata_sem = ttnn.create_global_semaphore(self.mesh_device, self.core_range_set, 0)
+        self.selective_reduce_combine_sem = ttnn.create_global_semaphore(self.mesh_device, self.core_range_set, 0)
+
         # Synchronize the device to ensure that the semaphores are created
         ttnn.synchronize_device(self.mesh_device)
 
@@ -177,6 +181,38 @@ class CCL:
 
         # Get runtime CCL parameters for reduce_scatter
         ccl_params = self.get_ccl_params_for_reduce_scatter(cluster_axis)
+
+        # Merge static config with runtime CCL parameters
+        return {**ccl_config, **ccl_params}
+
+    def populate_all_to_all_dispatch_metadata_args(self, ccl_config: dict) -> dict:
+        """Populate all_to_all_dispatch runtime arguments (semaphore) into the config.
+        Args:
+            ccl_config: Static CCL configuration dict
+        Returns:
+            Complete configuration dict with both static and runtime parameters
+        Example:
+            ttnn.experimental.all_to_all_dispatch_metadata(x, **ccl.populate_all_to_all_dispatch_metadata_args(cfg["all_to_all_dispatch_metadata"]))
+        """
+
+        # Get runtime CCL parameters for all_to_all_dispatch_metadata
+        ccl_params = {"cross_device_semaphore": self.all_to_all_dispatch_metadata_sem}
+
+        # Merge static config with runtime CCL parameters
+        return {**ccl_config, **ccl_params}
+
+    def populate_selective_reduce_combine_args(self, ccl_config: dict) -> dict:
+        """Populate selective_reduce_combine runtime arguments (semaphore) into the config.
+        Args:
+            ccl_config: Static CCL configuration dict
+        Returns:
+            Complete configuration dict with both static and runtime parameters
+        Example:
+            ttnn.experimental.selective_reduce_combine(x, **ccl.populate_selective_reduce_combine_args(cfg["selective_reduce_combine"]))
+        """
+
+        # Get runtime CCL parameters for selective_reduce_combine
+        ccl_params = {"optional_cross_device_semaphore": self.selective_reduce_combine_sem}
 
         # Merge static config with runtime CCL parameters
         return {**ccl_config, **ccl_params}

--- a/models/demos/deepseek_v3/tt/decoder_block/decoder_block_2d.py
+++ b/models/demos/deepseek_v3/tt/decoder_block/decoder_block_2d.py
@@ -63,6 +63,7 @@ class DecoderBlock2D(DecoderBlock2DBase):
         cls,
         hf_config: PretrainedConfig,
         mesh_device: ttnn.MeshDevice,
+        fabric_config: ttnn.FabricConfig,
     ) -> ModelState:
         return {}
 

--- a/models/demos/deepseek_v3/tt/decoder_block/decoder_block_base.py
+++ b/models/demos/deepseek_v3/tt/decoder_block/decoder_block_base.py
@@ -84,12 +84,14 @@ class DecoderBlockBase(SharedStateAddOn, AbstractModule):
         cls,
         hf_config: PretrainedConfig,
         mesh_device: ttnn.MeshDevice,
+        fabric_config: ttnn.FabricConfig,
     ) -> ModelState:
         logger.info(f"Creating {cls.__name__} shared state...")
         mlp_start = perf_counter()
         mlp_shared_state = cls.create_mlp_shared_state(
             hf_config,
             mesh_device,
+            fabric_config(),
         )
         logger.info(f"Created {cls.__name__} MLP shared state in {perf_counter() - mlp_start:.2f}s")
         state = {
@@ -175,6 +177,7 @@ class DecoderBlockBase(SharedStateAddOn, AbstractModule):
         cls,
         hf_config: PretrainedConfig,
         mesh_device: ttnn.MeshDevice,
+        fabric_config: ttnn.FabricConfig,
     ) -> ModelState:
         """
         Create the shared state for the MLP component of the decoder layer.

--- a/models/demos/deepseek_v3/tt/decoder_block/decoder_block_base.py
+++ b/models/demos/deepseek_v3/tt/decoder_block/decoder_block_base.py
@@ -91,7 +91,7 @@ class DecoderBlockBase(SharedStateAddOn, AbstractModule):
         mlp_shared_state = cls.create_mlp_shared_state(
             hf_config,
             mesh_device,
-            fabric_config(),
+            fabric_config,
         )
         logger.info(f"Created {cls.__name__} MLP shared state in {perf_counter() - mlp_start:.2f}s")
         state = {

--- a/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block_2d.py
+++ b/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block_2d.py
@@ -12,7 +12,7 @@ from models.demos.deepseek_v3.tt.ccl import CCL
 from models.demos.deepseek_v3.tt.decoder_block.decoder_block_2d_base import DecoderBlock2DBase
 from models.demos.deepseek_v3.tt.mlp.shared_expert import SharedExpert
 from models.demos.deepseek_v3.tt.moe import MoE
-from models.demos.deepseek_v3.utils.config_helpers import sub_state_dict
+from models.demos.deepseek_v3.utils.config_helpers import is_ring_fabric, sub_state_dict
 from models.demos.deepseek_v3.utils.run_config import (
     ModelDecodeConfig,
     ModelPrefillConfig,
@@ -179,7 +179,7 @@ class MoEDecoderBlock2D(DecoderBlock2DBase):
         if x_dim == hidden_size // tp_size:
             # Single reduce_scatter on combined output using MoE's config for consistency
 
-            if cfg["moe"]["fabric_config"] == ttnn.FabricConfig.FABRIC_1D_RING and tp_size == 8:
+            if is_ring_fabric(cfg["moe"]["fabric_config"]) and tp_size == 8:
                 summed_experts = ttnn.experimental.deepseek_moe_fast_reduce_nc(
                     combined_out,
                     dim=0,

--- a/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block_2d.py
+++ b/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block_2d.py
@@ -88,10 +88,11 @@ class MoEDecoderBlock2D(DecoderBlock2DBase):
         cls,
         hf_config: PretrainedConfig,
         mesh_device: ttnn.MeshDevice,
+        fabric_config: ttnn.FabricConfig,
     ) -> ModelState:
         return {
             "shared_expert": {},
-            "moe": MoE.create_shared_state(hf_config, mesh_device),
+            "moe": MoE.create_shared_state(hf_config, mesh_device, fabric_config),
         }
 
     @classmethod

--- a/models/demos/deepseek_v3/tt/experts.py
+++ b/models/demos/deepseek_v3/tt/experts.py
@@ -56,7 +56,7 @@ class Experts(AbstractModule):
         output_path: Path,
         mesh_device: ttnn.Device,
     ) -> WeightConfig:
-        if is_quad_mesh(mesh_device) and is_ring_fabric(get_fabric_config()):
+        if is_quad_mesh() and is_ring_fabric(get_fabric_config()):
             return cls._convert_weights_quad_ring(hf_config, state_dicts, output_path, mesh_device)
         return cls._convert_weights_default(hf_config, state_dicts, output_path, mesh_device)
 

--- a/models/demos/deepseek_v3/tt/experts.py
+++ b/models/demos/deepseek_v3/tt/experts.py
@@ -17,7 +17,7 @@ from models.demos.deepseek_v3.utils.config_helpers import (
     COMPUTE_KERNEL_CONFIG_LOFI,
     even_int_div,
     get_dequantized_tensor,
-    is_quad_mesh,
+    is_quad_ring,
     shard_and_save,
 )
 from models.demos.deepseek_v3.utils.run_config import (
@@ -47,8 +47,8 @@ class Experts(AbstractModule):
         output_path: Path,
         mesh_device: ttnn.Device,
     ) -> WeightConfig:
-        if is_quad_mesh(mesh_device):
-            return cls._convert_weights_quad(hf_config, state_dicts, output_path, mesh_device)
+        if is_quad_ring(mesh_device):
+            return cls._convert_weights_quad_ring(hf_config, state_dicts, output_path, mesh_device)
         return cls._convert_weights_default(hf_config, state_dicts, output_path, mesh_device)
 
     @classmethod
@@ -96,14 +96,48 @@ class Experts(AbstractModule):
         }
 
     @classmethod
-    def _convert_weights_quad(
+    def _convert_weights_quad_ring(
         cls,
         hf_config: PretrainedConfig,
         state_dicts: tuple[dict[str, torch.Tensor] | None, ...],
         output_path: Path,
         mesh_device: ttnn.Device,
     ) -> WeightConfig:
-        return cls._convert_weights_default(hf_config, state_dicts, output_path, mesh_device)
+        assert hf_config.n_routed_experts % mesh_device.get_num_devices() == 0, (
+            f"Number of experts ({hf_config.n_routed_experts}) must be divisible by the number of devices "
+            f"({mesh_device.get_num_devices()})"
+        )
+        (state_dict,) = state_dicts
+        assert state_dict is not None
+
+        def _load_expert_weight(hf_name: str) -> torch.Tensor:
+            weight_name = f"{hf_name}.weight"
+            expert_weights: list[torch.Tensor] = []
+            for expert_id in range(hf_config.n_routed_experts):
+                full_weight_name = f"experts.{expert_id}.{weight_name}"
+                expert_weights.append(
+                    get_dequantized_tensor(state_dict, full_weight_name, dtype=cls.WEIGHT_TORCH_DTYPE)
+                )
+
+            return torch.stack(expert_weights)
+
+        return {
+            ttnn_name: {
+                "input_tensor_b": shard_and_save(
+                    output_path / f"{ttnn_name}.input_tensor_b",
+                    _load_expert_weight(hf_name).unsqueeze(0).transpose(-1, -2),
+                    shard_dims=(1, 1),
+                    mesh_device=mesh_device,
+                    dtype=ttnn.bfloat4_b,
+                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                )
+            }
+            for hf_name, ttnn_name in [
+                ("gate_proj", "w1_experts"),
+                ("down_proj", "w2_experts"),
+                ("up_proj", "w3_experts"),
+            ]
+        }
 
     @classmethod
     def is_device_supported(cls, mesh_device: ttnn.Device) -> bool:

--- a/models/demos/deepseek_v3/tt/experts.py
+++ b/models/demos/deepseek_v3/tt/experts.py
@@ -61,6 +61,17 @@ class Experts(AbstractModule):
         return cls._convert_weights_default(hf_config, state_dicts, output_path, mesh_device)
 
     @classmethod
+    def _load_expert_weight(
+        cls, state_dict: dict[str, torch.Tensor], hf_name: str, n_routed_experts: int
+    ) -> torch.Tensor:
+        weight_name = f"{hf_name}.weight"
+        expert_weights: list[torch.Tensor] = []
+        for expert_id in range(n_routed_experts):
+            full_weight_name = f"experts.{expert_id}.{weight_name}"
+            expert_weights.append(get_dequantized_tensor(state_dict, full_weight_name, dtype=cls.WEIGHT_TORCH_DTYPE))
+        return torch.stack(expert_weights)
+
+    @classmethod
     def _convert_weights_default(
         cls,
         hf_config: PretrainedConfig,
@@ -75,22 +86,13 @@ class Experts(AbstractModule):
         (state_dict,) = state_dicts
         assert state_dict is not None
 
-        def _load_expert_weight(hf_name: str) -> torch.Tensor:
-            weight_name = f"{hf_name}.weight"
-            expert_weights: list[torch.Tensor] = []
-            for expert_id in range(hf_config.n_routed_experts):
-                full_weight_name = f"experts.{expert_id}.{weight_name}"
-                expert_weights.append(
-                    get_dequantized_tensor(state_dict, full_weight_name, dtype=cls.WEIGHT_TORCH_DTYPE)
-                )
-
-            return torch.stack(expert_weights)
-
         return {
             ttnn_name: {
                 "input_tensor_b": shard_and_save(
                     output_path / f"{ttnn_name}.input_tensor_b",
-                    _load_expert_weight(hf_name).unsqueeze(0).transpose(-1, -2),
+                    cls._load_expert_weight(state_dict, hf_name, hf_config.n_routed_experts)
+                    .unsqueeze(0)
+                    .transpose(-1, -2),
                     shard_dims=(1, 1),
                     mesh_device=mesh_device,
                     dtype=ttnn.bfloat8_b if hf_name == "down_proj" else ttnn.bfloat4_b,
@@ -121,40 +123,42 @@ class Experts(AbstractModule):
 
         num_layers = 1
         num_experts_per_device = cls._get_num_experts_per_device(hf_config, mesh_device)
-        hidden_size = hidden_size = hf_config.hidden_size
-        matmul_N = 2048
+        num_routed_experts = hf_config.n_routed_experts
+
+        w0 = cls._load_expert_weight(state_dict, "gate_proj", num_routed_experts).unsqueeze(0).transpose(-1, -2)
+        w1 = cls._load_expert_weight(state_dict, "up_proj", num_routed_experts).unsqueeze(0).transpose(-1, -2)
+        w2 = cls._load_expert_weight(state_dict, "down_proj", num_routed_experts).unsqueeze(0).transpose(-1, -2)
+
+        hidden_size = hf_config.hidden_size
+        matmul_N = w0.shape[-1]
         ring2cores, compute_matmul_dram_core_range_set = determine_compute_matmul_cores(mesh_device)
-
-        def _load_expert_weight(hf_name: str) -> torch.Tensor:
-            weight_name = f"{hf_name}.weight"
-            expert_weights: list[torch.Tensor] = []
-            for expert_id in range(hf_config.n_routed_experts):
-                full_weight_name = f"experts.{expert_id}.{weight_name}"
-                expert_weights.append(
-                    get_dequantized_tensor(state_dict, full_weight_name, dtype=cls.WEIGHT_TORCH_DTYPE)
-                )
-
-            return torch.stack(expert_weights)
-
-        w0 = _load_expert_weight("gate_proj").unsqueeze(0).transpose(-1, -2)
-        w1 = _load_expert_weight("up_proj").unsqueeze(0).transpose(-1, -2)
-        w2 = _load_expert_weight("down_proj").unsqueeze(0).transpose(-1, -2)
 
         prepared_w0_w1 = []
         prepared_w2 = []
-        for i in range(0, hf_config.n_routed_experts, num_experts_per_device):
+        for i in range(0, num_routed_experts, num_experts_per_device):
             prepared_w0_w1_tensor = prepare_w0_w1_tensor(
-                w0, w1, num_layers, num_experts_per_device, hidden_size, matmul_N, ring2cores
+                w0[:, i : i + num_experts_per_device, :, :],
+                w1[:, i : i + num_experts_per_device, :, :],
+                num_layers,
+                num_experts_per_device,
+                hidden_size,
+                matmul_N,
+                ring2cores,
             )
             prepared_w2_tensor = prepare_w2_tensor(
-                w2, num_layers, num_experts_per_device, matmul_N, hidden_size, ring2cores
+                w2[:, i : i + num_experts_per_device, :, :],
+                num_layers,
+                num_experts_per_device,
+                matmul_N,
+                hidden_size,
+                ring2cores,
             )
 
             prepared_w0_w1.append(prepared_w0_w1_tensor)
             prepared_w2.append(prepared_w2_tensor)
 
-        prepared_w0_w1 = torch.cat(prepared_w0_w1, dim=1)
-        prepared_w2 = torch.cat(prepared_w2, dim=1)
+        prepared_w0_w1 = torch.cat(prepared_w0_w1, dim=2)
+        prepared_w2 = torch.cat(prepared_w2, dim=2)
 
         w0_w1_memory_config = get_w0_w1_memory_config(
             num_layers, num_experts_per_device, hidden_size, compute_matmul_dram_core_range_set
@@ -164,21 +168,21 @@ class Experts(AbstractModule):
         )
 
         return {
-            "w0_w1_experts": {
+            "quad_ring_w0_w1_experts": {
                 "input_tensor_b": shard_and_save(
-                    output_path / "w1_experts.input_tensor_b",
+                    output_path / "quad_ring_w0_w1_experts.input_tensor_b",
                     prepared_w0_w1,
-                    shard_dims=(1, 1),
+                    shard_dims=(2, 2),
                     mesh_device=mesh_device,
                     dtype=ttnn.bfloat4_b,
                     memory_config=w0_w1_memory_config,
                 )
             },
-            "w2_experts": {
+            "quad_ring_w2_experts": {
                 "input_tensor_b": shard_and_save(
-                    output_path / "w2_experts.input_tensor_b",
+                    output_path / "quad_ring_w2_experts.input_tensor_b",
                     prepared_w2,
-                    shard_dims=(1, 1),
+                    shard_dims=(2, 2),
                     mesh_device=mesh_device,
                     dtype=ttnn.bfloat4_b,
                     memory_config=w2_memory_config,

--- a/models/demos/deepseek_v3/tt/experts.py
+++ b/models/demos/deepseek_v3/tt/experts.py
@@ -17,6 +17,7 @@ from models.demos.deepseek_v3.utils.config_helpers import (
     COMPUTE_KERNEL_CONFIG_LOFI,
     even_int_div,
     get_dequantized_tensor,
+    is_quad_mesh,
     shard_and_save,
 )
 from models.demos.deepseek_v3.utils.run_config import (
@@ -40,6 +41,18 @@ class Experts(AbstractModule):
 
     @classmethod
     def convert_weights(
+        cls,
+        hf_config: PretrainedConfig,
+        state_dicts: tuple[dict[str, torch.Tensor] | None, ...],
+        output_path: Path,
+        mesh_device: ttnn.Device,
+    ) -> WeightConfig:
+        if is_quad_mesh(mesh_device):
+            return cls._convert_weights_quad(hf_config, state_dicts, output_path, mesh_device)
+        return cls._convert_weights_default(hf_config, state_dicts, output_path, mesh_device)
+
+    @classmethod
+    def _convert_weights_default(
         cls,
         hf_config: PretrainedConfig,
         state_dicts: tuple[dict[str, torch.Tensor] | None, ...],
@@ -81,6 +94,16 @@ class Experts(AbstractModule):
                 ("up_proj", "w3_experts"),
             ]
         }
+
+    @classmethod
+    def _convert_weights_quad(
+        cls,
+        hf_config: PretrainedConfig,
+        state_dicts: tuple[dict[str, torch.Tensor] | None, ...],
+        output_path: Path,
+        mesh_device: ttnn.Device,
+    ) -> WeightConfig:
+        return cls._convert_weights_default(hf_config, state_dicts, output_path, mesh_device)
 
     @classmethod
     def is_device_supported(cls, mesh_device: ttnn.Device) -> bool:

--- a/models/demos/deepseek_v3/tt/experts.py
+++ b/models/demos/deepseek_v3/tt/experts.py
@@ -204,7 +204,6 @@ class Experts(AbstractModule):
         return mesh_device.shape[1] == 8
 
     @classmethod
-    @classmethod
     def _create_model_config(
         cls, hf_config: PretrainedConfig, mesh_device: ttnn.Device, mode: str
     ) -> ModelPrefillConfig | ModelDecodeConfig:
@@ -223,31 +222,42 @@ class Experts(AbstractModule):
             output_memory_config = ttnn.DRAM_MEMORY_CONFIG
 
         # Construct the config
-        return {
+        config = {
             "mesh_device": MeshDeviceStub(mesh_device.shape),
-            "w1_experts": LinearConfig(
-                input_tensor_b=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
-                memory_config=output_memory_config,
-                compute_kernel_config=COMPUTE_KERNEL_CONFIG_LOFI,
-            ),
-            "w2_experts": LinearConfig(
-                input_tensor_b=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
-                memory_config=output_memory_config,
-                compute_kernel_config=COMPUTE_KERNEL_CONFIG_HIFI2,
-            ),
-            "w3_experts": LinearConfig(
-                input_tensor_b=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
-                memory_config=output_memory_config,
-                compute_kernel_config=COMPUTE_KERNEL_CONFIG_LOFI,
-            ),
-            "mul_experts": MulConfig(
-                memory_config=output_memory_config,
-                input_tensor_a_activations=[ttnn.UnaryOpType.SILU],
-            ),
             "input_memory_config": input_memory_config,
             "output_memory_config": output_memory_config,
             "num_experts_per_device": num_experts_per_device,
         }
+
+        if is_quad_mesh() and is_ring_fabric(get_fabric_config()):
+            config["quad_ring_w0_w1_experts"] = {
+                "input_tensor_b": FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
+            }
+            config["quad_ring_w2_experts"] = {
+                "input_tensor_b": FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
+            }
+        else:
+            config["w1_experts"] = LinearConfig(
+                input_tensor_b=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
+                memory_config=output_memory_config,
+                compute_kernel_config=COMPUTE_KERNEL_CONFIG_LOFI,
+            )
+            config["w2_experts"] = LinearConfig(
+                input_tensor_b=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
+                memory_config=output_memory_config,
+                compute_kernel_config=COMPUTE_KERNEL_CONFIG_HIFI2,
+            )
+            config["w3_experts"] = LinearConfig(
+                input_tensor_b=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
+                memory_config=output_memory_config,
+                compute_kernel_config=COMPUTE_KERNEL_CONFIG_LOFI,
+            )
+            config["mul_experts"] = MulConfig(
+                memory_config=output_memory_config,
+                input_tensor_a_activations=[ttnn.UnaryOpType.SILU],
+            )
+
+        return config
 
     @classmethod
     def decode_model_config(cls, hf_config: PretrainedConfig, mesh_device: ttnn.Device) -> ModelDecodeConfig:

--- a/models/demos/deepseek_v3/tt/experts.py
+++ b/models/demos/deepseek_v3/tt/experts.py
@@ -17,7 +17,9 @@ from models.demos.deepseek_v3.utils.config_helpers import (
     COMPUTE_KERNEL_CONFIG_LOFI,
     even_int_div,
     get_dequantized_tensor,
-    is_quad_ring,
+    get_fabric_config,
+    is_quad_mesh,
+    is_ring_fabric,
     shard_and_save,
 )
 from models.demos.deepseek_v3.utils.run_config import (
@@ -52,7 +54,7 @@ class Experts(AbstractModule):
         output_path: Path,
         mesh_device: ttnn.Device,
     ) -> WeightConfig:
-        if is_quad_ring(mesh_device):
+        if is_quad_mesh(mesh_device) and is_ring_fabric(get_fabric_config()):
             return cls._convert_weights_quad_ring(hf_config, state_dicts, output_path, mesh_device)
         return cls._convert_weights_default(hf_config, state_dicts, output_path, mesh_device)
 

--- a/models/demos/deepseek_v3/tt/experts.py
+++ b/models/demos/deepseek_v3/tt/experts.py
@@ -33,6 +33,8 @@ from tests.nightly.tg.ccl.moe.test_moe_compute_6U import (
     determine_compute_matmul_cores,
     get_w0_w1_memory_config,
     get_w2_memory_config,
+    prepare_w0_w1_tensor,
+    prepare_w2_tensor,
 )
 
 
@@ -118,18 +120,10 @@ class Experts(AbstractModule):
         assert state_dict is not None
 
         num_layers = 1
-        experts_per_device = cls._get_num_experts_per_device(hf_config, mesh_device)
+        num_experts_per_device = cls._get_num_experts_per_device(hf_config, mesh_device)
         hidden_size = hidden_size = hf_config.hidden_size
         matmul_N = 2048
-
         ring2cores, compute_matmul_dram_core_range_set = determine_compute_matmul_cores(mesh_device)
-
-        w0_w1_memory_config = get_w0_w1_memory_config(
-            num_layers, experts_per_device, hidden_size, compute_matmul_dram_core_range_set
-        )
-        w2_memory_config = get_w2_memory_config(
-            num_layers, experts_per_device, matmul_N, compute_matmul_dram_core_range_set
-        )
 
         def _load_expert_weight(hf_name: str) -> torch.Tensor:
             weight_name = f"{hf_name}.weight"
@@ -142,22 +136,54 @@ class Experts(AbstractModule):
 
             return torch.stack(expert_weights)
 
+        w0 = _load_expert_weight("gate_proj").unsqueeze(0).transpose(-1, -2)
+        w1 = _load_expert_weight("up_proj").unsqueeze(0).transpose(-1, -2)
+        w2 = _load_expert_weight("down_proj").unsqueeze(0).transpose(-1, -2)
+
+        prepared_w0_w1 = []
+        prepared_w2 = []
+        for i in range(0, hf_config.n_routed_experts, num_experts_per_device):
+            prepared_w0_w1_tensor = prepare_w0_w1_tensor(
+                w0, w1, num_layers, num_experts_per_device, hidden_size, matmul_N, ring2cores
+            )
+            prepared_w2_tensor = prepare_w2_tensor(
+                w2, num_layers, num_experts_per_device, matmul_N, hidden_size, ring2cores
+            )
+
+            prepared_w0_w1.append(prepared_w0_w1_tensor)
+            prepared_w2.append(prepared_w2_tensor)
+
+        prepared_w0_w1 = torch.cat(prepared_w0_w1, dim=1)
+        prepared_w2 = torch.cat(prepared_w2, dim=1)
+
+        w0_w1_memory_config = get_w0_w1_memory_config(
+            num_layers, num_experts_per_device, hidden_size, compute_matmul_dram_core_range_set
+        )
+        w2_memory_config = get_w2_memory_config(
+            num_layers, num_experts_per_device, matmul_N, compute_matmul_dram_core_range_set
+        )
+
         return {
-            ttnn_name: {
+            "w0_w1_experts": {
                 "input_tensor_b": shard_and_save(
-                    output_path / f"{ttnn_name}.input_tensor_b",
-                    _load_expert_weight(hf_name).unsqueeze(0).transpose(-1, -2),
+                    output_path / "w1_experts.input_tensor_b",
+                    prepared_w0_w1,
                     shard_dims=(1, 1),
                     mesh_device=mesh_device,
                     dtype=ttnn.bfloat4_b,
-                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                    memory_config=w0_w1_memory_config,
                 )
-            }
-            for hf_name, ttnn_name in [
-                ("gate_proj", "w1_experts"),
-                ("down_proj", "w2_experts"),
-                ("up_proj", "w3_experts"),
-            ]
+            },
+            "w2_experts": {
+                "input_tensor_b": shard_and_save(
+                    output_path / "w2_experts.input_tensor_b",
+                    prepared_w2,
+                    shard_dims=(1, 1),
+                    mesh_device=mesh_device,
+                    dtype=ttnn.bfloat4_b,
+                    memory_config=w2_memory_config,
+                )
+            },
         }
 
     @classmethod

--- a/models/demos/deepseek_v3/tt/experts.py
+++ b/models/demos/deepseek_v3/tt/experts.py
@@ -27,6 +27,11 @@ from models.demos.deepseek_v3.utils.run_config import (
     RunPrefillConfig,
     WeightConfig,
 )
+from tests.nightly.tg.ccl.moe.test_moe_compute_6U import (
+    determine_compute_matmul_cores,
+    get_w0_w1_memory_config,
+    get_w2_memory_config,
+)
 
 
 class Experts(AbstractModule):
@@ -109,6 +114,20 @@ class Experts(AbstractModule):
         )
         (state_dict,) = state_dicts
         assert state_dict is not None
+
+        num_layers = 1
+        experts_per_device = cls._get_num_experts_per_device(hf_config, mesh_device)
+        hidden_size = hidden_size = hf_config.hidden_size
+        matmul_N = 2048
+
+        ring2cores, compute_matmul_dram_core_range_set = determine_compute_matmul_cores(mesh_device)
+
+        w0_w1_memory_config = get_w0_w1_memory_config(
+            num_layers, experts_per_device, hidden_size, compute_matmul_dram_core_range_set
+        )
+        w2_memory_config = get_w2_memory_config(
+            num_layers, experts_per_device, matmul_N, compute_matmul_dram_core_range_set
+        )
 
         def _load_expert_weight(hf_name: str) -> torch.Tensor:
             weight_name = f"{hf_name}.weight"

--- a/models/demos/deepseek_v3/tt/model/row_batched_model.py
+++ b/models/demos/deepseek_v3/tt/model/row_batched_model.py
@@ -171,6 +171,8 @@ class RowBatchedModel(SharedStateAddOn, AbstractModule):
         hf_config: PretrainedConfig,
         mesh_device: ttnn.MeshDevice,
     ) -> ModelState:
+        fabric_config = get_fabric_config()
+
         state: ModelState = {
             MESH_DEVICE_STATE_DICT_KEY: mesh_device,
             "num_rows": mesh_device.shape[0],
@@ -186,7 +188,7 @@ class RowBatchedModel(SharedStateAddOn, AbstractModule):
                     DecoderBlock2D.create_shared_state(
                         hf_config,
                         mesh_device,
-                        get_fabric_config(),
+                        fabric_config,
                     )
                 ],
             ),
@@ -197,14 +199,14 @@ class RowBatchedModel(SharedStateAddOn, AbstractModule):
                     MoEDecoderBlock2D.create_shared_state(
                         hf_config,
                         mesh_device,
-                        get_fabric_config(),
+                        fabric_config,
                     )
                 ],
             ),
         ]
         if cls._has_mtp_layer(hf_config):
             shared_state_steps.append(
-                ("MTP shared state", "mtp", lambda: MTP2D.create_shared_state(hf_config, mesh_device))
+                ("MTP shared state", "mtp", lambda: MTP2D.create_shared_state(hf_config, mesh_device, fabric_config))
             )
 
         total_steps = len(shared_state_steps)

--- a/models/demos/deepseek_v3/tt/model/row_batched_model.py
+++ b/models/demos/deepseek_v3/tt/model/row_batched_model.py
@@ -186,6 +186,7 @@ class RowBatchedModel(SharedStateAddOn, AbstractModule):
                     DecoderBlock2D.create_shared_state(
                         hf_config,
                         mesh_device,
+                        get_fabric_config(),
                     )
                 ],
             ),
@@ -196,6 +197,7 @@ class RowBatchedModel(SharedStateAddOn, AbstractModule):
                     MoEDecoderBlock2D.create_shared_state(
                         hf_config,
                         mesh_device,
+                        get_fabric_config(),
                     )
                 ],
             ),

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -18,6 +18,7 @@ from models.demos.deepseek_v3.utils.config_dataclass import (
     AllToAllCombineConfig,
     AllToAllDispatchConfig,
     AllToAllDispatchMetadataConfig,
+    DeepseekMoEPostCombineTilizeConfig,
     DeepseekMoEReduceScatterConfig,
     MeshDeviceStub,
     MoEComputeConfig,
@@ -308,10 +309,10 @@ class MoE(SharedStateAddOn, AbstractModule):
                 USERS_PER_ROW, hf_config.num_experts_per_tok
             )
             config["quad_ring_moreh_full"] = MorehFullConfig(
-                shape=ttnn.Shape([hf_config.num_experts_per_tok, USERS_PER_ROW, hf_config.hidden_size]),
+                shape=[hf_config.num_experts_per_tok, USERS_PER_ROW, hf_config.hidden_size],
                 fill_value=0,
                 device=mesh_device,
-                dtype=torch.bfloat16,
+                dtype=ttnn.bfloat16,
                 layout=ttnn.ROW_MAJOR_LAYOUT,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
             )
@@ -331,6 +332,9 @@ class MoE(SharedStateAddOn, AbstractModule):
                 data_parallel_core_dim=4,
                 worker_cores=ttnn.experimental.get_moe_combine_cores(mesh_device),
                 mux_core_range_set=ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(3, 0), ttnn.CoreCoord(4, 7))}),
+            )
+            config["quad_ring_deepseek_moe_post_combine_tilize_config"] = DeepseekMoEPostCombineTilizeConfig(
+                output_memory_config=DeepseekMoEPostCombineTilizeConfig.get_sharded_memory_config(),
             )
 
             # TODO: this is a temporary measure until we either a) uplift the optimized ops to support prefill shapes, or b) uplift prefill MMs to read from decode formatted weights
@@ -562,6 +566,7 @@ class MoE(SharedStateAddOn, AbstractModule):
             for batch_start in range(0, batch_size_per_device, chunk_size):
                 batch_end = min(batch_start + chunk_size, batch_size_per_device)
                 batch_chunk = batch_end - batch_start
+                pad_amount = cfg["moe_chunk_size"] - batch_chunk
 
                 x_rm_chunk = ttnn.slice(
                     x_rm,
@@ -570,7 +575,7 @@ class MoE(SharedStateAddOn, AbstractModule):
                 )
                 x_rm_chunk = ttnn.pad(
                     x_rm_chunk,
-                    padding=((0, cfg["moe_chunk_size"]), (0, 0), (0, 0), (0, 0)),
+                    padding=((0, pad_amount), (0, 0), (0, 0), (0, 0)),
                     value=0.0,
                 )
 
@@ -581,7 +586,7 @@ class MoE(SharedStateAddOn, AbstractModule):
                 )
                 topk_experts_indices_rm_chunk = ttnn.pad(
                     topk_experts_indices_rm_chunk,
-                    padding=((0, cfg["moe_chunk_size"]), (0, 0), (0, 0), (0, 0)),
+                    padding=((0, pad_amount), (0, 0), (0, 0), (0, 0)),
                     value=0.0,
                 )
 
@@ -592,7 +597,7 @@ class MoE(SharedStateAddOn, AbstractModule):
                 )
                 topk_experts_weights_rm_chunk = ttnn.pad(
                     topk_experts_weights_rm_chunk,
-                    padding=((0, cfg["moe_chunk_size"]), (0, 0), (0, 0), (0, 0)),
+                    padding=((0, pad_amount), (0, 0), (0, 0), (0, 0)),
                     value=0.0,
                 )
 
@@ -788,8 +793,8 @@ class MoE(SharedStateAddOn, AbstractModule):
             dispatch_output_expert_indices,
             dispatch_output_expert_scores,
             cfg["expert_mapping_tensor"],
-            cfg["moe_experts"]["quad_ring_w0_w1_experts"],
-            cfg["moe_experts"]["quad_ring_w2_experts"],
+            cfg["moe_experts"]["quad_ring_w0_w1_experts"]["input_tensor_b"],
+            cfg["moe_experts"]["quad_ring_w2_experts"]["input_tensor_b"],
             layer_id=0,  # each layer is composed of distinct tensors, as apposed to all layers fused together
             **cfg["quad_ring_moe_compute"],
         )
@@ -810,12 +815,10 @@ class MoE(SharedStateAddOn, AbstractModule):
         ttnn.deallocate(compute_ouput_dense_e_t)
         ttnn.deallocate(compute_output_token_counts)
 
-        combine_output = ttnn.to_layout(
-            combine_output,
-            layout=ttnn.TILE_LAYOUT,
-            memory_config=ttnn.L1_MEMORY_CONFIG,
-        )
         combine_output = ttnn.unsqueeze(combine_output, dim=1)
+        combine_output = ttnn.experimental.deepseek_moe_post_combine_tilize(
+            combine_output, **cfg["quad_ring_deepseek_moe_post_combine_tilize_config"]
+        )
 
         post_combine_output_tensor = ttnn.mul(
             combine_output, topk_experts_weights_for_scaling, **cfg["mul_experts_output_with_weights"]

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -17,11 +17,14 @@ from models.demos.deepseek_v3.utils.config_dataclass import (
     AllGatherAsyncConfig,
     AllToAllCombineConfig,
     AllToAllDispatchConfig,
+    AllToAllDispatchMetadataConfig,
     DeepseekMoEReduceScatterConfig,
     MeshDeviceStub,
+    MoEComputeConfig,
     MulConfig,
     ReduceScatterAsyncMinimalConfig,
     RepeatConfig,
+    SelectiveReduceCombineConfig,
 )
 from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW
 from models.demos.deepseek_v3.utils.run_config import (
@@ -78,8 +81,6 @@ class MoE(SharedStateAddOn, AbstractModule):
         Returns:
             ModelState containing shared tensors
         """
-        num_devices = mesh_device.get_num_devices()
-        num_experts_per_device = MoEExperts._get_num_experts_per_device(hf_config, mesh_device)
         num_dispatch_device_rows = mesh_device.shape[0]
 
         logger.info(
@@ -116,7 +117,6 @@ class MoE(SharedStateAddOn, AbstractModule):
         logger.info(f"Created MoE remap topk mask in {perf_counter() - remap_mask_start:.2f}s")
 
         return {
-            "expert_mapping_tensors": expert_mapping_tensors,
             "remap_topk_mask": remap_topk_mask,
             MESH_DEVICE_STATE_DICT_KEY: mesh_device,
         }
@@ -168,6 +168,7 @@ class MoE(SharedStateAddOn, AbstractModule):
         """
 
         num_experts_per_device = MoEExperts._get_num_experts_per_device(hf_config, mesh_device)
+        expert_mapping_tensor = cls._create_expert_mapping_tensor(mesh_device, mode, num_experts_per_device)
 
         if mode == "decode":
             memory_config = ttnn.L1_MEMORY_CONFIG
@@ -189,7 +190,7 @@ class MoE(SharedStateAddOn, AbstractModule):
             )
 
             # Construct the config
-            return {
+            decode_config = {
                 "mesh_device": MeshDeviceStub(mesh_device.shape),
                 "num_devices": mesh_device.get_num_devices(),
                 "fabric_config": fabric_config,
@@ -197,6 +198,7 @@ class MoE(SharedStateAddOn, AbstractModule):
                 "hidden_size": hf_config.hidden_size,
                 "num_experts_per_tok": hf_config.num_experts_per_tok,
                 "num_dispatch_devices": mesh_device.shape[0],
+                "expert_mapping_tensor": expert_mapping_tensor,
                 "moe_gate": MoEGate.model_config(hf_config, mesh_device, mode, topk_fallback=topk_fallback),
                 "all_to_all_dispatch_output_memory_config": memory_config,
                 "all_to_all_dispatch_metadata_memory_config": ttnn.DRAM_MEMORY_CONFIG,
@@ -235,6 +237,44 @@ class MoE(SharedStateAddOn, AbstractModule):
                     cluster_axis=1,
                 ),
             }
+
+            # optimized MoE ops only functional for quad torus
+            if ["fabric_config"] == ttnn.FabricConfig.FABRIC_1D_RING and mesh_device.shape[0] == 16:
+                batch = USERS_PER_ROW * mesh_device.shape[0]
+                seq_len = 1
+
+                decode_config["quad_ring_all_to_all_dispatch_metadata"] = AllToAllDispatchMetadataConfig(
+                    cluster_axis=0,
+                    worker_mode=ttnn.WorkerMode.DIRECT,
+                    dispatch_algorithm=ttnn.DispatchAlgorithm.SPARSE_MCAST_SHORTEST_PATH,
+                    output_tensors=AllToAllDispatchMetadataConfig.create_preallocated_dispatch_output_tensors(
+                        mesh_device,
+                        mesh_device.shape,
+                        mesh_device.shape[0],
+                        batch,
+                        HIDDEN_SIZE,
+                        hf_config.num_experts_per_tok,
+                    ),
+                )
+                decode_config["quad_ring_moe_compute"] = MoEComputeConfig(
+                    output_height_shard_dim=4,
+                    output_width_shard_dim=4,
+                    cluster_axis=0,
+                )
+                decode_config["quad_ring_selective_reduce_combine"] = SelectiveReduceCombineConfig(
+                    hidden_size=hf_config.hidden_size,
+                    batch=batch,
+                    seq=seq_len,
+                    select_experts_k=hf_config.num_experts_per_tok,
+                    experts=hf_config.n_routed_experts,
+                    axis=0,
+                    token_parallel_core_dim=4,
+                    data_parallel_core_dim=4,
+                    worker_cores=ttnn.experimental.get_moe_combine_cores(mesh_device),
+                    mux_core_range_set=ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(3, 0), ttnn.CoreCoord(4, 7))}),
+                )
+
+            return decode_config
         else:
             memory_config = ttnn.DRAM_MEMORY_CONFIG
             # Construct the config
@@ -273,6 +313,56 @@ class MoE(SharedStateAddOn, AbstractModule):
             }
 
     @classmethod
+    def _create_expert_mapping_tensor(
+        mesh_device: ttnn.Device,
+        mode: str,
+        num_experts_per_device: int,
+    ):
+        num_devices = mesh_device.get_num_devices()
+        if mode == "decode":
+            # optimized MoE ops only functional for quad torus
+            num_dispatch_devices = mesh_device.shape[0]
+            if ["fabric_config"] == ttnn.FabricConfig.FABRIC_1D_RING and num_dispatch_devices == 16:
+                num_experts = num_devices * num_experts_per_device
+                tp_size = mesh_device.shape[1]
+                num_experts_per_cluster = num_experts // tp_size
+
+                e = torch.arange(num_experts, dtype=torch.int32)
+                torch_expert_mapping_tensor = (
+                    (
+                        ((e % num_experts_per_cluster) // num_experts_per_device) * tp_size
+                        + (e // num_experts_per_cluster)
+                    )
+                    .unsqueeze(0)
+                    .repeat(num_devices, 1)
+                )
+            else:
+                torch_expert_mapping_tensor = (
+                    torch.eye(num_devices, dtype=torch.int32)
+                    .repeat_interleave(num_experts_per_device, dim=0)
+                    .unsqueeze(0)
+                    .unsqueeze(0)
+                )
+        else:
+            torch_expert_mapping_tensor = (
+                torch.eye(num_devices, dtype=torch.int32)
+                .repeat_interleave(num_experts_per_device, dim=0)
+                .unsqueeze(0)
+                .unsqueeze(0)
+            )
+
+        expert_mapping_tensor = ttnn.from_torch(
+            torch_expert_mapping_tensor,
+            device=mesh_device,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+            dtype=ttnn.uint16,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+        )
+
+        return expert_mapping_tensor
+
+    @classmethod
     def decode_model_config(
         cls,
         hf_config: PretrainedConfig,
@@ -293,7 +383,34 @@ class MoE(SharedStateAddOn, AbstractModule):
         return cls.model_config(hf_config, mesh_device, fabric_config, "prefill", topk_fallback=topk_fallback)
 
     @classmethod
-    def forward(cls, x: ttnn.Tensor, cfg: RunDecodeConfig | RunPrefillConfig) -> ttnn.Tensor:
+    def forward_decode(cls, x: ttnn.Tensor, cfg: RunDecodeConfig | RunPrefillConfig) -> ttnn.Tensor:
+        seq_len = 1  # a2a dispatch and combine require DP=num_dispatch_devices, hence in prefill for bs=1, we interchange the seq_len with batch_size dimensions
+        batch_size_per_device = x.shape[
+            -2
+        ]  # Input is expected to be DP. In prefill, this is equivalent to seq_len_per_device
+        batch_size = batch_size_per_device * cfg["num_dispatch_devices"]  # Global batch size
+
+        # Note: all_gather is handled by the caller (decoder block or test)
+
+        # MoE Gate
+        topk_experts_weights, topk_experts_indices = cls._fwd_moe_gate(x, cfg)
+
+        # MOE
+        post_combine_output_tensor = cls._fwd_decode_moe(
+            x,
+            topk_experts_indices,
+            topk_experts_weights,
+            cfg,
+            batch_size_per_device,
+            batch_size,
+            seq_len,
+        )
+
+        # Note: sum_experts and reduce_scatter is handled by the caller (decoder block or test)
+        return post_combine_output_tensor
+
+    @classmethod
+    def forward_prefill(cls, x: ttnn.Tensor, cfg: RunDecodeConfig | RunPrefillConfig) -> ttnn.Tensor:
         # Chunk the full MoE prefill path at 16K tokens to avoid OOM.
         # Use global token count (local seq_len * num_dispatch_devices) to decide.
         chunk_tokens = int(cfg.get("prefill_chunk_size", 16384))
@@ -302,7 +419,7 @@ class MoE(SharedStateAddOn, AbstractModule):
         if global_tokens > chunk_tokens:
             chunk_size = max(1, chunk_tokens // max(1, num_dispatch_devices))
             return cls._forward_chunked_prefill(x, cfg, chunk_size)
-        return cls._forward_impl(x, cfg)
+        return cls._forward_prefill_impl(x, cfg)
 
     @classmethod
     def _forward_chunked_prefill(cls, x: ttnn.Tensor, cfg: RunPrefillConfig, chunk_size: int) -> ttnn.Tensor:
@@ -323,7 +440,7 @@ class MoE(SharedStateAddOn, AbstractModule):
         return output
 
     @classmethod
-    def _forward_impl(cls, x: ttnn.Tensor, cfg: RunDecodeConfig | RunPrefillConfig) -> ttnn.Tensor:
+    def _forward_prefill_impl(cls, x: ttnn.Tensor, cfg: RunDecodeConfig | RunPrefillConfig) -> ttnn.Tensor:
         # Validate input dimensions
         hidden_size = cfg["hidden_size"]
         mesh_device = cfg.get("mesh_device")
@@ -338,8 +455,6 @@ class MoE(SharedStateAddOn, AbstractModule):
                 f"(hidden_size={hidden_size}, tp_size={tp_size})"
             )
 
-        # breakpoint()
-        ccl = cfg["ccl"]  # CCL runtime initialization in execution order
         seq_len = 1  # a2a dispatch and combine require DP=num_dispatch_devices, hence in prefill for bs=1, we interchange the seq_len with batch_size dimensions
         batch_size_per_device = x.shape[
             -2
@@ -352,12 +467,10 @@ class MoE(SharedStateAddOn, AbstractModule):
         topk_experts_weights, topk_experts_indices = cls._fwd_moe_gate(x, cfg)
 
         # Repeat + Permute Expert weights
-
         topk_experts_weights = cls._fwd_repeat_permute_expert_weights(topk_experts_weights, cfg)
 
         # MOE
-
-        post_combine_output_tensor = cls._fwd_moe(
+        post_combine_output_tensor = cls._fwd_prefill_moe(
             x,
             topk_experts_indices,
             topk_experts_weights,
@@ -368,7 +481,6 @@ class MoE(SharedStateAddOn, AbstractModule):
         )
 
         # Note: sum_experts and reduce_scatter is handled by the caller (decoder block or test)
-
         return post_combine_output_tensor
 
     @classmethod
@@ -387,7 +499,150 @@ class MoE(SharedStateAddOn, AbstractModule):
         return topk_experts_weights
 
     @classmethod
-    def _fwd_moe(
+    def _fwd_decode_moe(
+        cls,
+        x: ttnn.Tensor,
+        topk_experts_indices: ttnn.Tensor,
+        topk_experts_weights: ttnn.Tensor,
+        cfg: RunDecodeConfig | RunPrefillConfig,
+        batch_size_per_device: int,
+        batch_size: int,
+        seq_len: int,
+    ) -> ttnn.Tensor:
+        x_rm = ttnn.to_layout(x, ttnn.ROW_MAJOR_LAYOUT)
+        x_rm = ttnn.reshape(
+            x_rm,
+            shape=(batch_size_per_device, 1, seq_len, cfg["hidden_size"]),
+        )
+
+        if cfg["fabric_config"] == ttnn.FabricConfig.FABRIC_1D_RING and cfg["num_dispatch_devices"] == 16:
+            ccl = cfg["ccl"]
+
+            preallocated_combine_output = ttnn.moreh_full(
+                shape=[cfg["num_experts_per_tok"], batch_size_per_device, cfg["hidden_size"]],
+                fill_value=0,
+                device=cfg["mesh_device"],
+                dtype=ttnn.bfloat16,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+
+            (
+                dispatch_output_sparse_buffer,
+                dispatch_output_expert_indices,
+                dispatch_output_expert_scores,
+            ) = ttnn.experimental.all_to_all_dispatch_metadata(
+                x_rm,
+                topk_experts_indices,  # TODO: (GR) may need to change shard spec of aho gate output
+                topk_experts_weights,  # TODO: (GR) may need to change shard spec of aho gate output
+                cfg["expert_mapping_tensor"],
+                **ccl.populate_all_to_all_dispatch_metadata_args(cfg["quad_ring_all_to_all_dispatch_metadata"]),
+            )
+
+            # TODO: (GR)
+            w0_w1 = ()
+            w2 = ()
+            layer_id = 0
+            (
+                compute_output_token_counts,
+                compute_output_dense_expert_activation,
+                compute_ouput_dense_e_t,
+                _,  # tile layout output of selective tilize (same buffer as output)
+                compute_output,
+            ) = ttnn.experimental.moe_compute(
+                dispatch_output_sparse_buffer,
+                dispatch_output_expert_indices,
+                dispatch_output_expert_scores,
+                cfg["expert_mapping_tensor"],
+                w0_w1,  # TODO: (GR)
+                w2,  # TODO: (GR)
+                layer_id=layer_id,  # TODO: (GR)
+                **cfg["quad_ring_moe_compute"],
+            )
+
+            combine_output = ttnn.experimental.selective_reduce_combine(
+                compute_output,
+                compute_output_dense_expert_activation,
+                compute_ouput_dense_e_t,
+                compute_output_token_counts,
+                output_tensor=preallocated_combine_output,
+                **ccl.populate_selective_reduce_combine_args(cfg["quad_ring_selective_reduce_combine"]),
+            )
+
+            combine_output = ttnn.to_layout(
+                combine_output,
+                layout=ttnn.TILE_LAYOUT,
+                memory_config=ttnn.L1_MEMORY_CONFIG,
+            )
+            combine_output = ttnn.unsqueeze(combine_output, dim=1)
+
+            topk_experts_weights = ttnn.permute(topk_experts_weights, (3, 1, 0, 2), memory_config=ttnn.L1_MEMORY_CONFIG)
+            topk_experts_weights = ttnn.to_layout(
+                topk_experts_weights, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG
+            )
+
+            post_combine_output_tensor = ttnn.mul(
+                combine_output, topk_experts_weights, memory_config=ttnn.L1_MEMORY_CONFIG
+            )
+        else:
+            topk_experts_indices_rm = ttnn.to_layout(topk_experts_indices, ttnn.ROW_MAJOR_LAYOUT)
+            topk_experts_indices_rm = ttnn.reshape(
+                topk_experts_indices_rm, shape=(batch_size_per_device, 1, seq_len, cfg["num_experts_per_tok"])
+            )
+
+            all_to_all_dispatch_output_tensors, all_to_all_dispatch_metadata_tensors = ttnn.all_to_all_dispatch(
+                x_rm,
+                topk_experts_indices_rm,
+                cfg["expert_mapping_tensor"],
+                **cfg["all_to_all_dispatch"],
+            )
+
+            post_all_to_all_dispatch_output = ttnn.reshape(
+                all_to_all_dispatch_output_tensors, shape=(1, 1, batch_size * seq_len, cfg["hidden_size"])
+            )
+            post_all_to_all_dispatch_output = ttnn.to_layout(post_all_to_all_dispatch_output, ttnn.TILE_LAYOUT)
+            # repeat remap_topk_mask for the num_tokens known at runtime
+
+            remap_topk_mask = ttnn.repeat(
+                cfg["remap_topk_mask"], ttnn.Shape((1, batch_size_per_device, 1, 1))
+            )  # TODO: move to static path
+
+            _, sparsity_t = ttnn.moe_expert_token_remap(
+                remap_topk_mask,
+                cfg["expert_mapping_tensor"],
+                all_to_all_dispatch_metadata_tensors,
+                reduction_size=cfg["sparsity_block_size"],
+            )
+
+            experts_output = MoEExperts._forward(post_all_to_all_dispatch_output, sparsity_t, cfg["moe_experts"])
+            ttnn.deallocate(post_all_to_all_dispatch_output)
+
+            experts_output = ttnn.to_layout(experts_output, ttnn.ROW_MAJOR_LAYOUT)
+            experts_output = ttnn.reshape(
+                experts_output, shape=(cfg["num_experts_per_device"], batch_size, seq_len, cfg["hidden_size"])
+            )
+
+            all_to_all_combine_output_tensors = ttnn.all_to_all_combine(
+                experts_output,
+                all_to_all_dispatch_metadata_tensors,
+                cfg["expert_mapping_tensor"],
+                **cfg["all_to_all_combine"],
+            )
+
+            post_combine_output_tensor = ttnn.reshape(
+                all_to_all_combine_output_tensors,
+                shape=(cfg["num_experts_per_tok"], 1, batch_size_per_device * seq_len, cfg["hidden_size"]),
+            )
+            post_combine_output_tensor = ttnn.to_layout(post_combine_output_tensor, ttnn.TILE_LAYOUT)
+
+            post_combine_output_tensor = ttnn.mul(
+                post_combine_output_tensor, topk_experts_weights, **cfg["mul_experts_output_with_weights"]
+            )
+
+        return post_combine_output_tensor
+
+    @classmethod
+    def _fwd_prefill_moe(
         cls,
         x: ttnn.Tensor,
         topk_experts_indices: ttnn.Tensor,
@@ -529,32 +784,13 @@ class MoE(SharedStateAddOn, AbstractModule):
         return ttnn.reduce_scatter(post_combine_output_tensor, **rs_kwargs)
 
     @classmethod
-    def forward_prefill(
-        cls, x: ttnn.Tensor, cfg: RunPrefillConfig, handle_tensor_parallel: bool = False
-    ) -> ttnn.Tensor:
-        # Handle all_gather if tensor parallel is enabled
-        if handle_tensor_parallel:
-            x = cls._fwd_all_gather(x, cfg)
-
-        # Run the forward pass
-        output = cls.forward(x, cfg)
-
-        # Handle sum_experts and reduce_scatter if tensor parallel is enabled
-        if handle_tensor_parallel:
-            ccl = cfg["ccl"]
-            output = ttnn.sum(output, dim=0, keepdim=True, memory_config=cfg["sum_experts_output_memory_config"])
-            output = cls._fwd_reduce_scatter(output, cfg, ccl)
-
-        return output
-
-    @classmethod
     def forward_decode(cls, x: ttnn.Tensor, cfg: RunDecodeConfig, handle_tensor_parallel: bool = False) -> ttnn.Tensor:
         # Handle all_gather if tensor parallel is enabled
         if handle_tensor_parallel:
             x = cls._fwd_all_gather(x, cfg)
 
         # Run the forward pass
-        output = cls.forward(x, cfg)
+        output = cls.forward_decode(x, cfg)
 
         # Handle sum_experts and reduce_scatter if tensor parallel is enabled
         if handle_tensor_parallel:
@@ -574,5 +810,24 @@ class MoE(SharedStateAddOn, AbstractModule):
             else:
                 output = ttnn.sum(output, dim=0, keepdim=True, memory_config=cfg["sum_experts_output_memory_config"])
                 output = cls._fwd_reduce_scatter(output, cfg, ccl)
+
+        return output
+
+    @classmethod
+    def forward_prefill(
+        cls, x: ttnn.Tensor, cfg: RunPrefillConfig, handle_tensor_parallel: bool = False
+    ) -> ttnn.Tensor:
+        # Handle all_gather if tensor parallel is enabled
+        if handle_tensor_parallel:
+            x = cls._fwd_all_gather(x, cfg)
+
+        # Run the forward pass
+        output = cls.forward_prefill(x, cfg)
+
+        # Handle sum_experts and reduce_scatter if tensor parallel is enabled
+        if handle_tensor_parallel:
+            ccl = cfg["ccl"]
+            output = ttnn.sum(output, dim=0, keepdim=True, memory_config=cfg["sum_experts_output_memory_config"])
+            output = cls._fwd_reduce_scatter(output, cfg, ccl)
 
         return output

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -321,6 +321,7 @@ class MoE(SharedStateAddOn, AbstractModule):
 
     @classmethod
     def _create_expert_mapping_tensor(
+        cls,
         mesh_device: ttnn.Device,
         mode: str,
         num_experts_per_device: int,

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -573,9 +573,7 @@ class MoE(SharedStateAddOn, AbstractModule):
                 **cfg["quad_ring_moe_compute"],
             )
 
-            ttnn.deallocate(dispatch_output_sparse_buffer)
-            ttnn.deallocate(dispatch_output_expert_indices)
-            ttnn.deallocate(dispatch_output_expert_scores)
+            # NOTE: can't deallocate dispatch output tensors as they are preallocated and reused across layers
 
             combine_output = ttnn.experimental.selective_reduce_combine(
                 compute_output,

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -306,6 +306,11 @@ class MoE(SharedStateAddOn, AbstractModule):
                 worker_mode=ttnn.WorkerMode.DIRECT,
                 dispatch_algorithm=ttnn.DispatchAlgorithm.SPARSE_MCAST_SHORTEST_PATH,
             )
+            config[
+                "quad_ring_all_to_all_dispatch_metadata_sharded_memory_config"
+            ] = AllToAllDispatchMetadataConfig.get_metadata_sharded_memory_config(
+                USERS_PER_ROW, hf_config.num_experts_per_tok
+            )
             config["quad_ring_moreh_full"] = MorehFullConfig(
                 shape=ttnn.Shape([hf_config.num_experts_per_tok, USERS_PER_ROW, hf_config.hidden_size]),
                 fill_value=0,
@@ -331,6 +336,10 @@ class MoE(SharedStateAddOn, AbstractModule):
                 worker_cores=ttnn.experimental.get_moe_combine_cores(mesh_device),
                 mux_core_range_set=ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(3, 0), ttnn.CoreCoord(4, 7))}),
             )
+
+            # TODO: this is a temporary measure until we either a) uplift the optimized ops to support prefill shapes, or b) uplift prefill MMs to read from decode formatted weights
+            # set chunk size for prefill
+            config["moe_chunk_size"] = USERS_PER_ROW
 
         return config
 
@@ -501,14 +510,41 @@ class MoE(SharedStateAddOn, AbstractModule):
         if cfg["fabric_config"] == ttnn.FabricConfig.FABRIC_1D_RING and cfg["num_dispatch_devices"] == 16:
             ccl = cfg["ccl"]
 
-            # L1 sharded topk_experts_weights need to be deallocated before moe_compute
+            # NOTE: can move towards removing these TMs once optimized moe_gate is integrated
+            topk_experts_indices_rm = ttnn.to_layout(
+                topk_experts_indices, ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG
+            )
+            topk_experts_weights_rm = ttnn.to_layout(
+                topk_experts_weights, ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG
+            )
+
+            topk_experts_indices_rm = ttnn.permute(
+                topk_experts_indices_rm, (2, 0, 1, 3), memory_config=ttnn.L1_MEMORY_CONFIG
+            )
+            topk_experts_weights_rm = ttnn.permute(
+                topk_experts_weights_rm, (2, 0, 1, 3), memory_config=ttnn.L1_MEMORY_CONFIG
+            )
+
+            topk_experts_indices_rm_sharded = ttnn.to_memory_config(
+                topk_experts_indices_rm,
+                memory_config=cfg["quad_ring_all_to_all_dispatch_metadata_sharded_memory_config"],
+            )
+            topk_experts_weights_rm_sharded = ttnn.to_memory_config(
+                topk_experts_weights_rm,
+                memory_config=cfg["quad_ring_all_to_all_dispatch_metadata_sharded_memory_config"],
+            )
+
+            # NOTE: L1 sharded topk_experts_weights need to be deallocated before moe_compute,
             # configure weights for post combine scaling prior to that deallocation, and store in DRAM
-            permuted_topk_experts_weights = ttnn.permute(
-                topk_experts_weights, (3, 1, 0, 2), memory_config=ttnn.L1_MEMORY_CONFIG
+            topk_experts_weights_for_scaling = ttnn.permute(
+                topk_experts_weights_rm, (3, 1, 0, 2), memory_config=ttnn.L1_MEMORY_CONFIG
             )
-            permuted_topk_experts_weights = ttnn.to_layout(
-                permuted_topk_experts_weights, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG
+            topk_experts_weights_for_scaling = ttnn.to_layout(
+                topk_experts_weights_for_scaling, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG
             )
+
+            ttnn.deallocate(topk_experts_indices_rm)
+            ttnn.deallocate(topk_experts_weights_rm)
 
             # NOTE: needs to run prior to all_to_all_dispatch_metadata
             preallocated_combine_output = ttnn.moreh_full(**cfg["quad_ring_moreh_full"])
@@ -519,8 +555,8 @@ class MoE(SharedStateAddOn, AbstractModule):
                 dispatch_output_expert_scores,
             ) = ttnn.experimental.all_to_all_dispatch_metadata(
                 x_rm,
-                topk_experts_indices,  # TODO: (GR) need to change shard spec of aho gate module output (once it's merged)
-                topk_experts_weights,  # TODO: (GR) need to change shard spec of aho gate module output (once it's merged)
+                topk_experts_indices_rm_sharded,
+                topk_experts_weights_rm_sharded,
                 cfg["expert_mapping_tensor"],
                 output_tensors=cfg["quad_ring_preallocated_all_to_all_dispatch_metadata_tensors"],
                 **ccl.populate_all_to_all_dispatch_metadata_args(cfg["quad_ring_all_to_all_dispatch_metadata"]),
@@ -577,8 +613,10 @@ class MoE(SharedStateAddOn, AbstractModule):
             combine_output = ttnn.unsqueeze(combine_output, dim=1)
 
             post_combine_output_tensor = ttnn.mul(
-                combine_output, permuted_topk_experts_weights, **cfg["mul_experts_output_with_weights"]
+                combine_output, topk_experts_weights_for_scaling, **cfg["mul_experts_output_with_weights"]
             )
+
+            ttnn.deallocate(combine_output)
         else:
             # Repeat + Permute Expert weights
             topk_experts_weights = cls._fwd_repeat_permute_expert_weights(topk_experts_weights, cfg)
@@ -653,7 +691,6 @@ class MoE(SharedStateAddOn, AbstractModule):
         # Repeat + Permute Expert weights
         topk_experts_weights = cls._fwd_repeat_permute_expert_weights(topk_experts_weights, cfg)
 
-        tokens = batch_size * seq_len
         x_rm = ttnn.to_layout(x, ttnn.ROW_MAJOR_LAYOUT)
         x_rm = ttnn.reshape(
             x_rm,
@@ -694,56 +731,138 @@ class MoE(SharedStateAddOn, AbstractModule):
                 [batch_end, 1, seq_len, cfg["num_experts_per_tok"]],
             )
 
-            all_to_all_dispatch_output_tensors, all_to_all_dispatch_metadata_tensors = ttnn.all_to_all_dispatch(
-                x_chunk,
-                topk_indices_chunk,
-                cfg["expert_mapping_tensors"],
-                **cfg["all_to_all_dispatch"],
-            )
-            ttnn.deallocate(x_chunk)
-            ttnn.deallocate(topk_indices_chunk)
+            if cfg["fabric_config"] == ttnn.FabricConfig.FABRIC_1D_RING and cfg["num_dispatch_devices"] == 16:
+                ccl = cfg["ccl"]
 
-            dispatch_chunk = ttnn.reshape(
-                all_to_all_dispatch_output_tensors,
-                shape=(1, 1, batch_size_chunk * seq_len, cfg["hidden_size"]),
-            )
-            dispatch_chunk = ttnn.repeat(dispatch_chunk, **cfg["activations_repeat"])
-            dispatch_chunk = ttnn.to_layout(dispatch_chunk, ttnn.TILE_LAYOUT)
-            ttnn.deallocate(all_to_all_dispatch_output_tensors)
+                # L1 sharded topk_experts_weights need to be deallocated before moe_compute
+                # configure weights for post combine scaling prior to that deallocation, and store in DRAM
+                permuted_topk_experts_weights = ttnn.permute(
+                    topk_experts_weights, (3, 1, 0, 2), memory_config=ttnn.L1_MEMORY_CONFIG
+                )
+                permuted_topk_experts_weights = ttnn.to_layout(
+                    permuted_topk_experts_weights, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG
+                )
 
-            experts_output = MoEExperts._forward(dispatch_chunk, cfg["moe_experts"])
-            ttnn.deallocate(dispatch_chunk)
+                # NOTE: needs to run prior to all_to_all_dispatch_metadata
+                preallocated_combine_output = ttnn.moreh_full(**cfg["quad_ring_moreh_full"])
 
-            experts_output = ttnn.to_layout(experts_output, ttnn.ROW_MAJOR_LAYOUT)
-            experts_output = ttnn.reshape(
-                experts_output, shape=(cfg["num_experts_per_device"], batch_size_chunk, seq_len, cfg["hidden_size"])
-            )
+                (
+                    dispatch_output_sparse_buffer,
+                    dispatch_output_expert_indices,
+                    dispatch_output_expert_scores,
+                ) = ttnn.experimental.all_to_all_dispatch_metadata(
+                    x_rm,
+                    topk_experts_indices,  # TODO: (GR) need to change shard spec of aho gate module output (once it's merged)
+                    topk_experts_weights,  # TODO: (GR) need to change shard spec of aho gate module output (once it's merged)
+                    cfg["expert_mapping_tensor"],
+                    output_tensors=cfg["quad_ring_preallocated_all_to_all_dispatch_metadata_tensors"],
+                    **ccl.populate_all_to_all_dispatch_metadata_args(cfg["quad_ring_all_to_all_dispatch_metadata"]),
+                )
 
-            all_to_all_dispatch_metadata_tensors = ttnn.reshape(
-                all_to_all_dispatch_metadata_tensors,
-                shape=(1, batch_size_chunk, seq_len, cfg["num_experts_per_tok"]),
-            )
+                # deallocation required in order to free up L1 space for moe_compute
+                ttnn.deallocate(x_rm)
+                ttnn.deallocate(topk_experts_indices)
+                ttnn.deallocate(topk_experts_weights)
 
-            all_to_all_combine_output_tensors = ttnn.all_to_all_combine(
-                experts_output,
-                all_to_all_dispatch_metadata_tensors,
-                cfg["expert_mapping_tensors"],
-                **cfg["all_to_all_combine"],
-            )
-            ttnn.deallocate(experts_output)
-            ttnn.deallocate(all_to_all_dispatch_metadata_tensors)
+                # NOTE: we are actively working on fusing moe_compute and selective_reduce_combine
 
-            post_combine_output_tensor = ttnn.reshape(
-                all_to_all_combine_output_tensors,
-                shape=(cfg["num_experts_per_tok"], 1, batch_chunk * seq_len, cfg["hidden_size"]),
-            )
-            post_combine_output_tensor = ttnn.to_layout(post_combine_output_tensor, ttnn.TILE_LAYOUT)
+                w0_w1 = ()  # TODO: (GR)
+                w2 = ()  # TODO: (GR)
+                layer_id = 0  # TODO: (GR)
+                (
+                    compute_output_token_counts,
+                    compute_output_dense_expert_activation,
+                    compute_ouput_dense_e_t,
+                    _,  # tile layout output of selective tilize (same buffer as output)
+                    compute_output,
+                ) = ttnn.experimental.moe_compute(
+                    dispatch_output_sparse_buffer,
+                    dispatch_output_expert_indices,
+                    dispatch_output_expert_scores,
+                    cfg["expert_mapping_tensor"],
+                    w0_w1,
+                    w2,
+                    layer_id=layer_id,
+                    **cfg["quad_ring_moe_compute"],
+                )
 
-            topk_weights_chunk = _slice_topk_weights(batch_start, batch_end)
-            post_combine_output_tensor = ttnn.mul(
-                post_combine_output_tensor, topk_weights_chunk, **cfg["mul_experts_output_with_weights"]
-            )
-            ttnn.deallocate(topk_weights_chunk)
+                # NOTE: can't deallocate dispatch output tensors as they are preallocated and reused across layers
+
+                combine_output = ttnn.experimental.selective_reduce_combine(
+                    compute_output,
+                    compute_output_dense_expert_activation,
+                    compute_ouput_dense_e_t,
+                    compute_output_token_counts,
+                    output_tensor=preallocated_combine_output,
+                    **ccl.populate_selective_reduce_combine_args(cfg["quad_ring_selective_reduce_combine"]),
+                )
+
+                ttnn.deallocate(compute_output)
+                ttnn.deallocate(compute_output_dense_expert_activation)
+                ttnn.deallocate(compute_ouput_dense_e_t)
+                ttnn.deallocate(compute_output_token_counts)
+
+                combine_output = ttnn.to_layout(
+                    combine_output,
+                    layout=ttnn.TILE_LAYOUT,
+                    memory_config=ttnn.L1_MEMORY_CONFIG,
+                )
+                combine_output = ttnn.unsqueeze(combine_output, dim=1)
+
+                post_combine_output_tensor = ttnn.mul(
+                    combine_output, permuted_topk_experts_weights, **cfg["mul_experts_output_with_weights"]
+                )
+            else:
+                all_to_all_dispatch_output_tensors, all_to_all_dispatch_metadata_tensors = ttnn.all_to_all_dispatch(
+                    x_chunk,
+                    topk_indices_chunk,
+                    cfg["expert_mapping_tensors"],
+                    **cfg["all_to_all_dispatch"],
+                )
+                ttnn.deallocate(x_chunk)
+                ttnn.deallocate(topk_indices_chunk)
+
+                dispatch_chunk = ttnn.reshape(
+                    all_to_all_dispatch_output_tensors,
+                    shape=(1, 1, batch_size_chunk * seq_len, cfg["hidden_size"]),
+                )
+                dispatch_chunk = ttnn.repeat(dispatch_chunk, **cfg["activations_repeat"])
+                dispatch_chunk = ttnn.to_layout(dispatch_chunk, ttnn.TILE_LAYOUT)
+                ttnn.deallocate(all_to_all_dispatch_output_tensors)
+
+                experts_output = MoEExperts._forward(dispatch_chunk, cfg["moe_experts"])
+                ttnn.deallocate(dispatch_chunk)
+
+                experts_output = ttnn.to_layout(experts_output, ttnn.ROW_MAJOR_LAYOUT)
+                experts_output = ttnn.reshape(
+                    experts_output, shape=(cfg["num_experts_per_device"], batch_size_chunk, seq_len, cfg["hidden_size"])
+                )
+
+                all_to_all_dispatch_metadata_tensors = ttnn.reshape(
+                    all_to_all_dispatch_metadata_tensors,
+                    shape=(1, batch_size_chunk, seq_len, cfg["num_experts_per_tok"]),
+                )
+
+                all_to_all_combine_output_tensors = ttnn.all_to_all_combine(
+                    experts_output,
+                    all_to_all_dispatch_metadata_tensors,
+                    cfg["expert_mapping_tensors"],
+                    **cfg["all_to_all_combine"],
+                )
+                ttnn.deallocate(experts_output)
+                ttnn.deallocate(all_to_all_dispatch_metadata_tensors)
+
+                post_combine_output_tensor = ttnn.reshape(
+                    all_to_all_combine_output_tensors,
+                    shape=(cfg["num_experts_per_tok"], 1, batch_chunk * seq_len, cfg["hidden_size"]),
+                )
+                post_combine_output_tensor = ttnn.to_layout(post_combine_output_tensor, ttnn.TILE_LAYOUT)
+
+                topk_weights_chunk = _slice_topk_weights(batch_start, batch_end)
+                post_combine_output_tensor = ttnn.mul(
+                    post_combine_output_tensor, topk_weights_chunk, **cfg["mul_experts_output_with_weights"]
+                )
+                ttnn.deallocate(topk_weights_chunk)
 
             output_chunks.append(post_combine_output_tensor)
 

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -21,6 +21,7 @@ from models.demos.deepseek_v3.utils.config_dataclass import (
     DeepseekMoEReduceScatterConfig,
     MeshDeviceStub,
     MoEComputeConfig,
+    MorehFullConfig,
     MulConfig,
     ReduceScatterAsyncMinimalConfig,
     RepeatConfig,
@@ -249,12 +250,18 @@ class MoE(SharedStateAddOn, AbstractModule):
                     dispatch_algorithm=ttnn.DispatchAlgorithm.SPARSE_MCAST_SHORTEST_PATH,
                     output_tensors=AllToAllDispatchMetadataConfig.create_preallocated_dispatch_output_tensors(
                         mesh_device,
-                        mesh_device.shape,
-                        mesh_device.shape[0],
                         batch,
                         HIDDEN_SIZE,
                         hf_config.num_experts_per_tok,
                     ),
+                )
+                decode_config["quad_ring_moreh_full"] = MorehFullConfig(
+                    shape=ttnn.Shape([hf_config.num_experts_per_tok, USERS_PER_ROW, hf_config.hidden_size]),
+                    fill_value=0,
+                    device=mesh_device,
+                    dtype=torch.bfloat16,
+                    layout=ttnn.ROW_MAJOR_LAYOUT,
+                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
                 )
                 decode_config["quad_ring_moe_compute"] = MoEComputeConfig(
                     output_height_shard_dim=4,
@@ -466,9 +473,6 @@ class MoE(SharedStateAddOn, AbstractModule):
         # MoE Gate
         topk_experts_weights, topk_experts_indices = cls._fwd_moe_gate(x, cfg)
 
-        # Repeat + Permute Expert weights
-        topk_experts_weights = cls._fwd_repeat_permute_expert_weights(topk_experts_weights, cfg)
-
         # MOE
         post_combine_output_tensor = cls._fwd_prefill_moe(
             x,
@@ -518,14 +522,17 @@ class MoE(SharedStateAddOn, AbstractModule):
         if cfg["fabric_config"] == ttnn.FabricConfig.FABRIC_1D_RING and cfg["num_dispatch_devices"] == 16:
             ccl = cfg["ccl"]
 
-            preallocated_combine_output = ttnn.moreh_full(
-                shape=[cfg["num_experts_per_tok"], batch_size_per_device, cfg["hidden_size"]],
-                fill_value=0,
-                device=cfg["mesh_device"],
-                dtype=ttnn.bfloat16,
-                layout=ttnn.ROW_MAJOR_LAYOUT,
-                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            # L1 sharded topk_experts_weights need to be deallocated before moe_compute
+            # configure weights for post combine scaling prior to that deallocation, and store in DRAM
+            permuted_topk_experts_weights = ttnn.permute(
+                topk_experts_weights, (3, 1, 0, 2), memory_config=ttnn.L1_MEMORY_CONFIG
             )
+            permuted_topk_experts_weights = ttnn.to_layout(
+                permuted_topk_experts_weights, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG
+            )
+
+            # NOTE: needs to run prior to all_to_all_dispatch_metadata
+            preallocated_combine_output = ttnn.moreh_full(**cfg["quad_ring_moreh_full"])
 
             (
                 dispatch_output_sparse_buffer,
@@ -539,10 +546,14 @@ class MoE(SharedStateAddOn, AbstractModule):
                 **ccl.populate_all_to_all_dispatch_metadata_args(cfg["quad_ring_all_to_all_dispatch_metadata"]),
             )
 
-            # TODO: (GR)
-            w0_w1 = ()
-            w2 = ()
-            layer_id = 0
+            # deallocation required in order to free up L1 space for moe_compute
+            ttnn.deallocate(x_rm)
+            ttnn.deallocate(topk_experts_indices)
+            ttnn.deallocate(topk_experts_weights)
+
+            w0_w1 = ()  # TODO: (GR)
+            w2 = ()  # TODO: (GR)
+            layer_id = 0  # TODO: (GR)
             (
                 compute_output_token_counts,
                 compute_output_dense_expert_activation,
@@ -554,11 +565,15 @@ class MoE(SharedStateAddOn, AbstractModule):
                 dispatch_output_expert_indices,
                 dispatch_output_expert_scores,
                 cfg["expert_mapping_tensor"],
-                w0_w1,  # TODO: (GR)
-                w2,  # TODO: (GR)
-                layer_id=layer_id,  # TODO: (GR)
+                w0_w1,
+                w2,
+                layer_id=layer_id,
                 **cfg["quad_ring_moe_compute"],
             )
+
+            ttnn.deallocate(dispatch_output_sparse_buffer)
+            ttnn.deallocate(dispatch_output_expert_indices)
+            ttnn.deallocate(dispatch_output_expert_scores)
 
             combine_output = ttnn.experimental.selective_reduce_combine(
                 compute_output,
@@ -569,6 +584,11 @@ class MoE(SharedStateAddOn, AbstractModule):
                 **ccl.populate_selective_reduce_combine_args(cfg["quad_ring_selective_reduce_combine"]),
             )
 
+            ttnn.deallocate(compute_output)
+            ttnn.deallocate(compute_output_dense_expert_activation)
+            ttnn.deallocate(compute_ouput_dense_e_t)
+            ttnn.deallocate(compute_output_token_counts)
+
             combine_output = ttnn.to_layout(
                 combine_output,
                 layout=ttnn.TILE_LAYOUT,
@@ -576,15 +596,13 @@ class MoE(SharedStateAddOn, AbstractModule):
             )
             combine_output = ttnn.unsqueeze(combine_output, dim=1)
 
-            topk_experts_weights = ttnn.permute(topk_experts_weights, (3, 1, 0, 2), memory_config=ttnn.L1_MEMORY_CONFIG)
-            topk_experts_weights = ttnn.to_layout(
-                topk_experts_weights, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG
-            )
-
             post_combine_output_tensor = ttnn.mul(
-                combine_output, topk_experts_weights, memory_config=ttnn.L1_MEMORY_CONFIG
+                combine_output, permuted_topk_experts_weights, **cfg["mul_experts_output_with_weights"]
             )
         else:
+            # Repeat + Permute Expert weights
+            topk_experts_weights = cls._fwd_repeat_permute_expert_weights(topk_experts_weights, cfg)
+
             topk_experts_indices_rm = ttnn.to_layout(topk_experts_indices, ttnn.ROW_MAJOR_LAYOUT)
             topk_experts_indices_rm = ttnn.reshape(
                 topk_experts_indices_rm, shape=(batch_size_per_device, 1, seq_len, cfg["num_experts_per_tok"])
@@ -652,6 +670,9 @@ class MoE(SharedStateAddOn, AbstractModule):
         batch_size: int,
         seq_len: int,
     ) -> ttnn.Tensor:
+        # Repeat + Permute Expert weights
+        topk_experts_weights = cls._fwd_repeat_permute_expert_weights(topk_experts_weights, cfg)
+
         tokens = batch_size * seq_len
         x_rm = ttnn.to_layout(x, ttnn.ROW_MAJOR_LAYOUT)
         x_rm = ttnn.reshape(

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -514,47 +514,8 @@ class MoE(SharedStateAddOn, AbstractModule):
                 topk_experts_indices_rm, shape=(batch_size_per_device, 1, seq_len, cfg["num_experts_per_tok"])
             )
 
-            all_to_all_dispatch_output_tensors, all_to_all_dispatch_metadata_tensors = ttnn.all_to_all_dispatch(
-                x_rm,
-                topk_experts_indices_rm,
-                cfg["expert_mapping_tensor"],
-                **cfg["all_to_all_dispatch"],
-            )
-
-            post_all_to_all_dispatch_output = ttnn.reshape(
-                all_to_all_dispatch_output_tensors, shape=(1, 1, batch_size * seq_len, cfg["hidden_size"])
-            )
-            post_all_to_all_dispatch_output = ttnn.repeat(post_all_to_all_dispatch_output, **cfg["activations_repeat"])
-            post_all_to_all_dispatch_output = ttnn.to_layout(post_all_to_all_dispatch_output, ttnn.TILE_LAYOUT)
-
-            experts_output = MoEExperts._forward(post_all_to_all_dispatch_output, cfg["moe_experts"])
-            ttnn.deallocate(post_all_to_all_dispatch_output)
-
-            experts_output = ttnn.to_layout(experts_output, ttnn.ROW_MAJOR_LAYOUT)
-            experts_output = ttnn.reshape(
-                experts_output, shape=(cfg["num_experts_per_device"], batch_size, seq_len, cfg["hidden_size"])
-            )
-
-            all_to_all_dispatch_metadata_tensors = ttnn.reshape(
-                all_to_all_dispatch_metadata_tensors,
-                shape=(1, batch_size, seq_len, cfg["num_experts_per_tok"]),
-            )
-
-            all_to_all_combine_output_tensors = ttnn.all_to_all_combine(
-                experts_output,
-                all_to_all_dispatch_metadata_tensors,
-                cfg["expert_mapping_tensor"],
-                **cfg["all_to_all_combine"],
-            )
-
-            post_combine_output_tensor = ttnn.reshape(
-                all_to_all_combine_output_tensors,
-                shape=(cfg["num_experts_per_tok"], 1, batch_size_per_device * seq_len, cfg["hidden_size"]),
-            )
-            post_combine_output_tensor = ttnn.to_layout(post_combine_output_tensor, ttnn.TILE_LAYOUT)
-
-            post_combine_output_tensor = ttnn.mul(
-                post_combine_output_tensor, topk_experts_weights, **cfg["mul_experts_output_with_weights"]
+            post_combine_output_tensor = cls._forward_moe_default_impl(
+                cfg, x_rm, topk_experts_indices_rm, topk_experts_weights, batch_size_per_device, batch_size, seq_len
             )
 
         return post_combine_output_tensor
@@ -677,62 +638,15 @@ class MoE(SharedStateAddOn, AbstractModule):
                     [batch_start, 0, 0, 0],
                     [batch_end, 1, seq_len, cfg["num_experts_per_tok"]],
                 )
-
-                all_to_all_dispatch_output_tensors, all_to_all_dispatch_metadata_tensors = ttnn.all_to_all_dispatch(
-                    x_chunk,
-                    topk_indices_chunk,
-                    cfg["expert_mapping_tensor"],
-                    **cfg["all_to_all_dispatch"],
-                )
-                ttnn.deallocate(x_chunk)
-                ttnn.deallocate(topk_indices_chunk)
-
-                dispatch_chunk = ttnn.reshape(
-                    all_to_all_dispatch_output_tensors,
-                    shape=(1, 1, batch_size_chunk * seq_len, cfg["hidden_size"]),
-                )
-                dispatch_chunk = ttnn.repeat(dispatch_chunk, **cfg["activations_repeat"])
-                dispatch_chunk = ttnn.to_layout(dispatch_chunk, ttnn.TILE_LAYOUT)
-                ttnn.deallocate(all_to_all_dispatch_output_tensors)
-
-                experts_output = MoEExperts._forward(dispatch_chunk, cfg["moe_experts"])
-                ttnn.deallocate(dispatch_chunk)
-
-                experts_output = ttnn.to_layout(experts_output, ttnn.ROW_MAJOR_LAYOUT)
-                experts_output = ttnn.reshape(
-                    experts_output, shape=(cfg["num_experts_per_device"], batch_size_chunk, seq_len, cfg["hidden_size"])
-                )
-
-                all_to_all_dispatch_metadata_tensors = ttnn.reshape(
-                    all_to_all_dispatch_metadata_tensors,
-                    shape=(1, batch_size_chunk, seq_len, cfg["num_experts_per_tok"]),
-                )
-
-                all_to_all_combine_output_tensors = ttnn.all_to_all_combine(
-                    experts_output,
-                    all_to_all_dispatch_metadata_tensors,
-                    cfg["expert_mapping_tensor"],
-                    **cfg["all_to_all_combine"],
-                )
-                ttnn.deallocate(experts_output)
-                ttnn.deallocate(all_to_all_dispatch_metadata_tensors)
-
-                post_combine_output_tensor = ttnn.reshape(
-                    all_to_all_combine_output_tensors,
-                    shape=(cfg["num_experts_per_tok"], 1, batch_chunk * seq_len, cfg["hidden_size"]),
-                )
-                post_combine_output_tensor = ttnn.to_layout(post_combine_output_tensor, ttnn.TILE_LAYOUT)
-
                 topk_weights_chunk = ttnn.slice(
                     topk_experts_weights,
                     [0, 0, batch_start, 0],
                     [cfg["num_experts_per_tok"], 1, batch_end, cfg["hidden_size"]],
                 )
-                post_combine_output_tensor = ttnn.mul(
-                    post_combine_output_tensor, topk_weights_chunk, **cfg["mul_experts_output_with_weights"]
-                )
-                ttnn.deallocate(topk_weights_chunk)
 
+                post_combine_output_tensor = cls._forward_moe_default_impl(
+                    cfg, x_chunk, topk_indices_chunk, topk_weights_chunk, batch_chunk, batch_size_chunk, seq_len
+                )
                 output_chunks.append(post_combine_output_tensor)
 
             ttnn.deallocate(topk_experts_indices_rm)
@@ -746,6 +660,70 @@ class MoE(SharedStateAddOn, AbstractModule):
                 ttnn.deallocate(chunk)
 
         ttnn.deallocate(x_rm)
+        return post_combine_output_tensor
+
+    @classmethod
+    def _forward_moe_default_impl(
+        cls,
+        cfg: RunDecodeConfig | RunPrefillConfig,
+        x_rm: ttnn.Tensor,
+        topk_experts_indices_rm: ttnn.Tensor,
+        topk_experts_weights_rm: ttnn.Tensor,
+        batch_size_per_device: int,
+        batch_size: int,
+        seq_len: int,
+    ):
+        all_to_all_dispatch_output_tensors, all_to_all_dispatch_metadata_tensors = ttnn.all_to_all_dispatch(
+            x_rm,
+            topk_experts_indices_rm,
+            cfg["expert_mapping_tensor"],
+            **cfg["all_to_all_dispatch"],
+        )
+        ttnn.deallocate(x_rm)
+        ttnn.deallocate(topk_experts_indices_rm)
+
+        post_all_to_all_dispatch_output = ttnn.reshape(
+            all_to_all_dispatch_output_tensors,
+            shape=(1, 1, batch_size * seq_len, cfg["hidden_size"]),
+        )
+        post_all_to_all_dispatch_output = ttnn.repeat(post_all_to_all_dispatch_output, **cfg["activations_repeat"])
+        post_all_to_all_dispatch_output = ttnn.to_layout(post_all_to_all_dispatch_output, ttnn.TILE_LAYOUT)
+        ttnn.deallocate(all_to_all_dispatch_output_tensors)
+
+        experts_output = MoEExperts._forward(post_all_to_all_dispatch_output, cfg["moe_experts"])
+        ttnn.deallocate(post_all_to_all_dispatch_output)
+
+        experts_output = ttnn.to_layout(experts_output, ttnn.ROW_MAJOR_LAYOUT)
+        experts_output = ttnn.reshape(
+            experts_output, shape=(cfg["num_experts_per_device"], batch_size, seq_len, cfg["hidden_size"])
+        )
+
+        all_to_all_dispatch_metadata_tensors = ttnn.reshape(
+            all_to_all_dispatch_metadata_tensors,
+            shape=(1, batch_size, seq_len, cfg["num_experts_per_tok"]),
+        )
+
+        all_to_all_combine_output_tensors = ttnn.all_to_all_combine(
+            experts_output,
+            all_to_all_dispatch_metadata_tensors,
+            cfg["expert_mapping_tensor"],
+            **cfg["all_to_all_combine"],
+        )
+        ttnn.deallocate(experts_output)
+        ttnn.deallocate(all_to_all_dispatch_metadata_tensors)
+
+        post_combine_output_tensor = ttnn.reshape(
+            all_to_all_combine_output_tensors,
+            shape=(cfg["num_experts_per_tok"], 1, batch_size_per_device * seq_len, cfg["hidden_size"]),
+        )
+        post_combine_output_tensor = ttnn.to_layout(post_combine_output_tensor, ttnn.TILE_LAYOUT)
+        ttnn.deallocate(all_to_all_combine_output_tensors)
+
+        post_combine_output_tensor = ttnn.mul(
+            post_combine_output_tensor, topk_experts_weights_rm, **cfg["mul_experts_output_with_weights"]
+        )
+        ttnn.deallocate(topk_experts_weights_rm)
+
         return post_combine_output_tensor
 
     @classmethod

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -92,33 +92,30 @@ class MoE(SharedStateAddOn, AbstractModule):
             f"(num_devices={num_devices}, experts_per_device={num_experts_per_device})..."
         )
         expert_mapping_start = perf_counter()
-        expert_mapping_tensors = ttnn.from_torch(
-            torch.eye(num_devices, dtype=torch.int32)
-            .repeat_interleave(num_experts_per_device, dim=0)
-            .unsqueeze(0)
-            .unsqueeze(0),
+
+        # optimized ops (exclusive to quad with ring fabric) use a different mapping format
+        if is_ring_fabric(fabric_config) and num_dispatch_device_rows == 16:
+            num_experts = num_devices * num_experts_per_device
+            torch_expert_mapping_tensor = (
+                (torch.arange(num_experts) // num_experts_per_device).unsqueeze(0).repeat(num_devices, 1)
+            )
+        else:
+            torch_expert_mapping_tensor = (
+                torch.eye(num_devices, dtype=torch.int32)
+                .repeat_interleave(num_experts_per_device, dim=0)
+                .unsqueeze(0)
+                .unsqueeze(0)
+            )
+        expert_mapping_tensor = ttnn.from_torch(
+            torch_expert_mapping_tensor,
             device=mesh_device,
             mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
             dtype=ttnn.uint16,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             layout=ttnn.ROW_MAJOR_LAYOUT,
         )
-        logger.info(f"Created MoE expert mapping tensor in {perf_counter() - expert_mapping_start:.2f}s")
 
-        logger.info(
-            "Creating MoE shared state: remap topk mask "
-            f"(dispatch_rows={num_dispatch_device_rows}, experts={hf_config.n_routed_experts})..."
-        )
-        remap_mask_start = perf_counter()
-        remap_topk_mask = ttnn.from_torch(
-            torch.ones((1, num_dispatch_device_rows, 1, hf_config.n_routed_experts), dtype=torch.bfloat16),
-            device=mesh_device,
-            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
-            dtype=ttnn.bfloat16,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            layout=ttnn.ROW_MAJOR_LAYOUT,
-        )
-        logger.info(f"Created MoE remap topk mask in {perf_counter() - remap_mask_start:.2f}s")
+        logger.info(f"Created MoE expert mapping tensor in {perf_counter() - expert_mapping_start:.2f}s")
 
         config = {
             "expert_mapping_tensor": expert_mapping_tensor,

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -518,6 +518,9 @@ class MoE(SharedStateAddOn, AbstractModule):
                 topk_experts_weights, ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG
             )
 
+            ttnn.deallocate(topk_experts_indices)
+            ttnn.deallocate(topk_experts_weights)
+
             topk_experts_indices_rm = ttnn.permute(
                 topk_experts_indices_rm, (2, 0, 1, 3), memory_config=ttnn.L1_MEMORY_CONFIG
             )
@@ -564,8 +567,8 @@ class MoE(SharedStateAddOn, AbstractModule):
 
             # deallocation required in order to free up L1 space for moe_compute
             ttnn.deallocate(x_rm)
-            ttnn.deallocate(topk_experts_indices)
-            ttnn.deallocate(topk_experts_weights)
+            ttnn.deallocate(topk_experts_indices_rm_sharded)
+            ttnn.deallocate(topk_experts_weights_rm_sharded)
 
             # NOTE: we are actively working on fusing moe_compute and selective_reduce_combine
 
@@ -688,60 +691,78 @@ class MoE(SharedStateAddOn, AbstractModule):
         batch_size: int,
         seq_len: int,
     ) -> ttnn.Tensor:
-        # Repeat + Permute Expert weights
-        topk_experts_weights = cls._fwd_repeat_permute_expert_weights(topk_experts_weights, cfg)
-
         x_rm = ttnn.to_layout(x, ttnn.ROW_MAJOR_LAYOUT)
         x_rm = ttnn.reshape(
             x_rm,
             shape=(batch_size_per_device, 1, seq_len, cfg["hidden_size"]),
         )
 
-        topk_experts_indices_rm = ttnn.to_layout(topk_experts_indices, ttnn.ROW_MAJOR_LAYOUT)
-        topk_experts_indices_rm = ttnn.reshape(
-            topk_experts_indices_rm, shape=(batch_size_per_device, 1, seq_len, cfg["num_experts_per_tok"])
-        )
-
         # Chunk along local batch dimension to keep all_to_all_dispatch output small in prefill.
         chunk_size = min(batch_size_per_device, max(1, cfg.get("moe_chunk_size", batch_size_per_device)))
         output_chunks: list[ttnn.Tensor] = []
 
-        def _slice_topk_weights(batch_start: int, batch_end: int) -> ttnn.Tensor:
-            token_start = batch_start * seq_len
-            token_end = batch_end * seq_len
-            return ttnn.slice(
-                topk_experts_weights,
-                [0, 0, token_start, 0],
-                [cfg["num_experts_per_tok"], 1, token_end, cfg["hidden_size"]],
+        if cfg["fabric_config"] == ttnn.FabricConfig.FABRIC_1D_RING and cfg["num_dispatch_devices"] == 16:
+            ccl = cfg["ccl"]
+
+            topk_experts_indices_rm = ttnn.to_layout(
+                topk_experts_indices, ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG
+            )
+            topk_experts_weights_rm = ttnn.to_layout(
+                topk_experts_weights, ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG
             )
 
-        for batch_start in range(0, batch_size_per_device, chunk_size):
-            batch_end = min(batch_start + chunk_size, batch_size_per_device)
-            batch_chunk = batch_end - batch_start
-            batch_size_chunk = batch_chunk * cfg["num_dispatch_devices"]
+            ttnn.deallocate(topk_experts_indices)
+            ttnn.deallocate(topk_experts_weights)
 
-            x_chunk = ttnn.slice(
-                x_rm,
-                [batch_start, 0, 0, 0],
-                [batch_end, 1, seq_len, cfg["hidden_size"]],
+            topk_experts_indices_rm = ttnn.permute(
+                topk_experts_indices_rm, (2, 0, 1, 3), memory_config=ttnn.DRAM_MEMORY_CONFIG
             )
-            topk_indices_chunk = ttnn.slice(
-                topk_experts_indices_rm,
-                [batch_start, 0, 0, 0],
-                [batch_end, 1, seq_len, cfg["num_experts_per_tok"]],
+            topk_experts_weights_rm = ttnn.permute(
+                topk_experts_weights_rm, (2, 0, 1, 3), memory_config=ttnn.DRAM_MEMORY_CONFIG
             )
 
-            if cfg["fabric_config"] == ttnn.FabricConfig.FABRIC_1D_RING and cfg["num_dispatch_devices"] == 16:
-                ccl = cfg["ccl"]
+            for batch_start in range(0, batch_size_per_device, chunk_size):
+                batch_end = min(batch_start + chunk_size, batch_size_per_device)
 
-                # L1 sharded topk_experts_weights need to be deallocated before moe_compute
+                x_chunk = ttnn.slice(
+                    x_rm,
+                    [batch_start, 0, 0, 0],
+                    [batch_end, 1, seq_len, cfg["hidden_size"]],
+                )
+
+                topk_experts_indices_rm_chunk = ttnn.slice(
+                    topk_experts_indices_rm,
+                    [batch_start, 0, 0, 0],
+                    [batch_end, 1, seq_len, cfg["num_experts_per_tok"]],
+                )
+                topk_experts_indices_rm_chunk_sharded = ttnn.to_memory_config(
+                    topk_experts_indices_rm_chunk,
+                    memory_config=cfg["quad_ring_all_to_all_dispatch_metadata_sharded_memory_config"],
+                )
+
+                topk_experts_weights_rm_chunk = ttnn.slice(
+                    topk_experts_weights_rm,
+                    [batch_start, 0, 0, 0],
+                    [batch_end, 1, seq_len, cfg["num_experts_per_tok"]],
+                )
+                topk_expert_weights_rm_chunk_sharded = ttnn.to_memory_config(
+                    topk_experts_weights_rm_chunk,
+                    memory_config=cfg["quad_ring_all_to_all_dispatch_metadata_sharded_memory_config"],
+                )
+
+                # NOTE: L1 sharded topk_experts_weights need to be deallocated before moe_compute,
                 # configure weights for post combine scaling prior to that deallocation, and store in DRAM
-                permuted_topk_experts_weights = ttnn.permute(
-                    topk_experts_weights, (3, 1, 0, 2), memory_config=ttnn.L1_MEMORY_CONFIG
+                topk_experts_weights_for_scaling_chunk = ttnn.permute(
+                    topk_experts_weights_rm_chunk, (3, 1, 0, 2), memory_config=ttnn.L1_MEMORY_CONFIG
                 )
-                permuted_topk_experts_weights = ttnn.to_layout(
-                    permuted_topk_experts_weights, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG
+                topk_experts_weights_for_scaling_chunk = ttnn.to_layout(
+                    topk_experts_weights_for_scaling_chunk,
+                    layout=ttnn.TILE_LAYOUT,
+                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
                 )
+
+                ttnn.deallocate(topk_experts_indices_rm_chunk)
+                ttnn.deallocate(topk_experts_weights_rm_chunk)
 
                 # NOTE: needs to run prior to all_to_all_dispatch_metadata
                 preallocated_combine_output = ttnn.moreh_full(**cfg["quad_ring_moreh_full"])
@@ -751,18 +772,18 @@ class MoE(SharedStateAddOn, AbstractModule):
                     dispatch_output_expert_indices,
                     dispatch_output_expert_scores,
                 ) = ttnn.experimental.all_to_all_dispatch_metadata(
-                    x_rm,
-                    topk_experts_indices,  # TODO: (GR) need to change shard spec of aho gate module output (once it's merged)
-                    topk_experts_weights,  # TODO: (GR) need to change shard spec of aho gate module output (once it's merged)
+                    x_chunk,
+                    topk_experts_indices_rm_chunk_sharded,
+                    topk_expert_weights_rm_chunk_sharded,
                     cfg["expert_mapping_tensor"],
                     output_tensors=cfg["quad_ring_preallocated_all_to_all_dispatch_metadata_tensors"],
                     **ccl.populate_all_to_all_dispatch_metadata_args(cfg["quad_ring_all_to_all_dispatch_metadata"]),
                 )
 
                 # deallocation required in order to free up L1 space for moe_compute
-                ttnn.deallocate(x_rm)
-                ttnn.deallocate(topk_experts_indices)
-                ttnn.deallocate(topk_experts_weights)
+                ttnn.deallocate(x_chunk)
+                ttnn.deallocate(topk_experts_indices_rm_chunk_sharded)
+                ttnn.deallocate(topk_expert_weights_rm_chunk_sharded)
 
                 # NOTE: we are actively working on fusing moe_compute and selective_reduce_combine
 
@@ -810,9 +831,33 @@ class MoE(SharedStateAddOn, AbstractModule):
                 combine_output = ttnn.unsqueeze(combine_output, dim=1)
 
                 post_combine_output_tensor = ttnn.mul(
-                    combine_output, permuted_topk_experts_weights, **cfg["mul_experts_output_with_weights"]
+                    combine_output, topk_experts_weights_for_scaling_chunk, **cfg["mul_experts_output_with_weights"]
                 )
-            else:
+        else:
+            # Repeat + Permute Expert weights
+            topk_experts_weights = cls._fwd_repeat_permute_expert_weights(topk_experts_weights, cfg)
+
+            topk_experts_indices_rm = ttnn.to_layout(topk_experts_indices, ttnn.ROW_MAJOR_LAYOUT)
+            topk_experts_indices_rm = ttnn.reshape(
+                topk_experts_indices_rm, shape=(batch_size_per_device, 1, seq_len, cfg["num_experts_per_tok"])
+            )
+
+            for batch_start in range(0, batch_size_per_device, chunk_size):
+                batch_end = min(batch_start + chunk_size, batch_size_per_device)
+                batch_chunk = batch_end - batch_start
+                batch_size_chunk = batch_chunk * cfg["num_dispatch_devices"]
+
+                x_chunk = ttnn.slice(
+                    x_rm,
+                    [batch_start, 0, 0, 0],
+                    [batch_end, 1, seq_len, cfg["hidden_size"]],
+                )
+                topk_indices_chunk = ttnn.slice(
+                    topk_experts_indices_rm,
+                    [batch_start, 0, 0, 0],
+                    [batch_end, 1, seq_len, cfg["num_experts_per_tok"]],
+                )
+
                 all_to_all_dispatch_output_tensors, all_to_all_dispatch_metadata_tensors = ttnn.all_to_all_dispatch(
                     x_chunk,
                     topk_indices_chunk,
@@ -858,7 +903,11 @@ class MoE(SharedStateAddOn, AbstractModule):
                 )
                 post_combine_output_tensor = ttnn.to_layout(post_combine_output_tensor, ttnn.TILE_LAYOUT)
 
-                topk_weights_chunk = _slice_topk_weights(batch_start, batch_end)
+                topk_weights_chunk = ttnn.slice(
+                    topk_experts_weights,
+                    [0, 0, batch_start, 0],
+                    [cfg["num_experts_per_tok"], 1, batch_end, cfg["hidden_size"]],
+                )
                 post_combine_output_tensor = ttnn.mul(
                     post_combine_output_tensor, topk_weights_chunk, **cfg["mul_experts_output_with_weights"]
                 )

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -127,8 +127,10 @@ class MoE(SharedStateAddOn, AbstractModule):
             MESH_DEVICE_STATE_DICT_KEY: mesh_device,
         }
 
+        # TODO: #41009
         # optimized ops (exclusive to quad with ring fabric) require preallocated tensors for all_to_all_dispatch_metadata
-        if is_ring_fabric(fabric_config) and num_dispatch_device_rows == 16:
+        # if is_ring_fabric(fabric_config) and num_dispatch_device_rows == 16:
+        if False:
             # NOTE: these do not have to be double buffered, due to the synchronization between all_to_all_dispatch_metadata and selective_reduce_combine inside the MoE block
             batch = OPTIMIZED_MOE_BLOCK_USERS_PER_ROW * mesh_device.shape[0]
             preallocated_all_to_all_dispatch_metadata_tensors = (
@@ -302,10 +304,14 @@ class MoE(SharedStateAddOn, AbstractModule):
             batch = OPTIMIZED_MOE_BLOCK_USERS_PER_ROW * mesh_device.shape[0]
             seq_len = 1
 
+            # TODO: #41009
             config["quad_ring_all_to_all_dispatch_metadata"] = AllToAllDispatchMetadataConfig(
-                cluster_axis=0,
                 worker_mode=ttnn.WorkerMode.DIRECT,
                 dispatch_algorithm=ttnn.DispatchAlgorithm.SPARSE_MCAST_SHORTEST_PATH,
+                drain_sync_tilizer_core=(6, 9),
+                cluster_axis=0,
+                num_links=4,
+                cross_device_semaphore=None,
             )
             config[
                 "quad_ring_all_to_all_dispatch_metadata_sharded_memory_config"
@@ -486,6 +492,7 @@ class MoE(SharedStateAddOn, AbstractModule):
 
         # optimized ops are exclusive to quad with ring fabric
         if is_ring_fabric(cfg["fabric_config"]) and cfg["num_dispatch_devices"] == 16:
+            # TODO: #41009
             # NOTE: can move towards removing these TMs once optimized moe_gate is integrated
             topk_experts_indices_rm = ttnn.to_layout(
                 topk_experts_indices, ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG
@@ -546,8 +553,10 @@ class MoE(SharedStateAddOn, AbstractModule):
         chunk_size = min(batch_size_per_device, max(1, cfg.get("moe_chunk_size", batch_size_per_device)))
         output_chunks: list[ttnn.Tensor] = []
 
+        # TODO: #41009
         # optimized ops are exclusive to quad with ring fabric
         if is_ring_fabric(cfg["fabric_config"]) and cfg["num_dispatch_devices"] == 16:
+            # TODO: #41009
             topk_experts_indices_rm = ttnn.to_layout(
                 topk_experts_indices, ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG
             )
@@ -558,6 +567,7 @@ class MoE(SharedStateAddOn, AbstractModule):
             ttnn.deallocate(topk_experts_indices)
             ttnn.deallocate(topk_experts_weights)
 
+            # TODO: #41009
             # NOTE: store in DRAM while chunking, as moe_compute requires just about all of L1
             topk_experts_indices_rm = ttnn.permute(
                 topk_experts_indices_rm, (2, 0, 1, 3), memory_config=ttnn.DRAM_MEMORY_CONFIG
@@ -766,6 +776,7 @@ class MoE(SharedStateAddOn, AbstractModule):
         # NOTE: needs to run prior to all_to_all_dispatch_metadata
         preallocated_combine_output = ttnn.moreh_full(**cfg["quad_ring_moreh_full"])
 
+        # TODO: #41009
         (
             dispatch_output_sparse_buffer,
             dispatch_output_expert_indices,
@@ -775,8 +786,8 @@ class MoE(SharedStateAddOn, AbstractModule):
             topk_experts_indices_rm_sharded,
             topk_experts_weights_rm_sharded,
             cfg["expert_mapping_tensor"],
-            output_tensors=cfg["quad_ring_preallocated_all_to_all_dispatch_metadata_tensors"],
-            **ccl.populate_all_to_all_dispatch_metadata_args(cfg["quad_ring_all_to_all_dispatch_metadata"]),
+            output_tensors=None,
+            **cfg["quad_ring_all_to_all_dispatch_metadata"],
         )
 
         # deallocation required in order to free up L1 space for moe_compute

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -169,7 +169,9 @@ class MoE(SharedStateAddOn, AbstractModule):
         """
 
         num_experts_per_device = MoEExperts._get_num_experts_per_device(hf_config, mesh_device)
-        expert_mapping_tensor = cls._create_expert_mapping_tensor(mesh_device, mode, num_experts_per_device)
+        expert_mapping_tensor = cls._create_expert_mapping_tensor(
+            mesh_device, fabric_config, mode, num_experts_per_device
+        )
 
         if mode == "decode":
             memory_config = ttnn.L1_MEMORY_CONFIG
@@ -240,7 +242,7 @@ class MoE(SharedStateAddOn, AbstractModule):
             }
 
             # optimized MoE ops only functional for quad torus
-            if ["fabric_config"] == ttnn.FabricConfig.FABRIC_1D_RING and mesh_device.shape[0] == 16:
+            if fabric_config == ttnn.FabricConfig.FABRIC_1D_RING and mesh_device.shape[0] == 16:
                 batch = USERS_PER_ROW * mesh_device.shape[0]
                 seq_len = 1
 
@@ -323,6 +325,7 @@ class MoE(SharedStateAddOn, AbstractModule):
     def _create_expert_mapping_tensor(
         cls,
         mesh_device: ttnn.Device,
+        fabric_config: ttnn.FabricConfig,
         mode: str,
         num_experts_per_device: int,
     ):
@@ -330,7 +333,7 @@ class MoE(SharedStateAddOn, AbstractModule):
         if mode == "decode":
             # optimized MoE ops only functional for quad torus
             num_dispatch_devices = mesh_device.shape[0]
-            if ["fabric_config"] == ttnn.FabricConfig.FABRIC_1D_RING and num_dispatch_devices == 16:
+            if fabric_config == ttnn.FabricConfig.FABRIC_1D_RING and num_dispatch_devices == 16:
                 num_experts = num_devices * num_experts_per_device
                 tp_size = mesh_device.shape[1]
                 num_experts_per_cluster = num_experts // tp_size

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -660,6 +660,9 @@ class MoE(SharedStateAddOn, AbstractModule):
                     topk_experts_weights_rm_chunk,
                 )
                 output_chunks.append(post_combine_output_tensor)
+
+            ttnn.deallocate(topk_experts_indices_rm)
+            ttnn.deallocate(topk_experts_weights_rm)
         else:
             # Repeat + Permute Expert weights
             topk_experts_weights = cls._fwd_repeat_permute_expert_weights(topk_experts_weights, cfg)
@@ -742,6 +745,9 @@ class MoE(SharedStateAddOn, AbstractModule):
 
                 output_chunks.append(post_combine_output_tensor)
 
+            ttnn.deallocate(topk_experts_indices_rm)
+            ttnn.deallocate(topk_experts_weights)
+
         if len(output_chunks) == 1:
             post_combine_output_tensor = output_chunks[0]
         else:
@@ -750,7 +756,6 @@ class MoE(SharedStateAddOn, AbstractModule):
                 ttnn.deallocate(chunk)
 
         ttnn.deallocate(x_rm)
-        ttnn.deallocate(topk_experts_indices_rm)
         return post_combine_output_tensor
 
     @classmethod

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -122,7 +122,6 @@ class MoE(SharedStateAddOn, AbstractModule):
 
         config = {
             "expert_mapping_tensor": expert_mapping_tensor,
-            "remap_topk_mask": remap_topk_mask,
             MESH_DEVICE_STATE_DICT_KEY: mesh_device,
         }
 
@@ -552,20 +551,8 @@ class MoE(SharedStateAddOn, AbstractModule):
                 all_to_all_dispatch_output_tensors, shape=(1, 1, batch_size * seq_len, cfg["hidden_size"])
             )
             post_all_to_all_dispatch_output = ttnn.to_layout(post_all_to_all_dispatch_output, ttnn.TILE_LAYOUT)
-            # repeat remap_topk_mask for the num_tokens known at runtime
 
-            remap_topk_mask = ttnn.repeat(
-                cfg["remap_topk_mask"], ttnn.Shape((1, batch_size_per_device, 1, 1))
-            )  # TODO: move to static path
-
-            _, sparsity_t = ttnn.moe_expert_token_remap(
-                remap_topk_mask,
-                cfg["expert_mapping_tensor"],
-                all_to_all_dispatch_metadata_tensors,
-                reduction_size=cfg["sparsity_block_size"],
-            )
-
-            experts_output = MoEExperts._forward(post_all_to_all_dispatch_output, sparsity_t, cfg["moe_experts"])
+            experts_output = MoEExperts._forward(post_all_to_all_dispatch_output, cfg["moe_experts"])
             ttnn.deallocate(post_all_to_all_dispatch_output)
 
             experts_output = ttnn.to_layout(experts_output, ttnn.ROW_MAJOR_LAYOUT)
@@ -714,7 +701,7 @@ class MoE(SharedStateAddOn, AbstractModule):
                 all_to_all_dispatch_output_tensors, all_to_all_dispatch_metadata_tensors = ttnn.all_to_all_dispatch(
                     x_chunk,
                     topk_indices_chunk,
-                    cfg["expert_mapping_tensors"],
+                    cfg["expert_mapping_tensor"],
                     **cfg["all_to_all_dispatch"],
                 )
                 ttnn.deallocate(x_chunk)
@@ -744,7 +731,7 @@ class MoE(SharedStateAddOn, AbstractModule):
                 all_to_all_combine_output_tensors = ttnn.all_to_all_combine(
                     experts_output,
                     all_to_all_dispatch_metadata_tensors,
-                    cfg["expert_mapping_tensors"],
+                    cfg["expert_mapping_tensor"],
                     **cfg["all_to_all_combine"],
                 )
                 ttnn.deallocate(experts_output)

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -540,8 +540,8 @@ class MoE(SharedStateAddOn, AbstractModule):
                 dispatch_output_expert_scores,
             ) = ttnn.experimental.all_to_all_dispatch_metadata(
                 x_rm,
-                topk_experts_indices,  # TODO: (GR) may need to change shard spec of aho gate output
-                topk_experts_weights,  # TODO: (GR) may need to change shard spec of aho gate output
+                topk_experts_indices,  # TODO: (GR) need to change shard spec of aho gate module output (once it's merged)
+                topk_experts_weights,  # TODO: (GR) need to change shard spec of aho gate module output (once it's merged)
                 cfg["expert_mapping_tensor"],
                 **ccl.populate_all_to_all_dispatch_metadata_args(cfg["quad_ring_all_to_all_dispatch_metadata"]),
             )
@@ -550,6 +550,8 @@ class MoE(SharedStateAddOn, AbstractModule):
             ttnn.deallocate(x_rm)
             ttnn.deallocate(topk_experts_indices)
             ttnn.deallocate(topk_experts_weights)
+
+            # NOTE: we are actively working on fusing moe_compute and selective_reduce_combine
 
             w0_w1 = ()  # TODO: (GR)
             w2 = ()  # TODO: (GR)

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -356,6 +356,20 @@ class MoE(SharedStateAddOn, AbstractModule):
 
     @classmethod
     def forward_decode(cls, x: ttnn.Tensor, cfg: RunDecodeConfig | RunPrefillConfig) -> ttnn.Tensor:
+        # Validate input dimensions
+        hidden_size = cfg["hidden_size"]
+        mesh_device = cfg.get("mesh_device")
+        tp_size = mesh_device.shape[1] if mesh_device else 1
+
+        x_dim = x.shape[-1]
+        expected_dims = [hidden_size, hidden_size // tp_size] if tp_size > 1 else [hidden_size]
+
+        if x_dim not in expected_dims:
+            raise ValueError(
+                f"MoE: Unexpected input dimension {x_dim}. Expected one of {expected_dims}. "
+                f"(hidden_size={hidden_size}, tp_size={tp_size})"
+            )
+
         seq_len = 1  # a2a dispatch and combine require DP=num_dispatch_devices, hence in prefill for bs=1, we interchange the seq_len with batch_size dimensions
         batch_size_per_device = x.shape[
             -2

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -363,7 +363,7 @@ class MoE(SharedStateAddOn, AbstractModule):
         return cls.model_config(hf_config, mesh_device, fabric_config, "prefill", topk_fallback=topk_fallback)
 
     @classmethod
-    def forward_decode(cls, x: ttnn.Tensor, cfg: RunDecodeConfig | RunPrefillConfig) -> ttnn.Tensor:
+    def _forward_decode(cls, x: ttnn.Tensor, cfg: RunDecodeConfig | RunPrefillConfig) -> ttnn.Tensor:
         # Validate input dimensions
         hidden_size = cfg["hidden_size"]
         mesh_device = cfg.get("mesh_device")
@@ -404,7 +404,7 @@ class MoE(SharedStateAddOn, AbstractModule):
         return post_combine_output_tensor
 
     @classmethod
-    def forward_prefill(cls, x: ttnn.Tensor, cfg: RunDecodeConfig | RunPrefillConfig) -> ttnn.Tensor:
+    def _forward_prefill(cls, x: ttnn.Tensor, cfg: RunDecodeConfig | RunPrefillConfig) -> ttnn.Tensor:
         # Chunk the full MoE prefill path at 16K tokens to avoid OOM.
         # Use global token count (local seq_len * num_dispatch_devices) to decide.
         chunk_tokens = int(cfg.get("prefill_chunk_size", 16384))
@@ -914,7 +914,7 @@ class MoE(SharedStateAddOn, AbstractModule):
             x = cls._fwd_all_gather(x, cfg)
 
         # Run the forward pass
-        output = cls.forward_decode(x, cfg)
+        output = cls._forward_decode(x, cfg)
 
         # Handle sum_experts and reduce_scatter if tensor parallel is enabled
         if handle_tensor_parallel:
@@ -946,7 +946,7 @@ class MoE(SharedStateAddOn, AbstractModule):
             x = cls._fwd_all_gather(x, cfg)
 
         # Run the forward pass
-        output = cls.forward_prefill(x, cfg)
+        output = cls._forward_prefill(x, cfg)
 
         # Handle sum_experts and reduce_scatter if tensor parallel is enabled
         if handle_tensor_parallel:

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -127,7 +127,6 @@ class MoE(SharedStateAddOn, AbstractModule):
         }
 
         # optimized ops (exclusive to quad with ring fabric) require preallocated tensors for all_to_all_dispatch_metadata
-        # TODO: (GR)
         if fabric_config == ttnn.FabricConfig.FABRIC_1D_RING and num_dispatch_device_rows == 16:
             batch = USERS_PER_ROW * mesh_device.shape[0]
             preallocated_all_to_all_dispatch_metadata_tensors = (
@@ -338,7 +337,6 @@ class MoE(SharedStateAddOn, AbstractModule):
             )
 
             # TODO: this is a temporary measure until we either a) uplift the optimized ops to support prefill shapes, or b) uplift prefill MMs to read from decode formatted weights
-            # set chunk size for prefill
             config["moe_chunk_size"] = USERS_PER_ROW
 
         return config
@@ -507,9 +505,8 @@ class MoE(SharedStateAddOn, AbstractModule):
             shape=(batch_size_per_device, 1, seq_len, cfg["hidden_size"]),
         )
 
+        # optimized ops are exclusive to quad with ring fabric
         if cfg["fabric_config"] == ttnn.FabricConfig.FABRIC_1D_RING and cfg["num_dispatch_devices"] == 16:
-            ccl = cfg["ccl"]
-
             # NOTE: can move towards removing these TMs once optimized moe_gate is integrated
             topk_experts_indices_rm = ttnn.to_layout(
                 topk_experts_indices, ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG
@@ -528,98 +525,12 @@ class MoE(SharedStateAddOn, AbstractModule):
                 topk_experts_weights_rm, (2, 0, 1, 3), memory_config=ttnn.L1_MEMORY_CONFIG
             )
 
-            topk_experts_indices_rm_sharded = ttnn.to_memory_config(
-                topk_experts_indices_rm,
-                memory_config=cfg["quad_ring_all_to_all_dispatch_metadata_sharded_memory_config"],
-            )
-            topk_experts_weights_rm_sharded = ttnn.to_memory_config(
-                topk_experts_weights_rm,
-                memory_config=cfg["quad_ring_all_to_all_dispatch_metadata_sharded_memory_config"],
-            )
-
-            # NOTE: L1 sharded topk_experts_weights need to be deallocated before moe_compute,
-            # configure weights for post combine scaling prior to that deallocation, and store in DRAM
-            topk_experts_weights_for_scaling = ttnn.permute(
-                topk_experts_weights_rm, (3, 1, 0, 2), memory_config=ttnn.L1_MEMORY_CONFIG
-            )
-            topk_experts_weights_for_scaling = ttnn.to_layout(
-                topk_experts_weights_for_scaling, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG
-            )
-
-            ttnn.deallocate(topk_experts_indices_rm)
-            ttnn.deallocate(topk_experts_weights_rm)
-
-            # NOTE: needs to run prior to all_to_all_dispatch_metadata
-            preallocated_combine_output = ttnn.moreh_full(**cfg["quad_ring_moreh_full"])
-
-            (
-                dispatch_output_sparse_buffer,
-                dispatch_output_expert_indices,
-                dispatch_output_expert_scores,
-            ) = ttnn.experimental.all_to_all_dispatch_metadata(
+            post_combine_output_tensor = cls._forward_moe_quad_ring_impl(
+                cfg,
                 x_rm,
-                topk_experts_indices_rm_sharded,
-                topk_experts_weights_rm_sharded,
-                cfg["expert_mapping_tensor"],
-                output_tensors=cfg["quad_ring_preallocated_all_to_all_dispatch_metadata_tensors"],
-                **ccl.populate_all_to_all_dispatch_metadata_args(cfg["quad_ring_all_to_all_dispatch_metadata"]),
+                topk_experts_indices_rm,
+                topk_experts_weights_rm,
             )
-
-            # deallocation required in order to free up L1 space for moe_compute
-            ttnn.deallocate(x_rm)
-            ttnn.deallocate(topk_experts_indices_rm_sharded)
-            ttnn.deallocate(topk_experts_weights_rm_sharded)
-
-            # NOTE: we are actively working on fusing moe_compute and selective_reduce_combine
-
-            w0_w1 = ()  # TODO: (GR)
-            w2 = ()  # TODO: (GR)
-            layer_id = 0  # TODO: (GR)
-            (
-                compute_output_token_counts,
-                compute_output_dense_expert_activation,
-                compute_ouput_dense_e_t,
-                _,  # tile layout output of selective tilize (same buffer as output)
-                compute_output,
-            ) = ttnn.experimental.moe_compute(
-                dispatch_output_sparse_buffer,
-                dispatch_output_expert_indices,
-                dispatch_output_expert_scores,
-                cfg["expert_mapping_tensor"],
-                w0_w1,
-                w2,
-                layer_id=layer_id,
-                **cfg["quad_ring_moe_compute"],
-            )
-
-            # NOTE: can't deallocate dispatch output tensors as they are preallocated and reused across layers
-
-            combine_output = ttnn.experimental.selective_reduce_combine(
-                compute_output,
-                compute_output_dense_expert_activation,
-                compute_ouput_dense_e_t,
-                compute_output_token_counts,
-                output_tensor=preallocated_combine_output,
-                **ccl.populate_selective_reduce_combine_args(cfg["quad_ring_selective_reduce_combine"]),
-            )
-
-            ttnn.deallocate(compute_output)
-            ttnn.deallocate(compute_output_dense_expert_activation)
-            ttnn.deallocate(compute_ouput_dense_e_t)
-            ttnn.deallocate(compute_output_token_counts)
-
-            combine_output = ttnn.to_layout(
-                combine_output,
-                layout=ttnn.TILE_LAYOUT,
-                memory_config=ttnn.L1_MEMORY_CONFIG,
-            )
-            combine_output = ttnn.unsqueeze(combine_output, dim=1)
-
-            post_combine_output_tensor = ttnn.mul(
-                combine_output, topk_experts_weights_for_scaling, **cfg["mul_experts_output_with_weights"]
-            )
-
-            ttnn.deallocate(combine_output)
         else:
             # Repeat + Permute Expert weights
             topk_experts_weights = cls._fwd_repeat_permute_expert_weights(topk_experts_weights, cfg)
@@ -701,9 +612,8 @@ class MoE(SharedStateAddOn, AbstractModule):
         chunk_size = min(batch_size_per_device, max(1, cfg.get("moe_chunk_size", batch_size_per_device)))
         output_chunks: list[ttnn.Tensor] = []
 
+        # optimized ops are exclusive to quad with ring fabric
         if cfg["fabric_config"] == ttnn.FabricConfig.FABRIC_1D_RING and cfg["num_dispatch_devices"] == 16:
-            ccl = cfg["ccl"]
-
             topk_experts_indices_rm = ttnn.to_layout(
                 topk_experts_indices, ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG
             )
@@ -714,6 +624,7 @@ class MoE(SharedStateAddOn, AbstractModule):
             ttnn.deallocate(topk_experts_indices)
             ttnn.deallocate(topk_experts_weights)
 
+            # NOTE: store in DRAM while chunking, as moe_compute requires just about all of L1
             topk_experts_indices_rm = ttnn.permute(
                 topk_experts_indices_rm, (2, 0, 1, 3), memory_config=ttnn.DRAM_MEMORY_CONFIG
             )
@@ -724,7 +635,7 @@ class MoE(SharedStateAddOn, AbstractModule):
             for batch_start in range(0, batch_size_per_device, chunk_size):
                 batch_end = min(batch_start + chunk_size, batch_size_per_device)
 
-                x_chunk = ttnn.slice(
+                x_rm_chunk = ttnn.slice(
                     x_rm,
                     [batch_start, 0, 0, 0],
                     [batch_end, 1, seq_len, cfg["hidden_size"]],
@@ -735,104 +646,20 @@ class MoE(SharedStateAddOn, AbstractModule):
                     [batch_start, 0, 0, 0],
                     [batch_end, 1, seq_len, cfg["num_experts_per_tok"]],
                 )
-                topk_experts_indices_rm_chunk_sharded = ttnn.to_memory_config(
-                    topk_experts_indices_rm_chunk,
-                    memory_config=cfg["quad_ring_all_to_all_dispatch_metadata_sharded_memory_config"],
-                )
 
                 topk_experts_weights_rm_chunk = ttnn.slice(
                     topk_experts_weights_rm,
                     [batch_start, 0, 0, 0],
                     [batch_end, 1, seq_len, cfg["num_experts_per_tok"]],
                 )
-                topk_expert_weights_rm_chunk_sharded = ttnn.to_memory_config(
+
+                post_combine_output_tensor = cls._forward_moe_quad_ring_impl(
+                    cfg,
+                    x_rm_chunk,
+                    topk_experts_indices_rm_chunk,
                     topk_experts_weights_rm_chunk,
-                    memory_config=cfg["quad_ring_all_to_all_dispatch_metadata_sharded_memory_config"],
                 )
-
-                # NOTE: L1 sharded topk_experts_weights need to be deallocated before moe_compute,
-                # configure weights for post combine scaling prior to that deallocation, and store in DRAM
-                topk_experts_weights_for_scaling_chunk = ttnn.permute(
-                    topk_experts_weights_rm_chunk, (3, 1, 0, 2), memory_config=ttnn.L1_MEMORY_CONFIG
-                )
-                topk_experts_weights_for_scaling_chunk = ttnn.to_layout(
-                    topk_experts_weights_for_scaling_chunk,
-                    layout=ttnn.TILE_LAYOUT,
-                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                )
-
-                ttnn.deallocate(topk_experts_indices_rm_chunk)
-                ttnn.deallocate(topk_experts_weights_rm_chunk)
-
-                # NOTE: needs to run prior to all_to_all_dispatch_metadata
-                preallocated_combine_output = ttnn.moreh_full(**cfg["quad_ring_moreh_full"])
-
-                (
-                    dispatch_output_sparse_buffer,
-                    dispatch_output_expert_indices,
-                    dispatch_output_expert_scores,
-                ) = ttnn.experimental.all_to_all_dispatch_metadata(
-                    x_chunk,
-                    topk_experts_indices_rm_chunk_sharded,
-                    topk_expert_weights_rm_chunk_sharded,
-                    cfg["expert_mapping_tensor"],
-                    output_tensors=cfg["quad_ring_preallocated_all_to_all_dispatch_metadata_tensors"],
-                    **ccl.populate_all_to_all_dispatch_metadata_args(cfg["quad_ring_all_to_all_dispatch_metadata"]),
-                )
-
-                # deallocation required in order to free up L1 space for moe_compute
-                ttnn.deallocate(x_chunk)
-                ttnn.deallocate(topk_experts_indices_rm_chunk_sharded)
-                ttnn.deallocate(topk_expert_weights_rm_chunk_sharded)
-
-                # NOTE: we are actively working on fusing moe_compute and selective_reduce_combine
-
-                w0_w1 = ()  # TODO: (GR)
-                w2 = ()  # TODO: (GR)
-                layer_id = 0  # TODO: (GR)
-                (
-                    compute_output_token_counts,
-                    compute_output_dense_expert_activation,
-                    compute_ouput_dense_e_t,
-                    _,  # tile layout output of selective tilize (same buffer as output)
-                    compute_output,
-                ) = ttnn.experimental.moe_compute(
-                    dispatch_output_sparse_buffer,
-                    dispatch_output_expert_indices,
-                    dispatch_output_expert_scores,
-                    cfg["expert_mapping_tensor"],
-                    w0_w1,
-                    w2,
-                    layer_id=layer_id,
-                    **cfg["quad_ring_moe_compute"],
-                )
-
-                # NOTE: can't deallocate dispatch output tensors as they are preallocated and reused across layers
-
-                combine_output = ttnn.experimental.selective_reduce_combine(
-                    compute_output,
-                    compute_output_dense_expert_activation,
-                    compute_ouput_dense_e_t,
-                    compute_output_token_counts,
-                    output_tensor=preallocated_combine_output,
-                    **ccl.populate_selective_reduce_combine_args(cfg["quad_ring_selective_reduce_combine"]),
-                )
-
-                ttnn.deallocate(compute_output)
-                ttnn.deallocate(compute_output_dense_expert_activation)
-                ttnn.deallocate(compute_ouput_dense_e_t)
-                ttnn.deallocate(compute_output_token_counts)
-
-                combine_output = ttnn.to_layout(
-                    combine_output,
-                    layout=ttnn.TILE_LAYOUT,
-                    memory_config=ttnn.L1_MEMORY_CONFIG,
-                )
-                combine_output = ttnn.unsqueeze(combine_output, dim=1)
-
-                post_combine_output_tensor = ttnn.mul(
-                    combine_output, topk_experts_weights_for_scaling_chunk, **cfg["mul_experts_output_with_weights"]
-                )
+                output_chunks.append(post_combine_output_tensor)
         else:
             # Repeat + Permute Expert weights
             topk_experts_weights = cls._fwd_repeat_permute_expert_weights(topk_experts_weights, cfg)
@@ -913,7 +740,7 @@ class MoE(SharedStateAddOn, AbstractModule):
                 )
                 ttnn.deallocate(topk_weights_chunk)
 
-            output_chunks.append(post_combine_output_tensor)
+                output_chunks.append(post_combine_output_tensor)
 
         if len(output_chunks) == 1:
             post_combine_output_tensor = output_chunks[0]
@@ -924,6 +751,110 @@ class MoE(SharedStateAddOn, AbstractModule):
 
         ttnn.deallocate(x_rm)
         ttnn.deallocate(topk_experts_indices_rm)
+        return post_combine_output_tensor
+
+    @classmethod
+    def _forward_moe_quad_ring_impl(
+        cls,
+        cfg: RunDecodeConfig | RunPrefillConfig,
+        x_rm: ttnn.Tensor,
+        topk_experts_indices_rm: ttnn.Tensor,
+        topk_experts_weights_rm: ttnn.Tensor,
+    ):
+        ccl = cfg["ccl"]
+
+        topk_experts_indices_rm_sharded = ttnn.to_memory_config(
+            topk_experts_indices_rm,
+            memory_config=cfg["quad_ring_all_to_all_dispatch_metadata_sharded_memory_config"],
+        )
+        topk_experts_weights_rm_sharded = ttnn.to_memory_config(
+            topk_experts_weights_rm,
+            memory_config=cfg["quad_ring_all_to_all_dispatch_metadata_sharded_memory_config"],
+        )
+
+        # NOTE: L1 sharded topk_experts_weights need to be deallocated before moe_compute,
+        # configure weights for post combine scaling prior to that deallocation, and store in DRAM
+        topk_experts_weights_for_scaling = ttnn.permute(
+            topk_experts_weights_rm, (3, 1, 0, 2), memory_config=ttnn.L1_MEMORY_CONFIG
+        )
+        topk_experts_weights_for_scaling = ttnn.to_layout(
+            topk_experts_weights_for_scaling, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG
+        )
+
+        ttnn.deallocate(topk_experts_indices_rm)
+        ttnn.deallocate(topk_experts_weights_rm)
+
+        # NOTE: needs to run prior to all_to_all_dispatch_metadata
+        preallocated_combine_output = ttnn.moreh_full(**cfg["quad_ring_moreh_full"])
+
+        (
+            dispatch_output_sparse_buffer,
+            dispatch_output_expert_indices,
+            dispatch_output_expert_scores,
+        ) = ttnn.experimental.all_to_all_dispatch_metadata(
+            x_rm,
+            topk_experts_indices_rm_sharded,
+            topk_experts_weights_rm_sharded,
+            cfg["expert_mapping_tensor"],
+            output_tensors=cfg["quad_ring_preallocated_all_to_all_dispatch_metadata_tensors"],
+            **ccl.populate_all_to_all_dispatch_metadata_args(cfg["quad_ring_all_to_all_dispatch_metadata"]),
+        )
+
+        # deallocation required in order to free up L1 space for moe_compute
+        ttnn.deallocate(x_rm)
+        ttnn.deallocate(topk_experts_indices_rm_sharded)
+        ttnn.deallocate(topk_experts_weights_rm_sharded)
+
+        # NOTE: we are actively working on fusing moe_compute and selective_reduce_combine
+
+        w0_w1 = ()  # TODO: (GR)
+        w2 = ()  # TODO: (GR)
+        layer_id = 0  # TODO: (GR)
+        (
+            compute_output_token_counts,
+            compute_output_dense_expert_activation,
+            compute_ouput_dense_e_t,
+            _,  # tile layout output of selective tilize (same buffer as output)
+            compute_output,
+        ) = ttnn.experimental.moe_compute(
+            dispatch_output_sparse_buffer,
+            dispatch_output_expert_indices,
+            dispatch_output_expert_scores,
+            cfg["expert_mapping_tensor"],
+            w0_w1,
+            w2,
+            layer_id=layer_id,
+            **cfg["quad_ring_moe_compute"],
+        )
+
+        # NOTE: can't deallocate dispatch output tensors as they are preallocated and reused across layers
+
+        combine_output = ttnn.experimental.selective_reduce_combine(
+            compute_output,
+            compute_output_dense_expert_activation,
+            compute_ouput_dense_e_t,
+            compute_output_token_counts,
+            output_tensor=preallocated_combine_output,
+            **ccl.populate_selective_reduce_combine_args(cfg["quad_ring_selective_reduce_combine"]),
+        )
+
+        ttnn.deallocate(compute_output)
+        ttnn.deallocate(compute_output_dense_expert_activation)
+        ttnn.deallocate(compute_ouput_dense_e_t)
+        ttnn.deallocate(compute_output_token_counts)
+
+        combine_output = ttnn.to_layout(
+            combine_output,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
+        )
+        combine_output = ttnn.unsqueeze(combine_output, dim=1)
+
+        post_combine_output_tensor = ttnn.mul(
+            combine_output, topk_experts_weights_for_scaling, **cfg["mul_experts_output_with_weights"]
+        )
+
+        ttnn.deallocate(combine_output)
         return post_combine_output_tensor
 
     @classmethod

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -27,7 +27,7 @@ from models.demos.deepseek_v3.utils.config_dataclass import (
     RepeatConfig,
     SelectiveReduceCombineConfig,
 )
-from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW
+from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, is_ring_fabric
 from models.demos.deepseek_v3.utils.run_config import (
     MESH_DEVICE_STATE_DICT_KEY,
     ModelDecodeConfig,
@@ -127,7 +127,7 @@ class MoE(SharedStateAddOn, AbstractModule):
         }
 
         # optimized ops (exclusive to quad with ring fabric) require preallocated tensors for all_to_all_dispatch_metadata
-        if fabric_config == ttnn.FabricConfig.FABRIC_1D_RING and num_dispatch_device_rows == 16:
+        if is_ring_fabric(fabric_config) and num_dispatch_device_rows == 16:
             # NOTE: these do not have to be double buffered, due to the synchronization between all_to_all_dispatch_metadata and selective_reduce_combine inside the MoE block
             batch = USERS_PER_ROW * mesh_device.shape[0]
             preallocated_all_to_all_dispatch_metadata_tensors = (
@@ -297,7 +297,7 @@ class MoE(SharedStateAddOn, AbstractModule):
             }
 
         # configs for optimized ops (exclusive to quad with ring fabric)
-        if fabric_config == ttnn.FabricConfig.FABRIC_1D_RING and mesh_device.shape[0] == 16:
+        if is_ring_fabric(fabric_config) and mesh_device.shape[0] == 16:
             batch = USERS_PER_ROW * mesh_device.shape[0]
             seq_len = 1
 
@@ -507,7 +507,7 @@ class MoE(SharedStateAddOn, AbstractModule):
         )
 
         # optimized ops are exclusive to quad with ring fabric
-        if cfg["fabric_config"] == ttnn.FabricConfig.FABRIC_1D_RING and cfg["num_dispatch_devices"] == 16:
+        if is_ring_fabric(cfg["fabric_config"]) and cfg["num_dispatch_devices"] == 16:
             # NOTE: can move towards removing these TMs once optimized moe_gate is integrated
             topk_experts_indices_rm = ttnn.to_layout(
                 topk_experts_indices, ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG
@@ -614,7 +614,7 @@ class MoE(SharedStateAddOn, AbstractModule):
         output_chunks: list[ttnn.Tensor] = []
 
         # optimized ops are exclusive to quad with ring fabric
-        if cfg["fabric_config"] == ttnn.FabricConfig.FABRIC_1D_RING and cfg["num_dispatch_devices"] == 16:
+        if is_ring_fabric(cfg["fabric_config"]) and cfg["num_dispatch_devices"] == 16:
             topk_experts_indices_rm = ttnn.to_layout(
                 topk_experts_indices, ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG
             )
@@ -921,7 +921,7 @@ class MoE(SharedStateAddOn, AbstractModule):
             ccl = cfg["ccl"]
             tp_size = cfg["mesh_device"].shape[1]
 
-            if cfg["fabric_config"] == ttnn.FabricConfig.FABRIC_1D_RING and tp_size == 8:
+            if is_ring_fabric(cfg["fabric_config"]) and tp_size == 8:
                 output = ttnn.experimental.deepseek_moe_fast_reduce_nc(
                     output,
                     dim=0,

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -323,11 +323,11 @@ class MoE(SharedStateAddOn, AbstractModule):
             )
             config["quad_ring_selective_reduce_combine"] = SelectiveReduceCombineConfig(
                 hidden_size=hf_config.hidden_size,
-                batch=batch,
-                seq=seq_len,
+                batch_size=batch,
+                seq_size=seq_len,
                 select_experts_k=hf_config.num_experts_per_tok,
                 experts=hf_config.n_routed_experts,
-                axis=0,
+                cluster_axis=0,
                 token_parallel_core_dim=4,
                 data_parallel_core_dim=4,
                 worker_cores=ttnn.experimental.get_moe_combine_cores(mesh_device),

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -634,11 +634,17 @@ class MoE(SharedStateAddOn, AbstractModule):
 
             for batch_start in range(0, batch_size_per_device, chunk_size):
                 batch_end = min(batch_start + chunk_size, batch_size_per_device)
+                batch_chunk = batch_end - batch_start
 
                 x_rm_chunk = ttnn.slice(
                     x_rm,
                     [batch_start, 0, 0, 0],
                     [batch_end, 1, seq_len, cfg["hidden_size"]],
+                )
+                x_rm_chunk = ttnn.pad(
+                    x_rm_chunk,
+                    padding=((0, batch_chunk), (0, 0), (0, 0), (0, 0)),
+                    value=0.0,
                 )
 
                 topk_experts_indices_rm_chunk = ttnn.slice(
@@ -646,11 +652,21 @@ class MoE(SharedStateAddOn, AbstractModule):
                     [batch_start, 0, 0, 0],
                     [batch_end, 1, seq_len, cfg["num_experts_per_tok"]],
                 )
+                topk_experts_indices_rm_chunk = ttnn.pad(
+                    topk_experts_indices_rm_chunk,
+                    padding=((0, batch_chunk), (0, 0), (0, 0), (0, 0)),
+                    value=0.0,
+                )
 
                 topk_experts_weights_rm_chunk = ttnn.slice(
                     topk_experts_weights_rm,
                     [batch_start, 0, 0, 0],
                     [batch_end, 1, seq_len, cfg["num_experts_per_tok"]],
+                )
+                topk_experts_weights_rm_chunk = ttnn.pad(
+                    topk_experts_weights_rm_chunk,
+                    padding=((0, batch_chunk), (0, 0), (0, 0), (0, 0)),
+                    value=0.0,
                 )
 
                 post_combine_output_tensor = cls._forward_moe_quad_ring_impl(
@@ -659,6 +675,12 @@ class MoE(SharedStateAddOn, AbstractModule):
                     topk_experts_indices_rm_chunk,
                     topk_experts_weights_rm_chunk,
                 )
+                post_combine_output_tensor = ttnn.slice(
+                    post_combine_output_tensor,
+                    [0, 0, 0, 0],
+                    [cfg["num_experts_per_tok"], 1, batch_chunk, cfg["hidden_size"]],
+                )
+
                 output_chunks.append(post_combine_output_tensor)
 
             ttnn.deallocate(topk_experts_indices_rm)

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -337,7 +337,8 @@ class MoE(SharedStateAddOn, AbstractModule):
             )
 
             # TODO: this is a temporary measure until we either a) uplift the optimized ops to support prefill shapes, or b) uplift prefill MMs to read from decode formatted weights
-            config["moe_chunk_size"] = USERS_PER_ROW
+            DECODE_USERS_PER_ROW_PER_DEVICE = 32
+            config["moe_chunk_size"] = DECODE_USERS_PER_ROW_PER_DEVICE
 
         return config
 
@@ -572,7 +573,7 @@ class MoE(SharedStateAddOn, AbstractModule):
                 )
                 x_rm_chunk = ttnn.pad(
                     x_rm_chunk,
-                    padding=((0, batch_chunk), (0, 0), (0, 0), (0, 0)),
+                    padding=((0, cfg["moe_chunk_size"]), (0, 0), (0, 0), (0, 0)),
                     value=0.0,
                 )
 
@@ -583,7 +584,7 @@ class MoE(SharedStateAddOn, AbstractModule):
                 )
                 topk_experts_indices_rm_chunk = ttnn.pad(
                     topk_experts_indices_rm_chunk,
-                    padding=((0, batch_chunk), (0, 0), (0, 0), (0, 0)),
+                    padding=((0, cfg["moe_chunk_size"]), (0, 0), (0, 0), (0, 0)),
                     value=0.0,
                 )
 
@@ -594,7 +595,7 @@ class MoE(SharedStateAddOn, AbstractModule):
                 )
                 topk_experts_weights_rm_chunk = ttnn.pad(
                     topk_experts_weights_rm_chunk,
-                    padding=((0, batch_chunk), (0, 0), (0, 0), (0, 0)),
+                    padding=((0, cfg["moe_chunk_size"]), (0, 0), (0, 0), (0, 0)),
                     value=0.0,
                 )
 

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -550,6 +550,7 @@ class MoE(SharedStateAddOn, AbstractModule):
             post_all_to_all_dispatch_output = ttnn.reshape(
                 all_to_all_dispatch_output_tensors, shape=(1, 1, batch_size * seq_len, cfg["hidden_size"])
             )
+            post_all_to_all_dispatch_output = ttnn.repeat(post_all_to_all_dispatch_output, **cfg["activations_repeat"])
             post_all_to_all_dispatch_output = ttnn.to_layout(post_all_to_all_dispatch_output, ttnn.TILE_LAYOUT)
 
             experts_output = MoEExperts._forward(post_all_to_all_dispatch_output, cfg["moe_experts"])
@@ -558,6 +559,11 @@ class MoE(SharedStateAddOn, AbstractModule):
             experts_output = ttnn.to_layout(experts_output, ttnn.ROW_MAJOR_LAYOUT)
             experts_output = ttnn.reshape(
                 experts_output, shape=(cfg["num_experts_per_device"], batch_size, seq_len, cfg["hidden_size"])
+            )
+
+            all_to_all_dispatch_metadata_tensors = ttnn.reshape(
+                all_to_all_dispatch_metadata_tensors,
+                shape=(1, batch_size, seq_len, cfg["num_experts_per_tok"]),
             )
 
             all_to_all_combine_output_tensors = ttnn.all_to_all_combine(

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -28,7 +28,11 @@ from models.demos.deepseek_v3.utils.config_dataclass import (
     RepeatConfig,
     SelectiveReduceCombineConfig,
 )
-from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, is_ring_fabric
+from models.demos.deepseek_v3.utils.config_helpers import (
+    OPTIMIZED_MOE_BLOCK_USERS_PER_ROW,
+    USERS_PER_ROW,
+    is_ring_fabric,
+)
 from models.demos.deepseek_v3.utils.run_config import (
     MESH_DEVICE_STATE_DICT_KEY,
     ModelDecodeConfig,
@@ -126,7 +130,7 @@ class MoE(SharedStateAddOn, AbstractModule):
         # optimized ops (exclusive to quad with ring fabric) require preallocated tensors for all_to_all_dispatch_metadata
         if is_ring_fabric(fabric_config) and num_dispatch_device_rows == 16:
             # NOTE: these do not have to be double buffered, due to the synchronization between all_to_all_dispatch_metadata and selective_reduce_combine inside the MoE block
-            batch = USERS_PER_ROW * mesh_device.shape[0]
+            batch = OPTIMIZED_MOE_BLOCK_USERS_PER_ROW * mesh_device.shape[0]
             preallocated_all_to_all_dispatch_metadata_tensors = (
                 AllToAllDispatchMetadataConfig.create_preallocated_dispatch_output_tensors(
                     mesh_device,
@@ -295,7 +299,7 @@ class MoE(SharedStateAddOn, AbstractModule):
 
         # configs for optimized ops (exclusive to quad with ring fabric)
         if is_ring_fabric(fabric_config) and mesh_device.shape[0] == 16:
-            batch = USERS_PER_ROW * mesh_device.shape[0]
+            batch = OPTIMIZED_MOE_BLOCK_USERS_PER_ROW * mesh_device.shape[0]
             seq_len = 1
 
             config["quad_ring_all_to_all_dispatch_metadata"] = AllToAllDispatchMetadataConfig(
@@ -306,10 +310,10 @@ class MoE(SharedStateAddOn, AbstractModule):
             config[
                 "quad_ring_all_to_all_dispatch_metadata_sharded_memory_config"
             ] = AllToAllDispatchMetadataConfig.get_metadata_sharded_memory_config(
-                USERS_PER_ROW, hf_config.num_experts_per_tok
+                OPTIMIZED_MOE_BLOCK_USERS_PER_ROW, hf_config.num_experts_per_tok
             )
             config["quad_ring_moreh_full"] = MorehFullConfig(
-                shape=[hf_config.num_experts_per_tok, USERS_PER_ROW, hf_config.hidden_size],
+                shape=[hf_config.num_experts_per_tok, OPTIMIZED_MOE_BLOCK_USERS_PER_ROW, hf_config.hidden_size],
                 fill_value=0,
                 device=mesh_device,
                 dtype=ttnn.bfloat16,
@@ -338,8 +342,7 @@ class MoE(SharedStateAddOn, AbstractModule):
             )
 
             # TODO: this is a temporary measure until we either a) uplift the optimized ops to support prefill shapes, or b) uplift prefill MMs to read from decode formatted weights
-            DECODE_USERS_PER_ROW_PER_DEVICE = 32
-            config["moe_chunk_size"] = DECODE_USERS_PER_ROW_PER_DEVICE
+            config["moe_chunk_size"] = OPTIMIZED_MOE_BLOCK_USERS_PER_ROW
 
         return config
 

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -834,10 +834,6 @@ class MoE(SharedStateAddOn, AbstractModule):
         ttnn.deallocate(topk_experts_weights_rm_sharded)
 
         # NOTE: we are actively working on fusing moe_compute and selective_reduce_combine
-
-        w0_w1 = ()  # TODO: (GR)
-        w2 = ()  # TODO: (GR)
-        layer_id = 0  # TODO: (GR)
         (
             compute_output_token_counts,
             compute_output_dense_expert_activation,
@@ -849,9 +845,9 @@ class MoE(SharedStateAddOn, AbstractModule):
             dispatch_output_expert_indices,
             dispatch_output_expert_scores,
             cfg["expert_mapping_tensor"],
-            w0_w1,
-            w2,
-            layer_id=layer_id,
+            cfg["moe_experts"]["w0_w1_experts"],
+            cfg["moe_experts"]["w2_experts"],
+            layer_id=0,  # each layer is composed of distinct tensors, as apposed to all layers fused together
             **cfg["quad_ring_moe_compute"],
         )
 

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -845,8 +845,8 @@ class MoE(SharedStateAddOn, AbstractModule):
             dispatch_output_expert_indices,
             dispatch_output_expert_scores,
             cfg["expert_mapping_tensor"],
-            cfg["moe_experts"]["w0_w1_experts"],
-            cfg["moe_experts"]["w2_experts"],
+            cfg["moe_experts"]["quad_ring_w0_w1_experts"],
+            cfg["moe_experts"]["quad_ring_w2_experts"],
             layer_id=0,  # each layer is composed of distinct tensors, as apposed to all layers fused together
             **cfg["quad_ring_moe_compute"],
         )

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -401,7 +401,7 @@ class MoE(SharedStateAddOn, AbstractModule):
         for start in range(0, seq_len, chunk_size):
             end = min(start + chunk_size, seq_len)
             x_chunk = ttnn.slice(x, [0, 0, start, 0], [x.shape[0], x.shape[1], end, x.shape[3]])
-            output_chunks.append(cls._forward_impl(x_chunk, cfg))
+            output_chunks.append(cls._forward_prefill_impl(x_chunk, cfg))
             ttnn.deallocate(x_chunk)
 
         if len(output_chunks) == 1:

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -128,6 +128,7 @@ class MoE(SharedStateAddOn, AbstractModule):
 
         # optimized ops (exclusive to quad with ring fabric) require preallocated tensors for all_to_all_dispatch_metadata
         if fabric_config == ttnn.FabricConfig.FABRIC_1D_RING and num_dispatch_device_rows == 16:
+            # NOTE: these do not have to be double buffered, due to the synchronization between all_to_all_dispatch_metadata and selective_reduce_combine inside the MoE block
             batch = USERS_PER_ROW * mesh_device.shape[0]
             preallocated_all_to_all_dispatch_metadata_tensors = (
                 AllToAllDispatchMetadataConfig.create_preallocated_dispatch_output_tensors(

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -73,6 +73,7 @@ class MoE(SharedStateAddOn, AbstractModule):
         cls,
         hf_config: PretrainedConfig,
         mesh_device: ttnn.Device,
+        fabric_config: ttnn.FabricConfig,
     ) -> ModelState:
         """Create shared model state containing tensors that are constant across all instances.
 
@@ -82,6 +83,8 @@ class MoE(SharedStateAddOn, AbstractModule):
         Returns:
             ModelState containing shared tensors
         """
+        num_devices = mesh_device.get_num_devices()
+        num_experts_per_device = MoEExperts._get_num_experts_per_device(hf_config, mesh_device)
         num_dispatch_device_rows = mesh_device.shape[0]
 
         logger.info(
@@ -117,10 +120,29 @@ class MoE(SharedStateAddOn, AbstractModule):
         )
         logger.info(f"Created MoE remap topk mask in {perf_counter() - remap_mask_start:.2f}s")
 
-        return {
+        config = {
+            "expert_mapping_tensor": expert_mapping_tensor,
             "remap_topk_mask": remap_topk_mask,
             MESH_DEVICE_STATE_DICT_KEY: mesh_device,
         }
+
+        # optimized ops (exclusive to quad with ring fabric) require preallocated tensors for all_to_all_dispatch_metadata
+        # TODO: (GR)
+        if fabric_config == ttnn.FabricConfig.FABRIC_1D_RING and num_dispatch_device_rows == 16:
+            batch = USERS_PER_ROW * mesh_device.shape[0]
+            preallocated_all_to_all_dispatch_metadata_tensors = (
+                AllToAllDispatchMetadataConfig.create_preallocated_dispatch_output_tensors(
+                    mesh_device,
+                    batch,
+                    hf_config.hidden_size,
+                    hf_config.num_experts_per_tok,
+                )
+            )
+            config[
+                "quad_ring_preallocated_all_to_all_dispatch_metadata_tensors"
+            ] = preallocated_all_to_all_dispatch_metadata_tensors
+
+        return config
 
     @classmethod
     def create_state(
@@ -169,9 +191,6 @@ class MoE(SharedStateAddOn, AbstractModule):
         """
 
         num_experts_per_device = MoEExperts._get_num_experts_per_device(hf_config, mesh_device)
-        expert_mapping_tensor = cls._create_expert_mapping_tensor(
-            mesh_device, fabric_config, mode, num_experts_per_device
-        )
 
         if mode == "decode":
             memory_config = ttnn.L1_MEMORY_CONFIG
@@ -193,7 +212,7 @@ class MoE(SharedStateAddOn, AbstractModule):
             )
 
             # Construct the config
-            decode_config = {
+            config = {
                 "mesh_device": MeshDeviceStub(mesh_device.shape),
                 "num_devices": mesh_device.get_num_devices(),
                 "fabric_config": fabric_config,
@@ -201,7 +220,6 @@ class MoE(SharedStateAddOn, AbstractModule):
                 "hidden_size": hf_config.hidden_size,
                 "num_experts_per_tok": hf_config.num_experts_per_tok,
                 "num_dispatch_devices": mesh_device.shape[0],
-                "expert_mapping_tensor": expert_mapping_tensor,
                 "moe_gate": MoEGate.model_config(hf_config, mesh_device, mode, topk_fallback=topk_fallback),
                 "all_to_all_dispatch_output_memory_config": memory_config,
                 "all_to_all_dispatch_metadata_memory_config": ttnn.DRAM_MEMORY_CONFIG,
@@ -240,54 +258,11 @@ class MoE(SharedStateAddOn, AbstractModule):
                     cluster_axis=1,
                 ),
             }
-
-            # optimized MoE ops only functional for quad torus
-            if fabric_config == ttnn.FabricConfig.FABRIC_1D_RING and mesh_device.shape[0] == 16:
-                batch = USERS_PER_ROW * mesh_device.shape[0]
-                seq_len = 1
-
-                decode_config["quad_ring_all_to_all_dispatch_metadata"] = AllToAllDispatchMetadataConfig(
-                    cluster_axis=0,
-                    worker_mode=ttnn.WorkerMode.DIRECT,
-                    dispatch_algorithm=ttnn.DispatchAlgorithm.SPARSE_MCAST_SHORTEST_PATH,
-                    output_tensors=AllToAllDispatchMetadataConfig.create_preallocated_dispatch_output_tensors(
-                        mesh_device,
-                        batch,
-                        HIDDEN_SIZE,
-                        hf_config.num_experts_per_tok,
-                    ),
-                )
-                decode_config["quad_ring_moreh_full"] = MorehFullConfig(
-                    shape=ttnn.Shape([hf_config.num_experts_per_tok, USERS_PER_ROW, hf_config.hidden_size]),
-                    fill_value=0,
-                    device=mesh_device,
-                    dtype=torch.bfloat16,
-                    layout=ttnn.ROW_MAJOR_LAYOUT,
-                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                )
-                decode_config["quad_ring_moe_compute"] = MoEComputeConfig(
-                    output_height_shard_dim=4,
-                    output_width_shard_dim=4,
-                    cluster_axis=0,
-                )
-                decode_config["quad_ring_selective_reduce_combine"] = SelectiveReduceCombineConfig(
-                    hidden_size=hf_config.hidden_size,
-                    batch=batch,
-                    seq=seq_len,
-                    select_experts_k=hf_config.num_experts_per_tok,
-                    experts=hf_config.n_routed_experts,
-                    axis=0,
-                    token_parallel_core_dim=4,
-                    data_parallel_core_dim=4,
-                    worker_cores=ttnn.experimental.get_moe_combine_cores(mesh_device),
-                    mux_core_range_set=ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(3, 0), ttnn.CoreCoord(4, 7))}),
-                )
-
-            return decode_config
         else:
             memory_config = ttnn.DRAM_MEMORY_CONFIG
+
             # Construct the config
-            return {
+            config = {
                 "mesh_device": MeshDeviceStub(mesh_device.shape),
                 "num_devices": mesh_device.get_num_devices(),
                 "fabric_config": fabric_config,
@@ -321,57 +296,43 @@ class MoE(SharedStateAddOn, AbstractModule):
                 ),
             }
 
-    @classmethod
-    def _create_expert_mapping_tensor(
-        cls,
-        mesh_device: ttnn.Device,
-        fabric_config: ttnn.FabricConfig,
-        mode: str,
-        num_experts_per_device: int,
-    ):
-        num_devices = mesh_device.get_num_devices()
-        if mode == "decode":
-            # optimized MoE ops only functional for quad torus
-            num_dispatch_devices = mesh_device.shape[0]
-            if fabric_config == ttnn.FabricConfig.FABRIC_1D_RING and num_dispatch_devices == 16:
-                num_experts = num_devices * num_experts_per_device
-                tp_size = mesh_device.shape[1]
-                num_experts_per_cluster = num_experts // tp_size
+        # configs for optimized ops (exclusive to quad with ring fabric)
+        if fabric_config == ttnn.FabricConfig.FABRIC_1D_RING and mesh_device.shape[0] == 16:
+            batch = USERS_PER_ROW * mesh_device.shape[0]
+            seq_len = 1
 
-                e = torch.arange(num_experts, dtype=torch.int32)
-                torch_expert_mapping_tensor = (
-                    (
-                        ((e % num_experts_per_cluster) // num_experts_per_device) * tp_size
-                        + (e // num_experts_per_cluster)
-                    )
-                    .unsqueeze(0)
-                    .repeat(num_devices, 1)
-                )
-            else:
-                torch_expert_mapping_tensor = (
-                    torch.eye(num_devices, dtype=torch.int32)
-                    .repeat_interleave(num_experts_per_device, dim=0)
-                    .unsqueeze(0)
-                    .unsqueeze(0)
-                )
-        else:
-            torch_expert_mapping_tensor = (
-                torch.eye(num_devices, dtype=torch.int32)
-                .repeat_interleave(num_experts_per_device, dim=0)
-                .unsqueeze(0)
-                .unsqueeze(0)
+            config["quad_ring_all_to_all_dispatch_metadata"] = AllToAllDispatchMetadataConfig(
+                cluster_axis=0,
+                worker_mode=ttnn.WorkerMode.DIRECT,
+                dispatch_algorithm=ttnn.DispatchAlgorithm.SPARSE_MCAST_SHORTEST_PATH,
+            )
+            config["quad_ring_moreh_full"] = MorehFullConfig(
+                shape=ttnn.Shape([hf_config.num_experts_per_tok, USERS_PER_ROW, hf_config.hidden_size]),
+                fill_value=0,
+                device=mesh_device,
+                dtype=torch.bfloat16,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+            config["quad_ring_moe_compute"] = MoEComputeConfig(
+                output_height_shard_dim=4,
+                output_width_shard_dim=4,
+                cluster_axis=0,
+            )
+            config["quad_ring_selective_reduce_combine"] = SelectiveReduceCombineConfig(
+                hidden_size=hf_config.hidden_size,
+                batch=batch,
+                seq=seq_len,
+                select_experts_k=hf_config.num_experts_per_tok,
+                experts=hf_config.n_routed_experts,
+                axis=0,
+                token_parallel_core_dim=4,
+                data_parallel_core_dim=4,
+                worker_cores=ttnn.experimental.get_moe_combine_cores(mesh_device),
+                mux_core_range_set=ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(3, 0), ttnn.CoreCoord(4, 7))}),
             )
 
-        expert_mapping_tensor = ttnn.from_torch(
-            torch_expert_mapping_tensor,
-            device=mesh_device,
-            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
-            dtype=ttnn.uint16,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            layout=ttnn.ROW_MAJOR_LAYOUT,
-        )
-
-        return expert_mapping_tensor
+        return config
 
     @classmethod
     def decode_model_config(
@@ -547,6 +508,7 @@ class MoE(SharedStateAddOn, AbstractModule):
                 topk_experts_indices,  # TODO: (GR) need to change shard spec of aho gate module output (once it's merged)
                 topk_experts_weights,  # TODO: (GR) need to change shard spec of aho gate module output (once it's merged)
                 cfg["expert_mapping_tensor"],
+                output_tensors=cfg["quad_ring_preallocated_all_to_all_dispatch_metadata_tensors"],
                 **ccl.populate_all_to_all_dispatch_metadata_args(cfg["quad_ring_all_to_all_dispatch_metadata"]),
             )
 

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -362,48 +362,11 @@ class MoE(SharedStateAddOn, AbstractModule):
         return cls.model_config(hf_config, mesh_device, fabric_config, "prefill", topk_fallback=topk_fallback)
 
     @classmethod
-    def _forward_decode(cls, x: ttnn.Tensor, cfg: RunDecodeConfig | RunPrefillConfig) -> ttnn.Tensor:
-        # Validate input dimensions
-        hidden_size = cfg["hidden_size"]
-        mesh_device = cfg.get("mesh_device")
-        tp_size = mesh_device.shape[1] if mesh_device else 1
-
-        x_dim = x.shape[-1]
-        expected_dims = [hidden_size, hidden_size // tp_size] if tp_size > 1 else [hidden_size]
-
-        if x_dim not in expected_dims:
-            raise ValueError(
-                f"MoE: Unexpected input dimension {x_dim}. Expected one of {expected_dims}. "
-                f"(hidden_size={hidden_size}, tp_size={tp_size})"
-            )
-
-        seq_len = 1  # a2a dispatch and combine require DP=num_dispatch_devices, hence in prefill for bs=1, we interchange the seq_len with batch_size dimensions
-        batch_size_per_device = x.shape[
-            -2
-        ]  # Input is expected to be DP. In prefill, this is equivalent to seq_len_per_device
-        batch_size = batch_size_per_device * cfg["num_dispatch_devices"]  # Global batch size
-
-        # Note: all_gather is handled by the caller (decoder block or test)
-
-        # MoE Gate
-        topk_experts_weights, topk_experts_indices = cls._fwd_moe_gate(x, cfg)
-
-        # MOE
-        post_combine_output_tensor = cls._fwd_decode_moe(
-            x,
-            topk_experts_indices,
-            topk_experts_weights,
-            cfg,
-            batch_size_per_device,
-            batch_size,
-            seq_len,
-        )
-
-        # Note: sum_experts and reduce_scatter is handled by the caller (decoder block or test)
-        return post_combine_output_tensor
+    def _forward_decode(cls, x: ttnn.Tensor, cfg: RunDecodeConfig) -> ttnn.Tensor:
+        return cls._forward_impl(x, cfg, "decode")
 
     @classmethod
-    def _forward_prefill(cls, x: ttnn.Tensor, cfg: RunDecodeConfig | RunPrefillConfig) -> ttnn.Tensor:
+    def _forward_prefill(cls, x: ttnn.Tensor, cfg: RunPrefillConfig) -> ttnn.Tensor:
         # Chunk the full MoE prefill path at 16K tokens to avoid OOM.
         # Use global token count (local seq_len * num_dispatch_devices) to decide.
         chunk_tokens = int(cfg.get("prefill_chunk_size", 16384))
@@ -412,7 +375,7 @@ class MoE(SharedStateAddOn, AbstractModule):
         if global_tokens > chunk_tokens:
             chunk_size = max(1, chunk_tokens // max(1, num_dispatch_devices))
             return cls._forward_chunked_prefill(x, cfg, chunk_size)
-        return cls._forward_prefill_impl(x, cfg)
+        return cls._forward_impl(x, cfg, "prefill")
 
     @classmethod
     def _forward_chunked_prefill(cls, x: ttnn.Tensor, cfg: RunPrefillConfig, chunk_size: int) -> ttnn.Tensor:
@@ -422,7 +385,7 @@ class MoE(SharedStateAddOn, AbstractModule):
         for start in range(0, seq_len, chunk_size):
             end = min(start + chunk_size, seq_len)
             x_chunk = ttnn.slice(x, [0, 0, start, 0], [x.shape[0], x.shape[1], end, x.shape[3]])
-            output_chunks.append(cls._forward_prefill_impl(x_chunk, cfg))
+            output_chunks.append(cls._forward_impl(x_chunk, cfg, "prefill"))
             ttnn.deallocate(x_chunk)
 
         if len(output_chunks) == 1:
@@ -433,7 +396,7 @@ class MoE(SharedStateAddOn, AbstractModule):
         return output
 
     @classmethod
-    def _forward_prefill_impl(cls, x: ttnn.Tensor, cfg: RunDecodeConfig | RunPrefillConfig) -> ttnn.Tensor:
+    def _forward_impl(cls, x: ttnn.Tensor, cfg: RunDecodeConfig | RunPrefillConfig, mode: str) -> ttnn.Tensor:
         # Validate input dimensions
         hidden_size = cfg["hidden_size"]
         mesh_device = cfg.get("mesh_device")
@@ -460,15 +423,26 @@ class MoE(SharedStateAddOn, AbstractModule):
         topk_experts_weights, topk_experts_indices = cls._fwd_moe_gate(x, cfg)
 
         # MOE
-        post_combine_output_tensor = cls._fwd_prefill_moe(
-            x,
-            topk_experts_indices,
-            topk_experts_weights,
-            cfg,
-            batch_size_per_device,
-            batch_size,
-            seq_len,
-        )
+        if mode == "decode":
+            post_combine_output_tensor = cls._fwd_decode_moe(
+                x,
+                topk_experts_indices,
+                topk_experts_weights,
+                cfg,
+                batch_size_per_device,
+                batch_size,
+                seq_len,
+            )
+        else:
+            post_combine_output_tensor = cls._fwd_prefill_moe(
+                x,
+                topk_experts_indices,
+                topk_experts_weights,
+                cfg,
+                batch_size_per_device,
+                batch_size,
+                seq_len,
+            )
 
         # Note: sum_experts and reduce_scatter is handled by the caller (decoder block or test)
         return post_combine_output_tensor
@@ -494,7 +468,7 @@ class MoE(SharedStateAddOn, AbstractModule):
         x: ttnn.Tensor,
         topk_experts_indices: ttnn.Tensor,
         topk_experts_weights: ttnn.Tensor,
-        cfg: RunDecodeConfig | RunPrefillConfig,
+        cfg: RunDecodeConfig,
         batch_size_per_device: int,
         batch_size: int,
         seq_len: int,
@@ -591,7 +565,7 @@ class MoE(SharedStateAddOn, AbstractModule):
         x: ttnn.Tensor,
         topk_experts_indices: ttnn.Tensor,
         topk_experts_weights: ttnn.Tensor,
-        cfg: RunDecodeConfig | RunPrefillConfig,
+        cfg: RunPrefillConfig,
         batch_size_per_device: int,
         batch_size: int,
         seq_len: int,

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -831,7 +831,7 @@ class MoE(SharedStateAddOn, AbstractModule):
 
         combine_output = ttnn.unsqueeze(combine_output, dim=1)
 
-        if batches_per_device == ttnn.TILE_SIZE:
+        if combine_output.shape[2] == ttnn.TILE_SIZE:
             combine_output = ttnn.experimental.deepseek_moe_post_combine_tilize(
                 combine_output,
                 **cfg["quad_ring_deepseek_moe_post_combine_tilize_config"],

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -830,9 +830,24 @@ class MoE(SharedStateAddOn, AbstractModule):
         ttnn.deallocate(compute_output_token_counts)
 
         combine_output = ttnn.unsqueeze(combine_output, dim=1)
-        combine_output = ttnn.experimental.deepseek_moe_post_combine_tilize(
-            combine_output, **cfg["quad_ring_deepseek_moe_post_combine_tilize_config"]
-        )
+
+        if batches_per_device == ttnn.TILE_SIZE:
+            combine_output = ttnn.experimental.deepseek_moe_post_combine_tilize(
+                combine_output,
+                **cfg["quad_ring_deepseek_moe_post_combine_tilize_config"],
+            )
+
+        else:
+            combine_output_shape = list(combine_output.shape)
+            combine_output_shape[2] = (
+                (combine_output_shape[2] + ttnn.TILE_SIZE - 1) // ttnn.TILE_SIZE
+            ) * ttnn.TILE_SIZE
+            combine_output = ttnn.tilize_with_val_padding(
+                combine_output,
+                output_tensor_shape=combine_output_shape,
+                pad_value=0.0,
+                memory_config=fg["quad_ring_deepseek_moe_post_combine_tilize_config"]["output_memory_config"],
+            )
 
         post_combine_output_tensor = ttnn.mul(
             combine_output, topk_experts_weights_for_scaling, **cfg["mul_experts_output_with_weights"]

--- a/models/demos/deepseek_v3/tt/mtp.py
+++ b/models/demos/deepseek_v3/tt/mtp.py
@@ -242,10 +242,12 @@ class MTP2D(AbstractModule):
         }
 
     @classmethod
-    def create_shared_state(cls, hf_config: PretrainedConfig, mesh_device: ttnn.MeshDevice) -> ModelState:
+    def create_shared_state(
+        cls, hf_config: PretrainedConfig, mesh_device: ttnn.MeshDevice, fabric_config: ttnn.FabricConfig
+    ) -> ModelState:
         logger.info("Creating MTP shared state...")
         decoder_block_start = perf_counter()
-        decoder_block_shared_state = MoEDecoderBlock2D.create_shared_state(hf_config, mesh_device)
+        decoder_block_shared_state = MoEDecoderBlock2D.create_shared_state(hf_config, mesh_device, fabric_config)
         logger.info(f"Created MTP decoder block shared state in {perf_counter() - decoder_block_start:.2f}s")
         return {
             "decoder_block": decoder_block_shared_state,

--- a/models/demos/deepseek_v3/utils/config_dataclass.py
+++ b/models/demos/deepseek_v3/utils/config_dataclass.py
@@ -458,6 +458,23 @@ class AllToAllDispatchMetadataConfig(OpConfigBase):
             preallocated_dispatch_output_expert_scores,
         )
 
+    @classmethod
+    def get_metadata_sharded_memory_config(cls, users_per_row: int, num_experts_per_tok: int):
+        num_cores_y = min(8, users_per_row)
+        num_cores_x = (users_per_row + num_cores_y - 1) // num_cores_y
+
+        return ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
+                ttnn.CoreRangeSet(
+                    {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_cores_x - 1, num_cores_y - 1))}
+                ),
+                [1, num_experts_per_tok],
+                ttnn.ShardOrientation.ROW_MAJOR,
+            ),
+        )
+
     cluster_axis: int | None = None
     num_links: int | None = 4
     worker_mode: ttnn.WorkerMode

--- a/models/demos/deepseek_v3/utils/config_dataclass.py
+++ b/models/demos/deepseek_v3/utils/config_dataclass.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass, fields
 from pathlib import Path
 from typing import Any, Union
 
+import torch
+
 import ttnn
 
 optimal_topology = ttnn.Topology.Ring if (os.getenv("USE_TORUS_MODE") is not None) else ttnn.Topology.Linear
@@ -394,6 +396,100 @@ class AllToAllCombineConfig(OpConfigBase):
     memory_config: ttnn.MemoryConfig
     num_links: int | None = None
     topology: ttnn.Topology = optimal_topology
+
+
+@dataclass
+class AllToAllDispatchMetadataConfig(OpConfigBase):
+    """Common parameters for a ttnn.all_to_all_dispatch_metadata op"""
+
+    @classmethod
+    def create_preallocated_dispatch_output_tensors(
+        mesh_device, mesh_shape, dispatch_devices, batch, hidden_size, num_experts_per_tok
+    ):
+        preallocated_dispatch_output_sparse_buffer = ttnn.from_torch(
+            torch.zeros([dispatch_devices, batch, hidden_size], dtype=torch.bfloat16),
+            device=mesh_device,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            dtype=ttnn.bfloat16,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(0, None), mesh_shape=mesh_shape),
+        )
+
+        preallocated_dispatch_output_expert_indices = ttnn.from_torch(
+            torch.zeros([dispatch_devices, batch, num_experts_per_tok], dtype=torch.uint16),
+            device=mesh_device,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            dtype=ttnn.uint16,
+            memory_config=ttnn.MemoryConfig(
+                ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+                ttnn.BufferType.L1,
+                ttnn.ShardSpec(
+                    ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(6, 9), ttnn.CoreCoord(6, 9))}),
+                    [batch, num_experts_per_tok],
+                    ttnn.ShardOrientation.ROW_MAJOR,
+                ),
+            ),
+            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(0, None), mesh_shape=mesh_shape),
+        )
+
+        preallocated_dispatch_output_expert_scores = ttnn.from_torch(
+            torch.zeros([dispatch_devices, batch, num_experts_per_tok], dtype=torch.bfloat16),
+            device=mesh_device,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            dtype=ttnn.bfloat16,
+            memory_config=ttnn.MemoryConfig(
+                ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+                ttnn.BufferType.L1,
+                ttnn.ShardSpec(
+                    ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(6, 9), ttnn.CoreCoord(6, 9))}),
+                    [batch, num_experts_per_tok],
+                    ttnn.ShardOrientation.ROW_MAJOR,
+                ),
+            ),
+            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(0, None), mesh_shape=mesh_shape),
+        )
+
+        return (
+            preallocated_dispatch_output_sparse_buffer,
+            preallocated_dispatch_output_expert_indices,
+            preallocated_dispatch_output_expert_scores,
+        )
+
+    cluster_axis: int | None = None
+    num_links: int | None = 4
+    worker_mode: ttnn.WorkerMode
+    dispatch_algorithm: ttnn.DispatchAlgorithm
+    output_tensors: list[ttnn.Tensor] | None = None
+    cross_device_semaphore: ttnn.global_semaphore.global_semaphore | None = None
+
+
+@dataclass
+class MoEComputeConfig(OpConfigBase):
+    """Common parameters for a ttnn.moe_compute op"""
+
+    output_height_shard_dim: int
+    output_width_shard_dim: int
+    cluster_axis: int | None = None
+
+
+@dataclass
+class SelectiveReduceCombineConfig(OpConfigBase):
+    """Common parameters for a ttnn.selective_reduce_combine op"""
+
+    hidden_size: int
+    batch: int
+    seq: int
+    select_experts_k: int
+    experts: int
+    axis: int | None = None
+    topology: ttnn.Topology = ttnn.Topology.Ring
+    num_links: int = 4
+    token_parallel_core_dim: int
+    data_parallel_core_dim: int
+    worker_cores: list[ttnn.CoreCoord]
+    mux_core_range_set: ttnn.CoreRangeset
+    output_tensor: ttnn.Tensor | None = None
+    optional_cross_device_semaphore: ttnn.global_semaphore.global_semaphore | None = None
 
 
 @dataclass

--- a/models/demos/deepseek_v3/utils/config_dataclass.py
+++ b/models/demos/deepseek_v3/utils/config_dataclass.py
@@ -403,7 +403,9 @@ class AllToAllDispatchMetadataConfig(OpConfigBase):
     """Common parameters for a ttnn.all_to_all_dispatch_metadata op"""
 
     @classmethod
-    def create_preallocated_dispatch_output_tensors(mesh_device, batch, hidden_size, num_experts_per_tok):
+    def create_preallocated_dispatch_output_tensors(
+        cls, mesh_device: ttnn.Device, batch: int, hidden_size: int, num_experts_per_tok: int
+    ):
         mesh_shape = mesh_device.shape
         dispatch_devices = mesh_shape[0]
 

--- a/models/demos/deepseek_v3/utils/config_dataclass.py
+++ b/models/demos/deepseek_v3/utils/config_dataclass.py
@@ -484,7 +484,9 @@ class AllToAllDispatchMetadataConfig(OpConfigBase):
 
 @dataclass
 class MorehFullConfig(OpConfigBase):
-    shape: ttnn.Shape
+    """Common parameters for a ttnn.moreh_full op"""
+
+    shape: list[int]
     fill_value: int
     device: ttnn.Device
     dtype: ttnn.DataType
@@ -518,6 +520,28 @@ class SelectiveReduceCombineConfig(OpConfigBase):
     topology: ttnn.Topology = ttnn.Topology.Ring
     num_links: int = 4
     optional_cross_device_semaphore: ttnn._ttnn.global_semaphore.global_semaphore | None = None
+
+
+@dataclass
+class DeepseekMoEPostCombineTilizeConfig(OpConfigBase):
+    """Common parameters for a ttnn.deepseek_moe_post_combine_tilize op"""
+
+    @classmethod
+    def get_sharded_memory_config(cls):
+        return ttnn.MemoryConfig(
+            buffer_type=ttnn.BufferType.L1,
+            nd_shard_spec=ttnn.NdShardSpec(
+                shard_shape=[32, 1024],
+                grid=ttnn.CoreRangeSet(
+                    {
+                        ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(6, 7)),
+                    }
+                ),
+                orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            ),
+        )
+
+    output_memory_config: ttnn.MemoryConfig
 
 
 @dataclass

--- a/models/demos/deepseek_v3/utils/config_dataclass.py
+++ b/models/demos/deepseek_v3/utils/config_dataclass.py
@@ -488,7 +488,7 @@ class MorehFullConfig(OpConfigBase):
     fill_value: int
     device: ttnn.Device
     dtype: ttnn.DataType
-    layout: ttnn.layout
+    layout: ttnn.Layout
     memory_config: ttnn.MemoryConfig
 
 

--- a/models/demos/deepseek_v3/utils/config_dataclass.py
+++ b/models/demos/deepseek_v3/utils/config_dataclass.py
@@ -477,6 +477,7 @@ class AllToAllDispatchMetadataConfig(OpConfigBase):
 
     worker_mode: ttnn.WorkerMode
     dispatch_algorithm: ttnn.DispatchAlgorithm
+    drain_sync_tilizer_core: tuple[int, int] | None = None
     cluster_axis: int | None = None
     num_links: int | None = 4
     cross_device_semaphore: ttnn._ttnn.global_semaphore.global_semaphore | None = None

--- a/models/demos/deepseek_v3/utils/config_dataclass.py
+++ b/models/demos/deepseek_v3/utils/config_dataclass.py
@@ -513,7 +513,7 @@ class SelectiveReduceCombineConfig(OpConfigBase):
     token_parallel_core_dim: int
     data_parallel_core_dim: int
     worker_cores: list[ttnn.CoreCoord]
-    mux_core_range_set: ttnn.CoreRangeset
+    mux_core_range_set: ttnn.CoreRangeSet
     axis: int | None = None
     topology: ttnn.Topology = ttnn.Topology.Ring
     num_links: int = 4

--- a/models/demos/deepseek_v3/utils/config_dataclass.py
+++ b/models/demos/deepseek_v3/utils/config_dataclass.py
@@ -403,9 +403,10 @@ class AllToAllDispatchMetadataConfig(OpConfigBase):
     """Common parameters for a ttnn.all_to_all_dispatch_metadata op"""
 
     @classmethod
-    def create_preallocated_dispatch_output_tensors(
-        mesh_device, mesh_shape, dispatch_devices, batch, hidden_size, num_experts_per_tok
-    ):
+    def create_preallocated_dispatch_output_tensors(mesh_device, batch, hidden_size, num_experts_per_tok):
+        mesh_shape = mesh_device.shape
+        dispatch_devices = mesh_shape[0]
+
         preallocated_dispatch_output_sparse_buffer = ttnn.from_torch(
             torch.zeros([dispatch_devices, batch, hidden_size], dtype=torch.bfloat16),
             device=mesh_device,
@@ -461,6 +462,16 @@ class AllToAllDispatchMetadataConfig(OpConfigBase):
     dispatch_algorithm: ttnn.DispatchAlgorithm
     output_tensors: list[ttnn.Tensor] | None = None
     cross_device_semaphore: ttnn.global_semaphore.global_semaphore | None = None
+
+
+@dataclass
+class MorehFullConfig(OpConfigBase):
+    shape: ttnn.Shape
+    fill_value: int
+    device: ttnn.Device
+    dtype: ttnn.DataType
+    layout: ttnn.layout
+    memory_config: ttnn.MemoryConfig
 
 
 @dataclass

--- a/models/demos/deepseek_v3/utils/config_dataclass.py
+++ b/models/demos/deepseek_v3/utils/config_dataclass.py
@@ -475,10 +475,10 @@ class AllToAllDispatchMetadataConfig(OpConfigBase):
             ),
         )
 
-    cluster_axis: int | None = None
-    num_links: int | None = 4
     worker_mode: ttnn.WorkerMode
     dispatch_algorithm: ttnn.DispatchAlgorithm
+    cluster_axis: int | None = None
+    num_links: int | None = 4
     cross_device_semaphore: ttnn._ttnn.global_semaphore.global_semaphore | None = None
 
 
@@ -510,14 +510,13 @@ class SelectiveReduceCombineConfig(OpConfigBase):
     seq: int
     select_experts_k: int
     experts: int
-    axis: int | None = None
-    topology: ttnn.Topology = ttnn.Topology.Ring
-    num_links: int = 4
     token_parallel_core_dim: int
     data_parallel_core_dim: int
     worker_cores: list[ttnn.CoreCoord]
     mux_core_range_set: ttnn.CoreRangeset
-    output_tensor: ttnn.Tensor | None = None
+    axis: int | None = None
+    topology: ttnn.Topology = ttnn.Topology.Ring
+    num_links: int = 4
     optional_cross_device_semaphore: ttnn._ttnn.global_semaphore.global_semaphore | None = None
 
 

--- a/models/demos/deepseek_v3/utils/config_dataclass.py
+++ b/models/demos/deepseek_v3/utils/config_dataclass.py
@@ -508,15 +508,15 @@ class SelectiveReduceCombineConfig(OpConfigBase):
     """Common parameters for a ttnn.selective_reduce_combine op"""
 
     hidden_size: int
-    batch: int
-    seq: int
+    batch_size: int
+    seq_size: int
     select_experts_k: int
     experts: int
     token_parallel_core_dim: int
     data_parallel_core_dim: int
     worker_cores: list[ttnn.CoreCoord]
     mux_core_range_set: ttnn.CoreRangeSet
-    axis: int | None = None
+    cluster_axis: int | None = None
     topology: ttnn.Topology = ttnn.Topology.Ring
     num_links: int = 4
     optional_cross_device_semaphore: ttnn._ttnn.global_semaphore.global_semaphore | None = None

--- a/models/demos/deepseek_v3/utils/config_dataclass.py
+++ b/models/demos/deepseek_v3/utils/config_dataclass.py
@@ -462,7 +462,6 @@ class AllToAllDispatchMetadataConfig(OpConfigBase):
     num_links: int | None = 4
     worker_mode: ttnn.WorkerMode
     dispatch_algorithm: ttnn.DispatchAlgorithm
-    output_tensors: list[ttnn.Tensor] | None = None
     cross_device_semaphore: ttnn.global_semaphore.global_semaphore | None = None
 
 

--- a/models/demos/deepseek_v3/utils/config_dataclass.py
+++ b/models/demos/deepseek_v3/utils/config_dataclass.py
@@ -479,7 +479,7 @@ class AllToAllDispatchMetadataConfig(OpConfigBase):
     num_links: int | None = 4
     worker_mode: ttnn.WorkerMode
     dispatch_algorithm: ttnn.DispatchAlgorithm
-    cross_device_semaphore: ttnn.global_semaphore.global_semaphore | None = None
+    cross_device_semaphore: ttnn._ttnn.global_semaphore.global_semaphore | None = None
 
 
 @dataclass
@@ -518,7 +518,7 @@ class SelectiveReduceCombineConfig(OpConfigBase):
     worker_cores: list[ttnn.CoreCoord]
     mux_core_range_set: ttnn.CoreRangeset
     output_tensor: ttnn.Tensor | None = None
-    optional_cross_device_semaphore: ttnn.global_semaphore.global_semaphore | None = None
+    optional_cross_device_semaphore: ttnn._ttnn.global_semaphore.global_semaphore | None = None
 
 
 @dataclass

--- a/models/demos/deepseek_v3/utils/config_helpers.py
+++ b/models/demos/deepseek_v3/utils/config_helpers.py
@@ -22,9 +22,21 @@ NORM_CATEGORIES = {"attention_norm", "mlp_norm", "q_norm", "k_norm"}
 QUAD_MESH_SHAPE = (16, 8)
 
 
-def is_quad_ring(mesh_device: ttnn.Device) -> bool:
-    """Check whether the given mesh device has a QUAD configuration (16x8) and ring fabric topology."""
-    return tuple(mesh_device.shape) == QUAD_MESH_SHAPE and (os.getenv("USE_TORUS_MODE") is not None)
+def get_fabric_config():
+    """Get the fabric config for the model."""
+    return (
+        ttnn.FabricConfig.FABRIC_1D_RING if (os.getenv("USE_TORUS_MODE") is not None) else ttnn.FabricConfig.FABRIC_1D
+    )
+
+
+def is_ring_fabric(fabric_config: ttnn.FabricConfig):
+    """Check whether the given fabric config has a RING configuration"""
+    return fabric_config == ttnn.FabricConfig.FABRIC_1D_RING
+
+
+def is_quad_mesh(mesh_device: ttnn.Device) -> bool:
+    """Check whether the given mesh device has a QUAD configuration (16x8)"""
+    return tuple(mesh_device.shape) == QUAD_MESH_SHAPE
 
 
 USERS_PER_ROW = 32

--- a/models/demos/deepseek_v3/utils/config_helpers.py
+++ b/models/demos/deepseek_v3/utils/config_helpers.py
@@ -19,24 +19,23 @@ from models.demos.deepseek_v3.utils.lazy_state_dict import LazyStateDict
 
 # Constants
 NORM_CATEGORIES = {"attention_norm", "mlp_norm", "q_norm", "k_norm"}
-QUAD_MESH_SHAPE = (16, 8)
 
 
-def get_fabric_config():
+def get_fabric_config() -> ttnn.FabricConfig:
     """Get the fabric config for the model."""
     return (
         ttnn.FabricConfig.FABRIC_1D_RING if (os.getenv("USE_TORUS_MODE") is not None) else ttnn.FabricConfig.FABRIC_1D
     )
 
 
-def is_ring_fabric(fabric_config: ttnn.FabricConfig):
+def is_ring_fabric(fabric_config: ttnn.FabricConfig) -> bool:
     """Check whether the given fabric config has a RING configuration"""
     return fabric_config == ttnn.FabricConfig.FABRIC_1D_RING
 
 
-def is_quad_mesh(mesh_device: ttnn.Device) -> bool:
+def is_quad_mesh() -> bool:
     """Check whether the given mesh device has a QUAD configuration (16x8)"""
-    return tuple(mesh_device.shape) == QUAD_MESH_SHAPE
+    return os.getenv("MESH_DEVICE") == "QUAD"
 
 
 USERS_PER_ROW = 32

--- a/models/demos/deepseek_v3/utils/config_helpers.py
+++ b/models/demos/deepseek_v3/utils/config_helpers.py
@@ -19,6 +19,14 @@ from models.demos.deepseek_v3.utils.lazy_state_dict import LazyStateDict
 
 # Constants
 NORM_CATEGORIES = {"attention_norm", "mlp_norm", "q_norm", "k_norm"}
+QUAD_MESH_SHAPE = (16, 8)
+
+
+def is_quad_mesh(mesh_device: ttnn.Device) -> bool:
+    """Check whether the given mesh device has a QUAD configuration (16x8)."""
+    return tuple(mesh_device.shape) == QUAD_MESH_SHAPE
+
+
 USERS_PER_ROW = 32
 SEQ_LEN_CHUNK_SIZE = 1024  # NOTE: should be 512 for blackhole (in case of future bring-up)
 TOPK_MIN_WIDTH = 64  # Minimum width of the topk input tensor

--- a/models/demos/deepseek_v3/utils/config_helpers.py
+++ b/models/demos/deepseek_v3/utils/config_helpers.py
@@ -14,7 +14,6 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.demos.deepseek_v3.tt.model.row_batched_model import get_fabric_config
 from models.demos.deepseek_v3.utils.config_dataclass import DeepseekSamplingArgs, SavedWeight
 from models.demos.deepseek_v3.utils.lazy_state_dict import LazyStateDict
 
@@ -25,7 +24,7 @@ QUAD_MESH_SHAPE = (16, 8)
 
 def is_quad_ring(mesh_device: ttnn.Device) -> bool:
     """Check whether the given mesh device has a QUAD configuration (16x8) and ring fabric topology."""
-    return tuple(mesh_device.shape) == QUAD_MESH_SHAPE and get_fabric_config() == ttnn.FabricConfig.FABRIC_1D_RING
+    return tuple(mesh_device.shape) == QUAD_MESH_SHAPE and (os.getenv("USE_TORUS_MODE") is not None)
 
 
 USERS_PER_ROW = 32

--- a/models/demos/deepseek_v3/utils/config_helpers.py
+++ b/models/demos/deepseek_v3/utils/config_helpers.py
@@ -14,6 +14,7 @@ import torch
 from loguru import logger
 
 import ttnn
+from models.demos.deepseek_v3.tt.model.row_batched_model import get_fabric_config
 from models.demos.deepseek_v3.utils.config_dataclass import DeepseekSamplingArgs, SavedWeight
 from models.demos.deepseek_v3.utils.lazy_state_dict import LazyStateDict
 
@@ -22,9 +23,9 @@ NORM_CATEGORIES = {"attention_norm", "mlp_norm", "q_norm", "k_norm"}
 QUAD_MESH_SHAPE = (16, 8)
 
 
-def is_quad_mesh(mesh_device: ttnn.Device) -> bool:
-    """Check whether the given mesh device has a QUAD configuration (16x8)."""
-    return tuple(mesh_device.shape) == QUAD_MESH_SHAPE
+def is_quad_ring(mesh_device: ttnn.Device) -> bool:
+    """Check whether the given mesh device has a QUAD configuration (16x8) and ring fabric topology."""
+    return tuple(mesh_device.shape) == QUAD_MESH_SHAPE and get_fabric_config() == ttnn.FabricConfig.FABRIC_1D_RING
 
 
 USERS_PER_ROW = 32

--- a/models/demos/deepseek_v3/utils/config_helpers.py
+++ b/models/demos/deepseek_v3/utils/config_helpers.py
@@ -52,12 +52,6 @@ DEFAULT_SAMPLING_TOP_P = 0.95
 DEFAULT_SAMPLING_TOP_K = 32
 
 
-def get_fabric_config():
-    return (
-        ttnn.FabricConfig.FABRIC_1D_RING if (os.getenv("USE_TORUS_MODE") is not None) else ttnn.FabricConfig.FABRIC_1D
-    )
-
-
 def make_deepseek_sampling_args(
     mesh_device,
     vocab_size: int,

--- a/models/demos/deepseek_v3/utils/config_helpers.py
+++ b/models/demos/deepseek_v3/utils/config_helpers.py
@@ -38,6 +38,7 @@ def is_quad_mesh() -> bool:
     return os.getenv("MESH_DEVICE") == "QUAD"
 
 
+OPTIMIZED_MOE_BLOCK_USERS_PER_ROW = 32
 USERS_PER_ROW = 32
 SEQ_LEN_CHUNK_SIZE = 1024  # NOTE: should be 512 for blackhole (in case of future bring-up)
 TOPK_MIN_WIDTH = 64  # Minimum width of the topk input tensor

--- a/tests/nightly/tg/ccl/moe/test_all_to_all_dispatch_metadata_6U.py
+++ b/tests/nightly/tg/ccl/moe/test_all_to_all_dispatch_metadata_6U.py
@@ -654,8 +654,8 @@ def run_all_to_all_dispatch_metadata_test(
     indirect=["mesh_device"],
 )
 @pytest.mark.parametrize("experts_per_device", [2])
-def test_correctness(mesh_device, mesh_shape, cluster_axis, experts_per_device):
-    batches_per_device = 32
+@pytest.mark.parametrize("batches_per_device", [3, 8, 16, 32])
+def test_correctness(mesh_device, mesh_shape, cluster_axis, experts_per_device, batches_per_device):
     experts = experts_per_device * mesh_shape[cluster_axis]
     select_experts_k = 8
     hidden_size = 7168

--- a/tests/nightly/tg/ccl/moe/test_moe_compute_6U.py
+++ b/tests/nightly/tg/ccl/moe/test_moe_compute_6U.py
@@ -604,6 +604,54 @@ def prepare_w2_tensor(torch_w2, L, E, N, K, ring2cores):
     return all_groups_per_bank
 
 
+def get_w0_w1_memory_config(num_layers, experts_per_device, hidden_size, compute_matmul_dram_core_range_set):
+    w0_w1_shard_height = num_layers * experts_per_device * 3 * hidden_size
+    w0_w1_shard_width = 4 * ttnn.TILE_SIZE
+    w0_w1_shard_spec = ttnn.ShardSpec(
+        compute_matmul_dram_core_range_set, (w0_w1_shard_height, w0_w1_shard_width), ttnn.ShardOrientation.ROW_MAJOR
+    )
+    w0_w1_memory_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.DRAM, w0_w1_shard_spec
+    )
+    return w0_w1_memory_config
+
+
+def get_w2_memory_config(num_layers, experts_per_device, matmul_N, compute_matmul_dram_core_range_set):
+    w2_shard_height = num_layers * experts_per_device * 5 * (matmul_N + 192)
+    w2_shard_width = 4 * ttnn.TILE_SIZE
+    w2_shard_spec = ttnn.ShardSpec(
+        compute_matmul_dram_core_range_set, (w2_shard_height, w2_shard_width), ttnn.ShardOrientation.ROW_MAJOR
+    )
+    w2_memory_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.DRAM, w2_shard_spec)
+    return w2_memory_config
+
+
+def determine_compute_matmul_cores(mesh_device):
+    MATMUL_FULL_CORES = {0, 3, 6, 9}
+    MATMUL_PAD_CORES = {1, 2, 4, 5, 7, 8, 10, 11}
+
+    in0_core_coords = ttnn.device.get_optimal_dram_bank_to_logical_worker_assignment(mesh_device, 0)
+    core2dram = {}
+    for dram_bank_id, core_coords in enumerate(in0_core_coords):
+        core2dram[core_coords] = dram_bank_id
+
+    in0_num_cores = len(in0_core_coords)
+
+    # Make a new list of core coords that are sorted in decreasing order by y coordinate and then x coordinate.
+    in0_core_coords_sorted = sorted(in0_core_coords, key=lambda x: (x.y, x.x), reverse=True)
+
+    ring2cores = {}
+    for ring_pos, core_coord in enumerate(in0_core_coords_sorted):
+        # key: ring_pos, value: (core_coord, dram_bank_id, pad_flag)
+        ring2cores[ring_pos] = (core_coord, core2dram[core_coord], 1 if ring_pos in MATMUL_PAD_CORES else 0)
+
+    dram_core_coords = [ttnn.CoreCoord(ring2cores[i][1], 0) for i in range(in0_num_cores)]
+    dram_core_range = [ttnn.CoreRange(dram_core_coord, dram_core_coord) for dram_core_coord in dram_core_coords]
+    dram_core_range_set = ttnn.CoreRangeSet(dram_core_range)
+
+    return ring2cores, dram_core_range_set
+
+
 def tt_to_torch_dtype(tt_dtype):
     if tt_dtype == ttnn.bfloat16:
         return torch.bfloat16
@@ -1226,30 +1274,7 @@ def test_moe_compute(
     # --------------------------------------------------------------------------
     # Shard grid
     # --------------------------------------------------------------------------
-    MATMUL_FULL_CORES_A = {0, 1, 8, 9}
-    MATMUL_PAD_CORES_A = {2, 3, 4, 5, 6, 7, 10, 11}
-
-    MATMUL_FULL_CORES_B = {0, 3, 6, 9}
-    MATMUL_PAD_CORES_B = {1, 2, 4, 5, 7, 8, 10, 11}
-
-    in0_core_coords = ttnn.device.get_optimal_dram_bank_to_logical_worker_assignment(mesh_device, 0)
-    core2dram = {}
-    for dram_bank_id, core_coords in enumerate(in0_core_coords):
-        core2dram[core_coords] = dram_bank_id
-
-    in0_num_cores = len(in0_core_coords)
-
-    # Make a new list of core coords that are sorted in decreasing order by y coordinate and then x coordinate.
-    in0_core_coords_sorted = sorted(in0_core_coords, key=lambda x: (x.y, x.x), reverse=True)
-
-    ring2cores = {}
-    for ring_pos, core_coord in enumerate(in0_core_coords_sorted):
-        # key: ring_pos, value: (core_coord, dram_bank_id, pad_flag)
-        ring2cores[ring_pos] = (core_coord, core2dram[core_coord], 1 if ring_pos in MATMUL_PAD_CORES_B else 0)
-
-    dram_core_coords = [ttnn.CoreCoord(ring2cores[i][1], 0) for i in range(in0_num_cores)]
-    dram_core_range = [ttnn.CoreRange(dram_core_coord, dram_core_coord) for dram_core_coord in dram_core_coords]
-    dram_core_range_set = ttnn.CoreRangeSet(dram_core_range)
+    ring2cores, dram_core_range_set = determine_compute_matmul_cores(mesh_device)
 
     torch_w0 = create_torch_w0(num_layers, experts_per_device, hidden_size, N)
     torch_w1 = create_torch_w1(num_layers, experts_per_device, hidden_size, N)
@@ -1273,27 +1298,13 @@ def test_moe_compute(
     # Create DRAM shard spec for w0_w1
     # Tensor shape: (num_layers, experts_per_device, hidden_size, 4608) -> padded and reordered to (12, num_layers, experts_per_device, 6, hidden_size, 64)
     # ------------------------------------------------------------------------
-    w0_w1_shard_height = num_layers * experts_per_device * 3 * hidden_size
-    w0_w1_shard_width = 4 * ttnn.TILE_SIZE
-
-    w0_w1_shard_spec = ttnn.ShardSpec(
-        dram_core_range_set, (w0_w1_shard_height, w0_w1_shard_width), ttnn.ShardOrientation.ROW_MAJOR
-    )
-
-    w0_w1_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.DRAM, w0_w1_shard_spec)
+    w0_w1_mem_config = get_w0_w1_memory_config(num_layers, experts_per_device, hidden_size, dram_core_range_set)
 
     # ------------------------------------------------------------------------
     # Create DRAM shard spec for w2
     # Tensor shape: (num_layers, experts_per_device, N, hidden_size) -> padded and reordered to (12, num_layers, experts_per_device, 5, N + 192, 128)
     # ------------------------------------------------------------------------
-    w2_shard_height = num_layers * experts_per_device * 5 * (N + 192)
-    w2_shard_width = 4 * ttnn.TILE_SIZE
-
-    w2_shard_spec = ttnn.ShardSpec(
-        dram_core_range_set, (w2_shard_height, w2_shard_width), ttnn.ShardOrientation.ROW_MAJOR
-    )
-
-    w2_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.DRAM, w2_shard_spec)
+    w2_mem_config = get_w2_memory_config(num_layers, experts_per_device, N, dram_core_range_set)
 
     # ------------------------------------------------------------------------
     # Prepare w0_w1 tensor (interleaved, padded, and reordered)

--- a/tests/nightly/tg/ccl/moe/test_moe_compute_6U.py
+++ b/tests/nightly/tg/ccl/moe/test_moe_compute_6U.py
@@ -289,9 +289,11 @@ def prepare_output_tensor_from_combine_writer(
 
             torch_output[e, t] = contrib
 
-            if output_token_shard_row == (
-                tokens_per_shard_chunk if output_token_shard < tokens_per_shard_rem else tokens_per_shard_chunk - 1
-            ):
+            # Determine how many tokens this shard should have
+            # First tokens_per_shard_rem shards get one extra token
+            tokens_in_this_shard = tokens_per_shard_chunk + (1 if output_token_shard < tokens_per_shard_rem else 0)
+
+            if output_token_shard_row + 1 == tokens_in_this_shard:
                 output_token_shard += 1
                 output_token_shard_row = 0
             else:
@@ -341,10 +343,13 @@ def validate_matmul(
 
     matmul_all_passed = True
 
-    MATMUL_PCC_THRESHOLD = 0.987
+    # smaller batch -> smaller dataset so PCC is less stable. A lower threshold is acceptable.
+    MATMUL_PCC_THRESHOLD = 0.987 if total_tokens == 512 else 0.986
     for d in range(devices):
         for expert_id in range(experts_per_device):
             active_tokens = expert_token_counts[d, expert_id].item()
+            if active_tokens == 0:
+                continue
             # torch_output_ref is (L, D, E/D, T, H)
             torch_layer_output = torch_output_ref[layer_id, d, expert_id, :active_tokens, :]
             tt_layer_output = reshaped_device_outputs[d, expert_id, :active_tokens, :]
@@ -1064,7 +1069,7 @@ def create_sharded_memory_config(core_range_set, tensor_shape, dtype):
 )
 @pytest.mark.parametrize("cluster_axis", [1])
 @pytest.mark.parametrize("experts_per_device", [2])
-@pytest.mark.parametrize("tokens_per_device", [32])  # Collapsed batch * seq_len
+@pytest.mark.parametrize("tokens_per_device", [3, 8, 16, 32])  # Collapsed batch * seq_len
 @pytest.mark.parametrize(
     "selected_experts_k, num_layers, num_iterations",
     [(1, 1, 1), (8, 5, 1)],
@@ -1072,7 +1077,7 @@ def create_sharded_memory_config(core_range_set, tensor_shape, dtype):
 )
 @pytest.mark.parametrize("N, hidden_size", [(2048, 7168)])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])
-@pytest.mark.parametrize("enable_trace", [True, False])
+@pytest.mark.parametrize("enable_trace", [False, True])
 @pytest.mark.parametrize("output_height_shard_dim", [4])
 @pytest.mark.parametrize("output_width_shard_dim", [4])
 def test_moe_compute(

--- a/tests/nightly/tg/ccl/moe/test_selective_combine_6U.py
+++ b/tests/nightly/tg/ccl/moe/test_selective_combine_6U.py
@@ -685,7 +685,7 @@ def _run_test(
     ],
     indirect=["mesh_device"],
 )
-@pytest.mark.parametrize("batch", [512, 128, 64])
+@pytest.mark.parametrize("batch", [512, 128, 64, 48])
 @pytest.mark.parametrize("select_experts_k", [1, 2, 8])
 @pytest.mark.parametrize("hidden_size", [7168])
 @pytest.mark.parametrize("seq", [1])

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/reader_all_to_all_dispatch_metadata.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/reader_all_to_all_dispatch_metadata.cpp
@@ -81,6 +81,10 @@ void kernel_main() {
     const auto mapping_addr_gen = TensorAccessor(mapping_args, mapping_tensor_address, mapping_page_size);
     const auto metadata_addr_gen = TensorAccessor(metadata_args, metadata_tensor_address, metadata_page_size);
 
+    if (token_start_idx == token_end_idx) {
+        return;
+    }
+
     // Read the expert mapping table - new format: [devices, experts]
     // Each page is one device's view of the mapping. Read only the source device's page.
     // Page index = linearized_mesh_coord (source device index)

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/writer_all_to_all_dispatch_metadata.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/writer_all_to_all_dispatch_metadata.cpp
@@ -909,6 +909,10 @@ void kernel_main() {
     constexpr uint32_t num_directions = 4;
     constexpr std::array<bool, num_directions> directions = DIRECTIONS;
 
+    if (token_start_idx == token_end_idx) {
+        return;
+    }
+
 #ifdef USE_MUX
     // ========================================================================
     // MUX PATH: Use WorkerToFabricMuxSender connections via fabric mux

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.cpp
@@ -226,8 +226,16 @@ ttnn::device_operation::CachedProgram<UnifiedSelectReduce::shared_variables_t> U
     // buffer padding NOT supported because we don't rely on tensor shapes to represent the data layout
     const auto token_segment_buffer_size_bytes =
         *std::max_element(data_parallel_sizes_bytes.begin(), data_parallel_sizes_bytes.end());
-    const auto expert_token_segment_buffer_block_size_bytes =
-        token_segment_buffer_size_bytes * total_tokens / num_token_parallel_cores;
+
+    // slightly awkward. we want the token dimension but the underlying shape might not represent the data layout.
+    //  This is in line with the assumption that tokens are split across the entirety of the shard, regardless of
+    //  number of tokens
+    const auto input_shards = input_tensor.memory_config().shard_spec()->grid.num_cores();
+    const auto token_expert_row_offset = input_tensor.logical_shape().volume() / input_shards /
+                                         (hidden_size / num_data_parallel_cores / experts_per_device) /
+                                         num_token_parallel_cores;
+    const auto expert_token_segment_buffer_block_size_bytes = token_segment_buffer_size_bytes * token_expert_row_offset;
+
     const auto buffer_size_bytes = expert_token_segment_buffer_block_size_bytes * experts_per_device;
 
     const auto input_data_format = datatype_to_dataformat_converter(input_tensor.dtype());

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp
@@ -442,8 +442,12 @@ void kernel_main() {
         uint64_t drain_scores_noc_addr = get_noc_addr(drain_core_noc_x, drain_core_noc_y, local_scores_addr);
 
         // NOC read indices and scores for this core's token range
-        noc_async_read(drain_indices_noc_addr, local_indices_addr, num_tokens_this_core * aligned_indices_page_size);
-        noc_async_read(drain_scores_noc_addr, local_scores_addr, num_tokens_this_core * aligned_scores_page_size);
+
+        if (num_tokens_this_core > 0) {
+            noc_async_read(
+                drain_indices_noc_addr, local_indices_addr, num_tokens_this_core * aligned_indices_page_size);
+            noc_async_read(drain_scores_noc_addr, local_scores_addr, num_tokens_this_core * aligned_scores_page_size);
+        }
     }
 
     // Wait for all reads to complete (mapping + indices/scores for non-drain)
@@ -733,7 +737,9 @@ void kernel_main() {
         // Write to DRAM: activated rows (num_activated_tokens) rows
         uint32_t expert_activation_write_size = num_activated_tokens * aligned_activation_row_bytes;
         uint64_t expert_activation_dram_addr = get_noc_addr(0, expert_activation_output_tensor_addr_gen);
-        noc_async_write(expert_activation_base, expert_activation_dram_addr, expert_activation_write_size);
+        if (num_activated_tokens > 0) {
+            noc_async_write(expert_activation_base, expert_activation_dram_addr, expert_activation_write_size);
+        }
         // Barrier for this write is at the very end of the kernel
 
         // DEBUG: print_e_t_buffer<experts_per_device, tokens, e_t_entry_size>(e_t_cb_id);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_program_factory.cpp
@@ -435,7 +435,7 @@ MoEComputeMeshWorkloadFactory::create_at(
         tilize_e_t_output_data_format);
 
     // Assume indices tensor is sharded in L1
-    tt::tt_metal::create_cb(
+    const auto indices_cb_output = tt::tt_metal::create_cb(
         indices_tensor_cb_id,
         program,
         tilize_core_range_set,
@@ -443,9 +443,10 @@ MoEComputeMeshWorkloadFactory::create_at(
         tilize_indices_pages,  // double buffer buffer packets
         tilize_indices_data_format,
         tilize_indices_tensor.buffer());
+    const auto indices_cb_handle = std::get<1>(indices_cb_output);
 
     // Assume scores tensor is sharded in L1
-    tt::tt_metal::create_cb(
+    const auto scores_cb_output = tt::tt_metal::create_cb(
         scores_tensor_cb_id,
         program,
         tilize_core_range_set,
@@ -453,6 +454,7 @@ MoEComputeMeshWorkloadFactory::create_at(
         tilize_input_scores_pages,
         tilize_input_scores_data_format,
         tilize_input_scores_tensor.buffer());
+    const auto scores_cb_handle = std::get<1>(scores_cb_output);
 
     // For each batch's tokens, we need to read the relevant experts from the mapping tensor
     // For in range (tokens) every time tokens/batch increments, read in new mapping tensor page
@@ -761,6 +763,8 @@ MoEComputeMeshWorkloadFactory::create_at(
         "ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_compute.cpp",
         tilize_core_range_set,
         tt::tt_metal::ComputeConfig{.named_compile_args = compute_tilize_named_compile_time_args});
+
+    std::cout << "PROGRAM FACTORY: " << tilize_indices_tensor.buffer()->address() << std::endl;
 
     std::vector<uint32_t> tilize_runtime_args = {
         tilize_input_tensor.buffer()->address(),                           // 0
@@ -1083,8 +1087,10 @@ MoEComputeMeshWorkloadFactory::create_at(
          .tilize_cores = tilize_cores,
          .matmul_kernel_handles = {matmul_dm0_kernel_handle, matmul_dm1_kernel_handle, matmul_compute_kernel_handle},
          .matmul_cores = matmul_cores,
+         .indices_cb_handle = indices_cb_handle,
+         .scores_cb_handle = scores_cb_handle,
          .sharded_output_cb_handle = sharded_output_cb_handle,
-         .matmul_writer_cb_handle=matmul_writer_cb_handle}};
+         .matmul_writer_cb_handle = matmul_writer_cb_handle}};
 }
 
 void MoEComputeMeshWorkloadFactory::override_runtime_arguments(
@@ -1103,6 +1109,12 @@ void MoEComputeMeshWorkloadFactory::override_runtime_arguments(
 
         // Update sharded circular buffer address
         tt::tt_metal::UpdateDynamicCircularBufferAddress(
+            program, shared_variables.indices_cb_handle, *tensor_args.tilize_expert_indices_tensor.buffer());
+
+        tt::tt_metal::UpdateDynamicCircularBufferAddress(
+            program, shared_variables.scores_cb_handle, *tensor_args.tilize_expert_scores_tensor.buffer());
+
+        tt::tt_metal::UpdateDynamicCircularBufferAddress(
             program, shared_variables.sharded_output_cb_handle, *tilize_output_tensor.buffer());
 
         tt::tt_metal::UpdateDynamicCircularBufferAddress(
@@ -1111,6 +1123,7 @@ void MoEComputeMeshWorkloadFactory::override_runtime_arguments(
         //-------------------------------------------------------------------------
         // Tilize
         //-------------------------------------------------------------------------
+
         for (const auto& core : shared_variables.tilize_cores) {
             // reader
             auto& tilize_reader_runtime_args =

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_program_factory.cpp
@@ -764,8 +764,6 @@ MoEComputeMeshWorkloadFactory::create_at(
         tilize_core_range_set,
         tt::tt_metal::ComputeConfig{.named_compile_args = compute_tilize_named_compile_time_args});
 
-    std::cout << "PROGRAM FACTORY: " << tilize_indices_tensor.buffer()->address() << std::endl;
-
     std::vector<uint32_t> tilize_runtime_args = {
         tilize_input_tensor.buffer()->address(),                           // 0
         tilize_indices_tensor.buffer()->address(),                         // 1

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_program_factory.hpp
@@ -24,6 +24,12 @@ struct MoEComputeMeshWorkloadFactory {
         // Matmul cores
         std::vector<CoreCoord> matmul_cores;
 
+        // CB handle for tensor backed indices tensor
+        tt::tt_metal::CBHandle indices_cb_handle;
+
+        // CB handle for tensor backed scores tensor
+        tt::tt_metal::CBHandle scores_cb_handle;
+
         // CB handle for shared global sharded tensor
         tt::tt_metal::CBHandle sharded_output_cb_handle;
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/38704)

### Issue tracking integration work
https://github.com/tenstorrent/tt-metal/issues/40412

### Misc
- Reference unit test for optimized MoE sequence: `/models/demos/deepseek_v3/tests/fused_op_unit_tests/moe/test_optimized_moe_decode_block.py`
- GPT OSS integration: https://github.com/tenstorrent/tt-metal/pull/40174

### What's changed
- Integrate optimized MoE ops into model for high batch deepseek
  - Ops are exclusive to quad and running with ring fabric
  - Ops require new format for expert weights
  - Based off Nov 25 2025 spreadsheet, cuts decode MoE sequence time from `9620 us` to `578 us`
- Ops are designed specifically for decode shapes, however since the model doesn't have disaggregated prefill and decode (meaning we can't have separate weights for prefill and decode), we are temporarily using them for prefill via a chunking method
  - Going forward, we'll want to adjust this prefill strategy, the 2 proposed current approaches are:
    - Uplifting the optimized ops to be functional for prefill shapes
    - Updating the existing prefill MMs to be able to read weights that are formatted for decode
- Followup tasks include
  - Stress testing quad model to determine if ND hang discovered during week of March 9th still occurs
  - Integrate fused `moe_compute` and `selective_reduce_tilize`
    - Estimated to save `~ 45 us` off our `578 us` number
  - Move metadata processing from `moe_compute` to `all_to_all_dispatch_metadata`
    - Estimated to save `~ 10 us` off our `578 us` number
  - Fuse `ttnn.moreh_full` into `all_to_all_dispatch_metadata`
    - Estimated to save `37 us` off our `578 us` number
  - Integrating optimized moe gate
    - Gate time not included in the `9620 us` or `578 us` numbers quoted above

### Testing

- Single GLX Pipeline Passing: https://github.com/tenstorrent/tt-metal/actions/runs/23253819817
  - Indicates non-optimized code paths remain functional
- Dual Pipline: https://github.com/tenstorrent/tt-metal/actions/runs/23262041185
  - Passing all but 2 tests, both of which have save permissions error as run on main: https://github.com/tenstorrent/tt-metal/actions/runs/23178785447
  - Will re-run after rebase that picks up other dependent changes
- TODO:
  - Test optimized code path on quad
    - Blocked by quad model functionality on main

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:{{branch_name}})
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
