### PR TITLE
Reduce CB ID usage in MLA

### DIFF
--- a/models/demos/deepseek_v3_b1/circular_buffer_utils.py
+++ b/models/demos/deepseek_v3_b1/circular_buffer_utils.py
@@ -145,11 +145,13 @@ def cb_descriptor_from_overlapped_tensors(
     assert len(overlapped_list) > 0
 
     first = overlapped_list[0]
-    if core_ranges is None:
+    core_range_override = core_ranges is not None
+    if not core_range_override:
         core_ranges = first.core_range_set
-        for ot in overlapped_list[1:]:
-            assert ot.dtype == first.dtype
-            assert ot.tile_shape == first.tile_shape
+    for ot in overlapped_list[1:]:
+        assert ot.dtype == first.dtype
+        assert ot.tile_shape == first.tile_shape
+        if not core_range_override:
             core_ranges = core_ranges.merge(ot.core_range_set)
 
     cb_desc = ttnn.cb_descriptor_from_sharded_tensor(

--- a/models/demos/deepseek_v3_b1/circular_buffer_utils.py
+++ b/models/demos/deepseek_v3_b1/circular_buffer_utils.py
@@ -135,6 +135,7 @@ def cb_descriptor_from_overlapped_tensors(
     cb_index: int,
     overlapped_list: list[OverlappedTensor],
     fused_tensor_device: ttnn.Tensor,
+    core_ranges: ttnn.CoreRangeSet = None,
 ) -> ttnn.CBDescriptor:
     """Create a single CBDescriptor spanning multiple OverlappedTensors in the same fused buffer.
 
@@ -144,16 +145,17 @@ def cb_descriptor_from_overlapped_tensors(
     assert len(overlapped_list) > 0
 
     first = overlapped_list[0]
-    merged_core_ranges = first.core_range_set
-    for ot in overlapped_list[1:]:
-        assert ot.dtype == first.dtype
-        assert ot.tile_shape == first.tile_shape
-        merged_core_ranges = merged_core_ranges.merge(ot.core_range_set)
+    if core_ranges is None:
+        core_ranges = first.core_range_set
+        for ot in overlapped_list[1:]:
+            assert ot.dtype == first.dtype
+            assert ot.tile_shape == first.tile_shape
+            core_ranges = core_ranges.merge(ot.core_range_set)
 
     cb_desc = ttnn.cb_descriptor_from_sharded_tensor(
         cb_index,
         fused_tensor_device,
-        core_ranges=merged_core_ranges,
+        core_ranges=core_ranges,
     )
     tile = ttnn.Tile(first.tile_shape)
     cb_desc.format_descriptors = [

--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/kernels/attention_block_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/kernels/attention_block_kernel.cpp
@@ -841,8 +841,9 @@ void kernel_main() {
 
     // RMSNorm compute runtime args
     deepseek_b1_ops::RMSNorm::ComputeArgs rmsnorm_args{
-        get_common_arg_val<uint32_t>(0),  // epsilon
-        get_common_arg_val<float>(1),     // scalar (1/sqrt(7168))
+        get_common_arg_val<uint32_t>(0),   // epsilon
+        get_common_arg_val<float>(1),      // scalar (1/sqrt(7168))
+        get_common_arg_val<uint32_t>(15),  // rmsnorm_gamma_addr
     };
 
     // Mcast compute args (no-op for TRISC)
@@ -881,8 +882,9 @@ void kernel_main() {
 
     // RMSNorm2 compute args (separate CBs with exact sizes for testing)
     deepseek_b1_ops::RMSNorm::ComputeArgs rmsnorm2_args{
-        get_common_arg_val<uint32_t>(0),  // epsilon (same as rmsnorm1)
-        get_common_arg_val<float>(2),     // scalar (1/sqrt(1536))
+        get_common_arg_val<uint32_t>(0),   // epsilon (same as rmsnorm1)
+        get_common_arg_val<float>(2),      // scalar (1/sqrt(1536))
+        get_common_arg_val<uint32_t>(16),  // rmsnorm2_gamma_addr
     };
 
     // Matmul2 CTArgs type alias (out_w is compile-time for TRISC)
@@ -911,6 +913,7 @@ void kernel_main() {
         get_named_compile_time_arg_val("matmul3_in1"),
         get_named_compile_time_arg_val("matmul3_out"),
         get_named_compile_time_arg_val("matmul3_k_num_tiles"),
+        get_common_arg_val<uint32_t>(11),  // matmul3_weights_addr
     };
 
     // Qrope CTArgs type alias
@@ -925,6 +928,7 @@ void kernel_main() {
         get_named_compile_time_arg_val("qrope_rotated_in_interm_cb"),
         get_named_compile_time_arg_val("qrope_cos_sin_interm_cb"),
         get_named_compile_time_arg_val("qrope_output_cb"),
+        get_common_arg_val<uint32_t>(14),  // qrope_trans_mat_addr
     };
 
     // CreateQHeads compute args (tilization on SDPA input cores)
@@ -963,8 +967,9 @@ void kernel_main() {
 
     // RMSNorm compute runtime args
     deepseek_b1_ops::RMSNorm::ComputeArgs kv_rmsnorm_args{
-        get_common_arg_val<uint32_t>(0),  // epsilon
-        get_common_arg_val<float>(3),     // kv_scalar (1/sqrt(512))
+        get_common_arg_val<uint32_t>(0),   // epsilon
+        get_common_arg_val<float>(3),      // kv_scalar (1/sqrt(512))
+        get_common_arg_val<uint32_t>(17),  // kv_rmsnorm_gamma_addr
     };
 
     using K_RopeCTArgs = deepseek_b1_ops::Rope::
@@ -986,6 +991,7 @@ void kernel_main() {
         .rotated_in_interm_cb = krope_rotated_in_interm_cb,
         .cos_sin_interm_cb = krope_cos_sin_interm_cb,
         .out_cb = krope_output_cb,
+        .trans_mat_address_override = get_common_arg_val<uint32_t>(14),
     };
 
     deepseek_b1_ops::KVCacheUpdate::ComputeArgs kv_cache_update_args{
@@ -1038,6 +1044,7 @@ void kernel_main() {
         get_named_compile_time_arg_val("matmul4_in1"),
         get_named_compile_time_arg_val("matmul4_out"),
         get_named_compile_time_arg_val("matmul4_k_num_tiles"),
+        get_common_arg_val<uint32_t>(12),  // matmul4_weights_addr
     };
 
     // Gather2 compute args (no-op)
@@ -1054,6 +1061,7 @@ void kernel_main() {
         get_named_compile_time_arg_val("matmul5_in1"),
         get_named_compile_time_arg_val("matmul5_out"),
         get_named_compile_time_arg_val("matmul5_k_num_tiles"),
+        get_common_arg_val<uint32_t>(13),  // matmul5_weights_addr
     };
 
     // Gather3 compute args (no-op)
@@ -1106,63 +1114,7 @@ void kernel_main() {
 #endif
 
     // Setup all tensor-backed sharded buffers (marks pre-loaded tiles as ready)
-    auto setup_all_sharded_buffers = [&]() __attribute__((always_inline)) {
-#if defined(COMPILE_FOR_NCRISC)
-        if constexpr (Core::is_input_core) {
-            // Multi-device mode: NCRISC sets up gamma buffers while BRISC handles CCL
-            // RMSNorm gamma buffer
-            constexpr uint32_t rmsnorm_input_cb = get_named_compile_time_arg_val("rmsnorm_input_cb");
-            constexpr uint32_t rmsnorm_gamma_cb = get_named_compile_time_arg_val("rmsnorm_gamma_cb");
-            constexpr uint32_t rmsnorm_num_tiles = get_named_compile_time_arg_val("rmsnorm_num_tiles");
-            unified_kernels::setup_sharded_buffer(rmsnorm_gamma_cb, rmsnorm_num_tiles);
-
-            // RMSNorm2 gamma buffer (3 tiles of 16x32)
-            constexpr uint32_t rmsnorm2_gamma_cb = get_named_compile_time_arg_val("rmsnorm2_gamma_cb");
-            constexpr uint32_t rmsnorm2_num_tiles = get_named_compile_time_arg_val("rmsnorm2_num_tiles");
-            unified_kernels::setup_sharded_buffer(rmsnorm2_gamma_cb, rmsnorm2_num_tiles);
-        }
-        if constexpr (Core::is_qnope_core) {
-            // Matmul3 CB indices and parameters from named compile-time args
-            constexpr uint32_t matmul3_in1 = get_named_compile_time_arg_val("matmul3_in1");
-            constexpr uint32_t matmul3_k_num_tiles = get_named_compile_time_arg_val("matmul3_k_num_tiles");
-            constexpr uint32_t matmul3_out_w_per_core = get_named_compile_time_arg_val("matmul3_out_w_per_core");
-
-            // Matmul3 weights (on Qnope cores, [128, 512] = 4 * 16 = 64 tiles per core)
-            unified_kernels::setup_sharded_buffer(matmul3_in1, matmul3_k_num_tiles * matmul3_out_w_per_core);
-        }
-
-        if constexpr (Core::is_qrope_core) {
-            constexpr uint32_t qrope_trans_mat_cb = get_named_compile_time_arg_val("qrope_trans_mat_cb");
-            unified_kernels::setup_sharded_buffer(qrope_trans_mat_cb, 1);
-        }
-
-        if constexpr (Core::is_kv_rmsnorm_core) {
-            // RMSNorm gamma (sharded weights)
-            constexpr uint32_t kv_rmsnorm_gamma_cb = get_named_compile_time_arg_val("kv_rmsnorm_gamma_cb");
-            constexpr uint32_t kv_rmsnorm_num_tiles = get_named_compile_time_arg_val("kv_rmsnorm_num_tiles");
-            unified_kernels::setup_sharded_buffer(kv_rmsnorm_gamma_cb, kv_rmsnorm_num_tiles);
-        }
-
-        if constexpr (Core::is_krope_core) {
-            constexpr uint32_t krope_trans_mat_cb = get_named_compile_time_arg_val("krope_trans_mat_cb");
-            unified_kernels::setup_sharded_buffer(krope_trans_mat_cb, 1);
-        }
-
-        if constexpr (Core::is_matmul4_core) {
-            constexpr uint32_t matmul4_in1 = get_named_compile_time_arg_val("matmul4_in1");
-            constexpr uint32_t matmul4_k_num_tiles = get_named_compile_time_arg_val("matmul4_k_num_tiles");
-            constexpr uint32_t matmul4_out_w_per_core = get_named_compile_time_arg_val("matmul4_out_w_per_core");
-            unified_kernels::setup_sharded_buffer(matmul4_in1, matmul4_k_num_tiles * matmul4_out_w_per_core);
-        }
-
-        if constexpr (Core::is_matmul5_core) {
-            constexpr uint32_t matmul5_in1 = get_named_compile_time_arg_val("matmul5_in1");
-            constexpr uint32_t matmul5_k_num_tiles = get_named_compile_time_arg_val("matmul5_k_num_tiles");
-            constexpr uint32_t matmul5_out_w_per_core = get_named_compile_time_arg_val("matmul5_out_w_per_core");
-            unified_kernels::setup_sharded_buffer(matmul5_in1, matmul5_k_num_tiles * matmul5_out_w_per_core);
-        }
-#endif
-    };
+    auto setup_all_sharded_buffers = [&]() __attribute__((always_inline)) {};
 
 #if defined(COMPILE_FOR_BRISC)
     uint32_t cur_pos_addr = get_common_arg_val<uint32_t>(1);

--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
@@ -883,7 +883,6 @@ class AttentionBlock:
         assert (
             trans_mat_tensor.get_tile() == matmul_weights_tensor.get_tile()
         ), f"Qrope trans mat tensor tile ({trans_mat_tensor.get_tile()}) must be equal to matmul weights tensor tile ({matmul_weights_tensor.get_tile()})"
-        # qrope_trans_mat_cb = cb_id_context.get_cb_id(data_format, TD_32x32)  # Trans_mat CB for RoPE
         qrope_rotated_input_interm_cb = cb_id_context.get_cb_id(
             data_format, TD_1x32
         )  # Rotated input intermediate CB for RoPE
@@ -894,7 +893,6 @@ class AttentionBlock:
         )  # DKV Matmul output CB, 64 bytes (1 tile per core for rope input)
         kv_rmsnorm_input_cb = cb_id_context.get_cb_id(data_format, TD_16x32)  # Input CB for KV Cache Branch RMSNorm
         kv_rmsnorm_gamma_cb = rmsnorm2_gamma_cb
-        # kv_rmsnorm_gamma_cb = cb_id_context.get_cb_id(data_format, TD_16x32)  # Gamma CB for KV Cache Branch RMSNorm
         kv_rmsnorm_output_cb = cb_id_context.get_cb_id(data_format, TD_16x32)  # Output CB for KV Cache Branch RMSNorm
         krope_output_cb = cb_id_context.get_cb_id(data_format, TD_1x32)  # Output CB for KV Cache Branch RoPE
         krope_cos_sin_cb = cb_id_context.get_cb_id(data_format, TD_1x32)  # Cos/Sin CB for RoPE
@@ -2192,11 +2190,6 @@ class AttentionBlock:
         qrope_cos_sin_cb_descriptor.format_descriptors = [qrope_cos_sin_cb_format]
         sdpa_out_interm_running_offset_qrope += qrope_cos_sin_cb_descriptor.total_size
 
-        # CB 19: Trans_mat (sharded tensor)
-        # qrope_trans_mat_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
-        #     qrope_trans_mat_cb, ref_trans_mat_tensor, core_ranges=full_device_grid
-        # )
-
         # CB 20: Rotated input intermediate CB — overlap with sdpa_out_interm L1 buffer
         # at offset 13888 B. This CB is consumed before SDPA runs.
         qrope_interm_tile_size = qrope_head_dim_per_core_t * TILE_1x32.get_tile_size(data_format)
@@ -2329,13 +2322,6 @@ class AttentionBlock:
             )
         ]
         sdpa_kv_cache_running_offset += kv_rmsnorm_input_cb_descriptor.total_size  # +1024 B
-
-        # CB: KV RMSNorm gamma buffer (backed by fused overlapped tensor)
-        # kv_rmsnorm_gamma_cb_descriptor = cb_descriptor_from_overlapped_tensor(
-        #     kv_rmsnorm_gamma_cb, dkv_rmsnorm_gamma_tensor, ref_gamma_fused_tensor
-        # )
-        # kv_rmsnorm_gamma_cb_descriptor.format_descriptors[0].tile = kv_rmsnorm_tile_descriptor
-        # kv_rmsnorm_gamma_cb_descriptor.format_descriptors[0].page_size = kv_rmsnorm_page_size
 
         # CB 27: KV RMSNorm output buffer — overlap with sdpa_out_interm L1 buffer
         # at offset 15360 B. This CB is consumed before SDPA runs.
@@ -2760,19 +2746,6 @@ class AttentionBlock:
         ccl_packet_header_cb_descriptor.format_descriptors = [ccl_packet_header_cb_format]
         sdpa_forwarder_scratch_running_offset += ccl_packet_header_cb_descriptor.total_size
         post_sdpa_cb_list.append(ccl_packet_header_cb_descriptor)
-
-        # Get from fused
-        # CB 14: SDPA local L (aliased to input tensor)
-        # sdpa_local_l_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
-        #    sdpa_cb_local_l, ref_sdpa_input_l
-        # )
-        # post_sdpa_cb_list.append(sdpa_local_l_cb_descriptor)
-
-        # CB 15: SDPA local MS (aliased to input tensor)
-        # sdpa_local_ms_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
-        #    sdpa_cb_local_ms, ref_sdpa_input_ms
-        # )
-        # post_sdpa_cb_list.append(sdpa_local_ms_cb_descriptor)
 
         # CB 16: SDPA neighbor L (aliased to intermediate recv buffer)
         # The recv buffer holds both L and MS data, but this CB should only

--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
@@ -208,7 +208,6 @@ class AttentionBlock:
         dkv_matmul_weights_tensor,
         dkv_rmsnorm_gamma_tensor,
         kv_cache_tensor,
-        position_id,
         position_ids_tensor,
         scale,
         output_tensor,
@@ -862,9 +861,13 @@ class AttentionBlock:
         matmul2_output_cb = cb_id_context.get_cb_id(
             data_format, TD_1x32
         )  # Output CB for second matmul ([64, 1, 128] + [64, 1, 64])
-        matmul3_weights_cb = cb_id_context.get_cb_id(  # Weights CB for third matmul (height sharded on Qnope grid)
-            matmul3_weights_tensor.dtype, ttnn.TileDescriptor(matmul3_weights_tensor.get_tile())
-        )
+        matmul3_weights_cb = matmul_weights_cb_overlapped
+        assert (
+            matmul3_weights_tensor.dtype == matmul_weights_tensor.dtype
+        ), f"Matmul3 weights tensor dtype ({matmul3_weights_tensor.dtype}) must be equal to matmul weights tensor dtype ({matmul_weights_tensor.dtype})"
+        assert (
+            matmul3_weights_tensor.get_tile() == matmul_weights_tensor.get_tile()
+        ), f"Matmul3 weights tensor tile ({matmul3_weights_tensor.get_tile()}) must be equal to matmul weights tensor tile ({matmul_weights_tensor.get_tile()})"
         matmul3_output_cb = cb_id_context.get_cb_id(
             data_format, TD_1x32
         )  # Output CB for third matmul (Qnope final output)
@@ -873,7 +876,14 @@ class AttentionBlock:
             data_format, TD_8x32
         )  # Output CB for CreateQHeads (linked to output tensor on receiver cores)
         qrope_cos_sin_cb = cb_id_context.get_cb_id(data_format, TD_1x32)  # Cos/Sin CB for RoPE
-        qrope_trans_mat_cb = cb_id_context.get_cb_id(data_format, TD_32x32)  # Trans_mat CB for RoPE
+        qrope_trans_mat_cb = matmul_weights_cb_overlapped
+        assert (
+            trans_mat_tensor.dtype == matmul_weights_tensor.dtype
+        ), f"Qrope trans mat tensor dtype ({trans_mat_tensor.dtype}) must be equal to matmul weights tensor dtype ({matmul_weights_tensor.dtype})"
+        assert (
+            trans_mat_tensor.get_tile() == matmul_weights_tensor.get_tile()
+        ), f"Qrope trans mat tensor tile ({trans_mat_tensor.get_tile()}) must be equal to matmul weights tensor tile ({matmul_weights_tensor.get_tile()})"
+        # qrope_trans_mat_cb = cb_id_context.get_cb_id(data_format, TD_32x32)  # Trans_mat CB for RoPE
         qrope_rotated_input_interm_cb = cb_id_context.get_cb_id(
             data_format, TD_1x32
         )  # Rotated input intermediate CB for RoPE
@@ -883,7 +893,8 @@ class AttentionBlock:
             data_format, TD_1x32
         )  # DKV Matmul output CB, 64 bytes (1 tile per core for rope input)
         kv_rmsnorm_input_cb = cb_id_context.get_cb_id(data_format, TD_16x32)  # Input CB for KV Cache Branch RMSNorm
-        kv_rmsnorm_gamma_cb = cb_id_context.get_cb_id(data_format, TD_16x32)  # Gamma CB for KV Cache Branch RMSNorm
+        kv_rmsnorm_gamma_cb = rmsnorm2_gamma_cb
+        # kv_rmsnorm_gamma_cb = cb_id_context.get_cb_id(data_format, TD_16x32)  # Gamma CB for KV Cache Branch RMSNorm
         kv_rmsnorm_output_cb = cb_id_context.get_cb_id(data_format, TD_16x32)  # Output CB for KV Cache Branch RMSNorm
         krope_output_cb = cb_id_context.get_cb_id(data_format, TD_1x32)  # Output CB for KV Cache Branch RoPE
         krope_cos_sin_cb = cb_id_context.get_cb_id(data_format, TD_1x32)  # Cos/Sin CB for RoPE
@@ -920,15 +931,23 @@ class AttentionBlock:
         sdpa_cb_l_out = cb_id_context.get_cb_id(data_format, TD_SDPA)
 
         matmul4_in0_cb = cb_id_context.get_cb_id(data_format, TD_1x32)  # Matmul4 input (kv_b2 grid)
-        matmul4_in1_cb = cb_id_context.get_cb_id(  # Matmul4 weights (kv_b2 grid)
-            post_sdpa_weights1_tensor.dtype, ttnn.TileDescriptor(post_sdpa_weights1_tensor.get_tile())
-        )
+        matmul4_in1_cb = matmul_weights_cb_overlapped
+        assert (
+            post_sdpa_weights1_tensor.dtype == matmul_weights_tensor.dtype
+        ), f"Post SDPA weights1 tensor dtype ({post_sdpa_weights1_tensor.dtype}) must be equal to matmul weights tensor dtype ({matmul_weights_tensor.dtype})"
+        assert (
+            post_sdpa_weights1_tensor.get_tile() == matmul_weights_tensor.get_tile()
+        ), f"Post SDPA weights1 tensor tile ({post_sdpa_weights1_tensor.get_tile()}) must be equal to matmul weights tensor tile ({matmul_weights_tensor.get_tile()})"
         matmul4_out_cb = cb_id_context.get_cb_id(data_format, TD_1x32)  # Matmul4 output (kv_b2 grid)
         gather2_dst_cb = cb_id_context.get_cb_id(data_format, TD_1x32)  # Gather2 output = Mcast3 source (gather core)
         matmul5_in0_cb = cb_id_context.get_cb_id(data_format, TD_1x32)  # Mcast3 dst = Matmul5 input (13x10 mcast3 grid)
-        matmul5_in1_cb = cb_id_context.get_cb_id(  # Matmul5 weights (112 active cores)
-            post_sdpa_weights2_tensor.dtype, ttnn.TileDescriptor(post_sdpa_weights2_tensor.get_tile())
-        )
+        matmul5_in1_cb = matmul_weights_cb_overlapped
+        assert (
+            post_sdpa_weights2_tensor.dtype == matmul_weights_tensor.dtype
+        ), f"Post SDPA weights2 tensor dtype ({post_sdpa_weights2_tensor.dtype}) must be equal to matmul weights tensor dtype ({matmul_weights_tensor.dtype})"
+        assert (
+            post_sdpa_weights2_tensor.get_tile() == matmul_weights_tensor.get_tile()
+        ), f"Post SDPA weights2 tensor tile ({post_sdpa_weights2_tensor.get_tile()}) must be equal to matmul weights tensor tile ({matmul_weights_tensor.get_tile()})"
         matmul5_out_cb = cb_id_context.get_cb_id(data_format, TD_1x32)  # Matmul5 output (112 active cores)
         gather3_dst_cb = cb_id_context.get_cb_id(
             data_format, TD_INTERP
@@ -1960,6 +1979,7 @@ class AttentionBlock:
             matmul_weights_cb_overlapped,
             [matmul_weights_tensor, matmul2_weights_tensor, dkv_matmul_weights_tensor],
             ref_fused_weights_tensor,
+            core_ranges=full_device_grid,
         )
 
         # CB: Matmul input buffer (1x32 tiles, receives mcast data)
@@ -2110,11 +2130,6 @@ class AttentionBlock:
 
         sdpa_out_interm_running_offset_qrope = sdpa_out_interm_running_offset
 
-        # CB 13: Matmul3 weights (backed by fused kv_b12 overlapped tensor)
-        matmul3_weights_cb_descriptor = cb_descriptor_from_overlapped_tensor(
-            matmul3_weights_cb, matmul3_weights_tensor, ref_kv_b12_fused_tensor
-        )
-
         # CB 14: Matmul3 output buffer — overlap with sdpa_out_interm L1 buffer
         # at offset 12608 B. This CB is consumed before SDPA runs.
         matmul3_output_tile_descriptor = ttnn.TileDescriptor(TILE_1x32)
@@ -2178,9 +2193,9 @@ class AttentionBlock:
         sdpa_out_interm_running_offset_qrope += qrope_cos_sin_cb_descriptor.total_size
 
         # CB 19: Trans_mat (sharded tensor)
-        qrope_trans_mat_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
-            qrope_trans_mat_cb, ref_trans_mat_tensor, core_ranges=full_device_grid
-        )
+        # qrope_trans_mat_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+        #     qrope_trans_mat_cb, ref_trans_mat_tensor, core_ranges=full_device_grid
+        # )
 
         # CB 20: Rotated input intermediate CB — overlap with sdpa_out_interm L1 buffer
         # at offset 13888 B. This CB is consumed before SDPA runs.
@@ -2316,11 +2331,11 @@ class AttentionBlock:
         sdpa_kv_cache_running_offset += kv_rmsnorm_input_cb_descriptor.total_size  # +1024 B
 
         # CB: KV RMSNorm gamma buffer (backed by fused overlapped tensor)
-        kv_rmsnorm_gamma_cb_descriptor = cb_descriptor_from_overlapped_tensor(
-            kv_rmsnorm_gamma_cb, dkv_rmsnorm_gamma_tensor, ref_gamma_fused_tensor
-        )
-        kv_rmsnorm_gamma_cb_descriptor.format_descriptors[0].tile = kv_rmsnorm_tile_descriptor
-        kv_rmsnorm_gamma_cb_descriptor.format_descriptors[0].page_size = kv_rmsnorm_page_size
+        # kv_rmsnorm_gamma_cb_descriptor = cb_descriptor_from_overlapped_tensor(
+        #     kv_rmsnorm_gamma_cb, dkv_rmsnorm_gamma_tensor, ref_gamma_fused_tensor
+        # )
+        # kv_rmsnorm_gamma_cb_descriptor.format_descriptors[0].tile = kv_rmsnorm_tile_descriptor
+        # kv_rmsnorm_gamma_cb_descriptor.format_descriptors[0].page_size = kv_rmsnorm_page_size
 
         # CB 27: KV RMSNorm output buffer — overlap with sdpa_out_interm L1 buffer
         # at offset 15360 B. This CB is consumed before SDPA runs.
@@ -2580,11 +2595,6 @@ class AttentionBlock:
         matmul4_in0_cb_descriptor.format_descriptors = [matmul4_in0_cb_format]
         sdpa_kv_cache_running_offset_post_sdpa += matmul4_in0_cb_descriptor.total_size
 
-        # CB 1: Matmul4 weights (from kv_b2 overlapped tensor)
-        matmul4_in1_cb_descriptor = cb_descriptor_from_overlapped_tensor(
-            matmul4_in1_cb, post_sdpa_weights1_tensor, ref_post_sdpa_weights1_fused_tensor
-        )
-
         # CB 2: Matmul4 output (4 tiles of 1x32 per core, kv_b2 grid)
         # When kv_cache buffer is available, overlap into it. Otherwise standalone.
         matmul4_out_tile_descriptor = ttnn.TileDescriptor(TILE_1x32)
@@ -2641,11 +2651,6 @@ class AttentionBlock:
         matmul5_in0_cb_descriptor.format_descriptors = [matmul5_in0_cb_format]
         sdpa_kv_cache_running_offset_post_sdpa += matmul5_in0_cb_descriptor.total_size
 
-        # CB 5: Matmul5 weights (from o_proj overlapped tensor)
-        matmul5_in1_cb_descriptor = cb_descriptor_from_overlapped_tensor(
-            matmul5_in1_cb, post_sdpa_weights2_tensor, ref_post_sdpa_weights2_fused_tensor
-        )
-
         # CB 6: Matmul5 output (2 tiles of 1x32 per core, 112 active matmul5 cores)
         matmul5_out_cb_format = ttnn.CBFormatDescriptor(
             buffer_index=matmul5_out_cb,
@@ -2685,11 +2690,9 @@ class AttentionBlock:
 
         post_sdpa_cb_list = [
             matmul4_in0_cb_descriptor,
-            matmul4_in1_cb_descriptor,
             matmul4_out_cb_descriptor,
             gather2_dst_cb_descriptor,
             matmul5_in0_cb_descriptor,
-            matmul5_in1_cb_descriptor,
             matmul5_out_cb_descriptor,
             gather3_dst_cb_descriptor,
         ]
@@ -3250,17 +3253,16 @@ class AttentionBlock:
             rmsnorm2_output_cb_descriptor,
             matmul2_input_cb_descriptor,
             matmul2_output_cb_descriptor,
-            matmul3_weights_cb_descriptor,
             matmul3_output_cb_descriptor,
             qrope_output_cb_descriptor,
             create_q_heads_out_cb_descriptor,
             qrope_cos_sin_cb_descriptor,
-            qrope_trans_mat_cb_descriptor,
+            # qrope_trans_mat_cb_descriptor,
             qrope_rotated_input_interm_cb_descriptor,
             qrope_cos_sin_interm_cb_descriptor,
             dkv_matmul_output_cb_descriptor,
             kv_rmsnorm_input_cb_descriptor,
-            kv_rmsnorm_gamma_cb_descriptor,
+            # kv_rmsnorm_gamma_cb_descriptor,
             kv_rmsnorm_output_cb_descriptor,
             krope_output_cb_descriptor,
             krope_cos_sin_cb_descriptor,
@@ -3468,6 +3470,17 @@ class AttentionBlock:
                 matmul_weights_addr = fused_weights_base_addr + matmul_weights_tensor.byte_offset
                 matmul2_weights_addr = fused_weights_base_addr + matmul2_weights_tensor.byte_offset
                 dkv_matmul_weights_addr = fused_weights_base_addr + dkv_matmul_weights_tensor.byte_offset
+                gamma_addr = ref_gamma_fused_tensor.buffer_address() + gamma_tensor.byte_offset
+                matmul3_weights_addr = ref_kv_b12_fused_tensor.buffer_address() + matmul3_weights_tensor.byte_offset
+                matmul4_weights_addr = (
+                    ref_post_sdpa_weights1_fused_tensor.buffer_address() + post_sdpa_weights1_tensor.byte_offset
+                )
+                matmul5_weights_addr = (
+                    ref_post_sdpa_weights2_fused_tensor.buffer_address() + post_sdpa_weights2_tensor.byte_offset
+                )
+                qrope_trans_mat_addr = ref_trans_mat_tensor.buffer_address()
+                rmsnorm2_gamma_addr = ref_gamma_fused_tensor.buffer_address() + rmsnorm2_gamma_tensor.byte_offset
+                kv_rmsnorm_gamma_addr = ref_gamma_fused_tensor.buffer_address() + dkv_rmsnorm_gamma_tensor.byte_offset
 
                 # TRISC common runtime args (shared scalar values)
                 trisc_common_runtime_args = [
@@ -3482,6 +3495,13 @@ class AttentionBlock:
                     matmul_weights_addr,  # idx 8
                     matmul2_weights_addr,  # idx 9
                     dkv_matmul_weights_addr,  # idx 10
+                    matmul3_weights_addr,  # idx 11
+                    matmul4_weights_addr,  # idx 12
+                    matmul5_weights_addr,  # idx 13
+                    qrope_trans_mat_addr,  # idx 14
+                    gamma_addr,  # idx 15
+                    rmsnorm2_gamma_addr,  # idx 16
+                    kv_rmsnorm_gamma_addr,  # idx 17
                 ]
 
                 qrope_ncrisc_addr_args = [
@@ -3812,7 +3832,6 @@ class AttentionBlock:
         dkv_matmul_weights_tensor,
         dkv_rmsnorm_gamma_tensor,
         kv_cache_tensor,
-        position_id,
         position_ids_tensor,
         scale,
         output_tensor,
@@ -3860,7 +3879,6 @@ class AttentionBlock:
             dkv_matmul_weights_tensor,
             dkv_rmsnorm_gamma_tensor,
             kv_cache_tensor,
-            position_id,
             position_ids_tensor,
             scale,
             output_tensor,
@@ -4085,6 +4103,5 @@ class AttentionBlock:
                 ]
 
             mesh_program_descriptor[ttnn.MeshCoordinateRange(mesh_coord, mesh_coord)] = program
-
         result = ttnn.generic_op(io_tensors, mesh_program_descriptor)
         return result

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_attention_block.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_attention_block.py
@@ -485,7 +485,7 @@ def test_attention_block(
 
     ttnn_trans_mat = ttnn.from_torch(
         trans_mat_replicated,
-        dtype=ttnn.bfloat16,
+        dtype=ttnn.bfloat8_b,
         layout=ttnn.TILE_LAYOUT,
         device=submesh,
         memory_config=trans_mem_config,
@@ -869,7 +869,6 @@ def test_attention_block(
             dkv_matmul_weights_overlapped,
             dkv_rmsnorm_gamma_overlapped,
             ttnn_kv_cache,
-            position_id,
             ttnn_position_ids,
             scale,
             ttnn_output,
@@ -1113,7 +1112,8 @@ def test_attention_block(
             assert dev_eq, f"Device {device_idx} output mismatch"
 
         passing, pcc = comp_pcc(torch_output_expected, received, 0.997)
-        logger.info(f"Device {device_idx} Attention Block Output PCC: {pcc}")
+        max_diff = torch.max(torch.abs(torch_output_expected - received))
+        logger.info(f"Device {device_idx} Attention Block Output PCC: {pcc} Max Diff: {max_diff}")
         assert passing, f"Device {device_idx} Attention Block Output PCC check failed: {pcc}"
 
     logger.info("✓ Attention Block mesh test passed!")

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_attention_block.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_attention_block.py
@@ -1112,7 +1112,7 @@ def test_attention_block(
             assert dev_eq, f"Device {device_idx} output mismatch"
 
         passing, pcc = comp_pcc(torch_output_expected, received, 0.997)
-        max_diff = torch.max(torch.abs(torch_output_expected - received))
+        max_diff = torch.max(torch.abs(torch_output_expected - received)).item()
         logger.info(f"Device {device_idx} Attention Block Output PCC: {pcc} Max Diff: {max_diff}")
         assert passing, f"Device {device_idx} Attention Block Output PCC check failed: {pcc}"
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Most weights in MLA do not need a dedicated CB in order to be used, since we don't really need to push/pop them.

### What's changed
Reuse CB ids across different MLA weights by changing the CB read ptr of a shared CB id.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aho/mla-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aho/mla-fixes)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aho/mla-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/mla-fixes)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aho/mla-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/mla-fixes)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aho/mla-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/mla-fixes)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aho/mla-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/mla-fixes)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aho/mla-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/mla-fixes)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
