### PR TITLE
Add fixes for tt-train tests to run green with LLK_ASSERTS enabled

### DIFF
--- a/tt-train/tests/ops/linear_op_test.cpp
+++ b/tt-train/tests/ops/linear_op_test.cpp
@@ -10,7 +10,6 @@
 #include "core/compute_kernel_config.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "init/tensor_initializers.hpp"
-#include "core/system_utils.hpp"
 
 class LinearOpTest : public ::testing::Test {
 protected:
@@ -55,9 +54,6 @@ bool compare_tensors_for_broken(const ttnn::Tensor& t1, const ttnn::Tensor& t2, 
 }
 
 TEST_F(LinearOpTest, TTNNBackwardGoodShape) {
-    SKIP_FOR_LLK_ASSERTS(
-        "LLK_ASSERT(semaphore_read(index) < semaphore::SEMAPHORE_MAX_VALUE, Semaphore must not be already at max "
-        "value.)");
     auto tensor = ttml::autograd::create_tensor();
     ttml::init::uniform_init(tensor, ttnn::Shape({64, 1, 256, 64}), ttml::init::UniformRange{-0.1F, 0.1F});
     tensor->set_requires_grad(true);
@@ -107,9 +103,6 @@ void test_linear(uint32_t batch, uint32_t emb_dim) {
     ttml::ops::linear_op(tensor, weight, bias);
 }
 TEST_F(LinearOpTest, TTNNLargeLinearOpWithBias) {
-    SKIP_FOR_LLK_ASSERTS(
-        "LLK_ASSERT(semaphore_read(index) < semaphore::SEMAPHORE_MAX_VALUE, Semaphore must not be already at max "
-        "value.)");
     uint32_t dim = 4096;
     uint32_t batch = 32;  // it works with batch = 1, please try to check from 4 to 64
     EXPECT_NO_FATAL_FAILURE(test_linear(batch, 4 * dim));

--- a/tt-train/tests/ops/sdpa_bw_op_test.cpp
+++ b/tt-train/tests/ops/sdpa_bw_op_test.cpp
@@ -11,6 +11,7 @@
 #include "autograd/auto_context.hpp"
 #include "core/compute_kernel_config.hpp"
 #include "core/random.hpp"
+#include "core/system_utils.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "metal/operations.hpp"
 #include "ttnn/operations/data_movement/concat/concat.hpp"
@@ -768,6 +769,7 @@ TEST_F(SDPABackwardTest, CausalMask_MHA) {
 }
 
 TEST_F(SDPABackwardTest, CausalMask_GQA) {
+    SKIP_FOR_LLK_ASSERTS("Skip due to too large code size when assert is enabled.");
     // Test causal mask with Grouped Query Attention
     // Both sdpa_bw_q and sdpa_bw_kv support on-the-fly causal mask generation
     SDPABackwardTestConfig config{

--- a/tt-train/tests/ops/sdpa_fw_op_test.cpp
+++ b/tt-train/tests/ops/sdpa_fw_op_test.cpp
@@ -19,6 +19,7 @@
 
 #include "autograd/auto_context.hpp"
 #include "core/random.hpp"
+#include "core/system_utils.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "metal/common/const_utils.hpp"
 #include "metal/operations.hpp"
@@ -662,6 +663,7 @@ TEST_F(SDPAForwardTest, SDPAForwardTest_CausalMask_SingleTile) {
 }
 
 TEST_F(SDPAForwardTest, SDPAForwardTest_CausalMask_MHA_Batch4_Seq256) {
+    SKIP_FOR_LLK_ASSERTS("Skip due to too large code size when assert is enabled.");
     // Multi-head attention with equal query and KV heads (standard MHA)
     // batch=4, seq=256 (8 tile rows), 6 heads with 128 dim per head
     SDPATestConfig config{
@@ -677,6 +679,7 @@ TEST_F(SDPAForwardTest, SDPAForwardTest_CausalMask_MHA_Batch4_Seq256) {
 }
 
 TEST_F(SDPAForwardTest, SDPAForwardTest_CausalMask_GQA_Batch16_Seq512) {
+    SKIP_FOR_LLK_ASSERTS("Skip due to too large code size when assert is enabled.");
     // Grouped Query Attention with different query and KV heads
     // batch=16, seq=512 (16 tile rows), 8 query heads, 4 KV heads (2:1 ratio)
     SDPATestConfig config{

--- a/tt-train/tests/utils/memory_utils_test.cpp
+++ b/tt-train/tests/utils/memory_utils_test.cpp
@@ -192,7 +192,7 @@ TEST_F(MemoryUtilsTest, DRAMUsageMultipleOperations) {
     // LLK_ASSERTs add constant DRAM overhead due to additional assertion code
     // in unpacker/packer configurations that invoke functions exclusively used for assertions.
     if (ttml::core::is_llk_assert_enabled()) {
-        expected_peak_size += 22528;  // Additional program cache overhead
+        expected_peak_size += 12288;  // Additional program cache overhead
     }
 
     expected_size = expected_peak_size;

--- a/tt-train/tests/utils/memory_utils_test.cpp
+++ b/tt-train/tests/utils/memory_utils_test.cpp
@@ -192,7 +192,7 @@ TEST_F(MemoryUtilsTest, DRAMUsageMultipleOperations) {
     // LLK_ASSERTs add constant DRAM overhead due to additional assertion code
     // in unpacker/packer configurations that invoke functions exclusively used for assertions.
     if (ttml::core::is_llk_assert_enabled()) {
-        expected_peak_size += 12288;  // Additional program cache overhead
+        expected_peak_size += 22528;  // Additional program cache overhead
     }
 
     expected_size = expected_peak_size;

--- a/tt-train/tests/utils/memory_utils_test.cpp
+++ b/tt-train/tests/utils/memory_utils_test.cpp
@@ -192,7 +192,7 @@ TEST_F(MemoryUtilsTest, DRAMUsageMultipleOperations) {
     // LLK_ASSERTs add constant DRAM overhead due to additional assertion code
     // in unpacker/packer configurations that invoke functions exclusively used for assertions.
     if (ttml::core::is_llk_assert_enabled()) {
-        expected_peak_size += 14336;  // Additional program cache overhead
+        expected_peak_size += 22528;  // Additional program cache overhead
     }
 
     expected_size = expected_peak_size;
@@ -244,8 +244,8 @@ TEST_F(MemoryUtilsTest, L1Usage) {
         auto l1_usage = ttml::utils::MemoryUsageTracker::get_l1_usage();
 
         // TODO: verify that 10240 comes from program cache
-        // LLK_ASSERTs add constant DRAM overhead (14336 vs 12288) for assertion-specific code.
-        size_t expected_dram_alloc = ttml::core::is_llk_assert_enabled() ? 14336 : 10240;
+        // LLK_ASSERTs add constant DRAM overhead (12288 vs 10240) for assertion-specific code.
+        size_t expected_dram_alloc = ttml::core::is_llk_assert_enabled() ? 12288 : 10240;
         EXPECT_EQ(dram_usage.total_allocations, expected_dram_alloc);
 
         // peak_cb = tile_size * sizeof(bfloat16) * n_cb (cb0, cb1, cb_out)

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/kernels/moreh_matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/kernels/moreh_matmul.cpp
@@ -276,10 +276,10 @@ FORCE_INLINE void matmul_with_transpose_and_mask(
                 cb_wait_front(mm_src1, onetile);
             }
 
-            mm_init_short(mm_src0, mm_src1);
 #if defined FP32_DEST_ACC_EN
             reconfig_data_format(mm_src0, mm_src1);
 #endif
+            mm_init_short(mm_src0, mm_src1);
             matmul_tiles(mm_src0, mm_src1, 0, 0, 0);
             tile_regs_commit();
 


### PR DESCRIPTION
### Ticket
 #39202

### Problem description
Currently, not all tt-train related tests are passing when LLK_ASSERTS are enabled.

### What's changed
In this PR, there is a fix in a single kernel which reorders reconfigure and init in order to ensure matching between init and hw configuration. Also a fix in memory usage and skips for tests which can't be run because of increased code size when LLK_ASSERTS are enabled.

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/fixes_for_tt_train_tests_with_llk_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/fixes_for_tt_train_tests_with_llk_asserts)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ndivnic/fixes_for_tt_train_tests_with_llk_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ndivnic/fixes_for_tt_train_tests_with_llk_asserts)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/fixes_for_tt_train_tests_with_llk_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/fixes_for_tt_train_tests_with_llk_asserts)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/fixes_for_tt_train_tests_with_llk_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/fixes_for_tt_train_tests_with_llk_asserts)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/fixes_for_tt_train_tests_with_llk_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/fixes_for_tt_train_tests_with_llk_asserts)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/fixes_for_tt_train_tests_with_llk_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/fixes_for_tt_train_tests_with_llk_asserts)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
