### PR TITLE
[skip ci] Remove merge_group trigger in tt-train-build-and-test

### DIFF
--- a/.github/workflows/tt-train-build-and-test.yaml
+++ b/.github/workflows/tt-train-build-and-test.yaml
@@ -3,7 +3,6 @@ name: "[tt-train] Build and Test"
 on:
   workflow_call:
   workflow_dispatch:
-  merge_group:
 
 jobs:
   run-tests:


### PR DESCRIPTION
### Problem description
This workflow is constantly failing and blocking merge queue

### What's changed
Remove merge queue trigger for this workflow

