### PR TITLE
[Cleanup] Remove internal init methods from the API

### DIFF
--- a/tt_metal/api/tt-metalium/device.hpp
+++ b/tt_metal/api/tt-metalium/device.hpp
@@ -152,16 +152,6 @@ public:
         size_t worker_l1_size,
         ttsl::Span<const std::uint32_t> l1_bank_remap = {},
         bool minimal = false) = 0;
-    [[deprecated("This is an internal function. It will be removed.")]]
-    virtual void init_command_queue_host() = 0;
-    [[deprecated("This is an internal function. It will be removed.")]]
-    virtual void init_command_queue_device() = 0;
-
-    // return false if compile fails (mainly come from Nebula on TG)
-    [[deprecated("This is an internal function. It will be removed.")]]
-    virtual bool compile_fabric() = 0;
-    [[deprecated("This is an internal function. It will be removed.")]]
-    virtual void configure_fabric() = 0;
     // Puts device into reset
     virtual bool close() = 0;
 

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -167,14 +167,6 @@ public:
         size_t worker_l1_size,
         ttsl::Span<const std::uint32_t> l1_bank_remap = {},
         bool minimal = false) override;
-    [[deprecated("This is an internal function. It will be removed.")]]
-    void init_command_queue_host() override;
-    [[deprecated("This is an internal function. It will be removed.")]]
-    void init_command_queue_device() override;
-    [[deprecated("This is an internal function. It will be removed.")]]
-    bool compile_fabric() override;
-    [[deprecated("This is an internal function. It will be removed.")]]
-    void configure_fabric() override;
     bool close() override;
     void enable_program_cache() override;
     void clear_program_cache() override;

--- a/tt_metal/distributed/dispatch_context.cpp
+++ b/tt_metal/distributed/dispatch_context.cpp
@@ -50,7 +50,7 @@ void DispatchContext::initialize_fast_dispatch(distributed::MeshDevice* mesh_dev
         "Manually setting up and tearing down Fast Dispatch is only supported on Galaxy and Blackhole clusters.");
 
     const auto& device_manager = MetalContext::instance(context_id).device_manager();
-    const auto& active_devices = device_manager->get_all_active_devices();
+    const auto& active_devices = device_manager->get_all_active_devices_impl();
 
     uint8_t num_hw_cqs = active_devices[0]->num_hw_cqs();
 

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -1311,23 +1311,6 @@ bool MeshDeviceImpl::initialize_impl(
     return true;
 }
 
-void MeshDeviceImpl::init_command_queue_host() {
-    TT_THROW("init_command_queue_host() is not supported on MeshDevice - use individual devices instead");
-    reference_device()->init_command_queue_host();
-}
-void MeshDeviceImpl::init_command_queue_device() {
-    TT_THROW("init_command_queue_device() is not supported on MeshDevice - use individual devices instead");
-    reference_device()->init_command_queue_device();
-}
-bool MeshDeviceImpl::compile_fabric() {
-    TT_THROW("compile_fabric() is not supported on MeshDevice - use individual devices instead");
-    return reference_device()->compile_fabric();
-}
-void MeshDeviceImpl::configure_fabric() {
-    TT_THROW("configure_fabric() is not supported on MeshDevice - use individual devices instead");
-    reference_device()->configure_fabric();
-}
-
 program_cache::detail::ProgramCache& MeshDeviceImpl::get_program_cache() { return *program_cache_; }
 HalProgrammableCoreType MeshDeviceImpl::get_programmable_core_type(CoreCoord virtual_core) const {
     return reference_device()->get_programmable_core_type(virtual_core);
@@ -1574,10 +1557,6 @@ bool MeshDevice::initialize(
     return pimpl_->initialize_impl(
         this, num_hw_cqs, l1_small_size, trace_region_size, worker_l1_size, l1_bank_remap, minimal);
 }
-void MeshDevice::init_command_queue_host() { pimpl_->init_command_queue_host(); }
-void MeshDevice::init_command_queue_device() { pimpl_->init_command_queue_device(); }
-bool MeshDevice::compile_fabric() { return pimpl_->compile_fabric(); }
-void MeshDevice::configure_fabric() { pimpl_->configure_fabric(); }
 bool MeshDevice::close() { return pimpl_->close_impl(this); }
 void MeshDevice::enable_program_cache() { pimpl_->enable_program_cache(); }
 void MeshDevice::clear_program_cache() { pimpl_->clear_program_cache(); }

--- a/tt_metal/distributed/mesh_device_impl.hpp
+++ b/tt_metal/distributed/mesh_device_impl.hpp
@@ -275,10 +275,6 @@ public:
         size_t worker_l1_size,
         tt::stl::Span<const std::uint32_t> l1_bank_remap = {},
         bool minimal = false);
-    void init_command_queue_host() override;
-    void init_command_queue_device() override;
-    bool compile_fabric() override;
-    void configure_fabric() override;
     bool close() override;
     bool close_impl(MeshDevice* pimpl_wrapper);
     void enable_program_cache() override;

--- a/tt_metal/impl/device/device_impl.hpp
+++ b/tt_metal/impl/device/device_impl.hpp
@@ -136,13 +136,13 @@ public:
         size_t worker_l1_size,
         tt::stl::Span<const std::uint32_t> l1_bank_remap = {},
         bool minimal = false) override;
-    void init_command_queue_host() override;
-    void init_command_queue_device() override;
+    void init_command_queue_host();
+    void init_command_queue_device();
 
     void init_command_queue_device_with_topology(DispatchTopology* topology);
 
-    bool compile_fabric() override;
-    void configure_fabric() override;
+    bool compile_fabric();
+    void configure_fabric();
     // Puts device into reset
     bool close() override;
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
- These are internal APIs which should not be called by the user
- They were marked for removal last month

### What's changed
- Remove from public API
- Keep the init methods in the Device impl. The mesh device doesn't need this as they internally contain the Device impls which we use to init

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nhuang/cleanup-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nhuang/cleanup-2)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nhuang/cleanup-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nhuang/cleanup-2)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nhuang/cleanup-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nhuang/cleanup-2)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nhuang/cleanup-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nhuang/cleanup-2)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nhuang/cleanup-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nhuang/cleanup-2)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nhuang/cleanup-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nhuang/cleanup-2)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
