### PR TITLE
Fix Mochi 2x2 config, add Mochi to QB2 CI, update Wan2.2 docs

### DIFF
--- a/.github/workflows/blackhole-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-demo-tests-impl.yaml
@@ -135,23 +135,6 @@ jobs:
           mkdir -p /localdev/blackhole_demos/huggingface_data/black-forest-labs
           wget -r -nH -x --cut-dirs=5 -np --progress=dot:giga -R "index.html*" -P /localdev/blackhole_demos/huggingface_data/black-forest-labs http://yyz2-lfcache564.yyz2.tenstorrent.com/mldata/model_checkpoints/pytorch/huggingface/black-forest-labs/models--black-forest-labs--FLUX.1-dev/
           wget -r -nH -x --cut-dirs=5 -np --progress=dot:giga -R "index.html*" -P /localdev/blackhole_demos/huggingface_data/black-forest-labs http://yyz2-lfcache564.yyz2.tenstorrent.com/mldata/model_checkpoints/pytorch/huggingface/black-forest-labs/models--black-forest-labs--FLUX.1-dev/.no_exist/
-      - name: Download Mochi model weights to local cache
-        if: ${{ inputs.weights-cache-mode == 'local-disk' && contains(matrix.test-group.name, 'Mochi') }}
-        timeout-minutes: 120
-        run: |
-          set -e
-          mkdir -p /localdev/blackhole_demos/huggingface_data/genmo
-          python3 - <<'PY'
-          import os
-          from huggingface_hub import snapshot_download
-
-          snapshot_download(
-              repo_id="genmo/mochi-1-preview",
-              cache_dir="/localdev/blackhole_demos/huggingface_data/genmo",
-              token=os.environ.get("HF_TOKEN"),
-              resume_download=True,
-          )
-          PY
       - name: Run demo regression tests
         timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |

--- a/.github/workflows/blackhole-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-demo-tests-impl.yaml
@@ -135,6 +135,23 @@ jobs:
           mkdir -p /localdev/blackhole_demos/huggingface_data/black-forest-labs
           wget -r -nH -x --cut-dirs=5 -np --progress=dot:giga -R "index.html*" -P /localdev/blackhole_demos/huggingface_data/black-forest-labs http://yyz2-lfcache564.yyz2.tenstorrent.com/mldata/model_checkpoints/pytorch/huggingface/black-forest-labs/models--black-forest-labs--FLUX.1-dev/
           wget -r -nH -x --cut-dirs=5 -np --progress=dot:giga -R "index.html*" -P /localdev/blackhole_demos/huggingface_data/black-forest-labs http://yyz2-lfcache564.yyz2.tenstorrent.com/mldata/model_checkpoints/pytorch/huggingface/black-forest-labs/models--black-forest-labs--FLUX.1-dev/.no_exist/
+      - name: Download Mochi model weights to local cache
+        if: ${{ inputs.regenerate-ttnn-cache && inputs.weights-cache-mode == 'local-disk' && contains(matrix.test-group.name, 'Mochi') }}
+        timeout-minutes: 120
+        run: |
+          set -e
+          mkdir -p /localdev/blackhole_demos/huggingface_data/genmo
+          python3 - <<'PY'
+          import os
+          from huggingface_hub import snapshot_download
+
+          snapshot_download(
+              repo_id="genmo/mochi-1-preview",
+              cache_dir="/localdev/blackhole_demos/huggingface_data/genmo",
+              token=os.environ.get("HF_TOKEN"),
+              resume_download=True,
+          )
+          PY
       - name: Run demo regression tests
         timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |

--- a/.github/workflows/blackhole-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-demo-tests-impl.yaml
@@ -137,7 +137,7 @@ jobs:
           wget -r -nH -x --cut-dirs=5 -np --progress=dot:giga -R "index.html*" -P /localdev/blackhole_demos/huggingface_data/black-forest-labs http://yyz2-lfcache564.yyz2.tenstorrent.com/mldata/model_checkpoints/pytorch/huggingface/black-forest-labs/models--black-forest-labs--FLUX.1-dev/.no_exist/
       - name: Download Mochi model weights to local cache
         if: ${{ inputs.weights-cache-mode == 'local-disk' && contains(matrix.test-group.name, 'Mochi') }}
-        timeout-minutes: 15
+        timeout-minutes: 120
         run: |
           set -e
           mkdir -p /localdev/blackhole_demos/huggingface_data/genmo

--- a/.github/workflows/blackhole-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-demo-tests-impl.yaml
@@ -135,6 +135,23 @@ jobs:
           mkdir -p /localdev/blackhole_demos/huggingface_data/black-forest-labs
           wget -r -nH -x --cut-dirs=5 -np --progress=dot:giga -R "index.html*" -P /localdev/blackhole_demos/huggingface_data/black-forest-labs http://yyz2-lfcache564.yyz2.tenstorrent.com/mldata/model_checkpoints/pytorch/huggingface/black-forest-labs/models--black-forest-labs--FLUX.1-dev/
           wget -r -nH -x --cut-dirs=5 -np --progress=dot:giga -R "index.html*" -P /localdev/blackhole_demos/huggingface_data/black-forest-labs http://yyz2-lfcache564.yyz2.tenstorrent.com/mldata/model_checkpoints/pytorch/huggingface/black-forest-labs/models--black-forest-labs--FLUX.1-dev/.no_exist/
+      - name: Download Mochi model weights to local cache
+        if: ${{ inputs.weights-cache-mode == 'local-disk' && contains(matrix.test-group.name, 'Mochi') }}
+        timeout-minutes: 15
+        run: |
+          set -e
+          mkdir -p /localdev/blackhole_demos/huggingface_data/genmo
+          python3 - <<'PY'
+          import os
+          from huggingface_hub import snapshot_download
+
+          snapshot_download(
+              repo_id="genmo/mochi-1-preview",
+              cache_dir="/localdev/blackhole_demos/huggingface_data/genmo",
+              token=os.environ.get("HF_TOKEN"),
+              resume_download=True,
+          )
+          PY
       - name: Run demo regression tests
         timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |

--- a/.github/workflows/blackhole-demo-tests.yaml
+++ b/.github/workflows/blackhole-demo-tests.yaml
@@ -22,6 +22,7 @@ on:
           - llama3.3-70b
           - qwen3-32b
           - flux.1-dev
+          - mochi
           - wan2.2-t2v-a14b
       system-type:
         description: 'Select system type to test'

--- a/models/tt_dit/models/Wan2_2.md
+++ b/models/tt_dit/models/Wan2_2.md
@@ -1,19 +1,39 @@
-# Wan2.2-T2V-A14B
+# Wan2.2-A14B
 
 ## Introduction
 
-[Wan2.2-T2V-A14B](https://huggingface.co/Wan-AI/Wan2.2-T2V-A14B-Diffusers) is a leading text-to-video generative model.
+[Wan2.2](https://huggingface.co/Wan-AI) is a state-of-the-art open-weights video generative model supporting both text-to-video (T2V) and image-to-video (I2V) generation.
 
-This model is implemented in the TT-DiT library to enable inference on Wormhole LoudBox and Galaxy systems.
+This model is implemented in the TT-DiT library to enable inference on Wormhole and Blackhole multi-chip systems.
 
-## Upcoming Features
-- optimized performance on Wormhole systems
-- functional and optimized performance on Blackhole systems
+## Details
+
+The architecture is described in the paper [Wan: Open and Advanced Large-Scale Video Generative Models](https://arxiv.org/abs/2503.20314).
+
+The model consists of a text encoder ([UMT5-XXL](https://huggingface.co/google/umt5-xxl)), a scheduler, two WanTransformer3DModel transformers, and a VAE. Each transformer has 40 blocks of self-attention, cross-attention, and feedforward layers, with RoPE positional embeddings.
+
+Wan2.2 uses a Mixture-of-Experts (MoE) architecture with two-stage denoising. A high-noise expert handles the first 87.5% of timesteps and a low-noise expert handles the remainder, giving 27B total parameters with 14B active per step. Classifier-free guidance (CFG) is used with separate guidance scales per stage.
 
 ## Performance
 
-This section will be updated as performance work progresses.
-There are many items we're making progress on to improve performance:
+Current T2V (text-to-video) performance for supported systems is detailed below. Performance is measured in total seconds per video, with 81 frames and 40 denoising steps.
+
+### 480p (832x480)
+
+| System           | Arch | SP | TP | Current Performance |
+|------------------|------|----|----|---------------------|
+| Loud Box (2x4)   | WH   | 2  | 4  | 735s                |
+| Quiet Box (2x2)  | BH   | 2  | 2  | 466s                |
+| Loud Box (2x4)   | BH   | 4  | 2  | 207s                |
+
+### 720p (1280x720)
+
+| System           | Arch | SP | TP | Current Performance |
+|------------------|------|----|----|---------------------|
+| Galaxy (4x8)     | WH   | 8  | 4  | 354s                |
+| Galaxy (4x8)     | BH   | 8  | 4  | 168s                |
+
+Performance work is ongoing to improve these numbers:
 - increased matmul utilization
 - increased SDPA utilization
 - overlapped AllGather-Matmul and Matmul-ReduceScatter
@@ -32,12 +52,79 @@ There are many items we're making progress on to improve performance:
 # Set the directory to cache the weights to speed up future runs
 export TT_DIT_CACHE_DIR=/your/cache/path
 
-# Generate a video with the pipeline test. Same comment here, use 2x4 on 8-chip systems and 4x8 on 32-chip systems.
-pytest models/tt_dit/tests/models/wan2_2/test_pipeline_wan.py -k "4x8"
+# Text-to-Video (T2V)
+
+# Run T2V on Blackhole Quiet Box (2x2 mesh)
+pytest models/tt_dit/tests/models/wan2_2/test_pipeline_wan.py -k "2x2sp0tp1"
+
+# Run T2V on Wormhole Loud Box (2x4 mesh)
+pytest models/tt_dit/tests/models/wan2_2/test_pipeline_wan.py -k "2x4sp0tp1"
+
+# Run T2V on Blackhole Loud Box (2x4 mesh)
+pytest models/tt_dit/tests/models/wan2_2/test_performance_wan.py -k "bh_2x4sp1tp0"
+
+# Run T2V on Wormhole Galaxy (4x8 mesh)
+pytest models/tt_dit/tests/models/wan2_2/test_pipeline_wan.py -k "wh_4x8sp1tp0"
+
+# Run T2V on Blackhole Galaxy (4x8 mesh)
+pytest models/tt_dit/tests/models/wan2_2/test_pipeline_wan.py -k "bh_4x8sp1tp0"
+
+# Image-to-Video (I2V)
+
+# Run I2V on Blackhole Quiet Box (2x2 mesh)
+pytest models/tt_dit/tests/models/wan2_2/test_pipeline_wan_i2v.py -k "2x2sp0tp1"
+
+# Run I2V on Wormhole Loud Box (2x4 mesh)
+pytest models/tt_dit/tests/models/wan2_2/test_pipeline_wan_i2v.py -k "2x4sp0tp1"
+
+# Run I2V on Blackhole Loud Box (2x4 mesh)
+pytest models/tt_dit/tests/models/wan2_2/test_pipeline_wan_i2v.py -k "bh_2x4sp1tp0"
+
+# Run I2V on Wormhole Galaxy (4x8 mesh)
+pytest models/tt_dit/tests/models/wan2_2/test_pipeline_wan_i2v.py -k "wh_4x8sp1tp0"
+
+# Run I2V on Blackhole Galaxy (4x8 mesh)
+pytest models/tt_dit/tests/models/wan2_2/test_pipeline_wan_i2v.py -k "bh_4x8sp1tp0"
 ```
+
+## Scalability
+
+Wan2.2 has been implemented to support execution on the following systems:
+
+**Wormhole:**
+- 8-chip (Loud Box with 2x4 mesh topology)
+- 32-chip (Galaxy with 4x8 mesh topology)
+
+**Blackhole:**
+- 4-chip (Quiet Box with 2x2 mesh topology)
+- 8-chip (Loud Box with 2x4 mesh topology)
+- 32-chip (Galaxy with 4x8 mesh topology)
+
+The DiT model can be parallelized on 2 main axes:
+1. `sp` (sequence parallel) - the input sequence is fractured across a mesh axis. Self-attention is implemented with ring attention, overlapping KV all-gather with computation.
+2. `tp` (tensor parallel) - weights are fractured across a mesh axis. CCLs such as AllGather and ReduceScatter are used to gather and scatter activations.
+
+A parallel config is defined by the mesh shape and the axis assignments for `sp` and `tp`. For example, on a 2x4 mesh with `sp_axis=0, tp_axis=1`, we get `sp` parallelism with factor 2 on axis 0 and `tp` factor 4 on axis 1. On a 4x8 mesh with `sp_axis=1, tp_axis=0`, we get `sp` factor 8 on axis 1 and `tp` factor 4 on axis 0.
+
+The text encoder (UMT5) is parallelized with tensor parallelism. The VAE is parallelized with height/width spatial parallelism across the mesh.
+
+## Model Variants
+
+### Text-to-Video (T2V)
+- Generates video from a text prompt and an optional negative prompt
+- Uses [Wan-AI/Wan2.2-T2V-A14B-Diffusers](https://huggingface.co/Wan-AI/Wan2.2-T2V-A14B-Diffusers) checkpoint
+- Supports 480p (832x480) and 720p (1280x720) resolutions
+- Default: 81 frames, 40 denoising steps
+
+### Image-to-Video (I2V)
+- Generates video conditioned on one or more input images and a text prompt
+- Uses [Wan-AI/Wan2.2-I2V-A14B-Diffusers](https://huggingface.co/Wan-AI/Wan2.2-I2V-A14B-Diffusers) checkpoint
+- Input images are encoded through the VAE encoder and concatenated with the latent noise
+- Supports the same resolutions and frame counts as T2V
+
+Both variants use the same MoE two-stage denoising architecture with separate high-noise and low-noise expert transformers.
 
 ## Limitations
 
 While output videos look good, we have many items of work in progress to improve correctness.
-As of now, running on systems smaller than a 2x4 Wormhole mesh is not well supported. The model is large and requires 8-chips worth of memory to run.
 Performance optimization is in progress.

--- a/models/tt_dit/models/vae/vae_mochi.py
+++ b/models/tt_dit/models/vae/vae_mochi.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 import torch
 
 import ttnn
+from models.common.utility_functions import is_blackhole
 
 from ...layers.conv3d import ContextParallelConv3d
 from ...layers.module import Module, ModuleList, Parameter
@@ -184,7 +185,7 @@ class ResBlock(Module):
             if in_channels in (768, 512, 256)
             else mesh_device.core_grid.y
         )
-        max_grid_y = 7 if grid_size_x > 8 else mesh_device.core_grid.y
+        max_grid_y = 7 if is_blackhole() else mesh_device.core_grid.y
         grid_size_y = min(grid_size_y, max_grid_y)
         self.grid_size = ttnn.CoreGrid(y=grid_size_y, x=grid_size_x)
 

--- a/models/tt_dit/models/vae/vae_mochi.py
+++ b/models/tt_dit/models/vae/vae_mochi.py
@@ -184,6 +184,8 @@ class ResBlock(Module):
             if in_channels in (768, 512, 256)
             else mesh_device.core_grid.y
         )
+        max_grid_y = 7 if grid_size_x > 8 else mesh_device.core_grid.y
+        grid_size_y = min(grid_size_y, max_grid_y)
         self.grid_size = ttnn.CoreGrid(y=grid_size_y, x=grid_size_x)
 
         self.norm1 = GroupNorm(

--- a/models/tt_dit/pipelines/mochi/pipeline_mochi.py
+++ b/models/tt_dit/pipelines/mochi/pipeline_mochi.py
@@ -334,6 +334,10 @@ class MochiPipeline(DiffusionPipeline):
                 },
             }
         else:
+            assert tuple(mesh_device.shape) != (
+                2,
+                2,
+            ), "Mochi 2x2 is only supported on Blackhole. Wormhole does not have enough memory for this configuration."
             default_config = {
                 (2, 4): {
                     "sp_axis": 0,

--- a/models/tt_dit/pipelines/mochi/pipeline_mochi.py
+++ b/models/tt_dit/pipelines/mochi/pipeline_mochi.py
@@ -309,7 +309,7 @@ class MochiPipeline(DiffusionPipeline):
                     "sp_axis": 0,
                     "tp_axis": 1,
                     "num_links": 2,
-                    "vae_mesh_shape": (2, 2),
+                    "vae_mesh_shape": (1, 4),
                     "vae_sp_axis": 0,
                     "vae_tp_axis": 1,
                     "reload_dit_model": True,

--- a/models/tt_dit/tests/models/mochi/test_performance_mochi.py
+++ b/models/tt_dit/tests/models/mochi/test_performance_mochi.py
@@ -23,9 +23,8 @@ from ....pipelines.mochi.pipeline_mochi import MochiPipeline as TTMochiPipeline
 @pytest.mark.parametrize(
     "mesh_device, sp_axis, tp_axis, vae_mesh_shape, vae_sp_axis, vae_tp_axis, topology, num_links",
     [
-        # VAE mesh shape = (1, 8) is more memory efficient.
         [(2, 2), 0, 1, (1, 4), 0, 1, ttnn.Topology.Linear, 2],
-        [(2, 4), 0, 1, (1, 8), 0, 1, ttnn.Topology.Linear, 2],
+        [(2, 4), 0, 1, (1, 8), 0, 1, ttnn.Topology.Linear, 2],  # VAE mesh shape = (1, 8) is more memory efficient.
         [(2, 4), 0, 1, (1, 8), 0, 1, ttnn.Topology.Linear, 1],
         [(4, 8), 1, 0, (4, 8), 0, 1, ttnn.Topology.Linear, 4],  # note sp <-> tp switch for VAE for memory efficiency.
         [(4, 8), 1, 0, (4, 8), 0, 1, ttnn.Topology.Linear, 2],  # note sp <-> tp switch for VAE for memory efficiency.
@@ -238,6 +237,15 @@ def test_mochi_pipeline_performance(
             "denoising": 1320,
             "vae": 55,
             "total": 1385,
+        }
+    elif tuple(mesh_device.shape) == (2, 2) and vae_mesh_shape == (1, 4):
+        assert is_blackhole(), "2x2 is only supported for blackhole"
+        # Tighten these once we have a stable BH QuietBox baseline in CI.
+        expected_metrics = {
+            "encoder": 8.0,
+            "denoising": 2600,
+            "vae": 90,
+            "total": 2700,
         }
     elif tuple(mesh_device.shape) == (4, 8) and vae_mesh_shape == (4, 8):
         expected_metrics = {

--- a/models/tt_dit/tests/models/mochi/test_performance_mochi.py
+++ b/models/tt_dit/tests/models/mochi/test_performance_mochi.py
@@ -46,6 +46,7 @@ from ....pipelines.mochi.pipeline_mochi import MochiPipeline as TTMochiPipeline
 def test_mochi_pipeline_performance(
     *,
     mesh_device: ttnn.MeshDevice,
+    model_location_generator,
     model_name: str,
     image_w: int,
     image_h: int,
@@ -95,7 +96,10 @@ def test_mochi_pipeline_performance(
     logger.info(f"DiT SP axis: {sp_axis}, TP axis: {tp_axis}")
     logger.info(f"VAE SP axis: {vae_sp_axis}, TP axis: {tp_axis}")
 
-    tt_pipe = TTMochiPipeline.create_pipeline(mesh_device=mesh_device, checkpoint_name=model_name)
+    tt_pipe = TTMochiPipeline.create_pipeline(
+        mesh_device=mesh_device,
+        checkpoint_name=model_location_generator(model_name),
+    )
 
     # Test prompts
     prompts = [

--- a/models/tt_dit/tests/models/mochi/test_pipeline_mochi.py
+++ b/models/tt_dit/tests/models/mochi/test_pipeline_mochi.py
@@ -112,10 +112,9 @@ def test_mochi_diffusers_pipeline():
 @pytest.mark.parametrize(
     "mesh_device, sp_axis, tp_axis, vae_mesh_shape, vae_sp_axis, vae_tp_axis, num_links",
     [
-        # VAE mesh shape = (1, 8) is more memory efficient.
         [(2, 2), 0, 1, (2, 2), 0, 1, 2],
         [(1, 8), 1, 0, (1, 8), 0, 1, 1],
-        [(2, 4), 0, 1, (1, 8), 0, 1, 1],
+        [(2, 4), 0, 1, (1, 8), 0, 1, 1],  # VAE mesh shape = (1, 8) is more memory efficient.
         [(4, 8), 1, 0, (4, 8), 0, 1, 4],  # note sp <-> tp switch for VAE for memory efficiency.
     ],
     ids=[

--- a/models/tt_dit/tests/models/mochi/test_pipeline_mochi.py
+++ b/models/tt_dit/tests/models/mochi/test_pipeline_mochi.py
@@ -112,13 +112,13 @@ def test_mochi_diffusers_pipeline():
 @pytest.mark.parametrize(
     "mesh_device, sp_axis, tp_axis, vae_mesh_shape, vae_sp_axis, vae_tp_axis, num_links",
     [
-        [(2, 2), 0, 1, (2, 2), 0, 1, 2],
+        [(2, 2), 0, 1, (1, 4), 0, 1, 2],  # VAE mesh shape = (1, 4) is more memory efficient.
         [(1, 8), 1, 0, (1, 8), 0, 1, 1],
         [(2, 4), 0, 1, (1, 8), 0, 1, 1],  # VAE mesh shape = (1, 8) is more memory efficient.
         [(4, 8), 1, 0, (4, 8), 0, 1, 4],  # note sp <-> tp switch for VAE for memory efficiency.
     ],
     ids=[
-        "dit_2x2sp0tp1_vae_2x2sp0tp1",
+        "dit_2x2sp0tp1_vae_1x4sp0tp1",
         "dit_1x8sp1tp0_vae_1x8sp0tp1",
         "dit_2x4sp0tp1_vae_1x8sp0tp1",
         "dit_4x8sp1tp0_vae_4x8sp0tp1",

--- a/models/tt_dit/tests/models/mochi/test_pipeline_mochi.py
+++ b/models/tt_dit/tests/models/mochi/test_pipeline_mochi.py
@@ -113,11 +113,13 @@ def test_mochi_diffusers_pipeline():
     "mesh_device, sp_axis, tp_axis, vae_mesh_shape, vae_sp_axis, vae_tp_axis, num_links",
     [
         # VAE mesh shape = (1, 8) is more memory efficient.
+        [(2, 2), 0, 1, (2, 2), 0, 1, 2],
         [(1, 8), 1, 0, (1, 8), 0, 1, 1],
         [(2, 4), 0, 1, (1, 8), 0, 1, 1],
         [(4, 8), 1, 0, (4, 8), 0, 1, 4],  # note sp <-> tp switch for VAE for memory efficiency.
     ],
     ids=[
+        "dit_2x2sp0tp1_vae_2x2sp0tp1",
         "dit_1x8sp1tp0_vae_1x8sp0tp1",
         "dit_2x4sp0tp1_vae_1x8sp0tp1",
         "dit_4x8sp1tp0_vae_4x8sp0tp1",

--- a/models/tt_dit/tests/models/wan2_2/test_pipeline_wan.py
+++ b/models/tt_dit/tests/models/wan2_2/test_pipeline_wan.py
@@ -2,10 +2,14 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import itertools
+import os
+
 import numpy as np
 import pytest
 import torch
 from diffusers.utils import export_to_video
+from loguru import logger
 
 import ttnn
 from models.tt_dit.pipelines.wan.pipeline_wan import WanPipeline
@@ -13,6 +17,10 @@ from models.tt_dit.pipelines.wan.pipeline_wan import WanPipeline
 from ....utils.test import line_params, ring_params
 
 
+@pytest.mark.parametrize(
+    "no_prompt",
+    [{"1": True, "0": False}.get(os.environ.get("NO_PROMPT"), False)],
+)
 @pytest.mark.parametrize(
     "mesh_device, mesh_shape, sp_axis, tp_axis, num_links, dynamic_load, device_params, topology, is_fsdp",
     [
@@ -53,17 +61,13 @@ def test_pipeline_inference(
     width,
     height,
     is_fsdp,
+    no_prompt,
 ):
     parent_mesh = mesh_device
     mesh_device = parent_mesh.create_submesh(ttnn.MeshShape(*mesh_shape))
-    # Test parameters
-    prompt = "Two anthropomorphic cats in comfy boxing gear and bright gloves fight intensely on a spotlighted stage."
 
     num_frames = 81
     num_inference_steps = 40
-
-    print(f"Running inference with prompt: '{prompt}'")
-    print(f"Parameters: {height}x{width}, {num_frames} frames, {num_inference_steps} steps")
 
     pipeline = WanPipeline.create_pipeline(
         mesh_device=mesh_device,
@@ -76,41 +80,54 @@ def test_pipeline_inference(
         checkpoint_name="Wan-AI/Wan2.2-T2V-A14B-Diffusers",
     )
 
-    seed = 42
-    # Run inference
-    with torch.no_grad():
-        result = pipeline(
-            prompt=prompt,
-            height=height,
-            width=width,
-            num_frames=num_frames,
-            num_inference_steps=num_inference_steps,
-            seed=seed,
-            guidance_scale=4.0,
-            guidance_scale_2=3.0,
-        )
+    prompt = "Two anthropomorphic cats in comfy boxing gear and bright gloves fight intensely on a spotlighted stage."
 
-    # Check output
-    if hasattr(result, "frames"):
-        frames = result.frames
+    def run(*, prompt, number, seed):
+        logger.info(f"Running inference with prompt: '{prompt}'")
+        logger.info(f"Parameters: {height}x{width}, {num_frames} frames, {num_inference_steps} steps")
+
+        with torch.no_grad():
+            result = pipeline(
+                prompt=prompt,
+                height=height,
+                width=width,
+                num_frames=num_frames,
+                num_inference_steps=num_inference_steps,
+                seed=seed,
+                guidance_scale=4.0,
+                guidance_scale_2=3.0,
+            )
+
+        if hasattr(result, "frames"):
+            frames = result.frames
+        else:
+            frames = result[0] if isinstance(result, tuple) else result
+
+        logger.info(f"Inference completed successfully")
+        logger.info(f"  Output shape: {frames.shape if hasattr(frames, 'shape') else 'Unknown'}")
+        logger.info(f"  Output type: {type(frames)}")
+
+        if isinstance(frames, np.ndarray):
+            logger.info(f"  Video data range: [{frames.min():.3f}, {frames.max():.3f}]")
+        elif isinstance(frames, torch.Tensor):
+            logger.info(f"  Video data range: [{frames.min().item():.3f}, {frames.max().item():.3f}]")
+
+        # Remove batch dimension
+        frames = frames[0]
+        output_filename = f"wan_t2v_{width}x{height}_{number}.mp4"
+        try:
+            export_to_video(frames, output_filename, fps=16)
+            logger.info(f"Saved video to: {output_filename}")
+        except AttributeError as e:
+            logger.info(f"AttributeError: {e}")
+
+    if no_prompt:
+        run(prompt=prompt, number=0, seed=42)
     else:
-        frames = result[0] if isinstance(result, tuple) else result
-
-    print(f"✓ Inference completed successfully")
-    print(f"  Output shape: {frames.shape if hasattr(frames, 'shape') else 'Unknown'}")
-    print(f"  Output type: {type(frames)}")
-
-    # Basic validation
-    if isinstance(frames, np.ndarray):
-        print(f"  Video data range: [{frames.min():.3f}, {frames.max():.3f}]")
-    elif isinstance(frames, torch.Tensor):
-        print(f"  Video data range: [{frames.min().item():.3f}, {frames.max().item():.3f}]")
-
-    # Save video using diffusers utility
-    # Remove batch dimension
-    frames = frames[0]
-    try:
-        export_to_video(frames, "wan_output_video.mp4", fps=16)
-        print("✓ Saved video to: wan_output_video.mp4")
-    except AttributeError as e:
-        print(f"AttributeError: {e}")
+        for i in itertools.count():
+            new_prompt = input("Enter the input prompt, or q to exit: ")
+            if new_prompt:
+                prompt = new_prompt
+            if prompt[0] == "q":
+                break
+            run(prompt=prompt, number=i, seed=i)

--- a/models/tt_dit/tests/models/wan2_2/test_pipeline_wan_i2v.py
+++ b/models/tt_dit/tests/models/wan2_2/test_pipeline_wan_i2v.py
@@ -2,11 +2,15 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import itertools
+import os
+
 import numpy as np
 import PIL
 import pytest
 import torch
 from diffusers.utils import export_to_video
+from loguru import logger
 
 import ttnn
 from models.tt_dit.pipelines.wan.pipeline_wan_i2v import ImagePrompt, WanPipelineI2V
@@ -14,6 +18,10 @@ from models.tt_dit.pipelines.wan.pipeline_wan_i2v import ImagePrompt, WanPipelin
 from ....utils.test import line_params, ring_params
 
 
+@pytest.mark.parametrize(
+    "no_prompt",
+    [{"1": True, "0": False}.get(os.environ.get("NO_PROMPT"), False)],
+)
 @pytest.mark.parametrize(
     "mesh_device, mesh_shape, sp_axis, tp_axis, num_links, dynamic_load, device_params, topology, is_fsdp",
     [
@@ -57,12 +65,11 @@ def test_pipeline_inference(
     width,
     height,
     is_fsdp,
+    no_prompt,
 ):
     parent_mesh = mesh_device
     mesh_device = parent_mesh.create_submesh(ttnn.MeshShape(*mesh_shape))
 
-    # Test parameters
-    prompt = "The cat in the hat runs up the hill to the house."
     pil_image = PIL.Image.open("./prompt_image.png")
     image_prompt = [ImagePrompt(image=pil_image, frame_pos=0)]
     negative_prompt = "色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走"
@@ -71,9 +78,6 @@ def test_pipeline_inference(
     num_inference_steps = 40
     guidance_scale = 3.5
     guidance_scale_2 = 3.5
-
-    print(f"Running inference with prompt: '{prompt}'")
-    print(f"Parameters: {height}x{width}, {num_frames} frames, {num_inference_steps} steps")
 
     pipeline = WanPipelineI2V.create_pipeline(
         mesh_device=mesh_device,
@@ -85,42 +89,56 @@ def test_pipeline_inference(
         is_fsdp=is_fsdp,
     )
 
-    # Run inference
-    with torch.no_grad():
-        result = pipeline(
-            prompt=prompt,
-            image_prompt=image_prompt,
-            negative_prompt=negative_prompt,
-            height=height,
-            width=width,
-            num_frames=num_frames,
-            num_inference_steps=num_inference_steps,
-            guidance_scale=guidance_scale,
-            guidance_scale_2=guidance_scale_2,
-        )
+    prompt = "The cat in the hat runs up the hill to the house."
 
-    # Check output
-    if hasattr(result, "frames"):
-        frames = result.frames
+    def run(*, prompt, number, seed):
+        logger.info(f"Running inference with prompt: '{prompt}'")
+        logger.info(f"Parameters: {height}x{width}, {num_frames} frames, {num_inference_steps} steps")
+
+        with torch.no_grad():
+            result = pipeline(
+                prompt=prompt,
+                image_prompt=image_prompt,
+                negative_prompt=negative_prompt,
+                height=height,
+                width=width,
+                num_frames=num_frames,
+                num_inference_steps=num_inference_steps,
+                seed=seed,
+                guidance_scale=guidance_scale,
+                guidance_scale_2=guidance_scale_2,
+            )
+
+        if hasattr(result, "frames"):
+            frames = result.frames
+        else:
+            frames = result[0] if isinstance(result, tuple) else result
+
+        logger.info(f"Inference completed successfully")
+        logger.info(f"  Output shape: {frames.shape if hasattr(frames, 'shape') else 'Unknown'}")
+        logger.info(f"  Output type: {type(frames)}")
+
+        if isinstance(frames, np.ndarray):
+            logger.info(f"  Video data range: [{frames.min():.3f}, {frames.max():.3f}]")
+        elif isinstance(frames, torch.Tensor):
+            logger.info(f"  Video data range: [{frames.min().item():.3f}, {frames.max().item():.3f}]")
+
+        # Remove batch dimension
+        frames = frames[0]
+        output_filename = f"wan_i2v_{width}x{height}_{number}.mp4"
+        try:
+            export_to_video(frames, output_filename, fps=16)
+            logger.info(f"Saved video to: {output_filename}")
+        except AttributeError as e:
+            logger.info(f"AttributeError: {e}")
+
+    if no_prompt:
+        run(prompt=prompt, number=0, seed=42)
     else:
-        frames = result[0] if isinstance(result, tuple) else result
-
-    print(f"✓ Inference completed successfully")
-    print(f"  Output shape: {frames.shape if hasattr(frames, 'shape') else 'Unknown'}")
-    print(f"  Output type: {type(frames)}")
-
-    # Basic validation
-    if isinstance(frames, np.ndarray):
-        print(f"  Video data range: [{frames.min():.3f}, {frames.max():.3f}]")
-    elif isinstance(frames, torch.Tensor):
-        print(f"  Video data range: [{frames.min().item():.3f}, {frames.max().item():.3f}]")
-
-    # Save video using diffusers utility
-    # Remove batch dimension
-    frames = frames[0]
-
-    try:
-        export_to_video(frames, "wan_output_video.mp4", fps=16)
-    except AttributeError as e:
-        print(f"AttributeError: {e}")
-    print("✓ Saved video to: wan_output_video.mp4")
+        for i in itertools.count():
+            new_prompt = input("Enter the input prompt, or q to exit: ")
+            if new_prompt:
+                prompt = new_prompt
+            if prompt[0] == "q":
+                break
+            run(prompt=prompt, number=i, seed=i)

--- a/tests/pipeline_reorg/blackhole_demo_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_demo_tests.yaml
@@ -289,6 +289,15 @@
   team: models
   model-name: flux.1-dev
 
+- name: Mochi BH QuietBox 2 performance (2x2sp0tp1)
+  cmd: HF_HUB_CACHE=/localdev/blackhole_demos/huggingface_data/genmo TT_DIT_CACHE_DIR="/tmp/TT_DIT_CACHE" pytest models/tt_dit/tests/models/mochi/test_performance_mochi.py -k "dit_2x2sp0tp1_vae_1x4sp0tp1_BH_QB" --timeout=1800
+  skus:
+    bh_quietbox_2:
+      timeout: 30
+  owner_id: U06BXU8RWQ2 # Kevin Mi
+  team: models
+  model-name: mochi
+
 - name: Wan2.2-T2V-A14B BH QuietBox 2 performance
   cmd: HF_HUB_CACHE=/localdev/blackhole_demos/huggingface_data/Wan-AI TT_DIT_CACHE_DIR="/tmp/TT_DIT_CACHE" pytest models/tt_dit/tests/models/wan2_2/test_performance_wan.py -k "2x2sp0tp1 and resolution_480p and t2v" --timeout=1200
   skus:

--- a/tests/scripts/t3000/run_t3000_demo_tests.sh
+++ b/tests/scripts/t3000/run_t3000_demo_tests.sh
@@ -393,7 +393,7 @@ run_t3000_wan22_tests() {
   echo "LOG_METAL: Running run_t3000_wan22_tests"
 
   export TT_DIT_CACHE_DIR="/tmp/TT_DIT_CACHE"
-  pytest models/tt_dit/tests/models/wan2_2/test_pipeline_wan.py -k "2x4sp0tp1 and resolution_480p" --timeout 1500; fail+=$?
+  NO_PROMPT=1 pytest models/tt_dit/tests/models/wan2_2/test_pipeline_wan.py -k "2x4sp0tp1 and resolution_480p" --timeout 1500; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-shield/actions/runs/23148662691/job/67254679853#step:21:222

### Problem description
When `MochiPipeline.create_pipeline` is called with a `(2, 2)` mesh on non-Blackhole (Wormhole) hardware, line 360 raises a `KeyError` because the non-Blackhole `default_config` dict only has entries for `(2, 4)` and `(4, 8)` — there is no `(2, 2)` key. Wormhole does not have enough memory to support Mochi on a 2x2 mesh, so rather than adding a config, we assert.

### What's changed

1. **Assert on WH 2x2** — Added an assertion in `MochiPipeline.create_pipeline` that prevents running Mochi on a `(2, 2)` Wormhole mesh (insufficient memory), replacing the uninformative `KeyError` with a clear error message.

2. **Add Mochi to QB2 CI** — Added a Mochi BH QuietBox 2 performance test (`dit_2x2sp0tp1_vae_1x4sp0tp1_BH_QB`) to `blackhole_demo_tests.yaml` and made Mochi selectable in the BH demo workflow.

3. **Add 2x2 BH test parametrization** — Added `dit_2x2sp0tp1_vae_2x2sp0tp1` to `test_pipeline_mochi.py` and 2x2 BH performance thresholds to `test_performance_mochi.py`.

4. **Update Wan2.2 docs** — Updated `Wan2_2.md` with specific supported device configurations (Blackhole and Wormhole systems), a Scalability section, per-system pytest commands (including BH 2x4), and performance tables with current 480p/720p thresholds from `test_performance_wan.py`, matching the style of `Flux1.md`.

5. **Enable interactive user input for Wan2.2 pipeline tests** — Added `NO_PROMPT` env variable support to `test_pipeline_wan.py` (T2V) and `test_pipeline_wan_i2v.py` (I2V), matching the pattern used by SD3.5, Flux1, Mochi, Motif, and QwenImage pipeline tests. When `NO_PROMPT=1` (CI), runs with hardcoded prompts. When unset, enters an interactive loop for user-provided prompts. Also adds `NO_PROMPT=1` to the T3000 demo script.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kevinmi/fix-mochi-2x2-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kevinmi/fix-mochi-2x2-config)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=kevinmi/fix-mochi-2x2-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:kevinmi/fix-mochi-2x2-config)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kevinmi/fix-mochi-2x2-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kevinmi/fix-mochi-2x2-config)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early

#### Model tests

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kevinmi/fix-mochi-2x2-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kevinmi/fix-mochi-2x2-config)
  - [ ] `models-mandatory` preset
  - [ ] other selection: `pytest models/tt_dit/tests/models/mochi/test_pipeline_mochi.py -k "2x2"`