### PR TITLE
Switch ring joint SDPA test to ring topology

### DIFF
--- a/tests/nightly/blackhole/ccl/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/ccl/test_ring_joint_sdpa.py
@@ -286,9 +286,14 @@ def run_ring_joint_sdpa(
     num_devices = detect_devices_without_opening()
     sp_size, tp_size, arch_type = calculate_mesh_config(num_devices)
 
+    # Ring topology requires >2 devices; fall back to linear for <=2
+    use_ring = sp_size > 2
+    fabric_config = ttnn.FabricConfig.FABRIC_1D_RING if use_ring else ttnn.FabricConfig.FABRIC_1D
+    topology = Topology.Ring if use_ring else Topology.Linear
+
     # Configure fabric for ring joint attention
     ttnn.set_fabric_config(
-        ttnn.FabricConfig.FABRIC_1D_RING,
+        fabric_config,
         ttnn.FabricReliabilityMode.STRICT_INIT,
         None,
         ttnn.FabricTensixConfig.DISABLED,
@@ -487,7 +492,7 @@ def run_ring_joint_sdpa(
                 num_links=num_links,
                 cluster_axis=sp_axis,
                 mesh_device=mesh_device,
-                topology=Topology.Ring,
+                topology=topology,
                 subdevice_id=worker_sub_device_id,
                 ccl_core_grid_offset=(ccl_column, 0),  # Point to CCL column
                 use_column_major_ccl=True,

--- a/tests/nightly/blackhole/ccl/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/ccl/test_ring_joint_sdpa.py
@@ -288,7 +288,7 @@ def run_ring_joint_sdpa(
 
     # Configure fabric for ring joint attention
     ttnn.set_fabric_config(
-        ttnn.FabricConfig.FABRIC_1D,
+        ttnn.FabricConfig.FABRIC_1D_RING,
         ttnn.FabricReliabilityMode.STRICT_INIT,
         None,
         ttnn.FabricTensixConfig.DISABLED,
@@ -487,7 +487,7 @@ def run_ring_joint_sdpa(
                 num_links=num_links,
                 cluster_axis=sp_axis,
                 mesh_device=mesh_device,
-                topology=Topology.Linear,
+                topology=Topology.Ring,
                 subdevice_id=worker_sub_device_id,
                 ccl_core_grid_offset=(ccl_column, 0),  # Point to CCL column
                 use_column_major_ccl=True,


### PR DESCRIPTION
## Summary

Switch ring joint SDPA test from linear topology to ring topology (`Topology.Ring`, `FABRIC_1D_RING`), with fallback to linear topology (`Topology.Linear`, `FABRIC_1D`) when sp_size <= 2.

## Test plan
- [x] [![(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=skrstic%2Fring-joint-sdpa-ring-topology)](https://github.com/tenstorrent/tt-metal/actions/runs/23337506851)

🤖 Generated with [Claude Code](https://claude.com/claude-code)