### PR TITLE
New Quasar API testing on Runtime tests

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/direct_write/test_direct_write.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/direct_write/test_direct_write.cpp
@@ -7,6 +7,7 @@
 #include "dm_common.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
+#include <tt-metalium/experimental/host_api.hpp>
 #include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
@@ -129,14 +130,26 @@ bool run_dm(
 
     std::string sender_kernel_path = kernels_dir + sender_kernel_filename;
 
-    CreateKernel(
-        program,
-        sender_kernel_path,
-        test_config.sender_core_coord,
-        DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_0,
-            .noc = test_config.noc_id,
-            .compile_args = sender_compile_args});
+    // Create kernel on sender core - branch by architecture
+    if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
+        // Quasar path: Use experimental API
+        experimental::quasar::CreateKernel(
+            program,
+            sender_kernel_path,
+            test_config.sender_core_coord,
+            experimental::quasar::QuasarDataMovementConfig{
+                .num_threads_per_cluster = 1, .compile_args = sender_compile_args});
+    } else {
+        // WH/BH path: Use legacy API with processor selection
+        CreateKernel(
+            program,
+            sender_kernel_path,
+            test_config.sender_core_coord,
+            DataMovementConfig{
+                .processor = DataMovementProcessor::RISCV_0,
+                .noc = test_config.noc_id,
+                .compile_args = sender_compile_args});
+    }
 
     // Assign unique id
     log_info(LogTest, "Running Test ID: {}, Run ID: {}", test_config.test_id, unit_tests::dm::runtime_host_id);

--- a/tests/tt_metal/tt_metal/data_movement/dram_sharded/test_dram_sharded.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_sharded/test_dram_sharded.cpp
@@ -11,6 +11,7 @@
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
+#include <tt-metalium/experimental/host_api.hpp>
 #include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
@@ -101,15 +102,27 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const DramSh
     }
     kernel_path += ".cpp";
 
-    // Kernels
-    auto reader_kernel = CreateKernel(
-        program,
-        kernel_path,
-        test_config.cores,
-        DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_0,
-            .noc = NOC::RISCV_0_default,
-            .compile_args = reader_compile_args});
+    // Create kernel on reader cores - branch by architecture
+    KernelHandle reader_kernel;
+    if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
+        // Quasar path: Use experimental API
+        reader_kernel = experimental::quasar::CreateKernel(
+            program,
+            kernel_path,
+            test_config.cores,
+            experimental::quasar::QuasarDataMovementConfig{
+                .num_threads_per_cluster = 1, .compile_args = reader_compile_args});
+    } else {
+        // WH/BH path: Use legacy API
+        reader_kernel = CreateKernel(
+            program,
+            kernel_path,
+            test_config.cores,
+            DataMovementConfig{
+                .processor = DataMovementProcessor::RISCV_0,
+                .noc = NOC::RISCV_0_default,
+                .compile_args = reader_compile_args});
+    }
 
     uint32_t l1_addr = get_l1_address_and_size(mesh_device, corerange_to_cores(test_config.cores)[0]).base_address;
     std::vector<uint32_t> reader_run_time_args = {input_buffer_address, l1_addr};

--- a/tests/tt_metal/tt_metal/data_movement/dram_unary/test_unary_dram.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_unary/test_unary_dram.cpp
@@ -5,6 +5,7 @@
 #include "multi_device_fixture.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
+#include <tt-metalium/experimental/host_api.hpp>
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
@@ -96,23 +97,39 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const DramCo
     std::string reader_kernel_path = kernels_dir + reader_kernel_filename + ".cpp";
     std::string writer_kernel_path = kernels_dir + writer_kernel_filename + ".cpp";
 
-    CreateKernel(
-        program,
-        reader_kernel_path,
-        test_config.core_coord,
-        DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_1,
-            .noc = NOC::RISCV_1_default,
-            .compile_args = reader_compile_args});
+    if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
+        experimental::quasar::CreateKernel(
+            program,
+            reader_kernel_path,
+            test_config.core_coord,
+            experimental::quasar::QuasarDataMovementConfig{
+                .num_threads_per_cluster = 1, .compile_args = reader_compile_args});
 
-    CreateKernel(
-        program,
-        writer_kernel_path,
-        test_config.core_coord,
-        DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_0,
-            .noc = NOC::RISCV_0_default,
-            .compile_args = writer_compile_args});
+        experimental::quasar::CreateKernel(
+            program,
+            writer_kernel_path,
+            test_config.core_coord,
+            experimental::quasar::QuasarDataMovementConfig{
+                .num_threads_per_cluster = 1, .compile_args = writer_compile_args});
+    } else {
+        CreateKernel(
+            program,
+            reader_kernel_path,
+            test_config.core_coord,
+            DataMovementConfig{
+                .processor = DataMovementProcessor::RISCV_1,
+                .noc = NOC::RISCV_1_default,
+                .compile_args = reader_compile_args});
+
+        CreateKernel(
+            program,
+            writer_kernel_path,
+            test_config.core_coord,
+            DataMovementConfig{
+                .processor = DataMovementProcessor::RISCV_0,
+                .noc = NOC::RISCV_0_default,
+                .compile_args = writer_compile_args});
+    }
 
     // Assign unique id
     log_info(LogTest, "Running Test ID: {}, Run ID: {}", test_config.test_id, unit_tests::dm::runtime_host_id);

--- a/tests/tt_metal/tt_metal/data_movement/loopback/test_loopback.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/loopback/test_loopback.cpp
@@ -5,6 +5,7 @@
 #include "multi_device_fixture.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
+#include <tt-metalium/experimental/host_api.hpp>
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
@@ -78,14 +79,24 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const Loopba
         (uint32_t)test_config.test_id};
 
     // Kernels
-    auto sender_kernel = CreateKernel(
-        program,
-        "tests/tt_metal/tt_metal/data_movement/loopback/kernels/sender.cpp",
-        master_core_set,
-        DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_0,
-            .noc = test_config.noc_id,
-            .compile_args = sender_compile_args});
+    KernelHandle sender_kernel;
+    if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
+        sender_kernel = experimental::quasar::CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/data_movement/loopback/kernels/sender.cpp",
+            master_core_set,
+            experimental::quasar::QuasarDataMovementConfig{
+                .num_threads_per_cluster = 1, .compile_args = sender_compile_args});
+    } else {
+        sender_kernel = CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/data_movement/loopback/kernels/sender.cpp",
+            master_core_set,
+            DataMovementConfig{
+                .processor = DataMovementProcessor::RISCV_0,
+                .noc = test_config.noc_id,
+                .compile_args = sender_compile_args});
+    }
 
     // Semaphores
     CoreRangeSet sem_core_set = subordinate_core_set.merge<CoreRangeSet>(master_core_set);

--- a/tests/tt_metal/tt_metal/data_movement/noc_api_latency/test_noc_api_latency.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_api_latency/test_noc_api_latency.cpp
@@ -7,6 +7,7 @@
 #include "dm_common.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
+#include <tt-metalium/experimental/host_api.hpp>
 
 namespace tt::tt_metal {
 
@@ -115,18 +116,12 @@ bool run_noc_api_latency_test(
 
     std::string kernel_path = kernels_dir + kernel_filename + ".cpp";
 
-    auto riscv = DataMovementProcessor::RISCV_0;
-
-    if (test_config.kernel_type == KernelType::UNICAST_READ || test_config.kernel_type == KernelType::STATEFUL_READ) {
-        riscv = DataMovementProcessor::RISCV_1;
-    }
-
     // Create kernel on source core
-    CreateKernel(
+    experimental::quasar::CreateKernel(
         program,
         kernel_path,
         test_config.source_core_coord,
-        DataMovementConfig{.processor = riscv, .noc = test_config.noc_id, .compile_args = compile_args});
+        experimental::quasar::QuasarDataMovementConfig{.num_threads_per_cluster = 1, .compile_args = compile_args});
 
     // Assign unique id
     log_info(LogTest, "Running Test ID: {}, Run ID: {}", test_config.test_id, unit_tests::dm::runtime_host_id);

--- a/tests/tt_metal/tt_metal/data_movement/noc_api_latency/test_noc_api_latency.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_api_latency/test_noc_api_latency.cpp
@@ -116,12 +116,29 @@ bool run_noc_api_latency_test(
 
     std::string kernel_path = kernels_dir + kernel_filename + ".cpp";
 
-    // Create kernel on source core
-    experimental::quasar::CreateKernel(
-        program,
-        kernel_path,
-        test_config.source_core_coord,
-        experimental::quasar::QuasarDataMovementConfig{.num_threads_per_cluster = 1, .compile_args = compile_args});
+    // Create kernel on source core - branch by architecture
+    if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
+        // Quasar path: Use experimental API
+        experimental::quasar::CreateKernel(
+            program,
+            kernel_path,
+            test_config.source_core_coord,
+            experimental::quasar::QuasarDataMovementConfig{.num_threads_per_cluster = 1, .compile_args = compile_args});
+    } else {
+        // WH/BH path: Use legacy API with processor selection
+        auto riscv = DataMovementProcessor::RISCV_0;
+
+        if (test_config.kernel_type == KernelType::UNICAST_READ ||
+            test_config.kernel_type == KernelType::STATEFUL_READ) {
+            riscv = DataMovementProcessor::RISCV_1;
+        }
+
+        CreateKernel(
+            program,
+            kernel_path,
+            test_config.source_core_coord,
+            DataMovementConfig{.processor = riscv, .noc = test_config.noc_id, .compile_args = compile_args});
+    }
 
     // Assign unique id
     log_info(LogTest, "Running Test ID: {}, Run ID: {}", test_config.test_id, unit_tests::dm::runtime_host_id);

--- a/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
@@ -5,6 +5,7 @@
 #include "multi_device_fixture.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
+#include <tt-metalium/experimental/host_api.hpp>
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
@@ -96,14 +97,24 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneFro
     };
 
     // Kernels
-    auto gatherer_kernel = CreateKernel(
-        program,
-        "tests/tt_metal/tt_metal/data_movement/one_from_all/kernels/gatherer.cpp",
-        master_core_set,
-        DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_1,
-            .noc = test_config.noc_id,
-            .compile_args = gatherer_compile_args});
+    KernelHandle gatherer_kernel;
+    if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
+        gatherer_kernel = experimental::quasar::CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/data_movement/one_from_all/kernels/gatherer.cpp",
+            master_core_set,
+            experimental::quasar::QuasarDataMovementConfig{
+                .num_threads_per_cluster = 1, .compile_args = gatherer_compile_args});
+    } else {
+        gatherer_kernel = CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/data_movement/one_from_all/kernels/gatherer.cpp",
+            master_core_set,
+            DataMovementConfig{
+                .processor = DataMovementProcessor::RISCV_1,
+                .noc = test_config.noc_id,
+                .compile_args = gatherer_compile_args});
+    }
 
     // Runtime Arguments
     vector<uint32_t> master_runtime_args;

--- a/tests/tt_metal/tt_metal/data_movement/one_from_one/test_one_from_one.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_one/test_one_from_one.cpp
@@ -5,6 +5,7 @@
 #include "multi_device_fixture.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
+#include <tt-metalium/experimental/host_api.hpp>
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
@@ -83,14 +84,24 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneFro
     }
     std::string requestor_kernel_path = kernels_dir + requestor_kernel_filename + ".cpp";
 
-    auto requestor_kernel = CreateKernel(
-        program,
-        requestor_kernel_path,
-        master_core_set,
-        DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_1,
-            .noc = test_config.noc_id,
-            .compile_args = requestor_compile_args});
+    KernelHandle requestor_kernel;
+    if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
+        requestor_kernel = experimental::quasar::CreateKernel(
+            program,
+            requestor_kernel_path,
+            master_core_set,
+            experimental::quasar::QuasarDataMovementConfig{
+                .num_threads_per_cluster = 1, .compile_args = requestor_compile_args});
+    } else {
+        requestor_kernel = CreateKernel(
+            program,
+            requestor_kernel_path,
+            master_core_set,
+            DataMovementConfig{
+                .processor = DataMovementProcessor::RISCV_1,
+                .noc = test_config.noc_id,
+                .compile_args = requestor_compile_args});
+    }
 
     // Runtime Arguments
     CoreCoord physical_subordinate_core = device->worker_core_from_logical_core(test_config.subordinate_core_coord);

--- a/tests/tt_metal/tt_metal/data_movement/one_packet/test_one_packet.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_packet/test_one_packet.cpp
@@ -9,6 +9,7 @@
 #include "dm_common.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
+#include <tt-metalium/experimental/host_api.hpp>
 #include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
@@ -84,23 +85,41 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OnePac
     // Kernel
     tt::tt_metal::KernelHandle kernel;
     if (test_config.read) {
-        kernel = CreateKernel(
-            program,
-            kernels_dir,
-            master_core_set,
-            DataMovementConfig{
-                .processor = DataMovementProcessor::RISCV_1,
-                .noc = NOC::RISCV_1_default,
-                .compile_args = compile_args});
+        if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
+            kernel = experimental::quasar::CreateKernel(
+                program,
+                kernels_dir,
+                master_core_set,
+                experimental::quasar::QuasarDataMovementConfig{
+                    .num_threads_per_cluster = 1, .compile_args = compile_args});
+        } else {
+            kernel = CreateKernel(
+                program,
+                kernels_dir,
+                master_core_set,
+                DataMovementConfig{
+                    .processor = DataMovementProcessor::RISCV_1,
+                    .noc = NOC::RISCV_1_default,
+                    .compile_args = compile_args});
+        }
     } else {
-        kernel = CreateKernel(
-            program,
-            kernels_dir,
-            master_core_set,
-            DataMovementConfig{
-                .processor = DataMovementProcessor::RISCV_0,
-                .noc = NOC::RISCV_0_default,
-                .compile_args = compile_args});
+        if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
+            kernel = experimental::quasar::CreateKernel(
+                program,
+                kernels_dir,
+                master_core_set,
+                experimental::quasar::QuasarDataMovementConfig{
+                    .num_threads_per_cluster = 1, .compile_args = compile_args});
+        } else {
+            kernel = CreateKernel(
+                program,
+                kernels_dir,
+                master_core_set,
+                DataMovementConfig{
+                    .processor = DataMovementProcessor::RISCV_0,
+                    .noc = NOC::RISCV_0_default,
+                    .compile_args = compile_args});
+        }
     }
 
     // Runtime Arguments


### PR DESCRIPTION
### Summary
Adds architecture branching to the NOC API latency test suite to support both Quasar experimental API and legacy WH/BH API, maintaining backward compatibility.

### Changes
- Added architecture check to branch between Quasar and WH/BH code paths
- **Quasar path:** Uses `experimental::quasar::CreateKernel()` with `QuasarDataMovementConfig` and `num_threads_per_cluster = 1`
- **WH/BH path:** Preserves original `CreateKernel()` with `DataMovementConfig`, RISCV processor selection (RISCV_0/RISCV_1), and NOC configuration

### Test Validation
https://docs.google.com/spreadsheets/d/1B4_6tWCOwFcyk3za4FgMWMSTDXUJhGhiqhm6Rbx6qpg/edit?gid=0#gid=0

### Context
This change follows the architecture branching pattern from `test_direct.cpp`, allowing the test to use Quasar experimental API features on QUASAR hardware while maintaining full compatibility with WH/BH. Addresses review feedback to preserve backward compatibility.