### PR TITLE
HostTensor as backing storage for TTNN::Tensor

### DIFF
--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -10,6 +10,9 @@
 #include <tuple>
 
 #include "tt-metalium/distributed_host_buffer.hpp"
+#include "tt-metalium/experimental/tensor/host_tensor.hpp"
+#include <ttnn/tensor/tensor_spec.hpp>
+#include <ttnn/distributed/tensor_topology.hpp>
 #include "ttnn/tensor/types.hpp"
 #include "ttnn/tensor/tensor_spec.hpp"
 
@@ -23,8 +26,20 @@ public:
     // Creates HostStorage distributed over 1x1 mesh.
     explicit HostStorage(HostBuffer buffer);
 
+    // Creates HostStorage from a HostTensor.
+    explicit HostStorage(HostTensor tensor);
+
+    // Copy a HostStorage with a new TensorSpec and TensorTopology, this is meant for transition
+    HostStorage(const HostStorage& other, TensorSpec spec, TensorTopology topology);
+
+    // Move a HostStorage with a new TensorSpec and TensorTopology
+    HostStorage(HostStorage&& other, TensorSpec spec, TensorTopology topology);
+
     // Returns the distributed host buffer.
     const DistributedHostBuffer& buffer() const;
+
+    // Returns the host tensor.
+    const HostTensor& host_tensor() const;
 
     // Applies a transformation function to each device buffer in parallel, returning a new HostStorage.
     HostStorage transform(const std::function<HostBuffer(const HostBuffer&)>& callable) const;
@@ -33,7 +48,7 @@ public:
     auto attribute_values() const { return std::forward_as_tuple(); }
 
 private:
-    DistributedHostBuffer distributed_buffer_;
+    HostTensor tensor;
 };
 
 struct DeviceStorage {

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -14,7 +14,7 @@
 #include <ttnn/tensor/tensor_spec.hpp>
 #include <ttnn/distributed/tensor_topology.hpp>
 #include "ttnn/tensor/types.hpp"
-#include "ttnn/tensor/tensor_spec.hpp"
+
 
 namespace tt::tt_metal {
 

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -21,9 +21,11 @@ namespace tt::tt_metal {
 class HostStorage {
 public:
     // Creates HostStorage distributed over a mesh that matches `buffer` shape.
+    [[deprecated("Use HostStorage(HostTensor tensor) instead")]]
     explicit HostStorage(DistributedHostBuffer buffer);
 
     // Creates HostStorage distributed over 1x1 mesh.
+    [[deprecated("Use HostStorage(HostTensor tensor) instead")]]
     explicit HostStorage(HostBuffer buffer);
 
     // Creates HostStorage from a HostTensor.

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -29,10 +29,12 @@ public:
     // Creates HostStorage from a HostTensor.
     explicit HostStorage(HostTensor tensor);
 
-    // Copy a HostStorage with a new TensorSpec and TensorTopology, this is meant for transition
+    // Transitional constructors: accept a pre-transition HostStorage (constructed
+    // without TensorSpec and TensorTopology) and assign them during construction.
+    // Overrides any existing spec/topology in the HostStorage.
+    //
+    // TODO(#40348): Remove these.
     HostStorage(const HostStorage& other, TensorSpec spec, TensorTopology topology);
-
-    // Move a HostStorage with a new TensorSpec and TensorTopology
     HostStorage(HostStorage&& other, TensorSpec spec, TensorTopology topology);
 
     // Returns the distributed host buffer.

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -53,6 +53,8 @@ public:
     [[nodiscard]] Tensor(HostStorage storage, TensorSpec tensor_spec, TensorTopology tensor_topology);
     [[nodiscard]] Tensor(DeviceStorage storage, TensorSpec tensor_spec, TensorTopology tensor_topology);
 
+    [[nodiscard]] Tensor(HostTensor tensor);
+
     // Constructors of `Tensor` that take physical data encoded in `HostBuffer`.
     // The encoded data type and physical size of the data must match the specified tensor physical shape and data type.
     [[nodiscard]] Tensor(
@@ -234,6 +236,10 @@ public:
     // Throws if the tensor is not on host.
     const HostStorage& host_storage() const&;
     const HostStorage& host_storage() const&& = delete;  // prevents dangling reference to temporaries.
+
+    // Returns the associated HostTensor.
+    const HostTensor& host_tensor() const&;
+    const HostTensor& host_tensor() const&& = delete;  // prevents dangling reference to temporaries.
 
     // Returns device `MeshBuffer`.
     // Throws if the tensor is not allocated on a device.

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -60,7 +60,7 @@ public:
 
     [[nodiscard]] Tensor(DeviceStorage storage, TensorSpec tensor_spec, TensorTopology tensor_topology);
 
-    [[nodiscard]] Tensor(HostTensor tensor);
+    [[nodiscard]] explicit Tensor(HostTensor tensor);
 
     // Constructors of `Tensor` that take physical data encoded in `HostBuffer`.
     // The encoded data type and physical size of the data must match the specified tensor physical shape and data type.

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -49,8 +49,15 @@ public:
     Tensor& operator=(Tensor&& other) noexcept;
     ~Tensor();
 
-    // Constructs a tensor with `Storage`, `TensorSpec`, and `TensorTopology`.
+    // Transitional constructor: use Tensor(HostTensor) instead.
+    //
+    // Accepts a pre-transition HostStorage (constructed without TensorSpec and
+    // TensorTopology) and assigns them during Tensor construction.
+    // Overrides any existing spec/topology in the HostStorage.
+    //
+    // TODO(#40348): Remove this.
     [[nodiscard]] Tensor(HostStorage storage, TensorSpec tensor_spec, TensorTopology tensor_topology);
+
     [[nodiscard]] Tensor(DeviceStorage storage, TensorSpec tensor_spec, TensorTopology tensor_topology);
 
     [[nodiscard]] Tensor(HostTensor tensor);

--- a/ttnn/api/ttnn/tensor/tensor_attributes.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_attributes.hpp
@@ -15,7 +15,25 @@ namespace tt::tt_metal {
 class TensorAttributes : public std::enable_shared_from_this<TensorAttributes> {
 public:
     TensorAttributes(HostStorage storage);
-    TensorAttributes(Storage storage, TensorSpec tensor_spec, TensorTopology tensor_topology);
+
+    // Transitional constructor: use TensorAttributes(HostStorage) instead.
+    //
+    // Accepts a pre-transition HostStorage (constructed without TensorSpec and
+    // TensorTopology) and assigns them during TensorAttributes construction.
+    // Overrides any existing spec/topology in the HostStorage.
+    //
+    // e.g. This protects this usage:
+    // HostStorage storage(buffer);
+    // Tensor(storage, tensor_spec, tensor_topology);
+    //
+    // (after transition, should be):
+    // HostStorage storage(HostTensor(buffer, tensor_spec, tensor_topology));
+    // Tensor(storage);
+    //
+    // TODO(#40348): Remove this.
+    TensorAttributes(HostStorage storage, TensorSpec tensor_spec, TensorTopology tensor_topology);
+
+    TensorAttributes(DeviceStorage storage, TensorSpec tensor_spec, TensorTopology tensor_topology);
     TensorAttributes(const TensorAttributes&) = default;
     TensorAttributes(TensorAttributes&&) = default;
     TensorAttributes& operator=(const TensorAttributes&) = default;
@@ -31,6 +49,10 @@ public:
 
 private:
     Storage storage_;
+
+    // These will be removed after Runtime Tensor refactoring,
+    // as they will be part of the Host and MeshTensor,
+    // Thus a part of Storage.
     TensorSpec tensor_spec_;
     TensorTopology tensor_topology_;
 };

--- a/ttnn/api/ttnn/tensor/tensor_attributes.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_attributes.hpp
@@ -14,6 +14,7 @@ namespace tt::tt_metal {
 
 class TensorAttributes : public std::enable_shared_from_this<TensorAttributes> {
 public:
+    TensorAttributes(HostStorage storage);
     TensorAttributes(Storage storage, TensorSpec tensor_spec, TensorTopology tensor_topology);
     TensorAttributes(const TensorAttributes&) = default;
     TensorAttributes(TensorAttributes&&) = default;

--- a/ttnn/api/ttnn/tensor/tensor_impl.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_impl.hpp
@@ -126,8 +126,6 @@ void copy_to_device(
 
 Tensor to_layout(const Tensor& tensor, Layout target_layout);
 
-Tensor to_layout_bfloat(const Tensor& tensor, Layout target_layout);
-
 // ======================================================================================
 //                                  .pad() and .unpad()
 // ======================================================================================

--- a/ttnn/core/distributed/api.cpp
+++ b/ttnn/core/distributed/api.cpp
@@ -108,7 +108,7 @@ Tensor from_host_shards(const std::vector<Tensor>& tensor_shards, const MeshShap
     }
 
     TensorTopology topology = TensorTopology::create_sharded_tensor_topology(mesh_shape, shard_dim);
-    return Tensor(HostStorage{std::move(distributed_host_buffer)}, reference_shard.tensor_spec(), std::move(topology));
+    return Tensor(HostTensor(std::move(distributed_host_buffer), reference_shard.tensor_spec(), std::move(topology)));
 }
 
 Tensor combine_device_tensors(const std::vector<Tensor>& tensor_shards, int shard_dim) {

--- a/ttnn/core/distributed/distributed_tensor.cpp
+++ b/ttnn/core/distributed/distributed_tensor.cpp
@@ -192,7 +192,7 @@ public:
             const auto tensor_topology =
                 tt::tt_metal::TensorTopology(distribution_shape_, config_.placements, buffer_coords);
 
-            return Tensor(tt::tt_metal::HostStorage(std::move(distributed_buffer)), tensor_spec, tensor_topology);
+            return Tensor(tt::tt_metal::HostTensor(std::move(distributed_buffer), tensor_spec, tensor_topology));
         }
 
         // Otherwise, use xtensor to chunk the data into shards.
@@ -362,7 +362,7 @@ private:
         const auto tensor_topology =
             tt::tt_metal::TensorTopology(actual_distribution_shape, config_.placements, buffer_coords);
 
-        return Tensor(tt::tt_metal::HostStorage(std::move(distributed_buffer)), shard_spec, tensor_topology);
+        return Tensor(tt::tt_metal::HostTensor(std::move(distributed_buffer), shard_spec, tensor_topology));
     }
 
     // MeshDevice parameters.

--- a/ttnn/core/distributed/host_ccl.cpp
+++ b/ttnn/core/distributed/host_ccl.cpp
@@ -104,6 +104,6 @@ Tensor all_gather(const Tensor& tensor) {
     }
 
     return Tensor(
-        tt::tt_metal::HostStorage{std::move(all_gather_buffer)}, tensor.tensor_spec(), tensor.tensor_topology());
+        tt::tt_metal::HostTensor(std::move(all_gather_buffer), tensor.tensor_spec(), tensor.tensor_topology()));
 }
 }  // namespace ttnn::distributed::host_ccl

--- a/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
+++ b/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
@@ -241,13 +241,12 @@ Tensor from_flatbuffer(
 
     // NOTE: Existing tensor cache files may not have a tensor topology.
     // Create tensor topology from flatbuffer if it exists, otherwise create a fully replicated topology.
-    tt::tt_metal::HostStorage host_storage{std::move(distributed_buffer)};
     const auto* fb_topology = fb_tensor->tensor_topology();
     tt::tt_metal::TensorTopology topology =
         fb_topology != nullptr ? from_flatbuffer(fb_topology)
                                : tt::tt_metal::TensorTopology::create_fully_replicated_tensor_topology(ttnn_mesh_shape);
 
-    return Tensor(std::move(host_storage), spec, std::move(topology));
+    return Tensor(tt::tt_metal::HostTensor(std::move(distributed_buffer), spec, std::move(topology)));
 }
 
 }  // namespace ttnn

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -43,10 +43,7 @@ const DistributedHostBuffer& HostStorage::buffer() const { return tensor.buffer(
 const HostTensor& HostStorage::host_tensor() const { return tensor; }
 
 HostStorage HostStorage::transform(const std::function<HostBuffer(const HostBuffer&)>& callable) const {
-    auto transformed_buffer =
-        tensor.buffer().transform(callable, DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL);
-    auto transformed_tensor = HostTensor(std::move(transformed_buffer), tensor.tensor_spec(), tensor.tensor_topology());
-    return HostStorage(std::move(transformed_tensor));
+    return HostStorage(tensor.transform(callable));
 }
 
 DeviceStorage::DeviceStorage(

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -7,23 +7,46 @@
 #include <unordered_set>
 #include <vector>
 
+#include <ttnn/tensor/layout/layout.hpp>
 #include "tt-metalium/mesh_coord.hpp"
 
 #include "ttnn/tensor/storage.hpp"
 
 namespace tt::tt_metal {
 
-HostStorage::HostStorage(HostBuffer buffer) :
-    distributed_buffer_(DistributedHostBuffer::create(distributed::MeshShape(1, 1))) {
-    distributed_buffer_.emplace_shard(distributed::MeshCoordinate(0, 0), [&buffer]() { return std::move(buffer); });
+DistributedHostBuffer create_unit_distributed_host_buffer(HostBuffer buffer) {
+    auto distributed_buffer = DistributedHostBuffer::create(distributed::MeshShape(1, 1));
+    distributed_buffer.emplace_shard(distributed::MeshCoordinate(0, 0), [&buffer]() { return std::move(buffer); });
+    return distributed_buffer;
 }
-HostStorage::HostStorage(DistributedHostBuffer buffer) : distributed_buffer_(std::move(buffer)) {}
 
-const DistributedHostBuffer& HostStorage::buffer() const { return distributed_buffer_; }
+HostStorage::HostStorage(HostBuffer buffer) : HostStorage(create_unit_distributed_host_buffer(std::move(buffer))) {}
+
+HostTensor create_dummy_host_tensor(DistributedHostBuffer buffer) {
+    TensorSpec spec{Shape{}, TensorLayout{DataType::BFLOAT16, PageConfig{Layout::ROW_MAJOR}, MemoryConfig{}}};
+    TensorTopology topology;
+    return HostTensor(std::move(buffer), std::move(spec), std::move(topology));
+}
+
+HostStorage::HostStorage(DistributedHostBuffer buffer) : tensor(create_dummy_host_tensor(std::move(buffer))) {}
+
+HostStorage::HostStorage(HostTensor tensor) : tensor(std::move(tensor)) {}
+
+HostStorage::HostStorage(const HostStorage& other, TensorSpec spec, TensorTopology topology) :
+    tensor(HostTensor(other.buffer(), std::move(spec), std::move(topology))) {}
+
+HostStorage::HostStorage(HostStorage&& other, TensorSpec spec, TensorTopology topology) :
+    tensor(HostTensor(std::move(other.tensor), std::move(spec), std::move(topology))) {}
+
+const DistributedHostBuffer& HostStorage::buffer() const { return tensor.buffer(); }
+
+const HostTensor& HostStorage::host_tensor() const { return tensor; }
 
 HostStorage HostStorage::transform(const std::function<HostBuffer(const HostBuffer&)>& callable) const {
-    return HostStorage(
-        distributed_buffer_.transform(callable, DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL));
+    auto transformed_buffer =
+        tensor.buffer().transform(callable, DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL);
+    auto transformed_tensor = HostTensor(std::move(transformed_buffer), tensor.tensor_spec(), tensor.tensor_topology());
+    return HostStorage(std::move(transformed_tensor));
 }
 
 DeviceStorage::DeviceStorage(

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -14,7 +14,7 @@
 
 namespace tt::tt_metal {
 
-DistributedHostBuffer create_unit_distributed_host_buffer(HostBuffer buffer) {
+static DistributedHostBuffer create_unit_distributed_host_buffer(HostBuffer buffer) {
     auto distributed_buffer = DistributedHostBuffer::create(distributed::MeshShape(1, 1));
     distributed_buffer.emplace_shard(distributed::MeshCoordinate(0, 0), [&buffer]() { return std::move(buffer); });
     return distributed_buffer;

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -101,7 +101,7 @@ Tensor::Tensor(
 }
 
 Tensor::Tensor(HostBuffer buffer, TensorSpec tensor_spec) :
-    Tensor(HostStorage(std::move(buffer)), std::move(tensor_spec), TensorTopology{}) {}
+    Tensor(HostTensor(std::move(buffer), std::move(tensor_spec), TensorTopology{})) {}
 
 Tensor::Tensor(HostStorage storage, TensorSpec tensor_spec, TensorTopology tensor_topology) :
     tensor_id(Tensor::next_tensor_id()),

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -108,6 +108,10 @@ Tensor::Tensor(HostStorage storage, TensorSpec tensor_spec, TensorTopology tenso
     tensor_attributes(
         std::make_shared<TensorAttributes>(std::move(storage), std::move(tensor_spec), std::move(tensor_topology))) {}
 
+Tensor::Tensor(HostTensor tensor) :
+    tensor_id(Tensor::next_tensor_id()),
+    tensor_attributes(std::make_shared<TensorAttributes>(HostStorage(std::move(tensor)))) {}
+
 Tensor::Tensor(DeviceStorage storage, TensorSpec tensor_spec, TensorTopology tensor_topology) :
     tensor_id(Tensor::next_tensor_id()),
     tensor_attributes(
@@ -622,6 +626,12 @@ const HostStorage& Tensor::host_storage() const& {
     const auto* host_storage = std::get_if<HostStorage>(&this->storage());
     TT_FATAL(host_storage != nullptr, "Expected Tensor with HostStorage, got {}", this->storage_type());
     return *host_storage;
+}
+
+const HostTensor& Tensor::host_tensor() const& {
+    const auto* host_storage = std::get_if<HostStorage>(&this->storage());
+    TT_FATAL(host_storage != nullptr, "Expected Tensor with HostStorage, got {}", this->storage_type());
+    return host_storage->host_tensor();
 }
 
 distributed::MeshDevice* Tensor::device() const {

--- a/ttnn/core/tensor/tensor_attributes.cpp
+++ b/ttnn/core/tensor/tensor_attributes.cpp
@@ -8,7 +8,7 @@
 
 namespace tt::tt_metal {
 
-const HostTensor& get_host_tensor(const Storage& storage) {
+static const HostTensor& get_host_tensor(const Storage& storage) {
     if (const auto* host_storage = std::get_if<HostStorage>(&storage)) {
         return host_storage->host_tensor();
     }

--- a/ttnn/core/tensor/tensor_attributes.cpp
+++ b/ttnn/core/tensor/tensor_attributes.cpp
@@ -9,14 +9,35 @@
 namespace tt::tt_metal {
 
 TensorAttributes::TensorAttributes(Storage storage, TensorSpec tensor_spec, TensorTopology tensor_topology) :
-    storage_(std::move(storage)), tensor_spec_(std::move(tensor_spec)), tensor_topology_(std::move(tensor_topology)) {}
+    storage_(std::move(storage)), tensor_spec_(std::move(tensor_spec)), tensor_topology_(std::move(tensor_topology)) {
+    if (auto* host_storage = std::get_if<HostStorage>(&storage_)) {
+        storage_ = HostStorage(std::move(*host_storage), tensor_spec_, tensor_topology_);
+    }
+}
 
 const Storage& TensorAttributes::get_storage() const { return storage_; }
 Storage& TensorAttributes::get_storage() { return storage_; }
-const TensorSpec& TensorAttributes::get_tensor_spec() const { return tensor_spec_; }
-const TensorTopology& TensorAttributes::get_tensor_topology() const { return tensor_topology_; }
+
+const TensorSpec& TensorAttributes::get_tensor_spec() const {
+    if (const auto* host_storage = std::get_if<HostStorage>(&storage_)) {
+        return host_storage->host_tensor().tensor_spec();
+    }
+    return tensor_spec_;
+}
+
+const TensorTopology& TensorAttributes::get_tensor_topology() const {
+    if (const auto* host_storage = std::get_if<HostStorage>(&storage_)) {
+        return host_storage->host_tensor().tensor_topology();
+    }
+    return tensor_topology_;
+}
 
 TensorAttributes TensorAttributes::with_tensor_topology(TensorTopology tensor_topology) const {
+    // This need to moved to HostTensor after TODO(#39485)
+    if (const auto* host_storage = std::get_if<HostStorage>(&storage_)) {
+        HostStorage new_storage(*host_storage, tensor_spec_, tensor_topology);
+        return TensorAttributes(std::move(new_storage), tensor_spec_, tensor_topology);
+    }
     TensorAttributes result = *this;
     result.tensor_topology_ = std::move(tensor_topology);
     return result;

--- a/ttnn/core/tensor/tensor_attributes.cpp
+++ b/ttnn/core/tensor/tensor_attributes.cpp
@@ -45,7 +45,7 @@ const TensorTopology& TensorAttributes::get_tensor_topology() const {
 }
 
 TensorAttributes TensorAttributes::with_tensor_topology(TensorTopology tensor_topology) const {
-    // This need to moved to HostTensor after TODO(#39485)
+    // This needs to be moved to HostTensor after TODO(#39485)
     if (const auto* host_storage = std::get_if<HostStorage>(&storage_)) {
         HostStorage new_storage(*host_storage, tensor_spec_, tensor_topology);
         return TensorAttributes(std::move(new_storage), tensor_spec_, tensor_topology);

--- a/ttnn/core/tensor/tensor_attributes.cpp
+++ b/ttnn/core/tensor/tensor_attributes.cpp
@@ -8,6 +8,18 @@
 
 namespace tt::tt_metal {
 
+const HostTensor& get_host_tensor(const Storage& storage) {
+    if (const auto* host_storage = std::get_if<HostStorage>(&storage)) {
+        return host_storage->host_tensor();
+    }
+    return std::get<HostStorage>(storage).host_tensor();
+}
+
+TensorAttributes::TensorAttributes(HostStorage storage) :
+    storage_(std::move(storage)),
+    tensor_spec_(get_host_tensor(storage_).tensor_spec()),
+    tensor_topology_(get_host_tensor(storage_).tensor_topology()) {}
+
 TensorAttributes::TensorAttributes(Storage storage, TensorSpec tensor_spec, TensorTopology tensor_topology) :
     storage_(std::move(storage)), tensor_spec_(std::move(tensor_spec)), tensor_topology_(std::move(tensor_topology)) {
     if (auto* host_storage = std::get_if<HostStorage>(&storage_)) {

--- a/ttnn/core/tensor/tensor_attributes.cpp
+++ b/ttnn/core/tensor/tensor_attributes.cpp
@@ -20,17 +20,22 @@ TensorAttributes::TensorAttributes(HostStorage storage) :
     tensor_spec_(get_host_tensor(storage_).tensor_spec()),
     tensor_topology_(get_host_tensor(storage_).tensor_topology()) {}
 
-TensorAttributes::TensorAttributes(Storage storage, TensorSpec tensor_spec, TensorTopology tensor_topology) :
-    storage_(std::move(storage)), tensor_spec_(std::move(tensor_spec)), tensor_topology_(std::move(tensor_topology)) {
-    if (auto* host_storage = std::get_if<HostStorage>(&storage_)) {
-        storage_ = HostStorage(std::move(*host_storage), tensor_spec_, tensor_topology_);
-    }
-}
+// Transitional: assumes a HostStorage constructed without proper TensorSpec and TensorTopology.
+// Overrides the existing spec and topology in the HostStorage.
+TensorAttributes::TensorAttributes(HostStorage storage, TensorSpec tensor_spec, TensorTopology tensor_topology) :
+    storage_(HostStorage(std::move(storage), tensor_spec, tensor_topology)),
+    tensor_spec_(std::move(tensor_spec)),
+    tensor_topology_(std::move(tensor_topology)) {}
+
+TensorAttributes::TensorAttributes(DeviceStorage storage, TensorSpec tensor_spec, TensorTopology tensor_topology) :
+    storage_(std::move(storage)), tensor_spec_(std::move(tensor_spec)), tensor_topology_(std::move(tensor_topology)) {}
 
 const Storage& TensorAttributes::get_storage() const { return storage_; }
 Storage& TensorAttributes::get_storage() { return storage_; }
 
 const TensorSpec& TensorAttributes::get_tensor_spec() const {
+    // Prefer spec from HostStorage
+    // TODO(#40348): TensorAttributes should not store spec and topology.
     if (const auto* host_storage = std::get_if<HostStorage>(&storage_)) {
         return host_storage->host_tensor().tensor_spec();
     }
@@ -38,6 +43,8 @@ const TensorSpec& TensorAttributes::get_tensor_spec() const {
 }
 
 const TensorTopology& TensorAttributes::get_tensor_topology() const {
+    // Prefer spec from HostStorage
+    // TODO(#40348): TensorAttributes should not store spec and topology.
     if (const auto* host_storage = std::get_if<HostStorage>(&storage_)) {
         return host_storage->host_tensor().tensor_topology();
     }
@@ -48,7 +55,7 @@ TensorAttributes TensorAttributes::with_tensor_topology(TensorTopology tensor_to
     // This needs to be moved to HostTensor after TODO(#39485)
     if (const auto* host_storage = std::get_if<HostStorage>(&storage_)) {
         HostStorage new_storage(*host_storage, tensor_spec_, tensor_topology);
-        return TensorAttributes(std::move(new_storage), tensor_spec_, tensor_topology);
+        return TensorAttributes(std::move(new_storage));
     }
     TensorAttributes result = *this;
     result.tensor_topology_ = std::move(tensor_topology);

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -8,6 +8,7 @@
 #include <sys/mman.h>
 #include <unistd.h>
 
+#include "tt-metalium/experimental/tensor/host_tensor.hpp"
 #include "ttnn/distributed/distributed_tensor.hpp"
 #include "ttnn/distributed/api.hpp"
 #include "ttnn/tensor/host_buffer/functions.hpp"
@@ -554,8 +555,8 @@ Tensor to_host(const Tensor& tensor, bool blocking, std::optional<tt::tt_metal::
 
     mesh_cq.enqueue_read(mesh_buffer, distributed_host_buffer, /*shards=*/std::nullopt, blocking);
 
-    HostStorage host_storage(std::move(distributed_host_buffer));
-    return Tensor(std::move(host_storage), tensor.tensor_spec(), tensor.tensor_topology());
+    HostTensor host_tensor(std::move(distributed_host_buffer), tensor.tensor_spec(), tensor.tensor_topology());
+    return Tensor(std::move(host_tensor));
 }
 
 // ======================================================================================
@@ -708,10 +709,8 @@ void copy_to_host(
 
     mesh_cq.enqueue_read(mesh_buffer, dst_distributed_host_buffer, /*shards=*/std::nullopt, blocking);
 
-    host_tensor = Tensor(
-        HostStorage(std::move(dst_distributed_host_buffer)),
-        device_tensor.tensor_spec(),
-        device_tensor.tensor_topology());
+    host_tensor = Tensor(HostTensor(
+        std::move(dst_distributed_host_buffer), device_tensor.tensor_spec(), device_tensor.tensor_topology()));
 }
 
 void copy_to_host(
@@ -1364,8 +1363,8 @@ struct bfloat4_tag {};
 struct bfloat8_tag {};
 
 // Preprocess the storage to unpack the bfloat8/4 tiles into float32.
-tt::tt_metal::HostStorage preprocess_storage(
-    const tt::tt_metal::HostStorage& input_storage, const DataType input_dtype) {
+tt::tt_metal::DistributedHostBuffer preprocess_buffers(
+    const tt::tt_metal::DistributedHostBuffer& input_storage, const DataType input_dtype) {
     constexpr bool row_major_output = false;
     constexpr bool is_exp_a = false;
 
@@ -1387,10 +1386,10 @@ tt::tt_metal::HostStorage preprocess_storage(
 }
 
 template <typename SrcType, typename DstType>
-tt::tt_metal::HostStorage transform_storage(
-    const tt::tt_metal::TensorSpec& input_tensor_spec, const tt::tt_metal::HostStorage& input_storage) {
+tt::tt_metal::DistributedHostBuffer transform_buffers(
+    const tt::tt_metal::TensorSpec& input_tensor_spec, const tt::tt_metal::DistributedHostBuffer& input_buffer) {
     if constexpr (std::is_same_v<SrcType, DstType>) {
-        return input_storage;
+        return input_buffer;
     } else if constexpr (std::is_same_v<DstType, bfloat4_tag> || std::is_same_v<DstType, bfloat8_tag>) {
         auto transform_fn = [&](const tt::tt_metal::HostBuffer& buffer) {
             ttsl::Span<const SrcType> data = buffer.view_as<const SrcType>();
@@ -1415,7 +1414,7 @@ tt::tt_metal::HostStorage transform_storage(
             return tt::tt_metal::HostBuffer(std::move(float_packed_data));
         };
 
-        return input_storage.transform(transform_fn);
+        return input_buffer.transform(transform_fn);
     } else {
         auto transform_fn = [&](const tt::tt_metal::HostBuffer& buffer) {
             auto data = buffer.view_as<const SrcType>();
@@ -1426,7 +1425,7 @@ tt::tt_metal::HostStorage transform_storage(
             return tt::tt_metal::HostBuffer(std::move(output_vector));
         };
 
-        return input_storage.transform(transform_fn);
+        return input_buffer.transform(transform_fn);
     }
 }
 
@@ -1439,11 +1438,11 @@ Tensor to_dtype(const Tensor& input_tensor, DataType dtype) {
     }
     TT_FATAL(is_cpu_tensor(input_tensor), "to_dtype(...) function only supports host tensors!");
 
-    auto input_storage = detail::preprocess_storage(input_tensor.host_storage(), src_type);
+    auto input_buffer = detail::preprocess_buffers(input_tensor.host_tensor().buffer(), src_type);
 
-    auto output_storage = [src_type, dst_type = dtype, &input_tensor, &input_storage]() {
+    auto output_storage = [src_type, dst_type = dtype, &input_tensor, &input_buffer]() {
         auto with_src_and_dst = [&]<typename SrcType, typename DstType>() {
-            return detail::transform_storage<SrcType, DstType>(input_tensor.tensor_spec(), input_storage);
+            return detail::transform_buffers<SrcType, DstType>(input_tensor.tensor_spec(), input_buffer);
         };
 
         auto with_src = [dst_type, &with_src_and_dst]<typename SrcType>() {
@@ -1487,7 +1486,7 @@ Tensor to_dtype(const Tensor& input_tensor, DataType dtype) {
             input_tensor.logical_shape(),
             input_tensor.padded_shape()));
 
-    return Tensor(tt::tt_metal::HostStorage(std::move(output_storage)), output_spec, input_tensor.tensor_topology());
+    return Tensor(HostTensor(std::move(output_storage), output_spec, input_tensor.tensor_topology()));
 }
 
 }  // namespace tt::tt_metal::tensor_impl

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -60,7 +60,7 @@ Tensor allocate_tensor_on_host(const TensorSpec& tensor_spec, distributed::MeshD
         DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL);
 
     // TODO (#25340): Implement correct logic and add test for this
-    return Tensor(HostStorage(std::move(distributed_host_buffer)), tensor_spec, TensorTopology{});
+    return Tensor(HostTensor(std::move(distributed_host_buffer), tensor_spec, TensorTopology{}));
 }
 
 Tensor create_device_tensor(const TensorSpec& tensor_spec, IDevice* device) {
@@ -345,7 +345,8 @@ Tensor view(const Tensor& input_tensor, const Shape& new_logical_shape, const Sh
                 return Tensor(view_storage, new_spec, tensor.tensor_topology());
             }
 
-            return Tensor(tensor.host_storage(), new_spec, tensor.tensor_topology());
+            const auto& buffer = tensor.host_storage().buffer();
+            return Tensor(HostTensor(buffer, new_spec, tensor.tensor_topology()));
         });
     output = tt::tt_metal::set_tensor_id(output);
     tt::tt_metal::GraphTracker::instance().track_function_end(output);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/36877

### PR Kind
Refactor

### Problem description
Runtime is lowering ttnn::Tensor to metal.
TTNN::Tensor now will be built upon Runtime tensors.

### What's changed
Swap out the base class composition of ttnn::Tensor so it's using HostTensor as the storage data class.

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/host-tensor-integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/host-tensor-integration)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu/host-tensor-integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/host-tensor-integration)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/host-tensor-integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/host-tensor-integration)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/host-tensor-integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/host-tensor-integration)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/host-tensor-integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/host-tensor-integration)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/host-tensor-integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/host-tensor-integration)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
