### PR TITLE
[cleanup] fabric stream reg assignments in builder and adapter

### DIFF
--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -1021,41 +1021,59 @@ FabricEriscDatamoverBuilder::CompileTimeArgs FabricEriscDatamoverBuilder::get_co
     // ===== Build named compile-time args (all non-pool/channel-mapping args) =====
     std::unordered_map<std::string, uint32_t> named_args;
 
-    // --- Stream IDs ---
-    const auto& stream_ids = StreamRegAssignments::get_all_stream_ids();
-    named_args["TO_RECEIVER_0_PKTS_SENT_ID"] = stream_ids[0];
-    named_args["TO_RECEIVER_1_PKTS_SENT_ID"] = stream_ids[1];
-    named_args["TO_SENDER_0_PKTS_ACKED_ID"] = stream_ids[2];
-    named_args["TO_SENDER_1_PKTS_ACKED_ID"] = stream_ids[3];
-    named_args["TO_SENDER_2_PKTS_ACKED_ID"] = stream_ids[4];
-    named_args["TO_SENDER_3_PKTS_ACKED_ID"] = stream_ids[5];
-    named_args["TO_SENDER_0_PKTS_COMPLETED_ID"] = stream_ids[6];
-    named_args["TO_SENDER_1_PKTS_COMPLETED_ID"] = stream_ids[7];
-    named_args["TO_SENDER_2_PKTS_COMPLETED_ID"] = stream_ids[8];
-    named_args["TO_SENDER_3_PKTS_COMPLETED_ID"] = stream_ids[9];
-    named_args["TO_SENDER_4_PKTS_COMPLETED_ID"] = stream_ids[10];
-    named_args["TO_SENDER_5_PKTS_COMPLETED_ID"] = stream_ids[11];
-    named_args["TO_SENDER_6_PKTS_COMPLETED_ID"] = stream_ids[12];
-    named_args["TO_SENDER_7_PKTS_COMPLETED_ID"] = stream_ids[13];
-    named_args["VC0_FREE_SLOTS_FROM_DOWNSTREAM_EDGE_1_STREAM_ID"] = stream_ids[14];
-    named_args["VC0_FREE_SLOTS_FROM_DOWNSTREAM_EDGE_2_STREAM_ID"] = stream_ids[15];
-    named_args["VC0_FREE_SLOTS_FROM_DOWNSTREAM_EDGE_3_STREAM_ID"] = stream_ids[16];
-    named_args["VC0_FREE_SLOTS_FROM_DOWNSTREAM_EDGE_4_STREAM_ID"] = stream_ids[17];
-    named_args["VC1_FREE_SLOTS_FROM_DOWNSTREAM_EDGE_1_STREAM_ID"] = stream_ids[18];
-    named_args["VC1_FREE_SLOTS_FROM_DOWNSTREAM_EDGE_2_STREAM_ID"] = stream_ids[19];
-    named_args["VC1_FREE_SLOTS_FROM_DOWNSTREAM_EDGE_3_STREAM_ID"] = stream_ids[20];
-    named_args["VC1_FREE_SLOTS_FROM_DOWNSTREAM_EDGE_4_STREAM_ID"] = stream_ids[21];
-    named_args["SENDER_CHANNEL_0_FREE_SLOTS_STREAM_ID"] = stream_ids[22];
-    named_args["SENDER_CHANNEL_1_FREE_SLOTS_STREAM_ID"] = stream_ids[23];
-    named_args["SENDER_CHANNEL_2_FREE_SLOTS_STREAM_ID"] = stream_ids[24];
-    named_args["SENDER_CHANNEL_3_FREE_SLOTS_STREAM_ID"] = stream_ids[25];
-    named_args["SENDER_CHANNEL_4_FREE_SLOTS_STREAM_ID"] = stream_ids[26];
-    named_args["SENDER_CHANNEL_5_FREE_SLOTS_STREAM_ID"] = stream_ids[27];
-    named_args["SENDER_CHANNEL_6_FREE_SLOTS_STREAM_ID"] = stream_ids[28];
-    named_args["SENDER_CHANNEL_7_FREE_SLOTS_STREAM_ID"] = stream_ids[29];
-    named_args["TENSIX_RELAY_LOCAL_FREE_SLOTS_STREAM_ID"] = stream_ids[30];
-    named_args["MULTI_RISC_TEARDOWN_SYNC_STREAM_ID"] = stream_ids[31];
-    named_args["ETH_RETRAIN_LINK_SYNC_STREAM_ID"] = stream_ids[32];
+    // --- Stream IDs (increment-on-write registers) ---
+    named_args["TO_RECEIVER_0_PKTS_SENT_ID"] = StreamRegAssignments::IncrementOnWrite::to_receiver_0_pkts_sent_id;
+    named_args["TO_RECEIVER_1_PKTS_SENT_ID"] = StreamRegAssignments::IncrementOnWrite::to_receiver_1_pkts_sent_id;
+    named_args["TO_SENDER_0_PKTS_ACKED_ID"] = StreamRegAssignments::IncrementOnWrite::to_sender_0_pkts_acked_id;
+    named_args["TO_SENDER_1_PKTS_ACKED_ID"] = StreamRegAssignments::IncrementOnWrite::to_sender_1_pkts_acked_id;
+    named_args["TO_SENDER_2_PKTS_ACKED_ID"] = StreamRegAssignments::IncrementOnWrite::to_sender_2_pkts_acked_id;
+    named_args["TO_SENDER_3_PKTS_ACKED_ID"] = StreamRegAssignments::IncrementOnWrite::to_sender_3_pkts_acked_id;
+    named_args["TO_SENDER_0_PKTS_COMPLETED_ID"] = StreamRegAssignments::IncrementOnWrite::to_sender_0_pkts_completed_id;
+    named_args["TO_SENDER_1_PKTS_COMPLETED_ID"] = StreamRegAssignments::IncrementOnWrite::to_sender_1_pkts_completed_id;
+    named_args["TO_SENDER_2_PKTS_COMPLETED_ID"] = StreamRegAssignments::IncrementOnWrite::to_sender_2_pkts_completed_id;
+    named_args["TO_SENDER_3_PKTS_COMPLETED_ID"] = StreamRegAssignments::IncrementOnWrite::to_sender_3_pkts_completed_id;
+    named_args["TO_SENDER_4_PKTS_COMPLETED_ID"] = StreamRegAssignments::IncrementOnWrite::to_sender_4_pkts_completed_id;
+    named_args["TO_SENDER_5_PKTS_COMPLETED_ID"] = StreamRegAssignments::IncrementOnWrite::to_sender_5_pkts_completed_id;
+    named_args["TO_SENDER_6_PKTS_COMPLETED_ID"] = StreamRegAssignments::IncrementOnWrite::to_sender_6_pkts_completed_id;
+    named_args["TO_SENDER_7_PKTS_COMPLETED_ID"] = StreamRegAssignments::IncrementOnWrite::to_sender_7_pkts_completed_id;
+    named_args["VC0_FREE_SLOTS_FROM_DOWNSTREAM_EDGE_1_STREAM_ID"] =
+        StreamRegAssignments::IncrementOnWrite::vc_0_free_slots_from_downstream_edge_1;
+    named_args["VC0_FREE_SLOTS_FROM_DOWNSTREAM_EDGE_2_STREAM_ID"] =
+        StreamRegAssignments::IncrementOnWrite::vc_0_free_slots_from_downstream_edge_2;
+    named_args["VC0_FREE_SLOTS_FROM_DOWNSTREAM_EDGE_3_STREAM_ID"] =
+        StreamRegAssignments::IncrementOnWrite::vc_0_free_slots_from_downstream_edge_3;
+    named_args["VC0_FREE_SLOTS_FROM_DOWNSTREAM_EDGE_4_STREAM_ID"] =
+        StreamRegAssignments::IncrementOnWrite::vc_0_free_slots_from_downstream_edge_4;
+    named_args["VC1_FREE_SLOTS_FROM_DOWNSTREAM_EDGE_1_STREAM_ID"] =
+        StreamRegAssignments::IncrementOnWrite::vc_1_free_slots_from_downstream_edge_1;
+    named_args["VC1_FREE_SLOTS_FROM_DOWNSTREAM_EDGE_2_STREAM_ID"] =
+        StreamRegAssignments::IncrementOnWrite::vc_1_free_slots_from_downstream_edge_2;
+    named_args["VC1_FREE_SLOTS_FROM_DOWNSTREAM_EDGE_3_STREAM_ID"] =
+        StreamRegAssignments::IncrementOnWrite::vc_1_free_slots_from_downstream_edge_3;
+    named_args["VC1_FREE_SLOTS_FROM_DOWNSTREAM_EDGE_4_STREAM_ID"] =
+        StreamRegAssignments::IncrementOnWrite::vc_1_free_slots_from_downstream_edge_4;
+    named_args["SENDER_CHANNEL_0_FREE_SLOTS_STREAM_ID"] =
+        StreamRegAssignments::IncrementOnWrite::sender_channel_0_free_slots_stream_id;
+    named_args["SENDER_CHANNEL_1_FREE_SLOTS_STREAM_ID"] =
+        StreamRegAssignments::IncrementOnWrite::sender_channel_1_free_slots_stream_id;
+    named_args["SENDER_CHANNEL_2_FREE_SLOTS_STREAM_ID"] =
+        StreamRegAssignments::IncrementOnWrite::sender_channel_2_free_slots_stream_id;
+    named_args["SENDER_CHANNEL_3_FREE_SLOTS_STREAM_ID"] =
+        StreamRegAssignments::IncrementOnWrite::sender_channel_3_free_slots_stream_id;
+    named_args["SENDER_CHANNEL_4_FREE_SLOTS_STREAM_ID"] =
+        StreamRegAssignments::IncrementOnWrite::sender_channel_4_free_slots_stream_id;
+    named_args["SENDER_CHANNEL_5_FREE_SLOTS_STREAM_ID"] =
+        StreamRegAssignments::IncrementOnWrite::sender_channel_5_free_slots_stream_id;
+    named_args["SENDER_CHANNEL_6_FREE_SLOTS_STREAM_ID"] =
+        StreamRegAssignments::IncrementOnWrite::sender_channel_6_free_slots_stream_id;
+    named_args["SENDER_CHANNEL_7_FREE_SLOTS_STREAM_ID"] =
+        StreamRegAssignments::IncrementOnWrite::sender_channel_7_free_slots_stream_id;
+    named_args["TENSIX_RELAY_LOCAL_FREE_SLOTS_STREAM_ID"] =
+        StreamRegAssignments::IncrementOnWrite::tensix_relay_local_free_slots_stream_id;
+    // --- Stream IDs (scratch registers) ---
+    named_args["MULTI_RISC_TEARDOWN_SYNC_STREAM_ID"] =
+        StreamRegAssignments::Scratch::multi_risc_teardown_sync_stream_id;
+    named_args["ETH_RETRAIN_LINK_SYNC_STREAM_ID"] = StreamRegAssignments::Scratch::eth_retrain_link_sync_stream_id;
 
     // --- Max channel counts ---
     named_args["MAX_NUM_SENDER_CHANNELS"] = builder_config::num_max_sender_channels;

--- a/tt_metal/fabric/erisc_datamover_builder.hpp
+++ b/tt_metal/fabric/erisc_datamover_builder.hpp
@@ -107,100 +107,111 @@ Receiver channel side registers are defined here to receive free-slot credits fr
                                    South Router
 */
 struct StreamRegAssignments {
-    // Packet send/ack/complete stream IDs
-    static constexpr uint32_t to_receiver_0_pkts_sent_id = 0;      // VC0 Ethernet Rx
-    static constexpr uint32_t to_receiver_1_pkts_sent_id = 1;      // VC1 Ethernet Rx
-    static constexpr uint32_t to_sender_0_pkts_acked_id = 2;       // VC0 Ethernet Sender Channel 0
-    static constexpr uint32_t to_sender_1_pkts_acked_id = 3;       // VC0 Ethernet Sender Channel 1
-    static constexpr uint32_t to_sender_2_pkts_acked_id = 4;       // VC0 Ethernet Sender Channel 2
-    static constexpr uint32_t to_sender_3_pkts_acked_id = 5;       // VC0 Ethernet Sender Channel 3
-    static constexpr uint32_t to_sender_0_pkts_completed_id = 6;   // VC0 Tensix Worker on upstream device
-    static constexpr uint32_t to_sender_1_pkts_completed_id = 7;   // VC0 Passthrough from upstream device X/Y edge
-    static constexpr uint32_t to_sender_2_pkts_completed_id = 8;   // VC0 Passthrough from upstream device X/Y edge
-    static constexpr uint32_t to_sender_3_pkts_completed_id = 9;   // VC0 Passthrough from upstream device X/Y edge
-    static constexpr uint32_t to_sender_4_pkts_completed_id = 10;  // VC1 Passthrough from upstream device Z edge
-    static constexpr uint32_t to_sender_5_pkts_completed_id = 11;  // VC1 Passthrough from upstream device X/Y edge
-    static constexpr uint32_t to_sender_6_pkts_completed_id = 12;  // VC1 Passthrough from upstream device X/Y edge
-    static constexpr uint32_t to_sender_7_pkts_completed_id = 13;  // VC1 Passthrough from upstream device X/Y edge
-    // Receiver channel free slots stream IDs
-    static constexpr uint32_t vc_0_free_slots_from_downstream_edge_1 =
-        14;  // for downstream E/W/N/S edge on: 2D X/Y Router->VC0, E edge on: 2D Z Router->VC0
-    static constexpr uint32_t vc_0_free_slots_from_downstream_edge_2 =
-        15;  // for downstream E/W/N/S edge on: 2D X/Y Router->VC0, W edge on: 2D Z Router->VC0
-    static constexpr uint32_t vc_0_free_slots_from_downstream_edge_3 =
-        16;  // for downstream E/W/N/S edge on: 2D X/Y Router->VC0, N edge on: 2D Z Router->VC0
-    static constexpr uint32_t vc_0_free_slots_from_downstream_edge_4 =
-        17;  // for downstream Z edge on: 2D+Z X/Y Router->VC0, S edge on: 2D Z Router->VC0
-    static constexpr uint32_t vc_1_free_slots_from_downstream_edge_1 =
-        18;  // for downstream E/W/N/S edge on: 2D X/Y Router->VC1
-    static constexpr uint32_t vc_1_free_slots_from_downstream_edge_2 =
-        19;  // for downstream E/W/N/S edge on: 2D X/Y Router->VC1
-    static constexpr uint32_t vc_1_free_slots_from_downstream_edge_3 =
-        20;  // for downstream E/W/N/S edge on: 2D X/Y Router->VC1
-    static constexpr uint32_t vc_1_free_slots_from_downstream_edge_4 =
-        21;  // for downstream Z edge on: 2D+Z X/Y Router->VC1, S edge on: 2D Z Router->VC1
-    // Sender channel free slots stream IDs.
-    // Decremented by respective upstream senders.
-    static constexpr uint32_t sender_channel_0_free_slots_stream_id = 22;  // for upstream tensix worker
-    static constexpr uint32_t sender_channel_1_free_slots_stream_id =
-        23;  // for upstream edge on: 1D->VC0, E/W/N/S edge on: 2D X/Y Router->VC0, E edge on: 2D Z Router->VC0
-    static constexpr uint32_t sender_channel_2_free_slots_stream_id =
-        24;  // for upstream E/W/N/S edge on: 2D X/Y Router->VC0, W edge on: 2D Z Router->VC0
-    static constexpr uint32_t sender_channel_3_free_slots_stream_id =
-        25;  // for upstream E/W/N/S edge on: 2D X/Y Router->VC0, N edge on: 2D Z Router->VC0
-    static constexpr uint32_t sender_channel_4_free_slots_stream_id =
-        26;  // for upstream E/W/N/S edge on: 2D X/Y Router->VC1, S edge on: 2D Z Router->VC0
-    static constexpr uint32_t sender_channel_5_free_slots_stream_id =
-        27;  // for upstream E/W/N/S edge on: 2D X/Y Router->VC1
-    static constexpr uint32_t sender_channel_6_free_slots_stream_id =
-        28;  // for upstream E/W/N/S edge on: 2D X/Y Router->VC1
-    static constexpr uint32_t sender_channel_7_free_slots_stream_id = 29;  // for upstream Z edge on: 2D+Z->VC1
+    // Stream registers used as auto-increment counters. Writing to these increments the register value.
+    struct IncrementOnWrite {
+        // Packet send/ack/complete stream IDs
+        static constexpr uint32_t to_receiver_0_pkts_sent_id = 0;      // VC0 Ethernet Rx
+        static constexpr uint32_t to_receiver_1_pkts_sent_id = 1;      // VC1 Ethernet Rx
+        static constexpr uint32_t to_sender_0_pkts_acked_id = 2;       // VC0 Ethernet Sender Channel 0
+        static constexpr uint32_t to_sender_1_pkts_acked_id = 3;       // VC0 Ethernet Sender Channel 1
+        static constexpr uint32_t to_sender_2_pkts_acked_id = 4;       // VC0 Ethernet Sender Channel 2
+        static constexpr uint32_t to_sender_3_pkts_acked_id = 5;       // VC0 Ethernet Sender Channel 3
+        static constexpr uint32_t to_sender_0_pkts_completed_id = 6;   // VC0 Tensix Worker on upstream device
+        static constexpr uint32_t to_sender_1_pkts_completed_id = 7;   // VC0 Passthrough from upstream device X/Y edge
+        static constexpr uint32_t to_sender_2_pkts_completed_id = 8;   // VC0 Passthrough from upstream device X/Y edge
+        static constexpr uint32_t to_sender_3_pkts_completed_id = 9;   // VC0 Passthrough from upstream device X/Y edge
+        static constexpr uint32_t to_sender_4_pkts_completed_id = 10;  // VC1 Passthrough from upstream device Z edge
+        static constexpr uint32_t to_sender_5_pkts_completed_id = 11;  // VC1 Passthrough from upstream device X/Y edge
+        static constexpr uint32_t to_sender_6_pkts_completed_id = 12;  // VC1 Passthrough from upstream device X/Y edge
+        static constexpr uint32_t to_sender_7_pkts_completed_id = 13;  // VC1 Passthrough from upstream device X/Y edge
+        // Receiver channel free slots stream IDs
+        static constexpr uint32_t vc_0_free_slots_from_downstream_edge_1 =
+            14;  // for downstream E/W/N/S edge on: 2D X/Y Router->VC0, E edge on: 2D Z Router->VC0
+        static constexpr uint32_t vc_0_free_slots_from_downstream_edge_2 =
+            15;  // for downstream E/W/N/S edge on: 2D X/Y Router->VC0, W edge on: 2D Z Router->VC0
+        static constexpr uint32_t vc_0_free_slots_from_downstream_edge_3 =
+            16;  // for downstream E/W/N/S edge on: 2D X/Y Router->VC0, N edge on: 2D Z Router->VC0
+        static constexpr uint32_t vc_0_free_slots_from_downstream_edge_4 =
+            17;  // for downstream Z edge on: 2D+Z X/Y Router->VC0, S edge on: 2D Z Router->VC0
+        static constexpr uint32_t vc_1_free_slots_from_downstream_edge_1 =
+            18;  // for downstream E/W/N/S edge on: 2D X/Y Router->VC1
+        static constexpr uint32_t vc_1_free_slots_from_downstream_edge_2 =
+            19;  // for downstream E/W/N/S edge on: 2D X/Y Router->VC1
+        static constexpr uint32_t vc_1_free_slots_from_downstream_edge_3 =
+            20;  // for downstream E/W/N/S edge on: 2D X/Y Router->VC1
+        static constexpr uint32_t vc_1_free_slots_from_downstream_edge_4 =
+            21;  // for downstream Z edge on: 2D+Z X/Y Router->VC1, S edge on: 2D Z Router->VC1
+        // Sender channel free slots stream IDs.
+        // Decremented by respective upstream senders.
+        static constexpr uint32_t sender_channel_0_free_slots_stream_id = 22;  // for upstream tensix worker
+        static constexpr uint32_t sender_channel_1_free_slots_stream_id =
+            23;  // for upstream edge on: 1D->VC0, E/W/N/S edge on: 2D X/Y Router->VC0, E edge on: 2D Z Router->VC0
+        static constexpr uint32_t sender_channel_2_free_slots_stream_id =
+            24;  // for upstream E/W/N/S edge on: 2D X/Y Router->VC0, W edge on: 2D Z Router->VC0
+        static constexpr uint32_t sender_channel_3_free_slots_stream_id =
+            25;  // for upstream E/W/N/S edge on: 2D X/Y Router->VC0, N edge on: 2D Z Router->VC0
+        static constexpr uint32_t sender_channel_4_free_slots_stream_id =
+            26;  // for upstream E/W/N/S edge on: 2D X/Y Router->VC1, S edge on: 2D Z Router->VC0
+        static constexpr uint32_t sender_channel_5_free_slots_stream_id =
+            27;  // for upstream E/W/N/S edge on: 2D X/Y Router->VC1
+        static constexpr uint32_t sender_channel_6_free_slots_stream_id =
+            28;  // for upstream E/W/N/S edge on: 2D X/Y Router->VC1
+        static constexpr uint32_t sender_channel_7_free_slots_stream_id = 29;  // for upstream Z edge on: 2D+Z->VC1
+        // Local tensix relay free slots stream ID (UDM mode only)
+        // Dual-use: also used as scratch for eth_retrain (see Scratch::eth_retrain_link_sync_stream_id)
+        static constexpr uint32_t tensix_relay_local_free_slots_stream_id = 30;
+    };
 
-    // Local tensix relay free slots stream ID (UDM mode only)
-    static constexpr uint32_t tensix_relay_local_free_slots_stream_id = 30;
-    // Multi-RISC teardown synchronization stream ID
-    // overlay scratch register
-    static constexpr uint32_t multi_risc_teardown_sync_stream_id = 31;
-    // Eth retrain synchronization stream ID
-    // overlay scratch register
-    static constexpr uint32_t eth_retrain_link_sync_stream_id = 30;
+    // Stream registers used as scratch/overlay storage. Writing overwrites the register value.
+    struct Scratch {
+        // Eth retrain synchronization stream ID
+        // Dual-use: also used as inc-on-write for tensix_relay (see
+        // IncrementOnWrite::tensix_relay_local_free_slots_stream_id)
+        static constexpr uint32_t eth_retrain_link_sync_stream_id = 30;
+        // Multi-RISC teardown synchronization stream ID
+        static constexpr uint32_t multi_risc_teardown_sync_stream_id = 31;
+    };
 
-    static const auto& get_all_stream_ids() {
-        static constexpr std::array stream_ids = {
-            to_receiver_0_pkts_sent_id,
-            to_receiver_1_pkts_sent_id,
-            to_sender_0_pkts_acked_id,
-            to_sender_1_pkts_acked_id,
-            to_sender_2_pkts_acked_id,
-            to_sender_3_pkts_acked_id,
-            to_sender_0_pkts_completed_id,
-            to_sender_1_pkts_completed_id,
-            to_sender_2_pkts_completed_id,
-            to_sender_3_pkts_completed_id,
-            to_sender_4_pkts_completed_id,
-            to_sender_5_pkts_completed_id,
-            to_sender_6_pkts_completed_id,
-            to_sender_7_pkts_completed_id,
-            vc_0_free_slots_from_downstream_edge_1,
-            vc_0_free_slots_from_downstream_edge_2,
-            vc_0_free_slots_from_downstream_edge_3,
-            vc_0_free_slots_from_downstream_edge_4,
-            vc_1_free_slots_from_downstream_edge_1,
-            vc_1_free_slots_from_downstream_edge_2,
-            vc_1_free_slots_from_downstream_edge_3,
-            vc_1_free_slots_from_downstream_edge_4,
-            sender_channel_0_free_slots_stream_id,
-            sender_channel_1_free_slots_stream_id,
-            sender_channel_2_free_slots_stream_id,
-            sender_channel_3_free_slots_stream_id,
-            sender_channel_4_free_slots_stream_id,
-            sender_channel_5_free_slots_stream_id,
-            sender_channel_6_free_slots_stream_id,
-            sender_channel_7_free_slots_stream_id,
-            tensix_relay_local_free_slots_stream_id,
-            multi_risc_teardown_sync_stream_id,
-            eth_retrain_link_sync_stream_id};
-        return stream_ids;
+    static const auto& get_inc_on_write_ids() {
+        static constexpr std::array inc_on_write_ids = {
+            IncrementOnWrite::to_receiver_0_pkts_sent_id,
+            IncrementOnWrite::to_receiver_1_pkts_sent_id,
+            IncrementOnWrite::to_sender_0_pkts_acked_id,
+            IncrementOnWrite::to_sender_1_pkts_acked_id,
+            IncrementOnWrite::to_sender_2_pkts_acked_id,
+            IncrementOnWrite::to_sender_3_pkts_acked_id,
+            IncrementOnWrite::to_sender_0_pkts_completed_id,
+            IncrementOnWrite::to_sender_1_pkts_completed_id,
+            IncrementOnWrite::to_sender_2_pkts_completed_id,
+            IncrementOnWrite::to_sender_3_pkts_completed_id,
+            IncrementOnWrite::to_sender_4_pkts_completed_id,
+            IncrementOnWrite::to_sender_5_pkts_completed_id,
+            IncrementOnWrite::to_sender_6_pkts_completed_id,
+            IncrementOnWrite::to_sender_7_pkts_completed_id,
+            IncrementOnWrite::vc_0_free_slots_from_downstream_edge_1,
+            IncrementOnWrite::vc_0_free_slots_from_downstream_edge_2,
+            IncrementOnWrite::vc_0_free_slots_from_downstream_edge_3,
+            IncrementOnWrite::vc_0_free_slots_from_downstream_edge_4,
+            IncrementOnWrite::vc_1_free_slots_from_downstream_edge_1,
+            IncrementOnWrite::vc_1_free_slots_from_downstream_edge_2,
+            IncrementOnWrite::vc_1_free_slots_from_downstream_edge_3,
+            IncrementOnWrite::vc_1_free_slots_from_downstream_edge_4,
+            IncrementOnWrite::sender_channel_0_free_slots_stream_id,
+            IncrementOnWrite::sender_channel_1_free_slots_stream_id,
+            IncrementOnWrite::sender_channel_2_free_slots_stream_id,
+            IncrementOnWrite::sender_channel_3_free_slots_stream_id,
+            IncrementOnWrite::sender_channel_4_free_slots_stream_id,
+            IncrementOnWrite::sender_channel_5_free_slots_stream_id,
+            IncrementOnWrite::sender_channel_6_free_slots_stream_id,
+            IncrementOnWrite::sender_channel_7_free_slots_stream_id,
+            IncrementOnWrite::tensix_relay_local_free_slots_stream_id};
+        return inc_on_write_ids;
+    }
+
+    static const auto& get_scratch_ids() {
+        static constexpr std::array scratch_ids = {
+            Scratch::eth_retrain_link_sync_stream_id, Scratch::multi_risc_teardown_sync_stream_id};
+        return scratch_ids;
     }
 };
 

--- a/tt_metal/fabric/fabric_tensix_builder_impl.cpp
+++ b/tt_metal/fabric/fabric_tensix_builder_impl.cpp
@@ -968,14 +968,15 @@ std::vector<uint32_t> FabricTensixDatamoverMuxBuilder::get_channel_stream_ids(Ch
                     break;
                 case tt::tt_fabric::Topology::Linear:
                 case tt::tt_fabric::Topology::Ring:
-                    fabric_stream_ids = {tt::tt_fabric::StreamRegAssignments::sender_channel_1_free_slots_stream_id};
+                    fabric_stream_ids = {
+                        tt::tt_fabric::StreamRegAssignments::IncrementOnWrite::sender_channel_1_free_slots_stream_id};
                     break;
                 case tt::tt_fabric::Topology::Mesh:
                 case tt::tt_fabric::Topology::Torus:
                     fabric_stream_ids = {
-                        tt::tt_fabric::StreamRegAssignments::sender_channel_1_free_slots_stream_id,
-                        tt::tt_fabric::StreamRegAssignments::sender_channel_2_free_slots_stream_id,
-                        tt::tt_fabric::StreamRegAssignments::sender_channel_3_free_slots_stream_id};
+                        tt::tt_fabric::StreamRegAssignments::IncrementOnWrite::sender_channel_1_free_slots_stream_id,
+                        tt::tt_fabric::StreamRegAssignments::IncrementOnWrite::sender_channel_2_free_slots_stream_id,
+                        tt::tt_fabric::StreamRegAssignments::IncrementOnWrite::sender_channel_3_free_slots_stream_id};
                     break;
                 default: TT_THROW("Unknown fabric topology: {}", static_cast<int>(topology)); break;
             }

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
@@ -42,8 +42,12 @@ namespace tt::tt_fabric {
  * As the adapter writes into the EDM, it updates the local wrptr. As the EDM reads from its local L1 channel buffer,
  * it will notify the worker/adapter (here) by updating the worker remote_rdptr to carry the value of the EDM rdptr.
  */
-template <bool I_USE_STREAM_REG_FOR_CREDIT_RECEIVE, uint8_t EDM_NUM_BUFFER_SLOTS = 0>
-struct WorkerToFabricEdmSenderImpl {
+template <
+    bool I_USE_STREAM_REG_FOR_CREDIT_RECEIVE,
+    uint8_t EDM_NUM_BUFFER_SLOTS = 0,
+    uint32_t STREAM_ID = tt::tt_fabric::connection_interface::sender_channel_0_free_slots_stream_id>
+struct WorkerToFabricEdmSenderBase {
+    static_assert(STREAM_ID <= 31, "Stream ID must be in range 0-31");
     static constexpr bool ENABLE_STATEFUL_WRITE_CREDIT_TO_DOWNSTREAM_EDM =
 #if !defined(DEBUG_PRINT_ENABLED) and !defined(WATCHER_ENABLED)
         true;
@@ -59,10 +63,10 @@ struct WorkerToFabricEdmSenderImpl {
     static constexpr size_t BUFFER_SLOT_PTR_WRAP = EDM_NUM_BUFFER_SLOTS * 2;
     // HACK: Need a way to properly set this up
 
-    WorkerToFabricEdmSenderImpl() = default;
+    WorkerToFabricEdmSenderBase() = default;
 
     template <ProgrammableCoreType my_core_type>
-    static WorkerToFabricEdmSenderImpl build_from_args(std::size_t& arg_idx) {
+    static WorkerToFabricEdmSenderBase build_from_args(std::size_t& arg_idx) {
         constexpr bool is_persistent_fabric = true;
         uint8_t direction;
         uint8_t edm_worker_x;
@@ -115,7 +119,7 @@ struct WorkerToFabricEdmSenderImpl {
             auto writer_send_sem_id = get_arg_val<uint32_t>(arg_idx++);
             writer_send_sem_addr =
                 reinterpret_cast<volatile uint32_t*>(get_semaphore<my_core_type>(writer_send_sem_id));
-            worker_free_slots_stream_id = tt::tt_fabric::connection_interface::sender_channel_0_free_slots_stream_id;
+            worker_free_slots_stream_id = STREAM_ID;
         }
 
         // DEAD CODE
@@ -126,7 +130,7 @@ struct WorkerToFabricEdmSenderImpl {
         auto worker_teardown_sem_addr =
             reinterpret_cast<volatile uint32_t* const>(get_semaphore<my_core_type>(get_arg_val<uint32_t>(arg_idx++)));
         const auto worker_buffer_index_semaphore_addr = get_semaphore<my_core_type>(get_arg_val<uint32_t>(arg_idx++));
-        return WorkerToFabricEdmSenderImpl(
+        return WorkerToFabricEdmSenderBase(
             is_persistent_fabric,
             edm_worker_x,
             edm_worker_y,
@@ -215,7 +219,7 @@ struct WorkerToFabricEdmSenderImpl {
     }
 
     template <ProgrammableCoreType my_core_type = ProgrammableCoreType::ACTIVE_ETH>
-    FORCE_INLINE WorkerToFabricEdmSenderImpl(
+    FORCE_INLINE WorkerToFabricEdmSenderBase(
         bool connected_to_persistent_fabric,
         uint8_t edm_worker_x,
         uint8_t edm_worker_y,
@@ -597,6 +601,12 @@ private:
         post_send_payload_increment_pointers();
     }
 };
+
+// Type alias preserving the current name for all existing callers.
+// Stream ID 22 (sender_channel_0 free slots) is the default for VC0/VC1 worker connections.
+template <bool I_USE_STREAM_REG_FOR_CREDIT_RECEIVE, uint8_t EDM_NUM_BUFFER_SLOTS = 0>
+using WorkerToFabricEdmSenderImpl =
+    WorkerToFabricEdmSenderBase<I_USE_STREAM_REG_FOR_CREDIT_RECEIVE, EDM_NUM_BUFFER_SLOTS>;
 
 using WorkerToFabricEdmSender = WorkerToFabricEdmSenderImpl<false, 0>;
 


### PR DESCRIPTION
this cleans up the distinction between stream/overlay register types that are used/assigned in the fabric builder. Incremental changes for in progress work. Additionally, worker adapter is cleaned up to take a stream ID as a template argument so we can parametrize it to support multiple non-static fabric connections.

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snijjar/cleanup-fabric-stream-reg-assignments)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snijjar/cleanup-fabric-stream-reg-assignments)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snijjar/cleanup-fabric-stream-reg-assignments)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snijjar/cleanup-fabric-stream-reg-assignments)
- [x] [![tm-fabric-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tm-fabric-tests.yaml/badge.svg?branch=snijjar/cleanup-fabric-stream-reg-assignments)](https://github.com/tenstorrent/tt-metal/actions/workflows/tm-fabric-tests.yaml?query=branch:snijjar/cleanup-fabric-stream-reg-assignments) - same failures on main