### PR TITLE
[feature] fabric builder extend max vc to 3

### DIFF
--- a/tests/tt_metal/tt_fabric/fabric_router/test_channel_trimming_capture.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_channel_trimming_capture.cpp
@@ -59,7 +59,8 @@ namespace tt::tt_fabric::fabric_router_tests {
 // ============================================================================
 // Type alias for the capture results struct used throughout these tests
 // ============================================================================
-using CaptureResults = FabricDatapathUsageL1Results<true, builder_config::num_max_receiver_channels, builder_config::num_max_sender_channels>;
+using CaptureResults =
+    FabricDatapathUsageL1Results<true, builder_config::MAX_NUM_VCS, builder_config::num_max_sender_channels>;
 
 // ============================================================================
 // Helper: Result of reading capture data from a single ETH core

--- a/tt_metal/fabric/builder/fabric_builder_config.hpp
+++ b/tt_metal/fabric/builder/fabric_builder_config.hpp
@@ -41,7 +41,7 @@ struct FabricEriscDatamoverOptions {
 
 namespace builder_config {
 // Number of Virtual Channels supported (VC0 and VC1)
-static constexpr std::size_t MAX_NUM_VCS = 2;
+static constexpr std::size_t MAX_NUM_VCS = 3;
 
 // linear/mesh/ring/torus: for fabric with tensix extension, only one sender channel will be present on fabric router
 static constexpr std::size_t num_sender_channels_with_tensix_config = 1;

--- a/tt_metal/fabric/builder/fabric_remote_channels_allocator.hpp
+++ b/tt_metal/fabric/builder/fabric_remote_channels_allocator.hpp
@@ -108,7 +108,11 @@ public:
      * @return Total number of used receiver channels
      */
     size_t get_num_receiver_channels() const {
-        return num_used_receiver_channels_per_vc_[0] + num_used_receiver_channels_per_vc_[1];
+        size_t total = 0;
+        for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
+            total += num_used_receiver_channels_per_vc_[vc];
+        }
+        return total;
     }
 
     /**

--- a/tt_metal/fabric/builder/fabric_remote_channels_allocator.hpp
+++ b/tt_metal/fabric/builder/fabric_remote_channels_allocator.hpp
@@ -122,7 +122,7 @@ private:
         remote_receiver_channels_base_address_ = {};
     std::array<std::array<size_t, builder_config::num_max_receiver_channels>, builder_config::MAX_NUM_VCS>
         remote_receiver_channels_num_buffers_ = {};
-    std::array<size_t, builder_config::MAX_NUM_VCS> num_used_receiver_channels_per_vc_ = {0, 0};
+    std::array<size_t, builder_config::MAX_NUM_VCS> num_used_receiver_channels_per_vc_ = {};
 };
 
 inline void FabricRemoteChannelsAllocator::print(std::ostream& os) const {

--- a/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
+++ b/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
@@ -285,12 +285,14 @@ void FabricStaticSizedChannelsAllocator::configure_buffer_slots_helper(
         num_receiver_buffer_slots_per_vc,
     std::array<std::array<size_t, builder_config::num_max_receiver_channels>, builder_config::MAX_NUM_VCS>&
         num_remote_receiver_buffer_slots_per_vc) {
-    // Per-VC buffer slot configuration: {vc0_sender, vc0_receiver, vc1_sender, vc1_receiver}
+    // Per-VC buffer slot configuration: {vc0_sender, vc0_receiver, vc1_sender, vc1_receiver, vc2_sender, vc2_receiver}
     struct PerVcBufferSlots {
         size_t vc0_sender_slots;
         size_t vc0_receiver_slots;
         size_t vc1_sender_slots;
         size_t vc1_receiver_slots;
+        size_t vc2_sender_slots;
+        size_t vc2_receiver_slots;
     };
 
     // fabric with tensix extension uses different buffer slots options, since only one or two sender channels are
@@ -299,109 +301,154 @@ void FabricStaticSizedChannelsAllocator::configure_buffer_slots_helper(
     static const std::vector<std::vector<PerVcBufferSlots>> default_with_tensix_buffer_slot_options = {
         // WORMHOLE_B0
         {
-            {16, 16, 0, 0},  // Option 1
-            {8, 16, 0, 0},   // Option 2
-            {8, 8, 0, 0},    // Option 3
-            {4, 8, 0, 0},    // Option 4
-            {4, 4, 0, 0},    // Option 5: VC0 only, smaller
-            {2, 4, 0, 0},    // Option 6: VC0 only, smaller
-            {2, 2, 0, 0},    // Option 7: VC0 only, smaller
-            {1, 2, 0, 0},    // Option 8: VC0 only, smallest
-            {1, 1, 0, 0},    // Option 9: VC0 only, smallest
-            {4, 8, 4, 4},    // Option 10: supports both VCs
-            {4, 8, 2, 2},    // Option 11: supports both VCs
-            {4, 4, 2, 2},    // Option 12: supports both VCs
-            {2, 2, 2, 2}     // Option 13: supports both VCs
+            {16, 16, 0, 0, 0, 0},  // Option 1
+            {8, 16, 0, 0, 0, 0},   // Option 2
+            {8, 8, 0, 0, 0, 0},    // Option 3
+            {4, 8, 0, 0, 0, 0},    // Option 4
+            {4, 4, 0, 0, 0, 0},    // Option 5: VC0 only, smaller
+            {2, 4, 0, 0, 0, 0},    // Option 6: VC0 only, smaller
+            {2, 2, 0, 0, 0, 0},    // Option 7: VC0 only, smaller
+            {1, 2, 0, 0, 0, 0},    // Option 8: VC0 only, smallest
+            {1, 1, 0, 0, 0, 0},    // Option 9: VC0 only, smallest
+            {4, 8, 4, 4, 0, 0},    // Option 10: supports VC0+VC1
+            {4, 8, 2, 2, 0, 0},    // Option 11: supports VC0+VC1
+            {4, 4, 2, 2, 0, 0},    // Option 12: supports VC0+VC1
+            {2, 2, 2, 2, 0, 0}     // Option 13: supports VC0+VC1
         },
         // BLACKHOLE
         {
-            {32, 32, 0, 0},  // Option 1
-            {16, 32, 0, 0},  // Option 2
-            {16, 16, 0, 0},  // Option 3
-            {8, 16, 0, 0},   // Option 4
-            {8, 8, 0, 0},    // Option 5
-            {4, 8, 0, 0},    // Option 6
-            {4, 4, 0, 0},    // Option 7
-            {2, 4, 0, 0},    // Option 8
-            {2, 2, 0, 0},    // Option 9
-            {1, 2, 0, 0},    // Option 10
-            {1, 1, 0, 0},    // Option 11
-            {4, 8, 2, 4},    // Option 12: supports both VCs
-            {4, 8, 2, 2},    // Option 13: supports both VCs, smaller VC1 receiver
-            {2, 4, 2, 2},    // Option 14: supports both VCs, smaller overall
-            {2, 4, 1, 1},    // Option 15: supports both VCs, smaller overall
-            {2, 2, 1, 1},    // Option 16: supports both VCs, smaller overall
-            {1, 1, 1, 1}     // Option 17: supports both VCs, smaller overall
+            {32, 32, 0, 0, 0, 0},  // Option 1
+            {16, 32, 0, 0, 0, 0},  // Option 2
+            {16, 16, 0, 0, 0, 0},  // Option 3
+            {8, 16, 0, 0, 0, 0},   // Option 4
+            {8, 8, 0, 0, 0, 0},    // Option 5
+            {4, 8, 0, 0, 0, 0},    // Option 6
+            {4, 4, 0, 0, 0, 0},    // Option 7
+            {2, 4, 0, 0, 0, 0},    // Option 8
+            {2, 2, 0, 0, 0, 0},    // Option 9
+            {1, 2, 0, 0, 0, 0},    // Option 10
+            {1, 1, 0, 0, 0, 0},    // Option 11
+            {4, 8, 2, 4, 0, 0},    // Option 12: supports VC0+VC1
+            {4, 8, 2, 2, 0, 0},    // Option 13: supports VC0+VC1, smaller VC1 receiver
+            {2, 4, 2, 2, 0, 0},    // Option 14: supports VC0+VC1, smaller overall
+            {2, 4, 1, 1, 0, 0},    // Option 15: supports VC0+VC1, smaller overall
+            {2, 2, 1, 1, 0, 0},    // Option 16: supports VC0+VC1, smaller overall
+            {1, 1, 1, 1, 0, 0}     // Option 17: supports VC0+VC1, smaller overall
 
         }};
 
-    auto get_num_buffer_slots = [](Topology topology, size_t arch_index) -> const std::vector<PerVcBufferSlots>& {
-        // Architecture-specific buffer slot configurations per VC
-        // Format: {vc0_sender, vc0_receiver, vc1_sender, vc1_receiver}
-        static const std::vector<std::vector<PerVcBufferSlots>> mesh_buffer_slot_options = {
+    auto get_num_buffer_slots =
+        [](Topology topology, size_t arch_index, size_t num_active_vcs) -> const std::vector<PerVcBufferSlots>& {
+        // Architecture-specific buffer slot configurations per VC, split by active VC count
+        // Format: {vc0_sender, vc0_receiver, vc1_sender, vc1_receiver, vc2_sender, vc2_receiver}
+
+        // VC0-only mesh options: vc1 slots = 0, vc2 slots = 0
+        static const std::vector<std::vector<PerVcBufferSlots>> vc0_only_mesh_buffer_slot_options = {
             // WORMHOLE_B0
             {
-                {7, 11, 0, 0},  // Option 1: VC0 only
-                {4, 8, 0, 0},   // Option 2: VC0 only, smaller
-                {4, 4, 0, 0},   // Option 3: VC0 only, smaller
-                {2, 4, 0, 0},   // Option 4: VC0 only, smaller
-                {2, 2, 0, 0},   // Option 5: VC0 only, smaller
-                {1, 2, 0, 0},   // Option 6: VC0 only, smallest
-                {1, 1, 0, 0},   // Option 7: VC0 only, smallest
-                {4, 8, 2, 4},   // Option 8: supports both VCs
-                {4, 8, 2, 2},   // Option 9: supports both VCs, smaller VC1 receiver
-                {2, 4, 2, 2},   // Option 10: supports both VCs, smaller overall
-                {2, 4, 1, 1},   // Option 11: supports both VCs, smaller overall
-                {2, 2, 1, 1},   // Option 12: supports both VCs, smaller overall
-                {1, 1, 1, 1}    // Option 13: supports both VCs, smaller overall
+                {7, 11, 0, 0, 0, 0},  // Option 1: VC0 only
+                {4, 8, 0, 0, 0, 0},   // Option 2: VC0 only, smaller
+                {4, 4, 0, 0, 0, 0},   // Option 3: VC0 only, smaller
+                {2, 4, 0, 0, 0, 0},   // Option 4: VC0 only, smaller
+                {2, 2, 0, 0, 0, 0},   // Option 5: VC0 only, smaller
+                {1, 2, 0, 0, 0, 0},   // Option 6: VC0 only, smallest
+                {1, 1, 0, 0, 0, 0}    // Option 7: VC0 only, smallest
             },
             // BLACKHOLE
             {
-                {8, 16, 0, 0},  // Option 1: VC0 only
-                {8, 8, 0, 0},   // Option 2: VC0 only
-                {4, 8, 0, 0},   // Option 3: VC0 only
-                {4, 4, 0, 0},   // Option 4: VC0 only, smaller
-                {2, 4, 0, 0},   // Option 5: VC0 only, smaller
-                {2, 2, 0, 0},   // Option 6: VC0 only, smaller
-                {1, 2, 0, 0},   // Option 7: VC0 only, smallest
-                {1, 1, 0, 0},   // Option 8: VC0 only, smallest
-                {4, 8, 2, 4},   // Option 9: supports both VCs
-                {4, 8, 2, 2},   // Option 10: supports both VCs, smaller VC1 receiver
-                {2, 4, 2, 2},   // Option 11: supports both VCs, smaller overall
-                {2, 4, 1, 1},   // Option 12: supports both VCs, smaller overall
-                {2, 2, 1, 1},   // Option 13: supports both VCs, smaller overall
-                {1, 1, 1, 1}    // Option 14: supports both VCs, smaller overall
+                {8, 16, 0, 0, 0, 0},  // Option 1: VC0 only
+                {8, 8, 0, 0, 0, 0},   // Option 2: VC0 only
+                {4, 8, 0, 0, 0, 0},   // Option 3: VC0 only
+                {4, 4, 0, 0, 0, 0},   // Option 4: VC0 only, smaller
+                {2, 4, 0, 0, 0, 0},   // Option 5: VC0 only, smaller
+                {2, 2, 0, 0, 0, 0},   // Option 6: VC0 only, smaller
+                {1, 2, 0, 0, 0, 0},   // Option 7: VC0 only, smallest
+                {1, 1, 0, 0, 0, 0}    // Option 8: VC0 only, smallest
             }};
+
+        // VC0+VC1 mesh options: vc1 slots > 0, vc2 slots = 0
+        static const std::vector<std::vector<PerVcBufferSlots>> vc0_vc1_mesh_buffer_slot_options = {
+            // WORMHOLE_B0
+            {
+                {4, 8, 2, 4, 0, 0},  // Option 1: supports VC0+VC1
+                {4, 8, 2, 2, 0, 0},  // Option 2: supports VC0+VC1, smaller VC1 receiver
+                {2, 4, 2, 2, 0, 0},  // Option 3: supports VC0+VC1, smaller overall
+                {2, 4, 1, 1, 0, 0},  // Option 4: supports VC0+VC1, smaller overall
+                {2, 2, 1, 1, 0, 0},  // Option 5: supports VC0+VC1, smaller overall
+                {1, 1, 1, 1, 0, 0}   // Option 6: supports VC0+VC1, smallest
+            },
+            // BLACKHOLE
+            {
+                {4, 8, 2, 4, 0, 0},  // Option 1: supports VC0+VC1
+                {4, 8, 2, 2, 0, 0},  // Option 2: supports VC0+VC1, smaller VC1 receiver
+                {2, 4, 2, 2, 0, 0},  // Option 3: supports VC0+VC1, smaller overall
+                {2, 4, 1, 1, 0, 0},  // Option 4: supports VC0+VC1, smaller overall
+                {2, 2, 1, 1, 0, 0},  // Option 5: supports VC0+VC1, smaller overall
+                {1, 1, 1, 1, 0, 0}   // Option 6: supports VC0+VC1, smallest
+            }};
+
+        // VC0+VC1+VC2 mesh options: vc2 mirrors vc1 values in each row
+        static const std::vector<std::vector<PerVcBufferSlots>> vc0_vc1_vc2_mesh_buffer_slot_options = {
+            // WORMHOLE_B0
+            {
+                {4, 8, 2, 4, 2, 4},  // Option 1: supports VC0+VC1+VC2
+                {4, 8, 2, 2, 2, 2},  // Option 2: supports VC0+VC1+VC2, smaller VC1/VC2 receiver
+                {2, 4, 2, 2, 2, 2},  // Option 3: supports VC0+VC1+VC2, smaller overall
+                {2, 4, 1, 1, 1, 1},  // Option 4: supports VC0+VC1+VC2, smaller overall
+                {2, 2, 1, 1, 1, 1},  // Option 5: supports VC0+VC1+VC2, smaller overall
+                {1, 1, 1, 1, 1, 1}   // Option 6: supports VC0+VC1+VC2, smallest
+            },
+            // BLACKHOLE
+            {
+                {4, 8, 2, 4, 2, 4},  // Option 1: supports VC0+VC1+VC2
+                {4, 8, 2, 2, 2, 2},  // Option 2: supports VC0+VC1+VC2, smaller VC1/VC2 receiver
+                {2, 4, 2, 2, 2, 2},  // Option 3: supports VC0+VC1+VC2, smaller overall
+                {2, 4, 1, 1, 1, 1},  // Option 4: supports VC0+VC1+VC2, smaller overall
+                {2, 2, 1, 1, 1, 1},  // Option 5: supports VC0+VC1+VC2, smaller overall
+                {1, 1, 1, 1, 1, 1}   // Option 6: supports VC0+VC1+VC2, smallest
+            }};
+
         static const std::vector<std::vector<PerVcBufferSlots>> other_buffer_slot_options = {
             // WORMHOLE_B0
-            {{16, 16, 0, 0},  // Only VC0 for non-mesh topologies.
-             {8, 16, 0, 0},
-             {8, 8, 0, 0},
-             {4, 8, 0, 0},
-             {4, 4, 0, 0},
-             {2, 4, 0, 0},
-             {2, 2, 0, 0},
-             {1, 2, 0, 0},
-             {1, 1, 0, 0}},
+            {{16, 16, 0, 0, 0, 0},  // Only VC0 for non-mesh topologies.
+             {8, 16, 0, 0, 0, 0},
+             {8, 8, 0, 0, 0, 0},
+             {4, 8, 0, 0, 0, 0},
+             {4, 4, 0, 0, 0, 0},
+             {2, 4, 0, 0, 0, 0},
+             {2, 2, 0, 0, 0, 0},
+             {1, 2, 0, 0, 0, 0},
+             {1, 1, 0, 0, 0, 0}},
             // BLACKHOLE
-            {{32, 32, 0, 0},  // Only VC0 for non-mesh topologies.
-             {16, 32, 0, 0},
-             {16, 16, 0, 0},
-             {8, 16, 0, 0},
-             {8, 8, 0, 0},
-             {4, 8, 0, 0},
-             {4, 4, 0, 0},
-             {2, 4, 0, 0},
-             {2, 2, 0, 0},
-             {1, 2, 0, 0},
-             {1, 1, 0, 0}}};
+            {{32, 32, 0, 0, 0, 0},  // Only VC0 for non-mesh topologies.
+             {16, 32, 0, 0, 0, 0},
+             {16, 16, 0, 0, 0, 0},
+             {8, 16, 0, 0, 0, 0},
+             {8, 8, 0, 0, 0, 0},
+             {4, 8, 0, 0, 0, 0},
+             {4, 4, 0, 0, 0, 0},
+             {2, 4, 0, 0, 0, 0},
+             {2, 2, 0, 0, 0, 0},
+             {1, 2, 0, 0, 0, 0},
+             {1, 1, 0, 0, 0, 0}}};
 
-        static tt::stl::Indestructible<std::vector<std::vector<PerVcBufferSlots>>> mesh_slots(mesh_buffer_slot_options);
+        static tt::stl::Indestructible<std::vector<std::vector<PerVcBufferSlots>>> vc0_only_mesh_slots(
+            vc0_only_mesh_buffer_slot_options);
+        static tt::stl::Indestructible<std::vector<std::vector<PerVcBufferSlots>>> vc0_vc1_mesh_slots(
+            vc0_vc1_mesh_buffer_slot_options);
+        static tt::stl::Indestructible<std::vector<std::vector<PerVcBufferSlots>>> vc0_vc1_vc2_mesh_slots(
+            vc0_vc1_vc2_mesh_buffer_slot_options);
         static tt::stl::Indestructible<std::vector<std::vector<PerVcBufferSlots>>> other_slots(
             other_buffer_slot_options);
 
         if (topology == Topology::Mesh || topology == Topology::Torus) {
-            return mesh_slots.get()[arch_index];
+            if (num_active_vcs >= 3) {
+                return vc0_vc1_vc2_mesh_slots.get()[arch_index];
+            } else if (num_active_vcs >= 2) {
+                return vc0_vc1_mesh_slots.get()[arch_index];
+            } else {
+                return vc0_only_mesh_slots.get()[arch_index];
+            }
         }
         return other_slots.get()[arch_index];
     };
@@ -412,17 +459,24 @@ void FabricStaticSizedChannelsAllocator::configure_buffer_slots_helper(
                                             size_t num_vc0_receiver_channels,
                                             size_t num_vc1_sender_channels,
                                             size_t num_vc1_receiver_channels,
+                                            size_t num_vc2_sender_channels,
+                                            size_t num_vc2_receiver_channels,
                                             size_t& vc0_sender_buffer_slots,
                                             size_t& vc0_receiver_buffer_slots,
                                             size_t& vc1_sender_buffer_slots,
-                                            size_t& vc1_receiver_buffer_slots) {
+                                            size_t& vc1_receiver_buffer_slots,
+                                            size_t& vc2_sender_buffer_slots,
+                                            size_t& vc2_receiver_buffer_slots) {
         bool vc1_needed = (num_vc1_sender_channels > 0) || (num_vc1_receiver_channels > 0);
+        bool vc2_needed = (num_vc2_sender_channels > 0) || (num_vc2_receiver_channels > 0);
         bool found_valid_option = false;
         for (auto& option : buffer_slot_options) {
             vc0_sender_buffer_slots = option.vc0_sender_slots;
             vc0_receiver_buffer_slots = option.vc0_receiver_slots;
             vc1_sender_buffer_slots = option.vc1_sender_slots;
             vc1_receiver_buffer_slots = option.vc1_receiver_slots;
+            vc2_sender_buffer_slots = option.vc2_sender_slots;
+            vc2_receiver_buffer_slots = option.vc2_receiver_slots;
             // skip the VC0 only options if VC1 is needed (either sender or receiver channels)
             if (vc1_needed) {
                 // Check if we need VC1 sender channels but this option doesn't provide them
@@ -434,15 +488,26 @@ void FabricStaticSizedChannelsAllocator::configure_buffer_slots_helper(
                     continue;  // Skip this option - VC1 is needed but this option doesn't support it
                 }
             }
+            // skip options without VC2 slots if VC2 is needed
+            if (vc2_needed) {
+                bool skip_due_to_vc2_sender = (num_vc2_sender_channels > 0) && (vc2_sender_buffer_slots == 0);
+                bool skip_due_to_vc2_receiver = (num_vc2_receiver_channels > 0) && (vc2_receiver_buffer_slots == 0);
 
-            // Calculate total slots across both VCs
+                if (skip_due_to_vc2_sender || skip_due_to_vc2_receiver) {
+                    continue;  // Skip this option - VC2 is needed but this option doesn't support it
+                }
+            }
+
+            // Calculate total slots across all VCs
             auto vc0_total_sender_slots = num_vc0_sender_channels * vc0_sender_buffer_slots;
             auto vc0_total_receiver_slots = num_vc0_receiver_channels * vc0_receiver_buffer_slots;
             auto vc1_total_sender_slots = num_vc1_sender_channels * vc1_sender_buffer_slots;
             auto vc1_total_receiver_slots = num_vc1_receiver_channels * vc1_receiver_buffer_slots;
+            auto vc2_total_sender_slots = num_vc2_sender_channels * vc2_sender_buffer_slots;
+            auto vc2_total_receiver_slots = num_vc2_receiver_channels * vc2_receiver_buffer_slots;
 
             auto total_num_bytes = (vc0_total_sender_slots + vc0_total_receiver_slots + vc1_total_sender_slots +
-                                    vc1_total_receiver_slots) *
+                                    vc1_total_receiver_slots + vc2_total_sender_slots + vc2_total_receiver_slots) *
                                    this->channel_buffer_size_bytes;
 
             if (total_num_bytes <= this->available_channel_buffering_space) {
@@ -451,20 +516,25 @@ void FabricStaticSizedChannelsAllocator::configure_buffer_slots_helper(
             }
         }
 
-        // Validate that we found a valid option, especially if VC1 is needed
+        // Validate that we found a valid option
         if (!found_valid_option) {
             TT_THROW(
-                "Failed to find suitable buffer slot configuration. VC1 needed: {}, VC0 channels: {} senders/{} "
-                "receivers, VC1 channels: {} senders/{} receivers, Available space: {} bytes",
+                "Failed to find suitable buffer slot configuration. VC1 needed: {}, VC2 needed: {}, VC0 channels: {} "
+                "senders/{} "
+                "receivers, VC1 channels: {} senders/{} receivers, VC2 channels: {} senders/{} receivers, Available "
+                "space: {} bytes",
                 vc1_needed,
+                vc2_needed,
                 num_vc0_sender_channels,
                 num_vc0_receiver_channels,
                 num_vc1_sender_channels,
                 num_vc1_receiver_channels,
+                num_vc2_sender_channels,
+                num_vc2_receiver_channels,
                 this->available_channel_buffering_space);
         }
 
-        // Additional validation: ensure VC1 buffer slots are non-zero if VC1 channels are needed
+        // Additional validation: ensure VC1/VC2 buffer slots are non-zero if those channels are needed
     };
 
     // auto axis_index = static_cast<std::size_t>(options.edm_axis);
@@ -484,6 +554,7 @@ void FabricStaticSizedChannelsAllocator::configure_buffer_slots_helper(
             uint32_t target_channel = get_worker_connected_sender_channel();
             size_t vc0_sender_buffer_slots, vc0_receiver_buffer_slots;
             size_t vc1_sender_buffer_slots, vc1_receiver_buffer_slots;
+            size_t vc2_sender_buffer_slots, vc2_receiver_buffer_slots;
 
             // get the optimal buffer slots for MUX mode (per-VC)
             get_optimal_num_slots_per_vc(
@@ -492,20 +563,26 @@ void FabricStaticSizedChannelsAllocator::configure_buffer_slots_helper(
                 num_used_receiver_channels_per_vc[0],
                 num_used_sender_channels_per_vc[1],
                 num_used_receiver_channels_per_vc[1],
+                num_used_sender_channels_per_vc[2],
+                num_used_receiver_channels_per_vc[2],
                 vc0_sender_buffer_slots,
                 vc0_receiver_buffer_slots,
                 vc1_sender_buffer_slots,
-                vc1_receiver_buffer_slots);
+                vc1_receiver_buffer_slots,
+                vc2_sender_buffer_slots,
+                vc2_receiver_buffer_slots);
 
             // set buffer slots for VC0 worker channel only
             num_sender_buffer_slots_per_vc[0][target_channel] = vc0_sender_buffer_slots;
             num_remote_sender_buffer_slots_per_vc[0][target_channel] = vc0_sender_buffer_slots;
 
-            // Fill receiver buffer slots for both VCs
+            // Fill receiver buffer slots for all VCs
             num_receiver_buffer_slots_per_vc[0].fill(vc0_receiver_buffer_slots);
             num_remote_receiver_buffer_slots_per_vc[0].fill(vc0_receiver_buffer_slots);
             num_receiver_buffer_slots_per_vc[1].fill(vc1_receiver_buffer_slots);
             num_remote_receiver_buffer_slots_per_vc[1].fill(vc1_receiver_buffer_slots);
+            num_receiver_buffer_slots_per_vc[2].fill(vc2_receiver_buffer_slots);
+            num_remote_receiver_buffer_slots_per_vc[2].fill(vc2_receiver_buffer_slots);
             return;
         }
         default: break;
@@ -514,18 +591,32 @@ void FabricStaticSizedChannelsAllocator::configure_buffer_slots_helper(
     // Default case: Configure buffer slots with per-VC options
     size_t vc0_sender_buffer_slots, vc0_receiver_buffer_slots;
     size_t vc1_sender_buffer_slots, vc1_receiver_buffer_slots;
+    size_t vc2_sender_buffer_slots, vc2_receiver_buffer_slots;
 
-    // Get optimal buffer slots considering both VCs
+    // Determine how many VCs are active based on channel usage
+    size_t num_active_vcs = 1;
+    if (num_used_sender_channels_per_vc[1] > 0 || num_used_receiver_channels_per_vc[1] > 0) {
+        num_active_vcs = 2;
+    }
+    if (num_used_sender_channels_per_vc[2] > 0 || num_used_receiver_channels_per_vc[2] > 0) {
+        num_active_vcs = 3;
+    }
+
+    // Get optimal buffer slots considering all VCs
     get_optimal_num_slots_per_vc(
-        get_num_buffer_slots(topology, arch_index),
+        get_num_buffer_slots(topology, arch_index, num_active_vcs),
         num_used_sender_channels_per_vc[0],
         num_used_receiver_channels_per_vc[0],
         num_used_sender_channels_per_vc[1],
         num_used_receiver_channels_per_vc[1],
+        num_used_sender_channels_per_vc[2],
+        num_used_receiver_channels_per_vc[2],
         vc0_sender_buffer_slots,
         vc0_receiver_buffer_slots,
         vc1_sender_buffer_slots,
-        vc1_receiver_buffer_slots);
+        vc1_receiver_buffer_slots,
+        vc2_sender_buffer_slots,
+        vc2_receiver_buffer_slots);
 
     // Apply the buffer slot configuration to each VC
     num_sender_buffer_slots_per_vc[0].fill(vc0_sender_buffer_slots);
@@ -537,6 +628,11 @@ void FabricStaticSizedChannelsAllocator::configure_buffer_slots_helper(
     num_remote_sender_buffer_slots_per_vc[1].fill(vc1_sender_buffer_slots);
     num_receiver_buffer_slots_per_vc[1].fill(vc1_receiver_buffer_slots);
     num_remote_receiver_buffer_slots_per_vc[1].fill(vc1_receiver_buffer_slots);
+
+    num_sender_buffer_slots_per_vc[2].fill(vc2_sender_buffer_slots);
+    num_remote_sender_buffer_slots_per_vc[2].fill(vc2_sender_buffer_slots);
+    num_receiver_buffer_slots_per_vc[2].fill(vc2_receiver_buffer_slots);
+    num_remote_receiver_buffer_slots_per_vc[2].fill(vc2_receiver_buffer_slots);
 }
 
 void FabricStaticSizedChannelsAllocator::emit_ct_args(std::vector<uint32_t>& ct_args) const {

--- a/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.hpp
+++ b/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.hpp
@@ -107,10 +107,18 @@ public:
     }
     // For total counts: return sum across all VCs
     size_t get_num_sender_channels() const {
-        return num_used_sender_channels_per_vc[0] + num_used_sender_channels_per_vc[1];
+        size_t total = 0;
+        for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
+            total += num_used_sender_channels_per_vc[vc];
+        }
+        return total;
     }
     size_t get_num_receiver_channels() const {
-        return num_used_receiver_channels_per_vc[0] + num_used_receiver_channels_per_vc[1];
+        size_t total = 0;
+        for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
+            total += num_used_receiver_channels_per_vc[vc];
+        }
+        return total;
     }
 
     // Override virtual print method from base class
@@ -188,10 +196,22 @@ inline void FabricStaticSizedChannelsAllocator::print(std::ostream& os) const {
 
     // Configuration parameters
     os << "  Configuration:\n";
-    os << "    num_used_sender_channels_per_vc: [" << num_used_sender_channels_per_vc[0] << ", "
-       << num_used_sender_channels_per_vc[1] << "]\n";
-    os << "    num_used_receiver_channels_per_vc: [" << num_used_receiver_channels_per_vc[0] << ", "
-       << num_used_receiver_channels_per_vc[1] << "]\n";
+    os << "    num_used_sender_channels_per_vc: [";
+    for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
+        if (vc > 0) {
+            os << ", ";
+        }
+        os << num_used_sender_channels_per_vc[vc];
+    }
+    os << "]\n";
+    os << "    num_used_receiver_channels_per_vc: [";
+    for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
+        if (vc > 0) {
+            os << ", ";
+        }
+        os << num_used_receiver_channels_per_vc[vc];
+    }
+    os << "]\n";
     os << "    channel_buffer_size_bytes: " << channel_buffer_size_bytes << " B\n";
     os << "    available_channel_buffering_space: " << available_channel_buffering_space << " B\n";
     os << "    buffer_region_start: 0x" << std::hex << buffer_region_start << std::dec << "\n";

--- a/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.hpp
+++ b/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.hpp
@@ -138,8 +138,8 @@ private:
             builder_config::MAX_NUM_VCS>& num_remote_receiver_buffer_slots_per_vc);
 
     // Configuration parameters
-    std::array<size_t, builder_config::MAX_NUM_VCS> num_used_sender_channels_per_vc = {0, 0};
-    std::array<size_t, builder_config::MAX_NUM_VCS> num_used_receiver_channels_per_vc = {0, 0};
+    std::array<size_t, builder_config::MAX_NUM_VCS> num_used_sender_channels_per_vc = {};
+    std::array<size_t, builder_config::MAX_NUM_VCS> num_used_receiver_channels_per_vc = {};
     size_t channel_buffer_size_bytes = 0;
     size_t available_channel_buffering_space = 0;
     size_t max_l1_loading_size = 0;

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -265,7 +265,7 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(Topology topology) : topo
         this->datapath_usage_l1_address = next_l1_addr;
         this->datapath_usage_buffer_size = sizeof(tt::tt_fabric::FabricDatapathUsageL1Results<
                                                   true,
-                                                  builder_config::num_max_receiver_channels,
+                                                  builder_config::MAX_NUM_VCS,
                                                   builder_config::num_max_sender_channels>);
         next_l1_addr += this->datapath_usage_buffer_size;
     } else {
@@ -1078,6 +1078,7 @@ FabricEriscDatamoverBuilder::CompileTimeArgs FabricEriscDatamoverBuilder::get_co
     // --- Max channel counts ---
     named_args["MAX_NUM_SENDER_CHANNELS"] = builder_config::num_max_sender_channels;
     named_args["MAX_NUM_RECEIVER_CHANNELS"] = builder_config::num_max_receiver_channels;
+    named_args["MAX_NUM_VCS"] = static_cast<uint32_t>(builder_config::MAX_NUM_VCS);
 
     // --- Downstream tensix connections ---
     named_args["NUM_DS_OR_LOCAL_TENSIX_CONNECTIONS"] = this->num_downstream_tensix_connections;

--- a/tt_metal/fabric/erisc_datamover_builder.hpp
+++ b/tt_metal/fabric/erisc_datamover_builder.hpp
@@ -329,8 +329,10 @@ struct FabricEriscDatamoverConfig {
 
     std::size_t num_used_sender_channels = 0;    // Total across all VCs (duplicate in allocator... don't modify)
     std::size_t num_used_receiver_channels = 0;  // Total across all VCs (duplicate in allocator... don't modify)
-    std::array<std::size_t, builder_config::MAX_NUM_VCS> num_used_sender_channels_per_vc = {0, 0};    // Per-VC sender channel counts
-    std::array<std::size_t, builder_config::MAX_NUM_VCS> num_used_receiver_channels_per_vc = {0, 0};  // Per-VC receiver channel counts
+    std::array<std::size_t, builder_config::MAX_NUM_VCS> num_used_sender_channels_per_vc =
+        {};  // Per-VC sender channel counts
+    std::array<std::size_t, builder_config::MAX_NUM_VCS> num_used_receiver_channels_per_vc =
+        {};  // Per-VC receiver channel counts
     std::size_t num_fwd_paths = 0;
     std::size_t sender_txq_id = 0;
     std::size_t receiver_txq_id = 0;

--- a/tt_metal/fabric/fabric_builder_context.cpp
+++ b/tt_metal/fabric/fabric_builder_context.cpp
@@ -280,7 +280,6 @@ IntermeshVCConfig FabricBuilderContext::compute_intermesh_vc_config() const {
     // Set router type based on detection
     config.router_type = has_z_routers ? IntermeshRouterType::Z_INTERMESH : IntermeshRouterType::XY_INTERMESH;
 
-    // VC2 requires: VC1 active + Blackhole architecture + no UDM/mux extension
     if (config.requires_vc1) {
         auto arch = tt::tt_metal::MetalContext::instance().hal().get_arch();
         auto tensix_config = tt::tt_metal::MetalContext::instance().get_fabric_tensix_config();
@@ -288,6 +287,12 @@ IntermeshVCConfig FabricBuilderContext::compute_intermesh_vc_config() const {
         bool is_udm_mode = (tensix_config == FabricTensixConfig::UDM);
         bool is_mux_extension = (tensix_config == FabricTensixConfig::MUX);
         config.requires_vc2 = is_blackhole && !is_udm_mode && !is_mux_extension;
+
+        // VC2 requires: RT option enabled + VC1 active + Blackhole + no UDM/mux
+        const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
+        TT_FATAL(
+            !rtoptions.get_enable_fabric_vc2(),
+            "TT_METAL_ENABLE_FABRIC_VC2 is not yet supported — VC2 feature is under development");
     }
 
     return config;

--- a/tt_metal/fabric/fabric_builder_context.cpp
+++ b/tt_metal/fabric/fabric_builder_context.cpp
@@ -280,6 +280,16 @@ IntermeshVCConfig FabricBuilderContext::compute_intermesh_vc_config() const {
     // Set router type based on detection
     config.router_type = has_z_routers ? IntermeshRouterType::Z_INTERMESH : IntermeshRouterType::XY_INTERMESH;
 
+    // VC2 requires: VC1 active + Blackhole architecture + no UDM/mux extension
+    if (config.requires_vc1) {
+        auto arch = tt::tt_metal::MetalContext::instance().hal().get_arch();
+        auto tensix_config = tt::tt_metal::MetalContext::instance().get_fabric_tensix_config();
+        bool is_blackhole = (arch == tt::ARCH::BLACKHOLE);
+        bool is_udm_mode = (tensix_config == FabricTensixConfig::UDM);
+        bool is_mux_extension = (tensix_config == FabricTensixConfig::MUX);
+        config.requires_vc2 = is_blackhole && !is_udm_mode && !is_mux_extension;
+    }
+
     return config;
 }
 

--- a/tt_metal/fabric/fabric_builder_context.hpp
+++ b/tt_metal/fabric/fabric_builder_context.hpp
@@ -64,6 +64,7 @@ struct IntermeshVCConfig {
     bool requires_vc1 = false;                      // True if VC1 needed for intermesh
     bool requires_vc1_full_mesh = false;            // True if VC1 needed throughout mesh (not just edges)
     bool requires_vc1_mesh_pass_through = false;    // True if VC1 must support inter-mesh pass-through
+    bool requires_vc2 = false;                      // True if VC2 needed (Blackhole + 2D + no UDM/mux)
 
     IntermeshVCConfig() = default;
 
@@ -176,6 +177,7 @@ public:
     bool requires_intermesh_vc() const { return intermesh_vc_config_.requires_vc1; }
     bool requires_intermesh_vc_full_mesh() const { return intermesh_vc_config_.requires_vc1_full_mesh; }
     bool requires_intermesh_vc_mesh_pass_through() const { return intermesh_vc_config_.requires_vc1_mesh_pass_through; }
+    bool requires_vc2() const { return intermesh_vc_config_.requires_vc2; }
 
 private:
 

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
@@ -76,6 +76,7 @@ constexpr uint32_t ETH_RETRAIN_LINK_SYNC_STREAM_ID = NAMED_CT_ARG("ETH_RETRAIN_L
 // ============================================================================
 constexpr size_t MAX_NUM_SENDER_CHANNELS = NAMED_CT_ARG("MAX_NUM_SENDER_CHANNELS");
 constexpr size_t MAX_NUM_RECEIVER_CHANNELS = NAMED_CT_ARG("MAX_NUM_RECEIVER_CHANNELS");
+constexpr size_t MAX_NUM_VCS = NAMED_CT_ARG("MAX_NUM_VCS");
 // VC0 and VC1 channel counts depend on router type:
 // Z_ROUTER: 5 VC0 + 4 VC1 = 9 total
 // MESH: 4 VC0 + 4 VC1 = 8 total (with some unused)
@@ -643,7 +644,7 @@ constexpr size_t RESOURCE_USAGE_CAPTURE_OUTPUT_L1_ADDRESS =
 using ChannelTrimmingUsagePtr = tt::tt_fabric::FabricDatapathUsageL1Ptr<
     ENABLE_CHANNEL_TRIMMING_RESOURCE_USAGE_CAPTURE,
     RESOURCE_USAGE_CAPTURE_OUTPUT_L1_ADDRESS,
-    MAX_NUM_RECEIVER_CHANNELS,
+    MAX_NUM_VCS,
     MAX_NUM_SENDER_CHANNELS>;
 constexpr ChannelTrimmingUsagePtr channel_trimming_usage_recorder{};
 

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -92,6 +92,7 @@ enum class EnvVarID {
     TT_METAL_ENABLE_CHANNEL_TRIMMING_CAPTURE,  // Enable channel trimming resource usage capture
     TT_METAL_FABRIC_TRIMMING_PROFILE,          // Path to channel trimming profile YAML for import
     TT_METAL_FABRIC_TRIMMING_OVERRIDE,         // Path to channel trimming global override YAML
+    TT_METAL_ENABLE_FABRIC_VC2,                // Enable fabric VC2 (neighbour exchange)
     TT_METAL_FORCE_REINIT,                     // Force context reinitialization
     TT_METAL_DISABLE_FABRIC_TWO_ERISC,         // Disable fabric 2-ERISC mode
     TT_METAL_LOG_KERNELS_COMPILE_COMMANDS,     // Log kernel compilation commands
@@ -575,6 +576,13 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
         case EnvVarID::TT_METAL_FABRIC_TRIMMING_OVERRIDE:
             this->fabric_trimming_override_path = std::string(value);
             break;
+
+        // TT_METAL_ENABLE_FABRIC_VC2
+        // Enables the third virtual channel (VC2) for single-hop neighbour exchange traffic.
+        // Only effective when intermesh VC is also enabled (2D + multi-mesh + Blackhole + no UDM/mux).
+        // Default: false
+        // Usage: export TT_METAL_ENABLE_FABRIC_VC2=1
+        case EnvVarID::TT_METAL_ENABLE_FABRIC_VC2: this->enable_fabric_vc2 = true; break;
 
         // RELIABILITY_MODE
         // Sets the fabric reliability mode (STRICT, RELAXED, or DYNAMIC).

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -285,6 +285,9 @@ class RunTimeOptions {
     // Path to channel trimming global override YAML
     std::string fabric_trimming_override_path;
 
+    // Enable fabric VC2 (neighbour exchange, single-hop)
+    bool enable_fabric_vc2 = false;
+
     // Enable fabric telemetry
     bool enable_fabric_telemetry = false;
     FabricTelemetrySettings fabric_telemetry_settings;
@@ -678,6 +681,10 @@ public:
     bool has_fabric_trimming_override() const { return !fabric_trimming_override_path.empty(); }
     const std::string& get_fabric_trimming_override_path() const { return fabric_trimming_override_path; }
     void set_fabric_trimming_override_path(const std::string& path) { fabric_trimming_override_path = path; }
+
+    // Fabric VC2 enable
+    bool get_enable_fabric_vc2() const { return enable_fabric_vc2; }
+    void set_enable_fabric_vc2(bool enable) { enable_fabric_vc2 = enable; }
 
     // Reliability mode override accessor
     std::optional<tt::tt_fabric::FabricReliabilityMode> get_reliability_mode() const { return reliability_mode; }


### PR DESCRIPTION
This extends some of the internal fabric builder datastructures to support a 3rd VC. This change _does not_ enable the third VC itself


### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snijjar/fabric-builder-extend-max-vc-to-3)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snijjar/fabric-builder-extend-max-vc-to-3)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snijjar/fabric-builder-extend-max-vc-to-3)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snijjar/fabric-builder-extend-max-vc-to-3)
- [ ] [![tm-fabric-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tm-fabric-tests.yaml/badge.svg?branch=snijjar/fabric-builder-extend-max-vc-to-3)](https://github.com/tenstorrent/tt-metal/actions/workflows/tm-fabric-tests.yaml?query=branch:snijjar/fabric-builder-extend-max-vc-to-3)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early

