### PR TITLE
[#39863] Fix: DPRINT mesh-coord test resets target filter back to (0,0) after fixture re-setup

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_dprint_mesh_coords.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_dprint_mesh_coords.cpp
@@ -197,14 +197,10 @@ TEST_F(DPrintMeshCoordsFixture, TensixTestDprintMeshCoordsFiltersAllCoords) {
         }
     }
 
-    for (size_t i = 0; i < local_coords.size(); ++i) {
-        auto [row, col] = local_coords[i];
-
-        if (i > 0) {
-            DPrintMeshFixture::TearDown();
-            this->target_coord = {row, col};  // set before SetUp so ExtraSetUp picks it up
-            DPrintMeshFixture::SetUp();
-        }
+    for (auto [row, col] : local_coords) {
+        DPrintMeshFixture::TearDown();
+        this->target_coord = {row, col};  // set before SetUp so ExtraSetUp picks it up
+        DPrintMeshFixture::SetUp();
 
         ASSERT_FALSE(
             MetalContext::instance()
@@ -213,7 +209,6 @@ TEST_F(DPrintMeshCoordsFixture, TensixTestDprintMeshCoordsFiltersAllCoords) {
                 .empty())
             << "No chip resolved for coord (" << row << "," << col << ").";
 
-        this->target_coord = {row, col};
         log_info(tt::LogTest, "Filtering test: coord ({},{})", row, col);
         CMAKE_UNIQUE_NAMESPACE::RunFilteringTest(this, this->devices_);
         MetalContext::instance().dprint_server()->clear_log_file();

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_dprint_mesh_coords.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_dprint_mesh_coords.cpp
@@ -169,7 +169,7 @@ void DPrintMeshCoordsFixture::ExtraSetUp() {
     // because ParseAllFeatureEnv resets them to defaults on re-initialization.
     MetalContext::instance().teardown();
     CMAKE_UNIQUE_NAMESPACE::ConfigureDPrintForCoord(
-        MetalContext::instance().rtoptions(), dprint_file_name, /*row=*/0, /*col=*/0);
+        MetalContext::instance().rtoptions(), dprint_file_name, target_coord.first, target_coord.second);
 }
 
 void DPrintMeshCoordsFixture::ExtraTearDown() { MetalContext::instance().teardown(); }
@@ -202,9 +202,7 @@ TEST_F(DPrintMeshCoordsFixture, TensixTestDprintMeshCoordsFiltersAllCoords) {
 
         if (i > 0) {
             DPrintMeshFixture::TearDown();
-            MetalContext::instance().teardown();
-            CMAKE_UNIQUE_NAMESPACE::ConfigureDPrintForCoord(
-                MetalContext::instance().rtoptions(), dprint_file_name, row, col);
+            this->target_coord = {row, col};  // set before SetUp so ExtraSetUp picks it up
             DPrintMeshFixture::SetUp();
         }
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/39863

### Problem description
`ExtraSetUp()` always hardcoded `(0,0)` as the DPRINT mesh-coord filter, overwriting whatever coordinate the test loop had configured before calling `SetUp()`, so iterations beyond the first never tested the intended coordinate.

### What's changed
`ExtraSetUp()` now reads `target_coord` from the fixture instead of hardcoding `(0,0)`, and `TensixTestDprintMeshCoordsFiltersAllCoords` sets `target_coord` before calling `SetUp()` (removing the now-redundant inline teardown/configure that `ExtraSetUp` already handles).

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jpanasiuk/dprint_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jpanasiuk/dprint_fix)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jpanasiuk/dprint_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jpanasiuk/dprint_fix)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jpanasiuk/dprint_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jpanasiuk/dprint_fix)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jpanasiuk/dprint_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jpanasiuk/dprint_fix)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jpanasiuk/dprint_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jpanasiuk/dprint_fix)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jpanasiuk/dprint_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jpanasiuk/dprint_fix)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
