### PR TITLE
Add missing nanobind vector include to pool nanobind

### DIFF
--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools_nanobind.cpp
@@ -14,6 +14,7 @@
 #include <nanobind/stl/array.h>
 #include <nanobind/stl/optional.h>
 #include <nanobind/stl/variant.h>
+#include <nanobind/stl/vector.h>
 
 #include "ttnn-nanobind/bind_function.hpp"
 #include "ttnn/types.hpp"


### PR DESCRIPTION
## Summary

- Adds missing `#include <nanobind/stl/vector.h>` to `generic_pools_nanobind.cpp`
- `max_pool2d` with `return_indices=True` calls `nb::cast()` on a `std::vector<Tensor>` but relied on the Unity build grouping with `dram_prefetcher_nanobind.cpp` (which has the include) to provide the type caster
- PR #39625 added new source files to the `ttnn` target, reshuffling Unity groups in CI so the include was no longer transitively available, causing `RuntimeError: std::bad_cast` in `test_mpwi_20_core_C_dims[in_c=1]`

## Test plan
- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic%2Ffix_pool_nanobind)](https://github.com/tenstorrent/tt-metal/actions/runs/23188653662)
- [x] [![Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic%2Ffix_pool_nanobind)](https://github.com/tenstorrent/tt-metal/actions/runs/23188655302)

🤖 Generated with [Claude Code](https://claude.com/claude-code)