### PR TITLE
ring attention non-determinism fixed (introduce by #39289)

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.cpp
@@ -602,10 +602,10 @@ void ring_attention_all_gather_async_multicore_with_workers_override_runtime_arg
             worker_writer_sender_backward_runtime_args_by_core[sender_worker_cores[0 + (link * 2)].x]
                                                               [sender_worker_cores[0 + (link * 2)].y];
 
-        worker_reader_sender_forward_runtime_args[9] = semaphore.at(1).address();
-        worker_reader_sender_backward_runtime_args[9] = semaphore.at(0).address();
-        worker_writer_sender_forward_runtime_args[11] = semaphore.at(1).address();
-        worker_writer_sender_backward_runtime_args[11] = semaphore.at(0).address();
+        worker_reader_sender_forward_runtime_args[2] = semaphore.at(1).address();
+        worker_reader_sender_backward_runtime_args[2] = semaphore.at(0).address();
+        worker_writer_sender_forward_runtime_args[4] = semaphore.at(1).address();
+        worker_writer_sender_backward_runtime_args[4] = semaphore.at(0).address();
         for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
             // sender reader
             worker_reader_sender_forward_runtime_args[reader_sender_rt_offset + input_idx] =

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.cpp
@@ -28,6 +28,12 @@
 
 namespace ttnn::experimental::prim {
 
+// Runtime-arg indices for worker sender semaphore addresses.
+// Keeping these as named constants avoids desynchronization with the
+// runtime-arg layout used when constructing the command streams.
+constexpr std::size_t kWorkerReaderSemaphoreRtArgIndex = 2;
+constexpr std::size_t kWorkerWriterSemaphoreRtArgIndex = 4;
+
 RingAttentionAllGatherAsyncMultiCoreWithWorkersProgramFactory::cached_program_shared_variable_t
 RingAttentionAllGatherAsyncMultiCoreWithWorkersProgramFactory::create_at(
     const operation_attributes_t& operation_attributes,
@@ -602,10 +608,10 @@ void ring_attention_all_gather_async_multicore_with_workers_override_runtime_arg
             worker_writer_sender_backward_runtime_args_by_core[sender_worker_cores[0 + (link * 2)].x]
                                                               [sender_worker_cores[0 + (link * 2)].y];
 
-        worker_reader_sender_forward_runtime_args[2] = semaphore.at(1).address();
-        worker_reader_sender_backward_runtime_args[2] = semaphore.at(0).address();
-        worker_writer_sender_forward_runtime_args[4] = semaphore.at(1).address();
-        worker_writer_sender_backward_runtime_args[4] = semaphore.at(0).address();
+        worker_reader_sender_forward_runtime_args[kWorkerReaderSemaphoreRtArgIndex] = semaphore.at(1).address();
+        worker_reader_sender_backward_runtime_args[kWorkerReaderSemaphoreRtArgIndex] = semaphore.at(0).address();
+        worker_writer_sender_forward_runtime_args[kWorkerWriterSemaphoreRtArgIndex] = semaphore.at(1).address();
+        worker_writer_sender_backward_runtime_args[kWorkerWriterSemaphoreRtArgIndex] = semaphore.at(0).address();
         for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
             // sender reader
             worker_reader_sender_forward_runtime_args[reader_sender_rt_offset + input_idx] =

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.cpp
@@ -608,10 +608,10 @@ void ring_attention_all_gather_async_multicore_with_workers_override_runtime_arg
             worker_writer_sender_backward_runtime_args_by_core[sender_worker_cores[0 + (link * 2)].x]
                                                               [sender_worker_cores[0 + (link * 2)].y];
 
-        worker_reader_sender_forward_runtime_args[kWorkerReaderSemaphoreRtArgIndex] = semaphore.at(1).address();
-        worker_reader_sender_backward_runtime_args[kWorkerReaderSemaphoreRtArgIndex] = semaphore.at(0).address();
-        worker_writer_sender_forward_runtime_args[kWorkerWriterSemaphoreRtArgIndex] = semaphore.at(1).address();
-        worker_writer_sender_backward_runtime_args[kWorkerWriterSemaphoreRtArgIndex] = semaphore.at(0).address();
+        worker_reader_sender_forward_runtime_args[experimental::prim::kWorkerReaderSemaphoreRtArgIndex] = semaphore.at(1).address();
+        worker_reader_sender_backward_runtime_args[experimental::prim::kWorkerReaderSemaphoreRtArgIndex] = semaphore.at(0).address();
+        worker_writer_sender_forward_runtime_args[experimental::prim::kWorkerWriterSemaphoreRtArgIndex] = semaphore.at(1).address();
+        worker_writer_sender_backward_runtime_args[experimental::prim::kWorkerWriterSemaphoreRtArgIndex] = semaphore.at(0).address();
         for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
             // sender reader
             worker_reader_sender_forward_runtime_args[reader_sender_rt_offset + input_idx] =


### PR DESCRIPTION
### Problem description
`tests/nightly/blackhole/ccl/test_ring_joint_sdpa.py::test_ring_joint_attention_sdpa_determinism` fails. Determinism failed when program cache was enabled due to reordered kernel runtime arguments.

### What's changed
Appropriate indexes used in runtime arguments override function of ring all gather.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ipotkonjak/cache_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ipotkonjak/cache_fix)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ipotkonjak/cache_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ipotkonjak/cache_fix)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ipotkonjak/cache_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ipotkonjak/cache_fix)
- [x] [(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/runs/23246303801)
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ipotkonjak/cache_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ipotkonjak/cache_fix)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ipotkonjak/cache_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ipotkonjak/cache_fix)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ipotkonjak/cache_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ipotkonjak/cache_fix)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
