### PR TITLE
Cross-Process H <-> D Sockets

### DIFF
--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -60,7 +60,7 @@ jobs:
             test-type: fast
           - name: Sockets fast unit test
             cmd: |
-              mpirun -np 2 --tag-output ./build/test/tt_metal/distributed/multiproc_loopback_test
+              mpirun -np 2 --allow-run-as-root --tag-output ./build/test/tt_metal/distributed/multiproc_loopback_test
               ./build/test/tt_metal/distributed/distributed_unit_tests --gtest_filter="*HDSocketFixture*"
             timeout: 10
             test-type: fast

--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -60,7 +60,6 @@ jobs:
             test-type: fast
           - name: Sockets fast unit test
             cmd: |
-              mpirun -np 2 --allow-run-as-root --tag-output ./build/test/tt_metal/distributed/multiproc_loopback_test
               ./build/test/tt_metal/distributed/distributed_unit_tests --gtest_filter="*HDSocketFixture*"
             timeout: 10
             test-type: fast

--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -60,6 +60,7 @@ jobs:
             test-type: fast
           - name: Sockets fast unit test
             cmd: |
+              mpirun -np 2 --tag-output ./build/test/tt_metal/distributed/multiproc_loopback_test
               ./build/test/tt_metal/distributed/distributed_unit_tests --gtest_filter="*HDSocketFixture*"
             timeout: 10
             test-type: fast

--- a/tests/tt_metal/distributed/CMakeLists.txt
+++ b/tests/tt_metal/distributed/CMakeLists.txt
@@ -79,4 +79,28 @@ set_target_properties(
             ${PROJECT_BINARY_DIR}/test/tt_metal/distributed
 )
 
+add_executable(multiproc_loopback_test)
+target_sources(multiproc_loopback_test PRIVATE test_multiproc_loopback.cpp)
+
+target_link_libraries(
+    multiproc_loopback_test
+    PRIVATE
+        tt_metal
+        test_common_libs
+)
+
+target_include_directories(
+    multiproc_loopback_test
+    PRIVATE
+        "$<TARGET_PROPERTY:Metalium::Metal,INCLUDE_DIRECTORIES>"
+        ${PROJECT_SOURCE_DIR}/tests
+)
+
+set_target_properties(
+    multiproc_loopback_test
+    PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY
+            ${PROJECT_BINARY_DIR}/test/tt_metal/distributed
+)
+
 add_subdirectory(multiprocess)

--- a/tests/tt_metal/distributed/test_multiproc_loopback.cpp
+++ b/tests/tt_metal/distributed/test_multiproc_loopback.cpp
@@ -1,0 +1,188 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//
+// MPI-based cross-process loopback socket test.
+// Rank 0 (launcher): opens device, creates H2D+D2H sockets, launches loopback kernel.
+// Rank 1 (connector): connects to sockets via descriptors exported by the launcher, drives data.
+//
+// Run with: mpirun -np 2 ./multiproc_loopback_test
+//
+
+#include <cstdint>
+#include <iostream>
+#include <numeric>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/distributed_context.hpp>
+#include <tt-metalium/experimental/sockets/h2d_socket.hpp>
+#include <tt-metalium/experimental/sockets/d2h_socket.hpp>
+#include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
+#include "impl/context/metal_context.hpp"
+
+static int g_world_rank = -1;
+static int g_world_size = -1;
+static int test_counter = 0;
+
+namespace tt::tt_metal::distributed {
+namespace {
+
+using namespace tt::tt_metal::distributed::multihost;
+
+constexpr uint32_t NUM_ITERATIONS = 1000;
+
+struct LoopbackConfig {
+    std::size_t fifo_size;
+    std::size_t page_size;
+    std::size_t data_size;
+};
+
+constexpr LoopbackConfig loopback_configs[] = {
+    {1024, 64, 1024},       // No wrap
+    {1024, 64, 32768},      // Even wrap
+    {4096, 1088, 78336},    // Uneven wrap
+    {16512, 1088, 156672},  // Uneven wrap, multiple host pages
+};
+
+const MeshCoreCoord SOCKET_CORE = {MeshCoordinate(0, 0), CoreCoord(0, 0)};
+
+void run_launcher(const std::shared_ptr<MeshDevice>& mesh_device, H2DMode h2d_mode, const LoopbackConfig& cfg) {
+    const auto& socket_core = SOCKET_CORE;
+    std::string h2d_socket_id = fmt::format("test_h2d_xproc_{}", test_counter);
+    std::string d2h_socket_id = fmt::format("test_d2h_xproc_{}", test_counter);
+
+    auto h2d_socket = H2DSocket(mesh_device, socket_core, BufferType::L1, cfg.fifo_size, h2d_mode);
+    h2d_socket.export_descriptor(h2d_socket_id);
+
+    auto d2h_socket = D2HSocket(mesh_device, socket_core, cfg.fifo_size);
+    d2h_socket.export_descriptor(d2h_socket_id);
+
+    auto program = CreateProgram();
+    CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/misc/socket/pcie_socket_loopback.cpp",
+        socket_core.core_coord,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0,
+            .noc = NOC::RISCV_0_default,
+            .compile_args = {
+                static_cast<uint32_t>(h2d_socket.get_config_buffer_address()),
+                static_cast<uint32_t>(d2h_socket.get_config_buffer_address()),
+                static_cast<uint32_t>(cfg.page_size),
+                static_cast<uint32_t>(cfg.data_size),
+                static_cast<uint32_t>(NUM_ITERATIONS),
+                static_cast<uint32_t>(h2d_mode == H2DMode::DEVICE_PULL),
+            }});
+
+    auto mesh_workload = MeshWorkload();
+    mesh_workload.add_program(MeshCoordinateRange(socket_core.device_coord), std::move(program));
+    EnqueueMeshWorkload(mesh_device->mesh_command_queue(), mesh_workload, false);
+    Finish(mesh_device->mesh_command_queue());
+}
+
+void run_connector(const LoopbackConfig& cfg) {
+    std::string h2d_socket_id = fmt::format("test_h2d_xproc_{}", test_counter);
+    std::string d2h_socket_id = fmt::format("test_d2h_xproc_{}", test_counter);
+
+    auto h2d_socket = H2DSocket::connect(h2d_socket_id, 30000);
+    auto d2h_socket = D2HSocket::connect(d2h_socket_id, 30000);
+
+    h2d_socket->set_page_size(cfg.page_size);
+    d2h_socket->set_page_size(cfg.page_size);
+
+    uint32_t page_size_words = cfg.page_size / sizeof(uint32_t);
+    uint32_t data_size_words = cfg.data_size / sizeof(uint32_t);
+    uint32_t num_txns = cfg.data_size / cfg.page_size;
+
+    std::vector<uint32_t> src_vec(data_size_words * NUM_ITERATIONS);
+    std::vector<uint32_t> dst_vec(data_size_words * NUM_ITERATIONS, 0);
+    std::iota(src_vec.begin(), src_vec.end(), 0);
+
+    std::thread write_thread([&]() {
+        for (uint32_t i = 0; i < NUM_ITERATIONS; i++) {
+            for (uint32_t j = 0; j < num_txns; j++) {
+                h2d_socket->write(src_vec.data() + (i * data_size_words) + (j * page_size_words), 1);
+            }
+        }
+    });
+
+    std::thread read_thread([&]() {
+        for (uint32_t i = 0; i < NUM_ITERATIONS; i++) {
+            for (uint32_t j = 0; j < num_txns; j++) {
+                d2h_socket->read(dst_vec.data() + (i * data_size_words) + (j * page_size_words), 1);
+            }
+        }
+    });
+
+    write_thread.join();
+    read_thread.join();
+
+    h2d_socket->barrier();
+    d2h_socket->barrier();
+
+    EXPECT_EQ(src_vec, dst_vec) << "Loopback verification FAILED (fifo=" << cfg.fifo_size << " page=" << cfg.page_size
+                                << " data=" << cfg.data_size << ")";
+}
+
+class MultiProcLoopbackFixture : public MeshDeviceFixtureBase {
+protected:
+    MultiProcLoopbackFixture() : MeshDeviceFixtureBase(Config{.mesh_shape = MeshShape{1, 1}}) {}
+
+    void SetUp() override {
+        ASSERT_EQ(g_world_size, 2) << "This test requires exactly 2 MPI ranks";
+        rank_ = g_world_rank;
+        if (rank_ == 0) {
+            MeshDeviceFixtureBase::SetUp();
+        }
+    }
+
+    void TearDown() override {
+        if (rank_ == 0) {
+            MeshDeviceFixtureBase::TearDown();
+        }
+    }
+
+    int rank_ = -1;
+};
+
+TEST_F(MultiProcLoopbackFixture, CrossProcessLoopback) {
+    if (rank_ == 0) {
+        if (!experimental::GetMemoryPinningParameters(*mesh_device_).can_map_to_noc) {
+            GTEST_SKIP() << "Mapping host memory to NOC is not supported on this system";
+        }
+    }
+
+    for (auto h2d_mode : {H2DMode::HOST_PUSH, H2DMode::DEVICE_PULL}) {
+        for (const auto& cfg : loopback_configs) {
+            if (rank_ == 0) {
+                run_launcher(mesh_device_, h2d_mode, cfg);
+            } else {
+                run_connector(cfg);
+            }
+            test_counter++;
+        }
+    }
+}
+
+}  // namespace
+}  // namespace tt::tt_metal::distributed
+
+int main(int argc, char** argv) {
+    using namespace tt::tt_metal::distributed::multihost;
+
+    DistributedContext::create(argc, argv);
+    const auto& world = DistributedContext::get_current_world();
+    g_world_rank = *world->rank();
+    g_world_size = *world->size();
+
+    auto local_ctx = world->split(Color(g_world_rank), Key(0));
+    DistributedContext::set_current_world(local_ctx);
+
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/tt_metal/api/tt-metalium/experimental/sockets/d2h_socket.hpp
+++ b/tt_metal/api/tt-metalium/experimental/sockets/d2h_socket.hpp
@@ -180,10 +180,11 @@ public:
 
     MeshDevice* get_mesh_device() const;
 
-private:
-    D2HSocket() = default;
     D2HSocket(const D2HSocket&) = delete;
     D2HSocket& operator=(const D2HSocket&) = delete;
+
+private:
+    D2HSocket() = default;
 
     struct PinnedBufferInfo {
         uint32_t pcie_xy_enc = 0;

--- a/tt_metal/api/tt-metalium/experimental/sockets/d2h_socket.hpp
+++ b/tt_metal/api/tt-metalium/experimental/sockets/d2h_socket.hpp
@@ -6,6 +6,7 @@
 
 #include <tt-metalium/experimental/sockets/mesh_socket.hpp>
 #include <tt-metalium/experimental/pinned_memory.hpp>
+#include <memory>
 #include <utility>
 
 namespace tt::umd {
@@ -13,6 +14,9 @@ class TlbWindow;
 }
 
 namespace tt::tt_metal::distributed {
+
+class NamedShm;
+class PCIeCoreWriter;
 
 /**
  * @brief A socket for streaming data from a device core to the host.
@@ -72,11 +76,41 @@ public:
     D2HSocket(const std::shared_ptr<MeshDevice>& mesh_device, const MeshCoreCoord& sender_core, uint32_t fifo_size);
 
     /**
+     * @brief Connects to an existing D2HSocket from another process.
+     *
+     * Waits for the flatbuffer descriptor exported by the owner, opens the named
+     * shared memory, and sets up PCIe write access to the device core via
+     * PCIeCoreWriter (bypasses MetalContext). The returned socket is fully
+     * functional for read() and barrier() operations.
+     *
+     * @param socket_id The identifier used when the owner called export_descriptor().
+     * @param timeout_ms Max time to wait for the descriptor file (default 10s).
+     * @return A connected D2HSocket ready for data transfer.
+     */
+    static std::unique_ptr<D2HSocket> connect(
+        const std::string& socket_id, std::optional<uint32_t> timeout_ms = std::nullopt);
+
+    /**
+     * @brief Exports a descriptor file for cross-process socket attachment.
+     *
+     * Writes a flatbuffer binary to /dev/shm/ containing all metadata needed for
+     * a remote process to connect: shared memory name, buffer layout, device
+     * addresses, pre-resolved core coordinates, and PCIe alignment.
+     *
+     * @param socket_id A user-provided identifier used in the descriptor filename.
+     * @return The full path to the written descriptor file.
+     */
+    std::string export_descriptor(const std::string& socket_id);
+
+    /**
      * @brief Destroys the D2HSocket.
      *
      * Releases pinned memory mappings before freeing the underlying host buffers.
      * This ensures the DMA mappings are properly cleaned up to avoid "File exists"
      * errors when re-pinning memory at the same virtual address.
+     * Owner: waits for device acknowledgement, unpins memory, unlinks shared memory,
+     * removes descriptor file.
+     * Connector: unmaps shared memory via NamedShm destructor.
      */
     ~D2HSocket() noexcept;
 
@@ -95,7 +129,7 @@ public:
      *
      * @return The L1 address of the configuration buffer.
      */
-    uint32_t get_config_buffer_address() const { return config_buffer_->address(); }
+    uint32_t get_config_buffer_address() const { return config_buffer_address_; }
 
     /**
      * @brief Sets the page size for subsequent read operations.
@@ -147,24 +181,28 @@ public:
     MeshDevice* get_mesh_device() const;
 
 private:
-    // Helper struct for pinned buffer NOC address info
+    D2HSocket() = default;
+    D2HSocket(const D2HSocket&) = delete;
+    D2HSocket& operator=(const D2HSocket&) = delete;
+
     struct PinnedBufferInfo {
         uint32_t pcie_xy_enc = 0;
         uint32_t addr_lo = 0;
         uint32_t addr_hi = 0;
     };
 
-    // Initialization helpers
     PinnedBufferInfo init_host_buffer(
         const std::shared_ptr<MeshDevice>& mesh_device,
         const MeshCoordinateRangeSet& device_range,
-        uint32_t pcie_alignment);
+        uint32_t pcie_alignment,
+        const std::string& shm_name);
     void init_config_buffer(const std::shared_ptr<MeshDevice>& mesh_device);
     void write_socket_metadata(
         const std::shared_ptr<MeshDevice>& mesh_device,
         const PinnedBufferInfo& data_info,
         const PinnedBufferInfo& bytes_sent_info);
-    void init_sender_tlb(const std::shared_ptr<MeshDevice>& mesh_device);
+    void init_sender_tlb(
+        const std::shared_ptr<MeshDevice>& mesh_device, std::optional<uint32_t> device_id = std::nullopt);
 
     void wait_for_bytes(uint32_t num_bytes);
     void pop_bytes(uint32_t num_bytes);
@@ -178,11 +216,20 @@ private:
     uint32_t bytes_sent_ = 0;
     uint32_t read_ptr_ = 0;
     uint32_t fifo_curr_size_ = 0;
+    uint32_t config_buffer_address_ = 0;
+    uint32_t pcie_alignment_ = 0;
+    uint32_t bytes_acked_device_offset_ = 0;
     tt::umd::TlbWindow* sender_core_tlb_ = nullptr;
     std::shared_ptr<tt::tt_metal::experimental::PinnedMemory> pinned_memory_ = nullptr;
     std::shared_ptr<uint32_t[]> host_buffer_ = nullptr;
     uint32_t* bytes_sent_ptr_ = nullptr;
     std::function<void(void*, uint32_t, uint64_t)> pcie_writer_ = nullptr;
+    std::unique_ptr<NamedShm> shm_;
+    std::unique_ptr<PCIeCoreWriter> pcie_writer_instance_;
+    MeshDevice* mesh_device_ = nullptr;
+    bool is_owner_ = true;
+    std::string descriptor_path_;
+    bool exported_ = false;
 };
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/api/tt-metalium/experimental/sockets/h2d_socket.hpp
+++ b/tt_metal/api/tt-metalium/experimental/sockets/h2d_socket.hpp
@@ -133,10 +133,11 @@ public:
 
     H2DMode get_h2d_mode() const;
 
-private:
-    H2DSocket() = default;
     H2DSocket(const H2DSocket&) = delete;
     H2DSocket& operator=(const H2DSocket&) = delete;
+
+private:
+    H2DSocket() = default;
 
     struct PinnedBufferInfo {
         uint32_t pcie_xy_enc = 0;

--- a/tt_metal/api/tt-metalium/experimental/sockets/h2d_socket.hpp
+++ b/tt_metal/api/tt-metalium/experimental/sockets/h2d_socket.hpp
@@ -6,6 +6,7 @@
 
 #include <tt-metalium/experimental/sockets/mesh_socket.hpp>
 #include <tt-metalium/experimental/pinned_memory.hpp>
+#include <memory>
 #include <utility>
 
 namespace tt::umd {
@@ -13,6 +14,9 @@ class TlbWindow;
 }
 
 namespace tt::tt_metal::distributed {
+
+class NamedShm;
+class PCIeCoreWriter;
 
 /**
  * @brief Specifies the data transfer mode for Host-to-Device communication.
@@ -28,33 +32,45 @@ enum class H2DMode : uint8_t {
  * H2DSocket provides a FIFO-based interface for transferring data from the host CPU
  * to a specific core on a Tenstorrent device. It supports two transfer modes:
  *
- * - **HOST_PUSH**: The host writes data directly to device L1 memory via TLB-mapped
- *   PCIe writes.
- *
+ * - **HOST_PUSH**: The host writes data directly to device L1 memory via PCIe writes.
  * - **DEVICE_PULL**: The host writes data to pinned host memory, and the device core
  *   pulls data via PCIe NOC reads.
- * Both Modes require vIOMMU to be enabled on the system, based on the current implementation.
+ *
+ * Both modes require vIOMMU to be enabled on the system.
  *
  * The socket uses a circular FIFO buffer with flow control. The host tracks `bytes_sent`
  * and the device kernel updates `bytes_acked` to indicate consumed data. The host blocks
  * on write() if the FIFO is full until the device acknowledges data.
  *
+ * Supports cross-process usage: the owner process creates the socket and exports a
+ * flatbuffer descriptor. A remote process connects via the descriptor using only UMD
+ * (no MetalContext required).
+ *
  * Usage:
  * @code
+ *   // Owner process creates the socket and exports a descriptor
  *   auto socket = H2DSocket(mesh_device, recv_core, BufferType::L1, fifo_size, H2DMode::HOST_PUSH);
- *   socket.set_page_size(page_size);
- *   socket.write(data_ptr, num_pages);
- *   socket.barrier();  // Wait for device to consume all data
+ *   socket.export_descriptor("my_socket");
+ *
+ *   // Remote process connects via socket ID (no MetalContext needed)
+ *   auto remote = H2DSocket::connect("my_socket");
+ *   remote->set_page_size(page_size);
+ *   remote->write(data_ptr, num_pages);
+ *   remote->barrier();
  * @endcode
  */
 class H2DSocket {
 public:
     /**
-     * @brief Constructs an H2DSocket for streaming data to a device core.
+     * @brief Constructs an H2DSocket for streaming data to a device core (owner).
+     *
+     * Allocates named shared memory for host-side buffers, pins it for device DMA,
+     * and sets up device-side config and data buffers. The socket can be exported
+     * via export_descriptor() for cross-process attachment.
      *
      * @param mesh_device The mesh device containing the target core.
      * @param recv_core The target core coordinate (device + core) to receive data.
-     * @param buffer_type Memory type for the device-side FIFO buffer (L1 or DRAM).
+     * @param buffer_type Memory type for the device-side FIFO buffer (currently only L1).
      * @param fifo_size Size of the circular FIFO buffer in bytes. Must be PCIe-aligned.
      * @param h2d_mode Transfer mode: HOST_PUSH or DEVICE_PULL.
      */
@@ -66,57 +82,49 @@ public:
         H2DMode h2d_mode);
 
     /**
+     * @brief Connects to an existing H2DSocket from another process.
+     *
+     * Waits for the flatbuffer descriptor exported by the owner, opens the named
+     * shared memory, and sets up PCIe write access to the device core via
+     * PCIeCoreWriter (bypasses MetalContext). Does not allocate device-side buffers
+     * or pin memory. The returned socket is fully functional for write() and
+     * barrier() operations.
+     *
+     * @param socket_id The identifier used when the owner called export_descriptor().
+     * @param timeout_ms Max time to wait for the descriptor file (default 10s).
+     * @return A connected H2DSocket ready for data transfer.
+     */
+    static std::unique_ptr<H2DSocket> connect(
+        const std::string& socket_id, std::optional<uint32_t> timeout_ms = std::nullopt);
+
+    /**
+     * @brief Exports a descriptor file for cross-process socket attachment.
+     *
+     * Writes a flatbuffer binary to /dev/shm/ containing all metadata needed for
+     * a remote process to connect: shared memory name, buffer layout, device
+     * addresses, pre-resolved core coordinates, and PCIe alignment.
+     *
+     * @param socket_id A user-provided identifier used in the descriptor filename.
+     * @return The full path to the written descriptor file.
+     */
+    std::string export_descriptor(const std::string& socket_id);
+
+    /**
      * @brief Destroys the H2DSocket.
      *
-     * Frees the pinned memory allocated for the socket.
-     * Also issues a barrier to wait for the device to acknowledge all data over the socket.
+     * Owner: waits for device acknowledgement, unpins memory, unlinks shared memory.
+     * Connector: waits for device acknowledgement, unmaps shared memory.
      */
     ~H2DSocket() noexcept;
 
-    /**
-     * @brief Returns the currently configured page size.
-     */
     uint32_t get_page_size() const { return page_size_; }
 
-    /**
-     * @brief Returns the L1 address of the socket configuration buffer on the device.
-     *
-     * This address is passed to the device kernel to access socket metadata.
-     */
-    uint32_t get_config_buffer_address() const { return config_buffer_->address(); }
+    uint32_t get_config_buffer_address() const { return config_buffer_address_; }
 
-    /**
-     * @brief Sets the page size for subsequent write operations.
-     *
-     * The page size determines the granularity of data transfers. Must be PCIe-aligned
-     * and less than or equal to the FIFO size. The write pointer is aligned to the new
-     * page size boundary.
-     *
-     * @param page_size Page size in bytes. Must be PCIe-aligned.
-     */
     void set_page_size(uint32_t page_size);
 
-    /**
-     * @brief Writes data pages to the socket FIFO.
-     *
-     * Blocks if the FIFO does not have enough space, waiting for the device to
-     * acknowledge previously written data. After writing, notifies the device
-     * that new data is available.
-     *
-     * @param data Pointer to the source data buffer.
-     * @param num_pages Number of pages to write.
-     */
     void write(void* data, uint32_t num_pages);
 
-    /**
-     * @brief Blocks until the device has acknowledged all written data.
-     *
-     * Waits until `bytes_acked` equals `bytes_sent`, indicating the device has
-     * consumed all data in the FIFO.
-     *
-     * @param timeout_ms Optional timeout in milliseconds. If specified, the function will throw an exception if the
-     * barrier is not met within the timeout.
-     */
     void barrier(std::optional<uint32_t> timeout_ms = std::nullopt);
 
     std::vector<MeshCoreCoord> get_active_cores() const;
@@ -126,23 +134,27 @@ public:
     H2DMode get_h2d_mode() const;
 
 private:
-    // Helper struct for pinned buffer NOC address info
+    H2DSocket() = default;
+    H2DSocket(const H2DSocket&) = delete;
+    H2DSocket& operator=(const H2DSocket&) = delete;
+
     struct PinnedBufferInfo {
         uint32_t pcie_xy_enc = 0;
         uint32_t addr_lo = 0;
         uint32_t addr_hi = 0;
     };
 
-    // Initialization helpers
     PinnedBufferInfo init_bytes_acked_buffer(
         const std::shared_ptr<MeshDevice>& mesh_device,
         const MeshCoordinateRangeSet& device_range,
-        uint32_t pcie_alignment);
+        uint32_t pcie_alignment,
+        const std::string& shm_name);
 
     PinnedBufferInfo init_host_data_buffer(
         const std::shared_ptr<MeshDevice>& mesh_device,
         const MeshCoordinateRangeSet& device_range,
-        uint32_t pcie_alignment);
+        uint32_t pcie_alignment,
+        const std::string& shm_name);
 
     void init_config_buffer(const std::shared_ptr<MeshDevice>& mesh_device);
     void init_data_buffer(const std::shared_ptr<MeshDevice>& mesh_device, uint32_t pcie_alignment);
@@ -150,7 +162,8 @@ private:
         const std::shared_ptr<MeshDevice>& mesh_device,
         const PinnedBufferInfo& bytes_acked_info,
         const PinnedBufferInfo& data_info);
-    void init_receiver_tlb(const std::shared_ptr<MeshDevice>& mesh_device);
+    void init_receiver_tlb(
+        const std::shared_ptr<MeshDevice>& mesh_device, std::optional<uint32_t> device_id = std::nullopt);
 
     void reserve_bytes(uint32_t num_bytes);
     void push_bytes(uint32_t num_bytes);
@@ -167,12 +180,20 @@ private:
     uint32_t write_ptr_ = 0;
     uint32_t fifo_curr_size_ = 0;
     uint32_t aligned_data_buf_start_ = 0;
+    uint32_t config_buffer_address_ = 0;
+    uint32_t pcie_alignment_ = 0;
     tt::umd::TlbWindow* receiver_core_tlb_ = nullptr;
     std::shared_ptr<tt::tt_metal::experimental::PinnedMemory> pinned_memory_ = nullptr;
     std::shared_ptr<uint32_t[]> host_buffer_ = nullptr;
     uint32_t* bytes_acked_ptr_ = nullptr;
     std::function<void(void*, uint32_t, uint64_t)> pcie_writer = nullptr;
     H2DMode h2d_mode_ = H2DMode::HOST_PUSH;
+    std::unique_ptr<NamedShm> shm_;
+    std::unique_ptr<PCIeCoreWriter> pcie_writer_instance_;
+    MeshDevice* mesh_device_ = nullptr;
+    bool is_owner_ = true;
+    std::string descriptor_path_;
+    bool exported_ = false;
 };
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/CMakeLists.txt
+++ b/tt_metal/distributed/CMakeLists.txt
@@ -3,7 +3,10 @@ include(sources.cmake)
 # Include helper functions and generate headers from flatbuffer schemas
 include(flatbuffers)
 
-set(FLATBUFFER_SCHEMAS ${CMAKE_CURRENT_SOURCE_DIR}/flatbuffer/socket_peer_descriptor.fbs)
+set(FLATBUFFER_SCHEMAS
+    ${CMAKE_CURRENT_SOURCE_DIR}/flatbuffer/socket_peer_descriptor.fbs
+    ${CMAKE_CURRENT_SOURCE_DIR}/flatbuffer/hd_socket_descriptor.fbs
+)
 
 # Check if distributed compute is enabled
 if(NOT DEFINED ENABLE_DISTRIBUTED)

--- a/tt_metal/distributed/d2h_socket.cpp
+++ b/tt_metal/distributed/d2h_socket.cpp
@@ -175,13 +175,11 @@ D2HSocket::D2HSocket(
 }
 
 D2HSocket::~D2HSocket() noexcept {
-    if (!exported_) {
-        // Wait for 1000ms for the device to acknowledge all data over the socket.
-        // This may need to be tuned in future, depending on the application and
-        // the amount of data being sent.
-        // Realistically a hang should not be seen here since most user workloads
-        // synchronize with the device before the application exits and destructors are called.
-        barrier(1000);
+    try {
+        if (!exported_) {
+            barrier(1000);
+        }
+    } catch (...) {
     }
     if (is_owner_) {
         pinned_memory_.reset();

--- a/tt_metal/distributed/d2h_socket.cpp
+++ b/tt_metal/distributed/d2h_socket.cpp
@@ -146,11 +146,13 @@ void D2HSocket::init_sender_tlb(const std::shared_ptr<MeshDevice>& mesh_device, 
 
 D2HSocket::D2HSocket(
     const std::shared_ptr<MeshDevice>& mesh_device, const MeshCoreCoord& sender_core, uint32_t fifo_size) :
-    sender_core_(sender_core), fifo_size_(fifo_size), mesh_device_(mesh_device.get()), is_owner_(true) {
+    sender_core_(sender_core),
+    fifo_size_(fifo_size),
+    pcie_alignment_(MetalContext::instance().hal().get_alignment(HalMemType::HOST)),
+    mesh_device_(mesh_device.get()) {
     MeshCoordinateRangeSet sender_device_range_set;
     sender_device_range_set.merge(MeshCoordinateRange(sender_core_.device_coord));
 
-    pcie_alignment_ = MetalContext::instance().hal().get_alignment(HalMemType::HOST);
     const uint32_t pcie_alignment = pcie_alignment_;
     TT_FATAL(fifo_size_ % pcie_alignment == 0, "FIFO size must be PCIe-aligned.");
 
@@ -307,7 +309,7 @@ std::string D2HSocket::export_descriptor(const std::string& socket_id) {
 
 std::unique_ptr<D2HSocket> D2HSocket::connect(const std::string& socket_id, std::optional<uint32_t> timeout_ms) {
     auto desc = HDSocketDescriptor::wait_and_read(
-        fmt::format("/dev/shm/tt_d2h_{}.bin", socket_id), "d2h", timeout_ms.value_or(10000));
+        descriptor_path_for_socket("d2h", socket_id), "d2h", timeout_ms.value_or(10000));
 
     auto socket = std::unique_ptr<D2HSocket>(new D2HSocket());
     socket->is_owner_ = false;

--- a/tt_metal/distributed/d2h_socket.cpp
+++ b/tt_metal/distributed/d2h_socket.cpp
@@ -4,6 +4,9 @@
 
 #include <tt-metalium/experimental/sockets/d2h_socket.hpp>
 #include "tt_metal/distributed/mesh_socket_utils.hpp"
+#include "tt_metal/distributed/named_shm.hpp"
+#include "tt_metal/distributed/hd_socket_descriptor.hpp"
+#include "tt_metal/distributed/pcie_core_writer.hpp"
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/hw/inc/hostdev/socket.h"
 #include "tt_metal/llrt/tt_cluster.hpp"
@@ -12,30 +15,29 @@
 #include <cstdlib>
 #include <cstring>
 #include <sys/mman.h>
+#include <unistd.h>
 
 namespace tt::tt_metal::distributed {
 
 D2HSocket::PinnedBufferInfo D2HSocket::init_host_buffer(
     const std::shared_ptr<MeshDevice>& mesh_device,
     const MeshCoordinateRangeSet& device_range,
-    uint32_t pcie_alignment) {
-    // Use mmap to ensure page-aligned allocation that won't share pages with other PinnedMemory objects.
-    // This prevents failures when multiple sockets try to pin overlapping page regions to the NOC, since
-    // the driver does not allow this.
+    uint32_t pcie_alignment,
+    const std::string& shm_name) {
     // Buffer layout: [data_region (fifo_size bytes)][bytes_sent (4 bytes)]
     uint32_t total_buffer_size_bytes = fifo_size_ + sizeof(uint32_t);
     uint32_t total_buffer_size_words = total_buffer_size_bytes / sizeof(uint32_t);
-    size_t page_size = sysconf(_SC_PAGESIZE);  // OS Specified Page Size
     // Round up to page boundary
+    size_t page_size = sysconf(_SC_PAGESIZE);
     size_t alloc_size = align(total_buffer_size_bytes, page_size);
-    void* aligned_ptr = mmap(nullptr, alloc_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-    TT_FATAL(aligned_ptr != MAP_FAILED, "Failed to allocate page-aligned memory for D2H socket buffer.");
+
+    shm_ = std::make_unique<NamedShm>(NamedShm::create(shm_name, alloc_size));
+    void* aligned_ptr = shm_->ptr();
     TT_FATAL(
         reinterpret_cast<uintptr_t>(aligned_ptr) % pcie_alignment == 0,
         "System Memory Allocation Error: D2H socket buffer must be aligned to the PCIe alignment.");
-    std::memset(aligned_ptr, 0, total_buffer_size_bytes);
-    host_buffer_ = std::shared_ptr<uint32_t[]>(
-        static_cast<uint32_t*>(aligned_ptr), [alloc_size](uint32_t* p) { munmap(p, alloc_size); });
+    // NamedShm::create zero-initializes the region; no explicit memset needed.
+    host_buffer_ = std::shared_ptr<uint32_t[]>(static_cast<uint32_t*>(aligned_ptr), [](uint32_t*) {});
     bytes_sent_ptr_ = host_buffer_.get() + (fifo_size_ / sizeof(uint32_t));
 
     tt::tt_metal::HostBuffer host_buffer_view(
@@ -102,45 +104,58 @@ void D2HSocket::write_socket_metadata(
         mesh_device->mesh_command_queue(0), config_buffer_, config_data, sender_core_.device_coord, true);
 }
 
-void D2HSocket::init_sender_tlb(const std::shared_ptr<MeshDevice>& mesh_device) {
-    const auto& cluster = MetalContext::instance().get_cluster();
-    auto sender_device_id = mesh_device->get_device(sender_core_.device_coord)->id();
-    auto sender_virtual_core = mesh_device->worker_core_from_logical_core(sender_core_.core_coord);
+void D2HSocket::init_sender_tlb(const std::shared_ptr<MeshDevice>& mesh_device, std::optional<uint32_t> device_id) {
+    TT_FATAL(mesh_device || device_id.has_value(), "Either mesh_device or device_id must be provided.");
 
-    sender_core_tlb_ = cluster.get_driver()
-                           ->get_chip(sender_device_id)
-                           ->get_tlb_manager()
-                           ->get_tlb_window(tt_xy_pair(sender_virtual_core.x, sender_virtual_core.y));
+    uint32_t sender_device_id;
+    CoreCoord sender_virtual_core;
+
+    const auto& cluster = MetalContext::instance().get_cluster();
+
+    if (mesh_device) {
+        sender_device_id = mesh_device->get_device(sender_core_.device_coord)->id();
+        sender_virtual_core = mesh_device->worker_core_from_logical_core(sender_core_.core_coord);
+        sender_core_tlb_ = cluster.get_driver()
+                               ->get_chip(sender_device_id)
+                               ->get_tlb_manager()
+                               ->get_tlb_window(tt_xy_pair(sender_virtual_core.x, sender_virtual_core.y));
+    } else {
+        sender_device_id = device_id.value();
+        sender_virtual_core = cluster.get_virtual_coordinate_from_logical_coordinates(
+            sender_device_id, sender_core_.core_coord, CoreType::TENSIX);
+    }
 
     auto arch = MetalContext::instance().hal().get_arch();
-    if (arch == tt::ARCH::BLACKHOLE) {
+    if (arch == tt::ARCH::BLACKHOLE && mesh_device) {
+        // This process owns a mesh_device and hence has statically initialized TLBs.
         // Entire device address space for Blackhole is statically mapped.
         // Safe to use static TLBs without requiring the driver to do a reconfig.
         pcie_writer_ = [this](void* data, uint32_t num_bytes, uint64_t device_addr) {
             sender_core_tlb_->write_block(device_addr, data, num_bytes);
         };
-    } else if (arch == tt::ARCH::WORMHOLE_B0) {
+    } else {
+        // Mesh Device not owned - use dynamic TLBs through UMD.
         // Wormhole B0 may require the driver to do a reconfig of the TLB for each write,
         // since the device address space is not statically mapped.
         pcie_writer_ = [sender_device_id, sender_virtual_core](void* data, uint32_t num_bytes, uint64_t device_addr) {
             const auto& cluster = MetalContext::instance().get_cluster();
             cluster.write_core(data, num_bytes, tt_cxy_pair(sender_device_id, sender_virtual_core), device_addr);
         };
-    } else {
-        TT_THROW("Unsupported architecture: {}", arch);
     }
 }
 
 D2HSocket::D2HSocket(
     const std::shared_ptr<MeshDevice>& mesh_device, const MeshCoreCoord& sender_core, uint32_t fifo_size) :
-    sender_core_(sender_core), fifo_size_(fifo_size) {
+    sender_core_(sender_core), fifo_size_(fifo_size), mesh_device_(mesh_device.get()), is_owner_(true) {
     MeshCoordinateRangeSet sender_device_range_set;
     sender_device_range_set.merge(MeshCoordinateRange(sender_core_.device_coord));
 
-    const uint32_t pcie_alignment = MetalContext::instance().hal().get_alignment(HalMemType::HOST);
+    pcie_alignment_ = MetalContext::instance().hal().get_alignment(HalMemType::HOST);
+    const uint32_t pcie_alignment = pcie_alignment_;
     TT_FATAL(fifo_size_ % pcie_alignment == 0, "FIFO size must be PCIe-aligned.");
 
-    PinnedBufferInfo data_info = init_host_buffer(mesh_device, sender_device_range_set, pcie_alignment);
+    std::string shm_name = generate_shm_name("d2h");
+    PinnedBufferInfo data_info = init_host_buffer(mesh_device, sender_device_range_set, pcie_alignment, shm_name);
 
     // bytes_sent is located at the end of the data buffer in the same pinned memory
     PinnedBufferInfo bytes_sent_info = data_info;
@@ -151,22 +166,35 @@ D2HSocket::D2HSocket(
     init_config_buffer(mesh_device);
     write_socket_metadata(mesh_device, data_info, bytes_sent_info);
     init_sender_tlb(mesh_device);
+
+    config_buffer_address_ = config_buffer_->address();
+    const SocketSenderSize sender_size;
+    bytes_acked_device_offset_ = sender_size.md_size_bytes;
 }
 
 D2HSocket::~D2HSocket() noexcept {
-    // Wait for 1000ms for the device to acknowledge all data over the socket.
-    // This may need to be tuned in future, depending on the application and
-    // the amount of data being sent.
-    // Realistically a hang should not be seen here since most user workloads
-    // synchronize with the device before the application exits and destructors are called.
-    barrier(1000);
-    // Release pinned memory before the underlying buffer is freed
-    pinned_memory_.reset();
+    if (!exported_) {
+        // Wait for 1000ms for the device to acknowledge all data over the socket.
+        // This may need to be tuned in future, depending on the application and
+        // the amount of data being sent.
+        // Realistically a hang should not be seen here since most user workloads
+        // synchronize with the device before the application exits and destructors are called.
+        barrier(1000);
+    }
+    if (is_owner_) {
+        pinned_memory_.reset();
+        if (shm_) {
+            shm_->unlink();
+        }
+        if (!descriptor_path_.empty()) {
+            std::remove(descriptor_path_.c_str());
+        }
+    }
 }
 
 void D2HSocket::set_page_size(uint32_t page_size) {
-    const auto pcie_alignment = MetalContext::instance().hal().get_alignment(HalMemType::HOST);
-    TT_FATAL(page_size % pcie_alignment == 0, "Page size must be PCIE-aligned.");
+    TT_FATAL(pcie_alignment_ > 0, "PCIe alignment not initialized.");
+    TT_FATAL(page_size % pcie_alignment_ == 0, "Page size must be PCIE-aligned.");
     TT_FATAL(page_size <= fifo_size_, "Page size must be less than or equal to the FIFO size.");
 
     uint32_t next_fifo_rd_ptr = align(read_ptr_, page_size);
@@ -214,8 +242,7 @@ void D2HSocket::pop_bytes(uint32_t num_bytes) {
 }
 
 void D2HSocket::notify_sender() {
-    const SocketSenderSize sender_size;
-    uint32_t bytes_acked_addr = config_buffer_->address() + sender_size.md_size_bytes;
+    uint32_t bytes_acked_addr = config_buffer_address_ + bytes_acked_device_offset_;
     pcie_writer_(&bytes_acked_, sizeof(bytes_acked_), bytes_acked_addr);
     tt_driver_atomics::sfence();
 }
@@ -261,6 +288,44 @@ void D2HSocket::read(void* data, uint32_t num_pages, bool notify_sender) {
 
 std::vector<MeshCoreCoord> D2HSocket::get_active_cores() const { return {sender_core_}; }
 
-MeshDevice* D2HSocket::get_mesh_device() const { return config_buffer_->device(); }
+MeshDevice* D2HSocket::get_mesh_device() const { return mesh_device_; }
+
+std::string D2HSocket::export_descriptor(const std::string& socket_id) {
+    TT_FATAL(is_owner_, "Only the owner process can export a socket descriptor.");
+    TT_FATAL(shm_ && shm_->is_open(), "Cannot export descriptor: shared memory is not initialized.");
+
+    HDSocketDescriptor desc;
+    desc.populate_from_owner("d2h", *shm_, fifo_size_, config_buffer_address_, mesh_device_, sender_core_);
+    desc.bytes_sent_offset = fifo_size_;
+    desc.bytes_acked_device_offset = bytes_acked_device_offset_;
+
+    descriptor_path_ = descriptor_path_for_socket("d2h", socket_id);
+    desc.write_to_file(descriptor_path_);
+    exported_ = true;
+    return descriptor_path_;
+}
+
+std::unique_ptr<D2HSocket> D2HSocket::connect(const std::string& socket_id, std::optional<uint32_t> timeout_ms) {
+    auto desc = HDSocketDescriptor::wait_and_read(
+        fmt::format("/dev/shm/tt_d2h_{}.bin", socket_id), "d2h", timeout_ms.value_or(10000));
+
+    auto socket = std::unique_ptr<D2HSocket>(new D2HSocket());
+    socket->is_owner_ = false;
+    socket->fifo_size_ = desc.fifo_size;
+    socket->config_buffer_address_ = desc.config_buffer_address;
+    socket->pcie_alignment_ = desc.pcie_alignment;
+    socket->sender_core_ = MeshCoreCoord(MeshCoordinate(0, 0), CoreCoord(desc.core_x, desc.core_y));
+    socket->bytes_acked_device_offset_ = desc.bytes_acked_device_offset;
+
+    socket->shm_ = std::make_unique<NamedShm>(NamedShm::open(desc.shm_name, desc.shm_size));
+    socket->host_buffer_ = std::shared_ptr<uint32_t[]>(static_cast<uint32_t*>(socket->shm_->ptr()), [](uint32_t*) {});
+    socket->bytes_sent_ptr_ = static_cast<uint32_t*>(socket->shm_->ptr()) + (desc.bytes_sent_offset / sizeof(uint32_t));
+
+    socket->pcie_writer_instance_ =
+        std::make_unique<PCIeCoreWriter>(desc.device_id, desc.virtual_core_x, desc.virtual_core_y);
+    socket->pcie_writer_ = socket->pcie_writer_instance_->get_pcie_writer();
+
+    return socket;
+}
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/d2h_socket.cpp
+++ b/tt_metal/distributed/d2h_socket.cpp
@@ -12,6 +12,7 @@
 #include "tt_metal/llrt/tt_cluster.hpp"
 #include <tt-metalium/tt_align.hpp>
 #include <umd/device/chip_helpers/tlb_manager.hpp>
+#include <tt-logger/tt-logger.hpp>
 #include <cstdlib>
 #include <cstring>
 #include <sys/mman.h>
@@ -179,7 +180,10 @@ D2HSocket::~D2HSocket() noexcept {
         if (!exported_) {
             barrier(1000);
         }
+    } catch (const std::exception& e) {
+        log_warning(LogMetal, "D2HSocket destructor: barrier failed with exception: {}", e.what());
     } catch (...) {
+        log_warning(LogMetal, "D2HSocket destructor: barrier failed with unknown exception");
     }
     if (is_owner_) {
         pinned_memory_.reset();

--- a/tt_metal/distributed/flatbuffer/hd_socket_descriptor.fbs
+++ b/tt_metal/distributed/flatbuffer/hd_socket_descriptor.fbs
@@ -1,0 +1,36 @@
+namespace tt.tt_metal.distributed.flatbuffer;
+
+table HDSocketDescriptor {
+    // Socket identity
+    socket_type: string;
+
+    // Named shared memory
+    shm_name: string;
+    shm_size: uint64;
+
+    // Buffer layout (offsets within the shm region)
+    data_offset: uint32;
+    bytes_acked_offset: uint32;
+    bytes_sent_offset: uint32;
+
+    // Socket parameters
+    fifo_size: uint32;
+    h2d_mode: uint32;
+
+    // Device-side L1 addresses
+    config_buffer_address: uint32;
+    aligned_data_buf_start: uint32;
+
+    // Core identification
+    device_id: uint32;
+    core_x: uint32;
+    core_y: uint32;
+
+    // Pre-resolved transport info
+    virtual_core_x: uint32;
+    virtual_core_y: uint32;
+    pcie_alignment: uint32;
+    bytes_acked_device_offset: uint32;
+}
+
+root_type HDSocketDescriptor;

--- a/tt_metal/distributed/h2d_socket.cpp
+++ b/tt_metal/distributed/h2d_socket.cpp
@@ -4,6 +4,9 @@
 
 #include <tt-metalium/experimental/sockets/h2d_socket.hpp>
 #include "tt_metal/distributed/mesh_socket_utils.hpp"
+#include "tt_metal/distributed/named_shm.hpp"
+#include "tt_metal/distributed/hd_socket_descriptor.hpp"
+#include "tt_metal/distributed/pcie_core_writer.hpp"
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/hw/inc/hostdev/socket.h"
 #include "tt_metal/llrt/tt_cluster.hpp"
@@ -12,26 +15,23 @@
 #include <cstdlib>
 #include <cstring>
 #include <sys/mman.h>
+#include <unistd.h>
 
 namespace tt::tt_metal::distributed {
 
 H2DSocket::PinnedBufferInfo H2DSocket::init_bytes_acked_buffer(
     const std::shared_ptr<MeshDevice>& mesh_device,
     const MeshCoordinateRangeSet& device_range,
-    uint32_t pcie_alignment) {
-    // Use mmap to ensure page-aligned allocation that won't share pages with other PinnedMemory objects.
-    // This prevents failures when multiple sockets try to pin overlapping page regions to the NOC, since
-    // the driver does not allow this.
-    size_t page_size = sysconf(_SC_PAGESIZE);  // OS Specified Page Size
-    // Allocate a single page for the bytes_acked buffer, since its only 4 bytes.
-    void* aligned_ptr = mmap(nullptr, page_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-    TT_FATAL(aligned_ptr != MAP_FAILED, "Failed to allocate page-aligned memory for bytes_acked buffer.");
+    uint32_t pcie_alignment,
+    const std::string& shm_name) {
+    size_t page_size = sysconf(_SC_PAGESIZE);
+    shm_ = std::make_unique<NamedShm>(NamedShm::create(shm_name, page_size));
+    void* aligned_ptr = shm_->ptr();
     TT_FATAL(
         reinterpret_cast<uintptr_t>(aligned_ptr) % pcie_alignment == 0,
         "System Memory Allocation Error: Bytes_acked buffer must be aligned to the PCIe alignment.");
-    std::memset(aligned_ptr, 0, sizeof(uint32_t));
-    host_buffer_ = std::shared_ptr<uint32_t[]>(
-        static_cast<uint32_t*>(aligned_ptr), [page_size](uint32_t* p) { munmap(p, page_size); });
+    // NamedShm::create zero-initializes the region; no explicit memset needed.
+    host_buffer_ = std::shared_ptr<uint32_t[]>(static_cast<uint32_t*>(aligned_ptr), [](uint32_t*) {});
     tt::tt_metal::HostBuffer bytes_acked_buffer_view(
         tt::stl::Span<uint32_t>(host_buffer_.get(), 1), tt::tt_metal::MemoryPin(host_buffer_));
     pinned_memory_ =
@@ -52,23 +52,18 @@ H2DSocket::PinnedBufferInfo H2DSocket::init_bytes_acked_buffer(
 H2DSocket::PinnedBufferInfo H2DSocket::init_host_data_buffer(
     const std::shared_ptr<MeshDevice>& mesh_device,
     const MeshCoordinateRangeSet& device_range,
-    uint32_t pcie_alignment) {
-    // Use mmap to ensure page-aligned allocation that won't share pages with other PinnedMemory objects.
-    // This prevents failures when multiple sockets try to pin overlapping page regions to the NOC, since
-    // the driver does not allow this.
+    uint32_t pcie_alignment,
+    const std::string& shm_name) {
     uint32_t host_buffer_size_bytes = fifo_size_ + sizeof(uint32_t);
     uint32_t host_buffer_size_words = host_buffer_size_bytes / sizeof(uint32_t);
-    size_t page_size = sysconf(_SC_PAGESIZE);  // OS Specified Page Size
-    // Round up to page boundary
+    size_t page_size = sysconf(_SC_PAGESIZE);
     size_t alloc_size = align(host_buffer_size_bytes, page_size);
-    void* aligned_ptr = mmap(nullptr, alloc_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-    TT_FATAL(aligned_ptr != MAP_FAILED, "Failed to allocate page-aligned memory for host data buffer.");
+    shm_ = std::make_unique<NamedShm>(NamedShm::create(shm_name, alloc_size));
+    void* aligned_ptr = shm_->ptr();
     TT_FATAL(
         reinterpret_cast<uintptr_t>(aligned_ptr) % pcie_alignment == 0,
         "System Memory Allocation Error: Host data buffer must be aligned to the PCIe alignment.");
-    std::memset(aligned_ptr, 0, host_buffer_size_bytes);
-    host_buffer_ = std::shared_ptr<uint32_t[]>(
-        static_cast<uint32_t*>(aligned_ptr), [alloc_size](uint32_t* p) { munmap(p, alloc_size); });
+    host_buffer_ = std::shared_ptr<uint32_t[]>(static_cast<uint32_t*>(aligned_ptr), [](uint32_t*) {});
 
     tt::tt_metal::HostBuffer host_buffer_view(
         tt::stl::Span<uint32_t>(host_buffer_.get(), host_buffer_size_words), tt::tt_metal::MemoryPin(host_buffer_));
@@ -158,30 +153,42 @@ void H2DSocket::write_socket_metadata(
         mesh_device->mesh_command_queue(0), config_buffer_, config_data, recv_core_.device_coord, true);
 }
 
-void H2DSocket::init_receiver_tlb(const std::shared_ptr<MeshDevice>& mesh_device) {
+void H2DSocket::init_receiver_tlb(const std::shared_ptr<MeshDevice>& mesh_device, std::optional<uint32_t> device_id) {
+    TT_FATAL(mesh_device || device_id.has_value(), "Either mesh_device or device_id must be provided.");
+
+    uint32_t recv_device_id;
+    CoreCoord recv_virtual_core;
+
     const auto& cluster = MetalContext::instance().get_cluster();
-    auto recv_device_id = mesh_device->get_device(recv_core_.device_coord)->id();
-    auto recv_virtual_core = mesh_device->worker_core_from_logical_core(recv_core_.core_coord);
-    receiver_core_tlb_ = cluster.get_driver()
-                             ->get_chip(recv_device_id)
-                             ->get_tlb_manager()
-                             ->get_tlb_window(tt_xy_pair(recv_virtual_core.x, recv_virtual_core.y));
+
+    if (mesh_device) {
+        recv_device_id = mesh_device->get_device(recv_core_.device_coord)->id();
+        recv_virtual_core = mesh_device->worker_core_from_logical_core(recv_core_.core_coord);
+        receiver_core_tlb_ = cluster.get_driver()
+                                 ->get_chip(recv_device_id)
+                                 ->get_tlb_manager()
+                                 ->get_tlb_window(tt_xy_pair(recv_virtual_core.x, recv_virtual_core.y));
+    } else {
+        recv_device_id = device_id.value();
+        recv_virtual_core = cluster.get_virtual_coordinate_from_logical_coordinates(
+            recv_device_id, recv_core_.core_coord, CoreType::TENSIX);
+    }
     auto arch = MetalContext::instance().hal().get_arch();
-    if (arch == tt::ARCH::BLACKHOLE) {
+    if (arch == tt::ARCH::BLACKHOLE && mesh_device) {
+        // This process owns a mesh_device and hence has statically initialized TLBs.
         // Entire device address space for Blackhole is statically mapped.
         // Safe to use static TLBs without requiring the driver to do a reconfig.
         pcie_writer = [&](void* data, uint32_t num_bytes, uint64_t device_addr) {
             receiver_core_tlb_->write_block(device_addr, data, num_bytes);
         };
-    } else if (arch == tt::ARCH::WORMHOLE_B0) {
+    } else {
+        // Mesh Device not owned - use dynamic TLBs through UMD.
         // Wormhole B0 may require the driver to do a reconfig of the TLB for each write,
         // since the device address space is not statically mapped.
         pcie_writer = [recv_device_id, recv_virtual_core](void* data, uint32_t num_bytes, uint64_t device_addr) {
             const auto& cluster = MetalContext::instance().get_cluster();
             cluster.write_core(data, num_bytes, tt_cxy_pair(recv_device_id, recv_virtual_core), device_addr);
         };
-    } else {
-        TT_THROW("Unsupported architecture: {}", arch);
     }
 }
 
@@ -195,21 +202,24 @@ H2DSocket::H2DSocket(
     buffer_type_(buffer_type),
     fifo_size_(fifo_size),
     pinned_memory_(nullptr),
-    h2d_mode_(h2d_mode) {
+    h2d_mode_(h2d_mode),
+    mesh_device_(mesh_device.get()),
+    is_owner_(true) {
     MeshCoordinateRangeSet recv_device_range_set;
     recv_device_range_set.merge(MeshCoordinateRange(recv_core_.device_coord));
 
-    const uint32_t pcie_alignment = MetalContext::instance().hal().get_alignment(HalMemType::HOST);
+    pcie_alignment_ = MetalContext::instance().hal().get_alignment(HalMemType::HOST);
+    const uint32_t pcie_alignment = pcie_alignment_;
     TT_FATAL(fifo_size_ % pcie_alignment == 0, "FIFO size must be PCIE-aligned.");
     TT_FATAL(buffer_type_ == BufferType::L1, "H2D sockets currently only support data buffers in SRAM.");
+
+    std::string shm_name = generate_shm_name("h2d");
 
     PinnedBufferInfo bytes_acked_info = {};
     PinnedBufferInfo data_info = {};
     if (h2d_mode_ == H2DMode::DEVICE_PULL) {
-        // Allocate host data buffer and bytes_acked buffer in the same pinned memory.
-        data_info = init_host_data_buffer(mesh_device, recv_device_range_set, pcie_alignment);
+        data_info = init_host_data_buffer(mesh_device, recv_device_range_set, pcie_alignment, shm_name);
         bytes_acked_info = data_info;
-        // Bytes acked buffer is located after the data buffer in the same pinned memory.
         auto bytes_acked_addr = (static_cast<uint64_t>(data_info.addr_hi) << 32 | data_info.addr_lo) + fifo_size_;
         bytes_acked_info.addr_hi = static_cast<uint32_t>(bytes_acked_addr >> 32);
         bytes_acked_info.addr_lo = static_cast<uint32_t>(bytes_acked_addr & 0xFFFFFFFFull);
@@ -218,8 +228,7 @@ H2DSocket::H2DSocket(
             bytes_acked_info.pcie_xy_enc == data_info.pcie_xy_enc,
             "Bytes_acked and data pinned memory must be mapped to the same PCIe core.");
     } else {
-        // Dedicate a separate pinned memory for the bytes_acked buffer.
-        bytes_acked_info = init_bytes_acked_buffer(mesh_device, recv_device_range_set, pcie_alignment);
+        bytes_acked_info = init_bytes_acked_buffer(mesh_device, recv_device_range_set, pcie_alignment, shm_name);
         bytes_acked_ptr_ = host_buffer_.get();
     }
 
@@ -227,16 +236,28 @@ H2DSocket::H2DSocket(
     init_data_buffer(mesh_device, pcie_alignment);
     write_socket_metadata(mesh_device, bytes_acked_info, data_info);
     init_receiver_tlb(mesh_device);
+
+    config_buffer_address_ = config_buffer_->address();
 }
 
 H2DSocket::~H2DSocket() noexcept {
-    // Wait for 1000ms for the device to acknowledge all data over the socket.
-    // This may need to be tuned in future, depending on the application and
-    // the amount of data being sent.
-    // Realistically a hang should not be seen here since most user workloads
-    // synchronize with the device before the application exits and destructors are called.
-    barrier(1000);
-    pinned_memory_.reset();
+    if (!exported_) {
+        // Wait for 1000ms for the device to acknowledge all data over the socket.
+        // This may need to be tuned in future, depending on the application and
+        // the amount of data being sent.
+        // Realistically a hang should not be seen here since most user workloads
+        // synchronize with the device before the application exits and destructors are called.
+        barrier(1000);
+    }
+    if (is_owner_) {
+        pinned_memory_.reset();
+        if (shm_) {
+            shm_->unlink();
+        }
+        if (!descriptor_path_.empty()) {
+            std::remove(descriptor_path_.c_str());
+        }
+    }
 }
 
 void H2DSocket::reserve_bytes(uint32_t num_bytes) {
@@ -260,14 +281,14 @@ void H2DSocket::push_bytes(uint32_t num_bytes) {
 }
 
 void H2DSocket::notify_receiver() {
-    uint32_t bytes_sent_addr = config_buffer_->address() + offsetof(receiver_socket_md, bytes_sent);
+    uint32_t bytes_sent_addr = config_buffer_address_ + offsetof(receiver_socket_md, bytes_sent);
     pcie_writer(&bytes_sent_, sizeof(bytes_sent_), bytes_sent_addr);
     tt_driver_atomics::sfence();
 }
 
 void H2DSocket::set_page_size(uint32_t page_size) {
-    const auto pcie_alignment = MetalContext::instance().hal().get_alignment(HalMemType::HOST);
-    TT_FATAL(page_size % pcie_alignment == 0, "Page size must be PCIE-aligned.");
+    TT_FATAL(pcie_alignment_ > 0, "PCIe alignment not initialized.");
+    TT_FATAL(page_size % pcie_alignment_ == 0, "Page size must be PCIE-aligned.");
     TT_FATAL(page_size <= fifo_size_, "Page size must be less than or equal to the FIFO size.");
 
     uint32_t next_fifo_wr_ptr = align(write_ptr_, page_size);
@@ -323,8 +344,54 @@ void H2DSocket::write(void* data, uint32_t num_pages) {
 
 std::vector<MeshCoreCoord> H2DSocket::get_active_cores() const { return {recv_core_}; }
 
-MeshDevice* H2DSocket::get_mesh_device() const { return config_buffer_->device(); }
+MeshDevice* H2DSocket::get_mesh_device() const { return mesh_device_; }
 
 H2DMode H2DSocket::get_h2d_mode() const { return h2d_mode_; }
+
+std::string H2DSocket::export_descriptor(const std::string& socket_id) {
+    TT_FATAL(is_owner_, "Only the owner process can export a socket descriptor.");
+    TT_FATAL(shm_ && shm_->is_open(), "Cannot export descriptor: shared memory is not initialized.");
+
+    HDSocketDescriptor desc;
+    desc.populate_from_owner("h2d", *shm_, fifo_size_, config_buffer_address_, mesh_device_, recv_core_);
+    desc.bytes_acked_offset = (h2d_mode_ == H2DMode::DEVICE_PULL) ? fifo_size_ : 0;
+    desc.h2d_mode = static_cast<uint32_t>(h2d_mode_);
+    desc.aligned_data_buf_start = aligned_data_buf_start_;
+
+    descriptor_path_ = descriptor_path_for_socket("h2d", socket_id);
+    desc.write_to_file(descriptor_path_);
+    exported_ = true;
+    return descriptor_path_;
+}
+
+std::unique_ptr<H2DSocket> H2DSocket::connect(const std::string& socket_id, std::optional<uint32_t> timeout_ms) {
+    auto desc = HDSocketDescriptor::wait_and_read(
+        descriptor_path_for_socket("h2d", socket_id), "h2d", timeout_ms.value_or(10000));
+
+    auto socket = std::unique_ptr<H2DSocket>(new H2DSocket());
+    socket->is_owner_ = false;
+    socket->fifo_size_ = desc.fifo_size;
+    socket->config_buffer_address_ = desc.config_buffer_address;
+    socket->pcie_alignment_ = desc.pcie_alignment;
+    socket->recv_core_ = MeshCoreCoord(MeshCoordinate(0, 0), CoreCoord(desc.core_x, desc.core_y));
+    socket->h2d_mode_ = static_cast<H2DMode>(desc.h2d_mode);
+    socket->aligned_data_buf_start_ = desc.aligned_data_buf_start;
+    socket->shm_ = std::make_unique<NamedShm>(NamedShm::open(desc.shm_name, desc.shm_size));
+
+    if (socket->h2d_mode_ == H2DMode::DEVICE_PULL) {
+        socket->host_buffer_ =
+            std::shared_ptr<uint32_t[]>(static_cast<uint32_t*>(socket->shm_->ptr()), [](uint32_t*) {});
+        socket->bytes_acked_ptr_ =
+            static_cast<uint32_t*>(socket->shm_->ptr()) + (desc.bytes_acked_offset / sizeof(uint32_t));
+    } else {
+        socket->bytes_acked_ptr_ = static_cast<uint32_t*>(socket->shm_->ptr());
+    }
+
+    socket->pcie_writer_instance_ =
+        std::make_unique<PCIeCoreWriter>(desc.device_id, desc.virtual_core_x, desc.virtual_core_y);
+    socket->pcie_writer = socket->pcie_writer_instance_->get_pcie_writer();
+
+    return socket;
+}
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/h2d_socket.cpp
+++ b/tt_metal/distributed/h2d_socket.cpp
@@ -12,6 +12,7 @@
 #include "tt_metal/llrt/tt_cluster.hpp"
 #include <tt-metalium/tt_align.hpp>
 #include <umd/device/chip_helpers/tlb_manager.hpp>
+#include <tt-logger/tt-logger.hpp>
 #include <cstdlib>
 #include <cstring>
 #include <sys/mman.h>
@@ -244,7 +245,10 @@ H2DSocket::~H2DSocket() noexcept {
         if (!exported_) {
             barrier(1000);
         }
+    } catch (const std::exception& e) {
+        log_warning(LogMetal, "H2DSocket destructor: barrier failed with exception: {}", e.what());
     } catch (...) {
+        log_warning(LogMetal, "H2DSocket destructor: barrier failed with unknown exception");
     }
     if (is_owner_) {
         pinned_memory_.reset();

--- a/tt_metal/distributed/h2d_socket.cpp
+++ b/tt_metal/distributed/h2d_socket.cpp
@@ -240,13 +240,11 @@ H2DSocket::H2DSocket(
 }
 
 H2DSocket::~H2DSocket() noexcept {
-    if (!exported_) {
-        // Wait for 1000ms for the device to acknowledge all data over the socket.
-        // This may need to be tuned in future, depending on the application and
-        // the amount of data being sent.
-        // Realistically a hang should not be seen here since most user workloads
-        // synchronize with the device before the application exits and destructors are called.
-        barrier(1000);
+    try {
+        if (!exported_) {
+            barrier(1000);
+        }
+    } catch (...) {
     }
     if (is_owner_) {
         pinned_memory_.reset();

--- a/tt_metal/distributed/h2d_socket.cpp
+++ b/tt_metal/distributed/h2d_socket.cpp
@@ -201,14 +201,13 @@ H2DSocket::H2DSocket(
     recv_core_(recv_core),
     buffer_type_(buffer_type),
     fifo_size_(fifo_size),
+    pcie_alignment_(MetalContext::instance().hal().get_alignment(HalMemType::HOST)),
     pinned_memory_(nullptr),
     h2d_mode_(h2d_mode),
-    mesh_device_(mesh_device.get()),
-    is_owner_(true) {
+    mesh_device_(mesh_device.get()) {
     MeshCoordinateRangeSet recv_device_range_set;
     recv_device_range_set.merge(MeshCoordinateRange(recv_core_.device_coord));
 
-    pcie_alignment_ = MetalContext::instance().hal().get_alignment(HalMemType::HOST);
     const uint32_t pcie_alignment = pcie_alignment_;
     TT_FATAL(fifo_size_ % pcie_alignment == 0, "FIFO size must be PCIE-aligned.");
     TT_FATAL(buffer_type_ == BufferType::L1, "H2D sockets currently only support data buffers in SRAM.");

--- a/tt_metal/distributed/hd_socket_descriptor.cpp
+++ b/tt_metal/distributed/hd_socket_descriptor.cpp
@@ -10,7 +10,10 @@
 #include <tt-metalium/distributed.hpp>
 #include "impl/context/metal_context.hpp"
 
+#include <cerrno>
 #include <chrono>
+#include <cstdio>
+#include <cstring>
 #include <filesystem>
 #include <fstream>
 #include <thread>
@@ -65,24 +68,33 @@ void HDSocketDescriptor::write_to_file(const std::string& path) const {
         bytes_acked_device_offset);
     builder.Finish(fb_desc);
 
-    std::ofstream ofs(path, std::ios::binary);
-    TT_FATAL(ofs.is_open(), "Failed to open descriptor file for writing: {}", path);
+    std::string tmp_path = path + ".tmp";
+    std::ofstream ofs(tmp_path, std::ios::binary);
+    TT_FATAL(ofs.is_open(), "Failed to open descriptor file for writing: {}", tmp_path);
     ofs.write(reinterpret_cast<const char*>(builder.GetBufferPointer()), builder.GetSize());
     ofs.close();
-    TT_FATAL(!ofs.fail(), "Failed to write descriptor file: {}", path);
+    TT_FATAL(!ofs.fail(), "Failed to write descriptor file: {}", tmp_path);
+    TT_FATAL(
+        std::rename(tmp_path.c_str(), path.c_str()) == 0,
+        "Failed to rename descriptor file from {} to {}: {}",
+        tmp_path,
+        path,
+        std::strerror(errno));
 }
 
 HDSocketDescriptor HDSocketDescriptor::read_from_file(const std::string& path) {
     std::ifstream ifs(path, std::ios::binary | std::ios::ate);
     TT_FATAL(ifs.is_open(), "Failed to open descriptor file for reading: {}", path);
 
-    auto size = ifs.tellg();
+    auto pos = ifs.tellg();
+    TT_FATAL(pos > 0, "Descriptor file is empty or unreadable: {}", path);
+    auto size = static_cast<std::size_t>(pos);
     ifs.seekg(0, std::ios::beg);
     std::vector<uint8_t> buf(size);
     ifs.read(reinterpret_cast<char*>(buf.data()), size);
     TT_FATAL(!ifs.fail(), "Failed to read descriptor file: {}", path);
 
-    auto* fb = flatbuffer::GetHDSocketDescriptor(buf.data());
+    const auto* fb = flatbuffer::GetHDSocketDescriptor(buf.data());
     TT_FATAL(fb, "Failed to parse flatbuffer descriptor from: {}", path);
 
     HDSocketDescriptor desc;

--- a/tt_metal/distributed/hd_socket_descriptor.cpp
+++ b/tt_metal/distributed/hd_socket_descriptor.cpp
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_metal/distributed/hd_socket_descriptor.hpp"
+#include "tt_metal/distributed/named_shm.hpp"
+#include "hd_socket_descriptor_generated.h"
+
+#include <tt_stl/assert.hpp>
+#include <tt-metalium/distributed.hpp>
+#include "impl/context/metal_context.hpp"
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <thread>
+
+namespace tt::tt_metal::distributed {
+
+void HDSocketDescriptor::populate_from_owner(
+    const std::string& type,
+    const NamedShm& shm,
+    uint32_t fifo_size_arg,
+    uint32_t config_buffer_address_arg,
+    MeshDevice* mesh_device,
+    const MeshCoreCoord& core) {
+    socket_type = type;
+    shm_name = shm.name();
+    shm_size = shm.size();
+    data_offset = 0;
+    fifo_size = fifo_size_arg;
+    config_buffer_address = config_buffer_address_arg;
+    device_id = static_cast<uint32_t>(mesh_device->get_device(core.device_coord)->id());
+    core_x = core.core_coord.x;
+    core_y = core.core_coord.y;
+    auto vc = mesh_device->worker_core_from_logical_core(core.core_coord);
+    virtual_core_x = vc.x;
+    virtual_core_y = vc.y;
+    pcie_alignment = MetalContext::instance().hal().get_alignment(HalMemType::HOST);
+}
+
+void HDSocketDescriptor::write_to_file(const std::string& path) const {
+    flatbuffers::FlatBufferBuilder builder(512);
+    auto fb_socket_type = builder.CreateString(socket_type);
+    auto fb_shm_name = builder.CreateString(shm_name);
+
+    auto fb_desc = flatbuffer::CreateHDSocketDescriptor(
+        builder,
+        fb_socket_type,
+        fb_shm_name,
+        shm_size,
+        data_offset,
+        bytes_acked_offset,
+        bytes_sent_offset,
+        fifo_size,
+        h2d_mode,
+        config_buffer_address,
+        aligned_data_buf_start,
+        device_id,
+        core_x,
+        core_y,
+        virtual_core_x,
+        virtual_core_y,
+        pcie_alignment,
+        bytes_acked_device_offset);
+    builder.Finish(fb_desc);
+
+    std::ofstream ofs(path, std::ios::binary);
+    TT_FATAL(ofs.is_open(), "Failed to open descriptor file for writing: {}", path);
+    ofs.write(reinterpret_cast<const char*>(builder.GetBufferPointer()), builder.GetSize());
+    ofs.close();
+    TT_FATAL(!ofs.fail(), "Failed to write descriptor file: {}", path);
+}
+
+HDSocketDescriptor HDSocketDescriptor::read_from_file(const std::string& path) {
+    std::ifstream ifs(path, std::ios::binary | std::ios::ate);
+    TT_FATAL(ifs.is_open(), "Failed to open descriptor file for reading: {}", path);
+
+    auto size = ifs.tellg();
+    ifs.seekg(0, std::ios::beg);
+    std::vector<uint8_t> buf(size);
+    ifs.read(reinterpret_cast<char*>(buf.data()), size);
+    TT_FATAL(!ifs.fail(), "Failed to read descriptor file: {}", path);
+
+    auto* fb = flatbuffer::GetHDSocketDescriptor(buf.data());
+    TT_FATAL(fb, "Failed to parse flatbuffer descriptor from: {}", path);
+
+    HDSocketDescriptor desc;
+    desc.socket_type = fb->socket_type() ? fb->socket_type()->str() : "";
+    desc.shm_name = fb->shm_name() ? fb->shm_name()->str() : "";
+    desc.shm_size = fb->shm_size();
+    desc.data_offset = fb->data_offset();
+    desc.bytes_acked_offset = fb->bytes_acked_offset();
+    desc.bytes_sent_offset = fb->bytes_sent_offset();
+    desc.fifo_size = fb->fifo_size();
+    desc.h2d_mode = fb->h2d_mode();
+    desc.config_buffer_address = fb->config_buffer_address();
+    desc.aligned_data_buf_start = fb->aligned_data_buf_start();
+    desc.device_id = fb->device_id();
+    desc.core_x = fb->core_x();
+    desc.core_y = fb->core_y();
+    desc.virtual_core_x = fb->virtual_core_x();
+    desc.virtual_core_y = fb->virtual_core_y();
+    desc.pcie_alignment = fb->pcie_alignment();
+    desc.bytes_acked_device_offset = fb->bytes_acked_device_offset();
+
+    return desc;
+}
+
+HDSocketDescriptor HDSocketDescriptor::wait_and_read(
+    const std::string& descriptor_path, const std::string& expected_type, uint32_t timeout_ms) {
+    auto start_time = std::chrono::high_resolution_clock::now();
+    while (!std::filesystem::exists(descriptor_path)) {
+        auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                              std::chrono::high_resolution_clock::now() - start_time)
+                              .count();
+        if (elapsed_ms > timeout_ms) {
+            TT_THROW("Timeout waiting for descriptor file to be created: {}", descriptor_path);
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    auto desc = read_from_file(descriptor_path);
+    TT_FATAL(
+        desc.socket_type == expected_type,
+        "Descriptor type mismatch: expected '{}', got '{}'",
+        expected_type,
+        desc.socket_type);
+    return desc;
+}
+
+}  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/hd_socket_descriptor.hpp
+++ b/tt_metal/distributed/hd_socket_descriptor.hpp
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <fmt/format.h>
+#include <tt-metalium/experimental/sockets/mesh_socket.hpp>
+
+namespace tt::tt_metal::distributed {
+
+class MeshDevice;
+class NamedShm;
+
+/**
+ * @brief Serializable descriptor for cross-process H2D/D2H socket attachment.
+ *
+ * The owner process creates an H2D or D2H socket and exports a flatbuffer
+ * descriptor containing everything a remote process needs to attach: named
+ * shared memory identifiers, buffer layout, device-side L1 addresses, and
+ * pre-resolved core coordinates for PCIe writes.
+ *
+ * The connecting process reads this descriptor, opens the named shared memory,
+ * and reconstructs the host-side socket state without re-allocating device
+ * resources or initializing MetalContext.
+ */
+struct HDSocketDescriptor {
+    // --- Socket identity ---
+    std::string socket_type;  // "h2d" or "d2h"
+
+    // --- Named shared memory ---
+    std::string shm_name;   // POSIX shm name (e.g. "/tt_h2d_<id>")
+    uint64_t shm_size = 0;  // Total mmap size in bytes
+
+    // --- Buffer layout (offsets within the shm region) ---
+    uint32_t data_offset = 0;         // Offset to FIFO data region (always 0 for current layouts)
+    uint32_t bytes_acked_offset = 0;  // H2D: offset of bytes_acked (HOST_PUSH: 0, DEVICE_PULL: fifo_size)
+    uint32_t bytes_sent_offset = 0;   // D2H: offset of bytes_sent (fifo_size)
+
+    // --- Socket parameters ---
+    uint32_t fifo_size = 0;
+    uint32_t h2d_mode = 0;  // H2DMode as uint8_t (H2D only; 0=HOST_PUSH, 1=DEVICE_PULL)
+
+    // --- Device-side L1 addresses (already allocated by owner) ---
+    uint32_t config_buffer_address = 0;   // L1 address of the socket config buffer
+    uint32_t aligned_data_buf_start = 0;  // H2D only: L1 address of the aligned data buffer
+
+    // --- Core identification (for TLB setup by the connector) ---
+    uint32_t device_id = 0;  // Physical chip ID
+    uint32_t core_x = 0;     // Logical core coordinate X
+    uint32_t core_y = 0;     // Logical core coordinate Y
+
+    // --- Pre-resolved transport info (connector uses these to bypass MetalContext) ---
+    uint32_t virtual_core_x = 0;             // Virtual (translated) core coordinate X
+    uint32_t virtual_core_y = 0;             // Virtual (translated) core coordinate Y
+    uint32_t pcie_alignment = 0;             // PCIe page alignment in bytes (e.g. 64 for Blackhole)
+    uint32_t bytes_acked_device_offset = 0;  // D2H: L1 offset of bytes_acked within config buffer
+
+    /**
+     * @brief Populate common fields from the owner socket's state.
+     *
+     * Sets shm_name, shm_size, fifo_size, config_buffer_address, and resolves
+     * device_id, core coordinates (logical + virtual), and pcie_alignment from
+     * the mesh device. Called by the owner during export_descriptor().
+     */
+    void populate_from_owner(
+        const std::string& type,
+        const NamedShm& shm,
+        uint32_t fifo_size,
+        uint32_t config_buffer_address,
+        MeshDevice* mesh_device,
+        const MeshCoreCoord& core);
+
+    /**
+     * @brief Serialize this descriptor to a flatbuffer file.
+     * @param path File path to write (e.g. "/dev/shm/tt_socket_<id>.bin").
+     */
+    void write_to_file(const std::string& path) const;
+
+    /**
+     * @brief Deserialize a descriptor from a flatbuffer file.
+     * @param path File path to read.
+     * @return Populated HDSocketDescriptor.
+     */
+    static HDSocketDescriptor read_from_file(const std::string& path);
+
+    /**
+     * @brief Wait for a descriptor file to appear and read it.
+     * @param descriptor_path Full path to the descriptor file.
+     * @param expected_type Expected socket_type ("h2d" or "d2h").
+     * @param timeout_ms Max wait time in milliseconds (default 10000).
+     * @return Populated HDSocketDescriptor.
+     */
+    static HDSocketDescriptor wait_and_read(
+        const std::string& descriptor_path, const std::string& expected_type, uint32_t timeout_ms = 10000);
+};
+
+inline std::string descriptor_path_for_socket(const std::string& type, const std::string& socket_id) {
+    return fmt::format("/dev/shm/tt_{}_{}.bin", type, socket_id);
+}
+
+}  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/named_shm.cpp
+++ b/tt_metal/distributed/named_shm.cpp
@@ -78,6 +78,15 @@ NamedShm NamedShm::open(const std::string& name, size_t size) {
     int fd = shm_open(name.c_str(), O_RDWR, 0600);
     TT_FATAL(fd != -1, "shm_open(open) failed for '{}': {}", name, std::strerror(errno));
 
+    struct stat st;
+    TT_FATAL(fstat(fd, &st) == 0, "fstat failed for '{}': {}", name, std::strerror(errno));
+    TT_FATAL(
+        static_cast<size_t>(st.st_size) >= size,
+        "Shared memory '{}' backing size ({}) is smaller than requested size ({})",
+        name,
+        st.st_size,
+        size);
+
     void* ptr = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
     int mmap_errno = errno;
     ::close(fd);

--- a/tt_metal/distributed/named_shm.cpp
+++ b/tt_metal/distributed/named_shm.cpp
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_metal/distributed/named_shm.hpp"
+
+#include <tt_stl/assert.hpp>
+#include <fmt/format.h>
+
+#include <atomic>
+#include <cerrno>
+#include <cstring>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+namespace tt::tt_metal::distributed {
+
+NamedShm::NamedShm(const std::string& name, void* ptr, size_t size) : name_(name), ptr_(ptr), size_(size) {}
+
+NamedShm::~NamedShm() noexcept { close(); }
+
+NamedShm::NamedShm(NamedShm&& other) noexcept : name_(std::move(other.name_)), ptr_(other.ptr_), size_(other.size_) {
+    other.ptr_ = nullptr;
+    other.size_ = 0;
+}
+
+NamedShm& NamedShm::operator=(NamedShm&& other) noexcept {
+    if (this != &other) {
+        close();
+        name_ = std::move(other.name_);
+        ptr_ = other.ptr_;
+        size_ = other.size_;
+        other.ptr_ = nullptr;
+        other.size_ = 0;
+    }
+    return *this;
+}
+
+NamedShm NamedShm::create(const std::string& name, size_t size) {
+    TT_FATAL(!name.empty() && name[0] == '/', "POSIX shm name must start with '/': {}", name);
+    TT_FATAL(size > 0, "Shared memory size must be > 0");
+
+    int fd = shm_open(name.c_str(), O_CREAT | O_EXCL | O_RDWR, 0600);
+    TT_FATAL(
+        fd != -1,
+        "shm_open(create) failed for '{}': {}. If a stale shm object exists, remove it with shm_unlink or delete "
+        "/dev/shm{}.",
+        name,
+        std::strerror(errno),
+        name);
+
+    int rc = ftruncate(fd, static_cast<off_t>(size));
+    if (rc == -1) {
+        int saved_errno = errno;
+        ::close(fd);
+        shm_unlink(name.c_str());
+        TT_THROW("ftruncate failed for '{}': {}", name, std::strerror(saved_errno));
+    }
+
+    void* ptr = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    int mmap_errno = errno;
+    ::close(fd);
+    if (ptr == MAP_FAILED) {
+        shm_unlink(name.c_str());
+        TT_THROW("mmap failed for '{}': {}", name, std::strerror(mmap_errno));
+    }
+
+    std::memset(ptr, 0, size);
+    return NamedShm(name, ptr, size);
+}
+
+NamedShm NamedShm::open(const std::string& name, size_t size) {
+    TT_FATAL(!name.empty() && name[0] == '/', "POSIX shm name must start with '/': {}", name);
+    TT_FATAL(size > 0, "Shared memory size must be > 0");
+
+    int fd = shm_open(name.c_str(), O_RDWR, 0600);
+    TT_FATAL(fd != -1, "shm_open(open) failed for '{}': {}", name, std::strerror(errno));
+
+    void* ptr = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    int mmap_errno = errno;
+    ::close(fd);
+    if (ptr == MAP_FAILED) {
+        TT_THROW("mmap failed for '{}': {}", name, std::strerror(mmap_errno));
+    }
+
+    return NamedShm(name, ptr, size);
+}
+
+void NamedShm::close() {
+    if (ptr_ != nullptr) {
+        munmap(ptr_, size_);
+        ptr_ = nullptr;
+        size_ = 0;
+    }
+}
+
+void NamedShm::unlink() {
+    close();
+    if (!name_.empty()) {
+        shm_unlink(name_.c_str());
+        name_.clear();
+    }
+}
+
+std::string generate_shm_name(const std::string& prefix) {
+    static std::atomic<uint32_t> counter{0};
+    return fmt::format("/tt_{}_{}_{}", prefix, getpid(), counter.fetch_add(1));
+}
+
+}  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/named_shm.hpp
+++ b/tt_metal/distributed/named_shm.hpp
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+namespace tt::tt_metal::distributed {
+
+/**
+ * @brief RAII wrapper around a POSIX named shared memory region.
+ *
+ * Provides create/open/close/unlink semantics for inter-process shared memory.
+ * The underlying object lives in /dev/shm/ on Linux.
+ */
+class NamedShm {
+public:
+    NamedShm() = default;
+    ~NamedShm() noexcept;
+
+    NamedShm(NamedShm&& other) noexcept;
+    NamedShm& operator=(NamedShm&& other) noexcept;
+
+    NamedShm(const NamedShm&) = delete;
+    NamedShm& operator=(const NamedShm&) = delete;
+
+    /**
+     * @brief Create a new named shared memory region.
+     *
+     * Creates the shm object via shm_open(O_CREAT|O_EXCL|O_RDWR), sets its size via ftruncate,
+     * and maps it with mmap(MAP_SHARED). The region is zero-initialized.
+     *
+     * @param name POSIX shm name (e.g. "/tt_h2d_abc123"). Must start with '/'.
+     * @param size Size of the shared memory region in bytes.
+     * @return NamedShm owning the new mapping.
+     */
+    static NamedShm create(const std::string& name, size_t size);
+
+    /**
+     * @brief Open and map an existing named shared memory region.
+     *
+     * Opens the shm object via shm_open(O_RDWR) and maps it with mmap(MAP_SHARED).
+     *
+     * @param name POSIX shm name matching a previously created region.
+     * @param size Size of the region to map (must match the created size).
+     * @return NamedShm with a mapping to the existing region.
+     */
+    static NamedShm open(const std::string& name, size_t size);
+
+    /**
+     * @brief Unmap the shared memory region from this process.
+     *
+     */
+    void close();
+
+    /**
+     * @brief Remove the named shared memory object from the filesystem.
+     *
+     */
+    void unlink();
+
+    void* ptr() const { return ptr_; }
+    size_t size() const { return size_; }
+    const std::string& name() const { return name_; }
+    bool is_open() const { return ptr_ != nullptr; }
+
+private:
+    NamedShm(const std::string& name, void* ptr, size_t size);
+
+    std::string name_;
+    void* ptr_ = nullptr;
+    size_t size_ = 0;
+};
+
+/**
+ * @brief Generate a unique POSIX shm name: /tt_{prefix}_{pid}_{counter}.
+ */
+std::string generate_shm_name(const std::string& prefix);
+
+}  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/pcie_core_writer.cpp
+++ b/tt_metal/distributed/pcie_core_writer.cpp
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_metal/distributed/pcie_core_writer.hpp"
+
+#include <umd/device/cluster.hpp>
+#include <umd/device/types/core_coordinates.hpp>
+
+namespace tt::tt_metal::distributed {
+
+std::mutex PCIeCoreWriter::cluster_cache_mutex_;
+std::unordered_map<uint32_t, std::unique_ptr<tt::umd::Cluster>> PCIeCoreWriter::cluster_cache_;
+
+tt::umd::Cluster* PCIeCoreWriter::get_or_create_cluster(uint32_t device_id) {
+    std::lock_guard lock(cluster_cache_mutex_);
+    auto it = cluster_cache_.find(device_id);
+    if (it != cluster_cache_.end()) {
+        return it->second.get();
+    }
+    auto cluster = std::make_unique<tt::umd::Cluster>(tt::umd::ClusterOptions{
+        .target_devices = {static_cast<int>(device_id)},
+    });
+    auto* ptr = cluster.get();
+    cluster_cache_.emplace(device_id, std::move(cluster));
+    return ptr;
+}
+
+PCIeCoreWriter::PCIeCoreWriter(uint32_t device_id, uint32_t virtual_core_x, uint32_t virtual_core_y) :
+    device_id_(device_id), virtual_core_x_(virtual_core_x), virtual_core_y_(virtual_core_y) {
+    get_or_create_cluster(device_id);
+}
+
+std::function<void(void*, uint32_t, uint64_t)> PCIeCoreWriter::get_pcie_writer() const {
+    auto* cluster = get_or_create_cluster(device_id_);
+    auto chip_id = static_cast<int>(device_id_);
+    auto vx = virtual_core_x_;
+    auto vy = virtual_core_y_;
+    tt::umd::CoreCoord core(vx, vy, CoreType::TENSIX, CoordSystem::TRANSLATED);
+    return [cluster, chip_id, core](void* data, uint32_t num_bytes, uint64_t device_addr) {
+        cluster->write_to_device(data, num_bytes, chip_id, core, device_addr);
+    };
+}
+
+}  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/pcie_core_writer.hpp
+++ b/tt_metal/distributed/pcie_core_writer.hpp
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+
+namespace tt::umd {
+class Cluster;
+}
+
+namespace tt::tt_metal::distributed {
+
+/**
+ * Lightweight UMD-only device access for cross-process socket connectors.
+ *
+ * Opens the UMD driver for a single chip without going through MetalContext
+ * or tt-metal's Cluster (no ethernet firmware init, no RISC reset).
+ * Caches the UMD Cluster per device_id so topology discovery runs only once.
+ */
+class PCIeCoreWriter {
+public:
+    PCIeCoreWriter(uint32_t device_id, uint32_t virtual_core_x, uint32_t virtual_core_y);
+
+    PCIeCoreWriter(const PCIeCoreWriter&) = delete;
+    PCIeCoreWriter& operator=(const PCIeCoreWriter&) = delete;
+    PCIeCoreWriter(PCIeCoreWriter&&) noexcept = default;
+    PCIeCoreWriter& operator=(PCIeCoreWriter&&) noexcept = default;
+
+    std::function<void(void*, uint32_t, uint64_t)> get_pcie_writer() const;
+
+private:
+    static tt::umd::Cluster* get_or_create_cluster(uint32_t device_id);
+
+    static std::mutex cluster_cache_mutex_;
+    static std::unordered_map<uint32_t, std::unique_ptr<tt::umd::Cluster>> cluster_cache_;
+
+    uint32_t device_id_ = 0;
+    uint32_t virtual_core_x_ = 0;
+    uint32_t virtual_core_y_ = 0;
+};
+
+}  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/sources.cmake
+++ b/tt_metal/distributed/sources.cmake
@@ -23,5 +23,8 @@ set(DISTRIBUTED_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch_context.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/h2d_socket.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/d2h_socket.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/named_shm.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/hd_socket_descriptor.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/pcie_core_writer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/experimental/blitz_decode_pipeline.cpp
 )


### PR DESCRIPTION
### Ticket
No Ticket.

### Problem description
- `H2D` and `D2H` sockets currently require the consuming process to own the device
- Both socket creation and data transfer must happen within the same `MetalContext` 
- This prevents a common deployment pattern where one process (e.g. a Python model runner) launches a workload on device, and a separate process (e.g. an inference server) needs to feed input and read output through the same sockets without opening or managing the device itself

### What's changed
- Introduce cross-process `H2D/D2H` socket support. A connector process can now attach to sockets exported by an owner process and drive data over PCIe without initializing a device, `MetalContext` or the `Cluster` object

**Core changes**

- `H2DSocket::connect()` / `D2HSocket::connect()`: No `MetalContext` in the loop. Reads a `flatbuffer` socket descriptor, opens shared memory, and sets up PCIe writes via `PCIeCoreWriter`. Returns a fully functional socket.
- `PCIeCoreWriter`: Lightweight UMD-only PCIe write path. Opens a `tt::umd::Cluster` targeting a single chip, bypassing `MetalContext`. Caches the UMD Cluster handle per device to avoid repeated topology discovery.
- `HDSocketDescriptor`: Flatbuffer-serialized descriptor exported by the owner to `/dev/shm/`. Contains pre-resolved socket attributes, that the connector uses to initialize its Socket Handle.
- `NamedShm`: POSIX shared memory RAII wrapper for cross-process buffer sharing. Permissions tightened are owner-only. Used for sharing `PinnedMemory` across processes.

**Testing**
  - MPI based loopback workload launching 2 processes talking to the same physical device
  - Rank 0 owns the device and launches a loopback kernel
  - Rank 1 connects to the workload over sockets and drives data

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=asaigal/x_proc_hd_sockets)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:asaigal/x_proc_hd_sockets)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=asaigal/x_proc_hd_sockets)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:asaigal/x_proc_hd_sockets)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=asaigal/x_proc_hd_sockets)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:asaigal/x_proc_hd_sockets)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=asaigal/x_proc_hd_sockets)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:asaigal/x_proc_hd_sockets)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=asaigal/x_proc_hd_sockets)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:asaigal/x_proc_hd_sockets)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=asaigal/x_proc_hd_sockets)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:asaigal/x_proc_hd_sockets)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
