### PR TITLE
Fix stress tests broken by removal of get_device_core_grid

### DIFF
--- a/tests/ttnn/stress_tests/test_data_movement.py
+++ b/tests/ttnn/stress_tests/test_data_movement.py
@@ -6,7 +6,7 @@ import pytest
 import torch
 
 import ttnn
-from ttnn.device import get_device_core_grid, is_blackhole, is_wormhole_b0
+from ttnn.device import is_blackhole, is_wormhole_b0
 
 NUM_REPEATS = 5
 NUM_DEVICES = ttnn.distributed.get_num_pcie_devices()
@@ -82,7 +82,7 @@ def sharding_input_shape():
 @pytest.mark.parametrize("mesh_device", [(1, NUM_DEVICES)], indirect=True)
 def test_stress_reshard(mesh_device):
     input_tensor_shape = sharding_input_shape()
-    core_grid = get_device_core_grid(mesh_device)
+    core_grid = mesh_device.core_grid
 
     l1_shard_grid = ttnn.CoreRangeSet(
         {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(core_grid.x - 1, core_grid.y - 1))}

--- a/tests/ttnn/stress_tests/test_eltwise.py
+++ b/tests/ttnn/stress_tests/test_eltwise.py
@@ -6,7 +6,7 @@ import pytest
 import torch
 
 import ttnn
-from ttnn.device import get_device_core_grid, is_blackhole, is_wormhole_b0
+from ttnn.device import is_blackhole, is_wormhole_b0
 
 NUM_REPEATS = 5
 NUM_DEVICES = ttnn.distributed.get_num_pcie_devices()


### PR DESCRIPTION
## Summary
- PR #37707 moved `MeshDevice.core_grid` from a Python-defined property to C++, deleting the `get_device_core_grid` helper function from `ttnn.device`
- Two stress test files (`test_data_movement.py`, `test_eltwise.py`) still imported `get_device_core_grid` by name, causing `ImportError` during collection
- Updated imports to remove `get_device_core_grid` and replaced the one call site with `mesh_device.core_grid`

Fixes the nightly **(Blackhole) e2e tests** → `blackhole-ttnn-stress-tests` failure:
https://github.com/tenstorrent/tt-metal/actions/runs/23184582324/job/67377516229

## Test plan
- [x] Verified `from ttnn.device import is_blackhole, is_wormhole_b0` imports successfully
- [x] Verified `device.core_grid` returns `ttnn.CoreGrid` on local device
- [x] Verified `pytest --collect-only tests/ttnn/stress_tests/` collects all 119 tests with 0 errors
- [x] Blackhole e2e pipeline should pass stress tests https://github.com/tenstorrent/tt-metal/actions/runs/23210021301