### PR TITLE
[QSR][TEST]: Enable Waypoint test for Quasar

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
@@ -70,20 +70,21 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
     CoreCoord xy_end = is_quasar ? CoreCoord{0, 0} : CoreCoord{4, 4};
 
     // Allocate and zero-init L1 sync flag for host-device handshake
-    uint32_t sync_flag_addr = device->allocator()->get_base_allocator_addr(HalMemType::L1);
+    uint32_t tensix_sync_addr = device->allocator()->get_base_allocator_addr(HalMemType::L1);
+    uint32_t idle_eth_sync_addr = hal.get_dev_addr(HalProgrammableCoreType::IDLE_ETH, HalL1MemAddrType::UNRESERVED);
     std::vector<uint32_t> zero_data = {0};
 
     // Zero-init sync flag on all tensix cores
     for (uint32_t x = xy_start.x; x <= xy_end.x; x++) {
         for (uint32_t y = xy_start.y; y <= xy_end.y; y++) {
-            tt::tt_metal::detail::WriteToDeviceL1(device, CoreCoord{x, y}, sync_flag_addr, zero_data);
+            tt::tt_metal::detail::WriteToDeviceL1(device, CoreCoord{x, y}, tensix_sync_addr, zero_data);
         }
     }
 
     // Runtime args differ by core type:
-    // - TENSIX / idle ERISC: sync_flag_addr (arg 0) - blocks until host writes 1
+    // - TENSIX / idle ERISC: tensix_sync_addr/idle_eth_sync_addr (arg 0) - blocks until host writes 1
     // - Active ERISC: delay_cycles (arg 0) - timed wait, can't block due to tunneling
-    const std::vector<uint32_t> args = {sync_flag_addr};
+    const std::vector<uint32_t> tensix_args = {tensix_sync_addr};
     uint32_t clk_mhz = tt::tt_metal::MetalContext::instance().get_cluster().get_device_aiclk(device->id());
     uint32_t delay_cycles = clk_mhz * 3000000;  // 3 seconds - enough for watcher to capture waypoint
     const std::vector<uint32_t> active_eth_args = {delay_cycles};
@@ -101,8 +102,8 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
             kernel_path,
             CoreRange(xy_start, xy_end),
             tt::tt_metal::experimental::quasar::QuasarComputeConfig{.num_threads_per_cluster = 4});
-        SetCommonRuntimeArgs(program_, dm_kid, args);
-        SetCommonRuntimeArgs(program_, compute_kid, args);
+        SetCommonRuntimeArgs(program_, dm_kid, tensix_args);
+        SetCommonRuntimeArgs(program_, compute_kid, tensix_args);
     } else {
         auto brisc_kid = CreateKernel(
             program_,
@@ -115,9 +116,9 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
             CoreRange(xy_start, xy_end),
             DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
         auto trisc_kid = CreateKernel(program_, kernel_path, CoreRange(xy_start, xy_end), ComputeConfig{});
-        SetCommonRuntimeArgs(program_, brisc_kid, args);
-        SetCommonRuntimeArgs(program_, ncrisc_kid, args);
-        SetCommonRuntimeArgs(program_, trisc_kid, args);
+        SetCommonRuntimeArgs(program_, brisc_kid, tensix_args);
+        SetCommonRuntimeArgs(program_, ncrisc_kid, tensix_args);
+        SetCommonRuntimeArgs(program_, trisc_kid, tensix_args);
     }
 
     // Create kernels for ethernet cores
@@ -136,9 +137,10 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
 
     if (has_idle_eth_cores) {
         std::set<CoreRange> ranges;
+        const std::vector<uint32_t> idle_eth_args = {idle_eth_sync_addr};
         for (const auto& core : device->get_inactive_ethernet_cores()) {
             ranges.insert(CoreRange(core, core));
-            tt::tt_metal::detail::WriteToDeviceL1(device, core, sync_flag_addr, zero_data, CoreType::ETH);
+            tt::tt_metal::detail::WriteToDeviceL1(device, core, idle_eth_sync_addr, zero_data, CoreType::ETH);
         }
         // Create kernel for each idle ETH processor (use HAL to get count)
         uint32_t num_idle_eth_processors = hal.get_num_risc_processors(HalProgrammableCoreType::IDLE_ETH);
@@ -149,7 +151,7 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
                 kernel_path,
                 ranges,
                 tt_metal::EthernetConfig{.eth_mode = Eth::IDLE, .noc = tt_metal::NOC::NOC_0, .processor = processor});
-            SetCommonRuntimeArgs(program_, kid, args);
+            SetCommonRuntimeArgs(program_, kid, idle_eth_args);
         }
     }
 
@@ -190,12 +192,12 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
     std::vector<uint32_t> release_data = {1};
     for (uint32_t x = xy_start.x; x <= xy_end.x; x++) {
         for (uint32_t y = xy_start.y; y <= xy_end.y; y++) {
-            tt::tt_metal::detail::WriteToDeviceL1(device, CoreCoord{x, y}, sync_flag_addr, release_data);
+            tt::tt_metal::detail::WriteToDeviceL1(device, CoreCoord{x, y}, tensix_sync_addr, release_data);
         }
     }
     if (has_idle_eth_cores) {
         for (const auto& core : device->get_inactive_ethernet_cores()) {
-            tt::tt_metal::detail::WriteToDeviceL1(device, core, sync_flag_addr, release_data, CoreType::ETH);
+            tt::tt_metal::detail::WriteToDeviceL1(device, core, idle_eth_sync_addr, release_data, CoreType::ETH);
         }
     }
     distributed::Finish(mesh_device->mesh_command_queue());

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
@@ -3,19 +3,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <fmt/base.h>
+#include <fmt/format.h>
 #include <gtest/gtest.h>
+#include <chrono>
 #include <cstdint>
-#include <tt-metalium/host_api.hpp>
-#include <functional>
 #include <set>
 #include <string>
-#include <unordered_set>
-#include <variant>
+#include <thread>
 #include <vector>
 
+#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/distributed.hpp>
-#include <tt-metalium/buffer.hpp>
-#include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/kernel_types.hpp>
 #include "debug_tools_fixture.hpp"
@@ -37,7 +35,21 @@ using namespace tt::tt_metal;
 
 namespace {
 namespace CMAKE_UNIQUE_NAMESPACE {
+
 const std::string waypoint = "AAAA";
+
+// Build a comma-separated waypoint string for n processors (e.g., "AAAA,AAAA,AAAA")
+std::string build_waypoint_string(uint32_t n) {
+    if (n == 0) {
+        return "";
+    }
+    std::string result = waypoint;
+    for (uint32_t i = 1; i < n; i++) {
+        result += "," + waypoint;
+    }
+    return result;
+}
+
 void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
     // Set up program
     distributed::MeshWorkload workload;
@@ -49,37 +61,36 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
     auto* device = mesh_device->get_devices()[0];
     const auto& hal = MetalContext::instance().hal();
     const bool is_quasar = hal.get_arch() == tt::ARCH::QUASAR;
+    // TENSIX/ACTIVE_ETH cores: SD only used for Quasar watcher tests (match test_assert, test_sanitize)
+    if (fixture->IsSlowDispatch() && !is_quasar && device->get_inactive_ethernet_cores().empty()) {
+        GTEST_SKIP() << "Slow Dispatch tests only run on Quasar or IDLE_ETH cores";
+    }
     const std::string kernel_path = "tests/tt_metal/tt_metal/test_kernels/misc/watcher_waypoints.cpp";
-
     CoreCoord xy_start = {0, 0};
-    CoreCoord xy_end;
-    if (is_quasar) {
-        // Quasar only supports single cluster currently
-        xy_end = {0, 0};
-    } else {
-        // BH/WH: 5x5 grid
-        xy_end = {4, 4};
+    CoreCoord xy_end = is_quasar ? CoreCoord{0, 0} : CoreCoord{4, 4};
+
+    // Allocate and zero-init L1 sync flag for host-device handshake
+    uint32_t sync_flag_addr = device->allocator()->get_base_allocator_addr(HalMemType::L1);
+    std::vector<uint32_t> zero_data = {0};
+
+    // Zero-init sync flag on all tensix cores
+    for (uint32_t x = xy_start.x; x <= xy_end.x; x++) {
+        for (uint32_t y = xy_start.y; y <= xy_end.y; y++) {
+            tt::tt_metal::detail::WriteToDeviceL1(device, CoreCoord{x, y}, sync_flag_addr, zero_data);
+        }
     }
 
-    // The kernels need arguments to be passed in: the number of cycles to delay while syncing,
-    // and an L1 buffer to use for the syncing.
+    // Runtime args differ by core type:
+    // - TENSIX / idle ERISC: sync_flag_addr (arg 0) - blocks until host writes 1
+    // - Active ERISC: delay_cycles (arg 0) - timed wait, can't block due to tunneling
+    const std::vector<uint32_t> args = {sync_flag_addr};
     uint32_t clk_mhz = tt::tt_metal::MetalContext::instance().get_cluster().get_device_aiclk(device->id());
-    uint32_t delay_cycles = clk_mhz * 2000000; // 2 seconds
-    tt_metal::InterleavedBufferConfig l1_config {
-        .device = device,
-        .size = sizeof(uint32_t),
-        .page_size = sizeof(uint32_t),
-        .buffer_type = tt_metal::BufferType::L1
-    };
-    auto l1_buffer = CreateBuffer(l1_config);
+    uint32_t delay_cycles = clk_mhz * 3000000;  // 3 seconds - enough for watcher to capture waypoint
+    const std::vector<uint32_t> active_eth_args = {delay_cycles};
 
-    // Runtime args
-    const std::vector<uint32_t> args = { delay_cycles, l1_buffer->address() };
-
-    // Run a kernel that posts waypoints and waits on certain gating values to be written before
-    // posting the next waypoint.
+    // Create kernels for TENSIX cores
     if (is_quasar) {
-        auto num_dms = hal.get_processor_types_count(HalProgrammableCoreType::TENSIX, 0);  // 8
+        auto num_dms = hal.get_processor_types_count(HalProgrammableCoreType::TENSIX, 0);
         auto dm_kid = tt::tt_metal::experimental::quasar::CreateKernel(
             program_,
             kernel_path,
@@ -109,149 +120,130 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
         SetCommonRuntimeArgs(program_, trisc_kid, args);
     }
 
-    // Also run on ethernet cores if they're present
+    // Create kernels for ethernet cores
     bool has_eth_cores = !device->get_active_ethernet_cores(true).empty();
-    bool has_idle_eth_cores = !device->get_inactive_ethernet_cores().empty();
-
-    // TODO: Enable this when FD-on-idle-eth is supported.
-    if (!fixture->IsSlowDispatch()) {
-        has_idle_eth_cores = false;
-    }
+    bool has_idle_eth_cores = fixture->IsSlowDispatch() && !device->get_inactive_ethernet_cores().empty();
 
     if (has_eth_cores) {
-        std::set<CoreRange> eth_core_ranges;
+        std::set<CoreRange> ranges;
         for (const auto& core : device->get_active_ethernet_cores(true)) {
-            eth_core_ranges.insert(CoreRange(core, core));
+            ranges.insert(CoreRange(core, core));
         }
-        auto erisc_kid =
-            CreateKernel(program_, kernel_path, eth_core_ranges, tt_metal::EthernetConfig{.noc = tt_metal::NOC::NOC_0});
-        SetCommonRuntimeArgs(program_, erisc_kid, args);
+        // Active ERISC: pass delay_cycles for timed wait (can't block forever due to tunneling)
+        auto kid = CreateKernel(program_, kernel_path, ranges, tt_metal::EthernetConfig{.noc = tt_metal::NOC::NOC_0});
+        SetCommonRuntimeArgs(program_, kid, active_eth_args);
     }
-    if (has_idle_eth_cores) {
-        std::set<CoreRange> eth_core_ranges;
-        for (const auto& core : device->get_inactive_ethernet_cores()) {
-            eth_core_ranges.insert(CoreRange(core, core));
-        }
-        auto ierisc_kid0 = CreateKernel(
-            program_,
-            kernel_path,
-            eth_core_ranges,
-            tt_metal::EthernetConfig{
-                .eth_mode = Eth::IDLE, .noc = tt_metal::NOC::NOC_0, .processor = DataMovementProcessor::RISCV_0});
-        SetCommonRuntimeArgs(program_, ierisc_kid0, args);
 
-        if (device->arch() == ARCH::BLACKHOLE) {
-            auto ierisc_kid1 = CreateKernel(
+    if (has_idle_eth_cores) {
+        std::set<CoreRange> ranges;
+        for (const auto& core : device->get_inactive_ethernet_cores()) {
+            ranges.insert(CoreRange(core, core));
+            tt::tt_metal::detail::WriteToDeviceL1(device, core, sync_flag_addr, zero_data, CoreType::ETH);
+        }
+        // Create kernel for each idle ETH processor (use HAL to get count)
+        uint32_t num_idle_eth_processors = hal.get_num_risc_processors(HalProgrammableCoreType::IDLE_ETH);
+        for (uint32_t proc_id = 0; proc_id < num_idle_eth_processors; proc_id++) {
+            auto processor = (proc_id == 0) ? DataMovementProcessor::RISCV_0 : DataMovementProcessor::RISCV_1;
+            auto kid = CreateKernel(
                 program_,
                 kernel_path,
-                eth_core_ranges,
-                tt_metal::EthernetConfig{
-                    .eth_mode = Eth::IDLE, .noc = tt_metal::NOC::NOC_0, .processor = DataMovementProcessor::RISCV_1});
-            SetCommonRuntimeArgs(program_, ierisc_kid1, args);
+                ranges,
+                tt_metal::EthernetConfig{.eth_mode = Eth::IDLE, .noc = tt_metal::NOC::NOC_0, .processor = processor});
+            SetCommonRuntimeArgs(program_, kid, args);
         }
     }
 
-    // Run the program in a new thread, we'll have to update gate values in this thread.
-    fixture->RunProgram(mesh_device, workload);
+    // Dispatch non-blocking: kernels post waypoint then spin on sync flag
+    distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, false);
 
-    // Check that the expected waypoints are in the watcher log, a set for each core.
+    // Build poll patterns and wait for waypoints to appear
+    std::vector<std::string> poll_strings;
+    for (uint32_t x = xy_start.x; x <= xy_end.x; x++) {
+        for (uint32_t y = xy_start.y; y <= xy_end.y; y++) {
+            poll_strings.push_back(fmt::format("worker core(x={:2},y={:2})*: {}", x, y, waypoint));
+        }
+    }
+    if (has_eth_cores) {
+        for (const auto& core : device->get_active_ethernet_cores(true)) {
+            poll_strings.push_back(fmt::format("acteth core(x={:2},y={:2})*: {}", core.x, core.y, waypoint));
+        }
+    }
+    if (has_idle_eth_cores) {
+        for (const auto& core : device->get_inactive_ethernet_cores()) {
+            poll_strings.push_back(fmt::format("idleth core(x={:2},y={:2})*: {}", core.x, core.y, waypoint));
+        }
+    }
+
+    log_info(tt::LogTest, "Polling for {} patterns", poll_strings.size());
+
+    constexpr int timeout_ms = 30000;
+    auto start = std::chrono::steady_clock::now();
+    while (!FileContainsAllStrings(fixture->log_file_name, poll_strings)) {
+        auto elapsed =
+            std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start).count();
+        ASSERT_LT(elapsed, timeout_ms) << "Timed out waiting for watcher to log " << waypoint << " waypoints";
+        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+    }
+    log_info(tt::LogTest, "All patterns found!");
+
+    // Release all cores
+    std::vector<uint32_t> release_data = {1};
+    for (uint32_t x = xy_start.x; x <= xy_end.x; x++) {
+        for (uint32_t y = xy_start.y; y <= xy_end.y; y++) {
+            tt::tt_metal::detail::WriteToDeviceL1(device, CoreCoord{x, y}, sync_flag_addr, release_data);
+        }
+    }
+    if (has_idle_eth_cores) {
+        for (const auto& core : device->get_inactive_ethernet_cores()) {
+            tt::tt_metal::detail::WriteToDeviceL1(device, core, sync_flag_addr, release_data, CoreType::ETH);
+        }
+    }
+    distributed::Finish(mesh_device->mesh_command_queue());
+
+    // Get processor counts from HAL and build expected waypoint strings
+    uint32_t num_tensix = hal.get_num_risc_processors(HalProgrammableCoreType::TENSIX);
+    uint32_t num_idle_eth = hal.get_num_risc_processors(HalProgrammableCoreType::IDLE_ETH);
+    std::string tensix_waypoints = build_waypoint_string(num_tensix);
+    std::string idle_eth_waypoints = build_waypoint_string(num_idle_eth);
+
+    log_info(tt::LogTest, "Verifying: {} waypoints/TENSIX, 1/active ETH, {}/idle ETH", num_tensix, num_idle_eth);
+
+    // Verify waypoints with device ID and virtual coordinates
     auto check_core = [&](const CoreCoord& logical_core,
                           const CoreCoord& virtual_core,
-                          bool is_eth_core,
-                          bool is_active) {
-        vector<std::string> expected_waypoints;
-        std::string expected;
-        // Need to update the expected strings based on each core.
-        // for (string waypoint : {"AAAA", "BBBB", "CCCC"}) { // Stripped this down since the wait function is flaky
-        for (std::string waypoint : {"AAAA"}) {
-            if (is_eth_core) {
-                // Each different config has a different calculation for k_id, let's just do one. Fast Dispatch, one device.
-                std::string k_id_s;
-                if (tt::tt_metal::GetNumAvailableDevices() == 1 && !fixture->IsSlowDispatch()) {
-                    // blank | prefetch, dispatch | tensix kernels
-                    int k_id = 1 + 2 + 3;
-                    std::string k_id_s = fmt::format("{:3}", k_id);
-                    if (device->arch() == ARCH::BLACKHOLE) {
-                        k_id_s += fmt::format("|{:3}", k_id + 1);
-                    }
-                } else {
-                    k_id_s = "";
-                }
-                std::string erisc1_s = "   X";
-                if (device->arch() == ARCH::BLACKHOLE &&
-                    tt::tt_metal::MetalContext::instance().rtoptions().get_enable_2_erisc_mode()) {
-                    // There is a second erisc on Blackhole
-                    erisc1_s = "   W";
-                }
-                expected = fmt::format(
-                    "Device {} {}eth core(x={:2},y={:2}) virtual(x={:2},y={:2}): {},{},   X,   X,   X  ",
-                    device->id(),
-                    is_active ? "act" : "idl",
-                    logical_core.x,
-                    logical_core.y,
-                    virtual_core.x,
-                    virtual_core.y,
-                    waypoint,
-                    // TODO(#17275): Rework risc counts & masks into HAL and generalize this test.
-                    // Active eth core only has one available erisc to test on.
-                    (device->arch() == ARCH::BLACKHOLE and not is_active) ? waypoint : erisc1_s);
-                if (device->arch() == ARCH::BLACKHOLE) {
-                    expected += fmt::format("rmsg:???|?? h_id:  ? smsg:? k_ids:{}", k_id_s);
-                } else {
-                    expected += fmt::format("rmsg:???|? h_id:  ? k_ids:{}", k_id_s);
-                }
-            } else {
-                // Each different config has a different calculation for k_id, let's just do one. Fast Dispatch, one device.
-                std::string k_id_s;
-                if (tt::tt_metal::GetNumAvailableDevices() == 1 && !fixture->IsSlowDispatch()) {
-                    // blank | prefetch, dispatch
-                    int k_id = 1 + 2;
-                    // NOLINTNEXTLINE(bugprone-unused-local-non-trivial-variable)
-                    std::string k_id_s = fmt::format("{:3}|{:3}|{:3}", k_id, k_id + 1, k_id + 2);
-                } else {
-                    k_id_s = "";
-                }
-                expected = fmt::format(
-                    "Device {} worker core(x={:2},y={:2}) virtual(x={:2},y={:2}): {},{},{},{},{}  rmsg:???|??? h_id:  "
-                    "? smsg:???? k_ids:{}",
-                    device->id(),
-                    logical_core.x,
-                    logical_core.y,
-                    virtual_core.x,
-                    virtual_core.y,
-                    waypoint,
-                    waypoint,
-                    waypoint,
-                    waypoint,
-                    waypoint,
-                    k_id_s);
-            }
-            expected_waypoints.push_back(expected);
-        }
-        EXPECT_TRUE(
-            FileContainsAllStringsInOrder(
-                fixture->log_file_name,
-                expected_waypoints
-            )
-        );
+                          const std::string& type,
+                          const std::string& wp) {
+        std::string expected = fmt::format(
+            "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2}): {}*rmsg:*",
+            device->id(),
+            type,
+            logical_core.x,
+            logical_core.y,
+            virtual_core.x,
+            virtual_core.y,
+            wp);
+        bool found = FileContainsAllStringsInOrder(fixture->log_file_name, {expected});
+        EXPECT_TRUE(found) << "Missing waypoint log for " << type << " core (" << logical_core.x << ","
+                           << logical_core.y << ")\n"
+                           << "Expected: " << expected;
     };
     for (uint32_t x = xy_start.x; x <= xy_end.x; x++) {
         for (uint32_t y = xy_start.y; y <= xy_end.y; y++) {
             CoreCoord logical_core = {x, y};
             CoreCoord virtual_core = device->worker_core_from_logical_core(logical_core);
-            check_core(logical_core, virtual_core, false, false);
+            check_core(logical_core, virtual_core, "worker", tensix_waypoints);
         }
     }
     if (has_eth_cores) {
         for (const auto& core : device->get_active_ethernet_cores(true)) {
             CoreCoord virtual_core = device->ethernet_core_from_logical_core(core);
-            check_core(core, virtual_core, true, true);
+            check_core(core, virtual_core, "acteth", waypoint);
         }
     }
     if (has_idle_eth_cores) {
         for (const auto& core : device->get_inactive_ethernet_cores()) {
             CoreCoord virtual_core = device->ethernet_core_from_logical_core(core);
-            check_core(core, virtual_core, true, false);
+            check_core(core, virtual_core, "idleth", idle_eth_waypoints);
         }
     }
 }

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
@@ -26,6 +26,7 @@
 #include "impl/context/metal_context.hpp"
 #include <umd/device/types/arch.hpp>
 #include "impl/kernels/kernel.hpp"
+#include <tt-metalium/experimental/host_api.hpp>
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // A test for checking watcher waypoints.
@@ -36,6 +37,7 @@ using namespace tt::tt_metal;
 
 namespace {
 namespace CMAKE_UNIQUE_NAMESPACE {
+const std::string waypoint = "AAAA";
 void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
     // Set up program
     distributed::MeshWorkload workload;
@@ -45,28 +47,19 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
     workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
     auto* device = mesh_device->get_devices()[0];
+    const auto& hal = MetalContext::instance().hal();
+    const bool is_quasar = hal.get_arch() == tt::ARCH::QUASAR;
+    const std::string kernel_path = "tests/tt_metal/tt_metal/test_kernels/misc/watcher_waypoints.cpp";
 
-    // Test runs on a 5x5 grid
     CoreCoord xy_start = {0, 0};
-    CoreCoord xy_end = {4, 4};
-
-    // Run a kernel that posts waypoints and waits on certain gating values to be written before
-    // posting the next waypoint.
-    auto brisc_kid = CreateKernel(
-        program_,
-        "tests/tt_metal/tt_metal/test_kernels/misc/watcher_waypoints.cpp",
-        CoreRange(xy_start, xy_end),
-        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
-    auto ncrisc_kid = CreateKernel(
-        program_,
-        "tests/tt_metal/tt_metal/test_kernels/misc/watcher_waypoints.cpp",
-        CoreRange(xy_start, xy_end),
-        DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
-    auto trisc_kid = CreateKernel(
-        program_,
-        "tests/tt_metal/tt_metal/test_kernels/misc/watcher_waypoints.cpp",
-        CoreRange(xy_start, xy_end),
-        ComputeConfig{});
+    CoreCoord xy_end;
+    if (is_quasar) {
+        // Quasar only supports single cluster currently
+        xy_end = {0, 0};
+    } else {
+        // BH/WH: 5x5 grid
+        xy_end = {4, 4};
+    }
 
     // The kernels need arguments to be passed in: the number of cycles to delay while syncing,
     // and an L1 buffer to use for the syncing.
@@ -80,15 +73,42 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
     };
     auto l1_buffer = CreateBuffer(l1_config);
 
-    // Write runtime args
+    // Runtime args
     const std::vector<uint32_t> args = { delay_cycles, l1_buffer->address() };
-    for (uint32_t x = xy_start.x; x <= xy_end.x; x++) {
-        for (uint32_t y = xy_start.y; y <= xy_end.y; y++) {
-            SetRuntimeArgs(program_, brisc_kid, CoreCoord{x, y}, args);
-            SetRuntimeArgs(program_, ncrisc_kid, CoreCoord{x, y}, args);
-            SetRuntimeArgs(program_, trisc_kid, CoreCoord{x, y}, args);
-        }
+
+    // Run a kernel that posts waypoints and waits on certain gating values to be written before
+    // posting the next waypoint.
+    if (is_quasar) {
+        auto num_dms = hal.get_processor_types_count(HalProgrammableCoreType::TENSIX, 0);  // 8
+        auto dm_kid = tt::tt_metal::experimental::quasar::CreateKernel(
+            program_,
+            kernel_path,
+            CoreRange(xy_start, xy_end),
+            tt::tt_metal::experimental::quasar::QuasarDataMovementConfig{.num_threads_per_cluster = num_dms});
+        auto compute_kid = tt::tt_metal::experimental::quasar::CreateKernel(
+            program_,
+            kernel_path,
+            CoreRange(xy_start, xy_end),
+            tt::tt_metal::experimental::quasar::QuasarComputeConfig{.num_threads_per_cluster = 4});
+        SetCommonRuntimeArgs(program_, dm_kid, args);
+        SetCommonRuntimeArgs(program_, compute_kid, args);
+    } else {
+        auto brisc_kid = CreateKernel(
+            program_,
+            kernel_path,
+            CoreRange(xy_start, xy_end),
+            DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+        auto ncrisc_kid = CreateKernel(
+            program_,
+            kernel_path,
+            CoreRange(xy_start, xy_end),
+            DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
+        auto trisc_kid = CreateKernel(program_, kernel_path, CoreRange(xy_start, xy_end), ComputeConfig{});
+        SetCommonRuntimeArgs(program_, brisc_kid, args);
+        SetCommonRuntimeArgs(program_, ncrisc_kid, args);
+        SetCommonRuntimeArgs(program_, trisc_kid, args);
     }
+
     // Also run on ethernet cores if they're present
     bool has_eth_cores = !device->get_active_ethernet_cores(true).empty();
     bool has_idle_eth_cores = !device->get_inactive_ethernet_cores().empty();
@@ -99,51 +119,37 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
     }
 
     if (has_eth_cores) {
-        KernelHandle erisc_kid;
         std::set<CoreRange> eth_core_ranges;
         for (const auto& core : device->get_active_ethernet_cores(true)) {
             eth_core_ranges.insert(CoreRange(core, core));
         }
-        erisc_kid = CreateKernel(
-            program_,
-            "tests/tt_metal/tt_metal/test_kernels/misc/watcher_waypoints.cpp",
-            eth_core_ranges,
-            tt_metal::EthernetConfig{.noc = tt_metal::NOC::NOC_0});
-
-        for (const auto& core : device->get_active_ethernet_cores(true)) {
-            SetRuntimeArgs(program_, erisc_kid, core, args);
-        }
+        auto erisc_kid =
+            CreateKernel(program_, kernel_path, eth_core_ranges, tt_metal::EthernetConfig{.noc = tt_metal::NOC::NOC_0});
+        SetCommonRuntimeArgs(program_, erisc_kid, args);
     }
     if (has_idle_eth_cores) {
-        KernelHandle ierisc_kid0{}, ierisc_kid1{};
         std::set<CoreRange> eth_core_ranges;
         for (const auto& core : device->get_inactive_ethernet_cores()) {
             eth_core_ranges.insert(CoreRange(core, core));
         }
-        ierisc_kid0 = CreateKernel(
+        auto ierisc_kid0 = CreateKernel(
             program_,
-            "tests/tt_metal/tt_metal/test_kernels/misc/watcher_waypoints.cpp",
+            kernel_path,
             eth_core_ranges,
             tt_metal::EthernetConfig{
                 .eth_mode = Eth::IDLE, .noc = tt_metal::NOC::NOC_0, .processor = DataMovementProcessor::RISCV_0});
+        SetCommonRuntimeArgs(program_, ierisc_kid0, args);
 
         if (device->arch() == ARCH::BLACKHOLE) {
-            ierisc_kid1 = CreateKernel(
+            auto ierisc_kid1 = CreateKernel(
                 program_,
-                "tests/tt_metal/tt_metal/test_kernels/misc/watcher_waypoints.cpp",
+                kernel_path,
                 eth_core_ranges,
                 tt_metal::EthernetConfig{
                     .eth_mode = Eth::IDLE, .noc = tt_metal::NOC::NOC_0, .processor = DataMovementProcessor::RISCV_1});
-        }
-
-        for (const auto& core : device->get_inactive_ethernet_cores()) {
-            SetRuntimeArgs(program_, ierisc_kid0, core, args);
-            if (device->arch() == ARCH::BLACKHOLE) {
-                SetRuntimeArgs(program_, ierisc_kid1, core, args);
-            }
+            SetCommonRuntimeArgs(program_, ierisc_kid1, args);
         }
     }
-
 
     // Run the program in a new thread, we'll have to update gate values in this thread.
     fixture->RunProgram(mesh_device, workload);

--- a/tests/tt_metal/tt_metal/test_kernels/misc/watcher_waypoints.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/watcher_waypoints.cpp
@@ -4,43 +4,43 @@
 
 #include <cstdint>
 #include "api/debug/waypoint.h"
-#include "api/debug/ring_buffer.h"
+#include "risc_common.h"
 
-// Helper function to sync execution by forcing other riscs to wait for brisc, which in turn waits
-// for a set number of cycles.
-void hacky_sync(uint32_t sync_num, uint32_t wait_cycles, uint32_t sync_addr) {
-    volatile tt_l1_ptr uint32_t* sync_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sync_addr);
-#if defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_IDLE_ERISC)
-    riscv_wait(wait_cycles);
-#if defined(COMPILE_FOR_BRISC)
-    // ERISC doesn't have to sync, doesn't have the L1 buffer
-    *(sync_ptr) = sync_num;
-#endif
-#else
-    while (*(sync_ptr) != sync_num) {
-        invalidate_l1_cache();
-    }
-#endif
-}
-
-/*
- * A test for the watcher waypointing feature.
-*/
 #if defined(COMPILE_FOR_TRISC)
 #include "api/compute/common.h"
+#else
+#include "api/dataflow/dataflow_api.h"
+#endif
+
+#if defined(ARCH_QUASAR)
+#include "internal/tt-2xx/quasar/overlay/overlay_addresses.h"
 #endif
 
 void kernel_main() {
-    uint32_t sync_wait_cycles = get_common_arg_val<uint32_t>(0);
-    uint32_t sync_address     = get_common_arg_val<uint32_t>(1);
-    WATCHER_RING_BUFFER_PUSH(sync_wait_cycles);
-
-    // Post a new waypoint with a delay after (to let the watcher poll it)
-    hacky_sync(1, sync_wait_cycles, sync_address);
+    // Post waypoint
     WAYPOINT("AAAA");
-    hacky_sync(2, sync_wait_cycles, sync_address);
-    //WAYPOINT("BBBB");
-    hacky_sync(3, sync_wait_cycles, sync_address);
-    //WAYPOINT("CCCC");
-    hacky_sync(4, sync_wait_cycles, sync_address);
+
+#if defined(COMPILE_FOR_ERISC) && !defined(COMPILE_FOR_IDLE_ERISC)
+    // Active ERISC: timed wait to give watcher time to capture waypoint,
+    // then exit to resume tunneling duties. Can't block for sync signal.
+    uint32_t delay_cycles = get_common_arg_val<uint32_t>(0);
+    riscv_wait(delay_cycles);
+#else
+    // TENSIX / idle ERISC: block until host signals
+    uint32_t sync_flag_addr = get_common_arg_val<uint32_t>(0);
+    volatile uint32_t* sync_flag =
+        reinterpret_cast<volatile uint32_t*>(sync_flag_addr);
+
+    while (*sync_flag != 1) {
+#if defined(ARCH_QUASAR)
+        // On Quasar DM cores, we must invalidate L2 to see updated host writes in L1
+        // TODO: Use invalidate_l2_cache_line() once PR #38124 is merged
+        __asm__ __volatile__("fence" ::: "memory");
+        *reinterpret_cast<volatile uint64_t*>(L2_INVALIDATE_ADDR) = sync_flag_addr;
+        __asm__ __volatile__("fence" ::: "memory");
+#else
+        invalidate_l1_cache();
+#endif
+    }
+#endif
 }

--- a/tests/tt_metal/tt_metal/test_kernels/misc/watcher_waypoints.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/watcher_waypoints.cpp
@@ -26,14 +26,13 @@ void hacky_sync(uint32_t sync_num, uint32_t wait_cycles, uint32_t sync_addr) {
 /*
  * A test for the watcher waypointing feature.
 */
-#if !defined(COMPILE_FOR_BRISC) && !defined(COMPILE_FOR_NCRISC) && !defined(COMPILE_FOR_ERISC) && \
-    !defined(COMPILE_FOR_IDLE_ERISC)
+#if defined(COMPILE_FOR_TRISC)
 #include "api/compute/common.h"
 #endif
 
 void kernel_main() {
-    uint32_t sync_wait_cycles = get_arg_val<uint32_t>(0);
-    uint32_t sync_address     = get_arg_val<uint32_t>(1);
+    uint32_t sync_wait_cycles = get_common_arg_val<uint32_t>(0);
+    uint32_t sync_address     = get_common_arg_val<uint32_t>(1);
     WATCHER_RING_BUFFER_PUSH(sync_wait_cycles);
 
     // Post a new waypoint with a delay after (to let the watcher poll it)


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/38105

### Problem description
Bring up watcher waypoint test on Quasar. Device-side support was added in https://github.com/tenstorrent/tt-metal/pull/38251. The original test used a "hacky sync" for host watcher reader to read device waypoints that didn't scale well with Quasar's multiple DM processors running as threads.

### What's changed
- Refactored host-device synchronization to L1 flag-based handshake for DMs, TRISCs, and idle ERISC.  Active ERISC uses timed wait (~3s) since blocking breaks tunneling to remote devices. The delay is sufficient for multiple watcher poll cycles to capture the waypoint.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  
- Simplified waypoint verification using HAL APIs for dynamic processor counts and glob patterns instead of exact string matching.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snadkarni/quasar_waypoints)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snadkarni/quasar_waypoints)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snadkarni/quasar_waypoints)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snadkarni/quasar_waypoints)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadkarni/quasar_waypoints)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadkarni/quasar_waypoints)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early

Quasar emulator test run: https://gist.github.com/sidnadTT/dd8426863dadafe5bf25b32e087c09dc


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snadkarni/quasar_waypoints)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snadkarni/quasar_waypoints)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snadkarni/quasar_waypoints)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snadkarni/quasar_waypoints)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snadkarni/quasar_waypoints)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snadkarni/quasar_waypoints)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
