### PR TITLE
Fix SDPA non-determinism caused by incorrect qktv subblock dimensions (#40023 regression)

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -322,21 +322,21 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
 
     // now for out0
     const uint32_t out_in0_block_w = Sk_chunk_t;
-
-    auto [out_out_subblock_h, out_out_subblock_w] = detail::determine_largest_subblock_size(Sq_chunk_t, vDHt, dst_size);
-
-    const uint32_t out_in0_num_subblocks = Sq_chunk_t / out_out_subblock_h;
-    const uint32_t out_in1_num_subblocks = vDHt / out_out_subblock_w;
     const uint32_t out_num_blocks = Sk_chunk_t / out_in0_block_w;
 
     // This is done only in the non-causal case:
     // Streaming compute v2: eliminates row buffers via cb_push_back_hold_wr_ptr.
-    // Ring joint has no causal/mask/sink/sliding/chunked flags — gating is simpler.
     // Streaming v2 requires q_num_subblocks > 1 (Sq_chunk_t > subblock_h) because the Phase 2
     // pipeline assumes at least one q_subblock iteration for correct softmax drain + SALAD overlap.
     const bool use_streaming_compute = !fp32_dest_acc_en && qk_out_subblock_h <= 2 &&
-                                       Sk_chunk_t % (8 / qk_out_subblock_h) == 0 && qk_in0_num_subblocks > 1 && !args.is_causal;
+                                       Sk_chunk_t % (dst_size / qk_out_subblock_h) == 0 && qk_in0_num_subblocks > 1 && !args.is_causal;
     log_debug(tt::LogOp, "use_streaming_compute: {}", use_streaming_compute);
+
+    auto [out_out_subblock_h, out_out_subblock_w] =
+        detail::determine_largest_subblock_size(Sq_chunk_t, vDHt, dst_size, use_streaming_compute ? 2 : UINT32_MAX);
+
+    const uint32_t out_in0_num_subblocks = Sq_chunk_t / out_out_subblock_h;
+    const uint32_t out_in1_num_subblocks = vDHt / out_out_subblock_w;
 
     // log all values
     log_debug(tt::LogOp, "dst_size: {}", dst_size);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -81,6 +81,7 @@ bool can_use_streaming_compute(
     bool fp32_dest_acc_en,
     uint32_t qk_out_subblock_h,
     uint32_t Sk_chunk_t,
+    uint32_t dst_size,
     uint32_t padded_Sk,
     uint32_t Sk,
     uint32_t Sq_chunk_t) {
@@ -90,7 +91,7 @@ bool can_use_streaming_compute(
     if (sliding_window_size.value_or(0) != 0 || is_chunked || fp32_dest_acc_en) {
         return false;
     }
-    if (qk_out_subblock_h > 2 || Sk_chunk_t % (8 / qk_out_subblock_h) != 0) {
+    if (qk_out_subblock_h > 2 || Sk_chunk_t % (dst_size / qk_out_subblock_h) != 0) {
         return false;
     }
     // Streaming v2 requires q_num_subblocks > 1 (Sq_chunk_t > subblock_h) because the Phase 2
@@ -394,6 +395,7 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
         fp32_dest_acc_en,
         qk_out_subblock_h,
         Sk_chunk_t,
+        dst_size,
         padded_Sk,
         Sk,
         Sq_chunk_t);
@@ -429,7 +431,8 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
     // now for out0
     const uint32_t out_in0_block_w = Sk_chunk_t;
 
-    auto [out_out_subblock_h, out_out_subblock_w] = detail::determine_largest_subblock_size(Sq_chunk_t, vDHt, dst_size);
+    auto [out_out_subblock_h, out_out_subblock_w] =
+        detail::determine_largest_subblock_size(Sq_chunk_t, vDHt, dst_size, use_streaming_compute ? 2 : UINT32_MAX);
 
     const uint32_t out_in0_num_subblocks = Sq_chunk_t / out_out_subblock_h;
     const uint32_t out_in1_num_subblocks = vDHt / out_out_subblock_w;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_subblock_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_subblock_utils.hpp
@@ -13,11 +13,12 @@ namespace ttnn::prim::detail {
 // Determine the largest subblock size for matmul that:
 // 1. Has subblock_h * subblock_w <= dst_size
 // 2. subblock_h divides block_height and subblock_w divides block_width
+// 3. subblock_h <= max_subblock_h (omit or pass UINT32_MAX to leave unconstrained)
 //
 // Candidates are ordered by total volume (h*w) descending to maximize
 // dest register utilization.
 static inline std::pair<uint32_t, uint32_t> determine_largest_subblock_size(
-    uint32_t block_height, uint32_t block_width, uint32_t dst_size) {
+    uint32_t block_height, uint32_t block_width, uint32_t dst_size, uint32_t max_subblock_h = UINT32_MAX) {
     constexpr std::array<std::pair<uint32_t, uint32_t>, 20> subblocks = {{
         {2, 4}, {4, 2}, {1, 8}, {8, 1}, {1, 7}, {7, 1}, {2, 3}, {3, 2}, {1, 6}, {6, 1},
         {1, 5}, {5, 1}, {2, 2}, {1, 4}, {4, 1}, {1, 3}, {3, 1}, {1, 2}, {2, 1}, {1, 1},
@@ -25,6 +26,9 @@ static inline std::pair<uint32_t, uint32_t> determine_largest_subblock_size(
 
     for (auto [subblock_height, subblock_width] : subblocks) {
         if (subblock_height * subblock_width > dst_size) {
+            continue;
+        }
+        if (subblock_height > max_subblock_h) {
             continue;
         }
         if ((block_height % subblock_height != 0) || (block_width % subblock_width != 0)) {


### PR DESCRIPTION
## Summary

Fixes a determinism regression introduced by #40023 (eca9573de8d). The streaming SDPA kernel received incorrect \`qktv_subblock_h/w\` values for certain chunk size configurations, producing non-deterministic outputs.

**Failing configs:** \`k256-q224\` on both WAN 2.2 shapes (\`wan2_2_1xGLX_analog\`, \`wan2_2_4xGLX_analog\`) — 28k differing elements, max diff=688.

### Root cause

#40023 lifted \`qktv_subblock_h/w\` out of \`sdpa_inner_loop_step\` into template parameters, and the callers passed \`out_subblock_h/w\` — values computed by \`determine_largest_subblock_size(Sq_chunk_t, vDHt, dst_size)\` for the standard (non-streaming) output matmul.

For \`q=224\` → \`Sq_chunk_t=7\`, \`vDHt=4\`, this function returns \`(7, 1)\`. The streaming Phase 2 (QKT@V + SALAD) only supports \`qktv_subblock_h\` of 1 or 2. With \`h=7\`, \`qktv_q_num_subblocks = 7/7 = 1\` instead of 7, collapsing the SALAD correction loop and breaking softmax drain sequencing → non-deterministic results.

### Fix

- Add \`max_subblock_h\` parameter (default \`UINT32_MAX\`) to \`determine_largest_subblock_size\` in \`sdpa_subblock_utils.hpp\`.
- In both \`sdpa_program_factory.cpp\` and \`ring_joint_sdpa_program_factory.cpp\`: compute QK subblock unconstrainted → determine \`use_streaming_compute\` (which already gates on \`qk_out_subblock_h <= 2\`) → compute output subblock with \`max_subblock_h = use_streaming_compute ? 2 : UINT32_MAX\`.
- Also fixes hardcoded \`8\` in \`can_use_streaming_compute\` to use \`dst_size\` for correctness with fp32 dest accumulation.

## Test plan
- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic%2Ffix_sdpa_determinism)](https://github.com/tenstorrent/tt-metal/actions/runs/23219857834)
- [ ] [![Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic%2Ffix_sdpa_determinism)](https://github.com/tenstorrent/tt-metal/actions/runs/23219576110)
- [ ] [![Nightly tt-metal L2 tests (sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic%2Ffix_sdpa_determinism)](https://github.com/tenstorrent/tt-metal/actions/runs/23219930118)
- [ ] [![Static checks & linters](https://github.com/tenstorrent/tt-metal/actions/workflows/all-static-checks.yaml/badge.svg?branch=pjosipovic%2Ffix_sdpa_determinism)](https://github.com/tenstorrent/tt-metal/actions/runs/23219588454)
- [ ] [![(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml/badge.svg?branch=pjosipovic%2Ffix_sdpa_determinism)](https://github.com/tenstorrent/tt-metal/actions/runs/23219579167)
- [ ] [![(T3K) T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml/badge.svg?branch=pjosipovic%2Ffix_sdpa_determinism)](https://github.com/tenstorrent/tt-metal/actions/runs/23219581100)
- [ ] [![(T3K) T3000 e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=pjosipovic%2Ffix_sdpa_determinism)](https://github.com/tenstorrent/tt-metal/actions/runs/23219886836)
- [ ] [![(Blackhole) Demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-demo-tests.yaml/badge.svg?branch=pjosipovic%2Ffix_sdpa_determinism)](https://github.com/tenstorrent/tt-metal/actions/runs/23219584703)
- [ ] [![(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=pjosipovic%2Ffix_sdpa_determinism)](https://github.com/tenstorrent/tt-metal/actions/runs/23236500071)

🤖 Generated with [Claude Code](https://claude.com/claude-code)