### PR TITLE
Cleanup Rope and Flash MLA

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/kernels/attention_block_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/kernels/attention_block_kernel.cpp
@@ -174,12 +174,10 @@ void kernel_main() {
 
     deepseek_b1_ops::Rope::ReaderArgs qrope_args{
         .in_cb = get_named_compile_time_arg_val("qrope_in_cb"),
-        .cos_cb = get_named_compile_time_arg_val("qrope_cos_cb"),
-        .sin_cb = get_named_compile_time_arg_val("qrope_sin_cb"),
+        .cos_sin_cb = get_named_compile_time_arg_val("qrope_cos_sin_cb"),
         .cos_tensor_address = get_named_compile_time_arg_val("qrope_cos_tensor_address"),
         .sin_tensor_address = get_named_compile_time_arg_val("qrope_sin_tensor_address"),
         .position_ids_tensor_address = get_named_compile_time_arg_val("qrope_position_ids_tensor_address"),
-        .trans_mat_cb = get_named_compile_time_arg_val("qrope_trans_mat_cb"),
     };
 
     // NCRISC: Sender args for QNOPE/QROPE cores
@@ -250,12 +248,10 @@ void kernel_main() {
 
     deepseek_b1_ops::Rope::ReaderArgs krope_args{
         .in_cb = get_named_compile_time_arg_val("krope_in_cb"),
-        .cos_cb = get_named_compile_time_arg_val("krope_cos_cb"),
-        .sin_cb = get_named_compile_time_arg_val("krope_sin_cb"),
+        .cos_sin_cb = get_named_compile_time_arg_val("krope_cos_sin_cb"),
         .cos_tensor_address = get_named_compile_time_arg_val("krope_cos_tensor_address"),
         .sin_tensor_address = get_named_compile_time_arg_val("krope_sin_tensor_address"),
         .position_ids_tensor_address = get_named_compile_time_arg_val("krope_position_ids_tensor_address"),
-        .trans_mat_cb = get_named_compile_time_arg_val("krope_trans_mat_cb"),
     };
 
     deepseek_b1_ops::KVCacheUpdate::ReaderArgs kv_cache_update_args{};
@@ -924,12 +920,10 @@ void kernel_main() {
     // Qrope compute args (from compile-time args)
     deepseek_b1_ops::Rope::ComputeArgs qrope_args{
         get_named_compile_time_arg_val("qrope_in_cb"),  // Input from matmul2 output
-        get_named_compile_time_arg_val("qrope_cos_cb"),
-        get_named_compile_time_arg_val("qrope_sin_cb"),
+        get_named_compile_time_arg_val("qrope_cos_sin_cb"),
         get_named_compile_time_arg_val("qrope_trans_mat_cb"),
         get_named_compile_time_arg_val("qrope_rotated_in_interm_cb"),
-        get_named_compile_time_arg_val("qrope_cos_interm_cb"),
-        get_named_compile_time_arg_val("qrope_sin_interm_cb"),
+        get_named_compile_time_arg_val("qrope_cos_sin_interm_cb"),
         get_named_compile_time_arg_val("qrope_output_cb"),
     };
 
@@ -978,23 +972,19 @@ void kernel_main() {
 
     // CB indices (passed as runtime args to ComputeArgs)
     constexpr uint32_t krope_input_cb = get_named_compile_time_arg_val("krope_in_cb");
-    constexpr uint32_t krope_cos_cb = get_named_compile_time_arg_val("krope_cos_cb");
-    constexpr uint32_t krope_sin_cb = get_named_compile_time_arg_val("krope_sin_cb");
+    constexpr uint32_t krope_cos_sin_cb = get_named_compile_time_arg_val("krope_cos_sin_cb");
     constexpr uint32_t krope_trans_mat_cb = get_named_compile_time_arg_val("krope_trans_mat_cb");
     constexpr uint32_t krope_rotated_in_interm_cb = get_named_compile_time_arg_val("krope_rotated_in_interm_cb");
-    constexpr uint32_t krope_cos_interm_cb = get_named_compile_time_arg_val("krope_cos_interm_cb");
-    constexpr uint32_t krope_sin_interm_cb = get_named_compile_time_arg_val("krope_sin_interm_cb");
+    constexpr uint32_t krope_cos_sin_interm_cb = get_named_compile_time_arg_val("krope_cos_sin_interm_cb");
     constexpr uint32_t krope_output_cb = get_named_compile_time_arg_val("krope_output_cb");
 
     // Compute args: all CB indices
     deepseek_b1_ops::Rope::ComputeArgs krope_args{
         .in_cb = krope_input_cb,
-        .cos_cb = krope_cos_cb,
-        .sin_cb = krope_sin_cb,
+        .cos_sin_cb = krope_cos_sin_cb,
         .trans_mat_cb = krope_trans_mat_cb,
         .rotated_in_interm_cb = krope_rotated_in_interm_cb,
-        .cos_interm_cb = krope_cos_interm_cb,
-        .sin_interm_cb = krope_sin_interm_cb,
+        .cos_sin_interm_cb = krope_cos_sin_interm_cb,
         .out_cb = krope_output_cb,
     };
 

--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
@@ -872,14 +872,12 @@ class AttentionBlock:
         create_q_heads_out_cb = cb_id_context.get_cb_id(
             data_format, TD_8x32
         )  # Output CB for CreateQHeads (linked to output tensor on receiver cores)
-        qrope_cos_cb = cb_id_context.get_cb_id(data_format, TD_1x32)  # Cos CB for RoPE
-        qrope_sin_cb = cb_id_context.get_cb_id(data_format, TD_1x32)  # Sin CB for RoPE
+        qrope_cos_sin_cb = cb_id_context.get_cb_id(data_format, TD_1x32)  # Cos/Sin CB for RoPE
         qrope_trans_mat_cb = cb_id_context.get_cb_id(data_format, TD_32x32)  # Trans_mat CB for RoPE
         qrope_rotated_input_interm_cb = cb_id_context.get_cb_id(
             data_format, TD_1x32
         )  # Rotated input intermediate CB for RoPE
-        qrope_cos_interm_cb = cb_id_context.get_cb_id(data_format, TD_1x32)  # Cos intermediate CB for RoPE
-        qrope_sin_interm_cb = cb_id_context.get_cb_id(data_format, TD_1x32)  # Sin intermediate CB for RoPE
+        qrope_cos_sin_interm_cb = cb_id_context.get_cb_id(data_format, TD_1x32)  # Cos/Sin intermediate CB for RoPE
         # KV cache branch
         dkv_matmul_output_cb = cb_id_context.get_cb_id(
             data_format, TD_1x32
@@ -888,8 +886,7 @@ class AttentionBlock:
         kv_rmsnorm_gamma_cb = cb_id_context.get_cb_id(data_format, TD_16x32)  # Gamma CB for KV Cache Branch RMSNorm
         kv_rmsnorm_output_cb = cb_id_context.get_cb_id(data_format, TD_16x32)  # Output CB for KV Cache Branch RMSNorm
         krope_output_cb = cb_id_context.get_cb_id(data_format, TD_1x32)  # Output CB for KV Cache Branch RoPE
-        krope_cos_cb = cb_id_context.get_cb_id(data_format, TD_1x32)  # Cos CB for RoPE
-        krope_sin_cb = cb_id_context.get_cb_id(data_format, TD_1x32)  # Sin CB for RoPE
+        krope_cos_sin_cb = cb_id_context.get_cb_id(data_format, TD_1x32)  # Cos/Sin CB for RoPE
         create_q_heads_receiver_in_cb = cb_id_context.get_cb_id(
             data_format, TD_8x32
         )  # Intermediate CB for CreateQHeads (row-major data before tilization)
@@ -1122,8 +1119,7 @@ class AttentionBlock:
         qrope_total_Wt = qrope_head_dim_per_core_t  # all cores read full head_dim, so total_Wt = Wt
         qrope_ncrisc_named_compile_time_args = [
             ("qrope_in_cb", matmul2_output_cb),
-            ("qrope_cos_cb", qrope_cos_cb),
-            ("qrope_sin_cb", qrope_sin_cb),
+            ("qrope_cos_sin_cb", qrope_cos_sin_cb),
             ("qrope_trans_mat_cb", qrope_trans_mat_cb),
             ("qrope_Wt", qrope_head_dim_per_core_t),
             ("qrope_Ht", qrope_num_heads_per_core),
@@ -1135,12 +1131,10 @@ class AttentionBlock:
         # TRISC: in_cb, cos_cb, sin_cb, trans_mat_cb, rotated_in_interm_cb, cos_interm_cb, sin_interm_cb, out_cb, Wt, Ht
         qrope_trisc_named_compile_time_args = [
             ("qrope_in_cb", matmul2_output_cb),
-            ("qrope_cos_cb", qrope_cos_cb),
-            ("qrope_sin_cb", qrope_sin_cb),
+            ("qrope_cos_sin_cb", qrope_cos_sin_cb),
             ("qrope_trans_mat_cb", qrope_trans_mat_cb),
             ("qrope_rotated_in_interm_cb", qrope_rotated_input_interm_cb),
-            ("qrope_cos_interm_cb", qrope_cos_interm_cb),
-            ("qrope_sin_interm_cb", qrope_sin_interm_cb),
+            ("qrope_cos_sin_interm_cb", qrope_cos_sin_interm_cb),
             ("qrope_output_cb", qrope_output_cb),
             ("qrope_Wt", qrope_head_dim_per_core_t),
             ("qrope_Ht", qrope_num_heads_per_core),
@@ -1419,8 +1413,7 @@ class AttentionBlock:
         krope_ncrisc_named_compile_time_args = [
             ("krope_output_cb", krope_output_cb),
             ("krope_in_cb", dkv_matmul_output_cb),
-            ("krope_cos_cb", krope_cos_cb),
-            ("krope_sin_cb", krope_sin_cb),
+            ("krope_cos_sin_cb", krope_cos_sin_cb),
             ("krope_trans_mat_cb", qrope_trans_mat_cb),
             ("krope_Wt", krope_Wt),
             ("krope_Ht", krope_Ht),
@@ -1429,12 +1422,10 @@ class AttentionBlock:
         ]
         krope_trisc_named_compile_time_args = [
             ("krope_in_cb", dkv_matmul_output_cb),
-            ("krope_cos_cb", krope_cos_cb),
-            ("krope_sin_cb", krope_sin_cb),
+            ("krope_cos_sin_cb", krope_cos_sin_cb),
             ("krope_trans_mat_cb", qrope_trans_mat_cb),
             ("krope_rotated_in_interm_cb", qrope_rotated_input_interm_cb),
-            ("krope_cos_interm_cb", qrope_cos_interm_cb),
-            ("krope_sin_interm_cb", qrope_sin_interm_cb),
+            ("krope_cos_sin_interm_cb", qrope_cos_sin_interm_cb),
             ("krope_output_cb", krope_output_cb),
             ("krope_Wt", krope_Wt),
             ("krope_Ht", krope_Ht),
@@ -2168,40 +2159,23 @@ class AttentionBlock:
         ]
         sdpa_out_interm_running_offset_qrope += qrope_output_cb_descriptor.total_size  # +256 B
 
-        # CB 17: Cos (DRAM, read by NCRISC)
+        # CB 17: Cos/Sin (DRAM, read by NCRISC)
         qrope_rope_tile_descriptor = ttnn.TileDescriptor(TILE_1x32)
-        qrope_cos_cb_format = ttnn.CBFormatDescriptor(
-            buffer_index=qrope_cos_cb,
+        qrope_cos_sin_cb_format = ttnn.CBFormatDescriptor(
+            buffer_index=qrope_cos_sin_cb,
             data_format=data_format,
             page_size=qrope_rope_tile_size,
             tile=qrope_rope_tile_descriptor,
         )
-        qrope_cos_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
-            qrope_cos_cb,
+        qrope_cos_sin_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+            qrope_cos_sin_cb,
             ref_sdpa_out_interm_buffer,
             address_offset=sdpa_out_interm_running_offset_qrope,
-            total_size=qrope_head_dim_per_core_t * qrope_rope_tile_size,
+            total_size=qrope_head_dim_per_core_t * qrope_rope_tile_size * 2,
             core_ranges=full_device_grid,
         )
-        qrope_cos_cb_descriptor.format_descriptors = [qrope_cos_cb_format]
-        sdpa_out_interm_running_offset_qrope += qrope_cos_cb_descriptor.total_size
-
-        # CB 18: Sin (DRAM, read by NCRISC)
-        qrope_sin_cb_format = ttnn.CBFormatDescriptor(
-            buffer_index=qrope_sin_cb,
-            data_format=data_format,
-            page_size=qrope_rope_tile_size,
-            tile=qrope_rope_tile_descriptor,
-        )
-        qrope_sin_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
-            qrope_sin_cb,
-            ref_sdpa_out_interm_buffer,
-            address_offset=sdpa_out_interm_running_offset_qrope,
-            total_size=qrope_head_dim_per_core_t * qrope_rope_tile_size,
-            core_ranges=full_device_grid,
-        )
-        qrope_sin_cb_descriptor.format_descriptors = [qrope_sin_cb_format]
-        sdpa_out_interm_running_offset_qrope += qrope_sin_cb_descriptor.total_size
+        qrope_cos_sin_cb_descriptor.format_descriptors = [qrope_cos_sin_cb_format]
+        sdpa_out_interm_running_offset_qrope += qrope_cos_sin_cb_descriptor.total_size
 
         # CB 19: Trans_mat (sharded tensor)
         qrope_trans_mat_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
@@ -2228,43 +2202,24 @@ class AttentionBlock:
         ]
         sdpa_out_interm_running_offset_qrope += qrope_rotated_input_interm_cb_descriptor.total_size  # +128 B
 
-        # CB 21: Cos intermediate CB — overlap with sdpa_out_interm L1 buffer
+        # CB 21: Cos/Sin intermediate CB — overlap with sdpa_out_interm L1 buffer
         # at offset 14016 B. This CB is consumed before SDPA runs.
-        qrope_cos_interm_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
-            qrope_cos_interm_cb,
+        qrope_cos_sin_interm_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+            qrope_cos_sin_interm_cb,
             ref_sdpa_out_interm_buffer,
             address_offset=sdpa_out_interm_running_offset_qrope,  # 28352 B
-            total_size=qrope_interm_tile_size,
+            total_size=qrope_interm_tile_size * 2,
             core_ranges=full_device_grid,
         )
-        qrope_cos_interm_cb_descriptor.format_descriptors = [
+        qrope_cos_sin_interm_cb_descriptor.format_descriptors = [
             ttnn.CBFormatDescriptor(
-                buffer_index=qrope_cos_interm_cb,
+                buffer_index=qrope_cos_sin_interm_cb,
                 data_format=data_format,
                 page_size=TILE_1x32.get_tile_size(data_format),
                 tile=ttnn.TileDescriptor(TILE_1x32),
             )
         ]
-        sdpa_out_interm_running_offset_qrope += qrope_cos_interm_cb_descriptor.total_size  # +128 B
-
-        # CB 22: Sin intermediate CB — overlap with sdpa_out_interm L1 buffer
-        # at offset 14144 B. This CB is consumed before SDPA runs.
-        qrope_sin_interm_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
-            qrope_sin_interm_cb,
-            ref_sdpa_out_interm_buffer,
-            address_offset=sdpa_out_interm_running_offset_qrope,  # 28480 B
-            total_size=qrope_interm_tile_size,
-            core_ranges=full_device_grid,
-        )
-        qrope_sin_interm_cb_descriptor.format_descriptors = [
-            ttnn.CBFormatDescriptor(
-                buffer_index=qrope_sin_interm_cb,
-                data_format=data_format,
-                page_size=TILE_1x32.get_tile_size(data_format),
-                tile=ttnn.TileDescriptor(TILE_1x32),
-            )
-        ]
-        sdpa_out_interm_running_offset_qrope += qrope_sin_interm_cb_descriptor.total_size  # +128 B
+        sdpa_out_interm_running_offset_qrope += qrope_cos_sin_interm_cb_descriptor.total_size
 
         sdpa_out_interm_running_offset = max(sdpa_out_interm_running_offset, sdpa_out_interm_running_offset_qrope)
 
@@ -2387,37 +2342,21 @@ class AttentionBlock:
         sdpa_kv_cache_running_offset += kv_rmsnorm_output_cb_descriptor.total_size  # +1024 B
         # CB 29: Cos (DRAM, read by NCRISC)
         krope_rope_tile_descriptor = ttnn.TileDescriptor(TILE_1x32)
-        krope_cos_cb_format = ttnn.CBFormatDescriptor(
-            buffer_index=krope_cos_cb,
+        krope_cos_sin_cb_format = ttnn.CBFormatDescriptor(
+            buffer_index=krope_cos_sin_cb,
             data_format=data_format,
             page_size=krope_rope_tile_size,
             tile=krope_rope_tile_descriptor,
         )
-        krope_cos_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
-            krope_cos_cb,
+        krope_cos_sin_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+            krope_cos_sin_cb,
             ref_sdpa_kv_cache_buffer,
             address_offset=sdpa_kv_cache_running_offset,
-            total_size=krope_Wt * krope_rope_tile_size,
+            total_size=krope_Wt * krope_rope_tile_size * 2,
             core_ranges=full_device_grid,
         )
-        krope_cos_cb_descriptor.format_descriptors = [krope_cos_cb_format]
-        sdpa_kv_cache_running_offset += krope_cos_cb_descriptor.total_size
-        # CB 30: Sin (DRAM, read by NCRISC)
-        krope_sin_cb_format = ttnn.CBFormatDescriptor(
-            buffer_index=krope_sin_cb,
-            data_format=data_format,
-            page_size=krope_rope_tile_size,
-            tile=krope_rope_tile_descriptor,
-        )
-        krope_sin_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
-            krope_sin_cb,
-            ref_sdpa_kv_cache_buffer,
-            address_offset=sdpa_kv_cache_running_offset,
-            total_size=krope_Wt * krope_rope_tile_size,
-            core_ranges=full_device_grid,
-        )
-        krope_sin_cb_descriptor.format_descriptors = [krope_sin_cb_format]
-        sdpa_kv_cache_running_offset += krope_sin_cb_descriptor.total_size
+        krope_cos_sin_cb_descriptor.format_descriptors = [krope_cos_sin_cb_format]
+        sdpa_kv_cache_running_offset += krope_cos_sin_cb_descriptor.total_size
 
         # CB 28: KRoPE output — overlap with sdpa_out_interm L1 buffer
         # at offset 16384 B. This CB is consumed before SDPA runs.
@@ -3315,19 +3254,16 @@ class AttentionBlock:
             matmul3_output_cb_descriptor,
             qrope_output_cb_descriptor,
             create_q_heads_out_cb_descriptor,
-            qrope_cos_cb_descriptor,
-            qrope_sin_cb_descriptor,
+            qrope_cos_sin_cb_descriptor,
             qrope_trans_mat_cb_descriptor,
             qrope_rotated_input_interm_cb_descriptor,
-            qrope_cos_interm_cb_descriptor,
-            qrope_sin_interm_cb_descriptor,
+            qrope_cos_sin_interm_cb_descriptor,
             dkv_matmul_output_cb_descriptor,
             kv_rmsnorm_input_cb_descriptor,
             kv_rmsnorm_gamma_cb_descriptor,
             kv_rmsnorm_output_cb_descriptor,
             krope_output_cb_descriptor,
-            krope_cos_cb_descriptor,
-            krope_sin_cb_descriptor,
+            krope_cos_sin_cb_descriptor,
             create_q_heads_interm_cb_descriptor,
             kv_cache_output_cb_descriptor,
             kv_cache_intermed_cb_descriptor,

--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
@@ -1128,7 +1128,7 @@ class AttentionBlock:
         ]
         # BRISC: no-op (empty args)
         qrope_brisc_named_compile_time_args = []
-        # TRISC: in_cb, cos_cb, sin_cb, trans_mat_cb, rotated_in_interm_cb, cos_interm_cb, sin_interm_cb, out_cb, Wt, Ht
+        # TRISC: in_cb, cos_sin_cb, trans_mat_cb, rotated_in_interm_cb, cos_sin_interm_cb, out_cb, Wt, Ht
         qrope_trisc_named_compile_time_args = [
             ("qrope_in_cb", matmul2_output_cb),
             ("qrope_cos_sin_cb", qrope_cos_sin_cb),

--- a/models/demos/deepseek_v3_b1/fused_ops/kv_cache_branch/kernels/kv_cache_branch_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/kv_cache_branch/kernels/kv_cache_branch_kernel.cpp
@@ -67,8 +67,7 @@ void kernel_main() {
         get_named_compile_time_arg_val("total_Wt"),
         get_named_compile_time_arg_val("start_tile_offset")>;
     constexpr uint32_t k_rope_input_cb = get_named_compile_time_arg_val("in_cb");
-    constexpr uint32_t cos_cb = get_named_compile_time_arg_val("cos_cb");
-    constexpr uint32_t sin_cb = get_named_compile_time_arg_val("sin_cb");
+    constexpr uint32_t cos_sin_cb = get_named_compile_time_arg_val("cos_sin_cb");
     constexpr uint32_t cos_tensor_address = get_named_compile_time_arg_val("cos_tensor_address");
     constexpr uint32_t sin_tensor_address = get_named_compile_time_arg_val("sin_tensor_address");
     constexpr uint32_t position_ids_tensor_address = get_named_compile_time_arg_val("position_ids_tensor_address");
@@ -76,12 +75,10 @@ void kernel_main() {
 
     deepseek_b1_ops::Rope::ReaderArgs k_rope_args{
         .in_cb = k_rope_input_cb,
-        .cos_cb = cos_cb,
-        .sin_cb = sin_cb,
+        .cos_sin_cb = cos_sin_cb,
         .cos_tensor_address = cos_tensor_address,
         .sin_tensor_address = sin_tensor_address,
         .position_ids_tensor_address = position_ids_tensor_address,
-        .trans_mat_cb = trans_mat_cb,
     };
 
 // ============================================================================
@@ -151,23 +148,19 @@ void kernel_main() {
 
     // CB indices (passed as runtime args to ComputeArgs)
     constexpr uint32_t k_rope_input_cb = get_named_compile_time_arg_val("in_cb");
-    constexpr uint32_t cos_cb = get_named_compile_time_arg_val("cos_cb");
-    constexpr uint32_t sin_cb = get_named_compile_time_arg_val("sin_cb");
+    constexpr uint32_t cos_sin_cb = get_named_compile_time_arg_val("cos_sin_cb");
     constexpr uint32_t trans_mat_cb = get_named_compile_time_arg_val("trans_mat_cb");
     constexpr uint32_t rotated_in_interm_cb = get_named_compile_time_arg_val("rotated_in_interm_cb");
-    constexpr uint32_t cos_interm_cb = get_named_compile_time_arg_val("cos_interm_cb");
-    constexpr uint32_t sin_interm_cb = get_named_compile_time_arg_val("sin_interm_cb");
+    constexpr uint32_t cos_sin_interm_cb = get_named_compile_time_arg_val("cos_sin_interm_cb");
     constexpr uint32_t k_rope_output_cb = get_named_compile_time_arg_val("out_cb");
 
     // Compute args: all CB indices
     deepseek_b1_ops::Rope::ComputeArgs k_rope_args{
         .in_cb = k_rope_input_cb,
-        .cos_cb = cos_cb,
-        .sin_cb = sin_cb,
+        .cos_sin_cb = cos_sin_cb,
         .trans_mat_cb = trans_mat_cb,
         .rotated_in_interm_cb = rotated_in_interm_cb,
-        .cos_interm_cb = cos_interm_cb,
-        .sin_interm_cb = sin_interm_cb,
+        .cos_sin_interm_cb = cos_sin_interm_cb,
         .out_cb = k_rope_output_cb,
     };
     deepseek_compute_kernel_init();

--- a/models/demos/deepseek_v3_b1/fused_ops/kv_cache_branch/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/kv_cache_branch/op.py
@@ -135,12 +135,10 @@ class KVCacheBranch:
         # CONSOLIDATE!!!!!!!!!
         # Tile sizes: 1x32 = 64 bytes (BF16), 16x32 = 1024 bytes (BF16), 32x32 = 2048 bytes (BF16)
 
-        cos_cb = 0  # tile (NCRISC reads from DRAM)
-        sin_cb = 1  # tile (NCRISC reads from DRAM)
+        cos_sin_cb = 0  # tile (NCRISC reads from DRAM)
         trans_mat_cb = 2  # 1x32 tile, 64 bytes (sharded, 1 tile per core) - actually 32x32 for matmul
         rotated_input_interm_cb = 3  # 1x32 tile, 64 bytes (Wt tiles, intermediate)
-        cos_interm_cb = 4  # 1x32 tile, 64 bytes (Wt tiles, intermediate)
-        sin_interm_cb = 5  # 1x32 tile, 64 bytes (Wt tiles, intermediate)
+        cos_sin_interm_cb = 4  # 1x32 tile, 64 bytes (Wt tiles, intermediate)
         dkv_matmul_input_cb = 6  # 1x32 tile, 64 bytes (224 tiles = 1x7168)
         dkv_matmul_output_cb = 7  # 1x32 tile, 64 bytes (1 tile per core for rope input)
         dkv_matmul_weights_cb = 8  # 32x32 tile, 2048 bytes (sharded weights)
@@ -277,8 +275,7 @@ class KVCacheBranch:
         ]
         krope_ncrisc_named_compile_time_args = [
             ("in_cb", dkv_matmul_output_cb),
-            ("cos_cb", cos_cb),
-            ("sin_cb", sin_cb),
+            ("cos_sin_cb", cos_sin_cb),
             ("cos_tensor_address", cos_tensor_address),
             ("sin_tensor_address", sin_tensor_address),
             ("position_ids_tensor_address", position_ids_tensor_addr),
@@ -290,12 +287,10 @@ class KVCacheBranch:
         ]
         krope_trisc_named_compile_time_args = [
             ("in_cb", dkv_matmul_output_cb),
-            ("cos_cb", cos_cb),
-            ("sin_cb", sin_cb),
+            ("cos_sin_cb", cos_sin_cb),
             ("trans_mat_cb", trans_mat_cb),
             ("rotated_in_interm_cb", rotated_input_interm_cb),
-            ("cos_interm_cb", cos_interm_cb),
-            ("sin_interm_cb", sin_interm_cb),
+            ("cos_sin_interm_cb", cos_sin_interm_cb),
             ("out_cb", k_rope_output_cb),
             ("Wt", krope_Wt),
             ("Ht", krope_Ht),
@@ -367,27 +362,16 @@ class KVCacheBranch:
         krope_tile_descriptor = ttnn.TileDescriptor(TILE_1x32)
 
         rope_tile_descriptor = ttnn.TileDescriptor(rope_tile)
-        cos_cb_format = ttnn.CBFormatDescriptor(
-            buffer_index=cos_cb,
+        cos_sin_cb_format = ttnn.CBFormatDescriptor(
+            buffer_index=cos_sin_cb,
             data_format=data_format,
             page_size=rope_tile_size,
             tile=rope_tile_descriptor,
         )
-        cos_cb_descriptor = ttnn.CBDescriptor(
-            total_size=1 * rope_tile_size,
+        cos_sin_cb_descriptor = ttnn.CBDescriptor(
+            total_size=2 * rope_tile_size,
             core_ranges=krope_core_grid,
-            format_descriptors=[cos_cb_format],
-        )
-        sin_cb_format = ttnn.CBFormatDescriptor(
-            buffer_index=sin_cb,
-            data_format=data_format,
-            page_size=rope_tile_size,
-            tile=rope_tile_descriptor,
-        )
-        sin_cb_descriptor = ttnn.CBDescriptor(
-            total_size=1 * rope_tile_size,
-            core_ranges=krope_core_grid,
-            format_descriptors=[sin_cb_format],
+            format_descriptors=[cos_sin_cb_format],
         )
         # CB X: Trans_mat (sharded tensor)
         trans_mat_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(trans_mat_cb, trans_mat_tensor)
@@ -405,30 +389,16 @@ class KVCacheBranch:
             format_descriptors=[rotated_interm_format],
         )
 
-        # CB X: Cos intermediate (not backed by tensor)
-        cos_interm_format = ttnn.CBFormatDescriptor(
-            buffer_index=cos_interm_cb,
+        cos_sin_interm_format = ttnn.CBFormatDescriptor(
+            buffer_index=cos_sin_interm_cb,
             data_format=data_format,
             page_size=krope_tile_size,
             tile=krope_tile_descriptor,
         )
-        cos_interm_cb_descriptor = ttnn.CBDescriptor(
-            total_size=1 * krope_tile_size,
+        cos_sin_interm_cb_descriptor = ttnn.CBDescriptor(
+            total_size=2 * krope_tile_size,
             core_ranges=krope_core_grid,
-            format_descriptors=[cos_interm_format],
-        )
-
-        # CB X: Sin intermediate (not backed by tensor)
-        sin_interm_format = ttnn.CBFormatDescriptor(
-            buffer_index=sin_interm_cb,
-            data_format=data_format,
-            page_size=krope_tile_size,
-            tile=krope_tile_descriptor,
-        )
-        sin_interm_cb_descriptor = ttnn.CBDescriptor(
-            total_size=1 * krope_tile_size,
-            core_ranges=krope_core_grid,
-            format_descriptors=[sin_interm_format],
+            format_descriptors=[cos_sin_interm_format],
         )
 
         k_rope_output_cb_format = ttnn.CBFormatDescriptor(
@@ -542,12 +512,10 @@ class KVCacheBranch:
                 kv_rmsnorm_input_cb_descriptor,
                 kv_rmsnorm_gamma_cb_descriptor,
                 kv_rmsnorm_output_cb_descriptor,
-                cos_cb_descriptor,
-                sin_cb_descriptor,
+                cos_sin_cb_descriptor,
                 trans_mat_cb_descriptor,
                 rotated_interm_cb_descriptor,
-                cos_interm_cb_descriptor,
-                sin_interm_cb_descriptor,
+                cos_sin_interm_cb_descriptor,
                 k_rope_output_cb_descriptor,
             ],
             semaphores=[

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
@@ -184,13 +184,10 @@ uint32_t per_core_rta_arg_idx = 0;
 
     deepseek_b1_ops::Rope::ReaderArgs qrope_args{
         .in_cb = get_named_compile_time_arg_val("qrope_in_cb"),
-        .cos_cb = get_named_compile_time_arg_val("qrope_cos_cb"),
-        .sin_cb = get_named_compile_time_arg_val("qrope_sin_cb"),
+        .cos_sin_cb = get_named_compile_time_arg_val("qrope_cos_sin_cb"),
         .cos_tensor_address = get_named_compile_time_arg_val("qrope_cos_tensor_address"),
         .sin_tensor_address = get_named_compile_time_arg_val("qrope_sin_tensor_address"),
-        .position_ids_tensor_address = get_named_compile_time_arg_val("qrope_position_ids_tensor_address"),
-        .trans_mat_cb = get_named_compile_time_arg_val("qrope_trans_mat_cb"),
-    };
+        .position_ids_tensor_address = get_named_compile_time_arg_val("qrope_position_ids_tensor_address")};
 
     // NCRISC: Sender args for QNOPE/QROPE cores
     // Senders write to intermediate CB, then compute tilizes to output CB
@@ -260,13 +257,10 @@ uint32_t per_core_rta_arg_idx = 0;
 
     deepseek_b1_ops::Rope::ReaderArgs krope_args{
         .in_cb = get_named_compile_time_arg_val("krope_in_cb"),
-        .cos_cb = get_named_compile_time_arg_val("krope_cos_cb"),
-        .sin_cb = get_named_compile_time_arg_val("krope_sin_cb"),
+        .cos_sin_cb = get_named_compile_time_arg_val("krope_cos_sin_cb"),
         .cos_tensor_address = get_named_compile_time_arg_val("krope_cos_tensor_address"),
         .sin_tensor_address = get_named_compile_time_arg_val("krope_sin_tensor_address"),
-        .position_ids_tensor_address = get_named_compile_time_arg_val("krope_position_ids_tensor_address"),
-        .trans_mat_cb = get_named_compile_time_arg_val("krope_trans_mat_cb"),
-    };
+        .position_ids_tensor_address = get_named_compile_time_arg_val("krope_position_ids_tensor_address")};
 
     deepseek_b1_ops::KVCacheUpdate::ReaderArgs kv_cache_update_args{};
 
@@ -623,12 +617,10 @@ uint32_t per_core_rta_arg_idx = 0;
     // Qrope compute args (from compile-time args)
     deepseek_b1_ops::Rope::ComputeArgs qrope_args{
         get_named_compile_time_arg_val("qrope_in_cb"),  // Input from matmul2 output
-        get_named_compile_time_arg_val("qrope_cos_cb"),
-        get_named_compile_time_arg_val("qrope_sin_cb"),
+        get_named_compile_time_arg_val("qrope_cos_sin_cb"),
         get_named_compile_time_arg_val("qrope_trans_mat_cb"),
         get_named_compile_time_arg_val("qrope_rotated_in_interm_cb"),
-        get_named_compile_time_arg_val("qrope_cos_interm_cb"),
-        get_named_compile_time_arg_val("qrope_sin_interm_cb"),
+        get_named_compile_time_arg_val("qrope_cos_sin_interm_cb"),
         get_named_compile_time_arg_val("qrope_output_cb"),
     };
 
@@ -676,23 +668,19 @@ uint32_t per_core_rta_arg_idx = 0;
 
     // CB indices (passed as runtime args to ComputeArgs)
     constexpr uint32_t krope_input_cb = get_named_compile_time_arg_val("krope_in_cb");
-    constexpr uint32_t krope_cos_cb = get_named_compile_time_arg_val("krope_cos_cb");
-    constexpr uint32_t krope_sin_cb = get_named_compile_time_arg_val("krope_sin_cb");
+    constexpr uint32_t krope_cos_sin_cb = get_named_compile_time_arg_val("krope_cos_sin_cb");
     constexpr uint32_t krope_trans_mat_cb = get_named_compile_time_arg_val("krope_trans_mat_cb");
     constexpr uint32_t krope_rotated_in_interm_cb = get_named_compile_time_arg_val("krope_rotated_in_interm_cb");
-    constexpr uint32_t krope_cos_interm_cb = get_named_compile_time_arg_val("krope_cos_interm_cb");
-    constexpr uint32_t krope_sin_interm_cb = get_named_compile_time_arg_val("krope_sin_interm_cb");
+    constexpr uint32_t krope_cos_sin_interm_cb = get_named_compile_time_arg_val("krope_cos_sin_interm_cb");
     constexpr uint32_t krope_output_cb = get_named_compile_time_arg_val("krope_output_cb");
 
     // Compute args: all CB indices
     deepseek_b1_ops::Rope::ComputeArgs krope_args{
         .in_cb = krope_input_cb,
-        .cos_cb = krope_cos_cb,
-        .sin_cb = krope_sin_cb,
+        .cos_sin_cb = krope_cos_sin_cb,
         .trans_mat_cb = krope_trans_mat_cb,
         .rotated_in_interm_cb = krope_rotated_in_interm_cb,
-        .cos_interm_cb = krope_cos_interm_cb,
-        .sin_interm_cb = krope_sin_interm_cb,
+        .cos_sin_interm_cb = krope_cos_sin_interm_cb,
         .out_cb = krope_output_cb,
     };
 

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
@@ -568,12 +568,10 @@ class PreSDPA:
         matmul3_output_cb = 14  # Output CB for third matmul (Qnope final output)
         qrope_output_cb = 15  # Output CB for Qrope (RoPE output)
         create_q_heads_out_cb = 16  # Output CB for CreateQHeads (linked to output tensor on receiver cores)
-        qrope_cos_cb = 17  # Cos CB for RoPE
-        qrope_sin_cb = 18  # Sin CB for RoPE
+        qrope_cos_sin_cb = 17  # Cos/Sin CB for RoPE
         qrope_trans_mat_cb = 19  # Trans_mat CB for RoPE
         qrope_rotated_input_interm_cb = 20  # Rotated input intermediate CB for RoPE
-        qrope_cos_interm_cb = 21  # Cos intermediate CB for RoPE
-        qrope_sin_interm_cb = 22  # Sin intermediate CB for RoPE
+        qrope_cos_sin_interm_cb = 21  # Cos/Sin intermediate CB for RoPE
         # KV cache branch
         dkv_matmul_weights_cb = 23  # DKV Matmul weights CB
         dkv_matmul_output_cb = 24  # DKV Matmul output CB, 64 bytes (1 tile per core for rope input)
@@ -581,8 +579,7 @@ class PreSDPA:
         kv_rmsnorm_gamma_cb = 26  # Gamma CB for KV Cache Branch RMSNorm
         kv_rmsnorm_output_cb = 27  # Output CB for KV Cache Branch RMSNorm
         krope_output_cb = 28  # Output CB for KV Cache Branch RoPE
-        krope_cos_cb = 29  # Cos CB for RoPE
-        krope_sin_cb = 30  # Sin CB for RoPE
+        krope_cos_sin_cb = 29  # Cos/Sin CB for RoPE
         create_q_heads_receiver_in_cb = 31  # Intermediate CB for CreateQHeads (row-major data before tilization)
 
         kv_cache_output_cb = 32  # Output CB for KV Cache Branch
@@ -778,8 +775,7 @@ class PreSDPA:
         qrope_total_Wt = qrope_head_dim_per_core_t  # all cores read full head_dim, so total_Wt = Wt
         qrope_ncrisc_named_compile_time_args = [
             ("qrope_in_cb", matmul2_output_cb),
-            ("qrope_cos_cb", qrope_cos_cb),
-            ("qrope_sin_cb", qrope_sin_cb),
+            ("qrope_cos_sin_cb", qrope_cos_sin_cb),
             ("qrope_trans_mat_cb", qrope_trans_mat_cb),
             ("qrope_Wt", qrope_head_dim_per_core_t),
             ("qrope_Ht", qrope_num_heads_per_core),
@@ -788,15 +784,12 @@ class PreSDPA:
         ]
         # BRISC: no-op (empty args)
         qrope_brisc_named_compile_time_args = []
-        # TRISC: in_cb, cos_cb, sin_cb, trans_mat_cb, rotated_in_interm_cb, cos_interm_cb, sin_interm_cb, out_cb, Wt, Ht
         qrope_trisc_named_compile_time_args = [
             ("qrope_in_cb", matmul2_output_cb),
-            ("qrope_cos_cb", qrope_cos_cb),
-            ("qrope_sin_cb", qrope_sin_cb),
+            ("qrope_cos_sin_cb", qrope_cos_sin_cb),
             ("qrope_trans_mat_cb", qrope_trans_mat_cb),
             ("qrope_rotated_in_interm_cb", qrope_rotated_input_interm_cb),
-            ("qrope_cos_interm_cb", qrope_cos_interm_cb),
-            ("qrope_sin_interm_cb", qrope_sin_interm_cb),
+            ("qrope_cos_sin_interm_cb", qrope_cos_sin_interm_cb),
             ("qrope_output_cb", qrope_output_cb),
             ("qrope_Wt", qrope_head_dim_per_core_t),
             ("qrope_Ht", qrope_num_heads_per_core),
@@ -1075,8 +1068,7 @@ class PreSDPA:
         krope_ncrisc_named_compile_time_args = [
             ("krope_output_cb", krope_output_cb),
             ("krope_in_cb", dkv_matmul_output_cb),
-            ("krope_cos_cb", krope_cos_cb),
-            ("krope_sin_cb", krope_sin_cb),
+            ("krope_cos_sin_cb", krope_cos_sin_cb),
             ("krope_trans_mat_cb", qrope_trans_mat_cb),
             ("krope_Wt", krope_Wt),
             ("krope_Ht", krope_Ht),
@@ -1085,12 +1077,10 @@ class PreSDPA:
         ]
         krope_trisc_named_compile_time_args = [
             ("krope_in_cb", dkv_matmul_output_cb),
-            ("krope_cos_cb", krope_cos_cb),
-            ("krope_sin_cb", krope_sin_cb),
+            ("krope_cos_sin_cb", krope_cos_sin_cb),
             ("krope_trans_mat_cb", qrope_trans_mat_cb),
             ("krope_rotated_in_interm_cb", qrope_rotated_input_interm_cb),
-            ("krope_cos_interm_cb", qrope_cos_interm_cb),
-            ("krope_sin_interm_cb", qrope_sin_interm_cb),
+            ("krope_cos_sin_interm_cb", qrope_cos_sin_interm_cb),
             ("krope_output_cb", krope_output_cb),
             ("krope_Wt", krope_Wt),
             ("krope_Ht", krope_Ht),
@@ -1632,31 +1622,18 @@ class PreSDPA:
                     )
                 ]
                 sdpa_out_interm_running_offset += qrope_output_cb_descriptor.total_size
-                # CB 17: Cos (DRAM, read by NCRISC)
+                # CB 17: Cos/Sin (DRAM, read by NCRISC)
                 qrope_rope_tile_descriptor = ttnn.TileDescriptor(TILE_1x32)
-                qrope_cos_cb_format = ttnn.CBFormatDescriptor(
-                    buffer_index=qrope_cos_cb,
+                qrope_cos_sin_cb_format = ttnn.CBFormatDescriptor(
+                    buffer_index=qrope_cos_sin_cb,
                     data_format=data_format,
                     page_size=qrope_rope_tile_size,
                     tile=qrope_rope_tile_descriptor,
                 )
-                qrope_cos_cb_descriptor = ttnn.CBDescriptor(
-                    total_size=qrope_head_dim_per_core_t * qrope_rope_tile_size,
+                qrope_cos_sin_cb_descriptor = ttnn.CBDescriptor(
+                    total_size=qrope_head_dim_per_core_t * qrope_rope_tile_size * 2,
                     core_ranges=qrope_grid,
-                    format_descriptors=[qrope_cos_cb_format],
-                )
-
-                # CB 18: Sin (DRAM, read by NCRISC)
-                qrope_sin_cb_format = ttnn.CBFormatDescriptor(
-                    buffer_index=qrope_sin_cb,
-                    data_format=data_format,
-                    page_size=qrope_rope_tile_size,
-                    tile=qrope_rope_tile_descriptor,
-                )
-                qrope_sin_cb_descriptor = ttnn.CBDescriptor(
-                    total_size=qrope_head_dim_per_core_t * qrope_rope_tile_size,
-                    core_ranges=qrope_grid,
-                    format_descriptors=[qrope_sin_cb_format],
+                    format_descriptors=[qrope_cos_sin_cb_format],
                 )
 
                 # CB 19: Trans_mat (sharded tensor)
@@ -1682,40 +1659,23 @@ class PreSDPA:
                     )
                 ]
                 sdpa_out_interm_running_offset += qrope_rotated_input_interm_cb_descriptor.total_size
-                # CB 21: Cos intermediate CB — overlap with sdpa_out_interm L1 buffer
+                # CB 21: Cos/Sin intermediate CB — overlap with sdpa_out_interm L1 buffer
                 # This CB is consumed before SDPA runs.
-                qrope_cos_interm_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
-                    qrope_cos_interm_cb,
+                qrope_cos_sin_interm_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+                    qrope_cos_sin_interm_cb,
                     sdpa_out_interm_buffer_device,
                     address_offset=sdpa_out_interm_running_offset,
-                    total_size=qrope_interm_tile_size,
+                    total_size=qrope_interm_tile_size * 2,
                 )
-                qrope_cos_interm_cb_descriptor.format_descriptors = [
+                qrope_cos_sin_interm_cb_descriptor.format_descriptors = [
                     ttnn.CBFormatDescriptor(
-                        buffer_index=qrope_cos_interm_cb,
+                        buffer_index=qrope_cos_sin_interm_cb,
                         data_format=data_format,
                         page_size=TILE_1x32.get_tile_size(data_format),
                         tile=ttnn.TileDescriptor(TILE_1x32),
                     )
                 ]
-                sdpa_out_interm_running_offset += qrope_cos_interm_cb_descriptor.total_size
-                # CB 22: Sin intermediate CB — overlap with sdpa_out_interm L1 buffer
-                # This CB is consumed before SDPA runs.
-                qrope_sin_interm_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
-                    qrope_sin_interm_cb,
-                    sdpa_out_interm_buffer_device,
-                    address_offset=sdpa_out_interm_running_offset,
-                    total_size=qrope_interm_tile_size,
-                )
-                qrope_sin_interm_cb_descriptor.format_descriptors = [
-                    ttnn.CBFormatDescriptor(
-                        buffer_index=qrope_sin_interm_cb,
-                        data_format=data_format,
-                        page_size=TILE_1x32.get_tile_size(data_format),
-                        tile=ttnn.TileDescriptor(TILE_1x32),
-                    )
-                ]
-                sdpa_out_interm_running_offset += qrope_sin_interm_cb_descriptor.total_size
+                sdpa_out_interm_running_offset += qrope_cos_sin_interm_cb_descriptor.total_size
                 # CB 31: CreateQHeads intermediate buffer (row-major data before tilization)
                 # Senders write row-major data here via NOC, receiver marks pages, TRISC tilizes to output
                 # Allocated on union of sender (QNOPE/QROPE) and receiver (SDPA Input) grids
@@ -1827,30 +1787,18 @@ class PreSDPA:
                     )
                 ]
                 sdpa_out_interm_running_offset += kv_rmsnorm_output_cb_descriptor.total_size
-                # CB 29: Cos (DRAM, read by NCRISC)
+                # CB 29: Cos/Sin (DRAM, read by NCRISC)
                 krope_rope_tile_descriptor = ttnn.TileDescriptor(TILE_1x32)
-                krope_cos_cb_format = ttnn.CBFormatDescriptor(
-                    buffer_index=krope_cos_cb,
+                krope_cos_sin_cb_format = ttnn.CBFormatDescriptor(
+                    buffer_index=krope_cos_sin_cb,
                     data_format=data_format,
                     page_size=krope_rope_tile_size,
                     tile=krope_rope_tile_descriptor,
                 )
-                krope_cos_cb_descriptor = ttnn.CBDescriptor(
-                    total_size=krope_Wt * krope_rope_tile_size,
+                krope_cos_sin_cb_descriptor = ttnn.CBDescriptor(
+                    total_size=krope_Wt * krope_rope_tile_size * 2,
                     core_ranges=krope_grid,
-                    format_descriptors=[krope_cos_cb_format],
-                )
-                # CB 30: Sin (DRAM, read by NCRISC)
-                krope_sin_cb_format = ttnn.CBFormatDescriptor(
-                    buffer_index=krope_sin_cb,
-                    data_format=data_format,
-                    page_size=krope_rope_tile_size,
-                    tile=krope_rope_tile_descriptor,
-                )
-                krope_sin_cb_descriptor = ttnn.CBDescriptor(
-                    total_size=krope_Wt * krope_rope_tile_size,
-                    core_ranges=krope_grid,
-                    format_descriptors=[krope_sin_cb_format],
+                    format_descriptors=[krope_cos_sin_cb_format],
                 )
 
                 # CB 28: KRoPE output — overlap with sdpa_out_interm L1 buffer
@@ -2396,20 +2344,17 @@ class PreSDPA:
                     matmul3_output_cb_descriptor,
                     qrope_output_cb_descriptor,
                     create_q_heads_out_cb_descriptor,
-                    qrope_cos_cb_descriptor,
-                    qrope_sin_cb_descriptor,
+                    qrope_cos_sin_cb_descriptor,
                     qrope_trans_mat_cb_descriptor,
                     qrope_rotated_input_interm_cb_descriptor,
-                    qrope_cos_interm_cb_descriptor,
-                    qrope_sin_interm_cb_descriptor,
+                    qrope_cos_sin_interm_cb_descriptor,
                     dkv_matmul_weights_cb_descriptor,
                     dkv_matmul_output_cb_descriptor,
                     kv_rmsnorm_input_cb_descriptor,
                     kv_rmsnorm_gamma_cb_descriptor,
                     kv_rmsnorm_output_cb_descriptor,
                     krope_output_cb_descriptor,
-                    krope_cos_cb_descriptor,
-                    krope_sin_cb_descriptor,
+                    krope_cos_sin_cb_descriptor,
                     create_q_heads_interm_cb_descriptor,
                     kv_cache_output_cb_descriptor,
                     kv_cache_intermed_cb_descriptor,

--- a/models/demos/deepseek_v3_b1/micro_ops/rope/kernels/rope_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/rope/kernels/rope_kernel.cpp
@@ -33,8 +33,7 @@ void kernel_main() {
     using RopeCTArgs = deepseek_b1_ops::Rope::ReaderCTArgs<Wt, Ht, cos_sin_page_size, total_Wt, start_tile_offset>;
 
     constexpr uint32_t in_cb = get_named_compile_time_arg_val("in_cb");
-    constexpr uint32_t cos_cb = get_named_compile_time_arg_val("cos_cb");
-    constexpr uint32_t sin_cb = get_named_compile_time_arg_val("sin_cb");
+    constexpr uint32_t cos_sin_cb = get_named_compile_time_arg_val("cos_sin_cb");
     constexpr uint32_t cos_tensor_address = get_named_compile_time_arg_val("cos_tensor_address");
     constexpr uint32_t sin_tensor_address = get_named_compile_time_arg_val("sin_tensor_address");
     constexpr uint32_t position_ids_tensor_address = get_named_compile_time_arg_val("position_ids_tensor_address");
@@ -45,12 +44,10 @@ void kernel_main() {
 
     deepseek_b1_ops::Rope::ReaderArgs rope_args{
         .in_cb = in_cb,
-        .cos_cb = cos_cb,
-        .sin_cb = sin_cb,
+        .cos_sin_cb = cos_sin_cb,
         .cos_tensor_address = cos_tensor_address,
         .sin_tensor_address = sin_tensor_address,
         .position_ids_tensor_address = position_ids_tensor_address,
-        .trans_mat_cb = trans_mat_cb,
     };
 
 #elif defined(COMPILE_FOR_BRISC)
@@ -68,23 +65,19 @@ void kernel_main() {
 
     // CB indices (passed as runtime args to ComputeArgs)
     constexpr uint32_t in_cb = get_named_compile_time_arg_val("in_cb");
-    constexpr uint32_t cos_cb = get_named_compile_time_arg_val("cos_cb");
-    constexpr uint32_t sin_cb = get_named_compile_time_arg_val("sin_cb");
+    constexpr uint32_t cos_sin_cb = get_named_compile_time_arg_val("cos_sin_cb");
     constexpr uint32_t trans_mat_cb = get_named_compile_time_arg_val("trans_mat_cb");
     constexpr uint32_t rotated_in_interm_cb = get_named_compile_time_arg_val("rotated_in_interm_cb");
-    constexpr uint32_t cos_interm_cb = get_named_compile_time_arg_val("cos_interm_cb");
-    constexpr uint32_t sin_interm_cb = get_named_compile_time_arg_val("sin_interm_cb");
+    constexpr uint32_t cos_sin_interm_cb = get_named_compile_time_arg_val("cos_sin_interm_cb");
     constexpr uint32_t out_cb = get_named_compile_time_arg_val("out_cb");
 
     // Compute args: all CB indices
     deepseek_b1_ops::Rope::ComputeArgs rope_args{
         .in_cb = in_cb,
-        .cos_cb = cos_cb,
-        .sin_cb = sin_cb,
+        .cos_sin_cb = cos_sin_cb,
         .trans_mat_cb = trans_mat_cb,
         .rotated_in_interm_cb = rotated_in_interm_cb,
-        .cos_interm_cb = cos_interm_cb,
-        .sin_interm_cb = sin_interm_cb,
+        .cos_sin_interm_cb = cos_sin_interm_cb,
         .out_cb = out_cb,
     };
     deepseek_compute_kernel_init();

--- a/models/demos/deepseek_v3_b1/micro_ops/rope/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/rope/op.py
@@ -127,13 +127,11 @@ class RopeSingleCore:
 
         # CB indices (matching C++ implementation)
         input_cb = 0  # c_0
-        cos_cb = 1  # c_1
-        sin_cb = 2  # c_2
+        cos_sin_cb = 1  # c_1
         trans_mat_cb = 3  # c_3
         output_cb = 16  # c_16 (output operands start at 16)
         rotated_input_interm_cb = 24  # c_24
-        cos_interm_cb = 25  # c_25
-        sin_interm_cb = 26  # c_26
+        cos_sin_interm_cb = 25  # c_25
 
         # Create tile descriptor
         tile_descriptor = ttnn.TileDescriptor(tile)
@@ -145,30 +143,16 @@ class RopeSingleCore:
         # CB 0: Input (sharded tensor)
         input_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(input_cb, input_tensor)
 
-        # CB 1: Cos (same tile format as input for broadcast compatibility)
-        cos_format = ttnn.CBFormatDescriptor(
-            buffer_index=cos_cb,
+        cos_sin_format = ttnn.CBFormatDescriptor(
+            buffer_index=cos_sin_cb,
             data_format=data_format,
             page_size=tile_size,
             tile=tile_descriptor,
         )
-        cos_cb_descriptor = ttnn.CBDescriptor(
-            total_size=head_dim_per_core_t * tile_size,
+        cos_sin_cb_descriptor = ttnn.CBDescriptor(
+            total_size=2 * head_dim_per_core_t * tile_size,
             core_ranges=core_grid,
-            format_descriptors=[cos_format],
-        )
-
-        # CB 2: Sin (same tile format as input for broadcast compatibility)
-        sin_format = ttnn.CBFormatDescriptor(
-            buffer_index=sin_cb,
-            data_format=data_format,
-            page_size=tile_size,
-            tile=tile_descriptor,
-        )
-        sin_cb_descriptor = ttnn.CBDescriptor(
-            total_size=head_dim_per_core_t * tile_size,
-            core_ranges=core_grid,
-            format_descriptors=[sin_format],
+            format_descriptors=[cos_sin_format],
         )
 
         # CB 3: Trans_mat (sharded tensor)
@@ -190,30 +174,16 @@ class RopeSingleCore:
             format_descriptors=[rotated_interm_format],
         )
 
-        # CB 25: Cos intermediate (not backed by tensor)
-        cos_interm_format = ttnn.CBFormatDescriptor(
-            buffer_index=cos_interm_cb,
+        cos_sin_interm_format = ttnn.CBFormatDescriptor(
+            buffer_index=cos_sin_interm_cb,
             data_format=data_format,
             page_size=tile_size,
             tile=tile_descriptor,
         )
-        cos_interm_cb_descriptor = ttnn.CBDescriptor(
-            total_size=num_interm_tiles * tile_size,
+        cos_sin_interm_cb_descriptor = ttnn.CBDescriptor(
+            total_size=2 * num_interm_tiles * tile_size,
             core_ranges=core_grid,
-            format_descriptors=[cos_interm_format],
-        )
-
-        # CB 26: Sin intermediate (not backed by tensor)
-        sin_interm_format = ttnn.CBFormatDescriptor(
-            buffer_index=sin_interm_cb,
-            data_format=data_format,
-            page_size=tile_size,
-            tile=tile_descriptor,
-        )
-        sin_interm_cb_descriptor = ttnn.CBDescriptor(
-            total_size=num_interm_tiles * tile_size,
-            core_ranges=core_grid,
-            format_descriptors=[sin_interm_format],
+            format_descriptors=[cos_sin_interm_format],
         )
 
         # ========================================================================
@@ -229,8 +199,7 @@ class RopeSingleCore:
             ("cos_tensor_address", cos_tensor.buffer_address()),
             ("sin_tensor_address", sin_tensor.buffer_address()),
             ("position_ids_tensor_address", position_ids_tensor.buffer_address()),
-            ("cos_cb", cos_cb),
-            ("sin_cb", sin_cb),
+            ("cos_sin_cb", cos_sin_cb),
             ("trans_mat_cb", trans_mat_cb),
             ("cos_sin_page_size", tile_size),
             ("Wt", head_dim_per_core_t),
@@ -248,12 +217,10 @@ class RopeSingleCore:
         # Named compile-time args for TRISC
         trisc_named_compile_time_args = [
             ("in_cb", input_cb),
-            ("cos_cb", cos_cb),
-            ("sin_cb", sin_cb),
+            ("cos_sin_cb", cos_sin_cb),
             ("trans_mat_cb", trans_mat_cb),
             ("rotated_in_interm_cb", rotated_input_interm_cb),
-            ("cos_interm_cb", cos_interm_cb),
-            ("sin_interm_cb", sin_interm_cb),
+            ("cos_sin_interm_cb", cos_sin_interm_cb),
             ("out_cb", output_cb),
             ("Wt", head_dim_per_core_t),
             ("Ht", 1),
@@ -296,13 +263,11 @@ class RopeSingleCore:
             kernels=unified_kernel.get_kernel_descriptors().kernels,
             cbs=[
                 input_cb_descriptor,
-                cos_cb_descriptor,
-                sin_cb_descriptor,
+                cos_sin_cb_descriptor,
                 trans_mat_cb_descriptor,
                 output_cb_descriptor,
                 rotated_interm_cb_descriptor,
-                cos_interm_cb_descriptor,
-                sin_interm_cb_descriptor,
+                cos_sin_interm_cb_descriptor,
             ],
         )
 

--- a/models/demos/deepseek_v3_b1/unified_kernels/deepseek_moe_gate.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/deepseek_moe_gate.hpp
@@ -9,8 +9,12 @@
 #include "api/dataflow/dataflow_api.h"
 #elif defined(COMPILE_FOR_TRISC)
 #include <cstdint>
+#ifndef REDUCE_OP
 #define REDUCE_OP PoolType::SUM
+#endif
+#ifndef REDUCE_DIM
 #define REDUCE_DIM ReduceDim::REDUCE_ROW
+#endif
 #include "api/compute/compute_kernel_api.h"
 #include "api/compute/common.h"
 #include "api/compute/tile_move_copy.h"

--- a/models/demos/deepseek_v3_b1/unified_kernels/flash_mla.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/flash_mla.hpp
@@ -233,7 +233,12 @@ struct FlashMLADecode {
                 cur_pos, args.cur_batch, args.core_num_in_reduce, args.num_cores_per_head, args.k_chunk_size);
             (void)k_num_chunks;
 
+            volatile tt_l1_ptr uint32_t* kv_cache_cur_pos_ready_semaphore_ptr =
+                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.kv_cache_cur_pos_ready_semaphore_addr);
+
             if (k_chunk_start == k_chunk_end) {
+                noc_semaphore_wait(kv_cache_cur_pos_ready_semaphore_ptr, args.kv_cache_cur_pos_ready_value);
+                noc_semaphore_set(kv_cache_cur_pos_ready_semaphore_ptr, 0);
                 return;
             }
 
@@ -270,9 +275,6 @@ struct FlashMLADecode {
                 uint64_t k_src_noc_addr = get_shard_noc_addr_helper(k_reader, shard_id);
                 noc_async_read_one_packet_set_state<true>(k_src_noc_addr, args.k_page_size, args.vc, READ_NOC_INDEX);
             }
-
-            volatile tt_l1_ptr uint32_t* kv_cache_cur_pos_ready_semaphore_ptr =
-                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.kv_cache_cur_pos_ready_semaphore_addr);
 
             // Wait for KV cache cur pos ready
             noc_semaphore_wait(kv_cache_cur_pos_ready_semaphore_ptr, args.kv_cache_cur_pos_ready_value);
@@ -370,6 +372,7 @@ struct FlashMLADecode {
 
             const bool is_mcast_sender = args.is_mcast_sender == 1;
             const bool is_output_core = args.is_output_core == 1;
+            noc_async_write_set_trid(0, WRITE_NOC_INDEX);
 
             {
                 DeviceZoneScopedN("reader-q-read");
@@ -567,6 +570,7 @@ struct FlashMLADecode {
                         cb_push_back(args.cb_out_in, out_chunk_tiles);
                     }
                 }
+                noc_semaphore_set(in0_receiver_semaphore_addr_ptr, 0);
             }
 
 // ====================================================================

--- a/models/demos/deepseek_v3_b1/unified_kernels/rope.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/rope.hpp
@@ -68,12 +68,10 @@ struct Rope {
     // Reader args (NCRISC): CB indices for sharded input signaling
     struct ReaderArgs {
         uint32_t in_cb;
-        uint32_t cos_cb;
-        uint32_t sin_cb;
+        uint32_t cos_sin_cb;
         uint32_t cos_tensor_address;
         uint32_t sin_tensor_address;
         uint32_t position_ids_tensor_address;
-        uint32_t trans_mat_cb;
     };
 
     // Writer args (BRISC): none
@@ -82,13 +80,12 @@ struct Rope {
     // Compute args (TRISC): CB indices as runtime args
     struct ComputeArgs {
         uint32_t in_cb;
-        uint32_t cos_cb;
-        uint32_t sin_cb;
+        uint32_t cos_sin_cb;
         uint32_t trans_mat_cb;
         uint32_t rotated_in_interm_cb;
-        uint32_t cos_interm_cb;
-        uint32_t sin_interm_cb;
+        uint32_t cos_sin_interm_cb;
         uint32_t out_cb;
+        uint32_t trans_mat_address_override = 0;  // byte address; overrides trans_mat read ptr if > 0
     };
 
     using RTArgs = unified_kernels::SelectByRISCV<ReaderArgs, WriterArgs, ComputeArgs>;
@@ -124,25 +121,20 @@ struct Rope {
 
             auto cos_accessor = TensorAccessor(
                 tensor_accessor::make_interleaved_dspec</*is_dram=*/true>(), args.cos_tensor_address, page_size);
-            cb_reserve_back(args.cos_cb, Wt);
-            uint32_t l1_write_addr = get_write_ptr(args.cos_cb);
+            cb_reserve_back(args.cos_sin_cb, Wt * 2);
+            uint32_t l1_write_addr = get_write_ptr(args.cos_sin_cb);
             for (uint32_t i = 0; i < Wt; i++) {
                 noc_async_read_page(start_page + i, cos_accessor, l1_write_addr);
                 l1_write_addr += page_size;
             }
-            noc_async_read_barrier();
-            cb_push_back(args.cos_cb, Wt);
-
             auto sin_accessor = TensorAccessor(
                 tensor_accessor::make_interleaved_dspec</*is_dram=*/true>(), args.sin_tensor_address, page_size);
-            cb_reserve_back(args.sin_cb, Wt);
-            l1_write_addr = get_write_ptr(args.sin_cb);
             for (uint32_t i = 0; i < Wt; i++) {
                 noc_async_read_page(start_page + i, sin_accessor, l1_write_addr);
                 l1_write_addr += page_size;
             }
             noc_async_read_barrier();
-            cb_push_back(args.sin_cb, Wt);
+            cb_push_back(args.cos_sin_cb, Wt * 2);
 
 #endif
 #if defined(COMPILE_FOR_TRISC)
@@ -155,9 +147,12 @@ struct Rope {
             // ================================================================
             // Wait for sharded CBs (signaled by NCRISC)
             // ================================================================
-            cb_wait_front(args.trans_mat_cb, 1);  // Trans_mat: 1 tile, reused for all heads
-            cb_wait_front(args.sin_cb, Wt);       // Sin: Wt tiles (reused for all heads)
-            cb_wait_front(args.cos_cb, Wt);       // Cos: Wt tiles (reused for all heads)
+            if (args.trans_mat_address_override > 0) {
+                UNPACK(({ unified_kernels::override_cb_rd_ptr(args.trans_mat_cb, args.trans_mat_address_override); }));
+            } else {
+                cb_wait_front(args.trans_mat_cb, 1);  // Trans_mat: 1 tile, reused for all heads
+            }
+            cb_wait_front(args.cos_sin_cb, Wt * 2);  // Cos/Sin: Wt tiles (reused for all heads)
 
             // ================================================================
             // Main loop: process Ht heads, each head consumes Wt tiles
@@ -167,8 +162,7 @@ struct Rope {
 
                 // Reserve intermediate and output buffers
                 cb_reserve_back(args.rotated_in_interm_cb, Wt);
-                cb_reserve_back(args.sin_interm_cb, Wt);
-                cb_reserve_back(args.cos_interm_cb, Wt);
+                cb_reserve_back(args.cos_sin_interm_cb, Wt * 2);
                 cb_reserve_back(args.out_cb, Wt);
 
                 cb_wait_front(args.in_cb, Wt);
@@ -194,18 +188,18 @@ struct Rope {
                 // Step 2: sin_interm = rotated * sin (broadcast multiply)
                 // ============================================================
                 reconfig_data_format_srca<false, true>(args.rotated_in_interm_cb);
-                mul_bcast_rows_init_short(args.rotated_in_interm_cb, args.sin_cb);
+                mul_bcast_rows_init_short(args.rotated_in_interm_cb, args.cos_sin_cb);
                 tile_regs_acquire();
                 for (uint32_t j = 0; j < Wt; ++j) {
-                    mul_tiles_bcast<BroadcastType::ROW>(args.rotated_in_interm_cb, args.sin_cb, j, j, j);
+                    mul_tiles_bcast<BroadcastType::ROW>(args.rotated_in_interm_cb, args.cos_sin_cb, j, Wt + j, j);
                 }
                 tile_regs_commit();
                 tile_regs_wait();
                 for (uint32_t j = 0; j < Wt; ++j) {
-                    pack_tile(j, args.sin_interm_cb, j);
+                    pack_tile(j, args.cos_sin_interm_cb);
                 }
                 tile_regs_release();
-                cb_push_back(args.sin_interm_cb, Wt);
+                cb_push_back(args.cos_sin_interm_cb, Wt);
                 cb_pop_front(args.rotated_in_interm_cb, Wt);
 
                 // ============================================================
@@ -213,26 +207,25 @@ struct Rope {
                 // ============================================================
                 tile_regs_acquire();
                 for (uint32_t j = 0; j < Wt; ++j) {
-                    mul_tiles_bcast<BroadcastType::ROW>(args.in_cb, args.cos_cb, j, j, j);
+                    mul_tiles_bcast<BroadcastType::ROW>(args.in_cb, args.cos_sin_cb, j, j, j);
                 }
                 tile_regs_commit();
                 tile_regs_wait();
                 for (uint32_t j = 0; j < Wt; ++j) {
-                    pack_tile(j, args.cos_interm_cb, j);
+                    pack_tile(j, args.cos_sin_interm_cb);
                 }
                 tile_regs_release();
-                cb_push_back(args.cos_interm_cb, Wt);
+                cb_push_back(args.cos_sin_interm_cb, Wt);
                 cb_pop_front(args.in_cb, Wt);
 
                 // ============================================================
                 // Step 4: output = cos_interm + sin_interm (add)
                 // ============================================================
-                cb_wait_front(args.sin_interm_cb, Wt);
-                cb_wait_front(args.cos_interm_cb, Wt);
-                add_tiles_init(args.cos_interm_cb, args.sin_interm_cb);
+                cb_wait_front(args.cos_sin_interm_cb, Wt * 2);
+                add_tiles_init(args.cos_sin_interm_cb, args.cos_sin_interm_cb);
                 tile_regs_acquire();
                 for (uint32_t j = 0; j < Wt; ++j) {
-                    add_tiles(args.cos_interm_cb, args.sin_interm_cb, j, j, j);
+                    add_tiles(args.cos_sin_interm_cb, args.cos_sin_interm_cb, j, Wt + j, j);
                 }
                 tile_regs_commit();
                 tile_regs_wait();
@@ -241,16 +234,14 @@ struct Rope {
                 }
                 tile_regs_release();
                 cb_push_back(args.out_cb, Wt);
-                cb_pop_front(args.sin_interm_cb, Wt);
-                cb_pop_front(args.cos_interm_cb, Wt);
+                cb_pop_front(args.cos_sin_interm_cb, Wt * 2);
             }
 
             // ================================================================
             // Cleanup: pop sin/cos (trans_mat is reused, not popped)
             // Note: sin/cos are reused for all heads, so only pop once after all heads processed
             // ================================================================
-            cb_pop_front(args.sin_cb, Wt);
-            cb_pop_front(args.cos_cb, Wt);
+            cb_pop_front(args.cos_sin_cb, Wt * 2);
 #endif
         }
     };


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Rope uses a lot of CBs which can be consolidated.
Flash MLA did not properly support looping.

### What's changed
Consolidate con/sin cbs and cos_interm/sin_interm for rope.
Add missing semaphore clears in Flash MLA.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aho/mla-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aho/mla-fixes)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aho/mla-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/mla-fixes)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aho/mla-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/mla-fixes)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aho/mla-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/mla-fixes)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aho/mla-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/mla-fixes)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aho/mla-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/mla-fixes)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
