### PR TITLE
Fix DRAM group_norm fallback for invalid y-grid

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
@@ -202,13 +202,18 @@ Tensor group_norm(
     auto kernel_config_val =
         init_device_compute_kernel_config(arch, compute_kernel_config, math_fidelity, approx_mode, fp32_acc);
 
-    // For non-sharded DRAM tensors, validate that the requested core grid is not too
-    // large for the input spatial dimensions. The constraint is Ht >= num_virtual_rows,
-    // where num_virtual_rows = (grid_x / num_virtual_cols) * grid_y and Ht = NHW / TILE_SIZE.
-    // Violating this leads to per_core_Mt == 0, causing division-by-zero in kernels.
+    // For non-sharded DRAM tensors, use a core grid that fits the input spatial dimensions.
+    // If the requested grid is invalid (e.g. Ht not divisible by num_virtual_rows), use the
+    // largest valid grid within the requested bounds instead of throwing (see issue #39806).
     if (!input_tensor.is_sharded()) {
         const uint32_t W = input_padded_shape[3];
         const uint32_t Ht = nhw / ttnn::types::TILE_SIZE;
+        const CoreGrid requested = core_grid.value();
+        auto valid_grid =
+            operations::normalization::find_expected_dram_grid(requested.x, requested.y, W, num_groups, nhw);
+        if (valid_grid.has_value() && valid_grid->x == requested.x) {
+            core_grid = *valid_grid;
+        }
         validate_dram_grid(core_grid.value(), W, Ht, num_groups);
     }
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/39806

### Problem description
`ttnn.group_norm` fails for some non-sharded DRAM inputs when the requested `core_grid` is too tall for the computed `Ht` constraints (for example `(8,8)` when `(8,5)` is the largest valid subgrid). This caused the deterministic Mochi decoder failure tracked in #39806.

### What's changed
For non-sharded DRAM group norm, the op now computes the largest valid grid within the requested bounds and uses it when possible, but only when `grid_x` remains unchanged.

This preserves virtual-column assumptions tied to `grid_x` while allowing safe fallback on `grid_y` (e.g. `8x8 -> 8x5`) and avoids throwing for this class of invalid requested grids.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ebanerjee/39806-ci-t3k-t3000-integration-tests-t3k_mochi_tests-test_tt_decoder_forward-fails-with-groupnorm-tt_throw)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ebanerjee/39806-ci-t3k-t3000-integration-tests-t3k_mochi_tests-test_tt_decoder_forward-fails-with-groupnorm-tt_throw)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ebanerjee/39806-ci-t3k-t3000-integration-tests-t3k_mochi_tests-test_tt_decoder_forward-fails-with-groupnorm-tt_throw)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ebanerjee/39806-ci-t3k-t3000-integration-tests-t3k_mochi_tests-test_tt_decoder_forward-fails-with-groupnorm-tt_throw)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ebanerjee/39806-ci-t3k-t3000-integration-tests-t3k_mochi_tests-test_tt_decoder_forward-fails-with-groupnorm-tt_throw)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ebanerjee/39806-ci-t3k-t3000-integration-tests-t3k_mochi_tests-test_tt_decoder_forward-fails-with-groupnorm-tt_throw)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early

#### Model tests

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ebanerjee/39806-ci-t3k-t3000-integration-tests-t3k_mochi_tests-test_tt_decoder_forward-fails-with-groupnorm-tt_throw)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ebanerjee/39806-ci-t3k-t3000-integration-tests-t3k_mochi_tests-test_tt_decoder_forward-fails-with-groupnorm-tt_throw)
  - [ ] `models-mandatory` preset
  - [ ] `models-extended` preset
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ebanerjee/39806-ci-t3k-t3000-integration-tests-t3k_mochi_tests-test_tt_decoder_forward-fails-with-groupnorm-tt_throw)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ebanerjee/39806-ci-t3k-t3000-integration-tests-t3k_mochi_tests-test_tt_decoder_forward-fails-with-groupnorm-tt_throw)
  - [ ] `models-mandatory` preset
  - [ ] `models-extended` preset
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ebanerjee/39806-ci-t3k-t3000-integration-tests-t3k_mochi_tests-test_tt_decoder_forward-fails-with-groupnorm-tt_throw)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ebanerjee/39806-ci-t3k-t3000-integration-tests-t3k_mochi_tests-test_tt_decoder_forward-fails-with-groupnorm-tt_throw)
  - [ ] `models-mandatory` preset
  - [ ] `models-extended` preset
  - [ ] other selection - specify runs

Made with [Cursor](https://cursor.com)