### PR TITLE
[CI] Mitigate false watchdog abort in t3k_fabric_stability_tests

### DIFF
--- a/tests/pipeline_reorg/t3k_e2e_tests.yaml
+++ b/tests/pipeline_reorg/t3k_e2e_tests.yaml
@@ -50,7 +50,7 @@
   team: fabric
 
 - name: t3k_fabric_stability_tests
-  cmd: TT_METAL_CLEAR_L1=1 build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_stability.yaml
+  cmd: TT_METAL_OPERATION_TIMEOUT_SECONDS=30 TT_METAL_CLEAR_L1=1 build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_stability.yaml
   skus:
     wh_llmbox:
       timeout: 120


### PR DESCRIPTION
## Summary
- Scope `TT_METAL_OPERATION_TIMEOUT_SECONDS=30` to `t3k_fabric_stability_tests` in the T3K e2e matrix.
- This mitigates deterministic aborts caused by the CI-wide auto-triage hang-detection default (`5s`) being too aggressive for this long-running fabric stability workload.
- Keep behavior unchanged for all other T3K jobs by avoiding any global workflow/action timeout changes.

Refs #39830

## Root-cause hypothesis
The failing job aborts in `FDMeshCommandQueue::finish_nolock` with:
`Timeout waiting for Ethernet core service remote IO request.`

In this workflow, `setup-job` exports `TT_METAL_OPERATION_TIMEOUT_SECONDS=5` globally for auto-triage hang detection. For this specific fabric stability scenario, valid dispatch progress can exceed that threshold transiently, producing a deterministic false-positive abort (`exit 134`) rather than a true hang.

## Validation
- Reviewed failing CI job logs from issue #39830 and confirmed timeout exception path.
- Verified `setup-job` sets `TT_METAL_OPERATION_TIMEOUT_SECONDS` from `hang-detection-timeout` (default `5.0`).
- Ran:
  - `python3 .github/scripts/utils/verify_time_budget.py tests/pipeline_reorg/t3k_e2e_tests.yaml .github/time_budget.yaml e2e`

## Limitations
- No local T3000 hardware reproduction in this environment.
- Validation is log-driven plus configuration consistency checks.

## Auto-triage input usage
- No separate auto-triage run URL was provided for this ticket.
- Investigation used the failing job logs linked in the issue.

## CI plan
- Run a targeted `Custom test dispatch` for only `t3k_fabric_stability_tests` on this branch.
- If green, monitor subsequent main runs to confirm stability and no masking of real hangs in other jobs.

## In-progress workflow runs
- Custom test dispatch (`CI-39830 targeted t3k_fabric_stability_tests`): https://github.com/tenstorrent/tt-metal/actions/runs/23210342685
- (Canceled) `(T3K) T3000 e2e tests`: https://github.com/tenstorrent/tt-metal/actions/runs/23210196798