### PR TITLE
Uplift Optimized Deepseek RS to Support Sub Tile Shapes

### DIFF
--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/test_decode_reduce_scatter.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/test_decode_reduce_scatter.py
@@ -190,6 +190,40 @@ def run_decode_reduce_scatter_deepseek_impl(
             3,
             4,
         ),
+        (
+            [8, 1, 8, 7168],
+            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
+            ttnn.MemoryConfig(
+                ttnn.BufferType.L1,
+                ttnn.NdShardSpec(
+                    ttnn.Shape([1, 1, 32, 128]),
+                    ttnn.CoreRangeSet(
+                        [
+                            ttnn.CoreRange(ttnn.CoreCoord(2, 0), ttnn.CoreCoord(2, 0)),
+                            ttnn.CoreRange(ttnn.CoreCoord(2, 5), ttnn.CoreCoord(2, 5)),
+                            ttnn.CoreRange(ttnn.CoreCoord(3, 0), ttnn.CoreCoord(3, 0)),
+                            ttnn.CoreRange(ttnn.CoreCoord(3, 5), ttnn.CoreCoord(3, 5)),
+                            ttnn.CoreRange(ttnn.CoreCoord(6, 0), ttnn.CoreCoord(6, 0)),
+                            ttnn.CoreRange(ttnn.CoreCoord(6, 5), ttnn.CoreCoord(6, 5)),
+                            ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0)),
+                        ]
+                    ),
+                    ttnn.ShardOrientation.ROW_MAJOR,
+                    ttnn.ShardDistributionStrategy.ROUND_ROBIN_1D,
+                ),
+            ),
+            ttnn.MemoryConfig(
+                ttnn.BufferType.L1,
+                ttnn.NdShardSpec(
+                    ttnn.Shape([1, 1, 32, 32]),
+                    ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 6))]),
+                    ttnn.ShardOrientation.ROW_MAJOR,
+                    ttnn.ShardDistributionStrategy.ROUND_ROBIN_1D,
+                ),
+            ),
+            3,
+            4,
+        ),
     ],
 )
 @pytest.mark.parametrize(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_moe_reduce_scatter/device/deepseek_moe_reduce_scatter_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_moe_reduce_scatter/device/deepseek_moe_reduce_scatter_device_operation.cpp
@@ -47,8 +47,8 @@ void DeepseekMoEReduceScatterDeviceOperation::validate_on_program_cache_miss(
 
     // input tensor properties
     const ttnn::Tensor& first_input_tensor = input_tensors.at(0);
-    const uint32_t input_tensor_rank = first_input_tensor.logical_shape().rank();
-    const auto& input_tensor_shape = first_input_tensor.logical_shape();
+    const uint32_t input_tensor_rank = first_input_tensor.padded_shape().rank();
+    const auto& input_tensor_shape = first_input_tensor.padded_shape();
     TT_FATAL(
         first_input_tensor.buffer()->page_size() % first_input_tensor.buffer()->alignment() == 0,
         "deepseek_moe_reduce_scatter requires aligned pages");
@@ -80,7 +80,7 @@ void DeepseekMoEReduceScatterDeviceOperation::validate_on_program_cache_miss(
         "deepseek_moe_reduce_scatter requires nd sharded input tensors");
     const uint32_t num_pages_per_shard =
         first_input_tensor.nd_shard_spec().value().shard_shape.volume() / num_tile_elements;
-    const uint32_t num_shards = first_input_tensor.logical_volume() / (num_tile_elements * num_pages_per_shard);
+    const uint32_t num_shards = first_input_tensor.physical_volume() / (num_tile_elements * num_pages_per_shard);
     TT_FATAL(num_pages_per_shard % 2 == 0, "deepseek_moe_reduce_scatter requires shards have an even number pages");
     TT_FATAL(
         num_shards <= num_directions_per_link * num_links,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_moe_reduce_scatter/device/deepseek_moe_reduce_scatter_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_moe_reduce_scatter/device/deepseek_moe_reduce_scatter_program_factory.cpp
@@ -116,7 +116,7 @@ DeepseekMoEReduceScatterProgramArtifacts build_deepseek_moe_reduce_scatter_progr
     // tensor details
     const NdShardSpec& input_nd_shard_spec = input_tensors.at(0).nd_shard_spec().value();
     const uint32_t num_pages_per_shard = input_nd_shard_spec.shard_shape.volume() / num_tile_elements;
-    const uint32_t num_shards = input_tensors.at(0).logical_volume() / (num_tile_elements * num_pages_per_shard);
+    const uint32_t num_shards = input_tensors.at(0).physical_volume() / (num_tile_elements * num_pages_per_shard);
     const uint32_t num_pages_per_slice = input_tensors.at(0).buffer()->num_pages();
     const uint32_t page_size = input_tensors.at(0).buffer()->page_size();
 

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc/device/deepseek_moe_fast_reduce_nc_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc/device/deepseek_moe_fast_reduce_nc_device_operation.cpp
@@ -58,12 +58,12 @@ ttnn::TensorSpec DeepseekMoEFastReduceNCDeviceOperation::compute_output_specs(
     const uint32_t reduction_dim = operation_attributes.dim;
     const tt::tt_metal::MemoryConfig& output_memory_config = operation_attributes.output_memory_config;
     const ttnn::Tensor& input_tensor = tensor_args.input_tensor;
-    const auto& input_shape = input_tensor.padded_shape();
+    const auto& input_shape = input_tensor.logical_shape();
 
     const uint32_t num_output_tensors = input_shape[-1] / operation_attributes.split_size;
     const uint32_t split_dim = input_shape.rank() - 1;
 
-    auto output_shape = input_tensor.padded_shape();
+    auto output_shape = input_tensor.logical_shape();
     output_shape[reduction_dim] = 1;  // keepdim = true
     output_shape[split_dim] /= num_output_tensors;
 
@@ -78,7 +78,7 @@ std::vector<ttnn::Tensor> DeepseekMoEFastReduceNCDeviceOperation::create_output_
 
     const ttnn::TensorSpec& output_tensor_spec = compute_output_specs(operation_attributes, tensor_args);
 
-    const uint32_t num_output_tensors = input_tensor.padded_shape()[-1] / operation_attributes.split_size;
+    const uint32_t num_output_tensors = input_tensor.logical_shape()[-1] / operation_attributes.split_size;
     std::vector<ttnn::Tensor> output_tensors(num_output_tensors);
     for (uint32_t i = 0; i < num_output_tensors; ++i) {
         output_tensors[i] = create_device_tensor(output_tensor_spec, input_tensor.device());


### PR DESCRIPTION
### Problem description
- Op was originally designed for an input shape of `[8, 1, 32, 7168]` to fast reduce and `[1, 1, 32, 7168]` to RS
- Some code paths in the model have subtile dim 2, i.e. input shape of `[8, 1, 8, 7168]` to fast reduce and `[1, 1, 8, 7168]` to RS
- RS was still outputting 32 for dim 2 though, even with subtile input, causing PCC issues for the respective code paths

### What's changed
- Uplift the optimized fast reduce and RS to maintain the sub tile input shape
- Add subtile shape test to deepseek unit test


### Pipelines
- GLX E2E: https://github.com/tenstorrent/tt-metal/actions/runs/23228395839
- T3K E2E: https://github.com/tenstorrent/tt-metal/actions/runs/23228395839
- Ran deepseek module unit test manually
  - Required as none of the deepseek pipeline currently run with ring fabric enabled (ring fabric required for optimized ops)

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=grechsteiner/rs-padded-fun)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:grechsteiner/rs-padded-fun)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=grechsteiner/rs-padded-fun)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:grechsteiner/rs-padded-fun)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=grechsteiner/rs-padded-fun)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:grechsteiner/rs-padded-fun)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=grechsteiner/rs-padded-fun)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:grechsteiner/rs-padded-fun)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=grechsteiner/rs-padded-fun)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:grechsteiner/rs-padded-fun)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=grechsteiner/rs-padded-fun)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:grechsteiner/rs-padded-fun)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
