### PR TITLE
Implement Host and MeshTensor

### DIFF
--- a/tests/tt_metal/tt_metal/api/sources.cmake
+++ b/tests/tt_metal/tt_metal/api/sources.cmake
@@ -22,6 +22,8 @@ set(UNIT_TESTS_API_SOURCES
     dataflow_buffer/test_dataflow_buffer_configs.cpp
     distribution_spec/test_buffer_distribution_spec.cpp
     tensor/test_tensor_sharding.cpp
+    tensor/test_host_tensor.cpp
+    tensor/test_mesh_tensor.cpp
     test_banked.cpp
     test_bit_utils.cpp
     test_buffer_region.cpp

--- a/tests/tt_metal/tt_metal/api/tensor/README.md
+++ b/tests/tt_metal/tt_metal/api/tensor/README.md
@@ -7,3 +7,5 @@ These tests correspond to the tensor implementation in `tt_metal/impl/tensor/` a
 ## Test Files
 
 - `test_tensor_sharding.cpp` - TensorSpec sharding validation
+- `test_host_tensor.cpp` - Sanity tests for HostTensor (type traits, construction, copy/move semantics)
+- `test_mesh_tensor.cpp` - Sanity tests for MeshTensor (type traits, construction, move semantics, device-based tests with MeshBuffer)

--- a/tests/tt_metal/tt_metal/api/tensor/test_host_tensor.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_host_tensor.cpp
@@ -149,8 +149,7 @@ TEST(HostTensorTest, MoveAssignment) {
 TEST(HostTensorTest, CopyConstruction) {
     Shape shape{2, 64};
     auto tensor = create_simple_host_tensor(shape);
-    const HostTensor copied_tensor(tensor);
-    (void)copied_tensor;
+    const HostTensor copied_tensor(tensor);  // NOLINT(performance-unnecessary-copy-initialization)
 
     EXPECT_EQ(copied_tensor.logical_shape(), shape);
     EXPECT_EQ(copied_tensor.dtype(), DataType::BFLOAT16);

--- a/tests/tt_metal/tt_metal/api/tensor/test_host_tensor.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_host_tensor.cpp
@@ -1,0 +1,258 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Sanity tests for HostTensor class.
+//
+// These are minimal tests to verify HostTensor's basic type properties and
+// functionality including:
+// - Type traits (copyable, movable, etc.)
+// - Construction with DistributedHostBuffer, TensorSpec, and TensorTopology
+// - Copy and move semantics
+// - Getter methods for tensor properties
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include <type_traits>
+
+#include <tt-metalium/experimental/tensor/host_tensor.hpp>
+#include <tt-metalium/experimental/tensor/spec/tensor_spec.hpp>
+#include <tt-metalium/experimental/tensor/spec/layout/tensor_layout.hpp>
+#include <tt-metalium/experimental/tensor/spec/layout/page_config.hpp>
+#include <tt-metalium/experimental/tensor/topology/tensor_topology.hpp>
+#include <tt-metalium/distributed_host_buffer.hpp>
+#include <tt-metalium/shape.hpp>
+
+namespace tt::tt_metal {
+namespace {
+
+TensorSpec create_simple_spec(const Shape& shape, DataType dtype = DataType::BFLOAT16) {
+    auto page_config = PageConfig(Layout::ROW_MAJOR);
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    auto tensor_layout = TensorLayout(dtype, page_config, memory_config);
+    return TensorSpec(shape, tensor_layout);
+}
+
+HostTensor create_simple_host_tensor(const Shape& shape, DataType dtype = DataType::BFLOAT16) {
+    auto spec = create_simple_spec(shape, dtype);
+    auto buffer = DistributedHostBuffer::create(distributed::MeshShape{1});
+    auto topology = TensorTopology();
+    return HostTensor(std::move(buffer), std::move(spec), std::move(topology));
+}
+
+// Type trait tests verifying HostTensor's semantic constraints
+
+TEST(HostTensorTypeTraitsTest, IsDefaultConstructible) { EXPECT_TRUE(std::is_default_constructible_v<HostTensor>); }
+
+TEST(HostTensorTypeTraitsTest, IsDestructible) { EXPECT_TRUE(std::is_destructible_v<HostTensor>); }
+
+TEST(HostTensorTypeTraitsTest, IsCopyConstructible) { EXPECT_TRUE(std::is_copy_constructible_v<HostTensor>); }
+
+TEST(HostTensorTypeTraitsTest, IsCopyAssignable) { EXPECT_TRUE(std::is_copy_assignable_v<HostTensor>); }
+
+TEST(HostTensorTypeTraitsTest, IsMoveConstructible) { EXPECT_TRUE(std::is_move_constructible_v<HostTensor>); }
+
+TEST(HostTensorTypeTraitsTest, IsMoveAssignable) { EXPECT_TRUE(std::is_move_assignable_v<HostTensor>); }
+
+TEST(HostTensorTypeTraitsTest, IsNothrowMoveConstructible) {
+    EXPECT_TRUE(std::is_nothrow_move_constructible_v<HostTensor>);
+}
+
+TEST(HostTensorTypeTraitsTest, IsNothrowMoveAssignable) { EXPECT_TRUE(std::is_nothrow_move_assignable_v<HostTensor>); }
+
+// Runtime tests
+
+TEST(HostTensorTest, ConstructionWithSpec) {
+    Shape shape{2, 64};
+    auto tensor = create_simple_host_tensor(shape);
+
+    EXPECT_EQ(tensor.logical_shape(), shape);
+    EXPECT_EQ(tensor.dtype(), DataType::BFLOAT16);
+    EXPECT_EQ(tensor.layout(), Layout::ROW_MAJOR);
+}
+
+TEST(HostTensorTest, LogicalVolume) {
+    Shape shape{4, 8, 16};
+    auto tensor = create_simple_host_tensor(shape);
+
+    EXPECT_EQ(tensor.logical_volume(), 4 * 8 * 16);
+}
+
+TEST(HostTensorTest, ElementSizeBFloat16) {
+    auto tensor = create_simple_host_tensor(Shape{1, 32}, DataType::BFLOAT16);
+    EXPECT_EQ(tensor.element_size(), sizeof(bfloat16));
+}
+
+TEST(HostTensorTest, ElementSizeFloat32) {
+    auto tensor = create_simple_host_tensor(Shape{1, 32}, DataType::FLOAT32);
+    EXPECT_EQ(tensor.element_size(), sizeof(float));
+}
+
+TEST(HostTensorTest, ElementSizeUInt32) {
+    auto tensor = create_simple_host_tensor(Shape{1, 32}, DataType::UINT32);
+    EXPECT_EQ(tensor.element_size(), sizeof(uint32_t));
+}
+
+TEST(HostTensorTest, ElementSizeInt32) {
+    auto tensor = create_simple_host_tensor(Shape{1, 32}, DataType::INT32);
+    EXPECT_EQ(tensor.element_size(), sizeof(int32_t));
+}
+
+TEST(HostTensorTest, ElementSizeUInt16) {
+    auto tensor = create_simple_host_tensor(Shape{1, 32}, DataType::UINT16);
+    EXPECT_EQ(tensor.element_size(), sizeof(uint16_t));
+}
+
+TEST(HostTensorTest, ElementSizeUInt8) {
+    auto tensor = create_simple_host_tensor(Shape{1, 32}, DataType::UINT8);
+    EXPECT_EQ(tensor.element_size(), sizeof(uint8_t));
+}
+
+TEST(HostTensorTest, MoveConstruction) {
+    Shape shape{2, 64};
+    auto tensor = create_simple_host_tensor(shape);
+    HostTensor moved_tensor(std::move(tensor));
+
+    EXPECT_EQ(moved_tensor.logical_shape(), shape);
+    EXPECT_EQ(moved_tensor.dtype(), DataType::BFLOAT16);
+}
+
+TEST(HostTensorTest, MoveAssignment) {
+    Shape shape{2, 64};
+    auto tensor = create_simple_host_tensor(shape);
+    auto other = create_simple_host_tensor(Shape{1, 32});
+    other = std::move(tensor);
+
+    EXPECT_EQ(other.logical_shape(), shape);
+    EXPECT_EQ(other.dtype(), DataType::BFLOAT16);
+}
+
+TEST(HostTensorTest, CopyConstruction) {
+    Shape shape{2, 64};
+    auto tensor = create_simple_host_tensor(shape);
+    const HostTensor copied_tensor(tensor);
+
+    EXPECT_EQ(copied_tensor.logical_shape(), shape);
+    EXPECT_EQ(copied_tensor.dtype(), DataType::BFLOAT16);
+    // Original should still be valid
+    EXPECT_EQ(tensor.logical_shape(), shape);
+}
+
+TEST(HostTensorTest, CopyAssignment) {
+    Shape shape{2, 64};
+    auto tensor = create_simple_host_tensor(shape);
+    auto other = create_simple_host_tensor(Shape{1, 32});
+    other = tensor;
+
+    EXPECT_EQ(other.logical_shape(), shape);
+    EXPECT_EQ(other.dtype(), DataType::BFLOAT16);
+    // Original should still be valid
+    EXPECT_EQ(tensor.logical_shape(), shape);
+}
+
+TEST(HostTensorTest, TensorSpecAccess) {
+    Shape shape{4, 32};
+    auto tensor = create_simple_host_tensor(shape, DataType::FLOAT32);
+
+    const auto& spec = tensor.tensor_spec();
+    EXPECT_EQ(spec.logical_shape(), shape);
+    EXPECT_EQ(spec.data_type(), DataType::FLOAT32);
+    EXPECT_EQ(spec.layout(), Layout::ROW_MAJOR);
+}
+
+TEST(HostTensorTest, TensorTopologyAccess) {
+    Shape shape{4, 32};
+    auto tensor = create_simple_host_tensor(shape);
+
+    const auto& topology = tensor.tensor_topology();
+    // Default topology should have distribution shape of {1}
+    EXPECT_EQ(topology.distribution_shape().dims(), 1);
+}
+
+TEST(HostTensorTest, MemoryConfigAccess) {
+    Shape shape{4, 32};
+    auto tensor = create_simple_host_tensor(shape);
+
+    const auto& memory_config = tensor.memory_config();
+    EXPECT_EQ(memory_config.memory_layout(), TensorMemoryLayout::INTERLEAVED);
+    EXPECT_EQ(memory_config.buffer_type(), BufferType::DRAM);
+}
+
+TEST(HostTensorTest, IsSharded) {
+    Shape shape{4, 32};
+    auto tensor = create_simple_host_tensor(shape);
+
+    // Default memory config is INTERLEAVED, not sharded
+    EXPECT_FALSE(tensor.is_sharded());
+}
+
+TEST(HostTensorTest, Strides) {
+    Shape shape{2, 4, 8};
+    auto tensor = create_simple_host_tensor(shape);
+
+    auto strides = tensor.strides();
+    // For row-major layout, strides should be [4*8, 8, 1] = [32, 8, 1]
+    ASSERT_EQ(strides.size(), 3);
+    EXPECT_EQ(strides[0], 32);
+    EXPECT_EQ(strides[1], 8);
+    EXPECT_EQ(strides[2], 1);
+}
+
+TEST(HostTensorTest, BufferAccess) {
+    Shape shape{4, 32};
+    auto tensor = create_simple_host_tensor(shape);
+
+    const auto& buffer = tensor.buffer();
+    // Buffer should have shape {1} (single device)
+    EXPECT_EQ(buffer.shape().dims(), 1);
+}
+
+TEST(HostTensorTest, MoveConstructionWithNewSpecAndTopology) {
+    Shape original_shape{2, 64};
+    auto tensor = create_simple_host_tensor(original_shape);
+
+    Shape new_shape{4, 32};
+    auto new_spec = create_simple_spec(new_shape, DataType::FLOAT32);
+    auto new_topology = TensorTopology();
+
+    HostTensor new_tensor(std::move(tensor), std::move(new_spec), std::move(new_topology));
+
+    EXPECT_EQ(new_tensor.logical_shape(), new_shape);
+    EXPECT_EQ(new_tensor.dtype(), DataType::FLOAT32);
+}
+
+TEST(HostTensorTest, PaddedShape) {
+    Shape shape{2, 64};
+    auto tensor = create_simple_host_tensor(shape);
+
+    // For row-major layout without explicit padding, padded shape equals logical shape
+    const auto& padded = tensor.padded_shape();
+    EXPECT_EQ(padded, shape);
+}
+
+TEST(HostTensorTest, PhysicalVolume) {
+    Shape shape{4, 8, 16};
+    auto tensor = create_simple_host_tensor(shape);
+
+    // For non-padded row-major layout, physical volume equals logical volume
+    EXPECT_EQ(tensor.physical_volume(), tensor.logical_volume());
+}
+
+TEST(HostTensorTest, LegacyShardSpecNotSet) {
+    Shape shape{4, 32};
+    auto tensor = create_simple_host_tensor(shape);
+
+    // INTERLEAVED memory config should not have shard spec
+    EXPECT_FALSE(tensor.legacy_shard_spec().has_value());
+}
+
+TEST(HostTensorTest, NdShardSpecNotSet) {
+    Shape shape{4, 32};
+    auto tensor = create_simple_host_tensor(shape);
+
+    // INTERLEAVED memory config should not have nd shard spec
+    EXPECT_FALSE(tensor.nd_shard_spec().has_value());
+}
+
+}  // namespace
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/api/tensor/test_host_tensor.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_host_tensor.cpp
@@ -21,6 +21,7 @@
 #include <tt-metalium/experimental/tensor/spec/layout/page_config.hpp>
 #include <tt-metalium/experimental/tensor/topology/tensor_topology.hpp>
 #include <tt-metalium/distributed_host_buffer.hpp>
+#include <tt-metalium/host_buffer.hpp>
 #include <tt-metalium/shape.hpp>
 
 namespace tt::tt_metal {
@@ -69,6 +70,24 @@ TEST(HostTensorTest, ConstructionWithSpec) {
     EXPECT_EQ(tensor.logical_shape(), shape);
     EXPECT_EQ(tensor.dtype(), DataType::BFLOAT16);
     EXPECT_EQ(tensor.layout(), Layout::ROW_MAJOR);
+}
+
+TEST(HostTensorTest, ConstructionWithHostBuffer) {
+    Shape shape{2, 32};
+    auto spec = create_simple_spec(shape, DataType::FLOAT32);
+    auto topology = TensorTopology();
+
+    std::vector<float> data(shape.volume(), 1.0f);
+    HostBuffer host_buffer(std::move(data));
+
+    HostTensor tensor(std::move(host_buffer), std::move(spec), std::move(topology));
+
+    EXPECT_EQ(tensor.logical_shape(), shape);
+    EXPECT_EQ(tensor.dtype(), DataType::FLOAT32);
+    EXPECT_EQ(tensor.layout(), Layout::ROW_MAJOR);
+
+    const auto& buffer = tensor.buffer();
+    EXPECT_TRUE(buffer.get_shard(distributed::MeshCoordinate(0, 0)).has_value());
 }
 
 TEST(HostTensorTest, LogicalVolume) {

--- a/tests/tt_metal/tt_metal/api/tensor/test_host_tensor.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_host_tensor.cpp
@@ -150,6 +150,27 @@ TEST(HostTensorTest, CopyAssignment) {
     EXPECT_EQ(tensor.logical_shape(), shape);
 }
 
+TEST(HostTensorTest, CopyConstructionFromDefaultConstructed) {
+    HostTensor default_tensor;
+    [[maybe_unused]] HostTensor copied(default_tensor);
+    // Both should be in default-constructed state (no assertions, just shouldn't crash)
+}
+
+TEST(HostTensorTest, CopyAssignmentFromDefaultConstructed) {
+    HostTensor default_tensor;
+    [[maybe_unused]] auto tensor = create_simple_host_tensor(Shape{2, 64});
+    tensor = default_tensor;
+    // tensor should now be in default-constructed state (no assertions, just shouldn't crash)
+}
+
+TEST(HostTensorTest, MoveConstructionWithNewSpecFromDefaultConstructedFails) {
+    HostTensor default_tensor;
+    auto new_spec = create_simple_spec(Shape{4, 32}, DataType::FLOAT32);
+    auto new_topology = TensorTopology();
+
+    EXPECT_ANY_THROW(HostTensor(std::move(default_tensor), std::move(new_spec), std::move(new_topology)));
+}
+
 TEST(HostTensorTest, TensorSpecAccess) {
     Shape shape{4, 32};
     auto tensor = create_simple_host_tensor(shape, DataType::FLOAT32);

--- a/tests/tt_metal/tt_metal/api/tensor/test_host_tensor.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_host_tensor.cpp
@@ -131,6 +131,7 @@ TEST(HostTensorTest, CopyConstruction) {
     Shape shape{2, 64};
     auto tensor = create_simple_host_tensor(shape);
     const HostTensor copied_tensor(tensor);
+    (void)copied_tensor;
 
     EXPECT_EQ(copied_tensor.logical_shape(), shape);
     EXPECT_EQ(copied_tensor.dtype(), DataType::BFLOAT16);
@@ -152,7 +153,8 @@ TEST(HostTensorTest, CopyAssignment) {
 
 TEST(HostTensorTest, CopyConstructionFromDefaultConstructed) {
     HostTensor default_tensor;
-    [[maybe_unused]] HostTensor copied(default_tensor);
+    HostTensor copied(default_tensor);
+    (void)copied;
     // Both should be in default-constructed state (no assertions, just shouldn't crash)
 }
 

--- a/tests/tt_metal/tt_metal/api/tensor/test_host_tensor.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_host_tensor.cpp
@@ -153,7 +153,7 @@ TEST(HostTensorTest, CopyAssignment) {
 
 TEST(HostTensorTest, CopyConstructionFromDefaultConstructed) {
     HostTensor default_tensor;
-    HostTensor copied(default_tensor);
+    const HostTensor& copied(default_tensor);
     (void)copied;
     // Both should be in default-constructed state (no assertions, just shouldn't crash)
 }

--- a/tests/tt_metal/tt_metal/api/tensor/test_mesh_tensor.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_mesh_tensor.cpp
@@ -80,6 +80,18 @@ TEST(MeshTensorTest, ConstructionWithNullMeshBufferFails) {
     EXPECT_ANY_THROW(MeshTensor(nullptr, std::move(spec), std::move(topology)));
 }
 
+TEST(MeshTensorTest, MoveConstructionWithNewSpecFromDefaultConstructedFails) {
+    MeshTensor default_tensor;
+
+    auto page_config = PageConfig(Layout::ROW_MAJOR);
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    auto tensor_layout = TensorLayout(DataType::BFLOAT16, page_config, memory_config);
+    auto new_spec = TensorSpec(Shape{4, 32}, tensor_layout);
+    auto new_topology = TensorTopology();
+
+    EXPECT_ANY_THROW(MeshTensor(std::move(default_tensor), std::move(new_spec), std::move(new_topology)));
+}
+
 // Device-based tests using GenericMeshDeviceFixture
 using MeshTensorDeviceTest = GenericMeshDeviceFixture;
 

--- a/tests/tt_metal/tt_metal/api/tensor/test_mesh_tensor.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_mesh_tensor.cpp
@@ -1,0 +1,235 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Sanity tests for MeshTensor class.
+//
+// These are minimal compile-time and runtime checks to verify MeshTensor's
+// basic type properties and construction semantics. MeshTensor enforces unique
+// ownership of device memory: movable but non-copyable.
+//
+// Device-based tests use GenericMeshDeviceFixture and require hardware access.
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include <type_traits>
+
+#include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
+#include <tt-metalium/experimental/tensor/spec/tensor_spec.hpp>
+#include <tt-metalium/experimental/tensor/spec/layout/tensor_layout.hpp>
+#include <tt-metalium/experimental/tensor/spec/layout/page_config.hpp>
+#include <tt-metalium/experimental/tensor/topology/tensor_topology.hpp>
+#include <tt-metalium/mesh_buffer.hpp>
+#include <tt-metalium/math.hpp>
+
+#include "tt_metal/tt_metal/common/multi_device_fixture.hpp"
+
+namespace tt::tt_metal {
+namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
+
+// Type trait tests verifying MeshTensor's semantic constraints
+
+TEST(MeshTensorTypeTraitsTest, IsDefaultConstructible) { EXPECT_TRUE(std::is_default_constructible_v<MeshTensor>); }
+
+TEST(MeshTensorTypeTraitsTest, IsDestructible) { EXPECT_TRUE(std::is_destructible_v<MeshTensor>); }
+
+TEST(MeshTensorTypeTraitsTest, IsNotCopyConstructible) { EXPECT_FALSE(std::is_copy_constructible_v<MeshTensor>); }
+
+TEST(MeshTensorTypeTraitsTest, IsNotCopyAssignable) { EXPECT_FALSE(std::is_copy_assignable_v<MeshTensor>); }
+
+TEST(MeshTensorTypeTraitsTest, IsMoveConstructible) { EXPECT_TRUE(std::is_move_constructible_v<MeshTensor>); }
+
+TEST(MeshTensorTypeTraitsTest, IsMoveAssignable) { EXPECT_TRUE(std::is_move_assignable_v<MeshTensor>); }
+
+TEST(MeshTensorTypeTraitsTest, IsNothrowMoveConstructible) {
+    EXPECT_TRUE(std::is_nothrow_move_constructible_v<MeshTensor>);
+}
+
+TEST(MeshTensorTypeTraitsTest, IsNothrowMoveAssignable) { EXPECT_TRUE(std::is_nothrow_move_assignable_v<MeshTensor>); }
+
+// Runtime tests for default construction and move semantics
+
+TEST(MeshTensorTest, DefaultConstruction) {
+    MeshTensor tensor;
+    // Default constructed tensor is in valueless state
+    // Accessing members would trigger TT_ASSERT in debug builds
+    (void)tensor;
+}
+
+TEST(MeshTensorTest, MoveConstruction) {
+    MeshTensor tensor;
+    MeshTensor moved(std::move(tensor));
+    (void)moved;
+}
+
+TEST(MeshTensorTest, MoveAssignment) {
+    MeshTensor tensor;
+    MeshTensor other;
+    other = std::move(tensor);
+    (void)other;
+}
+
+TEST(MeshTensorTest, ConstructionWithNullMeshBufferFails) {
+    auto page_config = PageConfig(Layout::ROW_MAJOR);
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    auto tensor_layout = TensorLayout(DataType::BFLOAT16, page_config, memory_config);
+    auto spec = TensorSpec(Shape{1, 32}, tensor_layout);
+    auto topology = TensorTopology();
+
+    EXPECT_ANY_THROW(MeshTensor(nullptr, std::move(spec), std::move(topology)));
+}
+
+// Device-based tests using GenericMeshDeviceFixture
+using MeshTensorDeviceTest = GenericMeshDeviceFixture;
+
+auto create_mesh_buffer(
+    distributed::MeshDevice& mesh_device, const TensorSpec& spec, float buffer_size_multiplier = 1.0f) {
+    auto page_size = spec.compute_page_size_bytes();
+
+    distributed::DeviceLocalBufferConfig local_config{
+        .page_size = static_cast<uint32_t>(page_size),
+        .buffer_type = BufferType::DRAM,
+    };
+
+    auto buffer_size_needed = spec.compute_packed_buffer_size_bytes();
+    auto scaled_size = static_cast<DeviceAddr>(buffer_size_needed * buffer_size_multiplier);
+    // Round down to nearest multiple of page_size (buffer_size % page_size must == 0).
+    // Ensure minimum of one page.
+    auto buffer_size = std::max(round_down(scaled_size, page_size), page_size);
+
+    distributed::ReplicatedBufferConfig buffer_config{.size = buffer_size};
+
+    return distributed::MeshBuffer::create(buffer_config, local_config, &mesh_device);
+}
+
+TEST_F(MeshTensorDeviceTest, ConstructionWithMeshBuffer) {
+    auto page_config = PageConfig(Layout::ROW_MAJOR);
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    auto tensor_layout = TensorLayout(DataType::BFLOAT16, page_config, memory_config);
+    auto spec = TensorSpec(Shape{1, 32}, tensor_layout);
+
+    auto mesh_buffer = create_mesh_buffer(*mesh_device_, spec);
+    ASSERT_NE(mesh_buffer, nullptr);
+    ASSERT_TRUE(mesh_buffer->is_allocated());
+
+    auto topology = TensorTopology();
+
+    MeshTensor tensor(mesh_buffer, std::move(spec), std::move(topology));
+
+    EXPECT_EQ(&tensor.mesh_buffer(), mesh_buffer.get());
+    EXPECT_EQ(&tensor.device(), mesh_device_.get());
+    EXPECT_EQ(tensor.dtype(), DataType::BFLOAT16);
+    EXPECT_EQ(tensor.layout(), Layout::ROW_MAJOR);
+    EXPECT_EQ(tensor.logical_shape(), Shape({1, 32}));
+}
+
+TEST_F(MeshTensorDeviceTest, MoveConstructionTransfersOwnership) {
+    auto page_config = PageConfig(Layout::ROW_MAJOR);
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    auto tensor_layout = TensorLayout(DataType::BFLOAT16, page_config, memory_config);
+    auto spec = TensorSpec(Shape{2, 64}, tensor_layout);
+
+    auto mesh_buffer = create_mesh_buffer(*mesh_device_, spec);
+    auto topology = TensorTopology();
+
+    MeshTensor original(mesh_buffer, std::move(spec), std::move(topology));
+    auto* buffer_ptr = &original.mesh_buffer();
+
+    MeshTensor moved(std::move(original));
+
+    EXPECT_EQ(&moved.mesh_buffer(), buffer_ptr);
+    EXPECT_EQ(moved.logical_shape(), Shape({2, 64}));
+}
+
+TEST_F(MeshTensorDeviceTest, MoveAssignmentTransfersOwnership) {
+    auto page_config = PageConfig(Layout::ROW_MAJOR);
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    auto tensor_layout = TensorLayout(DataType::BFLOAT16, page_config, memory_config);
+
+    auto spec1 = TensorSpec(Shape{1, 32}, tensor_layout);
+    auto spec2 = TensorSpec(Shape{2, 64}, tensor_layout);
+
+    auto mesh_buffer1 = create_mesh_buffer(*mesh_device_, spec1);
+    auto mesh_buffer2 = create_mesh_buffer(*mesh_device_, spec2);
+
+    MeshTensor tensor1(mesh_buffer1, std::move(spec1), TensorTopology());
+    MeshTensor tensor2(mesh_buffer2, std::move(spec2), TensorTopology());
+
+    auto* buffer1_ptr = &tensor1.mesh_buffer();
+
+    tensor2 = std::move(tensor1);
+
+    EXPECT_EQ(&tensor2.mesh_buffer(), buffer1_ptr);
+    EXPECT_EQ(tensor2.logical_shape(), Shape({1, 32}));
+}
+
+TEST_F(MeshTensorDeviceTest, MoveConstructionWithNewSpecAndTopology) {
+    auto page_config = PageConfig(Layout::ROW_MAJOR);
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    auto tensor_layout = TensorLayout(DataType::BFLOAT16, page_config, memory_config);
+    auto spec = TensorSpec(Shape{2, 64}, tensor_layout);
+
+    auto mesh_buffer = create_mesh_buffer(*mesh_device_, spec);
+    MeshTensor original(mesh_buffer, std::move(spec), TensorTopology());
+    auto* buffer_ptr = &original.mesh_buffer();
+
+    auto new_tensor_layout = TensorLayout(DataType::FLOAT32, page_config, memory_config);
+    auto new_spec = TensorSpec(Shape{4, 32}, new_tensor_layout);
+    auto new_topology = TensorTopology();
+
+    MeshTensor moved(std::move(original), std::move(new_spec), std::move(new_topology));
+
+    EXPECT_EQ(&moved.mesh_buffer(), buffer_ptr);
+    EXPECT_EQ(moved.logical_shape(), Shape({4, 32}));
+    EXPECT_EQ(moved.dtype(), DataType::FLOAT32);
+}
+
+TEST_F(MeshTensorDeviceTest, TensorProperties) {
+    auto page_config = PageConfig(Layout::ROW_MAJOR);
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    auto tensor_layout = TensorLayout(DataType::FLOAT32, page_config, memory_config);
+    auto spec = TensorSpec(Shape{4, 8, 16}, tensor_layout);
+
+    auto mesh_buffer = create_mesh_buffer(*mesh_device_, spec);
+    auto topology = TensorTopology();
+
+    MeshTensor tensor(mesh_buffer, std::move(spec), std::move(topology));
+
+    EXPECT_EQ(tensor.dtype(), DataType::FLOAT32);
+    EXPECT_EQ(tensor.layout(), Layout::ROW_MAJOR);
+    EXPECT_EQ(tensor.logical_shape(), Shape({4, 8, 16}));
+    EXPECT_EQ(tensor.logical_volume(), 4 * 8 * 16);
+    EXPECT_EQ(tensor.element_size(), sizeof(float));
+    EXPECT_FALSE(tensor.is_sharded());
+    EXPECT_EQ(tensor.memory_config().buffer_type(), BufferType::DRAM);
+}
+
+TEST_F(MeshTensorDeviceTest, ConstructionWithTooSmallBufferFails) {
+    // Create a TensorSpec that requires multiple pages, then create a buffer
+    // that's too small to hold the tensor but still valid (multiple of page_size).
+    auto page_config = PageConfig(Layout::ROW_MAJOR);
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    auto tensor_layout = TensorLayout(DataType::BFLOAT16, page_config, memory_config);
+    // Use a larger shape to ensure multiple pages are required.
+    auto spec = TensorSpec(Shape{4, 512}, tensor_layout);
+
+    const size_t required_size = spec.compute_packed_buffer_size_bytes();
+    const size_t page_size = spec.compute_page_size_bytes();
+    ASSERT_GT(required_size, page_size);  // Ensure we need multiple pages
+
+    // Create a buffer at half the required size (rounded to page boundary).
+    auto mesh_buffer = create_mesh_buffer(*mesh_device_, spec, 0.5f);
+    ASSERT_NE(mesh_buffer, nullptr);
+    ASSERT_TRUE(mesh_buffer->is_allocated());
+    ASSERT_LT(mesh_buffer->size(), required_size);
+
+    auto topology = TensorTopology();
+
+    EXPECT_ANY_THROW(MeshTensor(mesh_buffer, std::move(spec), std::move(topology)));
+}
+
+}  // namespace CMAKE_UNIQUE_NAMESPACE
+}  // namespace
+
+}  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/experimental/tensor/host_tensor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/host_tensor.hpp
@@ -26,9 +26,6 @@
 // Using namespace tt::tt_metal avoids double namespace renaming for the refactoring effort.
 namespace tt::tt_metal {
 
-// This will be brought in at #37692
-class HostStorage;
-
 // Implementation details for HostTensor
 class HostTensorImpl;
 
@@ -68,15 +65,16 @@ public:
      */
     HostTensor() = default;
 
-    // TODO(#38376), TODO(#38689):
-    // These constructors should be hidden or go away.
-    // External user should not be able to construct a HostTensor directly and opt to use the from_xxx static methods
-    // instead, as the constructor does not perform invariant checks.
-    explicit HostTensor(HostStorage storage, TensorSpec tensor_spec, TensorTopology tensor_topology);
+    explicit HostTensor(DistributedHostBuffer buffer, TensorSpec spec, TensorTopology topology);
 
-    explicit HostTensor(HostBuffer buffer, TensorSpec spec, TensorTopology topology);
+    /**
+     * Move constructor with new spec and topology.
+     * Moves the buffer from other and uses the provided spec/topology.
+     * This is meant for transition as TTNN-Tensor current has a two-step construction for HostTensor.
+     */
+    HostTensor(HostTensor&& other, TensorSpec spec, TensorTopology topology);
 
-    ~HostTensor() = default;
+    ~HostTensor();
 
     /**
      * Copy constructor.
@@ -173,16 +171,12 @@ public:
      */
     const TensorTopology& tensor_topology() const;
 
-    // DeviceStorage is meant to bridge ttnn::Tensor and HostTensor,
-    // this should go away as part of refactoring, see: #38376
-    const HostStorage& get_legacy_host_storage() const;
-
     /**
      * Returns the DistributedHostBuffer of the HostTensor.
      *
      * pre-condition: The HostTensor must be engaged.
      */
-    const DistributedHostBuffer& get_distributed_host_buffer() const;
+    const DistributedHostBuffer& buffer() const;
 
     // Derivables:
 
@@ -210,7 +204,10 @@ public:
 
     // Questionables:
 
-    void update_tensor_topology(TensorTopology tensor_topology);
+    // Applies a transformation function to each device buffer in parallel, returning a new HostTensor.
+    HostTensor transform(const std::function<HostBuffer(const HostBuffer&)>& callable) const;
+
+    // void update_tensor_topology(TensorTopology tensor_topology);
 
 private:
     std::unique_ptr<HostTensorImpl> impl;

--- a/tt_metal/api/tt-metalium/experimental/tensor/host_tensor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/host_tensor.hpp
@@ -65,7 +65,16 @@ public:
      */
     HostTensor();
 
+    /**
+     * Constructs a host tensor from a distributed host buffer.
+     */
     explicit HostTensor(DistributedHostBuffer buffer, TensorSpec spec, TensorTopology topology);
+
+    /**
+     * Constructs a host tensor from a single device host storage.
+     * The buffer is occupies the 0x0 shard of the distributed host buffer.
+     */
+    explicit HostTensor(HostBuffer buffer, TensorSpec spec, TensorTopology topology);
 
     /**
      * Move constructor with new spec and topology.

--- a/tt_metal/api/tt-metalium/experimental/tensor/host_tensor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/host_tensor.hpp
@@ -204,7 +204,7 @@ public:
 
     // Questionables:
 
-    // Applies a transformation function to each device buffer in parallel, returning a new HostTensor.
+    // Applies a transformation function to each host buffer across devices in parallel, returning a new HostTensor.
     HostTensor transform(const std::function<HostBuffer(const HostBuffer&)>& callable) const;
 
     // void update_tensor_topology(TensorTopology tensor_topology);

--- a/tt_metal/api/tt-metalium/experimental/tensor/host_tensor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/host_tensor.hpp
@@ -63,7 +63,7 @@ public:
     /**
      * Constructs a host tensor in the default constructed state, acting like a nullptr.
      */
-    HostTensor() = default;
+    HostTensor();
 
     explicit HostTensor(DistributedHostBuffer buffer, TensorSpec spec, TensorTopology topology);
 
@@ -207,7 +207,8 @@ public:
     // Applies a transformation function to each host buffer across devices in parallel, returning a new HostTensor.
     HostTensor transform(const std::function<HostBuffer(const HostBuffer&)>& callable) const;
 
-    // void update_tensor_topology(TensorTopology tensor_topology);
+    // Updates the topology of the HostTensor post construction.
+    void update_tensor_topology(TensorTopology tensor_topology);
 
 private:
     std::unique_ptr<HostTensorImpl> impl;

--- a/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
@@ -58,7 +58,7 @@ public:
     /**
      * Construct a tensor that does not own any device memory.
      */
-    MeshTensor() = default;
+    MeshTensor();
 
     // Internal Constructor for transition.
     explicit MeshTensor(std::shared_ptr<distributed::MeshBuffer> mesh_buffer, TensorSpec spec, TensorTopology topology);
@@ -92,14 +92,14 @@ public:
      *
      * post-condition: The other MeshTensor will be in a default constructed state.
      */
-    MeshTensor(MeshTensor&& other) = default;
+    MeshTensor(MeshTensor&& other) noexcept;
 
     /**
      * Transfer ownership of the underlying device memory to the other MeshTensor.
      *
      * post-condition: The other MeshTensor will be in a default constructed state.
      */
-    MeshTensor& operator=(MeshTensor&& other) = default;
+    MeshTensor& operator=(MeshTensor&& other) noexcept;
 
     // End special member functions
 
@@ -171,6 +171,9 @@ public:
 
     Strides strides() const;
 
+    // Update the topology of the MeshTensor post construction.
+    // TODO(river): Is this a good idea? Would a move constructor be better?
+    // Is a MeshTensor with a new tensor topology fundamentally different?
     void update_tensor_topology(TensorTopology tensor_topology);
 
 private:

--- a/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
@@ -75,7 +75,7 @@ public:
      * Whether or not the device memory is actually deallocated depends on the destructor semantics of the underlying
      * MeshBuffer.
      */
-    ~MeshTensor() = default;
+    ~MeshTensor();
 
     /**
      * A device tensor is non-copyable as this is the sole owner of the underlying device memory.

--- a/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
@@ -19,9 +19,6 @@
 // Using namespace tt::tt_metal avoids double namespace renaming for the refactoring effort.
 namespace tt::tt_metal {
 
-// This will be brought in at #37692
-class DeviceStorage;
-
 // Implementation details for MeshTensor
 class MeshTensorImpl;
 
@@ -63,10 +60,15 @@ public:
      */
     MeshTensor() = default;
 
-    // TODO(#38376), TODO(#38689):
-    // This should be a private constructor, external user should not be able to construct a MeshTensor
-    // directly. As this will lead to leaks of the MeshBuffer unique ownership.
-    explicit MeshTensor(DeviceStorage storage, TensorSpec tensor_spec, TensorTopology tensor_topology);
+    // Internal Constructor for transition.
+    explicit MeshTensor(std::shared_ptr<distributed::MeshBuffer> mesh_buffer, TensorSpec spec, TensorTopology topology);
+
+    /**
+     * Move constructor with new spec and topology.
+     * Moves the buffer from other and uses the provided spec/topology.
+     * This is meant for transition as TTNN-Tensor current has a two-step construction for HostTensor.
+     */
+    MeshTensor(MeshTensor&& other, TensorSpec spec, TensorTopology topology);
 
     /**
      * Release ownership of the underlying device memory.
@@ -104,13 +106,6 @@ public:
     // Deallocation related:
 
     /**
-     * Check if the device tensor owns any device memory.
-     *
-     * pre-condition: The device tensor must not be in a default constructed state.
-     */
-    bool is_allocated() const;
-
-    /**
      * Return the underlying device storage MeshBuffer.
      *
      * pre-condition: The device tensor must not be in a default constructed state.
@@ -145,10 +140,6 @@ public:
      * pre-condition: The device tensor must not be in a default constructed state.
      */
     const TensorTopology& tensor_topology() const;
-
-    // DeviceStorage is meant to bridge ttnn::Tensor and MeshTensor,
-    // this should go away as part of refactoring, see: #38376
-    const DeviceStorage& get_legacy_device_storage() const;
 
     // Derivables:
 

--- a/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
@@ -66,7 +66,7 @@ public:
     /**
      * Move constructor with new spec and topology.
      * Moves the buffer from other and uses the provided spec/topology.
-     * This is meant for transition as TTNN-Tensor current has a two-step construction for HostTensor.
+     * This is meant for transition as TTNN-Tensor current has a two-step construction for MeshTensor.
      */
     MeshTensor(MeshTensor&& other, TensorSpec spec, TensorTopology topology);
 

--- a/tt_metal/impl/tensor/host_tensor.cpp
+++ b/tt_metal/impl/tensor/host_tensor.cpp
@@ -17,10 +17,16 @@ public:
     HostTensorImpl& operator=(HostTensorImpl&& other) noexcept = default;
     ~HostTensorImpl() = default;
 
+    // Two step construction for HostTensor,
+    // for transiet purpose.
+    HostTensorImpl(HostTensorImpl&& other, TensorSpec spec, TensorTopology topology) :
+        buffer_(std::move(other.buffer_)), spec_(std::move(spec)), topology_(std::move(topology)) {}
+
     const DistributedHostBuffer& buffer() const& { return buffer_; }
     DistributedHostBuffer buffer() const&& { return buffer_; }
     const TensorSpec& spec() const { return spec_; }
     const TensorTopology& topology() const { return topology_; }
+    void update_topology(TensorTopology topology) { topology_ = std::move(topology); }
 
 private:
     DistributedHostBuffer buffer_;
@@ -28,11 +34,13 @@ private:
     TensorTopology topology_;
 };
 
+HostTensor::HostTensor() = default;
+
 HostTensor::HostTensor(DistributedHostBuffer buffer, TensorSpec spec, TensorTopology topology) :
     impl(std::make_unique<HostTensorImpl>(std::move(buffer), std::move(spec), std::move(topology))) {}
 
 HostTensor::HostTensor(HostTensor&& other, TensorSpec spec, TensorTopology topology) :
-    impl(std::make_unique<HostTensorImpl>(std::move(other.impl)->buffer(), std::move(spec), std::move(topology))) {}
+    impl(std::make_unique<HostTensorImpl>(std::move(*other.impl), std::move(spec), std::move(topology))) {}
 
 HostTensor::HostTensor(const HostTensor& other) : impl(std::make_unique<HostTensorImpl>(*other.impl)) {}
 
@@ -108,6 +116,11 @@ HostTensor HostTensor::transform(const std::function<HostBuffer(const HostBuffer
     auto transformed_buffer =
         buffer().transform(callable, DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL);
     return HostTensor(std::move(transformed_buffer), tensor_spec(), tensor_topology());
+}
+
+void HostTensor::update_tensor_topology(TensorTopology tensor_topology) {
+    TT_ASSERT(impl != nullptr, "HostTensor is in default constructed state.");
+    impl->update_topology(std::move(tensor_topology));
 }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/tensor/host_tensor.cpp
+++ b/tt_metal/impl/tensor/host_tensor.cpp
@@ -32,11 +32,14 @@ HostTensor::HostTensor(DistributedHostBuffer buffer, TensorSpec spec, TensorTopo
     impl(std::make_unique<HostTensorImpl>(std::move(buffer), std::move(spec), std::move(topology))) {}
 
 HostTensor::HostTensor(HostTensor&& other, TensorSpec spec, TensorTopology topology) :
-    impl(std::make_unique<HostTensorImpl>(other.impl->buffer(), std::move(spec), std::move(topology))) {}
+    impl(std::make_unique<HostTensorImpl>(std::move(other.impl)->buffer(), std::move(spec), std::move(topology))) {}
 
 HostTensor::HostTensor(const HostTensor& other) : impl(std::make_unique<HostTensorImpl>(*other.impl)) {}
 
 HostTensor& HostTensor::operator=(const HostTensor& other) {
+    if (this == &other) {
+        return *this;
+    }
     impl = std::make_unique<HostTensorImpl>(*other.impl);
     return *this;
 }
@@ -50,11 +53,20 @@ HostTensor& HostTensor::operator=(HostTensor&& other) noexcept {
 
 HostTensor::~HostTensor() = default;
 
-const TensorSpec& HostTensor::tensor_spec() const { return impl->spec(); }
+const TensorSpec& HostTensor::tensor_spec() const {
+    TT_ASSERT(impl != nullptr, "HostTensor is in default constructed state.");
+    return impl->spec();
+}
 
-const TensorTopology& HostTensor::tensor_topology() const { return impl->topology(); }
+const TensorTopology& HostTensor::tensor_topology() const {
+    TT_ASSERT(impl != nullptr, "HostTensor is in default constructed state.");
+    return impl->topology();
+}
 
-const DistributedHostBuffer& HostTensor::buffer() const { return impl->buffer(); }
+const DistributedHostBuffer& HostTensor::buffer() const {
+    TT_ASSERT(impl != nullptr, "HostTensor is in default constructed state.");
+    return impl->buffer();
+}
 
 DataType HostTensor::dtype() const { return tensor_spec().tensor_layout().get_data_type(); }
 

--- a/tt_metal/impl/tensor/host_tensor.cpp
+++ b/tt_metal/impl/tensor/host_tensor.cpp
@@ -6,40 +6,55 @@
 
 namespace tt::tt_metal {
 
-/*
+class HostTensorImpl {
+public:
+    HostTensorImpl(DistributedHostBuffer buffer, TensorSpec spec, TensorTopology topology) :
+        buffer_(std::move(buffer)), spec_(std::move(spec)), topology_(std::move(topology)) {}
 
-// TODO: Implement once HostStorage is migrated (#37692)
-// HostTensor::HostTensor(HostStorage storage, TensorSpec tensor_spec, TensorTopology tensor_topology)
+    HostTensorImpl(const HostTensorImpl& other) = default;
+    HostTensorImpl(HostTensorImpl&& other) noexcept = default;
+    HostTensorImpl& operator=(const HostTensorImpl& other) = default;
+    HostTensorImpl& operator=(HostTensorImpl&& other) noexcept = default;
+    ~HostTensorImpl() = default;
 
-// TODO: Implement once HostStorage is migrated (#37692)
-// HostTensor::HostTensor(HostBuffer buffer, TensorSpec spec, TensorTopology topology)
+    const DistributedHostBuffer& buffer() const& { return buffer_; }
+    DistributedHostBuffer buffer() const&& { return buffer_; }
+    const TensorSpec& spec() const { return spec_; }
+    const TensorTopology& topology() const { return topology_; }
 
-// TODO: Implement once HostStorage is migrated (#37692)
-// HostTensor::HostTensor(const HostTensor& other)
+private:
+    DistributedHostBuffer buffer_;
+    TensorSpec spec_;
+    TensorTopology topology_;
+};
 
-// TODO: Implement once HostStorage is migrated (#37692)
-// HostTensor& HostTensor::operator=(const HostTensor& other)
+HostTensor::HostTensor(DistributedHostBuffer buffer, TensorSpec spec, TensorTopology topology) :
+    impl(std::make_unique<HostTensorImpl>(std::move(buffer), std::move(spec), std::move(topology))) {}
 
-// TODO: Implement once HostStorage is migrated (#37692)
-// HostTensor::HostTensor(HostTensor&& other) noexcept
+HostTensor::HostTensor(HostTensor&& other, TensorSpec spec, TensorTopology topology) :
+    impl(std::make_unique<HostTensorImpl>(other.impl->buffer(), std::move(spec), std::move(topology))) {}
 
-// TODO: Implement once HostStorage is migrated (#37692)
-// HostTensor& HostTensor::operator=(HostTensor&& other) noexcept
+HostTensor::HostTensor(const HostTensor& other) : impl(std::make_unique<HostTensorImpl>(*other.impl)) {}
 
-// TODO: Implement once HostStorage is migrated (#37692)
-// const TensorSpec& HostTensor::tensor_spec() const
+HostTensor& HostTensor::operator=(const HostTensor& other) {
+    impl = std::make_unique<HostTensorImpl>(*other.impl);
+    return *this;
+}
 
-// TODO: Implement once HostStorage is migrated (#37692)
-// const TensorTopology& HostTensor::tensor_topology() const
+HostTensor::HostTensor(HostTensor&& other) noexcept : impl(std::move(other.impl)) {}
 
-// TODO: Implement once HostStorage is migrated (#37692)
-// const HostStorage& HostTensor::get_legacy_host_storage() const
+HostTensor& HostTensor::operator=(HostTensor&& other) noexcept {
+    impl = std::move(other.impl);
+    return *this;
+}
 
-// TODO: Implement once HostStorage is migrated (#37692)
-// const DistributedHostBuffer& HostTensor::get_distributed_host_buffer() const
+HostTensor::~HostTensor() = default;
 
-// TODO: Implement once HostStorage is migrated (#37692)
-// void HostTensor::update_tensor_topology(TensorTopology tensor_topology)
+const TensorSpec& HostTensor::tensor_spec() const { return impl->spec(); }
+
+const TensorTopology& HostTensor::tensor_topology() const { return impl->topology(); }
+
+const DistributedHostBuffer& HostTensor::buffer() const { return impl->buffer(); }
 
 DataType HostTensor::dtype() const { return tensor_spec().tensor_layout().get_data_type(); }
 
@@ -77,6 +92,10 @@ std::size_t HostTensor::element_size() const {
 
 Strides HostTensor::strides() const { return tensor_spec().tensor_layout().compute_strides(logical_shape()); }
 
-*/
+HostTensor HostTensor::transform(const std::function<HostBuffer(const HostBuffer&)>& callable) const {
+    auto transformed_buffer =
+        buffer().transform(callable, DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL);
+    return HostTensor(std::move(transformed_buffer), tensor_spec(), tensor_topology());
+}
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/tensor/host_tensor.cpp
+++ b/tt_metal/impl/tensor/host_tensor.cpp
@@ -39,16 +39,19 @@ HostTensor::HostTensor() = default;
 HostTensor::HostTensor(DistributedHostBuffer buffer, TensorSpec spec, TensorTopology topology) :
     impl(std::make_unique<HostTensorImpl>(std::move(buffer), std::move(spec), std::move(topology))) {}
 
-HostTensor::HostTensor(HostTensor&& other, TensorSpec spec, TensorTopology topology) :
-    impl(std::make_unique<HostTensorImpl>(std::move(*other.impl), std::move(spec), std::move(topology))) {}
+HostTensor::HostTensor(HostTensor&& other, TensorSpec spec, TensorTopology topology) {
+    TT_FATAL(other.impl != nullptr, "Cannot move from a default-constructed or moved-from HostTensor.");
+    impl = std::make_unique<HostTensorImpl>(std::move(*other.impl), std::move(spec), std::move(topology));
+}
 
-HostTensor::HostTensor(const HostTensor& other) : impl(std::make_unique<HostTensorImpl>(*other.impl)) {}
+HostTensor::HostTensor(const HostTensor& other) :
+    impl(other.impl ? std::make_unique<HostTensorImpl>(*other.impl) : nullptr) {}
 
 HostTensor& HostTensor::operator=(const HostTensor& other) {
     if (this == &other) {
         return *this;
     }
-    impl = std::make_unique<HostTensorImpl>(*other.impl);
+    impl = other.impl ? std::make_unique<HostTensorImpl>(*other.impl) : nullptr;
     return *this;
 }
 

--- a/tt_metal/impl/tensor/host_tensor.cpp
+++ b/tt_metal/impl/tensor/host_tensor.cpp
@@ -39,6 +39,22 @@ HostTensor::HostTensor() = default;
 HostTensor::HostTensor(DistributedHostBuffer buffer, TensorSpec spec, TensorTopology topology) :
     impl(std::make_unique<HostTensorImpl>(std::move(buffer), std::move(spec), std::move(topology))) {}
 
+namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
+DistributedHostBuffer create_unit_distributed_host_buffer(HostBuffer buffer) {
+    auto distributed_buffer = DistributedHostBuffer::create(distributed::MeshShape(1, 1));
+    distributed_buffer.emplace_shard(distributed::MeshCoordinate(0, 0), [&buffer]() { return std::move(buffer); });
+    return distributed_buffer;
+}
+};  // namespace CMAKE_UNIQUE_NAMESPACE
+};  // namespace
+
+HostTensor::HostTensor(HostBuffer buffer, TensorSpec spec, TensorTopology topology) :
+    impl(std::make_unique<HostTensorImpl>(
+        CMAKE_UNIQUE_NAMESPACE::create_unit_distributed_host_buffer(std::move(buffer)),
+        std::move(spec),
+        std::move(topology))) {}
+
 HostTensor::HostTensor(HostTensor&& other, TensorSpec spec, TensorTopology topology) {
     TT_FATAL(other.impl != nullptr, "Cannot move from a default-constructed or moved-from HostTensor.");
     impl = std::make_unique<HostTensorImpl>(std::move(*other.impl), std::move(spec), std::move(topology));

--- a/tt_metal/impl/tensor/mesh_tensor.cpp
+++ b/tt_metal/impl/tensor/mesh_tensor.cpp
@@ -6,28 +6,28 @@
 
 namespace tt::tt_metal {
 
-/*
+class MeshTensorImpl {
+public:
+    MeshTensorImpl(std::shared_ptr<distributed::MeshBuffer> mesh_buffer, TensorSpec spec, TensorTopology topology) :
+        mesh_buffer_(std::move(mesh_buffer)), spec_(std::move(spec)), topology_(std::move(topology)) {}
 
-// TODO: Implement once DeviceStorage is migrated (#37692)
-// MeshTensor::MeshTensor(DeviceStorage storage, TensorSpec tensor_spec, TensorTopology tensor_topology)
+    const std::shared_ptr<distributed::MeshBuffer>& mesh_buffer() const& { return mesh_buffer_; }
+    std::shared_ptr<distributed::MeshBuffer> mesh_buffer() const&& { return mesh_buffer_; }
+    const TensorSpec& spec() const { return spec_; }
+    const TensorTopology& topology() const { return topology_; }
 
-// TODO: Implement once DeviceStorage is migrated (#37692)
-// bool MeshTensor::is_allocated() const
+private:
+    std::shared_ptr<distributed::MeshBuffer> mesh_buffer_;
+    TensorSpec spec_;
+    TensorTopology topology_;
+};
 
-// TODO: Implement once DeviceStorage is migrated (#37692)
-// std::shared_ptr<distributed::MeshBuffer> MeshTensor::mesh_buffer_invariant_breaking() const
+MeshTensor::MeshTensor(std::shared_ptr<distributed::MeshBuffer> mesh_buffer, TensorSpec spec, TensorTopology topology) :
+    impl(std::make_unique<MeshTensorImpl>(std::move(mesh_buffer), std::move(spec), std::move(topology))) {}
 
-// TODO: Implement once DeviceStorage is migrated (#37692)
-// const TensorSpec& MeshTensor::tensor_spec() const
-
-// TODO: Implement once DeviceStorage is migrated (#37692)
-// const TensorTopology& MeshTensor::tensor_topology() const
-
-// TODO: Implement once DeviceStorage is migrated (#37692)
-// const DeviceStorage& MeshTensor::get_legacy_device_storage() const
-
-// TODO: Implement once DeviceStorage is migrated (#37692)
-// void MeshTensor::update_tensor_topology(TensorTopology tensor_topology)
+MeshTensor::MeshTensor(MeshTensor&& other, TensorSpec spec, TensorTopology topology) :
+    impl(std::make_unique<MeshTensorImpl>(std::move(other.impl)->mesh_buffer(), std::move(spec), std::move(topology))) {
+}
 
 distributed::MeshBuffer& MeshTensor::mesh_buffer() const { return *mesh_buffer_invariant_breaking(); }
 
@@ -70,7 +70,5 @@ std::size_t MeshTensor::element_size() const {
 }
 
 Strides MeshTensor::strides() const { return tensor_spec().tensor_layout().compute_strides(logical_shape()); }
-
-*/
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/tensor/mesh_tensor.cpp
+++ b/tt_metal/impl/tensor/mesh_tensor.cpp
@@ -29,6 +29,8 @@ MeshTensor::MeshTensor(MeshTensor&& other, TensorSpec spec, TensorTopology topol
     impl(std::make_unique<MeshTensorImpl>(std::move(other.impl)->mesh_buffer(), std::move(spec), std::move(topology))) {
 }
 
+MeshTensor::~MeshTensor() = default;
+
 distributed::MeshBuffer& MeshTensor::mesh_buffer() const { return *mesh_buffer_invariant_breaking(); }
 
 distributed::MeshDevice& MeshTensor::device() const { return *mesh_buffer().device(); }

--- a/tt_metal/impl/tensor/mesh_tensor.cpp
+++ b/tt_metal/impl/tensor/mesh_tensor.cpp
@@ -63,8 +63,10 @@ MeshTensor& MeshTensor::operator=(MeshTensor&& other) noexcept = default;
 MeshTensor::MeshTensor(std::shared_ptr<distributed::MeshBuffer> mesh_buffer, TensorSpec spec, TensorTopology topology) :
     impl(std::make_unique<MeshTensorImpl>(std::move(mesh_buffer), std::move(spec), std::move(topology))) {}
 
-MeshTensor::MeshTensor(MeshTensor&& other, TensorSpec spec, TensorTopology topology) :
-    impl(std::make_unique<MeshTensorImpl>(std::move(*other.impl), std::move(spec), std::move(topology))) {}
+MeshTensor::MeshTensor(MeshTensor&& other, TensorSpec spec, TensorTopology topology) {
+    TT_FATAL(other.impl != nullptr, "Cannot move from a default-constructed or moved-from MeshTensor.");
+    impl = std::make_unique<MeshTensorImpl>(std::move(*other.impl), std::move(spec), std::move(topology));
+}
 
 MeshTensor::~MeshTensor() = default;
 

--- a/tt_metal/impl/tensor/mesh_tensor.cpp
+++ b/tt_metal/impl/tensor/mesh_tensor.cpp
@@ -33,7 +33,22 @@ MeshTensor::~MeshTensor() = default;
 
 distributed::MeshBuffer& MeshTensor::mesh_buffer() const { return *mesh_buffer_invariant_breaking(); }
 
+std::shared_ptr<distributed::MeshBuffer> MeshTensor::mesh_buffer_invariant_breaking() const {
+    TT_ASSERT(impl != nullptr, "MeshTensor is in default constructed state.");
+    return impl->mesh_buffer();
+}
+
 distributed::MeshDevice& MeshTensor::device() const { return *mesh_buffer().device(); }
+
+const TensorSpec& MeshTensor::tensor_spec() const {
+    TT_ASSERT(impl != nullptr, "MeshTensor is in default constructed state.");
+    return impl->spec();
+}
+
+const TensorTopology& MeshTensor::tensor_topology() const {
+    TT_ASSERT(impl != nullptr, "MeshTensor is in default constructed state.");
+    return impl->topology();
+}
 
 DeviceAddr MeshTensor::address() const { return mesh_buffer().address(); }
 

--- a/tt_metal/impl/tensor/mesh_tensor.cpp
+++ b/tt_metal/impl/tensor/mesh_tensor.cpp
@@ -9,25 +9,62 @@ namespace tt::tt_metal {
 class MeshTensorImpl {
 public:
     MeshTensorImpl(std::shared_ptr<distributed::MeshBuffer> mesh_buffer, TensorSpec spec, TensorTopology topology) :
-        mesh_buffer_(std::move(mesh_buffer)), spec_(std::move(spec)), topology_(std::move(topology)) {}
+        MeshTensorImpl(std::move(mesh_buffer), std::move(spec), std::move(topology), nullptr) {}
 
-    const std::shared_ptr<distributed::MeshBuffer>& mesh_buffer() const& { return mesh_buffer_; }
-    std::shared_ptr<distributed::MeshBuffer> mesh_buffer() const&& { return mesh_buffer_; }
+    MeshTensorImpl(
+        std::shared_ptr<distributed::MeshBuffer> mesh_buffer,
+        TensorSpec spec,
+        TensorTopology topology,
+        std::shared_ptr<distributed::MeshBuffer> root_mesh_buffer) :
+        mesh_buffer_(std::move(mesh_buffer)),
+        spec_(std::move(spec)),
+        topology_(std::move(topology)),
+        root_mesh_buffer_(std::move(root_mesh_buffer)) {
+        TT_FATAL(mesh_buffer_ != nullptr, "MeshBuffer cannot be nullptr.");
+        TT_FATAL(mesh_buffer_->is_allocated(), "MeshBuffer must be allocated.");
+        TT_FATAL(
+            mesh_buffer_->size() >= spec.compute_packed_buffer_size_bytes(),
+            "MeshBuffer must be large enough to hold the tensor.");
+    }
+
+    // Two step construction for MeshTensor,
+    // for transiet purpose.
+    MeshTensorImpl(MeshTensorImpl&& other, TensorSpec spec, TensorTopology topology) :
+        mesh_buffer_(std::move(other.mesh_buffer_)),
+        spec_(std::move(spec)),
+        topology_(std::move(topology)),
+        root_mesh_buffer_(std::move(other.root_mesh_buffer_)) {}
+
+    const std::shared_ptr<distributed::MeshBuffer>& mesh_buffer() const { return mesh_buffer_; }
     const TensorSpec& spec() const { return spec_; }
     const TensorTopology& topology() const { return topology_; }
+    void update_topology(TensorTopology topology) { topology_ = std::move(topology); }
 
 private:
+    // Invariant:
+    // 1. Cannot be nullptr and must be allocated.
+    // 2. Must be large enough to hold a tensor describale with spec_
     std::shared_ptr<distributed::MeshBuffer> mesh_buffer_;
     TensorSpec spec_;
+    // TODO(river): What is the invariant of topology?
     TensorTopology topology_;
+
+    // Experimental feature: Accomodates #38101
+    // This keeps mesh_buffer_ alive in limited cases.
+    std::shared_ptr<distributed::MeshBuffer> root_mesh_buffer_;
 };
+
+MeshTensor::MeshTensor() = default;
+
+MeshTensor::MeshTensor(MeshTensor&& other) noexcept = default;
+
+MeshTensor& MeshTensor::operator=(MeshTensor&& other) noexcept = default;
 
 MeshTensor::MeshTensor(std::shared_ptr<distributed::MeshBuffer> mesh_buffer, TensorSpec spec, TensorTopology topology) :
     impl(std::make_unique<MeshTensorImpl>(std::move(mesh_buffer), std::move(spec), std::move(topology))) {}
 
 MeshTensor::MeshTensor(MeshTensor&& other, TensorSpec spec, TensorTopology topology) :
-    impl(std::make_unique<MeshTensorImpl>(std::move(other.impl)->mesh_buffer(), std::move(spec), std::move(topology))) {
-}
+    impl(std::make_unique<MeshTensorImpl>(std::move(*other.impl), std::move(spec), std::move(topology))) {}
 
 MeshTensor::~MeshTensor() = default;
 
@@ -87,5 +124,10 @@ std::size_t MeshTensor::element_size() const {
 }
 
 Strides MeshTensor::strides() const { return tensor_spec().tensor_layout().compute_strides(logical_shape()); }
+
+void MeshTensor::update_tensor_topology(TensorTopology tensor_topology) {
+    TT_ASSERT(impl != nullptr, "MeshTensor is in default constructed state.");
+    impl->update_topology(std::move(tensor_topology));
+}
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/tensor/mesh_tensor.cpp
+++ b/tt_metal/impl/tensor/mesh_tensor.cpp
@@ -23,7 +23,7 @@ public:
         TT_FATAL(mesh_buffer_ != nullptr, "MeshBuffer cannot be nullptr.");
         TT_FATAL(mesh_buffer_->is_allocated(), "MeshBuffer must be allocated.");
         TT_FATAL(
-            mesh_buffer_->size() >= spec.compute_packed_buffer_size_bytes(),
+            mesh_buffer_->size() >= spec_.compute_packed_buffer_size_bytes(),
             "MeshBuffer must be large enough to hold the tensor.");
     }
 


### PR DESCRIPTION
### Ticket
#36877

### Type
New Feature

### Problem description
Runtime is introducing two new construct, host and mesh tensor.

### What's changed
Wires up internals of the Host and MeshTensor.
More infrastructure will come down with the refactoring of ttnn::Tensor to use Host and MeshTensor as backing storage.

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/tensor-impl)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/tensor-impl)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu/tensor-impl)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/tensor-impl)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/tensor-impl)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/tensor-impl)
- [x] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early

