### PR TITLE
Sanity checks fix

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/parallel_sequential/test_parallel_sequential.py
+++ b/tests/ttnn/unit_tests/operations/fused/parallel_sequential/test_parallel_sequential.py
@@ -1316,7 +1316,7 @@ class TestCrossOpCompilation:
         "rmsnorm_post": "ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/device/kernels/compute/rmsnorm_post_allgather.cpp",
         "matmul": "ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm.cpp",
         "batchnorm": "ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_kernel.cpp",
-        "untilize": "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/common.cpp",
+        "untilize": "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp",
         "eltwise_sfpu": "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/eltwise_sfpu.cpp",
         "typecast": "ttnn/cpp/ttnn/operations/copy/typecast/device/kernels/compute/eltwise_typecast.cpp",
     }


### PR DESCRIPTION
### Ticket                                                                                                                                                                                                                                                                                                                                                              
  N/A                                                                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                                          
  ### Problem description                                                                                                                                                                                                                                                                                                                                                 
  Commit 751f7ae0ed (#39294) deleted `untilize/device/kernels/compute/common.cpp` as part of the Tilize/Untilize helpers integration, but `TestCrossOpCompilation` still referenced it, [breaking the sanity test](https://github.com/tenstorrent/tt-metal/actions/runs/23243575137/job/67572528952).                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                                                                          
  ### What's changed                                                                                                                                                                                                                                                                                                                                                      
  Updated the kernel path for `"untilize"` in `TestCrossOpCompilation` to point to the correct remaining kernel file `untilize.cpp`.                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                          
  ### Checklist                                                                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                                          
  - [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=astancov/fix_sanity)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:astancov/fix_sanity) — [passing run](https://github.com/tenstorrent/tt-metal/actions/runs/23244828875)