### PR TITLE
Default compute config to HiFi3 with fp32 on WH

### DIFF
--- a/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.cpp
+++ b/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.cpp
@@ -55,6 +55,7 @@ void verify_numerical_configuration(
     if (!cfg.fp32_dest_acc_en || cfg.math_fidelity != MathFidelity::HiFi4) {
         return;
     }
+    // Only print warning once per process.
     static std::atomic<bool> warning_generated{false};
     if (!warning_generated) {
         log_warning(

--- a/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.cpp
+++ b/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.cpp
@@ -2,7 +2,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <atomic>
+
 #include <tt-metalium/constants.hpp>
+#include <tt-logger/tt-logger.hpp>
 #include "compute_kernel_config.hpp"
 #include "ttnn/device.hpp"
 
@@ -36,6 +39,31 @@ DeviceComputeKernelConfig init_device_compute_kernel_config(
         .packer_l1_acc = default_l1_acc,
         .dst_full_sync_en = default_dst_full_sync_en,
         .throttle_level = default_throttle_level};
+}
+
+void verify_numerical_configuration(
+    // Due to hardware bug (#38306), HiFi4 + fp32_dest_acc_en can sometime produce incorrect results on Wormhole.
+    tt::ARCH arch,
+    const std::optional<const DeviceComputeKernelConfig>& user_compute_kernel_config) {
+    if (arch != tt::ARCH::WORMHOLE_B0) {
+        return;
+    }
+    if (!user_compute_kernel_config.has_value()) {
+        return;
+    }
+    const auto& cfg = user_compute_kernel_config.value();
+    if (!cfg.fp32_dest_acc_en || cfg.math_fidelity != MathFidelity::HiFi4) {
+        return;
+    }
+    static std::atomic<bool> warning_generated{false};
+    if (!warning_generated) {
+        log_warning(
+            tt::LogOp,
+            "On Wormhole with fp32 accumulation, output accuracy can be worse with HiFi4 than HiFi3 due to a hardware "
+            "bug. "
+            "Prefer using HiFi3 with fp32 accumulation on Wormhole.");
+        warning_generated = true;
+    }
 }
 
 bool get_fp32_dest_acc_en(const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {

--- a/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.cpp
+++ b/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.cpp
@@ -55,15 +55,16 @@ void verify_numerical_configuration(
     if (!cfg.fp32_dest_acc_en || cfg.math_fidelity != MathFidelity::HiFi4) {
         return;
     }
-    // Only print warning once per process.
+    // Only print warning once per process
+    // (compare-and-swap so concurrent callers do not double-log).
     static std::atomic<bool> warning_generated{false};
-    if (!warning_generated) {
+    bool expected = false;
+    if (warning_generated.compare_exchange_strong(expected, true, std::memory_order_acq_rel)) {
         log_warning(
             tt::LogOp,
             "On Wormhole with fp32 accumulation, output accuracy can be worse with HiFi4 than HiFi3 due to a hardware "
             "bug. "
             "Prefer using HiFi3 with fp32 accumulation on Wormhole.");
-        warning_generated = true;
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.hpp
+++ b/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.hpp
@@ -48,9 +48,6 @@ DeviceComputeKernelConfig init_device_compute_kernel_config(
     ttnn::operations::compute_throttle_utils::ThrottleLevel default_throttle_level =
         ttnn::operations::compute_throttle_utils::ThrottleLevel::NO_THROTTLE);
 
-// Unlike many verify_* helpers in the codebase, this does not TT_FATAL. If the user supplied a compute
-// kernel config that triggers hardware bug #38306 on Wormhole (HiFi4 + fp32 dest accumulation), logs a
-// warning at most once per process.
 void verify_numerical_configuration(
     tt::ARCH arch, const std::optional<const DeviceComputeKernelConfig>& user_compute_kernel_config);
 

--- a/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.hpp
+++ b/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.hpp
@@ -48,6 +48,12 @@ DeviceComputeKernelConfig init_device_compute_kernel_config(
     ttnn::operations::compute_throttle_utils::ThrottleLevel default_throttle_level =
         ttnn::operations::compute_throttle_utils::ThrottleLevel::NO_THROTTLE);
 
+// Unlike many verify_* helpers in the codebase, this does not TT_FATAL. If the user supplied a compute
+// kernel config that triggers hardware bug #38306 on Wormhole (HiFi4 + fp32 dest accumulation), logs a
+// warning at most once per process.
+void verify_numerical_configuration(
+    tt::ARCH arch, const std::optional<const DeviceComputeKernelConfig>& user_compute_kernel_config);
+
 bool get_fp32_dest_acc_en(const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 bool get_dst_full_sync_en(const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 MathFidelity get_math_fidelity(const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
@@ -158,13 +158,6 @@ UnaryProgramFactory::cached_program_t UnaryProgramFactory::create(
     // Use HiFi3 when fp32_dest_acc_en is True on Wormhole B0.
     const auto default_fp32_acc_math_fidelity =
         (args.fp32_dest_acc_en && device->arch() == tt::ARCH::WORMHOLE_B0) ? MathFidelity::HiFi3 : MathFidelity::HiFi4;
-    if (args.fp32_dest_acc_en && device->arch() == tt::ARCH::WORMHOLE_B0) {
-        log_warning(
-            tt::LogOp,
-            "On Wormhole with fp32 accumulation, output accuracy can be worse with HiFi4 than HiFi3 due to a hardware "
-            "bug."
-            "Prefer using HiFi3 with fp32 accumulation on Wormhole.");
-    }
 
     auto eltwise_unary_kernel_group_1_id = tt::tt_metal::CreateKernel(
         program,
@@ -401,13 +394,6 @@ UnarySubCoreGridProgramFactory::cached_program_t UnarySubCoreGridProgramFactory:
 
     // Due to hardware bug (#38306), HiFi4 + fp32_dest_acc_en produces incorrect results on Wormhole B0.
     // Use HiFi3 when fp32_dest_acc_en is True on Wormhole B0.
-    if (args.fp32_dest_acc_en && input.device()->arch() == tt::ARCH::WORMHOLE_B0) {
-        log_warning(
-            tt::LogOp,
-            "On Wormhole with fp32 accumulation, output accuracy can be worse with HiFi4 than HiFi3 due to a hardware "
-            "bug. "
-            "Prefer using HiFi3 with fp32 accumulation on Wormhole.");
-    }
     const auto default_fp32_acc_math_fidelity_sub =
         (args.fp32_dest_acc_en && input.device()->arch() == tt::ARCH::WORMHOLE_B0) ? MathFidelity::HiFi3
                                                                                    : MathFidelity::HiFi4;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
@@ -156,13 +156,13 @@ UnaryProgramFactory::cached_program_t UnaryProgramFactory::create(
 
     // Due to hardware bug (#38306), HiFi4 + fp32_dest_acc_en produces incorrect results on Wormhole B0.
     // Use HiFi3 when fp32_dest_acc_en is True on Wormhole B0.
-    const auto math_fidelity_for_config =
+    const auto default_fp32_acc_math_fidelity =
         (args.fp32_dest_acc_en && device->arch() == tt::ARCH::WORMHOLE_B0) ? MathFidelity::HiFi3 : MathFidelity::HiFi4;
     if (args.fp32_dest_acc_en && device->arch() == tt::ARCH::WORMHOLE_B0) {
         log_warning(
             tt::LogOp,
-            "Unary op with fp32_dest_acc_en on Wormhole B0: using HiFi3 instead of HiFi4 "
-            "to avoid hardware bug (#38306).");
+            "On Wormhole with fp32 accumulation, output accuracy can be worse with HiFi4 than HiFi3. "
+            "Prefer using HiFi3 with fp32 accumulation on Wormhole.");
     }
 
     auto eltwise_unary_kernel_group_1_id = tt::tt_metal::CreateKernel(
@@ -170,7 +170,7 @@ UnaryProgramFactory::cached_program_t UnaryProgramFactory::create(
         path,
         core_group_1,
         tt::tt_metal::ComputeConfig{
-            .math_fidelity = math_fidelity_for_config,
+            .math_fidelity = default_fp32_acc_math_fidelity,
             .fp32_dest_acc_en = args.fp32_dest_acc_en,
             .unpack_to_dest_mode = unpack_to_dest_mode,
             .bfp8_pack_precise = args.bfp8_pack_precise,
@@ -190,7 +190,7 @@ UnaryProgramFactory::cached_program_t UnaryProgramFactory::create(
             path,
             core_group_2,
             tt::tt_metal::ComputeConfig{
-                .math_fidelity = math_fidelity_for_config,
+                .math_fidelity = default_fp32_acc_math_fidelity,
                 .fp32_dest_acc_en = args.fp32_dest_acc_en,
                 .unpack_to_dest_mode = unpack_to_dest_mode,
                 .bfp8_pack_precise = args.bfp8_pack_precise,
@@ -403,19 +403,19 @@ UnarySubCoreGridProgramFactory::cached_program_t UnarySubCoreGridProgramFactory:
     if (args.fp32_dest_acc_en && input.device()->arch() == tt::ARCH::WORMHOLE_B0) {
         log_warning(
             tt::LogOp,
-            "Unary op with fp32_dest_acc_en on Wormhole B0: using HiFi3 instead of HiFi4 "
-            "to avoid hardware bug (#38306).");
+            "On Wormhole with fp32 accumulation, output accuracy can be worse with HiFi4 than HiFi3. "
+            "Prefer using HiFi3 with fp32 accumulation on Wormhole.");
     }
-    const auto math_fidelity_for_config_sub = (args.fp32_dest_acc_en && input.device()->arch() == tt::ARCH::WORMHOLE_B0)
-                                                  ? MathFidelity::HiFi3
-                                                  : MathFidelity::HiFi4;
+    const auto default_fp32_acc_math_fidelity_sub =
+        (args.fp32_dest_acc_en && input.device()->arch() == tt::ARCH::WORMHOLE_B0) ? MathFidelity::HiFi3
+                                                                                   : MathFidelity::HiFi4;
 
     auto eltwise_unary_kernel_id = tt::tt_metal::CreateKernel(
         program,
         path,
         all_cores,
         tt::tt_metal::ComputeConfig{
-            .math_fidelity = math_fidelity_for_config_sub,
+            .math_fidelity = default_fp32_acc_math_fidelity_sub,
             .fp32_dest_acc_en = args.fp32_dest_acc_en,
             .unpack_to_dest_mode = unpack_to_dest_mode,
             .bfp8_pack_precise = args.bfp8_pack_precise,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
@@ -161,7 +161,8 @@ UnaryProgramFactory::cached_program_t UnaryProgramFactory::create(
     if (args.fp32_dest_acc_en && device->arch() == tt::ARCH::WORMHOLE_B0) {
         log_warning(
             tt::LogOp,
-            "On Wormhole with fp32 accumulation, output accuracy can be worse with HiFi4 than HiFi3. "
+            "On Wormhole with fp32 accumulation, output accuracy can be worse with HiFi4 than HiFi3 due to a hardware "
+            "bug."
             "Prefer using HiFi3 with fp32 accumulation on Wormhole.");
     }
 
@@ -403,7 +404,8 @@ UnarySubCoreGridProgramFactory::cached_program_t UnarySubCoreGridProgramFactory:
     if (args.fp32_dest_acc_en && input.device()->arch() == tt::ARCH::WORMHOLE_B0) {
         log_warning(
             tt::LogOp,
-            "On Wormhole with fp32 accumulation, output accuracy can be worse with HiFi4 than HiFi3. "
+            "On Wormhole with fp32 accumulation, output accuracy can be worse with HiFi4 than HiFi3 due to a hardware "
+            "bug. "
             "Prefer using HiFi3 with fp32 accumulation on Wormhole.");
     }
     const auto default_fp32_acc_math_fidelity_sub =

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
@@ -155,7 +155,7 @@ UnaryProgramFactory::cached_program_t UnaryProgramFactory::create(
     auto path = fmt::format("{}/{}", compute_root, utils::get_compute_kernel_path(ops_chain[0].type(), input.dtype()));
 
     // Due to hardware bug (#38306), HiFi4 + fp32_dest_acc_en can sometime produce incorrect results on Wormhole.
-    // Use HiFi3 when fp32_dest_acc_en is True on Wormhole B0.
+    // Use HiFi3 when fp32_dest_acc_en is True on Wormhole (less likely to give bad results).
     const auto default_fp32_acc_math_fidelity =
         (args.fp32_dest_acc_en && device->arch() == tt::ARCH::WORMHOLE_B0) ? MathFidelity::HiFi3 : MathFidelity::HiFi4;
 
@@ -393,7 +393,7 @@ UnarySubCoreGridProgramFactory::cached_program_t UnarySubCoreGridProgramFactory:
     auto path = fmt::format("{}/{}", compute_root, utils::get_compute_kernel_path(ops_chain[0].type(), input.dtype()));
 
     // Due to hardware bug (#38306), HiFi4 + fp32_dest_acc_en can sometime produce incorrect results on Wormhole.
-    // Use HiFi3 when fp32_dest_acc_en is True on Wormhole B0.
+    // Use HiFi3 when fp32_dest_acc_en is True on Wormhole (less likely to give bad results).
     const auto default_fp32_acc_math_fidelity_sub =
         (args.fp32_dest_acc_en && input.device()->arch() == tt::ARCH::WORMHOLE_B0) ? MathFidelity::HiFi3
                                                                                    : MathFidelity::HiFi4;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
@@ -154,7 +154,7 @@ UnaryProgramFactory::cached_program_t UnaryProgramFactory::create(
 
     auto path = fmt::format("{}/{}", compute_root, utils::get_compute_kernel_path(ops_chain[0].type(), input.dtype()));
 
-    // Due to hardware bug (#38306), HiFi4 + fp32_dest_acc_en produces incorrect results on Wormhole B0.
+    // Due to hardware bug (#38306), HiFi4 + fp32_dest_acc_en can sometime produce incorrect results on Wormhole.
     // Use HiFi3 when fp32_dest_acc_en is True on Wormhole B0.
     const auto default_fp32_acc_math_fidelity =
         (args.fp32_dest_acc_en && device->arch() == tt::ARCH::WORMHOLE_B0) ? MathFidelity::HiFi3 : MathFidelity::HiFi4;
@@ -392,7 +392,7 @@ UnarySubCoreGridProgramFactory::cached_program_t UnarySubCoreGridProgramFactory:
 
     auto path = fmt::format("{}/{}", compute_root, utils::get_compute_kernel_path(ops_chain[0].type(), input.dtype()));
 
-    // Due to hardware bug (#38306), HiFi4 + fp32_dest_acc_en produces incorrect results on Wormhole B0.
+    // Due to hardware bug (#38306), HiFi4 + fp32_dest_acc_en can sometime produce incorrect results on Wormhole.
     // Use HiFi3 when fp32_dest_acc_en is True on Wormhole B0.
     const auto default_fp32_acc_math_fidelity_sub =
         (args.fp32_dest_acc_en && input.device()->arch() == tt::ARCH::WORMHOLE_B0) ? MathFidelity::HiFi3

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
@@ -154,12 +154,23 @@ UnaryProgramFactory::cached_program_t UnaryProgramFactory::create(
 
     auto path = fmt::format("{}/{}", compute_root, utils::get_compute_kernel_path(ops_chain[0].type(), input.dtype()));
 
+    // Due to hardware bug (#38306), HiFi4 + fp32_dest_acc_en produces incorrect results on Wormhole B0.
+    // Use HiFi3 when fp32_dest_acc_en is True on Wormhole B0.
+    const auto math_fidelity_for_config =
+        (args.fp32_dest_acc_en && device->arch() == tt::ARCH::WORMHOLE_B0) ? MathFidelity::HiFi3 : MathFidelity::HiFi4;
+    if (args.fp32_dest_acc_en && device->arch() == tt::ARCH::WORMHOLE_B0) {
+        log_warning(
+            tt::LogOp,
+            "Unary op with fp32_dest_acc_en on Wormhole B0: using HiFi3 instead of HiFi4 "
+            "to avoid hardware bug (#38306).");
+    }
+
     auto eltwise_unary_kernel_group_1_id = tt::tt_metal::CreateKernel(
         program,
         path,
         core_group_1,
         tt::tt_metal::ComputeConfig{
-            .math_fidelity = MathFidelity::HiFi4,
+            .math_fidelity = math_fidelity_for_config,
             .fp32_dest_acc_en = args.fp32_dest_acc_en,
             .unpack_to_dest_mode = unpack_to_dest_mode,
             .bfp8_pack_precise = args.bfp8_pack_precise,
@@ -179,7 +190,7 @@ UnaryProgramFactory::cached_program_t UnaryProgramFactory::create(
             path,
             core_group_2,
             tt::tt_metal::ComputeConfig{
-                .math_fidelity = MathFidelity::HiFi4,
+                .math_fidelity = math_fidelity_for_config,
                 .fp32_dest_acc_en = args.fp32_dest_acc_en,
                 .unpack_to_dest_mode = unpack_to_dest_mode,
                 .bfp8_pack_precise = args.bfp8_pack_precise,
@@ -387,12 +398,24 @@ UnarySubCoreGridProgramFactory::cached_program_t UnarySubCoreGridProgramFactory:
 
     auto path = fmt::format("{}/{}", compute_root, utils::get_compute_kernel_path(ops_chain[0].type(), input.dtype()));
 
+    // Due to hardware bug (#38306), HiFi4 + fp32_dest_acc_en produces incorrect results on Wormhole B0.
+    // Use HiFi3 when fp32_dest_acc_en is True on Wormhole B0.
+    if (args.fp32_dest_acc_en && input.device()->arch() == tt::ARCH::WORMHOLE_B0) {
+        log_warning(
+            tt::LogOp,
+            "Unary op with fp32_dest_acc_en on Wormhole B0: using HiFi3 instead of HiFi4 "
+            "to avoid hardware bug (#38306).");
+    }
+    const auto math_fidelity_for_config_sub = (args.fp32_dest_acc_en && input.device()->arch() == tt::ARCH::WORMHOLE_B0)
+                                                  ? MathFidelity::HiFi3
+                                                  : MathFidelity::HiFi4;
+
     auto eltwise_unary_kernel_id = tt::tt_metal::CreateKernel(
         program,
         path,
         all_cores,
         tt::tt_metal::ComputeConfig{
-            .math_fidelity = MathFidelity::HiFi4,
+            .math_fidelity = math_fidelity_for_config_sub,
             .fp32_dest_acc_en = args.fp32_dest_acc_en,
             .unpack_to_dest_mode = unpack_to_dest_mode,
             .bfp8_pack_precise = args.bfp8_pack_precise,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_sharded_program_factory.cpp
@@ -186,7 +186,8 @@ UnaryShardedProgramFactory::cached_program_t UnaryShardedProgramFactory::create(
     if (args.fp32_dest_acc_en && input.device()->arch() == tt::ARCH::WORMHOLE_B0) {
         log_warning(
             tt::LogOp,
-            "On Wormhole with fp32 accumulation, output accuracy can be worse with HiFi4 than HiFi3. "
+            "On Wormhole with fp32 accumulation, output accuracy can be worse with HiFi4 than HiFi3 due to a hardware "
+            "bug. "
             "Prefer using HiFi3 with fp32 accumulation on Wormhole.");
     }
     const auto default_fp32_acc_math_fidelity =

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_sharded_program_factory.cpp
@@ -181,12 +181,24 @@ UnaryShardedProgramFactory::cached_program_t UnaryShardedProgramFactory::create(
     auto path =
         fmt::format("{}/{}", compute_root_sharded, utils::get_compute_kernel_path(ops_chain[0].type(), input.dtype()));
 
+    // Due to hardware bug (#38306), HiFi4 + fp32_dest_acc_en produces incorrect results on Wormhole B0.
+    // Use HiFi3 when fp32_dest_acc_en is True on Wormhole B0.
+    if (args.fp32_dest_acc_en && input.device()->arch() == tt::ARCH::WORMHOLE_B0) {
+        log_warning(
+            tt::LogOp,
+            "Unary op with fp32_dest_acc_en on Wormhole B0: using HiFi3 instead of HiFi4 "
+            "to avoid hardware bug (#38306).");
+    }
+    const auto math_fidelity_for_config = (args.fp32_dest_acc_en && input.device()->arch() == tt::ARCH::WORMHOLE_B0)
+                                              ? MathFidelity::HiFi3
+                                              : MathFidelity::HiFi4;
+
     auto eltwise_unary_kernel_group_1_id = tt::tt_metal::CreateKernel(
         program,
         path,
         all_cores,
         tt::tt_metal::ComputeConfig{
-            .math_fidelity = MathFidelity::HiFi4,
+            .math_fidelity = math_fidelity_for_config,
             .fp32_dest_acc_en = args.fp32_dest_acc_en,
             .unpack_to_dest_mode = unpack_to_dest_mode,
             .bfp8_pack_precise = args.bfp8_pack_precise,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_sharded_program_factory.cpp
@@ -182,7 +182,7 @@ UnaryShardedProgramFactory::cached_program_t UnaryShardedProgramFactory::create(
         fmt::format("{}/{}", compute_root_sharded, utils::get_compute_kernel_path(ops_chain[0].type(), input.dtype()));
 
     // Due to hardware bug (#38306), HiFi4 + fp32_dest_acc_en can sometime produce incorrect results on Wormhole.
-    // Use HiFi3 when fp32_dest_acc_en is True on Wormhole B0.
+    // Use HiFi3 when fp32_dest_acc_en is True on Wormhole (less likely to give bad results).
     const auto default_fp32_acc_math_fidelity =
         (args.fp32_dest_acc_en && input.device()->arch() == tt::ARCH::WORMHOLE_B0) ? MathFidelity::HiFi3
                                                                                    : MathFidelity::HiFi4;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_sharded_program_factory.cpp
@@ -181,7 +181,7 @@ UnaryShardedProgramFactory::cached_program_t UnaryShardedProgramFactory::create(
     auto path =
         fmt::format("{}/{}", compute_root_sharded, utils::get_compute_kernel_path(ops_chain[0].type(), input.dtype()));
 
-    // Due to hardware bug (#38306), HiFi4 + fp32_dest_acc_en produces incorrect results on Wormhole B0.
+    // Due to hardware bug (#38306), HiFi4 + fp32_dest_acc_en can sometime produce incorrect results on Wormhole.
     // Use HiFi3 when fp32_dest_acc_en is True on Wormhole B0.
     const auto default_fp32_acc_math_fidelity =
         (args.fp32_dest_acc_en && input.device()->arch() == tt::ARCH::WORMHOLE_B0) ? MathFidelity::HiFi3

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_sharded_program_factory.cpp
@@ -183,13 +183,6 @@ UnaryShardedProgramFactory::cached_program_t UnaryShardedProgramFactory::create(
 
     // Due to hardware bug (#38306), HiFi4 + fp32_dest_acc_en produces incorrect results on Wormhole B0.
     // Use HiFi3 when fp32_dest_acc_en is True on Wormhole B0.
-    if (args.fp32_dest_acc_en && input.device()->arch() == tt::ARCH::WORMHOLE_B0) {
-        log_warning(
-            tt::LogOp,
-            "On Wormhole with fp32 accumulation, output accuracy can be worse with HiFi4 than HiFi3 due to a hardware "
-            "bug. "
-            "Prefer using HiFi3 with fp32 accumulation on Wormhole.");
-    }
     const auto default_fp32_acc_math_fidelity =
         (args.fp32_dest_acc_en && input.device()->arch() == tt::ARCH::WORMHOLE_B0) ? MathFidelity::HiFi3
                                                                                    : MathFidelity::HiFi4;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_sharded_program_factory.cpp
@@ -186,19 +186,19 @@ UnaryShardedProgramFactory::cached_program_t UnaryShardedProgramFactory::create(
     if (args.fp32_dest_acc_en && input.device()->arch() == tt::ARCH::WORMHOLE_B0) {
         log_warning(
             tt::LogOp,
-            "Unary op with fp32_dest_acc_en on Wormhole B0: using HiFi3 instead of HiFi4 "
-            "to avoid hardware bug (#38306).");
+            "On Wormhole with fp32 accumulation, output accuracy can be worse with HiFi4 than HiFi3. "
+            "Prefer using HiFi3 with fp32 accumulation on Wormhole.");
     }
-    const auto math_fidelity_for_config = (args.fp32_dest_acc_en && input.device()->arch() == tt::ARCH::WORMHOLE_B0)
-                                              ? MathFidelity::HiFi3
-                                              : MathFidelity::HiFi4;
+    const auto default_fp32_acc_math_fidelity =
+        (args.fp32_dest_acc_en && input.device()->arch() == tt::ARCH::WORMHOLE_B0) ? MathFidelity::HiFi3
+                                                                                   : MathFidelity::HiFi4;
 
     auto eltwise_unary_kernel_group_1_id = tt::tt_metal::CreateKernel(
         program,
         path,
         all_cores,
         tt::tt_metal::ComputeConfig{
-            .math_fidelity = math_fidelity_for_config,
+            .math_fidelity = default_fp32_acc_math_fidelity,
             .fp32_dest_acc_en = args.fp32_dest_acc_en,
             .unpack_to_dest_mode = unpack_to_dest_mode,
             .bfp8_pack_precise = args.bfp8_pack_precise,

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_device_operation.cpp
@@ -5,6 +5,7 @@
 #include "minimal_matmul_device_operation.hpp"
 #include "minimal_matmul_program_factory.hpp"
 
+#include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/math.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/constants.hpp>
@@ -267,13 +268,23 @@ std::vector<Tensor> minimal_matmul(
     const std::optional<Tensor>& fused_ternary_input_a,
     const std::optional<Tensor>& fused_ternary_input_b) {
     using OperationType = experimental::prim::MinimalMatmulDeviceOperation;
+    const auto arch = input_tensor.device()->arch();
     auto kernel_config_val = init_device_compute_kernel_config(
-        input_tensor.device()->arch(),
+        arch,
         compute_kernel_config,
         MathFidelity::HiFi2,
         false /*approx_mode*/,
         true /*fp32_acc*/,
         true /*packer_acc*/);
+    // Warn if user explicitly passed HiFi4 + fp32_dest_acc_en on Wormhole B0 (hw bug #38306).
+    // The default (HiFi2 + fp32_acc) is safe; only user-supplied HiFi4+fp32 is vulnerable.
+    if (arch == tt::ARCH::WORMHOLE_B0 && compute_kernel_config.has_value() && compute_kernel_config->fp32_dest_acc_en &&
+        compute_kernel_config->math_fidelity == MathFidelity::HiFi4) {
+        log_warning(
+            tt::LogOp,
+            "HiFi4 + fp32_dest_acc_en on Wormhole B0 may produce incorrect results "
+            "(hw bug #38306). Prefer HiFi3.");
+    }
 
     return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_device_operation.cpp
@@ -282,7 +282,8 @@ std::vector<Tensor> minimal_matmul(
         compute_kernel_config->math_fidelity == MathFidelity::HiFi4) {
         log_warning(
             tt::LogOp,
-            "On Wormhole with fp32 accumulation, output accuracy can be worse with HiFi4 than HiFi3. "
+            "On Wormhole with fp32 accumulation, output accuracy can be worse with HiFi4 than HiFi3 due to a hardware "
+            "bug. "
             "Prefer using HiFi3 with fp32 accumulation on Wormhole.");
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_device_operation.cpp
@@ -276,7 +276,7 @@ std::vector<Tensor> minimal_matmul(
         false /*approx_mode*/,
         true /*fp32_acc*/,
         true /*packer_acc*/);
-    // Warn if user explicitly passed HiFi4 + fp32_dest_acc_en on Wormhole B0 (hw bug #38306).
+    // Warn if user explicitly passed HiFi4 + fp32_dest_acc_en on Wormhole B0 (hardware bug #38306).
     // The default (HiFi2 + fp32_acc) is safe; only user-supplied HiFi4+fp32 is vulnerable.
     if (arch == tt::ARCH::WORMHOLE_B0 && compute_kernel_config.has_value() && compute_kernel_config->fp32_dest_acc_en &&
         compute_kernel_config->math_fidelity == MathFidelity::HiFi4) {

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_device_operation.cpp
@@ -282,8 +282,8 @@ std::vector<Tensor> minimal_matmul(
         compute_kernel_config->math_fidelity == MathFidelity::HiFi4) {
         log_warning(
             tt::LogOp,
-            "HiFi4 + fp32_dest_acc_en on Wormhole B0 may produce incorrect results "
-            "(hw bug #38306). Prefer HiFi3.");
+            "On Wormhole with fp32 accumulation, output accuracy can be worse with HiFi4 than HiFi3. "
+            "Prefer using HiFi3 with fp32 accumulation on Wormhole.");
     }
 
     return ttnn::device_operation::launch<OperationType>(

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_device_operation.cpp
@@ -5,7 +5,6 @@
 #include "minimal_matmul_device_operation.hpp"
 #include "minimal_matmul_program_factory.hpp"
 
-#include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/math.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/constants.hpp>
@@ -276,16 +275,7 @@ std::vector<Tensor> minimal_matmul(
         false /*approx_mode*/,
         true /*fp32_acc*/,
         true /*packer_acc*/);
-    // Warn if user explicitly passed HiFi4 + fp32_dest_acc_en on Wormhole B0 (hardware bug #38306).
-    // The default (HiFi2 + fp32_acc) is safe; only user-supplied HiFi4+fp32 is vulnerable.
-    if (arch == tt::ARCH::WORMHOLE_B0 && compute_kernel_config.has_value() && compute_kernel_config->fp32_dest_acc_en &&
-        compute_kernel_config->math_fidelity == MathFidelity::HiFi4) {
-        log_warning(
-            tt::LogOp,
-            "On Wormhole with fp32 accumulation, output accuracy can be worse with HiFi4 than HiFi3 due to a hardware "
-            "bug. "
-            "Prefer using HiFi3 with fp32 accumulation on Wormhole.");
-    }
+    ttnn::verify_numerical_configuration(arch, compute_kernel_config);
 
     return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/dit_rms_norm_unary_fused/dit_rms_norm_unary_fused.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/dit_rms_norm_unary_fused/dit_rms_norm_unary_fused.cpp
@@ -40,7 +40,7 @@ ttnn::Tensor dit_rms_norm_unary_fused(
         kernel_config_val.fp32_dest_acc_en = (input_tensor.dtype() == DataType::FLOAT32);
     }
 
-    // Warn if user explicitly passed HiFi4 + fp32_dest_acc_en on Wormhole B0 (hw bug #38306).
+    // Warn if user explicitly passed HiFi4 + fp32_dest_acc_en on Wormhole B0 (hardware bug #38306).
     if (is_wormhole && compute_kernel_config.has_value() && compute_kernel_config->fp32_dest_acc_en &&
         compute_kernel_config->math_fidelity == MathFidelity::HiFi4) {
         log_warning(

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/dit_rms_norm_unary_fused/dit_rms_norm_unary_fused.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/dit_rms_norm_unary_fused/dit_rms_norm_unary_fused.cpp
@@ -39,13 +39,14 @@ ttnn::Tensor dit_rms_norm_unary_fused(
     if (!compute_kernel_config.has_value()) {
         kernel_config_val.fp32_dest_acc_en = (input_tensor.dtype() == DataType::FLOAT32);
     }
-    
+
     // Warn if user explicitly passed HiFi4 + fp32_dest_acc_en on Wormhole B0 (hw bug #38306).
     if (is_wormhole && compute_kernel_config.has_value() && compute_kernel_config->fp32_dest_acc_en &&
         compute_kernel_config->math_fidelity == MathFidelity::HiFi4) {
         log_warning(
             tt::LogOp,
-            "On Wormhole with fp32 accumulation, output accuracy can be worse with HiFi4 than HiFi3. "
+            "On Wormhole with fp32 accumulation, output accuracy can be worse with HiFi4 than HiFi3 due to a hardware "
+            "bug. "
             "Prefer using HiFi3 with fp32 accumulation on Wormhole.");
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/dit_rms_norm_unary_fused/dit_rms_norm_unary_fused.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/dit_rms_norm_unary_fused/dit_rms_norm_unary_fused.cpp
@@ -28,11 +28,25 @@ ttnn::Tensor dit_rms_norm_unary_fused(
                                                                    : ttnn::GetDefaultDevice()->arch();
     const bool approx_mode = true;
     const bool fp32_acc = false;
+    const bool is_fp32_input = input_tensor.dtype() == DataType::FLOAT32;
+    // Due to hardware bug (#38306), HiFi4 + fp32_dest_acc_en produces incorrect results on Wormhole B0.
+    // fp32_dest_acc_en will be True for FLOAT32 inputs (set below), so use HiFi3 as default on Wormhole B0.
+    const auto is_wormhole = arch == tt::ARCH::WORMHOLE_B0;
+    const auto default_fidelity = (is_wormhole && is_fp32_input) ? MathFidelity::HiFi3 : MathFidelity::HiFi4;
     auto kernel_config_val = compute_kernel_config.value_or(
-        init_device_compute_kernel_config(arch, std::nullopt, MathFidelity::HiFi4, approx_mode, fp32_acc));
+        init_device_compute_kernel_config(arch, std::nullopt, default_fidelity, approx_mode, fp32_acc));
 
     if (!compute_kernel_config.has_value()) {
         kernel_config_val.fp32_dest_acc_en = (input_tensor.dtype() == DataType::FLOAT32);
+    }
+    
+    // Warn if user explicitly passed HiFi4 + fp32_dest_acc_en on Wormhole B0 (hw bug #38306).
+    if (is_wormhole && compute_kernel_config.has_value() && compute_kernel_config->fp32_dest_acc_en &&
+        compute_kernel_config->math_fidelity == MathFidelity::HiFi4) {
+        log_warning(
+            tt::LogOp,
+            "HiFi4 + fp32_dest_acc_en on Wormhole B0 may produce incorrect results "
+            "(hw bug #38306). Prefer HiFi3.");
     }
 
     return ttnn::prim::layer_norm(

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/dit_rms_norm_unary_fused/dit_rms_norm_unary_fused.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/dit_rms_norm_unary_fused/dit_rms_norm_unary_fused.cpp
@@ -5,6 +5,7 @@
 
 #include "ttnn/operations/normalization/layernorm/device/layernorm_device_operation.hpp"
 #include "ttnn/operations/normalization/layernorm/device/layernorm_common.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/device.hpp"
 
 namespace ttnn::experimental {
@@ -29,7 +30,7 @@ ttnn::Tensor dit_rms_norm_unary_fused(
     const bool approx_mode = true;
     const bool fp32_acc = false;
     const bool is_fp32_input = input_tensor.dtype() == DataType::FLOAT32;
-    // Due to hardware bug (#38306), HiFi4 + fp32_dest_acc_en produces incorrect results on Wormhole B0.
+    // Due to hardware bug (#38306), HiFi4 + fp32_dest_acc_en can sometime produce incorrect results on Wormhole.
     // fp32_dest_acc_en will be True for FLOAT32 inputs (set below), so use HiFi3 as default on Wormhole B0.
     const auto is_wormhole = arch == tt::ARCH::WORMHOLE_B0;
     const auto default_fidelity = (is_wormhole && is_fp32_input) ? MathFidelity::HiFi3 : MathFidelity::HiFi4;
@@ -40,15 +41,7 @@ ttnn::Tensor dit_rms_norm_unary_fused(
         kernel_config_val.fp32_dest_acc_en = (input_tensor.dtype() == DataType::FLOAT32);
     }
 
-    // Warn if user explicitly passed HiFi4 + fp32_dest_acc_en on Wormhole B0 (hardware bug #38306).
-    if (is_wormhole && compute_kernel_config.has_value() && compute_kernel_config->fp32_dest_acc_en &&
-        compute_kernel_config->math_fidelity == MathFidelity::HiFi4) {
-        log_warning(
-            tt::LogOp,
-            "On Wormhole with fp32 accumulation, output accuracy can be worse with HiFi4 than HiFi3 due to a hardware "
-            "bug. "
-            "Prefer using HiFi3 with fp32 accumulation on Wormhole.");
-    }
+    ttnn::verify_numerical_configuration(arch, compute_kernel_config);
 
     return ttnn::prim::layer_norm(
         input_tensor,

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/dit_rms_norm_unary_fused/dit_rms_norm_unary_fused.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/dit_rms_norm_unary_fused/dit_rms_norm_unary_fused.cpp
@@ -45,8 +45,8 @@ ttnn::Tensor dit_rms_norm_unary_fused(
         compute_kernel_config->math_fidelity == MathFidelity::HiFi4) {
         log_warning(
             tt::LogOp,
-            "HiFi4 + fp32_dest_acc_en on Wormhole B0 may produce incorrect results "
-            "(hw bug #38306). Prefer HiFi3.");
+            "On Wormhole with fp32 accumulation, output accuracy can be worse with HiFi4 than HiFi3. "
+            "Prefer using HiFi3 with fp32 accumulation on Wormhole.");
     }
 
     return ttnn::prim::layer_norm(

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -1497,7 +1497,10 @@ MatmulParams create_matmul_attributes(
     const auto increase_fidelity = !has_program_config && !has_user_grid && !are_inputs_low_precision_df;
     auto math_fidelity = increase_fidelity ? MathFidelity::HiFi2 : MathFidelity::LoFi;
     bool are_inputs_32F = (input_tensor_a.dtype() == DataType::FLOAT32 && input_tensor_b.dtype() == DataType::FLOAT32);
-    math_fidelity = are_inputs_32F ? MathFidelity::HiFi4 : math_fidelity;
+    // Due to hardware bug (#38306), HiFi4 + fp32_dest_acc_en produces incorrect results on Wormhole B0.
+    // When inputs are FLOAT32 (which drives fp32_dest_acc_en=True by default), use HiFi3 on Wormhole B0.
+    const auto is_wormhole = arch == tt::ARCH::WORMHOLE_B0;
+    math_fidelity = are_inputs_32F ? (is_wormhole ? MathFidelity::HiFi3 : MathFidelity::HiFi4) : math_fidelity;
 
     bool broadcast_batch = parameters.bcast_batch.value_or(get_broadcast_batch(
         input_tensor_a, input_tensor_b, parameters.transpose_a, parameters.transpose_b, parameters.program_config));
@@ -1543,6 +1546,15 @@ MatmulParams create_matmul_attributes(
         /*default_approx_mode=*/false,
         /*default_fp32_acc=*/is_float_32,
         /*default_l1_acc=*/!is_float_32);
+    // Warn if user explicitly passed HiFi4 + fp32_dest_acc_en on Wormhole B0 (hw bug #38306).
+    if (is_wormhole && parameters.compute_kernel_config.has_value() &&
+        parameters.compute_kernel_config->fp32_dest_acc_en &&
+        parameters.compute_kernel_config->math_fidelity == MathFidelity::HiFi4) {
+        log_warning(
+            tt::LogOp,
+            "HiFi4 + fp32_dest_acc_en on Wormhole B0 may produce incorrect results "
+            "(hw bug #38306). Prefer HiFi3.");
+    }
     auto in0_tile = operations::matmul::utilities::get_matmul_tile(input_tensor_a, parameters.transpose_a);
     auto in1_tile = operations::matmul::utilities::get_matmul_tile(input_tensor_b, parameters.transpose_b);
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -1497,7 +1497,7 @@ MatmulParams create_matmul_attributes(
     const auto increase_fidelity = !has_program_config && !has_user_grid && !are_inputs_low_precision_df;
     auto math_fidelity = increase_fidelity ? MathFidelity::HiFi2 : MathFidelity::LoFi;
     bool are_inputs_32F = (input_tensor_a.dtype() == DataType::FLOAT32 && input_tensor_b.dtype() == DataType::FLOAT32);
-    // Due to hardware bug (#38306), HiFi4 + fp32_dest_acc_en produces incorrect results on Wormhole B0.
+    // Due to hardware bug (#38306), HiFi4 + fp32_dest_acc_en can sometime produce incorrect results on Wormhole.
     // When inputs are FLOAT32 (which drives fp32_dest_acc_en=True by default), use HiFi3 on Wormhole B0.
     const auto is_wormhole = arch == tt::ARCH::WORMHOLE_B0;
     math_fidelity = are_inputs_32F ? (is_wormhole ? MathFidelity::HiFi3 : MathFidelity::HiFi4) : math_fidelity;
@@ -1546,16 +1546,7 @@ MatmulParams create_matmul_attributes(
         /*default_approx_mode=*/false,
         /*default_fp32_acc=*/is_float_32,
         /*default_l1_acc=*/!is_float_32);
-    // Warn if user explicitly passed HiFi4 + fp32_dest_acc_en on Wormhole B0 (hardware bug #38306).
-    if (is_wormhole && parameters.compute_kernel_config.has_value() &&
-        parameters.compute_kernel_config->fp32_dest_acc_en &&
-        parameters.compute_kernel_config->math_fidelity == MathFidelity::HiFi4) {
-        log_warning(
-            tt::LogOp,
-            "On Wormhole with fp32 accumulation, output accuracy can be worse with HiFi4 than HiFi3 due to a hardware "
-            "bug. "
-            "Prefer using HiFi3 with fp32 accumulation on Wormhole.");
-    }
+    ttnn::verify_numerical_configuration(arch, parameters.compute_kernel_config);
     auto in0_tile = operations::matmul::utilities::get_matmul_tile(input_tensor_a, parameters.transpose_a);
     auto in1_tile = operations::matmul::utilities::get_matmul_tile(input_tensor_b, parameters.transpose_b);
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -1546,7 +1546,7 @@ MatmulParams create_matmul_attributes(
         /*default_approx_mode=*/false,
         /*default_fp32_acc=*/is_float_32,
         /*default_l1_acc=*/!is_float_32);
-    // Warn if user explicitly passed HiFi4 + fp32_dest_acc_en on Wormhole B0 (hw bug #38306).
+    // Warn if user explicitly passed HiFi4 + fp32_dest_acc_en on Wormhole B0 (hardware bug #38306).
     if (is_wormhole && parameters.compute_kernel_config.has_value() &&
         parameters.compute_kernel_config->fp32_dest_acc_en &&
         parameters.compute_kernel_config->math_fidelity == MathFidelity::HiFi4) {

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -1552,8 +1552,8 @@ MatmulParams create_matmul_attributes(
         parameters.compute_kernel_config->math_fidelity == MathFidelity::HiFi4) {
         log_warning(
             tt::LogOp,
-            "HiFi4 + fp32_dest_acc_en on Wormhole B0 may produce incorrect results "
-            "(hw bug #38306). Prefer HiFi3.");
+            "On Wormhole with fp32 accumulation, output accuracy can be worse with HiFi4 than HiFi3. "
+            "Prefer using HiFi3 with fp32 accumulation on Wormhole.");
     }
     auto in0_tile = operations::matmul::utilities::get_matmul_tile(input_tensor_a, parameters.transpose_a);
     auto in1_tile = operations::matmul::utilities::get_matmul_tile(input_tensor_b, parameters.transpose_b);

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -1552,7 +1552,8 @@ MatmulParams create_matmul_attributes(
         parameters.compute_kernel_config->math_fidelity == MathFidelity::HiFi4) {
         log_warning(
             tt::LogOp,
-            "On Wormhole with fp32 accumulation, output accuracy can be worse with HiFi4 than HiFi3. "
+            "On Wormhole with fp32 accumulation, output accuracy can be worse with HiFi4 than HiFi3 due to a hardware "
+            "bug. "
             "Prefer using HiFi3 with fp32 accumulation on Wormhole.");
     }
     auto in0_tile = operations::matmul::utilities::get_matmul_tile(input_tensor_a, parameters.transpose_a);

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_utils.cpp
@@ -19,7 +19,10 @@ DeviceComputeKernelConfig resolve_compute_kernel_config(
         input.storage_type());
 
     const auto arch = input.device()->arch();
-    const auto default_fp32_acc_math_fidelity = MathFidelity::HiFi4;
+    // Due to hardware bug (#38306), HiFi4 + fp32_dest_acc_en produces incorrect results on Wormhole B0.
+    // Use HiFi3 when fp32_dest_acc_en is True on Wormhole B0.
+    const auto default_fp32_acc_math_fidelity =
+        (arch == tt::ARCH::WORMHOLE_B0) ? MathFidelity::HiFi3 : MathFidelity::HiFi4;
     const auto default_approx_mode = false;
     const auto default_fp32_acc = true;
     const auto default_l1_acc = true;

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_utils.cpp
@@ -19,7 +19,7 @@ DeviceComputeKernelConfig resolve_compute_kernel_config(
         input.storage_type());
 
     const auto arch = input.device()->arch();
-    const auto default_math_fidelity = MathFidelity::HiFi4;
+    const auto default_fp32_acc_math_fidelity = MathFidelity::HiFi4;
     const auto default_approx_mode = false;
     const auto default_fp32_acc = true;
     const auto default_l1_acc = true;
@@ -27,7 +27,7 @@ DeviceComputeKernelConfig resolve_compute_kernel_config(
     return init_device_compute_kernel_config(
         arch,
         compute_kernel_config,
-        default_math_fidelity,
+        default_fp32_acc_math_fidelity,
         default_approx_mode,
         default_fp32_acc,
         default_l1_acc,

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_utils.cpp
@@ -19,7 +19,7 @@ DeviceComputeKernelConfig resolve_compute_kernel_config(
         input.storage_type());
 
     const auto arch = input.device()->arch();
-    // Due to hardware bug (#38306), HiFi4 + fp32_dest_acc_en produces incorrect results on Wormhole B0.
+    // Due to hardware bug (#38306), HiFi4 + fp32_dest_acc_en can sometime produce incorrect results on Wormhole.
     // Use HiFi3 when fp32_dest_acc_en is True on Wormhole B0.
     const auto default_fp32_acc_math_fidelity =
         (arch == tt::ARCH::WORMHOLE_B0) ? MathFidelity::HiFi3 : MathFidelity::HiFi4;

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_utils.cpp
@@ -20,7 +20,7 @@ DeviceComputeKernelConfig resolve_compute_kernel_config(
 
     const auto arch = input.device()->arch();
     // Due to hardware bug (#38306), HiFi4 + fp32_dest_acc_en can sometime produce incorrect results on Wormhole.
-    // Use HiFi3 when fp32_dest_acc_en is True on Wormhole B0.
+    // Use HiFi3 when fp32_dest_acc_en is True on Wormhole (less likely to give bad results).
     const auto default_fp32_acc_math_fidelity =
         (arch == tt::ARCH::WORMHOLE_B0) ? MathFidelity::HiFi3 : MathFidelity::HiFi4;
     const auto default_approx_mode = false;

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.cpp
@@ -413,14 +413,7 @@ static DeviceComputeKernelConfig softmax_init_compute_kernel_config(
     tt::ARCH arch, const std::optional<const DeviceComputeKernelConfig>& compute_kernel_config, bool is_fp32) {
     const auto is_wormhole = arch == tt::ARCH::WORMHOLE_B0;
     const auto default_fidelity = (is_wormhole && is_fp32) ? MathFidelity::HiFi3 : MathFidelity::HiFi4;
-    if (is_wormhole && compute_kernel_config.has_value() && compute_kernel_config->fp32_dest_acc_en &&
-        compute_kernel_config->math_fidelity == MathFidelity::HiFi4) {
-        log_warning(
-            tt::LogOp,
-            "On Wormhole with fp32 accumulation, output accuracy can be worse with HiFi4 than HiFi3 due to a hardware "
-            "bug. "
-            "Prefer using HiFi3 with fp32 accumulation on Wormhole.");
-    }
+    verify_numerical_configuration(arch, compute_kernel_config);
     return init_device_compute_kernel_config(arch, compute_kernel_config, default_fidelity, true, is_fp32, false);
 }
 

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.cpp
@@ -418,8 +418,24 @@ Tensor softmax(
     TT_FATAL(
         input_tensor.device() != nullptr,
         "input_tensor.device() == nullptr, No device found, move input_tensor to device");
+
+    // Due to hardware bug (#38306), HiFi4 + fp32_dest_acc_en produces incorrect results on Wormhole B0.
+    // Change the default to HiFi3 when this op defaults to fp32=True (i.e. input is FLOAT32).
+    const auto is_wormhole = input_tensor.device()->arch() == tt::ARCH::WORMHOLE_B0;
+    const auto default_math_fidelity = (is_wormhole && is_fp32) ? MathFidelity::HiFi3 : MathFidelity::HiFi4;
+
     const auto compute_kernel_config_val = init_device_compute_kernel_config(
-        input_tensor.device()->arch(), compute_kernel_config, MathFidelity::HiFi4, true, is_fp32, false);
+        input_tensor.device()->arch(), compute_kernel_config, default_math_fidelity, true, is_fp32, false);
+
+    // Warn if user explicitly passed HiFi4 + fp32_dest_acc_en on Wormhole B0.
+    if (is_wormhole && compute_kernel_config.has_value() && compute_kernel_config->fp32_dest_acc_en &&
+        compute_kernel_config->math_fidelity == MathFidelity::HiFi4) {
+        log_warning(
+            tt::LogOp,
+            "HiFi4 + fp32_dest_acc_en on Wormhole B0 may produce incorrect results "
+            "(hw bug #38306). Prefer HiFi3.");
+    }
+
     const auto rank = input_tensor.logical_shape().size();
     const auto dim_calculated = dim < 0 ? rank + dim : dim;
     if (rank > 4) {
@@ -495,8 +511,17 @@ Tensor scale_mask_softmax(
     bool numeric_stable) {
     // Constants
     const auto is_fp32 = input_tensor.dtype() == DataType::FLOAT32;
-    const auto compute_kernel_config_val = init_device_compute_kernel_config(
-        input_tensor.device()->arch(), compute_kernel_config, MathFidelity::HiFi4, true, is_fp32, false);
+    const auto arch = input_tensor.device()->arch();
+    const auto is_wormhole = arch == tt::ARCH::WORMHOLE_B0;
+    const auto default_math_fidelity = (is_wormhole && is_fp32) ? MathFidelity::HiFi3 : MathFidelity::HiFi4;
+    const auto compute_kernel_config_val =
+        init_device_compute_kernel_config(arch, compute_kernel_config, default_math_fidelity, true, is_fp32, false);
+    if (is_wormhole && compute_kernel_config.has_value() && compute_kernel_config->fp32_dest_acc_en &&
+        compute_kernel_config->math_fidelity == MathFidelity::HiFi4) {
+        log_warning(
+            tt::LogOp,
+            "HiFi4 + fp32_dest_acc_en on Wormhole B0 may produce incorrect results (hw bug #38306). Prefer HiFi3.");
+    }
 
     // Input tensor formatting
     const ttnn::Shape input_pad_shape = ttnn::operations::data_movement::pad_to_tile_shape(input_tensor.padded_shape());
@@ -579,8 +604,17 @@ Tensor softmax_in_place(
     bool numeric_stable) {
     // Constants
     const auto is_fp32 = input_tensor.dtype() == DataType::FLOAT32;
-    const auto compute_kernel_config_val = init_device_compute_kernel_config(
-        input_tensor.device()->arch(), compute_kernel_config, MathFidelity::HiFi4, true, is_fp32, false);
+    const auto arch = input_tensor.device()->arch();
+    const auto is_wormhole = arch == tt::ARCH::WORMHOLE_B0;
+    const auto default_math_fidelity = (is_wormhole && is_fp32) ? MathFidelity::HiFi3 : MathFidelity::HiFi4;
+    const auto compute_kernel_config_val =
+        init_device_compute_kernel_config(arch, compute_kernel_config, default_math_fidelity, true, is_fp32, false);
+    if (is_wormhole && compute_kernel_config.has_value() && compute_kernel_config->fp32_dest_acc_en &&
+        compute_kernel_config->math_fidelity == MathFidelity::HiFi4) {
+        log_warning(
+            tt::LogOp,
+            "HiFi4 + fp32_dest_acc_en on Wormhole B0 may produce incorrect results (hw bug #38306). Prefer HiFi3.");
+    }
 
     // Operation specific checks
     TT_FATAL(
@@ -618,8 +652,17 @@ Tensor scale_mask_softmax_in_place(
     bool numeric_stable) {
     // Constants
     const auto is_fp32 = input_tensor.dtype() == DataType::FLOAT32;
-    const auto compute_kernel_config_val = init_device_compute_kernel_config(
-        input_tensor.device()->arch(), compute_kernel_config, MathFidelity::HiFi4, true, is_fp32, false);
+    const auto arch = input_tensor.device()->arch();
+    const auto is_wormhole = arch == tt::ARCH::WORMHOLE_B0;
+    const auto default_math_fidelity = (is_wormhole && is_fp32) ? MathFidelity::HiFi3 : MathFidelity::HiFi4;
+    const auto compute_kernel_config_val =
+        init_device_compute_kernel_config(arch, compute_kernel_config, default_math_fidelity, true, is_fp32, false);
+    if (is_wormhole && compute_kernel_config.has_value() && compute_kernel_config->fp32_dest_acc_en &&
+        compute_kernel_config->math_fidelity == MathFidelity::HiFi4) {
+        log_warning(
+            tt::LogOp,
+            "HiFi4 + fp32_dest_acc_en on Wormhole B0 may produce incorrect results (hw bug #38306). Prefer HiFi3.");
+    }
     const auto rank = input_tensor.logical_shape().size();
     const auto dim = rank - 1;
 
@@ -648,8 +691,17 @@ Tensor scale_causal_mask_hw_dims_softmax_in_place(
     bool numeric_stable) {
     // Constants
     const auto is_fp32 = input_tensor.dtype() == DataType::FLOAT32;
-    const auto compute_kernel_config_val = init_device_compute_kernel_config(
-        input_tensor.device()->arch(), compute_kernel_config, MathFidelity::HiFi4, true, is_fp32, false);
+    const auto arch = input_tensor.device()->arch();
+    const auto is_wormhole = arch == tt::ARCH::WORMHOLE_B0;
+    const auto default_math_fidelity = (is_wormhole && is_fp32) ? MathFidelity::HiFi3 : MathFidelity::HiFi4;
+    const auto compute_kernel_config_val =
+        init_device_compute_kernel_config(arch, compute_kernel_config, default_math_fidelity, true, is_fp32, false);
+    if (is_wormhole && compute_kernel_config.has_value() && compute_kernel_config->fp32_dest_acc_en &&
+        compute_kernel_config->math_fidelity == MathFidelity::HiFi4) {
+        log_warning(
+            tt::LogOp,
+            "HiFi4 + fp32_dest_acc_en on Wormhole B0 may produce incorrect results (hw bug #38306). Prefer HiFi3.");
+    }
     const auto rank = input_tensor.logical_shape().size();
     const auto dim = rank - 1;
 

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.cpp
@@ -417,7 +417,8 @@ static DeviceComputeKernelConfig softmax_init_compute_kernel_config(
         compute_kernel_config->math_fidelity == MathFidelity::HiFi4) {
         log_warning(
             tt::LogOp,
-            "On Wormhole with fp32 accumulation, output accuracy can be worse with HiFi4 than HiFi3. "
+            "On Wormhole with fp32 accumulation, output accuracy can be worse with HiFi4 than HiFi3 due to a hardware "
+            "bug. "
             "Prefer using HiFi3 with fp32 accumulation on Wormhole.");
     }
     return init_device_compute_kernel_config(arch, compute_kernel_config, default_fidelity, true, is_fp32, false);

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.cpp
@@ -407,6 +407,22 @@ SoftmaxDeviceOperation::create_op_performance_model(
     return result;
 }
 
+// hw bug (#38306): on Wormhole B0, HiFi4 with fp32 accumulation can produce less accurate
+// results than HiFi3 for some inputs. Use HiFi3 as the safe default when fp32 acc is enabled.
+static DeviceComputeKernelConfig softmax_init_compute_kernel_config(
+    tt::ARCH arch, const std::optional<const DeviceComputeKernelConfig>& compute_kernel_config, bool is_fp32) {
+    const auto is_wormhole = arch == tt::ARCH::WORMHOLE_B0;
+    const auto default_fidelity = (is_wormhole && is_fp32) ? MathFidelity::HiFi3 : MathFidelity::HiFi4;
+    if (is_wormhole && compute_kernel_config.has_value() && compute_kernel_config->fp32_dest_acc_en &&
+        compute_kernel_config->math_fidelity == MathFidelity::HiFi4) {
+        log_warning(
+            tt::LogOp,
+            "On Wormhole with fp32 accumulation, output accuracy can be worse with HiFi4 than HiFi3. "
+            "Prefer using HiFi3 with fp32 accumulation on Wormhole.");
+    }
+    return init_device_compute_kernel_config(arch, compute_kernel_config, default_fidelity, true, is_fp32, false);
+}
+
 Tensor softmax(
     const Tensor& input_tensor,
     int8_t dim,
@@ -419,22 +435,8 @@ Tensor softmax(
         input_tensor.device() != nullptr,
         "input_tensor.device() == nullptr, No device found, move input_tensor to device");
 
-    // Due to hardware bug (#38306), HiFi4 + fp32_dest_acc_en produces incorrect results on Wormhole B0.
-    // Change the default to HiFi3 when this op defaults to fp32=True (i.e. input is FLOAT32).
-    const auto is_wormhole = input_tensor.device()->arch() == tt::ARCH::WORMHOLE_B0;
-    const auto default_math_fidelity = (is_wormhole && is_fp32) ? MathFidelity::HiFi3 : MathFidelity::HiFi4;
-
-    const auto compute_kernel_config_val = init_device_compute_kernel_config(
-        input_tensor.device()->arch(), compute_kernel_config, default_math_fidelity, true, is_fp32, false);
-
-    // Warn if user explicitly passed HiFi4 + fp32_dest_acc_en on Wormhole B0.
-    if (is_wormhole && compute_kernel_config.has_value() && compute_kernel_config->fp32_dest_acc_en &&
-        compute_kernel_config->math_fidelity == MathFidelity::HiFi4) {
-        log_warning(
-            tt::LogOp,
-            "HiFi4 + fp32_dest_acc_en on Wormhole B0 may produce incorrect results "
-            "(hw bug #38306). Prefer HiFi3.");
-    }
+    const auto compute_kernel_config_val =
+        softmax_init_compute_kernel_config(input_tensor.device()->arch(), compute_kernel_config, is_fp32);
 
     const auto rank = input_tensor.logical_shape().size();
     const auto dim_calculated = dim < 0 ? rank + dim : dim;
@@ -511,17 +513,8 @@ Tensor scale_mask_softmax(
     bool numeric_stable) {
     // Constants
     const auto is_fp32 = input_tensor.dtype() == DataType::FLOAT32;
-    const auto arch = input_tensor.device()->arch();
-    const auto is_wormhole = arch == tt::ARCH::WORMHOLE_B0;
-    const auto default_math_fidelity = (is_wormhole && is_fp32) ? MathFidelity::HiFi3 : MathFidelity::HiFi4;
     const auto compute_kernel_config_val =
-        init_device_compute_kernel_config(arch, compute_kernel_config, default_math_fidelity, true, is_fp32, false);
-    if (is_wormhole && compute_kernel_config.has_value() && compute_kernel_config->fp32_dest_acc_en &&
-        compute_kernel_config->math_fidelity == MathFidelity::HiFi4) {
-        log_warning(
-            tt::LogOp,
-            "HiFi4 + fp32_dest_acc_en on Wormhole B0 may produce incorrect results (hw bug #38306). Prefer HiFi3.");
-    }
+        softmax_init_compute_kernel_config(input_tensor.device()->arch(), compute_kernel_config, is_fp32);
 
     // Input tensor formatting
     const ttnn::Shape input_pad_shape = ttnn::operations::data_movement::pad_to_tile_shape(input_tensor.padded_shape());
@@ -604,17 +597,8 @@ Tensor softmax_in_place(
     bool numeric_stable) {
     // Constants
     const auto is_fp32 = input_tensor.dtype() == DataType::FLOAT32;
-    const auto arch = input_tensor.device()->arch();
-    const auto is_wormhole = arch == tt::ARCH::WORMHOLE_B0;
-    const auto default_math_fidelity = (is_wormhole && is_fp32) ? MathFidelity::HiFi3 : MathFidelity::HiFi4;
     const auto compute_kernel_config_val =
-        init_device_compute_kernel_config(arch, compute_kernel_config, default_math_fidelity, true, is_fp32, false);
-    if (is_wormhole && compute_kernel_config.has_value() && compute_kernel_config->fp32_dest_acc_en &&
-        compute_kernel_config->math_fidelity == MathFidelity::HiFi4) {
-        log_warning(
-            tt::LogOp,
-            "HiFi4 + fp32_dest_acc_en on Wormhole B0 may produce incorrect results (hw bug #38306). Prefer HiFi3.");
-    }
+        softmax_init_compute_kernel_config(input_tensor.device()->arch(), compute_kernel_config, is_fp32);
 
     // Operation specific checks
     TT_FATAL(
@@ -652,17 +636,8 @@ Tensor scale_mask_softmax_in_place(
     bool numeric_stable) {
     // Constants
     const auto is_fp32 = input_tensor.dtype() == DataType::FLOAT32;
-    const auto arch = input_tensor.device()->arch();
-    const auto is_wormhole = arch == tt::ARCH::WORMHOLE_B0;
-    const auto default_math_fidelity = (is_wormhole && is_fp32) ? MathFidelity::HiFi3 : MathFidelity::HiFi4;
     const auto compute_kernel_config_val =
-        init_device_compute_kernel_config(arch, compute_kernel_config, default_math_fidelity, true, is_fp32, false);
-    if (is_wormhole && compute_kernel_config.has_value() && compute_kernel_config->fp32_dest_acc_en &&
-        compute_kernel_config->math_fidelity == MathFidelity::HiFi4) {
-        log_warning(
-            tt::LogOp,
-            "HiFi4 + fp32_dest_acc_en on Wormhole B0 may produce incorrect results (hw bug #38306). Prefer HiFi3.");
-    }
+        softmax_init_compute_kernel_config(input_tensor.device()->arch(), compute_kernel_config, is_fp32);
     const auto rank = input_tensor.logical_shape().size();
     const auto dim = rank - 1;
 
@@ -691,17 +666,8 @@ Tensor scale_causal_mask_hw_dims_softmax_in_place(
     bool numeric_stable) {
     // Constants
     const auto is_fp32 = input_tensor.dtype() == DataType::FLOAT32;
-    const auto arch = input_tensor.device()->arch();
-    const auto is_wormhole = arch == tt::ARCH::WORMHOLE_B0;
-    const auto default_math_fidelity = (is_wormhole && is_fp32) ? MathFidelity::HiFi3 : MathFidelity::HiFi4;
     const auto compute_kernel_config_val =
-        init_device_compute_kernel_config(arch, compute_kernel_config, default_math_fidelity, true, is_fp32, false);
-    if (is_wormhole && compute_kernel_config.has_value() && compute_kernel_config->fp32_dest_acc_en &&
-        compute_kernel_config->math_fidelity == MathFidelity::HiFi4) {
-        log_warning(
-            tt::LogOp,
-            "HiFi4 + fp32_dest_acc_en on Wormhole B0 may produce incorrect results (hw bug #38306). Prefer HiFi3.");
-    }
+        softmax_init_compute_kernel_config(input_tensor.device()->arch(), compute_kernel_config, is_fp32);
     const auto rank = input_tensor.logical_shape().size();
     const auto dim = rank - 1;
 

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.cpp
@@ -96,8 +96,12 @@ AccumulationProgramFactory::cached_program_t AccumulationProgramFactory::create(
     std::vector<uint32_t> reader_compile_time_args;
     tt::tt_metal::TensorAccessorArgs(src_buffer).append_to(reader_compile_time_args);
     const ReaderDataMovementConfig reader_config{reader_compile_time_args};
+    // Due to hardware bug (#38306), HiFi4 + fp32_dest_acc_en produces incorrect results on Wormhole B0.
+    // Use HiFi3 silently when fp32_dest_acc_en is True on Wormhole B0.
+    const auto math_fidelity =
+        (fp32_dest_acc_en && device->arch() == tt::ARCH::WORMHOLE_B0) ? MathFidelity::HiFi3 : MathFidelity::HiFi4;
     const ComputeConfig compute_config{
-        .math_fidelity = MathFidelity::HiFi4,
+        .math_fidelity = math_fidelity,
         .fp32_dest_acc_en = fp32_dest_acc_en,
         .math_approx_mode = false,
         .compile_args = {},

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.cpp
@@ -96,7 +96,7 @@ AccumulationProgramFactory::cached_program_t AccumulationProgramFactory::create(
     std::vector<uint32_t> reader_compile_time_args;
     tt::tt_metal::TensorAccessorArgs(src_buffer).append_to(reader_compile_time_args);
     const ReaderDataMovementConfig reader_config{reader_compile_time_args};
-    // Due to hardware bug (#38306), HiFi4 + fp32_dest_acc_en produces incorrect results on Wormhole B0.
+    // Due to hardware bug (#38306), HiFi4 + fp32_dest_acc_en can sometime produce incorrect results on Wormhole.
     // Use HiFi3 silently when fp32_dest_acc_en is True on Wormhole B0.
     const auto math_fidelity =
         (fp32_dest_acc_en && device->arch() == tt::ARCH::WORMHOLE_B0) ? MathFidelity::HiFi3 : MathFidelity::HiFi4;

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
@@ -89,12 +89,23 @@ Tensor reduce(
         input_tensor.device() != nullptr,
         "input_tensor.device() == nullptr, No device found, move input_tensor to device");
 
+    // Due to hardware bug (#38306), HiFi4 + fp32_dest_acc_en produces incorrect results on Wormhole B0.
+    // fp32_dest_acc_en defaults to True here, so always use HiFi3 as default on Wormhole B0.
+    const auto arch = input_tensor.device()->arch();
+    const auto is_wormhole = arch == tt::ARCH::WORMHOLE_B0;
     ttnn::DeviceComputeKernelConfig config = compute_kernel_config.value_or(ttnn::init_device_compute_kernel_config(
-        input_tensor.device()->arch(),
+        arch,
         std::nullopt,
-        MathFidelity::HiFi4,
+        is_wormhole ? MathFidelity::HiFi3 : MathFidelity::HiFi4,
         /*default_approx_mode=*/false,
         /*default_fp32_acc=*/true));
+    if (is_wormhole && compute_kernel_config.has_value() && compute_kernel_config->fp32_dest_acc_en &&
+        compute_kernel_config->math_fidelity == MathFidelity::HiFi4) {
+        log_warning(
+            tt::LogOp,
+            "HiFi4 + fp32_dest_acc_en on Wormhole B0 may produce incorrect results "
+            "(hw bug #38306). Prefer HiFi3.");
+    }
 
     // Reduce only works with tile layout, so we need to tilize the input tensor if necessary
     auto padded_shape = ttnn::operations::data_movement::pad_to_tile_shape(input_tensor.padded_shape());

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
@@ -89,7 +89,7 @@ Tensor reduce(
         input_tensor.device() != nullptr,
         "input_tensor.device() == nullptr, No device found, move input_tensor to device");
 
-    // Due to hardware bug (#38306), HiFi4 + fp32_dest_acc_en produces incorrect results on Wormhole B0.
+    // Due to hardware bug (#38306), HiFi4 + fp32_dest_acc_en can sometime produce incorrect results on Wormhole.
     // fp32_dest_acc_en defaults to True here, so always use HiFi3 as default on Wormhole B0.
     const auto arch = input_tensor.device()->arch();
     const auto is_wormhole = arch == tt::ARCH::WORMHOLE_B0;
@@ -99,14 +99,7 @@ Tensor reduce(
         is_wormhole ? MathFidelity::HiFi3 : MathFidelity::HiFi4,
         /*default_approx_mode=*/false,
         /*default_fp32_acc=*/true));
-    if (is_wormhole && compute_kernel_config.has_value() && compute_kernel_config->fp32_dest_acc_en &&
-        compute_kernel_config->math_fidelity == MathFidelity::HiFi4) {
-        log_warning(
-            tt::LogOp,
-            "On Wormhole with fp32 accumulation, output accuracy can be worse with HiFi4 than HiFi3 due to a hardware "
-            "bug. "
-            "Prefer using HiFi3 with fp32 accumulation on Wormhole.");
-    }
+    ttnn::verify_numerical_configuration(arch, compute_kernel_config);
 
     // Reduce only works with tile layout, so we need to tilize the input tensor if necessary
     auto padded_shape = ttnn::operations::data_movement::pad_to_tile_shape(input_tensor.padded_shape());

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
@@ -103,8 +103,8 @@ Tensor reduce(
         compute_kernel_config->math_fidelity == MathFidelity::HiFi4) {
         log_warning(
             tt::LogOp,
-            "HiFi4 + fp32_dest_acc_en on Wormhole B0 may produce incorrect results "
-            "(hw bug #38306). Prefer HiFi3.");
+            "On Wormhole with fp32 accumulation, output accuracy can be worse with HiFi4 than HiFi3. "
+            "Prefer using HiFi3 with fp32 accumulation on Wormhole.");
     }
 
     // Reduce only works with tile layout, so we need to tilize the input tensor if necessary

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
@@ -103,7 +103,8 @@ Tensor reduce(
         compute_kernel_config->math_fidelity == MathFidelity::HiFi4) {
         log_warning(
             tt::LogOp,
-            "On Wormhole with fp32 accumulation, output accuracy can be worse with HiFi4 than HiFi3. "
+            "On Wormhole with fp32 accumulation, output accuracy can be worse with HiFi4 than HiFi3 due to a hardware "
+            "bug. "
             "Prefer using HiFi3 with fp32 accumulation on Wormhole.");
     }
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
@@ -357,7 +357,8 @@ Tensor non_height_width_reduce(
         compute_kernel_config->math_fidelity == MathFidelity::HiFi4) {
         log_warning(
             tt::LogOp,
-            "On Wormhole with fp32 accumulation, output accuracy can be worse with HiFi4 than HiFi3. "
+            "On Wormhole with fp32 accumulation, output accuracy can be worse with HiFi4 than HiFi3 due to a hardware "
+            "bug. "
             "Prefer using HiFi3 with fp32 accumulation on Wormhole.");
     }
     Tensor output_tensor = ttnn::experimental::reduction::fast_reduce_nc(

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
@@ -343,12 +343,23 @@ Tensor non_height_width_reduce(
     std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config) {
     auto memory_config = memory_config_arg.value_or(input_tensor.memory_config());
     const auto& input_shape = input_tensor.logical_shape();
+    // Due to hardware bug (#38306), HiFi4 + fp32_dest_acc_en produces incorrect results on Wormhole B0.
+    // fp32_dest_acc_en defaults to True here, so always use HiFi3 as default on Wormhole B0.
+    const auto arch = input_tensor.device()->arch();
+    const auto is_wormhole = arch == tt::ARCH::WORMHOLE_B0;
     ttnn::DeviceComputeKernelConfig config = compute_kernel_config.value_or(ttnn::init_device_compute_kernel_config(
-        input_tensor.device()->arch(),
+        arch,
         std::nullopt,
-        MathFidelity::HiFi4,
+        is_wormhole ? MathFidelity::HiFi3 : MathFidelity::HiFi4,
         /*default_approx_mode=*/false,
         /*default_fp32_acc=*/true));
+    if (is_wormhole && compute_kernel_config.has_value() && compute_kernel_config->fp32_dest_acc_en &&
+        compute_kernel_config->math_fidelity == MathFidelity::HiFi4) {
+        log_warning(
+            tt::LogOp,
+            "HiFi4 + fp32_dest_acc_en on Wormhole B0 may produce incorrect results "
+            "(hw bug #38306). Prefer HiFi3.");
+    }
     Tensor output_tensor = ttnn::experimental::reduction::fast_reduce_nc(
         input_tensor, dims, /*output=*/std::nullopt, memory_config, config);
     auto [start, end, step] = get_slice_parameters(input_shape, output_tensor.logical_shape());

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
@@ -15,7 +15,7 @@
 #include "ttnn/operations/reduction/generic/device/reduce_op.hpp"
 #include "ttnn/operations/reduction/reduction_common/reduction_common.hpp"
 #include "ttnn/operations/core/core.hpp"
-#include <tt-logger/tt-logger.hpp>
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 
 namespace ttnn::operations::reduction {
 
@@ -344,7 +344,7 @@ Tensor non_height_width_reduce(
     std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config) {
     auto memory_config = memory_config_arg.value_or(input_tensor.memory_config());
     const auto& input_shape = input_tensor.logical_shape();
-    // Due to hardware bug (#38306), HiFi4 + fp32_dest_acc_en produces incorrect results on Wormhole B0.
+    // Due to hardware bug (#38306), HiFi4 + fp32_dest_acc_en can sometime produce incorrect results on Wormhole.
     // fp32_dest_acc_en defaults to True here, so always use HiFi3 as default on Wormhole B0.
     const auto arch = input_tensor.device()->arch();
     const auto is_wormhole = arch == tt::ARCH::WORMHOLE_B0;
@@ -354,14 +354,7 @@ Tensor non_height_width_reduce(
         is_wormhole ? MathFidelity::HiFi3 : MathFidelity::HiFi4,
         /*default_approx_mode=*/false,
         /*default_fp32_acc=*/true));
-    if (is_wormhole && compute_kernel_config.has_value() && compute_kernel_config->fp32_dest_acc_en &&
-        compute_kernel_config->math_fidelity == MathFidelity::HiFi4) {
-        log_warning(
-            tt::LogOp,
-            "On Wormhole with fp32 accumulation, output accuracy can be worse with HiFi4 than HiFi3 due to a hardware "
-            "bug. "
-            "Prefer using HiFi3 with fp32 accumulation on Wormhole.");
-    }
+    ttnn::verify_numerical_configuration(arch, compute_kernel_config);
     Tensor output_tensor = ttnn::experimental::reduction::fast_reduce_nc(
         input_tensor, dims, /*output=*/std::nullopt, memory_config, config);
     auto [start, end, step] = get_slice_parameters(input_shape, output_tensor.logical_shape());

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
@@ -357,8 +357,8 @@ Tensor non_height_width_reduce(
         compute_kernel_config->math_fidelity == MathFidelity::HiFi4) {
         log_warning(
             tt::LogOp,
-            "HiFi4 + fp32_dest_acc_en on Wormhole B0 may produce incorrect results "
-            "(hw bug #38306). Prefer HiFi3.");
+            "On Wormhole with fp32 accumulation, output accuracy can be worse with HiFi4 than HiFi3. "
+            "Prefer using HiFi3 with fp32 accumulation on Wormhole.");
     }
     Tensor output_tensor = ttnn::experimental::reduction::fast_reduce_nc(
         input_tensor, dims, /*output=*/std::nullopt, memory_config, config);

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
@@ -15,6 +15,7 @@
 #include "ttnn/operations/reduction/generic/device/reduce_op.hpp"
 #include "ttnn/operations/reduction/reduction_common/reduction_common.hpp"
 #include "ttnn/operations/core/core.hpp"
+#include <tt-logger/tt-logger.hpp>
 
 namespace ttnn::operations::reduction {
 


### PR DESCRIPTION
### Ticket
#39562

### Problem description
Wormhole has a hardware in MVMUL/ELWMUL that can be triggered when using fp32 accumulation ( #38306 ). This bug happens most frequently at higher math fidelities such as HiFi4. 
As a result, fp32_acc+HiFi3 matmul/softmax can be more accurate than fp32_acc+HiFi3. 

### What's changed
- On wormhole, instead of setting default accuracy to HiFi4 + fp32_acc, set default accuracy to HiFi3 + fp32_acc. 
- If `compute_config` is passed with HiFi4 + fp32_acc then print a warning. This warning is printed once per process (c.f. `static std::atomic`). 

Updated affected ops are: matmul, softmax, minimal_matmul, dit_rms_norm_unary_fused, accumulation, reduction, batch_norm, element-wise.

The operations with updated default compute config have been identified through the following [results](https://docs.google.com/spreadsheets/d/1TEIUpGJWaq6hNKTXqRkKmJAlw5scrngZIuXH6GlMmWU/edit?usp=sharing): 


### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nmaurice/39562-use-hifi3-with-fp32-on-wh)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nmaurice/39562-use-hifi3-with-fp32-on-wh)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nmaurice/39562-use-hifi3-with-fp32-on-wh)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nmaurice/39562-use-hifi3-with-fp32-on-wh)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nmaurice/39562-use-hifi3-with-fp32-on-wh)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nmaurice/39562-use-hifi3-with-fp32-on-wh) (OK, failures in main)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nmaurice/39562-use-hifi3-with-fp32-on-wh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nmaurice/39562-use-hifi3-with-fp32-on-wh) (OK, failures in main)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs
  - [ ] Device perf regression: [OK](https://github.com/tenstorrent/tt-metal/actions/runs/23440025372) failures in [main](https://github.com/tenstorrent/tt-metal/actions/runs/23432685834/job/68163971610)

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nmaurice/39562-use-hifi3-with-fp32-on-wh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nmaurice/39562-use-hifi3-with-fp32-on-wh) OK, failures in main
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nmaurice/39562-use-hifi3-with-fp32-on-wh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nmaurice/39562-use-hifi3-with-fp32-on-wh)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
