### PR TITLE
Add missing total_size field to OverlappedTensor serialization/deserialization

### DIFF
--- a/models/demos/deepseek_v3_b1/prepare_weights.py
+++ b/models/demos/deepseek_v3_b1/prepare_weights.py
@@ -863,8 +863,23 @@ def _core_range_set_from_list(lst: list[list[list[int]]]) -> ttnn.CoreRangeSet:
     return ttnn.CoreRangeSet(ranges)
 
 
+_OVERLAPPED_SERIALIZED_FIELDS = {
+    "tensor_shape",
+    "shard_shape",
+    "core_range_set",
+    "dtype",
+    "tile_shape",
+    "byte_offset",
+    "total_size",
+}
+_OVERLAPPED_SKIP_FIELDS = {"fused_tensor"}
+
+
 def _overlapped_tensor_to_json(ot: OverlappedTensor) -> dict:
     """Serialize one OverlappedTensor's metadata to a JSON-serializable dict."""
+    all_fields = {f.name for f in fields(OverlappedTensor)}
+    missing = all_fields - _OVERLAPPED_SERIALIZED_FIELDS - _OVERLAPPED_SKIP_FIELDS
+    assert not missing, f"OverlappedTensor has new fields not serialized: {missing}"
     dtype_str = _DTYPE_TO_STR.get(ot.dtype)
     if dtype_str is None:
         dtype_str = str(ot.dtype)
@@ -875,6 +890,7 @@ def _overlapped_tensor_to_json(ot: OverlappedTensor) -> dict:
         "dtype": dtype_str,
         "tile_shape": list(ot.tile_shape),
         "byte_offset": ot.byte_offset,
+        "total_size": ot.total_size,
     }
 
 
@@ -886,6 +902,9 @@ def _overlapped_tensor_from_dict(
     dtype = _STR_TO_DTYPE.get(d["dtype"])
     if dtype is None:
         raise ValueError(f"Unknown dtype in manifest: {d['dtype']}")
+    total_size = d.get("total_size", 0)
+    if total_size == 0:
+        raise ValueError("manifest is missing 'total_size' for OverlappedTensor — regenerate the weight cache")
     return OverlappedTensor(
         fused_tensor=fused_tensor,
         tensor_shape=tuple(d["tensor_shape"]),
@@ -894,6 +913,7 @@ def _overlapped_tensor_from_dict(
         dtype=dtype,
         tile_shape=tuple(d["tile_shape"]),
         byte_offset=d["byte_offset"],
+        total_size=total_size,
     )
 
 

--- a/models/demos/deepseek_v3_b1/scripts/generate_cache.py
+++ b/models/demos/deepseek_v3_b1/scripts/generate_cache.py
@@ -15,7 +15,7 @@ Modes:
 
 Usage:
   python generate_cache.py --model-path /path/to/DeepSeek-V3 --output-path /path/to/cache --layer-num 0 --type dense
-  python generate_cache.py --model-path /path/to/DeepSeek-V3 --output-path /path/to/cache --layer-num 4 --type moe
+  python generate_cache.py --model-path /path/to/DeepSeek-V3 --output-path /path/to/cache --layer-num 3 4 5 6 --type moe
   python generate_cache.py --model-path /path/to/DeepSeek-V3 --output-path /path/to/cache --type embedding
   python generate_cache.py --model-path /path/to/DeepSeek-V3 --output-path /path/to/cache --type lm_head
 """
@@ -72,7 +72,7 @@ _PLACEMENTS_REPLICATE = [ttnn.PlacementReplicate()]  # MoE routed experts (per e
 
 def _create_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Generate weight cache for a single DeepSeek V3 layer from HuggingFace weights.",
+        description="Generate weight cache for one or more DeepSeek V3 layers from HuggingFace weights.",
     )
     parser.add_argument(
         "--model-path",
@@ -89,8 +89,9 @@ def _create_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--layer-num",
         type=int,
+        nargs="+",
         default=None,
-        help="Layer index (0-60); required for dense/moe, ignored for embedding/lm_head",
+        help="Layer index(es) (0-60); one or more, required for dense/moe, ignored for embedding/lm_head",
     )
     parser.add_argument(
         "--type",
@@ -114,20 +115,19 @@ def _create_parser() -> argparse.ArgumentParser:
 
 def _validate_args(args: argparse.Namespace) -> None:
     """Validate arguments and exit with message on failure."""
-    layer_num = args.layer_num
+    layer_nums = args.layer_num
     mode = args.mode
     output_path = args.output_path.resolve()
 
-    # Layer-num required and validated only for layer-based modes
     if mode in ("dense", "moe"):
-        if layer_num is None:
+        if not layer_nums:
             logger.error("--layer-num is required for type={}", mode)
             sys.exit(1)
-        if layer_num < 0 or layer_num >= NUM_LAYERS:
-            logger.error("layer-num must be in [0, {}], got {}", NUM_LAYERS - 1, layer_num)
-            sys.exit(1)
-        if mode == "dense":
-            if layer_num >= FIRST_K_DENSE_REPLACE:
+        for layer_num in layer_nums:
+            if layer_num < 0 or layer_num >= NUM_LAYERS:
+                logger.error("layer-num must be in [0, {}], got {}", NUM_LAYERS - 1, layer_num)
+                sys.exit(1)
+            if mode == "dense" and layer_num >= FIRST_K_DENSE_REPLACE:
                 logger.error(
                     "type=dense requires layer-num < {} (dense layers are 0-{}), got {}",
                     FIRST_K_DENSE_REPLACE,
@@ -135,8 +135,7 @@ def _validate_args(args: argparse.Namespace) -> None:
                     layer_num,
                 )
                 sys.exit(1)
-        else:
-            if layer_num < FIRST_K_DENSE_REPLACE:
+            if mode == "moe" and layer_num < FIRST_K_DENSE_REPLACE:
                 logger.error(
                     "type=moe requires layer-num >= {} (MoE layers are {}-{}), got {}",
                     FIRST_K_DENSE_REPLACE,
@@ -147,7 +146,6 @@ def _validate_args(args: argparse.Namespace) -> None:
                 sys.exit(1)
 
     if args.verify:
-        # Verify mode: no model-path; require output_path and cache dir/manifest
         if not output_path.exists():
             logger.error("output-path must exist for verify: {}", output_path)
             sys.exit(1)
@@ -162,17 +160,17 @@ def _validate_args(args: argparse.Namespace) -> None:
                 logger.error("lm_head/manifest.json not found for verify: {}", manifest_path)
                 sys.exit(1)
         else:
-            layer_dir = output_path / f"layer_{layer_num:03d}"
-            if not layer_dir.is_dir():
-                logger.error("Layer directory must exist for verify: {}", layer_dir)
-                sys.exit(1)
-            manifest_path = layer_dir / "manifest.json"
-            if not manifest_path.is_file():
-                logger.error("manifest.json not found for verify: {}", manifest_path)
-                sys.exit(1)
+            for layer_num in layer_nums:
+                layer_dir = output_path / f"layer_{layer_num:03d}"
+                if not layer_dir.is_dir():
+                    logger.error("Layer directory must exist for verify: {}", layer_dir)
+                    sys.exit(1)
+                manifest_path = layer_dir / "manifest.json"
+                if not manifest_path.is_file():
+                    logger.error("manifest.json not found for verify: {}", manifest_path)
+                    sys.exit(1)
         return
 
-    # Generate mode: require model-path and index
     if args.model_path is None:
         logger.error("--model-path is required for generate (omit --verify to generate)")
         sys.exit(1)
@@ -198,14 +196,15 @@ def _validate_args(args: argparse.Namespace) -> None:
                 logger.error("lm_head cache already exists. Use --force to overwrite.")
                 sys.exit(1)
         else:
-            layer_dir = output_path / f"layer_{layer_num:03d}"
-            manifest = layer_dir / "manifest.json"
-            if manifest.exists():
-                logger.error(
-                    "Layer {} cache already exists (manifest.json). Use --force to overwrite.",
-                    layer_num,
-                )
-                sys.exit(1)
+            for layer_num in layer_nums:
+                layer_dir = output_path / f"layer_{layer_num:03d}"
+                manifest = layer_dir / "manifest.json"
+                if manifest.exists():
+                    logger.error(
+                        "Layer {} cache already exists (manifest.json). Use --force to overwrite.",
+                        layer_num,
+                    )
+                    sys.exit(1)
 
 
 def _check_file(path: Path, layer_dir: Path) -> bool:
@@ -564,7 +563,7 @@ def main() -> int:
     args = parser.parse_args()
     _validate_args(args)
 
-    layer_num = args.layer_num
+    layer_nums = args.layer_num or []
     mode = args.mode
     output_path = args.output_path.resolve()
 
@@ -574,7 +573,11 @@ def main() -> int:
         elif mode == "lm_head":
             ok = _verify_lm_head_cache(output_path)
         else:
-            ok = _verify_cache(output_path, layer_num, mode)
+            ok = True
+            for layer_num in layer_nums:
+                if not _verify_cache(output_path, layer_num, mode):
+                    ok = False
+                    break
         return 0 if ok else 1
 
     model_path = args.model_path.resolve()
@@ -583,9 +586,9 @@ def main() -> int:
     total_t0 = time.perf_counter()
 
     logger.info(
-        "Generating cache: mode={}, layer_num={}, model_path={}, output_path={}",
+        "Generating cache: mode={}, layers={}, model_path={}, output_path={}",
         mode,
-        layer_num,
+        layer_nums if layer_nums else "N/A",
         model_path,
         output_path,
     )
@@ -594,7 +597,6 @@ def main() -> int:
     with LazyStateDict(model_path) as state_dict:
         logger.info("LazyStateDict initialized in {:.3f}s", time.perf_counter() - t0)
 
-        # Same initialization as bh_2d_mesh_device fixture (conftest.bh_2d_mesh_device_context).
         if not os.environ.get("TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS"):
             os.environ["TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS"] = "30000"
             logger.info("Set TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS=30000 (fabric init may be slow)")
@@ -615,37 +617,43 @@ def main() -> int:
             )
 
             if mode == "dense":
-                logger.info("Preparing dense decoder layer weights...")
-                t0 = time.perf_counter()
-                layer = prepare_dense_layer_weights(bdw, state_dict, layer_num)
-                logger.info("prepare_dense_layer_weights took {:.3f}s", time.perf_counter() - t0)
-                logger.info("Saving dense layer to disk...")
-                t0 = time.perf_counter()
-                save_decoder_layer(
-                    layer,
-                    output_path,
-                    layer_num,
-                    hf_model_name=manifest_kw["hf_model_name"],
-                    hf_state_dict_name=manifest_kw["hf_state_dict_name"],
-                    device_mesh_shape=manifest_kw["device_mesh_shape"],
-                )
-                logger.info("save_decoder_layer took {:.3f}s", time.perf_counter() - t0)
+                for layer_num in layer_nums:
+                    layer_t0 = time.perf_counter()
+                    logger.info("Preparing dense decoder layer {} weights...", layer_num)
+                    t0 = time.perf_counter()
+                    layer = prepare_dense_layer_weights(bdw, state_dict, layer_num)
+                    logger.info("prepare_dense_layer_weights took {:.3f}s", time.perf_counter() - t0)
+                    logger.info("Saving dense layer {} to disk...", layer_num)
+                    t0 = time.perf_counter()
+                    save_decoder_layer(
+                        layer,
+                        output_path,
+                        layer_num,
+                        hf_model_name=manifest_kw["hf_model_name"],
+                        hf_state_dict_name=manifest_kw["hf_state_dict_name"],
+                        device_mesh_shape=manifest_kw["device_mesh_shape"],
+                    )
+                    logger.info("save_decoder_layer took {:.3f}s", time.perf_counter() - t0)
+                    logger.info("Layer {} done in {:.3f}s", layer_num, time.perf_counter() - layer_t0)
             elif mode == "moe":
-                logger.info("Preparing full MoE layer weights...")
-                t0 = time.perf_counter()
-                layer = prepare_moe_layer_weights(bdw, state_dict, layer_num)
-                logger.info("prepare_moe_layer_weights took {:.3f}s", time.perf_counter() - t0)
-                logger.info("Saving MoE layer to disk...")
-                t0 = time.perf_counter()
-                save_decoder_layer(
-                    layer,
-                    output_path,
-                    layer_num,
-                    hf_model_name=manifest_kw["hf_model_name"],
-                    hf_state_dict_name=manifest_kw["hf_state_dict_name"],
-                    device_mesh_shape=manifest_kw["device_mesh_shape"],
-                )
-                logger.info("save_decoder_layer took {:.3f}s", time.perf_counter() - t0)
+                for layer_num in layer_nums:
+                    layer_t0 = time.perf_counter()
+                    logger.info("Preparing full MoE layer {} weights...", layer_num)
+                    t0 = time.perf_counter()
+                    layer = prepare_moe_layer_weights(bdw, state_dict, layer_num)
+                    logger.info("prepare_moe_layer_weights took {:.3f}s", time.perf_counter() - t0)
+                    logger.info("Saving MoE layer {} to disk...", layer_num)
+                    t0 = time.perf_counter()
+                    save_decoder_layer(
+                        layer,
+                        output_path,
+                        layer_num,
+                        hf_model_name=manifest_kw["hf_model_name"],
+                        hf_state_dict_name=manifest_kw["hf_state_dict_name"],
+                        device_mesh_shape=manifest_kw["device_mesh_shape"],
+                    )
+                    logger.info("save_decoder_layer took {:.3f}s", time.perf_counter() - t0)
+                    logger.info("Layer {} done in {:.3f}s", layer_num, time.perf_counter() - layer_t0)
             elif mode == "embedding":
                 logger.info("Preparing embedding weights...")
                 t0 = time.perf_counter()
@@ -669,7 +677,7 @@ def main() -> int:
     if mode in ("embedding", "lm_head"):
         logger.info("Cache generation complete (mode={}) in {:.3f}s", mode, elapsed)
     else:
-        logger.info("Cache generation complete for layer {} (mode={}) in {:.3f}s", layer_num, mode, elapsed)
+        logger.info("Cache generation complete for layers {} (mode={}) in {:.3f}s", layer_nums, mode, elapsed)
     return 0
 
 

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_prepare_weights.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_prepare_weights.py
@@ -14,6 +14,7 @@ Tests for prepare_weights: per-layer prepare/save/load on 4x2 mesh.
 """
 
 import time
+from dataclasses import fields as dataclass_fields
 
 import pytest
 import torch
@@ -94,6 +95,9 @@ def _core_range_set_to_tuples(crs):
     return sorted(((r.start.x, r.start.y), (r.end.x, r.end.y)) for r in crs.ranges())
 
 
+_OVERLAPPED_TENSOR_SKIPPED_FIELDS = {"fused_tensor"}
+
+
 def _assert_overlapped_tensors_match(a: OverlappedTensor, b: OverlappedTensor) -> None:
     """Assert two OverlappedTensors have matching metadata (not fused_tensor identity)."""
     assert a.tensor_shape == b.tensor_shape
@@ -101,7 +105,12 @@ def _assert_overlapped_tensors_match(a: OverlappedTensor, b: OverlappedTensor) -
     assert a.dtype == b.dtype
     assert a.tile_shape == b.tile_shape
     assert a.byte_offset == b.byte_offset
+    assert a.total_size == b.total_size
     assert _core_range_set_to_tuples(a.core_range_set) == _core_range_set_to_tuples(b.core_range_set)
+    checked = {"tensor_shape", "shard_shape", "dtype", "tile_shape", "byte_offset", "total_size", "core_range_set"}
+    all_fields = {f.name for f in dataclass_fields(OverlappedTensor)}
+    unchecked = all_fields - checked - _OVERLAPPED_TENSOR_SKIPPED_FIELDS
+    assert not unchecked, f"OverlappedTensor has new fields not covered by assertion: {unchecked}"
 
 
 def _assert_on_device(tensor: ttnn.Tensor) -> None:


### PR DESCRIPTION
### Summary

This change fixes a bug where the total size field of the overlapped tensor type was not preserved when serializing/deserializing.

Added test coverage to prevent similar issues in the future.

### Checklist

- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=esmal/fix-overlapped-tensor-serializer)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:esmal/fix-overlapped-tensor-serializer)
