### PR TITLE
Uplift sdpa custom mm reuse dest srcb to new custom MM unpack scheme

### DIFF
--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_sdpa_custom_mm_reuse_dest_srcb_api.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_sdpa_custom_mm_reuse_dest_srcb_api.h
@@ -9,96 +9,42 @@
 /*************************************************************************
  * LLK UNPACK AB SDPA_CUSTOM_MM_REUSE_DEST_SRCB
  *
- * Custom matmul that uses MOP to loop both srcA and srcB along inner dim. Output height
+ * Custom matmul that reuses SrcB from dest and only unpacks SrcA. Output height
  * and width should be single tile with tile shape [1, 32]. Further work will uplift the
  * custom mm to support for tiles along the width.
  *
- * Simplified API containing only functions used by sdpa_custom_mm_reuse_dest_srcb_block_init and
- *sdpa_custom_mm_reuse_dest_srcb_block. Uses llk_unpack_AB_sdpa_custom_mm_reuse_dest_srcb.h as the low-level
- *implementation.
+ * Uses generic llk_unpack_hw_configure for hardware configuration (operation
+ * specific hw_configures are deprecated). Uses
+ * llk_unpack_AB_sdpa_custom_mm_reuse_dest_srcb.h as the low-level implementation.
  *************************************************************************/
 
-template <bool is_fp32_dest_acc_en, StochRndType stoch_rnd_mode = StochRndType::None>
-inline void llk_unpack_AB_sdpa_custom_mm_reuse_dest_srcb_hw_configure_disaggregated(
-    const std::uint32_t unpA_operand, const std::uint32_t unpB_operand, const std::uint32_t transpose_xy_srca = 0) {
-    // In0 -> unpB
-    // In1 -> unpA
-    const uint32_t unpA_operand_id = get_operand_id(unpB_operand);
-    const uint32_t unpB_operand_id = get_operand_id(unpA_operand);
-
-    // unpA -> srcA
-    // unpB -> srcB
-    const uint32_t unpA_num_faces = get_operand_num_faces(unpA_operand_id);
-    const uint32_t unpB_num_faces = get_operand_num_faces(unpB_operand_id);
-
-    const uint32_t unpA_face_r_dim = get_operand_face_r_dim(unpA_operand_id);
-    const uint32_t unpB_face_r_dim = get_operand_face_r_dim(unpB_operand_id);
-
-    _llk_unpack_AB_sdpa_custom_mm_reuse_dest_srcb_hw_configure_<is_fp32_dest_acc_en, stoch_rnd_mode>(
-        unpack_src_format[unpA_operand_id],
-        unpack_src_format[unpB_operand_id],
-        unpack_dst_format[unpA_operand_id],
-        unpack_dst_format[unpB_operand_id],
-        unpA_face_r_dim,
-        unpB_face_r_dim,
-        transpose_xy_srca,
-        unpA_num_faces,
-        unpB_num_faces,
-        get_local_cb_interface(unpA_operand_id).fifo_page_size,
-        get_local_cb_interface(unpB_operand_id).fifo_page_size);
-}
-
 __attribute__((always_inline)) inline void llk_unpack_AB_sdpa_custom_mm_reuse_dest_srcb_init(
-    const std::uint32_t operandA,
-    const std::uint32_t operandB,
+    const std::uint32_t operand0,
+    const std::uint32_t operand1,
     const std::uint32_t transpose = 0,
-    const std::uint32_t kt_dim = 1) {
-    // In0 -> srcB (supports partial face)
-    // In1 -> srcA
-    const uint32_t operandA_id = get_operand_id(operandB);
-    const uint32_t operandB_id = get_operand_id(operandA);
+    const std::uint32_t nt_dim = 1) {
+    const std::uint32_t operandA_id = get_operand_id(operand1);
 
     const uint32_t unpA_face_r_dim = get_operand_face_r_dim(operandA_id);
-    const uint32_t unpB_face_r_dim = get_operand_face_r_dim(operandB_id);
-
-    const bool partial_face_b = get_operand_partial_face(operandB_id);
-
     const uint32_t unpA_num_faces = get_operand_num_faces(operandA_id);
-    const uint32_t unpB_num_faces =
-        partial_face_b ? 1 : get_operand_num_faces(operandB_id);  // if partial face -> unpack face by face
 
-    _llk_unpack_AB_sdpa_custom_mm_reuse_dest_srcb_init_(
-        kt_dim, unpA_face_r_dim, unpB_face_r_dim, unpA_num_faces, unpB_num_faces, partial_face_b);
+    _llk_unpack_AB_sdpa_custom_mm_reuse_dest_srcb_init_(nt_dim, unpA_face_r_dim, unpA_num_faces);
 }
 
 inline void llk_unpack_AB_sdpa_custom_mm_reuse_dest_srcb(
-    const std::uint32_t operandA,
-    const std::uint32_t operandB,
-    const std::uint32_t tile_index_a,
-    const std::uint32_t tile_index_b,
+    const std::uint32_t operand0,
+    const std::uint32_t operand1,
+    const std::uint32_t tile_index_0,
+    const std::uint32_t tile_index_1,
     const std::uint32_t kt_dim = 1,
     const std::uint32_t nt_dim = 1,
     const std::uint32_t in1_k_stride = 1) {
-    // In0/InA -> srcB (supports partial face)
-    // In1/InB -> srcA
+    const std::uint32_t operandA_id = get_operand_id(operand1);
 
-    const std::uint32_t operandA_id = get_operand_id(operandA);
-    const std::uint32_t operandB_id = get_operand_id(operandB);
-
-    std::uint32_t base_address_a = get_local_cb_interface(operandA_id).fifo_rd_ptr - 1;
-    std::uint32_t base_address_b = get_local_cb_interface(operandB_id).fifo_rd_ptr - 1;
-
-    std::uint32_t tile_size_a = get_local_cb_interface(operandA_id).fifo_page_size;
-    std::uint32_t tile_size_b = get_local_cb_interface(operandB_id).fifo_page_size;
+    const std::uint32_t base_address_A = get_local_cb_interface(operandA_id).fifo_rd_ptr - 1;
+    const std::uint32_t tile_index_A = tile_index_1;
+    const std::uint32_t tile_size_A = get_local_cb_interface(operandA_id).fifo_page_size;
 
     _llk_unpack_AB_sdpa_custom_mm_reuse_dest_srcb_(
-        base_address_a,
-        base_address_b,
-        tile_index_a,
-        tile_index_b,
-        tile_size_a,
-        tile_size_b,
-        kt_dim,
-        nt_dim,
-        in1_k_stride);
+        base_address_A, tile_index_A, tile_size_A, kt_dim, nt_dim, in1_k_stride);
 }

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/sdpa_custom_mm_reuse_dest_srcb.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/sdpa_custom_mm_reuse_dest_srcb.h
@@ -18,13 +18,13 @@ namespace ckernel {
 /**
  * Initialization for sdpa_custom_mm_reuse_dest_srcb_block operation. Must be called before sdpa_custom_mm_reuse_dest_srcb_block.
  *
- * Custom matmul that uses MOP to loop both srcA and srcB along inner dim. Output height
+ * Custom matmul that reuses SrcB from dest and only unpacks SrcA. Output height
  * and width should be single tile with tile shape [1, 32]. Further work will uplift the
  * custom mm to support for tiles along the width.
  *
  * This is optimized for K-dimension reduction where ct_dim=1, rt_dim=1, and kt_dim>1.
- * The MOP replay buffer can unpack both SrcA and SrcB, looping over the K dimension
- * with hardware pipelining for maximum throughput (up to 128 K tiles per MOP call).
+ * The MOP replay buffer unpacks SrcA using CFGSHIFTMASK for address auto-increment,
+ * collapsing the nt_dim loop into a single MOP call per kt_dim iteration.
  *
  * NOTE: This API only supports ct_dim=1 and rt_dim=1 (single output tile).
  *
@@ -36,7 +36,8 @@ namespace ckernel {
  * | in1_cb_id      | The identifier of the second input circular buffer (CB)       | uint32_t | 0 to 31                                          | False    |
  * | out_cb_id      | The identifier of the output circular buffer (CB)             | uint32_t | 0 to 31                                          | False    |
  * | transpose      | The transpose flag for performing transpose operation on B    | uint32_t | Any positive value will indicate tranpose is set | False    |
- * | kt_dim         | The inner dim of the input matrices in tiles                  | uint32_t | 1 to 128 per MOP call, chunked if larger        | False    |
+ * | kt_dim         | The inner dim of the input matrices in tiles                  | uint32_t | even number from 2 to 256                        | False    |
+ * | nt_dim         | The number of SrcA tiles per K iteration                      | uint32_t | 1 to 16                                          | False    |
  */
 // clang-format on
 ALWI void sdpa_custom_mm_reuse_dest_srcb_block_init(
@@ -46,9 +47,9 @@ ALWI void sdpa_custom_mm_reuse_dest_srcb_block_init(
     const uint32_t transpose = 0,
     uint32_t kt_dim = 1,
     uint32_t nt_dim = 1) {
-    UNPACK((
-        llk_unpack_AB_sdpa_custom_mm_reuse_dest_srcb_hw_configure_disaggregated<DST_ACCUM_MODE>(in0_cb_id, in1_cb_id)));
-    UNPACK((llk_unpack_AB_sdpa_custom_mm_reuse_dest_srcb_init(in0_cb_id, in1_cb_id, transpose, kt_dim)));
+    // Intentionally swap in0 and in1 as operation specific hw_configures are deprecated
+    UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(in1_cb_id, in0_cb_id)));
+    UNPACK((llk_unpack_AB_sdpa_custom_mm_reuse_dest_srcb_init(in0_cb_id, in1_cb_id, transpose, nt_dim)));
 
     MATH((llk_math_sdpa_custom_mm_reuse_dest_srcb_init<MATH_FIDELITY>(in0_cb_id, in1_cb_id, transpose, kt_dim)));
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
@@ -66,7 +67,7 @@ ALWI void sdpa_custom_mm_reuse_dest_srcb_block_init_short(
     const uint32_t transpose = 0,
     uint32_t kt_dim = 1,
     uint32_t nt_dim = 1) {
-    UNPACK((llk_unpack_AB_sdpa_custom_mm_reuse_dest_srcb_init(in0_cb_id, in1_cb_id, transpose, kt_dim)));
+    UNPACK((llk_unpack_AB_sdpa_custom_mm_reuse_dest_srcb_init(in0_cb_id, in1_cb_id, transpose, nt_dim)));
     MATH((llk_math_sdpa_custom_mm_reuse_dest_srcb_init<MATH_FIDELITY>(in0_cb_id, in1_cb_id, transpose, kt_dim)));
 }
 

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_sdpa_custom_mm_reuse_dest_srcb.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_sdpa_custom_mm_reuse_dest_srcb.h
@@ -17,234 +17,149 @@ using namespace ckernel;
 using namespace ckernel::unpacker;
 
 // SDPA_CUSTOM_MM_REUSE_DEST_SRCB
-// Custom matmul that uses MOP to loop both srcA and srcB along inner dim. Output height
-// and width should be single tile with tile shape [1, 32]. Further work will uplift the
-// custom mm to support for tiles along the width.
+// Custom matmul that reuses SrcB from dest and only unpacks SrcA.
+// Output height and width should be single tile with tile shape [1, 32].
 //
-// K-dimension optimized implementation with MOP looping over kt_dim
+// Both nt_dim and kt_dim loops are collapsed into a single MOP call using
+// CFGSHIFTMASK with two scratch registers:
+//   SCRATCH_SEC0 = block_increment (advance to next tile within a k-row)
+//   SCRATCH_SEC1 = inner_increment (jump from end of one k-row to start of next)
 //
-// Implementation assumptions:
-// - ct_dim = 1, rt_dim = 1 (single output tile, optimized for K-dimension reduction)
-// - MOP replay buffer unpacks both SrcA and SrcB, incrementing both addresses per iteration
-// - kernel_broadcast_a = 0 (no broadcast)
-// - kernel_broadcast_b = 0 (no broadcast)
-inline void _llk_unpack_AB_sdpa_custom_mm_reuse_dest_srcb_mop_config_() {
-    // in0/inA - loaded to SrcB
-    // in1/inB - loaded to SrcA
+// The replay buffer is 30 instructions, containing 9 block_increment
+// reuse blocks followed by 1 inner_increment reuse block (3 insns each).
+// The MOP template selects sliding windows into this buffer to cover any
+// nt_dim from 1 to 16. Each MOP iteration covers 2 k-rows (via B-mode or
+// halo-mode), and kt_dim/2 MOP iterations cover the full inner dimension.
+//
+// Constraints:
+// - ct_dim = 1, rt_dim = 1 (single output tile)
+// - nt_dim: 1 to 16
+// - kt_dim: even number from 2 to 256 (inclusive)
+// - kernel_broadcast_a = 0, kernel_broadcast_b = 0
+inline void _llk_unpack_AB_sdpa_custom_mm_reuse_dest_srcb_mop_config_(const std::uint32_t nt_dim) {
+    // Replay buffer layout (30 instructions):
+    //   [0-26]:  9 reuse blocks with block_increment (3 insns each)
+    //   [27-29]: 1 final reuse block with inner_increment (3 insns)
+    //
+    // Each reuse block: SrcA unpack + CFGSHIFTMASK + NOP (3 insns)
+    // block_increment reuse: CFGSHIFTMASK selects SCRATCH_SEC0
+    // inner_increment reuse (final): CFGSHIFTMASK selects SCRATCH_SEC1
+    //
+    // This supports first_half up to 9 tiles and second_half up to 9 tiles = 18 max.
+    // Practical limit is 16 due to dst size.
 
-    // MOP replay buffer now updates both SrcA and SrcB addresses for K-dimension loop
-    const std::uint32_t replay_buf_run_len = 3;
-    const std::uint32_t replay_buf_prog_len = replay_buf_run_len * 2;
+    constexpr std::uint32_t REPLAY_BUF_LEN = 30;
+    load_replay_buf(0, REPLAY_BUF_LEN, [] {
+        for (std::uint32_t i = 0; i < 9; i++) {
+            TTI_UNPACR_COMMON(SrcA, 0b00000000, 1);
+            TTI_CFGSHIFTMASK(1, 3, 32 - 1, 0, 0, THCON_SEC0_REG3_Base_address_ADDR32);
+            TTI_NOP;
+        }
+        TTI_UNPACR_COMMON(SrcA, 0b00000000, 1);
+        TTI_CFGSHIFTMASK(1, 3, 32 - 1, 0, 1, THCON_SEC0_REG3_Base_address_ADDR32);
+        TTI_NOP;
+    });
 
-    load_replay_buf(
-        0,
-        replay_buf_prog_len,
-        // Lambda function to set up replay buffer
-        [] {
-            // === Context 0 ===
-            // Wait for context available
-            t6_semaphore_wait_on_zero<p_stall::STALL_UNPACK>(semaphore::UNPACK_SYNC);
+    // Mop covers two k-rows per iteration, allowing up to 256 kt_dim with 128 MOP iterations.
+    // zmask is always 0 (skip path never used), which is required for iterations beyond 32.
+    //
+    // Each k-row processes nt_dim tiles: (nt_dim-1) tiles with block_increment, then
+    // 1 tile with inner_increment. The tiles are split between two halves for the template:
+    //   first_half_iterations = ceil(nt_dim/2)
+    //   second_half_iterations = floor(nt_dim/2)
+    //
+    // first_half window: starts at buffer beginning, covers first_half_iterations * 3 insns
+    // second_half window: ends at buffer end (always includes inner_increment block),
+    //   covers second_half_iterations * 3 insns
+    //
+    // nt_dim == 1: B-mode (A0 + B), both pointing to the inner_increment block
+    // nt_dim >= 2: Halo-mode (A0, A1, A2, A3), alternating first_half/second_half
 
-            // Unpack SrcA (in1/inB)
-            TTI_UNPACR(
-                SrcA,
-                0b00000000,
-                0,
-                0,
-                0,
-                1 /*Set OvrdThreadId*/,
-                1 /*Set Dvalid*/,
-                p_unpacr::RAREFYB_DISABLE,
-                0,
-                0 /* Set ContextIdInc */,
-                0,
-                0,
-                1);
+    const std::uint32_t first_half_iters = (nt_dim + 1) >> 1;
+    const std::uint32_t second_half_iters = nt_dim >> 1;
 
-            // Signal context done
-            t6_semaphore_get(semaphore::UNPACK_SYNC);
+    const std::uint32_t first_half = lltt::replay_insn(0, first_half_iters * 3);
+    const std::uint32_t second_half = lltt::replay_insn(REPLAY_BUF_LEN - second_half_iters * 3, second_half_iters * 3);
 
-            // === Context 1 ===
-            // Wait for context available
-            t6_semaphore_wait_on_zero<p_stall::STALL_UNPACK>(semaphore::UNPACK_SYNC);
-
-            // Unpack SrcA (in1/inB)
-            TTI_UNPACR(
-                SrcA,
-                0b00000000,
-                0,
-                1,
-                0,
-                1 /*Set OvrdThreadId*/,
-                1 /*Set Dvalid*/,
-                p_unpacr::RAREFYB_DISABLE,
-                0,
-                0 /* Set ContextIdInc */,
-                0,
-                0,
-                1);
-
-            t6_semaphore_get(semaphore::UNPACK_SYNC);
-        });
+    // For nt_dim == 1: only inner_increment block is needed, use B-mode
+    // block_increment == inner_increment when nt_dim == 1 so either block works,
+    // but we use the inner_increment block (last 3 insns) for correctness
+    const std::uint32_t single_tile = lltt::replay_insn(REPLAY_BUF_LEN - 3, 3);
 
     ckernel_unpack_template tmp = ckernel_unpack_template(
-        false,                                     // src B
-        false,                                     // halo - just used for 4 unpacks
-        lltt::replay_insn(0, replay_buf_run_len),  // runs when context is 0
-        0,
-        0,
-        0,
-        lltt::replay_insn(replay_buf_run_len, replay_buf_run_len),  // runs when context is 1
-        0,
-        0);
+        nt_dim == 1,                             // B-mode when single tile per k-row
+        nt_dim != 1,                             // Halo-mode when multiple tiles per k-row
+        nt_dim == 1 ? single_tile : first_half,  // A0
+        second_half,                             // A1
+        nt_dim == 1 ? single_tile : first_half,  // A2
+        second_half,                             // A3
+        0,                                       // Skip A (unused, zmask always 0)
+        single_tile,                             // B (used in B-mode for nt_dim==1)
+        0                                        // Skip B (unused)
+    );
 
     tmp.program();
+    TTI_MOP_CFG(0);
 }
 
-template <bool is_fp32_dest_acc_en, StochRndType stoch_rnd_mode = StochRndType::None>
-inline void _llk_unpack_AB_sdpa_custom_mm_reuse_dest_srcb_hw_configure_(
-    const std::uint32_t unpA_src_format,
-    const std::uint32_t unpB_src_format,
-    const std::uint32_t unpA_dst_format,
-    const std::uint32_t unpB_dst_format,
-    const std::uint32_t unpA_face_r_dim = FACE_R_DIM,
-    const std::uint32_t unpB_face_r_dim = FACE_R_DIM,
-    const std::uint32_t within_face_16x16_transpose = 0,
-    const std::uint32_t unpA_num_faces = 4,
-    const std::uint32_t unpB_num_faces = 4,
-    const std::uint32_t unpA_tile_size = 0,
-    const std::uint32_t unpB_tile_size = 0) {
-    constexpr bool is_row_pool = false;
-    constexpr bool stoch_rnd_en = (stoch_rnd_mode == StochRndType::All);
-    constexpr bool fpu_srnd_en = stoch_rnd_en || (stoch_rnd_mode == StochRndType::Fpu);
-    constexpr bool pack_srnd_en = stoch_rnd_en || (stoch_rnd_mode == StochRndType::Pack);
-
-    configure_unpack_AB<is_fp32_dest_acc_en, is_row_pool, fpu_srnd_en, pack_srnd_en>(
-        unpA_src_format,
-        unpB_src_format,
-        unpA_dst_format,
-        unpB_dst_format,
-        unpA_face_r_dim,
-        unpB_face_r_dim,
-        within_face_16x16_transpose,
-        unpA_num_faces,
-        unpB_num_faces);
-
-    // Configure tile size in datums
-    const uint32_t unpA_x_end = unpA_num_faces * unpA_face_r_dim * FACE_C_DIM - 1;
-    const uint32_t unpB_x_end = unpB_num_faces * unpB_face_r_dim * FACE_C_DIM - 1;
-    TT_SETADCXX(p_setadc::UNP_A, unpA_x_end, 0x0);
-    TT_SETADCXX(p_setadc::UNP_B, unpB_x_end, 0x0);
-
-    regfile[p_gpr_unpack::TILE_SIZE_A] = unpA_tile_size;
-    regfile[p_gpr_unpack::TILE_SIZE_B] = unpB_tile_size;
-    sync_regfile_write(p_gpr_unpack::TILE_SIZE_B);
-}
-
-// K-dimension optimized initialization:
-// - transpose = 0 (no transpose)
-// - ct_dim = 1 (column tile dimension is 1, single output tile width)
-// - rt_dim = 1 (row tile dimension is 1, single output tile height)
-// - unpA_partial_face = false (always use full tile unpacking for input A)
 __attribute__((always_inline)) inline void _llk_unpack_AB_sdpa_custom_mm_reuse_dest_srcb_init_(
-    const std::uint32_t kt_dim = 1,
+    const std::uint32_t nt_dim = 1,
     const std::uint32_t unpA_face_r_dim = FACE_R_DIM,
-    const std::uint32_t unpB_face_r_dim = FACE_R_DIM,
-    const std::uint32_t unpA_num_faces = 4,
-    const std::uint32_t unpB_num_faces = 4,
-    const bool unpB_partial_face = false) {
-    // also turn on within_face_16x16_transpose if it was turned off by datacopy at runtime
-    // on WH, the unpacker performs both transpose of faces as well as transpose each face.
-    // the former is configured in mop, the latter is configured in cfg register in hw_configure
-    // in large matmul, datacopy will disable the transpose of faces, so we need it turn it back on for matmul.
+    const std::uint32_t unpA_num_faces = 4) {
     cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(0);
 
     const uint32_t unpA_x_end = unpA_num_faces * unpA_face_r_dim * FACE_C_DIM - 1;
     TT_SETADCXX(p_setadc::UNP_A, unpA_x_end, 0x0);
 
-    _llk_unpack_AB_sdpa_custom_mm_reuse_dest_srcb_mop_config_();
+    _llk_unpack_AB_sdpa_custom_mm_reuse_dest_srcb_mop_config_(nt_dim);
+
+    TTI_SETADCZW(0b011, 0, 0, 0, 0, 0b1111);
+    TTI_SETADCXY(0b011, 0, 0, 0, 0, 0b1010);
 }
 
-// K-dimension optimized implementation:
-// - ct_dim = 1 (column tile dimension is 1, single output tile width)
-// - rt_dim = 1 (row tile dimension is 1, single output tile height)
-// - MOP loops kt_dim times, unpacking both SrcA and SrcB with address increments
-// - unpA_partial_face = false (always use full tile unpacking for input A)
+// Both nt_dim and kt_dim loops collapsed into a single MOP call.
+// CFGSHIFTMASK auto-increments the SrcA L1 address:
+//   SCRATCH_SEC0 = block_increment (tile_size_a, advances within a k-row)
+//   SCRATCH_SEC1 = inner_increment (jumps from end of one k-row to start of next)
 // - in1_k_stride: stride between K tiles in in1 (default 1 for contiguous, use out_w for row-major layout)
 inline void _llk_unpack_AB_sdpa_custom_mm_reuse_dest_srcb_(
     const std::uint32_t base_address_a,
-    const std::uint32_t base_address_b,
     const std::uint32_t tile_index_a,
-    const std::uint32_t tile_index_b,
     const std::uint32_t tile_size_a,
-    const std::uint32_t tile_size_b,
     const std::uint32_t kt_dim = 1,
     const std::uint32_t nt_dim = 1,
     const std::uint32_t in1_k_stride = 1) {
-    // In0/InA -> srcB (supports partial face)
-    // In1/InB -> srcA
+    volatile uint* cfg = get_cfg_pointer();
 
-    volatile uint* cfg = get_cfg_pointer();  // get pointer to registers for current state ID
+    const std::uint32_t address_a = base_address_a + tile_size_a * tile_index_a;
+    const std::uint32_t block_increment = tile_size_a;
+    // inner_increment: after (nt_dim-1) block_increments we're at the last tile of the k-row.
+    // We need to jump to the first tile of the next k-row.
+    // After processing a full k-row, address has advanced by (nt_dim-1) * tile_size_a
+    // via block_increments. The inner_increment must bring us to the next k-row:
+    //   (nt_dim - 1) * tile_size_a + inner_increment = in1_k_stride * tile_size_a
+    //   inner_increment = (in1_k_stride - nt_dim + 1) * tile_size_a
+    const std::uint32_t inner_increment = (in1_k_stride - nt_dim + 1) * tile_size_a;
 
-    std::uint32_t offset_address_a = tile_size_a * tile_index_a;
-    std::uint32_t offset_address_b = tile_size_b * tile_index_b;
+    wait_for_next_context(1);
+    reset_config_context();
 
-    std::uint32_t address_a = base_address_a + offset_address_a;
-    std::uint32_t address_b = base_address_b + offset_address_b;
+    cfg[THCON_SEC0_REG3_Base_address_ADDR32] = address_a;
+    cfg[SCRATCH_SEC0_val_ADDR32] = block_increment;
+    cfg[SCRATCH_SEC1_val_ADDR32] = inner_increment;
 
-    // Calculate byte stride for in1 (SrcA) - stride in tiles * tile_size
-    const std::uint32_t address_b_stride = tile_size_b;
-    std::uint32_t offset_kt_stride = in1_k_stride - nt_dim;
+    semaphore_post(semaphore::UNPACK_SYNC);
+
+    TTI_STALLWAIT(p_stall::STALL_UNPACK, p_stall::TRISC_CFG);
+
+    TT_MOP(0, (kt_dim / 2) - 1, 0);
+
+    t6_semaphore_get(semaphore::UNPACK_SYNC);
+
     // Wait for all contexts to be free
     wait_for_next_context(1);
     reset_config_context();
+
     TTI_SETADCZW(0b011, 0, 0, 0, 0, 0b1111);
     TTI_SETADCXY(0b011, 0, 0, 0, 0, 0b1010);
-    std::uint32_t num_loops = nt_dim / 16;
-    std::uint32_t remaining_nt_dim = nt_dim % 16;
-    for (std::uint32_t i = 0; i < kt_dim; i++) {
-        // Unpack 16 tiles per loop, run 16 mop iterations and risc does 16 unrolled address updates 8 cnxt0 + 8 cnxt1
-        for (std::uint32_t j = 0; j < num_loops; j++) {
-            TTI_MOP(0, 15, 0xAAAA);
-#pragma GCC unroll 8
-            for (std::uint32_t k = 0; k < 8; k++) {
-                wait_for_next_context(2);
-                cfg[THCON_SEC0_REG3_Base_address_ADDR32] = address_b;
-                address_b += address_b_stride;
-                semaphore_post(semaphore::UNPACK_SYNC);
-                wait_for_next_context(2);
-                cfg[THCON_SEC0_REG3_Base_cntx1_address_ADDR32] = address_b;
-                address_b += address_b_stride;
-                semaphore_post(semaphore::UNPACK_SYNC);
-            }
-        }
-
-        // Do any remaining kt_dim % 16 iterations, run mop remaining_kt times and risc does similar address updates
-        if (remaining_nt_dim != 0) {
-            TT_MOP(0, remaining_nt_dim - 1, 0xAAAA);
-            for (std::uint32_t j = 0; j < remaining_nt_dim / 2; j++) {
-                wait_for_next_context(2);
-                cfg[THCON_SEC0_REG3_Base_address_ADDR32] = address_b;
-                address_b += address_b_stride;
-                semaphore_post(semaphore::UNPACK_SYNC);
-                wait_for_next_context(2);
-                cfg[THCON_SEC0_REG3_Base_cntx1_address_ADDR32] = address_b;
-                address_b += address_b_stride;
-                semaphore_post(semaphore::UNPACK_SYNC);
-            }
-            // Last address update if odd number of remaining kt_dim only hits context 0
-            if ((remaining_nt_dim % 2) != 0) {
-                wait_for_next_context(2);
-                cfg[THCON_SEC0_REG3_Base_address_ADDR32] = address_b;
-                address_b += address_b_stride;
-                semaphore_post(semaphore::UNPACK_SYNC);
-            }
-        }
-        address_b += offset_kt_stride * address_b_stride;
-    }
-
-    // Wait for all contexts to be free
-    wait_for_next_context(1);
-    reset_config_context();
-    unpacker_addr_counter_init();
 }


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Regular custom MM was uplifted to a new unpack scheme.

### What's changed
Uplift the dest reuse srcb version in sdpa to a similar scheme.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aho/sdpa-custom-mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aho/sdpa-custom-mm)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aho/sdpa-custom-mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/sdpa-custom-mm)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aho/sdpa-custom-mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/sdpa-custom-mm)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aho/sdpa-custom-mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/sdpa-custom-mm)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aho/sdpa-custom-mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/sdpa-custom-mm)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aho/sdpa-custom-mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/sdpa-custom-mm)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
