### PR TITLE
Optimize ring joint SDPA: reuse Q across ring iterations for single-chunk cores

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -1649,7 +1649,8 @@ void sdpa_inner_loop(
     const uint32_t cb_out,
     const LightweightMaskContext& lw_mask = {},
     const bool is_causal = false,
-    const bool is_balanced = false) {
+    const bool is_balanced = false,
+    const bool is_last_ring_iter = true) {
     uint32_t KV_chunks_processed_in_iter = 0;
 
     for (uint32_t q_iter = iter_q_start; q_iter < iter_q_end; ++q_iter) {
@@ -2017,7 +2018,12 @@ void sdpa_inner_loop(
             cb_pop_front(alias_prev_max, Sq_chunk_t);
         }
 
-        cb_pop_front(cb_q_in, q_chunk_tiles);
+        // When q_per_core == 1, Q is identical across ring iterations so we keep it
+        // fronted in the CB and only pop on the last iteration to avoid redundant DRAM re-reads.
+        const uint32_t q_per_core = iter_q_end - iter_q_start;
+        if (q_per_core > 1 || is_last_ring_iter) {
+            cb_pop_front(cb_q_in, q_chunk_tiles);
+        }
     }
 
     if constexpr (sdpa_type == RING) {
@@ -2356,7 +2362,8 @@ void sdpa_ring(
     const uint32_t cb_out,
     const LightweightMaskContext& lw_mask,
     const bool is_causal,
-    const bool is_balanced) {
+    const bool is_balanced,
+    const bool is_last_ring_iter) {
     sdpa_inner_loop<
         RING,
         cb_qk_im,
@@ -2431,7 +2438,8 @@ void sdpa_ring(
         cb_out,
         lw_mask,
         is_causal,
-        is_balanced);
+        is_balanced,
+        is_last_ring_iter);
 }
 
 /**

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -1652,6 +1652,7 @@ void sdpa_inner_loop(
     const bool is_balanced = false,
     const bool is_last_ring_iter = true) {
     uint32_t KV_chunks_processed_in_iter = 0;
+    const uint32_t q_per_core = iter_q_end - iter_q_start;
 
     for (uint32_t q_iter = iter_q_start; q_iter < iter_q_end; ++q_iter) {
         uint32_t q_low_idx;
@@ -2020,7 +2021,6 @@ void sdpa_inner_loop(
 
         // When q_per_core == 1, Q is identical across ring iterations so we keep it
         // fronted in the CB and only pop on the last iteration to avoid redundant DRAM re-reads.
-        const uint32_t q_per_core = iter_q_end - iter_q_start;
         if (q_per_core > 1 || is_last_ring_iter) {
             cb_pop_front(cb_q_in, q_chunk_tiles);
         }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -1463,8 +1463,12 @@ void sdpa_ring_v2(
             }
         }
 
-        // Pop Q — not popped inside step since ring_mode gates the early Q pop
-        cb_pop_front(cb_q_in, Sq_chunk_t * DHt);
+        // Pop Q — not popped inside step since ring_mode gates the early Q pop.
+        // When q_per_core == 1, Q is identical across ring iterations so we keep it
+        // fronted in the CB and only pop on the last iteration to avoid redundant DRAM re-reads.
+        if (q_per_core > 1 || is_last_ring_iter) {
+            cb_pop_front(cb_q_in, Sq_chunk_t * DHt);
+        }
 
         // Persist or save accumulators for next ring iteration
         if (q_per_core == 1) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
@@ -190,8 +190,9 @@ void kernel_main() {
             lw_mask.global_n_padded_tiles = Sk_chunk_t - valid_tiles;
         }
 
+        const bool is_last_ring_iter = (ring_iter == last_active_ring_iter);
+
         if constexpr (use_streaming_compute) {
-            const bool is_last_ring_iter = (ring_iter == last_active_ring_iter);
             sdpa_ring_v2<
                 Sq_chunk_t,
                 Sk_chunk_t,
@@ -300,7 +301,8 @@ void kernel_main() {
                 cb_out,
                 lw_mask,
                 causality,
-                balancing);
+                balancing,
+                is_last_ring_iter);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
@@ -52,6 +52,7 @@ void kernel_main() {
     const uint32_t joint_v_addr = get_arg_val<uint32_t>(argidx++);
     const uint32_t global_q_start = get_arg_val<uint32_t>(argidx++);
     const uint32_t global_q_end = get_arg_val<uint32_t>(argidx++);
+    const uint32_t q_per_core = global_q_end - global_q_start;
 
     const uint32_t is_chain_participant = get_arg_val<uint32_t>(argidx++);
     const uint32_t is_injector = get_arg_val<uint32_t>(argidx++);
@@ -232,6 +233,10 @@ void kernel_main() {
                                         (q_iter_local < next_core_q_chunks);
             const bool should_receive = is_chain_participant && !is_injector && (nb == chain_batch && nq == chain_head);
 
+            // When q_per_core == 1, Q is identical across ring iterations: compute keeps it
+            // fronted in the CB, so we only need to read it once on ring_iter 0.
+            const bool need_q_read = (q_per_core > 1) || (ring_iter == 0);
+
             for (uint32_t k_chunk = 0; k_chunk < iter_num_kv_chunks; ++k_chunk) {
                 /**
                  * Iterate over all KV chunks for this Q chunk.
@@ -327,7 +332,7 @@ void kernel_main() {
                 // Push Q one subblock at a time so compute can start QK matmul incrementally.
                 // Placed after K forward so no outstanding NOC writes remain
                 // (noc_async_read_barrier inside subblock read would deadlock with in-flight writes).
-                if (k_chunk == 0) {
+                if (k_chunk == 0 && need_q_read) {
                     if constexpr (use_q_subblock_push) {
                         for (uint32_t q_sub = 0; q_sub < q_num_subblocks; ++q_sub) {
                             const uint32_t sb_row_start = q_slice.d2_start + q_sub * qk_subblock_h;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
@@ -157,6 +157,10 @@ void kernel_main() {
     const auto joint_k_generator = PaddedAddrGenerator(joint_k_reader, joint_input_tile_logical);
     const auto joint_v_generator = PaddedAddrGenerator(joint_v_reader, joint_input_tile_logical);
 
+    // Tracks whether Q has been pushed for q_per_core == 1 optimization.
+    // When q_per_core == 1, Q is identical across ring iterations so we only push it once.
+    bool q_pushed = false;
+
     /**
      * Iterate over ring indices.
      * On the first iteration, read from local K, V.
@@ -234,8 +238,8 @@ void kernel_main() {
             const bool should_receive = is_chain_participant && !is_injector && (nb == chain_batch && nq == chain_head);
 
             // When q_per_core == 1, Q is identical across ring iterations: compute keeps it
-            // fronted in the CB, so we only need to read it once on ring_iter 0.
-            const bool need_q_read = (q_per_core > 1) || (ring_iter == 0);
+            // fronted in the CB, so we only need to read it once on the first active ring iteration.
+            const bool need_q_read = (q_per_core > 1) || !q_pushed;
 
             for (uint32_t k_chunk = 0; k_chunk < iter_num_kv_chunks; ++k_chunk) {
                 /**
@@ -357,6 +361,7 @@ void kernel_main() {
                             false /*transpose*/
                         );
                     }
+                    q_pushed = true;
                 }
 
                 // V: either read locally (injector or not participant) or receive from previous core


### PR DESCRIPTION
## Summary

In ring joint SDPA, when a core processes only a single Q chunk (`q_per_core == 1`), the Q data is identical across all ring iterations. Previously, Q was re-read from DRAM and re-pushed into the circular buffer on every iteration.

This change keeps Q fronted in the CB across ring iterations and only pops it on the final one, skipping the redundant DRAM re-reads on both the reader and compute sides.

About ~0.4% improvement on galaxy for wan2.2 shape.

## Test plan
- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic%2Fring-sdpa-q-reuse-opt)](https://github.com/tenstorrent/tt-metal/actions/runs/23305317062)
- [x] [![(Single-card) Fast dispatch frequent tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml/badge.svg?branch=skrstic%2Fring-sdpa-q-reuse-opt)](https://github.com/tenstorrent/tt-metal/actions/runs/23305318802)
- [x] [![Nightly tt-metal L2 tests (sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic%2Fring-sdpa-q-reuse-opt)](https://github.com/tenstorrent/tt-metal/actions/runs/23307214063)
- [x] [![Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=skrstic%2Fring-sdpa-q-reuse-opt)](https://github.com/tenstorrent/tt-metal/actions/runs/23305322477)
- [x] [![(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=skrstic%2Fring-sdpa-q-reuse-opt)](https://github.com/tenstorrent/tt-metal/actions/runs/23305324465)
- [x] [![(Galaxy) demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml/badge.svg?branch=skrstic%2Fring-sdpa-q-reuse-opt)](https://github.com/tenstorrent/tt-metal/actions/runs/23305326184)
- [x] [![(T3K) T3000 integration tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-integration-tests.yaml/badge.svg?branch=skrstic%2Fring-sdpa-q-reuse-opt)](https://github.com/tenstorrent/tt-metal/actions/runs/23305327957)
- [x] [![(T3K) T3000 e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=skrstic%2Fring-sdpa-q-reuse-opt)](https://github.com/tenstorrent/tt-metal/actions/runs/23305329567)

🤖 Generated with [Claude Code](https://claude.com/claude-code)