### PR TITLE
Skip Falcon7B prefill seq 2048 perf test on WH due to nd failures

### DIFF
--- a/models/demos/falcon7b_common/tests/test_perf_falcon.py
+++ b/models/demos/falcon7b_common/tests/test_perf_falcon.py
@@ -90,6 +90,9 @@ class TestParametrized:
         model_config_str,
         mesh_device,
     ):
+        if llm_mode == "prefill" and seq_len == 2048:
+            pytest.skip("Skipping prefill seq 2048 on WH due to perf regression, see #40015")
+
         if llm_mode == "prefill":
             expected_output_pcc, expected_k_cache_pcc, expected_v_cache_pcc = PREFILL_CONFIG_TO_PCC[
                 DeviceSetup.WORMHOLE_B0


### PR DESCRIPTION
### Ticket
#40015

### Problem description
Falcon prefill perf test with seq len 2k has been failing non-deterministically for a while now. Disabling as the owners had other priorities.

### Checklist
Model perf: https://github.com/tenstorrent/tt-metal/actions/runs/23186782509 ✅ 
