### PR TITLE
Gate sender barrier in dram prefetcher by architecture

### DIFF
--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_program_factory.cpp
@@ -207,7 +207,7 @@ DramPrefetcherProgramFactory::cached_program_t DramPrefetcherProgramFactory::cre
     // Configs to enable for performance mode
     writer_ct_args.push_back((uint32_t)enable_performance_mode /* skip_ptr_update */);
 
-    // The sender barrier was introduced for Blackhole prefetcher integration, not used in TG/Wormhole.
+    // Issue:40112 The sender barrier was introduced for Blackhole prefetcher integration, not used in TG/Wormhole.
     const bool enable_sender_barrier = arch == tt::ARCH::BLACKHOLE;
     writer_ct_args.push_back((uint32_t)enable_sender_barrier);
 

--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_program_factory.cpp
@@ -74,6 +74,7 @@ DramPrefetcherProgramFactory::cached_program_t DramPrefetcherProgramFactory::cre
     Program program{};
 
     // In validate we make sure that all tensors are on the same device
+    auto arch = tensors[0].device()->arch();
     uint32_t num_tensors = tensors.size();
     auto sender_receiver_core_mapping = global_cb.sender_receiver_core_mapping()[0];
     uint32_t num_receivers_per_reader = sender_receiver_core_mapping.second.num_cores();
@@ -205,6 +206,10 @@ DramPrefetcherProgramFactory::cached_program_t DramPrefetcherProgramFactory::cre
 
     // Configs to enable for performance mode
     writer_ct_args.push_back((uint32_t)enable_performance_mode /* skip_ptr_update */);
+
+    // The sender barrier was introduced for Blackhole prefetcher integration, not used in TG/Wormhole.
+    const bool enable_sender_barrier = arch == tt::ARCH::BLACKHOLE;
+    writer_ct_args.push_back((uint32_t)enable_sender_barrier);
 
     auto writer_kernel_id = CreateKernel(
         program,

--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/kernels/writer_l1.cpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/kernels/writer_l1.cpp
@@ -25,6 +25,7 @@ void kernel_main() {
     constexpr uint32_t remote_cb_id = get_compile_time_arg_val(6);
     constexpr uint32_t sync_cb_id = get_compile_time_arg_val(7);
     constexpr bool skip_ptr_update = get_compile_time_arg_val(8);
+    constexpr bool enable_sender_barrier = get_compile_time_arg_val(9);
 
     // Runtime args
     // Note: Coalesced sizes -> wrt to receiver cores, sizes -> wrt to dram reader cores
@@ -67,7 +68,7 @@ void kernel_main() {
                 }
             }
 
-            if (t == num_tensors - 1) {
+            if (enable_sender_barrier && t == num_tensors - 1) {
                 experimental::remote_cb_sender_barrier(remote_cb_id);
             }
         }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/39093#issuecomment-4076150726

### Problem description
The extra barrier introduced in the earlier DRAM prefetcher bring up on BH caused a perf drop on WH
For now created an issue to track this race and needs more thorough investigation for why this only happens on BH and not WH. This is to prevent any perf drop for Llama/Qwen WH GLX .

### What's changed
- Add the barrier only for BH
- Added issue number to track the missing barrier race: https://github.com/tenstorrent/tt-metal/issues/40112

### Checklist
- [ ] [BH dram prefetcher unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/23209175355)
- [ ] [BH demo](https://github.com/tenstorrent/tt-metal/actions/runs/23209023282)
- [ ] [Galaxy demo](https://github.com/tenstorrent/tt-metal/actions/runs/23209044044)