### PR TITLE
DeepSeek Compressed Tensor DRAM matmul support

### DIFF
--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_custom_mm_compressed_runtime.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_custom_mm_compressed_runtime.h
@@ -34,6 +34,7 @@ FORCE_INLINE void custom_mm_compressed_block_runtime(
     UNPACK(({
         volatile uint* cfg = get_cfg_pointer();
         uint32_t reg0_base = cfg[THCON_SEC0_REG0_TileDescriptor_ADDR32] & ~0x0f;
+        uint32_t reg2_base = cfg[THCON_SEC0_REG2_Out_data_format_ADDR32] & ~0x0f;
 
         // Per-pair tile info: two uint32s loaded together.
         // Each uint32: [abs_addr:24 | fmt:8], precomputed by host.
@@ -62,13 +63,13 @@ FORCE_INLINE void custom_mm_compressed_block_runtime(
 
                 wait_for_next_context(2);
                 // TODO: investigate why we need to also configure the output data format
-                // for DRAM matmul, while SRAM matmul we dont need to.
-                reconfig_custom_mm_srca_raw(cfg, t0.fmt, reg0_base, reg0_base);
+                // for DRAM matmul, while SRAM matmul we don't need to.
+                reconfig_custom_mm_srca_raw(cfg, t0.fmt, reg0_base, reg2_base);
                 cfg[THCON_SEC0_REG3_Base_address_ADDR32] = t0.addr;
                 semaphore_post(semaphore::UNPACK_SYNC);
 
                 wait_for_next_context(2);
-                reconfig_custom_mm_srca_raw(cfg, t1.fmt, reg0_base, reg0_base);
+                reconfig_custom_mm_srca_raw(cfg, t1.fmt, reg0_base, reg2_base);
                 cfg[THCON_SEC0_REG3_Base_cntx1_address_ADDR32] = t1.addr;
                 semaphore_post(semaphore::UNPACK_SYNC);
             }
@@ -84,12 +85,12 @@ FORCE_INLINE void custom_mm_compressed_block_runtime(
                     tile_idx += 2;
 
                     wait_for_next_context(2);
-                    reconfig_custom_mm_srca_raw(cfg, t0.fmt, reg0_base, reg0_base);
+                    reconfig_custom_mm_srca_raw(cfg, t0.fmt, reg0_base, reg2_base);
                     cfg[THCON_SEC0_REG3_Base_address_ADDR32] = t0.addr;
                     semaphore_post(semaphore::UNPACK_SYNC);
 
                     wait_for_next_context(2);
-                    reconfig_custom_mm_srca_raw(cfg, t1.fmt, reg0_base, reg0_base);
+                    reconfig_custom_mm_srca_raw(cfg, t1.fmt, reg0_base, reg2_base);
                     cfg[THCON_SEC0_REG3_Base_cntx1_address_ADDR32] = t1.addr;
                     semaphore_post(semaphore::UNPACK_SYNC);
                 }

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_custom_mm_compressed_runtime.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_custom_mm_compressed_runtime.h
@@ -14,16 +14,21 @@ namespace compressed {
  * @brief Runtime loop reading per-pair tile info from an L1 tensor.
  *
  * fmt_l1_addr: byte address of uint32 array in L1, two uint32s per pair.
- *   Each uint32: [abs_addr:24 | fmt:8]
- *     abs_addr = precomputed absolute THCON-shifted address (from host)
- *     fmt      = DataFormat value for unpacker reconfig
+ *   Each uint32: [addr:24 | fmt:8]
+ *     addr = THCON-shifted address (absolute when RELATIVE_ADDR=false,
+ *            relative to subblock start when RELATIVE_ADDR=true)
+ *     fmt  = DataFormat value for unpacker reconfig
  *   Layout: {info0, info1, info0, info1, ...} (pairs of tiles)
+ *
+ * When RELATIVE_ADDR=true (DRAM streaming), tile addresses are relative offsets
+ * within the subblock. The kernel computes absolute addresses as addr_in1 + offset.
+ * Zero tiles use ZERO_TILE_SENTINEL (0xFFFFFF) and resolve to ZEROS_ADDR_SHIFTED.
  *
  * Hot loop per tile: one L1 load (uint32), one mask, one shift, two cfg stores.
  * Zero tiles have abs_addr = ZEROS_ADDR_SHIFTED, precomputed by host.
- * No per-tile arithmetic, no branches.
+ * No per-tile arithmetic, no branches (when RELATIVE_ADDR=false).
  */
-template <uint32_t KT_DIM, uint32_t CT_DIM, bool FINALIZE = true>
+template <uint32_t KT_DIM, uint32_t CT_DIM, bool FINALIZE = true, bool RELATIVE_ADDR = false>
 FORCE_INLINE void custom_mm_compressed_block_runtime(
     uint32_t fmt_l1_addr, uint32_t addr_in0, uint32_t addr_in1, uint32_t in0_face_r_dim, uint32_t dst_index) {
     static_assert(CT_DIM > 0, "CT_DIM must be > 0");
@@ -31,17 +36,20 @@ FORCE_INLINE void custom_mm_compressed_block_runtime(
     static_assert(
         CT_DIM == 1 || KT_DIM % 2 == 0 || CT_DIM % 2 == 0, "ct=1 requires even KT_DIM; ct>1 requires even CT_DIM");
 
+    // Sentinel for zero tiles in relative-address mode (must match host-side _ZERO_TILE_SENTINEL)
+    constexpr uint32_t ZERO_TILE_SENTINEL = 0xFFFFFF;
+
     UNPACK(({
         volatile uint* cfg = get_cfg_pointer();
         uint32_t reg0_base = cfg[THCON_SEC0_REG0_TileDescriptor_ADDR32] & ~0x0f;
 
         // Per-pair tile info: two uint32s loaded together.
-        // Each uint32: [abs_addr:24 | fmt:8], precomputed by host.
+        // Each uint32: [addr:24 | fmt:8], precomputed by host.
         union TileInfo {
             uint32_t packed;
             struct {
                 uint8_t fmt;         // bits [7:0]  — DataFormat value
-                uint32_t addr : 24;  // bits [31:8] — absolute THCON-shifted address
+                uint32_t addr : 24;  // bits [31:8] — THCON-shifted address
             };
         };
 
@@ -60,14 +68,21 @@ FORCE_INLINE void custom_mm_compressed_block_runtime(
                 t0.packed = tile_ptr[pair * 2].packed;
                 t1.packed = tile_ptr[pair * 2 + 1].packed;
 
+                uint32_t addr0 = t0.addr;
+                uint32_t addr1 = t1.addr;
+                if constexpr (RELATIVE_ADDR) {
+                    addr0 = (addr0 == ZERO_TILE_SENTINEL) ? ZEROS_ADDR_SHIFTED : (addr_in1 + addr0);
+                    addr1 = (addr1 == ZERO_TILE_SENTINEL) ? ZEROS_ADDR_SHIFTED : (addr_in1 + addr1);
+                }
+
                 wait_for_next_context(2);
                 reconfig_custom_mm_srca_input_only(cfg, t0.fmt, reg0_base);
-                cfg[THCON_SEC0_REG3_Base_address_ADDR32] = t0.addr;
+                cfg[THCON_SEC0_REG3_Base_address_ADDR32] = addr0;
                 semaphore_post(semaphore::UNPACK_SYNC);
 
                 wait_for_next_context(2);
                 reconfig_custom_mm_srca_input_only(cfg, t1.fmt, reg0_base);
-                cfg[THCON_SEC0_REG3_Base_cntx1_address_ADDR32] = t1.addr;
+                cfg[THCON_SEC0_REG3_Base_cntx1_address_ADDR32] = addr1;
                 semaphore_post(semaphore::UNPACK_SYNC);
             }
         } else {
@@ -81,14 +96,21 @@ FORCE_INLINE void custom_mm_compressed_block_runtime(
                     t1.packed = tile_ptr[tile_idx + 1].packed;
                     tile_idx += 2;
 
+                    uint32_t addr0 = t0.addr;
+                    uint32_t addr1 = t1.addr;
+                    if constexpr (RELATIVE_ADDR) {
+                        addr0 = (addr0 == ZERO_TILE_SENTINEL) ? ZEROS_ADDR_SHIFTED : (addr_in1 + addr0);
+                        addr1 = (addr1 == ZERO_TILE_SENTINEL) ? ZEROS_ADDR_SHIFTED : (addr_in1 + addr1);
+                    }
+
                     wait_for_next_context(2);
                     reconfig_custom_mm_srca_input_only(cfg, t0.fmt, reg0_base);
-                    cfg[THCON_SEC0_REG3_Base_address_ADDR32] = t0.addr;
+                    cfg[THCON_SEC0_REG3_Base_address_ADDR32] = addr0;
                     semaphore_post(semaphore::UNPACK_SYNC);
 
                     wait_for_next_context(2);
                     reconfig_custom_mm_srca_input_only(cfg, t1.fmt, reg0_base);
-                    cfg[THCON_SEC0_REG3_Base_cntx1_address_ADDR32] = t1.addr;
+                    cfg[THCON_SEC0_REG3_Base_cntx1_address_ADDR32] = addr1;
                     semaphore_post(semaphore::UNPACK_SYNC);
                 }
             }

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_custom_mm_compressed_runtime.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_custom_mm_compressed_runtime.h
@@ -23,7 +23,7 @@ namespace compressed {
  * Zero tiles have abs_addr = ZEROS_ADDR_SHIFTED, precomputed by host.
  * No per-tile arithmetic, no branches.
  */
-template <uint32_t KT_DIM, uint32_t CT_DIM>
+template <uint32_t KT_DIM, uint32_t CT_DIM, bool FINALIZE = true>
 FORCE_INLINE void custom_mm_compressed_block_runtime(
     uint32_t fmt_l1_addr, uint32_t addr_in0, uint32_t addr_in1, uint32_t in0_face_r_dim, uint32_t dst_index) {
     static_assert(CT_DIM > 0, "CT_DIM must be > 0");
@@ -93,8 +93,14 @@ FORCE_INLINE void custom_mm_compressed_block_runtime(
                 }
             }
         }
+
+        // Reset counters so subsequent subblock calls start clean (matches _llk_unpack_AB_custom_mm_run_)
+        wait_for_next_context(1);
+        reset_config_context();
+        TTI_SETADCZW(0b011, 0, 0, 0, 0, 0b1111);
+        TTI_SETADCXY(0b011, 0, 0, 0, 0, 0b1010);
     }));
-    MATH((_llk_math_custom_mm_<true>(in0_face_r_dim, dst_index, KT_DIM, CT_DIM)));
+    MATH((_llk_math_custom_mm_<FINALIZE>(in0_face_r_dim, dst_index, KT_DIM, CT_DIM)));
 }
 
 }  // namespace compressed

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_custom_mm_compressed_runtime.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_custom_mm_compressed_runtime.h
@@ -14,21 +14,16 @@ namespace compressed {
  * @brief Runtime loop reading per-pair tile info from an L1 tensor.
  *
  * fmt_l1_addr: byte address of uint32 array in L1, two uint32s per pair.
- *   Each uint32: [addr:24 | fmt:8]
- *     addr = THCON-shifted address (absolute when RELATIVE_ADDR=false,
- *            relative to subblock start when RELATIVE_ADDR=true)
- *     fmt  = DataFormat value for unpacker reconfig
+ *   Each uint32: [abs_addr:24 | fmt:8]
+ *     abs_addr = precomputed absolute THCON-shifted address (from host)
+ *     fmt      = DataFormat value for unpacker reconfig
  *   Layout: {info0, info1, info0, info1, ...} (pairs of tiles)
- *
- * When RELATIVE_ADDR=true (DRAM streaming), tile addresses are relative offsets
- * within the subblock. The kernel computes absolute addresses as addr_in1 + offset.
- * Zero tiles use ZERO_TILE_SENTINEL (0xFFFFFF) and resolve to ZEROS_ADDR_SHIFTED.
  *
  * Hot loop per tile: one L1 load (uint32), one mask, one shift, two cfg stores.
  * Zero tiles have abs_addr = ZEROS_ADDR_SHIFTED, precomputed by host.
- * No per-tile arithmetic, no branches (when RELATIVE_ADDR=false).
+ * No per-tile arithmetic, no branches.
  */
-template <uint32_t KT_DIM, uint32_t CT_DIM, bool FINALIZE = true, bool RELATIVE_ADDR = false>
+template <uint32_t KT_DIM, uint32_t CT_DIM, bool FINALIZE = true>
 FORCE_INLINE void custom_mm_compressed_block_runtime(
     uint32_t fmt_l1_addr, uint32_t addr_in0, uint32_t addr_in1, uint32_t in0_face_r_dim, uint32_t dst_index) {
     static_assert(CT_DIM > 0, "CT_DIM must be > 0");
@@ -36,20 +31,17 @@ FORCE_INLINE void custom_mm_compressed_block_runtime(
     static_assert(
         CT_DIM == 1 || KT_DIM % 2 == 0 || CT_DIM % 2 == 0, "ct=1 requires even KT_DIM; ct>1 requires even CT_DIM");
 
-    // Sentinel for zero tiles in relative-address mode (must match host-side _ZERO_TILE_SENTINEL)
-    constexpr uint32_t ZERO_TILE_SENTINEL = 0xFFFFFF;
-
     UNPACK(({
         volatile uint* cfg = get_cfg_pointer();
         uint32_t reg0_base = cfg[THCON_SEC0_REG0_TileDescriptor_ADDR32] & ~0x0f;
 
         // Per-pair tile info: two uint32s loaded together.
-        // Each uint32: [addr:24 | fmt:8], precomputed by host.
+        // Each uint32: [abs_addr:24 | fmt:8], precomputed by host.
         union TileInfo {
             uint32_t packed;
             struct {
                 uint8_t fmt;         // bits [7:0]  — DataFormat value
-                uint32_t addr : 24;  // bits [31:8] — THCON-shifted address
+                uint32_t addr : 24;  // bits [31:8] — absolute THCON-shifted address
             };
         };
 
@@ -68,21 +60,14 @@ FORCE_INLINE void custom_mm_compressed_block_runtime(
                 t0.packed = tile_ptr[pair * 2].packed;
                 t1.packed = tile_ptr[pair * 2 + 1].packed;
 
-                uint32_t addr0 = t0.addr;
-                uint32_t addr1 = t1.addr;
-                if constexpr (RELATIVE_ADDR) {
-                    addr0 = (addr0 == ZERO_TILE_SENTINEL) ? ZEROS_ADDR_SHIFTED : (addr_in1 + addr0);
-                    addr1 = (addr1 == ZERO_TILE_SENTINEL) ? ZEROS_ADDR_SHIFTED : (addr_in1 + addr1);
-                }
-
                 wait_for_next_context(2);
-                reconfig_custom_mm_srca_input_only(cfg, t0.fmt, reg0_base);
-                cfg[THCON_SEC0_REG3_Base_address_ADDR32] = addr0;
+                reconfig_custom_mm_srca_raw(cfg, t0.fmt, reg0_base, reg0_base);
+                cfg[THCON_SEC0_REG3_Base_address_ADDR32] = t0.addr;
                 semaphore_post(semaphore::UNPACK_SYNC);
 
                 wait_for_next_context(2);
-                reconfig_custom_mm_srca_input_only(cfg, t1.fmt, reg0_base);
-                cfg[THCON_SEC0_REG3_Base_cntx1_address_ADDR32] = addr1;
+                reconfig_custom_mm_srca_raw(cfg, t1.fmt, reg0_base, reg0_base);
+                cfg[THCON_SEC0_REG3_Base_cntx1_address_ADDR32] = t1.addr;
                 semaphore_post(semaphore::UNPACK_SYNC);
             }
         } else {
@@ -96,21 +81,14 @@ FORCE_INLINE void custom_mm_compressed_block_runtime(
                     t1.packed = tile_ptr[tile_idx + 1].packed;
                     tile_idx += 2;
 
-                    uint32_t addr0 = t0.addr;
-                    uint32_t addr1 = t1.addr;
-                    if constexpr (RELATIVE_ADDR) {
-                        addr0 = (addr0 == ZERO_TILE_SENTINEL) ? ZEROS_ADDR_SHIFTED : (addr_in1 + addr0);
-                        addr1 = (addr1 == ZERO_TILE_SENTINEL) ? ZEROS_ADDR_SHIFTED : (addr_in1 + addr1);
-                    }
-
                     wait_for_next_context(2);
-                    reconfig_custom_mm_srca_input_only(cfg, t0.fmt, reg0_base);
-                    cfg[THCON_SEC0_REG3_Base_address_ADDR32] = addr0;
+                    reconfig_custom_mm_srca_raw(cfg, t0.fmt, reg0_base, reg0_base);
+                    cfg[THCON_SEC0_REG3_Base_address_ADDR32] = t0.addr;
                     semaphore_post(semaphore::UNPACK_SYNC);
 
                     wait_for_next_context(2);
-                    reconfig_custom_mm_srca_input_only(cfg, t1.fmt, reg0_base);
-                    cfg[THCON_SEC0_REG3_Base_cntx1_address_ADDR32] = addr1;
+                    reconfig_custom_mm_srca_raw(cfg, t1.fmt, reg0_base, reg0_base);
+                    cfg[THCON_SEC0_REG3_Base_cntx1_address_ADDR32] = t1.addr;
                     semaphore_post(semaphore::UNPACK_SYNC);
                 }
             }

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_custom_mm_compressed_runtime.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_custom_mm_compressed_runtime.h
@@ -61,6 +61,8 @@ FORCE_INLINE void custom_mm_compressed_block_runtime(
                 t1.packed = tile_ptr[pair * 2 + 1].packed;
 
                 wait_for_next_context(2);
+                // TODO: investigate why we need to also configure the output data format
+                // for DRAM matmul, while SRAM matmul we dont need to.
                 reconfig_custom_mm_srca_raw(cfg, t0.fmt, reg0_base, reg0_base);
                 cfg[THCON_SEC0_REG3_Base_address_ADDR32] = t0.addr;
                 semaphore_post(semaphore::UNPACK_SYNC);

--- a/models/demos/deepseek_v3_b1/micro_ops/dram_streaming_matmul_compressed/kernels/dram_streaming_matmul_compressed_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/dram_streaming_matmul_compressed/kernels/dram_streaming_matmul_compressed_kernel.cpp
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+// DRAM Streaming Matmul with Compressed Weights
+//
+// Combines DRAM streaming (variable-size reads) with per-tile BFP format reconfig.
+// NCRISC: Streams compressed tiles from DRAM with variable block sizes from L1 metadata.
+// BRISC: No-op.
+// TRISC: Compressed matmul with subblock-K partial accumulation.
+
+#include "../../../unified_kernels/kernel_op_api.hpp"
+#include "../../../unified_kernels/kernel_utils.hpp"
+#include "../../../unified_kernels/dram_streaming_matmul_compressed.hpp"
+
+struct Core {
+    static constexpr bool is_active_core = get_named_compile_time_arg_val("is_active_core") == 1;
+};
+
+void kernel_main() {
+#if defined(COMPILE_FOR_NCRISC)
+    using CTArgs = deepseek_b1_ops::DRAMStreamingMatmulCompressed::ReaderCTArgs<
+        get_named_compile_time_arg_val("cb_in1"),
+        get_named_compile_time_arg_val("cb_out"),
+        get_named_compile_time_arg_val("in1_tensor_addr"),
+        get_named_compile_time_arg_val("subblock_k"),
+        get_named_compile_time_arg_val("per_core_n"),
+        get_named_compile_time_arg_val("out_num_tiles"),
+        get_named_compile_time_arg_val("num_subblocks_k"),
+        get_named_compile_time_arg_val("bank_id"),
+        get_named_compile_time_arg_val("vc"),
+        get_named_compile_time_arg_val("meta_l1_addr"),
+        get_named_compile_time_arg_val("cb_in1_size_bytes"),
+        get_named_compile_time_arg_val("noc_max_page_size")>;
+
+    constexpr uint32_t cb_in0 = get_named_compile_time_arg_val("cb_in0");
+    constexpr uint32_t num_tiles_k = get_named_compile_time_arg_val("num_tiles_k");
+
+    if constexpr (Core::is_active_core) {
+        unified_kernels::setup_sharded_buffer(cb_in0, num_tiles_k);
+    }
+
+#elif defined(COMPILE_FOR_BRISC)
+    using CTArgs = deepseek_b1_ops::DRAMStreamingMatmulCompressed::WriterCTArgs;
+
+#elif defined(COMPILE_FOR_TRISC)
+    using CTArgs = deepseek_b1_ops::DRAMStreamingMatmulCompressed::ComputeCTArgs<
+        get_named_compile_time_arg_val("cb_in0"),
+        get_named_compile_time_arg_val("cb_in1"),
+        get_named_compile_time_arg_val("cb_out"),
+        get_named_compile_time_arg_val("subblock_k"),
+        get_named_compile_time_arg_val("per_core_n"),
+        get_named_compile_time_arg_val("num_subblocks_k"),
+        get_named_compile_time_arg_val("fmt_l1_addr")>;
+
+    deepseek_compute_kernel_init();
+#endif
+
+    deepseek_b1_ops::DRAMStreamingMatmulCompressed::Op<CTArgs, Core::is_active_core> op;
+    op();
+}

--- a/models/demos/deepseek_v3_b1/micro_ops/dram_streaming_matmul_compressed/kernels/dram_streaming_matmul_compressed_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/dram_streaming_matmul_compressed/kernels/dram_streaming_matmul_compressed_kernel.cpp
@@ -4,9 +4,11 @@
 // DRAM Streaming Matmul with Compressed Weights
 //
 // Combines DRAM streaming (variable-size reads) with per-tile BFP format reconfig.
-// NCRISC: Streams compressed tiles from DRAM with variable block sizes from L1 metadata.
-// BRISC: No-op.
-// TRISC: Compressed matmul with subblock-K partial accumulation.
+// Supports pipelined multi-core-per-bank mode (cores_per_bank > 1):
+//   Each core reads its own portion of N columns directly from DRAM.
+//   Cores sharing a bank read sequentially with semaphore handoff:
+//   core 0 reads first, signals core 1 after last request, core 1 waits then reads, etc.
+//   BRISC: no-op. TRISC: compressed matmul with subblock-K partial accumulation.
 
 #include "../../../unified_kernels/kernel_op_api.hpp"
 #include "../../../unified_kernels/kernel_utils.hpp"
@@ -30,7 +32,12 @@ void kernel_main() {
         get_named_compile_time_arg_val("vc"),
         get_named_compile_time_arg_val("meta_l1_addr"),
         get_named_compile_time_arg_val("cb_in1_size_bytes"),
-        get_named_compile_time_arg_val("noc_max_page_size")>;
+        get_named_compile_time_arg_val("noc_max_page_size"),
+        get_named_compile_time_arg_val("dram_start_offset"),
+        get_named_compile_time_arg_val("core_in_bank_idx"),
+        get_named_compile_time_arg_val("pipeline_sem_id"),
+        get_named_compile_time_arg_val("next_core_noc_x"),
+        get_named_compile_time_arg_val("next_core_noc_y")>;
 
     constexpr uint32_t cb_in0 = get_named_compile_time_arg_val("cb_in0");
     constexpr uint32_t num_tiles_k = get_named_compile_time_arg_val("num_tiles_k");

--- a/models/demos/deepseek_v3_b1/micro_ops/dram_streaming_matmul_compressed/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/dram_streaming_matmul_compressed/op.py
@@ -1,0 +1,350 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+DRAM Streaming Matmul with Compressed Weights.
+
+Computes: output = A @ decompress(B_compressed)
+
+B is WIDTH_SHARDED in DRAM with compressed tiles (mixed bfp8/bfp4/bfp2).
+Tiles are streamed from DRAM in variable-size subblocks.
+An L1 metadata tensor stores per-subblock byte sizes and an L1 format
+tensor stores per-tile packed pair info for compute-side format reconfig.
+
+Key differences from MatmulCustomCompressed (L1 version):
+  - B lives in DRAM, streamed in subblocks via NCRISC
+  - Variable-size DRAM reads: metadata tensor tells NCRISC how many bytes per subblock
+  - Subblock-K partial accumulation with finalize on last subblock
+  - Uses DRAM bank-to-worker core mapping
+"""
+
+import numpy as np
+import torch
+from loguru import logger
+
+import ttnn
+from models.demos.deepseek_v3_b1.compressed_tensor.compressed_tensor import CompressedTensor
+from models.demos.deepseek_v3_b1.unified_kernel_descriptor import (
+    PerCoreCompileTimeDescriptor,
+    UnifiedCompileTimeCoreDescriptor,
+    UnifiedKernelDescriptor,
+)
+
+# Must match compressed::TILE_SIZES in llk_unpack_compressed.h
+_TILE_SIZES = [1088, 576, 320, 0]  # bfp8, bfp4, bfp2, bfp0
+
+# Pre-resolved DataFormat values and shifted tile sizes (match op.py in matmul_custom_compressed)
+_DATA_FORMATS = [6, 7, 15, 0]  # bfp8=Bfp8_b(6), bfp4=Bfp4_b(7), bfp2=Bfp2_b(15), bfp0=0
+_TILE_SIZES_SHIFTED = [68, 36, 20, 0]  # tile_bytes >> 4
+
+
+def _compute_subblock_metadata(
+    device,
+    shard_assignment: np.ndarray,
+    subblock_k: int,
+    per_core_n: int,
+    num_subblocks_k: int,
+) -> tuple[list[int], list[int]]:
+    """Compute per-subblock NOC read metadata and packed pair format metadata.
+
+    The assignment is in column-major order within the shard:
+    for each N column, K tiles are contiguous.
+
+    Returns:
+        block_sizes: list of uint32, one per subblock (block_size_bytes).
+            Total entries: num_subblocks_k * per_core_n
+        packed_pairs: list of uint32, packed pair format info for TRISC.
+            Each word: [sz1:8 | sz0:8 | fmt1:8 | fmt0:8]
+            Total entries: (subblock_k / 2) * num_subblocks_k * per_core_n
+    """
+    num_tiles_k = subblock_k * num_subblocks_k
+    assert len(shard_assignment) == num_tiles_k * per_core_n
+
+    block_sizes = []
+    packed_pairs = []
+
+    tile_idx = 0
+    for _n in range(per_core_n):
+        for sb_k in range(num_subblocks_k):
+            # Compute block size for this subblock
+            block_bytes = 0
+            subblock_start = tile_idx
+            for t in range(subblock_k):
+                fmt_idx = int(shard_assignment[tile_idx])
+                block_bytes += _TILE_SIZES[fmt_idx]
+                tile_idx += 1
+
+            block_sizes.append(block_bytes)
+
+            # Pack pairs for this subblock
+            for p in range(0, subblock_k, 2):
+                a0 = int(shard_assignment[subblock_start + p])
+                a1 = int(shard_assignment[subblock_start + p + 1])
+                packed = (
+                    _DATA_FORMATS[a0]
+                    | (_DATA_FORMATS[a1] << 8)
+                    | (_TILE_SIZES_SHIFTED[a0] << 16)
+                    | (_TILE_SIZES_SHIFTED[a1] << 24)
+                )
+                packed_pairs.append(packed)
+
+    return block_sizes, packed_pairs
+
+
+class DRAMStreamingMatmulCompressed:
+    @staticmethod
+    def op(
+        input_a: ttnn.Tensor,
+        ct: CompressedTensor,
+        output_tensor: ttnn.Tensor,
+        subblock_k: int = None,
+    ) -> ttnn.Tensor:
+        """
+        A [M, K] @ decompress(B_compressed [K, N]) = output [M, N].
+
+        B is WIDTH_SHARDED in DRAM. Tiles are streamed in variable-size subblocks.
+
+        Args:
+            input_a: Activation tensor, HEIGHT_SHARDED (replicated) on compute cores.
+            ct: CompressedTensor with data in DRAM.
+            output_tensor: Output tensor, WIDTH_SHARDED on compute cores.
+            subblock_k: K subblock size in tiles. None means full K.
+        """
+        device = input_a.device()
+        data_tensor = ct.get_data_tensor()
+
+        # Get compute cores from DRAM bank assignment
+        in1_noc = ttnn.NOC.NOC_0
+        all_worker_cores = device.get_optimal_dram_bank_to_logical_worker_assignment(in1_noc)
+        num_cores = len(all_worker_cores)
+
+        compute_cores = ttnn.CoreRangeSet(
+            [ttnn.CoreRange(ttnn.CoreCoord(c.x, c.y), ttnn.CoreCoord(c.x, c.y)) for c in all_worker_cores]
+        )
+
+        # Shapes from shard specs
+        a_shard_shape = input_a.memory_config().shard_spec.shape
+        out_shard_shape = output_tensor.memory_config().shard_spec.shape
+        M = a_shard_shape[0]
+        K = a_shard_shape[1]
+        Kt = K // 32
+        per_core_N = out_shard_shape[1] // 32
+
+        if subblock_k is None:
+            subblock_k = Kt
+        assert Kt % subblock_k == 0, f"Kt ({Kt}) must be divisible by subblock_k ({subblock_k})"
+        num_subblocks_k = Kt // subblock_k
+        assert subblock_k % 2 == 0, f"subblock_k ({subblock_k}) must be even"
+
+        logger.debug(
+            f"DRAMStreamingMatmulCompressed: M={M}, K={K}, Kt={Kt}, per_core_N={per_core_N}, "
+            f"subblock_k={subblock_k}, num_subblocks_k={num_subblocks_k}, num_cores={num_cores}"
+        )
+
+        # CB indices
+        cb_in0 = 0  # A tensor (HEIGHT_SHARDED, replicated)
+        cb_in1 = 1  # Working buffer for DRAM streaming
+        cb_out = 2  # Output tensor
+
+        # CB0: A tensor — tensor-backed
+        cb0_desc = ttnn.cb_descriptor_from_sharded_tensor(cb_in0, input_a)
+
+        # CB1: Working buffer for streaming — NOT tensor-backed.
+        # Size: 3 buffers * max possible subblock size (all bfp8 = subblock_k * 1088)
+        max_tile_size = _TILE_SIZES[0]  # bfp8 = 1088
+        num_in1_buffers = 3
+        max_subblock_bytes = subblock_k * max_tile_size
+        cb_in1_total_bytes = num_in1_buffers * max_subblock_bytes
+
+        tile_32x32 = ttnn.Tile([32, 32])
+        cb1_fmt = ttnn.CBFormatDescriptor(
+            buffer_index=cb_in1,
+            data_format=ttnn.bfloat8_b,
+            page_size=max_tile_size,
+            tile=ttnn.TileDescriptor(tile_32x32),
+        )
+        cb1_desc = ttnn.CBDescriptor(
+            total_size=cb_in1_total_bytes,
+            core_ranges=compute_cores,
+            format_descriptors=[cb1_fmt],
+        )
+
+        # CB2: Output tensor — tensor-backed
+        cb2_desc = ttnn.cb_descriptor_from_sharded_tensor(cb_out, output_tensor)
+
+        # Get DRAM buffer address
+        in1_buffer_addr = data_tensor.buffer_address()
+
+        # Build per-core metadata (block sizes + format pairs) and upload to L1
+        num_dram_banks = len(all_worker_cores)
+        bank_id_core_values = []
+        vc_core_values = []
+        bank_ids = []
+
+        # DRAM cores from B tensor's shard grid (matches CompressedTensor's assignment keys)
+        dram_cores = ttnn.corerange_to_cores(data_tensor.memory_config().shard_spec.grid)
+
+        # Metadata: block_sizes and fmt_pairs per core
+        all_block_sizes = []
+        all_fmt_pairs = []
+
+        for idx, core in enumerate(all_worker_cores):
+            # Bank ID and VC
+            bank_id = idx % num_dram_banks
+            vc = bank_id & 0x3
+            for j in range(idx):
+                prev_core = all_worker_cores[j]
+                if prev_core.y == core.y and (bank_ids[j] & 0x3) == (bank_id & 0x3):
+                    vc = (vc + 1) & 0x3
+                    break
+            bank_ids.append(bank_id)
+            bank_id_core_values.append((core, bank_id))
+            vc_core_values.append((core, vc))
+
+            # Get this bank's shard assignment using DRAM core coords.
+            # The data was pre-shuffled to column-major by shuffle_tensor_tiles before
+            # CompressedTensor creation, so the assignment from get_assignment_per_shard
+            # is already in the physical DRAM read order (column-major: n-major, k-minor).
+            shard_assignment = ct.get_assignment_per_shard(dram_cores[idx])
+
+            # Compute metadata
+            block_sizes, fmt_pairs = _compute_subblock_metadata(
+                device, shard_assignment, subblock_k, per_core_N, num_subblocks_k
+            )
+            all_block_sizes.append(block_sizes)
+            all_fmt_pairs.append(fmt_pairs)
+
+        # Upload block size metadata to L1 (HEIGHT_SHARDED, one shard per compute core)
+        # Each subblock has 1 uint32 entry: block_size_bytes
+        num_meta_entries = num_subblocks_k * per_core_N
+        meta_flat = []
+        for core_sizes in all_block_sizes:
+            meta_flat.extend(core_sizes)
+        meta_torch = torch.tensor(meta_flat, dtype=torch.int32).reshape(num_cores, num_meta_entries)
+        meta_shard_spec = ttnn.ShardSpec(compute_cores, [1, num_meta_entries * 4], ttnn.ShardOrientation.ROW_MAJOR)
+        meta_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, meta_shard_spec)
+        meta_tensor = ttnn.from_torch(
+            meta_torch.view(torch.uint8).reshape(num_cores, num_meta_entries * 4),
+            dtype=ttnn.uint8,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=device,
+            memory_config=meta_mem_config,
+        )
+        meta_l1_addr = meta_tensor.buffer_address()
+
+        # Upload format pairs metadata to L1 (HEIGHT_SHARDED)
+        num_pairs = (subblock_k // 2) * num_subblocks_k * per_core_N
+        fmt_flat = []
+        for core_pairs in all_fmt_pairs:
+            fmt_flat.extend(core_pairs)
+        fmt_torch = torch.tensor(fmt_flat, dtype=torch.int32).reshape(num_cores, num_pairs)
+        fmt_shard_spec = ttnn.ShardSpec(compute_cores, [1, num_pairs * 4], ttnn.ShardOrientation.ROW_MAJOR)
+        fmt_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, fmt_shard_spec)
+        fmt_tensor = ttnn.from_torch(
+            fmt_torch.view(torch.uint8).reshape(num_cores, num_pairs * 4),
+            dtype=ttnn.uint8,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=device,
+            memory_config=fmt_mem_config,
+        )
+        fmt_l1_addr = fmt_tensor.buffer_address()
+
+        # NOC max page size (arch-dependent)
+        arch = device.arch()
+        if arch == ttnn.device.Arch.WORMHOLE_B0:
+            noc_max_page_size = 8192
+        elif arch == ttnn.device.Arch.BLACKHOLE:
+            noc_max_page_size = 16384
+        else:
+            raise ValueError(f"Unsupported architecture: {arch}")
+
+        # Compile-time args
+        ncrisc_named_args = [
+            ("cb_in0", cb_in0),
+            ("cb_in1", cb_in1),
+            ("cb_out", cb_out),
+            ("num_tiles_k", Kt),
+            ("in1_tensor_addr", in1_buffer_addr),
+            ("subblock_k", subblock_k),
+            ("per_core_n", per_core_N),
+            ("out_num_tiles", per_core_N),
+            ("num_subblocks_k", num_subblocks_k),
+            ("meta_l1_addr", meta_l1_addr),
+            ("cb_in1_size_bytes", cb_in1_total_bytes),
+            ("noc_max_page_size", noc_max_page_size),
+        ]
+
+        brisc_named_args = [
+            ("cb_in0", cb_in0),
+            ("cb_in1", cb_in1),
+            ("cb_out", cb_out),
+            ("num_tiles_k", Kt),
+            ("in1_tensor_addr", in1_buffer_addr),
+            ("subblock_k", subblock_k),
+            ("per_core_n", per_core_N),
+            ("out_num_tiles", per_core_N),
+            ("num_subblocks_k", num_subblocks_k),
+            ("meta_l1_addr", meta_l1_addr),
+            ("cb_in1_size_bytes", cb_in1_total_bytes),
+            ("fmt_l1_addr", fmt_l1_addr),
+        ]
+
+        trisc_named_args = [
+            ("cb_in0", cb_in0),
+            ("cb_in1", cb_in1),
+            ("cb_out", cb_out),
+            ("num_tiles_k", Kt),
+            ("subblock_k", subblock_k),
+            ("per_core_n", per_core_N),
+            ("num_subblocks_k", num_subblocks_k),
+            ("fmt_l1_addr", fmt_l1_addr),
+        ]
+
+        KERNEL_PATH = "models/demos/deepseek_v3_b1/micro_ops/dram_streaming_matmul_compressed/kernels/dram_streaming_matmul_compressed_kernel.cpp"
+
+        unified_kernel = UnifiedKernelDescriptor(
+            kernel_source=KERNEL_PATH,
+            core_ranges=compute_cores,
+            ncrisc_named_compile_time_args=ncrisc_named_args,
+            brisc_named_compile_time_args=brisc_named_args,
+            trisc_named_compile_time_args=trisc_named_args,
+            trisc_compute_config=ttnn.ComputeConfigDescriptor(
+                math_fidelity=ttnn.MathFidelity.LoFi,
+                math_approx_mode=False,
+                fp32_dest_acc_en=False,
+                dst_full_sync_en=False,
+            ),
+            unified_compile_time_core_descriptors=[
+                UnifiedCompileTimeCoreDescriptor(
+                    named_compile_time_arg="is_active_core",
+                    core_range=compute_cores,
+                    value=1,
+                    other_value=0,
+                ),
+            ],
+            per_core_compile_time_descriptors=[
+                PerCoreCompileTimeDescriptor(
+                    named_compile_time_arg="bank_id",
+                    core_values=bank_id_core_values,
+                    other_value=0,
+                ),
+                PerCoreCompileTimeDescriptor(
+                    named_compile_time_arg="vc",
+                    core_values=vc_core_values,
+                    other_value=0,
+                ),
+            ],
+        )
+
+        kernel_descriptors = unified_kernel.get_kernel_descriptors()
+
+        program_descriptor = ttnn.ProgramDescriptor(
+            kernels=kernel_descriptors.kernels,
+            cbs=[cb0_desc, cb1_desc, cb2_desc],
+            semaphores=[],
+        )
+
+        io_tensors = [input_a, data_tensor, output_tensor, meta_tensor, fmt_tensor]
+        ttnn.generic_op(io_tensors, program_descriptor)
+
+        return output_tensor

--- a/models/demos/deepseek_v3_b1/micro_ops/dram_streaming_matmul_compressed/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/dram_streaming_matmul_compressed/op.py
@@ -24,6 +24,7 @@ from loguru import logger
 
 import ttnn
 from models.demos.deepseek_v3_b1.compressed_tensor.compressed_tensor import CompressedTensor
+from models.demos.deepseek_v3_b1.micro_ops.matmul_custom_compressed.op import _ZERO_TILE_SENTINEL, pack_tile_pairs
 from models.demos.deepseek_v3_b1.unified_kernel_descriptor import (
     PerCoreCompileTimeDescriptor,
     UnifiedCompileTimeCoreDescriptor,
@@ -33,10 +34,6 @@ from models.demos.deepseek_v3_b1.unified_kernel_descriptor import (
 # Must match compressed::TILE_SIZES in llk_unpack_compressed.h
 _TILE_SIZES = [1088, 576, 320, 0]  # bfp8, bfp4, bfp2, bfp0
 
-# Pre-resolved DataFormat values and shifted tile sizes (match op.py in matmul_custom_compressed)
-_DATA_FORMATS = [6, 7, 15, 0]  # bfp8=Bfp8_b(6), bfp4=Bfp4_b(7), bfp2=Bfp2_b(15), bfp0=0
-_TILE_SIZES_SHIFTED = [68, 36, 20, 0]  # tile_bytes >> 4
-
 
 def _compute_subblock_metadata(
     device,
@@ -45,7 +42,7 @@ def _compute_subblock_metadata(
     per_core_n: int,
     num_subblocks_k: int,
 ) -> tuple[list[int], list[int]]:
-    """Compute per-subblock NOC read metadata and packed pair format metadata.
+    """Compute per-subblock NOC read metadata and per-tile format metadata.
 
     The assignment is in column-major order within the shard:
     for each N column, K tiles are contiguous.
@@ -53,15 +50,16 @@ def _compute_subblock_metadata(
     Returns:
         block_sizes: list of uint32, one per subblock (block_size_bytes).
             Total entries: num_subblocks_k * per_core_n
-        packed_pairs: list of uint32, packed pair format info for TRISC.
-            Each word: [sz1:8 | sz0:8 | fmt1:8 | fmt0:8]
-            Total entries: (subblock_k / 2) * num_subblocks_k * per_core_n
+        tile_infos: list of uint32, per-tile [relative_offset:24 | fmt:8].
+            Relative offsets are within each subblock (base=0).
+            Zero tiles use _ZERO_TILE_SENTINEL as address.
+            Total entries: subblock_k * num_subblocks_k * per_core_n
     """
     num_tiles_k = subblock_k * num_subblocks_k
     assert len(shard_assignment) == num_tiles_k * per_core_n
 
     block_sizes = []
-    packed_pairs = []
+    tile_infos = []
 
     tile_idx = 0
     for _n in range(per_core_n):
@@ -76,19 +74,14 @@ def _compute_subblock_metadata(
 
             block_sizes.append(block_bytes)
 
-            # Pack pairs for this subblock
-            for p in range(0, subblock_k, 2):
-                a0 = int(shard_assignment[subblock_start + p])
-                a1 = int(shard_assignment[subblock_start + p + 1])
-                packed = (
-                    _DATA_FORMATS[a0]
-                    | (_DATA_FORMATS[a1] << 8)
-                    | (_TILE_SIZES_SHIFTED[a0] << 16)
-                    | (_TILE_SIZES_SHIFTED[a1] << 24)
-                )
-                packed_pairs.append(packed)
+            # Pack per-tile info for this subblock using pack_tile_pairs.
+            # base_addr_shifted=0 gives relative offsets within the subblock.
+            # The kernel adds addr_in1 (CB read pointer) at runtime.
+            subblock_slice = shard_assignment[subblock_start : subblock_start + subblock_k]
+            tiles = pack_tile_pairs(subblock_slice, base_addr_shifted=0, zero_tile_addr=_ZERO_TILE_SENTINEL)
+            tile_infos.extend(tiles)
 
-    return block_sizes, packed_pairs
+    return block_sizes, tile_infos
 
 
 class DRAMStreamingMatmulCompressed:
@@ -232,16 +225,17 @@ class DRAMStreamingMatmulCompressed:
         )
         meta_l1_addr = meta_tensor.buffer_address()
 
-        # Upload format pairs metadata to L1 (HEIGHT_SHARDED)
-        num_pairs = (subblock_k // 2) * num_subblocks_k * per_core_N
+        # Upload per-tile format metadata to L1 (HEIGHT_SHARDED)
+        # Each tile has one uint32: [relative_offset:24 | fmt:8]
+        num_tile_entries = subblock_k * num_subblocks_k * per_core_N
         fmt_flat = []
         for core_pairs in all_fmt_pairs:
             fmt_flat.extend(core_pairs)
-        fmt_torch = torch.tensor(fmt_flat, dtype=torch.int32).reshape(num_cores, num_pairs)
-        fmt_shard_spec = ttnn.ShardSpec(compute_cores, [1, num_pairs * 4], ttnn.ShardOrientation.ROW_MAJOR)
+        fmt_torch = torch.tensor(fmt_flat, dtype=torch.int32).reshape(num_cores, num_tile_entries)
+        fmt_shard_spec = ttnn.ShardSpec(compute_cores, [1, num_tile_entries * 4], ttnn.ShardOrientation.ROW_MAJOR)
         fmt_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, fmt_shard_spec)
         fmt_tensor = ttnn.from_torch(
-            fmt_torch.view(torch.uint8).reshape(num_cores, num_pairs * 4),
+            fmt_torch.view(torch.uint8).reshape(num_cores, num_tile_entries * 4),
             dtype=ttnn.uint8,
             layout=ttnn.ROW_MAJOR_LAYOUT,
             device=device,

--- a/models/demos/deepseek_v3_b1/micro_ops/dram_streaming_matmul_compressed/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/dram_streaming_matmul_compressed/op.py
@@ -25,7 +25,11 @@ from loguru import logger
 
 import ttnn
 from models.demos.deepseek_v3_b1.compressed_tensor.compressed_tensor import CompressedTensor
-from models.demos.deepseek_v3_b1.micro_ops.matmul_custom_compressed.op import _ZERO_TILE_SENTINEL, pack_tile_pairs
+from models.demos.deepseek_v3_b1.micro_ops.matmul_custom_compressed.op import (
+    _CB_ADDR_SHIFT,
+    _ZEROS_ADDR_SHIFTED,
+    pack_tile_pairs,
+)
 from models.demos.deepseek_v3_b1.unified_kernel_descriptor import (
     PerCoreCompileTimeDescriptor,
     UnifiedCompileTimeCoreDescriptor,
@@ -42,18 +46,24 @@ def _compute_subblock_metadata(
     subblock_k: int,
     per_core_n: int,
     num_subblocks_k: int,
+    cb_in1_base_shifted: int,
+    max_subblock_bytes_shifted: int,
+    num_buffers: int,
 ) -> tuple[list[int], list[int]]:
     """Compute per-subblock NOC read metadata and per-tile format metadata.
 
     The assignment is in column-major order within the shard:
     for each N column, K tiles are contiguous.
 
+    Uses absolute addressing: each tile's address is precomputed using the
+    known CB base address and deterministic triple-buffer slot rotation.
+
     Returns:
         block_sizes: list of uint32, one per subblock (block_size_bytes).
             Total entries: num_subblocks_k * per_core_n
-        tile_infos: list of uint32, per-tile [relative_offset:24 | fmt:8].
-            Relative offsets are within each subblock (base=0).
-            Zero tiles use _ZERO_TILE_SENTINEL as address.
+        tile_infos: list of uint32, per-tile [abs_addr:24 | fmt:8].
+            Absolute THCON-shifted addresses, precomputed by host.
+            Zero tiles use _ZEROS_ADDR_SHIFTED.
             Total entries: subblock_k * num_subblocks_k * per_core_n
     """
     num_tiles_k = subblock_k * num_subblocks_k
@@ -62,7 +72,9 @@ def _compute_subblock_metadata(
     block_sizes = []
     tile_infos = []
 
+    iteration = 0  # global iteration index for slot rotation
     tile_idx = 0
+    debug_logged = False
     for _n in range(per_core_n):
         for sb_k in range(num_subblocks_k):
             # Compute block size for this subblock
@@ -75,12 +87,18 @@ def _compute_subblock_metadata(
 
             block_sizes.append(block_bytes)
 
-            # Pack per-tile info for this subblock using pack_tile_pairs.
-            # base_addr_shifted=0 gives relative offsets within the subblock.
-            # The kernel adds addr_in1 (CB read pointer) at runtime.
+            # Absolute base for this subblock's slot in the triple-buffer
+            slot = iteration % num_buffers
+            slot_base_shifted = cb_in1_base_shifted + slot * max_subblock_bytes_shifted
+
             subblock_slice = shard_assignment[subblock_start : subblock_start + subblock_k]
-            tiles = pack_tile_pairs(subblock_slice, base_addr_shifted=0, zero_tile_addr=_ZERO_TILE_SENTINEL)
+            tiles = pack_tile_pairs(
+                subblock_slice, base_addr_shifted=slot_base_shifted, zero_tile_addr=_ZEROS_ADDR_SHIFTED
+            )
+
             tile_infos.extend(tiles)
+
+            iteration += 1
 
     return block_sizes, tile_infos
 
@@ -185,25 +203,38 @@ class DRAMStreamingMatmulCompressed:
         # CB0: A tensor — tensor-backed
         cb0_desc = ttnn.cb_descriptor_from_sharded_tensor(cb_in0, input_a)
 
-        # CB1: Working buffer for streaming — NOT tensor-backed.
+        # CB1: Working buffer for streaming — tensor-backed so the L1 address
+        # is known at host time, enabling absolute addressing in metadata.
         # Size: 3 buffers * max possible subblock size (all bfp8 = subblock_k * 1088)
         max_tile_size = _TILE_SIZES[0]  # bfp8 = 1088
         num_in1_buffers = 3
         max_subblock_bytes = subblock_k * max_tile_size
         cb_in1_total_bytes = num_in1_buffers * max_subblock_bytes
 
-        tile_32x32 = ttnn.Tile([32, 32])
-        cb1_fmt = ttnn.CBFormatDescriptor(
-            buffer_index=cb_in1,
-            data_format=ttnn.bfloat8_b,
-            page_size=max_tile_size,
-            tile=ttnn.TileDescriptor(tile_32x32),
+        # Create backing tensor as bfp8 tile-layout so cb_descriptor_from_sharded_tensor
+        # derives the correct CB format (page_size, data_format, tile descriptor).
+        in1_tile = ttnn.Tile([32, 32])
+        in1_cb_tiles = subblock_k * num_in1_buffers
+        in1_backing_shard_shape = (32, in1_cb_tiles * 32)
+        in1_backing_total_width = in1_cb_tiles * 32 * num_total_cores
+        in1_backing_shard_spec = ttnn.ShardSpec(compute_cores, in1_backing_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+        in1_backing_mem_config = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, in1_backing_shard_spec
         )
-        cb1_desc = ttnn.CBDescriptor(
-            total_size=cb_in1_total_bytes,
-            core_ranges=compute_cores,
-            format_descriptors=[cb1_fmt],
+        in1_backing_torch = torch.zeros([1, 1, 32, in1_backing_total_width]).bfloat16().float()
+        in1_backing_tensor = ttnn.from_torch(
+            in1_backing_torch,
+            dtype=ttnn.bfloat8_b,
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            memory_config=in1_backing_mem_config,
+            tile=in1_tile,
         )
+        cb_in1_base = in1_backing_tensor.buffer_address()
+        cb_in1_base_shifted = (cb_in1_base >> _CB_ADDR_SHIFT) - 1
+        max_subblock_bytes_shifted = max_subblock_bytes >> _CB_ADDR_SHIFT
+
+        cb1_desc = ttnn.cb_descriptor_from_sharded_tensor(cb_in1, in1_backing_tensor)
 
         # CB2: Output tensor — tensor-backed
         cb2_desc = ttnn.cb_descriptor_from_sharded_tensor(cb_out, output_tensor)
@@ -274,7 +305,14 @@ class DRAMStreamingMatmulCompressed:
 
                 # Compute metadata for this core's columns
                 block_sizes, tile_infos = _compute_subblock_metadata(
-                    device, core_assignment, subblock_k, per_core_N, num_subblocks_k
+                    device,
+                    core_assignment,
+                    subblock_k,
+                    per_core_N,
+                    num_subblocks_k,
+                    cb_in1_base_shifted,
+                    max_subblock_bytes_shifted,
+                    num_in1_buffers,
                 )
                 per_core_block_sizes[core_flat_idx] = block_sizes
                 per_core_fmt_pairs[core_flat_idx] = tile_infos
@@ -327,7 +365,8 @@ class DRAMStreamingMatmulCompressed:
         for core_idx in range(num_total_cores):
             fmt_flat.extend(per_core_fmt_pairs[core_idx])
 
-        fmt_torch = torch.tensor(fmt_flat, dtype=torch.int32).reshape(num_total_cores, num_tile_entries)
+        fmt_np = np.array(fmt_flat, dtype=np.uint32).view(np.int32).reshape(num_total_cores, num_tile_entries)
+        fmt_torch = torch.from_numpy(fmt_np)
         fmt_shard_spec = ttnn.ShardSpec(compute_cores, [1, num_tile_entries * 4], ttnn.ShardOrientation.ROW_MAJOR)
         fmt_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, fmt_shard_spec)
         fmt_tensor = ttnn.from_torch(
@@ -458,7 +497,7 @@ class DRAMStreamingMatmulCompressed:
             semaphores=semaphores,
         )
 
-        io_tensors = [input_a, data_tensor, output_tensor, meta_tensor, fmt_tensor]
+        io_tensors = [input_a, data_tensor, output_tensor, in1_backing_tensor, meta_tensor, fmt_tensor]
         ttnn.generic_op(io_tensors, program_descriptor)
 
         return output_tensor

--- a/models/demos/deepseek_v3_b1/micro_ops/dram_streaming_matmul_compressed/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/dram_streaming_matmul_compressed/op.py
@@ -74,7 +74,6 @@ def _compute_subblock_metadata(
 
     iteration = 0  # global iteration index for slot rotation
     tile_idx = 0
-    debug_logged = False
     for _n in range(per_core_n):
         for sb_k in range(num_subblocks_k):
             # Compute block size for this subblock

--- a/models/demos/deepseek_v3_b1/micro_ops/dram_streaming_matmul_compressed/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/dram_streaming_matmul_compressed/op.py
@@ -11,11 +11,12 @@ Tiles are streamed from DRAM in variable-size subblocks.
 An L1 metadata tensor stores per-subblock byte sizes and an L1 format
 tensor stores per-tile packed pair info for compute-side format reconfig.
 
-Key differences from MatmulCustomCompressed (L1 version):
-  - B lives in DRAM, streamed in subblocks via NCRISC
-  - Variable-size DRAM reads: metadata tensor tells NCRISC how many bytes per subblock
-  - Subblock-K partial accumulation with finalize on last subblock
-  - Uses DRAM bank-to-worker core mapping
+Supports pipelined multi-core-per-bank mode (cores_per_bank > 1):
+  Each core reads its own portion of N columns directly from DRAM.
+  Cores sharing a bank read sequentially with semaphore handoff:
+  core 0 reads first, signals core 1 after last request is sent,
+  core 1 waits on semaphore then reads from its offset, etc.
+  BRISC: no-op. TRISC: compressed matmul (unchanged).
 """
 
 import numpy as np
@@ -84,6 +85,26 @@ def _compute_subblock_metadata(
     return block_sizes, tile_infos
 
 
+def _compute_dram_start_offset(
+    shard_assignment: np.ndarray,
+    subblock_k: int,
+    num_subblocks_k: int,
+    col_start: int,
+) -> int:
+    """Compute the byte offset into the DRAM shard where col_start begins.
+
+    Tiles are stored column-major: for each N column, K tiles are contiguous.
+    We sum up the byte sizes of all tiles in columns [0, col_start).
+    """
+    num_tiles_k = subblock_k * num_subblocks_k
+    offset = 0
+    for col in range(col_start):
+        for t in range(num_tiles_k):
+            fmt_idx = int(shard_assignment[col * num_tiles_k + t])
+            offset += _TILE_SIZES[fmt_idx]
+    return offset
+
+
 class DRAMStreamingMatmulCompressed:
     @staticmethod
     def op(
@@ -91,6 +112,7 @@ class DRAMStreamingMatmulCompressed:
         ct: CompressedTensor,
         output_tensor: ttnn.Tensor,
         subblock_k: int = None,
+        cores_per_bank: int = 1,
     ) -> ttnn.Tensor:
         """
         A [M, K] @ decompress(B_compressed [K, N]) = output [M, N].
@@ -102,18 +124,19 @@ class DRAMStreamingMatmulCompressed:
             ct: CompressedTensor with data in DRAM.
             output_tensor: Output tensor, WIDTH_SHARDED on compute cores.
             subblock_k: K subblock size in tiles. None means full K.
+            cores_per_bank: Number of compute cores per DRAM bank (1, 2, or 4).
+                When > 1, uses pipelined DRAM reads: each core reads its own
+                N columns directly, with semaphore handoff between cores sharing a bank.
         """
+        assert cores_per_bank in (1, 2, 4), f"cores_per_bank must be 1, 2, or 4, got {cores_per_bank}"
+
         device = input_a.device()
         data_tensor = ct.get_data_tensor()
 
-        # Get compute cores from DRAM bank assignment
+        # Get primary cores from DRAM bank assignment (1 per bank)
         in1_noc = ttnn.NOC.NOC_0
-        all_worker_cores = device.get_optimal_dram_bank_to_logical_worker_assignment(in1_noc)
-        num_cores = len(all_worker_cores)
-
-        compute_cores = ttnn.CoreRangeSet(
-            [ttnn.CoreRange(ttnn.CoreCoord(c.x, c.y), ttnn.CoreCoord(c.x, c.y)) for c in all_worker_cores]
-        )
+        primary_worker_cores = device.get_optimal_dram_bank_to_logical_worker_assignment(in1_noc)
+        num_banks = len(primary_worker_cores)
 
         # Shapes from shard specs
         a_shard_shape = input_a.memory_config().shard_spec.shape
@@ -121,7 +144,12 @@ class DRAMStreamingMatmulCompressed:
         M = a_shard_shape[0]
         K = a_shard_shape[1]
         Kt = K // 32
+        # per_core_N is the N columns each core computes (from output shard)
         per_core_N = out_shard_shape[1] // 32
+        # total_N_per_bank is the total N columns per DRAM bank shard
+        total_N_per_bank = per_core_N * cores_per_bank
+
+        assert total_N_per_bank % cores_per_bank == 0
 
         if subblock_k is None:
             subblock_k = Kt
@@ -129,14 +157,29 @@ class DRAMStreamingMatmulCompressed:
         num_subblocks_k = Kt // subblock_k
         assert subblock_k % 2 == 0, f"subblock_k ({subblock_k}) must be even"
 
+        # Build expanded core grid: primary + partner cores
+        # Partner cores are at (primary.x + offset, primary.y)
+        all_compute_cores = []  # flat list: [primary0, partner0_1, ..., primary1, partner1_1, ...]
+        for bank_idx, primary_core in enumerate(primary_worker_cores):
+            for offset in range(cores_per_bank):
+                core = ttnn.CoreCoord(primary_core.x + offset, primary_core.y)
+                all_compute_cores.append(core)
+
+        num_total_cores = len(all_compute_cores)
+        compute_cores = ttnn.CoreRangeSet(
+            [ttnn.CoreRange(ttnn.CoreCoord(c.x, c.y), ttnn.CoreCoord(c.x, c.y)) for c in all_compute_cores]
+        )
+
         logger.debug(
             f"DRAMStreamingMatmulCompressed: M={M}, K={K}, Kt={Kt}, per_core_N={per_core_N}, "
-            f"subblock_k={subblock_k}, num_subblocks_k={num_subblocks_k}, num_cores={num_cores}"
+            f"total_N_per_bank={total_N_per_bank}, cores_per_bank={cores_per_bank}, "
+            f"subblock_k={subblock_k}, num_subblocks_k={num_subblocks_k}, "
+            f"num_banks={num_banks}, num_total_cores={num_total_cores}"
         )
 
         # CB indices
         cb_in0 = 0  # A tensor (HEIGHT_SHARDED, replicated)
-        cb_in1 = 1  # Working buffer for DRAM streaming
+        cb_in1 = 1  # Working buffer for streaming
         cb_out = 2  # Output tensor
 
         # CB0: A tensor — tensor-backed
@@ -165,59 +208,110 @@ class DRAMStreamingMatmulCompressed:
         # CB2: Output tensor — tensor-backed
         cb2_desc = ttnn.cb_descriptor_from_sharded_tensor(cb_out, output_tensor)
 
+        cbs = [cb0_desc, cb1_desc, cb2_desc]
+
         # Get DRAM buffer address
         in1_buffer_addr = data_tensor.buffer_address()
 
-        # Build per-core metadata (block sizes + format pairs) and upload to L1
-        num_dram_banks = len(all_worker_cores)
-        bank_id_core_values = []
-        vc_core_values = []
-        bank_ids = []
-
-        # DRAM cores from B tensor's shard grid (matches CompressedTensor's assignment keys)
+        # DRAM cores from B tensor's shard grid
         dram_cores = ttnn.corerange_to_cores(data_tensor.memory_config().shard_spec.grid)
 
-        # Metadata: block_sizes and fmt_pairs per core
-        all_block_sizes = []
-        all_fmt_pairs = []
+        # Semaphore for pipeline synchronization between cores sharing a bank
+        pipeline_sem_id = 0
+        semaphores = [
+            ttnn.SemaphoreDescriptor(
+                id=pipeline_sem_id,
+                core_ranges=compute_cores,
+                initial_value=0,
+            )
+        ]
 
-        for idx, core in enumerate(all_worker_cores):
-            # Bank ID and VC
-            bank_id = idx % num_dram_banks
+        # ====================================================================
+        # Build per-core metadata
+        # ====================================================================
+        per_core_block_sizes = {}  # core_idx → list of block sizes
+        per_core_fmt_pairs = {}  # core_idx → list of tile info uint32s
+
+        # Per-core compile-time arg values
+        bank_id_core_values = []
+        vc_core_values = []
+        per_core_n_core_values = []
+        dram_start_offset_core_values = []
+        core_in_bank_idx_core_values = []
+        next_core_noc_x_core_values = []
+        next_core_noc_y_core_values = []
+
+        bank_ids = []
+
+        for bank_idx, primary_core in enumerate(primary_worker_cores):
+            # Bank ID and VC for this bank
+            bank_id = bank_idx % num_banks
             vc = bank_id & 0x3
-            for j in range(idx):
-                prev_core = all_worker_cores[j]
-                if prev_core.y == core.y and (bank_ids[j] & 0x3) == (bank_id & 0x3):
+            for j in range(bank_idx):
+                prev_core = primary_worker_cores[j]
+                if prev_core.y == primary_core.y and (bank_ids[j] & 0x3) == (bank_id & 0x3):
                     vc = (vc + 1) & 0x3
                     break
             bank_ids.append(bank_id)
-            bank_id_core_values.append((core, bank_id))
-            vc_core_values.append((core, vc))
 
-            # Get this bank's shard assignment using DRAM core coords.
-            # The data was pre-shuffled to column-major by shuffle_tensor_tiles before
-            # CompressedTensor creation, so the assignment from get_assignment_per_shard
-            # is already in the physical DRAM read order (column-major: n-major, k-minor).
-            shard_assignment = ct.get_assignment_per_shard(dram_cores[idx])
+            # Get full shard assignment (all N columns for this bank)
+            shard_assignment = ct.get_assignment_per_shard(dram_cores[bank_idx])
 
-            # Compute metadata
-            block_sizes, fmt_pairs = _compute_subblock_metadata(
-                device, shard_assignment, subblock_k, per_core_N, num_subblocks_k
-            )
-            all_block_sizes.append(block_sizes)
-            all_fmt_pairs.append(fmt_pairs)
+            num_tiles_k = subblock_k * num_subblocks_k
 
-        # Upload block size metadata to L1 (HEIGHT_SHARDED, one shard per compute core)
-        # Each subblock has 1 uint32 entry: block_size_bytes
-        num_meta_entries = num_subblocks_k * per_core_N
+            for offset in range(cores_per_bank):
+                core_flat_idx = bank_idx * cores_per_bank + offset
+                core = all_compute_cores[core_flat_idx]
+                is_last = offset == cores_per_bank - 1
+
+                col_start = offset * per_core_N
+                col_end = col_start + per_core_N
+
+                # This core's slice of the shard assignment
+                core_assignment = np.concatenate(
+                    [shard_assignment[col * num_tiles_k : (col + 1) * num_tiles_k] for col in range(col_start, col_end)]
+                )
+
+                # Compute metadata for this core's columns
+                block_sizes, tile_infos = _compute_subblock_metadata(
+                    device, core_assignment, subblock_k, per_core_N, num_subblocks_k
+                )
+                per_core_block_sizes[core_flat_idx] = block_sizes
+                per_core_fmt_pairs[core_flat_idx] = tile_infos
+
+                # Compute DRAM byte offset to this core's first column
+                dram_offset = _compute_dram_start_offset(shard_assignment, subblock_k, num_subblocks_k, col_start)
+
+                bank_id_core_values.append((core, bank_id))
+                vc_core_values.append((core, vc))
+                per_core_n_core_values.append((core, per_core_N))
+                dram_start_offset_core_values.append((core, dram_offset))
+                core_in_bank_idx_core_values.append((core, offset))
+
+                # Next core NOC coords (for semaphore signal)
+                # Last core wraps back to first core in the bank group
+                if not is_last:
+                    next_core = all_compute_cores[core_flat_idx + 1]
+                else:
+                    next_core = all_compute_cores[bank_idx * cores_per_bank]
+                next_noc = device.worker_core_from_logical_core(next_core)
+                next_core_noc_x_core_values.append((core, next_noc.x))
+                next_core_noc_y_core_values.append((core, next_noc.y))
+
+        # ====================================================================
+        # Upload block size metadata to L1
+        # ====================================================================
+        meta_entries = per_core_N * num_subblocks_k  # same for all cores
+
         meta_flat = []
-        for core_sizes in all_block_sizes:
-            meta_flat.extend(core_sizes)
-        meta_torch = torch.tensor(meta_flat, dtype=torch.int32).reshape(num_cores, num_meta_entries)
-        meta_shard_spec = ttnn.ShardSpec(compute_cores, [1, num_meta_entries * 4], ttnn.ShardOrientation.ROW_MAJOR)
+        for core_idx in range(num_total_cores):
+            meta_flat.extend(per_core_block_sizes[core_idx])
+
+        meta_torch = torch.tensor(meta_flat, dtype=torch.int32).reshape(num_total_cores, meta_entries)
+        meta_shard_spec = ttnn.ShardSpec(compute_cores, [1, meta_entries * 4], ttnn.ShardOrientation.ROW_MAJOR)
         meta_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, meta_shard_spec)
         meta_tensor = ttnn.from_torch(
-            meta_torch.view(torch.uint8).reshape(num_cores, num_meta_entries * 4),
+            meta_torch.view(torch.uint8).reshape(num_total_cores, meta_entries * 4),
             dtype=ttnn.uint8,
             layout=ttnn.ROW_MAJOR_LAYOUT,
             device=device,
@@ -225,17 +319,19 @@ class DRAMStreamingMatmulCompressed:
         )
         meta_l1_addr = meta_tensor.buffer_address()
 
-        # Upload per-tile format metadata to L1 (HEIGHT_SHARDED)
-        # Each tile has one uint32: [relative_offset:24 | fmt:8]
+        # ====================================================================
+        # Upload per-tile format metadata to L1
+        # ====================================================================
         num_tile_entries = subblock_k * num_subblocks_k * per_core_N
         fmt_flat = []
-        for core_pairs in all_fmt_pairs:
-            fmt_flat.extend(core_pairs)
-        fmt_torch = torch.tensor(fmt_flat, dtype=torch.int32).reshape(num_cores, num_tile_entries)
+        for core_idx in range(num_total_cores):
+            fmt_flat.extend(per_core_fmt_pairs[core_idx])
+
+        fmt_torch = torch.tensor(fmt_flat, dtype=torch.int32).reshape(num_total_cores, num_tile_entries)
         fmt_shard_spec = ttnn.ShardSpec(compute_cores, [1, num_tile_entries * 4], ttnn.ShardOrientation.ROW_MAJOR)
         fmt_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, fmt_shard_spec)
         fmt_tensor = ttnn.from_torch(
-            fmt_torch.view(torch.uint8).reshape(num_cores, num_tile_entries * 4),
+            fmt_torch.view(torch.uint8).reshape(num_total_cores, num_tile_entries * 4),
             dtype=ttnn.uint8,
             layout=ttnn.ROW_MAJOR_LAYOUT,
             device=device,
@@ -252,7 +348,10 @@ class DRAMStreamingMatmulCompressed:
         else:
             raise ValueError(f"Unsupported architecture: {arch}")
 
+        # ====================================================================
         # Compile-time args
+        # ====================================================================
+        # NCRISC args
         ncrisc_named_args = [
             ("cb_in0", cb_in0),
             ("cb_in1", cb_in1),
@@ -260,29 +359,23 @@ class DRAMStreamingMatmulCompressed:
             ("num_tiles_k", Kt),
             ("in1_tensor_addr", in1_buffer_addr),
             ("subblock_k", subblock_k),
-            ("per_core_n", per_core_N),
             ("out_num_tiles", per_core_N),
             ("num_subblocks_k", num_subblocks_k),
             ("meta_l1_addr", meta_l1_addr),
             ("cb_in1_size_bytes", cb_in1_total_bytes),
             ("noc_max_page_size", noc_max_page_size),
+            ("pipeline_sem_id", pipeline_sem_id),
         ]
 
+        # BRISC args — no-op, minimal
         brisc_named_args = [
             ("cb_in0", cb_in0),
             ("cb_in1", cb_in1),
             ("cb_out", cb_out),
             ("num_tiles_k", Kt),
-            ("in1_tensor_addr", in1_buffer_addr),
-            ("subblock_k", subblock_k),
-            ("per_core_n", per_core_N),
-            ("out_num_tiles", per_core_N),
-            ("num_subblocks_k", num_subblocks_k),
-            ("meta_l1_addr", meta_l1_addr),
-            ("cb_in1_size_bytes", cb_in1_total_bytes),
-            ("fmt_l1_addr", fmt_l1_addr),
         ]
 
+        # TRISC args
         trisc_named_args = [
             ("cb_in0", cb_in0),
             ("cb_in1", cb_in1),
@@ -295,6 +388,44 @@ class DRAMStreamingMatmulCompressed:
         ]
 
         KERNEL_PATH = "models/demos/deepseek_v3_b1/micro_ops/dram_streaming_matmul_compressed/kernels/dram_streaming_matmul_compressed_kernel.cpp"
+
+        per_core_descriptors = [
+            PerCoreCompileTimeDescriptor(
+                named_compile_time_arg="bank_id",
+                core_values=bank_id_core_values,
+                other_value=0,
+            ),
+            PerCoreCompileTimeDescriptor(
+                named_compile_time_arg="vc",
+                core_values=vc_core_values,
+                other_value=0,
+            ),
+            PerCoreCompileTimeDescriptor(
+                named_compile_time_arg="per_core_n",
+                core_values=per_core_n_core_values,
+                other_value=0,
+            ),
+            PerCoreCompileTimeDescriptor(
+                named_compile_time_arg="dram_start_offset",
+                core_values=dram_start_offset_core_values,
+                other_value=0,
+            ),
+            PerCoreCompileTimeDescriptor(
+                named_compile_time_arg="core_in_bank_idx",
+                core_values=core_in_bank_idx_core_values,
+                other_value=0,
+            ),
+            PerCoreCompileTimeDescriptor(
+                named_compile_time_arg="next_core_noc_x",
+                core_values=next_core_noc_x_core_values,
+                other_value=0,
+            ),
+            PerCoreCompileTimeDescriptor(
+                named_compile_time_arg="next_core_noc_y",
+                core_values=next_core_noc_y_core_values,
+                other_value=0,
+            ),
+        ]
 
         unified_kernel = UnifiedKernelDescriptor(
             kernel_source=KERNEL_PATH,
@@ -316,26 +447,15 @@ class DRAMStreamingMatmulCompressed:
                     other_value=0,
                 ),
             ],
-            per_core_compile_time_descriptors=[
-                PerCoreCompileTimeDescriptor(
-                    named_compile_time_arg="bank_id",
-                    core_values=bank_id_core_values,
-                    other_value=0,
-                ),
-                PerCoreCompileTimeDescriptor(
-                    named_compile_time_arg="vc",
-                    core_values=vc_core_values,
-                    other_value=0,
-                ),
-            ],
+            per_core_compile_time_descriptors=per_core_descriptors,
         )
 
         kernel_descriptors = unified_kernel.get_kernel_descriptors()
 
         program_descriptor = ttnn.ProgramDescriptor(
             kernels=kernel_descriptors.kernels,
-            cbs=[cb0_desc, cb1_desc, cb2_desc],
-            semaphores=[],
+            cbs=cbs,
+            semaphores=semaphores,
         )
 
         io_tensors = [input_a, data_tensor, output_tensor, meta_tensor, fmt_tensor]

--- a/models/demos/deepseek_v3_b1/micro_ops/matmul_custom_compressed/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/matmul_custom_compressed/op.py
@@ -44,9 +44,12 @@ _CB_ADDR_SHIFT = 4  # CIRCULAR_BUFFER_COMPUTE_ADDR_SHIFT for TRISC on Blackhole
 # MEM_MAILBOX_END = MEM_MAILBOX_BASE(96) + MEM_MAILBOX_SIZE(12896) = 12992
 _MEM_ZEROS_BASE = 12992
 _ZEROS_ADDR_SHIFTED = _MEM_ZEROS_BASE >> _CB_ADDR_SHIFT  # 812
+_ZERO_TILE_SENTINEL = 0xFFFFFF  # Sentinel for zero tiles in relative-address mode (DRAM streaming)
 
 
-def pack_tile_pairs(assignment_flat: np.ndarray, base_addr_shifted: int) -> list[int]:
+def pack_tile_pairs(
+    assignment_flat: np.ndarray, base_addr_shifted: int, zero_tile_addr: int = _ZEROS_ADDR_SHIFTED
+) -> list[int]:
     """Pack per-pair metadata as two uint32s: lo=[addr0:24|fmt0:8], hi=[addr1:24|fmt1:8].
 
     Kernel loads both uint32s per pair (adjacent in memory). Each uint32 has the
@@ -55,6 +58,8 @@ def pack_tile_pairs(assignment_flat: np.ndarray, base_addr_shifted: int) -> list
     Args:
         assignment_flat: 1D array of format indices (0=bfp8, 1=bfp4, 2=bfp2, 3=bfp0).
         base_addr_shifted: THCON-shifted base address of the weight shard (buffer_address >> 4).
+        zero_tile_addr: Address to use for zero tiles (bfp0). Defaults to _ZEROS_ADDR_SHIFTED.
+            Use _ZERO_TILE_SENTINEL for relative-address mode (DRAM streaming).
 
     Returns:
         List of uint32, two per pair (interleaved: info0, info1, info0, info1, ...).
@@ -66,7 +71,7 @@ def pack_tile_pairs(assignment_flat: np.ndarray, base_addr_shifted: int) -> list
         a = int(assignment_flat[i])
         if a == 3:  # bfp0 / zero tile
             fmt = _DATA_FORMATS[2]  # bfp2 format for zero-tile decode
-            addr = _ZEROS_ADDR_SHIFTED
+            addr = zero_tile_addr
         else:
             fmt = _DATA_FORMATS[a]
             addr = base_addr_shifted + cum_offset_shifted

--- a/models/demos/deepseek_v3_b1/micro_ops/matmul_custom_compressed/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/matmul_custom_compressed/op.py
@@ -44,7 +44,6 @@ _CB_ADDR_SHIFT = 4  # CIRCULAR_BUFFER_COMPUTE_ADDR_SHIFT for TRISC on Blackhole
 # MEM_MAILBOX_END = MEM_MAILBOX_BASE(96) + MEM_MAILBOX_SIZE(12896) = 12992
 _MEM_ZEROS_BASE = 12992
 _ZEROS_ADDR_SHIFTED = _MEM_ZEROS_BASE >> _CB_ADDR_SHIFT  # 812
-_ZERO_TILE_SENTINEL = 0xFFFFFF  # Sentinel for zero tiles in relative-address mode (DRAM streaming)
 
 
 def pack_tile_pairs(
@@ -59,7 +58,7 @@ def pack_tile_pairs(
         assignment_flat: 1D array of format indices (0=bfp8, 1=bfp4, 2=bfp2, 3=bfp0).
         base_addr_shifted: THCON-shifted base address of the weight shard (buffer_address >> 4).
         zero_tile_addr: Address to use for zero tiles (bfp0). Defaults to _ZEROS_ADDR_SHIFTED.
-            Use _ZERO_TILE_SENTINEL for relative-address mode (DRAM streaming).
+            Use 0xFFFFFF for relative-address mode (DRAM streaming).
 
     Returns:
         List of uint32, two per pair (interleaved: info0, info1, info0, info1, ...).

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_dram_matmul_custom_compressed.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_dram_matmul_custom_compressed.py
@@ -39,6 +39,7 @@ def _run_dram_matmul_custom_compressed(
     N,
     formats,
     subblock_k=None,
+    cores_per_bank=1,
     threshold=0.993,
     pcc_threshold=0.98,
 ):
@@ -51,18 +52,26 @@ def _run_dram_matmul_custom_compressed(
     tile_w = 32
 
     # Get DRAM bank grid and compute cores
-    compute_cores_list = device.get_optimal_dram_bank_to_logical_worker_assignment(ttnn.NOC.NOC_0)
-    num_cores = len(compute_cores_list)
-    num_banks = device.dram_grid_size().x
-    assert num_cores == num_banks, f"num_cores ({num_cores}) != num_banks ({num_banks})"
+    primary_cores_list = device.get_optimal_dram_bank_to_logical_worker_assignment(ttnn.NOC.NOC_0)
+    num_banks = len(primary_cores_list)
+    assert (
+        num_banks == device.dram_grid_size().x
+    ), f"num_banks ({num_banks}) != dram_grid_size ({device.dram_grid_size().x})"
 
-    # Pad N to align with DRAM banks
-    n_padded = pad_to_dram_banks(N, tile_w, tile_w * num_banks)
-    per_core_N = n_padded // num_banks
+    # Build expanded compute core list: primary + partner cores
+    compute_cores_list = []
+    for primary_core in primary_cores_list:
+        for offset in range(cores_per_bank):
+            compute_cores_list.append(ttnn.CoreCoord(primary_core.x + offset, primary_core.y))
+    num_cores = len(compute_cores_list)
+
+    # Pad N to align with DRAM banks (total N per bank must be divisible by cores_per_bank)
+    n_padded = pad_to_dram_banks(N, tile_w, tile_w * num_banks * cores_per_bank)
+    per_core_N = n_padded // (num_banks * cores_per_bank)
 
     logger.info(
         f"DRAM compressed matmul: M={M}, K={K}, N={N}, n_padded={n_padded}, "
-        f"per_core_N={per_core_N}, num_cores={num_cores}"
+        f"per_core_N={per_core_N}, num_cores={num_cores}, cores_per_bank={cores_per_bank}"
     )
 
     Kt = K // tile_w
@@ -110,7 +119,8 @@ def _run_dram_matmul_custom_compressed(
             )
         ]
     )
-    b_shard_spec = ttnn.ShardSpec(dram_grid, [K, per_core_N], ttnn.ShardOrientation.ROW_MAJOR)
+    total_N_per_bank = per_core_N * cores_per_bank
+    b_shard_spec = ttnn.ShardSpec(dram_grid, [K, total_N_per_bank], ttnn.ShardOrientation.ROW_MAJOR)
     b_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, b_shard_spec)
 
     ct = CompressedTensor.from_torch(torch_b_shuffled, assigner, device=device, memory_config=b_mem_config)
@@ -160,6 +170,7 @@ def _run_dram_matmul_custom_compressed(
         ct,
         ttnn_output,
         subblock_k=subblock_k,
+        cores_per_bank=cores_per_bank,
     )
 
     output_torch = ttnn.to_torch(ttnn_result)
@@ -208,3 +219,31 @@ def test_dram_matmul_compressed_mixed(device):
 def test_dram_matmul_compressed_reversed_shape(device):
     """[1, 2048] x [2048, 7168], bfp8+bfp4. Transposed DeepSeek shape."""
     _run_dram_matmul_custom_compressed(device, 1, 2048, 7168, formats=["bfp8", "bfp4"])
+
+
+# --- Multi-core per bank tests ---
+
+
+def test_dram_matmul_compressed_2cores_small_bfp8(device):
+    """[1, 64] x [64, N_padded], bfp8 only, 2 cores per bank."""
+    _run_dram_matmul_custom_compressed(device, 1, 64, 64, formats=["bfp8"], subblock_k=2, cores_per_bank=2)
+
+
+def test_dram_matmul_compressed_2cores_bfp4(device):
+    """[1, 7168] x [7168, 2048], bfp4 only, 2 cores per bank."""
+    _run_dram_matmul_custom_compressed(device, 1, 7168, 2048, formats=["bfp4"], cores_per_bank=2)
+
+
+def test_dram_matmul_compressed_2cores_mixed(device):
+    """[1, 7168] x [7168, 2048], mixed bfp4+bfp2, 2 cores per bank."""
+    _run_dram_matmul_custom_compressed(device, 1, 7168, 2048, formats=["bfp4", "bfp2"], cores_per_bank=2)
+
+
+def test_dram_matmul_compressed_4cores_bfp4(device):
+    """[1, 7168] x [7168, 2048], bfp4 only, 4 cores per bank."""
+    _run_dram_matmul_custom_compressed(device, 1, 7168, 2048, formats=["bfp4"], cores_per_bank=4)
+
+
+def test_dram_matmul_compressed_4cores_mixed(device):
+    """[1, 7168] x [7168, 2048], mixed bfp4+bfp2, 2 cores per bank."""
+    _run_dram_matmul_custom_compressed(device, 1, 7168, 2048, formats=["bfp4", "bfp2"], cores_per_bank=4)

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_dram_matmul_custom_compressed.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_dram_matmul_custom_compressed.py
@@ -247,3 +247,8 @@ def test_dram_matmul_compressed_4cores_bfp4(device):
 def test_dram_matmul_compressed_4cores_mixed(device):
     """[1, 7168] x [7168, 2048], mixed bfp4+bfp2, 2 cores per bank."""
     _run_dram_matmul_custom_compressed(device, 1, 7168, 2048, formats=["bfp4", "bfp2"], cores_per_bank=4)
+
+
+def test_dram_matmul_compressed_4cores_mixed_bfp024(device):
+    """[1, 7168] x [7168, 2048], mixed bfp4+bfp2, 2 cores per bank."""
+    _run_dram_matmul_custom_compressed(device, 1, 7168, 2048, formats=["bfp4", "bfp2", "bfp0"], cores_per_bank=4)

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_dram_matmul_custom_compressed.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_dram_matmul_custom_compressed.py
@@ -1,0 +1,210 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+DRAM Streaming Matmul with Compressed Weights - Tests
+
+Tests the combined DRAM streaming + compressed tensor matmul where:
+- Input A is REPLICATED on compute cores (each core has full [M, K])
+- Input B (compressed weights) is WIDTH_SHARDED in DRAM with mixed BFP formats
+- Output is WIDTH_SHARDED in L1 on compute cores
+
+Key difference from test_matmul_custom_compressed.py (L1 version):
+B lives in DRAM and is streamed in variable-size subblocks.
+"""
+
+import torch
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import comp_pcc
+from models.demos.deepseek_v3_b1.compressed_tensor import CompressedTensor, CompressedTensorAssigner
+from models.demos.deepseek_v3_b1.micro_ops.dram_streaming_matmul_compressed.op import DRAMStreamingMatmulCompressed
+from models.demos.deepseek_v3_b1.tests.unit_tests.test_dram_streaming_matmul import shuffle_tensor_tiles
+from models.demos.deepseek_v3_b1.tests.unit_tests.test_eltwise_add_compressed import scale_tiles_for_mixed_formats
+
+
+def pad_to_dram_banks(num, tile_w, lcm):
+    """Pad number to be aligned with DRAM banks."""
+    remainder = num % lcm
+    if remainder == 0:
+        return num
+    return num + (lcm - remainder)
+
+
+def _run_dram_matmul_custom_compressed(
+    device,
+    M,
+    K,
+    N,
+    formats,
+    subblock_k=None,
+    threshold=0.993,
+    pcc_threshold=0.98,
+):
+    """Helper: run DRAM streaming compressed A @ decompress(B_compressed).
+
+    B [K, N] is WIDTH_SHARDED in DRAM across DRAM banks.
+    A [M, K] is replicated on compute cores.
+    Output [M, N] is WIDTH_SHARDED on compute cores.
+    """
+    tile_w = 32
+
+    # Get DRAM bank grid and compute cores
+    compute_cores_list = device.get_optimal_dram_bank_to_logical_worker_assignment(ttnn.NOC.NOC_0)
+    num_cores = len(compute_cores_list)
+    num_banks = device.dram_grid_size().x
+    assert num_cores == num_banks, f"num_cores ({num_cores}) != num_banks ({num_banks})"
+
+    # Pad N to align with DRAM banks
+    n_padded = pad_to_dram_banks(N, tile_w, tile_w * num_banks)
+    per_core_N = n_padded // num_banks
+
+    logger.info(
+        f"DRAM compressed matmul: M={M}, K={K}, N={N}, n_padded={n_padded}, "
+        f"per_core_N={per_core_N}, num_cores={num_cores}"
+    )
+
+    Kt = K // tile_w
+    if subblock_k is None:
+        # Default: use K/4 for large K, full K for small K
+        if Kt > 8:
+            subblock_k = Kt // 4
+        else:
+            subblock_k = Kt
+    # Ensure subblock_k is even
+    if subblock_k % 2 != 0:
+        subblock_k = max(2, subblock_k - 1)
+    assert Kt % subblock_k == 0, f"Kt ({Kt}) must be divisible by subblock_k ({subblock_k})"
+    num_subblocks_k = Kt // subblock_k
+
+    logger.info(f"Kt={Kt}, subblock_k={subblock_k}, num_subblocks_k={num_subblocks_k}")
+
+    # Build CoreRangeSet for compute cores
+    compute_core_grid = ttnn.CoreRangeSet(
+        [ttnn.CoreRange(ttnn.CoreCoord(c.x, c.y), ttnn.CoreCoord(c.x, c.y)) for c in compute_cores_list]
+    )
+
+    # Create test data
+    torch.manual_seed(0)
+    torch_a = torch.randn((M, K), dtype=torch.bfloat16)
+    torch_b = torch.randn((K, n_padded)).float()
+    scale_tiles_for_mixed_formats(torch_b, formats)
+
+    # Shuffle torch_b to column-major tile order within each DRAM shard.
+    # DRAM streaming reads K tiles contiguously per N column, but ttnn stores
+    # tiles row-major. Pre-shuffling ensures the compressed data in DRAM is in
+    # the order the kernel expects.
+    torch_b_shuffled = shuffle_tensor_tiles(torch_b, tile_w, num_banks)
+
+    # Create CompressedTensor in DRAM from the shuffled tensor
+    bfp0_mae = 1e-3 if "bfp0" in formats else 0.01
+    assigner = CompressedTensorAssigner(metric="pcc", threshold=threshold, formats=formats, bfp0_mae_threshold=bfp0_mae)
+
+    # DRAM bank grid for B tensor
+    dram_grid = ttnn.CoreRangeSet(
+        [
+            ttnn.CoreRange(
+                ttnn.CoreCoord(0, 0),
+                ttnn.CoreCoord(device.dram_grid_size().x - 1, device.dram_grid_size().y - 1),
+            )
+        ]
+    )
+    b_shard_spec = ttnn.ShardSpec(dram_grid, [K, per_core_N], ttnn.ShardOrientation.ROW_MAJOR)
+    b_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, b_shard_spec)
+
+    ct = CompressedTensor.from_torch(torch_b_shuffled, assigner, device=device, memory_config=b_mem_config)
+
+    logger.info(f"DRAM compressed B: {ct}")
+    logger.info(f"Tile counts: {ct.tile_counts}")
+
+    # Verify all requested formats are used
+    counts = ct.tile_counts
+    for fmt in formats:
+        assert counts.get(fmt, 0) > 0, f"Expected tiles with format {fmt}, got counts: {counts}"
+
+    # Golden: A @ B (original unshuffled, unquantized)
+    # PCC threshold accounts for BFP quantization error.
+    torch_expected = (torch_a.float() @ torch_b.float()).bfloat16()
+
+    # Input A — replicated: HEIGHT_SHARD so each compute core gets [M, K]
+    a_tile = ttnn.Tile([M, tile_w])
+    torch_a_replicated = torch_a.repeat(num_cores, 1)  # [M*num_cores, K]
+    a_shard_spec = ttnn.ShardSpec(compute_core_grid, [M, K], ttnn.ShardOrientation.ROW_MAJOR)
+    a_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, a_shard_spec)
+    ttnn_a = ttnn.from_torch(
+        torch_a_replicated,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=a_mem_config,
+        tile=a_tile,
+    )
+
+    # Output — WIDTH_SHARDED on compute cores
+    out_tile = ttnn.Tile([M, tile_w])
+    out_shard_spec = ttnn.ShardSpec(compute_core_grid, [M, per_core_N], ttnn.ShardOrientation.ROW_MAJOR)
+    out_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, out_shard_spec)
+    ttnn_output = ttnn.from_torch(
+        torch.zeros((M, n_padded), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=out_mem_config,
+        tile=out_tile,
+    )
+
+    # Run DRAM streaming compressed matmul
+    ttnn_result = DRAMStreamingMatmulCompressed.op(
+        ttnn_a,
+        ct,
+        ttnn_output,
+        subblock_k=subblock_k,
+    )
+
+    output_torch = ttnn.to_torch(ttnn_result)
+    # Slice to original N if padded
+    if n_padded != N:
+        output_torch = output_torch[..., :N]
+        torch_expected = torch_expected[..., :N]
+
+    assert (
+        output_torch.shape == torch_expected.shape
+    ), f"Shape mismatch: got {output_torch.shape}, expected {torch_expected.shape}"
+
+    passing, pcc_message = comp_pcc(torch_expected, output_torch, pcc_threshold)
+    logger.info(pcc_message)
+    assert passing, pcc_message
+
+
+# --- Basic tests ---
+
+
+def test_dram_matmul_compressed_small_bfp8(device):
+    """[1, 64] x [64, N_padded], bfp8 only. K=2 tiles."""
+    _run_dram_matmul_custom_compressed(device, 1, 64, 64, formats=["bfp8"], subblock_k=2)
+
+
+def test_dram_matmul_compressed_multi_n_bfp8(device):
+    """[1, 128] x [128, N_padded], bfp8 only. Kt=4, single subblock, multi-N columns."""
+    _run_dram_matmul_custom_compressed(device, 1, 128, 256, formats=["bfp8"], subblock_k=4)
+
+
+def test_dram_matmul_compressed_multi_subblock_bfp8(device):
+    """[1, 128] x [128, 64], bfp8 only. Kt=4, subblock_k=2, 2 subblocks, single N column."""
+    _run_dram_matmul_custom_compressed(device, 1, 128, 256, formats=["bfp8"], subblock_k=2)
+
+
+def test_dram_matmul_compressed_bfp8(device):
+    """[1, 7168] x [7168, 2048], bfp8 only. DeepSeek shape."""
+    _run_dram_matmul_custom_compressed(device, 1, 7168, 2048, formats=["bfp8"])
+
+
+def test_dram_matmul_compressed_mixed(device):
+    """[1, 7168] x [7168, 2048], mixed bfp8+bfp4."""
+    _run_dram_matmul_custom_compressed(device, 1, 7168, 2048, formats=["bfp8", "bfp4"])
+
+
+def test_dram_matmul_compressed_reversed_shape(device):
+    """[1, 2048] x [2048, 7168], bfp8+bfp4. Transposed DeepSeek shape."""
+    _run_dram_matmul_custom_compressed(device, 1, 2048, 7168, formats=["bfp8", "bfp4"])

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_dram_streaming_matmul.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_dram_streaming_matmul.py
@@ -130,7 +130,7 @@ def test_dram_streaming_matmul(device, k, n, m, fused_activation):
     """
 
     # Use 100 iterations for m=1 to stress-test CB boundary wrapping, 1 iteration otherwise
-    num_loop_iters = 1
+    num_loop_iters = 100 if m == 1 else 1
     tile_h = m  # Tile height matches m (1 for tiny tiles, 32 for standard)
     tile_w = 32
 

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_dram_streaming_matmul.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_dram_streaming_matmul.py
@@ -113,9 +113,9 @@ def shuffle_tensor_tiles(tensor, tile_size, num_banks):
     return shuffled
 
 
-@pytest.mark.parametrize("k, n", [(7168, 2048)])
-@pytest.mark.parametrize("m", [1])
-@pytest.mark.parametrize("fused_activation", [None])
+@pytest.mark.parametrize("k, n", [(7168, 2048), (2048, 7168)])
+@pytest.mark.parametrize("m", [1, 4, 8])
+@pytest.mark.parametrize("fused_activation", [None, "silu"])
 def test_dram_streaming_matmul(device, k, n, m, fused_activation):
     """Test simplified DRAM streaming matmul with optional fused activation.
 

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_dram_streaming_matmul.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_dram_streaming_matmul.py
@@ -113,9 +113,9 @@ def shuffle_tensor_tiles(tensor, tile_size, num_banks):
     return shuffled
 
 
-@pytest.mark.parametrize("k, n", [(7168, 2048), (2048, 7168)])
-@pytest.mark.parametrize("m", [1, 4, 8])
-@pytest.mark.parametrize("fused_activation", [None, "silu"])
+@pytest.mark.parametrize("k, n", [(7168, 2048)])
+@pytest.mark.parametrize("m", [1])
+@pytest.mark.parametrize("fused_activation", [None])
 def test_dram_streaming_matmul(device, k, n, m, fused_activation):
     """Test simplified DRAM streaming matmul with optional fused activation.
 
@@ -130,8 +130,7 @@ def test_dram_streaming_matmul(device, k, n, m, fused_activation):
     """
 
     # Use 100 iterations for m=1 to stress-test CB boundary wrapping, 1 iteration otherwise
-    num_loop_iters = 100 if m == 1 else 1
-
+    num_loop_iters = 1
     tile_h = m  # Tile height matches m (1 for tiny tiles, 32 for standard)
     tile_w = 32
 

--- a/models/demos/deepseek_v3_b1/unified_kernels/dram_streaming_matmul_compressed.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/dram_streaming_matmul_compressed.hpp
@@ -242,7 +242,7 @@ struct DRAMStreamingMatmulCompressed {
 
             reconfig_data_format<false, true>(CTArgs::cb_in1, CTArgs::cb_in0);
             pack_reconfig_data_format<true>(CTArgs::cb_out);
-            compressed::custom_mm_compressed_block_init_short<split_acc, dense_packing>(
+            compressed::custom_mm_compressed_block_init_short<true, 1, split_acc, dense_packing>(
                 CTArgs::cb_in0, CTArgs::cb_in1, CTArgs::cb_out);
 
             cb_wait_front(CTArgs::cb_in0, num_tiles_k);

--- a/models/demos/deepseek_v3_b1/unified_kernels/dram_streaming_matmul_compressed.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/dram_streaming_matmul_compressed.hpp
@@ -36,8 +36,9 @@ namespace deepseek_b1_ops {
 //   No data forwarding between cores — each reads directly from DRAM.
 //   BRISC: no-op. TRISC: compressed matmul (unchanged).
 //
-// When cores_per_bank=1, pipeline_sem_id is unused and the semaphore
-// wait/signal paths compile to no-ops (core_in_bank_idx=0, is_last_in_bank=1).
+// When cores_per_bank=1, pipeline_sem_id does not participate in inter-core
+// pipelining; the NCRISC path performs a degenerate self-signal/self-wait on
+// the semaphore each batch (functionally a no-op, but not compiled away).
 // ============================================================================
 struct DRAMStreamingMatmulCompressed {
     // ========================================================================

--- a/models/demos/deepseek_v3_b1/unified_kernels/dram_streaming_matmul_compressed.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/dram_streaming_matmul_compressed.hpp
@@ -1,0 +1,287 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "kernel_op_api.hpp"
+
+#if defined(COMPILE_FOR_BRISC)
+#include "api/dataflow/dataflow_api.h"
+#elif defined(COMPILE_FOR_NCRISC)
+#include "api/dataflow/dataflow_api.h"
+#elif defined(COMPILE_FOR_TRISC)
+#include <cstdint>
+#include "api/compute/tile_move_copy.h"
+#include "../kernel_includes/tt_metal/include/compute_kernel_api/custom_mm.h"
+#include "../kernel_includes/tt_metal/include/compute_kernel_api/deepseek_compute_kernel_hw_startup.h"
+#include "api/compute/compute_kernel_api.h"
+#include "api/compute/reconfig_data_format.h"
+#include "api/compute/pack.h"
+#include "../kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_custom_mm_compressed_common.h"
+#include "../kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_custom_mm_compressed_runtime.h"
+#endif
+
+namespace deepseek_b1_ops {
+
+// ============================================================================
+// DRAMStreamingMatmulCompressed micro-op
+//
+// Computes: output[1,N] = in0[1,K] @ decompress(in1_compressed[K,N])
+// with in1 streamed from DRAM in variable-size subblocks.
+//
+// CB States:
+//   NCRISC: Streams compressed in1 from DRAM with variable-size reads per
+//           subblock. Block sizes read from L1 metadata tensor.
+//   BRISC: No-op
+//   TRISC: Compressed matmul with per-tile format reconfig, subblock-K
+//          streaming with partial accumulation.
+// ============================================================================
+struct DRAMStreamingMatmulCompressed {
+    // ========================================================================
+    // Compile-time args structs
+    // ========================================================================
+
+    // Reader CTArgs (NCRISC) - DRAM streaming with variable block sizes
+    template <
+        uint32_t cb_in1_,
+        uint32_t cb_out_,
+        uint32_t in1_tensor_addr_,
+        uint32_t subblock_k_,
+        uint32_t per_core_n_,
+        uint32_t out_num_tiles_,
+        uint32_t num_subblocks_k_,
+        uint32_t bank_id_,
+        uint32_t vc_,
+        uint32_t meta_l1_addr_,
+        uint32_t cb_in1_size_bytes_,
+        uint32_t noc_max_page_size_>
+    struct ReaderCTArgs {
+        static constexpr uint32_t cb_in1 = cb_in1_;
+        static constexpr uint32_t cb_out = cb_out_;
+        static constexpr uint32_t in1_tensor_addr = in1_tensor_addr_;
+        static constexpr uint32_t subblock_k = subblock_k_;
+        static constexpr uint32_t per_core_n = per_core_n_;
+        static constexpr uint32_t out_num_tiles = out_num_tiles_;
+        static constexpr uint32_t num_subblocks_k = num_subblocks_k_;
+        static constexpr uint32_t bank_id = bank_id_;
+        static constexpr uint32_t vc = vc_;
+        static constexpr uint32_t meta_l1_addr = meta_l1_addr_;
+        static constexpr uint32_t cb_in1_size_bytes = cb_in1_size_bytes_;
+        static constexpr uint32_t noc_max_page_size = noc_max_page_size_;
+    };
+
+    // Writer CTArgs (BRISC) - no-op
+    struct WriterCTArgs {};
+
+    // Compute CTArgs (TRISC) - compressed matmul with streaming
+    template <
+        uint32_t cb_in0_,
+        uint32_t cb_in1_,
+        uint32_t cb_out_,
+        uint32_t subblock_k_,
+        uint32_t per_core_n_,
+        uint32_t num_subblocks_k_,
+        uint32_t fmt_l1_addr_>
+    struct ComputeCTArgs {
+        static constexpr uint32_t cb_in0 = cb_in0_;
+        static constexpr uint32_t cb_in1 = cb_in1_;
+        static constexpr uint32_t cb_out = cb_out_;
+        static constexpr uint32_t subblock_k = subblock_k_;
+        static constexpr uint32_t per_core_n = per_core_n_;
+        static constexpr uint32_t num_subblocks_k = num_subblocks_k_;
+        static constexpr uint32_t fmt_l1_addr = fmt_l1_addr_;
+    };
+
+    // ========================================================================
+    // Op - the actual operation
+    // ========================================================================
+    template <typename CTArgs, bool IsActiveCore, bool PopIn0 = true>
+    class Op {
+    public:
+        void operator()() {
+            if constexpr (IsActiveCore) {
+                impl();
+            }
+        }
+
+    private:
+        void impl() {
+#if defined(COMPILE_FOR_NCRISC)
+            // ================================================================
+            // NCRISC: Stream compressed in1 from DRAM with variable block sizes
+            //
+            // Metadata tensor layout (per core, uint32 array in L1):
+            //   For each subblock: block_size_bytes (1 uint32)
+            //   Total entries = num_subblocks_k * per_core_n
+            //   Order: for n in per_core_n: for sb_k in num_subblocks_k
+            //
+            // Each subblock is read in chunks of <= noc_max_page_size.
+            // ================================================================
+            constexpr uint32_t num_iterations = CTArgs::num_subblocks_k * CTArgs::per_core_n;
+            constexpr uint32_t dram_bank_id = CTArgs::bank_id;
+            constexpr uint32_t vc = CTArgs::vc;
+            constexpr uint32_t max_page_size = CTArgs::noc_max_page_size;
+
+            const volatile uint32_t* meta_ptr = reinterpret_cast<const volatile uint32_t*>(CTArgs::meta_l1_addr);
+
+            reset_noc_trid_barrier_counter(NOC_CLEAR_OUTSTANDING_REQ_MASK, noc_index);
+
+            uint64_t in1_base_addr = get_noc_addr_from_bank_id<true>(dram_bank_id, CTArgs::in1_tensor_addr);
+            uint32_t l1_write_addr_in1;
+            uint32_t dram_read_offset = 0;
+
+            // Triple-buffering with transaction IDs
+            constexpr uint32_t num_buffers = 3;
+            constexpr uint32_t extra_blocks_in_flight = 1;
+            uint32_t num_free_blocks_in_buffer = num_buffers;
+            uint32_t curr_block_trid = 1;
+            uint32_t block_trid_to_wait = 1;
+
+            // Reserve initial space
+            cb_reserve_back(CTArgs::cb_in1, CTArgs::subblock_k * (extra_blocks_in_flight + 1));
+            l1_write_addr_in1 = get_write_ptr(CTArgs::cb_in1);
+
+            uint32_t cb_in1_base = l1_write_addr_in1;
+            uint32_t cb_in1_end = cb_in1_base + CTArgs::cb_in1_size_bytes;
+
+            // Each CB slot is max_subblock_bytes, matching CB's page_size-based accounting.
+            // Actual compressed data may be smaller, but we snap to slot boundaries.
+            constexpr uint32_t max_subblock_bytes = CTArgs::cb_in1_size_bytes / num_buffers;
+
+            for (uint32_t iter = 0; iter < num_iterations; ++iter) {
+                uint32_t block_size = meta_ptr[iter];
+                uint32_t slot_start = l1_write_addr_in1;
+
+                noc_async_read_set_trid(curr_block_trid);
+
+                uint32_t remaining = block_size;
+                while (remaining > 0) {
+                    uint32_t chunk = (remaining > max_page_size) ? max_page_size : remaining;
+                    noc_async_read_one_packet_set_state<true>(in1_base_addr, chunk, vc);
+                    noc_async_read_one_packet_with_state_with_trid(
+                        in1_base_addr, dram_read_offset, l1_write_addr_in1, curr_block_trid);
+                    dram_read_offset += chunk;
+                    l1_write_addr_in1 += chunk;
+                    remaining -= chunk;
+                }
+
+                // Advance to next CB slot boundary (CB thinks each tile is max_tile_size)
+                l1_write_addr_in1 = slot_start + max_subblock_bytes;
+
+                if (num_free_blocks_in_buffer == num_buffers - extra_blocks_in_flight) {
+                    noc_async_read_barrier_with_trid(block_trid_to_wait);
+                    cb_push_back(CTArgs::cb_in1, CTArgs::subblock_k);
+                    block_trid_to_wait = block_trid_to_wait == num_buffers ? 1 : (block_trid_to_wait + 1);
+                    cb_reserve_back(CTArgs::cb_in1, CTArgs::subblock_k * (extra_blocks_in_flight + 1));
+                } else {
+                    num_free_blocks_in_buffer -= 1;
+                }
+
+                curr_block_trid = (curr_block_trid == num_buffers) ? 1 : (curr_block_trid + 1);
+
+                // Wrap at CB boundary
+                if (l1_write_addr_in1 >= cb_in1_end) {
+                    l1_write_addr_in1 = cb_in1_base;
+                }
+            }
+
+            // Push remaining blocks
+            for (uint32_t i = 0; i < extra_blocks_in_flight; ++i) {
+                noc_async_read_barrier_with_trid(block_trid_to_wait);
+                cb_push_back(CTArgs::cb_in1, CTArgs::subblock_k);
+                block_trid_to_wait = block_trid_to_wait == num_buffers ? 1 : (block_trid_to_wait + 1);
+            }
+
+#elif defined(COMPILE_FOR_TRISC)
+            // ================================================================
+            // TRISC: Compressed matmul with subblock-K streaming
+            //
+            // For each N output column:
+            //   tile_regs_acquire()
+            //   For each K subblock:
+            //     cb_wait_front(cb_in1, subblock_k)  // wait for streamed data
+            //     Run compressed matmul with per-tile format reconfig
+            //     cb_pop_front(cb_in1, subblock_k)
+            //   Pack output
+            //
+            // Format metadata: packed pairs in L1 at fmt_l1_addr.
+            // Layout: per_core_n * num_subblocks_k groups of (subblock_k/2) pairs.
+            // Each pair is [sz1:8 | sz0:8 | fmt1:8 | fmt0:8].
+            // ================================================================
+            constexpr uint32_t num_tiles_k = CTArgs::subblock_k * CTArgs::num_subblocks_k;
+            constexpr bool split_acc = true;
+            constexpr bool dense_packing = false;
+
+            reconfig_data_format<false, true>(CTArgs::cb_in1, CTArgs::cb_in0);
+            pack_reconfig_data_format<true>(CTArgs::cb_out);
+            custom_mm_block_init_short<false, split_acc, dense_packing>(CTArgs::cb_in0, CTArgs::cb_in1, CTArgs::cb_out);
+
+            cb_wait_front(CTArgs::cb_in0, num_tiles_k);
+
+            // Get in0 base address and tile size
+            uint32_t addr_in0 = 0;
+            uint32_t in0_face_r_dim = 0;
+            uint32_t in0_tile_size = 0;
+            UNPACK(({
+                uint32_t in0_id = get_operand_id(CTArgs::cb_in0);
+                addr_in0 = get_local_cb_interface(in0_id).fifo_rd_ptr - 1;
+                in0_face_r_dim = get_operand_face_r_dim(in0_id);
+                in0_tile_size = get_local_cb_interface(in0_id).fifo_page_size;
+            }));
+
+            // Packed pairs metadata pointer
+            const volatile uint32_t* fmt_base_ptr = reinterpret_cast<const volatile uint32_t*>(CTArgs::fmt_l1_addr);
+            constexpr uint32_t pairs_per_subblock = CTArgs::subblock_k / 2;
+
+            uint32_t fmt_pair_offset = 0;
+
+            for (uint32_t n = 0; n < CTArgs::per_core_n; n++) {
+                cb_reserve_back(CTArgs::cb_out, 1);
+                tile_regs_acquire();
+
+                uint32_t addr_in0_subblock = addr_in0;
+
+                for (uint32_t sb_k = 0; sb_k < CTArgs::num_subblocks_k; sb_k++) {
+                    cb_wait_front(CTArgs::cb_in1, CTArgs::subblock_k);
+
+                    // Get in1 read address from CB
+                    uint32_t addr_in1 = 0;
+                    UNPACK(({
+                        uint32_t in1_id = get_operand_id(CTArgs::cb_in1);
+                        addr_in1 = get_local_cb_interface(in1_id).fifo_rd_ptr - 1;
+                    }));
+
+                    const volatile uint32_t* fmt_ptr = fmt_base_ptr + fmt_pair_offset;
+                    uint32_t fmt_addr = reinterpret_cast<uint32_t>(fmt_ptr);
+                    if (sb_k < CTArgs::num_subblocks_k - 1) {
+                        compressed::custom_mm_compressed_block_runtime<CTArgs::subblock_k, 1, false>(
+                            fmt_addr, addr_in0_subblock, addr_in1, in0_face_r_dim, 0);
+                    } else {
+                        compressed::custom_mm_compressed_block_runtime<CTArgs::subblock_k, 1, true>(
+                            fmt_addr, addr_in0_subblock, addr_in1, in0_face_r_dim, 0);
+                    }
+
+                    addr_in0_subblock += CTArgs::subblock_k * in0_tile_size;
+                    fmt_pair_offset += pairs_per_subblock;
+                    cb_pop_front(CTArgs::cb_in1, CTArgs::subblock_k);
+                }
+
+                tile_regs_commit();
+                tile_regs_wait();
+                pack_tile(0, CTArgs::cb_out, 0);
+                tile_regs_release();
+                cb_push_back(CTArgs::cb_out, 1);
+            }
+
+            custom_mm_block_uninit<dense_packing>();
+
+            if constexpr (PopIn0) {
+                cb_pop_front(CTArgs::cb_in0, num_tiles_k);
+            }
+#endif
+        }
+    };  // class Op
+
+};  // struct DRAMStreamingMatmulCompressed
+
+}  // namespace deepseek_b1_ops

--- a/models/demos/deepseek_v3_b1/unified_kernels/dram_streaming_matmul_compressed.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/dram_streaming_matmul_compressed.hpp
@@ -273,21 +273,17 @@ struct DRAMStreamingMatmulCompressed {
                 for (uint32_t sb_k = 0; sb_k < CTArgs::num_subblocks_k; sb_k++) {
                     cb_wait_front(CTArgs::cb_in1, CTArgs::subblock_k);
 
-                    // Get in1 read address from CB (changes per subblock due to triple-buffering)
-                    uint32_t addr_in1 = 0;
-                    UNPACK(({
-                        uint32_t in1_id = get_operand_id(CTArgs::cb_in1);
-                        addr_in1 = get_local_cb_interface(in1_id).fifo_rd_ptr - 1;
-                    }));
-
+                    // Absolute addresses are precomputed in fmt metadata by host
+                    // (CB is tensor-backed so L1 address is known at compile time).
+                    // addr_in1 is unused when RELATIVE_ADDR=false.
                     const volatile uint32_t* fmt_ptr = fmt_base_ptr + fmt_tile_offset;
                     uint32_t fmt_addr = reinterpret_cast<uint32_t>(fmt_ptr);
                     if (sb_k < CTArgs::num_subblocks_k - 1) {
-                        compressed::custom_mm_compressed_block_runtime<CTArgs::subblock_k, 1, false, true>(
-                            fmt_addr, addr_in0_subblock, addr_in1, in0_face_r_dim, 0);
+                        compressed::custom_mm_compressed_block_runtime<CTArgs::subblock_k, 1, false>(
+                            fmt_addr, addr_in0_subblock, 0, in0_face_r_dim, 0);
                     } else {
-                        compressed::custom_mm_compressed_block_runtime<CTArgs::subblock_k, 1, true, true>(
-                            fmt_addr, addr_in0_subblock, addr_in1, in0_face_r_dim, 0);
+                        compressed::custom_mm_compressed_block_runtime<CTArgs::subblock_k, 1, true>(
+                            fmt_addr, addr_in0_subblock, 0, in0_face_r_dim, 0);
                     }
 
                     addr_in0_subblock += CTArgs::subblock_k * in0_tile_size;

--- a/models/demos/deepseek_v3_b1/unified_kernels/dram_streaming_matmul_compressed.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/dram_streaming_matmul_compressed.hpp
@@ -29,19 +29,22 @@ namespace deepseek_b1_ops {
 // Computes: output[1,N] = in0[1,K] @ decompress(in1_compressed[K,N])
 // with in1 streamed from DRAM in variable-size subblocks.
 //
-// CB States:
-//   NCRISC: Streams compressed in1 from DRAM with variable-size reads per
-//           subblock. Block sizes read from L1 metadata tensor.
-//   BRISC: No-op
-//   TRISC: Compressed matmul with per-tile format reconfig, subblock-K
-//          streaming with partial accumulation.
+// Multi-core-per-bank support (cores_per_bank > 1):
+//   Each core reads its own portion of N columns from the same DRAM bank.
+//   Pipelined access: core 0 reads first, signals core 1 after last request
+//   is sent, core 1 waits then reads from its offset, signals core 2, etc.
+//   No data forwarding between cores — each reads directly from DRAM.
+//   BRISC: no-op. TRISC: compressed matmul (unchanged).
+//
+// When cores_per_bank=1, pipeline_sem_id is unused and the semaphore
+// wait/signal paths compile to no-ops (core_in_bank_idx=0, is_last_in_bank=1).
 // ============================================================================
 struct DRAMStreamingMatmulCompressed {
     // ========================================================================
     // Compile-time args structs
     // ========================================================================
 
-    // Reader CTArgs (NCRISC) - DRAM streaming with variable block sizes
+    // Reader CTArgs (NCRISC) - DRAM streaming with pipelined bank access
     template <
         uint32_t cb_in1_,
         uint32_t cb_out_,
@@ -54,7 +57,12 @@ struct DRAMStreamingMatmulCompressed {
         uint32_t vc_,
         uint32_t meta_l1_addr_,
         uint32_t cb_in1_size_bytes_,
-        uint32_t noc_max_page_size_>
+        uint32_t noc_max_page_size_,
+        uint32_t dram_start_offset_,
+        uint32_t core_in_bank_idx_,
+        uint32_t pipeline_sem_id_,
+        uint32_t next_core_noc_x_,
+        uint32_t next_core_noc_y_>
     struct ReaderCTArgs {
         static constexpr uint32_t cb_in1 = cb_in1_;
         static constexpr uint32_t cb_out = cb_out_;
@@ -68,6 +76,11 @@ struct DRAMStreamingMatmulCompressed {
         static constexpr uint32_t meta_l1_addr = meta_l1_addr_;
         static constexpr uint32_t cb_in1_size_bytes = cb_in1_size_bytes_;
         static constexpr uint32_t noc_max_page_size = noc_max_page_size_;
+        static constexpr uint32_t dram_start_offset = dram_start_offset_;
+        static constexpr uint32_t core_in_bank_idx = core_in_bank_idx_;
+        static constexpr uint32_t pipeline_sem_id = pipeline_sem_id_;
+        static constexpr uint32_t next_core_noc_x = next_core_noc_x_;
+        static constexpr uint32_t next_core_noc_y = next_core_noc_y_;
     };
 
     // Writer CTArgs (BRISC) - no-op
@@ -108,14 +121,15 @@ struct DRAMStreamingMatmulCompressed {
         void impl() {
 #if defined(COMPILE_FOR_NCRISC)
             // ================================================================
-            // NCRISC: Stream compressed in1 from DRAM with variable block sizes
+            // NCRISC: Stream compressed in1 from DRAM with pipelined bank access.
             //
-            // Metadata tensor layout (per core, uint32 array in L1):
-            //   For each subblock: block_size_bytes (1 uint32)
-            //   Total entries = num_subblocks_k * per_core_n
-            //   Order: for n in per_core_n: for sb_k in num_subblocks_k
+            // Pipeline protocol (ring topology):
+            //   Cores sharing a DRAM bank take turns reading in chunks of
+            //   num_buffers subblocks. After issuing num_buffers reads, a core
+            //   signals the next core and waits for its turn again.
+            //   Last core wraps back to first core.
             //
-            // Each subblock is read in chunks of <= noc_max_page_size.
+            // Each core reads per_core_n columns starting at dram_start_offset.
             // ================================================================
             constexpr uint32_t num_iterations = CTArgs::num_subblocks_k * CTArgs::per_core_n;
             constexpr uint32_t dram_bank_id = CTArgs::bank_id;
@@ -124,11 +138,23 @@ struct DRAMStreamingMatmulCompressed {
 
             const volatile uint32_t* meta_ptr = reinterpret_cast<const volatile uint32_t*>(CTArgs::meta_l1_addr);
 
+            volatile tt_l1_ptr uint32_t* sem_ptr =
+                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(CTArgs::pipeline_sem_id));
+            uint32_t next_sem_l1 = get_semaphore(CTArgs::pipeline_sem_id);
+            uint64_t next_noc_addr = get_noc_addr(CTArgs::next_core_noc_x, CTArgs::next_core_noc_y, 0);
+            uint64_t next_sem_noc_addr = next_noc_addr | (uint64_t)next_sem_l1;
+
+            // --- Wait for previous core before first batch ---
+            if constexpr (CTArgs::core_in_bank_idx > 0) {
+                noc_semaphore_wait(sem_ptr, 1);
+                noc_semaphore_set(sem_ptr, 0);
+            }
+
             reset_noc_trid_barrier_counter(NOC_CLEAR_OUTSTANDING_REQ_MASK, noc_index);
 
             uint64_t in1_base_addr = get_noc_addr_from_bank_id<true>(dram_bank_id, CTArgs::in1_tensor_addr);
             uint32_t l1_write_addr_in1;
-            uint32_t dram_read_offset = 0;
+            uint32_t dram_read_offset = CTArgs::dram_start_offset;
 
             // Triple-buffering with transaction IDs
             constexpr uint32_t num_buffers = 3;
@@ -136,7 +162,6 @@ struct DRAMStreamingMatmulCompressed {
             uint32_t num_free_blocks_in_buffer = num_buffers;
             uint32_t curr_block_trid = 1;
             uint32_t block_trid_to_wait = 1;
-
             // Reserve initial space
             cb_reserve_back(CTArgs::cb_in1, CTArgs::subblock_k * (extra_blocks_in_flight + 1));
             l1_write_addr_in1 = get_write_ptr(CTArgs::cb_in1);
@@ -144,44 +169,58 @@ struct DRAMStreamingMatmulCompressed {
             uint32_t cb_in1_base = l1_write_addr_in1;
             uint32_t cb_in1_end = cb_in1_base + CTArgs::cb_in1_size_bytes;
 
-            // Each CB slot is max_subblock_bytes, matching CB's page_size-based accounting.
-            // Actual compressed data may be smaller, but we snap to slot boundaries.
             constexpr uint32_t max_subblock_bytes = CTArgs::cb_in1_size_bytes / num_buffers;
 
-            for (uint32_t iter = 0; iter < num_iterations; ++iter) {
-                uint32_t block_size = meta_ptr[iter];
-                uint32_t slot_start = l1_write_addr_in1;
+            uint32_t iter = 0;
+            while (iter < num_iterations) {
+                uint32_t batch_size = std::min(num_buffers, num_iterations - iter);
 
-                noc_async_read_set_trid(curr_block_trid);
+                for (uint32_t b = 0; b < batch_size; b++) {
+                    uint32_t block_size = meta_ptr[iter];
+                    uint32_t slot_start = l1_write_addr_in1;
 
-                uint32_t remaining = block_size;
-                while (remaining > 0) {
-                    uint32_t chunk = (remaining > max_page_size) ? max_page_size : remaining;
-                    noc_async_read_one_packet_set_state<true>(in1_base_addr, chunk, vc);
-                    noc_async_read_one_packet_with_state_with_trid(
-                        in1_base_addr, dram_read_offset, l1_write_addr_in1, curr_block_trid);
-                    dram_read_offset += chunk;
-                    l1_write_addr_in1 += chunk;
-                    remaining -= chunk;
+                    noc_async_read_set_trid(curr_block_trid);
+
+                    uint32_t remaining = block_size;
+                    while (remaining > 0) {
+                        uint32_t chunk = (remaining > max_page_size) ? max_page_size : remaining;
+                        noc_async_read_one_packet_set_state<true>(in1_base_addr, chunk, vc);
+                        noc_async_read_one_packet_with_state_with_trid(
+                            in1_base_addr, dram_read_offset, l1_write_addr_in1, curr_block_trid);
+                        dram_read_offset += chunk;
+                        l1_write_addr_in1 += chunk;
+                        remaining -= chunk;
+                    }
+
+                    l1_write_addr_in1 = slot_start + max_subblock_bytes;
+
+                    // Signal next core after last read in batch, before barrier
+                    if (b == batch_size - 1) {
+                        noc_semaphore_inc(next_sem_noc_addr, 1);
+                    }
+
+                    if (num_free_blocks_in_buffer == num_buffers - extra_blocks_in_flight) {
+                        noc_async_read_barrier_with_trid(block_trid_to_wait);
+                        cb_push_back(CTArgs::cb_in1, CTArgs::subblock_k);
+                        block_trid_to_wait = block_trid_to_wait == num_buffers ? 1 : (block_trid_to_wait + 1);
+                        cb_reserve_back(CTArgs::cb_in1, CTArgs::subblock_k * (extra_blocks_in_flight + 1));
+                    } else {
+                        num_free_blocks_in_buffer -= 1;
+                    }
+
+                    curr_block_trid = (curr_block_trid == num_buffers) ? 1 : (curr_block_trid + 1);
+
+                    if (l1_write_addr_in1 >= cb_in1_end) {
+                        l1_write_addr_in1 = cb_in1_base;
+                    }
+
+                    iter++;
                 }
 
-                // Advance to next CB slot boundary (CB thinks each tile is max_tile_size)
-                l1_write_addr_in1 = slot_start + max_subblock_bytes;
-
-                if (num_free_blocks_in_buffer == num_buffers - extra_blocks_in_flight) {
-                    noc_async_read_barrier_with_trid(block_trid_to_wait);
-                    cb_push_back(CTArgs::cb_in1, CTArgs::subblock_k);
-                    block_trid_to_wait = block_trid_to_wait == num_buffers ? 1 : (block_trid_to_wait + 1);
-                    cb_reserve_back(CTArgs::cb_in1, CTArgs::subblock_k * (extra_blocks_in_flight + 1));
-                } else {
-                    num_free_blocks_in_buffer -= 1;
-                }
-
-                curr_block_trid = (curr_block_trid == num_buffers) ? 1 : (curr_block_trid + 1);
-
-                // Wrap at CB boundary
-                if (l1_write_addr_in1 >= cb_in1_end) {
-                    l1_write_addr_in1 = cb_in1_base;
+                // Wait for our turn again before next batch
+                if (iter < num_iterations) {
+                    noc_semaphore_wait(sem_ptr, 1);
+                    noc_semaphore_set(sem_ptr, 0);
                 }
             }
 
@@ -194,20 +233,8 @@ struct DRAMStreamingMatmulCompressed {
 
 #elif defined(COMPILE_FOR_TRISC)
             // ================================================================
-            // TRISC: Compressed matmul with subblock-K streaming
-            //
-            // For each N output column:
-            //   tile_regs_acquire()
-            //   For each K subblock:
-            //     cb_wait_front(cb_in1, subblock_k)  // wait for streamed data
-            //     Run compressed matmul with per-tile format reconfig
-            //     cb_pop_front(cb_in1, subblock_k)
-            //   Pack output
-            //
-            // Format metadata: per-tile info in L1 at fmt_l1_addr.
-            // Layout: per_core_n * num_subblocks_k groups of subblock_k tiles.
-            // Each tile is [relative_offset:24 | fmt:8].
-            // Relative offsets are within each subblock; the kernel adds addr_in1.
+            // TRISC: Compressed matmul with subblock-K streaming.
+            // Identical on all cores — each consumes from its own cb_in1.
             // ================================================================
             constexpr uint32_t num_tiles_k = CTArgs::subblock_k * CTArgs::num_subblocks_k;
             constexpr bool split_acc = true;

--- a/models/demos/deepseek_v3_b1/unified_kernels/dram_streaming_matmul_compressed.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/dram_streaming_matmul_compressed.hpp
@@ -204,9 +204,10 @@ struct DRAMStreamingMatmulCompressed {
             //     cb_pop_front(cb_in1, subblock_k)
             //   Pack output
             //
-            // Format metadata: packed pairs in L1 at fmt_l1_addr.
-            // Layout: per_core_n * num_subblocks_k groups of (subblock_k/2) pairs.
-            // Each pair is [sz1:8 | sz0:8 | fmt1:8 | fmt0:8].
+            // Format metadata: per-tile info in L1 at fmt_l1_addr.
+            // Layout: per_core_n * num_subblocks_k groups of subblock_k tiles.
+            // Each tile is [relative_offset:24 | fmt:8].
+            // Relative offsets are within each subblock; the kernel adds addr_in1.
             // ================================================================
             constexpr uint32_t num_tiles_k = CTArgs::subblock_k * CTArgs::num_subblocks_k;
             constexpr bool split_acc = true;
@@ -214,7 +215,8 @@ struct DRAMStreamingMatmulCompressed {
 
             reconfig_data_format<false, true>(CTArgs::cb_in1, CTArgs::cb_in0);
             pack_reconfig_data_format<true>(CTArgs::cb_out);
-            custom_mm_block_init_short<false, split_acc, dense_packing>(CTArgs::cb_in0, CTArgs::cb_in1, CTArgs::cb_out);
+            compressed::custom_mm_compressed_block_init_short<split_acc, dense_packing>(
+                CTArgs::cb_in0, CTArgs::cb_in1, CTArgs::cb_out);
 
             cb_wait_front(CTArgs::cb_in0, num_tiles_k);
 
@@ -229,11 +231,11 @@ struct DRAMStreamingMatmulCompressed {
                 in0_tile_size = get_local_cb_interface(in0_id).fifo_page_size;
             }));
 
-            // Packed pairs metadata pointer
+            // Per-tile metadata pointer
             const volatile uint32_t* fmt_base_ptr = reinterpret_cast<const volatile uint32_t*>(CTArgs::fmt_l1_addr);
-            constexpr uint32_t pairs_per_subblock = CTArgs::subblock_k / 2;
+            constexpr uint32_t tiles_per_subblock = CTArgs::subblock_k;
 
-            uint32_t fmt_pair_offset = 0;
+            uint32_t fmt_tile_offset = 0;
 
             for (uint32_t n = 0; n < CTArgs::per_core_n; n++) {
                 cb_reserve_back(CTArgs::cb_out, 1);
@@ -244,25 +246,25 @@ struct DRAMStreamingMatmulCompressed {
                 for (uint32_t sb_k = 0; sb_k < CTArgs::num_subblocks_k; sb_k++) {
                     cb_wait_front(CTArgs::cb_in1, CTArgs::subblock_k);
 
-                    // Get in1 read address from CB
+                    // Get in1 read address from CB (changes per subblock due to triple-buffering)
                     uint32_t addr_in1 = 0;
                     UNPACK(({
                         uint32_t in1_id = get_operand_id(CTArgs::cb_in1);
                         addr_in1 = get_local_cb_interface(in1_id).fifo_rd_ptr - 1;
                     }));
 
-                    const volatile uint32_t* fmt_ptr = fmt_base_ptr + fmt_pair_offset;
+                    const volatile uint32_t* fmt_ptr = fmt_base_ptr + fmt_tile_offset;
                     uint32_t fmt_addr = reinterpret_cast<uint32_t>(fmt_ptr);
                     if (sb_k < CTArgs::num_subblocks_k - 1) {
-                        compressed::custom_mm_compressed_block_runtime<CTArgs::subblock_k, 1, false>(
+                        compressed::custom_mm_compressed_block_runtime<CTArgs::subblock_k, 1, false, true>(
                             fmt_addr, addr_in0_subblock, addr_in1, in0_face_r_dim, 0);
                     } else {
-                        compressed::custom_mm_compressed_block_runtime<CTArgs::subblock_k, 1, true>(
+                        compressed::custom_mm_compressed_block_runtime<CTArgs::subblock_k, 1, true, true>(
                             fmt_addr, addr_in0_subblock, addr_in1, in0_face_r_dim, 0);
                     }
 
                     addr_in0_subblock += CTArgs::subblock_k * in0_tile_size;
-                    fmt_pair_offset += pairs_per_subblock;
+                    fmt_tile_offset += tiles_per_subblock;
                     cb_pop_front(CTArgs::cb_in1, CTArgs::subblock_k);
                 }
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/38745?issue=tenstorrent%7Ctt-metal%7C39982)

### Problem description
DRAM matmul also needs mixed precision support for in1 tensor, similar to SRAM matmul

### What's changed
Record in1 tensor format, and calculate the in1 CB address offset explicitly on host, device side use the format array to get the address offset within the in1 CB.
Add a handshake / token passing mechanism to use more cores to read a DRAM bank, work as follows:
1. first core start reading, fills up its CB buffer slots (triple buffer = 3), notify the next reader, meanwhile the compute runs
2. 2nd reader start reading, fills up its CB buffer slots, notify the next reader, etc.
Idea is to pre-fetch from the other cores, while the local compute is slow, thus we overlap the compute.

perf (1x7168x2048):
baseline (bfp4): 17.7us
1-core per bank(bfp2/4): 28us
2-core per bank(bfp2/4): 17us
4-core per bank(bfp2/4): 14.8us


### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=yugao/compressed_tensor2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:yugao/compressed_tensor2)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=yugao/compressed_tensor2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:yugao/compressed_tensor2)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=yugao/compressed_tensor2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:yugao/compressed_tensor2)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=yugao/compressed_tensor2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:yugao/compressed_tensor2)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=yugao/compressed_tensor2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:yugao/compressed_tensor2)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=yugao/compressed_tensor2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:yugao/compressed_tensor2)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
