### PR TITLE
Reduce more cb id usage inside attention block

### DIFF
--- a/models/demos/deepseek_v3_b1/circular_buffer_utils.py
+++ b/models/demos/deepseek_v3_b1/circular_buffer_utils.py
@@ -175,11 +175,17 @@ def record_cb_metadata(cb_descriptors):
     """
     Extract per-CB config metadata from a list of CBDescriptors.
 
+    A single CB ID may appear more than once with different core_ranges (e.g. when
+    qrope and krope share a CB ID but need different L1 addresses per core set).
+    The returned dict maps cb_id → list of (addr, total_size, num_pages, page_size,
+    core_ranges) so that build_cb_reconfig_tensor can write the correct config to
+    each core independently.
+
     Args:
         cb_descriptors: List of ttnn.CBDescriptor objects
 
     Returns:
-        dict mapping cb_id → (addr, total_size, num_pages, page_size, core_ranges)
+        dict mapping cb_id → list of (addr, total_size, num_pages, page_size, core_ranges)
     """
 
     cb_metadata = {}
@@ -192,7 +198,7 @@ def record_cb_metadata(cb_descriptors):
             total_size = desc.total_size
             page_size = fmt.page_size
             num_pages = total_size // page_size
-            cb_metadata[cb_id] = (addr, total_size, num_pages, page_size, desc.core_ranges)
+            cb_metadata.setdefault(cb_id, []).append((addr, total_size, num_pages, page_size, desc.core_ranges))
     return cb_metadata
 
 
@@ -214,7 +220,7 @@ def build_cb_reconfig_tensor(cb_metadata, full_device_grid, mesh_device):
         Words 260-263: reserved (zeros)
 
     Args:
-        cb_metadata: dict mapping cb_id → (addr, total_size, num_pages, page_size, core_ranges)
+        cb_metadata: dict mapping cb_id → list of (addr, total_size, num_pages, page_size, core_ranges)
         full_device_grid: CoreRangeSet covering all cores on the device
         mesh_device: Device or MeshDevice to place the tensor on
 
@@ -233,22 +239,23 @@ def build_cb_reconfig_tensor(cb_metadata, full_device_grid, mesh_device):
     WORDS_PER_CORE = 264
     config = torch.zeros((num_cores, WORDS_PER_CORE), dtype=torch.uint32)
 
-    for cb_id, (addr, total_size, num_pages, page_size, core_ranges) in cb_metadata.items():
-        cb_cores = ttnn.corerange_to_cores(core_ranges, row_wise=True)
-        for core in cb_cores:
-            key = (core.x, core.y)
-            if key not in core_to_idx:
-                continue
-            core_idx = core_to_idx[key]
-            base = cb_id * 4
-            config[core_idx, base + 0] = addr
-            config[core_idx, base + 1] = total_size
-            config[core_idx, base + 2] = num_pages
-            config[core_idx, base + 3] = page_size
-            if cb_id < 32:
-                config[core_idx, 256] |= 1 << cb_id
-            else:
-                config[core_idx, 257] |= 1 << (cb_id - 32)
+    for cb_id, entries in cb_metadata.items():
+        for addr, total_size, num_pages, page_size, core_ranges in entries:
+            cb_cores = ttnn.corerange_to_cores(core_ranges, row_wise=True)
+            for core in cb_cores:
+                key = (core.x, core.y)
+                if key not in core_to_idx:
+                    continue
+                core_idx = core_to_idx[key]
+                base = cb_id * 4
+                config[core_idx, base + 0] = addr
+                config[core_idx, base + 1] = total_size
+                config[core_idx, base + 2] = num_pages
+                config[core_idx, base + 3] = page_size
+                if cb_id < 32:
+                    config[core_idx, 256] |= 1 << cb_id
+                else:
+                    config[core_idx, 257] |= 1 << (cb_id - 32)
 
     num_devices = mesh_device.get_num_devices() if hasattr(mesh_device, "get_num_devices") else 1
     mesh_mapper = ttnn.ReplicateTensorToMesh(mesh_device) if num_devices > 1 else None

--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/kernels/attention_block_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/kernels/attention_block_kernel.cpp
@@ -174,7 +174,7 @@ void kernel_main() {
 
     deepseek_b1_ops::Rope::ReaderArgs qrope_args{
         .in_cb = get_named_compile_time_arg_val("qrope_in_cb"),
-        .cos_sin_cb = get_named_compile_time_arg_val("qrope_cos_sin_cb"),
+        .cos_sin_cb = get_named_compile_time_arg_val("qkv_rope_cos_sin_cb"),
         .cos_tensor_address = get_named_compile_time_arg_val("qrope_cos_tensor_address"),
         .sin_tensor_address = get_named_compile_time_arg_val("qrope_sin_tensor_address"),
         .position_ids_tensor_address = get_named_compile_time_arg_val("qrope_position_ids_tensor_address"),
@@ -923,7 +923,7 @@ void kernel_main() {
     // Qrope compute args (from compile-time args)
     deepseek_b1_ops::Rope::ComputeArgs qrope_args{
         get_named_compile_time_arg_val("qrope_in_cb"),  // Input from matmul2 output
-        get_named_compile_time_arg_val("qrope_cos_sin_cb"),
+        get_named_compile_time_arg_val("qkv_rope_cos_sin_cb"),
         get_named_compile_time_arg_val("qrope_trans_mat_cb"),
         get_named_compile_time_arg_val("qrope_rotated_in_interm_cb"),
         get_named_compile_time_arg_val("qrope_cos_sin_interm_cb"),

--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
@@ -871,7 +871,7 @@ class AttentionBlock:
         matmul3_output_cb = cb_id_context.get_cb_id(
             data_format, TD_1x32
         )  # Output CB for third matmul (Qnope final output)
-        qrope_output_cb = cb_id_context.get_cb_id(data_format, TD_1x32)  # Output CB for Qrope (RoPE output)
+        qrope_output_cb = matmul3_output_cb  # Shares CB ID (disjoint: qrope_grid cols 8-11, rows 0-7)
         create_q_heads_out_cb = cb_id_context.get_cb_id(
             data_format, TD_8x32
         )  # Output CB for CreateQHeads (linked to output tensor on receiver cores)
@@ -888,13 +888,11 @@ class AttentionBlock:
         )  # Rotated input intermediate CB for RoPE
         qrope_cos_sin_interm_cb = cb_id_context.get_cb_id(data_format, TD_1x32)  # Cos/Sin intermediate CB for RoPE
         # KV cache branch
-        dkv_matmul_output_cb = cb_id_context.get_cb_id(
-            data_format, TD_1x32
-        )  # DKV Matmul output CB, 64 bytes (1 tile per core for rope input)
-        kv_rmsnorm_input_cb = cb_id_context.get_cb_id(data_format, TD_16x32)  # Input CB for KV Cache Branch RMSNorm
+        dkv_matmul_output_cb = matmul_output_cb  # Reuse matmul1 output CB ID (disjoint grids: rows 0-7 vs rows 8-9)
+        kv_rmsnorm_input_cb = rmsnorm2_input_cb  # Reuse rmsnorm2 input CB ID (disjoint grids: rows 0-7 vs rows 8-9)
         kv_rmsnorm_gamma_cb = rmsnorm2_gamma_cb
-        kv_rmsnorm_output_cb = cb_id_context.get_cb_id(data_format, TD_16x32)  # Output CB for KV Cache Branch RMSNorm
-        krope_output_cb = cb_id_context.get_cb_id(data_format, TD_1x32)  # Output CB for KV Cache Branch RoPE
+        kv_rmsnorm_output_cb = rmsnorm2_output_cb  # Reuse rmsnorm2 output CB ID (disjoint grids: rows 0-7 vs rows 8-9)
+        krope_output_cb = matmul3_output_cb  # Shares CB ID (disjoint: krope_grid col 8, rows 8-9)
         create_q_heads_receiver_in_cb = cb_id_context.get_cb_id(
             data_format, TD_8x32
         )  # Intermediate CB for CreateQHeads (row-major data before tilization)
@@ -2011,7 +2009,7 @@ class AttentionBlock:
             ref_sdpa_out_interm_buffer,
             address_offset=sdpa_out_interm_running_offset,  # 14336 B
             total_size=matmul_output_page_size,
-            core_ranges=full_device_grid,
+            core_ranges=matmul_weights_core_grid,
         )
         matmul_output_cb_descriptor.format_descriptors = [
             ttnn.CBFormatDescriptor(
@@ -2023,14 +2021,16 @@ class AttentionBlock:
         ]
         sdpa_out_interm_running_offset += matmul_output_cb_descriptor.total_size  # +64 B
 
-        # CB 7: RMSNorm2 input buffer (3 tiles) — overlap with sdpa_out_interm L1 buffer
-        # at offset 64 B. This CB is consumed before SDPA runs.
+        # CB 7: RMSNorm2 input buffer (3 tiles) — overlap with sdpa_kv_cache L1 buffer
+        # at offset 14400 B. This CB is consumed before SDPA runs.
+        # Covers gather_reduce senders (matmul_weights_core_grid, rows 0-7) + receiver (rmsnorm_core_grid)
+        # kv_rmsnorm_input_cb shares this CB ID on dkv_gather_sender_grid + dkv receiver (rows 8-9)
         rmsnorm2_input_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
             rmsnorm2_input_cb,
             ref_sdpa_kv_cache_buffer,
             address_offset=sdpa_kv_cache_running_offset_mcast_core,  # 14400 B
             total_size=rmsnorm2_num_tiles * rmsnorm2_page_size,
-            core_ranges=full_device_grid,
+            core_ranges=matmul_weights_core_grid.merge(rmsnorm_core_grid),
         )
         rmsnorm2_input_cb_descriptor.format_descriptors = [
             ttnn.CBFormatDescriptor(
@@ -2064,13 +2064,15 @@ class AttentionBlock:
         ]
         sdpa_kv_cache_running_offset_mcast_core += gather_reduce_scratch_cb_descriptor.total_size
 
-        # CB: RMSNorm2 output buffer (3 tiles)
+        # CB: RMSNorm2 output buffer (3 tiles) — overlap with sdpa_kv_cache L1 buffer
+        # at offset 20544 B. This CB is consumed before SDPA runs.
+        # kv_rmsnorm_output_cb shares this CB ID on dkv_gather_receiver_core_grid (rows 8-9)
         rmsnorm2_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
             rmsnorm2_output_cb,
             ref_sdpa_kv_cache_buffer,
             address_offset=sdpa_kv_cache_running_offset_mcast_core,  # 20544 B
             total_size=rmsnorm2_num_tiles * rmsnorm2_page_size,
-            core_ranges=full_device_grid,
+            core_ranges=rmsnorm_core_grid,
         )
         rmsnorm2_output_cb_descriptor.format_descriptors = [
             ttnn.CBFormatDescriptor(
@@ -2129,6 +2131,7 @@ class AttentionBlock:
 
         # CB 14: Matmul3 output buffer — overlap with sdpa_out_interm L1 buffer
         # at offset 12608 B. This CB is consumed before SDPA runs.
+        # qrope_output_cb (qrope_grid) and krope_output_cb (krope_grid) share this CB ID
         matmul3_output_tile_descriptor = ttnn.TileDescriptor(TILE_1x32)
         matmul3_output_page_size = TILE_1x32.get_tile_size(data_format)
         matmul3_output_total_size = matmul3_out_w * matmul3_output_page_size  # 16 tiles
@@ -2137,7 +2140,7 @@ class AttentionBlock:
             ref_sdpa_out_interm_buffer,
             address_offset=sdpa_out_interm_running_offset,  # 26944 B
             total_size=matmul3_output_total_size,
-            core_ranges=full_device_grid,
+            core_ranges=qnope_grid,
         )
         matmul3_output_cb_descriptor.format_descriptors = [
             ttnn.CBFormatDescriptor(
@@ -2151,6 +2154,7 @@ class AttentionBlock:
 
         # CB 15: Qrope output buffer — overlap with sdpa_out_interm L1 buffer
         # at offset 13632 B. This CB is consumed before SDPA runs.
+        # Shares CB ID with matmul3_output_cb (qnope_grid) and krope_output_cb (krope_grid)
         qrope_output_tile_descriptor = ttnn.TileDescriptor(TILE_1x32)
         qrope_output_page_size = TILE_1x32.get_tile_size(data_format)
         qrope_output_total_size = matmul2_out_w * qrope_output_page_size  # 4 tiles
@@ -2159,7 +2163,7 @@ class AttentionBlock:
             ref_sdpa_out_interm_buffer,
             address_offset=sdpa_out_interm_running_offset_qrope,  # 27968 B
             total_size=qrope_output_total_size,
-            core_ranges=full_device_grid,
+            core_ranges=qrope_grid,
         )
         qrope_output_cb_descriptor.format_descriptors = [
             ttnn.CBFormatDescriptor(
@@ -2280,8 +2284,9 @@ class AttentionBlock:
         ]
         sdpa_forwarder_scratch_running_offset += create_q_heads_out_cb_descriptor.total_size
 
-        # CB 24: DKV Matmul output — overlap with sdpa_out_interm L1 buffer
-        # at offset 14272 B. This CB is consumed before SDPA runs.
+        # CB 24: DKV Matmul output — shares CB ID with matmul_output_cb (disjoint grids)
+        # matmul_output_cb covers matmul_weights_core_grid (rows 0-7)
+        # dkv_matmul_output_cb covers dkv_matmul_weights_core_grid (rows 8-9)
         dkv_matmul_output_tile_descriptor = ttnn.TileDescriptor(TILE_1x32)
         dkv_matmul_output_page_size = TILE_1x32.get_tile_size(data_format)
         dkv_matmul_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
@@ -2289,7 +2294,7 @@ class AttentionBlock:
             ref_sdpa_kv_cache_buffer,
             address_offset=sdpa_kv_cache_running_offset,  # 37824 B
             total_size=dkv_matmul_output_page_size,
-            core_ranges=full_device_grid,
+            core_ranges=dkv_matmul_weights_core_grid,
         )
         dkv_matmul_output_cb_descriptor.format_descriptors = [
             ttnn.CBFormatDescriptor(
@@ -2301,8 +2306,13 @@ class AttentionBlock:
         ]
         sdpa_kv_cache_running_offset += dkv_matmul_output_cb_descriptor.total_size  # +64 B
 
-        # CB 25: KV RMSNorm input buffer — overlap with sdpa_out_interm L1 buffer
-        # at offset 14336 B. This CB is consumed before SDPA runs.
+        # CB 25: KV RMSNorm input buffer — overlap with sdpa_kv_cache L1 buffer
+        # at offset 37888 B. This CB is consumed before SDPA runs.
+        # Shares CB ID with rmsnorm2_input_cb (disjoint grids: rows 0-7 vs rows 8-9)
+        # Covers dkv gather senders (dkv_gather_sender_grid, rows 8-9) + dkv receiver core
+        dkv_gather_receiver_core_grid = ttnn.CoreRangeSet(
+            [ttnn.CoreRange(dkv_gather_receiver_core, dkv_gather_receiver_core)]
+        )
         kv_rmsnorm_tile_descriptor = ttnn.TileDescriptor(TILE_16x32)
         kv_rmsnorm_page_size = TILE_16x32.get_tile_size(input_tensor_sample.dtype)
         kv_rmsnorm_input_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
@@ -2310,7 +2320,7 @@ class AttentionBlock:
             ref_sdpa_kv_cache_buffer,
             address_offset=sdpa_kv_cache_running_offset,  # 37888 B
             total_size=1 * kv_rmsnorm_page_size,
-            core_ranges=full_device_grid,
+            core_ranges=dkv_gather_sender_grid.merge(dkv_gather_receiver_core_grid),
         )
         kv_rmsnorm_input_cb_descriptor.format_descriptors = [
             ttnn.CBFormatDescriptor(
@@ -2322,14 +2332,15 @@ class AttentionBlock:
         ]
         sdpa_kv_cache_running_offset += kv_rmsnorm_input_cb_descriptor.total_size  # +1024 B
 
-        # CB 27: KV RMSNorm output buffer — overlap with sdpa_out_interm L1 buffer
-        # at offset 15360 B. This CB is consumed before SDPA runs.
+        # CB 27: KV RMSNorm output buffer — overlap with sdpa_kv_cache L1 buffer
+        # at offset 38912 B. This CB is consumed before SDPA runs.
+        # Shares CB ID with rmsnorm2_output_cb (disjoint grids: rows 0-7 vs rows 8-9)
         kv_rmsnorm_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
             kv_rmsnorm_output_cb,
             ref_sdpa_kv_cache_buffer,
             address_offset=sdpa_kv_cache_running_offset,  # 38912 B
             total_size=kv_rmsnorm_num_tiles * kv_rmsnorm_page_size,
-            core_ranges=full_device_grid,
+            core_ranges=dkv_gather_receiver_core_grid,  # Only the nope core (BRISC) reads kv_rmsnorm_output_cb
         )
         kv_rmsnorm_output_cb_descriptor.format_descriptors = [
             ttnn.CBFormatDescriptor(
@@ -2358,15 +2369,16 @@ class AttentionBlock:
         krope_cos_sin_cb_descriptor.format_descriptors = [krope_cos_sin_cb_format]
         sdpa_kv_cache_running_offset += krope_cos_sin_cb_descriptor.total_size
 
-        # CB 28: KRoPE output — overlap with sdpa_out_interm L1 buffer
-        # at offset 16384 B. This CB is consumed before SDPA runs.
+        # CB 28: KRoPE output — overlap with sdpa_kv_cache L1 buffer
+        # at offset 39936 B. This CB is consumed before SDPA runs.
+        # Shares CB ID with matmul3_output_cb (qnope_grid) and qrope_output_cb (qrope_grid)
         krope_tile_size = TILE_1x32.get_tile_size(data_format)
         krope_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
             krope_output_cb,
             ref_sdpa_kv_cache_buffer,
             address_offset=sdpa_kv_cache_running_offset,  # 39936 B
             total_size=1 * krope_tile_size,
-            core_ranges=full_device_grid,
+            core_ranges=krope_grid,
         )
         krope_output_cb_descriptor.format_descriptors = [
             ttnn.CBFormatDescriptor(

--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
@@ -875,7 +875,7 @@ class AttentionBlock:
         create_q_heads_out_cb = cb_id_context.get_cb_id(
             data_format, TD_8x32
         )  # Output CB for CreateQHeads (linked to output tensor on receiver cores)
-        qrope_cos_sin_cb = cb_id_context.get_cb_id(data_format, TD_1x32)  # Cos/Sin CB for RoPE
+        qkv_rope_cos_sin_cb = cb_id_context.get_cb_id(data_format, TD_1x32)  # Cos/Sin CB for RoPE
         qrope_trans_mat_cb = matmul_weights_cb_overlapped
         assert (
             trans_mat_tensor.dtype == matmul_weights_tensor.dtype
@@ -895,7 +895,6 @@ class AttentionBlock:
         kv_rmsnorm_gamma_cb = rmsnorm2_gamma_cb
         kv_rmsnorm_output_cb = cb_id_context.get_cb_id(data_format, TD_16x32)  # Output CB for KV Cache Branch RMSNorm
         krope_output_cb = cb_id_context.get_cb_id(data_format, TD_1x32)  # Output CB for KV Cache Branch RoPE
-        krope_cos_sin_cb = cb_id_context.get_cb_id(data_format, TD_1x32)  # Cos/Sin CB for RoPE
         create_q_heads_receiver_in_cb = cb_id_context.get_cb_id(
             data_format, TD_8x32
         )  # Intermediate CB for CreateQHeads (row-major data before tilization)
@@ -1136,7 +1135,7 @@ class AttentionBlock:
         qrope_total_Wt = qrope_head_dim_per_core_t  # all cores read full head_dim, so total_Wt = Wt
         qrope_ncrisc_named_compile_time_args = [
             ("qrope_in_cb", matmul2_output_cb),
-            ("qrope_cos_sin_cb", qrope_cos_sin_cb),
+            ("qkv_rope_cos_sin_cb", qkv_rope_cos_sin_cb),
             ("qrope_trans_mat_cb", qrope_trans_mat_cb),
             ("qrope_Wt", qrope_head_dim_per_core_t),
             ("qrope_Ht", qrope_num_heads_per_core),
@@ -1148,7 +1147,7 @@ class AttentionBlock:
         # TRISC: in_cb, cos_sin_cb, trans_mat_cb, rotated_in_interm_cb, cos_sin_interm_cb, out_cb, Wt, Ht
         qrope_trisc_named_compile_time_args = [
             ("qrope_in_cb", matmul2_output_cb),
-            ("qrope_cos_sin_cb", qrope_cos_sin_cb),
+            ("qkv_rope_cos_sin_cb", qkv_rope_cos_sin_cb),
             ("qrope_trans_mat_cb", qrope_trans_mat_cb),
             ("qrope_rotated_in_interm_cb", qrope_rotated_input_interm_cb),
             ("qrope_cos_sin_interm_cb", qrope_cos_sin_interm_cb),
@@ -1430,7 +1429,7 @@ class AttentionBlock:
         krope_ncrisc_named_compile_time_args = [
             ("krope_output_cb", krope_output_cb),
             ("krope_in_cb", dkv_matmul_output_cb),
-            ("krope_cos_sin_cb", krope_cos_sin_cb),
+            ("krope_cos_sin_cb", qkv_rope_cos_sin_cb),
             ("krope_trans_mat_cb", qrope_trans_mat_cb),
             ("krope_Wt", krope_Wt),
             ("krope_Ht", krope_Ht),
@@ -1439,7 +1438,7 @@ class AttentionBlock:
         ]
         krope_trisc_named_compile_time_args = [
             ("krope_in_cb", dkv_matmul_output_cb),
-            ("krope_cos_sin_cb", krope_cos_sin_cb),
+            ("krope_cos_sin_cb", qkv_rope_cos_sin_cb),
             ("krope_trans_mat_cb", qrope_trans_mat_cb),
             ("krope_rotated_in_interm_cb", qrope_rotated_input_interm_cb),
             ("krope_cos_sin_interm_cb", qrope_cos_sin_interm_cb),
@@ -2174,21 +2173,21 @@ class AttentionBlock:
 
         # CB 17: Cos/Sin (DRAM, read by NCRISC)
         qrope_rope_tile_descriptor = ttnn.TileDescriptor(TILE_1x32)
-        qrope_cos_sin_cb_format = ttnn.CBFormatDescriptor(
-            buffer_index=qrope_cos_sin_cb,
+        qkv_rope_cos_sin_cb_format = ttnn.CBFormatDescriptor(
+            buffer_index=qkv_rope_cos_sin_cb,
             data_format=data_format,
             page_size=qrope_rope_tile_size,
             tile=qrope_rope_tile_descriptor,
         )
-        qrope_cos_sin_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
-            qrope_cos_sin_cb,
+        qkv_rope_cos_sin_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+            qkv_rope_cos_sin_cb,
             ref_sdpa_out_interm_buffer,
             address_offset=sdpa_out_interm_running_offset_qrope,
             total_size=qrope_head_dim_per_core_t * qrope_rope_tile_size * 2,
-            core_ranges=full_device_grid,
+            core_ranges=qrope_grid,
         )
-        qrope_cos_sin_cb_descriptor.format_descriptors = [qrope_cos_sin_cb_format]
-        sdpa_out_interm_running_offset_qrope += qrope_cos_sin_cb_descriptor.total_size
+        qkv_rope_cos_sin_cb_descriptor.format_descriptors = [qkv_rope_cos_sin_cb_format]
+        sdpa_out_interm_running_offset_qrope += qkv_rope_cos_sin_cb_descriptor.total_size
 
         # CB 20: Rotated input intermediate CB — overlap with sdpa_out_interm L1 buffer
         # at offset 13888 B. This CB is consumed before SDPA runs.
@@ -2344,17 +2343,17 @@ class AttentionBlock:
         # CB 29: Cos (DRAM, read by NCRISC)
         krope_rope_tile_descriptor = ttnn.TileDescriptor(TILE_1x32)
         krope_cos_sin_cb_format = ttnn.CBFormatDescriptor(
-            buffer_index=krope_cos_sin_cb,
+            buffer_index=qkv_rope_cos_sin_cb,
             data_format=data_format,
             page_size=krope_rope_tile_size,
             tile=krope_rope_tile_descriptor,
         )
         krope_cos_sin_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
-            krope_cos_sin_cb,
+            qkv_rope_cos_sin_cb,
             ref_sdpa_kv_cache_buffer,
             address_offset=sdpa_kv_cache_running_offset,
             total_size=krope_Wt * krope_rope_tile_size * 2,
-            core_ranges=full_device_grid,
+            core_ranges=krope_grid,
         )
         krope_cos_sin_cb_descriptor.format_descriptors = [krope_cos_sin_cb_format]
         sdpa_kv_cache_running_offset += krope_cos_sin_cb_descriptor.total_size
@@ -3229,7 +3228,7 @@ class AttentionBlock:
             matmul3_output_cb_descriptor,
             qrope_output_cb_descriptor,
             create_q_heads_out_cb_descriptor,
-            qrope_cos_sin_cb_descriptor,
+            qkv_rope_cos_sin_cb_descriptor,
             # qrope_trans_mat_cb_descriptor,
             qrope_rotated_input_interm_cb_descriptor,
             qrope_cos_sin_interm_cb_descriptor,


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Attention block still wastes a lot of CB ids.

### What's changed
- Swap K rope to use same CB as Q rope
- Reuse q and k matmul output
- Reuse q and k rmsnorm input cb
- Reuse q and k rmsnorm output
- Reuse qk rope and q nope output

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aho/mla-fixes2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aho/mla-fixes2)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aho/mla-fixes2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/mla-fixes2)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aho/mla-fixes2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/mla-fixes2)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aho/mla-fixes2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/mla-fixes2)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aho/mla-fixes2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/mla-fixes2)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aho/mla-fixes2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/mla-fixes2)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
