### PR TITLE
[skip ci] Link instructions to /models dir for clarity

### DIFF
--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -85,7 +85,7 @@ All binaries support only Linux and distros with glibc 2.34 or newer.
 
 #### Step 2. (For models users only) Set Up Environment for Models:
 
-To try our pre-built models in `models/`, you must:
+To try our pre-built models in [`tt-metal/models/`](https://github.com/tenstorrent/tt-metal/tree/main/models), you must:
 
   - Install their required dependencies
   - Set appropriate environment variables


### PR DESCRIPTION
### Ticket
[No explanation about the models/ folder #31500](https://github.com/tenstorrent/tt-metal/issues/31500)

### What's changed
Added a link to `tt-metal/models` dir in instructions to add clarity for users reading from docs.tenstorrent.com 