### PR TITLE
Fix RowMajor permute address corruption for padded tensors

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_rm_program_factory.cpp
@@ -58,7 +58,7 @@ PermuteDeviceOperation::MultiCoreRowInvariant::cached_program_t PermuteDeviceOpe
     uint32_t src0_cb_index = tt::CBIndex::c_0;
     uint32_t num_input_pages_to_read = 2;
 
-    uint32_t num_rows = input_tensor.physical_volume() / input_tensor.logical_shape()[-1];
+    uint32_t num_rows = detail::num_pages(input_tensor);
 
     auto compute_with_storage_grid_size = input_tensor.device()->compute_with_storage_grid_size();
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
@@ -207,7 +207,7 @@ PermuteDeviceOperation::MultiCoreBlockedGeneric::create(
     uint32_t W_stride = output_strides[x_dim];
 
     uint32_t N = operation_attributes.dims.size();
-    uint32_t num_rows = input_tensor.physical_volume() / input_tensor.logical_shape()[-1];
+    uint32_t num_rows = detail::num_pages(input_tensor);
 
     // treat the input tensor as 3D with rows * x_blocks * w_blocks
     uint32_t x_blocks = tt::div_up(X, x_block_size);
@@ -250,7 +250,7 @@ PermuteDeviceOperation::MultiCoreBlockedGeneric::create(
         {"x_block_size", x_block_size},
         {"w_block_size", w_block_size},
         {"element_size", input_tensor.element_size()},
-        {"input_tensor_page_size", input_tensor.logical_shape()[-1] * input_tensor.element_size()}};
+        {"input_tensor_page_size", static_cast<uint32_t>(src_buffer->aligned_page_size())}};
 
     TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
 
@@ -279,7 +279,7 @@ PermuteDeviceOperation::MultiCoreBlockedGeneric::create(
         {"x_block_size", x_block_size},
         {"w_block_size", w_block_size},
         {"W", W},
-        {"output_tensor_page_size", output_tensor.logical_shape()[-1] * output_tensor.element_size()}};
+        {"output_tensor_page_size", static_cast<uint32_t>(dst_buffer->aligned_page_size())}};
 
     TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
     tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(


### PR DESCRIPTION
## Summary

- Fix `MultiCoreBlockedGeneric` and `MultiCoreRowInvariant` permute program factories to use the buffer's actual `aligned_page_size()` for `TensorAccessor` initialization, instead of deriving page size from `logical_shape()[-1]`.
- Fix `num_rows` calculation in both factories to use `logical_volume()` (via existing `detail::num_pages()`) instead of `physical_volume()`, which inflated the row count by the padded/logical ratio for tensors with last-dim padding.

## Problem

When the input tensor has a gap between logical and padded last dimension (e.g. conv3d output with `C_out=3`, padded to 32), the permute reader kernel received `input_tensor_page_size = 3 × 2 = 6 bytes` while the DRAM buffer was allocated with 64-byte pages (`32 × 2`). The `InterleavedAddrGen` rounds page size up to DRAM alignment:

| Arch | DRAM alignment | `align(6)` | Buffer page size | Match? |
|------|---------------|------------|-----------------|--------|
| **Wormhole** | 32 B | **32** | 64 | **No → corruption** |
| **Blackhole** | 64 B | **64** | 64 | Yes (by luck) |

On Wormhole, after the first cycle through DRAM banks, every subsequent read used stride 32 instead of 64, reading from wrong addresses and producing horizontal line artifacts in video output.

The `num_rows` bug (`physical_volume / logical_last_dim`) gave ~10.67× too many rows for `C_out=3`, causing the kernel to process redundant wrapped blocks.

## Test plan

- [ ] Rebuild with `./build_metal.sh`
- [ ] Run Wan conv3d unit test: `pytest models/tt_dit/tests/models/wan2_2/test_vae_wan2_1.py::test_wan_conv3d -k "conv_6"`
- [ ] Run Wan decoder test: `pytest models/tt_dit/tests/models/wan2_2/test_vae_wan2_1.py::test_wan_decoder3d --timeout 1500`
- [ ] Run Wan pipeline on WH T3K: `pytest models/tt_dit/tests/models/wan2_2/test_pipeline_wan.py -k "2x4sp0tp1 and resolution_480p" --timeout 1500`
- [ ] Verify no horizontal line artifacts in output video
- [ ] Run existing permute unit tests to check for regressions

## Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kevinmi/fix-permute-rm-padded-page-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kevinmi/fix-permute-rm-padded-page-size)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=kevinmi/fix-permute-rm-padded-page-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:kevinmi/fix-permute-rm-padded-page-size)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kevinmi/fix-permute-rm-padded-page-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kevinmi/fix-permute-rm-padded-page-size)
- [x] New/Existing tests provide coverage for changes

#### Model tests

- [x] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kevinmi/fix-permute-rm-padded-page-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kevinmi/fix-permute-rm-padded-page-size)
  - [x] `models-mandatory` preset
  - [ ] `models-extended` preset

- [x] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kevinmi/fix-permute-rm-padded-page-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kevinmi/fix-permute-rm-padded-page-size)
  - [x] `models-mandatory` preset
  - [ ] `models-extended` preset

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kevinmi/fix-permute-rm-padded-page-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kevinmi/fix-permute-rm-padded-page-size)
  - [ ] `models-mandatory` preset
  - [ ] `models-extended` preset