### PR TITLE
Add non physical loopback support to PipelineBlock

### DIFF
--- a/models/demos/deepseek_v3_b1/micro_ops/host_io/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/host_io/op.py
@@ -44,90 +44,103 @@ class HostInterface:
         h2d_page_size,
         d2h_page_size,
         core_to_core_socket_buffer_size=1024,
-        h2d_downstream_core=ttnn.MeshCoreCoord(ttnn.MeshCoordinate(0, 0), ttnn.CoreCoord(0, 0)),
-        d2h_upstream_core=ttnn.MeshCoreCoord(ttnn.MeshCoordinate(0, 0), ttnn.CoreCoord(0, 0)),
+        h2d_downstream_core=None,
+        d2h_upstream_core=None,
         embedding_tensor=None,
         loopback_mode=False,
         embedding_cb_index=None,
         fabric_packet_header_cb_index=None,
     ):
+        assert h2d_socket is not None or d2h_socket is not None, "Either h2d_socket or d2h_socket must be provided"
+
+        if h2d_socket and d2h_socket:
+            assert (
+                h2d_socket.get_mesh_device() == d2h_socket.get_mesh_device()
+            ), "Expected Host <-> Device Communication for Blitz Decode to be on the same mesh device."
+
         self.h2d_socket = h2d_socket
         self.d2h_socket = d2h_socket
         self.h2d_page_size = h2d_page_size
         self.d2h_page_size = d2h_page_size
-        self.h2d_socket.set_page_size(self.h2d_page_size)
-        self.d2h_socket.set_page_size(self.d2h_page_size)
+        if self.h2d_socket:
+            self.h2d_socket.set_page_size(self.h2d_page_size)
+        if self.d2h_socket:
+            self.d2h_socket.set_page_size(self.d2h_page_size)
         self.loopback_mode = loopback_mode
         self.core_to_core_socket_buffer_size = core_to_core_socket_buffer_size
         self.embedding_tensor = embedding_tensor
         self.h2d_downstream_core = h2d_downstream_core
         self.d2h_upstream_core = d2h_upstream_core
-        # Validate single-core, single-chip constraint
-        # Current implementation only supports host communication with one core on one chip
-        if len(h2d_socket.get_active_cores()) != 1 or len(d2h_socket.get_active_cores()) != 1:
-            raise ValueError("Host <-> Device Communication for Blitz Decode must be on a single core.")
-        if h2d_socket.get_mesh_device().id() != d2h_socket.get_mesh_device().id():
-            raise ValueError("Expected Host <-> Device Communication for Blitz Decode to be on the same mesh device.")
+
+        if self.h2d_socket:
+            if len(self.h2d_socket.get_active_cores()) != 1:
+                raise ValueError("Host <-> Device Communication for Blitz Decode must be on a single core.")
+        if self.d2h_socket:
+            if len(self.d2h_socket.get_active_cores()) != 1:
+                raise ValueError("Host <-> Device Communication for Blitz Decode must be on a single core.")
 
         if loopback_mode:
+            assert h2d_socket and d2h_socket, "Loopback mode requires both H2D and D2H sockets"
             if h2d_socket.get_active_cores()[0] != d2h_socket.get_active_cores()[0]:
                 raise ValueError("Expected Host <-> Device Communication for Blitz Decode to be on the same core.")
 
-        self.mesh_device = h2d_socket.get_mesh_device()
-        self.h2d_mesh_core_coord = self.h2d_socket.get_active_cores()[0]
-        self.d2h_mesh_core_coord = self.d2h_socket.get_active_cores()[0]
+        self.mesh_device = self.h2d_socket.get_mesh_device() if self.h2d_socket else self.d2h_socket.get_mesh_device()
 
-        if self.h2d_mesh_core_coord.core_coord == self.d2h_mesh_core_coord.core_coord:
-            termination_semaphore_core_range = ttnn.CoreRangeSet(
-                [
-                    ttnn.CoreRange(self.h2d_mesh_core_coord.core_coord, self.h2d_mesh_core_coord.core_coord),
-                ]
+        self.h2d_mesh_core_coord = self.h2d_socket.get_active_cores()[0] if self.h2d_socket else None
+        self.d2h_mesh_core_coord = self.d2h_socket.get_active_cores()[0] if self.d2h_socket else None
+
+        # Build termination semaphore core range from whichever sockets are present
+        sem_core_ranges = []
+        if self.h2d_mesh_core_coord is not None:
+            sem_core_ranges.append(
+                ttnn.CoreRange(self.h2d_mesh_core_coord.core_coord, self.h2d_mesh_core_coord.core_coord)
             )
-        else:
-            termination_semaphore_core_range = ttnn.CoreRangeSet(
-                [
-                    ttnn.CoreRange(self.h2d_mesh_core_coord.core_coord, self.h2d_mesh_core_coord.core_coord),
-                    ttnn.CoreRange(self.d2h_mesh_core_coord.core_coord, self.d2h_mesh_core_coord.core_coord),
-                ]
-            )
+        if self.d2h_mesh_core_coord is not None:
+            d2h_range = ttnn.CoreRange(self.d2h_mesh_core_coord.core_coord, self.d2h_mesh_core_coord.core_coord)
+            if not sem_core_ranges or self.d2h_mesh_core_coord.core_coord != self.h2d_mesh_core_coord.core_coord:
+                sem_core_ranges.append(d2h_range)
+
+        termination_semaphore_core_range = ttnn.CoreRangeSet(sem_core_ranges)
         self.termination_semaphore = ttnn.create_global_semaphore(
             self.mesh_device,
             termination_semaphore_core_range,
             0,
             ttnn.BufferType.L1,
         )
-        # Loopback mode is for testing purposes only - H2D receiver <-> D2H sender communication over CBs
-        # For real workloads, downstream/upstream cores connect to H2D receiver and D2H sender via D2D sockets
-        # NOTE: Downstream and upstream cores must be on the same device as the host I/O core (single-chip constraint)
-        if not loopback_mode:
-            downstream_socket_connection = ttnn.SocketConnection(
-                self.h2d_mesh_core_coord,
-                self.h2d_downstream_core,
-            )
-            upstream_socket_connection = ttnn.SocketConnection(
-                self.d2h_upstream_core,
-                self.d2h_mesh_core_coord,
-            )
+
+        self.downstream_socket_pair = None
+        self.upstream_socket_pair = None
+
+        if loopback_mode:
+            self.intermed_cb_index = 0
+        else:
             socket_memory_config = ttnn.SocketMemoryConfig(ttnn.BufferType.L1, core_to_core_socket_buffer_size)
 
-            downstream_socket_config = ttnn.SocketConfig(
-                [downstream_socket_connection],
-                socket_memory_config,
-            )
+            if self.h2d_socket and self.h2d_downstream_core is not None:
+                downstream_socket_connection = ttnn.SocketConnection(
+                    self.h2d_mesh_core_coord,
+                    self.h2d_downstream_core,
+                )
+                downstream_socket_config = ttnn.SocketConfig(
+                    [downstream_socket_connection],
+                    socket_memory_config,
+                )
+                self.downstream_socket_pair = ttnn.create_socket_pair(
+                    self.mesh_device, self.mesh_device, downstream_socket_config
+                )
 
-            upstream_socket_config = ttnn.SocketConfig(
-                [upstream_socket_connection],
-                socket_memory_config,
-            )
-
-            self.downstream_socket_pair = ttnn.create_socket_pair(
-                self.mesh_device, self.mesh_device, downstream_socket_config
-            )
-            self.upstream_socket_pair = ttnn.create_socket_pair(
-                self.mesh_device, self.mesh_device, upstream_socket_config
-            )
-        else:
-            self.intermed_cb_index = 0
+            if self.d2h_socket and self.d2h_upstream_core is not None:
+                upstream_socket_connection = ttnn.SocketConnection(
+                    self.d2h_upstream_core,
+                    self.d2h_mesh_core_coord,
+                )
+                upstream_socket_config = ttnn.SocketConfig(
+                    [upstream_socket_connection],
+                    socket_memory_config,
+                )
+                self.upstream_socket_pair = ttnn.create_socket_pair(
+                    self.mesh_device, self.mesh_device, upstream_socket_config
+                )
 
         self.has_embedding = self.embedding_tensor is not None
         if self.has_embedding:
@@ -289,28 +302,50 @@ class HostInterface:
 
     def run(self):
         dummy_tensor = ttnn.allocate_tensor_on_device(
-            ttnn.Shape([0, 0, 0, 0]), ttnn.uint32, ttnn.ROW_MAJOR_LAYOUT, self.h2d_socket.get_mesh_device()
+            ttnn.Shape([0, 0, 0, 0]), ttnn.uint32, ttnn.ROW_MAJOR_LAYOUT, self.mesh_device
         )
 
-        h2d_fabric_node_id = self.mesh_device.get_fabric_node_id(self.h2d_mesh_core_coord.device_coord)
-        d2h_fabric_node_id = self.mesh_device.get_fabric_node_id(self.d2h_mesh_core_coord.device_coord)
+        h2d_fabric_node_id = None
+        d2h_fabric_node_id = None
+        my_downstream_fabric_node_id = None
+        my_upstream_fabric_node_id = None
 
-        my_downstream_fabric_node_id = self.mesh_device.get_fabric_node_id(self.h2d_downstream_core.device_coord)
-        my_upstream_fabric_node_id = self.mesh_device.get_fabric_node_id(self.d2h_upstream_core.device_coord)
+        if self.h2d_mesh_core_coord is not None:
+            h2d_fabric_node_id = self.mesh_device.get_fabric_node_id(self.h2d_mesh_core_coord.device_coord)
+        if self.d2h_mesh_core_coord is not None:
+            d2h_fabric_node_id = self.mesh_device.get_fabric_node_id(self.d2h_mesh_core_coord.device_coord)
+        if self.h2d_downstream_core is not None:
+            my_downstream_fabric_node_id = self.mesh_device.get_fabric_node_id(self.h2d_downstream_core.device_coord)
+        if self.d2h_upstream_core is not None:
+            my_upstream_fabric_node_id = self.mesh_device.get_fabric_node_id(self.d2h_upstream_core.device_coord)
 
-        h2d_kernel = self._create_h2d_kernel()
-        d2h_kernel = self._create_d2h_kernel()
-        h2d_cb_descriptors = self._create_cb_descriptors(
-            self.h2d_mesh_core_coord, h2d_fabric_node_id != my_downstream_fabric_node_id
+        h2d_kernel = None
+        h2d_cb_descriptors = None
+        d2h_kernel = None
+        d2h_cb_descriptors = None
+
+        if self.h2d_socket:
+            h2d_kernel = self._create_h2d_kernel()
+            h2d_cb_descriptors = self._create_cb_descriptors(
+                self.h2d_mesh_core_coord, h2d_fabric_node_id != my_downstream_fabric_node_id
+            )
+
+        if self.d2h_socket:
+            d2h_kernel = self._create_d2h_kernel()
+            d2h_cb_descriptors = self._create_cb_descriptors(
+                self.d2h_mesh_core_coord, d2h_fabric_node_id != my_upstream_fabric_node_id
+            )
+
+        same_device = (
+            self.h2d_socket
+            and self.d2h_socket
+            and self.h2d_mesh_core_coord.device_coord == self.d2h_mesh_core_coord.device_coord
         )
-        d2h_cb_descriptors = self._create_cb_descriptors(
-            self.d2h_mesh_core_coord, d2h_fabric_node_id != my_upstream_fabric_node_id
-        )
 
-        same_device = self.h2d_mesh_core_coord.device_coord == self.d2h_mesh_core_coord.device_coord
+        h2d_program = None
+        d2h_program = None
 
         if same_device:
-            # Place both kernels in a single program when on the same device
             h2d_cb_ids = {fd.buffer_index for cb in h2d_cb_descriptors for fd in cb.format_descriptors}
             combined_cbs = h2d_cb_descriptors + [
                 cb
@@ -322,63 +357,66 @@ class HostInterface:
                 semaphores=[],
                 cbs=combined_cbs,
             )
-            d2h_program = h2d_program  # alias so d2h references point to the same program
+            d2h_program = h2d_program
         else:
-            h2d_program = ttnn.ProgramDescriptor(
-                kernels=[h2d_kernel],
-                semaphores=[],
-                cbs=h2d_cb_descriptors,
-            )
-            d2h_program = ttnn.ProgramDescriptor(
-                kernels=[d2h_kernel],
-                semaphores=[],
-                cbs=d2h_cb_descriptors,
-            )
-
-        # h2d kernel is always kernels[0]
-        h2d_program.kernels[0].runtime_args[self.h2d_mesh_core_coord.core_coord.x][
-            self.h2d_mesh_core_coord.core_coord.y
-        ] = []
-        h2d_rt_args_ref = h2d_program.kernels[0].runtime_args[self.h2d_mesh_core_coord.core_coord.x][
-            self.h2d_mesh_core_coord.core_coord.y
-        ]
-        if h2d_fabric_node_id != my_downstream_fabric_node_id:
-            for idx in range(self.num_fwd_links):
-                fwd_fabric_args = ttnn.setup_fabric_connection(
-                    h2d_fabric_node_id,
-                    my_downstream_fabric_node_id,
-                    idx,
-                    h2d_program,
-                    self.h2d_mesh_core_coord.core_coord,
+            if self.h2d_socket:
+                h2d_program = ttnn.ProgramDescriptor(
+                    kernels=[h2d_kernel],
+                    semaphores=[],
+                    cbs=h2d_cb_descriptors,
                 )
-                h2d_rt_args_ref.extend(fwd_fabric_args)
-
-        # d2h kernel is kernels[1] when combined, kernels[0] when separate
-        d2h_kernel_idx = 1 if same_device else 0
-        d2h_program.kernels[d2h_kernel_idx].runtime_args[self.d2h_mesh_core_coord.core_coord.x][
-            self.d2h_mesh_core_coord.core_coord.y
-        ] = []
-        d2h_rt_args_ref = d2h_program.kernels[d2h_kernel_idx].runtime_args[self.d2h_mesh_core_coord.core_coord.x][
-            self.d2h_mesh_core_coord.core_coord.y
-        ]
-
-        if d2h_fabric_node_id != my_upstream_fabric_node_id:
-            for idx in range(self.num_bwd_links):
-                bwd_fabric_args = ttnn.setup_fabric_connection(
-                    d2h_fabric_node_id,
-                    my_upstream_fabric_node_id,
-                    idx,
-                    d2h_program,
-                    self.d2h_mesh_core_coord.core_coord,
+            if self.d2h_socket:
+                d2h_program = ttnn.ProgramDescriptor(
+                    kernels=[d2h_kernel],
+                    semaphores=[],
+                    cbs=d2h_cb_descriptors,
                 )
-                d2h_rt_args_ref.extend(bwd_fabric_args)
+
+        if self.h2d_socket and h2d_program is not None:
+            h2d_program.kernels[0].runtime_args[self.h2d_mesh_core_coord.core_coord.x][
+                self.h2d_mesh_core_coord.core_coord.y
+            ] = []
+            h2d_rt_args_ref = h2d_program.kernels[0].runtime_args[self.h2d_mesh_core_coord.core_coord.x][
+                self.h2d_mesh_core_coord.core_coord.y
+            ]
+            if h2d_fabric_node_id != my_downstream_fabric_node_id:
+                for idx in range(self.num_fwd_links):
+                    fwd_fabric_args = ttnn.setup_fabric_connection(
+                        h2d_fabric_node_id,
+                        my_downstream_fabric_node_id,
+                        idx,
+                        h2d_program,
+                        self.h2d_mesh_core_coord.core_coord,
+                    )
+                    h2d_rt_args_ref.extend(fwd_fabric_args)
+
+        if self.d2h_socket and d2h_program is not None:
+            d2h_kernel_idx = 1 if same_device else 0
+            d2h_program.kernels[d2h_kernel_idx].runtime_args[self.d2h_mesh_core_coord.core_coord.x][
+                self.d2h_mesh_core_coord.core_coord.y
+            ] = []
+            d2h_rt_args_ref = d2h_program.kernels[d2h_kernel_idx].runtime_args[self.d2h_mesh_core_coord.core_coord.x][
+                self.d2h_mesh_core_coord.core_coord.y
+            ]
+
+            if d2h_fabric_node_id != my_upstream_fabric_node_id:
+                for idx in range(self.num_bwd_links):
+                    bwd_fabric_args = ttnn.setup_fabric_connection(
+                        d2h_fabric_node_id,
+                        my_upstream_fabric_node_id,
+                        idx,
+                        d2h_program,
+                        self.d2h_mesh_core_coord.core_coord,
+                    )
+                    d2h_rt_args_ref.extend(bwd_fabric_args)
 
         mesh_program_descriptor = ttnn.MeshProgramDescriptor()
-        mesh_program_descriptor[
-            ttnn.MeshCoordinateRange(self.h2d_mesh_core_coord.device_coord, self.h2d_mesh_core_coord.device_coord)
-        ] = h2d_program
+        if self.h2d_socket and h2d_program is not None:
+            mesh_program_descriptor[
+                ttnn.MeshCoordinateRange(self.h2d_mesh_core_coord.device_coord, self.h2d_mesh_core_coord.device_coord)
+            ] = h2d_program
 
-        if not same_device:
+        if self.d2h_socket and d2h_program is not None and not same_device:
             mesh_program_descriptor[
                 ttnn.MeshCoordinateRange(self.d2h_mesh_core_coord.device_coord, self.d2h_mesh_core_coord.device_coord)
             ] = d2h_program
@@ -397,8 +435,11 @@ class HostInterface:
         return self.upstream_socket_pair[0]
 
     def terminate(self, sync_devices):
-        self.h2d_socket.barrier()
-        self.d2h_socket.barrier()
+        if self.h2d_socket:
+            self.h2d_socket.barrier()
+        if self.d2h_socket:
+            self.d2h_socket.barrier()
+
         ttnn.reset_global_semaphore_value(self.termination_semaphore, 1)
         if sync_devices:
             ttnn.synchronize_device(self.mesh_device)

--- a/models/demos/deepseek_v3_b1/micro_ops/host_io/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/host_io/op.py
@@ -83,6 +83,11 @@ class HostInterface:
             assert h2d_socket and d2h_socket, "Loopback mode requires both H2D and D2H sockets"
             if h2d_socket.get_active_cores()[0] != d2h_socket.get_active_cores()[0]:
                 raise ValueError("Expected Host <-> Device Communication for Blitz Decode to be on the same core.")
+        else:
+            if self.h2d_socket:
+                assert self.h2d_downstream_core is not None
+            if self.d2h_socket:
+                assert self.d2h_upstream_core is not None
 
         self.mesh_device = self.h2d_socket.get_mesh_device() if self.h2d_socket else self.d2h_socket.get_mesh_device()
 
@@ -326,15 +331,21 @@ class HostInterface:
 
         if self.h2d_socket:
             h2d_kernel = self._create_h2d_kernel()
-            h2d_cb_descriptors = self._create_cb_descriptors(
-                self.h2d_mesh_core_coord, h2d_fabric_node_id != my_downstream_fabric_node_id
+            h2d_uses_fabric = (
+                h2d_fabric_node_id is not None
+                and my_downstream_fabric_node_id is not None
+                and h2d_fabric_node_id != my_downstream_fabric_node_id
             )
+            h2d_cb_descriptors = self._create_cb_descriptors(self.h2d_mesh_core_coord, h2d_uses_fabric)
 
         if self.d2h_socket:
             d2h_kernel = self._create_d2h_kernel()
-            d2h_cb_descriptors = self._create_cb_descriptors(
-                self.d2h_mesh_core_coord, d2h_fabric_node_id != my_upstream_fabric_node_id
+            d2h_uses_fabric = (
+                d2h_fabric_node_id is not None
+                and my_upstream_fabric_node_id is not None
+                and d2h_fabric_node_id != my_upstream_fabric_node_id
             )
+            d2h_cb_descriptors = self._create_cb_descriptors(self.d2h_mesh_core_coord, d2h_uses_fabric)
 
         same_device = (
             self.h2d_socket
@@ -379,7 +390,7 @@ class HostInterface:
             h2d_rt_args_ref = h2d_program.kernels[0].runtime_args[self.h2d_mesh_core_coord.core_coord.x][
                 self.h2d_mesh_core_coord.core_coord.y
             ]
-            if h2d_fabric_node_id != my_downstream_fabric_node_id:
+            if h2d_uses_fabric:
                 for idx in range(self.num_fwd_links):
                     fwd_fabric_args = ttnn.setup_fabric_connection(
                         h2d_fabric_node_id,
@@ -399,7 +410,7 @@ class HostInterface:
                 self.d2h_mesh_core_coord.core_coord.y
             ]
 
-            if d2h_fabric_node_id != my_upstream_fabric_node_id:
+            if d2h_uses_fabric:
                 for idx in range(self.num_bwd_links):
                     bwd_fabric_args = ttnn.setup_fabric_connection(
                         d2h_fabric_node_id,
@@ -429,10 +440,16 @@ class HostInterface:
         return ttnn.generic_op(io_tensors, mesh_program_descriptor)
 
     def get_downstream_socket(self):
-        return self.downstream_socket_pair[1]
+        if self.downstream_socket_pair is not None:
+            return self.downstream_socket_pair[1]
+        else:
+            raise ValueError("Downstream socket not available")
 
     def get_upstream_socket(self):
-        return self.upstream_socket_pair[0]
+        if self.upstream_socket_pair is not None:
+            return self.upstream_socket_pair[0]
+        else:
+            raise ValueError("Upstream socket not available")
 
     def terminate(self, sync_devices):
         if self.h2d_socket:

--- a/models/demos/deepseek_v3_b1/micro_ops/pipeline_block/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/pipeline_block/op.py
@@ -145,17 +145,18 @@ class PipelineBlock:
         embedding_tensor,
     ):
         assert h2d_socket_fifo_size is not None, "H2D Socket FIFO Size must be provided to first pipeline stage"
-        assert d2h_socket_fifo_size is not None, "D2H Socket FIFO Size must be provided to first pipeline stage"
-        assert d2h_socket_page_size is not None, "D2H Socket Page Size must be provided to first pipeline stage"
         assert embedding_tensor is not None, "Embedding Tensor must be provided to first pipeline stage"
 
         h2d_device_coord = pipeline_config[self.my_mesh_id].entry_node_coord
-        d2h_device_coord = pipeline_config[self.num_procs].exit_node_coord
 
         embedding_size_bytes = embedding_tensor.shape[-1] * dtype_size(embedding_tensor.dtype)
 
+        if self.initialize_loopback:
+            assert d2h_socket_fifo_size is not None, "D2H Socket FIFO Size must be provided to first pipeline stage"
+            assert d2h_socket_page_size is not None, "D2H Socket Page Size must be provided to first pipeline stage"
+            assert d2h_socket_fifo_size >= d2h_socket_page_size
+
         assert h2d_socket_fifo_size >= token_size_bytes
-        assert d2h_socket_fifo_size >= d2h_socket_page_size
         assert downstream_d2d_socket_page_size == embedding_size_bytes
         assert upstream_d2d_socket_page_size == d2h_socket_page_size
 
@@ -168,6 +169,7 @@ class PipelineBlock:
         )
 
         if self.initialize_loopback:
+            d2h_device_coord = pipeline_config[self.num_procs].exit_node_coord
             self.d2h_socket = ttnn.D2HSocket(
                 mesh_device, ttnn.MeshCoreCoord(d2h_device_coord, pipeline_core_coord), d2h_socket_fifo_size
             )
@@ -177,7 +179,7 @@ class PipelineBlock:
             self.d2h_socket,
             token_size_bytes,
             d2h_socket_page_size,
-            core_to_core_socket_buffer_size=downstream_d2d_socket_page_size,
+            core_to_core_socket_buffer_size=downstream_d2d_socket_fifo_size,
             h2d_downstream_core=ttnn.MeshCoreCoord(
                 pipeline_config[self.my_mesh_id].exit_node_coord, pipeline_core_coord
             ),
@@ -223,6 +225,7 @@ class PipelineBlock:
     ):
         assert d2h_socket_fifo_size is not None, "D2H Socket FIFO Size must be provided to last pipeline stage"
         assert d2h_socket_page_size is not None, "D2H Socket Page Size must be provided to last pipeline stage"
+        assert d2h_socket_fifo_size >= d2h_socket_page_size
 
         d2h_device_coord = pipeline_config[self.num_procs - 1].exit_node_coord
         d2h_upstream_core = (
@@ -339,7 +342,10 @@ class PipelineBlock:
         self.d2h_socket.read_tensor(output_tensor)
 
     def get_upstream_socket(self):
-        return self.exit_socket_interface.get_upstream_socket()
+        if hasattr(self, "exit_socket_interface"):
+            return self.exit_socket_interface.get_upstream_socket()
+        elif hasattr(self, "host_io"):
+            return self.host_io.get_upstream_socket()
 
     def get_downstream_socket(self):
         return self.entry_socket_interface.get_downstream_socket()

--- a/models/demos/deepseek_v3_b1/micro_ops/pipeline_block/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/pipeline_block/op.py
@@ -9,16 +9,30 @@ Provides a PipelineBlock class that encapsulates a single stage of a multi-host
 pipeline. Each PipelineBlock manages the setup and lifecycle of D2D socket
 interfaces for forwarding data between pipeline stages across hosts.
 
-The first pipeline stage (mesh_id == 0) additionally manages:
-- A HostInterface for H2D/D2H communication with the host
-- An embedding tensor lookup on incoming tokens
-- Loopback connectivity from the last pipeline stage back to the host
-
-Intermediate stages forward data from their entry node to their exit node
-via upstream and downstream D2D socket interfaces.
-
 Pipeline topology is determined by generate_blitz_decode_pipeline(), which
 maps physical ASIC locations to logical mesh coordinates for each stage.
+
+There are four distinct stage configurations:
+
+  1. First stage (mesh_id == 0):
+     H2D socket receives tokens from host, looks up embedding in DRAM,
+     forwards embedding rows downstream via exit D2D socket.
+     If loopback is enabled, also receives results from the last stage
+     via entry D2D socket and sends them back to host via D2H socket.
+
+  2. Middle stage (0 < mesh_id < num_procs - 1):
+     Entry D2D socket receives data from previous stage, exit D2D socket
+     forwards it to the next stage. Pure passthrough.
+
+  3. Last stage with loopback (mesh_id == num_procs - 1, loopback enabled):
+     Entry D2D receives from previous stage, exit D2D sends back to
+     stage 0's loopback entry.
+
+  4. Last stage without loopback (mesh_id == num_procs - 1, loopback disabled):
+     Entry D2D receives from previous stage, D2H socket sends results
+     directly to the host on this process. The entry D2D's downstream
+     socket is wired to the D2H kernel's upstream socket so data flows
+     through a single shared socket pair.
 """
 
 import ttnn
@@ -42,6 +56,7 @@ class PipelineBlock:
         entry_node_downstream=None,
         exit_node_upstream=None,
         embedding_tensor=None,
+        initialize_loopback=True,
     ):
         assert (
             upstream_d2d_socket_fifo_size >= upstream_d2d_socket_page_size
@@ -51,120 +66,248 @@ class PipelineBlock:
         ), "Downstream D2D Socket FIFO Size must be greater than or equal to downstream D2D Socket Page Size"
 
         self.my_mesh_id = mesh_device.get_system_mesh_id()
-        self.is_pipeline_start = self.my_mesh_id == 0
+        self.num_procs = int(ttnn.distributed_context_get_size())
+        self.initialize_loopback = initialize_loopback
+
         pipeline_config = ttnn._ttnn.multi_device.experimental.generate_blitz_decode_pipeline(mesh_device)
-        num_procs = int(ttnn.distributed_context_get_size())
-        assert len(pipeline_config) == num_procs + 1
+        if initialize_loopback:
+            assert len(pipeline_config) == self.num_procs + 1
+
+        self.is_pipeline_start = self.my_mesh_id == 0
+        self.is_last_stage = self.my_mesh_id == self.num_procs - 1
+        self.has_exit = not self.is_last_stage or initialize_loopback
+        self.has_d2h = (self.is_last_stage and not initialize_loopback) or (
+            self.is_pipeline_start and initialize_loopback
+        )
+
+        self.host_io = None
+        self.h2d_socket = None
+        self.d2h_socket = None
+        self.entry_socket_interface = None
+        self.exit_socket_interface = None
+
+        token_size_bytes = 64
 
         if self.is_pipeline_start:
-            assert h2d_socket_fifo_size is not None, "H2D Socket FIFO Size must be provided to first pipeline stage"
-            assert d2h_socket_fifo_size is not None, "D2H Socket FIFO Size must be provided to first pipeline stage"
-            assert d2h_socket_page_size is not None, "D2H Socket Page Size must be provided to first pipeline stage"
-            assert embedding_tensor is not None, "Embedding Tensor must be provided to first pipeline stage"
-
-            h2d_device_coord = pipeline_config[self.my_mesh_id].entry_node_coord
-            d2h_device_coord = pipeline_config[num_procs].exit_node_coord
-            token_size_bytes = 64  # Hardcode for now - don't expect this to change
-
-            assert (
-                h2d_socket_fifo_size >= token_size_bytes
-            ), "H2D Socket FIFO Size must be greater than or equal to token size"
-            assert (
-                d2h_socket_fifo_size >= d2h_socket_page_size
-            ), "D2H Socket FIFO Size must be greater than or equal to D2H Socket Page Size"
-
-            # Embedding can be 2D (vocab_size, hidden_size) or 4D (..., hidden_size); page = last dim
-            embedding_size_bytes = embedding_tensor.shape[-1] * dtype_size(embedding_tensor.dtype)
-
-            # Exit D2D Socket forwards embedding rows to first decoder. Granularity of socket transfer is set to embedding size.
-            assert (
-                downstream_d2d_socket_page_size == embedding_size_bytes
-            ), "Expected downstream D2D Socket Page size to be equal to embedding size"
-            # Logic here is that the loopback connection on the first pipeline stage simply
-            # forwards data from the final stage back to host. Page sizes must be equal.
-            assert (
-                upstream_d2d_socket_page_size == d2h_socket_page_size
-            ), "Expected upstream D2D Socket Page Size to be equal to D2H Socket Page Size on first pipeline stage"
-
-            self.h2d_socket = ttnn.H2DSocket(
+            self._init_first_stage(
                 mesh_device,
-                ttnn.MeshCoreCoord(h2d_device_coord, pipeline_core_coord),
-                ttnn.BufferType.L1,
+                pipeline_config,
+                pipeline_core_coord,
+                token_size_bytes,
+                upstream_d2d_socket_fifo_size,
+                downstream_d2d_socket_fifo_size,
+                upstream_d2d_socket_page_size,
+                downstream_d2d_socket_page_size,
                 h2d_socket_fifo_size,
-                ttnn.H2DMode.HOST_PUSH,  # Host Push is faster than Device Pull for small page sizes
+                d2h_socket_fifo_size,
+                d2h_socket_page_size,
+                embedding_tensor,
             )
+        elif self.is_last_stage and not initialize_loopback:
+            self._init_last_stage_with_d2h(
+                mesh_device,
+                pipeline_config,
+                pipeline_core_coord,
+                token_size_bytes,
+                upstream_d2d_socket_fifo_size,
+                upstream_d2d_socket_page_size,
+                downstream_d2d_socket_page_size,
+                d2h_socket_fifo_size,
+                d2h_socket_page_size,
+                exit_node_upstream,
+            )
+        else:
+            self._init_forwarding_stage(
+                mesh_device,
+                pipeline_config,
+                pipeline_core_coord,
+                upstream_d2d_socket_fifo_size,
+                downstream_d2d_socket_fifo_size,
+                upstream_d2d_socket_page_size,
+                downstream_d2d_socket_page_size,
+                entry_node_downstream,
+                exit_node_upstream,
+            )
+
+    def _init_first_stage(
+        self,
+        mesh_device,
+        pipeline_config,
+        pipeline_core_coord,
+        token_size_bytes,
+        upstream_d2d_socket_fifo_size,
+        downstream_d2d_socket_fifo_size,
+        upstream_d2d_socket_page_size,
+        downstream_d2d_socket_page_size,
+        h2d_socket_fifo_size,
+        d2h_socket_fifo_size,
+        d2h_socket_page_size,
+        embedding_tensor,
+    ):
+        assert h2d_socket_fifo_size is not None, "H2D Socket FIFO Size must be provided to first pipeline stage"
+        assert d2h_socket_fifo_size is not None, "D2H Socket FIFO Size must be provided to first pipeline stage"
+        assert d2h_socket_page_size is not None, "D2H Socket Page Size must be provided to first pipeline stage"
+        assert embedding_tensor is not None, "Embedding Tensor must be provided to first pipeline stage"
+
+        h2d_device_coord = pipeline_config[self.my_mesh_id].entry_node_coord
+        d2h_device_coord = pipeline_config[self.num_procs].exit_node_coord
+
+        embedding_size_bytes = embedding_tensor.shape[-1] * dtype_size(embedding_tensor.dtype)
+
+        assert h2d_socket_fifo_size >= token_size_bytes
+        assert d2h_socket_fifo_size >= d2h_socket_page_size
+        assert downstream_d2d_socket_page_size == embedding_size_bytes
+        assert upstream_d2d_socket_page_size == d2h_socket_page_size
+
+        self.h2d_socket = ttnn.H2DSocket(
+            mesh_device,
+            ttnn.MeshCoreCoord(h2d_device_coord, pipeline_core_coord),
+            ttnn.BufferType.L1,
+            h2d_socket_fifo_size,
+            ttnn.H2DMode.HOST_PUSH,
+        )
+
+        if self.initialize_loopback:
             self.d2h_socket = ttnn.D2HSocket(
                 mesh_device, ttnn.MeshCoreCoord(d2h_device_coord, pipeline_core_coord), d2h_socket_fifo_size
             )
 
-            self.host_io = HostInterface(
-                self.h2d_socket,
-                self.d2h_socket,
-                token_size_bytes,
-                d2h_socket_page_size,
-                core_to_core_socket_buffer_size=downstream_d2d_socket_page_size,
-                h2d_downstream_core=ttnn.MeshCoreCoord(
-                    pipeline_config[self.my_mesh_id].exit_node_coord, pipeline_core_coord
-                ),
-                d2h_upstream_core=ttnn.MeshCoreCoord(pipeline_config[num_procs].entry_node_coord, pipeline_core_coord),
-                embedding_tensor=embedding_tensor,
-            )
+        self.host_io = HostInterface(
+            self.h2d_socket,
+            self.d2h_socket,
+            token_size_bytes,
+            d2h_socket_page_size,
+            core_to_core_socket_buffer_size=downstream_d2d_socket_page_size,
+            h2d_downstream_core=ttnn.MeshCoreCoord(
+                pipeline_config[self.my_mesh_id].exit_node_coord, pipeline_core_coord
+            ),
+            d2h_upstream_core=ttnn.MeshCoreCoord(pipeline_config[self.num_procs].entry_node_coord, pipeline_core_coord),
+            embedding_tensor=embedding_tensor,
+        )
 
-            self.exit_socket_interface = SocketInterface(
-                downstream_d2d_socket_page_size,
-                downstream_d2d_socket_fifo_size,
-                downstream_d2d_socket_page_size,
-                ttnn.MeshCoreCoord(pipeline_config[self.my_mesh_id].exit_node_coord, pipeline_core_coord),
-                ttnn.MeshCoreCoord(pipeline_config[self.my_mesh_id + 1].entry_node_coord, pipeline_core_coord),
-                upstream_socket=self.host_io.get_downstream_socket(),
-                sender_mesh=MeshWrapper(mesh_device),
-                receiver_mesh=MeshWrapper(mesh_id=self.my_mesh_id + 1),
-            )
+        self.exit_socket_interface = SocketInterface(
+            downstream_d2d_socket_page_size,
+            downstream_d2d_socket_fifo_size,
+            downstream_d2d_socket_page_size,
+            ttnn.MeshCoreCoord(pipeline_config[self.my_mesh_id].exit_node_coord, pipeline_core_coord),
+            ttnn.MeshCoreCoord(pipeline_config[self.my_mesh_id + 1].entry_node_coord, pipeline_core_coord),
+            upstream_socket=self.host_io.get_downstream_socket(),
+            sender_mesh=MeshWrapper(mesh_device),
+            receiver_mesh=MeshWrapper(mesh_id=self.my_mesh_id + 1),
+        )
 
+        if self.initialize_loopback:
             self.entry_socket_interface = SocketInterface(
-                upstream_d2d_socket_page_size,  # Entry node page size needs to be configurable
+                upstream_d2d_socket_page_size,
                 upstream_d2d_socket_fifo_size,
                 upstream_d2d_socket_page_size,
-                ttnn.MeshCoreCoord(pipeline_config[num_procs - 1].exit_node_coord, pipeline_core_coord),
-                ttnn.MeshCoreCoord(pipeline_config[num_procs].entry_node_coord, pipeline_core_coord),
+                ttnn.MeshCoreCoord(pipeline_config[self.num_procs - 1].exit_node_coord, pipeline_core_coord),
+                ttnn.MeshCoreCoord(pipeline_config[self.num_procs].entry_node_coord, pipeline_core_coord),
                 downstream_socket=self.host_io.get_upstream_socket(),
-                sender_mesh=MeshWrapper(mesh_id=num_procs - 1),
+                sender_mesh=MeshWrapper(mesh_id=self.num_procs - 1),
                 receiver_mesh=MeshWrapper(mesh_device),
             )
 
-        else:
-            self.entry_socket_interface = SocketInterface(
-                upstream_d2d_socket_page_size,
-                upstream_d2d_socket_fifo_size,
-                upstream_d2d_socket_page_size,
-                ttnn.MeshCoreCoord(pipeline_config[self.my_mesh_id - 1].exit_node_coord, pipeline_core_coord),
-                ttnn.MeshCoreCoord(pipeline_config[self.my_mesh_id].entry_node_coord, pipeline_core_coord),
-                downstream_core_coord=entry_node_downstream
-                if entry_node_downstream
-                else ttnn.MeshCoreCoord(pipeline_config[self.my_mesh_id].exit_node_coord, pipeline_core_coord),
-                sender_mesh=MeshWrapper(mesh_id=self.my_mesh_id - 1),
-                receiver_mesh=MeshWrapper(mesh_device),
-            )
-            self.exit_socket_interface = SocketInterface(
-                downstream_d2d_socket_page_size,
-                downstream_d2d_socket_fifo_size,
-                downstream_d2d_socket_page_size,
-                ttnn.MeshCoreCoord(pipeline_config[self.my_mesh_id].exit_node_coord, pipeline_core_coord),
-                ttnn.MeshCoreCoord(pipeline_config[self.my_mesh_id + 1].entry_node_coord, pipeline_core_coord),
-                upstream_core_coord=exit_node_upstream,
-                upstream_socket=self.entry_socket_interface.get_downstream_socket() if not exit_node_upstream else None,
-                sender_mesh=MeshWrapper(mesh_device),
-                receiver_mesh=MeshWrapper(mesh_id=self.my_mesh_id + 1 if self.my_mesh_id < num_procs - 1 else 0),
-            )
+    def _init_last_stage_with_d2h(
+        self,
+        mesh_device,
+        pipeline_config,
+        pipeline_core_coord,
+        token_size_bytes,
+        upstream_d2d_socket_fifo_size,
+        upstream_d2d_socket_page_size,
+        downstream_d2d_socket_page_size,
+        d2h_socket_fifo_size,
+        d2h_socket_page_size,
+        exit_node_upstream,
+    ):
+        assert d2h_socket_fifo_size is not None, "D2H Socket FIFO Size must be provided to last pipeline stage"
+        assert d2h_socket_page_size is not None, "D2H Socket Page Size must be provided to last pipeline stage"
+
+        d2h_device_coord = pipeline_config[self.num_procs - 1].exit_node_coord
+        d2h_upstream_core = (
+            exit_node_upstream
+            if exit_node_upstream
+            else ttnn.MeshCoreCoord(pipeline_config[self.my_mesh_id].entry_node_coord, pipeline_core_coord)
+        )
+
+        self.d2h_socket = ttnn.D2HSocket(
+            mesh_device, ttnn.MeshCoreCoord(d2h_device_coord, pipeline_core_coord), d2h_socket_fifo_size
+        )
+
+        # HostInterface creates an upstream_socket_pair (entry_core → exit_core) for its D2H
+        # kernel. We then wire the entry_socket_interface's downstream to the same pair so that
+        # the D2D exchange kernel pushes into the socket the D2H kernel reads from.
+        self.host_io = HostInterface(
+            None,
+            self.d2h_socket,
+            token_size_bytes,
+            d2h_socket_page_size,
+            core_to_core_socket_buffer_size=downstream_d2d_socket_page_size,
+            d2h_upstream_core=d2h_upstream_core,
+        )
+
+        self.entry_socket_interface = SocketInterface(
+            upstream_d2d_socket_page_size,
+            upstream_d2d_socket_fifo_size,
+            upstream_d2d_socket_page_size,
+            ttnn.MeshCoreCoord(pipeline_config[self.my_mesh_id - 1].exit_node_coord, pipeline_core_coord),
+            ttnn.MeshCoreCoord(pipeline_config[self.my_mesh_id].entry_node_coord, pipeline_core_coord),
+            downstream_socket=self.host_io.get_upstream_socket(),
+            sender_mesh=MeshWrapper(mesh_id=self.my_mesh_id - 1),
+            receiver_mesh=MeshWrapper(mesh_device),
+        )
+
+    def _init_forwarding_stage(
+        self,
+        mesh_device,
+        pipeline_config,
+        pipeline_core_coord,
+        upstream_d2d_socket_fifo_size,
+        downstream_d2d_socket_fifo_size,
+        upstream_d2d_socket_page_size,
+        downstream_d2d_socket_page_size,
+        entry_node_downstream,
+        exit_node_upstream,
+    ):
+        self.entry_socket_interface = SocketInterface(
+            upstream_d2d_socket_page_size,
+            upstream_d2d_socket_fifo_size,
+            upstream_d2d_socket_page_size,
+            ttnn.MeshCoreCoord(pipeline_config[self.my_mesh_id - 1].exit_node_coord, pipeline_core_coord),
+            ttnn.MeshCoreCoord(pipeline_config[self.my_mesh_id].entry_node_coord, pipeline_core_coord),
+            downstream_core_coord=entry_node_downstream
+            if entry_node_downstream
+            else ttnn.MeshCoreCoord(pipeline_config[self.my_mesh_id].exit_node_coord, pipeline_core_coord),
+            sender_mesh=MeshWrapper(mesh_id=self.my_mesh_id - 1),
+            receiver_mesh=MeshWrapper(mesh_device),
+        )
+
+        next_mesh_id = self.my_mesh_id + 1 if not self.is_last_stage else 0
+        self.exit_socket_interface = SocketInterface(
+            downstream_d2d_socket_page_size,
+            downstream_d2d_socket_fifo_size,
+            downstream_d2d_socket_page_size,
+            ttnn.MeshCoreCoord(pipeline_config[self.my_mesh_id].exit_node_coord, pipeline_core_coord),
+            ttnn.MeshCoreCoord(pipeline_config[self.my_mesh_id + 1].entry_node_coord, pipeline_core_coord),
+            upstream_core_coord=exit_node_upstream,
+            upstream_socket=self.entry_socket_interface.get_downstream_socket() if not exit_node_upstream else None,
+            sender_mesh=MeshWrapper(mesh_device),
+            receiver_mesh=MeshWrapper(mesh_id=next_mesh_id),
+        )
 
     def run(self):
         if self.is_pipeline_start:
             self.host_io.run()
             self.exit_socket_interface.run()
-            self.entry_socket_interface.run()
+            if self.initialize_loopback:
+                self.entry_socket_interface.run()
         else:
-            self.exit_socket_interface.run()
             self.entry_socket_interface.run()
+            if self.has_exit:
+                self.exit_socket_interface.run()
+            if self.host_io is not None:
+                self.host_io.run()
 
     def terminate(self):
         # Multi-Process barrier here that all outstanding requests issued to pipeline block
@@ -172,11 +315,15 @@ class PipelineBlock:
         ttnn.distributed_context_barrier()
         if self.is_pipeline_start:
             self.host_io.terminate(False)
-            self.entry_socket_interface.terminate(False)
+            if self.initialize_loopback:
+                self.entry_socket_interface.terminate(False)
             self.exit_socket_interface.terminate(True)
         else:
             self.entry_socket_interface.terminate(False)
-            self.exit_socket_interface.terminate(True)
+            if self.has_exit:
+                self.exit_socket_interface.terminate(not self.has_d2h)
+            if self.host_io is not None:
+                self.host_io.terminate(True)
 
     def is_first_pipeline_stage(self):
         return self.is_pipeline_start
@@ -186,13 +333,13 @@ class PipelineBlock:
         self.h2d_socket.write_tensor(token_tensor)
 
     def read_output(self, output_tensor):
-        assert self.is_first_pipeline_stage(), "Output can only be read from the first pipeline stage"
+        assert (
+            self.d2h_socket is not None
+        ), "read_output requires a D2H socket: valid on stage 0 with loopback, or last stage without loopback"
         self.d2h_socket.read_tensor(output_tensor)
 
-    # Returns sender socket feeding exit node
     def get_upstream_socket(self):
         return self.exit_socket_interface.get_upstream_socket()
 
-    # Returns receiver socket draining entry node
     def get_downstream_socket(self):
         return self.entry_socket_interface.get_downstream_socket()

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_multi_host_pipeline.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_multi_host_pipeline.py
@@ -624,9 +624,6 @@ def test_pipeline_block_no_loopback(mesh_device, vocab_size, embedding_dim, toke
                 torch_input, dtype=ttnn_dtype_from_torch_dtype(token_dtype), layout=ttnn.ROW_MAJOR_LAYOUT
             )
             torch_output = torch.zeros(1, embedding_shape[3], dtype=embedding_dtype)
-            output_tensor = ttnn.from_torch(
-                torch_output, dtype=ttnn_dtype_from_torch_dtype(embedding_dtype), layout=ttnn.ROW_MAJOR_LAYOUT
-            )
             pipeline_block.write_token(input_tensor)
 
         logger.info(f"{vocab_size} token lookups verified successfully over multi-host pipeline")

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_multi_host_pipeline.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_multi_host_pipeline.py
@@ -526,3 +526,124 @@ def test_pipeline_block(mesh_device, vocab_size, embedding_dim, token_fifo_size,
         logger.info(f"{vocab_size} token lookups verified successfully over multi-host pipeline")
 
     pipeline_block.terminate()
+
+
+@pytest.mark.parametrize(
+    "vocab_size, embedding_dim",
+    [
+        (256, 14336),
+        (512, 7168),
+        (1024, 3584),
+        (2048, 1792),
+    ],
+)
+@pytest.mark.parametrize(
+    "token_fifo_size, embedding_fifo_factor",
+    [
+        (128, 2),
+        (256, 4),
+        (512, 8),
+    ],
+)
+@pytest.mark.parametrize(
+    "mesh_device",
+    [(4, 2)],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_2D_TORUS_Y,
+            "fabric_router_config": create_fabric_router_config(15232),
+        }
+    ],
+    indirect=True,
+)
+def test_pipeline_block_no_loopback(mesh_device, vocab_size, embedding_dim, token_fifo_size, embedding_fifo_factor):
+    if not is_slow_dispatch():
+        pytest.skip("Skipping test in fast dispatch mode")
+
+    ttnn.enable_asynchronous_slow_dispatch(mesh_device)
+
+    torch.manual_seed(0)
+
+    pipeline_core_coord = ttnn.CoreCoord(0, 0)
+
+    num_procs = int(ttnn.distributed_context_get_size())
+
+    embedding_dtype = torch.bfloat16
+    embedding_shape = (1, 1, vocab_size, embedding_dim)
+    embedding_size_bytes = embedding_dim * dtype_size(embedding_dtype)
+    embedding_fifo_size = embedding_size_bytes * embedding_fifo_factor
+
+    torch_embedding = torch.randn(embedding_shape, dtype=embedding_dtype)
+
+    if mesh_device.get_system_mesh_id() == 0:
+        embedding_tensor = ttnn.from_torch(
+            torch_embedding, dtype=ttnn_dtype_from_torch_dtype(embedding_dtype), layout=ttnn.ROW_MAJOR_LAYOUT
+        )
+        embedding_tensor = ttnn.to_device(embedding_tensor, mesh_device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        pipeline_block = PipelineBlock(
+            mesh_device,
+            pipeline_core_coord,
+            embedding_fifo_size,  # upstream d2d socket fifo size
+            embedding_fifo_size,  # downstream d2d socket fifo size
+            embedding_size_bytes,  # upstream d2d socket page size
+            embedding_size_bytes,  # downstream d2d socket page size
+            h2d_socket_fifo_size=token_fifo_size,  # h2d socket fifo size
+            d2h_socket_fifo_size=embedding_fifo_size,  # d2h socket fifo size
+            d2h_socket_page_size=embedding_size_bytes,  # d2h socket page size
+            embedding_tensor=embedding_tensor,
+            initialize_loopback=False,
+        )
+    else:
+        pipeline_block = PipelineBlock(
+            mesh_device,
+            pipeline_core_coord,
+            embedding_fifo_size,  # upstream d2d socket fifo size
+            embedding_fifo_size,  # downstream d2d socket fifo size
+            embedding_size_bytes,  # upstream d2d socket page size
+            embedding_size_bytes,  # downstream d2d socket page size
+            initialize_loopback=False,
+            d2h_socket_fifo_size=embedding_fifo_size,
+            d2h_socket_page_size=embedding_size_bytes,
+        )
+
+    pipeline_block.run()
+
+    if pipeline_block.is_first_pipeline_stage():
+        token_dtype = torch.uint32
+        token_size_bytes = 64
+        token_size_datums = token_size_bytes // dtype_size(token_dtype)
+
+        for token_id in range(vocab_size):
+            torch_input = torch.zeros(1, token_size_datums, dtype=token_dtype)
+            torch_input[0, 0] = token_id
+            input_tensor = ttnn.from_torch(
+                torch_input, dtype=ttnn_dtype_from_torch_dtype(token_dtype), layout=ttnn.ROW_MAJOR_LAYOUT
+            )
+            torch_output = torch.zeros(1, embedding_shape[3], dtype=embedding_dtype)
+            output_tensor = ttnn.from_torch(
+                torch_output, dtype=ttnn_dtype_from_torch_dtype(embedding_dtype), layout=ttnn.ROW_MAJOR_LAYOUT
+            )
+            pipeline_block.write_token(input_tensor)
+
+        logger.info(f"{vocab_size} token lookups verified successfully over multi-host pipeline")
+
+    elif mesh_device.get_system_mesh_id() == num_procs - 1:
+        for token_id in range(vocab_size):
+            torch_output = torch.zeros(1, embedding_shape[3], dtype=embedding_dtype)
+            output_tensor = ttnn.from_torch(
+                torch_output, dtype=ttnn_dtype_from_torch_dtype(embedding_dtype), layout=ttnn.ROW_MAJOR_LAYOUT
+            )
+            pipeline_block.read_output(output_tensor)
+            result_torch = ttnn.to_torch(output_tensor).reshape(-1)
+            expected = torch_embedding[0, 0, token_id, :].reshape(-1)
+            match = torch.equal(expected, result_torch)
+            assert match, (
+                f"Token {token_id}: D2H output does not match embedding row!\n"
+                f"Expected: {expected[:8]}...\nGot: {result_torch[:8]}..."
+            )
+
+    pipeline_block.terminate()


### PR DESCRIPTION
### Ticket
No Ticket.

### Problem description
- Need to support instantiating the `PipelineBlock` interface when we don't have a physical loopback connection
- In this case, the final pipeline stage can issue the read and send the output data back to the first stage over MPI

### What's changed
- Add `initialize_loopback` field to `PipelineBlock`. If false, the pipeline is initialized with a D2H socket on the final stage
- Add testing where the last stage reads the output and compares against the input from the first stage

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=asaigal/no_loopback)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:asaigal/no_loopback)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=asaigal/no_loopback)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:asaigal/no_loopback)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=asaigal/no_loopback)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:asaigal/no_loopback)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=asaigal/no_loopback)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:asaigal/no_loopback)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=asaigal/no_loopback)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:asaigal/no_loopback)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=asaigal/no_loopback)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:asaigal/no_loopback)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
