### PR TITLE
[LAYERNOM] Reader kernel does not account for different num_tiles_scaler reads on welford or default path 

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln.cpp
@@ -224,10 +224,13 @@ void kernel_main() {
         uint32_t l1_read_addr_ex_remote = cb_ex_obj.get_read_ptr();
         cb_ex_global_obj.reserve_back(block_h * num_tiles_scaler);
         uint32_t gather_write_offset = 0;
+        // Account for num_tiles_scaler (2 for Welford, 1 otherwise) when checking
+        // if the gather read fits in a single NOC packet.
+        constexpr uint32_t gather_tiles_scaler = use_welford ? 2 : 1;
         for (uint32_t block = 0; block < num_all_to_all_workers_first_stage; ++block) {
             uint32_t num_tiles_bytes = block == num_all_to_all_workers_first_stage - 1 ? num_tiles_per_worker_last_bytes
                                                                                        : num_tiles_per_worker_bytes;
-            if constexpr (num_tiles_per_worker_bytes <= NOC_MAX_BURST_SIZE) {
+            if constexpr (num_tiles_per_worker_bytes * gather_tiles_scaler <= NOC_MAX_BURST_SIZE) {
                 noc.async_read<experimental::Noc::TxnIdMode::DISABLED, NOC_MAX_BURST_SIZE>(
                     remote_ep,
                     cb_ex_global_obj,


### PR DESCRIPTION
### Ticket
[#37171](https://github.com/tenstorrent/tt-metal/issues/37171https://github.com/tenstorrent/tt-metal/issues/37171https://github.com/tenstorrent/tt-metal/issues/37171)

### Problem description
[Sanity test with watcher](https://github.com/tenstorrent/tt-metal/actions/runs/23174148342/job/67344133648) enabled are failing due to assert detecting potential race condition. The gather section of the mcast sender kernel uses a compile time check (num_tiles_per_worker_bytes <= NOC_MAX_BURST_SIZE) to decide whether a NOC read fits in a single packet. However, the actual read size is num_tiles_scaler * num_tiles_bytes, it is 2x larger when using Welford's algorithm. With the default layernorm config (fp32_dest_acc_en=true, Float32 tiles = 4096B), this results in num_tiles_per_worker_bytes = 8192 = NOC_MAX_BURST_SIZE, passing the check, but the actual read is 16384 bytes which exceeds the hardware burst limit. This causes a software/hardware NOC read counter mismatch, detected by the watcher as pending reads at kernel end.

### What's changed
The fix accounts for the Welford scaler in the compile time check so oversized reads fall through to the generic any_len path that properly splits them.

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dstoiljkovic/layernorm_watcher_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dstoiljkovic/layernorm_watcher_fix)