### PR TITLE
Extend run_fabric_tests.sh to support multi-pod fabric tests

### DIFF
--- a/tools/scaleout/exabox/BRINGUP.md
+++ b/tools/scaleout/exabox/BRINGUP.md
@@ -277,7 +277,8 @@ Which tests to run depends on whether the pod is new or previously validated:
 2. Run **single-pod fabric tests** to verify coordinated workloads across the mesh - see [Fabric Tests](./README.md#fabric-tests)
 
 **Existing pod with new inter-pod cabling** (pod already tested/used):
-- Skip dispatch and single-pod fabric tests. Instead, run **multi-pod fabric tests** (documentation coming soon in the top-level README).
+
+- Skip dispatch and single-pod fabric tests. Instead, run **multi-pod fabric tests** using `--num-meshes` and `--mesh-graph-desc-path` - see [Multi-Pod Fabric Tests](./README.md#multi-pod-4-meshes-x-4-hosts--16-hosts).
 
 ## Troubleshooting
 

--- a/tools/scaleout/exabox/README.md
+++ b/tools/scaleout/exabox/README.md
@@ -156,7 +156,7 @@ If these tests fail, raise the issue in the `#exabox-infra` Slack channel and ta
 
 Stress tests for the TT-Fabric layer. Ensures TT-Fabric SW and FW is compatible with the cluster topology. Also stresses the physical ethernet interconnect, verifying cluster stability. Only run after physical validation passes.
 
-**Topology-Specific Scripts:**
+#### Single-Pod (Exabox, 4 hosts)
 
 The current BH Exabox has two different cluster topologies (both with 4 Galaxies, 128 chips):
 - **8x16** (16×8 mesh topology) - Located in Aisle C - Used for DeepSeek-R1 implementation, machines in cluster:
@@ -174,9 +174,33 @@ The mesh shape affects how workloads are distributed across chips. Choose the sc
 
 Logs are saved to `fabric_test_logs/` in your current directory.
 
+**Important: Host Ordering Matters for 4x32 Clusters**
+
+For 4x32 topology, you **must** specify hosts in physical connectivity order. The 4 Galaxies are connected in a ring (`1 <-> 2 <-> 3 <-> 4 <-> 1`). If you see `TT_FATAL: Graph specified in MGD could not fit in the discovered physical topology`, see [Fabric Test Fails with "Graph could not fit in physical topology"](./TROUBLESHOOTING.md#fabric-test-fails-with-graph-could-not-fit-in-physical-topology) for diagnosis and resolution.
+
+#### Multi-Pod (4 meshes x 4 hosts = 16 hosts)
+
+For multi-pod deployments pass `--num-meshes` and `--mesh-graph-desc-path` directly. This targets 4 meshes (each 32x4, 4 hosts per mesh), spawning 16 MPI ranks and using the 2D torus multi-mesh fabric test config.
+
+Provide all 16 hosts in mesh order: hosts 0-3 -> mesh 0, hosts 4-7 -> mesh 1, hosts 8-11 -> mesh 2, hosts 12-15 -> mesh 3.
+
+```bash
+./tools/scaleout/exabox/run_fabric_tests.sh \
+    --num-meshes 4 \
+    --mesh-graph-desc-path tt_metal/fabric/mesh_graph_descriptors/bh_galaxy_sp4_torus_xy_graph_descriptor.textproto \
+    --hosts <host0>,<host1>,...,<host15> \
+    --image <docker-image>
+```
+
+Logs are saved to `multi_mesh_fabric_test_logs/` in your current directory. A reference host-ordered list for the D3-D10 racks is in `tools/scaleout/exabox/sp4_d3_d10_rankfile.txt`.
+
+For more on mesh graph descriptors, rank bindings, and the full multi-mesh workflow, see the [Cluster Validation README](../validation/README.md#multi-mesh-fabric-testing).
+
+#### Analyzing Results
+
 Analyze results with:
 ```bash
-python3 tools/scaleout/exabox/analyze_fabric_results.py fabric_test_logs/<log-file>.log
+python3 tools/scaleout/exabox/analyze_fabric_results.py <output-dir>/<log-file>.log
 ```
 
 The script parses the test log and provides:
@@ -197,11 +221,6 @@ The script returns specific exit codes for automated workflows:
 - `6` - Ethernet core timeout
 - `50` - Inconclusive (manual review required)
 - `66` - Input error (log file not found)
-
-
-**Important: Host Ordering Matters for 4x32 Clusters**
-
-For 4x32 topology, you **must** specify hosts in physical connectivity order. The 4 Galaxies are connected in a ring (`1 <-> 2 <-> 3 <-> 4 <-> 1`). If you see `TT_FATAL: Graph specified in MGD could not fit in the discovered physical topology`, see [Fabric Test Fails with "Graph could not fit in physical topology"](./TROUBLESHOOTING.md#fabric-test-fails-with-graph-could-not-fit-in-physical-topology) for diagnosis and resolution.
 
 If these tests fail, raise the issue in the `#exabox-infra` Slack channel and tag the syseng and scaleout teams.
 
@@ -287,7 +306,7 @@ A missing cable or bad port/connection will show up as a **consistently missing 
 | `recover_*.sh` | Quick reset + 5 traffic iterations |
 | `run_validation.sh` | Full 50-loop validation |
 | `run_dispatch_tests.sh` | Chip stability stress tests |
-| `run_fabric_tests.sh` | Fabric connectivity tests |
+| `run_fabric_tests.sh` | Fabric connectivity tests (`--config 4x32\|8x16` or `--num-meshes N`) |
 | `analyze_validation_results.py` | Parse validation logs |
 | `analyze_dispatch_results.py` | Parse dispatch test logs |
 | `analyze_fabric_results.py` | Parse fabric test logs |

--- a/tools/scaleout/exabox/run_fabric_tests.sh
+++ b/tools/scaleout/exabox/run_fabric_tests.sh
@@ -53,10 +53,7 @@ Examples:
     # Multi-pod (4 meshes, 16 hosts, requires MGD)
     $0 --num-meshes 4 \\
        --mesh-graph-desc-path tt_metal/fabric/mesh_graph_descriptors/bh_galaxy_sp4_torus_xy_graph_descriptor.textproto \\
-       --hosts bh-glx-d03u02,bh-glx-d03u08,bh-glx-d04u08,bh-glx-d04u02,\\
-               bh-glx-d05u02,bh-glx-d05u08,bh-glx-d06u08,bh-glx-d06u02,\\
-               bh-glx-d07u02,bh-glx-d07u08,bh-glx-d08u08,bh-glx-d08u02,\\
-               bh-glx-d09u02,bh-glx-d09u08,bh-glx-d10u08,bh-glx-d10u02 \\
+       --hosts bh-glx-d03u02,bh-glx-d03u08,bh-glx-d04u08,bh-glx-d04u02,bh-glx-d05u02,bh-glx-d05u08,bh-glx-d06u08,bh-glx-d06u02,bh-glx-d07u02,bh-glx-d07u08,bh-glx-d08u08,bh-glx-d08u02,bh-glx-d09u02,bh-glx-d09u08,bh-glx-d10u08,bh-glx-d10u02 \\
        --image ghcr.io/tenstorrent/tt-metal/upstream-tests-bh-glx:latest
 EOF
 }
@@ -157,6 +154,15 @@ if [[ -z "$DOCKER_IMAGE" ]]; then
     echo "Error: --image is required"; echo ""; show_help; exit 1
 fi
 
+# --hosts-per-mesh is only valid alongside --num-meshes; reject it alone to
+# avoid silently ignoring it when a single-pod preset takes over.
+if [[ -z "$NUM_MESHES" && -n "$HOSTS_PER_MESH" ]]; then
+    echo "Error: --hosts-per-mesh requires --num-meshes"
+    echo ""
+    show_help
+    exit 1
+fi
+
 # --- Resolve topology -------------------------------------------------------
 # --num-meshes triggers multi-pod mode; --config drives single-pod mode.
 
@@ -174,6 +180,16 @@ else
     [[ -z "$MESH_GRAPH_DESC_PATH" ]] && MESH_GRAPH_DESC_PATH="${PRESET_MGD[$CONFIG]}"
     [[ -z "$TEST_CONFIG" ]]          && TEST_CONFIG="${PRESET_TEST_CONFIG[$CONFIG]}"
     [[ -z "$OUTPUT_DIR" ]]           && OUTPUT_DIR="${PRESET_OUTPUT[$CONFIG]}"
+fi
+
+# --- Validate topology parameters are positive integers ---------------------
+if ! [[ "$NUM_MESHES" =~ ^[1-9][0-9]*$ ]]; then
+    echo "Error: --num-meshes ('$NUM_MESHES') must be a positive integer"
+    exit 1
+fi
+if ! [[ "$HOSTS_PER_MESH" =~ ^[1-9][0-9]*$ ]]; then
+    echo "Error: --hosts-per-mesh ('$HOSTS_PER_MESH') must be a positive integer"
+    exit 1
 fi
 
 # --- Validate host count ----------------------------------------------------

--- a/tools/scaleout/exabox/run_fabric_tests.sh
+++ b/tools/scaleout/exabox/run_fabric_tests.sh
@@ -1,190 +1,232 @@
 #!/bin/bash
 
-# Function to display help
+# Run TT-Fabric tests on BH Galaxy clusters.
+#
+# Single-pod (4x32, 8x16): use --config. Multi-pod: use --num-meshes +
+# --hosts-per-mesh + --mesh-graph-desc-path.
+#
+# MPI host ordering encodes the rank-to-mesh mapping implicitly: hosts are
+# assigned sequentially, so the first hosts_per_mesh hosts land on mesh 0,
+# the next on mesh 1, etc. No separate rankfile or rank-bindings YAML is needed.
+
 show_help() {
     cat << EOF
 Usage: $0 --hosts <comma-separated-host-list> --image <docker-image> [OPTIONS]
 
-Run fabric tests on 4x32 or 8x16 cluster configuration.
+Run fabric tests on BH Galaxy clusters (single-pod or multi-pod).
+Hosts must be in mesh order: first hosts_per_mesh hosts -> mesh 0, next -> mesh 1, etc.
 
 Required Options:
-    --hosts <host-list>                 Comma-separated list of hosts
+    --hosts <host-list>                 Comma-separated list of hosts in mesh order
     --image <docker-image>              Docker image to use
 
 Optional:
-    --config <4x32|8x16>                Mesh configuration (default: 4x32)
-    --output <directory>                Output directory for log files (default: fabric_test_logs)
-    --mesh-graph-desc-path <path>       Path to mesh graph descriptor file (overrides --config)
-                                        4x32 default: tt_metal/fabric/mesh_graph_descriptors/32x4_quad_bh_galaxy_torus_xy_graph_descriptor.textproto
-                                        8x16 default: tt_metal/fabric/mesh_graph_descriptors/16x8_quad_bh_galaxy_torus_xy_graph_descriptor.textproto
+    --config <preset>                   Named single-pod topology preset (default: 4x32)
+                                        4x32, 8x16
+    --num-meshes <N>                    Number of meshes for multi-pod runs; requires
+                                        --mesh-graph-desc-path
+    --hosts-per-mesh <N>                Hosts per mesh (default: 4)
+    --mesh-graph-desc-path <path>       Path to mesh graph descriptor; overrides --config default
     --test-binary <path>                Path to test binary
                                         (default: ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric)
-    --test-config <path>                Path to test configuration file
-                                        (default: tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_stability.yaml)
+    --test-config <path>                Path to test configuration YAML; overrides --config default
+    --output <directory>                Output directory for log files; overrides default
     --help                              Display this help message and exit
 
-Example:
-    $0 --hosts bh-glx-c01u02,bh-glx-c01u08 \\
-       --image ghcr.io/tenstorrent/tt-metal/upstream-tests-wh-6u:latest
+Presets:
+    4x32   1 mesh, 4 hosts, stability tests   (32x4 mesh topology, Aisle B)
+    8x16   1 mesh, 4 hosts, stability tests   (16x8 mesh topology, Aisle C)
+
+MGD defaults per preset:
+    4x32 -> tt_metal/fabric/mesh_graph_descriptors/32x4_quad_bh_galaxy_torus_xy_graph_descriptor.textproto
+    8x16 -> tt_metal/fabric/mesh_graph_descriptors/16x8_quad_bh_galaxy_torus_xy_graph_descriptor.textproto
+
+Examples:
+    # Single-pod (default: 4x32)
+    $0 --hosts bh-glx-c01u02,bh-glx-c01u08,bh-glx-c02u02,bh-glx-c02u08 \\
+       --image ghcr.io/tenstorrent/tt-metal/upstream-tests-bh-glx:latest
+
+    $0 --config 8x16 \\
+       --hosts bh-glx-c01u02,bh-glx-c01u08,bh-glx-c02u02,bh-glx-c02u08 \\
+       --image ghcr.io/tenstorrent/tt-metal/upstream-tests-bh-glx:latest
+
+    # Multi-pod (4 meshes, 16 hosts, requires MGD)
+    $0 --num-meshes 4 \\
+       --mesh-graph-desc-path tt_metal/fabric/mesh_graph_descriptors/bh_galaxy_sp4_torus_xy_graph_descriptor.textproto \\
+       --hosts bh-glx-d03u02,bh-glx-d03u08,bh-glx-d04u08,bh-glx-d04u02,\\
+               bh-glx-d05u02,bh-glx-d05u08,bh-glx-d06u08,bh-glx-d06u02,\\
+               bh-glx-d07u02,bh-glx-d07u08,bh-glx-d08u08,bh-glx-d08u02,\\
+               bh-glx-d09u02,bh-glx-d09u08,bh-glx-d10u08,bh-glx-d10u02 \\
+       --image ghcr.io/tenstorrent/tt-metal/upstream-tests-bh-glx:latest
 EOF
 }
 
-# Parse command line arguments
+# --- Preset table (single-pod configs only) ---------------------------------
+declare -A PRESET_NUM_MESHES=( [4x32]=1  [8x16]=1  )
+declare -A PRESET_HOSTS_PER=(  [4x32]=4  [8x16]=4  )
+declare -A PRESET_MGD=(
+    [4x32]="tt_metal/fabric/mesh_graph_descriptors/32x4_quad_bh_galaxy_torus_xy_graph_descriptor.textproto"
+    [8x16]="tt_metal/fabric/mesh_graph_descriptors/16x8_quad_bh_galaxy_torus_xy_graph_descriptor.textproto"
+)
+declare -A PRESET_TEST_CONFIG=(
+    [4x32]="tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_stability.yaml"
+    [8x16]="tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_stability.yaml"
+)
+declare -A PRESET_OUTPUT=( [4x32]="fabric_test_logs"  [8x16]="fabric_test_logs"  )
+
+# --- Defaults (resolved after parsing) --------------------------------------
+CONFIG="4x32"
 HOSTS=""
 DOCKER_IMAGE=""
-OUTPUT_DIR="fabric_test_logs"
-MESH_GRAPH_DESC_PATH_4x32="tt_metal/fabric/mesh_graph_descriptors/32x4_quad_bh_galaxy_torus_xy_graph_descriptor.textproto"
-MESH_GRAPH_DESC_PATH_8x16="tt_metal/fabric/mesh_graph_descriptors/16x8_quad_bh_galaxy_torus_xy_graph_descriptor.textproto"
-CONFIG="4x32"
+NUM_MESHES=""
+HOSTS_PER_MESH=""
 MESH_GRAPH_DESC_PATH=""
-MESH_GRAPH_DESC_PATH_EXPLICIT=false
 TEST_BINARY="./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric"
-TEST_CONFIG="tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_stability.yaml"
+TEST_CONFIG=""
+OUTPUT_DIR=""
 
+# --- Argument parsing -------------------------------------------------------
 while [[ $# -gt 0 ]]; do
     case $1 in
         --hosts)
             if [[ -z "$2" ]] || [[ "$2" == --* ]]; then
-                echo "Error: --hosts requires a non-empty value"
-                exit 1
+                echo "Error: --hosts requires a non-empty value"; exit 1
             fi
-            HOSTS="$2"
-            shift 2
-            ;;
+            HOSTS="$2"; shift 2 ;;
         --image)
             if [[ -z "$2" ]] || [[ "$2" == --* ]]; then
-                echo "Error: --image requires a non-empty value"
-                exit 1
+                echo "Error: --image requires a non-empty value"; exit 1
             fi
-            DOCKER_IMAGE="$2"
-            shift 2
-            ;;
+            DOCKER_IMAGE="$2"; shift 2 ;;
         --config)
             if [[ -z "$2" ]] || [[ "$2" == --* ]]; then
-                echo "Error: --config requires a non-empty value"
-                exit 1
+                echo "Error: --config requires a non-empty value"; exit 1
             fi
             CONFIG="$2"
-            if [[ "$CONFIG" != "4x32" && "$CONFIG" != "8x16" ]]; then
-                echo "Error: --config must be either '4x32' or '8x16'"
-                echo ""
-                show_help
+            if [[ -z "${PRESET_NUM_MESHES[$CONFIG]}" ]]; then
+                echo "Error: unknown --config '$CONFIG'. Known presets: ${!PRESET_NUM_MESHES[*]}"
+                echo "       For multi-pod runs use --num-meshes + --mesh-graph-desc-path."
                 exit 1
             fi
-            shift 2
-            ;;
-        --output)
+            shift 2 ;;
+        --num-meshes)
             if [[ -z "$2" ]] || [[ "$2" == --* ]]; then
-                echo "Error: --output requires a non-empty value"
-                exit 1
+                echo "Error: --num-meshes requires a non-empty value"; exit 1
             fi
-            OUTPUT_DIR="$2"
-            shift 2
-            ;;
+            NUM_MESHES="$2"; shift 2 ;;
+        --hosts-per-mesh)
+            if [[ -z "$2" ]] || [[ "$2" == --* ]]; then
+                echo "Error: --hosts-per-mesh requires a non-empty value"; exit 1
+            fi
+            HOSTS_PER_MESH="$2"; shift 2 ;;
         --mesh-graph-desc-path)
             if [[ -z "$2" ]] || [[ "$2" == --* ]]; then
-                echo "Error: --mesh-graph-desc-path requires a non-empty value"
-                exit 1
+                echo "Error: --mesh-graph-desc-path requires a non-empty value"; exit 1
             fi
-            MESH_GRAPH_DESC_PATH="$2"
-            MESH_GRAPH_DESC_PATH_EXPLICIT=true
-            shift 2
-            ;;
+            MESH_GRAPH_DESC_PATH="$2"; shift 2 ;;
         --test-binary)
             if [[ -z "$2" ]] || [[ "$2" == --* ]]; then
-                echo "Error: --test-binary requires a non-empty value"
-                exit 1
+                echo "Error: --test-binary requires a non-empty value"; exit 1
             fi
-            TEST_BINARY="$2"
-            shift 2
-            ;;
+            TEST_BINARY="$2"; shift 2 ;;
         --test-config)
             if [[ -z "$2" ]] || [[ "$2" == --* ]]; then
-                echo "Error: --test-config requires a non-empty value"
-                exit 1
+                echo "Error: --test-config requires a non-empty value"; exit 1
             fi
-            TEST_CONFIG="$2"
-            shift 2
-            ;;
+            TEST_CONFIG="$2"; shift 2 ;;
+        --output)
+            if [[ -z "$2" ]] || [[ "$2" == --* ]]; then
+                echo "Error: --output requires a non-empty value"; exit 1
+            fi
+            OUTPUT_DIR="$2"; shift 2 ;;
         --help)
-            show_help
-            exit 0
-            ;;
+            show_help; exit 0 ;;
         *)
             echo "Error: Unknown option: $1"
             echo ""
             show_help
-            exit 1
-            ;;
+            exit 1 ;;
     esac
 done
 
-# Validate required arguments
+# --- Validate required arguments --------------------------------------------
 if [[ -z "$HOSTS" ]]; then
-    echo "Error: --hosts is required"
-    echo ""
-    show_help
-    exit 1
+    echo "Error: --hosts is required"; echo ""; show_help; exit 1
 fi
-
 if [[ -z "$DOCKER_IMAGE" ]]; then
-    echo "Error: --image is required"
-    echo ""
-    show_help
+    echo "Error: --image is required"; echo ""; show_help; exit 1
+fi
+
+# --- Resolve topology -------------------------------------------------------
+# --num-meshes triggers multi-pod mode; --config drives single-pod mode.
+
+if [[ -n "$NUM_MESHES" ]]; then
+    [[ -z "$HOSTS_PER_MESH" ]] && HOSTS_PER_MESH=4
+    if [[ -z "$MESH_GRAPH_DESC_PATH" ]]; then
+        echo "Error: --mesh-graph-desc-path is required for multi-pod runs (--num-meshes)"
+        exit 1
+    fi
+    [[ -z "$TEST_CONFIG" ]] && TEST_CONFIG="tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_multi_mesh.yaml"
+    [[ -z "$OUTPUT_DIR" ]]  && OUTPUT_DIR="multi_mesh_fabric_test_logs"
+else
+    NUM_MESHES="${PRESET_NUM_MESHES[$CONFIG]}"
+    HOSTS_PER_MESH="${PRESET_HOSTS_PER[$CONFIG]}"
+    [[ -z "$MESH_GRAPH_DESC_PATH" ]] && MESH_GRAPH_DESC_PATH="${PRESET_MGD[$CONFIG]}"
+    [[ -z "$TEST_CONFIG" ]]          && TEST_CONFIG="${PRESET_TEST_CONFIG[$CONFIG]}"
+    [[ -z "$OUTPUT_DIR" ]]           && OUTPUT_DIR="${PRESET_OUTPUT[$CONFIG]}"
+fi
+
+# --- Validate host count ----------------------------------------------------
+EXPECTED_HOSTS=$(( NUM_MESHES * HOSTS_PER_MESH ))
+IFS=',' read -ra HOST_ARRAY <<< "$HOSTS"
+NUM_HOSTS=${#HOST_ARRAY[@]}
+if [[ "$NUM_HOSTS" -ne "$EXPECTED_HOSTS" ]]; then
+    echo "Error: expected $EXPECTED_HOSTS hosts ($NUM_MESHES mesh(es) x $HOSTS_PER_MESH hosts/mesh), got $NUM_HOSTS"
     exit 1
 fi
 
-# Set mesh graph descriptor path based on config if not explicitly provided
-if [[ "$MESH_GRAPH_DESC_PATH_EXPLICIT" == false ]]; then
-    if [[ "$CONFIG" == "4x32" ]]; then
-        MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH_4x32"
-    elif [[ "$CONFIG" == "8x16" ]]; then
-        MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH_8x16"
-    fi
-fi
-
-# Create output directory if it doesn't exist
+# --- Run --------------------------------------------------------------------
 mkdir -p "$OUTPUT_DIR"
-
 LOG_FILE="$OUTPUT_DIR/fabric_tests_$(date +%Y%m%d_%H%M%S).log"
 
 echo "=========================================="
 echo "Running fabric tests..."
-echo "Using hosts: $HOSTS"
-echo "Using docker image: $DOCKER_IMAGE"
-echo "Configuration: $CONFIG"
-echo "Output directory: $OUTPUT_DIR"
+echo "Meshes: $NUM_MESHES  Hosts/mesh: $HOSTS_PER_MESH  Total ranks: $EXPECTED_HOSTS"
+echo "Hosts: $HOSTS"
+echo "Docker image: $DOCKER_IMAGE"
 echo "Mesh graph descriptor: $MESH_GRAPH_DESC_PATH"
 echo "Test binary: $TEST_BINARY"
 echo "Test config: $TEST_CONFIG"
+echo "Output directory: $OUTPUT_DIR"
 echo "Log file: $LOG_FILE"
 echo "=========================================="
 echo ""
 
-./tools/scaleout/exabox/mpi-docker --image "$DOCKER_IMAGE" \
-    --empty-entrypoint \
-    --bind-to none \
-    --host "$HOSTS" \
-    -np 1 \
-    -x TT_MESH_ID=0 \
-    -x TT_MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH" \
-    -x TT_MESH_HOST_RANK=0 "$TEST_BINARY" \
-    --test_config "$TEST_CONFIG" : \
-    -np 1 \
-    -x TT_MESH_ID=0 \
-    -x TT_MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH" \
-    -x TT_MESH_HOST_RANK=1 "$TEST_BINARY" \
-    --test_config "$TEST_CONFIG" : \
-    -np 1 \
-    -x TT_MESH_ID=0 \
-    -x TT_MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH" \
-    -x TT_MESH_HOST_RANK=2 "$TEST_BINARY" \
-    --test_config "$TEST_CONFIG" : \
-    -np 1 \
-    -x TT_MESH_ID=0 \
-    -x TT_MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH" \
-    -x TT_MESH_HOST_RANK=3 "$TEST_BINARY" \
-    --test_config "$TEST_CONFIG" |& tee "$LOG_FILE"
+CMD=(
+    ./tools/scaleout/exabox/mpi-docker
+    --image "$DOCKER_IMAGE"
+    --empty-entrypoint
+    --bind-to none
+    --host "$HOSTS"
+)
+
+for ((mesh_id = 0; mesh_id < NUM_MESHES; mesh_id++)); do
+    for ((mesh_host_rank = 0; mesh_host_rank < HOSTS_PER_MESH; mesh_host_rank++)); do
+        CMD+=(
+            -np 1
+            -x TT_MESH_ID=$mesh_id
+            -x TT_MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH"
+            -x TT_MESH_HOST_RANK=$mesh_host_rank
+            "$TEST_BINARY"
+            --test_config "$TEST_CONFIG"
+        )
+        if [[ $mesh_id -lt $((NUM_MESHES - 1)) || $mesh_host_rank -lt $((HOSTS_PER_MESH - 1)) ]]; then
+            CMD+=(:)
+        fi
+    done
+done
+
+"${CMD[@]}" |& tee "$LOG_FILE"
 
 echo ""
 echo "=========================================="

--- a/tools/scaleout/validation/README.md
+++ b/tools/scaleout/validation/README.md
@@ -240,25 +240,25 @@ To visualize the discovered connectivity, the user can use the `--print-connecti
 
 ```
 
-## SuperPod and Multi-Mesh Fabric Testing
+## Multi-Mesh Fabric Testing
 
-SuperPod testing goes beyond single-pod validation: it exercises the fabric across multiple pods (meshes) and requires matching Mesh Graph Descriptors, rank bindings, and MPI placement to your physical deployment.
+Multi-mesh testing goes beyond single-pod validation: it exercises the fabric across multiple pods (meshes) and requires matching Mesh Graph Descriptors, rank bindings, and MPI placement to your physical deployment.
 
 ### Mainlined Artifacts
 
-The following artifacts are provided for minimal multi-pod (SuperPod) fabric testing:
+The following artifacts are provided for minimal multi-mesh fabric testing:
 
 - **Fabric test config (2D torus, multi-mesh):**
   `tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_multi_mesh.yaml`
   Defines fabric tests (e.g. RandomPairingMesh, AllToAllMesh, and 2D Torus XY variants) for Mesh and Torus topologies.
 
-- **Minimal 4-mesh (e.g. 4× SuperPod, each pod 32×4) Mesh Graph Descriptor:**
+- **Minimal 4-mesh (32×4 per pod) Mesh Graph Descriptor:**
   `tt_metal/fabric/mesh_graph_descriptors/bh_galaxy_sp4_torus_xy_graph_descriptor.textproto`
-  Describes four meshes (each 32×4, 4 hosts per mesh) with full 2D torus-style connectivity between meshes (SP4 = Super-Pod 4).
+  Describes four meshes (each 32×4, 4 hosts per mesh) with full 2D torus-style connectivity between meshes.
 
 ### Building Your Mesh Graph Descriptor
 
-Your Mesh Graph Descriptor must match your physical SuperPod layout:
+Your Mesh Graph Descriptor must match your physical multi-mesh layout:
 
 - **Number of meshes** — One graph instance per pod (or per logical mesh).
 - **Shape of each mesh** — e.g. 32×4 (device dims) and host topology (e.g. 4×1) must match how many hosts and devices you have per pod.
@@ -298,13 +298,13 @@ mesh_graph_desc_path: "tt_metal/fabric/mesh_graph_descriptors/bh_galaxy_sp4_toru
 
 ### Examples
 
-This section walks through how rank bindings and the Mesh Graph Descriptor are built for Dual Pod (SP2) and Quad Pod (SP4) configurations, how to assign hostnames to MPI ranks from your physical topology, and a visual example for SP2.
+This section walks through how rank bindings and the Mesh Graph Descriptor are built for 2-mesh and 4-mesh configurations, how to assign hostnames to MPI ranks from your physical topology, and a visual example for 2 meshes.
 
-#### Building rank bindings and Mesh Graph Descriptor for SP2 and SP4
+#### Building rank bindings and Mesh Graph Descriptor for 2-mesh and 4-mesh configurations
 
-- **SP2 (Dual Pod)** — Two meshes (pods). The Mesh Graph Descriptor defines two mesh instances and the links between them (e.g. a single connection or torus XY). Rank bindings repeat the per-pod pattern twice: one block of entries for mesh_id 0 (ranks 0 … N−1, where N = hosts per mesh) and one for mesh_id 1 (ranks N … 2N−1). Each entry sets `mesh_id`, `mesh_host_rank`, and the file includes `mesh_graph_desc_path` to your two-mesh descriptor.
+- **2-mesh** — The Mesh Graph Descriptor defines two mesh instances and the links between them (e.g. a single connection or torus XY). Rank bindings repeat the per-pod pattern twice: one block of entries for mesh_id 0 (ranks 0 … N−1, where N = hosts per mesh) and one for mesh_id 1 (ranks N … 2N−1). Each entry sets `mesh_id`, `mesh_host_rank`, and the file includes `mesh_graph_desc_path` to your two-mesh descriptor.
 
-- **SP4 (Quad Pod)** — Four meshes (pods). Same idea at larger scale: the mainlined `bh_galaxy_sp4_torus_xy_graph_descriptor.textproto` defines four mesh instances with 2D torus connectivity. The mainlined `bh_galaxy_sp4_rank_bindings.yaml` stamps out the config for one pod four times — 4 meshes × 4 hosts = 16 ranks, with `mesh_id` 0..3 and `mesh_host_rank` 0..3 in each mesh. The descriptor path in that file points at the SP4 MGD.
+- **4-mesh** — Same idea at larger scale: the mainlined `bh_galaxy_sp4_torus_xy_graph_descriptor.textproto` defines four mesh instances with 2D torus connectivity. The mainlined `bh_galaxy_sp4_rank_bindings.yaml` stamps out the config for one pod four times — 4 meshes × 4 hosts = 16 ranks, with `mesh_id` 0..3 and `mesh_host_rank` 0..3 in each mesh.
 
 In both cases, the MGD must match your real pod count, mesh shape (device and host topology), and inter-pod wiring; rank bindings must have one entry per MPI rank and the same `mesh_graph_desc_path`.
 
@@ -315,9 +315,9 @@ MPI ranks must align with the rank bindings. Each rank's (mesh_id, mesh_host_ran
 
 The rankfile maps hostnames to ranks (line 1 = rank 0, line 2 = rank 1, etc.). Map each physical host to its (mesh_id, mesh_host_rank) from your deployment, then list hostnames in rank order.
 
-#### Visualization: SP2 with MPI rank, mesh_id, and mesh_host_rank
+#### Visualization: 2-mesh system with MPI rank, mesh_id, and mesh_host_rank
 
-Below is a sketch of a Dual Pod (SP2) system with 2 meshes and 4 hosts per mesh (8 ranks). Each box is a host; the label shows (mesh_id, mesh_host_rank) and the MPI rank.
+Below is a sketch of a 2-mesh system with 4 hosts per mesh (8 ranks total). Each box is a host; the label shows (mesh_id, mesh_host_rank) and the MPI rank.
 
 ```
     Mesh 0 (mesh_id=0)              Mesh 1 (mesh_id=1)
@@ -330,13 +330,29 @@ Below is a sketch of a Dual Pod (SP2) system with 2 meshes and 4 hosts per mesh 
     └─────────┴─────────┘            └─────────┴─────────┘
 ```
 
-In this example: rank 0 → (0,0), rank 1 → (0,1), rank 4 → (1,0), etc. The rankfile lists hostnames in this rank order. For SP4, the same pattern extends to 4 meshes and 16 ranks.
+In this example: rank 0 → (0,0), rank 1 → (0,1), rank 4 → (1,0), etc. The rankfile lists hostnames in this rank order. For 4 meshes, the same pattern extends to 16 ranks.
 
-### Running Fabric Tests with tt-run
+### Running Fabric Tests
 
-Use `tt-run` with a **rank-binding** file and MPI arguments that include your **rankfile** and **host list**. The test binary is `./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric`; pass the fabric test config via `--test_config`.
+There are two ways to run multi-mesh fabric tests. Choose the one that fits your setup.
 
-Example (use your own rankfile and host list; `--host` order must match the rankfile):
+#### Option A: Script (recommended for Exabox / Docker-based deployments)
+
+`run_fabric_tests.sh --num-meshes` handles all MPI rank assignment inline - no separate rankfile or rank-bindings YAML needed. Hosts passed via `--hosts` are assigned to meshes in order (first 4 -> mesh 0, next 4 -> mesh 1, etc.).
+
+```bash
+./tools/scaleout/exabox/run_fabric_tests.sh \
+    --num-meshes 4 \
+    --mesh-graph-desc-path tt_metal/fabric/mesh_graph_descriptors/bh_galaxy_sp4_torus_xy_graph_descriptor.textproto \
+    --hosts <host0>,<host1>,...,<host15> \
+    --image <docker-image>
+```
+
+Logs go to `multi_mesh_fabric_test_logs/`. See [Exabox README](../../tools/scaleout/exabox/README.md#multi-pod-4-meshes--4-hosts--16-hosts) for full usage.
+
+#### Option B: tt-run (for non-Docker or custom deployments)
+
+Use `tt-run` with an explicit **rank-binding** file and a **rankfile** mapping ranks to hostnames. The test binary is `./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric`.
 
 ```bash
 tt-run \
@@ -350,7 +366,7 @@ Use the correct NIC for your environment (`btl_tcp_if_include`; e.g. `ens5f0np0`
 
 For more on rankfiles and generating cluster descriptors from multiple hosts, see [README_generate_cluster_descriptors.md](../../scripts/scaleout/README_generate_cluster_descriptors.md).
 
-### Validating the setup (without a SuperPod)
+### Validating the setup (without hardware)
 
 You can sanity-check the mainlined artifacts before running on real hardware. All commands below assume you run from the **repository root** (paths are relative to repo root).
 
@@ -384,7 +400,7 @@ You can sanity-check the mainlined artifacts before running on real hardware. Al
    "
    ```
 
-**Full end-to-end** validation requires either a 16-host SuperPod (run the `tt-run` example above) or a mock cluster: create a 16-rank mock cluster descriptor mapping and use `tt-run --mock-cluster-rank-binding <mapping> --rank-binding ...` with `--mpi-args "--allow-run-as-root"` to run 16 processes on one machine (see [custom_mock_cluster_descriptors/README.md](../../tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/README.md)).
+**Full end-to-end** validation requires either a 16-host multi-mesh cluster (run the `tt-run` example above) or a mock cluster: create a 16-rank mock cluster descriptor mapping and use `tt-run --mock-cluster-rank-binding <mapping> --rank-binding ...` with `--mpi-args "--allow-run-as-root"` to run 16 processes on one machine (see [custom_mock_cluster_descriptors/README.md](../../tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/README.md)).
 
 ## Directed Link Retrains (Wormhole Only)
 

--- a/tools/scaleout/validation/README.md
+++ b/tools/scaleout/validation/README.md
@@ -242,7 +242,7 @@ To visualize the discovered connectivity, the user can use the `--print-connecti
 
 ## Multi-Mesh Fabric Testing
 
-Multi-mesh testing goes beyond single-pod validation: it exercises the fabric across multiple pods (meshes) and requires matching Mesh Graph Descriptors, rank bindings, and MPI placement to your physical deployment.
+Multi-mesh testing goes beyond single-pod validation: it exercises the fabric across multiple pods (meshes) and requires a correct rank-to-(mesh_id, mesh_host_rank) mapping - provided either via a rank-bindings YAML or per-rank environment variables - along with matching Mesh Graph Descriptors and MPI placement.
 
 ### Mainlined Artifacts
 


### PR DESCRIPTION
### Ticket
No issue.

### Problem description

- `run_fabric_tests.sh` only supported single-pod topologies (`4x32`, `8x16`); there was no
  productized script for running fabric tests across multiple pods, leaving multi-mesh bringup
  undocumented and manual.
- The exabox bringup and cluster validation READMEs had no guidance on how to run or configure
  multi-mesh fabric tests, including which MGD to use, how host ordering maps to mesh assignment,
  and what test config to pass.

### What's changed

- Extended `run_fabric_tests.sh` with `--num-meshes` and `--hosts-per-mesh` flags; multi-pod runs
  derive rank-to-mesh assignment directly from host ordering, eliminating the need for a separate
  rankfile or rank-bindings YAML, with `--mesh-graph-desc-path` required explicitly so the MGD
  always matches the physical deployment.
- Updated `exabox/README.md`, `BRINGUP.md`, and `validation/README.md` to document the multi-pod
  invocation, cross-link the relevant artifacts, and add a two-option (script vs `tt-run`) guide
  in the cluster validation README covering host ordering, MGD selection, and offline validation steps.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jpanasiuk/fabric_test_script_updated)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jpanasiuk/fabric_test_script_updated)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jpanasiuk/fabric_test_script_updated)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jpanasiuk/fabric_test_script_updated)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jpanasiuk/fabric_test_script_updated)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jpanasiuk/fabric_test_script_updated)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jpanasiuk/fabric_test_script_updated)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jpanasiuk/fabric_test_script_updated)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jpanasiuk/fabric_test_script_updated)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jpanasiuk/fabric_test_script_updated)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jpanasiuk/fabric_test_script_updated)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jpanasiuk/fabric_test_script_updated)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
