### PR TITLE
ci: skip fabric_ring tests in Galaxy multi-user isolation tray scenario

### DIFF
--- a/.github/workflows/galaxy-multi-user-isolation-tests.yaml
+++ b/.github/workflows/galaxy-multi-user-isolation-tests.yaml
@@ -82,6 +82,7 @@ jobs:
             container_prefix: tray
             mesh_descriptor: t3k_mesh_graph_descriptor.textproto
             test_path: tests/nightly/t3000/ccl/test_minimal_all_gather_async.py
+            # Exclude fabric_ring tests for tray: t3k tray topology and mesh descriptor are mismatched, causing these cases to fail in CI.
             test_args: "-k 'not fabric_ring'"
     runs-on:
       - topology-6u

--- a/.github/workflows/galaxy-multi-user-isolation-tests.yaml
+++ b/.github/workflows/galaxy-multi-user-isolation-tests.yaml
@@ -82,7 +82,7 @@ jobs:
             container_prefix: tray
             mesh_descriptor: t3k_mesh_graph_descriptor.textproto
             test_path: tests/nightly/t3000/ccl/test_minimal_all_gather_async.py
-            test_args: ""
+            test_args: "-k 'not fabric_ring'"
     runs-on:
       - topology-6u
       - arch-${{ matrix.arch }}


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Failed CI: https://github.com/tenstorrent/tt-metal/actions/runs/23123001526/job/67160799826#step:12:277

`FABRIC_1D_RING` maps to `TORUS_XY` topology, but the tray scenario uses `t3k_mesh_graph_descriptor.textproto` (MESH 2x4, no ring), which cannot satisfy `TORUS_XY`.

### What's changed
Added `-k 'not fabric_ring'` to exclude incompatible tests on this runners.

Passed CI: https://github.com/tenstorrent/tt-metal/actions/runs/23180352705/job/67352289667

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix-isolation-failed)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix-isolation-failed)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fix-isolation-failed)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fix-isolation-failed)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix-isolation-failed)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix-isolation-failed)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early