### PR TITLE
Improve demo caching experience

### DIFF
--- a/models/demos/deepseek_v3/demo/demo.py
+++ b/models/demos/deepseek_v3/demo/demo.py
@@ -9,6 +9,7 @@ import os
 from glob import glob
 from pathlib import Path
 
+import torch
 from loguru import logger
 
 import ttnn
@@ -496,6 +497,13 @@ def run_demo(
         )
     else:
         mesh_device = ttnn.open_mesh_device(mesh_shape=mesh_shape, dispatch_core_config=dispatch_core_config)
+
+    # MPI_Init_thread (triggered by open_mesh_device in multi-host configs) sets OpenMP threads to 1,
+    # torch inherits this setting, which makes CPU-side computations extremely slow.
+    if requested_system_name.upper() in ("DUAL", "QUAD"):
+        num_torch_threads = max(1, os.cpu_count())
+        logger.info(f"Restoring torch num_threads to {num_torch_threads}")
+        torch.set_num_threads(num_torch_threads)
 
     # Load tokenizer only for full-model mode; in random-weights mode we synthesize token ids
     tokenizer = None

--- a/models/demos/deepseek_v3/utils/config_helpers.py
+++ b/models/demos/deepseek_v3/utils/config_helpers.py
@@ -790,6 +790,16 @@ def shard_and_save(
                 not remove_dim or tensor.shape[shard_dim] == mesh_dim
             ), f"The removed dim {shard_dim} must be fully sharded"
 
+    cache_path = (
+        path if path.name.endswith(TENSOR_CACHE_EXTENSION) else path.with_name(f"{path.name}{TENSOR_CACHE_EXTENSION}")
+    )
+    if cache_path.exists():
+        logger.info(f"Cache file already exists, skipping shard_and_save: {cache_path}")
+        relative_cache_path = _get_relative_cache_path(cache_path)
+        if relative_cache_path is None:
+            raise ValueError(f"Expected path under a 'mesh_<rows>x<cols>' cache directory: {cache_path}")
+        return SavedWeight(Path(relative_cache_path), memory_config)
+
     if _torch_impl:
         ttnn_tensor = _shard_torch_impl(
             path=path,
@@ -819,8 +829,6 @@ def shard_and_save(
 
     path.parent.mkdir(parents=True, exist_ok=True)
 
-    if path.exists():
-        logger.warning(f"Overwriting existing cache file: {path}")
     record = {
         "event": "deepseek_v3.cache_tensor_spec",
         "pid": os.getpid(),

--- a/models/demos/deepseek_v3/utils/weight_config.py
+++ b/models/demos/deepseek_v3/utils/weight_config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import fcntl
 import json
+import shutil
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
@@ -88,10 +89,14 @@ def _try_load_cached_config(config_path: Path, weight_cache_path: Path, force_re
     if force_recalculate:
         logger.info("Forcing recalculating weights")
         if weight_cache_path.exists():
-            import shutil
-
             logger.info(f"Deleting existing cache directory: {weight_cache_path}")
-            shutil.rmtree(weight_cache_path)
+            try:
+                if weight_cache_path.is_dir():
+                    shutil.rmtree(weight_cache_path)
+                else:
+                    weight_cache_path.unlink()
+            except OSError as e:
+                logger.warning(f"Failed to remove weight cache at {weight_cache_path}: {e}")
         return None
     if not config_path.exists():
         logger.info("Weight configuration file does not exist, forcing recalculating weights")

--- a/models/demos/deepseek_v3/utils/weight_config.py
+++ b/models/demos/deepseek_v3/utils/weight_config.py
@@ -87,6 +87,11 @@ def _try_load_cached_config(config_path: Path, weight_cache_path: Path, force_re
     """
     if force_recalculate:
         logger.info("Forcing recalculating weights")
+        if weight_cache_path.exists():
+            import shutil
+
+            logger.info(f"Deleting existing cache directory: {weight_cache_path}")
+            shutil.rmtree(weight_cache_path)
         return None
     if not config_path.exists():
         logger.info("Weight configuration file does not exist, forcing recalculating weights")


### PR DESCRIPTION
This PR aims to improve the DeepSeek-V3 demo’s caching behavior and runtime ergonomics by making cache regeneration more explicit, avoiding unnecessary tensor re-serialization, and mitigating a multi-host performance issue caused by MPI/OpenMP thread settings.

Changes:

When force_recalculate is enabled, delete the existing per-mesh cache directory before regenerating weights.
In shard_and_save, skip work if the target .tensorbin already exists instead of overwriting it.
In the demo entrypoint, restore torch CPU thread count after open_mesh_device() for DUAL/QUAD configs.