### PR TITLE
[skip ci] Update T3000 ResNet50 perf baselines (fix #39824)

### DIFF
--- a/models/demos/vision/classification/resnet50/ttnn_resnet/tests/test_perf_e2e_resnet50.py
+++ b/models/demos/vision/classification/resnet50/ttnn_resnet/tests/test_perf_e2e_resnet50.py
@@ -7,12 +7,13 @@ import pytest
 from models.common.utility_functions import run_for_wormhole_b0
 from models.demos.vision.classification.resnet50.ttnn_resnet.tests.common.perf_e2e_resnet50 import run_perf_resnet
 
+# T3000 baselines updated from last 10 CI runs (excluding watcher one-off), see #39824
 PERF_EXPECTATIONS = {
     "t3000": {
-        "test_perf": {"inference_time": 0.0157, "compile_time": 60},
+        "test_perf": {"inference_time": 0.0175, "compile_time": 60},
         "test_perf_trace": {"inference_time": 0.0038, "compile_time": 60},
-        "test_perf_2cqs": {"inference_time": 0.015, "compile_time": 60},
-        "test_perf_trace_2cqs": {"inference_time": 0.0031, "compile_time": 60},
+        "test_perf_2cqs": {"inference_time": 0.017, "compile_time": 60},
+        "test_perf_trace_2cqs": {"inference_time": 0.0033, "compile_time": 60},
     },
     "tg": {
         "test_perf": {"inference_time": 0.017, "compile_time": 60},


### PR DESCRIPTION
Fixes https://github.com/tenstorrent/tt-metal/issues/39824

**Summary**
Updates T3000 ResNet50 perf expectations so CI stops failing on small inference-time regressions that are within normal variance. No code or model changes; baseline-only update.

Latest failing run: https://github.com/tenstorrent/tt-metal/actions/runs/23193973924/job/67398136329

**Data source**
Baselines are derived from the **last 10** `(T3K) T3000 perf tests` runs (resnet50 job). The run that had watcher enabled accidentally (massive one-off regression) was excluded from the sample.

**Changes**
| Variant | Previous | New | Max observed (excl. watcher) |
|---------|----------|-----|-------------------------------|
| `test_perf` | 0.0157 | **0.0175** | 0.0172 |
| `test_perf_trace` | 0.0038 | 0.0038 (unchanged) | — |
| `test_perf_2cqs` | 0.015 | **0.017** | 0.0166 |
| `test_perf_trace_2cqs` | 0.0031 | **0.0033** | 0.0032 |

New values add a small headroom above the observed max to reduce flakiness.