### PR TITLE
[CI] Mitigate T3K llama3-70b destructor trace-release segfault

### DIFF
--- a/.github/workflows/t3000-demo-tests.yaml
+++ b/.github/workflows/t3000-demo-tests.yaml
@@ -7,33 +7,32 @@ on:
         description: "Select model to test"
         required: true
         type: choice
-        default: llama3_70b
+        default: all
         options:
-          # [TO REVERT] Keep only the target model while validating CI issue #40123.
+          - all
+          - falcon7b
+          - falcon40b
+          - llama3
+          - llama3_vision
+          - llama3_90b_vision
           - llama3_70b
-          # - all
-          # - falcon7b
-          # - falcon40b
-          # - llama3
-          # - llama3_vision
-          # - llama3_90b_vision
-          # - resnet50
-          # - sentence_bert
-          # - sd35_large
-          # - flux1-dev
-          # - motif
-          # - qwenimage
-          # - mistral
-          # - mixtral
-          # - whisper
-          # - qwen3
-          # - qwen25
-          # - qwen25_vl
-          # - qwen3_vl
-          # - gemma3
-          # - wan22
-          # - mochi
-          # - gpt-oss
+          - resnet50
+          - sentence_bert
+          - sd35_large
+          - flux1-dev
+          - motif
+          - qwenimage
+          - mistral
+          - mixtral
+          - whisper
+          - qwen3
+          - qwen25
+          - qwen25_vl
+          - qwen3_vl
+          - gemma3
+          - wan22
+          - mochi
+          - gpt-oss
       platform:
         required: false
         type: choice
@@ -63,17 +62,15 @@ on:
         type: boolean
         default: true
         description: "Set to false to allow write access to MLPerf mount"
-  # [TO REVERT] Disable scheduled broad runs for targeted validation-only dispatch.
-  # schedule:
-  #   - cron: '0 0 * * 1,3,5' # This cron schedule runs the workflow every Monday/Wednesday/Friday at 12am UTC
+  schedule:
+    - cron: '0 0 * * 1,3,5' # This cron schedule runs the workflow every Monday/Wednesday/Friday at 12am UTC
   workflow_call:
     inputs:
       model:
         description: "Select model to test (all, falcon7b, falcon40b, llama3, etc.)"
         required: false
         type: string
-        # [TO REVERT] Keep workflow_call default aligned to targeted validation model.
-        default: "llama3_70b"
+        default: "all"
       platform:
         required: false
         type: string

--- a/.github/workflows/t3000-demo-tests.yaml
+++ b/.github/workflows/t3000-demo-tests.yaml
@@ -7,32 +7,33 @@ on:
         description: "Select model to test"
         required: true
         type: choice
-        default: all
+        default: llama3_70b
         options:
-          - all
-          - falcon7b
-          - falcon40b
-          - llama3
-          - llama3_vision
-          - llama3_90b_vision
+          # [TO REVERT] Keep only the target model while validating CI issue #40123.
           - llama3_70b
-          - resnet50
-          - sentence_bert
-          - sd35_large
-          - flux1-dev
-          - motif
-          - qwenimage
-          - mistral
-          - mixtral
-          - whisper
-          - qwen3
-          - qwen25
-          - qwen25_vl
-          - qwen3_vl
-          - gemma3
-          - wan22
-          - mochi
-          - gpt-oss
+          # - all
+          # - falcon7b
+          # - falcon40b
+          # - llama3
+          # - llama3_vision
+          # - llama3_90b_vision
+          # - resnet50
+          # - sentence_bert
+          # - sd35_large
+          # - flux1-dev
+          # - motif
+          # - qwenimage
+          # - mistral
+          # - mixtral
+          # - whisper
+          # - qwen3
+          # - qwen25
+          # - qwen25_vl
+          # - qwen3_vl
+          # - gemma3
+          # - wan22
+          # - mochi
+          # - gpt-oss
       platform:
         required: false
         type: choice
@@ -62,15 +63,17 @@ on:
         type: boolean
         default: true
         description: "Set to false to allow write access to MLPerf mount"
-  schedule:
-    - cron: '0 0 * * 1,3,5' # This cron schedule runs the workflow every Monday/Wednesday/Friday at 12am UTC
+  # [TO REVERT] Disable scheduled broad runs for targeted validation-only dispatch.
+  # schedule:
+  #   - cron: '0 0 * * 1,3,5' # This cron schedule runs the workflow every Monday/Wednesday/Friday at 12am UTC
   workflow_call:
     inputs:
       model:
         description: "Select model to test (all, falcon7b, falcon40b, llama3, etc.)"
         required: false
         type: string
-        default: "all"
+        # [TO REVERT] Keep workflow_call default aligned to targeted validation model.
+        default: "llama3_70b"
       platform:
         required: false
         type: string

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -36,6 +36,7 @@ from models.tt_transformers.tt.common import (
 
 # Maximum total sequence length for batched prefill (batch_size * per_user_seq_len)
 MAX_BATCHED_PREFILL_SEQ_LEN = 128 * 1024
+SKIP_DESTRUCTOR_TRACE_RELEASE_ENV = "TT_TRANSFORMERS_SKIP_TRACE_RELEASE_IN_DESTRUCTOR"
 
 
 def max_prefill_chunk_size_cutoff(sequence_length, max_prefill_chunk_size):
@@ -2215,53 +2216,55 @@ class Generator(WarmupForwardMixin):
     ## Destructor
 
     def __del__(self):
-        # Release all captured traces to prevent nanobind memory leaks
-        # Traces must be released before closing the mesh device
-        try:
-            # Release prefill traces
-            if hasattr(self, "trace_id_prefill"):
-                for trace_key, trace_id in self.trace_id_prefill.items():
-                    if trace_id is not None:
-                        # Extract model_id from trace_key (format: "{prefill_seq_len}_{model_id}" or "{prefill_seq_len}_{model_id}_{batch_size}")
-                        parts = trace_key.split("_")
-                        model_id = int(parts[1]) if len(parts) >= 2 else 0
-                        try:
-                            ttnn.release_trace(self.model_args[model_id].mesh_device, trace_id)
-                        except Exception:
-                            pass  # Ignore errors during cleanup
+        skip_trace_release = os.getenv(SKIP_DESTRUCTOR_TRACE_RELEASE_ENV, "").lower() in ("1", "true", "yes")
+        if not skip_trace_release:
+            # Release all captured traces to prevent nanobind memory leaks
+            # Traces must be released before closing the mesh device
+            try:
+                # Release prefill traces
+                if hasattr(self, "trace_id_prefill"):
+                    for trace_key, trace_id in self.trace_id_prefill.items():
+                        if trace_id is not None:
+                            # Extract model_id from trace_key (format: "{prefill_seq_len}_{model_id}" or "{prefill_seq_len}_{model_id}_{batch_size}")
+                            parts = trace_key.split("_")
+                            model_id = int(parts[1]) if len(parts) >= 2 else 0
+                            try:
+                                ttnn.release_trace(self.model_args[model_id].mesh_device, trace_id)
+                            except Exception:
+                                pass  # Ignore errors during cleanup
 
-            # Release prefill sampling traces
-            if hasattr(self, "trace_id_prefill_sampling"):
-                for trace_key, trace_id in self.trace_id_prefill_sampling.items():
-                    if trace_id is not None:
-                        parts = trace_key.split("_")
-                        m_id = int(parts[-1]) if len(parts) >= 2 else 0
-                        try:
-                            ttnn.release_trace(self.model_args[m_id].mesh_device, trace_id)
-                        except Exception:
-                            pass
+                # Release prefill sampling traces
+                if hasattr(self, "trace_id_prefill_sampling"):
+                    for trace_key, trace_id in self.trace_id_prefill_sampling.items():
+                        if trace_id is not None:
+                            parts = trace_key.split("_")
+                            m_id = int(parts[-1]) if len(parts) >= 2 else 0
+                            try:
+                                ttnn.release_trace(self.model_args[m_id].mesh_device, trace_id)
+                            except Exception:
+                                pass
 
-            # Release decode traces
-            if hasattr(self, "trace_ids_decode"):
-                for sampling_key, trace_ids_dict in self.trace_ids_decode.items():
-                    if trace_ids_dict is not None:
-                        for model_id, trace_id in trace_ids_dict.items():
-                            if trace_id is not None:
-                                try:
-                                    ttnn.release_trace(self.model_args[model_id].mesh_device, trace_id)
-                                except Exception:
-                                    pass  # Ignore errors during cleanup
+                # Release decode traces
+                if hasattr(self, "trace_ids_decode"):
+                    for sampling_key, trace_ids_dict in self.trace_ids_decode.items():
+                        if trace_ids_dict is not None:
+                            for model_id, trace_id in trace_ids_dict.items():
+                                if trace_id is not None:
+                                    try:
+                                        ttnn.release_trace(self.model_args[model_id].mesh_device, trace_id)
+                                    except Exception:
+                                        pass  # Ignore errors during cleanup
 
-            # Release vision traces if present
-            if hasattr(self, "trace_ids"):
-                for model_id, trace_id in self.trace_ids.items():
-                    if trace_id is not None:
-                        try:
-                            ttnn.release_trace(self.mesh_device, trace_id)
-                        except Exception:
-                            pass  # Ignore errors during cleanup
-        except Exception:
-            pass  # Ignore any errors during trace cleanup
+                # Release vision traces if present
+                if hasattr(self, "trace_ids"):
+                    for model_id, trace_id in self.trace_ids.items():
+                        if trace_id is not None:
+                            try:
+                                ttnn.release_trace(self.mesh_device, trace_id)
+                            except Exception:
+                                pass  # Ignore errors during cleanup
+            except Exception:
+                pass  # Ignore any errors during trace cleanup
 
         # Workaround for issue #19052
         if self.data_parallel > 1:

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -2230,8 +2230,12 @@ class Generator(WarmupForwardMixin):
                             model_id = int(parts[1]) if len(parts) >= 2 else 0
                             try:
                                 ttnn.release_trace(self.model_args[model_id].mesh_device, trace_id)
-                            except Exception:
-                                pass  # Ignore errors during cleanup
+                            except Exception as e:
+                                # Keep destructor non-fatal, but log cleanup failures for diagnosis.
+                                logger.debug(
+                                    f"Failed to release prefill trace {trace_id} for key '{trace_key}' "
+                                    f"and model_id {model_id}: {e!r}"
+                                )
 
                 # Release prefill sampling traces
                 if hasattr(self, "trace_id_prefill_sampling"):
@@ -2241,8 +2245,12 @@ class Generator(WarmupForwardMixin):
                             m_id = int(parts[-1]) if len(parts) >= 2 else 0
                             try:
                                 ttnn.release_trace(self.model_args[m_id].mesh_device, trace_id)
-                            except Exception:
-                                pass
+                            except Exception as e:
+                                # Keep destructor non-fatal, but log cleanup failures for diagnosis.
+                                logger.debug(
+                                    f"Failed to release prefill sampling trace {trace_id} for key '{trace_key}' "
+                                    f"and model_id {m_id}: {e!r}"
+                                )
 
                 # Release decode traces
                 if hasattr(self, "trace_ids_decode"):
@@ -2252,8 +2260,12 @@ class Generator(WarmupForwardMixin):
                                 if trace_id is not None:
                                     try:
                                         ttnn.release_trace(self.model_args[model_id].mesh_device, trace_id)
-                                    except Exception:
-                                        pass  # Ignore errors during cleanup
+                                    except Exception as e:
+                                        # Keep destructor non-fatal, but log cleanup failures for diagnosis.
+                                        logger.debug(
+                                            f"Failed to release decode trace {trace_id} for sampling_key "
+                                            f"'{sampling_key}' and model_id {model_id}: {e!r}"
+                                        )
 
                 # Release vision traces if present
                 if hasattr(self, "trace_ids"):
@@ -2261,10 +2273,14 @@ class Generator(WarmupForwardMixin):
                         if trace_id is not None:
                             try:
                                 ttnn.release_trace(self.mesh_device, trace_id)
-                            except Exception:
-                                pass  # Ignore errors during cleanup
-            except Exception:
-                pass  # Ignore any errors during trace cleanup
+                            except Exception as e:
+                                # Keep destructor non-fatal, but log cleanup failures for diagnosis.
+                                logger.debug(
+                                    f"Failed to release vision trace {trace_id} for model_id {model_id}: {e!r}"
+                                )
+            except Exception as e:
+                # Keep destructor non-fatal, but retain context for unexpected cleanup errors.
+                logger.debug(f"Error during trace cleanup in Generator.__del__: {e!r}")
 
         # Workaround for issue #19052
         if self.data_parallel > 1:

--- a/tests/scripts/t3000/run_t3000_demo_tests.sh
+++ b/tests/scripts/t3000/run_t3000_demo_tests.sh
@@ -35,7 +35,8 @@ run_t3000_llama3_70b_tests() {
   llama70b=meta-llama/Llama-3.1-70B-Instruct
   tt_cache_llama70b=$TT_CACHE_HOME/$llama70b
 
-  HF_MODEL=$llama70b TT_CACHE_PATH=$tt_cache_llama70b pytest models/tt_transformers/demo/simple_text_demo.py --timeout 1800 -k "not performance-ci-stress-1"; fail+=$?
+  HF_MODEL=$llama70b TT_CACHE_PATH=$tt_cache_llama70b TT_TRANSFORMERS_SKIP_TRACE_RELEASE_IN_DESTRUCTOR=1 \
+    pytest models/tt_transformers/demo/simple_text_demo.py --timeout 1800 -k "not performance-ci-stress-1"; fail+=$?
 
 
   # Record the end time


### PR DESCRIPTION
Refs #40123

## Root-cause hypothesis
- The crash occurs during Python GC while running `models/tt_transformers/demo/simple_text_demo.py` for Llama 3.1 70B on T3K.
- Job logs point to `models/tt_transformers/tt/generator.py::__del__` at `ttnn.release_trace(...)` during `models/conftest.py::ensure_gc`.
- A recent change added destructor-time trace release for this generator, which can call into native trace cleanup while GC is collecting, leading to a process-level segfault (`exit 139`).

## What this change does
- Adds an env-gated bypass in `models/tt_transformers/tt/generator.py::__del__`:
  - `TT_TRANSFORMERS_SKIP_TRACE_RELEASE_IN_DESTRUCTOR=1` skips `ttnn.release_trace(...)` calls in destructor.
- Enables this env var only for the failing 70B CI invocation in `tests/scripts/t3000/run_t3000_demo_tests.sh`.
- Keeps the mitigation scoped to the affected job path instead of changing global cleanup behavior for all demos/tests.

## Validation performed
- `python3 -m py_compile models/tt_transformers/tt/generator.py`
- `bash -n tests/scripts/t3000/run_t3000_demo_tests.sh`
- Pre-commit hooks passed on commit.

## Limitations
- No local T3K hardware available, so this is a log-driven mitigation and not locally reproduced/verified on target hardware.
- This is intentionally conservative and scoped; if segfaults persist, follow-up should move cleanup to an explicit non-destructor lifecycle point.

## CI plan
- Run targeted `Custom test dispatch` on T3000 (`config-t3000`) for:
  - `run_t3000_llama3_70b_tests`
- If green, consider broader `(T3K) T3000 demo tests` coverage.

Made with [Cursor](https://cursor.com)

## Workflow runs
- Targeted dispatch (in progress): https://github.com/tenstorrent/tt-metal/actions/runs/23212477389
- Official workflow targeted run (temporary workflow-pruning commit `5494fdbe349`, reverted by `a00b0d51a29` immediately after dispatch): https://github.com/tenstorrent/tt-metal/actions/runs/23214164758
