### PR TITLE
[#40012] Support In-Process Topology Updates after Link Recovery 

### DIFF
--- a/tools/scaleout/cabling_generator/cabling_generator.cpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.cpp
@@ -1230,10 +1230,9 @@ static tt::scaleout_tools::fsd::proto::FactorySystemDescriptor build_factory_sys
         host->set_motherboard(deployment_host.motherboard);
     }
 
-    // Only include board types and connections for hosts that are in deployment_hosts.
+    // Only include board types and connections for hosts present in the deployment.
     const size_t num_deployment_hosts = deployment_hosts.size();
 
-    // Add board types that are present in the deployment descriptor only
     for (const auto& [host_id, node] : host_id_to_node) {
         if (*host_id >= num_deployment_hosts) {
             continue;
@@ -1246,7 +1245,6 @@ static tt::scaleout_tools::fsd::proto::FactorySystemDescriptor build_factory_sys
         }
     }
 
-    // Add ASIC connections (only between hosts present in deployment)
     for (const auto& [start, end] : chip_connections) {
         if (*start.host_id >= num_deployment_hosts || *end.host_id >= num_deployment_hosts) {
             continue;

--- a/tools/scaleout/cabling_generator/cabling_generator.cpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.cpp
@@ -1230,8 +1230,14 @@ static tt::scaleout_tools::fsd::proto::FactorySystemDescriptor build_factory_sys
         host->set_motherboard(deployment_host.motherboard);
     }
 
-    // Add board types
+    // Only include board types and connections for hosts that are in deployment_hosts.
+    const size_t num_deployment_hosts = deployment_hosts.size();
+
+    // Add board types that are present in the deployment descriptor only
     for (const auto& [host_id, node] : host_id_to_node) {
+        if (*host_id >= num_deployment_hosts) {
+            continue;
+        }
         for (const auto& [tray_id, board] : node->boards) {
             auto* board_location = fsd.mutable_board_types()->add_board_locations();
             board_location->set_host_id(*host_id);
@@ -1240,8 +1246,11 @@ static tt::scaleout_tools::fsd::proto::FactorySystemDescriptor build_factory_sys
         }
     }
 
-    // Add ASIC connections from chip_connections
+    // Add ASIC connections (only between hosts present in deployment)
     for (const auto& [start, end] : chip_connections) {
+        if (*start.host_id >= num_deployment_hosts || *end.host_id >= num_deployment_hosts) {
+            continue;
+        }
         auto* connection = fsd.mutable_eth_connections()->add_connection();
 
         auto* endpoint_a = connection->mutable_endpoint_a();

--- a/tools/scaleout/validation/run_cluster_validation.cpp
+++ b/tools/scaleout/validation/run_cluster_validation.cpp
@@ -406,9 +406,7 @@ int main(int argc, char* argv[]) {
         return -1;
     }
     if (links_reset) {
-        // Return and ask user to run again, otherwise some incorrect HW states might persist and cause hangs
-        log_output_rank0("Ethernet Links were Retrained. Please run the validation tool again to issue traffic.");
-        return 0;
+        cluster.rediscover_ethernet_links();
     }
 
     ConnectivityValidationConfig validation_config{

--- a/tools/scaleout/validation/utils/cluster_validation_utils.cpp
+++ b/tools/scaleout/validation/utils/cluster_validation_utils.cpp
@@ -31,6 +31,7 @@
 #include <yaml-cpp/yaml.h>
 #include "protobuf/factory_system_descriptor.pb.h"
 #include <llrt/tt_cluster.hpp>
+#include "umd/device/utils/semver.hpp"
 
 namespace tt::scaleout_tools {
 
@@ -1350,6 +1351,22 @@ void reset_local_ethernet_links(
         }
     }
 
+    // DEBUG: Log how many links will be reset and which ones. If this is 0 for a directed reset,
+    // the link was skipped (likely because it is cross-node and dst host != my host).
+    log_warning(
+        tt::LogDistributed,
+        "[DEBUG reset_local_ethernet_links] {} link(s) queued for local reset (my_host={})",
+        links_to_reset.size(),
+        physical_system_descriptor.my_host_name());
+    for (const auto& link : links_to_reset) {
+        log_warning(
+            tt::LogDistributed,
+            "[DEBUG reset_local_ethernet_links]   chip_id={} chan={} | {}",
+            link.chip_id,
+            link.channel,
+            link.log_message);
+    }
+
     // Perform resets on all links in vector
     send_reset_msg_to_links(links_to_reset);
 }
@@ -1610,8 +1627,18 @@ void perform_link_reset(
     uint32_t reset_asic_location,
     uint32_t reset_channel,
     PhysicalSystemDescriptor& physical_system_descriptor) {
-    bool link_retrain_supported = tt::tt_metal::MetalContext::instance().get_cluster().arch() == tt::ARCH::WORMHOLE_B0;
-    TT_FATAL(link_retrain_supported, "Link reset is only supported on WORMHOLE_B0 architecture");
+    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+    const bool link_retrain_supported =
+        (cluster.arch() == tt::ARCH::WORMHOLE_B0 ||
+         (cluster.arch() == tt::ARCH::BLACKHOLE &&
+          cluster.get_ethernet_firmware_version() >= tt::umd::semver_t(1, 9, 0)));
+    TT_FATAL(
+        link_retrain_supported,
+        "Link reset is only supported on WORMHOLE_B0 or BLACKHOLE with ETH FW >= 1.9.0 (detected arch: {}, FW: {})",
+        cluster.arch(),
+        cluster.get_ethernet_firmware_version().has_value()
+            ? cluster.get_ethernet_firmware_version()->to_string()
+            : "unknown");
 
     tt::tt_metal::AsicTopology reset_topology =
         build_reset_topology(reset_host, reset_tray_id, reset_asic_location, reset_channel, physical_system_descriptor);

--- a/tools/scaleout/validation/utils/cluster_validation_utils.cpp
+++ b/tools/scaleout/validation/utils/cluster_validation_utils.cpp
@@ -1351,22 +1351,6 @@ void reset_local_ethernet_links(
         }
     }
 
-    // DEBUG: Log how many links will be reset and which ones. If this is 0 for a directed reset,
-    // the link was skipped (likely because it is cross-node and dst host != my host).
-    log_warning(
-        tt::LogDistributed,
-        "[DEBUG reset_local_ethernet_links] {} link(s) queued for local reset (my_host={})",
-        links_to_reset.size(),
-        physical_system_descriptor.my_host_name());
-    for (const auto& link : links_to_reset) {
-        log_warning(
-            tt::LogDistributed,
-            "[DEBUG reset_local_ethernet_links]   chip_id={} chan={} | {}",
-            link.chip_id,
-            link.channel,
-            link.log_message);
-    }
-
     // Perform resets on all links in vector
     send_reset_msg_to_links(links_to_reset);
 }

--- a/tools/scaleout/validation/utils/ethernet_link_api.cpp
+++ b/tools/scaleout/validation/utils/ethernet_link_api.cpp
@@ -47,6 +47,20 @@ void reset_links_wh(const std::vector<ResetLink>& links_to_reset) {
         do {
             cluster.read_core(reset_status, sizeof(uint32_t), tt_cxy_pair(link.chip_id, coord), eth_retrain_addr);
         } while (reset_status[0]);
+
+        // DEBUG: Read ETH_TRAIN_STATUS_ADDR (0x1104) immediately after RETRAIN_FORCE clears to check
+        // whether the FW has updated the training status. Expected: 1 (SUCCESS). If 0 (IN_PROGRESS),
+        // the FW either hasn't finished writing yet or doesn't update this register during forced retrains.
+        constexpr tt::tt_metal::DeviceAddr ETH_TRAIN_STATUS_ADDR = 0x1104;
+        std::vector<uint32_t> train_status = {0};
+        cluster.read_core(train_status, sizeof(uint32_t), tt_cxy_pair(link.chip_id, coord), ETH_TRAIN_STATUS_ADDR);
+        log_warning(
+            tt::LogDistributed,
+            "[DEBUG reset_links_wh] chip_id={} chan={} ETH_TRAIN_STATUS (0x1104)={} after RETRAIN_FORCE cleared "
+            "(0=IN_PROGRESS, 1=SUCCESS, 2=FAIL)",
+            link.chip_id,
+            link.channel,
+            train_status[0]);
     }
 }
 

--- a/tools/scaleout/validation/utils/ethernet_link_api.cpp
+++ b/tools/scaleout/validation/utils/ethernet_link_api.cpp
@@ -47,20 +47,6 @@ void reset_links_wh(const std::vector<ResetLink>& links_to_reset) {
         do {
             cluster.read_core(reset_status, sizeof(uint32_t), tt_cxy_pair(link.chip_id, coord), eth_retrain_addr);
         } while (reset_status[0]);
-
-        // DEBUG: Read ETH_TRAIN_STATUS_ADDR (0x1104) immediately after RETRAIN_FORCE clears to check
-        // whether the FW has updated the training status. Expected: 1 (SUCCESS). If 0 (IN_PROGRESS),
-        // the FW either hasn't finished writing yet or doesn't update this register during forced retrains.
-        constexpr tt::tt_metal::DeviceAddr ETH_TRAIN_STATUS_ADDR = 0x1104;
-        std::vector<uint32_t> train_status = {0};
-        cluster.read_core(train_status, sizeof(uint32_t), tt_cxy_pair(link.chip_id, coord), ETH_TRAIN_STATUS_ADDR);
-        log_warning(
-            tt::LogDistributed,
-            "[DEBUG reset_links_wh] chip_id={} chan={} ETH_TRAIN_STATUS (0x1104)={} after RETRAIN_FORCE cleared "
-            "(0=IN_PROGRESS, 1=SUCCESS, 2=FAIL)",
-            link.chip_id,
-            link.channel,
-            train_status[0]);
     }
 }
 

--- a/tools/tests/scaleout/test_link_retraining.cpp
+++ b/tools/tests/scaleout/test_link_retraining.cpp
@@ -17,17 +17,15 @@
 
 namespace tt::scaleout_tools {
 
-// WH: ETH_TRAIN_STATUS_ADDR (0x1104) in the node_info FW layout.
-//     Values: 0 = IN_PROGRESS, 1 = SUCCESS, 2 = FAIL.
-// BH: port_status field inside eth_status_t in boot_results_t, at BOOT_RESULTS_ADDR + 4 = 0x7CC04.
-//     Values: 0 = PORT_UNKNOWN (in-progress), 1 = PORT_UP (success), 2 = PORT_DOWN (fail).
-// Both architectures use the same 0/1/2 encoding, matching EthTrainingStatus::IN_PROGRESS/SUCCESS/FAIL.
+// Returns the L1 address of the ETH training status register for the given arch.
+// WH: ETH_TRAIN_STATUS_ADDR (0x1104)
+// BH: port_status in boot_results_t (BOOT_RESULTS_ADDR + 4).
+// Both use the same encoding: 0 = IN_PROGRESS, 1 = SUCCESS, 2 = FAIL.
 [[nodiscard]] uint32_t get_eth_train_status_addr(const tt::Cluster& cluster) {
     if (cluster.arch() == tt::ARCH::WORMHOLE_B0) {
-        return tt::umd::wormhole::ETH_TRAIN_STATUS_ADDR;  // 0x1104
+        return tt::umd::wormhole::ETH_TRAIN_STATUS_ADDR;
     }
     if (cluster.arch() == tt::ARCH::BLACKHOLE) {
-        // port_status is the second uint32_t in eth_status_t, located at BOOT_RESULTS_ADDR + 4.
         return tt::umd::blackhole::BOOT_RESULTS_ADDR +
                static_cast<uint32_t>(offsetof(tt::umd::blackhole::eth_status_t, port_status));
     }

--- a/tools/tests/scaleout/test_link_retraining.cpp
+++ b/tools/tests/scaleout/test_link_retraining.cpp
@@ -8,6 +8,8 @@
 #include "tt_metal/fabric/physical_system_discovery.hpp"
 #include "tt_metal/llrt/tt_cluster.hpp"
 #include <umd/device/types/xy_pair.hpp>
+#include <umd/device/types/wormhole_eth.hpp>
+#include <umd/device/types/blackhole_eth.hpp>
 #include <factory_system_descriptor/utils.hpp>
 #include <gtest/gtest.h>
 #include <yaml-cpp/yaml.h>
@@ -15,7 +17,22 @@
 
 namespace tt::scaleout_tools {
 
-constexpr uint32_t ETH_TRAINING_STATUS_REG = 0x1104;
+// WH: ETH_TRAIN_STATUS_ADDR (0x1104) in the node_info FW layout.
+//     Values: 0 = IN_PROGRESS, 1 = SUCCESS, 2 = FAIL.
+// BH: port_status field inside eth_status_t in boot_results_t, at BOOT_RESULTS_ADDR + 4 = 0x7CC04.
+//     Values: 0 = PORT_UNKNOWN (in-progress), 1 = PORT_UP (success), 2 = PORT_DOWN (fail).
+// Both architectures use the same 0/1/2 encoding, matching EthTrainingStatus::IN_PROGRESS/SUCCESS/FAIL.
+[[nodiscard]] uint32_t get_eth_train_status_addr(const tt::Cluster& cluster) {
+    if (cluster.arch() == tt::ARCH::WORMHOLE_B0) {
+        return tt::umd::wormhole::ETH_TRAIN_STATUS_ADDR;  // 0x1104
+    }
+    if (cluster.arch() == tt::ARCH::BLACKHOLE) {
+        // port_status is the second uint32_t in eth_status_t, located at BOOT_RESULTS_ADDR + 4.
+        return tt::umd::blackhole::BOOT_RESULTS_ADDR +
+               static_cast<uint32_t>(offsetof(tt::umd::blackhole::eth_status_t, port_status));
+    }
+    TT_THROW("Unsupported architecture for ETH training status check: {}", cluster.arch());
+}
 
 struct LinkDescriptors {
     std::string host;
@@ -34,7 +51,7 @@ struct LinkDescriptors {
 
 void set_link_training_status(const tt::Cluster& cluster, ChipId chip_id, const tt_xy_pair& coord, uint32_t status) {
     const std::vector<uint32_t> status_data{status};
-    cluster.write_core(chip_id, coord, status_data, ETH_TRAINING_STATUS_REG);
+    cluster.write_core(chip_id, coord, status_data, get_eth_train_status_addr(cluster));
     cluster.l1_barrier(chip_id);
 }
 
@@ -53,13 +70,12 @@ protected:
         driver_ = &cluster_->get_driver();
         distributed_context_ = context_->get_distributed_context_ptr();
 
-        // Check if running on T3K (8 WH devices)
-        auto* const cluster_desc = (*driver_)->get_cluster_description();
-        const size_t num_devices = cluster_->get_unique_chip_ids().size();
-        const auto board_type = cluster_desc->get_board_type(0);
-
-        if (num_devices != 8 || board_type != BoardType::N300) {
-            GTEST_SKIP() << "This test requires a T3K system";
+        const bool link_retrain_supported =
+            cluster_->arch() == tt::ARCH::WORMHOLE_B0 ||
+            (cluster_->arch() == tt::ARCH::BLACKHOLE &&
+             cluster_->get_ethernet_firmware_version() >= tt::umd::semver_t(1, 9, 0));
+        if (!link_retrain_supported) {
+            GTEST_SKIP() << "Link retraining not supported on this system (requires WH or BH with ETH FW >= 1.9.0)";
         }
 
         // Initialize physical system descriptor
@@ -82,12 +98,14 @@ public:
         return *physical_system_descriptor_;
     }
     const std::unordered_map<uint64_t, ChipId>& get_asic_id_to_chip_id() const { return asic_id_to_chip_id_; }
-    std::string get_cabling_descriptor_path() const { return "tools/tests/scaleout/cabling_descriptors/t3k.textproto"; }
+    std::string get_cabling_descriptor_path() const {
+        return "/data/scaleout_configs/bh_glx_exabox/cabling_descriptor.textproto";
+    }
 };
 
 [[nodiscard]] uint32_t get_link_training_status(const tt::Cluster& cluster, ChipId chip_id, const tt_xy_pair& coord) {
     std::vector<uint32_t> status(1, 0);
-    cluster.read_core(status, sizeof(uint32_t), tt_cxy_pair(chip_id, coord), ETH_TRAINING_STATUS_REG);
+    cluster.read_core(status, sizeof(uint32_t), tt_cxy_pair(chip_id, coord), get_eth_train_status_addr(cluster));
     return status[0];
 }
 
@@ -178,7 +196,6 @@ TEST_F(DirectedRetrainingFixture, TestActiveEthRetraining) {
         driver_ref, distributed_context_, context_->rtoptions().get_target_device(), true, true);
     get_physical_system_descriptor().merge(std::move(new_psd));
 
-    // Validate connectivity after link reset
     validate_connectivity(get_physical_system_descriptor(), get_cabling_descriptor_path());
 }
 
@@ -321,7 +338,6 @@ TEST_F(DirectedRetrainingFixture, TestOnDemandCableRestart) {
         EXPECT_EQ(get_link_training_status(get_cluster(), link.chip_id, link.coord), 1);
     }
 
-    // Validate connectivity after link resets using T3K cabling descriptor
     validate_connectivity(get_physical_system_descriptor(), get_cabling_descriptor_path());
 }
 

--- a/tools/tests/scaleout/test_link_retraining.cpp
+++ b/tools/tests/scaleout/test_link_retraining.cpp
@@ -96,9 +96,7 @@ public:
         return *physical_system_descriptor_;
     }
     const std::unordered_map<uint64_t, ChipId>& get_asic_id_to_chip_id() const { return asic_id_to_chip_id_; }
-    std::string get_cabling_descriptor_path() const {
-        return "/data/scaleout_configs/bh_glx_exabox/cabling_descriptor.textproto";
-    }
+    std::string get_cabling_descriptor_path() const { return "tools/tests/scaleout/cabling_descriptors/t3k.textproto"; }
 };
 
 [[nodiscard]] uint32_t get_link_training_status(const tt::Cluster& cluster, ChipId chip_id, const tt_xy_pair& coord) {
@@ -336,6 +334,47 @@ TEST_F(DirectedRetrainingFixture, TestOnDemandCableRestart) {
         EXPECT_EQ(get_link_training_status(get_cluster(), link.chip_id, link.coord), 1);
     }
 
+    validate_connectivity(get_physical_system_descriptor(), get_cabling_descriptor_path());
+}
+
+TEST_F(DirectedRetrainingFixture, TestLinkRetrainingWithDescriptorRefresh) {
+    validate_connectivity(get_physical_system_descriptor(), get_cabling_descriptor_path());
+
+    // Take down MMIO-to-MMIO and non-MMIO-to-non-MMIO links
+    process_ethernet_connections(
+        get_physical_system_descriptor(),
+        get_asic_id_to_chip_id(),
+        get_cluster(),
+        get_driver(),
+        [&](ChipId chip_id, const tt_xy_pair& coord) { set_link_training_status(get_cluster(), chip_id, coord, 0); });
+
+    // Retrain all downed links
+    reset_ethernet_links(
+        get_physical_system_descriptor(),
+        get_physical_system_descriptor().get_asic_topology(get_physical_system_descriptor().my_host_name()));
+
+    // Verify links are back up at the register level
+    process_ethernet_connections(
+        get_physical_system_descriptor(),
+        get_asic_id_to_chip_id(),
+        get_cluster(),
+        get_driver(),
+        [&](ChipId chip_id, const tt_xy_pair& coord) {
+            EXPECT_EQ(get_link_training_status(get_cluster(), chip_id, coord), 1);
+        });
+
+    // Refresh the cluster descriptor so the driver sees the recovered topology
+    auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+    cluster.rediscover_ethernet_links();
+
+    // Re-run physical system discovery with the refreshed descriptor
+    auto& driver_ref = const_cast<tt::umd::Cluster&>(*get_driver());
+    get_physical_system_descriptor().clear();
+    auto new_psd = tt::tt_metal::run_physical_system_discovery(
+        driver_ref, distributed_context_, context_->rtoptions().get_target_device(), true, true);
+    get_physical_system_descriptor().merge(std::move(new_psd));
+
+    // Validate that the refreshed topology matches the expected cabling
     validate_connectivity(get_physical_system_descriptor(), get_cabling_descriptor_path());
 }
 

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -264,13 +264,13 @@ bool Cluster::is_ubb_galaxy() const { return Cluster::is_ubb_galaxy(this->cluste
 
 tt::tt_metal::ClusterType Cluster::get_cluster_type() const { return this->cluster_type_; }
 
-BoardType Cluster::get_board_type(ChipId chip_id) const { return this->cluster_desc_->get_board_type(chip_id); }
+BoardType Cluster::get_board_type(ChipId chip_id) const { return this->get_cluster_desc()->get_board_type(chip_id); }
 
 bool Cluster::is_base_routing_fw_enabled() const { return Cluster::is_base_routing_fw_enabled(this->cluster_type_); }
 
 void Cluster::generate_cluster_descriptor() {
-    this->cluster_desc_ = this->driver_->get_cluster_description();
-    this->cluster_type_ = Cluster::get_cluster_type_from_cluster_desc(this->rtoptions_, this->cluster_desc_);
+    this->cluster_type_ =
+        Cluster::get_cluster_type_from_cluster_desc(this->rtoptions_, this->get_cluster_desc());
     if (this->cluster_type_ == tt::tt_metal::ClusterType::CUSTOM) {
         TT_FATAL(
             this->rtoptions_.is_custom_fabric_mesh_graph_desc_path_specified(),
@@ -283,7 +283,7 @@ void Cluster::generate_cluster_descriptor() {
 
     if (this->arch_ == tt::ARCH::BLACKHOLE) {
         TT_FATAL(
-            this->cluster_desc_->get_noc_translation_table_en().at(0),
+            this->get_cluster_desc()->get_noc_translation_table_en().at(0),
             "Running Metal on Blackhole requires FW >= 80.18.0.0");
     }
 }
@@ -321,7 +321,7 @@ void Cluster::initialize_device_drivers() {
     this->get_metal_desc_from_tt_desc();
     this->validate_harvesting_masks();
 
-    for (const auto& [mmio_device_id, controlled_devices] : this->cluster_desc_->get_chips_grouped_by_closest_mmio()) {
+    for (const auto& [mmio_device_id, controlled_devices] : this->get_cluster_desc()->get_chips_grouped_by_closest_mmio()) {
         this->assign_mem_channels_to_devices(mmio_device_id, controlled_devices);
     }
 
@@ -373,11 +373,8 @@ void Cluster::get_metal_desc_from_tt_desc() {
         silicon_dram_metadata_yaml = get_soc_description_file(this->arch_, this->target_type_, rtoptions_);
     }
     for (const auto& id : this->driver_->get_target_device_ids()) {
-        tt::umd::SocDescriptor umd_soc = this->driver_->get_soc_descriptor(id);
-        if (this->target_type_ == TargetDevice::Silicon) {
-            umd_soc.device_descriptor_file_path = silicon_dram_metadata_yaml;
-        }
-        this->sdesc_per_chip_.emplace(id, metal_SocDescriptor(umd_soc, this->cluster_desc_->get_board_type(id)));
+        this->sdesc_per_chip_.emplace(
+            id, metal_SocDescriptor(this->driver_->get_soc_descriptor(id), this->get_cluster_desc()->get_board_type(id)));
     }
 }
 
@@ -516,17 +513,17 @@ Cluster::~Cluster() {
 }
 
 std::unordered_map<ChipId, EthCoord> Cluster::get_user_chip_ethernet_coordinates() const {
-    auto user_chip_ethernet_coordinates = this->cluster_desc_->get_chip_locations();
+    auto user_chip_ethernet_coordinates = this->get_cluster_desc()->get_chip_locations();
     if (this->is_galaxy_cluster()) {
         std::erase_if(user_chip_ethernet_coordinates, [this](const auto& entry) {
-            return this->cluster_desc_->get_board_type(entry.first) != BoardType::GALAXY;
+            return this->get_cluster_desc()->get_board_type(entry.first) != BoardType::GALAXY;
         });
     }
     return user_chip_ethernet_coordinates;
 }
 
 std::unordered_map<ChipId, EthCoord> Cluster::get_all_chip_ethernet_coordinates() const {
-    return this->cluster_desc_->get_chip_locations();
+    return this->get_cluster_desc()->get_chip_locations();
 }
 
 ChipId Cluster::get_physical_chip_id_from_eth_coord(const EthCoord& eth_coord) const {
@@ -543,7 +540,7 @@ size_t Cluster::number_of_user_devices() const {
     if (this->cluster_type_ == tt::tt_metal::ClusterType::TG) {
         const auto& chips = this->driver_->get_target_device_ids();
         return std::count_if(chips.begin(), chips.end(), [&](const auto& id) {
-            return this->cluster_desc_->get_board_type(id) == BoardType::GALAXY;
+            return this->get_cluster_desc()->get_board_type(id) == BoardType::GALAXY;
         });
     }
     return this->driver_->get_target_device_ids().size();
@@ -554,7 +551,7 @@ std::set<ChipId> Cluster::user_exposed_chip_ids() const {
         std::set<ChipId> galaxy_boards;
         const auto& chips = this->driver_->get_target_device_ids();
         for (const auto& id : chips) {
-            if (this->cluster_desc_->get_board_type(id) == BoardType::GALAXY) {
+            if (this->get_cluster_desc()->get_board_type(id) == BoardType::GALAXY) {
                 galaxy_boards.insert(id);
             }
         }
@@ -733,7 +730,7 @@ std::unordered_map<int, int> Cluster::get_worker_logical_to_virtual_y(ChipId chi
 
 int Cluster::get_device_aiclk(const ChipId& chip_id) const { return this->driver_->get_chip(chip_id)->get_clock(); }
 
-uint16_t Cluster::get_bus_id(ChipId chip) const { return this->cluster_desc_->get_bus_id(chip); }
+uint16_t Cluster::get_bus_id(ChipId chip) const { return this->get_cluster_desc()->get_bus_id(chip); }
 
 std::optional<int> Cluster::get_physical_slot(ChipId chip) const {
     if (this->target_type_ != tt::TargetDevice::Silicon) {
@@ -800,7 +797,7 @@ bool Cluster::supports_dma_operations(ChipId chip_id, uint32_t sz_in_bytes) cons
 
     // DMA reads and writes are only supported on WH. If/when DMA reads and writes are supported on BH, this should be
     // updated to support BH architectures as well. See https://github.com/tenstorrent/tt-metal/issues/22957
-    return this->arch_ == tt::ARCH::WORMHOLE_B0 && this->cluster_desc_->is_chip_mmio_capable(chip_id) &&
+    return this->arch_ == tt::ARCH::WORMHOLE_B0 && this->get_cluster_desc()->is_chip_mmio_capable(chip_id) &&
            sz_in_bytes >= min_dma_size_bytes;
 }
 
@@ -827,7 +824,7 @@ void Cluster::write_core(const void* mem_ptr, uint32_t sz_in_bytes, tt_cxy_pair 
         this->driver_->write_to_device(mem_ptr, sz_in_bytes, core.chip, core_coord, addr);
     }
 
-    if (this->cluster_desc_->is_chip_remote(chip_id)) {
+    if (this->get_cluster_desc()->is_chip_remote(chip_id)) {
         this->driver_->wait_for_non_mmio_flush(chip_id);
     }
 }
@@ -877,7 +874,7 @@ void Cluster::write_core_immediate(const void* mem_ptr, uint32_t sz_in_bytes, tt
     tt::umd::CoreCoord core_coord = soc_desc.get_coord_at(core, CoordSystem::TRANSLATED);
     this->driver_->write_to_device_reg(mem_ptr, sz_in_bytes, core.chip, core_coord, addr);
 
-    if (this->cluster_desc_->is_chip_remote(chip_id)) {
+    if (this->get_cluster_desc()->is_chip_remote(chip_id)) {
         this->driver_->wait_for_non_mmio_flush(chip_id);
     }
 }
@@ -906,7 +903,7 @@ void Cluster::write_reg(const std::uint32_t* mem_ptr, tt_cxy_pair target, uint64
     }
     tt::umd::CoreCoord target_coord = soc_desc.get_coord_at(target, CoordSystem::TRANSLATED);
     this->driver_->write_to_device_reg(mem_ptr, size_in_bytes, target.chip, target_coord, addr);
-    if (this->cluster_desc_->is_chip_remote(chip_id)) {
+    if (this->get_cluster_desc()->is_chip_remote(chip_id)) {
         this->driver_->wait_for_non_mmio_flush(chip_id);
     }
 }
@@ -964,20 +961,20 @@ void Cluster::noc_multicast_write(
 
     this->driver_->noc_multicast_write(const_cast<void*>(mem_ptr), sz_in_bytes, chip_id, start_coord, end_coord, addr);
 
-    if (this->cluster_desc_->is_chip_remote(chip_id)) {
+    if (this->get_cluster_desc()->is_chip_remote(chip_id)) {
         this->driver_->wait_for_non_mmio_flush(chip_id);
     }
 }
 
 void Cluster::write_sysmem(
     const void* vec, uint32_t size_in_bytes, uint64_t addr, ChipId src_device_id, uint16_t channel) const {
-    TT_ASSERT(this->cluster_desc_->is_chip_mmio_capable(src_device_id));
+    TT_ASSERT(this->get_cluster_desc()->is_chip_mmio_capable(src_device_id));
     this->driver_->write_to_sysmem(vec, size_in_bytes, addr, channel & HOST_MEM_CHANNELS_MASK, src_device_id);
 }
 
 void Cluster::read_sysmem(
     void* vec, uint32_t size_in_bytes, uint64_t addr, ChipId src_device_id, uint16_t channel) const {
-    TT_ASSERT(this->cluster_desc_->is_chip_mmio_capable(src_device_id));
+    TT_ASSERT(this->get_cluster_desc()->is_chip_mmio_capable(src_device_id));
     this->driver_->read_from_sysmem(vec, addr, channel & HOST_MEM_CHANNELS_MASK, size_in_bytes, src_device_id);
 }
 
@@ -1046,17 +1043,17 @@ void Cluster::l1_barrier(ChipId chip_id) const {
 }
 
 uint32_t Cluster::get_num_host_channels(ChipId device_id) const {
-    bool mmio_capable = this->cluster_desc_->is_chip_mmio_capable(device_id);
+    bool mmio_capable = this->get_cluster_desc()->is_chip_mmio_capable(device_id);
     return mmio_capable ? this->driver_->get_num_host_channels(device_id) : 0;
 }
 
 uint32_t Cluster::get_host_channel_size(ChipId device_id, uint32_t channel) const {
-    TT_ASSERT(this->cluster_desc_->is_chip_mmio_capable(device_id));
+    TT_ASSERT(this->get_cluster_desc()->is_chip_mmio_capable(device_id));
     return this->driver_->get_host_channel_size(device_id, channel & HOST_MEM_CHANNELS_MASK);
 }
 
 void* Cluster::host_dma_address(uint64_t offset, ChipId src_device_id, uint16_t channel) const {
-    TT_ASSERT(this->cluster_desc_->is_chip_mmio_capable(src_device_id));
+    TT_ASSERT(this->get_cluster_desc()->is_chip_mmio_capable(src_device_id));
     return this->driver_->host_dma_address(offset, src_device_id, channel & HOST_MEM_CHANNELS_MASK);
 }
 
@@ -1072,7 +1069,7 @@ const std::unordered_set<ChipId>& Cluster::get_devices_controlled_by_mmio_device
 std::unordered_map<ChipId, std::vector<CoreCoord>> Cluster::get_ethernet_cores_grouped_by_connected_chips(
     ChipId chip_id) const {
     std::unordered_map<ChipId, std::vector<CoreCoord>> connected_chips;
-    const auto& all_eth_connections = this->cluster_desc_->get_ethernet_connections();
+    const auto& all_eth_connections = this->get_cluster_desc()->get_ethernet_connections();
     if (!all_eth_connections.contains(chip_id)) {
         return {};
     }
@@ -1082,7 +1079,7 @@ std::unordered_map<ChipId, std::vector<CoreCoord>> Cluster::get_ethernet_cores_g
             std::vector<CoreCoord> active_ethernet_cores;
 
             for (const auto& channel_pair :
-                 this->cluster_desc_->get_directly_connected_ethernet_channels_between_chips(chip_id, other_chip_id)) {
+                 this->get_cluster_desc()->get_directly_connected_ethernet_channels_between_chips(chip_id, other_chip_id)) {
                 EthernetChannel local_chip_chan = std::get<0>(channel_pair);
                 active_ethernet_cores.emplace_back(
                     get_soc_desc(chip_id).get_eth_core_for_channel(local_chip_chan, CoordSystem::LOGICAL));
@@ -1140,7 +1137,7 @@ void Cluster::disable_ethernet_cores_with_retrain() {
         for (const auto& [other_chip_id, eth_cores] : connected_chips) {
             for (const auto& eth_core : eth_cores) {
                 if (rtoptions_.get_skip_eth_cores_with_retrain() and
-                    this->cluster_desc_->get_board_type(chip_id) == BoardType::UBB) {
+                    this->get_cluster_desc()->get_board_type(chip_id) == BoardType::UBB) {
                     tt_cxy_pair virtual_eth_core(
                         chip_id, get_virtual_coordinate_from_logical_coordinates(chip_id, eth_core, CoreType::ETH));
                     this->read_core(read_vec, sizeof(uint32_t), virtual_eth_core, retrain_count_addr_);
@@ -1159,13 +1156,10 @@ void Cluster::disable_ethernet_cores_with_retrain() {
 }
 
 void Cluster::rediscover_ethernet_links() {
-    // Update the UMD descriptor's ethernet fields in-place; cluster_desc_ raw pointer remains valid.
-    this->driver_->rediscover_ethernet_links();
+    this->driver_->refresh_cluster_description();
 
-    // Add any newly active eth cores to routing info as IDLE (existing entries are left untouched).
     this->initialize_ethernet_cores_router_mode();
 
-    // Rebuild from fresh descriptor state.
     this->ethernet_sockets_.clear();
     this->frequent_retrain_cores_.clear();
     this->disable_ethernet_cores_with_retrain();
@@ -1173,7 +1167,7 @@ void Cluster::rediscover_ethernet_links() {
 }
 
 void Cluster::initialize_ethernet_cores_router_mode() {
-    for (const auto& [assoc_mmio_device, devices] : this->cluster_desc_->get_chips_grouped_by_closest_mmio()) {
+    for (const auto& [assoc_mmio_device, devices] : this->get_cluster_desc()->get_chips_grouped_by_closest_mmio()) {
         for (const auto& chip_id : devices) {
             if (!this->device_eth_routing_info_.contains(chip_id)) {
                 this->device_eth_routing_info_.insert({chip_id, {}});
@@ -1183,7 +1177,7 @@ void Cluster::initialize_ethernet_cores_router_mode() {
         for (const auto& chip_id : devices) {
             // Mark all remaining ethernet cores as idle to be used by fabric
             const auto& soc_desc = get_soc_desc(chip_id);
-            for (const auto& eth_channel : cluster_desc_->get_active_eth_channels(chip_id)) {
+            for (const auto& eth_channel : get_cluster_desc()->get_active_eth_channels(chip_id)) {
                 auto eth_core = soc_desc.get_eth_core_for_channel(eth_channel, CoordSystem::LOGICAL);
                 // Chip ID is guaranteed to be present in device_eth_routing_info_, since it was populated above
                 auto& routing_info = this->device_eth_routing_info_[chip_id];
@@ -1260,7 +1254,7 @@ void Cluster::reserve_ethernet_cores_for_fabric_routers(uint8_t num_routing_plan
                 // Last link reserved for dispatch
                 // Only need fabric routers in the same tunnel
                 // TODO: https://github.com/tenstorrent/tt-metal/issues/24413
-                const auto is_mmio_device = [&](int id) { return cluster_desc_->is_chip_mmio_capable(id); };
+                const auto is_mmio_device = [&](int id) { return get_cluster_desc()->is_chip_mmio_capable(id); };
                 const auto is_last_link = [&]() { return num_reserved_cores == num_cores_to_reserve - 1; };
                 if (is_last_link() && is_mmio_device(chip_id) && is_mmio_device(connected_chip_id)) {
                     num_reserved_cores++;
@@ -1340,7 +1334,7 @@ std::vector<CoreCoord> Cluster::get_fabric_ethernet_routers_between_src_and_dest
 bool Cluster::is_ethernet_link_up(ChipId chip_id, const CoreCoord& logical_core) const {
     const auto& soc_desc = get_soc_desc(chip_id);
     EthernetChannel eth_chan = soc_desc.logical_eth_core_to_chan_map.at(logical_core);
-    return this->cluster_desc_->ethernet_core_has_active_ethernet_link(chip_id, eth_chan);
+    return this->get_cluster_desc()->ethernet_core_has_active_ethernet_link(chip_id, eth_chan);
 }
 
 std::tuple<ChipId, CoreCoord> Cluster::get_connected_ethernet_core(std::tuple<ChipId, CoreCoord> eth_core) const {
@@ -1359,7 +1353,7 @@ std::tuple<ChipId, CoreCoord> Cluster::get_connected_ethernet_core(std::tuple<Ch
         std::get<0>(eth_core),
         std::get<1>(eth_core).str());
     auto connected_eth_core =
-        this->cluster_desc_->get_chip_and_channel_of_remote_ethernet_core(std::get<0>(eth_core), eth_chan);
+        this->get_cluster_desc()->get_chip_and_channel_of_remote_ethernet_core(std::get<0>(eth_core), eth_chan);
     return std::make_tuple(
         std::get<0>(connected_eth_core),
         soc_desc.get_eth_core_for_channel(std::get<1>(connected_eth_core), CoordSystem::LOGICAL));
@@ -1531,11 +1525,6 @@ uint32_t Cluster::get_alignment_requirements(ChipId chip_id, uint32_t size_in_by
         return this->hal_->get_dma_alignment();
     }
     return 1;
-}
-
-umd::ClusterDescriptor* Cluster::get_cluster_desc() const {
-    TT_FATAL(this->cluster_desc_ != nullptr, "Cluster descriptor is not initialized.");
-    return this->cluster_desc_;
 }
 
 const std::unique_ptr<tt::umd::Cluster>& Cluster::get_driver() const {

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -1158,6 +1158,20 @@ void Cluster::disable_ethernet_cores_with_retrain() {
     }
 }
 
+void Cluster::rediscover_ethernet_links() {
+    // Update the UMD descriptor's ethernet fields in-place; cluster_desc_ raw pointer remains valid.
+    this->driver_->rediscover_ethernet_links();
+
+    // Add any newly active eth cores to routing info as IDLE (existing entries are left untouched).
+    this->initialize_ethernet_cores_router_mode();
+
+    // Rebuild from fresh descriptor state.
+    this->ethernet_sockets_.clear();
+    this->frequent_retrain_cores_.clear();
+    this->disable_ethernet_cores_with_retrain();
+    this->initialize_ethernet_sockets();
+}
+
 void Cluster::initialize_ethernet_cores_router_mode() {
     for (const auto& [assoc_mmio_device, devices] : this->cluster_desc_->get_chips_grouped_by_closest_mmio()) {
         for (const auto& chip_id : devices) {

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -87,7 +87,7 @@ public:
 
     std::set<ChipId> all_pci_chip_ids() const { return this->driver_->get_target_mmio_device_ids(); }
 
-    umd::ClusterDescriptor* get_cluster_desc() const;
+    umd::ClusterDescriptor* get_cluster_desc() const { return this->driver_->get_cluster_description(); }
 
     const std::unique_ptr<tt::umd::Cluster>& get_driver() const;
 
@@ -97,12 +97,12 @@ public:
     // TODO: UMD will eventually consolidate ethernet coordinates and unique ids, we can remove the ethernet coord
     // getter after that change is in
     const std::unordered_map<ChipId, uint64_t>& get_unique_chip_ids() const {
-        return this->cluster_desc_->get_chip_unique_ids();
+        return this->get_cluster_desc()->get_chip_unique_ids();
     }
 
     // Returns map of logical chip ID to PCIe device ID
     const std::unordered_map<ChipId, ChipId>& get_chips_with_mmio() const {
-        return this->cluster_desc_->get_chips_with_mmio();
+        return this->get_cluster_desc()->get_chips_with_mmio();
     }
 
     std::unordered_map<ChipId, EthCoord> get_all_chip_ethernet_coordinates() const;
@@ -279,18 +279,18 @@ public:
 
     const std::unordered_map<ChipId, std::unordered_map<EthernetChannel, std::tuple<ChipId, EthernetChannel>>>&
     get_ethernet_connections() const {
-        return this->cluster_desc_->get_ethernet_connections();
+        return this->get_cluster_desc()->get_ethernet_connections();
     }
 
     // TODO: unify uint64_t with ChipUID
     const std::unordered_map<ChipId, std::unordered_map<EthernetChannel, std::tuple<uint64_t, EthernetChannel>>>&
     get_ethernet_connections_to_remote_devices() const {
-        return this->cluster_desc_->get_ethernet_connections_to_remote_devices();
+        return this->get_cluster_desc()->get_ethernet_connections_to_remote_devices();
     }
 
     // Returns MMIO device ID (logical) that controls given `device_id`. If `device_id` is MMIO device it is returned.
     ChipId get_associated_mmio_device(ChipId device_id) const {
-        return this->cluster_desc_->get_closest_mmio_capable_chip(device_id);
+        return this->get_cluster_desc()->get_closest_mmio_capable_chip(device_id);
     }
 
     uint16_t get_assigned_channel_for_device(ChipId device_id) const {
@@ -420,11 +420,6 @@ private:
     bool iommu_enabled_ = false;
     // Cached system NOC mapping status to avoid slow queries at MeshDevice construction
     bool noc_mapping_enabled_ = false;
-
-    // Need to hold reference to cluster descriptor to detect total number of devices available in cluster
-    // UMD static APIs `detect_available_device_ids` and `detect_number_of_chips` only returns number of MMIO mapped
-    // devices
-    umd::ClusterDescriptor* cluster_desc_ = nullptr;
 
     // There is an entry for every device that can be targeted (MMIO and remote)
     std::unordered_map<ChipId, metal_SocDescriptor> sdesc_per_chip_;

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -374,6 +374,10 @@ public:
         return this->frequent_retrain_cores_.at(chip_id);
     }
 
+    // Re-runs UMD topology discovery and rebuilds ethernet_sockets_ and frequent_retrain_cores_.
+    // Call after link retraining to allow continued operation without restarting the process.
+    void rediscover_ethernet_links();
+
     const std::unordered_map<CoreCoord, EthRouterMode>& get_eth_routing_info(ChipId chip_id) const {
         return this->device_eth_routing_info_.at(chip_id);
     }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/40012

### Status

Waiting for https://github.com/tenstorrent/tt-umd/pull/2343 merge

### Problem description
- `run_cluster_validation` exited early after retraining ethernet links, requiring a full re-invocation to send traffic — preventing single-run validate-recover-traffic workflows
- `perform_link_reset` rejected Blackhole systems unconditionally, despite BH ETH FW ≥ 1.9.0 supporting link retraining
- `build_factory_system_descriptor` included board types and connections for all hosts in the cabling descriptor, causing an out-of-bounds access when validating on a subset of the full system

### What's changed
- Added `Cluster::rediscover_ethernet_links()` at both the UMD and tt-metal layers: re-runs topology discovery in-place and rebuilds `ethernet_sockets_` and `frequent_retrain_cores_` without restarting the process; `run_cluster_validation` now calls this after retraining and proceeds directly to traffic generation
- Extended `perform_link_reset` arch guard to allow Blackhole with ETH FW ≥ 1.9.0, and updated `test_link_retraining` to use an arch-aware ETH training status address (WH: `0x1104`, BH: `port_status` in `boot_results_t`)
- Fixed `build_factory_system_descriptor` to filter board types and eth connections to only the hosts present in the deployment descriptor


### Local testing

1. Reserved galaxy
2. Went to https://github.com/tenstorrent/tt-metal/tree/asaigal/eth_link_down
3. Ran `./build_Release/test/tools/scaleout/test_link_retraining --gtest_filter="*TestOnDemandCableRestart*"`
4. Ran `./build/tools/scaleout/run_cluster_validation --deployment-descriptor-path /data/scaleout_configs/bh_glx_exabox/deployment_descriptor.textproto --cabling-descriptor-path /data/scaleout_configs/bh_glx_exabox/cabling_descriptor.textproto --send-traffic`
5. Got https://gist.github.com/jpanasiukTT/8304ab6f33f4123ee1e698926027721a (no traffic sent, bad, needs tt-smi -glx_reset to work properly)
6. Reran the command and got https://gist.github.com/jpanasiukTT/06aa355edd0037d5dd28e43b5c9cb215 (all works all good)
7. Ran `./build_Release/test/tools/scaleout/test_link_retraining --gtest_filter="*TestOnDemandCableRestart*"` still on Aditya's branch
8. Checked out to this branch
9. Ran `./build/tools/scaleout/run_cluster_validation --deployment-descriptor-path /data/scaleout_configs/bh_glx_exabox/deployment_descriptor.textproto --cabling-descriptor-path /data/scaleout_configs/bh_glx_exabox/cabling_descriptor.textproto --send-traffic`
10. Got https://gist.github.com/jpanasiukTT/c40ade1dd4b0ad2f6b36ec5e2b3533ed (traffic is being sent, hurray no tt-smi -glx_reset needed)
11. Celebrate

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jpanasiuk/rediscover_links)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jpanasiuk/rediscover_links)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jpanasiuk/rediscover_links)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jpanasiuk/rediscover_links)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jpanasiuk/rediscover_links)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jpanasiuk/rediscover_links)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jpanasiuk/rediscover_links)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jpanasiuk/rediscover_links)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jpanasiuk/rediscover_links)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jpanasiuk/rediscover_links)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jpanasiuk/rediscover_links)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jpanasiuk/rediscover_links)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jpanasiuk/rediscover_links)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jpanasiuk/rediscover_links)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jpanasiuk/rediscover_links)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jpanasiuk/rediscover_links)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jpanasiuk/rediscover_links)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jpanasiuk/rediscover_links)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jpanasiuk/rediscover_links)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jpanasiuk/rediscover_links)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jpanasiuk/rediscover_links)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jpanasiuk/rediscover_links)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jpanasiuk/rediscover_links)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jpanasiuk/rediscover_links)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jpanasiuk/rediscover_links)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jpanasiuk/rediscover_links)